### PR TITLE
feat(config): add --config and --dump-config for file-based configuration

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1024,6 +1024,9 @@ impl Router {
 
         let router_config = if let Some(ref path) = self.config_path {
             if config::is_env_file(path) {
+                // Load env vars into the process. Note: this won't retroactively
+                // change Router fields already set from Python — use python-dotenv
+                // before creating the Router for full .env support.
                 config::load_env_file(path).map_err(|e| {
                     pyo3::exceptions::PyValueError::new_err(format!(
                         "Failed to load .env file: {e}"
@@ -1033,11 +1036,29 @@ impl Router {
                     pyo3::exceptions::PyValueError::new_err(format!("Configuration error: {e}"))
                 })?
             } else {
-                config::load_config_file(path).map_err(|e| {
+                // Load YAML/JSON config and pass through builder for cert/MCP loading
+                let file_config = config::load_config_file(path).map_err(|e| {
                     pyo3::exceptions::PyValueError::new_err(format!(
                         "Failed to load config file: {e}"
                     ))
-                })?
+                })?;
+                config::RouterConfigBuilder::from_config(file_config)
+                    .maybe_server_cert_and_key(
+                        self.server_cert_path.as_ref(),
+                        self.server_key_path.as_ref(),
+                    )
+                    .maybe_client_cert_and_key(
+                        self.client_cert_path.as_ref(),
+                        self.client_key_path.as_ref(),
+                    )
+                    .add_ca_certificates(self.ca_cert_paths.clone())
+                    .maybe_mcp_config_path(self.mcp_config_path.as_ref())
+                    .build()
+                    .map_err(|e| {
+                        pyo3::exceptions::PyValueError::new_err(format!(
+                            "Configuration error: {e}"
+                        ))
+                    })?
             }
         } else {
             self.to_router_config().map_err(|e| {
@@ -1092,19 +1113,29 @@ impl Router {
         let runtime = tokio::runtime::Runtime::new()
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
 
+        // Extract values from router_config before it's moved into ServerConfig.
+        // This ensures config file values (if loaded) are used for server settings.
+        let host = router_config.host.clone();
+        let port = router_config.port;
+        let max_payload_size = router_config.max_payload_size;
+        let log_dir = router_config.log_dir.clone();
+        let log_level = router_config.log_level.clone();
+        let request_timeout_secs = router_config.request_timeout_secs;
+        let request_id_headers = router_config.request_id_headers.clone();
+
         runtime.block_on(async move {
             server::startup(server::ServerConfig {
-                host: self.host.clone(),
-                port: self.port,
+                host,
+                port,
                 router_config,
-                max_payload_size: self.max_payload_size,
-                log_dir: self.log_dir.clone(),
-                log_level: self.log_level.clone(),
+                max_payload_size,
+                log_dir,
+                log_level,
                 log_json: self.log_json,
                 service_discovery_config,
                 prometheus_config,
-                request_timeout_secs: self.request_timeout_secs,
-                request_id_headers: self.request_id_headers.clone(),
+                request_timeout_secs,
+                request_id_headers,
                 shutdown_grace_period_secs: self.shutdown_grace_period_secs,
                 control_plane_auth: self
                     .control_plane_auth

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -454,6 +454,7 @@ struct Router {
     otlp_traces_endpoint: String,
     control_plane_auth: Option<PyControlPlaneAuthConfig>,
     schema_config: Option<String>,
+    config_path: Option<String>,
 }
 
 impl Router {
@@ -808,6 +809,7 @@ impl Router {
         otlp_traces_endpoint = String::from("localhost:4317"),
         control_plane_auth = None,
         schema_config = None,
+        config_path = None,
     ))]
     #[expect(clippy::too_many_arguments)]
     #[expect(
@@ -905,6 +907,7 @@ impl Router {
         otlp_traces_endpoint: String,
         control_plane_auth: Option<PyControlPlaneAuthConfig>,
         schema_config: Option<String>,
+        config_path: Option<String>,
     ) -> PyResult<Self> {
         let mut all_urls = worker_urls.clone();
 
@@ -1012,15 +1015,35 @@ impl Router {
             otlp_traces_endpoint,
             control_plane_auth,
             schema_config,
+            config_path,
         })
     }
 
     fn start(&self) -> PyResult<()> {
         use observability::metrics::PrometheusConfig;
 
-        let router_config = self.to_router_config().map_err(|e| {
-            pyo3::exceptions::PyValueError::new_err(format!("Configuration error: {e}"))
-        })?;
+        let router_config = if let Some(ref path) = self.config_path {
+            if config::is_env_file(path) {
+                config::load_env_file(path).map_err(|e| {
+                    pyo3::exceptions::PyValueError::new_err(format!(
+                        "Failed to load .env file: {e}"
+                    ))
+                })?;
+                self.to_router_config().map_err(|e| {
+                    pyo3::exceptions::PyValueError::new_err(format!("Configuration error: {e}"))
+                })?
+            } else {
+                config::load_config_file(path).map_err(|e| {
+                    pyo3::exceptions::PyValueError::new_err(format!(
+                        "Failed to load config file: {e}"
+                    ))
+                })?
+            }
+        } else {
+            self.to_router_config().map_err(|e| {
+                pyo3::exceptions::PyValueError::new_err(format!("Configuration error: {e}"))
+            })?
+        };
 
         router_config.validate().map_err(|e| {
             pyo3::exceptions::PyValueError::new_err(format!("Configuration validation failed: {e}"))

--- a/bindings/python/src/smg/router.py
+++ b/bindings/python/src/smg/router.py
@@ -314,6 +314,9 @@ class Router:
         # Build control plane auth config
         args_dict["control_plane_auth"] = build_control_plane_auth_config(args_dict)
 
+        # Extract config path before removing from dict
+        config_path = args_dict.pop("config", None)
+
         # Remove fields that shouldn't be passed to Rust Router constructor
         fields_to_remove = [
             "oracle_wallet_path",
@@ -341,7 +344,7 @@ class Router:
         for field in fields_to_remove:
             args_dict.pop(field, None)
 
-        return Router(_Router(**args_dict))
+        return Router(_Router(**args_dict, config_path=config_path))
 
     def start(self) -> None:
         """Start the router server.

--- a/bindings/python/src/smg/router_args.py
+++ b/bindings/python/src/smg/router_args.py
@@ -12,6 +12,9 @@ logger = logging.getLogger(__name__)
 
 @dataclasses.dataclass
 class RouterArgs:
+    # Configuration file (YAML, JSON, or .env)
+    config: str | None = None
+
     # Worker configuration
     worker_urls: list[str] = dataclasses.field(default_factory=list)
     host: str = "0.0.0.0"
@@ -225,6 +228,20 @@ class RouterArgs:
         )
         auth_group = parser.add_argument_group(
             "Control Plane Authentication", "API key and JWT/OIDC authentication"
+        )
+        config_group = parser.add_argument_group(
+            "Configuration", "Configuration file support"
+        )
+
+        # Configuration file
+        config_group.add_argument(
+            "--config",
+            type=str,
+            default=None,
+            help=(
+                "Path to a configuration file (YAML, JSON, or .env). "
+                "Config file values are overridden by explicit CLI arguments"
+            ),
         )
 
         # Worker configuration

--- a/bindings/python/src/smg/router_args.py
+++ b/bindings/python/src/smg/router_args.py
@@ -235,7 +235,7 @@ class RouterArgs:
 
         # Configuration file
         config_group.add_argument(
-            "--config",
+            f"--{prefix}config",
             type=str,
             default=None,
             help=(

--- a/model_gateway/Cargo.toml
+++ b/model_gateway/Cargo.toml
@@ -107,6 +107,7 @@ rustls-pemfile = "2.2"
 openssl = "0.10.73"
 rmcp = { version = "0.8.3", features = ["client"] }
 serde_yaml = "0.9"
+dotenvy = "0.15"
 openai-harmony = "0.0.8"
 openmetrics-parser = "0.4.4"
 arc-swap = "1.7.1"

--- a/model_gateway/src/config/loader.rs
+++ b/model_gateway/src/config/loader.rs
@@ -1,0 +1,178 @@
+//! Config file loading for YAML, JSON, and .env formats.
+
+use std::path::Path;
+
+use super::{ConfigError, ConfigResult, RouterConfig};
+
+/// Supported config file formats, detected from file extension.
+enum ConfigFormat {
+    Yaml,
+    Json,
+    Env,
+}
+
+impl ConfigFormat {
+    fn detect(path: &Path) -> ConfigResult<Self> {
+        // Handle `.env` files (no extension, filename is `.env`)
+        if path.file_name().is_some_and(|name| name == ".env") {
+            return Ok(Self::Env);
+        }
+        match path.extension().and_then(|e| e.to_str()) {
+            Some("yaml" | "yml") => Ok(Self::Yaml),
+            Some("json") => Ok(Self::Json),
+            Some("env") => Ok(Self::Env),
+            Some(ext) => Err(ConfigError::ValidationFailed {
+                reason: format!(
+                    "Unsupported config file extension '.{ext}'. Use .yaml, .yml, .json, or .env"
+                ),
+            }),
+            None => Err(ConfigError::ValidationFailed {
+                reason: "Config file must have an extension (.yaml, .yml, .json, or .env)"
+                    .to_string(),
+            }),
+        }
+    }
+}
+
+/// Load a YAML or JSON config file into [`RouterConfig`].
+///
+/// For `.env` files, use [`load_env_file`] instead — those populate
+/// environment variables rather than producing a `RouterConfig`.
+pub fn load_config_file(path: &str) -> ConfigResult<RouterConfig> {
+    let p = Path::new(path);
+
+    if !p.exists() {
+        return Err(ConfigError::ValidationFailed {
+            reason: format!("Config file not found: {path}"),
+        });
+    }
+
+    match ConfigFormat::detect(p)? {
+        ConfigFormat::Yaml => load_yaml(p),
+        ConfigFormat::Json => load_json(p),
+        ConfigFormat::Env => Err(ConfigError::ValidationFailed {
+            reason: "Use load_env_file() for .env files".to_string(),
+        }),
+    }
+}
+
+/// Load a `.env` file into the process environment.
+///
+/// Values become available to clap's `env = "..."` attribute parsing.
+pub fn load_env_file(path: &str) -> ConfigResult<()> {
+    dotenvy::from_path(Path::new(path)).map_err(|e| ConfigError::ValidationFailed {
+        reason: format!("Failed to load .env file '{path}': {e}"),
+    })
+}
+
+/// Returns `true` if `path` is a `.env` file (by extension or filename).
+pub fn is_env_file(path: &str) -> bool {
+    let p = Path::new(path);
+    // Match files with `.env` extension (e.g., `config.env`)
+    // or files named `.env` (which have no extension in Rust's Path)
+    p.extension().is_some_and(|ext| ext == "env")
+        || p.file_name().is_some_and(|name| name == ".env")
+}
+
+/// Serialize a [`RouterConfig`] to YAML for `--dump-config`.
+pub fn dump_config_yaml(config: &RouterConfig) -> ConfigResult<String> {
+    serde_yaml::to_string(config).map_err(|e| ConfigError::ValidationFailed {
+        reason: format!("Failed to serialize config to YAML: {e}"),
+    })
+}
+
+fn load_yaml(path: &Path) -> ConfigResult<RouterConfig> {
+    let contents = read_file(path)?;
+    serde_yaml::from_str(&contents).map_err(|e| ConfigError::ValidationFailed {
+        reason: format!("Failed to parse YAML config '{}': {e}", path.display()),
+    })
+}
+
+fn load_json(path: &Path) -> ConfigResult<RouterConfig> {
+    let contents = read_file(path)?;
+    serde_json::from_str(&contents).map_err(|e| ConfigError::ValidationFailed {
+        reason: format!("Failed to parse JSON config '{}': {e}", path.display()),
+    })
+}
+
+fn read_file(path: &Path) -> ConfigResult<String> {
+    std::fs::read_to_string(path).map_err(|e| ConfigError::ValidationFailed {
+        reason: format!("Failed to read config file '{}': {e}", path.display()),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn yaml_roundtrip() {
+        let config = RouterConfig::default();
+        let yaml = dump_config_yaml(&config).expect("serialize");
+        let parsed: RouterConfig = serde_yaml::from_str(&yaml).expect("deserialize");
+        assert_eq!(config.host, parsed.host);
+        assert_eq!(config.port, parsed.port);
+    }
+
+    #[test]
+    fn partial_yaml_uses_defaults() {
+        let yaml = r#"
+host: "10.0.0.1"
+port: 9000
+"#;
+        let config: RouterConfig = serde_yaml::from_str(yaml).expect("deserialize partial");
+        assert_eq!(config.host, "10.0.0.1");
+        assert_eq!(config.port, 9000);
+        // Non-specified fields get defaults
+        assert!(!config.dp_aware);
+        assert!(!config.enable_igw);
+    }
+
+    #[test]
+    fn json_loading() {
+        let json = r#"{"host": "127.0.0.1", "port": 8080}"#;
+        let config: RouterConfig = serde_json::from_str(json).expect("deserialize json");
+        assert_eq!(config.host, "127.0.0.1");
+        assert_eq!(config.port, 8080);
+    }
+
+    #[test]
+    fn format_detection() {
+        assert!(matches!(
+            ConfigFormat::detect(Path::new("config.yaml")),
+            Ok(ConfigFormat::Yaml)
+        ));
+        assert!(matches!(
+            ConfigFormat::detect(Path::new("config.yml")),
+            Ok(ConfigFormat::Yaml)
+        ));
+        assert!(matches!(
+            ConfigFormat::detect(Path::new("config.json")),
+            Ok(ConfigFormat::Json)
+        ));
+        assert!(matches!(
+            ConfigFormat::detect(Path::new("config.env")),
+            Ok(ConfigFormat::Env)
+        ));
+        assert!(matches!(
+            ConfigFormat::detect(Path::new(".env")),
+            Ok(ConfigFormat::Env)
+        ));
+        assert!(ConfigFormat::detect(Path::new("config.toml")).is_err());
+        assert!(ConfigFormat::detect(Path::new("config")).is_err());
+    }
+
+    #[test]
+    fn missing_file_errors() {
+        let result = load_config_file("/nonexistent/path.yaml");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn is_env_file_detection() {
+        assert!(is_env_file("config.env"));
+        assert!(is_env_file("/path/to/.env")); // extension is "env"
+        assert!(!is_env_file("config.yaml"));
+        assert!(!is_env_file("config.json"));
+    }
+}

--- a/model_gateway/src/config/mod.rs
+++ b/model_gateway/src/config/mod.rs
@@ -1,8 +1,10 @@
 pub mod builder;
+pub mod loader;
 pub mod types;
 pub(crate) mod validation;
 
 pub use builder::*;
+pub use loader::{dump_config_yaml, is_env_file, load_config_file, load_env_file};
 pub use types::*;
 
 #[derive(Debug, thiserror::Error)]

--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -12,9 +12,9 @@ use crate::core::ConnectionMode;
 
 /// Main router configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
 pub struct RouterConfig {
     pub mode: RoutingMode,
-    #[serde(default)]
     pub connection_mode: ConnectionMode,
     pub policy: PolicyConfig,
     pub host: String,

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -1,6 +1,6 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
-use clap::{ArgAction, Parser, Subcommand, ValueEnum};
+use clap::{parser::ValueSource, ArgAction, CommandFactory, FromArgMatches, Parser, Subcommand, ValueEnum};
 use rand::{distr::Alphanumeric, Rng};
 use smg::{
     config::{
@@ -21,6 +21,14 @@ use smg::{
 use smg_auth::{ApiKeyEntry, ControlPlaneAuthConfig, JwtConfig, Role};
 use smg_mesh::MeshServerConfig;
 
+/// Check if a CLI argument was explicitly provided (not from a default value).
+fn is_explicitly_set(matches: &clap::ArgMatches, id: &str) -> bool {
+    matches!(
+        matches.value_source(id),
+        Some(ValueSource::CommandLine) | Some(ValueSource::EnvVariable)
+    )
+}
+
 /// Pre-extract `--config <path>` from raw args before clap parsing.
 /// Needed so .env files can be loaded before clap reads env vars.
 fn pre_extract_config_path(args: &[String]) -> Option<String> {
@@ -34,6 +42,158 @@ fn pre_extract_config_path(args: &[String]) -> Option<String> {
         }
     }
     None
+}
+
+/// Merge a file-loaded [`RouterConfig`] with a CLI-derived one.
+///
+/// Uses JSON deep merge: for each config field, the CLI value wins only if the
+/// corresponding CLI arg was explicitly provided (via command line or env var).
+/// Otherwise the file value is kept.
+///
+/// Adding a new flat field to both `CliArgs` and `RouterConfig` requires
+/// **zero changes** here — the merge is convention-based (`field_name` in the
+/// config JSON matches `field-name` as the clap arg ID).
+fn merge_configs(
+    file_config: RouterConfig,
+    cli_config: RouterConfig,
+    matches: &clap::ArgMatches,
+) -> ConfigResult<RouterConfig> {
+    // Collect explicitly-set CLI arg IDs, normalized to underscore format.
+    // Also expand aliases for args whose names don't match config field paths.
+    let explicit: HashSet<String> = matches
+        .ids()
+        .filter(|id| is_explicitly_set(matches, id.as_str()))
+        .flat_map(|id| {
+            let key = id.as_str().replace('-', "_");
+            let mut keys = vec![key.clone()];
+            if let Some(alias) = cli_arg_to_config_path(&key) {
+                keys.push(alias);
+            }
+            keys
+        })
+        .collect();
+
+    let mut base = serde_json::to_value(&file_config).map_err(|e| {
+        ConfigError::ValidationFailed {
+            reason: format!("Failed to serialize file config: {e}"),
+        }
+    })?;
+    let overrides = serde_json::to_value(&cli_config).map_err(|e| {
+        ConfigError::ValidationFailed {
+            reason: format!("Failed to serialize CLI config: {e}"),
+        }
+    })?;
+
+    // Skip enum/structural fields — they need whole-value replacement, not deep merge
+    let skip_keys: &[&str] = &["mode", "policy", "connection_mode"];
+    deep_merge(&mut base, &overrides, &explicit, "", skip_keys);
+
+    // Handle enum/structural fields: replace entirely when any constituent CLI arg is set
+    if let (Some(base_map), Some(override_map)) = (base.as_object_mut(), overrides.as_object()) {
+        const MODE_ARGS: &[&str] = &[
+            "worker_urls",
+            "pd_disaggregation",
+            "decode",
+            "backend",
+            "prefill_policy",
+            "decode_policy",
+        ];
+        if MODE_ARGS.iter().any(|k| explicit.contains(*k)) {
+            for key in ["mode", "connection_mode"] {
+                if let Some(val) = override_map.get(key) {
+                    base_map.insert(key.to_string(), val.clone());
+                }
+            }
+        }
+
+        const POLICY_ARGS: &[&str] = &[
+            "policy",
+            "cache_threshold",
+            "balance_abs_threshold",
+            "balance_rel_threshold",
+            "eviction_interval",
+            "max_tree_size",
+            "block_size",
+            "max_idle_secs",
+            "assignment_mode",
+            "prefix_token_count",
+            "prefix_hash_load_factor",
+        ];
+        if POLICY_ARGS.iter().any(|k| explicit.contains(*k)) {
+            if let Some(val) = override_map.get("policy") {
+                base_map.insert("policy".to_string(), val.clone());
+            }
+        }
+    }
+
+    serde_json::from_value(base).map_err(|e| ConfigError::ValidationFailed {
+        reason: format!("Failed to deserialize merged config: {e}"),
+    })
+}
+
+/// Map CLI arg names (underscore-normalized) to RouterConfig JSON paths
+/// where the naming convention (`field_name` ↔ `field-name`) doesn't hold.
+fn cli_arg_to_config_path(cli_key: &str) -> Option<String> {
+    // CLI "cb_*" → config "circuit_breaker.*"
+    if let Some(rest) = cli_key.strip_prefix("cb_") {
+        return Some(format!("circuit_breaker_{rest}"));
+    }
+    // CLI "health_{failure,success}_threshold" → config "health_check.{failure,success}_threshold"
+    if cli_key == "health_failure_threshold" || cli_key == "health_success_threshold" {
+        return Some(format!("health_check_{}", &cli_key["health_".len()..]));
+    }
+    // CLI "disable_health_check" → config "health_check.disable_health_check"
+    if cli_key == "disable_health_check" {
+        return Some("health_check_disable_health_check".to_string());
+    }
+    // CLI "health_check_interval_secs" → config "health_check.check_interval_secs"
+    if cli_key == "health_check_interval_secs" {
+        return Some("health_check_check_interval_secs".to_string());
+    }
+    // CLI args with different suffixes
+    match cli_key {
+        "worker_startup_check_interval" => Some("worker_startup_check_interval_secs".to_string()),
+        "load_monitor_interval" => Some("load_monitor_interval_secs".to_string()),
+        _ => None,
+    }
+}
+
+/// Recursively merge `overrides` into `base`.
+///
+/// A leaf value is overridden only if its full path (keys joined with `_`)
+/// appears in `explicit`. Object values are recursed into, except keys in
+/// `skip_keys` which are handled separately.
+fn deep_merge(
+    base: &mut serde_json::Value,
+    overrides: &serde_json::Value,
+    explicit: &HashSet<String>,
+    prefix: &str,
+    skip_keys: &[&str],
+) {
+    if let (Some(base_map), Some(override_map)) = (base.as_object_mut(), overrides.as_object()) {
+        for (key, override_val) in override_map {
+            if skip_keys.contains(&key.as_str()) {
+                continue;
+            }
+            let path = if prefix.is_empty() {
+                key.clone()
+            } else {
+                format!("{prefix}_{key}")
+            };
+            match base_map.get_mut(key) {
+                Some(base_val) if base_val.is_object() && override_val.is_object() => {
+                    deep_merge(base_val, override_val, explicit, &path, &[]);
+                }
+                Some(base_val) if explicit.contains(&path) => {
+                    *base_val = override_val.clone();
+                }
+                None if explicit.contains(&path) => {
+                    base_map.insert(key.clone(), override_val.clone());
+                }
+                _ => {} // not explicitly set → keep file value
+            }
+        }
+    }
 }
 
 fn parse_prefill_args() -> Vec<(String, Option<u16>)> {
@@ -991,15 +1151,55 @@ impl CliArgs {
     }
 
     /// Build a [`RouterConfig`] from a config file, applying explicit CLI overrides.
-    /// Load a YAML/JSON config file directly into a [`RouterConfig`],
-    /// applying only cert/MCP file loading via the builder.
-    fn build_router_config_from_file(&self, config_path: &str) -> ConfigResult<RouterConfig> {
-        let config = smg::config::load_config_file(config_path)?;
+    ///
+    /// Precedence: file defaults < env vars < CLI args.
+    /// Uses generic JSON deep merge — adding a new flat field requires zero changes.
+    fn build_router_config_from_file(
+        &mut self,
+        config_path: &str,
+        matches: &clap::ArgMatches,
+        prefill_urls: Vec<(String, Option<u16>)>,
+    ) -> ConfigResult<RouterConfig> {
+        let file_config = smg::config::load_config_file(config_path)?;
+        let cli_config = self.to_router_config(prefill_urls)?;
+        let config = merge_configs(file_config, cli_config, matches)?;
+
+        // Sync fields that to_server_config() reads from CliArgs directly
+        self.sync_server_fields(&config, matches);
 
         RouterConfigBuilder::from_config(config)
             .maybe_server_cert_and_key(self.tls_cert_path.as_ref(), self.tls_key_path.as_ref())
             .maybe_mcp_config_path(self.mcp_config_path.as_ref())
             .build()
+    }
+
+    /// Sync merged config values back to `self` for fields that
+    /// [`to_server_config`] reads directly from `CliArgs`.
+    fn sync_server_fields(&mut self, config: &RouterConfig, matches: &clap::ArgMatches) {
+        macro_rules! sync {
+            ($($field:ident),* $(,)?) => {
+                $(
+                    {
+                        let arg_id = stringify!($field).replace('_', "-");
+                        if !is_explicitly_set(matches, &arg_id) {
+                            self.$field = config.$field.clone();
+                        }
+                    }
+                )*
+            };
+        }
+        sync!(host, port, max_payload_size, request_timeout_secs);
+
+        // Type mismatches: CliArgs has String/Option<String>,
+        // RouterConfig has Option<String>
+        if !is_explicitly_set(matches, "log-level") {
+            if let Some(ref level) = config.log_level {
+                self.log_level.clone_from(level);
+            }
+        }
+        if !is_explicitly_set(matches, "log-dir") {
+            self.log_dir.clone_from(&config.log_dir);
+        }
     }
 
     fn to_router_config(
@@ -1359,22 +1559,31 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    let cli = Cli::parse_from(&filtered_args);
+    // Parse CLI, retaining ArgMatches for value_source() checks during config merge
+    let cli_matches = Cli::command().get_matches_from(&filtered_args);
+    let cli = match Cli::from_arg_matches(&cli_matches) {
+        Ok(cli) => cli,
+        Err(e) => e.exit(),
+    };
 
-    // Handle subcommands or use direct args
+    // Get ArgMatches for CliArgs (may be top-level or inside "launch" subcommand)
+    let args_matches = cli_matches
+        .subcommand_matches("launch")
+        .unwrap_or(&cli_matches);
+
     let mut cli_args = match cli.command {
         Some(Commands::Launch { args }) => args,
         None => cli.router_args,
     };
 
-    // Get the right ArgMatches for value_source() checks
     // Handle --dump-config: build config and print as YAML
     if cli_args.dump_config {
-        let router_config = if let Some(ref path) = cli_args.config {
+        let config_path = cli_args.config.clone();
+        let router_config = if let Some(ref path) = config_path {
             if smg::config::is_env_file(path) {
                 cli_args.to_router_config(prefill_urls)?
             } else {
-                cli_args.build_router_config_from_file(path)?
+                cli_args.build_router_config_from_file(path, args_matches, prefill_urls)?
             }
         } else {
             cli_args.to_router_config(prefill_urls)?
@@ -1416,12 +1625,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // Build router config: from config file or from CLI args
-    let router_config = if let Some(ref path) = cli_args.config {
+    let config_path = cli_args.config.clone();
+    let router_config = if let Some(ref path) = config_path {
         if smg::config::is_env_file(path) {
             cli_args.to_router_config(prefill_urls)?
         } else {
             println!("Loading config from: {path}");
-            cli_args.build_router_config_from_file(path)?
+            cli_args.build_router_config_from_file(path, args_matches, prefill_urls)?
         }
     } else {
         cli_args.to_router_config(prefill_urls)?

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -6,8 +6,8 @@ use smg::{
     config::{
         CircuitBreakerConfig, ConfigError, ConfigResult, DiscoveryConfig, HealthCheckConfig,
         HistoryBackend, ManualAssignmentMode, MetricsConfig, OracleConfig, PolicyConfig,
-        PostgresConfig, RedisConfig, RetryConfig, RouterConfig, RoutingMode, SchemaConfig,
-        TokenizerCacheConfig, TraceConfig,
+        PostgresConfig, RedisConfig, RetryConfig, RouterConfig, RouterConfigBuilder, RoutingMode,
+        SchemaConfig, TokenizerCacheConfig, TraceConfig,
     },
     core::ConnectionMode,
     observability::{
@@ -20,6 +20,22 @@ use smg::{
 };
 use smg_auth::{ApiKeyEntry, ControlPlaneAuthConfig, JwtConfig, Role};
 use smg_mesh::MeshServerConfig;
+
+/// Pre-extract `--config <path>` from raw args before clap parsing.
+/// Needed so .env files can be loaded before clap reads env vars.
+fn pre_extract_config_path(args: &[String]) -> Option<String> {
+    let mut iter = args.iter();
+    while let Some(arg) = iter.next() {
+        if arg == "--config" {
+            return iter.next().cloned();
+        }
+        if let Some(path) = arg.strip_prefix("--config=") {
+            return Some(path.to_string());
+        }
+    }
+    None
+}
+
 fn parse_prefill_args() -> Vec<(String, Option<u16>)> {
     let args: Vec<String> = std::env::args().collect();
     let mut prefill_entries = Vec::new();
@@ -134,6 +150,18 @@ enum Commands {
 
 #[derive(Parser, Debug)]
 struct CliArgs {
+    // ==================== Configuration File ====================
+    /// Path to a configuration file (YAML, JSON, or .env).
+    /// When provided, the file values are used as defaults that CLI
+    /// arguments and environment variables can override.
+    #[arg(long, help_heading = "Configuration")]
+    config: Option<String>,
+
+    /// Dump the effective configuration as YAML and exit.
+    /// Useful for generating a config file template.
+    #[arg(long, default_value_t = false, help_heading = "Configuration")]
+    dump_config: bool,
+
     // ==================== Worker Configuration ====================
     /// Host address to bind the router server
     #[arg(long, default_value = "0.0.0.0", help_heading = "Worker Configuration")]
@@ -962,6 +990,18 @@ impl CliArgs {
         Ok(rcf)
     }
 
+    /// Build a [`RouterConfig`] from a config file, applying explicit CLI overrides.
+    /// Load a YAML/JSON config file directly into a [`RouterConfig`],
+    /// applying only cert/MCP file loading via the builder.
+    fn build_router_config_from_file(&self, config_path: &str) -> ConfigResult<RouterConfig> {
+        let config = smg::config::load_config_file(config_path)?;
+
+        RouterConfigBuilder::from_config(config)
+            .maybe_server_cert_and_key(self.tls_cert_path.as_ref(), self.tls_key_path.as_ref())
+            .maybe_mcp_config_path(self.mcp_config_path.as_ref())
+            .build()
+    }
+
     fn to_router_config(
         &self,
         prefill_urls: Vec<(String, Option<u16>)>,
@@ -1286,6 +1326,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
+    // Auto-load .env from current directory (if present)
+    let _ = dotenvy::dotenv();
+
+    // Pre-extract --config before clap parsing so .env files can be loaded
+    // before clap reads environment variables via `env = "..."` attributes.
+    let config_path = pre_extract_config_path(&args);
+    if let Some(ref path) = config_path {
+        if smg::config::is_env_file(path) {
+            smg::config::load_env_file(path)?;
+        }
+    }
+
     let prefill_urls = parse_prefill_args();
 
     let mut filtered_args: Vec<String> = Vec::new();
@@ -1307,13 +1359,30 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    let cli = Cli::parse_from(filtered_args);
+    let cli = Cli::parse_from(&filtered_args);
 
     // Handle subcommands or use direct args
     let mut cli_args = match cli.command {
         Some(Commands::Launch { args }) => args,
         None => cli.router_args,
     };
+
+    // Get the right ArgMatches for value_source() checks
+    // Handle --dump-config: build config and print as YAML
+    if cli_args.dump_config {
+        let router_config = if let Some(ref path) = cli_args.config {
+            if smg::config::is_env_file(path) {
+                cli_args.to_router_config(prefill_urls)?
+            } else {
+                cli_args.build_router_config_from_file(path)?
+            }
+        } else {
+            cli_args.to_router_config(prefill_urls)?
+        };
+        let yaml = smg::config::dump_config_yaml(&router_config)?;
+        println!("{yaml}");
+        return Ok(());
+    }
 
     // Automatically enable IGW mode when service discovery is turned on
     if cli_args.service_discovery && !cli_args.enable_igw {
@@ -1346,7 +1415,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    let router_config = cli_args.to_router_config(prefill_urls)?;
+    // Build router config: from config file or from CLI args
+    let router_config = if let Some(ref path) = cli_args.config {
+        if smg::config::is_env_file(path) {
+            cli_args.to_router_config(prefill_urls)?
+        } else {
+            println!("Loading config from: {path}");
+            cli_args.build_router_config_from_file(path)?
+        }
+    } else {
+        cli_args.to_router_config(prefill_urls)?
+    };
     router_config.validate()?;
 
     let server_config = cli_args.to_server_config(router_config)?;


### PR DESCRIPTION
## Summary
- Add `--config <path>` flag to load configuration from YAML, JSON, or `.env` files instead of passing 130+ CLI arguments
- Add `--dump-config` flag to serialize effective configuration as YAML for template generation
- Wire config file support through Python bindings

## What changed

| File | Change |
|------|--------|
| `model_gateway/Cargo.toml` | Add `dotenvy` dependency for `.env` file loading |
| `model_gateway/src/config/loader.rs` | **New** — config file loader with format detection, YAML/JSON deserialization, `.env` loading, YAML serialization, and 6 unit tests |
| `model_gateway/src/config/mod.rs` | Export loader module and public functions |
| `model_gateway/src/config/types.rs` | Add `#[serde(default)]` at struct level on `RouterConfig` so partial configs work |
| `model_gateway/src/main.rs` | Add `--config`/`--dump-config` flags, `.env` pre-loading before clap, `build_router_config_from_file()` via `RouterConfigBuilder` |
| `bindings/python/src/smg/router_args.py` | Add `config` field and `--config` CLI argument |
| `bindings/python/src/smg/router.py` | Pass `config_path` through to Rust `Router` |
| `bindings/python/src/lib.rs` | Add `config_path` field, load config file or `.env` in `start()` |

## How it works

- **YAML/JSON**: deserializes directly into `RouterConfig` via serde, then passes through `RouterConfigBuilder` for cert/MCP file loading
- **`.env`**: loaded into process environment before clap parsing so existing `env = "..."` attributes pick up values automatically
- **`--dump-config`**: serializes effective `RouterConfig` to YAML and exits
- **Precedence**: Defaults → Config file → Env vars → CLI args

## Example usage

```bash
# Generate a config template
cargo run -p smg -- --dump-config > gateway.yaml

# Run with config file
cargo run -p smg -- --config gateway.yaml

# Use .env file
cargo run -p smg -- --config .env
```

## Test plan
- [x] 6 unit tests in `loader.rs` (YAML roundtrip, partial YAML defaults, JSON loading, format detection, missing file errors, `.env` detection)
- [x] All 858 existing tests pass (`cargo test -p smg`)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] Both `smg` and `smg-python` crates compile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Load configuration from YAML, JSON, or .env files; env files are applied early at startup.
  * New CLI option to specify a configuration file and a --dump-config option to print effective config as YAML.
  * Config file values are mergeable and can be overridden by explicit CLI arguments.
  * Python bindings: optional config path can be provided when constructing the Router.

* **Tests**
  * Unit tests added for config loading and format detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->