### PR TITLE
fix(ci): prevent runner shutdown on concurrent main pushes and restore path filters

### DIFF
--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -288,7 +288,7 @@ jobs:
     needs: build-wheel
     if: github.actor != 'dependabot[bot]'
     runs-on: 4-gpu-h100
-    timeout-minutes: 20
+    timeout-minutes: 30
     permissions:
       contents: read
     steps:
@@ -372,8 +372,11 @@ jobs:
               - 'Cargo.lock'
               - '.github/actions/**'
               - '.github/workflows/pr-test-rust.yml'
+              - '.github/workflows/e2e-gpu-job.yml'
               - 'scripts/ci_setup_python_venv.sh'
               - 'scripts/ci_install_sglang.sh'
+              - 'scripts/ci_install_e2e_deps.sh'
+              - 'scripts/ci_killall_sglang.sh'
               - 'scripts/ci_build_wheel.sh'
               - 'crates/tokenizer/**'
               - 'crates/tool_parser/**'
@@ -510,6 +513,7 @@ jobs:
       always()
       && !cancelled()
       && needs.build-wheel.result == 'success'
+      && github.actor != 'dependabot[bot]'
       && (github.event_name != 'pull_request'
           || (needs.detect-changes.result == 'success'
               && (needs.detect-changes.outputs.common == 'true'
@@ -528,7 +532,9 @@ jobs:
     name: e2e-2gpu-pd (${{ matrix.engine }})
     needs: [e2e-1gpu-gateway, detect-changes]
     if: >-
-      !cancelled()
+      always()
+      && !cancelled()
+      && needs.e2e-1gpu-gateway.result == 'success'
       && (github.event_name != 'pull_request'
           || (needs.detect-changes.result == 'success'
               && (needs.detect-changes.outputs.common == 'true'


### PR DESCRIPTION
## Summary

Fixes flaky CI failures where ARC ephemeral runners receive shutdown signals during e2e tests, caused by `cancel-in-progress: true` racing between concurrent push-to-main runs. Also restores the `detect-changes` path filter job that was removed in #643.

Refs: https://github.com/lightseekorg/smg/actions/runs/22840166403/job/66245282176

## What changed

### 1. Concurrency fix (`.github/workflows/pr-test-rust.yml`)

Changed `cancel-in-progress` from `true` to `${{ github.event_name == 'pull_request' }}`:
- **Push to main**: runs always complete fully, no cancellation between merges
- **Pull requests**: new pushes still cancel old in-progress runs

**Root cause**: Two commits pushed to main 14 seconds apart shared the concurrency group `gateway-tests-refs/heads/main`. The second run cancelled the first, but the ARC runner pod assigned to the new run received a late shutdown signal, causing a `KeyboardInterrupt` in `worker.py:357` only 10 minutes into a 20-minute timeout.

### 2. Restored `detect-changes` job

Added back `dorny/paths-filter` with five filter categories:
- `common`: core gateway, protocols, bindings, infra, CI scripts
- `chat-completions`: reasoning parser, multimodal, grpc, router tests, engine scripts
- `agentic`: MCP, data connector, responses/messages tests, Oracle scripts
- `embeddings`: embedding test files
- `go-bindings`: Go binding test files

### 3. Wired path filters into GPU-heavy jobs

| Job | Filter (PR only) |
|-----|-----------------|
| `e2e-1gpu-chat` | common \|\| chat-completions |
| `e2e-1gpu-embeddings` | common \|\| embeddings |
| `e2e-1gpu-gateway` | common \|\| chat-completions |
| `e2e-2gpu-responses` | common \|\| agentic |
| `e2e-2gpu-pd` | common \|\| chat-completions |
| `e2e-vendor` | common \|\| agentic |
| `go-bindings-e2e` | common \|\| go-bindings |
| `benchmarks` | always (no filter) |

Push to main and `workflow_dispatch` always run all tests regardless of path filters.

### 4. Decoupled `e2e-2gpu-responses` from `e2e-1gpu-chat`

Changed dependency from `needs: [e2e-1gpu-chat]` to `needs: [build-wheel, detect-changes]` so agentic-only changes still trigger responses tests (previously blocked when chat tests were skipped).

## Why

- The runner shutdown issue caused the `e2e-1gpu-chat (vllm)` job to fail with a `KeyboardInterrupt` during model loading, despite all 46 tests passing
- Path filters save significant GPU time on PRs that only touch specific subsystems
- The `detect-changes` job was accidentally removed during the e2e test reorganization in #643

## Test plan

- [ ] Verify push-to-main runs complete without cancellation
- [ ] Verify PR runs still cancel old in-progress runs on new push
- [ ] Verify PR touching only `e2e_test/responses/` skips chat/embeddings/gateway jobs but runs vendor + responses
- [ ] Verify PR touching `model_gateway/` runs all e2e jobs (common filter matches)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Chores
* Added a PR-only change-detection job that exposes affected areas (common, chat-completions, agentic, embeddings, go-bindings) to downstream jobs.
* Gated end-to-end test suites so only relevant suites run on pull requests, speeding feedback and saving resources.
* Made in-progress CI cancellation conditional to PR events and increased benchmark timeout for stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->