### PR TITLE
fix(multimodal): handle images smaller than patch_size * merge_size

### DIFF
--- a/crates/multimodal/src/vision/processors/qwen2_vl.rs
+++ b/crates/multimodal/src/vision/processors/qwen2_vl.rs
@@ -326,12 +326,15 @@ mod tests {
     }
 
     #[test]
-    fn test_smart_resize_too_small_dimension_error() {
+    fn test_smart_resize_small_dimension_clamps_to_factor() {
         let processor = Qwen2VLProcessor::new();
 
-        // Dimension smaller than factor
-        let result = processor.smart_resize(10, 100);
-        assert!(result.is_err());
+        // Dimension smaller than factor (28) should be clamped up, not rejected
+        let (h, w) = processor.smart_resize(10, 100).unwrap();
+        assert!(h >= 28);
+        assert!(w >= 28);
+        assert_eq!(h % 28, 0);
+        assert_eq!(w % 28, 0);
     }
 
     #[test]

--- a/crates/multimodal/src/vision/processors/qwen3_vl.rs
+++ b/crates/multimodal/src/vision/processors/qwen3_vl.rs
@@ -301,12 +301,15 @@ mod tests {
     }
 
     #[test]
-    fn test_smart_resize_too_small_dimension_error() {
+    fn test_smart_resize_small_dimension_clamps_to_factor() {
         let processor = Qwen3VLProcessor::new();
 
-        // Dimension smaller than factor (32)
-        let result = processor.smart_resize(10, 100);
-        assert!(result.is_err());
+        // Dimension smaller than factor (32) should be clamped up, not rejected
+        let (h, w) = processor.smart_resize(10, 100).unwrap();
+        assert!(h >= 32);
+        assert!(w >= 32);
+        assert_eq!(h % 32, 0);
+        assert_eq!(w % 32, 0);
     }
 
     #[test]

--- a/crates/multimodal/src/vision/processors/qwen_vl_base.rs
+++ b/crates/multimodal/src/vision/processors/qwen_vl_base.rs
@@ -137,7 +137,7 @@ impl QwenVLProcessorBase {
     /// (new_height, new_width) or error if aspect ratio is too extreme
     ///
     /// # Errors
-    /// - If height or width is smaller than the factor
+    /// - If height or width is zero
     /// - If aspect ratio exceeds 200:1
     pub fn smart_resize(
         &self,
@@ -146,10 +146,10 @@ impl QwenVLProcessorBase {
     ) -> Result<(usize, usize), TransformError> {
         let factor = self.get_factor();
 
-        // Validate minimum dimensions
-        if height < factor || width < factor {
+        // Validate non-zero dimensions
+        if height == 0 || width == 0 {
             return Err(TransformError::InvalidShape {
-                expected: format!("dimensions >= {factor} (patch_size * merge_size)"),
+                expected: "non-zero dimensions".to_string(),
                 actual: vec![height, width],
             });
         }


### PR DESCRIPTION
## Description

### Problem

SMG's Qwen VL image preprocessor rejects images where any dimension is smaller than `patch_size * merge_size` (32 for Qwen3-VL, 28 for Qwen2-VL). This causes multimodal requests to fail with:

```
Multimodal processing failed: Image preprocessing failed: Invalid tensor shape:
expected dimensions >= 32 (patch_size * merge_size), got [30, 328]
```

This was hit in practice when running MMMU benchmark evaluation via `lmms-eval` against SMG — some MMMU images are as small as 30px in one dimension. The same images process fine through vLLM, which delegates to the HuggingFace `transformers` implementation of `smart_resize`.

### Solution

The HuggingFace transformers [`smart_resize`](https://github.com/huggingface/transformers/blob/main/src/transformers/models/qwen2_vl/image_processing_qwen2_vl.py) handles sub-factor dimensions by rounding up:

```python
h_bar = max(factor, round(height / factor) * factor)
w_bar = max(factor, round(width / factor) * factor)
```

SMG's implementation already has the equivalent `.max(factor)` clamp after rounding (lines 175-176 of `qwen_vl_base.rs`), but an early dimension check rejected small images before that code could run. Removing the early rejection and keeping only a zero-dimension guard lets the existing rounding + clamping logic handle small images correctly, matching transformers behavior.

## Changes

- `crates/multimodal/src/vision/processors/qwen_vl_base.rs`: Replace the `height < factor || width < factor` rejection with a zero-dimension check. The existing `h_bar.max(factor)` / `w_bar.max(factor)` clamps handle sub-factor dimensions.
- `crates/multimodal/src/vision/processors/qwen3_vl.rs`: Update test to expect success with clamping instead of error.
- `crates/multimodal/src/vision/processors/qwen2_vl.rs`: Same test update.

## Test Plan

1. `cargo test -p llm-multimodal` — 220 tests pass
2. Reproduce with a 30x328 image via the chat completions API:
   - **Before**: `400 multimodal_processing_failed: Invalid tensor shape: expected dimensions >= 32 (patch_size * merge_size), got [30, 328]`
   - **After**: Image is resized to 32x352 and processed successfully
3. Run MMMU benchmark via `lmms-eval` against SMG serving Qwen3-VL — the previously failing samples now complete

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of image resizing for vision models by automatically adjusting small dimensions to meet alignment requirements instead of rejecting them.
  * Stricter validation now rejects only zero-dimension inputs, allowing previously unsupported small image sizes to be processed correctly.

* **Tests**
  * Updated test cases for vision model processors to verify correct behavior with adjusted image dimensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->