### PR TITLE
fix(pd): abort both PD requests when one side hits a transport error

### DIFF
--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -579,10 +579,29 @@ impl PDRouter {
         }
         .emit();
 
-        let (prefill_result, decode_result) =
-            tokio::join!(prefill_request.send(), decode_request.send());
+        // Send both requests concurrently. Use try_join so that if either side
+        // hits a transport error, the other is cancelled immediately — otherwise
+        // the surviving request hangs waiting for a PD bootstrap that will never
+        // come (see #831).
+        let pd_result = tokio::try_join!(prefill_request.send(), decode_request.send());
 
         events::RequestReceivedEvent {}.emit();
+
+        let (prefill_result, decode_result): (
+            Result<reqwest::Response, reqwest::Error>,
+            Result<reqwest::Response, reqwest::Error>,
+        ) = match pd_result {
+            Ok((prefill_resp, decode_resp)) => (Ok(prefill_resp), Ok(decode_resp)),
+            Err(e) => {
+                error!("PD request transport error, both sides aborted: {e}");
+                // Don't record_outcome here — the caller (execute_dual_dispatch)
+                // records outcomes from the response status after we return.
+                return error::bad_gateway(
+                    "PD disaggregation request failed",
+                    format!("Transport error: {e}"),
+                );
+            }
+        };
 
         // Process decode response
         match decode_result {


### PR DESCRIPTION
## Summary

Fixes PD disaggregation requests hanging forever when one side hits a transport error.

Closes #831

## Problem

`tokio::join!` waits for **both** prefill and decode requests to complete. If prefill fails with a connection reset, the decode request hangs waiting for a PD bootstrap from prefill that will never come — until the bootstrap timeout (default 60s).

## Fix

Replace `tokio::join!` with `tokio::try_join!`. When either request returns `Err` (transport error), `try_join!` drops the other future, cancelling the in-flight request immediately. Both workers are recorded as failed (circuit breaker), and a `502 Bad Gateway` is returned.

## What changed

- **pd_router.rs**: `execute_pd_request_once` uses `tokio::try_join!` instead of `tokio::join!` for the prefill+decode concurrent send. On transport error, returns `bad_gateway` immediately.
- Health check path (`health_generate`) still uses `tokio::join!` — health checks don't involve bootstrap.

## Test plan

- [ ] `cargo check -p smg` passes
- [ ] `cargo clippy -p smg -- -D warnings` passes
- [ ] PD request with one failing worker returns 502 immediately instead of hanging
- [ ] PD request with both workers healthy continues to work normally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Gateway now fails fast on the first transport error when making parallel requests, canceling remaining in-flight work.
  * Transport errors are logged and an explicit error response is returned immediately.
  * Improves responsiveness and reliability during network or connection issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->