### PR TITLE
ci(docker): add engine-specific image build pipelines

### DIFF
--- a/.github/workflows/release-sglang-docker.yml
+++ b/.github/workflows/release-sglang-docker.yml
@@ -1,0 +1,131 @@
+name: Release SMG_SGLang Docker Image
+
+run-name: >
+  Release SMG_SGLang  image |
+  base_image_ref=${{ github.event.inputs.base_image_ref }} |
+  sglang_repo=${{ github.event.inputs.sglang_repo }} |
+  sglang_commit=${{ github.event.inputs.sglang_commit }} |
+  smg_repo=${{ github.event.inputs.smg_repo }} |
+  smg_commit=${{ github.event.inputs.smg_commit }} |
+  by @${{ github.actor }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_image_ref:
+        description: 'Base image (full image:tag, e.g. lmsysorg/sglang:v0.5.9)'
+        default: 'lmsysorg/sglang:v0.5.9'
+        required: true
+        type: string
+      sglang_repo:
+        description: 'SGLang repo URL, official: https://github.com/sgl-project/sglang.git, if empty, will not refresh engine code and use the one in base image'
+        required: false
+        type: string
+      sglang_commit:
+        description: 'SGLang commit SHA or ref (use "latest" for HEAD)'
+        required: false
+        default: 'latest'
+        type: string
+      smg_repo:
+        description: 'SMG repo URL'
+        required: false
+        default: 'https://github.com/lightseekorg/smg'
+        type: string
+      smg_commit:
+        description: 'SMG commit SHA or ref (use "latest" for HEAD)'
+        required: false
+        default: 'latest'
+        type: string
+      tag:
+        description: 'Override image tag (e.g. v1.2.0-sglang-v0.5.9). If empty, tag is auto-generated.'
+        required: false
+        type: string
+
+jobs:
+  build-and-push:
+    if: github.repository == 'lightseekorg/smg'
+    runs-on: ["8-gpu-h200"]
+    steps:
+      - name: Print inputs to summary
+        run: |
+          echo "## Inputs" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Parameter | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|-----------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| base_image_ref | \`${{ inputs.base_image_ref }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| sglang_repo | \`${{ inputs.sglang_repo }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| sglang_commit | \`${{ inputs.sglang_commit }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| smg_repo | \`${{ inputs.smg_repo }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| smg_commit | \`${{ inputs.smg_commit }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| tag | \`${{ inputs.tag || '(auto)' }}\` |" >> $GITHUB_STEP_SUMMARY
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve image tag
+        id: resolve-tag
+        env:
+          BASE_IMAGE_REF: ${{ inputs.base_image_ref }}
+          SGLANG_REPO: ${{ inputs.sglang_repo }}
+          SGLANG_COMMIT: ${{ inputs.sglang_commit }}
+        run: |
+          SMG_VERSION=$(grep -m1 '^version = ' bindings/python/pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+          if [ -n "${{ inputs.tag }}" ]; then
+            IMAGE_TAG="${{ inputs.tag }}"
+          else
+            if [ -n "${SGLANG_REPO}" ]; then
+              SGLANG_COMMIT="${SGLANG_COMMIT//\//-}"
+              SGLANG_COMMIT="${SGLANG_COMMIT// /}"
+            else
+              # No engine repo: use the base image tag as the engine version identifier
+              SGLANG_COMMIT="${BASE_IMAGE_REF##*:}"
+              SGLANG_COMMIT="${SGLANG_COMMIT//\//-}"
+            fi
+            IMAGE_TAG="${SMG_VERSION}-sglang-${SGLANG_COMMIT}"
+          fi
+          echo "image_tag=${IMAGE_TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile.engine
+          target: custom-sglang
+          push: false
+          load: true
+          build-args: |
+            BASE_IMAGE_REF=${{ inputs.base_image_ref || 'lmsysorg/sglang:v0.5.9' }}
+            ENGINE_REPO=${{ inputs.sglang_repo }}
+            ENGINE_COMMIT=${{ inputs.sglang_commit }}
+            SMG_REPO=${{ inputs.smg_repo }}
+            SMG_COMMIT=${{ inputs.smg_commit }}
+          tags: smg-build:${{ steps.resolve-tag.outputs.image_tag }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Push image to GHCR
+        id: push-ghcr
+        env:
+          IMAGE_TAG: ${{ steps.resolve-tag.outputs.image_tag }}
+          BASE_IMAGE_TAG: smg-build:${{ steps.resolve-tag.outputs.image_tag }}
+        run: |
+          TARGET_IMAGE="ghcr.io/${{ github.repository_owner }}/smg:${IMAGE_TAG}"
+          echo "image_name=${TARGET_IMAGE}" >> "$GITHUB_OUTPUT"
+          docker tag "$BASE_IMAGE_TAG" "$TARGET_IMAGE"
+          docker push "$TARGET_IMAGE"
+
+      - name: Summary
+        run: |
+          echo "## Image" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Image name:** \`${{ steps.push-ghcr.outputs.image_name }}\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release-trtllm-docker.yml
+++ b/.github/workflows/release-trtllm-docker.yml
@@ -1,0 +1,202 @@
+name: Release SMG_TRTLLM Docker Image
+
+run-name: >
+  Release SMG_TRTLLM  image |
+  base_image_ref=${{ github.event.inputs.base_image_ref }} |
+  trtllm_repo=${{ github.event.inputs.trtllm_repo }} |
+  trtllm_commit=${{ github.event.inputs.trtllm_commit }} |
+  smg_repo=${{ github.event.inputs.smg_repo }} |
+  smg_commit=${{ github.event.inputs.smg_commit }} |
+  by @${{ github.actor }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_image_ref:
+        description: 'Base image (full image:tag, e.g. nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc4). If empty, base image will be built from trtllm_repo (engine code will NOT be refreshed in that case).'
+        required: false
+        type: string
+      trtllm_repo:
+        description: 'TRTLLM repo URL (required when base_image_ref is empty to build base image), e.g. https://github.com/NVIDIA/TensorRT-LLM.git'
+        required: false
+        type: string
+      trtllm_commit:
+        description: 'TRTLLM commit SHA or ref (use "latest" for HEAD; only used when building base image)'
+        required: false
+        default: 'latest'
+        type: string
+      smg_repo:
+        description: 'SMG repo URL'
+        required: false
+        default: 'https://github.com/lightseekorg/smg'
+        type: string
+      smg_commit:
+        description: 'SMG commit SHA or ref (use "latest" for HEAD)'
+        required: false
+        default: 'latest'
+        type: string
+      tag:
+        description: 'Override image tag (e.g. v1.2.0-trtllm-1.3.0). If empty, tag is auto-generated.'
+        required: false
+        type: string
+env:
+  GITHUB_TOKEN: ${{ secrets.ROBOT_GITHUB_TOKEN }}
+
+jobs:
+  build-and-push:
+    if: github.repository == 'lightseekorg/smg'
+    runs-on: ["8-gpu-h200"]
+    steps:
+      - name: Print inputs to summary
+        run: |
+          echo "## Inputs" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Parameter | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|-----------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| base_image_ref | \`${{ inputs.base_image_ref }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| trtllm_repo | \`${{ inputs.trtllm_repo }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| trtllm_commit | \`${{ inputs.trtllm_commit }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| smg_repo | \`${{ inputs.smg_repo }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| smg_commit | \`${{ inputs.smg_commit }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| tag | \`${{ inputs.tag || '(auto)' }}\` |" >> $GITHUB_STEP_SUMMARY
+
+      - name: Checkout current repo
+        uses: actions/checkout@v4
+
+      - name: Validate inputs
+        env:
+          INPUT_BASE_IMAGE_REF: ${{ inputs.base_image_ref }}
+          TRTLLM_REPO: ${{ inputs.trtllm_repo }}
+        run: |
+          if [ -z "${INPUT_BASE_IMAGE_REF}" ] && [ -z "${TRTLLM_REPO}" ]; then
+            echo "ERROR: Either base_image_ref or trtllm_repo must be set." >&2
+            exit 1
+          fi
+
+      # Only check out the TensorRT-LLM repo when base_image_ref is empty,
+      # so we can build the base image from source.
+      - name: Resolve trtllm checkout ref
+        id: trtllm-ref
+        if: ${{ github.event.inputs.base_image_ref == '' }}
+        run: |
+          if [ "${{ github.event.inputs.trtllm_commit }}" = "latest" ]; then
+            echo "ref=" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=${{ github.event.inputs.trtllm_commit }}" >> "$GITHUB_OUTPUT"
+          fi
+          # Strip protocol and host to get owner/repo (e.g. https://github.com/NVIDIA/TensorRT-LLM.git → NVIDIA/TensorRT-LLM)
+          repo="${{ github.event.inputs.trtllm_repo }}"
+          repo="${repo#https://github.com/}"
+          repo="${repo%.git}"
+          repo="${repo%/}"
+          echo "repo=${repo}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout TensorRT-LLM repo (build base image)
+        if: ${{ github.event.inputs.base_image_ref == '' && github.event.inputs.trtllm_repo != '' }}
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ steps.trtllm-ref.outputs.repo }}
+          ref: ${{ steps.trtllm-ref.outputs.ref }}
+          token: ${{ secrets.GH_SYNC_TOKEN }}
+          fetch-depth: 0
+          submodules: recursive
+          lfs: true
+          path: tensorrt-llm
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Resolve the effective base image reference and compute the final image tag.
+      #   base_image_ref: provided → use as-is; empty → use image built from source below
+      #   image_tag convention: <smg_commit>-trtllm-<trtllm_commit>
+      - name: Resolve image refs and tag
+        id: resolve-base
+        env:
+          INPUT_BASE_IMAGE_REF: ${{ inputs.base_image_ref }}
+          TRTLLM_REPO: ${{ inputs.trtllm_repo }}
+          TRTLLM_COMMIT: ${{ inputs.trtllm_commit }}
+        run: |
+          SMG_VERSION=$(grep -m1 '^version = ' bindings/python/pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+          if [ -n "${{ inputs.tag }}" ]; then
+            IMAGE_TAG="${{ inputs.tag }}"
+          else
+            if [ -n "${TRTLLM_REPO}" ]; then
+              TRTLLM_COMMIT="${TRTLLM_COMMIT//\//-}"
+              TRTLLM_COMMIT="${TRTLLM_COMMIT// /}"
+            else
+              # No engine repo: use the base image tag as the engine version identifier
+              TRTLLM_COMMIT="${INPUT_BASE_IMAGE_REF##*:}"
+              TRTLLM_COMMIT="${TRTLLM_COMMIT//\//-}"
+            fi
+            IMAGE_TAG="${SMG_VERSION}-trtllm-${TRTLLM_COMMIT}"
+          fi
+          echo "image_tag=${IMAGE_TAG}" >> "$GITHUB_OUTPUT"
+          if [ -n "${INPUT_BASE_IMAGE_REF}" ]; then
+            echo "base_image_ref=${INPUT_BASE_IMAGE_REF}" >> "$GITHUB_OUTPUT"
+            echo "engine_repo=${TRTLLM_REPO}" >> "$GITHUB_OUTPUT"
+          else
+            echo "base_image_ref=smg-build/release:${IMAGE_TAG}" >> "$GITHUB_OUTPUT"
+            echo "engine_repo=" >> "$GITHUB_OUTPUT"
+          fi
+          echo "=== Outputs ==="
+          cat "$GITHUB_OUTPUT"
+
+      # Build the TensorRT-LLM base image from source when no base_image_ref is given.
+      # Engine code IS baked into the base image in this path.
+      - name: Build base image from source
+        if: ${{ github.event.inputs.base_image_ref == '' && github.event.inputs.trtllm_repo != '' }}
+        run: make -C tensorrt-llm/docker release_build CUDA_ARCHS="100-real" IMAGE_TAG="${{ steps.resolve-base.outputs.image_tag }}" IMAGE_NAME="smg-build"
+
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile.engine
+          target: custom-trtllm
+          push: false
+          load: true
+          build-args: |
+            BASE_IMAGE_REF=${{ steps.resolve-base.outputs.base_image_ref }}
+            ENGINE_REPO=${{ steps.resolve-base.outputs.engine_repo }}
+            ENGINE_COMMIT=${{ inputs.trtllm_commit }}
+            SMG_REPO=${{ inputs.smg_repo }}
+            SMG_COMMIT=${{ inputs.smg_commit }}
+          tags: smg-build:${{ steps.resolve-base.outputs.image_tag }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Push image to GHCR
+        id: push-ghcr
+        env:
+          IMAGE_TAG: ${{ steps.resolve-base.outputs.image_tag }}
+          BASE_IMAGE_TAG: smg-build:${{ steps.resolve-base.outputs.image_tag }}
+        run: |
+          TARGET_IMAGE="ghcr.io/${{ github.repository_owner }}/smg:${IMAGE_TAG}"
+          echo "image_name=${TARGET_IMAGE}" >> "$GITHUB_OUTPUT"
+          cat "$GITHUB_OUTPUT"
+
+          docker tag "${BASE_IMAGE_TAG}" "${TARGET_IMAGE}"
+          docker push "${TARGET_IMAGE}"
+
+      - name: Clean up local images
+        if: always()
+        env:
+          IMAGE_TAG: ${{ steps.resolve-base.outputs.image_tag }}
+        run: |
+          docker rmi "smg-build:${IMAGE_TAG}" || true
+          docker rmi "${{ steps.push-ghcr.outputs.image_name }}" || true
+
+      - name: Summary
+        run: |
+          echo "## Image" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Image name:** \`${{ steps.push-ghcr.outputs.image_name }}\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release-vllm-docker.yml
+++ b/.github/workflows/release-vllm-docker.yml
@@ -1,0 +1,112 @@
+name: Release SMG_vLLM Docker Image
+
+run-name: >
+  Release SMG_vLLM  image |
+  base_image_ref=${{ github.event.inputs.base_image_ref }} |
+  vllm_repo=${{ github.event.inputs.vllm_repo }} |
+  vllm_commit=${{ github.event.inputs.vllm_commit }} |
+  smg_repo=${{ github.event.inputs.smg_repo }} |
+  smg_commit=${{ github.event.inputs.smg_commit }} |
+  by @${{ github.actor }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_image_ref:
+        description: 'Base image (full image:tag, e.g. vllm/vllm-openai:v0.16.0-cu130)'
+        default: 'vllm/vllm-openai:v0.16.0-cu130'
+        required: true
+        type: string
+      vllm_repo:
+        description: 'vLLM repo URL, official: https://github.com/vllm-project/vllm.git, if empty, will not refresh engine code and use the one in base image'
+        required: false
+        type: string
+      vllm_commit:
+        description: 'vLLM commit SHA or ref (use "latest" for HEAD)'
+        required: false
+        default: 'latest'
+        type: string
+      smg_repo:
+        description: 'SMG repo URL'
+        required: false
+        default: 'https://github.com/lightseekorg/smg'
+        type: string
+      smg_commit:
+        description: 'SMG commit SHA or ref (use "latest" for HEAD)'
+        required: false
+        default: 'v1.1.0'
+        type: string
+      tag:
+        description: 'Override image tag (e.g. v1.2.0-vllm-v0.16.0). If empty, tag is auto-generated.'
+        required: false
+        type: string
+
+jobs:
+  build:
+    runs-on: ["8-gpu-h200"]
+    steps:
+      - name: Print inputs to summary
+        run: |
+          echo "## Inputs" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Parameter | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|-----------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| base_image_ref | \`${{ inputs.base_image_ref }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| vllm_repo | \`${{ inputs.vllm_repo }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| vllm_commit | \`${{ inputs.vllm_commit }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| smg_repo | \`${{ inputs.smg_repo }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| smg_commit | \`${{ inputs.smg_commit }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| tag | \`${{ inputs.tag }}\` |" >> $GITHUB_STEP_SUMMARY
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        id: push-ghcr
+        env:
+          BASE_IMAGE_REF: ${{ inputs.base_image_ref }}
+          VLLM_REPO: ${{ inputs.vllm_repo }}
+          VLLM_COMMIT: ${{ inputs.vllm_commit }}
+          SMG_REPO: ${{ inputs.smg_repo }}
+          SMG_COMMIT: ${{ inputs.smg_commit }}
+        run: |
+          SMG_VERSION=$(grep -m1 '^version = ' bindings/python/pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+          if [ -n "${{ inputs.tag }}" ]; then
+            IMAGE_TAG="${{ inputs.tag }}"
+          else
+            if [ -n "${VLLM_REPO}" ]; then
+              VLLM_TAG="${VLLM_COMMIT//\//-}"
+              VLLM_TAG="${VLLM_TAG// /}"
+            else
+              # No engine repo: use the base image tag as the engine version identifier
+              VLLM_TAG="${BASE_IMAGE_REF##*:}"
+              VLLM_TAG="${VLLM_TAG//\//-}"
+            fi
+            IMAGE_TAG="${SMG_VERSION}-vllm-${VLLM_TAG}"
+          fi
+          TARGET_IMAGE="ghcr.io/${{ github.repository_owner }}/smg:${IMAGE_TAG}"
+          echo "image_name=${TARGET_IMAGE}" >> "$GITHUB_OUTPUT"
+          docker build \
+            --build-arg BASE_IMAGE_REF="${BASE_IMAGE_REF}" \
+            --build-arg ENGINE_REPO="${VLLM_REPO}" \
+            --build-arg ENGINE_COMMIT="${VLLM_COMMIT}" \
+            --build-arg SMG_REPO="${SMG_REPO}" \
+            --build-arg SMG_COMMIT="${SMG_COMMIT}" \
+            --file docker/Dockerfile.engine \
+            --target custom-vllm \
+            --tag "${TARGET_IMAGE}" \
+            .
+          docker push "${TARGET_IMAGE}"
+
+      - name: Summary
+        run: |
+          echo "## Image" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Image name:** \`${{ steps.push-ghcr.outputs.image_name }}\`" >> $GITHUB_STEP_SUMMARY

--- a/docker/Dockerfile.engine
+++ b/docker/Dockerfile.engine
@@ -1,0 +1,68 @@
+# Multi-stage: each base has its own tag. Build with --target vllm|sglang|trtllm|tgl
+# Build args: BASE_IMAGE_REF (full image:tag); ENGINE_REPO, ENGINE_COMMIT; SMG_REPO, SMG_COMMIT
+ARG BASE_IMAGE_REF
+
+# Shared sources: clone engine and smg from GitHub, copy scripts
+FROM alpine:3.19 AS sources
+ARG ENGINE_REPO
+ARG ENGINE_COMMIT
+ARG SMG_REPO
+ARG SMG_COMMIT
+RUN apk add --no-cache git \
+    && if [ -n "${ENGINE_REPO}" ] && [ -n "${ENGINE_COMMIT}" ]; then \
+         git clone --depth 1 "${ENGINE_REPO}" /opt/engine-sr \
+         && ( cd /opt/engine-src && ( [ "${ENGINE_COMMIT}" = "latest" ] || git checkout "${ENGINE_COMMIT}" ) ); \
+       else mkdir -p /opt/engine-src; fi \
+    && git clone --depth 1 "${SMG_REPO}" /tmp/smg-src \
+    && ( cd /tmp/smg-src && ( [ "${SMG_COMMIT}" = "latest" ] || git checkout "${SMG_COMMIT}" ) )
+COPY scripts/installation/install-vllm.sh /tmp/install-vllm.sh
+COPY scripts/installation/install-sglang.sh /tmp/install-sglang.sh
+COPY scripts/installation/install-tgl.sh /tmp/install-tgl.sh
+COPY scripts/installation/install-trtllm.sh /tmp/install-trtllm.sh
+COPY scripts/installation/install-smg.sh /tmp/install-smg.sh
+
+
+# custom base (override with BASE_IMAGE_REF, e.g. vllm/vllm-openai:nightly)
+FROM ${BASE_IMAGE_REF} AS custom-vllm
+
+ARG ENGINE_REPO
+ENV SMG_DEFAULT_BACKEND=vllm
+COPY --from=sources /opt/engine-src /opt/vllm-src
+COPY --from=sources /tmp/smg-src /opt/smg-src
+COPY --from=sources /tmp/install-vllm.sh /tmp/install-vllm.sh
+COPY --from=sources /tmp/install-smg.sh /tmp/install-smg.sh
+RUN bash /tmp/install-smg.sh /opt/smg-src
+RUN if [ -n "${ENGINE_REPO}" ]; then bash /tmp/install-vllm.sh /opt/vllm-src; fi
+
+FROM ${BASE_IMAGE_REF} AS custom-sglang
+
+ARG ENGINE_REPO
+ENV SMG_DEFAULT_BACKEND=sglang
+COPY --from=sources /opt/engine-src /opt/sglang-src
+COPY --from=sources /tmp/smg-src /opt/smg-src
+COPY --from=sources /tmp/install-sglang.sh /tmp/install-sglang.sh
+COPY --from=sources /tmp/install-smg.sh /tmp/install-smg.sh
+RUN bash /tmp/install-smg.sh /opt/smg-src
+RUN if [ -n "${ENGINE_REPO}" ]; then bash /tmp/install-sglang.sh /opt/sglang-src; fi
+
+FROM ${BASE_IMAGE_REF} AS custom-trtllm
+
+ARG ENGINE_REPO
+ENV SMG_DEFAULT_BACKEND=trtllm
+COPY --from=sources /opt/engine-src /opt/trtllm-src
+COPY --from=sources /tmp/smg-src /opt/smg-src
+COPY --from=sources /tmp/install-trtllm.sh /tmp/install-trtllm.sh
+COPY --from=sources /tmp/install-smg.sh /tmp/install-smg.sh
+RUN bash /tmp/install-smg.sh /opt/smg-src
+RUN if [ -n "${ENGINE_REPO}" ]; then bash /tmp/install-trtllm.sh /opt/trtllm-src; fi
+
+FROM ${BASE_IMAGE_REF} AS custom-tgl
+
+ARG ENGINE_REPO
+ENV SMG_DEFAULT_BACKEND=sglang
+COPY --from=sources /opt/engine-src /opt/tgl-src
+COPY --from=sources /tmp/smg-src /opt/smg-src
+COPY --from=sources /tmp/install-tgl.sh /tmp/install-tgl.sh
+COPY --from=sources /tmp/install-smg.sh /tmp/install-smg.sh
+RUN bash /tmp/install-smg.sh /opt/smg-src
+RUN if [ -n "${ENGINE_REPO}" ]; then bash /tmp/install-tgl.sh /opt/tgl-src; fi

--- a/scripts/installation/install-sglang.sh
+++ b/scripts/installation/install-sglang.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+# Install sglang from source.
+# Usage: install-sglang.sh [path-to-sglang-src]
+# Default path: /tmp/sglang-src
+
+SGL_SRC="${1:-/tmp/sglang-src}"
+cd "${SGL_SRC}/python"
+pip install --force-reinstall --editable .

--- a/scripts/installation/install-smg.sh
+++ b/scripts/installation/install-smg.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -e
+
+# Install smg from source.
+# Usage: install-smg.sh [path-to-smg-src]
+# Default path: /tmp/smg-src
+
+SMG_SRC="${1:-/tmp/smg-src}"
+
+apt update -y \
+    && apt install -y git build-essential libssl-dev pkg-config unzip wget \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt clean
+
+cd /tmp && \
+    wget https://github.com/protocolbuffers/protobuf/releases/download/v32.0/protoc-32.0-linux-x86_64.zip && \
+    unzip protoc-32.0-linux-x86_64.zip -d /usr/local && \
+    rm protoc-32.0-linux-x86_64.zip
+protoc --version
+
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
+    && rustc --version && cargo --version && protoc --version
+
+export PATH="/root/.cargo/bin:${PATH}"
+
+pip install --no-cache-dir --upgrade pip \
+    && pip install maturin --no-cache-dir --force-reinstall
+
+cd "${SMG_SRC}/bindings/python"
+ulimit -n 65536 && maturin build --release --features vendored-openssl --out dist
+pip install --force-reinstall dist/*.whl

--- a/scripts/installation/install-tgl.sh
+++ b/scripts/installation/install-tgl.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+# Install tgl from source.
+# Usage: install-tgl.sh [path-to-tgl-src]
+# Default path: /tmp/tgl-src
+
+TGL_SRC="${1:-/tmp/tgl-src}"
+cd "${TGL_SRC}/python"
+pip install --force-reinstall --editable .

--- a/scripts/installation/install-trtllm.sh
+++ b/scripts/installation/install-trtllm.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -e
+
+# Install trtllm from source.
+# Usage: install-trtllm.sh [path-to-trtllm-src]
+# Default path: /tmp/trtllm-src
+
+if ! command -v git-lfs >/dev/null 2>&1; then
+  echo "git-lfs is not installed. Installing..." >&2
+  apt-get update && apt-get install -y --no-install-recommends git-lfs && rm -rf /var/lib/apt/lists/*
+fi
+
+TRTLLM_SRC="${1:-/tmp/trtllm-src}"
+cd "${TRTLLM_SRC}"
+git submodule update --init --recursive
+git lfs pull
+python3 ./scripts/build_wheel.py --clean
+pip install --force-reinstall ./build/tensorrt_llm*.whl

--- a/scripts/installation/install-vllm.sh
+++ b/scripts/installation/install-vllm.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+# Install vllm from source.
+# Usage: install-vllm.sh [path-to-vllm-src]
+# Default path: /tmp/vllm-src
+
+VLLM_SRC="${1:-/tmp/vllm-src}"
+cd "${VLLM_SRC}"
+VLLM_USE_PRECOMPILED=1 pip install --force-reinstall --editable .


### PR DESCRIPTION
## Summary

Add separate Docker workflows and a shared Dockerfile for building engine-specific images (SGLang, vLLM, TRT-LLM). Each workflow builds from a common base image with modular install scripts.

Re-opened from #604 with corrected commit metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced automated Docker image release workflows for SGLang, TRTLLM, and vLLM inference engines, enabling users to easily build and publish customized images with configurable base images and specific commit references.

* **Chores**
  * Added installation scripts for streamlined setup of multiple inference engine backends (SGLang, TRTLLM, vLLM, TGL) and required system dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->