### PR TITLE
perf(multimodal): tile-first strategy for LLaMA 4 to reduce peak memory

### DIFF
--- a/crates/multimodal/src/vision/processors/llama4_vision.rs
+++ b/crates/multimodal/src/vision/processors/llama4_vision.rs
@@ -19,8 +19,8 @@
 //! 2. **Get best fit**: Find optimal resolution without distortion
 //! 3. **Resize**: Scale to target resolution maintaining aspect ratio
 //! 4. **Pad**: Add black padding (0) to reach target dimensions
-//! 5. **Normalize**: Apply [0.5, 0.5, 0.5] mean/std normalization
-//! 6. **Tile**: Split into (num_tiles_h * num_tiles_w, 3, 336, 336) tiles
+//! 5. **Tile**: Crop padded canvas into (num_tiles_h * num_tiles_w) tile images
+//! 6. **Normalize**: Apply [0.5, 0.5, 0.5] mean/std normalization per tile
 //! 7. **Global tile**: If multiple tiles, add global view at the end
 //!
 //! # Token Count
@@ -282,33 +282,6 @@ impl Llama4VisionProcessor {
         DynamicImage::ImageRgb8(padded)
     }
 
-    /// Split image tensor into tiles.
-    fn split_to_tiles(
-        &self,
-        tensor: &Array3<f32>,
-        num_tiles_h: usize,
-        num_tiles_w: usize,
-    ) -> Array4<f32> {
-        let tile = self.tile_size as usize;
-        let num_tiles = num_tiles_h * num_tiles_w;
-
-        let mut tiles = Array4::<f32>::zeros((num_tiles, 3, tile, tile));
-
-        for h_idx in 0..num_tiles_h {
-            for w_idx in 0..num_tiles_w {
-                let tile_idx = h_idx * num_tiles_w + w_idx;
-                let y_start = h_idx * tile;
-                let x_start = w_idx * tile;
-
-                let tile_view =
-                    tensor.slice(s![.., y_start..y_start + tile, x_start..x_start + tile]);
-                tiles.slice_mut(s![tile_idx, .., .., ..]).assign(&tile_view);
-            }
-        }
-
-        tiles
-    }
-
     /// Create global image by bilinear interpolation to tile size.
     fn create_global_image(&self, image: &DynamicImage) -> Array3<f32> {
         let tile = self.tile_size;
@@ -345,17 +318,26 @@ impl Llama4VisionProcessor {
         // Step 4: Pad to target_size (the canvas from get_best_fit, not resize_target)
         let padded = self.pad_image(&resized, target_w, target_h);
 
-        // Step 5: Convert to tensor and normalize
-        let tensor = transforms::to_tensor_and_normalize(&padded, &self.mean, &self.std);
-
-        // Step 6: Calculate tile counts based on target_size (canvas size)
+        // Step 5-6: Tile first, then normalize each tile independently.
+        // This avoids materializing a single tensor for the entire padded canvas
+        // (up to 3 × H_canvas × W_canvas × 4 bytes), reducing peak memory.
         let tile = self.tile_size as usize;
         let num_tiles_h = target_h as usize / tile;
         let num_tiles_w = target_w as usize / tile;
-
-        // Step 7: Split into tiles
-        let tiles = self.split_to_tiles(&tensor, num_tiles_h, num_tiles_w);
         let num_tiles = num_tiles_h * num_tiles_w;
+
+        let mut tiles = Array4::<f32>::zeros((num_tiles, 3, tile, tile));
+        for h_idx in 0..num_tiles_h {
+            for w_idx in 0..num_tiles_w {
+                let tile_idx = h_idx * num_tiles_w + w_idx;
+                let x = (w_idx * tile) as u32;
+                let y = (h_idx * tile) as u32;
+                let tile_img = padded.crop_imm(x, y, self.tile_size, self.tile_size);
+                let tile_tensor =
+                    transforms::to_tensor_and_normalize(&tile_img, &self.mean, &self.std);
+                tiles.slice_mut(s![tile_idx, .., .., ..]).assign(&tile_tensor);
+            }
+        }
 
         // Step 8: Add global tile if there are multiple tiles
         let output = if num_tiles > 1 {


### PR DESCRIPTION
## Summary
- Restructures `Llama4VisionProcessor::process_single_image` to crop tiles from the padded `DynamicImage` first, then normalize each 336x336 tile independently, instead of normalizing the entire padded canvas (up to 3 x 5376 x 336 x 4 bytes) into a single tensor and then splitting.
- Removes the now-unused `split_to_tiles` method.
- Numerically identical output — all 81 tests and 30 golden tests pass unchanged.

## Test plan
- [x] `cargo test -p llm-multimodal` — 81 passed
- [x] `cargo test -p llm-multimodal -- vision_golden` — 30 golden tests passed (including all LLaMA 4 golden tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked image preprocessing to crop and normalize on a per-tile basis rather than processing the full padded image first. This changes the preprocessing order and may affect image handling and model outputs (consistency and behavior of vision inputs).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->