### PR TITLE
chore(ci): optimize Docker setup for ephemeral K8s pod runners

### DIFF
--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -317,6 +317,7 @@ jobs:
           pip uninstall -y smg || true
           pip install wheel/*.whl
           bash scripts/ci_install_e2e_deps.sh ${{ matrix.extra_deps }}
+
       - name: Setup Oracle Instant Client
         if: matrix.setup_oracle
         run: |
@@ -340,7 +341,7 @@ jobs:
       - name: Start Oracle Database
         if: matrix.setup_oracle
         run: |
-          docker run --rm -d -p 1521:1521 -e ORACLE_PASSWORD=oracle --name oracle-db gvenzl/oracle-xe:21-slim-faststart
+          docker run -d --rm -p 1521:1521 -e ORACLE_PASSWORD=oracle --name oracle-db gvenzl/oracle-xe:21-slim-faststart
           echo "Starting Oracle DB..."
 
           # Export Oracle connection environment variables
@@ -353,7 +354,7 @@ jobs:
         env:
           BRAVE_API_KEY: ${{ secrets.BRAVE_API_KEY }}
         run: |
-          docker run --rm -d \
+          docker run -d --rm \
             -p 8001:8080 \
             -e BRAVE_API_KEY \
             --name brave-search-server \


### PR DESCRIPTION
## Description

  ### Problem

The first `docker run` on a fresh DinD pod is slow due to Docker daemon cold start. K8s pod runners pull Docker images (Oracle XE, Brave MCP) from Docker Hub on every CI run because pods are ephemeral and have no persistent image cache. Additionally, Docker container cleanup steps cause unnecessary delays since the pod is destroyed after job completion. 

  ### Solution
  - Pull image from docker hub is actually not the bottleneck. Using cache and reload might also slower than directly pull, so didn't adopt the cache solution
  - Remove Docker container cleanup steps as K8s pod is destroyed after job completion
  - Add Docker daemon warmup step to avoid cold-start penalty on first container
  - Switch Oracle image to `21-slim-faststart` for faster DB startup

  ## Changes
  - Remove `Cleanup Brave MCP Server` and `Cleanup Oracle Database` steps
  - Add `docker info` warmup step (conditional on `setup_oracle || setup_brave`)
  - Switch `gvenzl/oracle-xe:21-slim` → `gvenzl/oracle-xe:21-slim-faststart`

## Test Plan

<!-- Provide a thorough reproducible test showing before and after behavior. -->

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized CI/CD workflow for end-to-end testing pipeline.
  * Improved Docker resource management by adding container cleanup.
  * Enhanced Oracle Database initialization with faster startup configuration.
  * Streamlined artifact handling during test preparation stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->