### PR TITLE
feat(http-router): use per-model retry config from WorkerRegistry

### DIFF
--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -211,13 +211,13 @@ impl Router {
         );
 
         // Use per-model retry config if set by a worker, otherwise fall back to router default.
-        let retry_config = self
-            .worker_registry
-            .get_retry_config(model_id)
-            .unwrap_or_else(|| self.retry_config.clone());
+        let per_model_retry_config = self.worker_registry.get_retry_config(model_id);
+        let retry_config = per_model_retry_config
+            .as_ref()
+            .unwrap_or(&self.retry_config);
 
         let response = RetryExecutor::execute_response_with_retry(
-            &retry_config,
+            retry_config,
             // operation per attempt
             |_: u32| async {
                 let res = self


### PR DESCRIPTION
## Description

Part of the per-worker resilience refactor series: #799 → #803 → #821 → #836 → #875 → **this PR**.

### Problem

HTTP router uses a single global `retry_config` from `RouterConfig` for all requests, ignoring per-model retry config set by workers via `WorkerSpec.resilience`.

### Solution

Look up per-model retry config from `WorkerRegistry` at request time, falling back to the router-level default if no worker group override exists.

```rust
let retry_config = self
    .worker_registry
    .get_retry_config(model_id)
    .unwrap_or_else(|| self.retry_config.clone());
```

This is the first router migrated. Other routers (gRPC, OpenAI, Gemini, PD) will follow in subsequent PRs.

## Changes

- `route_typed_request()` in HTTP router now reads retry config from `WorkerRegistry` per model ID

## Test Plan

- `cargo test -p smg --lib` — all 439 tests pass, 0 failures
- Pre-commit hooks pass (rustfmt, clippy, codespell, DCO)
- Backwards compatible: workers without resilience overrides use the same router default as before

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: raw summary by coderabbit.ai -->
<!-- end of auto-generated comment: raw summary by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retry behavior can be customized per model so individual models can use their own retry settings.
  * Per-request/model retry configuration is applied automatically when available.
  * If a model-specific setting is not present, the system falls back to the global retry configuration to preserve consistent handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

<!-- This is an auto-generated comment: summary by coderabbit.ai -->
<!-- end of auto-generated comment: summary by coderabbit.ai -->