### PR TITLE
perf(multimodal): single-pass image transpose replacing double fliph+rotate allocation

### DIFF
--- a/crates/multimodal/src/vision/processors/phi3_vision.rs
+++ b/crates/multimodal/src/vision/processors/phi3_vision.rs
@@ -115,9 +115,9 @@ impl Phi3VisionProcessor {
         let (width, height) = image.dimensions();
 
         let (img, transposed) = if width < height {
-            // Transpose (PIL's Image.TRANSPOSE): equivalent to fliph + rotate270 (ccw 90°)
-            // This swaps x and y coordinates: pixel at (x, y) goes to (y, x)
-            (image.fliph().rotate270(), true)
+            // Transpose (PIL's Image.TRANSPOSE): swap x and y coordinates
+            // pixel at (x, y) goes to (y, x), done in a single pass
+            (transforms::transpose(image), true)
         } else {
             (image.clone(), false)
         };
@@ -146,7 +146,7 @@ impl Phi3VisionProcessor {
 
         // Transpose back if needed (transpose is self-inverse)
         if transposed {
-            padded.fliph().rotate270()
+            transforms::transpose(&padded)
         } else {
             padded
         }
@@ -541,7 +541,7 @@ mod tests {
 
     #[test]
     fn test_transpose_equivalence() {
-        // Test that fliph().rotate270() correctly implements PIL's Image.TRANSPOSE
+        // Test that transforms::transpose correctly implements PIL's Image.TRANSPOSE
         // TRANSPOSE swaps x and y coordinates: pixel at (x, y) goes to (y, x)
         use image::{GenericImageView, Rgb, RgbImage};
 
@@ -552,12 +552,18 @@ mod tests {
         img.put_pixel(99, 199, Rgb([255, 255, 0])); // Bottom-right = yellow
 
         let img = DynamicImage::ImageRgb8(img);
-        let transposed = img.fliph().rotate270();
+        let transposed = transforms::transpose(&img);
 
         // After TRANSPOSE: (x, y) -> (y, x)
+        assert_eq!(transposed.dimensions(), (200, 100)); // width/height swapped
         assert_eq!(transposed.get_pixel(0, 0).0[0..3], [255, 0, 0]); // (0,0) -> (0,0)
         assert_eq!(transposed.get_pixel(0, 99).0[0..3], [0, 255, 0]); // (99,0) -> (0,99)
         assert_eq!(transposed.get_pixel(199, 0).0[0..3], [0, 0, 255]); // (0,199) -> (199,0)
         assert_eq!(transposed.get_pixel(199, 99).0[0..3], [255, 255, 0]); // (99,199) -> (199,99)
+
+        // Verify equivalence with the old fliph().rotate270() approach
+        let old_transposed = img.fliph().rotate270();
+        assert_eq!(transposed.dimensions(), old_transposed.dimensions());
+        assert_eq!(transposed.to_rgb8().into_raw(), old_transposed.to_rgb8().into_raw());
     }
 }

--- a/crates/multimodal/src/vision/transforms.rs
+++ b/crates/multimodal/src/vision/transforms.rs
@@ -315,6 +315,20 @@ pub fn stack_batch(tensors: &[Array3<f32>]) -> Result<Array4<f32>> {
     Ok(batch)
 }
 
+/// Transpose image: swap x and y coordinates (equivalent to PIL's Image.TRANSPOSE).
+/// Pixel at (x, y) moves to (y, x). Output dimensions are (height, width) of input.
+pub fn transpose(image: &DynamicImage) -> DynamicImage {
+    let rgb = image.to_rgb8();
+    let (w, h) = (rgb.width(), rgb.height());
+    let mut out = RgbImage::new(h, w);
+    for y in 0..h {
+        for x in 0..w {
+            out.put_pixel(y, x, *rgb.get_pixel(x, y));
+        }
+    }
+    DynamicImage::ImageRgb8(out)
+}
+
 /// Convert PIL/HuggingFace resampling enum to image crate filter.
 ///
 /// PIL resampling constants:


### PR DESCRIPTION
## Summary
- Replace `image.fliph().rotate270()` (two intermediate full-size image buffers) with a single-pass `transforms::transpose()` that swaps (x,y) -> (y,x) in one allocation, matching PIL's `Image.TRANSPOSE` semantics
- Add `transpose` function to `transforms.rs` as a reusable utility
- Update `test_transpose_equivalence` to validate the new function and verify pixel-level equivalence with the old approach

## Test plan
- [x] `cargo test -p llm-multimodal -- test_transpose_equivalence` passes (validates pixel-level equivalence with old fliph+rotate270)
- [x] `cargo test -p llm-multimodal` — all 135 unit tests pass
- [x] `cargo test -p llm-multimodal -- vision_golden` — all 81 golden tests pass (including phi3_vision golden tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified image transformation logic for more consistent handling of rotated images.
  * Improved transpose behavior to make dimension and pixel ordering more explicit.

* **Tests**
  * Expanded transformation tests to verify swapped dimensions and exact pixel-level equivalence with the previous behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->