### PR TITLE
feat(reasoning-parser): add CohereCmdParser for Command models

### DIFF
--- a/reasoning_parser/README.md
+++ b/reasoning_parser/README.md
@@ -51,6 +51,7 @@ async fn main() {
 | Kimi | `◁think▷`/`◁/think▷` | Unicode delimiters |
 | Step3 | `<think>`/`</think>` | Starts in reasoning mode |
 | MiniMax M2 | `<think>`/`</think>` | Auto-prepends start token |
+| Cohere Command | `<\|START_THINKING\|>`/`<\|END_THINKING\|>` | CMD3/CMD4 format |
 | Nemotron-Nano | `<think>`/`</think>` | Qwen3-compatible |
 
 Unknown models fall back to a passthrough parser that returns all text as normal output.
@@ -255,8 +256,9 @@ Pattern priority (first match wins):
 5. `kimi` → KimiParser
 6. `step3` → Step3Parser
 7. `minimax` / `mm-m2` → MiniMaxParser
-8. `nemotron-nano` / `nano-v3` → Qwen3Parser
-9. (fallback) → BaseReasoningParser (passthrough)
+8. `command-r` / `command-a` / `c4ai-command` / `cohere` → CohereCmdParser
+9. `nemotron-nano` / `nano-v3` → Qwen3Parser
+10. (fallback) → BaseReasoningParser (passthrough)
 
 ## Thread Safety
 

--- a/reasoning_parser/src/lib.rs
+++ b/reasoning_parser/src/lib.rs
@@ -4,7 +4,7 @@ pub mod traits;
 
 pub use factory::{ParserFactory, ParserRegistry, PooledParser};
 pub use parsers::{
-    BaseReasoningParser, DeepSeekR1Parser, Glm45Parser, KimiParser, MiniMaxParser, Qwen3Parser,
-    QwenThinkingParser, Step3Parser,
+    BaseReasoningParser, CohereCmdParser, DeepSeekR1Parser, Glm45Parser, KimiParser, MiniMaxParser,
+    Qwen3Parser, QwenThinkingParser, Step3Parser,
 };
 pub use traits::{ParseError, ParserConfig, ParserResult, ReasoningParser};

--- a/reasoning_parser/src/parsers/cohere_cmd.rs
+++ b/reasoning_parser/src/parsers/cohere_cmd.rs
@@ -1,0 +1,249 @@
+//! Cohere Command model reasoning parser.
+//!
+//! Parses thinking blocks from `<|START_THINKING|>...<|END_THINKING|>`.
+//! Supports CMD3 and CMD4 format.
+
+use crate::{
+    parsers::BaseReasoningParser,
+    traits::{ParseError, ParserConfig, ParserResult, ReasoningParser},
+};
+
+/// Cohere Command model reasoning parser.
+///
+/// Handles `<|START_THINKING|>` and `<|END_THINKING|>` tokens.
+/// Unlike DeepSeek-R1, Cohere requires explicit start token (initial_in_reasoning=false).
+pub struct CohereCmdParser {
+    base: BaseReasoningParser,
+}
+
+impl CohereCmdParser {
+    /// Create a new Cohere Command parser.
+    pub fn new() -> Self {
+        let config = ParserConfig {
+            think_start_token: "<|START_THINKING|>".to_string(),
+            think_end_token: "<|END_THINKING|>".to_string(),
+            stream_reasoning: true,
+            max_buffer_size: 65536,
+            initial_in_reasoning: false, // Requires explicit start token
+        };
+
+        Self {
+            base: BaseReasoningParser::new(config).with_model_type("cohere_cmd".to_string()),
+        }
+    }
+}
+
+impl Default for CohereCmdParser {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ReasoningParser for CohereCmdParser {
+    fn detect_and_parse_reasoning(&mut self, text: &str) -> Result<ParserResult, ParseError> {
+        self.base.detect_and_parse_reasoning(text)
+    }
+
+    fn parse_reasoning_streaming_incremental(
+        &mut self,
+        text: &str,
+    ) -> Result<ParserResult, ParseError> {
+        self.base.parse_reasoning_streaming_incremental(text)
+    }
+
+    fn reset(&mut self) {
+        self.base.reset()
+    }
+
+    fn model_type(&self) -> &str {
+        self.base.model_type()
+    }
+
+    fn is_in_reasoning(&self) -> bool {
+        self.base.is_in_reasoning()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cohere_cmd_no_reasoning() {
+        let mut parser = CohereCmdParser::new();
+
+        // Without thinking tags, text should be returned as normal
+        let result = parser
+            .detect_and_parse_reasoning("This is a normal response.")
+            .unwrap();
+        assert_eq!(result.normal_text, "This is a normal response.");
+        assert_eq!(result.reasoning_text, "");
+    }
+
+    #[test]
+    fn test_cohere_cmd_with_thinking() {
+        let mut parser = CohereCmdParser::new();
+
+        let result = parser
+            .detect_and_parse_reasoning(
+                "<|START_THINKING|>Let me analyze this step by step.<|END_THINKING|>The answer is 42.",
+            )
+            .unwrap();
+        assert_eq!(result.normal_text, "The answer is 42.");
+        assert_eq!(result.reasoning_text, "Let me analyze this step by step.");
+    }
+
+    #[test]
+    fn test_cohere_cmd_truncated_thinking() {
+        let mut parser = CohereCmdParser::new();
+
+        // Thinking block without end token (truncated)
+        let result = parser
+            .detect_and_parse_reasoning("<|START_THINKING|>Analyzing the problem...")
+            .unwrap();
+        assert_eq!(result.normal_text, "");
+        assert_eq!(result.reasoning_text, "Analyzing the problem...");
+    }
+
+    #[test]
+    fn test_cohere_cmd_streaming() {
+        let mut parser = CohereCmdParser::new();
+
+        // First chunk - start of thinking
+        let result1 = parser
+            .parse_reasoning_streaming_incremental("<|START_THINKING|>Step 1: ")
+            .unwrap();
+        assert_eq!(result1.reasoning_text, "Step 1: ");
+        assert_eq!(result1.normal_text, "");
+
+        // Second chunk - continue thinking
+        let result2 = parser
+            .parse_reasoning_streaming_incremental("Analyze inputs. ")
+            .unwrap();
+        assert_eq!(result2.reasoning_text, "Analyze inputs. ");
+        assert_eq!(result2.normal_text, "");
+
+        // Third chunk - end thinking and normal text
+        let result3 = parser
+            .parse_reasoning_streaming_incremental(
+                "Step 2: Check.<|END_THINKING|>Here's the answer.",
+            )
+            .unwrap();
+        assert_eq!(result3.reasoning_text, "Step 2: Check.");
+        assert_eq!(result3.normal_text, "Here's the answer.");
+    }
+
+    #[test]
+    fn test_cohere_cmd_streaming_partial_token() {
+        let mut parser = CohereCmdParser::new();
+
+        // Partial start token
+        let result1 = parser
+            .parse_reasoning_streaming_incremental("<|START_")
+            .unwrap();
+        assert_eq!(result1.reasoning_text, "");
+        assert_eq!(result1.normal_text, "");
+
+        // Complete the start token
+        let result2 = parser
+            .parse_reasoning_streaming_incremental("THINKING|>reasoning")
+            .unwrap();
+        assert_eq!(result2.reasoning_text, "reasoning");
+        assert_eq!(result2.normal_text, "");
+    }
+
+    #[test]
+    fn test_cohere_cmd_reset() {
+        let mut parser = CohereCmdParser::new();
+
+        // Process some text
+        parser
+            .parse_reasoning_streaming_incremental("<|START_THINKING|>thinking<|END_THINKING|>done")
+            .unwrap();
+
+        // Reset
+        parser.reset();
+        assert!(!parser.is_in_reasoning());
+
+        // Should work fresh again
+        let result = parser
+            .detect_and_parse_reasoning("<|START_THINKING|>new<|END_THINKING|>text")
+            .unwrap();
+        assert_eq!(result.reasoning_text, "new");
+        assert_eq!(result.normal_text, "text");
+    }
+
+    #[test]
+    fn test_model_type() {
+        let parser = CohereCmdParser::new();
+        assert_eq!(parser.model_type(), "cohere_cmd");
+    }
+
+    #[test]
+    fn test_cohere_full_response_format() {
+        let mut parser = CohereCmdParser::new();
+
+        // Simulate full Cohere response with thinking and response markers
+        let input = r#"<|START_THINKING|>
+Let me analyze this step by step.
+1. First, I'll consider the question.
+2. Then, I'll formulate a response.
+<|END_THINKING|>
+<|START_RESPONSE|>The answer is 42.<|END_RESPONSE|>"#;
+
+        let result = parser.detect_and_parse_reasoning(input).unwrap();
+        assert!(result.reasoning_text.contains("step by step"));
+        // Note: Response markers are passed through - cleaned by tool_parser or response processor
+        assert!(result.normal_text.contains("START_RESPONSE"));
+    }
+
+    #[test]
+    fn test_cohere_cmd_empty_thinking() {
+        let mut parser = CohereCmdParser::new();
+
+        let result = parser
+            .detect_and_parse_reasoning("<|START_THINKING|><|END_THINKING|>The answer.")
+            .unwrap();
+        assert_eq!(result.normal_text, "The answer.");
+        assert_eq!(result.reasoning_text, "");
+    }
+
+    #[test]
+    fn test_cohere_cmd_unicode_in_thinking() {
+        let mut parser = CohereCmdParser::new();
+
+        let result = parser
+            .detect_and_parse_reasoning(
+                "<|START_THINKING|>分析这个问题 🤔 emoji test<|END_THINKING|>答案是42。",
+            )
+            .unwrap();
+        assert_eq!(result.reasoning_text, "分析这个问题 🤔 emoji test");
+        assert_eq!(result.normal_text, "答案是42。");
+    }
+
+    #[test]
+    fn test_cohere_cmd_angle_brackets_in_thinking() {
+        let mut parser = CohereCmdParser::new();
+
+        // Angle brackets that don't match tokens should pass through
+        let result = parser
+            .detect_and_parse_reasoning(
+                "<|START_THINKING|>check if x < 10 and y > 5<|END_THINKING|>result",
+            )
+            .unwrap();
+        assert_eq!(result.reasoning_text, "check if x < 10 and y > 5");
+        assert_eq!(result.normal_text, "result");
+    }
+
+    #[test]
+    fn test_cohere_cmd_whitespace_only_thinking() {
+        let mut parser = CohereCmdParser::new();
+
+        let result = parser
+            .detect_and_parse_reasoning("<|START_THINKING|>   \n\t  <|END_THINKING|>answer")
+            .unwrap();
+        // BaseReasoningParser trims reasoning text
+        assert_eq!(result.reasoning_text, "");
+        assert_eq!(result.normal_text, "answer");
+    }
+}

--- a/reasoning_parser/src/parsers/mod.rs
+++ b/reasoning_parser/src/parsers/mod.rs
@@ -1,4 +1,5 @@
 pub mod base;
+pub mod cohere_cmd;
 pub mod deepseek_r1;
 pub mod glm45;
 pub mod kimi;
@@ -7,6 +8,7 @@ pub mod qwen3;
 pub mod step3;
 
 pub use base::BaseReasoningParser;
+pub use cohere_cmd::CohereCmdParser;
 pub use deepseek_r1::DeepSeekR1Parser;
 pub use glm45::Glm45Parser;
 pub use kimi::KimiParser;


### PR DESCRIPTION
## Summary

Implements CohereCmdParser for parsing reasoning/thinking blocks from Cohere Command (CMD3/CMD4) models.

Closes #306

## What changed

| File | Change |
|------|--------|
| `reasoning_parser/src/parsers/cohere_cmd.rs` | New parser wrapping BaseReasoningParser with Cohere tokens |
| `reasoning_parser/src/parsers/mod.rs` | Export CohereCmdParser |
| `reasoning_parser/src/lib.rs` | Add CohereCmdParser to public exports |
| `reasoning_parser/src/factory.rs` | Register parser + model patterns (command-r, command-a, c4ai-command, cohere) |
| `reasoning_parser/README.md` | Add Cohere to supported models table and pattern list |

## Why

Enable SMG to extract reasoning/thinking content from Cohere Command models. Cohere uses:

```
<|START_THINKING|>
Let me analyze this step by step...
<|END_THINKING|>
<|START_RESPONSE|>The answer is 42.<|END_RESPONSE|>
```

Key difference from DeepSeek-R1: Cohere requires explicit `<|START_THINKING|>` token (`initial_in_reasoning: false`).

## How

- Wraps `BaseReasoningParser` with Cohere-specific config (composition pattern)
- No code duplication - delegates all logic to base
- Pattern matching for model auto-detection

## Test plan

- [x] `cargo test -p reasoning-parser` - All 68 tests pass
- [x] 12 CohereCmdParser tests including:
  - Basic parsing (with/without thinking)
  - Streaming with partial tokens
  - Edge cases: empty thinking, unicode, angle brackets, whitespace-only
- [x] Factory test for model pattern matching

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Cohere Command models (command-r, command-a, c4ai-command, and cohere variants) with reasoning extraction capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->