### PR TITLE
chore: fix nightly benchmark, prevent execution when pushing to main

### DIFF
--- a/.github/workflows/nightly-benchmark.yml
+++ b/.github/workflows/nightly-benchmark.yml
@@ -3,12 +3,6 @@ name: Nightly Benchmark
 on:
   schedule:
     - cron: '0 0 * * *'
-  push:
-    branches: [ main ]
-    paths-ignore:
-      - "docs/**"
-      - "mkdocs.yml"
-      - "*.md"
   workflow_dispatch:
     inputs:
       models:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated nightly benchmark workflow configuration to remove automatic triggering on code pushes to main. The workflow now executes only via scheduled intervals and manual triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->