### PR TITLE
feat(render): add render endpoints for chat template + tokenization without generation

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1154,6 +1154,7 @@ impl Router {
                 },
                 webrtc_bind_addr: None,
                 webrtc_stun_server: None,
+                server_mode: server::ServerMode::Http,
             })
             .await
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))

--- a/crates/grpc_client/build.rs
+++ b/crates/grpc_client/build.rs
@@ -4,6 +4,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo:rerun-if-changed=proto/sglang_scheduler.proto");
     println!("cargo:rerun-if-changed=proto/vllm_engine.proto");
     println!("cargo:rerun-if-changed=proto/trtllm_service.proto");
+    println!("cargo:rerun-if-changed=proto/render_service.proto");
 
     // Pass 1: compile shared message types (no gRPC service generation)
     tonic_prost_build::configure()
@@ -37,6 +38,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             ],
             &["proto"],
         )?;
+
+    // Pass 3: compile render service proto with serde support for HTTP+gRPC shared types
+    // Apply serde derive to ALL types in the render package (including oneof inner enums)
+    let render_serde = "#[derive(serde::Serialize, serde::Deserialize)]";
+    tonic_prost_build::configure()
+        .build_server(true)
+        .build_client(true)
+        .type_attribute(".", render_serde)
+        .protoc_arg("--experimental_allow_proto3_optional")
+        .compile_protos(&["proto/render_service.proto"], &["proto"])?;
 
     Ok(())
 }

--- a/crates/grpc_client/proto/render_service.proto
+++ b/crates/grpc_client/proto/render_service.proto
@@ -1,0 +1,129 @@
+syntax = "proto3";
+
+package smg.grpc.render;
+
+// Render service: chat template + tokenization without generation.
+// Returns token IDs only — no inference, no GPU required.
+service RenderService {
+  // Apply chat template to messages and tokenize
+  rpc RenderChat(RenderChatRequest) returns (RenderResponse);
+
+  // Tokenize completion prompt with optional special tokens
+  rpc RenderCompletion(RenderCompletionRequest) returns (RenderResponse);
+}
+
+// =====================
+// Chat Rendering
+// =====================
+
+message ImageUrlContent {
+  string url = 1;
+  optional string detail = 2;
+}
+
+message InputAudioContent {
+  string data = 1;
+  string format = 2;
+}
+
+message VideoUrlContent {
+  string url = 1;
+}
+
+message ContentPart {
+  string type = 1;
+  oneof payload {
+    string text = 2;
+    ImageUrlContent image_url = 3;
+    InputAudioContent input_audio = 4;
+    VideoUrlContent video_url = 5;
+  }
+}
+
+message ToolCallFunction {
+  string name = 1;
+  string arguments = 2;
+}
+
+message ToolCall {
+  string id = 1;
+  string type = 2;
+  ToolCallFunction function = 3;
+}
+
+message FunctionDefinition {
+  string name = 1;
+  optional string description = 2;
+  optional string parameters_json = 3;
+  optional bool strict = 4;
+}
+
+message ChatCompletionTool {
+  string type = 1;
+  FunctionDefinition function = 2;
+}
+
+message ChatCompletionMessage {
+  string role = 1;
+  optional string content = 2;
+  repeated ContentPart content_parts = 3;
+  optional string name = 4;
+  repeated ToolCall tool_calls = 5;
+  optional string tool_call_id = 6;
+  optional string refusal = 7;
+  optional string reasoning = 8;
+}
+
+message RenderChatRequest {
+  repeated ChatCompletionMessage messages = 1;
+  string model = 2;
+  repeated ChatCompletionTool tools = 3;
+  optional string tool_choice = 4;
+  optional string chat_template = 5;
+  optional bool add_generation_prompt = 6;
+  optional bool continue_final_message = 7;
+}
+
+// =====================
+// Completion Rendering
+// =====================
+
+message CompletionPromptTexts {
+  repeated string texts = 1;
+}
+
+message TokenIdSequence {
+  repeated uint32 token_ids = 1;
+}
+
+message CompletionPromptTokenIdBatch {
+  repeated TokenIdSequence batches = 1;
+}
+
+message CompletionPrompt {
+  oneof prompt {
+    string text = 1;
+    CompletionPromptTexts texts = 2;
+    TokenIdSequence token_ids = 3;
+    CompletionPromptTokenIdBatch token_id_batches = 4;
+  }
+}
+
+message RenderCompletionRequest {
+  string model = 1;
+  CompletionPrompt prompt = 2;
+  optional bool echo = 3;
+  optional string suffix = 4;
+  optional int32 prompt_logprobs = 5;
+  optional bool add_special_tokens = 6;
+  optional string cache_salt = 7;
+}
+
+// =====================
+// Response (shared)
+// =====================
+
+message RenderResponse {
+  repeated uint32 token_ids = 1;
+  uint32 count = 2;
+}

--- a/crates/grpc_client/python/smg_grpc_proto/__init__.py
+++ b/crates/grpc_client/python/smg_grpc_proto/__init__.py
@@ -8,6 +8,8 @@ __version__ = version("smg-grpc-proto")
 # These imports will work after the package is built (stubs generated at build time)
 try:
     from smg_grpc_proto.generated import (
+        render_service_pb2,
+        render_service_pb2_grpc,
         sglang_encoder_pb2,
         sglang_encoder_pb2_grpc,
         sglang_scheduler_pb2,
@@ -19,6 +21,8 @@ try:
     )
 
     __all__ = [
+        "render_service_pb2",
+        "render_service_pb2_grpc",
         "sglang_scheduler_pb2",
         "sglang_scheduler_pb2_grpc",
         "sglang_encoder_pb2",

--- a/crates/grpc_client/src/lib.rs
+++ b/crates/grpc_client/src/lib.rs
@@ -7,6 +7,15 @@ pub mod common_proto {
     #![allow(clippy::all, clippy::absolute_paths, unused_qualifications)]
     tonic::include_proto!("smg.grpc.common");
 }
+pub mod render_service_proto {
+    #![allow(
+        clippy::all,
+        clippy::absolute_paths,
+        clippy::allow_attributes,
+        unused_qualifications
+    )]
+    tonic::include_proto!("smg.grpc.render");
+}
 pub mod sglang_scheduler;
 pub mod tokenizer_bundle;
 pub mod trtllm_service;

--- a/crates/protocols/src/tokenize.rs
+++ b/crates/protocols/src/tokenize.rs
@@ -178,6 +178,86 @@ pub struct RemoveTokenizerResponse {
 }
 
 // ============================================================================
+// Render API (chat template + tokenization, no generation)
+// ============================================================================
+
+/// Request schema for the /v1/chat/completions/render endpoint
+///
+/// Applies the chat template to messages and tokenizes the result,
+/// returning token IDs without performing any generation.
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
+pub struct RenderChatRequest {
+    /// ID of the model to use for tokenizer selection
+    pub model: String,
+
+    /// A list of messages comprising the conversation
+    pub messages: Vec<super::chat::ChatMessage>,
+
+    /// A list of tools the model may call
+    #[serde(default)]
+    pub tools: Option<Vec<super::common::Tool>>,
+
+    /// Controls which (if any) tool is called by the model
+    pub tool_choice: Option<super::common::ToolChoice>,
+
+    /// Custom chat template (path or inline Jinja2 string)
+    pub chat_template: Option<String>,
+
+    /// Whether to add a generation prompt after the messages
+    #[serde(default = "default_true")]
+    pub add_generation_prompt: bool,
+
+    /// Continue generating from final assistant message
+    #[serde(default)]
+    pub continue_final_message: bool,
+
+    /// Additional template keyword arguments
+    pub chat_template_kwargs: Option<std::collections::HashMap<String, serde_json::Value>>,
+}
+
+/// Request schema for the /v1/completions/render endpoint
+///
+/// Tokenizes the prompt text with optional special tokens,
+/// returning token IDs without performing any generation.
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
+pub struct RenderCompletionRequest {
+    /// ID of the model to use for tokenizer selection
+    pub model: String,
+
+    /// The prompt(s) to tokenize - can be a single string or array of strings
+    pub prompt: StringOrArray,
+
+    /// Whether to add special tokens (BOS/EOS) during tokenization
+    #[serde(default = "default_true")]
+    pub add_special_tokens: bool,
+
+    /// Echo back the prompt in addition to the completion
+    #[serde(default)]
+    pub echo: Option<bool>,
+
+    /// The suffix that comes after a completion of inserted text
+    pub suffix: Option<String>,
+
+    /// Number of prompt logprobs to return
+    pub prompt_logprobs: Option<i32>,
+
+    /// Cache salt for prompt caching
+    pub cache_salt: Option<String>,
+}
+
+/// Response schema for the /v1/chat/completions/render and /v1/completions/render endpoints
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct RenderResponse {
+    /// The resulting token IDs
+    pub token_ids: Vec<u32>,
+
+    /// Number of tokens
+    pub count: usize,
+}
+
+// ============================================================================
 // Helper Types
 // ============================================================================
 

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -143,6 +143,11 @@ struct CliArgs {
     #[arg(long, default_value_t = 30000, help_heading = "Worker Configuration")]
     port: u16,
 
+    /// Server protocol mode: http (REST API) or grpc (gRPC render service)
+    /// Server protocol mode: http (REST API) or grpc (gRPC render service)
+    #[arg(long, value_enum, default_value_t = server::ServerMode::Http, help_heading = "Worker Configuration")]
+    server: server::ServerMode,
+
     /// List of worker URLs (supports IPv4 and IPv6)
     #[arg(long, num_args = 0.., help_heading = "Worker Configuration")]
     worker_urls: Vec<String>,
@@ -1274,6 +1279,7 @@ impl CliArgs {
             mesh_server_config,
             webrtc_bind_addr: self.webrtc_bind_addr,
             webrtc_stun_server: self.webrtc_stun_server.clone(),
+            server_mode: self.server,
         })
     }
 }

--- a/model_gateway/src/routers/tokenize/grpc_service.rs
+++ b/model_gateway/src/routers/tokenize/grpc_service.rs
@@ -1,0 +1,211 @@
+//! gRPC service implementation for the Render service.
+//!
+//! Converts proto types to internal types and delegates to shared core logic.
+
+use std::sync::Arc;
+
+use llm_tokenizer::TokenizerRegistry;
+use openai_protocol::{
+    chat::{ChatMessage, MessageContent},
+    common::{Function, FunctionCallResponse, Tool, ToolChoice, ToolChoiceValue},
+};
+use smg_grpc_client::render_service_proto::{self as proto, render_service_server::RenderService};
+use tonic::{Request, Response, Status};
+
+use super::handlers;
+
+/// gRPC service for rendering (chat template + tokenization, no generation).
+pub struct RenderGrpcService {
+    tokenizer_registry: Arc<TokenizerRegistry>,
+}
+
+impl RenderGrpcService {
+    pub fn new(tokenizer_registry: Arc<TokenizerRegistry>) -> Self {
+        Self { tokenizer_registry }
+    }
+}
+
+#[tonic::async_trait]
+impl RenderService for RenderGrpcService {
+    async fn render_chat(
+        &self,
+        request: Request<proto::RenderChatRequest>,
+    ) -> Result<Response<proto::RenderResponse>, Status> {
+        let req = request.into_inner();
+
+        let chat_request = proto_to_chat_request(&req)
+            .map_err(|e| Status::invalid_argument(format!("Invalid request: {e}")))?;
+
+        let token_ids = handlers::render_chat_core(&self.tokenizer_registry, &chat_request)
+            .map_err(Status::internal)?;
+
+        Ok(Response::new(proto::RenderResponse {
+            count: token_ids.len() as u32,
+            token_ids,
+        }))
+    }
+
+    async fn render_completion(
+        &self,
+        request: Request<proto::RenderCompletionRequest>,
+    ) -> Result<Response<proto::RenderResponse>, Status> {
+        let req = request.into_inner();
+
+        let prompt = extract_prompt_text(&req)
+            .map_err(|e| Status::invalid_argument(format!("Invalid prompt: {e}")))?;
+        let add_special_tokens = req.add_special_tokens.unwrap_or(true);
+
+        let token_ids = handlers::render_completion_core(
+            &self.tokenizer_registry,
+            &req.model,
+            &prompt,
+            add_special_tokens,
+        )
+        .map_err(Status::internal)?;
+
+        Ok(Response::new(proto::RenderResponse {
+            count: token_ids.len() as u32,
+            token_ids,
+        }))
+    }
+}
+
+// ============================================================================
+// Proto → Internal type conversions
+// ============================================================================
+
+fn proto_to_chat_request(
+    req: &proto::RenderChatRequest,
+) -> Result<openai_protocol::chat::ChatCompletionRequest, String> {
+    let messages: Vec<ChatMessage> = req
+        .messages
+        .iter()
+        .map(proto_message_to_chat_message)
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let tools: Option<Vec<Tool>> = if req.tools.is_empty() {
+        None
+    } else {
+        Some(
+            req.tools
+                .iter()
+                .map(|t| {
+                    let func = t.function.as_ref().ok_or("Tool missing function")?;
+                    let params = func
+                        .parameters_json
+                        .as_ref()
+                        .and_then(|s| serde_json::from_str(s).ok());
+                    Ok(Tool {
+                        tool_type: "function".to_string(),
+                        function: Function {
+                            name: func.name.clone(),
+                            description: func.description.clone(),
+                            parameters: params
+                                .unwrap_or(serde_json::Value::Object(Default::default())),
+                            strict: func.strict,
+                        },
+                    })
+                })
+                .collect::<Result<Vec<_>, String>>()?,
+        )
+    };
+
+    let tool_choice = req.tool_choice.as_deref().and_then(|s| match s {
+        "none" => Some(ToolChoice::Value(ToolChoiceValue::None)),
+        "auto" => Some(ToolChoice::Value(ToolChoiceValue::Auto)),
+        "required" => Some(ToolChoice::Value(ToolChoiceValue::Required)),
+        _ => serde_json::from_str(s).ok(),
+    });
+
+    let continue_final_message = req.continue_final_message.unwrap_or(false);
+
+    Ok(openai_protocol::chat::ChatCompletionRequest {
+        model: req.model.clone(),
+        messages,
+        tools,
+        tool_choice,
+        continue_final_message,
+        ..Default::default()
+    })
+}
+
+fn proto_message_to_chat_message(
+    msg: &proto::ChatCompletionMessage,
+) -> Result<ChatMessage, String> {
+    let content_from_str = |s: &Option<String>| -> MessageContent {
+        MessageContent::Text(s.clone().unwrap_or_default())
+    };
+
+    match msg.role.as_str() {
+        "system" => Ok(ChatMessage::System {
+            content: content_from_str(&msg.content),
+            name: msg.name.clone(),
+        }),
+        "user" => Ok(ChatMessage::User {
+            content: content_from_str(&msg.content),
+            name: msg.name.clone(),
+        }),
+        "assistant" => {
+            let tool_calls = if msg.tool_calls.is_empty() {
+                None
+            } else {
+                Some(
+                    msg.tool_calls
+                        .iter()
+                        .map(|tc| {
+                            let func = tc.function.as_ref().ok_or("ToolCall missing function")?;
+                            Ok(openai_protocol::common::ToolCall {
+                                id: tc.id.clone(),
+                                tool_type: "function".to_string(),
+                                function: FunctionCallResponse {
+                                    name: func.name.clone(),
+                                    arguments: Some(func.arguments.clone()),
+                                },
+                            })
+                        })
+                        .collect::<Result<Vec<_>, String>>()?,
+                )
+            };
+            Ok(ChatMessage::Assistant {
+                content: msg
+                    .content
+                    .as_ref()
+                    .map(|s| MessageContent::Text(s.clone())),
+                name: msg.name.clone(),
+                tool_calls,
+                reasoning_content: msg.reasoning.clone(),
+            })
+        }
+        "tool" => Ok(ChatMessage::Tool {
+            content: content_from_str(&msg.content),
+            tool_call_id: msg.tool_call_id.clone().unwrap_or_default(),
+        }),
+        "developer" => Ok(ChatMessage::Developer {
+            content: content_from_str(&msg.content),
+            tools: None,
+            name: msg.name.clone(),
+        }),
+        other => Err(format!("Unknown role: {other}")),
+    }
+}
+
+fn extract_prompt_text(req: &proto::RenderCompletionRequest) -> Result<String, String> {
+    match &req.prompt {
+        Some(prompt) => match &prompt.prompt {
+            Some(proto::completion_prompt::Prompt::Text(s)) => Ok(s.clone()),
+            Some(proto::completion_prompt::Prompt::Texts(texts)) => texts
+                .texts
+                .first()
+                .cloned()
+                .ok_or_else(|| "Empty texts array".to_string()),
+            Some(proto::completion_prompt::Prompt::TokenIds(_)) => {
+                Err("Token ID input not supported for render; use text input".to_string())
+            }
+            Some(proto::completion_prompt::Prompt::TokenIdBatches(_)) => {
+                Err("Token ID batch input not supported for render; use text input".to_string())
+            }
+            None => Err("Empty prompt".to_string()),
+        },
+        None => Err("Missing prompt field".to_string()),
+    }
+}

--- a/model_gateway/src/routers/tokenize/grpc_service.rs
+++ b/model_gateway/src/routers/tokenize/grpc_service.rs
@@ -209,3 +209,189 @@ fn extract_prompt_text(req: &proto::RenderCompletionRequest) -> Result<String, S
         None => Err("Missing prompt field".to_string()),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_proto_message_system() {
+        let msg = proto::ChatCompletionMessage {
+            role: "system".to_string(),
+            content: Some("You are helpful.".to_string()),
+            name: None,
+            ..Default::default()
+        };
+        let result = proto_message_to_chat_message(&msg).unwrap();
+        assert!(matches!(result, ChatMessage::System { .. }));
+    }
+
+    #[test]
+    fn test_proto_message_user() {
+        let msg = proto::ChatCompletionMessage {
+            role: "user".to_string(),
+            content: Some("hello".to_string()),
+            name: Some("alice".to_string()),
+            ..Default::default()
+        };
+        let result = proto_message_to_chat_message(&msg).unwrap();
+        match result {
+            ChatMessage::User { content, name } => {
+                assert_eq!(content, MessageContent::Text("hello".to_string()));
+                assert_eq!(name, Some("alice".to_string()));
+            }
+            _ => panic!("Expected User variant"),
+        }
+    }
+
+    #[test]
+    fn test_proto_message_assistant_with_tool_calls() {
+        let msg = proto::ChatCompletionMessage {
+            role: "assistant".to_string(),
+            content: None,
+            tool_calls: vec![proto::ToolCall {
+                id: "call_1".to_string(),
+                r#type: "function".to_string(),
+                function: Some(proto::ToolCallFunction {
+                    name: "get_weather".to_string(),
+                    arguments: "{}".to_string(),
+                }),
+            }],
+            ..Default::default()
+        };
+        let result = proto_message_to_chat_message(&msg).unwrap();
+        match result {
+            ChatMessage::Assistant { tool_calls, .. } => {
+                let calls = tool_calls.unwrap();
+                assert_eq!(calls.len(), 1);
+                assert_eq!(calls[0].id, "call_1");
+                assert_eq!(calls[0].function.name, "get_weather");
+            }
+            _ => panic!("Expected Assistant variant"),
+        }
+    }
+
+    #[test]
+    fn test_proto_message_tool() {
+        let msg = proto::ChatCompletionMessage {
+            role: "tool".to_string(),
+            content: Some("sunny".to_string()),
+            tool_call_id: Some("call_1".to_string()),
+            ..Default::default()
+        };
+        let result = proto_message_to_chat_message(&msg).unwrap();
+        match result {
+            ChatMessage::Tool {
+                content,
+                tool_call_id,
+            } => {
+                assert_eq!(content, MessageContent::Text("sunny".to_string()));
+                assert_eq!(tool_call_id, "call_1");
+            }
+            _ => panic!("Expected Tool variant"),
+        }
+    }
+
+    #[test]
+    fn test_proto_message_unknown_role() {
+        let msg = proto::ChatCompletionMessage {
+            role: "unknown".to_string(),
+            ..Default::default()
+        };
+        let result = proto_message_to_chat_message(&msg);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Unknown role"));
+    }
+
+    #[test]
+    fn test_proto_to_chat_request_basic() {
+        let req = proto::RenderChatRequest {
+            model: "test-model".to_string(),
+            messages: vec![proto::ChatCompletionMessage {
+                role: "user".to_string(),
+                content: Some("hello".to_string()),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let result = proto_to_chat_request(&req).unwrap();
+        assert_eq!(result.model, "test-model");
+        assert_eq!(result.messages.len(), 1);
+    }
+
+    #[test]
+    fn test_proto_to_chat_request_with_tools() {
+        let req = proto::RenderChatRequest {
+            model: "test-model".to_string(),
+            messages: vec![],
+            tools: vec![proto::ChatCompletionTool {
+                r#type: "function".to_string(),
+                function: Some(proto::FunctionDefinition {
+                    name: "get_weather".to_string(),
+                    description: Some("Get weather".to_string()),
+                    parameters_json: Some(r#"{"type":"object"}"#.to_string()),
+                    strict: None,
+                }),
+            }],
+            tool_choice: Some("auto".to_string()),
+            ..Default::default()
+        };
+        let result = proto_to_chat_request(&req).unwrap();
+        assert!(result.tools.is_some());
+        assert_eq!(result.tools.as_ref().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_extract_prompt_text_string() {
+        let req = proto::RenderCompletionRequest {
+            model: "test".to_string(),
+            prompt: Some(proto::CompletionPrompt {
+                prompt: Some(proto::completion_prompt::Prompt::Text("hello".to_string())),
+            }),
+            ..Default::default()
+        };
+        assert_eq!(extract_prompt_text(&req).unwrap(), "hello");
+    }
+
+    #[test]
+    fn test_extract_prompt_text_texts() {
+        let req = proto::RenderCompletionRequest {
+            model: "test".to_string(),
+            prompt: Some(proto::CompletionPrompt {
+                prompt: Some(proto::completion_prompt::Prompt::Texts(
+                    proto::CompletionPromptTexts {
+                        texts: vec!["first".to_string(), "second".to_string()],
+                    },
+                )),
+            }),
+            ..Default::default()
+        };
+        assert_eq!(extract_prompt_text(&req).unwrap(), "first");
+    }
+
+    #[test]
+    fn test_extract_prompt_text_token_ids_rejected() {
+        let req = proto::RenderCompletionRequest {
+            model: "test".to_string(),
+            prompt: Some(proto::CompletionPrompt {
+                prompt: Some(proto::completion_prompt::Prompt::TokenIds(
+                    proto::TokenIdSequence {
+                        token_ids: vec![1, 2, 3],
+                    },
+                )),
+            }),
+            ..Default::default()
+        };
+        assert!(extract_prompt_text(&req).is_err());
+    }
+
+    #[test]
+    fn test_extract_prompt_missing() {
+        let req = proto::RenderCompletionRequest {
+            model: "test".to_string(),
+            prompt: None,
+            ..Default::default()
+        };
+        assert!(extract_prompt_text(&req).is_err());
+    }
+}

--- a/model_gateway/src/routers/tokenize/handlers.rs
+++ b/model_gateway/src/routers/tokenize/handlers.rs
@@ -515,4 +515,24 @@ mod tests {
             Ok(_) => panic!("Expected error"),
         }
     }
+
+    #[test]
+    fn test_render_completion_core_model_not_found() {
+        let registry = TokenizerRegistry::new();
+        let result = render_completion_core(&registry, "nonexistent", "hello", true);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("No tokenizers available"));
+    }
+
+    #[test]
+    fn test_render_chat_core_model_not_found() {
+        let registry = TokenizerRegistry::new();
+        let chat_request = ChatCompletionRequest {
+            model: "nonexistent".to_string(),
+            messages: vec![],
+            ..Default::default()
+        };
+        let result = render_chat_core(&registry, &chat_request);
+        assert!(result.is_err());
+    }
 }

--- a/model_gateway/src/routers/tokenize/handlers.rs
+++ b/model_gateway/src/routers/tokenize/handlers.rs
@@ -11,16 +11,24 @@ use axum::{
     Json,
 };
 use llm_tokenizer::{registry::TokenizerEntry, traits::Tokenizer, TokenizerRegistry};
-use openai_protocol::tokenize::{
-    AddTokenizerRequest, AddTokenizerResponse, CountResult, DetokenizeRequest, DetokenizeResponse,
-    ListTokenizersResponse, RemoveTokenizerResponse, TextResult, TokenizeRequest, TokenizeResponse,
-    TokenizerInfo, TokensResult,
+use openai_protocol::{
+    chat::ChatCompletionRequest,
+    tokenize::{
+        AddTokenizerRequest, AddTokenizerResponse, CountResult, DetokenizeRequest,
+        DetokenizeResponse, ListTokenizersResponse, RemoveTokenizerResponse, RenderChatRequest,
+        RenderCompletionRequest, RenderResponse, TextResult, TokenizeRequest, TokenizeResponse,
+        TokenizerInfo, TokensResult,
+    },
 };
 use tracing::{debug, error, warn};
 
 use crate::{
     app_context::AppContext,
     core::{steps::TokenizerConfigRequest, Job, UNKNOWN_MODEL_ID},
+    routers::grpc::{
+        harmony::{builder::HarmonyBuilder, detector::HarmonyDetector},
+        utils::process_chat_messages,
+    },
 };
 
 /// Helper to create error responses
@@ -180,6 +188,147 @@ pub async fn detokenize(registry: &Arc<TokenizerRegistry>, request: DetokenizeRe
     };
 
     Json(DetokenizeResponse { text }).into_response()
+}
+
+// ============================================================================
+// Render Handlers (chat template + tokenization, no generation)
+// ============================================================================
+
+/// Handle POST /v1/chat/completions/render
+///
+/// Applies the chat template to messages and tokenizes the result.
+/// Supports both HuggingFace/tiktoken models and Harmony (gpt-oss) models.
+pub async fn render_chat(
+    registry: &Arc<TokenizerRegistry>,
+    request: RenderChatRequest,
+) -> Response {
+    debug!("Render chat request for model: {}", request.model);
+
+    // Check if this is a Harmony (gpt-oss) model
+    if HarmonyDetector::is_harmony_model(&request.model) {
+        return render_chat_harmony(&request);
+    }
+
+    // HuggingFace / tiktoken path
+    let tokenizer = match get_tokenizer(registry, &request.model) {
+        Ok(t) => t,
+        Err(e) => {
+            return error_response(StatusCode::BAD_REQUEST, &e, "tokenizer_not_found");
+        }
+    };
+
+    // Build a ChatCompletionRequest from the render request
+    let chat_request = ChatCompletionRequest {
+        model: request.model.clone(),
+        messages: request.messages,
+        tools: request.tools,
+        tool_choice: request.tool_choice,
+        continue_final_message: request.continue_final_message,
+        chat_template_kwargs: request.chat_template_kwargs,
+        ..Default::default()
+    };
+
+    // Apply chat template and get formatted text
+    let processed = match process_chat_messages(&chat_request, tokenizer.as_ref()) {
+        Ok(p) => p,
+        Err(e) => {
+            error!("Chat template processing failed: {}", e);
+            return error_response(
+                StatusCode::BAD_REQUEST,
+                &format!("Chat template processing failed: {e}"),
+                "template_error",
+            );
+        }
+    };
+
+    // Tokenize the formatted text
+    let encoding = match tokenizer.encode(&processed.text, false) {
+        Ok(enc) => enc,
+        Err(e) => {
+            error!("Tokenization failed: {}", e);
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &format!("Tokenization failed: {e}"),
+                "tokenization_error",
+            );
+        }
+    };
+
+    let token_ids: Vec<u32> = encoding.token_ids().to_vec();
+    let count = token_ids.len();
+
+    Json(RenderResponse { token_ids, count }).into_response()
+}
+
+/// Harmony (gpt-oss) chat rendering path
+fn render_chat_harmony(request: &RenderChatRequest) -> Response {
+    let chat_request = ChatCompletionRequest {
+        model: request.model.clone(),
+        messages: request.messages.clone(),
+        tools: request.tools.clone(),
+        tool_choice: request.tool_choice.clone(),
+        ..Default::default()
+    };
+
+    let builder = HarmonyBuilder::new();
+    match builder.build_from_chat(&chat_request) {
+        Ok(output) => {
+            let count = output.input_ids.len();
+            Json(RenderResponse {
+                token_ids: output.input_ids,
+                count,
+            })
+            .into_response()
+        }
+        Err(e) => {
+            error!("Harmony encoding failed: {}", e);
+            error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &format!("Harmony encoding failed: {e}"),
+                "harmony_error",
+            )
+        }
+    }
+}
+
+/// Handle POST /v1/completions/render
+///
+/// Tokenizes the prompt text with optional special tokens.
+pub async fn render_completion(
+    registry: &Arc<TokenizerRegistry>,
+    request: RenderCompletionRequest,
+) -> Response {
+    debug!("Render completion request for model: {}", request.model);
+
+    let tokenizer = match get_tokenizer(registry, &request.model) {
+        Ok(t) => t,
+        Err(e) => {
+            return error_response(StatusCode::BAD_REQUEST, &e, "tokenizer_not_found");
+        }
+    };
+
+    let texts = request.prompt.as_strings();
+
+    // For single prompt, return flat response; for batch, return first
+    // (batch support can be extended later if needed)
+    let text = texts.first().copied().unwrap_or("");
+
+    let encoding = match tokenizer.encode(text, request.add_special_tokens) {
+        Ok(enc) => enc,
+        Err(e) => {
+            error!("Tokenization failed: {}", e);
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &format!("Tokenization failed: {e}"),
+                "tokenization_error",
+            );
+        }
+    };
+
+    let token_ids: Vec<u32> = encoding.token_ids().to_vec();
+    let count = token_ids.len();
+
+    Json(RenderResponse { token_ids, count }).into_response()
 }
 
 // ============================================================================

--- a/model_gateway/src/routers/tokenize/handlers.rs
+++ b/model_gateway/src/routers/tokenize/handlers.rs
@@ -191,35 +191,64 @@ pub async fn detokenize(registry: &Arc<TokenizerRegistry>, request: DetokenizeRe
 }
 
 // ============================================================================
-// Render Handlers (chat template + tokenization, no generation)
+// Render Core Logic (shared by HTTP and gRPC handlers)
+// ============================================================================
+
+/// Core render chat logic: apply chat template and tokenize.
+/// Shared by HTTP and gRPC handlers.
+pub fn render_chat_core(
+    registry: &TokenizerRegistry,
+    chat_request: &ChatCompletionRequest,
+) -> Result<Vec<u32>, String> {
+    // Check if this is a Harmony (gpt-oss) model
+    if HarmonyDetector::is_harmony_model(&chat_request.model) {
+        let builder = HarmonyBuilder::new();
+        let output = builder.build_from_chat(chat_request)?;
+        return Ok(output.input_ids);
+    }
+
+    // HuggingFace / tiktoken path
+    let tokenizer = get_tokenizer(registry, &chat_request.model)?;
+
+    let processed = process_chat_messages(chat_request, tokenizer.as_ref())?;
+
+    let encoding = tokenizer
+        .encode(&processed.text, false)
+        .map_err(|e| format!("Tokenization failed: {e}"))?;
+
+    Ok(encoding.token_ids().to_vec())
+}
+
+/// Core render completion logic: tokenize prompt with optional special tokens.
+/// Shared by HTTP and gRPC handlers.
+pub fn render_completion_core(
+    registry: &TokenizerRegistry,
+    model: &str,
+    prompt: &str,
+    add_special_tokens: bool,
+) -> Result<Vec<u32>, String> {
+    let tokenizer = get_tokenizer(registry, model)?;
+
+    let encoding = tokenizer
+        .encode(prompt, add_special_tokens)
+        .map_err(|e| format!("Tokenization failed: {e}"))?;
+
+    Ok(encoding.token_ids().to_vec())
+}
+
+// ============================================================================
+// Render HTTP Handlers
 // ============================================================================
 
 /// Handle POST /v1/chat/completions/render
-///
-/// Applies the chat template to messages and tokenizes the result.
-/// Supports both HuggingFace/tiktoken models and Harmony (gpt-oss) models.
 pub async fn render_chat(
     registry: &Arc<TokenizerRegistry>,
     request: RenderChatRequest,
 ) -> Response {
     debug!("Render chat request for model: {}", request.model);
 
-    // Check if this is a Harmony (gpt-oss) model
-    if HarmonyDetector::is_harmony_model(&request.model) {
-        return render_chat_harmony(&request);
-    }
-
-    // HuggingFace / tiktoken path
-    let tokenizer = match get_tokenizer(registry, &request.model) {
-        Ok(t) => t,
-        Err(e) => {
-            return error_response(StatusCode::BAD_REQUEST, &e, "tokenizer_not_found");
-        }
-    };
-
-    // Build a ChatCompletionRequest from the render request
     let chat_request = ChatCompletionRequest {
-        model: request.model.clone(),
+        model: request.model,
         messages: request.messages,
         tools: request.tools,
         tool_choice: request.tool_choice,
@@ -228,107 +257,38 @@ pub async fn render_chat(
         ..Default::default()
     };
 
-    // Apply chat template and get formatted text
-    let processed = match process_chat_messages(&chat_request, tokenizer.as_ref()) {
-        Ok(p) => p,
-        Err(e) => {
-            error!("Chat template processing failed: {}", e);
-            return error_response(
-                StatusCode::BAD_REQUEST,
-                &format!("Chat template processing failed: {e}"),
-                "template_error",
-            );
-        }
-    };
-
-    // Tokenize the formatted text
-    let encoding = match tokenizer.encode(&processed.text, false) {
-        Ok(enc) => enc,
-        Err(e) => {
-            error!("Tokenization failed: {}", e);
-            return error_response(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                &format!("Tokenization failed: {e}"),
-                "tokenization_error",
-            );
-        }
-    };
-
-    let token_ids: Vec<u32> = encoding.token_ids().to_vec();
-    let count = token_ids.len();
-
-    Json(RenderResponse { token_ids, count }).into_response()
-}
-
-/// Harmony (gpt-oss) chat rendering path
-fn render_chat_harmony(request: &RenderChatRequest) -> Response {
-    let chat_request = ChatCompletionRequest {
-        model: request.model.clone(),
-        messages: request.messages.clone(),
-        tools: request.tools.clone(),
-        tool_choice: request.tool_choice.clone(),
-        ..Default::default()
-    };
-
-    let builder = HarmonyBuilder::new();
-    match builder.build_from_chat(&chat_request) {
-        Ok(output) => {
-            let count = output.input_ids.len();
-            Json(RenderResponse {
-                token_ids: output.input_ids,
-                count,
-            })
-            .into_response()
+    match render_chat_core(registry, &chat_request) {
+        Ok(token_ids) => {
+            let count = token_ids.len();
+            Json(RenderResponse { token_ids, count }).into_response()
         }
         Err(e) => {
-            error!("Harmony encoding failed: {}", e);
-            error_response(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                &format!("Harmony encoding failed: {e}"),
-                "harmony_error",
-            )
+            error!("Render chat failed: {}", e);
+            error_response(StatusCode::BAD_REQUEST, &e, "render_error")
         }
     }
 }
 
 /// Handle POST /v1/completions/render
-///
-/// Tokenizes the prompt text with optional special tokens.
 pub async fn render_completion(
     registry: &Arc<TokenizerRegistry>,
     request: RenderCompletionRequest,
 ) -> Response {
     debug!("Render completion request for model: {}", request.model);
 
-    let tokenizer = match get_tokenizer(registry, &request.model) {
-        Ok(t) => t,
-        Err(e) => {
-            return error_response(StatusCode::BAD_REQUEST, &e, "tokenizer_not_found");
-        }
-    };
-
     let texts = request.prompt.as_strings();
-
-    // For single prompt, return flat response; for batch, return first
-    // (batch support can be extended later if needed)
     let text = texts.first().copied().unwrap_or("");
 
-    let encoding = match tokenizer.encode(text, request.add_special_tokens) {
-        Ok(enc) => enc,
-        Err(e) => {
-            error!("Tokenization failed: {}", e);
-            return error_response(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                &format!("Tokenization failed: {e}"),
-                "tokenization_error",
-            );
+    match render_completion_core(registry, &request.model, text, request.add_special_tokens) {
+        Ok(token_ids) => {
+            let count = token_ids.len();
+            Json(RenderResponse { token_ids, count }).into_response()
         }
-    };
-
-    let token_ids: Vec<u32> = encoding.token_ids().to_vec();
-    let count = token_ids.len();
-
-    Json(RenderResponse { token_ids, count }).into_response()
+        Err(e) => {
+            error!("Render completion failed: {}", e);
+            error_response(StatusCode::BAD_REQUEST, &e, "render_error")
+        }
+    }
 }
 
 // ============================================================================

--- a/model_gateway/src/routers/tokenize/mod.rs
+++ b/model_gateway/src/routers/tokenize/mod.rs
@@ -9,5 +9,5 @@ mod handlers;
 
 pub use handlers::{
     add_tokenizer, detokenize, get_tokenizer_info, get_tokenizer_status, list_tokenizers,
-    remove_tokenizer, tokenize,
+    remove_tokenizer, render_chat, render_completion, tokenize,
 };

--- a/model_gateway/src/routers/tokenize/mod.rs
+++ b/model_gateway/src/routers/tokenize/mod.rs
@@ -5,9 +5,11 @@
 //! - Detokenizing token IDs back to text
 //! - Managing tokenizers (add, list, get, remove)
 
+pub mod grpc_service;
 mod handlers;
 
 pub use handlers::{
     add_tokenizer, detokenize, get_tokenizer_info, get_tokenizer_status, list_tokenizers,
-    remove_tokenizer, render_chat, render_completion, tokenize,
+    remove_tokenizer, render_chat, render_chat_core, render_completion, render_completion_core,
+    tokenize,
 };

--- a/model_gateway/src/server.rs
+++ b/model_gateway/src/server.rs
@@ -29,7 +29,10 @@ use openai_protocol::{
     },
     rerank::{RerankRequest, V1RerankReqInput},
     responses::{ResponsesGetParams, ResponsesRequest},
-    tokenize::{AddTokenizerRequest, DetokenizeRequest, TokenizeRequest},
+    tokenize::{
+        AddTokenizerRequest, DetokenizeRequest, RenderChatRequest, RenderCompletionRequest,
+        TokenizeRequest,
+    },
     validated::ValidatedJson,
     worker::{WorkerSpec, WorkerUpdateRequest},
 };
@@ -585,6 +588,20 @@ async fn v1_detokenize(
     tokenize::detokenize(&state.context.tokenizer_registry, request).await
 }
 
+async fn v1_chat_completions_render(
+    State(state): State<Arc<AppState>>,
+    Json(request): Json<RenderChatRequest>,
+) -> Response {
+    tokenize::render_chat(&state.context.tokenizer_registry, request).await
+}
+
+async fn v1_completions_render(
+    State(state): State<Arc<AppState>>,
+    Json(request): Json<RenderCompletionRequest>,
+) -> Response {
+    tokenize::render_completion(&state.context.tokenizer_registry, request).await
+}
+
 async fn v1_tokenizers_add(
     State(state): State<Arc<AppState>>,
     Json(request): Json<AddTokenizerRequest>,
@@ -693,9 +710,14 @@ pub fn build_app(
             "/v1/conversations/{conversation_id}/items/{item_id}",
             get(v1_conversations_get_item).delete(v1_conversations_delete_item),
         )
-        // Tokenize / Detokenize endpoints
+        // Tokenize / Detokenize / Render endpoints
         .route("/v1/tokenize", post(v1_tokenize))
         .route("/v1/detokenize", post(v1_detokenize))
+        .route(
+            "/v1/chat/completions/render",
+            post(v1_chat_completions_render),
+        )
+        .route("/v1/completions/render", post(v1_completions_render))
         // Realtime REST endpoints (same middleware as other protected routes)
         .route("/v1/realtime/sessions", post(v1_realtime_session))
         .route(

--- a/model_gateway/src/server.rs
+++ b/model_gateway/src/server.rs
@@ -634,6 +634,14 @@ async fn v1_tokenizers_remove(
     tokenize::remove_tokenizer(&state.context, &tokenizer_id).await
 }
 
+#[derive(Copy, Clone, Debug, Eq, PartialEq, clap::ValueEnum)]
+pub enum ServerMode {
+    #[value(name = "http")]
+    Http,
+    #[value(name = "grpc")]
+    Grpc,
+}
+
 pub struct ServerConfig {
     pub host: String,
     pub port: u16,
@@ -656,6 +664,8 @@ pub struct ServerConfig {
     /// STUN server for ICE candidate gathering (host:port).
     /// `None` means use the default (stun.l.google.com:19302).
     pub webrtc_stun_server: Option<String>,
+    /// Server protocol mode: http (REST) or grpc (render service)
+    pub server_mode: ServerMode,
 }
 
 pub fn build_app(
@@ -1218,45 +1228,68 @@ pub async fn startup(config: ServerConfig) -> Result<(), Box<dyn std::error::Err
         .parse()
         .map_err(|e| format!("Invalid address: {e}"))?;
 
-    let handle = axum_server::Handle::new();
-    let handle_clone = handle.clone();
-    let grace_period = Duration::from_secs(config.shutdown_grace_period_secs);
-    #[expect(
-        clippy::disallowed_methods,
-        reason = "shutdown signal handler must outlive the server to trigger graceful shutdown"
-    )]
-    spawn(async move {
-        shutdown_signal().await;
-        handle_clone.graceful_shutdown(Some(grace_period));
-    });
+    let server_result = match config.server_mode {
+        ServerMode::Grpc => {
+            // gRPC render service mode
+            info!("Starting gRPC render server on {}", bind_addr);
+            let render_service = tokenize::grpc_service::RenderGrpcService::new(
+                app_context.tokenizer_registry.clone(),
+            );
+            {
+                use smg_grpc_client::render_service_proto::render_service_server::RenderServiceServer;
+                tonic::transport::Server::builder()
+                    .add_service(RenderServiceServer::new(render_service))
+            }
+                .serve_with_shutdown(addr, shutdown_signal())
+                .await
+                .map_err(|e| e.to_string())
+        }
+        ServerMode::Http => {
+            // HTTP REST API mode (default)
+            let handle = axum_server::Handle::new();
+            let handle_clone = handle.clone();
+            let grace_period = Duration::from_secs(config.shutdown_grace_period_secs);
+            #[expect(
+                clippy::disallowed_methods,
+                reason = "shutdown signal handler must outlive the server to trigger graceful shutdown"
+            )]
+            spawn(async move {
+                shutdown_signal().await;
+                handle_clone.graceful_shutdown(Some(grace_period));
+            });
 
-    let server_result = if let (Some(cert), Some(key)) = (
-        &config.router_config.server_cert,
-        &config.router_config.server_key,
-    ) {
-        info!("TLS enabled");
-        ring::default_provider()
-            .install_default()
-            .map_err(|e| format!("Failed to install rustls ring provider: {e:?}"))?;
+            if let (Some(cert), Some(key)) = (
+                &config.router_config.server_cert,
+                &config.router_config.server_key,
+            ) {
+                info!("TLS enabled");
+                ring::default_provider()
+                    .install_default()
+                    .map_err(|e| format!("Failed to install rustls ring provider: {e:?}"))?;
 
-        let tls_config = axum_server::tls_rustls::RustlsConfig::from_pem(cert.clone(), key.clone())
-            .await
-            .map_err(|e| format!("Failed to create TLS config: {e}"))?;
+                let tls_config =
+                    axum_server::tls_rustls::RustlsConfig::from_pem(cert.clone(), key.clone())
+                        .await
+                        .map_err(|e| format!("Failed to create TLS config: {e}"))?;
 
-        axum_server::bind_rustls(addr, tls_config)
-            .handle(handle)
-            .serve(app.into_make_service())
-            .await
-    } else {
-        axum_server::bind(addr)
-            .handle(handle)
-            .serve(app.into_make_service())
-            .await
+                axum_server::bind_rustls(addr, tls_config)
+                    .handle(handle)
+                    .serve(app.into_make_service())
+                    .await
+                    .map_err(|e| e.to_string())
+            } else {
+                axum_server::bind(addr)
+                    .handle(handle)
+                    .serve(app.into_make_service())
+                    .await
+                    .map_err(|e| e.to_string())
+            }
+        }
     };
 
     // Graceful Shutdown
 
-    info!("HTTP server stopped. Starting component cleanup...");
+    info!("Server stopped. Starting component cleanup...");
 
     // This triggers background task cancellation, waits for tools, and denies approvals
     if let Some(orchestrator) = app_context.mcp_orchestrator.get() {
@@ -1266,7 +1299,7 @@ pub async fn startup(config: ServerConfig) -> Result<(), Box<dyn std::error::Err
     info!("Cleanup complete. Process exiting.");
 
     // Return original server error if any, otherwise Ok
-    server_result.map_err(|e| Box::new(e) as Box<dyn std::error::Error>)
+    server_result.map_err(|e| -> Box<dyn std::error::Error> { e.into() })
 }
 
 #[expect(


### PR DESCRIPTION
## Description

### Problem

Disaggregated serving requires a way to apply chat templates and tokenize prompts without running GPU inference. Previously, this was attempted via a GPU-less vLLM Python server (PR #784), but SMG already has all the necessary components in Rust: chat template engine (`crates/tokenizer`), model-specific tool parsers (`crates/tool_parser`), and Harmony encoding for gpt-oss models.

Per slin1237's review feedback on PR #784, this implements the "early return" approach — exposing SMG's existing pipeline as render endpoints rather than adding a separate vLLM dependency.

### Solution

Add two render endpoints accessible via both HTTP REST and gRPC:

**HTTP:**
- `POST /v1/chat/completions/render` — messages → chat template → tokenize → token_ids
- `POST /v1/completions/render` — prompt → tokenize (with `add_special_tokens` support) → token_ids

**gRPC:**
- `smg.grpc.render.RenderService/RenderChat`
- `smg.grpc.render.RenderService/RenderCompletion`

Server mode is selected via `--server http|grpc` CLI flag (same port, default: http).

Both protocols share core logic (`render_chat_core`, `render_completion_core`) with thin HTTP/gRPC adapter layers. Harmony (gpt-oss) models are auto-detected via `HarmonyDetector` and routed to `HarmonyBuilder`.

## Changes

- `crates/grpc_client/proto/render_service.proto` — New proto with `RenderService` (RenderChat, RenderCompletion RPCs)
- `crates/grpc_client/build.rs` — Compile render_service.proto with serde derive for all types
- `crates/grpc_client/src/lib.rs` — Export `render_service_proto` module
- `crates/protocols/src/tokenize.rs` — HTTP request/response types (RenderChatRequest, RenderCompletionRequest, RenderResponse)
- `model_gateway/src/routers/tokenize/handlers.rs` — Shared core functions + HTTP handlers
- `model_gateway/src/routers/tokenize/grpc_service.rs` — gRPC handler with proto → ChatCompletionRequest conversion
- `model_gateway/src/routers/tokenize/mod.rs` — Module exports
- `model_gateway/src/server.rs` — HTTP routes + gRPC server mode (ServerMode enum)
- `model_gateway/src/main.rs` — `--server http|grpc` CLI option
- `bindings/python/src/lib.rs` — Default `server_mode: Http` for Python binding
- `crates/grpc_client/python/smg_grpc_proto/__init__.py` — Python gRPC stubs export

## Test Plan

```bash
# Unit tests (20 tests)
cargo test -p smg -- tokenize
# Includes:
# - gRPC proto conversion: system/user/assistant/tool message, unknown role, tool calls
# - prompt extraction: text, texts, token_ids rejected, missing
# - handler core: model not found errors

# HTTP manual test
cargo run --bin smg -- launch --model-path "openai/gpt-oss-20b"
curl -X POST http://localhost:30000/v1/chat/completions/render \
  -H "Content-Type: application/json" \
  -d '{"model":"openai/gpt-oss-20b","messages":[{"role":"user","content":"hello"}]}'

curl -X POST http://localhost:30000/v1/completions/render \
  -H "Content-Type: application/json" \
  -d '{"model":"openai/gpt-oss-20b","prompt":"hello world"}'

# gRPC manual test
cargo run --bin smg -- launch --server grpc --model-path "openai/gpt-oss-20b"
grpcurl -plaintext -proto crates/grpc_client/proto/render_service.proto \
  -d '{"model":"openai/gpt-oss-20b","messages":[{"role":"user","content":"hello"}]}' \
  localhost:30000 smg.grpc.render.RenderService/RenderChat
```

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>