### PR TITLE
fix(tool-call): skip guided decoding constraint when tool parser is configured (#838)

### DIFF
--- a/e2e_test/chat_completions/test_function_calling.py
+++ b/e2e_test/chat_completions/test_function_calling.py
@@ -1569,6 +1569,52 @@ class TestToolChoiceMistral(_TestToolChoiceBase):
         "test_multi_tool_scenario_required",
     }
 
+    def test_simple_tool_call_required(self, setup_backend, api_client):
+        """Test simple single-tool scenario with tool_choice='required'.
+
+        Regression test for #838: bos_token injection + guided decoding conflict.
+        With bos_token correctly injected, Mistral outputs [TOOL_CALLS] prefix which
+        conflicts with JSON schema guided decoding. This test uses a minimal prompt
+        (single tool, no system message) to reproduce the issue.
+        """
+        _, model, client, _ = setup_backend
+
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Get the current weather for a given location.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "location": {
+                                "type": "string",
+                                "description": "The name of the city.",
+                            }
+                        },
+                        "required": ["location"],
+                    },
+                },
+            }
+        ]
+        messages = [{"role": "user", "content": "What is the weather in Seoul?"}]
+
+        response = client.chat.completions.create(
+            model=model,
+            messages=messages,
+            tools=tools,
+            tool_choice="required",
+            max_tokens=200,
+            temperature=0.2,
+            stream=False,
+        )
+
+        tool_calls = response.choices[0].message.tool_calls
+        assert tool_calls is not None, "Expected tool calls but got None"
+        assert len(tool_calls) > 0, f"Expected at least 1 tool call, got {len(tool_calls)}"
+        assert tool_calls[0].function.name == "get_weather"
+
     @pytest.mark.skip(reason="Fails due to whitespace issue with Mistral - skipping")
     def test_complex_parameters_required_non_streaming(self, setup_backend, api_client):
         """Validate complex nested parameter schemas in non-streaming required mode."""


### PR DESCRIPTION
## Description

### Problem

When `bos_token` is correctly injected into the chat template context (#818), Mistral-7B-Instruct-v0.3's `tool_choice: "required"` tool calling breaks. With `bos_token` present, the model outputs its native `[TOOL_CALLS]` prefix, which conflicts with SMG's JSON schema guided decoding constraint — vLLM's guided decoding forces JSON-only output but the model tries to produce `[TOOL_CALLS]` first, resulting in an unclosed JSON array filled with whitespace.

Tracked in #838 with detailed reproduction steps and test results.

### Solution

When `--tool-call-parser` is configured, skip the JSON schema constraint for `tool_choice: "required"` and let the model output its native tool call format (e.g. Mistral's `[TOOL_CALLS][...]`). The configured tool parser handles parsing instead of guided decoding.

Three changes are needed together:
1. **Skip constraint**: Don't send JSON schema to vLLM when a tool parser will handle parsing
2. **Route to tool parser**: Use the tool parser (not JSON schema parser) for response parsing
3. **Preserve special tokens**: Set `skip_special_tokens=false` in the detokenizer so tokens like `[TOOL_CALLS]` are not stripped before the parser sees them

When `--tool-call-parser` is not set, behavior is unchanged (JSON schema constraint is still used).

## Changes

- `model_gateway/src/routers/grpc/utils/chat_utils.rs`: Add `has_tool_parser` param to `generate_tool_constraints()`. Skip JSON schema for `required` when parser available.
- `model_gateway/src/routers/grpc/context.rs`: Add `has_tool_parser: bool` to `SharedComponents`.
- `model_gateway/src/routers/grpc/router.rs`, `pd_router.rs`: Set `has_tool_parser` from `configured_tool_parser`.
- `model_gateway/src/routers/grpc/regular/stages/chat/preparation.rs`: Pass `has_tool_parser` to constraint generation. Preserve special tokens when tool parser handles parsing.
- `model_gateway/src/routers/grpc/regular/stages/messages/preparation.rs`: Pass `has_tool_parser`.
- `model_gateway/src/routers/grpc/regular/processor.rs`: Route `tool_choice: required` to tool parser instead of JSON schema parser when `tool_parser_available`.
- `model_gateway/src/routers/grpc/regular/streaming.rs`: Same for streaming + Messages API paths.
- `bindings/golang/src/*.rs`: Pass `false` for `has_tool_parser` (no change in behavior).
- `e2e_test/chat_completions/test_function_calling.py`: Add `test_simple_tool_call_required` regression test for #838.

## Test Plan

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] Unit test: `cargo test -p smg --lib -- generate_tool_constraints`
- [x] Manual test with Mistral-7B-Instruct-v0.3 on vLLM gRPC:
  - `tool_choice: required` travel scenario: 10/10 success (main: 10/10)
  - `tool_choice: required` simple scenario: 5/5 success (main: 0/5)
- [ ] CI: `e2e-1gpu-chat (vllm)` — `TestToolChoiceMistral::test_simple_tool_call_required`

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for function calling with required tool selection in the chat completions API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->