### PR TITLE
docs: add Docker/PyPI badges and release docker notes script

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 <p align="center">
   <a href="https://github.com/lightseekorg/smg/releases/latest"><img src="https://img.shields.io/github/v/release/lightseekorg/smg?logo=github&label=Release" alt="Release"></a>
+  <a href="https://github.com/orgs/lightseekorg/packages/container/package/smg"><img src="https://img.shields.io/badge/ghcr.io-lightseekorg%2Fsmg-blue?logo=docker" alt="Docker"></a>
+  <a href="https://pypi.org/project/smg/"><img src="https://img.shields.io/pypi/v/smg?logo=pypi&logoColor=white&label=PyPI" alt="PyPI"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License"></a>
   <a href="https://lightseekorg.github.io/smg"><img src="https://img.shields.io/badge/docs-latest-brightgreen.svg" alt="Docs"></a>
   <a href="https://discord.lightseek.org"><img src="https://img.shields.io/badge/Discord-Join%20Us-5865F2?logo=discord&logoColor=white" alt="Discord"></a>

--- a/scripts/release_docker_notes.sh
+++ b/scripts/release_docker_notes.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+# Generate Docker image markdown for release notes.
+#
+# Queries GHCR for all container tags matching a given SMG version
+# and outputs a markdown snippet to paste into release notes.
+#
+# Usage:
+#   ./scripts/release_docker_notes.sh v1.3.1
+#   ./scripts/release_docker_notes.sh 1.3.1
+#
+# Uses the OCI registry API (no auth needed for public packages).
+# Falls back to gh CLI if available with read:packages scope.
+
+set -euo pipefail
+
+VERSION="${1:-}"
+if [[ -z "$VERSION" ]]; then
+    echo "Usage: $0 <version>" >&2
+    echo "Example: $0 v1.3.1" >&2
+    exit 1
+fi
+
+# Strip leading 'v' for tag matching
+VERSION="${VERSION#v}"
+
+PACKAGE="smg"
+ORG="lightseekorg"
+REGISTRY="ghcr.io/${ORG}/${PACKAGE}"
+
+# ---------------------------------------------------------------------------
+# Fetch tags — try OCI registry API first (works without auth for public pkgs)
+# ---------------------------------------------------------------------------
+fetch_tags_oci() {
+    # Get an anonymous token for the public package
+    local token
+    token=$(curl -sf "https://ghcr.io/token?scope=repository:${ORG}/${PACKAGE}:pull" \
+        | python3 -c "import sys,json; print(json.load(sys.stdin)['token'])" 2>/dev/null) || return 1
+
+    # List tags from the OCI registry
+    curl -sf -H "Authorization: Bearer ${token}" \
+        "https://ghcr.io/v2/${ORG}/${PACKAGE}/tags/list" \
+        | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+for tag in sorted(data.get('tags', [])):
+    print(tag)
+" 2>/dev/null
+}
+
+fetch_tags_gh() {
+    gh api --paginate \
+        "/orgs/${ORG}/packages/container/${PACKAGE}/versions" \
+        --jq ".[].metadata.container.tags[]" 2>/dev/null
+}
+
+echo "Fetching tags for ${REGISTRY}..." >&2
+ALL_TAGS=$(fetch_tags_oci 2>/dev/null || fetch_tags_gh 2>/dev/null || true)
+
+# Filter to tags matching this version
+TAGS=$(echo "$ALL_TAGS" | grep "^${VERSION}-" | sort -t'-' -k2,2 -k3,3V || true)
+
+if [[ -z "$TAGS" ]]; then
+    echo "No Docker images found for version ${VERSION}" >&2
+    echo "" >&2
+    echo "Make sure:" >&2
+    echo "  1. Docker builds have completed for this release" >&2
+    echo "  2. The version tag is correct (tried: ${VERSION}-*)" >&2
+    echo "" >&2
+    echo "Available tags matching '${VERSION}':" >&2
+    echo "$ALL_TAGS" | grep "${VERSION}" | head -10 >&2 || echo "  (none)" >&2
+    exit 1
+fi
+
+TAG_COUNT=$(echo "$TAGS" | wc -l | tr -d ' ')
+echo "Found ${TAG_COUNT} image(s) for v${VERSION}" >&2
+echo "" >&2
+
+# ---------------------------------------------------------------------------
+# Group tags by engine and output markdown
+# Uses python3 to avoid bash 3.x associative array limitations (macOS)
+# ---------------------------------------------------------------------------
+echo "$TAGS" | python3 -c "
+import sys
+
+registry = '${REGISTRY}'
+version = '${VERSION}'
+
+tags = [line.strip() for line in sys.stdin if line.strip()]
+engines = {'sglang': [], 'vllm': [], 'trtllm': [], 'other': []}
+
+for tag in tags:
+    suffix = tag[len(version) + 1:]  # strip 'VERSION-'
+    engine = suffix.split('-')[0]
+    if engine in engines:
+        engines[engine].append(tag)
+    else:
+        engines['other'].append(tag)
+
+labels = {'sglang': 'SGLang', 'vllm': 'vLLM', 'trtllm': 'TensorRT-LLM', 'other': 'Other'}
+
+print('### Docker Images')
+print()
+print(f'Pre-built engine images on [GitHub Container Registry](https://github.com/orgs/lightseekorg/packages/container/package/smg):')
+print()
+
+for engine in ['sglang', 'vllm', 'trtllm', 'other']:
+    engine_tags = engines[engine]
+    if not engine_tags:
+        continue
+    print(f'**{labels[engine]}:**')
+    print('\`\`\`bash')
+    for tag in engine_tags:
+        print(f'docker pull {registry}:{tag}')
+    print('\`\`\`')
+    print()
+
+print('<details>')
+print(f'<summary>All images for v{version}</summary>')
+print()
+print('| Engine | Tag | Pull Command |')
+print('|--------|-----|--------------|')
+for tag in tags:
+    suffix = tag[len(version) + 1:]
+    engine = suffix.split('-')[0]
+    print(f'| {engine} | \`{tag}\` | \`docker pull {registry}:{tag}\` |')
+print()
+print('</details>')
+"


### PR DESCRIPTION
## Summary

- Adds Docker (GHCR) and PyPI badges to README header
- Adds a script to generate Docker image markdown for release notes

## What changed

- **README.md**: Two new badges between Release and License:
  - Docker badge → links to [GHCR packages page](https://github.com/orgs/lightseekorg/packages/container/package/smg)
  - PyPI badge → links to [smg on PyPI](https://pypi.org/project/smg/)

- **scripts/release_docker_notes.sh**: Queries the GHCR OCI registry API (no auth needed for public packages) for all tags matching a version, groups by engine, and outputs markdown:

```bash
$ ./scripts/release_docker_notes.sh v1.3.1

### Docker Images
...
**SGLang:**
docker pull ghcr.io/lightseekorg/smg:1.3.1-sglang-v0.5.9

**vLLM:**
docker pull ghcr.io/lightseekorg/smg:1.3.1-vllm-v0.17.0
...
```

Handles multiple engine versions per release (e.g., 9 images when we ship 3 versions per engine).

## Test plan

- [ ] Badges render correctly in README
- [ ] `./scripts/release_docker_notes.sh v1.3.1` outputs correct markdown
- [ ] `./scripts/release_docker_notes.sh v1.2.0` handles multiple tags per engine

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Docker and PyPI badges to README for easier package discovery.

* **Chores**
  * Added automated script for generating Docker release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->