### PR TITLE
ci: improve label management with router-specific and feature labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -31,7 +31,9 @@ docker:
 
 grpc:
   - changed-files:
-      - any-glob-to-any-file: 'grpc_client/**/*'
+      - any-glob-to-any-file:
+          - 'grpc_client/**/*'
+          - 'model_gateway/src/routers/grpc/**/*'
 
 mcp:
   - changed-files:
@@ -78,6 +80,25 @@ workflow:
 model-gateway:
   - changed-files:
       - any-glob-to-any-file: 'model_gateway/**/*'
+
+openai:
+  - changed-files:
+      - any-glob-to-any-file: 'model_gateway/src/routers/openai/**/*'
+
+anthropic:
+  - changed-files:
+      - any-glob-to-any-file: 'model_gateway/src/routers/anthropic/**/*'
+
+gemini:
+  - changed-files:
+      - any-glob-to-any-file: 'model_gateway/src/routers/gemini/**/*'
+
+realtime-api:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'protocols/src/realtime_*'
+          - 'protocols/src/builders/realtime/**/*'
+          - 'model_gateway/src/routers/openai/realtime/**/*'
 
 benchmarks:
   - changed-files:


### PR DESCRIPTION
## Description

### Problem

The auto-labeling configuration only covers crate-level labels (e.g. `model-gateway`, `protocols`) but lacks router-specific and feature-level labels. This makes it hard to track work on specific routers (openai, anthropic, gemini) or features (realtime-api) that may span multiple crates.

Additionally:
- The `vllm` label had no description and couldn't be reliably auto-applied (gRPC is shared by vllm, sglang, and tensorrt-llm)
- The `grpc` label only matched `grpc_client/` but not `model_gateway/src/routers/grpc/`
- The `realtime-api` label had no description and no auto-labeling rule

### Solution

Update `.github/labeler.yml` to add router-specific and feature-level auto-labeling rules. Also performed GitHub label cleanup (label creation/deletion/description updates were applied directly via `gh` CLI).

## Changes

**Labeler config (`.github/labeler.yml`):**
- Add `openai` label rule matching `model_gateway/src/routers/openai/**/*`
- Add `anthropic` label rule matching `model_gateway/src/routers/anthropic/**/*`
- Add `gemini` label rule matching `model_gateway/src/routers/gemini/**/*`
- Add `realtime-api` label rule matching `protocols/src/realtime_*`, `protocols/src/builders/realtime/**/*`, `model_gateway/src/routers/openai/realtime/**/*`
- Update `grpc` rule to also match `model_gateway/src/routers/grpc/**/*`

**GitHub label changes (already applied):**
- Created: `openai`, `anthropic`, `gemini` labels with descriptions
- Deleted: `vllm` label (can't distinguish gRPC backends by file paths)
- Updated descriptions: `grpc` → "gRPC client and router changes", `realtime-api` → "Realtime API related changes"

**Retroactive PR labeling (already applied):**
- PRs #364, #387, #389, #390, #406 → `realtime-api`
- PR #406 → `openai`
- PR #407 → `anthropic`
- PR #417 → `gemini`

## Test Plan

- Verify labeler config is valid YAML
- Future PRs touching router paths will be auto-labeled correctly by the `actions/labeler` workflow

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] (Optional) Documentation updated

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull request labeling configuration to better categorize and organize changes across additional service modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->