### PR TITLE
feat(realtime-api): WebRTC config plumbing through AppContext and CLI

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1088,6 +1088,8 @@ impl Router {
                     .as_ref()
                     .map(|c| c.to_auth_control_plane_config()),
                 mesh_server_config: None,
+                webrtc_bind_addr: None,
+                webrtc_stun_server: None,
             })
             .await
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))

--- a/model_gateway/benches/wasm_middleware_latency.rs
+++ b/model_gateway/benches/wasm_middleware_latency.rs
@@ -66,7 +66,9 @@ fn bench_wasm_middleware_buffering(c: &mut Criterion) {
     // Setup AppContext with WASM enabled
     let config = RouterConfig::builder().enable_wasm(true).build_unchecked();
 
-    let context = rt.block_on(AppContext::from_config(config, 30)).unwrap();
+    let context = rt
+        .block_on(AppContext::from_config(config, 30, None, None))
+        .unwrap();
     let app_state = Arc::new(AppState {
         router: Arc::new(MockRouter),
         context: Arc::new(context),

--- a/model_gateway/src/app_context.rs
+++ b/model_gateway/src/app_context.rs
@@ -64,6 +64,10 @@ pub struct AppContext {
     pub inflight_tracker: Arc<InFlightRequestTracker>,
     pub kv_event_monitor: Option<Arc<KvEventMonitor>>,
     pub realtime_registry: Arc<RealtimeRegistry>,
+    /// Bind address for WebRTC UDP sockets (`None` = `0.0.0.0`, auto-detect).
+    pub webrtc_bind_addr: Option<std::net::IpAddr>,
+    /// STUN server for ICE candidate gathering (`None` = `stun.l.google.com:19302`).
+    pub webrtc_stun_server: Option<String>,
 }
 
 impl std::fmt::Debug for AppContext {
@@ -93,6 +97,8 @@ pub struct AppContextBuilder {
     mcp_orchestrator: Option<Arc<OnceLock<Arc<McpOrchestrator>>>>,
     wasm_manager: Option<Arc<WasmModuleManager>>,
     kv_event_monitor: Option<Arc<KvEventMonitor>>,
+    webrtc_bind_addr: Option<std::net::IpAddr>,
+    webrtc_stun_server: Option<String>,
 }
 
 impl AppContext {
@@ -105,11 +111,15 @@ impl AppContext {
     pub fn from_config(
         router_config: RouterConfig,
         request_timeout_secs: u64,
+        webrtc_bind_addr: Option<std::net::IpAddr>,
+        webrtc_stun_server: Option<String>,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Self, String>> + Send>> {
         Box::pin(async move {
             Box::pin(AppContextBuilder::from_config(
                 router_config,
                 request_timeout_secs,
+                webrtc_bind_addr,
+                webrtc_stun_server,
             ))
             .await?
             .build()
@@ -139,6 +149,8 @@ impl AppContextBuilder {
             mcp_orchestrator: None,
             wasm_manager: None,
             kv_event_monitor: None,
+            webrtc_bind_addr: None,
+            webrtc_stun_server: None,
         }
     }
 
@@ -244,6 +256,16 @@ impl AppContextBuilder {
         self
     }
 
+    pub fn webrtc_bind_addr(mut self, addr: Option<std::net::IpAddr>) -> Self {
+        self.webrtc_bind_addr = addr;
+        self
+    }
+
+    pub fn webrtc_stun_server(mut self, server: Option<String>) -> Self {
+        self.webrtc_stun_server = server;
+        self
+    }
+
     pub fn build(self) -> Result<AppContext, AppContextBuildError> {
         let router_config = self
             .router_config
@@ -303,6 +325,8 @@ impl AppContextBuilder {
             inflight_tracker: InFlightRequestTracker::new(),
             kv_event_monitor: self.kv_event_monitor,
             realtime_registry: Arc::new(RealtimeRegistry::new()),
+            webrtc_bind_addr: self.webrtc_bind_addr,
+            webrtc_stun_server: self.webrtc_stun_server,
         })
     }
 
@@ -311,6 +335,8 @@ impl AppContextBuilder {
     pub async fn from_config(
         router_config: RouterConfig,
         request_timeout_secs: u64,
+        webrtc_bind_addr: Option<std::net::IpAddr>,
+        webrtc_stun_server: Option<String>,
     ) -> Result<Self, String> {
         Ok(Self::new()
             .with_client(&router_config, request_timeout_secs)?
@@ -329,6 +355,8 @@ impl AppContextBuilder {
             .await?
             .with_wasm_manager(&router_config)
             .with_kv_event_monitor(&router_config)
+            .webrtc_bind_addr(webrtc_bind_addr)
+            .webrtc_stun_server(webrtc_stun_server)
             .router_config(router_config))
     }
 

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -627,6 +627,20 @@ struct CliArgs {
 
     #[arg(long, num_args = 0..)]
     mesh_peer_urls: Vec<String>,
+
+    // ==================== WebRTC ====================
+    /// Bind address for WebRTC UDP sockets (client-facing ICE candidate IP).
+    /// Default: 0.0.0.0 (auto-detect via routing table).
+    /// Set to 127.0.0.1 for local development on the same machine.
+    #[arg(long, help_heading = "WebRTC")]
+    webrtc_bind_addr: Option<std::net::IpAddr>,
+
+    /// STUN server for ICE candidate gathering (host:port).
+    /// Set to your own STUN server for enterprise deployments that
+    /// restrict outbound traffic to external STUN servers.
+    /// Defaults to `stun.l.google.com:19302` at runtime when omitted.
+    #[arg(long, help_heading = "WebRTC")]
+    webrtc_stun_server: Option<String>,
 }
 
 enum OracleConnectSource {
@@ -1248,6 +1262,8 @@ impl CliArgs {
             shutdown_grace_period_secs: self.shutdown_grace_period_secs,
             control_plane_auth,
             mesh_server_config,
+            webrtc_bind_addr: self.webrtc_bind_addr,
+            webrtc_stun_server: self.webrtc_stun_server.clone(),
         })
     }
 }

--- a/model_gateway/src/server.rs
+++ b/model_gateway/src/server.rs
@@ -622,6 +622,12 @@ pub struct ServerConfig {
     /// Control plane authentication configuration
     pub control_plane_auth: Option<smg_auth::ControlPlaneAuthConfig>,
     pub mesh_server_config: Option<MeshServerConfig>,
+    /// Bind address for WebRTC UDP sockets.
+    /// `None` means use the default (0.0.0.0, auto-detect candidate IP).
+    pub webrtc_bind_addr: Option<std::net::IpAddr>,
+    /// STUN server for ICE candidate gathering (host:port).
+    /// `None` means use the default (stun.l.google.com:19302).
+    pub webrtc_stun_server: Option<String>,
 }
 
 pub fn build_app(
@@ -887,7 +893,13 @@ pub async fn startup(config: ServerConfig) -> Result<(), Box<dyn std::error::Err
     );
 
     let app_context = Arc::new(
-        AppContext::from_config(config.router_config.clone(), config.request_timeout_secs).await?,
+        AppContext::from_config(
+            config.router_config.clone(),
+            config.request_timeout_secs,
+            config.webrtc_bind_addr,
+            config.webrtc_stun_server.clone(),
+        )
+        .await?,
     );
 
     if config.prometheus_config.is_some() {

--- a/model_gateway/src/service_discovery.rs
+++ b/model_gateway/src/service_discovery.rs
@@ -931,6 +931,8 @@ mod tests {
             inflight_tracker: InFlightRequestTracker::new(),
             kv_event_monitor: None,
             realtime_registry: Arc::new(RealtimeRegistry::new()),
+            webrtc_bind_addr: None,
+            webrtc_stun_server: None,
         })
     }
 


### PR DESCRIPTION
## Description

### Problem

The upcoming WebRTC relay feature requires two configuration parameters — a UDP bind address for ICE candidates and a STUN server for candidate gathering. These need to flow through the CLI, ServerConfig, and AppContext before
  any WebRTC logic can be implemented.

### Solution

Add webrtc_bind_addr: Option<IpAddr> and webrtc_stun_server: Option<String> as optional config fields threaded through the full config pipeline. All defaults are None, so there is no behavior change. This is pure plumbing to
  unblock subsequent WebRTC PRs.

## Changes

- `app_context.rs` — Added webrtc_bind_addr: Option<IpAddr> and webrtc_stun_server: Option<String> to AppContext + AppContextBuilder, updated both from_config() signatures, added builder methods
- `main.rs` — Added --webrtc-bind-addr and --webrtc-stun-server CLI args under [WebRTC] heading, passed through to ServerConfig
- `server.rs` — Added fields to ServerConfig, passed through in startup()
- `service_discovery.rs` — Added None defaults to test fixture AppContext
- `wasm_middleware_latency.rs` — Updated from_config(config, 30) → from_config(config, 30, None, None)
- `bindings/python/src/lib.rs` — Added None defaults to ServerConfig construction

## Test Plan

<!-- Provide a thorough reproducible test showing before and after behavior. -->

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Added optional WebRTC bind address for custom UDP socket binding.
  - Added optional STUN server configuration for ICE candidate gathering.
  - Both options are available as command-line arguments and in the server configuration (optional, default: unset).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->