### PR TITLE
fix(deps): pin gRPC packages to 1.78.0 in sglang install script

### DIFF
--- a/scripts/installation/install-sglang.sh
+++ b/scripts/installation/install-sglang.sh
@@ -8,3 +8,7 @@ set -e
 SGL_SRC="${1:-/tmp/sglang-src}"
 cd "${SGL_SRC}/python"
 pip install --no-deps --force-reinstall --editable .
+
+# Pin gRPC packages to 1.78.0 — grpcio 1.78.1 was yanked from PyPI 
+# TODO: remove when new SGLang 0.5.10 is released
+pip install --force-reinstall grpcio==1.78.0 grpcio-reflection==1.78.0 grpcio-tools==1.78.0 grpcio-health-checking==1.78.0


### PR DESCRIPTION
## Summary
- Pin `grpcio`, `grpcio-reflection`, `grpcio-tools`, and `grpcio-health-checking` to `==1.78.0` in `install-sglang.sh`
- `grpcio==1.78.1` was [yanked from PyPI](https://pypi.org/project/grpcio/1.78.1/) due to a major outage in gcloud serverless environments ([grpc/grpc#41725](https://github.com/grpc/grpc/issues/41725)), but `grpcio-reflection==1.78.1` was **not** yanked
- This causes a runtime version mismatch crash when sglang starts with `--grpc-mode`: the reflection package's generated code asserts `grpcio>=1.78.1`, but pip installs `grpcio==1.78.0` (since 1.78.1 is yanked)

## Test plan
- [ ] Build engine image with sglang base and verify `--grpc-mode` starts without `RuntimeError`
- [ ] Verify `pip list | grep grpc` shows all packages at 1.78.0 inside the container

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated installation process to pin gRPC-related packages to a specific compatible version, ensuring successful deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->