### PR TITLE
chore(ci): Change nightly benchmark schedule to midnight PST

### DIFF
--- a/.github/workflows/nightly-benchmark.yml
+++ b/.github/workflows/nightly-benchmark.yml
@@ -2,7 +2,7 @@ name: Nightly Benchmark
 
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 8 * * *'
   workflow_dispatch:
     inputs:
       models:


### PR DESCRIPTION
## Description

### Problem
Current schedule is 0 UTC, which is 4 pm PST.

<!-- What problem is this PR trying to solve? -->

### Solution
Changed it to 8 AM UTC, it will run midnight PST
<!-- How does this PR solve the problem? -->

## Changes

<!-- - Describe your changes here. -->

## Test Plan

<!-- Provide a thorough reproducible test showing before and after behavior. -->

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>
