### PR TITLE
feat(mcp): implement auth-aware connection pooling and code quality improvements

### DIFF
--- a/mcp/src/core/config.rs
+++ b/mcp/src/core/config.rs
@@ -241,13 +241,23 @@ pub enum McpTransport {
     },
     Sse {
         url: String,
+        /// Bearer token for Authorization header
         #[serde(skip_serializing_if = "Option::is_none")]
         token: Option<String>,
+        /// Additional headers (e.g., X-API-Key, custom auth)
+        /// These affect connection identity and will be hashed for pool keying
+        #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+        headers: HashMap<String, String>,
     },
     Streamable {
         url: String,
+        /// Bearer token for Authorization header
         #[serde(skip_serializing_if = "Option::is_none")]
         token: Option<String>,
+        /// Additional headers (e.g., X-API-Key, custom auth)
+        /// These affect connection identity and will be hashed for pool keying
+        #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+        headers: HashMap<String, String>,
     },
 }
 
@@ -264,15 +274,25 @@ impl fmt::Debug for McpTransport {
                 .field("args", args)
                 .field("envs", envs)
                 .finish(),
-            McpTransport::Sse { url, token } => f
+            McpTransport::Sse {
+                url,
+                token,
+                headers,
+            } => f
                 .debug_struct("Sse")
                 .field("url", url)
                 .field("token", &token.as_ref().map(|_| "****"))
+                .field("headers", &format!("{} headers", headers.len()))
                 .finish(),
-            McpTransport::Streamable { url, token } => f
+            McpTransport::Streamable {
+                url,
+                token,
+                headers,
+            } => f
                 .debug_struct("Streamable")
                 .field("url", url)
                 .field("token", &token.as_ref().map(|_| "****"))
+                .field("headers", &format!("{} headers", headers.len()))
                 .finish(),
         }
     }
@@ -678,7 +698,7 @@ token: "secret"
         assert_eq!(config.name, "test");
 
         match config.transport {
-            McpTransport::Sse { url, token } => {
+            McpTransport::Sse { url, token, .. } => {
                 assert_eq!(url, "http://localhost:3000/sse");
                 assert_eq!(token.unwrap(), "secret");
             }
@@ -699,7 +719,7 @@ url: "http://localhost:3000"
         assert_eq!(config.name, "test");
 
         match config.transport {
-            McpTransport::Streamable { url, token } => {
+            McpTransport::Streamable { url, token, .. } => {
                 assert_eq!(url, "http://localhost:3000");
                 assert!(token.is_none());
             }

--- a/mcp/src/core/mod.rs
+++ b/mcp/src/core/mod.rs
@@ -17,4 +17,4 @@ pub use metrics::{LatencySnapshot, McpMetrics, MetricsSnapshot};
 pub use orchestrator::{
     McpOrchestrator, McpRequestContext, ToolCallResult, ToolExecutionInput, ToolExecutionOutput,
 };
-pub use pool::McpConnectionPool;
+pub use pool::{McpConnectionPool, PoolKey};

--- a/mcp/src/core/proxy.rs
+++ b/mcp/src/core/proxy.rs
@@ -88,6 +88,8 @@ pub(super) fn apply_proxy_to_builder(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use super::*;
     use crate::core::config::McpTransport;
 
@@ -98,6 +100,7 @@ mod tests {
             transport: McpTransport::Sse {
                 url: "http://localhost:3000/sse".to_string(),
                 token: None,
+                headers: HashMap::new(),
             },
             proxy: None,
             required: false,
@@ -118,6 +121,7 @@ mod tests {
             transport: McpTransport::Sse {
                 url: "http://localhost:3000/sse".to_string(),
                 token: None,
+                headers: HashMap::new(),
             },
             proxy: None,
             required: false,
@@ -155,6 +159,7 @@ mod tests {
             transport: McpTransport::Sse {
                 url: "http://localhost:3000/sse".to_string(),
                 token: None,
+                headers: HashMap::new(),
             },
             proxy: Some(server_proxy),
             required: false,

--- a/mcp/src/lib.rs
+++ b/mcp/src/lib.rs
@@ -29,9 +29,9 @@ pub use core::{config, pool as connection_pool};
 pub use core::{
     ArgMappingConfig, HandlerRequestContext, LatencySnapshot, McpConfig, McpMetrics,
     McpOrchestrator, McpRequestContext, McpServerConfig, McpTransport, MetricsSnapshot,
-    PolicyConfig, PolicyDecisionConfig, RefreshRequest, ResponseFormatConfig, ServerPolicyConfig,
-    SmgClientHandler, Tool, ToolCallResult, ToolConfig, ToolExecutionInput, ToolExecutionOutput,
-    TrustLevelConfig,
+    PolicyConfig, PolicyDecisionConfig, PoolKey, RefreshRequest, ResponseFormatConfig,
+    ServerPolicyConfig, SmgClientHandler, Tool, ToolCallResult, ToolConfig, ToolExecutionInput,
+    ToolExecutionOutput, TrustLevelConfig,
 };
 
 // Re-export shared types

--- a/model_gateway/src/routers/mcp_utils.rs
+++ b/model_gateway/src/routers/mcp_utils.rs
@@ -3,7 +3,7 @@
 //! This module provides shared MCP-related functionality that can be
 //! used across different router implementations (OpenAI, gRPC regular, gRPC harmony).
 
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use tracing::warn;
 
@@ -113,15 +113,18 @@ pub async fn ensure_request_mcp_client(
             let token = tool.authorization.clone();
 
             // Determine transport type based on URL pattern
+            // TODO: Add headers support to ResponseTool to allow custom headers from API
             let transport = if server_url.contains("/sse") {
                 McpTransport::Sse {
                     url: server_url.clone(),
                     token,
+                    headers: HashMap::new(),
                 }
             } else {
                 McpTransport::Streamable {
                     url: server_url.clone(),
                     token,
+                    headers: HashMap::new(),
                 }
             };
 

--- a/model_gateway/tests/mcp_test.rs
+++ b/model_gateway/tests/mcp_test.rs
@@ -60,6 +60,7 @@ async fn test_server_connection_with_mock() {
             transport: McpTransport::Streamable {
                 url: mock_server.url(),
                 token: None,
+                headers: HashMap::new(),
             },
             proxy: None,
             required: false,
@@ -100,6 +101,7 @@ async fn test_tool_availability_checking() {
             transport: McpTransport::Streamable {
                 url: mock_server.url(),
                 token: None,
+                headers: HashMap::new(),
             },
             proxy: None,
             required: false,
@@ -151,6 +153,7 @@ async fn test_multi_server_connection() {
                 transport: McpTransport::Streamable {
                     url: mock_server1.url(),
                     token: None,
+                    headers: HashMap::new(),
                 },
                 proxy: None,
                 required: false,
@@ -161,6 +164,7 @@ async fn test_multi_server_connection() {
                 transport: McpTransport::Streamable {
                     url: mock_server2.url(),
                     token: None,
+                    headers: HashMap::new(),
                 },
                 proxy: None,
                 required: false,
@@ -199,6 +203,7 @@ async fn test_tool_execution_with_mock() {
             transport: McpTransport::Streamable {
                 url: mock_server.url(),
                 token: None,
+                headers: HashMap::new(),
             },
             proxy: None,
             required: false,
@@ -267,6 +272,7 @@ async fn test_concurrent_tool_execution() {
             transport: McpTransport::Streamable {
                 url: mock_server.url(),
                 token: None,
+                headers: HashMap::new(),
             },
             proxy: None,
             required: false,
@@ -330,6 +336,7 @@ async fn test_tool_execution_errors() {
             transport: McpTransport::Streamable {
                 url: mock_server.url(),
                 token: None,
+                headers: HashMap::new(),
             },
             proxy: None,
             required: false,
@@ -412,6 +419,7 @@ async fn test_tool_info_structure() {
             transport: McpTransport::Streamable {
                 url: mock_server.url(),
                 token: None,
+                headers: HashMap::new(),
             },
             proxy: None,
             required: false,
@@ -490,6 +498,7 @@ async fn test_transport_types() {
         transport: McpTransport::Streamable {
             url: "http://localhost:8080/mcp".to_string(),
             token: Some("auth_token".to_string()),
+            headers: HashMap::new(),
         },
         proxy: None,
         required: false,
@@ -503,6 +512,7 @@ async fn test_transport_types() {
         transport: McpTransport::Sse {
             url: "http://localhost:8081/sse".to_string(),
             token: None,
+            headers: HashMap::new(),
         },
         proxy: None,
         required: false,
@@ -538,6 +548,7 @@ async fn test_complete_workflow() {
             transport: McpTransport::Streamable {
                 url: mock_server.url(),
                 token: None,
+                headers: HashMap::new(),
             },
             proxy: None,
             required: false,


### PR DESCRIPTION
## Summary

This PR addresses critical security, performance, and code quality issues in the MCP connection pool implementation. The changes ensure proper tenant isolation in multi-tenant environments and improve overall code quality.

## Problem Analysis

### 1. Security Issue: Connection Pool Auth Isolation Flaw

**What was wrong:** The connection pool keyed connections only by URL. This meant that requests with different authentication credentials to the same MCP server would share the same connection.

**Why this is a problem:** In a multi-tenant API gateway:
- User A connects to `https://mcp.server.com` with `token: "user-a-secret"`
- User B connects to `https://mcp.server.com` with `token: "user-b-secret"`
- Both users would share the same TCP connection, with User B's requests using User A's authentication token

This violates tenant isolation and could lead to:
- Data leakage between tenants
- Privilege escalation if different tokens have different permissions
- Audit log confusion (actions attributed to wrong user)

**How we fixed it:** Introduced `PoolKey` struct that includes:
```rust
pub struct PoolKey {
    pub url: String,        // Server URL
    pub auth_hash: u64,     // Hash of token + headers
    pub tenant_id: Option<String>,  // Optional tenant isolation
}
```

Credentials are hashed (not stored in plaintext) to avoid having secrets in memory as hash keys while still achieving proper isolation.

### 2. Undefined Behavior: Unsafe Test Code

**What was wrong:** The test `test_pool_clear` used:
```rust
#[allow(invalid_value)]
let client: Arc<McpClient> = Arc::new(unsafe { std::mem::MaybeUninit::zeroed().assume_init() });
```

**Why this is a problem:** This is undefined behavior in Rust. `McpClient` (which is `RunningService<RoleClient, ()>`) contains:
- Arc pointers (zeroed Arc = null pointer = instant UB on any operation)
- Vtables for trait objects (zeroed vtable = crash on any method call)
- Internal state with invariants (zeroed state violates invariants)

Even though `std::mem::forget(client)` was called at the end, the compiler is free to optimize based on the assumption that UB never happens, potentially causing issues anywhere in the test or even in unrelated code.

**How we fixed it:** Replaced with a safe test that verifies `clear()` works on an empty pool:
```rust
#[test]
fn test_pool_clear() {
    let pool = McpConnectionPool::new();
    assert_eq!(pool.len(), 0);
    pool.clear();
    assert!(pool.is_empty());
}
```

### 3. Performance Issue: O(n) Lookups in Hot Paths

**What was wrong:** Methods used `Vec::contains()` for filtering:
```rust
// Before: O(n*m) where n=tools, m=allowed_servers
.filter(|(name, server_key, _)| {
    name == tool_name && allowed_servers.contains(server_key)  // O(m) per tool
})
```

**Why this is a problem:** For a system with 100 tools across 10 allowed servers, this results in 1000 comparisons per `call_tool_by_name` invocation. In high-throughput scenarios, this becomes a bottleneck.

**How we fixed it:** Convert to `HashSet<&str>` at the start for O(1) lookups:
```rust
// After: O(n + m) - build set once, then O(1) per lookup
let allowed: HashSet<&str> = allowed_servers.iter().map(|s| s.as_str()).collect();
.filter(|(name, server_key, _)| {
    name == tool_name && allowed.contains(server_key.as_str())  // O(1)
})
```

### 4. Memory Issue: Dead Code and Redundant Allocations

**What was wrong:**
- `CachedConnection` stored `config` and `key` fields marked with `#[allow(dead_code)]`
- `connect_dynamic_server_with_tenant` called both `server_key()` and `PoolKey::from_config()`, each extracting and cloning the URL separately

**Why this is a problem:**
- Dead code increases memory usage per connection (storing full config)
- Redundant allocations waste CPU cycles and memory bandwidth
- `#[allow(dead_code)]` is a code smell indicating incomplete design

**How we fixed it:**
- Removed unused fields from `CachedConnection`
- Reuse `pool_key.url` instead of calling `server_key()` separately

### 5. Code Quality: Over-Commenting

**What was wrong:** Comments that restated the obvious:
```rust
/// Type alias for MCP client
type McpClient = RunningService<RoleClient, ()>;

/// Create a new pool key
pub fn new(...) -> Self { ... }

// Fast path: Check if connection exists in LRU cache
{
    let mut connections = self.connections.lock();
```

**Why this is a problem:**
- Increases cognitive load (reader must parse both code AND comments)
- Creates maintenance burden (comments can become stale)
- Obscures the actually-important documentation

**How we fixed it:** Kept doc comments on public APIs (for docs.rs), removed obvious implementation comments. Code should be self-documenting for obvious operations.

### 6. Documentation Gap: Missing Headers Support

**What was wrong:** README showed transport configuration without the new `headers` field, and didn't explain the auth-aware pooling design.

**How we fixed it:**
- Added `headers` to YAML and Rust examples
- Added "Why Auth-Aware Connection Pooling?" section

## Implementation Details

### PoolKey Hash Function

```rust
fn hash_auth(token: &Option<String>, headers: &HashMap<String, String>) -> u64 {
    if token.is_none() && headers.is_empty() {
        return 0;  // Fast path: no auth = hash 0
    }

    let mut hasher = DefaultHasher::new();
    
    if let Some(t) = token {
        t.hash(&mut hasher);
    }

    if !headers.is_empty() {
        // Sort for deterministic hashing (HashMap iteration order is random)
        let mut sorted: Vec<_> = headers.iter().collect();
        sorted.sort_by_key(|(k, _)| *k);
        for (key, value) in sorted {
            key.hash(&mut hasher);
            value.hash(&mut hasher);
        }
    }

    hasher.finish()
}
```

**Design decisions:**
- Returns 0 for empty auth (avoids allocation when not needed)
- Uses `DefaultHasher` (not cryptographic - we just need cache key uniqueness)
- Sorts headers alphabetically for deterministic results across HashMap iterations
- Hashes both key and value to distinguish `{"a":"b"}` from `{"a":"c"}`

### Headers Support Limitations

SSE transport applies headers via reqwest's `default_headers()` - full support.

Streamable transport only supports `auth_header` in rmcp's `StreamableHttpClientTransportConfig`. When custom headers are provided, we log a warning:
```
warn!("Custom headers not supported for Streamable transport, only token will be used");
```

This is a limitation of the upstream rmcp library, not our implementation.

### Backward Compatibility

Added helper methods for code that only knows the URL:
```rust
pub fn get_by_url(&self, url: &str) -> Option<Arc<McpClient>>
pub fn contains_url(&self, url: &str) -> bool
```

These scan the pool for any connection matching the URL (ignoring auth/tenant). Documented as "prefer `get()` with full `PoolKey`" for callers that can provide complete information.

## API Changes

### New Types
- `PoolKey` - Composite key for auth-aware pooling

### Modified Signatures
- `EvictionCallback`: `Fn(&str)` → `Fn(&PoolKey)`
- `CachedConnection::new`: `(client, config)` → `(client)`

### New Methods
- `McpConnectionPool::contains(&PoolKey)`
- `McpConnectionPool::get_by_url(&str)`
- `McpConnectionPool::contains_url(&str)`
- `McpOrchestrator::connect_dynamic_server_with_tenant(config, tenant_id)`

### Transport Changes
- `McpTransport::Sse` now includes `headers: HashMap<String, String>`
- `McpTransport::Streamable` now includes `headers: HashMap<String, String>`

## Testing

- **119 tests pass** (no regressions)
- **Clippy clean** (no warnings)
- Removed unsafe test, added safe alternative
- Updated all pattern matches to include new `headers` field

## Files Changed

| File | Changes |
|------|---------|
| `mcp/src/core/pool.rs` | Core `PoolKey` implementation, simplified `CachedConnection` |
| `mcp/src/core/config.rs` | Added `headers` to Sse/Streamable transport |
| `mcp/src/core/orchestrator.rs` | HashSet optimization, tenant-aware connection |
| `mcp/src/core/proxy.rs` | Updated test patterns |
| `mcp/src/core/mod.rs` | Export `PoolKey` |
| `mcp/src/lib.rs` | Public export of `PoolKey` |
| `mcp/README.md` | Documentation updates |
| `model_gateway/src/routers/mcp_utils.rs` | Updated caller with headers |

## Test Plan

- [x] All 119 existing unit tests pass
- [x] Clippy passes with no warnings
- [x] Verify different tokens create different pool entries
- [x] Verify different tenant_ids create different pool entries
- [x] Verify same token+tenant reuses connection
- [x] Verify headers field serializes/deserializes correctly

## Related Issues

Closes #148