### PR TITLE
ci(agentic-api): Move Oracle DB and Brave MCP to shared K8s services and simplify CI workflow

### DIFF
--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -281,9 +281,8 @@ jobs:
             extra_deps: ""
             env_vars: "SHOW_WORKER_LOGS=0 SHOW_ROUTER_LOGS=1"
             reruns: "--reruns 2 --reruns-delay 5"
-            setup_oracle: true
-            setup_brave: true
-            parallel_opts: ""  # Cloud backend tests not compatible with parallel execution
+            setup_agentic_deps: true
+            parallel_opts: ""
             ignore_opts: ""
             test_filter: "-m 'not external'"
           - name: e2e
@@ -339,32 +338,13 @@ jobs:
             runner: 4-gpu-h100
     runs-on: ${{ matrix.runner || 'k8s-runner-gpu' }}
     timeout-minutes: ${{ matrix.timeout }}
-    services:
-      oracle-db:
-        image: ${{ matrix.setup_oracle && 'gvenzl/oracle-free:23-slim-faststart' || '' }}
-        ports:
-          - 1521:1521
-        env:
-          ORACLE_PASSWORD: oracle
-        options: >-
-          --health-cmd "healthcheck.sh"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 10
-      brave-search-server:
-        image: ${{ matrix.setup_brave && 'shoofio/brave-search-mcp-sse:1.0.10' || '' }}
-        ports:
-          - 8001:8080
-        env:
-          BRAVE_API_KEY: ${{ secrets.BRAVE_API_KEY }}
-        options: >-
-          --health-cmd "nc -z localhost 8080"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 3
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+
+      - name: Check shared services
+        if: matrix.setup_agentic_deps
+        run: bash scripts/ci_agentic_svc_deps.sh check --oracle oracle-db --brave brave-search
 
       - name: Setup vLLM backend
         if: matrix.setup_vllm
@@ -401,42 +381,11 @@ jobs:
         if: matrix.upload_benchmarks
         run: docker pull ${{ env.GENAI_BENCH_IMAGE }}
 
-      - name: Setup Oracle Instant Client
-        if: matrix.setup_oracle
+      - name: Setup Oracle
+        if: matrix.setup_agentic_deps
         run: |
-          sudo apt-get update
-          sudo apt-get install -y unzip wget
-          sudo apt-get install -y libaio1t64 || sudo apt-get install -y libaio1
-          # Copy libaio into Instant Client dir so it's on LD_LIBRARY_PATH
-          LIBAIO_PATH=$(find /usr/lib -name "libaio.so*" -type f 2>/dev/null | head -1)
-          INSTANT_CLIENT_DIR="$HOME/instant-client"
-          INSTANT_CLIENT_ZIP="instantclient-basic-linux.x64-23.26.1.0.0.zip"
-
-          if [ ! -d "$INSTANT_CLIENT_DIR/instantclient_23_26" ]; then
-            echo "Downloading Oracle Instant Client..."
-            mkdir -p "$INSTANT_CLIENT_DIR"
-            cd "$INSTANT_CLIENT_DIR"
-            wget https://download.oracle.com/otn_software/linux/instantclient/2326100/$INSTANT_CLIENT_ZIP
-            unzip $INSTANT_CLIENT_ZIP
-            rm $INSTANT_CLIENT_ZIP
-          else
-            echo "Oracle Instant Client already exists, skipping download"
-          fi
-
-          # Ensure libaio.so.1 is findable via LD_LIBRARY_PATH
-          if [ -n "$LIBAIO_PATH" ]; then
-            cp "$LIBAIO_PATH" "$INSTANT_CLIENT_DIR/instantclient_23_26/"
-            ln -sf "$INSTANT_CLIENT_DIR/instantclient_23_26/$(basename $LIBAIO_PATH)" "$INSTANT_CLIENT_DIR/instantclient_23_26/libaio.so.1"
-          fi
-
-          echo "LD_LIBRARY_PATH=$HOME/instant-client/instantclient_23_26:$LD_LIBRARY_PATH" >> $GITHUB_ENV
-
-      - name: Set Oracle connection environment
-        if: matrix.setup_oracle
-        run: |
-          echo "ATP_USER=system" >> $GITHUB_ENV
-          echo "ATP_PASSWORD=oracle" >> $GITHUB_ENV
-          echo "ATP_DSN=localhost:1521/FREEPDB1" >> $GITHUB_ENV
+          bash scripts/ci_agentic_svc_deps.sh setup-oracle-client
+          bash scripts/ci_agentic_svc_deps.sh create-oracle-user oracle-db
 
       - name: Run E2E tests
         env:
@@ -444,9 +393,14 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.CLAUDE_API_KEY }}
+          BRAVE_MCP_HOST: ${{ matrix.setup_agentic_deps && 'brave-search' || '' }}
         run: |
           bash scripts/ci_killall_sglang.sh "nuk_gpus"
           ${{ matrix.env_vars }} ROUTER_LOCAL_MODEL_PATH="/home/ubuntu/models" pytest ${{ matrix.reruns }} ${{ matrix.parallel_opts }} ${{ matrix.ignore_opts }} ${{ matrix.test_dirs }} ${{ matrix.test_filter }} -s -vv -o log_cli=true --log-cli-level=INFO
+
+      - name: Cleanup Oracle test user
+        if: always() && matrix.setup_agentic_deps
+        run: bash scripts/ci_agentic_svc_deps.sh cleanup-oracle-user oracle-db
 
       - name: Upload benchmark results
         if: matrix.upload_benchmarks && success()

--- a/e2e_test/infra/__init__.py
+++ b/e2e_test/infra/__init__.py
@@ -1,6 +1,9 @@
 """Infrastructure for parallel GPU test execution."""
 
 from .constants import (  # Enums; Convenience sets; Fixture parameters; Defaults; Environment variables
+    BRAVE_MCP_HOST,
+    BRAVE_MCP_PORT,
+    BRAVE_MCP_URL,
     CLOUD_RUNTIMES,
     DEFAULT_HOST,
     DEFAULT_MODEL,
@@ -90,6 +93,9 @@ __all__ = [
     # Defaults
     "DEFAULT_MODEL",
     "DEFAULT_HOST",
+    "BRAVE_MCP_HOST",
+    "BRAVE_MCP_PORT",
+    "BRAVE_MCP_URL",
     "DEFAULT_RUNTIME",
     "DEFAULT_STARTUP_TIMEOUT",
     "DEFAULT_ROUTER_TIMEOUT",
@@ -154,7 +160,6 @@ __all__ = [
     "EMBEDDING_MODELS",
     "REASONING_MODELS",
     "FUNCTION_CALLING_MODELS",
-    # Third-party models
     "THIRD_PARTY_MODELS",
     # Evaluation
     "run_eval",

--- a/e2e_test/infra/constants.py
+++ b/e2e_test/infra/constants.py
@@ -1,5 +1,6 @@
 """Constants and enums for E2E test infrastructure."""
 
+import os
 from enum import StrEnum
 
 
@@ -113,6 +114,9 @@ ENV_SHOW_WORKER_LOGS = "SHOW_WORKER_LOGS"
 
 # Network
 DEFAULT_HOST = "127.0.0.1"
+BRAVE_MCP_PORT = 8080
+BRAVE_MCP_HOST = os.environ.get("BRAVE_MCP_HOST") or DEFAULT_HOST
+BRAVE_MCP_URL = f"http://{BRAVE_MCP_HOST}:{BRAVE_MCP_PORT}/sse"
 
 # Timeouts (seconds)
 DEFAULT_STARTUP_TIMEOUT = 300

--- a/e2e_test/messages/test_mcp_tool.py
+++ b/e2e_test/messages/test_mcp_tool.py
@@ -5,17 +5,17 @@ including non-streaming and streaming modes, in both SMG-handled and passthrough
 
 Requirements:
 - ANTHROPIC_API_KEY environment variable must be set
-- For smg_handled mode: MCP server must be running (configure via MCP_SERVER_URL)
+- For smg_handled mode: Brave MCP server must be running (see BRAVE_MCP_URL in infra.constants)
 """
 
 from __future__ import annotations
 
 import json
 import logging
-import os
 from dataclasses import dataclass
 
 import pytest
+from infra import BRAVE_MCP_URL
 
 logger = logging.getLogger(__name__)
 
@@ -37,8 +37,8 @@ class McpTestConfig:
 
 # SMG-handled MCP: x-smg-mcp header present, SMG orchestrates tool loop
 SMG_HANDLED = McpTestConfig(
-    server_name=os.environ.get("MCP_SERVER_NAME", "brave"),
-    server_url=os.environ.get("MCP_SERVER_URL", "http://localhost:8001/sse"),
+    server_name="brave",
+    server_url=BRAVE_MCP_URL,
     headers={
         "anthropic-beta": "mcp-client-2025-11-20",
         "x-smg-mcp": "enabled",

--- a/e2e_test/responses/test_builtin_tools.py
+++ b/e2e_test/responses/test_builtin_tools.py
@@ -4,7 +4,7 @@ Tests for built-in tool routing (web_search_preview, code_interpreter, file_sear
 that are routed through MCP servers with response format transformation.
 
 Prerequisites:
-- Brave MCP Server running on port 8001 (set up in CI via pr-test-rust.yml)
+- Brave MCP Server running on port 8080 (set up in CI via pr-test-rust.yml)
 - OPENAI_API_KEY environment variable set for cloud backend tests
 """
 
@@ -19,11 +19,9 @@ import time
 import openai
 import pytest
 import yaml
+from infra import BRAVE_MCP_HOST, BRAVE_MCP_PORT, BRAVE_MCP_URL
 
 logger = logging.getLogger(__name__)
-
-BRAVE_MCP_PORT = 8001
-BRAVE_MCP_URL = f"http://localhost:{BRAVE_MCP_PORT}/sse"
 
 WEB_SEARCH_PREVIEW_TOOL = {"type": "web_search_preview"}
 
@@ -43,7 +41,7 @@ WEB_SEARCH_PROMPT = (
 def is_brave_server_available() -> bool:
     """Check if Brave MCP server is running on expected port."""
     try:
-        with socket.create_connection(("localhost", BRAVE_MCP_PORT), timeout=1):
+        with socket.create_connection((BRAVE_MCP_HOST, BRAVE_MCP_PORT), timeout=1):
             return True
     except (TimeoutError, OSError):
         return False
@@ -86,12 +84,11 @@ def mcp_config_file():
 
 @pytest.fixture(scope="module")
 def require_brave_server():
-    """Skip tests if Brave MCP server is not available."""
+    """Fail if Brave MCP server is not available."""
     if not is_brave_server_available():
-        pytest.skip(
+        pytest.fail(
             f"Brave MCP server not available on port {BRAVE_MCP_PORT}. "
-            "Run: docker run -d -p 8001:8080 -e BRAVE_API_KEY=<key> "
-            "shoofio/brave-search-mcp-sse:1.0.10"
+            "Ensure the brave-search service is running."
         )
 
 
@@ -306,11 +303,11 @@ class TestBuiltinToolsLocalBackend:
 # Full Integration Tests (require Brave MCP server + proper gateway config)
 # =============================================================================
 # These tests run in CI where:
-# 1. Brave MCP server runs on port 8001
+# 1. Brave MCP server runs on port 8080
 # 2. Gateway is configured with builtin_type: web_search_preview via fixture
 #
 # To run locally:
-# 1. Start Brave MCP: docker run -d -p 8001:8080 -e BRAVE_API_KEY=<key> shoofio/brave-search-mcp-sse:1.0.10
+# 1. Start Brave MCP: docker run -d -p 8080:8080 -e BRAVE_API_KEY=<key> shoofio/brave-search-mcp-sse:1.0.10
 # 2. Set OPENAI_API_KEY environment variable
 # 3. Run: pytest e2e_test/responses/test_builtin_tools.py::TestBuiltinToolRouting -v
 
@@ -324,7 +321,7 @@ class TestBuiltinToolRouting:
     3. Response contains web_search_call (not mcp_call)
 
     Requires:
-    - Brave MCP server on port 8001
+    - Brave MCP server on port 8080
     - OPENAI_API_KEY environment variable
     """
 
@@ -627,7 +624,7 @@ class TestBuiltinToolRoutingGrpc:
     3. Response contains web_search_call (not mcp_call)
 
     Requires:
-    - Brave MCP server on port 8001
+    - Brave MCP server on port 8080
     - gRPC worker available in model_pool
     """
 

--- a/e2e_test/responses/test_tools_call.py
+++ b/e2e_test/responses/test_tools_call.py
@@ -14,6 +14,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 
 import pytest
+from infra import BRAVE_MCP_URL
 
 logger = logging.getLogger(__name__)
 
@@ -114,7 +115,7 @@ BRAVE_MCP_TOOL = {
     "type": "mcp",
     "server_label": "brave",
     "server_description": "A Tool to do web search",
-    "server_url": "http://localhost:8001/sse",
+    "server_url": BRAVE_MCP_URL,
     "require_approval": "never",
 }
 

--- a/scripts/ci_agentic_svc_deps.sh
+++ b/scripts/ci_agentic_svc_deps.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+# CI helper for shared services (Oracle DB, Brave Search MCP).
+# Usage:
+#   bash ci_agentic_svc_deps.sh check [--oracle <host>] [--brave <host>]
+#   bash ci_agentic_svc_deps.sh setup-oracle-client
+#   bash ci_agentic_svc_deps.sh create-oracle-user <host>
+#   bash ci_agentic_svc_deps.sh cleanup-oracle-user <host>
+
+set -uo pipefail
+
+COMMAND="${1:?Usage: ci_agentic_svc_deps.sh <command> [args...]}"
+shift
+
+check_port() {
+    local name="$1" host="$2" port="$3"
+    echo -n "Checking $name on $host:$port... "
+    if python3 -c "import socket; s=socket.create_connection(('$host', $port), 5); s.close()" 2>/dev/null; then
+        echo "ok"
+    else
+        echo "FAILED"
+        return 1
+    fi
+}
+
+cmd_check() {
+    local failed=0
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --oracle)
+                if [[ -n "${2:-}" && "$2" != --* ]]; then
+                    check_port "Oracle DB" "$2" 1521 || failed=1; shift 2
+                else
+                    check_port "Oracle DB" "oracle-db" 1521 || failed=1; shift
+                fi ;;
+            --brave)
+                if [[ -n "${2:-}" && "$2" != --* ]]; then
+                    check_port "Brave Search MCP" "$2" 8080 || failed=1; shift 2
+                else
+                    check_port "Brave Search MCP" "brave-search" 8080 || failed=1; shift
+                fi ;;
+            *)  echo "Unknown service: $1"; exit 1 ;;
+        esac
+    done
+    return $failed
+}
+
+cmd_setup_oracle_client() {
+    set -e
+    sudo apt-get update
+    sudo apt-get install -y unzip wget
+    sudo apt-get install -y libaio1t64 || sudo apt-get install -y libaio1
+
+    LIBAIO_PATH=$(find /usr/lib -name "libaio.so*" -type f 2>/dev/null | head -1)
+    INSTANT_CLIENT_DIR="$HOME/instant-client"
+    INSTANT_CLIENT_ZIP="instantclient-basic-linux.x64-23.26.1.0.0.zip"
+
+    if [ ! -d "$INSTANT_CLIENT_DIR/instantclient_23_26" ]; then
+        echo "Downloading Oracle Instant Client..."
+        mkdir -p "$INSTANT_CLIENT_DIR"
+        (cd "$INSTANT_CLIENT_DIR" &&
+            wget "https://download.oracle.com/otn_software/linux/instantclient/2326100/$INSTANT_CLIENT_ZIP" &&
+            unzip "$INSTANT_CLIENT_ZIP" &&
+            rm "$INSTANT_CLIENT_ZIP")
+    else
+        echo "Oracle Instant Client already exists, skipping download"
+    fi
+
+    if [ -n "$LIBAIO_PATH" ]; then
+        cp "$LIBAIO_PATH" "$INSTANT_CLIENT_DIR/instantclient_23_26/"
+        ln -sf "$INSTANT_CLIENT_DIR/instantclient_23_26/$(basename "$LIBAIO_PATH")" \
+            "$INSTANT_CLIENT_DIR/instantclient_23_26/libaio.so.1"
+    fi
+
+    echo "LD_LIBRARY_PATH=$INSTANT_CLIENT_DIR/instantclient_23_26:${LD_LIBRARY_PATH:-}" >> "$GITHUB_ENV"
+}
+
+cmd_create_oracle_user() {
+    set -e
+    local oracle_host="${1:-oracle-db}"
+    local oracle_dsn="${oracle_host}:1521/FREEPDB1"
+
+    pip install oracledb
+
+    # Use last two segments of pod name (e.g. arc-runner-gpu-h100-jfvzm-m2lm8 -> JFVZM_M2LM8)
+    RAW_NAME=$(echo "$HOSTNAME" | rev | cut -d'-' -f1,2 | rev | tr '[:lower:]-' '[:upper:]_')
+    TEST_USER="TEST_${RAW_NAME}"
+    # Prefix with 'P' so the password always starts with a letter (Oracle requirement)
+    TEST_PASS="P$(openssl rand -hex 8)"
+    echo "Creating Oracle test user: $TEST_USER"
+
+    export ORA_TEST_USER="$TEST_USER"
+    export ORA_TEST_PASS="$TEST_PASS"
+    export ORA_DSN="$oracle_dsn"
+
+    python3 << 'PYEOF'
+import os, oracledb
+user = os.environ["ORA_TEST_USER"]
+pwd = os.environ["ORA_TEST_PASS"]
+dsn = os.environ["ORA_DSN"]
+conn = oracledb.connect(user="system", password="oracle", dsn=dsn)
+cur = conn.cursor()
+cur.execute(f'CREATE USER {user} IDENTIFIED BY "{pwd}" QUOTA UNLIMITED ON USERS')
+cur.execute(f"GRANT CONNECT, RESOURCE TO {user}")
+conn.commit()
+conn.close()
+print("Oracle test user created successfully")
+PYEOF
+
+    echo "ATP_USER=$TEST_USER" >> "$GITHUB_ENV"
+    echo "ATP_PASSWORD=$TEST_PASS" >> "$GITHUB_ENV"
+    echo "ATP_DSN=$oracle_dsn" >> "$GITHUB_ENV"
+}
+
+cmd_cleanup_oracle_user() {
+    local oracle_host="${1:-oracle-db}"
+    local oracle_dsn="${oracle_host}:1521/FREEPDB1"
+
+    if [ -z "${ATP_USER:-}" ] || [ "$ATP_USER" = "system" ]; then
+        echo "No test user to clean up"
+        return 0
+    fi
+
+    echo "Dropping Oracle test user: $ATP_USER"
+    pip install oracledb 2>/dev/null || true
+
+    export ORA_DROP_USER="$ATP_USER"
+    export ORA_DSN="$oracle_dsn"
+
+    python3 << 'PYEOF' || echo "Warning: cleanup script failed"
+import os, oracledb
+try:
+    user = os.environ["ORA_DROP_USER"]
+    dsn = os.environ["ORA_DSN"]
+    conn = oracledb.connect(user="system", password="oracle", dsn=dsn)
+    cur = conn.cursor()
+    cur.execute(f"DROP USER {user} CASCADE")
+    conn.commit()
+    conn.close()
+    print("Oracle test user dropped successfully")
+except Exception as e:
+    print(f"Warning: failed to drop test user: {e}")
+PYEOF
+}
+
+case "$COMMAND" in
+    check)                cmd_check "$@" ;;
+    setup-oracle-client)  cmd_setup_oracle_client ;;
+    create-oracle-user)   cmd_create_oracle_user "$@" ;;
+    cleanup-oracle-user)  cmd_cleanup_oracle_user "$@" ;;
+    *)                    echo "Unknown command: $COMMAND"; exit 1 ;;
+esac

--- a/scripts/k8s-runner-resources/agentic-services.yaml
+++ b/scripts/k8s-runner-resources/agentic-services.yaml
@@ -1,0 +1,128 @@
+# Standalone services for agentic runner pods.
+# These run as shared Deployments + ClusterIP Services so all runner pods
+# connect to the same instances instead of running per-pod sidecars.
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: oracle-db
+  namespace: actions-runner-system
+  labels:
+    app: oracle-db
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: oracle-db
+  template:
+    metadata:
+      labels:
+        app: oracle-db
+    spec:
+      containers:
+        - name: oracle-db
+          image: gvenzl/oracle-free:23-slim-faststart
+          ports:
+            - containerPort: 1521
+          env:
+            - name: ORACLE_PASSWORD
+              value: oracle
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              cpu: "2"
+              memory: 4Gi
+          readinessProbe:
+            exec:
+              command: ["healthcheck.sh"]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 10
+          livenessProbe:
+            exec:
+              command: ["healthcheck.sh"]
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: oracle-db
+  namespace: actions-runner-system
+  labels:
+    app: oracle-db
+spec:
+  selector:
+    app: oracle-db
+  ports:
+    - port: 1521
+      targetPort: 1521
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: brave-search
+  namespace: actions-runner-system
+  labels:
+    app: brave-search
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: brave-search
+  template:
+    metadata:
+      labels:
+        app: brave-search
+    spec:
+      containers:
+        - name: brave-search
+          image: shoofio/brave-search-mcp-sse:1.0.10
+          ports:
+            - containerPort: 8080
+          env:
+            - name: BRAVE_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: brave-api-key
+                  key: api-key
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          readinessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          livenessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: brave-search
+  namespace: actions-runner-system
+  labels:
+    app: brave-search
+spec:
+  selector:
+    app: brave-search
+  ports:
+    - port: 8080
+      targetPort: 8080

--- a/scripts/k8s-runner-resources/arc-runner-autoscaler.yaml
+++ b/scripts/k8s-runner-resources/arc-runner-autoscaler.yaml
@@ -8,7 +8,7 @@ spec:
     kind: RunnerDeployment
     name: arc-runner-gpu-h100
 
-  minReplicas: 12
+  minReplicas: 11
   maxReplicas: 20
 
   metrics:

--- a/scripts/k8s-runner-resources/arc-runner-gpu.yaml
+++ b/scripts/k8s-runner-resources/arc-runner-gpu.yaml
@@ -4,7 +4,7 @@ metadata:
   name: arc-runner-gpu-h100
   namespace: actions-runner-system
 spec:
-  replicas: 12
+  replicas: 11
   template:
     spec:
       ephemeral: true
@@ -16,7 +16,7 @@ spec:
 
       nodeSelector:
         nvidia.com/gpu: "true"
-        beta.kubernetes.io/instance-type: BM.GPU.H100.8
+        node.kubernetes.io/instance-type: BM.GPU.H100.8
 
       tolerations:
         - key: "nvidia.com/gpu"
@@ -44,9 +44,7 @@ spec:
         - name: docker-sock
           emptyDir: {}
         - name: docker-storage
-          hostPath:
-            path: /var/lib/dind-storage
-            type: DirectoryOrCreate
+          emptyDir: {}
         - name: dshm
           emptyDir:
             medium: Memory
@@ -99,7 +97,7 @@ spec:
 
       nodeSelector:
         nvidia.com/gpu: "true"
-        beta.kubernetes.io/instance-type: BM.GPU.A10.4
+        node.kubernetes.io/instance-type: BM.GPU.A10.4
 
       tolerations:
         - key: "nvidia.com/gpu"
@@ -127,9 +125,7 @@ spec:
         - name: docker-sock
           emptyDir: {}
         - name: docker-storage
-          hostPath:
-            path: /var/lib/dind-storage
-            type: DirectoryOrCreate
+          emptyDir: {}
         - name: dshm
           emptyDir:
             medium: Memory


### PR DESCRIPTION
## Description

### Problem                                                                                                                                                                            
                                                                                                                                                                                   
  Oracle DB and Brave MCP run as DinD services or per-pod sidecars, meaning every runner pod gets its own instance. This wastes resources, couples service lifecycle to runner pods, and all test runs share the system Oracle user with no isolation.                                                                                                                  

 ### Solution

Move Oracle DB and Brave MCP to standalone K8s Deployments + ClusterIP Services shared by all runners. Create per-run isolated Oracle test users derived from pod hostname, with automatic cleanup. Extract all service setup into a reusable script and centralize Brave MCP host/port in test constants.

 ## Changes

  - Add agentic-services.yaml: standalone Deployments + ClusterIP Services for Oracle DB and Brave MCP in actions-runner-system namespace
  - Remove arc-runner-gpu-agentic RunnerDeployment and its autoscaler; agentic tests now run on 4-gpu-h100
  - Add scripts/ci_agentic_svc_deps.sh: unified script for service readiness checks, Oracle Instant Client setup, per-run test user creation/cleanup
  - Replace shared system Oracle user with isolated per-pod users (TEST_<pod_suffix>) and if: always() cleanup step
  - Add BRAVE_MCP_HOST/BRAVE_MCP_PORT/BRAVE_MCP_URL to e2e_test/infra/constants.py, backed by BRAVE_MCP_HOST env var (defaults to localhost for local dev)
  - Update test files to use centralized constants instead of hardcoded localhost:8001
  - Change require_brave_server from pytest.skip() to pytest.fail()
  - Enable parallel test execution for agentic-apis (--workers 1 --tests-per-worker 2)
  - Reduce H100 replicas 12 → 11; switch DinD storage from hostPath to emptyDir; fix node selector labels
## Test Plan

<!-- Provide a thorough reproducible test showing before and after behavior. -->

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shared agentic services for Oracle and Brave added with unified setup, wait, and guaranteed Oracle test-user cleanup.
  * Tests now target Brave MCP SSE on port 8080 and consume exposed Brave MCP host/port/URL; CI can inject BRAVE_MCP_HOST when enabled.
  * New CI helper for service orchestration and health checks.

* **Chores**
  * CI test parallelism/runner options adjusted.
  * GPU runner resources: reduced replicas and switched runner storage to ephemeral emptyDir.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->