### PR TITLE
fix(e2e): release leaked worker refs causing GPU starvation

### DIFF
--- a/e2e_test/router/test_worker_api.py
+++ b/e2e_test/router/test_worker_api.py
@@ -111,6 +111,7 @@ class TestIGWMode:
             logger.info("Models available: %d", len(models))
         finally:
             gateway.shutdown()
+            http_instance.release()
 
     def test_igw_add_and_remove_worker(self, model_pool: ModelPool):
         """Test adding and removing workers dynamically."""
@@ -137,6 +138,7 @@ class TestIGWMode:
                 logger.warning("Remove worker not supported: %s", msg)
         finally:
             gateway.shutdown()
+            http_instance.release()
 
     def test_igw_multiple_workers(self, model_pool: ModelPool):
         """Test adding multiple workers (HTTP + gRPC) to IGW gateway."""
@@ -162,6 +164,8 @@ class TestIGWMode:
                 logger.info("Worker: id=%s, url=%s", w.id, w.url)
         finally:
             gateway.shutdown()
+            http_instance.release()
+            grpc_instance.release()
 
 
 @pytest.mark.e2e
@@ -207,6 +211,7 @@ class TestDisableHealthCheck:
                 ), "Worker should be healthy when health checks disabled"
         finally:
             gateway.shutdown()
+            http_instance.release()
 
     def test_disable_health_check_gateway_starts_without_health_checker(
         self, model_pool: ModelPool


### PR DESCRIPTION
## Description

### Problem

The `e2e` CI job intermittently fails with GPU starvation — PD gRPC tests time out waiting for GPUs because all 4 are held with leaked references.

**Root cause**: `TestIGWMode` and `TestDisableHealthCheck` tests call `model_pool.get()` (which internally calls `acquire()`) but never call `release()`. Each test leaks a reference, driving `ref_count` up to 5 on `llama-8b:http` and making all workers permanently unevictable.

Confirmed via warning-level logging added in the first commit (now reverted):

```
[llama-8b:http] ref_count=5 is_in_use=True gpus=1
[llama-8b:grpc] ref_count=2 is_in_use=True gpus=1
[llama-8b:http:prefill_0] ref_count=1 is_in_use=True gpus=1
[llama-8b:http:decode_0] ref_count=1 is_in_use=True gpus=1
No evictable instances found — all 4 instances are in use or excluded
```

### Fix

Add `release()` calls in the `finally` blocks of all tests that call `model_pool.get()` directly:
- `test_igw_add_worker`
- `test_igw_add_and_remove_worker`
- `test_igw_multiple_workers`
- `test_disable_health_check_workers_immediately_healthy`

## Changes

- `e2e_test/router/test_worker_api.py`: Add `instance.release()` in `finally` blocks

## Test Plan

- [x] `e2e` job passes — PD gRPC tests no longer starved for GPUs
- [x] No change to other matrix entries

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced end-to-end test cleanup procedures to ensure proper resource release after test execution, improving test infrastructure reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->