### PR TITLE
fix(grpc): use `e.message()` instead of `Display` for `tonic::Status` in user-facing errors

### DIFF
--- a/model_gateway/src/routers/grpc/common/response_collection.rs
+++ b/model_gateway/src/routers/grpc/common/response_collection.rs
@@ -138,7 +138,7 @@ async fn collect_stream_responses(
                 // Don't mark as completed - let Drop send abort for error cases
                 return Err(e.to_http_error(
                     "worker_stream_failed",
-                    format!("{worker_name} stream failed: {e}"),
+                    format!("{worker_name} stream failed: {}", e.message()),
                 ));
             }
         }

--- a/model_gateway/src/routers/grpc/common/stages/request_execution.rs
+++ b/model_gateway/src/routers/grpc/common/stages/request_execution.rs
@@ -175,7 +175,7 @@ impl RequestExecutionStage {
             error!(function = "execute_single", error = %e, "Failed to start generation");
             e.to_http_error(
                 "start_generation_failed",
-                format!("Failed to start generation: {e}"),
+                format!("Failed to start generation: {}", e.message()),
             )
         })?;
 
@@ -202,7 +202,7 @@ impl RequestExecutionStage {
             error!(function = "execute_single_embed", error = %e, "Failed to start embedding");
             e.to_http_error(
                 "start_embedding_failed",
-                format!("Failed to start embedding: {e}"),
+                format!("Failed to start embedding: {}", e.message()),
             )
         })?;
 
@@ -265,7 +265,7 @@ impl RequestExecutionStage {
         // Handle prefill result
         let prefill_stream = prefill_result.map_err(|e| {
             error!(function = "execute_dual_dispatch", error = %e, "Prefill worker failed to start");
-            e.to_http_error("prefill_worker_failed_to_start", format!("Prefill worker failed to start: {e}"))
+            e.to_http_error("prefill_worker_failed_to_start", format!("Prefill worker failed to start: {}", e.message()))
         })?;
 
         // Handle decode result
@@ -273,7 +273,7 @@ impl RequestExecutionStage {
             error!(function = "execute_dual_dispatch", error = %e, "Decode worker failed to start");
             e.to_http_error(
                 "decode_worker_failed_to_start",
-                format!("Decode worker failed to start: {e}"),
+                format!("Decode worker failed to start: {}", e.message()),
             )
         })?;
 
@@ -359,7 +359,7 @@ impl RequestExecutionStage {
             .map_err(|e| {
                 workers.record_outcome_prefill(!e.is_cb_failure());
                 error!(function = "execute_sequential_pd", error = %e, "Prefill worker failed to start");
-                e.to_http_error("prefill_worker_failed_to_start", format!("Prefill worker failed to start: {e}"))
+                e.to_http_error("prefill_worker_failed_to_start", format!("Prefill worker failed to start: {}", e.message()))
             })?;
 
         // Drain prefill response (we just need to wait for completion)
@@ -373,7 +373,7 @@ impl RequestExecutionStage {
                     error!(function = "execute_sequential_pd", error = %e, "Prefill stream error");
                     return Err(e.to_http_error(
                         "prefill_stream_error",
-                        format!("Prefill stream error: {e}"),
+                        format!("Prefill stream error: {}", e.message()),
                     ));
                 }
             }
@@ -400,7 +400,7 @@ impl RequestExecutionStage {
             error!(function = "execute_sequential_pd", error = %e, "Decode worker failed to start");
             e.to_http_error(
                 "decode_worker_failed_to_start",
-                format!("Decode worker failed to start: {e}"),
+                format!("Decode worker failed to start: {}", e.message()),
             )
         })?;
 

--- a/model_gateway/src/routers/grpc/harmony/streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/streaming.rs
@@ -156,7 +156,7 @@ impl HarmonyStreamingProcessor {
         let mut cached_tokens: HashMap<u32, u32> = HashMap::new();
 
         while let Some(result) = prefill_stream.next().await {
-            let response = result.map_err(|e| format!("Prefill stream error: {e}"))?;
+            let response = result.map_err(|e| format!("Prefill stream error: {}", e.message()))?;
 
             if let ProtoResponseVariant::Complete(complete_wrapper) = response.into_response() {
                 prompt_tokens.insert(complete_wrapper.index(), complete_wrapper.prompt_tokens());
@@ -209,7 +209,7 @@ impl HarmonyStreamingProcessor {
 
         // Process stream
         while let Some(result) = decode_stream.next().await {
-            let response = result.map_err(|e| format!("Stream error: {e}"))?;
+            let response = result.map_err(|e| format!("Stream error: {}", e.message()))?;
 
             match response.into_response() {
                 ProtoResponseVariant::Chunk(chunk_wrapper) => {
@@ -504,7 +504,7 @@ impl HarmonyStreamingProcessor {
         // Phase 1: Drain prefill stream, collecting cached_tokens from Complete messages
         let mut prefill_cached_tokens_by_index: HashMap<u32, u32> = HashMap::new();
         while let Some(result) = prefill_stream.next().await {
-            let response = result.map_err(|e| format!("Prefill stream error: {e}"))?;
+            let response = result.map_err(|e| format!("Prefill stream error: {}", e.message()))?;
             if let ProtoResponseVariant::Complete(complete_wrapper) = response.into_response() {
                 prefill_cached_tokens_by_index
                     .insert(complete_wrapper.index(), complete_wrapper.cached_tokens());
@@ -557,7 +557,7 @@ impl HarmonyStreamingProcessor {
         let mut chunk_count = 0;
         while let Some(result) = decode_stream.next().await {
             chunk_count += 1;
-            let response = result.map_err(|e| format!("Decode stream error: {e}"))?;
+            let response = result.map_err(|e| format!("Decode stream error: {}", e.message()))?;
 
             match response.into_response() {
                 ProtoResponseVariant::Chunk(chunk_wrapper) => {

--- a/model_gateway/src/routers/grpc/regular/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/streaming.rs
@@ -260,7 +260,7 @@ impl StreamingProcessor {
 
         // Phase 2: Main streaming loop
         while let Some(response) = grpc_stream.next().await {
-            let gen_response = response.map_err(|e| format!("Stream error: {e}"))?;
+            let gen_response = response.map_err(|e| format!("Stream error: {}", e.message()))?;
 
             match gen_response.into_response() {
                 ProtoResponseVariant::Chunk(chunk) => {
@@ -573,7 +573,8 @@ impl StreamingProcessor {
         // Phase 1.5: Collect input_logprobs from prefill stream if requested
         if original_request.logprobs {
             while let Some(response) = prefill_stream.next().await {
-                let gen_response = response.map_err(|e| format!("Prefill stream error: {e}"))?;
+                let gen_response =
+                    response.map_err(|e| format!("Prefill stream error: {}", e.message()))?;
                 match gen_response.into_response() {
                     ProtoResponseVariant::Complete(_complete) => {
                         // Input logprobs collected but not yet used in streaming
@@ -707,7 +708,7 @@ impl StreamingProcessor {
         let mut completion_tokens_map: HashMap<u32, u32> = HashMap::new();
 
         while let Some(response) = stream.next().await {
-            let gen_response = response.map_err(|e| format!("Stream error: {e}"))?;
+            let gen_response = response.map_err(|e| format!("Stream error: {}", e.message()))?;
 
             match gen_response.into_response() {
                 ProtoResponseVariant::Chunk(chunk) => {
@@ -815,7 +816,8 @@ impl StreamingProcessor {
         let input_token_logprobs = if ctx.return_logprob {
             let mut input_logprobs = None;
             while let Some(response) = prefill_stream.next().await {
-                let gen_response = response.map_err(|e| format!("Prefill stream error: {e}"))?;
+                let gen_response =
+                    response.map_err(|e| format!("Prefill stream error: {}", e.message()))?;
                 match gen_response.into_response() {
                     ProtoResponseVariant::Complete(complete) => {
                         // Extract input_logprobs from prefill Complete message (convert proto to SGLang format)
@@ -874,7 +876,7 @@ impl StreamingProcessor {
         let mut completion_tokens_map: HashMap<u32, u32> = HashMap::new();
 
         while let Some(response) = stream.next().await {
-            let gen_response = response.map_err(|e| format!("Stream error: {e}"))?;
+            let gen_response = response.map_err(|e| format!("Stream error: {}", e.message()))?;
 
             match gen_response.into_response() {
                 ProtoResponseVariant::Chunk(chunk) => {


### PR DESCRIPTION
## Description

### Problem

Relates to #650.

gRPC backend errors include raw `tonic::Status` debug output in user-facing error messages. For example, a TRT-LLM validation error returns:

```json
{"message": "Failed to start generation: status: 'Client specified an invalid argument', self: \"Greedy decoding...\", metadata: {\"content-type\": \"application/grpc\"}"}
```

This is because `format!("Failed to start generation: {e}")` uses `tonic::Status`'s `Display` impl, which dumps the full debug representation including `status:`, `self:`, and `metadata:`.

### Solution

Replace `{e}` with `e.message()` in all error paths where `e` is a `tonic::Status`. This produces clean messages like:

```json
{"message": "Failed to start generation: Greedy decoding in the LLM API does not allow multiple returns..."}
```

## Changes

- `request_execution.rs` — 7 call sites (generate, embed, dual dispatch, sequential PD)
- `response_collection.rs` — 1 call site (stream collection)
- `regular/streaming.rs` — 3 call sites (stream and prefill errors)
- `harmony/streaming.rs` — 4 call sites (stream, prefill, decode errors)

## Test Plan

- `cargo check -p smg` passes
- Pre-commit (rustfmt, clippy) passes

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error message formatting consistency across multiple system components to enhance error reporting reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->