### PR TITLE
fix(grpc): add matched_stop support for vLLM and TensorRT-LLM

### DIFF
--- a/grpc_client/proto/trtllm_service.proto
+++ b/grpc_client/proto/trtllm_service.proto
@@ -386,8 +386,11 @@ message GenerateComplete {
   // Finish reason: "stop", "length", "stop_word"
   string finish_reason = 3;
 
-  // Specific stop reason (stop word/token that triggered stop)
-  optional string stop_reason = 4;
+  // Matched stop information (for stop sequences)
+  oneof matched_stop {
+    string matched_stop_str = 4;     // Stop string that matched (wire-compatible with old stop_reason)
+    uint32 matched_token_id = 13;    // Stop token ID that matched
+  }
 
   // Token counts for usage tracking
   uint32 prompt_tokens = 5;

--- a/grpc_client/proto/vllm_engine.proto
+++ b/grpc_client/proto/vllm_engine.proto
@@ -242,6 +242,12 @@ message GenerateComplete {
   // KV transfer parameters returned by prefill worker (Mooncake PD)
   // Contains prefill's side-channel address for decode to fetch KV cache
   KvTransferParams kv_transfer_params = 9;
+
+  // Matched stop information (for stop sequences)
+  oneof matched_stop {
+    uint32 matched_token_id = 10;
+    string matched_stop_str = 11;
+  }
 }
 
 // =====================

--- a/model_gateway/src/routers/grpc/proto_wrapper.rs
+++ b/model_gateway/src/routers/grpc/proto_wrapper.rs
@@ -7,12 +7,12 @@ use std::collections::HashMap;
 
 use futures_util::StreamExt;
 use smg_grpc_client::{
-    sglang_proto::{self as sglang, generate_complete::MatchedStop},
+    sglang_proto::{self as sglang, generate_complete::MatchedStop as SglangMatchedStop},
     sglang_scheduler::AbortOnDropStream as SglangStream,
-    trtllm_proto as trtllm,
+    trtllm_proto::{self as trtllm, generate_complete::MatchedStop as TrtllmMatchedStop},
     trtllm_service::AbortOnDropStream as TrtllmStream,
     vllm_engine::AbortOnDropStream as VllmStream,
-    vllm_proto as vllm,
+    vllm_proto::{self as vllm, generate_complete::MatchedStop as VllmMatchedStop},
 };
 
 // =====================
@@ -743,28 +743,38 @@ impl ProtoGenerateComplete {
         }
     }
 
-    /// Get matched stop (SGLang only, returns oneof)
-    /// vLLM and TensorRT-LLM don't have matched_stop, returns None
-    pub fn matched_stop(&self) -> Option<&MatchedStop> {
-        match self {
-            Self::Sglang(c) => c.matched_stop.as_ref(),
-            Self::Vllm(_) | Self::Trtllm(_) => None,
-        }
-    }
-
     /// Get matched stop as a JSON value
     ///
-    /// Converts the proto MatchedStop oneof into a serde_json::Value:
+    /// Converts the backend-specific `oneof matched_stop` into a `serde_json::Value`:
     /// - MatchedTokenId → Number
     /// - MatchedStopStr → String
     /// - None → None
     pub fn matched_stop_json(&self) -> Option<serde_json::Value> {
-        self.matched_stop().map(|m| match m {
-            MatchedStop::MatchedTokenId(id) => {
-                serde_json::Value::Number(serde_json::Number::from(*id))
-            }
-            MatchedStop::MatchedStopStr(s) => serde_json::Value::String(s.clone()),
-        })
+        macro_rules! convert {
+            ($oneof:expr, $token_id:path, $stop_str:path) => {
+                $oneof.as_ref().map(|m| match m {
+                    $token_id(id) => serde_json::Value::Number((*id).into()),
+                    $stop_str(s) => serde_json::Value::String(s.clone()),
+                })
+            };
+        }
+        match self {
+            Self::Sglang(c) => convert!(
+                &c.matched_stop,
+                SglangMatchedStop::MatchedTokenId,
+                SglangMatchedStop::MatchedStopStr
+            ),
+            Self::Vllm(c) => convert!(
+                &c.matched_stop,
+                VllmMatchedStop::MatchedTokenId,
+                VllmMatchedStop::MatchedStopStr
+            ),
+            Self::Trtllm(c) => convert!(
+                &c.matched_stop,
+                TrtllmMatchedStop::MatchedTokenId,
+                TrtllmMatchedStop::MatchedStopStr
+            ),
+        }
     }
 
     /// Get output IDs (decode tokens only)


### PR DESCRIPTION
## Description

### Problem

vLLM gRPC responses were missing `stop_reason` (which specific stop string/token triggered a stop). vLLM HTTP returns it (e.g., `stop_reason=','`), but the gRPC proto never defined the field. TensorRT-LLM had `optional string stop_reason` in its proto but the Rust wrapper ignored it. Only SGLang's `oneof matched_stop` was wired through.

### Solution

- Add `oneof matched_stop { matched_token_id, matched_stop_str }` to vLLM's `GenerateComplete` proto, matching SGLang's pattern to preserve `int | str` type distinction from vLLM's `CompletionOutput.stop_reason`
- Wire both vLLM and TensorRT-LLM through `matched_stop_json()` in the proto wrapper
- Remove the now-unused SGLang-only `matched_stop()` helper

## Changes

- `grpc_client/proto/vllm_engine.proto`: Add `oneof matched_stop` (fields 10-11) to `GenerateComplete`
- `model_gateway/src/routers/grpc/proto_wrapper.rs`: Rewrite `matched_stop_json()` to handle all three backends (SGLang oneof, vLLM oneof, TensorRT-LLM string), remove dead `matched_stop()` method

Note: The corresponding vLLM `grpc_server.py` change to populate the new field is in the vLLM fork.

## Test Plan

- [x] `cargo build -p smg` (proto re-generation + compilation)
- [x] `cargo clippy -p smg -- -D warnings` — zero warnings
- [x] `cargo test -p smg` — all tests pass
- [x] `pre-commit run --all-files` — all hooks pass
- [x] E2E: verify `stop_reason` appears in vLLM gRPC chat completion responses with stop sequences

<img width="692" height="63" alt="Screenshot 2026-03-03 at 2 09 39 PM" src="https://github.com/user-attachments/assets/6757d38d-272a-43fb-9554-2dfb5339826e" />

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Generation responses now include stop-sequence matching information indicating either a matched token ID or a matched stop string.
  * The prior free-form stop_reason has been replaced with this explicit matched-stop representation in generation results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->