### PR TITLE
feat(tool_parser): add DeepSeek V3.2 DSML tool call parser

### DIFF
--- a/crates/tool_parser/src/factory.rs
+++ b/crates/tool_parser/src/factory.rs
@@ -7,9 +7,9 @@ use tokio::sync::Mutex;
 
 use crate::{
     parsers::{
-        CohereParser, DeepSeekParser, Glm4MoeParser, JsonParser, KimiK2Parser, LlamaParser,
-        MinimaxM2Parser, MistralParser, PassthroughParser, PythonicParser, QwenCoderParser,
-        QwenParser, Step3Parser,
+        CohereParser, DeepSeekParser, DeepSeekV32Parser, Glm4MoeParser, JsonParser, KimiK2Parser,
+        LlamaParser, MinimaxM2Parser, MistralParser, PassthroughParser, PythonicParser,
+        QwenCoderParser, QwenParser, Step3Parser,
     },
     traits::ToolParser,
 };
@@ -239,6 +239,7 @@ impl ParserFactory {
         registry.register_parser("pythonic", || Box::new(PythonicParser::new()));
         registry.register_parser("llama", || Box::new(LlamaParser::new()));
         registry.register_parser("deepseek", || Box::new(DeepSeekParser::new()));
+        registry.register_parser("deepseek_v32", || Box::new(DeepSeekV32Parser::new()));
         registry.register_parser("glm45_moe", || Box::new(Glm4MoeParser::glm45()));
         registry.register_parser("glm47_moe", || Box::new(Glm4MoeParser::glm47()));
         registry.register_parser("step3", || Box::new(Step3Parser::new()));
@@ -285,7 +286,9 @@ impl ParserFactory {
         registry.map_model("llama-*", "json");
         registry.map_model("meta-llama-*", "json");
 
-        // DeepSeek models
+        // DeepSeek models (V3.2 before V3 — more specific patterns first)
+        registry.map_model("deepseek-v3.2*", "deepseek_v32");
+        registry.map_model("deepseek-ai/DeepSeek-V3.2*", "deepseek_v32");
         registry.map_model("deepseek-v3*", "deepseek");
         registry.map_model("deepseek-ai/DeepSeek-V3*", "deepseek");
         registry.map_model("deepseek-*", "pythonic");

--- a/crates/tool_parser/src/lib.rs
+++ b/crates/tool_parser/src/lib.rs
@@ -17,8 +17,8 @@ mod tests;
 // Re-export types used outside this module
 pub use factory::{ParserFactory, PooledParser};
 pub use parsers::{
-    CohereParser, DeepSeekParser, Glm4MoeParser, JsonParser, KimiK2Parser, LlamaParser,
-    MinimaxM2Parser, MistralParser, PythonicParser, QwenParser, Step3Parser,
+    CohereParser, DeepSeekParser, DeepSeekV32Parser, Glm4MoeParser, JsonParser, KimiK2Parser,
+    LlamaParser, MinimaxM2Parser, MistralParser, PythonicParser, QwenParser, Step3Parser,
 };
 pub use traits::ToolParser;
 pub use types::{FunctionCall, PartialToolCall, StreamingParseResult, ToolCall};

--- a/crates/tool_parser/src/parsers/deepseek_v32.rs
+++ b/crates/tool_parser/src/parsers/deepseek_v32.rs
@@ -1,0 +1,331 @@
+use async_trait::async_trait;
+use openai_protocol::common::Tool;
+use regex::Regex;
+use serde_json::Value;
+
+use crate::{
+    errors::{ParserError, ParserResult},
+    parsers::helpers,
+    traits::ToolParser,
+    types::{FunctionCall, StreamingParseResult, ToolCall, ToolCallItem},
+};
+
+/// DSML (DeepSeek Markup Language) tag constants used by DeepSeek V3.2
+const FUNCTION_CALLS_START: &str = "<\u{ff5c}DSML\u{ff5c}function_calls>";
+const FUNCTION_CALLS_END: &str = "</\u{ff5c}DSML\u{ff5c}function_calls>";
+const INVOKE_END: &str = "</\u{ff5c}DSML\u{ff5c}invoke>";
+
+/// DeepSeek V3.2 DSML format parser for tool calls
+///
+/// Handles the DeepSeek V3.2 specific format that uses DSML (DeepSeek Markup Language)
+/// with XML-like markup for function calls:
+///
+/// ```text
+/// <｜DSML｜function_calls>
+/// <｜DSML｜invoke name="get_weather">
+/// <｜DSML｜parameter name="location" string="true">Tokyo</｜DSML｜parameter>
+/// <｜DSML｜parameter name="count" string="false">5</｜DSML｜parameter>
+/// </｜DSML｜invoke>
+/// </｜DSML｜function_calls>
+/// ```
+///
+/// Also supports JSON inside invoke blocks (dual format):
+///
+/// ```text
+/// <｜DSML｜invoke name="get_weather">
+/// {"location": "Tokyo", "count": 5}
+/// </｜DSML｜invoke>
+/// ```
+///
+/// Features:
+/// - DSML XML-like markup with Unicode delimiters
+/// - Dual format: XML parameters or inline JSON
+/// - `string="true"` for raw string values, `string="false"` for JSON values
+/// - Buffer-until-complete-invoke streaming strategy
+pub struct DeepSeekV32Parser {
+    /// Regex for extracting complete invoke blocks
+    invoke_extractor: Regex,
+    /// Regex for extracting DSML parameters from an invoke body
+    param_extractor: Regex,
+
+    /// Buffer for accumulating incomplete patterns across chunks
+    buffer: String,
+
+    /// Stores complete tool call info (name and arguments) for each tool being parsed
+    prev_tool_call_arr: Vec<Value>,
+
+    /// Index of currently streaming tool call (-1 means no active tool)
+    current_tool_id: i32,
+
+    /// Flag for whether current tool's name has been sent to client
+    current_tool_name_sent: bool,
+
+    /// Tracks raw JSON string content streamed to client for each tool's arguments
+    streamed_args_for_tool: Vec<String>,
+}
+
+impl DeepSeekV32Parser {
+    /// Create a new DeepSeek V3.2 DSML parser
+    #[expect(
+        clippy::expect_used,
+        reason = "regex patterns are compile-time string literals"
+    )]
+    pub fn new() -> Self {
+        // Regex for matching complete invoke blocks
+        // Captures: (1) function name, (2) invoke body
+        let invoke_pattern =
+            "(?s)<\u{ff5c}DSML\u{ff5c}invoke name=\"([^\"]+)\">(.*?)</\u{ff5c}DSML\u{ff5c}invoke>";
+        let invoke_extractor = Regex::new(invoke_pattern).expect("Valid regex pattern");
+
+        // Regex for matching DSML parameter tags within an invoke body
+        // Captures: (1) param name, (2) string flag ("true"|"false"), (3) param value
+        let param_pattern = "(?s)<\u{ff5c}DSML\u{ff5c}parameter name=\"([^\"]+)\" string=\"(true|false)\">(.*?)</\u{ff5c}DSML\u{ff5c}parameter>";
+        let param_extractor = Regex::new(param_pattern).expect("Valid regex pattern");
+
+        Self {
+            invoke_extractor,
+            param_extractor,
+            buffer: String::new(),
+            prev_tool_call_arr: Vec::new(),
+            current_tool_id: -1,
+            current_tool_name_sent: false,
+            streamed_args_for_tool: Vec::new(),
+        }
+    }
+
+    /// Parse the body of a single invoke block into a ToolCall.
+    ///
+    /// Supports two formats:
+    /// 1. JSON body: the invoke body is valid JSON
+    /// 2. XML parameters: the invoke body contains `<｜DSML｜parameter>` tags
+    fn parse_invoke(&self, name: &str, body: &str) -> ParserResult<ToolCall> {
+        let trimmed = body.trim();
+
+        // Try JSON first (dual format support)
+        if let Ok(value) = serde_json::from_str::<Value>(trimmed) {
+            let args = if value.is_object() {
+                value
+            } else {
+                serde_json::json!({ "value": value })
+            };
+            let arguments = serde_json::to_string(&args)
+                .map_err(|e| ParserError::ParsingFailed(e.to_string()))?;
+            return Ok(ToolCall {
+                function: FunctionCall {
+                    name: name.to_string(),
+                    arguments,
+                },
+            });
+        }
+
+        // Fall back to XML parameter extraction
+        let mut args = serde_json::Map::new();
+        for cap in self.param_extractor.captures_iter(trimmed) {
+            let param_name = cap.get(1).map_or("", |m| m.as_str());
+            let is_string = cap.get(2).map_or("true", |m| m.as_str()) == "true";
+            let raw_value = cap.get(3).map_or("", |m| m.as_str());
+
+            let value = if is_string {
+                // string="true" -> always a raw string
+                Value::String(raw_value.to_string())
+            } else {
+                // string="false" -> try to parse as JSON, fall back to string
+                serde_json::from_str::<Value>(raw_value)
+                    .unwrap_or_else(|_| Value::String(raw_value.to_string()))
+            };
+
+            args.insert(param_name.to_string(), value);
+        }
+
+        if args.is_empty() && !trimmed.is_empty() {
+            // Body is non-empty but we couldn't parse it as JSON or XML params
+            return Err(ParserError::ParsingFailed(format!(
+                "Failed to parse invoke body for '{name}'"
+            )));
+        }
+
+        let arguments = serde_json::to_string(&Value::Object(args))
+            .map_err(|e| ParserError::ParsingFailed(e.to_string()))?;
+
+        Ok(ToolCall {
+            function: FunctionCall {
+                name: name.to_string(),
+                arguments,
+            },
+        })
+    }
+}
+
+impl Default for DeepSeekV32Parser {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ToolParser for DeepSeekV32Parser {
+    async fn parse_complete(&self, text: &str) -> ParserResult<(String, Vec<ToolCall>)> {
+        if !self.has_tool_markers(text) {
+            return Ok((text.to_string(), vec![]));
+        }
+
+        // Find where function calls begin
+        let idx = text.find(FUNCTION_CALLS_START).ok_or_else(|| {
+            ParserError::ParsingFailed("DSML function_calls marker not found".to_string())
+        })?;
+        let normal_text = text[..idx].to_string();
+
+        // Extract all invoke blocks
+        let mut tools = Vec::new();
+        for cap in self.invoke_extractor.captures_iter(text) {
+            let func_name = cap.get(1).map_or("", |m| m.as_str()).trim();
+            let body = cap.get(2).map_or("", |m| m.as_str());
+
+            match self.parse_invoke(func_name, body) {
+                Ok(tool) => tools.push(tool),
+                Err(e) => {
+                    tracing::debug!("Failed to parse DSML invoke block: {}", e);
+                    continue;
+                }
+            }
+        }
+
+        // If no tools were successfully parsed despite having markers, return entire text
+        if tools.is_empty() {
+            return Ok((text.to_string(), vec![]));
+        }
+
+        Ok((normal_text, tools))
+    }
+
+    async fn parse_incremental(
+        &mut self,
+        chunk: &str,
+        tools: &[Tool],
+    ) -> ParserResult<StreamingParseResult> {
+        self.buffer.push_str(chunk);
+        let current_text = self.buffer.clone();
+
+        // Check if we have any DSML markers
+        let has_dsml = self.has_tool_markers(&current_text)
+            || current_text.contains("<\u{ff5c}DSML\u{ff5c}invoke");
+
+        if !has_dsml {
+            // No DSML markers detected -- return all buffered content as normal text
+            let mut normal_text = std::mem::take(&mut self.buffer);
+            // Strip out end tokens if present
+            for e_token in [FUNCTION_CALLS_END, INVOKE_END] {
+                normal_text = normal_text.replace(e_token, "");
+            }
+            return Ok(StreamingParseResult {
+                normal_text,
+                calls: vec![],
+            });
+        }
+
+        let tool_indices = helpers::get_tool_indices(tools);
+        let mut calls: Vec<ToolCallItem> = Vec::new();
+
+        // Buffer-until-complete-invoke strategy: look for complete invoke blocks
+        while let Some(cap) = self.invoke_extractor.captures(&self.buffer.clone()) {
+            let full_match = cap.get(0).map_or("", |m| m.as_str());
+            let match_end = cap.get(0).map(|m| m.end()).unwrap_or(0);
+            let func_name = cap.get(1).map_or("", |m| m.as_str()).trim();
+            let body = cap.get(2).map_or("", |m| m.as_str());
+
+            // Validate tool name
+            if !tool_indices.contains_key(func_name) {
+                tracing::debug!(
+                    "Invalid tool name '{}' in DSML invoke - skipping",
+                    func_name
+                );
+                // Remove the invalid invoke from buffer and continue
+                self.buffer = self.buffer.replacen(full_match, "", 1);
+                continue;
+            }
+
+            // Initialize state if this is the first tool call
+            if self.current_tool_id == -1 {
+                self.current_tool_id = 0;
+                self.prev_tool_call_arr = Vec::new();
+                self.streamed_args_for_tool = vec![String::new()];
+            }
+
+            // Ensure capacity
+            helpers::ensure_capacity(
+                self.current_tool_id,
+                &mut self.prev_tool_call_arr,
+                &mut self.streamed_args_for_tool,
+            );
+
+            let tool_id = self.current_tool_id as usize;
+
+            // Parse the invoke body to get arguments
+            match self.parse_invoke(func_name, body) {
+                Ok(tool_call) => {
+                    // Emit name
+                    calls.push(ToolCallItem {
+                        tool_index: tool_id,
+                        name: Some(func_name.to_string()),
+                        parameters: String::new(),
+                    });
+
+                    // Emit full arguments at once
+                    let args_str = &tool_call.function.arguments;
+                    if !args_str.is_empty() {
+                        calls.push(ToolCallItem {
+                            tool_index: tool_id,
+                            name: None,
+                            parameters: args_str.clone(),
+                        });
+                        if tool_id < self.streamed_args_for_tool.len() {
+                            self.streamed_args_for_tool[tool_id].push_str(args_str);
+                        }
+                    }
+
+                    // Store the tool call info
+                    if tool_id < self.prev_tool_call_arr.len() {
+                        self.prev_tool_call_arr[tool_id] = serde_json::json!({
+                            "name": func_name,
+                            "arguments": serde_json::from_str::<Value>(args_str).unwrap_or(Value::Object(serde_json::Map::new())),
+                        });
+                    }
+                }
+                Err(e) => {
+                    tracing::debug!("Failed to parse DSML invoke during streaming: {}", e);
+                    // Remove the broken invoke from buffer and continue
+                    self.buffer = self.buffer.replacen(full_match, "", 1);
+                    continue;
+                }
+            }
+
+            // Remove the completed invoke from buffer
+            self.buffer = self.buffer[match_end..].to_string();
+
+            // Advance to next tool
+            self.current_tool_id += 1;
+            self.current_tool_name_sent = false;
+        }
+
+        Ok(StreamingParseResult {
+            normal_text: String::new(),
+            calls,
+        })
+    }
+
+    fn has_tool_markers(&self, text: &str) -> bool {
+        text.contains(FUNCTION_CALLS_START)
+    }
+
+    fn get_unstreamed_tool_args(&self) -> Option<Vec<ToolCallItem>> {
+        helpers::get_unstreamed_args(&self.prev_tool_call_arr, &self.streamed_args_for_tool)
+    }
+
+    fn reset(&mut self) {
+        self.buffer.clear();
+        self.prev_tool_call_arr.clear();
+        self.current_tool_id = -1;
+        self.current_tool_name_sent = false;
+        self.streamed_args_for_tool.clear();
+    }
+}

--- a/crates/tool_parser/src/parsers/deepseek_v32.rs
+++ b/crates/tool_parser/src/parsers/deepseek_v32.rs
@@ -170,6 +170,7 @@ impl ToolParser for DeepSeekV32Parser {
         }
 
         // Find where function calls begin
+        // INVARIANT: has_tool_markers() already confirmed the marker exists
         let idx = text.find(FUNCTION_CALLS_START).ok_or_else(|| {
             ParserError::ParsingFailed("DSML function_calls marker not found".to_string())
         })?;
@@ -204,15 +205,25 @@ impl ToolParser for DeepSeekV32Parser {
         tools: &[Tool],
     ) -> ParserResult<StreamingParseResult> {
         self.buffer.push_str(chunk);
-        let current_text = self.buffer.clone();
 
         // Check if we have any DSML markers
-        let has_dsml = self.has_tool_markers(&current_text)
-            || current_text.contains("<\u{ff5c}DSML\u{ff5c}invoke");
+        let has_dsml = self.has_tool_markers(&self.buffer)
+            || self.buffer.contains("<\u{ff5c}DSML\u{ff5c}invoke");
 
         if !has_dsml {
-            // No DSML markers detected -- return all buffered content as normal text
-            let mut normal_text = std::mem::take(&mut self.buffer);
+            // No DSML markers detected -- return buffered content as normal text,
+            // but retain any suffix that could be the start of a DSML tag.
+            // All DSML tags start with "<\u{ff5c}", so keep everything from the
+            // last occurrence of that prefix to avoid flushing a partial tag.
+            let buf = std::mem::take(&mut self.buffer);
+            let (flush, retain) = if let Some(pos) = buf.rfind("<\u{ff5c}") {
+                (buf[..pos].to_string(), buf[pos..].to_string())
+            } else {
+                (buf, String::new())
+            };
+            self.buffer = retain;
+
+            let mut normal_text = flush;
             // Strip out end tokens if present
             for e_token in [FUNCTION_CALLS_END, INVOKE_END] {
                 normal_text = normal_text.replace(e_token, "");
@@ -225,9 +236,24 @@ impl ToolParser for DeepSeekV32Parser {
 
         let tool_indices = helpers::get_tool_indices(tools);
         let mut calls: Vec<ToolCallItem> = Vec::new();
+        let mut normal_text = String::new();
+
+        // Emit any text that appears before the DSML block
+        if let Some(dsml_start) = self.buffer.find(FUNCTION_CALLS_START) {
+            if dsml_start > 0 {
+                normal_text = self.buffer[..dsml_start].to_string();
+                self.buffer = self.buffer[dsml_start..].to_string();
+            }
+        }
 
         // Buffer-until-complete-invoke strategy: look for complete invoke blocks
-        while let Some(cap) = self.invoke_extractor.captures(&self.buffer.clone()) {
+        // Clone needed because regex captures borrow the string, but we mutate
+        // the buffer inside the loop body.
+        loop {
+            let current_text = self.buffer.clone();
+            let Some(cap) = self.invoke_extractor.captures(&current_text) else {
+                break;
+            };
             let full_match = cap.get(0).map_or("", |m| m.as_str());
             let match_end = cap.get(0).map(|m| m.end()).unwrap_or(0);
             let func_name = cap.get(1).map_or("", |m| m.as_str()).trim();
@@ -307,10 +333,7 @@ impl ToolParser for DeepSeekV32Parser {
             self.current_tool_name_sent = false;
         }
 
-        Ok(StreamingParseResult {
-            normal_text: String::new(),
-            calls,
-        })
+        Ok(StreamingParseResult { normal_text, calls })
     }
 
     fn has_tool_markers(&self, text: &str) -> bool {

--- a/crates/tool_parser/src/parsers/mod.rs
+++ b/crates/tool_parser/src/parsers/mod.rs
@@ -5,6 +5,7 @@
 // Individual parser modules
 pub mod cohere;
 pub mod deepseek;
+pub mod deepseek_v32;
 pub mod glm4_moe;
 pub mod json;
 pub mod kimik2;
@@ -23,6 +24,7 @@ pub mod helpers;
 // Re-export parser types for convenience
 pub use cohere::CohereParser;
 pub use deepseek::DeepSeekParser;
+pub use deepseek_v32::DeepSeekV32Parser;
 pub use glm4_moe::Glm4MoeParser;
 pub use json::JsonParser;
 pub use kimik2::KimiK2Parser;

--- a/crates/tool_parser/tests/tool_parser_deepseek_v32.rs
+++ b/crates/tool_parser/tests/tool_parser_deepseek_v32.rs
@@ -136,6 +136,7 @@ async fn test_dsml_streaming_chunked() {
 
     let mut found_name = false;
     let mut found_args = false;
+    let mut collected_args_chunks: Vec<String> = Vec::new();
 
     for chunk in chunks {
         let result = parser.parse_incremental(chunk, &tools).await.unwrap();
@@ -147,12 +148,20 @@ async fn test_dsml_streaming_chunked() {
             }
             if call.name.is_none() && !call.parameters.is_empty() {
                 found_args = true;
+                collected_args_chunks.push(call.parameters.clone());
             }
         }
     }
 
     assert!(found_name, "Should have found tool name during streaming");
-    assert!(found_args, "Should have found tool arguments during streaming");
+    assert!(
+        found_args,
+        "Should have found tool arguments during streaming"
+    );
+
+    let full_args: String = collected_args_chunks.join("");
+    let _: serde_json::Value =
+        serde_json::from_str(&full_args).expect("Collected argument chunks should form valid JSON");
 }
 
 #[tokio::test]
@@ -194,9 +203,7 @@ fn test_dsml_format_detection() {
 
     // Should detect DSML format
     assert!(parser.has_tool_markers("<\u{ff5c}DSML\u{ff5c}function_calls>"));
-    assert!(parser.has_tool_markers(
-        "text with <\u{ff5c}DSML\u{ff5c}function_calls> marker"
-    ));
+    assert!(parser.has_tool_markers("text with <\u{ff5c}DSML\u{ff5c}function_calls> marker"));
 
     // Should not detect other formats
     assert!(!parser.has_tool_markers("<\u{ff5c}tool\u{2581}calls\u{2581}begin\u{ff5c}>"));
@@ -309,7 +316,10 @@ async fn test_dsml_streaming_xml_parameters() {
     }
 
     assert!(found_name, "Should have found tool name during streaming");
-    assert!(found_args, "Should have found tool arguments during streaming");
+    assert!(
+        found_args,
+        "Should have found tool arguments during streaming"
+    );
 }
 
 #[tokio::test]
@@ -329,16 +339,33 @@ async fn test_dsml_reset() {
     // Reset
     parser.reset();
 
-    // After reset, parser should work fresh
-    let input = "<\u{ff5c}DSML\u{ff5c}function_calls>\n\
-        <\u{ff5c}DSML\u{ff5c}invoke name=\"get_weather\">\n\
-        {\"location\": \"Paris\"}\n\
-        </\u{ff5c}DSML\u{ff5c}invoke>\n\
-        </\u{ff5c}DSML\u{ff5c}function_calls>";
+    // After reset, reuse the SAME parser instance to verify state was cleared
+    let chunks = vec![
+        "<\u{ff5c}DSML\u{ff5c}function_calls>\n",
+        "<\u{ff5c}DSML\u{ff5c}invoke name=\"get_weather\">\n",
+        "{\"location\": \"Paris\"}\n",
+        "</\u{ff5c}DSML\u{ff5c}invoke>\n",
+        "</\u{ff5c}DSML\u{ff5c}function_calls>",
+    ];
 
-    // Use parse_complete on a fresh parser to verify it works
-    let fresh_parser = DeepSeekV32Parser::new();
-    let (_, tools_result) = fresh_parser.parse_complete(input).await.unwrap();
-    assert_eq!(tools_result.len(), 1);
-    assert_eq!(tools_result[0].function.name, "get_weather");
+    let mut found_name = false;
+    let mut found_args = false;
+
+    for chunk in chunks {
+        let result = parser.parse_incremental(chunk, &tools).await.unwrap();
+        for call in result.calls {
+            if let Some(name) = &call.name {
+                assert_eq!(name, "get_weather");
+                found_name = true;
+            }
+            if call.name.is_none() && !call.parameters.is_empty() {
+                let args: serde_json::Value = serde_json::from_str(&call.parameters).unwrap();
+                assert_eq!(args["location"], "Paris");
+                found_args = true;
+            }
+        }
+    }
+
+    assert!(found_name, "After reset, parser should find tool name");
+    assert!(found_args, "After reset, parser should find tool arguments");
 }

--- a/crates/tool_parser/tests/tool_parser_deepseek_v32.rs
+++ b/crates/tool_parser/tests/tool_parser_deepseek_v32.rs
@@ -1,0 +1,344 @@
+//! DeepSeek V3.2 DSML Parser Integration Tests
+mod common;
+
+use common::create_test_tools;
+use tool_parser::{DeepSeekV32Parser, ToolParser};
+
+#[tokio::test]
+async fn test_dsml_complete_xml_parameters() {
+    let parser = DeepSeekV32Parser::new();
+
+    let input = "Let me check that for you.\n\
+        <\u{ff5c}DSML\u{ff5c}function_calls>\n\
+        <\u{ff5c}DSML\u{ff5c}invoke name=\"get_weather\">\n\
+        <\u{ff5c}DSML\u{ff5c}parameter name=\"location\" string=\"true\">Tokyo</\u{ff5c}DSML\u{ff5c}parameter>\n\
+        <\u{ff5c}DSML\u{ff5c}parameter name=\"units\" string=\"true\">celsius</\u{ff5c}DSML\u{ff5c}parameter>\n\
+        </\u{ff5c}DSML\u{ff5c}invoke>\n\
+        </\u{ff5c}DSML\u{ff5c}function_calls>";
+
+    let (normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(normal_text, "Let me check that for you.\n");
+    assert_eq!(tools[0].function.name, "get_weather");
+
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
+    assert_eq!(args["location"], "Tokyo");
+    assert_eq!(args["units"], "celsius");
+}
+
+#[tokio::test]
+async fn test_dsml_complete_json_body() {
+    let parser = DeepSeekV32Parser::new();
+
+    let input = "<\u{ff5c}DSML\u{ff5c}function_calls>\n\
+        <\u{ff5c}DSML\u{ff5c}invoke name=\"get_weather\">\n\
+        {\"location\": \"Tokyo\", \"units\": \"celsius\"}\n\
+        </\u{ff5c}DSML\u{ff5c}invoke>\n\
+        </\u{ff5c}DSML\u{ff5c}function_calls>";
+
+    let (normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(normal_text, "");
+    assert_eq!(tools[0].function.name, "get_weather");
+
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
+    assert_eq!(args["location"], "Tokyo");
+    assert_eq!(args["units"], "celsius");
+}
+
+#[tokio::test]
+async fn test_dsml_string_false_type_coercion() {
+    let parser = DeepSeekV32Parser::new();
+
+    let input = "<\u{ff5c}DSML\u{ff5c}function_calls>\n\
+        <\u{ff5c}DSML\u{ff5c}invoke name=\"process\">\n\
+        <\u{ff5c}DSML\u{ff5c}parameter name=\"count\" string=\"false\">5</\u{ff5c}DSML\u{ff5c}parameter>\n\
+        <\u{ff5c}DSML\u{ff5c}parameter name=\"rate\" string=\"false\">7.5</\u{ff5c}DSML\u{ff5c}parameter>\n\
+        <\u{ff5c}DSML\u{ff5c}parameter name=\"enabled\" string=\"false\">true</\u{ff5c}DSML\u{ff5c}parameter>\n\
+        <\u{ff5c}DSML\u{ff5c}parameter name=\"text\" string=\"true\">hello world</\u{ff5c}DSML\u{ff5c}parameter>\n\
+        </\u{ff5c}DSML\u{ff5c}invoke>\n\
+        </\u{ff5c}DSML\u{ff5c}function_calls>";
+
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "process");
+
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
+    // string="false" values should be parsed as their JSON types
+    assert_eq!(args["count"], 5);
+    assert_eq!(args["rate"], 7.5);
+    assert_eq!(args["enabled"], true);
+    // string="true" value should be a raw string
+    assert_eq!(args["text"], "hello world");
+}
+
+#[tokio::test]
+async fn test_dsml_string_false_fallback_to_string() {
+    let parser = DeepSeekV32Parser::new();
+
+    // When string="false" but the value is not valid JSON, it should fall back to string
+    let input = "<\u{ff5c}DSML\u{ff5c}function_calls>\n\
+        <\u{ff5c}DSML\u{ff5c}invoke name=\"search\">\n\
+        <\u{ff5c}DSML\u{ff5c}parameter name=\"query\" string=\"false\">not valid json here</\u{ff5c}DSML\u{ff5c}parameter>\n\
+        </\u{ff5c}DSML\u{ff5c}invoke>\n\
+        </\u{ff5c}DSML\u{ff5c}function_calls>";
+
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "search");
+
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
+    // Should fall back to string when JSON parse fails
+    assert_eq!(args["query"], "not valid json here");
+}
+
+#[tokio::test]
+async fn test_dsml_multiple_invocations() {
+    let parser = DeepSeekV32Parser::new();
+
+    let input = "<\u{ff5c}DSML\u{ff5c}function_calls>\n\
+        <\u{ff5c}DSML\u{ff5c}invoke name=\"search\">\n\
+        <\u{ff5c}DSML\u{ff5c}parameter name=\"query\" string=\"true\">rust programming</\u{ff5c}DSML\u{ff5c}parameter>\n\
+        </\u{ff5c}DSML\u{ff5c}invoke>\n\
+        <\u{ff5c}DSML\u{ff5c}invoke name=\"translate\">\n\
+        {\"text\": \"Hello World\", \"to\": \"ja\"}\n\
+        </\u{ff5c}DSML\u{ff5c}invoke>\n\
+        </\u{ff5c}DSML\u{ff5c}function_calls>";
+
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 2);
+    assert_eq!(tools[0].function.name, "search");
+    assert_eq!(tools[1].function.name, "translate");
+
+    let args0: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
+    assert_eq!(args0["query"], "rust programming");
+
+    let args1: serde_json::Value = serde_json::from_str(&tools[1].function.arguments).unwrap();
+    assert_eq!(args1["text"], "Hello World");
+    assert_eq!(args1["to"], "ja");
+}
+
+#[tokio::test]
+async fn test_dsml_streaming_chunked() {
+    let tools = create_test_tools();
+    let mut parser = DeepSeekV32Parser::new();
+
+    // Simulate streaming chunks that build up a complete DSML invoke
+    let chunks = vec![
+        "<\u{ff5c}DSML\u{ff5c}function_calls>\n",
+        "<\u{ff5c}DSML\u{ff5c}invoke name=\"get_weather\">\n",
+        "{\"location\": ",
+        "\"Beijing\", ",
+        "\"units\": \"metric\"}",
+        "\n</\u{ff5c}DSML\u{ff5c}invoke>",
+        "\n</\u{ff5c}DSML\u{ff5c}function_calls>",
+    ];
+
+    let mut found_name = false;
+    let mut found_args = false;
+
+    for chunk in chunks {
+        let result = parser.parse_incremental(chunk, &tools).await.unwrap();
+
+        for call in result.calls {
+            if let Some(name) = &call.name {
+                assert_eq!(name, "get_weather");
+                found_name = true;
+            }
+            if call.name.is_none() && !call.parameters.is_empty() {
+                found_args = true;
+            }
+        }
+    }
+
+    assert!(found_name, "Should have found tool name during streaming");
+    assert!(found_args, "Should have found tool arguments during streaming");
+}
+
+#[tokio::test]
+async fn test_dsml_streaming_multiple_invocations() {
+    let tools = create_test_tools();
+    let mut parser = DeepSeekV32Parser::new();
+
+    let chunks = vec![
+        "<\u{ff5c}DSML\u{ff5c}function_calls>\n",
+        "<\u{ff5c}DSML\u{ff5c}invoke name=\"search\">\n",
+        "{\"query\": \"rust\"}\n",
+        "</\u{ff5c}DSML\u{ff5c}invoke>\n",
+        "<\u{ff5c}DSML\u{ff5c}invoke name=\"translate\">\n",
+        "{\"text\": \"hello\", \"to\": \"ja\"}\n",
+        "</\u{ff5c}DSML\u{ff5c}invoke>\n",
+        "</\u{ff5c}DSML\u{ff5c}function_calls>",
+    ];
+
+    let mut names_found: Vec<String> = Vec::new();
+
+    for chunk in chunks {
+        let result = parser.parse_incremental(chunk, &tools).await.unwrap();
+
+        for call in result.calls {
+            if let Some(name) = call.name {
+                names_found.push(name);
+            }
+        }
+    }
+
+    assert_eq!(names_found.len(), 2);
+    assert_eq!(names_found[0], "search");
+    assert_eq!(names_found[1], "translate");
+}
+
+#[test]
+fn test_dsml_format_detection() {
+    let parser = DeepSeekV32Parser::new();
+
+    // Should detect DSML format
+    assert!(parser.has_tool_markers("<\u{ff5c}DSML\u{ff5c}function_calls>"));
+    assert!(parser.has_tool_markers(
+        "text with <\u{ff5c}DSML\u{ff5c}function_calls> marker"
+    ));
+
+    // Should not detect other formats
+    assert!(!parser.has_tool_markers("<\u{ff5c}tool\u{2581}calls\u{2581}begin\u{ff5c}>"));
+    assert!(!parser.has_tool_markers("[TOOL_CALLS]"));
+    assert!(!parser.has_tool_markers("<tool_call>"));
+    assert!(!parser.has_tool_markers("plain text"));
+}
+
+#[tokio::test]
+async fn test_dsml_normal_text_before_block() {
+    let parser = DeepSeekV32Parser::new();
+
+    let input = "Sure, I'll look that up for you!\n\
+        <\u{ff5c}DSML\u{ff5c}function_calls>\n\
+        <\u{ff5c}DSML\u{ff5c}invoke name=\"search\">\n\
+        {\"query\": \"rust async\"}\n\
+        </\u{ff5c}DSML\u{ff5c}invoke>\n\
+        </\u{ff5c}DSML\u{ff5c}function_calls>";
+
+    let (normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(normal_text, "Sure, I'll look that up for you!\n");
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "search");
+}
+
+#[tokio::test]
+async fn test_dsml_no_tool_markers() {
+    let parser = DeepSeekV32Parser::new();
+
+    let input = "This is just normal text with no tool calls.";
+
+    let (normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(normal_text, input);
+    assert!(tools.is_empty());
+}
+
+#[tokio::test]
+async fn test_dsml_nested_json_in_parameter() {
+    let parser = DeepSeekV32Parser::new();
+
+    let input = "<\u{ff5c}DSML\u{ff5c}function_calls>\n\
+        <\u{ff5c}DSML\u{ff5c}invoke name=\"process\">\n\
+        <\u{ff5c}DSML\u{ff5c}parameter name=\"data\" string=\"false\">{\"nested\": {\"deep\": [1, 2, 3]}}</\u{ff5c}DSML\u{ff5c}parameter>\n\
+        </\u{ff5c}DSML\u{ff5c}invoke>\n\
+        </\u{ff5c}DSML\u{ff5c}function_calls>";
+
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "process");
+
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
+    assert!(args["data"]["nested"]["deep"].is_array());
+    assert_eq!(args["data"]["nested"]["deep"][0], 1);
+}
+
+#[tokio::test]
+async fn test_dsml_empty_args() {
+    let parser = DeepSeekV32Parser::new();
+
+    // Invoke with empty body -- should produce empty object
+    let input = "<\u{ff5c}DSML\u{ff5c}function_calls>\n\
+        <\u{ff5c}DSML\u{ff5c}invoke name=\"ping\">\n\
+        </\u{ff5c}DSML\u{ff5c}invoke>\n\
+        </\u{ff5c}DSML\u{ff5c}function_calls>";
+
+    let (_normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].function.name, "ping");
+
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
+    assert!(args.is_object());
+}
+
+#[tokio::test]
+async fn test_dsml_streaming_xml_parameters() {
+    let tools = create_test_tools();
+    let mut parser = DeepSeekV32Parser::new();
+
+    // Stream an invoke with XML parameters
+    let chunks = vec![
+        "<\u{ff5c}DSML\u{ff5c}function_calls>\n",
+        "<\u{ff5c}DSML\u{ff5c}invoke name=\"process\">\n",
+        "<\u{ff5c}DSML\u{ff5c}parameter name=\"count\" ",
+        "string=\"false\">42",
+        "</\u{ff5c}DSML\u{ff5c}parameter>\n",
+        "<\u{ff5c}DSML\u{ff5c}parameter name=\"text\" string=\"true\">hello</\u{ff5c}DSML\u{ff5c}parameter>\n",
+        "</\u{ff5c}DSML\u{ff5c}invoke>",
+        "\n</\u{ff5c}DSML\u{ff5c}function_calls>",
+    ];
+
+    let mut found_name = false;
+    let mut found_args = false;
+
+    for chunk in chunks {
+        let result = parser.parse_incremental(chunk, &tools).await.unwrap();
+
+        for call in result.calls {
+            if let Some(name) = &call.name {
+                assert_eq!(name, "process");
+                found_name = true;
+            }
+            if call.name.is_none() && !call.parameters.is_empty() {
+                found_args = true;
+                // Verify the arguments are valid JSON
+                let args: serde_json::Value = serde_json::from_str(&call.parameters).unwrap();
+                assert_eq!(args["count"], 42);
+                assert_eq!(args["text"], "hello");
+            }
+        }
+    }
+
+    assert!(found_name, "Should have found tool name during streaming");
+    assert!(found_args, "Should have found tool arguments during streaming");
+}
+
+#[tokio::test]
+async fn test_dsml_reset() {
+    let tools = create_test_tools();
+    let mut parser = DeepSeekV32Parser::new();
+
+    // Feed partial data
+    let _ = parser
+        .parse_incremental(
+            "<\u{ff5c}DSML\u{ff5c}function_calls>\n<\u{ff5c}DSML\u{ff5c}invoke name=\"search\">\n",
+            &tools,
+        )
+        .await
+        .unwrap();
+
+    // Reset
+    parser.reset();
+
+    // After reset, parser should work fresh
+    let input = "<\u{ff5c}DSML\u{ff5c}function_calls>\n\
+        <\u{ff5c}DSML\u{ff5c}invoke name=\"get_weather\">\n\
+        {\"location\": \"Paris\"}\n\
+        </\u{ff5c}DSML\u{ff5c}invoke>\n\
+        </\u{ff5c}DSML\u{ff5c}function_calls>";
+
+    // Use parse_complete on a fresh parser to verify it works
+    let fresh_parser = DeepSeekV32Parser::new();
+    let (_, tools_result) = fresh_parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools_result.len(), 1);
+    assert_eq!(tools_result[0].function.name, "get_weather");
+}


### PR DESCRIPTION
## Description

### Problem
DeepSeek V3.2 introduces DSML (DeepSeek Markup Language), a completely new XML-like tool call format that differs fundamentally from V3's Unicode token delimiter format. Without a dedicated parser, V3.2 model outputs cannot be parsed for tool calls.

### Solution
Add a `DeepSeekV32Parser` that handles the DSML format with dual-format support (XML parameters and inline JSON), a `string` type attribute system, and buffer-until-complete-invoke streaming.

## Changes

### New files
- `crates/tool_parser/src/parsers/deepseek_v32.rs` -- New parser implementing `ToolParser` trait
- `crates/tool_parser/tests/tool_parser_deepseek_v32.rs` -- 14 integration tests

### Modified files
- `crates/tool_parser/src/parsers/mod.rs` -- Register module and re-export
- `crates/tool_parser/src/factory.rs` -- Register parser and add model mappings (`deepseek-v3.2*`, `deepseek-ai/DeepSeek-V3.2*`)
- `crates/tool_parser/src/lib.rs` -- Add `DeepSeekV32Parser` to public re-exports

### DSML format details

**XML parameter format:**
```xml
<｜DSML｜function_calls>
<｜DSML｜invoke name="get_weather">
<｜DSML｜parameter name="location" string="true">Tokyo</｜DSML｜parameter>
<｜DSML｜parameter name="count" string="false">5</｜DSML｜parameter>
</｜DSML｜invoke>
</｜DSML｜function_calls>
```

**Inline JSON format (dual format):**
```xml
<｜DSML｜invoke name="get_weather">
{"location": "Tokyo", "count": 5}
</｜DSML｜invoke>
```

### Key design decisions
- **Dual format**: JSON body is tried first, XML parameter extraction is the fallback
- **Type system**: `string="true"` produces raw string values, `string="false"` parses as JSON with graceful fallback to string if parsing fails
- **Streaming**: Buffer-until-complete-invoke strategy -- chunks accumulate until a full `</｜DSML｜invoke>` is found, then name + arguments are emitted at once. This avoids partial parse complexity since DSML tags cannot be incrementally parsed.

## Test Plan
- 14 integration tests covering:
  - Complete parsing with XML parameters (`string="true"` and `string="false"`)
  - Complete parsing with JSON inside invoke blocks
  - Type coercion for `string="false"` (numbers, floats, booleans)
  - `string="false"` fallback to string when JSON parse fails
  - Multiple invocations in a single function_calls block
  - Streaming with chunked delivery (JSON body)
  - Streaming with multiple invocations
  - Streaming with XML parameters
  - `has_tool_markers` positive and negative detection
  - Normal text extraction before DSML block
  - Nested JSON in parameters
  - Empty argument invocations
  - Parser reset
- Existing V3 DeepSeek tests continue to pass (7/7)
- `cargo clippy -p tool-parser --all-targets -- -D warnings` passes clean

<details>
<summary>Checklist</summary>

- [x] New parser implementation
- [x] Factory registration and model mappings
- [x] Public re-exports
- [x] Integration tests (14 tests)
- [x] Existing tests unaffected
- [x] Clippy clean
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for DeepSeek V3.2 DSML parsing, extracting tool calls from V3.2 model output.
  * Handles both full-message and streaming/incremental DSML inputs and accepts JSON or XML-style parameter formats.
  * Model routing updated so V3.2 model IDs select the new parser.

* **Tests**
  * Added comprehensive tests for complete and streaming parsing, parameter coercion, multiple invokes, marker detection, and reset behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->