### PR TITLE
ci(mergify): enable auto-close for non-conforming branch names

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -15,15 +15,20 @@ pull_request_rules:
 
           Allowed types: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `ci`, `perf`
 
-          > **Note:** We will bypass this check for existing PRs during the grace period, but PRs with non-conforming branch names **will be auto-closed** in the future. Please follow the naming convention for all new branches.
+          > **Note:** PRs with non-conforming branch names **will be auto-closed**. Please follow the naming convention for all branches.
       post_check:
         title: Branch naming convention
         summary: |
           Branch `{{head}}` does not match the required pattern: `<type>/<description>` or `<username>/<description>`.
-      # TODO: Re-enable auto-close once existing non-conforming PRs are merged
-      # close:
-      #   message: |
-      #     Closing this PR because the branch name does not follow the naming convention. Please rename your branch and reopen.
+      close:
+        message: |
+          Closing this PR because the branch name `{{head}}` does not follow the naming convention.
+
+          To fix this, please rename your branch locally, push the new branch, and open a new PR:
+          ```bash
+          git branch -m <new-branch-name>
+          git push origin -u <new-branch-name>
+          ```
 
   - name: Comment on DCO check failure
     description: Post fix instructions when DCO sign-off is missing


### PR DESCRIPTION
## Description

### Problem

The Mergify auto-close action for PRs with non-conforming branch names was temporarily disabled to give a grace period for existing PRs to be merged.

### Solution

Re-enable the auto-close action now that the grace period is over, and update the comment message to reflect that enforcement is active.

## Changes

- Uncommented the `close` action in the branch naming convention rule
- Updated the warning message to remove grace period language — now states PRs **will be** auto-closed (no "in the future" qualifier)
- Removed the `TODO` comment about re-enabling

## Test Plan

- Verify Mergify config is valid by checking the PR's mergify status
- Confirm that a PR opened from a non-conforming branch triggers the close action

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Branch-naming enforcement now immediately closes non-conforming branches (no grace period).
  * Automatic closure action activated with a clear close message and explicit remediation steps for renaming and reopening.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->