### PR TITLE
Reduce benchmark CI overhead

### DIFF
--- a/.github/workflows/pr-benchmark-rust.yml
+++ b/.github/workflows/pr-benchmark-rust.yml
@@ -4,12 +4,25 @@ on:
   push:
     branches: [ main ]
     paths:
-      - "**"
+      - "benches/**"
+      - "src/routers/**"
+      - "src/core/**"
+      - "src/policies/**"
+      - "tokenizer/**"
+      - "tool-parser/**"
   pull_request:
     branches: [ main ]
     paths:
-      - "**"
+      - "benches/**"
+      - "src/routers/**"
+      - "src/core/**"
+      - "src/policies/**"
+      - "tokenizer/**"
+      - "tool-parser/**"
   workflow_dispatch:
+  schedule:
+    # Run weekly on Sunday at midnight UTC for baseline tracking
+    - cron: '0 0 * * 0'
 
 concurrency:
   group: pr-benchmark-rust-${{ github.ref }}
@@ -25,41 +38,6 @@ permissions:
   issues: write
 
 jobs:
-  benchmark-compile-check:
-    name: Benchmark Compilation Check
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install dependencies
-        run: |
-          bash scripts/ci_install_rust.sh
-
-      - name: Configure sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
-        with:
-          version: "v0.12.0"
-          disable_annotations: true
-
-      - name: Rust cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: .
-          shared-key: "rust-cache"
-          save-if: true
-          cache-all-crates: true
-          cache-on-failure: true
-
-      - name: Check benchmarks compile
-        run: |
-          source "$HOME/.cargo/env"
-          cargo check --benches
-
-      - name: Show sccache stats
-        if: always()
-        run: sccache --show-stats
-
   benchmark:
     name: Benchmark - ${{ matrix.name }}
     if: |


### PR DESCRIPTION
- Only trigger benchmarks when performance-critical paths change (benches/, src/routers/, src/core/, src/policies/, tokenizer/, tool-parser/)
- Add weekly scheduled run for baseline tracking
- Remove redundant benchmark-compile-check job