### PR TITLE
docs(grpc-proto): add remote dev workflow for testing proto changes

### DIFF
--- a/grpc_client/python/README.md
+++ b/grpc_client/python/README.md
@@ -53,6 +53,10 @@ After editing `.proto` files locally, build a wheel and install it in the remote
 ```bash
 # 1. Build wheel (regenerates Python stubs from latest .proto files)
 cd grpc_client/python
+# Copy proto files into the package tree (the repo uses a symlink which
+# won't survive wheel packaging)
+mkdir -p smg_grpc_proto/proto
+cp ../proto/*.proto smg_grpc_proto/proto/
 pip wheel . --no-deps -w dist/
 
 # 2. Copy to remote


### PR DESCRIPTION
## Description

### Problem

When iterating on `.proto` file changes, there's no documented workflow for testing updated Python stubs on a remote GPU machine (e.g. where vLLM runs). Developers have to figure out the wheel-build-and-copy process each time.

### Solution

Add a short section to the grpc_client Python README documenting the three-step workflow: build wheel locally, scp to remote, force-reinstall.

## Changes

- Added "Testing proto changes on a remote GPU machine" section to `grpc_client/python/README.md`

## Test Plan

Documentation-only change. Verified the wheel build/install steps work on a remote vLLM environment.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] (Optional) Documentation updated

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated README with step-by-step guidance for testing protocol buffer changes on remote GPU machines, including building a wheel from local changes, transferring and reinstalling it on the remote environment, and notes that no import changes are required on the remote side.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->