### PR TITLE
fix(ci): correct working-directory paths in PyPI release workflow

### DIFF
--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
-          working-directory: bindings/python
+          working-directory: smg-repo/bindings/python
           target: ${{ matrix.target }}
           manylinux: ${{ matrix.manylinux || 'auto' }}
           args: --release --out dist --features vendored-openssl --interpreter ${{ matrix.interpreter || '3.9 3.10 3.11 3.12 3.13 3.14' }}
@@ -103,15 +103,15 @@ jobs:
             protoc --version
 
       - name: List built packages
-        run: ${{ matrix.ls || 'ls -lh' }} bindings/python/dist/
+        run: ${{ matrix.ls || 'ls -lh' }} smg-repo/bindings/python/dist/
 
       - name: Check packages
-        run: twine check --strict bindings/python/dist/*
+        run: twine check --strict smg-repo/bindings/python/dist/*
 
       - uses: actions/upload-artifact@v6
         with:
           name: packages-${{ matrix.os }}-${{ matrix.target }}-${{ matrix.manylinux || 'auto' }}
-          path: bindings/python/dist/
+          path: smg-repo/bindings/python/dist/
 
   build-sdist:
     name: Build SDist
@@ -131,7 +131,7 @@ jobs:
       - name: Build SDist
         uses: PyO3/maturin-action@v1
         with:
-          working-directory: bindings/python
+          working-directory: smg-repo/bindings/python
           command: sdist
           args: --out dist
           rust-toolchain: stable
@@ -139,7 +139,7 @@ jobs:
       - uses: actions/upload-artifact@v6
         with:
           name: sdist
-          path: bindings/python/dist/*.tar.gz
+          path: smg-repo/bindings/python/dist/*.tar.gz
 
   upload:
     name: Upload to PyPI


### PR DESCRIPTION
## Description

### Problem

The PyPI release workflow (`release-pypi.yml`) checks out the repo into a subdirectory `smg-repo` (via `path: smg-repo` in `actions/checkout`), but all subsequent steps reference `bindings/python` relative to the workspace root — which doesn't exist. This causes every build job to fail with:

```
Error: The cwd: /Users/runner/work/smg/smg/bindings/python does not exist!
```

See: https://github.com/lightseekorg/smg/actions/runs/21735544811/job/62699682058

### Solution

Prefix all `working-directory` and path references with `smg-repo/` to match the checkout path.

## Changes

- Update `working-directory` for maturin build and sdist steps: `bindings/python` → `smg-repo/bindings/python`
- Update `List built packages`, `Check packages`, and `upload-artifact` paths accordingly

## Test Plan

- Re-run the release workflow via `workflow_dispatch` after merge and verify all build matrix jobs pass.

<details>
<summary>Checklist</summary>

- [x] No Rust changes — CI-only fix
- [x] Documentation not affected

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD release workflow configuration paths.

---

**Note:** This release contains internal infrastructure updates with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->