### PR TITLE
feat(serve): add unified --connection-mode and fix gRPC health checks

### DIFF
--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -38,8 +38,8 @@ smg serve --backend sglang --model-path /path/to/model --port 8080 --dp-size 4
 | Option | Default | Description |
 |--------|---------|-------------|
 | `--backend` | `sglang` | Backend to use: `sglang`, `vllm`, or `trtllm` |
-| `--connection-mode` | `grpc` | Connection mode: `grpc` or `http` (sglang only supports http) |
-| `--host` | `0.0.0.0` | Host for the router |
+| `--connection-mode` | `grpc` | Connection mode: `grpc` or `http`. vllm/trtllm only support grpc |
+| `--host` | `127.0.0.1` | Host for the router |
 | `--port` | `8080` | Port for the router |
 | `--dp-size` | `1` | Data parallel size (number of worker replicas) |
 | `--worker-host` | `127.0.0.1` | Host for worker processes |

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -11,14 +11,13 @@ authors = [
     {name = "Chang Su", email = "mckvtl@gmail.com"},
     {name = "Keyang Ru", email = "rukeyang@gmail.com"}
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 readme = "../../README.md"
 license = { text = "Apache-2.0" }
 classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Rust",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/bindings/python/src/smg/serve.py
+++ b/bindings/python/src/smg/serve.py
@@ -324,8 +324,8 @@ def add_serve_args(parser: argparse.ArgumentParser) -> None:
     # Router host/port - may be overridden by backend (e.g. sglang)
     group.add_argument(
         "--host",
-        default="0.0.0.0",
-        help="Host for the router (default: 0.0.0.0)",
+        default="127.0.0.1",
+        help="Host for the router (default: 127.0.0.1)",
     )
     group.add_argument(
         "--port",


### PR DESCRIPTION
## Summary

- Add `--connection-mode {grpc,http}` argument (default: `grpc`) for unified connection mode across backends
- sglang supports both grpc and http modes
- vllm and trtllm only support grpc (error if http requested)
- Move `health_check` and `worker_url` to base `WorkerLauncher` class to reduce duplication
- Add `grpcio` and `grpcio-health-checking` dependencies for proper gRPC health checks
- Remove unused dependencies (`uvicorn`, `fastapi`, `aiohttp`, `orjson`)
- Update README with `smg serve` command documentation

## Test plan

- [ ] Test `smg serve --backend sglang` with default grpc mode
- [ ] Test `smg serve --backend sglang --connection-mode http`
- [ ] Test `smg serve --backend vllm` (grpc only)
- [ ] Verify error when `--backend vllm --connection-mode http`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Python bindings README with Quick Start, installation, usage, serve options, and revised build/testing guidance.

* **New Features**
  * Added CLI options: --connection-mode (grpc/http, default grpc), --host (default 127.0.0.1), --port, and --data-parallel-size (default 1).

* **Chores**
  * Adjusted Python packaging metadata and dependencies to add gRPC support and remove unused web-framework packages.

* **Tests**
  * Test coverage updated to validate new CLI args, defaults, and per-backend connection-mode behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->