### PR TITLE
docs: add Messages API, external providers, and mesh HA documentation

### DIFF
--- a/docs/concepts/architecture/high-availability.md
+++ b/docs/concepts/architecture/high-availability.md
@@ -110,6 +110,18 @@ Real-time synchronization of all cluster state.
 
 ## Configuration
 
+### Quick Start
+
+Enable mesh networking with minimal flags:
+
+```bash
+# Start first node
+smg --enable-mesh --mesh-port 39527
+
+# Start second node, joining the first
+smg --enable-mesh --mesh-port 39528 --mesh-peer-urls 10.0.0.1:39527
+```
+
 ### Command Line Options
 
 | Flag | Default | Description |
@@ -119,6 +131,15 @@ Real-time synchronization of all cluster state.
 | `--mesh-host` | `0.0.0.0` | Host address for mesh communication |
 | `--mesh-port` | `39527` | Port for mesh gRPC communication |
 | `--mesh-peer-urls` | (none) | Initial peer URLs for cluster bootstrap |
+| `--router-selector` | (none) | Label selector for Kubernetes pod discovery (e.g. `app=smg tier=router`) |
+
+### Python Entrypoint
+
+`--enable-mesh` is also available in the Python entrypoint used by the Docker image:
+
+```bash
+smg launch --enable-mesh --mesh-port 39527
+```
 
 ### Basic Configuration
 
@@ -269,6 +290,17 @@ Routing policy configuration and state.
 
 </div>
 
+### Cache-Aware State Sync
+
+Cache-aware routing policy state is synchronized across mesh nodes. This ensures that KV cache routing decisions are consistent across all routers in the cluster, preventing redundant cache misses and enabling optimal prefix reuse regardless of which router handles the request.
+
+!!! info "Sync Endpoints"
+    The following endpoints expose cache-aware state across the mesh:
+
+    - `GET /mesh/cluster/status` — Cluster membership
+    - `GET /mesh/workers/state` — Worker state sync
+    - `GET /mesh/policies/state` — Policy state sync
+
 ### CRDT Implementation
 
 SMG uses several CRDT types for conflict-free synchronization:
@@ -401,6 +433,17 @@ spec:
   - port: 39527
     name: mesh
 ```
+
+### Kubernetes Pod Discovery
+
+Use `--router-selector` to enable automatic pod discovery via the Kubernetes API. SMG will find and join other router pods matching the given label selector, removing the need for static `--mesh-peer-urls`:
+
+```bash
+smg --enable-mesh --service-discovery --router-selector app=smg tier=router
+```
+
+!!! tip "Label Selectors"
+    The `--router-selector` flag accepts space-separated `key=value` pairs that map to Kubernetes label selectors. All matching pods with an exposed mesh port are automatically added as peers.
 
 ---
 

--- a/docs/concepts/routing/cache-aware.md
+++ b/docs/concepts/routing/cache-aware.md
@@ -374,6 +374,33 @@ When running multiple SMG instances behind a load balancer:
 
 ---
 
+## Event-Driven Block Size
+
+By default, SMG uses the `--block-size` CLI flag (default: 16) to align the radix tree with backend KV cache page boundaries. However, when workers report KV cache events, the cache-aware policy can **learn the actual block size** directly from those events.
+
+This is especially useful when different backends use different page sizes—rather than requiring a single global flag, each worker's block size is discovered automatically from its event stream. The learned block size takes precedence over the CLI default, ensuring routing accuracy without manual configuration per backend.
+
+| Source | Priority | Use Case |
+|--------|----------|----------|
+| **Worker KV events** | Highest | Automatically learned per worker |
+| **`--block-size` flag** | Fallback | Global default when events are unavailable |
+
+!!! note
+    Event-driven block size detection requires backends that emit KV cache events (e.g., SGLang with event reporting enabled). If a worker does not report events, the `--block-size` CLI value is used as the fallback.
+
+---
+
+## Mesh State Synchronization
+
+When running in mesh HA mode (`--enable-mesh`), cache-aware routing state is **synchronized across all router nodes**. Each node's radix tree receives updates from the mesh, ensuring that every gateway instance has a consistent view of backend KV cache state. This eliminates the cache efficiency penalty described in [Multi-Gateway Considerations](#multi-gateway-considerations) and enables accurate cache-aware decisions across the entire cluster.
+
+For mesh setup and configuration details, see [High Availability](../architecture/high-availability.md).
+
+!!! tip
+    When using cache-aware routing with mesh HA, KV cache state is automatically synchronized across all nodes. No additional configuration is needed beyond enabling mesh.
+
+---
+
 ## Comparison with Other Policies
 
 | Aspect | cache_aware | prefix_hash | consistent_hashing |

--- a/docs/getting-started/external-providers.md
+++ b/docs/getting-started/external-providers.md
@@ -1,0 +1,148 @@
+---
+title: External Providers
+---
+
+# External Providers
+
+SMG can route requests to external LLM provider APIs (OpenAI, Anthropic, xAI, Google Gemini), acting as a unified gateway. This enables provider-agnostic applications, load balancing across providers, and centralized observability.
+
+<div class="prerequisites" markdown>
+
+#### Before you begin
+
+- Completed the [Getting Started](index.md) guide
+- An API key for at least one external provider
+
+</div>
+
+---
+
+## Supported Providers
+
+SMG auto-detects the provider from the model name in each request and applies the correct API transformations:
+
+| Provider | Auto-Detection | Header Format |
+|----------|---------------|---------------|
+| OpenAI | `gpt-*`, `o1-*`, `o3-*` models | `Authorization: Bearer` |
+| Anthropic | `claude-*` models | `x-api-key` |
+| xAI | `grok-*` models | `Authorization: Bearer` |
+| Google Gemini | `gemini-*` models | `Authorization: Bearer` |
+
+---
+
+## Quick Start
+
+Register an external worker via IGW mode:
+
+```bash
+# Start SMG in IGW mode
+smg --enable-igw
+```
+
+```bash
+# Register an OpenAI worker
+curl -X POST http://localhost:30000/workers \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "https://api.openai.com/v1",
+    "api_key": "sk-...",
+    "runtime_type": "external",
+    "provider": "openai"
+  }'
+```
+
+Send a request through the gateway:
+
+```bash
+curl http://localhost:30000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-4o",
+    "messages": [{"role": "user", "content": "Hello!"}]
+  }'
+```
+
+---
+
+## Model Discovery
+
+SMG supports fan-out model discovery across all registered external workers. When a caller sends a `GET /v1/models` request with a bearer token, SMG:
+
+1. Fans out the request to all healthy external workers concurrently
+2. Forwards the caller's token to each upstream provider
+3. Aggregates and returns the discovered models from all providers
+
+```bash
+curl http://localhost:30000/v1/models \
+  -H "Authorization: Bearer sk-..."
+```
+
+This supports BYOK (bring your own key) — the caller's token is forwarded to the upstream provider, so each caller can discover models available under their own account.
+
+---
+
+## API Key Handling
+
+SMG supports two methods for providing API keys to external providers:
+
+- **Stored key** — Set at worker registration time via the `api_key` field
+- **Caller key (BYOK)** — Passed by the caller via the `Authorization` header at request time
+
+If both a stored key and a caller key are present, the caller's key takes precedence.
+
+!!! note "Provider-aware routing"
+    SMG routes each request to the correct provider based on the model name. API keys are only forwarded to the matching provider, preventing keys from leaking across providers.
+
+---
+
+## Multiple Providers
+
+Register workers for multiple providers to route across them by model name:
+
+```bash
+# Register OpenAI
+curl -X POST http://localhost:30000/workers \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "https://api.openai.com/v1",
+    "provider": "openai",
+    "api_key": "sk-..."
+  }'
+
+# Register Anthropic
+curl -X POST http://localhost:30000/workers \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "https://api.anthropic.com/v1",
+    "provider": "anthropic",
+    "api_key": "sk-ant-..."
+  }'
+```
+
+SMG picks the right provider based on the model name in each request:
+
+```bash
+# Routes to OpenAI
+curl http://localhost:30000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-4o",
+    "messages": [{"role": "user", "content": "Hello"}]
+  }'
+
+# Routes to Anthropic
+curl http://localhost:30000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "claude-sonnet-4-20250514",
+    "messages": [{"role": "user", "content": "Hello"}]
+  }'
+```
+
+---
+
+## Next Steps
+
+- [Multiple Workers](multiple-workers.md) — Load balancing, worker types, and IGW configuration options
+- [Load Balancing](load-balancing.md) — Routing policies for distributing traffic across workers
+- [Monitoring](monitoring.md) — Track request rates, latency, and worker health across providers

--- a/docs/reference/api/messages.md
+++ b/docs/reference/api/messages.md
@@ -1,0 +1,85 @@
+---
+title: Anthropic Messages API
+---
+
+# Anthropic Messages API
+
+SMG supports the Anthropic Messages API (`/v1/messages`), enabling applications to use Claude models through the gateway. Both HTTP proxy mode (forwarding to Anthropic's API) and gRPC mode (routing to local inference backends) are supported.
+
+---
+
+## Endpoint
+
+Create a message.
+
+```
+POST /v1/messages
+```
+
+For streaming responses, set `"stream": true` in the request body.
+
+---
+
+## Request Example
+
+```bash
+curl http://localhost:30000/v1/messages \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: $ANTHROPIC_API_KEY" \
+  -H "anthropic-version: 2023-06-01" \
+  -d '{
+    "model": "claude-sonnet-4-20250514",
+    "max_tokens": 1024,
+    "messages": [
+      {"role": "user", "content": "What is the meaning of life?"}
+    ]
+  }'
+```
+
+---
+
+## Streaming
+
+To receive responses as Server-Sent Events, set `"stream": true`:
+
+```bash
+curl http://localhost:30000/v1/messages \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: $ANTHROPIC_API_KEY" \
+  -H "anthropic-version: 2023-06-01" \
+  -d '{
+    "model": "claude-sonnet-4-20250514",
+    "max_tokens": 1024,
+    "messages": [
+      {"role": "user", "content": "What is the meaning of life?"}
+    ],
+    "stream": true
+  }'
+```
+
+---
+
+## gRPC Backend
+
+The Messages API works with gRPC backends such as SGLang and vLLM. When routing to a gRPC backend, SMG translates the Anthropic message format to the backend's native format and translates the response back.
+
+!!! note
+    When using the Messages API with gRPC backends, SMG handles format translation automatically. The backend receives requests in its native format.
+
+---
+
+## Connection Modes
+
+| Mode | Backend | Description |
+|------|---------|-------------|
+| HTTP (proxy) | Anthropic API | Forward requests to `api.anthropic.com` |
+| gRPC | SGLang/vLLM | Translate and route to local inference |
+
+---
+
+## Features
+
+- Streaming and non-streaming responses
+- Tool use (via MCP integration)
+- Extended thinking
+- Multi-turn conversations

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -252,6 +252,14 @@ Note: Enabling service discovery automatically enables IGW mode.
 | Default | None |
 | Description | Path to chat template file |
 
+### Disable Tokenizer Autoload
+
+| Option | `--disable-tokenizer-autoload` |
+|--------|-------------------------------|
+| Environment | - |
+| Default | `false` |
+| Description | Disable automatic tokenizer loading at startup and during worker registration. Useful when tokenizers are loaded on-demand via the API. |
+
 ### Tokenizer Cache (L0 - Exact Match)
 
 | Option | Description | Default |
@@ -366,17 +374,17 @@ Note: Enabling service discovery automatically enables IGW mode.
 
 ---
 
-## Mesh/HA Configuration
+## Mesh Server Configuration
 
-High-availability mesh networking for router coordination.
+High-availability mesh networking for multi-router coordination.
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `--enable-mesh` | Enable mesh server for HA | `false` |
-| `--mesh-server-name` | Unique name for this mesh node | Auto-generated |
-| `--mesh-host` | Host address for mesh server | `0.0.0.0` |
-| `--mesh-port` | Port for mesh server | `39527` |
-| `--mesh-peer-urls` | URLs of peer mesh nodes | Empty |
+| `--enable-mesh` | Enable mesh server for HA multi-router coordination. Requires at least two SMG instances. | `false` |
+| `--mesh-server-name` | Name for this mesh node. If not set, a random name is generated (e.g., `Mesh_a1b2`). | Auto-generated |
+| `--mesh-host` | Bind address for the mesh server. | `0.0.0.0` |
+| `--mesh-port` | Port for the mesh server. | `39527` |
+| `--mesh-peer-urls` | Peer mesh node addresses to join (format: `host:port`). Used for initial cluster formation. | (none) |
 
 **Example**:
 ```bash
@@ -529,7 +537,7 @@ delay = min(initial_backoff * multiplier^attempt, max_backoff) * (1 + random(0, 
 | `--health-check-interval-secs` | Interval between health checks | `60` |
 | `--health-check-endpoint` | Health check endpoint path | `/health` |
 | `--disable-health-check` | Disable all health checks | `false` |
-| `--remove-unhealthy-workers` | Remove workers after being marked unhealthy | `false` |
+| `--remove-unhealthy-workers` | Remove workers from the registry when marked unhealthy by health checks. Useful for ephemeral worker pools where failed workers should be deregistered. | `false` |
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -157,6 +157,7 @@ nav:
           - Load Balancing: getting-started/load-balancing.md
           - Tokenizer Caching: getting-started/tokenizer-caching.md
           - MCP in Responses API: getting-started/mcp.md
+          - External Providers: getting-started/external-providers.md
   - Concepts:
       - concepts/index.md
       - Architecture:
@@ -188,6 +189,7 @@ nav:
       - API:
           - OpenAI Compatible: reference/api/openai.md
           - Responses API: reference/api/responses.md
+          - Anthropic Messages API: reference/api/messages.md
           - Admin API: reference/api/admin.md
           - Gateway Extensions: reference/api/extensions.md
       - Configuration: reference/configuration.md


### PR DESCRIPTION
## Summary

Catches up documentation with 69 features shipped since the last docs update (~Feb 10).

## New Pages

- **`reference/api/messages.md`** — Anthropic Messages API (`/v1/messages`) with streaming, gRPC backend translation, and connection modes
- **`getting-started/external-providers.md`** — Guide for external providers (OpenAI, Anthropic, xAI, Gemini): worker registration, model discovery fan-out, BYOK, multi-provider routing

## Updated Pages

- **`reference/configuration.md`** — New CLI flags: `--remove-unhealthy-workers`, `--disable-tokenizer-autoload`, mesh server flags (`--enable-mesh`, `--mesh-host`, `--mesh-port`, `--mesh-peer-urls`, `--mesh-server-name`)
- **`concepts/architecture/high-availability.md`** — Quick start CLI examples, Python bindings `smg launch --enable-mesh`, cache-aware state sync endpoints, `--router-selector` for k8s pod discovery
- **`concepts/routing/cache-aware.md`** — Event-driven KV block size learning, mesh state synchronization
- **`mkdocs.yml`** — Navigation entries for new pages

## Not Documented (Not Ready)

- Gemini Router (not production-ready)
- Realtime/WebRTC API (not production-ready)
- gRPC Servicer (internal)

## Test plan

- [ ] `mkdocs serve` renders all pages without errors
- [ ] New nav entries appear correctly
- [ ] Internal links resolve

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added External LLM Provider Gateway documentation with provider-agnostic routing and auto-detection
  * New Anthropic Messages API reference including streaming support
  * Expanded High Availability documentation with mesh networking quick start and Kubernetes pod discovery
  * Enhanced cache-aware state synchronization documentation for consistent routing state across nodes
  * Updated configuration reference with new tokenizer autoload option and clarified mesh server settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->