### PR TITLE
feat(discovery): per-provider admin API keys for external worker model discovery

### DIFF
--- a/model_gateway/src/core/steps/worker/external/discover_models.rs
+++ b/model_gateway/src/core/steps/worker/external/discover_models.rs
@@ -183,16 +183,16 @@ fn infer_provider_from_id(id: &str) -> Option<ProviderType> {
 /// Resolve the API key to use for model discovery.
 ///
 /// Priority: per-provider env var > config.api_key > None (wildcard).
-fn resolve_discovery_api_key(url: &str, config_api_key: Option<&str>) -> Option<String> {
+fn resolve_discovery_api_key(
+    provider: Option<&ProviderType>,
+    url: &str,
+    config_api_key: Option<&str>,
+) -> Option<String> {
     // 1. Try per-provider admin key from env var
-    if let Some(provider) = ProviderType::from_url(url) {
-        if let Some(env_name) = provider.admin_key_env_var() {
-            if let Ok(key) = std::env::var(env_name) {
-                if !key.is_empty() {
-                    debug!("Using {} for model discovery on {}", env_name, url);
-                    return Some(key);
-                }
-            }
+    if let Some(env_name) = provider.and_then(|p| p.admin_key_env_var()) {
+        if let Some(key) = std::env::var(env_name).ok().filter(|k| !k.is_empty()) {
+            debug!("Using {} for model discovery on {}", env_name, url);
+            return Some(key);
         }
     }
 
@@ -274,7 +274,8 @@ impl StepExecutor<WorkerWorkflowData> for DiscoverModelsStep {
         let provider = ProviderType::from_url(&config.url);
 
         // Resolve discovery API key: env var admin key > config.api_key > None (wildcard)
-        let discovery_key = resolve_discovery_api_key(&config.url, config.api_key.as_deref());
+        let discovery_key =
+            resolve_discovery_api_key(provider.as_ref(), &config.url, config.api_key.as_deref());
 
         if discovery_key.is_none() {
             info!(

--- a/protocols/Cargo.toml
+++ b/protocols/Cargo.toml
@@ -29,6 +29,7 @@ tokio.workspace = true
 tracing.workspace = true
 schemars.workspace = true
 # Only used by protocols
+url = "2.5"
 validator = { version = "0.20.0", features = ["derive"] }
 
 [lints]

--- a/protocols/src/worker.rs
+++ b/protocols/src/worker.rs
@@ -197,16 +197,18 @@ impl ProviderType {
         }
     }
 
-    /// Detect provider from URL domain patterns.
-    /// Returns `None` for URLs that don't match known providers.
+    /// Detect provider from URL host.
+    /// Returns `None` for URLs that don't match known providers or can't be parsed.
     pub fn from_url(url: &str) -> Option<Self> {
-        if url.contains("openai.com") {
+        let host = url::Url::parse(url).ok()?.host_str()?.to_lowercase();
+
+        if host.ends_with("openai.com") {
             Some(Self::OpenAI)
-        } else if url.contains("x.ai") {
+        } else if host.ends_with("x.ai") {
             Some(Self::XAI)
-        } else if url.contains("anthropic") {
+        } else if host.ends_with("anthropic.com") {
             Some(Self::Anthropic)
-        } else if url.contains("googleapis.com") {
+        } else if host.ends_with("googleapis.com") {
             Some(Self::Gemini)
         } else {
             None


### PR DESCRIPTION
## Summary

- Add per-provider admin API keys (via env vars) for external worker model discovery, so multiple providers can use different credentials
- Add provider-aware auth header handling (Anthropic uses `x-api-key` instead of Bearer)
- Fully backward compatible: `--api-key` without env vars works identically to before

Refs: external worker registration support

## What changed

**`protocols/src/worker.rs`** — 3 new methods on `ProviderType`:
- `from_url(url)` → `Option<ProviderType>` — detect provider from URL domain (`openai.com`, `x.ai`, `anthropic`, `googleapis.com`)
- `admin_key_env_var()` → `Option<&str>` — maps provider to env var name (`OPENAI_ADMIN_KEY`, `XAI_ADMIN_KEY`, `ANTHROPIC_ADMIN_KEY`, `GEMINI_ADMIN_KEY`)
- `uses_x_api_key()` → `bool` — Anthropic requires `x-api-key` header

**`model_gateway/src/core/steps/worker/external/discover_models.rs`**:
- Add `resolve_discovery_api_key()` — resolves API key with priority: per-provider env var → `--api-key` → None (wildcard mode)
- Update `fetch_models()` — accepts `Option<&ProviderType>`, sends `x-api-key` for Anthropic, Bearer for all others
- Update `DiscoverModelsStep::execute()` — uses new resolution logic instead of checking `config.api_key` directly

## Why

When registering multiple external backends (OpenAI, Anthropic, xAI, Gemini), model discovery requires calling `/v1/models` with a valid API key. The existing `--api-key` flag serves as a single key for all providers, which doesn't work when different providers need different credentials. Per-provider admin keys solve this by allowing operators to set `OPENAI_ADMIN_KEY`, `XAI_ADMIN_KEY`, etc. as environment variables, each used only for discovery on the matching provider.

## How

API key resolution follows a clear priority chain: first check for a per-provider env var based on URL domain detection (`ProviderType::from_url`), then fall back to `--api-key`, then enter wildcard mode. The `ProviderType` enum in the protocols crate was extended (rather than creating a new enum) to keep provider logic centralized and reusable by both `core` and `routers` layers.

## Usage examples

```bash
# Per-provider admin keys (multiple providers, IGW mode):
export OPENAI_ADMIN_KEY=sk-admin-openai
export XAI_ADMIN_KEY=xai-admin-key
smg --worker-url https://api.openai.com --worker-url https://api.x.ai --enable-igw

# Admin key for discovery + master key for inference:
export OPENAI_ADMIN_KEY=sk-admin-openai
smg --worker-url https://api.openai.com --api-key sk-inference

# Backward compatible (no env vars):
smg --worker-url https://api.openai.com --api-key sk-xxx
```

## Test plan

- [x] `cargo check -p smg` — compiles
- [x] `cargo clippy -p smg -- -D warnings` — no warnings
- [x] `cargo clippy -p openai-protocol -- -D warnings` — no warnings
- [x] `cargo test -p smg` — all 413 tests pass
- [ ] Manual: set `OPENAI_ADMIN_KEY`, start with `--worker-url https://api.openai.com --enable-igw`, verify models discovered
- [ ] Manual: verify `--api-key` without env vars still works as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved model discovery with per-provider environment variable and configuration fallbacks for API keys.
  * Added provider detection from model URLs and provider-aware model fetching to select the correct authentication header format.
* **Chores**
  * Added URL parsing dependency to support provider resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->