### PR TITLE
pass through backend args

### DIFF
--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "setproctitle",
     "grpcio",
     "grpcio-health-checking",
+    "PyYAML",
 ]
 
 [project.optional-dependencies]

--- a/bindings/python/src/smg/serve.py
+++ b/bindings/python/src/smg/serve.py
@@ -31,7 +31,9 @@ class WorkerLauncher(ABC):
     """Abstract base class for backend worker launchers."""
 
     @abstractmethod
-    def build_command(self, args: argparse.Namespace, backend_args: list[str], host: str, port: int) -> list[str]:
+    def build_command(
+        self, args: argparse.Namespace, backend_args: list[str], host: str, port: int
+    ) -> list[str]:
         """Build the CLI command list to launch a worker."""
         ...
 
@@ -77,12 +79,7 @@ class WorkerLauncher(ABC):
         return filtered_backend_args
 
     def launch(
-        self,
-        args: argparse.Namespace,
-        backend_args: list[str],
-        host: str,
-        port: int,
-        env: dict
+        self, args: argparse.Namespace, backend_args: list[str], host: str, port: int, env: dict
     ) -> subprocess.Popen:
         """Launch the worker subprocess."""
         cmd = self.build_command(args, backend_args, host, port)

--- a/bindings/python/tests/test_serve.py
+++ b/bindings/python/tests/test_serve.py
@@ -583,6 +583,7 @@ class TestHttpHealthCheck:
         with patch("urllib.request.urlopen", return_value=mock_resp):
             assert _http_health_check("http://localhost:31000/health", 5.0) is False
 
+
 class TestGrpcHealthCheck:
     """Test _grpc_health_check with mocked grpc and health stub."""
 


### PR DESCRIPTION
## Description

### Problem

<!-- What problem is this PR trying to solve? -->

### Solution

<!-- How does this PR solve the problem? -->

## Changes

<!-- - Describe your changes here. -->

## Test Plan

<!-- Provide a thorough reproducible test showing before and after behavior. -->

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Default backend can be set via SMG_DEFAULT_BACKEND.
  * Backend-specific args (e.g., --config, --model, tp-size) can be passed through to backends.

* **Improvements**
  * Backend args consistently propagate through serve and launcher flow.
  * TensorRT-LLM tensor-parallel size now reads config files with precedence and warns on failures.
  * Worker launch logs commands, uses unbuffered I/O, and streams stdout/stderr separately.
* **Tests**
  * Health-check and backend-args flows are covered by new tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->