### PR TITLE
fix: remove broken cli.md references in docs

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -76,8 +76,7 @@ In-depth guides for configuring specific SMG features and subsystems.
 
 For a complete list of all configuration options, see:
 
-- [CLI Reference](../reference/cli.md) - All command-line flags
-- [Configuration Reference](../reference/configuration.md) - Configuration options by category
+- [Configuration Reference](../reference/configuration.md) - All CLI options, environment variables, and configuration by category
 
 ---
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -36,19 +36,11 @@ Reference documentation provides detailed specifications for SMG's APIs, CLI, co
 
 <div class="grid cards" markdown>
 
--   :material-console:{ .lg .middle } **CLI Reference**
+-   :material-cog:{ .lg .middle } **Configuration Reference**
 
     ---
 
-    Complete command-line interface reference with all options and environment variables.
-
-    [:octicons-arrow-right-24: CLI Reference](cli.md)
-
--   :material-cog:{ .lg .middle } **Configuration**
-
-    ---
-
-    Configuration options for tuning SMG behavior including routing, rate limiting, and reliability.
+    Complete CLI options, environment variables, and configuration for tuning SMG behavior.
 
     [:octicons-arrow-right-24: Configuration](configuration.md)
 
@@ -76,8 +68,8 @@ Reference documentation provides detailed specifications for SMG's APIs, CLI, co
 
 | Reference | Description |
 |-----------|-------------|
-| [CLI Options](cli.md#options) | All command-line flags |
-| [Environment Variables](cli.md#environment-variables) | Configurable environment variables |
+| [CLI Options](configuration.md#worker-configuration) | All command-line flags |
+| [Environment Variables](configuration.md#environment-variable-reference) | Configurable environment variables |
 | [Chat Completions API](api/openai.md#chat-completions) | `/v1/chat/completions` endpoint |
 | [HTTP Metrics](metrics.md#layer-1-http-metrics) | HTTP request metrics |
 | [Worker Metrics](metrics.md#layer-3-worker-metrics) | Worker health and performance metrics |


### PR DESCRIPTION
## Summary
Fix broken links to non-existent `cli.md` file that caused `mkdocs build --strict` to fail.

## Changes
- **docs/reference/index.md**: Update links to point to `configuration.md`
- **docs/configuration/index.md**: Remove reference to `cli.md`

The `configuration.md` file already contains comprehensive CLI reference including all options and environment variables.

## Test plan
- [x] `mkdocs build --strict` passes