### PR TITLE
fix(deps): pin unicode-segmentation <1.12 in WASM guest crates

### DIFF
--- a/examples/wasm/wasm-guest-storage-hook-passthrough/Cargo.toml
+++ b/examples/wasm/wasm-guest-storage-hook-passthrough/Cargo.toml
@@ -10,3 +10,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 wit-bindgen = { version = "0.21", features = ["macros"] }
+# Pin to avoid heck 0.4.1 breakage with unicode-segmentation 1.12.0
+unicode-segmentation = ">=1.10, <1.12"

--- a/examples/wasm/wasm-guest-storage-hook/Cargo.toml
+++ b/examples/wasm/wasm-guest-storage-hook/Cargo.toml
@@ -10,3 +10,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 wit-bindgen = { version = "0.21", features = ["macros"] }
+# Pin to avoid heck 0.4.1 breakage with unicode-segmentation 1.12.0
+unicode-segmentation = ">=1.10, <1.12"


### PR DESCRIPTION
## Description

### Problem
All CI jobs are failing because `unicode-segmentation` 1.12.0 made `UnicodeWords` struct private, breaking `heck` 0.4.1 (used transitively by `wit-bindgen` 0.21):

```
error[E0603]: struct `UnicodeWords` is private
  --> heck-0.4.1/src/lib.rs:69:51
```

### Solution
Pin `unicode-segmentation` to `>=1.10, <1.12` in the two affected WASM guest crates until `wit-bindgen` upgrades to `heck` 0.5+.

## Changes
- `examples/wasm/wasm-guest-storage-hook/Cargo.toml` — add `unicode-segmentation` version constraint
- `examples/wasm/wasm-guest-storage-hook-passthrough/Cargo.toml` — same

## Test Plan
- CI should pass again once this merges

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependencies in WebAssembly example projects to resolve compatibility issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->