### PR TITLE
fix(concurrency): release tokio mutex before awaiting task in LoadMonitor::stop()

### DIFF
--- a/model_gateway/src/core/worker_manager.rs
+++ b/model_gateway/src/core/worker_manager.rs
@@ -323,11 +323,14 @@ impl LoadMonitor {
     }
 
     pub async fn stop(&self) {
-        let mut handle_guard = self.monitor_handle.lock().await;
-        if let Some(handle) = handle_guard.take() {
+        let handle = {
+            let mut handle_guard = self.monitor_handle.lock().await;
+            handle_guard.take()
+        };
+        if let Some(handle) = handle {
             info!("Stopping load monitoring");
             handle.abort();
-            let _ = handle.await; // Wait for task to finish
+            let _ = handle.await;
         }
     }
 

--- a/model_gateway/src/policies/bucket.rs
+++ b/model_gateway/src/policies/bucket.rs
@@ -1,5 +1,7 @@
 use std::{
     collections::{HashMap, HashSet, VecDeque},
+    // std::sync::Mutex is correct: all locking functions are synchronous,
+    // so there is no risk of holding locks across .await points.
     sync::{Arc, Mutex, RwLock},
     thread,
     time::{Duration, SystemTime},

--- a/model_gateway/src/service_discovery.rs
+++ b/model_gateway/src/service_discovery.rs
@@ -1,5 +1,8 @@
 use std::{
     collections::{HashMap, HashSet},
+    // std::sync::Mutex is intentional: all critical sections are tiny
+    // (HashSet insert/remove/contains) and never cross .await boundaries.
+    // See: https://docs.rs/tokio/latest/tokio/sync/struct.Mutex.html#which-kind-of-mutex-should-you-use
     sync::{Arc, Mutex},
     time::Duration,
 };


### PR DESCRIPTION
## Summary

- Fix concurrency issue in `LoadMonitor::stop()` where a `tokio::sync::Mutex` guard was held across `.await`, blocking all other callers (`start()`, `is_running()`, `Drop`) for the duration of task cleanup
- Audit all `std::sync::Mutex` usage in async contexts — confirmed correct everywhere, added explanatory comments

Refs: G10

## What changed

- **`model_gateway/src/core/worker_manager.rs`**: Scope the mutex guard in `stop()` to just the `.take()` operation, releasing the lock before `handle.await`. Previously the lock was held for the entire duration of task abort + await, which is potentially unbounded.
- **`model_gateway/src/service_discovery.rs`**: Added comment explaining why `std::sync::Mutex` is intentional (tiny critical sections that never cross `.await` boundaries).
- **`model_gateway/src/policies/bucket.rs`**: Added comment explaining why `std::sync::Mutex` is correct (all locking functions are synchronous).

## Why

The `stop()` method held a `tokio::sync::Mutex` guard while calling `handle.await` on a `JoinHandle`. This meant any concurrent call to `start()`, `is_running()`, or the `Drop` impl would block until task cleanup completed — potentially unbounded time. This is the classic "holding a lock across `.await`" anti-pattern that can cause contention and latency spikes.

The `std::sync::Mutex` audit confirmed all uses follow the recommended Tokio pattern: prefer `std::sync::Mutex` when the lock is never held across `.await` points and critical sections are small.

## How

Extracted the `.take()` into a scoped block so the mutex guard drops immediately after taking the handle. The subsequent `handle.abort()` and `handle.await` then run without holding any lock.

## Test plan

- `cargo check -p smg` — compiles clean
- `cargo clippy -p smg` — no warnings
- `cargo test -p smg` — all existing tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code optimizations improving system stability and performance.

* **Chores**
  * Added clarifying documentation for code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->