### PR TITLE
chore[ci]: upgrade oracle image

### DIFF
--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -402,7 +402,7 @@ jobs:
         run: |
           echo "ATP_USER=system" >> $GITHUB_ENV
           echo "ATP_PASSWORD=oracle" >> $GITHUB_ENV
-          echo "ATP_DSN=localhost:1521/XEPDB1" >> $GITHUB_ENV
+          echo "ATP_DSN=localhost:1521/FREEPDB1" >> $GITHUB_ENV
 
       - name: Run E2E tests
         env:


### PR DESCRIPTION
## Description

### Problem
Got warning from current docker container
```
NOTICE: YOU ARE USING AN OLD IMAGE VERSION!
 PLEASE CONSIDER UPGRADING TO gvenzl/oracle-free!
```
<!-- What problem is this PR trying to solve? -->

### Solution
upgrade image based on the suggestion. remove useless docker warmup step
<!-- How does this PR solve the problem? -->

## Changes

<!-- - Describe your changes here. -->

## Test Plan

<!-- Provide a thorough reproducible test showing before and after behavior. -->

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflows: replaced Oracle Docker image with a newer variant, removed a Docker daemon warm‑up step from the pipeline, and adjusted the Oracle connection identifier used in CI environment setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->