### PR TITLE
fix(tokenizer): enable trim_blocks and lstrip_blocks in Jinja2 environment

### DIFF
--- a/crates/tokenizer/src/chat_template.rs
+++ b/crates/tokenizer/src/chat_template.rs
@@ -443,6 +443,12 @@ fn sort_json_keys(value: &JsonValue) -> JsonValue {
 fn build_environment(template: String) -> Result<Environment<'static>> {
     let mut env = Environment::new();
 
+    // Match HuggingFace's Jinja2 defaults: trim_blocks and lstrip_blocks are
+    // enabled in Python's transformers but default to false in minijinja.
+    // Without these, templates like GLM-5's produce incorrect whitespace.
+    env.set_trim_blocks(true);
+    env.set_lstrip_blocks(true);
+
     // Register the template with owned storage (no lifetime dependency on caller)
     env.add_template_owned("chat".to_owned(), template)
         .map_err(|e| anyhow!("Failed to add template: {e}"))?;


### PR DESCRIPTION
## Summary

Enable `trim_blocks` and `lstrip_blocks` on the minijinja `Environment` to match HuggingFace Python's Jinja2 defaults, fixing incorrect whitespace rendering for templates like GLM-5.

## What changed

- **`crates/tokenizer/src/chat_template.rs`**: Added `env.set_trim_blocks(true)` and `env.set_lstrip_blocks(true)` in `build_environment()` after `Environment::new()`

## Why

Python's `transformers` library creates its Jinja2 Environment with `trim_blocks=True` and `lstrip_blocks=True` by default. minijinja defaults both to `false`. This mismatch causes chat templates that rely on implicit whitespace stripping (e.g. GLM-5 using `{% set` instead of `{%- set`) to render with extra whitespace, breaking radix cache prefix matching and producing malformed prompts.

## How

Uses minijinja's stable `Environment` setter API

## Test plan

- `cargo build -p llm-tokenizer` — compiles cleanly
- `cargo test -p llm-tokenizer` — all 145 tests pass (100 unit + 45 integration), no regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed chat template whitespace handling to resolve formatting inconsistencies. Whitespace within templates is now properly trimmed and managed, effectively preventing rendering issues that previously affected output consistency. This improves the reliability and correctness of template processing across different language models, ensuring consistent behavior when rendering templates of all types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->