### PR TITLE
fix: use crates.io version for openai-harmony dependency

### DIFF
--- a/model_gateway/Cargo.toml
+++ b/model_gateway/Cargo.toml
@@ -108,7 +108,7 @@ rustls-pemfile = "2.2"
 openssl = "0.10.73"
 rmcp = { version = "0.8.3", features = ["client"] }
 serde_yaml = "0.9"
-openai-harmony = { git = "https://github.com/openai/harmony", tag = "v0.0.4" }
+openai-harmony = "0.0.8"
 openmetrics-parser = "0.4.4"
 arc-swap = "1.7.1"
 bitflags = "2.10.0"


### PR DESCRIPTION
## Summary
Replace git dependency with crates.io version 0.0.8 to allow publishing smg crate to crates.io.

Git dependencies without versions cannot be published to crates.io.

## Test plan
- [ ] Merge and trigger publish workflow
- [ ] Verify smg 0.4.0 publishes successfully