### PR TITLE
fix(deps): remove aws-lc-sys to fix aarch64 PyPI build

### DIFF
--- a/model_gateway/Cargo.toml
+++ b/model_gateway/Cargo.toml
@@ -79,7 +79,7 @@ smg-grpc-client.workspace = true
 
 # External dependencies (not in workspace)
 clap = { version = "4", features = ["derive", "env"] }
-axum-server = { version = "0.8.0", default-features = false, features = ["tls-rustls"] }
+axum-server = { version = "0.8.0", default-features = false, features = ["tls-rustls-no-provider"] }
 tower = { version = "0.5", features = ["full"] }
 tower-http = { version = "0.6", features = ["trace", "compression-gzip", "cors", "timeout", "limit", "request-id", "util"] }
 serde_json = { version = "1.0", default-features = false, features = ["std", "preserve_order"] }
@@ -96,7 +96,7 @@ tracing-opentelemetry = "0.28"
 kube = { version = "3.0.1", features = ["runtime", "derive"] }
 k8s-openapi = { version = "0.27.0", features = ["v1_33"] }
 metrics = "0.24.2"
-metrics-exporter-prometheus = "0.18.1"
+metrics-exporter-prometheus = { version = "0.18.1", default-features = false, features = ["http-listener"] }
 regex = "1.10"
 memchr = "2.7"
 url = "2.5.4"


### PR DESCRIPTION
## Summary

Fixes the v1.3.0 PyPI release failure on `linux aarch64` by removing `aws-lc-sys` from the dependency tree entirely.

- Refs: https://github.com/lightseekorg/smg/actions/runs/23093714817/job/67082553288

## What changed

- **`model_gateway/Cargo.toml`**: `axum-server` feature `tls-rustls` → `tls-rustls-no-provider` to stop it from activating `rustls/aws-lc-rs`
- **`model_gateway/Cargo.toml`**: `metrics-exporter-prometheus` disabled default features (unused `push-gateway` was activating `hyper-rustls/aws-lc-rs`), enabled only `http-listener`

## Why

The `aws-lc-sys@0.38.0` C code requires `stdatomic.h` (C11 header) which the aarch64 cross-compilation GCC toolchain in the maturin Docker container doesn't provide. The project only uses `ring` as its crypto backend, so `aws-lc-sys` was compiled but never used — pure build-time waste.

## How

Traced the dependency chain using `cargo tree -i aws-lc-sys -e features` and found two feature paths that activated `aws-lc-rs`:

1. `axum-server[tls-rustls]` → `rustls[aws-lc-rs]` → `aws-lc-rs` → `aws-lc-sys`
2. `metrics-exporter-prometheus[default]` → `push-gateway` → `hyper-rustls[aws-lc-rs]` → `rustls[aws-lc-rs]` → `aws-lc-rs` → `aws-lc-sys`

Both paths eliminated. `cargo tree -i aws-lc-sys` now returns "did not match any packages". Full `cargo check` passes.

## Test plan

- [x] `cargo check` passes — no compilation errors from removing the features
- [x] `cargo tree -i aws-lc-sys` confirms the dependency is fully eliminated
- [ ] After merge, re-run "Release SMG to PyPI" workflow via `workflow_dispatch` to publish v1.3.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal server and monitoring dependencies to optimize build configuration and feature flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->