### PR TITLE
chore(mesh): bump smg-mesh version to 1.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ kv-index = { version = "1.0.0", path = "kv_index" }
 smg-data-connector = { version = "1.1.0", path = "data_connector", package = "data-connector" }
 llm-multimodal = { version = "1.1.0", path = "multimodal" }
 smg-wasm = { version = "1.0.0", path = "wasm", package = "smg-wasm" }
-smg-mesh = { version = "1.0.0", path = "mesh", package = "smg-mesh" }
+smg-mesh = { version = "1.1.0", path = "mesh", package = "smg-mesh" }
 smg-grpc-client = { version = "1.1.0", path = "grpc_client" }
 
 # Shared dependencies

--- a/mesh/Cargo.toml
+++ b/mesh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-mesh"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 description = "Mesh gossip protocol and distributed state synchronization for Shepherd Model Gateway"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Bump `smg-mesh` crate version from `1.0.0` to `1.1.0` to fix `cargo publish` verification failures for the `smg` crate in the `release-crates.yml` workflow (tier 3).

## What changed

- `mesh/Cargo.toml`: version `1.0.0` → `1.1.0`
- `Cargo.toml` (workspace): `smg-mesh` dependency version `1.0.0` → `1.1.0`

## Why

The `smg-mesh` crate has had API changes (new `MeshServerBuilder` exports, `MeshServerHandler` field changes, `write_data` return type update) that are not reflected in the published `1.0.0` on crates.io. When `release-crates.yml` tier 3 runs `cargo publish` for the `smg` crate, verification compiles against crates.io dependencies — resolving the old `smg-mesh@1.0.0` and failing with 12 compilation errors.

Bumping to `1.1.0` ensures tier 2 publishes the new mesh API first, so tier 3 resolves the correct version.

## Test plan

- `cargo check --all-targets --all-features` passes locally
- `release-crates.yml` tier 2 will publish `smg-mesh@1.1.0`, then tier 3 `cargo publish` for `smg` will succeed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped package version to 1.1.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->