### PR TITLE
refactor: Rename sgl-model-gateway to smg across entire codebase

### DIFF
--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -287,7 +287,7 @@ jobs:
           context: .
           file: docker/Dockerfile
           push: false
-          tags: sgl-model-gateway:test
+          tags: smg:test
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "chron
 uuid = { version = "1.10" }
 
 [package]
-name = "sgl-model-gateway"
+name = "smg"
 version = "0.3.2"
 edition = "2021"
 
@@ -58,10 +58,6 @@ unused_qualifications = "warn"
 [lib]
 name = "smg"
 crate-type = ["rlib"]
-
-[[bin]]
-name = "sgl-model-gateway"
-path = "src/main.rs"
 
 [[bin]]
 name = "smg"

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ help: ## Show this help message
 	@echo ""
 
 build: ## Build the project in release mode
-	@echo "Building SGLang Model Gateway..."
+	@echo "Building Shepherd Model Gateway..."
 	@cargo build --release
 
 test: ## Run all tests
@@ -112,8 +112,8 @@ python-clean: ## Clean Python build artifacts
 	@echo "Cleaning Python build artifacts..."
 	@rm -rf $(PYTHON_DIR)/dist/
 	@rm -rf $(PYTHON_DIR)/target/
-	@rm -rf $(PYTHON_DIR)/sglang_router.egg-info/
-	@rm -rf $(PYTHON_DIR)/sglang_router/__pycache__/
+	@rm -rf $(PYTHON_DIR)/smg.egg-info/
+	@rm -rf $(PYTHON_DIR)/smg/__pycache__/
 	@find $(PYTHON_DIR) -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
 	@find $(PYTHON_DIR) -name "*.pyc" -delete 2>/dev/null || true
 	@echo "Python build artifacts cleaned!"
@@ -139,7 +139,7 @@ VERSION_FILES := Cargo.toml \
                  bindings/golang/Cargo.toml \
                  bindings/python/Cargo.toml \
                  bindings/python/pyproject.toml \
-                 bindings/python/src/sglang_router/version.py
+                 bindings/python/src/smg/version.py
 
 show-version: ## Show current version across all files
 	@echo "Current versions:"
@@ -147,7 +147,7 @@ show-version: ## Show current version across all files
 	@echo "  bindings/golang/Cargo.toml: $$(grep -m1 '^version = ' bindings/golang/Cargo.toml | sed 's/version = "\(.*\)"/\1/')"
 	@echo "  bindings/python/Cargo.toml: $$(grep -m1 '^version = ' bindings/python/Cargo.toml | sed 's/version = "\(.*\)"/\1/')"
 	@echo "  bindings/python/pyproject.toml: $$(grep -m1 '^version = ' bindings/python/pyproject.toml | sed 's/version = "\(.*\)"/\1/')"
-	@echo "  bindings/python/.../version.py: $$(grep '__version__' bindings/python/src/sglang_router/version.py | sed 's/__version__ = "\(.*\)"/\1/')"
+	@echo "  bindings/python/.../version.py: $$(grep '__version__' bindings/python/src/smg/version.py | sed 's/__version__ = "\(.*\)"/\1/')"
 
 bump-version: ## Bump version across all files (usage: make bump-version VERSION=0.3.3)
 	@if [ -z "$(VERSION)" ]; then \
@@ -168,13 +168,13 @@ bump-version: ## Bump version across all files (usage: make bump-version VERSION
 	@# Update pyproject.toml
 	@sed -i.bak 's/^version = ".*"/version = "$(VERSION)"/' bindings/python/pyproject.toml && rm -f bindings/python/pyproject.toml.bak
 	@# Update version.py
-	@sed -i.bak 's/__version__ = ".*"/__version__ = "$(VERSION)"/' bindings/python/src/sglang_router/version.py && rm -f bindings/python/src/sglang_router/version.py.bak
+	@sed -i.bak 's/__version__ = ".*"/__version__ = "$(VERSION)"/' bindings/python/src/smg/version.py && rm -f bindings/python/src/smg/version.py.bak
 	@echo "Version updated to $(VERSION) in all files:"
 	@echo "  - Cargo.toml"
 	@echo "  - bindings/golang/Cargo.toml"
 	@echo "  - bindings/python/Cargo.toml"
 	@echo "  - bindings/python/pyproject.toml"
-	@echo "  - bindings/python/src/sglang_router/version.py"
+	@echo "  - bindings/python/src/smg/version.py"
 	@echo ""
 	@echo "Verify with: make show-version"
 

--- a/bindings/golang/Cargo.toml
+++ b/bindings/golang/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "sgl-model-gateway-golang"
+name = "smg-golang"
 version = "0.3.2"
 edition = "2021"
 
 [lib]
-name = "sgl_model_gateway_go"
+name = "smg_go"
 crate-type = ["cdylib"]
 
 [dependencies]
@@ -19,13 +19,13 @@ futures-util = "0.3"
 tracing = "0.1"
 libc = "0.2.179"
 
-[dependencies.sgl-model-gateway]
+[dependencies.smg]
 path = "../.."
 default-features = true
 
 [features]
 default = []
-vendored-openssl = ["sgl-model-gateway/vendored-openssl"]
+vendored-openssl = ["smg/vendored-openssl"]
 
 [profile.release]
 opt-level = "z"     # Optimize for size

--- a/bindings/golang/Makefile
+++ b/bindings/golang/Makefile
@@ -1,10 +1,10 @@
-# Makefile for sgl-model-gateway golang bindings
+# Makefile for Shepherd Model Gateway golang bindings
 # This builds the Rust FFI library and provides convenience targets for Go development
 
 # Configuration
 CARGO_BUILD_DIR ?= $(shell pwd)/target
 BUILD_MODE ?= release
-LIB_NAME = libsgl_model_gateway_go
+LIB_NAME = libsmg_go
 
 # Detect OS
 UNAME_S := $(shell uname -s)
@@ -30,7 +30,7 @@ PYTHON_LDFLAGS := $(shell python3-config --ldflags --embed 2>/dev/null || python
 
 # CGO flags - use exported lib directory if available, otherwise build directory
 LIB_DIR := $(if $(wildcard $(LIB_EXPORT_PATH)),$(LIB_EXPORT_DIR),$(LIB_BUILD_DIR))
-export CGO_LDFLAGS = -L$(LIB_DIR) -lsgl_model_gateway_go $(PYTHON_LDFLAGS) -ldl
+export CGO_LDFLAGS = -L$(LIB_DIR) -lsmg_go $(PYTHON_LDFLAGS) -ldl
 export $(LD_LIBRARY_PATH_VAR) := $(LIB_DIR):$($(LD_LIBRARY_PATH_VAR))
 
 .PHONY: all build build-dev lib lib-clean clean test examples help run-simple run-streaming check-lib

--- a/bindings/golang/README.md
+++ b/bindings/golang/README.md
@@ -1,8 +1,8 @@
-# SGLang Go gRPC SDK
+# SMG Go gRPC SDK
 
-A high-level Go SDK for interacting with SGLang gRPC API, designed with an OpenAI-style API for familiarity and ease of use.
+A high-level Go SDK for interacting with Shepherd Model Gateway (SMG) gRPC API, designed with an OpenAI-style API for familiarity and ease of use.
 
-**Location**: `sgl-model-gateway/bindings/golang/`
+**Location**: `smg/bindings/golang/`
 
 ## Table of Contents
 
@@ -37,13 +37,13 @@ A high-level Go SDK for interacting with SGLang gRPC API, designed with an OpenA
 ## Installation
 
 ```bash
-go get github.com/sglang/sglang-go-grpc-sdk
+go get github.com/lightseekorg/smg-go-grpc-sdk
 ```
 
 ### Sync Dependencies
 
 ```bash
-cd sgl-model-gateway/bindings/golang
+cd smg/bindings/golang
 go mod tidy
 ```
 
@@ -105,12 +105,12 @@ import (
     "fmt"
     "log"
 
-    "github.com/sglang/sglang-go-grpc-sdk"
+    "github.com/lightseekorg/smg-go-grpc-sdk"
 )
 
 func main() {
     // Create client
-    client, err := sglang.NewClient(sglang.ClientConfig{
+    client, err := smg.NewClient(smg.ClientConfig{
         Endpoint:      "grpc://localhost:20000",
         TokenizerPath: "/path/to/tokenizer",
     })
@@ -120,9 +120,9 @@ func main() {
     defer client.Close()
 
     // Create completion
-    resp, err := client.CreateChatCompletion(context.Background(), sglang.ChatCompletionRequest{
+    resp, err := client.CreateChatCompletion(context.Background(), smg.ChatCompletionRequest{
         Model: "default",
-        Messages: []sglang.ChatMessage{
+        Messages: []smg.ChatMessage{
             {Role: "user", Content: "Hello!"},
         },
         Stream: false,
@@ -150,12 +150,12 @@ import (
     "io"
     "log"
 
-    "github.com/sglang/sglang-go-grpc-sdk"
+    "github.com/lightseekorg/smg-go-grpc-sdk"
 )
 
 func main() {
     // Create client
-    client, err := sglang.NewClient(sglang.ClientConfig{
+    client, err := smg.NewClient(smg.ClientConfig{
         Endpoint:      "grpc://localhost:20000",
         TokenizerPath: "/path/to/tokenizer",
     })
@@ -166,9 +166,9 @@ func main() {
 
     // Create streaming completion
     ctx := context.Background()
-    stream, err := client.CreateChatCompletionStream(ctx, sglang.ChatCompletionRequest{
+    stream, err := client.CreateChatCompletionStream(ctx, smg.ChatCompletionRequest{
         Model: "default",
-        Messages: []sglang.ChatMessage{
+        Messages: []smg.ChatMessage{
             {Role: "user", Content: "Tell me a story"},
         },
         Stream:              true,
@@ -315,11 +315,11 @@ go tool cover -html=coverage.out -o coverage.html
 
 ### Integration Tests
 
-Integration tests require a running SGLang server and test the full client-server interaction.
+Integration tests require a running SMG server and test the full client-server interaction.
 
 #### Prerequisites
 
-1. Start SGLang server: `python -m sglang.launch_server --model-path <model_path>`
+1. Start SMG server: `smg --model-path <model_path>`
 2. Set environment variables:
    ```bash
    export SGL_GRPC_ENDPOINT=grpc://localhost:20000
@@ -375,7 +375,7 @@ All public types and functions include comprehensive documentation with usage ex
 
 ```bash
 godoc -http=:6060
-# Visit: http://localhost:6060/pkg/github.com/sglang/sglang-go-grpc-sdk/
+# Visit: http://localhost:6060/pkg/github.com/lightseekorg/smg-go-grpc-sdk/
 ```
 
 ## Development
@@ -418,7 +418,7 @@ Run `go mod tidy` to sync dependencies.
 
 ### Connection Errors
 
-Ensure SGLang server is running and check `SGL_GRPC_ENDPOINT`.
+Ensure SMG server is running and check `SGL_GRPC_ENDPOINT`.
 
 ### Tokenizer Not Found
 
@@ -428,11 +428,11 @@ Set `SGL_TOKENIZER_PATH` environment variable.
 
 ### Build Failures
 
-**Error**: `library 'sgl_model_gateway_go' not found`
+**Error**: `library 'smg_go' not found`
 
 **Solution**:
-1. Rebuild Rust library: `cd sgl-model-gateway/bindings/golang && make build`
-2. Or manually with cargo: `cd sgl-model-gateway/bindings/golang && cargo build --release`
+1. Rebuild Rust library: `cd smg/bindings/golang && make build`
+2. Or manually with cargo: `cd smg/bindings/golang && cargo build --release`
 3. Set `CARGO_BUILD_DIR` if using non-standard build location
 4. Ensure Rust toolchain is installed: `rustup toolchain list`
 

--- a/bindings/golang/examples/oai_server/Makefile
+++ b/bindings/golang/examples/oai_server/Makefile
@@ -15,7 +15,7 @@ BINARY := $(BUILD_DIR)/$(APP_NAME)
 
 # Rust FFI library paths
 LIB_DIR := $(BINDINGS_DIR)/lib
-LIB_NAME = libsgl_model_gateway_go
+LIB_NAME = libsmg_go
 
 # Detect OS
 UNAME_S := $(shell uname -s)

--- a/bindings/golang/examples/oai_server/README.md
+++ b/bindings/golang/examples/oai_server/README.md
@@ -1,6 +1,6 @@
-# Go SGLang Router - OpenAI Compatible API Server
+# Go SMG Router - OpenAI Compatible API Server
 
-Go SGLang Router is a high-performance OpenAI-compatible API server that communicates with the SGLang backend via gRPC and performs efficient preprocessing and postprocessing through Rust FFI.
+Go SMG Router is a high-performance OpenAI-compatible API server that communicates with the SMG backend via gRPC and performs efficient preprocessing and postprocessing through Rust FFI.
 
 ## Features
 
@@ -17,7 +17,7 @@ Go SGLang Router is a high-performance OpenAI-compatible API server that communi
 - **Preprocessing**: chat_template and tokenization (request phase)
 - **Postprocessing**: token decoding and tool parsing (response phase)
 
-gRPC is only used for communication with the SGLang backend, while input/output processing completely relies on Rust FFI.
+gRPC is only used for communication with the SMG backend, while input/output processing completely relies on Rust FFI.
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
@@ -233,7 +233,7 @@ type Timeouts struct {
 ## File Structure
 
 ```
-sgl-model-gateway/bindings/golang/
+smg/bindings/golang/
 ├── client.go                          # High-level client API
 ├── internal/
 │   ├── grpc/

--- a/bindings/golang/examples/oai_server/run.sh
+++ b/bindings/golang/examples/oai_server/run.sh
@@ -22,7 +22,7 @@ fi
 PYTHON_LDFLAGS=$(python3-config --ldflags --embed 2>/dev/null || python3-config --ldflags 2>/dev/null || echo "")
 
 # Set CGO_LDFLAGS to link with the Rust library
-# Note: -lsgl_model_gateway_go and -ldl are already in the #cgo directive in internal/ffi/client.go
+# Note: -lsmg_go and -ldl are already in the #cgo directive in internal/ffi/client.go
 # We only need to add the library path (-L) and Python flags
 export CGO_LDFLAGS="-L${LIB_DIR} ${PYTHON_LDFLAGS}"
 

--- a/bindings/golang/examples/simple/run.sh
+++ b/bindings/golang/examples/simple/run.sh
@@ -19,7 +19,7 @@ fi
 PYTHON_LDFLAGS=$(python3-config --ldflags --embed 2>/dev/null || python3-config --ldflags 2>/dev/null || echo "")
 
 # Set CGO_LDFLAGS to link with the Rust library
-export CGO_LDFLAGS="-L${LIB_DIR} -lsgl_model_gateway_go ${PYTHON_LDFLAGS} -ldl"
+export CGO_LDFLAGS="-L${LIB_DIR} -lsmg_go ${PYTHON_LDFLAGS} -ldl"
 
 # macOS uses DYLD_LIBRARY_PATH, Linux uses LD_LIBRARY_PATH
 if [[ "$OSTYPE" == "darwin"* ]]; then

--- a/bindings/golang/examples/streaming/run.sh
+++ b/bindings/golang/examples/streaming/run.sh
@@ -19,7 +19,7 @@ fi
 PYTHON_LDFLAGS=$(python3-config --ldflags --embed 2>/dev/null || python3-config --ldflags 2>/dev/null || echo "")
 
 # Set CGO_LDFLAGS to link with the Rust library
-export CGO_LDFLAGS="-L${LIB_DIR} -lsgl_model_gateway_go ${PYTHON_LDFLAGS} -ldl"
+export CGO_LDFLAGS="-L${LIB_DIR} -lsmg_go ${PYTHON_LDFLAGS} -ldl"
 
 # macOS uses DYLD_LIBRARY_PATH, Linux uses LD_LIBRARY_PATH
 if [[ "$OSTYPE" == "darwin"* ]]; then

--- a/bindings/golang/internal/ffi/client.go
+++ b/bindings/golang/internal/ffi/client.go
@@ -1,17 +1,17 @@
-// Package ffi provides Go bindings for SGLang's Rust FFI (Foreign Function Interface).
+// Package ffi provides Go bindings for SMG's Rust FFI (Foreign Function Interface).
 //
-// This package wraps the Rust FFI layer of SGLang, providing low-level access to:
+// This package wraps the Rust FFI layer of Shepherd Model Gateway, providing low-level access to:
 // - Client creation and connection management
 // - Chat completion streaming
 // - Stream reading and response conversion
 // - Memory management for C strings
 //
-// Internal use only: This package is intended for internal use by the sglang package.
-// End users should use the public sglang package instead.
+// Internal use only: This package is intended for internal use by the smg package.
+// End users should use the public smg package instead.
 package ffi
 
 /*
-#cgo LDFLAGS: -lsgl_model_gateway_go -ldl
+#cgo LDFLAGS: -lsmg_go -ldl
 #include <stdlib.h>
 #include <stdint.h>
 
@@ -87,13 +87,13 @@ func (e ErrorCode) Error() string {
 
 // SglangClientHandle wraps the Rust client SDK FFI handle.
 //
-// This struct maintains a connection to the SGLang gRPC server and is used
+// This struct maintains a connection to the SMG gRPC server and is used
 // to create streams and manage the underlying Rust client resources.
 type SglangClientHandle struct {
 	handle *C.SglangClientHandle
 }
 
-// NewClient creates a new SGLang client handle via FFI.
+// NewClient creates a new SMG client handle via FFI.
 //
 // This function initializes the Rust client with the given endpoint and tokenizer path.
 //

--- a/bindings/golang/internal/ffi/grpc_converter.go
+++ b/bindings/golang/internal/ffi/grpc_converter.go
@@ -1,7 +1,8 @@
+// Package ffi provides Go bindings for SMG's Rust FFI (Foreign Function Interface).
 package ffi
 
 /*
-#cgo LDFLAGS: -lsgl_model_gateway_go -ldl
+#cgo LDFLAGS: -lsmg_go -ldl
 #include <stdlib.h>
 #include <stdint.h>
 

--- a/bindings/golang/internal/ffi/postprocessor.go
+++ b/bindings/golang/internal/ffi/postprocessor.go
@@ -1,8 +1,8 @@
-// Package ffi provides Go bindings for SGLang's Rust FFI (Foreign Function Interface).
+// Package ffi provides Go bindings for SMG's Rust FFI (Foreign Function Interface).
 package ffi
 
 /*
-#cgo LDFLAGS: -lsgl_model_gateway_go -ldl
+#cgo LDFLAGS: -lsmg_go -ldl
 #include <stdlib.h>
 #include <stdint.h>
 

--- a/bindings/golang/internal/ffi/preprocessor.go
+++ b/bindings/golang/internal/ffi/preprocessor.go
@@ -1,8 +1,8 @@
-// Package ffi provides Go bindings for SGLang's Rust FFI (Foreign Function Interface).
+// Package ffi provides Go bindings for SMG's Rust FFI (Foreign Function Interface).
 package ffi
 
 /*
-#cgo LDFLAGS: -lsgl_model_gateway_go -ldl
+#cgo LDFLAGS: -lsmg_go -ldl
 #include <stdlib.h>
 #include <stdint.h>
 

--- a/bindings/golang/src/lib.rs
+++ b/bindings/golang/src/lib.rs
@@ -1,4 +1,4 @@
-//! FFI module for exposing sgl-model-gateway preprocessing and postprocessing functions
+//! FFI module for exposing Shepherd Model Gateway preprocessing and postprocessing functions
 //! to C-compatible languages (e.g., Golang via cgo)
 //!
 //! This module provides C-compatible function signatures for:

--- a/bindings/python/.coveragerc
+++ b/bindings/python/.coveragerc
@@ -1,7 +1,6 @@
 [run]
-source = sglang_router
+source = smg
 omit =
-    */mini_lb.py
     */cli.py
     */__main__.py
 

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "sgl-model-gateway-python"
+name = "smg-python"
 version = "0.3.2"
 edition = "2021"
 
@@ -12,13 +12,13 @@ pyo3 = { version = "0.27.1", features = ["extension-module", "abi3-py38"] }
 tokio = { version = "1.42.0", features = ["full"] }
 once_cell = "1.19"
 
-[dependencies.sgl-model-gateway]
+[dependencies.smg]
 path = "../.."
 default-features = true
 
 [features]
 default = ["pyo3/extension-module"]
-vendored-openssl = ["sgl-model-gateway/vendored-openssl"]
+vendored-openssl = ["smg/vendored-openssl"]
 
 [profile.ci]
 inherits = "release"

--- a/bindings/python/MANIFEST.in
+++ b/bindings/python/MANIFEST.in
@@ -6,4 +6,4 @@ include ../../LICENSE
 recursive-include src *.rs      # Python bindings wrapper
 recursive-include ../../src *.rs  # Main Rust source files
 recursive-include ../../src/proto *.proto  # Protobuf definitions
-recursive-include sglang_router *.py  # Python source files
+recursive-include smg *.py  # Python source files

--- a/build.rs
+++ b/build.rs
@@ -1,12 +1,12 @@
 use std::process::Command;
 
 const DEFAULT_VERSION: &str = "0.0.0";
-const DEFAULT_PROJECT_NAME: &str = "sgl-model-gateway";
+const DEFAULT_PROJECT_NAME: &str = "smg";
 
-/// Set a compile-time environment variable with the SGL_MODEL_GATEWAY_ prefix
+/// Set a compile-time environment variable with the SMG_ prefix
 macro_rules! set_env {
     ($name:expr, $value:expr) => {
-        println!("cargo:rustc-env=SGL_MODEL_GATEWAY_{}={}", $name, $value);
+        println!("cargo:rustc-env=SMG_{}={}", $name, $value);
     };
 }
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -49,10 +49,10 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
     && rustc --version && cargo --version && protoc --version
 
 # copy source code
-COPY --from=local_src /src /opt/sgl-model-gateway
+COPY --from=local_src /src /opt/smg
 
 # working directory
-WORKDIR /opt/sgl-model-gateway
+WORKDIR /opt/smg
 
 # install maturin and build the wheel with vendored OpenSSL
 RUN uv pip install maturin \
@@ -66,7 +66,7 @@ RUN uv pip install maturin \
 FROM base AS router-image
 
 # Copy the built package from the build image
-COPY --from=build-image /opt/sgl-model-gateway/bindings/python/dist/*.whl dist/
+COPY --from=build-image /opt/smg/bindings/python/dist/*.whl dist/
 
 # Build the package and install
 RUN uv pip install --force-reinstall dist/*.whl
@@ -76,4 +76,4 @@ RUN rm -rf /root/.cache dist/ \
     && apt purge -y --auto-remove curl
 
 # Set the entrypoint to the main command
-ENTRYPOINT ["python3", "-m", "sglang_router.launch_router"]
+ENTRYPOINT ["python3", "-m", "smg.launch_router"]

--- a/docs/contributing/code-style.md
+++ b/docs/contributing/code-style.md
@@ -40,7 +40,7 @@ cargo clippy -- -D warnings
 
 | Item | Convention | Example |
 |------|------------|---------|
-| Crates | `snake_case` | `sgl_model_gateway` |
+| Crates | `snake_case` | `smg` |
 | Modules | `snake_case` | `load_balancer` |
 | Types | `PascalCase` | `CircuitBreaker` |
 | Functions | `snake_case` | `get_healthy_workers` |

--- a/e2e_test/conftest.py
+++ b/e2e_test/conftest.py
@@ -122,7 +122,7 @@ from pathlib import Path
 # Path setup (must happen before other imports)
 # ---------------------------------------------------------------------------
 
-_ROOT = Path(__file__).resolve().parents[1]  # sgl-model-gateway/
+_ROOT = Path(__file__).resolve().parents[1]  # smg/
 _E2E_TEST = Path(__file__).resolve().parent  # e2e_test/
 _SRC = _ROOT / "bindings" / "python"
 

--- a/e2e_test/infra/gateway.py
+++ b/e2e_test/infra/gateway.py
@@ -1,4 +1,4 @@
-"""Gateway class for managing sgl-model-gateway router instances."""
+"""Gateway class for managing Shepherd Model Gateway router instances."""
 
 from __future__ import annotations
 
@@ -33,7 +33,7 @@ class WorkerInfo:
 
 
 class Gateway:
-    """Manages a sgl-model-gateway router instance.
+    """Manages a Shepherd Model Gateway router instance.
 
     Provides lifecycle management and API access for:
     - Starting/stopping the router

--- a/e2e_test/pyproject.toml
+++ b/e2e_test/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
-name = "sgl-model-gateway-e2e-tests"
+name = "smg-e2e-tests"
 version = "0.1.0"
-description = "E2E tests for sgl-model-gateway"
+description = "E2E tests for Shepherd Model Gateway"
 requires-python = ">=3.9"
 
 dependencies = [

--- a/examples/wasm/README.md
+++ b/examples/wasm/README.md
@@ -1,6 +1,6 @@
-# WASM Guest Examples for sgl-model-gateway
+# WASM Guest Examples for Shepherd Model Gateway
 
-This directory contains example WASM middleware components demonstrating how to implement custom middleware for sgl-model-gateway using the WebAssembly Component Model.
+This directory contains example WASM middleware components demonstrating how to implement custom middleware for Shepherd Model Gateway (SMG) using the WebAssembly Component Model.
 
 ## Examples Overview
 
@@ -56,7 +56,7 @@ All examples require:
 - Rust toolchain (latest stable)
 - `wasm32-wasip2` target: `rustup target add wasm32-wasip2`
 - `wasm-tools`: `cargo install wasm-tools`
-- sgl-model-gateway running with WASM enabled (`--enable-wasm`)
+- SMG running with WASM enabled (`--enable-wasm`)
 
 ## Building All Examples
 

--- a/examples/wasm/wasm-guest-auth/README.md
+++ b/examples/wasm/wasm-guest-auth/README.md
@@ -1,6 +1,6 @@
-# WASM Auth Example for sgl-model-gateway
+# WASM Auth Example for Shepherd Model Gateway
 
-This example demonstrates API key authentication middleware for sgl-model-gateway using the WebAssembly Component Model.
+This example demonstrates API key authentication middleware for Shepherd Model Gateway (SMG) using the WebAssembly Component Model.
 
 ## Overview
 

--- a/examples/wasm/wasm-guest-auth/src/lib.rs
+++ b/examples/wasm/wasm-guest-auth/src/lib.rs
@@ -1,21 +1,21 @@
-//! WASM Guest Auth Example for sgl-model-gateway
+//! WASM Guest Auth Example for Shepherd Model Gateway
 //!
 //! This example demonstrates API key authentication middleware
-//! for sgl-model-gateway using the WebAssembly Component Model.
+//! for Shepherd Model Gateway using the WebAssembly Component Model.
 //!
 //! Features:
 //! - API Key authentication
 
 wit_bindgen::generate!({
-    path: "../../../src/wasm/interface",
-    world: "sgl-model-gateway",
+    path: "../../../wasm/src/interface",
+    world: "smg",
 });
 
-use exports::sgl::model_gateway::{
+use exports::smg::gateway::{
     middleware_on_request::Guest as OnRequestGuest,
     middleware_on_response::Guest as OnResponseGuest,
 };
-use sgl::model_gateway::middleware_types::{Action, Request, Response};
+use smg::gateway::middleware_types::{Action, Request, Response};
 
 /// Expected API Key (in production, this should be passed as configuration)
 const EXPECTED_API_KEY: &str = "secret-api-key-12345";
@@ -25,7 +25,7 @@ struct Middleware;
 
 // Helper function to find header value
 fn find_header_value(
-    headers: &[sgl::model_gateway::middleware_types::Header],
+    headers: &[smg::gateway::middleware_types::Header],
     name: &str,
 ) -> Option<String> {
     headers

--- a/examples/wasm/wasm-guest-logging/README.md
+++ b/examples/wasm/wasm-guest-logging/README.md
@@ -1,6 +1,6 @@
-# WASM Logging Example for sgl-model-gateway
+# WASM Logging Example for Shepherd Model Gateway
 
-This example demonstrates logging and tracing middleware for sgl-model-gateway using the WebAssembly Component Model.
+This example demonstrates logging and tracing middleware for Shepherd Model Gateway (SMG) using the WebAssembly Component Model.
 
 ## Overview
 

--- a/examples/wasm/wasm-guest-logging/src/lib.rs
+++ b/examples/wasm/wasm-guest-logging/src/lib.rs
@@ -1,22 +1,22 @@
-//! WASM Guest Logging Example for sgl-model-gateway
+//! WASM Guest Logging Example for Shepherd Model Gateway
 //!
 //! This example demonstrates logging and tracing middleware
-//! for sgl-model-gateway using the WebAssembly Component Model.
+//! for Shepherd Model Gateway using the WebAssembly Component Model.
 //!
 //! Features:
 //! - Request tracking and tracing headers
 //! - Response status code conversion
 
 wit_bindgen::generate!({
-    path: "../../../src/wasm/interface",
-    world: "sgl-model-gateway",
+    path: "../../../wasm/src/interface",
+    world: "smg",
 });
 
-use exports::sgl::router::{
+use exports::smg::gateway::{
     middleware_on_request::Guest as OnRequestGuest,
     middleware_on_response::Guest as OnResponseGuest,
 };
-use sgl::router::middleware_types::{Action, Header, ModifyAction, Request, Response};
+use smg::gateway::middleware_types::{Action, Header, ModifyAction, Request, Response};
 
 /// Main middleware implementation
 struct Middleware;

--- a/examples/wasm/wasm-guest-ratelimit/README.md
+++ b/examples/wasm/wasm-guest-ratelimit/README.md
@@ -1,6 +1,6 @@
-# WASM Rate Limit Example for sgl-model-gateway
+# WASM Rate Limit Example for Shepherd Model Gateway
 
-This example demonstrates rate limiting middleware for sgl-model-gateway using the WebAssembly Component Model.
+This example demonstrates rate limiting middleware for Shepherd Model Gateway (SMG) using the WebAssembly Component Model.
 
 ## Overview
 

--- a/examples/wasm/wasm-guest-ratelimit/src/lib.rs
+++ b/examples/wasm/wasm-guest-ratelimit/src/lib.rs
@@ -1,7 +1,7 @@
-//! WASM Guest Rate Limit Example for sgl-model-gateway
+//! WASM Guest Rate Limit Example for Shepherd Model Gateway
 //!
 //! This example demonstrates rate limiting middleware
-//! for sgl-model-gateway using the WebAssembly Component Model.
+//! for Shepherd Model Gateway using the WebAssembly Component Model.
 //!
 //! Features:
 //! - Rate limiting based on API Key or IP address
@@ -13,17 +13,17 @@
 //! implementing rate limiting at the host/router level with shared state.
 
 wit_bindgen::generate!({
-    path: "../../../src/wasm/interface",
-    world: "sgl-model-gateway",
+    path: "../../../wasm/src/interface",
+    world: "smg",
 });
 
 use std::cell::RefCell;
 
-use exports::sgl::router::{
+use exports::smg::gateway::{
     middleware_on_request::Guest as OnRequestGuest,
     middleware_on_response::Guest as OnResponseGuest,
 };
-use sgl::router::middleware_types::{Action, Request, Response};
+use smg::gateway::middleware_types::{Action, Request, Response};
 
 /// Main middleware implementation
 struct Middleware;
@@ -87,7 +87,7 @@ thread_local! {
 fn get_identifier(req: &Request) -> String {
     // Helper function to find header value
     let find_header_value =
-        |headers: &[sgl::router::middleware_types::Header], name: &str| -> Option<String> {
+        |headers: &[smg::gateway::middleware_types::Header], name: &str| -> Option<String> {
             headers
                 .iter()
                 .find(|h| h.name.eq_ignore_ascii_case(name))

--- a/mesh/Cargo.toml
+++ b/mesh/Cargo.toml
@@ -2,7 +2,7 @@
 name = "smg-mesh"
 version = "0.1.0"
 edition = "2021"
-description = "Mesh gossip protocol and distributed state synchronization for sgl-model-gateway"
+description = "Mesh gossip protocol and distributed state synchronization for Shepherd Model Gateway"
 license = "Apache-2.0"
 repository = "https://github.com/lightseekorg/smg"
 authors = [

--- a/scripts/generate_gateway_release_notes.sh
+++ b/scripts/generate_gateway_release_notes.sh
@@ -6,7 +6,7 @@ set -e
 
 # Configuration
 GATEWAY_PATHS=(
-    "sgl-model-gateway"
+    "smg"
     "python/sglang/srt/grpc"
     "python/sglang/srt/entrypoints/grpc_server.py"
 )
@@ -86,7 +86,7 @@ if [[ -z "$PREV_TAG" ]] || [[ -z "$CURR_TAG" ]]; then
     usage
 fi
 
-# Navigate to repo root (main sglang repo, not sgl-model-gateway)
+# Navigate to repo root (main sglang repo, not smg)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 cd "$REPO_ROOT"

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -38,7 +38,7 @@ use crate::{
         module::{MiddlewareAttachPoint, WasmModuleAttachPoint},
         spec::{
             apply_modify_action_to_headers, build_wasm_headers_from_axum_headers,
-            sgl::model_gateway::middleware_types::{
+            smg::gateway::middleware_types::{
                 Action, Request as WasmRequest, Response as WasmResponse,
             },
         },

--- a/src/version.rs
+++ b/src/version.rs
@@ -4,7 +4,7 @@
 
 macro_rules! build_env {
     ($name:ident) => {
-        env!(concat!("SGL_MODEL_GATEWAY_", stringify!($name)))
+        env!(concat!("SMG_", stringify!($name)))
     };
 }
 

--- a/src/wasm/mod.rs
+++ b/src/wasm/mod.rs
@@ -1,4 +1,4 @@
-//! WebAssembly (WASM) module support for sgl-model-gateway
+//! WebAssembly (WASM) module support for Shepherd Model Gateway
 //!
 //! This module re-exports the smg-wasm crate and provides HTTP API routes.
 

--- a/tests/wasm_test.rs
+++ b/tests/wasm_test.rs
@@ -744,7 +744,7 @@ async fn test_wasm_module_execution() {
 
     // Execute the module
     use smg::wasm::{
-        spec::sgl::model_gateway::middleware_types,
+        spec::smg::gateway::middleware_types,
         types::{WasmComponentInput, WasmComponentOutput},
     };
 

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -2,7 +2,7 @@
 name = "smg-wasm"
 version = "0.1.0"
 edition = "2021"
-description = "WebAssembly runtime and module management for sgl-model-gateway"
+description = "WebAssembly runtime and module management for Shepherd Model Gateway"
 license = "Apache-2.0"
 repository = "https://github.com/lightseekorg/smg"
 authors = [

--- a/wasm/README.md
+++ b/wasm/README.md
@@ -1,10 +1,10 @@
-# WebAssembly (WASM) Extensibility for sgl-model-gateway
+# WebAssembly (WASM) Extensibility for Shepherd Model Gateway
 
-This module provides WebAssembly-based extensibility for sgl-model-gateway, enabling dynamic, safe, and portable middleware execution without requiring router restarts or recompilation.
+This module provides WebAssembly-based extensibility for Shepherd Model Gateway (SMG), enabling dynamic, safe, and portable middleware execution without requiring router restarts or recompilation.
 
 ## Overview
 
-The WASM module allows you to extend sgl-model-gateway functionality by deploying WebAssembly components that can:
+The WASM module allows you to extend SMG functionality by deploying WebAssembly components that can:
 
 - **Intercept requests/responses** at various lifecycle points (OnRequest, OnResponse)
 - **Modify HTTP headers and bodies** before/after processing
@@ -68,7 +68,7 @@ See [`interface/`](./interface/) for the complete interface definition.
 
 ### Prerequisites
 
-- sgl-model-gateway compiled with WASM support
+- SMG compiled with WASM support
 - Rust toolchain (for building WASM components)
 - `wasm32-wasip2` target: `rustup target add wasm32-wasip2`
 - `wasm-tools`: `cargo install wasm-tools`
@@ -78,7 +78,7 @@ See [`interface/`](./interface/) for the complete interface definition.
 Enable WASM support when starting the router:
 
 ```bash
-./sgl-model-gateway --enable-wasm --worker-urls=http://0.0.0.0:30000 --port=3000
+./smg --enable-wasm --worker-urls=http://0.0.0.0:30000 --port=3000
 ```
 
 ### Deploying a WASM Module
@@ -207,12 +207,12 @@ Define your component using the WASM interface from `interface/spec.*`:
 
 ```rust
 wit_bindgen::generate!({
-    path: "../../../src/wasm/interface",
-    world: "sgl-model-gateway",
+    path: "../../../wasm/src/interface",
+    world: "smg",
 });
 
-use exports::sgl::model_gateway::middleware_on_request::Guest as OnRequestGuest;
-use sgl::model_gateway::middleware_types::{Request, Action};
+use exports::smg::gateway::middleware_on_request::Guest as OnRequestGuest;
+use smg::gateway::middleware_types::{Request, Action};
 
 struct Middleware;
 

--- a/wasm/src/interface/spec.wit
+++ b/wasm/src/interface/spec.wit
@@ -1,4 +1,4 @@
-package sgl:model-gateway;
+package smg:gateway;
 
 interface middleware-types {
   record header { name: string, value: string }
@@ -48,7 +48,7 @@ interface middleware-on-response {
   on-response: func(resp: response) -> action;
 }
 
-world sgl-model-gateway {
+world smg {
   export middleware-on-request;
   export middleware-on-response;
 }

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -1,4 +1,4 @@
-//! WebAssembly (WASM) module support for sgl-model-gateway
+//! WebAssembly (WASM) module support for Shepherd Model Gateway
 //!
 //! This crate provides WASM component execution capabilities using the WebAssembly Component Model.
 //! It supports middleware execution at various attach points (OnRequest, OnResponse) with async support.
@@ -21,7 +21,5 @@ pub use module::{
 };
 pub use module_manager::WasmModuleManager;
 pub use runtime::WasmRuntime;
-pub use spec::{
-    apply_modify_action_to_headers, build_wasm_headers_from_axum_headers, sgl, SglModelGateway,
-};
+pub use spec::{apply_modify_action_to_headers, build_wasm_headers_from_axum_headers, smg, Smg};
 pub use types::{WasiState, WasmComponentInput, WasmComponentOutput};

--- a/wasm/src/module_manager.rs
+++ b/wasm/src/module_manager.rs
@@ -232,7 +232,7 @@ impl WasmModuleManager {
         module: &WasmModule,
         attach_point: WasmModuleAttachPoint,
         input: WasmComponentInput,
-    ) -> Option<crate::spec::sgl::model_gateway::middleware_types::Action> {
+    ) -> Option<crate::spec::smg::gateway::middleware_types::Action> {
         use tracing::error;
 
         let action_result = self

--- a/wasm/src/runtime.rs
+++ b/wasm/src/runtime.rs
@@ -31,7 +31,7 @@ use crate::{
     config::WasmRuntimeConfig,
     errors::{Result, WasmError, WasmRuntimeError},
     module::{MiddlewareAttachPoint, WasmModuleAttachPoint},
-    spec::SglModelGateway,
+    spec::Smg,
     types::{WasiState, WasmComponentInput, WasmComponentOutput},
 };
 
@@ -420,7 +420,7 @@ impl WasmThreadPool {
                 };
 
                 // Instantiate component (must use async instantiation when async support is enabled)
-                let bindings = SglModelGateway::instantiate_async(&mut store, &component, &linker)
+                let bindings = Smg::instantiate_async(&mut store, &component, &linker)
                     .await
                     .map_err(|e| {
                         WasmError::from(WasmRuntimeError::InstanceCreateFailed(e.to_string()))
@@ -428,7 +428,7 @@ impl WasmThreadPool {
 
                 // Call on-request (async call when async support is enabled)
                 let action_result = bindings
-                    .sgl_model_gateway_middleware_on_request()
+                    .smg_gateway_middleware_on_request()
                     .call_on_request(&mut store, &request)
                     .await
                     .map_err(|e| map_wasm_error(e, config.max_execution_time_ms))?;
@@ -448,7 +448,7 @@ impl WasmThreadPool {
                 };
 
                 // Instantiate component (must use async instantiation when async support is enabled)
-                let bindings = SglModelGateway::instantiate_async(&mut store, &component, &linker)
+                let bindings = Smg::instantiate_async(&mut store, &component, &linker)
                     .await
                     .map_err(|e| {
                         WasmError::from(WasmRuntimeError::InstanceCreateFailed(e.to_string()))
@@ -456,7 +456,7 @@ impl WasmThreadPool {
 
                 // Call on-response (async call when async support is enabled)
                 let action_result = bindings
-                    .sgl_model_gateway_middleware_on_response()
+                    .smg_gateway_middleware_on_response()
                     .call_on_response(&mut store, &response)
                     .await
                     .map_err(|e| map_wasm_error(e, config.max_execution_time_ms))?;

--- a/wasm/src/spec.rs
+++ b/wasm/src/spec.rs
@@ -7,7 +7,7 @@ use axum::http::{header, HeaderMap, HeaderValue};
 
 wasmtime::component::bindgen!({
     path: "src/interface",
-    world: "sgl-model-gateway",
+    world: "smg",
     imports: { default: async | trappable },
     exports: { default: async },
 });
@@ -15,11 +15,11 @@ wasmtime::component::bindgen!({
 /// Build WebAssembly headers from Axum HeaderMap
 pub fn build_wasm_headers_from_axum_headers(
     headers: &HeaderMap,
-) -> Vec<sgl::model_gateway::middleware_types::Header> {
+) -> Vec<smg::gateway::middleware_types::Header> {
     let mut wasm_headers = Vec::new();
     for (name, value) in headers.iter() {
         if let Ok(value_str) = value.to_str() {
-            wasm_headers.push(sgl::model_gateway::middleware_types::Header {
+            wasm_headers.push(smg::gateway::middleware_types::Header {
                 name: name.as_str().to_string(),
                 value: value_str.to_string(),
             });
@@ -31,7 +31,7 @@ pub fn build_wasm_headers_from_axum_headers(
 /// Apply ModifyAction header modifications to Axum HeaderMap
 pub fn apply_modify_action_to_headers(
     headers: &mut HeaderMap,
-    modify: &sgl::model_gateway::middleware_types::ModifyAction,
+    modify: &smg::gateway::middleware_types::ModifyAction,
 ) {
     // Apply headers_set
     for header_mod in &modify.headers_set {

--- a/wasm/src/types.rs
+++ b/wasm/src/types.rs
@@ -8,7 +8,7 @@ use wasmtime_wasi::{WasiCtx, WasiCtxView, WasiView};
 
 use crate::{
     module::{MiddlewareAttachPoint, WasmModuleAttachPoint},
-    spec::sgl::model_gateway::middleware_types,
+    spec::smg::gateway::middleware_types,
 };
 
 /// Generic input type for WASM component execution


### PR DESCRIPTION
This commit completes the comprehensive renaming from sgl-model-gateway to smg (Shepherd Model Gateway) throughout the project.

Package and Library Names:
- Cargo.toml: package name sgl-model-gateway → smg, binary name → smg
- bindings/golang/Cargo.toml: smg-golang, lib name smg_go
- bindings/python/Cargo.toml: smg-python, lib name smg_rs
- mesh/Cargo.toml: description updated to Shepherd Model Gateway
- wasm/Cargo.toml: description updated to Shepherd Model Gateway

WASM Component Model:
- wasm/src/interface/spec.wit: package smg:gateway, world smg
- wasm/src/spec.rs: world "smg", namespace smg::gateway::middleware_types
- wasm/src/runtime.rs: Smg struct, smg_gateway_middleware_on_* methods
- wasm/src/lib.rs: export smg, Smg instead of sgl, SglModelGateway
- examples/wasm/*/src/lib.rs: updated imports to smg::gateway

Build System:
- build.rs: SMG_ env prefix instead of SGL_MODEL_GATEWAY_
- Makefile: updated paths and descriptions
- docker/Dockerfile: paths and entrypoint to smg.launch_router

Golang Bindings:
- internal/ffi/*.go: #cgo LDFLAGS -lsmg_go, updated doc comments
- Makefile: LIB_NAME = libsmg_go
- examples/*/run.sh: library references updated
- README.md: package references and examples

Documentation:
- wasm/README.md: SMG references and code examples
- examples/wasm/*/README.md: Shepherd Model Gateway
- bindings/golang/README.md: SMG SDK documentation
- docs/contributing/code-style.md: crate naming example

CI/CD and Scripts:
- .github/workflows/pr-test-rust.yml: docker tag smg:test
- scripts/generate_gateway_release_notes.sh: path references

Tests:
- e2e_test/pyproject.toml: smg-e2e-tests
- e2e_test/conftest.py: path comment
- e2e_test/infra/gateway.py: doc comments
- bindings/python/.coveragerc: source = smg
- bindings/python/MANIFEST.in: smg directory