### PR TITLE
feat(tool_parser): add DeepSeek V3.1 tool call parser

### DIFF
--- a/crates/tool_parser/src/factory.rs
+++ b/crates/tool_parser/src/factory.rs
@@ -7,9 +7,9 @@ use tokio::sync::Mutex;
 
 use crate::{
     parsers::{
-        CohereParser, DeepSeekParser, Glm4MoeParser, JsonParser, KimiK2Parser, LlamaParser,
-        MinimaxM2Parser, MistralParser, PassthroughParser, PythonicParser, QwenCoderParser,
-        QwenParser, Step3Parser,
+        CohereParser, DeepSeekParser, DeepSeekV31Parser, DeepSeekV32Parser, Glm4MoeParser,
+        JsonParser, KimiK2Parser, LlamaParser, MinimaxM2Parser, MistralParser,
+        PassthroughParser, PythonicParser, QwenCoderParser, QwenParser, Step3Parser,
     },
     traits::ToolParser,
 };
@@ -239,6 +239,8 @@ impl ParserFactory {
         registry.register_parser("pythonic", || Box::new(PythonicParser::new()));
         registry.register_parser("llama", || Box::new(LlamaParser::new()));
         registry.register_parser("deepseek", || Box::new(DeepSeekParser::new()));
+        registry.register_parser("deepseek_v31", || Box::new(DeepSeekV31Parser::new()));
+        registry.register_parser("deepseek_v32", || Box::new(DeepSeekV32Parser::new()));
         registry.register_parser("glm45_moe", || Box::new(Glm4MoeParser::glm45()));
         registry.register_parser("glm47_moe", || Box::new(Glm4MoeParser::glm47()));
         registry.register_parser("step3", || Box::new(Step3Parser::new()));
@@ -285,7 +287,11 @@ impl ParserFactory {
         registry.map_model("llama-*", "json");
         registry.map_model("meta-llama-*", "json");
 
-        // DeepSeek models
+        // DeepSeek models (V3.2 before V3.1 before V3 — more specific patterns first)
+        registry.map_model("deepseek-v3.2*", "deepseek_v32");
+        registry.map_model("deepseek-ai/DeepSeek-V3.2*", "deepseek_v32");
+        registry.map_model("deepseek-v3.1*", "deepseek_v31");
+        registry.map_model("deepseek-ai/DeepSeek-V3.1*", "deepseek_v31");
         registry.map_model("deepseek-v3*", "deepseek");
         registry.map_model("deepseek-ai/DeepSeek-V3*", "deepseek");
         registry.map_model("deepseek-*", "pythonic");

--- a/crates/tool_parser/src/lib.rs
+++ b/crates/tool_parser/src/lib.rs
@@ -17,8 +17,9 @@ mod tests;
 // Re-export types used outside this module
 pub use factory::{ParserFactory, PooledParser};
 pub use parsers::{
-    CohereParser, DeepSeekParser, Glm4MoeParser, JsonParser, KimiK2Parser, LlamaParser,
-    MinimaxM2Parser, MistralParser, PythonicParser, QwenParser, Step3Parser,
+    CohereParser, DeepSeekParser, DeepSeekV31Parser, DeepSeekV32Parser, Glm4MoeParser, JsonParser,
+    KimiK2Parser, LlamaParser, MinimaxM2Parser, MistralParser, PythonicParser, QwenParser,
+    Step3Parser,
 };
 pub use traits::ToolParser;
 pub use types::{FunctionCall, PartialToolCall, StreamingParseResult, ToolCall};

--- a/crates/tool_parser/src/parsers/deepseek_v31.rs
+++ b/crates/tool_parser/src/parsers/deepseek_v31.rs
@@ -1,0 +1,336 @@
+use async_trait::async_trait;
+use openai_protocol::common::Tool;
+use regex::Regex;
+use serde_json::Value;
+
+use crate::{
+    errors::{ParserError, ParserResult},
+    parsers::helpers,
+    traits::ToolParser,
+    types::{FunctionCall, StreamingParseResult, ToolCall, ToolCallItem},
+};
+
+/// DeepSeek V3.1 format parser for tool calls
+///
+/// Handles the DeepSeek V3.1 specific format that uses Unicode tokens with raw JSON
+/// (no code fence, no type field):
+/// `<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location": "Tokyo"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>`
+///
+/// Key differences from V3:
+/// - No `function` type prefix before the tool name
+/// - No code fence (````json ... ````) around JSON arguments
+/// - Raw JSON arguments directly after `<｜tool▁sep｜>`
+///
+/// Features:
+/// - Unicode token delimiters (same as V3)
+/// - Raw JSON arguments (no code blocks)
+/// - Support for multiple sequential tool calls
+pub struct DeepSeekV31Parser {
+    /// Regex for extracting complete tool calls
+    tool_call_extractor: Regex,
+    /// Regex for extracting function details (name + raw JSON args)
+    func_detail_extractor: Regex,
+    /// Regex for matching partial tool calls during streaming
+    partial_tool_call_regex: Regex,
+    /// Regex pattern for removing completed tool calls from buffer
+    tool_call_end_pattern: Regex,
+
+    /// Buffer for accumulating incomplete patterns across chunks
+    buffer: String,
+
+    /// Stores complete tool call info (name and arguments) for each tool being parsed
+    prev_tool_call_arr: Vec<Value>,
+
+    /// Index of currently streaming tool call (-1 means no active tool)
+    current_tool_id: i32,
+
+    /// Flag for whether current tool's name has been sent to client
+    current_tool_name_sent: bool,
+
+    /// Tracks raw JSON string content streamed to client for each tool's arguments
+    streamed_args_for_tool: Vec<String>,
+}
+
+impl DeepSeekV31Parser {
+    /// Create a new DeepSeek V3.1 parser
+    #[expect(
+        clippy::expect_used,
+        reason = "regex patterns are compile-time string literals"
+    )]
+    pub fn new() -> Self {
+        // Use (?s) flag for DOTALL mode to handle newlines in JSON
+        let tool_call_pattern = r"(?s)<｜tool▁call▁begin｜>.*?<｜tool▁call▁end｜>";
+        let tool_call_extractor = Regex::new(tool_call_pattern).expect("Valid regex pattern");
+
+        // V3.1: 2 capture groups (name, raw JSON) — no type field, no code fence
+        let func_detail_pattern =
+            r"(?s)<｜tool▁call▁begin｜>(.*?)<｜tool▁sep｜>(.*?)<｜tool▁call▁end｜>";
+        let func_detail_extractor = Regex::new(func_detail_pattern).expect("Valid regex pattern");
+
+        // Partial pattern for streaming - uses .* (greedy) not .*? to match all partial content
+        // V3.1: 2 capture groups (name, partial raw JSON) — no type field, no code fence
+        let partial_pattern = r"(?s)<｜tool▁call▁begin｜>(.*)<｜tool▁sep｜>(.*)";
+        let partial_tool_call_regex = Regex::new(partial_pattern).expect("Valid regex pattern");
+
+        // Pattern for removing completed tool calls
+        let end_pattern = r"(?s)<｜tool▁call▁begin｜>.*?<｜tool▁call▁end｜>";
+        let tool_call_end_pattern = Regex::new(end_pattern).expect("Valid regex pattern");
+
+        Self {
+            tool_call_extractor,
+            func_detail_extractor,
+            partial_tool_call_regex,
+            tool_call_end_pattern,
+            buffer: String::new(),
+            prev_tool_call_arr: Vec::new(),
+            current_tool_id: -1,
+            current_tool_name_sent: false,
+            streamed_args_for_tool: Vec::new(),
+        }
+    }
+
+    /// Parse a single tool call block - throws error if parsing fails
+    ///
+    /// V3.1 format: `<｜tool▁call▁begin｜>{name}<｜tool▁sep｜>{raw_json}<｜tool▁call▁end｜>`
+    /// Group 1 = function name (no type validation needed)
+    /// Group 2 = raw JSON arguments
+    fn parse_tool_call(&self, block: &str) -> ParserResult<ToolCall> {
+        let captures = self.func_detail_extractor.captures(block).ok_or_else(|| {
+            ParserError::ParsingFailed("Failed to match tool call pattern".to_string())
+        })?;
+
+        // Group 1: function name (V3.1 has no type field)
+        let func_name = captures.get(1).map_or("", |m| m.as_str()).trim();
+        if func_name.is_empty() {
+            return Err(ParserError::ParsingFailed(
+                "Empty function name".to_string(),
+            ));
+        }
+
+        // Group 2: raw JSON arguments (no code fence in V3.1)
+        let json_args = captures.get(2).map_or("{}", |m| m.as_str()).trim();
+
+        // Parse JSON arguments
+        let value = serde_json::from_str::<Value>(json_args)
+            .map_err(|e| ParserError::ParsingFailed(format!("Invalid JSON: {e}")))?;
+
+        // Create arguments object
+        let args = if value.is_object() {
+            value
+        } else {
+            // If not an object, wrap it
+            serde_json::json!({ "value": value })
+        };
+
+        let arguments =
+            serde_json::to_string(&args).map_err(|e| ParserError::ParsingFailed(e.to_string()))?;
+
+        Ok(ToolCall {
+            function: FunctionCall {
+                name: func_name.to_string(),
+                arguments,
+            },
+        })
+    }
+}
+
+impl Default for DeepSeekV31Parser {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ToolParser for DeepSeekV31Parser {
+    async fn parse_complete(&self, text: &str) -> ParserResult<(String, Vec<ToolCall>)> {
+        if !self.has_tool_markers(text) {
+            return Ok((text.to_string(), vec![]));
+        }
+
+        // Find where tool calls begin
+        // Safe: has_tool_markers() already confirmed the marker exists
+        let idx = text
+            .find("<｜tool▁calls▁begin｜>")
+            .ok_or_else(|| ParserError::ParsingFailed("tool call marker not found".to_string()))?;
+        let normal_text = text[..idx].to_string();
+
+        // Try to extract tool calls, log warnings for failures
+        let mut tools = Vec::new();
+        for mat in self.tool_call_extractor.find_iter(text) {
+            match self.parse_tool_call(mat.as_str()) {
+                Ok(tool) => tools.push(tool),
+                Err(e) => {
+                    tracing::debug!("Failed to parse tool call: {}", e);
+                    continue;
+                }
+            }
+        }
+
+        // If no tools were successfully parsed despite having markers, return entire text as fallback
+        if tools.is_empty() {
+            return Ok((text.to_string(), vec![]));
+        }
+
+        Ok((normal_text, tools))
+    }
+
+    async fn parse_incremental(
+        &mut self,
+        chunk: &str,
+        tools: &[Tool],
+    ) -> ParserResult<StreamingParseResult> {
+        self.buffer.push_str(chunk);
+        let current_text = &self.buffer.clone();
+
+        // Check if we have a tool call (either the start token or individual tool call)
+        let has_tool_call =
+            self.has_tool_markers(current_text) || current_text.contains("<｜tool▁call▁begin｜>");
+
+        if !has_tool_call {
+            // No tool markers detected - return all buffered content as normal text
+            // Strip out end tokens if present
+            let mut normal_text = std::mem::take(&mut self.buffer);
+            for e_token in ["<｜tool▁calls▁end｜>", "<｜tool▁call▁end｜>"] {
+                normal_text = normal_text.replace(e_token, "");
+            }
+            return Ok(StreamingParseResult {
+                normal_text,
+                calls: vec![],
+            });
+        }
+
+        // Build tool indices for validation
+        let tool_indices = helpers::get_tool_indices(tools);
+
+        let mut calls: Vec<ToolCallItem> = Vec::new();
+
+        // Try to match the partial tool call pattern
+        // V3.1: group 1 = name, group 2 = raw JSON args (no type field, no code fence)
+        if let Some(captures) = self.partial_tool_call_regex.captures(current_text) {
+            let func_name = captures.get(1).map_or("", |m| m.as_str()).trim();
+            let func_args_raw = captures.get(2).map_or("", |m| m.as_str()).trim();
+
+            // Validate tool name
+            if !tool_indices.contains_key(func_name) {
+                // Invalid tool name - skip this tool, preserve indexing for next tool
+                tracing::debug!("Invalid tool name '{}' - skipping", func_name);
+                helpers::reset_current_tool_state(
+                    &mut self.buffer,
+                    &mut self.current_tool_name_sent,
+                    &mut self.streamed_args_for_tool,
+                    &self.prev_tool_call_arr,
+                );
+                return Ok(StreamingParseResult::default());
+            }
+
+            // Initialize state if this is the first tool call
+            if self.current_tool_id == -1 {
+                self.current_tool_id = 0;
+                self.prev_tool_call_arr = Vec::new();
+                self.streamed_args_for_tool = vec![String::new()];
+            }
+
+            // Ensure we have enough entries in our tracking arrays
+            helpers::ensure_capacity(
+                self.current_tool_id,
+                &mut self.prev_tool_call_arr,
+                &mut self.streamed_args_for_tool,
+            );
+
+            // Send tool name if not sent yet
+            if self.current_tool_name_sent {
+                // Compute incremental diff
+                let tool_id = self.current_tool_id as usize;
+                let last_sent = self
+                    .streamed_args_for_tool
+                    .get(tool_id)
+                    .map(|s| s.as_str())
+                    .unwrap_or("");
+
+                let argument_diff = func_args_raw
+                    .strip_prefix(last_sent)
+                    .unwrap_or(func_args_raw);
+
+                if !argument_diff.is_empty() {
+                    calls.push(ToolCallItem {
+                        tool_index: tool_id,
+                        name: None,
+                        parameters: argument_diff.to_string(),
+                    });
+                    if tool_id < self.streamed_args_for_tool.len() {
+                        self.streamed_args_for_tool[tool_id].push_str(argument_diff);
+                    }
+                }
+
+                // Check if JSON is complete
+                if helpers::is_complete_json(func_args_raw) {
+                    // Update the stored arguments
+                    if let Ok(parsed_args) = serde_json::from_str::<Value>(func_args_raw) {
+                        let tool_id = self.current_tool_id as usize;
+                        if tool_id < self.prev_tool_call_arr.len() {
+                            if let Some(obj) = self.prev_tool_call_arr[tool_id].as_object_mut() {
+                                obj.insert("arguments".to_string(), parsed_args);
+                            }
+                        }
+                    }
+
+                    // Find the end of the current tool call and remove only that part from buffer
+                    if let Some(mat) = self.tool_call_end_pattern.find(current_text) {
+                        // Remove the completed tool call from buffer, keep any remaining content
+                        self.buffer = current_text[mat.end()..].to_string();
+                    } else {
+                        self.buffer.clear();
+                    }
+
+                    let result = StreamingParseResult {
+                        normal_text: String::new(),
+                        calls,
+                    };
+
+                    self.current_tool_id += 1;
+                    self.current_tool_name_sent = false;
+                    return Ok(result);
+                }
+            } else {
+                calls.push(ToolCallItem {
+                    tool_index: self.current_tool_id as usize,
+                    name: Some(func_name.to_string()),
+                    parameters: String::new(),
+                });
+                self.current_tool_name_sent = true;
+
+                // Store the tool call info for serving layer completions endpoint
+                let tool_id = self.current_tool_id as usize;
+                if self.prev_tool_call_arr.len() <= tool_id {
+                    self.prev_tool_call_arr
+                        .resize_with(tool_id + 1, || Value::Null);
+                }
+                self.prev_tool_call_arr[tool_id] = serde_json::json!({
+                    "name": func_name,
+                    "arguments": {},
+                });
+            }
+        }
+
+        Ok(StreamingParseResult {
+            normal_text: String::new(),
+            calls,
+        })
+    }
+
+    fn has_tool_markers(&self, text: &str) -> bool {
+        text.contains("<｜tool▁calls▁begin｜>")
+    }
+
+    fn get_unstreamed_tool_args(&self) -> Option<Vec<ToolCallItem>> {
+        helpers::get_unstreamed_args(&self.prev_tool_call_arr, &self.streamed_args_for_tool)
+    }
+
+    fn reset(&mut self) {
+        self.buffer.clear();
+        self.prev_tool_call_arr.clear();
+        self.current_tool_id = -1;
+        self.current_tool_name_sent = false;
+        self.streamed_args_for_tool.clear();
+    }
+}

--- a/crates/tool_parser/src/parsers/deepseek_v32.rs
+++ b/crates/tool_parser/src/parsers/deepseek_v32.rs
@@ -1,0 +1,331 @@
+use async_trait::async_trait;
+use openai_protocol::common::Tool;
+use regex::Regex;
+use serde_json::Value;
+
+use crate::{
+    errors::{ParserError, ParserResult},
+    parsers::helpers,
+    traits::ToolParser,
+    types::{FunctionCall, StreamingParseResult, ToolCall, ToolCallItem},
+};
+
+/// DSML (DeepSeek Markup Language) tag constants used by DeepSeek V3.2
+const FUNCTION_CALLS_START: &str = "<\u{ff5c}DSML\u{ff5c}function_calls>";
+const FUNCTION_CALLS_END: &str = "</\u{ff5c}DSML\u{ff5c}function_calls>";
+const INVOKE_END: &str = "</\u{ff5c}DSML\u{ff5c}invoke>";
+
+/// DeepSeek V3.2 DSML format parser for tool calls
+///
+/// Handles the DeepSeek V3.2 specific format that uses DSML (DeepSeek Markup Language)
+/// with XML-like markup for function calls:
+///
+/// ```text
+/// <｜DSML｜function_calls>
+/// <｜DSML｜invoke name="get_weather">
+/// <｜DSML｜parameter name="location" string="true">Tokyo</｜DSML｜parameter>
+/// <｜DSML｜parameter name="count" string="false">5</｜DSML｜parameter>
+/// </｜DSML｜invoke>
+/// </｜DSML｜function_calls>
+/// ```
+///
+/// Also supports JSON inside invoke blocks (dual format):
+///
+/// ```text
+/// <｜DSML｜invoke name="get_weather">
+/// {"location": "Tokyo", "count": 5}
+/// </｜DSML｜invoke>
+/// ```
+///
+/// Features:
+/// - DSML XML-like markup with Unicode delimiters
+/// - Dual format: XML parameters or inline JSON
+/// - `string="true"` for raw string values, `string="false"` for JSON values
+/// - Buffer-until-complete-invoke streaming strategy
+pub struct DeepSeekV32Parser {
+    /// Regex for extracting complete invoke blocks
+    invoke_extractor: Regex,
+    /// Regex for extracting DSML parameters from an invoke body
+    param_extractor: Regex,
+
+    /// Buffer for accumulating incomplete patterns across chunks
+    buffer: String,
+
+    /// Stores complete tool call info (name and arguments) for each tool being parsed
+    prev_tool_call_arr: Vec<Value>,
+
+    /// Index of currently streaming tool call (-1 means no active tool)
+    current_tool_id: i32,
+
+    /// Flag for whether current tool's name has been sent to client
+    current_tool_name_sent: bool,
+
+    /// Tracks raw JSON string content streamed to client for each tool's arguments
+    streamed_args_for_tool: Vec<String>,
+}
+
+impl DeepSeekV32Parser {
+    /// Create a new DeepSeek V3.2 DSML parser
+    #[expect(
+        clippy::expect_used,
+        reason = "regex patterns are compile-time string literals"
+    )]
+    pub fn new() -> Self {
+        // Regex for matching complete invoke blocks
+        // Captures: (1) function name, (2) invoke body
+        let invoke_pattern =
+            "(?s)<\u{ff5c}DSML\u{ff5c}invoke name=\"([^\"]+)\">(.*?)</\u{ff5c}DSML\u{ff5c}invoke>";
+        let invoke_extractor = Regex::new(invoke_pattern).expect("Valid regex pattern");
+
+        // Regex for matching DSML parameter tags within an invoke body
+        // Captures: (1) param name, (2) string flag ("true"|"false"), (3) param value
+        let param_pattern = "(?s)<\u{ff5c}DSML\u{ff5c}parameter name=\"([^\"]+)\" string=\"(true|false)\">(.*?)</\u{ff5c}DSML\u{ff5c}parameter>";
+        let param_extractor = Regex::new(param_pattern).expect("Valid regex pattern");
+
+        Self {
+            invoke_extractor,
+            param_extractor,
+            buffer: String::new(),
+            prev_tool_call_arr: Vec::new(),
+            current_tool_id: -1,
+            current_tool_name_sent: false,
+            streamed_args_for_tool: Vec::new(),
+        }
+    }
+
+    /// Parse the body of a single invoke block into a ToolCall.
+    ///
+    /// Supports two formats:
+    /// 1. JSON body: the invoke body is valid JSON
+    /// 2. XML parameters: the invoke body contains `<｜DSML｜parameter>` tags
+    fn parse_invoke(&self, name: &str, body: &str) -> ParserResult<ToolCall> {
+        let trimmed = body.trim();
+
+        // Try JSON first (dual format support)
+        if let Ok(value) = serde_json::from_str::<Value>(trimmed) {
+            let args = if value.is_object() {
+                value
+            } else {
+                serde_json::json!({ "value": value })
+            };
+            let arguments = serde_json::to_string(&args)
+                .map_err(|e| ParserError::ParsingFailed(e.to_string()))?;
+            return Ok(ToolCall {
+                function: FunctionCall {
+                    name: name.to_string(),
+                    arguments,
+                },
+            });
+        }
+
+        // Fall back to XML parameter extraction
+        let mut args = serde_json::Map::new();
+        for cap in self.param_extractor.captures_iter(trimmed) {
+            let param_name = cap.get(1).map_or("", |m| m.as_str());
+            let is_string = cap.get(2).map_or("true", |m| m.as_str()) == "true";
+            let raw_value = cap.get(3).map_or("", |m| m.as_str());
+
+            let value = if is_string {
+                // string="true" → always a raw string
+                Value::String(raw_value.to_string())
+            } else {
+                // string="false" → try to parse as JSON, fall back to string
+                serde_json::from_str::<Value>(raw_value)
+                    .unwrap_or_else(|_| Value::String(raw_value.to_string()))
+            };
+
+            args.insert(param_name.to_string(), value);
+        }
+
+        if args.is_empty() && !trimmed.is_empty() {
+            // Body is non-empty but we couldn't parse it as JSON or XML params
+            return Err(ParserError::ParsingFailed(format!(
+                "Failed to parse invoke body for '{name}'"
+            )));
+        }
+
+        let arguments = serde_json::to_string(&Value::Object(args))
+            .map_err(|e| ParserError::ParsingFailed(e.to_string()))?;
+
+        Ok(ToolCall {
+            function: FunctionCall {
+                name: name.to_string(),
+                arguments,
+            },
+        })
+    }
+}
+
+impl Default for DeepSeekV32Parser {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ToolParser for DeepSeekV32Parser {
+    async fn parse_complete(&self, text: &str) -> ParserResult<(String, Vec<ToolCall>)> {
+        if !self.has_tool_markers(text) {
+            return Ok((text.to_string(), vec![]));
+        }
+
+        // Find where function calls begin
+        let idx = text.find(FUNCTION_CALLS_START).ok_or_else(|| {
+            ParserError::ParsingFailed("DSML function_calls marker not found".to_string())
+        })?;
+        let normal_text = text[..idx].to_string();
+
+        // Extract all invoke blocks
+        let mut tools = Vec::new();
+        for cap in self.invoke_extractor.captures_iter(text) {
+            let func_name = cap.get(1).map_or("", |m| m.as_str()).trim();
+            let body = cap.get(2).map_or("", |m| m.as_str());
+
+            match self.parse_invoke(func_name, body) {
+                Ok(tool) => tools.push(tool),
+                Err(e) => {
+                    tracing::debug!("Failed to parse DSML invoke block: {}", e);
+                    continue;
+                }
+            }
+        }
+
+        // If no tools were successfully parsed despite having markers, return entire text
+        if tools.is_empty() {
+            return Ok((text.to_string(), vec![]));
+        }
+
+        Ok((normal_text, tools))
+    }
+
+    async fn parse_incremental(
+        &mut self,
+        chunk: &str,
+        tools: &[Tool],
+    ) -> ParserResult<StreamingParseResult> {
+        self.buffer.push_str(chunk);
+        let current_text = self.buffer.clone();
+
+        // Check if we have any DSML markers
+        let has_dsml = self.has_tool_markers(&current_text)
+            || current_text.contains("<\u{ff5c}DSML\u{ff5c}invoke");
+
+        if !has_dsml {
+            // No DSML markers detected — return all buffered content as normal text
+            let mut normal_text = std::mem::take(&mut self.buffer);
+            // Strip out end tokens if present
+            for e_token in [FUNCTION_CALLS_END, INVOKE_END] {
+                normal_text = normal_text.replace(e_token, "");
+            }
+            return Ok(StreamingParseResult {
+                normal_text,
+                calls: vec![],
+            });
+        }
+
+        let tool_indices = helpers::get_tool_indices(tools);
+        let mut calls: Vec<ToolCallItem> = Vec::new();
+
+        // Buffer-until-complete-invoke strategy: look for complete invoke blocks
+        while let Some(cap) = self.invoke_extractor.captures(&self.buffer.clone()) {
+            let full_match = cap.get(0).map_or("", |m| m.as_str());
+            let match_end = cap.get(0).map(|m| m.end()).unwrap_or(0);
+            let func_name = cap.get(1).map_or("", |m| m.as_str()).trim();
+            let body = cap.get(2).map_or("", |m| m.as_str());
+
+            // Validate tool name
+            if !tool_indices.contains_key(func_name) {
+                tracing::debug!(
+                    "Invalid tool name '{}' in DSML invoke - skipping",
+                    func_name
+                );
+                // Remove the invalid invoke from buffer and continue
+                self.buffer = self.buffer.replacen(full_match, "", 1);
+                continue;
+            }
+
+            // Initialize state if this is the first tool call
+            if self.current_tool_id == -1 {
+                self.current_tool_id = 0;
+                self.prev_tool_call_arr = Vec::new();
+                self.streamed_args_for_tool = vec![String::new()];
+            }
+
+            // Ensure capacity
+            helpers::ensure_capacity(
+                self.current_tool_id,
+                &mut self.prev_tool_call_arr,
+                &mut self.streamed_args_for_tool,
+            );
+
+            let tool_id = self.current_tool_id as usize;
+
+            // Parse the invoke body to get arguments
+            match self.parse_invoke(func_name, body) {
+                Ok(tool_call) => {
+                    // Emit name
+                    calls.push(ToolCallItem {
+                        tool_index: tool_id,
+                        name: Some(func_name.to_string()),
+                        parameters: String::new(),
+                    });
+
+                    // Emit full arguments at once
+                    let args_str = &tool_call.function.arguments;
+                    if !args_str.is_empty() {
+                        calls.push(ToolCallItem {
+                            tool_index: tool_id,
+                            name: None,
+                            parameters: args_str.clone(),
+                        });
+                        if tool_id < self.streamed_args_for_tool.len() {
+                            self.streamed_args_for_tool[tool_id].push_str(args_str);
+                        }
+                    }
+
+                    // Store the tool call info
+                    if tool_id < self.prev_tool_call_arr.len() {
+                        self.prev_tool_call_arr[tool_id] = serde_json::json!({
+                            "name": func_name,
+                            "arguments": serde_json::from_str::<Value>(args_str).unwrap_or(Value::Object(serde_json::Map::new())),
+                        });
+                    }
+                }
+                Err(e) => {
+                    tracing::debug!("Failed to parse DSML invoke during streaming: {}", e);
+                    // Remove the broken invoke from buffer and continue
+                    self.buffer = self.buffer.replacen(full_match, "", 1);
+                    continue;
+                }
+            }
+
+            // Remove the completed invoke from buffer
+            self.buffer = self.buffer[match_end..].to_string();
+
+            // Advance to next tool
+            self.current_tool_id += 1;
+            self.current_tool_name_sent = false;
+        }
+
+        Ok(StreamingParseResult {
+            normal_text: String::new(),
+            calls,
+        })
+    }
+
+    fn has_tool_markers(&self, text: &str) -> bool {
+        text.contains(FUNCTION_CALLS_START)
+    }
+
+    fn get_unstreamed_tool_args(&self) -> Option<Vec<ToolCallItem>> {
+        helpers::get_unstreamed_args(&self.prev_tool_call_arr, &self.streamed_args_for_tool)
+    }
+
+    fn reset(&mut self) {
+        self.buffer.clear();
+        self.prev_tool_call_arr.clear();
+        self.current_tool_id = -1;
+        self.current_tool_name_sent = false;
+        self.streamed_args_for_tool.clear();
+    }
+}

--- a/crates/tool_parser/src/parsers/mod.rs
+++ b/crates/tool_parser/src/parsers/mod.rs
@@ -5,6 +5,8 @@
 // Individual parser modules
 pub mod cohere;
 pub mod deepseek;
+pub mod deepseek_v31;
+pub mod deepseek_v32;
 pub mod glm4_moe;
 pub mod json;
 pub mod kimik2;
@@ -23,6 +25,8 @@ pub mod helpers;
 // Re-export parser types for convenience
 pub use cohere::CohereParser;
 pub use deepseek::DeepSeekParser;
+pub use deepseek_v31::DeepSeekV31Parser;
+pub use deepseek_v32::DeepSeekV32Parser;
 pub use glm4_moe::Glm4MoeParser;
 pub use json::JsonParser;
 pub use kimik2::KimiK2Parser;

--- a/crates/tool_parser/tests/tool_parser_deepseek_v31.rs
+++ b/crates/tool_parser/tests/tool_parser_deepseek_v31.rs
@@ -1,0 +1,195 @@
+//! DeepSeek V3.1 Parser Integration Tests
+//!
+//! V3.1 format differs from V3: no `function` type prefix, no code fence around JSON args.
+//! Format: `<｜tool▁call▁begin｜>{name}<｜tool▁sep｜>{raw_json}<｜tool▁call▁end｜>`
+mod common;
+
+use common::create_test_tools;
+use tool_parser::{DeepSeekV31Parser, ToolParser};
+
+#[tokio::test]
+async fn test_deepseek_v31_complete_parsing() {
+    let parser = DeepSeekV31Parser::new();
+
+    let input = "Let me help you with that.\n\
+        <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>\
+        {\"location\": \"Tokyo\", \"units\": \"celsius\"}\
+        <｜tool▁call▁end｜><｜tool▁calls▁end｜>";
+
+    let (normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(normal_text, "Let me help you with that.\n");
+    assert_eq!(tools[0].function.name, "get_weather");
+
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
+    assert_eq!(args["location"], "Tokyo");
+    assert_eq!(args["units"], "celsius");
+}
+
+#[tokio::test]
+async fn test_deepseek_v31_multiple_tools() {
+    let parser = DeepSeekV31Parser::new();
+
+    let input = "<｜tool▁calls▁begin｜>\
+        <｜tool▁call▁begin｜>search<｜tool▁sep｜>{\"query\": \"rust programming\"}<｜tool▁call▁end｜>\
+        <｜tool▁call▁begin｜>translate<｜tool▁sep｜>{\"text\": \"Hello World\", \"to\": \"ja\"}<｜tool▁call▁end｜>\
+        <｜tool▁calls▁end｜>";
+
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 2);
+    assert_eq!(tools[0].function.name, "search");
+    assert_eq!(tools[1].function.name, "translate");
+
+    let args0: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
+    assert_eq!(args0["query"], "rust programming");
+
+    let args1: serde_json::Value = serde_json::from_str(&tools[1].function.arguments).unwrap();
+    assert_eq!(args1["text"], "Hello World");
+    assert_eq!(args1["to"], "ja");
+}
+
+#[tokio::test]
+async fn test_deepseek_v31_streaming() {
+    let tools = create_test_tools();
+
+    let mut parser = DeepSeekV31Parser::new();
+
+    // Simulate streaming chunks — V3.1 format (no "function" prefix, no code fence)
+    let chunks = vec![
+        "<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>",
+        "get_weather<｜tool▁sep｜>",
+        r#"{"location": "#,
+        r#""Beijing", "#,
+        r#""units": "metric"}"#,
+        "<｜tool▁call▁end｜><｜tool▁calls▁end｜>",
+    ];
+
+    let mut found_name = false;
+    let mut collected_args = String::new();
+
+    for chunk in chunks {
+        let result = parser.parse_incremental(chunk, &tools).await.unwrap();
+
+        for call in result.calls {
+            if let Some(name) = call.name {
+                assert_eq!(name, "get_weather");
+                found_name = true;
+            }
+            if !call.parameters.is_empty() {
+                collected_args.push_str(&call.parameters);
+            }
+        }
+    }
+
+    assert!(found_name, "Should have found tool name during streaming");
+    assert!(
+        !collected_args.is_empty(),
+        "Should have collected argument chunks"
+    );
+}
+
+#[tokio::test]
+async fn test_deepseek_v31_no_type_field() {
+    // V3.1 should NOT require "function" type prefix
+    let parser = DeepSeekV31Parser::new();
+
+    // V3 format (with "function" type) should fail or not match in V3.1 parser
+    let v3_input = "<｜tool▁calls▁begin｜>\
+        <｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather\n\
+        ```json\n{\"location\": \"Tokyo\"}\n```\
+        <｜tool▁call▁end｜><｜tool▁calls▁end｜>";
+
+    let (_text, tools) = parser.parse_complete(v3_input).await.unwrap();
+    // The V3 format should either fail to parse JSON or produce an incorrect name
+    // because V3.1 treats everything before <｜tool▁sep｜> as the function name
+    // and everything after as raw JSON (which includes the code fence markers).
+    // Either way, it should not produce a valid "get_weather" tool call.
+    let valid_tools: Vec<_> = tools
+        .iter()
+        .filter(|t| t.function.name == "get_weather")
+        .collect();
+    assert!(
+        valid_tools.is_empty(),
+        "V3 format should not parse correctly with V3.1 parser as a clean get_weather call"
+    );
+
+    // V3.1 format (no type, no code fence) should work
+    let v31_input = "<｜tool▁calls▁begin｜>\
+        <｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{\"location\": \"Tokyo\"}\
+        <｜tool▁call▁end｜><｜tool▁calls▁end｜>";
+
+    let (_text, tools) = parser.parse_complete(v31_input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "get_weather");
+}
+
+#[test]
+fn test_deepseek_v31_format_detection() {
+    let parser = DeepSeekV31Parser::new();
+
+    // Should detect DeepSeek format (same markers as V3)
+    assert!(parser.has_tool_markers("<｜tool▁calls▁begin｜>"));
+    assert!(parser.has_tool_markers(
+        "text with <｜tool▁calls▁begin｜> marker"
+    ));
+
+    // Should not detect other formats
+    assert!(!parser.has_tool_markers("[TOOL_CALLS]"));
+    assert!(!parser.has_tool_markers("<tool_call>"));
+    assert!(!parser.has_tool_markers("plain text"));
+}
+
+#[tokio::test]
+async fn test_deepseek_v31_nested_json() {
+    let parser = DeepSeekV31Parser::new();
+
+    let input = "<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>process<｜tool▁sep｜>\
+        {\"data\": {\"nested\": {\"deep\": [1, 2, 3]}}}\
+        <｜tool▁call▁end｜><｜tool▁calls▁end｜>";
+
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "process");
+
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
+    assert!(args["data"]["nested"]["deep"].is_array());
+}
+
+#[tokio::test]
+async fn test_deepseek_v31_malformed_json_handling() {
+    let parser = DeepSeekV31Parser::new();
+
+    // Malformed JSON should be skipped, valid one parsed
+    let input = "<｜tool▁calls▁begin｜>\
+        <｜tool▁call▁begin｜>search<｜tool▁sep｜>{invalid json}<｜tool▁call▁end｜>\
+        <｜tool▁call▁begin｜>search<｜tool▁sep｜>{\"query\": \"valid\"}<｜tool▁call▁end｜>\
+        <｜tool▁calls▁end｜>";
+
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "search");
+}
+
+#[tokio::test]
+async fn test_deepseek_v31_no_tools_in_text() {
+    let parser = DeepSeekV31Parser::new();
+
+    let input = "Just a normal response with no tool calls.";
+    let (normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(normal_text, input);
+    assert!(tools.is_empty());
+}
+
+#[tokio::test]
+async fn test_deepseek_v31_text_before_tools() {
+    let parser = DeepSeekV31Parser::new();
+
+    let input = "I'll search for that information.\n\
+        <｜tool▁calls▁begin｜><｜tool▁call▁begin｜>search<｜tool▁sep｜>\
+        {\"query\": \"rust async\"}<｜tool▁call▁end｜><｜tool▁calls▁end｜>";
+
+    let (normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(normal_text, "I'll search for that information.\n");
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "search");
+}

--- a/crates/tool_parser/tests/tool_parser_deepseek_v32.rs
+++ b/crates/tool_parser/tests/tool_parser_deepseek_v32.rs
@@ -1,0 +1,344 @@
+//! DeepSeek V3.2 DSML Parser Integration Tests
+mod common;
+
+use common::create_test_tools;
+use tool_parser::{DeepSeekV32Parser, ToolParser};
+
+#[tokio::test]
+async fn test_dsml_complete_xml_parameters() {
+    let parser = DeepSeekV32Parser::new();
+
+    let input = "Let me check that for you.\n\
+        <\u{ff5c}DSML\u{ff5c}function_calls>\n\
+        <\u{ff5c}DSML\u{ff5c}invoke name=\"get_weather\">\n\
+        <\u{ff5c}DSML\u{ff5c}parameter name=\"location\" string=\"true\">Tokyo</\u{ff5c}DSML\u{ff5c}parameter>\n\
+        <\u{ff5c}DSML\u{ff5c}parameter name=\"units\" string=\"true\">celsius</\u{ff5c}DSML\u{ff5c}parameter>\n\
+        </\u{ff5c}DSML\u{ff5c}invoke>\n\
+        </\u{ff5c}DSML\u{ff5c}function_calls>";
+
+    let (normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(normal_text, "Let me check that for you.\n");
+    assert_eq!(tools[0].function.name, "get_weather");
+
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
+    assert_eq!(args["location"], "Tokyo");
+    assert_eq!(args["units"], "celsius");
+}
+
+#[tokio::test]
+async fn test_dsml_complete_json_body() {
+    let parser = DeepSeekV32Parser::new();
+
+    let input = "<\u{ff5c}DSML\u{ff5c}function_calls>\n\
+        <\u{ff5c}DSML\u{ff5c}invoke name=\"get_weather\">\n\
+        {\"location\": \"Tokyo\", \"units\": \"celsius\"}\n\
+        </\u{ff5c}DSML\u{ff5c}invoke>\n\
+        </\u{ff5c}DSML\u{ff5c}function_calls>";
+
+    let (normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(normal_text, "");
+    assert_eq!(tools[0].function.name, "get_weather");
+
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
+    assert_eq!(args["location"], "Tokyo");
+    assert_eq!(args["units"], "celsius");
+}
+
+#[tokio::test]
+async fn test_dsml_string_false_type_coercion() {
+    let parser = DeepSeekV32Parser::new();
+
+    let input = "<\u{ff5c}DSML\u{ff5c}function_calls>\n\
+        <\u{ff5c}DSML\u{ff5c}invoke name=\"process\">\n\
+        <\u{ff5c}DSML\u{ff5c}parameter name=\"count\" string=\"false\">5</\u{ff5c}DSML\u{ff5c}parameter>\n\
+        <\u{ff5c}DSML\u{ff5c}parameter name=\"rate\" string=\"false\">7.5</\u{ff5c}DSML\u{ff5c}parameter>\n\
+        <\u{ff5c}DSML\u{ff5c}parameter name=\"enabled\" string=\"false\">true</\u{ff5c}DSML\u{ff5c}parameter>\n\
+        <\u{ff5c}DSML\u{ff5c}parameter name=\"text\" string=\"true\">hello world</\u{ff5c}DSML\u{ff5c}parameter>\n\
+        </\u{ff5c}DSML\u{ff5c}invoke>\n\
+        </\u{ff5c}DSML\u{ff5c}function_calls>";
+
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "process");
+
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
+    // string="false" values should be parsed as their JSON types
+    assert_eq!(args["count"], 5);
+    assert_eq!(args["rate"], 7.5);
+    assert_eq!(args["enabled"], true);
+    // string="true" value should be a raw string
+    assert_eq!(args["text"], "hello world");
+}
+
+#[tokio::test]
+async fn test_dsml_string_false_fallback_to_string() {
+    let parser = DeepSeekV32Parser::new();
+
+    // When string="false" but the value is not valid JSON, it should fall back to string
+    let input = "<\u{ff5c}DSML\u{ff5c}function_calls>\n\
+        <\u{ff5c}DSML\u{ff5c}invoke name=\"search\">\n\
+        <\u{ff5c}DSML\u{ff5c}parameter name=\"query\" string=\"false\">not valid json here</\u{ff5c}DSML\u{ff5c}parameter>\n\
+        </\u{ff5c}DSML\u{ff5c}invoke>\n\
+        </\u{ff5c}DSML\u{ff5c}function_calls>";
+
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "search");
+
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
+    // Should fall back to string when JSON parse fails
+    assert_eq!(args["query"], "not valid json here");
+}
+
+#[tokio::test]
+async fn test_dsml_multiple_invocations() {
+    let parser = DeepSeekV32Parser::new();
+
+    let input = "<\u{ff5c}DSML\u{ff5c}function_calls>\n\
+        <\u{ff5c}DSML\u{ff5c}invoke name=\"search\">\n\
+        <\u{ff5c}DSML\u{ff5c}parameter name=\"query\" string=\"true\">rust programming</\u{ff5c}DSML\u{ff5c}parameter>\n\
+        </\u{ff5c}DSML\u{ff5c}invoke>\n\
+        <\u{ff5c}DSML\u{ff5c}invoke name=\"translate\">\n\
+        {\"text\": \"Hello World\", \"to\": \"ja\"}\n\
+        </\u{ff5c}DSML\u{ff5c}invoke>\n\
+        </\u{ff5c}DSML\u{ff5c}function_calls>";
+
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 2);
+    assert_eq!(tools[0].function.name, "search");
+    assert_eq!(tools[1].function.name, "translate");
+
+    let args0: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
+    assert_eq!(args0["query"], "rust programming");
+
+    let args1: serde_json::Value = serde_json::from_str(&tools[1].function.arguments).unwrap();
+    assert_eq!(args1["text"], "Hello World");
+    assert_eq!(args1["to"], "ja");
+}
+
+#[tokio::test]
+async fn test_dsml_streaming_chunked() {
+    let tools = create_test_tools();
+    let mut parser = DeepSeekV32Parser::new();
+
+    // Simulate streaming chunks that build up a complete DSML invoke
+    let chunks = vec![
+        "<\u{ff5c}DSML\u{ff5c}function_calls>\n",
+        "<\u{ff5c}DSML\u{ff5c}invoke name=\"get_weather\">\n",
+        "{\"location\": ",
+        "\"Beijing\", ",
+        "\"units\": \"metric\"}",
+        "\n</\u{ff5c}DSML\u{ff5c}invoke>",
+        "\n</\u{ff5c}DSML\u{ff5c}function_calls>",
+    ];
+
+    let mut found_name = false;
+    let mut found_args = false;
+
+    for chunk in chunks {
+        let result = parser.parse_incremental(chunk, &tools).await.unwrap();
+
+        for call in result.calls {
+            if let Some(name) = &call.name {
+                assert_eq!(name, "get_weather");
+                found_name = true;
+            }
+            if call.name.is_none() && !call.parameters.is_empty() {
+                found_args = true;
+            }
+        }
+    }
+
+    assert!(found_name, "Should have found tool name during streaming");
+    assert!(found_args, "Should have found tool arguments during streaming");
+}
+
+#[tokio::test]
+async fn test_dsml_streaming_multiple_invocations() {
+    let tools = create_test_tools();
+    let mut parser = DeepSeekV32Parser::new();
+
+    let chunks = vec![
+        "<\u{ff5c}DSML\u{ff5c}function_calls>\n",
+        "<\u{ff5c}DSML\u{ff5c}invoke name=\"search\">\n",
+        "{\"query\": \"rust\"}\n",
+        "</\u{ff5c}DSML\u{ff5c}invoke>\n",
+        "<\u{ff5c}DSML\u{ff5c}invoke name=\"translate\">\n",
+        "{\"text\": \"hello\", \"to\": \"ja\"}\n",
+        "</\u{ff5c}DSML\u{ff5c}invoke>\n",
+        "</\u{ff5c}DSML\u{ff5c}function_calls>",
+    ];
+
+    let mut names_found: Vec<String> = Vec::new();
+
+    for chunk in chunks {
+        let result = parser.parse_incremental(chunk, &tools).await.unwrap();
+
+        for call in result.calls {
+            if let Some(name) = call.name {
+                names_found.push(name);
+            }
+        }
+    }
+
+    assert_eq!(names_found.len(), 2);
+    assert_eq!(names_found[0], "search");
+    assert_eq!(names_found[1], "translate");
+}
+
+#[test]
+fn test_dsml_format_detection() {
+    let parser = DeepSeekV32Parser::new();
+
+    // Should detect DSML format
+    assert!(parser.has_tool_markers("<\u{ff5c}DSML\u{ff5c}function_calls>"));
+    assert!(parser.has_tool_markers(
+        "text with <\u{ff5c}DSML\u{ff5c}function_calls> marker"
+    ));
+
+    // Should not detect other formats
+    assert!(!parser.has_tool_markers("<\u{ff5c}tool\u{2581}calls\u{2581}begin\u{ff5c}>"));
+    assert!(!parser.has_tool_markers("[TOOL_CALLS]"));
+    assert!(!parser.has_tool_markers("<tool_call>"));
+    assert!(!parser.has_tool_markers("plain text"));
+}
+
+#[tokio::test]
+async fn test_dsml_normal_text_before_block() {
+    let parser = DeepSeekV32Parser::new();
+
+    let input = "Sure, I'll look that up for you!\n\
+        <\u{ff5c}DSML\u{ff5c}function_calls>\n\
+        <\u{ff5c}DSML\u{ff5c}invoke name=\"search\">\n\
+        {\"query\": \"rust async\"}\n\
+        </\u{ff5c}DSML\u{ff5c}invoke>\n\
+        </\u{ff5c}DSML\u{ff5c}function_calls>";
+
+    let (normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(normal_text, "Sure, I'll look that up for you!\n");
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "search");
+}
+
+#[tokio::test]
+async fn test_dsml_no_tool_markers() {
+    let parser = DeepSeekV32Parser::new();
+
+    let input = "This is just normal text with no tool calls.";
+
+    let (normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(normal_text, input);
+    assert!(tools.is_empty());
+}
+
+#[tokio::test]
+async fn test_dsml_nested_json_in_parameter() {
+    let parser = DeepSeekV32Parser::new();
+
+    let input = "<\u{ff5c}DSML\u{ff5c}function_calls>\n\
+        <\u{ff5c}DSML\u{ff5c}invoke name=\"process\">\n\
+        <\u{ff5c}DSML\u{ff5c}parameter name=\"data\" string=\"false\">{\"nested\": {\"deep\": [1, 2, 3]}}</\u{ff5c}DSML\u{ff5c}parameter>\n\
+        </\u{ff5c}DSML\u{ff5c}invoke>\n\
+        </\u{ff5c}DSML\u{ff5c}function_calls>";
+
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "process");
+
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
+    assert!(args["data"]["nested"]["deep"].is_array());
+    assert_eq!(args["data"]["nested"]["deep"][0], 1);
+}
+
+#[tokio::test]
+async fn test_dsml_empty_args() {
+    let parser = DeepSeekV32Parser::new();
+
+    // Invoke with empty body — should produce empty object
+    let input = "<\u{ff5c}DSML\u{ff5c}function_calls>\n\
+        <\u{ff5c}DSML\u{ff5c}invoke name=\"ping\">\n\
+        </\u{ff5c}DSML\u{ff5c}invoke>\n\
+        </\u{ff5c}DSML\u{ff5c}function_calls>";
+
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "ping");
+
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
+    assert!(args.is_object());
+}
+
+#[tokio::test]
+async fn test_dsml_streaming_xml_parameters() {
+    let tools = create_test_tools();
+    let mut parser = DeepSeekV32Parser::new();
+
+    // Stream an invoke with XML parameters
+    let chunks = vec![
+        "<\u{ff5c}DSML\u{ff5c}function_calls>\n",
+        "<\u{ff5c}DSML\u{ff5c}invoke name=\"process\">\n",
+        "<\u{ff5c}DSML\u{ff5c}parameter name=\"count\" ",
+        "string=\"false\">42",
+        "</\u{ff5c}DSML\u{ff5c}parameter>\n",
+        "<\u{ff5c}DSML\u{ff5c}parameter name=\"text\" string=\"true\">hello</\u{ff5c}DSML\u{ff5c}parameter>\n",
+        "</\u{ff5c}DSML\u{ff5c}invoke>",
+        "\n</\u{ff5c}DSML\u{ff5c}function_calls>",
+    ];
+
+    let mut found_name = false;
+    let mut found_args = false;
+
+    for chunk in chunks {
+        let result = parser.parse_incremental(chunk, &tools).await.unwrap();
+
+        for call in result.calls {
+            if let Some(name) = &call.name {
+                assert_eq!(name, "process");
+                found_name = true;
+            }
+            if call.name.is_none() && !call.parameters.is_empty() {
+                found_args = true;
+                // Verify the arguments are valid JSON
+                let args: serde_json::Value = serde_json::from_str(&call.parameters).unwrap();
+                assert_eq!(args["count"], 42);
+                assert_eq!(args["text"], "hello");
+            }
+        }
+    }
+
+    assert!(found_name, "Should have found tool name during streaming");
+    assert!(found_args, "Should have found tool arguments during streaming");
+}
+
+#[tokio::test]
+async fn test_dsml_reset() {
+    let tools = create_test_tools();
+    let mut parser = DeepSeekV32Parser::new();
+
+    // Feed partial data
+    let _ = parser
+        .parse_incremental(
+            "<\u{ff5c}DSML\u{ff5c}function_calls>\n<\u{ff5c}DSML\u{ff5c}invoke name=\"search\">\n",
+            &tools,
+        )
+        .await
+        .unwrap();
+
+    // Reset
+    parser.reset();
+
+    // After reset, parser should work fresh
+    let input = "<\u{ff5c}DSML\u{ff5c}function_calls>\n\
+        <\u{ff5c}DSML\u{ff5c}invoke name=\"get_weather\">\n\
+        {\"location\": \"Paris\"}\n\
+        </\u{ff5c}DSML\u{ff5c}invoke>\n\
+        </\u{ff5c}DSML\u{ff5c}function_calls>";
+
+    // Use parse_complete on a fresh parser to verify it works
+    let fresh_parser = DeepSeekV32Parser::new();
+    let (_, tools_result) = fresh_parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools_result.len(), 1);
+    assert_eq!(tools_result[0].function.name, "get_weather");
+}


### PR DESCRIPTION
## Summary

Add a new `DeepSeekV31Parser` for the DeepSeek V3.1 tool call format, which uses a simplified wire format compared to V3:

- **No type prefix**: V3.1 places the function name directly after `<｜tool▁call▁begin｜>`, whereas V3 requires `function` as a type discriminator
- **No code fence**: V3.1 passes raw JSON arguments directly after `<｜tool▁sep｜>`, whereas V3 wraps them in ````json ... ````

### V3.1 format
```
<｜tool▁call▁begin｜>get_weather<｜tool▁sep｜>{"location": "Tokyo"}<｜tool▁call▁end｜>
```

### V3 format (existing)
```
<｜tool▁call▁begin｜>function<｜tool▁sep｜>get_weather
` ``json
{"location": "Tokyo"}
` ``<｜tool▁call▁end｜>
```

## Changes

- **`crates/tool_parser/src/parsers/deepseek_v31.rs`** (new): `DeepSeekV31Parser` struct with 2-group regex patterns (name + raw JSON) instead of V3's 3-group patterns (type + name + code-fenced JSON). Supports both complete and incremental streaming parsing.
- **`crates/tool_parser/src/parsers/mod.rs`**: Register `deepseek_v31` module and re-export `DeepSeekV31Parser`.
- **`crates/tool_parser/src/factory.rs`**: Register `"deepseek_v31"` parser factory and add model mappings for `deepseek-v3.1*` and `deepseek-ai/DeepSeek-V3.1*` (placed before V3 glob patterns so more specific patterns match first).
- **`crates/tool_parser/src/lib.rs`**: Add `DeepSeekV31Parser` to public re-exports.
- **`crates/tool_parser/tests/tool_parser_deepseek_v31.rs`** (new): 9 integration tests covering complete parsing, multiple tool calls, streaming, format detection, nested JSON, malformed JSON handling, no-tools passthrough, text-before-tools extraction, and V3-vs-V3.1 format discrimination.

## Test Plan

- `cargo test -p tool-parser --test tool_parser_deepseek_v31` — all 9 new tests pass
- `cargo test -p tool-parser --test tool_parser_deepseek` — all 7 existing V3 tests still pass (no regression)
- `cargo clippy -p tool-parser --lib --test tool_parser_deepseek_v31 -- -D warnings` — clean, no warnings
- No source code outside `crates/tool_parser/` was modified

<details>
<summary>Checklist</summary>

- [x] New parser implementation with complete + streaming support
- [x] Factory registration with model name glob mappings
- [x] Integration tests for all parsing modes
- [x] Clippy clean
- [x] Existing V3 parser tests unaffected
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added version-specific parsers for DeepSeek V3.1 and V3.2 models with optimized tool-call format support
  * Improved parser factory routing to prioritize model-specific implementations over generic handlers

* **Tests**
  * Added comprehensive integration tests for DeepSeek V3.1 and V3.2 parser implementations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->