### PR TITLE
ci: add needs-rebase label management to Mergify

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -73,6 +73,7 @@ pull_request_rules:
     conditions:
       - -conflict
       - -closed
+      - label = needs-rebase
     actions:
       label:
         remove:


### PR DESCRIPTION
## Description

### Problem

When PRs have merge conflicts, there's no easy way to filter or track them.

### Solution

Add two Mergify rules following vLLM's pattern:
- Add `needs-rebase` label + comment with rebase instructions when a PR has conflicts
- Automatically remove `needs-rebase` label when the conflict is resolved

## Changes

- Update merge conflict rule in `.github/mergify.yml` to add `needs-rebase` label
- Add new rule to remove `needs-rebase` label when conflict is resolved

## Test Plan

- Verify Mergify adds `needs-rebase` label on PRs with conflicts
- Verify label is removed after rebasing

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] Documentation updated

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Renamed the conflict-notification rule to add a needs-rebase label and post rebase instructions when merge conflicts are detected.
  * Expanded conflict handling to apply the needs-rebase label in addition to commenting.
  * Added automated removal of the needs-rebase label once merge conflicts are resolved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->