### PR TITLE
fix(ci): use standard install scripts for go-bindings-benchmark

### DIFF
--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -410,14 +410,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Clone SGLang repository
-        run: git clone https://github.com/sgl-project/sglang.git
-
-      - name: Install SGLang dependencies
+      - name: Install inference backend
         run: |
-          sudo apt-get update
-          cd sglang
-          sudo --preserve-env=PATH bash scripts/ci/cuda/ci_install_dependency.sh
+          bash scripts/ci_setup_python_venv.sh
+          source .venv/bin/activate
+          bash scripts/ci_install_sglang.sh
 
       - name: Setup Go
         uses: actions/setup-go@v5


### PR DESCRIPTION
## Summary
- Replace inline SGLang clone + manual dependency install in the `go-bindings-benchmark` job with the project's standard CI scripts
- Uses `ci_setup_python_venv.sh` for venv setup and `ci_install_sglang.sh` for cloning + installing SGLang dependencies
- These scripts already handle `apt update`, CUDA env vars, and the full install flow — matching how other CI jobs install inference backends

## Test plan
- [ ] Verify `go-bindings-benchmark` job passes in CI