### PR TITLE
perf(tokenizer): optimize stop sequence search using Aho-Corasick algorithm

### DIFF
--- a/tokenizer/Cargo.toml
+++ b/tokenizer/Cargo.toml
@@ -30,6 +30,7 @@ tokio = { workspace = true, features = ["sync", "rt-multi-thread", "macros"] }
 tracing.workspace = true
 uuid = { workspace = true, features = ["v4", "serde"] }
 # Only used by tokenizer
+aho-corasick = "1.1"
 hf-hub = { version = "0.4.3", features = ["tokio"] }
 minijinja = { version = "2.0", features = ["unstable_machinery", "json", "builtins"] }
 minijinja-contrib = { version = "2.0", features = ["pycompat"] }
@@ -38,6 +39,11 @@ tiktoken-rs = "0.7.0"
 tokenizers = "0.22.0"
 
 [dev-dependencies]
+criterion = "0.5"
 openai-protocol.workspace = true
 reqwest = { workspace = true, features = ["blocking"] }
 tempfile = "3.8"
+
+[[bench]]
+name = "stop_sequence_search"
+harness = false

--- a/tokenizer/benches/stop_sequence_search.rs
+++ b/tokenizer/benches/stop_sequence_search.rs
@@ -1,0 +1,46 @@
+use aho_corasick::AhoCorasick;
+use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+
+/// Naive implementation using nested loops with find()
+fn find_stop_sequence_naive(text: &str, stop_sequences: &[String]) -> Option<(usize, usize)> {
+    for stop_seq in stop_sequences {
+        if let Some(pos) = text.find(stop_seq) {
+            return Some((pos, pos + stop_seq.len()));
+        }
+    }
+    None
+}
+
+/// Optimized implementation using Aho-Corasick automaton
+fn find_stop_sequence_aho(text: &str, ac: &AhoCorasick) -> Option<(usize, usize)> {
+    ac.find(text).map(|mat| (mat.start(), mat.end()))
+}
+
+fn bench_stop_sequence_search(c: &mut Criterion) {
+    let mut group = c.benchmark_group("stop_sequence_search");
+
+    // Simulate realistic streaming text from LLM
+    let text = "User: Hello! Assistant: How can I help you today? ".repeat(1000);
+    group.throughput(Throughput::Bytes(text.len() as u64));
+
+    for token_count in [5, 20, 50] {
+        let stop_sequences: Vec<String> = (0..token_count)
+            .map(|i| format!("<|stop_sequence_{}|>", i))
+            .collect();
+
+        let ac = AhoCorasick::new(&stop_sequences).unwrap();
+
+        group.bench_function(format!("naive_{}_sequences", token_count), |b| {
+            b.iter(|| find_stop_sequence_naive(black_box(&text), black_box(&stop_sequences)))
+        });
+
+        group.bench_function(format!("aho_corasick_{}_sequences", token_count), |b| {
+            b.iter(|| find_stop_sequence_aho(black_box(&text), black_box(&ac)))
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_stop_sequence_search);
+criterion_main!(benches);

--- a/tokenizer/src/stop.rs
+++ b/tokenizer/src/stop.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashSet, sync::Arc};
 
+use aho_corasick::AhoCorasick;
 use anyhow::Result;
 
 use crate::{
@@ -64,6 +65,11 @@ pub struct StopSequenceDecoder {
     /// Sequence for incremental decoding (replaces token_buffer + offsets)
     sequence: Sequence,
     config: StopSequenceConfig,
+    /// Aho-Corasick automaton for O(N) stop sequence matching
+    aho_corasick: Option<AhoCorasick>,
+    /// Index boundary: patterns [0..visible_boundary_idx) are hidden,
+    /// patterns [visible_boundary_idx..) are visible
+    visible_boundary_idx: usize,
     /// Buffer for partial matches (the "jail")
     jail_buffer: String,
     /// Whether we've stopped
@@ -77,9 +83,34 @@ impl StopSequenceDecoder {
         config: StopSequenceConfig,
         skip_special_tokens: bool,
     ) -> Self {
+        // Build Aho-Corasick automaton from all stop sequences
+        // Hidden sequences come first, then visible sequences
+        let mut patterns: Vec<&str> = config
+            .stop_sequences
+            .iter()
+            .filter(|s| !s.is_empty())
+            .map(|s| s.as_str())
+            .collect();
+        let visible_boundary_idx = patterns.len();
+        patterns.extend(
+            config
+                .visible_stop_sequences
+                .iter()
+                .filter(|s| !s.is_empty())
+                .map(|s| s.as_str()),
+        );
+
+        let aho_corasick = if patterns.is_empty() {
+            None
+        } else {
+            Some(AhoCorasick::new(patterns).expect("Failed to build Aho-Corasick automaton"))
+        };
+
         StopSequenceDecoder {
             sequence: Sequence::new_with_options(tokenizer, skip_special_tokens),
             config,
+            aho_corasick,
+            visible_boundary_idx,
             jail_buffer: String::new(),
             stopped: false,
         }
@@ -122,28 +153,27 @@ impl StopSequenceDecoder {
 
         self.jail_buffer.push_str(&new_text);
 
-        // Check for hidden stop sequences
-        for stop_seq in &self.config.stop_sequences {
-            if let Some(pos) = self.jail_buffer.find(stop_seq) {
+        // Check for stop sequences using Aho-Corasick (O(N) single-pass)
+        if let Some(ac) = &self.aho_corasick {
+            if let Some(mat) = ac.find(&self.jail_buffer) {
                 self.stopped = true;
-                let output = self.jail_buffer[..pos].to_string();
-                self.jail_buffer.clear();
-                return Ok(if output.is_empty() {
-                    SequenceDecoderOutput::Stopped
-                } else {
-                    SequenceDecoderOutput::StoppedWithText(output)
-                });
-            }
-        }
+                let is_visible = mat.pattern().as_usize() >= self.visible_boundary_idx;
 
-        // Check for visible stop sequences
-        for stop_seq in &self.config.visible_stop_sequences {
-            if let Some(pos) = self.jail_buffer.find(stop_seq) {
-                self.stopped = true;
-                let end_pos = pos + stop_seq.len();
-                let output = self.jail_buffer[..end_pos].to_string();
-                self.jail_buffer.clear();
-                return Ok(SequenceDecoderOutput::StoppedWithText(output));
+                if is_visible {
+                    // Visible stop sequence: include it in output
+                    let output = self.jail_buffer[..mat.end()].to_string();
+                    self.jail_buffer.clear();
+                    return Ok(SequenceDecoderOutput::StoppedWithText(output));
+                } else {
+                    // Hidden stop sequence: exclude it from output
+                    let output = self.jail_buffer[..mat.start()].to_string();
+                    self.jail_buffer.clear();
+                    return Ok(if output.is_empty() {
+                        SequenceDecoderOutput::Stopped
+                    } else {
+                        SequenceDecoderOutput::StoppedWithText(output)
+                    });
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

- Optimize stop sequence search from O(N × M) to O(N) using Aho-Corasick automaton
- Add benchmark to verify performance improvement

## Problem

The previous implementation of `StopSequenceDecoder` used naive nested loops to search for stop sequences. For each of M stop sequences, it called `.find()` which scans the entire text of length N, resulting in **O(N × M)** time complexity. This caused performance degradation as the number of stop sequences increased.

## Solution

Replace the nested `.find()` loops with a single-pass **Aho-Corasick automaton**. The algorithm builds a finite state machine from all patterns and scans the text in a single pass, achieving **O(N + M + Z)** time complexity where Z is the number of matches.

## Implementation Details

- Added `aho-corasick = "1.1"` dependency
- Added `aho_corasick: Option<AhoCorasick>` field to `StopSequenceDecoder`
- Added `visible_boundary_idx` to distinguish hidden vs visible matches based on pattern index
- Build the automaton once during construction, combining hidden and visible stop sequences
- Replace two separate loops (hidden + visible) with single `ac.find()` call
- Automaton is `None` when no stop sequences configured (zero overhead)

## Benchmark Results

Text size: 50KB, varying stop sequence count:

| Sequences | Naive | Aho-Corasick | Speedup |
|-----------|-------|--------------|---------|
| 5 | 17.3 µs | 735 ns | **24x** |
| 20 | 68.8 µs | 738 ns | **93x** |
| 50 | 118 µs | 734 ns | **161x** |

**Key observation**: Aho-Corasick time remains constant (~735ns) regardless of pattern count, while naive approach scales linearly.

## Test Plan

- [x] All 15 existing stop sequence tests pass
- [x] Benchmark added and verified
