### PR TITLE
fix(docs): add light mode support for custom CSS theme

### DIFF
--- a/docs/assets/stylesheets/extra.css
+++ b/docs/assets/stylesheets/extra.css
@@ -60,17 +60,13 @@
 [data-md-color-scheme="default"] .md-typeset .hero h1 {
   background: linear-gradient(
     135deg,
-    #18181b 0%,
-    #18181b 20%,
+    var(--md-code-fg-color) 0%,
+    var(--md-code-fg-color) 20%,
     var(--mesh-purple) 40%,
     var(--mesh-cyan) 60%,
     var(--mesh-blue) 80%,
-    #18181b 100%
+    var(--md-code-fg-color) 100%
   );
-  background-size: 200% 200%;
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
 }
 
 /* Hero last paragraph */
@@ -123,11 +119,7 @@
 
 /* Stat values: dark gradient instead of white */
 [data-md-color-scheme="default"] .md-typeset .stat-value {
-  background: linear-gradient(135deg, #18181b 0%, var(--mesh-purple) 50%, var(--mesh-cyan) 100%);
-  background-size: 200% 200%;
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  background: linear-gradient(135deg, var(--md-code-fg-color) 0%, var(--mesh-purple) 50%, var(--mesh-cyan) 100%);
 }
 
 [data-md-color-scheme="default"] .md-typeset .stat-label {


### PR DESCRIPTION
## Description

### Problem

Switching to light mode in the docs site renders the entire UI broken — all text is invisible (white on white), the header/navigation disappears, and cards/buttons/stats are unreadable. This is because the custom CSS in `extra.css` was built entirely for dark mode with hardcoded dark backgrounds, white text, and `rgba(255,255,255,*)` borders throughout.

### Solution

Add comprehensive `[data-md-color-scheme="default"]` overrides for all custom components, and scope dark-mode-specific overrides to `[data-md-color-scheme="slate"]` only so light mode falls back to MkDocs Material's native styling.

## Changes

- **Light theme variables**: Add `--md-typeset-a-color`, `--md-code-bg-color`, `--md-code-fg-color` for the default scheme
- **Hero section**: Fade to white instead of black (`::after`), dark gradient text instead of white for `h1`
- **Cards**: White background with subtle purple border and shadow, dark text colors
- **Buttons**: Primary uses indigo gradient with white text; secondary uses light indigo tint with indigo text
- **Stats**: Dark-to-purple gradient text instead of white-to-purple
- **Backend pills**: Dark text with subtle indigo border instead of white text with white border
- **Community links**: Dark text with visible border
- **h2 underline**: Remove glow effect in light mode
- **Header/tabs/sidebar**: Scope `background` override to `[data-md-color-scheme="slate"]` only — light mode now uses Material's native colored header

## Test Plan

- Run `mkdocs serve` and toggle between dark and light mode using the theme switcher
- Verify in light mode: header, nav tabs, hero text, cards, buttons, stats, backend pills, and all body text are readable
- Verify dark mode is unchanged

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] (Optional) Documentation updated

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Enhanced light-mode theme: updated hero visuals (gradient title/subtitle and subtle after-element), cards, buttons, stat blocks, pills, and community link styles.
  * Improved gradients, hover/glow effects, and typography for better contrast and readability in light mode.
  * Scoped navigation/header/sidebar rules for more consistent dark-mode behavior and reduced broad overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->