### PR TITLE
feat: Rename TensorRT-LLM gRPC client from TrtLlmEngine to TrtllmService

### DIFF
--- a/grpc_client/build.rs
+++ b/grpc_client/build.rs
@@ -2,7 +2,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Rebuild triggers
     println!("cargo:rerun-if-changed=proto/sglang_scheduler.proto");
     println!("cargo:rerun-if-changed=proto/vllm_engine.proto");
-    println!("cargo:rerun-if-changed=proto/trtllm_engine.proto");
+    println!("cargo:rerun-if-changed=proto/trtllm_service.proto");
 
     // Compile protobuf files
     tonic_prost_build::configure()
@@ -14,7 +14,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             &[
                 "proto/sglang_scheduler.proto",
                 "proto/vllm_engine.proto",
-                "proto/trtllm_engine.proto",
+                "proto/trtllm_service.proto",
             ],
             &["proto"],
         )?;

--- a/grpc_client/proto/trtllm_service.proto
+++ b/grpc_client/proto/trtllm_service.proto
@@ -16,7 +16,7 @@
 syntax = "proto3";
 package trtllm;
 
-// TensorRT-LLM gRPC Engine Service
+// TensorRT-LLM gRPC Service
 //
 // This service provides high-performance inference for LLMs using TensorRT-LLM.
 // It accepts pre-tokenized requests and returns raw token IDs, enabling efficient
@@ -27,7 +27,7 @@ package trtllm;
 // - Streaming delta mode: Chunks contain only new tokens since last chunk
 // - Full feature support: All TensorRT-LLM capabilities exposed
 
-service TrtLlmEngine {
+service TrtllmService {
   // Generate tokens from pre-tokenized input
   // Returns a stream of responses containing token IDs
   rpc Generate(GenerateRequest) returns (stream GenerateResponse);

--- a/grpc_client/src/lib.rs
+++ b/grpc_client/src/lib.rs
@@ -4,7 +4,7 @@
 //! SGLang scheduler, vLLM engine, and TensorRT-LLM engine backends.
 
 pub mod sglang_scheduler;
-pub mod trtllm_engine;
+pub mod trtllm_service;
 pub mod vllm_engine;
 
 // Re-export clients
@@ -12,7 +12,7 @@ use std::sync::Arc;
 
 pub use sglang_scheduler::{proto as sglang_proto, SglangSchedulerClient};
 use tonic::metadata::MetadataMap;
-pub use trtllm_engine::{proto as trtllm_proto, TrtllmEngineClient};
+pub use trtllm_service::{proto as trtllm_proto, TrtllmServiceClient};
 pub use vllm_engine::{proto as vllm_proto, VllmEngineClient};
 
 /// Trait for injecting trace context into gRPC metadata.

--- a/grpc_client/src/trtllm_service.rs
+++ b/grpc_client/src/trtllm_service.rs
@@ -32,7 +32,7 @@ pub mod proto {
 pub struct AbortOnDropStream {
     inner: Streaming<proto::GenerateResponse>,
     request_id: String,
-    client: TrtllmEngineClient,
+    client: TrtllmServiceClient,
     aborted: Arc<AtomicBool>,
 }
 
@@ -41,7 +41,7 @@ impl AbortOnDropStream {
     pub fn new(
         stream: Streaming<proto::GenerateResponse>,
         request_id: String,
-        client: TrtllmEngineClient,
+        client: TrtllmServiceClient,
     ) -> Self {
         debug!("Created AbortOnDropStream for request {}", request_id);
         Self {
@@ -107,14 +107,14 @@ impl futures::Stream for AbortOnDropStream {
     }
 }
 
-/// gRPC client for TensorRT-LLM engine
+/// gRPC client for TensorRT-LLM service
 #[derive(Clone)]
-pub struct TrtllmEngineClient {
-    client: proto::trt_llm_engine_client::TrtLlmEngineClient<Channel>,
+pub struct TrtllmServiceClient {
+    client: proto::trtllm_service_client::TrtllmServiceClient<Channel>,
     trace_injector: BoxedTraceInjector,
 }
 
-impl TrtllmEngineClient {
+impl TrtllmServiceClient {
     /// Create a new client and connect to the TensorRT-LLM server
     pub async fn connect(endpoint: &str) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
         Self::connect_with_trace_injector(endpoint, Arc::new(NoopTraceInjector)).await
@@ -146,7 +146,7 @@ impl TrtllmEngineClient {
             .connect()
             .await?;
 
-        let client = proto::trt_llm_engine_client::TrtLlmEngineClient::new(channel);
+        let client = proto::trtllm_service_client::TrtllmServiceClient::new(channel);
 
         Ok(Self {
             client,
@@ -760,7 +760,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_client_connect_invalid_endpoint() {
-        let result = TrtllmEngineClient::connect("invalid://endpoint").await;
+        let result = TrtllmServiceClient::connect("invalid://endpoint").await;
         assert!(result.is_err());
     }
 

--- a/model_gateway/src/routers/grpc/client.rs
+++ b/model_gateway/src/routers/grpc/client.rs
@@ -1,7 +1,7 @@
 //! Unified gRPC client wrapper for SGLang, vLLM, and TensorRT-LLM backends
 
 use crate::{
-    grpc_client::{SglangSchedulerClient, TrtllmEngineClient, VllmEngineClient},
+    grpc_client::{SglangSchedulerClient, TrtllmServiceClient, VllmEngineClient},
     routers::grpc::proto_wrapper::{
         ProtoEmbedRequest, ProtoEmbedResponse, ProtoGenerateRequest, ProtoStream,
     },
@@ -19,7 +19,7 @@ pub struct HealthCheckResponse {
 pub enum GrpcClient {
     Sglang(SglangSchedulerClient),
     Vllm(VllmEngineClient),
-    Trtllm(TrtllmEngineClient),
+    Trtllm(TrtllmServiceClient),
 }
 
 impl GrpcClient {
@@ -56,7 +56,7 @@ impl GrpcClient {
     }
 
     /// Get reference to TensorRT-LLM client (panics if not TensorRT-LLM)
-    pub fn as_trtllm(&self) -> &TrtllmEngineClient {
+    pub fn as_trtllm(&self) -> &TrtllmServiceClient {
         match self {
             Self::Trtllm(client) => client,
             _ => panic!("Expected TensorRT-LLM client"),
@@ -64,7 +64,7 @@ impl GrpcClient {
     }
 
     /// Get mutable reference to TensorRT-LLM client (panics if not TensorRT-LLM)
-    pub fn as_trtllm_mut(&mut self) -> &mut TrtllmEngineClient {
+    pub fn as_trtllm_mut(&mut self) -> &mut TrtllmServiceClient {
         match self {
             Self::Trtllm(client) => client,
             _ => panic!("Expected TensorRT-LLM client"),
@@ -94,7 +94,7 @@ impl GrpcClient {
         match runtime_type {
             "sglang" => Ok(Self::Sglang(SglangSchedulerClient::connect(url).await?)),
             "vllm" => Ok(Self::Vllm(VllmEngineClient::connect(url).await?)),
-            "trtllm" | "tensorrt-llm" => Ok(Self::Trtllm(TrtllmEngineClient::connect(url).await?)),
+            "trtllm" | "tensorrt-llm" => Ok(Self::Trtllm(TrtllmServiceClient::connect(url).await?)),
             _ => Err(format!("Unknown runtime type: {}", runtime_type).into()),
         }
     }

--- a/model_gateway/src/routers/grpc/proto_wrapper.rs
+++ b/model_gateway/src/routers/grpc/proto_wrapper.rs
@@ -8,8 +8,8 @@ use futures_util::StreamExt;
 use crate::grpc_client::{
     sglang_proto::{self as sglang, generate_complete::MatchedStop},
     sglang_scheduler::AbortOnDropStream as SglangStream,
-    trtllm_engine::AbortOnDropStream as TrtllmStream,
     trtllm_proto as trtllm,
+    trtllm_service::AbortOnDropStream as TrtllmStream,
     vllm_engine::AbortOnDropStream as VllmStream,
     vllm_proto as vllm,
 };


### PR DESCRIPTION
## Description

### Problem

The TensorRT-LLM gRPC service was renamed from `TrtLlmEngine` to `TrtllmService` in the upstream TensorRT-LLM PR [#11037](https://github.com/NVIDIA/TensorRT-LLM/pull/11037). Our SMG grpc_client needs to align with this change.

### Solution

Rename all TRT-LLM gRPC related types and files to use the new naming convention.

## Changes

- Rename proto file: `trtllm_engine.proto` -> `trtllm_service.proto`
- Rename Rust module: `trtllm_engine.rs` -> `trtllm_service.rs`
- Rename client struct: `TrtllmEngineClient` -> `TrtllmServiceClient`
- Update proto service name from `TrtLlmEngine` to `TrtllmService`
- Update all references in `build.rs`, `lib.rs`, `client.rs`, `proto_wrapper.rs`

## Test Plan

- [x] `cargo build` passes
- [x] E2E test with TensorRT-LLM backend
  - [x] Streaming
  - [x] n > 1
  - [x] Abort/cancellation

<img width="2261" height="780" alt="Screenshot 2026-01-28 at 10 23 40 AM" src="https://github.com/user-attachments/assets/ac265957-0adc-41cd-bdaf-1837f941faed" />

<img width="1115" height="833" alt="Screenshot 2026-01-28 at 10 52 42 AM" src="https://github.com/user-attachments/assets/ac40aa8d-f337-4b11-a035-5789c7516d01" />

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)