### PR TITLE
feat(discovery): add --model-id-from flag for per-worker model_id customization

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -390,6 +390,7 @@ struct Router {
     prefill_selector: HashMap<String, String>,
     decode_selector: HashMap<String, String>,
     bootstrap_port_annotation: String,
+    model_id_from: Option<String>,
     prometheus_port: Option<u16>,
     prometheus_host: Option<String>,
     prometheus_duration_buckets: Option<Vec<f64>>,
@@ -557,7 +558,7 @@ impl Router {
                 bootstrap_port_annotation: self.bootstrap_port_annotation.clone(),
                 router_selector: HashMap::new(),
                 router_mesh_port_annotation: "sglang.ai/mesh-port".to_string(),
-                model_id_source: None,
+                model_id_source: self.model_id_from.clone(),
             })
         } else {
             None
@@ -715,6 +716,7 @@ impl Router {
         prefill_selector = HashMap::new(),
         decode_selector = HashMap::new(),
         bootstrap_port_annotation = String::from("sglang.ai/bootstrap-port"),
+        model_id_from = None,
         prometheus_port = None,
         prometheus_host = None,
         prometheus_duration_buckets = None,
@@ -808,6 +810,7 @@ impl Router {
         prefill_selector: HashMap<String, String>,
         decode_selector: HashMap<String, String>,
         bootstrap_port_annotation: String,
+        model_id_from: Option<String>,
         prometheus_port: Option<u16>,
         prometheus_host: Option<String>,
         prometheus_duration_buckets: Option<Vec<f64>>,
@@ -910,6 +913,7 @@ impl Router {
             prefill_selector,
             decode_selector,
             bootstrap_port_annotation,
+            model_id_from,
             prometheus_port,
             prometheus_host,
             prometheus_duration_buckets,
@@ -984,6 +988,18 @@ impl Router {
             pyo3::exceptions::PyValueError::new_err(format!("Configuration validation failed: {e}"))
         })?;
 
+        let model_id_source = self
+            .model_id_from
+            .as_deref()
+            .map(|s| {
+                service_discovery::ModelIdSource::parse(s).map_err(|e| {
+                    pyo3::exceptions::PyValueError::new_err(format!(
+                        "Invalid --model-id-from value '{s}': {e}"
+                    ))
+                })
+            })
+            .transpose()?;
+
         let service_discovery_config = if self.service_discovery {
             Some(service_discovery::ServiceDiscoveryConfig {
                 enabled: true,
@@ -997,7 +1013,7 @@ impl Router {
                 bootstrap_port_annotation: self.bootstrap_port_annotation.clone(),
                 router_selector: HashMap::new(),
                 router_mesh_port_annotation: "sglang.ai/mesh-port".to_string(),
-                model_id_source: None,
+                model_id_source,
             })
         } else {
             None

--- a/bindings/python/src/smg/router_args.py
+++ b/bindings/python/src/smg/router_args.py
@@ -55,6 +55,7 @@ class RouterArgs:
     prefill_selector: dict[str, str] = dataclasses.field(default_factory=dict)
     decode_selector: dict[str, str] = dataclasses.field(default_factory=dict)
     bootstrap_port_annotation: str = "sglang.ai/bootstrap-port"
+    model_id_from: str | None = None
     # Prometheus configuration
     prometheus_port: int | None = None
     prometheus_host: str | None = None
@@ -477,6 +478,16 @@ class RouterArgs:
             default={},
             help=(
                 "Label selector for decode server pods in PD mode (format: key1=value1 key2=value2)"
+            ),
+        )
+        k8s_group.add_argument(
+            f"--{prefix}model-id-from",
+            type=str,
+            default=None,
+            help=(
+                "Override each worker's model ID from pod metadata."
+                " Accepted values: 'namespace', 'label:<key>', 'annotation:<key>'."
+                " The backend-discovered model name becomes an alias."
             ),
         )
         # Prometheus configuration

--- a/model_gateway/src/core/steps/worker/local/create_worker.rs
+++ b/model_gateway/src/core/steps/worker/local/create_worker.rs
@@ -64,19 +64,7 @@ impl StepExecutor<LocalWorkerWorkflowData> for CreateLocalWorkerStep {
             .or_else(|| labels.get("model_path").cloned())
             .unwrap_or_else(|| UNKNOWN_MODEL_ID.to_string());
 
-        let mut model_card = build_model_card(&model_id, config, &labels);
-
-        // Per-worker override from pod metadata (--model-id-from).
-        // Replaces the primary model ID; the backend-discovered name becomes an alias.
-        if let Some(ref override_id) = config.model_id_override {
-            if !override_id.is_empty() && *override_id != model_id {
-                if model_id != UNKNOWN_MODEL_ID {
-                    model_card.aliases.push(model_id.clone());
-                    model_card.aliases.retain(|a| a != override_id);
-                }
-                model_card.id.clone_from(override_id);
-            }
-        }
+        let model_card = build_model_card(&model_id, config, &labels);
 
         let runtime_type = match context.data.detected_runtime_type.as_deref() {
             Some(s) => s.parse::<RuntimeType>().unwrap_or(config.runtime_type),

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -1096,7 +1096,7 @@ impl CliArgs {
         builder.build()
     }
 
-    fn to_server_config(&self, router_config: RouterConfig) -> ServerConfig {
+    fn to_server_config(&self, router_config: RouterConfig) -> ConfigResult<ServerConfig> {
         let service_discovery_config = if self.service_discovery {
             // Get router discovery config from router_config.discovery if available
             let (router_selector, router_mesh_port_annotation) = router_config
@@ -1119,7 +1119,14 @@ impl CliArgs {
                         .as_ref()
                         .and_then(|d| d.model_id_source.as_deref())
                 })
-                .and_then(|s| ModelIdSource::parse(s).ok());
+                .map(|s| {
+                    ModelIdSource::parse(s).map_err(|e| ConfigError::InvalidValue {
+                        field: "model_id_source".to_string(),
+                        value: s.to_string(),
+                        reason: e,
+                    })
+                })
+                .transpose()?;
 
             Some(ServiceDiscoveryConfig {
                 enabled: true,
@@ -1192,7 +1199,7 @@ impl CliArgs {
             None
         };
 
-        ServerConfig {
+        Ok(ServerConfig {
             host: self.host.clone(),
             port: self.port,
             router_config,
@@ -1211,7 +1218,7 @@ impl CliArgs {
             shutdown_grace_period_secs: self.shutdown_grace_period_secs,
             control_plane_auth,
             mesh_server_config,
-        }
+        })
     }
 }
 
@@ -1296,7 +1303,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let router_config = cli_args.to_router_config(prefill_urls)?;
     router_config.validate()?;
 
-    let server_config = cli_args.to_server_config(router_config);
+    let server_config = cli_args.to_server_config(router_config)?;
     let runtime = tokio::runtime::Runtime::new()?;
     runtime.block_on(async move { server::startup(server_config).await })?;
     if is_otel_enabled() {

--- a/model_gateway/src/service_discovery.rs
+++ b/model_gateway/src/service_discovery.rs
@@ -525,8 +525,13 @@ async fn handle_pod_event(
             let mut spec = WorkerSpec::new(worker_url.clone());
             spec.worker_type = worker_type;
             spec.bootstrap_port = bootstrap_port;
-            spec.model_id_override
-                .clone_from(&pod_info.model_id_override);
+            // Inject pod-metadata model_id as a label so the existing
+            // resolution chain in create_worker.rs picks it up at
+            // priority #2 (served_model_name).
+            if let Some(ref override_id) = pod_info.model_id_override {
+                spec.labels
+                    .insert("served_model_name".to_string(), override_id.clone());
+            }
             spec.api_key.clone_from(&app_context.router_config.api_key);
             // Health config is resolved at worker build time from router
             // defaults + per-worker overrides (spec.health).

--- a/protocols/src/worker.rs
+++ b/protocols/src/worker.rs
@@ -494,12 +494,6 @@ pub struct WorkerSpec {
     /// Falls back to the global `load_monitor_interval_secs` from router config.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub load_monitor_interval_secs: Option<u64>,
-
-    /// Per-worker model_id override from pod metadata (e.g., namespace).
-    /// When set during service discovery, this becomes the primary model ID
-    /// and the backend-discovered name becomes an alias.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub model_id_override: Option<String>,
 }
 
 impl WorkerSpec {
@@ -526,7 +520,6 @@ impl WorkerSpec {
             health: HealthCheckUpdate::default(),
             max_connection_attempts: default_max_connection_attempts(),
             load_monitor_interval_secs: None,
-            model_id_override: None,
         }
     }
 }


### PR DESCRIPTION
## Description

### Problem
https://github.com/lightseekorg/smg/issues/549

When using Kubernetes service discovery, each worker's model_id is auto-resolved from the backend's metadata (e.g., /server_info). There is no way to override this per-worker. In namespace-scoped deployments, users want clients to route by namespace (e.g., "model": "team-a-serving") instead of internal model paths like /models/llama-3.1-70b.

### Solution

Add a --model-id-from CLI flag that reads a value from pod metadata (namespace, label, or annotation) and uses it as the worker's model_id. The backend-discovered model_id becomes an alias so both names continue to route correctly. This chains with the existing --served-model-name flag.

## Changes

- protocols/src/worker.rs — Add `model_id_override`: Option<String> field to WorkerSpec (with serde backward-compat attributes)
- model_gateway/src/service_discovery.rs — Add `ModelIdSource` enum (Namespace, Label(key), Annotation(key)) with parse() and extract() methods; add model_id_source to ServiceDiscoveryConfig; add model_id_override to PodInfo; wire override through handle_pod_event()
- model_gateway/src/core/steps/worker/local/create_worker.rs — Apply per-worker override before router-level served_model_name, using current_model_id to chain both stages correctly
- model_gateway/src/config/types.rs — Add `model_id_source`: Option<String> to DiscoveryConfig
- model_gateway/src/main.rs — Add `--model-id-from` CLI arg with value_parser validation; wire into both to_router_config() and to_server_config()
- bindings/python/src/lib.rs — Add model_id_source: None to struct literals for compatibility

## Test Plan

Use pod namespace as model_id
`smg --model-id-from namespace --selector app=serving`

Use a pod label value
`smg --model-id-from label:ome.io/inferenceservice --selector app=serving`

Use a pod annotation value
`smg --model-id-from annotation:ome.io/base-model-name --selector app=serving`

Added unit tests

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] (Optional) Documentation updated

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-worker model ID overrides for Kubernetes service discovery, deriving model IDs from pod namespace, labels, or annotations.
  * New CLI option to select the pod metadata source for deriving per-worker model ID overrides, with validation.
  * Service discovery and worker registration now propagate per-worker overrides when configured; defaults remain unset.
* **Tests**
  * Expanded tests covering parsing, extraction, and propagation of override sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->