### PR TITLE
feat(grpc): add model metadata fields to vLLM GetModelInfo RPC

### DIFF
--- a/crates/grpc_client/proto/vllm_engine.proto
+++ b/crates/grpc_client/proto/vllm_engine.proto
@@ -296,6 +296,13 @@ message GetModelInfoResponse {
   uint32 vocab_size = 4;
   bool supports_vision = 5;
   string served_model_name = 6;
+  string tokenizer_path = 7;
+  string model_type = 8;
+  repeated string architectures = 9;
+  repeated int32 eos_token_ids = 10;
+  int32 pad_token_id = 11;
+  int32 bos_token_id = 12;
+  int32 max_req_input_len = 13;
 }
 
 message GetServerInfoRequest {}

--- a/grpc_servicer/smg_grpc_servicer/vllm/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/vllm/servicer.py
@@ -264,6 +264,16 @@ class VllmEngineServicer(vllm_engine_pb2_grpc.VllmEngineServicer):
             GetModelInfoResponse protobuf
         """
         model_config = self.async_llm.model_config
+        hf_config = model_config.hf_config
+
+        # eos_token_id can be int or list[int]
+        eos = getattr(hf_config, "eos_token_id", None)
+        if isinstance(eos, int):
+            eos_token_ids = [eos]
+        elif isinstance(eos, list):
+            eos_token_ids = eos
+        else:
+            eos_token_ids = []
 
         return vllm_engine_pb2.GetModelInfoResponse(
             model_path=model_config.model,
@@ -272,6 +282,13 @@ class VllmEngineServicer(vllm_engine_pb2_grpc.VllmEngineServicer):
             vocab_size=model_config.get_vocab_size(),
             supports_vision=model_config.is_multimodal_model,
             served_model_name=model_config.served_model_name or model_config.model,
+            tokenizer_path=model_config.tokenizer or "",
+            model_type=getattr(hf_config, "model_type", "") or "",
+            architectures=model_config.architectures or [],
+            eos_token_ids=eos_token_ids,
+            pad_token_id=getattr(hf_config, "pad_token_id", None) or 0,
+            bos_token_id=getattr(hf_config, "bos_token_id", None) or 0,
+            max_req_input_len=model_config.max_model_len,
         )
 
     async def GetServerInfo(


### PR DESCRIPTION
## Description

vLLM gRPC workers return only 6 fields in `GetModelInfo` while SGLang returns 15. This adds 7 missing fields so the gateway has full worker metadata for vLLM backends.

## Changes

- `crates/grpc_client/proto/vllm_engine.proto`: Added fields 7-13 to `GetModelInfoResponse` — tokenizer_path, model_type, architectures, eos_token_ids, pad_token_id, bos_token_id, max_req_input_len
- `grpc_servicer/smg_grpc_servicer/vllm/servicer.py`: Populate from `model_config` and `hf_config`

## Test Plan

- Proto backward-compatible (additive only)
- Needs GPU test with vLLM backend

<details>
<summary>Checklist</summary>

- [x] Proto updated
- [x] Servicer updated
- [ ] GPU test with vLLM backend
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Model information queries now return expanded metadata including tokenizer configuration, model architecture details, and token specifications, providing greater visibility into deployed model characteristics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->