### PR TITLE
fix(ci): speed up chat-completions CI jobs

### DIFF
--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -183,19 +183,19 @@ jobs:
           - name: chat-completions-sglang
             timeout: 45
             test_dirs: "e2e_test/chat_completions"
-            extra_deps: ""
+            extra_deps: "pytest-parallel py"
             env_vars: "E2E_RUNTIME=sglang SHOW_WORKER_LOGS=0 SHOW_ROUTER_LOGS=1"
             reruns: "--reruns 2 --reruns-delay 5"
-            parallel_opts: ""
+            parallel_opts: "--workers 1 --tests-per-worker 4"
             test_filter: ""
             ignore_opts: ""
           - name: chat-completions-vllm
             timeout: 45
             test_dirs: "e2e_test/chat_completions"
-            extra_deps: ""
+            extra_deps: "pytest-parallel py"
             env_vars: "E2E_RUNTIME=vllm SHOW_WORKER_LOGS=0 SHOW_ROUTER_LOGS=1"
             reruns: "--reruns 2 --reruns-delay 5"
-            parallel_opts: ""
+            parallel_opts: "--workers 1 --tests-per-worker 4"
             # TODO: Remove filter when vLLM supports logprobs and n>1 with greedy sampling
             # Excludes: 5-grpc (logprobs=5), 2-None-grpc (n=2 with no logprobs), multiple_choices (n=2 tests)
             test_filter: "-k 'not (5-grpc or 2-None-grpc or multiple_choices)'"
@@ -212,7 +212,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/pip/wheels
-          key: flash-attn-${{ runner.os }}-py310-${{ hashFiles('**/setup.py') }}
+          key: flash-attn-${{ runner.os }}-py310-${{ hashFiles('scripts/ci_install_vllm.sh') }}
 
       - name: Install inference backend
         run: |

--- a/scripts/ci_install_sglang.sh
+++ b/scripts/ci_install_sglang.sh
@@ -14,7 +14,7 @@ SGLANG_DIR="${1:-sglang}"
 # Clone SGLang if not already present
 if [ ! -d "$SGLANG_DIR" ]; then
     echo "Cloning SGLang repository..."
-    git clone https://github.com/sgl-project/sglang.git "$SGLANG_DIR"
+    git clone --depth 1 https://github.com/sgl-project/sglang.git "$SGLANG_DIR"
 fi
 
 # Install SGLang dependencies

--- a/scripts/ci_killall_sglang.sh
+++ b/scripts/ci_killall_sglang.sh
@@ -15,13 +15,15 @@ else
 
     # Clean all GPU processes if any argument is provided
     if [ $# -gt 0 ]; then
-        # Check if sudo is available
-        if command -v sudo >/dev/null 2>&1; then
-            sudo apt-get update
-            sudo apt-get install -y lsof
-        else
-            apt-get update
-            apt-get install -y lsof
+        # Install lsof if not already available
+        if ! command -v lsof >/dev/null 2>&1; then
+            if command -v sudo >/dev/null 2>&1; then
+                sudo apt-get update
+                sudo apt-get install -y lsof
+            else
+                apt-get update
+                apt-get install -y lsof
+            fi
         fi
         kill -9 $(nvidia-smi | sed -n '/Processes:/,$p' | grep "   [0-9]" | awk '{print $5}') 2>/dev/null
         lsof /dev/nvidia* | awk '{print $2}' | xargs kill -9 2>/dev/null


### PR DESCRIPTION
## Description

### Problem

<!-- What problem is this PR trying to solve? -->

### Solution

<!-- How does this PR solve the problem? -->

## Changes

<!-- - Describe your changes here. -->

- Enable pytest-parallel for chat-completions-sglang and chat-completions-vllm jobs (thread-based, --workers 1 --tests-per-worker 4)
- Guard lsof install behind command -v check to skip apt-get update when already installed
- Use shallow clone (--depth 1) for sglang repo
- Fix flash-attn cache key to hash ci_install_vllm.sh instead of unrelated setup.py files

## Test Plan

<!-- Provide a thorough reproducible test showing before and after behavior. -->

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>
