### PR TITLE
fix(mcp): pass raw auth token to rmcp transport

### DIFF
--- a/mcp/src/manager.rs
+++ b/mcp/src/manager.rs
@@ -853,7 +853,7 @@ impl McpManager {
 
                 let transport = if let Some(tok) = token {
                     let mut cfg = StreamableHttpClientTransportConfig::with_uri(url.as_str());
-                    cfg.auth_header = Some(format!("Bearer {}", tok));
+                    cfg.auth_header = Some(tok.to_string());
                     StreamableHttpClientTransport::from_config(cfg)
                 } else {
                     StreamableHttpClientTransport::from_uri(url.as_str())


### PR DESCRIPTION
- Stop prefixing Bearer  when setting MCP streamable auth header
- Prevent double-Bearer Authorization headers with rmcp’s bearer_auth logic