### PR TITLE
fix(openai): read lazily discovered models in /v1/models endpoint

### DIFF
--- a/model_gateway/src/core/worker.rs
+++ b/model_gateway/src/core/worker.rs
@@ -640,10 +640,12 @@ impl Worker for BasicWorker {
 
     fn models(&self) -> Vec<ModelCard> {
         let overridden = self.models_override.load();
-        if !overridden.is_wildcard() {
-            return overridden.all().to_vec();
-        }
-        self.metadata.spec.models.all().to_vec()
+        let source = if overridden.is_wildcard() {
+            self.metadata.spec.models.all()
+        } else {
+            overridden.all()
+        };
+        source.to_vec()
     }
 
     fn supports_model(&self, model_id: &str) -> bool {
@@ -665,10 +667,7 @@ impl Worker for BasicWorker {
     }
 
     fn has_models_discovered(&self) -> bool {
-        if !self.models_override.load().is_wildcard() {
-            return true;
-        }
-        !self.metadata.spec.models.is_wildcard()
+        !self.models_override.load().is_wildcard() || !self.metadata.spec.models.is_wildcard()
     }
 
     async fn get_grpc_client(&self) -> WorkerResult<Option<Arc<GrpcClient>>> {
@@ -1767,5 +1766,29 @@ mod tests {
         drop(guard2);
         assert_eq!(worker.load(), 0);
         assert_eq!(worker.worker_routing_key_load().value(), 0);
+    }
+
+    #[test]
+    fn test_lazy_discovered_models_override_wildcard() {
+        let worker = BasicWorkerBuilder::new("http://test:8080").build();
+
+        // Wildcard worker starts with no models listed, but accepts any model
+        assert!(worker.models().is_empty());
+        assert!(!worker.has_models_discovered());
+        assert!(worker.supports_model("gpt-4o-mini")); // wildcard accepts anything
+
+        // Simulate lazy discovery via set_models
+        let discovered = vec![
+            ModelCard::new("gpt-4o-mini"),
+            ModelCard::new("text-embedding-3-small"),
+        ];
+        worker.set_models(discovered);
+
+        let ids: Vec<String> = worker.models().into_iter().map(|m| m.id).collect();
+        assert_eq!(ids, vec!["gpt-4o-mini", "text-embedding-3-small"]);
+        assert!(worker.supports_model("gpt-4o-mini"));
+        assert!(worker.supports_model("text-embedding-3-small"));
+        assert!(!worker.supports_model("non-existent-model"));
+        assert!(worker.has_models_discovered());
     }
 }

--- a/model_gateway/src/core/worker.rs
+++ b/model_gateway/src/core/worker.rs
@@ -2,11 +2,12 @@ use std::{
     fmt,
     sync::{
         atomic::{AtomicBool, AtomicUsize, Ordering},
-        Arc, LazyLock, RwLock as StdRwLock,
+        Arc, LazyLock,
     },
     time::Duration,
 };
 
+use arc_swap::ArcSwap;
 use async_trait::async_trait;
 use axum::body::Body;
 // Re-export protocol types as the canonical types for the gateway
@@ -353,8 +354,8 @@ pub trait Worker: Send + Sync + fmt::Debug {
     }
 
     /// Get all models this worker can serve.
-    fn models(&self) -> &[ModelCard] {
-        self.metadata().spec.models.all()
+    fn models(&self) -> Vec<ModelCard> {
+        self.metadata().spec.models.all().to_vec()
     }
 
     /// Set models for this worker (for lazy discovery).
@@ -485,10 +486,10 @@ pub struct BasicWorker {
     /// Lazily initialized gRPC client for gRPC workers.
     /// Uses OnceCell for lock-free reads after initialization.
     pub grpc_client: Arc<OnceCell<Arc<GrpcClient>>>,
-    /// Runtime-mutable models override (for lazy discovery)
-    /// When set, overrides metadata.models for routing decisions.
-    /// Uses std::sync::RwLock for synchronous access in supports_model().
-    pub models_override: Arc<StdRwLock<Option<WorkerModels>>>,
+    /// Runtime-mutable models override (for lazy discovery).
+    /// When not `Wildcard`, overrides metadata.models for routing decisions.
+    /// Uses `ArcSwap` for lock-free reads on the hot path (`supports_model`).
+    pub models_override: Arc<ArcSwap<WorkerModels>>,
 }
 
 impl fmt::Debug for BasicWorker {
@@ -637,37 +638,36 @@ impl Worker for BasicWorker {
         &self.circuit_breaker
     }
 
-    fn supports_model(&self, model_id: &str) -> bool {
-        // Check models_override first (for lazy discovery)
-        if let Ok(guard) = self.models_override.read() {
-            if let Some(ref models) = *guard {
-                // Models were discovered - check if this model is supported
-                return models.supports(model_id);
-            }
+    fn models(&self) -> Vec<ModelCard> {
+        let overridden = self.models_override.load();
+        if !overridden.is_wildcard() {
+            return overridden.all().to_vec();
         }
-        // Fall back to metadata.models
+        self.metadata.spec.models.all().to_vec()
+    }
+
+    fn supports_model(&self, model_id: &str) -> bool {
+        let overridden = self.models_override.load();
+        if !overridden.is_wildcard() {
+            return overridden.supports(model_id);
+        }
         self.metadata.supports_model(model_id)
     }
 
     fn set_models(&self, models: Vec<ModelCard>) {
-        if let Ok(mut guard) = self.models_override.write() {
-            tracing::debug!(
-                "Setting {} models for worker {} via lazy discovery",
-                models.len(),
-                self.metadata.spec.url
-            );
-            *guard = Some(WorkerModels::from(models));
-        }
+        tracing::debug!(
+            "Setting {} models for worker {} via lazy discovery",
+            models.len(),
+            self.metadata.spec.url
+        );
+        self.models_override
+            .store(Arc::new(WorkerModels::from(models)));
     }
 
     fn has_models_discovered(&self) -> bool {
-        // Check if models_override has been set
-        if let Ok(guard) = self.models_override.read() {
-            if guard.is_some() {
-                return true;
-            }
+        if !self.models_override.load().is_wildcard() {
+            return true;
         }
-        // Fall back to checking metadata.models
         !self.metadata.spec.models.is_wildcard()
     }
 

--- a/model_gateway/src/core/worker_builder.rs
+++ b/model_gateway/src/core/worker_builder.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use arc_swap::ArcSwap;
 use openai_protocol::{
     model_card::ModelCard,
     worker::{HealthCheckConfig, WorkerModels, WorkerSpec},
@@ -183,7 +184,7 @@ impl BasicWorkerBuilder {
     pub fn build(mut self) -> BasicWorker {
         use std::sync::{
             atomic::{AtomicBool, AtomicUsize},
-            Arc, RwLock as StdRwLock,
+            Arc,
         };
 
         use tokio::sync::OnceCell;
@@ -230,7 +231,7 @@ impl BasicWorkerBuilder {
             ),
             metadata,
             grpc_client,
-            models_override: Arc::new(StdRwLock::new(None)),
+            models_override: Arc::new(ArcSwap::from_pointee(WorkerModels::Wildcard)),
         }
     }
 }


### PR DESCRIPTION
## Description

### Problem

The OpenAI `/v1/models` endpoint returns an empty model list for wildcard proxy workers. When a worker is in wildcard mode (no API key configured), `refresh_external_models()` correctly discovers models from backends and stores them via `set_models()` into `models_override`. However, `get_models()` then calls `worker.models()` which reads from the immutable `metadata.spec.models` — ignoring the lazily discovered models entirely.

### Solution

- Override `models()` on `BasicWorker` to check `models_override` first (same pattern as `supports_model()` and `has_models_discovered()`)
- Change the trait return type from `&[ModelCard]` to `Vec<ModelCard>` so the override can return owned data from the `ArcSwap`
- Replace `RwLock<Option<WorkerModels>>` with `ArcSwap<WorkerModels>` for lock-free reads on the hot path (`supports_model` is called on every request)

## Changes

- **`worker.rs`**: Added `BasicWorker::models()` override; replaced `StdRwLock` with `ArcSwap`; simplified `supports_model`, `set_models`, `has_models_discovered` — no more lock guard boilerplate
- **`worker_builder.rs`**: Initialize `models_override` with `ArcSwap::from_pointee(WorkerModels::Wildcard)` instead of `RwLock::new(None)`

## Test Plan

- `cargo check -p smg` passes
- `cargo test -p smg -- worker` — all 14 worker tests pass
- e2e local test passes

<img width="1624" height="1061" alt="Screenshot 2026-02-27 at 1 47 44 PM" src="https://github.com/user-attachments/assets/0fc7aac4-ae31-46a0-81c5-3035bf4f2e1a" />

<img width="1624" height="1061" alt="Screenshot 2026-02-27 at 1 47 43 PM" src="https://github.com/user-attachments/assets/c7e52dba-7f50-4bc9-ba37-3042dcf12c95" />

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved model discovery and routing to use lock-free reads, reducing contention and improving responsiveness under concurrency.
* **Breaking Change**
  * Updated public model-listing behavior and override handling (interface semantics changed; consumers may need adjustments).
* **Tests**
  * Added coverage for wildcard discovery and override behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->