### PR TITLE
fix: rename auth to smg-auth and add protoc to publish workflow

### DIFF
--- a/.github/actions/publish-crate/action.yml
+++ b/.github/actions/publish-crate/action.yml
@@ -44,6 +44,12 @@ runs:
       if: steps.check.outputs.changed == 'true'
       uses: dtolnay/rust-toolchain@stable
 
+    - name: Install protoc
+      if: steps.check.outputs.changed == 'true'
+      uses: arduino/setup-protoc@v3
+      with:
+        repo-token: ${{ github.token }}
+
     - name: Publish to crates.io
       if: steps.check.outputs.changed == 'true'
       shell: bash

--- a/.github/workflows/release-auth.yml
+++ b/.github/workflows/release-auth.yml
@@ -1,4 +1,4 @@
-name: Publish auth
+name: Publish smg-auth
 
 permissions:
   contents: read
@@ -16,6 +16,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/publish-crate
         with:
-          crate: auth
+          crate: smg-auth
           path: auth
           token: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 
 [workspace.dependencies]
 openai-protocol = { version = "1.0.0", path = "protocols" }
-smg-auth = { version = "1.0.0", path = "auth", package = "auth" }
+smg-auth = { version = "1.0.0", path = "auth" }
 smg-mcp = { version = "1.0.0", path = "mcp" }
 smg-data-connector = { version = "1.0.0", path = "data_connector", package = "data-connector" }
 smg-wasm = { version = "1.0.0", path = "wasm", package = "smg-wasm" }

--- a/auth/Cargo.toml
+++ b/auth/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "auth"
+name = "smg-auth"
 version = "1.0.0"
 edition = "2021"
 description = "Authentication and authorization for control plane APIs"


### PR DESCRIPTION
## Summary
- Rename `auth` crate to `smg-auth` to avoid crates.io name conflict (the name "auth" is already taken)
- Add protoc installation step to publish-crate action for crates that require protobuf compiler (`smg-mesh`, `smg-grpc-client`)

## Current Publishing Status
Successfully published:
- ✅ openai-protocol, reasoning-parser, kv-index, data-connector
- ✅ wfaas, smg-wasm, tool-parser, llm-tokenizer, smg-mcp

Pending (blocked by this PR):
- ❌ smg-auth (name conflict)
- ❌ smg-mesh, smg-grpc-client (need protoc)
- 🔄 llm-multimodal (in progress)

## Test plan
- [ ] Merge this PR
- [ ] Re-trigger failed publish workflows