### PR TITLE
feat(vllm-pd): add Mooncake KV transfer support with auto-discovery

### DIFF
--- a/bindings/golang/src/policy.rs
+++ b/bindings/golang/src/policy.rs
@@ -67,6 +67,8 @@ impl GrpcWorker {
             api_key: None,
             bootstrap_host: String::new(),
             bootstrap_port: None,
+            kv_connector: None,
+            kv_role: None,
             models: Vec::new(),
             default_provider: None,
             default_model_type: smg::core::model_type::ModelType::LLM,

--- a/docs/concepts/routing/pd-disaggregation.md
+++ b/docs/concepts/routing/pd-disaggregation.md
@@ -74,7 +74,16 @@ SMG supports PD disaggregation with two inference backends:
 | Runtime | Protocol | Dispatch | KV Transfer | Best For |
 |---------|----------|----------|-------------|----------|
 | **SGLang** | HTTP | Parallel | Bootstrap-based coordination | Production deployments with SGLang |
-| **vLLM** | gRPC | Sequential | NIXL (RDMA-based) | High-performance with RDMA networking |
+| **vLLM** | gRPC | Sequential | NIXL or Mooncake | High-performance with RDMA/TCP networking |
+
+### vLLM KV Transfer Backends
+
+vLLM supports two backends for KV cache transfer:
+
+| Backend | Transport | Configuration | Best For |
+|---------|-----------|---------------|----------|
+| **NIXL** | RDMA | `VLLM_NIXL_SIDE_CHANNEL_PORT` env var | High-bandwidth RDMA networks |
+| **Mooncake** | TCP/RDMA | `MOONCAKE_MASTER` env var or config file | Flexible deployment, TCP fallback |
 
 ---
 
@@ -132,7 +141,7 @@ sequenceDiagram
     P-->>S: Prefill complete (discarded)
 
     S->>D: Forward original request
-    Note over P,D: NIXL auto-discovers KV cache
+    Note over P,D: NIXL/Mooncake auto-discovers KV cache
 
     loop Token generation
         D->>D: Generate token
@@ -144,12 +153,12 @@ sequenceDiagram
     S-->>C: Final response
 ```
 
-vLLM uses **sequential dispatch** with NIXL KV transfer:
+vLLM uses **sequential dispatch** with NIXL or Mooncake KV transfer:
 
 1. SMG sends request to prefill worker with `max_tokens=1`
 2. Prefill computes KV cache and returns (response discarded)
 3. SMG sends original request to decode worker
-4. NIXL transparently transfers KV cache via RDMA
+4. KV backend (NIXL/Mooncake) transparently transfers KV cache
 5. Decode streams tokens back to client
 
 ### Request Flow
@@ -180,7 +189,7 @@ smg \
 
 ### vLLM PD Setup
 
-vLLM workers use gRPC and NIXL for KV transfer (no bootstrap port needed):
+vLLM workers use gRPC and NIXL/Mooncake for KV transfer (no bootstrap port needed):
 
 ```bash
 smg \
@@ -188,8 +197,12 @@ smg \
   --prefill grpc://prefill1:50051 \
   --prefill grpc://prefill2:50052 \
   --decode grpc://decode1:50053 \
-  --decode grpc://decode2:50054
+  --decode grpc://decode2:50054 \
+  --model-path /path/to/model
 ```
+
+!!! note "Model Path Required"
+    The `--model-path` parameter is required for vLLM PD mode to load the tokenizer for request processing.
 
 ### Parameters
 
@@ -328,11 +341,15 @@ The KV cache is transferred between workers using the backend's native mechanism
 | Backend | Transfer Method | Coordination |
 |---------|-----------------|--------------|
 | SGLang | NCCL/Gloo over network | Bootstrap metadata (host/port/room) |
-| vLLM | NIXL (RDMA-based) | Automatic prefix matching |
+| vLLM + NIXL | RDMA | Automatic prefix matching |
+| vLLM + Mooncake | TCP/RDMA | P2P handshake via master server |
 
 **SGLang**: SMG injects bootstrap metadata (`DisaggregatedParams`) into requests, enabling workers to coordinate KV transfer through a shared "room".
 
-**vLLM**: SMG uses the simple proxy pattern—sends `max_tokens=1` to prefill to trigger KV cache computation, then NIXL automatically discovers and transfers the cache to decode via RDMA prefix matching. No protocol changes required.
+**vLLM**: SMG uses the simple proxy pattern—sends `max_tokens=1` to prefill to trigger KV cache computation, then the KV backend (NIXL or Mooncake) automatically discovers and transfers the cache to decode. No protocol changes required.
+
+- **NIXL**: Uses RDMA for high-bandwidth KV transfer with automatic prefix matching
+- **Mooncake**: Supports both TCP and RDMA, uses P2P handshake for coordination (no external metadata server required)
 
 ---
 
@@ -506,13 +523,37 @@ smg \
   --prefill grpc://prefill-1:50052 \
   --decode grpc://decode-0:50053 \
   --decode grpc://decode-1:50054 \
+  --model-path /path/to/model \
   --prefill-policy cache_aware \
   --decode-policy round_robin
 ```
 
+### vLLM PD (Static Workers with Mooncake)
+
+```bash
+smg \
+  --pd-disaggregation \
+  --prefill grpc://prefill-0:50051 8998 \
+  --prefill grpc://prefill-1:50052 8999 \
+  --decode grpc://decode-0:50053 \
+  --decode grpc://decode-1:50054 \
+  --model-path /path/to/model \
+  --prefill-policy cache_aware \
+  --decode-policy round_robin
+```
+
+Note: For Mooncake, each prefill worker needs a unique bootstrap port (8998, 8999, etc.) passed to SMG.
+
+Workers should be started with Mooncake configuration:
+
+```bash
+# Launch workers using helper script (auto-assigns unique bootstrap ports)
+KV_BACKEND=mooncake ./scripts/launch-pd-workers.sh vllm /path/to/model
+```
+
 ### Launching vLLM PD Workers
 
-vLLM workers require NIXL configuration for KV transfer:
+#### Option 1: NIXL Backend (RDMA)
 
 ```bash
 # Prefill worker (kv_producer)
@@ -530,10 +571,54 @@ python -m vllm.entrypoints.grpc_server \
   --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_consumer"}'
 ```
 
-Or use the provided helper script:
+#### Option 2: Mooncake Backend (TCP/RDMA)
+
+Mooncake requires each prefill worker to have a unique bootstrap port for P2P coordination:
 
 ```bash
+# Prefill worker 1 (kv_producer) - bootstrap port 8998
+VLLM_MOONCAKE_BOOTSTRAP_PORT=8998 \
+python -m vllm.entrypoints.grpc_server \
+  --model /path/to/model \
+  --port 50051 \
+  --kv-transfer-config '{"kv_connector":"MooncakeConnector","kv_role":"kv_producer"}'
+
+# Prefill worker 2 (kv_producer) - bootstrap port 8999 (must be unique!)
+VLLM_MOONCAKE_BOOTSTRAP_PORT=8999 \
+python -m vllm.entrypoints.grpc_server \
+  --model /path/to/model \
+  --port 50052 \
+  --kv-transfer-config '{"kv_connector":"MooncakeConnector","kv_role":"kv_producer"}'
+
+# Decode worker (kv_consumer) - no bootstrap port needed
+python -m vllm.entrypoints.grpc_server \
+  --model /path/to/model \
+  --port 50053 \
+  --kv-transfer-config '{"kv_connector":"MooncakeConnector","kv_role":"kv_consumer"}'
+```
+
+Mooncake environment variables:
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `VLLM_MOONCAKE_BOOTSTRAP_PORT` | Bootstrap port for prefill workers (must be unique per worker) | Required for prefill |
+| `MOONCAKE_PROTOCOL` | Transport protocol: `tcp` or `rdma` | `tcp` |
+| `MOONCAKE_DEVICE` | RDMA device name (for RDMA protocol) | `""` |
+
+#### Helper Script
+
+Use the provided helper script to launch workers with either backend:
+
+```bash
+# NIXL backend (default)
 ./scripts/launch-pd-workers.sh vllm /path/to/model
+
+# Mooncake backend
+KV_BACKEND=mooncake ./scripts/launch-pd-workers.sh vllm /path/to/model
+
+# Mooncake with custom bootstrap port
+KV_BACKEND=mooncake MOONCAKE_BOOTSTRAP_PORT=9000 \
+  ./scripts/launch-pd-workers.sh vllm /path/to/model
 ```
 
 ---

--- a/grpc_client/proto/vllm_engine.proto
+++ b/grpc_client/proto/vllm_engine.proto
@@ -101,6 +101,16 @@ message GenerateRequest {
 
   // Streaming
   bool stream = 5;
+
+  // KV transfer parameters for PD disaggregation (Mooncake)
+  // Decode worker uses this to fetch KV cache from prefill worker
+  KvTransferParams kv_transfer_params = 6;
+}
+
+// KV cache transfer parameters for Mooncake PD disaggregation
+message KvTransferParams {
+  string remote_host = 1;  // Prefill worker's side-channel host
+  uint32 remote_port = 2;  // Prefill worker's side-channel port
 }
 
 // =====================
@@ -169,6 +179,10 @@ message GenerateComplete {
 
   // Index for n>1 support (0-indexed, identifies which of n outputs this belongs to)
   uint32 index = 8;
+
+  // KV transfer parameters returned by prefill worker (Mooncake PD)
+  // Contains prefill's side-channel address for decode to fetch KV cache
+  KvTransferParams kv_transfer_params = 9;
 }
 
 // =====================
@@ -226,4 +240,8 @@ message GetServerInfoResponse {
   double last_receive_timestamp = 3;
   double uptime_seconds = 4;
   string server_type = 5;  // "vllm-grpc"
+
+  // KV transfer config (for PD disaggregation)
+  string kv_connector = 6;  // "MooncakeConnector", "NixlConnector", "" if not configured
+  string kv_role = 7;       // "kv_producer", "kv_consumer", "kv_both", "" if not configured
 }

--- a/grpc_client/src/vllm_engine.rs
+++ b/grpc_client/src/vllm_engine.rs
@@ -278,6 +278,7 @@ impl VllmEngineClient {
             )),
             sampling_params: Some(sampling_params),
             stream: body.stream,
+            kv_transfer_params: None,
         };
 
         Ok(grpc_request)
@@ -304,6 +305,7 @@ impl VllmEngineClient {
             )),
             sampling_params: Some(sampling_params),
             stream: body.stream,
+            kv_transfer_params: None,
         };
 
         Ok(grpc_request)
@@ -341,6 +343,7 @@ impl VllmEngineClient {
             )),
             sampling_params: Some(sampling_params),
             stream: body.stream.unwrap_or(false),
+            kv_transfer_params: None,
         };
 
         Ok(grpc_request)
@@ -661,6 +664,7 @@ mod tests {
             )),
             sampling_params: Some(sampling_params),
             stream: false,
+            kv_transfer_params: None,
         };
 
         assert_eq!(gen_req.request_id, "test-req-123");

--- a/model_gateway/src/core/mod.rs
+++ b/model_gateway/src/core/mod.rs
@@ -35,7 +35,7 @@ pub use model_card::{ModelCard, ProviderType};
 pub use retry::{is_retryable_status, RetryExecutor};
 pub use worker::{
     AttachedBody, BasicWorker, ConnectionMode, HealthConfig, RuntimeType, Worker, WorkerLoadGuard,
-    WorkerType,
+    WorkerType, DEFAULT_BOOTSTRAP_PORT, MOONCAKE_CONNECTOR,
 };
 pub use worker_builder::{BasicWorkerBuilder, DPAwareWorkerBuilder};
 pub use worker_manager::{LoadMonitor, WorkerManager};

--- a/model_gateway/src/core/worker.rs
+++ b/model_gateway/src/core/worker.rs
@@ -32,6 +32,12 @@ pub const DEFAULT_WORKER_COST: f32 = 1.0;
 /// Default HTTP client timeout for worker requests (in seconds)
 pub const DEFAULT_WORKER_HTTP_TIMEOUT_SECS: u64 = 30;
 
+/// Default bootstrap port for PD disaggregation (used by SGLang and vLLM Mooncake)
+pub const DEFAULT_BOOTSTRAP_PORT: u16 = 8998;
+
+/// vLLM Mooncake KV connector name
+pub const MOONCAKE_CONNECTOR: &str = "MooncakeConnector";
+
 static WORKER_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
     reqwest::Client::builder()
         .timeout(Duration::from_secs(DEFAULT_WORKER_HTTP_TIMEOUT_SECS))
@@ -574,6 +580,10 @@ pub struct WorkerMetadata {
     pub bootstrap_host: String,
     /// Cached bootstrap port (from WorkerType::Prefill)
     pub bootstrap_port: Option<u16>,
+    /// KV connector type (e.g., "MooncakeConnector", "NixlConnector", empty if not configured)
+    pub kv_connector: Option<String>,
+    /// KV role (e.g., "kv_producer", "kv_consumer", "kv_both", empty if not configured)
+    pub kv_role: Option<String>,
     /// Models this worker can serve.
     /// If empty, worker accepts any model (backward compatible behavior).
     pub models: Vec<ModelCard>,
@@ -1957,6 +1967,8 @@ mod tests {
             api_key: None,
             bootstrap_host: "test".to_string(),
             bootstrap_port: None,
+            kv_connector: None,
+            kv_role: None,
             models: Vec::new(), // Empty = accepts any model
             default_provider: None,
             default_model_type: ModelType::LLM,
@@ -1987,6 +1999,8 @@ mod tests {
             api_key: None,
             bootstrap_host: "test".to_string(),
             bootstrap_port: None,
+            kv_connector: None,
+            kv_role: None,
             models: vec![model1, model2],
             default_provider: None,
             default_model_type: ModelType::LLM,

--- a/model_gateway/src/core/worker_builder.rs
+++ b/model_gateway/src/core/worker_builder.rs
@@ -23,6 +23,8 @@ pub struct BasicWorkerBuilder {
     health_config: HealthConfig,
     circuit_breaker_config: CircuitBreakerConfig,
     grpc_client: Option<GrpcClient>,
+    kv_connector: Option<String>,
+    kv_role: Option<String>,
 }
 
 impl BasicWorkerBuilder {
@@ -39,6 +41,8 @@ impl BasicWorkerBuilder {
             health_config: HealthConfig::default(),
             circuit_breaker_config: CircuitBreakerConfig::default(),
             grpc_client: None,
+            kv_connector: None,
+            kv_role: None,
         }
     }
 
@@ -55,6 +59,8 @@ impl BasicWorkerBuilder {
             health_config: HealthConfig::default(),
             circuit_breaker_config: CircuitBreakerConfig::default(),
             grpc_client: None,
+            kv_connector: None,
+            kv_role: None,
         }
     }
 
@@ -109,6 +115,18 @@ impl BasicWorkerBuilder {
     /// Set gRPC client for gRPC workers
     pub fn grpc_client(mut self, client: GrpcClient) -> Self {
         self.grpc_client = Some(client);
+        self
+    }
+
+    /// Set KV connector type (e.g., "MooncakeConnector", "NixlConnector")
+    pub fn kv_connector(mut self, connector: impl Into<String>) -> Self {
+        self.kv_connector = Some(connector.into());
+        self
+    }
+
+    /// Set KV role (e.g., "kv_producer", "kv_consumer", "kv_both")
+    pub fn kv_role(mut self, role: impl Into<String>) -> Self {
+        self.kv_role = Some(role.into());
         self
     }
 
@@ -171,6 +189,8 @@ impl BasicWorkerBuilder {
             health_config: self.health_config,
             bootstrap_host,
             bootstrap_port,
+            kv_connector: self.kv_connector,
+            kv_role: self.kv_role,
             models: self.models,                // Empty = accepts any model
             default_provider: None,             // Native/passthrough
             default_model_type: ModelType::LLM, // Standard LLM capabilities
@@ -222,6 +242,8 @@ pub struct DPAwareWorkerBuilder {
     health_config: HealthConfig,
     circuit_breaker_config: CircuitBreakerConfig,
     grpc_client: Option<GrpcClient>,
+    kv_connector: Option<String>,
+    kv_role: Option<String>,
 }
 
 impl DPAwareWorkerBuilder {
@@ -240,6 +262,8 @@ impl DPAwareWorkerBuilder {
             health_config: HealthConfig::default(),
             circuit_breaker_config: CircuitBreakerConfig::default(),
             grpc_client: None,
+            kv_connector: None,
+            kv_role: None,
         }
     }
 
@@ -263,6 +287,8 @@ impl DPAwareWorkerBuilder {
             health_config: HealthConfig::default(),
             circuit_breaker_config: CircuitBreakerConfig::default(),
             grpc_client: None,
+            kv_connector: None,
+            kv_role: None,
         }
     }
 
@@ -332,6 +358,18 @@ impl DPAwareWorkerBuilder {
         self
     }
 
+    /// Set the KV connector type (for PD disaggregation)
+    pub fn kv_connector(mut self, connector: impl Into<String>) -> Self {
+        self.kv_connector = Some(connector.into());
+        self
+    }
+
+    /// Set the KV role (for PD disaggregation)
+    pub fn kv_role(mut self, role: impl Into<String>) -> Self {
+        self.kv_role = Some(role.into());
+        self
+    }
+
     /// Build the DPAwareWorker instance
     pub fn build(self) -> DPAwareWorker {
         let worker_url = format!("{}@{}", self.base_url, self.dp_rank);
@@ -349,6 +387,12 @@ impl DPAwareWorkerBuilder {
         }
         if let Some(api_key) = self.api_key {
             builder = builder.api_key(api_key);
+        }
+        if let Some(kv_connector) = self.kv_connector {
+            builder = builder.kv_connector(kv_connector);
+        }
+        if let Some(kv_role) = self.kv_role {
+            builder = builder.kv_role(kv_role);
         }
 
         let base_worker = builder.build();


### PR DESCRIPTION
## Summary

Add support for vLLM PD disaggregation with Mooncake KV transfer, including automatic discovery of KV transfer configuration from vLLM's GetServerInfo RPC.

### Key Features

- **Auto-discovery**: Router automatically detects `kv_connector` (Mooncake vs NIXL) from vLLM server
- **Mooncake mode**: Injects `kv_transfer_params` (host/port) into decode request for KV cache transfer
- **NIXL mode**: Uses automatic prefix matching (no explicit params needed)
- **Backward compatible**: Falls back to NIXL if server doesn't report `kv_connector`

### Changes

**Proto** (`grpc_client/proto/vllm_engine.proto`):
- Add `KvTransferParams` message with `remote_host` and `remote_port`
- Add `kv_transfer_params` field to `GenerateRequest` and `GenerateComplete`
- Add `kv_connector` and `kv_role` fields to `GetServerInfoResponse`

**Worker Discovery** (`discover_metadata.rs`):
- Extract `kv_connector`/`kv_role` from GetServerInfo response

**Worker Creation** (`create_worker.rs`, `worker_builder.rs`):
- Store KV config in dedicated `WorkerMetadata` fields (not labels)
- Add builder methods for `kv_connector`/`kv_role`

**Request Execution** (`request_execution.rs`):
- Detect Mooncake via `kv_connector == "MooncakeConnector"`
- Inject `kv_transfer_params` into decode request for Mooncake mode
- Add informative logging for debugging

**Constants** (`worker.rs`, `mod.rs`):
- `DEFAULT_BOOTSTRAP_PORT = 8998`
- `MOONCAKE_CONNECTOR = "MooncakeConnector"`

## Testing

### 1P1D Setup

**Start vLLM workers:**
```bash
# Prefill
python -m vllm.entrypoints.grpc_server \
  --model meta-llama/Llama-3.1-8B-Instruct \
  --port 50051 \
  --kv-transfer-config '{"kv_connector":"MooncakeConnector","kv_role":"kv_producer"}'

# Decode
python -m vllm.entrypoints.grpc_server \
  --model meta-llama/Llama-3.1-8B-Instruct \
  --port 50052 \
  --kv-transfer-config '{"kv_connector":"MooncakeConnector","kv_role":"kv_consumer"}'
```

**Start SMG router:**
```bash
smg --port 8080 --pd-mode
```

**Register workers:**
```bash
curl -X POST http://localhost:8080/workers \
  -H "Content-Type: application/json" \
  -d '{"url": "localhost:50051", "worker_type": "prefill"}'

curl -X POST http://localhost:8080/workers \
  -H "Content-Type: application/json" \
  -d '{"url": "localhost:50052", "worker_type": "decode"}'
```

**Test request:**
```bash
curl -X POST http://localhost:8080/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "meta-llama/Llama-3.1-8B-Instruct",
    "messages": [{"role": "user", "content": "Hello!"}],
    "max_tokens": 100
  }'
```

### Expected Logs

For Mooncake mode:
```
vLLM PD (Mooncake): will inject kv_transfer_params into decode request
```

For NIXL mode:
```
vLLM PD (NIXL): using automatic prefix matching for KV transfer
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Mooncake as an alternative KV backend for vLLM prefix disaggregation, providing TCP/RDMA transport alongside existing NIXL support
  * Enhanced KV transfer configuration with improved connector and role metadata

* **Documentation**
  * Comprehensively expanded vLLM prefix disaggregation documentation with Mooncake backend configuration, deployment examples, and environment variable guidance
  * Added model-path requirements and bootstrap port configuration instructions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->