### PR TITLE
fix(ci): add VERSION_OVERRIDE to check-versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -223,11 +223,4 @@ bump-version: ## Bump version across all files (usage: make bump-version VERSION
 	@echo "Verify with: make show-version"
 
 check-versions: ## Check workspace crate versions against latest tag (usage: make check-versions [TAG=v1.0.0] [VERSION_OVERRIDE=1.3.1])
-	@args=""; \
-	if [ -n "$(TAG)" ]; then args="$$args $(TAG)"; fi; \
-	if [ -n "$(VERSION_OVERRIDE)" ]; then export VERSION_OVERRIDE="$(VERSION_OVERRIDE)"; fi; \
-	if [ -n "$$args" ]; then \
-		./scripts/check_release_versions.sh $$args; \
-	else \
-		./scripts/check_release_versions.sh; \
-	fi
+	@VERSION_OVERRIDE="$(VERSION_OVERRIDE)" ./scripts/check_release_versions.sh $(TAG)

--- a/scripts/check_release_versions.sh
+++ b/scripts/check_release_versions.sh
@@ -122,6 +122,16 @@ if ! git rev-parse "$TAG" >/dev/null 2>&1; then
     exit 1
 fi
 
+# ---------------------------------------------------------------------------
+# VERSION_OVERRIDE: skip conventional-commit detection and use this version
+# for all bumps. Set via: VERSION_OVERRIDE=1.3.1 ./check_release_versions.sh
+# ---------------------------------------------------------------------------
+VERSION_OVERRIDE="${VERSION_OVERRIDE:-}"
+if [[ -n "$VERSION_OVERRIDE" && ! "$VERSION_OVERRIDE" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo -e "${RED}ERROR: VERSION_OVERRIDE must be in X.Y.Z format, got: '$VERSION_OVERRIDE'${NC}" >&2
+    exit 1
+fi
+
 echo -e "${BOLD}Checking workspace versions against tag: ${BLUE}$TAG${NC}"
 if [[ -n "$VERSION_OVERRIDE" ]]; then
     echo -e "${BOLD}Version override: ${CYAN}$VERSION_OVERRIDE${NC} (ignoring conventional commit detection)"
@@ -171,12 +181,6 @@ get_workspace_dep_version() {
         | grep -o 'version = "[^"]*"' \
         | sed 's/version = "\(.*\)"/\1/'
 }
-
-# ---------------------------------------------------------------------------
-# VERSION_OVERRIDE: skip conventional-commit detection and use this version
-# for all bumps. Set via: VERSION_OVERRIDE=1.3.1 ./check_release_versions.sh
-# ---------------------------------------------------------------------------
-VERSION_OVERRIDE="${VERSION_OVERRIDE:-}"
 
 # Detect semver bump level from conventional commits touching a directory.
 # Scans commit subjects and bodies for:


### PR DESCRIPTION
## Summary

- Adds `VERSION_OVERRIDE` parameter to `make check-versions` that bypasses conventional commit detection and uses the specified version for all bumps
- Fixes the case where `feat:` commits trigger a minor bump (e.g., 1.3.0 → 1.4.0) when only a patch bump is warranted (1.3.0 → 1.3.1)

## What changed

- **Makefile**: `check-versions` target accepts `VERSION_OVERRIDE`, exports it as env var to the script
- **scripts/check_release_versions.sh**:
  - `bump_version()` returns the override when `VERSION_OVERRIDE` is set, skipping level-based computation
  - Displays override notice in output header for visibility

## Usage

```bash
# Auto-detect bump level from conventional commits (existing behavior)
make check-versions

# Override bump level — use 1.3.1 for all bumps regardless of commit types
make check-versions VERSION_OVERRIDE=1.3.1
```

## Test plan

- [ ] `make check-versions` without override behaves as before (auto-detect from commits)
- [ ] `make check-versions VERSION_OVERRIDE=1.3.1` proposes 1.3.1 for all unbumped crates
- [ ] Applying the fix with override correctly updates all version files and sync targets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced release version-checking tooling to always run checks and support an optional version-override parameter. The override is validated for proper semantic format (X.Y.Z), initialized safely, and when used the tool reports the override and applies it to version bumps instead of automatic detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->