### PR TITLE
chore: bump smg-grpc-proto to 0.4.5

### DIFF
--- a/crates/grpc_client/python/pyproject.toml
+++ b/crates/grpc_client/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "smg-grpc-proto"
-version = "0.4.4"
+version = "0.4.5"
 description = "SMG gRPC proto definitions for SGLang, vLLM, and TRT-LLM"
 requires-python = ">=3.10"
 dependencies = [


### PR DESCRIPTION
## Description

### Problem

PR #879 added `include_stop_token_in_output` to the trtllm gRPC proto. Need to release a new version of `smg-grpc-proto` so TRT-LLM can depend on it.

### Solution

Bump version 0.4.4 → 0.4.5. The `release-grpc.yml` workflow will automatically build and upload to PyPI when this merges to main.

## Changes

- `crates/grpc_client/python/pyproject.toml` — version 0.4.4 → 0.4.5

## Test Plan

No code changes, version bump only.

<details>
<summary>Checklist</summary>

- [x] Version bump only, no code changes

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Python gRPC client package version to 0.4.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->