### PR TITLE
refactor(core): move DP fields to WorkerSpec and remove default_model_type

### DIFF
--- a/bindings/golang/src/policy.rs
+++ b/bindings/golang/src/policy.rs
@@ -22,7 +22,7 @@ use smg::{
     core::{
         circuit_breaker::CircuitBreaker,
         worker::{RuntimeType, WorkerMetadata, WorkerRoutingKeyLoad},
-        ConnectionMode, ModelType, Worker, WorkerType,
+        ConnectionMode, Worker, WorkerType,
     },
     policies::{
         BucketPolicy, CacheAwarePolicy, LoadBalancingPolicy, PowerOfTwoPolicy, RandomPolicy,
@@ -64,7 +64,6 @@ impl GrpcWorker {
         let metadata = WorkerMetadata {
             spec,
             health_endpoint: "/health".to_string(),
-            default_model_type: ModelType::LLM,
         };
         Self {
             client,

--- a/model_gateway/src/core/worker.rs
+++ b/model_gateway/src/core/worker.rs
@@ -184,27 +184,42 @@ pub trait Worker: Send + Sync + fmt::Debug {
 
     /// Check if this worker is DP-aware
     fn is_dp_aware(&self) -> bool {
-        false
+        self.metadata().spec.dp_rank.is_some()
     }
 
     /// Get the base URL without any DP rank suffix
     fn base_url(&self) -> &str {
-        self.url()
+        self.metadata()
+            .spec
+            .dp_base_url
+            .as_deref()
+            .unwrap_or(self.url())
     }
 
     /// Get DP rank if this is a DP-aware worker
     fn dp_rank(&self) -> Option<usize> {
-        None
+        self.metadata().spec.dp_rank
     }
 
     /// Get DP size if this worker is part of a DP group
     fn dp_size(&self) -> Option<usize> {
-        None
+        self.metadata().spec.dp_size
     }
 
     /// Transform a request for DP-aware routing
-    async fn prepare_request(&self, req: serde_json::Value) -> WorkerResult<serde_json::Value> {
-        Ok(req)
+    async fn prepare_request(&self, mut req: serde_json::Value) -> WorkerResult<serde_json::Value> {
+        if let Some(rank) = self.metadata().spec.dp_rank {
+            if let Some(map) = req.as_object_mut() {
+                map.insert("data_parallel_rank".to_string(), serde_json::json!(rank));
+                Ok(req)
+            } else {
+                Err(WorkerError::InvalidConfiguration {
+                    message: "Request must be a JSON object for DP-aware routing".to_string(),
+                })
+            }
+        } else {
+            Ok(req)
+        }
     }
 
     /// Get the actual endpoint URL for requests
@@ -403,8 +418,6 @@ pub struct WorkerMetadata {
     pub spec: WorkerSpec,
     /// Health check endpoint path (internal-only, from router config).
     pub health_endpoint: String,
-    /// Default model type for unknown models (defaults to LLM capabilities).
-    pub default_model_type: ModelType,
 }
 
 impl WorkerMetadata {
@@ -420,12 +433,14 @@ impl WorkerMetadata {
     }
 
     /// Check if this worker supports an endpoint for a given model.
-    /// Falls back to default_model_type if model not found.
+    /// Falls back to LLM capabilities if model not found — this is safe because
+    /// non-LLM workers (embeddings, rerank) are always registered with explicit
+    /// models via discovery, never as wildcards.
     pub fn supports_endpoint(&self, model_id: &str, endpoint: Endpoint) -> bool {
         if let Some(model) = self.find_model(model_id) {
             model.supports_endpoint(endpoint)
         } else {
-            self.default_model_type.supports_endpoint(endpoint)
+            ModelType::LLM.supports_endpoint(endpoint)
         }
     }
 
@@ -466,31 +481,16 @@ pub struct BasicWorker {
     /// When set, overrides metadata.models for routing decisions.
     /// Uses std::sync::RwLock for synchronous access in supports_model().
     pub models_override: Arc<StdRwLock<Option<WorkerModels>>>,
-    /// DP rank for this worker (None = not DP-aware)
-    pub dp_rank: Option<usize>,
-    /// Total DP size (None = not DP-aware)
-    pub dp_size: Option<usize>,
-    /// Base URL without DP suffix (None = not DP-aware)
-    pub dp_base_url: Option<String>,
 }
 
 impl fmt::Debug for BasicWorker {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut s = f.debug_struct("BasicWorker");
-        s.field("metadata", &self.metadata)
+        f.debug_struct("BasicWorker")
+            .field("metadata", &self.metadata)
             .field("healthy", &self.healthy.load(Ordering::Relaxed))
             .field("circuit_breaker", &self.circuit_breaker)
-            .field("grpc_client", &"<RwLock>");
-        if let Some(rank) = self.dp_rank {
-            s.field("dp_rank", &rank);
-        }
-        if let Some(size) = self.dp_size {
-            s.field("dp_size", &size);
-        }
-        if let Some(ref base_url) = self.dp_base_url {
-            s.field("dp_base_url", base_url);
-        }
-        s.finish()
+            .field("grpc_client", &"<OnceCell>")
+            .finish()
     }
 }
 
@@ -626,41 +626,6 @@ impl Worker for BasicWorker {
 
     fn circuit_breaker(&self) -> &CircuitBreaker {
         &self.circuit_breaker
-    }
-
-    fn is_dp_aware(&self) -> bool {
-        self.dp_rank.is_some()
-    }
-
-    fn base_url(&self) -> &str {
-        self.dp_base_url.as_deref().unwrap_or(self.url())
-    }
-
-    fn dp_rank(&self) -> Option<usize> {
-        self.dp_rank
-    }
-
-    fn dp_size(&self) -> Option<usize> {
-        self.dp_size
-    }
-
-    async fn prepare_request(&self, mut req: serde_json::Value) -> WorkerResult<serde_json::Value> {
-        if let Some(rank) = self.dp_rank {
-            if let Some(map) = req.as_object_mut() {
-                map.insert("data_parallel_rank".to_string(), serde_json::json!(rank));
-                Ok(req)
-            } else {
-                Err(WorkerError::InvalidConfiguration {
-                    message: "Request must be a JSON object for DP-aware routing".to_string(),
-                })
-            }
-        } else {
-            Ok(req)
-        }
-    }
-
-    fn endpoint_url(&self, route: &str) -> String {
-        format!("{}{}", self.base_url(), route)
     }
 
     fn supports_model(&self, model_id: &str) -> bool {
@@ -1574,7 +1539,6 @@ mod tests {
         let metadata = WorkerMetadata {
             spec: WorkerSpec::new("http://test:8080"),
             health_endpoint: "/health".to_string(),
-            default_model_type: ModelType::LLM,
         };
 
         // Empty models list should accept any model
@@ -1597,7 +1561,6 @@ mod tests {
         let metadata = WorkerMetadata {
             spec,
             health_endpoint: "/health".to_string(),
-            default_model_type: ModelType::LLM,
         };
 
         // Find by primary ID

--- a/protocols/src/worker.rs
+++ b/protocols/src/worker.rs
@@ -412,6 +412,19 @@ pub struct WorkerSpec {
     #[serde(default, skip)]
     pub bootstrap_host: String,
 
+    /// Base URL without DP rank suffix (for DP-aware workers).
+    /// When set, `url` contains the rank-suffixed form (`{base}@{rank}`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dp_base_url: Option<String>,
+
+    /// Data-parallel rank (None = not DP-aware).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dp_rank: Option<usize>,
+
+    /// Total data-parallel group size (None = not DP-aware).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dp_size: Option<usize>,
+
     /// KV connector type (e.g. "MooncakeConnector", "NixlConnector").
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub kv_connector: Option<String>,
@@ -445,6 +458,9 @@ impl WorkerSpec {
             api_key: None,
             bootstrap_port: None,
             bootstrap_host: String::new(),
+            dp_base_url: None,
+            dp_rank: None,
+            dp_size: None,
             kv_connector: None,
             kv_role: None,
             health: HealthCheckConfig::default(),


### PR DESCRIPTION
## Summary

Moves the three data-parallel identity fields (`dp_rank`, `dp_size`, `dp_base_url`) from `BasicWorker` to `WorkerSpec` in the protocols crate, and removes the always-hardcoded `default_model_type` field from `WorkerMetadata`. Follows up on #434 which consolidated `DPAwareWorker` into `BasicWorker`.

Closes #435

## What changed

| File | Change |
|------|--------|
| `protocols/src/worker.rs` | Added `dp_base_url`, `dp_rank`, `dp_size` fields to `WorkerSpec` with `serde(default, skip_serializing_if)` for backwards compatibility |
| `model_gateway/src/core/worker.rs` | Replaced 6 hardcoded DP trait defaults with implementations reading from `self.metadata().spec`; removed 3 DP fields and 6 method overrides from `BasicWorker`; simplified `Debug` impl; removed `default_model_type` from `WorkerMetadata`, inlined `ModelType::LLM` in `supports_endpoint()` fallback; updated 2 test struct literals |
| `model_gateway/src/core/worker_builder.rs` | Removed 3 DP fields from builder struct and all 3 constructors; `dp_config()` now writes to `self.spec.*`; removed `default_model_type` from `build()`; removed unused `ModelType` import |
| `bindings/golang/src/policy.rs` | Removed `default_model_type` from `WorkerMetadata` construction and `ModelType` from imports |

## Why

After consolidating `DPAwareWorker` into `BasicWorker` (#434), the DP fields were still on `BasicWorker` alongside runtime state (atomic counters, circuit breakers). These are config/identity — set at construction, never mutated — and belong in `WorkerSpec`.

Benefits:
- DP info now visible in `GET /workers` API responses (via `WorkerInfo`'s `#[serde(flatten)]` on spec)
- Any future `Worker` implementor gets DP support for free via trait defaults
- ~30 fewer lines, 6 fewer method overrides
- `default_model_type` was `ModelType::LLM` at all 4 construction sites — inlined and removed

## How

- DP fields use `Option<T>` with `#[serde(default)]` so old clients that don't send these fields get `None` (backwards compatible)
- `Worker` trait defaults now read from `metadata().spec` instead of returning hardcoded `None`/`false`
- `BasicWorker` no longer overrides the 6 DP methods — trait defaults handle everything
- `BasicWorkerBuilder::dp_config()` writes directly to `self.spec.dp_*` fields

## Test plan

- `cargo check -p openai-protocol` — WorkerSpec compiles with new fields
- `cargo check --all-targets` — all downstream usage compiles
- `cargo test` — all tests pass (including 12+ DP-specific tests)
- `cargo clippy --all-targets -- -D warnings` — no warnings
- Verified `dp_rank`/`dp_size`/`dp_base_url` only appear in trait defaults and `WorkerSpec`, not on `BasicWorker` struct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * DP routing configuration moved into worker specifications: new optional fields let instances expose base URL, rank, and size for data-parallel routing.
  * Worker implementations now use trait-provided DP-aware defaults for URL, rank handling, and request preparation rather than per-worker transient fields.
  * Implicit default model-type in worker metadata removed, clarifying capability fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->