### PR TITLE
docs: add Slack invite links

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License"></a>
   <a href="https://lightseekorg.github.io/smg"><img src="https://img.shields.io/badge/docs-latest-brightgreen.svg" alt="Docs"></a>
   <a href="https://discord.gg/wkQ73CVTvR"><img src="https://img.shields.io/badge/Discord-Join%20Us-5865F2?logo=discord&logoColor=white" alt="Discord"></a>
+  <a href="https://join.slack.com/t/lightseekorg/shared_invite/zt-3py6mpreo-XUGd064dSsWeQizh3YKQrQ"><img src="https://img.shields.io/badge/Slack-Join%20Us-4A154B?logo=slack&logoColor=white" alt="Slack"></a>
 </p>
 
 High-performance model-routing gateway for large-scale LLM deployments. Centralizes worker lifecycle management, balances traffic across HTTP/gRPC/OpenAI-compatible backends, and provides enterprise-ready control over history storage, MCP tooling, and privacy-sensitive workflows.

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -143,7 +143,7 @@ docs(readme): update installation instructions
 
 - **Questions**: Open a [GitHub Discussion](https://github.com/lightseekorg/smg/discussions)
 - **Bugs**: Open an [Issue](https://github.com/lightseekorg/smg/issues)
-- **Chat**: Join our community on [Discord](https://discord.gg/wkQ73CVTvR)
+- **Chat**: Join our community on [Discord](https://discord.gg/wkQ73CVTvR) or [Slack](https://join.slack.com/t/lightseekorg/shared_invite/zt-3py6mpreo-XUGd064dSsWeQizh3YKQrQ)
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -182,5 +182,5 @@ Complete reference for the OpenAI-compatible API and SMG extensions.
 </div>
 
 <div class="community-links" markdown>
-:fontawesome-brands-github: [GitHub](https://github.com/lightseekorg/smg) · :fontawesome-brands-slack: [Slack](https://lightseekorg.slack.com) · :fontawesome-brands-discord: [Discord](https://discord.gg/wkQ73CVTvR)
+:fontawesome-brands-github: [GitHub](https://github.com/lightseekorg/smg) · :fontawesome-brands-slack: [Slack](https://join.slack.com/t/lightseekorg/shared_invite/zt-3py6mpreo-XUGd064dSsWeQizh3YKQrQ) · :fontawesome-brands-discord: [Discord](https://discord.gg/wkQ73CVTvR)
 </div>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,7 +78,7 @@ extra:
     - icon: fontawesome/brands/github
       link: https://github.com/lightseekorg/smg
     - icon: fontawesome/brands/slack
-      link: https://lightseekorg.slack.com
+      link: https://join.slack.com/t/lightseekorg/shared_invite/zt-3py6mpreo-XUGd064dSsWeQizh3YKQrQ
   generator: false
   version:
     provider: mike


### PR DESCRIPTION
## Summary
Add Slack community invite links across documentation and README, replacing placeholder URLs with the shared invite link.

## What changed
- **README.md**: Added Slack shield badge with invite link next to existing Discord badge
- **docs/index.md**: Updated Slack link from placeholder (`lightseekorg.slack.com`) to shared invite URL
- **docs/contributing/index.md**: Added Slack as an additional chat option alongside Discord in Getting Help section
- **mkdocs.yml**: Updated social footer Slack link to shared invite URL

## Why
We created a new Slack workspace for the community. The existing placeholder URLs (`lightseekorg.slack.com`) didn't allow users to join — this replaces them with a proper shared invite link so anyone can join directly.

## Test plan
- [ ] Verify Slack badge renders correctly in README
- [ ] Verify Slack link works in docs landing page
- [ ] Verify contributing page shows both Discord and Slack
- [ ] Verify mkdocs footer social link points to invite URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Slack community invite links to README and contributing documentation.
  * Updated Slack invitation URLs across documentation and site configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->