### PR TITLE
chore(grpc-proto): bump version to 0.4.2

### DIFF
--- a/grpc_client/python/pyproject.toml
+++ b/grpc_client/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "smg-grpc-proto"
-version = "0.4.1"
+version = "0.4.2"
 description = "SMG gRPC proto definitions for SGLang, vLLM, and TRT-LLM"
 requires-python = ">=3.10"
 dependencies = [


### PR DESCRIPTION
## Description

### Problem

smg-grpc-proto 0.4.1 is already published to PyPI. Need a new version to publish the latest changes (version source of truth moved to pyproject.toml in #610).

### Solution

Bump version to 0.4.2 in pyproject.toml.

## Changes

- Bump `smg-grpc-proto` version from 0.4.1 to 0.4.2

## Test Plan

- CI workflow will build and publish to PyPI on merge

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.4.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->