### PR TITLE
perf(multimodal): fuse to_tensor + normalize in Pixtral processor

### DIFF
--- a/crates/multimodal/src/vision/processors/pixtral.rs
+++ b/crates/multimodal/src/vision/processors/pixtral.rs
@@ -148,9 +148,9 @@ impl PixtralProcessor {
         // Step 2: Resize image using bicubic interpolation
         let resized = transforms::resize(image, target_w, target_h, FilterType::CatmullRom);
 
-        // Step 3: Convert to tensor (0-1 range) and normalize
-        let mut tensor = transforms::to_tensor(&resized);
-        transforms::normalize(&mut tensor, &self.image_mean, &self.image_std);
+        // Step 3: Convert to tensor (0-1 range) and normalize in a single pass
+        let tensor =
+            transforms::to_tensor_and_normalize(&resized, &self.image_mean, &self.image_std);
 
         // Step 4: Reshape to (1, C, H, W)
         let (c, h, w) = (tensor.shape()[0], tensor.shape()[1], tensor.shape()[2]);


### PR DESCRIPTION
## Summary
- Replaces the two-pass `to_tensor()` + `normalize()` sequence with the fused `to_tensor_and_normalize()` in the Pixtral image processor, eliminating a redundant iteration over the tensor data.

## Test plan
- [x] All 135 unit tests pass (`cargo test -p llm-multimodal`)
- [x] All 81 golden tests pass (`cargo test -p llm-multimodal -- vision_golden`)
- [x] All 4 integration tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined image preprocessing by combining conversion and normalization into a single step.
  * Removed intermediate mutable tensor state in favor of an immutable result, preserving output shape and behavior.
  * Improves efficiency and simplifies the image-to-tensor pipeline in the Pixtral vision processor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->