### PR TITLE
fix(ci): disable Docker layer cache for engine image builds

### DIFF
--- a/.github/workflows/_build-engine-image.yml
+++ b/.github/workflows/_build-engine-image.yml
@@ -218,6 +218,7 @@ jobs:
           file: docker/engine.Dockerfile
           push: false
           load: true
+          no-cache: true
           build-args: |
             BASE_IMAGE_REF=${{ steps.resolve.outputs.base_image_ref }}
             ENGINE=${{ inputs.engine }}


### PR DESCRIPTION
## Description

Engine docker builds were serving stale pip install layers from Docker cache, causing images to contain old smg-grpc-proto/servicer versions even after new releases.

## Changes

- `.github/workflows/_build-engine-image.yml`: Add `no-cache: true` to the docker build step

## Test Plan

- After merge, trigger vLLM docker build and verify `pip freeze` shows latest packages

<details>
<summary>Checklist</summary>

- [x] Workflow updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

No end-user-visible changes in this release. This update modifies internal build infrastructure only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->