### PR TITLE
fix(ci): migrate benchmark-radix-tree to k8s gpu runner

### DIFF
--- a/.github/workflows/benchmark-radix-tree.yml
+++ b/.github/workflows/benchmark-radix-tree.yml
@@ -48,7 +48,7 @@ jobs:
       needs.check-ci.outputs.should_run == 'true' &&
       (github.event_name != 'pull_request' ||
        contains(github.event.pull_request.labels.*.name, 'router-benchmark'))
-    runs-on: 4-gpu-a10
+    runs-on: k8s-runner-gpu
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary
- Switch `benchmark-radix-tree` workflow from `4-gpu-a10` to `k8s-runner-gpu`
- This was the last remaining workflow using the legacy a10 runner
- All GPU workflows now consistently use k8s-based infrastructure

## Test plan
- [ ] Verify benchmark-radix-tree workflow triggers and runs on k8s-runner-gpu