### PR TITLE
fix(logging): add --log-json to python cli

### DIFF
--- a/bindings/python/src/smg/router_args.py
+++ b/bindings/python/src/smg/router_args.py
@@ -43,6 +43,7 @@ class RouterArgs:
     api_key: Optional[str] = None
     log_dir: Optional[str] = None
     log_level: Optional[str] = None
+    log_json: bool = False
     # Service discovery configuration
     service_discovery: bool = False
     selector: Dict[str, str] = dataclasses.field(default_factory=dict)
@@ -382,6 +383,12 @@ class RouterArgs:
             default="info",
             choices=["debug", "info", "warn", "error"],
             help="Set the logging level. If not specified, defaults to INFO.",
+        )
+        logging_group.add_argument(
+            f"--{prefix}log-json",
+            action="store_true",
+            default=RouterArgs.log_json,
+            help="Output logs in JSON format",
         )
 
         # Service discovery configuration


### PR DESCRIPTION
## Description

### Problem

Python launch_router CLI rejects --log-json

### Solution

Add --log-json to the Python router CLI args with default of False

## Changes

- Register --log-json in RouterArgs.add_cli_args
- Add log_json field to RouterArgs

## Test Plan

<!-- Provide a thorough reproducible test showing before and after behavior. -->

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>
