### PR TITLE
fix(ci): add packages:write permission to engine docker release workflows

### DIFF
--- a/.github/workflows/release-sglang-docker.yml
+++ b/.github/workflows/release-sglang-docker.yml
@@ -50,6 +50,10 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build:
     uses: ./.github/workflows/_build-engine-image.yml

--- a/.github/workflows/release-trtllm-docker.yml
+++ b/.github/workflows/release-trtllm-docker.yml
@@ -43,6 +43,10 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build:
     uses: ./.github/workflows/_build-engine-image.yml

--- a/.github/workflows/release-vllm-docker.yml
+++ b/.github/workflows/release-vllm-docker.yml
@@ -43,6 +43,10 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build:
     uses: ./.github/workflows/_build-engine-image.yml


### PR DESCRIPTION
## Summary

Fixes GHCR push failure in engine docker release workflows (sglang, vllm, trtllm).

## What changed

- Added `permissions: contents: read, packages: write` to `release-sglang-docker.yml`, `release-vllm-docker.yml`, `release-trtllm-docker.yml`

## Why

The workflows failed with `error from registry: installation not allowed to Write organization package` because the `GITHUB_TOKEN` only had `Packages: read`. The `nightly-docker.yml` workflow already has this permission set correctly — this brings the engine release workflows in line.

## Test plan

- [x] Verified `nightly-docker.yml` uses the same permissions pattern
- [ ] Re-run engine docker builds after merge to confirm push succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Docker image release automation with explicit permissions configuration. Updated workflows now specify minimal required access levels for repository contents and package registry operations across all release pipelines, establishing clear security boundaries for the automated container image release infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->