### PR TITLE
fix(multimodal): detect data: URIs as DataUrl in tracker

### DIFF
--- a/multimodal/src/tracker.rs
+++ b/multimodal/src/tracker.rs
@@ -71,10 +71,9 @@ impl AsyncMultiModalTracker {
                 Ok(())
             }
             ChatContentPart::ImageUrl { url, detail, uuid } => {
-                let source = if url.get(..5).is_some_and(|s| s.eq_ignore_ascii_case("data:")) {
-                    MediaSource::DataUrl(url)
-                } else {
-                    MediaSource::Url(url)
+                let source = match url::Url::parse(&url) {
+                    Ok(parsed) if parsed.scheme() == "data" => MediaSource::DataUrl(url),
+                    _ => MediaSource::Url(url),
                 };
                 self.enqueue_image(source, detail.unwrap_or_default(), uuid)
             }


### PR DESCRIPTION
## Description

### Problem

When a user sends an image via a `data:` URI (base64 inline image) through the `image_url` field in a chat message, the multimodal tracker incorrectly classifies it as `MediaSource::Url` and attempts to fetch it as a remote URL. This causes the request to fail since `data:` URIs are not valid HTTP endpoints.

### Solution

Add a check in `AsyncMultiModalTracker` to detect `data:` URI prefixes in the `image_url` path and route them to `MediaSource::DataUrl` instead of `MediaSource::Url`.

## Changes

- In `tracker.rs`, added `data:` prefix detection in the `ImageUrl` handler to correctly dispatch to `MediaSource::DataUrl`

## Test Plan

Tested with a chat completion request containing a base64-encoded image in `image_url.url`:
```json
{
  "type": "image_url",
  "image_url": { "url": "data:image/png;base64,iVBOR..." }
}
```
Verified the image is decoded inline rather than triggering an HTTP fetch.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of image references in multimodal content to correctly recognize and treat embedded data URLs separately from external links.
  * Results in more reliable image enqueuing and rendering across varied content sources, reducing missed or misinterpreted images and improving overall media reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->