### PR TITLE
fix(kv): stop retrying SubscribeKvEvents when backend returns UNIMPLEMENTED

### DIFF
--- a/model_gateway/src/core/kv_event_monitor.rs
+++ b/model_gateway/src/core/kv_event_monitor.rs
@@ -282,6 +282,18 @@ impl KvEventMonitor {
                     stream
                 }
                 Err(e) => {
+                    // If the backend doesn't implement SubscribeKvEvents (e.g. vLLM),
+                    // stop retrying — this RPC will never succeed.
+                    if let Some(status) = e.downcast_ref::<tonic::Status>() {
+                        if status.code() == tonic::Code::Unimplemented {
+                            warn!(
+                                worker_url = %worker_url,
+                                "Backend does not implement SubscribeKvEvents, \
+                                 disabling KV event subscription for this worker"
+                            );
+                            return;
+                        }
+                    }
                     warn!(
                         worker_url = %worker_url,
                         error = %e,


### PR DESCRIPTION
## Description

### Problem

When a gRPC backend (e.g. vLLM) does not implement the `SubscribeKvEvents` RPC, the KV event monitor retries forever with exponential backoff (100ms → 30s), spamming warning logs. This RPC will never succeed for backends that don't support it.

### Solution

Before retrying, downcast the error to `tonic::Status` and check for `Code::Unimplemented`. If detected, log a single warning and exit the subscription loop permanently for that worker.

## Changes

- In `kv_event_monitor.rs` `subscription_loop`, added early return when `subscribe_kv_events` fails with gRPC `UNIMPLEMENTED` status code.

## Test Plan

- Deploy SMG against a vLLM backend without `SubscribeKvEvents` support
- Verify: single warning log "Backend does not implement SubscribeKvEvents, disabling KV event subscription for this worker" appears once
- Verify: no repeated retry spam in logs
- Other transient errors (e.g. connection refused) still retry with backoff as before

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved KV event subscription error handling to gracefully disable the feature when unavailable, preventing unnecessary retry loops. Other error conditions continue to retry with backoff as designed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->