### PR TITLE
perf(mesh): skip full-store scans when nothing has changed

### DIFF
--- a/crates/mesh/src/crdt_kv/crdt.rs
+++ b/crates/mesh/src/crdt_kv/crdt.rs
@@ -293,6 +293,11 @@ impl CrdtOrMap {
         self.store.contains_key(key)
     }
 
+    /// Mutation generation counter. Increments on every insert/remove/upsert.
+    pub fn generation(&self) -> u64 {
+        self.store.generation()
+    }
+
     /// Get all key-value pairs
     pub fn all(&self) -> std::collections::BTreeMap<String, Vec<u8>> {
         self.store.all()

--- a/crates/mesh/src/crdt_kv/kv_store.rs
+++ b/crates/mesh/src/crdt_kv/kv_store.rs
@@ -1,4 +1,7 @@
-use std::sync::Arc;
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc,
+};
 
 use dashmap::{mapref::entry::Entry, DashMap};
 
@@ -6,10 +9,16 @@ use dashmap::{mapref::entry::Entry, DashMap};
 // High-Performance In-Memory KV Storage - Concurrent-Safe Implementation Based on DashMap
 // ============================================================================
 
-/// Basic KV storage, using DashMap for thread-safe high-performance access
+/// Basic KV storage, using DashMap for thread-safe high-performance access.
+///
+/// Includes a generation counter that increments on every mutation. This allows
+/// the incremental update collector to skip expensive full-store scans when
+/// nothing has changed.
 #[derive(Debug, Clone)]
 pub struct KvStore {
     store: Arc<DashMap<String, Vec<u8>>>,
+    /// Monotonically increasing counter, bumped on every insert/remove/upsert.
+    generation: Arc<AtomicU64>,
 }
 
 impl KvStore {
@@ -17,11 +26,18 @@ impl KvStore {
     pub fn new() -> Self {
         Self {
             store: Arc::new(DashMap::new()),
+            generation: Arc::new(AtomicU64::new(0)),
         }
+    }
+
+    /// Current generation (mutation counter).
+    pub fn generation(&self) -> u64 {
+        self.generation.load(Ordering::Acquire)
     }
 
     /// Insert or update key-value pair
     pub fn insert(&self, key: String, value: Vec<u8>) -> Option<Vec<u8>> {
+        self.generation.fetch_add(1, Ordering::Release);
         self.store.insert(key, value)
     }
 
@@ -30,6 +46,7 @@ impl KvStore {
     where
         F: FnOnce(Option<&[u8]>) -> Vec<u8>,
     {
+        self.generation.fetch_add(1, Ordering::Release);
         match self.store.entry(key) {
             Entry::Occupied(mut entry) => {
                 let new_value = updater(Some(entry.get().as_slice()));
@@ -51,6 +68,7 @@ impl KvStore {
 
     /// Remove key
     pub fn remove(&self, key: &str) -> Option<Vec<u8>> {
+        self.generation.fetch_add(1, Ordering::Release);
         self.store.remove(key).map(|(_, v)| v)
     }
 

--- a/crates/mesh/src/incremental.rs
+++ b/crates/mesh/src/incremental.rs
@@ -55,11 +55,21 @@ struct LastSentVersions {
     rate_limit: HashMap<String, u64>, // Track last sent timestamp for rate limit counter shards
 }
 
+/// Tracks store generation to skip unchanged stores
+#[derive(Debug, Clone, Default)]
+struct LastScannedGenerations {
+    worker: u64,
+    policy: u64,
+    app: u64,
+    membership: u64,
+}
+
 /// Incremental update collector
 pub struct IncrementalUpdateCollector {
     stores: Arc<StateStores>,
     self_name: String,
     last_sent: Arc<RwLock<LastSentVersions>>,
+    last_scanned: Arc<RwLock<LastScannedGenerations>>,
 }
 
 impl IncrementalUpdateCollector {
@@ -68,6 +78,7 @@ impl IncrementalUpdateCollector {
             stores,
             self_name,
             last_sent: Arc::new(RwLock::new(LastSentVersions::default())),
+            last_scanned: Arc::new(RwLock::new(LastScannedGenerations::default())),
         }
     }
 
@@ -126,13 +137,19 @@ impl IncrementalUpdateCollector {
         updates
     }
 
-    /// Collect incremental updates for a specific store type
+    /// Collect incremental updates for a specific store type.
+    /// Skips the expensive `.all()` scan when the store generation hasn't changed.
     pub fn collect_updates_for_store(&self, store_type: StoreType) -> Vec<StateUpdate> {
         let mut updates = Vec::new();
         let last_sent = self.last_sent.read();
+        let last_scanned = self.last_scanned.read();
 
         match store_type {
             StoreType::Worker => {
+                let gen = self.stores.worker.generation();
+                if gen == last_scanned.worker {
+                    return vec![];
+                }
                 let all_workers = self.stores.worker.all();
                 updates = self.collect_serializable_updates(
                     all_workers,
@@ -142,6 +159,10 @@ impl IncrementalUpdateCollector {
                 );
             }
             StoreType::Policy => {
+                let gen = self.stores.policy.generation();
+                if gen == last_scanned.policy {
+                    return vec![];
+                }
                 let all_policies = self.stores.policy.all();
                 updates = self.collect_serializable_updates(
                     all_policies,
@@ -151,6 +172,10 @@ impl IncrementalUpdateCollector {
                 );
             }
             StoreType::App => {
+                let gen = self.stores.app.generation();
+                if gen == last_scanned.app {
+                    return vec![];
+                }
                 let all_apps = self.stores.app.all();
                 updates = self.collect_serializable_updates(
                     all_apps,
@@ -160,6 +185,10 @@ impl IncrementalUpdateCollector {
                 );
             }
             StoreType::Membership => {
+                let gen = self.stores.membership.generation();
+                if gen == last_scanned.membership {
+                    return vec![];
+                }
                 let all_members = self.stores.membership.all();
                 updates = self.collect_serializable_updates(
                     all_members,
@@ -232,9 +261,23 @@ impl IncrementalUpdateCollector {
         all_updates
     }
 
-    /// Mark updates as sent (called after successful transmission)
+    /// Mark updates as sent (called after successful transmission).
+    /// Also records the store generation to enable skipping unchanged stores.
     pub fn mark_sent(&self, store_type: StoreType, updates: &[StateUpdate]) {
         let mut last_sent = self.last_sent.write();
+        let mut last_scanned = self.last_scanned.write();
+
+        // Record the current generation so the next collection cycle can skip
+        // this store if nothing has changed since.
+        match store_type {
+            StoreType::Worker => last_scanned.worker = self.stores.worker.generation(),
+            StoreType::Policy => last_scanned.policy = self.stores.policy.generation(),
+            StoreType::App => last_scanned.app = self.stores.app.generation(),
+            StoreType::Membership => {
+                last_scanned.membership = self.stores.membership.generation();
+            }
+            StoreType::RateLimit => {} // Rate limit uses timestamp-based tracking
+        }
 
         for update in updates {
             match store_type {

--- a/crates/mesh/src/stores.rs
+++ b/crates/mesh/src/stores.rs
@@ -82,6 +82,11 @@ impl<T: CrdtValue> CrdtStore<T> {
         }
     }
 
+    /// Mutation generation counter. Cheap check to skip unchanged stores.
+    fn generation(&self) -> u64 {
+        self.inner.generation()
+    }
+
     fn get(&self, key: &str) -> Option<T> {
         self.inner.get(key).and_then(|bytes| {
             T::from_bytes(&bytes)
@@ -351,6 +356,11 @@ macro_rules! define_state_store {
                 Self {
                     inner: CrdtStore::new(),
                 }
+            }
+
+            /// Mutation generation counter. Cheap check to skip unchanged stores.
+            pub fn generation(&self) -> u64 {
+                self.inner.generation()
             }
 
             pub fn get(&self, key: &str) -> Option<$value_type> {


### PR DESCRIPTION
## Summary

Adds generation-based change tracking to eliminate expensive full-store scans during idle sync cycles.

## Problem

Every second, each `IncrementalUpdateCollector` calls `.all()` on every store, which:
1. Iterates the entire DashMap, cloning every key and value
2. Deserializes each value from bytes
3. Compares versions against last-sent watermarks
4. Discards everything if nothing changed

With N peer connections, this is N × 5 stores × entries clone+deserialize operations per second — even when nothing has changed.

## Solution

Add an `AtomicU64` generation counter to `KvStore` that increments on every mutation. The collector checks the generation before scanning:

- **No mutation since last `mark_sent`** → skip `.all()` entirely (5 atomic loads total)
- **Mutation detected** → do the full scan as before

The generation is recorded in `mark_sent` (not on collect) so that unsent updates are re-collected on the next cycle.

## What changed

| File | Change |
|------|--------|
| `crdt_kv/kv_store.rs` | Add `AtomicU64` generation counter, bump on insert/remove/upsert |
| `crdt_kv/crdt.rs` | Expose `generation()` through `CrdtOrMap` |
| `stores.rs` | Expose `generation()` on `CrdtStore` and macro-generated stores |
| `incremental.rs` | Add `LastScannedGenerations`, check before `.all()`, record on `mark_sent` |

## Impact

| Scenario | Before | After |
|----------|--------|-------|
| Idle cluster (no changes) | N × 5 full DashMap scans/sec | 5 atomic loads/sec |
| Active cluster | Same as before | Same + 5 atomic loads overhead |

## Test plan

- [ ] `cargo test -p smg-mesh` — 152 pass
- [ ] `cargo clippy -p smg-mesh --all-targets -- -D warnings` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Enhanced data store efficiency by implementing generation tracking mechanisms that skip redundant scans and processing of unchanged stores, reducing unnecessary work and improving overall system responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->