### PR TITLE
chore: Standardize package metadata across all workspace crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,7 +135,7 @@ wfaas = { path = "workflow", package = "workflow" }
 llm-tokenizer = { path = "tokenizer", package = "tokenizer" }
 smg-auth = { path = "auth", package = "auth" }
 smg-mcp = { path = "mcp", package = "mcp" }
-kv_index = { path = "kv_index" }
+kv-index = { path = "kv_index", package = "kv-index" }
 smg-data-connector = { path = "data_connector", package = "data-connector" }
 llm-multimodal = { path = "multimodal" }
 
@@ -184,7 +184,7 @@ serial_test = "3.0"
 rsa = { version = "0.9", features = ["sha2"] }
 jsonwebtoken = "9.3"
 validator = "0.20.0"
-kv_index = { path = "kv_index" }
+kv-index = { path = "kv_index", package = "kv-index" }
 
 [[bench]]
 name = "wasm_middleware_latency"

--- a/auth/Cargo.toml
+++ b/auth/Cargo.toml
@@ -5,6 +5,11 @@ edition = "2021"
 description = "Authentication and authorization for control plane APIs"
 license = "Apache-2.0"
 repository = "https://github.com/lightseekorg/smg"
+authors = [
+    "Simo Lin <linsimo.mark@gmail.com>",
+    "Chang Su <mckvtl@gmail.com>",
+    "Keyang Ru <rukeyang@gmail.com>",
+]
 keywords = ["auth", "jwt", "oidc", "api-key", "middleware"]
 categories = ["authentication", "web-programming"]
 

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -9,8 +9,7 @@ description = "High-performance Rust-based load balancer for SGLang with multipl
 authors = [
     {name = "Simo Lin", email = "linsimo.mark@gmail.com"},
     {name = "Chang Su", email = "mckvtl@gmail.com"},
-    {name = "Keyang Ru", email = "rukeyang@gmail.com"},
-    {name = "Byron Hsu", email = "byronhsu1230@gmail.com"}
+    {name = "Keyang Ru", email = "rukeyang@gmail.com"}
 ]
 requires-python = ">=3.8"
 readme = "../../README.md"

--- a/data_connector/Cargo.toml
+++ b/data_connector/Cargo.toml
@@ -4,6 +4,11 @@ version = "0.1.0"
 edition = "2021"
 description = "Storage backends for conversations and responses"
 license = "Apache-2.0"
+authors = [
+    "Simo Lin <linsimo.mark@gmail.com>",
+    "Chang Su <mckvtl@gmail.com>",
+    "Keyang Ru <rukeyang@gmail.com>",
+]
 
 [dependencies]
 async-trait.workspace = true

--- a/kv_index/Cargo.toml
+++ b/kv_index/Cargo.toml
@@ -1,8 +1,17 @@
 [package]
-name = "kv_index"
+name = "kv-index"
 version = "0.1.0"
 edition = "2021"
 description = "Radix tree implementations for prefix matching and cache-aware routing"
+license = "Apache-2.0"
+repository = "https://github.com/lightseekorg/smg"
+authors = [
+    "Simo Lin <linsimo.mark@gmail.com>",
+    "Chang Su <mckvtl@gmail.com>",
+    "Keyang Ru <rukeyang@gmail.com>",
+]
+keywords = ["radix-tree", "prefix-matching", "cache-routing", "llm"]
+categories = ["data-structures", "caching"]
 
 [dependencies]
 dashmap = { workspace = true }

--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -5,6 +5,11 @@ edition = "2021"
 description = "Model Context Protocol (MCP) client implementation"
 license = "Apache-2.0"
 repository = "https://github.com/lightseekorg/smg"
+authors = [
+    "Simo Lin <linsimo.mark@gmail.com>",
+    "Chang Su <mckvtl@gmail.com>",
+    "Keyang Ru <rukeyang@gmail.com>",
+]
 keywords = ["mcp", "model-context-protocol", "llm", "tools"]
 categories = ["api-bindings"]
 

--- a/multimodal/Cargo.toml
+++ b/multimodal/Cargo.toml
@@ -5,6 +5,10 @@ edition = "2021"
 description = "Multimodal processing for vision and other modalities"
 license = "Apache-2.0"
 repository = "https://github.com/lightseekorg/smg"
+authors = [
+    "Simo Lin <linsimo.mark@gmail.com>",
+    "Chang Su <mckvtl@gmail.com>",
+]
 keywords = ["vision", "multimodal", "image-processing", "llm"]
 categories = ["multimedia::images", "science"]
 

--- a/protocols/Cargo.toml
+++ b/protocols/Cargo.toml
@@ -5,6 +5,11 @@ edition = "2021"
 description = "OpenAI-compatible API protocol definitions and types"
 license = "Apache-2.0"
 repository = "https://github.com/lightseekorg/smg"
+authors = [
+    "Simo Lin <linsimo.mark@gmail.com>",
+    "Chang Su <mckvtl@gmail.com>",
+    "Keyang Ru <rukeyang@gmail.com>",
+]
 keywords = ["openai", "llm", "api", "protocol", "types"]
 categories = ["api-bindings", "data-structures"]
 

--- a/reasoning_parser/Cargo.toml
+++ b/reasoning_parser/Cargo.toml
@@ -5,6 +5,10 @@ edition = "2021"
 description = "Parser for AI model reasoning/thinking outputs (chain-of-thought, etc.)"
 license = "Apache-2.0"
 repository = "https://github.com/lightseekorg/smg"
+authors = [
+    "Simo Lin <linsimo.mark@gmail.com>",
+    "Chang Su <mckvtl@gmail.com>",
+]
 keywords = ["llm", "reasoning", "parser", "chain-of-thought"]
 categories = ["parsing", "text-processing"]
 

--- a/tokenizer/Cargo.toml
+++ b/tokenizer/Cargo.toml
@@ -5,6 +5,11 @@ edition = "2021"
 description = "LLM tokenizer library with caching and chat template support"
 license = "Apache-2.0"
 repository = "https://github.com/lightseekorg/smg"
+authors = [
+    "Simo Lin <linsimo.mark@gmail.com>",
+    "Chang Su <mckvtl@gmail.com>",
+    "Keyang Ru <rukeyang@gmail.com>",
+]
 keywords = ["tokenizer", "llm", "huggingface", "tiktoken", "chat-template"]
 categories = ["text-processing", "parsing"]
 

--- a/tool_parser/Cargo.toml
+++ b/tool_parser/Cargo.toml
@@ -5,6 +5,10 @@ edition = "2021"
 description = "Tool/function call parser for LLM model outputs"
 license = "Apache-2.0"
 repository = "https://github.com/lightseekorg/smg"
+authors = [
+    "Simo Lin <linsimo.mark@gmail.com>",
+    "Chang Su <mckvtl@gmail.com>",
+]
 keywords = ["llm", "tool-calling", "function-calling", "parser"]
 categories = ["parsing", "api-bindings"]
 

--- a/workflow/Cargo.toml
+++ b/workflow/Cargo.toml
@@ -5,6 +5,11 @@ edition = "2021"
 description = "Workflow-as-a-Service engine for managing multi-step operations"
 license = "Apache-2.0"
 repository = "https://github.com/lightseekorg/smg"
+authors = [
+    "Simo Lin <linsimo.mark@gmail.com>",
+    "Chang Su <mckvtl@gmail.com>",
+    "Keyang Ru <rukeyang@gmail.com>",
+]
 keywords = ["workflow", "orchestration", "dag", "state-machine"]
 categories = ["asynchronous"]
 


### PR DESCRIPTION
- Rename kv_index package to kv-index (folder remains kv_index)
- Add Apache-2.0 license to all crates
- Add authors metadata to all workspace Cargo.toml files:
  - Simo Lin <linsimo.mark@gmail.com>
  - Chang Su <mckvtl@gmail.com>
  - Keyang Ru <rukeyang@gmail.com>
- Add repository, keywords, and categories to kv-index
- Update root Cargo.toml dependency reference for kv-index

Affected crates:
- kv-index (renamed from kv_index)
- auth
- tokenizer
- openai-protocol
- mcp
- workflow
- data-connector
- reasoning-parser
- tool-parser
- llm-multimodal