### PR TITLE
refactor(ci): split nightly benchmark into per-model jobs

### DIFF
--- a/.github/workflows/nightly-benchmark.yml
+++ b/.github/workflows/nightly-benchmark.yml
@@ -1,13 +1,8 @@
 name: Nightly Benchmark
 
 on:
-  # TODO: Uncomment after testing
-  # schedule:
-  #   - cron: '0 0 * * 0'
-  pull_request:
-    paths:
-      - '.github/workflows/nightly-benchmark.yml'
-      - 'e2e_test/benchmarks/test_nightly_perf.py'
+  schedule:
+    - cron: '0 0 * * 0'
   workflow_dispatch:
     inputs:
       models:

--- a/e2e_test/benchmarks/test_nightly_perf.py
+++ b/e2e_test/benchmarks/test_nightly_perf.py
@@ -30,8 +30,7 @@ _MAX_REQUESTS = 300
 _MAX_TIME_PER_RUN = 10  # seconds per scenario×concurrency combo
 _TIMEOUT_SEC = 10800  # 3 hours per model
 
-# TODO: Set to False after testing workflow changes
-_TEST_MODE = True
+_TEST_MODE = False
 _TEST_NUM_CONCURRENCY = 1
 _TEST_TRAFFIC_SCENARIO = "D(100,100)"
 _TEST_MAX_REQUESTS = 10


### PR DESCRIPTION
## Summary

Refactors the nightly benchmark workflow to run each model as a separate job instead of running all models in a single pytest session. This improves debuggability and fault isolation.

Closes: N/A (workflow improvement)

## What changed

**`.github/workflows/nightly-benchmark.yml`**:
- Replaced monolithic `single-sglang` and `single-vllm` jobs with a unified `single-worker` matrix job
- Matrix: 9 models × 2 runtimes (sglang, vllm) = 18 separate jobs
- Added `fail-fast: false` so one model failure doesn't stop other models
- Added `if: !cancelled()` to ensure jobs run even if dependencies fail
- Updated job dependencies: `multi-worker` now depends on `single-worker`
- Added `llama-4-maverick-17b` to single-worker matrix (was missing)
- Temporarily added PR trigger for testing this workflow

**`e2e_test/benchmarks/test_nightly_perf.py`**:
- Enabled `_TEST_MODE = True` for fast benchmark runs during testing
- Uses 1 concurrency level, 10 requests, 5min timeout instead of full settings

## Why

- **Before**: All models ran in a single pytest session. If one model failed, the entire step failed, making it impossible to determine which model caused the failure.
- **After**: Each model runs as a separate job with clear pass/fail status in the GitHub UI. Failures are isolated and don't block other models.

## How

- Unified the matrix pattern between `single-worker` and `multi-worker` jobs
- Each matrix entry runs: checkout → install backend → download wheel → run pytest with model-specific `-k` filter → upload artifacts → cleanup
- Filter step skips jobs based on `models` and `runtime` workflow_dispatch inputs

## Test plan

- [ ] PR triggers the workflow (via `pull_request` trigger on workflow file changes)
- [ ] Each model appears as a separate job in the GitHub Actions UI
- [ ] Jobs complete quickly due to `_TEST_MODE = True`
- [ ] If a model fails, other models continue running
- [ ] Summary job runs and generates report

## Before merging

- [ ] Revert `_TEST_MODE = True` back to `False`
- [ ] Uncomment the `schedule` trigger
- [ ] Remove the `pull_request` trigger

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized nightly benchmark workflow to run models and variants in isolated jobs with improved filtering and parallelization controls. Updated job dependencies and artifact naming conventions for better organization and traceability of benchmark results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->