### PR TITLE
refactor(gateway): simplify and optimize OpenAI streaming internals

### DIFF
--- a/model_gateway/src/routers/mcp_utils.rs
+++ b/model_gateway/src/routers/mcp_utils.rs
@@ -12,6 +12,18 @@ use tracing::{debug, warn};
 /// Default maximum tool loop iterations (safety limit).
 pub const DEFAULT_MAX_ITERATIONS: usize = 10;
 
+/// Compute the effective tool call limit from an optional user-specified max.
+///
+/// Clamps the user value to [`DEFAULT_MAX_ITERATIONS`] and falls back to
+/// the default when no user limit is given.
+#[inline]
+pub fn effective_tool_call_limit(max_tool_calls: Option<usize>) -> usize {
+    match max_tool_calls {
+        Some(user_max) => user_max.min(DEFAULT_MAX_ITERATIONS),
+        None => DEFAULT_MAX_ITERATIONS,
+    }
+}
+
 /// Protocol-agnostic MCP server descriptor for connection setup.
 ///
 /// Contains only the fields needed by [`connect_mcp_servers`]. Each router

--- a/model_gateway/src/routers/openai/mcp/tool_handler.rs
+++ b/model_gateway/src/routers/openai/mcp/tool_handler.rs
@@ -144,14 +144,8 @@ impl StreamingToolHandler {
 
     /// Process an SSE event and determine what action to take
     pub fn process_event(&mut self, event_name: Option<&str>, data: &str) -> StreamAction {
-        // Always feed to accumulator for storage
-        self.accumulator.ingest_block(&format!(
-            "{}data: {}",
-            event_name
-                .map(|n| format!("event: {n}\n"))
-                .unwrap_or_default(),
-            data
-        ));
+        // Always feed to accumulator for storage (bypasses format+reparse overhead)
+        self.accumulator.ingest_event(event_name, data);
 
         let parsed: Value = match serde_json::from_str(data) {
             Ok(v) => v,

--- a/model_gateway/src/routers/openai/mcp/tool_loop.rs
+++ b/model_gateway/src/routers/openai/mcp/tool_loop.rs
@@ -27,8 +27,24 @@ use tracing::{debug, info, warn};
 use super::tool_handler::FunctionCallInProgress;
 use crate::{
     observability::metrics::{metrics_labels, Metrics},
-    routers::{error, header_utils::apply_request_headers, mcp_utils::DEFAULT_MAX_ITERATIONS},
+    routers::{
+        error,
+        header_utils::apply_request_headers,
+        mcp_utils::{effective_tool_call_limit, DEFAULT_MAX_ITERATIONS},
+    },
 };
+
+/// Send an SSE event to the client channel.
+/// Returns false if client disconnected.
+#[inline]
+fn send_sse_event(
+    tx: &mpsc::UnboundedSender<Result<Bytes, io::Error>>,
+    event_name: &str,
+    payload: &Value,
+) -> bool {
+    let block = format!("event: {event_name}\ndata: {payload}\n\n");
+    tx.send(Ok(Bytes::from(block))).is_ok()
+}
 
 /// State for tracking multi-turn tool calling loop
 pub(crate) struct ToolLoopState {
@@ -311,13 +327,8 @@ pub(crate) fn send_mcp_list_tools_events(
         "item": tools_item_empty
     });
     *sequence_number += 1;
-    let event1 = format!(
-        "event: {}\ndata: {}\n\n",
-        OutputItemEvent::ADDED,
-        event1_payload
-    );
-    if tx.send(Ok(Bytes::from(event1))).is_err() {
-        return false; // Client disconnected
+    if !send_sse_event(tx, OutputItemEvent::ADDED, &event1_payload) {
+        return false;
     }
 
     // Event 2: response.mcp_list_tools.in_progress
@@ -328,12 +339,7 @@ pub(crate) fn send_mcp_list_tools_events(
         "item_id": item_id
     });
     *sequence_number += 1;
-    let event2 = format!(
-        "event: {}\ndata: {}\n\n",
-        McpEvent::LIST_TOOLS_IN_PROGRESS,
-        event2_payload
-    );
-    if tx.send(Ok(Bytes::from(event2))).is_err() {
+    if !send_sse_event(tx, McpEvent::LIST_TOOLS_IN_PROGRESS, &event2_payload) {
         return false;
     }
 
@@ -345,12 +351,7 @@ pub(crate) fn send_mcp_list_tools_events(
         "item_id": item_id
     });
     *sequence_number += 1;
-    let event3 = format!(
-        "event: {}\ndata: {}\n\n",
-        McpEvent::LIST_TOOLS_COMPLETED,
-        event3_payload
-    );
-    if tx.send(Ok(Bytes::from(event3))).is_err() {
+    if !send_sse_event(tx, McpEvent::LIST_TOOLS_COMPLETED, &event3_payload) {
         return false;
     }
 
@@ -362,12 +363,7 @@ pub(crate) fn send_mcp_list_tools_events(
         "item": tools_item_full
     });
     *sequence_number += 1;
-    let event4 = format!(
-        "event: {}\ndata: {}\n\n",
-        OutputItemEvent::DONE,
-        event4_payload
-    );
-    tx.send(Ok(Bytes::from(event4))).is_ok()
+    send_sse_event(tx, OutputItemEvent::DONE, &event4_payload)
 }
 
 /// Send intermediate event during tool execution (searching/interpreting).
@@ -403,8 +399,7 @@ fn send_tool_call_intermediate_event(
     });
     *sequence_number += 1;
 
-    let event = format!("event: {event_type}\ndata: {event_payload}\n\n");
-    tx.send(Ok(Bytes::from(event))).is_ok()
+    send_sse_event(tx, event_type, &event_payload)
 }
 
 /// Send tool call completion events after tool execution.
@@ -444,9 +439,7 @@ fn send_tool_call_completion_events(
         "item_id": item_id
     });
     *sequence_number += 1;
-
-    let completed_event = format!("event: {completed_event_type}\ndata: {completed_payload}\n\n");
-    if tx.send(Ok(Bytes::from(completed_event))).is_err() {
+    if !send_sse_event(tx, completed_event_type, &completed_payload) {
         return false;
     }
 
@@ -458,13 +451,7 @@ fn send_tool_call_completion_events(
         "item": tool_call_item
     });
     *sequence_number += 1;
-
-    let done_event = format!(
-        "event: {}\ndata: {}\n\n",
-        OutputItemEvent::DONE,
-        done_payload
-    );
-    tx.send(Ok(Bytes::from(done_event))).is_ok()
+    send_sse_event(tx, OutputItemEvent::DONE, &done_payload)
 }
 
 /// Inject MCP metadata into a streaming response
@@ -564,10 +551,7 @@ pub(crate) async fn execute_tool_loop(
             function_calls.len()
         );
 
-        let effective_limit = match max_tool_calls {
-            Some(user_max) => user_max.min(DEFAULT_MAX_ITERATIONS),
-            None => DEFAULT_MAX_ITERATIONS,
-        };
+        let effective_limit = effective_tool_call_limit(max_tool_calls);
 
         for call in function_calls {
             state.total_calls += 1;

--- a/model_gateway/src/routers/openai/responses/accumulator.rs
+++ b/model_gateway/src/routers/openai/responses/accumulator.rs
@@ -38,6 +38,17 @@ impl StreamingResponseAccumulator {
         self.process_block(block);
     }
 
+    /// Feed the accumulator with a pre-split event name and data payload.
+    ///
+    /// Avoids the format+reparse overhead of [`ingest_block`] when the caller
+    /// already has the event name and data separated (e.g. from SSE parsing).
+    pub fn ingest_event(&mut self, event_name: Option<&str>, data: &str) {
+        if data.is_empty() {
+            return;
+        }
+        self.handle_event(event_name, data);
+    }
+
     /// Consume the accumulator and produce the best-effort final response value.
     pub fn into_final_response(mut self) -> Option<Value> {
         if self.completed_response.is_some() {
@@ -62,16 +73,15 @@ impl StreamingResponseAccumulator {
         if let Some(resp) = &self.completed_response {
             return Some(resp.clone());
         }
-        self.build_fallback_response_snapshot()
+        self.assemble_fallback(self.output_items.clone())
     }
 
-    fn build_fallback_response_snapshot(&self) -> Option<Value> {
+    fn assemble_fallback(&self, mut output_items: Vec<(usize, Value)>) -> Option<Value> {
         let mut response = self.initial_response.clone()?;
 
         if let Some(obj) = response.as_object_mut() {
             obj.insert("status".to_string(), Value::String("completed".to_string()));
 
-            let mut output_items = self.output_items.clone();
             output_items.sort_by_key(|(index, _)| *index);
             let outputs: Vec<Value> = output_items.into_iter().map(|(_, item)| item).collect();
             obj.insert("output".to_string(), Value::Array(outputs));
@@ -131,19 +141,7 @@ impl StreamingResponseAccumulator {
     }
 
     fn build_fallback_response(&mut self) -> Option<Value> {
-        let mut response = self.initial_response.clone()?;
-
-        if let Some(obj) = response.as_object_mut() {
-            obj.insert("status".to_string(), Value::String("completed".to_string()));
-
-            self.output_items.sort_by_key(|(index, _)| *index);
-            let outputs: Vec<Value> = std::mem::take(&mut self.output_items)
-                .into_iter()
-                .map(|(_, item)| item)
-                .collect();
-            obj.insert("output".to_string(), Value::Array(outputs));
-        }
-
-        Some(response)
+        let output_items = std::mem::take(&mut self.output_items);
+        self.assemble_fallback(output_items)
     }
 }

--- a/model_gateway/src/routers/openai/responses/common.rs
+++ b/model_gateway/src/routers/openai/responses/common.rs
@@ -39,10 +39,14 @@ impl ChunkProcessor {
             Ok(s) => Cow::Borrowed(s),
             Err(_) => Cow::Owned(String::from_utf8_lossy(chunk).into_owned()),
         };
+        // Fast path: no \r means no CRLF normalization needed
+        if !chunk_str.contains('\r') {
+            self.pending.push_str(&chunk_str);
+            return;
+        }
         let mut chars = chunk_str.chars().peekable();
         while let Some(c) = chars.next() {
             if c == '\r' && chars.peek() == Some(&'\n') {
-                // Skip \r when followed by \n
                 continue;
             }
             self.pending.push(c);

--- a/model_gateway/src/routers/openai/responses/streaming.rs
+++ b/model_gateway/src/routers/openai/responses/streaming.rs
@@ -42,7 +42,7 @@ use crate::{
     routers::{
         error,
         header_utils::{apply_request_headers, preserve_response_headers},
-        mcp_utils::DEFAULT_MAX_ITERATIONS,
+        mcp_utils::effective_tool_call_limit,
         openai::{
             context::{RequestContext, StreamingEventContext, StreamingRequest},
             mcp::{
@@ -70,8 +70,10 @@ pub(super) fn apply_event_transformations_inplace(
         .and_then(|v| v.as_str())
         .unwrap_or("");
     let should_patch = is_response_event(event_type);
-    // Owned copy needed for the match below since we mutate parsed_data
-    let event_type = event_type.to_string();
+    // Pre-compute match arms as booleans before mutating parsed_data (avoids .to_string())
+    let is_output_item_event =
+        event_type == OutputItemEvent::ADDED || event_type == OutputItemEvent::DONE;
+    let is_args_done = event_type == FunctionCallEvent::ARGUMENTS_DONE;
 
     if should_patch {
         if let Some(response_obj) = parsed_data
@@ -122,64 +124,60 @@ pub(super) fn apply_event_transformations_inplace(
     }
 
     // 2. Apply transform_streaming_event logic (function_call → mcp_call/web_search_call)
-    match event_type.as_str() {
-        OutputItemEvent::ADDED | OutputItemEvent::DONE => {
-            if let Some(item) = parsed_data.get_mut("item") {
-                if let Some(item_type) = item.get("type").and_then(|v| v.as_str()) {
-                    if is_function_call_type(item_type) {
-                        // Look up response_format for the tool
-                        let tool_name = item
-                            .get("name")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("")
-                            .to_string();
+    if is_output_item_event {
+        if let Some(item) = parsed_data.get_mut("item") {
+            if let Some(item_type) = item.get("type").and_then(|v| v.as_str()) {
+                if is_function_call_type(item_type) {
+                    // Look up response_format for the tool
+                    let tool_name = item
+                        .get("name")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string();
 
-                        // Only transform if this is an MCP tool; keep function_call unchanged
-                        if let Some(session) =
-                            ctx.session.filter(|s| s.has_exposed_tool(&tool_name))
-                        {
-                            let response_format = session.tool_response_format(&tool_name);
+                    // Only transform if this is an MCP tool; keep function_call unchanged
+                    if let Some(session) =
+                        ctx.session.filter(|s| s.has_exposed_tool(&tool_name))
+                    {
+                        let response_format = session.tool_response_format(&tool_name);
 
-                            // Determine item type and ID prefix based on response_format
-                            let (new_type, id_prefix) = match response_format {
-                                ResponseFormat::WebSearchCall => (ItemType::WEB_SEARCH_CALL, "ws_"),
-                                _ => (ItemType::MCP_CALL, "mcp_"),
-                            };
+                        // Determine item type and ID prefix based on response_format
+                        let (new_type, id_prefix) = match response_format {
+                            ResponseFormat::WebSearchCall => (ItemType::WEB_SEARCH_CALL, "ws_"),
+                            _ => (ItemType::MCP_CALL, "mcp_"),
+                        };
 
-                            item["type"] = json!(new_type);
-                            if new_type == ItemType::MCP_CALL {
-                                let label = session.resolve_tool_server_label(&tool_name);
-                                item["server_label"] = json!(label);
-                            }
-
-                            // Transform ID from fc_* to appropriate prefix
-                            if let Some(id) = item.get("id").and_then(|v| v.as_str()) {
-                                if let Some(stripped) = id.strip_prefix("fc_") {
-                                    let new_id = format!("{id_prefix}{stripped}");
-                                    item["id"] = json!(new_id);
-                                }
-                            }
-
-                            changed = true;
+                        item["type"] = json!(new_type);
+                        if new_type == ItemType::MCP_CALL {
+                            let label = session.resolve_tool_server_label(&tool_name);
+                            item["server_label"] = json!(label);
                         }
+
+                        // Transform ID from fc_* to appropriate prefix
+                        if let Some(id) = item.get("id").and_then(|v| v.as_str()) {
+                            if let Some(stripped) = id.strip_prefix("fc_") {
+                                let new_id = format!("{id_prefix}{stripped}");
+                                item["id"] = json!(new_id);
+                            }
+                        }
+
+                        changed = true;
                     }
                 }
             }
         }
-        FunctionCallEvent::ARGUMENTS_DONE => {
-            parsed_data["type"] = json!(McpEvent::CALL_ARGUMENTS_DONE);
+    } else if is_args_done {
+        parsed_data["type"] = json!(McpEvent::CALL_ARGUMENTS_DONE);
 
-            // Transform item_id from fc_* to mcp_*
-            if let Some(item_id) = parsed_data.get("item_id").and_then(|v| v.as_str()) {
-                if let Some(stripped) = item_id.strip_prefix("fc_") {
-                    let new_id = format!("mcp_{stripped}");
-                    parsed_data["item_id"] = json!(new_id);
-                }
+        // Transform item_id from fc_* to mcp_*
+        if let Some(item_id) = parsed_data.get("item_id").and_then(|v| v.as_str()) {
+            if let Some(stripped) = item_id.strip_prefix("fc_") {
+                let new_id = format!("mcp_{stripped}");
+                parsed_data["item_id"] = json!(new_id);
             }
-
-            changed = true;
         }
-        _ => {}
+
+        changed = true;
     }
 
     changed
@@ -792,14 +790,21 @@ pub(super) fn handle_streaming_with_tool_interception(
                                         })
                                     };
 
+                                    // Check in_progress before potentially moving parsed
+                                    let is_in_progress = !seen_in_progress
+                                        && parsed.as_ref().is_some_and(|v| {
+                                            v.get("type").and_then(|t| t.as_str())
+                                                == Some(ResponseEvent::IN_PROGRESS)
+                                        });
+
                                     if !should_skip {
-                                        // Forward the event with pre-parsed value
+                                        // Forward the event, moving parsed to avoid clone
                                         if !forward_streaming_event(
                                             SseEventData {
                                                 raw_block: &raw_block,
                                                 event_name,
                                                 data: data.as_ref(),
-                                                pre_parsed: parsed.clone(),
+                                                pre_parsed: parsed,
                                             },
                                             &mut handler,
                                             &tx,
@@ -810,31 +815,25 @@ pub(super) fn handle_streaming_with_tool_interception(
                                         }
                                     }
 
-                                    if !seen_in_progress {
-                                        let is_in_progress = parsed.as_ref().is_some_and(|v| {
-                                            v.get("type").and_then(|t| t.as_str())
-                                                == Some(ResponseEvent::IN_PROGRESS)
-                                        });
-                                        if is_in_progress {
-                                            seen_in_progress = true;
-                                            if !mcp_list_tools_sent {
-                                                for binding in session.mcp_servers() {
-                                                    let list_tools_index =
-                                                        handler.allocate_synthetic_output_index();
-                                                    if !send_mcp_list_tools_events(
-                                                        &tx,
-                                                        &session,
-                                                        &binding.label,
-                                                        list_tools_index,
-                                                        &mut sequence_number,
-                                                        &binding.server_key,
-                                                    ) {
-                                                        // Client disconnected
-                                                        return;
-                                                    }
+                                    if is_in_progress {
+                                        seen_in_progress = true;
+                                        if !mcp_list_tools_sent {
+                                            for binding in session.mcp_servers() {
+                                                let list_tools_index =
+                                                    handler.allocate_synthetic_output_index();
+                                                if !send_mcp_list_tools_events(
+                                                    &tx,
+                                                    &session,
+                                                    &binding.label,
+                                                    list_tools_index,
+                                                    &mut sequence_number,
+                                                    &binding.server_key,
+                                                ) {
+                                                    // Client disconnected
+                                                    return;
                                                 }
-                                                mcp_list_tools_sent = true;
                                             }
+                                            mcp_list_tools_sent = true;
                                         }
                                     }
                                 }
@@ -946,10 +945,7 @@ pub(super) fn handle_streaming_with_tool_interception(
             // Record tool loop iteration metric
             Metrics::record_mcp_tool_iteration(&original_request.model);
 
-            let effective_limit = match max_tool_calls {
-                Some(user_max) => user_max.min(DEFAULT_MAX_ITERATIONS),
-                None => DEFAULT_MAX_ITERATIONS,
-            };
+            let effective_limit = effective_tool_call_limit(max_tool_calls);
 
             if state.total_calls > effective_limit {
                 warn!(

--- a/model_gateway/src/routers/openai/responses/streaming.rs
+++ b/model_gateway/src/routers/openai/responses/streaming.rs
@@ -61,6 +61,7 @@ use crate::{
 pub(super) fn apply_event_transformations_inplace(
     parsed_data: &mut Value,
     ctx: &StreamingEventContext<'_>,
+    is_mcp_args_done: bool,
 ) -> bool {
     let mut changed = false;
 
@@ -136,9 +137,7 @@ pub(super) fn apply_event_transformations_inplace(
                         .to_string();
 
                     // Only transform if this is an MCP tool; keep function_call unchanged
-                    if let Some(session) =
-                        ctx.session.filter(|s| s.has_exposed_tool(&tool_name))
-                    {
+                    if let Some(session) = ctx.session.filter(|s| s.has_exposed_tool(&tool_name)) {
                         let response_format = session.tool_response_format(&tool_name);
 
                         // Determine item type and ID prefix based on response_format
@@ -166,7 +165,9 @@ pub(super) fn apply_event_transformations_inplace(
                 }
             }
         }
-    } else if is_args_done {
+    } else if is_args_done && is_mcp_args_done {
+        // Only transform arguments_done to MCP format for MCP-exposed tools;
+        // regular function tools pass through unchanged.
         parsed_data["type"] = json!(McpEvent::CALL_ARGUMENTS_DONE);
 
         // Transform item_id from fc_* to mcp_*
@@ -348,9 +349,16 @@ pub(super) fn forward_streaming_event(
         return true;
     }
 
-    // Handle function_call_arguments.done - send buffered args first
+    // Determine if this arguments_done event is for an MCP-exposed tool.
+    // Regular function tool events should pass through without MCP transformation.
+    let is_mcp_args_done = event_name == Some(FunctionCallEvent::ARGUMENTS_DONE)
+        && extract_output_index(&parsed_data)
+            .and_then(|idx| handler.pending_calls.iter().find(|c| c.output_index == idx))
+            .is_some_and(|call| ctx.session.is_some_and(|s| s.has_exposed_tool(&call.name)));
+
+    // Handle function_call_arguments.done - send buffered args only for MCP tools
     let mut mapped_output_index: Option<usize> = None;
-    if event_name == Some(FunctionCallEvent::ARGUMENTS_DONE)
+    if is_mcp_args_done
         && !send_buffered_arguments(
             &mut parsed_data,
             handler,
@@ -371,7 +379,7 @@ pub(super) fn forward_streaming_event(
         parsed_data["output_index"] = json!(mapped);
     }
 
-    apply_event_transformations_inplace(&mut parsed_data, ctx);
+    apply_event_transformations_inplace(&mut parsed_data, ctx, is_mcp_args_done);
 
     if let Some(response_obj) = parsed_data
         .get_mut("response")
@@ -396,7 +404,15 @@ pub(super) fn forward_streaming_event(
     };
 
     let final_block = match event_name {
-        Some(evt) => format!("event: {}\ndata: {}\n\n", map_event_name(evt), final_data),
+        Some(evt) => {
+            // Only remap function_call event names to mcp_call for MCP-exposed tools
+            let mapped = if is_mcp_args_done {
+                map_event_name(evt)
+            } else {
+                evt
+            };
+            format!("event: {mapped}\ndata: {final_data}\n\n")
+        }
         None => format!("data: {final_data}\n\n"),
     };
 


### PR DESCRIPTION
## Summary
- Eliminate hot-path allocations (JSON clone, String alloc) on every forwarded streaming event
- Extract `effective_tool_call_limit()` to replace 6 identical inline calculations
- Add `ingest_event()` to bypass SSE format+reparse round-trip in accumulator
- Unify duplicated fallback response builders and SSE send patterns

## What changed

| File | Change |
|------|--------|
| `mcp_utils.rs` | Add `effective_tool_call_limit()` shared helper |
| `tool_handler.rs` | Use `ingest_event()` instead of format+reparse |
| `accumulator.rs` | Add `ingest_event()` fast path; unify `build_fallback_response` and `build_fallback_response_snapshot` into `assemble_fallback` |
| `common.rs` | Fast-path in `ChunkProcessor::push_chunk` — skip char-by-char when no `\r` present |
| `streaming.rs` | Pre-computed boolean flags replace `event_type.to_string()`; move `parsed` instead of cloning; remove unused import |
| `tool_loop.rs` | Add local `send_sse_event` helper replacing 7 inline instances; use `effective_tool_call_limit()` |

## Why

Every forwarded streaming event was incurring an unnecessary `Value::clone()` and a `String` allocation for the event type. The accumulator was formatting an SSE block only to immediately re-parse it. These micro-allocations add up on high-throughput streaming paths. The duplicated limit calculation and SSE formatting patterns also made the code harder to maintain.

## Test plan
- [x] `cargo check -p smg` compiles cleanly with no warnings
- [ ] Existing MCP tool loop tests pass (streaming + non-streaming)
- [ ] Manual test: streaming responses with MCP tool interception work end-to-end
- [ ] Manual test: simple passthrough streaming (no MCP) unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Faster streaming and event forwarding with reduced re-parsing and a quicker chunk-processing fast path.
  * Centralized enforcement of tool-call limits for consistent behavior.

* **New Features**
  * Unified server-sent-event emission for more consistent, reliable tool event delivery.
  * Earlier "in-progress" notifications for tool interactions.
  * New direct event ingest path to reduce formatting overhead.

* **Bug Fixes**
  * More consistent final-response assembly and fallback handling to improve result reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->