### PR TITLE
perf(data-connector): eliminate double HashMap lookup in list_identifier_responses

### DIFF
--- a/data_connector/src/memory.rs
+++ b/data_connector/src/memory.rs
@@ -431,7 +431,7 @@ impl ResponseStorage for MemoryResponseStorage {
             // Collect responses with their timestamps for sorting
             let mut responses_with_time: Vec<_> = user_response_ids
                 .iter()
-                .filter_map(|id| store.responses.get(id).map(|r| (r.created_at, id)))
+                .filter_map(|id| store.responses.get(id).map(|r| (r.created_at, r)))
                 .collect();
 
             // Sort by creation time (newest first)
@@ -442,7 +442,7 @@ impl ResponseStorage for MemoryResponseStorage {
             let user_responses: Vec<StoredResponse> = responses_with_time
                 .into_iter()
                 .take(limit)
-                .filter_map(|(_, id)| store.responses.get(id).cloned())
+                .map(|(_, r)| r.clone())
                 .collect();
 
             Ok(user_responses)


### PR DESCRIPTION
## Description

### Problem

`list_identifier_responses` in `memory.rs` performs two HashMap lookups per response: once to get the timestamp for sorting, and again to clone the response after sorting. The second lookup is redundant since we already have access to the response in the first pass.

### Solution

Store `&StoredResponse` references from the first lookup pass instead of IDs, so the second pass can clone directly without re-looking up each entry.

## Changes

- Change first pass to collect `(created_at, &StoredResponse)` tuples instead of `(created_at, &ResponseId)`
- Change second pass from `filter_map(|(_, id)| store.responses.get(id).cloned())` to `map(|(_, r)| r.clone())`

## Test Plan

Existing unit tests in `memory::tests` pass unchanged, including `test_user_responses` which exercises this exact code path.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal data handling for improved efficiency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->