### PR TITLE
feat(completions): add native gRPC pipeline typing for /v1/completions

### DIFF
--- a/model_gateway/src/routers/grpc/common/stages/dispatch_metadata.rs
+++ b/model_gateway/src/routers/grpc/common/stages/dispatch_metadata.rs
@@ -32,6 +32,7 @@ impl PipelineStage for DispatchMetadataStage {
         let request_id = proto_request.request_id().to_string();
         let model = match &ctx.input.request_type {
             RequestType::Chat(req) => req.model.clone(),
+            RequestType::Completion(req) => req.model.clone(),
             RequestType::Generate(_req) => {
                 // Generate requests don't have a model field
                 // Use model_id from input or UNKNOWN_MODEL_ID

--- a/model_gateway/src/routers/grpc/context.rs
+++ b/model_gateway/src/routers/grpc/context.rs
@@ -11,6 +11,7 @@ use llm_tokenizer::{stop::StopSequenceDecoder, traits::Tokenizer, TokenizerRegis
 use openai_protocol::{
     chat::{ChatCompletionRequest, ChatCompletionResponse},
     classify::{ClassifyRequest, ClassifyResponse},
+    completion::{CompletionRequest, CompletionResponse},
     embedding::{EmbeddingRequest, EmbeddingResponse},
     generate::{GenerateRequest, GenerateResponse},
     messages::{CreateMessageRequest, Message},
@@ -50,6 +51,7 @@ pub(crate) struct RequestInput {
 pub(crate) enum RequestType {
     Chat(Arc<ChatCompletionRequest>),
     Generate(Arc<GenerateRequest>),
+    Completion(Arc<CompletionRequest>),
     Responses(Arc<ResponsesRequest>),
     Embedding(Arc<EmbeddingRequest>),
     Classify(Arc<ClassifyRequest>),
@@ -61,6 +63,7 @@ impl std::fmt::Display for RequestType {
         match self {
             Self::Chat(_) => write!(f, "Chat"),
             Self::Generate(_) => write!(f, "Generate"),
+            Self::Completion(_) => write!(f, "Completion"),
             Self::Responses(_) => write!(f, "Responses"),
             Self::Embedding(_) => write!(f, "Embedding"),
             Self::Classify(_) => write!(f, "Classify"),
@@ -254,6 +257,24 @@ impl RequestContext {
         }
     }
 
+    /// Create context for completion request
+    pub fn for_completion(
+        request: Arc<CompletionRequest>,
+        headers: Option<HeaderMap>,
+        model_id: Option<String>,
+        components: Arc<SharedComponents>,
+    ) -> Self {
+        Self {
+            input: RequestInput {
+                request_type: RequestType::Completion(request),
+                headers,
+                model_id,
+            },
+            components,
+            state: ProcessingState::default(),
+        }
+    }
+
     /// Create context for Responses API request
     pub fn for_responses(
         request: Arc<ResponsesRequest>,
@@ -374,6 +395,38 @@ impl RequestContext {
         }
     }
 
+    /// Get completion request (panics if not completion)
+    #[expect(
+        dead_code,
+        reason = "ref accessor provided for API completeness alongside Arc accessor"
+    )]
+    #[expect(
+        clippy::panic,
+        reason = "typed accessor: caller guarantees variant via RequestType construction"
+    )]
+    pub fn completion_request(&self) -> &CompletionRequest {
+        match &self.input.request_type {
+            RequestType::Completion(req) => req.as_ref(),
+            _ => panic!("Expected completion request"),
+        }
+    }
+
+    /// Get Arc clone of completion request (panics if not completion)
+    #[expect(
+        dead_code,
+        reason = "Arc accessor is introduced before later stacked PRs use it from completion stages"
+    )]
+    #[expect(
+        clippy::panic,
+        reason = "typed accessor: caller guarantees variant via RequestType construction"
+    )]
+    pub fn completion_request_arc(&self) -> Arc<CompletionRequest> {
+        match &self.input.request_type {
+            RequestType::Completion(req) => Arc::clone(req),
+            _ => panic!("Expected completion request"),
+        }
+    }
+
     /// Get Arc clone of responses request (panics if not responses)
     #[expect(
         clippy::panic,
@@ -419,6 +472,7 @@ impl RequestContext {
         match &self.input.request_type {
             RequestType::Chat(req) => req.stream,
             RequestType::Generate(req) => req.stream,
+            RequestType::Completion(req) => req.stream,
             RequestType::Responses(req) => req.stream.unwrap_or(false),
             RequestType::Messages(req) => req.stream.unwrap_or(false),
             RequestType::Embedding(_) => false, // Embeddings are never streaming
@@ -597,10 +651,16 @@ pub(crate) enum ExecutionResult {
 
 /// Final processed response
 #[derive(Debug)]
+#[expect(
+    dead_code,
+    reason = "Completion final response is introduced in the plumbing PR before later stacked PRs produce it"
+)]
 pub(crate) enum FinalResponse {
     Chat(ChatCompletionResponse),
     /// Generate response is a Vec of GenerateResponse (n=1 returns single item, n>1 returns multiple)
     Generate(Vec<GenerateResponse>),
+    /// Completion response (OpenAI /v1/completions format)
+    Completion(CompletionResponse),
     /// Embedding response
     Embedding(EmbeddingResponse),
     /// Classification response

--- a/model_gateway/src/routers/grpc/harmony/stages/request_building.rs
+++ b/model_gateway/src/routers/grpc/harmony/stages/request_building.rs
@@ -62,18 +62,54 @@ impl PipelineStage for HarmonyRequestBuildingStage {
         let request_id = match &ctx.input.request_type {
             RequestType::Chat(_) => format!("chatcmpl-{}", Uuid::now_v7()),
             RequestType::Responses(_) => format!("responses-{}", Uuid::now_v7()),
-            request_type @ (RequestType::Generate(_)
-            | RequestType::Embedding(_)
-            | RequestType::Classify(_)
-            | RequestType::Messages(_)) => {
+            RequestType::Generate(_) => {
                 error!(
                     function = "HarmonyRequestBuildingStage::execute",
-                    request_type = %request_type,
-                    "{request_type} request type not supported for Harmony models"
+                    "Generate request type not supported for Harmony models"
                 );
                 return Err(error::bad_request(
-                    "not_supported_in_harmony",
-                    format!("{request_type} requests are not supported with Harmony models"),
+                    "harmony_generate_not_supported",
+                    "Generate requests are not supported with Harmony models".to_string(),
+                ));
+            }
+            RequestType::Completion(_) => {
+                error!(
+                    function = "HarmonyRequestBuildingStage::execute",
+                    "Completion request type not supported for Harmony models"
+                );
+                return Err(error::bad_request(
+                    "harmony_completion_not_supported",
+                    "Completion requests are not supported with Harmony models".to_string(),
+                ));
+            }
+            RequestType::Embedding(_) => {
+                error!(
+                    function = "HarmonyRequestBuildingStage::execute",
+                    "Embedding request type not supported for Harmony models"
+                );
+                return Err(error::bad_request(
+                    "harmony_embedding_not_supported",
+                    "Embedding requests are not supported with Harmony models".to_string(),
+                ));
+            }
+            RequestType::Classify(_) => {
+                error!(
+                    function = "HarmonyRequestBuildingStage::execute",
+                    "Classify request type not supported for Harmony models"
+                );
+                return Err(error::bad_request(
+                    "harmony_classify_not_supported",
+                    "Classify requests are not supported with Harmony models".to_string(),
+                ));
+            }
+            RequestType::Messages(_) => {
+                error!(
+                    function = "HarmonyRequestBuildingStage::execute",
+                    "Messages request type not supported for Harmony models"
+                );
+                return Err(error::bad_request(
+                    "harmony_messages_not_supported",
+                    "Messages requests are not supported with Harmony models".to_string(),
                 ));
             }
         };

--- a/model_gateway/src/routers/grpc/harmony/stages/response_processing.rs
+++ b/model_gateway/src/routers/grpc/harmony/stages/response_processing.rs
@@ -138,18 +138,54 @@ impl PipelineStage for HarmonyResponseProcessingStage {
                 ctx.state.response.responses_iteration_result = Some(iteration_result);
                 Ok(None)
             }
-            request_type @ (RequestType::Generate(_)
-            | RequestType::Embedding(_)
-            | RequestType::Classify(_)
-            | RequestType::Messages(_)) => {
+            RequestType::Generate(_) => {
                 error!(
                     function = "HarmonyResponseProcessingStage::execute",
-                    request_type = %request_type,
-                    "{request_type} request type not supported in Harmony pipeline"
+                    "Generate request type not supported in Harmony pipeline"
                 );
                 Err(error::internal_error(
-                    "not_supported_in_harmony",
-                    format!("{request_type} requests not supported in Harmony pipeline"),
+                    "harmony_generate_not_supported",
+                    "Generate requests not supported in Harmony pipeline",
+                ))
+            }
+            RequestType::Completion(_) => {
+                error!(
+                    function = "HarmonyResponseProcessingStage::execute",
+                    "Completion request type not supported in Harmony pipeline"
+                );
+                Err(error::internal_error(
+                    "harmony_completion_not_supported",
+                    "Completion requests not supported in Harmony pipeline",
+                ))
+            }
+            RequestType::Embedding(_) => {
+                error!(
+                    function = "HarmonyResponseProcessingStage::execute",
+                    "Embedding request type not supported in Harmony pipeline"
+                );
+                Err(error::internal_error(
+                    "harmony_embedding_not_supported",
+                    "Embedding requests not supported in Harmony pipeline",
+                ))
+            }
+            RequestType::Classify(_) => {
+                error!(
+                    function = "HarmonyResponseProcessingStage::execute",
+                    "Classify request type not supported in Harmony pipeline"
+                );
+                Err(error::internal_error(
+                    "harmony_classify_not_supported",
+                    "Classify requests not supported in Harmony pipeline",
+                ))
+            }
+            RequestType::Messages(_) => {
+                error!(
+                    function = "HarmonyResponseProcessingStage::execute",
+                    "Messages request type not supported in Harmony pipeline"
+                );
+                Err(error::internal_error(
+                    "harmony_messages_not_supported",
+                    "Messages requests not supported in Harmony pipeline",
                 ))
             }
         }

--- a/model_gateway/src/routers/grpc/pipeline.rs
+++ b/model_gateway/src/routers/grpc/pipeline.rs
@@ -9,6 +9,7 @@ use axum::response::{IntoResponse, Response};
 use openai_protocol::{
     chat::{ChatCompletionRequest, ChatCompletionResponse},
     classify::ClassifyRequest,
+    completion::CompletionRequest,
     embedding::EmbeddingRequest,
     generate::GenerateRequest,
     messages::CreateMessageRequest,
@@ -408,12 +409,13 @@ impl RequestPipeline {
                 axum::Json(response).into_response()
             }
             Some(FinalResponse::Generate(_))
+            | Some(FinalResponse::Completion(_))
             | Some(FinalResponse::Embedding(_))
             | Some(FinalResponse::Classify(_))
             | Some(FinalResponse::Messages(_)) => {
                 error!(
                     function = "execute_chat",
-                    "Wrong response type: expected Chat, got Generate/Embedding/Classify/Messages"
+                    "Wrong response type: expected Chat, got Generate/Completion/Embedding/Classify/Messages"
                 );
                 Metrics::record_router_error(
                     metrics_labels::ROUTER_GRPC,
@@ -443,6 +445,7 @@ impl RequestPipeline {
         }
     }
 
+    /// Execute the complete pipeline for a generate request
     /// Execute the complete pipeline for a generate request
     pub async fn execute_generate(
         &self,
@@ -512,12 +515,13 @@ impl RequestPipeline {
                 axum::Json(response).into_response()
             }
             Some(FinalResponse::Chat(_))
+            | Some(FinalResponse::Completion(_))
             | Some(FinalResponse::Embedding(_))
             | Some(FinalResponse::Classify(_))
             | Some(FinalResponse::Messages(_)) => {
                 error!(
                     function = "execute_generate",
-                    "Wrong response type: expected Generate, got Chat/Embedding/Classify/Messages"
+                    "Wrong response type: expected Generate, got Chat/Completion/Embedding/Classify/Messages"
                 );
                 Metrics::record_router_error(
                     metrics_labels::ROUTER_GRPC,
@@ -540,6 +544,116 @@ impl RequestPipeline {
                     metrics_labels::CONNECTION_GRPC,
                     model_id.as_deref().unwrap_or(UNKNOWN_MODEL_ID),
                     metrics_labels::ENDPOINT_GENERATE,
+                    metrics_labels::ERROR_INTERNAL,
+                );
+                error::internal_error("no_response_produced", "No response produced")
+            }
+        }
+    }
+
+    /// Execute the complete pipeline for a completion request
+    #[expect(
+        dead_code,
+        reason = "Completion pipeline entrypoint is introduced before later stacked PRs wire the router to call it"
+    )]
+    pub async fn execute_completion(
+        &self,
+        request: Arc<CompletionRequest>,
+        headers: Option<http::HeaderMap>,
+        model_id: Option<String>,
+        components: Arc<SharedComponents>,
+    ) -> Response {
+        let start = Instant::now();
+        let model = request.model.clone();
+        let streaming = request.stream;
+
+        Metrics::record_router_request(
+            metrics_labels::ROUTER_GRPC,
+            self.backend_type,
+            metrics_labels::CONNECTION_GRPC,
+            &model,
+            metrics_labels::ENDPOINT_COMPLETIONS,
+            bool_to_static_str(streaming),
+        );
+
+        let mut ctx =
+            RequestContext::for_completion(request, headers, model_id.clone(), components);
+
+        for stage in self.stages.iter() {
+            match stage.execute(&mut ctx).await {
+                Ok(Some(response)) => {
+                    Metrics::record_router_duration(
+                        metrics_labels::ROUTER_GRPC,
+                        self.backend_type,
+                        metrics_labels::CONNECTION_GRPC,
+                        &model,
+                        metrics_labels::ENDPOINT_COMPLETIONS,
+                        start.elapsed(),
+                    );
+                    return response;
+                }
+                Ok(None) => continue,
+                Err(response) => {
+                    Metrics::record_router_error(
+                        metrics_labels::ROUTER_GRPC,
+                        self.backend_type,
+                        metrics_labels::CONNECTION_GRPC,
+                        &model,
+                        metrics_labels::ENDPOINT_COMPLETIONS,
+                        error_type_from_status(response.status()),
+                    );
+                    error!(
+                        "Stage {} failed with status {}",
+                        stage.name(),
+                        response.status()
+                    );
+                    return response;
+                }
+            }
+        }
+
+        match ctx.state.response.final_response {
+            Some(FinalResponse::Completion(response)) => {
+                Metrics::record_router_duration(
+                    metrics_labels::ROUTER_GRPC,
+                    self.backend_type,
+                    metrics_labels::CONNECTION_GRPC,
+                    &model,
+                    metrics_labels::ENDPOINT_COMPLETIONS,
+                    start.elapsed(),
+                );
+                axum::Json(response).into_response()
+            }
+            Some(FinalResponse::Chat(_))
+            | Some(FinalResponse::Generate(_))
+            | Some(FinalResponse::Embedding(_))
+            | Some(FinalResponse::Classify(_))
+            | Some(FinalResponse::Messages(_)) => {
+                error!(
+                    function = "execute_completion",
+                    "Wrong response type: expected Completion"
+                );
+                Metrics::record_router_error(
+                    metrics_labels::ROUTER_GRPC,
+                    self.backend_type,
+                    metrics_labels::CONNECTION_GRPC,
+                    &model,
+                    metrics_labels::ENDPOINT_COMPLETIONS,
+                    metrics_labels::ERROR_INTERNAL,
+                );
+                error::internal_error("wrong_response_type", "Internal error: wrong response type")
+            }
+            None => {
+                error!(
+                    function = "execute_completion",
+                    "No response produced by pipeline"
+                );
+                Metrics::record_router_error(
+                    metrics_labels::ROUTER_GRPC,
+                    self.backend_type,
+                    metrics_labels::CONNECTION_GRPC,
+                    &model,
+                    metrics_labels::ENDPOINT_COMPLETIONS,
                     metrics_labels::ERROR_INTERNAL,
                 );
                 error::internal_error("no_response_produced", "No response produced")
@@ -818,6 +932,7 @@ impl RequestPipeline {
             }
             Some(FinalResponse::Chat(_))
             | Some(FinalResponse::Generate(_))
+            | Some(FinalResponse::Completion(_))
             | Some(FinalResponse::Embedding(_))
             | Some(FinalResponse::Classify(_)) => {
                 error!(
@@ -899,6 +1014,7 @@ impl RequestPipeline {
         match ctx.state.response.final_response {
             Some(FinalResponse::Chat(response)) => Ok(response),
             Some(FinalResponse::Generate(_))
+            | Some(FinalResponse::Completion(_))
             | Some(FinalResponse::Embedding(_))
             | Some(FinalResponse::Classify(_))
             | Some(FinalResponse::Messages(_)) => {

--- a/model_gateway/src/routers/grpc/regular/stages/request_building.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/request_building.rs
@@ -41,7 +41,9 @@ impl PipelineStage for RequestBuildingStage {
             RequestType::Generate(_) => self.generate_stage.execute(ctx).await,
             RequestType::Embedding(_) => self.embedding_stage.execute(ctx).await,
             RequestType::Classify(_) => self.embedding_stage.execute(ctx).await,
-            request_type @ (RequestType::Responses(_) | RequestType::Messages(_)) => {
+            request_type @ (RequestType::Completion(_)
+            | RequestType::Responses(_)
+            | RequestType::Messages(_)) => {
                 error!(
                     function = "RequestBuildingStage::execute",
                     request_type = %request_type,

--- a/model_gateway/src/routers/grpc/regular/stages/response_processing.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/response_processing.rs
@@ -53,7 +53,9 @@ impl PipelineStage for ResponseProcessingStage {
             RequestType::Generate(_) => self.generate_stage.execute(ctx).await,
             RequestType::Embedding(_) => self.embedding_stage.execute(ctx).await,
             RequestType::Classify(_) => self.classify_stage.execute(ctx).await,
-            request_type @ (RequestType::Responses(_) | RequestType::Messages(_)) => {
+            request_type @ (RequestType::Completion(_)
+            | RequestType::Responses(_)
+            | RequestType::Messages(_)) => {
                 error!(
                     function = "ResponseProcessingStage::execute",
                     request_type = %request_type,


### PR DESCRIPTION
## Description

### Problem

This PR continues the `/v1/completions` rollout by making completions a
first-class native request type in the gRPC pipeline.

Even with a validated request contract, the gRPC pipeline did not yet treat
completions as a native request type, which made `/v1/completions`
impossible to support cleanly through the same pipeline contract used by
chat, generate, embeddings, and other endpoints.

### Solution

Introduce `CompletionRequest` as a first-class gRPC pipeline request type and
extend shared pipeline orchestration to carry completion requests and
completion responses natively.

This PR adds the native completion pipeline type, metadata flow, and
completion entrypoint, while leaving the actual completion stage wiring to the
later stacked PRs.

## Changes

- Add `RequestType::Completion`
- Add `FinalResponse::Completion`
- Add completion request context construction and typed accessors
- Update dispatch metadata to read completion model IDs directly
- Make Harmony/shared stages exhaustive for completion requests
- Add `execute_completion()` to the gRPC request pipeline
- Temporarily keep regular request-building and response-processing
  delegators buildable until native completion stages land in the stacked follow-up PRs

## Test Plan

- [x] `cargo test -p smg completion --quiet`
- [x] `cargo clippy -p smg --all-targets --all-features -- -D warnings`

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>