### PR TITLE
feat(multimodal): derive keep_on_cpu keys from model spec

### DIFF
--- a/grpc_client/proto/vllm_engine.proto
+++ b/grpc_client/proto/vllm_engine.proto
@@ -133,6 +133,10 @@ message MultimodalInputs {
   // e.g. {"pixel_values": "patches_per_image"} means pixel_values should be
   // split per-item using sizes from the patches_per_image tensor.
   map<string, string> flat_keys = 8;
+
+  // Tensor keys that should remain on CPU (not transferred to GPU).
+  // Maps to vLLM's MultiModalFieldConfig keep_on_cpu flag.
+  repeated string keep_on_cpu_keys = 9;
 }
 
 // =====================

--- a/model_gateway/src/routers/grpc/multimodal.rs
+++ b/model_gateway/src/routers/grpc/multimodal.rs
@@ -142,6 +142,8 @@ pub(crate) struct MultimodalIntermediate {
     pub im_token_id: Option<u32>,
     /// Per-tensor field layout classification from the model spec.
     pub field_layouts: HashMap<String, FieldLayout>,
+    /// Tensor keys that should remain on CPU (vLLM `keep_on_cpu` hint).
+    pub keep_on_cpu_keys: Vec<String>,
 }
 
 /// Check if any messages in the request contain multimodal content (images).
@@ -333,6 +335,7 @@ pub(crate) async fn process_multimodal(
         patch_offsets: expanded.patch_offsets,
         im_token_id,
         field_layouts: spec.field_layouts(),
+        keep_on_cpu_keys: spec.keep_on_cpu_keys(),
     };
 
     Ok(MultimodalOutput {
@@ -501,6 +504,7 @@ fn assemble_vllm(intermediate: MultimodalIntermediate) -> VllmMultimodalData {
         mm_hashes,
         batched_keys,
         flat_keys,
+        keep_on_cpu_keys: intermediate.keep_on_cpu_keys,
     }
 }
 

--- a/model_gateway/src/routers/grpc/proto_wrapper.rs
+++ b/model_gateway/src/routers/grpc/proto_wrapper.rs
@@ -56,6 +56,8 @@ pub struct VllmMultimodalData {
     pub mm_hashes: Vec<String>,
     pub batched_keys: Vec<String>,
     pub flat_keys: HashMap<String, String>,
+    /// Tensor keys that should remain on CPU (`keep_on_cpu=True` in vLLM).
+    pub keep_on_cpu_keys: Vec<String>,
 }
 
 /// TRT-LLM multimodal data: raw image bytes only.
@@ -152,6 +154,7 @@ impl VllmMultimodalData {
             mm_hashes: self.mm_hashes,
             batched_keys: self.batched_keys,
             flat_keys: self.flat_keys,
+            keep_on_cpu_keys: self.keep_on_cpu_keys,
         }
     }
 }

--- a/multimodal/src/registry.rs
+++ b/multimodal/src/registry.rs
@@ -77,6 +77,16 @@ pub trait ModelProcessorSpec: Send + Sync {
         // Default: pixel_values is batched (most models).
         HashMap::from([("pixel_values".to_string(), FieldLayout::Batched)])
     }
+
+    /// Tensor keys that should remain on CPU (not transferred to GPU).
+    ///
+    /// In vLLM, certain model-specific tensors are marked `keep_on_cpu=True`
+    /// in their `MultiModalFieldConfig`.  This method mirrors that per-model
+    /// knowledge so the router can send the hint via gRPC, avoiding the need
+    /// for the backend to instantiate a Python processor just to query it.
+    fn keep_on_cpu_keys(&self) -> Vec<String> {
+        vec![]
+    }
 }
 
 pub struct ModelRegistry {
@@ -309,6 +319,10 @@ impl ModelProcessorSpec for Qwen3VLVisionSpec {
             ("patches_per_image".to_string(), FieldLayout::Batched),
         ])
     }
+
+    fn keep_on_cpu_keys(&self) -> Vec<String> {
+        vec!["image_grid_thw".to_string()]
+    }
 }
 
 struct QwenVLVisionSpec;
@@ -396,6 +410,10 @@ impl ModelProcessorSpec for QwenVLVisionSpec {
             ("image_grid_thw".to_string(), FieldLayout::Batched),
             ("patches_per_image".to_string(), FieldLayout::Batched),
         ])
+    }
+
+    fn keep_on_cpu_keys(&self) -> Vec<String> {
+        vec!["image_grid_thw".to_string()]
     }
 }
 


### PR DESCRIPTION
## Description

### Problem

vLLM marks certain model-specific tensors with `keep_on_cpu=True` in their `MultiModalFieldConfig`, but the only way to query this was through the Python processor's private `_get_mm_fields_config()` API. This forced the backend to instantiate a Python multimodal processor just to discover which tensors should stay on CPU.

### Solution

Add `keep_on_cpu_keys()` to the `ModelProcessorSpec` trait so the router can derive these hints in Rust and send them via gRPC, removing the Python dependency for this metadata.

Qwen2-VL and Qwen3-VL return `["image_grid_thw"]` as keep-on-CPU keys. The keys flow through `MultimodalIntermediate` → `VllmMultimodalData` → proto field 9 (`repeated string keep_on_cpu_keys`).

## Changes

- Add `keep_on_cpu_keys()` default method to `ModelProcessorSpec` trait (returns empty vec)
- Override in `Qwen3VLVisionSpec` and `QwenVLVisionSpec` to return `["image_grid_thw"]`
- Add `keep_on_cpu_keys` field to `MultimodalIntermediate` and `VllmMultimodalData`
- Wire through `assemble_vllm()` and `VllmMultimodalData::into_proto()`
- Add `keep_on_cpu_keys` (field 9) to `MultimodalInputs` proto message

## Test Plan

```
cargo check -p llm-multimodal -p smg
cargo test -p llm-multimodal
pre-commit run --all-files  # passes
```

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced multimodal processing with intelligent tensor memory optimization. Specific tensor keys for vision models (including Qwen, Qwen2, Phi3, and Llama4) now remain on CPU during inference by default, reducing GPU memory consumption and improving inference performance. Changes are automatically applied without configuration required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->