### PR TITLE
ci(mergify): allow multi-segment branch names for dependabot

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,16 +1,17 @@
 pull_request_rules:
-  - name: Enforce branch naming convention
-    description: Branch must follow <type>/<description> or <username>/<description> format
+  - name: Enforce branch naming convention (internal)
+    description: Auto-close PRs from internal branches that don't follow naming convention
     conditions:
-      - -head~=^[a-z0-9]([a-z0-9._-]*[a-z0-9])?/[a-z0-9._-]+(/[a-z0-9._-]+)*$
+      - -head~=^[a-z0-9]([a-z0-9._-]*[a-z0-9])?(/[a-z0-9._-]+)+$
       - head != main
+      - head-repo-full-name = lightseekorg/smg
     actions:
       comment:
         message: |
           Hi @{{author}}, the branch `{{head}}` does not follow our naming convention.
 
           Please use one of the following formats:
-          - `<type>/<description>` — e.g. `feat/add-auth`, `fix/null-pointer`
+          - `<type>/<description>` — e.g. `feat/add-auth`, `fix/null-pointer`, `dependabot/cargo/pyo3-0.28.1`
           - `<username>/<description>` — e.g. `changsu/fix-routing`
 
           Allowed types: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `ci`, `perf`
@@ -19,7 +20,7 @@ pull_request_rules:
       post_check:
         title: Branch naming convention
         summary: |
-          Branch `{{head}}` does not match the required pattern: `<type>/<description>` or `<username>/<description>`.
+          Branch `{{head}}` does not match the required pattern: `<type>/<description>` or `<username>/<description>` (sub-paths like `a/b/c` are also allowed).
       close:
         message: |
           Closing this PR because the branch name `{{head}}` does not follow the naming convention.


### PR DESCRIPTION
## Description

### Problem

Dependabot PRs (e.g. `dependabot/cargo/pyo3-0.28.1`) use multi-segment branch names with more than one `/`, which the current branch naming regex rejects and auto-closes.

### Solution

Update the regex to allow additional path segments by appending `(/[a-z0-9._-]+)*`.

## Changes

- Updated branch naming regex from `^[a-z0-9]([a-z0-9._-]*[a-z0-9])?/[a-z0-9._-]+$` to `^[a-z0-9]([a-z0-9._-]*[a-z0-9])?/[a-z0-9._-]+(/[a-z0-9._-]+)*$`

## Test Plan

- Verified regex matches dependabot branches: `dependabot/cargo/jsonwebtoken-10.3`, `dependabot/cargo/toml-1.0`, `dependabot/cargo/rustc-hash-2.1`, `dependabot/cargo/pyo3-0.28.1`
- Verified standard branches still pass: `feat/add-auth`, `fix/null-pointer`, `changsu/fix-routing`
- Verified invalid branches still fail: `main`, `mybranch`, `FEAT/something`, `feat/`

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Renamed internal branch-naming enforcement rule and clarified it applies to internal branches.
  * Relaxed branch-name validation to allow multi-segment sub-paths (e.g., a/b/c) and updated guidance.
  * Added an additional compliant example format (e.g., dependabot/cargo/pyo3-0.28.1).
  * Noted that PRs with non-conforming branch names will be auto-closed; rule limited to this repository.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->