### PR TITLE
ops(ci): increase 1-gpu runner max from 8 to 16

### DIFF
--- a/scripts/k8s-runner-resources/runner-values-1-gpu.yaml
+++ b/scripts/k8s-runner-resources/runner-values-1-gpu.yaml
@@ -7,7 +7,7 @@ githubConfigSecret: github-arc-secret
 
 ## Runner scaling configuration
 minRunners: 2
-maxRunners: 8
+maxRunners: 16
 
 ## name of the runner scale set to create.  Defaults to the helm release name
 runnerScaleSetName: "1-gpu"


### PR DESCRIPTION
## Summary
Increase the `maxRunners` for the `1-gpu` ARC runner scale set from 8 to 16.

## What changed
- `scripts/k8s-runner-resources/runner-values-1-gpu.yaml`: `maxRunners: 8` → `maxRunners: 16`

## Why
Each full workflow run needs ~5 `1-gpu` slots. With 2-3 concurrent runs (PRs + push to main), the max of 8 was a bottleneck — pods were stuck in Pending. The cluster has 84+ idle GPUs across unused H100/A10 nodes, so 16 is well within capacity.

## Test plan
- [x] Already applied to cluster via `helm upgrade` — verified with `kubectl get autoscalingrunnersets`
- [x] Confirmed no pending pods after the change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased runner scaling capacity to support higher concurrent workload handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->