### PR TITLE
refactor(realtime): simplify proxy and registry internals

### DIFF
--- a/model_gateway/src/routers/openai/realtime/proxy.rs
+++ b/model_gateway/src/routers/openai/realtime/proxy.rs
@@ -1,6 +1,6 @@
 //! Bidirectional WebSocket proxy between client (axum) and upstream (tungstenite).
 
-use std::sync::Arc;
+use std::{borrow::Cow, sync::Arc};
 
 use axum::extract::ws::{Message as AxumMessage, WebSocket};
 use futures::{
@@ -21,10 +21,13 @@ type UpstreamWs = tokio_tungstenite::WebSocketStream<MaybeTlsStream<TcpStream>>;
 /// realtime event JSON payload. Avoids the cost of fully deserializing
 /// `ClientEvent`/`ServerEvent` (which box large variants like `SessionConfig`
 /// at 624 B) on every frame — critical for high-frequency audio streams.
+///
+/// Uses `Cow<str>` so serde can borrow zero-copy for plain strings while
+/// still handling JSON escape sequences (e.g. `\u002E`) that require allocation.
 #[derive(Deserialize)]
 struct EventTypeOnly<'a> {
-    #[serde(rename = "type")]
-    event_type: &'a str,
+    #[serde(rename = "type", borrow)]
+    event_type: Cow<'a, str>,
 }
 
 /// Run a bidirectional WebSocket proxy between a client and upstream.
@@ -135,12 +138,13 @@ async fn forward_client_to_upstream(
                         let tungstenite_msg = match axum_msg {
                             AxumMessage::Text(text) => {
                                 if let Ok(ev) = serde_json::from_str::<EventTypeOnly>(&text) {
-                                    match ev.event_type {
+                                    let et: &str = &ev.event_type;
+                                    match et {
                                         "input_audio_buffer.append" => {
-                                            trace!(session_id, event_type = ev.event_type, "Client→Upstream");
+                                            trace!(session_id, event_type = et, "Client→Upstream");
                                         }
                                         _ => {
-                                            debug!(session_id, event_type = ev.event_type, "Client→Upstream");
+                                            debug!(session_id, event_type = et, "Client→Upstream");
                                         }
                                     }
                                 }
@@ -191,21 +195,22 @@ async fn forward_upstream_to_client(
                         match tungstenite_msg {
                             TungsteniteMessage::Text(text) => {
                                 if let Ok(ev) = serde_json::from_str::<EventTypeOnly>(&text) {
-                                    match ev.event_type {
+                                    let et: &str = &ev.event_type;
+                                    match et {
                                         "response.output_audio.delta"
                                         | "response.output_text.delta"
                                         | "response.output_audio_transcript.delta"
                                         | "response.function_call_arguments.delta" => {
-                                            trace!(session_id, event_type = ev.event_type, "Upstream→Client");
+                                            trace!(session_id, event_type = et, "Upstream→Client");
                                         }
                                         "session.created" | "session.updated"
                                         | "response.created" | "response.done"
                                         | "response.function_call_arguments.done"
                                         | "error" => {
-                                            info!(session_id, event_type = ev.event_type, "Upstream→Client");
+                                            info!(session_id, event_type = et, "Upstream→Client");
                                         }
                                         _ => {
-                                            debug!(session_id, event_type = ev.event_type, "Upstream→Client");
+                                            debug!(session_id, event_type = et, "Upstream→Client");
                                         }
                                     }
                                 }
@@ -272,12 +277,19 @@ fn get_tls_connector() -> tokio_tungstenite::Connector {
         let root_store = rustls::RootCertStore {
             roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
         };
-        // Safety: ring always supports default TLS protocol versions.
-        #[expect(clippy::expect_used, reason = "ring infallibly supports default TLS versions")]
+        // INVARIANT: `ring::default_provider()` supports rustls default TLS protocol versions.
+        #[expect(
+            clippy::expect_used,
+            reason = "ring infallibly supports default TLS versions"
+        )]
         let builder = ClientConfig::builder_with_provider(Arc::new(ring::default_provider()))
             .with_safe_default_protocol_versions()
             .expect("ring supports default TLS protocol versions");
-        Arc::new(builder.with_root_certificates(root_store).with_no_client_auth())
+        Arc::new(
+            builder
+                .with_root_certificates(root_store)
+                .with_no_client_auth(),
+        )
     });
 
     tokio_tungstenite::Connector::Rustls(Arc::clone(config))

--- a/model_gateway/src/routers/openai/realtime/registry.rs
+++ b/model_gateway/src/routers/openai/realtime/registry.rs
@@ -85,22 +85,16 @@ impl ConnectionMap {
     /// Remove stale entries and cancel their tokens. Returns count of reaped entries.
     fn reap_stale(&self, is_stale: impl Fn(ConnectionState, Duration) -> bool) -> usize {
         let now = Instant::now();
-        let stale_ids: Vec<String> = self
-            .0
-            .iter()
-            .filter(|e| is_stale(e.state, now.duration_since(e.created_at)))
-            .map(|e| e.id.clone())
-            .collect();
-
         let mut reaped = 0;
-        for id in &stale_ids {
-            if let Some((_, entry)) = self.0.remove_if(id, |_, e| {
-                is_stale(e.state, now.duration_since(e.created_at))
-            }) {
+        self.0.retain(|_, entry| {
+            if is_stale(entry.state, now.duration_since(entry.created_at)) {
                 entry.cancel_token.cancel();
                 reaped += 1;
+                false
+            } else {
+                true
             }
-        }
+        });
         reaped
     }
 


### PR DESCRIPTION
## Summary

Simplifies the OpenAI Realtime API proxy and registry code introduced in #637.

## What changed

**`proxy.rs`**
- Replaced full `ClientEvent`/`ServerEvent` deserialization with a lightweight `EventTypeOnly<'a>` struct that zero-copy extracts only the `"type"` field. This avoids parsing large boxed variants (`SessionConfig` 624B, `ResponseCreateParams` 384B) on every audio frame in the hot path.
- Cached the rustls `ClientConfig` via `OnceLock` instead of rebuilding it (including cloning all webpki root certificates) on every new connection.
- Removed the now-unused `openai_protocol::realtime_events::{ClientEvent, ServerEvent}` import.

**`registry.rs`**
- Unified `SessionEntry` and `CallEntry` (identical except for the id field name) into a single `ConnectionEntry` struct with an `id: String` field.
- Extracted shared CRUD operations (register, get, set_state, remove) and reaper logic into a `ConnectionMap` wrapper, eliminating ~30 lines of duplicated code.

## Why

- The full JSON deserialization on every WebSocket frame was unnecessary overhead for logging-only event type extraction, especially on high-frequency `input_audio_buffer.append` streams.
- The TLS config is immutable and can be safely shared across connections.
- The two entry types and their method duplications added maintenance burden without semantic value.

## Test plan

- [x] `cargo check -p smg` passes
- [x] `cargo clippy -p smg --all-targets -- -D warnings` passes
- [x] No behavioral changes — all public API signatures preserved

Refs: #637

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reduced per-frame event parsing by extracting only event types, lowering CPU overhead and improving realtime responsiveness
  * Enabled zero-copy event-type handling to further reduce parsing cost and latency
  * Introduced a cached, shared TLS connector to speed connection setup and reuse resources
  * Consolidated session/call management into a unified connection model for simpler, more reliable state handling
  * Streamlined stale-connection cleanup for more consistent lifecycle and fewer orphaned entries
<!-- end of auto-generated comment: release notes by coderabbit.ai -->