### PR TITLE
docs(routing): audit and fix PD disaggregation and cache-aware routing documentation

### DIFF
--- a/docs/concepts/routing/cache-aware.md
+++ b/docs/concepts/routing/cache-aware.md
@@ -291,7 +291,7 @@ The radix tree grows with unique prefixes. Configure based on your memory budget
 | `smg_worker_requests_active` | Active requests per worker | Imbalance >50% |
 | `smg_worker_selection_total` | Worker selection count | - |
 | `smg_router_request_duration_seconds` | End-to-end request latency | - |
-| `smg_router_ttft_seconds` | Time to first token | - |
+| `smg_router_ttft_seconds` | Time to first token (gRPC only) | - |
 
 ### Useful PromQL Queries
 
@@ -310,7 +310,7 @@ avg(smg_worker_requests_active)
 
 <div class="card" markdown>
 
-#### Time to First Token
+#### Time to First Token (gRPC only)
 
 ```promql
 rate(smg_router_ttft_seconds_sum[5m]) /

--- a/docs/concepts/routing/pd-disaggregation.md
+++ b/docs/concepts/routing/pd-disaggregation.md
@@ -360,9 +360,9 @@ Decode is **memory-bandwidth-bound**:
 | Metric | Description |
 |--------|-------------|
 | `smg_worker_requests_active` | Active requests per worker (label: `worker`) |
-| `smg_worker_selection_total` | Worker selection count (label: `worker`) |
+| `smg_worker_selection_total` | Worker selection count (labels: `worker_type`, `connection_mode`, `model`, `policy`) |
 | `smg_router_request_duration_seconds` | End-to-end request duration |
-| `smg_router_ttft_seconds` | Time to first token |
+| `smg_router_ttft_seconds` | Time to first token (gRPC/vLLM only) |
 
 ### Key Performance Indicators
 
@@ -389,10 +389,11 @@ smg_worker_requests_active
 
 <div class="card" markdown>
 
-#### Time to First Token
+#### Time to First Token (gRPC/vLLM only)
 
 ```promql
 # Average TTFT
+# gRPC/vLLM streaming path only; not available for SGLang HTTP PD
 rate(smg_router_ttft_seconds_sum[5m]) /
 rate(smg_router_ttft_seconds_count[5m])
 ```


### PR DESCRIPTION
## Description

### Problem
PD disaggregation and cache-aware routing documentation contained incorrect CLI flags,
a wrong environment variable name, and multiple references to Prometheus metrics that
don't exist in the codebase.

### Solution
Systematic audit of 5 doc files against source code, verifying 62 claims and fixing
10 inaccuracies. Changes reviewed by tech lead agent before submission.

## Changes
- Verified 62 claims across 5 doc files
- Fixed 10 inaccuracies:
  - Prefill workers flag: `--worker-urls` → `--prefill` (repeated per URL) in the per-phase policy CLI example (`model_gateway/src/main.rs:29-44`)
  - Mooncake config: `MOONCAKE_MASTER` → `VLLM_MOONCAKE_BOOTSTRAP_PORT` — the former does not exist anywhere in the codebase (`scripts/launch-pd-workers.sh:265`)
  - Removed 4 non-existent PD metrics from `concepts/routing/pd-disaggregation.md`: `smg_pd_prefill_duration_seconds`, `smg_pd_decode_duration_seconds`, `smg_pd_kv_transfer_duration_seconds`, `smg_pd_pair_selections_total`; replaced with real registered metrics
  - Removed non-existent `smg_worker_max_concurrent` from PromQL Worker Utilization query
  - Removed 3 non-existent cache routing metrics from `concepts/routing/cache-aware.md`: `smg_router_cache_hits_total`, `smg_router_cache_misses_total`, `smg_router_cache_tree_size`; replaced with real registered metrics
  - Updated alert thresholds and PromQL examples to use achievable queries over real metrics
- 38 claims confirmed accurate, 11 uncertain items left unchanged
- Details in `docs/_audit/routing-worker.md`

## Test Plan
- Every metric verified against `model_gateway/src/observability/metrics.rs` — confirmed removed metrics are absent, replacement metrics are registered
- Each fix cites a source code reference (file:line)
- Full audit report at `docs/_audit/routing-worker.md`
- All changes reviewed by tech lead agent before commit
- No source code was modified

<details>
<summary>Checklist</summary>

- [x] Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Completed comprehensive audit of routing configuration documentation with verified accuracy checks
  * Updated cache-aware monitoring guidance with correct instrumentation metrics
  * Corrected CLI configuration examples for disaggregation and multi-phase worker deployment
  * Fixed environment variable specifications for Mooncake KV transfer integration
  * Replaced inaccurate observability metrics with current monitoring data points

<!-- end of auto-generated comment: release notes by coderabbit.ai -->