### PR TITLE
feat(version): add startup banner with braille art shepherd motif

### DIFF
--- a/.github/workflows/nightly-benchmark.yml
+++ b/.github/workflows/nightly-benchmark.yml
@@ -245,7 +245,7 @@ jobs:
           pip uninstall -y smg || true
           pip install wheel/*.whl
           bash scripts/ci_install_e2e_deps.sh ${{ matrix.variant.extra_deps }}
-      
+
       - name: Pull genai-bench image
         if: steps.filter.outputs.skip != 'true'
         run: docker pull ${{ env.GENAI_BENCH_IMAGE }}

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1029,6 +1029,12 @@ fn get_verbose_version_string() -> String {
     version::get_verbose_version_string()
 }
 
+/// Print the startup banner with braille art and key configuration info.
+#[pyfunction]
+fn print_banner(host: &str, port: u16, mode: &str) {
+    version::print_banner(host, port, mode);
+}
+
 /// Get the list of available tool call parsers from the Rust factory.
 #[pyfunction]
 fn get_available_tool_call_parsers() -> Vec<String> {
@@ -1056,6 +1062,7 @@ fn smg_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<Router>()?;
     m.add_function(wrap_pyfunction!(get_version_string, m)?)?;
     m.add_function(wrap_pyfunction!(get_verbose_version_string, m)?)?;
+    m.add_function(wrap_pyfunction!(print_banner, m)?)?;
     m.add_function(wrap_pyfunction!(get_available_tool_call_parsers, m)?)?;
     Ok(())
 }

--- a/bindings/python/src/smg/launch_router.py
+++ b/bindings/python/src/smg/launch_router.py
@@ -5,6 +5,7 @@ import sys
 import setproctitle
 
 from smg.router_args import RouterArgs
+from smg.smg_rs import print_banner
 
 logger = logging.getLogger("router")
 
@@ -37,6 +38,16 @@ def launch_router(args: argparse.Namespace | RouterArgs) -> None:
         if Router is None:
             raise RuntimeError("Rust Router is not installed")
         router_args._validate_router_args()
+
+        # Determine mode for banner
+        if getattr(router_args, "pd_disaggregation", False):
+            mode = "PD Disaggregated"
+        elif getattr(router_args, "enable_igw", False):
+            mode = "IGW"
+        else:
+            mode = "Regular"
+        print_banner(router_args.host, router_args.port, mode)
+
         router = Router.from_args(router_args)
         router.start()
 

--- a/grpc_client/python/setup.py
+++ b/grpc_client/python/setup.py
@@ -2,6 +2,7 @@
 Custom setup.py to generate protobuf stubs at build time.
 The generated files are NOT committed to git — they're created fresh during pip install.
 """
+
 from pathlib import Path
 
 from setuptools import setup
@@ -16,9 +17,7 @@ def compile_grpc_protos():
     output_dir = package_dir / "smg_grpc_proto" / "generated"
 
     output_dir.mkdir(parents=True, exist_ok=True)
-    (output_dir / "__init__.py").write_text(
-        '"""Auto-generated protobuf stubs. Do not edit."""\n'
-    )
+    (output_dir / "__init__.py").write_text('"""Auto-generated protobuf stubs. Do not edit."""\n')
 
     proto_files = list(proto_dir.glob("*.proto"))
     if not proto_files:
@@ -26,10 +25,10 @@ def compile_grpc_protos():
 
     # Use grpc_tools.protoc Python API (same approach as vLLM)
     try:
-        from grpc_tools import protoc
-
         # Include well-known types (google/protobuf/*.proto) shipped with grpc_tools
         import grpc_tools
+        from grpc_tools import protoc
+
         well_known_protos = Path(grpc_tools.__file__).parent / "_proto"
 
         args = [
@@ -48,9 +47,7 @@ def compile_grpc_protos():
             raise RuntimeError(f"protoc returned non-zero exit code: {result}")
 
     except ImportError:
-        raise RuntimeError(
-            "grpcio-tools not installed. Install with: pip install grpcio-tools"
-        )
+        raise RuntimeError("grpcio-tools not installed. Install with: pip install grpcio-tools")
 
     # Fix imports in generated files (grpcio-tools generates absolute imports)
     # Also add mypy ignore-errors comment for generated code
@@ -62,9 +59,7 @@ def compile_grpc_protos():
         # Fix imports to be relative
         for proto_file in proto_files:
             module_name = proto_file.stem + "_pb2"
-            content = content.replace(
-                f"import {module_name}", f"from . import {module_name}"
-            )
+            content = content.replace(f"import {module_name}", f"from . import {module_name}")
 
         # Add mypy ignore-errors if not already present
         if not content.startswith("# mypy:"):
@@ -78,9 +73,7 @@ def compile_grpc_protos():
         if not content.startswith("# mypy:"):
             pyi_file.write_text(mypy_header + content)
 
-    generated_count = len(list(output_dir.glob("*.py"))) + len(
-        list(output_dir.glob("*.pyi"))
-    )
+    generated_count = len(list(output_dir.glob("*.py"))) + len(list(output_dir.glob("*.pyi")))
     print(f"Generated {generated_count} files (including type stubs)")
 
 

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -1215,8 +1215,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         cli_args.enable_igw = true;
     }
 
-    println!("Shepherd Model Gateway starting...");
-    println!("Host: {}:{}", cli_args.host, cli_args.port);
     let mode_str = if cli_args.enable_igw {
         "IGW (Inference Gateway)".to_string()
     } else if matches!(cli_args.backend, Some(Backend::Openai)) {
@@ -1230,7 +1228,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     } else {
         "Regular".to_string()
     };
-    println!("Mode: {}", mode_str);
+
+    version::print_banner(&cli_args.host, cli_args.port, &mode_str);
 
     if !cli_args.enable_igw {
         println!("Policy: {}", cli_args.policy);

--- a/model_gateway/src/version.rs
+++ b/model_gateway/src/version.rs
@@ -55,3 +55,56 @@ Compiler:\n\
 pub fn get_version() -> &'static str {
     VERSION
 }
+
+/// Print the startup banner with braille art and key configuration info.
+///
+/// Layout inspired by vLLM's startup banner — art on the left,
+/// useful context on the right. Shepherd with sheep motif.
+pub fn print_banner(host: &str, port: u16, mode: &str) {
+    let info: [(&str, String); 4] = [
+        ("", PROJECT_NAME.to_string()),
+        ("version", VERSION.to_string()),
+        ("listening", format!("{}:{}", host, port)),
+        ("mode", mode.to_string()),
+    ];
+
+    let art: [&str; 15] = [
+        "⠀⠀⠀⠀⠀⠀⠀⠀⠀⣀⣤⣤⣴⠟⠛⢶⣤⣤⣄⠀⠀⠀⠀⠀⠀⠀⠀⠀",
+        "⠀⠀⠀⠀⠀⠀⠀⠀⣰⡏⠀⠀⠁⠀⠀⠈⠁⠀⢹⣇⠀⠀⠀⠀⠀⠀⠀⠀",
+        "⠀⠀⠀⠀⠀⠀⠀⡾⠋⠉⠀⠀⠀⠀⠀⠀⠀⠀⠈⠙⢳⡄⠀⠀⠀⠀⠀⠀",
+        "⢀⡾⠛⠛⠀⢶⣤⣿⡄⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢠⣾⣧⡶⠞⠛⠛⢳⡄",
+        "⠈⣷⡀⠀⠀⠀⠈⣟⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢹⡇⠀⠀⠀⠀⣼⠃",
+        "⠀⠈⠻⣦⣤⣤⣤⡿⢷⡦⠀⠀⠀⠀⠀⠀⠀⠀⢰⡶⢿⣤⣤⣤⣴⠾⠃⠀",
+        "⠀⢠⡾⠋⠁⢸⠏⠀⠈⢷⣤⣤⣦⠀⠀⣰⣤⣠⡼⠃⠀⠘⣧⠈⠉⢻⡆⠀",
+        "⠀⢈⣷⡄⠀⣿⠀⠀⠀⣴⡄⠀⠙⠛⠛⠋⠀⢠⣦⡄⠀⠀⣿⠀⢠⣾⡃⠀",
+        "⠀⣾⠁⠀⠀⣿⠀⠀⠀⠉⠁⠀⠀⠀⠀⠀⠀⠀⠉⠀⠀⠀⣼⠀⠀⠈⣿⠀",
+        "⠀⢘⣿⠆⠀⢻⡄⠀⠀⠀⢀⠀⠈⣳⣾⠃⠀⡀⠀⠀⠀⢀⣿⠀⠰⢾⡋⠀",
+        "⠀⠘⣧⣀⡀⠈⣷⡀⠀⠀⠈⠛⠛⠋⠉⠛⠛⠉⠀⠀⢀⣼⠃⢀⣀⣸⠇⠀",
+        "⠀⠀⠈⣿⠃⠀⠈⠻⣄⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⡀⠾⠁⠀⠈⣿⠁⠀⠀",
+        "⠀⠀⠀⠘⠷⢶⡖⠀⠈⠛⠶⣤⣤⣤⣤⣤⣤⠶⠛⠁⠀⢰⡦⠾⠋⠀⠀⠀",
+        "⠀⠀⠀⠀⠀⠘⢷⣤⣴⡆⠀⠀⡀⠀⠀⢀⠀⠀⢠⣦⣤⡾⠃⠀⠀⠀⠀⠀",
+        "⠀⠀⠀⠀⠀⠀⠀⠀⠈⠻⠶⠾⢻⣤⣤⡾⠷⠶⠞⠁⠀⠀⠀⠀⠀⠀⠀⠀",
+    ];
+
+    // Info appears to the right of lines 11-14 (lower body area)
+    let info_start: usize = 11;
+    let art_width: usize = art.iter().map(|l| l.chars().count()).max().unwrap_or(0);
+    let pad = 3;
+
+    for (i, line) in art.iter().enumerate() {
+        let idx = i.wrapping_sub(info_start);
+        if idx < info.len() {
+            let chars = line.chars().count();
+            let padding = " ".repeat(art_width - chars + pad);
+            let (label, value) = &info[idx];
+            if label.is_empty() {
+                println!("{}{}{}", line, padding, value);
+            } else {
+                println!("{}{}{}  {}", line, padding, label, value);
+            }
+        } else {
+            println!("{}", line);
+        }
+    }
+    println!();
+}


### PR DESCRIPTION
## Summary
- Add a startup banner with braille art shepherd-with-sheep motif, inspired by vLLM's ASCII art banner
- Display project name, version, listen address, and mode to the right of the art
- Expose `print_banner` to the Python binding so the banner appears across all entry points (`smg launch`, `smg server`, `smg serve`)

## Sample output

```
⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣠⣴⡶⠤⣤⡀
⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣠⣶⢟⣤⡀⡤⢄⣿⠲⣄⡀
⠀⠀⠀⠀⠀⠀⠀⠀⢀⡶⠊⠁⣿⢸⣻⡇⢿⣻⢿⡆⠀⠉⡇
⠀⠀⠀⠀⠀⠀⠀⠀⠈⠧⣄⡼⢹⠀⠀⠀⠀⠀⢸⡝⠒⠚⠁
⠀⠀⠀⠀⣠⠴⠶⠖⠲⠴⠦⠤⣴⠧⣄⠠⡄⢀⣤⣯
⣀⣀⡴⠋⠁⠀⠀⠀⠀⠀⠀⠈⠣⣴⢿⣿⣿⠉⣵⢿⠦⡀
⠻⢶⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣸⠎⠛⠛⠀⢯⣿⣻⠁
⠀⠈⢧⢀⠀⠀⠀⡀⠀⢀⣠⣀⡴⠃            smg
⠀⠀⠈⢹⢻⢿⠚⠓⢺⡏⡟⡏              version  1.0.1
⠀⠀⠀⢸⠈⢯⣷⠀⣸⠀⣧⡱⣄             listening  0.0.0.0:30000
⠀⠀⠀⠈⠉⠋⠁⠀⠈⠀⠀⠋⠃             mode  Regular
```

## Changes
- `model_gateway/src/version.rs`: add `print_banner()` with 11-line braille shepherd art and right-aligned info
- `model_gateway/src/main.rs`: replace plain-text startup log lines with `print_banner()` call
- `bindings/python/src/lib.rs`: expose `print_banner` as a pyfunction in the `smg_rs` module
- `bindings/python/src/smg/launch_router.py`: call `print_banner` before `router.start()`, deriving mode from router args

## Test plan
- [x] `cargo check -p smg` compiles
- [x] `cargo check -p smg-python` compiles
- [x] Banner preview renders correctly with art + right-aligned info

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Startup now shows a formatted banner with project name, version, listening address, and operational mode (displayed for both gateway and router).
* **Style**
  * Minor formatting and consolidation changes in packaging/tooling scripts for readability.
* **Chores**
  * Non-functional whitespace/formatting tweak in the nightly workflow file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->