### PR TITLE
docs(mcp): document O(n) complexity on pool URL-based lookups

### DIFF
--- a/mcp/src/core/pool.rs
+++ b/mcp/src/core/pool.rs
@@ -227,7 +227,11 @@ impl McpConnectionPool {
         self.connections.lock().contains(key)
     }
 
-    /// Get by URL only (backward compat). Prefer `get()` with full `PoolKey`.
+    /// Look up a connection by URL only (backward compatibility).
+    ///
+    /// **O(n)** — performs a linear scan of all pooled connections under the
+    /// lock. Callers on hot paths should prefer [`get()`](Self::get) with a
+    /// full [`PoolKey`] for O(1) lookup.
     pub fn get_by_url(&self, url: &str) -> Option<Arc<McpClient>> {
         self.connections
             .lock()
@@ -236,6 +240,12 @@ impl McpConnectionPool {
             .map(|(_, cached)| Arc::clone(&cached.client))
     }
 
+    /// Check whether a connection with the given URL exists (backward
+    /// compatibility).
+    ///
+    /// **O(n)** — performs a linear scan of all pooled connections under the
+    /// lock. Callers on hot paths should prefer [`contains()`](Self::contains)
+    /// with a full [`PoolKey`] for O(1) lookup.
     pub fn contains_url(&self, url: &str) -> bool {
         self.connections
             .lock()


### PR DESCRIPTION
## Summary

- Add doc comments to `get_by_url` and `contains_url` in `McpConnectionPool` noting O(n) linear scan complexity and recommending `PoolKey`-based alternatives for hot paths.

## What changed

- `mcp/src/core/pool.rs`: Expanded doc comments on `get_by_url` and `contains_url` with complexity annotations (`O(n)` linear scan under the lock) and guidance to prefer `get()` / `contains()` with a full `PoolKey` for O(1) lookup.

## Why

These two methods perform linear scans of the entire connection pool under the mutex lock. While this is acceptable for their current low usage (one caller for `get_by_url` in `orchestrator.rs`, zero external callers for `contains_url`), future callers should be aware of the cost and prefer the `PoolKey`-based alternatives.

A secondary `HashMap<String, PoolKey>` index was considered but deemed unnecessary given the minimal caller count.

## How

Documentation-only change. Searched the entire workspace for callers of both methods to confirm low usage before deciding on the documentation approach over adding an index.

## Test plan

- [x] `cargo check -p smg-mcp` passes
- [x] `cargo test -p smg-mcp` passes (151 tests)