### PR TITLE
chore: add release 1.3.2

### DIFF
--- a/.github/workflows/release-sglang-docker.yml
+++ b/.github/workflows/release-sglang-docker.yml
@@ -4,7 +4,7 @@ run-name: >-
   SMG+SGLang |
   base=${{ inputs.base_image_ref || 'lmsysorg/sglang:v0.5.9' }} |
   engine=${{ inputs.sglang_commit || 'latest' }} |
-  smg=${{ inputs.smg_commit || 'v1.3.1' }} |
+  smg=${{ inputs.smg_commit || 'v1.3.2' }} |
   by @${{ github.actor }}
 
 on:
@@ -43,10 +43,10 @@ on:
       smg_commit:
         description: 'SMG commit/ref ("latest" for HEAD)'
         required: false
-        default: 'v1.3.1'
+        default: 'v1.3.2'
         type: string
       tag:
-        description: 'Override image tag (e.g. v1.3.1-sglang-v0.5.9)'
+        description: 'Override image tag (e.g. v1.3.2-sglang-v0.5.9)'
         required: false
         type: string
 
@@ -63,7 +63,7 @@ jobs:
       engine_repo: ${{ inputs.sglang_repo }}
       engine_commit: ${{ inputs.sglang_commit || 'latest' }}
       smg_repo: ${{ inputs.smg_repo || 'https://github.com/lightseekorg/smg' }}
-      smg_commit: ${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.3.1' }}
+      smg_commit: ${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.3.2' }}
       tag: ${{ inputs.tag }}
       dry_run: ${{ github.event_name == 'pull_request' }}
     secrets: inherit

--- a/.github/workflows/release-trtllm-docker.yml
+++ b/.github/workflows/release-trtllm-docker.yml
@@ -36,10 +36,10 @@ on:
       smg_commit:
         description: 'SMG commit/ref ("latest" for HEAD)'
         required: false
-        default: 'v1.3.1'
+        default: 'v1.3.2'
         type: string
       tag:
-        description: 'Override image tag (e.g. v1.3.1-trtllm-1.3.0)'
+        description: 'Override image tag (e.g. v1.3.2-trtllm-1.3.0)'
         required: false
         type: string
 
@@ -56,7 +56,7 @@ jobs:
       engine_repo: ${{ inputs.trtllm_repo }}
       engine_commit: ${{ inputs.trtllm_commit || 'latest' }}
       smg_repo: ${{ inputs.smg_repo || 'https://github.com/lightseekorg/smg' }}
-      smg_commit: ${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.3.1' }}
+      smg_commit: ${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.3.2' }}
       tag: ${{ inputs.tag }}
       source_build_repo: ${{ inputs.trtllm_repo }}
       source_build_ref: ${{ inputs.trtllm_commit || 'latest' }}

--- a/.github/workflows/release-vllm-docker.yml
+++ b/.github/workflows/release-vllm-docker.yml
@@ -36,10 +36,10 @@ on:
       smg_commit:
         description: 'SMG commit/ref ("latest" for HEAD)'
         required: false
-        default: 'v1.3.1'
+        default: 'v1.3.2'
         type: string
       tag:
-        description: 'Override image tag (e.g. v1.3.1-vllm-v0.17.0)'
+        description: 'Override image tag (e.g. v1.3.2-vllm-v0.17.0)'
         required: false
         type: string
 
@@ -56,6 +56,6 @@ jobs:
       engine_repo: ${{ inputs.vllm_repo }}
       engine_commit: ${{ inputs.vllm_commit || 'latest' }}
       smg_repo: ${{ inputs.smg_repo || 'https://github.com/lightseekorg/smg' }}
-      smg_commit: ${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.3.1' }}
+      smg_commit: ${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.3.2' }}
       tag: ${{ inputs.tag }}
     secrets: inherit

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [workspace.dependencies]
 # Internal workspace crates
-openai-protocol = { version = "1.4.0", path = "crates/protocols" }
+openai-protocol = { version = "1.4.1", path = "crates/protocols" }
 reasoning-parser = { version = "1.2.1", path = "crates/reasoning_parser" }
 tool-parser = { version = "1.1.2", path = "crates/tool_parser" }
 wfaas = { version = "1.0.3", path = "crates/workflow" }

--- a/bindings/golang/Cargo.toml
+++ b/bindings/golang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-golang"
-version = "1.3.1"
+version = "1.3.2"
 edition = "2021"
 
 [lib]

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-python"
-version = "1.3.1"
+version = "1.3.2"
 edition = "2021"
 
 [lib]

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "smg"
-version = "1.3.1"
+version = "1.3.2"
 description = "High-performance Rust-based inference gateway for large-scale LLM deployments"
 authors = [
     {name = "Simo Lin", email = "linsimo.mark@gmail.com"},

--- a/crates/grpc_client/python/pyproject.toml
+++ b/crates/grpc_client/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "smg-grpc-proto"
-version = "0.4.2"
+version = "0.4.3"
 description = "SMG gRPC proto definitions for SGLang, vLLM, and TRT-LLM"
 requires-python = ">=3.10"
 dependencies = [

--- a/crates/protocols/Cargo.toml
+++ b/crates/protocols/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openai-protocol"
-version = "1.4.0"
+version = "1.4.1"
 edition = "2021"
 description = "OpenAI-compatible API protocol definitions and types"
 license = "Apache-2.0"

--- a/model_gateway/Cargo.toml
+++ b/model_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg"
-version = "1.3.1"
+version = "1.3.2"
 edition = "2021"
 description = "High-performance model-routing gateway for large-scale LLM deployments"
 license = "Apache-2.0"


### PR DESCRIPTION
## Description

### Problem

<!-- What problem is this PR trying to solve? -->

### Solution

<!-- How does this PR solve the problem? -->

## Changes

<!-- - Describe your changes here. -->

## Test Plan

<!-- Provide a thorough reproducible test showing before and after behavior. -->

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped package versions to v1.3.2 across bindings and services.
  * Updated internal protocol dependency to v1.4.1.
  * Updated Python gRPC client package to v0.4.3.
  * Updated Docker release workflow defaults and descriptive examples to reference v1.3.2, ensuring new default fallback values and examples align with the bumped version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->