### PR TITLE
docs(README): resolve broken doc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,13 +83,13 @@ That's it. SMG is now load-balancing requests across your workers.
 
 | Feature | Description |
 |---------|-------------|
-| **[8 Routing Policies](docs/configuration/routing.md)** | cache_aware, round_robin, power_of_two, consistent_hashing, prefix_hash, manual, random, bucket |
-| **[gRPC Pipeline](docs/configuration/grpc-pipeline.md)** | Native gRPC with streaming, reasoning extraction, and tool call parsing |
-| **[MCP Integration](docs/configuration/mcp.md)** | Connect external tool servers via Model Context Protocol |
-| **[High Availability](docs/configuration/high-availability.md)** | Mesh networking with SWIM protocol for multi-node deployments |
-| **[Chat History](docs/configuration/storage.md)** | Pluggable storage: PostgreSQL, Oracle, Redis, or in-memory |
-| **[WASM Plugins](docs/configuration/wasm-plugins.md)** | Extend with custom WebAssembly logic |
-| **[Resilience](docs/configuration/resilience.md)** | Circuit breakers, retries with backoff, rate limiting |
+| **[8 Routing Policies](docs/concepts/routing/load-balancing.md)** | cache_aware, round_robin, power_of_two, consistent_hashing, prefix_hash, manual, random, bucket |
+| **[gRPC Pipeline](docs/concepts/architecture/grpc-pipeline.md)** | Native gRPC with streaming, reasoning extraction, and tool call parsing |
+| **[MCP Integration](docs/concepts/extensibility/mcp.md)** | Connect external tool servers via Model Context Protocol |
+| **[High Availability](docs/concepts/architecture/high-availability.md)** | Mesh networking with SWIM protocol for multi-node deployments |
+| **[Chat History](docs/concepts/data/chat-history.md)** | Pluggable storage: PostgreSQL, Oracle, Redis, or in-memory |
+| **[WASM Plugins](docs/concepts/extensibility/wasm-plugins.md)** | Extend with custom WebAssembly logic |
+| **[Resilience](docs/concepts/reliability/index.md)** | Circuit breakers, retries with backoff, rate limiting |
 
 ## Documentation
 

--- a/docs/concepts/reliability/index.md
+++ b/docs/concepts/reliability/index.md
@@ -1,0 +1,11 @@
+# Reliability & Resilience
+
+SMG provides several mechanisms to ensure high availability and stability.
+
+## Core Mechanisms
+
+*   **[Circuit Breakers](./circuit-breakers.md)**: Automatically detect failing workers and temporarily stop sending traffic to them until they recover.
+*   **[Retries & Backoff](./retries.md)**: Configurable retry logic with exponential backoff to handle transient network issues or worker busy states.
+*   **[Rate Limiting](./rate-limiting.md)**: Protect your workers from being overwhelmed by controlling the concurrency and request rate.
+*   **[Health Checks](./health-checks.md)**: Active and passive monitoring of worker health to remove unhealthy nodes from the rotation.
+*   **[Graceful Shutdown](./graceful-shutdown.md)**: Ensure in-flight requests complete before the server stops.


### PR DESCRIPTION
## Description

### Problem
This PR fixes broken documentation links in the README. 


The `Reliability` section lacked a single landing page to jump to. I added `index.md` so the directory links work correctly.
Please let me know if this is an overkill.


<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>
