### PR TITLE
fix: use correct rust-toolchain action name

### DIFF
--- a/.github/actions/publish-crate/action.yml
+++ b/.github/actions/publish-crate/action.yml
@@ -42,7 +42,7 @@ runs:
 
     - name: Setup Rust
       if: steps.check.outputs.changed == 'true'
-      uses: dtolnay/rust-action@stable
+      uses: dtolnay/rust-toolchain@stable
 
     - name: Publish to crates.io
       if: steps.check.outputs.changed == 'true'


### PR DESCRIPTION
## Summary
Fix crate publishing workflows failing with "repository not found" error.

## Problem
The action `dtolnay/rust-action` does not exist.

## Fix
Changed to `dtolnay/rust-toolchain@stable` which is the correct action name.

## Test plan
- [ ] Re-run failed publishing workflows