### PR TITLE
fix(ci): prevent upload-servicer from being skipped

### DIFF
--- a/.github/workflows/release-grpc.yml
+++ b/.github/workflows/release-grpc.yml
@@ -139,8 +139,11 @@ jobs:
 
   upload-servicer:
     name: Upload servicer to PyPI
-    if: github.repository == 'lightseekorg/smg'
     needs: [build-servicer]
+    if: >-
+      always()
+      && github.repository == 'lightseekorg/smg'
+      && needs.build-servicer.result == 'success'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v8


### PR DESCRIPTION
## Summary
- Add `always()` to `upload-servicer` job condition so skipped proto jobs don't propagate skip status through the `build-servicer` dependency chain
- Also adds explicit `needs.build-servicer.result == 'success'` guard so upload only runs when the build actually succeeded

## Context
The servicer v0.5.0 release (#745) built successfully but the PyPI upload was skipped because `build-proto` and `upload-proto` were skipped (no proto changes), and GitHub Actions propagated that skip to `upload-servicer`.

## Test plan
- [ ] Merge and verify `workflow_dispatch` triggers upload-servicer correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release pipeline reliability by enhancing job execution conditions to ensure successful completion of prerequisite build steps before proceeding with deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->