### PR TITLE
fix(ci): add CPU/memory resource requests to GPU runner pods

### DIFF
--- a/scripts/k8s-runner-resources/runner-values-1-gpu-h100.yaml
+++ b/scripts/k8s-runner-resources/runner-values-1-gpu-h100.yaml
@@ -70,6 +70,9 @@ template:
           - name: RUNNER_WAIT_FOR_DOCKER_IN_SECONDS
             value: '120'
         resources:
+          requests:
+            cpu: "8"
+            memory: "32Gi"
           limits:
             nvidia.com/gpu: 1
         volumeMounts:

--- a/scripts/k8s-runner-resources/runner-values-2-gpu-h100.yaml
+++ b/scripts/k8s-runner-resources/runner-values-2-gpu-h100.yaml
@@ -70,6 +70,9 @@ template:
           - name: RUNNER_WAIT_FOR_DOCKER_IN_SECONDS
             value: '120'
         resources:
+          requests:
+            cpu: "16"
+            memory: "64Gi"
           limits:
             nvidia.com/gpu: 2
         volumeMounts:

--- a/scripts/k8s-runner-resources/runner-values-4-gpu-general.yaml
+++ b/scripts/k8s-runner-resources/runner-values-4-gpu-general.yaml
@@ -78,6 +78,9 @@ template:
           - name: RUNNER_WAIT_FOR_DOCKER_IN_SECONDS
             value: '120'
         resources:
+          requests:
+            cpu: "32"
+            memory: "128Gi"
           limits:
             nvidia.com/gpu: 4
         volumeMounts:

--- a/scripts/k8s-runner-resources/runner-values-4-gpu-h100.yaml
+++ b/scripts/k8s-runner-resources/runner-values-4-gpu-h100.yaml
@@ -69,6 +69,9 @@ template:
           - name: RUNNER_WAIT_FOR_DOCKER_IN_SECONDS
             value: '120'
         resources:
+          requests:
+            cpu: "32"
+            memory: "128Gi"
           limits:
             nvidia.com/gpu: 4
         volumeMounts:


### PR DESCRIPTION
## Summary
- GPU runner pods only declared `nvidia.com/gpu` limits with **no CPU or memory requests**, causing the k8s scheduler to pack multiple runners on the same node
- When both runners ran CI jobs simultaneously, they competed for CPU/memory with no guarantees — causing OOM kills (exit code -9) and CPU starvation (test timeouts)
- Adds proportional CPU/memory requests to all 4 GPU runner Helm values files

## What changed

| File | GPU | CPU request | Memory request |
|------|-----|-------------|----------------|
| `runner-values-1-gpu-h100.yaml` | 1 | 8 | 32Gi |
| `runner-values-2-gpu-h100.yaml` | 2 | 16 | 64Gi |
| `runner-values-4-gpu-general.yaml` | 4 | 32 | 128Gi |
| `runner-values-4-gpu-h100.yaml` | 4 | 32 | 128Gi |

`runner-values-cpu.yaml` already had proper requests (cpu: 8, memory: 16Gi) — no change needed.

## Why
After migrating from summerwind CRD to GitHub Actions Runner Controller (ARC), CI became extremely unstable. Root cause: without CPU/memory requests, the scheduler over-packed H100 nodes with 2x 4-GPU runner pods. Both pods had 224 CPUs and 2TB RAM available in theory, but the kernel OOM-killed processes when memory pressure peaked during concurrent CI jobs.

## Test plan
- [x] Already applied live via `kubectl patch autoscalingrunnerset` — pods rolled and new resource requests confirmed
- [x] Verified scheduler now rejects pods that can't fit (Pending state observed)
- [ ] Monitor CI stability over the next few runs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kubernetes resource configurations for GPU runners with explicit CPU and memory requests to improve resource scheduling and allocation across all GPU variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->