### PR TITLE
refactor(data-connector): extract shared random hex ID helper

### DIFF
--- a/data_connector/src/core.rs
+++ b/data_connector/src/core.rs
@@ -20,6 +20,24 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map as JsonMap, Value};
 
 // ============================================================================
+// Shared helpers
+// ============================================================================
+
+/// Generate a 50-character hex string from 25 cryptographically random bytes.
+/// Used by both `ConversationId::new()` and `make_item_id()`.
+fn random_hex_id() -> String {
+    let mut rng = rand::rng();
+    let mut bytes = [0u8; 25];
+    rng.fill_bytes(&mut bytes);
+    let mut hex_string = String::with_capacity(50);
+    for b in &bytes {
+        // Writing to a String is infallible; discard the always-Ok result.
+        let _ = write!(hex_string, "{b:02x}");
+    }
+    hex_string
+}
+
+// ============================================================================
 // PART 1: Conversation Storage
 // ============================================================================
 
@@ -28,15 +46,7 @@ pub struct ConversationId(pub String);
 
 impl ConversationId {
     pub fn new() -> Self {
-        let mut rng = rand::rng();
-        let mut bytes = [0u8; 25];
-        rng.fill_bytes(&mut bytes);
-        let mut hex_string = String::with_capacity(50);
-        for b in &bytes {
-            // Writing to a String is infallible; discard the always-Ok result.
-            let _ = write!(hex_string, "{b:02x}");
-        }
-        Self(format!("conv_{hex_string}"))
+        Self(format!("conv_{}", random_hex_id()))
     }
 }
 
@@ -275,15 +285,7 @@ pub trait ConversationItemStorage: Send + Sync + 'static {
 
 /// Helper to build id prefix based on item_type
 pub fn make_item_id(item_type: &str) -> ConversationItemId {
-    // Generate exactly 50 hex characters (25 bytes) for the part after the underscore
-    let mut rng = rand::rng();
-    let mut bytes = [0u8; 25];
-    rng.fill_bytes(&mut bytes);
-    let mut hex_string = String::with_capacity(50);
-    for b in &bytes {
-        // Writing to a String is infallible; discard the always-Ok result.
-        let _ = write!(hex_string, "{b:02x}");
-    }
+    let hex_string = random_hex_id();
 
     let prefix = match item_type {
         "message" => "msg",


### PR DESCRIPTION
## Description

### Problem

`ConversationId::new()` and `make_item_id()` in `data_connector/src/core.rs` both contain an identical 7-line block that generates a 50-character hex string from 25 random bytes. This duplication increases maintenance burden and risks divergence.

### Solution

Extract a shared `random_hex_id()` helper function that both `ConversationId::new()` and `make_item_id()` now call. Behavior is unchanged — both still produce the same format of IDs.

## Changes

- Add `random_hex_id()` private helper in `core.rs` that generates 25 random bytes and encodes them as a 50-char lowercase hex string
- Simplify `ConversationId::new()` to call `random_hex_id()`
- Simplify `make_item_id()` to call `random_hex_id()`

## Test Plan

Existing unit tests cover the behavior:
- `conversation_id_new_has_conv_prefix` / `conversation_id_new_generates_unique_ids` / `conversation_id_new_has_consistent_length`
- `make_item_id_*` tests

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal ID generation logic through consolidation of common functionality, improving code maintainability without affecting public APIs or user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->