### PR TITLE
fix: address PR #489 review follow-ups

### DIFF
--- a/model_gateway/src/core/steps/worker/local/update_worker_properties.rs
+++ b/model_gateway/src/core/steps/worker/local/update_worker_properties.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 use wfaas::{StepExecutor, StepResult, WorkflowContext, WorkflowError, WorkflowResult};
 
 use crate::core::{steps::workflow_data::WorkerUpdateWorkflowData, BasicWorkerBuilder, Worker};
@@ -89,6 +89,13 @@ impl StepExecutor<WorkerUpdateWorkflowData> for UpdateWorkerPropertiesStep {
             if worker.is_dp_aware() {
                 if let (Some(rank), Some(size)) = (worker.dp_rank(), worker.dp_size()) {
                     builder = builder.dp_config(rank, size);
+                } else {
+                    warn!(
+                        worker_url = %worker.url(),
+                        dp_rank = ?worker.dp_rank(),
+                        dp_size = ?worker.dp_size(),
+                        "DP-aware worker is missing dp_rank or dp_size; skipping DP config"
+                    );
                 }
             }
 

--- a/model_gateway/src/core/token_bucket.rs
+++ b/model_gateway/src/core/token_bucket.rs
@@ -65,6 +65,10 @@ impl TokenBucket {
 
     /// Sync version of try_acquire (for internal use).
     fn try_acquire_sync(&self, tokens: f64) -> Result<(), ()> {
+        debug_assert!(
+            tokens.is_finite() && tokens >= 0.0,
+            "token amount must be non-negative and finite, got {tokens}"
+        );
         let mut inner = self.inner.lock();
 
         let now = Instant::now();
@@ -157,6 +161,10 @@ impl TokenBucket {
     /// This is safe to call from sync contexts (e.g., Drop handlers).
     /// Uses `parking_lot::Mutex` which never blocks indefinitely.
     pub fn return_tokens_sync(&self, tokens: f64) {
+        debug_assert!(
+            tokens.is_finite() && tokens >= 0.0,
+            "token amount must be non-negative and finite, got {tokens}"
+        );
         {
             let mut inner = self.inner.lock();
             inner.tokens = (inner.tokens + tokens).min(self.capacity);

--- a/model_gateway/src/routers/grpc/harmony/streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/streaming.rs
@@ -114,6 +114,7 @@ impl HarmonyStreamingProcessor {
                     "Embeddings not supported in Harmony streaming",
                     "invalid_request_error",
                 );
+                let _ = tx.send(Ok(Bytes::from("data: [DONE]\n\n")));
             }
         }
 

--- a/model_gateway/src/routers/grpc/regular/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/streaming.rs
@@ -160,6 +160,7 @@ impl StreamingProcessor {
                     "Embeddings not supported in streaming mode",
                     "invalid_request_error",
                 );
+                let _ = tx.send(Ok(Bytes::from("data: [DONE]\n\n")));
             }
         }
 
@@ -678,6 +679,7 @@ impl StreamingProcessor {
                     "Embeddings not supported in streaming generate",
                     "invalid_request_error",
                 );
+                let _ = tx.send(Ok(Bytes::from("data: [DONE]\n\n")));
             }
         }
 


### PR DESCRIPTION
## Summary

Addresses deferred review comments from PR #489 (clippy enforcement) that required behavioral changes and were out of scope for a lint-only PR.

Refs: PR #489 review comments

## What changed

### SSE streaming: missing `[DONE]` terminator (harmony + regular)
- **`model_gateway/src/routers/grpc/harmony/streaming.rs`**: Added `[DONE]` event after embedding error SSE
- **`model_gateway/src/routers/grpc/regular/streaming.rs`**: Added `[DONE]` event after both chat and generate embedding error SSEs
- The `Single` and `Dual` execution paths already sent `[DONE]` after errors, but the `Embedding` paths did not, which could leave SSE clients hanging

### Bucket policy: duplicate add + stale state on removal
- **`model_gateway/src/policies/bucket.rs` (`add_prefill_url`)**: Added early-return guard when worker URL already exists. Previously, duplicate adds called `init_prefill_worker_urls` which resets `chars_per_url` load counters and recomputes boundaries, wiping balancing history
- **`model_gateway/src/policies/bucket.rs` (`remove_prefill_url`)**: Always call `init_prefill_worker_urls` after removal, even when the last URL is removed. Previously cleanup was skipped when `updated_len == 0`, leaving stale boundary and `chars_per_url` state

### Token bucket: input validation
- **`model_gateway/src/core/token_bucket.rs`**: Added `debug_assert!` on `try_acquire_sync` and `return_tokens_sync` to catch non-finite or negative token amounts during development. Zero-cost in release builds

### Worker properties: DP config observability
- **`model_gateway/src/core/steps/worker/local/update_worker_properties.rs`**: Added `warn!` log when a DP-aware worker is missing `dp_rank` or `dp_size` metadata. Previously this inconsistent state was silently ignored, making misconfigurations hard to diagnose

## Test plan
- [ ] `cargo clippy --workspace` passes with zero warnings
- [ ] Existing streaming tests pass (SSE `[DONE]` terminator is additive)
- [ ] Bucket policy behavior unchanged for non-duplicate add/remove paths
- [ ] `debug_assert!` is zero-cost in release builds, active only in debug/test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Fixed streaming responses to properly complete streams when certain operations are unsupported, ensuring clients receive proper termination signals

## Improvements
- Enhanced duplicate worker resource handling to prevent unnecessary state updates
- Added validation safeguards for token bucket operations
- Improved diagnostic logging for distributed worker configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->