### PR TITLE
ci: re-enable GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,8 +1,14 @@
 name: Documentation
 
-# Disabled: Docs are private (view in repo). Re-enable when repo goes public.
 on:
-  workflow_dispatch:  # Manual trigger only
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -32,13 +38,11 @@ jobs:
         run: mkdocs build --strict
 
       - name: Upload artifact
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-pages-artifact@v3
         with:
           path: ./site
 
   deploy:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary
Re-enable automatic GitHub Pages deployment now that enterprise access controls are available.

## Changes
- Trigger deployment on push to main when `docs/**`, `mkdocs.yml`, or the workflow itself changes
- Keep manual `workflow_dispatch` trigger for on-demand deployments
- Remove unnecessary conditional checks (workflow only runs on main branch anyway)

## Setup Required
After merging, configure access control in repo settings:
1. **Settings** → **Pages** → **Source**: GitHub Actions
2. **Settings** → **Pages** → **Access Control**: Select restricted access option

## Test plan
- [ ] Merge PR and verify workflow runs
- [ ] Confirm site deploys to https://lightseekorg.github.io/smg/
- [ ] Verify access controls work as expected