### PR TITLE
ci(test): verify mergify DCO rule with probot app

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,3 +1,4 @@
+# Test: verifying DCO check-failure rule fires with probot app (will revert)
 pull_request_rules:
   - name: Enforce branch naming convention (internal)
     description: Auto-close PRs from internal branches that don't follow naming convention


### PR DESCRIPTION
## Description

**Test PR — will close after verification.**

Testing whether the Mergify `check-failure = dco` rule fires when the probot DCO app detects a missing `Signed-off-by` line. This commit is intentionally unsigned.

Ref: investigating why Mergify didn't comment on #484 when DCO was missing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD configuration for internal testing purposes.

**Note:** This release contains no user-facing changes or new features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->