### PR TITLE
refactor(mcp): remove unused invoked_tool_name and resolved_tool_name from ToolExecutionOutput

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -489,8 +489,6 @@ let session = McpToolSession::new(&orchestrator, vec![binding], "req-123");
 - `ToolExecutionInput`: Tool call ID, name, and arguments
 - `ToolExecutionOutput`: Full result including raw output, transformed item, duration, and error info
   - `tool_name`: Name used in transformed output items
-  - `invoked_tool_name`: Name originally provided by the caller/model (when available)
-  - `resolved_tool_name`: Canonical MCP tool name used for execution (when available)
 - `server_label`: User-facing label for API responses (distinct from internal `server_key`)
 
 Router code should use `McpToolSession` so exposed tool names are collision-safe and execution always resolves through session mapping (exposed name -> `{server_key, tool_name}`).

--- a/mcp/src/core/orchestrator.rs
+++ b/mcp/src/core/orchestrator.rs
@@ -229,14 +229,6 @@ pub struct ToolExecutionOutput {
     ///
     /// This is the display name used for response transformation/output.
     pub tool_name: String,
-    /// Tool name received from the caller/model before resolution.
-    ///
-    /// When no aliasing is used, this is typically the same as `tool_name`.
-    pub invoked_tool_name: Option<String>,
-    /// Canonical MCP tool name resolved for execution.
-    ///
-    /// When no aliasing is used, this is typically the same as `tool_name`.
-    pub resolved_tool_name: Option<String>,
     /// Server key where the tool was executed (internal identifier, may be URL).
     pub server_key: String,
     /// User-facing server label for API responses.
@@ -967,8 +959,6 @@ impl McpOrchestrator {
         ToolExecutionOutput {
             call_id: input.call_id,
             tool_name: input.tool_name,
-            invoked_tool_name: None,
-            resolved_tool_name: None,
             server_key: server_key.to_string(),
             server_label: server_label.to_string(),
             arguments_str,

--- a/mcp/src/core/session.rs
+++ b/mcp/src/core/session.rs
@@ -205,8 +205,6 @@ impl<'a> McpToolSession<'a> {
                 )
                 .await;
 
-            output.invoked_tool_name = Some(invoked_name.clone());
-            output.resolved_tool_name = Some(resolved_tool_name);
             output.tool_name = invoked_name;
             output
         } else {
@@ -220,8 +218,6 @@ impl<'a> McpToolSession<'a> {
             ToolExecutionOutput {
                 call_id: input.call_id,
                 tool_name: invoked_name.clone(),
-                invoked_tool_name: Some(invoked_name),
-                resolved_tool_name: None,
                 server_key: UNKNOWN_SERVER_KEY.to_string(),
                 server_label: fallback_label,
                 arguments_str: input.arguments.to_string(),


### PR DESCRIPTION
## Summary

Remove the write-only `invoked_tool_name` and `resolved_tool_name` fields from `ToolExecutionOutput`, reducing struct bloat without any behavioral change.

## What changed

- **mcp/src/core/orchestrator.rs**: Removed both `Option<String>` field declarations from the `ToolExecutionOutput` struct, and their `None` initialisations in `execute_tool_resolved` and `execute_tool_entry`.
- **mcp/src/core/session.rs**: Removed the field assignments in `McpToolSession::execute_tool` on both the success and error paths.
- **mcp/README.md**: Removed the stale documentation bullets describing the two fields.

## Why

Both fields were populated in `session.rs` but **never read** by any consumer in the entire workspace. The existing `tool_name` field already carries the display name (the session overwrites it with the invoked name), so the extra optional variants added struct size without providing value.

## How

1. Searched every `.rs` file for `invoked_tool_name` and `resolved_tool_name` -- all hits were declarations or assignments, zero reads.
2. Removed the fields and all write sites.
3. Verified with `cargo check -p smg-mcp`, `cargo check -p smg`, and `cargo test -p smg-mcp` (151 tests pass).

## Test plan

- `cargo check -p smg-mcp` -- compiles cleanly
- `cargo check -p smg` -- compiles cleanly
- `cargo test -p smg-mcp` -- 151 tests pass, 0 failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Removed unused internal fields from a data structure to streamline code and improve maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->