### PR TITLE
fix(grpc): return `tonic::Status` directly from grpc_client RPC methods

### DIFF
--- a/grpc_client/src/lib.rs
+++ b/grpc_client/src/lib.rs
@@ -60,10 +60,7 @@ macro_rules! impl_subscribe_kv_events {
         pub async fn subscribe_kv_events(
             &self,
             start_sequence_number: u64,
-        ) -> Result<
-            tonic::Streaming<$crate::common_proto::KvEventBatch>,
-            Box<dyn std::error::Error + Send + Sync>,
-        > {
+        ) -> Result<tonic::Streaming<$crate::common_proto::KvEventBatch>, tonic::Status> {
             let request = tonic::Request::new($crate::common_proto::SubscribeKvEventsRequest {
                 start_sequence_number,
             });

--- a/grpc_client/src/sglang_scheduler.rs
+++ b/grpc_client/src/sglang_scheduler.rs
@@ -183,7 +183,7 @@ impl SglangSchedulerClient {
     pub async fn generate(
         &self,
         req: proto::GenerateRequest,
-    ) -> Result<AbortOnDropStream, Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<AbortOnDropStream, tonic::Status> {
         let request_id = req.request_id.clone();
         let mut client = self.client.clone();
         let mut request = Request::new(req);
@@ -206,7 +206,7 @@ impl SglangSchedulerClient {
     pub async fn embed(
         &self,
         req: proto::EmbedRequest,
-    ) -> Result<proto::EmbedResponse, Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<proto::EmbedResponse, tonic::Status> {
         let mut client = self.client.clone();
         let mut request = Request::new(req);
 
@@ -220,9 +220,7 @@ impl SglangSchedulerClient {
     }
 
     /// Perform health check
-    pub async fn health_check(
-        &self,
-    ) -> Result<proto::HealthCheckResponse, Box<dyn std::error::Error + Send + Sync>> {
+    pub async fn health_check(&self) -> Result<proto::HealthCheckResponse, tonic::Status> {
         debug!("Sending health check request");
         // HealthCheckRequest is now empty - server generates its own health check internally
         let request = Request::new(proto::HealthCheckRequest {});
@@ -238,7 +236,7 @@ impl SglangSchedulerClient {
         &self,
         request_id: String,
         reason: String,
-    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<(), tonic::Status> {
         debug!(
             "Sending abort request for {} (reason: {})",
             request_id, reason
@@ -260,9 +258,7 @@ impl SglangSchedulerClient {
     }
 
     /// Get model information
-    pub async fn get_model_info(
-        &self,
-    ) -> Result<proto::GetModelInfoResponse, Box<dyn std::error::Error + Send + Sync>> {
+    pub async fn get_model_info(&self) -> Result<proto::GetModelInfoResponse, tonic::Status> {
         debug!("Requesting model info");
         let request = Request::new(proto::GetModelInfoRequest {});
 
@@ -273,9 +269,7 @@ impl SglangSchedulerClient {
     }
 
     /// Get server information
-    pub async fn get_server_info(
-        &self,
-    ) -> Result<proto::GetServerInfoResponse, Box<dyn std::error::Error + Send + Sync>> {
+    pub async fn get_server_info(&self) -> Result<proto::GetServerInfoResponse, tonic::Status> {
         debug!("Requesting server info");
         let request = Request::new(proto::GetServerInfoRequest {});
 
@@ -289,7 +283,7 @@ impl SglangSchedulerClient {
     pub async fn get_loads(
         &self,
         include: Vec<String>,
-    ) -> Result<proto::GetLoadsResponse, Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<proto::GetLoadsResponse, tonic::Status> {
         debug!("Requesting load metrics");
         let request = Request::new(proto::GetLoadsRequest {
             dp_rank: None,

--- a/grpc_client/src/trtllm_service.rs
+++ b/grpc_client/src/trtllm_service.rs
@@ -182,7 +182,7 @@ impl TrtllmServiceClient {
     pub async fn generate(
         &self,
         req: proto::GenerateRequest,
-    ) -> Result<AbortOnDropStream, Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<AbortOnDropStream, tonic::Status> {
         let request_id = req.request_id.clone();
         let mut client = self.client.clone();
         let mut request = Request::new(req);
@@ -202,9 +202,7 @@ impl TrtllmServiceClient {
     }
 
     /// Perform health check
-    pub async fn health_check(
-        &self,
-    ) -> Result<proto::HealthCheckResponse, Box<dyn std::error::Error + Send + Sync>> {
+    pub async fn health_check(&self) -> Result<proto::HealthCheckResponse, tonic::Status> {
         debug!("Sending health check request");
         let request = Request::new(proto::HealthCheckRequest {});
 
@@ -218,7 +216,7 @@ impl TrtllmServiceClient {
     pub async fn abort_request(
         &self,
         request_id: String,
-    ) -> Result<proto::AbortResponse, Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<proto::AbortResponse, tonic::Status> {
         debug!("Sending abort request for {}", request_id);
         let request = Request::new(proto::AbortRequest {
             request_id: request_id.clone(),
@@ -236,9 +234,7 @@ impl TrtllmServiceClient {
     }
 
     /// Get model information
-    pub async fn get_model_info(
-        &self,
-    ) -> Result<proto::GetModelInfoResponse, Box<dyn std::error::Error + Send + Sync>> {
+    pub async fn get_model_info(&self) -> Result<proto::GetModelInfoResponse, tonic::Status> {
         debug!("Requesting model info");
         let request = Request::new(proto::GetModelInfoRequest {});
 
@@ -249,9 +245,7 @@ impl TrtllmServiceClient {
     }
 
     /// Get server information
-    pub async fn get_server_info(
-        &self,
-    ) -> Result<proto::GetServerInfoResponse, Box<dyn std::error::Error + Send + Sync>> {
+    pub async fn get_server_info(&self) -> Result<proto::GetServerInfoResponse, tonic::Status> {
         debug!("Requesting server info");
         let request = Request::new(proto::GetServerInfoRequest {});
 

--- a/grpc_client/src/vllm_engine.rs
+++ b/grpc_client/src/vllm_engine.rs
@@ -183,7 +183,7 @@ impl VllmEngineClient {
     pub async fn generate(
         &self,
         req: proto::GenerateRequest,
-    ) -> Result<AbortOnDropStream, Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<AbortOnDropStream, tonic::Status> {
         let request_id = req.request_id.clone();
         let mut client = self.client.clone();
         let mut request = Request::new(req);
@@ -203,9 +203,7 @@ impl VllmEngineClient {
     }
 
     /// Perform health check
-    pub async fn health_check(
-        &self,
-    ) -> Result<proto::HealthCheckResponse, Box<dyn std::error::Error + Send + Sync>> {
+    pub async fn health_check(&self) -> Result<proto::HealthCheckResponse, tonic::Status> {
         debug!("Sending health check request");
         // HealthCheckRequest is now empty - server generates its own health check internally
         let request = Request::new(proto::HealthCheckRequest {});
@@ -221,7 +219,7 @@ impl VllmEngineClient {
         &self,
         request_id: String,
         _reason: String,
-    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<(), tonic::Status> {
         debug!("Sending abort request for {}", request_id);
         let request = Request::new(proto::AbortRequest {
             request_ids: vec![request_id.clone()],
@@ -234,9 +232,7 @@ impl VllmEngineClient {
     }
 
     /// Get model information
-    pub async fn get_model_info(
-        &self,
-    ) -> Result<proto::GetModelInfoResponse, Box<dyn std::error::Error + Send + Sync>> {
+    pub async fn get_model_info(&self) -> Result<proto::GetModelInfoResponse, tonic::Status> {
         debug!("Requesting model info");
         let request = Request::new(proto::GetModelInfoRequest {});
 
@@ -247,9 +243,7 @@ impl VllmEngineClient {
     }
 
     /// Get server information
-    pub async fn get_server_info(
-        &self,
-    ) -> Result<proto::GetServerInfoResponse, Box<dyn std::error::Error + Send + Sync>> {
+    pub async fn get_server_info(&self) -> Result<proto::GetServerInfoResponse, tonic::Status> {
         debug!("Requesting server info");
         let request = Request::new(proto::GetServerInfoRequest {});
 

--- a/model_gateway/src/core/kv_event_monitor.rs
+++ b/model_gateway/src/core/kv_event_monitor.rs
@@ -328,16 +328,14 @@ impl KvEventMonitor {
                 Err(e) => {
                     // If the backend doesn't implement SubscribeKvEvents (e.g. vLLM),
                     // stop retrying — this RPC will never succeed.
-                    if let Some(status) = e.downcast_ref::<tonic::Status>() {
-                        if status.code() == tonic::Code::Unimplemented {
-                            warn!(
-                                worker_url = %worker_url,
-                                "Backend does not implement SubscribeKvEvents, \
-                                 disabling KV event subscription for this worker"
-                            );
-                            indexer.remove_worker(worker_id, worker_blocks);
-                            return;
-                        }
+                    if e.code() == tonic::Code::Unimplemented {
+                        warn!(
+                            worker_url = %worker_url,
+                            "Backend does not implement SubscribeKvEvents, \
+                             disabling KV event subscription for this worker"
+                        );
+                        indexer.remove_worker(worker_id, worker_blocks);
+                        return;
                     }
                     warn!(
                         worker_url = %worker_url,

--- a/model_gateway/src/routers/grpc/client.rs
+++ b/model_gateway/src/routers/grpc/client.rs
@@ -121,9 +121,7 @@ impl GrpcClient {
         }
     }
 
-    pub async fn health_check(
-        &self,
-    ) -> Result<HealthCheckResponse, Box<dyn std::error::Error + Send + Sync>> {
+    pub async fn health_check(&self) -> Result<HealthCheckResponse, tonic::Status> {
         match self {
             Self::Sglang(client) => {
                 let resp = client.health_check().await?;
@@ -151,9 +149,7 @@ impl GrpcClient {
         }
     }
 
-    pub async fn get_model_info(
-        &self,
-    ) -> Result<ModelInfo, Box<dyn std::error::Error + Send + Sync>> {
+    pub async fn get_model_info(&self) -> Result<ModelInfo, tonic::Status> {
         match self {
             Self::Sglang(client) => Ok(ModelInfo::Sglang(Box::new(client.get_model_info().await?))),
             Self::Vllm(client) => Ok(ModelInfo::Vllm(client.get_model_info().await?)),
@@ -163,15 +159,15 @@ impl GrpcClient {
 
     /// Get the full load response from the backend.
     /// Only supported for SGLang backends. Returns per-DP-rank load metrics.
-    pub async fn get_loads(
-        &self,
-    ) -> Result<WorkerLoadResponse, Box<dyn std::error::Error + Send + Sync>> {
+    pub async fn get_loads(&self) -> Result<WorkerLoadResponse, tonic::Status> {
         match self {
             Self::Sglang(client) => {
                 let resp = client.get_loads(vec!["core".to_string()]).await?;
                 Ok(WorkerLoadResponse::from(resp))
             }
-            _ => Err("GetLoads RPC not supported for this backend".into()),
+            _ => Err(tonic::Status::unimplemented(
+                "GetLoads RPC not supported for this backend",
+            )),
         }
     }
 
@@ -179,10 +175,7 @@ impl GrpcClient {
     pub async fn subscribe_kv_events(
         &self,
         start_seq: u64,
-    ) -> Result<
-        tonic::Streaming<smg_grpc_client::common_proto::KvEventBatch>,
-        Box<dyn std::error::Error + Send + Sync>,
-    > {
+    ) -> Result<tonic::Streaming<smg_grpc_client::common_proto::KvEventBatch>, tonic::Status> {
         match self {
             Self::Sglang(client) => client.subscribe_kv_events(start_seq).await,
             Self::Vllm(client) => client.subscribe_kv_events(start_seq).await,
@@ -190,9 +183,7 @@ impl GrpcClient {
         }
     }
 
-    pub async fn get_server_info(
-        &self,
-    ) -> Result<ServerInfo, Box<dyn std::error::Error + Send + Sync>> {
+    pub async fn get_server_info(&self) -> Result<ServerInfo, tonic::Status> {
         match self {
             Self::Sglang(client) => Ok(ServerInfo::Sglang(Box::new(
                 client.get_server_info().await?,
@@ -232,15 +223,15 @@ impl GrpcClient {
     ) -> Result<ProtoStream, tonic::Status> {
         match (self, req) {
             (Self::Sglang(client), ProtoGenerateRequest::Sglang(boxed_req)) => {
-                let stream = client.generate(*boxed_req).await.map_err(into_status)?;
+                let stream = client.generate(*boxed_req).await?;
                 Ok(ProtoStream::Sglang(stream))
             }
             (Self::Vllm(client), ProtoGenerateRequest::Vllm(boxed_req)) => {
-                let stream = client.generate(*boxed_req).await.map_err(into_status)?;
+                let stream = client.generate(*boxed_req).await?;
                 Ok(ProtoStream::Vllm(stream))
             }
             (Self::Trtllm(client), ProtoGenerateRequest::Trtllm(boxed_req)) => {
-                let stream = client.generate(*boxed_req).await.map_err(into_status)?;
+                let stream = client.generate(*boxed_req).await?;
                 Ok(ProtoStream::Trtllm(stream))
             }
             #[expect(
@@ -257,7 +248,7 @@ impl GrpcClient {
     ) -> Result<ProtoEmbedResponse, tonic::Status> {
         match (self, req) {
             (Self::Sglang(client), ProtoEmbedRequest::Sglang(boxed_req)) => {
-                let resp = client.embed(*boxed_req).await.map_err(into_status)?;
+                let resp = client.embed(*boxed_req).await?;
                 Ok(ProtoEmbedResponse::Sglang(resp))
             }
             #[expect(
@@ -366,15 +357,6 @@ impl GrpcClient {
                 Ok(ProtoGenerateRequest::Trtllm(Box::new(req)))
             }
         }
-    }
-}
-
-/// Downcast a boxed error to `tonic::Status`, falling back to `Status::internal`.
-/// The grpc_client crate returns `Box<dyn Error>` but the concrete type is always `tonic::Status`.
-fn into_status(err: Box<dyn std::error::Error + Send + Sync>) -> tonic::Status {
-    match err.downcast::<tonic::Status>() {
-        Ok(status) => *status,
-        Err(other) => tonic::Status::internal(other.to_string()),
     }
 }
 


### PR DESCRIPTION
## Description

### Problem

The `grpc_client` crate returns `Box<dyn Error + Send + Sync>` from all RPC methods despite the concrete error always being `tonic::Status`. This was a prototype choice copy-pasted from `connect()` (which legitimately needs `Box` for mixed error types) that was never cleaned up.

This forces every caller to downcast back to `tonic::Status`:
- `into_status()` in `client.rs`
- `downcast_ref::<tonic::Status>()` in `kv_event_monitor.rs`

### Solution

Change all RPC method return types from `Box<dyn Error + Send + Sync>` to `tonic::Status` directly, eliminating the downcast workarounds.

`connect()` and `get_tokenizer()` remain `Box<dyn Error>` because they have genuinely mixed error types (`tonic::transport::Error`, timeout errors).

## Changes

- **`grpc_client/src/sglang_scheduler.rs`**: Change 7 RPC methods (`generate`, `embed`, `health_check`, `abort_request`, `get_model_info`, `get_server_info`, `get_loads`) to return `tonic::Status`.
- **`grpc_client/src/vllm_engine.rs`**: Change 5 RPC methods (`generate`, `health_check`, `abort_request`, `get_model_info`, `get_server_info`) to return `tonic::Status`.
- **`grpc_client/src/trtllm_service.rs`**: Change 5 RPC methods (`generate`, `health_check`, `abort_request`, `get_model_info`, `get_server_info`) to return `tonic::Status`.
- **`grpc_client/src/lib.rs`**: Change `impl_subscribe_kv_events!` macro return type to `tonic::Status`.
- **`model_gateway/src/routers/grpc/client.rs`**: Delete `into_status()`, remove 4 `.map_err(into_status)` calls, change 5 wrapper return types to `tonic::Status`, use `tonic::Status::unimplemented()` for unsupported backends.
- **`model_gateway/src/core/kv_event_monitor.rs`**: Simplify `downcast_ref::<tonic::Status>()` pattern to direct `.code()` access.

## Test Plan

- `cargo check --workspace` — zero warnings
- `cargo test --workspace` — all tests pass (1 pre-existing flaky mesh test excluded)
- `grep -r "into_status" model_gateway/` — no results
- `grep -r "downcast.*tonic::Status" model_gateway/` — only `tokenizer_registration.rs` (unchanged, calls `get_tokenizer()` which stays `Box<dyn Error>`)

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Refactor**
- Standardized error handling across all gRPC client methods for consistent error type propagation throughout service operations.
- Updated error types in health checks, model information retrieval, load monitoring, stream operations, and event subscriptions.
- Enhanced error handling logic in event subscription monitoring with improved gRPC status code evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->