### PR TITLE
fix(ci): add memory limits to 4-gpu-h100 runner to prevent benchmark OOM

### DIFF
--- a/scripts/k8s-runner-resources/runner-values-4-gpu-h100.yaml
+++ b/scripts/k8s-runner-resources/runner-values-4-gpu-h100.yaml
@@ -69,8 +69,11 @@ template:
           - name: RUNNER_WAIT_FOR_DOCKER_IN_SECONDS
             value: '120'
         resources:
+          requests:
+            memory: "128Gi"
           limits:
             nvidia.com/gpu: 4
+            memory: "128Gi"
         volumeMounts:
           - name: model-cache
             mountPath: /models


### PR DESCRIPTION
## Description

### Problem

PR Test and Nightly benchmark jobs on `4-gpu-h100` runners have been consistently failing with exit code -9 (SIGKILL/OOM) for the past 48+ hours. All 4 recent PR Test benchmark failures show the same pattern: `genai-bench failed with exit code -9`.

Root cause: The runner pod spec in `runner-values-4-gpu-h100.yaml` (introduced in #659) has no memory `requests` or `limits` — only `nvidia.com/gpu: 4`. Without memory reservations, k8s can over-schedule multiple runner pods onto the same `BM.GPU.H100.8` node, causing memory contention and OOM kills when model servers + genai-bench run concurrently.

### Solution

Add `memory: "128Gi"` as both `requests` and `limits` on the runner container. This ensures k8s reserves sufficient memory per pod and prevents over-packing nodes.

## Changes

- `scripts/k8s-runner-resources/runner-values-4-gpu-h100.yaml`: Add memory requests/limits to runner container resources

## Test Plan

- Verify the next PR Test benchmark run completes without OOM (exit code -9)
- Monitor that pods are scheduled with proper memory reservations via `kubectl describe pod`

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GPU H100 runner configurations with memory resource specifications: memory requests and memory limits both set to 128Gi per instance. This ensures optimal resource allocation within the clusters, improves scheduling efficiency, prevents memory-related performance issues, and enhances the overall stability and reliability for GPU-intensive computational workloads and operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->