### PR TITLE
fix: update CODEOWNERS paths after crate relocation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,28 +19,28 @@
 /scripts @gongwei-130 @CatherineSue @key4ng @XinyueZhang369 @slin1237
 
 # Main source code (model_gateway)
-/model_gateway/src/config @slin1237
-/model_gateway/src/core @slin1237
+/model_gateway/src/config @slin1237 @CatherineSue
+/model_gateway/src/core @slin1237 @CatherineSue
 /model_gateway/src/policies @slin1237
 /model_gateway/src/routers @CatherineSue @key4ng @slin1237
 
 # Workspace crates
-/auth @slin1237
-/data_connector @key4ng
-/grpc_client @CatherineSue @slin1237
-/grpc_client/proto/vllm_engine.proto @njhill @CatherineSue @slin1237
-/grpc_client/proto/common.proto @njhill @CatherineSue @slin1237
-/grpc_servicer @njhill @CatherineSue
-/kv_index @slin1237
-/mcp @key4ng @CatherineSue @slin1237
-/mesh @slin1237 @tonyluj
-/multimodal @slin1237 @CatherineSue
-/protocols @CatherineSue @key4ng
-/reasoning_parser @CatherineSue
-/tokenizer @slin1237 @CatherineSue
-/tool_parser @slin1237 @CatherineSue
-/wasm @slin1237 @tonyluj
-/workflow @slin1237 @CatherineSue
+/crates/auth @slin1237
+/crates/data_connector @key4ng
+/crates/grpc_client @CatherineSue @slin1237
+/crates/grpc_client/proto/vllm_engine.proto @njhill @CatherineSue @slin1237
+/crates/grpc_client/proto/common.proto @njhill @CatherineSue @slin1237
+/crates/grpc_servicer @njhill @CatherineSue
+/crates/kv_index @slin1237
+/crates/mcp @key4ng @CatherineSue @slin1237
+/crates/mesh @tonyluj @llfl @slin1237
+/crates/multimodal @slin1237 @CatherineSue
+/crates/protocols @CatherineSue @key4ng
+/crates/reasoning_parser @CatherineSue
+/crates/tokenizer @slin1237 @CatherineSue
+/crates/tool_parser @slin1237 @CatherineSue
+/crates/wasm @slin1237 @tonyluj
+/crates/workflow @slin1237 @CatherineSue
 
 # Examples
 /examples/wasm @tonyluj @slin1237


### PR DESCRIPTION
## Summary
- Update all 16 workspace crate paths from `/<crate>` to `/crates/<crate>` in CODEOWNERS to match the repo restructure
- Add @CatherineSue to `/model_gateway/src/config` and `/model_gateway/src/core` ownership
- Also updates `/crates/mesh` owners to include @llfl

## Test plan
- [x] Verify CODEOWNERS syntax is valid (no CI failures)
- [x] Confirm paths match actual crate locations under `/crates/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code ownership assignments across internal repository configuration.

---

**Note:** This release contains no user-facing changes or new features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->