### PR TITLE
fix(client): auto-close streaming responses on iteration exhaustion

### DIFF
--- a/clients/python/smg_client/_streaming.py
+++ b/clients/python/smg_client/_streaming.py
@@ -40,7 +40,11 @@ class SyncStream(Generic[T]):
         return self
 
     def __next__(self) -> T:
-        event = next(self._iterator)
+        try:
+            event = next(self._iterator)
+        except StopIteration:
+            self.close()
+            raise
         return self._model_cls.model_validate_json(event.data)
 
     def __enter__(self) -> SyncStream[T]:
@@ -73,7 +77,11 @@ class AsyncStream(Generic[T]):
         return self
 
     async def __anext__(self) -> T:
-        event = await self._iterator.__anext__()
+        try:
+            event = await self._iterator.__anext__()
+        except StopAsyncIteration:
+            await self.aclose()
+            raise
         return self._model_cls.model_validate_json(event.data)
 
     async def __aenter__(self) -> AsyncStream[T]:
@@ -161,7 +169,11 @@ class ResponsesSyncStream:
         return self
 
     def __next__(self) -> EventObject:
-        event = next(self._iterator)
+        try:
+            event = next(self._iterator)
+        except StopIteration:
+            self.close()
+            raise
         try:
             data = event.json()
         except ValueError as e:
@@ -196,7 +208,11 @@ class ResponsesAsyncStream:
         return self
 
     async def __anext__(self) -> EventObject:
-        event = await self._iterator.__anext__()
+        try:
+            event = await self._iterator.__anext__()
+        except StopAsyncIteration:
+            await self.aclose()
+            raise
         try:
             data = event.json()
         except ValueError as e:
@@ -248,7 +264,11 @@ class AnthropicSyncStream:
         return self
 
     def __next__(self) -> EventObject:
-        event = next(self._iterator)
+        try:
+            event = next(self._iterator)
+        except StopIteration:
+            self.close()
+            raise
         obj = _parse_anthropic_event(event)
         self._accumulate(obj)
         return obj
@@ -386,7 +406,11 @@ class AnthropicAsyncStream:
         return self
 
     async def __anext__(self) -> EventObject:
-        event = await self._iterator.__anext__()
+        try:
+            event = await self._iterator.__anext__()
+        except StopAsyncIteration:
+            await self.aclose()
+            raise
         obj = _parse_anthropic_event(event)
         self._accumulate(obj)
         return obj


### PR DESCRIPTION
## Description

### Problem

SmgClient's streaming classes (`SyncStream`, `AsyncStream`, `ResponsesSyncStream`, `ResponsesAsyncStream`, `AnthropicSyncStream`, `AnthropicAsyncStream`) hold an `httpx.Response` but only release it via `close()` / `__exit__`. When a stream is iterated to exhaustion without a `with` block:

```python
stream = client.chat.completions.create(stream=True, ...)
for chunk in stream:
    ...
# socket leaks — close() never called
```

The underlying `httpx.Response` is never closed, leaking a socket. After enough streaming calls, this causes connection pool exhaustion or FD exhaustion. The OpenAI SDK handles this correctly by auto-closing on exhaustion.

This became a practical concern after PR #812 added SmgClient parametrization to all e2e tests — every streaming test now runs through SmgClient, and many iterate without a `with` block.

### Solution

Catch `StopIteration` / `StopAsyncIteration` in each stream's `__next__` / `__anext__`, call `close()` / `aclose()`, then re-raise. This matches the behavior of the OpenAI SDK and ensures the `httpx.Response` is always released when iteration completes.

## Changes

- Patch `__next__` in `SyncStream`, `ResponsesSyncStream`, `AnthropicSyncStream`
- Patch `__anext__` in `AsyncStream`, `ResponsesAsyncStream`, `AnthropicAsyncStream`

## Test Plan

- [ ] Existing e2e streaming tests pass (these exercise all patched code paths)
- [ ] No socket leak warnings in CI logs after SmgClient parametrized streaming tests

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced stream termination handling in the Python client to ensure proper resource cleanup when streams end.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->