### PR TITLE
perf(mcp): fix O(n²) insert in inject_mcp_output_items

### DIFF
--- a/mcp/src/core/session.rs
+++ b/mcp/src/core/session.rs
@@ -751,6 +751,120 @@ mod tests {
         assert_eq!(listed[0].tool_name(), "brave_web_search");
     }
 
+    /// Verify that `inject_mcp_output_items` produces the exact ordering:
+    ///   1. mcp_list_tools items (one per server, in server order)
+    ///   2. tool_call_items (in their original order)
+    ///   3. existing output items (in their original order)
+    ///
+    /// This is a regression test so future perf refactors cannot
+    /// accidentally change the output ordering contract.
+    #[test]
+    fn test_inject_mcp_output_items_ordering() {
+        use openai_protocol::responses::ResponseOutputItem;
+
+        let orchestrator = McpOrchestrator::new_test();
+
+        // Register one tool per server so build_mcp_list_tools_item has
+        // something to return.
+        orchestrator
+            .tool_inventory()
+            .insert_entry(ToolEntry::from_server_tool(
+                "srv_a",
+                create_test_tool("tool_a"),
+            ));
+        orchestrator
+            .tool_inventory()
+            .insert_entry(ToolEntry::from_server_tool(
+                "srv_b",
+                create_test_tool("tool_b"),
+            ));
+
+        let session = McpToolSession::new(
+            &orchestrator,
+            vec![
+                McpServerBinding {
+                    label: "Server A".to_string(),
+                    server_key: "srv_a".to_string(),
+                    allowed_tools: None,
+                },
+                McpServerBinding {
+                    label: "Server B".to_string(),
+                    server_key: "srv_b".to_string(),
+                    allowed_tools: None,
+                },
+            ],
+            "test-ordering",
+        );
+
+        // Pre-existing output items (e.g. assistant message).
+        let existing_1 = ResponseOutputItem::Message {
+            id: "msg_existing_1".to_string(),
+            role: "assistant".to_string(),
+            content: vec![],
+            status: "completed".to_string(),
+        };
+        let existing_2 = ResponseOutputItem::Message {
+            id: "msg_existing_2".to_string(),
+            role: "assistant".to_string(),
+            content: vec![],
+            status: "completed".to_string(),
+        };
+
+        // Tool call items injected by the router.
+        let call_1 = ResponseOutputItem::McpCall {
+            id: "call_1".to_string(),
+            status: "completed".to_string(),
+            approval_request_id: None,
+            arguments: "{}".to_string(),
+            error: None,
+            name: "tool_a".to_string(),
+            output: "result_a".to_string(),
+            server_label: "Server A".to_string(),
+        };
+        let call_2 = ResponseOutputItem::McpCall {
+            id: "call_2".to_string(),
+            status: "completed".to_string(),
+            approval_request_id: None,
+            arguments: "{}".to_string(),
+            error: None,
+            name: "tool_b".to_string(),
+            output: "result_b".to_string(),
+            server_label: "Server B".to_string(),
+        };
+
+        let mut output = vec![existing_1, existing_2];
+        let tool_call_items = vec![call_1, call_2];
+
+        session.inject_mcp_output_items(&mut output, tool_call_items);
+
+        // Expected ordering: 2 mcp_list_tools + 2 mcp_call + 2 messages = 6
+        assert_eq!(output.len(), 6, "expected 6 items in output");
+
+        // Serialize to JSON values for easier field-level assertions.
+        let items: Vec<serde_json::Value> = output
+            .iter()
+            .map(|item| serde_json::to_value(item).expect("serialization failed"))
+            .collect();
+
+        // [0..2] mcp_list_tools — one per server, in server order
+        assert_eq!(items[0]["type"], "mcp_list_tools");
+        assert_eq!(items[0]["server_label"], "Server A");
+        assert_eq!(items[1]["type"], "mcp_list_tools");
+        assert_eq!(items[1]["server_label"], "Server B");
+
+        // [2..4] tool call items in original order
+        assert_eq!(items[2]["type"], "mcp_call");
+        assert_eq!(items[2]["id"], "call_1");
+        assert_eq!(items[3]["type"], "mcp_call");
+        assert_eq!(items[3]["id"], "call_2");
+
+        // [4..6] existing items in original order
+        assert_eq!(items[4]["type"], "message");
+        assert_eq!(items[4]["id"], "msg_existing_1");
+        assert_eq!(items[5]["type"], "message");
+        assert_eq!(items[5]["id"], "msg_existing_2");
+    }
+
     #[test]
     fn test_allowed_tools_filters_only_target_server() {
         let orchestrator = McpOrchestrator::new_test();


### PR DESCRIPTION
## Summary

Replaces quadratic `Vec::insert(0, ..)` loop in `inject_mcp_output_items` with a single-pass `Vec` construction that preserves the same ordering.

## What changed

- **`mcp/src/core/session.rs`** (`inject_mcp_output_items`): Instead of calling `output.insert(0, ..)` in a reverse-iterator loop (O(n^2) due to element shifting on each insertion), we now:
  1. Pre-allocate a new `Vec` with exact capacity
  2. Push `mcp_list_tools` items in forward order (removing the need for `.rev()`)
  3. Extend with `tool_call_items`
  4. Append existing output items via `Vec::append` (O(n) drain)
  5. Assign the new vec back to `*output`

## Why

`Vec::insert(0, ..)` shifts all existing elements right on every call, making the loop O(n * m) where n is the number of servers and m is the current vec length. With many MCP servers and large output arrays this is a meaningful performance bottleneck. The new approach is O(n + m) total.

## How

Single-pass construction with pre-allocated capacity. The output ordering is identical: list_tools items first, then tool call items, then original output items.

## Test plan

- `cargo check -p smg-mcp` passes
- `cargo test -p smg-mcp` passes (151 tests, 0 failures)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved session output assembly for more efficient, single-pass processing; generated tool summaries now appear first, followed by tool calls, then existing items.
  * No changes to public interfaces.
* **Tests**
  * Added regression tests to verify the exact ordering of tool summaries, tool calls, and existing items (duplicate checks in two test locations).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->