### PR TITLE
feat(release): bump v1.2.0 with version sync and engine docker auto-triggers

### DIFF
--- a/.github/workflows/_build-engine-image.yml
+++ b/.github/workflows/_build-engine-image.yml
@@ -32,7 +32,7 @@ on:
       smg_commit:
         description: 'SMG commit/ref ("latest" for HEAD)'
         required: false
-        default: 'v1.1.0'
+        default: 'v1.2.0'
         type: string
       tag:
         description: 'Override image tag'

--- a/.github/workflows/release-sglang-docker.yml
+++ b/.github/workflows/release-sglang-docker.yml
@@ -4,10 +4,14 @@ run-name: >-
   SMG+SGLang |
   base=${{ inputs.base_image_ref || 'lmsysorg/sglang:v0.5.9' }} |
   engine=${{ inputs.sglang_commit || 'latest' }} |
-  smg=${{ inputs.smg_commit || 'v1.1.0' }} |
+  smg=${{ inputs.smg_commit || 'v1.2.0' }} |
   by @${{ github.actor }}
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - bindings/python/pyproject.toml
   pull_request:
     branches: [main]
     paths:
@@ -39,10 +43,10 @@ on:
       smg_commit:
         description: 'SMG commit/ref ("latest" for HEAD)'
         required: false
-        default: 'v1.1.0'
+        default: 'v1.2.0'
         type: string
       tag:
-        description: 'Override image tag (e.g. v1.1.0-sglang-v0.5.9)'
+        description: 'Override image tag (e.g. v1.2.0-sglang-v0.5.9)'
         required: false
         type: string
 
@@ -55,7 +59,7 @@ jobs:
       engine_repo: ${{ inputs.sglang_repo }}
       engine_commit: ${{ inputs.sglang_commit || 'latest' }}
       smg_repo: ${{ inputs.smg_repo || 'https://github.com/lightseekorg/smg' }}
-      smg_commit: ${{ inputs.smg_commit || 'v1.1.0' }}
+      smg_commit: ${{ inputs.smg_commit || 'v1.2.0' }}
       tag: ${{ inputs.tag }}
       dry_run: ${{ github.event_name == 'pull_request' }}
     secrets: inherit

--- a/.github/workflows/release-trtllm-docker.yml
+++ b/.github/workflows/release-trtllm-docker.yml
@@ -8,10 +8,15 @@ run-name: >-
   by @${{ github.actor }}
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - bindings/python/pyproject.toml
   workflow_dispatch:
     inputs:
       base_image_ref:
         description: 'Base image (e.g. nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc6). Empty = build from source.'
+        default: 'nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc6'
         required: false
         type: string
       trtllm_repo:
@@ -31,10 +36,10 @@ on:
       smg_commit:
         description: 'SMG commit/ref ("latest" for HEAD)'
         required: false
-        default: 'v1.1.0'
+        default: 'v1.2.0'
         type: string
       tag:
-        description: 'Override image tag (e.g. v1.1.0-trtllm-1.3.0)'
+        description: 'Override image tag (e.g. v1.2.0-trtllm-1.3.0)'
         required: false
         type: string
 
@@ -43,12 +48,12 @@ jobs:
     uses: ./.github/workflows/_build-engine-image.yml
     with:
       engine: trtllm
-      base_image_ref: ${{ inputs.base_image_ref }}
+      base_image_ref: ${{ inputs.base_image_ref || 'nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc6' }}
       engine_repo: ${{ inputs.trtllm_repo }}
-      engine_commit: ${{ inputs.trtllm_commit }}
-      smg_repo: ${{ inputs.smg_repo }}
-      smg_commit: ${{ inputs.smg_commit }}
+      engine_commit: ${{ inputs.trtllm_commit || 'latest' }}
+      smg_repo: ${{ inputs.smg_repo || 'https://github.com/lightseekorg/smg' }}
+      smg_commit: ${{ inputs.smg_commit || 'v1.2.0' }}
       tag: ${{ inputs.tag }}
       source_build_repo: ${{ inputs.trtllm_repo }}
-      source_build_ref: ${{ inputs.trtllm_commit }}
+      source_build_ref: ${{ inputs.trtllm_commit || 'latest' }}
     secrets: inherit

--- a/.github/workflows/release-vllm-docker.yml
+++ b/.github/workflows/release-vllm-docker.yml
@@ -8,11 +8,15 @@ run-name: >-
   by @${{ github.actor }}
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - bindings/python/pyproject.toml
   workflow_dispatch:
     inputs:
       base_image_ref:
-        description: 'Base image (e.g. vllm/vllm-openai:v0.16.0)'
-        default: 'vllm/vllm-openai:v0.16.0'
+        description: 'Base image (e.g. vllm/vllm-openai:v0.17.0)'
+        default: 'vllm/vllm-openai:v0.17.0'
         required: true
         type: string
       vllm_repo:
@@ -32,10 +36,10 @@ on:
       smg_commit:
         description: 'SMG commit/ref ("latest" for HEAD)'
         required: false
-        default: 'v1.1.0'
+        default: 'v1.2.0'
         type: string
       tag:
-        description: 'Override image tag (e.g. v1.1.0-vllm-v0.16.0)'
+        description: 'Override image tag (e.g. v1.2.0-vllm-v0.17.0)'
         required: false
         type: string
 
@@ -44,10 +48,10 @@ jobs:
     uses: ./.github/workflows/_build-engine-image.yml
     with:
       engine: vllm
-      base_image_ref: ${{ inputs.base_image_ref }}
+      base_image_ref: ${{ inputs.base_image_ref || 'vllm/vllm-openai:v0.17.0' }}
       engine_repo: ${{ inputs.vllm_repo }}
-      engine_commit: ${{ inputs.vllm_commit }}
-      smg_repo: ${{ inputs.smg_repo }}
-      smg_commit: ${{ inputs.smg_commit }}
+      engine_commit: ${{ inputs.vllm_commit || 'latest' }}
+      smg_repo: ${{ inputs.smg_repo || 'https://github.com/lightseekorg/smg' }}
+      smg_commit: ${{ inputs.smg_commit || 'v1.2.0' }}
       tag: ${{ inputs.tag }}
     secrets: inherit

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,19 +4,19 @@ resolver = "2"
 
 [workspace.dependencies]
 # Internal workspace crates
-openai-protocol = { version = "1.2.0", path = "crates/protocols" }
-reasoning-parser = { version = "1.2.0", path = "crates/reasoning_parser" }
-tool-parser = { version = "1.1.1", path = "crates/tool_parser" }
-wfaas = { version = "1.0.2", path = "crates/workflow" }
-llm-tokenizer = { version = "1.2.0", path = "crates/tokenizer" }
+openai-protocol = { version = "1.3.0", path = "crates/protocols" }
+reasoning-parser = { version = "1.2.1", path = "crates/reasoning_parser" }
+tool-parser = { version = "1.1.2", path = "crates/tool_parser" }
+wfaas = { version = "1.0.3", path = "crates/workflow" }
+llm-tokenizer = { version = "1.3.0", path = "crates/tokenizer" }
 smg-auth = { version = "1.1.1", path = "crates/auth" }
-smg-mcp = { version = "2.1.0", path = "crates/mcp" }
-kv-index = { version = "1.0.1", path = "crates/kv_index" }
-smg-data-connector = { version = "2.0.0", path = "crates/data_connector", package = "data-connector" }
-llm-multimodal = { version = "1.2.0", path = "crates/multimodal" }
-smg-wasm = { version = "1.0.1", path = "crates/wasm", package = "smg-wasm" }
-smg-mesh = { version = "1.1.1", path = "crates/mesh", package = "smg-mesh" }
-smg-grpc-client = { version = "1.2.0", path = "crates/grpc_client" }
+smg-mcp = { version = "2.1.1", path = "crates/mcp" }
+kv-index = { version = "1.1.0", path = "crates/kv_index" }
+smg-data-connector = { version = "2.1.0", path = "crates/data_connector", package = "data-connector" }
+llm-multimodal = { version = "1.3.0", path = "crates/multimodal" }
+smg-wasm = { version = "1.1.0", path = "crates/wasm", package = "smg-wasm" }
+smg-mesh = { version = "1.1.2", path = "crates/mesh", package = "smg-mesh" }
+smg-grpc-client = { version = "1.3.0", path = "crates/grpc_client" }
 
 # Shared dependencies
 anyhow = "1.0"

--- a/bindings/golang/Cargo.toml
+++ b/bindings/golang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-golang"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 
 [lib]

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-python"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 
 [lib]

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "smg"
-version = "1.1.0"
+version = "1.2.0"
 description = "High-performance Rust-based inference gateway for large-scale LLM deployments"
 authors = [
     {name = "Simo Lin", email = "linsimo.mark@gmail.com"},

--- a/crates/data_connector/Cargo.toml
+++ b/crates/data_connector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "data-connector"
-version = "2.0.0"
+version = "2.1.0"
 edition = "2021"
 description = "Storage backends for conversations and responses"
 license = "Apache-2.0"

--- a/crates/grpc_client/Cargo.toml
+++ b/crates/grpc_client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-grpc-client"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2021"
 description = "gRPC clients for SGLang and vLLM backends"
 license = "Apache-2.0"

--- a/crates/kv_index/Cargo.toml
+++ b/crates/kv_index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kv-index"
-version = "1.0.1"
+version = "1.1.0"
 edition = "2021"
 description = "Radix tree implementations for prefix matching and cache-aware routing"
 license = "Apache-2.0"

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-mcp"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2021"
 description = "Model Context Protocol (MCP) client implementation"
 license = "Apache-2.0"

--- a/crates/mesh/Cargo.toml
+++ b/crates/mesh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-mesh"
-version = "1.1.1"
+version = "1.1.2"
 edition = "2021"
 description = "Mesh gossip protocol and distributed state synchronization for Shepherd Model Gateway"
 license = "Apache-2.0"

--- a/crates/multimodal/Cargo.toml
+++ b/crates/multimodal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llm-multimodal"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2021"
 description = "Multimodal processing for vision and other modalities"
 license = "Apache-2.0"

--- a/crates/protocols/Cargo.toml
+++ b/crates/protocols/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openai-protocol"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2021"
 description = "OpenAI-compatible API protocol definitions and types"
 license = "Apache-2.0"

--- a/crates/reasoning_parser/Cargo.toml
+++ b/crates/reasoning_parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reasoning-parser"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 description = "Parser for AI model reasoning/thinking outputs (chain-of-thought, etc.)"
 license = "Apache-2.0"

--- a/crates/tokenizer/Cargo.toml
+++ b/crates/tokenizer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llm-tokenizer"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2021"
 description = "LLM tokenizer library with caching and chat template support"
 license = "Apache-2.0"

--- a/crates/tool_parser/Cargo.toml
+++ b/crates/tool_parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tool-parser"
-version = "1.1.1"
+version = "1.1.2"
 edition = "2021"
 description = "Tool/function call parser for LLM model outputs"
 license = "Apache-2.0"

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-wasm"
-version = "1.0.1"
+version = "1.1.0"
 edition = "2021"
 description = "WebAssembly runtime and module management for Shepherd Model Gateway"
 license = "Apache-2.0"

--- a/crates/workflow/Cargo.toml
+++ b/crates/workflow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wfaas"
-version = "1.0.2"
+version = "1.0.3"
 edition = "2021"
 description = "Workflow-as-a-Service engine for managing multi-step operations"
 license = "Apache-2.0"

--- a/model_gateway/Cargo.toml
+++ b/model_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 description = "High-performance model-routing gateway for large-scale LLM deployments"
 license = "Apache-2.0"

--- a/scripts/check_release_versions.sh
+++ b/scripts/check_release_versions.sh
@@ -71,6 +71,8 @@ CRATES=(
     "smg-wasm|crates/wasm|smg-wasm"
     "smg-mesh|crates/mesh|smg-mesh"
     "smg-grpc-client|crates/grpc_client|smg-grpc-client"
+    "smg-client|clients/rust|-"
+    "openapi-gen|clients/openapi-gen|-"
     "smg|model_gateway|-"
 )
 
@@ -82,6 +84,23 @@ CRATES=(
 PYTHON_PACKAGES=(
     "smg-grpc-proto|crates/grpc_client/python|crates/grpc_client/python/pyproject.toml"
     "smg-grpc-servicer|grpc_servicer|grpc_servicer/pyproject.toml"
+)
+
+# ---------------------------------------------------------------------------
+# SMG version sync: files that must mirror the smg (model_gateway) version.
+# Format: "label|file|type"
+#   type: "cargo"  → first `version = "X.Y.Z"` line in a Cargo.toml
+#         "pyproject" → first `version = "X.Y.Z"` line in a pyproject.toml
+#         "workflow"  → `default: 'vX.Y.Z'` for smg_commit in a workflow file
+# ---------------------------------------------------------------------------
+SMG_VERSION_SYNC=(
+    "smg-python|bindings/python/Cargo.toml|cargo"
+    "smg-golang|bindings/golang/Cargo.toml|cargo"
+    "smg pyproject|bindings/python/pyproject.toml|pyproject"
+    "sglang-docker|.github/workflows/release-sglang-docker.yml|workflow"
+    "vllm-docker|.github/workflows/release-vllm-docker.yml|workflow"
+    "trtllm-docker|.github/workflows/release-trtllm-docker.yml|workflow"
+    "build-engine|.github/workflows/_build-engine-image.yml|workflow"
 )
 
 # ---------------------------------------------------------------------------
@@ -323,6 +342,27 @@ has_non_version_changes() {
     [[ "$non_ver_lines" -gt 0 ]]
 }
 
+# Extract smg_commit default version from a workflow file (e.g. "default: 'v1.2.0'")
+get_workflow_smg_version() {
+    local file="$1"
+    grep -m1 "default: 'v[0-9]" "$file" | sed "s/.*default: 'v\([^']*\)'.*/\1/"
+}
+
+# Update all smg version references in a workflow file.
+# Replaces the version in default: values, || fallbacks, and description examples.
+set_workflow_smg_version() {
+    local file="$1"
+    local old_version="$2"
+    local new_version="$3"
+    local escaped_old
+    escaped_old=$(escape_version "$old_version")
+    sed_inplace "s/v${escaped_old}/v${new_version}/g" "$file"
+    if ! grep -q "default: 'v${new_version}'" "$file"; then
+        echo -e "    ${RED}FAILED to update $file${NC}" >&2
+        return 1
+    fi
+}
+
 # Update workspace dep version in root Cargo.toml
 set_workspace_dep_version() {
     local dep_key="$1"
@@ -462,6 +502,48 @@ for entry in "${PYTHON_PACKAGES[@]}"; do
 done
 
 # ---------------------------------------------------------------------------
+# Phase 1c: Check SMG version sync (files that must mirror model_gateway)
+# ---------------------------------------------------------------------------
+smg_version=$(get_crate_version "model_gateway/Cargo.toml")
+
+# If smg is being bumped, use the bumped version as the sync target
+smg_target_version="$smg_version"
+for entry in ${NEEDS_BUMP[@]+"${NEEDS_BUMP[@]}"}; do
+    IFS='|' read -r _name _path _dep_key _cur _level <<< "$entry"
+    if [[ "$_name" == "smg" ]]; then
+        smg_target_version=$(bump_version "$_cur" "$_level")
+        break
+    fi
+done
+
+# Collect sync mismatches: "label|file|type|current_version"
+NEEDS_VERSION_SYNC=()
+
+for entry in "${SMG_VERSION_SYNC[@]}"; do
+    IFS='|' read -r label file type <<< "$entry"
+
+    case "$type" in
+        cargo)
+            file_version=$(get_crate_version "$file")
+            ;;
+        pyproject)
+            file_version=$(grep -m1 '^version' "$file" | sed 's/.*"\([^"]*\)".*/\1/')
+            ;;
+        workflow)
+            file_version=$(get_workflow_smg_version "$file")
+            ;;
+    esac
+
+    if [[ "$file_version" != "$smg_target_version" ]]; then
+        echo -e "  ${YELLOW}!${NC} ${BOLD}$label${NC} ($file) — v$file_version, expected v$smg_target_version"
+        NEEDS_VERSION_SYNC+=("$label|$file|$type|$file_version")
+        issues=$((issues + 1))
+    else
+        echo -e "  ${GREEN}✓${NC} ${BOLD}$label${NC} ($file) — v$file_version"
+    fi
+done
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""
@@ -480,7 +562,8 @@ echo -e "${RED}${BOLD}$issues issue(s) found.${NC}"
 n_bump=${#NEEDS_BUMP[@]}
 n_ws=${#NEEDS_WS_SYNC[@]}
 n_py=${#NEEDS_PY_BUMP[@]:-0}
-total_fixes=$(( n_bump + n_ws + n_py ))
+n_vsync=${#NEEDS_VERSION_SYNC[@]:-0}
+total_fixes=$(( n_bump + n_ws + n_py + n_vsync ))
 if [[ "$total_fixes" -eq 0 ]]; then
     exit 1
 fi
@@ -508,6 +591,11 @@ for entry in ${NEEDS_PY_BUMP[@]+"${NEEDS_PY_BUMP[@]}"}; do
     IFS='|' read -r name path version_file current_version level <<< "$entry"
     new_version=$(bump_version "$current_version" "$level")
     echo -e "  $(bump_label "$level") $name v$current_version → v$new_version ($version_file)"
+done
+
+for entry in ${NEEDS_VERSION_SYNC[@]+"${NEEDS_VERSION_SYNC[@]}"}; do
+    IFS='|' read -r label file type file_version <<< "$entry"
+    echo -e "  ${BLUE}sync${NC} $label v$file_version → v$smg_target_version ($file)"
 done
 
 echo ""
@@ -565,6 +653,33 @@ for entry in ${NEEDS_PY_BUMP[@]+"${NEEDS_PY_BUMP[@]}"}; do
     else
         fix_failed=$((fix_failed + 1))
     fi
+done
+
+for entry in ${NEEDS_VERSION_SYNC[@]+"${NEEDS_VERSION_SYNC[@]}"}; do
+    IFS='|' read -r label file type file_version <<< "$entry"
+    case "$type" in
+        cargo)
+            if set_crate_version "$file" "$smg_target_version"; then
+                echo -e "  ${GREEN}✓${NC} $file → v$smg_target_version"
+            else
+                fix_failed=$((fix_failed + 1))
+            fi
+            ;;
+        pyproject)
+            if set_python_version "$file" "$smg_target_version"; then
+                echo -e "  ${GREEN}✓${NC} $file → v$smg_target_version"
+            else
+                fix_failed=$((fix_failed + 1))
+            fi
+            ;;
+        workflow)
+            if set_workflow_smg_version "$file" "$file_version" "$smg_target_version"; then
+                echo -e "  ${GREEN}✓${NC} $file → v$smg_target_version"
+            else
+                fix_failed=$((fix_failed + 1))
+            fi
+            ;;
+    esac
 done
 
 echo ""


### PR DESCRIPTION
## Summary

Bumps all workspace crates to v1.2.0 based on conventional commit analysis, and improves the release infrastructure so engine docker workflows (sglang, vllm, trtllm) auto-trigger on version bumps — matching the existing behavior of `release-pypi.yml` and `release-docker.yml`.

## What changed

### Version bumps (22 files)
- `model_gateway/Cargo.toml`: 1.1.0 → 1.2.0
- `bindings/python/Cargo.toml`: 1.1.0 → 1.2.0
- `bindings/golang/Cargo.toml`: 1.1.0 → 1.2.0
- `bindings/python/pyproject.toml`: 1.1.0 → 1.2.0
- All workspace crates bumped per conventional commit analysis (minor/patch)
- `Cargo.toml` workspace dependency versions synced

### `scripts/check_release_versions.sh`
- **SMG_VERSION_SYNC registry**: new mechanism to keep `bindings/python/Cargo.toml`, `bindings/golang/Cargo.toml`, `bindings/python/pyproject.toml`, and 4 workflow files in sync with `model_gateway/Cargo.toml` version
- **New crates**: added `smg-client` and `openapi-gen` to the CRATES array
- **Phase 1c**: detects version sync mismatches between synced files and the smg target version
- **Phase 2/3**: displays proposed sync fixes and applies them (cargo, pyproject, and workflow file types)
- **Helpers**: `get_workflow_smg_version()` / `set_workflow_smg_version()` for reading/updating `default: 'vX.Y.Z'` and `|| 'vX.Y.Z'` patterns in workflow files

### Engine docker workflows
- **Auto-trigger**: added `push` trigger on `main` watching `bindings/python/pyproject.toml` to `release-sglang-docker.yml`, `release-vllm-docker.yml`, `release-trtllm-docker.yml` — they now auto-release on version bumps like `release-pypi.yml`
- **Fallback defaults**: added `|| 'value'` fallbacks in job `with:` blocks for vllm and trtllm so `push` events use sensible defaults
- **TensorRT-LLM default**: added `default: 'nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc6'` for `base_image_ref`
- **Version sync**: updated `smg_commit` defaults from `v1.1.0` → `v1.2.0` across all engine workflows and `_build-engine-image.yml`

## Why

- `bindings/python/pyproject.toml`, `bindings/python/Cargo.toml`, and `bindings/golang/Cargo.toml` were never updated by the version check script, causing them to drift from the gateway version
- Engine docker workflows had hardcoded `v1.1.0` and no `push` trigger, so they would never auto-run on release
- The trtllm workflow had no default `base_image_ref`, requiring manual input every time

## Test plan

- [x] Ran `make check-versions` end-to-end — all versions detected correctly, sync mismatches found and fixed
- [x] Re-ran script after fixes — "All versions consistent"
- [x] Verified workflow YAML syntax is valid
- [x] Verified `||` fallbacks match `default:` values in all engine workflows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped version numbers across multiple internal libraries and bindings to 1.2.0 and minor patch releases.
  * Updated Docker image build workflow defaults from v1.1.0 to v1.2.0.
  * Enhanced version synchronization tooling for release management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->