### PR TITLE
chore(release): bump version to 1.3.3

### DIFF
--- a/.github/workflows/release-sglang-docker.yml
+++ b/.github/workflows/release-sglang-docker.yml
@@ -4,7 +4,7 @@ run-name: >-
   SMG+SGLang |
   base=${{ inputs.base_image_ref || 'lmsysorg/sglang:v0.5.9' }} |
   engine=${{ inputs.sglang_commit || 'latest' }} |
-  smg=${{ inputs.smg_commit || 'v1.3.2' }} |
+  smg=${{ inputs.smg_commit || 'v1.3.3' }} |
   by @${{ github.actor }}
 
 on:
@@ -43,10 +43,10 @@ on:
       smg_commit:
         description: 'SMG commit/ref ("latest" for HEAD)'
         required: false
-        default: 'v1.3.2'
+        default: 'v1.3.3'
         type: string
       tag:
-        description: 'Override image tag (e.g. v1.3.2-sglang-v0.5.9)'
+        description: 'Override image tag (e.g. v1.3.3-sglang-v0.5.9)'
         required: false
         type: string
 
@@ -63,7 +63,7 @@ jobs:
       engine_repo: ${{ inputs.sglang_repo }}
       engine_commit: ${{ inputs.sglang_commit || 'latest' }}
       smg_repo: ${{ inputs.smg_repo || 'https://github.com/lightseekorg/smg' }}
-      smg_commit: ${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.3.2' }}
+      smg_commit: ${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.3.3' }}
       tag: ${{ inputs.tag }}
       dry_run: ${{ github.event_name == 'pull_request' }}
     secrets: inherit

--- a/.github/workflows/release-trtllm-docker.yml
+++ b/.github/workflows/release-trtllm-docker.yml
@@ -36,10 +36,10 @@ on:
       smg_commit:
         description: 'SMG commit/ref ("latest" for HEAD)'
         required: false
-        default: 'v1.3.2'
+        default: 'v1.3.3'
         type: string
       tag:
-        description: 'Override image tag (e.g. v1.3.2-trtllm-1.3.0)'
+        description: 'Override image tag (e.g. v1.3.3-trtllm-1.3.0)'
         required: false
         type: string
 
@@ -56,7 +56,7 @@ jobs:
       engine_repo: ${{ inputs.trtllm_repo }}
       engine_commit: ${{ inputs.trtllm_commit || 'latest' }}
       smg_repo: ${{ inputs.smg_repo || 'https://github.com/lightseekorg/smg' }}
-      smg_commit: ${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.3.2' }}
+      smg_commit: ${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.3.3' }}
       tag: ${{ inputs.tag }}
       source_build_repo: ${{ inputs.trtllm_repo }}
       source_build_ref: ${{ inputs.trtllm_commit || 'latest' }}

--- a/.github/workflows/release-vllm-docker.yml
+++ b/.github/workflows/release-vllm-docker.yml
@@ -36,10 +36,10 @@ on:
       smg_commit:
         description: 'SMG commit/ref ("latest" for HEAD)'
         required: false
-        default: 'v1.3.2'
+        default: 'v1.3.3'
         type: string
       tag:
-        description: 'Override image tag (e.g. v1.3.2-vllm-v0.17.0)'
+        description: 'Override image tag (e.g. v1.3.3-vllm-v0.17.0)'
         required: false
         type: string
 
@@ -56,6 +56,6 @@ jobs:
       engine_repo: ${{ inputs.vllm_repo }}
       engine_commit: ${{ inputs.vllm_commit || 'latest' }}
       smg_repo: ${{ inputs.smg_repo || 'https://github.com/lightseekorg/smg' }}
-      smg_commit: ${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.3.2' }}
+      smg_commit: ${{ github.event_name == 'pull_request' && 'main' || inputs.smg_commit || 'v1.3.3' }}
       tag: ${{ inputs.tag }}
     secrets: inherit

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [workspace.dependencies]
 # Internal workspace crates
-openai-protocol = { version = "1.4.1", path = "crates/protocols" }
+openai-protocol = { version = "1.5.0", path = "crates/protocols" }
 reasoning-parser = { version = "1.2.1", path = "crates/reasoning_parser" }
 tool-parser = { version = "1.1.2", path = "crates/tool_parser" }
 wfaas = { version = "1.0.3", path = "crates/workflow" }
@@ -15,7 +15,7 @@ kv-index = { version = "1.1.0", path = "crates/kv_index" }
 smg-data-connector = { version = "2.1.0", path = "crates/data_connector", package = "data-connector" }
 llm-multimodal = { version = "1.4.0", path = "crates/multimodal" }
 smg-wasm = { version = "1.1.0", path = "crates/wasm", package = "smg-wasm" }
-smg-mesh = { version = "1.2.0", path = "crates/mesh", package = "smg-mesh" }
+smg-mesh = { version = "1.2.1", path = "crates/mesh", package = "smg-mesh" }
 smg-grpc-client = { version = "1.4.0", path = "crates/grpc_client" }
 
 # Shared dependencies

--- a/bindings/golang/Cargo.toml
+++ b/bindings/golang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-golang"
-version = "1.3.2"
+version = "1.3.3"
 edition = "2021"
 
 [lib]

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-python"
-version = "1.3.2"
+version = "1.3.3"
 edition = "2021"
 
 [lib]

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "smg"
-version = "1.3.2"
+version = "1.3.3"
 description = "High-performance Rust-based inference gateway for large-scale LLM deployments"
 authors = [
     {name = "Simo Lin", email = "linsimo.mark@gmail.com"},

--- a/crates/mesh/Cargo.toml
+++ b/crates/mesh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-mesh"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 description = "Mesh gossip protocol and distributed state synchronization for Shepherd Model Gateway"
 license = "Apache-2.0"

--- a/crates/protocols/Cargo.toml
+++ b/crates/protocols/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openai-protocol"
-version = "1.4.1"
+version = "1.5.0"
 edition = "2021"
 description = "OpenAI-compatible API protocol definitions and types"
 license = "Apache-2.0"

--- a/model_gateway/Cargo.toml
+++ b/model_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg"
-version = "1.3.2"
+version = "1.3.3"
 edition = "2021"
 description = "High-performance model-routing gateway for large-scale LLM deployments"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Patch release v1.3.3 — version bumps across all crates and sync targets.

## Version Changes

| Crate | Before | After |
|-------|--------|-------|
| smg (model_gateway) | 1.3.2 | **1.3.3** |
| openai-protocol | 1.4.1 | **1.5.0** |
| smg-mesh | 1.2.0 | **1.2.1** |
| smg-python | 1.3.2 | 1.3.3 |
| smg-golang | 1.3.2 | 1.3.3 |
| pyproject.toml | 1.3.2 | 1.3.3 |
| Docker workflows | v1.3.2 | v1.3.3 |

## Test plan

- [ ] `make check-versions VERSION_OVERRIDE=1.3.3` reports all versions consistent
- [ ] `cargo build --release` succeeds
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped version from 1.3.2 to 1.3.3 across the project.
  * Updated dependency versions: openai-protocol to 1.5.0 and smg-mesh to 1.2.1.
  * Updated release workflow defaults to align with the new version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->