### PR TITLE
fix(multimodal): fall back to config.model_type for aliased model IDs

### DIFF
--- a/crates/multimodal/src/registry/llama4.rs
+++ b/crates/multimodal/src/registry/llama4.rs
@@ -83,8 +83,11 @@ impl ModelProcessorSpec for Llama4Spec {
 
     fn matches(&self, metadata: &ModelMetadata) -> bool {
         let id = metadata.model_id.to_ascii_lowercase();
-        // Match "llama-4", "llama4", "Llama-4-Maverick", "Llama-4-Scout", etc.
-        id.contains("llama-4") || id.contains("llama4")
+        id.contains("llama-4")
+            || id.contains("llama4")
+            || metadata
+                .config_model_type()
+                .is_some_and(|mt| mt == "llama4")
     }
 
     fn placeholder_token(&self, _metadata: &ModelMetadata) -> RegistryResult<String> {
@@ -264,5 +267,30 @@ mod tests {
                                                                      // The token before the last patch block is <|image|> (global tile marker)
                                                                      // Position: 1 + 290 + 290 = 581
         assert_eq!(replacements[0].tokens[581], 200090); // <|image|>
+    }
+
+    #[test]
+    fn llama4_matches_alias_via_model_type() {
+        let tokenizer = TestTokenizer::new(&[
+            ("<|image|>", 200090),
+            ("<|image_start|>", 200088),
+            ("<|image_end|>", 200089),
+            ("<|patch|>", 200092),
+            ("<|tile_x_separator|>", 200093),
+            ("<|tile_y_separator|>", 200094),
+        ]);
+        let config = json!({
+            "model_type": "llama4",
+            "image_token_index": 200092,
+            "vision_config": {"image_size": 336, "patch_size": 14}
+        });
+        let metadata = ModelMetadata {
+            model_id: "custom-model",
+            tokenizer: &tokenizer,
+            config: &config,
+        };
+        let registry = ModelRegistry::new();
+        let spec = registry.lookup(&metadata).expect("llama4 alias");
+        assert_eq!(spec.name(), "llama4");
     }
 }

--- a/crates/multimodal/src/registry/llava.rs
+++ b/crates/multimodal/src/registry/llava.rs
@@ -32,6 +32,9 @@ impl ModelProcessorSpec for LlavaSpec {
 
     fn matches(&self, metadata: &ModelMetadata) -> bool {
         metadata.model_id.to_ascii_lowercase().contains("llava")
+            || metadata
+                .config_model_type()
+                .is_some_and(|mt| mt == "llava" || mt == "llava_next")
     }
 
     fn placeholder_token(&self, _metadata: &ModelMetadata) -> RegistryResult<String> {
@@ -102,5 +105,23 @@ mod tests {
             .prompt_replacements(&metadata, &test_preprocessed(&[ImageSize::new(336, 336)]))
             .unwrap();
         assert_eq!(replacements[0].tokens.len(), 576);
+    }
+
+    #[test]
+    fn llava_matches_alias_via_model_type() {
+        let tokenizer = TestTokenizer::new(&[("<image>", 32000)]);
+        let config = json!({
+            "model_type": "llava",
+            "image_token_index": 32000,
+            "vision_config": {"patch_size": 14}
+        });
+        let metadata = ModelMetadata {
+            model_id: "custom-model",
+            tokenizer: &tokenizer,
+            config: &config,
+        };
+        let registry = ModelRegistry::new();
+        let spec = registry.lookup(&metadata).expect("llava alias");
+        assert_eq!(spec.name(), "llava");
     }
 }

--- a/crates/multimodal/src/registry/phi3_v.rs
+++ b/crates/multimodal/src/registry/phi3_v.rs
@@ -26,6 +26,9 @@ impl ModelProcessorSpec for Phi3VisionSpec {
     fn matches(&self, metadata: &ModelMetadata) -> bool {
         let id = metadata.model_id.to_ascii_lowercase();
         id.contains("phi") && id.contains("vision")
+            || metadata
+                .config_model_type()
+                .is_some_and(|mt| mt == "phi3_v")
     }
 
     fn placeholder_token(&self, _metadata: &ModelMetadata) -> RegistryResult<String> {
@@ -91,5 +94,22 @@ mod tests {
             .unwrap();
         assert_eq!(replacements[0].tokens.len(), 144);
         assert_eq!(replacements[0].tokens[0], 555);
+    }
+
+    #[test]
+    fn phi3_matches_alias_via_model_type() {
+        let tokenizer = TestTokenizer::new(&[("<image>", 555)]);
+        let config = json!({
+            "model_type": "phi3_v",
+            "img_processor": {"num_img_tokens": 144}
+        });
+        let metadata = ModelMetadata {
+            model_id: "custom-model",
+            tokenizer: &tokenizer,
+            config: &config,
+        };
+        let registry = ModelRegistry::new();
+        let spec = registry.lookup(&metadata).expect("phi3 alias");
+        assert_eq!(spec.name(), "phi3_v");
     }
 }

--- a/crates/multimodal/src/registry/qwen3_vl.rs
+++ b/crates/multimodal/src/registry/qwen3_vl.rs
@@ -47,6 +47,9 @@ impl ModelProcessorSpec for Qwen3VLVisionSpec {
     fn matches(&self, metadata: &ModelMetadata) -> bool {
         let id = metadata.model_id.to_ascii_lowercase();
         id.contains("qwen3") && id.contains("vl")
+            || metadata
+                .config_model_type()
+                .is_some_and(|mt| mt == "qwen3_vl")
     }
 
     fn placeholder_token(&self, metadata: &ModelMetadata) -> RegistryResult<String> {
@@ -174,6 +177,27 @@ mod tests {
         let registry = ModelRegistry::new();
         let spec = registry.lookup(&metadata).expect("should match qwen3");
         // Must match qwen3_vl spec, not qwen_vl
+        assert_eq!(spec.name(), "qwen3_vl");
+    }
+
+    #[test]
+    fn qwen3_vl_matches_alias_via_model_type() {
+        let tokenizer = TestTokenizer::new(&[("<|image_pad|>", 151655)]);
+        let config = json!({
+            "model_type": "qwen3_vl",
+            "vision_start_token_id": 151652,
+            "image_token_id": 151655,
+            "vision_end_token_id": 151653
+        });
+        let metadata = ModelMetadata {
+            model_id: "custom-model",
+            tokenizer: &tokenizer,
+            config: &config,
+        };
+        let registry = ModelRegistry::new();
+        let spec = registry
+            .lookup(&metadata)
+            .expect("should match qwen3 alias");
         assert_eq!(spec.name(), "qwen3_vl");
     }
 }

--- a/crates/multimodal/src/registry/qwen_vl.rs
+++ b/crates/multimodal/src/registry/qwen_vl.rs
@@ -36,8 +36,11 @@ impl ModelProcessorSpec for QwenVLVisionSpec {
     }
 
     fn matches(&self, metadata: &ModelMetadata) -> bool {
-        metadata.model_id.to_ascii_lowercase().contains("qwen")
-            && metadata.model_id.to_ascii_lowercase().contains("vl")
+        let id = metadata.model_id.to_ascii_lowercase();
+        id.contains("qwen") && id.contains("vl")
+            || metadata
+                .config_model_type()
+                .is_some_and(|mt| mt == "qwen2_vl")
     }
 
     fn placeholder_token(&self, _metadata: &ModelMetadata) -> RegistryResult<String> {
@@ -137,5 +140,24 @@ mod tests {
         assert_eq!(replacements[0].tokens.len(), 257);
         assert_eq!(replacements[0].tokens[0], 151652);
         assert_eq!(replacements[0].tokens[1], 151654);
+    }
+
+    #[test]
+    fn qwen_vl_matches_alias_via_model_type() {
+        let tokenizer = TestTokenizer::new(&[("<image>", 999)]);
+        let config = json!({
+            "model_type": "qwen2_vl",
+            "vision_start_token_id": 151652,
+            "vision_token_id": 151654,
+            "image_token_id": 151655
+        });
+        let metadata = ModelMetadata {
+            model_id: "custom-model",
+            tokenizer: &tokenizer,
+            config: &config,
+        };
+        let registry = ModelRegistry::new();
+        let spec = registry.lookup(&metadata).expect("should match qwen alias");
+        assert_eq!(spec.name(), "qwen_vl");
     }
 }

--- a/crates/multimodal/src/registry/traits.rs
+++ b/crates/multimodal/src/registry/traits.rs
@@ -42,6 +42,10 @@ impl<'a> ModelMetadata<'a> {
         Self::find_value(self.config, path).and_then(|value| value.as_u64().map(|v| v as u32))
     }
 
+    pub fn config_model_type(&self) -> Option<&str> {
+        Self::find_value(self.config, &["model_type"]).and_then(Value::as_str)
+    }
+
     fn find_value<'v>(value: &'v Value, path: &[&str]) -> Option<&'v Value> {
         let mut current = value;
         for key in path {

--- a/crates/multimodal/src/vision/image_processor.rs
+++ b/crates/multimodal/src/vision/image_processor.rs
@@ -337,22 +337,22 @@ impl ImageProcessorRegistry {
         self.processors.insert(pattern.into(), processor);
     }
 
-    /// Find a processor for the given model ID.
+    /// Find a processor for the given model ID, falling back to model_type.
     ///
     /// Matches by substring containment (case-insensitive).
-    pub fn find(&self, model_id: &str) -> Option<&dyn ImagePreProcessor> {
-        let model_lower = model_id.to_lowercase();
+    pub fn find(&self, model_id: &str, model_type: Option<&str>) -> Option<&dyn ImagePreProcessor> {
+        self.find_in_candidate(model_id)
+            .or_else(|| model_type.and_then(|mt| self.find_in_candidate(mt)))
+    }
+
+    fn find_in_candidate(&self, candidate: &str) -> Option<&dyn ImagePreProcessor> {
+        let candidate = candidate.to_lowercase();
         for (pattern, processor) in &self.processors {
-            if model_lower.contains(&pattern.to_lowercase()) {
+            if candidate.contains(&pattern.to_lowercase()) {
                 return Some(processor.as_ref());
             }
         }
         None
-    }
-
-    /// Check if a model has a registered processor.
-    pub fn has_processor(&self, model_id: &str) -> bool {
-        self.find(model_id).is_some()
     }
 
     /// Get list of supported model patterns.
@@ -434,6 +434,10 @@ impl ImageProcessorRegistry {
         );
         registry.register(
             "phi3-vision",
+            Box::new(super::processors::Phi3VisionProcessor::new()),
+        );
+        registry.register(
+            "phi3_v",
             Box::new(super::processors::Phi3VisionProcessor::new()),
         );
 
@@ -543,15 +547,19 @@ mod tests {
         let registry = ImageProcessorRegistry::with_defaults();
 
         // Should find LLaVA processor
-        assert!(registry.has_processor("llava-hf/llava-1.5-7b-hf"));
-        assert!(registry.has_processor("liuhaotian/llava-v1.5-7b"));
+        assert!(registry.find("llava-hf/llava-1.5-7b-hf", None).is_some());
+        assert!(registry.find("liuhaotian/llava-v1.5-7b", None).is_some());
 
         // Should find LLaVA-NeXT processor
-        assert!(registry.has_processor("llava-hf/llava-v1.6-mistral-7b-hf"));
-        assert!(registry.has_processor("lmms-lab/llava-next-interleave-qwen-7b"));
+        assert!(registry
+            .find("llava-hf/llava-v1.6-mistral-7b-hf", None)
+            .is_some());
+        assert!(registry
+            .find("lmms-lab/llava-next-interleave-qwen-7b", None)
+            .is_some());
 
         // Get the processor and check model name
-        let processor = registry.find("llava-hf/llava-1.5-7b-hf").unwrap();
+        let processor = registry.find("llava-hf/llava-1.5-7b-hf", None).unwrap();
         assert_eq!(processor.model_name(), "llava");
     }
 
@@ -562,8 +570,40 @@ mod tests {
         // Create a mock processor using LlavaProcessor
         registry.register("test-model", Box::new(LlavaProcessor::new()));
 
-        assert!(registry.has_processor("test-model-7b"));
-        assert!(registry.has_processor("TEST-MODEL"));
-        assert!(!registry.has_processor("other-model"));
+        assert!(registry.find("test-model-7b", None).is_some());
+        assert!(registry.find("TEST-MODEL", None).is_some());
+        assert!(registry.find("other-model", None).is_none());
+    }
+
+    #[test]
+    fn test_registry_find_falls_back_to_model_type() {
+        let registry = ImageProcessorRegistry::with_defaults();
+
+        assert!(registry.find("custom-model", None).is_none());
+
+        let processor = registry
+            .find("custom-model", Some("qwen3_vl"))
+            .expect("qwen3 processor by model_type");
+        assert_eq!(processor.model_name(), "qwen3-vl");
+    }
+
+    #[test]
+    fn test_registry_find_preserves_fast_path() {
+        let registry = ImageProcessorRegistry::with_defaults();
+
+        let processor = registry
+            .find("Qwen3-VL-30B-A3B-Instruct", Some("qwen2_vl"))
+            .expect("qwen3 processor by model_id");
+        assert_eq!(processor.model_name(), "qwen3-vl");
+    }
+
+    #[test]
+    fn test_registry_find_phi3_model_type_fallback() {
+        let registry = ImageProcessorRegistry::with_defaults();
+
+        let processor = registry
+            .find("custom-model", Some("phi3_v"))
+            .expect("phi3 processor by model_type");
+        assert_eq!(processor.model_name(), "phi3-vision");
     }
 }

--- a/model_gateway/src/routers/grpc/multimodal.rs
+++ b/model_gateway/src/routers/grpc/multimodal.rs
@@ -382,6 +382,10 @@ async fn process_multimodal_parts(
 
     // Step 2: Resolve model spec and preprocess images
     let model_config = components.get_or_load_config(model_id, tokenizer_source)?;
+    let model_type = model_config
+        .config
+        .get("model_type")
+        .and_then(|v| v.as_str());
     let metadata = ModelMetadata {
         model_id,
         tokenizer,
@@ -394,7 +398,7 @@ async fn process_multimodal_parts(
 
     let image_processor = components
         .image_processor_registry
-        .find(model_id)
+        .find(model_id, model_type)
         .ok_or_else(|| anyhow::anyhow!("No image processor found for model: {model_id}"))?;
 
     // ImagePreProcessor::preprocess takes &[DynamicImage]; images are behind Arc<ImageFrame>.


### PR DESCRIPTION
## Description

### Problem

Multimodal family detection fails when a vision model is served under a custom/aliased name (e.g. `custom-model`) because both the model spec registry and image processor registry match exclusively on the request-side `model_id` string. Even though `config.json` and `preprocessor_config.json` are loaded successfully from the real model path, the family detection never consults `config.model_type`.

### Solution

Add a `config.model_type` fallback to each spec's `matches()` method and to `ImageProcessorRegistry::find()`. The existing `model_id` substring check remains the fast path; `config.model_type` is only consulted when `model_id` does not match any known family. Unlike the `model_id` path which uses substring matching, `model_type` uses exact equality since it is a known fixed value from `config.json`.

## Changes

- Add `config_model_type()` helper to `ModelMetadata` for reading `config.json`'s `model_type` field
- Update each multimodal spec's `matches()` to fall back to exact `config.model_type` matching when `model_id` substring check fails (qwen3_vl, qwen_vl, llava, llama4, phi3_v)
- Extend `ImageProcessorRegistry::find()` to accept an optional `model_type` parameter and fall back to it when `model_id` doesn't match
- Register `phi3_v` pattern in image processor defaults so model_type fallback can match it
- Thread `model_type` from loaded config through the caller in `multimodal.rs`
- Remove unused `has_processor()` from `ImageProcessorRegistry`
- Add regression tests for aliased model IDs across all multimodal specs and image processor lookup

Supersedes #755
Fixes #754 

## Test Plan

1. `cargo test -p llm-multimodal` — all 220 tests pass
2. `cargo check -p smg` — gateway compiles cleanly
3. Configure a gRPC worker to serve a supported multimodal model under an aliased name such as `custom-model`
4. Send a chat completion request with image content using the aliased model name
5. Verify SMG resolves the correct multimodal spec and image processor

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved model detection to recognize several vision and multimodal models via an optional config "model_type", and enhanced image processor selection to fall back to this model type when needed.
* **Tests**
  * Added unit tests covering model-type-based identification and the new processor selection fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes #754