### PR TITLE
ci: add Docker image release workflow

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -1,0 +1,64 @@
+name: Release Docker Image
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - docker/Dockerfile
+      - bindings/python/pyproject.toml
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Image tag (e.g. v1.0.1). Leave empty to use version from pyproject.toml'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-push:
+    name: Build and push Docker image
+    if: github.repository == 'lightseekorg/smg'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Determine version tag
+        id: version
+        run: |
+          if [[ -n "${{ inputs.tag }}" ]]; then
+            VERSION="${{ inputs.tag }}"
+          else
+            VERSION=$(grep -m1 '^version = ' bindings/python/pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Using version: ${VERSION}"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile
+          push: true
+          tags: |
+            lightseekorg/smg:${{ steps.version.outputs.version }}
+            lightseekorg/smg:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
## Summary

Add automated Docker image publishing to Docker Hub for multi-platform builds.

## What changed

- **`.github/workflows/release-docker.yml`**: New workflow that:
  - Triggers on push to `main` when `docker/Dockerfile` or `bindings/python/pyproject.toml` changes
  - Supports manual dispatch with optional tag override
  - Builds multi-platform images (`linux/amd64`, `linux/arm64`) using QEMU + Docker Buildx
  - Pushes versioned (`lightseekorg/smg:<version>`) and `latest` tags to Docker Hub
  - Uses GHA layer caching for faster rebuilds
  - Reads version from `pyproject.toml` by default

## Prerequisites

GitHub secrets `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` have been configured on the repo.

## Test plan

- [ ] Trigger workflow manually via `workflow_dispatch` to verify build and push
- [ ] Verify both `lightseekorg/smg:<version>` and `lightseekorg/smg:latest` appear on Docker Hub
- [ ] Verify multi-platform manifest includes both amd64 and arm64

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Established automated Docker image building and publishing to container registry with multi-architecture support (AMD64, ARM64)
  * Configured for automatic triggering on main branch updates with manual activation capability
  * Integrated build caching mechanisms to optimize performance and reduce release cycle times

<!-- end of auto-generated comment: release notes by coderabbit.ai -->