### PR TITLE
chore: prepare v1.0.0 release

### DIFF
--- a/auth/Cargo.toml
+++ b/auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "auth"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2021"
 description = "Authentication and authorization for control plane APIs"
 license = "Apache-2.0"

--- a/data_connector/Cargo.toml
+++ b/data_connector/Cargo.toml
@@ -1,14 +1,17 @@
 [package]
 name = "data-connector"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2021"
 description = "Storage backends for conversations and responses"
 license = "Apache-2.0"
+repository = "https://github.com/lightseekorg/smg"
 authors = [
     "Simo Lin <linsimo.mark@gmail.com>",
     "Chang Su <mckvtl@gmail.com>",
     "Keyang Ru <rukeyang@gmail.com>",
 ]
+keywords = ["storage", "database", "postgres", "redis", "oracle"]
+categories = ["database", "asynchronous"]
 
 [dependencies]
 async-trait.workspace = true

--- a/grpc_client/Cargo.toml
+++ b/grpc_client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-grpc-client"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2021"
 description = "gRPC clients for SGLang and vLLM backends"
 license = "Apache-2.0"

--- a/kv_index/Cargo.toml
+++ b/kv_index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kv-index"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2021"
 description = "Radix tree implementations for prefix matching and cache-aware routing"
 license = "Apache-2.0"

--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-mcp"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2021"
 description = "Model Context Protocol (MCP) client implementation"
 license = "Apache-2.0"

--- a/mesh/Cargo.toml
+++ b/mesh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-mesh"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2021"
 description = "Mesh gossip protocol and distributed state synchronization for Shepherd Model Gateway"
 license = "Apache-2.0"

--- a/model_gateway/Cargo.toml
+++ b/model_gateway/Cargo.toml
@@ -1,7 +1,17 @@
 [package]
 name = "smg"
-version = "0.3.2"
+version = "1.0.0"
 edition = "2021"
+description = "High-performance model-routing gateway for large-scale LLM deployments"
+license = "Apache-2.0"
+repository = "https://github.com/lightseekorg/smg"
+authors = [
+    "Simo Lin <linsimo.mark@gmail.com>",
+    "Chang Su <mckvtl@gmail.com>",
+    "Keyang Ru <rukeyang@gmail.com>",
+]
+keywords = ["llm", "inference", "gateway", "load-balancer", "openai"]
+categories = ["web-programming", "network-programming"]
 
 [features]
 default = ["grpc-client"]

--- a/multimodal/Cargo.toml
+++ b/multimodal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llm-multimodal"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2021"
 description = "Multimodal processing for vision and other modalities"
 license = "Apache-2.0"

--- a/protocols/Cargo.toml
+++ b/protocols/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openai-protocol"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2021"
 description = "OpenAI-compatible API protocol definitions and types"
 license = "Apache-2.0"

--- a/reasoning_parser/Cargo.toml
+++ b/reasoning_parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reasoning-parser"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2021"
 description = "Parser for AI model reasoning/thinking outputs (chain-of-thought, etc.)"
 license = "Apache-2.0"

--- a/tokenizer/Cargo.toml
+++ b/tokenizer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llm-tokenizer"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2021"
 description = "LLM tokenizer library with caching and chat template support"
 license = "Apache-2.0"

--- a/tool_parser/Cargo.toml
+++ b/tool_parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tool-parser"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2021"
 description = "Tool/function call parser for LLM model outputs"
 license = "Apache-2.0"

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-wasm"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2021"
 description = "WebAssembly runtime and module management for Shepherd Model Gateway"
 license = "Apache-2.0"

--- a/workflow/Cargo.toml
+++ b/workflow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wfaas"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2021"
 description = "Workflow-as-a-Service engine for managing multi-step operations"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
Prepare all workspace crates for v1.0.0 release to crates.io.

## Changes

### Version Updates
All 14 crates updated from 0.1.0 to 1.0.0:
- openai-protocol
- reasoning-parser
- tool-parser
- wfaas
- llm-tokenizer
- auth
- smg-mcp
- kv-index
- data-connector
- llm-multimodal
- smg-wasm
- smg-mesh
- smg-grpc-client
- smg (main gateway)

### Metadata Fixes
- **data_connector**: Added `repository` and `keywords` fields
- **model_gateway**: Added `description`, `license`, `repository`, `authors`, `keywords`, `categories` fields

## Verification
All crates now have complete metadata:
- ✅ Authors
- ✅ License (Apache-2.0)
- ✅ Keywords
- ✅ Repository URL
- ✅ Description
- ✅ Categories

## Test plan
- [x] `cargo check` passes
- [ ] Merge and verify crate publishing workflows trigger