### PR TITLE
feat(responses): add mcp approval items to protocols and routers

### DIFF
--- a/model_gateway/src/routers/grpc/harmony/builder.rs
+++ b/model_gateway/src/routers/grpc/harmony/builder.rs
@@ -21,7 +21,7 @@ use openai_protocol::{
         ResponsesRequest, StringOrContentParts,
     },
 };
-use tracing::{debug, trace};
+use tracing::{debug, trace, warn};
 
 use super::types::HarmonyBuildOutput;
 use crate::routers::grpc::{proto_wrapper::ProtoOutputLogProbs, utils};
@@ -696,6 +696,15 @@ impl HarmonyBuilder {
                     channel: None,
                     content_type: None,
                 })
+            }
+
+            ResponseInputOutputItem::McpApprovalResponse { .. }
+            | ResponseInputOutputItem::McpApprovalRequest { .. } => {
+                warn!(
+                    function = "parse_response_item_to_harmony_message",
+                    "Approval item reached Harmony conversion"
+                );
+                Err("Unsupported input item type".to_string())
             }
         }
     }

--- a/model_gateway/src/routers/grpc/regular/responses/conversions.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/conversions.rs
@@ -19,6 +19,7 @@ use openai_protocol::{
     },
     UNKNOWN_MODEL_ID,
 };
+use tracing::warn;
 
 use crate::routers::grpc::common::responses::utils::extract_tools_from_response_tools;
 
@@ -142,6 +143,14 @@ pub(crate) fn responses_to_chat(req: &ResponsesRequest) -> Result<ChatCompletion
                             content: MessageContent::Text(output.clone()),
                             tool_call_id: call_id.clone(),
                         });
+                    }
+                    ResponseInputOutputItem::McpApprovalResponse { .. }
+                    | ResponseInputOutputItem::McpApprovalRequest { .. } => {
+                        warn!(
+                            function = "responses_to_chat",
+                            "Approval item reached chat conversion"
+                        );
+                        return Err("Unsupported input item type".to_string());
                     }
                 }
             }

--- a/model_gateway/src/routers/openai/responses/utils.rs
+++ b/model_gateway/src/routers/openai/responses/utils.rs
@@ -4,6 +4,7 @@ use openai_protocol::{
     event_types::is_response_event,
     responses::{ResponseTool, ResponseToolType, ResponsesRequest},
 };
+use serde::Serialize;
 use serde_json::{json, Map, Value};
 use tracing::warn;
 
@@ -184,14 +185,21 @@ pub(super) fn rewrite_streaming_block(
     Some(rebuild_sse_block(trimmed, &new_payload))
 }
 
-/// Helper to insert an optional string field into a JSON map
-pub(super) fn insert_optional_string(
+/// Helper to insert an optional serializable field into a JSON map.
+pub(super) fn insert_optional_value<T: Serialize>(
     map: &mut Map<String, Value>,
     key: &str,
-    value: Option<&String>,
+    value: Option<&T>,
 ) {
     if let Some(v) = value {
-        map.insert(key.to_string(), Value::String(v.clone()));
+        match serde_json::to_value(v) {
+            Ok(val) => {
+                map.insert(key.to_string(), val);
+            }
+            Err(e) => {
+                warn!(field = key, error = %e, "Failed to serialize optional field");
+            }
+        }
     }
 }
 
@@ -204,14 +212,14 @@ pub(super) fn response_tool_to_value(tool: &ResponseTool) -> Option<Value> {
         ResponseToolType::Mcp if tool.server_url.is_some() => {
             let mut m = Map::new();
             m.insert("type".to_string(), json!("mcp"));
-            insert_optional_string(&mut m, "server_label", tool.server_label.as_ref());
-            insert_optional_string(&mut m, "server_url", tool.server_url.as_ref());
-            insert_optional_string(
+            insert_optional_value(&mut m, "server_label", tool.server_label.as_ref());
+            insert_optional_value(&mut m, "server_url", tool.server_url.as_ref());
+            insert_optional_value(
                 &mut m,
                 "server_description",
                 tool.server_description.as_ref(),
             );
-            insert_optional_string(&mut m, "require_approval", tool.require_approval.as_ref());
+            insert_optional_value(&mut m, "require_approval", tool.require_approval.as_ref());
             if let Some(allowed) = &tool.allowed_tools {
                 m.insert(
                     "allowed_tools".to_string(),

--- a/model_gateway/tests/api/responses_api_test.rs
+++ b/model_gateway/tests/api/responses_api_test.rs
@@ -4,8 +4,8 @@ use axum::http::StatusCode;
 use openai_protocol::{
     common::{GenerationRequest, ToolChoice, ToolChoiceValue, UsageInfo},
     responses::{
-        ReasoningEffort, ResponseInput, ResponseReasoningParam, ResponseTool, ResponseToolType,
-        ResponsesRequest, ServiceTier, Truncation,
+        ReasoningEffort, RequireApproval, ResponseInput, ResponseReasoningParam, ResponseTool,
+        ResponseToolType, ResponsesRequest, ServiceTier, Truncation,
     },
 };
 use smg::{
@@ -578,7 +578,7 @@ async fn test_multi_turn_loop_with_mcp() {
             server_url: Some(mcp.url()),
             server_label: Some("mock".to_string()),
             server_description: Some("Mock MCP server for testing".to_string()),
-            require_approval: Some("never".to_string()),
+            require_approval: Some(RequireApproval::Never),
             ..Default::default()
         }]),
         top_logprobs: Some(0),
@@ -907,7 +907,7 @@ async fn test_streaming_with_mcp_tool_calls() {
             server_url: Some(mcp.url()),
             server_label: Some("mock".to_string()),
             server_description: Some("Mock MCP for streaming test".to_string()),
-            require_approval: Some("never".to_string()),
+            require_approval: Some(RequireApproval::Never),
             ..Default::default()
         }]),
         top_logprobs: Some(0),

--- a/protocols/src/responses.rs
+++ b/protocols/src/responses.rs
@@ -36,7 +36,8 @@ pub struct ResponseTool {
     pub headers: Option<HashMap<String, String>>,
     pub server_label: Option<String>,
     pub server_description: Option<String>,
-    pub require_approval: Option<String>,
+    /// Approval requirement configuration for MCP tools.
+    pub require_approval: Option<RequireApproval>,
     pub allowed_tools: Option<Vec<String>>,
 }
 
@@ -54,6 +55,14 @@ impl Default for ResponseTool {
             allowed_tools: None,
         }
     }
+}
+
+/// `require_approval` values.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RequireApproval {
+    Always,
+    Never,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
@@ -155,6 +164,22 @@ pub enum ResponseInputOutputItem {
         #[serde(skip_serializing_if = "Option::is_none")]
         status: Option<String>,
     },
+    #[serde(rename = "mcp_approval_request")]
+    McpApprovalRequest {
+        id: String,
+        server_label: String,
+        name: String,
+        arguments: String,
+    },
+    #[serde(rename = "mcp_approval_response")]
+    McpApprovalResponse {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        id: Option<String>,
+        approval_request_id: String,
+        approve: bool,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        reason: Option<String>,
+    },
     #[serde(untagged)]
     SimpleInputMessage {
         content: StringOrContentParts,
@@ -246,6 +271,13 @@ pub enum ResponseOutputItem {
         name: String,
         output: String,
         server_label: String,
+    },
+    #[serde(rename = "mcp_approval_request")]
+    McpApprovalRequest {
+        id: String,
+        server_label: String,
+        name: String,
+        arguments: String,
     },
     #[serde(rename = "web_search_call")]
     WebSearchCall {
@@ -871,6 +903,8 @@ impl GenerationRequest for ResponsesRequest {
                     ResponseInputOutputItem::FunctionCallOutput { output, .. } => {
                         Some(output.clone())
                     }
+                    ResponseInputOutputItem::McpApprovalRequest { .. } => None,
+                    ResponseInputOutputItem::McpApprovalResponse { .. } => None,
                 })
                 .collect::<Vec<String>>()
                 .join(" "),
@@ -1116,6 +1150,8 @@ fn validate_input_item(item: &ResponseInputOutputItem) -> Result<(), ValidationE
             }
         }
         ResponseInputOutputItem::FunctionToolCall { .. } => {}
+        ResponseInputOutputItem::McpApprovalRequest { .. } => {}
+        ResponseInputOutputItem::McpApprovalResponse { .. } => {}
     }
     Ok(())
 }


### PR DESCRIPTION
## Description

### Problem

We need to implement an OpenAI-compatible MCP approval flow for the Responses API. This is the first PR in that effort, and it focuses on adding the missing protocol/schema pieces so later PRs can implement the router-side interrupt/continue behavior.

### Solution

Add protocol support for MCP approval items and require_approval (restricted to "always" / "never"), plus minimal router/test adjustments to keep existing paths compiling and correctly restoring tool JSON.

## Changes

- Add mcp_approval_request to both ResponseOutputItem and ResponseInputOutputItem (so it can be returned and later replayed in stateless mode).
- Add mcp_approval_response to ResponseInputOutputItem.
- Model tools[].require_approval as RequireApproval enum (always/never) and update tool restoration to serialize it back into JSON.
- Update gRPC conversions to error if approval items reach chat/harmony conversion (they must be handled at the responses router layer).
- Update Responses API integration tests to use RequireApproval::Never.

## Test Plan

<!-- Provide a thorough reproducible test showing before and after behavior. -->

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for MCP approval request and response items in the responses model.
  * Replaced string-based approval setting with a typed enum for require_approval.

* **Bug Fixes**
  * MCP approval items are now rejected early during chat/Harmony conversions with a warning and an error to prevent incorrect processing.

* **Improvements**
  * JSON serialization now supports optional non-string values for response tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->