### PR TITLE
feat(proto): add sglang encoder proto to smg-grpc-proto

### DIFF
--- a/grpc_client/proto/sglang_encoder.proto
+++ b/grpc_client/proto/sglang_encoder.proto
@@ -1,0 +1,91 @@
+syntax = "proto3";
+
+package sglang.grpc.encoder;
+
+// Service definition for SGLang encoder server communication
+// This protocol enables gRPC-based encoding for EPD (Encode-Prefill-Decode) mode
+service SglangEncoder {
+  // Encode multimodal items (images/videos/audio)
+  rpc Encode(EncodeRequest) returns (EncodeResponse);
+
+  // Send encoded embeddings to prefill server (for mooncake backend)
+  rpc Send(SendRequest) returns (SendResponse);
+
+  // Register scheduler receive URL (for zmq_to_scheduler backend)
+  rpc SchedulerReceiveUrl(SchedulerReceiveUrlRequest) returns (SchedulerReceiveUrlResponse);
+}
+
+// =====================
+// Encode Request/Response
+// =====================
+
+message EncodeRequest {
+  // List of multimodal item URLs (images, videos, audio)
+  repeated string mm_items = 1;
+
+  // Unique request identifier
+  string req_id = 2;
+
+  // Number of parts for distributed encoding
+  uint32 num_parts = 3;
+
+  // Current part index
+  uint32 part_idx = 4;
+
+  // Prefill server host for ZMQ transfer
+  string prefill_host = 5;
+
+  // Embedding ports for ZMQ transfer (multiple for distributed)
+  repeated uint32 embedding_port = 6;
+}
+
+message EncodeResponse {
+  // Size of embedding in bytes (for mooncake backend)
+  uint64 embedding_size = 1;
+
+  // Number of embedding vectors (sequence length)
+  uint64 embedding_len = 2;
+
+  // Dimension of each embedding vector
+  uint64 embedding_dim = 3;
+}
+
+// =====================
+// Send Request/Response (mooncake backend)
+// =====================
+
+message SendRequest {
+  // Request identifier
+  string req_id = 1;
+
+  // Prefill server host
+  string prefill_host = 2;
+
+  // Embedding port for ZMQ transfer
+  uint32 embedding_port = 3;
+
+  // Mooncake session ID
+  string session_id = 4;
+
+  // Mooncake buffer address for RDMA transfer
+  uint64 buffer_address = 5;
+}
+
+message SendResponse {}
+
+// =====================
+// Scheduler Receive URL (zmq_to_scheduler backend)
+// =====================
+
+message SchedulerReceiveUrlRequest {
+  // Request identifier
+  string req_id = 1;
+
+  // URL where scheduler expects to receive embeddings
+  string receive_url = 2;
+
+  // Expected number of receive endpoints
+  uint32 receive_count = 3;
+}
+
+message SchedulerReceiveUrlResponse {}

--- a/grpc_client/python/README.md
+++ b/grpc_client/python/README.md
@@ -7,6 +7,7 @@ Protocol Buffer definitions for [SMG](https://github.com/lightseekorg/smg) (Shep
 
 This package provides pre-compiled Python gRPC stubs for:
 - **SGLang** scheduler service (`sglang_scheduler.proto`)
+- **SGLang** encoder service (`sglang_encoder.proto`)
 - **vLLM** engine service (`vllm_engine.proto`)
 - **TensorRT-LLM** service (`trtllm_service.proto`)
 
@@ -22,6 +23,7 @@ Requires `grpcio>=1.78.0` and `protobuf>=5.26.0`.
 
 ```python
 from smg_grpc_proto import sglang_scheduler_pb2, sglang_scheduler_pb2_grpc
+from smg_grpc_proto import sglang_encoder_pb2, sglang_encoder_pb2_grpc
 from smg_grpc_proto import vllm_engine_pb2, vllm_engine_pb2_grpc
 from smg_grpc_proto import trtllm_service_pb2, trtllm_service_pb2_grpc
 ```

--- a/grpc_client/python/smg_grpc_proto/__init__.py
+++ b/grpc_client/python/smg_grpc_proto/__init__.py
@@ -6,6 +6,8 @@ __version__ = "0.4.1"
 # These imports will work after the package is built (stubs generated at build time)
 try:
     from smg_grpc_proto.generated import (
+        sglang_encoder_pb2,
+        sglang_encoder_pb2_grpc,
         sglang_scheduler_pb2,
         sglang_scheduler_pb2_grpc,
         trtllm_service_pb2,
@@ -17,6 +19,8 @@ try:
     __all__ = [
         "sglang_scheduler_pb2",
         "sglang_scheduler_pb2_grpc",
+        "sglang_encoder_pb2",
+        "sglang_encoder_pb2_grpc",
         "vllm_engine_pb2",
         "vllm_engine_pb2_grpc",
         "trtllm_service_pb2",


### PR DESCRIPTION
## Background

This change is part of [[model gateway][0/N] router EPD support: add encoder grpc server backend support (#16552)](https://github.com/sgl-project/sglang/pull/16552).

That PR adds gRPC encoder support in the SGLang runtime for EPD disaggregation, but after the scheduler protos moved to smg-grpc-proto, the encoder proto also needs to live here.


## Changes
  
  - Adds sglang_encoder.proto to smg-grpc-proto.
  - Exports encoder stubs in python/smg_grpc_proto/__init__.py.
  - Updates the Python README to document the encoder proto.
  - Bumps Python package version to 0.4.1.

## Test Plan

Not run (proto-only change)

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] (Optional) Documentation updated

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added encoder gRPC service for distributed multimodal encoding and processing workflows with support for distributed encoding and scheduler integration.

* **Documentation**
  * Updated Python gRPC client documentation with encoder service examples and usage patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->