### PR TITLE
fix(mesh): use bincode for snapshot generation to match receivers

### DIFF
--- a/crates/mesh/src/ping_server.rs
+++ b/crates/mesh/src/ping_server.rs
@@ -81,7 +81,7 @@ impl GossipService {
                 .all()
                 .into_iter()
                 .map(|(k, v)| {
-                    let serialized = serde_json::to_vec(&v).unwrap_or_else(|e| {
+                    let serialized = bincode::serialize(&v).unwrap_or_else(|e| {
                         log::error!("Failed to serialize membership state: {}", e);
                         vec![]
                     });
@@ -93,7 +93,7 @@ impl GossipService {
                 .all()
                 .into_iter()
                 .map(|(k, v)| {
-                    let serialized = serde_json::to_vec(&v).unwrap_or_else(|e| {
+                    let serialized = bincode::serialize(&v).unwrap_or_else(|e| {
                         log::error!("Failed to serialize app state: {}", e);
                         vec![]
                     });
@@ -105,7 +105,7 @@ impl GossipService {
                 .all()
                 .into_iter()
                 .map(|(k, v)| {
-                    let serialized = serde_json::to_vec(&v).unwrap_or_else(|e| {
+                    let serialized = bincode::serialize(&v).unwrap_or_else(|e| {
                         log::error!("Failed to serialize worker state: {}", e);
                         vec![]
                     });
@@ -117,7 +117,7 @@ impl GossipService {
                 .all()
                 .into_iter()
                 .map(|(k, v)| {
-                    let serialized = serde_json::to_vec(&v).unwrap_or_else(|e| {
+                    let serialized = bincode::serialize(&v).unwrap_or_else(|e| {
                         log::error!("Failed to serialize policy state: {}", e);
                         vec![]
                     });
@@ -134,7 +134,7 @@ impl GossipService {
                         if stores.rate_limit.is_owner(&key) {
                             stores.rate_limit.get_counter(&key).map(|counter_value| {
                                 let serialized =
-                                    serde_json::to_vec(&counter_value).unwrap_or_else(|e| {
+                                    bincode::serialize(&counter_value).unwrap_or_else(|e| {
                                         log::error!(
                                             "Failed to serialize rate limit counter: {}",
                                             e


### PR DESCRIPTION
## Summary

Fixes a serialization format mismatch introduced by #809 that breaks snapshot-based state bootstrap for new nodes joining a mesh cluster.

## Problem

PR #809 switched incremental sync paths to bincode but missed the snapshot generation path. `create_snapshot_chunks()` still used `serde_json::to_vec` while the snapshot receive paths (lines 926-1007) were converted to `bincode::deserialize`. When a new node joins and requests snapshots, all entries would silently fail to deserialize.

## What changed

- **ping_server.rs**: Replace 5 remaining `serde_json::to_vec` calls with `bincode::serialize` in `create_snapshot_chunks()` for Membership, App, Worker, Policy, and RateLimit stores.

No more `serde_json` usage in production code paths of the mesh crate.

## Test plan

- [ ] `cargo test -p smg-mesh` — 152 pass
- [ ] `cargo clippy -p smg-mesh --all-targets -- -D warnings` — clean
- [ ] Deploy 2+ mesh nodes — new node joining should receive snapshot data correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized snapshot serialization mechanism across multiple system components to improve efficiency and reduce data payload sizes while maintaining all existing error handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->