### PR TITLE
ci: temporarily disable auto-close for branch naming violations

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -14,13 +14,16 @@ pull_request_rules:
           - `<username>/<description>` — e.g. `changsu/fix-routing`
 
           Allowed types: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `ci`, `perf`
+
+          > **Note:** We will bypass this check for existing PRs during the grace period, but PRs with non-conforming branch names **will be auto-closed** in the future. Please follow the naming convention for all new branches.
       post_check:
         title: Branch naming convention
         summary: |
           Branch `{{head}}` does not match the required pattern: `<type>/<description>` or `<username>/<description>`.
-      close:
-        message: |
-          Closing this PR because the branch name does not follow the naming convention. Please rename your branch and reopen.
+      # TODO: Re-enable auto-close once existing non-conforming PRs are merged
+      # close:
+      #   message: |
+      #     Closing this PR because the branch name does not follow the naming convention. Please rename your branch and reopen.
 
   - name: Comment on DCO check failure
     description: Post fix instructions when DCO sign-off is missing


### PR DESCRIPTION
## Description

### Problem

Existing open PRs have non-conforming branch names that predate the new naming convention rule. The auto-close action would immediately close them.

### Solution

Temporarily comment out the `close` action in the Mergify branch naming rule. Non-conforming PRs will still get a comment and a failing check, but won't be auto-closed.

## Changes

- Comment out the `close` action in `.github/mergify.yml` branch naming rule
- Add TODO to re-enable once existing non-conforming PRs are merged

## Test Plan

- Verify Mergify still comments and posts a failing check on non-conforming branch names
- Verify existing PRs are not auto-closed

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] Documentation updated

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Temporarily disabled automatic closure of pull requests for branch-naming violations.
  * Added a prominent notice clarifying that existing PRs are exempt during the grace period; new non-conforming branches will be closed in future.
  * Replaced the active close behavior with a commented placeholder and a TODO to re-enable automatic closure after outstanding non-conforming PRs are resolved.
  * No change to post-check messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->