### PR TITLE
feat(realtime-api): WebRTC Router trait interface + HTTP route regist…

### DIFF
--- a/model_gateway/src/observability/metrics.rs
+++ b/model_gateway/src/observability/metrics.rs
@@ -396,6 +396,7 @@ pub mod metrics_labels {
 
     // Connection modes
     pub const CONNECTION_WEBSOCKET: &str = "websocket";
+    pub const CONNECTION_WEBRTC: &str = "webrtc";
 
     // Worker types
     pub const WORKER_REGULAR: &str = "regular";

--- a/model_gateway/src/routers/mod.rs
+++ b/model_gateway/src/routers/mod.rs
@@ -286,6 +286,15 @@ pub trait RouterTrait: Send + Sync + Debug {
             .into_response()
     }
 
+    /// Route a realtime WebRTC upgrade request
+    async fn route_realtime_webrtc(&self, _req: Request<Body>, _model_id: &str) -> Response {
+        (
+            StatusCode::NOT_IMPLEMENTED,
+            "Realtime WebRTC not implemented",
+        )
+            .into_response()
+    }
+
     /// Get router type name
     fn router_type(&self) -> &'static str;
 

--- a/model_gateway/src/routers/router_manager.rs
+++ b/model_gateway/src/routers/router_manager.rs
@@ -914,6 +914,19 @@ impl RouterTrait for RouterManager {
         }
     }
 
+    async fn route_realtime_webrtc(&self, req: Request<Body>, model: &str) -> Response {
+        let router = self.select_router_for_request(None, Some(model));
+        if let Some(router) = router {
+            router.route_realtime_webrtc(req, model).await
+        } else {
+            (
+                StatusCode::NOT_FOUND,
+                "No router available for realtime WebRTC request",
+            )
+                .into_response()
+        }
+    }
+
     fn router_type(&self) -> &'static str {
         "manager"
     }

--- a/model_gateway/src/server.rs
+++ b/model_gateway/src/server.rs
@@ -438,6 +438,17 @@ async fn v1_conversations_delete_item(
     .await
 }
 
+async fn v1_realtime_webrtc(
+    State(state): State<Arc<AppState>>,
+    Query(params): Query<RealtimeQueryParams>,
+    req: Request,
+) -> Response {
+    // Model may come from query param (application/sdp) or session body
+    // (multipart/form-data). Let the handler validate per content type.
+    let model = params.model.unwrap_or_default();
+    state.router.route_realtime_webrtc(req, &model).await
+}
+
 async fn v1_realtime_ws(
     State(state): State<Arc<AppState>>,
     Query(params): Query<RealtimeQueryParams>,
@@ -702,11 +713,12 @@ pub fn build_app(
             middleware::wasm_middleware,
         ));
 
-    // WebSocket route: auth + concurrency but NO WASM middleware.
+    // WebSocket and WebRTC routes: auth + concurrency but NO WASM middleware.
     // WASM OnResponse reconstructs the response from status/headers/body,
     // dropping the response extensions that carry the WebSocket upgrade future.
-    let ws_routes = Router::new()
+    let realtime_routes = Router::new()
         .route("/v1/realtime", get(v1_realtime_ws))
+        .route("/v1/realtime/calls", post(v1_realtime_webrtc))
         .route_layer(axum::middleware::from_fn_with_state(
             app_state.clone(),
             middleware::concurrency_limit_middleware,
@@ -795,7 +807,7 @@ pub fn build_app(
 
     Router::new()
         .merge(protected_routes)
-        .merge(ws_routes)
+        .merge(realtime_routes)
         .merge(public_routes)
         .merge(admin_routes)
         .merge(worker_routes)


### PR DESCRIPTION

## Description

### Problem
There is no HTTP endpoint or routing interface for WebRTC realtime calls. The upcoming WebRTC relay feature (bridge, handler) needs a route to plug into and a trait method to implement.
### Solution
Define route_realtime_webrtc on RouterTrait with a default 501 Not Implemented response, following the same pattern as the existing route_realtime_ws. Register POST /v1/realtime/calls in the ws_routes group (auth + concurrency
  limit, no WASM middleware). Add a CONNECTION_WEBRTC metrics constant for future instrumentation.
## Changes

- `model_gateway/src/routers/mod.rs` — Add route_realtime_webrtc(&self, req, model_id) -> Response with default 501 to RouterTrait.
- `model_gateway/src/routers/router_manager.rs` — Implement route_realtime_webrtc on RouterManager — select router, delegate.                                 
- `model_gateway/src/server.rs` — dd v1_realtime_webrtc handler function + .route("/v1/realtime/calls", post(v1_realtime_webrtc)) to ws_routes.
- `model_gateway/src/observability/metrics.rs` — Add CONNECTION_WEBRTC: &str = "webrtc" constant.                                                              

## Test Plan

<!-- Provide a thorough reproducible test showing before and after behavior. -->

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added WebRTC realtime endpoint (`POST /v1/realtime/calls`) for establishing real-time connections
  * Enhanced realtime routing to support both WebSocket and WebRTC protocols
  * Improved validation for realtime requests to ensure required parameters are present

<!-- end of auto-generated comment: release notes by coderabbit.ai -->