### PR TITLE
chore(release): bump version to 1.3.1

### DIFF
--- a/.github/workflows/release-sglang-docker.yml
+++ b/.github/workflows/release-sglang-docker.yml
@@ -4,7 +4,7 @@ run-name: >-
   SMG+SGLang |
   base=${{ inputs.base_image_ref || 'lmsysorg/sglang:v0.5.9' }} |
   engine=${{ inputs.sglang_commit || 'latest' }} |
-  smg=${{ inputs.smg_commit || 'v1.3.0' }} |
+  smg=${{ inputs.smg_commit || 'v1.3.1' }} |
   by @${{ github.actor }}
 
 on:
@@ -43,10 +43,10 @@ on:
       smg_commit:
         description: 'SMG commit/ref ("latest" for HEAD)'
         required: false
-        default: 'v1.3.0'
+        default: 'v1.3.1'
         type: string
       tag:
-        description: 'Override image tag (e.g. v1.3.0-sglang-v0.5.9)'
+        description: 'Override image tag (e.g. v1.3.1-sglang-v0.5.9)'
         required: false
         type: string
 
@@ -63,7 +63,7 @@ jobs:
       engine_repo: ${{ inputs.sglang_repo }}
       engine_commit: ${{ inputs.sglang_commit || 'latest' }}
       smg_repo: ${{ inputs.smg_repo || 'https://github.com/lightseekorg/smg' }}
-      smg_commit: ${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.3.0' }}
+      smg_commit: ${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.3.1' }}
       tag: ${{ inputs.tag }}
       dry_run: ${{ github.event_name == 'pull_request' }}
     secrets: inherit

--- a/.github/workflows/release-trtllm-docker.yml
+++ b/.github/workflows/release-trtllm-docker.yml
@@ -36,10 +36,10 @@ on:
       smg_commit:
         description: 'SMG commit/ref ("latest" for HEAD)'
         required: false
-        default: 'v1.3.0'
+        default: 'v1.3.1'
         type: string
       tag:
-        description: 'Override image tag (e.g. v1.3.0-trtllm-1.3.0)'
+        description: 'Override image tag (e.g. v1.3.1-trtllm-1.3.0)'
         required: false
         type: string
 
@@ -56,7 +56,7 @@ jobs:
       engine_repo: ${{ inputs.trtllm_repo }}
       engine_commit: ${{ inputs.trtllm_commit || 'latest' }}
       smg_repo: ${{ inputs.smg_repo || 'https://github.com/lightseekorg/smg' }}
-      smg_commit: ${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.3.0' }}
+      smg_commit: ${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.3.1' }}
       tag: ${{ inputs.tag }}
       source_build_repo: ${{ inputs.trtllm_repo }}
       source_build_ref: ${{ inputs.trtllm_commit || 'latest' }}

--- a/.github/workflows/release-vllm-docker.yml
+++ b/.github/workflows/release-vllm-docker.yml
@@ -36,10 +36,10 @@ on:
       smg_commit:
         description: 'SMG commit/ref ("latest" for HEAD)'
         required: false
-        default: 'v1.3.0'
+        default: 'v1.3.1'
         type: string
       tag:
-        description: 'Override image tag (e.g. v1.3.0-vllm-v0.17.0)'
+        description: 'Override image tag (e.g. v1.3.1-vllm-v0.17.0)'
         required: false
         type: string
 
@@ -56,6 +56,6 @@ jobs:
       engine_repo: ${{ inputs.vllm_repo }}
       engine_commit: ${{ inputs.vllm_commit || 'latest' }}
       smg_repo: ${{ inputs.smg_repo || 'https://github.com/lightseekorg/smg' }}
-      smg_commit: ${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.3.0' }}
+      smg_commit: ${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.3.1' }}
       tag: ${{ inputs.tag }}
     secrets: inherit

--- a/bindings/golang/Cargo.toml
+++ b/bindings/golang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-golang"
-version = "1.3.0"
+version = "1.3.1"
 edition = "2021"
 
 [lib]

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-python"
-version = "1.3.0"
+version = "1.3.1"
 edition = "2021"
 
 [lib]

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "smg"
-version = "1.3.0"
+version = "1.3.1"
 description = "High-performance Rust-based inference gateway for large-scale LLM deployments"
 authors = [
     {name = "Simo Lin", email = "linsimo.mark@gmail.com"},

--- a/model_gateway/Cargo.toml
+++ b/model_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg"
-version = "1.3.0"
+version = "1.3.1"
 edition = "2021"
 description = "High-performance model-routing gateway for large-scale LLM deployments"
 license = "Apache-2.0"

--- a/scripts/check_release_versions.sh
+++ b/scripts/check_release_versions.sh
@@ -100,7 +100,6 @@ SMG_VERSION_SYNC=(
     "sglang-docker|.github/workflows/release-sglang-docker.yml|workflow"
     "vllm-docker|.github/workflows/release-vllm-docker.yml|workflow"
     "trtllm-docker|.github/workflows/release-trtllm-docker.yml|workflow"
-    "build-engine|.github/workflows/_build-engine-image.yml|workflow"
 )
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Patch release v1.3.1 — bumps all version references from 1.3.0 to 1.3.1.

## What changed

- **model_gateway/Cargo.toml**: 1.3.0 → 1.3.1
- **bindings/python/Cargo.toml**: 1.3.0 → 1.3.1
- **bindings/python/pyproject.toml**: 1.3.0 → 1.3.1
- **bindings/golang/Cargo.toml**: 1.3.0 → 1.3.1
- **release-sglang-docker.yml**: v1.3.0 → v1.3.1 (defaults, fallbacks, description examples)
- **release-vllm-docker.yml**: v1.3.0 → v1.3.1
- **release-trtllm-docker.yml**: v1.3.0 → v1.3.1
- **check_release_versions.sh**: remove `build-engine` from `SMG_VERSION_SYNC` — it uses `default: 'main'` (branch ref), not a version tag, so it should not be version-synced

## How

Generated via `VERSION_OVERRIDE=1.3.1 ./scripts/check_release_versions.sh` (from #764).

## Test plan

- [ ] `make check-versions VERSION_OVERRIDE=1.3.1` reports all versions consistent
- [ ] `cargo build --release` succeeds
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version from v1.3.0 to v1.3.1 across Docker workflows, Python and Go bindings, and related packages.
  * Synchronized version references in build and release configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->