### PR TITLE
fix(ci): auto-trigger benchmark workflows on code changes

### DIFF
--- a/.github/workflows/benchmark-manual-policy.yml
+++ b/.github/workflows/benchmark-manual-policy.yml
@@ -6,11 +6,17 @@ on:
     paths:
       - 'model_gateway/benches/manual_policy_benchmark.rs'
       - 'model_gateway/src/policies/**'
+      - '!model_gateway/src/policies/**/tests/**'
+      - '!model_gateway/src/policies/**/*_test.rs'
+      - '!model_gateway/src/policies/**/test_*.rs'
   pull_request:
     branches: [ main ]
     paths:
       - 'model_gateway/benches/manual_policy_benchmark.rs'
       - 'model_gateway/src/policies/**'
+      - '!model_gateway/src/policies/**/tests/**'
+      - '!model_gateway/src/policies/**/*_test.rs'
+      - '!model_gateway/src/policies/**/test_*.rs'
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * 0'
@@ -43,9 +49,7 @@ jobs:
     needs: check-ci
     if: |
       github.repository == 'lightseekorg/smg' &&
-      needs.check-ci.outputs.should_run == 'true' &&
-      (github.event_name != 'pull_request' ||
-       contains(github.event.pull_request.labels.*.name, 'router-benchmark'))
+      needs.check-ci.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/benchmark-radix-tree.yml
+++ b/.github/workflows/benchmark-radix-tree.yml
@@ -6,13 +6,17 @@ on:
     paths:
       - 'model_gateway/benches/radix_tree_benchmark.rs'
       - 'kv_index/**'
-      - 'model_gateway/src/policies/tree.rs'
+      - '!kv_index/**/tests/**'
+      - '!kv_index/**/*_test.rs'
+      - '!kv_index/**/test_*.rs'
   pull_request:
     branches: [ main ]
     paths:
       - 'model_gateway/benches/radix_tree_benchmark.rs'
       - 'kv_index/**'
-      - 'model_gateway/src/policies/tree.rs'
+      - '!kv_index/**/tests/**'
+      - '!kv_index/**/*_test.rs'
+      - '!kv_index/**/test_*.rs'
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * 0'
@@ -45,9 +49,7 @@ jobs:
     needs: check-ci
     if: |
       github.repository == 'lightseekorg/smg' &&
-      needs.check-ci.outputs.should_run == 'true' &&
-      (github.event_name != 'pull_request' ||
-       contains(github.event.pull_request.labels.*.name, 'router-benchmark'))
+      needs.check-ci.outputs.should_run == 'true'
     runs-on: k8s-runner-gpu
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/benchmark-request-processing.yml
+++ b/.github/workflows/benchmark-request-processing.yml
@@ -8,6 +8,9 @@ on:
       - 'model_gateway/src/routers/**'
       - 'model_gateway/src/core/**'
       - 'model_gateway/src/middleware.rs'
+      - '!model_gateway/src/**/tests/**'
+      - '!model_gateway/src/**/*_test.rs'
+      - '!model_gateway/src/**/test_*.rs'
   pull_request:
     branches: [ main ]
     paths:
@@ -15,6 +18,9 @@ on:
       - 'model_gateway/src/routers/**'
       - 'model_gateway/src/core/**'
       - 'model_gateway/src/middleware.rs'
+      - '!model_gateway/src/**/tests/**'
+      - '!model_gateway/src/**/*_test.rs'
+      - '!model_gateway/src/**/test_*.rs'
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * 0'
@@ -47,9 +53,7 @@ jobs:
     needs: check-ci
     if: |
       github.repository == 'lightseekorg/smg' &&
-      needs.check-ci.outputs.should_run == 'true' &&
-      (github.event_name != 'pull_request' ||
-       contains(github.event.pull_request.labels.*.name, 'router-benchmark'))
+      needs.check-ci.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/benchmark-tokenizer.yml
+++ b/.github/workflows/benchmark-tokenizer.yml
@@ -6,11 +6,17 @@ on:
     paths:
       - 'model_gateway/benches/tokenizer_benchmark.rs'
       - 'tokenizer/**'
+      - '!tokenizer/**/tests/**'
+      - '!tokenizer/**/*_test.rs'
+      - '!tokenizer/**/test_*.rs'
   pull_request:
     branches: [ main ]
     paths:
       - 'model_gateway/benches/tokenizer_benchmark.rs'
       - 'tokenizer/**'
+      - '!tokenizer/**/tests/**'
+      - '!tokenizer/**/*_test.rs'
+      - '!tokenizer/**/test_*.rs'
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * 0'
@@ -43,9 +49,7 @@ jobs:
     needs: check-ci
     if: |
       github.repository == 'lightseekorg/smg' &&
-      needs.check-ci.outputs.should_run == 'true' &&
-      (github.event_name != 'pull_request' ||
-       contains(github.event.pull_request.labels.*.name, 'router-benchmark'))
+      needs.check-ci.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/benchmark-tool-parser.yml
+++ b/.github/workflows/benchmark-tool-parser.yml
@@ -6,11 +6,17 @@ on:
     paths:
       - 'model_gateway/benches/tool_parser_benchmark.rs'
       - 'tool_parser/**'
+      - '!tool_parser/**/tests/**'
+      - '!tool_parser/**/*_test.rs'
+      - '!tool_parser/**/test_*.rs'
   pull_request:
     branches: [ main ]
     paths:
       - 'model_gateway/benches/tool_parser_benchmark.rs'
       - 'tool_parser/**'
+      - '!tool_parser/**/tests/**'
+      - '!tool_parser/**/*_test.rs'
+      - '!tool_parser/**/test_*.rs'
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * 0'
@@ -43,9 +49,7 @@ jobs:
     needs: check-ci
     if: |
       github.repository == 'lightseekorg/smg' &&
-      needs.check-ci.outputs.should_run == 'true' &&
-      (github.event_name != 'pull_request' ||
-       contains(github.event.pull_request.labels.*.name, 'router-benchmark'))
+      needs.check-ci.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Description

### Problem

All 5 benchmark workflows (manual-policy, radix-tree, request-processing, tokenizer, tool-parser) were never executing on PRs. Despite having correct path filters, the benchmark job had a secondary `if` condition requiring the `router-benchmark` label on the PR. Without manually adding that label, benchmarks were silently skipped.

Additionally, the radix-tree benchmark referenced a stale path (`model_gateway/src/policies/tree.rs`) that no longer exists.

### Solution

Remove the `router-benchmark` label requirement so benchmarks auto-trigger on relevant code changes. Fix the stale path reference and add test file exclusions to avoid unnecessary runs.

## Changes

- **All 5 benchmark workflows**: Remove `router-benchmark` label gate from the benchmark job `if` condition. Benchmarks now run automatically when path filters match, gated only by `check-ci` (trusted contributor check).
- **benchmark-radix-tree.yml**: Replace stale `model_gateway/src/policies/tree.rs` path with `kv_index/**`.
- **All 5 benchmark workflows**: Add `!` path exclusions for test files (`**/tests/**`, `**/*_test.rs`, `**/test_*.rs`) so unit test changes don't trigger benchmark runs.

## Test Plan

- Verify workflows trigger on PRs that touch relevant source paths without needing the `router-benchmark` label.
- Verify workflows do NOT trigger when only test files are changed.
- `workflow_dispatch` and weekly `schedule` triggers remain unchanged.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated benchmark workflow configurations to exclude test-related files from triggering benchmark runs
  * Simplified benchmark job execution requirements across multiple workflow pipelines

<!-- end of auto-generated comment: release notes by coderabbit.ai -->