### PR TITLE
refactor(e2e): simplify test helpers and fix redundant HF_HOME env passing

### DIFF
--- a/e2e_test/benchmarks/conftest.py
+++ b/e2e_test/benchmarks/conftest.py
@@ -61,7 +61,7 @@ def _build_command(
         cmd.extend(["-v", f"{hf_home}:{hf_home}", "-e", f"HF_HOME={hf_home}"])
 
     # Pass through environment variables the container may need
-    for var in ("HF_TOKEN", "HF_HOME"):
+    for var in ("HF_TOKEN",):
         if os.environ.get(var):
             cmd.extend(["-e", var])
 
@@ -151,7 +151,7 @@ def _cleanup_procs(procs: list, drain_delay: int) -> None:
         time.sleep(drain_delay)
     for p in procs:
         try:
-            proc = getattr(p, "proc", p) if hasattr(p, "proc") else p
+            proc = getattr(p, "proc", p)
             if isinstance(proc, subprocess.Popen):
                 terminate_process(proc)
         except Exception:

--- a/e2e_test/realtime/test_realtime_ws.py
+++ b/e2e_test/realtime/test_realtime_ws.py
@@ -43,6 +43,18 @@ def _make_event(event_type: str, **payload) -> str:
     return json.dumps({"type": event_type, **payload})
 
 
+def _make_user_message(text: str) -> str:
+    """Build a conversation.item.create event with a user text message."""
+    return _make_event(
+        "conversation.item.create",
+        item={
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": text}],
+        },
+    )
+
+
 def _parse_event(raw: str) -> dict | None:
     """Parse a JSON event, returning None on decode errors."""
     try:
@@ -181,21 +193,7 @@ class TestRealtimeWebSocket:
 
         async def _run():
             async with _realtime_session(ws_url, ws_headers) as ws:
-                await ws.send(
-                    _make_event(
-                        "conversation.item.create",
-                        item={
-                            "type": "message",
-                            "role": "user",
-                            "content": [
-                                {
-                                    "type": "input_text",
-                                    "text": "Say hello in one short sentence.",
-                                }
-                            ],
-                        },
-                    )
-                )
+                await ws.send(_make_user_message("Say hello in one short sentence."))
                 await ws.send(
                     _make_event(
                         "response.create",
@@ -215,32 +213,14 @@ class TestRealtimeWebSocket:
         async def _run():
             async with _realtime_session(ws_url, ws_headers) as ws:
                 # Turn 1
-                await ws.send(
-                    _make_event(
-                        "conversation.item.create",
-                        item={
-                            "type": "message",
-                            "role": "user",
-                            "content": [{"type": "input_text", "text": "My name is Alice."}],
-                        },
-                    )
-                )
+                await ws.send(_make_user_message("My name is Alice."))
                 await ws.send(_make_event("response.create", response={"modalities": ["text"]}))
                 text1 = await _collect_response_text(ws)
                 assert len(text1) > 0
                 logger.info("Turn 1: %s", text1[:100])
 
                 # Turn 2 — model should remember the name
-                await ws.send(
-                    _make_event(
-                        "conversation.item.create",
-                        item={
-                            "type": "message",
-                            "role": "user",
-                            "content": [{"type": "input_text", "text": "What is my name?"}],
-                        },
-                    )
-                )
+                await ws.send(_make_user_message("What is my name?"))
                 await ws.send(_make_event("response.create", response={"modalities": ["text"]}))
                 text2 = await _collect_response_text(ws)
                 assert "alice" in text2.lower(), f"Expected 'Alice' in response, got: {text2}"
@@ -253,16 +233,7 @@ class TestRealtimeWebSocket:
 
         async def _run():
             async with _realtime_session(ws_url, ws_headers) as ws:
-                await ws.send(
-                    _make_event(
-                        "conversation.item.create",
-                        item={
-                            "type": "message",
-                            "role": "user",
-                            "content": [{"type": "input_text", "text": "Hi"}],
-                        },
-                    )
-                )
+                await ws.send(_make_user_message("Hi"))
                 event = await _recv_event(ws, event_type="conversation.item.created")
                 assert event["type"] == "conversation.item.created"
                 assert event["item"]["role"] == "user"
@@ -276,19 +247,7 @@ class TestRealtimeWebSocket:
         async def _run():
             async with _realtime_session(ws_url, ws_headers) as ws:
                 await ws.send(
-                    _make_event(
-                        "conversation.item.create",
-                        item={
-                            "type": "message",
-                            "role": "user",
-                            "content": [
-                                {
-                                    "type": "input_text",
-                                    "text": "Write a very long essay about the history of computing.",
-                                }
-                            ],
-                        },
-                    )
+                    _make_user_message("Write a very long essay about the history of computing.")
                 )
                 await ws.send(_make_event("response.create", response={"modalities": ["text"]}))
 
@@ -336,16 +295,7 @@ class TestRealtimeWebSocket:
 
         async def _run():
             async with _realtime_session(ws_url, ws_headers) as ws:
-                await ws.send(
-                    _make_event(
-                        "conversation.item.create",
-                        item={
-                            "type": "message",
-                            "role": "user",
-                            "content": [{"type": "input_text", "text": "Say hi."}],
-                        },
-                    )
-                )
+                await ws.send(_make_user_message("Say hi."))
                 await ws.send(_make_event("response.create", response={"modalities": ["text"]}))
 
                 event = await _recv_event(ws, event_type="response.done")
@@ -387,16 +337,7 @@ class TestRealtimeWebSocket:
 
         async def _run():
             async with _realtime_session(ws_url, ws_headers) as ws:
-                await ws.send(
-                    _make_event(
-                        "conversation.item.create",
-                        item={
-                            "type": "message",
-                            "role": "user",
-                            "content": [{"type": "input_text", "text": "Say hello."}],
-                        },
-                    )
-                )
+                await ws.send(_make_user_message("Say hello."))
                 await ws.send(_make_event("response.create", response={"modalities": ["text"]}))
 
                 # Collect a few deltas and validate schema


### PR DESCRIPTION
## Summary

Follow-up cleanup to #686. Simplifies e2e test code by extracting a shared helper, fixing a redundant Docker env-var pass, and removing a dead code guard.

## What changed

- **`e2e_test/realtime/test_realtime_ws.py`**: Extracted `_make_user_message(text)` helper to replace 7 identical copy-pasted `conversation.item.create` dict structures (~70 lines removed).
- **`e2e_test/benchmarks/conftest.py:64`**: Removed `"HF_HOME"` from the env-var pass-through tuple. The HF cache mount block on line 61 already explicitly passes `-e HF_HOME={hf_home}` when the directory exists, so the loop entry was redundant and could theoretically set a conflicting value.
- **`e2e_test/benchmarks/conftest.py:154`**: Simplified `getattr(p, "proc", p) if hasattr(p, "proc") else p` to `getattr(p, "proc", p)` — the `hasattr` guard was redundant since `getattr` with a default already handles the missing attribute case.

## Why

Reduces copy-paste boilerplate in the realtime WebSocket tests and fixes a minor correctness issue where `HF_HOME` could be passed twice to Docker with potentially different values.

## How

- Added a `_make_user_message(text)` helper that wraps the `conversation.item.create` event structure, then replaced all 7 inline usages.
- Narrowed the env-var pass-through tuple from `("HF_TOKEN", "HF_HOME")` to `("HF_TOKEN",)`.
- Removed the redundant `hasattr` check before `getattr` with a default value.

## Test plan

- [ ] `python3 -c "import ast; ast.parse(open('e2e_test/realtime/test_realtime_ws.py').read())"` — syntax OK
- [ ] `python3 -c "import ast; ast.parse(open('e2e_test/benchmarks/conftest.py').read())"` — syntax OK
- [ ] Realtime WebSocket tests remain functionally identical (helper produces the same JSON)
- [ ] Benchmark container env setup unchanged for `HF_TOKEN`; `HF_HOME` still passed via the explicit mount block

Refs: #686

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Improved benchmark test environment handling for Docker runs (reduced forwarded variables).
  * Reorganized realtime WebSocket tests to use a centralized helper for constructing user message payloads, improving test clarity and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->