### PR TITLE
refactor(protocols): use serde_with::skip_serializing_none to reduce boilerplate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ rand = "0.9.2"
 reqwest = { version = "0.12.8", default-features = false }
 serde = { version = "1.0" }
 serde_json = "1.0"
+serde_with = { version = "3", features = ["macros"] }
 subtle = "2.6"
 thiserror = "2.0.12"
 tokio = { version = "1.42.0" }

--- a/protocols/Cargo.toml
+++ b/protocols/Cargo.toml
@@ -23,6 +23,7 @@ chrono.workspace = true
 rand.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["preserve_order"] }
+serde_with.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 # Only used by protocols

--- a/protocols/src/chat.rs
+++ b/protocols/src/chat.rs
@@ -22,31 +22,26 @@ use crate::{
 // Chat Messages
 // ============================================================================
 
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(tag = "role")]
 pub enum ChatMessage {
     #[serde(rename = "system")]
     System {
         content: MessageContent,
-        #[serde(skip_serializing_if = "Option::is_none")]
         name: Option<String>,
     },
     #[serde(rename = "user")]
     User {
         content: MessageContent,
-        #[serde(skip_serializing_if = "Option::is_none")]
         name: Option<String>,
     },
     #[serde(rename = "assistant")]
     Assistant {
-        #[serde(skip_serializing_if = "Option::is_none")]
         content: Option<MessageContent>,
-        #[serde(skip_serializing_if = "Option::is_none")]
         name: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none")]
         tool_calls: Option<Vec<ToolCall>>,
         /// Reasoning content for O1-style models (SGLang extension)
-        #[serde(skip_serializing_if = "Option::is_none")]
         reasoning_content: Option<String>,
     },
     #[serde(rename = "tool")]
@@ -59,9 +54,7 @@ pub enum ChatMessage {
     #[serde(rename = "developer")]
     Developer {
         content: MessageContent,
-        #[serde(skip_serializing_if = "Option::is_none")]
         tools: Option<Vec<Tool>>,
-        #[serde(skip_serializing_if = "Option::is_none")]
         name: Option<String>,
     },
 }
@@ -146,6 +139,7 @@ impl MessageContent {
 // Chat Completion Request
 // ============================================================================
 
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Deserialize, Serialize, Default, Validate)]
 #[validate(schema(function = "validate_chat_cross_parameters"))]
 pub struct ChatCompletionRequest {
@@ -158,22 +152,18 @@ pub struct ChatCompletionRequest {
     pub model: String,
 
     /// Number between -2.0 and 2.0. Positive values penalize new tokens based on their existing frequency in the text so far
-    #[serde(skip_serializing_if = "Option::is_none")]
     #[validate(range(min = -2.0, max = 2.0))]
     pub frequency_penalty: Option<f32>,
 
     /// Deprecated: Replaced by tool_choice
-    #[serde(skip_serializing_if = "Option::is_none")]
     #[deprecated(note = "Use tool_choice instead")]
     pub function_call: Option<FunctionCall>,
 
     /// Deprecated: Replaced by tools
-    #[serde(skip_serializing_if = "Option::is_none")]
     #[deprecated(note = "Use tools instead")]
     pub functions: Option<Vec<Function>>,
 
     /// Modify the likelihood of specified tokens appearing in the completion
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub logit_bias: Option<HashMap<String, f32>>,
 
     /// Whether to return log probabilities of the output tokens
@@ -181,65 +171,51 @@ pub struct ChatCompletionRequest {
     pub logprobs: bool,
 
     /// Deprecated: Replaced by max_completion_tokens
-    #[serde(skip_serializing_if = "Option::is_none")]
     #[deprecated(note = "Use max_completion_tokens instead")]
     #[validate(range(min = 1))]
     pub max_tokens: Option<u32>,
 
     /// An upper bound for the number of tokens that can be generated for a completion
-    #[serde(skip_serializing_if = "Option::is_none")]
     #[validate(range(min = 1))]
     pub max_completion_tokens: Option<u32>,
 
     /// Developer-defined tags and values used for filtering completions in the dashboard
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<HashMap<String, String>>,
 
     /// Output types that you would like the model to generate for this request
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub modalities: Option<Vec<String>>,
 
     /// How many chat completion choices to generate for each input message
-    #[serde(skip_serializing_if = "Option::is_none")]
     #[validate(range(min = 1, max = 10))]
     pub n: Option<u32>,
 
     /// Whether to enable parallel function calling during tool use
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub parallel_tool_calls: Option<bool>,
 
     /// Number between -2.0 and 2.0. Positive values penalize new tokens based on whether they appear in the text so far
-    #[serde(skip_serializing_if = "Option::is_none")]
     #[validate(range(min = -2.0, max = 2.0))]
     pub presence_penalty: Option<f32>,
 
     /// Cache key for prompts (beta feature)
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub prompt_cache_key: Option<String>,
 
     /// Effort level for reasoning models (low, medium, high)
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning_effort: Option<String>,
 
     /// An object specifying the format that the model must output
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub response_format: Option<ResponseFormat>,
 
     /// Safety identifier for content moderation
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub safety_identifier: Option<String>,
 
     /// Deprecated: This feature is in Legacy mode
-    #[serde(skip_serializing_if = "Option::is_none")]
     #[deprecated(note = "This feature is in Legacy mode")]
     pub seed: Option<i64>,
 
     /// The service tier to use for this request
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub service_tier: Option<String>,
 
     /// Up to 4 sequences where the API will stop generating further tokens
-    #[serde(skip_serializing_if = "Option::is_none")]
     #[validate(custom(function = "validate_stop"))]
     pub stop: Option<StringOrArray>,
 
@@ -248,34 +224,27 @@ pub struct ChatCompletionRequest {
     pub stream: bool,
 
     /// Options for streaming response
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub stream_options: Option<StreamOptions>,
 
     /// What sampling temperature to use, between 0 and 2
-    #[serde(skip_serializing_if = "Option::is_none")]
     #[validate(range(min = 0.0, max = 2.0))]
     pub temperature: Option<f32>,
 
     /// Controls which (if any) tool is called by the model
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_choice: Option<ToolChoice>,
 
     /// A list of tools the model may call
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub tools: Option<Vec<Tool>>,
 
     /// An integer between 0 and 20 specifying the number of most likely tokens to return
-    #[serde(skip_serializing_if = "Option::is_none")]
     #[validate(range(min = 0, max = 20))]
     pub top_logprobs: Option<u32>,
 
     /// An alternative to sampling with temperature
-    #[serde(skip_serializing_if = "Option::is_none")]
     #[validate(custom(function = "validate_top_p_value"))]
     pub top_p: Option<f32>,
 
     /// Verbosity level for debugging
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub verbosity: Option<i32>,
 
     // =============================================================================
@@ -285,35 +254,28 @@ pub struct ChatCompletionRequest {
     // control model generation behavior in engine-specific ways.
     // =============================================================================
     /// Top-k sampling parameter (-1 to disable)
-    #[serde(skip_serializing_if = "Option::is_none")]
     #[validate(custom(function = "validate_top_k_value"))]
     pub top_k: Option<i32>,
 
     /// Min-p nucleus sampling parameter
-    #[serde(skip_serializing_if = "Option::is_none")]
     #[validate(range(min = 0.0, max = 1.0))]
     pub min_p: Option<f32>,
 
     /// Minimum number of tokens to generate
-    #[serde(skip_serializing_if = "Option::is_none")]
     #[validate(range(min = 1))]
     pub min_tokens: Option<u32>,
 
     /// Repetition penalty for reducing repetitive text
-    #[serde(skip_serializing_if = "Option::is_none")]
     #[validate(range(min = 0.0, max = 2.0))]
     pub repetition_penalty: Option<f32>,
 
     /// Regex constraint for output generation
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub regex: Option<String>,
 
     /// EBNF grammar constraint for structured output
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub ebnf: Option<String>,
 
     /// Specific token IDs to use as stop conditions
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub stop_token_ids: Option<Vec<u32>>,
 
     /// Skip trimming stop tokens from output
@@ -333,11 +295,9 @@ pub struct ChatCompletionRequest {
     pub skip_special_tokens: bool,
 
     /// Path to LoRA adapter(s) for model customization
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub lora_path: Option<String>,
 
     /// Session parameters for continual prompting
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub session_params: Option<HashMap<String, Value>>,
 
     /// Separate reasoning content from final answer (O1-style models)
@@ -349,7 +309,6 @@ pub struct ChatCompletionRequest {
     pub stream_reasoning: bool,
 
     /// Chat template kwargs
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub chat_template_kwargs: Option<HashMap<String, Value>>,
 
     /// Return model hidden states
@@ -357,7 +316,6 @@ pub struct ChatCompletionRequest {
     pub return_hidden_states: bool,
 
     /// Random seed for sampling for deterministic outputs
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sampling_seed: Option<u64>,
 }
 
@@ -702,6 +660,7 @@ impl GenerationRequest for ChatCompletionRequest {
 // Response Types
 // ============================================================================
 
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ChatCompletionResponse {
     pub id: String,
@@ -709,9 +668,7 @@ pub struct ChatCompletionResponse {
     pub created: u64,
     pub model: String,
     pub choices: Vec<ChatChoice>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub usage: Option<Usage>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub system_fingerprint: Option<String>,
 }
 
@@ -753,16 +710,15 @@ pub struct ChatChoice {
     pub hidden_states: Option<Vec<f32>>,
 }
 
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ChatCompletionStreamResponse {
     pub id: String,
     pub object: String, // "chat.completion.chunk"
     pub created: u64,
     pub model: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub system_fingerprint: Option<String>,
     pub choices: Vec<ChatStreamChoice>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub usage: Option<Usage>,
 }
 

--- a/protocols/src/classify.rs
+++ b/protocols/src/classify.rs
@@ -16,6 +16,7 @@ use super::common::{GenerationRequest, UsageInfo};
 // ============================================================================
 
 /// Classification request - compatible with vLLM's /v1/classify API
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ClassifyRequest {
     /// ID of the model to use
@@ -28,19 +29,15 @@ pub struct ClassifyRequest {
     pub input: Value,
 
     /// Optional user identifier
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<String>,
 
     /// SGLang extension: request id for tracking
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub rid: Option<String>,
 
     /// SGLang extension: request priority
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub priority: Option<i32>,
 
     /// SGLang extension: enable/disable logging of metrics
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub log_metrics: Option<bool>,
 }
 

--- a/protocols/src/common.rs
+++ b/protocols/src/common.rs
@@ -230,23 +230,20 @@ pub struct StreamOptions {
     pub include_usage: Option<bool>,
 }
 
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ToolCallDelta {
     pub index: u32,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "type")]
     pub tool_type: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub function: Option<FunctionCallDelta>,
 }
 
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct FunctionCallDelta {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub arguments: Option<String>,
 }
 
@@ -382,14 +379,13 @@ pub struct Tool {
     pub function: Function,
 }
 
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Function {
     pub name: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     pub parameters: Value, // JSON Schema
     /// Whether to enable strict schema adherence (OpenAI structured outputs)
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub strict: Option<bool>,
 }
 
@@ -501,14 +497,13 @@ pub struct CompletionTokensDetails {
 }
 
 /// Usage information (used by rerank and other endpoints)
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct UsageInfo {
     pub prompt_tokens: u32,
     pub completion_tokens: u32,
     pub total_tokens: u32,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning_tokens: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub prompt_tokens_details: Option<PromptTokenUsageInfo>,
 }
 
@@ -559,14 +554,13 @@ pub struct ErrorResponse {
     pub error: ErrorDetail,
 }
 
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ErrorDetail {
     pub message: String,
     #[serde(rename = "type")]
     pub error_type: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub param: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub code: Option<String>,
 }
 

--- a/protocols/src/completion.rs
+++ b/protocols/src/completion.rs
@@ -9,6 +9,7 @@ use super::common::*;
 // Completions API (v1/completions) - DEPRECATED but still supported
 // ============================================================================
 
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct CompletionRequest {
     /// ID of the model to use (required for OpenAI, optional for some implementations, such as SGLang)
@@ -18,23 +19,18 @@ pub struct CompletionRequest {
     pub prompt: StringOrArray,
 
     /// The suffix that comes after a completion of inserted text
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub suffix: Option<String>,
 
     /// The maximum number of tokens to generate
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_tokens: Option<u32>,
 
     /// What sampling temperature to use, between 0 and 2
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub temperature: Option<f32>,
 
     /// An alternative to sampling with temperature (nucleus sampling)
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub top_p: Option<f32>,
 
     /// How many completions to generate for each prompt
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub n: Option<u32>,
 
     /// Whether to stream back partial progress
@@ -42,11 +38,9 @@ pub struct CompletionRequest {
     pub stream: bool,
 
     /// Options for streaming response
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub stream_options: Option<StreamOptions>,
 
     /// Include the log probabilities on the logprobs most likely tokens
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub logprobs: Option<u32>,
 
     /// Echo back the prompt in addition to the completion
@@ -54,64 +48,49 @@ pub struct CompletionRequest {
     pub echo: bool,
 
     /// Up to 4 sequences where the API will stop generating further tokens
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub stop: Option<StringOrArray>,
 
     /// Number between -2.0 and 2.0. Positive values penalize new tokens based on whether they appear in the text so far
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub presence_penalty: Option<f32>,
 
     /// Number between -2.0 and 2.0. Positive values penalize new tokens based on their existing frequency in the text so far
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub frequency_penalty: Option<f32>,
 
     /// Generates best_of completions server-side and returns the "best"
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub best_of: Option<u32>,
 
     /// Modify the likelihood of specified tokens appearing in the completion
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub logit_bias: Option<HashMap<String, f32>>,
 
     /// A unique identifier representing your end-user
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<String>,
 
     /// If specified, our system will make a best effort to sample deterministically
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub seed: Option<i64>,
 
     // -------- Engine Specific Sampling Parameters --------
     /// Top-k sampling parameter (-1 to disable)
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub top_k: Option<i32>,
 
     /// Min-p nucleus sampling parameter
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub min_p: Option<f32>,
 
     /// Minimum number of tokens to generate
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub min_tokens: Option<u32>,
 
     /// Repetition penalty for reducing repetitive text
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub repetition_penalty: Option<f32>,
 
     /// Regex constraint for output generation
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub regex: Option<String>,
 
     /// EBNF grammar constraint for structured output
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub ebnf: Option<String>,
 
     /// JSON schema constraint for structured output
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub json_schema: Option<String>,
 
     /// Specific token IDs to use as stop conditions
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub stop_token_ids: Option<Vec<u32>>,
 
     /// Skip trimming stop tokens from output
@@ -127,11 +106,9 @@ pub struct CompletionRequest {
     pub skip_special_tokens: bool,
 
     /// Path to LoRA adapter(s) for model customization
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub lora_path: Option<String>,
 
     /// Session parameters for continual prompting
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub session_params: Option<HashMap<String, Value>>,
 
     /// Return model hidden states
@@ -139,7 +116,6 @@ pub struct CompletionRequest {
     pub return_hidden_states: bool,
 
     /// Sampling seed for deterministic outputs
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sampling_seed: Option<u64>,
 
     /// Additional fields including bootstrap info for PD routing
@@ -168,6 +144,7 @@ impl GenerationRequest for CompletionRequest {
 // Response Types
 // ============================================================================
 
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct CompletionResponse {
     pub id: String,
@@ -175,9 +152,7 @@ pub struct CompletionResponse {
     pub created: u64,
     pub model: String,
     pub choices: Vec<CompletionChoice>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub usage: Option<Usage>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub system_fingerprint: Option<String>,
 }
 

--- a/protocols/src/embedding.rs
+++ b/protocols/src/embedding.rs
@@ -7,6 +7,7 @@ use super::common::{GenerationRequest, UsageInfo};
 // Embedding API
 // ============================================================================
 
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct EmbeddingRequest {
     /// ID of the model to use
@@ -16,23 +17,18 @@ pub struct EmbeddingRequest {
     pub input: Value,
 
     /// Optional encoding format (e.g., "float", "base64")
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub encoding_format: Option<String>,
 
     /// Optional user identifier
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<String>,
 
     /// Optional number of dimensions for the embedding
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub dimensions: Option<u32>,
 
     /// SGLang extension: request id for tracking
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub rid: Option<String>,
 
     /// SGLang extension: enable/disable logging of metrics for this request
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub log_metrics: Option<bool>,
 }
 

--- a/protocols/src/generate.rs
+++ b/protocols/src/generate.rs
@@ -267,20 +267,18 @@ pub struct GenerateResponse {
 }
 
 /// Metadata for a single generate completion
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GenerateMetaInfo {
     pub id: String,
     pub finish_reason: GenerateFinishReason,
     pub prompt_tokens: u32,
     pub weight_version: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub input_token_logprobs: Option<Vec<Vec<Option<f64>>>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub output_token_logprobs: Option<Vec<Vec<Option<f64>>>>,
     pub completion_tokens: u32,
     pub cached_tokens: u32,
     pub e2e_latency: f64,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub matched_stop: Option<Value>,
 }
 

--- a/protocols/src/messages.rs
+++ b/protocols/src/messages.rs
@@ -18,6 +18,7 @@ use crate::validated::Normalizable;
 /// Request to create a message using the Anthropic Messages API.
 ///
 /// This is the main request type for `/v1/messages` endpoint.
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize, Validate)]
 pub struct CreateMessageRequest {
     /// The model that will complete your prompt.
@@ -33,56 +34,43 @@ pub struct CreateMessageRequest {
     pub max_tokens: u32,
 
     /// An object describing metadata about the request.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<Metadata>,
 
     /// Service tier for the request (auto or standard_only).
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub service_tier: Option<ServiceTier>,
 
     /// Custom text sequences that will cause the model to stop generating.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub stop_sequences: Option<Vec<String>>,
 
     /// Whether to incrementally stream the response using server-sent events.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub stream: Option<bool>,
 
     /// System prompt for providing context and instructions.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub system: Option<SystemContent>,
 
     /// Amount of randomness injected into the response (0.0 to 1.0).
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub temperature: Option<f64>,
 
     /// Configuration for extended thinking.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub thinking: Option<ThinkingConfig>,
 
     /// How the model should use the provided tools.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_choice: Option<ToolChoice>,
 
     /// Definitions of tools that the model may use.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub tools: Option<Vec<Tool>>,
 
     /// Only sample from the top K options for each subsequent token.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub top_k: Option<u32>,
 
     /// Use nucleus sampling.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub top_p: Option<f64>,
 
     // Beta features
     /// Container configuration for code execution (beta).
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub container: Option<ContainerConfig>,
 
     /// MCP servers to be utilized in this request (beta).
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub mcp_servers: Option<Vec<McpServerConfig>>,
 }
 
@@ -183,17 +171,16 @@ pub enum InputContentBlock {
 }
 
 /// Text content block
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TextBlock {
     /// The text content
     pub text: String,
 
     /// Cache control for this block
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_control: Option<CacheControl>,
 
     /// Citations for this text block
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub citations: Option<Vec<Citation>>,
 }
 
@@ -217,25 +204,22 @@ pub enum ImageSource {
 }
 
 /// Document content block
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DocumentBlock {
     /// The document source
     pub source: DocumentSource,
 
     /// Cache control for this block
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_control: Option<CacheControl>,
 
     /// Optional title for the document
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
 
     /// Optional context for the document
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub context: Option<String>,
 
     /// Citations configuration
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub citations: Option<CitationsConfig>,
 }
 
@@ -267,21 +251,19 @@ pub struct ToolUseBlock {
 }
 
 /// Tool result block (in user messages)
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ToolResultBlock {
     /// The ID of the tool use this is a result for
     pub tool_use_id: String,
 
     /// The result content (string or blocks)
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<ToolResultContent>,
 
     /// Whether this result indicates an error
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub is_error: Option<bool>,
 
     /// Cache control for this block
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_control: Option<CacheControl>,
 }
 
@@ -338,6 +320,7 @@ pub struct ServerToolUseBlock {
 }
 
 /// Search result block
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SearchResultBlock {
     /// Source URL or identifier
@@ -350,11 +333,9 @@ pub struct SearchResultBlock {
     pub content: Vec<TextBlock>,
 
     /// Cache control for this block
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_control: Option<CacheControl>,
 
     /// Citations configuration
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub citations: Option<CitationsConfig>,
 }
 
@@ -512,37 +493,35 @@ pub enum Tool {
 }
 
 /// Custom tool definition
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CustomTool {
     /// Name of the tool
     pub name: String,
 
     /// Optional type (defaults to "custom")
-    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "type")]
     pub tool_type: Option<String>,
 
     /// Description of what this tool does
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 
     /// JSON schema for the tool's input
     pub input_schema: InputSchema,
 
     /// Cache control for this tool
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_control: Option<CacheControl>,
 }
 
 /// JSON Schema for tool input
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InputSchema {
     #[serde(rename = "type")]
     pub schema_type: String,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub properties: Option<HashMap<String, Value>>,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub required: Option<Vec<String>>,
 
     /// Additional properties can be stored here
@@ -575,6 +554,7 @@ pub struct TextEditorTool {
 }
 
 /// Web search tool
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WebSearchTool {
     #[serde(rename = "type")]
@@ -582,38 +562,30 @@ pub struct WebSearchTool {
 
     pub name: String, // "web_search"
 
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub allowed_domains: Option<Vec<String>>,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub blocked_domains: Option<Vec<String>>,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_uses: Option<u32>,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub user_location: Option<UserLocation>,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_control: Option<CacheControl>,
 }
 
 /// User location for web search
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UserLocation {
     #[serde(rename = "type")]
     pub location_type: String, // "approximate"
 
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub city: Option<String>,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub region: Option<String>,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub country: Option<String>,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub timezone: Option<String>,
 }
 
@@ -622,23 +594,21 @@ pub struct UserLocation {
 // ============================================================================
 
 /// How the model should use the provided tools
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ToolChoice {
     /// The model will automatically decide whether to use tools
     Auto {
-        #[serde(skip_serializing_if = "Option::is_none")]
         disable_parallel_tool_use: Option<bool>,
     },
     /// The model will use any available tools
     Any {
-        #[serde(skip_serializing_if = "Option::is_none")]
         disable_parallel_tool_use: Option<bool>,
     },
     /// The model will use the specified tool
     Tool {
         name: String,
-        #[serde(skip_serializing_if = "Option::is_none")]
         disable_parallel_tool_use: Option<bool>,
     },
     /// The model will not use tools
@@ -747,6 +717,7 @@ pub enum StopReason {
 }
 
 /// Billing and rate-limit usage
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Usage {
     /// The number of input tokens used
@@ -756,23 +727,18 @@ pub struct Usage {
     pub output_tokens: u32,
 
     /// The number of input tokens used to create the cache entry
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_creation_input_tokens: Option<u32>,
 
     /// The number of input tokens read from the cache
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_read_input_tokens: Option<u32>,
 
     /// Breakdown of cached tokens by TTL
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_creation: Option<CacheCreation>,
 
     /// Server tool usage information
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub server_tool_use: Option<ServerToolUsage>,
 
     /// Service tier used for the request
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub service_tier: Option<String>,
 }
 
@@ -825,30 +791,26 @@ pub enum MessageStreamEvent {
 }
 
 /// Message delta for streaming updates
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MessageDelta {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub stop_reason: Option<StopReason>,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub stop_sequence: Option<String>,
 }
 
 /// Usage delta for streaming updates
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MessageDeltaUsage {
     pub output_tokens: u32,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub input_tokens: Option<u32>,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_creation_input_tokens: Option<u32>,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_read_input_tokens: Option<u32>,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub server_tool_use: Option<ServerToolUsage>,
 }
 
@@ -901,6 +863,7 @@ pub enum ApiError {
 // ============================================================================
 
 /// Request to count tokens in a message
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CountMessageTokensRequest {
     /// The model to use for token counting
@@ -910,19 +873,15 @@ pub struct CountMessageTokensRequest {
     pub messages: Vec<InputMessage>,
 
     /// System prompt
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub system: Option<SystemContent>,
 
     /// Thinking configuration
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub thinking: Option<ThinkingConfig>,
 
     /// Tool choice
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_choice: Option<ToolChoice>,
 
     /// Tool definitions
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub tools: Option<Vec<Tool>>,
 }
 
@@ -967,18 +926,18 @@ pub struct ListModelsResponse {
 // ============================================================================
 
 /// Container configuration for code execution (beta)
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ContainerConfig {
     /// Container ID for reuse across requests
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
 
     /// Skills to be loaded in the container
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub skills: Option<Vec<String>>,
 }
 
 /// MCP server configuration (beta)
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct McpServerConfig {
     /// Name of the MCP server
@@ -988,23 +947,20 @@ pub struct McpServerConfig {
     pub url: String,
 
     /// Authorization token (if required)
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub authorization_token: Option<String>,
 
     /// Tool configuration for this server
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_configuration: Option<McpToolConfiguration>,
 }
 
 /// MCP tool configuration
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct McpToolConfiguration {
     /// Whether to allow all tools
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub enabled: Option<bool>,
 
     /// Allowed tool names
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub allowed_tools: Option<Vec<String>>,
 }
 
@@ -1033,25 +989,24 @@ pub struct McpToolUseBlock {
 }
 
 /// MCP tool result block (beta) - for user messages
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct McpToolResultBlock {
     /// The ID of the tool use this is a result for
     pub tool_use_id: String,
 
     /// The result content
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<ToolResultContent>,
 
     /// Whether this result indicates an error
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub is_error: Option<bool>,
 
     /// Cache control for this block
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_control: Option<CacheControl>,
 }
 
 /// MCP toolset definition (beta)
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct McpToolset {
     #[serde(rename = "type")]
@@ -1061,39 +1016,34 @@ pub struct McpToolset {
     pub mcp_server_name: String,
 
     /// Default configuration applied to all tools from this server
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub default_config: Option<McpToolDefaultConfig>,
 
     /// Configuration overrides for specific tools
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub configs: Option<HashMap<String, McpToolConfig>>,
 
     /// Cache control for this toolset
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_control: Option<CacheControl>,
 }
 
 /// Default configuration for MCP tools
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct McpToolDefaultConfig {
     /// Whether tools are enabled
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub enabled: Option<bool>,
 
     /// Whether to defer loading
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub defer_loading: Option<bool>,
 }
 
 /// Per-tool MCP configuration
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct McpToolConfig {
     /// Whether this tool is enabled
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub enabled: Option<bool>,
 
     /// Whether to defer loading
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub defer_loading: Option<bool>,
 }
 
@@ -1102,6 +1052,7 @@ pub struct McpToolConfig {
 // ============================================================================
 
 /// Code execution tool (beta)
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CodeExecutionTool {
     #[serde(rename = "type")]
@@ -1110,19 +1061,15 @@ pub struct CodeExecutionTool {
     pub name: String, // "code_execution"
 
     /// Allowed callers for this tool
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub allowed_callers: Option<Vec<String>>,
 
     /// Whether to defer loading
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub defer_loading: Option<bool>,
 
     /// Whether to use strict mode
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub strict: Option<bool>,
 
     /// Cache control for this tool
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_control: Option<CacheControl>,
 }
 
@@ -1336,6 +1283,7 @@ pub enum TextEditorCodeExecutionToolResultErrorCode {
 // ============================================================================
 
 /// Web fetch tool (beta)
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WebFetchTool {
     #[serde(rename = "type")]
@@ -1344,15 +1292,12 @@ pub struct WebFetchTool {
     pub name: String, // "web_fetch"
 
     /// Allowed callers for this tool
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub allowed_callers: Option<Vec<String>>,
 
     /// Maximum number of uses
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_uses: Option<u32>,
 
     /// Cache control for this tool
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_control: Option<CacheControl>,
 }
 
@@ -1422,6 +1367,7 @@ pub enum WebFetchToolResultErrorCode {
 // ============================================================================
 
 /// Tool search tool (beta)
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ToolSearchTool {
     #[serde(rename = "type")]
@@ -1430,11 +1376,9 @@ pub struct ToolSearchTool {
     pub name: String,
 
     /// Allowed callers for this tool
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub allowed_callers: Option<Vec<String>>,
 
     /// Cache control for this tool
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_control: Option<CacheControl>,
 }
 
@@ -1506,6 +1450,7 @@ pub struct ContainerUploadBlock {
 // ============================================================================
 
 /// Memory tool (beta)
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MemoryTool {
     #[serde(rename = "type")]
@@ -1514,23 +1459,18 @@ pub struct MemoryTool {
     pub name: String, // "memory"
 
     /// Allowed callers for this tool
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub allowed_callers: Option<Vec<String>>,
 
     /// Whether to defer loading
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub defer_loading: Option<bool>,
 
     /// Whether to use strict mode
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub strict: Option<bool>,
 
     /// Input examples
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub input_examples: Option<Vec<Value>>,
 
     /// Cache control for this tool
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_control: Option<CacheControl>,
 }
 
@@ -1539,6 +1479,7 @@ pub struct MemoryTool {
 // ============================================================================
 
 /// Computer use tool (beta)
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ComputerUseTool {
     #[serde(rename = "type")]
@@ -1553,15 +1494,12 @@ pub struct ComputerUseTool {
     pub display_height_px: u32,
 
     /// Display number (optional)
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub display_number: Option<u32>,
 
     /// Allowed callers for this tool
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub allowed_callers: Option<Vec<String>>,
 
     /// Cache control for this tool
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_control: Option<CacheControl>,
 }
 
@@ -1606,13 +1544,13 @@ pub enum BetaInputContentBlock {
 }
 
 /// Beta output content block types (extends ContentBlock)
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum BetaContentBlock {
     // Standard types
     Text {
         text: String,
-        #[serde(skip_serializing_if = "Option::is_none")]
         citations: Option<Vec<Citation>>,
     },
     ToolUse {
@@ -1646,9 +1584,7 @@ pub enum BetaContentBlock {
     },
     McpToolResult {
         tool_use_id: String,
-        #[serde(skip_serializing_if = "Option::is_none")]
         content: Option<ToolResultContent>,
-        #[serde(skip_serializing_if = "Option::is_none")]
         is_error: Option<bool>,
     },
 
@@ -1679,7 +1615,6 @@ pub enum BetaContentBlock {
     },
     ToolReference {
         tool_name: String,
-        #[serde(skip_serializing_if = "Option::is_none")]
         description: Option<String>,
     },
 
@@ -1687,7 +1622,6 @@ pub enum BetaContentBlock {
     ContainerUpload {
         file_id: String,
         file_name: String,
-        #[serde(skip_serializing_if = "Option::is_none")]
         file_path: Option<String>,
     },
 }

--- a/protocols/src/rerank.rs
+++ b/protocols/src/rerank.rs
@@ -118,20 +118,19 @@ impl RerankRequest {
 }
 
 /// Individual rerank result
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RerankResult {
     /// Relevance score for the document
     pub score: f32,
 
     /// The document text (if return_documents was true)
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub document: Option<String>,
 
     /// Original index of the document in the request
     pub index: usize,
 
     /// Additional metadata about the ranking
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub meta_info: Option<HashMap<String, Value>>,
 }
 

--- a/protocols/src/responses.rs
+++ b/protocols/src/responses.rs
@@ -20,6 +20,7 @@ use crate::{builders::ResponsesResponseBuilder, validated::Normalizable};
 // Response Tools (MCP and others)
 // ============================================================================
 
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ResponseTool {
     #[serde(rename = "type")]
@@ -27,23 +28,15 @@ pub struct ResponseTool {
     // Function tool fields (used when type == "function")
     // In Responses API, function fields are flattened at the top level
     #[serde(flatten)]
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub function: Option<Function>,
     // MCP-specific fields (used when type == "mcp")
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub server_url: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub authorization: Option<String>,
     /// Custom headers to send to MCP server (from request payload, not HTTP headers)
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub headers: Option<HashMap<String, String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub server_label: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub server_description: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub require_approval: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub allowed_tools: Option<Vec<String>>,
 }
 
@@ -76,12 +69,11 @@ pub enum ResponseToolType {
 // Reasoning Parameters
 // ============================================================================
 
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ResponseReasoningParam {
     #[serde(default = "default_reasoning_effort")]
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub effort: Option<ReasoningEffort>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub summary: Option<ReasoningSummary>,
 }
 
@@ -197,16 +189,16 @@ pub enum ResponseReasoningContent {
 }
 
 /// MCP Tool information for the mcp_list_tools output item
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct McpToolInfo {
     pub name: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     pub input_schema: Value,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub annotations: Option<Value>,
 }
 
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(tag = "type")]
 #[serde(rename_all = "snake_case")]
@@ -223,7 +215,6 @@ pub enum ResponseOutputItem {
         id: String,
         summary: Vec<String>,
         content: Vec<ResponseReasoningContent>,
-        #[serde(skip_serializing_if = "Option::is_none")]
         status: Option<String>,
     },
     #[serde(rename = "function_call")]
@@ -232,7 +223,6 @@ pub enum ResponseOutputItem {
         call_id: String,
         name: String,
         arguments: String,
-        #[serde(skip_serializing_if = "Option::is_none")]
         output: Option<String>,
         status: String,
     },
@@ -246,10 +236,8 @@ pub enum ResponseOutputItem {
     McpCall {
         id: String,
         status: String,
-        #[serde(skip_serializing_if = "Option::is_none")]
         approval_request_id: Option<String>,
         arguments: String,
-        #[serde(skip_serializing_if = "Option::is_none")]
         error: Option<String>,
         name: String,
         output: String,
@@ -266,9 +254,7 @@ pub enum ResponseOutputItem {
         id: String,
         status: CodeInterpreterCallStatus,
         container_id: String,
-        #[serde(skip_serializing_if = "Option::is_none")]
         code: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none")]
         outputs: Option<Vec<CodeInterpreterOutput>>,
     },
     #[serde(rename = "file_search_call")]
@@ -276,7 +262,6 @@ pub enum ResponseOutputItem {
         id: String,
         status: FileSearchCallStatus,
         queries: Vec<String>,
-        #[serde(skip_serializing_if = "Option::is_none")]
         results: Option<Vec<FileSearchResult>>,
     },
 }
@@ -355,15 +340,13 @@ pub enum FileSearchCallStatus {
 }
 
 /// A result from file search.
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct FileSearchResult {
     pub file_id: String,
     pub filename: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub text: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub score: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub attributes: Option<Value>,
 }
 
@@ -400,11 +383,10 @@ pub enum ResponseStatus {
     Cancelled,
 }
 
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ReasoningInfo {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub effort: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub summary: Option<String>,
 }
 
@@ -420,6 +402,7 @@ pub struct TextConfig {
 }
 
 /// Text format: text (default), json_object (legacy), or json_schema (recommended)
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(tag = "type")]
 pub enum TextFormat {
@@ -433,9 +416,7 @@ pub enum TextFormat {
     JsonSchema {
         name: String,
         schema: Value,
-        #[serde(skip_serializing_if = "Option::is_none")]
         description: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none")]
         strict: Option<bool>,
     },
 }
@@ -462,14 +443,13 @@ pub enum IncludeField {
 // ============================================================================
 
 /// OpenAI Responses API usage format (different from standard UsageInfo)
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ResponseUsage {
     pub input_tokens: u32,
     pub output_tokens: u32,
     pub total_tokens: u32,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub input_tokens_details: Option<InputTokensDetails>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub output_tokens_details: Option<OutputTokensDetails>,
 }
 
@@ -1213,6 +1193,7 @@ pub fn generate_id(prefix: &str) -> String {
     format!("{}_{}", prefix, hex_string)
 }
 
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ResponsesResponse {
     /// Response ID
@@ -1229,19 +1210,15 @@ pub struct ResponsesResponse {
     pub status: ResponseStatus,
 
     /// Error information if status is failed
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<Value>,
 
     /// Incomplete details if response was truncated
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub incomplete_details: Option<Value>,
 
     /// System instructions used
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub instructions: Option<String>,
 
     /// Max output tokens setting
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_output_tokens: Option<u32>,
 
     /// Model name
@@ -1256,11 +1233,9 @@ pub struct ResponsesResponse {
     pub parallel_tool_calls: bool,
 
     /// Previous response ID if this is a continuation
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub previous_response_id: Option<String>,
 
     /// Reasoning information
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning: Option<ReasoningInfo>,
 
     /// Whether the response is stored
@@ -1268,11 +1243,9 @@ pub struct ResponsesResponse {
     pub store: bool,
 
     /// Temperature setting used
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub temperature: Option<f32>,
 
     /// Text format settings
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub text: Option<TextConfig>,
 
     /// Tool choice setting
@@ -1284,23 +1257,18 @@ pub struct ResponsesResponse {
     pub tools: Vec<ResponseTool>,
 
     /// Top-p setting used
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub top_p: Option<f32>,
 
     /// Truncation strategy used
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub truncation: Option<String>,
 
     /// Usage information
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub usage: Option<ResponsesUsage>,
 
     /// User identifier
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<String>,
 
     /// Safety identifier for content moderation
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub safety_identifier: Option<String>,
 
     /// Additional metadata

--- a/protocols/src/sampling_params.rs
+++ b/protocols/src/sampling_params.rs
@@ -4,59 +4,41 @@ use validator::Validate;
 use super::common::StringOrArray;
 
 /// Sampling parameters for text generation
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Deserialize, Serialize, Default, Validate)]
 #[validate(schema(function = "validate_sampling_params"))]
 pub struct SamplingParams {
     /// Temperature for sampling (must be >= 0.0, no upper limit)
-    #[serde(skip_serializing_if = "Option::is_none")]
     #[validate(range(min = 0.0))]
     pub temperature: Option<f32>,
     /// Maximum number of new tokens to generate (must be >= 0)
-    #[serde(skip_serializing_if = "Option::is_none")]
     #[validate(range(min = 0))]
     pub max_new_tokens: Option<u32>,
     /// Top-p nucleus sampling (0.0 < top_p <= 1.0)
-    #[serde(skip_serializing_if = "Option::is_none")]
     #[validate(custom(function = "validate_top_p_value"))]
     pub top_p: Option<f32>,
     /// Top-k sampling (-1 to disable, or >= 1)
-    #[serde(skip_serializing_if = "Option::is_none")]
     #[validate(custom(function = "validate_top_k_value"))]
     pub top_k: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     #[validate(range(min = -2.0, max = 2.0))]
     pub frequency_penalty: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     #[validate(range(min = -2.0, max = 2.0))]
     pub presence_penalty: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     #[validate(range(min = 0.0, max = 2.0))]
     pub repetition_penalty: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub stop: Option<StringOrArray>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub ignore_eos: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub skip_special_tokens: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub json_schema: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub regex: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub ebnf: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     #[validate(range(min = 0.0, max = 1.0))]
     pub min_p: Option<f32>,
     /// Minimum number of new tokens (validated in schema function for cross-field check with max_new_tokens)
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub min_new_tokens: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub stop_token_ids: Option<Vec<u32>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub no_stop_trim: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub n: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub sampling_seed: Option<u64>,
 }
 

--- a/protocols/src/worker_spec.rs
+++ b/protocols/src/worker_spec.rs
@@ -17,55 +17,45 @@ use serde_json::{json, Value};
 use super::UNKNOWN_MODEL_ID;
 
 /// Worker configuration for API requests
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct WorkerConfigRequest {
     /// Worker URL (required)
     pub url: String,
 
     /// Worker API key (optional)
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub api_key: Option<String>,
 
     /// Model ID (optional, will query from server if not provided)
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub model_id: Option<String>,
 
     /// Worker priority (optional, default: 50, higher = preferred)
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub priority: Option<u32>,
 
     /// Worker cost factor (optional, default: 1.0)
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub cost: Option<f32>,
 
     /// Worker type (optional: "regular", "prefill", "decode")
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub worker_type: Option<String>,
 
     /// Bootstrap port for prefill workers (optional)
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub bootstrap_port: Option<u16>,
 
     /// Runtime type (optional: "sglang", "vllm", default: "sglang")
     /// Only relevant for gRPC workers
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub runtime: Option<String>,
 
     // gRPC-specific configuration (optional, ignored in HTTP mode)
     /// Tokenizer path for gRPC mode
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub tokenizer_path: Option<String>,
 
     /// Reasoning parser type for gRPC mode
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning_parser: Option<String>,
 
     /// Tool parser type for gRPC mode
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_parser: Option<String>,
 
     /// Chat template for gRPC mode
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub chat_template: Option<String>,
 
     /// Additional labels (optional)
@@ -123,6 +113,7 @@ fn default_max_connection_attempts() -> u32 {
 }
 
 /// Worker information for API responses
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Serialize)]
 pub struct WorkerInfo {
     /// Worker unique identifier
@@ -153,24 +144,18 @@ pub struct WorkerInfo {
     pub connection_mode: String,
 
     /// Runtime type (sglang or vllm, for gRPC workers)
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub runtime_type: Option<String>,
 
     // gRPC-specific fields (None for HTTP workers)
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub tokenizer_path: Option<String>,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning_parser: Option<String>,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_parser: Option<String>,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub chat_template: Option<String>,
 
     /// Bootstrap port for prefill workers
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub bootstrap_port: Option<u16>,
 
     /// Additional metadata
@@ -181,7 +166,6 @@ pub struct WorkerInfo {
     pub disable_health_check: bool,
 
     /// Job status for async operations (if available)
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub job_status: Option<JobStatus>,
 }
 
@@ -298,42 +282,34 @@ pub struct WorkerTypeStats {
 }
 
 /// Worker update request
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WorkerUpdateRequest {
     /// Update priority
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub priority: Option<u32>,
 
     /// Update cost
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub cost: Option<f32>,
 
     /// Update labels
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub labels: Option<HashMap<String, String>>,
 
     /// Update API key (for key rotation)
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub api_key: Option<String>,
 
     /// Update health check timeout in seconds
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub health_check_timeout_secs: Option<u64>,
 
     /// Update health check interval in seconds
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub health_check_interval_secs: Option<u64>,
 
     /// Update health success threshold
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub health_success_threshold: Option<u32>,
 
     /// Update health failure threshold
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub health_failure_threshold: Option<u32>,
 
     /// Disable periodic health checks for this worker
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub disable_health_check: Option<bool>,
 }
 
@@ -355,34 +331,26 @@ pub struct WorkerErrorResponse {
 }
 
 /// Server info response from /get_server_info endpoint
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Deserialize)]
 pub struct ServerInfo {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub model_id: Option<String>,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub model_path: Option<String>,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub priority: Option<u32>,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub cost: Option<f32>,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub worker_type: Option<String>,
 
     // gRPC-specific
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub tokenizer_path: Option<String>,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning_parser: Option<String>,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_parser: Option<String>,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub chat_template: Option<String>,
 }
 


### PR DESCRIPTION
## Description

### Problem

The protocols crate has ~400 repetitive `#[serde(skip_serializing_if = "Option::is_none")]` field annotations scattered across 12 files, adding visual noise and maintenance burden.

### Solution

Add the `serde_with` crate and use `#[serde_with::skip_serializing_none]` at the struct/enum level, which automatically applies `skip_serializing_if = "Option::is_none"` to all `Option<T>` fields. This removes ~290 boilerplate annotations with zero serialization behavior changes.

The macro was **only** applied to types where every `Option<T>` field already had the annotation, ensuring no behavioral differences.

## Changes

- Add `serde_with = { version = "3", features = ["macros"] }` to workspace and protocols dependencies
- Apply `#[serde_with::skip_serializing_none]` to qualifying types across 11 files
- Remove redundant per-field `#[serde(skip_serializing_if = "Option::is_none")]` from those types
- Preserve all non-Option skip patterns (`Vec::is_empty`, `HashMap::is_empty`) and `#[serde(flatten)]`

### Types skipped (not all `Option` fields were annotated — applying the macro would change serialization behavior)

| Type | Unannotated `Option` Field(s) | Reason |
|---|---|---|
| `ChatCompletionMessage` | `reasoning_content` | Intentionally serializes `None` as `null` |
| `ChatChoice` | `finish_reason` | OpenAI API: `null` in response until determined |
| `ChatMessageDelta` | `reasoning_content` | Intentionally serializes `None` as `null` |
| `ChatStreamChoice` | `logprobs`, `finish_reason` | OpenAI streaming: `null` until final chunk |
| `CompletionChoice` | `finish_reason` | Same as `ChatChoice` |
| `CompletionStreamChoice` | `finish_reason` | Same as above |
| `CompletionStreamResponse` | `system_fingerprint` | Only 1 annotation (threshold: 2+) |
| `ResponseInputOutputItem` | `id` (in `FunctionCallOutput`) | Intentionally nullable |
| `ResponseContentPart` | `logprobs` | Only 1 annotation |
| `ResponsesRequest` | `stream` | Has `#[serde(default)]` but no skip — serializes `None` as `null` |
| `GenerateRequest` | `model` | Intentionally nullable |
| `RerankRequest` | `user` | Not annotated |

## Test Plan

- `cargo check -p openai-protocol` passes
- Verified all `Vec::is_empty` / `HashMap::is_empty` / `flatten` annotations preserved
- Verified 0 remaining `Option::is_none` annotations in transformed types
- Verified 105 `Option::is_none` annotations remain in non-transformed types (unchanged)

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized JSON serialization across all API endpoints: optional empty fields are now consistently omitted from both request and response payloads instead of being included as null values, resulting in cleaner response formatting, reduced payload sizes, and improved clarity in API integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->