### PR TITLE
refactor(mcp): simplify ensure_request_mcp_client and remove McpLoopConfig

### DIFF
--- a/model_gateway/src/routers/grpc/common/responses/utils.rs
+++ b/model_gateway/src/routers/grpc/common/responses/utils.rs
@@ -57,7 +57,7 @@ pub(crate) async fn ensure_mcp_connection(
 
     if let Some(tools) = tools {
         match ensure_request_mcp_client(mcp_orchestrator, tools).await {
-            Some((_orchestrator, mcp_servers)) => {
+            Some(mcp_servers) => {
                 return Ok((true, mcp_servers));
             }
             None => {

--- a/model_gateway/src/routers/openai/responses/non_streaming.rs
+++ b/model_gateway/src/routers/openai/responses/non_streaming.rs
@@ -18,7 +18,7 @@ use crate::{
     mcp::McpToolSession,
     routers::{
         header_utils::{apply_provider_headers, extract_auth_header},
-        mcp_utils::{ensure_request_mcp_client, McpLoopConfig},
+        mcp_utils::ensure_request_mcp_client,
         openai::context::{PayloadState, RequestContext},
         persistence_utils::persist_conversation_items,
     },
@@ -57,8 +57,8 @@ pub async fn handle_non_streaming_response(mut ctx: RequestContext) -> Response 
         }
     };
 
-    // Check for MCP tools and create request context if needed
-    let mcp_result = if let Some(tools) = original_body.tools.as_deref() {
+    // Check for MCP tools and create session if needed
+    let mcp_servers = if let Some(tools) = original_body.tools.as_deref() {
         ensure_request_mcp_client(mcp_orchestrator, tools).await
     } else {
         None
@@ -66,17 +66,13 @@ pub async fn handle_non_streaming_response(mut ctx: RequestContext) -> Response 
 
     let mut response_json: Value;
 
-    if let Some((orchestrator, mcp_servers)) = mcp_result {
+    if let Some(mcp_servers) = mcp_servers {
         let session_request_id = original_body
             .request_id
             .clone()
             .unwrap_or_else(|| format!("req_{}", uuid::Uuid::new_v4()));
-        let session = McpToolSession::new(&orchestrator, mcp_servers.clone(), &session_request_id);
+        let session = McpToolSession::new(mcp_orchestrator, mcp_servers, &session_request_id);
         prepare_mcp_tools_as_functions(&mut payload, &session);
-        let config = McpLoopConfig {
-            mcp_servers,
-            ..McpLoopConfig::default()
-        };
 
         match execute_tool_loop(
             ctx.components.client(),
@@ -85,7 +81,6 @@ pub async fn handle_non_streaming_response(mut ctx: RequestContext) -> Response 
             payload,
             original_body,
             &session,
-            &config,
         )
         .await
         {


### PR DESCRIPTION
## Description

### Problem

MCP session setup in the OpenAI path had unnecessary indirection:
- `ensure_request_mcp_client` returned a redundant `Arc<McpOrchestrator>` clone that callers already had.
- `McpLoopConfig` was a thin wrapper around `max_iterations` + `mcp_servers` with no real value.

### Solution

- Simplify `ensure_request_mcp_client` to return `Option<Vec<(String, String)>>` — callers already hold the orchestrator.
- Delete `McpLoopConfig` struct and `impl Default` — callers reference `DEFAULT_MAX_ITERATIONS` directly and pass `mcp_servers` as a plain `Vec`.

## Changes

- `mcp_utils.rs`: Simplified return type, removed `McpLoopConfig`
- `openai/responses/non_streaming.rs`: Use simplified `ensure_request_mcp_client`, create `McpToolSession` directly
- `openai/responses/streaming.rs`: Replace `McpLoopConfig` with direct `mcp_servers` + `DEFAULT_MAX_ITERATIONS`
- `openai/responses/mcp.rs`: Remove `config` param from `execute_tool_loop`, use `DEFAULT_MAX_ITERATIONS`
- `grpc/common/responses/utils.rs`: Update `ensure_mcp_connection` for new return type

## Test Plan

```bash
cargo build -p smg
cargo test -p smg --lib   # 340 tests pass
```

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified MCP tool handling by streamlining configuration management and function signatures.
  * Improved code maintainability by consolidating configuration parameters with a constant-based approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->