### PR TITLE
fix(mesh): increase timeouts in test_multi_node_data_propagation

### DIFF
--- a/mesh/src/tests/comprehensive.rs
+++ b/mesh/src/tests/comprehensive.rs
@@ -501,7 +501,7 @@ async fn test_multi_node_data_propagation() {
                 && handler_b.state.read().len() == 3
                 && handler_c.state.read().len() == 3
         },
-        Duration::from_secs(30),
+        Duration::from_secs(60),
         "all 3 nodes see each other",
     )
     .await;
@@ -517,7 +517,7 @@ async fn test_multi_node_data_propagation() {
             handler_b.stores.app.get("propagated_key").is_some()
                 && handler_c.stores.app.get("propagated_key").is_some()
         },
-        Duration::from_secs(30),
+        Duration::from_secs(60),
         "propagated_key synced to B and C",
     )
     .await;
@@ -551,7 +551,7 @@ async fn test_multi_node_data_propagation() {
                     .get("propagated_key")
                     .is_some_and(|v| v.value == b"propagated_value2")
         },
-        Duration::from_secs(30),
+        Duration::from_secs(60),
         "updated propagated_key synced to A and C",
     )
     .await;


### PR DESCRIPTION
## Description

### Problem

`test_multi_node_data_propagation` has been failing consistently in CI (~10 times in the past 48 hours) with timeout panics at `test_utils.rs:35`. The test creates a 3-node mesh cluster and waits for data sync, but the 30s timeouts are too tight for k8s CPU runners under parallel CI load.

### Solution

Increase all `wait_for` timeouts from 30s to 60s, matching the pattern already used in `test_five_node_cluster_with_failure`.

## Changes

- `mesh/src/tests/comprehensive.rs`: Increase 3 timeout values from 30s to 60s in `test_multi_node_data_propagation`

## Test Plan

- Pre-commit hooks pass (rustfmt, clippy)
- Monitor CI for reduced flakiness

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Adjusted test timeout durations to improve reliability in multi-node data propagation testing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->