### PR TITLE
fix(gateway): release job queue semaphore permit before waiting for completion

### DIFF
--- a/model_gateway/src/core/job_queue.rs
+++ b/model_gateway/src/core/job_queue.rs
@@ -265,7 +265,7 @@ impl JobQueue {
         job: Job,
         context: Weak<AppContext>,
         status_map: Arc<DashMap<String, JobStatus>>,
-        _permit: tokio::sync::OwnedSemaphorePermit,
+        permit: tokio::sync::OwnedSemaphorePermit,
     ) {
         let job_type = job.job_type();
         let worker_url = job.worker_url().to_string();
@@ -278,6 +278,12 @@ impl JobQueue {
         );
 
         debug!("Processing job: type={}, worker={}", job_type, worker_url);
+
+        // Release concurrency slot immediately. The semaphore bounds how many
+        // jobs can be dequeued concurrently (preventing thundering herd), but
+        // long-running waits (e.g. 30-min worker health checks) must not hold
+        // a slot or they starve the queue for all other job types.
+        drop(permit);
 
         // Execute job
         match context.upgrade() {
@@ -298,8 +304,6 @@ impl JobQueue {
                 );
             }
         }
-
-        // Permit automatically released when dropped
     }
 
     /// Execute a specific job


### PR DESCRIPTION
## Summary
- Fix semaphore starvation in job queue where long-running jobs (AddWorker 30min, RegisterMcpServer 2hr) hold concurrency permits during `wait_for_completion` polling loops
- With `max_concurrent_jobs=10`, registering >10 workers blocks the entire queue, starving fast jobs and eventually filling the 1000-entry bounded channel

## What changed
- `model_gateway/src/core/job_queue.rs`: Drop the semaphore permit immediately after updating status to "processing", before calling `execute_job`
- Rename `_permit` → `permit` for explicit `drop(permit)` call

## Why this is safe
- `start_workflow` spawns a detached `tokio::spawn` task — workflows run independently
- `wait_for_completion` is just a polling loop checking workflow state
- Neither consumes gateway resources worth rate-limiting
- The semaphore still bounds concurrent dequeue rate (prevents thundering herd on startup)

## Test plan
- [x] `cargo check -p smg` — compiles clean
- [x] `cargo clippy -p smg` — no warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced job queue performance by optimizing how processing capacity is allocated, allowing long-running jobs to free up slots sooner for other jobs to execute.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->