### PR TITLE
feat(gateway): add MessageRequestBuildingStage for Messages API

### DIFF
--- a/crates/grpc_client/src/sglang_scheduler.rs
+++ b/crates/grpc_client/src/sglang_scheduler.rs
@@ -12,6 +12,7 @@ use openai_protocol::{
     chat::ChatCompletionRequest,
     common::{ResponseFormat, StringOrArray, ToolChoice, ToolChoiceValue},
     generate::GenerateRequest,
+    messages::CreateMessageRequest,
     responses::ResponsesRequest,
     sampling_params::SamplingParams as GenerateSamplingParams,
 };
@@ -605,6 +606,74 @@ impl SglangSchedulerClient {
         } else {
             Ok(None)
         }
+    }
+
+    /// Build a GenerateRequest from CreateMessageRequest (Anthropic Messages API)
+    #[expect(
+        clippy::unused_self,
+        reason = "method receiver kept for consistent public API"
+    )]
+    pub fn build_generate_request_from_messages(
+        &self,
+        request_id: String,
+        body: &CreateMessageRequest,
+        processed_text: String,
+        token_ids: Vec<u32>,
+        multimodal_inputs: Option<proto::MultimodalInputs>,
+        tool_call_constraint: Option<(String, String)>,
+    ) -> Result<proto::GenerateRequest, String> {
+        let sampling_params =
+            Self::build_grpc_sampling_params_from_messages(body, tool_call_constraint)?;
+
+        let grpc_request = proto::GenerateRequest {
+            request_id,
+            tokenized: Some(proto::TokenizedInput {
+                original_text: processed_text,
+                input_ids: token_ids,
+            }),
+            mm_inputs: multimodal_inputs,
+            sampling_params: Some(sampling_params),
+            return_logprob: false,
+            logprob_start_len: -1,
+            top_logprobs_num: 0,
+            return_hidden_states: false,
+            stream: body.stream.unwrap_or(false),
+            ..Default::default()
+        };
+
+        Ok(grpc_request)
+    }
+
+    /// Build gRPC SamplingParams from CreateMessageRequest
+    fn build_grpc_sampling_params_from_messages(
+        request: &CreateMessageRequest,
+        tool_call_constraint: Option<(String, String)>,
+    ) -> Result<proto::SamplingParams, String> {
+        let stop_sequences = request.stop_sequences.clone().unwrap_or_default();
+
+        // skip_special_tokens: false when tools are present (same logic as chat)
+        let skip_special_tokens =
+            tool_call_constraint.is_none() && request.tools.as_ref().is_none_or(|t| t.is_empty());
+
+        Ok(proto::SamplingParams {
+            temperature: request.temperature.unwrap_or(1.0) as f32,
+            top_p: request.top_p.unwrap_or(1.0) as f32,
+            top_k: request.top_k.map(|v| v as i32).unwrap_or(-1),
+            min_p: 0.0,
+            frequency_penalty: 0.0,
+            presence_penalty: 0.0,
+            repetition_penalty: 1.0,
+            max_new_tokens: Some(request.max_tokens),
+            stop: stop_sequences,
+            stop_token_ids: vec![],
+            skip_special_tokens,
+            spaces_between_special_tokens: true,
+            ignore_eos: false,
+            no_stop_trim: false,
+            n: 1,
+            constraint: Self::build_constraint_for_responses(tool_call_constraint)?,
+            ..Default::default()
+        })
     }
 
     fn build_single_constraint_from_plain(

--- a/crates/grpc_client/src/trtllm_service.rs
+++ b/crates/grpc_client/src/trtllm_service.rs
@@ -12,6 +12,7 @@ use openai_protocol::{
     chat::ChatCompletionRequest,
     common::{ResponseFormat, StringOrArray},
     generate::GenerateRequest,
+    messages::CreateMessageRequest,
     responses::ResponsesRequest,
     sampling_params::SamplingParams as GenerateSamplingParams,
 };
@@ -619,6 +620,95 @@ impl TrtllmServiceClient {
             }))
         } else {
             Ok(None)
+        }
+    }
+
+    /// Build a GenerateRequest from CreateMessageRequest (Anthropic Messages API)
+    #[expect(
+        clippy::unused_self,
+        reason = "method receiver kept for consistent public API"
+    )]
+    pub fn build_generate_request_from_messages(
+        &self,
+        request_id: String,
+        body: &CreateMessageRequest,
+        processed_text: String,
+        token_ids: Vec<u32>,
+        multimodal_input: Option<proto::MultimodalInput>,
+        tool_call_constraint: Option<(String, String)>,
+    ) -> Result<proto::GenerateRequest, String> {
+        let sampling_config = Self::build_sampling_config_from_messages(body);
+        let output_config = proto::OutputConfig {
+            logprobs: None,
+            prompt_logprobs: None,
+            return_context_logits: false,
+            return_generation_logits: false,
+            exclude_input_from_output: true,
+            return_encoder_output: false,
+            return_perf_metrics: false,
+        };
+
+        let guided_decoding = Self::build_guided_decoding_from_responses(tool_call_constraint)?;
+
+        let stop = body.stop_sequences.clone().unwrap_or_default();
+        let max_tokens = body.max_tokens;
+
+        let grpc_request = proto::GenerateRequest {
+            request_id,
+            tokenized: Some(proto::TokenizedInput {
+                original_text: processed_text,
+                input_token_ids: token_ids,
+                query_token_ids: vec![],
+            }),
+            sampling_config: Some(sampling_config),
+            output_config: Some(output_config),
+            max_tokens,
+            streaming: body.stream.unwrap_or(false),
+            stop,
+            stop_token_ids: vec![],
+            ignore_eos: false,
+            bad: vec![],
+            bad_token_ids: vec![],
+            guided_decoding,
+            embedding_bias: vec![],
+            lora_config: None,
+            prompt_tuning_config: None,
+            multimodal_input,
+            kv_cache_retention: None,
+            disaggregated_params: None,
+            lookahead_config: None,
+            cache_salt_id: None,
+            arrival_time: None,
+        };
+
+        Ok(grpc_request)
+    }
+
+    /// Build SamplingConfig from CreateMessageRequest
+    fn build_sampling_config_from_messages(
+        request: &CreateMessageRequest,
+    ) -> proto::SamplingConfig {
+        proto::SamplingConfig {
+            beam_width: 1,
+            num_return_sequences: 1,
+            top_k: request.top_k.map(|v| v as i32),
+            top_p: Some(request.top_p.unwrap_or(1.0) as f32),
+            top_p_min: None,
+            top_p_reset_ids: None,
+            top_p_decay: None,
+            seed: None,
+            temperature: Some(request.temperature.unwrap_or(1.0) as f32),
+            min_tokens: None,
+            beam_search_diversity_rate: None,
+            repetition_penalty: Some(1.0),
+            presence_penalty: None,
+            frequency_penalty: None,
+            prompt_ignore_length: None,
+            length_penalty: None,
+            early_stopping: None,
+            no_repeat_ngram_size: None,
+            min_p: None,
+            beam_width_array: vec![],
         }
     }
 

--- a/crates/grpc_client/src/vllm_engine.rs
+++ b/crates/grpc_client/src/vllm_engine.rs
@@ -12,6 +12,7 @@ use openai_protocol::{
     chat::ChatCompletionRequest,
     common::{ResponseFormat, StringOrArray, ToolChoice, ToolChoiceValue},
     generate::GenerateRequest,
+    messages::CreateMessageRequest,
     responses::ResponsesRequest,
     sampling_params::SamplingParams as GenerateSamplingParams,
 };
@@ -538,6 +539,72 @@ impl VllmEngineClient {
         } else {
             Ok(None)
         }
+    }
+
+    /// Build a GenerateRequest from CreateMessageRequest (Anthropic Messages API)
+    #[expect(
+        clippy::unused_self,
+        reason = "method receiver kept for consistent public API across gRPC backends"
+    )]
+    pub fn build_generate_request_from_messages(
+        &self,
+        request_id: String,
+        body: &CreateMessageRequest,
+        processed_text: String,
+        token_ids: Vec<u32>,
+        multimodal_inputs: Option<proto::MultimodalInputs>,
+        tool_call_constraint: Option<(String, String)>,
+    ) -> Result<proto::GenerateRequest, String> {
+        let sampling_params =
+            Self::build_grpc_sampling_params_from_messages(body, tool_call_constraint)?;
+
+        let grpc_request = proto::GenerateRequest {
+            request_id,
+            input: Some(proto::generate_request::Input::Tokenized(
+                proto::TokenizedInput {
+                    original_text: processed_text,
+                    input_ids: token_ids,
+                },
+            )),
+            sampling_params: Some(sampling_params),
+            stream: body.stream.unwrap_or(false),
+            kv_transfer_params: None,
+            mm_inputs: multimodal_inputs,
+        };
+
+        Ok(grpc_request)
+    }
+
+    /// Build gRPC SamplingParams from CreateMessageRequest
+    fn build_grpc_sampling_params_from_messages(
+        request: &CreateMessageRequest,
+        tool_call_constraint: Option<(String, String)>,
+    ) -> Result<proto::SamplingParams, String> {
+        let stop_sequences = request.stop_sequences.clone().unwrap_or_default();
+
+        // skip_special_tokens: false when tools are present (same logic as chat)
+        let skip_special_tokens =
+            tool_call_constraint.is_none() && request.tools.as_ref().is_none_or(|t| t.is_empty());
+
+        Ok(proto::SamplingParams {
+            temperature: Some(request.temperature.unwrap_or(1.0) as f32),
+            top_p: request.top_p.unwrap_or(1.0) as f32,
+            top_k: request.top_k.unwrap_or(0), // 0 means disabled in vLLM
+            min_p: 0.0,
+            frequency_penalty: 0.0,
+            presence_penalty: 0.0,
+            repetition_penalty: 1.0,
+            max_tokens: Some(request.max_tokens),
+            stop: stop_sequences,
+            stop_token_ids: vec![],
+            skip_special_tokens,
+            spaces_between_special_tokens: true,
+            ignore_eos: false,
+            n: 1,
+            logprobs: None,
+            constraint: Self::build_constraint_for_responses(tool_call_constraint)?,
+            ..Default::default()
+        })
     }
 
     fn build_single_constraint_from_plain(

--- a/model_gateway/src/routers/grpc/client.rs
+++ b/model_gateway/src/routers/grpc/client.rs
@@ -3,7 +3,8 @@
 use std::collections::HashMap;
 
 use openai_protocol::{
-    chat::ChatCompletionRequest, generate::GenerateRequest, worker::WorkerLoadResponse,
+    chat::ChatCompletionRequest, generate::GenerateRequest, messages::CreateMessageRequest,
+    worker::WorkerLoadResponse,
 };
 use smg_grpc_client::{
     tokenizer_bundle, tokenizer_bundle::StreamBundle, SglangSchedulerClient, TrtllmServiceClient,
@@ -309,6 +310,68 @@ impl GrpcClient {
                     _ => unreachable!("caller guarantees matching variant"),
                 });
                 let req = client.build_generate_request_from_chat(
+                    request_id,
+                    body,
+                    processed_text,
+                    token_ids,
+                    trtllm_mm,
+                    tool_constraints,
+                )?;
+                Ok(ProtoGenerateRequest::Trtllm(Box::new(req)))
+            }
+        }
+    }
+
+    #[expect(
+        clippy::unreachable,
+        reason = "assembly stage guarantees matching MultimodalData variant for each backend"
+    )]
+    pub fn build_messages_request(
+        &self,
+        request_id: String,
+        body: &CreateMessageRequest,
+        processed_text: String,
+        token_ids: Vec<u32>,
+        multimodal_inputs: Option<MultimodalData>,
+        tool_constraints: Option<(String, String)>,
+    ) -> Result<ProtoGenerateRequest, String> {
+        match self {
+            Self::Sglang(client) => {
+                let sglang_mm = multimodal_inputs.map(|mm| match mm {
+                    MultimodalData::Sglang(data) => data.into_proto(),
+                    _ => unreachable!("caller guarantees matching variant"),
+                });
+                let req = client.build_generate_request_from_messages(
+                    request_id,
+                    body,
+                    processed_text,
+                    token_ids,
+                    sglang_mm,
+                    tool_constraints,
+                )?;
+                Ok(ProtoGenerateRequest::Sglang(Box::new(req)))
+            }
+            Self::Vllm(client) => {
+                let vllm_mm = multimodal_inputs.map(|mm| match mm {
+                    MultimodalData::Vllm(data) => data.into_proto(),
+                    _ => unreachable!("caller guarantees matching variant"),
+                });
+                let req = client.build_generate_request_from_messages(
+                    request_id,
+                    body,
+                    processed_text,
+                    token_ids,
+                    vllm_mm,
+                    tool_constraints,
+                )?;
+                Ok(ProtoGenerateRequest::Vllm(Box::new(req)))
+            }
+            Self::Trtllm(client) => {
+                let trtllm_mm = multimodal_inputs.map(|mm| match mm {
+                    MultimodalData::Trtllm(data) => data.into_proto(),
+                    _ => unreachable!("caller guarantees matching variant"),
+                });
+                let req = client.build_generate_request_from_messages(
                     request_id,
                     body,
                     processed_text,

--- a/model_gateway/src/routers/grpc/regular/stages/messages/mod.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/messages/mod.rs
@@ -1,9 +1,12 @@
 //! Messages API endpoint pipeline stages
 //!
-//! These stages handle Messages API-specific preprocessing.
-//! Request building and response processing will be added in follow-up PRs.
+//! These stages handle Messages API-specific preprocessing and request building.
+//! Response processing will be added in a follow-up PR.
 
 mod preparation;
+mod request_building;
 
 #[expect(unused_imports, reason = "wired in follow-up PR (pipeline factory)")]
 pub(crate) use preparation::MessagePreparationStage;
+#[expect(unused_imports, reason = "wired in follow-up PR (pipeline factory)")]
+pub(crate) use request_building::MessageRequestBuildingStage;

--- a/model_gateway/src/routers/grpc/regular/stages/messages/request_building.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/messages/request_building.rs
@@ -1,0 +1,105 @@
+//! Message request building stage: Build proto GenerateRequest for message requests
+#![allow(dead_code)] // wired in follow-up PR (pipeline factory)
+
+use async_trait::async_trait;
+use axum::response::Response;
+use tracing::error;
+use uuid::Uuid;
+
+use crate::routers::{
+    error,
+    grpc::{
+        common::stages::{helpers, PipelineStage},
+        context::{ClientSelection, RequestContext},
+        proto_wrapper::ProtoRequest,
+    },
+};
+
+/// Message request building stage
+///
+/// Builds a backend-specific proto GenerateRequest from the PreparationOutput
+/// and CreateMessageRequest sampling parameters.
+pub(crate) struct MessageRequestBuildingStage {
+    inject_pd_metadata: bool,
+}
+
+impl MessageRequestBuildingStage {
+    pub fn new(inject_pd_metadata: bool) -> Self {
+        Self { inject_pd_metadata }
+    }
+}
+
+#[async_trait]
+impl PipelineStage for MessageRequestBuildingStage {
+    async fn execute(&self, ctx: &mut RequestContext) -> Result<Option<Response>, Response> {
+        // Take preparation state (last consumer — worker_selection already ran)
+        let prep = ctx.state.preparation.take().ok_or_else(|| {
+            error!(
+                function = "MessageRequestBuildingStage::execute",
+                "Preparation not completed"
+            );
+            error::internal_error("preparation_not_completed", "Preparation not completed")
+        })?;
+
+        let clients = ctx.state.clients.as_ref().ok_or_else(|| {
+            error!(
+                function = "MessageRequestBuildingStage::execute",
+                "Client acquisition not completed"
+            );
+            error::internal_error(
+                "client_acquisition_not_completed",
+                "Client acquisition not completed",
+            )
+        })?;
+
+        let messages_request = ctx.messages_request_arc();
+
+        // Get client for building request (use prefill client if PD mode)
+        let builder_client = match clients {
+            ClientSelection::Single { client } => client,
+            ClientSelection::Dual { prefill, .. } => prefill,
+        };
+
+        // Build message request
+        let request_id = format!("msg_{}", Uuid::now_v7());
+
+        // Build proto request — take ownership of preparation fields (no clones needed)
+        let processed_messages = prep.processed_messages.ok_or_else(|| {
+            error!(
+                function = "MessageRequestBuildingStage::execute",
+                "processed_messages not set in preparation state"
+            );
+            error::internal_error(
+                "processed_messages_missing",
+                "processed_messages not set - this is a bug in the pipeline",
+            )
+        })?;
+
+        let mut proto_request = builder_client
+            .build_messages_request(
+                request_id,
+                &messages_request,
+                processed_messages.text,
+                prep.token_ids,
+                None, // multimodal data — postponed
+                prep.tool_constraints,
+            )
+            .map_err(|e| {
+                error!(function = "MessageRequestBuildingStage::execute", error = %e, "Failed to build generate request");
+                error::bad_request("invalid_request_parameters", format!("Invalid request parameters: {e}"))
+            })?;
+
+        if self.inject_pd_metadata {
+            if let Some(workers) = ctx.state.workers.as_ref() {
+                helpers::maybe_inject_pd_metadata(&mut proto_request, workers);
+            }
+        }
+
+        ctx.state.proto_request = Some(ProtoRequest::Generate(proto_request));
+        Ok(None)
+    }
+
+    fn name(&self) -> &'static str {
+        "MessageRequestBuilding"
+    }
+}


### PR DESCRIPTION
## Summary

- Add Stage 4 (MessageRequestBuildingStage) for the Messages API gRPC pipeline
- Add `build_generate_request_from_messages` + sampling params builders to all 3 backends (sglang, vLLM, TRT-LLM)
- Add `build_messages_request` dispatcher to `GrpcClient`

## What changed

**New file:**
- `model_gateway/src/routers/grpc/regular/stages/messages/request_building.rs` — MessageRequestBuildingStage, copied from chat's request_building.rs and adapted: `msg_{uuid}` request ID prefix, `ctx.messages_request_arc()`, `build_messages_request()`, no `filtered_request` pattern, multimodal postponed

**Backend sampling params (3 files in `crates/grpc_client/src/`):**
- `sglang_scheduler.rs` — `build_generate_request_from_messages()` + `build_grpc_sampling_params_from_messages()`. Maps `CreateMessageRequest` fields to sglang proto `SamplingParams` (top_k=-1 for disabled)
- `vllm_engine.rs` — Same pattern for vLLM (top_k=0 for disabled, `Option<f32>` temperature)
- `trtllm_service.rs` — Same pattern using TRT-LLM's `SamplingConfig` + `OutputConfig` + `GuidedDecodingParams` proto types

**GrpcClient dispatcher:**
- `model_gateway/src/routers/grpc/client.rs` — `build_messages_request()` dispatches to each backend's `build_generate_request_from_messages()`

**Module wiring:**
- `model_gateway/src/routers/grpc/regular/stages/messages/mod.rs` — Wire `request_building` module + re-export

## Why

PR 3 in the Messages API gRPC series. Bridges preparation (Stage 1, #741) and response processing (Stage 7, future PR). `CreateMessageRequest` has fewer sampling knobs than `ChatCompletionRequest` — no `min_p`, `frequency_penalty`, `presence_penalty`, `repetition_penalty`, `n`, `logprobs`, `response_format`/`ebnf`/`regex`. Constraints are limited to `tool_call_constraint` from the preparation stage (same pattern as Responses API).

## Test plan

- `cargo clippy -p smg --all-targets --all-features -- -D warnings` — passes
- `cargo clippy -p smg-grpc-client --all-targets --all-features -- -D warnings` — passes
- `cargo fmt --check` — passes
- Stage is not yet wired into pipeline factory (follow-up PR), so `#![allow(dead_code)]` is used

Refs: #739, #741

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended gRPC backend support to handle Anthropic Messages API format
  * All backends (SGLang, TRTLlm, vLLM) now process message-based requests with full sampling configuration and constraint handling
  * Improved routing and pipeline integration for message-based generation requests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->