### PR TITLE
fix(ci): drop [grpc] extra from nightly vllm install

### DIFF
--- a/scripts/ci_install_vllm.sh
+++ b/scripts/ci_install_vllm.sh
@@ -19,8 +19,8 @@ fi
 
 echo "Using uv version: $(uv --version)"
 
-echo "Installing vLLM (nightly with smg-grpc-servicer support)..."
-uv pip install "vllm[grpc]" --extra-index-url https://wheels.vllm.ai/nightly/cu129
+echo "Installing vLLM (nightly for smg-grpc-servicer support)..."
+uv pip install vllm --extra-index-url https://wheels.vllm.ai/nightly/cu129
 
 # Install nixl for vLLM PD disaggregation (NIXL KV transfer)
 echo "Installing nixl..."


### PR DESCRIPTION
Hotfix: the nightly vllm wheel doesn't have the [grpc] extra, causing all vLLM CI jobs to fail at setup. Install vllm without extras — smg-grpc-servicer is already installed from source in the next step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration setup to simplify vLLM dependency installation while maintaining CUDA version compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->