### PR TITLE
ci(docker): use H200 runner for builds and add nightly GHCR workflow

### DIFF
--- a/.github/workflows/nightly-docker.yml
+++ b/.github/workflows/nightly-docker.yml
@@ -1,0 +1,50 @@
+name: Nightly Docker Build
+
+on:
+  schedule:
+    # 06:00 UTC daily — 2 hours before nightly benchmarks (08:00 UTC)
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: nightly-docker
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    name: Build nightly Docker image
+    if: github.repository == 'lightseekorg/smg'
+    runs-on: ["8-gpu-h200"]
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile
+          push: true
+          tags: ghcr.io/lightseekorg/smg:nightly
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -21,7 +21,7 @@ jobs:
   build-and-push:
     name: Build and push Docker image
     if: github.repository == 'lightseekorg/smg'
-    runs-on: ubuntu-latest
+    runs-on: ["8-gpu-h200"]
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## Summary

Use the H200 GPU runner for Docker builds (replacing single-core `ubuntu-latest`) and add a nightly build that publishes to GitHub Container Registry.

## What changed

- **`.github/workflows/release-docker.yml`**: Changed `runs-on` from `ubuntu-latest` to `["8-gpu-h200"]` for faster builds
- **`.github/workflows/nightly-docker.yml`** (new): Nightly Docker build at 06:00 UTC pushing to `ghcr.io/lightseekorg/smg:nightly`

## Why

The H200 runner is only used during nightly benchmarks (08:00 UTC), leaving it idle the rest of the time. Docker builds on `ubuntu-latest` are slow due to limited compute. Moving builds to H200 leverages its many cores for significantly faster builds.

The nightly GHCR image provides a daily snapshot without cluttering Docker Hub releases. Uses a single `:nightly` tag that gets overwritten each run to avoid storage accumulation.

## How

- Nightly scheduled at 06:00 UTC — 2 hours before benchmarks at 08:00 UTC to avoid runner contention
- Uses QEMU + buildx for multi-platform (linux/amd64, linux/arm64)
- GHA build cache (`type=gha`) for layer caching
- Concurrency group prevents overlapping runs
- `if: github.repository == 'lightseekorg/smg'` guard prevents fork execution
- `GITHUB_TOKEN` (built-in) with `packages: write` permission for GHCR — no extra secrets needed

## Test plan

- [ ] Trigger `workflow_dispatch` on nightly-docker workflow to verify GHCR push
- [ ] Trigger `workflow_dispatch` on release-docker workflow to verify H200 build
- [ ] Confirm no runner contention between nightly docker (06:00) and benchmarks (08:00)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Nightly Docker images are now automatically built and published daily.

* **Chores**
  * Updated Docker build infrastructure for improved performance and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->