### PR TITLE
perf(multimodal): skip redundant to_rgb8 conversion when image is already RGB8

### DIFF
--- a/crates/multimodal/src/vision/processors/phi3_vision.rs
+++ b/crates/multimodal/src/vision/processors/phi3_vision.rs
@@ -241,7 +241,10 @@ impl Phi3VisionProcessor {
         config: &PreProcessorConfig,
     ) -> (Array4<f32>, (usize, usize), usize) {
         // 1. Convert to RGB
-        let image = DynamicImage::ImageRgb8(image.to_rgb8());
+        let image = match image {
+            DynamicImage::ImageRgb8(_) => image.clone(),
+            _ => DynamicImage::ImageRgb8(image.to_rgb8()),
+        };
 
         // 2. HD transform
         let hd_image = self.hd_transform(&image);


### PR DESCRIPTION
## Summary
- In `phi3_vision.rs`, `process_single_image` unconditionally called `image.to_rgb8()` even when the input was already `DynamicImage::ImageRgb8`, causing a needless full-pixel copy.
- Added a match guard that clones the image directly when it is already RGB8, and only converts otherwise.

## Test plan
- [x] `cargo test -p llm-multimodal` — all 81 tests pass
- [x] `cargo test -p llm-multimodal -- vision_golden` — all 30 golden tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Optimized the vision image pipeline to skip unnecessary RGB conversions when images are already in RGB, reducing CPU and memory use and speeding up image processing for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->