### PR TITLE
feat(gprc): add TensorRT-LLM multimodal support

### DIFF
--- a/grpc_client/proto/trtllm_service.proto
+++ b/grpc_client/proto/trtllm_service.proto
@@ -276,14 +276,10 @@ message PromptTuningConfig {
 // ============================================================================
 
 message MultimodalInput {
-  // Multimodal content hashes for caching
-  repeated int64 multimodal_hashes = 1;
-
-  // Positions in input where multimodal content is inserted
-  repeated int32 multimodal_positions = 2;
-
-  // Lengths of multimodal content at each position
-  repeated int32 multimodal_lengths = 3;
+  // Raw image bytes (JPEG/PNG) for each image in the request.
+  // TRT-LLM's input processor handles hashing, position tracking,
+  // and vision encoding server-side.
+  repeated bytes image_data = 1;
 }
 
 // ============================================================================

--- a/grpc_client/src/trtllm_service.rs
+++ b/grpc_client/src/trtllm_service.rs
@@ -269,6 +269,7 @@ impl TrtllmServiceClient {
         body: &ChatCompletionRequest,
         processed_text: String,
         token_ids: Vec<u32>,
+        multimodal_input: Option<proto::MultimodalInput>,
         tool_call_constraint: Option<(String, String)>, // (constraint_type, constraint_value)
     ) -> Result<proto::GenerateRequest, String> {
         // Build sampling config
@@ -305,7 +306,7 @@ impl TrtllmServiceClient {
             embedding_bias: vec![],
             lora_config: None,
             prompt_tuning_config: None,
-            multimodal_input: None,
+            multimodal_input,
             kv_cache_retention: None,
             disaggregated_params: None,
             lookahead_config: None,

--- a/model_gateway/src/routers/grpc/client.rs
+++ b/model_gateway/src/routers/grpc/client.rs
@@ -245,11 +245,13 @@ impl GrpcClient {
                 Ok(ProtoGenerateRequest::Vllm(Box::new(req)))
             }
             Self::Trtllm(client) => {
+                let trtllm_mm = multimodal_inputs.map(|mm| mm.into_trtllm_proto());
                 let req = client.build_generate_request_from_chat(
                     request_id,
                     body,
                     processed_text,
                     token_ids,
+                    trtllm_mm,
                     tool_constraints,
                 )?;
                 Ok(ProtoGenerateRequest::Trtllm(Box::new(req)))

--- a/model_gateway/src/routers/grpc/harmony/stages/request_building.rs
+++ b/model_gateway/src/routers/grpc/harmony/stages/request_building.rs
@@ -201,6 +201,7 @@ impl PipelineStage for HarmonyRequestBuildingStage {
                                 body,
                                 placeholder_processed_text,
                                 prep.token_ids.clone(),
+                                None, // No multimodal in Harmony pipeline
                                 prep.tool_constraints.clone(),
                             )
                             .map_err(|e| {

--- a/model_gateway/src/routers/grpc/multimodal.rs
+++ b/model_gateway/src/routers/grpc/multimodal.rs
@@ -356,7 +356,7 @@ pub(crate) fn preprocess_for_sglang(
 ///
 /// vLLM handles image preprocessing and token expansion internally,
 /// so we only send the raw JPEG/PNG bytes.
-fn build_vllm_multimodal_data(images: &[Arc<ImageFrame>]) -> MultimodalData {
+fn build_raw_multimodal_data(images: &[Arc<ImageFrame>]) -> MultimodalData {
     MultimodalData {
         image_data: images
             .iter()
@@ -373,9 +373,8 @@ fn build_vllm_multimodal_data(images: &[Arc<ImageFrame>]) -> MultimodalData {
 /// Phase 2: Backend-specific multimodal processing.
 ///
 /// For SGLang: preprocesses images, expands placeholder tokens, builds full MultimodalData.
-/// For vLLM: extracts raw image bytes only, returns original token IDs unchanged.
-///
-/// TRT-LLM does not support multimodal — callers must reject it before calling this.
+/// For vLLM/TRT-LLM: extracts raw image bytes only, returns original token IDs unchanged.
+/// Both vLLM and TRT-LLM handle image preprocessing and token expansion internally.
 pub(crate) fn process_for_backend(
     images: &[Arc<ImageFrame>],
     is_sglang: bool,
@@ -396,7 +395,7 @@ pub(crate) fn process_for_backend(
         )?;
         Ok((output.expanded_token_ids, output.multimodal_data))
     } else {
-        Ok((token_ids, build_vllm_multimodal_data(images)))
+        Ok((token_ids, build_raw_multimodal_data(images)))
     }
 }
 

--- a/model_gateway/src/routers/grpc/proto_wrapper.rs
+++ b/model_gateway/src/routers/grpc/proto_wrapper.rs
@@ -97,6 +97,16 @@ impl MultimodalData {
             image_data: self.image_data,
         }
     }
+
+    /// Convert to TensorRT-LLM proto MultimodalInput, consuming self to avoid clones.
+    ///
+    /// Only sends raw image bytes — TRT-LLM's input processor handles hashing,
+    /// position tracking, and vision encoding server-side.
+    pub fn into_trtllm_proto(self) -> trtllm::MultimodalInput {
+        trtllm::MultimodalInput {
+            image_data: self.image_data,
+        }
+    }
 }
 
 // =====================


### PR DESCRIPTION
## Description

### Problem

The gRPC pipeline doesn't support multimodal (image) requests for the TensorRT-LLM backend. 

TRT-LLM's LLM API already supports VLM inference when given `prompt_token_ids` + `multi_modal_data`.

### Solution

Wire TensorRT-LLM multimodal support through the gRPC pipeline using the same approach as vLLM: send unexpanded token IDs + raw image bytes. TRT-LLM's input processor handles hashing, position tracking, and vision encoding server-side.

## Changes

- **Proto** (`grpc_client/proto/trtllm_service.proto`): Simplify `MultimodalInput` to carry only `repeated bytes image_data` — remove unused `multimodal_hashes`, `multimodal_positions`, `multimodal_lengths` fields
- **Proto wrapper** (`proto_wrapper.rs`): Add `into_trtllm_proto()` conversion method on `MultimodalData`
- **gRPC client** (`trtllm_service.rs`): Accept `multimodal_input: Option<proto::MultimodalInput>` in `build_generate_request_from_chat()` and wire it into the proto request
- **Client dispatch** (`client.rs`): Convert and pass multimodal data in the TRT-LLM branch
- **Harmony pipeline** (`harmony/stages/request_building.rs`): Pass `None` for the new multimodal param (Harmony doesn't support multimodal)
- **Doc comment** (`multimodal.rs`): Update `process_for_backend()` doc to reflect TRT-LLM now uses the vLLM (raw bytes) branch

## Test Plan

- E2E testing with TRT-LLM VLM model (e.g., Qwen2-VL) via chat completions with image content
- Verify non-multimodal TRT-LLM requests are unaffected (multimodal_input = None)
- Verify Harmony pipeline compiles and works (passes None for multimodal)

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Multimodal inputs now carry raw image bytes instead of separate client-side metadata.
  * Server now performs image hashing, position tracking, and vision encoding.
  * Client submission simplified for non-SGLang backends; unified image handling across backends.
  * Introduces a breaking change to the public multimodal request surface (compatibility impact).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->