### PR TITLE
fix(grpc-proto): bump grpcio minimum to >=1.78.0

### DIFF
--- a/grpc_client/python/README.md
+++ b/grpc_client/python/README.md
@@ -1,17 +1,22 @@
 # smg-grpc-proto
 
-Protocol Buffer definitions for SMG (Shepherd Model Gateway) gRPC services.
+[![PyPI](https://img.shields.io/pypi/v/smg-grpc-proto)](https://pypi.org/project/smg-grpc-proto/)
+[![Python](https://img.shields.io/pypi/pyversions/smg-grpc-proto)](https://pypi.org/project/smg-grpc-proto/)
 
-This package provides the Python gRPC stubs for:
-- **SGLang** scheduler service
-- **vLLM** engine service
-- **TRT-LLM** service
+Protocol Buffer definitions for [SMG](https://github.com/lightseekorg/smg) (Shepherd Model Gateway) gRPC services.
+
+This package provides pre-compiled Python gRPC stubs for:
+- **SGLang** scheduler service (`sglang_scheduler.proto`)
+- **vLLM** engine service (`vllm_engine.proto`)
+- **TensorRT-LLM** service (`trtllm_service.proto`)
 
 ## Installation
 
 ```bash
 pip install smg-grpc-proto
 ```
+
+Requires `grpcio>=1.78.0` and `protobuf>=5.26.0`.
 
 ## Usage
 
@@ -21,14 +26,15 @@ from smg_grpc_proto import vllm_engine_pb2, vllm_engine_pb2_grpc
 from smg_grpc_proto import trtllm_service_pb2, trtllm_service_pb2_grpc
 ```
 
+## Proto Source
+
+The proto source files live in [`grpc_client/proto/`](https://github.com/lightseekorg/smg/tree/main/grpc_client/proto) in the SMG repository. Python stubs are generated at build time using `grpcio-tools` and shipped in the wheel.
+
 ## Development
 
-The proto files are located in `grpc_client/proto/` in the SMG repository. A symlink at `smg_grpc_proto/proto` points to the proto source files. Python stubs are generated at build time using `grpcio-tools`.
-
-To install in editable mode:
+To install in editable mode from the repo root:
 
 ```bash
-# From repo root (symlink handles proto file discovery)
 pip install -e grpc_client/python/
 ```
 

--- a/grpc_client/python/pyproject.toml
+++ b/grpc_client/python/pyproject.toml
@@ -1,14 +1,14 @@
 [build-system]
-requires = ["setuptools>=68.0", "grpcio-tools>=1.62.0"]
+requires = ["setuptools>=68.0", "grpcio-tools>=1.78.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "smg-grpc-proto"
-version = "0.3.2"
+dynamic = ["version"]
 description = "SMG gRPC proto definitions for SGLang, vLLM, and TRT-LLM"
 requires-python = ">=3.10"
 dependencies = [
-    "grpcio>=1.62.0",
+    "grpcio>=1.78.0",
     "protobuf>=5.26.0",
 ]
 readme = "README.md"
@@ -35,6 +35,9 @@ Repository = "https://github.com/lightseekorg/smg"
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["smg_grpc_proto*"]
+
+[tool.setuptools.dynamic]
+version = {attr = "smg_grpc_proto.__version__"}
 
 [tool.setuptools.package-data]
 smg_grpc_proto = ["proto/*.proto", "generated/*.py", "generated/*.pyi"]

--- a/grpc_client/python/smg_grpc_proto/__init__.py
+++ b/grpc_client/python/smg_grpc_proto/__init__.py
@@ -1,6 +1,6 @@
 """SMG gRPC Proto - Protocol definitions for SGLang, vLLM, and TRT-LLM."""
 
-__version__ = "0.3.2"
+__version__ = "0.3.3"
 
 # Re-export generated modules for convenient access
 # These imports will work after the package is built (stubs generated at build time)


### PR DESCRIPTION
## Description

### Problem

`smg-grpc-proto==0.3.2` declares `grpcio>=1.62.0` as its runtime dependency, but the stubs shipped in the wheel were generated with `grpcio-tools>=1.78.0`. The generated `*_pb2_grpc.py` files embed a runtime version check that raises `RuntimeError` when `grpcio<1.78.0` is installed:

```
RuntimeError: The grpc package installed is at version 1.75.1, but the generated code
in sglang_scheduler_pb2_grpc.py depends on grpcio>=1.78.0.
```

### Solution

Bump both the build-time (`grpcio-tools`) and runtime (`grpcio`) lower bounds to `>=1.78.0` to match what the generated stubs actually require. Bump version to `0.3.3`.

## Changes

- `grpc_client/python/pyproject.toml`: bump `grpcio-tools>=1.78.0` (build), `grpcio>=1.78.0` (runtime), version `0.3.3`
- `grpc_client/python/smg_grpc_proto/__init__.py`: bump `__version__` to `0.3.3`
- `grpc_client/python/README.md`: add PyPI badges, document grpcio requirement, clarify proto source location

## Test Plan

```bash
pip install grpcio==1.78.0
pip install smg-grpc-proto  # after publishing 0.3.3
python -c "from smg_grpc_proto import vllm_engine_pb2; print('OK')"
```

Verified locally: import succeeds with `grpcio==1.78.0`, fails with `grpcio==1.75.1`.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded README with PyPI badges, explicit service names (renamed to TensorRT-LLM), listed proto files, and a new "Proto Source" section
  * Clarified installation and compatibility (grpcio/protobuf versions), added usage examples importing service stubs
  * Added editable-install and CI-friendly fallback workflow; noted stubs are pre-compiled and shipped in the wheel

* **Chores**
  * Bumped package version to 0.3.3
  * Raised minimum grpcio and grpcio-tools requirements; switched to dynamic version sourcing for package metadata
<!-- end of auto-generated comment: release notes by coderabbit.ai -->