### PR TITLE
refactor: Consolidate "unknown" model id usage

### DIFF
--- a/src/policies/cache_aware.rs
+++ b/src/policies/cache_aware.rs
@@ -70,7 +70,7 @@ use super::{
     CacheAwareConfig, LoadBalancingPolicy, SelectWorkerInfo,
 };
 use crate::{
-    core::Worker,
+    core::{Worker, UNKNOWN_MODEL_ID},
     mesh::{tree_ops::TreeOperation, OptionalMeshSyncManager},
 };
 
@@ -234,10 +234,10 @@ impl CacheAwarePolicy {
     }
 
     /// Normalize model_id for mesh synchronization
-    /// Converts "unknown" or empty to "default" for consistency
+    /// Converts empty model_id to UNKNOWN_MODEL_ID for consistency
     fn normalize_mesh_model_id(model_id: &str) -> &str {
-        if model_id.is_empty() || model_id == "unknown" {
-            "default"
+        if model_id.is_empty() {
+            UNKNOWN_MODEL_ID
         } else {
             model_id
         }
@@ -698,8 +698,8 @@ mod tests {
             )
             .unwrap();
 
-        // Verify tree operation was synced to mesh
-        let tree_state = mesh_sync.get_tree_state("default");
+        // Verify tree operation was synced to mesh (under UNKNOWN_MODEL_ID since no model was specified)
+        let tree_state = mesh_sync.get_tree_state(UNKNOWN_MODEL_ID);
         assert!(tree_state.is_some());
         let tree = tree_state.unwrap();
         assert!(!tree.operations.is_empty());

--- a/src/routers/grpc/common/stages/worker_selection.rs
+++ b/src/routers/grpc/common/stages/worker_selection.rs
@@ -181,7 +181,7 @@ impl WorkerSelectionStage {
         Metrics::record_worker_selection(
             metrics_labels::WORKER_REGULAR,
             metrics_labels::CONNECTION_GRPC,
-            model_id.unwrap_or("default"),
+            model_id.unwrap_or(UNKNOWN_MODEL_ID),
             policy.name(),
         );
 
@@ -247,7 +247,7 @@ impl WorkerSelectionStage {
         let prefill_idx = policy.select_worker(&available_prefill, &info)?;
         let decode_idx = policy.select_worker(&available_decode, &info)?;
 
-        let model = model_id.unwrap_or("default");
+        let model = model_id.unwrap_or(UNKNOWN_MODEL_ID);
         let policy_name = policy.name();
 
         // Record worker selection metrics for both prefill and decode

--- a/src/routers/http/pd_router.rs
+++ b/src/routers/http/pd_router.rs
@@ -281,7 +281,7 @@ impl PDRouter {
         let start_time = Instant::now();
 
         let route = context.route;
-        let model = context.model_id.unwrap_or("default");
+        let model = context.model_id.unwrap_or(UNKNOWN_MODEL_ID);
         let endpoint = route_to_endpoint(route);
 
         // Record request start (Layer 2)
@@ -759,7 +759,7 @@ impl PDRouter {
         )?;
 
         // Record worker selection metrics (Layer 3)
-        let model = model_id.unwrap_or("default");
+        let model = model_id.unwrap_or(UNKNOWN_MODEL_ID);
         Metrics::record_worker_selection(
             metrics_labels::WORKER_PREFILL,
             metrics_labels::CONNECTION_HTTP,

--- a/src/routers/http/router.rs
+++ b/src/routers/http/router.rs
@@ -181,7 +181,7 @@ impl Router {
         Metrics::record_worker_selection(
             metrics_labels::WORKER_REGULAR,
             metrics_labels::CONNECTION_HTTP,
-            model_id.unwrap_or("default"),
+            model_id.unwrap_or(UNKNOWN_MODEL_ID),
             policy.name(),
         );
 
@@ -198,7 +198,7 @@ impl Router {
         let start = Instant::now();
         let is_stream = typed_req.is_stream();
         let text = typed_req.extract_text_for_routing();
-        let model = model_id.unwrap_or("default");
+        let model = model_id.unwrap_or(UNKNOWN_MODEL_ID);
         let endpoint = route_to_endpoint(route);
 
         // Record request start (Layer 2)

--- a/src/routers/tokenize/handlers.rs
+++ b/src/routers/tokenize/handlers.rs
@@ -14,7 +14,7 @@ use tracing::{debug, error, warn};
 
 use crate::{
     app_context::AppContext,
-    core::{steps::TokenizerConfigRequest, Job},
+    core::{steps::TokenizerConfigRequest, Job, UNKNOWN_MODEL_ID},
     protocols::tokenize::{
         AddTokenizerRequest, AddTokenizerResponse, CountResult, DetokenizeRequest,
         DetokenizeResponse, ListTokenizersResponse, RemoveTokenizerResponse, TextResult,
@@ -45,8 +45,8 @@ fn get_tokenizer(registry: &TokenizerRegistry, model: &str) -> Result<Arc<dyn To
         return Ok(tokenizer);
     }
 
-    // Try "default" if model is "default" or empty
-    if model == "default" || model.is_empty() {
+    // Try UNKNOWN_MODEL_ID if model is "unknown" or empty
+    if model == UNKNOWN_MODEL_ID || model.is_empty() {
         // Try to find any tokenizer as fallback
         let entries = registry.list();
         if let Some(first) = entries.first() {
@@ -414,9 +414,9 @@ mod tests {
     }
 
     #[test]
-    fn test_get_tokenizer_default_fallback() {
+    fn test_get_tokenizer_unknown_model_fallback() {
         let registry = create_test_registry();
-        let result = get_tokenizer(&registry, "default");
+        let result = get_tokenizer(&registry, UNKNOWN_MODEL_ID);
         assert!(result.is_ok());
     }
 


### PR DESCRIPTION
## Motivation

This PR consolidates the "unknown" model id label. Currently, tokenizer registry and load uses `"unknown"` as the default model name. But other modules like `metrics`, `cache_aware` uses `"default"`.