### PR TITLE
feat(mcp): enforce allowed_tools filtering across openai and grpc routers

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -419,7 +419,7 @@ orchestrator.register_alias(
 For executing multiple tools efficiently (e.g., parallel tool calls from LLM):
 
 ```rust
-use smg_mcp::{McpToolSession, ToolExecutionInput, ToolExecutionOutput};
+use smg_mcp::{McpSessionOptions, McpToolSession, ToolExecutionInput, ToolExecutionOutput};
 
 // Convert tool calls to inputs
 let inputs: Vec<ToolExecutionInput> = tool_calls
@@ -435,6 +435,7 @@ let session = McpToolSession::new(
     &orchestrator,
     vec![("my-server".to_string(), "my-server".to_string())],
     "req-123",
+    Default::default(),
 );
 
 // Execute all tools through session mapping
@@ -453,6 +454,29 @@ for output in outputs {
         eprintln!("Tool {} failed: {:?}", output.tool_name, output.error_message);
     }
 }
+```
+
+### Allowed Tools Filtering
+
+To enforce the OpenAI Responses-style MCP allowlist (`allowed_tools: ["toolA", ...]`),
+pass the request's `tools` array via `McpSessionOptions`. Filtering is applied per
+MCP toolset/server.
+
+```rust
+use smg_mcp::{McpSessionOptions, McpToolSession};
+
+// Default behavior: no allowlist filtering
+let session = McpToolSession::new(&orchestrator, mcp_servers, "req-123", Default::default());
+
+// Optional: enforce allowlist filtering from the incoming request
+let session = McpToolSession::new(
+    &orchestrator,
+    mcp_servers,
+    "req-123",
+    McpSessionOptions {
+        request_tools: request.tools.as_deref(),
+    },
+);
 ```
 
 **Key types:**

--- a/mcp/src/core/mod.rs
+++ b/mcp/src/core/mod.rs
@@ -22,4 +22,4 @@ pub use orchestrator::{
 };
 pub use pool::{McpConnectionPool, PoolKey};
 pub use reconnect::ReconnectionManager;
-pub use session::McpToolSession;
+pub use session::{McpSessionOptions, McpToolSession};

--- a/mcp/src/lib.rs
+++ b/mcp/src/lib.rs
@@ -30,9 +30,10 @@ pub use core::{config, pool as connection_pool};
 pub use core::{
     ArgMappingConfig, BuiltinToolType, ConfigValidationError, HandlerRequestContext,
     LatencySnapshot, McpConfig, McpMetrics, McpOrchestrator, McpRequestContext, McpServerConfig,
-    McpToolSession, McpTransport, MetricsSnapshot, PolicyConfig, PolicyDecisionConfig, PoolKey,
-    RefreshRequest, ResponseFormatConfig, ServerPolicyConfig, SmgClientHandler, Tool,
-    ToolCallResult, ToolConfig, ToolExecutionInput, ToolExecutionOutput, TrustLevelConfig,
+    McpSessionOptions, McpToolSession, McpTransport, MetricsSnapshot, PolicyConfig,
+    PolicyDecisionConfig, PoolKey, RefreshRequest, ResponseFormatConfig, ServerPolicyConfig,
+    SmgClientHandler, Tool, ToolCallResult, ToolConfig, ToolExecutionInput, ToolExecutionOutput,
+    TrustLevelConfig,
 };
 
 // Re-export shared types

--- a/model_gateway/src/routers/anthropic/mcp.rs
+++ b/model_gateway/src/routers/anthropic/mcp.rs
@@ -181,7 +181,12 @@ pub(crate) async fn ensure_connection(
     let allowed_tools = collect_allowed_tools_from_toolsets(&request.tools);
 
     let session_id = format!("msg_{}", uuid::Uuid::new_v4());
-    let session = McpToolSession::new(orchestrator, mcp_servers.clone(), &session_id);
+    let session = McpToolSession::new(
+        orchestrator,
+        mcp_servers.clone(),
+        &session_id,
+        Default::default(),
+    );
 
     inject_mcp_tools_into_request(request, &session, &allowed_tools);
 

--- a/model_gateway/src/routers/anthropic/non_streaming.rs
+++ b/model_gateway/src/routers/anthropic/non_streaming.rs
@@ -36,7 +36,12 @@ pub(crate) async fn execute(router: &RouterContext, mut req_ctx: RequestContext)
     // MCP tool loop path
     let session_id = format!("msg_{}", uuid::Uuid::new_v4());
     let mcp_servers = req_ctx.mcp_servers.take().unwrap_or_default();
-    let session = McpToolSession::new(&router.mcp_orchestrator, mcp_servers, &session_id);
+    let session = McpToolSession::new(
+        &router.mcp_orchestrator,
+        mcp_servers,
+        &session_id,
+        Default::default(),
+    );
 
     let mut all_mcp_calls: Vec<mcp::McpToolCall> = Vec::new();
 

--- a/model_gateway/src/routers/anthropic/streaming.rs
+++ b/model_gateway/src/routers/anthropic/streaming.rs
@@ -195,7 +195,12 @@ async fn run_tool_loop(
 ) -> Result<(), String> {
     let session_id = format!("msg_{}", uuid::Uuid::new_v4());
     let mcp_servers = req_ctx.mcp_servers.take().unwrap_or_default();
-    let session = McpToolSession::new(&router.mcp_orchestrator, mcp_servers, &session_id);
+    let session = McpToolSession::new(
+        &router.mcp_orchestrator,
+        mcp_servers,
+        &session_id,
+        Default::default(),
+    );
 
     let mut global_index: u32 = 0;
     let mut total_input_tokens: u32 = 0;

--- a/model_gateway/src/routers/grpc/harmony/responses/non_streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/non_streaming.rs
@@ -14,7 +14,7 @@ use openai_protocol::{
     },
 };
 use serde_json::{json, to_string};
-use smg_mcp::McpToolSession;
+use smg_mcp::{McpSessionOptions, McpToolSession};
 use tracing::{debug, error, warn};
 
 use super::{
@@ -103,7 +103,15 @@ async fn execute_with_mcp_loop(
 
     // Create session once — bundles orchestrator, request_ctx, server_keys, mcp_tools
     let session_request_id = format!("resp_{}", uuid::Uuid::new_v4());
-    let session = McpToolSession::new(&ctx.mcp_orchestrator, mcp_servers, &session_request_id);
+
+    let session = McpToolSession::new(
+        &ctx.mcp_orchestrator,
+        mcp_servers,
+        &session_request_id,
+        McpSessionOptions {
+            request_tools: original_tools.as_deref(),
+        },
+    );
 
     // Add filtered MCP tools (static + requested dynamic) to the request
     let mcp_tools = session.mcp_tools();

--- a/model_gateway/src/routers/grpc/harmony/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/streaming.rs
@@ -6,7 +6,7 @@ use axum::response::Response;
 use bytes::Bytes;
 use openai_protocol::responses::{ResponseToolType, ResponsesRequest};
 use serde_json::json;
-use smg_mcp::McpToolSession;
+use smg_mcp::{McpSessionOptions, McpToolSession};
 use tokio::sync::mpsc;
 use tracing::{debug, warn};
 use uuid::Uuid;
@@ -131,7 +131,15 @@ async fn execute_mcp_tool_loop_streaming(
 
     // Create session once — bundles orchestrator, request_ctx, server_keys, mcp_tools
     let session_request_id = format!("resp_{}", Uuid::new_v4());
-    let session = McpToolSession::new(&ctx.mcp_orchestrator, mcp_servers, &session_request_id);
+
+    let session = McpToolSession::new(
+        &ctx.mcp_orchestrator,
+        mcp_servers,
+        &session_request_id,
+        McpSessionOptions {
+            request_tools: original_request.tools.as_deref(),
+        },
+    );
 
     // Add filtered MCP tools (static + requested dynamic) to the request
     let mcp_tools = session.mcp_tools();

--- a/model_gateway/src/routers/grpc/regular/responses/non_streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/non_streaming.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use axum::response::Response;
 use openai_protocol::responses::{ResponseStatus, ResponsesRequest, ResponsesResponse};
 use serde_json::json;
-use smg_mcp::{McpToolSession, ToolExecutionInput};
+use smg_mcp::{McpSessionOptions, McpToolSession, ToolExecutionInput};
 use tracing::{debug, error, trace, warn};
 
 use super::{
@@ -151,7 +151,15 @@ pub(super) async fn execute_tool_loop(
         .response_id
         .clone()
         .unwrap_or_else(|| format!("resp_{}", uuid::Uuid::new_v4()));
-    let session = McpToolSession::new(&ctx.mcp_orchestrator, mcp_servers, &session_request_id);
+
+    let session = McpToolSession::new(
+        &ctx.mcp_orchestrator,
+        mcp_servers,
+        &session_request_id,
+        McpSessionOptions {
+            request_tools: original_request.tools.as_deref(),
+        },
+    );
 
     // Get MCP tools and convert to chat format (do this once before loop)
     let mcp_chat_tools = convert_mcp_tools_to_chat_tools(&session);

--- a/model_gateway/src/routers/grpc/regular/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/streaming.rs
@@ -31,7 +31,7 @@ use openai_protocol::{
 };
 use serde_json::{json, Value};
 use smg_data_connector::{ConversationItemStorage, ConversationStorage, ResponseStorage};
-use smg_mcp::{McpToolSession, ResponseFormat, ToolExecutionInput};
+use smg_mcp::{McpSessionOptions, McpToolSession, ResponseFormat, ToolExecutionInput};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::{debug, trace, warn};
@@ -498,7 +498,14 @@ async fn execute_tool_loop_streaming_internal(
     let response_id = format!("resp_{}", Uuid::new_v4());
 
     // Create session once — bundles orchestrator, request_ctx, server_keys, mcp_tools
-    let session = McpToolSession::new(&ctx.mcp_orchestrator, mcp_servers, &response_id);
+    let session = McpToolSession::new(
+        &ctx.mcp_orchestrator,
+        mcp_servers,
+        &response_id,
+        McpSessionOptions {
+            request_tools: original_request.tools.as_deref(),
+        },
+    );
 
     // Create response event emitter
     let model = current_request.model.clone();

--- a/model_gateway/src/routers/openai/responses/non_streaming.rs
+++ b/model_gateway/src/routers/openai/responses/non_streaming.rs
@@ -8,7 +8,7 @@ use axum::{
     Json,
 };
 use serde_json::Value;
-use smg_mcp::McpToolSession;
+use smg_mcp::{McpSessionOptions, McpToolSession};
 use tracing::warn;
 
 use super::{
@@ -71,7 +71,14 @@ pub async fn handle_non_streaming_response(mut ctx: RequestContext) -> Response 
             .request_id
             .clone()
             .unwrap_or_else(|| format!("req_{}", uuid::Uuid::new_v4()));
-        let session = McpToolSession::new(mcp_orchestrator, mcp_servers, &session_request_id);
+        let session = McpToolSession::new(
+            mcp_orchestrator,
+            mcp_servers,
+            &session_request_id,
+            McpSessionOptions {
+                request_tools: original_body.tools.as_deref(),
+            },
+        );
         prepare_mcp_tools_as_functions(&mut payload, &session);
 
         match execute_tool_loop(

--- a/model_gateway/src/routers/openai/responses/streaming.rs
+++ b/model_gateway/src/routers/openai/responses/streaming.rs
@@ -24,7 +24,7 @@ use openai_protocol::{
     responses::{ResponseToolType, ResponsesRequest},
 };
 use serde_json::{json, Value};
-use smg_mcp::{McpOrchestrator, McpToolSession, ResponseFormat};
+use smg_mcp::{McpOrchestrator, McpSessionOptions, McpToolSession, ResponseFormat};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::warn;
@@ -696,6 +696,9 @@ pub(super) async fn handle_streaming_with_tool_interception(
             &orchestrator_clone,
             mcp_servers.clone(),
             &session_request_id,
+            McpSessionOptions {
+                request_tools: original_request.tools.as_deref(),
+            },
         );
         let mut current_payload = payload_clone;
         prepare_mcp_tools_as_functions(&mut current_payload, &session);


### PR DESCRIPTION
## Description

### Problem

The Responses API MCP tool accepted allowed_tools in the request schema, but it was not actually enforced. As a result, models could still see/list/call the full MCP tool inventory. The gRPC Responses paths also did not apply allowed_tools.

### Solution

Enforce the simple OpenAI-compatible form allowed_tools: ["toolA", ...] (matching MCP original tool names) on a per-server/toolset basis. The allowlist is applied at McpToolSession creation so it consistently affects tool exposure, mcp_list_tools, and tool execution across OpenAI HTTP and gRPC routers. Unknown/empty tool names are ignored (matching OpenAI behavior), resulting in an empty tool list rather than an error.

## Changes

- Introduce McpSessionOptions (Default) and extend McpToolSession::new(..., options) to accept per-request configuration
- Enforce request-level MCP allowlists during McpToolSession creation:
  - reads tools[].allowed_tools from McpSessionOptions.request_tools (OpenAI Responses request tools)
  - applies allowlists per MCP toolset/server label (only toolsets that specify allowed_tools are filtered)
  - maps server_label -> server_key for servers connected in this request; allowlists for unknown/unconnected labels are ignored
  - ignores unknown/empty/whitespace tool names (OpenAI-compatible), which may produce an empty tool list but does not error
- Filter the MCP tool inventory at session creation when an allowlist is present; only allowlisted tools are exposed and executable
- Make mcp_list_tools use the session’s pre-filtered tool snapshot (so listing matches model-visible tools)
- Wire allowlist enforcement into OpenAI Responses (HTTP) and gRPC Responses (regular/harmony, streaming/non-streaming) by passing:
  - Anthropic: Default::default()
  - OpenAI/gRPC: McpSessionOptions { request_tools: request.tools.as_deref() }
- Documentation: add ### Allowed Tools Filtering to mcp/README.md
- Tests: add coverage for allowlist filtering (single-server and cross-server behavior) and mcp_list_tools consistency

## Test Plan

<!-- Provide a thorough reproducible test showing before and after behavior. -->

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session configuration option to specify per-request tool allowlists, enabling per-server tool filtering before execution.
  * Tool inventories are now pre-filtered to respect request-level tool selections for consistent behavior.

* **Documentation**
  * Updated batch tool execution example to show the new session configuration.

* **Tests**
  * Added tests covering per-server and cross-server tool filtering and inventory/listing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->