### PR TITLE
perf(multimodal): fuse to_tensor + normalize in LLaVA processors

### DIFF
--- a/crates/multimodal/src/vision/processors/llava.rs
+++ b/crates/multimodal/src/vision/processors/llava.rs
@@ -41,8 +41,8 @@ use crate::vision::{
     image_processor::{ImagePreProcessor, PreprocessedImages},
     preprocessor_config::PreProcessorConfig,
     transforms::{
-        center_crop, expand_to_square, mean_to_rgb, normalize, pil_to_filter, resize, stack_batch,
-        to_tensor, TransformError,
+        center_crop, expand_to_square, mean_to_rgb, pil_to_filter, resize, stack_batch, to_tensor,
+        to_tensor_and_normalize, TransformError,
     },
 };
 
@@ -242,15 +242,12 @@ impl LlavaProcessor {
             }
         };
 
-        // Convert to tensor [C, H, W] normalized to [0, 1]
-        let mut tensor = to_tensor(&processed);
-
-        // Normalize with mean/std
+        // Convert to tensor [C, H, W] normalized to [0, 1], fusing normalize when enabled
         if config.do_normalize.unwrap_or(true) {
-            normalize(&mut tensor, &mean, &std);
+            to_tensor_and_normalize(&processed, &mean, &std)
+        } else {
+            to_tensor(&processed)
         }
-
-        tensor
     }
 }
 
@@ -483,15 +480,12 @@ impl LlavaNextProcessor {
             resized
         };
 
-        // Convert to tensor
-        let mut tensor = to_tensor(&cropped);
-
-        // Normalize
+        // Convert to tensor, fusing normalize when enabled
         if config.do_normalize.unwrap_or(true) {
-            normalize(&mut tensor, &mean, &std);
+            to_tensor_and_normalize(&cropped, &mean, &std)
+        } else {
+            to_tensor(&cropped)
         }
-
-        tensor
     }
 }
 


### PR DESCRIPTION
## Summary
- Replace separate `to_tensor()` + `normalize()` calls with the fused `to_tensor_and_normalize()` in both `LlavaProcessor::process_one_image` and `LlavaNextProcessor::process_patch`
- Eliminates a second pass over pixel data, matching the pattern already used by llama4_vision and qwen_vl_base processors
- Remove unused `normalize` import, add `to_tensor_and_normalize`

## Test plan
- [x] `cargo test -p llm-multimodal` — all 135 unit tests pass
- [x] `cargo test -p llm-multimodal -- vision_golden` — all 81 golden tests pass (bit-exact output preserved)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined image processing internals by consolidating tensor conversion and normalization steps, removing redundant intermediate state. Improves efficiency and maintainability while preserving existing behavior and outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->