### PR TITLE
feat(core): add DetectBackendStep for vLLM HTTP support

### DIFF
--- a/model_gateway/src/core/steps/worker/local/detect_backend.rs
+++ b/model_gateway/src/core/steps/worker/local/detect_backend.rs
@@ -1,0 +1,308 @@
+//! Backend runtime detection step.
+//!
+//! Detects the runtime type (sglang, vllm, trtllm) for both HTTP and gRPC workers.
+//! - HTTP: probes `/v1/models` (owned_by field), falls back to unique endpoints.
+//! - gRPC: tries sglang → vllm → trtllm health checks sequentially.
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use reqwest::Client;
+use tracing::debug;
+use wfaas::{StepExecutor, StepResult, WorkflowContext, WorkflowError, WorkflowResult};
+
+use super::{
+    detect_connection::do_grpc_health_check, discover_metadata::ModelsResponse, strip_protocol,
+};
+use crate::core::{steps::workflow_data::LocalWorkerWorkflowData, ConnectionMode};
+
+// ─── gRPC backend detection ────────────────────────────────────────────────
+
+/// Detect gRPC backend by trying runtime-specific health checks sequentially.
+///
+/// If `runtime_hint` is provided (from explicit config), tries that first.
+/// Otherwise tries sglang → vllm → trtllm.
+async fn detect_grpc_backend(
+    url: &str,
+    timeout_secs: u64,
+    runtime_hint: Option<&str>,
+) -> Result<String, String> {
+    let grpc_url = if url.starts_with("grpc://") {
+        url.to_string()
+    } else {
+        format!("grpc://{}", strip_protocol(url))
+    };
+
+    // If we have a hint, try it first
+    if let Some(hint) = runtime_hint {
+        if do_grpc_health_check(&grpc_url, timeout_secs, hint)
+            .await
+            .is_ok()
+        {
+            return Ok(hint.to_string());
+        }
+    }
+
+    // Try each runtime sequentially (most common first), skipping the hint we already tried
+    for runtime in &["sglang", "vllm", "trtllm"] {
+        if Some(*runtime) == runtime_hint {
+            continue;
+        }
+        if do_grpc_health_check(&grpc_url, timeout_secs, runtime)
+            .await
+            .is_ok()
+        {
+            return Ok(runtime.to_string());
+        }
+    }
+
+    Err(format!(
+        "gRPC backend detection failed for {} (tried sglang, vllm, trtllm)",
+        url
+    ))
+}
+
+// ─── HTTP backend detection ────────────────────────────────────────────────
+
+/// Detect HTTP backend by checking `/v1/models` `owned_by` field.
+async fn detect_via_models_endpoint(
+    url: &str,
+    timeout_secs: u64,
+    client: &Client,
+    api_key: Option<&str>,
+) -> Result<String, String> {
+    let is_https = url.starts_with("https://");
+    let protocol = if is_https { "https" } else { "http" };
+    let clean_url = strip_protocol(url).trim_end_matches('/').to_string();
+    let models_url = format!("{}://{}/v1/models", protocol, clean_url);
+
+    let mut req = client
+        .get(&models_url)
+        .timeout(Duration::from_secs(timeout_secs));
+    if let Some(key) = api_key {
+        req = req.bearer_auth(key);
+    }
+
+    let response = req
+        .send()
+        .await
+        .map_err(|e| format!("Failed to reach {}: {}", models_url, e))?;
+
+    if !response.status().is_success() {
+        return Err(format!(
+            "/v1/models returned status {} from {}",
+            response.status(),
+            models_url
+        ));
+    }
+
+    let models: ModelsResponse = response
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse /v1/models response: {}", e))?;
+
+    let first_model = models
+        .data
+        .first()
+        .ok_or_else(|| format!("/v1/models returned empty data array from {}", models_url))?;
+
+    match first_model.owned_by.as_deref() {
+        Some("sglang") => Ok("sglang".to_string()),
+        Some("vllm") => Ok("vllm".to_string()),
+        other => Err(format!("Unrecognized owned_by value: {:?}", other)),
+    }
+}
+
+/// Probe vLLM's `/version` endpoint.
+async fn try_vllm_version(
+    url: &str,
+    timeout_secs: u64,
+    client: &Client,
+    api_key: Option<&str>,
+) -> Result<(), String> {
+    let is_https = url.starts_with("https://");
+    let protocol = if is_https { "https" } else { "http" };
+    let clean_url = strip_protocol(url).trim_end_matches('/').to_string();
+    let version_url = format!("{}://{}/version", protocol, clean_url);
+
+    let mut req = client
+        .get(&version_url)
+        .timeout(Duration::from_secs(timeout_secs));
+    if let Some(key) = api_key {
+        req = req.bearer_auth(key);
+    }
+
+    let response = req
+        .send()
+        .await
+        .map_err(|e| format!("Failed to reach {}: {}", version_url, e))?;
+
+    if !response.status().is_success() {
+        return Err(format!("/version returned {}", response.status()));
+    }
+
+    Ok(())
+}
+
+/// Probe SGLang's `/server_info` endpoint.
+async fn try_sglang_server_info(
+    url: &str,
+    timeout_secs: u64,
+    client: &Client,
+    api_key: Option<&str>,
+) -> Result<(), String> {
+    let is_https = url.starts_with("https://");
+    let protocol = if is_https { "https" } else { "http" };
+    let clean_url = strip_protocol(url).trim_end_matches('/').to_string();
+    let info_url = format!("{}://{}/server_info", protocol, clean_url);
+
+    let mut req = client
+        .get(&info_url)
+        .timeout(Duration::from_secs(timeout_secs));
+    if let Some(key) = api_key {
+        req = req.bearer_auth(key);
+    }
+
+    let response = req
+        .send()
+        .await
+        .map_err(|e| format!("Failed to reach {}: {}", info_url, e))?;
+
+    if !response.status().is_success() {
+        return Err(format!("/server_info returned {}", response.status()));
+    }
+
+    Ok(())
+}
+
+/// Detect HTTP backend runtime type.
+///
+/// Strategy:
+/// 1. Primary: `GET /v1/models` → check `owned_by` field
+/// 2. Fallback: probe `/version` (vLLM) and `/server_info` (SGLang) in parallel
+async fn detect_http_backend(
+    url: &str,
+    timeout_secs: u64,
+    client: &Client,
+    api_key: Option<&str>,
+) -> Result<String, String> {
+    // Strategy 1: /v1/models owned_by
+    match detect_via_models_endpoint(url, timeout_secs, client, api_key).await {
+        Ok(runtime) => {
+            debug!("Detected HTTP backend via /v1/models owned_by: {}", runtime);
+            return Ok(runtime);
+        }
+        Err(e) => {
+            debug!(
+                "Could not detect backend via /v1/models, trying fallback: {}",
+                e
+            );
+        }
+    }
+
+    // Strategy 2: probe unique endpoints in parallel.
+    // /version is unique to vLLM. /server_info is NOT unique to SGLang — vLLM can
+    // also expose it. So /version takes priority: if it succeeds, it's definitely vLLM
+    // regardless of whether /server_info also succeeds. We only conclude SGLang if
+    // /server_info succeeds and /version does not.
+    let (vllm_result, sglang_result) = tokio::join!(
+        try_vllm_version(url, timeout_secs, client, api_key),
+        try_sglang_server_info(url, timeout_secs, client, api_key),
+    );
+
+    if vllm_result.is_ok() {
+        if sglang_result.is_ok() {
+            debug!(
+                "Both /version and /server_info succeeded for {}; /version is vLLM-specific, detecting as vllm",
+                url
+            );
+        }
+        return Ok("vllm".to_string());
+    }
+    if sglang_result.is_ok() {
+        debug!("Detected HTTP backend via /server_info (no /version): sglang");
+        return Ok("sglang".to_string());
+    }
+
+    Err(format!(
+        "Could not detect HTTP backend for {} (tried /v1/models, /version, /server_info)",
+        url
+    ))
+}
+
+// ─── Step implementation ───────────────────────────────────────────────────
+
+/// Step 2: Detect backend runtime type (sglang, vllm, trtllm).
+///
+/// Runs after `detect_connection_mode` and before `discover_metadata`.
+/// Sets `detected_runtime_type` in workflow data for all downstream steps.
+pub struct DetectBackendStep;
+
+#[async_trait]
+impl StepExecutor<LocalWorkerWorkflowData> for DetectBackendStep {
+    async fn execute(
+        &self,
+        context: &mut WorkflowContext<LocalWorkerWorkflowData>,
+    ) -> WorkflowResult<StepResult> {
+        let config = &context.data.config;
+        let connection_mode =
+            context.data.connection_mode.as_ref().ok_or_else(|| {
+                WorkflowError::ContextValueNotFound("connection_mode".to_string())
+            })?;
+        let app_context = context
+            .data
+            .app_context
+            .as_ref()
+            .ok_or_else(|| WorkflowError::ContextValueNotFound("app_context".to_string()))?;
+
+        let timeout = config
+            .health
+            .timeout_secs
+            .unwrap_or(app_context.router_config.health_check.timeout_secs);
+
+        // If runtime_type is explicitly configured (non-default), use it and skip detection
+        let config_runtime = config.runtime_type;
+        if config_runtime != crate::core::worker::RuntimeType::default() {
+            debug!(
+                "Using explicitly configured runtime type: {} for {}",
+                config_runtime, config.url
+            );
+            context.data.detected_runtime_type = Some(config_runtime.to_string());
+            return Ok(StepResult::Success);
+        }
+
+        debug!(
+            "Detecting backend for {} ({:?})",
+            config.url, connection_mode
+        );
+
+        let detected = match connection_mode {
+            ConnectionMode::Http => {
+                let client = &app_context.client;
+                detect_http_backend(&config.url, timeout, client, config.api_key.as_deref())
+                    .await
+                    .map_err(|e| WorkflowError::StepFailed {
+                        step_id: wfaas::StepId::new("detect_backend"),
+                        message: format!("HTTP backend detection failed for {}: {}", config.url, e),
+                    })?
+            }
+            ConnectionMode::Grpc => detect_grpc_backend(&config.url, timeout, None)
+                .await
+                .map_err(|e| WorkflowError::StepFailed {
+                    step_id: wfaas::StepId::new("detect_backend"),
+                    message: format!("gRPC backend detection failed for {}: {}", config.url, e),
+                })?,
+        };
+
+        debug!(
+            "Detected backend: {} for {} ({:?})",
+            detected, config.url, connection_mode
+        );
+        context.data.detected_runtime_type = Some(detected);
+        Ok(StepResult::Success)
+    }
+
+    fn is_retryable(&self, _error: &WorkflowError) -> bool {
+        true
+    }
+}

--- a/model_gateway/src/core/steps/worker/local/detect_connection.rs
+++ b/model_gateway/src/core/steps/worker/local/detect_connection.rs
@@ -1,4 +1,8 @@
 //! Connection mode detection step.
+//!
+//! Determines whether a worker communicates via HTTP or gRPC.
+//! This step only answers "HTTP or gRPC?" — backend runtime detection
+//! (sglang vs vllm vs trtllm) is handled by the separate DetectBackendStep.
 
 use std::time::Duration;
 
@@ -14,11 +18,7 @@ use crate::{
 };
 
 /// Try HTTP health check.
-async fn try_http_health_check(
-    url: &str,
-    timeout_secs: u64,
-    client: &Client,
-) -> Result<(), String> {
+async fn try_http_reachable(url: &str, timeout_secs: u64, client: &Client) -> Result<(), String> {
     let is_https = url.starts_with("https://");
     let protocol = if is_https { "https" } else { "http" };
     let clean_url = strip_protocol(url);
@@ -35,8 +35,10 @@ async fn try_http_health_check(
     Ok(())
 }
 
-/// Perform gRPC health check with runtime type.
-async fn do_grpc_health_check(
+/// Perform a single gRPC health check with a specific runtime type.
+///
+/// Shared with `detect_backend` which uses this for runtime identification.
+pub(super) async fn do_grpc_health_check(
     grpc_url: &str,
     timeout_secs: u64,
     runtime_type: &str,
@@ -56,49 +58,36 @@ async fn do_grpc_health_check(
     Ok(())
 }
 
-/// Try gRPC health check (tries SGLang first, then vLLM, then TensorRT-LLM if not specified).
-/// Returns the detected runtime type on success.
-async fn try_grpc_health_check(
-    url: &str,
-    timeout_secs: u64,
-    runtime_type: Option<&str>,
-) -> Result<String, String> {
+/// Check if gRPC is reachable by trying all known runtime types in parallel.
+///
+/// We don't care which runtime it is here — that's detect_backend's job.
+/// We just need to know: does this endpoint speak gRPC at all?
+async fn try_grpc_reachable(url: &str, timeout_secs: u64) -> Result<(), String> {
     let grpc_url = if url.starts_with("grpc://") {
         url.to_string()
     } else {
         format!("grpc://{}", strip_protocol(url))
     };
 
-    match runtime_type {
-        Some(runtime) => {
-            do_grpc_health_check(&grpc_url, timeout_secs, runtime).await?;
-            Ok(runtime.to_string())
-        }
-        None => {
-            // Try SGLang first, then vLLM, then TensorRT-LLM as fallback
-            if do_grpc_health_check(&grpc_url, timeout_secs, "sglang")
-                .await
-                .is_ok()
-            {
-                return Ok("sglang".to_string());
-            }
-            if do_grpc_health_check(&grpc_url, timeout_secs, "vllm")
-                .await
-                .is_ok()
-            {
-                return Ok("vllm".to_string());
-            }
-            do_grpc_health_check(&grpc_url, timeout_secs, "trtllm")
-                .await
-                .map_err(|e| {
-                    format!("gRPC failed (tried SGLang, vLLM, and TensorRT-LLM): {}", e)
-                })?;
-            Ok("trtllm".to_string())
-        }
+    let (sglang, vllm, trtllm) = tokio::join!(
+        do_grpc_health_check(&grpc_url, timeout_secs, "sglang"),
+        do_grpc_health_check(&grpc_url, timeout_secs, "vllm"),
+        do_grpc_health_check(&grpc_url, timeout_secs, "trtllm"),
+    );
+
+    match (sglang, vllm, trtllm) {
+        (Ok(_), _, _) | (_, Ok(_), _) | (_, _, Ok(_)) => Ok(()),
+        (Err(e1), Err(e2), Err(e3)) => Err(format!(
+            "gRPC not reachable (tried sglang, vllm, trtllm): sglang={}, vllm={}, trtllm={}",
+            e1, e2, e3,
+        )),
     }
 }
 
-/// Step 1: Detect connection mode by probing HTTP and gRPC.
+/// Step 1: Detect connection mode (HTTP vs gRPC).
+///
+/// Probes both protocols in parallel. HTTP takes priority if both succeed.
+/// Does NOT detect backend runtime — that's handled by DetectBackendStep.
 pub struct DetectConnectionModeStep;
 
 #[async_trait]
@@ -119,35 +108,26 @@ impl StepExecutor<LocalWorkerWorkflowData> for DetectConnectionModeStep {
             config.url, config.health.timeout_secs, config.max_connection_attempts
         );
 
-        // Try both protocols in parallel
         let url = config.url.clone();
-        // Use per-worker timeout override if set, otherwise fall back to router default
         let timeout = config
             .health
             .timeout_secs
             .unwrap_or(app_context.router_config.health_check.timeout_secs);
         let client = &app_context.client;
-        // Auto-detect runtime unless explicitly set to non-default
-        let runtime_type_str = config.runtime_type.to_string();
-        let runtime_hint = if runtime_type_str == "sglang" {
-            None
-        } else {
-            Some(runtime_type_str.as_str())
-        };
 
         let (http_result, grpc_result) = tokio::join!(
-            try_http_health_check(&url, timeout, client),
-            try_grpc_health_check(&url, timeout, runtime_hint)
+            try_http_reachable(&url, timeout, client),
+            try_grpc_reachable(&url, timeout)
         );
 
-        let (connection_mode, detected_runtime) = match (http_result, grpc_result) {
+        let connection_mode = match (http_result, grpc_result) {
             (Ok(_), _) => {
                 debug!("{} detected as HTTP", config.url);
-                (ConnectionMode::Http, None)
+                ConnectionMode::Http
             }
-            (_, Ok(runtime)) => {
-                debug!("{} detected as gRPC (runtime: {})", config.url, runtime);
-                (ConnectionMode::Grpc, Some(runtime))
+            (_, Ok(_)) => {
+                debug!("{} detected as gRPC", config.url);
+                ConnectionMode::Grpc
             }
             (Err(http_err), Err(grpc_err)) => {
                 return Err(WorkflowError::StepFailed {
@@ -161,10 +141,6 @@ impl StepExecutor<LocalWorkerWorkflowData> for DetectConnectionModeStep {
         };
 
         context.data.connection_mode = Some(connection_mode);
-        // Save detected runtime type from health check for use in metadata discovery
-        if let Some(runtime) = detected_runtime {
-            context.data.detected_runtime_type = Some(runtime);
-        }
         Ok(StepResult::Success)
     }
 

--- a/model_gateway/src/core/steps/worker/local/discover_metadata.rs
+++ b/model_gateway/src/core/steps/worker/local/discover_metadata.rs
@@ -43,6 +43,25 @@ pub struct ServerInfo {
     pub max_num_reqs: Option<usize>,
 }
 
+/// Single entry from the `/v1/models` endpoint response.
+///
+/// Shared struct used by both backend detection (`detect_backend`) and metadata
+/// discovery (`discover_metadata`). Fields are a superset: `owned_by` is used for
+/// runtime detection, while `id`, `root`, and `max_model_len` are used for metadata.
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct ModelsResponseEntry {
+    pub owned_by: Option<String>,
+    pub id: Option<String>,
+    pub root: Option<String>,
+    pub max_model_len: Option<usize>,
+}
+
+/// Response shape for the `/v1/models` endpoint (shared by sglang and vllm).
+#[derive(Debug, Clone, Deserialize)]
+pub(super) struct ModelsResponse {
+    pub data: Vec<ModelsResponseEntry>,
+}
+
 /// Model information returned from /model_info endpoint.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ModelInfo {
@@ -217,6 +236,97 @@ async fn fetch_grpc_metadata(
     Ok((labels, runtime_type.to_string()))
 }
 
+/// Fetch metadata from an SGLang HTTP worker using /server_info and /model_info.
+async fn fetch_sglang_http_metadata(url: &str, api_key: Option<&str>) -> HashMap<String, String> {
+    let mut labels = HashMap::new();
+
+    // Fetch from /server_info for server-related metadata
+    if let Ok(server_info) = get_server_info(url, api_key).await {
+        if let Some(model_path) = server_info.model_path.filter(|s| !s.is_empty()) {
+            labels.insert("model_path".to_string(), model_path);
+        }
+        if let Some(served_model_name) = server_info.served_model_name.filter(|s| !s.is_empty()) {
+            labels.insert("served_model_name".to_string(), served_model_name);
+        }
+        if let Some(tp_size) = server_info.tp_size {
+            labels.insert("tp_size".to_string(), tp_size.to_string());
+        }
+        if let Some(dp_size) = server_info.dp_size {
+            labels.insert("dp_size".to_string(), dp_size.to_string());
+        }
+        if let Some(load_balance_method) = server_info.load_balance_method {
+            labels.insert("load_balance_method".to_string(), load_balance_method);
+        }
+        if let Some(disaggregation_mode) = server_info.disaggregation_mode {
+            labels.insert("disaggregation_mode".to_string(), disaggregation_mode);
+        }
+    }
+
+    // Fetch from /model_info for model-related metadata
+    if let Ok(model_info) = get_model_info(url, api_key).await {
+        if let Some(model_type) = model_info.model_type.filter(|s| !s.is_empty()) {
+            labels.insert("model_type".to_string(), model_type);
+        }
+        if let Some(architectures) = model_info.architectures.filter(|a| !a.is_empty()) {
+            if let Ok(json_str) = serde_json::to_string(&architectures) {
+                labels.insert("architectures".to_string(), json_str);
+            }
+        }
+    }
+
+    labels
+}
+
+/// Fetch metadata from a vLLM HTTP worker using /v1/models.
+async fn fetch_vllm_http_metadata(url: &str, api_key: Option<&str>) -> HashMap<String, String> {
+    let mut labels = HashMap::new();
+
+    let is_https = url.starts_with("https://");
+    let protocol = if is_https { "https" } else { "http" };
+    let clean_url = strip_protocol(url).trim_end_matches('/').to_string();
+    let models_url = format!("{}://{}/v1/models", protocol, clean_url);
+
+    let mut req = HTTP_CLIENT.get(&models_url);
+    if let Some(key) = api_key {
+        req = req.bearer_auth(key);
+    }
+
+    let response = match req.send().await {
+        Ok(r) if r.status().is_success() => r,
+        Ok(r) => {
+            warn!("vLLM /v1/models returned status {}", r.status());
+            return labels;
+        }
+        Err(e) => {
+            warn!("Failed to fetch vLLM /v1/models: {}", e);
+            return labels;
+        }
+    };
+
+    match response.json::<ModelsResponse>().await {
+        Ok(models) => {
+            if let Some(model) = models.data.first() {
+                // vLLM uses `root` as the model path (equivalent to sglang's model_path)
+                if let Some(root) = model.root.as_deref().filter(|s| !s.is_empty()) {
+                    labels.insert("model_path".to_string(), root.to_string());
+                }
+                // vLLM uses `id` as the served model name
+                if let Some(id) = model.id.as_deref().filter(|s| !s.is_empty()) {
+                    labels.insert("served_model_name".to_string(), id.to_string());
+                }
+                if let Some(max_model_len) = model.max_model_len {
+                    labels.insert("max_model_len".to_string(), max_model_len.to_string());
+                }
+            }
+        }
+        Err(e) => {
+            warn!("Failed to parse vLLM /v1/models response: {}", e);
+        }
+    }
+
+    labels
+}
+
 /// Step 2a: Discover metadata from worker.
 pub struct DiscoverMetadataStep;
 
@@ -239,47 +349,24 @@ impl StepExecutor<LocalWorkerWorkflowData> for DiscoverMetadataStep {
 
         let (discovered_labels, detected_runtime) = match connection_mode {
             ConnectionMode::Http => {
-                let mut labels = HashMap::new();
+                let runtime = match context.data.detected_runtime_type.as_deref() {
+                    Some(rt) => rt,
+                    None => {
+                        warn!(
+                            "No detected_runtime_type for HTTP worker {}, falling back to sglang metadata",
+                            config.url
+                        );
+                        "sglang"
+                    }
+                };
+                debug!("Fetching HTTP metadata using runtime: {}", runtime);
 
-                // Fetch from /server_info for server-related metadata
-                if let Ok(server_info) =
-                    get_server_info(&config.url, config.api_key.as_deref()).await
-                {
-                    if let Some(model_path) = server_info.model_path.filter(|s| !s.is_empty()) {
-                        labels.insert("model_path".to_string(), model_path);
+                let labels = match runtime {
+                    "vllm" => {
+                        fetch_vllm_http_metadata(&config.url, config.api_key.as_deref()).await
                     }
-                    if let Some(served_model_name) =
-                        server_info.served_model_name.filter(|s| !s.is_empty())
-                    {
-                        labels.insert("served_model_name".to_string(), served_model_name);
-                    }
-                    if let Some(tp_size) = server_info.tp_size {
-                        labels.insert("tp_size".to_string(), tp_size.to_string());
-                    }
-                    if let Some(dp_size) = server_info.dp_size {
-                        labels.insert("dp_size".to_string(), dp_size.to_string());
-                    }
-                    if let Some(load_balance_method) = server_info.load_balance_method {
-                        labels.insert("load_balance_method".to_string(), load_balance_method);
-                    }
-                    if let Some(disaggregation_mode) = server_info.disaggregation_mode {
-                        labels.insert("disaggregation_mode".to_string(), disaggregation_mode);
-                    }
-                }
-
-                // Fetch from /model_info for model-related metadata
-                if let Ok(model_info) = get_model_info(&config.url, config.api_key.as_deref()).await
-                {
-                    if let Some(model_type) = model_info.model_type.filter(|s| !s.is_empty()) {
-                        labels.insert("model_type".to_string(), model_type);
-                    }
-                    if let Some(architectures) = model_info.architectures.filter(|a| !a.is_empty())
-                    {
-                        if let Ok(json_str) = serde_json::to_string(&architectures) {
-                            labels.insert("architectures".to_string(), json_str);
-                        }
-                    }
-                }
+                    _ => fetch_sglang_http_metadata(&config.url, config.api_key.as_deref()).await,
+                };
 
                 Ok((labels, None))
             }


### PR DESCRIPTION
## Summary

- Introduces a dedicated `DetectBackendStep` workflow step that auto-detects the backend runtime (sglang, vllm, trtllm) for both HTTP and gRPC workers
- Separates connection mode detection (HTTP vs gRPC) from backend runtime detection into distinct workflow steps with clear single responsibilities
- Enables vLLM HTTP mode support — previously all HTTP workers were hardcoded to `RuntimeType::Sglang`

## Design

New workflow DAG:
```
detect_connection_mode → detect_backend → discover_metadata → discover_dp_info → create_worker → ...
   (HTTP vs gRPC)       (sglang/vllm/trtllm)  (runtime-aware)   (runtime-aware)
```

**HTTP detection strategy:**
1. Primary: `GET /v1/models` → check `owned_by` field (`"sglang"` vs `"vllm"`)
2. Fallback: probe `/version` (vLLM-only) and `/server_info` (SGLang-only) in parallel
3. Fails fast if detection fails

**gRPC detection:** sequential sglang → vllm → trtllm health checks (moved out of `detect_connection.rs` into `detect_backend.rs`)

## Changes

| File | Change |
|------|--------|
| `detect_backend.rs` | **New.** Owns all runtime detection for both HTTP and gRPC |
| `detect_connection.rs` | Simplified to only determine HTTP vs gRPC. Consistent `try_http_reachable`/`try_grpc_reachable` naming. `do_grpc_health_check` made `pub(super)` for reuse |
| `create_worker.rs` | `determine_runtime_type()` uses `detected_runtime_type` uniformly instead of hardcoding sglang for HTTP |
| `discover_metadata.rs` | Runtime-aware HTTP metadata: `fetch_sglang_http_metadata` (via `/server_info` + `/model_info`) and `fetch_vllm_http_metadata` (via `/v1/models`) |
| `discover_dp.rs` | Skips DP discovery for non-sglang HTTP workers (vLLM doesn't expose `dp_size` via `/server_info`) |
| `mod.rs` | Wires `DetectBackendStep` into workflow DAG between `detect_connection_mode` and `discover_metadata` |

## Test plan

- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] Tested against live SGLang server (127.0.0.1:30001) — auto-detected as `sglang` with full metadata
- [x] Tested against live vLLM server (0.0.0.0:8000) — auto-detected as `vllm` with metadata from `/v1/models`
- [x] Both workers registered, healthy, and routing works through the gateway
- [ ] Verify explicit `runtime_type` config override skips auto-detection
- [ ] Verify gRPC workers still register correctly (no regression)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic backend runtime detection for local workers (HTTP and gRPC).
  * New DP info discovery step with selective execution based on runtime.

* **Improvements**
  * Runtime-aware metadata fetching for more accurate model info.
  * Connection-mode detection now separates HTTP vs gRPC checks and prefers HTTP when both are reachable.

* **Bug Fixes**
  * Runtime selection now uses detected runtime (when available) and otherwise falls back to configured runtime, removing prior implicit defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->