### PR TITLE
feat(tokenizer): Enrich tokenizer metadata with backend, vocab_size, and creation time

### DIFF
--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
     {name = "Chang Su", email = "mckvtl@gmail.com"},
     {name = "Keyang Ru", email = "rukeyang@gmail.com"}
 ]
-requires-python = ">=3.12"
+requires-python = ">=3.9"
 readme = "../../README.md"
 license = { text = "Apache-2.0" }
 classifiers = [

--- a/bindings/python/src/smg/cli.py
+++ b/bindings/python/src/smg/cli.py
@@ -10,6 +10,8 @@ Usage:
     smg --help                 # Show help
 """
 
+from __future__ import annotations
+
 import argparse
 import os
 import sys

--- a/bindings/python/src/smg/launch_router.py
+++ b/bindings/python/src/smg/launch_router.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import logging
 import sys

--- a/bindings/python/src/smg/launch_server.py
+++ b/bindings/python/src/smg/launch_server.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import asyncio
 import copy

--- a/bindings/python/src/smg/router.py
+++ b/bindings/python/src/smg/router.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from smg.router_args import RouterArgs
 from smg.smg_rs import (
     BackendType,
@@ -236,7 +238,7 @@ class Router:
         self._router = router
 
     @staticmethod
-    def from_args(args: RouterArgs) -> "Router":
+    def from_args(args: RouterArgs) -> Router:
         """Create a router from a RouterArgs instance."""
 
         args_dict = vars(args)

--- a/bindings/python/src/smg/router_args.py
+++ b/bindings/python/src/smg/router_args.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import dataclasses
 import logging
@@ -952,9 +954,7 @@ class RouterArgs:
         )
 
     @classmethod
-    def from_cli_args(
-        cls, args: argparse.Namespace, use_router_prefix: bool = False
-    ) -> "RouterArgs":
+    def from_cli_args(cls, args: argparse.Namespace, use_router_prefix: bool = False) -> RouterArgs:
         """
         Create RouterArgs instance from parsed command line arguments.
 

--- a/bindings/python/src/smg/serve.py
+++ b/bindings/python/src/smg/serve.py
@@ -4,6 +4,8 @@ Serve command: two-pass CLI argument parsing with lazy backend import.
 Launches backend worker(s) + gateway router via a single `smg serve` command.
 """
 
+from __future__ import annotations
+
 import argparse
 import atexit
 import logging

--- a/model_gateway/src/core/steps/tokenizer_registration.rs
+++ b/model_gateway/src/core/steps/tokenizer_registration.rs
@@ -104,7 +104,7 @@ impl StepExecutor<TokenizerWorkflowData> for LoadTokenizerStep {
         // This handles: validation, deduplication, and loading
         let result = app_context
             .tokenizer_registry
-            .load(&id, &name, &source, || {
+            .load(&id, &name, &source, chat_template.as_deref(), || {
                 let source = source.clone();
                 let chat_template = chat_template.clone();
                 let cache_cfg = cache_config.clone();

--- a/model_gateway/src/routers/tokenize/handlers.rs
+++ b/model_gateway/src/routers/tokenize/handlers.rs
@@ -284,7 +284,10 @@ pub async fn list_tokenizers(registry: &Arc<TokenizerRegistry>) -> Response {
             id: e.id,
             name: e.name,
             source: e.source,
-            vocab_size: e.tokenizer.vocab_size(),
+            vocab_size: e.vocab_size, // Use pre-calculated size from entry
+            chat_template_path: e.chat_template_path,
+            backend: e.backend.to_string(),
+            created_at: e.created_at,
         })
         .collect();
 
@@ -338,7 +341,10 @@ pub async fn get_tokenizer_info(context: &Arc<AppContext>, tokenizer_id: &str) -
                 id: e.id,
                 name: e.name,
                 source: e.source,
-                vocab_size: e.tokenizer.vocab_size(),
+                vocab_size: e.vocab_size,
+                chat_template_path: e.chat_template_path,
+                backend: e.backend.to_string(),
+                created_at: e.created_at,
             };
             Json(info).into_response()
         }

--- a/multimodal/src/registry.rs
+++ b/multimodal/src/registry.rs
@@ -394,6 +394,10 @@ mod tests {
         fn as_any(&self) -> &dyn std::any::Any {
             self
         }
+
+        fn backend(&self) -> llm_tokenizer::TokenizerBackend {
+            llm_tokenizer::TokenizerBackend::Mock
+        }
     }
 
     #[test]

--- a/protocols/Cargo.toml
+++ b/protocols/Cargo.toml
@@ -20,7 +20,7 @@ axum = ["dep:axum"]
 [dependencies]
 axum = { workspace = true, optional = true }
 bitflags.workspace = true
-chrono.workspace = true
+chrono = { workspace = true, features = ["serde"] }
 rand.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["preserve_order"] }

--- a/protocols/src/tokenize.rs
+++ b/protocols/src/tokenize.rs
@@ -3,6 +3,7 @@
 //! These types mirror the SGLang Python implementation for compatibility.
 //! See: python/sglang/srt/entrypoints/openai/protocol.py
 
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use super::UNKNOWN_MODEL_ID;
@@ -161,6 +162,9 @@ pub struct TokenizerInfo {
     /// Source path or HuggingFace model ID
     pub source: String,
     pub vocab_size: usize,
+    pub chat_template_path: Option<String>,
+    pub backend: String,
+    pub created_at: DateTime<Utc>,
 }
 
 /// Request schema for removing a tokenizer

--- a/tokenizer/Cargo.toml
+++ b/tokenizer/Cargo.toml
@@ -19,6 +19,7 @@ name = "llm_tokenizer"
 [dependencies]
 anyhow.workspace = true
 blake3.workspace = true
+chrono.workspace = true
 bytemuck = { workspace = true, features = ["derive"] }
 dashmap.workspace = true
 lru.workspace = true

--- a/tokenizer/src/cache/mod.rs
+++ b/tokenizer/src/cache/mod.rs
@@ -272,6 +272,10 @@ impl Tokenizer for CachedTokenizer {
         self
     }
 
+    fn backend(&self) -> crate::traits::TokenizerBackend {
+        self.inner.backend()
+    }
+
     fn apply_chat_template(
         &self,
         messages: &[serde_json::Value],

--- a/tokenizer/src/huggingface.rs
+++ b/tokenizer/src/huggingface.rs
@@ -267,6 +267,10 @@ impl TokenizerTrait for HuggingFaceTokenizer {
         self
     }
 
+    fn backend(&self) -> crate::traits::TokenizerBackend {
+        crate::traits::TokenizerBackend::HuggingFace
+    }
+
     fn apply_chat_template(
         &self,
         messages: &[serde_json::Value],

--- a/tokenizer/src/lib.rs
+++ b/tokenizer/src/lib.rs
@@ -35,6 +35,7 @@ pub use stream::DecodeStream;
 pub use tiktoken::{TiktokenModel, TiktokenTokenizer};
 pub use traits::{
     Decoder, Encoder, Encoding, SpecialTokens, TokenIdType, Tokenizer as TokenizerTrait,
+    TokenizerBackend,
 };
 
 /// Main tokenizer wrapper that provides a unified interface for different tokenizer implementations

--- a/tokenizer/src/mock.rs
+++ b/tokenizer/src/mock.rs
@@ -125,4 +125,8 @@ impl TokenizerTrait for MockTokenizer {
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
+
+    fn backend(&self) -> crate::traits::TokenizerBackend {
+        crate::traits::TokenizerBackend::Mock
+    }
 }

--- a/tokenizer/src/tiktoken.rs
+++ b/tokenizer/src/tiktoken.rs
@@ -480,6 +480,10 @@ impl TokenizerTrait for TiktokenTokenizer {
         self
     }
 
+    fn backend(&self) -> crate::traits::TokenizerBackend {
+        crate::traits::TokenizerBackend::Tiktoken
+    }
+
     fn apply_chat_template(
         &self,
         messages: &[serde_json::Value],

--- a/tokenizer/src/traits.rs
+++ b/tokenizer/src/traits.rs
@@ -31,6 +31,9 @@ pub trait Tokenizer: Encoder + Decoder {
     /// Enable downcasting to concrete types
     fn as_any(&self) -> &dyn std::any::Any;
 
+    /// Get the backend type of the tokenizer
+    fn backend(&self) -> TokenizerBackend;
+
     /// Apply chat template to messages. Default returns an error for tokenizers without template support.
     fn apply_chat_template(
         &self,
@@ -50,6 +53,19 @@ pub trait Tokenizer: Encoder + Decoder {
     /// Set or override the chat template.
     fn set_chat_template(&mut self, _template: String) {
         // no-op by default
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TokenizerBackend {
+    HuggingFace,
+    Tiktoken,
+    Mock,
+}
+
+impl std::fmt::Display for TokenizerBackend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
     }
 }
 


### PR DESCRIPTION
### Problem


Closes #28 

### Solution

This PR enriches the `TokenizerEntry` structure and the corresponding `TokenizerInfo` API response with comprehensive metadata.

* **Backend Identification**: Introduced a `TokenizerBackend` enum and a `backend()` method on the `Tokenizer` trait.
* **Automatic Population**: Updated `TokenizerRegistry::load` to automatically capture:
  * `vocab_size`
  * detected `backend`
  * `created_at` timestamp
* **API Exposure**: Updated the `TokenizerInfo` protocol to expose these new fields to API clients.

---

## Changes

### **tokenizer crate**

* Added `TokenizerBackend` enum in `traits.rs`.
* Extended `TokenizerEntry` with:

  * `vocab_size`
  * `chat_template_path`
  * `backend`
  * `created_at`
* Implemented `backend()` for:

  * `HuggingFaceTokenizer`
  * `TiktokenTokenizer`
  * `MockTokenizer`
  * `CachedTokenizer`
* Updated `TokenizerRegistry::load` to populate metadata automatically.
* Re-exported `TokenizerBackend` in `lib.rs`.

### **protocols crate**

* Updated `TokenizerInfo` to include the new metadata fields.
* Enabled the `serde` feature for the `chrono` dependency.

### **model_gateway crate**

* Updated `LoadTokenizerStep` to pass chat template paths correctly.
* Updated handlers to map `TokenizerEntry` metadata to `TokenizerInfo`.

### **multimodal crate**

* Updated `TestTokenizer` to implement the new `backend()` trait method.

---

## Test Plan

Added new unit tests in `tokenizer/src/registry.rs` to verify metadata population and registry behavior.

### 1. Verify Metadata Population

```bash
cargo test --package llm-tokenizer --lib registry::tests::test_metadata_population
```

*Asserts that vocab_size is correctly captured, backend is identified as Mock, and timestamps are valid.*

### 2. Verify Registry Immutability

```bash
cargo test --package llm-tokenizer --lib registry::tests::test_load_ignores_updates
```

*Asserts that attempting to reload a tokenizer with different parameters does not corrupt the existing entry.*

### 3. General Regression

Ran full test suite for tokenizer crate:

```bash
cargo test --package llm-tokenizer
```




<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] (Optional) Documentation updated

</details>




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced tokenizer backend identification system allowing tokenizers to expose their backend type (HuggingFace, Tiktoken, Mock) for improved service discovery.
  * Enhanced tokenizer information with chat template path references and UTC creation timestamps for better metadata tracking and auditing capabilities.

* **Improvements**
  * Extended Python version compatibility to support Python 3.9 and later versions (previously required 3.12+).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->