### PR TITLE
fix(ci): add apt-get update before SGLang dependency install

### DIFF
--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -415,6 +415,7 @@ jobs:
 
       - name: Install SGLang dependencies
         run: |
+          sudo apt-get update
           cd sglang
           sudo --preserve-env=PATH bash scripts/ci/cuda/ci_install_dependency.sh
 


### PR DESCRIPTION
## Summary
- Adds `sudo apt-get update` before the SGLang dependency install step in the `go-bindings-benchmark` CI job
- The job was failing because `apt install` couldn't locate packages (`libnuma-dev`, `libssl-dev`, etc.) due to stale package lists
- Other CI steps that install SGLang dependencies work because they run `apt-get update` first

## Test plan
- [ ] Verify `go-bindings-benchmark` job passes in CI