### PR TITLE
refactor(openai): cleanup dead code, redundant state, and hot-path inefficiencies

### DIFF
--- a/crates/protocols/src/event_types.rs
+++ b/crates/protocols/src/event_types.rs
@@ -278,6 +278,7 @@ pub enum ItemType {
 
 impl ItemType {
     pub const FUNCTION_CALL: &'static str = "function_call";
+    pub const FUNCTION_CALL_OUTPUT: &'static str = "function_call_output";
     pub const FUNCTION_TOOL_CALL: &'static str = "function_tool_call";
     pub const MCP_CALL: &'static str = "mcp_call";
     pub const FUNCTION: &'static str = "function";

--- a/model_gateway/src/routers/openai/chat.rs
+++ b/model_gateway/src/routers/openai/chat.rs
@@ -34,7 +34,6 @@ pub(super) struct ChatRouterContext<'a> {
     pub worker_registry: &'a WorkerRegistry,
     pub provider_registry: &'a ProviderRegistry,
     pub shared_components: &'a Arc<SharedComponents>,
-    pub client: &'a reqwest::Client,
     pub retry_config: &'a RetryConfig,
 }
 
@@ -58,7 +57,7 @@ pub(super) async fn route_chat(
         bool_to_static_str(streaming),
     );
 
-    let selector = WorkerSelector::new(deps.worker_registry, deps.client);
+    let selector = WorkerSelector::new(deps.worker_registry, &deps.shared_components.client);
     let worker = match selector
         .select_worker(&SelectWorkerRequest {
             model_id: model,

--- a/model_gateway/src/routers/openai/mcp/tool_handler.rs
+++ b/model_gateway/src/routers/openai/mcp/tool_handler.rs
@@ -97,8 +97,6 @@ pub(crate) struct StreamingToolHandler {
     pub accumulator: StreamingResponseAccumulator,
     /// Function calls being built from deltas
     pub pending_calls: Vec<FunctionCallInProgress>,
-    /// Track if we're currently in a function call
-    in_function_call: bool,
     /// Manage output_index remapping so they increment per item
     output_index_mapper: OutputIndexMapper,
     /// Original response id captured from the first response.created event
@@ -110,7 +108,6 @@ impl StreamingToolHandler {
         Self {
             accumulator: StreamingResponseAccumulator::new(),
             pending_calls: Vec::new(),
-            in_function_call: false,
             output_index_mapper: OutputIndexMapper::with_start(start),
             original_response_id: None,
         }
@@ -189,7 +186,8 @@ impl StreamingToolHandler {
     }
 
     fn handle_output_item_added(&mut self, parsed: &Value) -> StreamAction {
-        if let Some(output_index) = extract_output_index(parsed) {
+        let cached_output_index = extract_output_index(parsed);
+        if let Some(output_index) = cached_output_index {
             self.ensure_output_index(output_index);
         }
 
@@ -204,7 +202,7 @@ impl StreamingToolHandler {
             return StreamAction::Forward;
         }
 
-        let Some(output_index) = extract_output_index(parsed) else {
+        let Some(output_index) = cached_output_index else {
             warn!(
                 "Missing output_index in function_call added event, \
                  forwarding without processing for tool execution"
@@ -220,7 +218,6 @@ impl StreamingToolHandler {
         call.call_id = call_id.to_string();
         call.name = name.to_string();
         call.assigned_output_index = Some(assigned_index);
-        self.in_function_call = true;
 
         StreamAction::Forward
     }
@@ -282,8 +279,6 @@ impl StreamingToolHandler {
         let item_type = delta.get("type").and_then(|v| v.as_str());
 
         if item_type.is_some_and(is_function_call_type) {
-            self.in_function_call = true;
-
             // Get or create function call for this output index
             let call = self.get_or_create_call(output_index, delta);
             call.assigned_output_index = Some(assigned_index);

--- a/model_gateway/src/routers/openai/mcp/tool_loop.rs
+++ b/model_gateway/src/routers/openai/mcp/tool_loop.rs
@@ -76,7 +76,7 @@ impl ToolLoopState {
         self.conversation_history.push(func_item);
 
         let output_item = json!({
-            "type": "function_call_output",
+            "type": ItemType::FUNCTION_CALL_OUTPUT,
             "call_id": call_id,
             "output": output_str
         });
@@ -133,12 +133,7 @@ pub(crate) async fn execute_streaming_tool_calls(
                     &call.name,
                     &call.arguments_buffer,
                 );
-                if !send_tool_call_completion_events(
-                    tx,
-                    &call,
-                    mcp_call_item.clone(),
-                    sequence_number,
-                ) {
+                if !send_tool_call_completion_events(tx, &call, &mcp_call_item, sequence_number) {
                     return false;
                 }
                 state.record_call(
@@ -182,7 +177,7 @@ pub(crate) async fn execute_streaming_tool_calls(
             json!({})
         });
 
-        if !send_tool_call_completion_events(tx, &call, mcp_call_item.clone(), sequence_number) {
+        if !send_tool_call_completion_events(tx, &call, &mcp_call_item, sequence_number) {
             return false;
         }
 
@@ -413,7 +408,7 @@ fn send_tool_call_intermediate_event(
 fn send_tool_call_completion_events(
     tx: &mpsc::UnboundedSender<Result<Bytes, io::Error>>,
     call: &FunctionCallInProgress,
-    tool_call_item: Value,
+    tool_call_item: &Value,
     sequence_number: &mut u64,
 ) -> bool {
     let effective_output_index = call.effective_output_index();
@@ -815,7 +810,7 @@ fn extract_function_calls(resp: &Value) -> Vec<ExtractedFunctionCall> {
         return Vec::new();
     };
 
-    let mut calls = Vec::new();
+    let mut calls = Vec::with_capacity(4);
     for item in output {
         let Some(obj) = item.as_object() else {
             continue;

--- a/model_gateway/src/routers/openai/responses/common.rs
+++ b/model_gateway/src/routers/openai/responses/common.rs
@@ -39,13 +39,10 @@ impl ChunkProcessor {
             Ok(s) => Cow::Borrowed(s),
             Err(_) => Cow::Owned(String::from_utf8_lossy(chunk).into_owned()),
         };
-        let mut chars = chunk_str.chars().peekable();
-        while let Some(c) = chars.next() {
-            if c == '\r' && chars.peek() == Some(&'\n') {
-                // Skip \r when followed by \n
-                continue;
-            }
-            self.pending.push(c);
+        if chunk_str.contains('\r') {
+            self.pending.push_str(&chunk_str.replace("\r\n", "\n"));
+        } else {
+            self.pending.push_str(&chunk_str);
         }
     }
 

--- a/model_gateway/src/routers/openai/responses/history.rs
+++ b/model_gateway/src/routers/openai/responses/history.rs
@@ -134,7 +134,7 @@ pub(crate) async fn load_input_history(
                                 }
                             }
                         }
-                        "function_call_output" => {
+                        ItemType::FUNCTION_CALL_OUTPUT => {
                             tracing::debug!(
                                 item_id = %item.id.0,
                                 "Loading function_call_output from DB"

--- a/model_gateway/src/routers/openai/responses/streaming.rs
+++ b/model_gateway/src/routers/openai/responses/streaming.rs
@@ -37,6 +37,8 @@ use super::{
         rewrite_streaming_block,
     },
 };
+const SSE_DONE: &str = "data: [DONE]\n\n";
+
 use crate::{
     observability::metrics::Metrics,
     routers::{
@@ -792,14 +794,21 @@ pub(super) fn handle_streaming_with_tool_interception(
                                         })
                                     };
 
+                                    // Check in_progress before moving parsed into SseEventData
+                                    let is_in_progress = !seen_in_progress
+                                        && parsed.as_ref().is_some_and(|v| {
+                                            v.get("type").and_then(|t| t.as_str())
+                                                == Some(ResponseEvent::IN_PROGRESS)
+                                        });
+
                                     if !should_skip {
-                                        // Forward the event with pre-parsed value
+                                        // Forward the event with pre-parsed value (moved, not cloned)
                                         if !forward_streaming_event(
                                             SseEventData {
                                                 raw_block: &raw_block,
                                                 event_name,
                                                 data: data.as_ref(),
-                                                pre_parsed: parsed.clone(),
+                                                pre_parsed: parsed,
                                             },
                                             &mut handler,
                                             &tx,
@@ -810,31 +819,25 @@ pub(super) fn handle_streaming_with_tool_interception(
                                         }
                                     }
 
-                                    if !seen_in_progress {
-                                        let is_in_progress = parsed.as_ref().is_some_and(|v| {
-                                            v.get("type").and_then(|t| t.as_str())
-                                                == Some(ResponseEvent::IN_PROGRESS)
-                                        });
-                                        if is_in_progress {
-                                            seen_in_progress = true;
-                                            if !mcp_list_tools_sent {
-                                                for binding in session.mcp_servers() {
-                                                    let list_tools_index =
-                                                        handler.allocate_synthetic_output_index();
-                                                    if !send_mcp_list_tools_events(
-                                                        &tx,
-                                                        &session,
-                                                        &binding.label,
-                                                        list_tools_index,
-                                                        &mut sequence_number,
-                                                        &binding.server_key,
-                                                    ) {
-                                                        // Client disconnected
-                                                        return;
-                                                    }
+                                    if is_in_progress {
+                                        seen_in_progress = true;
+                                        if !mcp_list_tools_sent {
+                                            for binding in session.mcp_servers() {
+                                                let list_tools_index =
+                                                    handler.allocate_synthetic_output_index();
+                                                if !send_mcp_list_tools_events(
+                                                    &tx,
+                                                    &session,
+                                                    &binding.label,
+                                                    list_tools_index,
+                                                    &mut sequence_number,
+                                                    &binding.server_key,
+                                                ) {
+                                                    // Client disconnected
+                                                    return;
                                                 }
-                                                mcp_list_tools_sent = true;
                                             }
+                                            mcp_list_tools_sent = true;
                                         }
                                     }
                                 }
@@ -932,7 +935,7 @@ pub(super) fn handle_streaming_with_tool_interception(
                     }
                 }
 
-                let _ = tx.send(Ok(Bytes::from("data: [DONE]\n\n")));
+                let _ = tx.send(Ok(Bytes::from_static(SSE_DONE.as_bytes())));
                 return;
             }
 
@@ -961,7 +964,7 @@ pub(super) fn handle_streaming_with_tool_interception(
                     "error",
                     &json!({"error": {"message": "Exceeded max_tool_calls limit"}}),
                 );
-                let _ = tx.send(Ok(Bytes::from("data: [DONE]\n\n")));
+                let _ = tx.send(Ok(Bytes::from_static(SSE_DONE.as_bytes())));
                 return;
             }
 
@@ -997,7 +1000,7 @@ pub(super) fn handle_streaming_with_tool_interception(
                         "error",
                         &json!({"error": {"message": format!("Failed to build resume payload: {}", e)}}),
                     );
-                    let _ = tx.send(Ok(Bytes::from("data: [DONE]\n\n")));
+                    let _ = tx.send(Ok(Bytes::from_static(SSE_DONE.as_bytes())));
                     return;
                 }
             }

--- a/model_gateway/src/routers/openai/router.rs
+++ b/model_gateway/src/routers/openai/router.rs
@@ -148,7 +148,6 @@ impl crate::routers::RouterTrait for OpenAIRouter {
             worker_registry: &self.worker_registry,
             provider_registry: &self.provider_registry,
             shared_components: &self.shared_components,
-            client: &self.shared_components.client,
             retry_config: &self.retry_config,
         };
         chat::route_chat(&deps, headers, body, model_id).await


### PR DESCRIPTION
## Summary

Code quality and efficiency improvements to the OpenAI router module (24 files, 5473 lines reviewed).

## Changes

| Fix | File | Impact |
|-----|------|--------|
| Remove dead `in_function_call` field | `mcp/tool_handler.rs` | Dead code removal |
| Remove redundant `client` field | `chat.rs`, `router.rs` | Duplicated `shared_components.client` |
| Cache `extract_output_index` result | `mcp/tool_handler.rs` | Avoid double JSON lookup |
| Fast-path CRLF normalization | `responses/common.rs` | Hot path: char-by-char → `contains`/`replace` |
| Eliminate `parsed.clone()` on SSE forward | `responses/streaming.rs` | Avoid `Value` deep clone per event |
| Add `SSE_DONE` constant | `responses/streaming.rs` | `Bytes::from_static` avoids heap alloc |
| `send_tool_call_completion_events` takes `&Value` | `mcp/tool_loop.rs` | Avoid `Value` deep clone per tool call |
| Add `ItemType::FUNCTION_CALL_OUTPUT` | `event_types.rs`, `tool_loop.rs`, `history.rs` | Replace raw string literal |
| `Vec::with_capacity(4)` | `mcp/tool_loop.rs` | Avoid realloc in `extract_function_calls` |

## Deferred (larger refactors)

- Triple JSON parse per SSE event in MCP streaming path
- Sequential → parallel tool execution
- Metrics helper extraction (~100 lines of boilerplate)
- Unified streaming/non-streaming tool loop

## Test plan

- [ ] `cargo check -p smg` passes
- [ ] `cargo clippy -p smg -- -D warnings` passes
- [ ] E2E tests pass (no behavior changes, only internal cleanup)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized internal streaming event handling and buffer management for improved efficiency.
  * Streamlined protocol handling to reduce unnecessary data cloning operations.
  * Reorganized dependency injection architecture for better separation of concerns.
  * Improved tool interaction state management for enhanced stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->