### PR TITLE
ci: add PR title conventional commits check

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,0 +1,45 @@
+name: PR Title Check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+concurrency:
+  group: pr-title-check-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check-pr-title:
+    name: Conventional Commit Title
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Validate PR title format
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          REGEX='^(feat|fix|chore|docs|refactor|test|ci|perf|lint|style|revert|build)(\([a-z0-9_./-]+\))?!?: .+'
+
+          if [[ ! "$PR_TITLE" =~ $REGEX ]]; then
+            echo "::error::PR title does not follow conventional commits format."
+            echo ""
+            echo "Expected format:"
+            echo "  type(scope): description"
+            echo "  type: description"
+            echo ""
+            echo "Allowed types: feat, fix, chore, docs, refactor, test, ci, perf, lint, style, revert, build"
+            echo ""
+            echo "Examples:"
+            echo "  feat(auth): add OAuth2 support"
+            echo "  fix: resolve null pointer in parser"
+            echo "  refactor(grpc): simplify connection pooling"
+            echo "  perf: optimize JSON streaming validation"
+            echo "  feat!: breaking change"
+            echo "  feat(api)!: breaking change with scope"
+            echo ""
+            echo "Your title: '$PR_TITLE'"
+            exit 1
+          fi
+
+          echo "✅ PR title is valid: '$PR_TITLE'"


### PR DESCRIPTION
## Description

### Problem

PR titles that don't follow conventional commits format slip through and pollute the commit history (e.g., `fix parameters pass through for trtllm` instead of `fix: parameters pass through for trtllm`).

### Solution

Add a GitHub Actions workflow that validates PR titles against conventional commits format on open/edit/sync/reopen. Rejects titles missing the `type: ` or `type(scope): ` prefix with a clear error message showing expected format and examples.

## Changes

- Add `.github/workflows/pr-title-check.yml` — validates PR titles match `^(feat|fix|chore|docs|refactor|test|ci|perf|lint|style|revert|build)(\([a-z0-9_./-]+\))?: .+`

## Test Plan

Regex tested locally against 16 valid and 8 invalid PR titles (all existing recent commits pass, the offending `fix parameters pass through for trtllm` is correctly rejected).

> **Note:** After merging, add `Conventional Commit Title` as a required status check in branch protection rules.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated validation for pull request titles to enforce conventional commit–style formatting.
  * When a title is invalid, contributors receive clear guidance, examples, and an error that prevents merging until corrected.
  * When a title is valid, contributors receive a confirmation message indicating success.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->