### PR TITLE
perf(mcp): use AtomicUsize for lock-free pool stats reads

### DIFF
--- a/mcp/src/core/pool.rs
+++ b/mcp/src/core/pool.rs
@@ -195,7 +195,8 @@ impl McpConnectionPool {
     }
 
     pub fn clear(&self) {
-        self.connections.lock().clear();
+        let mut connections = self.connections.lock();
+        connections.clear();
         self.connection_count.store(0, Ordering::Relaxed);
     }
 


### PR DESCRIPTION
## Summary

Replace mutex acquisition in `len()`, `is_empty()`, and `stats()` with an `AtomicUsize` counter for lock-free reads, eliminating unnecessary contention on the connection pool mutex.

## What changed

- **`mcp/src/core/pool.rs`**: Added `connection_count: AtomicUsize` field to `McpConnectionPool`.
  - Initialized to `0` in all three constructors (`new`, `with_capacity`, `with_full_config`).
  - `get_or_create`: increments the counter (`fetch_add(1)`) when a new entry is inserted without eviction. Eviction replaces an existing entry so the count stays constant.
  - `clear()`: resets the counter to `0` after clearing the LRU cache.
  - `len()`, `is_empty()`, `stats()`: now read from the atomic counter instead of acquiring the mutex.

## Why

`len()`, `is_empty()`, and `stats()` are read-only diagnostic queries that previously acquired the `parking_lot::Mutex` just to read the LRU cache length. On hot paths (e.g., health checks, metrics collection), this creates unnecessary contention with `get_or_create`. An `AtomicUsize` with `Relaxed` ordering provides a consistent-enough snapshot for diagnostics without blocking writers.

## How

The counter is incremented inside the existing lock scope of `get_or_create`, only on the no-eviction branch (`LruCache::push` returns `None`). When an eviction occurs (`push` returns `Some`), the count remains unchanged since one entry replaces another. `clear()` resets the counter to `0` after clearing the underlying map. `Relaxed` ordering is sufficient because these reads are advisory and do not guard other shared state.

## Test plan

- `cargo check -p smg-mcp` passes with no errors.
- `cargo test -p smg-mcp` passes all 151 tests, including existing pool tests (`test_pool_creation`, `test_pool_stats`, `test_pool_clear`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved connection pool tracking for more efficient, concurrent-safe counting of active connections; pool queries (size, empty, stats) and clear operations now reflect this optimized counter behavior, improving performance and accuracy under concurrent load.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->