### PR TITLE
fix(e2e): respect workers_config in vLLM/TRT-LLM gRPC multi-worker setup

### DIFF
--- a/e2e_test/fixtures/setup_backend.py
+++ b/e2e_test/fixtures/setup_backend.py
@@ -494,8 +494,12 @@ def _setup_grpc_backend(
     try:
         if num_workers > 1:
             # Multi-worker: find existing gRPC workers, launch missing ones
+            # get_workers_by_type auto-acquires all returned workers
             all_existing = model_pool.get_workers_by_type(model_id, WorkerType.REGULAR)
             existing_grpc = [w for w in all_existing if w.mode == ConnectionMode.GRPC]
+
+            # Track all acquired workers immediately so they get cleaned up on failure
+            instances = list(existing_grpc)
 
             # Release workers we won't use (wrong mode)
             for w in all_existing:
@@ -525,13 +529,21 @@ def _setup_grpc_backend(
                     missing,
                 )
                 new_instances = model_pool.launch_workers(workers_to_launch, startup_timeout=300)
+
+                if not new_instances:
+                    pytest.fail(
+                        f"Failed to launch {runtime_label} gRPC workers: needed "
+                        f"{missing} workers but could not allocate GPUs"
+                    )
+
                 for inst in new_instances:
                     inst.acquire()
-                instances = existing_grpc + new_instances
+                    instances.append(inst)
 
-            if not instances:
+            if len(instances) < num_workers:
                 pytest.fail(
-                    f"Failed to get {num_workers} {runtime_label} gRPC workers for {model_id}"
+                    f"Failed to get {num_workers} {runtime_label} gRPC workers for {model_id} "
+                    f"(got {len(instances)})"
                 )
             worker_urls = [inst.worker_url for inst in instances]
             model_path = instances[0].model_path
@@ -579,7 +591,7 @@ def _setup_grpc_backend(
         "Setup %s gRPC backend: model=%s, workers=%d, gateway=%s, policy=%s",
         runtime_label,
         model_id,
-        num_workers,
+        len(instances),
         gateway.base_url,
         gateway_config["policy"],
     )


### PR DESCRIPTION
## Summary

- Fix `_setup_grpc_backend()` to actually read `workers_config["count"]` and launch the requested number of gRPC workers for vLLM and TRT-LLM multi-worker tests
- Single-worker path (count=1) is unchanged for backward compatibility

## What changed

- **`e2e_test/fixtures/setup_backend.py`**: Rewrote `_setup_grpc_backend()` to support multi-worker mode using the same pattern as `_setup_local_backend()` — `get_workers_by_type()` to find existing gRPC REGULAR workers, `launch_workers()` with `WorkerIdentity` for missing ones, proper cleanup of all instances

## Why

Nightly benchmark run showed HTTP winning every metric by 4-27% aggregate, with vLLM multi-worker gRPC TTFT p99 up to **24× worse** than HTTP. Investigation of gateway logs revealed the root cause: vLLM multi-worker tests had **4 HTTP workers but only 1 gRPC worker** behind the gateway.

`_setup_grpc_backend()` accepted `workers_config` as a parameter but never read it — it always called `model_pool.get_grpc_worker()` which returns exactly one worker. SGLang was unaffected because SGLang gRPC falls through to `_setup_local_backend()` which correctly handles multi-worker.

## How

- When `count > 1`: uses `get_workers_by_type(model_id, WorkerType.REGULAR)`, filters by `ConnectionMode.GRPC`, launches missing workers via `launch_workers()`, collects all worker URLs for the gateway
- When `count == 1`: preserves existing `get_grpc_worker()` path (no behavior change)
- Cleanup paths iterate over all instances instead of a single one
- Both vLLM and TRT-LLM are fixed since both route through `_setup_grpc_backend()` (line 125: `if is_vllm() or is_trtllm()`)

## Test plan

- [ ] Re-run nightly benchmarks and verify vLLM multi-worker gRPC tests now launch the correct number of workers (check gateway logs for worker count)
- [ ] Verify vLLM single-worker gRPC tests still work (unchanged code path)
- [ ] Verify SGLang tests are unaffected (different code path via `_setup_local_backend`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  - Added robust multi-worker support to backend test setup, allowing tests to acquire and reuse multiple worker instances.
  - Improved error handling and cleanup to reliably release acquired workers on failure.
  - Updated test logging and messages to report worker counts and clearly indicate when additional workers are launched.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->