### PR TITLE
fix(ci): use ignore-pr-updates for stale PR detection, disable issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,4 +1,4 @@
-name: 'Close inactive issues and PRs'
+name: 'Close stale PRs'
 
 on:
   schedule:
@@ -7,10 +7,9 @@ on:
   workflow_dispatch:
 
 jobs:
-  close-issues-and-pull-requests:
+  close-stale-prs:
     if: github.repository == 'lightseekorg/smg'
     permissions:
-      issues: write
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
@@ -19,21 +18,20 @@ jobs:
           operations-per-run: 500
           exempt-draft-pr: true
 
-          days-before-issue-stale: 90
-          days-before-issue-close: 30
-          stale-issue-label: 'stale'
-          stale-issue-message: >
-            This issue has been automatically marked as stale because it has not
-            had any activity within 90 days. It will be automatically closed if no
-            further activity occurs within 30 days. Leave a comment if
-            you feel this issue should remain open. Thank you!
-          close-issue-message: >
-            This issue has been automatically closed due to inactivity. Please
-            feel free to reopen if you feel it is still relevant. Thank you!
+          # Disable issue processing
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
 
+          # PR staleness
           days-before-pr-stale: 14
           days-before-pr-close: 16
           stale-pr-label: 'stale'
+
+          # Use creation/update of stale label to track staleness instead of
+          # updated_at, which GitHub silently bumps for invisible events like
+          # merge conflict recalculation when main changes.
+          ignore-pr-updates: true
+
           stale-pr-message: >
             This pull request has been automatically marked as stale because it
             has not had any activity within 14 days. It will be automatically


### PR DESCRIPTION
## Description

### Problem

Follow-up to #798. The actions/stale workflow uses updated_at by default to determine staleness. GitHub silently bumps updated_at for invisible events like merge conflict recalculation when main changes. Manual testing confirmed old PRs like #463 and #253 (inactive since Jan/Feb) were marked "not stale" because updated_at showed yesterday.

### Solution

- Set ignore-pr-updates: true so staleness is tracked from the stale label creation date, not updated_at. Only real activity (comments, commits) that removes the stale label resets the timer.
- Disable issue processing (days-before-issue-stale: -1) to focus on PRs only for now.
- Remove issues: write permission since we no longer process issues.

## Changes

- .github/workflows/stale.yml: Add ignore-pr-updates, disable issues, simplify permissions

## Test Plan

After merge, trigger manually via Actions tab and verify old inactive PRs receive the stale label.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined pull request automation by refocusing the stale detection workflow to handle pull requests exclusively with improved staleness tracking based on PR activity and creation dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->