### PR TITLE
fix(grpc-proto): reorder authors in pyproject.toml

### DIFF
--- a/grpc_client/python/pyproject.toml
+++ b/grpc_client/python/pyproject.toml
@@ -14,8 +14,8 @@ dependencies = [
 readme = "README.md"
 license = { text = "Apache-2.0" }
 authors = [
-    {name = "Simo Lin", email = "linsimo.mark@gmail.com"},
     {name = "Chang Su", email = "mckvtl@gmail.com"},
+    {name = "Simo Lin", email = "linsimo.mark@gmail.com"},
     {name = "Keyang Ru", email = "rukeyang@gmail.com"}
 ]
 classifiers = [


### PR DESCRIPTION
## Description

### Problem

The PyPI page for smg-grpc-proto shows Simo Lin as the first author, but Chang Su should be listed first.

### Solution

Reorder the authors list in `grpc_client/python/pyproject.toml` to put Chang Su first.

## Changes

- Reorder authors in pyproject.toml: Chang Su, Simo Lin, Keyang Ru

## Test Plan

Metadata-only change. The updated author order will be reflected on PyPI when the next version is published.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] (Optional) Documentation updated

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project authors list metadata ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->