### PR TITLE
fix(harmony): add analysis channel trigger to tool call structural tag

### DIFF
--- a/model_gateway/src/routers/grpc/harmony/stages/preparation.rs
+++ b/model_gateway/src/routers/grpc/harmony/stages/preparation.rs
@@ -325,38 +325,40 @@ impl HarmonyPreparationStage {
             _ => {}
         }
 
-        // Build tags for each tool - need two patterns per tool for reasoning on/off
+        // Analysis (reasoning) channel tag: any text until <|end|>
+        // This is needed so xgrammar's `at_least_one` allows the model to
+        // generate analysis content before entering the commentary channel.
+        tags.push(json!({
+            "begin": "<|channel|>analysis<|message|>",
+            "content": { "type": "any_text" },
+            "end": "<|end|>"
+        }));
+
+        // Build commentary channel tags for each tool
         for tool in tools_to_use {
             let tool_name = &tool.function.name;
             let params_schema = &tool.function.parameters;
 
-            // Pattern 1: For reasoning-enabled mode (with analysis channel before commentary)
-            tags.push(json!({
-                "begin": format!("<|start|>assistant<|channel|>commentary to=functions.{}<|constrain|>json<|message|>", tool_name),
-                "content": {
-                    "type": "json_schema",
-                    "json_schema": params_schema
-                },
-                "end": "" // `end` is empty because <|call|> comes naturally from Harmony stop tokens
-            }));
-
-            // Pattern 2: For reasoning-disabled mode (goes directly to commentary channel)
             tags.push(json!({
                 "begin": format!("<|channel|>commentary to=functions.{}<|constrain|>json<|message|>", tool_name),
                 "content": {
                     "type": "json_schema",
                     "json_schema": params_schema
                 },
-                "end": ""
+                "end": "" // `end` is empty because <|call|> comes naturally from Harmony stop tokens
             }));
         }
 
+        // stop_after_first: true when a specific function is requested (tool_choice=function),
+        // false when any tool can be called (tool_choice=required) to allow multiple tool calls.
+        // Note: analysis tag doesn't count toward "first" since it has an end tag and the
+        // grammar returns to free text after it completes.
         let stop_after_first = specific_function.is_some();
 
         let structural_tag = json!({
             "format": {
                 "type": "triggered_tags",
-                "triggers": ["<|start|>assistant<|channel|>commentary", "<|channel|>commentary"],
+                "triggers": ["<|channel|>analysis", "<|channel|>commentary"],
                 "tags": tags,
                 "at_least_one": true,
                 "stop_after_first": stop_after_first


### PR DESCRIPTION
## Description

### Problem

Same root cause as #789: the tool call structural tag only defined triggers for the commentary channel (`<|channel|>commentary`), without the analysis (reasoning) channel. With xgrammar's `at_least_one: true`, the grammar blocked all non-trigger-prefix tokens from the first token, preventing the model from generating reasoning before making tool calls.

### Solution

Add `<|channel|>analysis` trigger with `any_text` content until `<|end|>`, matching the fix in #789. This allows the full Harmony flow: analysis → free text → commentary (constrained tool call arguments).

Also simplified from two patterns per tool (reasoning-on/off) to one, since the analysis trigger now handles the reasoning phase explicitly.

## Changes

- `preparation.rs`: Added analysis channel tag to `build_tool_call_structural_tag()`, updated triggers from `["<|start|>assistant<|channel|>commentary", "<|channel|>commentary"]` to `["<|channel|>analysis", "<|channel|>commentary"]`

## Test Plan

Verified xgrammar bitmask allows both `analysis` and `commentary` after `<|channel|>` token, matching the validated behavior from #789.

`tool_choice=required` and `tool_choice=function` both preserve their original `stop_after_first` semantics.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal system for handling tool analysis and commentary processing, improving efficiency of reasoning workflows while maintaining existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->