### PR TITLE
feat(grpc): add subscribe_kv_events to all backend clients

### DIFF
--- a/grpc_client/src/lib.rs
+++ b/grpc_client/src/lib.rs
@@ -48,6 +48,33 @@ macro_rules! impl_get_tokenizer {
 }
 pub(crate) use impl_get_tokenizer;
 
+/// Shared `subscribe_kv_events()` implementation for all engine clients.
+///
+/// Each engine's generated proto client has a `subscribe_kv_events` RPC method
+/// with identical signature (using common proto types). This macro provides
+/// the wrapper that returns a `tonic::Streaming<KvEventBatch>`.
+macro_rules! impl_subscribe_kv_events {
+    () => {
+        /// Subscribe to KV cache events from the backend.
+        /// Returns a long-lived server-streaming response.
+        pub async fn subscribe_kv_events(
+            &self,
+            start_sequence_number: u64,
+        ) -> Result<
+            tonic::Streaming<$crate::common_proto::KvEventBatch>,
+            Box<dyn std::error::Error + Send + Sync>,
+        > {
+            let request = tonic::Request::new($crate::common_proto::SubscribeKvEventsRequest {
+                start_sequence_number,
+            });
+            let mut client = self.client.clone();
+            let response = client.subscribe_kv_events(request).await?;
+            Ok(response.into_inner())
+        }
+    };
+}
+pub(crate) use impl_subscribe_kv_events;
+
 /// Trait for injecting trace context into gRPC metadata.
 ///
 /// Implement this trait to enable distributed tracing across gRPC calls.

--- a/grpc_client/src/sglang_scheduler.rs
+++ b/grpc_client/src/sglang_scheduler.rs
@@ -303,6 +303,7 @@ impl SglangSchedulerClient {
     }
 
     crate::impl_get_tokenizer!();
+    crate::impl_subscribe_kv_events!();
 
     /// Build a single SGLang EmbedRequest
     #[expect(

--- a/grpc_client/src/trtllm_service.rs
+++ b/grpc_client/src/trtllm_service.rs
@@ -259,6 +259,7 @@ impl TrtllmServiceClient {
     }
 
     crate::impl_get_tokenizer!();
+    crate::impl_subscribe_kv_events!();
 
     /// Build a TensorRT-LLM GenerateRequest from OpenAI ChatCompletionRequest
     #[expect(

--- a/grpc_client/src/vllm_engine.rs
+++ b/grpc_client/src/vllm_engine.rs
@@ -260,6 +260,7 @@ impl VllmEngineClient {
     }
 
     crate::impl_get_tokenizer!();
+    crate::impl_subscribe_kv_events!();
 
     /// Build a single vLLM GenerateRequest from OpenAI ChatCompletionRequest
     #[expect(

--- a/model_gateway/src/routers/grpc/client.rs
+++ b/model_gateway/src/routers/grpc/client.rs
@@ -175,6 +175,21 @@ impl GrpcClient {
         }
     }
 
+    /// Subscribe to KV cache events (all backends).
+    pub async fn subscribe_kv_events(
+        &self,
+        start_seq: u64,
+    ) -> Result<
+        tonic::Streaming<smg_grpc_client::common_proto::KvEventBatch>,
+        Box<dyn std::error::Error + Send + Sync>,
+    > {
+        match self {
+            Self::Sglang(client) => client.subscribe_kv_events(start_seq).await,
+            Self::Vllm(client) => client.subscribe_kv_events(start_seq).await,
+            Self::Trtllm(client) => client.subscribe_kv_events(start_seq).await,
+        }
+    }
+
     pub async fn get_server_info(
         &self,
     ) -> Result<ServerInfo, Box<dyn std::error::Error + Send + Sync>> {


### PR DESCRIPTION
## Summary

- Add `impl_subscribe_kv_events!()` shared macro for KV event subscription across all three backend clients
- Add unified `subscribe_kv_events()` to `GrpcClient` enum for backend-agnostic usage
- Part of KV cache event-driven routing (Task 2 of 9)

## What changed

| File | Change |
|------|--------|
| `grpc_client/src/lib.rs` | New `impl_subscribe_kv_events!()` macro (follows `impl_get_tokenizer!()` pattern) |
| `grpc_client/src/sglang_scheduler.rs` | Invoke macro to add `subscribe_kv_events()` method |
| `grpc_client/src/vllm_engine.rs` | Invoke macro to add `subscribe_kv_events()` method |
| `grpc_client/src/trtllm_service.rs` | Invoke macro to add `subscribe_kv_events()` method |
| `model_gateway/src/routers/grpc/client.rs` | Unified `subscribe_kv_events()` on `GrpcClient` enum |

## Why

The gateway needs to subscribe to real-time KV cache events from backends for event-driven cache-aware routing. All three backends expose the same `SubscribeKvEvents` RPC (added in #557), so a shared macro eliminates duplication — same pattern as the existing `impl_get_tokenizer!()`.

## How

- Macro in `lib.rs` generates a `subscribe_kv_events(start_sequence_number) -> Result<Streaming<KvEventBatch>>` method
- Each backend client invokes the macro inside its `impl` block
- `GrpcClient::subscribe_kv_events()` dispatches to the correct backend variant
- Uses `$crate::common_proto::*` types for the request/response (shared proto types)

## Test plan

- [x] `cargo build -p smg-grpc-client` compiles
- [x] `cargo build -p smg` compiles
- No runtime tests — requires a live backend with the SubscribeKvEvents RPC implemented

Refs: `.claude/kv-event/DESIGN.md` Section 7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added KV cache event subscription allowing clients to stream KV events from all supported inference engines.
  * Unified client API to subscribe starting from a specified sequence number, providing consistent access to KV event streams across backends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->