### PR TITLE
Use request-scoped MCP contexts in gRPC responses

### DIFF
--- a/mcp/src/manager.rs
+++ b/mcp/src/manager.rs
@@ -889,6 +889,7 @@ impl McpManager {
 pub struct RequestMcpContext {
     inventory: Arc<ToolInventory>,
     clients: HashMap<String, Arc<McpClient>>,
+    server_keys: Vec<String>,
 }
 
 impl RequestMcpContext {
@@ -896,11 +897,16 @@ impl RequestMcpContext {
         inventory: Arc<ToolInventory>,
         clients: HashMap<String, Arc<McpClient>>,
     ) -> Self {
-        Self { inventory, clients }
+        let server_keys = clients.keys().cloned().collect();
+        Self {
+            inventory,
+            clients,
+            server_keys,
+        }
     }
 
-    pub fn server_keys(&self) -> Vec<String> {
-        self.clients.keys().cloned().collect()
+    pub fn server_keys(&self) -> &[String] {
+        &self.server_keys
     }
 
     pub fn list_tools_for_servers(&self, server_keys: &[String]) -> Vec<Tool> {

--- a/model_gateway/src/routers/grpc/common/responses/context.rs
+++ b/model_gateway/src/routers/grpc/common/responses/context.rs
@@ -2,7 +2,7 @@
 //!
 //! This context is used by both regular and harmony response implementations.
 
-use std::sync::{Arc, RwLock as StdRwLock};
+use std::sync::Arc;
 
 use crate::{
     data_connector::{ConversationItemStorage, ConversationStorage, ResponseStorage},
@@ -33,9 +33,6 @@ pub(crate) struct ResponsesContext {
 
     /// MCP manager for tool support
     pub mcp_manager: Arc<McpManager>,
-
-    /// Server keys for MCP tools requested in this context
-    pub requested_servers: Arc<StdRwLock<Vec<String>>>,
 }
 
 impl ResponsesContext {
@@ -55,7 +52,6 @@ impl ResponsesContext {
             conversation_storage,
             conversation_item_storage,
             mcp_manager,
-            requested_servers: Arc::new(StdRwLock::new(Vec::new())),
         }
     }
 }

--- a/model_gateway/src/routers/grpc/harmony/responses/execution.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/execution.rs
@@ -8,7 +8,7 @@ use tracing::{debug, error, warn};
 
 use super::common::McpCallTracking;
 use crate::{
-    mcp::{self, McpManager},
+    mcp::{self, RequestMcpContext},
     observability::metrics::{metrics_labels, Metrics},
     protocols::{
         common::{Function, ToolCall},
@@ -43,7 +43,7 @@ pub(crate) struct ToolResult {
 ///
 /// Vector of tool results (one per tool call)
 pub(super) async fn execute_mcp_tools(
-    mcp_manager: &Arc<McpManager>,
+    mcp_manager: &Arc<RequestMcpContext>,
     tool_calls: &[ToolCall],
     tracking: &mut McpCallTracking,
     model_id: &str,

--- a/model_gateway/src/routers/grpc/regular/responses/common.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/common.rs
@@ -15,7 +15,7 @@ use uuid::Uuid;
 
 use crate::{
     data_connector::{self, ConversationId, ResponseId},
-    mcp::{self, McpManager},
+    mcp::{self, RequestMcpContext},
     protocols::{
         chat::ChatCompletionRequest,
         common::{Function, Tool, ToolChoice, ToolChoiceValue},
@@ -178,7 +178,7 @@ pub(super) fn generate_mcp_id(prefix: &str) -> String {
 
 /// Build mcp_list_tools output item
 pub(super) fn build_mcp_list_tools_item(
-    mcp: &Arc<McpManager>,
+    mcp: &Arc<RequestMcpContext>,
     server_label: &str,
     server_keys: &[String],
 ) -> ResponseOutputItem {

--- a/model_gateway/src/routers/openai/responses/non_streaming.rs
+++ b/model_gateway/src/routers/openai/responses/non_streaming.rs
@@ -55,7 +55,7 @@ pub async fn handle_non_streaming_response(mut ctx: RequestContext) -> Response 
         .await;
     let server_keys = active_mcp
         .as_ref()
-        .map(|ctx| ctx.server_keys())
+        .map(|ctx| ctx.server_keys().to_vec())
         .unwrap_or_default();
 
     let mut response_json: Value;

--- a/model_gateway/src/routers/openai/responses/streaming.rs
+++ b/model_gateway/src/routers/openai/responses/streaming.rs
@@ -997,7 +997,7 @@ pub async fn handle_streaming_response(ctx: RequestContext) -> Response {
         .await;
     let server_keys = active_mcp
         .as_ref()
-        .map(|ctx| ctx.server_keys())
+        .map(|ctx| ctx.server_keys().to_vec())
         .unwrap_or_default();
 
     let client = ctx.components.client().clone();


### PR DESCRIPTION
Follow up on PR https://github.com/lightseekorg/smg/pull/43
- Cache per-request server_keys inside RequestMcpContext and return them by reference.
- Remove gRPC’s shared requested_servers state and propagate request-scoped MCP context through regular/harmony paths.
- Update tool listing/calls to use request-scoped keys and adjust OpenAI router to the new server_keys() signature.