### PR TITLE
fix: add version numbers to path dependencies for crates.io publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,13 +4,13 @@ exclude = ["bindings/python", "bindings/golang"]
 resolver = "2"
 
 [workspace.dependencies]
-openai-protocol = { path = "protocols" }
-smg-auth = { path = "auth", package = "auth" }
-smg-mcp = { path = "mcp" }
-smg-data-connector = { path = "data_connector", package = "data-connector" }
-smg-wasm = { path = "wasm", package = "smg-wasm" }
-smg-mesh = { path = "mesh", package = "smg-mesh" }
-smg-grpc-client = { path = "grpc_client" }
+openai-protocol = { version = "1.0.0", path = "protocols" }
+smg-auth = { version = "1.0.0", path = "auth", package = "auth" }
+smg-mcp = { version = "1.0.0", path = "mcp" }
+smg-data-connector = { version = "1.0.0", path = "data_connector", package = "data-connector" }
+smg-wasm = { version = "1.0.0", path = "wasm", package = "smg-wasm" }
+smg-mesh = { version = "1.0.0", path = "mesh", package = "smg-mesh" }
+smg-grpc-client = { version = "1.0.0", path = "grpc_client" }
 
 # Shared dependencies
 anyhow = "1.0"

--- a/mesh/Cargo.toml
+++ b/mesh/Cargo.toml
@@ -43,7 +43,7 @@ tonic = { version = "0.14.2", features = ["gzip", "transport"] }
 tonic-prost = "0.14.2"
 
 # Workspace crates
-kv-index = { path = "../kv_index", package = "kv-index" }
+kv-index = { version = "1.0.0", path = "../kv_index", package = "kv-index" }
 
 [build-dependencies]
 tonic-prost-build = "0.14.2"

--- a/model_gateway/Cargo.toml
+++ b/model_gateway/Cargo.toml
@@ -64,16 +64,16 @@ tokio = { workspace = true, features = ["full"] }
 uuid = { workspace = true, features = ["v4", "serde"] }
 
 # Workspace crates
-openai-protocol = { path = "../protocols", features = ["axum"] }
-reasoning-parser = { path = "../reasoning_parser" }
-tool-parser = { path = "../tool_parser" }
-wfaas = { path = "../workflow" }
-llm-tokenizer = { path = "../tokenizer" }
+openai-protocol = { version = "1.0.0", path = "../protocols", features = ["axum"] }
+reasoning-parser = { version = "1.0.0", path = "../reasoning_parser" }
+tool-parser = { version = "1.0.0", path = "../tool_parser" }
+wfaas = { version = "1.0.0", path = "../workflow" }
+llm-tokenizer = { version = "1.0.0", path = "../tokenizer" }
 smg-auth.workspace = true
 smg-mcp.workspace = true
-kv-index = { path = "../kv_index", package = "kv-index" }
+kv-index = { version = "1.0.0", path = "../kv_index", package = "kv-index" }
 smg-data-connector.workspace = true
-llm-multimodal = { path = "../multimodal" }
+llm-multimodal = { version = "1.0.0", path = "../multimodal" }
 smg-wasm.workspace = true
 smg-mesh.workspace = true
 smg-grpc-client.workspace = true

--- a/multimodal/Cargo.toml
+++ b/multimodal/Cargo.toml
@@ -32,7 +32,7 @@ tracing.workspace = true
 url = "2.5.4"
 
 # Workspace crates
-llm-tokenizer = { path = "../tokenizer" }
+llm-tokenizer = { version = "1.0.0", path = "../tokenizer" }
 anyhow = "1.0.100"
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary
- Adds version = "1.0.0" to all workspace path dependencies that were missing explicit version numbers
- Required for crates.io publishing which mandates all dependencies have version requirements

## Files Changed
- **Cargo.toml**: Workspace dependency definitions (openai-protocol, smg-auth, smg-mcp, smg-data-connector, smg-wasm, smg-mesh, smg-grpc-client)
- **mesh/Cargo.toml**: kv-index dependency
- **multimodal/Cargo.toml**: llm-tokenizer dependency
- **model_gateway/Cargo.toml**: openai-protocol, reasoning-parser, tool-parser, wfaas, llm-tokenizer, kv-index, llm-multimodal

## Test plan
- [ ] Verify `cargo check` passes
- [ ] Verify crates.io publish workflows succeed after merge