### PR TITLE
feat(mcp): implement ResponseFormat transformation in tool execution pipeline

### DIFF
--- a/model_gateway/src/routers/grpc/harmony/responses/non_streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/non_streaming.rs
@@ -244,6 +244,7 @@ async fn execute_with_mcp_loop(
                         &mut mcp_tracking,
                         &current_request.model,
                         &request_id,
+                        &server_label,
                         &mcp_tools,
                     )
                     .await?

--- a/model_gateway/src/routers/grpc/harmony/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/streaming.rs
@@ -361,6 +361,7 @@ async fn execute_mcp_tool_loop_streaming(
                         &mut mcp_tracking,
                         &current_request.model,
                         &request_id,
+                        &server_label,
                         &mcp_tools,
                     )
                     .await

--- a/model_gateway/src/routers/grpc/regular/responses/common.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/common.rs
@@ -59,30 +59,22 @@ impl ToolLoopState {
         tool_name: String,
         args_json_str: String,
         output_str: String,
-        success: bool,
-        error: Option<String>,
+        output_item: ResponseOutputItem,
+        _success: bool,
     ) {
         // Add function_tool_call item with both arguments and output
         self.conversation_history
             .push(ResponseInputOutputItem::FunctionToolCall {
                 id: call_id.clone(),
                 call_id: call_id.clone(),
-                name: tool_name.clone(),
-                arguments: args_json_str.clone(),
-                output: Some(output_str.clone()),
+                name: tool_name,
+                arguments: args_json_str,
+                output: Some(output_str),
                 status: Some("completed".to_string()),
             });
 
-        // Add mcp_call output item for metadata
-        let mcp_call = build_mcp_call_item(
-            &tool_name,
-            &args_json_str,
-            &output_str,
-            &self.server_label,
-            success,
-            error.as_deref(),
-        );
-        self.mcp_call_items.push(mcp_call);
+        // Add transformed output item (respects tool's response_format)
+        self.mcp_call_items.push(output_item);
     }
 }
 
@@ -199,27 +191,6 @@ pub(super) fn build_mcp_list_tools_item(
         id: generate_mcp_id("mcpl"),
         server_label: server_label.to_string(),
         tools: tools_info,
-    }
-}
-
-/// Build mcp_call output item
-pub(super) fn build_mcp_call_item(
-    tool_name: &str,
-    arguments: &str,
-    output: &str,
-    server_label: &str,
-    success: bool,
-    error: Option<&str>,
-) -> ResponseOutputItem {
-    ResponseOutputItem::McpCall {
-        id: generate_mcp_id("mcp"),
-        status: if success { "completed" } else { "failed" }.to_string(),
-        approval_request_id: None,
-        arguments: arguments.to_string(),
-        error: error.map(|e| e.to_string()),
-        name: tool_name.to_string(),
-        output: output.to_string(),
-        server_label: server_label.to_string(),
     }
 }
 

--- a/model_gateway/src/routers/grpc/regular/responses/non_streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/non_streaming.rs
@@ -342,7 +342,7 @@ pub(super) async fn execute_tool_loop(
             // Execute all MCP tools via unified API
             let results = ctx
                 .mcp_orchestrator
-                .execute_tools(inputs, &server_keys, &request_ctx)
+                .execute_tools(inputs, &server_keys, &server_label, &request_ctx)
                 .await;
 
             // Process results: record metrics and state
@@ -371,14 +371,16 @@ pub(super) async fn execute_tool_loop(
                     },
                 );
 
-                // Record the call in state
+                // Record the call in state with transformed output item
+                let output_item = result.to_response_item();
+                let output_str = result.output.to_string();
                 state.record_call(
                     result.call_id,
                     result.tool_name,
                     result.arguments_str,
-                    result.output_str,
+                    output_str,
+                    output_item,
                     !result.is_error,
-                    result.error_message,
                 );
 
                 // Increment total calls counter

--- a/model_gateway/tests/mcp_test.rs
+++ b/model_gateway/tests/mcp_test.rs
@@ -232,6 +232,7 @@ async fn test_tool_execution_with_mock() {
                 "query": "rust programming",
                 "count": 1
             }),
+            "mock_server",
             &request_ctx,
         )
         .await;
@@ -301,7 +302,7 @@ async fn test_concurrent_tool_execution() {
 
     for (tool_name, args) in tool_calls {
         let result = manager
-            .call_tool("mock_server", tool_name, args, &request_ctx)
+            .call_tool("mock_server", tool_name, args, "mock_server", &request_ctx)
             .await;
 
         assert!(result.is_ok(), "Tool {} should succeed", tool_name);
@@ -359,7 +360,13 @@ async fn test_tool_execution_errors() {
 
     // Try to call unknown tool
     let result = manager
-        .call_tool("mock_server", "unknown_tool", json!({}), &request_ctx)
+        .call_tool(
+            "mock_server",
+            "unknown_tool",
+            json!({}),
+            "mock_server",
+            &request_ctx,
+        )
         .await;
     assert!(result.is_err(), "Should fail for unknown tool");
 
@@ -595,6 +602,7 @@ async fn test_complete_workflow() {
                 "query": "SGLang router MCP integration",
                 "count": 1
             }),
+            "integration_test",
             &request_ctx,
         )
         .await;


### PR DESCRIPTION
## Summary

This PR completes **Phase 1 of Built-in Tool Support via MCP**, implementing proper response transformation from MCP tool results to OpenAI-compatible output types (`web_search_call`, `code_interpreter_call`, `file_search_call`, `mcp_call`).

**Key changes:**
- Thread `server_label` through the entire tool execution call chain
- Add `response_format` and `server_label` to `ToolExecutionOutput` batch API
- Implement `to_response_item()` method using `ResponseTransformer`
- Update all three routers (OpenAI, Harmony gRPC, Regular gRPC) to use transformed output
- Standardize on linear scan for small server collections
- Refactor approval logic to eliminate code duplication

## Issues Closed

Closes #165 - Add response_format to ToolExecutionOutput
Closes #166 - Add to_response_item() method to ToolExecutionOutput
Closes #167 - Update Harmony router to use transformed MCP output
Closes #168 - Update Regular router to use transformed MCP output
Closes #169 - Update OpenAI router to use transformed MCP output
Closes #145 - Integrate ResponseTransformer into McpManager

## Related Issues

Part of #164 - Built-in Tool Support via MCP (Tracking Issue)

**Remaining (Phase 2 - Request Routing):**
- #170 - Add builtin_type config to McpServerConfig
- #171 - Add find_builtin_server() lookup method to McpOrchestrator
- #172 - Update router tool processing to route built-in types to MCP
- #173 - Add tests for built-in tool support

---

## Problem Statement

### Problem 1: server_label Architecture Was Fundamentally Broken

**What was happening:**

The MCP orchestrator was using `server_key` (an internal identifier) as the user-facing label in API responses. For dynamic servers connected via URL, this exposed internal URLs to end users:

```json
// What users saw (broken):
{
  "type": "mcp_call",
  "server_label": "https://mcp.example.com/sse",  // Internal URL leaked!
  "tool_name": "web_search"
}

// What users should see (correct):
{
  "type": "mcp_call", 
  "server_label": "brave",  // Friendly user-configured label
  "tool_name": "web_search"
}
```

**Why this was a problem:**

1. **Security concern**: Internal infrastructure URLs exposed to API consumers
2. **Poor UX**: Users see cryptic URLs instead of meaningful labels
3. **Inconsistency**: Static servers showed names, dynamic servers showed URLs
4. **Workarounds needed**: Routers had to patch JSON after the fact

**Root cause analysis:**

The `call_tool()` method signature was:
```rust
pub async fn call_tool(&self, server_key: &str, tool_name: &str, arguments: Value, ...)
```

There was no `server_label` parameter. The transformation layer at the end needed a user-facing label but only had access to `server_key`, so it used that as a fallback. The call chain from router → orchestrator → transformer never passed `server_label` through.

---

### Problem 2: ToolExecutionOutput Lacked Critical Metadata

**What was happening:**

The batch execution API returned `ToolExecutionOutput` without essential fields:

```rust
// Before (incomplete):
pub struct ToolExecutionOutput {
    pub call_id: String,
    pub tool_name: String,
    pub arguments_str: String,
    pub output: Value,
    pub output_str: String,  // Pre-serialized, inflexible
    pub is_error: bool,
    pub error_message: Option<String>,
    pub duration: Duration,
    // Missing: server_key, server_label, response_format
}
```

**Why this was a problem:**

1. **No `response_format`**: Routers couldn't know whether to output `mcp_call`, `web_search_call`, etc.
2. **No `server_label`**: Routers couldn't set correct user-facing labels without additional lookups
3. **No `server_key`**: Routers couldn't identify which server executed the tool for logging/metrics
4. **Pre-serialized `output_str`**: Forced double serialization when routers needed different formats

**Consequences:**

Routers had to:
1. Look up tool metadata separately after batch execution
2. Patch JSON responses after building them (fragile)
3. Duplicate transformation logic (DRY violation)

---

### Problem 3: Routers Hardcoded mcp_call Output Type

**What was happening:**

All three routers had hardcoded `mcp_call` construction:

```rust
// OpenAI router (mcp.rs:863)
fn build_mcp_call_item(...) -> Value {
    json!({
        "type": "mcp_call",  // Hardcoded!
        ...
    })
}

// Harmony router (common.rs:243)  
fn inject_mcp_metadata(...) {
    // Always creates McpCall variant
}

// Regular router (common.rs:214)
fn build_mcp_call_item(...) {
    // Always creates McpCall
}
```

**Why this was a problem:**

The MCP crate already had `ResponseTransformer` with proper transformation logic:

```rust
pub enum ResponseFormat {
    Passthrough,         // → mcp_call
    WebSearchCall,       // → web_search_call
    CodeInterpreterCall, // → code_interpreter_call  
    FileSearchCall,      // → file_search_call
}
```

This infrastructure was **completely ignored**. Tools configured with `response_format: WebSearchCall` would still produce `mcp_call` output.

---

### Problem 4: Inconsistent Collection Types for Server Filtering

**What was happening:**

```rust
// Some places used HashSet
let allowed: HashSet<&str> = allowed_servers.iter().map(|s| s.as_str()).collect();
if allowed.contains(server_key) { ... }

// Other places used Vec
if allowed_servers.contains(&server_key.to_string()) { ... }

// Yet others used iter().any()
if allowed_servers.iter().any(|s| s == server_key) { ... }
```

**Why this was a problem:**

1. **Inconsistency**: Different patterns in different places
2. **Suboptimal performance**: HashSet allocation overhead exceeds benefits for small n
3. **Cognitive load**: Readers must understand multiple patterns

For typical MCP deployments (1-5 servers per request), HashSet construction cost dominates.

---

### Problem 5: Code Duplication in Approval Logic

**What was happening:**

Two nearly-identical methods existed:

```rust
// Returns transformed ResponseOutputItem
async fn execute_tool_with_approval(...) -> McpResult<ToolCallResult>

// Returns raw CallToolResult  
async fn execute_tool_with_approval_raw(...) -> McpResult<RawToolCallResult>
```

Both contained the same approval checking logic, differing only in the final transformation step.

---

## Solution

### 1. Thread server_label Through Entire Call Chain

**Change:**

Added `server_label` parameter to all tool execution methods:

```rust
// Updated signatures
pub async fn call_tool(
    &self,
    server_key: &str,      // Internal identifier (may be URL)
    tool_name: &str,
    arguments: Value,
    server_label: &str,    // NEW: User-facing label
    request_ctx: &McpRequestContext<'_>,
) -> McpResult<ToolCallResult>

pub async fn call_tool_by_name(
    &self,
    tool_name: &str,
    arguments: Value,
    allowed_servers: &[String],
    server_label: &str,    // NEW
    request_ctx: &McpRequestContext<'_>,
) -> McpResult<ToolCallResult>

pub async fn execute_tools(
    &self,
    inputs: Vec<ToolExecutionInput>,
    allowed_servers: &[String],
    server_label: &str,    // NEW
    request_ctx: &McpRequestContext<'_>,
) -> Vec<ToolExecutionOutput>
```

**Rationale:**

- **Compile-time safety**: Forgetting `server_label` is now a compile error
- **Explicit contract**: Callers must provide the label, can't accidentally use wrong value
- **Flexibility**: Callers can override labels (useful for aliased tools)
- **No runtime lookups**: Label available without inventory queries

---

### 2. Extend ToolExecutionOutput with Required Fields

**Change:**

```rust
pub struct ToolExecutionOutput {
    pub call_id: String,
    pub tool_name: String,
    pub server_key: String,      // NEW: Internal identifier
    pub server_label: String,    // NEW: User-facing label
    pub arguments_str: String,
    pub output: Value,           // CHANGED: Raw Value (was output_str)
    pub is_error: bool,
    pub error_message: Option<String>,
    pub response_format: ResponseFormat,  // NEW: For transformation
    pub duration: Duration,
}
```

**Rationale:**

- **Complete metadata**: Everything needed for transformation in one struct
- **Raw output**: Routers can serialize as needed (no forced format)
- **Self-contained**: No additional lookups needed after batch execution

---

### 3. Add to_response_item() Transformation Method

**Change:**

```rust
impl ToolExecutionOutput {
    /// Transform raw output to typed ResponseOutputItem.
    pub fn to_response_item(&self) -> ResponseOutputItem {
        ResponseTransformer::transform(
            &self.output,
            &self.response_format,
            &self.call_id,
            &self.server_label,  // Uses user-facing label
            &self.tool_name,
            &self.arguments_str,
        )
    }
}
```

**Rationale:**

- **Single source of truth**: All transformation via `ResponseTransformer`
- **Encapsulation**: Transformation logic doesn't leak to routers
- **Testability**: Dedicated unit tests for transformer

---

### 4. Update All Routers to Use Transformed Output

**OpenAI Router changes:**

- Removed `build_mcp_call_item()` function
- Removed `inject_mcp_metadata_streaming()` function
- Removed JSON patching workarounds
- Uses `output.to_response_item()` for batch results
- Uses `ResponseTransformer::transform()` directly for streaming

**Harmony gRPC Router changes:**

- `execute_mcp_tools()` now calls `output.to_response_item()` 
- `inject_mcp_metadata()` accepts pre-transformed items
- Removed hardcoded `McpCall` construction

**Regular gRPC Router changes:**

- Similar updates to Harmony router
- Unified with same transformation pattern

---

### 5. Refactor Approval Logic with Internal Enum

**Change:**

```rust
enum ApprovalExecutionResult {
    Success(CallToolResult),
    PendingApproval(McpApprovalRequest),
}
```

**Rationale:**

- **DRY**: Approval logic written once
- **Type safety**: Enum ensures all cases handled
- **Maintainability**: Changes to approval flow in one place

---

### 6. Standardize on Linear Scan for Small Collections

**Change:**

```rust
// Before (HashSet with allocation):
let allowed: HashSet<&str> = allowed_servers.iter().map(|s| s.as_str()).collect();

// After (linear scan, no allocation):
let is_allowed = |key: &str| allowed_servers.iter().any(|s| s == key);
```

**Rationale:**

For n < 10 elements (typical: 1-5 servers):
- `Vec::iter().any()` is faster (no allocation)
- HashSet construction cost dominates
- Linear scan has better cache locality

---

## Design Decisions

### Why explicit server_label parameter vs. lookup?

| Approach | Pros | Cons |
|----------|------|------|
| **Explicit parameter** ✓ | Compile-time safety, no runtime lookup, flexibility | More parameters |
| Lookup from inventory | Fewer parameters | Runtime cost, can fail |
| Derive from server_key | Simple | Wrong for dynamic servers |

### Why transform at orchestrator level vs. router level?

| Approach | Pros | Cons |
|----------|------|------|
| **Orchestrator level** ✓ | Single source of truth, consistent, testable | MCP crate has protocol knowledge |
| Router level | Routers control output | Duplication, inconsistency |

### Why keep both raw output and transformation method?

- **Conversation history**: Needs raw output, not transformed
- **Logging/debugging**: Raw format more useful
- **Custom processing**: Routers may need to augment

---

## Test Plan

- [x] All 91 API integration tests pass
- [x] All 119 MCP crate unit tests pass
- [x] `ResponseTransformer` unit tests cover all format types
- [ ] Manual testing with web_search_preview configured tool
- [ ] Verify server_label appears correctly in responses

---

## Files Changed

| File | Changes |
|------|---------|
| `mcp/src/core/orchestrator.rs` | Core execution pipeline, new fields, transformation |
| `mcp/README.md` | Documentation updates |
| `model_gateway/src/routers/openai/responses/mcp.rs` | Tool loop transformation |
| `model_gateway/src/routers/openai/responses/streaming.rs` | Remove patching |
| `model_gateway/src/routers/grpc/harmony/responses/common.rs` | Injection updates |
| `model_gateway/src/routers/grpc/harmony/responses/execution.rs` | Batch execution |
| `model_gateway/src/routers/grpc/harmony/responses/*.rs` | Call site updates |
| `model_gateway/src/routers/grpc/regular/responses/*.rs` | Call site updates |
| `model_gateway/tests/mcp_test.rs` | Updated test signatures |