### PR TITLE
refactor(e2e): clean up test infrastructure code quality and efficiency

### DIFF
--- a/e2e_test/fixtures/hooks.py
+++ b/e2e_test/fixtures/hooks.py
@@ -12,6 +12,8 @@ import os
 import pytest
 from infra import get_runtime
 
+from .markers import resolve_class_marker
+
 # ---------------------------------------------------------------------------
 # Marker registration
 # ---------------------------------------------------------------------------
@@ -95,32 +97,13 @@ def pytest_runtest_setup(item: pytest.Item) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _get_own_class_marker(item: pytest.Item, name: str):
-    """Get a marker defined on the item's own class, not inherited from parents.
-
-    When a test class subclasses another test class, pytest's pytestmark list
-    includes parent markers first and child markers last.  get_closest_marker()
-    therefore returns the parent's marker, which can be wrong when the child
-    intentionally overrides a marker (e.g. engine("sglang") overriding
-    engine("sglang","vllm","trtllm")).
-
-    This helper checks the child class's __dict__ directly.
-    """
-    cls = getattr(item, "cls", None)
-    if cls is None:
-        return None
-    own_marks = cls.__dict__.get("pytestmark", [])
-    if not isinstance(own_marks, list):
-        own_marks = [own_marks]
-    for mark in own_marks:
-        if getattr(mark, "name", None) == name:
-            return mark
-    return None
-
-
 def _get_marker(item: pytest.Item, name: str):
-    """Get the most specific marker, preferring child class over parent."""
-    return _get_own_class_marker(item, name) or item.get_closest_marker(name)
+    """Get the most specific marker, preferring child class over parent.
+
+    Delegates to resolve_class_marker() which walks the class MRO (child-first)
+    so that a child class marker overrides a parent class marker.
+    """
+    return resolve_class_marker(item, name)
 
 
 def pytest_collection_modifyitems(

--- a/e2e_test/infra/constants.py
+++ b/e2e_test/infra/constants.py
@@ -69,8 +69,6 @@ def get_runtime() -> str:
     """
     global _RUNTIME_CACHE
     if _RUNTIME_CACHE is None:
-        import os
-
         _RUNTIME_CACHE = os.environ.get(ENV_RUNTIME, DEFAULT_RUNTIME)
     return _RUNTIME_CACHE
 

--- a/e2e_test/infra/gateway.py
+++ b/e2e_test/infra/gateway.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import os
 import subprocess
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -373,10 +374,8 @@ class Gateway:
                 worker_id = data.get("worker_id")
 
                 if wait_ready and worker_id:
-                    import time
-
-                    start = time.time()
-                    while time.time() - start < ready_timeout:
+                    start = time.perf_counter()
+                    while time.perf_counter() - start < ready_timeout:
                         workers = self.list_workers()
                         for w in workers:
                             if w.id == worker_id:

--- a/e2e_test/infra/gpu_monitor.py
+++ b/e2e_test/infra/gpu_monitor.py
@@ -20,11 +20,10 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _percentile(samples: list[float], p: float) -> float:
-    """Calculate percentile from sorted samples."""
-    if not samples:
+def _percentile(sorted_samples: list[float], p: float) -> float:
+    """Calculate percentile from pre-sorted samples."""
+    if not sorted_samples:
         return 0.0
-    sorted_samples = sorted(samples)
     idx = max(
         0,
         min(len(sorted_samples) - 1, int(round((p / 100.0) * (len(sorted_samples) - 1)))),
@@ -64,17 +63,18 @@ def _compute_stats(
     if not trimmed:
         trimmed = samples  # Fallback to original if trimming removes all samples
 
+    sorted_trimmed = sorted(trimmed)
     return {
         "mean": sum(trimmed) / len(trimmed),
-        "min": min(trimmed),
-        "max": max(trimmed),
-        "p5": _percentile(trimmed, 5),
-        "p10": _percentile(trimmed, 10),
-        "p25": _percentile(trimmed, 25),
-        "p50": _percentile(trimmed, 50),
-        "p75": _percentile(trimmed, 75),
-        "p90": _percentile(trimmed, 90),
-        "p95": _percentile(trimmed, 95),
+        "min": sorted_trimmed[0],
+        "max": sorted_trimmed[-1],
+        "p5": _percentile(sorted_trimmed, 5),
+        "p10": _percentile(sorted_trimmed, 10),
+        "p25": _percentile(sorted_trimmed, 25),
+        "p50": _percentile(sorted_trimmed, 50),
+        "p75": _percentile(sorted_trimmed, 75),
+        "p90": _percentile(sorted_trimmed, 90),
+        "p95": _percentile(sorted_trimmed, 95),
         "count": len(trimmed),
     }
 

--- a/e2e_test/infra/model_specs.py
+++ b/e2e_test/infra/model_specs.py
@@ -110,22 +110,31 @@ def get_models_with_feature(feature: str) -> list[str]:
     ]
 
 
+def _parse_tp_overrides() -> dict | None:
+    """Parse E2E_MODEL_TP_OVERRIDES env var once at import time."""
+    raw = os.environ.get("E2E_MODEL_TP_OVERRIDES")
+    if raw:
+        try:
+            parsed = json.loads(raw)
+            if isinstance(parsed, dict):
+                return parsed
+        except json.JSONDecodeError:
+            pass
+    return None
+
+
+_TP_OVERRIDES = _parse_tp_overrides()
+
+
 def get_model_spec(model_id: str) -> dict:
     """Get spec for a specific model, raising KeyError if not found."""
     if model_id not in MODEL_SPECS:
         raise KeyError(f"Unknown model: {model_id}. Available: {list(MODEL_SPECS.keys())}")
     spec = dict(MODEL_SPECS[model_id])
-    tp_overrides_json = os.environ.get("E2E_MODEL_TP_OVERRIDES")
-    if tp_overrides_json:
-        try:
-            tp_overrides = json.loads(tp_overrides_json)
-            if isinstance(tp_overrides, dict):
-                override = tp_overrides.get(model_id)
-                if isinstance(override, int) and override > 0:
-                    spec["tp"] = override
-        except json.JSONDecodeError:
-            # Ignore malformed override config and fall back to canonical specs.
-            pass
+    if _TP_OVERRIDES is not None:
+        override = _TP_OVERRIDES.get(model_id)
+        if isinstance(override, int) and override > 0:
+            spec["tp"] = override
     return spec
 
 

--- a/e2e_test/infra/worker.py
+++ b/e2e_test/infra/worker.py
@@ -324,37 +324,33 @@ class Worker:
             )
 
         start = time.perf_counter()
-        while time.perf_counter() - start < timeout:
-            if not self.is_alive():
-                pid = self.process.pid if self.process else "unknown"
-                raise RuntimeError(f"Worker {self.model_id} (PID {pid}) died during startup")
-            try:
-                channel = grpc.insecure_channel(f"{DEFAULT_HOST}:{self.port}")
+        channel = grpc.insecure_channel(f"{DEFAULT_HOST}:{self.port}")
+        try:
+            while time.perf_counter() - start < timeout:
+                if not self.is_alive():
+                    pid = self.process.pid if self.process else "unknown"
+                    raise RuntimeError(f"Worker {self.model_id} (PID {pid}) died during startup")
                 try:
                     stub = health_pb2_grpc.HealthStub(channel)
                     request = health_pb2.HealthCheckRequest(service="")
                     response = stub.Check(request, timeout=5.0)
                     if response.status == health_pb2.HealthCheckResponse.SERVING:
                         return
-                finally:
-                    channel.close()
-            except grpc.RpcError as e:
-                # UNIMPLEMENTED means server is up but doesn't have health service;
-                # fall back to channel connectivity check
-                if hasattr(e, "code") and e.code() == grpc.StatusCode.UNIMPLEMENTED:
-                    try:
-                        channel = grpc.insecure_channel(f"{DEFAULT_HOST}:{self.port}")
+                except grpc.RpcError as e:
+                    # UNIMPLEMENTED means server is up but doesn't have health service;
+                    # fall back to channel connectivity check
+                    if hasattr(e, "code") and e.code() == grpc.StatusCode.UNIMPLEMENTED:
                         try:
                             grpc.channel_ready_future(channel).result(timeout=5.0)
                             return
-                        finally:
-                            channel.close()
-                    except Exception:
-                        pass
-            except Exception:
-                pass
+                        except Exception:
+                            pass
+                except Exception:
+                    pass
 
-            time.sleep(HEALTH_CHECK_INTERVAL)
+                time.sleep(HEALTH_CHECK_INTERVAL)
+        finally:
+            channel.close()
 
         raise TimeoutError(
             f"gRPC worker {self.model_id} on port {self.port} "


### PR DESCRIPTION
## Summary

Six targeted code quality and efficiency improvements across the E2E test infrastructure, reducing net 15 lines while improving consistency and eliminating redundant work.

## What changed

- **`e2e_test/fixtures/hooks.py`**: Removed duplicate `_get_own_class_marker()` (26 lines) that reimplemented the same MRO-walking logic already in `markers.resolve_class_marker()`. The `_get_marker()` helper now delegates directly.
- **`e2e_test/infra/constants.py`**: Removed redundant `import os` inside `get_runtime()` — `os` is already imported at module level.
- **`e2e_test/infra/gateway.py`**: Moved `import time` from inside `add_worker()` to module level; replaced `time.time()` with `time.perf_counter()` for consistency with the rest of the codebase.
- **`e2e_test/infra/gpu_monitor.py`**: Changed `_percentile()` to accept a pre-sorted list and sort once in `_compute_stats()` instead of re-sorting 7 times per call. Also use `sorted_list[0]`/`sorted_list[-1]` for min/max instead of separate `min()`/`max()` traversals.
- **`e2e_test/infra/model_specs.py`**: Cached `E2E_MODEL_TP_OVERRIDES` JSON parsing at module load via `_parse_tp_overrides()` instead of re-parsing the env var on every `get_model_spec()` call.
- **`e2e_test/infra/worker.py`**: Create one gRPC channel before the health check retry loop and reuse it across iterations (with `finally` cleanup) instead of creating+closing a new channel per attempt.

## Why

These are low-risk housekeeping fixes identified via systematic code review:
- **Code reuse**: hooks.py duplicated logic already available in markers.py
- **Consistency**: mixed `time.time()` vs `time.perf_counter()`, inline vs module-level imports
- **Efficiency**: redundant sorting, repeated JSON parsing, unnecessary gRPC channel churn

## Test plan

- [ ] Verify `pytest --collect-only` still collects tests correctly (hooks.py marker resolution)
- [ ] Verify GPU monitor stats produce identical results (gpu_monitor.py sort change is behavioral no-op)
- [ ] Verify gRPC health checks still work for workers (worker.py channel reuse)
- [ ] CI passes on existing E2E test suite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal test infrastructure including timer resolution, data processing efficiency, and gRPC health-check lifecycle management.
  * Consolidated marker resolution logic and streamlined environment variable parsing with caching for improved startup performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->