### PR TITLE
fix(e2e): thread-aware caching for setup_backend fixture

### DIFF
--- a/e2e_test/conftest.py
+++ b/e2e_test/conftest.py
@@ -197,7 +197,6 @@ def pytest_runtest_logstart(nodeid: str, location: tuple) -> None:
 # Import fixtures - pytest discovers these by name
 # Import hooks - pytest discovers these by name
 from fixtures import (
-    _cleanup_backend_cache,
     backend_router,
     model_base_url,
     model_client,
@@ -206,6 +205,7 @@ from fixtures import (
     pytest_collection_modifyitems,
     pytest_configure,
     pytest_runtest_setup,
+    pytest_sessionfinish,
     setup_backend,
 )
 
@@ -217,11 +217,11 @@ __all__ = [
     "pytest_collection_finish",
     "pytest_configure",
     "pytest_runtest_setup",
+    "pytest_sessionfinish",
     # Fixtures
     "model_pool",
     "model_client",
     "model_base_url",
     "setup_backend",
     "backend_router",
-    "_cleanup_backend_cache",
 ]

--- a/e2e_test/fixtures/__init__.py
+++ b/e2e_test/fixtures/__init__.py
@@ -19,6 +19,7 @@ from .hooks import (
     pytest_collection_modifyitems,
     pytest_configure,
     pytest_runtest_setup,
+    pytest_sessionfinish,
     validate_gpu_requirements,
 )
 
@@ -27,7 +28,7 @@ from .markers import get_marker_kwargs, get_marker_value
 
 # Fixtures (imported by conftest.py)
 from .pool import model_base_url, model_client, model_pool
-from .setup_backend import _cleanup_backend_cache, backend_router, setup_backend
+from .setup_backend import backend_router, setup_backend
 
 __all__ = [
     # Hooks
@@ -35,6 +36,7 @@ __all__ = [
     "pytest_collection_finish",
     "pytest_configure",
     "pytest_runtest_setup",
+    "pytest_sessionfinish",
     "get_pool_requirements",
     "validate_gpu_requirements",
     "is_parallel_execution",
@@ -45,7 +47,6 @@ __all__ = [
     # Backend fixtures
     "setup_backend",
     "backend_router",
-    "_cleanup_backend_cache",
     # Marker helpers
     "get_marker_value",
     "get_marker_kwargs",

--- a/e2e_test/fixtures/hooks.py
+++ b/e2e_test/fixtures/hooks.py
@@ -448,6 +448,17 @@ def is_parallel_execution(config: pytest.Config) -> bool:
         return False
 
 
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+    """Cleanup all thread-cached backends at session end.
+
+    This hook runs exactly once when the session ends, unlike session-scoped
+    autouse fixtures which fire per-test under pytest-parallel's thread model.
+    """
+    from .setup_backend import cleanup_all_cached_backends
+
+    cleanup_all_cached_backends()
+
+
 def pytest_runtest_setup(item: pytest.Item) -> None:
     """Skip tests based on markers and runtime configuration."""
     from infra import get_runtime

--- a/e2e_test/fixtures/setup_backend.py
+++ b/e2e_test/fixtures/setup_backend.py
@@ -228,10 +228,13 @@ def setup_backend(request: pytest.FixtureRequest, model_pool: "ModelPool"):
     yield value
 
 
-@pytest.fixture(scope="session", autouse=True)
-def _cleanup_backend_cache():
-    """Cleanup all thread-cached backends at session end."""
-    yield
+def cleanup_all_cached_backends() -> None:
+    """Cleanup all thread-cached backends.
+
+    Called from pytest_sessionfinish hook to ensure it runs exactly once,
+    not per-test (which is what happens with session-scoped autouse fixtures
+    under pytest-parallel's thread model).
+    """
     with _cache_lock:
         entries = list(_thread_cache.values())
         _thread_cache.clear()


### PR DESCRIPTION
## Description

### Problem

With `--tests-per-worker 4`, pytest-parallel distributes test methods to threads across class boundaries. The class-scoped `setup_backend` fixture doesn't get properly torn down/recreated when a thread transitions between classes, causing tests to run with the wrong model (e.g. `TestReasoningContentAPI` receiving Mistral instead of deepseek-7b from the preceding `TestToolChoiceMistral`).

### Solution

Change `setup_backend` from `scope="class"` to `scope="function"` with manual per-thread caching keyed on `(thread_id, class, param)`. The gateway is only restarted when the test class actually changes on a given thread — same performance as class-scoped.

- **Cache hit** (same class + param on this thread): reuse cached gateway (free)
- **Class change** on thread: teardown old gateway, create new one (correct isolation)
- **Session end**: `_cleanup_backend_cache` fixture tears down all remaining cached entries

Fixes: https://github.com/lightseekorg/smg/issues/320

## Changes

- Extract routing logic from `setup_backend` into `_create_backend()` helper that returns a generator
- Replace class-scoped `setup_backend` with function-scoped fixture using thread-local cache (`_thread_cache` dict protected by `_cache_lock`)
- Add session-scoped `_cleanup_backend_cache` autouse fixture for end-of-session teardown
- Export `_cleanup_backend_cache` from `fixtures/__init__.py` and `conftest.py`

## Test Plan

- [x] Verify chat-completions-sglang CI job passes (previously flaky due to fixture leakage)
- [x] Verify chat-completions-vllm CI job passes
- [x] Confirm no increase in gateway startup count (check logs for "reusing cached backend" messages)

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Backend fixture now uses per-thread caching to improve test isolation and reuse on the same thread.
  * Fixture scope changed to function-level to optimize lifecycle and resource management during parallel runs.
  * Automatic session-end cleanup added to ensure cached backend resources are reliably torn down.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->