### PR TITLE
fix(harmony): include developer message when instructions are present

### DIFF
--- a/model_gateway/src/routers/grpc/harmony/builder.rs
+++ b/model_gateway/src/routers/grpc/harmony/builder.rs
@@ -437,8 +437,8 @@ impl HarmonyBuilder {
             let sys_msg = self.build_system_message_from_responses(request, with_custom_tools);
             all_messages.push(sys_msg);
 
-            // Add developer message only if we have custom tools
-            if with_custom_tools {
+            // Add developer message if we have custom tools or instructions
+            if with_custom_tools || request.instructions.is_some() {
                 let dev_msg = self.build_developer_message_from_responses(
                     request.instructions.as_deref(),
                     request.tools.as_ref(),


### PR DESCRIPTION
## Description

### Problem

The Harmony Responses API path silently ignores the `instructions` parameter when no tools are present. The `instructions` content is carried in the developer message, but `construct_input_messages_with_harmony()` only emitted the developer message when custom tools were detected (`if with_custom_tools`). Without tools, the developer message was skipped entirely, and instructions had no effect on model output.

### Solution

Widen the condition to `if with_custom_tools || request.instructions.is_some()` so the developer message is emitted whenever instructions are present, regardless of whether tools are configured.

## Changes

- `builder.rs`: Changed the developer message guard from `if with_custom_tools` to `if with_custom_tools || request.instructions.is_some()`

## Test Plan

**Before (instructions ignored):**
```bash
curl -s -X POST http://localhost:3002/v1/responses \
  -H "Content-Type: application/json" \
  -d '{
    "model": "/models/openai/gpt-oss-20b",
    "instructions": "Always respond in French.",
    "input": "What is the capital of Japan?",
    "store": false
  }' | python3 -m json.tool
# Returns English response: "The capital of Japan is Tokyo."
```

**After (instructions respected):**
```
# Returns French response: "La capitale du Japon est Tokyo."
```

Verified on both gpt-oss-20b (sglang) and gpt-oss-120b (vLLM) backends.

> **Note:** vLLM has the same bug in `serving.py:1032` — developer message only added when `with_custom_tools` is true.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (on smg package; `--all-features` hits pre-existing OpenSSL assembler issue in CI env)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved message construction logic in the request handler to better support additional request parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->