### PR TITLE
chore(ci): bump trtllm default base image to 1.3.0rc7

### DIFF
--- a/.github/workflows/release-trtllm-docker.yml
+++ b/.github/workflows/release-trtllm-docker.yml
@@ -15,8 +15,8 @@ on:
   workflow_dispatch:
     inputs:
       base_image_ref:
-        description: 'Base image (e.g. nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc6). Empty = build from source.'
-        default: 'nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc6'
+        description: 'Base image (e.g. nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc7). Empty = build from source.'
+        default: 'nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc7'
         required: false
         type: string
       trtllm_repo:
@@ -52,7 +52,7 @@ jobs:
     uses: ./.github/workflows/_build-engine-image.yml
     with:
       engine: trtllm
-      base_image_ref: ${{ inputs.base_image_ref || 'nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc6' }}
+      base_image_ref: ${{ inputs.base_image_ref || 'nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc7' }}
       engine_repo: ${{ inputs.trtllm_repo }}
       engine_commit: ${{ inputs.trtllm_commit || 'latest' }}
       smg_repo: ${{ inputs.smg_repo || 'https://github.com/lightseekorg/smg' }}


### PR DESCRIPTION
## Summary

Updates the default TensorRT-LLM base image from `1.3.0rc6` to `1.3.0rc7` in `release-trtllm-docker.yml`.

Ref: https://github.com/NVIDIA/TensorRT-LLM/releases/tag/v1.3.0rc7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build infrastructure components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->