### PR TITLE
[Tokenizer][gRPC] Add GetTokenizer Proto and Tokenizer Bundle Streaming

### DIFF
--- a/grpc_client/Cargo.toml
+++ b/grpc_client/Cargo.toml
@@ -22,6 +22,7 @@ serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 tracing.workspace = true
+llm-tokenizer.workspace = true
 
 # gRPC dependencies
 tonic.workspace = true

--- a/grpc_client/proto/sglang_scheduler.proto
+++ b/grpc_client/proto/sglang_scheduler.proto
@@ -29,6 +29,9 @@ service SglangScheduler {
   // Get comprehensive load metrics
   rpc GetLoads(GetLoadsRequest) returns (GetLoadsResponse);
 
+  // Get tokenizer artifacts for remote construction
+  rpc GetTokenizer(GetTokenizerRequest) returns (stream GetTokenizerChunk);
+
 }
 
 // =====================
@@ -563,4 +566,38 @@ message AggregateMetrics {
   double avg_token_usage = 4;
   double avg_throughput = 5;
   double avg_utilization = 6;
+}
+
+
+// =====================
+// Tokenizer
+// =====================
+
+message GetTokenizerRequest {}
+
+message GetTokenizerChunk {
+  oneof chunk {
+    TokenizerMetadata metadata = 1;
+    TokenizerFileChunk file_chunk = 2;
+  }
+}
+
+message TokenizerMetadata {
+  string model_identifier = 1;
+  string fingerprint = 2;
+  repeated TokenizerFileDescriptor files = 3;
+  string bundle_format = 4;
+}
+
+message TokenizerFileDescriptor {
+  string file_name = 1;
+  string mime_type = 2;
+  bool optional = 3;
+}
+
+message TokenizerFileChunk {
+  string file_name = 1;
+  bytes data = 2;
+  uint32 chunk_index = 3;
+  bool is_last_chunk = 4;
 }

--- a/grpc_client/proto/trtllm_service.proto
+++ b/grpc_client/proto/trtllm_service.proto
@@ -46,6 +46,9 @@ service TrtllmService {
 
   // Get server information (version, parallelism, etc.)
   rpc GetServerInfo(GetServerInfoRequest) returns (GetServerInfoResponse);
+
+  // Get tokenizer artifacts for remote construction
+  rpc GetTokenizer(GetTokenizerRequest) returns (stream GetTokenizerChunk);
 }
 
 // ============================================================================
@@ -508,4 +511,37 @@ message GetServerInfoResponse {
   int32 pipeline_parallel_size = 4; // PP size
   int32 context_parallel_size = 5;  // CP size
   int32 world_size = 6;             // Total world size
+}
+
+// ============================================================================
+// Tokenizer
+// ============================================================================
+
+message GetTokenizerRequest {}
+
+message GetTokenizerChunk {
+  oneof chunk {
+    TokenizerMetadata metadata = 1;
+    TokenizerFileChunk file_chunk = 2;
+  }
+}
+
+message TokenizerMetadata {
+  string model_identifier = 1;
+  string fingerprint = 2;
+  repeated TokenizerFileDescriptor files = 3;
+  string bundle_format = 4;
+}
+
+message TokenizerFileDescriptor {
+  string file_name = 1;
+  string mime_type = 2;
+  bool optional = 3;
+}
+
+message TokenizerFileChunk {
+  string file_name = 1;
+  bytes data = 2;
+  uint32 chunk_index = 3;
+  bool is_last_chunk = 4;
 }

--- a/grpc_client/proto/vllm_engine.proto
+++ b/grpc_client/proto/vllm_engine.proto
@@ -23,6 +23,9 @@ service VllmEngine {
 
   // Get server information
   rpc GetServerInfo(GetServerInfoRequest) returns (GetServerInfoResponse);
+
+  // Get tokenizer artifacts for remote construction
+  rpc GetTokenizer(GetTokenizerRequest) returns (stream GetTokenizerChunk);
 }
 
 // =====================
@@ -244,4 +247,37 @@ message GetServerInfoResponse {
   // KV transfer config (for PD disaggregation)
   string kv_connector = 6;  // "MooncakeConnector", "NixlConnector", "" if not configured
   string kv_role = 7;       // "kv_producer", "kv_consumer", "kv_both", "" if not configured
+}
+
+// =====================
+// Tokenizer
+// =====================
+
+message GetTokenizerRequest {}
+
+message GetTokenizerChunk {
+  oneof chunk {
+    TokenizerMetadata metadata = 1;
+    TokenizerFileChunk file_chunk = 2;
+  }
+}
+
+message TokenizerMetadata {
+  string model_identifier = 1;
+  string fingerprint = 2;
+  repeated TokenizerFileDescriptor files = 3;
+  string bundle_format = 4;
+}
+
+message TokenizerFileDescriptor {
+  string file_name = 1;
+  string mime_type = 2;
+  bool optional = 3;
+}
+
+message TokenizerFileChunk {
+  string file_name = 1;
+  bytes data = 2;
+  uint32 chunk_index = 3;
+  bool is_last_chunk = 4;
 }

--- a/grpc_client/src/lib.rs
+++ b/grpc_client/src/lib.rs
@@ -44,3 +44,73 @@ impl TraceInjector for NoopTraceInjector {
 
 /// Type alias for a boxed trace injector.
 pub type BoxedTraceInjector = Arc<dyn TraceInjector>;
+
+/// Generate a `decode_tokenizer_chunk` function for each backend's proto module.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! impl_decode_tokenizer_chunk {
+    () => {
+        fn decode_tokenizer_chunk(
+            chunk: proto::GetTokenizerChunk,
+        ) -> Result<TokenizerChunk, String> {
+            match chunk.chunk {
+                Some(proto::get_tokenizer_chunk::Chunk::Metadata(meta)) => {
+                    Ok(TokenizerChunk::Metadata(TokenizerMetadata {
+                        model_identifier: meta.model_identifier,
+                        fingerprint: meta.fingerprint,
+                        files: meta
+                            .files
+                            .into_iter()
+                            .map(|file| TokenizerFileDescriptor {
+                                file_name: file.file_name,
+                                mime_type: file.mime_type,
+                                optional: file.optional,
+                            })
+                            .collect(),
+                        bundle_format: meta.bundle_format,
+                    }))
+                }
+                Some(proto::get_tokenizer_chunk::Chunk::FileChunk(file_chunk)) => {
+                    Ok(TokenizerChunk::FileChunk(TokenizerFileChunk {
+                        data: file_chunk.data,
+                        chunk_index: file_chunk.chunk_index,
+                        is_last_chunk: file_chunk.is_last_chunk,
+                    }))
+                }
+                None => Err("Protocol error: empty tokenizer chunk".to_string()),
+            }
+        }
+    };
+}
+
+/// Generate a `get_tokenizer` method for each backend client.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! impl_get_tokenizer {
+    () => {
+        /// Get tokenizer bundle from the backend.
+        ///
+        /// Streams a tokenizer bundle (metadata + compressed file chunks)
+        /// from the backend and validates the streaming output.
+        /// The stream is bounded by a 120s timeout to prevent indefinite
+        /// blocking on slow or stalled backends.
+        pub async fn get_tokenizer(
+            &self,
+        ) -> Result<TokenizerBundle, Box<dyn std::error::Error + Send + Sync>> {
+            tracing::debug!("Requesting tokenizer from backend");
+            let request = tonic::Request::new(proto::GetTokenizerRequest {});
+            let mut client = self.client.clone();
+            let mut stream = client.get_tokenizer(request).await?.into_inner();
+            let timeout = std::time::Duration::from_secs(120);
+            tokio::time::timeout(
+                timeout,
+                collect_tokenizer_bundle(&mut stream, decode_tokenizer_chunk),
+            )
+            .await
+            .map_err(|_| -> Box<dyn std::error::Error + Send + Sync> {
+                "get_tokenizer stream timed out after 120s".into()
+            })?
+            .map_err(|e| e.into())
+        }
+    };
+}

--- a/grpc_client/src/sglang_scheduler.rs
+++ b/grpc_client/src/sglang_scheduler.rs
@@ -8,6 +8,11 @@ use std::{
     time::Duration,
 };
 
+/// Tokenizer bundle downloaded from backend
+use llm_tokenizer::bundle::{
+    collect_tokenizer_bundle, TokenizerBundle, TokenizerChunk, TokenizerFileChunk,
+    TokenizerFileDescriptor, TokenizerMetadata,
+};
 use openai_protocol::{
     chat::ChatCompletionRequest,
     common::{ResponseFormat, StringOrArray, ToolChoice, ToolChoiceValue},
@@ -115,6 +120,8 @@ impl futures::Stream for AbortOnDropStream {
         Pin::new(&mut self.inner).poll_next(cx)
     }
 }
+
+crate::impl_decode_tokenizer_chunk!();
 
 /// gRPC client for SGLang scheduler
 #[derive(Clone)]
@@ -280,6 +287,8 @@ impl SglangSchedulerClient {
         debug!("Server info response received");
         Ok(response.into_inner())
     }
+
+    crate::impl_get_tokenizer!();
 
     /// Build a single SGLang EmbedRequest
     pub fn build_embed_request(

--- a/grpc_client/src/trtllm_service.rs
+++ b/grpc_client/src/trtllm_service.rs
@@ -8,6 +8,10 @@ use std::{
     time::Duration,
 };
 
+use llm_tokenizer::bundle::{
+    collect_tokenizer_bundle, TokenizerBundle, TokenizerChunk, TokenizerFileChunk,
+    TokenizerFileDescriptor, TokenizerMetadata,
+};
 use openai_protocol::{
     chat::ChatCompletionRequest, common::ResponseFormat, generate::GenerateRequest,
     responses::ResponsesRequest, sampling_params::SamplingParams as GenerateSamplingParams,
@@ -106,6 +110,8 @@ impl futures::Stream for AbortOnDropStream {
         Pin::new(&mut self.inner).poll_next(cx)
     }
 }
+
+crate::impl_decode_tokenizer_chunk!();
 
 /// gRPC client for TensorRT-LLM service
 #[derive(Clone)]
@@ -248,6 +254,8 @@ impl TrtllmServiceClient {
         debug!("Server info response received");
         Ok(response.into_inner())
     }
+
+    crate::impl_get_tokenizer!();
 
     /// Build a TensorRT-LLM GenerateRequest from OpenAI ChatCompletionRequest
     pub fn build_generate_request_from_chat(

--- a/grpc_client/src/vllm_engine.rs
+++ b/grpc_client/src/vllm_engine.rs
@@ -8,6 +8,10 @@ use std::{
     time::Duration,
 };
 
+use llm_tokenizer::bundle::{
+    collect_tokenizer_bundle, TokenizerBundle, TokenizerChunk, TokenizerFileChunk,
+    TokenizerFileDescriptor, TokenizerMetadata,
+};
 use openai_protocol::{
     chat::ChatCompletionRequest,
     common::{ResponseFormat, StringOrArray, ToolChoice, ToolChoiceValue},
@@ -115,6 +119,8 @@ impl futures::Stream for AbortOnDropStream {
         Pin::new(&mut self.inner).poll_next(cx)
     }
 }
+
+crate::impl_decode_tokenizer_chunk!();
 
 /// gRPC client for vLLM scheduler
 #[derive(Clone)]
@@ -254,6 +260,8 @@ impl VllmEngineClient {
         debug!("Server info response received");
         Ok(response.into_inner())
     }
+
+    crate::impl_get_tokenizer!();
 
     /// Build a single vLLM GenerateRequest from OpenAI ChatCompletionRequest
     pub fn build_generate_request_from_chat(

--- a/model_gateway/Cargo.toml
+++ b/model_gateway/Cargo.toml
@@ -113,6 +113,8 @@ bitflags.workspace = true
 once_cell = "1.21.3"
 sha2 = "0.10"
 wasmtime = { workspace = true }
+zip = "8.1"
+tempfile = "3.8"
 
 [build-dependencies]
 chrono = { version = "0.4", features = ["clock"] }
@@ -123,7 +125,6 @@ criterion = { version = "0.8", features = ["html_reports"] }
 tower = { version = "0.5", features = ["util"] }
 http-body-util = "0.1"
 portpicker = "0.1"
-tempfile = "3.8"
 lazy_static = "1.4"
 wasm-encoder = "0.244"
 npyz = { version = "0.8", features = ["npz"] }

--- a/model_gateway/src/routers/grpc/client.rs
+++ b/model_gateway/src/routers/grpc/client.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 
+use llm_tokenizer::bundle::TokenizerBundle;
 use openai_protocol::{chat::ChatCompletionRequest, generate::GenerateRequest};
 use smg_grpc_client::{
     sglang_proto::MultimodalInputs, SglangSchedulerClient, TrtllmServiceClient, VllmEngineClient,
@@ -145,6 +146,20 @@ impl GrpcClient {
         }
     }
 
+    /// Fetch tokenizer bundle from backend runtime when supported.
+    pub async fn get_tokenizer(
+        &self,
+    ) -> Result<TokenizerBundle, Box<dyn std::error::Error + Send + Sync>> {
+        match self {
+            Self::Sglang(client) => client.get_tokenizer().await,
+            Self::Vllm(client) => client.get_tokenizer().await,
+            Self::Trtllm(client) => client.get_tokenizer().await,
+        }
+    }
+
+    /// Generate streaming response from request
+    ///
+    /// Dispatches to the appropriate backend client and wraps the result in ProtoStream
     pub async fn generate(
         &mut self,
         req: ProtoGenerateRequest,

--- a/tokenizer/Cargo.toml
+++ b/tokenizer/Cargo.toml
@@ -29,6 +29,7 @@ thiserror.workspace = true
 tokio = { workspace = true, features = ["sync", "rt-multi-thread", "macros"] }
 tracing.workspace = true
 uuid = { workspace = true, features = ["v4", "serde"] }
+futures.workspace = true
 # Only used by tokenizer
 aho-corasick = "1.1"
 base64 = "0.22"
@@ -39,6 +40,8 @@ minijinja-contrib = { version = "2.0", features = ["pycompat"] }
 rayon = "1.10"
 tiktoken-rs = "0.9.1"
 tokenizers = "0.22.0"
+sha2 = "0.10"
+zip = "8.1"
 
 [dev-dependencies]
 criterion = "0.8"

--- a/tokenizer/src/bundle.rs
+++ b/tokenizer/src/bundle.rs
@@ -1,0 +1,343 @@
+use futures::{Stream, StreamExt};
+use serde::{Deserialize, Serialize};
+use tracing::debug;
+
+/// Maximum number of entries allowed in a tokenizer zip archive.
+pub const MAX_ZIP_ENTRIES: usize = 50;
+
+/// Maximum total uncompressed size for all extracted files (500 MB).
+pub const MAX_UNCOMPRESSED_SIZE: u64 = 500 * 1024 * 1024;
+
+/// Maximum total size for streamed tokenizer bundle data (200 MB).
+pub const MAX_TOKENIZER_BUNDLE_SIZE: usize = 200 * 1024 * 1024;
+
+/// Descriptor for a file in the tokenizer bundle
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TokenizerFileDescriptor {
+    pub file_name: String,
+    pub mime_type: String,
+    pub optional: bool,
+}
+
+/// Metadata for a tokenizer bundle
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TokenizerMetadata {
+    pub model_identifier: String,
+    pub fingerprint: String,
+    pub files: Vec<TokenizerFileDescriptor>,
+    pub bundle_format: String,
+}
+
+/// Tokenizer bundle containing metadata and compressed data
+#[derive(Debug, Clone)]
+pub struct TokenizerBundle {
+    pub metadata: TokenizerMetadata,
+    pub compressed_data: Vec<u8>,
+}
+
+#[derive(Debug, Clone)]
+pub struct TokenizerFileChunk {
+    pub data: Vec<u8>,
+    pub chunk_index: u32,
+    pub is_last_chunk: bool,
+}
+
+#[derive(Debug, Clone)]
+pub enum TokenizerChunk {
+    Metadata(TokenizerMetadata),
+    FileChunk(TokenizerFileChunk),
+}
+
+/// Stateful collector for tokenizer chunks.
+#[derive(Debug, Default)]
+pub struct TokenizerBundleCollector {
+    metadata: Option<TokenizerMetadata>,
+    compressed_data: Vec<u8>,
+    expected_chunk_index: u32,
+    last_chunk_received: bool,
+}
+
+impl TokenizerBundleCollector {
+    pub fn push_chunk(&mut self, chunk: TokenizerChunk) -> Result<(), String> {
+        if self.last_chunk_received {
+            return Err("Protocol error: received chunk after final chunk".to_string());
+        }
+
+        match chunk {
+            TokenizerChunk::Metadata(meta) => {
+                if self.metadata.is_some() {
+                    return Err(format!(
+                        "Protocol error: unexpected metadata chunk at position {}",
+                        self.expected_chunk_index
+                    ));
+                }
+
+                debug!(
+                    "Received tokenizer metadata: model={}, fingerprint={}, files={}, format={}",
+                    meta.model_identifier,
+                    meta.fingerprint,
+                    meta.files.len(),
+                    meta.bundle_format
+                );
+
+                if meta.bundle_format != "zip" {
+                    return Err(format!(
+                        "Unsupported tokenizer bundle format '{}', expected 'zip'",
+                        meta.bundle_format
+                    ));
+                }
+
+                self.metadata = Some(meta);
+                Ok(())
+            }
+            TokenizerChunk::FileChunk(file_chunk) => {
+                if self.metadata.is_none() {
+                    return Err(
+                        "Protocol error: first chunk must be metadata, got file chunk".to_string(),
+                    );
+                }
+
+                if file_chunk.chunk_index != self.expected_chunk_index {
+                    return Err(format!(
+                        "Protocol error: expected chunk index {}, got {}",
+                        self.expected_chunk_index, file_chunk.chunk_index
+                    ));
+                }
+
+                let new_total = self.compressed_data.len() + file_chunk.data.len();
+                if new_total > MAX_TOKENIZER_BUNDLE_SIZE {
+                    return Err(format!(
+                        "Tokenizer bundle exceeds maximum size limit ({} bytes > {} bytes)",
+                        new_total, MAX_TOKENIZER_BUNDLE_SIZE
+                    ));
+                }
+
+                debug!(
+                    "Received file chunk {}: {} bytes, is_last={}",
+                    file_chunk.chunk_index,
+                    file_chunk.data.len(),
+                    file_chunk.is_last_chunk
+                );
+
+                self.compressed_data.extend_from_slice(&file_chunk.data);
+                self.last_chunk_received = file_chunk.is_last_chunk;
+                self.expected_chunk_index += 1;
+
+                Ok(())
+            }
+        }
+    }
+
+    pub fn finish(self) -> Result<TokenizerBundle, String> {
+        let metadata = self
+            .metadata
+            .ok_or_else(|| "Empty stream: expected metadata chunk".to_string())?;
+
+        if !self.last_chunk_received {
+            return Err("Protocol error: stream ended without receiving final chunk".to_string());
+        }
+
+        if self.compressed_data.is_empty() {
+            return Err("Protocol error: received empty tokenizer bundle".to_string());
+        }
+
+        debug!(
+            "Tokenizer bundle received successfully: {} bytes compressed",
+            self.compressed_data.len()
+        );
+
+        Ok(TokenizerBundle {
+            metadata,
+            compressed_data: self.compressed_data,
+        })
+    }
+}
+
+/// Parse tokenizer chunks from an async stream into a validated `TokenizerBundle`.
+pub async fn collect_tokenizer_bundle<S, C, E, DecodeFn>(
+    stream: &mut S,
+    decode_chunk: DecodeFn,
+) -> Result<TokenizerBundle, String>
+where
+    S: Stream<Item = Result<C, E>> + Unpin,
+    E: std::fmt::Display,
+    DecodeFn: Fn(C) -> Result<TokenizerChunk, String>,
+{
+    let mut collector = TokenizerBundleCollector::default();
+
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|e| format!("Tokenizer stream error: {}", e))?;
+        let decoded = decode_chunk(chunk)?;
+        collector.push_chunk(decoded)?;
+    }
+
+    collector.finish()
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::{executor::block_on, stream};
+
+    use super::*;
+
+    fn metadata() -> TokenizerMetadata {
+        TokenizerMetadata {
+            model_identifier: "test-model".to_string(),
+            fingerprint: "test-fingerprint".to_string(),
+            files: vec![TokenizerFileDescriptor {
+                file_name: "tokenizer.json".to_string(),
+                mime_type: "application/json".to_string(),
+                optional: false,
+            }],
+            bundle_format: "zip".to_string(),
+        }
+    }
+
+    #[test]
+    fn test_collector_accepts_valid_metadata_and_chunks() {
+        let mut collector = TokenizerBundleCollector::default();
+
+        collector
+            .push_chunk(TokenizerChunk::Metadata(metadata()))
+            .unwrap();
+        collector
+            .push_chunk(TokenizerChunk::FileChunk(TokenizerFileChunk {
+                data: b"abc".to_vec(),
+                chunk_index: 0,
+                is_last_chunk: false,
+            }))
+            .unwrap();
+        collector
+            .push_chunk(TokenizerChunk::FileChunk(TokenizerFileChunk {
+                data: b"def".to_vec(),
+                chunk_index: 1,
+                is_last_chunk: true,
+            }))
+            .unwrap();
+
+        let bundle = collector.finish().unwrap();
+        assert_eq!(bundle.metadata.model_identifier, "test-model");
+        assert_eq!(bundle.compressed_data, b"abcdef");
+    }
+
+    #[test]
+    fn test_collector_rejects_file_chunk_before_metadata() {
+        let mut collector = TokenizerBundleCollector::default();
+
+        let err = collector
+            .push_chunk(TokenizerChunk::FileChunk(TokenizerFileChunk {
+                data: vec![1, 2, 3],
+                chunk_index: 0,
+                is_last_chunk: true,
+            }))
+            .unwrap_err();
+
+        assert!(err.contains("first chunk must be metadata"));
+    }
+
+    #[test]
+    fn test_collector_rejects_out_of_order_chunk_index() {
+        let mut collector = TokenizerBundleCollector::default();
+        collector
+            .push_chunk(TokenizerChunk::Metadata(metadata()))
+            .unwrap();
+
+        let err = collector
+            .push_chunk(TokenizerChunk::FileChunk(TokenizerFileChunk {
+                data: vec![1, 2, 3],
+                chunk_index: 1,
+                is_last_chunk: true,
+            }))
+            .unwrap_err();
+
+        assert!(err.contains("expected chunk index 0, got 1"));
+    }
+
+    #[test]
+    fn test_collector_rejects_chunk_after_last_chunk() {
+        let mut collector = TokenizerBundleCollector::default();
+        collector
+            .push_chunk(TokenizerChunk::Metadata(metadata()))
+            .unwrap();
+        collector
+            .push_chunk(TokenizerChunk::FileChunk(TokenizerFileChunk {
+                data: vec![1, 2, 3],
+                chunk_index: 0,
+                is_last_chunk: true,
+            }))
+            .unwrap();
+
+        let err = collector
+            .push_chunk(TokenizerChunk::FileChunk(TokenizerFileChunk {
+                data: vec![4, 5, 6],
+                chunk_index: 1,
+                is_last_chunk: true,
+            }))
+            .unwrap_err();
+
+        assert!(err.contains("received chunk after final chunk"));
+    }
+
+    #[test]
+    fn test_collector_finish_requires_final_chunk() {
+        let mut collector = TokenizerBundleCollector::default();
+        collector
+            .push_chunk(TokenizerChunk::Metadata(metadata()))
+            .unwrap();
+        collector
+            .push_chunk(TokenizerChunk::FileChunk(TokenizerFileChunk {
+                data: vec![1, 2, 3],
+                chunk_index: 0,
+                is_last_chunk: false,
+            }))
+            .unwrap();
+
+        let err = collector.finish().unwrap_err();
+        assert!(err.contains("stream ended without receiving final chunk"));
+    }
+
+    #[test]
+    fn test_collector_rejects_unsupported_bundle_format() {
+        let mut collector = TokenizerBundleCollector::default();
+
+        let mut meta = metadata();
+        meta.bundle_format = "tar.gz".to_string();
+
+        let err = collector
+            .push_chunk(TokenizerChunk::Metadata(meta))
+            .unwrap_err();
+
+        assert!(err.contains("Unsupported tokenizer bundle format 'tar.gz'"));
+    }
+
+    #[test]
+    fn test_collector_rejects_bundle_exceeding_max_size() {
+        let mut collector = TokenizerBundleCollector::default();
+        collector
+            .push_chunk(TokenizerChunk::Metadata(metadata()))
+            .unwrap();
+
+        // Send a single chunk that exceeds the limit
+        let oversized = vec![0u8; MAX_TOKENIZER_BUNDLE_SIZE + 1];
+        let err = collector
+            .push_chunk(TokenizerChunk::FileChunk(TokenizerFileChunk {
+                data: oversized,
+                chunk_index: 0,
+                is_last_chunk: true,
+            }))
+            .unwrap_err();
+
+        assert!(err.contains("exceeds maximum size limit"));
+    }
+
+    #[test]
+    fn test_collect_tokenizer_bundle_propagates_stream_errors() {
+        let mut s = stream::iter(vec![
+            Ok(TokenizerChunk::Metadata(metadata())),
+            Err("socket closed"),
+        ]);
+
+        let err = block_on(collect_tokenizer_bundle(&mut s, Ok)).unwrap_err();
+        assert!(err.contains("Tokenizer stream error: socket closed"));
+    }
+}

--- a/tokenizer/src/lib.rs
+++ b/tokenizer/src/lib.rs
@@ -12,9 +12,11 @@ pub mod stop;
 pub mod stream;
 pub mod traits;
 
+pub mod bundle;
 pub mod chat_template;
 pub mod huggingface;
 pub mod tiktoken;
+pub mod validation;
 
 #[cfg(test)]
 mod tests;

--- a/tokenizer/src/validation.rs
+++ b/tokenizer/src/validation.rs
@@ -1,0 +1,142 @@
+use std::io::{Read, Seek};
+
+use sha2::{Digest, Sha256};
+use zip::ZipArchive;
+
+use crate::bundle::{TokenizerBundle, MAX_UNCOMPRESSED_SIZE, MAX_ZIP_ENTRIES};
+
+/// Validate the SHA-256 fingerprint of a tokenizer bundle
+pub fn validate_tokenizer_bundle_sha256(bundle: &TokenizerBundle) -> Result<(), String> {
+    if bundle.metadata.fingerprint.is_empty() {
+        return Ok(());
+    }
+
+    let computed = format!("{:x}", Sha256::digest(&bundle.compressed_data));
+    if !computed.eq_ignore_ascii_case(&bundle.metadata.fingerprint) {
+        return Err(format!(
+            "Tokenizer bundle fingerprint mismatch: expected {}, got {}",
+            bundle.metadata.fingerprint, computed
+        ));
+    }
+    Ok(())
+}
+
+/// Validate and open a zip archive from bytes
+///
+/// checks:
+/// - Maximum number of entries
+/// - Maximum total uncompressed size
+pub fn validate_zip_archive<R: Read + Seek>(reader: R) -> Result<ZipArchive<R>, String> {
+    let mut archive =
+        ZipArchive::new(reader).map_err(|e| format!("Failed to open zip archive: {}", e))?;
+
+    if archive.len() > MAX_ZIP_ENTRIES {
+        return Err(format!(
+            "Tokenizer zip archive has too many entries ({} > {})",
+            archive.len(),
+            MAX_ZIP_ENTRIES
+        ));
+    }
+
+    let total_uncompressed: u64 = (0..archive.len())
+        .map(|i| archive.by_index_raw(i).map(|f| f.size()).unwrap_or(0))
+        .sum();
+
+    if total_uncompressed > MAX_UNCOMPRESSED_SIZE {
+        return Err(format!(
+            "Tokenizer zip archive uncompressed size too large ({} bytes > {} bytes)",
+            total_uncompressed, MAX_UNCOMPRESSED_SIZE
+        ));
+    }
+
+    Ok(archive)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Cursor, Write};
+
+    use sha2::{Digest, Sha256};
+    use zip::{write::SimpleFileOptions, ZipWriter};
+
+    use super::*;
+    use crate::bundle::TokenizerMetadata;
+
+    fn build_test_zip(entry_count: usize, payload: &[u8]) -> Vec<u8> {
+        let cursor = Cursor::new(Vec::new());
+        let mut writer = ZipWriter::new(cursor);
+
+        for i in 0..entry_count {
+            writer
+                .start_file(format!("file-{}.txt", i), SimpleFileOptions::default())
+                .unwrap();
+            writer.write_all(payload).unwrap();
+        }
+
+        writer.finish().unwrap().into_inner()
+    }
+
+    fn make_bundle(compressed_data: Vec<u8>, fingerprint: String) -> TokenizerBundle {
+        TokenizerBundle {
+            metadata: TokenizerMetadata {
+                model_identifier: "test-model".to_string(),
+                fingerprint,
+                files: vec![],
+                bundle_format: "zip".to_string(),
+            },
+            compressed_data,
+        }
+    }
+
+    #[test]
+    fn test_validate_tokenizer_bundle_sha256_accepts_matching_fingerprint() {
+        let compressed_data = b"test-bundle".to_vec();
+        let fingerprint = format!("{:x}", Sha256::digest(&compressed_data));
+        let bundle = make_bundle(compressed_data, fingerprint);
+
+        validate_tokenizer_bundle_sha256(&bundle).unwrap();
+    }
+
+    #[test]
+    fn test_validate_tokenizer_bundle_sha256_accepts_uppercase_fingerprint() {
+        let compressed_data = b"test-bundle".to_vec();
+        let fingerprint = format!("{:x}", Sha256::digest(&compressed_data)).to_uppercase();
+        let bundle = make_bundle(compressed_data, fingerprint);
+
+        validate_tokenizer_bundle_sha256(&bundle).unwrap();
+    }
+
+    #[test]
+    fn test_validate_tokenizer_bundle_sha256_rejects_mismatch() {
+        let bundle = make_bundle(b"test-bundle".to_vec(), "deadbeef".to_string());
+
+        let err = validate_tokenizer_bundle_sha256(&bundle).unwrap_err();
+        assert!(err.contains("fingerprint mismatch"));
+    }
+
+    #[test]
+    fn test_validate_tokenizer_bundle_sha256_allows_missing_fingerprint() {
+        let bundle = make_bundle(b"test-bundle".to_vec(), String::new());
+        validate_tokenizer_bundle_sha256(&bundle).unwrap();
+    }
+
+    #[test]
+    fn test_validate_zip_archive_accepts_valid_zip() {
+        let zip_bytes = build_test_zip(1, b"hello");
+        let archive = validate_zip_archive(Cursor::new(zip_bytes)).unwrap();
+        assert_eq!(archive.len(), 1);
+    }
+
+    #[test]
+    fn test_validate_zip_archive_rejects_invalid_zip_data() {
+        let err = validate_zip_archive(Cursor::new(vec![1, 2, 3, 4])).unwrap_err();
+        assert!(err.contains("Failed to open zip archive"));
+    }
+
+    #[test]
+    fn test_validate_zip_archive_rejects_too_many_entries() {
+        let zip_bytes = build_test_zip(MAX_ZIP_ENTRIES + 1, b"x");
+        let err = validate_zip_archive(Cursor::new(zip_bytes)).unwrap_err();
+        assert!(err.contains("too many entries"));
+    }
+}


### PR DESCRIPTION
## Description

### Problem

When the gateway does not have local access to tokenizer files (e.g. tokenizer is only available on the backend worker), there is no mechanism to dynamically acquire the tokenizer from a running gRPC backend. This blocks scenarios where the gateway and workers run on separate machines without shared filesystem access.

### Solution

Add a `GetTokenizer` gRPC streaming endpoint to all three backends (SGLang, vLLM, TensorRT-LLM) that streams tokenizer artifacts as a chunked bundle. The gateway can now fall back to fetching the tokenizer from a healthy gRPC worker when local loading fails, extracting the zip archive to a temp directory and loading from there.

A shared `TokenizerBundleCollector` in the `llm-tokenizer` crate handles protocol validation (chunk ordering, size limits, format checks) and SHA-256 fingerprint verification.

## Changes

- **Proto definitions** (`grpc_client/proto/`): Add `GetTokenizer` RPC returning `stream GetTokenizerChunk` with `TokenizerMetadata` and `TokenizerFileChunk` messages to all three proto files (SGLang, vLLM, TRT-LLM).
- **`tokenizer/src/bundle.rs`** (new): Shared domain types (`TokenizerBundle`, `TokenizerMetadata`, `TokenizerChunk`, etc.), a stateful `TokenizerBundleCollector` with protocol validation (chunk ordering, size limits, format checks), and an async `collect_tokenizer_bundle` stream helper.
- **`tokenizer/src/validation.rs`** (new): SHA-256 fingerprint verification (`validate_tokenizer_bundle_sha256`) and zip archive safety validation (`validate_zip_archive` — entry count + uncompressed size limits).
- **`grpc_client/src/lib.rs`**: `impl_decode_tokenizer_chunk!` and `impl_get_tokenizer!` macros to avoid triplicating the proto-to-domain decode logic and `get_tokenizer` method across backends.
- **`grpc_client/src/{sglang,vllm,trtllm}_scheduler.rs`**: Invoke the shared macros to add `get_tokenizer()` support.
- **`model_gateway/src/routers/grpc/client.rs`**: Add `GrpcClient::get_tokenizer()` dispatching to the appropriate backend.
- **`model_gateway/src/core/steps/tokenizer_registration.rs`**: New `fetch_tokenizer_from_worker` fallback — when local tokenizer loading fails, iterates healthy gRPC workers, streams the bundle, validates fingerprint + zip integrity, extracts to a temp dir, and loads.

## Test Plan

- Unit tests for `TokenizerBundleCollector`: valid flow, out-of-order chunks, chunks after final, missing metadata, stream errors.
- Unit tests for `validate_tokenizer_bundle_sha256`: matching fingerprint, mismatch rejection, empty fingerprint passthrough.
- Unit tests for `validate_zip_archive`: valid zip, invalid data, too many entries.
- Existing gRPC client tests pass (`cargo test -p smg-grpc-client`).
- Existing tokenizer tests pass (`cargo test -p llm-tokenizer`).
- `cargo check -p smg` compiles cleanly.
- Clippy passes with no new warnings.

## Screenshot
<img width="1920" height="1080" alt="Screenshot 2026-02-17 at 6 03 54 PM" src="https://github.com/user-attachments/assets/32d77ee7-2758-42c3-8505-ba320113e96f" />


<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streaming tokenizer retrieval added across backend services.
  * New tokenizer bundle protocol: metadata + chunked file streaming, ZIP format support, and checksum validation.
  * Automatic fallback to fetch tokenizers from healthy workers when local load fails.

* **Tests**
  * Comprehensive unit tests for tokenizer bundling, validation, and stream error handling.

* **Chores**
  * Added runtime dependencies for ZIP handling and temporary file support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->