### PR TITLE
refactor(workflow): simplify definition and engine internals

### DIFF
--- a/workflow/src/definition.rs
+++ b/workflow/src/definition.rs
@@ -171,6 +171,11 @@ impl<D: WorkflowData> StepDefinition<D> {
         self.run_if = Some(Arc::new(condition));
         self
     }
+
+    /// Iterator over all dependencies (both `depends_on` and `depends_on_any`)
+    pub fn all_dependencies(&self) -> impl Iterator<Item = &StepId> {
+        self.depends_on.iter().chain(self.depends_on_any.iter())
+    }
 }
 
 /// Complete workflow definition
@@ -252,15 +257,7 @@ impl<D: WorkflowData> WorkflowDefinition<D> {
 
         // Check all dependencies exist (both depends_on and depends_on_any)
         for step in &self.steps {
-            for dep in &step.depends_on {
-                if !steps_map.contains_key(dep) {
-                    return Err(ValidationError::MissingDependency {
-                        step: step.id.clone(),
-                        dependency: dep.clone(),
-                    });
-                }
-            }
-            for dep in &step.depends_on_any {
+            for dep in step.all_dependencies() {
                 if !steps_map.contains_key(dep) {
                     return Err(ValidationError::MissingDependency {
                         step: step.id.clone(),
@@ -286,13 +283,7 @@ impl<D: WorkflowData> WorkflowDefinition<D> {
         // Include both depends_on and depends_on_any
         self.reverse_deps.clear();
         for (idx, step) in self.steps.iter().enumerate() {
-            for dep_id in &step.depends_on {
-                self.reverse_deps
-                    .entry(dep_id.clone())
-                    .or_default()
-                    .push(idx);
-            }
-            for dep_id in &step.depends_on_any {
+            for dep_id in step.all_dependencies() {
                 self.reverse_deps
                     .entry(dep_id.clone())
                     .or_default()
@@ -333,12 +324,7 @@ impl<D: WorkflowData> WorkflowDefinition<D> {
         // O(1) lookup instead of linear search
         // Check both depends_on and depends_on_any for cycles
         if let Some(step) = steps_map.get(step_id) {
-            for dep in &step.depends_on {
-                if Self::has_cycle(dep, steps_map, visited, rec_stack) {
-                    return true;
-                }
-            }
-            for dep in &step.depends_on_any {
+            for dep in step.all_dependencies() {
                 if Self::has_cycle(dep, steps_map, visited, rec_stack) {
                     return true;
                 }

--- a/workflow/src/engine.rs
+++ b/workflow/src/engine.rs
@@ -182,10 +182,9 @@ pub struct WorkflowEngine<D: WorkflowData, S: StateStore<D> = InMemoryStore<D>> 
     definitions: Arc<RwLock<HashMap<WorkflowId, Arc<WorkflowDefinition<D>>>>>,
     state_store: S,
     event_bus: Arc<EventBus>,
-    /// Shutdown signal sender - when true, engine is shutting down
+    /// Shutdown signal sender - when true, engine is shutting down.
+    /// Also used to derive receivers via `subscribe()` and check state via `borrow()`.
     shutdown_tx: Arc<watch::Sender<bool>>,
-    /// Shutdown signal receiver for cloning to tasks
-    shutdown_rx: watch::Receiver<bool>,
     /// Count of active workflow executions
     active_workflows: Arc<AtomicUsize>,
     _phantom: PhantomData<D>,
@@ -200,13 +199,12 @@ impl<D: WorkflowData> WorkflowEngine<D, InMemoryStore<D>> {
 impl<D: WorkflowData, S: StateStore<D> + 'static> WorkflowEngine<D, S> {
     /// Create a new workflow engine with a custom state store
     pub fn with_store(state_store: S) -> Self {
-        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        let (shutdown_tx, _) = watch::channel(false);
         Self {
             definitions: Arc::new(RwLock::new(HashMap::new())),
             state_store,
             event_bus: Arc::new(EventBus::new()),
             shutdown_tx: Arc::new(shutdown_tx),
-            shutdown_rx,
             active_workflows: Arc::new(AtomicUsize::new(0)),
             _phantom: PhantomData,
         }
@@ -214,7 +212,7 @@ impl<D: WorkflowData, S: StateStore<D> + 'static> WorkflowEngine<D, S> {
 
     /// Check if the engine is shutting down
     pub fn is_shutting_down(&self) -> bool {
-        *self.shutdown_rx.borrow()
+        *self.shutdown_tx.borrow()
     }
 
     /// Initiate graceful shutdown
@@ -364,7 +362,7 @@ impl<D: WorkflowData, S: StateStore<D> + 'static> WorkflowEngine<D, S> {
         let state_store = self.state_store.clone();
         let ttl = ttl.unwrap_or(Duration::from_secs(3600)); // 1 hour default
         let interval = interval.unwrap_or(Duration::from_secs(300)); // 5 minutes default
-        let mut shutdown_rx = self.shutdown_rx.clone();
+        let mut shutdown_rx = self.shutdown_tx.subscribe();
 
         #[expect(
             clippy::disallowed_methods,
@@ -440,6 +438,7 @@ impl<D: WorkflowData, S: StateStore<D> + 'static> WorkflowEngine<D, S> {
         let mut state = WorkflowState::new(instance_id, definition_id.clone(), data);
         state.status = WorkflowStatus::Running;
 
+        state.step_states.reserve(definition.steps.len());
         for step in &definition.steps {
             state
                 .step_states
@@ -1176,7 +1175,6 @@ impl<D: WorkflowData, S: StateStore<D> + 'static> WorkflowEngine<D, S> {
             state_store: self.state_store.clone(),
             event_bus: Arc::clone(&self.event_bus),
             shutdown_tx: Arc::clone(&self.shutdown_tx),
-            shutdown_rx: self.shutdown_rx.clone(),
             active_workflows: Arc::clone(&self.active_workflows),
             _phantom: PhantomData,
         }


### PR DESCRIPTION
## Summary

Simplify the workflow crate (`wfaas`) internals by eliminating code duplication in `definition.rs` and removing redundant state in `engine.rs`.

## What changed

- **`workflow/src/definition.rs`**: Added `StepDefinition::all_dependencies()` iterator that chains `depends_on` and `depends_on_any`, replacing three separate duplicate iteration blocks in `validate()` — dependency existence check, reverse-deps build, and cycle detection DFS.
- **`workflow/src/engine.rs`**: Removed the redundant `shutdown_rx: watch::Receiver<bool>` field from `WorkflowEngine`. The receiver was derivable from `shutdown_tx.subscribe()` and current state from `shutdown_tx.borrow()`, so storing it separately was unnecessary.
- **`workflow/src/engine.rs`**: Pre-sized `step_states` HashMap with `reserve(steps.len())` before populating it, avoiding rehashing during workflow startup.

## Why

Code review identified three instances of duplicated iteration over both dependency types (`depends_on` + `depends_on_any`) in the validation logic, a redundant struct field that was derivable from an existing field, and an avoidable allocation pattern. These are straightforward simplifications with no behavior change.

## How

- `all_dependencies()` returns `self.depends_on.iter().chain(self.depends_on_any.iter())` — a zero-cost iterator composition.
- `shutdown_rx` removal uses `watch::Sender::borrow()` (for checking current value) and `watch::Sender::subscribe()` (for creating new receivers) which are standard tokio watch channel APIs.
- `HashMap::reserve()` is called once before the insert loop with the known step count.

## Test plan

- `cargo check -p wfaas` — compiles clean
- `cargo test -p wfaas` — all 21 tests pass (2 unit + 21 integration)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal dependency handling logic to improve code maintainability.
  * Optimized workflow state allocation for improved execution efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->