### PR TITLE
refactor(grpc): replace hand-rolled tool-info JSON with build_mcp_tool_infos

### DIFF
--- a/model_gateway/src/routers/grpc/common/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/common/responses/streaming.rs
@@ -18,6 +18,7 @@ use serde_json::json;
 use smg_mcp::{self as mcp, ResponseFormat};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::UnboundedReceiverStream;
+use tracing::warn;
 use uuid::Uuid;
 
 use crate::routers::grpc::harmony::responses::ToolResult;
@@ -927,7 +928,10 @@ impl ResponseStreamEventEmitter {
         let (output_index, item_id) = self.allocate_output_index(OutputItemType::McpListTools);
 
         // Build per-tool JSON items
-        let tool_items = Self::tool_entries_to_json(tools).unwrap_or_default();
+        let tool_items = Self::tool_entries_to_json(tools).unwrap_or_else(|e| {
+            warn!("Failed to serialize McpToolInfo to JSON: {e}");
+            Vec::new()
+        });
 
         // In-progress item (empty tools)
         let item_in_progress = json!({


### PR DESCRIPTION
## Summary

- Replace two inline `json!()` tool-info constructions in the gRPC streaming emitter with calls to the shared `mcp::build_mcp_tool_infos()` function
- Add a thin private helper `tool_entries_to_json()` that bridges the typed `Vec<McpToolInfo>` return value to `Vec<serde_json::Value>` needed by the JSON event emitter
- This also picks up the `annotations` field that the hand-rolled JSON was missing

## What changed

- `model_gateway/src/routers/grpc/common/responses/streaming.rs`:
  - Added `tool_entries_to_json()` helper method on `ResponseStreamEventEmitter`
  - Replaced inline tool-info JSON in `emit_mcp_list_tools_completed()` (line ~386)
  - Replaced inline tool-info JSON in `emit_mcp_list_tools_sequence()` (line ~931)

## Why

The two call sites duplicated the same tool-info mapping logic (`name`, `description`, `input_schema` extraction from `ToolEntry`) that `build_mcp_tool_infos` in `smg-mcp/src/responses_bridge.rs` already provides. Centralizing eliminates duplication and ensures consistent serialization (including the `annotations` field).

## How

`build_mcp_tool_infos` returns `Vec<McpToolInfo>` structs, but the streaming emitter needs `Vec<serde_json::Value>` for embedding in `json!()` macros. The new `tool_entries_to_json` helper bridges this via `serde_json::to_value()`.

## Test plan

- [x] `cargo check -p smg` passes
- [x] `cargo check -p smg-mcp` passes
- Existing streaming tests cover the affected event emission paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated tool conversion logic into a shared utility to reduce duplication.

* **Bug Fix**
  * Improved runtime error handling during tool list processing: failures are now logged and handled gracefully to avoid crashes (may result in an empty tool list instead of an error).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->