### PR TITLE
refactor: remove remaining pub use re-export aliases from lib.rs

### DIFF
--- a/bindings/golang/Cargo.toml
+++ b/bindings/golang/Cargo.toml
@@ -24,6 +24,15 @@ async-trait = "0.1"
 path = "../../model_gateway"
 default-features = true
 
+[dependencies.openai-protocol]
+workspace = true
+
+[dependencies.llm-tokenizer]
+path = "../../tokenizer"
+
+[dependencies.tool-parser]
+path = "../../tool_parser"
+
 [dependencies.smg-grpc-client]
 workspace = true
 

--- a/bindings/golang/src/client.rs
+++ b/bindings/golang/src/client.rs
@@ -7,11 +7,9 @@ use std::{
     sync::Arc,
 };
 
-use smg::{
-    protocols::chat::ChatCompletionRequest,
-    routers::grpc::utils::{generate_tool_constraints, process_chat_messages},
-    tokenizer::{create_tokenizer_from_file, traits::Tokenizer},
-};
+use llm_tokenizer::{create_tokenizer_from_file, traits::Tokenizer};
+use openai_protocol::chat::ChatCompletionRequest;
+use smg::routers::grpc::utils::{generate_tool_constraints, process_chat_messages};
 use smg_grpc_client::sglang_scheduler::SglangSchedulerClient;
 use uuid::Uuid;
 

--- a/bindings/golang/src/policy.rs
+++ b/bindings/golang/src/policy.rs
@@ -16,6 +16,8 @@ use std::{
 };
 
 use async_trait::async_trait;
+use llm_tokenizer::{create_tokenizer_from_file, traits::Tokenizer};
+use openai_protocol::{chat::ChatCompletionRequest, worker::WorkerSpec};
 use smg::{
     core::{
         circuit_breaker::CircuitBreaker,
@@ -26,9 +28,7 @@ use smg::{
         BucketPolicy, CacheAwarePolicy, LoadBalancingPolicy, PowerOfTwoPolicy, RandomPolicy,
         RoundRobinPolicy, SelectWorkerInfo,
     },
-    protocols::{chat::ChatCompletionRequest, worker::WorkerSpec},
     routers::grpc::utils::{generate_tool_constraints, process_chat_messages},
-    tokenizer::{create_tokenizer_from_file, traits::Tokenizer},
 };
 use smg_grpc_client::sglang_scheduler::SglangSchedulerClient;
 use uuid::Uuid;

--- a/bindings/golang/src/preprocessor.rs
+++ b/bindings/golang/src/preprocessor.rs
@@ -13,11 +13,9 @@ use std::{
     ptr,
 };
 
-use smg::{
-    protocols::chat::ChatCompletionRequest,
-    routers::grpc::utils::{generate_tool_constraints, process_chat_messages},
-    tokenizer::{create_tokenizer_from_file, traits::Tokenizer},
-};
+use llm_tokenizer::{create_tokenizer_from_file, traits::Tokenizer};
+use openai_protocol::chat::ChatCompletionRequest;
+use smg::routers::grpc::utils::{generate_tool_constraints, process_chat_messages};
 
 use super::{
     error::{set_error_message, SglErrorCode},

--- a/bindings/golang/src/runtime.rs
+++ b/bindings/golang/src/runtime.rs
@@ -1,8 +1,8 @@
 //! Shared runtime and global resources for FFI
 
 use once_cell::sync::Lazy;
-use smg::tool_parser::ParserFactory;
 use tokio::runtime::Runtime;
+use tool_parser::ParserFactory;
 
 /// Global tokio runtime for all async FFI operations
 pub static RUNTIME: Lazy<Runtime> =

--- a/bindings/golang/src/stream_state.rs
+++ b/bindings/golang/src/stream_state.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 
-use smg::tokenizer::stream::DecodeStream;
+use llm_tokenizer::stream::DecodeStream;
 
 /// Per-index state for streaming responses
 pub struct StreamIndexState {

--- a/bindings/golang/src/tokenizer.rs
+++ b/bindings/golang/src/tokenizer.rs
@@ -7,11 +7,11 @@ use std::{
     sync::Arc,
 };
 
-use serde_json::Value;
-use smg::tokenizer::{
+use llm_tokenizer::{
     chat_template::ChatTemplateParams, create_tokenizer, huggingface::HuggingFaceTokenizer,
     traits::Tokenizer as TokenizerTrait,
 };
+use serde_json::Value;
 
 use super::error::{clear_error_message, set_error_message, SglErrorCode};
 

--- a/bindings/golang/src/tool_parser.rs
+++ b/bindings/golang/src/tool_parser.rs
@@ -8,8 +8,9 @@ use std::{
     sync::Arc,
 };
 
+use openai_protocol::common::Tool;
 use serde_json::{json, Value};
-use smg::{protocols::common::Tool, tool_parser::ToolParser};
+use tool_parser::ToolParser;
 
 use super::{
     error::{clear_error_message, set_error_message, SglErrorCode},

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -16,6 +16,12 @@ once_cell = "1.19"
 path = "../../model_gateway"
 default-features = true
 
+[dependencies.smg-auth]
+path = "../../auth"
+
+[dependencies.tool-parser]
+path = "../../tool_parser"
+
 [features]
 default = ["pyo3/extension-module"]
 vendored-openssl = ["smg/vendored-openssl"]

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use once_cell::sync::OnceCell;
 use pyo3::prelude::*;
 use smg::*;
+use smg_auth as auth;
 
 // Define the enums with PyO3 bindings
 #[pyclass(eq)]

--- a/model_gateway/benches/request_processing.rs
+++ b/model_gateway/benches/request_processing.rs
@@ -1,16 +1,16 @@
 use std::{hint::black_box, time::Instant};
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use openai_protocol::{
+    chat::{ChatCompletionRequest, ChatMessage, MessageContent},
+    common::StringOrArray,
+    completion::CompletionRequest,
+    generate::GenerateRequest,
+    sampling_params::SamplingParams,
+};
 use serde_json::{from_str, to_string, to_value, to_vec};
 use smg::{
     core::{BasicWorker, BasicWorkerBuilder, Worker, WorkerType},
-    protocols::{
-        chat::{ChatCompletionRequest, ChatMessage, MessageContent},
-        common::StringOrArray,
-        completion::CompletionRequest,
-        generate::GenerateRequest,
-        sampling_params::SamplingParams,
-    },
     routers::http::pd_types::{generate_room_id, RequestWithBootstrap},
 };
 

--- a/model_gateway/benches/tokenizer_benchmark.rs
+++ b/model_gateway/benches/tokenizer_benchmark.rs
@@ -14,7 +14,7 @@ use std::{
 };
 
 use criterion::{criterion_group, BenchmarkId, Criterion, Throughput};
-use smg::tokenizer::{
+use llm_tokenizer::{
     cache::{CacheConfig, CachedTokenizer},
     huggingface::HuggingFaceTokenizer,
     sequence::Sequence,
@@ -32,7 +32,7 @@ fn get_tokenizer_path() -> &'static PathBuf {
         // with special: true, normalized: false - perfect for demonstrating L1 cache
         let rt = tokio::runtime::Runtime::new().expect("Failed to create tokio runtime");
         let tokenizer_dir = rt.block_on(async {
-            smg::tokenizer::hub::download_tokenizer_from_hf("Qwen/Qwen3-4B-Instruct-2507")
+            llm_tokenizer::hub::download_tokenizer_from_hf("Qwen/Qwen3-4B-Instruct-2507")
                 .await
                 .expect("Failed to download Qwen3-4B-Instruct tokenizer from HuggingFace")
         });

--- a/model_gateway/benches/tool_parser_benchmark.rs
+++ b/model_gateway/benches/tool_parser_benchmark.rs
@@ -19,12 +19,10 @@ use std::{
 };
 
 use criterion::{criterion_group, BenchmarkId, Criterion, Throughput};
+use openai_protocol::common::{Function, Tool};
 use serde_json::json;
-use smg::{
-    protocols::common::{Function, Tool},
-    tool_parser::{JsonParser, ParserFactory as ToolParserFactory, ToolParser},
-};
 use tokio::runtime::Runtime;
+use tool_parser::{JsonParser, ParserFactory as ToolParserFactory, ToolParser};
 
 // Test data for different parser formats - realistic complex examples
 const JSON_SIMPLE: &str = r#"{"name": "code_interpreter", "arguments": "{\"language\": \"python\", \"code\": \"import numpy as np\\nimport matplotlib.pyplot as plt\\n\\n# Generate sample data\\nx = np.linspace(0, 10, 100)\\ny = np.sin(x) * np.exp(-x/10)\\n\\n# Create the plot\\nplt.figure(figsize=(10, 6))\\nplt.plot(x, y, 'b-', linewidth=2)\\nplt.grid(True)\\nplt.xlabel('Time (s)')\\nplt.ylabel('Amplitude')\\nplt.title('Damped Oscillation')\\nplt.show()\"}"}"#;

--- a/model_gateway/benches/wasm_middleware_latency.rs
+++ b/model_gateway/benches/wasm_middleware_latency.rs
@@ -8,9 +8,10 @@ use axum::{
 };
 use criterion::{criterion_group, criterion_main, Criterion};
 use http_body_util::BodyExt;
+use openai_protocol::chat::ChatCompletionRequest;
 use smg::{
     app_context::AppContext, config::RouterConfig, middleware::wasm_middleware,
-    protocols::chat::ChatCompletionRequest, routers::RouterTrait, server::AppState,
+    routers::RouterTrait, server::AppState,
 };
 use tokio::runtime::Runtime;
 use tower::{Layer, Service};

--- a/model_gateway/src/app_context.rs
+++ b/model_gateway/src/app_context.rs
@@ -3,12 +3,15 @@ use std::{
     time::Duration,
 };
 
+use llm_tokenizer::registry::TokenizerRegistry;
+use reasoning_parser::ParserFactory as ReasoningParserFactory;
 use reqwest::Client;
 use smg_data_connector::{
     create_storage, ConversationItemStorage, ConversationStorage, ResponseStorage,
     StorageFactoryConfig,
 };
 use smg_mcp::McpOrchestrator;
+use tool_parser::ParserFactory as ToolParserFactory;
 use tracing::debug;
 
 use crate::{
@@ -17,10 +20,7 @@ use crate::{
     middleware::TokenBucket,
     observability::inflight_tracker::InFlightRequestTracker,
     policies::PolicyRegistry,
-    reasoning_parser::ParserFactory as ReasoningParserFactory,
     routers::router_manager::RouterManager,
-    tokenizer::registry::TokenizerRegistry,
-    tool_parser::ParserFactory as ToolParserFactory,
     wasm::{config::WasmRuntimeConfig, module_manager::WasmModuleManager},
 };
 

--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -1,13 +1,12 @@
 use std::collections::HashMap;
 
+use openai_protocol::worker::HealthCheckConfig as ProtocolHealthCheckConfig;
 use serde::{Deserialize, Serialize};
 // Re-export storage config types from data_connector
 pub use smg_data_connector::{HistoryBackend, OracleConfig, PostgresConfig, RedisConfig};
 
 use super::ConfigResult;
-use crate::{
-    core::ConnectionMode, protocols::worker::HealthCheckConfig as ProtocolHealthCheckConfig,
-};
+use crate::core::ConnectionMode;
 
 /// Main router configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/model_gateway/src/core/job_queue.rs
+++ b/model_gateway/src/core/job_queue.rs
@@ -9,6 +9,9 @@ use std::{
 };
 
 use dashmap::DashMap;
+use openai_protocol::worker::{
+    JobStatus, RuntimeType, WorkerSpec, WorkerType, WorkerUpdateRequest,
+};
 use smg_mcp::McpConfig;
 use tokio::sync::{mpsc, Semaphore};
 use tracing::{debug, error, info, warn};
@@ -25,7 +28,6 @@ use crate::{
         McpServerConfigRequest, TokenizerConfigRequest, TokenizerRemovalRequest,
         WasmModuleConfigRequest, WasmModuleRemovalRequest,
     },
-    protocols::worker::{JobStatus, RuntimeType, WorkerSpec, WorkerType, WorkerUpdateRequest},
 };
 
 /// Job types for control plane operations

--- a/model_gateway/src/core/mod.rs
+++ b/model_gateway/src/core/mod.rs
@@ -10,7 +10,7 @@
 //! - Common utilities
 
 // Re-export UNKNOWN_MODEL_ID from protocols for use throughout core
-pub use crate::protocols::UNKNOWN_MODEL_ID;
+pub use openai_protocol::UNKNOWN_MODEL_ID;
 
 pub mod circuit_breaker;
 pub mod error;
@@ -29,6 +29,11 @@ pub mod worker_service;
 pub use circuit_breaker::{CircuitBreaker, CircuitBreakerConfig};
 pub use error::{WorkerError, WorkerResult};
 pub use job_queue::{Job, JobQueue, JobQueueConfig};
+pub use openai_protocol::{
+    model_card::ModelCard,
+    model_type::{Endpoint, ModelType},
+    worker::ProviderType,
+};
 pub use retry::{is_retryable_status, RetryExecutor};
 pub use worker::{
     AttachedBody, BasicWorker, ConnectionMode, RuntimeType, Worker, WorkerLoadGuard, WorkerType,
@@ -38,9 +43,3 @@ pub use worker_builder::{BasicWorkerBuilder, DPAwareWorkerBuilder};
 pub use worker_manager::{LoadMonitor, WorkerManager};
 pub use worker_registry::{HashRing, WorkerRegistry};
 pub use worker_service::WorkerService;
-
-pub use crate::protocols::{
-    model_card::ModelCard,
-    model_type::{Endpoint, ModelType},
-    worker::ProviderType,
-};

--- a/model_gateway/src/core/steps/tokenizer_registration.rs
+++ b/model_gateway/src/core/steps/tokenizer_registration.rs
@@ -10,6 +10,12 @@
 use std::{sync::Arc, time::Duration};
 
 use async_trait::async_trait;
+use llm_tokenizer::{
+    cache::{CacheConfig, CachedTokenizer},
+    factory,
+    registry::LoadOutcome,
+    traits::Tokenizer,
+};
 use serde::{Deserialize, Serialize};
 use tracing::{error, info};
 use wfaas::{
@@ -18,16 +24,7 @@ use wfaas::{
 };
 
 use super::workflow_data::TokenizerWorkflowData;
-use crate::{
-    app_context::AppContext,
-    config::TokenizerCacheConfig,
-    tokenizer::{
-        cache::{CacheConfig, CachedTokenizer},
-        factory,
-        registry::LoadOutcome,
-        traits::Tokenizer,
-    },
-};
+use crate::{app_context::AppContext, config::TokenizerCacheConfig};
 
 /// Configuration for adding a tokenizer
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/model_gateway/src/core/steps/worker/external/create_workers.rs
+++ b/model_gateway/src/core/steps/worker/external/create_workers.rs
@@ -3,17 +3,15 @@
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
+use openai_protocol::worker::HealthCheckConfig;
 use tracing::{debug, info};
 use wfaas::{StepExecutor, StepResult, WorkflowContext, WorkflowError, WorkflowResult};
 
-use crate::{
-    core::{
-        circuit_breaker::CircuitBreakerConfig,
-        steps::workflow_data::{ExternalWorkerWorkflowData, WorkerList},
-        worker::{RuntimeType, WorkerType},
-        BasicWorkerBuilder, ConnectionMode, Worker,
-    },
-    protocols::worker::HealthCheckConfig,
+use crate::core::{
+    circuit_breaker::CircuitBreakerConfig,
+    steps::workflow_data::{ExternalWorkerWorkflowData, WorkerList},
+    worker::{RuntimeType, WorkerType},
+    BasicWorkerBuilder, ConnectionMode, Worker,
 };
 
 /// Normalize URL for external APIs (ensure https://).

--- a/model_gateway/src/core/steps/worker/external/discover_models.rs
+++ b/model_gateway/src/core/steps/worker/external/discover_models.rs
@@ -4,16 +4,14 @@ use std::{collections::HashMap, time::Duration};
 
 use async_trait::async_trait;
 use once_cell::sync::Lazy;
+use openai_protocol::{model_card::ModelCard, model_type::ModelType, worker::ProviderType};
 use regex::Regex;
 use reqwest::Client;
 use serde::Deserialize;
 use tracing::{debug, info};
 use wfaas::{StepExecutor, StepId, StepResult, WorkflowContext, WorkflowError, WorkflowResult};
 
-use crate::{
-    core::steps::workflow_data::ExternalWorkerWorkflowData,
-    protocols::{model_card::ModelCard, model_type::ModelType, worker::ProviderType},
-};
+use crate::core::steps::workflow_data::ExternalWorkerWorkflowData;
 
 // HTTP client for API calls
 static HTTP_CLIENT: Lazy<Client> = Lazy::new(|| {

--- a/model_gateway/src/core/steps/worker/external/mod.rs
+++ b/model_gateway/src/core/steps/worker/external/mod.rs
@@ -13,13 +13,11 @@ pub use discover_models::{
     group_models_into_cards, infer_model_type_from_id, DiscoverModelsStep, ModelInfo,
     ModelsResponse,
 };
+use openai_protocol::worker::WorkerSpec;
 use wfaas::{BackoffStrategy, FailureAction, RetryPolicy, StepDefinition, WorkflowDefinition};
 
 use super::shared::{ActivateWorkersStep, RegisterWorkersStep, UpdatePoliciesStep};
-use crate::{
-    app_context::AppContext, core::steps::workflow_data::ExternalWorkerWorkflowData,
-    protocols::worker::WorkerSpec,
-};
+use crate::{app_context::AppContext, core::steps::workflow_data::ExternalWorkerWorkflowData};
 
 /// Create external worker registration workflow definition.
 ///

--- a/model_gateway/src/core/steps/worker/local/create_worker.rs
+++ b/model_gateway/src/core/steps/worker/local/create_worker.rs
@@ -3,6 +3,10 @@
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
+use openai_protocol::{
+    model_card::ModelCard,
+    worker::{HealthCheckConfig, WorkerSpec},
+};
 use tracing::debug;
 use wfaas::{StepExecutor, StepId, StepResult, WorkflowContext, WorkflowError, WorkflowResult};
 
@@ -13,10 +17,6 @@ use crate::{
         steps::workflow_data::LocalWorkerWorkflowData,
         worker::{RuntimeType, WorkerType},
         BasicWorkerBuilder, ConnectionMode, DPAwareWorkerBuilder, Worker, UNKNOWN_MODEL_ID,
-    },
-    protocols::{
-        model_card::ModelCard,
-        worker::{HealthCheckConfig, WorkerSpec},
     },
 };
 

--- a/model_gateway/src/core/steps/worker/local/mod.rs
+++ b/model_gateway/src/core/steps/worker/local/mod.rs
@@ -27,6 +27,7 @@ pub use discover_dp::{get_dp_info, DiscoverDPInfoStep, DpInfo};
 pub use discover_metadata::DiscoverMetadataStep;
 pub use find_worker_to_update::FindWorkerToUpdateStep;
 pub use find_workers_to_remove::{FindWorkersToRemoveStep, WorkerRemovalRequest};
+use openai_protocol::worker::{WorkerSpec, WorkerUpdateRequest};
 pub use remove_from_policy_registry::RemoveFromPolicyRegistryStep;
 pub use remove_from_worker_registry::RemoveFromWorkerRegistryStep;
 pub use submit_tokenizer_job::SubmitTokenizerJobStep;
@@ -45,7 +46,6 @@ use crate::{
         },
         Worker, WorkerRegistry,
     },
-    protocols::worker::{WorkerSpec, WorkerUpdateRequest},
 };
 
 /// Find workers by URL, supporting both DP-aware (prefix match) and regular (exact match) modes.

--- a/model_gateway/src/core/steps/worker/local/submit_tokenizer_job.rs
+++ b/model_gateway/src/core/steps/worker/local/submit_tokenizer_job.rs
@@ -5,15 +5,13 @@
 //! and caching - this step just submits the job.
 
 use async_trait::async_trait;
+use llm_tokenizer::TokenizerRegistry;
 use tracing::{debug, info, warn};
 use wfaas::{StepExecutor, StepResult, WorkflowContext, WorkflowError, WorkflowResult};
 
-use crate::{
-    core::{
-        steps::{workflow_data::LocalWorkerWorkflowData, TokenizerConfigRequest},
-        Job,
-    },
-    tokenizer::TokenizerRegistry,
+use crate::core::{
+    steps::{workflow_data::LocalWorkerWorkflowData, TokenizerConfigRequest},
+    Job,
 };
 
 /// Step: Submit tokenizer registration job for the worker's model

--- a/model_gateway/src/core/steps/workflow_data.rs
+++ b/model_gateway/src/core/steps/workflow_data.rs
@@ -12,6 +12,11 @@
 
 use std::{collections::HashMap, sync::Arc};
 
+/// Re-export the protocol types for convenience
+pub use openai_protocol::worker::{WorkerSpec, WorkerUpdateRequest as ProtocolUpdateRequest};
+use openai_protocol::{
+    model_card::ModelCard, worker::WorkerUpdateRequest as ProtocolWorkerUpdateRequest,
+};
 use serde::{Deserialize, Serialize};
 use wfaas::{WorkflowData, WorkflowError};
 
@@ -20,15 +25,7 @@ use super::{
     wasm_module_registration::WasmModuleConfigRequest,
     wasm_module_removal::WasmModuleRemovalRequest, worker::local::WorkerRemovalRequest,
 };
-/// Re-export the protocol types for convenience
-pub use crate::protocols::worker::{WorkerSpec, WorkerUpdateRequest as ProtocolUpdateRequest};
-use crate::{
-    app_context::AppContext,
-    core::Worker,
-    protocols::{
-        model_card::ModelCard, worker::WorkerUpdateRequest as ProtocolWorkerUpdateRequest,
-    },
-};
+use crate::{app_context::AppContext, core::Worker};
 
 // ============================================================================
 // Shared trait for worker registration workflows

--- a/model_gateway/src/core/worker.rs
+++ b/model_gateway/src/core/worker.rs
@@ -9,18 +9,18 @@ use std::{
 
 use async_trait::async_trait;
 use axum::body::Body;
+// Re-export protocol types as the canonical types for the gateway
+pub use openai_protocol::worker::{ConnectionMode, RuntimeType, WorkerType};
+use openai_protocol::{
+    model_card::ModelCard,
+    model_type::{Endpoint, ModelType},
+    worker::{ProviderType, WorkerInfo, WorkerModels, WorkerSpec},
+};
 use tokio::{sync::OnceCell, time};
 
 use super::{CircuitBreaker, WorkerError, WorkerResult, UNKNOWN_MODEL_ID};
-// Re-export protocol types as the canonical types for the gateway
-pub use crate::protocols::worker::{ConnectionMode, RuntimeType, WorkerType};
 use crate::{
     observability::metrics::{metrics_labels, Metrics},
-    protocols::{
-        model_card::ModelCard,
-        model_type::{Endpoint, ModelType},
-        worker::{ProviderType, WorkerInfo, WorkerModels, WorkerSpec},
-    },
     routers::grpc::client::GrpcClient,
 };
 
@@ -1100,7 +1100,7 @@ mod tests {
 
     #[test]
     fn test_health_config_default() {
-        use crate::protocols::worker::HealthCheckConfig;
+        use openai_protocol::worker::HealthCheckConfig;
         let config = HealthCheckConfig::default();
         assert_eq!(config.timeout_secs, 30);
         assert_eq!(config.check_interval_secs, 60);
@@ -1111,7 +1111,7 @@ mod tests {
 
     #[test]
     fn test_health_config_custom() {
-        use crate::protocols::worker::HealthCheckConfig;
+        use openai_protocol::worker::HealthCheckConfig;
         let config = HealthCheckConfig {
             timeout_secs: 10,
             check_interval_secs: 60,
@@ -1156,7 +1156,7 @@ mod tests {
 
     #[test]
     fn test_worker_with_health_config() {
-        use crate::protocols::worker::HealthCheckConfig;
+        use openai_protocol::worker::HealthCheckConfig;
         let custom_config = HealthCheckConfig {
             timeout_secs: 15,
             check_interval_secs: 45,

--- a/model_gateway/src/core/worker_builder.rs
+++ b/model_gateway/src/core/worker_builder.rs
@@ -1,5 +1,11 @@
 use std::collections::HashMap;
 
+use openai_protocol::{
+    model_card::ModelCard,
+    model_type::ModelType,
+    worker::{HealthCheckConfig, WorkerModels, WorkerSpec},
+};
+
 use super::{
     circuit_breaker::{CircuitBreaker, CircuitBreakerConfig},
     worker::{
@@ -7,15 +13,7 @@ use super::{
         WorkerRoutingKeyLoad, WorkerType,
     },
 };
-use crate::{
-    observability::metrics::Metrics,
-    protocols::{
-        model_card::ModelCard,
-        model_type::ModelType,
-        worker::{HealthCheckConfig, WorkerModels, WorkerSpec},
-    },
-    routers::grpc::client::GrpcClient,
-};
+use crate::{observability::metrics::Metrics, routers::grpc::client::GrpcClient};
 
 /// Builder for creating BasicWorker instances with fluent API.
 ///

--- a/model_gateway/src/core/worker_manager.rs
+++ b/model_gateway/src/core/worker_manager.rs
@@ -10,6 +10,7 @@ use futures::{
     stream::{self, StreamExt},
 };
 use http::StatusCode;
+use openai_protocol::worker::{FlushCacheResult, WorkerLoadInfo, WorkerLoadsResult};
 use serde_json::Value;
 use tokio::{
     sync::{watch, Mutex},
@@ -20,7 +21,6 @@ use tracing::{debug, info, warn};
 use crate::{
     core::{metrics_aggregator::MetricPack, ConnectionMode, Worker, WorkerRegistry, WorkerType},
     policies::PolicyRegistry,
-    protocols::worker::{FlushCacheResult, WorkerLoadInfo, WorkerLoadsResult},
 };
 
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);

--- a/model_gateway/src/core/worker_service.rs
+++ b/model_gateway/src/core/worker_service.rs
@@ -11,13 +11,13 @@ use axum::{
     response::{IntoResponse, Response},
     Json,
 };
+use openai_protocol::worker::{WorkerErrorResponse, WorkerInfo, WorkerSpec, WorkerUpdateRequest};
 use serde_json::json;
 use tracing::warn;
 
 use crate::{
     config::RouterConfig,
     core::{worker::worker_to_info, worker_registry::WorkerId, Job, JobQueue, WorkerRegistry},
-    protocols::worker::{WorkerErrorResponse, WorkerInfo, WorkerSpec, WorkerUpdateRequest},
 };
 
 /// Error types for worker service operations

--- a/model_gateway/src/lib.rs
+++ b/model_gateway/src/lib.rs
@@ -1,16 +1,11 @@
 pub mod app_context;
-pub use smg_auth as auth;
 pub mod config;
 pub mod core;
 pub mod middleware;
 pub mod observability;
 pub mod policies;
-pub use openai_protocol as protocols;
-pub use reasoning_parser;
 pub mod routers;
 pub mod server;
 pub mod service_discovery;
-pub use llm_tokenizer as tokenizer;
-pub use tool_parser;
 pub mod version;
 pub mod wasm;

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -3,7 +3,6 @@ use std::collections::HashMap;
 use clap::{ArgAction, Parser, Subcommand, ValueEnum};
 use rand::{distr::Alphanumeric, Rng};
 use smg::{
-    auth::{ApiKeyEntry, ControlPlaneAuthConfig, JwtConfig, Role},
     config::{
         CircuitBreakerConfig, ConfigError, ConfigResult, DiscoveryConfig, HealthCheckConfig,
         HistoryBackend, ManualAssignmentMode, MetricsConfig, OracleConfig, PolicyConfig,
@@ -19,6 +18,7 @@ use smg::{
     service_discovery::ServiceDiscoveryConfig,
     version,
 };
+use smg_auth::{ApiKeyEntry, ControlPlaneAuthConfig, JwtConfig, Role};
 use smg_mesh::MeshServerConfig;
 fn parse_prefill_args() -> Vec<(String, Option<u16>)> {
     let args: Vec<String> = std::env::args().collect();

--- a/model_gateway/src/routers/anthropic/context.rs
+++ b/model_gateway/src/routers/anthropic/context.rs
@@ -10,11 +10,9 @@ use std::{
 };
 
 use axum::http::HeaderMap;
+use openai_protocol::messages::CreateMessageRequest;
 
-use crate::{
-    core::{Worker, WorkerRegistry},
-    protocols::messages::CreateMessageRequest,
-};
+use crate::core::{Worker, WorkerRegistry};
 
 // ============================================================================
 // Request Input

--- a/model_gateway/src/routers/anthropic/messages/tools.rs
+++ b/model_gateway/src/routers/anthropic/messages/tools.rs
@@ -5,7 +5,7 @@
 //! - Executing tool calls via MCP orchestrator
 //! - Assembling tool results
 
-use crate::protocols::messages::{ContentBlock, ToolUseBlock};
+use openai_protocol::messages::{ContentBlock, ToolUseBlock};
 
 pub fn extract_tool_calls(content: &[ContentBlock]) -> Vec<ToolUseBlock> {
     content

--- a/model_gateway/src/routers/anthropic/pipeline.rs
+++ b/model_gateway/src/routers/anthropic/pipeline.rs
@@ -6,6 +6,7 @@
 use std::sync::Arc;
 
 use axum::{http::HeaderMap, response::Response};
+use openai_protocol::messages::CreateMessageRequest;
 use tracing::{debug, error, info};
 
 use super::{
@@ -15,7 +16,7 @@ use super::{
         WorkerSelectionStage,
     },
 };
-use crate::{protocols::messages::CreateMessageRequest, routers::error};
+use crate::routers::error;
 
 // Note: Arc is still used for SharedComponents (shared across stages) but not for
 // CreateMessageRequest (flows through sequential stages without shared ownership)

--- a/model_gateway/src/routers/anthropic/router.rs
+++ b/model_gateway/src/routers/anthropic/router.rs
@@ -17,11 +17,11 @@ use std::{any::Any, fmt, sync::Arc, time::Duration}; // Arc still needed for App
 
 use async_trait::async_trait;
 use axum::{body::Body, extract::Request, http::HeaderMap, response::Response};
+use openai_protocol::{chat::ChatCompletionRequest, messages::CreateMessageRequest};
 
 use super::{context::SharedComponents, models, pipeline::MessagesPipeline};
 use crate::{
     app_context::AppContext,
-    protocols::{chat::ChatCompletionRequest, messages::CreateMessageRequest},
     routers::{error, RouterTrait},
 };
 

--- a/model_gateway/src/routers/anthropic/stages/response_processing.rs
+++ b/model_gateway/src/routers/anthropic/stages/response_processing.rs
@@ -21,12 +21,12 @@ use axum::{
 };
 use bytes::Bytes;
 use futures::Stream;
+use openai_protocol::messages::Message;
 use tracing::{debug, error, info, warn};
 
 use super::{PipelineStage, StageResult};
 use crate::{
     observability::metrics::{bool_to_static_str, metrics_labels, Metrics},
-    protocols::messages::Message,
     routers::{
         anthropic::{
             context::RequestContext,

--- a/model_gateway/src/routers/grpc/common/response_formatting.rs
+++ b/model_gateway/src/routers/grpc/common/response_formatting.rs
@@ -6,10 +6,9 @@
 
 use std::collections::HashMap;
 
-use crate::{
-    protocols::common::Usage,
-    routers::grpc::proto_wrapper::{ProtoGenerateComplete, ProtoGenerateStreamChunk},
-};
+use openai_protocol::common::Usage;
+
+use crate::routers::grpc::proto_wrapper::{ProtoGenerateComplete, ProtoGenerateStreamChunk};
 
 /// Build usage information from collected gRPC responses
 ///

--- a/model_gateway/src/routers/grpc/common/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/common/responses/streaming.rs
@@ -3,26 +3,24 @@
 use axum::{body::Body, http::StatusCode, response::Response};
 use bytes::Bytes;
 use http::header::{HeaderValue, CONTENT_TYPE};
+use openai_protocol::{
+    chat::ChatCompletionStreamResponse,
+    common::{Usage, UsageInfo},
+    event_types::{
+        CodeInterpreterCallEvent, ContentPartEvent, FileSearchCallEvent, FunctionCallEvent,
+        McpEvent, OutputItemEvent, OutputTextEvent, ResponseEvent, WebSearchCallEvent,
+    },
+    responses::{
+        ResponseOutputItem, ResponseStatus, ResponsesRequest, ResponsesResponse, ResponsesUsage,
+    },
+};
 use serde_json::json;
 use smg_mcp::{self as mcp, ResponseFormat};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use uuid::Uuid;
 
-use crate::{
-    protocols::{
-        chat::ChatCompletionStreamResponse,
-        common::{Usage, UsageInfo},
-        event_types::{
-            CodeInterpreterCallEvent, ContentPartEvent, FileSearchCallEvent, FunctionCallEvent,
-            McpEvent, OutputItemEvent, OutputTextEvent, ResponseEvent, WebSearchCallEvent,
-        },
-        responses::{
-            ResponseOutputItem, ResponseStatus, ResponsesRequest, ResponsesResponse, ResponsesUsage,
-        },
-    },
-    routers::grpc::harmony::responses::ToolResult,
-};
+use crate::routers::grpc::harmony::responses::ToolResult;
 
 pub(crate) enum OutputItemType {
     Message,

--- a/model_gateway/src/routers/grpc/common/responses/utils.rs
+++ b/model_gateway/src/routers/grpc/common/responses/utils.rs
@@ -3,6 +3,10 @@
 use std::sync::Arc;
 
 use axum::response::Response;
+use openai_protocol::{
+    common::Tool,
+    responses::{ResponseTool, ResponseToolType, ResponsesRequest, ResponsesResponse},
+};
 use serde_json::to_value;
 use smg_data_connector::{ConversationItemStorage, ConversationStorage, ResponseStorage};
 use smg_mcp::McpOrchestrator;
@@ -10,10 +14,6 @@ use tracing::{debug, error, warn};
 
 use crate::{
     core::WorkerRegistry,
-    protocols::{
-        common::Tool,
-        responses::{ResponseTool, ResponseToolType, ResponsesRequest, ResponsesResponse},
-    },
     routers::{
         error, mcp_utils::ensure_request_mcp_client, persistence_utils::persist_conversation_items,
     },

--- a/model_gateway/src/routers/grpc/context.rs
+++ b/model_gateway/src/routers/grpc/context.rs
@@ -7,25 +7,23 @@
 use std::sync::Arc;
 
 use axum::http::HeaderMap;
+use llm_tokenizer::{stop::StopSequenceDecoder, traits::Tokenizer, TokenizerRegistry};
+use openai_protocol::{
+    chat::{ChatCompletionRequest, ChatCompletionResponse},
+    classify::{ClassifyRequest, ClassifyResponse},
+    embedding::{EmbeddingRequest, EmbeddingResponse},
+    generate::{GenerateRequest, GenerateResponse},
+    responses::ResponsesRequest,
+};
+use reasoning_parser::ParserFactory as ReasoningParserFactory;
+use tool_parser::ParserFactory as ToolParserFactory;
 use tracing::debug;
 
 use super::{
     client::GrpcClient,
     proto_wrapper::{ProtoEmbedComplete, ProtoRequest, ProtoStream},
 };
-use crate::{
-    core::{RuntimeType, Worker, WorkerLoadGuard},
-    protocols::{
-        chat::{ChatCompletionRequest, ChatCompletionResponse},
-        classify::{ClassifyRequest, ClassifyResponse},
-        embedding::{EmbeddingRequest, EmbeddingResponse},
-        generate::{GenerateRequest, GenerateResponse},
-        responses::ResponsesRequest,
-    },
-    reasoning_parser::ParserFactory as ReasoningParserFactory,
-    tokenizer::{stop::StopSequenceDecoder, traits::Tokenizer, TokenizerRegistry},
-    tool_parser::ParserFactory as ToolParserFactory,
-};
+use crate::core::{RuntimeType, Worker, WorkerLoadGuard};
 
 /// Main request processing context
 ///

--- a/model_gateway/src/routers/grpc/harmony/builder.rs
+++ b/model_gateway/src/routers/grpc/harmony/builder.rs
@@ -12,21 +12,19 @@ use openai_harmony::{
     },
     HarmonyEncoding, HarmonyEncodingName,
 };
+use openai_protocol::{
+    chat::{ChatCompletionRequest, ChatMessage, MessageContent},
+    common::{ChatLogProbs, ContentPart, Tool},
+    responses::{
+        ReasoningEffort as ResponsesReasoningEffort, ResponseContentPart, ResponseInput,
+        ResponseInputOutputItem, ResponseReasoningContent, ResponseTool, ResponseToolType,
+        ResponsesRequest, StringOrContentParts,
+    },
+};
 use tracing::{debug, trace};
 
 use super::types::HarmonyBuildOutput;
-use crate::{
-    protocols::{
-        chat::{ChatCompletionRequest, ChatMessage, MessageContent},
-        common::{ChatLogProbs, ContentPart, Tool},
-        responses::{
-            ReasoningEffort as ResponsesReasoningEffort, ResponseContentPart, ResponseInput,
-            ResponseInputOutputItem, ResponseReasoningContent, ResponseTool, ResponseToolType,
-            ResponsesRequest, StringOrContentParts,
-        },
-    },
-    routers::grpc::{proto_wrapper::ProtoOutputLogProbs, utils},
-};
+use crate::routers::grpc::{proto_wrapper::ProtoOutputLogProbs, utils};
 
 /// Global Harmony encoding (lazy-initialized)
 static HARMONY_ENCODING: OnceLock<HarmonyEncoding> = OnceLock::new();

--- a/model_gateway/src/routers/grpc/harmony/parser.rs
+++ b/model_gateway/src/routers/grpc/harmony/parser.rs
@@ -3,10 +3,10 @@
 //! Adapter for openai_harmony::StreamableParser that handles channel-based parsing.
 
 use openai_harmony::{chat::Role, HarmonyEncoding, StreamableParser};
+use openai_protocol::common::{FunctionCallResponse, ToolCall};
 use uuid::Uuid;
 
 use super::types::{HarmonyChannelDelta, HarmonyChannelOutput};
-use crate::protocols::common::{FunctionCallResponse, ToolCall};
 
 /// Get the global Harmony encoding
 ///

--- a/model_gateway/src/routers/grpc/harmony/processor.rs
+++ b/model_gateway/src/routers/grpc/harmony/processor.rs
@@ -3,24 +3,22 @@
 use std::sync::Arc;
 
 use axum::response::Response;
+use openai_protocol::{
+    chat::{ChatChoice, ChatCompletionMessage, ChatCompletionRequest, ChatCompletionResponse},
+    common::{ChatLogProbs, ToolCall, Usage},
+    responses::{
+        OutputTokensDetails, ResponseContentPart, ResponseOutputItem, ResponseReasoningContent,
+        ResponseStatus, ResponseUsage, ResponsesRequest, ResponsesResponse, ResponsesUsage,
+    },
+};
 use tracing::error;
 
 use super::{builder::convert_harmony_logprobs, HarmonyParserAdapter};
-use crate::{
-    protocols::{
-        chat::{ChatChoice, ChatCompletionMessage, ChatCompletionRequest, ChatCompletionResponse},
-        common::{ChatLogProbs, ToolCall, Usage},
-        responses::{
-            OutputTokensDetails, ResponseContentPart, ResponseOutputItem, ResponseReasoningContent,
-            ResponseStatus, ResponseUsage, ResponsesRequest, ResponsesResponse, ResponsesUsage,
-        },
-    },
-    routers::{
-        error,
-        grpc::{
-            common::{response_collection, response_formatting},
-            context::{DispatchMetadata, ExecutionResult},
-        },
+use crate::routers::{
+    error,
+    grpc::{
+        common::{response_collection, response_formatting},
+        context::{DispatchMetadata, ExecutionResult},
     },
 };
 

--- a/model_gateway/src/routers/grpc/harmony/responses/common.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/common.rs
@@ -1,6 +1,14 @@
 //! Shared helpers and state tracking for Harmony Responses
 
 use axum::response::Response;
+use openai_protocol::{
+    common::{ToolCall, ToolChoice, ToolChoiceValue},
+    responses::{
+        ResponseContentPart, ResponseInput, ResponseInputOutputItem, ResponseOutputItem,
+        ResponseReasoningContent, ResponseTool, ResponseToolType, ResponsesRequest,
+        ResponsesResponse, StringOrContentParts,
+    },
+};
 use serde_json::{from_value, to_string, Value};
 use smg_data_connector::ResponseId;
 use smg_mcp::McpToolSession;
@@ -8,17 +16,7 @@ use tracing::{debug, error, warn};
 use uuid::Uuid;
 
 use super::execution::ToolResult;
-use crate::{
-    protocols::{
-        common::{ToolCall, ToolChoice, ToolChoiceValue},
-        responses::{
-            ResponseContentPart, ResponseInput, ResponseInputOutputItem, ResponseOutputItem,
-            ResponseReasoningContent, ResponseTool, ResponseToolType, ResponsesRequest,
-            ResponsesResponse, StringOrContentParts,
-        },
-    },
-    routers::{error, grpc::common::responses::ResponsesContext},
-};
+use crate::routers::{error, grpc::common::responses::ResponsesContext};
 
 /// Record of a single MCP tool call execution
 ///

--- a/model_gateway/src/routers/grpc/harmony/responses/execution.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/execution.rs
@@ -1,15 +1,13 @@
 //! MCP tool execution logic for Harmony Responses
 
 use axum::response::Response;
+use openai_protocol::{common::ToolCall, responses::ResponseTool};
 use serde_json::{from_str, json, Value};
 use smg_mcp::{McpToolSession, ToolExecutionInput};
 use tracing::{debug, error};
 
 use super::common::McpCallTracking;
-use crate::{
-    observability::metrics::{metrics_labels, Metrics},
-    protocols::{common::ToolCall, responses::ResponseTool},
-};
+use crate::observability::metrics::{metrics_labels, Metrics};
 
 /// Tool execution result
 ///

--- a/model_gateway/src/routers/grpc/harmony/responses/non_streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/non_streaming.rs
@@ -6,6 +6,13 @@ use std::{
 };
 
 use axum::response::Response;
+use openai_protocol::{
+    common::{ToolCall, Usage},
+    responses::{
+        OutputTokensDetails, ResponseContentPart, ResponseOutputItem, ResponseReasoningContent,
+        ResponseStatus, ResponseUsage, ResponsesRequest, ResponsesResponse, ResponsesUsage,
+    },
+};
 use serde_json::{json, to_string};
 use smg_mcp::McpToolSession;
 use tracing::{debug, error, warn};
@@ -19,13 +26,6 @@ use super::{
 };
 use crate::{
     observability::metrics::Metrics,
-    protocols::{
-        common::{ToolCall, Usage},
-        responses::{
-            OutputTokensDetails, ResponseContentPart, ResponseOutputItem, ResponseReasoningContent,
-            ResponseStatus, ResponseUsage, ResponsesRequest, ResponsesResponse, ResponsesUsage,
-        },
-    },
     routers::{
         error,
         grpc::{

--- a/model_gateway/src/routers/grpc/harmony/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/streaming.rs
@@ -4,6 +4,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use axum::response::Response;
 use bytes::Bytes;
+use openai_protocol::responses::{ResponseToolType, ResponsesRequest};
 use serde_json::json;
 use smg_mcp::McpToolSession;
 use tokio::sync::mpsc;
@@ -19,7 +20,6 @@ use super::{
 };
 use crate::{
     observability::metrics::Metrics,
-    protocols::responses::{ResponseToolType, ResponsesRequest},
     routers::{
         grpc::{
             common::responses::{

--- a/model_gateway/src/routers/grpc/harmony/stages/preparation.rs
+++ b/model_gateway/src/routers/grpc/harmony/stages/preparation.rs
@@ -2,23 +2,21 @@
 
 use async_trait::async_trait;
 use axum::response::Response;
+use openai_protocol::{
+    chat::ChatCompletionRequest,
+    common::{Tool, ToolChoice, ToolChoiceValue},
+    responses::ResponsesRequest,
+};
 use serde_json::json;
 use tracing::error;
 
 use super::super::HarmonyBuilder;
-use crate::{
-    protocols::{
-        chat::ChatCompletionRequest,
-        common::{Tool, ToolChoice, ToolChoiceValue},
-        responses::ResponsesRequest,
-    },
-    routers::{
-        error,
-        grpc::{
-            common::{responses::utils::extract_tools_from_response_tools, stages::PipelineStage},
-            context::{PreparationOutput, RequestContext, RequestType},
-            utils,
-        },
+use crate::routers::{
+    error,
+    grpc::{
+        common::{responses::utils::extract_tools_from_response_tools, stages::PipelineStage},
+        context::{PreparationOutput, RequestContext, RequestType},
+        utils,
     },
 };
 
@@ -209,9 +207,9 @@ impl HarmonyPreparationStage {
     /// Converts text.format to structural tag that constrains the final channel.
     /// Returns None if text.format is not specified or is "text".
     fn generate_text_format_constraint(
-        text_config: &crate::protocols::responses::TextConfig,
+        text_config: &openai_protocol::responses::TextConfig,
     ) -> Result<Option<(String, String)>, Box<Response>> {
-        use crate::protocols::responses::TextFormat;
+        use openai_protocol::responses::TextFormat;
 
         let Some(format) = &text_config.format else {
             return Ok(None);

--- a/model_gateway/src/routers/grpc/harmony/streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/streaming.rs
@@ -9,6 +9,15 @@ use std::{
 
 use axum::response::Response;
 use bytes::Bytes;
+use openai_protocol::{
+    chat::{
+        ChatCompletionRequest, ChatCompletionStreamResponse, ChatMessageDelta, ChatStreamChoice,
+    },
+    common::{ChatLogProbs, FunctionCallDelta, ToolCall, ToolCallDelta, Usage},
+    responses::{
+        OutputTokensDetails, ResponseStatus, ResponseUsage, ResponsesResponse, ResponsesUsage,
+    },
+};
 use serde_json::json;
 use smg_mcp::{McpToolSession, ResponseFormat};
 use tokio::sync::mpsc;
@@ -20,15 +29,6 @@ use super::{
 };
 use crate::{
     observability::metrics::{metrics_labels, Metrics, StreamingMetricsParams},
-    protocols::{
-        chat::{
-            ChatCompletionRequest, ChatCompletionStreamResponse, ChatMessageDelta, ChatStreamChoice,
-        },
-        common::{ChatLogProbs, FunctionCallDelta, ToolCall, ToolCallDelta, Usage},
-        responses::{
-            OutputTokensDetails, ResponseStatus, ResponseUsage, ResponsesResponse, ResponsesUsage,
-        },
-    },
     routers::grpc::{
         common::{
             response_formatting::CompletionTokenTracker,

--- a/model_gateway/src/routers/grpc/harmony/types.rs
+++ b/model_gateway/src/routers/grpc/harmony/types.rs
@@ -1,10 +1,9 @@
 //! Shared types for Harmony pipeline
 
 use openai_harmony::chat::Content;
+use openai_protocol::common::ToolCall;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-
-use crate::protocols::common::ToolCall;
 
 /// Harmony message format
 ///

--- a/model_gateway/src/routers/grpc/mod.rs
+++ b/model_gateway/src/routers/grpc/mod.rs
@@ -1,8 +1,7 @@
 //! gRPC router implementations
 
+use openai_protocol::common::StringOrArray;
 use smg_grpc_client::sglang_proto::MultimodalInputs;
-
-use crate::protocols::common::StringOrArray;
 
 pub mod client; // Used by core/
 pub(crate) mod common;

--- a/model_gateway/src/routers/grpc/pd_router.rs
+++ b/model_gateway/src/routers/grpc/pd_router.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use axum::{http::HeaderMap, response::Response};
+use openai_protocol::{chat::ChatCompletionRequest, generate::GenerateRequest};
 use tracing::debug;
 
 use super::{context::SharedComponents, pipeline::RequestPipeline};
@@ -13,7 +14,6 @@ use crate::{
         UNKNOWN_MODEL_ID,
     },
     observability::metrics::{metrics_labels, Metrics},
-    protocols::{chat::ChatCompletionRequest, generate::GenerateRequest},
     routers::RouterTrait,
 };
 

--- a/model_gateway/src/routers/grpc/pipeline.rs
+++ b/model_gateway/src/routers/grpc/pipeline.rs
@@ -6,6 +6,14 @@
 use std::{sync::Arc, time::Instant};
 
 use axum::response::{IntoResponse, Response};
+use openai_protocol::{
+    chat::{ChatCompletionRequest, ChatCompletionResponse},
+    classify::ClassifyRequest,
+    embedding::EmbeddingRequest,
+    generate::GenerateRequest,
+};
+use reasoning_parser::ParserFactory as ReasoningParserFactory;
+use tool_parser::ParserFactory as ToolParserFactory;
 use tracing::{debug, error};
 
 // Import embedding-specific and classify-specific stages
@@ -32,15 +40,7 @@ use crate::{
     core::{WorkerRegistry, UNKNOWN_MODEL_ID},
     observability::metrics::{bool_to_static_str, metrics_labels, Metrics},
     policies::PolicyRegistry,
-    protocols::{
-        chat::{ChatCompletionRequest, ChatCompletionResponse},
-        classify::ClassifyRequest,
-        embedding::EmbeddingRequest,
-        generate::GenerateRequest,
-    },
-    reasoning_parser::ParserFactory as ReasoningParserFactory,
     routers::error,
-    tool_parser::ParserFactory as ToolParserFactory,
 };
 
 /// Generic request pipeline for all request types
@@ -752,7 +752,7 @@ impl RequestPipeline {
     /// ResponsesIterationResult indicating whether to continue iteration or return
     pub async fn execute_harmony_responses(
         &self,
-        request: &crate::protocols::responses::ResponsesRequest,
+        request: &openai_protocol::responses::ResponsesRequest,
         harmony_ctx: &ResponsesContext,
     ) -> Result<harmony::ResponsesIterationResult, Response> {
         // Create RequestContext for this Responses request
@@ -815,7 +815,7 @@ impl RequestPipeline {
     /// The caller is responsible for keeping load_guards alive until stream processing completes.
     pub async fn execute_harmony_responses_streaming(
         &self,
-        request: &crate::protocols::responses::ResponsesRequest,
+        request: &openai_protocol::responses::ResponsesRequest,
         harmony_ctx: &ResponsesContext,
     ) -> Result<(ExecutionResult, Option<LoadGuards>), Response> {
         // Create RequestContext for this Responses request

--- a/model_gateway/src/routers/grpc/regular/processor.rs
+++ b/model_gateway/src/routers/grpc/regular/processor.rs
@@ -5,29 +5,27 @@
 
 use std::{sync::Arc, time::Instant};
 
+use llm_tokenizer::{
+    stop::{SequenceDecoderOutput, StopSequenceDecoder},
+    traits::Tokenizer,
+};
+use openai_protocol::{
+    chat::{ChatChoice, ChatCompletionMessage, ChatCompletionRequest, ChatCompletionResponse},
+    common::{FunctionCallResponse, ToolCall, ToolChoice, ToolChoiceValue},
+    generate::{GenerateMetaInfo, GenerateRequest, GenerateResponse},
+};
+use reasoning_parser::ParserFactory as ReasoningParserFactory;
+use tool_parser::ParserFactory as ToolParserFactory;
 use tracing::error;
 
-use crate::{
-    protocols::{
-        chat::{ChatChoice, ChatCompletionMessage, ChatCompletionRequest, ChatCompletionResponse},
-        common::{FunctionCallResponse, ToolCall, ToolChoice, ToolChoiceValue},
-        generate::{GenerateMetaInfo, GenerateRequest, GenerateResponse},
+use crate::routers::{
+    error,
+    grpc::{
+        common::{response_collection, response_formatting},
+        context::{DispatchMetadata, ExecutionResult},
+        proto_wrapper::ProtoGenerateComplete,
+        utils,
     },
-    reasoning_parser::ParserFactory as ReasoningParserFactory,
-    routers::{
-        error,
-        grpc::{
-            common::{response_collection, response_formatting},
-            context::{DispatchMetadata, ExecutionResult},
-            proto_wrapper::ProtoGenerateComplete,
-            utils,
-        },
-    },
-    tokenizer::{
-        stop::{SequenceDecoderOutput, StopSequenceDecoder},
-        traits::Tokenizer,
-    },
-    tool_parser::ParserFactory as ToolParserFactory,
 };
 
 /// Unified response processor for both routers

--- a/model_gateway/src/routers/grpc/regular/responses/common.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/common.rs
@@ -7,21 +7,19 @@
 //! - Conversation history loading
 
 use axum::{http, response::Response};
+use openai_protocol::{
+    chat::ChatCompletionRequest,
+    common::{Tool, ToolChoice, ToolChoiceValue},
+    responses::{
+        self, ResponseContentPart, ResponseInput, ResponseInputOutputItem, ResponseOutputItem,
+        ResponsesRequest,
+    },
+};
 use smg_data_connector::{self as data_connector, ConversationId, ResponseId};
 use smg_mcp::McpToolSession;
 use tracing::{debug, warn};
 
-use crate::{
-    protocols::{
-        chat::ChatCompletionRequest,
-        common::{Tool, ToolChoice, ToolChoiceValue},
-        responses::{
-            self, ResponseContentPart, ResponseInput, ResponseInputOutputItem, ResponseOutputItem,
-            ResponsesRequest,
-        },
-    },
-    routers::{error, grpc::common::responses::ResponsesContext},
-};
+use crate::routers::{error, grpc::common::responses::ResponsesContext};
 
 // ============================================================================
 // Tool Loop State
@@ -118,7 +116,7 @@ pub(super) struct ExtractedToolCall {
 
 /// Extract all tool calls from chat response (for parallel tool call support)
 pub(super) fn extract_all_tool_calls_from_chat(
-    response: &crate::protocols::chat::ChatCompletionResponse,
+    response: &openai_protocol::chat::ChatCompletionResponse,
 ) -> Vec<ExtractedToolCall> {
     // Check if response has choices with tool calls
     let Some(choice) = response.choices.first() else {

--- a/model_gateway/src/routers/grpc/regular/responses/conversions.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/conversions.rs
@@ -7,22 +7,20 @@
 //! This allows the gRPC router to reuse the existing chat pipeline infrastructure
 //! without requiring Python backend changes.
 
-use crate::{
-    protocols::{
-        chat::{ChatCompletionRequest, ChatCompletionResponse, ChatMessage, MessageContent},
-        common::{
-            FunctionCallResponse, JsonSchemaFormat, ResponseFormat, StreamOptions, ToolCall,
-            UsageInfo,
-        },
-        responses::{
-            ResponseContentPart, ResponseInput, ResponseInputOutputItem, ResponseOutputItem,
-            ResponseReasoningContent::ReasoningText, ResponseStatus, ResponsesRequest,
-            ResponsesResponse, ResponsesUsage, StringOrContentParts, TextConfig, TextFormat,
-        },
-        UNKNOWN_MODEL_ID,
+use openai_protocol::{
+    chat::{ChatCompletionRequest, ChatCompletionResponse, ChatMessage, MessageContent},
+    common::{
+        FunctionCallResponse, JsonSchemaFormat, ResponseFormat, StreamOptions, ToolCall, UsageInfo,
     },
-    routers::grpc::common::responses::utils::extract_tools_from_response_tools,
+    responses::{
+        ResponseContentPart, ResponseInput, ResponseInputOutputItem, ResponseOutputItem,
+        ResponseReasoningContent::ReasoningText, ResponseStatus, ResponsesRequest,
+        ResponsesResponse, ResponsesUsage, StringOrContentParts, TextConfig, TextFormat,
+    },
+    UNKNOWN_MODEL_ID,
 };
+
+use crate::routers::grpc::common::responses::utils::extract_tools_from_response_tools;
 
 /// Convert a ResponsesRequest to ChatCompletionRequest for processing through the chat pipeline
 ///

--- a/model_gateway/src/routers/grpc/regular/responses/handlers.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/handlers.rs
@@ -31,6 +31,7 @@ use axum::{
     http,
     response::{IntoResponse, Response},
 };
+use openai_protocol::responses::ResponsesRequest;
 use tracing::debug;
 use uuid::Uuid;
 
@@ -38,12 +39,9 @@ use super::{
     common::{load_conversation_history, ResponsesCallContext},
     conversions, non_streaming, streaming,
 };
-use crate::{
-    protocols::responses::ResponsesRequest,
-    routers::{
-        error,
-        grpc::common::responses::{ensure_mcp_connection, ResponsesContext},
-    },
+use crate::routers::{
+    error,
+    grpc::common::responses::{ensure_mcp_connection, ResponsesContext},
 };
 
 /// Main handler for POST /v1/responses

--- a/model_gateway/src/routers/grpc/regular/responses/non_streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/non_streaming.rs
@@ -8,6 +8,7 @@
 use std::sync::Arc;
 
 use axum::response::Response;
+use openai_protocol::responses::{ResponseStatus, ResponsesRequest, ResponsesResponse};
 use serde_json::json;
 use smg_mcp::{McpToolSession, ToolExecutionInput};
 use tracing::{debug, error, trace, warn};
@@ -22,7 +23,6 @@ use super::{
 };
 use crate::{
     observability::metrics::{metrics_labels, Metrics},
-    protocols::responses::{ResponseStatus, ResponsesRequest, ResponsesResponse},
     routers::{
         error,
         grpc::common::responses::{

--- a/model_gateway/src/routers/grpc/regular/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/streaming.rs
@@ -18,6 +18,17 @@ use axum::{
 };
 use bytes::Bytes;
 use futures_util::StreamExt;
+use openai_protocol::{
+    chat::{
+        ChatChoice, ChatCompletionMessage, ChatCompletionRequest, ChatCompletionResponse,
+        ChatCompletionStreamResponse,
+    },
+    common::{FunctionCallResponse, ToolCall, Usage, UsageInfo},
+    responses::{
+        ResponseContentPart, ResponseOutputItem, ResponseReasoningContent, ResponseStatus,
+        ResponsesRequest, ResponsesResponse, ResponsesUsage,
+    },
+};
 use serde_json::{json, Value};
 use smg_data_connector::{ConversationItemStorage, ConversationStorage, ResponseStorage};
 use smg_mcp::{McpToolSession, ResponseFormat, ToolExecutionInput};
@@ -35,17 +46,6 @@ use super::{
 };
 use crate::{
     observability::metrics::{metrics_labels, Metrics},
-    protocols::{
-        chat::{
-            ChatChoice, ChatCompletionMessage, ChatCompletionRequest, ChatCompletionResponse,
-            ChatCompletionStreamResponse,
-        },
-        common::{FunctionCallResponse, ToolCall, Usage, UsageInfo},
-        responses::{
-            ResponseContentPart, ResponseOutputItem, ResponseReasoningContent, ResponseStatus,
-            ResponsesRequest, ResponsesResponse, ResponsesUsage,
-        },
-    },
     routers::{
         grpc::common::responses::{
             build_sse_response, persist_response_if_needed,

--- a/model_gateway/src/routers/grpc/regular/stages/chat/preparation.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/chat/preparation.rs
@@ -4,17 +4,15 @@ use std::borrow::Cow;
 
 use async_trait::async_trait;
 use axum::response::Response;
+use openai_protocol::chat::ChatCompletionRequest;
 use tracing::error;
 
-use crate::{
-    protocols::chat::ChatCompletionRequest,
-    routers::{
-        error,
-        grpc::{
-            common::stages::PipelineStage,
-            context::{PreparationOutput, RequestContext},
-            utils,
-        },
+use crate::routers::{
+    error,
+    grpc::{
+        common::stages::PipelineStage,
+        context::{PreparationOutput, RequestContext},
+        utils,
     },
 };
 

--- a/model_gateway/src/routers/grpc/regular/stages/classify/response_processing.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/classify/response_processing.rs
@@ -11,19 +11,17 @@ use std::collections::HashMap;
 
 use async_trait::async_trait;
 use axum::response::Response;
+use openai_protocol::{
+    classify::{ClassifyData, ClassifyResponse},
+    common::UsageInfo,
+};
 use tracing::error;
 
-use crate::{
-    protocols::{
-        classify::{ClassifyData, ClassifyResponse},
-        common::UsageInfo,
-    },
-    routers::{
-        error,
-        grpc::{
-            common::stages::PipelineStage,
-            context::{ExecutionResult, FinalResponse, RequestContext, WorkerSelection},
-        },
+use crate::routers::{
+    error,
+    grpc::{
+        common::stages::PipelineStage,
+        context::{ExecutionResult, FinalResponse, RequestContext, WorkerSelection},
     },
 };
 

--- a/model_gateway/src/routers/grpc/regular/stages/embedding/preparation.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/embedding/preparation.rs
@@ -2,17 +2,15 @@
 
 use async_trait::async_trait;
 use axum::response::Response;
+use openai_protocol::common::GenerationRequest;
 use tracing::error;
 
-use crate::{
-    protocols::common::GenerationRequest,
-    routers::{
-        error,
-        grpc::{
-            common::stages::PipelineStage,
-            context::{PreparationOutput, RequestContext, RequestType},
-            utils,
-        },
+use crate::routers::{
+    error,
+    grpc::{
+        common::stages::PipelineStage,
+        context::{PreparationOutput, RequestContext, RequestType},
+        utils,
     },
 };
 

--- a/model_gateway/src/routers/grpc/regular/stages/embedding/response_processing.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/embedding/response_processing.rs
@@ -2,17 +2,15 @@
 
 use async_trait::async_trait;
 use axum::response::Response;
+use openai_protocol::embedding::{EmbeddingObject, EmbeddingResponse};
 use tracing::error;
 
-use crate::{
-    protocols::embedding::{EmbeddingObject, EmbeddingResponse},
-    routers::{
-        error,
-        grpc::{
-            common::stages::PipelineStage,
-            context::{ExecutionResult, FinalResponse, RequestContext},
-            proto_wrapper::ProtoEmbedComplete,
-        },
+use crate::routers::{
+    error,
+    grpc::{
+        common::stages::PipelineStage,
+        context::{ExecutionResult, FinalResponse, RequestContext},
+        proto_wrapper::ProtoEmbedComplete,
     },
 };
 
@@ -100,7 +98,7 @@ impl EmbeddingResponseProcessingStage {
 
         let prompt_tokens = proto.prompt_tokens();
 
-        let usage = crate::protocols::common::UsageInfo {
+        let usage = openai_protocol::common::UsageInfo {
             prompt_tokens,
             total_tokens: prompt_tokens, // Embedding has no completion tokens
             completion_tokens: 0,

--- a/model_gateway/src/routers/grpc/regular/stages/generate/preparation.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/generate/preparation.rs
@@ -4,19 +4,17 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use axum::response::Response;
+use llm_tokenizer::traits::Tokenizer;
+use openai_protocol::{common::InputIds, generate::GenerateRequest};
 use tracing::error;
 
-use crate::{
-    protocols::{common::InputIds, generate::GenerateRequest},
-    routers::{
-        error,
-        grpc::{
-            common::stages::PipelineStage,
-            context::{PreparationOutput, RequestContext},
-            utils,
-        },
+use crate::routers::{
+    error,
+    grpc::{
+        common::stages::PipelineStage,
+        context::{PreparationOutput, RequestContext},
+        utils,
     },
-    tokenizer::traits::Tokenizer,
 };
 
 /// Generate preparation stage

--- a/model_gateway/src/routers/grpc/router.rs
+++ b/model_gateway/src/routers/grpc/router.rs
@@ -5,6 +5,13 @@ use axum::{
     http::HeaderMap,
     response::{IntoResponse, Response},
 };
+use openai_protocol::{
+    chat::ChatCompletionRequest,
+    classify::ClassifyRequest,
+    embedding::EmbeddingRequest,
+    generate::GenerateRequest,
+    responses::{ResponsesGetParams, ResponsesRequest},
+};
 use tracing::debug;
 
 use super::{
@@ -23,13 +30,6 @@ use crate::{
     config::types::RetryConfig,
     core::{is_retryable_status, RetryExecutor, WorkerRegistry, UNKNOWN_MODEL_ID},
     observability::metrics::{metrics_labels, Metrics},
-    protocols::{
-        chat::ChatCompletionRequest,
-        classify::ClassifyRequest,
-        embedding::EmbeddingRequest,
-        generate::GenerateRequest,
-        responses::{ResponsesGetParams, ResponsesRequest},
-    },
     routers::RouterTrait,
 };
 

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -9,6 +9,13 @@ use axum::{
 };
 use futures_util::StreamExt;
 use memchr::memmem;
+use openai_protocol::{
+    chat::{ChatCompletionRequest, ChatMessage, MessageContent},
+    common::{InputIds, StringOrArray},
+    completion::CompletionRequest,
+    generate::GenerateRequest,
+    rerank::RerankRequest,
+};
 use reqwest::Client;
 use serde::Serialize;
 use serde_json::{json, Value};
@@ -28,13 +35,6 @@ use crate::{
         otel_trace::inject_trace_context_http,
     },
     policies::{LoadBalancingPolicy, PolicyRegistry, SelectWorkerInfo},
-    protocols::{
-        chat::{ChatCompletionRequest, ChatMessage, MessageContent},
-        common::{InputIds, StringOrArray},
-        completion::CompletionRequest,
-        generate::GenerateRequest,
-        rerank::RerankRequest,
-    },
     routers::{
         error,
         grpc::utils::{error_type_from_status, route_to_endpoint},

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -8,6 +8,16 @@ use axum::{
     Json,
 };
 use futures_util::{stream, StreamExt};
+use openai_protocol::{
+    chat::ChatCompletionRequest,
+    classify::ClassifyRequest,
+    common::GenerationRequest,
+    completion::CompletionRequest,
+    embedding::EmbeddingRequest,
+    generate::GenerateRequest,
+    rerank::{RerankRequest, RerankResponse, RerankResult},
+    responses::{ResponsesGetParams, ResponsesRequest},
+};
 use reqwest::Client;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::{debug, error};
@@ -25,16 +35,6 @@ use crate::{
         otel_trace::inject_trace_context_http,
     },
     policies::{PolicyRegistry, SelectWorkerInfo},
-    protocols::{
-        chat::ChatCompletionRequest,
-        classify::ClassifyRequest,
-        common::GenerationRequest,
-        completion::CompletionRequest,
-        embedding::EmbeddingRequest,
-        generate::GenerateRequest,
-        rerank::{RerankRequest, RerankResponse, RerankResult},
-        responses::{ResponsesGetParams, ResponsesRequest},
-    },
     routers::{
         error::{self, extract_error_code_from_response},
         grpc::utils::{error_type_from_status, route_to_endpoint},

--- a/model_gateway/src/routers/mcp_utils.rs
+++ b/model_gateway/src/routers/mcp_utils.rs
@@ -2,10 +2,9 @@
 
 use std::sync::Arc;
 
+use openai_protocol::responses::{ResponseTool, ResponseToolType};
 use smg_mcp::{BuiltinToolType, McpOrchestrator, McpServerConfig, McpTransport, ResponseFormat};
 use tracing::{debug, warn};
-
-use crate::protocols::responses::{ResponseTool, ResponseToolType};
 
 /// Default maximum tool loop iterations (safety limit).
 pub const DEFAULT_MAX_ITERATIONS: usize = 10;
@@ -205,10 +204,10 @@ pub async fn ensure_request_mcp_client(
 mod tests {
     use std::{collections::HashMap, sync::Arc};
 
+    use openai_protocol::responses::ResponseTool;
     use smg_mcp::{McpConfig, ResponseFormatConfig, ToolConfig};
 
     use super::*;
-    use crate::protocols::responses::ResponseTool;
 
     /// Create a test orchestrator with a built-in server configuration
     async fn create_test_orchestrator_with_builtin() -> Arc<McpOrchestrator> {

--- a/model_gateway/src/routers/mod.rs
+++ b/model_gateway/src/routers/mod.rs
@@ -9,8 +9,7 @@ use axum::{
     http::{HeaderMap, StatusCode},
     response::{IntoResponse, Response},
 };
-
-use crate::protocols::{
+use openai_protocol::{
     chat::ChatCompletionRequest,
     classify::ClassifyRequest,
     completion::CompletionRequest,

--- a/model_gateway/src/routers/openai/context.rs
+++ b/model_gateway/src/routers/openai/context.rs
@@ -3,15 +3,13 @@
 use std::sync::Arc;
 
 use axum::http::HeaderMap;
+use openai_protocol::{chat::ChatCompletionRequest, responses::ResponsesRequest};
 use serde_json::Value;
 use smg_data_connector::{ConversationItemStorage, ConversationStorage, ResponseStorage};
 use smg_mcp::{McpOrchestrator, McpToolSession};
 
 use super::provider::Provider;
-use crate::{
-    core::Worker,
-    protocols::{chat::ChatCompletionRequest, responses::ResponsesRequest},
-};
+use crate::core::Worker;
 
 pub struct RequestContext {
     pub input: RequestInput,

--- a/model_gateway/src/routers/openai/responses/accumulator.rs
+++ b/model_gateway/src/routers/openai/responses/accumulator.rs
@@ -1,10 +1,10 @@
 //! Streaming response accumulator for persisting responses.
 
+use openai_protocol::event_types::{OutputItemEvent, ResponseEvent};
 use serde_json::Value;
 use tracing::warn;
 
 use super::common::{extract_output_index, get_event_type};
-use crate::protocols::event_types::{OutputItemEvent, ResponseEvent};
 
 // ============================================================================
 // Streaming Response Accumulator

--- a/model_gateway/src/routers/openai/responses/mcp.rs
+++ b/model_gateway/src/routers/openai/responses/mcp.rs
@@ -12,6 +12,13 @@ use std::io;
 
 use axum::http::HeaderMap;
 use bytes::Bytes;
+use openai_protocol::{
+    event_types::{
+        is_function_call_type, CodeInterpreterCallEvent, FileSearchCallEvent, ItemType, McpEvent,
+        OutputItemEvent, WebSearchCallEvent,
+    },
+    responses::{generate_id, ResponseInput, ResponsesRequest},
+};
 use serde_json::{json, to_value, Value};
 use smg_mcp::{McpToolSession, ResponseFormat, ResponseTransformer, ToolExecutionInput};
 use tokio::sync::mpsc;
@@ -19,13 +26,6 @@ use tracing::{debug, info, warn};
 
 use crate::{
     observability::metrics::{metrics_labels, Metrics},
-    protocols::{
-        event_types::{
-            is_function_call_type, CodeInterpreterCallEvent, FileSearchCallEvent, ItemType,
-            McpEvent, OutputItemEvent, WebSearchCallEvent,
-        },
-        responses::{generate_id, ResponseInput, ResponsesRequest},
-    },
     routers::{header_utils::apply_request_headers, mcp_utils::DEFAULT_MAX_ITERATIONS},
 };
 

--- a/model_gateway/src/routers/openai/responses/streaming.rs
+++ b/model_gateway/src/routers/openai/responses/streaming.rs
@@ -16,6 +16,13 @@ use axum::{
 };
 use bytes::Bytes;
 use futures_util::StreamExt;
+use openai_protocol::{
+    event_types::{
+        is_function_call_type, is_response_event, CodeInterpreterCallEvent, FileSearchCallEvent,
+        FunctionCallEvent, ItemType, McpEvent, OutputItemEvent, ResponseEvent, WebSearchCallEvent,
+    },
+    responses::{ResponseToolType, ResponsesRequest},
+};
 use serde_json::{json, Value};
 use smg_mcp::{McpOrchestrator, McpToolSession, ResponseFormat};
 use tokio::sync::mpsc;
@@ -37,14 +44,6 @@ use super::{
 };
 use crate::{
     observability::metrics::Metrics,
-    protocols::{
-        event_types::{
-            is_function_call_type, is_response_event, CodeInterpreterCallEvent,
-            FileSearchCallEvent, FunctionCallEvent, ItemType, McpEvent, OutputItemEvent,
-            ResponseEvent, WebSearchCallEvent,
-        },
-        responses::{ResponseToolType, ResponsesRequest},
-    },
     routers::{
         error,
         header_utils::{apply_request_headers, preserve_response_headers},

--- a/model_gateway/src/routers/openai/responses/tool_handler.rs
+++ b/model_gateway/src/routers/openai/responses/tool_handler.rs
@@ -2,6 +2,9 @@
 
 use std::collections::HashMap;
 
+use openai_protocol::event_types::{
+    is_function_call_type, FunctionCallEvent, OutputItemEvent, ResponseEvent,
+};
 use serde_json::Value;
 use tracing::warn;
 
@@ -9,9 +12,6 @@ use super::{
     accumulator::StreamingResponseAccumulator,
     common::{extract_output_index, get_event_type},
     mcp::FunctionCallInProgress,
-};
-use crate::protocols::event_types::{
-    is_function_call_type, FunctionCallEvent, OutputItemEvent, ResponseEvent,
 };
 
 // ============================================================================

--- a/model_gateway/src/routers/openai/responses/utils.rs
+++ b/model_gateway/src/routers/openai/responses/utils.rs
@@ -1,12 +1,11 @@
 //! Response patching and transformation utilities for OpenAI responses
 
-use serde_json::{json, Map, Value};
-use tracing::warn;
-
-use crate::protocols::{
+use openai_protocol::{
     event_types::is_response_event,
     responses::{ResponseTool, ResponseToolType, ResponsesRequest},
 };
+use serde_json::{json, Map, Value};
+use tracing::warn;
 
 /// Check if a JSON value is missing, null, or an empty string
 fn is_missing_or_empty(value: Option<&Value>) -> bool {

--- a/model_gateway/src/routers/openai/router.rs
+++ b/model_gateway/src/routers/openai/router.rs
@@ -13,6 +13,13 @@ use axum::{
     Json,
 };
 use futures_util::{future::join_all, StreamExt};
+use openai_protocol::{
+    chat::ChatCompletionRequest,
+    responses::{
+        generate_id, ResponseContentPart, ResponseInput, ResponseInputOutputItem,
+        ResponsesGetParams, ResponsesRequest,
+    },
+};
 use serde_json::{json, to_value, Value};
 use smg_data_connector::{ConversationId, ListParams, ResponseId, SortOrder};
 use tokio::sync::mpsc;
@@ -35,13 +42,6 @@ use crate::{
         WorkerRegistry,
     },
     observability::metrics::{bool_to_static_str, metrics_labels, Metrics},
-    protocols::{
-        chat::ChatCompletionRequest,
-        responses::{
-            generate_id, ResponseContentPart, ResponseInput, ResponseInputOutputItem,
-            ResponsesGetParams, ResponsesRequest,
-        },
-    },
     routers::header_utils::{apply_provider_headers, extract_auth_header},
 };
 
@@ -300,7 +300,7 @@ impl OpenAIRouter {
             }
             ResponseInput::Items(current_items) => {
                 for item in current_items {
-                    items.push(crate::protocols::responses::normalize_input_item(item));
+                    items.push(openai_protocol::responses::normalize_input_item(item));
                 }
             }
         }

--- a/model_gateway/src/routers/parse/handlers.rs
+++ b/model_gateway/src/routers/parse/handlers.rs
@@ -7,12 +7,10 @@ use axum::{
     response::{IntoResponse, Response},
     Json,
 };
+use openai_protocol::parser::{ParseFunctionCallRequest, SeparateReasoningRequest};
 use tracing::error;
 
-use crate::{
-    app_context::AppContext,
-    protocols::parser::{ParseFunctionCallRequest, SeparateReasoningRequest},
-};
+use crate::app_context::AppContext;
 
 /// Helper to create error responses
 fn error_response(status: StatusCode, message: &str) -> Response {

--- a/model_gateway/src/routers/persistence_utils.rs
+++ b/model_gateway/src/routers/persistence_utils.rs
@@ -3,16 +3,15 @@
 use std::sync::Arc;
 
 use chrono::Utc;
+use openai_protocol::responses::{
+    generate_id, ResponseInput, ResponseInputOutputItem, ResponsesRequest, StringOrContentParts,
+};
 use serde_json::{json, Value};
 use smg_data_connector::{
     ConversationId, ConversationItem, ConversationItemId, ConversationItemStorage,
     ConversationStorage, NewConversationItem, ResponseId, ResponseStorage, StoredResponse,
 };
 use tracing::{debug, info, warn};
-
-use crate::protocols::responses::{
-    generate_id, ResponseInput, ResponseInputOutputItem, ResponsesRequest, StringOrContentParts,
-};
 
 // ============================================================================
 // Constants

--- a/model_gateway/src/routers/router_manager.rs
+++ b/model_gateway/src/routers/router_manager.rs
@@ -15,6 +15,16 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use dashmap::DashMap;
+use openai_protocol::{
+    chat::ChatCompletionRequest,
+    classify::ClassifyRequest,
+    completion::CompletionRequest,
+    embedding::EmbeddingRequest,
+    generate::GenerateRequest,
+    messages::CreateMessageRequest,
+    rerank::RerankRequest,
+    responses::{ResponsesGetParams, ResponsesRequest},
+};
 use serde_json::Value;
 use tracing::{debug, info, warn};
 
@@ -22,16 +32,6 @@ use crate::{
     app_context::AppContext,
     config::RoutingMode,
     core::{ConnectionMode, RuntimeType, WorkerRegistry, WorkerType},
-    protocols::{
-        chat::ChatCompletionRequest,
-        classify::ClassifyRequest,
-        completion::CompletionRequest,
-        embedding::EmbeddingRequest,
-        generate::GenerateRequest,
-        messages::CreateMessageRequest,
-        rerank::RerankRequest,
-        responses::{ResponsesGetParams, ResponsesRequest},
-    },
     routers::{
         factory::{router_ids, RouterId},
         RouterFactory, RouterTrait,

--- a/model_gateway/src/routers/tokenize/handlers.rs
+++ b/model_gateway/src/routers/tokenize/handlers.rs
@@ -10,17 +10,17 @@ use axum::{
     response::{IntoResponse, Response},
     Json,
 };
+use llm_tokenizer::{registry::TokenizerEntry, traits::Tokenizer, TokenizerRegistry};
+use openai_protocol::tokenize::{
+    AddTokenizerRequest, AddTokenizerResponse, CountResult, DetokenizeRequest, DetokenizeResponse,
+    ListTokenizersResponse, RemoveTokenizerResponse, TextResult, TokenizeRequest, TokenizeResponse,
+    TokenizerInfo, TokensResult,
+};
 use tracing::{debug, error, warn};
 
 use crate::{
     app_context::AppContext,
     core::{steps::TokenizerConfigRequest, Job, UNKNOWN_MODEL_ID},
-    protocols::tokenize::{
-        AddTokenizerRequest, AddTokenizerResponse, CountResult, DetokenizeRequest,
-        DetokenizeResponse, ListTokenizersResponse, RemoveTokenizerResponse, TextResult,
-        TokenizeRequest, TokenizeResponse, TokenizerInfo, TokensResult,
-    },
-    tokenizer::{registry::TokenizerEntry, traits::Tokenizer, TokenizerRegistry},
 };
 
 /// Helper to create error responses

--- a/model_gateway/src/service_discovery.rs
+++ b/model_gateway/src/service_discovery.rs
@@ -14,6 +14,7 @@ use kube::{
     },
     Client,
 };
+use openai_protocol::worker::{WorkerSpec, WorkerType};
 use rustls;
 use smg_mesh::{
     gossip::{NodeState, NodeStatus},
@@ -26,7 +27,6 @@ use crate::{
     app_context::AppContext,
     core::Job,
     observability::metrics::{metrics_labels, Metrics},
-    protocols::worker::{WorkerSpec, WorkerType},
 };
 
 #[derive(Debug, Clone)]
@@ -834,7 +834,7 @@ mod tests {
             worker_job_queue: worker_job_queue.clone(),
             workflow_engines: Arc::new(std::sync::OnceLock::new()),
             mcp_orchestrator: Arc::new(std::sync::OnceLock::new()),
-            tokenizer_registry: Arc::new(crate::tokenizer::registry::TokenizerRegistry::new()),
+            tokenizer_registry: Arc::new(llm_tokenizer::registry::TokenizerRegistry::new()),
             wasm_manager: None,
             worker_service: Arc::new(WorkerService::new(
                 worker_registry,

--- a/model_gateway/tests/api/responses_api_test.rs
+++ b/model_gateway/tests/api/responses_api_test.rs
@@ -1,15 +1,15 @@
 // Integration test for Responses API
 
 use axum::http::StatusCode;
+use openai_protocol::{
+    common::{GenerationRequest, ToolChoice, ToolChoiceValue, UsageInfo},
+    responses::{
+        ReasoningEffort, ResponseInput, ResponseReasoningParam, ResponseTool, ResponseToolType,
+        ResponsesRequest, ServiceTier, Truncation,
+    },
+};
 use smg::{
     config::RouterConfig,
-    protocols::{
-        common::{GenerationRequest, ToolChoice, ToolChoiceValue, UsageInfo},
-        responses::{
-            ReasoningEffort, ResponseInput, ResponseReasoningParam, ResponseTool, ResponseToolType,
-            ResponsesRequest, ServiceTier, Truncation,
-        },
-    },
     routers::{conversations, RouterFactory},
 };
 
@@ -398,7 +398,7 @@ fn test_usage_conversion() {
         completion_tokens: 25,
         total_tokens: 40,
         reasoning_tokens: Some(8),
-        prompt_tokens_details: Some(smg::protocols::common::PromptTokenUsageInfo {
+        prompt_tokens_details: Some(openai_protocol::common::PromptTokenUsageInfo {
             cached_tokens: 3,
         }),
     };

--- a/model_gateway/tests/common/mod.rs
+++ b/model_gateway/tests/common/mod.rs
@@ -17,7 +17,10 @@ use std::{
     sync::{Arc, Mutex, OnceLock},
 };
 
+use llm_tokenizer::registry::TokenizerRegistry;
 use mock_worker::{MockWorker, MockWorkerConfig};
+use openai_protocol::common::{Function, Tool};
+use reasoning_parser::ParserFactory as ReasoningParserFactory;
 use serde_json::json;
 use smg::{
     app_context::AppContext,
@@ -28,17 +31,14 @@ use smg::{
     },
     middleware::TokenBucket,
     policies::PolicyRegistry,
-    protocols::common::{Function, Tool},
-    reasoning_parser::ParserFactory as ReasoningParserFactory,
     routers::{RouterFactory, RouterTrait},
-    tokenizer::registry::TokenizerRegistry,
-    tool_parser::ParserFactory as ToolParserFactory,
 };
 use smg_data_connector::{
     MemoryConversationItemStorage, MemoryConversationStorage, MemoryResponseStorage,
 };
 #[allow(unused_imports)]
 pub use test_config::{TestRouterConfig, TestWorkerConfig};
+use tool_parser::ParserFactory as ToolParserFactory;
 
 /// Test context for directly testing mock workers without full router setup.
 pub struct WorkerTestContext {

--- a/model_gateway/tests/common/test_app.rs
+++ b/model_gateway/tests/common/test_app.rs
@@ -1,6 +1,7 @@
 use std::sync::{Arc, OnceLock};
 
 use axum::Router;
+use llm_tokenizer::registry::TokenizerRegistry;
 use reqwest::Client;
 use smg::{
     app_context::AppContext,
@@ -12,7 +13,6 @@ use smg::{
     policies::PolicyRegistry,
     routers::RouterTrait,
     server::{build_app, AppState},
-    tokenizer::registry::TokenizerRegistry,
 };
 use smg_data_connector::{
     MemoryConversationItemStorage, MemoryConversationStorage, MemoryResponseStorage,

--- a/model_gateway/tests/messages_test.rs
+++ b/model_gateway/tests/messages_test.rs
@@ -6,8 +6,8 @@
 //! - Request deserialization works
 //! - No breaking changes to existing functionality
 
+use openai_protocol::messages::{CreateMessageRequest, InputContent, Role, SystemContent};
 use serde_json::json;
-use smg::protocols::messages::{CreateMessageRequest, InputContent, Role, SystemContent};
 
 #[test]
 fn test_create_message_request_deserialization() {

--- a/model_gateway/tests/routing/policy_registry_integration.rs
+++ b/model_gateway/tests/routing/policy_registry_integration.rs
@@ -2,9 +2,10 @@
 
 use std::{collections::HashMap, sync::Arc};
 
+use openai_protocol::worker::WorkerSpec;
 use smg::{
     config::PolicyConfig, core::WorkerRegistry, policies::PolicyRegistry,
-    protocols::worker::WorkerSpec, routers::router_manager::RouterManager,
+    routers::router_manager::RouterManager,
 };
 
 #[tokio::test]

--- a/model_gateway/tests/routing/test_openai_routing.rs
+++ b/model_gateway/tests/routing/test_openai_routing.rs
@@ -16,16 +16,16 @@ use axum::{
     routing::post,
     Json, Router,
 };
+use openai_protocol::{
+    chat::{ChatCompletionRequest, ChatMessage, MessageContent},
+    common::StringOrArray,
+    completion::CompletionRequest,
+    generate::GenerateRequest,
+    responses::{ResponseInput, ResponsesGetParams, ResponsesRequest},
+};
 use serde_json::json;
 use smg::{
     config::{ConfigError, HistoryBackend, OracleConfig, RouterConfig, RoutingMode},
-    protocols::{
-        chat::{ChatCompletionRequest, ChatMessage, MessageContent},
-        common::StringOrArray,
-        completion::CompletionRequest,
-        generate::GenerateRequest,
-        responses::{ResponseInput, ResponsesGetParams, ResponsesRequest},
-    },
     routers::{openai::OpenAIRouter, RouterTrait},
 };
 use smg_data_connector::{ResponseId, StoredResponse};

--- a/model_gateway/tests/routing/test_pd_routing.rs
+++ b/model_gateway/tests/routing/test_pd_routing.rs
@@ -1,12 +1,12 @@
 #[cfg(test)]
 mod pd_routing_unit_tests {
+    use llm_tokenizer::registry::TokenizerRegistry;
     use serde_json::json;
     use smg::{
         app_context::AppContext,
         config::{PolicyConfig, RouterConfig, RoutingMode},
         core::{BasicWorkerBuilder, Worker, WorkerType},
         routers::{http::pd_types::PDSelectionPolicy, RouterFactory},
-        tokenizer::registry::TokenizerRegistry,
     };
 
     #[derive(Debug)]

--- a/model_gateway/tests/security/auth_integration_test.rs
+++ b/model_gateway/tests/security/auth_integration_test.rs
@@ -18,7 +18,7 @@ use jsonwebtoken::{encode, EncodingKey, Header};
 use rsa::{traits::PublicKeyParts, RsaPrivateKey};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use smg::auth::{ApiKeyEntry, ControlPlaneAuthConfig, ControlPlaneAuthState, JwtConfig, Role};
+use smg_auth::{ApiKeyEntry, ControlPlaneAuthConfig, ControlPlaneAuthState, JwtConfig, Role};
 use tokio::net::TcpListener;
 
 const TEST_KEY_ID: &str = "test-key-1";
@@ -570,7 +570,7 @@ async fn test_audit_logging_disabled() {
 
 #[tokio::test]
 async fn test_jwt_jti_replay_protection() {
-    use smg::auth::JwtValidator;
+    use smg_auth::JwtValidator;
 
     let (addr, _server) = start_mock_jwks_server().await;
 
@@ -610,7 +610,7 @@ async fn test_jwt_jti_replay_protection() {
 
 #[tokio::test]
 async fn test_jwt_different_tokens_no_replay() {
-    use smg::auth::JwtValidator;
+    use smg_auth::JwtValidator;
 
     let (addr, _server) = start_mock_jwks_server().await;
 

--- a/model_gateway/tests/spec/chat_completion.rs
+++ b/model_gateway/tests/spec/chat_completion.rs
@@ -1,5 +1,4 @@
-use serde_json::json;
-use smg::protocols::{
+use openai_protocol::{
     chat::{ChatCompletionRequest, ChatMessage, MessageContent},
     common::{
         Function, FunctionCall, FunctionChoice, StreamOptions, Tool, ToolChoice, ToolChoiceValue,
@@ -7,6 +6,7 @@ use smg::protocols::{
     },
     validated::Normalizable,
 };
+use serde_json::json;
 use validator::Validate;
 
 // Deprecated fields normalization tests

--- a/model_gateway/tests/spec/chat_message.rs
+++ b/model_gateway/tests/spec/chat_message.rs
@@ -1,5 +1,5 @@
+use openai_protocol::chat::{ChatMessage, MessageContent};
 use serde_json::json;
-use smg::protocols::chat::{ChatMessage, MessageContent};
 
 #[test]
 fn test_chat_message_tagged_by_role_system() {

--- a/model_gateway/tests/spec/embedding.rs
+++ b/model_gateway/tests/spec/embedding.rs
@@ -1,5 +1,5 @@
+use openai_protocol::{common::GenerationRequest, embedding::EmbeddingRequest};
 use serde_json::{from_str, json, to_string};
-use smg::protocols::{common::GenerationRequest, embedding::EmbeddingRequest};
 
 #[test]
 fn test_embedding_request_serialization_string_input() {

--- a/model_gateway/tests/spec/rerank.rs
+++ b/model_gateway/tests/spec/rerank.rs
@@ -1,10 +1,10 @@
 use std::collections::HashMap;
 
-use serde_json::{from_str, to_string, Number, Value};
-use smg::protocols::{
+use openai_protocol::{
     common::{GenerationRequest, StringOrArray, UsageInfo},
     rerank::{RerankRequest, RerankResponse, RerankResult, V1RerankReqInput},
 };
+use serde_json::{from_str, to_string, Number, Value};
 use validator::Validate;
 
 #[test]

--- a/model_gateway/tests/spec/responses.rs
+++ b/model_gateway/tests/spec/responses.rs
@@ -1,11 +1,11 @@
-use serde_json::json;
-use smg::protocols::{
+use openai_protocol::{
     common::{Function, StringOrArray, ToolChoice, ToolChoiceValue},
     responses::{
         IncludeField, ResponseInput, ResponseInputOutputItem, ResponseTool, ResponseToolType,
         ResponsesRequest, StringOrContentParts, TextConfig, TextFormat,
     },
 };
+use serde_json::json;
 use validator::Validate;
 
 /// Test that valid conversation IDs pass validation
@@ -966,7 +966,7 @@ fn test_validate_input_items_structure() {
 /// Test tool_choice defaults to auto when tools are present
 #[test]
 fn test_normalize_tool_choice_auto() {
-    use smg::protocols::validated::Normalizable;
+    use openai_protocol::validated::Normalizable;
 
     let mut request = ResponsesRequest {
         input: ResponseInput::Text("test".to_string()),
@@ -1008,7 +1008,7 @@ fn test_normalize_tool_choice_auto() {
 /// Test tool_choice defaults to none when tools array is empty
 #[test]
 fn test_normalize_tool_choice_none() {
-    use smg::protocols::validated::Normalizable;
+    use openai_protocol::validated::Normalizable;
 
     let mut request = ResponsesRequest {
         input: ResponseInput::Text("test".to_string()),
@@ -1035,7 +1035,7 @@ fn test_normalize_tool_choice_none() {
 /// Test tool_choice is not overridden if already set
 #[test]
 fn test_normalize_tool_choice_no_override() {
-    use smg::protocols::validated::Normalizable;
+    use openai_protocol::validated::Normalizable;
 
     let mut request = ResponsesRequest {
         input: ResponseInput::Text("test".to_string()),
@@ -1073,7 +1073,7 @@ fn test_normalize_tool_choice_no_override() {
 /// Test parallel_tool_calls defaults to true when tools are present
 #[test]
 fn test_normalize_parallel_tool_calls() {
-    use smg::protocols::validated::Normalizable;
+    use openai_protocol::validated::Normalizable;
 
     let mut request = ResponsesRequest {
         input: ResponseInput::Text("test".to_string()),
@@ -1113,7 +1113,7 @@ fn test_normalize_parallel_tool_calls() {
 /// Test parallel_tool_calls is not set when tools are absent
 #[test]
 fn test_normalize_parallel_tool_calls_no_tools() {
-    use smg::protocols::validated::Normalizable;
+    use openai_protocol::validated::Normalizable;
 
     let mut request = ResponsesRequest {
         input: ResponseInput::Text("test".to_string()),
@@ -1133,7 +1133,7 @@ fn test_normalize_parallel_tool_calls_no_tools() {
 /// Test parallel_tool_calls is not overridden if already set
 #[test]
 fn test_normalize_parallel_tool_calls_no_override() {
-    use smg::protocols::validated::Normalizable;
+    use openai_protocol::validated::Normalizable;
 
     let mut request = ResponsesRequest {
         input: ResponseInput::Text("test".to_string()),
@@ -1169,7 +1169,7 @@ fn test_normalize_parallel_tool_calls_no_override() {
 /// Test store defaults to true
 #[test]
 fn test_normalize_store_default() {
-    use smg::protocols::validated::Normalizable;
+    use openai_protocol::validated::Normalizable;
 
     let mut request = ResponsesRequest {
         input: ResponseInput::Text("test".to_string()),
@@ -1189,7 +1189,7 @@ fn test_normalize_store_default() {
 /// Test store is not overridden if already set
 #[test]
 fn test_normalize_store_no_override() {
-    use smg::protocols::validated::Normalizable;
+    use openai_protocol::validated::Normalizable;
 
     let mut request = ResponsesRequest {
         input: ResponseInput::Text("test".to_string()),

--- a/model_gateway/tests/wasm_test.rs
+++ b/model_gateway/tests/wasm_test.rs
@@ -15,6 +15,7 @@ use axum::{
     extract::Request,
     http::{header::CONTENT_TYPE, StatusCode},
 };
+use llm_tokenizer::TokenizerRegistry;
 use smg::{
     app_context::AppContext,
     config::RouterConfig,
@@ -22,7 +23,6 @@ use smg::{
     policies::PolicyRegistry,
     routers::RouterFactory,
     server::{build_app, AppState},
-    tokenizer::TokenizerRegistry,
     wasm::{
         module::{
             WasmModuleAddRequest, WasmModuleAddResponse, WasmModuleAttachPoint,


### PR DESCRIPTION
## Summary
- Removes the last 5 `pub use` re-exports from `model_gateway/src/lib.rs`, completing the cleanup started in #413
- All 100 affected files now import workspace crates (`openai_protocol`, `smg_auth`, `llm_tokenizer`, `reasoning_parser`, `tool_parser`) directly by their real names
- Binding crates (`golang`, `python`) gain direct `Cargo.toml` dependencies on the crates they use

## What changed

**`model_gateway/src/lib.rs`** — removed all re-export aliases:
```diff
-pub use openai_protocol as protocols;
-pub use reasoning_parser;
-pub use llm_tokenizer as tokenizer;
-pub use tool_parser;
-pub use smg_auth as auth;
```

**~85 source files** — replaced aliased imports:
| Old (alias) | New (direct) |
|---|---|
| `crate::protocols::` | `openai_protocol::` |
| `crate::auth::` | `smg_auth::` |
| `crate::tokenizer::` | `llm_tokenizer::` |
| `crate::reasoning_parser::` | `reasoning_parser::` |
| `crate::tool_parser::` | `tool_parser::` |

**14 test files + 4 bench files** — same `smg::protocols` → `openai_protocol` etc.

**Bindings** — `golang/Cargo.toml` and `python/Cargo.toml` now declare direct deps on the workspace crates they consume.

## Why
- Eliminates hidden dependency aliases that obscure the real crate graph
- Makes it immediately clear which workspace crate each import references
- Prevents accidental coupling through the gateway's `lib.rs` facade
- Completes the work from #413 (which removed `data_connector`, `grpc_client`, `mcp`, `mesh`, `workflow`)

## Test plan
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes (one bench file was caught and fixed during final validation)
- [ ] CI green on all workflow jobs

Refs: #413

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal module architecture by extracting core components into independent packages for improved modularity and maintainability.
  * Updated import paths throughout to align with the new modular structure.

* **Chores**
  * Added new internal dependencies to support the modularized architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->