### PR TITLE
perf(multimodal): reuse Resizer via thread_local

### DIFF
--- a/crates/multimodal/src/vision/transforms.rs
+++ b/crates/multimodal/src/vision/transforms.rs
@@ -3,6 +3,8 @@
 //! This module provides composable transforms that match HuggingFace image processor
 //! behavior, enabling pure Rust preprocessing without Python dependencies.
 
+use std::cell::RefCell;
+
 use fast_image_resize::{
     images::Image as FirImage, IntoImageView, ResizeAlg, ResizeOptions, Resizer,
 };
@@ -164,6 +166,10 @@ fn to_fir_algorithm(filter: FilterType) -> ResizeAlg {
     }
 }
 
+thread_local! {
+    static RESIZER: RefCell<Resizer> = RefCell::new(Resizer::new());
+}
+
 /// Resize image to exact dimensions using SIMD-accelerated resizer.
 ///
 /// # Arguments
@@ -178,8 +184,8 @@ pub fn resize(image: &DynamicImage, width: u32, height: u32, filter: FilterType)
     };
     let mut dst = FirImage::new(width, height, pixel_type);
     let options = ResizeOptions::new().resize_alg(to_fir_algorithm(filter));
-    let mut resizer = Resizer::new();
-    if resizer.resize(image, &mut dst, &options).is_err() {
+    let ok = RESIZER.with(|r| r.borrow_mut().resize(image, &mut dst, &options).is_ok());
+    if !ok {
         return image.resize_exact(width, height, filter);
     }
     fir_image_to_dynamic(dst, width, height, image, filter)


### PR DESCRIPTION
## Summary
- Reuse `fast_image_resize::Resizer` via a `thread_local!` static instead of allocating a new one on every `resize()` call
- `Resizer` caches coefficient tables and intermediate buffers internally; creating a fresh instance each call discards those caches, causing repeated allocation/deallocation in batch image processing
- The thread-local `RefCell<Resizer>` ensures each thread retains its own cached resizer across calls with zero contention

## Benchmark context
`Resizer::new()` itself is cheap, but the internal caches it builds (convolution coefficient tables, intermediate row buffers) are populated on first use and reused on subsequent calls with matching dimensions/filters. In batch preprocessing (e.g., processing all images in a multi-image request), the same resize dimensions are typically hit repeatedly, making cache reuse significant. This pattern mirrors the recommendation in the `fast_image_resize` documentation.

## Test plan
- [x] `cargo test -p llm-multimodal` -- all 135 unit tests pass
- [x] `cargo test -p llm-multimodal -- vision_golden` -- all 81 golden tests pass
- [x] No new warnings from `llm-multimodal` crate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized image resizing to reuse internal resources for faster, more efficient processing while preserving existing behavior and fallback handling when accelerated paths aren’t available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->