### PR TITLE
fix: address PR #676 follow-up comments

### DIFF
--- a/.github/workflows/nightly-benchmark.yml
+++ b/.github/workflows/nightly-benchmark.yml
@@ -48,7 +48,7 @@ jobs:
           path: |
             bindings/python/dist/*.whl
             clients/python/smg_client/types/_generated.py
-          key: nightly-wheel-${{ runner.os }}-${{ hashFiles('Cargo.lock', '**/Cargo.toml', 'crates/auth/src/**', 'bindings/python/src/**', 'crates/data_connector/src/**', 'crates/grpc_client/src/**', 'crates/kv_index/src/**', 'crates/mcp/src/**', 'crates/mesh/src/**', 'model_gateway/src/**', 'crates/multimodal/src/**', 'crates/protocols/src/**', 'crates/reasoning_parser/src/**', 'crates/tokenizer/src/**', 'crates/tool_parser/src/**', 'crates/wasm/src/**', 'crates/workflow/src/**') }}
+          key: nightly-wheel-${{ runner.os }}-${{ hashFiles('Cargo.lock', '**/Cargo.toml', 'crates/auth/src/**', 'bindings/python/src/**', 'clients/openapi-gen/src/**', 'crates/data_connector/src/**', 'crates/grpc_client/src/**', 'crates/kv_index/src/**', 'crates/mcp/src/**', 'crates/mesh/src/**', 'model_gateway/src/**', 'crates/multimodal/src/**', 'crates/protocols/src/**', 'crates/reasoning_parser/src/**', 'crates/tokenizer/src/**', 'crates/tool_parser/src/**', 'crates/wasm/src/**', 'crates/workflow/src/**') }}
           restore-keys: |
             nightly-wheel-${{ runner.os }}-
 

--- a/bindings/golang/Cargo.toml
+++ b/bindings/golang/Cargo.toml
@@ -28,10 +28,10 @@ default-features = true
 workspace = true
 
 [dependencies.llm-tokenizer]
-path = "../../crates/tokenizer"
+workspace = true
 
 [dependencies.tool-parser]
-path = "../../crates/tool_parser"
+workspace = true
 
 [dependencies.smg-grpc-client]
 workspace = true

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -18,10 +18,10 @@ path = "../../model_gateway"
 default-features = true
 
 [dependencies.smg-auth]
-path = "../../crates/auth"
+workspace = true
 
 [dependencies.tool-parser]
-path = "../../crates/tool_parser"
+workspace = true
 
 [features]
 default = ["pyo3/extension-module"]

--- a/clients/openapi-gen/Cargo.toml
+++ b/clients/openapi-gen/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 anyhow = { workspace = true }
-openai-protocol = { path = "../../crates/protocols" }
+openai-protocol = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }


### PR DESCRIPTION
## Description

### Problem

PR #676 (move library crates into `crates/` directory) left a few follow-up items from review comments that weren't addressed before merge.

### Solution

Address the open review comments from #676:

## Changes

- **`.github/workflows/nightly-benchmark.yml`**: Add `clients/openapi-gen/src/**` to the cache key `hashFiles` list so benchmark cache invalidates when openapi-gen source changes
- **`bindings/golang/Cargo.toml`**: Switch `llm-tokenizer` and `tool-parser` from explicit `path = "..."` to `workspace = true`
- **`bindings/python/Cargo.toml`**: Switch `smg-auth` and `tool-parser` from explicit `path = "..."` to `workspace = true`
- **`clients/openapi-gen/Cargo.toml`**: Switch `openai-protocol` from explicit `path = "..."` to `workspace = true`

## Test Plan

- `cargo check -p smg-golang -p smg-python -p openapi-gen` passes
- Workspace dependency resolution verified

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build system configuration to use workspace-based dependency resolution across bindings and client modules.
  * Modified cache validation for nightly build artifacts to include additional source paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->