### PR TITLE
fix(scripts): handle empty arrays in check_release_versions.sh

### DIFF
--- a/scripts/check_release_versions.sh
+++ b/scripts/check_release_versions.sh
@@ -385,7 +385,10 @@ echo -e "${RED}${BOLD}$issues issue(s) found.${NC}"
 # ---------------------------------------------------------------------------
 # Phase 2: Offer to fix
 # ---------------------------------------------------------------------------
-total_fixes=$(( ${#NEEDS_BUMP[@]} + ${#NEEDS_WS_SYNC[@]} + ${#NEEDS_PY_BUMP[@]} ))
+n_bump=${#NEEDS_BUMP[@]}
+n_ws=${#NEEDS_WS_SYNC[@]}
+n_py=${#NEEDS_PY_BUMP[@]:-0}
+total_fixes=$(( n_bump + n_ws + n_py ))
 if [[ "$total_fixes" -eq 0 ]]; then
     exit 1
 fi
@@ -393,7 +396,7 @@ fi
 echo ""
 echo -e "${BOLD}Proposed fixes:${NC}"
 
-for entry in "${NEEDS_BUMP[@]}"; do
+for entry in ${NEEDS_BUMP[@]+"${NEEDS_BUMP[@]}"}; do
     IFS='|' read -r name path dep_key current_version level <<< "$entry"
     new_version=$(bump_version "$current_version" "$level")
     echo -e "  $(bump_label "$level") $name v$current_version → v$new_version ($path/Cargo.toml)"
@@ -402,14 +405,14 @@ for entry in "${NEEDS_BUMP[@]}"; do
     fi
 done
 
-if [[ ${#NEEDS_WS_SYNC[@]} -gt 0 ]]; then
+if [[ "$n_ws" -gt 0 ]]; then
     for entry in "${NEEDS_WS_SYNC[@]}"; do
         IFS='|' read -r name dep_key crate_version ws_version path <<< "$entry"
         echo -e "  ${BLUE}sync${NC} workspace Cargo.toml $dep_key v$ws_version → v$crate_version"
     done
 fi
 
-for entry in "${NEEDS_PY_BUMP[@]}"; do
+for entry in ${NEEDS_PY_BUMP[@]+"${NEEDS_PY_BUMP[@]}"}; do
     IFS='|' read -r name path version_file current_version level <<< "$entry"
     new_version=$(bump_version "$current_version" "$level")
     echo -e "  $(bump_label "$level") $name v$current_version → v$new_version ($version_file)"
@@ -428,7 +431,7 @@ fi
 echo ""
 fix_failed=0
 
-for entry in "${NEEDS_BUMP[@]}"; do
+for entry in ${NEEDS_BUMP[@]+"${NEEDS_BUMP[@]}"}; do
     IFS='|' read -r name path dep_key current_version level <<< "$entry"
     new_version=$(bump_version "$current_version" "$level")
 
@@ -450,7 +453,7 @@ for entry in "${NEEDS_BUMP[@]}"; do
     fi
 done
 
-if [[ ${#NEEDS_WS_SYNC[@]} -gt 0 ]]; then
+if [[ "$n_ws" -gt 0 ]]; then
     for entry in "${NEEDS_WS_SYNC[@]}"; do
         IFS='|' read -r name dep_key crate_version ws_version path <<< "$entry"
         if set_workspace_dep_version "$dep_key" "$ws_version" "$crate_version"; then
@@ -461,7 +464,7 @@ if [[ ${#NEEDS_WS_SYNC[@]} -gt 0 ]]; then
     done
 fi
 
-for entry in "${NEEDS_PY_BUMP[@]}"; do
+for entry in ${NEEDS_PY_BUMP[@]+"${NEEDS_PY_BUMP[@]}"}; do
     IFS='|' read -r name path version_file current_version level <<< "$entry"
     new_version=$(bump_version "$current_version" "$level")
 


### PR DESCRIPTION
## Summary

Fixes `make check-versions` crashing with `NEEDS_PY_BUMP[@]: unbound variable` when Python package arrays are empty.

## What changed

- `scripts/check_release_versions.sh`: use `${arr[@]+"${arr[@]}"}` pattern for safe expansion of potentially-empty arrays in for-loops, and cache array lengths into local variables before conditionals.

## Why

Bash 3.x (macOS default) treats `${empty_array[@]}` as an unbound variable under `set -u` even after `=()` initialization. When `NEEDS_PY_BUMP` had no entries appended (e.g. the Python package already had its version bumped), the script crashed at line 388.

## How

- `${arr[@]+"${arr[@]}"}` — the `+` parameter expansion only expands if the variable is set and non-empty, avoiding the nounset error.
- Pre-cached `n_bump`, `n_ws`, `n_py` variables replace inline `${#arr[@]}` in guard conditionals to avoid the same issue.

## Test plan

- [x] Run `make check-versions` on macOS (bash 3.x) with no Python packages needing bumps — no crash
- [x] Run `make check-versions` with crates needing bumps — proposed fixes display correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved internal script reliability with enhanced array handling and null-safety checks to reduce potential edge-case errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->