### PR TITLE
fix(gateway): handle mismatched metric labels in PD disaggregation mode

### DIFF
--- a/model_gateway/src/core/metrics_aggregator.rs
+++ b/model_gateway/src/core/metrics_aggregator.rs
@@ -1,4 +1,3 @@
-use anyhow::ensure;
 use openmetrics_parser::{MetricFamily, MetricsExposition, PrometheusType, PrometheusValue};
 use tracing::warn;
 
@@ -66,14 +65,41 @@ fn merge_exposition(
 }
 
 fn merge_family(a: PrometheusFamily, b: PrometheusFamily) -> anyhow::Result<PrometheusFamily> {
-    ensure!(
-        a.get_label_names() == b.get_label_names(),
-        "Label names should agree a={:?} b={:?}",
-        a.get_label_names(),
-        b.get_label_names()
-    );
+    // When label schemas differ (e.g., prefill vs decode workers with different DP
+    // configs), pad missing labels with empty strings so both families share the
+    // same label set before merging.
+    let (a, b) = align_labels(a, b);
     a.with_samples(b.into_iter_samples())
         .map_err(|e| anyhow::anyhow!("failed to merge samples: {e:?}"))
+}
+
+/// Ensure two families have identical label sets by padding missing labels with `""`.
+/// Returns both families unchanged if labels already match.
+fn align_labels(a: PrometheusFamily, b: PrometheusFamily) -> (PrometheusFamily, PrometheusFamily) {
+    let a_names = a.get_label_names();
+    let b_names = b.get_label_names();
+    if a_names == b_names {
+        return (a, b);
+    }
+
+    let pad = |family: PrometheusFamily, other_names: &[String]| -> PrometheusFamily {
+        let own_names = family.get_label_names();
+        let missing: Vec<(&str, &str)> = other_names
+            .iter()
+            .filter(|n| !own_names.contains(n))
+            .map(|n| (n.as_str(), ""))
+            .collect();
+        if missing.is_empty() {
+            family
+        } else {
+            family.with_labels(missing)
+        }
+    };
+
+    // Clone names before moving families into pad()
+    let a_names = a_names.to_vec();
+    let b_names = b_names.to_vec();
+    (pad(a, &b_names), pad(b, &a_names))
 }
 
 fn try_reduce<I, T, E, F>(iterable: I, f: F) -> Result<Option<T>, E>

--- a/model_gateway/tests/metrics_aggregator_test.rs
+++ b/model_gateway/tests/metrics_aggregator_test.rs
@@ -261,6 +261,47 @@ sglang_prompt_tokens_total{model_name="meta-llama/Llama-3.1-8B-Instruct",source=
     assert_eq_sorted(&result, expected);
 }
 
+#[test]
+fn test_mismatched_labels_pd_mode() {
+    // Simulates PD disaggregation: prefill worker has no dp_rank label,
+    // decode worker has dp_rank. Previously this caused a 500 error.
+    let prefill = MetricPack {
+        labels: vec![("worker_addr".to_string(), "prefill:8000".to_string())],
+        metrics_text: r#"
+# HELP sglang_num_running_reqs The number of running requests
+# TYPE sglang_num_running_reqs gauge
+sglang_num_running_reqs{engine_type="prefill",model_name="kimi",tp_rank="0"} 10
+"#
+        .to_string(),
+    };
+    let decode = MetricPack {
+        labels: vec![("worker_addr".to_string(), "decode:8000".to_string())],
+        metrics_text: r#"
+# HELP sglang_num_running_reqs The number of running requests
+# TYPE sglang_num_running_reqs gauge
+sglang_num_running_reqs{dp_rank="0",engine_type="decode",model_name="kimi",tp_rank="0"} 20
+"#
+        .to_string(),
+    };
+
+    // Should succeed — not return an error
+    let result = aggregate_metrics(vec![prefill, decode]).unwrap();
+
+    // Both workers should appear in the output
+    assert!(result.contains("prefill:8000"), "prefill worker missing");
+    assert!(result.contains("decode:8000"), "decode worker missing");
+    // Prefill sample should get dp_rank="" (padded)
+    assert!(
+        result.contains(r#"dp_rank="""#),
+        "prefill should have empty dp_rank label"
+    );
+    // Decode sample should keep dp_rank="0"
+    assert!(
+        result.contains(r#"dp_rank="0""#),
+        "decode should keep dp_rank=0"
+    );
+}
+
 fn assert_eq_sorted(result: &str, expected: &str) {
     // Split into lines and sort to handle BTreeMap ordering issues between test environments
     let mut result_lines: Vec<_> = result.trim().lines().map(|l| l.trim()).collect();


### PR DESCRIPTION
## Summary

Fix `/engine_metrics` returning 500 when prefill and decode workers have different metric label schemas in PD disaggregation mode.

Closes #805

## What changed

- **`metrics_aggregator.rs`**: Replace the strict `ensure!(a.get_label_names() == b.get_label_names())` check in `merge_family()` with `align_labels()`, which pads missing labels with empty strings so both families share the same label set before merging.
- **`metrics_aggregator_test.rs`**: Add `test_mismatched_labels_pd_mode` that simulates prefill (no `dp_rank`) + decode (with `dp_rank="0"`) and verifies both samples appear correctly in the merged output.

## Why

In PD mode, decode workers with `--enable-dp-attention --dp-size 8` emit metrics with a `dp_rank` label that prefill workers don't have:

```
prefill: sglang_num_running_reqs{engine_type="prefill",model_name="kimi",tp_rank="0"} 10
decode:  sglang_num_running_reqs{dp_rank="0",engine_type="decode",model_name="kimi",tp_rank="0"} 20
```

The old code required exact label name match and failed with:
```
Label names should agree a=["engine_type","model_name","tp_rank","worker_addr"] b=["dp_rank","engine_type","model_name","tp_rank","worker_addr"]
```

## How

`align_labels()` computes the label name difference between two families and pads the missing labels with `""` using `with_labels()` from openmetrics-parser. After alignment, both families have identical label sets and merge normally. The fast path (labels already match) returns immediately with no overhead.

## Test plan

- [x] `cargo test -p smg --test metrics_aggregator_test` — all 6 tests pass (5 existing + 1 new)
- [x] New test covers the exact PD scenario from the issue (prefill without `dp_rank`, decode with `dp_rank="0"`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Improved metrics aggregation to handle metrics with different label structures. Missing labels are now automatically padded, allowing successful merge operations that previously would have failed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->