### PR TITLE
fix(ci): remove ignore-pr-updates that marks active PRs as stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -27,11 +27,6 @@ jobs:
           days-before-pr-close: 16
           stale-pr-label: 'stale'
 
-          # Use creation/update of stale label to track staleness instead of
-          # updated_at, which GitHub silently bumps for invisible events like
-          # merge conflict recalculation when main changes.
-          ignore-pr-updates: true
-
           stale-pr-message: >
             This pull request has been automatically marked as stale because it
             has not had any activity within 14 days. It will be automatically


### PR DESCRIPTION
## Description

### Problem

ignore-pr-updates: true in actions/stale uses creation date only, ignoring all activity. This caused active PRs (e.g., #586 with commits yesterday) to be marked stale simply because they were created >14 days ago.

### Solution

Remove the flag to use default updated_at-based tracking.

## Test Plan

Trigger manually and verify active PRs are not marked stale.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated stale pull request tracking configuration to consider recent activity and updates when determining staleness status. This ensures pull requests with ongoing changes are not marked as stale based solely on label history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->