### PR TITLE
chore(ci): remove pull request trigger from nightly benchmark workflow

### DIFF
--- a/.github/workflows/nightly-benchmark.yml
+++ b/.github/workflows/nightly-benchmark.yml
@@ -3,10 +3,6 @@ name: Nightly Benchmark
 on:
   schedule:
     - cron: '0 8 * * *'
-  pull_request:
-    paths:
-      - e2e_test/**
-      - .github/workflows/nightly-benchmark.yml
   workflow_dispatch:
     inputs:
       models:


### PR DESCRIPTION
## Description

### Problem
nightly benchmark workflow shouldn't be triggered by pr
<!-- What problem is this PR trying to solve? -->

### Solution

<!-- How does this PR solve the problem? -->

## Changes

<!-- - Describe your changes here. -->

## Test Plan

<!-- Provide a thorough reproducible test showing before and after behavior. -->

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow scheduling configuration for the nightly benchmark process. The workflow now runs only on scheduled intervals and manual triggers, removing automatic pull request-based execution to streamline continuous integration operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->