### PR TITLE
fix: handle already-published crates gracefully and set smg to v0.4.0

### DIFF
--- a/.github/actions/publish-crate/action.yml
+++ b/.github/actions/publish-crate/action.yml
@@ -57,5 +57,11 @@ runs:
         CARGO_REGISTRY_TOKEN: ${{ inputs.token }}
       run: |
         cd ${{ inputs.path }}
-        cargo publish
-        echo "Published ${{ inputs.crate }}@${{ steps.check.outputs.local }}"
+        if cargo publish 2>&1 | tee /tmp/publish.log; then
+          echo "Published ${{ inputs.crate }}@${{ steps.check.outputs.local }}"
+        elif grep -q "already exists" /tmp/publish.log; then
+          echo "Version already exists on crates.io, skipping"
+        else
+          cat /tmp/publish.log
+          exit 1
+        fi

--- a/model_gateway/Cargo.toml
+++ b/model_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg"
-version = "1.0.0"
+version = "0.4.0"
 edition = "2021"
 description = "High-performance model-routing gateway for large-scale LLM deployments"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
- Update publish-crate action to skip (not fail) when crate version already exists on crates.io
- Set smg crate version to 0.4.0

## Test plan
- [ ] Merge and trigger publish workflow
- [ ] Verify it doesn't fail on already-published crates
- [ ] Verify smg 0.4.0 gets published