### PR TITLE
feat(reasoning-parser): add NanoV3 reasoning parser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.dependencies]
 # Internal workspace crates
 openai-protocol = { version = "1.1.0", path = "protocols" }
-reasoning-parser = { version = "1.1.0", path = "reasoning_parser" }
+reasoning-parser = { version = "1.2.0", path = "reasoning_parser" }
 tool-parser = { version = "1.1.0", path = "tool_parser" }
 wfaas = { version = "1.0.1", path = "workflow" }
 llm-tokenizer = { version = "1.1.0", path = "tokenizer" }

--- a/reasoning_parser/Cargo.toml
+++ b/reasoning_parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reasoning-parser"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 description = "Parser for AI model reasoning/thinking outputs (chain-of-thought, etc.)"
 license = "Apache-2.0"

--- a/reasoning_parser/src/lib.rs
+++ b/reasoning_parser/src/lib.rs
@@ -5,6 +5,6 @@ pub mod traits;
 pub use factory::{ParserFactory, ParserRegistry, PooledParser};
 pub use parsers::{
     BaseReasoningParser, CohereCmdParser, DeepSeekR1Parser, Glm45Parser, KimiParser, MiniMaxParser,
-    Qwen3Parser, QwenThinkingParser, Step3Parser,
+    NanoV3Parser, Qwen3Parser, QwenThinkingParser, Step3Parser,
 };
 pub use traits::{ParseError, ParserConfig, ParserResult, ReasoningParser};

--- a/reasoning_parser/src/parsers/mod.rs
+++ b/reasoning_parser/src/parsers/mod.rs
@@ -4,6 +4,7 @@ pub mod deepseek_r1;
 pub mod glm45;
 pub mod kimi;
 pub mod minimax;
+pub mod nano_v3;
 pub mod qwen3;
 pub mod step3;
 
@@ -13,5 +14,6 @@ pub use deepseek_r1::DeepSeekR1Parser;
 pub use glm45::Glm45Parser;
 pub use kimi::KimiParser;
 pub use minimax::MiniMaxParser;
+pub use nano_v3::NanoV3Parser;
 pub use qwen3::{Qwen3Parser, QwenThinkingParser};
 pub use step3::Step3Parser;

--- a/reasoning_parser/src/parsers/nano_v3.rs
+++ b/reasoning_parser/src/parsers/nano_v3.rs
@@ -1,0 +1,126 @@
+// NanoV3 specific reasoning parser.
+// Uses the same format as DeepSeek-R1 (<think>...</think>) with initial_in_reasoning=true.
+
+use crate::{
+    parsers::BaseReasoningParser,
+    traits::{ParseError, ParserConfig, ParserResult, ReasoningParser},
+};
+
+/// NanoV3 reasoning parser.
+///
+/// Uses the same reasoning format as DeepSeek-R1: `<think>...</think>`.
+/// Starts with `initial_in_reasoning=true`, assuming all output is reasoning
+/// until a `</think>` token is encountered.
+pub struct NanoV3Parser {
+    base: BaseReasoningParser,
+}
+
+impl NanoV3Parser {
+    /// Create a new NanoV3 parser.
+    pub fn new() -> Self {
+        let config = ParserConfig {
+            think_start_token: "<think>".to_string(),
+            think_end_token: "</think>".to_string(),
+            stream_reasoning: true,
+            max_buffer_size: 65536,
+            initial_in_reasoning: true,
+        };
+
+        Self {
+            base: BaseReasoningParser::new(config).with_model_type("nano_v3".to_string()),
+        }
+    }
+}
+
+impl Default for NanoV3Parser {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ReasoningParser for NanoV3Parser {
+    fn detect_and_parse_reasoning(&mut self, text: &str) -> Result<ParserResult, ParseError> {
+        self.base.detect_and_parse_reasoning(text)
+    }
+
+    fn parse_reasoning_streaming_incremental(
+        &mut self,
+        text: &str,
+    ) -> Result<ParserResult, ParseError> {
+        self.base.parse_reasoning_streaming_incremental(text)
+    }
+
+    fn reset(&mut self) {
+        self.base.reset()
+    }
+
+    fn model_type(&self) -> &str {
+        self.base.model_type()
+    }
+
+    fn is_in_reasoning(&self) -> bool {
+        self.base.is_in_reasoning()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_nano_v3_initial_state() {
+        let mut parser = NanoV3Parser::new();
+
+        // Should treat text as reasoning even without start token
+        let result = parser
+            .detect_and_parse_reasoning("This is reasoning content")
+            .unwrap();
+        assert_eq!(result.normal_text, "");
+        assert_eq!(result.reasoning_text, "This is reasoning content");
+    }
+
+    #[test]
+    fn test_nano_v3_with_end_token() {
+        let mut parser = NanoV3Parser::new();
+
+        let result = parser
+            .detect_and_parse_reasoning("reasoning content</think>answer")
+            .unwrap();
+        assert_eq!(result.normal_text, "answer");
+        assert_eq!(result.reasoning_text, "reasoning content");
+    }
+
+    #[test]
+    fn test_nano_v3_with_both_tokens() {
+        let mut parser = NanoV3Parser::new();
+
+        let result = parser
+            .detect_and_parse_reasoning("<think>reasoning content</think>answer")
+            .unwrap();
+        assert_eq!(result.normal_text, "answer");
+        assert_eq!(result.reasoning_text, "reasoning content");
+    }
+
+    #[test]
+    fn test_nano_v3_streaming() {
+        let mut parser = NanoV3Parser::new();
+
+        let result1 = parser
+            .parse_reasoning_streaming_incremental("reasoning text ")
+            .unwrap();
+        assert_eq!(result1.normal_text, "");
+        assert_eq!(result1.reasoning_text, "reasoning text ");
+
+        let result2 = parser
+            .parse_reasoning_streaming_incremental("more reasoning</think>answer")
+            .unwrap();
+        assert_eq!(result2.normal_text, "answer");
+        assert_eq!(result2.reasoning_text, "more reasoning");
+    }
+
+    #[test]
+    fn test_model_type() {
+        let parser = NanoV3Parser::new();
+        assert_eq!(parser.model_type(), "nano_v3");
+    }
+}


### PR DESCRIPTION
## Summary
- Add dedicated `NanoV3Parser` for Nemotron Nano/Super models
- Uses same reasoning format as DeepSeek-R1: `<think>...</think>` with `initial_in_reasoning=true`
- Previously these models were incorrectly mapped to `qwen3` (which starts with `initial_in_reasoning=false`)

## What changed
- **New file** `reasoning_parser/src/parsers/nano_v3.rs`: `NanoV3Parser` struct with full `ReasoningParser` trait implementation and unit tests
- **`reasoning_parser/src/parsers/mod.rs`**: Register `nano_v3` module and re-export `NanoV3Parser`
- **`reasoning_parser/src/lib.rs`**: Add `NanoV3Parser` to public exports
- **`reasoning_parser/src/factory.rs`**: Register parser creator, update pattern mappings (`nemotron-nano`, `nemotron-super`, `nano-v3`), add factory test
- **`reasoning_parser/Cargo.toml`**: Bump version 1.1.0 → 1.2.0
- **`Cargo.toml`**: Update workspace dependency version

## Why
The NanoV3/Nemotron models start output in reasoning mode (like DeepSeek-R1), not in optional-reasoning mode (like Qwen3). The previous mapping to `qwen3` meant `initial_in_reasoning=false`, which would fail to capture reasoning content that appears before the first `<think>` tag.

## Test plan
- [x] All 74 reasoning-parser tests pass (5 new NanoV3 tests + 1 new factory pattern test)
- [x] Pattern matching works for `nano-v3-*`, `nemotron-nano-*`, `NVIDIA-Nemotron/nemotron-super`
- [x] `cargo check -p reasoning-parser` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added NanoV3 parser supporting Nemotron Nano variants and nano-v3 model identifiers with complete reasoning parsing implementation
  * Enhanced model mapping and automatic routing in parser factory
  * Full streaming support for incremental reasoning token detection and processing

* **Chores**
  * Version bumped to 1.2.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->