### PR TITLE
perf(e2e): reorder tests by model affinity to minimize GPU swaps

### DIFF
--- a/e2e_test/fixtures/hooks.py
+++ b/e2e_test/fixtures/hooks.py
@@ -38,7 +38,8 @@ _needs_default_model: bool = False
 # Track model affinity for each test item (nodeid -> model_id or None for cloud tests)
 _item_model_affinity: dict[str, str | None] = {}
 
-# Backends that require local GPU workers
+# Backends that require local GPU workers.
+# Matches ConnectionMode values (infra/constants.py) plus their pd_ prefixed variants.
 _LOCAL_BACKENDS = frozenset({"grpc", "http", "pd_grpc", "pd_http"})
 
 


### PR DESCRIPTION
## Description

### Problem
E2E tests take ~16 minutes, with a significant portion spent on GPU model swaps rather than actual testing. Tests alternate between models (`openai/gpt-oss-20b` for Harmony tests, `Qwen/Qwen2.5-14B-Instruct` for Local tests) across different files, causing repeated MRU eviction + relaunch cycles (~35–100s each). Both models require 2 GPUs (tp=2), but only GPUs 0–1 are available for swapping.

### Solution
Reorder tests at collection time to group them by GPU model affinity — cloud tests first, then all tests for each model contiguously — reducing model swaps from ~7 to 1 and bringing E2E time from ~16 min down to ~12 min.

## How it works

```
 BEFORE (default pytest collection order)
 ─────────────────────────────────────────────────────────────
  cloud │ModelA │ ModelB │ ModelA │ ModelB │ ModelA │ ModelB │ ...
        ↑swap    ↑swap    ↑swap    ↑swap    ↑swap    ↑swap    ↑swap
                         7 model swaps ≈ 4+ min wasted


 AFTER (reordered by model affinity)
 ─────────────────────────────────────────────────────────────
  cloud tests        │ all ModelA tests     │ all ModelB tests
  (no GPU needed)    │ (contiguous)         │ (contiguous)
                     ↑ load ModelA          ↑ 1 swap to ModelB

                         1 model swap ≈ 35–100s
```

The reordering happens in `pytest_collection_modifyitems()`:

1. During the existing marker scan, each test's **model affinity** is recorded — the GPU model it needs, or `None` for cloud-only tests
2. After scanning, `_reorder_to_minimize_model_swaps()` groups tests:
   - **Cloud tests** (affinity=None) run first — no GPU model needed
   - **Per-model groups** run contiguously, in first-appearance order
   - **Within each group**, original collection order is preserved
3. Test semantics are unchanged — only execution order changes

## Changes
- `e2e_test/fixtures/hooks.py`: Added `_item_model_affinity` dict and `_LOCAL_BACKENDS` frozenset to track each test's GPU model requirement. Populated affinity during the existing marker scan loop. Added `_reorder_to_minimize_model_swaps()` function that groups tests by model affinity (cloud first, then per-model). Updated `reset_collection_state()` to clear the new dict.

## Test plan
- [ ] Run full E2E suite — all tests pass with no functional change
- [ ] Verify log shows `Reordered tests to minimize model swaps: cloud=N, ModelA=N, ModelB=N`
- [ ] Confirm cloud tests execute before any local GPU tests
- [ ] Observe reduced model swap count in model_pool logs


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Tests now track per-test model affinity to distinguish local GPU runs from cloud runs.
  * Collection resets this affinity between runs to avoid stale assignments.
  * Collected tests are reordered to run cloud tests first, then contiguous groups per model (preserving within-group order) to reduce model switching and improve test-suite performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->