### PR TITLE
fix(mesh): break infinite retry loop for oversized incremental updates

### DIFF
--- a/crates/mesh/src/controller.rs
+++ b/crates/mesh/src/controller.rs
@@ -29,6 +29,7 @@ use super::{
     stores::StateStores,
     sync::MeshSyncManager,
 };
+use crate::flow_control::MessageSizeValidator;
 
 pub struct MeshController {
     state: ClusterState,
@@ -376,6 +377,7 @@ impl MeshController {
                     let self_name_incremental = self_name.clone();
                     let peer_name_incremental = peer_name.clone();
                     let shared_sequence = sequence.clone();
+                    let size_validator = MessageSizeValidator::default();
 
                     #[expect(clippy::disallowed_methods, reason = "incremental sender handle is stored and aborted when the parent sync_stream handler exits")]
                     tokio::spawn(async move {
@@ -390,6 +392,19 @@ impl MeshController {
                             if !all_updates.is_empty() {
                                 for (store_type, updates) in all_updates {
                                     let proto_store_type = store_type.to_proto();
+
+                                    // Validate message size before sending
+                                    let batch_size: usize = updates.iter().map(|u| u.value.len()).sum();
+                                    if let Err(e) = size_validator.validate(batch_size) {
+                                        log::warn!(
+                                            "Incremental update too large, skipping store {:?}: {} (max: {} bytes)",
+                                            store_type,
+                                            e,
+                                            size_validator.max_size()
+                                        );
+                                        collector.mark_sent(store_type, &updates);
+                                        continue;
+                                    }
 
                                     let incremental_update = StreamMessage {
                                         message_type: StreamMessageType::IncrementalUpdate as i32,
@@ -406,12 +421,11 @@ impl MeshController {
                                         peer_id: self_name_incremental.clone(),
                                     };
 
-                                    log::info!(
-                                        "Sending incremental update to {}: store={:?}, {} updates, versions: {:?}",
+                                    log::debug!(
+                                        "Sending incremental update to {}: store={:?}, {} updates",
                                         peer_name_incremental,
                                         store_type,
                                         updates.len(),
-                                        updates.iter().map(|u| (u.key.clone(), u.version)).collect::<Vec<_>>()
                                     );
 
                                     match tx_incremental.try_send(incremental_update) {

--- a/crates/mesh/src/ping_server.rs
+++ b/crates/mesh/src/ping_server.rs
@@ -423,10 +423,16 @@ impl Gossip for GossipService {
                             // Validate message size
                             if let Err(e) = size_validator_clone.validate(batch_size) {
                                 log::warn!(
-                                    "Incremental update too large, skipping: {} (max: {} bytes)",
+                                    "Incremental update too large, skipping store {:?}: {} (max: {} bytes)",
+                                    store_type,
                                     e,
                                     size_validator_clone.max_size()
                                 );
+                                // Mark as sent to prevent infinite retry loop.
+                                // Without this, the same oversized update is re-collected,
+                                // re-serialized, and re-skipped every second forever,
+                                // burning CPU and memory.
+                                collector.mark_sent(store_type, &updates);
                                 continue;
                             }
 


### PR DESCRIPTION
## Summary

Fixes critical mesh stability issue causing pod crashes at 20 CPU cores / 64 GiB memory when running in HA mode.

## Root Cause

When an incremental update exceeds the 10MB message size limit (common with cache-aware TreeState containing token payloads), the update was **skipped but never marked as sent**. This created an infinite retry loop:

1. `collect_all_updates()` collects oversized PolicyStore update (~23MB JSON)
2. Size validation fails → `continue` (skip sending)
3. `mark_sent()` never called → version watermark not advanced
4. Next second: same update re-collected, re-serialized, re-skipped
5. Repeat forever → 20 CPU cores burned on JSON serialization, memory balloons

## What changed

- **`ping_server.rs`**: Call `collector.mark_sent()` after skipping oversized updates to break the infinite loop
- **`controller.rs`**: Add **missing** size validation on client-side incremental sender (had none at all). Also call `mark_sent()` on oversized updates. Downgrade per-update log from `info` to `debug`.

## Limitations

This fix stops the bleeding but doesn't fix the underlying cause — TreeState with token payloads serialized as JSON easily exceeds 10MB. Follow-up PRs will address:
- Binary serialization for tree payloads (PR 2)
- Single collector per node (PR 3)
- Change-tracking instead of full store clones (PR 4)

## Test plan

- [ ] `cargo check -p smg-mesh` passes
- [ ] `cargo clippy -p smg-mesh -- -D warnings` passes
- [ ] Deploy 2 replicas with mesh enabled — CPU/memory should stay stable
- [ ] Log shows "Incremental update too large, skipping store Policy" at most once per change (not every second)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent sending oversized message batches during incremental updates.
  * Prevented infinite retry loops when batches exceed size limits by marking oversized batches as processed and skipping transmission.

* **Style**
  * Reduced log verbosity for incremental sends, showing simplified summary info instead of per-update details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->