### PR TITLE
refactor: Rename mcp package from 'mcp' to 'smg-mcp'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 [workspace.dependencies]
 openai-protocol = { path = "protocols" }
 smg-auth = { path = "auth", package = "auth" }
-smg-mcp = { path = "mcp", package = "mcp" }
+smg-mcp = { path = "mcp" }
 smg-data-connector = { path = "data_connector", package = "data-connector" }
 smg-wasm = { path = "wasm", package = "smg-wasm" }
 smg-mesh = { path = "mesh", package = "smg-mesh" }
@@ -137,7 +137,7 @@ tool-parser = { path = "tool_parser" }
 wfaas = { path = "workflow", package = "workflow" }
 llm-tokenizer = { path = "tokenizer", package = "tokenizer" }
 smg-auth = { path = "auth", package = "auth" }
-smg-mcp = { path = "mcp", package = "mcp" }
+smg-mcp = { path = "mcp" }
 kv-index = { path = "kv_index", package = "kv-index" }
 smg-data-connector = { path = "data_connector", package = "data-connector" }
 llm-multimodal = { path = "multimodal" }

--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "mcp"
+name = "smg-mcp"
 version = "0.1.0"
 edition = "2021"
 description = "Model Context Protocol (MCP) client implementation"
@@ -10,7 +10,7 @@ authors = [
     "Chang Su <mckvtl@gmail.com>",
     "Keyang Ru <rukeyang@gmail.com>",
 ]
-keywords = ["mcp", "model-context-protocol", "llm", "tools"]
+keywords = ["mcp", "smg", "llm", "tools"]
 categories = ["api-bindings"]
 
 [lib]


### PR DESCRIPTION
Update package name to follow project naming convention (smg- prefix). The lib name was already smg_mcp, now the package name matches.

- mcp/Cargo.toml: Change package name from 'mcp' to 'smg-mcp'
- Root Cargo.toml: Remove redundant 'package = "mcp"' from dependencies