### PR TITLE
refactor(mcp): add session-level tool builder convenience methods

### DIFF
--- a/mcp/src/core/session.rs
+++ b/mcp/src/core/session.rs
@@ -199,6 +199,50 @@ impl<'a> McpToolSession<'a> {
             .unwrap_or(ResponseFormat::Passthrough)
     }
 
+    /// Build function-tool JSON payloads for upstream model calls.
+    pub fn build_function_tools_json(&self) -> Vec<serde_json::Value> {
+        crate::responses_bridge::build_function_tools_json_with_names(
+            &self.mcp_tools,
+            Some(&self.exposed_name_by_qualified),
+        )
+    }
+
+    /// Build Chat API `Tool` structs for chat completions.
+    pub fn build_chat_function_tools(&self) -> Vec<openai_protocol::common::Tool> {
+        crate::responses_bridge::build_chat_function_tools_with_names(
+            &self.mcp_tools,
+            Some(&self.exposed_name_by_qualified),
+        )
+    }
+
+    /// Build Responses API `ResponseTool` structs.
+    pub fn build_response_tools(&self) -> Vec<openai_protocol::responses::ResponseTool> {
+        crate::responses_bridge::build_response_tools_with_names(
+            &self.mcp_tools,
+            Some(&self.exposed_name_by_qualified),
+        )
+    }
+
+    /// Build `mcp_list_tools` JSON for a specific server.
+    pub fn build_mcp_list_tools_json(
+        &self,
+        server_label: &str,
+        server_key: &str,
+    ) -> serde_json::Value {
+        let tools = self.list_tools_for_server(server_key);
+        crate::responses_bridge::build_mcp_list_tools_json(server_label, &tools)
+    }
+
+    /// Build typed `mcp_list_tools` output item for a specific server.
+    pub fn build_mcp_list_tools_item(
+        &self,
+        server_label: &str,
+        server_key: &str,
+    ) -> openai_protocol::responses::ResponseOutputItem {
+        let tools = self.list_tools_for_server(server_key);
+        crate::responses_bridge::build_mcp_list_tools_item(server_label, &tools)
+    }
+
     fn build_exposed_function_tools(
         tools: &[ToolEntry],
         mcp_servers: &[(String, String)],

--- a/model_gateway/src/routers/grpc/harmony/responses/common.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/common.rs
@@ -8,7 +8,7 @@ use uuid::Uuid;
 use super::execution::ToolResult;
 use crate::{
     data_connector::ResponseId,
-    mcp::{build_mcp_list_tools_item as mcp_build_list_tools_item, McpToolSession},
+    mcp::McpToolSession,
     protocols::{
         common::{ToolCall, ToolChoice, ToolChoiceValue},
         responses::{
@@ -178,21 +178,11 @@ pub(super) fn build_next_request_with_tools(
     Ok(request)
 }
 
-/// Inject MCP metadata into final response
-///
-/// Adds mcp_list_tools and tool output items to the response output array.
-/// The output items respect the tool's response_format configuration
-/// (McpCall, WebSearchCall, CodeInterpreterCall, FileSearchCall).
-///
-/// Following non-Harmony pipeline pattern:
-/// 1. Prepend mcp_list_tools for each server at the beginning
-/// 2. Append all tool output items at the end
 pub(super) fn inject_mcp_metadata(
     response: &mut ResponsesResponse,
     tracking: &McpCallTracking,
     session: &McpToolSession<'_>,
 ) {
-    let mcp_tools = session.mcp_tools();
     let mcp_servers = session.mcp_servers();
 
     // Collect tool output items (already transformed with correct type)
@@ -205,13 +195,7 @@ pub(super) fn inject_mcp_metadata(
     // Inject into response output:
     // 1. Prepend mcp_list_tools for each server at the beginning
     for (label, key) in mcp_servers.iter().rev() {
-        let tools_for_server: Vec<_> = mcp_tools
-            .iter()
-            .filter(|entry| entry.server_key() == key)
-            .cloned()
-            .collect();
-        let mcp_list_tools = mcp_build_list_tools_item(label, &tools_for_server);
-
+        let mcp_list_tools = session.build_mcp_list_tools_item(label, key);
         response.output.insert(0, mcp_list_tools);
     }
 

--- a/model_gateway/src/routers/grpc/harmony/responses/execution.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/execution.rs
@@ -6,7 +6,7 @@ use tracing::{debug, error};
 
 use super::common::McpCallTracking;
 use crate::{
-    mcp::{build_response_tools_with_names, McpToolSession, ToolExecutionInput},
+    mcp::{McpToolSession, ToolExecutionInput},
     observability::metrics::{metrics_labels, Metrics},
     protocols::{common::ToolCall, responses::ResponseTool},
 };
@@ -103,15 +103,8 @@ pub(super) async fn execute_mcp_tools(
     Ok(results)
 }
 
-/// Convert MCP tools to Responses API tool format
-///
-/// Converts MCP ToolEntry (from inventory) to ResponseTool format so the model
-/// knows about available MCP tools when making tool calls.
 pub(crate) fn convert_mcp_tools_to_response_tools(
     session: &McpToolSession<'_>,
 ) -> Vec<ResponseTool> {
-    build_response_tools_with_names(
-        session.mcp_tools(),
-        Some(session.exposed_name_by_qualified()),
-    )
+    session.build_response_tools()
 }

--- a/model_gateway/src/routers/grpc/regular/responses/common.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/common.rs
@@ -6,17 +6,12 @@
 //! - MCP metadata builders
 //! - Conversation history loading
 
-use std::sync::Arc;
-
 use axum::response::Response;
 use tracing::{debug, warn};
 
 use crate::{
     data_connector::{self, ConversationId, ResponseId},
-    mcp::{
-        build_chat_function_tools_with_names,
-        build_mcp_list_tools_item as mcp_build_list_tools_item, McpOrchestrator, McpToolSession,
-    },
+    mcp::McpToolSession,
     protocols::{
         chat::ChatCompletionRequest,
         common::{Tool, ToolChoice, ToolChoiceValue},
@@ -142,22 +137,8 @@ pub(super) fn extract_all_tool_calls_from_chat(
     }
 }
 
-/// Convert MCP tools to Chat API tool format
 pub(super) fn convert_mcp_tools_to_chat_tools(session: &McpToolSession<'_>) -> Vec<Tool> {
-    build_chat_function_tools_with_names(
-        session.mcp_tools(),
-        Some(session.exposed_name_by_qualified()),
-    )
-}
-
-/// Build mcp_list_tools output item
-pub(super) fn build_mcp_list_tools_item(
-    mcp: &Arc<McpOrchestrator>,
-    server_label: &str,
-    server_keys: &[String],
-) -> ResponseOutputItem {
-    let tools = mcp.list_tools_for_servers(server_keys);
-    mcp_build_list_tools_item(server_label, &tools)
+    session.build_chat_function_tools()
 }
 
 // ============================================================================

--- a/model_gateway/src/routers/grpc/regular/responses/non_streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/non_streaming.rs
@@ -13,9 +13,8 @@ use tracing::{debug, error, trace, warn};
 
 use super::{
     common::{
-        build_mcp_list_tools_item, build_next_request, convert_mcp_tools_to_chat_tools,
-        extract_all_tool_calls_from_chat, load_conversation_history, prepare_chat_tools_and_choice,
-        ExtractedToolCall, ToolLoopState,
+        build_next_request, convert_mcp_tools_to_chat_tools, extract_all_tool_calls_from_chat,
+        load_conversation_history, prepare_chat_tools_and_choice, ExtractedToolCall, ToolLoopState,
     },
     conversions,
 };
@@ -401,11 +400,7 @@ pub(super) async fn execute_tool_loop(
             if state.total_calls > 0 {
                 // Prepend mcp_list_tools items for each server
                 for (label, key) in session.mcp_servers().iter().rev() {
-                    let mcp_list_tools = build_mcp_list_tools_item(
-                        &ctx.mcp_orchestrator,
-                        label,
-                        std::slice::from_ref(key),
-                    );
+                    let mcp_list_tools = session.build_mcp_list_tools_item(label, key);
                     responses_response.output.insert(0, mcp_list_tools);
                 }
 


### PR DESCRIPTION
## Description

### Problem

Every router call site manually threads `(session.mcp_tools(), Some(session.exposed_name_by_qualified()))` into the centralized `responses_bridge` builder functions. This session boilerplate is duplicated across all three routers (OpenAI, gRPC Regular, gRPC Harmony), and the OpenAI router had its own `build_mcp_list_tools_item_from_session` helper to encapsulate one specific pattern.

### Solution

Add 5 convenience methods directly to `McpToolSession` that combine session state with bridge functions, then simplify all router call sites to use them. This eliminates the repeated parameter threading without moving or restructuring the core bridge logic.

## Changes

**`mcp/src/core/session.rs`**
- Add `build_function_tools_json()` — function-tool JSON payloads for upstream model calls
- Add `build_chat_function_tools()` — Chat API `Tool` structs for chat completions
- Add `build_response_tools()` — Responses API `ResponseTool` structs
- Add `build_mcp_list_tools_json(label, key)` — `mcp_list_tools` as JSON `Value`
- Add `build_mcp_list_tools_item(label, key)` — `mcp_list_tools` as typed `ResponseOutputItem`

**`model_gateway/src/routers/openai/responses/mcp.rs`**
- Simplify `prepare_mcp_tools_as_functions` to use `session.build_function_tools_json()`
- Replace all 4 call sites of `build_mcp_list_tools_item_from_session` with `session.build_mcp_list_tools_json()`
- Remove `build_mcp_list_tools_item_from_session` helper function
- Remove unused imports (`build_function_tools_json_with_names`, `build_mcp_list_tools_json`)

**`model_gateway/src/routers/grpc/regular/responses/common.rs`**
- Simplify `convert_mcp_tools_to_chat_tools` to `session.build_chat_function_tools()`
- Remove `build_mcp_list_tools_item` helper function
- Remove unused imports (`Arc`, `McpOrchestrator`, `build_chat_function_tools_with_names`, `build_mcp_list_tools_item`)

**`model_gateway/src/routers/grpc/regular/responses/non_streaming.rs`**
- Switch caller to `session.build_mcp_list_tools_item(label, key)`
- Remove import of deleted helper

**`model_gateway/src/routers/grpc/harmony/responses/execution.rs`**
- Simplify `convert_mcp_tools_to_response_tools` to `session.build_response_tools()`
- Remove unused import (`build_response_tools_with_names`)

**`model_gateway/src/routers/grpc/harmony/responses/common.rs`**
- Simplify `inject_mcp_metadata` to use `session.build_mcp_list_tools_item(label, key)` instead of manually filtering tools and calling the bridge
- Remove unused import (`build_mcp_list_tools_item as mcp_build_list_tools_item`)

## Test Plan

- `cargo check -p smg-mcp -p smg` — both crates compile cleanly
- `cargo test -p smg-mcp` — 146 passed, 0 failed
- `cargo test -p smg` — 16 passed, 0 failed
- `cargo clippy -p smg-mcp -p smg -- -D warnings` — no warnings

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>