### PR TITLE
fix(grpc): increase SGLang keep-alive timeout to prevent connection drops during long generation

### DIFF
--- a/grpc_client/src/sglang_scheduler.rs
+++ b/grpc_client/src/sglang_scheduler.rs
@@ -148,8 +148,8 @@ impl SglangSchedulerClient {
         };
 
         let channel = Channel::from_shared(http_endpoint)?
-            .http2_keep_alive_interval(Duration::from_secs(30))
-            .keep_alive_timeout(Duration::from_secs(10))
+            .http2_keep_alive_interval(Duration::from_secs(60))
+            .keep_alive_timeout(Duration::from_secs(120))
             .keep_alive_while_idle(true)
             .tcp_keepalive(Some(Duration::from_secs(60)))
             .tcp_nodelay(true)


### PR DESCRIPTION
## Description

### Problem

Long-running SGLang generation requests (30K+ output tokens, ~3-16 minutes) are silently killed mid-stream by the SMG's HTTP/2 keep-alive mechanism, then enter an expensive retry loop where each attempt regenerates all tokens before failing identically.

The SGLang proto has no application-level heartbeat — `GenerateResponse` only carries `chunk | complete | error`, so liveness depends entirely on HTTP/2 PING/PONG at the transport layer.

When the connection drops, `collect_stream_responses` (`grpc/utils.rs:681`) returns `worker_stream_failed` (500), which propagates up as `"Stage ResponseProcessing failed"` (`pipeline.rs:307`). Since 500 is retryable, `RetryExecutor` re-enters the pipeline, taking up another 3-16 minutes of GPU time per attempt.

### Solution

Relax the SGLang gRPC channel keep-alive settings:

| Setting | Before | After | Rationale |
|---------|--------|-------|-----------|
| `http2_keep_alive_interval` | 30s | **60s** | Matches existing `tcp_keepalive` (60s); reduces PING frequency to stay within server-side enforcement limits |
| `keep_alive_timeout` | 10s | **120s** | Gives SGLang's event loop adequate time to respond during heavy batch processing; still well under the 30-min `request_timeout_secs` |

vLLM and TRT-LLM clients are unchanged as this targets only the SGLang path where the issue is observed.

## Changes

- `grpc_client/src/sglang_scheduler.rs`: `http2_keep_alive_interval` 30s → 60s, `keep_alive_timeout` 10s → 120s

## Test Plan

- Deploy with a model that generates to max tokens (~32K) and verify requests complete without `ResponseProcessing` failures
- Confirm `worker_stream_failed` errors are eliminated for long generation requests
- Verify short-lived requests are unaffected

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Adjusted gRPC client keep-alive settings for improved connection management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->