### PR TITLE
Use request-scoped MCP clients for Responses API tools

### DIFF
--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -14,4 +14,4 @@ pub mod tool_args;
 
 // Re-export types used outside this module
 pub use config::{McpConfig, McpServerConfig, McpTransport, Tool};
-pub use manager::McpManager;
+pub use manager::{McpManager, RequestMcpContext};


### PR DESCRIPTION
## Problem
The PR identifies a security vulnerability: the connection pool caches by URL (server_key), but auth tokens are NOT part of that key.

User A: URL=X, token=A → creates connection, cached as "X"
User B: URL=X, token=B → gets cached connection "X" with token A's auth\!

## PR Solution

To address the security issue where the connection pool is cached only by URL (`server_key`) and does not include authentication context, we considered the following two approaches:

---

### Option 1: Per-request MCP Tool Context

**Approach**  
Create an isolated MCP tool context per request. Each request builds and uses its own connection context, ensuring that authentication state is never shared across users.

**Pros**
- Easy to implement  
- Strong isolation at the request level  
- Completely avoids cross-user credential leakage  

**Cons**
- Introduces additional overhead (connection setup / teardown per request)  
- Loses most connection pooling benefits  

---

### Option 2: Auth-aware Connection Caching

**Approach**  
Extend the connection pool cache key to include authentication information, so that connections are reused only when both the URL and auth context match.

**Pros**
- Allows connection reuse for the same user with the same authentication  
- Reduces connection creation overhead compared to per-request isolation  

**Cons**
- In enterprise MCP servers, authentication is almost always required  
- With the upcoming support for custom headers, using only URL + auth token as the cache key is insufficient — headers must also be included, since not all MCP servers follow the standard authentication mechanism, and many rely on custom headers (e.g. x-api-key) for authentication.
- Once headers are added to the cache key, the key space becomes highly fragmented  
- As a result, the practical benefit of connection pooling becomes very limited, while complexity increases significantly  

---

### Conclusion

Given the security guarantees required and the limited real-world benefits of connection reuse when authentication and headers are fully accounted for, **Option 1 (Per-request MCP tool context)** is the preferred solution.  

It provides clear security boundaries with minimal implementation risk, at the cost of some additional per-request overhead, which is considered acceptable for correctness and safety.

## Notes
- gRPC paths remain unchanged, will add this in a separate PR
- OpenAI Responses does not currently support static MCP tools, so RequestMcpContext intentionally ignores static servers/tools for now; we can revisit if/when builtin tools need it