### PR TITLE
fix(ci): remove ineffective caching from vLLM and SGLang actions

### DIFF
--- a/.github/actions/setup-sglang/action.yml
+++ b/.github/actions/setup-sglang/action.yml
@@ -1,5 +1,5 @@
 name: 'Setup SGLang Backend'
-description: 'Create Python venv, restore/save pip cache, and install SGLang.'
+description: 'Create Python venv and install SGLang.'
 
 runs:
   using: 'composite'
@@ -8,20 +8,6 @@ runs:
       shell: bash
       run: bash scripts/ci_setup_python_venv.sh
 
-    - name: Restore pip cache
-      id: pip-cache
-      uses: actions/cache/restore@v4
-      with:
-        path: ~/.cache/pip
-        key: sglang-pip-${{ runner.os }}-${{ hashFiles('scripts/ci_install_sglang.sh') }}
-
     - name: Install SGLang
       shell: bash
       run: bash scripts/ci_install_sglang.sh
-
-    - name: Save pip cache
-      if: steps.pip-cache.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v4
-      with:
-        path: ~/.cache/pip
-        key: sglang-pip-${{ runner.os }}-${{ hashFiles('scripts/ci_install_sglang.sh') }}

--- a/scripts/ci_install_sglang.sh
+++ b/scripts/ci_install_sglang.sh
@@ -9,11 +9,6 @@ if [ -f ".venv/bin/activate" ]; then
     source .venv/bin/activate
 fi
 
-# Ensure pip cache goes to the runner user's home (not /root) when running
-# under sudo, so that actions/cache can save it afterward.
-export PIP_CACHE_DIR="${PIP_CACHE_DIR:-$HOME/.cache/pip}"
-mkdir -p "$PIP_CACHE_DIR"
-
 SGLANG_DIR="${1:-sglang}"
 
 # Clone SGLang if not already present
@@ -59,9 +54,6 @@ if [ ! -f "$INSTALL_SCRIPT" ]; then
     exit 1
 fi
 
-sudo CUDA_HOME=/usr/local/cuda IS_BLACKWELL=1 --preserve-env=PATH,PIP_CACHE_DIR bash "$INSTALL_SCRIPT"
-
-# Fix ownership so actions/cache (running as the runner user) can read the files
-sudo chown -R "$(id -u):$(id -g)" "$PIP_CACHE_DIR" || true
+sudo CUDA_HOME=/usr/local/cuda IS_BLACKWELL=1 --preserve-env=PATH bash "$INSTALL_SCRIPT"
 
 echo "SGLang installation complete"


### PR DESCRIPTION
## Description

### Problem

The composite actions introduced in #319 have two caching issues:
1. **vLLM**: Caching `~/.cache/uv` saves **5.15 GB**, making cache save/restore slower than a fresh install (~1 min with `uv`). This also pushed the repo past the 10 GB cache limit, evicting the TRT-LLM wheel cache and causing a full 90-min source build.
2. **SGLang**: The install script runs pip under `sudo` via sglang's own `ci_install_dependency.sh`, so nothing gets written to `~/.cache/pip`. The saved cache entry was 0 MB — pure overhead with no benefit.

### Solution

1. **vLLM**: Remove caching entirely. `uv` is fast enough without it.
2. **SGLang**: Remove caching entirely. The sglang install script doesn't populate the runner user's pip cache, so there's nothing useful to cache.

## Changes

- `.github/actions/setup-vllm/action.yml`: Remove `~/.cache/uv` cache restore/save steps
- `.github/actions/setup-sglang/action.yml`: Remove `~/.cache/pip` cache restore/save steps
- `scripts/ci_install_sglang.sh`: Revert `PIP_CACHE_DIR` plumbing (no longer needed)

## Test Plan

- [x] vLLM: `Setup vLLM backend` step completes in ~1 min without the 5 GB cache overhead
- [x] TRT-LLM: Wheel cache (~728 MB) restored successfully now that the 5 GB vLLM cache is gone
- [x] SGLang: CI run validates the action executes successfully without cache steps

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified CI/CD workflow configurations for Python environment setup and package installation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->