### PR TITLE
perf(mesh): add operation log auto-compaction and tombstone GC

### DIFF
--- a/crates/mesh/src/controller.rs
+++ b/crates/mesh/src/controller.rs
@@ -119,6 +119,14 @@ impl MeshController {
             };
             cnt += 1;
 
+            // Periodic GC: clean up tombstoned CRDT metadata every 60 rounds (~60s)
+            if cnt.is_multiple_of(60) {
+                let removed = self.stores.gc_tombstones();
+                if removed > 0 {
+                    log::info!("GC: removed {removed} tombstoned CRDT metadata entries");
+                }
+            }
+
             tokio::select! {
 
                 _ = signal.changed() => {

--- a/crates/mesh/src/crdt_kv/crdt.rs
+++ b/crates/mesh/src/crdt_kv/crdt.rs
@@ -317,6 +317,47 @@ impl CrdtOrMap {
         self.replica_id
     }
 
+    /// Remove tombstoned keys from the metadata and key_locks maps.
+    /// Keys that are not in the live store and whose latest metadata entry
+    /// is a tombstone are cleaned up to prevent unbounded memory growth.
+    /// Returns the number of entries removed.
+    pub fn gc_tombstones(&self) -> usize {
+        let mut removed = 0;
+        let keys_to_check: Vec<String> = self
+            .metadata
+            .iter()
+            .filter(|entry| !self.store.contains_key(entry.key()))
+            .map(|entry| entry.key().clone())
+            .collect();
+
+        for key in keys_to_check {
+            if !self.key_is_tombstoned_or_unknown(&key) {
+                continue;
+            }
+            // Only remove key_locks if no other task holds the lock.
+            // Uses the same safety pattern as try_cleanup_key_lock:
+            // check strong_count and try_lock before removing.
+            self.key_locks.remove_if(&key, |_, lock| {
+                Arc::strong_count(lock) <= 2 && lock.try_lock().is_some()
+            });
+            // Atomically remove metadata only if the key is still not in the
+            // live store AND still tombstoned. The remove_if closure runs
+            // under the DashMap shard lock, preventing a concurrent insert
+            // from racing between check and remove.
+            let was_removed = self.metadata.remove_if(&key, |_, versions| {
+                !self.store.contains_key(&key)
+                    && versions
+                        .iter()
+                        .max_by_key(|v| v.version_key())
+                        .is_none_or(|winner| winner.is_tombstone)
+            });
+            if was_removed.is_some() {
+                removed += 1;
+            }
+        }
+        removed
+    }
+
     /// Get the operation log
     pub fn get_operation_log(&self) -> OperationLog {
         self.operation_log.read().clone()

--- a/crates/mesh/src/crdt_kv/operation.rs
+++ b/crates/mesh/src/crdt_kv/operation.rs
@@ -101,9 +101,37 @@ impl OperationLog {
         }
     }
 
-    /// Append operation to log
+    /// Threshold at which auto-compaction triggers. After compaction, the log
+    /// shrinks to at most one entry per unique key, so the next compaction
+    /// won't trigger until enough new operations accumulate again.
+    const AUTO_COMPACT_THRESHOLD: usize = 10_000;
+
+    /// Append operation to log. Auto-compacts when the log exceeds the threshold.
+    /// Compaction keeps only the latest operation per key, providing hysteresis:
+    /// if there are N unique keys, the next compaction triggers after N + (threshold - N)
+    /// new appends, not on every append. If compaction doesn't reduce below
+    /// threshold (very high key cardinality), the oldest entries are truncated.
     pub fn append(&mut self, operation: Operation) {
         self.operations.push(operation);
+        if self.operations.len() > Self::AUTO_COMPACT_THRESHOLD {
+            self.compact();
+            // If still over threshold after dedup (extremely high key cardinality
+            // >10K unique keys), truncate oldest entries. This drops state for the
+            // oldest keys, which will be re-synced from peers on the next merge.
+            // This is a safety valve — in practice mesh stores have hundreds
+            // of keys, not tens of thousands.
+            if self.operations.len() > Self::AUTO_COMPACT_THRESHOLD {
+                let keep = Self::AUTO_COMPACT_THRESHOLD * 3 / 4;
+                let drain_count = self.operations.len() - keep;
+                tracing::warn!(
+                    total = self.operations.len(),
+                    draining = drain_count,
+                    keeping = keep,
+                    "Operation log still over threshold after compaction, truncating oldest entries"
+                );
+                self.operations.drain(..drain_count);
+            }
+        }
     }
 
     /// Get all operations

--- a/crates/mesh/src/stores.rs
+++ b/crates/mesh/src/stores.rs
@@ -209,6 +209,11 @@ impl<T: CrdtValue> CrdtStore<T> {
             })
             .collect()
     }
+
+    /// Remove tombstoned keys from CRDT metadata maps.
+    fn gc_tombstones(&self) -> usize {
+        self.inner.gc_tombstones()
+    }
 }
 
 impl<T: CrdtValue> Default for CrdtStore<T> {
@@ -419,6 +424,11 @@ macro_rules! define_state_store {
 
             pub fn all(&self) -> BTreeMap<String, $value_type> {
                 self.inner.all()
+            }
+
+            /// Remove tombstoned keys from CRDT metadata to bound memory growth.
+            pub fn gc_tombstones(&self) -> usize {
+                self.inner.gc_tombstones()
             }
         }
 
@@ -725,6 +735,15 @@ impl StateStores {
             policy: PolicyStore::new(),
             rate_limit: RateLimitStore::new(self_name),
         }
+    }
+
+    /// Run garbage collection across all stores, removing tombstoned CRDT
+    /// metadata entries. Returns the total number of entries removed.
+    pub fn gc_tombstones(&self) -> usize {
+        self.membership.gc_tombstones()
+            + self.app.gc_tombstones()
+            + self.worker.gc_tombstones()
+            + self.policy.gc_tombstones()
     }
 }
 


### PR DESCRIPTION
## Summary

Prevents unbounded memory growth in long-running mesh clusters by adding auto-compaction and periodic garbage collection.

## Problem

Two unbounded data structures in the CRDT layer:

1. **Operation log** — grows with every insert/remove, only compacts during merge(). In high-throughput scenarios (frequent worker health updates), the log can grow to hundreds of thousands of entries between sync intervals.

2. **CRDT metadata map** — stores version metadata for every key ever seen, including deleted ones (tombstones). Tombstoned keys and their key_locks are never removed, causing monotonic memory growth.

## What changed

| File | Change |
|------|--------|
| `crdt_kv/operation.rs` | Auto-compact when log exceeds 10,000 entries in `append()` |
| `crdt_kv/crdt.rs` | Add `gc_tombstones()` — removes metadata and key_locks for tombstoned keys |
| `stores.rs` | Expose `gc_tombstones()` on stores and `StateStores` aggregate |
| `controller.rs` | Run `gc_tombstones()` every 60 event loop rounds (~60s) |

## Test plan

- [ ] `cargo test -p smg-mesh` — 152 pass
- [ ] `cargo clippy -p smg-mesh --all-targets -- -D warnings` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Periodic garbage collection now runs during normal operation to remove tombstoned metadata entries across all stores; removals are reported via info logs.
  * Automatic operation-log compaction triggers when the log exceeds 10,000 entries, with a safety truncation step and a warning log if truncation is applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->