### PR TITLE
refactor(grpc): remove redundant harmony_stop_ids from build_generate_request_from_responses

### DIFF
--- a/crates/grpc_client/src/sglang_scheduler.rs
+++ b/crates/grpc_client/src/sglang_scheduler.rs
@@ -409,17 +409,10 @@ impl SglangSchedulerClient {
         body: &ResponsesRequest,
         processed_text: String,
         token_ids: Vec<u32>,
-        harmony_stop_ids: Option<Vec<u32>>,
         constraint: Option<(String, String)>,
     ) -> Result<proto::GenerateRequest, String> {
         // Build sampling params from ResponsesRequest
-        let mut sampling_params =
-            Self::build_grpc_sampling_params_from_responses(body, constraint)?;
-
-        // Inject Harmony stop token IDs if provided
-        if let Some(stop_ids) = harmony_stop_ids {
-            sampling_params.stop_token_ids = stop_ids;
-        }
+        let sampling_params = Self::build_grpc_sampling_params_from_responses(body, constraint)?;
 
         let grpc_request = proto::GenerateRequest {
             request_id,

--- a/crates/grpc_client/src/trtllm_service.rs
+++ b/crates/grpc_client/src/trtllm_service.rs
@@ -410,7 +410,6 @@ impl TrtllmServiceClient {
         body: &ResponsesRequest,
         processed_text: String,
         token_ids: Vec<u32>,
-        _harmony_stop_ids: Option<Vec<u32>>,
         constraint: Option<(String, String)>,
     ) -> Result<proto::GenerateRequest, String> {
         let sampling_config = Self::build_sampling_config_from_responses(body);

--- a/crates/grpc_client/src/vllm_engine.rs
+++ b/crates/grpc_client/src/vllm_engine.rs
@@ -340,17 +340,10 @@ impl VllmEngineClient {
         body: &ResponsesRequest,
         processed_text: String,
         token_ids: Vec<u32>,
-        harmony_stop_ids: Option<Vec<u32>>,
         constraint: Option<(String, String)>,
     ) -> Result<proto::GenerateRequest, String> {
         // Build sampling params from ResponsesRequest
-        let mut sampling_params =
-            Self::build_grpc_sampling_params_from_responses(body, constraint)?;
-
-        // Inject Harmony stop token IDs if provided
-        if let Some(stop_ids) = harmony_stop_ids {
-            sampling_params.stop_token_ids = stop_ids;
-        }
+        let sampling_params = Self::build_grpc_sampling_params_from_responses(body, constraint)?;
 
         let grpc_request = proto::GenerateRequest {
             request_id,

--- a/model_gateway/src/routers/grpc/harmony/stages/request_building.rs
+++ b/model_gateway/src/routers/grpc/harmony/stages/request_building.rs
@@ -107,7 +107,6 @@ impl PipelineStage for HarmonyRequestBuildingStage {
                             request.as_ref(),
                             placeholder_processed_text,
                             prep.token_ids.clone(),
-                            prep.harmony_stop_ids.clone(),
                             prep.tool_constraints.clone(),
                         )
                         .map_err(|e| {
@@ -153,7 +152,6 @@ impl PipelineStage for HarmonyRequestBuildingStage {
                             request.as_ref(),
                             placeholder_processed_text,
                             prep.token_ids.clone(),
-                            prep.harmony_stop_ids.clone(),
                             prep.tool_constraints.clone(),
                         )
                         .map_err(|e| {
@@ -199,7 +197,6 @@ impl PipelineStage for HarmonyRequestBuildingStage {
                             request.as_ref(),
                             placeholder_processed_text,
                             prep.token_ids.clone(),
-                            prep.harmony_stop_ids.clone(),
                             prep.tool_constraints.clone(),
                         )
                         .map_err(|e| {


### PR DESCRIPTION
## Description

### Problem

`harmony_stop_ids` was passed to `build_generate_request_from_responses` in all three engine implementations (sglang, vllm, trtllm), where it was set on the request's stop token IDs. However, `HarmonyRequestBuildingStage` already injects the same IDs via `extend_from_slice` **after** the request is built — resulting in duplicated stop IDs for sglang/vllm, and the parameter being ignored entirely for trtllm (`_harmony_stop_ids`).

### Solution

Remove the `harmony_stop_ids` parameter from all three `build_generate_request_from_responses` methods and their call sites. `HarmonyRequestBuildingStage` is now the single source of truth for harmony stop token injection via `extend_from_slice`, which correctly preserves any existing stop tokens.

## Changes

- `crates/grpc_client/src/sglang_scheduler.rs` — remove `harmony_stop_ids` param and injection
- `crates/grpc_client/src/vllm_engine.rs` — remove `harmony_stop_ids` param and injection
- `crates/grpc_client/src/trtllm_service.rs` — remove unused `_harmony_stop_ids` param
- `model_gateway/src/routers/grpc/harmony/stages/request_building.rs` — remove `harmony_stop_ids` from all 3 call sites

## Test Plan

No behavior change — stop tokens are still injected by `HarmonyRequestBuildingStage` for all backends.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved handling of stop token ID injection across gRPC service clients by consolidating where these values are applied in the request pipeline, resulting in cleaner separation of concerns and simplified method signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->