### PR TITLE
fix: render README images on PyPI/crates.io and bump version to 1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 <p align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="docs/assets/images/logos/logomark-white.svg">
-    <source media="(prefers-color-scheme: light)" srcset="docs/assets/images/logos/logomark-dark.svg">
-    <img alt="SMG Logo" src="docs/assets/images/logos/logomark-dark.svg" width="80">
-  </picture>
+  <img alt="SMG Logo" src="https://raw.githubusercontent.com/lightseekorg/smg/main/docs/assets/images/logos/logomark-dark.svg" width="80">
 </p>
 
 <h1 align="center">Shepherd Model Gateway</h1>
@@ -19,7 +15,7 @@
 High-performance model-routing gateway for large-scale LLM deployments. Centralizes worker lifecycle management, balances traffic across HTTP/gRPC/OpenAI-compatible backends, and provides enterprise-ready control over history storage, MCP tooling, and privacy-sensitive workflows.
 
 <p align="center">
-  <img src="docs/assets/images/architecture-animated.svg" alt="SMG Architecture" width="100%">
+  <img src="https://raw.githubusercontent.com/lightseekorg/smg/main/docs/assets/images/architecture-animated.svg" alt="SMG Architecture" width="100%">
 </p>
 
 ## Why SMG?

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-python"
-version = "0.4.0"
+version = "1.0.1"
 edition = "2021"
 
 [lib]

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "smg"
-version = "0.4.0"
+version = "1.0.1"
 description = "High-performance Rust-based inference gateway for large-scale LLM deployments"
 authors = [
     {name = "Simo Lin", email = "linsimo.mark@gmail.com"},

--- a/model_gateway/Cargo.toml
+++ b/model_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 description = "High-performance model-routing gateway for large-scale LLM deployments"
 license = "Apache-2.0"
@@ -11,6 +11,7 @@ authors = [
     "Keyang Ru <rukeyang@gmail.com>",
 ]
 keywords = ["llm", "inference", "gateway", "load-balancer", "openai"]
+readme = "../README.md"
 categories = ["web-programming", "network-programming"]
 
 [features]


### PR DESCRIPTION
## Summary

Fix README images not rendering on PyPI and crates.io, and bump smg version to 1.0.1.

## What changed

- **README.md**: Replace relative SVG paths with absolute `raw.githubusercontent.com` URLs so images render on PyPI and crates.io. Replace `<picture>`/`<source>` dark/light mode tags with a plain `<img>` (neither platform supports `prefers-color-scheme`).
- **model_gateway/Cargo.toml**: Add `readme = "../README.md"` so crates.io displays the README. Bump version 1.0.0 → 1.0.1.
- **bindings/python/Cargo.toml**: Bump version 0.4.0 → 1.0.1.
- **bindings/python/pyproject.toml**: Bump version 0.4.0 → 1.0.1.

## Test plan

- [ ] Verify README renders correctly on the GitHub PR preview
- [ ] After merge, verify https://pypi.org/project/smg/ shows the logo and architecture SVG
- [ ] After merge, verify https://crates.io/crates/smg shows the README

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated embedded images in the project README to use externally hosted raw URLs.

* **Chores**
  * Bumped package versions to 1.0.1 for Python bindings and gateway packages.
  * Added README metadata to the gateway package manifest.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->