### PR TITLE
fix(kv-index): prevent synthetic "empty" tenant from polluting tree

### DIFF
--- a/kv_index/src/string_tree.rs
+++ b/kv_index/src/string_tree.rs
@@ -629,8 +629,10 @@ impl Tree {
 
         // Update timestamp probabilistically (1 in 8 matches) to reduce DashMap contention.
         // LRU eviction doesn't need perfect accuracy - approximate timestamps suffice.
+        // Skip the update for the synthetic "empty" tenant to avoid polluting the tree
+        // with a tenant that was never inserted via insert_text.
         let epoch = get_epoch();
-        if epoch & 0x7 == 0 {
+        if epoch & 0x7 == 0 && tenant.as_ref() != "empty" {
             curr.tenant_last_access_time
                 .insert(Arc::clone(&tenant), epoch);
         }


### PR DESCRIPTION
## Summary

- Fix flaky `test_tree_structure_integrity_after_stress` test in `kv_index/src/string_tree.rs`
- `match_prefix_with_counts` creates a synthetic `"empty"` tenant when a node has no tenants in `tenant_last_access_time`. The probabilistic timestamp update (line 633) was inserting this fake tenant back into the tree's `tenant_last_access_time`, causing `get_used_size_per_tenant` to find `"empty"` on nodes with 0 char count
- Skip the timestamp update for the `"empty"` sentinel so it never gets written into `tenant_last_access_time`

## Test plan

- [x] Ran the flaky test 50 times with 0 failures (was previously failing intermittently)
- [x] Full `kv-index` test suite passes (95/95)
