### PR TITLE
feat(mcp): forward HTTP request headers to MCP servers

### DIFF
--- a/model_gateway/src/routers/grpc/common/responses/utils.rs
+++ b/model_gateway/src/routers/grpc/common/responses/utils.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use axum::response::Response;
+use axum::{http::HeaderMap, response::Response};
 use serde_json::to_value;
 use tracing::{debug, error, warn};
 
@@ -27,6 +27,7 @@ use crate::{
 pub(crate) async fn ensure_mcp_connection(
     mcp_orchestrator: &Arc<McpOrchestrator>,
     tools: Option<&[ResponseTool]>,
+    request_headers: Option<&HeaderMap>,
 ) -> Result<(bool, Vec<String>), Response> {
     let has_mcp_tools = tools
         .map(|t| {
@@ -37,7 +38,7 @@ pub(crate) async fn ensure_mcp_connection(
 
     if has_mcp_tools {
         if let Some(tools) = tools {
-            match ensure_request_mcp_client(mcp_orchestrator, tools).await {
+            match ensure_request_mcp_client(mcp_orchestrator, tools, request_headers).await {
                 Some((_orchestrator, server_keys)) => {
                     return Ok((true, server_keys));
                 }

--- a/model_gateway/src/routers/grpc/harmony/responses/non_streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/non_streaming.rs
@@ -58,8 +58,12 @@ pub(crate) async fn serve_harmony_responses(
     let current_request = load_previous_messages(ctx, request).await?;
 
     // Check MCP connection and get whether MCP tools are present
-    let (has_mcp_tools, server_keys) =
-        ensure_mcp_connection(&ctx.mcp_orchestrator, current_request.tools.as_deref()).await?;
+    let (has_mcp_tools, server_keys) = ensure_mcp_connection(
+        &ctx.mcp_orchestrator,
+        current_request.tools.as_deref(),
+        None,
+    )
+    .await?;
 
     // Set the server keys in the context
     {

--- a/model_gateway/src/routers/grpc/harmony/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/streaming.rs
@@ -50,6 +50,7 @@ pub(crate) async fn serve_harmony_responses_stream(
     let (has_mcp_tools, server_keys) = match ensure_mcp_connection(
         &ctx.mcp_orchestrator,
         current_request.tools.as_deref(),
+        None,
     )
     .await
     {

--- a/model_gateway/src/routers/grpc/regular/responses/handlers.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/handlers.rs
@@ -111,7 +111,7 @@ async fn route_responses_streaming(
 
     // 2. Check MCP connection and get whether MCP tools are present
     let (has_mcp_tools, server_keys) =
-        match ensure_mcp_connection(&ctx.mcp_orchestrator, request.tools.as_deref()).await {
+        match ensure_mcp_connection(&ctx.mcp_orchestrator, request.tools.as_deref(), None).await {
             Ok(result) => result,
             Err(response) => return response,
         };

--- a/model_gateway/src/routers/grpc/regular/responses/non_streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/non_streaming.rs
@@ -51,7 +51,7 @@ pub(super) async fn route_responses_internal(
 
     // 2. Check MCP connection and get whether MCP tools are present
     let (has_mcp_tools, server_keys) =
-        ensure_mcp_connection(&ctx.mcp_orchestrator, request.tools.as_deref()).await?;
+        ensure_mcp_connection(&ctx.mcp_orchestrator, request.tools.as_deref(), None).await?;
 
     // Set the server keys in the context
     {

--- a/model_gateway/src/routers/openai/responses/non_streaming.rs
+++ b/model_gateway/src/routers/openai/responses/non_streaming.rs
@@ -56,7 +56,7 @@ pub async fn handle_non_streaming_response(mut ctx: RequestContext) -> Response 
 
     // Check for MCP tools and create request context if needed
     let mcp_result = if let Some(tools) = original_body.tools.as_deref() {
-        ensure_request_mcp_client(mcp_orchestrator, tools).await
+        ensure_request_mcp_client(mcp_orchestrator, tools, ctx.headers()).await
     } else {
         None
     };

--- a/model_gateway/src/routers/openai/responses/streaming.rs
+++ b/model_gateway/src/routers/openai/responses/streaming.rs
@@ -1004,7 +1004,7 @@ pub async fn handle_streaming_response(ctx: RequestContext) -> Response {
 
     // Check for MCP tools and create request context if needed
     let mcp_result = if let Some(tools) = original_body.tools.as_deref() {
-        ensure_request_mcp_client(mcp_orchestrator, tools).await
+        ensure_request_mcp_client(mcp_orchestrator, tools, headers.as_ref()).await
     } else {
         None
     };


### PR DESCRIPTION
## Summary

Forward filtered HTTP request headers to MCP servers to enable authentication passthrough, distributed tracing, and request correlation across service boundaries.

## Problem Statement

### The Core Issue

MCP servers often need contextual information from the original HTTP request to function correctly. Previously, MCP connections were established with **empty headers**, completely breaking several critical production use cases.

### Why This Matters

**1. Authentication Passthrough**
- MCP servers may share the same auth infrastructure as the gateway
- Without forwarding `Authorization`, MCP servers cannot validate user identity
- This breaks multi-tenant deployments where MCP servers need to know "who is calling"

**2. Distributed Tracing**
- Modern observability requires end-to-end trace propagation
- `traceparent` and `tracestate` headers (W3C Trace Context) must flow through all service calls
- Without these, MCP calls appear as "orphan spans" in tracing tools (Jaeger, Datadog, etc.)
- Production debugging becomes nearly impossible when traces break at MCP boundaries

**3. Request Correlation**
- `x-request-id` and `x-correlation-id` are essential for debugging
- Support teams need to trace a single request across all services
- Logs without correlation IDs cannot be connected to user-reported issues

**4. Routing Context**
- `x-smg-routing-key` enables tenant-aware or region-aware MCP routing
- Without this, MCP servers cannot make routing decisions based on gateway context

## Solution

### What We Did

Forward a **security-reviewed whitelist** of headers using the existing `should_forward_request_header` function from `header_utils.rs`.

### Headers Forwarded (Whitelist)

| Header | Purpose |
|--------|---------|
| `authorization` | Auth passthrough to MCP servers |
| `x-request-id` | Request correlation |
| `x-request-id-*` | Extended correlation (prefix match) |
| `x-correlation-id` | Alternative correlation standard |
| `traceparent` | W3C distributed tracing |
| `tracestate` | W3C trace context state |
| `x-smg-routing-key` | Gateway routing context |

### Headers NOT Forwarded (Security)

| Header | Reason |
|--------|--------|
| `host` | Hop-by-hop, could cause routing issues |
| `connection`, `transfer-encoding` | Hop-by-hop headers |
| `content-type`, `content-length` | Request-specific, set by transport |
| `cookie` | Privacy/security risk |
| `user-agent` | Privacy, not useful for MCP |
| `x-api-key`, arbitrary `x-*` | Attack surface reduction |

### Why This Whitelist Approach?

**Security-first design**: Instead of forwarding all headers (dangerous), we explicitly whitelist only headers with known, safe, and useful purposes. This:

1. Prevents accidental credential leakage
2. Reduces attack surface on MCP servers  
3. Avoids breaking MCP servers with unexpected headers
4. Follows principle of least privilege

## Implementation Details

### API Changes

```rust
// Before
pub async fn ensure_request_mcp_client(
    mcp_orchestrator: &Arc<McpOrchestrator>,
    tools: &[ResponseTool],
) -> Option<(Arc<McpOrchestrator>, Vec<String>)>

// After  
pub async fn ensure_request_mcp_client(
    mcp_orchestrator: &Arc<McpOrchestrator>,
    tools: &[ResponseTool],
    request_headers: Option<&HeaderMap>,  // NEW
) -> Option<(Arc<McpOrchestrator>, Vec<String>)>
```

### Router Updates

| Router | Headers Passed | Reason |
|--------|---------------|--------|
| OpenAI non_streaming | `ctx.headers()` | HTTP headers available |
| OpenAI streaming | `headers.as_ref()` | HTTP headers available |
| gRPC harmony/* | `None` | gRPC uses metadata, not HTTP headers |
| gRPC regular/* | `None` | gRPC uses metadata, not HTTP headers |

### Why gRPC Passes None?

gRPC has a fundamentally different transport model:
- Uses **metadata** instead of HTTP headers
- Metadata extraction would require different handling
- Passing `None` maintains existing behavior
- Future work could add metadata forwarding if needed

## Code Quality Improvements

During review, identified and fixed several issues in `mcp_utils.rs`:

### 1. Stale Documentation (Bug)

**Before:**
```rust
/// Headers are sourced from two places (merged, with API taking precedence):
/// 1. `tool.headers` - Explicit headers from API request body  ← WRONG
/// 2. `request_headers` - Forwarded from incoming HTTP request
```

**After:**
```rust
/// Forwards filtered HTTP request headers (auth, tracing, correlation IDs) to MCP servers.
```

### 2. Unreachable Code Path

**Before:**
```rust
if matches!(tool.r#type, ResponseToolType::Mcp) && tool.server_url.is_some() {
    let Some(server_url) = tool.server_url.as_ref()... else { continue }; // UNREACHABLE
```

**After:**
```rust
let Some(server_url) = tool.server_url.as_ref()
    .filter(|_| matches!(tool.r#type, ResponseToolType::Mcp))
    .map(|s| s.trim())
    .filter(|s| !s.is_empty())
else { continue };
```

### 3. Over-Commenting Removed

- Removed 4 ASCII section dividers (`// ====...====`)
- Removed 12+ comments that described "what" not "why"
- **Result: 202 → 156 lines (23% reduction)**

### 4. Resolved TODO

Removed: `// TODO: Add headers support to ResponseTool to allow custom headers from API`

## Files Changed

| File | Change |
|------|--------|
| `mcp_utils.rs` | Core implementation + quality improvements |
| `grpc/common/responses/utils.rs` | Updated wrapper signature |
| `grpc/harmony/responses/non_streaming.rs` | Pass `None` |
| `grpc/harmony/responses/streaming.rs` | Pass `None` |
| `grpc/regular/responses/handlers.rs` | Pass `None` |
| `grpc/regular/responses/non_streaming.rs` | Pass `None` |
| `openai/responses/non_streaming.rs` | Pass `ctx.headers()` |
| `openai/responses/streaming.rs` | Pass `headers.as_ref()` |

## Test Plan

- [x] `cargo clippy --all-targets --all-features` passes
- [x] No new warnings introduced
- [x] Header forwarding uses existing tested whitelist (`should_forward_request_header` has unit tests)
- [ ] Manual testing with MCP server that logs received headers

## Related

- Builds on #154 (auth-aware connection pooling)
- Uses header utilities from `header_utils.rs`
