### PR TITLE
fix(realtime-api): worker health tracking in websocket session

### DIFF
--- a/model_gateway/src/routers/openai/realtime/ws.rs
+++ b/model_gateway/src/routers/openai/realtime/ws.rs
@@ -11,8 +11,9 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use serde::Deserialize;
+use tracing::{debug, error};
 
-use super::{proxy::run_ws_proxy, RealtimeRegistry};
+use super::{proxy, RealtimeRegistry};
 use crate::{
     core::Worker,
     observability::metrics::{metrics_labels, Metrics},
@@ -116,7 +117,7 @@ pub(crate) async fn handle_realtime_ws(
     );
 
     ws.on_upgrade(move |socket: WebSocket| async move {
-        if let Err(e) = run_ws_proxy(
+        let success = match proxy::run_ws_proxy(
             socket,
             &upstream_ws_url,
             &auth_str,
@@ -126,12 +127,16 @@ pub(crate) async fn handle_realtime_ws(
         )
         .await
         {
-            tracing::error!(session_id, error = %e, "Realtime WebSocket proxy error");
-        }
+            Ok(()) => true,
+            Err(e) => {
+                error!(session_id, error = %e, "Realtime WebSocket proxy error");
+                false
+            }
+        };
 
-        // Cleanup: remove session on disconnect
+        worker.record_outcome(success);
         realtime_registry.remove_session(&session_id);
-        tracing::debug!(session_id, "Realtime session cleaned up");
+        debug!(session_id, "Realtime session cleaned up");
     })
 }
 


### PR DESCRIPTION
Ref: https://github.com/lightseekorg/smg/pull/637
## Description

### Problem

The realtime WebSocket handler does not call `worker.record_outcome()` after the proxy session completes. This means worker health tracking has no signal from realtime WebSocket sessions — unlike the REST path which already records outcomes. Without this, the load balancer cannot distinguish healthy workers from unhealthy ones based on realtime session results.
### Solution

Capture the proxy result as a success `boolean` and call `worker.record_outcome(success)` before cleaning up the session. This brings the WS handler in line with existing patterns in the REST path.

## Changes

- `model_gateway/src/routers/openai/realtime/ws.rs`
   - Refactor if let Err(e) = run_ws_proxy(...) into match that captures a success: bool
   - Call worker.record_outcome(success) after the proxy completes
   - Import proxy module directly instead of proxy::run_ws_proxy (aligns with module-level import convention)
   - Use explicit tracing::{debug, error} imports instead of tracing::error! / tracing::debug! via path

## Test Plan

<!-- Provide a thorough reproducible test showing before and after behavior. -->

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved error handling and logging for real-time WebSocket connections with enhanced session tracking and outcome recording.

* **Chores**
  * Updated error handling semantics and adjusted logging levels for better diagnostics and cleanup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->