### PR TITLE
fix(docker): install grpc packages from local source instead of PyPI

### DIFF
--- a/docker/engine.Dockerfile
+++ b/docker/engine.Dockerfile
@@ -66,7 +66,7 @@ RUN case "${ENGINE}" in \
          bash /tmp/scripts/install-${ENGINE}.sh /opt/engine-src; \
        fi \
     && if [ "${ENGINE}" = "vllm" ]; then \
-         pip install --no-cache-dir smg-grpc-proto "smg-grpc-servicer[vllm]"; \
+         pip install --no-cache-dir /opt/smg-src/crates/grpc_client/python "/opt/smg-src/grpc_servicer[vllm]"; \
        fi
 
 ENTRYPOINT ["smg"]


### PR DESCRIPTION
## Description

### Problem
The engine Dockerfile `pip install smg-grpc-proto "smg-grpc-servicer[vllm]"` from PyPI, but Docker layer caching served stale packages even after new versions were published. Freshly built images contained old proto/servicer versions (0.4.3/0.5.0 instead of 0.4.4/0.5.1).

### Solution
Install from `/opt/smg-src/` (already cloned in the sources stage) instead of PyPI. The packages always match the SMG commit being built, and the `COPY` layer invalidation naturally busts the cache when source code changes.

## Changes

- `docker/engine.Dockerfile`: Changed `pip install smg-grpc-proto "smg-grpc-servicer[vllm]"` to install from local paths `/opt/smg-src/crates/grpc_client/python` and `/opt/smg-src/grpc_servicer`

## Test Plan

- After merge, trigger vLLM docker build and verify `pip freeze` shows latest proto/servicer versions

<details>
<summary>Checklist</summary>

- [x] Dockerfile updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>