### PR TITLE
refactor(gateway): simplify openai router internals

### DIFF
--- a/model_gateway/src/routers/openai/context.rs
+++ b/model_gateway/src/routers/openai/context.rs
@@ -34,7 +34,7 @@ pub struct SharedComponents {
 }
 
 pub struct ResponsesComponents {
-    pub shared: SharedComponents,
+    pub shared: Arc<SharedComponents>,
     pub mcp_orchestrator: Arc<McpOrchestrator>,
     pub response_storage: Arc<dyn ResponseStorage>,
     pub conversation_storage: Arc<dyn ConversationStorage>,

--- a/model_gateway/src/routers/openai/mcp/tool_loop.rs
+++ b/model_gateway/src/routers/openai/mcp/tool_loop.rs
@@ -480,18 +480,12 @@ pub(crate) fn inject_mcp_metadata_streaming(
             item.get("type").and_then(|t| t.as_str()) != Some(ItemType::MCP_LIST_TOOLS)
         });
 
-        for binding in mcp_servers.iter().rev() {
-            let list_tools_item =
-                session.build_mcp_list_tools_json(&binding.label, &binding.server_key);
-            output_array.insert(0, list_tools_item);
+        let mut prefix = Vec::with_capacity(mcp_servers.len() + state.mcp_call_items.len());
+        for binding in mcp_servers {
+            prefix.push(session.build_mcp_list_tools_json(&binding.label, &binding.server_key));
         }
-
-        // Use stored transformed items (no reconstruction needed)
-        let mut insert_pos = mcp_servers.len();
-        for item in &state.mcp_call_items {
-            output_array.insert(insert_pos, item.clone());
-            insert_pos += 1;
-        }
+        prefix.extend(state.mcp_call_items.iter().cloned());
+        output_array.splice(0..0, prefix);
     } else if let Some(obj) = response.as_object_mut() {
         let mut output_items = Vec::new();
         for binding in mcp_servers {
@@ -728,24 +722,15 @@ fn build_incomplete_response(
 
         // Add mcp_list_tools and executed mcp_call items at the beginning
         if state.total_calls > 0 || !incomplete_items.is_empty() {
-            for binding in mcp_servers.iter().rev() {
-                let list_tools_item =
-                    session.build_mcp_list_tools_json(&binding.label, &binding.server_key);
-                output_array.insert(0, list_tools_item);
+            let mut prefix = Vec::with_capacity(
+                mcp_servers.len() + state.mcp_call_items.len() + incomplete_items.len(),
+            );
+            for binding in mcp_servers {
+                prefix.push(session.build_mcp_list_tools_json(&binding.label, &binding.server_key));
             }
-
-            // Insert stored transformed items for executed calls (no reconstruction needed)
-            let mut insert_pos = mcp_servers.len();
-            for item in &state.mcp_call_items {
-                output_array.insert(insert_pos, item.clone());
-                insert_pos += 1;
-            }
-
-            // Add incomplete mcp_call items (never executed, so no stored item)
-            for item in incomplete_items {
-                output_array.insert(insert_pos, item);
-                insert_pos += 1;
-            }
+            prefix.extend(state.mcp_call_items.iter().cloned());
+            prefix.extend(incomplete_items);
+            output_array.splice(0..0, prefix);
         }
     }
 

--- a/model_gateway/src/routers/openai/responses/history.rs
+++ b/model_gateway/src/routers/openai/responses/history.rs
@@ -4,8 +4,9 @@
 //! input before forwarding to the upstream provider.
 
 use axum::response::Response;
-use openai_protocol::responses::{
-    ResponseContentPart, ResponseInput, ResponseInputOutputItem, ResponsesRequest,
+use openai_protocol::{
+    event_types::ItemType,
+    responses::{ResponseContentPart, ResponseInput, ResponseInputOutputItem, ResponsesRequest},
 };
 use serde_json::Value;
 use smg_data_connector::{ConversationId, ListParams, ResponseId, SortOrder};
@@ -25,22 +26,18 @@ const MAX_CONVERSATION_HISTORY_ITEMS: usize = 100;
 /// Returns `Ok(original_previous_response_id)` on success, or `Err(response)` on validation failure.
 pub(crate) async fn load_input_history(
     components: &ResponsesComponents,
-    body: &ResponsesRequest,
+    conversation: Option<&str>,
     request_body: &mut ResponsesRequest,
     model: &str,
 ) -> Result<Option<String>, Response> {
-    let original_previous_response_id = request_body
+    let previous_response_id = request_body
         .previous_response_id
-        .clone()
+        .take()
         .filter(|id| !id.is_empty());
 
     // Load items from previous response chain if specified
     let mut chain_items: Option<Vec<ResponseInputOutputItem>> = None;
-    if let Some(prev_id_str) = request_body
-        .previous_response_id
-        .take()
-        .filter(|id| !id.is_empty())
-    {
+    if let Some(prev_id_str) = &previous_response_id {
         let prev_id = ResponseId::from(prev_id_str.as_str());
         match components
             .response_storage
@@ -74,8 +71,8 @@ pub(crate) async fn load_input_history(
     }
 
     // Load conversation history if specified
-    if let Some(conv_id_str) = body.conversation.clone().filter(|id| !id.is_empty()) {
-        let conv_id = ConversationId::from(conv_id_str.as_str());
+    if let Some(conv_id_str) = conversation {
+        let conv_id = ConversationId::from(conv_id_str);
 
         if let Ok(None) = components
             .conversation_storage
@@ -129,7 +126,7 @@ pub(crate) async fn load_input_history(
                                 }
                             }
                         }
-                        "function_call" => {
+                        ItemType::FUNCTION_CALL => {
                             match serde_json::from_value::<ResponseInputOutputItem>(item.content) {
                                 Ok(func_call) => items.push(func_call),
                                 Err(e) => {
@@ -164,7 +161,7 @@ pub(crate) async fn load_input_history(
                     }
                 }
 
-                append_current_input(&mut items, &request_body.input, &conv_id.0);
+                append_current_input(&mut items, &request_body.input, conv_id_str);
                 request_body.input = ResponseInput::Items(items);
             }
             Err(e) => {
@@ -178,12 +175,12 @@ pub(crate) async fn load_input_history(
     // (enforced by the caller in route_responses), so this branch and the
     // conversation branch above never both modify request_body.input.
     if let Some(mut items) = chain_items {
-        let id_suffix = original_previous_response_id.as_deref().unwrap_or("new");
+        let id_suffix = previous_response_id.as_deref().unwrap_or("new");
         append_current_input(&mut items, &request_body.input, id_suffix);
         request_body.input = ResponseInput::Items(items);
     }
 
-    Ok(original_previous_response_id)
+    Ok(previous_response_id)
 }
 
 /// Deserialize ResponseInputOutputItems from a JSON array value

--- a/model_gateway/src/routers/openai/responses/route.rs
+++ b/model_gateway/src/routers/openai/responses/route.rs
@@ -34,7 +34,6 @@ pub(in crate::routers::openai) struct ResponsesRouterContext<'a> {
     pub worker_registry: &'a WorkerRegistry,
     pub provider_registry: &'a ProviderRegistry,
     pub responses_components: &'a Arc<ResponsesComponents>,
-    pub client: &'a reqwest::Client,
 }
 
 /// Route a responses API request to the appropriate upstream worker.
@@ -57,14 +56,17 @@ pub(in crate::routers::openai) async fn route_responses(
         bool_to_static_str(streaming),
     );
 
-    let worker = match WorkerSelector::new(deps.worker_registry, deps.client)
-        .select_worker(&SelectWorkerRequest {
-            model_id: model,
-            headers,
-            provider: Some(ProviderType::OpenAI),
-            ..Default::default()
-        })
-        .await
+    let worker = match WorkerSelector::new(
+        deps.worker_registry,
+        &deps.responses_components.shared.client,
+    )
+    .select_worker(&SelectWorkerRequest {
+        model_id: model,
+        headers,
+        provider: Some(ProviderType::OpenAI),
+        ..Default::default()
+    })
+    .await
     {
         Ok(w) => w,
         Err(response) => {
@@ -82,12 +84,12 @@ pub(in crate::routers::openai) async fn route_responses(
 
     // Validate mutual exclusivity of conversation and previous_response_id
     // Treat empty strings as unset to match other metadata paths
-    let has_conversation = body.conversation.as_ref().is_some_and(|s| !s.is_empty());
+    let conversation = body.conversation.as_ref().filter(|s| !s.is_empty());
     let has_previous_response = body
         .previous_response_id
         .as_ref()
         .is_some_and(|s| !s.is_empty());
-    if has_conversation && has_previous_response {
+    if conversation.is_some() && has_previous_response {
         Metrics::record_router_error(
             metrics_labels::ROUTER_OPENAI,
             metrics_labels::BACKEND_EXTERNAL,
@@ -110,7 +112,7 @@ pub(in crate::routers::openai) async fn route_responses(
 
     let original_previous_response_id = match super::history::load_input_history(
         deps.responses_components,
-        body,
+        conversation.map(String::as_str),
         &mut request_body,
         model,
     )

--- a/model_gateway/src/routers/openai/router.rs
+++ b/model_gateway/src/routers/openai/router.rs
@@ -90,9 +90,7 @@ impl OpenAIRouter {
         });
 
         let responses_components = Arc::new(ResponsesComponents {
-            shared: SharedComponents {
-                client: ctx.client.clone(),
-            },
+            shared: Arc::clone(&shared_components),
             mcp_orchestrator: mcp_orchestrator.clone(),
             response_storage: ctx.response_storage.clone(),
             conversation_storage: ctx.conversation_storage.clone(),
@@ -166,7 +164,6 @@ impl crate::routers::RouterTrait for OpenAIRouter {
             worker_registry: &self.worker_registry,
             provider_registry: &self.provider_registry,
             responses_components: &self.responses_components,
-            client: &self.responses_components.shared.client,
         };
         responses_route::route_responses(&deps, headers, body, model_id).await
     }


### PR DESCRIPTION
## Summary

Cleanup pass on the OpenAI router internals following the recent extraction refactors (#732, #735). Eliminates redundant state, simplifies function signatures, and fixes an O(n*m) performance issue in MCP metadata injection.

Refs: #732, #735

## What changed

- **context.rs**: `ResponsesComponents.shared` changed from owned `SharedComponents` to `Arc<SharedComponents>`, sharing the same allocation with `OpenAIRouter.shared_components`
- **router.rs**: `ResponsesComponents` now clones the existing `shared_components` Arc instead of constructing a second `SharedComponents`; removed redundant `client` field from `ResponsesRouterContext` construction
- **route.rs**: Removed derivable `client` field from `ResponsesRouterContext` struct; extracted `conversation` as `Option<&str>` before passing to `load_input_history` instead of passing two `ResponsesRequest` references
- **history.rs**: Replaced two-`ResponsesRequest`-refs signature with explicit `conversation: Option<&str>` parameter; consolidated redundant `.clone().filter()` + `.take().filter()` of `previous_response_id` into a single `.take()`; replaced raw `"function_call"` string with `ItemType::FUNCTION_CALL` constant
- **tool_loop.rs**: Replaced O(n*m) `Vec::insert(0, ...)` loops in `inject_mcp_metadata_streaming` and `build_incomplete_response` with `Vec::splice(0..0, prefix)` using a pre-built prefix vector

## Why

The recent extraction refactors (#732, #735) faithfully moved code but left some structural redundancies:
- `reqwest::Client` was stored in two separate `SharedComponents` instances
- `ResponsesRouterContext` carried a `client` field always derivable from `responses_components`
- `load_input_history` took two references to `ResponsesRequest` (original + mutable clone) just to read the `conversation` field from the original
- `previous_response_id` was processed twice with the same filter predicate (clone+filter, then take+filter)
- MCP metadata injection used repeated `Vec::insert(0, ...)` causing O(n) shifts per insert

## How

- Changed `ResponsesComponents.shared` to `Arc<SharedComponents>` so both the chat and responses paths share the same allocation (transparent via Deref)
- Removed the `client` field and inlined the access path at the single call site
- Extracted `conversation` in `route_responses` before calling `load_input_history`, passing it as `Option<&str>` to eliminate the need for the original body reference
- Used a single `.take().filter()` and borrowed the result for the chain-loading branch
- Built prefix vectors and used `splice(0..0, ...)` for O(1) amortized prepend

## Test plan

- [x] `cargo check -p smg` passes
- [x] `cargo clippy -p smg --all-targets --all-features -- -D warnings` passes clean
- [x] All changes are internal refactors with no behavioral change — existing integration tests cover the affected paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized shared component initialization for improved memory efficiency.
  * Streamlined MCP tool list handling through bulk operation processing.
  * Simplified conversation history parameter handling and data flow.
  * Removed redundant internal field references and consolidated component access patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->