### PR TITLE
feat(realtime-api): realtime api conversation and response protocol

### DIFF
--- a/protocols/src/lib.rs
+++ b/protocols/src/lib.rs
@@ -20,6 +20,8 @@ pub mod messages;
 pub mod model_card;
 pub mod model_type;
 pub mod parser;
+pub mod realtime_conversation;
+pub mod realtime_response;
 pub mod realtime_session;
 pub mod rerank;
 pub mod responses;

--- a/protocols/src/realtime_conversation.rs
+++ b/protocols/src/realtime_conversation.rs
@@ -1,0 +1,195 @@
+// OpenAI Realtime Conversation API types
+// https://platform.openai.com/docs/api-reference/realtime
+//
+// Session configuration and audio types live in `realtime_session`.
+// Event type constants live in `event_types`.
+// This module covers conversation items, content parts.
+
+use serde::{Deserialize, Serialize};
+
+use crate::common::Redacted;
+
+// ============================================================================
+// Conversation Item
+// ============================================================================
+/// A conversation item in the Realtime API.
+///
+/// Discriminated by the `type` field:
+/// - `message`               — a text/audio/image message (system/user/assistant)
+/// - `function_call`         — a function call issued by the model
+/// - `function_call_output`  — the result supplied by the client
+/// - `mcp_call`              — an MCP tool call issued by the model
+/// - `mcp_list_tools`        — MCP list-tools result
+/// - `mcp_approval_request`  — server asks client to approve an MCP call
+/// - `mcp_approval_response` — client approves/denies an MCP call
+///
+/// # Content-part / role constraints
+///
+/// The OpenAI spec restricts which content-part types are valid per role:
+/// - `system`    → `input_text` only
+/// - `user`      → `input_text`, `input_audio`, `input_image`
+/// - `assistant` → `output_text`, `output_audio`
+///
+/// Serde does not enforce this. Call [`RealtimeConversationItem::validate()`]
+/// after deserialization to check these invariants.
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum RealtimeConversationItem {
+    Message {
+        content: Vec<RealtimeContentPart>,
+        role: ConversationItemRole,
+        id: Option<String>,
+        object: Option<ConversationItemObject>,
+        status: Option<ConversationItemStatus>,
+    },
+    FunctionCall {
+        arguments: String,
+        name: String,
+        id: Option<String>,
+        call_id: Option<String>,
+        object: Option<ConversationItemObject>,
+        status: Option<ConversationItemStatus>,
+    },
+    FunctionCallOutput {
+        call_id: String,
+        output: String,
+        id: Option<String>,
+        object: Option<ConversationItemObject>,
+        status: Option<ConversationItemStatus>,
+    },
+    McpApprovalResponse {
+        id: String,
+        approval_request_id: String,
+        approve: bool,
+        reason: Option<String>,
+    },
+    McpListTools {
+        server_label: String,
+        tools: Vec<McpListToolEntry>,
+        id: Option<String>,
+    },
+    McpCall {
+        id: String,
+        arguments: String,
+        name: String,
+        server_label: String,
+        approval_request_id: Option<String>,
+        error: Option<McpCallError>,
+        output: Option<String>,
+    },
+    McpApprovalRequest {
+        id: String,
+        arguments: String,
+        name: String,
+        server_label: String,
+    },
+}
+
+/// Object type for conversation items. Always `"realtime.item"`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum ConversationItemObject {
+    #[serde(rename = "realtime.item")]
+    RealtimeItem,
+}
+
+/// Status of a conversation item.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ConversationItemStatus {
+    Completed,
+    Incomplete,
+    InProgress,
+}
+
+/// Role for a conversation item.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ConversationItemRole {
+    User,
+    Assistant,
+    System,
+}
+
+// ============================================================================
+// Content Parts (Realtime-specific)
+// ============================================================================
+
+/// Content part inside a `RealtimeConversationItem::Message`.
+///
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum RealtimeContentPart {
+    InputText {
+        text: Option<String>,
+    },
+    InputAudio {
+        audio: Option<Redacted>,
+        transcript: Option<String>,
+    },
+    InputImage {
+        detail: Option<ImageDetail>,
+        image_url: Option<Redacted>,
+    },
+    OutputText {
+        text: Option<String>,
+    },
+    OutputAudio {
+        audio: Option<Redacted>,
+        transcript: Option<String>,
+    },
+}
+
+impl RealtimeContentPart {
+    /// Returns the wire-format type name (e.g. `"input_text"`).
+    pub const fn type_name(&self) -> &'static str {
+        match self {
+            Self::InputText { .. } => "input_text",
+            Self::InputAudio { .. } => "input_audio",
+            Self::InputImage { .. } => "input_image",
+            Self::OutputText { .. } => "output_text",
+            Self::OutputAudio { .. } => "output_audio",
+        }
+    }
+}
+
+/// Detail level for image processing. `auto` will default to `high`.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ImageDetail {
+    #[default]
+    Auto,
+    Low,
+    High,
+}
+
+// ============================================================================
+// MCP Types
+// ============================================================================
+
+/// A tool entry returned in `mcp_list_tools` conversation items.
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct McpListToolEntry {
+    pub input_schema: serde_json::Value,
+    pub name: String,
+    pub annotations: Option<serde_json::Value>,
+    pub description: Option<String>,
+}
+
+/// Error from an MCP tool call.
+///
+/// One of: protocol error, tool execution error, or HTTP error.
+#[expect(clippy::enum_variant_names)]
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum McpCallError {
+    /// MCP protocol-level error.
+    ProtocolError { code: i64, message: String },
+    /// Error during tool execution on the MCP server.
+    ToolExecutionError { message: String },
+    /// HTTP-level error communicating with the MCP server.
+    HttpError { code: i64, message: String },
+}

--- a/protocols/src/realtime_response.rs
+++ b/protocols/src/realtime_response.rs
@@ -1,0 +1,272 @@
+// OpenAI Realtime Conversation API types
+// https://platform.openai.com/docs/api-reference/realtime
+//
+// Session configuration and audio types live in `realtime_session`.
+// Event type constants live in `event_types`.
+// This module covers the realtime response
+// object, usage, errors, rate limits.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use validator::{Validate, ValidationError};
+
+use crate::{
+    common::ResponsePrompt,
+    realtime_conversation::{ConversationItemRole, RealtimeContentPart, RealtimeConversationItem},
+    realtime_session::{
+        MaxOutputTokens, OutputModality, RealtimeAudioFormats, RealtimeToolChoiceConfig,
+        RealtimeToolsConfig, Voice,
+    },
+};
+
+// ============================================================================
+// Realtime Response
+// ============================================================================
+
+/// A response object in the Realtime API.
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RealtimeResponse {
+    pub id: Option<String>,
+    pub audio: Option<RealtimeResponseCreateAudioOutput>,
+    pub conversation_id: Option<String>,
+    pub max_output_tokens: Option<MaxOutputTokens>,
+    pub metadata: Option<HashMap<String, String>>,
+    pub object: Option<RealtimeResponseObject>,
+    pub output: Option<Vec<RealtimeConversationItem>>,
+    pub output_modalities: Option<Vec<OutputModality>>,
+    pub status: Option<ResponseStatus>,
+    pub status_details: Option<RealtimeResponseStatus>,
+    pub usage: Option<RealtimeResponseUsage>,
+}
+
+// ============================================================================
+// Realtime Response Create Params
+// ============================================================================
+
+/// Parameters for creating a realtime response.
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize, Validate)]
+#[validate(schema(function = "validate_response_create_params"))]
+pub struct RealtimeResponseCreateParams {
+    pub audio: Option<RealtimeResponseCreateAudioOutput>,
+    pub conversation: Option<ResponseConversation>,
+    pub input: Option<Vec<RealtimeConversationItem>>,
+    pub instructions: Option<String>,
+    pub max_output_tokens: Option<MaxOutputTokens>,
+    pub metadata: Option<HashMap<String, String>>,
+    pub output_modalities: Option<Vec<OutputModality>>,
+    pub prompt: Option<ResponsePrompt>,
+    pub tool_choice: Option<RealtimeToolChoiceConfig>,
+    pub tools: Option<Vec<RealtimeToolsConfig>>,
+}
+
+// ============================================================================
+// Response Status
+// ============================================================================
+
+/// Object type for realtime responses. Always `"realtime.response"`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum RealtimeResponseObject {
+    #[serde(rename = "realtime.response")]
+    RealtimeResponse,
+}
+
+/// Status of a realtime response.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ResponseStatus {
+    Completed,
+    Cancelled,
+    Failed,
+    Incomplete,
+    InProgress,
+}
+
+/// The type within status details.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum StatusDetailsType {
+    Completed,
+    Cancelled,
+    Failed,
+    Incomplete,
+}
+
+/// Reason the response did not complete.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum StatusDetailsReason {
+    TurnDetected,
+    ClientCancelled,
+    MaxOutputTokens,
+    ContentFilter,
+}
+
+/// Error that caused the response to fail.
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResponseStatusError {
+    pub code: Option<String>,
+    #[serde(rename = "type")]
+    pub r#type: Option<String>,
+}
+
+/// Additional details about the response status.
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RealtimeResponseStatus {
+    pub error: Option<ResponseStatusError>,
+    pub reason: Option<StatusDetailsReason>,
+    #[serde(rename = "type")]
+    pub r#type: Option<StatusDetailsType>,
+}
+
+// ============================================================================
+// Response Audio Configuration
+// ============================================================================
+
+/// Audio output configuration for a response.
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResponseAudioOutputConfig {
+    pub format: Option<RealtimeAudioFormats>,
+    pub voice: Option<Voice>,
+}
+
+/// Audio configuration for a response (output only).
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RealtimeResponseCreateAudioOutput {
+    pub output: Option<ResponseAudioOutputConfig>,
+}
+
+// ============================================================================
+// Usage
+// ============================================================================
+
+/// Breakdown of cached token usage by modality.
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CachedTokensDetails {
+    pub audio_tokens: Option<u64>,
+    pub image_tokens: Option<u64>,
+    pub text_tokens: Option<u64>,
+}
+
+/// Input token usage details.
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RealtimeResponseUsageInputTokenDetails {
+    pub audio_tokens: Option<u64>,
+    pub cached_tokens: Option<u64>,
+    pub cached_tokens_details: Option<CachedTokensDetails>,
+    pub image_tokens: Option<u64>,
+    pub text_tokens: Option<u64>,
+}
+
+/// Output token usage details.
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RealtimeResponseUsageOutputTokenDetails {
+    pub audio_tokens: Option<u64>,
+    pub text_tokens: Option<u64>,
+}
+
+/// Token usage for a realtime response.
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RealtimeResponseUsage {
+    pub input_token_details: Option<RealtimeResponseUsageInputTokenDetails>,
+    pub input_tokens: Option<u64>,
+    pub output_token_details: Option<RealtimeResponseUsageOutputTokenDetails>,
+    pub output_tokens: Option<u64>,
+    pub total_tokens: Option<u64>,
+}
+
+// ============================================================================
+// Response Conversation
+// ============================================================================
+
+/// `"auto"`, `"none"`, or a conversation ID string.
+///
+/// Variant order matters for `#[serde(untagged)]`: serde tries `Mode` first.
+/// `"auto"` and `"none"` match `Mode`; any other string falls through to `Id`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ResponseConversation {
+    Mode(ResponseConversationMode),
+    Id(String),
+}
+
+/// Controls which conversation the response is added to.
+/// `auto` is the default.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ResponseConversationMode {
+    #[default]
+    Auto,
+    None,
+}
+
+/// Schema-level validation
+fn validate_response_create_params(
+    request: &RealtimeResponseCreateParams,
+) -> Result<(), ValidationError> {
+    // validate role→content-part constraints per the OpenAI spec
+    if let Some(items) = &request.input {
+        for item in items {
+            validate_conversation_item(item)?;
+        }
+    }
+    Ok(())
+}
+
+/// Validates role→content-part constraints per the OpenAI spec.
+///
+/// - `system`    → `input_text` only
+/// - `user`      → `input_text`, `input_audio`, `input_image`
+/// - `assistant` → `output_text`, `output_audio`
+///
+/// Non-`Message` variants are always valid.
+fn validate_conversation_item(item: &RealtimeConversationItem) -> Result<(), ValidationError> {
+    let (role, content) = match item {
+        RealtimeConversationItem::Message { role, content, .. } => (role, content),
+        _ => return Ok(()),
+    };
+
+    for (i, part) in content.iter().enumerate() {
+        let allowed = match role {
+            ConversationItemRole::System => {
+                matches!(part, RealtimeContentPart::InputText { .. })
+            }
+            ConversationItemRole::User => matches!(
+                part,
+                RealtimeContentPart::InputText { .. }
+                    | RealtimeContentPart::InputAudio { .. }
+                    | RealtimeContentPart::InputImage { .. }
+            ),
+            ConversationItemRole::Assistant => matches!(
+                part,
+                RealtimeContentPart::OutputText { .. } | RealtimeContentPart::OutputAudio { .. }
+            ),
+        };
+
+        if !allowed {
+            let mut err = ValidationError::new("invalid_content_part");
+            err.message = Some(
+                format!(
+                    "content[{}]: {:?} role does not allow \"{}\" content parts",
+                    i,
+                    role,
+                    part.type_name()
+                )
+                .into(),
+            );
+            return Err(err);
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
official api spec: https://developers.openai.com/api/reference/resources/realtime
Fix: https://github.com/lightseekorg/smg/issues/235 https://github.com/lightseekorg/smg/issues/236
## Description

### Problem
The OpenAI Realtime API (WebSocket/WebRTC/SIP) requires structured Rust types for conversation items, content parts, response objects, and usage tracking. The protocols crate had event type constants (event_types.rs) but no wire-format data structures for the conversation and response payloads.

### Solution

Add two new modules to the openai-protocol crate covering the Realtime API's conversation and response domain objects, derived from the [OpenAI Realtime API spec](https://platform.openai.com/docs/api-reference/realtime).

## Changes

- realtime_conversation.rs (new, 258 lines)

  - RealtimeConversationItem — tagged enum with 7 variants: Message, FunctionCall, FunctionCallOutput, McpCall, McpListTools, McpApprovalRequest, McpApprovalResponse
  - RealtimeContentPart — tagged enum for message content: InputText, InputAudio, InputImage, OutputText, OutputAudio
  - RealtimeConversationItem::validate() — runtime check for role→content-part constraints (system: input_text only; user: input_text/audio/image; assistant: output_text/audio)
  - RealtimeContentPart::type_name() — returns wire-format type string
  - McpCallError — tagged enum for MCP tool call errors (protocol, execution, HTTP)
  - Supporting enums: ConversationItemObject, ConversationItemStatus, ConversationItemRole, ImageDetail
- realtime_response.rs (new, 183 lines)

  - RealtimeResponse — response object with status, output items, usage, audio config
  - ResponseCreateParams — parameters for response.create client events
  - RealtimeUsage with u64 token counts for future-proofing (spec says unbounded integer)
  - Token detail breakdowns: RealtimeInputTokenDetails, RealtimeOutputTokenDetails, CachedTokensDetails
  - Response status types: RealtimeResponseStatus, RealtimeResponseStatusDetails, StatusDetailsReason
ResponseAudioConfig / ResponseAudioOutputConfig
- lib.rs — register realtime_conversation and realtime_response modules

### Note: realtime_response has dependency on realtime_session which has been created another pr https://github.com/lightseekorg/smg/pull/364. Will rebase this pr after previous one merged

## Test Plan

<!-- Provide a thorough reproducible test showing before and after behavior. -->

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for OpenAI Realtime Conversation API with new conversation item types (messages, function calls, MCP/tool operations) and validation.
  * Added realtime response models with status tracking, detailed error/status reasons, audio configuration, and token-usage reporting.
  * Added realtime and transcription session models including audio/transcription settings, tool choices and approvals, prompt/variable handling, and safe handling of client secrets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->