### PR TITLE
refactor(grpc-proto): move version to pyproject.toml as single source of truth

### DIFF
--- a/.github/workflows/release-grpc-proto.yml
+++ b/.github/workflows/release-grpc-proto.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - grpc_client/python/smg_grpc_proto/__init__.py  # Triggered when version bumped
+      - grpc_client/python/pyproject.toml  # Triggered when version bumped
   workflow_dispatch:
 
 permissions:
@@ -65,4 +65,4 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN_GRPC_PROTO }}
         run: |
           pip install twine
-          twine upload dist/* --verbose
+          twine upload dist/* --verbose --skip-existing

--- a/grpc_client/python/pyproject.toml
+++ b/grpc_client/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "smg-grpc-proto"
-dynamic = ["version"]
+version = "0.4.1"
 description = "SMG gRPC proto definitions for SGLang, vLLM, and TRT-LLM"
 requires-python = ">=3.10"
 dependencies = [
@@ -35,9 +35,6 @@ Repository = "https://github.com/lightseekorg/smg"
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["smg_grpc_proto*"]
-
-[tool.setuptools.dynamic]
-version = {attr = "smg_grpc_proto.__version__"}
 
 [tool.setuptools.package-data]
 smg_grpc_proto = ["proto/*.proto", "generated/*.py", "generated/*.pyi"]

--- a/grpc_client/python/smg_grpc_proto/__init__.py
+++ b/grpc_client/python/smg_grpc_proto/__init__.py
@@ -1,6 +1,8 @@
 """SMG gRPC Proto - Protocol definitions for SGLang, vLLM, and TRT-LLM."""
 
-__version__ = "0.4.1"
+from importlib.metadata import version
+
+__version__ = version("smg-grpc-proto")
 
 # Re-export generated modules for convenient access
 # These imports will work after the package is built (stubs generated at build time)


### PR DESCRIPTION
## Description

### Problem

`__init__.py` was serving as both the version source and a module re-export file. Since it now contains re-exports of generated gRPC modules, using it as the version source and CI trigger is fragile — import changes could accidentally trigger a release, or someone could modify imports without bumping the version.

### Solution

Move the version string to `pyproject.toml` as the single source of truth and use `importlib.metadata` in `__init__.py` to read the version at runtime. Revert the CI workflow trigger back to `pyproject.toml` so only intentional version bumps trigger releases.

## Changes

- **`grpc_client/python/pyproject.toml`**: Set version here as the canonical source
- **`grpc_client/python/smg_grpc_proto/__init__.py`**: Replace hardcoded `__version__` with `importlib.metadata.version()` lookup
- **`.github/workflows/release-grpc-proto.yml`**: Revert CI trigger path back to `pyproject.toml`; add `--skip-existing` to twine upload for idempotent releases

## Test Plan

- Verified `importlib.metadata.version("smg_grpc_proto")` resolves correctly from `pyproject.toml`
- Confirmed CI workflow only triggers on `pyproject.toml` changes, not `__init__.py` import changes

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined release workflow configuration to streamline the deployment process and improve overall reliability.
  * Enhanced package distribution upload handling to skip existing versions, reducing unnecessary re-uploads and improving release efficiency.
  * Updated version management system to maintain better consistency between package metadata and build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->