### PR TITLE
bug: Fix chat_template format detection for Llama 3.1

### DIFF
--- a/tokenizer/src/chat_template.rs
+++ b/tokenizer/src/chat_template.rs
@@ -265,18 +265,10 @@ impl<'a> Detector<'a> {
                     self.inspect_expr_for_structure(inner_ref);
                 }
             }
-            // content is sequence/iterable OR message.content is sequence/iterable
-            Expr::Test(t) => {
-                if t.name == "sequence" || t.name == "iterable" || t.name == "string" {
-                    if matches!(&t.expr, Expr::Var(v) if v.id == "content")
-                        || self.is_any_scope_var_content(&t.expr)
-                    {
-                        self.flags.saw_structure = true;
-                    }
-                } else {
-                    self.inspect_expr_for_structure(&t.expr);
-                }
-            }
+            // Type tests like `content is iterable` or `message.content is string`
+            // These are used for branching (e.g., Llama 3.1 uses them for tool output formatting),
+            // not as indicators that the template expects structured content. Keep walking.
+            Expr::Test(t) => self.inspect_expr_for_structure(&t.expr),
             Expr::GetAttr(g) => {
                 // Keep walking; nested expressions can hide structure checks
                 self.inspect_expr_for_structure(&g.expr);


### PR DESCRIPTION
## Description

### Problem

Llama 3.1's chat template was incorrectly detected as OpenAI format due to the `message.content is iterable` check used for tool message output formatting. This caused array content like `[{"type": "text", "text": "..."}]` to be passed directly to the template instead of being extracted to plain text, resulting in JSON appearing literally in the prompt and the model mimicking that format in responses.

### Solution

Type tests like `content is iterable` or `message.content is string` are branching logic for conditional output, not indicators that the template expects structured content. The fix updates the format detection to skip triggering `saw_structure` for these type tests while still walking the expression tree for other patterns.

## Changes

- `tokenizer/src/chat_template.rs`: Updated `Expr::Test` handling in `inspect_expr_for_structure` to not trigger OpenAI format detection for type tests
- `tokenizer/tests/chat_template_format_detection.rs`: Added test case for Llama 3.1 template format detection

## Test Plan

```bash
cargo test --package llm-tokenizer --test chat_template_format_detection
```

**Before:** Array content format causes model to return JSON-structured response

<img width="1500" height="249" alt="Screenshot 2026-01-26 at 11 01 50 PM" src="https://github.com/user-attachments/assets/9095e57c-a096-4bad-8713-822f74ebc179" />

**After:** Array content format returns plain text response (same as string content)

<img width="1491" height="256" alt="Screenshot 2026-01-27 at 12 53 23 AM" src="https://github.com/user-attachments/assets/3f5cefd2-44ef-466e-a192-2b47f4d70787" />

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>