### PR TITLE
fix(ci): modify docker-storage dir and add scaler for a10 runners

### DIFF
--- a/scripts/k8s-runner-resources/arc-runner-autoscaler.yaml
+++ b/scripts/k8s-runner-resources/arc-runner-autoscaler.yaml
@@ -8,8 +8,26 @@ spec:
     kind: RunnerDeployment
     name: arc-runner-gpu-h100
 
-  minReplicas: 10
+  minReplicas: 12
   maxReplicas: 20
+
+  metrics:
+    - type: TotalNumberOfQueuedAndInProgressWorkflowRuns
+      repositoryNames:
+        - lightseekorg/smg
+---
+apiVersion: actions.summerwind.dev/v1alpha1
+kind: HorizontalRunnerAutoscaler
+metadata:
+  name: arc-runner-a10-autoscaler
+  namespace: actions-runner-system
+spec:
+  scaleTargetRef:
+    kind: RunnerDeployment
+    name: arc-runner-gpu-a10
+
+  minReplicas: 2
+  maxReplicas: 4
 
   metrics:
     - type: PercentageRunnersBusy

--- a/scripts/k8s-runner-resources/arc-runner-gpu.yaml
+++ b/scripts/k8s-runner-resources/arc-runner-gpu.yaml
@@ -4,7 +4,7 @@ metadata:
   name: arc-runner-gpu-h100
   namespace: actions-runner-system
 spec:
-  replicas: 10
+  replicas: 12
   template:
     spec:
       repository: lightseekorg/smg
@@ -43,7 +43,9 @@ spec:
         - name: docker-sock
           emptyDir: {}
         - name: docker-storage
-          emptyDir: {}
+          hostPath:
+            path: /var/lib/dind-storage
+            type: DirectoryOrCreate
         - name: dshm
           emptyDir:
             medium: Memory
@@ -123,7 +125,9 @@ spec:
         - name: docker-sock
           emptyDir: {}
         - name: docker-storage
-          emptyDir: {}
+          hostPath:
+            path: /var/lib/dind-storage
+            type: DirectoryOrCreate
         - name: dshm
           emptyDir:
             medium: Memory


### PR DESCRIPTION
## Description

### Problem

  The current CI runner configuration has two issues:
  1. Docker-in-Docker (DinD) storage uses emptyDir volumes, which are backed by the node's memory or ephemeral storage and can lead to disk pressure or storage exhaustion during large container image builds.
  2. There is no autoscaler configured for A10 GPU runners, requiring manual scaling, and the H100 runner pool minimum replicas (10) is insufficient for current workload demands.

### Solution

  - Switch the DinD docker-storage volume from emptyDir to hostPath (/var/lib/dind-storage) for both H100 and A10 runner deployments, providing persistent and more spacious on-disk storage for Docker builds.
  - Add a new HorizontalRunnerAutoscaler for the arc-runner-gpu-a10 deployment (min 2, max 4 replicas) that scales based on queued and in-progress workflow runs.
  - Increase H100 runner pool minimum replicas from 10 to 12 and update the H100 autoscaler to also use the TotalNumberOfQueuedAndInProgressWorkflowRuns metric.

## Changes

  - scripts/k8s-runner-resources/arc-runner-gpu.yaml:
    - Increase H100 runner replicas from 10 to 12.
    - Change docker-storage volume from emptyDir to hostPath (/var/lib/dind-storage, DirectoryOrCreate) for both H100 and A10 runner specs.
  - scripts/k8s-runner-resources/arc-runner-autoscaler.yaml:
    - Increase H100 autoscaler minReplicas from 10 to 12.
    - Add TotalNumberOfQueuedAndInProgressWorkflowRuns metric scoped to lightseekorg/smg for H100 autoscaler.
    - Add new HorizontalRunnerAutoscaler for arc-runner-gpu-a10 (min 2, max 4) using PercentageRunnersBusy scaling metrics.

## Test Plan

applied on mle cluster

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GPU runner infrastructure with increased H100 replica capacity and enhanced workflow queue monitoring
  * Migrated docker storage from temporary to persistent configuration for both H100 and A10 GPU runners
  * Added automatic scaling support for A10 GPU runners with dynamic capacity management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->