### PR TITLE
fix(ci): use k8s pod env vars for API keys instead of GitHub secrets

### DIFF
--- a/.github/workflows/e2e-gpu-job.yml
+++ b/.github/workflows/e2e-gpu-job.yml
@@ -110,10 +110,6 @@ jobs:
       # Run tests
       - name: Run E2E tests
         env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.CLAUDE_API_KEY }}
           SHOW_WORKER_LOGS: "0"
           SHOW_ROUTER_LOGS: "1"
           BRAVE_MCP_HOST: ${{ inputs.setup_agentic_deps && 'brave-search-mcp' || '' }}

--- a/.github/workflows/nightly-benchmark.yml
+++ b/.github/workflows/nightly-benchmark.yml
@@ -184,7 +184,6 @@ jobs:
       - name: Run benchmark
         if: steps.filter.outputs.skip != 'true'
         env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
           GPU_TYPE: H100
           E2E_NIGHTLY: "1"
           E2E_MODEL_TP_OVERRIDES: '{"meta-llama/Llama-3.1-8B-Instruct":1,"Qwen/Qwen2.5-7B-Instruct":1,"Qwen/Qwen3-30B-A3B":1}'
@@ -298,7 +297,6 @@ jobs:
       - name: Run benchmark
         if: steps.filter.outputs.skip != 'true'
         env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
           GPU_TYPE: H100
           E2E_NIGHTLY: "1"
           E2E_MODEL_TP_OVERRIDES: '{"meta-llama/Llama-3.1-8B-Instruct":1,"Qwen/Qwen2.5-7B-Instruct":1,"Qwen/Qwen3-30B-A3B":1}'
@@ -416,7 +414,6 @@ jobs:
       - name: Run benchmark
         if: steps.filter.outputs.skip != 'true'
         env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
           GPU_TYPE: H200
           E2E_NIGHTLY: "1"
           E2E_LOG_DIR: nightly_gateway_logs

--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -328,7 +328,6 @@ jobs:
 
       - name: Run benchmarks
         env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
           ROUTER_LOCAL_MODEL_PATH: /home/ubuntu/models
         run: |
           bash scripts/ci_killall_sglang.sh "nuk_gpus"
@@ -665,9 +664,6 @@ jobs:
 
       - name: Run E2E tests
         env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.CLAUDE_API_KEY }}
           BRAVE_MCP_HOST: ${{ matrix.setup_agentic_deps && 'brave-search-mcp' || '' }}
         run: |
           ROUTER_LOCAL_MODEL_PATH="/home/ubuntu/models" pytest ${{ matrix.test_path }} \
@@ -779,8 +775,6 @@ jobs:
           bash scripts/ci_install_e2e_deps.sh
 
       - name: Run Go OAI server E2E tests
-        env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           bash scripts/ci_killall_sglang.sh "nuk_gpus"
           export CGO_LDFLAGS="-L$(pwd)/bindings/golang/target/release"


### PR DESCRIPTION
## Summary

- Removes GitHub secret references for API keys from workflow env blocks
- API keys are now injected as env vars on k8s runner pods via `secretKeyRef`

## Problem

GitHub secrets (`HF_TOKEN`, `OPENAI_API_KEY`, `CLAUDE_API_KEY`, `XAI_API_KEY`) were removed from the repo. The workflow env blocks `ANTHROPIC_API_KEY: ${{ secrets.CLAUDE_API_KEY }}` resolved to empty strings, overriding the pod-level env vars and causing all external API tests to fail.

## What changed

- **e2e-gpu-job.yml**: Removed `HF_TOKEN`, `OPENAI_API_KEY`, `XAI_API_KEY`, `ANTHROPIC_API_KEY`
- **pr-test-rust.yml**: Removed `HF_TOKEN`, `OPENAI_API_KEY`, `XAI_API_KEY`, `ANTHROPIC_API_KEY` from 3 env blocks
- **nightly-benchmark.yml**: Removed `HF_TOKEN` from 3 env blocks

## Test plan

- [ ] E2E tests pick up API keys from pod env vars
- [ ] `anthropic-messages` job no longer fails with "ANTHROPIC_API_KEY not set"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configurations to streamline test and benchmark execution environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->