### PR TITLE
fix(pre-commit): exclude Rust files from shebang check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,7 @@ repos:
       - id: check-added-large-files
       - id: check-merge-conflict
       - id: check-shebang-scripts-are-executable
+        exclude: \.rs$
       - id: detect-private-key
         exclude: .*tests/.*_test\.rs$
       - id: mixed-line-ending


### PR DESCRIPTION
## Description

### Problem

The `check-shebang-scripts-are-executable` pre-commit hook false-positives on Rust files whose first line is an inner attribute (`#![...]`), because `#!` looks like a shebang.

### Solution

Exclude `.rs` files from the hook. Rust source files are never executable scripts.

## Changes

- Added `exclude: \.rs$` to the `check-shebang-scripts-are-executable` hook in `.pre-commit-config.yaml`

## Test Plan

`pre-commit run check-shebang-scripts-are-executable --all-files` passes after the change.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development configuration to optimize pre-commit hook behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->