### PR TITLE
feat(gateway): add message_utils and MessagePreparationStage for Messages API

### DIFF
--- a/model_gateway/src/routers/grpc/context.rs
+++ b/model_gateway/src/routers/grpc/context.rs
@@ -408,10 +408,6 @@ impl RequestContext {
 
     /// Get Arc clone of messages request (panics if not messages)
     #[expect(
-        dead_code,
-        reason = "scaffolding for Messages API pipeline, wired in follow-up PR"
-    )]
-    #[expect(
         clippy::panic,
         reason = "typed accessor: caller guarantees variant via RequestType construction"
     )]

--- a/model_gateway/src/routers/grpc/regular/stages/messages/mod.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/messages/mod.rs
@@ -1,0 +1,9 @@
+//! Messages API endpoint pipeline stages
+//!
+//! These stages handle Messages API-specific preprocessing.
+//! Request building and response processing will be added in follow-up PRs.
+
+mod preparation;
+
+#[expect(unused_imports, reason = "wired in follow-up PR (pipeline factory)")]
+pub(crate) use preparation::MessagePreparationStage;

--- a/model_gateway/src/routers/grpc/regular/stages/messages/preparation.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/messages/preparation.rs
@@ -1,0 +1,158 @@
+//! Message API preparation stage: Convert tools, process messages, tokenize, build constraints
+#![allow(dead_code)] // wired in follow-up PR (pipeline factory)
+
+use async_trait::async_trait;
+use axum::response::Response;
+use openai_protocol::{common::StringOrArray, messages::CreateMessageRequest};
+use tracing::error;
+
+use crate::routers::{
+    error,
+    grpc::{
+        common::stages::PipelineStage,
+        context::{PreparationOutput, RequestContext},
+        utils::{self, message_utils},
+    },
+};
+
+/// Message API preparation stage
+///
+/// Parallel to `ChatPreparationStage` but works with `CreateMessageRequest`.
+/// Converts Anthropic Messages API types into the internal chat template format,
+/// tokenizes, and builds tool constraints.
+pub(crate) struct MessagePreparationStage;
+
+#[async_trait]
+impl PipelineStage for MessagePreparationStage {
+    async fn execute(&self, ctx: &mut RequestContext) -> Result<Option<Response>, Response> {
+        let request = ctx.messages_request_arc();
+        self.prepare_messages(ctx, &request).await?;
+        Ok(None)
+    }
+
+    fn name(&self) -> &'static str {
+        "MessagePreparation"
+    }
+}
+
+impl MessagePreparationStage {
+    #[expect(
+        clippy::unused_async,
+        reason = "multimodal processing will add .await in follow-up PR"
+    )]
+    async fn prepare_messages(
+        &self,
+        ctx: &mut RequestContext,
+        request: &CreateMessageRequest,
+    ) -> Result<(), Response> {
+        // Step 0: Resolve tokenizer from registry (cached for reuse in response processing)
+        let tokenizer = utils::resolve_tokenizer(ctx, "MessagePreparationStage::prepare_messages")
+            .map_err(|e| *e)?;
+
+        // Step 1: Convert Messages API tools to chat tools and filter by tool_choice
+        let chat_tools = request
+            .tools
+            .as_deref()
+            .map(message_utils::extract_chat_tools);
+
+        let chat_tool_choice = request
+            .tool_choice
+            .as_ref()
+            .map(message_utils::convert_message_tool_choice);
+
+        // Filter tools by tool_choice (reuse chat utility)
+        let filtered_tools = match (&chat_tools, &chat_tool_choice) {
+            (Some(tools), Some(tc)) => {
+                utils::filter_tools_by_tool_choice(tools, Some(tc)).unwrap_or_else(|| tools.clone())
+            }
+            (Some(tools), None) => tools.clone(),
+            _ => Vec::new(),
+        };
+
+        let tools_for_template = if filtered_tools.is_empty() {
+            None
+        } else {
+            Some(filtered_tools.as_slice())
+        };
+
+        // Step 2: Process messages and apply chat template
+        let processed_messages = match message_utils::process_messages(
+            request,
+            &*tokenizer,
+            tools_for_template,
+        ) {
+            Ok(msgs) => msgs,
+            Err(e) => {
+                error!(function = "MessagePreparationStage::execute", error = %e, "Failed to process messages");
+                return Err(error::bad_request("process_messages_failed", e));
+            }
+        };
+
+        // Step 3: Tokenize the processed text
+        let encoding = match tokenizer.encode(&processed_messages.text, false) {
+            Ok(encoding) => encoding,
+            Err(e) => {
+                error!(function = "MessagePreparationStage::execute", error = %e, "Tokenization failed");
+                return Err(error::internal_error(
+                    "tokenization_failed",
+                    format!("Tokenization failed: {e}"),
+                ));
+            }
+        };
+
+        let token_ids = encoding.token_ids().to_vec();
+
+        // Multimodal processing — postponed (see design doc appendix)
+
+        // Step 4: Build tool constraints if tools present
+        let tool_call_constraint = if filtered_tools.is_empty() {
+            None
+        } else {
+            utils::generate_tool_constraints(
+                &filtered_tools,
+                chat_tool_choice.as_ref(),
+                &request.model,
+            )
+            .map_err(|e| {
+                error!(function = "MessagePreparationStage::execute", error = %e, "Invalid tool configuration");
+                error::bad_request(
+                    "invalid_tool_configuration",
+                    format!("Invalid tool configuration: {e}"),
+                )
+            })?
+        };
+
+        // Step 5: Create stop sequence decoder
+        let stop_for_decoder = request
+            .stop_sequences
+            .as_ref()
+            .map(|seqs| StringOrArray::Array(seqs.clone()));
+
+        let stop_decoder = utils::create_stop_decoder(
+            &tokenizer,
+            stop_for_decoder.as_ref(),
+            None,  // no stop_token_ids in Messages API
+            false, // skip_special_tokens default
+            false, // no_stop_trim default
+        );
+
+        // Store results in context
+        ctx.state.preparation = Some(PreparationOutput {
+            original_text: Some(processed_messages.text.clone()),
+            token_ids,
+            processed_messages: Some(processed_messages),
+            tool_constraints: tool_call_constraint,
+            filtered_request: None, // Messages doesn't use Cow<ChatCompletionRequest> pattern
+            // Harmony fields (not used for messages)
+            harmony_mode: false,
+            selection_text: None,
+            harmony_messages: None,
+            harmony_stop_ids: None,
+        });
+
+        // Store stop decoder for reuse in response processing
+        ctx.state.response.stop_decoder = Some(stop_decoder);
+
+        Ok(())
+    }
+}

--- a/model_gateway/src/routers/grpc/regular/stages/mod.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/mod.rs
@@ -6,6 +6,7 @@ pub(crate) mod chat;
 pub(crate) mod classify;
 pub(crate) mod embedding;
 pub(crate) mod generate;
+pub(crate) mod messages;
 pub(crate) mod preparation;
 pub(crate) mod request_building;
 pub(crate) mod response_processing;

--- a/model_gateway/src/routers/grpc/regular/stages/preparation.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/preparation.rs
@@ -43,20 +43,15 @@ impl PipelineStage for PreparationStage {
         match &ctx.input.request_type {
             RequestType::Chat(_) => self.chat_stage.execute(ctx).await,
             RequestType::Generate(_) => self.generate_stage.execute(ctx).await,
-            other => {
-                let type_name = match other {
-                    RequestType::Embedding(_) => "Embedding",
-                    RequestType::Classify(_) => "Classify",
-                    RequestType::Responses(_) => "Responses",
-                    _ => "Unknown",
-                };
+            request_type => {
                 error!(
                     function = "PreparationStage::execute",
-                    "RequestType::{type_name} reached regular preparation stage"
+                    request_type = %request_type,
+                    "{request_type} request type reached regular preparation stage"
                 );
                 Err(grpc_error::internal_error(
                     "wrong_pipeline",
-                    format!("RequestType::{type_name} should use its dedicated pipeline"),
+                    format!("{request_type} should use its dedicated pipeline"),
                 ))
             }
         }

--- a/model_gateway/src/routers/grpc/utils/chat_utils.rs
+++ b/model_gateway/src/routers/grpc/utils/chat_utils.rs
@@ -91,7 +91,7 @@ pub(crate) fn resolve_tokenizer(
 
 /// Process tool call arguments in messages
 /// Per Transformers docs, tool call arguments in assistant messages should be dicts
-fn process_tool_call_arguments(messages: &mut [Value]) -> Result<(), String> {
+pub(crate) fn process_tool_call_arguments(messages: &mut [Value]) -> Result<(), String> {
     for msg in messages {
         let role = msg.get("role").and_then(|v| v.as_str());
         if role != Some("assistant") {

--- a/model_gateway/src/routers/grpc/utils/message_utils.rs
+++ b/model_gateway/src/routers/grpc/utils/message_utils.rs
@@ -1,0 +1,581 @@
+//! Message API utilities for converting Anthropic Messages API types
+//! into the internal chat template format.
+//!
+//! Parallel to `chat_utils.rs` but works with `CreateMessageRequest` / `InputMessage`
+//! instead of `ChatCompletionRequest` / `ChatMessage`.
+#![allow(dead_code)] // wired in follow-up PR (pipeline factory)
+
+use std::collections::HashMap;
+
+use llm_tokenizer::{
+    chat_template::{ChatTemplateContentFormat, ChatTemplateParams},
+    traits::Tokenizer,
+};
+use openai_protocol::{
+    common::{self, StringOrArray, Tool as ChatTool, ToolChoice as ChatToolChoice},
+    messages::{
+        self, CreateMessageRequest, InputContent, InputContentBlock, InputMessage, SystemContent,
+        ThinkingConfig, ToolResultContent,
+    },
+};
+use serde_json::{json, Value};
+
+use super::chat_utils;
+use crate::routers::grpc::ProcessedMessages;
+
+// ============================================================================
+// Top-level processing function
+// ============================================================================
+
+/// Process messages from a CreateMessageRequest and apply the chat template.
+///
+/// Parallel to `process_chat_messages()` in chat_utils, but works with
+/// Anthropic Messages API types. Converts InputMessages to JSON values
+/// that the chat template expects, then applies the template.
+pub fn process_messages(
+    request: &CreateMessageRequest,
+    tokenizer: &dyn Tokenizer,
+    chat_tools: Option<&[ChatTool]>,
+) -> Result<ProcessedMessages, String> {
+    let content_format = tokenizer.chat_template_content_format();
+
+    // Step 1: Convert InputMessages to chat template JSON values
+    let mut transformed_messages =
+        process_message_content_format(&request.messages, content_format)?;
+
+    // Step 2: Prepend system message if present
+    if let Some(system) = &request.system {
+        let system_text = match system {
+            SystemContent::String(s) => s.clone(),
+            SystemContent::Blocks(blocks) => blocks
+                .iter()
+                .map(|b| b.text.as_str())
+                .collect::<Vec<_>>()
+                .join("\n"),
+        };
+        transformed_messages.insert(0, json!({"role": "system", "content": system_text}));
+    }
+
+    // Step 3: Process tool call arguments in assistant messages (reuse from chat_utils)
+    chat_utils::process_tool_call_arguments(&mut transformed_messages)?;
+
+    // Step 4: Serialize tools to JSON values for template processing
+    let tools_json: Option<Vec<Value>> = chat_tools
+        .map(|tools| {
+            tools
+                .iter()
+                .map(serde_json::to_value)
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .transpose()
+        .map_err(|e| format!("Failed to serialize tools: {e}"))?;
+
+    // Step 5: Build template kwargs from ThinkingConfig
+    let mut combined_template_kwargs = HashMap::new();
+
+    if let Some(ThinkingConfig::Enabled { budget_tokens }) = &request.thinking {
+        // Pass thinking config as template kwargs
+        combined_template_kwargs.insert(
+            "thinking".to_string(),
+            json!({"type": "enabled", "budget_tokens": budget_tokens}),
+        );
+    }
+
+    let final_template_kwargs = if combined_template_kwargs.is_empty() {
+        None
+    } else {
+        Some(&combined_template_kwargs)
+    };
+
+    // Step 6: Apply chat template
+    let params = ChatTemplateParams {
+        add_generation_prompt: true,
+        tools: tools_json.as_deref(),
+        template_kwargs: final_template_kwargs,
+        ..Default::default()
+    };
+
+    let formatted_text = tokenizer
+        .apply_chat_template(&transformed_messages, params)
+        .map_err(|e| format!("Failed to apply chat template: {e}"))?;
+
+    // Step 7: Build ProcessedMessages
+    let stop_sequences = request
+        .stop_sequences
+        .as_ref()
+        .map(|seqs| StringOrArray::Array(seqs.clone()));
+
+    Ok(ProcessedMessages {
+        text: formatted_text,
+        multimodal_intermediate: None, // Multimodal postponed
+        stop_sequences,
+    })
+}
+
+// ============================================================================
+// InputMessage → JSON conversion
+// ============================================================================
+
+/// Convert InputMessage array to JSON Values for the chat template.
+///
+/// Mirrors `process_content_format()` in chat_utils but works with
+/// `InputMessage` instead of `ChatMessage`.
+///
+/// Key conversion rules:
+/// - User messages with String content → `{"role": "user", "content": "text"}`
+/// - User messages with Blocks → text/image blocks stay as user content,
+///   ToolResult blocks become separate `{"role": "tool", ...}` messages
+/// - Assistant messages → `{"role": "assistant", "content": ..., "tool_calls": [...], "reasoning_content": ...}`
+pub(crate) fn process_message_content_format(
+    messages: &[InputMessage],
+    content_format: ChatTemplateContentFormat,
+) -> Result<Vec<Value>, String> {
+    messages.iter().try_fold(Vec::new(), |mut result, message| {
+        match message.role {
+            messages::Role::User => {
+                convert_user_message(&message.content, content_format, &mut result);
+            }
+            messages::Role::Assistant => {
+                result.push(convert_assistant_message(&message.content, content_format));
+            }
+        }
+        Ok(result)
+    })
+}
+
+/// Convert a user message content to JSON values.
+///
+/// User messages may contain mixed content: text, images, and tool results.
+/// Tool results are split into separate "tool" role messages (the chat template
+/// expects tool results as their own messages, not embedded in user content).
+fn convert_user_message(
+    content: &InputContent,
+    content_format: ChatTemplateContentFormat,
+    result: &mut Vec<Value>,
+) {
+    match content {
+        InputContent::String(text) => {
+            result.push(json!({"role": "user", "content": text}));
+        }
+        InputContent::Blocks(blocks) => {
+            let (user_parts, tool_msgs) = blocks.iter().fold(
+                (Vec::new(), Vec::new()),
+                |(mut user_parts, mut tool_msgs), block| {
+                    match block {
+                        InputContentBlock::Text(t) => {
+                            user_parts.push(json!({"type": "text", "text": t.text}));
+                        }
+                        InputContentBlock::Image(_) => {
+                            user_parts.push(json!({"type": "image"}));
+                        }
+                        InputContentBlock::Document(_) => {
+                            user_parts.push(json!({"type": "document"}));
+                        }
+                        InputContentBlock::ToolResult(tr) => {
+                            tool_msgs.push(json!({
+                                "role": "tool",
+                                "tool_call_id": tr.tool_use_id,
+                                "content": extract_tool_result_text(tr)
+                            }));
+                        }
+                        _ => {}
+                    }
+                    (user_parts, tool_msgs)
+                },
+            );
+
+            if !user_parts.is_empty() {
+                let content = format_content_parts(user_parts, content_format);
+                result.push(json!({"role": "user", "content": content}));
+            }
+            result.extend(tool_msgs);
+        }
+    }
+}
+
+/// Extract text content from a ToolResult block.
+fn extract_tool_result_text(tool_result: &messages::ToolResultBlock) -> String {
+    match &tool_result.content {
+        Some(ToolResultContent::String(s)) => s.clone(),
+        Some(ToolResultContent::Blocks(blocks)) => blocks
+            .iter()
+            .filter_map(|b| match b {
+                messages::ToolResultContentBlock::Text(t) => Some(t.text.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("\n"),
+        None => String::new(),
+    }
+}
+
+/// Convert an assistant message content to a single JSON value.
+///
+/// Extracts text content, tool calls, and reasoning/thinking into the
+/// appropriate JSON fields that the chat template expects.
+fn convert_assistant_message(
+    content: &InputContent,
+    _content_format: ChatTemplateContentFormat,
+) -> Value {
+    match content {
+        InputContent::String(text) => json!({"role": "assistant", "content": text}),
+        InputContent::Blocks(blocks) => {
+            let (text_parts, tool_calls, thinking_parts) = blocks.iter().fold(
+                (
+                    Vec::<String>::new(),
+                    Vec::<Value>::new(),
+                    Vec::<String>::new(),
+                ),
+                |(mut texts, mut tools, mut thinking), block| {
+                    match block {
+                        InputContentBlock::Text(t) => texts.push(t.text.clone()),
+                        InputContentBlock::ToolUse(tu) => tools.push(json!({
+                            "id": tu.id,
+                            "type": "function",
+                            "function": {
+                                "name": tu.name,
+                                "arguments": serde_json::to_string(&tu.input)
+                                    .unwrap_or_else(|_| "{}".to_string())
+                            }
+                        })),
+                        InputContentBlock::Thinking(t) => thinking.push(t.thinking.clone()),
+                        _ => {}
+                    }
+                    (texts, tools, thinking)
+                },
+            );
+
+            let mut obj = serde_json::Map::new();
+            obj.insert("role".into(), Value::String("assistant".into()));
+
+            if !text_parts.is_empty() {
+                obj.insert("content".into(), Value::String(text_parts.join("")));
+            }
+            if !tool_calls.is_empty() {
+                obj.insert("tool_calls".into(), Value::Array(tool_calls));
+            }
+            if !thinking_parts.is_empty() {
+                obj.insert(
+                    "reasoning_content".into(),
+                    Value::String(thinking_parts.join("\n")),
+                );
+            }
+
+            Value::Object(obj)
+        }
+    }
+}
+
+/// Format content parts based on the template's content format preference.
+///
+/// - `String` format: join text parts into a single string
+/// - `OpenAI` format: keep as array of typed parts
+fn format_content_parts(parts: Vec<Value>, content_format: ChatTemplateContentFormat) -> Value {
+    match content_format {
+        ChatTemplateContentFormat::String => {
+            // Extract text parts and join
+            let text: String = parts
+                .iter()
+                .filter_map(|p| {
+                    p.as_object()
+                        .and_then(|obj| obj.get("type")?.as_str().filter(|&t| t == "text"))
+                        .and_then(|_| p.as_object()?.get("text")?.as_str())
+                        .map(String::from)
+                })
+                .collect::<Vec<_>>()
+                .join(" ");
+            Value::String(text)
+        }
+        ChatTemplateContentFormat::OpenAI => Value::Array(parts),
+    }
+}
+
+// ============================================================================
+// Type adapters: Messages API → Chat API types
+// ============================================================================
+
+/// Convert a Messages API CustomTool to a Chat API Tool.
+///
+/// Maps `CustomTool { name, description, input_schema }` to
+/// `ChatTool { type: "function", function: Function { name, description, parameters } }`
+pub(crate) fn custom_tool_to_chat_tool(tool: &messages::CustomTool) -> ChatTool {
+    // Convert InputSchema to a JSON Value for Function.parameters
+    let parameters = input_schema_to_value(&tool.input_schema);
+
+    ChatTool {
+        tool_type: "function".to_string(),
+        function: common::Function {
+            name: tool.name.clone(),
+            description: tool.description.clone(),
+            parameters,
+            strict: None,
+        },
+    }
+}
+
+/// Convert InputSchema struct to a serde_json::Value.
+fn input_schema_to_value(schema: &messages::InputSchema) -> Value {
+    let mut obj = serde_json::Map::new();
+    obj.insert(
+        "type".to_string(),
+        Value::String(schema.schema_type.clone()),
+    );
+
+    if let Some(properties) = &schema.properties {
+        let props: serde_json::Map<String, Value> = properties
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+        obj.insert("properties".to_string(), Value::Object(props));
+    }
+
+    if let Some(required) = &schema.required {
+        obj.insert(
+            "required".to_string(),
+            Value::Array(required.iter().map(|s| Value::String(s.clone())).collect()),
+        );
+    }
+
+    // Include any additional schema fields
+    for (key, value) in &schema.additional {
+        obj.insert(key.clone(), value.clone());
+    }
+
+    Value::Object(obj)
+}
+
+/// Convert a Messages API ToolChoice to a Chat API ToolChoice.
+///
+/// Mapping:
+/// - `Auto { .. }`    → `Value(Auto)`
+/// - `Any { .. }`     → `Value(Required)`
+/// - `Tool { name }`  → `Function { name }`
+/// - `None`           → `Value(None)`
+pub(crate) fn convert_message_tool_choice(tc: &messages::ToolChoice) -> ChatToolChoice {
+    match tc {
+        messages::ToolChoice::Auto { .. } => ChatToolChoice::Value(common::ToolChoiceValue::Auto),
+        messages::ToolChoice::Any { .. } => {
+            ChatToolChoice::Value(common::ToolChoiceValue::Required)
+        }
+        messages::ToolChoice::Tool { name, .. } => ChatToolChoice::Function {
+            tool_type: "function".to_string(),
+            function: common::FunctionChoice { name: name.clone() },
+        },
+        messages::ToolChoice::None => ChatToolChoice::Value(common::ToolChoiceValue::None),
+    }
+}
+
+/// Extract Custom tools from Messages API tool list and convert to ChatTool.
+///
+/// Only `Tool::Custom` is supported in gRPC mode. Other tool types
+/// (McpToolset, Bash, TextEditor, WebSearch, ToolSearch) are ignored
+/// since they require runtime capabilities not available in the gRPC pipeline.
+pub(crate) fn extract_chat_tools(tools: &[messages::Tool]) -> Vec<ChatTool> {
+    tools
+        .iter()
+        .filter_map(|t| match t {
+            messages::Tool::Custom(custom) => Some(custom_tool_to_chat_tool(custom)),
+            _ => None,
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use messages::{InputMessage, Role, TextBlock};
+
+    use super::*;
+
+    #[test]
+    fn test_simple_user_message() {
+        let messages = vec![InputMessage {
+            role: Role::User,
+            content: InputContent::String("Hello".to_string()),
+        }];
+
+        let result =
+            process_message_content_format(&messages, ChatTemplateContentFormat::String).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0]["role"], "user");
+        assert_eq!(result[0]["content"], "Hello");
+    }
+
+    #[test]
+    fn test_assistant_with_text() {
+        let messages = vec![InputMessage {
+            role: Role::Assistant,
+            content: InputContent::Blocks(vec![InputContentBlock::Text(TextBlock {
+                text: "Hi there".to_string(),
+                cache_control: None,
+                citations: None,
+            })]),
+        }];
+
+        let result =
+            process_message_content_format(&messages, ChatTemplateContentFormat::String).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0]["role"], "assistant");
+        assert_eq!(result[0]["content"], "Hi there");
+    }
+
+    #[test]
+    fn test_assistant_with_tool_use() {
+        let messages = vec![InputMessage {
+            role: Role::Assistant,
+            content: InputContent::Blocks(vec![
+                InputContentBlock::Text(TextBlock {
+                    text: "Let me check.".to_string(),
+                    cache_control: None,
+                    citations: None,
+                }),
+                InputContentBlock::ToolUse(messages::ToolUseBlock {
+                    id: "tu_1".to_string(),
+                    name: "calculator".to_string(),
+                    input: json!({"expr": "2+2"}),
+                    cache_control: None,
+                }),
+            ]),
+        }];
+
+        let result =
+            process_message_content_format(&messages, ChatTemplateContentFormat::String).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0]["role"], "assistant");
+        assert_eq!(result[0]["content"], "Let me check.");
+        let tool_calls = result[0]["tool_calls"].as_array().unwrap();
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(tool_calls[0]["function"]["name"], "calculator");
+    }
+
+    #[test]
+    fn test_user_with_tool_result_splits() {
+        let messages = vec![InputMessage {
+            role: Role::User,
+            content: InputContent::Blocks(vec![InputContentBlock::ToolResult(
+                messages::ToolResultBlock {
+                    tool_use_id: "tu_1".to_string(),
+                    content: Some(ToolResultContent::String("4".to_string())),
+                    is_error: None,
+                    cache_control: None,
+                },
+            )]),
+        }];
+
+        let result =
+            process_message_content_format(&messages, ChatTemplateContentFormat::String).unwrap();
+        // Tool result becomes a "tool" role message, not a "user" message
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0]["role"], "tool");
+        assert_eq!(result[0]["tool_call_id"], "tu_1");
+        assert_eq!(result[0]["content"], "4");
+    }
+
+    #[test]
+    fn test_assistant_with_thinking() {
+        // Single thinking block
+        let messages = vec![InputMessage {
+            role: Role::Assistant,
+            content: InputContent::Blocks(vec![
+                InputContentBlock::Thinking(messages::ThinkingBlock {
+                    thinking: "Let me reason...".to_string(),
+                    signature: "sig123".to_string(),
+                }),
+                InputContentBlock::Text(TextBlock {
+                    text: "The answer is 42.".to_string(),
+                    cache_control: None,
+                    citations: None,
+                }),
+            ]),
+        }];
+
+        let result =
+            process_message_content_format(&messages, ChatTemplateContentFormat::String).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0]["role"], "assistant");
+        assert_eq!(result[0]["content"], "The answer is 42.");
+        assert_eq!(result[0]["reasoning_content"], "Let me reason...");
+
+        // Multiple thinking blocks are concatenated
+        let messages = vec![InputMessage {
+            role: Role::Assistant,
+            content: InputContent::Blocks(vec![
+                InputContentBlock::Thinking(messages::ThinkingBlock {
+                    thinking: "First thought.".to_string(),
+                    signature: "sig1".to_string(),
+                }),
+                InputContentBlock::Thinking(messages::ThinkingBlock {
+                    thinking: "Second thought.".to_string(),
+                    signature: "sig2".to_string(),
+                }),
+                InputContentBlock::Text(TextBlock {
+                    text: "Combined answer.".to_string(),
+                    cache_control: None,
+                    citations: None,
+                }),
+            ]),
+        }];
+
+        let result =
+            process_message_content_format(&messages, ChatTemplateContentFormat::String).unwrap();
+        assert_eq!(
+            result[0]["reasoning_content"],
+            "First thought.\nSecond thought."
+        );
+    }
+
+    #[test]
+    fn test_tool_choice_conversion() {
+        assert!(matches!(
+            convert_message_tool_choice(&messages::ToolChoice::Auto {
+                disable_parallel_tool_use: None
+            }),
+            ChatToolChoice::Value(common::ToolChoiceValue::Auto)
+        ));
+        assert!(matches!(
+            convert_message_tool_choice(&messages::ToolChoice::Any {
+                disable_parallel_tool_use: None
+            }),
+            ChatToolChoice::Value(common::ToolChoiceValue::Required)
+        ));
+        assert!(matches!(
+            convert_message_tool_choice(&messages::ToolChoice::None),
+            ChatToolChoice::Value(common::ToolChoiceValue::None)
+        ));
+
+        let tc = convert_message_tool_choice(&messages::ToolChoice::Tool {
+            name: "calc".to_string(),
+            disable_parallel_tool_use: None,
+        });
+        assert!(matches!(tc, ChatToolChoice::Function { .. }));
+    }
+
+    #[test]
+    fn test_custom_tool_conversion() {
+        let custom = messages::CustomTool {
+            name: "weather".to_string(),
+            tool_type: None,
+            description: Some("Get weather".to_string()),
+            input_schema: messages::InputSchema {
+                schema_type: "object".to_string(),
+                properties: Some(
+                    [("city".to_string(), json!({"type": "string"}))]
+                        .into_iter()
+                        .collect(),
+                ),
+                required: Some(vec!["city".to_string()]),
+                additional: Default::default(),
+            },
+            defer_loading: None,
+            cache_control: None,
+        };
+
+        let chat_tool = custom_tool_to_chat_tool(&custom);
+        assert_eq!(chat_tool.function.name, "weather");
+        assert_eq!(
+            chat_tool.function.description,
+            Some("Get weather".to_string())
+        );
+        assert_eq!(chat_tool.function.parameters["type"], "object");
+        assert!(chat_tool.function.parameters["properties"]["city"].is_object());
+    }
+}

--- a/model_gateway/src/routers/grpc/utils/mod.rs
+++ b/model_gateway/src/routers/grpc/utils/mod.rs
@@ -2,6 +2,7 @@
 
 mod chat_utils;
 mod logprobs;
+pub(crate) mod message_utils;
 mod metrics;
 mod parsers;
 pub(crate) mod tonic_ext;


### PR DESCRIPTION
## Summary

- Add `message_utils.rs` with conversion functions for Anthropic Messages API types → internal chat template format
- Add `MessagePreparationStage` (Stage 1) parallel to `ChatPreparationStage`
- Make `process_tool_call_arguments` `pub(crate)` for reuse across message and chat paths

PR 2 in the Messages API gRPC pipeline series. PR 1 was #739 (type scaffolding).

## What changed

### New: `message_utils.rs`
Conversion utilities parallel to `chat_utils.rs` but for `CreateMessageRequest` / `InputMessage`:
- `process_messages()` — top-level orchestrator (parallel to `process_chat_messages()`)
- `process_message_content_format()` — converts `InputMessage[]` to `Vec<Value>` for chat template
- `convert_user_message()` — user messages with ToolResult splitting into separate "tool" role messages
- `convert_assistant_message()` — extracts text, tool_calls, reasoning_content
- `extract_chat_tools()` / `convert_message_tool_choice()` — type adapters from Messages API to chat types
- `extract_tool_result_text()` — helper for ToolResult content extraction
- 7 unit tests covering all major conversion paths

### New: `MessagePreparationStage`
Created via `git-cp` from `ChatPreparationStage` to preserve file history. Key differences:
- Uses `messages_request_arc()` instead of `chat_request_arc()`
- Calls `message_utils::process_messages()` instead of `utils::process_chat_messages()`
- Converts tools via `extract_chat_tools()` + `convert_message_tool_choice()` adapters
- Uses `request.stop_sequences` (Messages API) instead of `request.stop` (Chat API)
- No multimodal processing (postponed, async preserved for future `.await`)
- No `filtered_request` / `Cow<ChatCompletionRequest>` pattern

### Modified
- `chat_utils.rs`: `process_tool_call_arguments` visibility → `pub(crate)`
- `stages/preparation.rs`: delegating stage uses `Display`-based error messages
- `context.rs`: removed stale `#[expect(dead_code)]` from `messages_request_arc`

## How

Follows the same architecture as chat — reuses shared utilities (`resolve_tokenizer`, `filter_tools_by_tool_choice`, `generate_tool_constraints`, `create_stop_decoder`, `process_tool_call_arguments`) and only replaces the message-specific conversion layer.

| Shared utility | Reused as-is? |
|---|---|
| `resolve_tokenizer()` | Yes |
| `process_tool_call_arguments()` | Yes (made pub(crate)) |
| `generate_tool_constraints()` | Yes (after adapter) |
| `filter_tools_by_tool_choice()` | Yes (after adapter) |
| `create_stop_decoder()` | Yes (small conversion from `Vec<String>`) |
| `process_content_format()` | No — replaced by `process_message_content_format()` |

## Test plan

- [x] `cargo clippy -p smg --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt -p smg -- --check` — clean
- [x] `cargo test -p smg --lib -- message_utils` — 7/7 pass
- [x] `cargo test -p smg -- message` — all pass

Refs: #738

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Messages API pipeline with a preparation stage for CreateMessage requests.
  * End-to-end message → chat-template processing, including tool handling, tokenization, stop-sequences, and template application.
  * Tool constraint generation and stop-decoder stored for downstream stages.

* **Refactor**
  * Simplified unsupported-request-type error reporting.
  * Adjusted visibility and added utility modules for message/tool processing and reuse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->