### PR TITLE
fix(ci): enable ephemeral runners to prevent dead runner accumulation

### DIFF
--- a/scripts/k8s-runner-resources/arc-runner-cpu.yaml
+++ b/scripts/k8s-runner-resources/arc-runner-cpu.yaml
@@ -7,6 +7,7 @@ spec:
   replicas: 4
   template:
     spec:
+      ephemeral: true
       repository: lightseekorg/smg
       labels:
         - k8s-runner-cpu

--- a/scripts/k8s-runner-resources/arc-runner-gpu.yaml
+++ b/scripts/k8s-runner-resources/arc-runner-gpu.yaml
@@ -7,6 +7,7 @@ spec:
   replicas: 10
   template:
     spec:
+      ephemeral: true
       repository: lightseekorg/smg
       labels:
         - 4-gpu-h100
@@ -87,6 +88,7 @@ spec:
   replicas: 2
   template:
     spec:
+      ephemeral: true
       repository: lightseekorg/smg
       labels:
         - 4-gpu-a10


### PR DESCRIPTION
## Summary

Set `ephemeral: true` on all ARC RunnerDeployment specs to fix dead runner accumulation in GitHub.

## What changed

- `scripts/k8s-runner-resources/arc-runner-cpu.yaml` — added `ephemeral: true`
- `scripts/k8s-runner-resources/arc-runner-gpu.yaml` — added `ephemeral: true` to both H100 and A10 RunnerDeployments

## Why

Without ephemeral mode, runner pods that get killed, evicted, or scaled down never deregister from GitHub, leaving 120+ ghost "offline" runner entries. Each CI job spawns a new pod, but the old registration persists.

## How

With `ephemeral: true`, each runner picks up exactly one job, self-deregisters from GitHub on completion, then the pod terminates. The ARC controller replaces it to maintain `minReplicas`. This is the recommended mode for ARC with autoscaling.

## Test plan

- [x] Manually cleaned up 120 dead offline runners via `gh api`
- [x] Applied updated configs to k8s cluster (`kubectl apply`)
- [ ] Verify new runner pods register, pick up a job, and deregister cleanly
- [ ] Verify no new ghost runners accumulate after CI runs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured CPU and GPU runners to operate as ephemeral, enabling automatic cleanup after execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->