### PR TITLE
feat(harmony): support response_format in Chat Completions

### DIFF
--- a/e2e_test/chat_completions/test_openai_server.py
+++ b/e2e_test/chat_completions/test_openai_server.py
@@ -745,6 +745,7 @@ class TestChatCompletionGptOss(TestChatCompletion):
         assert set(parsed) == {"items"}
         assert isinstance(parsed["items"], list)
         assert len(parsed["items"]) == 2
+        assert all(isinstance(item, str) for item in parsed["items"])
 
         # Should not contain leaked Harmony markers
         assert "<|channel|>" not in content

--- a/model_gateway/src/routers/grpc/harmony/stages/preparation.rs
+++ b/model_gateway/src/routers/grpc/harmony/stages/preparation.rs
@@ -101,13 +101,18 @@ impl HarmonyPreparationStage {
         // Step 1: Filter tools if needed
         let mut body_ref = utils::filter_chat_request_by_tool_choice(request);
 
-        // Step 2: Build structural tag constraint (tool call or response_format, mutually exclusive)
+        // Step 2: Build structural tag constraint
+        // Try tool call constraint first; fall back to response_format if no tool constraint produced.
         let constraint = if let Some(tools) = body_ref.tools.as_ref() {
             Self::generate_tool_call_constraint(tools, body_ref.tool_choice.as_ref())
                 .map_err(|e| *e)?
         } else {
-            Self::generate_response_format_constraint(body_ref.response_format.as_ref())
-                .map_err(|e| *e)?
+            None
+        };
+        let constraint = match constraint {
+            Some(c) => Some(c),
+            None => Self::generate_response_format_constraint(body_ref.response_format.as_ref())
+                .map_err(|e| *e)?,
         };
 
         // If response_format was converted to a structural tag, clear it from the request


### PR DESCRIPTION
## Description

### Problem

The Harmony Chat Completions path handled `tool_choice` constraints via structural tags but completely ignored the `response_format` parameter (`json_object`, `json_schema`). Requests with `response_format` on Harmony models produced unconstrained output — the model generated freely without JSON schema enforcement.

### Solution

Add `generate_response_format_constraint()` which converts `response_format` to the same structural tag format used by the Responses API `text.format` path (`build_text_format_structural_tag`). When tools are not present, `response_format` is applied as a structural tag constraint on the final channel.

This reuses the structural tag format fixed in #789 (with analysis + final channel triggers).

## Changes

- `preparation.rs`: Added `generate_response_format_constraint()` method and integrated it into `prepare_chat()` — when no tools are present, falls through to check `response_format`

## Test Plan

```bash
curl -s -X POST http://localhost:3002/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "/models/openai/gpt-oss-120b",
    "messages": [{"role": "user", "content": "List 3 colors"}],
    "response_format": {
      "type": "json_schema",
      "json_schema": {
        "name": "colors",
        "strict": true,
        "schema": {
          "type": "object",
          "properties": {"colors": {"type": "array", "items": {"type": "string"}}},
          "required": ["colors"],
          "additionalProperties": false
        }
      }
    }
  }'
```

**Before**: Unconstrained output (no JSON enforcement)
**After**: JSON output constrained to schema via structural tag

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end checks validating JSON Schema–constrained chat responses (streaming and non‑streaming) across hosted and OSS models to ensure schema compliance and prevent leaked protocol markers.

* **Improvements**
  * Unified response-format handling so structured output constraints are applied consistently, preferring tool-driven constraints when available to reduce malformed responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->