### PR TITLE
fix(ci): bump NCCL to 2.28+ for TensorRT-LLM compatibility

### DIFF
--- a/scripts/ci_install_trtllm.sh
+++ b/scripts/ci_install_trtllm.sh
@@ -5,7 +5,7 @@
 # so we build from source (main branch) which compiles the C++
 # extensions properly and includes the gRPC serve command.
 #
-# Cache version: 2 — rebuild to pick up gRPC stop_words fix (#11292)
+# Cache version: 3 — rebuild for NCCL 2.28+ (required by TRT-LLM PR #12015)
 #
 # Prerequisites (expected on k8s-runner-gpu nodes):
 #   - NVIDIA driver 580+ (CUDA 13)
@@ -58,7 +58,7 @@ if [ -n "$CACHED_WHEEL" ] && [ -f "$CACHED_WHEEL" ]; then
 
     # ── Install NCCL runtime ─────────────────────────────────────────────────
     pip install --upgrade pip
-    pip install --no-cache-dir "nvidia-nccl-cu13>=2.27.7"
+    pip install --no-cache-dir "nvidia-nccl-cu13>=2.28.0"
 
     # ── Install cached wheel ─────────────────────────────────────────────────
     echo "Installing cached wheel..."
@@ -160,7 +160,7 @@ sudo ln -sf /usr/lib/x86_64-linux-gnu /usr/local/tensorrt/lib
 # Use pip-installed NCCL 2.27+ which has both headers and libraries.
 # This matches the working installation guide approach.
 pip install --upgrade pip
-pip install --no-cache-dir "nvidia-nccl-cu13>=2.27.7"
+pip install --no-cache-dir "nvidia-nccl-cu13>=2.28.0"
 
 SITE_PACKAGES=$(python3 -c "import site; print(site.getsitepackages()[0])")
 


### PR DESCRIPTION
## Summary

- Bumps NCCL minimum from 2.27.7 to 2.28.0 to fix TRT-LLM build failure in CI

## Root Cause

TRT-LLM [PR #12015](https://github.com/NVIDIA/TensorRT-LLM/pull/12015) (merged 2026-03-11, "Improve NCCL library load stability") wrapped `NCCLWindowAllocator` and `createNCCLWindowTensor` behind `#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 28, 0)` in `ncclUtils.h`, but `allreduceOp.cpp` still references these symbols unconditionally. Building against NCCL 2.27 causes:

```
error: 'NCCLWindowAllocator' has not been declared in 'tensorrt_llm::_v1::common::nccl_util'
```

## What changed

- **scripts/ci_install_trtllm.sh**: `nvidia-nccl-cu13>=2.27.7` → `nvidia-nccl-cu13>=2.28.0` (both cached and full-build paths). Cache version bumped to 3 to invalidate stale wheels.

## Test plan

- [ ] CI `e2e-1gpu-chat (trtllm)` job passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated NCCL runtime dependency to version 2.28.0 for improved compatibility and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->