### PR TITLE
fix(docker): add --no-deps to engine install scripts

### DIFF
--- a/scripts/installation/install-sglang.sh
+++ b/scripts/installation/install-sglang.sh
@@ -7,4 +7,4 @@ set -e
 
 SGL_SRC="${1:-/tmp/sglang-src}"
 cd "${SGL_SRC}/python"
-pip install --force-reinstall --editable .
+pip install --no-deps --force-reinstall --editable .

--- a/scripts/installation/install-tgl.sh
+++ b/scripts/installation/install-tgl.sh
@@ -7,4 +7,4 @@ set -e
 
 TGL_SRC="${1:-/tmp/tgl-src}"
 cd "${TGL_SRC}/python"
-pip install --force-reinstall --editable .
+pip install --no-deps --force-reinstall --editable .

--- a/scripts/installation/install-trtllm.sh
+++ b/scripts/installation/install-trtllm.sh
@@ -15,4 +15,4 @@ cd "${TRTLLM_SRC}"
 git submodule update --init --recursive
 git lfs pull
 python3 ./scripts/build_wheel.py --clean
-pip install --force-reinstall ./build/tensorrt_llm*.whl
+pip install --no-deps --force-reinstall ./build/tensorrt_llm*.whl

--- a/scripts/installation/install-vllm.sh
+++ b/scripts/installation/install-vllm.sh
@@ -7,4 +7,4 @@ set -e
 
 VLLM_SRC="${1:-/tmp/vllm-src}"
 cd "${VLLM_SRC}"
-VLLM_USE_PRECOMPILED=1 pip install --force-reinstall --editable .
+VLLM_USE_PRECOMPILED=1 pip install --no-deps --force-reinstall --editable .


### PR DESCRIPTION
## Description

### Problem

When building an engine image with both `base_image_ref` and `engine_repo` set, the engine install scripts (`install-sglang.sh`, `install-vllm.sh`, etc.) use `pip install --force-reinstall` which reinstalls **all** transitive dependencies. This can break the base image's carefully curated environment by pulling in incompatible versions of packages like `torch`, `triton`, `numpy`, CUDA libraries, etc.

For example, building sglang on top of its own base image fails because pip tries to reinstall `distro` which was installed by the system package manager:

```
docker build \
    --build-arg BASE_IMAGE_REF=lmsysorg/sglang:v0.5.9 \
    --build-arg ENGINE=sglang \
    --build-arg ENGINE_REPO=https://github.com/sgl-project/sglang \
    --build-arg ENGINE_COMMIT=v0.5.9 \
    --build-arg SMG_REPO=https://github.com/lightseekorg/smg \
    --build-arg SMG_COMMIT=latest \
    -f docker/engine.Dockerfile .
```

```
103.3 × Cannot uninstall distro 1.9.0
103.3 ╰─> The package's contents are unknown: no RECORD file was found for distro.
103.3
103.3 hint: The package was installed by debian. You should check if it can uninstall the package.
```

### Solution

Add `--no-deps` to all engine install scripts so that only the engine package itself is reinstalled, leaving all base image dependencies intact.

## Changes

- `scripts/installation/install-sglang.sh`: add `--no-deps`
- `scripts/installation/install-vllm.sh`: add `--no-deps`
- `scripts/installation/install-trtllm.sh`: add `--no-deps`
- `scripts/installation/install-tgl.sh`: add `--no-deps`

## Test Plan

- Build engine image with `base_image_ref` only (no `engine_repo`) — no change in behavior, engine install script is skipped.
- Build engine image with `base_image_ref` + `engine_repo` — only the engine package is reinstalled, base image deps are preserved, no `distro` uninstall error.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated installation scripts to modify package dependency handling during component setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->