### PR TITLE
feat(core): add per-worker resilience and HTTP pool config types

### DIFF
--- a/crates/protocols/src/worker.rs
+++ b/crates/protocols/src/worker.rs
@@ -526,6 +526,14 @@ pub struct WorkerSpec {
     #[serde(default, skip_serializing_if = "HealthCheckUpdate::is_empty")]
     pub health: HealthCheckUpdate,
 
+    /// Per-worker HTTP connection pool overrides.
+    #[serde(default, skip_serializing_if = "HttpPoolConfig::is_empty")]
+    pub http_pool: HttpPoolConfig,
+
+    /// Per-worker resilience overrides (retry + circuit breaker).
+    #[serde(default, skip_serializing_if = "ResilienceUpdate::is_empty")]
+    pub resilience: ResilienceUpdate,
+
     /// Maximum connection attempts during worker registration (default: 20).
     #[serde(default = "default_max_connection_attempts")]
     pub max_connection_attempts: u32,
@@ -560,6 +568,8 @@ impl WorkerSpec {
             kv_role: None,
             kv_block_size: None,
             health: HealthCheckUpdate::default(),
+            http_pool: HttpPoolConfig::default(),
+            resilience: ResilienceUpdate::default(),
             max_connection_attempts: default_max_connection_attempts(),
             load_monitor_interval_secs: None,
         }
@@ -731,6 +741,87 @@ impl HealthCheckUpdate {
                 .disable_health_check
                 .unwrap_or(existing.disable_health_check),
         }
+    }
+}
+
+/// Per-worker HTTP connection pool configuration.
+/// All fields optional — `None` means "use router/global default".
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct HttpPoolConfig {
+    /// Max idle connections per host (default: 8).
+    pub pool_max_idle_per_host: Option<usize>,
+    /// Idle connection timeout in seconds (default: 50).
+    pub pool_idle_timeout_secs: Option<u64>,
+    /// Request timeout in seconds (default: 30).
+    pub timeout_secs: Option<u64>,
+    /// Connect timeout in seconds (default: 10).
+    pub connect_timeout_secs: Option<u64>,
+}
+
+impl HttpPoolConfig {
+    /// Returns `true` if all fields are `None` (no overrides).
+    pub fn is_empty(&self) -> bool {
+        self.pool_max_idle_per_host.is_none()
+            && self.pool_idle_timeout_secs.is_none()
+            && self.timeout_secs.is_none()
+            && self.connect_timeout_secs.is_none()
+    }
+}
+
+/// Per-worker resilience overrides (retry + circuit breaker).
+/// All fields optional — `None` means "use router default".
+/// Mirrors `HealthCheckUpdate` pattern for PATCH-style config.
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct ResilienceUpdate {
+    // ── Retry overrides ──
+    /// Max retry attempts (includes first attempt). 1 = no retries.
+    pub max_retries: Option<u32>,
+    /// Initial backoff delay in milliseconds.
+    pub initial_backoff_ms: Option<u64>,
+    /// Maximum backoff delay in milliseconds.
+    pub max_backoff_ms: Option<u64>,
+    /// Backoff multiplier for exponential backoff.
+    pub backoff_multiplier: Option<f32>,
+    /// Jitter factor (0.0–1.0) applied to backoff delay.
+    pub jitter_factor: Option<f32>,
+    /// Disable retries entirely for this worker.
+    pub disable_retry: Option<bool>,
+
+    // ── Circuit breaker overrides ──
+    /// Consecutive failures to open the circuit.
+    pub cb_failure_threshold: Option<u32>,
+    /// Consecutive successes to close the circuit from half-open.
+    pub cb_success_threshold: Option<u32>,
+    /// Seconds to wait before attempting half-open.
+    pub cb_timeout_secs: Option<u64>,
+    /// Time window in seconds for failure counting.
+    pub cb_window_secs: Option<u64>,
+    /// Disable circuit breaker entirely for this worker.
+    pub disable_circuit_breaker: Option<bool>,
+
+    // ── Retryable status codes ──
+    /// Custom retryable HTTP status codes.
+    /// When set, replaces the default set (408, 429, 500, 502, 503, 504).
+    pub retryable_status_codes: Option<Vec<u16>>,
+}
+
+impl ResilienceUpdate {
+    /// Returns `true` if all fields are `None` (no overrides).
+    pub fn is_empty(&self) -> bool {
+        self.max_retries.is_none()
+            && self.initial_backoff_ms.is_none()
+            && self.max_backoff_ms.is_none()
+            && self.backoff_multiplier.is_none()
+            && self.jitter_factor.is_none()
+            && self.disable_retry.is_none()
+            && self.cb_failure_threshold.is_none()
+            && self.cb_success_threshold.is_none()
+            && self.cb_timeout_secs.is_none()
+            && self.cb_window_secs.is_none()
+            && self.disable_circuit_breaker.is_none()
+            && self.retryable_status_codes.is_none()
     }
 }
 

--- a/model_gateway/src/core/http_client.rs
+++ b/model_gateway/src/core/http_client.rs
@@ -1,0 +1,110 @@
+//! Per-worker HTTP client construction.
+//!
+//! Builds a `reqwest::Client` for each worker by merging per-worker
+//! `HttpPoolConfig` overrides with router-level TLS and timeout defaults.
+
+use std::time::Duration;
+
+use openai_protocol::worker::HttpPoolConfig;
+use tracing::debug;
+
+use crate::config::RouterConfig;
+
+/// Default pool settings for per-worker HTTP clients.
+const DEFAULT_POOL_MAX_IDLE_PER_HOST: usize = 8;
+const DEFAULT_POOL_IDLE_TIMEOUT_SECS: u64 = 50;
+const DEFAULT_CONNECT_TIMEOUT_SECS: u64 = 10;
+
+/// Build a per-worker `reqwest::Client`.
+///
+/// Merges `HttpPoolConfig` overrides with router-level TLS settings.
+/// Each worker gets its own connection pool, isolated from other workers.
+pub fn build_worker_http_client(
+    pool_config: &HttpPoolConfig,
+    router_config: &RouterConfig,
+) -> Result<reqwest::Client, String> {
+    let timeout_secs = pool_config
+        .timeout_secs
+        .unwrap_or(router_config.request_timeout_secs);
+    let connect_timeout_secs = pool_config
+        .connect_timeout_secs
+        .unwrap_or(DEFAULT_CONNECT_TIMEOUT_SECS);
+    let pool_max_idle = pool_config
+        .pool_max_idle_per_host
+        .unwrap_or(DEFAULT_POOL_MAX_IDLE_PER_HOST);
+    let pool_idle_timeout = pool_config
+        .pool_idle_timeout_secs
+        .unwrap_or(DEFAULT_POOL_IDLE_TIMEOUT_SECS);
+
+    let has_tls =
+        router_config.client_identity.is_some() || !router_config.ca_certificates.is_empty();
+
+    let mut builder = reqwest::Client::builder()
+        .pool_max_idle_per_host(pool_max_idle)
+        .pool_idle_timeout(Some(Duration::from_secs(pool_idle_timeout)))
+        .timeout(Duration::from_secs(timeout_secs))
+        .connect_timeout(Duration::from_secs(connect_timeout_secs))
+        .tcp_nodelay(true)
+        .tcp_keepalive(Some(Duration::from_secs(30)));
+
+    if has_tls {
+        builder = builder.use_rustls_tls();
+    }
+
+    if let Some(identity_pem) = &router_config.client_identity {
+        let identity = reqwest::Identity::from_pem(identity_pem)
+            .map_err(|e| format!("Failed to create client identity: {e}"))?;
+        builder = builder.identity(identity);
+    }
+
+    for ca_cert in &router_config.ca_certificates {
+        let cert = reqwest::Certificate::from_pem(ca_cert)
+            .map_err(|e| format!("Failed to add CA certificate: {e}"))?;
+        builder = builder.add_root_certificate(cert);
+    }
+
+    debug!(
+        pool_max_idle = pool_max_idle,
+        timeout_secs = timeout_secs,
+        "Building per-worker HTTP client"
+    );
+
+    builder
+        .build()
+        .map_err(|e| format!("Failed to create per-worker HTTP client: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::types::{PolicyConfig, RoutingMode};
+
+    fn test_router_config() -> RouterConfig {
+        RouterConfig::new(
+            RoutingMode::Regular {
+                worker_urls: vec![],
+            },
+            PolicyConfig::Random,
+        )
+    }
+
+    #[test]
+    fn test_build_client_with_defaults() {
+        let pool = HttpPoolConfig::default();
+        let config = test_router_config();
+        let client = build_worker_http_client(&pool, &config);
+        assert!(client.is_ok());
+    }
+
+    #[test]
+    fn test_build_client_with_overrides() {
+        let pool = HttpPoolConfig {
+            pool_max_idle_per_host: Some(16),
+            timeout_secs: Some(60),
+            ..Default::default()
+        };
+        let config = test_router_config();
+        let client = build_worker_http_client(&pool, &config);
+        assert!(client.is_ok());
+    }
+}

--- a/model_gateway/src/core/mod.rs
+++ b/model_gateway/src/core/mod.rs
@@ -14,9 +14,11 @@ pub use openai_protocol::UNKNOWN_MODEL_ID;
 
 pub mod circuit_breaker;
 pub mod error;
+pub mod http_client;
 pub mod job_queue;
 pub mod kv_event_monitor;
 pub mod metrics_aggregator;
+pub mod resilience;
 pub mod retry;
 pub mod steps;
 pub mod token_bucket;
@@ -29,6 +31,7 @@ pub mod worker_service;
 // Re-export commonly used types for convenience
 pub use circuit_breaker::{CircuitBreaker, CircuitBreakerConfig};
 pub use error::{WorkerError, WorkerResult};
+pub use http_client::build_worker_http_client;
 pub use job_queue::{Job, JobQueue, JobQueueConfig};
 pub use kv_event_monitor::KvEventMonitor;
 pub use openai_protocol::{
@@ -36,6 +39,7 @@ pub use openai_protocol::{
     model_type::{Endpoint, ModelType},
     worker::{ProviderType, WorkerGroupKey},
 };
+pub use resilience::{resolve_resilience, ResolvedResilience, DEFAULT_RETRYABLE_STATUS_CODES};
 pub use retry::{is_retryable_status, RetryExecutor};
 pub use worker::{
     AttachedBody, BasicWorker, ConnectionMode, RuntimeType, Worker, WorkerLoadGuard, WorkerType,

--- a/model_gateway/src/core/resilience.rs
+++ b/model_gateway/src/core/resilience.rs
@@ -1,0 +1,221 @@
+//! Resolved per-worker resilience configuration.
+//!
+//! Merges router-level defaults with per-worker overrides from `ResilienceUpdate`.
+//! Created at worker construction time — immutable after that.
+
+use std::{collections::HashSet, time::Duration};
+
+use openai_protocol::worker::ResilienceUpdate;
+
+use crate::{config::types::RetryConfig, core::circuit_breaker::CircuitBreakerConfig};
+
+/// Default retryable HTTP status codes.
+pub const DEFAULT_RETRYABLE_STATUS_CODES: &[u16] = &[408, 429, 500, 502, 503, 504];
+
+/// Fully resolved resilience configuration for a worker.
+///
+/// Created by merging `RouterConfig` defaults with `WorkerSpec.resilience` overrides.
+/// Immutable after construction.
+#[derive(Debug, Clone)]
+pub struct ResolvedResilience {
+    /// Effective retry config.
+    pub retry: RetryConfig,
+    /// Whether retries are enabled.
+    pub retry_enabled: bool,
+    /// Whether circuit breaker is enabled.
+    pub circuit_breaker_enabled: bool,
+    /// Set of HTTP status codes considered retryable.
+    pub retryable_status_codes: HashSet<u16>,
+}
+
+impl Default for ResolvedResilience {
+    fn default() -> Self {
+        Self {
+            retry: RetryConfig::default(),
+            retry_enabled: true,
+            circuit_breaker_enabled: true,
+            retryable_status_codes: DEFAULT_RETRYABLE_STATUS_CODES.iter().copied().collect(),
+        }
+    }
+}
+
+/// Resolve per-worker resilience config by merging router defaults with worker overrides.
+pub fn resolve_resilience(
+    base_retry: &RetryConfig,
+    base_cb: &CircuitBreakerConfig,
+    base_retry_enabled: bool,
+    base_cb_enabled: bool,
+    overrides: &ResilienceUpdate,
+) -> (ResolvedResilience, CircuitBreakerConfig) {
+    // Resolve retry config
+    let retry = RetryConfig {
+        max_retries: overrides.max_retries.unwrap_or(base_retry.max_retries),
+        initial_backoff_ms: overrides
+            .initial_backoff_ms
+            .unwrap_or(base_retry.initial_backoff_ms),
+        max_backoff_ms: overrides
+            .max_backoff_ms
+            .unwrap_or(base_retry.max_backoff_ms),
+        backoff_multiplier: overrides
+            .backoff_multiplier
+            .unwrap_or(base_retry.backoff_multiplier),
+        jitter_factor: overrides.jitter_factor.unwrap_or(base_retry.jitter_factor),
+    };
+
+    // Resolve circuit breaker config
+    let cb_config = CircuitBreakerConfig {
+        failure_threshold: overrides
+            .cb_failure_threshold
+            .unwrap_or(base_cb.failure_threshold),
+        success_threshold: overrides
+            .cb_success_threshold
+            .unwrap_or(base_cb.success_threshold),
+        timeout_duration: overrides
+            .cb_timeout_secs
+            .map(Duration::from_secs)
+            .unwrap_or(base_cb.timeout_duration),
+        window_duration: overrides
+            .cb_window_secs
+            .map(Duration::from_secs)
+            .unwrap_or(base_cb.window_duration),
+    };
+
+    // Resolve enabled flags (per-worker overrides router-level)
+    let retry_enabled = overrides
+        .disable_retry
+        .map(|d| !d)
+        .unwrap_or(base_retry_enabled);
+
+    let cb_enabled = overrides
+        .disable_circuit_breaker
+        .map(|d| !d)
+        .unwrap_or(base_cb_enabled);
+
+    // Resolve retryable status codes
+    let retryable_status_codes = overrides
+        .retryable_status_codes
+        .as_ref()
+        .map(|codes| codes.iter().copied().collect())
+        .unwrap_or_else(|| DEFAULT_RETRYABLE_STATUS_CODES.iter().copied().collect());
+
+    let resolved = ResolvedResilience {
+        retry,
+        retry_enabled,
+        circuit_breaker_enabled: cb_enabled,
+        retryable_status_codes,
+    };
+
+    (resolved, cb_config)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_resilience() {
+        let resolved = ResolvedResilience::default();
+        assert!(resolved.retry_enabled);
+        assert!(resolved.circuit_breaker_enabled);
+        assert_eq!(resolved.retryable_status_codes.len(), 6);
+        assert!(resolved.retryable_status_codes.contains(&429));
+        assert!(resolved.retryable_status_codes.contains(&503));
+    }
+
+    #[test]
+    fn test_resolve_with_no_overrides() {
+        let base_retry = RetryConfig::default();
+        let base_cb = CircuitBreakerConfig::default();
+        let overrides = ResilienceUpdate::default();
+
+        let (resolved, cb_config) =
+            resolve_resilience(&base_retry, &base_cb, true, true, &overrides);
+
+        assert_eq!(resolved.retry.max_retries, base_retry.max_retries);
+        assert_eq!(cb_config.failure_threshold, base_cb.failure_threshold);
+        assert!(resolved.retry_enabled);
+        assert!(resolved.circuit_breaker_enabled);
+    }
+
+    #[test]
+    fn test_resolve_with_retry_overrides() {
+        let base_retry = RetryConfig::default();
+        let base_cb = CircuitBreakerConfig::default();
+        let overrides = ResilienceUpdate {
+            max_retries: Some(10),
+            initial_backoff_ms: Some(200),
+            ..Default::default()
+        };
+
+        let (resolved, _) = resolve_resilience(&base_retry, &base_cb, true, true, &overrides);
+
+        assert_eq!(resolved.retry.max_retries, 10);
+        assert_eq!(resolved.retry.initial_backoff_ms, 200);
+        // Non-overridden fields keep base values
+        assert_eq!(resolved.retry.max_backoff_ms, base_retry.max_backoff_ms);
+    }
+
+    #[test]
+    fn test_resolve_disable_retry() {
+        let base_retry = RetryConfig::default();
+        let base_cb = CircuitBreakerConfig::default();
+        let overrides = ResilienceUpdate {
+            disable_retry: Some(true),
+            ..Default::default()
+        };
+
+        let (resolved, _) = resolve_resilience(&base_retry, &base_cb, true, true, &overrides);
+
+        assert!(!resolved.retry_enabled);
+    }
+
+    #[test]
+    fn test_resolve_worker_enables_when_router_disables() {
+        let base_retry = RetryConfig::default();
+        let base_cb = CircuitBreakerConfig::default();
+        let overrides = ResilienceUpdate {
+            disable_retry: Some(false),
+            ..Default::default()
+        };
+
+        // Router has retries disabled, but worker explicitly enables
+        let (resolved, _) = resolve_resilience(&base_retry, &base_cb, false, true, &overrides);
+
+        assert!(resolved.retry_enabled);
+    }
+
+    #[test]
+    fn test_resolve_custom_retryable_codes() {
+        let base_retry = RetryConfig::default();
+        let base_cb = CircuitBreakerConfig::default();
+        let overrides = ResilienceUpdate {
+            retryable_status_codes: Some(vec![502, 503]),
+            ..Default::default()
+        };
+
+        let (resolved, _) = resolve_resilience(&base_retry, &base_cb, true, true, &overrides);
+
+        assert_eq!(resolved.retryable_status_codes.len(), 2);
+        assert!(resolved.retryable_status_codes.contains(&502));
+        assert!(resolved.retryable_status_codes.contains(&503));
+        assert!(!resolved.retryable_status_codes.contains(&429));
+    }
+
+    #[test]
+    fn test_resolve_cb_overrides() {
+        let base_retry = RetryConfig::default();
+        let base_cb = CircuitBreakerConfig::default();
+        let overrides = ResilienceUpdate {
+            cb_failure_threshold: Some(10),
+            cb_timeout_secs: Some(60),
+            ..Default::default()
+        };
+
+        let (_, cb_config) = resolve_resilience(&base_retry, &base_cb, true, true, &overrides);
+
+        assert_eq!(cb_config.failure_threshold, 10);
+        assert_eq!(cb_config.timeout_duration, Duration::from_secs(60));
+        // Non-overridden
+        assert_eq!(cb_config.success_threshold, base_cb.success_threshold);
+    }
+}


### PR DESCRIPTION
## Description

### Problem

The model gateway has global retry, circuit breaker, and HTTP client config — all workers share the same settings. Workers cannot have per-worker overrides for resilience behavior or connection pools, creating implicit coupling and preventing fine-grained tuning.

### Solution

Add foundational config types for per-worker resilience. Protocol layer gets flat optional config types (`HttpPoolConfig`, `ResilienceUpdate`) following the existing `HealthCheckUpdate` PATCH-style pattern. Runtime layer resolves them against router defaults at worker creation time via `ResolvedResilience`. A per-worker HTTP client builder isolates connection pools per worker.

This is the first PR in the per-worker resilience refactor series — types only, no behavior changes, fully backwards compatible.

## Changes

- Add `HttpPoolConfig` and `ResilienceUpdate` structs to `WorkerSpec` in the protocol layer (`crates/protocols/src/worker.rs`)
- Add `ResolvedResilience` struct and `resolve_resilience()` function in `model_gateway/src/core/resilience.rs`
- Add `build_worker_http_client()` utility in `model_gateway/src/core/http_client.rs`
- Register new modules and public exports in `model_gateway/src/core/mod.rs`

## Test Plan

- `cargo test -p openai-protocol` — all 36 tests pass (no regressions)
- `cargo test -p smg --lib core::resilience` — 7 new tests covering default resolution, retry/CB overrides, disable flags, custom retryable codes
- `cargo test -p smg --lib core::http_client` — 2 new tests for default and overridden client construction
- `cargo test -p smg --lib` — all 435 tests pass, 0 failures

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: raw summary by coderabbit.ai -->
<!-- end of auto-generated comment: raw summary by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

<!-- This is an auto-generated comment: summary by coderabbit.ai -->
<!-- end of auto-generated comment: summary by coderabbit.ai -->