### PR TITLE
feat(realtime-api): add Realtime API REST handlers and session registry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ uuid = { version = "1.10", features = ["v7", "serde"] }
 wasmtime = { version = "41.0", features = ["component-model", "async"] }
 wasmtime-wasi = "41.0"
 tokio-util = { version = "0.7", features = ["rt"] }
+tokio-tungstenite = { version = "0.26", features = ["rustls-tls-native-roots"] }
 scopeguard = "1.2"
 bitflags = "2.10.0"
 schemars = "0.8"

--- a/model_gateway/Cargo.toml
+++ b/model_gateway/Cargo.toml
@@ -59,6 +59,7 @@ bytemuck = { workspace = true, features = ["derive"] }
 reqwest = { workspace = true, features = ["stream", "blocking", "json", "rustls-tls"] }
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["full"] }
+tokio-util.workspace = true
 uuid = { workspace = true, features = ["serde"] }
 
 # Workspace crates

--- a/model_gateway/src/app_context.rs
+++ b/model_gateway/src/app_context.rs
@@ -23,7 +23,7 @@ use crate::{
     middleware::TokenBucket,
     observability::inflight_tracker::InFlightRequestTracker,
     policies::PolicyRegistry,
-    routers::router_manager::RouterManager,
+    routers::{openai::realtime::RealtimeRegistry, router_manager::RouterManager},
     wasm::{config::WasmRuntimeConfig, module_manager::WasmModuleManager},
 };
 
@@ -63,6 +63,7 @@ pub struct AppContext {
     pub worker_service: Arc<WorkerService>,
     pub inflight_tracker: Arc<InFlightRequestTracker>,
     pub kv_event_monitor: Option<Arc<KvEventMonitor>>,
+    pub realtime_registry: Arc<RealtimeRegistry>,
 }
 
 impl std::fmt::Debug for AppContext {
@@ -301,6 +302,7 @@ impl AppContextBuilder {
             worker_service,
             inflight_tracker: InFlightRequestTracker::new(),
             kv_event_monitor: self.kv_event_monitor,
+            realtime_registry: Arc::new(RealtimeRegistry::new()),
         })
     }
 

--- a/model_gateway/src/routers/openai/mod.rs
+++ b/model_gateway/src/routers/openai/mod.rs
@@ -9,6 +9,7 @@
 
 mod context;
 mod provider;
+pub mod realtime;
 pub mod responses;
 mod router;
 

--- a/model_gateway/src/routers/openai/realtime/mod.rs
+++ b/model_gateway/src/routers/openai/realtime/mod.rs
@@ -1,0 +1,11 @@
+//! OpenAI Realtime API gateway implementation.
+//!
+//! Supports three transport mechanisms:
+//! - **WebSocket** (server-to-server): Bidirectional WS proxy with transparent MCP interception
+//! - **WebRTC** (browser-to-server): SDP signaling proxy; media + data channel flow directly
+//! - **REST**: Ephemeral token generation (`client_secrets`, `sessions`, `transcription_sessions`)
+
+pub mod registry;
+pub mod rest;
+
+pub use registry::RealtimeRegistry;

--- a/model_gateway/src/routers/openai/realtime/registry.rs
+++ b/model_gateway/src/routers/openai/realtime/registry.rs
@@ -1,0 +1,334 @@
+//! In-memory session and call registry for Realtime API connections.
+
+use std::{
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    time::{Duration, Instant},
+};
+
+use dashmap::DashMap;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info, warn};
+
+/// Connection state for a realtime session.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConnectionState {
+    /// WebSocket upgrade accepted but upstream not yet connected.
+    Pending,
+    /// Bidirectional proxy is active.
+    Connected,
+    /// Connection has been closed.
+    Disconnected,
+}
+
+/// A tracked WebSocket session.
+#[derive(Debug, Clone)]
+pub struct SessionEntry {
+    pub session_id: String,
+    pub model: String,
+    pub worker_url: String,
+    pub state: ConnectionState,
+    pub created_at: Instant,
+    pub cancel_token: CancellationToken,
+}
+
+/// A tracked WebRTC call.
+#[derive(Debug, Clone)]
+pub struct CallEntry {
+    pub call_id: String,
+    pub model: String,
+    pub worker_url: String,
+    pub state: ConnectionState,
+    pub created_at: Instant,
+    pub cancel_token: CancellationToken,
+}
+
+const DEFAULT_MAX_SESSIONS: usize = 10_000;
+const DEFAULT_MAX_CALLS: usize = 10_000;
+
+/// DashMap-backed registry for realtime sessions and WebRTC calls.
+///
+/// Uses atomic counters for capacity enforcement to avoid TOCTOU races
+/// between the length check and the DashMap insert.
+#[derive(Debug)]
+pub struct RealtimeRegistry {
+    sessions: DashMap<String, SessionEntry>,
+    calls: DashMap<String, CallEntry>,
+    session_count: AtomicUsize,
+    call_count: AtomicUsize,
+    max_sessions: usize,
+    max_calls: usize,
+}
+
+impl RealtimeRegistry {
+    pub fn new() -> Self {
+        Self {
+            sessions: DashMap::new(),
+            calls: DashMap::new(),
+            session_count: AtomicUsize::new(0),
+            call_count: AtomicUsize::new(0),
+            max_sessions: DEFAULT_MAX_SESSIONS,
+            max_calls: DEFAULT_MAX_CALLS,
+        }
+    }
+
+    pub fn with_capacity(max_sessions: usize, max_calls: usize) -> Self {
+        Self {
+            sessions: DashMap::new(),
+            calls: DashMap::new(),
+            session_count: AtomicUsize::new(0),
+            call_count: AtomicUsize::new(0),
+            max_sessions,
+            max_calls,
+        }
+    }
+
+    // ---- Session methods ----
+
+    pub fn register_session(
+        &self,
+        session_id: String,
+        model: String,
+        worker_url: String,
+    ) -> Option<SessionEntry> {
+        if !self.try_reserve_session() {
+            warn!(
+                max = self.max_sessions,
+                "Session registry at capacity, rejecting registration"
+            );
+            return None;
+        }
+        let entry = SessionEntry {
+            session_id: session_id.clone(),
+            model,
+            worker_url,
+            state: ConnectionState::Pending,
+            created_at: Instant::now(),
+            cancel_token: CancellationToken::new(),
+        };
+        if let Some(old) = self.sessions.insert(session_id, entry.clone()) {
+            // Replaced an existing entry — cancel its token so awaiting tasks
+            // are notified, and undo the extra reservation.
+            old.cancel_token.cancel();
+            self.session_count.fetch_sub(1, Ordering::Relaxed);
+        }
+        Some(entry)
+    }
+
+    pub fn set_session_state(&self, session_id: &str, state: ConnectionState) {
+        if let Some(mut entry) = self.sessions.get_mut(session_id) {
+            entry.state = state;
+        }
+    }
+
+    pub fn get_session(&self, session_id: &str) -> Option<SessionEntry> {
+        self.sessions.get(session_id).map(|e| e.clone())
+    }
+
+    pub fn remove_session(&self, session_id: &str) -> Option<SessionEntry> {
+        self.sessions.remove(session_id).map(|(_, e)| {
+            e.cancel_token.cancel();
+            self.session_count.fetch_sub(1, Ordering::Relaxed);
+            e
+        })
+    }
+
+    // ---- Call methods ----
+
+    pub fn register_call(
+        &self,
+        call_id: String,
+        model: String,
+        worker_url: String,
+    ) -> Option<CallEntry> {
+        if !self.try_reserve_call() {
+            warn!(
+                max = self.max_calls,
+                "Call registry at capacity, rejecting registration"
+            );
+            return None;
+        }
+        let entry = CallEntry {
+            call_id: call_id.clone(),
+            model,
+            worker_url,
+            state: ConnectionState::Pending,
+            created_at: Instant::now(),
+            cancel_token: CancellationToken::new(),
+        };
+        if let Some(old) = self.calls.insert(call_id, entry.clone()) {
+            // Replaced an existing entry — cancel its token so awaiting tasks
+            // are notified, and undo the extra reservation.
+            old.cancel_token.cancel();
+            self.call_count.fetch_sub(1, Ordering::Relaxed);
+        }
+        Some(entry)
+    }
+
+    pub fn get_call(&self, call_id: &str) -> Option<CallEntry> {
+        self.calls.get(call_id).map(|e| e.clone())
+    }
+
+    pub fn set_call_state(&self, call_id: &str, state: ConnectionState) {
+        if let Some(mut entry) = self.calls.get_mut(call_id) {
+            entry.state = state;
+        }
+    }
+
+    pub fn remove_call(&self, call_id: &str) -> Option<CallEntry> {
+        self.calls.remove(call_id).map(|(_, e)| {
+            e.cancel_token.cancel();
+            self.call_count.fetch_sub(1, Ordering::Relaxed);
+            e
+        })
+    }
+
+    // ---- Atomic reservation helpers ----
+
+    /// Atomically reserve a session slot. Returns `true` if a slot was
+    /// successfully claimed, `false` if at capacity.
+    fn try_reserve_session(&self) -> bool {
+        self.try_reserve(&self.session_count, self.max_sessions)
+    }
+
+    /// Atomically reserve a call slot.
+    fn try_reserve_call(&self) -> bool {
+        self.try_reserve(&self.call_count, self.max_calls)
+    }
+
+    /// CAS loop: increment `counter` only if it is below `max`.
+    #[expect(
+        clippy::unused_self,
+        reason = "method for API consistency with other registry methods"
+    )]
+    fn try_reserve(&self, counter: &AtomicUsize, max: usize) -> bool {
+        loop {
+            let current = counter.load(Ordering::Relaxed);
+            if current >= max {
+                return false;
+            }
+            if counter
+                .compare_exchange_weak(current, current + 1, Ordering::Relaxed, Ordering::Relaxed)
+                .is_ok()
+            {
+                return true;
+            }
+        }
+    }
+
+    // ---- Reaper ----
+
+    /// Start a background task that evicts stale entries.
+    ///
+    /// Returns a `CancellationToken` that stops the reaper when cancelled.
+    pub fn start_reaper(
+        self: &Arc<Self>,
+        max_age: Duration,
+        interval: Duration,
+    ) -> CancellationToken {
+        let shutdown = CancellationToken::new();
+        let token = shutdown.clone();
+        let registry = Arc::clone(self);
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "reaper task cancelled via returned token"
+        )]
+        tokio::spawn(async move {
+            let mut tick = tokio::time::interval(interval);
+            loop {
+                tokio::select! {
+                    _ = tick.tick() => {}
+                    () = shutdown.cancelled() => {
+                        info!("Realtime registry reaper shutting down");
+                        return;
+                    }
+                }
+                let now = Instant::now();
+
+                // Reap stale, non-active entries atomically using remove_if
+                // to avoid TOCTOU races with concurrent re-registration.
+                // Active (Connected) sessions are never reaped — they will
+                // be cleaned up when the connection closes normally.
+                let stale_session_ids: Vec<String> = registry
+                    .sessions
+                    .iter()
+                    .filter(|e| {
+                        e.state != ConnectionState::Connected
+                            && now.duration_since(e.created_at) > max_age
+                    })
+                    .map(|e| e.session_id.clone())
+                    .collect();
+
+                let mut sessions_reaped = 0usize;
+                for id in &stale_session_ids {
+                    if let Some((_, entry)) = registry.sessions.remove_if(id, |_, e| {
+                        e.state != ConnectionState::Connected
+                            && now.duration_since(e.created_at) > max_age
+                    }) {
+                        entry.cancel_token.cancel();
+                        sessions_reaped += 1;
+                    }
+                }
+
+                let stale_call_ids: Vec<String> = registry
+                    .calls
+                    .iter()
+                    .filter(|e| {
+                        e.state != ConnectionState::Connected
+                            && now.duration_since(e.created_at) > max_age
+                    })
+                    .map(|e| e.call_id.clone())
+                    .collect();
+
+                let mut calls_reaped = 0usize;
+                for id in &stale_call_ids {
+                    if let Some((_, entry)) = registry.calls.remove_if(id, |_, e| {
+                        e.state != ConnectionState::Connected
+                            && now.duration_since(e.created_at) > max_age
+                    }) {
+                        entry.cancel_token.cancel();
+                        calls_reaped += 1;
+                    }
+                }
+
+                // Sync atomic counters with actual removal counts.
+                if sessions_reaped > 0 {
+                    registry
+                        .session_count
+                        .fetch_sub(sessions_reaped, Ordering::Relaxed);
+                }
+                if calls_reaped > 0 {
+                    registry
+                        .call_count
+                        .fetch_sub(calls_reaped, Ordering::Relaxed);
+                }
+
+                if sessions_reaped > 0 || calls_reaped > 0 {
+                    debug!(
+                        sessions_reaped,
+                        calls_reaped, "Realtime registry reaper cycle"
+                    );
+                }
+            }
+        });
+        info!("Realtime registry reaper started (max_age={max_age:?}, interval={interval:?})");
+        token
+    }
+
+    /// Stats for observability.
+    pub fn session_count(&self) -> usize {
+        self.session_count.load(Ordering::Relaxed)
+    }
+
+    pub fn call_count(&self) -> usize {
+        self.call_count.load(Ordering::Relaxed)
+    }
+}
+
+impl Default for RealtimeRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/model_gateway/src/routers/openai/realtime/rest.rs
+++ b/model_gateway/src/routers/openai/realtime/rest.rs
@@ -1,0 +1,189 @@
+//! REST handlers for Realtime API token generation endpoints.
+//!
+//! These endpoints generate ephemeral tokens for browser-safe authentication.
+//! They do NOT create sessions — sessions are created implicitly when the
+//! client connects (WebSocket or WebRTC).
+
+use std::sync::Arc;
+
+use axum::{
+    extract::State,
+    http::{HeaderMap, StatusCode},
+    response::{IntoResponse, Response},
+    Json,
+};
+use serde_json::Value;
+use tracing::{debug, error};
+
+use crate::{
+    core::worker::{RuntimeType, Worker, WorkerLoadGuard},
+    routers::{error, header_utils::extract_auth_header},
+    server::AppState,
+};
+
+/// `POST /v1/realtime/client_secrets` — GA ephemeral token generation.
+///
+/// Generates a short-lived token for browser-safe auth. The session config
+/// (model, voice, tools) is included in the request body, pre-configuring
+/// the session. MCP tool definitions are injected before forwarding.
+pub async fn create_client_secret(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(body): Json<Value>,
+) -> Response {
+    let model = match body.pointer("/session/model").and_then(|v| v.as_str()) {
+        Some(m) => m.to_string(),
+        None => return error::bad_request("missing_model", "session.model is required"),
+    };
+
+    // TODO(Phase 3): Inject MCP tool definitions into body.session.tools
+
+    proxy_realtime_rest(
+        &state,
+        &headers,
+        &body,
+        &model,
+        "/v1/realtime/client_secrets",
+    )
+    .await
+}
+
+/// `POST /v1/realtime/sessions` — Legacy ephemeral token generation.
+///
+/// Kept for backwards compatibility; prefer `create_client_secret` for new integrations.
+pub async fn create_session(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(body): Json<Value>,
+) -> Response {
+    let model = match body.get("model").and_then(|v| v.as_str()) {
+        Some(m) => m.to_string(),
+        None => return error::bad_request("missing_model", "model is required"),
+    };
+
+    // TODO(Phase 3): Inject MCP tool definitions into body.tools
+
+    proxy_realtime_rest(&state, &headers, &body, &model, "/v1/realtime/sessions").await
+}
+
+/// `POST /v1/realtime/transcription_sessions` — Legacy ephemeral token generation for transcription.
+///
+/// Kept for backwards compatibility; prefer `create_client_secret` for new integrations.
+pub async fn create_transcription_session(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(body): Json<Value>,
+) -> Response {
+    let model = match body.get("model").and_then(|v| v.as_str()) {
+        Some(m) => m.to_string(),
+        None => return error::bad_request("missing_model", "model is required"),
+    };
+
+    // TODO(Phase 3): Inject MCP tool definitions into config
+
+    proxy_realtime_rest(
+        &state,
+        &headers,
+        &body,
+        &model,
+        "/v1/realtime/transcription_sessions",
+    )
+    .await
+}
+
+/// Shared proxy logic for all realtime REST endpoints.
+///
+/// Handles worker selection, load tracking, auth, header forwarding,
+/// upstream request, circuit breaker outcome recording, and response proxying.
+async fn proxy_realtime_rest(
+    state: &AppState,
+    headers: &HeaderMap,
+    body: &Value,
+    model: &str,
+    path: &str,
+) -> Response {
+    let worker = match select_worker(state, model) {
+        Some(w) => w,
+        None => {
+            error!(model, path, "No available worker for realtime model");
+            return StatusCode::SERVICE_UNAVAILABLE.into_response();
+        }
+    };
+
+    let auth = match extract_auth_header(Some(headers), worker.api_key()) {
+        Some(v) => v,
+        None => return StatusCode::UNAUTHORIZED.into_response(),
+    };
+
+    // Track load for the duration of the upstream request
+    let _guard = WorkerLoadGuard::new(worker.clone(), Some(headers));
+
+    let upstream_url = format!("{}{path}", worker.url().trim_end_matches('/'));
+    debug!(model, upstream_url, "Forwarding realtime REST request");
+
+    let result = forward_post(&state.context.client, &upstream_url, &auth, body)
+        .send()
+        .await;
+
+    match result {
+        Ok(resp) => {
+            let success = resp.status().is_success();
+            let response = proxy_response(resp).await;
+            worker.record_outcome(success);
+            response
+        }
+        Err(e) => {
+            error!(error = %e, path, "Failed to forward realtime REST request");
+            worker.record_outcome(false);
+            StatusCode::BAD_GATEWAY.into_response()
+        }
+    }
+}
+
+/// Build a POST request to upstream with the caller's auth token.
+fn forward_post(
+    client: &reqwest::Client,
+    upstream_url: &str,
+    auth: &http::HeaderValue,
+    body: &Value,
+) -> reqwest::RequestBuilder {
+    client
+        .post(upstream_url)
+        .header("Authorization", auth)
+        .json(body)
+}
+
+/// Select the best available worker for a realtime model.
+///
+/// Uses `supports_model()` which checks `models_override` (populated by lazy
+/// discovery), unlike `get_by_model()` which relies on `model_index` (not
+/// populated for lazily-discovered workers).
+pub(super) fn select_worker(state: &AppState, model: &str) -> Option<Arc<dyn Worker>> {
+    state
+        .context
+        .worker_registry
+        .get_workers_filtered(None, None, None, Some(RuntimeType::External), true)
+        .into_iter()
+        .filter(|w| w.supports_model(model) && w.circuit_breaker().can_execute())
+        .min_by_key(|w| w.load())
+}
+
+/// Convert an upstream reqwest Response into an axum Response,
+/// preserving status code and body.
+pub(super) async fn proxy_response(resp: reqwest::Response) -> Response {
+    let status = StatusCode::from_u16(resp.status().as_u16()).unwrap_or(StatusCode::BAD_GATEWAY);
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/json")
+        .to_string();
+
+    match resp.bytes().await {
+        Ok(body) => (status, [(http::header::CONTENT_TYPE, content_type)], body).into_response(),
+        Err(e) => {
+            error!(error = %e, "Failed to read upstream response body");
+            StatusCode::BAD_GATEWAY.into_response()
+        }
+    }
+}

--- a/model_gateway/src/server.rs
+++ b/model_gateway/src/server.rs
@@ -59,6 +59,7 @@ use crate::{
             get_mesh_health, get_policy_state, get_policy_states, get_worker_state,
             get_worker_states, set_global_rate_limit, trigger_graceful_shutdown, update_app_config,
         },
+        openai::realtime::rest as realtime_rest,
         parse,
         router_manager::RouterManager,
         tokenize, RouterTrait,
@@ -613,6 +614,25 @@ pub fn build_app(
             middleware::wasm_middleware,
         ));
 
+    let realtime_routes = Router::new()
+        .route("/v1/realtime/sessions", post(realtime_rest::create_session))
+        .route(
+            "/v1/realtime/client_secrets",
+            post(realtime_rest::create_client_secret),
+        )
+        .route(
+            "/v1/realtime/transcription_sessions",
+            post(realtime_rest::create_transcription_session),
+        )
+        .route_layer(axum::middleware::from_fn_with_state(
+            app_state.clone(),
+            middleware::concurrency_limit_middleware,
+        ))
+        .route_layer(axum::middleware::from_fn_with_state(
+            auth_config.clone(),
+            middleware::auth_middleware,
+        ));
+
     let public_routes = Router::new()
         .route("/liveness", get(liveness))
         .route("/readiness", get(readiness))
@@ -692,6 +712,7 @@ pub fn build_app(
 
     Router::new()
         .merge(protected_routes)
+        .merge(realtime_routes)
         .merge(public_routes)
         .merge(admin_routes)
         .merge(worker_routes)

--- a/model_gateway/src/service_discovery.rs
+++ b/model_gateway/src/service_discovery.rs
@@ -887,6 +887,7 @@ mod tests {
         use crate::{
             config::RouterConfig, core::WorkerService, middleware::TokenBucket,
             observability::inflight_tracker::InFlightRequestTracker,
+            routers::openai::realtime::RealtimeRegistry,
         };
 
         let router_config = RouterConfig::builder()
@@ -929,6 +930,7 @@ mod tests {
             )),
             inflight_tracker: InFlightRequestTracker::new(),
             kv_event_monitor: None,
+            realtime_registry: Arc::new(RealtimeRegistry::new()),
         })
     }
 


### PR DESCRIPTION
openai api spec: https://developers.openai.com/api/reference/resources/realtime
Fix: https://github.com/lightseekorg/smg/issues/240 https://github.com/lightseekorg/smg/issues/241 https://github.com/lightseekorg/smg/issues/242
## Description

### Problem
The model gateway has no support for OpenAI's Realtime API. Clients that need ephemeral tokens for browser-safe WebSocket or WebRTC authentication (via /v1/realtime/client_secrets, /v1/realtime/sessions, or /v1/realtime/transcription_sessions) cannot route through the gateway, forcing them to connect directly to upstream workers and bypassing the gateway's load balancing, auth, and
  circuit-breaker infrastructure.

  Additionally, there is no in-memory tracking of active WebSocket sessions or WebRTC calls, which will be needed for upcoming WebSocket/WebRTC proxy phases to manage connection lifecycle, enforce capacity limits, and reap stale entries.
### Solution

Introduce the Realtime API module (routers::openai::realtime) with two components:

  1. REST proxy handlers (rest.rs) — three POST endpoints that validate the request body for a model field, select the lowest-load external worker via circuit-breaker-aware routing, forward the request with passthrough auth, record the outcome for circuit breaker health tracking, and proxy the upstream response back to the client.
  2. In-memory session/call registry (registry.rs) — a DashMap-backed, thread-safe registry that tracks WebSocket sessions and WebRTC calls with ConnectionState lifecycle management (Pending → Connected → Disconnected). Uses CAS-based atomic counters for capacity enforcement (default 10k each) and includes a background reaper task that evicts stale non-active entries on a configurable
  interval.

  The REST endpoints are wired into the axum router behind the existing auth and concurrency-limit middleware. The registry is created in AppContext and made available through AppState for use by future WebSocket/WebRTC handler phases.

## Changes

 - model_gateway/src/routers/openai/realtime/mod.rs (new) — Module declaration exposing registry, rest, and re-exporting RealtimeRegistry.
  - model_gateway/src/routers/openai/realtime/registry.rs (new) — RealtimeRegistry with SessionEntry/CallEntry tracking, ConnectionState enum, atomic capacity enforcement, and a cancellable reaper background task.
  - model_gateway/src/routers/openai/realtime/rest.rs (new) — create_client_secret, create_session, create_transcription_session handlers with shared proxy_realtime_rest logic; select_worker and proxy_response exposed as pub(super) for future sibling modules.
  - model_gateway/src/server.rs — Registers the three realtime REST routes under a new realtime_routes group with auth and concurrency-limit middleware.
  - model_gateway/src/app_context.rs — Adds realtime_registry: Arc<RealtimeRegistry> to AppContext and initializes it in the builder.
  - model_gateway/src/routers/openai/mod.rs — Declares the new pub mod realtime submodule.
  - model_gateway/src/service_discovery.rs — Adds realtime_registry initialization in test fixture.
  - Cargo.toml (workspace) — Adds tokio-tungstenite and multer workspace dependencies (for upcoming WebSocket/WebRTC phases).
  - model_gateway/Cargo.toml — Adds tokio-util direct dependency for CancellationToken.

## Test Plan

#### Client secret: curl -X POST localhost:30000/v1/realtime/client_secrets -H "Authorization: Bearer $KEY" -d '{"session":{"type":"realtime","model":"gpt-4o-realtime-preview","audio":{"output":{"voice":"alloy"}}}}' → expect client_secret.value + expires_at
```
curl -X POST http://localhost:30000/v1/realtime/client_secrets \
                -H "Authorization: Bearer $KEY" \
                -H "Content-Type: application/json" \
                -d '{
                  "expires_after": {
                    "anchor": "created_at",
                    "seconds": 600
                  },
                  "session": {
                    "type": "realtime",
                    "model": "gpt-realtime",
                    "instructions": "You are a friendly assistant."}}'
{
  "value": "ek_698ceca6bad481919b5ca42dca20abb7",
  "expires_at": 1770843902,
  "session": {
    "type": "realtime",
    "object": "realtime.session",
    "id": "sess_D8BWgCxbdcPZIZiuA6f5j",
    "model": "gpt-realtime",
    "output_modalities": [
      "audio"
    ],
    "instructions": "You are a friendly assistant.",
    "tools": [],
    "tool_choice": "auto",
    "max_output_tokens": "inf",
    "tracing": null,
    "truncation": "auto",
    "prompt": null,
    "expires_at": 0,
    "audio": {
      "input": {
        "format": {
          "type": "audio/pcm",
          "rate": 24000
        },
        "transcription": null,
        "noise_reduction": null,
        "turn_detection": {
          "type": "server_vad",
          "threshold": 0.5,
          "prefix_padding_ms": 300,
          "silence_duration_ms": 200,
          "idle_timeout_ms": null,
          "create_response": true,
          "interrupt_response": true
        }
      },
      "output": {
        "format": {
          "type": "audio/pcm",
          "rate": 24000
        },
        "voice": "alloy",
        "speed": 1.0
      }
    },
    "include": null
  }
}%                                                                                                                                         
```

#### Session creation (legacy): curl -X POST http://localhost:30000/v1/realtime/sessions -H "Authorization: Bearer $KEY" -d '{"model":"gpt-4o-realtime-preview"}' → expect session object with client_secret.value

```
curl -X POST http://localhost：30000/v1/realtime/sessions \
                -H "Authorization: Bearer $KEY" \
                -H "Content-Type: application/json" \
                -d '{
                  "model": "gpt-realtime",
                  "modalities": ["audio", "text"],
                  "instructions": "You are a friendly assistant."
                }'
{
  "object": "realtime.session",
  "id": "sess_D8BZWy7dupg4uQ7mQZdPf",
  "model": "gpt-realtime",
  "modalities": [
    "audio",
    "text"
  ],
  "instructions": "You are a friendly assistant.",
  "voice": "alloy",
  "output_audio_format": "pcm16",
  "tools": [],
  "tool_choice": "auto",
  "temperature": 0.8,
  "max_response_output_tokens": "inf",
  "turn_detection": {
    "type": "server_vad",
    "threshold": 0.5,
    "prefix_padding_ms": 300,
    "silence_duration_ms": 200,
    "idle_timeout_ms": null,
    "create_response": true,
    "interrupt_response": true
  },
  "speed": 1.0,
  "tracing": null,
  "truncation": "auto",
  "prompt": null,
  "expires_at": 0,
  "input_audio_noise_reduction": null,
  "input_audio_format": "pcm16",
  "input_audio_transcription": null,
  "client_secret": {
    "value": "xxx",
    "expires_at": 1770844078
  },
  "include": null
}%                                     
```

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenAI Realtime API support with REST endpoints for session creation, client secret management, and transcription sessions
  * Added realtime session and call tracking with connection state awareness and automatic cleanup

* **Chores**
  * Workspace updated to include new dependencies required for realtime transports and multipart handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->