### PR TITLE
feat(tokenizer): lossy UTF-8 decode fallback, fix gRPC PD mode detection, enable loop_controls

### DIFF
--- a/crates/tokenizer/Cargo.toml
+++ b/crates/tokenizer/Cargo.toml
@@ -32,7 +32,7 @@ aho-corasick = "1.1"
 base64 = "0.22"
 rustc-hash = "1.1"
 hf-hub = { version = "0.5.0", features = ["tokio"] }
-minijinja = { version = "2.0", features = ["unstable_machinery", "json", "builtins", "loader"] }
+minijinja = { version = "2.0", features = ["unstable_machinery", "json", "builtins", "loader", "loop_controls"] }
 minijinja-contrib = { version = "2.0", features = ["pycompat"] }
 rayon = "1.10"
 tiktoken-rs = "0.9.1"

--- a/crates/tokenizer/src/tiktoken.rs
+++ b/crates/tokenizer/src/tiktoken.rs
@@ -451,9 +451,23 @@ impl Encoder for TiktokenTokenizer {
 
 impl Decoder for TiktokenTokenizer {
     fn decode(&self, token_ids: &[TokenIdType], _skip_special_tokens: bool) -> Result<String> {
-        self.tokenizer
-            .decode(token_ids.to_vec())
-            .map_err(|e| Error::msg(format!("Decoding failed: {e}")))
+        match self.tokenizer.decode(token_ids.to_vec()) {
+            Ok(text) => Ok(text),
+            Err(err) => {
+                // Fallback to lossy decoding for incomplete UTF-8 sequences
+                let bytes: Vec<u8> = self
+                    .tokenizer
+                    ._decode_native_and_split(token_ids.to_vec())
+                    .flatten()
+                    .collect();
+                tracing::warn!(
+                    error = %err,
+                    token_count = token_ids.len(),
+                    "tiktoken decode failed; returning lossy UTF-8 fallback"
+                );
+                Ok(String::from_utf8_lossy(&bytes).into_owned())
+            }
+        }
     }
 }
 
@@ -733,5 +747,48 @@ mod tests {
         assert!(config.special_tokens.bos_token.is_none());
         assert!(config.added_tokens.is_empty());
         assert!(config.chat_template.is_none());
+    }
+
+    #[test]
+    fn test_decode_lossy_fallback_for_invalid_utf8() {
+        // cl100k_base maps individual bytes to token IDs via its byte-level BPE.
+        // Encode a multi-byte UTF-8 character, then decode only a prefix of its
+        // tokens so the raw bytes form an incomplete (invalid) UTF-8 sequence.
+        // The old implementation would return an error; the new one should fall
+        // back to lossy decoding and produce U+FFFD replacement characters.
+        let tokenizer = TiktokenTokenizer::new(TiktokenModel::Cl100kBase).unwrap();
+
+        // "😀" is U+1F600, encoded as 4 UTF-8 bytes: [0xF0, 0x9F, 0x98, 0x80].
+        // With cl100k_base this encodes to multiple tokens. Taking a strict
+        // subset of those tokens gives bytes that aren't valid UTF-8.
+        let full_encoding = tokenizer.encode("😀", false).unwrap();
+        let full_ids = full_encoding.token_ids();
+        assert!(
+            full_ids.len() > 1,
+            "emoji should encode to multiple tokens in cl100k_base"
+        );
+
+        // Take only the first token — its raw bytes are an incomplete UTF-8 prefix.
+        let partial_ids = &full_ids[..1];
+        let result = tokenizer.decode(partial_ids, false);
+        assert!(
+            result.is_ok(),
+            "decode of partial UTF-8 should succeed via lossy fallback"
+        );
+        let decoded = result.unwrap();
+        assert!(
+            decoded.contains('\u{FFFD}') || decoded.is_empty(),
+            "lossy decode should contain replacement char or be empty, got: {decoded:?}"
+        );
+    }
+
+    #[test]
+    fn test_decode_valid_utf8_does_not_use_fallback() {
+        // Ensure that valid UTF-8 round-trips through the happy path unchanged.
+        let tokenizer = TiktokenTokenizer::new(TiktokenModel::Cl100kBase).unwrap();
+        let text = "Hello, 世界!";
+        let encoding = tokenizer.encode(text, false).unwrap();
+        let decoded = tokenizer.decode(encoding.token_ids(), false).unwrap();
+        assert_eq!(decoded, text);
     }
 }

--- a/model_gateway/src/routers/mod.rs
+++ b/model_gateway/src/routers/mod.rs
@@ -300,6 +300,58 @@ pub trait RouterTrait: Send + Sync + Debug {
 
     /// Check if this is a PD router
     fn is_pd_mode(&self) -> bool {
-        self.router_type() == "pd"
+        matches!(self.router_type(), "pd" | "grpc_pd")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Minimal stub implementing RouterTrait so we can test the default
+    /// `is_pd_mode` logic without spinning up a real router.
+    #[derive(Debug)]
+    struct StubRouter {
+        type_name: &'static str,
+    }
+
+    #[async_trait]
+    impl RouterTrait for StubRouter {
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+        fn router_type(&self) -> &'static str {
+            self.type_name
+        }
+    }
+
+    #[test]
+    fn test_is_pd_mode_for_pd_router_types() {
+        // "pd" (HTTP PD) and "grpc_pd" should both be recognized as PD mode
+        let pd = StubRouter { type_name: "pd" };
+        assert!(pd.is_pd_mode());
+
+        let grpc_pd = StubRouter {
+            type_name: "grpc_pd",
+        };
+        assert!(grpc_pd.is_pd_mode());
+    }
+
+    #[test]
+    fn test_is_pd_mode_false_for_non_pd_router_types() {
+        for name in &[
+            "openai",
+            "regular",
+            "grpc",
+            "gemini",
+            "anthropic",
+            "manager",
+        ] {
+            let router = StubRouter { type_name: name };
+            assert!(
+                !router.is_pd_mode(),
+                "router_type {name:?} should NOT be pd mode"
+            );
+        }
     }
 }


### PR DESCRIPTION
- TiktokenTokenizer::decode now falls back to lossy decoding (U+FFFD) for incomplete UTF-8 sequences instead of returning an error
- RouterTrait::is_pd_mode uses explicit match on "pd" | "grpc_pd" instead of == "pd", fixing gRPC PD router not being recognized
- Enable minijinja loop_controls feature for break/continue in templates
- Add tests for lossy decode fallback and is_pd_mode logic

## Description

### Problem

<!-- What problem is this PR trying to solve? -->

### Solution

<!-- How does this PR solve the problem? -->

## Changes

<!-- - Describe your changes here. -->

## Test Plan

<!-- Provide a thorough reproducible test showing before and after behavior. -->

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Decoder now gracefully falls back when encountering invalid UTF-8, avoiding failures and returning a safe lossy result.
  * Router mode detection expanded to recognize additional PD-related router types so configurations are detected more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->