### PR TITLE
fix(grpc_servicer): return served_model_name in vLLM GetModelInfo response

### DIFF
--- a/crates/grpc_client/proto/vllm_engine.proto
+++ b/crates/grpc_client/proto/vllm_engine.proto
@@ -295,6 +295,7 @@ message GetModelInfoResponse {
   uint32 max_context_length = 3;
   uint32 vocab_size = 4;
   bool supports_vision = 5;
+  string served_model_name = 6;
 }
 
 message GetServerInfoRequest {}

--- a/grpc_servicer/smg_grpc_servicer/vllm/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/vllm/servicer.py
@@ -271,6 +271,7 @@ class VllmEngineServicer(vllm_engine_pb2_grpc.VllmEngineServicer):
             max_context_length=model_config.max_model_len,
             vocab_size=model_config.get_vocab_size(),
             supports_vision=model_config.is_multimodal_model,
+            served_model_name=model_config.served_model_name or model_config.model,
         )
 
     async def GetServerInfo(


### PR DESCRIPTION
## Description

### Problem

When using `smg serve --backend vllm --served-model-name vllm-model`, the gateway registers the worker with the raw filesystem model path (e.g. `/raid/models/...`) instead of the user-specified `--served-model-name`.

This happens because the vLLM gRPC servicer returns `model_config.model` (always the filesystem path) in the `GetModelInfo` response, ignoring the `served_model_name` that vLLM sets when `--served-model-name` is provided.

### Solution

Use `model_config.served_model_name` (which vLLM sets via `get_served_model_name()` — falls back to `model_config.model` when not specified) instead of `model_config.model` in the `GetModelInfo` response.

## Changes

- `grpc_servicer/smg_grpc_servicer/vllm/servicer.py`: Return `model_config.served_model_name or model_config.model` in `model_path` field of `GetModelInfoResponse`

## Test Plan

1. Launch vLLM gRPC server with `--served-model-name vllm-model`
2. Connect smg gateway to the worker
3. Verify smg registers the worker with model name `vllm-model` instead of the filesystem path

**Before**
<img width="728" height="685" alt="Screenshot 2026-03-11 at 12 05 08 AM" src="https://github.com/user-attachments/assets/b38f8154-660f-4977-bae4-bc707a7b461f" />

**After**
<img width="722" height="411" alt="Screenshot 2026-03-11 at 12 54 52 PM" src="https://github.com/user-attachments/assets/214a356c-5875-4f09-b8d3-0d7bdc321db0" />
<img width="756" height="68" alt="Screenshot 2026-03-11 at 12 54 59 PM" src="https://github.com/user-attachments/assets/ab43e3be-d500-4d71-9e3c-34cef90cdfa6" />


<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Model info responses now include a "served model name" field so interfaces can display the configured served name when available.
* **Bug Fixes**
  * Improved model-name reporting to prefer the served model name with a fallback to the original model identifier, reducing ambiguity in displays and logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->