### PR TITLE
refactor(mcp): standardize output injection ordering across routers

### DIFF
--- a/model_gateway/src/routers/grpc/harmony/responses/common.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/common.rs
@@ -183,24 +183,13 @@ pub(super) fn inject_mcp_metadata(
     tracking: &McpCallTracking,
     session: &McpToolSession<'_>,
 ) {
-    let mcp_servers = session.mcp_servers();
-
-    // Collect tool output items (already transformed with correct type)
     let tool_output_items: Vec<ResponseOutputItem> = tracking
         .tool_calls
         .iter()
         .map(|record| record.output_item.clone())
         .collect();
 
-    // Inject into response output:
-    // 1. Prepend mcp_list_tools for each server at the beginning
-    for (label, key) in mcp_servers.iter().rev() {
-        let mcp_list_tools = session.build_mcp_list_tools_item(label, key);
-        response.output.insert(0, mcp_list_tools);
-    }
-
-    // 2. Append all tool output items at the end
-    response.output.extend(tool_output_items);
+    session.inject_mcp_output_items(&mut response.output, tool_output_items);
 }
 
 /// Load previous conversation messages from storage

--- a/model_gateway/src/routers/grpc/regular/responses/non_streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/non_streaming.rs
@@ -374,14 +374,8 @@ pub(super) async fn execute_tool_loop(
 
             // Inject MCP metadata into output
             if state.total_calls > 0 {
-                // Prepend mcp_list_tools items for each server
-                for (label, key) in session.mcp_servers().iter().rev() {
-                    let mcp_list_tools = session.build_mcp_list_tools_item(label, key);
-                    responses_response.output.insert(0, mcp_list_tools);
-                }
-
-                // Append all mcp_call items at the end
-                responses_response.output.extend(state.mcp_call_items);
+                session
+                    .inject_mcp_output_items(&mut responses_response.output, state.mcp_call_items);
 
                 trace!(
                     "Injected MCP metadata: {} mcp_list_tools + {} mcp_call items",


### PR DESCRIPTION
## Summary

Standardizes MCP output item ordering across all routers to the chronologically correct sequence: `mcp_list_tools → mcp_calls → messages`. Fixes audit finding 1.5 / recommendation #7.

Refs: audit finding 1.5

## What changed

- **`mcp/src/core/session.rs`**: Added `inject_mcp_output_items()` method to `McpToolSession` that centralizes the standardized ordering logic
- **`model_gateway/src/routers/grpc/harmony/responses/common.rs`**: Replaced manual loop + `.extend()` in `inject_mcp_metadata` with call to `session.inject_mcp_output_items()`
- **`model_gateway/src/routers/grpc/regular/responses/non_streaming.rs`**: Replaced inline loop + `.extend()` with call to `session.inject_mcp_output_items()`

## Why

The Regular and Harmony routers appended `mcp_call` items *after* message items using `.extend()`, producing `[mcp_list_tools, messages, mcp_calls]`. The OpenAI router correctly placed `mcp_call` items between `mcp_list_tools` and messages using `insert()`, producing the chronologically correct `[mcp_list_tools, mcp_calls, messages]` (tools listed → tools called → model responds).

This inconsistency meant the same request could produce differently ordered output depending on which router handled it.

## How

Added a shared `inject_mcp_output_items()` method to `McpToolSession` that enforces the canonical ordering:
1. `mcp_list_tools` items (one per server) — prepended
2. `tool_call_items` (mcp_call / web_search_call) — inserted after list_tools
3. Existing items (messages) — remain at end

Both Harmony and Regular routers now delegate to this method. The OpenAI router already had correct ordering and was not changed. Streaming paths emit events in real-time order and are already correct.

## Test plan

- [x] `cargo check -p smg-mcp -p smg` — both crates compile
- [x] `cargo test -p smg-mcp` — 146 tests pass
- [x] `cargo test -p smg` — all test suites pass
- [x] `cargo clippy -p smg-mcp -p smg -- -D warnings` — zero warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized MCP metadata injection into a single session-level routine to ensure consistent placement of per-server tool listings followed by tool-call items across responses.
  * Preserves existing response content and logging behavior while improving maintainability and consistency of response assembly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->