### PR TITLE
refactor: remove dead embedding/classify code from regular PreparationStage

### DIFF
--- a/model_gateway/src/routers/grpc/pipeline.rs
+++ b/model_gateway/src/routers/grpc/pipeline.rs
@@ -208,7 +208,7 @@ impl RequestPipeline {
         policy_registry: Arc<PolicyRegistry>,
     ) -> Self {
         let stages: Vec<Box<dyn PipelineStage>> = vec![
-            Box::new(EmbeddingPreparationStage),
+            Box::new(EmbeddingPreparationStage::new()),
             Box::new(WorkerSelectionStage::new(
                 worker_registry,
                 policy_registry,
@@ -236,7 +236,7 @@ impl RequestPipeline {
         policy_registry: Arc<PolicyRegistry>,
     ) -> Self {
         let stages: Vec<Box<dyn PipelineStage>> = vec![
-            Box::new(EmbeddingPreparationStage),
+            Box::new(EmbeddingPreparationStage::new()),
             Box::new(WorkerSelectionStage::new(
                 worker_registry,
                 policy_registry,

--- a/model_gateway/src/routers/grpc/regular/stages/embedding/preparation.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/embedding/preparation.rs
@@ -16,6 +16,12 @@ use crate::routers::{
 
 pub(crate) struct EmbeddingPreparationStage;
 
+impl EmbeddingPreparationStage {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
 #[async_trait]
 impl PipelineStage for EmbeddingPreparationStage {
     async fn execute(&self, ctx: &mut RequestContext) -> Result<Option<Response>, Response> {

--- a/model_gateway/src/routers/grpc/regular/stages/preparation.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/preparation.rs
@@ -7,10 +7,7 @@ use async_trait::async_trait;
 use axum::response::Response;
 use tracing::error;
 
-use super::{
-    chat::ChatPreparationStage, embedding::preparation::EmbeddingPreparationStage,
-    generate::GeneratePreparationStage,
-};
+use super::{chat::ChatPreparationStage, generate::GeneratePreparationStage};
 use crate::routers::{
     error as grpc_error,
     grpc::{
@@ -23,7 +20,6 @@ use crate::routers::{
 pub(crate) struct PreparationStage {
     chat_stage: ChatPreparationStage,
     generate_stage: GeneratePreparationStage,
-    embedding_stage: EmbeddingPreparationStage,
 }
 
 impl PreparationStage {
@@ -31,7 +27,6 @@ impl PreparationStage {
         Self {
             chat_stage: ChatPreparationStage,
             generate_stage: GeneratePreparationStage,
-            embedding_stage: EmbeddingPreparationStage,
         }
     }
 }
@@ -48,17 +43,20 @@ impl PipelineStage for PreparationStage {
         match &ctx.input.request_type {
             RequestType::Chat(_) => self.chat_stage.execute(ctx).await,
             RequestType::Generate(_) => self.generate_stage.execute(ctx).await,
-            RequestType::Embedding(_) => self.embedding_stage.execute(ctx).await,
-            // Classify reuses the embedding preparation (tokenization)
-            RequestType::Classify(_) => self.embedding_stage.execute(ctx).await,
-            RequestType::Responses(_) => {
+            other => {
+                let type_name = match other {
+                    RequestType::Embedding(_) => "Embedding",
+                    RequestType::Classify(_) => "Classify",
+                    RequestType::Responses(_) => "Responses",
+                    _ => "Unknown",
+                };
                 error!(
                     function = "PreparationStage::execute",
-                    "RequestType::Responses reached regular preparation stage"
+                    "RequestType::{type_name} reached regular preparation stage"
                 );
                 Err(grpc_error::internal_error(
-                    "responses_in_wrong_pipeline",
-                    "RequestType::Responses reached regular preparation stage",
+                    "wrong_pipeline",
+                    format!("RequestType::{type_name} should use its dedicated pipeline"),
                 ))
             }
         }


### PR DESCRIPTION
## Description

### Problem

`EmbeddingPreparationStage` was wired into the regular `PreparationStage` delegator for Embedding and Classify request types. However, these requests are routed to their own dedicated pipelines (`new_embeddings` / `new_classify`) by the gRPC router and never reach the regular pipeline — making this delegation dead code.

Additionally, `EmbeddingPreparationStage` had an inconsistent construction style compared to other stages: it used `::new()` in some places and bare struct syntax in others.

### Solution

- Remove `EmbeddingPreparationStage` from the delegating `PreparationStage` and replace the Embedding/Classify match arms with an error (matching the existing Responses arm pattern)
- Restore `new()` on `EmbeddingPreparationStage` for consistency with other stages constructed in `pipeline.rs`
- Remove the unnecessary `Default` impl that was only needed to satisfy clippy for the now-removed `new()`

## Changes

- `preparation.rs` (delegator): Remove `embedding_stage` field and Embedding/Classify match arms; collapse into a single error arm for unexpected request types
- `embedding/preparation.rs`: Restore `new()` constructor, remove `Default` impl
- `pipeline.rs`: Use `EmbeddingPreparationStage::new()` consistently

## Test Plan

- Pre-commit hooks pass (rustfmt, clippy)
- No behavioral change: Embedding/Classify requests already route to dedicated pipelines

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal request handling pipeline and improved error messaging for enhanced maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->