### PR TITLE
refactor(gateway): remove redundant connection_mode special-case for external providers

### DIFF
--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -1020,10 +1020,7 @@ impl CliArgs {
                 all_urls.extend(worker_urls.clone());
             }
         }
-        let connection_mode = match &mode {
-            RoutingMode::OpenAI { .. } => ConnectionMode::Http,
-            _ => Self::determine_connection_mode(&all_urls),
-        };
+        let connection_mode = Self::determine_connection_mode(&all_urls);
 
         let history_backend = match self.history_backend.as_str() {
             "none" => HistoryBackend::None,


### PR DESCRIPTION
## Description

### Problem

The `connection_mode` detection in `main.rs` had a special-case match arm that hardcoded `RoutingMode::OpenAI` to `ConnectionMode::Http`, bypassing `determine_connection_mode()`. This was a safety measure from the original OpenAI backend PR, but after Simo's cleanup in #9999 (simplified gRPC detection to scheme-only checking), it became redundant. Each new external provider (Anthropic, now Gemini in #679) was forced to either add its own match arm or fall through to URL detection accidentally.

### Solution

Remove the `RoutingMode` match and call `determine_connection_mode()` unconditionally. External provider URLs (`https://...`) never start with `grpc://`, so they always resolve to `ConnectionMode::Http` through the normal path. The factory already has error guards for invalid gRPC + external provider combinations as a safety net.

## Changes

- Remove the `RoutingMode::OpenAI` special-case match in `CliArgs::to_server_config()`, replacing it with a direct call to `Self::determine_connection_mode(&all_urls)`

## Test Plan

- `cargo check -p smg` passes
- No behavioral change: external provider URLs are always `https://`, which `determine_connection_mode()` already resolves to `ConnectionMode::Http`
- The factory's gRPC rejection errors for OpenAI/Anthropic remain as a safety net

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Connection mode detection now consistently uses worker URL schemes to determine protocol selection (gRPC or HTTP) across all routing configurations, removing special-case handling and improving reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->