### PR TITLE
fix(ci): install CUDA toolkit for SGLang JIT kernel compilation

### DIFF
--- a/scripts/ci_install_sglang.sh
+++ b/scripts/ci_install_sglang.sh
@@ -24,7 +24,7 @@ echo "Using uv version: $(uv --version)"
 CUDA_HOME="${CUDA_HOME:-/usr/local/cuda}"
 if [ ! -x "${CUDA_HOME}/bin/nvcc" ]; then
     echo "Installing CUDA toolkit (nvcc not found at ${CUDA_HOME}/bin/nvcc)..."
-    wget -qO /tmp/cuda-keyring.deb \
+    curl -fsSL -o /tmp/cuda-keyring.deb \
         https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb
     sudo dpkg -i /tmp/cuda-keyring.deb
     rm /tmp/cuda-keyring.deb


### PR DESCRIPTION
## Summary

SGLang 0.5.9 introduced JIT-compiled CUDA kernels (RoPE via `tvm_ffi`) that require `nvcc` at runtime. Our CI runners only have the CUDA driver but not the compiler toolkit, causing **all SGLang nightly jobs to fail** with `nvcc: not found` during CUDA graph capture.

Failing run: https://github.com/lightseekorg/smg/actions/runs/22298667170

## What changed

- **`scripts/ci_install_sglang.sh`**: Install `cuda-nvcc-12-9` and `cuda-cudart-dev-12-9` from NVIDIA's apt repo before installing SGLang
  - Idempotent: skips if `nvcc` already exists at `$CUDA_HOME/bin/nvcc`
  - Symlinks `/usr/local/cuda` → `/usr/local/cuda-12.9` if `CUDA_HOME` directory doesn't have a `bin/` yet
  - Runs before SGLang install so JIT cache warm-up works on first launch

## Why

- SGLang 0.5.8.post1 used pre-compiled kernels via `flashinfer-jit-cache` — no `nvcc` needed
- SGLang 0.5.9 added JIT compilation for RoPE kernels (`sglang/jit_kernel/rope.py`) which invokes `nvcc` via `tvm_ffi` at CUDA graph capture time
- Without `nvcc`, the scheduler crashes immediately after loading model weights:
  ```
  RuntimeError: ninja exited with status 127
  /bin/sh: 1: /usr/local/cuda/bin/nvcc: not found
  ```
- Last successful run (0.5.8.post1): https://github.com/lightseekorg/smg/actions/runs/22295067223

## Test plan

- [ ] Re-run nightly benchmark workflow and verify all SGLang jobs pass
- [ ] Verify `nvcc --version` output appears in CI logs
- [ ] Confirm vLLM jobs are unaffected (they don't use this script)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now automatically detects and installs the CUDA toolkit (nvcc) when absent, ensures the runtime path is correctly configured, and logs the nvcc version during initialization. This improves reliability of GPU-enabled builds and precedes other language/tooling setup steps to ensure a consistent build environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->