### PR TITLE
fix(tokenizer): use Value::UNDEFINED for missing chat template params

### DIFF
--- a/tokenizer/src/chat_template.rs
+++ b/tokenizer/src/chat_template.rs
@@ -471,11 +471,20 @@ fn render_chat_template(
     // Convert messages to minijinja::Value (messages already processed by router)
     let minijinja_messages: Vec<Value> = messages.iter().map(Value::from_serialize).collect();
 
+    // Use Value::UNDEFINED for missing optional params so they are truly "undefined"
+    // in the template context, matching HuggingFace Python behavior. Many chat templates
+    // use `{% if tools is defined %}` guards — passing null (none) instead of undefined
+    // would bypass those guards since `none` IS defined, causing `tools | length` to fail.
+    let tools_value = params.tools.map_or(Value::UNDEFINED, Value::from_serialize);
+    let documents_value = params
+        .documents
+        .map_or(Value::UNDEFINED, Value::from_serialize);
+
     let base_context = context! {
         messages => &minijinja_messages,
         add_generation_prompt => params.add_generation_prompt,
-        tools => params.tools,
-        documents => params.documents,
+        tools => tools_value,
+        documents => documents_value,
     };
 
     // Merge with template_kwargs if provided


### PR DESCRIPTION
## Summary
- Fix chat template rendering failure for models (e.g. Nemotron) whose templates use `{% if tools is defined %}` guards
- When `tools`/`documents` are not provided, pass `Value::UNDEFINED` instead of `None` (which serializes as minijinja's `none`) to match HuggingFace Python behavior
- Previously `none` bypassed `is defined` guards (since `none` IS defined), causing `tools | length` to fail with "cannot calculate length of value of type none"

## Test plan
- [x] Verified fix against live Nemotron model (`nemotron-super-rl-021826`) on vLLM gRPC backend
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes clean
- [x] Full unit test suite passes (`cargo test --all-targets --all-features`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Treat optional template parameters (such as tools and documents) as truly undefined when absent, aligning template guard behavior with expected semantics. This prevents unintended value operations on missing inputs and improves stability of rendered outputs while preserving existing rendering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->