### PR TITLE
fix(ci): run embedding tests before router tests to avoid GPU starvation

### DIFF
--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -205,7 +205,7 @@ jobs:
             ignore_opts: ""
           - name: e2e
             timeout: 45
-            test_dirs: "e2e_test/router e2e_test/embeddings"
+            test_dirs: "e2e_test/embeddings e2e_test/router"
             extra_deps: "pytest-parallel py"  # py is required for pytest-parallel with newer pytest
             env_vars: "SHOW_WORKER_LOGS=0 SHOW_ROUTER_LOGS=1"
             reruns: "--reruns 2 --reruns-delay 5"


### PR DESCRIPTION
## Description

### Problem

The `e2e` CI job runs both router tests (`e2e_test/router/`) and embedding tests (`e2e_test/embeddings/`) with 4 threads on 4 GPUs. The test collection order puts router tests first, so embedding tests end up at the tail of the queue. This causes GPU starvation:

1. Router tests use `llama-8b`, embedding tests use the `embedding` model — different models competing for the same 4-GPU pool
2. `pytest-parallel` distributes tests sequentially. Embedding tests (14 instances) are queued after all router tests (18 instances)
3. Three threads finish router tests and move to embedding while Thread-4 is still running PD MMLU reruns (scores below 0.65 threshold → automatic reruns, ~85s each)
4. PD holds 2 GPUs for prefill/decode workers; the other 2 GPUs are held by `llama-8b` workers acquired by concurrent MMLU reruns and IGW health checks
5. The model pool's eviction logic won't evict workers with active references from other threads
6. Embedding threads retry every 16s up to a 5-minute timeout, then get RERUN'd — wasting ~15 min of GPU time on failed attempts

This is currently failing on both main ([run 21694172054](https://github.com/lightseekorg/smg/actions/runs/21694172054)) and PR branches.

### Solution

Swap the `test_dirs` order from `e2e_test/router e2e_test/embeddings` to `e2e_test/embeddings e2e_test/router`. This runs embedding tests first — they're fast (simple API calls, no 64-sample MMLU evals) and finish before PD tests start consuming GPUs. Avoids adding a second GPU job (which would double the ~5-6 min SGLang setup cost).

## Changes

- `.github/workflows/pr-test-rust.yml`: Reorder `test_dirs` in the `e2e` matrix entry to run embedding tests before router tests

## Test Plan

- [ ] `e2e` job passes — embedding tests complete before PD tests start, no GPU starvation
- [ ] No change to other matrix entries

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>