### PR TITLE
feat(proto): add SubscribeKvEvents RPC and KV cache event messages

### DIFF
--- a/grpc_client/proto/common.proto
+++ b/grpc_client/proto/common.proto
@@ -11,3 +11,48 @@ message GetTokenizerChunk {
   bytes data = 1;       // Raw zip bytes (concatenate all chunks)
   string sha256 = 2;    // SHA-256 fingerprint; set on final chunk only, empty on previous
 }
+
+// =====================
+// KV Cache Events
+// =====================
+
+message SubscribeKvEventsRequest {
+  // Resume from this sequence number (0 = start from current state).
+  uint64 start_sequence_number = 1;
+}
+
+message KvEventBatch {
+  uint64 sequence_number = 1;
+  double timestamp = 2;
+  repeated KvCacheEvent events = 3;
+  optional int32 dp_rank = 4;
+}
+
+message KvCacheEvent {
+  uint64 event_id = 1;
+  oneof data {
+    KvBlocksStored stored = 2;
+    KvBlocksRemoved removed = 3;
+    KvCacheCleared cleared = 4;
+  }
+}
+
+message KvBlocksStored {
+  repeated KvBlock blocks = 1;
+  optional int64 parent_block_hash = 2;
+}
+
+message KvBlock {
+  int64 block_hash = 1;
+  repeated uint32 token_ids = 2;
+  int32 block_size = 3;
+  optional int64 lora_id = 4;
+  optional int32 cache_level = 5;
+}
+
+message KvBlocksRemoved {
+  repeated int64 block_hashes = 1;
+  optional int32 cache_level = 2;
+}
+
+message KvCacheCleared {}

--- a/grpc_client/proto/sglang_scheduler.proto
+++ b/grpc_client/proto/sglang_scheduler.proto
@@ -33,6 +33,9 @@ service SglangScheduler {
   // Get tokenizer artifacts for remote construction
   rpc GetTokenizer(smg.grpc.common.GetTokenizerRequest) returns (stream smg.grpc.common.GetTokenizerChunk);
 
+  // Subscribe to KV cache events (server-streaming)
+  rpc SubscribeKvEvents(smg.grpc.common.SubscribeKvEventsRequest)
+      returns (stream smg.grpc.common.KvEventBatch);
 }
 
 // =====================

--- a/grpc_client/proto/trtllm_service.proto
+++ b/grpc_client/proto/trtllm_service.proto
@@ -51,6 +51,10 @@ service TrtllmService {
 
   // Get tokenizer artifacts for remote construction
   rpc GetTokenizer(smg.grpc.common.GetTokenizerRequest) returns (stream smg.grpc.common.GetTokenizerChunk);
+
+  // Subscribe to KV cache events (server-streaming)
+  rpc SubscribeKvEvents(smg.grpc.common.SubscribeKvEventsRequest)
+      returns (stream smg.grpc.common.KvEventBatch);
 }
 
 // ============================================================================

--- a/grpc_client/proto/vllm_engine.proto
+++ b/grpc_client/proto/vllm_engine.proto
@@ -28,6 +28,10 @@ service VllmEngine {
 
   // Get tokenizer artifacts for remote construction
   rpc GetTokenizer(smg.grpc.common.GetTokenizerRequest) returns (stream smg.grpc.common.GetTokenizerChunk);
+
+  // Subscribe to KV cache events (server-streaming)
+  rpc SubscribeKvEvents(smg.grpc.common.SubscribeKvEventsRequest)
+      returns (stream smg.grpc.common.KvEventBatch);
 }
 
 // =====================


### PR DESCRIPTION
## Summary

- Add KV cache event message types to `common.proto` (SubscribeKvEventsRequest, KvEventBatch, KvCacheEvent, KvBlocksStored, KvBlock, KvBlocksRemoved, KvCacheCleared)
- Add `SubscribeKvEvents` server-streaming RPC to all three backend service protos (sglang, vllm, trtllm)
- Part of the KV cache event-driven routing feature (Task 1 of 9)

## What changed

| File | Change |
|------|--------|
| `grpc_client/proto/common.proto` | Added 7 new message types for KV cache events |
| `grpc_client/proto/sglang_scheduler.proto` | Added `SubscribeKvEvents` RPC to `SglangScheduler` service |
| `grpc_client/proto/vllm_engine.proto` | Added `SubscribeKvEvents` RPC to `VllmEngine` service |
| `grpc_client/proto/trtllm_service.proto` | Added `SubscribeKvEvents` RPC to `TrtllmService` service |

## Why

This is the proto foundation for event-driven cache-aware routing. Instead of the router guessing which worker has cached KV blocks (approximate radix tree), backends will stream real-time KV cache events to the gateway via this new RPC. The gateway can then route requests to workers with the highest actual cache overlap.

## How

- All event types are defined in `common.proto` to be shared across backends
- Each service proto references them via `smg.grpc.common.*` (consistent with existing `GetTokenizer` pattern)
- `KvEventBatch` includes `sequence_number` for gap detection and replay
- `KvCacheEvent` uses `oneof` for stored/removed/cleared variants
- `KvBlock` includes `block_hash` (position-aware, backend-computed), `token_ids`, and optional `lora_id`/`cache_level`
- `KvBlocksStored` includes `parent_block_hash` for extending previously stored sequences

## Test plan

- [x] `cargo build -p smg-grpc-client` compiles successfully with new proto types
- No runtime tests needed — proto-only change, backend Python implementation is a separate step

Refs: `.claude/kv-event/DESIGN.md` Section 5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added KV cache event streaming capability with resumable sequence tracking across gRPC services.
  * New subscription endpoints enable real-time monitoring of cache block operations, removals, and clearing events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->