### PR TITLE
perf(mcp): reverse iterate and add optional limit to AuditLog::for_request

### DIFF
--- a/mcp/src/approval/audit.rs
+++ b/mcp/src/approval/audit.rs
@@ -244,4 +244,109 @@ mod tests {
         let t1_entries = log.for_tenant(&tenant1, 10);
         assert_eq!(t1_entries.len(), 2);
     }
+
+    #[test]
+    fn test_for_request_reverse_order_no_limit() {
+        let log = AuditLog::new();
+        let tenant = TenantId::new("test");
+        let name = QualifiedToolName::new("server", "tool");
+
+        log.record_decision(
+            &name,
+            &tenant,
+            "req-1",
+            DecisionResult::Approved,
+            DecisionSource::PolicyEngine,
+        );
+        log.record_decision(
+            &name,
+            &tenant,
+            "req-2",
+            DecisionResult::Approved,
+            DecisionSource::PolicyEngine,
+        );
+        log.record_decision(
+            &name,
+            &tenant,
+            "req-1",
+            DecisionResult::Denied {
+                reason: "policy violation".into(),
+            },
+            DecisionSource::RuleMatch,
+        );
+        log.record_decision(
+            &name,
+            &tenant,
+            "req-1",
+            DecisionResult::Pending,
+            DecisionSource::UserInteractive,
+        );
+
+        let entries = log.for_request("req-1", None);
+        assert_eq!(entries.len(), 3);
+        // Newest first (reverse chronological)
+        assert!(matches!(entries[0].result, DecisionResult::Pending));
+        assert!(matches!(entries[1].result, DecisionResult::Denied { .. }));
+        assert!(matches!(entries[2].result, DecisionResult::Approved));
+    }
+
+    #[test]
+    fn test_for_request_with_limit() {
+        let log = AuditLog::new();
+        let tenant = TenantId::new("test");
+        let name = QualifiedToolName::new("server", "tool");
+
+        log.record_decision(
+            &name,
+            &tenant,
+            "req-1",
+            DecisionResult::Approved,
+            DecisionSource::PolicyEngine,
+        );
+        log.record_decision(
+            &name,
+            &tenant,
+            "req-1",
+            DecisionResult::Denied {
+                reason: "denied".into(),
+            },
+            DecisionSource::RuleMatch,
+        );
+        log.record_decision(
+            &name,
+            &tenant,
+            "req-1",
+            DecisionResult::Pending,
+            DecisionSource::UserInteractive,
+        );
+
+        // Limit to 1 returns only the newest entry
+        let entries = log.for_request("req-1", Some(1));
+        assert_eq!(entries.len(), 1);
+        assert!(matches!(entries[0].result, DecisionResult::Pending));
+
+        // Limit to 2 returns the two newest entries
+        let entries = log.for_request("req-1", Some(2));
+        assert_eq!(entries.len(), 2);
+        assert!(matches!(entries[0].result, DecisionResult::Pending));
+        assert!(matches!(entries[1].result, DecisionResult::Denied { .. }));
+    }
+
+    #[test]
+    fn test_for_request_with_zero_limit() {
+        let log = AuditLog::new();
+        let tenant = TenantId::new("test");
+        let name = QualifiedToolName::new("server", "tool");
+
+        log.record_decision(
+            &name,
+            &tenant,
+            "req-1",
+            DecisionResult::Approved,
+            DecisionSource::PolicyEngine,
+        );
+
+        let entries = log.for_request("req-1", Some(0));
+        assert!(entries.is_empty());
+    }
 }


### PR DESCRIPTION
## Summary

Optimizes `AuditLog::for_request` in `mcp/src/approval/audit.rs` to iterate in reverse order (most recent first) and adds an optional limit parameter, bringing it in line with the existing `for_tenant` method.

## What changed

- **`mcp/src/approval/audit.rs`**: Changed `for_request` signature from `(&self, request_id: &str) -> Vec<AuditEntry>` to `(&self, request_id: &str, limit: Option<usize>) -> Vec<AuditEntry>`. The iterator now uses `.rev()` and applies `.take(n)` when a limit is provided.

## Why

The `VecDeque` backing the audit log can hold up to 10,000 entries. `for_request` previously did a full forward linear scan over all entries. Since request entries are typically recent (appended to the back), iterating in reverse finds matching entries sooner. The optional limit parameter avoids collecting more results than needed and is consistent with `for_tenant` which already accepts a limit.

## How

Replaced `.iter()` with `.iter().rev()` and added a `match` on the `Option<usize>` limit to conditionally apply `.take(n)`. No callers exist outside tests, so no call-site updates were needed.

## Test plan

- `cargo check -p smg-mcp` passes
- `cargo test -p smg-mcp` passes (all 151 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audit entries now display in reverse-chronological order, with the most recent entries first.
  * Added optional limiting of the number of audit entries returned.

* **Tests**
  * Added tests validating reverse order, limit behavior (including 0), and correct entry counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->