### PR TITLE
ci: block AI co-author and sign-off lines in commits

### DIFF
--- a/.github/workflows/pr-naming-check.yml
+++ b/.github/workflows/pr-naming-check.yml
@@ -1,18 +1,19 @@
-name: PR Title Check
+name: PR Validation
 
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
 concurrency:
-  group: pr-title-check-${{ github.event.pull_request.number }}
+  group: pr-validation-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
-  check-pr-title:
-    name: Conventional Commit Title
+  pr-validation:
+    name: PR Title & Commit Messages
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: read
     steps:
       - name: Validate PR title format
@@ -43,3 +44,23 @@ jobs:
           fi
 
           echo "✅ PR title is valid: '$PR_TITLE'"
+
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check commit messages for forbidden AI co-authors
+        run: |
+          FORBIDDEN=$(git log --format='%B' origin/${{ github.base_ref }}..HEAD | \
+            grep -iE "^(Co-authored-by|Signed-off-by):.*(Claude|noreply@anthropic\.com)" || true)
+          if [ -n "$FORBIDDEN" ]; then
+            echo "::error::Commit messages must not reference Claude or noreply@anthropic.com in Co-authored-by/Signed-off-by lines."
+            echo ""
+            echo "Offending lines:"
+            echo "$FORBIDDEN"
+            echo ""
+            echo "Please amend the offending commits to remove these lines."
+            exit 1
+          fi
+
+          echo "✅ No forbidden AI co-author/sign-off lines found."

--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Run pre-commit checks
         env:
-          SKIP: rustfmt,clippy,no-commit-to-branch,branch-name-check,dco-check
+          SKIP: rustfmt,clippy,no-commit-to-branch,branch-name-check,dco-check,no-ai-co-author
         run: pre-commit run --all-files --show-diff-on-failure
 
   python-lint:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,6 +78,21 @@ repos:
         stages: [commit-msg]
         always_run: true
 
+      - id: no-ai-co-author
+        name: No AI co-author or sign-off
+        description: Reject Co-authored-by or Signed-off-by lines referencing Claude or noreply@anthropic.com
+        entry: |
+          bash -c '
+            if grep -iE "^(Co-authored-by|Signed-off-by):.*(Claude|noreply@anthropic\.com)" "$1"; then
+              echo ""
+              echo "ERROR: Commit message must not reference Claude or noreply@anthropic.com in Co-authored-by/Signed-off-by lines."
+              exit 1
+            fi
+          ' --
+        language: system
+        stages: [commit-msg]
+        always_run: true
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.0
     hooks:


### PR DESCRIPTION
## Description

### Problem

Commits with `Co-authored-by` or `Signed-off-by` lines referencing Claude or `noreply@anthropic.com` can slip into the repository unnoticed.

### Solution

Add a pre-commit hook and a CI check to reject these lines before they land.

## Changes

- **`.pre-commit-config.yaml`**: Add `no-ai-co-author` commit-msg hook that rejects `Co-authored-by` / `Signed-off-by` lines containing "Claude" or "noreply@anthropic.com"
- **`.github/workflows/pr-naming-check.yml`** (renamed from `pr-title-check.yml`): Extend into a broader PR validation workflow — adds a step that scans all PR commit messages for the same forbidden patterns
- **`.github/workflows/pr-test-rust.yml`**: Add `no-ai-co-author` to the `SKIP` list (commit-msg hooks can't run via `pre-commit run --all-files`)

## Test Plan

- Verified locally: attempted a commit with `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>` — hook blocked it as expected
- Clean commit (without forbidden lines) passed all hooks

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PR validation workflow with enhanced commit message checking
  * Added automated checks to reject commits with specific co-author attributions
  * Expanded pre-commit hook configuration to enforce commit message standards

<!-- end of auto-generated comment: release notes by coderabbit.ai -->