### PR TITLE
feat(responses): add mcp approval items to protocols and routers

### DIFF
--- a/model_gateway/src/routers/grpc/harmony/builder.rs
+++ b/model_gateway/src/routers/grpc/harmony/builder.rs
@@ -683,6 +683,16 @@ impl HarmonyBuilder {
                     content_type: None,
                 })
             }
+
+            ResponseInputOutputItem::McpApprovalResponse { .. } => Err(
+                "mcp_approval_response must be handled by the responses router before Harmony conversion"
+                    .to_string(),
+            ),
+
+            ResponseInputOutputItem::McpApprovalRequest { .. } => Err(
+                "mcp_approval_request must be handled by the responses router before Harmony conversion"
+                    .to_string(),
+            ),
         }
     }
 

--- a/model_gateway/src/routers/grpc/regular/responses/conversions.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/conversions.rs
@@ -143,6 +143,13 @@ pub(crate) fn responses_to_chat(req: &ResponsesRequest) -> Result<ChatCompletion
                             tool_call_id: call_id.clone(),
                         });
                     }
+                    ResponseInputOutputItem::McpApprovalResponse { .. }
+                    | ResponseInputOutputItem::McpApprovalRequest { .. } => {
+                        return Err(
+                            "mcp_approval_request/mcp_approval_response must be handled by the responses router before chat conversion"
+                                .to_string(),
+                        );
+                    }
                 }
             }
         }

--- a/model_gateway/src/routers/openai/responses/utils.rs
+++ b/model_gateway/src/routers/openai/responses/utils.rs
@@ -4,6 +4,7 @@ use openai_protocol::{
     event_types::is_response_event,
     responses::{ResponseTool, ResponseToolType, ResponsesRequest},
 };
+use serde::Serialize;
 use serde_json::{json, Map, Value};
 use tracing::warn;
 
@@ -195,6 +196,19 @@ pub(super) fn insert_optional_string(
     }
 }
 
+/// Helper to insert an optional serializable field into a JSON map.
+pub(super) fn insert_optional_value<T: Serialize>(
+    map: &mut Map<String, Value>,
+    key: &str,
+    value: &Option<T>,
+) {
+    if let Some(v) = value {
+        if let Ok(val) = serde_json::to_value(v) {
+            map.insert(key.to_string(), val);
+        }
+    }
+}
+
 /// Convert a single ResponseTool back to its original JSON representation.
 ///
 /// Handles MCP tools (with server metadata), web_search_preview, and code_interpreter.
@@ -207,7 +221,7 @@ pub(super) fn response_tool_to_value(tool: &ResponseTool) -> Option<Value> {
             insert_optional_string(&mut m, "server_label", &tool.server_label);
             insert_optional_string(&mut m, "server_url", &tool.server_url);
             insert_optional_string(&mut m, "server_description", &tool.server_description);
-            insert_optional_string(&mut m, "require_approval", &tool.require_approval);
+            insert_optional_value(&mut m, "require_approval", &tool.require_approval);
             if let Some(allowed) = &tool.allowed_tools {
                 m.insert(
                     "allowed_tools".to_string(),

--- a/model_gateway/tests/api/responses_api_test.rs
+++ b/model_gateway/tests/api/responses_api_test.rs
@@ -4,8 +4,8 @@ use axum::http::StatusCode;
 use openai_protocol::{
     common::{GenerationRequest, ToolChoice, ToolChoiceValue, UsageInfo},
     responses::{
-        ReasoningEffort, ResponseInput, ResponseReasoningParam, ResponseTool, ResponseToolType,
-        ResponsesRequest, ServiceTier, Truncation,
+        ReasoningEffort, RequireApproval, ResponseInput, ResponseReasoningParam, ResponseTool,
+        ResponseToolType, ResponsesRequest, ServiceTier, Truncation,
     },
 };
 use smg::{
@@ -577,7 +577,7 @@ async fn test_multi_turn_loop_with_mcp() {
             server_url: Some(mcp.url()),
             server_label: Some("mock".to_string()),
             server_description: Some("Mock MCP server for testing".to_string()),
-            require_approval: Some("never".to_string()),
+            require_approval: Some(RequireApproval::Never),
             ..Default::default()
         }]),
         top_logprobs: Some(0),
@@ -899,7 +899,7 @@ async fn test_streaming_with_mcp_tool_calls() {
             server_url: Some(mcp.url()),
             server_label: Some("mock".to_string()),
             server_description: Some("Mock MCP for streaming test".to_string()),
-            require_approval: Some("never".to_string()),
+            require_approval: Some(RequireApproval::Never),
             ..Default::default()
         }]),
         top_logprobs: Some(0),


### PR DESCRIPTION
## Description

### Problem

We need to implement an OpenAI-compatible MCP approval flow for the Responses API. This is the first PR in that effort, and it focuses on adding the missing protocol/schema pieces so later PRs can implement the router-side interrupt/continue behavior.

### Solution

Add protocol support for MCP approval items and require_approval (restricted to "always" / "never"), plus minimal router/test adjustments to keep existing paths compiling and correctly restoring tool JSON.

## Changes

- Add mcp_approval_request to both ResponseOutputItem and ResponseInputOutputItem (so it can be returned and later replayed in stateless mode).
- Add mcp_approval_response to ResponseInputOutputItem.
- Model tools[].require_approval as RequireApproval enum (always/never) and update tool restoration to serialize it back into JSON.
- Update gRPC conversions to error if approval items reach chat/harmony conversion (they must be handled at the responses router layer).
- Update Responses API integration tests to use RequireApproval::Never.
- Add repo doc capturing the overall approval flow PR plan: MCP_APPROVAL_FLOW_PLAN.md.

## Test Plan

<!-- Provide a thorough reproducible test showing before and after behavior. -->

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for MCP approval request and response workflows in the system.

* **Improvements**
  * Enhanced error handling with explicit validation for MCP approval items during message conversion.
  * Refactored approval handling to use structured types instead of string-based values for improved type safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->