### PR TITLE
feat(grpc): add model metadata fields to vLLM GetModelInfo RPC

### DIFF
--- a/crates/grpc_client/proto/vllm_engine.proto
+++ b/crates/grpc_client/proto/vllm_engine.proto
@@ -296,6 +296,13 @@ message GetModelInfoResponse {
   uint32 vocab_size = 4;
   bool supports_vision = 5;
   string served_model_name = 6;
+  string tokenizer_path = 7;
+  string model_type = 8;
+  repeated string architectures = 9;
+  repeated int32 eos_token_ids = 10;
+  int32 pad_token_id = 11;
+  int32 bos_token_id = 12;
+  int32 max_req_input_len = 13;
 }
 
 message GetServerInfoRequest {}

--- a/grpc_servicer/smg_grpc_servicer/vllm/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/vllm/servicer.py
@@ -264,6 +264,16 @@ class VllmEngineServicer(vllm_engine_pb2_grpc.VllmEngineServicer):
             GetModelInfoResponse protobuf
         """
         model_config = self.async_llm.model_config
+        hf_config = model_config.hf_config
+
+        # eos_token_id can be int or list[int]
+        eos = getattr(hf_config, "eos_token_id", None)
+        if isinstance(eos, int):
+            eos_token_ids = [eos]
+        elif isinstance(eos, list):
+            eos_token_ids = eos
+        else:
+            eos_token_ids = []
 
         return vllm_engine_pb2.GetModelInfoResponse(
             model_path=model_config.model,
@@ -272,6 +282,13 @@ class VllmEngineServicer(vllm_engine_pb2_grpc.VllmEngineServicer):
             vocab_size=model_config.get_vocab_size(),
             supports_vision=model_config.is_multimodal_model,
             served_model_name=model_config.served_model_name or model_config.model,
+            tokenizer_path=model_config.tokenizer or "",
+            model_type=getattr(hf_config, "model_type", "") or "",
+            architectures=model_config.architectures or [],
+            eos_token_ids=eos_token_ids,
+            pad_token_id=getattr(hf_config, "pad_token_id", None) or 0,
+            bos_token_id=getattr(hf_config, "bos_token_id", None) or 0,
+            max_req_input_len=model_config.max_model_len,
         )
 
     async def GetServerInfo(


### PR DESCRIPTION
## Description

### Problem
vLLM gRPC workers return only 6 fields in `GetModelInfo` (model_path, is_generation, max_context_length, vocab_size, supports_vision, served_model_name) while SGLang returns 15 fields. This causes missing worker metadata for vLLM backends — no tokenizer path, no architecture info, no token IDs.

### Solution
Add 7 fields to the vLLM `GetModelInfoResponse` proto and populate them from `model_config` and `hf_config` in the servicer. vLLM has no HTTP endpoint for detailed model metadata, so the engine object is the only source.

## Changes

- `crates/grpc_client/proto/vllm_engine.proto`: Added fields 7-13 to `GetModelInfoResponse`
  - `tokenizer_path` (7) — from `model_config.tokenizer`
  - `model_type` (8) — from `hf_config.model_type`
  - `architectures` (9) — from `model_config.architectures`
  - `eos_token_ids` (10) — from `hf_config.eos_token_id` (handles int or list)
  - `pad_token_id` (11) — from `hf_config.pad_token_id`
  - `bos_token_id` (12) — from `hf_config.bos_token_id`
  - `max_req_input_len` (13) — from `model_config.max_model_len`

- `grpc_servicer/smg_grpc_servicer/vllm/servicer.py`: Populate all new fields in `GetModelInfo`

## Test Plan

- Proto is backward-compatible (new fields only, no renumbering)
- Rust side auto-propagates via `flat_labels` serde — no gateway code changes needed
- Needs GPU test with vLLM backend to verify field values

<details>
<summary>Checklist</summary>

- [x] Proto updated
- [x] Servicer updated
- [ ] GPU test with vLLM backend
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Model information API now provides expanded metadata including tokenizer location, model type classification, supported architectures, special token configurations (EOS, PAD, BOS), and maximum input sequence length constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->