### PR TITLE
chore(ci): increase chat-completions-trtllm timeout to 60 minutes

### DIFF
--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -305,7 +305,7 @@ jobs:
             setup_vllm: true
             ignore_opts: ""
           - name: chat-completions-trtllm
-            timeout: 25
+            timeout: 60
             test_dirs: "e2e_test/chat_completions"
             extra_deps: "pytest-parallel py"
             env_vars: "E2E_RUNTIME=trtllm SHOW_WORKER_LOGS=1 SHOW_ROUTER_LOGS=1"


### PR DESCRIPTION
## Description

### Problem

The `chat-completions-trtllm` job has a 25-minute timeout, which is too short for uncached TRT-LLM wheel builds. Cache misses (from eviction, branch scoping, or intentional busting) cause the job to time out before it can build and save the wheel, creating a permanent failure loop on `main`.

### Solution

Increase the timeout to 60 minutes to accommodate uncached builds.

## Changes

- Bump `chat-completions-trtllm` matrix timeout from 25 to 60 minutes

## Test Plan

The next CI run on `main` should complete the TRT-LLM wheel build and cache it.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow timeout configuration for testing infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->