### PR TITLE
fix(ci): reduce docker stop grace period for CI cleanup containers

### DIFF
--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -367,15 +367,11 @@ jobs:
 
       - name: Cleanup Brave MCP Server
         if: always() && matrix.setup_brave
-        run: |
-          docker stop -t 1 brave-search-server || true
-          docker rm brave-search-server || true
+        run: docker rm -f brave-search-server || true
 
       - name: Cleanup Oracle Database
         if: always() && matrix.setup_oracle
-        run: |
-          docker stop -t 1 oracle-db || true
-          docker rm oracle-db || true
+        run: docker rm -f oracle-db || true
 
   go-unit-tests:
     name: go-unit-tests


### PR DESCRIPTION
## Summary
- Add `-t 1` to `docker stop` for Brave MCP Server and Oracle Database cleanup steps
- Avoids the default 10s SIGTERM grace period which can stall for ~2 minutes on ephemeral runners

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified Docker container cleanup in CI/CD workflows by consolidating multi-step removal processes into single force-remove commands for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->