### PR TITLE
chore(e2e): include model size in gpt-oss nightly benchmark slug

### DIFF
--- a/.github/workflows/nightly-benchmark.yml
+++ b/.github/workflows/nightly-benchmark.yml
@@ -92,7 +92,7 @@ jobs:
           - { id: deepseek-ai/DeepSeek-R1-Distill-Qwen-7B, slug: deepseek-ai-DeepSeek-R1-Distill-Qwen-7B, test_class: TestNightlyDeepseek7bSingle }
           - { id: Qwen/Qwen3-30B-A3B, slug: Qwen-Qwen3-30B-A3B, test_class: TestNightlyQwen30bSingle }
           - { id: mistralai/Mistral-7B-Instruct-v0.3, slug: mistralai-Mistral-7B-Instruct-v0.3, test_class: TestNightlyMistral7bSingle }
-          - { id: openai/gpt-oss-20b, slug: openai-gpt-oss-20b, test_class: TestNightlyGptOssSingle }
+          - { id: openai/gpt-oss-20b, slug: openai-gpt-oss-20b, test_class: TestNightlyGptOss20bSingle }
         variant:
           - { id: sglang, runtime: sglang, grpc_only: "false", setup_vllm: false, setup_trtllm: false, extra_deps: "genai-bench" }
           - { id: vllm,   runtime: vllm,   grpc_only: "true", setup_vllm: true, setup_trtllm: false, extra_deps: "genai-bench" }
@@ -196,7 +196,7 @@ jobs:
           - { id: deepseek-ai/DeepSeek-R1-Distill-Qwen-7B, slug: deepseek-ai-DeepSeek-R1-Distill-Qwen-7B, test_class: TestNightlyDeepseek7bMulti }
           - { id: Qwen/Qwen3-30B-A3B, slug: Qwen-Qwen3-30B-A3B, test_class: TestNightlyQwen30bMulti }
           - { id: mistralai/Mistral-7B-Instruct-v0.3, slug: mistralai-Mistral-7B-Instruct-v0.3, test_class: TestNightlyMistral7bMulti }
-          - { id: openai/gpt-oss-20b, slug: openai-gpt-oss-20b, test_class: TestNightlyGptOssMulti }
+          - { id: openai/gpt-oss-20b, slug: openai-gpt-oss-20b, test_class: TestNightlyGptOss20bMulti }
         variant:
           - { id: sglang, runtime: sglang, grpc_only: "false", setup_vllm: false, setup_trtllm: false, extra_deps: "genai-bench" }
           - { id: vllm,   runtime: vllm,   grpc_only: "true", setup_vllm: true, setup_trtllm: false, extra_deps: "genai-bench" }

--- a/e2e_test/benchmarks/test_nightly_perf.py
+++ b/e2e_test/benchmarks/test_nightly_perf.py
@@ -103,7 +103,7 @@ _NIGHTLY_MODELS: list[tuple[str, str, int, list[str], dict]] = [
     ("deepseek-ai/DeepSeek-R1-Distill-Qwen-7B", "Deepseek7b", 4, ["http", "grpc"], {}),
     ("Qwen/Qwen3-30B-A3B", "Qwen30b", 4, ["http", "grpc"], {}),
     ("mistralai/Mistral-7B-Instruct-v0.3", "Mistral7b", 4, ["http", "grpc"], {}),
-    ("openai/gpt-oss-20b", "GptOss", 4, ["http", "grpc"], {}),
+    ("openai/gpt-oss-20b", "GptOss20b", 4, ["http", "grpc"], {}),
     (
         "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8",
         "Llama4Maverick",


### PR DESCRIPTION
## Description

### Problem

The nightly benchmark slug for `openai/gpt-oss-20b` is `GptOss`, which omits the model size. Every other model includes its parameter count in the slug (`Llama8b`, `Qwen7b`, `Deepseek7b`, etc.). This makes job names vague and ambiguous—especially since a `gpt-oss-120b` variant also exists in the codebase.

### Solution

Rename the slug from `GptOss` to `GptOss20b` so the generated test class names and CI job names explicitly include the model size.

## Changes

- `e2e_test/benchmarks/test_nightly_perf.py`: `"GptOss"` → `"GptOss20b"` in `_NIGHTLY_MODELS`
- `.github/workflows/nightly-benchmark.yml`: update `test_class` references in both `single-worker` and `multi-worker` matrices (`TestNightlyGptOssSingle` → `TestNightlyGptOss20bSingle`, `TestNightlyGptOssMulti` → `TestNightlyGptOss20bMulti`)

## Test Plan

No functional change—only renames the slug used for test class generation and CI job naming.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated benchmarking test infrastructure and model configurations for improved test classification and tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->