### PR TITLE
ci: add automated crate publishing workflows

### DIFF
--- a/.github/actions/publish-crate/action.yml
+++ b/.github/actions/publish-crate/action.yml
@@ -27,16 +27,17 @@ runs:
       id: check
       shell: bash
       run: |
-        LOCAL=$(grep '^version = ' ${{ inputs.path }}/Cargo.toml | head -1 | cut -d'"' -f2)
+        LOCAL=$(grep -E '^[[:space:]]*version[[:space:]]*=' ${{ inputs.path }}/Cargo.toml | head -1 | cut -d'"' -f2)
         PUBLISHED=$(curl -s "https://crates.io/api/v1/crates/${{ inputs.crate }}" | jq -r '.crate.max_version // "0.0.0"')
         echo "local=${LOCAL}" >> $GITHUB_OUTPUT
         echo "published=${PUBLISHED}" >> $GITHUB_OUTPUT
         echo "${{ inputs.crate }}: local=${LOCAL}, published=${PUBLISHED}"
-        if [ "${LOCAL}" != "${PUBLISHED}" ]; then
+        # Use sort -V for proper semver comparison (publish only if local is newer)
+        if [ "$(printf '%s\n' "$PUBLISHED" "$LOCAL" | sort -V | tail -n1)" = "$LOCAL" ] && [ "$LOCAL" != "$PUBLISHED" ]; then
           echo "changed=true" >> $GITHUB_OUTPUT
         else
           echo "changed=false" >> $GITHUB_OUTPUT
-          echo "Version unchanged, skipping publish"
+          echo "Version unchanged or older, skipping publish"
         fi
 
     - name: Setup Rust

--- a/.github/workflows/release-auth.yml
+++ b/.github/workflows/release-auth.yml
@@ -1,5 +1,8 @@
 name: Publish auth
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/release-data-connector.yml
+++ b/.github/workflows/release-data-connector.yml
@@ -1,5 +1,8 @@
 name: Publish data-connector
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/release-kv-index.yml
+++ b/.github/workflows/release-kv-index.yml
@@ -1,5 +1,8 @@
 name: Publish kv-index
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/release-llm-multimodal.yml
+++ b/.github/workflows/release-llm-multimodal.yml
@@ -1,5 +1,8 @@
 name: Publish llm-multimodal
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/release-llm-tokenizer.yml
+++ b/.github/workflows/release-llm-tokenizer.yml
@@ -1,5 +1,8 @@
 name: Publish llm-tokenizer
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/release-openai-protocol.yml
+++ b/.github/workflows/release-openai-protocol.yml
@@ -1,5 +1,8 @@
 name: Publish openai-protocol
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/release-reasoning-parser.yml
+++ b/.github/workflows/release-reasoning-parser.yml
@@ -1,5 +1,8 @@
 name: Publish reasoning-parser
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/release-smg-grpc-client.yml
+++ b/.github/workflows/release-smg-grpc-client.yml
@@ -1,5 +1,8 @@
 name: Publish smg-grpc-client
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/release-smg-mcp.yml
+++ b/.github/workflows/release-smg-mcp.yml
@@ -1,5 +1,8 @@
 name: Publish smg-mcp
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/release-smg-mesh.yml
+++ b/.github/workflows/release-smg-mesh.yml
@@ -1,5 +1,8 @@
 name: Publish smg-mesh
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/release-smg-wasm.yml
+++ b/.github/workflows/release-smg-wasm.yml
@@ -1,5 +1,8 @@
 name: Publish smg-wasm
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/release-tool-parser.yml
+++ b/.github/workflows/release-tool-parser.yml
@@ -1,5 +1,8 @@
 name: Publish tool-parser
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/release-wfaas.yml
+++ b/.github/workflows/release-wfaas.yml
@@ -1,5 +1,8 @@
 name: Publish wfaas
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
## Summary
Add automated publishing to crates.io for all workspace crates.

## Changes
- **`.github/actions/publish-crate/action.yml`**: Reusable composite action that:
  - Checks local version against crates.io
  - Sets up Rust only if publish needed
  - Publishes to crates.io

- **13 workflow files** for each crate:
  - `release-openai-protocol.yml`
  - `release-reasoning-parser.yml`
  - `release-tool-parser.yml`
  - `release-wfaas.yml`
  - `release-llm-tokenizer.yml`
  - `release-auth.yml`
  - `release-smg-mcp.yml`
  - `release-kv-index.yml`
  - `release-data-connector.yml`
  - `release-llm-multimodal.yml`
  - `release-smg-wasm.yml`
  - `release-smg-mesh.yml`
  - `release-smg-grpc-client.yml`

## How it works
1. Workflow triggers on push to `main` when crate's `Cargo.toml` changes
2. Compares local version with published version on crates.io
3. Publishes only if version is different
4. Can also be triggered manually via `workflow_dispatch`

## Setup required
Add repository secret: `CARGO_REGISTRY_TOKEN` with your crates.io API token

## Test plan
- [ ] Add `CARGO_REGISTRY_TOKEN` secret
- [ ] Bump a crate version and merge to test