### PR TITLE
fix(ci): fix Docker build UID conflict and split build vs push triggers

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
       - name: Determine version tag
         id: version
@@ -48,6 +48,8 @@ jobs:
         id: should-push
         env:
           EVENT_NAME: ${{ github.event_name }}
+          EVENT_BEFORE: ${{ github.event.before }}
+          EVENT_AFTER: ${{ github.sha }}
         run: |
           PUSH="false"
           # Manual dispatch always pushes
@@ -55,8 +57,10 @@ jobs:
             PUSH="true"
           fi
           # Push event: only push if pyproject.toml changed (version bump)
+          # Uses the full push range (before..after) to catch changes across
+          # multiple commits, not just HEAD~1.
           if [[ "${EVENT_NAME}" == "push" ]]; then
-            if git diff --name-only HEAD~1 HEAD | grep -q 'bindings/python/pyproject.toml'; then
+            if git diff --name-only "${EVENT_BEFORE}" "${EVENT_AFTER}" | grep -q '^bindings/python/pyproject.toml$'; then
               PUSH="true"
             fi
           fi

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -78,7 +78,7 @@ RUN rm -rf /root/.cache dist/ \
 # Run as non-root user (SMG only binds to unprivileged ports 30000/29000)
 # UID 65532 follows the nonroot convention used by distroless images.
 # UID 1000 is already taken by the 'ubuntu' user in ubuntu:24.04.
-RUN useradd --no-log-init --create-home --uid 65532 smg
+RUN useradd --system --no-log-init --create-home --uid 65532 smg
 USER smg
 
 # Set the entrypoint to the main command


### PR DESCRIPTION
## Description

### Problem
Two issues with the Docker build workflow:

1. **UID conflict**: PR #863 added `useradd --uid 1000 smg` but Ubuntu 24.04 already has a user (`ubuntu`) at UID 1000, causing the build to fail with `useradd: UID 1000 is not unique` ([failed run](https://github.com/lightseekorg/smg/actions/runs/23391968744/job/68048080349))

2. **Unwanted pushes**: The workflow triggered on both `docker/Dockerfile` and `bindings/python/pyproject.toml` changes, pushing to Docker Hub in both cases. Dockerfile maintenance (formatting, comments, non-root user) should not publish a new image — only version bumps should.

### Solution

1. **Dockerfile**: Use UID 65532 (the `nonroot` convention from distroless images) instead of 1000
2. **Workflow**: Add a `should-push` step that checks whether `pyproject.toml` actually changed. Dockerfile-only changes still trigger the workflow (to test the build), but `push` is set to `false`. Manual dispatch always pushes.

## Changes

- `docker/Dockerfile`: `--uid 1000` → `--uid 65532`, added `--no-log-init` flag, added comment explaining the UID choice
- `.github/workflows/release-docker.yml`:
  - Added `fetch-depth: 2` for `HEAD~1` diff
  - New `should-push` step: checks if `pyproject.toml` changed or if manual dispatch
  - Docker Hub login only when pushing
  - `push:` is now dynamic (`true`/`false`) based on the check
  - Used `env:` variables instead of inline `${{ }}` in `run:` blocks

## Test Plan

| Trigger | Build | Push | Correct? |
|---------|-------|------|----------|
| Dockerfile change on main | Yes | No | Yes — test only |
| pyproject.toml change on main | Yes | Yes | Yes — release |
| Both change on main | Yes | Yes | Yes — release |
| Manual dispatch | Yes | Yes | Yes — explicit |

<details>
<summary>Checklist</summary>

- [x] Docker build fixed (UID conflict resolved)
- [x] Workflow logic updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release workflow now always builds Docker images but only logs in and pushes when appropriate (based on event type and detected changes), reducing unnecessary pushes.
  * Checkout now fetches full history to support accurate change detection.
  * Docker container runtime user modified to a system non-root account for improved security compliance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->