### PR TITLE
fix(streaming): complete SSE event emission for all built-in tool types

### DIFF
--- a/model_gateway/src/routers/grpc/regular/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/streaming.rs
@@ -723,13 +723,13 @@ async fn execute_tool_loop_streaming_internal(
                 let event = emitter.emit_output_item_added(output_index, &item);
                 emitter.send_event(&event, &tx)?;
 
-                // Emit tool_call.in_progress (mcp_call.in_progress or web_search_call.in_progress)
+                // Emit tool_call.in_progress
                 let event =
                     emitter.emit_tool_call_in_progress(output_index, &item_id, &response_format);
                 emitter.send_event(&event, &tx)?;
 
-                // Emit arguments events for all MCP formats except WebSearchCall
-                if !matches!(response_format, ResponseFormat::WebSearchCall) {
+                // Emit arguments events for mcp_call only (skip for builtin tools)
+                if matches!(response_format, ResponseFormat::Passthrough) {
                     // Emit mcp_call_arguments.delta (simulate streaming by sending full arguments)
                     let event = emitter.emit_mcp_call_arguments_delta(
                         output_index,
@@ -747,7 +747,7 @@ async fn execute_tool_loop_streaming_internal(
                     emitter.send_event(&event, &tx)?;
                 }
 
-                // For web_search_call, emit searching event before tool execution
+                // Emit searching/interpreting event for builtin tools
                 if let Some(event) =
                     emitter.emit_tool_call_searching(output_index, &item_id, &response_format)
                 {

--- a/model_gateway/src/routers/openai/responses/streaming.rs
+++ b/model_gateway/src/routers/openai/responses/streaming.rs
@@ -37,8 +37,9 @@ use crate::{
     mcp::{McpOrchestrator, ResponseFormat},
     protocols::{
         event_types::{
-            is_function_call_type, is_response_event, FunctionCallEvent, ItemType, McpEvent,
-            OutputItemEvent, ResponseEvent, WebSearchCallEvent,
+            is_function_call_type, is_response_event, CodeInterpreterCallEvent,
+            FileSearchCallEvent, FunctionCallEvent, ItemType, McpEvent, OutputItemEvent,
+            ResponseEvent, WebSearchCallEvent,
         },
         responses::{ResponseToolType, ResponsesRequest},
     },
@@ -404,7 +405,7 @@ pub(super) fn forward_streaming_event(
 }
 
 /// Inject in_progress event after a tool call item is added.
-/// Handles both mcp_call and web_search_call items.
+/// Handles mcp_call, web_search_call, code_interpreter_call, and file_search_call items.
 /// Returns false if client disconnected.
 fn maybe_inject_tool_in_progress(
     parsed_data: &Value,
@@ -421,6 +422,8 @@ fn maybe_inject_tool_in_progress(
     let event_type = match item_type {
         ItemType::MCP_CALL => McpEvent::CALL_IN_PROGRESS,
         ItemType::WEB_SEARCH_CALL => WebSearchCallEvent::IN_PROGRESS,
+        ItemType::CODE_INTERPRETER_CALL => CodeInterpreterCallEvent::IN_PROGRESS,
+        ItemType::FILE_SEARCH_CALL => FileSearchCallEvent::IN_PROGRESS,
         _ => return true, // Not a tool call item, nothing to inject
     };
 

--- a/protocols/src/event_types.rs
+++ b/protocols/src/event_types.rs
@@ -207,6 +207,62 @@ impl fmt::Display for WebSearchCallEvent {
     }
 }
 
+/// Code interpreter call events for streaming
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CodeInterpreterCallEvent {
+    InProgress,
+    Interpreting,
+    Completed,
+}
+
+impl CodeInterpreterCallEvent {
+    pub const IN_PROGRESS: &'static str = "response.code_interpreter_call.in_progress";
+    pub const INTERPRETING: &'static str = "response.code_interpreter_call.interpreting";
+    pub const COMPLETED: &'static str = "response.code_interpreter_call.completed";
+
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::InProgress => Self::IN_PROGRESS,
+            Self::Interpreting => Self::INTERPRETING,
+            Self::Completed => Self::COMPLETED,
+        }
+    }
+}
+
+impl fmt::Display for CodeInterpreterCallEvent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// File search call events for streaming
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum FileSearchCallEvent {
+    InProgress,
+    Searching,
+    Completed,
+}
+
+impl FileSearchCallEvent {
+    pub const IN_PROGRESS: &'static str = "response.file_search_call.in_progress";
+    pub const SEARCHING: &'static str = "response.file_search_call.searching";
+    pub const COMPLETED: &'static str = "response.file_search_call.completed";
+
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::InProgress => Self::IN_PROGRESS,
+            Self::Searching => Self::SEARCHING,
+            Self::Completed => Self::COMPLETED,
+        }
+    }
+}
+
+impl fmt::Display for FileSearchCallEvent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 /// Item type discriminators used in output items
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ItemType {
@@ -216,6 +272,8 @@ pub enum ItemType {
     Function,
     McpListTools,
     WebSearchCall,
+    CodeInterpreterCall,
+    FileSearchCall,
 }
 
 impl ItemType {
@@ -225,6 +283,8 @@ impl ItemType {
     pub const FUNCTION: &'static str = "function";
     pub const MCP_LIST_TOOLS: &'static str = "mcp_list_tools";
     pub const WEB_SEARCH_CALL: &'static str = "web_search_call";
+    pub const CODE_INTERPRETER_CALL: &'static str = "code_interpreter_call";
+    pub const FILE_SEARCH_CALL: &'static str = "file_search_call";
 
     pub const fn as_str(&self) -> &'static str {
         match self {
@@ -234,12 +294,22 @@ impl ItemType {
             Self::Function => Self::FUNCTION,
             Self::McpListTools => Self::MCP_LIST_TOOLS,
             Self::WebSearchCall => Self::WEB_SEARCH_CALL,
+            Self::CodeInterpreterCall => Self::CODE_INTERPRETER_CALL,
+            Self::FileSearchCall => Self::FILE_SEARCH_CALL,
         }
     }
 
     /// Check if this is a function call variant (FunctionCall or FunctionToolCall)
     pub const fn is_function_call(&self) -> bool {
         matches!(self, Self::FunctionCall | Self::FunctionToolCall)
+    }
+
+    /// Check if this is a builtin tool call variant
+    pub const fn is_builtin_tool_call(&self) -> bool {
+        matches!(
+            self,
+            Self::WebSearchCall | Self::CodeInterpreterCall | Self::FileSearchCall
+        )
     }
 }
 


### PR DESCRIPTION
## Summary

This PR fixes **critical P0 bugs** in SSE event emission for built-in tool types (`code_interpreter`, `file_search`) and refactors duplicated code. After PR #182 added router integration, the SSE streaming layer had incomplete support for the new tool types.

**Key fixes:**
- Complete `in_progress` event emission for all 4 tool types (was missing 2)
- Add intermediate events (`interpreting`/`searching`) for code_interpreter and file_search
- Fix `server_label` to only apply to `mcp_call` (not built-in tools)
- Fix arguments streaming to skip for all built-in tools (not just web_search)
- Refactor 9 duplicated emit methods into 1 generic helper

**Related to:** #164 (Built-in Tool Support tracking issue)

---

## Problems Identified

### P0 Issue 1: Missing `in_progress` Events (OpenAI Router)

**Location:** `openai/responses/streaming.rs:maybe_inject_tool_in_progress()`

**Problem:** The function only handled 2 of 4 tool call item types:

```rust
// BEFORE: Only 2 types handled
let event_type = match item_type {
    ItemType::MCP_CALL => McpEvent::CALL_IN_PROGRESS,
    ItemType::WEB_SEARCH_CALL => WebSearchCallEvent::IN_PROGRESS,
    _ => return true,  // ← CODE_INTERPRETER_CALL silently skipped!
                       // ← FILE_SEARCH_CALL silently skipped!
};
```

**Impact:** Clients would **never** receive:
- `response.code_interpreter_call.in_progress`
- `response.file_search_call.in_progress`

This breaks progress tracking for these tool types.

---

### P0 Issue 2: Missing Intermediate Events During Execution (OpenAI Router)

**Location:** `openai/responses/mcp.rs:send_web_search_searching_event()`

**Problem:** The function was hardcoded for web_search only:

```rust
// BEFORE: Only web_search got intermediate events
if matches!(response_format, ResponseFormat::WebSearchCall)
    && !send_web_search_searching_event(tx, &call, sequence_number)
```

**Impact:** During tool execution:
- ✅ `web_search_call` → emits `response.web_search_call.searching`
- ❌ `code_interpreter_call` → **NO** `response.code_interpreter_call.interpreting`
- ❌ `file_search_call` → **NO** `response.file_search_call.searching`

This creates poor UX during long-running operations - clients have no visibility into execution progress.

---

### P0 Issue 3: Incorrect `server_label` Application (gRPC Routers)

**Location:** `grpc/harmony/streaming.rs:818` and multiple other locations

**Problem:** The condition for adding `server_label` was semantically wrong:

```rust
// BEFORE: Added server_label to ALL non-WebSearchCall types
if matches!(response_format, Some(ref f) if !matches!(f, ResponseFormat::WebSearchCall))
{
    item["server_label"] = json!(label);  // ← CodeInterpreter incorrectly got this!
}
```

**Why this is wrong:**
1. `server_label` identifies which MCP server handled the call
2. Built-in tools (web_search, code_interpreter, file_search) are **NOT** MCP calls
3. Only `mcp_call` (Passthrough format) should have `server_label`

**Impact:** Built-in tool outputs would incorrectly include `server_label` field, which:
- Confuses clients about tool type
- Violates OpenAI API contract
- May cause client-side parsing errors

---

### P0 Issue 4: Arguments Streaming Not Skipped for Built-in Tools

**Location:** `grpc/harmony/streaming.rs` and `grpc/regular/responses/streaming.rs`

**Problem:** The condition only skipped arguments streaming for WebSearchCall:

```rust
// BEFORE: Only WebSearchCall was skipped
if !matches!(response_format, Some(ResponseFormat::WebSearchCall)) {
    emitter.emit_mcp_call_arguments_delta(...);  // ← CodeInterpreter/FileSearch got this!
    emitter.emit_mcp_call_arguments_done(...);
}
```

**Why arguments streaming should be skipped for built-in tools:**
1. Built-in tools receive arguments directly from the LLM
2. `mcp_call_arguments.delta` and `mcp_call_arguments.done` are MCP-specific protocol events
3. Emitting them for built-in tools creates inconsistent event sequences

**Impact:** Clients would receive spurious arguments events for code_interpreter and file_search:
- Parsing errors (unexpected event type)
- Incorrect state machine transitions
- Inconsistent behavior between tool types

---

### P2 Issue: Code Duplication in Event Emission

**Location:** `grpc/common/responses/streaming.rs`

**Problem:** Nine nearly-identical methods existed:

```rust
// Each method was ~10 lines with identical structure
pub fn emit_mcp_call_in_progress(...) { json!({ "type": McpEvent::CALL_IN_PROGRESS, ... }) }
pub fn emit_mcp_call_completed(...) { json!({ "type": McpEvent::CALL_COMPLETED, ... }) }
pub fn emit_web_search_call_in_progress(...) { json!({ "type": WebSearchCallEvent::IN_PROGRESS, ... }) }
pub fn emit_web_search_call_searching(...) { json!({ "type": WebSearchCallEvent::SEARCHING, ... }) }
pub fn emit_web_search_call_completed(...) { json!({ "type": WebSearchCallEvent::COMPLETED, ... }) }
// ... more duplicates
```

**Impact:**
- Violated DRY principle
- Adding new tool types required copying ~30 lines of boilerplate
- Inconsistency risk between implementations
- ~80 lines of duplicate code

---

## Solution

### 1. Event Type Infrastructure

**File:** `protocols/src/event_types.rs`

Added complete event definitions for all built-in tools:

```rust
pub enum CodeInterpreterCallEvent {
    InProgress,   // "response.code_interpreter_call.in_progress"
    Interpreting, // "response.code_interpreter_call.interpreting"
    Completed,    // "response.code_interpreter_call.completed"
}

pub enum FileSearchCallEvent {
    InProgress,   // "response.file_search_call.in_progress"
    Searching,    // "response.file_search_call.searching"
    Completed,    // "response.file_search_call.completed"
}
```

Extended `ItemType` and `OutputItemType` enums with new variants.

---

### 2. Unified Event Emission

**File:** `grpc/common/responses/streaming.rs`

Created single internal helper:

```rust
fn emit_tool_event(
    &mut self,
    event_type: &'static str,
    output_index: usize,
    item_id: &str,
) -> serde_json::Value {
    json!({
        "type": event_type,
        "sequence_number": self.next_sequence(),
        "output_index": output_index,
        "item_id": item_id
    })
}
```

Public methods now use exhaustive pattern matching:

```rust
pub fn emit_tool_call_in_progress(..., response_format: &ResponseFormat) {
    let event_type = match response_format {
        ResponseFormat::WebSearchCall => WebSearchCallEvent::IN_PROGRESS,
        ResponseFormat::CodeInterpreterCall => CodeInterpreterCallEvent::IN_PROGRESS,
        ResponseFormat::FileSearchCall => FileSearchCallEvent::IN_PROGRESS,
        ResponseFormat::Passthrough => McpEvent::CALL_IN_PROGRESS,
    };
    self.emit_tool_event(event_type, output_index, item_id)
}
```

**Result:** Removed 6 dead methods, consolidated ~80 lines → ~15 lines.

---

### 3. Generic Intermediate Event Handler

**File:** `openai/responses/mcp.rs`

Replaced `send_web_search_searching_event()` with `send_tool_call_intermediate_event()`:

```rust
fn send_tool_call_intermediate_event(
    tx: &mpsc::UnboundedSender<...>,
    call: &FunctionCallInProgress,
    response_format: &ResponseFormat,
    sequence_number: &mut u64,
) -> bool {
    let (event_type, id_prefix) = match response_format {
        ResponseFormat::WebSearchCall => (WebSearchCallEvent::SEARCHING, "ws_"),
        ResponseFormat::CodeInterpreterCall => (CodeInterpreterCallEvent::INTERPRETING, "ci_"),
        ResponseFormat::FileSearchCall => (FileSearchCallEvent::SEARCHING, "fs_"),
        ResponseFormat::Passthrough => return true, // No intermediate event for mcp_call
    };
    // ... emit event with correct type and ID prefix
}
```

---

### 4. Corrected `server_label` Logic

**Files:** `harmony/streaming.rs`, `regular/streaming.rs`

Changed all conditions to explicitly check for Passthrough:

```rust
// AFTER: Only Passthrough (mcp_call) gets server_label
if matches!(response_format, Some(ResponseFormat::Passthrough)) {
    if let Some(ref label) = emitter.mcp_server_label {
        item["server_label"] = json!(label);
    }
}
```

---

### 5. Corrected Arguments Streaming Logic

Changed all conditions to explicitly enable for Passthrough only:

```rust
// AFTER: Only mcp_call streams arguments
if matches!(response_format, Some(ResponseFormat::Passthrough) | None) {
    // Emit mcp_call_arguments.delta and mcp_call_arguments.done
}
```

The `| None` handles function calls (non-MCP tools) which also stream arguments.

---

## Design Decisions

### Why Pattern Matching Over Trait Polymorphism?

We chose exhaustive `match` statements because:
1. **Compile-time exhaustiveness** - Adding `ResponseFormat::NewTool` causes compiler errors in all incomplete matches
2. **Closed set** - All format variants are known at compile time
3. **Zero runtime overhead** - No dynamic dispatch
4. **IDE support** - "Implement missing arms" when enum changes

### Why `Passthrough` Instead of Negation?

Changed from "not WebSearchCall" to "is Passthrough" because:
1. **Explicit positive matching** is clearer than double negation
2. **Future-proof** - Adding new built-in types won't accidentally inherit mcp_call behavior
3. **Self-documenting** - Intent "only mcp_call does this" is directly expressed

### Why `| None` in Arguments Streaming?

```rust
if matches!(response_format, Some(ResponseFormat::Passthrough) | None)
```

The `None` case handles regular function calls (non-MCP tools) which should also stream arguments. This maintains backward compatibility.

---

## Files Changed

| File | Changes |
|------|---------|
| `protocols/src/event_types.rs` | Added `CodeInterpreterCallEvent`, `FileSearchCallEvent`, extended `ItemType` |
| `grpc/common/responses/streaming.rs` | Refactored emit methods, added `OutputItemType` variants |
| `grpc/harmony/streaming.rs` | Fixed `server_label` and arguments streaming conditions |
| `grpc/regular/responses/streaming.rs` | Fixed arguments streaming condition |
| `openai/responses/mcp.rs` | Replaced web_search-specific function with generic handler |
| `openai/responses/streaming.rs` | Extended `maybe_inject_tool_in_progress` to handle all 4 types |

---

## Event Sequence Comparison

### Before (Broken)

```
code_interpreter request:
→ response.output_item.added (type: code_interpreter_call)
→ ❌ NO in_progress event
→ mcp_call_arguments.delta  ← WRONG! Should not exist
→ mcp_call_arguments.done   ← WRONG! Should not exist
→ ❌ NO interpreting event
→ response.code_interpreter_call.completed
```

### After (Fixed)

```
code_interpreter request:
→ response.output_item.added (type: code_interpreter_call)
→ response.code_interpreter_call.in_progress  ← ADDED
→ response.code_interpreter_call.interpreting ← ADDED
→ response.code_interpreter_call.completed
```

---

## Testing

All existing tests pass. Manual E2E testing recommended with MCP servers configured for each built-in type.

## Test Plan

- [ ] Verify `in_progress` events emitted for all 4 tool types
- [ ] Verify `searching`/`interpreting` events emitted during execution
- [ ] Verify `server_label` only appears on `mcp_call` items
- [ ] Verify no `mcp_call_arguments.*` events for built-in tools
- [ ] Verify backward compatibility with existing `mcp_call` and `web_search_call`