### PR TITLE
fix(harmony): fix structural tag triggers for json_schema constrained output

### DIFF
--- a/model_gateway/src/routers/grpc/harmony/stages/preparation.rs
+++ b/model_gateway/src/routers/grpc/harmony/stages/preparation.rs
@@ -379,10 +379,13 @@ impl HarmonyPreparationStage {
 
 /// Build Harmony structural tag for structured output (JSON schema constraint)
 ///
-/// Creates a structural tag that applies JSON schema constraint to the final channel,
-/// supporting both reasoning-enabled and reasoning-disabled modes:
-/// - With reasoning: triggers on `<|start|>assistant<|channel|>final` (waits for analysis to complete)
-/// - Without reasoning: triggers on `<|channel|>final` (goes directly to final channel)
+/// Creates a structural tag that handles the full Harmony channel flow:
+/// 1. `<|channel|>analysis` trigger → reasoning content (any_text) until `<|end|>`
+/// 2. Free text (allows `<|start|>assistant` between messages)
+/// 3. `<|channel|>final` trigger → JSON content constrained to schema
+///
+/// Both triggers are needed so xgrammar's `at_least_one` mode allows the analysis
+/// channel tokens (otherwise xgrammar blocks all non-trigger-prefix tokens).
 ///
 /// This is used for the Responses API text.format field (json_object or json_schema).
 pub(crate) fn build_text_format_structural_tag(
@@ -391,19 +394,16 @@ pub(crate) fn build_text_format_structural_tag(
     let structural_tag = json!({
         "format": {
             "type": "triggered_tags",
-            "triggers": ["<|start|>assistant<|channel|>final", "<|channel|>final"],
+            "triggers": ["<|channel|>analysis", "<|channel|>final"],
             "tags": [
                 {
-                    // Pattern 1: For reasoning-enabled mode (with analysis channel before final)
-                    "begin": "<|start|>assistant<|channel|>final<|constrain|>json<|message|>",
-                    "content": {
-                        "type": "json_schema",
-                        "json_schema": schema
-                    },
-                    "end": ""
+                    // Analysis (reasoning) channel: any text until <|end|>
+                    "begin": "<|channel|>analysis<|message|>",
+                    "content": { "type": "any_text" },
+                    "end": "<|end|>"
                 },
                 {
-                    // Pattern 2: For reasoning-disabled mode (goes directly to final channel)
+                    // Final channel: JSON content constrained to schema
                     "begin": "<|channel|>final<|constrain|>json<|message|>",
                     "content": {
                         "type": "json_schema",
@@ -413,7 +413,7 @@ pub(crate) fn build_text_format_structural_tag(
                 }
             ],
             "at_least_one": true,
-            "stop_after_first": true
+            "stop_after_first": false
         }
     });
 


### PR DESCRIPTION
## Description

### Problem

The Harmony structural tag for `text.format.json_schema` only defined triggers for the final channel (`<|channel|>final`), without accounting for the analysis (reasoning) channel. With xgrammar's `at_least_one: true`, this caused the grammar to block **all** non-trigger-prefix tokens from the very first generated token — the model could not generate `<|channel|>analysis` or any reasoning content.

**Root cause**: xgrammar's `at_least_one: true` enforces that the grammar must start matching a trigger immediately. Since only `<|channel|>final` (and `<|start|>assistant<|channel|>final`) were registered as triggers, the grammar only allowed tokens that could be the start of those triggers. Tokens like `analysis` (35644) were blocked after `<|channel|>` because the grammar expected `final` (17196).

This was confirmed by testing the xgrammar `GrammarMatcher` bitmask directly:
- Before fix: after `<|channel|>`, only `final` was ALLOWED; `analysis` was blocked
- After fix: after `<|channel|>`, both `analysis` and `final` are ALLOWED

### Solution

Define both analysis and final channel triggers so the grammar handles the full Harmony channel flow:

1. `<|channel|>analysis` → reasoning content (`any_text`) until `<|end|>`
2. Free text between messages (allows `<|start|>assistant` etc.)
3. `<|channel|>final` → JSON content constrained to schema

Set `stop_after_first: false` so both tags fire sequentially.

## Changes

- `preparation.rs`: Rewrote `build_text_format_structural_tag()` to include both analysis and final channel triggers

## Test Plan

Tested with gpt-oss-120b on sglang (tp=4, `--reasoning-parser gpt-oss`):

```python
resp = client.responses.create(
    model=model,
    input="List exactly 2 fruits.",
    text={"format": {"type": "json_schema", "name": "fruits", "schema": {
        "type": "object",
        "properties": {"items": {"type": "array", "items": {"type": "string"}}},
        "required": ["items"], "additionalProperties": False,
    }, "strict": True}},
    store=False,
)
```

**Before**: Garbled output with non-breaking spaces, or text-encoded Harmony markers leaking into JSON
**After**: Clean JSON output with proper reasoning separation:
```
type=reasoning
  text='The user asks: "List exactly 2 fruits." ...'
type=message
  text='{"items":["Apple","Banana"]}'
```

Output token IDs confirm the structural tag trigger fires correctly — after `<|channel|>final`, only `<|constrain|>` (200003) is allowed by the grammar.

> **Note**: vLLM has a separate issue where `should_fill_bitmask()` returns False for structural_tag constraints on reasoning models, preventing the grammar from being applied. This requires a vLLM-side fix.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy -p smg -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced text output generation by restructuring the processing flow to include an analysis phase before final output, improving constraint handling and output quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->