### PR TITLE
perf(multimodal): pre-convert decoded images to RGB8 at decode time

### DIFF
--- a/crates/multimodal/src/media.rs
+++ b/crates/multimodal/src/media.rs
@@ -200,9 +200,13 @@ impl MediaConnector {
         let cursor = std::io::Cursor::new(bytes.clone());
         let reader = image::ImageReader::new(cursor).with_guessed_format()?;
 
-        let image = task::spawn_blocking(move || reader.decode())
-            .await
-            .map_err(MediaConnectorError::Blocking)??;
+        let image = task::spawn_blocking(move || {
+            let decoded = reader.decode()?;
+            // Pre-convert to RGB8 so downstream processors never need to
+            Ok::<_, image::ImageError>(image::DynamicImage::ImageRgb8(decoded.into_rgb8()))
+        })
+        .await
+        .map_err(MediaConnectorError::Blocking)??;
 
         Ok(Arc::new(ImageFrame::new(
             image, bytes, detail, source, hash,


### PR DESCRIPTION
## Summary
- Pre-converts decoded images to RGB8 format immediately after decoding in `MediaConnector::decode_image`
- Eliminates repeated downstream conversions when non-RGB8 images (RGBA, Luma, etc.) hit the fallback path in `rgb_bytes()`
- Single conversion at decode time replaces potentially multiple per-processor conversions

## Test plan
- [x] `cargo test -p llm-multimodal` — all 81 tests pass
- [x] `cargo test -p llm-multimodal -- vision_golden` — all 30 golden tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted internal image processing workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->