### PR TITLE
ci: Change to use model cache

### DIFF
--- a/.github/workflows/e2e-gpu-job.yml
+++ b/.github/workflows/e2e-gpu-job.yml
@@ -50,7 +50,7 @@ jobs:
       E2E_ENGINE: ${{ inputs.engine }}
       E2E_RUNTIME: ${{ inputs.engine }}
       E2E_GPU_TIER: ${{ inputs.gpu_tier }}
-      ROUTER_LOCAL_MODEL_PATH: /home/ubuntu/models
+      ROUTER_LOCAL_MODEL_PATH: /models
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -328,7 +328,7 @@ jobs:
 
       - name: Run benchmarks
         env:
-          ROUTER_LOCAL_MODEL_PATH: /home/ubuntu/models
+          ROUTER_LOCAL_MODEL_PATH: /models
         run: |
           bash scripts/ci_killall_sglang.sh "nuk_gpus"
           SHOW_WORKER_LOGS=0 SHOW_ROUTER_LOGS=1 pytest e2e_test/benchmarks \
@@ -690,7 +690,7 @@ jobs:
         env:
           BRAVE_MCP_HOST: ${{ matrix.setup_agentic_deps && 'brave-search-mcp' || '' }}
         run: |
-          ROUTER_LOCAL_MODEL_PATH="/home/ubuntu/models" pytest ${{ matrix.test_path }} \
+          ROUTER_LOCAL_MODEL_PATH="/models" pytest ${{ matrix.test_path }} \
             -m "not external" \
             --reruns 2 --reruns-delay 5 \
             -s -vv
@@ -803,7 +803,7 @@ jobs:
           bash scripts/ci_killall_sglang.sh "nuk_gpus"
           export CGO_LDFLAGS="-L$(pwd)/bindings/golang/target/release"
           export LD_LIBRARY_PATH="$(pwd)/bindings/golang/target/release:$LD_LIBRARY_PATH"
-          SHOW_WORKER_LOGS=0 SHOW_ROUTER_LOGS=1 ROUTER_LOCAL_MODEL_PATH="/home/ubuntu/models" \
+          SHOW_WORKER_LOGS=0 SHOW_ROUTER_LOGS=1 ROUTER_LOCAL_MODEL_PATH="/models" \
             pytest --reruns 2 --reruns-delay 5 e2e_test/bindings_go -s -vv
 
   go-bindings-benchmark:
@@ -860,7 +860,7 @@ jobs:
           bash scripts/ci_killall_sglang.sh "nuk_gpus"
           export CGO_LDFLAGS="-L$(pwd)/bindings/golang/target/release"
           export LD_LIBRARY_PATH="$(pwd)/bindings/golang/target/release:$LD_LIBRARY_PATH"
-          SHOW_WORKER_LOGS=0 SHOW_ROUTER_LOGS=1 ROUTER_LOCAL_MODEL_PATH="/home/ubuntu/models" \
+          SHOW_WORKER_LOGS=0 SHOW_ROUTER_LOGS=1 ROUTER_LOCAL_MODEL_PATH="/models" \
             pytest e2e_test/benchmarks/test_go_bindings_perf.py -s -vv
 
       - name: Upload benchmark results


### PR DESCRIPTION
## Description

### Problem

E2e tests are failing on 1 gpu runners due to high usage of ephemeral-storage.

### Solution

We mount the NVMe to `/models`, and need to configure right model path for E2e tests to start using NVMe for model downloading.

## Changes

 - `e2e-gpu-job.yml`: Update `ROUTER_LOCAL_MODEL_PATH` env var from `/home/ubuntu/models` to `/models`
  - `pr-test-rust.yml`: Update all 4 occurrences of `ROUTER_LOCAL_MODEL_PATH` from `/home/ubuntu/models` to `/models` (benchmarks, e2e tests, Go bindings tests, Go bindings benchmarks)


## Test Plan

- Verified CI passed successfully
- Verified the models are downloaded to `/models` in new runners
<img width="407" height="56" alt="Screenshot 2026-03-24 at 5 41 12 PM" src="https://github.com/user-attachments/assets/4d4775eb-0b1d-408d-aa58-0b9697a15b58" />

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal testing infrastructure configuration to support model path adjustments across benchmark and E2E test workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->