### PR TITLE
docs: standardize runtime ordering to SGLang, vLLM, TensorRT-LLM

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ High-performance model-routing gateway for large-scale LLM deployments. Centrali
 
 |                                 |                                                                                                                                                                  |
 |:--------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **🚀 Maximize GPU Utilization** | Cache-aware routing understands your inference engine's KV cache state—whether vLLM, SGLang, or TensorRT-LLM—to reuse prefixes and reduce redundant computation. |
-| **🔌 One API, Any Backend**     | Route to self-hosted models (vLLM, SGLang, TensorRT-LLM) or cloud providers (OpenAI, Anthropic, Gemini, Bedrock, and more) through a single unified endpoint.    |
+| **🚀 Maximize GPU Utilization** | Cache-aware routing understands your inference engine's KV cache state—whether SGLang, vLLM, or TensorRT-LLM—to reuse prefixes and reduce redundant computation. |
+| **🔌 One API, Any Backend**     | Route to self-hosted models (SGLang, vLLM, TensorRT-LLM) or cloud providers (OpenAI, Anthropic, Gemini, Bedrock, and more) through a single unified endpoint.    |
 | **⚡ Built for Speed**           | Native Rust with gRPC pipelines, sub-millisecond routing decisions, and zero-copy tokenization. Circuit breakers and automatic failover keep things running.     |
 | **🔒 Enterprise Control**       | Multi-tenant rate limiting with OIDC, WebAssembly plugins for custom logic, and a privacy boundary that keeps conversation history within your infrastructure.   |
 | **📊 Full Observability**       | 40+ Prometheus metrics, OpenTelemetry tracing, and structured JSON logs with request correlation—know exactly what's happening at every layer.                   |

--- a/docs/assets/images/architecture-animated.svg
+++ b/docs/assets/images/architecture-animated.svg
@@ -199,7 +199,7 @@
   <rect x="660" y="70" width="145" height="24" rx="10" fill="url(#greenGrad)"/>
   <rect x="660" y="82" width="145" height="12" fill="url(#greenGrad)"/>
   <text x="732" y="88" text-anchor="middle" class="label" font-size="10" fill="white">gRPC Workers</text>
-  <text x="732" y="110" text-anchor="middle" class="feature">vLLM / SGLang / TRT-LLM</text>
+  <text x="732" y="110" text-anchor="middle" class="feature">SGLang / vLLM / TRT-LLM</text>
   <text x="732" y="124" text-anchor="middle" class="feature">Raw Inference + PD</text>
   <text x="732" y="138" text-anchor="middle" class="feature">Max Performance</text>
 
@@ -208,7 +208,7 @@
   <rect x="660" y="170" width="145" height="24" rx="10" fill="url(#blueGrad)"/>
   <rect x="660" y="182" width="145" height="12" fill="url(#blueGrad)"/>
   <text x="732" y="188" text-anchor="middle" class="label" font-size="10" fill="white">HTTP Workers</text>
-  <text x="732" y="210" text-anchor="middle" class="feature">vLLM / SGLang / TRT-LLM</text>
+  <text x="732" y="210" text-anchor="middle" class="feature">SGLang / vLLM / TRT-LLM</text>
   <text x="732" y="224" text-anchor="middle" class="feature">OpenAI-Compatible</text>
 
   <!-- External APIs -->

--- a/docs/assets/images/concepts-overview.svg
+++ b/docs/assets/images/concepts-overview.svg
@@ -122,7 +122,7 @@
   <rect x="650" y="70" width="120" height="26" rx="10" fill="url(#co-greenGrad)"/>
   <rect x="650" y="88" width="120" height="8" fill="url(#co-greenGrad)"/>
   <text x="710" y="88" text-anchor="middle" class="co-label" font-size="10" fill="white">Workers</text>
-  <text x="710" y="110" text-anchor="middle" class="co-feature" fill="#e2e8f0">vLLM / SGLang</text>
+  <text x="710" y="110" text-anchor="middle" class="co-feature" fill="#e2e8f0">SGLang / vLLM</text>
   <text x="710" y="125" text-anchor="middle" class="co-feature">TensorRT-LLM</text>
 
   <!-- Cloud APIs box -->

--- a/docs/assets/images/mcp-architecture.svg
+++ b/docs/assets/images/mcp-architecture.svg
@@ -95,7 +95,7 @@
     <text x="72" y="150" text-anchor="middle" class="mcp-feature">Tool Call:</text>
     <text x="72" y="165" text-anchor="middle" class="mcp-code" fill="#a78bfa">web_search</text>
     <text x="72" y="180" text-anchor="middle" class="mcp-code" fill="#94a3b8">{"query": "..."}</text>
-    <text x="72" y="200" text-anchor="middle" class="mcp-feature" fill="#64748b">vLLM / SGLang</text>
+    <text x="72" y="200" text-anchor="middle" class="mcp-feature" fill="#64748b">SGLang / vLLM</text>
   </g>
 
   <!-- SMG Gateway Container -->

--- a/docs/assets/images/wasm-plugins.svg
+++ b/docs/assets/images/wasm-plugins.svg
@@ -158,7 +158,7 @@
   <rect x="630" y="150" width="85" height="26" rx="10" fill="url(#wp-greenGrad)"/>
   <rect x="630" y="168" width="85" height="8" fill="url(#wp-greenGrad)"/>
   <text x="672" y="169" text-anchor="middle" class="wp-label" font-size="10" fill="white">Worker</text>
-  <text x="672" y="195" text-anchor="middle" class="wp-feature">vLLM / SGLang</text>
+  <text x="672" y="195" text-anchor="middle" class="wp-feature">SGLang / vLLM</text>
   <text x="672" y="212" text-anchor="middle" class="wp-feature">LLM Inference</text>
   <text x="672" y="229" text-anchor="middle" class="wp-feature">KV Cache</text>
 

--- a/docs/concepts/architecture/overview.md
+++ b/docs/concepts/architecture/overview.md
@@ -216,7 +216,7 @@ The cache-aware policy optimizes for KV cache reuse:
 4. Otherwise, route to worker with most cache capacity
 5. Falls back to least-loaded when system is imbalanced
 
-This integrates with vLLM, SGLang, and TensorRT-LLM's native KV cache management.
+This integrates with SGLang, vLLM, and TensorRT-LLM's native KV cache management.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -107,7 +107,7 @@ Circuit breakers, automatic retries with exponential backoff, rate limiting, and
 
 **Gateway = Full Server**
 
-SMG handles everything: tokenization, chat templates, tool parsing, MCP loops, detokenization, and PD routing. Workers run raw inference on vLLM, SGLang, or TensorRT-LLM.
+SMG handles everything: tokenization, chat templates, tool parsing, MCP loops, detokenization, and PD routing. Workers run raw inference on SGLang, vLLM, or TensorRT-LLM.
 
 </div>
 
@@ -117,7 +117,7 @@ SMG handles everything: tokenization, chat templates, tool parsing, MCP loops, d
 
 **Gateway = Smart Proxy**
 
-SMG handles routing, load balancing, and failover. Workers run full OpenAI-compatible servers (vLLM, SGLang, TRT-LLM). Supports PD disaggregation.
+SMG handles routing, load balancing, and failover. Workers run full OpenAI-compatible servers (SGLang, vLLM, TRT-LLM). Supports PD disaggregation.
 
 </div>
 


### PR DESCRIPTION
## Summary

Standardize the listing order of supported runtimes across all documentation and diagrams to: **SGLang, vLLM, TensorRT-LLM**.

## What changed

- **README.md** — feature table (2 lines)
- **docs/index.md** — gRPC mode and HTTP mode descriptions (2 lines)
- **docs/concepts/architecture/overview.md** — KV cache integration note (1 line)
- **docs/assets/images/architecture-animated.svg** — gRPC and HTTP worker labels (2 lines)
- **docs/assets/images/concepts-overview.svg** — worker label (1 line)
- **docs/assets/images/mcp-architecture.svg** — worker label (1 line)
- **docs/assets/images/wasm-plugins.svg** — worker label (1 line)

All code-level references (error messages, detection logic, enum orderings) already use the correct order.

## Test plan

- [x] Verified no remaining `vLLM.*SGLang` listing-style references across the entire codebase
- [ ] Docs render correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated backend engine references in feature descriptions and architecture documentation for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->