### PR TITLE
fix(ci): use pull_request_target for labeler to support fork PRs

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,7 @@
 name: PR Labeler
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 permissions:


### PR DESCRIPTION
## Description

### Problem

The PR labeler workflow fails on fork PRs (e.g. #470) with `Resource not accessible by integration` because GitHub downgrades `GITHUB_TOKEN` to read-only for `pull_request` events from forks.

### Solution

Switch the trigger from `pull_request` to `pull_request_target` so the workflow runs in the base repo context with write permissions. This is safe because `actions/labeler` only reads the list of changed file paths — it does not check out or execute code from the PR branch.

## Changes

- Changed `pull_request` to `pull_request_target` in `.github/workflows/labeler.yml`

## Test Plan

- Confirm labeler succeeds on the next fork PR

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration for pull request processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->