### PR TITLE
chore(release): bump llm-multimodal to 1.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ smg-auth = { version = "1.1.1", path = "crates/auth" }
 smg-mcp = { version = "2.1.1", path = "crates/mcp" }
 kv-index = { version = "1.1.0", path = "crates/kv_index" }
 smg-data-connector = { version = "2.1.0", path = "crates/data_connector", package = "data-connector" }
-llm-multimodal = { version = "1.3.0", path = "crates/multimodal" }
+llm-multimodal = { version = "1.4.0", path = "crates/multimodal" }
 smg-wasm = { version = "1.1.0", path = "crates/wasm", package = "smg-wasm" }
 smg-mesh = { version = "1.2.0", path = "crates/mesh", package = "smg-mesh" }
 smg-grpc-client = { version = "1.4.0", path = "crates/grpc_client" }

--- a/crates/multimodal/Cargo.toml
+++ b/crates/multimodal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llm-multimodal"
-version = "1.3.0"
+version = "1.4.0"
 edition = "2021"
 description = "Multimodal processing for vision and other modalities"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Fixes crates.io publish failure caused by unbumped `llm-multimodal` crate.

## Problem

PR #776 added `MediaContentPart` to `llm-multimodal` but didn't bump the version. When `cargo publish` runs for `smg`, it downloads `llm-multimodal v1.3.0` from crates.io (which doesn't have `MediaContentPart`), causing:

```
error[E0432]: unresolved import `llm_multimodal::MediaContentPart`
```

## What changed

- **crates/multimodal/Cargo.toml**: 1.3.0 → 1.4.0
- **Cargo.toml**: workspace dep 1.3.0 → 1.4.0

## Test plan

- [ ] `cargo check` passes
- [ ] crates.io publish succeeds after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal package version and dependencies as part of routine maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->