### PR TITLE
fix(benchmarks): increase PD benchmark timeout from 240s to 480s

### DIFF
--- a/e2e_test/benchmarks/conftest.py
+++ b/e2e_test/benchmarks/conftest.py
@@ -53,6 +53,13 @@ def _build_command(
     if local_model_path:
         cmd.extend(["-v", f"{local_model_path}:{local_model_path}"])
 
+    # Mount host HF cache into container so genai-bench reuses tokenizers
+    # already downloaded by sglang workers instead of downloading from HF
+    # (HF downloads inside ephemeral containers hang intermittently).
+    hf_home = os.environ.get("HF_HOME", os.path.join(Path.home(), ".cache", "huggingface"))
+    if os.path.isdir(hf_home):
+        cmd.extend(["-v", f"{hf_home}:{hf_home}", "-e", f"HF_HOME={hf_home}"])
+
     # Pass through environment variables the container may need
     for var in ("HF_TOKEN", "HF_HOME"):
         if os.environ.get(var):


### PR DESCRIPTION
## Summary
The PD benchmark (`test_pd_perf[pd_http]`) consistently times out at the default 240s genai-bench subprocess timeout, causing CI failures with exit code -9.

## What changed
- `e2e_test/benchmarks/test_pd_perf.py`: Added explicit `timeout_sec=480` to the `genai_bench_runner` call

## Why
PD setup spins up 4 SGLang workers (2 prefill + 2 decode) plus a disaggregated gateway, which takes significantly longer to complete 200 requests compared to regular benchmarks. The default 240s timeout (from `conftest.py`) is insufficient.

## Test plan
- [x] Verified the regular benchmarks (http, grpc) pass fine within 240s
- [x] Confirmed PD benchmark was consistently failing at exactly 240s (`genai-bench timed out after 240s`)
- [ ] CI run on this PR should pass the PD benchmark

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized Docker configuration for benchmarks to cache HuggingFace dependencies, improving test execution efficiency by preventing unnecessary re-downloads across benchmark runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->