### PR TITLE
feat(interactions): Register Gemini Router

### DIFF
--- a/crates/protocols/src/interactions.rs
+++ b/crates/protocols/src/interactions.rs
@@ -11,6 +11,7 @@ use validator::{Validate, ValidationError};
 use super::{
     common::{default_model, default_true, Function, GenerationRequest},
     sampling_params::validate_top_p_value,
+    validated::Normalizable,
 };
 
 // ============================================================================
@@ -91,6 +92,10 @@ impl Default for InteractionsRequest {
             store: true,
         }
     }
+}
+
+impl Normalizable for InteractionsRequest {
+    // Use default no-op implementation
 }
 
 impl GenerationRequest for InteractionsRequest {

--- a/model_gateway/src/config/builder.rs
+++ b/model_gateway/src/config/builder.rs
@@ -86,6 +86,11 @@ impl RouterConfigBuilder {
         self
     }
 
+    pub fn gemini_mode(mut self, worker_urls: Vec<String>) -> Self {
+        self.config.mode = RoutingMode::Gemini { worker_urls };
+        self
+    }
+
     pub fn mode(mut self, mode: RoutingMode) -> Self {
         self.config.mode = mode;
         self

--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -179,6 +179,8 @@ pub enum RoutingMode {
     OpenAI { worker_urls: Vec<String> },
     #[serde(rename = "anthropic")]
     Anthropic { worker_urls: Vec<String> },
+    #[serde(rename = "gemini")]
+    Gemini { worker_urls: Vec<String> },
 }
 
 impl RoutingMode {
@@ -196,6 +198,7 @@ impl RoutingMode {
             } => prefill_urls.len() + decode_urls.len(),
             RoutingMode::OpenAI { worker_urls } => worker_urls.len(),
             RoutingMode::Anthropic { worker_urls } => worker_urls.len(),
+            RoutingMode::Gemini { worker_urls } => worker_urls.len(),
         }
     }
 
@@ -587,6 +590,7 @@ impl RouterConfig {
             RoutingMode::PrefillDecode { .. } => "prefill_decode",
             RoutingMode::OpenAI { .. } => "openai",
             RoutingMode::Anthropic { .. } => "anthropic",
+            RoutingMode::Gemini { .. } => "gemini",
         }
     }
 

--- a/model_gateway/src/config/validation.rs
+++ b/model_gateway/src/config/validation.rs
@@ -157,6 +157,12 @@ impl ConfigValidator {
                     Self::validate_urls(worker_urls)?;
                 }
             }
+            RoutingMode::Gemini { worker_urls } => {
+                // Allow empty URLs to support dynamic worker addition
+                if !worker_urls.is_empty() {
+                    Self::validate_urls(worker_urls)?;
+                }
+            }
         }
         Ok(())
     }
@@ -394,6 +400,11 @@ impl ConfigValidator {
             RoutingMode::Anthropic { .. } => {
                 return Err(ConfigError::ValidationFailed {
                     reason: "Anthropic mode does not support service discovery".to_string(),
+                });
+            }
+            RoutingMode::Gemini { .. } => {
+                return Err(ConfigError::ValidationFailed {
+                    reason: "Gemini mode does not support service discovery".to_string(),
                 });
             }
         }

--- a/model_gateway/src/core/job_queue.rs
+++ b/model_gateway/src/core/job_queue.rs
@@ -487,76 +487,17 @@ impl JobQueue {
 
                         prefill_workers.chain(decode_workers).collect()
                     }
-                    RoutingMode::OpenAI { worker_urls } => {
-                        // OpenAI mode: submit AddWorker jobs with runtime: "external"
-                        // The external_worker_registration workflow handles model discovery
-                        let api_key = router_config.api_key.clone();
-                        let mut submitted_count = 0;
-
-                        for url in worker_urls {
-                            let url_for_error = url.clone();
-                            let config =
-                                build_external_worker_config(url, api_key.clone(), router_config);
-
-                            let job = Job::AddWorker {
-                                config: Box::new(config),
-                            };
-
-                            if let Some(queue) = context.worker_job_queue.get() {
-                                queue.submit(job).await.map_err(|e| {
-                                    format!(
-                                        "Failed to submit AddWorker job for external endpoint {url_for_error}: {e}"
-                                    )
-                                })?;
-                                submitted_count += 1;
-                            } else {
-                                return Err("JobQueue not available".to_string());
-                            }
-                        }
-
-                        if submitted_count == 0 {
-                            info!("OpenAI mode: no worker URLs provided");
-                            return Ok("OpenAI mode: no worker URLs to initialize".to_string());
-                        }
-
-                        return Ok(format!(
-                            "Submitted {submitted_count} AddWorker jobs for external endpoints"
-                        ));
-                    }
-                    RoutingMode::Anthropic { worker_urls } => {
-                        // Anthropic mode: similar to OpenAI, submit AddWorker jobs with runtime: "external"
-                        let api_key = router_config.api_key.clone();
-                        let mut submitted_count = 0;
-
-                        for url in worker_urls {
-                            let url_for_error = url.clone();
-                            let config =
-                                build_external_worker_config(url, api_key.clone(), router_config);
-
-                            let job = Job::AddWorker {
-                                config: Box::new(config),
-                            };
-
-                            if let Some(queue) = context.worker_job_queue.get() {
-                                queue.submit(job).await.map_err(|e| {
-                                    format!(
-                                        "Failed to submit AddWorker job for Anthropic endpoint {url_for_error}: {e}"
-                                    )
-                                })?;
-                                submitted_count += 1;
-                            } else {
-                                return Err("JobQueue not available".to_string());
-                            }
-                        }
-
-                        if submitted_count == 0 {
-                            info!("Anthropic mode: no worker URLs provided");
-                            return Ok("Anthropic mode: no worker URLs to initialize".to_string());
-                        }
-
-                        return Ok(format!(
-                            "Submitted {submitted_count} AddWorker jobs for Anthropic endpoints"
-                        ));
+                    RoutingMode::OpenAI { worker_urls }
+                    | RoutingMode::Anthropic { worker_urls }
+                    | RoutingMode::Gemini { worker_urls } => {
+                        let provider_name = router_config.mode_type();
+                        return submit_external_worker_jobs(
+                            worker_urls,
+                            provider_name,
+                            router_config,
+                            context,
+                        )
+                        .await;
                     }
                 };
 
@@ -759,6 +700,46 @@ impl JobQueue {
             );
         }
     }
+}
+
+/// Submit AddWorker jobs for external provider endpoints (OpenAI/Anthropic/Gemini).
+async fn submit_external_worker_jobs(
+    worker_urls: &[String],
+    provider_name: &str,
+    router_config: &RouterConfig,
+    context: &Arc<AppContext>,
+) -> Result<String, String> {
+    let api_key = router_config.api_key.clone();
+    let mut submitted_count = 0;
+
+    for url in worker_urls {
+        let url_for_error = url.clone();
+        let config = build_external_worker_config(url, api_key.clone(), router_config);
+
+        let job = Job::AddWorker {
+            config: Box::new(config),
+        };
+
+        if let Some(queue) = context.worker_job_queue.get() {
+            queue.submit(job).await.map_err(|e| {
+                format!("Failed to submit AddWorker job for {provider_name} endpoint {url_for_error}: {e}")
+            })?;
+            submitted_count += 1;
+        } else {
+            return Err("JobQueue not available".to_string());
+        }
+    }
+
+    if submitted_count == 0 {
+        info!("{provider_name} mode: no worker URLs provided");
+        return Ok(format!(
+            "{provider_name} mode: no worker URLs to initialize"
+        ));
+    }
+
+    Ok(format!(
+        "Submitted {submitted_count} AddWorker jobs for {provider_name} endpoints"
+    ))
 }
 
 /// Build a `WorkerSpec` for an external API endpoint (OpenAI/Anthropic mode).

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -63,6 +63,8 @@ pub enum Backend {
     Openai,
     #[value(name = "anthropic")]
     Anthropic,
+    #[value(name = "gemini")]
+    Gemini,
 }
 
 impl std::fmt::Display for Backend {
@@ -73,6 +75,7 @@ impl std::fmt::Display for Backend {
             Backend::Trtllm => "trtllm",
             Backend::Openai => "openai",
             Backend::Anthropic => "anthropic",
+            Backend::Gemini => "gemini",
         };
         write!(f, "{s}")
     }
@@ -955,6 +958,10 @@ impl CliArgs {
             RoutingMode::Anthropic {
                 worker_urls: self.worker_urls.clone(),
             }
+        } else if matches!(self.backend, Some(Backend::Gemini)) {
+            RoutingMode::Gemini {
+                worker_urls: self.worker_urls.clone(),
+            }
         } else if self.pd_disaggregation {
             RoutingMode::PrefillDecode {
                 prefill_urls,
@@ -1017,6 +1024,9 @@ impl CliArgs {
                 all_urls.extend(worker_urls.clone());
             }
             RoutingMode::Anthropic { worker_urls } => {
+                all_urls.extend(worker_urls.clone());
+            }
+            RoutingMode::Gemini { worker_urls } => {
                 all_urls.extend(worker_urls.clone());
             }
         }

--- a/model_gateway/src/routers/factory.rs
+++ b/model_gateway/src/routers/factory.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use super::{
     anthropic::AnthropicRouter,
+    gemini::GeminiRouter,
     grpc::{pd_router::GrpcPDRouter, router::GrpcRouter},
     http::{pd_router::PDRouter, router::Router},
     openai::OpenAIRouter,
@@ -37,6 +38,7 @@ pub mod router_ids {
     pub const HTTP_PD: RouterId = RouterId::new("http-pd");
     pub const HTTP_OPENAI: RouterId = RouterId::new("http-openai");
     pub const HTTP_ANTHROPIC: RouterId = RouterId::new("http-anthropic");
+    pub const HTTP_GEMINI: RouterId = RouterId::new("http-gemini");
     pub const GRPC_REGULAR: RouterId = RouterId::new("grpc-regular");
     pub const GRPC_PD: RouterId = RouterId::new("grpc-pd");
 }
@@ -66,6 +68,9 @@ impl RouterFactory {
                 RoutingMode::Anthropic { .. } => {
                     Err("Anthropic mode requires HTTP connection_mode".to_string())
                 }
+                RoutingMode::Gemini { .. } => {
+                    Err("Gemini mode requires HTTP connection_mode".to_string())
+                }
             },
             ConnectionMode::Http => match &ctx.router_config.mode {
                 RoutingMode::Regular { .. } => Self::create_regular_router(ctx).await,
@@ -84,6 +89,7 @@ impl RouterFactory {
                 }
                 RoutingMode::OpenAI { .. } => Self::create_openai_router(ctx).await,
                 RoutingMode::Anthropic { .. } => Self::create_anthropic_router(ctx).await,
+                RoutingMode::Gemini { .. } => Self::create_gemini_router(ctx).await,
             },
         }
     }
@@ -170,6 +176,21 @@ impl RouterFactory {
         Ok(Box::new(router))
     }
 
+    /// Create a Gemini Interactions router
+    ///
+    /// Handles Gemini Interactions API (/v1/interactions) with support for
+    /// streaming, MCP tool interception, and native Gemini format passthrough.
+    #[expect(
+        clippy::unused_async,
+        reason = "async for API consistency with other create_* factory methods"
+    )]
+    pub async fn create_gemini_router(
+        ctx: &Arc<AppContext>,
+    ) -> Result<Box<dyn RouterTrait>, String> {
+        let router = GeminiRouter::new(ctx.clone())?;
+        Ok(Box::new(router))
+    }
+
     /// Create all routers for IGW (multi-router) mode.
     ///
     /// Returns a list of (router_id, label, creation_result) tuples.
@@ -208,6 +229,11 @@ impl RouterFactory {
                 router_ids::HTTP_ANTHROPIC,
                 "Anthropic",
                 Self::create_anthropic_router(ctx).await,
+            ),
+            (
+                router_ids::HTTP_GEMINI,
+                "Gemini",
+                Self::create_gemini_router(ctx).await,
             ),
         ]
     }

--- a/model_gateway/src/routers/gemini/context.rs
+++ b/model_gateway/src/routers/gemini/context.rs
@@ -4,7 +4,7 @@
 //! - `SharedComponents`: created once per router, `Arc`-cloned for each request.
 //! - `RequestContext`: created fresh per request, owned and mutated by steps.
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use axum::http::HeaderMap;
 use openai_protocol::interactions::InteractionsRequest;
@@ -34,6 +34,9 @@ pub(crate) struct SharedComponents {
 
     /// MCP orchestrator for creating tool sessions.
     pub mcp_orchestrator: Arc<McpOrchestrator>,
+
+    /// Per-request timeout from router config.
+    pub request_timeout: Duration,
 }
 
 // ============================================================================

--- a/model_gateway/src/routers/gemini/router.rs
+++ b/model_gateway/src/routers/gemini/router.rs
@@ -3,21 +3,18 @@
 use std::{
     any::Any,
     sync::{atomic::AtomicBool, Arc},
+    time::Duration,
 };
 
 use async_trait::async_trait;
-use axum::{
-    http::{HeaderMap, StatusCode},
-    response::{IntoResponse, Response},
-};
-use openai_protocol::{chat::ChatCompletionRequest, interactions::InteractionsRequest};
-use smg_mcp::McpOrchestrator;
+use axum::{http::HeaderMap, response::Response};
+use openai_protocol::interactions::InteractionsRequest;
 
 use super::{
     context::{RequestContext, SharedComponents},
     driver,
 };
-use crate::{core::WorkerRegistry, routers::RouterTrait};
+use crate::{app_context::AppContext, routers::RouterTrait};
 
 pub struct GeminiRouter {
     shared_components: Arc<SharedComponents>,
@@ -32,47 +29,26 @@ impl std::fmt::Debug for GeminiRouter {
 }
 
 impl GeminiRouter {
-    /// Create a new `GeminiRouter`.
-    pub fn new(
-        worker_registry: Arc<WorkerRegistry>,
-        mcp_orchestrator: Arc<McpOrchestrator>,
-        client: reqwest::Client,
-    ) -> Self {
+    /// Create a new `GeminiRouter` from the application context.
+    pub fn new(ctx: Arc<AppContext>) -> Result<Self, String> {
+        let mcp_orchestrator = ctx
+            .mcp_orchestrator
+            .get()
+            .ok_or_else(|| "Gemini router requires MCP orchestrator".to_string())?
+            .clone();
+
+        let request_timeout = Duration::from_secs(ctx.router_config.request_timeout_secs);
+
         let shared_components = Arc::new(SharedComponents {
-            client,
-            worker_registry,
+            client: ctx.client.clone(),
+            worker_registry: ctx.worker_registry.clone(),
             mcp_orchestrator,
+            request_timeout,
         });
-        Self {
+        Ok(Self {
             shared_components,
             healthy: AtomicBool::new(true),
-        }
-    }
-
-    /// Main handler for `POST /v1/interactions`.
-    ///
-    /// Builds a `RequestContext` and runs the driver state machine.
-    ///
-    /// For **non-streaming** requests the driver returns the HTTP response directly.
-    ///
-    /// For **streaming** requests the terminal streaming step (`StreamRequest` or
-    /// `StreamRequestWithTool`) creates an SSE channel internally, spawns the
-    /// streaming work in a background task, and returns the SSE `Response` — the
-    /// same pattern as `process_streaming_response` in the gRPC router.
-    pub async fn route_interactions(
-        &self,
-        headers: Option<HeaderMap>,
-        body: InteractionsRequest,
-        model_id: Option<String>,
-    ) -> Response {
-        let mut ctx = RequestContext::new(
-            Arc::new(body),
-            headers,
-            model_id,
-            self.shared_components.clone(),
-        );
-
-        driver::execute(&mut ctx).await
+        })
     }
 }
 
@@ -90,12 +66,19 @@ impl RouterTrait for GeminiRouter {
         "gemini"
     }
 
-    async fn route_chat(
+    async fn route_interactions(
         &self,
-        _headers: Option<&HeaderMap>,
-        _body: &ChatCompletionRequest,
-        _model_id: Option<&str>,
+        headers: Option<&HeaderMap>,
+        body: &InteractionsRequest,
+        model_id: Option<&str>,
     ) -> Response {
-        (StatusCode::NOT_IMPLEMENTED, "Not implemented").into_response()
+        let mut ctx = RequestContext::new(
+            Arc::new(body.clone()),
+            headers.cloned(),
+            model_id.map(String::from),
+            self.shared_components.clone(),
+        );
+
+        driver::execute(&mut ctx).await
     }
 }

--- a/model_gateway/src/routers/mod.rs
+++ b/model_gateway/src/routers/mod.rs
@@ -15,6 +15,7 @@ use openai_protocol::{
     completion::CompletionRequest,
     embedding::EmbeddingRequest,
     generate::GenerateRequest,
+    interactions::InteractionsRequest,
     messages::CreateMessageRequest,
     rerank::RerankRequest,
     responses::{ResponsesGetParams, ResponsesRequest},
@@ -214,6 +215,20 @@ pub trait RouterTrait: Send + Sync + Debug {
         (
             StatusCode::NOT_IMPLEMENTED,
             "Messages API not yet implemented for this router",
+        )
+            .into_response()
+    }
+
+    /// Route Gemini Interactions API requests (/v1/interactions)
+    async fn route_interactions(
+        &self,
+        _headers: Option<&HeaderMap>,
+        _body: &InteractionsRequest,
+        _model_id: Option<&str>,
+    ) -> Response {
+        (
+            StatusCode::NOT_IMPLEMENTED,
+            "Interactions API not implemented for this router",
         )
             .into_response()
     }

--- a/model_gateway/src/routers/router_manager.rs
+++ b/model_gateway/src/routers/router_manager.rs
@@ -21,6 +21,7 @@ use openai_protocol::{
     completion::CompletionRequest,
     embedding::EmbeddingRequest,
     generate::GenerateRequest,
+    interactions::InteractionsRequest,
     messages::CreateMessageRequest,
     rerank::RerankRequest,
     responses::{ResponsesGetParams, ResponsesRequest},
@@ -31,7 +32,7 @@ use tracing::{debug, info, warn};
 use crate::{
     app_context::AppContext,
     config::RoutingMode,
-    core::{ConnectionMode, RuntimeType, WorkerRegistry, WorkerType},
+    core::{ConnectionMode, ProviderType, RuntimeType, WorkerRegistry, WorkerType},
     routers::{
         factory::{router_ids, RouterId},
         RouterFactory, RouterTrait,
@@ -130,8 +131,10 @@ impl RouterManager {
             (ConnectionMode::Http, RoutingMode::Anthropic { .. }) => router_ids::HTTP_ANTHROPIC,
             (ConnectionMode::Grpc, RoutingMode::Regular { .. }) => router_ids::GRPC_REGULAR,
             (ConnectionMode::Grpc, RoutingMode::PrefillDecode { .. }) => router_ids::GRPC_PD,
+            (ConnectionMode::Http, RoutingMode::Gemini { .. }) => router_ids::HTTP_GEMINI,
             (ConnectionMode::Grpc, RoutingMode::OpenAI { .. }) => router_ids::GRPC_REGULAR,
             (ConnectionMode::Grpc, RoutingMode::Anthropic { .. }) => router_ids::GRPC_REGULAR,
+            (ConnectionMode::Grpc, RoutingMode::Gemini { .. }) => router_ids::GRPC_REGULAR,
         }
     }
 
@@ -216,7 +219,7 @@ impl RouterManager {
         let workers = self.worker_registry.get_by_model(model_id);
 
         // Find the best router ID based on worker capabilities
-        // Priority: external (OpenAI) > grpc-pd > http-pd > grpc-regular > http-regular
+        // Priority: external (provider-specific) > grpc-pd > http-pd > grpc-regular > http-regular
         let best_router_id = workers
             .iter()
             .map(|w| {
@@ -225,8 +228,13 @@ impl RouterManager {
                 let is_external = matches!(w.metadata().spec.runtime_type, RuntimeType::External);
 
                 if is_external {
-                    // External workers should be routed via OpenAI-compatible router
-                    return (4, &router_ids::HTTP_OPENAI);
+                    // Route external workers to the correct provider-specific router
+                    let router_id = match w.provider_for_model(model_id) {
+                        Some(ProviderType::Gemini) => &router_ids::HTTP_GEMINI,
+                        Some(ProviderType::Anthropic) => &router_ids::HTTP_ANTHROPIC,
+                        _ => &router_ids::HTTP_OPENAI,
+                    };
+                    return (4, router_id);
                 }
 
                 match (is_grpc, is_pd) {
@@ -598,6 +606,28 @@ impl RouterTrait for RouterManager {
             (
                 StatusCode::NOT_FOUND,
                 "No router available to handle responses request",
+            )
+                .into_response()
+        }
+    }
+
+    async fn route_interactions(
+        &self,
+        headers: Option<&HeaderMap>,
+        body: &InteractionsRequest,
+        model_id: Option<&str>,
+    ) -> Response {
+        let selected_model = model_id.or(body.model.as_deref()).or(body.agent.as_deref());
+        let router = self.select_router_for_request(headers, selected_model);
+
+        if let Some(router) = router {
+            router
+                .route_interactions(headers, body, selected_model)
+                .await
+        } else {
+            (
+                StatusCode::NOT_FOUND,
+                "No router available to handle interactions request",
             )
                 .into_response()
         }

--- a/model_gateway/src/server.rs
+++ b/model_gateway/src/server.rs
@@ -20,6 +20,7 @@ use openai_protocol::{
     completion::CompletionRequest,
     embedding::EmbeddingRequest,
     generate::GenerateRequest,
+    interactions::InteractionsRequest,
     messages::CreateMessageRequest,
     parser::{ParseFunctionCallRequest, SeparateReasoningRequest},
     rerank::{RerankRequest, V1RerankReqInput},
@@ -118,6 +119,7 @@ async fn readiness(State(state): State<Arc<AppState>>) -> Response {
             RoutingMode::Regular { .. } => !healthy_workers.is_empty(),
             RoutingMode::OpenAI { .. } => !healthy_workers.is_empty(),
             RoutingMode::Anthropic { .. } => !healthy_workers.is_empty(),
+            RoutingMode::Gemini { .. } => !healthy_workers.is_empty(),
         }
     };
 
@@ -234,6 +236,18 @@ async fn v1_responses(
     state
         .router
         .route_responses(Some(&headers), &body, Some(&body.model))
+        .await
+}
+
+async fn v1_interactions(
+    State(state): State<Arc<AppState>>,
+    headers: http::HeaderMap,
+    ValidatedJson(body): ValidatedJson<InteractionsRequest>,
+) -> Response {
+    let model_id = body.model.as_deref().or(body.agent.as_deref());
+    state
+        .router
+        .route_interactions(Some(&headers), &body, model_id)
         .await
 }
 
@@ -580,6 +594,7 @@ pub fn build_app(
         .route("/v1/responses", post(v1_responses))
         .route("/v1/embeddings", post(v1_embeddings))
         .route("/v1/messages", post(v1_messages))
+        .route("/v1/interactions", post(v1_interactions))
         .route("/v1/classify", post(v1_classify))
         .route("/v1/responses/{response_id}", get(v1_responses_get))
         .route(


### PR DESCRIPTION
## Description

### Problem

The model gateway currently supports OpenAI and Anthropic as external provider backends, but lacks support for Google's Gemini API. Users who want to route requests through Gemini-compatible endpoints cannot do so.

### Solution

Add the routing infrastructure and registration plumbing for Gemini as a new routing mode in the model gateway. This PR wires up the config, CLI, job queue, router factory, server endpoint, and router manager so that the
   Gemini router is fully registered and routable. The router implementation stubs (worker selection, request building, upstream execution, response processing) and integration tests will follow in a subsequent PR. Refer to https://github.com/lightseekorg/smg/pull/417 for more details of the gemini router structure 

## Changes

- Gemini routing mode: Add `RoutingMode::Gemini` variant to config types, validation, CLI `--backend gemini` flag, and job queue worker initialization
- Job queue refactor: Consolidate duplicate OpenAI/Anthropic worker submission into shared `submit_external_worker_jobs` helper, add Gemini to the combined match arm
 - Router registration: Register `GeminiRouter` in the router factory (both single-router and IGW multi-router modes), add `HTTP_GEMINI` router ID, include in `create_all_routers`
- Server endpoint: Add `POST /v1/interactions` route with `ValidatedJson<InteractionsRequest>` extractor
- RouterTrait: Add default `route_interactions` method (returns 501) so existing routers are unaffected
- Router manager: Implement `route_interactions` dispatch and provider-aware routing in `get_router_for_model` using `ProviderType`
- GeminiRouter: Construct from `AppContext` with `SharedComponents` (client, worker_registry, mcp_orchestrator, request_timeout), implement `RouterTrait::route_interactions`
- Protocol: Implement `Normalizable` for `InteractionsRequest` for `ValidatedJson` extractor compatibility


## Test Plan
- Existing tests pass — no behavioral changes to OpenAI/Anthropic paths
- `cargo build` succeeds with new Gemini config variants
- Integration tests for the Gemini router (mock server, round-trip, error cases, circuit breaker) will be added in the follow-up PR
- run ` cargo run -p smg --bin smg -- --backend gemini --worker-urls "https://generativelanguage.googleapis.com" --port 8080` to start smg for gemini backend. The router starts successfully and return 501 not implemented for /v1/interactions request

<img width="1835" height="848" alt="Screenshot 2026-03-09 at 9 13 41 AM" src="https://github.com/user-attachments/assets/38afa2dd-fe69-41f1-821a-557e2aec948b" />
<img width="1830" height="201" alt="Screenshot 2026-03-09 at 4 16 07 PM" src="https://github.com/user-attachments/assets/6f588d26-9677-40e2-8a5f-a91353b101de" />

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gemini backend added with configurable worker URLs, routing, and HTTP-only backend handling
  * New /v1/interactions endpoint and Interactions API routing support
  * Gemini model discovery via /v1beta/models and provider-specific auth (x-goog-api-key)
  * Worker selection, payload transformation, upstream request/response handling, and metadata patching for Gemini flows

* **Tests**
  * Comprehensive end-to-end tests and a Mock Gemini server for interactions testing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->