### PR TITLE
feat(realtime-api): realtime webrtc handler

### DIFF
--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -394,6 +394,7 @@ jobs:
               - 'crates/data_connector/**'
               - 'e2e_test/responses/**'
               - 'e2e_test/messages/**'
+              - 'e2e_test/realtime/**'
               - 'scripts/ci_agentic_svc_deps.sh'
               - 'scripts/oracle_flyway/**'
             embeddings:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ tokio-util = { version = "0.7", features = ["rt"] }
 tokio-tungstenite = { version = "0.28", features = ["rustls-tls-native-roots"] }
 webpki-roots = "1.0"
 multer = "3"
+str0m = { version = "0.16", default-features = false, features = ["openssl"] }
 scopeguard = "1.2"
 bitflags = "2.10.0"
 schemars = "0.8"

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -453,6 +453,8 @@ struct Router {
     otlp_traces_endpoint: String,
     control_plane_auth: Option<PyControlPlaneAuthConfig>,
     schema_config: Option<String>,
+    webrtc_bind_addr: Option<String>,
+    webrtc_stun_server: Option<String>,
 }
 
 impl Router {
@@ -806,6 +808,8 @@ impl Router {
         otlp_traces_endpoint = String::from("localhost:4317"),
         control_plane_auth = None,
         schema_config = None,
+        webrtc_bind_addr = None,
+        webrtc_stun_server = None,
     ))]
     #[expect(clippy::too_many_arguments)]
     #[expect(
@@ -902,6 +906,8 @@ impl Router {
         otlp_traces_endpoint: String,
         control_plane_auth: Option<PyControlPlaneAuthConfig>,
         schema_config: Option<String>,
+        webrtc_bind_addr: Option<String>,
+        webrtc_stun_server: Option<String>,
     ) -> PyResult<Self> {
         let mut all_urls = worker_urls.clone();
 
@@ -1008,6 +1014,8 @@ impl Router {
             otlp_traces_endpoint,
             control_plane_auth,
             schema_config,
+            webrtc_bind_addr,
+            webrtc_stun_server,
         })
     }
 
@@ -1084,6 +1092,17 @@ impl Router {
                     .as_ref()
                     .map(|c| c.to_auth_control_plane_config()),
                 mesh_server_config: None,
+                webrtc_bind_addr: self
+                    .webrtc_bind_addr
+                    .as_deref()
+                    .map(|s| s.parse::<std::net::IpAddr>())
+                    .transpose()
+                    .map_err(|e| {
+                        pyo3::exceptions::PyValueError::new_err(format!(
+                            "Invalid webrtc-bind-addr: {e}"
+                        ))
+                    })?,
+                webrtc_stun_server: self.webrtc_stun_server.clone(),
             })
             .await
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))

--- a/bindings/python/src/smg/router_args.py
+++ b/bindings/python/src/smg/router_args.py
@@ -149,6 +149,9 @@ class RouterArgs:
     jwt_audience: str | None = None
     jwt_jwks_uri: str | None = None
     jwt_role_mapping: dict[str, str] = dataclasses.field(default_factory=dict)
+    # WebRTC configuration
+    webrtc_bind_addr: str | None = None
+    webrtc_stun_server: str | None = "stun.l.google.com:19302"
 
     @staticmethod
     def add_cli_args(
@@ -995,6 +998,28 @@ class RouterArgs:
                 "Mapping from IDP role/group names to gateway roles."
                 " Format: 'idp_role=gateway_role'."
                 " Example: --jwt-role-mapping 'Gateway.Admin=admin' 'Gateway.User=user'"
+            ),
+        )
+
+        # WebRTC configuration
+        webrtc_group = parser.add_argument_group("WebRTC", "WebRTC signaling and ICE configuration")
+        webrtc_group.add_argument(
+            f"--{prefix}webrtc-bind-addr",
+            type=str,
+            default=None,
+            help=(
+                "Bind address for WebRTC UDP sockets (client-facing ICE candidate IP)."
+                " Default: 0.0.0.0 (auto-detect via routing table)."
+                " Set to 127.0.0.1 for local development on the same machine."
+            ),
+        )
+        webrtc_group.add_argument(
+            f"--{prefix}webrtc-stun-server",
+            type=str,
+            default="stun.l.google.com:19302",
+            help=(
+                "STUN server for ICE candidate gathering (host:port)."
+                " Set to your own STUN server for enterprise deployments."
             ),
         )
 

--- a/e2e_test/pyproject.toml
+++ b/e2e_test/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
   "pytest",
   "pytest-rerunfailures",
   "websockets",
+  "aiortc",
 ]
 
 [project.optional-dependencies]

--- a/e2e_test/realtime/test_realtime_webrtc.py
+++ b/e2e_test/realtime/test_realtime_webrtc.py
@@ -1,0 +1,846 @@
+"""E2E tests for the Realtime WebRTC relay (/v1/realtime/calls).
+
+Tests the gateway's ability to relay WebRTC sessions via SDP signaling:
+- SDP offer/answer exchange (direct and multipart content types)
+- SDP answer format validation (ICE, DTLS, audio media)
+- Error handling (missing model, invalid SDP, missing auth, wrong method)
+- Concurrency (parallel SDP offers)
+- Hangup call lifecycle
+- Data channel events (session lifecycle, text response, error handling)
+
+Prerequisites:
+- OPENAI_API_KEY environment variable set
+
+Usage:
+    pytest e2e_test/realtime/test_realtime_webrtc.py -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+import httpx
+import pytest
+import requests
+
+logger = logging.getLogger(__name__)
+
+OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY", "")
+REALTIME_MODEL = "gpt-4o-realtime-preview-2024-12-17"
+
+# Minimal SDP offer — enough for the signaling endpoint to accept and return
+# an answer.  We only test the HTTP signaling layer, not actual media flow.
+MINIMAL_SDP_OFFER = (
+    "v=0\r\n"
+    "o=- 0 0 IN IP4 127.0.0.1\r\n"
+    "s=-\r\n"
+    "t=0 0\r\n"
+    "a=group:BUNDLE 0 1\r\n"
+    "a=extmap-allow-mixed\r\n"
+    "a=msid-semantic: WMS\r\n"
+    "m=audio 9 UDP/TLS/RTP/SAVPF 111\r\n"
+    "c=IN IP4 0.0.0.0\r\n"
+    "a=rtcp:9 IN IP4 0.0.0.0\r\n"
+    "a=ice-ufrag:test\r\n"
+    "a=ice-pwd:testpasswordtestpassword\r\n"
+    "a=fingerprint:sha-256 00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00"
+    ":00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00\r\n"
+    "a=setup:actpass\r\n"
+    "a=mid:0\r\n"
+    "a=sendrecv\r\n"
+    "a=rtpmap:111 opus/48000/2\r\n"
+    "m=application 9 UDP/DTLS/SCTP webrtc-datachannel\r\n"
+    "c=IN IP4 0.0.0.0\r\n"
+    "a=ice-ufrag:test\r\n"
+    "a=ice-pwd:testpasswordtestpassword\r\n"
+    "a=fingerprint:sha-256 00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00"
+    ":00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00\r\n"
+    "a=setup:actpass\r\n"
+    "a=mid:1\r\n"
+    "a=sctp-port:5000\r\n"
+    "a=max-message-size:262144\r\n"
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _post_sdp(calls_url, auth_headers, *, model=None, sdp=MINIMAL_SDP_OFFER, timeout=30):
+    """POST an SDP offer to the calls endpoint and return the response."""
+    url = f"{calls_url}?model={model}" if model else calls_url
+    return requests.post(
+        url,
+        data=sdp,
+        headers={**auth_headers, "Content-Type": "application/sdp"},
+        timeout=timeout,
+    )
+
+
+def _post_multipart(calls_url, auth_headers, *, session_config, sdp=MINIMAL_SDP_OFFER, timeout=30):
+    """POST a multipart SDP offer with session config and return the response."""
+    files = {
+        "sdp": ("offer.sdp", sdp, "application/sdp"),
+        "session": ("session.json", json.dumps(session_config), "application/json"),
+    }
+    return requests.post(
+        calls_url,
+        files=files,
+        headers=auth_headers,
+        timeout=timeout,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def gateway():
+    """Launch a cloud gateway in OpenAI mode for realtime WebRTC tests."""
+    from infra import launch_cloud_gateway
+
+    if not OPENAI_API_KEY:
+        pytest.skip("OPENAI_API_KEY not set")
+
+    gw = launch_cloud_gateway("openai", history_backend="memory")
+    yield gw
+    gw.shutdown()
+
+
+@pytest.fixture(scope="module")
+def dc_gateway():
+    """Dedicated gateway for data-channel tests.
+
+    Signaling tests leave zombie bridges (fake SDP, no real ICE peer) that
+    consume sockets and poll-loop CPU. A fresh gateway avoids resource
+    starvation that causes DTLS handshake timeouts in CI.
+    """
+    from infra import launch_cloud_gateway
+
+    if not OPENAI_API_KEY:
+        pytest.skip("OPENAI_API_KEY not set")
+
+    gw = launch_cloud_gateway("openai", history_backend="memory")
+    yield gw
+    gw.shutdown()
+
+
+@pytest.fixture()
+def calls_url(gateway):
+    """Build the realtime calls URL."""
+    return f"http://{gateway.host}:{gateway.port}/v1/realtime/calls"
+
+
+@pytest.fixture()
+def auth_headers():
+    """Build the Authorization headers."""
+    return {"Authorization": f"Bearer {OPENAI_API_KEY}"}
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.e2e
+@pytest.mark.vendor("openai")
+@pytest.mark.gpu(0)
+class TestRealtimeWebRtcSignaling:
+    """E2E tests for the WebRTC SDP signaling layer."""
+
+    def test_sdp_offer_answer_direct(self, calls_url, auth_headers):
+        """POST application/sdp offer should return an SDP answer with 201."""
+        resp = _post_sdp(calls_url, auth_headers, model=REALTIME_MODEL)
+        assert resp.status_code == 201, (
+            f"Expected 201 CREATED, got {resp.status_code}: {resp.text[:500]}"
+        )
+        content_type = resp.headers.get("Content-Type", "")
+        assert "application/sdp" in content_type, (
+            f"Expected application/sdp Content-Type, got: {content_type}"
+        )
+        # Answer SDP must start with "v=0"
+        answer_sdp = resp.text
+        assert answer_sdp.startswith("v=0"), f"Answer SDP doesn't look valid: {answer_sdp[:200]}"
+        logger.info("Direct SDP: got %d-byte answer SDP", len(answer_sdp))
+
+    def test_sdp_offer_answer_multipart(self, calls_url, auth_headers):
+        """POST multipart/form-data with sdp + session fields should return SDP answer."""
+        resp = _post_multipart(
+            calls_url,
+            auth_headers,
+            session_config={
+                "model": REALTIME_MODEL,
+                "type": "realtime",
+                "audio": {"output": {"voice": "alloy"}},
+            },
+        )
+        assert resp.status_code == 201, (
+            f"Expected 201 CREATED, got {resp.status_code}: {resp.text[:500]}"
+        )
+        answer_sdp = resp.text
+        assert answer_sdp.startswith("v=0"), f"Answer SDP doesn't look valid: {answer_sdp[:200]}"
+        logger.info("Multipart SDP: got %d-byte answer SDP", len(answer_sdp))
+
+    def test_missing_model_returns_error(self, calls_url, auth_headers):
+        """POST without model should return 400."""
+        resp = _post_sdp(calls_url, auth_headers, timeout=10)
+        assert resp.status_code == 400, f"Expected 400 for missing model, got {resp.status_code}"
+
+    def test_missing_auth_returns_unauthorized(self, calls_url):
+        """POST without Authorization header should return 401."""
+        resp = _post_sdp(calls_url, {}, model=REALTIME_MODEL, timeout=10)
+        assert resp.status_code == 401, f"Expected 401 for missing auth, got {resp.status_code}"
+
+    def test_unsupported_content_type_returns_error(self, calls_url, auth_headers):
+        """POST with unsupported Content-Type should return 400."""
+        url = f"{calls_url}?model={REALTIME_MODEL}"
+        resp = requests.post(
+            url,
+            data='{"sdp": "fake"}',
+            headers={**auth_headers, "Content-Type": "application/json"},
+            timeout=10,
+        )
+        assert resp.status_code == 400, (
+            f"Expected 400 for unsupported content type, got {resp.status_code}"
+        )
+
+    def test_invalid_sdp_returns_error(self, calls_url, auth_headers):
+        """POST with invalid SDP body should return 400."""
+        resp = _post_sdp(
+            calls_url,
+            auth_headers,
+            model=REALTIME_MODEL,
+            sdp="this is not valid SDP",
+            timeout=10,
+        )
+        assert resp.status_code == 400, f"Expected 400 for invalid SDP, got {resp.status_code}"
+
+    def test_multipart_missing_sdp_returns_error(self, calls_url, auth_headers):
+        """POST multipart without sdp field should return 400."""
+        # Not using _post_multipart since we intentionally omit the sdp field
+        session_config = json.dumps({"model": REALTIME_MODEL, "type": "realtime"})
+        resp = requests.post(
+            calls_url,
+            files={
+                "session": ("session.json", session_config, "application/json"),
+            },
+            headers=auth_headers,
+            timeout=10,
+        )
+        assert resp.status_code == 400, (
+            f"Expected 400 for missing sdp field, got {resp.status_code}"
+        )
+
+    def test_multipart_missing_model_returns_error(self, calls_url, auth_headers):
+        """POST multipart with session but no model should return 400."""
+        resp = _post_multipart(
+            calls_url,
+            auth_headers,
+            session_config={"audio": {"output": {"voice": "alloy"}}},
+            timeout=10,
+        )
+        assert resp.status_code == 400, (
+            f"Expected 400 for missing model in session, got {resp.status_code}"
+        )
+
+    def test_empty_body_returns_error(self, calls_url, auth_headers):
+        """POST with empty SDP body should return an error."""
+        resp = _post_sdp(calls_url, auth_headers, model=REALTIME_MODEL, sdp="", timeout=10)
+        assert resp.status_code == 400, f"Expected 400 for empty SDP body, got {resp.status_code}"
+
+    def test_get_method_not_allowed(self, calls_url, auth_headers):
+        """GET /v1/realtime/calls should return 405 Method Not Allowed."""
+        url = f"{calls_url}?model={REALTIME_MODEL}"
+        resp = requests.get(url, headers=auth_headers, timeout=10)
+        assert resp.status_code == 405, f"Expected 405 for GET method, got {resp.status_code}"
+
+    def test_put_method_not_allowed(self, calls_url, auth_headers):
+        """PUT /v1/realtime/calls should return 405 Method Not Allowed."""
+        url = f"{calls_url}?model={REALTIME_MODEL}"
+        resp = requests.put(
+            url,
+            data=MINIMAL_SDP_OFFER,
+            headers={**auth_headers, "Content-Type": "application/sdp"},
+            timeout=10,
+        )
+        assert resp.status_code == 405, f"Expected 405 for PUT method, got {resp.status_code}"
+
+    def test_multipart_extra_fields_accepted(self, calls_url, auth_headers):
+        """POST multipart with extra unknown fields should be silently ignored by SMG."""
+        session_config = json.dumps({"model": REALTIME_MODEL, "type": "realtime"})
+        resp = requests.post(
+            calls_url,
+            files={
+                "sdp": ("offer.sdp", MINIMAL_SDP_OFFER, "application/sdp"),
+                "session": ("session.json", session_config, "application/json"),
+                "extra": ("extra.txt", "some extra data", "text/plain"),
+            },
+            headers=auth_headers,
+            timeout=30,
+        )
+        assert resp.status_code == 201, (
+            f"Expected 201 CREATED with extra fields, got {resp.status_code}: {resp.text[:500]}"
+        )
+
+    def test_concurrent_calls(self, calls_url, auth_headers):
+        """Multiple concurrent SDP offers should all succeed."""
+        num_calls = 3
+
+        def _make_call():
+            return _post_sdp(calls_url, auth_headers, model=REALTIME_MODEL)
+
+        with ThreadPoolExecutor(max_workers=num_calls) as pool:
+            futures = [pool.submit(_make_call) for _ in range(num_calls)]
+            results = [f.result() for f in as_completed(futures)]
+
+        for i, resp in enumerate(results):
+            assert resp.status_code == 201, (
+                f"Concurrent call {i} failed: {resp.status_code} {resp.text[:200]}"
+            )
+            assert resp.text.startswith("v=0"), (
+                f"Concurrent call {i} SDP invalid: {resp.text[:200]}"
+            )
+        logger.info("All %d concurrent calls succeeded", num_calls)
+
+
+@pytest.mark.e2e
+@pytest.mark.vendor("openai")
+@pytest.mark.gpu(0)
+class TestRealtimeWebRtcAnswerFormat:
+    """Validate the SDP answer format returned by the signaling endpoint."""
+
+    def test_answer_sdp_format(self, calls_url, auth_headers):
+        """SDP answer must have correct Content-Type, required SDP fields, ICE, DTLS, and audio."""
+        resp = _post_sdp(calls_url, auth_headers, model=REALTIME_MODEL)
+        assert resp.status_code == 201
+
+        # Content-Type
+        ct = resp.headers.get("Content-Type", "")
+        assert "application/sdp" in ct, f"Expected application/sdp, got: {ct}"
+
+        # Required SDP fields
+        answer = resp.text
+        assert "v=0" in answer, "Missing v= line in SDP answer"
+        assert "\no=" in answer or answer.startswith("v=0\r\no="), "Missing o= line"
+        assert "\ns=" in answer or "\r\ns=" in answer, "Missing s= line"
+        assert "\nm=" in answer or "\r\nm=" in answer, "Missing m= (media) line"
+
+        # ICE credentials
+        assert "a=ice-ufrag:" in answer, "Missing ice-ufrag in SDP answer"
+        assert "a=ice-pwd:" in answer, "Missing ice-pwd in SDP answer"
+
+        # DTLS fingerprint
+        assert "a=fingerprint:" in answer, "Missing DTLS fingerprint in SDP answer"
+
+        # Audio media
+        assert "m=audio" in answer, "Missing audio media line in SDP answer"
+        logger.info("SDP answer format validated (%d bytes)", len(answer))
+
+    def test_multipart_answer_matches_direct(self, calls_url, auth_headers):
+        """Multipart and direct SDP flows should return structurally similar answers."""
+        direct_resp = _post_sdp(calls_url, auth_headers, model=REALTIME_MODEL)
+        multi_resp = _post_multipart(
+            calls_url,
+            auth_headers,
+            session_config={"model": REALTIME_MODEL, "type": "realtime"},
+        )
+        assert direct_resp.status_code == 201
+        assert multi_resp.status_code == 201
+
+        # Both must be valid SDP with audio
+        for label, text in [("direct", direct_resp.text), ("multipart", multi_resp.text)]:
+            assert text.startswith("v=0"), f"{label} SDP doesn't start with v=0"
+            assert "m=audio" in text, f"{label} SDP missing audio media"
+            assert "a=ice-ufrag:" in text, f"{label} SDP missing ICE credentials"
+        logger.info("Direct and multipart answers are structurally consistent")
+
+
+# ---------------------------------------------------------------------------
+# Data channel event tests (requires aiortc)
+# ---------------------------------------------------------------------------
+
+RECV_TIMEOUT = 60  # seconds — DTLS handshake can be slow in CI
+
+
+def _parse_event(raw: str | bytes) -> dict | None:
+    """Parse a JSON event from a data channel message."""
+    try:
+        text = raw.decode("utf-8") if isinstance(raw, bytes) else raw
+        return json.loads(text)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        logger.warning("Non-JSON data channel message: %s", str(raw)[:200])
+        return None
+
+
+async def _recv_dc_event(
+    dc, *, event_type: str | None = None, timeout: float = RECV_TIMEOUT
+) -> dict:
+    """Receive the next JSON event from a data channel, optionally filtering by type."""
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    queue: asyncio.Queue = asyncio.Queue()
+
+    def _on_message(msg):
+        queue.put_nowait(msg)
+
+    dc.on("message", _on_message)
+    try:
+        while True:
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                raise TimeoutError(f"Timed out waiting for data channel event type={event_type}")
+            raw = await asyncio.wait_for(queue.get(), timeout=remaining)
+            event = _parse_event(raw)
+            if event is None:
+                continue
+            if event_type is None or event.get("type") == event_type:
+                return event
+            logger.debug(
+                "Skipping DC event %s while waiting for %s",
+                event.get("type"),
+                event_type,
+            )
+    finally:
+        dc.remove_all_listeners("message")
+
+
+async def _collect_dc_response_text(dc, *, timeout: float = RECV_TIMEOUT) -> str:
+    """Collect text deltas from the data channel until response.done."""
+    parts: list[str] = []
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    queue: asyncio.Queue = asyncio.Queue()
+
+    def _on_message(msg):
+        queue.put_nowait(msg)
+
+    dc.on("message", _on_message)
+    try:
+        while True:
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                raise TimeoutError("Timed out waiting for response.done on data channel")
+            raw = await asyncio.wait_for(queue.get(), timeout=remaining)
+            event = _parse_event(raw)
+            if event is None:
+                continue
+            etype = event.get("type", "")
+            if etype == "response.text.delta" and event.get("delta"):
+                parts.append(event["delta"])
+            elif etype == "response.done":
+                break
+            elif etype == "error":
+                raise RuntimeError(f"Upstream error: {json.dumps(event)}")
+    finally:
+        dc.remove_all_listeners("message")
+    return "".join(parts)
+
+
+async def _establish_webrtc_session(gateway_host, gateway_port, auth_headers):
+    """Complete SDP signaling + ICE/DTLS handshake, return (pc, dc).
+
+    Uses aiortc to create a real WebRTC peer connection to the SMG gateway,
+    waits for the data channel to open, and returns the peer connection and
+    data channel objects.
+    """
+    from aiortc import RTCPeerConnection, RTCSessionDescription
+
+    pc = RTCPeerConnection()
+
+    # Create a data channel (matches the "oai-events" channel SMG expects)
+    dc = pc.createDataChannel("oai-events")
+
+    # Add audio transceiver to match expected SDP structure
+    pc.addTransceiver("audio", direction="sendrecv")
+
+    # Create and set local offer
+    offer = await pc.createOffer()
+    await pc.setLocalDescription(offer)
+
+    # Send offer to SMG signaling endpoint (async to avoid blocking the aiortc event loop)
+    calls_url = f"http://{gateway_host}:{gateway_port}/v1/realtime/calls?model={REALTIME_MODEL}"
+    async with httpx.AsyncClient() as http_client:
+        resp = await http_client.post(
+            calls_url,
+            content=pc.localDescription.sdp,
+            headers={**auth_headers, "Content-Type": "application/sdp"},
+            timeout=30,
+        )
+    assert resp.status_code == 201, f"SDP signaling failed: {resp.status_code} {resp.text[:500]}"
+
+    # Set remote answer
+    answer = RTCSessionDescription(sdp=resp.text, type="answer")
+    await pc.setRemoteDescription(answer)
+
+    # Wait for data channel to open
+    dc_open = asyncio.Event()
+    original_dc = dc
+
+    @dc.on("open")
+    def _on_open():
+        dc_open.set()
+
+    # If SMG creates the data channel (server-initiated), capture it
+    @pc.on("datachannel")
+    def _on_datachannel(channel):
+        nonlocal original_dc, dc_open
+        if channel.label == "oai-events":
+            original_dc = channel
+            dc_open.set()
+
+    await asyncio.wait_for(dc_open.wait(), timeout=RECV_TIMEOUT)
+    return pc, original_dc
+
+
+async def _open_text_session(gateway_host, gateway_port, auth_headers):
+    """Establish WebRTC connection, wait for session.created, configure text mode.
+
+    Returns (pc, dc) with the session already in text-only mode.
+    """
+    pc, dc = await _establish_webrtc_session(gateway_host, gateway_port, auth_headers)
+    await _recv_dc_event(dc, event_type="session.created")
+    _send_dc_event(dc, "session.update", session={"modalities": ["text"]})
+    await _recv_dc_event(dc, event_type="session.updated")
+    return pc, dc
+
+
+def _send_dc_event(dc, event_type: str, **payload):
+    """Send a JSON event over the data channel."""
+    dc.send(json.dumps({"type": event_type, **payload}))
+
+
+def _send_user_message(dc, text: str):
+    """Send a user text message and trigger a text response."""
+    _send_dc_event(
+        dc,
+        "conversation.item.create",
+        item={
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": text}],
+        },
+    )
+    _send_dc_event(dc, "response.create", response={"modalities": ["text"]})
+
+
+@pytest.mark.e2e
+@pytest.mark.vendor("openai")
+@pytest.mark.gpu(0)
+@pytest.mark.flaky(reruns=4)
+@pytest.mark.xfail(reason="DTLS handshake flaky in CI (aiortc↔str0m)", strict=False)
+class TestRealtimeWebRtcDataChannel:
+    """E2E tests for client/server events over the WebRTC data channel.
+
+    These tests establish a real WebRTC peer connection via aiortc,
+    then exchange Realtime API events over the data channel — mirroring
+    the WebSocket event tests in test_realtime_ws.py.
+    """
+
+    def test_session_created_on_connect(self, dc_gateway, auth_headers):
+        """Connecting should receive a session.created event on the data channel."""
+
+        async def _run():
+            pc, dc = await _establish_webrtc_session(
+                dc_gateway.host,
+                dc_gateway.port,
+                auth_headers,
+            )
+            try:
+                event = await _recv_dc_event(dc, event_type="session.created")
+                assert event["type"] == "session.created"
+                assert "session" in event
+                assert event["session"].get("model") is not None
+                logger.info("DC session.created: id=%s", event["session"].get("id"))
+            finally:
+                await pc.close()
+
+        asyncio.run(_run())
+
+    def test_session_update(self, dc_gateway, auth_headers):
+        """Sending session.update over data channel should receive session.updated."""
+
+        async def _run():
+            pc, dc = await _establish_webrtc_session(
+                dc_gateway.host,
+                dc_gateway.port,
+                auth_headers,
+            )
+            try:
+                await _recv_dc_event(dc, event_type="session.created")
+                _send_dc_event(dc, "session.update", session={"modalities": ["text"]})
+                event = await _recv_dc_event(dc, event_type="session.updated")
+                assert event["type"] == "session.updated"
+                assert event["session"].get("modalities") == ["text"]
+                logger.info("DC session.updated successfully")
+            finally:
+                await pc.close()
+
+        asyncio.run(_run())
+
+    def test_text_response(self, dc_gateway, auth_headers):
+        """Full text round-trip over data channel: user message -> text response."""
+
+        async def _run():
+            pc, dc = await _open_text_session(
+                dc_gateway.host,
+                dc_gateway.port,
+                auth_headers,
+            )
+            try:
+                _send_user_message(dc, "Say hello in one short sentence.")
+                text = await _collect_dc_response_text(dc)
+                assert len(text) > 0, "Expected non-empty text response"
+                logger.info("DC text response: %s", text[:100])
+            finally:
+                await pc.close()
+
+        asyncio.run(_run())
+
+    def test_conversation_item_created_event(self, dc_gateway, auth_headers):
+        """Sending conversation.item.create should echo conversation.item.created."""
+
+        async def _run():
+            pc, dc = await _open_text_session(
+                dc_gateway.host,
+                dc_gateway.port,
+                auth_headers,
+            )
+            try:
+                _send_dc_event(
+                    dc,
+                    "conversation.item.create",
+                    item={
+                        "type": "message",
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": "Hi"}],
+                    },
+                )
+                event = await _recv_dc_event(dc, event_type="conversation.item.created")
+                assert event["type"] == "conversation.item.created"
+                assert event["item"]["role"] == "user"
+                logger.info("DC conversation.item.created: id=%s", event["item"].get("id"))
+            finally:
+                await pc.close()
+
+        asyncio.run(_run())
+
+    def test_invalid_event_returns_error(self, dc_gateway, auth_headers):
+        """Sending an unknown event type should return an error event."""
+
+        async def _run():
+            pc, dc = await _establish_webrtc_session(
+                dc_gateway.host,
+                dc_gateway.port,
+                auth_headers,
+            )
+            try:
+                await _recv_dc_event(dc, event_type="session.created")
+                _send_dc_event(dc, "totally.bogus.event")
+                event = await _recv_dc_event(dc, event_type="error")
+                assert event["type"] == "error"
+                logger.info("DC error: %s", event.get("error", {}).get("message", ""))
+            finally:
+                await pc.close()
+
+        asyncio.run(_run())
+
+    def test_response_done_format(self, dc_gateway, auth_headers):
+        """Validate response.done event schema over data channel."""
+
+        async def _run():
+            pc, dc = await _open_text_session(
+                dc_gateway.host,
+                dc_gateway.port,
+                auth_headers,
+            )
+            try:
+                _send_user_message(dc, "Say hi.")
+                event = await _recv_dc_event(dc, event_type="response.done")
+                assert "event_id" in event
+                resp = event["response"]
+                assert resp.get("status") == "completed"
+                assert isinstance(resp.get("output"), list)
+                assert len(resp["output"]) > 0
+                item = resp["output"][0]
+                assert item.get("role") == "assistant"
+                assert isinstance(item.get("content"), list)
+                assert len(item["content"]) > 0
+                assert isinstance(item["content"][0].get("text"), str)
+                usage = resp.get("usage")
+                assert isinstance(usage, dict)
+                assert usage.get("total_tokens", 0) > 0
+                logger.info("DC response.done schema OK: tokens=%d", usage["total_tokens"])
+            finally:
+                await pc.close()
+
+        asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# Upstream error forwarding tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.e2e
+@pytest.mark.vendor("openai")
+@pytest.mark.gpu(0)
+class TestRealtimeWebRtcErrorForwarding:
+    """Verify that upstream HTTP errors are forwarded (not masked as 502)."""
+
+    def test_invalid_api_key_forwards_upstream_401(self, calls_url):
+        """Request with invalid API key should forward upstream 401, not return 502."""
+        bad_headers = {"Authorization": "Bearer sk-invalid-key-for-testing"}
+        resp = _post_sdp(calls_url, bad_headers, model=REALTIME_MODEL, timeout=15)
+        # Upstream (OpenAI) should return 401; SMG should forward it, not mask as 502
+        assert resp.status_code == 401, (
+            f"Expected upstream 401 to be forwarded, got {resp.status_code}: {resp.text[:500]}"
+        )
+
+    def test_invalid_model_forwards_upstream_error(self, calls_url, auth_headers):
+        """Request with non-existent model should forward upstream error status."""
+        resp = _post_sdp(
+            calls_url,
+            auth_headers,
+            model="nonexistent-model-that-does-not-exist-12345",
+            timeout=15,
+        )
+        # Upstream should reject the model; SMG should forward the status (likely 400 or 404)
+        assert resp.status_code != 502, (
+            f"Expected upstream error to be forwarded, but got 502: {resp.text[:500]}"
+        )
+        assert 400 <= resp.status_code < 500, (
+            f"Expected 4xx from upstream, got {resp.status_code}: {resp.text[:500]}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Bridge cleanup tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.e2e
+@pytest.mark.vendor("openai")
+@pytest.mark.gpu(0)
+@pytest.mark.flaky(reruns=2)
+class TestRealtimeWebRtcBridgeCleanup:
+    """Verify bridge resources are cleaned up after disconnect."""
+
+    def test_reconnect_after_disconnect(self, dc_gateway, auth_headers):
+        """After closing a WebRTC session, a new session should succeed.
+
+        Verifies that bridge cleanup releases resources (sockets, registry
+        entries) so subsequent connections are not blocked.
+        """
+
+        async def _run():
+            # Establish first session
+            pc1, dc1 = await _establish_webrtc_session(
+                dc_gateway.host,
+                dc_gateway.port,
+                auth_headers,
+            )
+            event = await _recv_dc_event(dc1, event_type="session.created")
+            assert event["type"] == "session.created"
+            logger.info("First session established")
+
+            # Close first session
+            await pc1.close()
+            # Brief pause for bridge cleanup
+            await asyncio.sleep(1)
+
+            # Establish second session — should succeed if cleanup worked
+            pc2, dc2 = await _establish_webrtc_session(
+                dc_gateway.host,
+                dc_gateway.port,
+                auth_headers,
+            )
+            try:
+                event = await _recv_dc_event(dc2, event_type="session.created")
+                assert event["type"] == "session.created"
+                logger.info("Second session after disconnect succeeded")
+            finally:
+                await pc2.close()
+
+        asyncio.run(_run())
+
+    def test_multiple_sequential_sessions(self, gateway, auth_headers):
+        """Open and close 3 sessions sequentially to verify no resource leak."""
+
+        async def _run():
+            for i in range(3):
+                pc, dc = await _establish_webrtc_session(
+                    gateway.host,
+                    gateway.port,
+                    auth_headers,
+                )
+                event = await _recv_dc_event(dc, event_type="session.created")
+                assert event["type"] == "session.created"
+                logger.info("Sequential session %d established", i + 1)
+                await pc.close()
+                await asyncio.sleep(0.5)
+
+        asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# STUN integration tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.e2e
+@pytest.mark.vendor("openai")
+@pytest.mark.gpu(0)
+@pytest.mark.flaky(reruns=2)
+class TestRealtimeWebRtcStun:
+    """Verify WebRTC signaling works with STUN server configured."""
+
+    @pytest.fixture(scope="class")
+    def stun_gateway(self):
+        """Launch a gateway with an explicit STUN server configured."""
+        from infra import launch_cloud_gateway
+
+        if not OPENAI_API_KEY:
+            pytest.skip("OPENAI_API_KEY not set")
+
+        gw = launch_cloud_gateway(
+            "openai",
+            history_backend="memory",
+            extra_args=["--webrtc-stun-server", "stun.l.google.com:19302"],
+        )
+        yield gw
+        gw.shutdown()
+
+    def test_signaling_with_stun_server(self, stun_gateway, auth_headers):
+        """SDP signaling should succeed when a STUN server is configured."""
+        calls_url = f"http://{stun_gateway.host}:{stun_gateway.port}/v1/realtime/calls"
+        resp = _post_sdp(calls_url, auth_headers, model=REALTIME_MODEL)
+        assert resp.status_code == 201, (
+            f"Expected 201 with STUN configured, got {resp.status_code}: {resp.text[:500]}"
+        )
+        assert resp.text.startswith("v=0"), "SDP answer should be valid"
+        logger.info("Signaling with STUN server succeeded")
+
+    def test_data_channel_with_stun_server(self, stun_gateway, auth_headers):
+        """Full data channel round-trip should work with STUN server configured."""
+
+        async def _run():
+            pc, dc = await _establish_webrtc_session(
+                stun_gateway.host,
+                stun_gateway.port,
+                auth_headers,
+            )
+            try:
+                event = await _recv_dc_event(dc, event_type="session.created")
+                assert event["type"] == "session.created"
+                logger.info("Data channel with STUN server: session.created received")
+            finally:
+                await pc.close()
+
+        asyncio.run(_run())

--- a/model_gateway/Cargo.toml
+++ b/model_gateway/Cargo.toml
@@ -56,7 +56,7 @@ tracing-subscriber.workspace = true
 # Workspace dependencies (with extra features)
 axum = { workspace = true, features = ["macros", "ws", "tracing"] }
 bytemuck = { workspace = true, features = ["derive"] }
-reqwest = { workspace = true, features = ["stream", "blocking", "json", "rustls-tls"] }
+reqwest = { workspace = true, features = ["stream", "blocking", "json", "rustls-tls", "multipart"] }
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["full"] }
 tokio-util.workspace = true
@@ -119,6 +119,8 @@ tokio-tungstenite = { workspace = true }
 webpki-roots = { workspace = true }
 wasmtime = { workspace = true }
 tempfile = "3.8"
+multer = { workspace = true }
+str0m = { workspace = true }
 
 [build-dependencies]
 chrono = { version = "0.4", features = ["clock"] }

--- a/model_gateway/benches/wasm_middleware_latency.rs
+++ b/model_gateway/benches/wasm_middleware_latency.rs
@@ -66,7 +66,9 @@ fn bench_wasm_middleware_buffering(c: &mut Criterion) {
     // Setup AppContext with WASM enabled
     let config = RouterConfig::builder().enable_wasm(true).build_unchecked();
 
-    let context = rt.block_on(AppContext::from_config(config, 30)).unwrap();
+    let context = rt
+        .block_on(AppContext::from_config(config, 30, None, None))
+        .unwrap();
     let app_state = Arc::new(AppState {
         router: Arc::new(MockRouter),
         context: Arc::new(context),

--- a/model_gateway/src/app_context.rs
+++ b/model_gateway/src/app_context.rs
@@ -64,6 +64,10 @@ pub struct AppContext {
     pub inflight_tracker: Arc<InFlightRequestTracker>,
     pub kv_event_monitor: Option<Arc<KvEventMonitor>>,
     pub realtime_registry: Arc<RealtimeRegistry>,
+    /// Bind address for WebRTC UDP sockets (`None` = `0.0.0.0`, auto-detect).
+    pub webrtc_bind_addr: Option<std::net::IpAddr>,
+    /// STUN server for ICE candidate gathering (`None` = `stun.l.google.com:19302`).
+    pub webrtc_stun_server: Option<String>,
 }
 
 impl std::fmt::Debug for AppContext {
@@ -93,6 +97,8 @@ pub struct AppContextBuilder {
     mcp_orchestrator: Option<Arc<OnceLock<Arc<McpOrchestrator>>>>,
     wasm_manager: Option<Arc<WasmModuleManager>>,
     kv_event_monitor: Option<Arc<KvEventMonitor>>,
+    webrtc_bind_addr: Option<std::net::IpAddr>,
+    webrtc_stun_server: Option<String>,
 }
 
 impl AppContext {
@@ -105,11 +111,15 @@ impl AppContext {
     pub fn from_config(
         router_config: RouterConfig,
         request_timeout_secs: u64,
+        webrtc_bind_addr: Option<std::net::IpAddr>,
+        webrtc_stun_server: Option<String>,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Self, String>> + Send>> {
         Box::pin(async move {
             Box::pin(AppContextBuilder::from_config(
                 router_config,
                 request_timeout_secs,
+                webrtc_bind_addr,
+                webrtc_stun_server,
             ))
             .await?
             .build()
@@ -139,6 +149,8 @@ impl AppContextBuilder {
             mcp_orchestrator: None,
             wasm_manager: None,
             kv_event_monitor: None,
+            webrtc_bind_addr: None,
+            webrtc_stun_server: None,
         }
     }
 
@@ -244,6 +256,16 @@ impl AppContextBuilder {
         self
     }
 
+    pub fn webrtc_bind_addr(mut self, addr: Option<std::net::IpAddr>) -> Self {
+        self.webrtc_bind_addr = addr;
+        self
+    }
+
+    pub fn webrtc_stun_server(mut self, server: Option<String>) -> Self {
+        self.webrtc_stun_server = server;
+        self
+    }
+
     pub fn build(self) -> Result<AppContext, AppContextBuildError> {
         let router_config = self
             .router_config
@@ -303,6 +325,8 @@ impl AppContextBuilder {
             inflight_tracker: InFlightRequestTracker::new(),
             kv_event_monitor: self.kv_event_monitor,
             realtime_registry: Arc::new(RealtimeRegistry::new()),
+            webrtc_bind_addr: self.webrtc_bind_addr,
+            webrtc_stun_server: self.webrtc_stun_server,
         })
     }
 
@@ -311,6 +335,8 @@ impl AppContextBuilder {
     pub async fn from_config(
         router_config: RouterConfig,
         request_timeout_secs: u64,
+        webrtc_bind_addr: Option<std::net::IpAddr>,
+        webrtc_stun_server: Option<String>,
     ) -> Result<Self, String> {
         Ok(Self::new()
             .with_client(&router_config, request_timeout_secs)?
@@ -329,6 +355,8 @@ impl AppContextBuilder {
             .await?
             .with_wasm_manager(&router_config)
             .with_kv_event_monitor(&router_config)
+            .webrtc_bind_addr(webrtc_bind_addr)
+            .webrtc_stun_server(webrtc_stun_server)
             .router_config(router_config))
     }
 

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -623,6 +623,23 @@ struct CliArgs {
 
     #[arg(long, num_args = 0..)]
     mesh_peer_urls: Vec<String>,
+
+    // ==================== WebRTC ====================
+    // Bind address for WebRTC UDP sockets (client-facing ICE candidate IP).
+    // Default: 0.0.0.0 (auto-detect via routing table).
+    // Set to 127.0.0.1 for local development on the same machine.
+    #[arg(long, help_heading = "WebRTC")]
+    webrtc_bind_addr: Option<std::net::IpAddr>,
+
+    // STUN server for ICE candidate gathering (host:port).
+    // Set to your own STUN server for enterprise deployments that
+    // restrict outbound traffic to external STUN servers.
+    #[arg(
+        long,
+        help_heading = "WebRTC",
+        default_value = "stun.l.google.com:19302"
+    )]
+    webrtc_stun_server: Option<String>,
 }
 
 enum OracleConnectSource {
@@ -1244,6 +1261,8 @@ impl CliArgs {
             shutdown_grace_period_secs: self.shutdown_grace_period_secs,
             control_plane_auth,
             mesh_server_config,
+            webrtc_bind_addr: self.webrtc_bind_addr,
+            webrtc_stun_server: self.webrtc_stun_server.clone(),
         })
     }
 }

--- a/model_gateway/src/observability/metrics.rs
+++ b/model_gateway/src/observability/metrics.rs
@@ -396,6 +396,7 @@ pub mod metrics_labels {
 
     // Connection modes
     pub const CONNECTION_WEBSOCKET: &str = "websocket";
+    pub const CONNECTION_WEBRTC: &str = "webrtc";
 
     // Worker types
     pub const WORKER_REGULAR: &str = "regular";

--- a/model_gateway/src/routers/mod.rs
+++ b/model_gateway/src/routers/mod.rs
@@ -286,6 +286,15 @@ pub trait RouterTrait: Send + Sync + Debug {
             .into_response()
     }
 
+    /// Route a realtime WebRTC upgrade request
+    async fn route_realtime_webrtc(&self, _req: Request<Body>, _model_id: &str) -> Response {
+        (
+            StatusCode::NOT_IMPLEMENTED,
+            "Realtime WebRTC not implemented",
+        )
+            .into_response()
+    }
+
     /// Get router type name
     fn router_type(&self) -> &'static str;
 

--- a/model_gateway/src/routers/openai/realtime/mod.rs
+++ b/model_gateway/src/routers/openai/realtime/mod.rs
@@ -2,12 +2,14 @@
 //!
 //! Supports three transport mechanisms:
 //! - **WebSocket** (server-to-server): Bidirectional WS proxy with transparent MCP interception
-//! - **WebRTC** (browser-to-server): SDP signaling proxy; media + data channel flow directly
+//! - **WebRTC** (browser-to-server): Dual peer-connection relay; SMG terminates both sides
 //! - **REST**: Ephemeral token generation (`client_secrets`, `sessions`, `transcription_sessions`)
 
 pub mod proxy;
 pub mod registry;
 pub mod rest;
+pub mod webrtc;
+pub mod webrtc_bridge;
 pub mod ws;
 
 pub use registry::RealtimeRegistry;

--- a/model_gateway/src/routers/openai/realtime/webrtc.rs
+++ b/model_gateway/src/routers/openai/realtime/webrtc.rs
@@ -1,0 +1,457 @@
+//! WebRTC signaling handlers for `/v1/realtime/calls`.
+//!
+//! SMG acts as a WebRTC relay: it terminates the client's peer connection,
+//! establishes its own peer connection to upstream, and bridges data-channel
+//! messages plus audio RTP packets between the two.
+
+use std::{net::SocketAddr, sync::Arc};
+
+use axum::{
+    body::Bytes,
+    http::{header::CONTENT_TYPE, request::Parts, HeaderMap, HeaderValue, StatusCode},
+    response::{IntoResponse, Response},
+};
+use tracing::{debug, error, info, warn};
+
+use super::{
+    webrtc_bridge::{BridgeSetupError, WebRtcBridge},
+    RealtimeRegistry,
+};
+use crate::{
+    core::{worker::WorkerLoadGuard, Worker},
+    observability::metrics::{metrics_labels, Metrics},
+    routers::{error, header_utils::extract_auth_header},
+};
+
+/// Resolve a STUN server hostname to an IPv4 `SocketAddr`.
+/// Filters for IPv4 since our UDP sockets bind to `0.0.0.0`.
+/// Times out after 3 seconds to avoid blocking bridge setup on slow DNS.
+/// Returns `None` if no server is configured or resolution fails.
+async fn resolve_stun_server(server: Option<&str>) -> Option<SocketAddr> {
+    use std::time::Duration;
+
+    let host = server?;
+    match tokio::time::timeout(Duration::from_secs(3), tokio::net::lookup_host(host)).await {
+        Ok(Ok(mut addrs)) => addrs.find(|a| a.is_ipv4()),
+        Ok(Err(e)) => {
+            tracing::warn!(stun_server = host, error = %e, "Failed to resolve STUN server");
+            None
+        }
+        Err(_) => {
+            tracing::warn!(stun_server = host, "STUN server DNS resolution timed out");
+            None
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Request parsing
+// ---------------------------------------------------------------------------
+
+/// Pre-parsed WebRTC signaling request.
+///
+/// Created by [`parse_webrtc_request`] so the router can extract the model
+/// for worker selection before handing off to the bridge setup.
+pub(crate) struct WebRtcParsedRequest {
+    pub model: String,
+    pub sdp: String,
+    pub session_config: Option<serde_json::Value>,
+}
+
+/// Parse a WebRTC signaling request body.
+///
+/// Supports two content types:
+/// - `multipart/form-data`: Contains `sdp` (SDP offer) and `session` (JSON
+///   session config) fields. Model is extracted from `session.model`.
+/// - `application/sdp`: Raw SDP offer body. Model comes from `query_model`.
+pub(crate) async fn parse_webrtc_request(
+    parts: &Parts,
+    body: &Bytes,
+    query_model: &str,
+) -> Result<WebRtcParsedRequest, Response> {
+    let content_type = parts
+        .headers
+        .get(CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+
+    if content_type.starts_with("multipart/form-data") {
+        parse_multipart(content_type, body).await
+    } else if content_type.starts_with("application/sdp") {
+        parse_sdp(body, query_model)
+    } else {
+        error!(
+            content_type,
+            "Unsupported Content-Type for /v1/realtime/calls"
+        );
+        Err(error::bad_request(
+            "invalid_content_type",
+            "Expected Content-Type: multipart/form-data or application/sdp",
+        ))
+    }
+}
+
+/// Parse a `multipart/form-data` body into SDP + session config.
+async fn parse_multipart(
+    content_type: &str,
+    body: &Bytes,
+) -> Result<WebRtcParsedRequest, Response> {
+    let boundary = match multer::parse_boundary(content_type) {
+        Ok(b) => b,
+        Err(e) => {
+            error!(error = %e, "Failed to parse multipart boundary");
+            return Err(error::bad_request(
+                "invalid_multipart",
+                "Missing or invalid multipart boundary",
+            ));
+        }
+    };
+
+    let body_clone = body.clone();
+    let mut multipart = multer::Multipart::new(
+        futures::stream::once(async move { Ok::<_, std::io::Error>(body_clone) }),
+        boundary,
+    );
+
+    let mut sdp_offer: Option<Vec<u8>> = None;
+    let mut session_json: Option<serde_json::Value> = None;
+
+    loop {
+        let field = match multipart.next_field().await {
+            Ok(Some(field)) => field,
+            Ok(None) => break,
+            Err(e) => {
+                return Err(error::bad_request(
+                    "malformed_multipart",
+                    format!("Failed to read multipart field: {e}"),
+                ));
+            }
+        };
+        match field.name() {
+            Some("sdp") => match field.bytes().await {
+                Ok(b) => sdp_offer = Some(b.to_vec()),
+                Err(e) => {
+                    return Err(error::bad_request(
+                        "unreadable_sdp",
+                        format!("Failed to read 'sdp' field: {e}"),
+                    ));
+                }
+            },
+            Some("session") => match field.text().await {
+                Ok(text) => match serde_json::from_str(&text) {
+                    Ok(parsed) => session_json = Some(parsed),
+                    Err(e) => {
+                        return Err(error::bad_request(
+                            "invalid_session_json",
+                            format!("Invalid JSON in 'session' field: {e}"),
+                        ));
+                    }
+                },
+                Err(e) => {
+                    return Err(error::bad_request(
+                        "unreadable_session",
+                        format!("Failed to read 'session' field: {e}"),
+                    ));
+                }
+            },
+            _ => {}
+        }
+    }
+
+    let Some(sdp_bytes) = sdp_offer else {
+        return Err(error::bad_request(
+            "missing_sdp",
+            "multipart 'sdp' field is required",
+        ));
+    };
+
+    let sdp = validate_sdp(&sdp_bytes)?;
+
+    let model = session_json
+        .as_ref()
+        .and_then(|s| s.get("model"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    if model.is_empty() {
+        return Err(error::bad_request(
+            "missing_model",
+            "session.model is required",
+        ));
+    }
+
+    Ok(WebRtcParsedRequest {
+        model,
+        sdp,
+        session_config: session_json,
+    })
+}
+
+/// Parse an `application/sdp` body.
+#[expect(clippy::result_large_err, reason = "Response is inherently large")]
+fn parse_sdp(body: &Bytes, query_model: &str) -> Result<WebRtcParsedRequest, Response> {
+    if query_model.is_empty() {
+        return Err(error::bad_request(
+            "missing_model",
+            "query parameter 'model' is required for application/sdp requests",
+        ));
+    }
+
+    let sdp = validate_sdp(body)?;
+
+    Ok(WebRtcParsedRequest {
+        model: query_model.to_string(),
+        sdp,
+        session_config: None,
+    })
+}
+
+/// Validate and decode raw bytes as a valid SDP offer.
+#[expect(clippy::result_large_err, reason = "Response is inherently large")]
+fn validate_sdp(bytes: &[u8]) -> Result<String, Response> {
+    let sdp = std::str::from_utf8(bytes)
+        .map_err(|_| error::bad_request("invalid_sdp", "SDP is not valid UTF-8"))?;
+    if !sdp.starts_with("v=0") {
+        return Err(error::bad_request(
+            "invalid_sdp",
+            "SDP offer must start with 'v=0'",
+        ));
+    }
+    Ok(sdp.to_string())
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+/// Handle a pre-parsed realtime WebRTC signaling request.
+///
+/// The caller (router) is responsible for:
+/// 1. Parsing the request via [`parse_webrtc_request`]
+/// 2. Selecting a worker using the parsed model
+/// 3. Extracting the auth header
+#[expect(
+    clippy::too_many_arguments,
+    reason = "bridge setup requires all params"
+)]
+pub(crate) async fn handle_realtime_webrtc(
+    headers: HeaderMap,
+    parsed: WebRtcParsedRequest,
+    worker: Result<Arc<dyn Worker>, Response>,
+    auth_header: Option<HeaderValue>,
+    client: reqwest::Client,
+    bind_addr: std::net::IpAddr,
+    stun_server: Option<String>,
+    realtime_registry: Arc<RealtimeRegistry>,
+) -> Response {
+    let worker = match worker {
+        Ok(w) => w,
+        Err(response) => {
+            Metrics::record_router_error(
+                metrics_labels::ROUTER_OPENAI,
+                metrics_labels::BACKEND_EXTERNAL,
+                metrics_labels::CONNECTION_WEBRTC,
+                &parsed.model,
+                metrics_labels::ENDPOINT_REALTIME,
+                metrics_labels::ERROR_NO_WORKERS,
+            );
+            return response;
+        }
+    };
+
+    // Resolve auth: user-provided or fall back to worker's API key
+    let auth_str = match resolve_auth(&parsed.model, auth_header, worker.api_key()) {
+        Ok(s) => s,
+        Err(resp) => return resp,
+    };
+
+    let label = if parsed.session_config.is_some() {
+        "multipart"
+    } else {
+        "direct SDP"
+    };
+
+    setup_and_spawn_bridge(
+        &headers,
+        &parsed.sdp,
+        &parsed.model,
+        parsed.session_config,
+        &auth_str,
+        worker,
+        client,
+        bind_addr,
+        stun_server,
+        realtime_registry,
+        label,
+    )
+    .await
+}
+
+/// Resolve the effective auth string from user header or worker API key.
+#[expect(clippy::result_large_err, reason = "Response is inherently large")]
+fn resolve_auth(
+    model: &str,
+    auth_header: Option<HeaderValue>,
+    worker_api_key: Option<&String>,
+) -> Result<String, Response> {
+    let effective_auth = auth_header.or_else(|| extract_auth_header(None, worker_api_key));
+    match effective_auth {
+        Some(v) => match v.to_str() {
+            Ok(s) => Ok(s.to_string()),
+            Err(_) => {
+                Metrics::record_router_error(
+                    metrics_labels::ROUTER_OPENAI,
+                    metrics_labels::BACKEND_EXTERNAL,
+                    metrics_labels::CONNECTION_WEBRTC,
+                    model,
+                    metrics_labels::ENDPOINT_REALTIME,
+                    metrics_labels::ERROR_VALIDATION,
+                );
+                Err((
+                    StatusCode::BAD_REQUEST,
+                    "Authorization header contains invalid UTF-8 characters",
+                )
+                    .into_response())
+            }
+        },
+        None => {
+            Metrics::record_router_error(
+                metrics_labels::ROUTER_OPENAI,
+                metrics_labels::BACKEND_EXTERNAL,
+                metrics_labels::CONNECTION_WEBRTC,
+                model,
+                metrics_labels::ENDPOINT_REALTIME,
+                metrics_labels::ERROR_VALIDATION,
+            );
+            Err(StatusCode::UNAUTHORIZED.into_response())
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Shared bridge setup
+// ---------------------------------------------------------------------------
+
+/// Bridge creation → spawn relay task → return SDP answer.
+///
+/// Shared by both multipart and direct SDP paths. Worker selection is done
+/// by the caller (router layer).
+#[expect(
+    clippy::too_many_arguments,
+    reason = "bridge setup requires all params"
+)]
+async fn setup_and_spawn_bridge(
+    headers: &HeaderMap,
+    sdp_str: &str,
+    model: &str,
+    session_config: Option<serde_json::Value>,
+    auth_str: &str,
+    worker: Arc<dyn Worker>,
+    client: reqwest::Client,
+    bind_addr: std::net::IpAddr,
+    configured_stun_server: Option<String>,
+    realtime_registry: Arc<RealtimeRegistry>,
+    label: &str,
+) -> Response {
+    // Create the load guard now but move it into the spawned bridge task
+    // so the worker's load count remains elevated for the bridge lifetime,
+    // not just until the SDP answer is returned.
+    let load_guard = WorkerLoadGuard::new(worker.clone(), Some(headers));
+
+    let query = url::form_urlencoded::Serializer::new(String::new())
+        .append_pair("model", model)
+        .finish();
+    let upstream_url = format!(
+        "{}/v1/realtime/calls?{query}",
+        worker.url().trim_end_matches('/')
+    );
+
+    let call_id = uuid::Uuid::now_v7().to_string();
+    let stun_server = resolve_stun_server(configured_stun_server.as_deref()).await;
+
+    info!(
+        call_id,
+        model,
+        upstream_url,
+        ?stun_server,
+        "Creating WebRTC bridge ({label})"
+    );
+
+    let (mut bridge, client_sdp_answer) = match WebRtcBridge::setup(
+        sdp_str,
+        &upstream_url,
+        auth_str,
+        session_config,
+        call_id.clone(),
+        &client,
+        bind_addr,
+        stun_server,
+    )
+    .await
+    {
+        Ok(result) => result,
+        Err(e) => {
+            worker.record_outcome(false);
+            return match e {
+                BridgeSetupError::UpstreamHttp {
+                    status,
+                    body,
+                    content_type,
+                } => {
+                    warn!(call_id, model, %status, "Upstream rejected WebRTC bridge setup ({label})");
+                    let mut builder = Response::builder().status(status);
+                    if let Some(ct) = content_type {
+                        builder = builder.header("Content-Type", ct);
+                    }
+                    builder
+                        .body(axum::body::Body::from(body))
+                        .unwrap_or_else(|_| StatusCode::BAD_GATEWAY.into_response())
+                }
+                BridgeSetupError::Other(ref err) => {
+                    error!(call_id, model, error = %err, "Failed to create WebRTC bridge ({label})");
+                    StatusCode::BAD_GATEWAY.into_response()
+                }
+            };
+        }
+    };
+
+    // -- Register call and spawn bridge task --------------------------------
+    let entry = realtime_registry.register_call(
+        call_id.clone(),
+        model.to_string(),
+        worker.url().to_string(),
+    );
+    // Use the registry's cancel token so hangup cancellation reaches the bridge.
+    bridge.set_cancel_token(entry.cancel_token);
+
+    let bridge_registry = Arc::clone(&realtime_registry);
+    let bridge_call_id = call_id.clone();
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "bridge task self-terminates on disconnect/cancel"
+    )]
+    tokio::spawn(async move {
+        let _guard = load_guard; // keep worker load elevated until bridge ends
+        let success = Box::pin(bridge.run(bridge_registry.clone())).await;
+        worker.record_outcome(success);
+        bridge_registry.remove_call(&bridge_call_id);
+        debug!(
+            call_id = bridge_call_id,
+            success, "WebRTC bridge task completed"
+        );
+    });
+
+    debug!(call_id, model, "WebRTC bridge started ({label})");
+
+    // -- Return SMG-generated SDP answer ------------------------------------
+    #[expect(
+        clippy::expect_used,
+        reason = "infallible: static header names and valid body"
+    )]
+    Response::builder()
+        .status(StatusCode::CREATED)
+        .header("Content-Type", "application/sdp")
+        .body(axum::body::Body::from(client_sdp_answer))
+        .expect("static response builder")
+}

--- a/model_gateway/src/routers/openai/realtime/webrtc_bridge.rs
+++ b/model_gateway/src/routers/openai/realtime/webrtc_bridge.rs
@@ -1,0 +1,854 @@
+//! WebRTC-to-WebRTC relay bridge.
+//!
+//! Analogous to [`super::proxy`] for WebSocket, this module implements a
+//! bidirectional bridge between a client-facing and an upstream-facing WebRTC
+//! peer connection.  SMG terminates both connections and relays data-channel
+//! messages plus audio RTP packets, giving it full visibility into the traffic.
+
+use std::{
+    net::{IpAddr, SocketAddr},
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use str0m::{
+    change::{SdpAnswer, SdpOffer},
+    channel::{ChannelData, ChannelId},
+    media::{Direction, MediaKind, Mid},
+    net::{Protocol, Receive},
+    rtp::RtpPacket,
+    Candidate, Event, Input, Output, Rtc, RtcConfig,
+};
+use tokio::net::UdpSocket;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info, trace, warn};
+
+use super::registry::{ConnectionState, RealtimeRegistry};
+
+// ---------------------------------------------------------------------------
+// Error types
+// ---------------------------------------------------------------------------
+
+/// Error returned by [`WebRtcBridge::setup`].
+#[derive(Debug)]
+pub enum BridgeSetupError {
+    /// Upstream returned a non-success HTTP status (e.g. 401, 400).
+    /// Contains the status code and response body so the caller can forward
+    /// the appropriate error to the client instead of always returning 502.
+    UpstreamHttp {
+        status: reqwest::StatusCode,
+        body: String,
+        content_type: Option<String>,
+    },
+    /// Any other setup failure (network, SDP parsing, ICE, etc.).
+    Other(anyhow::Error),
+}
+
+impl std::fmt::Display for BridgeSetupError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UpstreamHttp { status, body, .. } => {
+                write!(
+                    f,
+                    "Upstream SDP exchange failed: status={status}, body={body}"
+                )
+            }
+            Self::Other(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl From<anyhow::Error> for BridgeSetupError {
+    fn from(err: anyhow::Error) -> Self {
+        Self::Other(err)
+    }
+}
+
+impl From<std::io::Error> for BridgeSetupError {
+    fn from(err: std::io::Error) -> Self {
+        Self::Other(err.into())
+    }
+}
+
+impl From<reqwest::Error> for BridgeSetupError {
+    fn from(err: reqwest::Error) -> Self {
+        Self::Other(err.into())
+    }
+}
+
+impl From<str0m::RtcError> for BridgeSetupError {
+    fn from(err: str0m::RtcError) -> Self {
+        Self::Other(err.into())
+    }
+}
+
+impl From<str0m::error::IceError> for BridgeSetupError {
+    fn from(err: str0m::error::IceError) -> Self {
+        Self::Other(err.into())
+    }
+}
+
+impl From<str0m::error::SdpError> for BridgeSetupError {
+    fn from(err: str0m::error::SdpError) -> Self {
+        Self::Other(err.into())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Opaque handle returned by [`WebRtcBridge::setup`] that the caller can
+/// `tokio::spawn` to run the relay loop.
+pub struct WebRtcBridge {
+    client_rtc: Rtc,
+    client_socket: UdpSocket,
+    /// The candidate address advertised in ICE (resolved IP + port).
+    /// Used as `destination` in `Receive::new` so str0m matches packets.
+    client_candidate_addr: SocketAddr,
+
+    upstream_rtc: Rtc,
+    upstream_socket: UdpSocket,
+    /// The candidate address advertised in ICE (resolved IP + port).
+    upstream_candidate_addr: SocketAddr,
+
+    /// Data channel id on the *client* peer (set when ChannelOpen fires).
+    client_channel: Option<ChannelId>,
+    /// Data channel id on the *upstream* peer (created during SDP setup).
+    upstream_channel: Option<ChannelId>,
+
+    /// Audio mid on the *upstream* peer — used to look up a TX stream for
+    /// forwarding client audio.
+    upstream_audio_mid: Option<Mid>,
+    /// Audio mid on the *client* peer — used to look up a TX stream for
+    /// forwarding upstream audio.
+    client_audio_mid: Option<Mid>,
+
+    /// Upstream data-channel messages received before the client channel opens.
+    /// Flushed once `client_channel` becomes `Some`.
+    pending_to_client: Vec<(bool, Vec<u8>)>,
+
+    call_id: String,
+    cancel_token: CancellationToken,
+}
+
+impl WebRtcBridge {
+    /// Create both peer connections, perform SDP exchange with upstream, and
+    /// return `(bridge, client_sdp_answer)`.
+    ///
+    /// The caller should then register the call, spawn `bridge.run()`, and
+    /// return the SDP answer to the client.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "setup requires all connection parameters"
+    )]
+    pub async fn setup(
+        client_sdp_offer_str: &str,
+        upstream_url: &str,
+        auth_header: &str,
+        session_config: Option<serde_json::Value>,
+        call_id: String,
+        http_client: &reqwest::Client,
+        bind_addr: IpAddr,
+        stun_server: Option<SocketAddr>,
+    ) -> Result<(Self, String), BridgeSetupError> {
+        // -- 1. Bind two UDP sockets (ephemeral ports) -----------------------
+        // In production, `bind_addr` is typically `0.0.0.0` and both sockets
+        // share the same bind/candidate IP (the server's routable address).
+        //
+        // For local development the user may set `--webrtc-bind-addr 127.0.0.1`
+        // so the browser (same machine) can reach the client-facing peer.
+        // A loopback address can't reach external servers, so the upstream
+        // socket falls back to `0.0.0.0` in that case.
+        let upstream_bind = if bind_addr.is_loopback() {
+            IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED)
+        } else {
+            bind_addr
+        };
+
+        let client_candidate_ip = resolve_candidate_ip(bind_addr)?;
+        let upstream_candidate_ip = resolve_candidate_ip(upstream_bind)?;
+
+        let client_socket = UdpSocket::bind(SocketAddr::new(bind_addr, 0)).await?;
+        let upstream_socket = UdpSocket::bind(SocketAddr::new(upstream_bind, 0)).await?;
+
+        let client_candidate =
+            SocketAddr::new(client_candidate_ip, client_socket.local_addr()?.port());
+        let upstream_candidate =
+            SocketAddr::new(upstream_candidate_ip, upstream_socket.local_addr()?.port());
+
+        // -- 1b. Gather server-reflexive candidate for *upstream* via STUN ---
+        // Client-facing peer uses ICE-lite (host candidates only), so no STUN
+        // needed there.
+        let upstream_srflx = match stun_server {
+            Some(stun) => {
+                let srflx = stun_gather_srflx(&upstream_socket, stun).await;
+                if srflx.is_some() {
+                    info!(upstream_srflx = ?srflx, "STUN gathering complete");
+                } else {
+                    warn!(%stun, "STUN gathering failed for upstream socket");
+                }
+                srflx
+            }
+            None => None,
+        };
+
+        debug!(
+            client_candidate = %client_candidate,
+            upstream_candidate = %upstream_candidate,
+            "Bound UDP sockets for WebRTC bridge"
+        );
+
+        // -- 2. Create upstream Rtc (offerer) --------------------------------
+        let now = Instant::now();
+        let mut upstream_rtc = RtcConfig::new().set_rtp_mode(true).build(now);
+        upstream_rtc.add_local_candidate(Candidate::host(upstream_candidate, Protocol::Udp)?);
+        if let Some(srflx) = upstream_srflx {
+            upstream_rtc.add_local_candidate(Candidate::server_reflexive(
+                srflx,
+                upstream_candidate,
+                Protocol::Udp,
+            )?);
+        }
+
+        // Add audio transceiver + data channel
+        let mut sdp_api = upstream_rtc.sdp_api();
+        let upstream_audio_mid =
+            sdp_api.add_media(MediaKind::Audio, Direction::SendRecv, None, None, None);
+        let upstream_channel_id = sdp_api.add_channel("oai-events".to_string());
+        let (upstream_offer, pending) = sdp_api
+            .apply()
+            .ok_or_else(|| anyhow::anyhow!("SDP apply produced no offer"))?;
+
+        // -- 3. Send offer to OpenAI, get answer ----------------------------
+        let upstream_answer = send_sdp_to_upstream(
+            http_client,
+            upstream_url,
+            auth_header,
+            &upstream_offer.to_sdp_string(),
+            session_config,
+        )
+        .await?;
+
+        upstream_rtc
+            .sdp_api()
+            .accept_answer(pending, upstream_answer)?;
+
+        // -- 4. Create client Rtc (answerer, ICE-lite) ----------------------
+        // ICE-lite: SMG only responds to the browser's connectivity checks.
+        // This avoids needing to resolve mDNS candidates the browser may
+        // advertise, and is the standard mode for SFU/relay servers.
+        let mut client_rtc = RtcConfig::new()
+            .set_rtp_mode(true)
+            .set_ice_lite(true)
+            .build(Instant::now());
+        client_rtc.add_local_candidate(Candidate::host(client_candidate, Protocol::Udp)?);
+
+        let client_offer = SdpOffer::from_sdp_string(client_sdp_offer_str)?;
+        let client_answer = client_rtc.sdp_api().accept_offer(client_offer)?;
+        let client_audio_mid = find_audio_mid(&client_rtc);
+
+        let answer_sdp = client_answer.to_sdp_string();
+
+        // Log sanitized SDP metadata (never the raw SDP which contains
+        // ICE credentials, candidate IPs, and DTLS fingerprints).
+        let ice_candidates = answer_sdp
+            .lines()
+            .filter(|l| l.starts_with("a=candidate:"))
+            .count();
+        let has_ice_credentials = answer_sdp.contains("a=ice-ufrag:");
+        let dtls_fingerprint_algo = answer_sdp
+            .lines()
+            .find(|l| l.starts_with("a=fingerprint:"))
+            .and_then(|l| l.strip_prefix("a=fingerprint:"))
+            .and_then(|l| l.split_whitespace().next())
+            .unwrap_or("none");
+        let codec_names: Vec<&str> = answer_sdp
+            .lines()
+            .filter_map(|l| l.strip_prefix("a=rtpmap:"))
+            .filter_map(|l| l.split_whitespace().nth(1))
+            .filter_map(|l| l.split('/').next())
+            .collect();
+        info!(
+            call_id,
+            ?upstream_audio_mid,
+            ?client_audio_mid,
+            ice_candidates,
+            has_ice_credentials,
+            dtls_fingerprint_algo,
+            ?codec_names,
+            "WebRTC bridge SDP exchange complete"
+        );
+
+        Ok((
+            Self {
+                client_rtc,
+                client_socket,
+                client_candidate_addr: client_candidate,
+                upstream_rtc,
+                upstream_socket,
+                upstream_candidate_addr: upstream_candidate,
+                client_channel: None,
+                pending_to_client: Vec::new(),
+                upstream_channel: Some(upstream_channel_id),
+                upstream_audio_mid: Some(upstream_audio_mid),
+                client_audio_mid,
+                call_id,
+                cancel_token: CancellationToken::new(),
+            },
+            answer_sdp,
+        ))
+    }
+
+    /// Replace the bridge's cancel token with the registry's token so that
+    /// hangup cancellation is observed by the relay loop.
+    pub fn set_cancel_token(&mut self, token: CancellationToken) {
+        self.cancel_token = token;
+    }
+
+    /// Run the bidirectional relay until cancelled or disconnected.
+    ///
+    /// Returns `true` if the session ended normally (cancellation or client
+    /// disconnect), `false` if the upstream worker died while the client was
+    /// still connected (indicates a worker-side failure).
+    pub async fn run(mut self, registry: Arc<RealtimeRegistry>) -> bool {
+        registry.set_call_state(&self.call_id, ConnectionState::Connected);
+
+        // 4096 bytes is sufficient for RTP packets (~1200-1500 bytes) and
+        // DTLS handshake fragments (up to MTU). Larger DTLS messages are
+        // fragmented at the DTLS layer before hitting UDP.
+        let mut buf_client = vec![0u8; 4096];
+        let mut buf_upstream = vec![0u8; 4096];
+
+        let mut cancelled = false;
+
+        loop {
+            // Fixed 50ms poll interval — str0m's poll_output drains events so
+            // Fixed poll interval. str0m's poll_output() could drive a more
+            // precise timeout, but 50ms is well under perceptible audio latency
+            // and with 20ms Opus frames the sockets are rarely idle this long.
+            let timeout = Duration::from_millis(50);
+
+            tokio::select! {
+                result = self.client_socket.recv_from(&mut buf_client) => {
+                    self.handle_udp_recv(result, &buf_client, Side::Client);
+                }
+
+                result = self.upstream_socket.recv_from(&mut buf_upstream) => {
+                    self.handle_udp_recv(result, &buf_upstream, Side::Upstream);
+                }
+
+                () = tokio::time::sleep(timeout) => {
+                    let now = Instant::now();
+                    let _ = self.client_rtc.handle_input(Input::Timeout(now));
+                    let _ = self.upstream_rtc.handle_input(Input::Timeout(now));
+                }
+
+                () = self.cancel_token.cancelled() => {
+                    debug!(call_id = self.call_id, "WebRTC bridge cancelled");
+                    cancelled = true;
+                    break;
+                }
+            }
+
+            // Drain outputs from both peers
+            self.process_outputs(Side::Client).await;
+            self.process_outputs(Side::Upstream).await;
+
+            // Exit if either peer is dead
+            if !self.client_rtc.is_alive() || !self.upstream_rtc.is_alive() {
+                info!(
+                    call_id = self.call_id,
+                    client_alive = self.client_rtc.is_alive(),
+                    upstream_alive = self.upstream_rtc.is_alive(),
+                    "WebRTC bridge peer disconnected"
+                );
+                break;
+            }
+        }
+
+        // Upstream dying while client is still connected is a worker failure.
+        let success = cancelled || !self.client_rtc.is_alive() || self.upstream_rtc.is_alive();
+
+        self.client_rtc.disconnect();
+        self.upstream_rtc.disconnect();
+        registry.set_call_state(&self.call_id, ConnectionState::Disconnected);
+        debug!(call_id = self.call_id, success, "WebRTC bridge ended");
+
+        success
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Internal: side abstraction for deduplication
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Copy)]
+enum Side {
+    Client,
+    Upstream,
+}
+
+impl WebRtcBridge {
+    fn rtc(&mut self, side: Side) -> &mut Rtc {
+        match side {
+            Side::Client => &mut self.client_rtc,
+            Side::Upstream => &mut self.upstream_rtc,
+        }
+    }
+
+    fn candidate_addr(&self, side: Side) -> SocketAddr {
+        match side {
+            Side::Client => self.client_candidate_addr,
+            Side::Upstream => self.upstream_candidate_addr,
+        }
+    }
+
+    fn socket(&self, side: Side) -> &UdpSocket {
+        match side {
+            Side::Client => &self.client_socket,
+            Side::Upstream => &self.upstream_socket,
+        }
+    }
+
+    fn side_label(side: Side) -> &'static str {
+        match side {
+            Side::Client => "client",
+            Side::Upstream => "upstream",
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Internal: UDP recv + output processing
+// ---------------------------------------------------------------------------
+
+impl WebRtcBridge {
+    fn handle_udp_recv(
+        &mut self,
+        result: std::io::Result<(usize, SocketAddr)>,
+        buf: &[u8],
+        side: Side,
+    ) {
+        let label = Self::side_label(side);
+        let (n, source) = match result {
+            Ok(pair) => pair,
+            Err(e) => {
+                warn!(call_id = self.call_id, error = %e, "{label} UDP recv error");
+                return;
+            }
+        };
+
+        trace!(call_id = self.call_id, %source, n, "{label} UDP packet");
+        let dest = self.candidate_addr(side);
+        match Receive::new(Protocol::Udp, source, dest, &buf[..n]) {
+            Ok(recv) => {
+                if let Err(e) = self
+                    .rtc(side)
+                    .handle_input(Input::Receive(Instant::now(), recv))
+                {
+                    warn!(call_id = self.call_id, error = %e, %source, "{label}_rtc rejected input");
+                }
+            }
+            Err(e) => {
+                debug!(call_id = self.call_id, error = %e, %source, n, "{label} Receive::new failed");
+            }
+        }
+    }
+
+    /// Drain all pending outputs from one Rtc peer.
+    async fn process_outputs(&mut self, side: Side) {
+        loop {
+            let output = match side {
+                Side::Client => self.client_rtc.poll_output(),
+                Side::Upstream => self.upstream_rtc.poll_output(),
+            };
+            match output {
+                Ok(Output::Transmit(t)) => {
+                    trace!(
+                        call_id = self.call_id,
+                        dest = %t.destination,
+                        len = t.contents.len(),
+                        "{} Rtc → transmit", Self::side_label(side)
+                    );
+                    let _ = self.socket(side).send_to(&t.contents, t.destination).await;
+                }
+                Ok(Output::Event(event)) => match side {
+                    Side::Client => self.handle_client_event(event),
+                    Side::Upstream => self.handle_upstream_event(event),
+                },
+                Ok(Output::Timeout(_)) => break,
+                Err(e) => {
+                    debug!(call_id = self.call_id, error = %e, "poll_output error");
+                    break;
+                }
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Internal: event handling
+// ---------------------------------------------------------------------------
+
+impl WebRtcBridge {
+    fn handle_client_event(&mut self, event: Event) {
+        match event {
+            Event::Connected => {
+                info!(call_id = self.call_id, "Client peer connected");
+            }
+            Event::IceConnectionStateChange(state) => {
+                info!(call_id = self.call_id, ?state, "Client ICE state");
+            }
+            Event::ChannelOpen(id, label) => {
+                debug!(
+                    call_id = self.call_id,
+                    ?id,
+                    label,
+                    "Client data channel opened"
+                );
+                self.client_channel = Some(id);
+                self.flush_pending_to_client();
+            }
+            Event::ChannelData(data) => {
+                log_data_channel(&self.call_id, &data, "Client→Upstream");
+                if let Some(ch_id) = self.upstream_channel {
+                    if let Some(mut ch) = self.upstream_rtc.channel(ch_id) {
+                        let _ = ch.write(data.binary, &data.data);
+                    }
+                }
+            }
+            Event::ChannelClose(id) => {
+                debug!(call_id = self.call_id, ?id, "Client data channel closed");
+            }
+            Event::RtpPacket(pkt) => {
+                trace!(call_id = self.call_id, "Client→Upstream RTP");
+                self.forward_rtp(&pkt, Side::Upstream);
+            }
+            Event::MediaAdded(added) => {
+                debug!(call_id = self.call_id, mid = ?added.mid, kind = ?added.kind, "Client media added");
+            }
+            _ => {}
+        }
+    }
+
+    fn handle_upstream_event(&mut self, event: Event) {
+        match event {
+            Event::Connected => {
+                info!(call_id = self.call_id, "Upstream peer connected");
+            }
+            Event::IceConnectionStateChange(state) => {
+                info!(call_id = self.call_id, ?state, "Upstream ICE state");
+            }
+            Event::ChannelOpen(id, label) => {
+                debug!(
+                    call_id = self.call_id,
+                    ?id,
+                    label,
+                    "Upstream data channel opened"
+                );
+                self.upstream_channel = Some(id);
+            }
+            Event::ChannelData(data) => {
+                log_data_channel(&self.call_id, &data, "Upstream→Client");
+                if let Some(ch_id) = self.client_channel {
+                    if let Some(mut ch) = self.client_rtc.channel(ch_id) {
+                        let _ = ch.write(data.binary, &data.data);
+                    }
+                } else if self.pending_to_client.len() >= 1000 {
+                    warn!(
+                        call_id = self.call_id,
+                        "Pending-to-client buffer full, dropping message"
+                    );
+                } else {
+                    trace!(
+                        call_id = self.call_id,
+                        "Buffering upstream event (client channel not open)"
+                    );
+                    self.pending_to_client
+                        .push((data.binary, data.data.to_vec()));
+                }
+            }
+            Event::ChannelClose(id) => {
+                debug!(call_id = self.call_id, ?id, "Upstream data channel closed");
+            }
+            Event::RtpPacket(pkt) => {
+                trace!(call_id = self.call_id, "Upstream→Client RTP");
+                self.forward_rtp(&pkt, Side::Client);
+            }
+            Event::MediaAdded(added) => {
+                debug!(call_id = self.call_id, mid = ?added.mid, kind = ?added.kind, "Upstream media added");
+            }
+            _ => {}
+        }
+    }
+
+    /// Send all buffered upstream events to the now-open client data channel.
+    fn flush_pending_to_client(&mut self) {
+        let Some(ch_id) = self.client_channel else {
+            return;
+        };
+        let pending = std::mem::take(&mut self.pending_to_client);
+        if pending.is_empty() {
+            return;
+        }
+        info!(
+            call_id = self.call_id,
+            count = pending.len(),
+            "Flushing buffered upstream events to client"
+        );
+        if let Some(mut ch) = self.client_rtc.channel(ch_id) {
+            for (binary, data) in pending {
+                let _ = ch.write(binary, &data);
+            }
+        }
+    }
+
+    /// Forward an RTP packet to the target side's audio track.
+    fn forward_rtp(&mut self, pkt: &RtpPacket, target: Side) {
+        let (mid, rtc) = match target {
+            Side::Upstream => (self.upstream_audio_mid, &mut self.upstream_rtc),
+            Side::Client => (self.client_audio_mid, &mut self.client_rtc),
+        };
+        let Some(mid) = mid else { return };
+        if let Some(tx) = rtc.direct_api().stream_tx_by_mid(mid, None) {
+            let _ = tx.write_rtp(
+                pkt.header.payload_type,
+                pkt.seq_no,
+                pkt.header.timestamp,
+                pkt.timestamp,
+                pkt.header.marker,
+                pkt.header.ext_vals.clone(),
+                true,
+                pkt.payload.clone(),
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Logging helpers — mirror proxy.rs patterns
+// ---------------------------------------------------------------------------
+
+/// Log a data channel message with appropriate verbosity based on event type.
+fn log_data_channel(call_id: &str, data: &ChannelData, direction: &str) {
+    if data.binary {
+        trace!(call_id, bytes = data.data.len(), "{direction} binary");
+        return;
+    }
+    let Ok(text) = std::str::from_utf8(&data.data) else {
+        return;
+    };
+
+    // Extract the raw "type" field from JSON so we always log the actual
+    // event type, even for events our protocol crate doesn't recognise yet.
+    let et = serde_json::from_str::<serde_json::Value>(text)
+        .ok()
+        .and_then(|v| v.get("type")?.as_str().map(String::from));
+
+    let Some(et) = et else {
+        debug!(call_id, "{direction} (non-JSON or missing type)");
+        return;
+    };
+
+    match et.as_str() {
+        // High-frequency streaming deltas → trace
+        "input_audio_buffer.append"
+        | "response.output_audio.delta"
+        | "response.output_text.delta"
+        | "response.output_audio_transcript.delta"
+        | "response.function_call_arguments.delta" => {
+            trace!(call_id, event_type = et, "{direction}");
+        }
+        // Key lifecycle events → info
+        "session.created"
+        | "session.updated"
+        | "response.created"
+        | "response.done"
+        | "response.function_call_arguments.done"
+        | "error" => {
+            info!(call_id, event_type = et, "{direction}");
+        }
+        // Everything else → debug
+        _ => {
+            debug!(call_id, event_type = et, "{direction}");
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Upstream SDP exchange
+// ---------------------------------------------------------------------------
+
+/// Send SMG's SDP offer to upstream (OpenAI) and parse the returned SDP
+/// answer.  Supports multipart (with session config) and direct SDP.
+async fn send_sdp_to_upstream(
+    client: &reqwest::Client,
+    upstream_url: &str,
+    auth_header: &str,
+    sdp_offer: &str,
+    session_config: Option<serde_json::Value>,
+) -> Result<SdpAnswer, BridgeSetupError> {
+    let req = client
+        .post(upstream_url)
+        .header("Authorization", auth_header);
+
+    let resp = if let Some(session) = session_config {
+        let form = reqwest::multipart::Form::new()
+            .part(
+                "sdp",
+                reqwest::multipart::Part::text(sdp_offer.to_string())
+                    .mime_str("application/sdp")?,
+            )
+            .part(
+                "session",
+                reqwest::multipart::Part::text(session.to_string()).mime_str("application/json")?,
+            );
+        req.multipart(form).send().await?
+    } else {
+        req.header("Content-Type", "application/sdp")
+            .body(sdp_offer.to_string())
+            .send()
+            .await?
+    };
+
+    let status = resp.status();
+    if !status.is_success() {
+        let content_type = resp
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .map(String::from);
+        let body = resp.text().await.unwrap_or_default();
+        return Err(BridgeSetupError::UpstreamHttp {
+            status,
+            body,
+            content_type,
+        });
+    }
+
+    let answer_text = resp.text().await?;
+    Ok(SdpAnswer::from_sdp_string(&answer_text)?)
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Resolve the effective IP for ICE candidates.
+///
+/// When `addr` is unspecified (`0.0.0.0` / `::`), performs a non-sending UDP
+/// "connect" to a public address to let the OS routing table pick the default
+/// outbound interface.  No traffic is sent.
+fn resolve_candidate_ip(addr: IpAddr) -> anyhow::Result<IpAddr> {
+    if !addr.is_unspecified() {
+        return Ok(addr);
+    }
+    let sock = std::net::UdpSocket::bind("0.0.0.0:0")?;
+    sock.connect("8.8.8.8:80")?;
+    Ok(sock.local_addr()?.ip())
+}
+
+/// Find the first audio Mid in an Rtc instance (after SDP negotiation).
+///
+/// str0m's `Rtc` only exposes `media(mid)` for individual lookup — there is no
+/// public iterator over all media sections.  SDP mid values are string
+/// representations of small integers ("0", "1", …).  OpenAI realtime sessions
+/// typically have ≤3 media lines (audio + data channel), so probing 0..16
+/// provides generous headroom while keeping the search bounded.
+fn find_audio_mid(rtc: &Rtc) -> Option<Mid> {
+    (0..16u32).find_map(|i| {
+        let mid = Mid::from(i.to_string().as_str());
+        rtc.media(mid)
+            .filter(|m| m.kind() == MediaKind::Audio)
+            .map(|_| mid)
+    })
+}
+
+// ---------------------------------------------------------------------------
+// STUN binding — minimal client for server-reflexive candidate gathering
+// ---------------------------------------------------------------------------
+
+/// Perform a STUN Binding Request (RFC 5389) on `socket` to discover its
+/// server-reflexive (public) address.  Returns `None` on timeout or parse
+/// failure — callers should proceed with host-only candidates in that case.
+async fn stun_gather_srflx(socket: &UdpSocket, stun_server: SocketAddr) -> Option<SocketAddr> {
+    // 20-byte STUN Binding Request
+    let mut req = [0u8; 20];
+    req[0..2].copy_from_slice(&0x0001u16.to_be_bytes()); // Binding Request
+                                                         // Length = 0 (no attributes)
+    req[4..8].copy_from_slice(&0x2112_A442u32.to_be_bytes()); // Magic Cookie
+                                                              // STUN transaction ID is 12 bytes (RFC 5389); truncate the 16-byte UUID.
+    let txn = uuid::Uuid::now_v7();
+    req[8..20].copy_from_slice(&txn.as_bytes()[..12]);
+
+    if let Err(e) = socket.send_to(&req, stun_server).await {
+        warn!(%stun_server, error = %e, "STUN send failed");
+        return None;
+    }
+    debug!(%stun_server, "STUN Binding Request sent");
+
+    let mut buf = [0u8; 512];
+    let (n, from) =
+        match tokio::time::timeout(Duration::from_secs(3), socket.recv_from(&mut buf)).await {
+            Ok(Ok(pair)) => pair,
+            Ok(Err(e)) => {
+                warn!(error = %e, "STUN recv error");
+                return None;
+            }
+            Err(_) => {
+                warn!(%stun_server, "STUN response timed out (3s)");
+                return None;
+            }
+        };
+
+    let addr = parse_stun_xor_mapped_address(&buf[..n], &req[8..20]);
+    if addr.is_some() {
+        info!(%from, srflx = ?addr, "STUN srflx discovered");
+    } else {
+        warn!(%from, n, "STUN response unparsable");
+    }
+    addr
+}
+
+/// Parse the XOR-MAPPED-ADDRESS attribute from a STUN Binding Success
+/// Response.  Returns the decoded `SocketAddr` or `None`.
+fn parse_stun_xor_mapped_address(resp: &[u8], txn_id: &[u8]) -> Option<SocketAddr> {
+    if resp.len() < 20 || resp[0] != 0x01 || resp[1] != 0x01 {
+        return None;
+    }
+    if &resp[8..20] != txn_id {
+        return None;
+    }
+
+    let msg_len = u16::from_be_bytes([resp[2], resp[3]]) as usize;
+    let end = (20 + msg_len).min(resp.len());
+    let mut off = 20;
+
+    while off + 4 <= end {
+        let attr_type = u16::from_be_bytes([resp[off], resp[off + 1]]);
+        let attr_len = u16::from_be_bytes([resp[off + 2], resp[off + 3]]) as usize;
+        off += 4;
+        if off + attr_len > end {
+            break;
+        }
+
+        // XOR-MAPPED-ADDRESS = 0x0020 (RFC 5389 §15.2)
+        // Port is XORed with top 16 bits of magic cookie (0x2112).
+        // IPv4 address is XORed with the full magic cookie (0x2112_A442).
+        if attr_type == 0x0020 && attr_len >= 8 && resp[off + 1] == 0x01 {
+            let port = u16::from_be_bytes([resp[off + 2], resp[off + 3]]) ^ 0x2112;
+            let ip = std::net::Ipv4Addr::new(
+                resp[off + 4] ^ 0x21,
+                resp[off + 5] ^ 0x12,
+                resp[off + 6] ^ 0xA4,
+                resp[off + 7] ^ 0x42,
+            );
+            return Some(SocketAddr::new(IpAddr::V4(ip), port));
+        }
+
+        // Attributes are padded to 4-byte boundaries
+        off += (attr_len + 3) & !3;
+    }
+    None
+}

--- a/model_gateway/src/routers/openai/realtime/ws.rs
+++ b/model_gateway/src/routers/openai/realtime/ws.rs
@@ -11,8 +11,9 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use serde::Deserialize;
+use tracing::{debug, error};
 
-use super::{proxy::run_ws_proxy, RealtimeRegistry};
+use super::{proxy, RealtimeRegistry};
 use crate::{
     core::Worker,
     observability::metrics::{metrics_labels, Metrics},
@@ -116,7 +117,7 @@ pub(crate) async fn handle_realtime_ws(
     );
 
     ws.on_upgrade(move |socket: WebSocket| async move {
-        if let Err(e) = run_ws_proxy(
+        let success = match proxy::run_ws_proxy(
             socket,
             &upstream_ws_url,
             &auth_str,
@@ -126,12 +127,16 @@ pub(crate) async fn handle_realtime_ws(
         )
         .await
         {
-            tracing::error!(session_id, error = %e, "Realtime WebSocket proxy error");
-        }
+            Ok(()) => true,
+            Err(e) => {
+                error!(session_id, error = %e, "Realtime WebSocket proxy error");
+                false
+            }
+        };
 
-        // Cleanup: remove session on disconnect
+        worker.record_outcome(success);
         realtime_registry.remove_session(&session_id);
-        tracing::debug!(session_id, "Realtime session cleaned up");
+        debug!(session_id, "Realtime session cleaned up");
     })
 }
 

--- a/model_gateway/src/routers/openai/router.rs
+++ b/model_gateway/src/routers/openai/router.rs
@@ -47,7 +47,10 @@ use crate::{
     observability::metrics::{bool_to_static_str, metrics_labels, Metrics},
     routers::{
         header_utils::{apply_provider_headers, extract_auth_header},
-        openai::realtime::{rest::forward_realtime_rest, ws::handle_realtime_ws, RealtimeRegistry},
+        openai::realtime::{
+            rest::forward_realtime_rest, webrtc, webrtc::handle_realtime_webrtc,
+            ws::handle_realtime_ws, RealtimeRegistry,
+        },
         worker_selection::{SelectWorkerRequest, WorkerSelector},
     },
 };
@@ -60,6 +63,7 @@ pub struct OpenAIRouter {
     responses_components: Arc<ResponsesComponents>,
     retry_config: RetryConfig,
     realtime_registry: Arc<RealtimeRegistry>,
+    context: Arc<AppContext>,
 }
 
 impl std::fmt::Debug for OpenAIRouter {
@@ -130,6 +134,7 @@ impl OpenAIRouter {
             responses_components,
             retry_config: ctx.router_config.effective_retry_config(),
             realtime_registry: ctx.realtime_registry.clone(),
+            context: Arc::clone(ctx),
         })
     }
 
@@ -977,6 +982,55 @@ impl crate::routers::RouterTrait for OpenAIRouter {
             model.to_owned(),
             worker,
             auth_header,
+            Arc::clone(&self.realtime_registry),
+        )
+        .await
+    }
+
+    async fn route_realtime_webrtc(&self, req: Request<Body>, model: &str) -> Response {
+        let (parts, body) = req.into_parts();
+        let body = match axum::body::to_bytes(body, 10 * 1024 * 1024).await {
+            Ok(b) => b,
+            Err(e) => {
+                return error::bad_request("invalid_body", format!("Failed to read body: {e}"));
+            }
+        };
+
+        // Parse body once to extract model, SDP, and session config.
+        // For multipart, the model comes from the session JSON body.
+        // For application/sdp, the model comes from the query parameter.
+        let parsed = match webrtc::parse_webrtc_request(&parts, &body, model).await {
+            Ok(p) => p,
+            Err(resp) => return resp,
+        };
+
+        Metrics::record_router_request(
+            metrics_labels::ROUTER_OPENAI,
+            metrics_labels::BACKEND_EXTERNAL,
+            metrics_labels::CONNECTION_WEBRTC,
+            &parsed.model,
+            metrics_labels::ENDPOINT_REALTIME,
+            "false",
+        );
+
+        let auth_header = extract_auth_header(Some(&parts.headers), None);
+        let worker = self
+            .select_worker(&parsed.model, Some(&parts.headers))
+            .await;
+
+        let bind_addr = self
+            .context
+            .webrtc_bind_addr
+            .unwrap_or_else(|| std::net::Ipv4Addr::UNSPECIFIED.into());
+
+        handle_realtime_webrtc(
+            parts.headers,
+            parsed,
+            worker,
+            auth_header,
+            self.shared_components.client.clone(),
+            bind_addr,
+            self.context.webrtc_stun_server.clone(),
             Arc::clone(&self.realtime_registry),
         )
         .await

--- a/model_gateway/src/routers/router_manager.rs
+++ b/model_gateway/src/routers/router_manager.rs
@@ -914,6 +914,19 @@ impl RouterTrait for RouterManager {
         }
     }
 
+    async fn route_realtime_webrtc(&self, req: Request<Body>, model: &str) -> Response {
+        let router = self.select_router_for_request(None, Some(model));
+        if let Some(router) = router {
+            router.route_realtime_webrtc(req, model).await
+        } else {
+            (
+                StatusCode::NOT_FOUND,
+                "No router available for realtime WebRTC request",
+            )
+                .into_response()
+        }
+    }
+
     fn router_type(&self) -> &'static str {
         "manager"
     }

--- a/model_gateway/src/server.rs
+++ b/model_gateway/src/server.rs
@@ -42,7 +42,7 @@ use tracing::{debug, error, info, warn, Level};
 use wfaas::LoggingSubscriber;
 
 use crate::{
-    app_context::AppContext,
+    app_context::{AppContext, AppContextBuilder},
     config::{RouterConfig, RoutingMode},
     core::{
         job_queue::{JobQueue, JobQueueConfig},
@@ -438,6 +438,17 @@ async fn v1_conversations_delete_item(
     .await
 }
 
+async fn v1_realtime_webrtc(
+    State(state): State<Arc<AppState>>,
+    Query(params): Query<RealtimeQueryParams>,
+    req: Request,
+) -> Response {
+    // Model may come from query param (application/sdp) or session body
+    // (multipart/form-data). Let the handler validate per content type.
+    let model = params.model.unwrap_or_default();
+    state.router.route_realtime_webrtc(req, &model).await
+}
+
 async fn v1_realtime_ws(
     State(state): State<Arc<AppState>>,
     Query(params): Query<RealtimeQueryParams>,
@@ -622,6 +633,12 @@ pub struct ServerConfig {
     /// Control plane authentication configuration
     pub control_plane_auth: Option<smg_auth::ControlPlaneAuthConfig>,
     pub mesh_server_config: Option<MeshServerConfig>,
+    /// Bind address for WebRTC UDP sockets.
+    /// `None` means use the default (0.0.0.0, auto-detect candidate IP).
+    pub webrtc_bind_addr: Option<std::net::IpAddr>,
+    /// STUN server for ICE candidate gathering (host:port).
+    /// `None` means use the default (stun.l.google.com:19302).
+    pub webrtc_stun_server: Option<String>,
 }
 
 pub fn build_app(
@@ -707,6 +724,7 @@ pub fn build_app(
     // dropping the response extensions that carry the WebSocket upgrade future.
     let ws_routes = Router::new()
         .route("/v1/realtime", get(v1_realtime_ws))
+        .route("/v1/realtime/calls", post(v1_realtime_webrtc))
         .route_layer(axum::middleware::from_fn_with_state(
             app_state.clone(),
             middleware::concurrency_limit_middleware,
@@ -887,7 +905,16 @@ pub async fn startup(config: ServerConfig) -> Result<(), Box<dyn std::error::Err
     );
 
     let app_context = Arc::new(
-        AppContext::from_config(config.router_config.clone(), config.request_timeout_secs).await?,
+        Box::pin(AppContextBuilder::from_config(
+            config.router_config.clone(),
+            config.request_timeout_secs,
+            config.webrtc_bind_addr,
+            config.webrtc_stun_server.clone(),
+        ))
+        .await
+        .map_err(|e| e.to_string())?
+        .build()
+        .map_err(|e| e.to_string())?,
     );
 
     if config.prometheus_config.is_some() {

--- a/model_gateway/src/service_discovery.rs
+++ b/model_gateway/src/service_discovery.rs
@@ -931,6 +931,8 @@ mod tests {
             inflight_tracker: InFlightRequestTracker::new(),
             kv_event_monitor: None,
             realtime_registry: Arc::new(RealtimeRegistry::new()),
+            webrtc_bind_addr: None,
+            webrtc_stun_server: None,
         })
     }
 

--- a/scripts/ci_install_e2e_deps.sh
+++ b/scripts/ci_install_e2e_deps.sh
@@ -10,7 +10,7 @@ if [ -f ".venv/bin/activate" ]; then
 fi
 
 echo "Installing e2e test dependencies..."
-python3 -m pip install pytest pytest-rerunfailures httpx openai anthropic grpcio grpcio-health-checking numpy pandas requests jinja2 tqdm websockets
+python3 -m pip install pytest pytest-rerunfailures httpx openai anthropic grpcio grpcio-health-checking numpy pandas requests jinja2 tqdm websockets aiortc
 
 # Install SmgClient (pure Python client for cross-SDK parity testing)
 echo "Installing smg-client..."


### PR DESCRIPTION
## Description
Fix https://github.com/lightseekorg/smg/issues/249
### Problem
SMG had no support for WebRTC-based realtime sessions. The OpenAI Realtime API supports WebRTC as an alternative transport to WebSocket, where clients exchange SDP offers/answers via HTTP POST and then communicate over data channels and RTP audio. Without WebRTC support, clients that prefer WebRTC (e.g., browser-based apps using the /v1/realtime/calls endpoint) could not use SMG as a gateway.

### Solution

Add a full WebRTC relay implementation where SMG terminates the client's peer connection, establishes its own peer connection to upstream, and bridges data-channel messages plus audio RTP packets between the two. The relay uses str0m (a pure-Rust WebRTC library) for DTLS/ICE/RTP handling and routes requests through the standard RouterTrait → RouterManager → OpenAiRouter pipeline, getting lazy model refresh, routing policy, and metrics for free.

## Changes

### WebRTC relay core
- **`webrtc_bridge.rs`** (new) — `WebRtcBridge` struct: bidirectional UDP relay between client and upstream peer connections via `str0m`. Handles ICE candidate gathering, DTLS handshake, data channel message forwarding, and RTP audio packet relay. `bridge.run()` returns `bool` for accurate `worker.record_outcome()` reporting (upstream dying while client connected = failure).
- **`webrtc.rs`** (new) — SDP signaling handlers for `POST /v1/realtime/calls`. Supports `application/sdp` (direct) and `multipart/form-data` (with session config). Includes `validate_sdp()` for early 400 on invalid/empty SDP. `BridgeSetupError::UpstreamHttp` preserves original status code and `Content-Type`. Upstream rejections log at `warn!`; internal failures at `error!`. Sanitized SDP logging (candidate count, fingerprint algo, codec names — no raw SDP).

### Router integration
- **`router.rs`** — `OpenAiRouter::route_realtime_webrtc()` implementation using `select_worker_for_model()` for lazy model refresh + routing policy
- **`router_manager.rs`** — Dispatch method for `route_realtime_webrtc()`
- **`mod.rs`** — `route_realtime_webrtc()` added to `RouterTrait` with default stub

### Configuration plumbing
- **`main.rs`** — `--webrtc-bind-addr` and `--webrtc-stun-server` CLI args (STUN default wired via `default_value` so `--help` shows it)
- **`server.rs`** — Passes webrtc params from `ServerConfig` into `AppContextBuilder`
- **`app_context.rs`** — `webrtc_bind_addr` and `webrtc_stun_server` fields on `AppContext` and `AppContextBuilder`
- **`router_args.py`** — Python `RouterArgs` mirrors both params for `python -m smg.launch_router`
- **`lib.rs`** (bindings) — PyO3 `Router` struct accepts and forwards both params to `ServerConfig`

### E2E tests
- **`test_realtime_webrtc.py`** (new) — 6 test classes:
  - `TestRealtimeWebRtcSignaling` — SDP offer/answer (direct + multipart), error handling (missing model, missing auth, unsupported content type, invalid SDP, empty body, wrong HTTP method), concurrent calls
  - `TestRealtimeWebRtcAnswerFormat` — Required SDP fields, ICE credentials, DTLS fingerprint, audio media, content type, multipart vs direct consistency
  - `TestRealtimeWebRtcDataChannel` — session.created, session.update, text response round-trip, conversation.item.created, invalid event → error, response.done schema validation (via `aiortc`)
  - `TestRealtimeWebRtcErrorForwarding` — Invalid API key → 401, invalid model → 4xx (not masked as 502)
  - `TestRealtimeWebRtcBridgeCleanup` — Reconnect after disconnect, multiple sequential sessions
  - `TestRealtimeWebRtcStun` — Signaling and data channel with explicit STUN server
- `httpx.AsyncClient` for SDP POST in async context (avoids blocking aiortc event loop)
- `@pytest.mark.flaky(reruns=2)` on data channel / bridge / STUN classes for cloud latency tolerance
- Session config uses correct API structure (`audio.output.voice` not `voice`)

### CI / infra
- **`Cargo.toml`** — Added `str0m` dependency
- **`ci_install_e2e_deps.sh`** / **`pyproject.toml`** — Added `aiortc`
- **`metrics.rs`** — Added `CONNECTION_WEBRTC` label
- **`pr-test-rust.yml`** — Updated CI workflow


## Notes:
For hangup call "post /v1/realtime/calls/{call_id}/hangup". 
I tried neither `application/sdp` nor `multipart/form-data`. Openai only returns a session_id from OpenAI's /v1/realtime/calls endpoint. I tried to use session_id to handup the call, however session_id is an incorrect identifier. 
```
"{
    "error": {
        "message": "No session found for the provided call_id",
        "type": "invalid_request_error",
        "code": "call_id_not_found",
        "param": ""
    }
}"
```
also tried raw http request with application/json. I got error " OpenAI's /v1/realtime/calls endpoint only accepts application/sdp and returns raw SDP"

For current solution in this code is SMG will generate call_id. And do hangup by just cancel the bridge.
If we want to respone the call_id to client, we can add a header such like X-CALL-ID to client and will handle it in following pr.
**I remove hangup call handler in this pr**

## Test Plan

- [x] Ephemeral direct WebRTC flow
- [x] Unified server-side flow
- [ ] E2e test passed

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * POST /v1/realtime/calls: WebRTC signaling (multipart and raw SDP), SDP answers, data-channel support, ICE/STUN handling, and configurable UDP bind/STUN options via CLI/config.
  * Bidirectional WebRTC relay with lifecycle, load management, and realtime metrics for WebRTC connections.

* **Bug Fixes / Improvements**
  * Improved realtime session cleanup and outcome reporting; more robust proxy outcome handling.

* **Tests**
  * Comprehensive end-to-end WebRTC realtime test suite added; test tooling/deps updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->