### PR TITLE
refactor(multimodal): remove dead MultiModalInputs/Tensor/Value types

### DIFF
--- a/multimodal/src/hasher.rs
+++ b/multimodal/src/hasher.rs
@@ -7,7 +7,7 @@ pub fn hash_image(raw_bytes: &[u8]) -> String {
 
 /// Compute per-image hashes keyed by modality.
 ///
-/// Returns a `BTreeMap` compatible with `MultiModalInputs.mm_hashes`,
+/// Returns a `BTreeMap` of per-modality hash lists,
 /// e.g. `{"image": ["abc123...", "def456..."]}`.
 pub fn hash_images(raw_bytes: &[impl AsRef<[u8]>]) -> BTreeMap<String, Vec<String>> {
     let hashes: Vec<String> = raw_bytes.iter().map(|b| hash_image(b.as_ref())).collect();

--- a/multimodal/src/lib.rs
+++ b/multimodal/src/lib.rs
@@ -12,8 +12,7 @@ pub use registry::{ModelMetadata, ModelProcessorSpec, ModelRegistry};
 pub use tracker::{AsyncMultiModalTracker, TrackerOutput};
 pub use types::{
     ChatContentPart, FieldLayout, ImageDetail, ImageFrame, ImageSize, ImageSource, Modality,
-    MultiModalData, MultiModalInputs, MultiModalTensor, MultiModalUUIDs, MultiModalValue,
-    PlaceholderRange, PromptReplacement, TokenId, TrackedMedia,
+    MultiModalData, MultiModalUUIDs, PlaceholderRange, PromptReplacement, TokenId, TrackedMedia,
 };
 // Re-export vision processing components
 pub use vision::{

--- a/multimodal/src/types.rs
+++ b/multimodal/src/types.rs
@@ -1,9 +1,4 @@
-use std::{
-    collections::{BTreeMap, HashMap},
-    fmt,
-    path::PathBuf,
-    sync::Arc,
-};
+use std::{collections::HashMap, fmt, path::PathBuf, sync::Arc};
 
 use image::DynamicImage;
 use serde::{Deserialize, Serialize};
@@ -180,42 +175,6 @@ pub struct PlaceholderRange {
     pub length: usize,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct MultiModalTensor {
-    pub shape: Vec<usize>,
-    pub dtype: String,
-    pub data: bytes::Bytes,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "kind", rename_all = "snake_case")]
-pub enum MultiModalValue {
-    Tensor(MultiModalTensor),
-    Json(Value),
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct MultiModalInputs {
-    pub prompt_token_ids: Vec<u32>,
-    #[serde(default)]
-    pub mm_kwargs: BTreeMap<String, Vec<MultiModalValue>>,
-    #[serde(default)]
-    pub mm_hashes: BTreeMap<String, Vec<String>>,
-    #[serde(default)]
-    pub mm_placeholders: BTreeMap<String, Vec<PlaceholderRange>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub cache_salt: Option<String>,
-}
-
-impl MultiModalInputs {
-    pub fn new(prompt_token_ids: Vec<u32>) -> Self {
-        Self {
-            prompt_token_ids,
-            ..Default::default()
-        }
-    }
-}
-
 #[derive(Debug, Clone)]
 pub struct PromptReplacement {
     pub modality: Modality,
@@ -249,13 +208,6 @@ impl PromptReplacement {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn multimodal_inputs_defaults() {
-        let inputs = MultiModalInputs::new(vec![1, 2, 3]);
-        assert_eq!(inputs.prompt_token_ids, vec![1, 2, 3]);
-        assert!(inputs.mm_kwargs.is_empty());
-    }
 
     #[test]
     fn placeholder_range_serializes() {


### PR DESCRIPTION
## Description

### Problem

`MultiModalInputs`, `MultiModalValue`, and `MultiModalTensor` in `llm-multimodal/types.rs` are dead code from an earlier design phase (mm_design.md Phase 16-17) that was superseded by the backend-specific assembly approach. They are defined, re-exported, and tested, but never used anywhere in the codebase, causing confusion about the intended data flow.

### Solution

Remove the dead types, their re-exports, and associated test. Update the doc comment in `hasher.rs` that referenced the deleted `MultiModalInputs.mm_hashes` field.

## Changes

- Delete `MultiModalTensor` struct, `MultiModalValue` enum, `MultiModalInputs` struct + impl from `types.rs`
- Delete `multimodal_inputs_defaults` test
- Remove unused `BTreeMap` import from `types.rs`
- Remove `MultiModalInputs`, `MultiModalTensor`, `MultiModalValue` from re-exports in `lib.rs`
- Update doc comment in `hasher.rs` to remove reference to deleted type

## Test Plan

```
cargo check -p llm-multimodal && cargo test -p llm-multimodal  # 212 tests pass
pre-commit run --all-files  # passes
```

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the public API by consolidating internal data structure exports, removing unnecessary re-exports to streamline the module interface.
  * Updated documentation for the hashing functionality to clarify the structure of returned data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->