### PR TITLE
refactor(grpc): Standardize token counts to uint32 across all protos

### DIFF
--- a/bindings/golang/src/client.rs
+++ b/bindings/golang/src/client.rs
@@ -173,7 +173,7 @@ pub unsafe extern "C" fn sgl_client_chat_completion_stream(
             return SglErrorCode::TokenizationError;
         }
     };
-    let prompt_tokens = token_ids.len() as i32; // Save prompt token count
+    let prompt_tokens = token_ids.len() as u32; // Save prompt token count
 
     // Generate tool constraints if needed
     let tool_constraint = if let Some(tools) = chat_request.tools.as_ref() {

--- a/bindings/golang/src/grpc_converter.rs
+++ b/bindings/golang/src/grpc_converter.rs
@@ -40,7 +40,7 @@ pub struct GrpcResponseConverterHandle {
     pub(crate) tool_choice: Option<ToolChoice>,
     pub(crate) history_tool_calls_count: usize,
     pub(crate) stream_state: StreamStateManager,
-    pub(crate) initial_prompt_tokens: Option<i32>,
+    pub(crate) initial_prompt_tokens: Option<u32>,
     pub(crate) skip_special_tokens: bool,
 }
 
@@ -568,7 +568,7 @@ pub(crate) async fn convert_proto_chunk_to_openai(
             } else if complete.completion_tokens > 0 {
                 complete.completion_tokens
             } else if !complete.output_ids.is_empty() {
-                complete.output_ids.len() as i32
+                complete.output_ids.len() as u32
             } else {
                 0
             };
@@ -582,9 +582,9 @@ pub(crate) async fn convert_proto_chunk_to_openai(
 
             // Always create usage, even if values are 0 (defensive)
             let usage = Some(Usage {
-                prompt_tokens: prompt_tokens.max(0) as u32,
-                completion_tokens: completion_tokens.max(0) as u32,
-                total_tokens: (prompt_tokens.max(0) + completion_tokens.max(0)) as u32,
+                prompt_tokens,
+                completion_tokens,
+                total_tokens: prompt_tokens + completion_tokens,
                 completion_tokens_details: None,
             });
 

--- a/bindings/golang/src/proto_parse.rs
+++ b/bindings/golang/src/proto_parse.rs
@@ -51,18 +51,18 @@ fn parse_chunk(json: &Value) -> proto::GenerateStreamChunk {
             .unwrap_or_default(),
         prompt_tokens: json
             .get("prompt_tokens")
-            .and_then(|v| v.as_i64())
-            .map(|n| n as i32)
+            .and_then(|v| v.as_u64())
+            .map(|n| n as u32)
             .unwrap_or(0),
         completion_tokens: json
             .get("completion_tokens")
-            .and_then(|v| v.as_i64())
-            .map(|n| n as i32)
+            .and_then(|v| v.as_u64())
+            .map(|n| n as u32)
             .unwrap_or(0),
         cached_tokens: json
             .get("cached_tokens")
-            .and_then(|v| v.as_i64())
-            .map(|n| n as i32)
+            .and_then(|v| v.as_u64())
+            .map(|n| n as u32)
             .unwrap_or(0),
         output_logprobs: None,
         hidden_states: vec![],
@@ -89,18 +89,18 @@ fn parse_complete(json: &Value) -> proto::GenerateComplete {
             .to_string(),
         prompt_tokens: json
             .get("prompt_tokens")
-            .and_then(|v| v.as_i64())
-            .map(|n| n as i32)
+            .and_then(|v| v.as_u64())
+            .map(|n| n as u32)
             .unwrap_or(0),
         completion_tokens: json
             .get("completion_tokens")
-            .and_then(|v| v.as_i64())
-            .map(|n| n as i32)
+            .and_then(|v| v.as_u64())
+            .map(|n| n as u32)
             .unwrap_or(0),
         cached_tokens: json
             .get("cached_tokens")
-            .and_then(|v| v.as_i64())
-            .map(|n| n as i32)
+            .and_then(|v| v.as_u64())
+            .map(|n| n as u32)
             .unwrap_or(0),
         output_logprobs: None,
         all_hidden_states: vec![],

--- a/bindings/golang/src/stream.rs
+++ b/bindings/golang/src/stream.rs
@@ -36,7 +36,7 @@ pub struct SglangStreamHandle {
     #[allow(dead_code)]
     pub(crate) client: Arc<SglangSchedulerClient>,
     #[allow(dead_code)]
-    pub(crate) prompt_tokens: i32, // Number of prompt tokens for this request
+    pub(crate) prompt_tokens: u32, // Number of prompt tokens for this request
 }
 
 /// Read next chunk from stream and convert to OpenAI format.

--- a/bindings/golang/src/stream_state.rs
+++ b/bindings/golang/src/stream_state.rs
@@ -10,8 +10,8 @@ pub struct StreamIndexState {
     pub decode_stream: Option<DecodeStream>,
     pub has_tool_calls: bool,
     pub is_first_chunk: bool,
-    pub prompt_tokens: i32,
-    pub completion_tokens: i32,
+    pub prompt_tokens: u32,
+    pub completion_tokens: u32,
 }
 
 impl Default for StreamIndexState {

--- a/grpc_client/proto/sglang_scheduler.proto
+++ b/grpc_client/proto/sglang_scheduler.proto
@@ -175,9 +175,9 @@ message GenerateStreamChunk {
   repeated uint32 token_ids = 1;
 
   // Cumulative counts
-  int32 prompt_tokens = 2;
-  int32 completion_tokens = 3;
-  int32 cached_tokens = 4;
+  uint32 prompt_tokens = 2;
+  uint32 completion_tokens = 3;
+  uint32 cached_tokens = 4;
 
   // Output logprobs (if requested) - incremental for streaming
   OutputLogProbs output_logprobs = 5;
@@ -200,9 +200,9 @@ message GenerateComplete {
   string finish_reason = 2;
 
   // Token usage counts
-  int32 prompt_tokens = 3;
-  int32 completion_tokens = 4;
-  int32 cached_tokens = 5;
+  uint32 prompt_tokens = 3;
+  uint32 completion_tokens = 4;
+  uint32 cached_tokens = 5;
 
   // Output logprobs if requested (cumulative)
   OutputLogProbs output_logprobs = 6;
@@ -304,11 +304,11 @@ message EmbedResponse {
 
 message EmbedComplete {
   repeated float embedding = 1;
-  int32 prompt_tokens = 2;
-  int32 cached_tokens = 3;
+  uint32 prompt_tokens = 2;
+  uint32 cached_tokens = 3;
 
   // Additional metadata
-  int32 embedding_dim = 4;
+  uint32 embedding_dim = 4;
 
   // For batch embeddings
   repeated Embedding batch_embeddings = 5;

--- a/grpc_client/proto/trtllm_service.proto
+++ b/grpc_client/proto/trtllm_service.proto
@@ -359,12 +359,12 @@ message GenerateStreamChunk {
   repeated uint32 token_ids = 1;
 
   // Beam/sequence index (for beam_width > 1 or n > 1)
-  int32 sequence_index = 2;
+  uint32 sequence_index = 2;
 
   // Token counts for usage tracking
-  int32 prompt_tokens = 3;
-  int32 completion_tokens = 4;
-  int32 cached_tokens = 5;
+  uint32 prompt_tokens = 3;
+  uint32 completion_tokens = 4;
+  uint32 cached_tokens = 5;
 
   // Log probabilities for this chunk's tokens (if requested)
   repeated TokenLogprob logprobs = 6;
@@ -376,7 +376,7 @@ message GenerateComplete {
   repeated uint32 output_token_ids = 1;
 
   // Beam/sequence index
-  int32 sequence_index = 2;
+  uint32 sequence_index = 2;
 
   // Finish reason: "stop", "length", "stop_word"
   string finish_reason = 3;
@@ -385,9 +385,9 @@ message GenerateComplete {
   optional string stop_reason = 4;
 
   // Token counts for usage tracking
-  int32 prompt_tokens = 5;
-  int32 completion_tokens = 6;
-  int32 cached_tokens = 7;
+  uint32 prompt_tokens = 5;
+  uint32 completion_tokens = 6;
+  uint32 cached_tokens = 7;
 
   // Generation log probabilities (if requested)
   repeated TokenLogprob logprobs = 8;
@@ -449,7 +449,7 @@ message EmbedRequest {
 message EmbedResponse {
   string request_id = 1;
   repeated float embedding = 2;  // Embedding vector
-  int32 prompt_tokens = 3;
+  uint32 prompt_tokens = 3;
 }
 
 // ============================================================================

--- a/model_gateway/src/routers/grpc/common/response_formatting.rs
+++ b/model_gateway/src/routers/grpc/common/response_formatting.rs
@@ -17,8 +17,8 @@ use crate::{protocols::common::Usage, routers::grpc::proto_wrapper::ProtoGenerat
 /// # Returns
 /// Usage object with aggregated token counts
 pub(crate) fn build_usage(responses: &[ProtoGenerateComplete]) -> Usage {
-    let total_prompt_tokens: u32 = responses.iter().map(|r| r.prompt_tokens() as u32).sum();
-    let total_completion_tokens: u32 = responses.iter().map(|r| r.completion_tokens() as u32).sum();
+    let total_prompt_tokens: u32 = responses.iter().map(|r| r.prompt_tokens()).sum();
+    let total_completion_tokens: u32 = responses.iter().map(|r| r.completion_tokens()).sum();
 
     Usage {
         prompt_tokens: total_prompt_tokens,

--- a/model_gateway/src/routers/grpc/harmony/streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/streaming.rs
@@ -236,9 +236,9 @@ impl HarmonyStreamingProcessor {
                             }
                         }),
                     );
-                    prompt_tokens.insert(index, complete_wrapper.prompt_tokens() as u32);
+                    prompt_tokens.insert(index, complete_wrapper.prompt_tokens());
                     *completion_tokens.entry(index).or_insert(0) =
-                        complete_wrapper.completion_tokens() as u32;
+                        complete_wrapper.completion_tokens();
 
                     // Finalize parser and emit final chunk
                     if let Some(parser) = parsers.get_mut(&index) {
@@ -319,10 +319,7 @@ impl HarmonyStreamingProcessor {
             let response = result.map_err(|e| format!("Prefill stream error: {}", e))?;
 
             if let ProtoResponseVariant::Complete(complete_wrapper) = response.into_response() {
-                prompt_tokens.insert(
-                    complete_wrapper.index(),
-                    complete_wrapper.prompt_tokens() as u32,
-                );
+                prompt_tokens.insert(complete_wrapper.index(), complete_wrapper.prompt_tokens());
             }
         }
 
@@ -411,7 +408,7 @@ impl HarmonyStreamingProcessor {
                         }),
                     );
                     *completion_tokens.entry(index).or_insert(0) =
-                        complete_wrapper.completion_tokens() as u32;
+                        complete_wrapper.completion_tokens();
 
                     if let Some(parser) = parsers.get_mut(&index) {
                         let matched_stop = matched_stops.get(&index).and_then(|m| m.clone());
@@ -949,8 +946,8 @@ impl HarmonyStreamingProcessor {
                             json!(s)
                         }
                     });
-                    prompt_tokens = complete_wrapper.prompt_tokens() as u32;
-                    completion_tokens = complete_wrapper.completion_tokens() as u32;
+                    prompt_tokens = complete_wrapper.prompt_tokens();
+                    completion_tokens = complete_wrapper.completion_tokens();
 
                     // Finalize parser and get complete output
                     let final_output = parser

--- a/model_gateway/src/routers/grpc/proto_wrapper.rs
+++ b/model_gateway/src/routers/grpc/proto_wrapper.rs
@@ -306,7 +306,7 @@ impl ProtoGenerateStreamChunk {
         match self {
             Self::Sglang(c) => c.index,
             Self::Vllm(c) => c.index,
-            Self::Trtllm(c) => c.sequence_index as u32,
+            Self::Trtllm(c) => c.sequence_index,
         }
     }
 
@@ -363,28 +363,28 @@ impl ProtoGenerateStreamChunk {
     }
 
     /// Get prompt tokens (cumulative)
-    pub fn prompt_tokens(&self) -> i32 {
+    pub fn prompt_tokens(&self) -> u32 {
         match self {
             Self::Sglang(c) => c.prompt_tokens,
-            Self::Vllm(c) => c.prompt_tokens as i32,
+            Self::Vllm(c) => c.prompt_tokens,
             Self::Trtllm(c) => c.prompt_tokens,
         }
     }
 
     /// Get completion tokens (cumulative)
-    pub fn completion_tokens(&self) -> i32 {
+    pub fn completion_tokens(&self) -> u32 {
         match self {
             Self::Sglang(c) => c.completion_tokens,
-            Self::Vllm(c) => c.completion_tokens as i32,
+            Self::Vllm(c) => c.completion_tokens,
             Self::Trtllm(c) => c.completion_tokens,
         }
     }
 
     /// Get cached tokens (cumulative)
-    pub fn cached_tokens(&self) -> i32 {
+    pub fn cached_tokens(&self) -> u32 {
         match self {
             Self::Sglang(c) => c.cached_tokens,
-            Self::Vllm(c) => c.cached_tokens as i32,
+            Self::Vllm(c) => c.cached_tokens,
             Self::Trtllm(c) => c.cached_tokens,
         }
     }
@@ -456,19 +456,19 @@ impl ProtoGenerateComplete {
     }
 
     /// Get prompt tokens
-    pub fn prompt_tokens(&self) -> i32 {
+    pub fn prompt_tokens(&self) -> u32 {
         match self {
             Self::Sglang(c) => c.prompt_tokens,
-            Self::Vllm(c) => c.prompt_tokens as i32,
+            Self::Vllm(c) => c.prompt_tokens,
             Self::Trtllm(c) => c.prompt_tokens,
         }
     }
 
     /// Get completion tokens
-    pub fn completion_tokens(&self) -> i32 {
+    pub fn completion_tokens(&self) -> u32 {
         match self {
             Self::Sglang(c) => c.completion_tokens,
-            Self::Vllm(c) => c.completion_tokens as i32,
+            Self::Vllm(c) => c.completion_tokens,
             Self::Trtllm(c) => c.completion_tokens,
         }
     }
@@ -488,7 +488,7 @@ impl ProtoGenerateComplete {
         match self {
             Self::Sglang(c) => c.index,
             Self::Vllm(c) => c.index,
-            Self::Trtllm(c) => c.sequence_index as u32,
+            Self::Trtllm(c) => c.sequence_index,
         }
     }
 
@@ -511,10 +511,10 @@ impl ProtoGenerateComplete {
     }
 
     /// Get cached tokens
-    pub fn cached_tokens(&self) -> i32 {
+    pub fn cached_tokens(&self) -> u32 {
         match self {
             Self::Sglang(c) => c.cached_tokens,
-            Self::Vllm(c) => c.cached_tokens as i32,
+            Self::Vllm(c) => c.cached_tokens,
             Self::Trtllm(c) => c.cached_tokens,
         }
     }
@@ -771,21 +771,21 @@ impl ProtoEmbedComplete {
     }
 
     /// Get prompt tokens
-    pub fn prompt_tokens(&self) -> i32 {
+    pub fn prompt_tokens(&self) -> u32 {
         match self {
             Self::Sglang(c) => c.prompt_tokens,
         }
     }
 
     /// Get cached tokens
-    pub fn cached_tokens(&self) -> i32 {
+    pub fn cached_tokens(&self) -> u32 {
         match self {
             Self::Sglang(c) => c.cached_tokens,
         }
     }
 
     /// Get embedding dimension
-    pub fn embedding_dim(&self) -> i32 {
+    pub fn embedding_dim(&self) -> u32 {
         match self {
             Self::Sglang(c) => c.embedding_dim,
         }

--- a/model_gateway/src/routers/grpc/regular/processor.rs
+++ b/model_gateway/src/routers/grpc/regular/processor.rs
@@ -442,15 +442,15 @@ impl ResponseProcessor {
             let meta_info = GenerateMetaInfo {
                 id: dispatch.request_id.clone(),
                 finish_reason,
-                prompt_tokens: complete.prompt_tokens() as u32,
+                prompt_tokens: complete.prompt_tokens(),
                 weight_version: dispatch
                     .weight_version
                     .clone()
                     .unwrap_or_else(|| "default".to_string()),
                 input_token_logprobs,
                 output_token_logprobs,
-                completion_tokens: complete.completion_tokens() as u32,
-                cached_tokens: complete.cached_tokens() as u32,
+                completion_tokens: complete.completion_tokens(),
+                cached_tokens: complete.cached_tokens(),
                 e2e_latency: start_time.elapsed().as_secs_f64(),
                 matched_stop,
             };

--- a/model_gateway/src/routers/grpc/regular/stages/classify/response_processing.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/classify/response_processing.rs
@@ -184,7 +184,7 @@ impl PipelineStage for ClassifyResponseProcessingStage {
         })?;
 
         // Build usage info
-        let prompt_tokens = proto_response.prompt_tokens().max(0) as u32;
+        let prompt_tokens = proto_response.prompt_tokens();
         let usage = UsageInfo {
             prompt_tokens,
             total_tokens: prompt_tokens,

--- a/model_gateway/src/routers/grpc/regular/stages/embedding/response_processing.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/embedding/response_processing.rs
@@ -98,8 +98,7 @@ impl EmbeddingResponseProcessingStage {
             index: 0,
         };
 
-        // Casting i32 to u32 for usage stats
-        let prompt_tokens = proto.prompt_tokens().max(0) as u32;
+        let prompt_tokens = proto.prompt_tokens();
 
         let usage = crate::protocols::common::UsageInfo {
             prompt_tokens,

--- a/model_gateway/src/routers/grpc/regular/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/streaming.rs
@@ -471,17 +471,17 @@ impl StreamingProcessor {
                     }
 
                     // Store metadata
-                    prompt_tokens.insert(index, complete.prompt_tokens() as u32);
+                    prompt_tokens.insert(index, complete.prompt_tokens());
 
                     // For vLLM, use accumulated count (we tracked deltas)
                     // For SGLang, use complete value (already cumulative)
                     if complete.is_vllm() {
                         completion_tokens.entry(index).or_insert(0);
                     } else {
-                        completion_tokens.insert(index, complete.completion_tokens() as u32);
+                        completion_tokens.insert(index, complete.completion_tokens());
                     }
 
-                    cached_tokens.insert(index, complete.cached_tokens() as u32);
+                    cached_tokens.insert(index, complete.cached_tokens());
                     finish_reasons.insert(index, complete.finish_reason().to_string());
 
                     // Extract matched_stop

--- a/model_gateway/src/routers/grpc/utils.rs
+++ b/model_gateway/src/routers/grpc/utils.rs
@@ -992,7 +992,7 @@ pub(crate) fn convert_generate_input_logprobs(
 /// For backward compatibility, also handles simple string "stop" -> Stop
 pub(crate) fn parse_finish_reason(
     reason_str: &str,
-    completion_tokens: i32,
+    completion_tokens: u32,
 ) -> GenerateFinishReason {
     if reason_str == "stop" {
         return GenerateFinishReason::Stop;
@@ -1000,7 +1000,7 @@ pub(crate) fn parse_finish_reason(
 
     if reason_str == "length" {
         return GenerateFinishReason::Length {
-            length: completion_tokens.max(0) as u32,
+            length: completion_tokens,
         };
     }
 


### PR DESCRIPTION
## Description

### Problem

Token count fields (prompt_tokens, completion_tokens, cached_tokens, sequence_index) use inconsistent types across different proto files - some use int32, others use uint32. Token counts are inherently non-negative values.

### Solution

Standardize all token count fields to uint32 across SGLang and TensorRT-LLM protos (vLLM already uses uint32).

## Changes

- **grpc_client/proto/sglang_scheduler.proto**: Change prompt_tokens, completion_tokens, cached_tokens, embedding_dim from int32 to uint32
- **grpc_client/proto/trtllm_service.proto**: Change sequence_index, prompt_tokens, completion_tokens, cached_tokens from int32 to uint32
- **model_gateway/src/routers/grpc/proto_wrapper.rs**: Update return types from i32 to u32
- **bindings/golang/**: Update types to match proto changes
- Remove unnecessary type casts throughout the codebase

## Test Plan

- Verify token counts are correctly reported in API responses
- Test with all three backends (SGLang, vLLM, TensorRT-LLM)

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>