### PR TITLE
fix(docker): remove GHA docker cache from engine image builds

### DIFF
--- a/.github/workflows/_build-engine-image.yml
+++ b/.github/workflows/_build-engine-image.yml
@@ -227,8 +227,6 @@ jobs:
             SMG_REPO=${{ inputs.smg_repo }}
             SMG_COMMIT=${{ inputs.smg_commit }}
           tags: smg-build:${{ steps.resolve.outputs.image_tag }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
       # ── Push to GHCR ────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Remove `cache-from: type=gha` and `cache-to: type=gha,mode=max` from the engine image build workflow
- These builds run on bare-metal self-hosted runners where Docker already caches layers locally
- The GHA cache (mode=max) was consuming the entire 10GB repo cache budget and evicting other caches

## Test plan
- [ ] Verify engine image build still works without GHA cache

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build pipeline configuration to adjust caching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->