### PR TITLE
ci: bump default engine vllm(0.18.0) and trt(1.3.0rc8) versions

### DIFF
--- a/.github/workflows/release-trtllm-docker.yml
+++ b/.github/workflows/release-trtllm-docker.yml
@@ -15,8 +15,8 @@ on:
   workflow_dispatch:
     inputs:
       base_image_ref:
-        description: 'Base image (e.g. nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc7). Empty = build from source.'
-        default: 'nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc7'
+        description: 'Base image (e.g. nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc8). Empty = build from source.'
+        default: 'nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc8'
         required: false
         type: string
       trtllm_repo:
@@ -52,7 +52,7 @@ jobs:
     uses: ./.github/workflows/_build-engine-image.yml
     with:
       engine: trtllm
-      base_image_ref: ${{ inputs.base_image_ref || 'nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc7' }}
+      base_image_ref: ${{ inputs.base_image_ref || 'nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc8' }}
       engine_repo: ${{ inputs.trtllm_repo }}
       engine_commit: ${{ inputs.trtllm_commit || 'latest' }}
       smg_repo: ${{ inputs.smg_repo || 'https://github.com/lightseekorg/smg' }}

--- a/.github/workflows/release-vllm-docker.yml
+++ b/.github/workflows/release-vllm-docker.yml
@@ -15,8 +15,8 @@ on:
   workflow_dispatch:
     inputs:
       base_image_ref:
-        description: 'Base image (e.g. vllm/vllm-openai:v0.17.0)'
-        default: 'vllm/vllm-openai:v0.17.0'
+        description: 'Base image (e.g. vllm/vllm-openai:v0.18.0)'
+        default: 'vllm/vllm-openai:v0.18.0'
         required: true
         type: string
       vllm_repo:
@@ -52,7 +52,7 @@ jobs:
     uses: ./.github/workflows/_build-engine-image.yml
     with:
       engine: vllm
-      base_image_ref: ${{ inputs.base_image_ref || 'vllm/vllm-openai:v0.17.0' }}
+      base_image_ref: ${{ inputs.base_image_ref || 'vllm/vllm-openai:v0.18.0' }}
       engine_repo: ${{ inputs.vllm_repo }}
       engine_commit: ${{ inputs.vllm_commit || 'latest' }}
       smg_repo: ${{ inputs.smg_repo || 'https://github.com/lightseekorg/smg' }}


### PR DESCRIPTION
## Summary

Update default engine versions in docker build workflows:
- **vLLM**: `v0.17.0` → `v0.18.0`
- **TensorRT-LLM**: `1.3.0rc7` → `1.3.0rc8`

## What changed

- `release-vllm-docker.yml`: base image default and description updated to `vllm/vllm-openai:v0.18.0`
- `release-trtllm-docker.yml`: base image default and description updated to `nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc8`

## Test plan

- [ ] Trigger vLLM docker build via workflow_dispatch to verify new default
- [ ] Trigger TRT-LLM docker build via workflow_dispatch to verify new default

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TensorRT-LLM base image reference from version 1.3.0rc7 to 1.3.0rc8
  * Updated vLLM base image reference from version 0.17.0 to 0.18.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->