### PR TITLE
fix(docs): restore gradient text rendering in light mode

### DIFF
--- a/docs/assets/stylesheets/extra.css
+++ b/docs/assets/stylesheets/extra.css
@@ -56,7 +56,9 @@
   background: linear-gradient(to bottom, transparent 0%, #fff 100%);
 }
 
-/* Hero title: dark gradient text instead of white */
+/* Hero title: dark gradient text instead of white.
+   background shorthand resets background-clip and background-size,
+   so all properties must be re-declared here. */
 [data-md-color-scheme="default"] .md-typeset .hero h1 {
   background: linear-gradient(
     135deg,
@@ -67,6 +69,15 @@
     var(--mesh-blue) 80%,
     var(--md-code-fg-color) 100%
   );
+  background-size: 200% 200%;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+/* Hero mesh blobs: reduce opacity on light background */
+[data-md-color-scheme="default"] .md-typeset .hero::before {
+  opacity: 0.3;
 }
 
 /* Hero last paragraph */
@@ -117,9 +128,15 @@
   border-color: rgba(79, 70, 229, 0.4);
 }
 
-/* Stat values: dark gradient instead of white */
+/* Stat values: dark gradient instead of white.
+   background shorthand resets background-clip and background-size,
+   so all properties must be re-declared here. */
 [data-md-color-scheme="default"] .md-typeset .stat-value {
   background: linear-gradient(135deg, var(--md-code-fg-color) 0%, var(--mesh-purple) 50%, var(--mesh-cyan) 100%);
+  background-size: 200% 200%;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
 }
 
 [data-md-color-scheme="default"] .md-typeset .stat-label {


### PR DESCRIPTION
## Description

### Problem

The light mode CSS from #355 incorrectly removed `background-size`, `-webkit-background-clip`, `-webkit-text-fill-color`, and `background-clip` from the hero title and stat value overrides, following a code review suggestion. This caused gradient text to render as solid gradient blocks instead of being clipped to the text shape.

The hero mesh background blobs are also too saturated (opacity 0.6) on a light background.

### Solution

Re-declare the properties that the `background` shorthand resets — `background-size`, `-webkit-background-clip`, `-webkit-text-fill-color`, `background-clip`. These are **not** redundant: the CSS `background` shorthand resets all its sub-properties (including `background-clip` and `background-size`) to initial values, so they must be explicitly set again in any rule that uses `background:`.

Reduce hero mesh blob opacity to 0.3 in light mode for a subtler effect.

## Changes

- `docs/assets/stylesheets/extra.css`:
  - Restore `background-size`, `-webkit-background-clip`, `-webkit-text-fill-color`, `background-clip` on light mode hero h1 and stat-value rules
  - Add light mode override for `.hero::before` with `opacity: 0.3`
  - Add comments explaining why these properties are required

## Test Plan

- `mkdocs serve`, toggle to light mode
- Verify hero title "Shepherd Model Gateway" renders as gradient text (not a solid block)
- Verify stat values (70%, <1ms, 40+, 100%) render as gradient text
- Verify hero mesh background is subtle, not overpowering
- Toggle back to dark mode and verify no regressions

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] (Optional) Documentation updated

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined gradient text effects in hero section title and stat values to maintain consistent visual styling across application themes
  * Enhanced hero section visual design by adjusting the opacity of decorative elements on light color schemes for improved content visibility
  * Improved overall visual hierarchy and content readability through strategic styling adjustments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->