### PR TITLE
fix(ci): pause minimax nightly bench and add HF token for H200 node

### DIFF
--- a/.github/workflows/nightly-benchmark.yml
+++ b/.github/workflows/nightly-benchmark.yml
@@ -345,7 +345,8 @@ jobs:
       matrix:
         model:
           - { id: meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8, slug: meta-llama-Llama-4-Maverick-17B-128E-Instruct-FP8, test_class: TestNightlyLlama4MaverickSingle }
-          - { id: minimaxai/minimax-m2, slug: minimaxai-minimax-m2, test_class: TestNightlyMinimaxM2Single }
+          # Pausing MiniMax M2 nightly benchmark
+          # - { id: minimaxai/minimax-m2, slug: minimaxai-minimax-m2, test_class: TestNightlyMinimaxM2Single }
         variant:
           - { id: sglang, runtime: sglang, grpc_only: "false", setup_vllm: false, setup_trtllm: false, extra_deps: "genai-bench" }
           - { id: vllm,   runtime: vllm,   grpc_only: "false", setup_vllm: true, setup_trtllm: false, extra_deps: "genai-bench" }
@@ -418,6 +419,8 @@ jobs:
           GPU_TYPE: H200
           E2E_NIGHTLY: "1"
           E2E_LOG_DIR: nightly_gateway_logs
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          HF_HOME: /raid/models
         run: |
           mkdir -p nightly_gateway_logs
           bash scripts/ci_killall_sglang.sh "nuk_gpus"


### PR DESCRIPTION
## Summary
- Pause MiniMax M2 model from nightly benchmark matrix
- Add `HF_TOKEN` and `HF_HOME` env vars for H200 node benchmark jobs

## Test plan
- [ ] Verify nightly benchmark workflow runs successfully without MiniMax M2
- [ ] Verify H200 node jobs can access HF models with the token

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled MiniMax M2 from the single-worker H200 benchmark job matrix.
  * Configured Hugging Face credentials in the nightly benchmark workflow to support model access and caching during benchmark runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->