### PR TITLE
fix(ci): install NCCL 2.28+ after TRT-LLM requirements to prevent downgrade

### DIFF
--- a/scripts/ci_install_trtllm.sh
+++ b/scripts/ci_install_trtllm.sh
@@ -180,47 +180,37 @@ if [ -f "requirements-dev.txt" ]; then
 fi
 
 # ── NCCL 2.28+ setup ────────────────────────────────────────────────────────
-# MUST run AFTER requirements-dev.txt which pins nvidia-nccl-cu13<=2.28.9.
-# TRT-LLM PR #12015 requires NCCL 2.28+ for NCCLWindowAllocator.
-# Force-reinstall to override any version TRT-LLM requirements pulled in.
+# TRT-LLM PR #12015 requires NCCL 2.28+ headers for NCCLWindowAllocator.
+# Problem: torch==2.9.1+cu130 pins nvidia-nccl-cu13==2.27.7 as an exact dep,
+# and build_wheel.py runs pip install internally which downgrades NCCL.
+#
+# Solution: install NCCL 2.28+, copy headers+libs to a fixed directory that
+# pip can't overwrite, and point NCCL_ROOT there for CMake.
 pip install --no-cache-dir --force-reinstall "nvidia-nccl-cu13>=2.28.0"
 
 SITE_PACKAGES=$(python3 -c "import site; print(site.getsitepackages()[0])")
+NCCL_PIP_ROOT="$SITE_PACKAGES/nvidia/nccl"
 
-# Use pip NCCL package as NCCL_ROOT (has both include/ and lib/ directories)
-NCCL_ROOT="$SITE_PACKAGES/nvidia/nccl"
+# Copy to a stable location that pip won't touch
+NCCL_ROOT="/tmp/nccl-stable"
+rm -rf "$NCCL_ROOT"
+mkdir -p "$NCCL_ROOT/include" "$NCCL_ROOT/lib"
+cp -a "$NCCL_PIP_ROOT/include/"* "$NCCL_ROOT/include/"
+cp -a "$NCCL_PIP_ROOT/lib/"* "$NCCL_ROOT/lib/"
+# Create libnccl.so symlink — pip only ships libnccl.so.2
+if [ -f "$NCCL_ROOT/lib/libnccl.so.2" ] && [ ! -e "$NCCL_ROOT/lib/libnccl.so" ]; then
+    ln -s libnccl.so.2 "$NCCL_ROOT/lib/libnccl.so"
+fi
 
 echo "=== NCCL diagnostics ==="
-echo "NCCL_ROOT=$NCCL_ROOT"
-ls -la "$NCCL_ROOT/" 2>/dev/null || echo "WARNING: NCCL_ROOT not found"
-ls -la "$NCCL_ROOT/include/" 2>/dev/null || echo "WARNING: NCCL include not found"
-ls -la "$NCCL_ROOT/lib/" 2>/dev/null || echo "WARNING: NCCL lib not found"
-# Verify NCCL version in header matches what we need
+echo "NCCL_ROOT=$NCCL_ROOT (stable copy, immune to pip downgrades)"
+ls -la "$NCCL_ROOT/include/" 2>/dev/null | head -5
+ls -la "$NCCL_ROOT/lib/" 2>/dev/null | head -5
 grep "NCCL_MAJOR\|NCCL_MINOR" "$NCCL_ROOT/include/nccl.h" 2>/dev/null | head -3
 echo "=== end NCCL diagnostics ==="
 
-# Symlink pip NCCL header to system path for other tools that look there
-NCCL_INCLUDE=$(find "$NCCL_ROOT" -name "nccl.h" 2>/dev/null | head -1)
-if [ -n "$NCCL_INCLUDE" ]; then
-    echo "Found pip NCCL header at: $NCCL_INCLUDE"
-    sudo mv /usr/include/nccl.h /usr/include/nccl.h.bak 2>/dev/null || true
-    sudo ln -sf "$NCCL_INCLUDE" /usr/include/nccl.h
-    echo "Symlinked pip NCCL header to /usr/include/nccl.h"
-else
-    echo "WARNING: Could not find pip-installed NCCL header"
-fi
-
-# Create libnccl.so symlink - pip package only has libnccl.so.2, but CMake looks for libnccl.so
-NCCL_LIB=$(find "$NCCL_ROOT" -name "libnccl.so.2" 2>/dev/null | head -1)
-if [ -n "$NCCL_LIB" ]; then
-    NCCL_LIB_DIR=$(dirname "$NCCL_LIB")
-    echo "Found NCCL library at: $NCCL_LIB"
-    ln -sf "$NCCL_LIB" "$NCCL_LIB_DIR/libnccl.so"
-    echo "Created symlink: $NCCL_LIB_DIR/libnccl.so -> libnccl.so.2"
-    ls -la "$NCCL_LIB_DIR"/libnccl*
-else
-    echo "WARNING: Could not find pip-installed NCCL library"
-fi
+# Symlink stable NCCL header to system path for other tools that look there
+sudo ln -sf "$NCCL_ROOT/include/nccl.h" /usr/include/nccl.h
 
 # ── Patch FindTensorRT.cmake ─────────────────────────────────────────────────
 # CMake needs to find TensorRT in system paths


### PR DESCRIPTION
## Summary

- Fixes TRT-LLM build failure caused by NCCL being downgraded by TRT-LLM's own `requirements-dev.txt`

## Root Cause

PR #777 bumped NCCL to 2.28+ but the install happened **before** `pip install -r requirements-dev.txt`. TRT-LLM's requirements pin `nvidia-nccl-cu13<=2.28.9,>=2.27.7`, which downgraded NCCL. CMake then found the downgraded 2.27.7 header, and the `#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 28, 0)` gate hid `NCCLWindowAllocator`.

## What changed

- **scripts/ci_install_trtllm.sh**: Moved NCCL install + symlink setup to **after** `requirements-dev.txt`. Uses `--force-reinstall` to override whatever version TRT-LLM pulled in. Added NCCL version diagnostics (`NCCL_MAJOR`/`NCCL_MINOR` from header) to catch version mismatches in the future.

## Test plan

- [ ] CI `e2e-1gpu-chat (trtllm)` job passes
- [ ] NCCL diagnostics in log show `NCCL_MAJOR 2` and `NCCL_MINOR >= 28`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now uses a stable NCCL 2.28+ setup to ensure consistent builds and prevent unintended downgrades.
  * Improved build detection and diagnostics for GPU communication libraries, honoring system hints and providing clearer version checks.
  * Updated CI dependency constraints and post-build verifications to harden and speed up continuous integration runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->