### PR TITLE
refactor(mcp): deduplicate McpConnectionPool constructors

### DIFF
--- a/mcp/src/core/pool.rs
+++ b/mcp/src/core/pool.rs
@@ -113,26 +113,11 @@ impl McpConnectionPool {
 
     /// Create pool with defaults (200 connections, proxy from env).
     pub fn new() -> Self {
-        let cache_cap = std::num::NonZeroUsize::new(Self::DEFAULT_MAX_CONNECTIONS)
-            .unwrap_or(std::num::NonZeroUsize::MIN);
-        Self {
-            connections: Arc::new(Mutex::new(LruCache::new(cache_cap))),
-            max_connections: Self::DEFAULT_MAX_CONNECTIONS,
-            global_proxy: McpProxyConfig::from_env(),
-            eviction_callback: None,
-        }
+        Self::with_full_config(Self::DEFAULT_MAX_CONNECTIONS, McpProxyConfig::from_env())
     }
 
     pub fn with_capacity(max_connections: usize) -> Self {
-        let max_connections = max_connections.max(1);
-        let cache_cap =
-            std::num::NonZeroUsize::new(max_connections).unwrap_or(std::num::NonZeroUsize::MIN);
-        Self {
-            connections: Arc::new(Mutex::new(LruCache::new(cache_cap))),
-            max_connections,
-            global_proxy: McpProxyConfig::from_env(),
-            eviction_callback: None,
-        }
+        Self::with_full_config(max_connections, McpProxyConfig::from_env())
     }
 
     pub fn with_full_config(max_connections: usize, global_proxy: Option<McpProxyConfig>) -> Self {


### PR DESCRIPTION
## Summary

Deduplicate `McpConnectionPool` constructor logic so `new()` and `with_capacity()` delegate to `with_full_config()` instead of each repeating the same initialization.

## What changed

- **`mcp/src/core/pool.rs`**: `new()` now calls `Self::with_full_config(DEFAULT_MAX_CONNECTIONS, McpProxyConfig::from_env())` instead of manually constructing the struct.
- **`mcp/src/core/pool.rs`**: `with_capacity(max)` now calls `Self::with_full_config(max, McpProxyConfig::from_env())` instead of manually constructing the struct.

## Why

All three constructors duplicated the same cache capacity clamping, `NonZeroUsize` conversion, `LruCache` creation, and struct field initialization. Any future changes to construction logic (e.g., adding new fields, changing defaults) would need to be replicated across all three, risking drift and inconsistency.

## How

The two simpler constructors now delegate to `with_full_config()`, which remains the single source of truth for pool initialization. The `max_connections.max(1)` clamping in `with_full_config()` covers the `DEFAULT_MAX_CONNECTIONS` case (200 > 1), so behavior is fully preserved. Net result is -17 lines of duplicated code replaced by 2 delegation calls.

## Test plan

- `cargo check -p smg-mcp` passes with no errors
- `cargo test -p smg-mcp` passes all 151 tests, including:
  - `test_pool_creation` (exercises `new()`)
  - `test_pool_stats` (exercises `with_capacity()`)
  - `test_pool_with_global_proxy` (exercises `with_full_config()`)
  - `test_pool_proxy_from_env` (exercises proxy-from-env path via `new()`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal initialization logic to eliminate code duplication and improve maintainability. No changes to user-facing functionality or API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->