### PR TITLE
feat(realtime-api): realtime api protocol builder

### DIFF
--- a/protocols/src/builders/mod.rs
+++ b/protocols/src/builders/mod.rs
@@ -7,6 +7,7 @@
 //!
 //! Builders are organized by API:
 //! - `chat/` - Chat Completion API builders (response, stream_response)
+//! - `realtime/` - Realtime API builders (response, server_event, client_event)
 //! - `responses/` - Responses API builder (response)
 //!
 //! # Optional Fields
@@ -20,8 +21,10 @@
 //! ```
 
 pub mod chat;
+pub mod realtime;
 pub mod responses;
 
 // Re-export all builders for convenient access
 pub use chat::{ChatCompletionResponseBuilder, ChatCompletionStreamResponseBuilder};
+pub use realtime::RealtimeResponseBuilder;
 pub use responses::ResponsesResponseBuilder;

--- a/protocols/src/builders/realtime/client_event.rs
+++ b/protocols/src/builders/realtime/client_event.rs
@@ -1,0 +1,165 @@
+//! Constructors for ClientEvent
+//!
+//! Associated functions on `ClientEvent` for constructing client-to-server
+//! events programmatically. Useful when the gateway needs to inject events
+//! (e.g., MCP tool call results) into the upstream connection.
+//!
+//! ```ignore
+//! ClientEvent::session_update(Some("evt_1".into()), config)
+//! ClientEvent::conversation_item_create(Some("evt_2".into()), None, item)
+//! ClientEvent::response_create(Some("evt_3".into()), Some(params))
+//! ```
+
+use crate::{
+    realtime_conversation::RealtimeConversationItem,
+    realtime_events::{ClientEvent, SessionConfig},
+    realtime_response::RealtimeResponseCreateParams,
+};
+
+impl ClientEvent {
+    // ---- Session ----
+
+    /// Build a `session.update` event.
+    pub fn session_update(event_id: Option<String>, session: SessionConfig) -> Self {
+        Self::SessionUpdate {
+            event_id,
+            session: Box::new(session),
+        }
+    }
+
+    // ---- Conversation items ----
+
+    /// Build a `conversation.item.create` event.
+    pub fn conversation_item_create(
+        event_id: Option<String>,
+        previous_item_id: Option<String>,
+        item: RealtimeConversationItem,
+    ) -> Self {
+        Self::ConversationItemCreate {
+            event_id,
+            previous_item_id,
+            item,
+        }
+    }
+
+    /// Build a `conversation.item.delete` event.
+    pub fn conversation_item_delete(event_id: Option<String>, item_id: impl Into<String>) -> Self {
+        Self::ConversationItemDelete {
+            event_id,
+            item_id: item_id.into(),
+        }
+    }
+
+    /// Build a `conversation.item.retrieve` event.
+    pub fn conversation_item_retrieve(
+        event_id: Option<String>,
+        item_id: impl Into<String>,
+    ) -> Self {
+        Self::ConversationItemRetrieve {
+            event_id,
+            item_id: item_id.into(),
+        }
+    }
+
+    /// Build a `conversation.item.truncate` event.
+    pub fn conversation_item_truncate(
+        event_id: Option<String>,
+        item_id: impl Into<String>,
+        content_index: u32,
+        audio_end_ms: u32,
+    ) -> Self {
+        Self::ConversationItemTruncate {
+            event_id,
+            item_id: item_id.into(),
+            content_index,
+            audio_end_ms,
+        }
+    }
+
+    // ---- Input audio buffer ----
+
+    /// Build an `input_audio_buffer.append` event.
+    pub fn input_audio_buffer_append(event_id: Option<String>, audio: impl Into<String>) -> Self {
+        Self::InputAudioBufferAppend {
+            event_id,
+            audio: audio.into(),
+        }
+    }
+
+    /// Build an `input_audio_buffer.clear` event.
+    pub fn input_audio_buffer_clear(event_id: Option<String>) -> Self {
+        Self::InputAudioBufferClear { event_id }
+    }
+
+    /// Build an `input_audio_buffer.commit` event.
+    pub fn input_audio_buffer_commit(event_id: Option<String>) -> Self {
+        Self::InputAudioBufferCommit { event_id }
+    }
+
+    // ---- Output audio buffer (WebRTC/SIP only) ----
+
+    /// Build an `output_audio_buffer.clear` event.
+    pub fn output_audio_buffer_clear(event_id: Option<String>) -> Self {
+        Self::OutputAudioBufferClear { event_id }
+    }
+
+    // ---- Response ----
+
+    /// Build a `response.cancel` event.
+    pub fn response_cancel(event_id: Option<String>, response_id: Option<String>) -> Self {
+        Self::ResponseCancel {
+            event_id,
+            response_id,
+        }
+    }
+
+    /// Build a `response.create` event.
+    pub fn response_create(
+        event_id: Option<String>,
+        response: Option<RealtimeResponseCreateParams>,
+    ) -> Self {
+        Self::ResponseCreate {
+            event_id,
+            response: response.map(Box::new),
+        }
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::realtime_session::{
+        OutputModality, RealtimeSessionCreateRequest, RealtimeSessionType,
+    };
+
+    #[test]
+    fn test_session_update() {
+        let config = SessionConfig::Realtime(Box::new(RealtimeSessionCreateRequest {
+            r#type: RealtimeSessionType::Realtime,
+            output_modalities: Some(vec![OutputModality::Audio]),
+            model: None,
+            instructions: None,
+            audio: None,
+            include: None,
+            tracing: None,
+            tools: None,
+            tool_choice: None,
+            max_output_tokens: None,
+            truncation: None,
+            prompt: None,
+        }));
+
+        let event = ClientEvent::session_update(Some("evt_1".into()), config);
+        assert_eq!(event.event_type(), "session.update");
+    }
+
+    #[test]
+    fn test_response_create_empty() {
+        let event = ClientEvent::response_create(None, None);
+        assert_eq!(event.event_type(), "response.create");
+    }
+}

--- a/protocols/src/builders/realtime/mod.rs
+++ b/protocols/src/builders/realtime/mod.rs
@@ -1,0 +1,8 @@
+//! Builders for Realtime API types
+
+pub mod client_event;
+pub mod response;
+pub mod server_event;
+
+pub use response::RealtimeResponseBuilder;
+pub use server_event::{ContentEventBuilder, ItemEventBuilder, ResponseEventBuilder};

--- a/protocols/src/builders/realtime/response.rs
+++ b/protocols/src/builders/realtime/response.rs
@@ -1,0 +1,215 @@
+//! Builder for RealtimeResponse
+//!
+//! Provides an ergonomic fluent API for constructing realtime response instances.
+
+use std::collections::HashMap;
+
+use crate::{
+    realtime_conversation::RealtimeConversationItem,
+    realtime_response::{
+        RealtimeResponse, RealtimeResponseCreateAudioOutput, RealtimeResponseObject,
+        RealtimeResponseStatus, RealtimeResponseUsage, ResponseStatus,
+    },
+    realtime_session::{MaxOutputTokens, OutputModality},
+};
+
+/// Builder for RealtimeResponse
+///
+/// Provides a fluent interface for constructing realtime responses with sensible defaults.
+#[must_use = "Builder does nothing until .build() is called"]
+#[derive(Clone, Debug)]
+pub struct RealtimeResponseBuilder {
+    id: String,
+    object: Option<RealtimeResponseObject>,
+    status: Option<ResponseStatus>,
+    status_details: Option<RealtimeResponseStatus>,
+    output: Vec<RealtimeConversationItem>,
+    metadata: HashMap<String, String>,
+    audio: Option<RealtimeResponseCreateAudioOutput>,
+    usage: Option<RealtimeResponseUsage>,
+    conversation_id: Option<String>,
+    output_modalities: Option<Vec<OutputModality>>,
+    max_output_tokens: Option<MaxOutputTokens>,
+}
+
+impl RealtimeResponseBuilder {
+    /// Create a new builder with the response ID.
+    ///
+    /// # Arguments
+    /// - `id`: Response ID (e.g., "resp_abc123")
+    pub fn new(id: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            object: Some(RealtimeResponseObject::RealtimeResponse),
+            status: Some(ResponseStatus::InProgress),
+            status_details: None,
+            output: Vec::new(),
+            metadata: HashMap::new(),
+            audio: None,
+            usage: None,
+            conversation_id: None,
+            output_modalities: None,
+            max_output_tokens: None,
+        }
+    }
+
+    /// Set the response status (default: InProgress).
+    pub fn status(mut self, status: ResponseStatus) -> Self {
+        self.status = Some(status);
+        self
+    }
+
+    /// Set status details (e.g. cancellation reason, failure error).
+    pub fn status_details(mut self, details: RealtimeResponseStatus) -> Self {
+        self.status_details = Some(details);
+        self
+    }
+
+    /// Set the full output items list.
+    pub fn output(mut self, output: Vec<RealtimeConversationItem>) -> Self {
+        self.output = output;
+        self
+    }
+
+    /// Add a single output item.
+    pub fn add_output(mut self, item: RealtimeConversationItem) -> Self {
+        self.output.push(item);
+        self
+    }
+
+    /// Set metadata.
+    pub fn metadata(mut self, metadata: HashMap<String, String>) -> Self {
+        self.metadata = metadata;
+        self
+    }
+
+    /// Add a single metadata entry.
+    pub fn add_metadata(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.metadata.insert(key.into(), value.into());
+        self
+    }
+
+    /// Set audio configuration.
+    pub fn audio(mut self, audio: RealtimeResponseCreateAudioOutput) -> Self {
+        self.audio = Some(audio);
+        self
+    }
+
+    /// Set usage statistics.
+    pub fn usage(mut self, usage: RealtimeResponseUsage) -> Self {
+        self.usage = Some(usage);
+        self
+    }
+
+    /// Set usage if provided (handles Option).
+    pub fn maybe_usage(mut self, usage: Option<RealtimeResponseUsage>) -> Self {
+        if let Some(u) = usage {
+            self.usage = Some(u);
+        }
+        self
+    }
+
+    /// Set the conversation ID.
+    pub fn conversation_id(mut self, id: impl Into<String>) -> Self {
+        self.conversation_id = Some(id.into());
+        self
+    }
+
+    /// Set output modalities.
+    pub fn output_modalities(mut self, modalities: Vec<OutputModality>) -> Self {
+        self.output_modalities = Some(modalities);
+        self
+    }
+
+    /// Set max output tokens.
+    pub fn max_output_tokens(mut self, max: MaxOutputTokens) -> Self {
+        self.max_output_tokens = Some(max);
+        self
+    }
+
+    /// Build the RealtimeResponse.
+    pub fn build(self) -> RealtimeResponse {
+        let metadata = if self.metadata.is_empty() {
+            None
+        } else {
+            Some(self.metadata)
+        };
+
+        let output = if self.output.is_empty() {
+            None
+        } else {
+            Some(self.output)
+        };
+
+        RealtimeResponse {
+            id: Some(self.id),
+            object: self.object,
+            status: self.status,
+            status_details: self.status_details,
+            output,
+            metadata,
+            audio: self.audio,
+            usage: self.usage,
+            conversation_id: self.conversation_id,
+            output_modalities: self.output_modalities,
+            max_output_tokens: self.max_output_tokens,
+        }
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_minimal() {
+        let response = RealtimeResponseBuilder::new("resp_123").build();
+
+        assert_eq!(response.id.as_ref().unwrap(), "resp_123");
+        assert_eq!(
+            response.object.as_ref().unwrap(),
+            &RealtimeResponseObject::RealtimeResponse
+        );
+        assert_eq!(
+            response.status.as_ref().unwrap(),
+            &ResponseStatus::InProgress
+        );
+        assert!(response.output.is_none());
+        assert!(response.metadata.is_none());
+        assert!(response.usage.is_none());
+    }
+
+    #[test]
+    fn test_build_complete() {
+        let usage = RealtimeResponseUsage {
+            total_tokens: Some(100),
+            input_tokens: Some(40),
+            output_tokens: Some(60),
+            input_token_details: None,
+            output_token_details: None,
+        };
+
+        let response = RealtimeResponseBuilder::new("resp_full")
+            .status(ResponseStatus::Completed)
+            .conversation_id("conv_123")
+            .output_modalities(vec![OutputModality::Audio, OutputModality::Text])
+            .max_output_tokens(MaxOutputTokens::Integer(4096))
+            .add_metadata("session", "test")
+            .maybe_usage(Some(usage))
+            .build();
+
+        assert_eq!(response.id.as_ref().unwrap(), "resp_full");
+        assert_eq!(
+            response.status.as_ref().unwrap(),
+            &ResponseStatus::Completed
+        );
+        assert_eq!(response.conversation_id.as_ref().unwrap(), "conv_123");
+        assert_eq!(response.output_modalities.as_ref().unwrap().len(), 2);
+        assert!(response.metadata.is_some());
+        assert_eq!(response.usage.as_ref().unwrap().total_tokens, Some(100));
+    }
+}

--- a/protocols/src/builders/realtime/server_event.rs
+++ b/protocols/src/builders/realtime/server_event.rs
@@ -1,0 +1,925 @@
+//! Constructors and streaming context builders for ServerEvent
+//!
+//! # One-shot events
+//!
+//! Simple events are constructed via associated functions on `ServerEvent`:
+//!
+//! ```ignore
+//! ServerEvent::session_created("evt_1", config)
+//! ServerEvent::error_event("evt_2", error)
+//! ```
+//!
+//! # Streaming events (hierarchical context builders)
+//!
+//! Response-streaming events share stable fields (`response_id`, `item_id`,
+//! `output_index`, `content_index`). Context builders capture this shared
+//! state and can be reused across many events — only `event_id` varies per call:
+//!
+//! ```ignore
+//! // One-shot chaining:
+//! ResponseEventBuilder::new("resp_1")
+//!     .for_item("item_1", 0)
+//!     .for_content(0)
+//!     .output_text_delta("evt_1", "Hello")
+//!
+//! // Streaming hot path — reuse the context, no rebuild:
+//! let ctx = ResponseEventBuilder::new("resp_1")
+//!     .for_item("item_1", 0)
+//!     .for_content(0);
+//! for chunk in chunks {
+//!     send(ctx.output_text_delta(next_event_id(), chunk));
+//! }
+//! ```
+
+use crate::{
+    realtime_conversation::RealtimeConversationItem,
+    realtime_events::{
+        Conversation, LogProbProperties, RealtimeError, RealtimeRateLimit, ResponseContentPart,
+        ServerEvent, SessionConfig, TranscriptionError, TranscriptionUsage,
+    },
+    realtime_response::RealtimeResponse,
+};
+
+// ============================================================================
+// ServerEvent associated constructors (one-shot events)
+// ============================================================================
+
+impl ServerEvent {
+    // ---- Session events ----
+
+    /// Build a `session.created` event.
+    pub fn session_created(event_id: impl Into<String>, session: SessionConfig) -> Self {
+        Self::SessionCreated {
+            event_id: event_id.into(),
+            session: Box::new(session),
+        }
+    }
+
+    /// Build a `session.updated` event.
+    pub fn session_updated(event_id: impl Into<String>, session: SessionConfig) -> Self {
+        Self::SessionUpdated {
+            event_id: event_id.into(),
+            session: Box::new(session),
+        }
+    }
+
+    // ---- Conversation events ----
+
+    /// Build a `conversation.created` event.
+    pub fn conversation_created(event_id: impl Into<String>, conversation: Conversation) -> Self {
+        Self::ConversationCreated {
+            event_id: event_id.into(),
+            conversation,
+        }
+    }
+
+    /// Build a `conversation.item.created` event.
+    pub fn conversation_item_created(
+        event_id: impl Into<String>,
+        previous_item_id: Option<String>,
+        item: RealtimeConversationItem,
+    ) -> Self {
+        Self::ConversationItemCreated {
+            event_id: event_id.into(),
+            previous_item_id,
+            item,
+        }
+    }
+
+    /// Build a `conversation.item.added` event.
+    pub fn conversation_item_added(
+        event_id: impl Into<String>,
+        previous_item_id: Option<String>,
+        item: RealtimeConversationItem,
+    ) -> Self {
+        Self::ConversationItemAdded {
+            event_id: event_id.into(),
+            previous_item_id,
+            item,
+        }
+    }
+
+    /// Build a `conversation.item.done` event.
+    pub fn conversation_item_done(
+        event_id: impl Into<String>,
+        previous_item_id: Option<String>,
+        item: RealtimeConversationItem,
+    ) -> Self {
+        Self::ConversationItemDone {
+            event_id: event_id.into(),
+            previous_item_id,
+            item,
+        }
+    }
+
+    /// Build a `conversation.item.deleted` event.
+    pub fn conversation_item_deleted(
+        event_id: impl Into<String>,
+        item_id: impl Into<String>,
+    ) -> Self {
+        Self::ConversationItemDeleted {
+            event_id: event_id.into(),
+            item_id: item_id.into(),
+        }
+    }
+
+    /// Build a `conversation.item.retrieved` event.
+    pub fn conversation_item_retrieved(
+        event_id: impl Into<String>,
+        item: RealtimeConversationItem,
+    ) -> Self {
+        Self::ConversationItemRetrieved {
+            event_id: event_id.into(),
+            item,
+        }
+    }
+
+    /// Build a `conversation.item.truncated` event.
+    pub fn conversation_item_truncated(
+        event_id: impl Into<String>,
+        item_id: impl Into<String>,
+        content_index: u32,
+        audio_end_ms: u32,
+    ) -> Self {
+        Self::ConversationItemTruncated {
+            event_id: event_id.into(),
+            item_id: item_id.into(),
+            content_index,
+            audio_end_ms,
+        }
+    }
+
+    // ---- Input audio transcription events ----
+
+    /// Build a `conversation.item.input_audio_transcription.completed` event.
+    pub fn input_audio_transcription_completed(
+        event_id: impl Into<String>,
+        item_id: impl Into<String>,
+        content_index: u32,
+        transcript: impl Into<String>,
+        usage: TranscriptionUsage,
+    ) -> Self {
+        Self::InputAudioTranscriptionCompleted {
+            event_id: event_id.into(),
+            item_id: item_id.into(),
+            content_index,
+            transcript: transcript.into(),
+            logprobs: None,
+            usage,
+        }
+    }
+
+    /// Build a `conversation.item.input_audio_transcription.completed` event with logprobs.
+    pub fn input_audio_transcription_completed_with_logprobs(
+        event_id: impl Into<String>,
+        item_id: impl Into<String>,
+        content_index: u32,
+        transcript: impl Into<String>,
+        usage: TranscriptionUsage,
+        logprobs: Vec<LogProbProperties>,
+    ) -> Self {
+        Self::InputAudioTranscriptionCompleted {
+            event_id: event_id.into(),
+            item_id: item_id.into(),
+            content_index,
+            transcript: transcript.into(),
+            logprobs: Some(logprobs),
+            usage,
+        }
+    }
+
+    /// Build a `conversation.item.input_audio_transcription.delta` event.
+    pub fn input_audio_transcription_delta(
+        event_id: impl Into<String>,
+        item_id: impl Into<String>,
+        content_index: Option<u32>,
+        delta: Option<String>,
+        logprobs: Option<Vec<LogProbProperties>>,
+    ) -> Self {
+        Self::InputAudioTranscriptionDelta {
+            event_id: event_id.into(),
+            item_id: item_id.into(),
+            content_index,
+            delta,
+            logprobs,
+        }
+    }
+
+    /// Build a `conversation.item.input_audio_transcription.failed` event.
+    pub fn input_audio_transcription_failed(
+        event_id: impl Into<String>,
+        item_id: impl Into<String>,
+        content_index: u32,
+        error: TranscriptionError,
+    ) -> Self {
+        Self::InputAudioTranscriptionFailed {
+            event_id: event_id.into(),
+            item_id: item_id.into(),
+            content_index,
+            error,
+        }
+    }
+
+    /// Build a `conversation.item.input_audio_transcription.segment` event.
+    #[expect(clippy::too_many_arguments)]
+    pub fn input_audio_transcription_segment(
+        event_id: impl Into<String>,
+        item_id: impl Into<String>,
+        content_index: u32,
+        text: impl Into<String>,
+        id: impl Into<String>,
+        speaker: impl Into<String>,
+        start: f32,
+        end: f32,
+    ) -> Self {
+        Self::InputAudioTranscriptionSegment {
+            event_id: event_id.into(),
+            item_id: item_id.into(),
+            content_index,
+            text: text.into(),
+            id: id.into(),
+            speaker: speaker.into(),
+            start,
+            end,
+        }
+    }
+
+    // ---- Input audio buffer events ----
+
+    /// Build an `input_audio_buffer.cleared` event.
+    pub fn input_audio_buffer_cleared(event_id: impl Into<String>) -> Self {
+        Self::InputAudioBufferCleared {
+            event_id: event_id.into(),
+        }
+    }
+
+    /// Build an `input_audio_buffer.committed` event.
+    pub fn input_audio_buffer_committed(
+        event_id: impl Into<String>,
+        item_id: impl Into<String>,
+        previous_item_id: Option<String>,
+    ) -> Self {
+        Self::InputAudioBufferCommitted {
+            event_id: event_id.into(),
+            previous_item_id,
+            item_id: item_id.into(),
+        }
+    }
+
+    /// Build an `input_audio_buffer.speech_started` event.
+    pub fn input_audio_buffer_speech_started(
+        event_id: impl Into<String>,
+        audio_start_ms: u32,
+        item_id: impl Into<String>,
+    ) -> Self {
+        Self::InputAudioBufferSpeechStarted {
+            event_id: event_id.into(),
+            audio_start_ms,
+            item_id: item_id.into(),
+        }
+    }
+
+    /// Build an `input_audio_buffer.speech_stopped` event.
+    pub fn input_audio_buffer_speech_stopped(
+        event_id: impl Into<String>,
+        audio_end_ms: u32,
+        item_id: impl Into<String>,
+    ) -> Self {
+        Self::InputAudioBufferSpeechStopped {
+            event_id: event_id.into(),
+            audio_end_ms,
+            item_id: item_id.into(),
+        }
+    }
+
+    /// Build an `input_audio_buffer.timeout_triggered` event.
+    pub fn input_audio_buffer_timeout_triggered(
+        event_id: impl Into<String>,
+        audio_start_ms: u32,
+        audio_end_ms: u32,
+        item_id: impl Into<String>,
+    ) -> Self {
+        Self::InputAudioBufferTimeoutTriggered {
+            event_id: event_id.into(),
+            audio_start_ms,
+            audio_end_ms,
+            item_id: item_id.into(),
+        }
+    }
+
+    /// Build an `input_audio_buffer.dtmf_event_received` event.
+    ///
+    /// DTMF events have no `event_id` per the OpenAI spec.
+    pub fn dtmf_event_received(event: impl Into<String>, received_at: i64) -> Self {
+        Self::InputAudioBufferDtmfEventReceived {
+            event: event.into(),
+            received_at,
+        }
+    }
+
+    // ---- MCP list tools events ----
+
+    /// Build an `mcp_list_tools.in_progress` event.
+    pub fn mcp_list_tools_in_progress(
+        event_id: impl Into<String>,
+        item_id: impl Into<String>,
+    ) -> Self {
+        Self::McpListToolsInProgress {
+            event_id: event_id.into(),
+            item_id: item_id.into(),
+        }
+    }
+
+    /// Build an `mcp_list_tools.completed` event.
+    pub fn mcp_list_tools_completed(
+        event_id: impl Into<String>,
+        item_id: impl Into<String>,
+    ) -> Self {
+        Self::McpListToolsCompleted {
+            event_id: event_id.into(),
+            item_id: item_id.into(),
+        }
+    }
+
+    /// Build an `mcp_list_tools.failed` event.
+    pub fn mcp_list_tools_failed(event_id: impl Into<String>, item_id: impl Into<String>) -> Self {
+        Self::McpListToolsFailed {
+            event_id: event_id.into(),
+            item_id: item_id.into(),
+        }
+    }
+
+    // ---- MCP call lifecycle events ----
+
+    /// Build a `response.mcp_call.in_progress` event.
+    pub fn mcp_call_in_progress(
+        event_id: impl Into<String>,
+        item_id: impl Into<String>,
+        output_index: u32,
+    ) -> Self {
+        Self::ResponseMcpCallInProgress {
+            event_id: event_id.into(),
+            output_index,
+            item_id: item_id.into(),
+        }
+    }
+
+    /// Build a `response.mcp_call.completed` event.
+    pub fn mcp_call_completed(
+        event_id: impl Into<String>,
+        item_id: impl Into<String>,
+        output_index: u32,
+    ) -> Self {
+        Self::ResponseMcpCallCompleted {
+            event_id: event_id.into(),
+            output_index,
+            item_id: item_id.into(),
+        }
+    }
+
+    /// Build a `response.mcp_call.failed` event.
+    pub fn mcp_call_failed(
+        event_id: impl Into<String>,
+        item_id: impl Into<String>,
+        output_index: u32,
+    ) -> Self {
+        Self::ResponseMcpCallFailed {
+            event_id: event_id.into(),
+            output_index,
+            item_id: item_id.into(),
+        }
+    }
+
+    // ---- Rate limits ----
+
+    /// Build a `rate_limits.updated` event.
+    pub fn rate_limits_updated(
+        event_id: impl Into<String>,
+        rate_limits: Vec<RealtimeRateLimit>,
+    ) -> Self {
+        Self::RateLimitsUpdated {
+            event_id: event_id.into(),
+            rate_limits,
+        }
+    }
+
+    // ---- Response lifecycle events ----
+
+    /// Build a `response.created` event.
+    pub fn response_created(event_id: impl Into<String>, response: RealtimeResponse) -> Self {
+        Self::ResponseCreated {
+            event_id: event_id.into(),
+            response: Box::new(response),
+        }
+    }
+
+    /// Build a `response.done` event.
+    pub fn response_done(event_id: impl Into<String>, response: RealtimeResponse) -> Self {
+        Self::ResponseDone {
+            event_id: event_id.into(),
+            response: Box::new(response),
+        }
+    }
+
+    // ---- Error ----
+
+    /// Build an `error` event.
+    pub fn error_event(event_id: impl Into<String>, error: RealtimeError) -> Self {
+        Self::Error {
+            event_id: event_id.into(),
+            error,
+        }
+    }
+}
+
+// ============================================================================
+// Level 2: ResponseEventBuilder (response_id)
+// ============================================================================
+
+/// Reusable context for response-scoped server events.
+///
+/// Holds `response_id`. Terminal methods take `event_id` per call, so the
+/// builder can be reused across many events in a streaming loop.
+/// Call `.for_item()` to descend into item-scoped events.
+#[derive(Clone, Debug)]
+pub struct ResponseEventBuilder {
+    response_id: String,
+}
+
+impl ResponseEventBuilder {
+    /// Create a new response-scoped context.
+    pub fn new(response_id: impl Into<String>) -> Self {
+        Self {
+            response_id: response_id.into(),
+        }
+    }
+
+    // ---- Transition ----
+
+    /// Descend into item-scoped events.
+    pub fn for_item(&self, item_id: impl Into<String>, output_index: u32) -> ItemEventBuilder {
+        ItemEventBuilder {
+            response_id: self.response_id.clone(),
+            item_id: item_id.into(),
+            output_index,
+        }
+    }
+
+    // ---- Output audio buffer events (WebRTC/SIP only) ----
+
+    /// Build an `output_audio_buffer.started` event.
+    pub fn output_audio_buffer_started(&self, event_id: impl Into<String>) -> ServerEvent {
+        ServerEvent::OutputAudioBufferStarted {
+            event_id: event_id.into(),
+            response_id: self.response_id.clone(),
+        }
+    }
+
+    /// Build an `output_audio_buffer.stopped` event.
+    pub fn output_audio_buffer_stopped(&self, event_id: impl Into<String>) -> ServerEvent {
+        ServerEvent::OutputAudioBufferStopped {
+            event_id: event_id.into(),
+            response_id: self.response_id.clone(),
+        }
+    }
+
+    /// Build an `output_audio_buffer.cleared` event.
+    pub fn output_audio_buffer_cleared(&self, event_id: impl Into<String>) -> ServerEvent {
+        ServerEvent::OutputAudioBufferCleared {
+            event_id: event_id.into(),
+            response_id: self.response_id.clone(),
+        }
+    }
+}
+
+// ============================================================================
+// Level 3: ItemEventBuilder (response_id + item_id + output_index)
+// ============================================================================
+
+/// Reusable context for item-scoped server events.
+///
+/// Holds `response_id`, `item_id`, and `output_index`. Terminal methods take
+/// `event_id` per call. Call `.for_content()` to descend into content-scoped events.
+#[derive(Clone, Debug)]
+pub struct ItemEventBuilder {
+    response_id: String,
+    item_id: String,
+    output_index: u32,
+}
+
+impl ItemEventBuilder {
+    /// Create a new item-scoped context directly.
+    pub fn new(
+        response_id: impl Into<String>,
+        item_id: impl Into<String>,
+        output_index: u32,
+    ) -> Self {
+        Self {
+            response_id: response_id.into(),
+            item_id: item_id.into(),
+            output_index,
+        }
+    }
+
+    // ---- Transition ----
+
+    /// Descend into content-scoped events.
+    pub fn for_content(&self, content_index: u32) -> ContentEventBuilder {
+        ContentEventBuilder {
+            response_id: self.response_id.clone(),
+            item_id: self.item_id.clone(),
+            output_index: self.output_index,
+            content_index,
+        }
+    }
+
+    // ---- Response output item events ----
+
+    /// Build a `response.output_item.added` event.
+    pub fn output_item_added(
+        &self,
+        event_id: impl Into<String>,
+        item: RealtimeConversationItem,
+    ) -> ServerEvent {
+        ServerEvent::ResponseOutputItemAdded {
+            event_id: event_id.into(),
+            response_id: self.response_id.clone(),
+            output_index: self.output_index,
+            item,
+        }
+    }
+
+    /// Build a `response.output_item.done` event.
+    pub fn output_item_done(
+        &self,
+        event_id: impl Into<String>,
+        item: RealtimeConversationItem,
+    ) -> ServerEvent {
+        ServerEvent::ResponseOutputItemDone {
+            event_id: event_id.into(),
+            response_id: self.response_id.clone(),
+            output_index: self.output_index,
+            item,
+        }
+    }
+
+    // ---- Response function call events ----
+
+    /// Build a `response.function_call_arguments.delta` event.
+    pub fn function_call_arguments_delta(
+        &self,
+        event_id: impl Into<String>,
+        call_id: impl Into<String>,
+        delta: impl Into<String>,
+    ) -> ServerEvent {
+        ServerEvent::ResponseFunctionCallArgumentsDelta {
+            event_id: event_id.into(),
+            response_id: self.response_id.clone(),
+            item_id: self.item_id.clone(),
+            output_index: self.output_index,
+            call_id: call_id.into(),
+            delta: delta.into(),
+        }
+    }
+
+    /// Build a `response.function_call_arguments.done` event.
+    pub fn function_call_arguments_done(
+        &self,
+        event_id: impl Into<String>,
+        call_id: impl Into<String>,
+        name: impl Into<String>,
+        arguments: impl Into<String>,
+    ) -> ServerEvent {
+        ServerEvent::ResponseFunctionCallArgumentsDone {
+            event_id: event_id.into(),
+            response_id: self.response_id.clone(),
+            item_id: self.item_id.clone(),
+            output_index: self.output_index,
+            call_id: call_id.into(),
+            name: name.into(),
+            arguments: arguments.into(),
+        }
+    }
+
+    // ---- Response MCP call events ----
+
+    /// Build a `response.mcp_call_arguments.delta` event.
+    pub fn mcp_call_arguments_delta(
+        &self,
+        event_id: impl Into<String>,
+        delta: impl Into<String>,
+        obfuscation: Option<String>,
+    ) -> ServerEvent {
+        ServerEvent::ResponseMcpCallArgumentsDelta {
+            event_id: event_id.into(),
+            response_id: self.response_id.clone(),
+            item_id: self.item_id.clone(),
+            output_index: self.output_index,
+            delta: delta.into(),
+            obfuscation,
+        }
+    }
+
+    /// Build a `response.mcp_call_arguments.done` event.
+    pub fn mcp_call_arguments_done(
+        &self,
+        event_id: impl Into<String>,
+        arguments: impl Into<String>,
+    ) -> ServerEvent {
+        ServerEvent::ResponseMcpCallArgumentsDone {
+            event_id: event_id.into(),
+            response_id: self.response_id.clone(),
+            item_id: self.item_id.clone(),
+            output_index: self.output_index,
+            arguments: arguments.into(),
+        }
+    }
+}
+
+// ============================================================================
+// Level 4: ContentEventBuilder
+//   (response_id + item_id + output_index + content_index)
+// ============================================================================
+
+/// Reusable context for content-scoped server events.
+///
+/// Holds `response_id`, `item_id`, `output_index`, and `content_index`.
+/// Terminal methods take `event_id` per call, enabling reuse in streaming loops.
+#[derive(Clone, Debug)]
+pub struct ContentEventBuilder {
+    response_id: String,
+    item_id: String,
+    output_index: u32,
+    content_index: u32,
+}
+
+impl ContentEventBuilder {
+    /// Create a new content-scoped context directly.
+    pub fn new(
+        response_id: impl Into<String>,
+        item_id: impl Into<String>,
+        output_index: u32,
+        content_index: u32,
+    ) -> Self {
+        Self {
+            response_id: response_id.into(),
+            item_id: item_id.into(),
+            output_index,
+            content_index,
+        }
+    }
+
+    // ---- Response content part events ----
+
+    /// Build a `response.content_part.added` event.
+    pub fn content_part_added(
+        &self,
+        event_id: impl Into<String>,
+        part: ResponseContentPart,
+    ) -> ServerEvent {
+        ServerEvent::ResponseContentPartAdded {
+            event_id: event_id.into(),
+            response_id: self.response_id.clone(),
+            item_id: self.item_id.clone(),
+            output_index: self.output_index,
+            content_index: self.content_index,
+            part,
+        }
+    }
+
+    /// Build a `response.content_part.done` event.
+    pub fn content_part_done(
+        &self,
+        event_id: impl Into<String>,
+        part: ResponseContentPart,
+    ) -> ServerEvent {
+        ServerEvent::ResponseContentPartDone {
+            event_id: event_id.into(),
+            response_id: self.response_id.clone(),
+            item_id: self.item_id.clone(),
+            output_index: self.output_index,
+            content_index: self.content_index,
+            part,
+        }
+    }
+
+    // ---- Response text events ----
+
+    /// Build a `response.output_text.delta` event.
+    pub fn output_text_delta(
+        &self,
+        event_id: impl Into<String>,
+        delta: impl Into<String>,
+    ) -> ServerEvent {
+        ServerEvent::ResponseOutputTextDelta {
+            event_id: event_id.into(),
+            response_id: self.response_id.clone(),
+            item_id: self.item_id.clone(),
+            output_index: self.output_index,
+            content_index: self.content_index,
+            delta: delta.into(),
+        }
+    }
+
+    /// Build a `response.output_text.done` event.
+    pub fn output_text_done(
+        &self,
+        event_id: impl Into<String>,
+        text: impl Into<String>,
+    ) -> ServerEvent {
+        ServerEvent::ResponseOutputTextDone {
+            event_id: event_id.into(),
+            response_id: self.response_id.clone(),
+            item_id: self.item_id.clone(),
+            output_index: self.output_index,
+            content_index: self.content_index,
+            text: text.into(),
+        }
+    }
+
+    // ---- Response audio events ----
+
+    /// Build a `response.output_audio.delta` event.
+    pub fn output_audio_delta(
+        &self,
+        event_id: impl Into<String>,
+        delta: impl Into<String>,
+    ) -> ServerEvent {
+        ServerEvent::ResponseOutputAudioDelta {
+            event_id: event_id.into(),
+            response_id: self.response_id.clone(),
+            item_id: self.item_id.clone(),
+            output_index: self.output_index,
+            content_index: self.content_index,
+            delta: delta.into(),
+        }
+    }
+
+    /// Build a `response.output_audio.done` event.
+    pub fn output_audio_done(&self, event_id: impl Into<String>) -> ServerEvent {
+        ServerEvent::ResponseOutputAudioDone {
+            event_id: event_id.into(),
+            response_id: self.response_id.clone(),
+            item_id: self.item_id.clone(),
+            output_index: self.output_index,
+            content_index: self.content_index,
+        }
+    }
+
+    // ---- Response audio transcript events ----
+
+    /// Build a `response.output_audio_transcript.delta` event.
+    pub fn output_audio_transcript_delta(
+        &self,
+        event_id: impl Into<String>,
+        delta: impl Into<String>,
+    ) -> ServerEvent {
+        ServerEvent::ResponseOutputAudioTranscriptDelta {
+            event_id: event_id.into(),
+            response_id: self.response_id.clone(),
+            item_id: self.item_id.clone(),
+            output_index: self.output_index,
+            content_index: self.content_index,
+            delta: delta.into(),
+        }
+    }
+
+    /// Build a `response.output_audio_transcript.done` event.
+    pub fn output_audio_transcript_done(
+        &self,
+        event_id: impl Into<String>,
+        transcript: impl Into<String>,
+    ) -> ServerEvent {
+        ServerEvent::ResponseOutputAudioTranscriptDone {
+            event_id: event_id.into(),
+            response_id: self.response_id.clone(),
+            item_id: self.item_id.clone(),
+            output_index: self.output_index,
+            content_index: self.content_index,
+            transcript: transcript.into(),
+        }
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::realtime_session::{
+        OutputModality, RealtimeSessionCreateRequest, RealtimeSessionType,
+    };
+
+    // One-shot events via ServerEvent associated functions
+    #[test]
+    fn test_session_created() {
+        let config = SessionConfig::Realtime(Box::new(RealtimeSessionCreateRequest {
+            r#type: RealtimeSessionType::Realtime,
+            output_modalities: Some(vec![OutputModality::Audio]),
+            model: None,
+            instructions: None,
+            audio: None,
+            include: None,
+            tracing: None,
+            tools: None,
+            tool_choice: None,
+            max_output_tokens: None,
+            truncation: None,
+            prompt: None,
+        }));
+
+        let event = ServerEvent::session_created("evt_1", config);
+        assert_eq!(event.event_type(), "session.created");
+        let json = serde_json::to_string(&event).expect("serialization failed");
+        assert!(json.contains("\"type\":\"session.created\""));
+    }
+
+    // Full hierarchy — verifies context propagation at every level
+    #[test]
+    fn test_full_hierarchy() {
+        let l2 = ResponseEventBuilder::new("resp_1");
+
+        // Level 2 terminal — only needs response_id
+        let event = l2.output_audio_buffer_started("evt_1");
+        assert_eq!(event.event_type(), "output_audio_buffer.started");
+        if let ServerEvent::OutputAudioBufferStarted { response_id, .. } = &event {
+            assert_eq!(response_id, "resp_1");
+        } else {
+            panic!("Expected OutputAudioBufferStarted");
+        }
+
+        // Level 3 terminal — needs response_id + item context
+        let l3 = l2.for_item("item_1", 0);
+        let item = RealtimeConversationItem::FunctionCallOutput {
+            call_id: "call_1".into(),
+            output: "result".into(),
+            id: None,
+            object: None,
+            status: None,
+        };
+        let event = l3.output_item_done("evt_2", item);
+        assert_eq!(event.event_type(), "response.output_item.done");
+        if let ServerEvent::ResponseOutputItemDone {
+            response_id,
+            output_index,
+            ..
+        } = &event
+        {
+            assert_eq!(response_id, "resp_1");
+            assert_eq!(*output_index, 0);
+        } else {
+            panic!("Expected ResponseOutputItemDone");
+        }
+
+        // Level 4 terminal — needs response_id + item + content context
+        let l4 = l3.for_content(0);
+        let event = l4.output_text_delta("evt_3", "Hello");
+        assert_eq!(event.event_type(), "response.output_text.delta");
+        if let ServerEvent::ResponseOutputTextDelta {
+            response_id,
+            item_id,
+            output_index,
+            content_index,
+            delta,
+            ..
+        } = &event
+        {
+            assert_eq!(response_id, "resp_1");
+            assert_eq!(item_id, "item_1");
+            assert_eq!(*output_index, 0);
+            assert_eq!(*content_index, 0);
+            assert_eq!(delta, "Hello");
+        } else {
+            panic!("Expected ResponseOutputTextDelta");
+        }
+    }
+
+    // Streaming reuse test — the main motivation for this refactoring
+    #[test]
+    fn test_streaming_reuse() {
+        let ctx = ResponseEventBuilder::new("resp_1")
+            .for_item("item_1", 0)
+            .for_content(0);
+
+        let chunks = ["Hello", " ", "world"];
+        let events: Vec<_> = chunks
+            .iter()
+            .enumerate()
+            .map(|(i, chunk)| ctx.output_text_delta(format!("evt_{i}"), *chunk))
+            .collect();
+
+        assert_eq!(events.len(), 3);
+        for (i, event) in events.iter().enumerate() {
+            assert_eq!(event.event_type(), "response.output_text.delta");
+            if let ServerEvent::ResponseOutputTextDelta {
+                event_id, delta, ..
+            } = event
+            {
+                assert_eq!(event_id, &format!("evt_{i}"));
+                assert_eq!(delta, chunks[i]);
+            }
+        }
+    }
+}

--- a/protocols/src/realtime_response.rs
+++ b/protocols/src/realtime_response.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 use validator::{Validate, ValidationError};
 
 use crate::{
+    builders::RealtimeResponseBuilder,
     common::ResponsePrompt,
     realtime_conversation::{ConversationItemRole, RealtimeContentPart, RealtimeConversationItem},
     realtime_session::{
@@ -269,4 +270,11 @@ fn validate_conversation_item(item: &RealtimeConversationItem) -> Result<(), Val
     }
 
     Ok(())
+}
+
+impl RealtimeResponse {
+    /// Create a builder for constructing a `RealtimeResponse`.
+    pub fn builder(id: impl Into<String>) -> RealtimeResponseBuilder {
+        RealtimeResponseBuilder::new(id)
+    }
 }


### PR DESCRIPTION
Fix: https://github.com/lightseekorg/smg/issues/239
## Description

### Problem

The Realtime API protocol types (`ServerEvent`, `RealtimeResponse`) have many variants and fields, making manual construction verbose and error-prone. Other APIs in this crate (Chat Completion, Responses) already have builder patterns, but the Realtime API does not.

### Solution

Add a builders/realtime/ module to the protocol crate with three construction patterns matched to their use cases:

1. **ServerEvent associated functions** — One-shot constructors for all 46 server event variants (session, conversation, transcription, rate limit, error events). Simple delegation, no intermediate builder state needed.

2. **Hierarchical context builders for streaming events** — A 3-level builder hierarchy (ResponseEventBuilder → ItemEventBuilder → ContentEventBuilder) that captures shared context and produces events via &self terminal methods. This allows builder reuse in the streaming hot path without rebuilding context per event:

```
let ctx = ResponseEventBuilder::new("resp_1")
    .for_item("item_1", 0)
    .for_content(0);
for chunk in chunks {
    send(ctx.output_text_delta(next_event_id(), chunk));
}
```
3. **ClientEvent associated functions** — Constructors for all 11 client event variants, enabling the gateway to programmatically inject events (e.g., MCP tool call results) into the upstream WebSocket connection.

4. **RealtimeResponseBuilder** — Fluent builder for RealtimeResponse with sensible defaults (object: realtime.response, status: InProgress).

## Changes

- protocols/src/builders/realtime/server_event.rs (new, 925 lines) — ServerEvent associated constructors + ResponseEventBuilder/ItemEventBuilder/ContentEventBuilder hierarchy with 3 tests
- protocols/src/builders/realtime/client_event.rs (new, 165 lines) — ClientEvent associated constructors for all 11 variants with 2 tests
- protocols/src/builders/realtime/response.rs (new, 215 lines) — RealtimeResponseBuilder with 2 tests
- protocols/src/builders/realtime/mod.rs (new) — Module declarations and re-exports
- protocols/src/builders/mod.rs — Register realtime submodule and re-export RealtimeResponseBuilder
- protocols/src/realtime_response.rs — Add RealtimeResponse::builder() entry point

## Test Plan

<!-- Provide a thorough reproducible test showing before and after behavior. -->

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Realtime API with fluent builders for creating realtime responses, server-to-client events, and client-to-server events.
  * Added hierarchical event builders to compose multi-level server event flows and streaming semantics.
  * Added convenient response builder for initializing and assembling response payloads.

* **Tests**
  * Added unit tests covering builder creation, full/partial builds, hierarchical usage, and streaming behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->