### PR TITLE
fix(ci): match probot DCO app check name in Mergify rule

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -34,7 +34,7 @@ pull_request_rules:
   - name: Comment on DCO check failure
     description: Post fix instructions when DCO sign-off is missing
     conditions:
-      - check-failure = dco
+      - check-failure = DCO
       - -closed
       - -draft
     actions:


### PR DESCRIPTION
## Description

### Problem

After switching from the GitHub Actions DCO workflow to the probot DCO app in #462, the Mergify rule that comments on DCO failures stopped working. The rule condition `check-failure = dco` never matches because the probot DCO app reports its check run as `DCO` (uppercase), and Mergify's `check-failure` condition is case-sensitive for check names.

### Solution

Update the Mergify condition from `check-failure = dco` to `check-failure = DCO` to match the probot app's actual check name.

## Changes

- Update `.github/mergify.yml`: change `check-failure = dco` to `check-failure = DCO`

## Test Plan

- Opened test PR #485 with an unsigned commit to verify the bug: the DCO probot check reported `action_required`, but Mergify's Summary confirmed `check-failure = dco` was **not matched**
- After this fix merges, open another test PR with an unsigned commit to confirm Mergify posts the DCO failure comment

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD configuration to improve Developer Certificate of Origin (DCO) check handling in the automated pull request workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->