### PR TITLE
fix(mcp): align streamable transport headers with SSE to forward custom headers consistently

### DIFF
--- a/mcp/src/core/orchestrator.rs
+++ b/mcp/src/core/orchestrator.rs
@@ -91,7 +91,7 @@ fn build_request_headers(
     Ok(headers)
 }
 
-/// Build a shared HTTP client (SSE + Streamable) with default headers.
+/// Build HTTP client with default headers.
 fn build_http_client(
     proxy_config: Option<&McpProxyConfig>,
     token: &Option<String>,


### PR DESCRIPTION
## Description

### Problem

Streamable MCP connections did not forward custom headers and could duplicate the Bearer prefix in Authorization, leading to missing headers on the MCP server.

### Solution

Unify Streamable and SSE HTTP client construction so both use the same default header path, and remove Streamable’s separate auth header handling.

## Changes

- Centralized HTTP client building for SSE/Streamable with shared default headers.
- Streamable now uses the same header path as SSE.
- Cleaned up redundant auth header handling.

## Test Plan

logs from a local mcp server
```
INFO:     127.0.0.1:53355 - "POST /mcp HTTP/1.1" 200 OK
INFO:     127.0.0.1:53356 - "POST /mcp HTTP/1.1" 202 Accepted
INFO:     127.0.0.1:53356 - "GET /mcp HTTP/1.1" 200 OK
INFO:     127.0.0.1:53357 - "POST /mcp HTTP/1.1" 200 OK
INFO:     127.0.0.1:53358 - "POST /mcp HTTP/1.1" 200 OK
{'content-type': 'application/json', 'authorization': 'Bearer authorization123', 'x-request-id': 'test1123'}
```

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>
