### PR TITLE
fix(python): lower minimum Python version from 3.12 to 3.9

### DIFF
--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
     {name = "Chang Su", email = "mckvtl@gmail.com"},
     {name = "Keyang Ru", email = "rukeyang@gmail.com"}
 ]
-requires-python = ">=3.12"
+requires-python = ">=3.9"
 readme = "../../README.md"
 license = { text = "Apache-2.0" }
 classifiers = [

--- a/bindings/python/src/smg/cli.py
+++ b/bindings/python/src/smg/cli.py
@@ -10,6 +10,8 @@ Usage:
     smg --help                 # Show help
 """
 
+from __future__ import annotations
+
 import argparse
 import os
 import sys

--- a/bindings/python/src/smg/launch_router.py
+++ b/bindings/python/src/smg/launch_router.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import logging
 import sys

--- a/bindings/python/src/smg/launch_server.py
+++ b/bindings/python/src/smg/launch_server.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import asyncio
 import copy

--- a/bindings/python/src/smg/router.py
+++ b/bindings/python/src/smg/router.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from smg.router_args import RouterArgs
 from smg.smg_rs import (
     BackendType,
@@ -236,7 +238,7 @@ class Router:
         self._router = router
 
     @staticmethod
-    def from_args(args: RouterArgs) -> "Router":
+    def from_args(args: RouterArgs) -> Router:
         """Create a router from a RouterArgs instance."""
 
         args_dict = vars(args)

--- a/bindings/python/src/smg/router_args.py
+++ b/bindings/python/src/smg/router_args.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import dataclasses
 import logging
@@ -952,9 +954,7 @@ class RouterArgs:
         )
 
     @classmethod
-    def from_cli_args(
-        cls, args: argparse.Namespace, use_router_prefix: bool = False
-    ) -> "RouterArgs":
+    def from_cli_args(cls, args: argparse.Namespace, use_router_prefix: bool = False) -> RouterArgs:
         """
         Create RouterArgs instance from parsed command line arguments.
 

--- a/bindings/python/src/smg/serve.py
+++ b/bindings/python/src/smg/serve.py
@@ -4,6 +4,8 @@ Serve command: two-pass CLI argument parsing with lazy backend import.
 Launches backend worker(s) + gateway router via a single `smg serve` command.
 """
 
+from __future__ import annotations
+
 import argparse
 import atexit
 import logging


### PR DESCRIPTION
## Summary
- Lower `requires-python` from `>=3.12` to `>=3.9` so the wheel installs on Python 3.9+
- The Rust extension already targets `abi3-py38`, so no native code changes needed

## What changed
- `bindings/python/pyproject.toml`: `requires-python = ">=3.9"`
- Added `from __future__ import annotations` to all Python modules that use PEP 604 union syntax (`X | Y`), making type hints lazy strings so they work on 3.9+:
  `cli.py`, `router.py`, `router_args.py`, `serve.py`, `launch_router.py`, `launch_server.py`

## Test plan
- [x] All modified files pass `py_compile` on Python 3.9.6
- [x] `pre-commit run --all-files` passes (ruff, ruff-format, clippy, rustfmt)
- [x] `cargo check -p smg-python` compiles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded Python version compatibility to support Python 3.9 and above, broadening accessibility across different Python environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->