### PR TITLE
refactor(grpc): deduplicate Harmony Chat Completion streaming decode logic

### DIFF
--- a/model_gateway/src/routers/grpc/harmony/streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/streaming.rs
@@ -202,7 +202,6 @@ impl HarmonyStreamingProcessor {
         // Per-index state management (for n>1 support)
         let mut parsers: HashMap<u32, HarmonyParserAdapter> = HashMap::new();
         let mut is_firsts: HashMap<u32, bool> = HashMap::new();
-        let mut finish_reasons: HashMap<u32, Option<String>> = HashMap::new();
         let mut matched_stops: HashMap<u32, Option<serde_json::Value>> = HashMap::new();
         let mut completion_tokens = CompletionTokenTracker::new();
 
@@ -272,8 +271,6 @@ impl HarmonyStreamingProcessor {
                     let index = complete_wrapper.index();
 
                     // Store final metadata
-                    finish_reasons
-                        .insert(index, Some(complete_wrapper.finish_reason().to_string()));
                     matched_stops.insert(index, complete_wrapper.matched_stop_json());
                     prompt_tokens
                         .entry(index)


### PR DESCRIPTION
## Description

### Problem

PR #592 review (Gemini, high priority) flagged significant code duplication between `process_single_stream` and `process_dual_stream` in `streaming.rs`. The decode loop, chunk parsing, delta emission, completion handling, finalization, usage emission, and metrics recording were nearly identical (~160 lines duplicated). The only differences:

1. `dual_stream` has a prefill phase that pre-populates `prompt_tokens` and `cached_tokens`
2. `single_stream` populates `prompt_tokens`/`cached_tokens` from Complete messages; `dual_stream` doesn't
3. `dual_stream` marks two streams complete (decode first, then prefill); `single_stream` marks one

### Solution

Extract the shared decode logic into `process_chat_decode_stream()`. Callers only set up `prompt_tokens`/`cached_tokens` and handle prefill-specific cleanup.

The `prompt_tokens`/`cached_tokens` difference is handled via `entry().or_insert_with()`:
- **single_stream**: maps start empty → always inserts (same as original `.insert()`)
- **dual_stream**: maps pre-populated from prefill → `or_insert_with` is a no-op (closure never called)

## Changes

- Added `process_chat_decode_stream()` — shared helper containing the full decode loop, metrics, and usage emission
- Simplified `process_single_stream()` — now just creates empty maps and delegates to the helper
- Simplified `process_dual_stream()` — keeps prefill phase, delegates decode to the helper, marks prefill stream completed after

**Performance note**: The dual-stream path now does an `entry().or_insert_with()` lookup in the Complete arm where the original code didn't touch those maps at all. This is one `u32` hash + comparison per Complete message per map — sub-nanosecond and completely negligible compared to any network I/O in the stream. The closure is lazy so `complete_wrapper.prompt_tokens()` / `cached_tokens()` are never called when the key already exists.

## Test Plan

- `cargo build -p smg` — passes
- `cargo clippy -p smg -- -D warnings` — passes (zero warnings)
- `cargo test -p smg` — all tests pass
- `pre-commit run --all-files` — all hooks pass

Note: PR #592 will need to rebase on this after merge.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated streaming decode logic into a shared handler, reducing duplication and centralizing per-chunk parsing, delta emission, finalization, and usage aggregation.
  * Synchronized token-tracking across decode and completion phases and clarified stream completion semantics to improve streaming reliability and preserve existing per-chunk behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->