### PR TITLE
fix(ci): use correct Mergify syntax for negated regex condition

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -2,7 +2,7 @@ pull_request_rules:
   - name: Enforce branch naming convention
     description: Branch must follow <type>/<description> or <username>/<description> format
     conditions:
-      - head ~!= ^[a-z0-9]([a-z0-9._-]*[a-z0-9])?/[a-z0-9._-]+$
+      - -head~=^[a-z0-9]([a-z0-9._-]*[a-z0-9])?/[a-z0-9._-]+$
       - head != main
     actions:
       comment:


### PR DESCRIPTION
## Description

### Problem

Mergify configuration is invalid and all rules are blocked from running. The branch naming enforcement rule uses `~!=` operator for negated regex matching, which is not a valid Mergify operator.

### Solution

Replace `head ~!= <regex>` with `-head~=<regex>` — the correct Mergify syntax for negating a condition is the `-` prefix.

## Changes

- Fix negated regex operator in branch naming convention rule: `head ~!=` → `-head~=`

## Test Plan

- Verify in the [Mergify config editor](https://dashboard.mergify.com/config-editor?repository=smg&login=lightseekorg) that the configuration is now valid
- After merge, Mergify should start evaluating all open PRs (e.g. PR #415 should get `needs-rebase` label)

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] (Optional) Documentation updated

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated branch validation configuration to refine naming rule enforcement logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->