### PR TITLE
refactor(e2e): add model fixture, remove deprecated smg fixture

### DIFF
--- a/e2e_test/chat_completions/test_enable_thinking.py
+++ b/e2e_test/chat_completions/test_enable_thinking.py
@@ -31,9 +31,8 @@ API_KEY = "not-used"
 class TestEnableThinking:
     """Tests for enable_thinking feature with Qwen3 reasoning parser."""
 
-    def test_chat_completion_with_reasoning(self, setup_backend, api_client):
+    def test_chat_completion_with_reasoning(self, model, api_client):
         """Test non-streaming with enable_thinking=True, reasoning_content should not be empty."""
-        _, model, _, _ = setup_backend
 
         response = api_client.chat.completions.create(
             model=model,
@@ -48,9 +47,8 @@ class TestEnableThinking:
         assert len(response.choices) > 0
         assert response.choices[0].message.reasoning_content is not None
 
-    def test_chat_completion_without_reasoning(self, setup_backend, api_client):
+    def test_chat_completion_without_reasoning(self, model, api_client):
         """Test non-streaming with enable_thinking=False, reasoning_content should be empty."""
-        _, model, _, _ = setup_backend
 
         response = api_client.chat.completions.create(
             model=model,
@@ -66,9 +64,8 @@ class TestEnableThinking:
         # With enable_thinking=False, reasoning_content should be empty
         assert response.choices[0].message.reasoning_content is None
 
-    def test_stream_chat_completion_with_reasoning(self, setup_backend, api_client):
+    def test_stream_chat_completion_with_reasoning(self, model, api_client):
         """Test streaming with enable_thinking=True, reasoning_content should not be empty."""
-        _, model, _, _ = setup_backend
 
         has_reasoning = False
         has_content = False
@@ -92,9 +89,8 @@ class TestEnableThinking:
         assert has_reasoning, "The reasoning content is not included in the stream response"
         assert has_content, "The stream response does not contain normal content"
 
-    def test_stream_chat_completion_without_reasoning(self, setup_backend, api_client):
+    def test_stream_chat_completion_without_reasoning(self, model, api_client):
         """Test streaming with enable_thinking=False, reasoning_content should be empty."""
-        _, model, _, _ = setup_backend
 
         has_reasoning = False
         has_content = False

--- a/e2e_test/chat_completions/test_function_calling.py
+++ b/e2e_test/chat_completions/test_function_calling.py
@@ -109,12 +109,11 @@ PYTHONIC_MESSAGES = [
 class TestOpenAIServerFunctionCalling:
     """Tests for OpenAI-compatible function calling with Llama tool parser."""
 
-    def test_function_calling_format(self, setup_backend, api_client):
+    def test_function_calling_format(self, model, api_client):
         """Test: Whether the function call format returned by the AI is correct.
 
         When returning a tool call, message.content should be None, and tool_calls should be a list.
         """
-        _, model, _, _ = setup_backend
 
         tools = [
             {
@@ -163,13 +162,12 @@ class TestOpenAIServerFunctionCalling:
         function_name = tool_calls[0].function.name
         assert function_name == "add", "Function name should be 'add'"
 
-    def test_function_calling_streaming_simple(self, setup_backend, api_client):
+    def test_function_calling_streaming_simple(self, model, api_client):
         """Test: Whether the function name can be correctly recognized in streaming mode.
 
         - Expect a function call to be found, and the function name to be correct.
         - Verify that streaming mode returns at least multiple chunks.
         """
-        _, model, _, _ = setup_backend
 
         tools = [
             {
@@ -239,14 +237,13 @@ class TestOpenAIServerFunctionCalling:
             "Final response of function calling should have finish_reason 'tool_calls'"
         )
 
-    def test_function_calling_streaming_args_parsing(self, setup_backend, api_client):
+    def test_function_calling_streaming_args_parsing(self, model, api_client):
         """Test: Whether the function call arguments returned in streaming mode can be correctly
         concatenated into valid JSON.
 
         - The user request requires multiple parameters.
         - AI may return the arguments in chunks that need to be concatenated.
         """
-        _, model, _, _ = setup_backend
 
         tools = [
             {
@@ -326,12 +323,11 @@ class TestOpenAIServerFunctionCalling:
     @pytest.mark.skip(
         reason="Skipping function call strict test as it is not supported by the router"
     )
-    def test_function_call_strict(self, setup_backend, api_client):
+    def test_function_call_strict(self, model, api_client):
         """Test: Whether the strict mode of function calling works as expected.
 
         - When strict mode is enabled, the AI should not return a function call if the function name is not recognized.
         """
-        _, model, _, _ = setup_backend
 
         tools = [
             {
@@ -378,12 +374,11 @@ class TestOpenAIServerFunctionCalling:
         assert str(args_obj["int_a"]) == "5", "Parameter int_a should be 5"
         assert str(args_obj["int_b"]) == "7", "Parameter int_b should be 7"
 
-    def test_function_call_required(self, setup_backend, api_client):
+    def test_function_call_required(self, model, api_client):
         """Test: Whether tool_choice: "required" works as expected.
 
         - When tool_choice == "required", the model should return one or more tool_calls.
         """
-        _, model, _, _ = setup_backend
 
         tools = [
             {
@@ -459,12 +454,11 @@ class TestOpenAIServerFunctionCalling:
             f"Parameter city should contain either 'Paris' or 'France', got: {city_value}"
         )
 
-    def test_function_call_specific(self, setup_backend, api_client):
+    def test_function_call_specific(self, model, api_client):
         """Test: Whether tool_choice: ToolChoice works as expected.
 
         - When tool_choice is a specific ToolChoice, the model should return one or more tool_calls.
         """
-        _, model, _, _ = setup_backend
 
         tools = [
             {
@@ -529,12 +523,11 @@ class TestOpenAIServerFunctionCalling:
         assert function_name == "get_weather", "Function name should be 'get_weather'"
         assert "city" in args_obj, "Function arguments should have 'city'"
 
-    def test_streaming_multiple_choices_finish_reason(self, setup_backend, api_client):
+    def test_streaming_multiple_choices_finish_reason(self, model, api_client):
         """Test: Verify that each choice gets its own finish_reason chunk in streaming mode with n > 1.
 
         This tests the fix for the bug where only the last index got a finish_reason chunk.
         """
-        _, model, _, _ = setup_backend
 
         tools = [
             {
@@ -602,13 +595,12 @@ class TestOpenAIServerFunctionCalling:
                 f"Expected finish_reason 'tool_calls' for index {index}, got {reasons[-1]}"
             )
 
-    def test_function_calling_streaming_no_tool_call(self, setup_backend, api_client):
+    def test_function_calling_streaming_no_tool_call(self, model, api_client):
         """Test: Whether the finish_reason is stop in streaming mode when no tool call is given.
 
         - Expect no function call to be found.
         - Verify that finish_reason is stop
         """
-        _, model, _, _ = setup_backend
 
         tools = [
             {
@@ -666,12 +658,11 @@ class TestOpenAIServerFunctionCalling:
             "Final response of no function calling should have finish_reason 'stop'"
         )
 
-    def test_streaming_multiple_choices_without_tools(self, setup_backend, api_client):
+    def test_streaming_multiple_choices_without_tools(self, model, api_client):
         """Test: Verify that each choice gets its own finish_reason chunk without tool calls.
 
         This tests the fix for regular content streaming with multiple choices.
         """
-        _, model, _, _ = setup_backend
 
         messages = [{"role": "user", "content": "Say hello in one word."}]
 
@@ -729,9 +720,8 @@ class TestOpenAIServerFunctionCalling:
 class TestOpenAIPythonicFunctionCalling:
     """Tests for pythonic function calling format."""
 
-    def test_pythonic_tool_call_prompt(self, setup_backend, api_client):
+    def test_pythonic_tool_call_prompt(self, model, api_client):
         """Test: Explicit prompt for pythonic tool call format without chat template."""
-        _, model, _, _ = setup_backend
 
         response = api_client.chat.completions.create(
             model=model,
@@ -748,9 +738,8 @@ class TestOpenAIPythonicFunctionCalling:
             f"Function name '{names}' should contain either 'get_weather' or 'get_tourist_attractions'"
         )
 
-    def test_pythonic_tool_call_streaming(self, setup_backend, api_client):
+    def test_pythonic_tool_call_streaming(self, model, api_client):
         """Test: Streaming pythonic tool call format; assert tool_call index is present."""
-        _, model, _, _ = setup_backend
 
         response_stream = api_client.chat.completions.create(
             model=model,
@@ -980,9 +969,8 @@ class _TestToolChoiceBase:
         """Check if the current test is marked as flaky for this class."""
         return test_name in self.FLAKY_TESTS
 
-    def test_tool_choice_auto_non_streaming(self, setup_backend, api_client):
+    def test_tool_choice_auto_non_streaming(self, model, api_client):
         """Test tool_choice='auto' in non-streaming mode."""
-        _, model, _, _ = setup_backend
 
         tools = get_test_tools()
         messages = get_test_messages()
@@ -999,9 +987,8 @@ class _TestToolChoiceBase:
         assert response.choices[0].message is not None
         # With auto, tool calls are optional
 
-    def test_tool_choice_auto_streaming(self, setup_backend, api_client):
+    def test_tool_choice_auto_streaming(self, model, api_client):
         """Test tool_choice='auto' in streaming mode."""
-        _, model, _, _ = setup_backend
 
         tools = get_test_tools()
         messages = get_test_messages()
@@ -1029,9 +1016,8 @@ class _TestToolChoiceBase:
         assert isinstance(content_chunks, list)
         assert isinstance(tool_call_chunks, list)
 
-    def test_tool_choice_required_non_streaming(self, setup_backend, api_client):
+    def test_tool_choice_required_non_streaming(self, model, api_client):
         """Test tool_choice='required' in non-streaming mode."""
-        _, model, _, _ = setup_backend
 
         tools = get_test_tools()
         messages = get_test_messages()
@@ -1051,9 +1037,8 @@ class _TestToolChoiceBase:
         assert tool_calls is not None
         assert len(tool_calls) > 0
 
-    def test_tool_choice_required_streaming(self, setup_backend, api_client):
+    def test_tool_choice_required_streaming(self, model, api_client):
         """Test tool_choice='required' in streaming mode."""
-        _, model, _, _ = setup_backend
 
         tools = get_test_tools()
         messages = get_test_messages()
@@ -1077,9 +1062,8 @@ class _TestToolChoiceBase:
         # With required, we should get tool call chunks
         assert len(tool_call_chunks) > 0
 
-    def test_tool_choice_specific_function_non_streaming(self, setup_backend, api_client):
+    def test_tool_choice_specific_function_non_streaming(self, model, api_client):
         """Test tool_choice with specific function in non-streaming mode."""
-        _, model, _, _ = setup_backend
 
         tools = get_test_tools()
         messages = get_test_messages()
@@ -1103,9 +1087,8 @@ class _TestToolChoiceBase:
         for tool_call in tool_calls:
             assert tool_call.function.name == "get_weather"
 
-    def test_tool_choice_specific_function_streaming(self, setup_backend, api_client):
+    def test_tool_choice_specific_function_streaming(self, model, api_client):
         """Test tool_choice with specific function in streaming mode."""
-        _, model, _, _ = setup_backend
 
         tools = get_test_tools()
         messages = get_test_messages()
@@ -1140,11 +1123,10 @@ class _TestToolChoiceBase:
 
         assert found_name == "get_weather"
 
-    def test_required_streaming_arguments_chunks_json(self, setup_backend, api_client):
+    def test_required_streaming_arguments_chunks_json(self, model, api_client):
         """In streaming required mode, complete tool call arguments should be valid JSON when
         all chunks are combined.
         """
-        _, model, _, _ = setup_backend
 
         tools = get_test_tools()
         messages = get_test_messages()
@@ -1201,9 +1183,8 @@ class _TestToolChoiceBase:
                     f"Invalid JSON in complete tool call arguments: {tool_call['function']['arguments']}"
                 )
 
-    def test_complex_parameters_required_non_streaming(self, setup_backend, api_client):
+    def test_complex_parameters_required_non_streaming(self, model, api_client):
         """Validate complex nested parameter schemas in non-streaming required mode."""
-        _, model, _, _ = setup_backend
 
         complex_tools = [
             {
@@ -1281,9 +1262,8 @@ class _TestToolChoiceBase:
                     f"Invalid JSON in complex tool call arguments: {tool_call.function.arguments}"
                 )
 
-    def test_multi_tool_scenario_auto(self, setup_backend, api_client):
+    def test_multi_tool_scenario_auto(self, model, api_client):
         """Test multi-tool scenario with tool_choice='auto'."""
-        _, model, _, _ = setup_backend
 
         tools = get_travel_tools()
         messages = get_travel_messages()
@@ -1320,9 +1300,8 @@ class _TestToolChoiceBase:
                 f"Expected functions {expected_functions}, got {called_functions}"
             )
 
-    def test_multi_tool_scenario_required(self, setup_backend, api_client):
+    def test_multi_tool_scenario_required(self, model, api_client):
         """Test multi-tool scenario with tool_choice='required'."""
-        _, model, _, _ = setup_backend
 
         tools = get_travel_tools()
         messages = get_travel_messages()
@@ -1364,9 +1343,8 @@ class _TestToolChoiceBase:
                 f"Expected functions {expected_functions}, got {called_functions}"
             )
 
-    def test_error_handling_invalid_tool_choice(self, setup_backend, api_client):
+    def test_error_handling_invalid_tool_choice(self, model, api_client):
         """Test error handling for invalid tool_choice."""
-        _, model, _, _ = setup_backend
 
         tools = get_test_tools()
         messages = get_test_messages()
@@ -1388,9 +1366,8 @@ class _TestToolChoiceBase:
         # Verify the error message contains the expected text
         assert "function 'nonexistent_function' not found in" in str(exc_info.value)
 
-    def test_invalid_tool_missing_name(self, setup_backend, api_client):
+    def test_invalid_tool_missing_name(self, model, api_client):
         """Test what happens when user doesn't provide a tool name in request."""
-        _, model, _, _ = setup_backend
 
         # Test with malformed JSON in tool parameters - missing required "name" field
         invalid_tools = [
@@ -1436,9 +1413,8 @@ class _TestToolChoiceBase:
         error_msg = str(exc_info.value).lower()
         assert "name" in error_msg
 
-    def test_conflicting_defs_required_tool_choice(self, setup_backend, api_client):
+    def test_conflicting_defs_required_tool_choice(self, model, api_client):
         """Test that conflicting $defs with required tool_choice returns 400 error."""
-        _, model, _, _ = setup_backend
 
         conflicting_tools = [
             {
@@ -1570,6 +1546,6 @@ class TestToolChoiceMistral(_TestToolChoiceBase):
     }
 
     @pytest.mark.skip(reason="Fails due to whitespace issue with Mistral - skipping")
-    def test_complex_parameters_required_non_streaming(self, setup_backend, api_client):
+    def test_complex_parameters_required_non_streaming(self, model, api_client):
         """Validate complex nested parameter schemas in non-streaming required mode."""
-        super().test_complex_parameters_required_non_streaming(setup_backend, api_client)
+        super().test_complex_parameters_required_non_streaming(model, api_client)

--- a/e2e_test/chat_completions/test_openai_server.py
+++ b/e2e_test/chat_completions/test_openai_server.py
@@ -36,9 +36,8 @@ class TestChatCompletion:
 
     @pytest.mark.parametrize("logprobs", [None, 5])
     @pytest.mark.parametrize("parallel_sample_num", [1, 2])
-    def test_chat_completion(self, setup_backend, api_client, logprobs, parallel_sample_num):
+    def test_chat_completion(self, model, api_client, logprobs, parallel_sample_num):
         """Test non-streaming chat completion with logprobs and parallel sampling."""
-        _, model, _, _ = setup_backend
         # Use temperature > 0 for n > 1 (greedy sampling rejects n > 1)
         temperature = 0.7 if parallel_sample_num > 1 else 0
         response = api_client.chat.completions.create(
@@ -72,9 +71,8 @@ class TestChatCompletion:
 
     @pytest.mark.parametrize("logprobs", [None, 5])
     @pytest.mark.parametrize("parallel_sample_num", [1, 2])
-    def test_chat_completion_stream(self, setup_backend, api_client, logprobs, parallel_sample_num):
+    def test_chat_completion_stream(self, model, api_client, logprobs, parallel_sample_num):
         """Test streaming chat completion with logprobs and parallel sampling."""
-        _, model, _, _ = setup_backend
         temperature = 0.7 if parallel_sample_num > 1 else 0
         generator = api_client.chat.completions.create(
             model=model,
@@ -135,9 +133,8 @@ class TestChatCompletion:
         "trtllm",
         reason="TRT-LLM gRPC bug: uses 'guided_decoding_params' instead of 'guided_decoding'",
     )
-    def test_regex(self, setup_backend, api_client):
+    def test_regex(self, model, api_client):
         """Test structured output with regex constraint."""
-        _, model, _, _ = setup_backend
 
         regex = (
             r"""\{\n""" + r"""   "name": "[\w]+",\n""" + r"""   "population": [\d]+\n""" + r"""\}"""
@@ -162,9 +159,8 @@ class TestChatCompletion:
         assert isinstance(js_obj["name"], str)
         assert isinstance(js_obj["population"], int)
 
-    def test_penalty(self, setup_backend, api_client):
+    def test_penalty(self, model, api_client):
         """Test that frequency_penalty parameter is accepted and produces output."""
-        _, model, _, _ = setup_backend
 
         response = api_client.chat.completions.create(
             model=model,
@@ -178,9 +174,8 @@ class TestChatCompletion:
         assert isinstance(response.choices[0].message.content, str)
         assert response.usage.completion_tokens > 0
 
-    def test_response_prefill(self, setup_backend, api_client):
+    def test_response_prefill(self, model, api_client):
         """Test assistant message prefill with continue_final_message."""
-        _, model, _, _ = setup_backend
 
         response = api_client.chat.completions.create(
             model=model,
@@ -210,9 +205,8 @@ convenient hands-free control to your smart devices.
 
         assert response.choices[0].message.content.strip().startswith('"name": "SmartHome Mini",')
 
-    def test_streaming_token_count_matches_chunks(self, setup_backend, api_client):
+    def test_streaming_token_count_matches_chunks(self, model, api_client):
         """Test that streaming completion_tokens matches the number of content chunks."""
-        _, model, _, _ = setup_backend
 
         generator = api_client.chat.completions.create(
             model=model,
@@ -256,16 +250,14 @@ convenient hands-free control to your smart devices.
             f"content chunk count ({content_chunk_count})"
         )
 
-    def test_model_list(self, setup_backend, api_client):
+    def test_model_list(self, model, api_client):
         """Test listing available models."""
-        _, model, _, _ = setup_backend
 
         models = list(api_client.models.list().data)
         assert len(models) == 1
 
-    def test_stop_sequences(self, setup_backend, api_client):
+    def test_stop_sequences(self, model, api_client):
         """Test that stop sequences cause the model to stop generating."""
-        _, model, _, _ = setup_backend
 
         response = api_client.chat.completions.create(
             model=model,
@@ -287,9 +279,8 @@ convenient hands-free control to your smart devices.
                 f"Stop sequence ',' should be the suffix of output: {content}"
             )
 
-    def test_stop_sequences_stream(self, setup_backend, api_client):
+    def test_stop_sequences_stream(self, model, api_client):
         """Test that stop sequences work in streaming mode."""
-        _, model, _, _ = setup_backend
 
         chunks = list(
             api_client.chat.completions.create(
@@ -355,34 +346,32 @@ class TestChatCompletionGptOss(TestChatCompletion):
 
     @pytest.mark.parametrize("logprobs", [None, 5])
     @pytest.mark.parametrize("parallel_sample_num", [1, 2])
-    def test_chat_completion(self, setup_backend, api_client, logprobs, parallel_sample_num):
+    def test_chat_completion(self, model, api_client, logprobs, parallel_sample_num):
         """Test non-streaming chat completion with logprobs and parallel sampling."""
-        super().test_chat_completion(setup_backend, api_client, logprobs, parallel_sample_num)
+        super().test_chat_completion(model, api_client, logprobs, parallel_sample_num)
 
     @pytest.mark.parametrize("logprobs", [None, 5])
     @pytest.mark.parametrize("parallel_sample_num", [1, 2])
-    def test_chat_completion_stream(self, setup_backend, api_client, logprobs, parallel_sample_num):
+    def test_chat_completion_stream(self, model, api_client, logprobs, parallel_sample_num):
         """Test streaming chat completion with logprobs and parallel sampling."""
-        super().test_chat_completion_stream(
-            setup_backend, api_client, logprobs, parallel_sample_num
-        )
+        super().test_chat_completion_stream(model, api_client, logprobs, parallel_sample_num)
 
-    def test_stop_sequences(self, setup_backend, api_client):
+    def test_stop_sequences(self, model, api_client):
         if is_trtllm():
             pytest.skip("TRT-LLM Harmony stop_word_ids path has known bugs")
-        super().test_stop_sequences(setup_backend, api_client)
+        super().test_stop_sequences(model, api_client)
 
-    def test_stop_sequences_stream(self, setup_backend, api_client):
+    def test_stop_sequences_stream(self, model, api_client):
         if is_trtllm():
             pytest.skip("TRT-LLM Harmony stop_word_ids path has known bugs")
         if is_sglang():
             self.STOP_SEQUENCE_TRIMMED = True
-        super().test_stop_sequences_stream(setup_backend, api_client)
+        super().test_stop_sequences_stream(model, api_client)
 
     @pytest.mark.skip(reason="gpt-oss models don't support regex constraints")
-    def test_regex(self, setup_backend, api_client):
+    def test_regex(self, model, api_client):
         pass
 
     @pytest.mark.skip(reason="gpt-oss Harmony pipeline doesn't implement continue_final_message")
-    def test_response_prefill(self, setup_backend, api_client):
+    def test_response_prefill(self, model, api_client):
         pass

--- a/e2e_test/chat_completions/test_reasoning_content.py
+++ b/e2e_test/chat_completions/test_reasoning_content.py
@@ -30,9 +30,8 @@ logger = logging.getLogger(__name__)
 class TestReasoningContentAPI:
     """Tests for reasoning content API with DeepSeek R1 reasoning parser."""
 
-    def test_streaming_separate_reasoning_false(self, setup_backend, api_client):
+    def test_streaming_separate_reasoning_false(self, model, api_client):
         """Test streaming with separate_reasoning=False, reasoning_content should be empty."""
-        _, model, _, _ = setup_backend
 
         response = api_client.chat.completions.create(
             model=model,
@@ -58,9 +57,8 @@ class TestReasoningContentAPI:
         assert len(reasoning_content) == 0
         assert len(content) > 0
 
-    def test_streaming_separate_reasoning_true(self, setup_backend, api_client):
+    def test_streaming_separate_reasoning_true(self, model, api_client):
         """Test streaming with separate_reasoning=True, reasoning_content should not be empty."""
-        _, model, _, _ = setup_backend
 
         response = api_client.chat.completions.create(
             model=model,
@@ -86,11 +84,8 @@ class TestReasoningContentAPI:
         assert len(reasoning_content) > 0
         assert len(content) > 0
 
-    def test_streaming_separate_reasoning_true_stream_reasoning_false(
-        self, setup_backend, api_client
-    ):
+    def test_streaming_separate_reasoning_true_stream_reasoning_false(self, model, api_client):
         """Test streaming with separate_reasoning=True and stream_reasoning=False."""
-        _, model, _, _ = setup_backend
 
         response = api_client.chat.completions.create(
             model=model,
@@ -126,9 +121,8 @@ class TestReasoningContentAPI:
         assert len(reasoning_content) > 0
         assert len(content) > 0
 
-    def test_nonstreaming_separate_reasoning_false(self, setup_backend, api_client):
+    def test_nonstreaming_separate_reasoning_false(self, model, api_client):
         """Test non-streaming with separate_reasoning=False, reasoning_content should be empty."""
-        _, model, _, _ = setup_backend
 
         response = api_client.chat.completions.create(
             model=model,
@@ -148,9 +142,8 @@ class TestReasoningContentAPI:
         )
         assert len(response.choices[0].message.content) > 0
 
-    def test_nonstreaming_separate_reasoning_true(self, setup_backend, api_client):
+    def test_nonstreaming_separate_reasoning_true(self, model, api_client):
         """Test non-streaming with separate_reasoning=True, reasoning_content should not be empty."""
-        _, model, _, _ = setup_backend
 
         response = api_client.chat.completions.create(
             model=model,

--- a/e2e_test/chat_completions/test_structured_output.py
+++ b/e2e_test/chat_completions/test_structured_output.py
@@ -17,9 +17,8 @@ import pytest
 class _TestStructuredOutputBase:
     """Base class for structured output tests. Not collected by pytest."""
 
-    def test_response_format_json_schema(self, setup_backend, api_client):
+    def test_response_format_json_schema(self, model, api_client):
         """Test response_format with json_schema produces valid constrained JSON."""
-        _, model, _, _ = setup_backend
 
         schema = {
             "type": "object",
@@ -65,9 +64,8 @@ class _TestStructuredOutputBase:
         assert "<|constrain|>" not in content
         assert "<|message|>" not in content
 
-    def test_response_format_json_schema_stream(self, setup_backend, api_client):
+    def test_response_format_json_schema_stream(self, model, api_client):
         """Test response_format with json_schema in streaming mode."""
-        _, model, _, _ = setup_backend
 
         schema = {
             "type": "object",

--- a/e2e_test/chat_completions/test_validation.py
+++ b/e2e_test/chat_completions/test_validation.py
@@ -46,13 +46,12 @@ def get_tokenizer(model_path: str):
 class TestIgnoreEOS:
     """Tests for ignore_eos feature."""
 
-    def test_ignore_eos(self, setup_backend, api_client):
+    def test_ignore_eos(self, model, api_client):
         """Test that ignore_eos=True allows generation to continue beyond EOS token.
 
         When ignore_eos=True, the model should generate until max_tokens is reached,
         even if it encounters an EOS token.
         """
-        _, model, _, _ = setup_backend
 
         tokenizer = get_tokenizer(model)
         max_tokens = 200
@@ -117,13 +116,12 @@ class TestIgnoreEOS:
 class TestLargeMaxNewTokens:
     """Tests for handling large max_new_tokens with concurrent requests."""
 
-    def test_concurrent_chat_completions(self, setup_backend, api_client):
+    def test_concurrent_chat_completions(self, model, api_client):
         """Test that multiple concurrent requests with large token generation complete.
 
         This test sends multiple requests that ask for long outputs concurrently
         to verify the server can handle concurrent long-running requests.
         """
-        _, model, _, _ = setup_backend
 
         num_requests = 4
 
@@ -178,9 +176,8 @@ class TestLargeMaxNewTokens:
 class TestHarmonyValidation:
     """Validation tests for Harmony models (GPT-OSS)."""
 
-    def test_ignore_eos_rejected(self, setup_backend, api_client):
+    def test_ignore_eos_rejected(self, model, api_client):
         """Test that ignore_eos is rejected for Harmony models with HTTP 400."""
-        _, model, _, _ = setup_backend
 
         with pytest.raises((openai.BadRequestError, smg_client.BadRequestError)) as exc_info:
             api_client.chat.completions.create(
@@ -193,9 +190,8 @@ class TestHarmonyValidation:
         assert exc_info.value.status_code == 400
         assert exc_info.value.code == "ignore_eos_not_supported"
 
-    def test_tool_choice_with_response_format_rejected(self, setup_backend, api_client):
+    def test_tool_choice_with_response_format_rejected(self, model, api_client):
         """Test that tool_choice + response_format is rejected with HTTP 400."""
-        _, model, _, _ = setup_backend
 
         with pytest.raises((openai.BadRequestError, smg_client.BadRequestError)) as exc_info:
             api_client.chat.completions.create(

--- a/e2e_test/conftest.py
+++ b/e2e_test/conftest.py
@@ -21,6 +21,7 @@ Fixtures
 --------
 setup_backend: Class-scoped fixture that launches workers + gateway per test class.
     Returns (backend_name, model_path, client, gateway).
+model: Convenience fixture that returns just the model_path from setup_backend.
 """
 
 from __future__ import annotations
@@ -113,16 +114,10 @@ from smg_client import SmgClient
 
 
 @pytest.fixture
-def smg(setup_backend):
-    """DEPRECATED: Use ``api_client`` fixture instead.
-
-    To test with SmgClient, add to your test class:
-    ``@pytest.mark.parametrize("api_client", ["openai", "smg"], indirect=True)``
-    """
-    _, _, _, gateway = setup_backend
-    client = SmgClient(base_url=gateway.base_url, max_retries=0)
-    yield client
-    client.close()
+def model(setup_backend):
+    """Return the model path from setup_backend."""
+    _, model_path, _, _ = setup_backend
+    return model_path
 
 
 @pytest.fixture
@@ -155,6 +150,6 @@ __all__ = [
     # Fixtures
     "setup_backend",
     "backend_router",
-    "smg",
+    "model",
     "api_client",
 ]

--- a/e2e_test/embeddings/test_basic.py
+++ b/e2e_test/embeddings/test_basic.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 class TestEmbeddingBasic:
     """Basic embedding API tests using local workers (gRPC and HTTP)."""
 
-    def test_embedding_single(self, setup_backend, api_client):
+    def test_embedding_single(self, model, api_client):
         """Test single text embedding.
 
         Verifies that:
@@ -35,7 +35,6 @@ class TestEmbeddingBasic:
         - Embedding is a non-empty list of floats
         - Usage statistics are present
         """
-        backend, model, _, _ = setup_backend
 
         input_text = "Hello world"
         response = api_client.embeddings.create(
@@ -62,13 +61,12 @@ class TestEmbeddingBasic:
             response.usage.prompt_tokens,
         )
 
-    def test_embedding_batch(self, setup_backend, api_client):
+    def test_embedding_batch(self, model, api_client):
         """Test batch embedding with multiple texts.
 
         Note: The original test expected len(response.data) == 1 for batch,
         which seems incorrect. This might be model-specific behavior.
         """
-        backend, model, _, _ = setup_backend
 
         input_texts = ["Hello world", "SGLang is fast"]
         response = api_client.embeddings.create(
@@ -85,13 +83,12 @@ class TestEmbeddingBasic:
 
         logger.info("Batch embedding: %d results", len(response.data))
 
-    def test_embedding_dimensions_consistent(self, setup_backend, api_client):
+    def test_embedding_dimensions_consistent(self, model, api_client):
         """Test that embedding dimensions are consistent across different inputs.
 
         Verifies that different length inputs produce embeddings with
         the same dimensionality.
         """
-        backend, model, _, _ = setup_backend
 
         response1 = api_client.embeddings.create(
             model=model,
@@ -108,13 +105,12 @@ class TestEmbeddingBasic:
         assert dim1 == dim2, f"Dimensions differ: {dim1} vs {dim2}"
         logger.info("Embedding dimensions: %d (consistent)", dim1)
 
-    def test_embedding_empty_string(self, setup_backend, api_client):
+    def test_embedding_empty_string(self, model, api_client):
         """Test embedding with empty string input.
 
         Some models may handle empty strings differently.
         This test verifies the API doesn't crash on empty input.
         """
-        backend, model, _, _ = setup_backend
 
         try:
             response = api_client.embeddings.create(
@@ -128,12 +124,11 @@ class TestEmbeddingBasic:
             # Some models may reject empty strings - that's acceptable
             logger.info("Empty string embedding rejected: %s", e)
 
-    def test_embedding_unicode(self, setup_backend, api_client):
+    def test_embedding_unicode(self, model, api_client):
         """Test embedding with unicode characters.
 
         Verifies that the API handles non-ASCII characters correctly.
         """
-        backend, model, _, _ = setup_backend
 
         input_text = "Hello 世界! 🚀 Привет мир"
         response = api_client.embeddings.create(

--- a/e2e_test/messages/test_basic.py
+++ b/e2e_test/messages/test_basic.py
@@ -19,9 +19,8 @@ logger = logging.getLogger(__name__)
 class TestMessagesBasic:
     """Basic message creation tests against the Anthropic Messages API."""
 
-    def test_non_streaming_basic(self, setup_backend, api_client):
+    def test_non_streaming_basic(self, model, api_client):
         """Test basic non-streaming message creation."""
-        _, model, _, _ = setup_backend
 
         response = api_client.messages.create(
             model=model,
@@ -40,9 +39,8 @@ class TestMessagesBasic:
         assert response.usage.input_tokens > 0
         assert response.usage.output_tokens > 0
 
-    def test_non_streaming_with_system(self, setup_backend, api_client):
+    def test_non_streaming_with_system(self, model, api_client):
         """Test non-streaming message with system prompt."""
-        _, model, _, _ = setup_backend
 
         response = api_client.messages.create(
             model=model,
@@ -58,9 +56,8 @@ class TestMessagesBasic:
         # With the "one word" instruction, response should be short
         assert len(response.content[0].text.split()) <= 10
 
-    def test_non_streaming_multi_turn(self, setup_backend, api_client):
+    def test_non_streaming_multi_turn(self, model, api_client):
         """Test multi-turn conversation preserves context."""
-        _, model, _, _ = setup_backend
 
         response = api_client.messages.create(
             model=model,
@@ -78,9 +75,8 @@ class TestMessagesBasic:
         assert response.content[0].type == "text"
         assert "alice" in response.content[0].text.lower()
 
-    def test_streaming_basic(self, setup_backend, api_client):
+    def test_streaming_basic(self, model, api_client):
         """Test streaming message creation returns expected event types."""
-        _, model, _, _ = setup_backend
 
         expected_event_types = {
             "message_start",
@@ -103,9 +99,8 @@ class TestMessagesBasic:
         missing = expected_event_types - event_types
         assert not missing, f"Missing expected event types: {missing}"
 
-    def test_streaming_collects_full_message(self, setup_backend, api_client):
+    def test_streaming_collects_full_message(self, model, api_client):
         """Test that streaming deltas concatenate to a non-empty message."""
-        _, model, _, _ = setup_backend
 
         with api_client.messages.stream(
             model=model,

--- a/e2e_test/messages/test_mcp_tool.py
+++ b/e2e_test/messages/test_mcp_tool.py
@@ -191,10 +191,9 @@ def assert_streaming_mcp_response(
 class TestMcpTool:
     """MCP tool use tests with SMG orchestration (X-SMG-MCP: enabled)."""
 
-    def test_mcp_non_streaming(self, setup_backend, api_client):
+    def test_mcp_non_streaming(self, model, api_client):
         """Test MCP tool execution in non-streaming mode."""
         cfg = SMG_HANDLED
-        _, model, _, _ = setup_backend
 
         response = api_client.messages.create(
             model=model,
@@ -206,10 +205,9 @@ class TestMcpTool:
 
         assert_non_streaming_mcp_response(response, model, cfg.server_name)
 
-    def test_mcp_streaming(self, setup_backend, api_client):
+    def test_mcp_streaming(self, model, api_client):
         """Test MCP tool execution with SSE streaming."""
         cfg = SMG_HANDLED
-        _, model, _, _ = setup_backend
 
         with api_client.messages.stream(
             model=model,
@@ -239,10 +237,9 @@ class TestMcpToolPassthrough:
     Requires external https://dmcp-server.deno.dev/sse to be reachable.
     """
 
-    def test_mcp_passthrough_non_streaming(self, setup_backend, api_client):
+    def test_mcp_passthrough_non_streaming(self, model, api_client):
         """Test MCP passthrough in non-streaming mode."""
         cfg = PASSTHROUGH
-        _, model, _, _ = setup_backend
 
         response = api_client.messages.create(
             model=model,
@@ -254,10 +251,9 @@ class TestMcpToolPassthrough:
 
         assert_non_streaming_mcp_response(response, model, cfg.server_name)
 
-    def test_mcp_passthrough_streaming(self, setup_backend, api_client):
+    def test_mcp_passthrough_streaming(self, model, api_client):
         """Test MCP passthrough with SSE streaming."""
         cfg = PASSTHROUGH
-        _, model, _, _ = setup_backend
 
         with api_client.messages.stream(
             model=model,

--- a/e2e_test/messages/test_tool_search.py
+++ b/e2e_test/messages/test_tool_search.py
@@ -91,13 +91,12 @@ def make_mcp_toolset(
 class TestToolSearchPassthrough:
     """Tool search passthrough tests — request forwarded to Anthropic as-is."""
 
-    def test_tool_search_with_deferred_tools_non_streaming(self, setup_backend, api_client):
+    def test_tool_search_with_deferred_tools_non_streaming(self, model, api_client):
         """Send tool_search_tool + deferred custom tools.
 
         Verifies the response can contain server_tool_use (tool search invocation)
         and that the model can discover and reference deferred tools.
         """
-        _, model, _, _ = setup_backend
 
         tools = [
             make_tool_search_tool(),
@@ -172,9 +171,8 @@ class TestToolSearchPassthrough:
         assert response.usage.input_tokens > 0
         assert response.usage.output_tokens > 0
 
-    def test_tool_search_with_deferred_tools_streaming(self, setup_backend, api_client):
+    def test_tool_search_with_deferred_tools_streaming(self, model, api_client):
         """Streaming variant of tool search passthrough."""
-        _, model, _, _ = setup_backend
 
         tools = [
             make_tool_search_tool(),
@@ -286,13 +284,12 @@ class TestToolSearchWithMcp:
                 "Ensure the MCP server is running before running these tests."
             )
 
-    def test_mcp_tools_with_deferred_loading(self, setup_backend, api_client):
+    def test_mcp_tools_with_deferred_loading(self, model, api_client):
         """Send tool_search_tool + mcp_toolset with defer_loading: true.
 
         Verifies the full flow: SMG injects MCP tools with defer_loading,
         Anthropic discovers them via tool search, SMG executes via MCP.
         """
-        _, model, _, _ = setup_backend
 
         tools = [
             make_tool_search_tool(),
@@ -364,9 +361,8 @@ class TestToolSearchWithMcp:
         assert response.usage.input_tokens > 0
         assert response.usage.output_tokens > 0
 
-    def test_mcp_tools_with_deferred_loading_streaming(self, setup_backend, api_client):
+    def test_mcp_tools_with_deferred_loading_streaming(self, model, api_client):
         """Streaming variant: tool_search + deferred MCP tools via SMG."""
-        _, model, _, _ = setup_backend
 
         tools = [
             make_tool_search_tool(),

--- a/e2e_test/messages/test_tool_use.py
+++ b/e2e_test/messages/test_tool_use.py
@@ -61,9 +61,8 @@ CALCULATE_TOOL = {
 class TestToolUseBasic:
     """Tool use tests against the Anthropic Messages API."""
 
-    def test_single_tool_call(self, setup_backend, api_client):
+    def test_single_tool_call(self, model, api_client):
         """Test that the model calls a single tool when appropriate."""
-        _, model, _, _ = setup_backend
 
         response = api_client.messages.create(
             model=model,
@@ -86,9 +85,8 @@ class TestToolUseBasic:
         assert isinstance(tool_use.input, dict)
         assert "location" in tool_use.input
 
-    def test_tool_call_and_result_round_trip(self, setup_backend, api_client):
+    def test_tool_call_and_result_round_trip(self, model, api_client):
         """Test full round-trip: tool call -> tool result -> final text response."""
-        _, model, _, _ = setup_backend
 
         # First request: model should request a tool call
         response1 = api_client.messages.create(
@@ -133,9 +131,8 @@ class TestToolUseBasic:
         assert len(text_blocks) > 0, "Final response should contain text"
         assert len(text_blocks[0].text) > 0
 
-    def test_tool_use_streaming(self, setup_backend, api_client):
+    def test_tool_use_streaming(self, model, api_client):
         """Test streaming with tool use returns input_json delta events."""
-        _, model, _, _ = setup_backend
 
         with api_client.messages.stream(
             model=model,
@@ -162,9 +159,8 @@ class TestToolUseBasic:
             parsed = json.loads(full_json_str)
             assert isinstance(parsed, dict)
 
-    def test_multiple_tools_available(self, setup_backend, api_client):
+    def test_multiple_tools_available(self, model, api_client):
         """Test that model selects the correct tool when multiple are available."""
-        _, model, _, _ = setup_backend
 
         response = api_client.messages.create(
             model=model,

--- a/e2e_test/responses/test_basic_crud.py
+++ b/e2e_test/responses/test_basic_crud.py
@@ -66,9 +66,8 @@ def wait_for_background_task(
 class TestResponseCRUD:
     """Tests for Response API CRUD operations."""
 
-    def test_create_and_get_response(self, setup_backend, api_client):
+    def test_create_and_get_response(self, model, api_client):
         """Test creating response and retrieving it."""
-        _, model, _, _ = setup_backend
 
         # Create response
         create_resp = api_client.responses.create(model=model, input="Hello, world!")
@@ -89,9 +88,8 @@ class TestResponseCRUD:
         assert len(input_resp.data) > 0
 
     @pytest.mark.skip(reason="TODO: Add delete response feature")
-    def test_delete_response(self, setup_backend, api_client):
+    def test_delete_response(self, model, api_client):
         """Test deleting response."""
-        _, model, _, _ = setup_backend
 
         # Create response
         create_resp = api_client.responses.create(model=model, input="Test deletion")
@@ -110,9 +108,8 @@ class TestResponseCRUD:
             api_client.responses.retrieve(response_id=response_id)
 
     @pytest.mark.skip(reason="TODO: Add background response feature")
-    def test_background_response(self, setup_backend, api_client):
+    def test_background_response(self, model, api_client):
         """Test background response execution."""
-        _, model, _, _ = setup_backend
 
         # Create background response
         create_resp = api_client.responses.create(
@@ -144,9 +141,8 @@ class TestResponseCRUD:
 class TestResponseCRUDOracleStorage:
     """Tests for Response API CRUD operations with Oracle history backend."""
 
-    def test_create_and_get_response(self, setup_backend, api_client):
+    def test_create_and_get_response(self, model, api_client):
         """Test creating response and retrieving it."""
-        _, model, _, _ = setup_backend
 
         # Create response
         create_resp = api_client.responses.create(model=model, input="Hello, world!")
@@ -167,9 +163,8 @@ class TestResponseCRUDOracleStorage:
         assert len(input_resp.data) > 0
 
     @pytest.mark.skip(reason="TODO: Add delete response feature")
-    def test_delete_response(self, setup_backend, api_client):
+    def test_delete_response(self, model, api_client):
         """Test deleting response."""
-        _, model, _, _ = setup_backend
 
         # Create response
         create_resp = api_client.responses.create(model=model, input="Test deletion")
@@ -188,9 +183,8 @@ class TestResponseCRUDOracleStorage:
             api_client.responses.retrieve(response_id=response_id)
 
     @pytest.mark.skip(reason="TODO: Add background response feature")
-    def test_background_response(self, setup_backend, api_client):
+    def test_background_response(self, model, api_client):
         """Test background response execution."""
-        _, model, _, _ = setup_backend
 
         # Create background response
         create_resp = api_client.responses.create(

--- a/e2e_test/responses/test_builtin_tools.py
+++ b/e2e_test/responses/test_builtin_tools.py
@@ -178,9 +178,8 @@ class TestBuiltinVsMcpComparison:
     These tests verify baseline MCP behavior without requiring builtin routing config.
     """
 
-    def test_mcp_tool_produces_mcp_call(self, setup_backend, api_client):
+    def test_mcp_tool_produces_mcp_call(self, model, api_client):
         """Verify that direct MCP tool produces mcp_call output."""
-        _, model, _, _ = setup_backend
 
         time.sleep(2)
 
@@ -216,9 +215,8 @@ class TestBuiltinToolsCloudBackend:
     Full routing tests require MCP config with builtin_type configured.
     """
 
-    def test_web_search_preview_accepted(self, setup_backend, api_client):
+    def test_web_search_preview_accepted(self, model, api_client):
         """Test that web_search_preview tool type is accepted."""
-        _, model, _, _ = setup_backend
 
         time.sleep(2)
 
@@ -232,9 +230,8 @@ class TestBuiltinToolsCloudBackend:
         assert resp.id is not None
         assert resp.status in ("completed", "incomplete")
 
-    def test_mixed_builtin_and_function_tools(self, setup_backend, api_client):
+    def test_mixed_builtin_and_function_tools(self, model, api_client):
         """Test mixing web_search_preview with function tools."""
-        _, model, _, _ = setup_backend
 
         time.sleep(2)
 
@@ -272,9 +269,8 @@ class TestBuiltinToolsLocalBackend:
     These tests verify built-in tool handling with local models.
     """
 
-    def test_web_search_preview_accepted(self, setup_backend, api_client):
+    def test_web_search_preview_accepted(self, model, api_client):
         """Test that web_search_preview tool type is accepted by local backend."""
-        _, model, _, _ = setup_backend
 
         time.sleep(1)
 
@@ -287,9 +283,8 @@ class TestBuiltinToolsLocalBackend:
 
         assert resp.id is not None
 
-    def test_mixed_builtin_and_function_tools(self, setup_backend, api_client):
+    def test_mixed_builtin_and_function_tools(self, model, api_client):
         """Test mixing web_search_preview with function tools on local backend."""
-        _, model, _, _ = setup_backend
 
         time.sleep(1)
 
@@ -421,13 +416,12 @@ class TestMcpWebSearchStreamingEvents:
         """Ensure Brave server is available for these tests."""
         pass
 
-    def test_mcp_web_search_streaming_events(self, setup_backend, api_client):
+    def test_mcp_web_search_streaming_events(self, model, api_client):
         """Test that MCP web search produces proper streaming events.
 
         This verifies the baseline MCP streaming behavior that built-in
         tools should eventually match (with different event types).
         """
-        _, model, _, _ = setup_backend
 
         time.sleep(2)
 

--- a/e2e_test/responses/test_state_management.py
+++ b/e2e_test/responses/test_state_management.py
@@ -25,10 +25,8 @@ logger = logging.getLogger(__name__)
 class _StateManagementCloudBase:
     """Base test methods for state management against cloud APIs."""
 
-    def test_basic_response_creation(self, setup_backend, api_client):
+    def test_basic_response_creation(self, model, api_client):
         """Test basic response creation without state."""
-        _, model, _, _ = setup_backend
-
         resp = api_client.responses.create(model=model, input="What is 2+2?")
 
         assert resp.id is not None
@@ -37,10 +35,8 @@ class _StateManagementCloudBase:
         assert len(resp.output_text) > 0
         assert resp.usage is not None
 
-    def test_streaming_response(self, setup_backend, api_client):
+    def test_streaming_response(self, model, api_client):
         """Test streaming response."""
-        _, model, _, _ = setup_backend
-
         resp = api_client.responses.create(
             model=model, input="Count to 5", stream=True, max_output_tokens=50
         )
@@ -51,10 +47,8 @@ class _StateManagementCloudBase:
 
         assert any(e.type in ["response.completed", "response.in_progress"] for e in events)
 
-    def test_previous_response_id_chaining(self, setup_backend, api_client):
+    def test_previous_response_id_chaining(self, model, api_client):
         """Test chaining responses using previous_response_id."""
-        _, model, _, _ = setup_backend
-
         # First response
         resp1 = api_client.responses.create(
             model=model, input="My name is Alice and my friend is Bob. Remember it."
@@ -80,9 +74,8 @@ class _StateManagementCloudBase:
         assert resp3.status == "completed"
         assert "Bob" in resp3.output_text
 
-    def test_conversation_with_multiple_turns(self, setup_backend, api_client):
+    def test_conversation_with_multiple_turns(self, model, api_client):
         """Test state management using conversation ID."""
-        _, model, _, _ = setup_backend
 
         # Create conversation
         conv_resp = api_client.conversations.create(metadata={"topic": "math"})
@@ -124,9 +117,8 @@ class _StateManagementCloudBase:
         # SmgClient: conversations API not supported, skipping comparison
 
     @pytest.mark.skip(reason="TODO: Add the invalid previous_response_id check")
-    def test_previous_response_id_invalid(self, setup_backend, api_client):
+    def test_previous_response_id_invalid(self, model, api_client):
         """Test using invalid previous_response_id."""
-        _, model, _, _ = setup_backend
         with pytest.raises((openai.BadRequestError, smg_client.BadRequestError)):
             api_client.responses.create(
                 model=model,
@@ -135,10 +127,8 @@ class _StateManagementCloudBase:
                 max_output_tokens=50,
             )
 
-    def test_mutually_exclusive_parameters(self, setup_backend, api_client):
+    def test_mutually_exclusive_parameters(self, model, api_client):
         """Test that previous_response_id and conversation are mutually exclusive."""
-        _, model, _, _ = setup_backend
-
         conversation_id = "conv_123"
         resp1 = api_client.responses.create(model=model, input="Test")
 
@@ -208,9 +198,8 @@ class TestStateManagementLocal:
     """State management tests against local gRPC backend."""
 
     @pytest.mark.skip(reason="TODO: Add the invalid previous_response_id check")
-    def test_previous_response_id_invalid(self, setup_backend, api_client):
+    def test_previous_response_id_invalid(self, model, api_client):
         """Test using invalid previous_response_id."""
-        _, model, _, _ = setup_backend
         with pytest.raises((openai.BadRequestError, smg_client.BadRequestError)):
             api_client.responses.create(
                 model=model,
@@ -219,10 +208,8 @@ class TestStateManagementLocal:
                 max_output_tokens=50,
             )
 
-    def test_basic_response_creation(self, setup_backend, api_client):
+    def test_basic_response_creation(self, model, api_client):
         """Test basic response creation without state."""
-        _, model, _, _ = setup_backend
-
         resp = api_client.responses.create(model=model, input="What is 2+2?")
 
         assert resp.id is not None
@@ -231,10 +218,8 @@ class TestStateManagementLocal:
         assert len(resp.output_text) > 0
         assert resp.usage is not None
 
-    def test_streaming_response(self, setup_backend, api_client):
+    def test_streaming_response(self, model, api_client):
         """Test streaming response."""
-        _, model, _, _ = setup_backend
-
         resp = api_client.responses.create(
             model=model, input="Count to 5", stream=True, max_output_tokens=50
         )
@@ -245,10 +230,8 @@ class TestStateManagementLocal:
 
         assert any(e.type in ["response.completed", "response.in_progress"] for e in events)
 
-    def test_previous_response_id_chaining(self, setup_backend, api_client):
+    def test_previous_response_id_chaining(self, model, api_client):
         """Test chaining responses using previous_response_id."""
-        _, model, _, _ = setup_backend
-
         # First response
         resp1 = api_client.responses.create(
             model=model, input="My name is Alice and my friend is Bob. Remember it."
@@ -274,10 +257,8 @@ class TestStateManagementLocal:
         assert resp3.status == "completed"
         assert "Bob" in resp3.output_text
 
-    def test_mutually_exclusive_parameters(self, setup_backend, api_client):
+    def test_mutually_exclusive_parameters(self, model, api_client):
         """Test that previous_response_id and conversation are mutually exclusive."""
-        _, model, _, _ = setup_backend
-
         conversation_id = "conv_123"
         resp1 = api_client.responses.create(model=model, input="Test")
 
@@ -306,9 +287,8 @@ class TestStateManagementHarmony:
     """State management tests against local gRPC backend with Harmony model."""
 
     @pytest.mark.skip(reason="TODO: Add the invalid previous_response_id check")
-    def test_previous_response_id_invalid(self, setup_backend, api_client):
+    def test_previous_response_id_invalid(self, model, api_client):
         """Test using invalid previous_response_id."""
-        _, model, _, _ = setup_backend
         with pytest.raises((openai.BadRequestError, smg_client.BadRequestError)):
             api_client.responses.create(
                 model=model,
@@ -317,10 +297,8 @@ class TestStateManagementHarmony:
                 max_output_tokens=50,
             )
 
-    def test_basic_response_creation(self, setup_backend, api_client):
+    def test_basic_response_creation(self, model, api_client):
         """Test basic response creation without state."""
-        _, model, _, _ = setup_backend
-
         resp = api_client.responses.create(model=model, input="What is 2+2?")
 
         assert resp.id is not None
@@ -329,10 +307,8 @@ class TestStateManagementHarmony:
         assert len(resp.output_text) > 0
         assert resp.usage is not None
 
-    def test_streaming_response(self, setup_backend, api_client):
+    def test_streaming_response(self, model, api_client):
         """Test streaming response."""
-        _, model, _, _ = setup_backend
-
         resp = api_client.responses.create(
             model=model, input="Count to 5", stream=True, max_output_tokens=50
         )
@@ -343,10 +319,8 @@ class TestStateManagementHarmony:
 
         assert any(e.type in ["response.completed", "response.in_progress"] for e in events)
 
-    def test_previous_response_id_chaining(self, setup_backend, api_client):
+    def test_previous_response_id_chaining(self, model, api_client):
         """Test chaining responses using previous_response_id."""
-        _, model, _, _ = setup_backend
-
         # First response
         resp1 = api_client.responses.create(
             model=model, input="My name is Alice and my friend is Bob. Remember it."
@@ -372,10 +346,8 @@ class TestStateManagementHarmony:
         assert resp3.status == "completed"
         assert "Bob" in resp3.output_text
 
-    def test_mutually_exclusive_parameters(self, setup_backend, api_client):
+    def test_mutually_exclusive_parameters(self, model, api_client):
         """Test that previous_response_id and conversation are mutually exclusive."""
-        _, model, _, _ = setup_backend
-
         conversation_id = "conv_123"
         resp1 = api_client.responses.create(model=model, input="Test")
 

--- a/e2e_test/responses/test_storage_hooks.py
+++ b/e2e_test/responses/test_storage_hooks.py
@@ -28,9 +28,8 @@ PASSTHROUGH_HOOK_PATH = "crates/wasm/tests/fixtures/storage_hook_passthrough.was
 class TestResponsesWithStorageHook:
     """Verify WASM storage hooks work end-to-end with the Responses API."""
 
-    def test_create_and_get_response_with_hook(self, setup_backend, api_client):
+    def test_create_and_get_response_with_hook(self, model, api_client):
         """Responses API works normally when a WASM storage hook is active."""
-        _, model, _, _ = setup_backend
 
         # Create response -- hook runs before(StoreResponse) and after(StoreResponse)
         resp = api_client.responses.create(model=model, input="Hello with hooks!")
@@ -45,9 +44,8 @@ class TestResponsesWithStorageHook:
         assert get_resp.error is None
         assert get_resp.status == "completed"
 
-    def test_conversation_with_previous_response_with_hook(self, setup_backend, api_client):
+    def test_conversation_with_previous_response_with_hook(self, model, api_client):
         """Multi-turn conversation works with hooks active."""
-        _, model, _, _ = setup_backend
 
         # First turn
         resp1 = api_client.responses.create(model=model, input="What is 2+2?")
@@ -69,9 +67,8 @@ class TestResponsesWithStorageHook:
         get2 = api_client.responses.retrieve(response_id=resp2.id)
         assert get2.id == resp2.id
 
-    def test_input_items_list_with_hook(self, setup_backend, api_client):
+    def test_input_items_list_with_hook(self, model, api_client):
         """Input items listing works with hooks active."""
-        _, model, _, _ = setup_backend
 
         resp = api_client.responses.create(model=model, input="Hello!")
         assert resp.id is not None

--- a/e2e_test/responses/test_streaming_events.py
+++ b/e2e_test/responses/test_streaming_events.py
@@ -32,13 +32,11 @@ logger = logging.getLogger(__name__)
 class TestStreamingEventsLocal:
     """Streaming event tests against local gRPC backend."""
 
-    def test_output_item_event_emitted(self, setup_backend, api_client):
+    def test_output_item_event_emitted(self, model, api_client):
         """Test that output_index is zero-based in streaming responses.
 
         Verifies that the first output item has output_index: 0.
         """
-        _, model, _, _ = setup_backend
-
         resp = api_client.responses.create(
             model=model,
             input="Count from 1 to 3",
@@ -118,13 +116,11 @@ class TestStreamingEventsLocal:
 class TestStreamingEventsHarmony:
     """Streaming event tests against local gRPC backend with Harmony model."""
 
-    def test_output_item_event_emitted(self, setup_backend, api_client):
+    def test_output_item_event_emitted(self, model, api_client):
         """Test that output_index is zero-based in streaming responses.
 
         Verifies that the first output item has output_index: 0.
         """
-        _, model, _, _ = setup_backend
-
         resp = api_client.responses.create(
             model=model,
             input="Count from 1 to 3",
@@ -188,14 +184,12 @@ class TestStreamingEventsHarmony:
             "Number of output_item.added events should match output array length"
         )
 
-    def test_reasoning_content(self, setup_backend, api_client):
+    def test_reasoning_content(self, model, api_client):
         """Test that reasoning content has correct zero-based output_index.
 
         Specifically tests that reasoning item has output_index: 0
         and message item has output_index: 1.
         """
-        _, model, _, _ = setup_backend
-
         resp = api_client.responses.create(
             model=model,
             input="What is the capital of France? Think step by step.",

--- a/e2e_test/responses/test_structured_output.py
+++ b/e2e_test/responses/test_structured_output.py
@@ -26,9 +26,8 @@ logger = logging.getLogger(__name__)
 class TestStructuredOutputCloud:
     """Structured output tests against cloud APIs."""
 
-    def test_structured_output_json_schema(self, setup_backend, api_client):
+    def test_structured_output_json_schema(self, model, api_client):
         """Test structured output with json_schema format."""
-        _, model, _, _ = setup_backend
 
         params = {
             "model": model,
@@ -126,9 +125,8 @@ class TestStructuredOutputCloud:
 class TestStructuredOutputHarmony:
     """Structured output tests against local gRPC backend with Harmony model."""
 
-    def test_structured_output_json_schema(self, setup_backend, api_client):
+    def test_structured_output_json_schema(self, model, api_client):
         """Test structured output with json_schema format."""
-        _, model, _, _ = setup_backend
 
         params = {
             "model": model,
@@ -228,9 +226,8 @@ class TestSimpleSchemaStructuredOutput:
     handle complex schemas well.
     """
 
-    def test_structured_output_json_schema(self, setup_backend, api_client):
+    def test_structured_output_json_schema(self, model, api_client):
         """Test structured output with simple json_schema format."""
-        _, model, _, _ = setup_backend
 
         params = {
             "model": model,

--- a/e2e_test/responses/test_tools_call.py
+++ b/e2e_test/responses/test_tools_call.py
@@ -144,10 +144,8 @@ MCP_TEST_PROMPT = (
 class TestToolCallingCloud:
     """Tool calling tests against cloud APIs."""
 
-    def test_basic_function_call(self, setup_backend, api_client):
+    def test_basic_function_call(self, model, api_client):
         """Test basic function calling workflow."""
-        _, model, _, _ = setup_backend
-
         tools = [GET_HOROSCOPE_FUNCTION]
         system_prompt = (
             "You are a helpful assistant that can call functions. "
@@ -219,9 +217,8 @@ class TestToolCallingCloud:
         full_text = " ".join(text_parts).lower()
         assert "baby otter" in full_text or "aquarius" in full_text
 
-    def test_mcp_basic_tool_call(self, setup_backend, api_client):
+    def test_mcp_basic_tool_call(self, model, api_client):
         """Test basic MCP tool call (non-streaming)."""
-        _, model, _, _ = setup_backend
 
         time.sleep(2)  # Avoid rate limiting
 
@@ -267,9 +264,8 @@ class TestToolCallingCloud:
                     assert isinstance(content_item.text, str)
                     assert len(content_item.text) > 0
 
-    def test_mcp_basic_tool_call_streaming(self, setup_backend, api_client):
+    def test_mcp_basic_tool_call_streaming(self, model, api_client):
         """Test basic MCP tool call (streaming)."""
-        _, model, _, _ = setup_backend
 
         time.sleep(2)  # Avoid rate limiting
 
@@ -349,9 +345,8 @@ class TestToolCallingCloud:
         final_text = text_done_events[0].text
         assert len(final_text) > 0, "Final text should not be empty"
 
-    def test_mcp_multi_server_tool_call(self, setup_backend, api_client):
+    def test_mcp_multi_server_tool_call(self, model, api_client):
         """Test MCP tool call with multiple MCP servers (non-streaming)."""
-        _, model, _, _ = setup_backend
 
         time.sleep(2)  # Avoid rate limiting
 
@@ -378,9 +373,8 @@ class TestToolCallingCloud:
         for mcp_call in mcp_calls:
             assert mcp_call.server_label == "brave"
 
-    def test_mcp_multi_server_tool_call_streaming(self, setup_backend, api_client):
+    def test_mcp_multi_server_tool_call_streaming(self, model, api_client):
         """Test MCP tool call with multiple MCP servers (streaming)."""
-        _, model, _, _ = setup_backend
 
         time.sleep(2)  # Avoid rate limiting
 
@@ -421,9 +415,8 @@ class TestToolCallingCloud:
         for mcp_call in mcp_calls:
             assert mcp_call.server_label == "brave"
 
-    def test_concurrent_mcp_different_servers(self, setup_backend, api_client):
+    def test_concurrent_mcp_different_servers(self, model, api_client):
         """Concurrent non-streaming requests with different MCP servers don't contaminate each other."""
-        _, model, _, _ = setup_backend
 
         def brave_request():
             return api_client.responses.create(
@@ -465,9 +458,8 @@ class TestToolCallingCloud:
         _check_response(resp_brave, "brave")
         _check_response(resp_deepwiki, "deepwiki")
 
-    def test_concurrent_mcp_different_servers_streaming(self, setup_backend, api_client):
+    def test_concurrent_mcp_different_servers_streaming(self, model, api_client):
         """Concurrent streaming requests with different MCP servers don't contaminate each other."""
-        _, model, _, _ = setup_backend
 
         def brave_stream():
             return list(
@@ -534,9 +526,8 @@ class TestToolCallingCloud:
 class TestToolChoiceHarmony:
     """Tool choice tests against local gRPC backend with Harmony model."""
 
-    def test_tool_choice_auto(self, setup_backend, api_client):
+    def test_tool_choice_auto(self, model, api_client):
         """Test tool_choice="auto" allows model to decide whether to use tools."""
-        _, model, _, _ = setup_backend
 
         tools = [GET_WEATHER_FUNCTION]
 
@@ -559,9 +550,8 @@ class TestToolChoiceHarmony:
             "Model should choose to call function with tool_choice='auto'"
         )
 
-    def test_tool_choice_required(self, setup_backend, api_client):
+    def test_tool_choice_required(self, model, api_client):
         """Test tool_choice="required" forces the model to call at least one tool."""
-        _, model, _, _ = setup_backend
 
         tools = [CALCULATE_FUNCTION]
 
@@ -582,9 +572,8 @@ class TestToolChoiceHarmony:
             "tool_choice='required' must force at least one function call"
         )
 
-    def test_tool_choice_specific_function(self, setup_backend, api_client):
+    def test_tool_choice_specific_function(self, model, api_client):
         """Test tool_choice with specific function name forces that function to be called."""
-        _, model, _, _ = setup_backend
 
         tools = [SEARCH_WEB_FUNCTION, GET_WEATHER_FUNCTION]
 
@@ -606,9 +595,8 @@ class TestToolChoiceHarmony:
             "Must call the function specified in tool_choice"
         )
 
-    def test_tool_choice_streaming(self, setup_backend, api_client):
+    def test_tool_choice_streaming(self, model, api_client):
         """Test tool_choice parameter works correctly with streaming."""
-        _, model, _, _ = setup_backend
 
         tools = [CALCULATE_FUNCTION]
 
@@ -633,9 +621,8 @@ class TestToolChoiceHarmony:
         function_calls = [item for item in output if item.type == "function_call"]
         assert len(function_calls) > 0
 
-    def test_tool_choice_with_mcp_tools(self, setup_backend, api_client):
+    def test_tool_choice_with_mcp_tools(self, model, api_client):
         """Test tool_choice parameter works with MCP tools."""
-        _, model, _, _ = setup_backend
 
         tools = [DEEPWIKI_MCP_TOOL]
 
@@ -657,9 +644,8 @@ class TestToolChoiceHarmony:
         mcp_calls = [item for item in output if item.type == "mcp_call"]
         assert len(mcp_calls) > 0, "tool_choice='auto' should allow MCP tool calls"
 
-    def test_tool_choice_mixed_function_and_mcp(self, setup_backend, api_client):
+    def test_tool_choice_mixed_function_and_mcp(self, model, api_client):
         """Test tool_choice with mixed function and MCP tools."""
-        _, model, _, _ = setup_backend
 
         tools = [DEEPWIKI_MCP_TOOL, LOCAL_SEARCH_FUNCTION]
 
@@ -682,9 +668,8 @@ class TestToolChoiceHarmony:
         mcp_calls = [item for item in output if item.type == "mcp_call"]
         assert len(mcp_calls) == 0, "Should only call specified function, not MCP tools"
 
-    def test_basic_function_call(self, setup_backend, api_client):
+    def test_basic_function_call(self, model, api_client):
         """Test basic function calling workflow."""
-        _, model, _, _ = setup_backend
 
         tools = [GET_HOROSCOPE_FUNCTION]
         system_prompt = (
@@ -715,9 +700,8 @@ class TestToolChoiceHarmony:
         assert "sign" in args
         assert args["sign"].lower() == "aquarius"
 
-    def test_mcp_basic_tool_call(self, setup_backend, api_client):
+    def test_mcp_basic_tool_call(self, model, api_client):
         """Test basic MCP tool call (non-streaming)."""
-        _, model, _, _ = setup_backend
 
         time.sleep(2)
 
@@ -746,9 +730,8 @@ class TestToolChoiceHarmony:
             assert mcp_call.status == "completed"
             assert mcp_call.server_label == "brave"
 
-    def test_mcp_basic_tool_call_streaming(self, setup_backend, api_client):
+    def test_mcp_basic_tool_call_streaming(self, model, api_client):
         """Test basic MCP tool call (streaming)."""
-        _, model, _, _ = setup_backend
 
         time.sleep(2)
 
@@ -769,9 +752,8 @@ class TestToolChoiceHarmony:
         assert "response.mcp_list_tools.completed" in event_types
         assert "response.mcp_call.completed" in event_types
 
-    def test_mixed_mcp_and_function_tools(self, setup_backend, api_client):
+    def test_mixed_mcp_and_function_tools(self, model, api_client):
         """Test mixed MCP and function tools (non-streaming)."""
-        _, model, _, _ = setup_backend
 
         resp = api_client.responses.create(
             model=model,
@@ -797,9 +779,8 @@ class TestToolChoiceHarmony:
         assert "system_name" in args
         assert "astra-7" in args["system_name"].lower()
 
-    def test_mixed_mcp_and_function_tools_streaming(self, setup_backend, api_client):
+    def test_mixed_mcp_and_function_tools_streaming(self, model, api_client):
         """Test mixed MCP and function tools (streaming)."""
-        _, model, _, _ = setup_backend
 
         resp = api_client.responses.create(
             model=model,
@@ -824,9 +805,8 @@ class TestToolChoiceHarmony:
         full_delta_event = "".join(e.delta for e in func_arg_deltas)
         assert "system_name" in full_delta_event.lower() and "astra-7" in full_delta_event.lower()
 
-    def test_mcp_multi_server_tool_call(self, setup_backend, api_client):
+    def test_mcp_multi_server_tool_call(self, model, api_client):
         """Test MCP tool call with multiple MCP servers (non-streaming)."""
-        _, model, _, _ = setup_backend
 
         time.sleep(2)
 
@@ -853,9 +833,8 @@ class TestToolChoiceHarmony:
         for mcp_call in mcp_calls:
             assert mcp_call.server_label == "brave"
 
-    def test_mcp_multi_server_tool_call_streaming(self, setup_backend, api_client):
+    def test_mcp_multi_server_tool_call_streaming(self, model, api_client):
         """Test MCP tool call with multiple MCP servers (streaming)."""
-        _, model, _, _ = setup_backend
 
         time.sleep(2)
 
@@ -912,9 +891,8 @@ class TestToolChoiceHarmony:
 class TestToolChoiceLocal:
     """Tool choice tests against local gRPC backend with Qwen model."""
 
-    def test_tool_choice_auto(self, setup_backend, api_client):
+    def test_tool_choice_auto(self, model, api_client):
         """Test tool_choice="auto" allows model to decide whether to use tools."""
-        _, model, _, _ = setup_backend
 
         tools = [GET_WEATHER_FUNCTION]
 
@@ -935,9 +913,8 @@ class TestToolChoiceLocal:
         function_calls = [item for item in output if item.type == "function_call"]
         assert len(function_calls) > 0
 
-    def test_tool_choice_required(self, setup_backend, api_client):
+    def test_tool_choice_required(self, model, api_client):
         """Test tool_choice="required" forces the model to call at least one tool."""
-        _, model, _, _ = setup_backend
 
         tools = [CALCULATE_FUNCTION]
 
@@ -955,9 +932,8 @@ class TestToolChoiceLocal:
         function_calls = [item for item in resp.output if item.type == "function_call"]
         assert len(function_calls) > 0
 
-    def test_tool_choice_specific_function(self, setup_backend, api_client):
+    def test_tool_choice_specific_function(self, model, api_client):
         """Test tool_choice with specific function name forces that function to be called."""
-        _, model, _, _ = setup_backend
 
         tools = [SEARCH_WEB_FUNCTION, GET_WEATHER_FUNCTION]
 
@@ -976,9 +952,8 @@ class TestToolChoiceLocal:
         assert len(function_calls) > 0
         assert function_calls[0].name == "search_web"
 
-    def test_mcp_basic_tool_call(self, setup_backend, api_client):
+    def test_mcp_basic_tool_call(self, model, api_client):
         """Test basic MCP tool call (non-streaming)."""
-        _, model, _, _ = setup_backend
 
         time.sleep(2)
 
@@ -1000,9 +975,8 @@ class TestToolChoiceLocal:
         mcp_calls = [item for item in resp.output if item.type == "mcp_call"]
         assert len(mcp_calls) > 0
 
-    def test_mcp_basic_tool_call_streaming(self, setup_backend, api_client):
+    def test_mcp_basic_tool_call_streaming(self, model, api_client):
         """Test basic MCP tool call (streaming)."""
-        _, model, _, _ = setup_backend
 
         time.sleep(2)
 
@@ -1021,9 +995,8 @@ class TestToolChoiceLocal:
         assert "response.created" in event_types
         assert "response.completed" in event_types
 
-    def test_tool_choice_with_mcp_tools(self, setup_backend, api_client):
+    def test_tool_choice_with_mcp_tools(self, model, api_client):
         """Test tool_choice parameter works with MCP tools."""
-        _, model, _, _ = setup_backend
 
         tools = [DEEPWIKI_MCP_TOOL]
 
@@ -1045,9 +1018,8 @@ class TestToolChoiceLocal:
         mcp_calls = [item for item in output if item.type == "mcp_call"]
         assert len(mcp_calls) > 0, "tool_choice='auto' should allow MCP tool calls"
 
-    def test_tool_choice_mixed_function_and_mcp(self, setup_backend, api_client):
+    def test_tool_choice_mixed_function_and_mcp(self, model, api_client):
         """Test tool_choice with mixed function and MCP tools."""
-        _, model, _, _ = setup_backend
 
         tools = [DEEPWIKI_MCP_TOOL, LOCAL_SEARCH_FUNCTION]
 
@@ -1070,9 +1042,8 @@ class TestToolChoiceLocal:
         mcp_calls = [item for item in output if item.type == "mcp_call"]
         assert len(mcp_calls) == 0, "Should only call specified function, not MCP tools"
 
-    def test_mixed_mcp_and_function_tools(self, setup_backend, api_client):
+    def test_mixed_mcp_and_function_tools(self, model, api_client):
         """Test mixed MCP and function tools (non-streaming)."""
-        _, model, _, _ = setup_backend
 
         resp = api_client.responses.create(
             model=model,
@@ -1098,9 +1069,8 @@ class TestToolChoiceLocal:
         assert "system_name" in args
         assert "astra-7" in args["system_name"].lower()
 
-    def test_mixed_mcp_and_function_tools_streaming(self, setup_backend, api_client):
+    def test_mixed_mcp_and_function_tools_streaming(self, model, api_client):
         """Test mixed MCP and function tools (streaming)."""
-        _, model, _, _ = setup_backend
 
         resp = api_client.responses.create(
             model=model,
@@ -1125,9 +1095,8 @@ class TestToolChoiceLocal:
         full_delta_event = "".join(e.delta for e in func_arg_deltas)
         assert "system_name" in full_delta_event.lower() and "astra-7" in full_delta_event.lower()
 
-    def test_mcp_multi_server_tool_call(self, setup_backend, api_client):
+    def test_mcp_multi_server_tool_call(self, model, api_client):
         """Test MCP tool call with multiple MCP servers (non-streaming)."""
-        _, model, _, _ = setup_backend
 
         time.sleep(2)
 
@@ -1154,9 +1123,8 @@ class TestToolChoiceLocal:
         for mcp_call in mcp_calls:
             assert mcp_call.server_label == "brave"
 
-    def test_mcp_multi_server_tool_call_streaming(self, setup_backend, api_client):
+    def test_mcp_multi_server_tool_call_streaming(self, model, api_client):
         """Test MCP tool call with multiple MCP servers (streaming)."""
-        _, model, _, _ = setup_backend
 
         time.sleep(2)
 


### PR DESCRIPTION
## Description

### Problem

Every test method that needs the model name has to unpack the 4-tuple from `setup_backend`:

```python
def test_foo(self, setup_backend, api_client):
    _, model, _, _ = setup_backend
```

This is repeated ~130 times across 18 test files. It's verbose, and the fact that both the test and `api_client` reference `setup_backend` makes it look like the backend is initialized twice (it isn't — pytest caches class-scoped fixtures).

Additionally, the `smg` fixture is fully deprecated since PR #812 replaced it with the parametrized `api_client` fixture, but it's still defined in conftest.py.

### Solution

- Add a `model` convenience fixture in `conftest.py` that extracts `model_path` from `setup_backend`
- Replace `setup_backend` with `model` in all test signatures that only need the model name
- Remove the deprecated `smg` fixture

Tests that need other tuple elements (`backend`, `client`, `gateway`) still use `setup_backend` directly.

## Changes

- Add `model` fixture to `e2e_test/conftest.py`
- Remove deprecated `smg` fixture from `e2e_test/conftest.py`
- Update ~130 test methods across 18 files to use `model` fixture instead of unpacking `setup_backend`

## Test Plan

- [ ] CI passes (no behavioral changes — purely mechanical refactor)
- [ ] `pytest --collect-only` confirms all tests are still discovered

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end tests to accept a direct "model" fixture instead of deriving the model from the previous backend fixture; test logic, assertions and behavior remain unchanged.
  * Test fixtures adjusted: removed the older client fixture and introduced a streamlined model fixture used by API tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->