### PR TITLE
feat(grpc-router): use per-model retry config from WorkerRegistry

### DIFF
--- a/model_gateway/src/routers/grpc/router.rs
+++ b/model_gateway/src/routers/grpc/router.rs
@@ -194,8 +194,14 @@ impl GrpcRouter {
         let model_id_cloned = model_id.to_string();
         let components = self.shared_components.clone();
 
+        // Use per-model retry config if set by a worker, otherwise fall back to router default.
+        let per_model_retry_config = self.worker_registry.get_retry_config(model_id);
+        let retry_config = per_model_retry_config
+            .as_ref()
+            .unwrap_or(&self.retry_config);
+
         RetryExecutor::execute_response_with_retry(
-            &self.retry_config,
+            retry_config,
             // Operation: execute pipeline (creates fresh context each attempt)
             |_attempt| {
                 let request = Arc::clone(&request);
@@ -245,8 +251,14 @@ impl GrpcRouter {
         let components = self.shared_components.clone();
         let pipeline = &self.pipeline;
 
+        // Use per-model retry config if set by a worker, otherwise fall back to router default.
+        let per_model_retry_config = self.worker_registry.get_retry_config(model_id);
+        let retry_config = per_model_retry_config
+            .as_ref()
+            .unwrap_or(&self.retry_config);
+
         RetryExecutor::execute_response_with_retry(
-            &self.retry_config,
+            retry_config,
             // Operation: execute pipeline (creates fresh context each attempt)
             |_attempt| {
                 let request = Arc::clone(&request);
@@ -371,8 +383,14 @@ impl GrpcRouter {
         let components = self.shared_components.clone();
         let pipeline = &self.messages_pipeline;
 
+        // Use per-model retry config if set by a worker, otherwise fall back to router default.
+        let per_model_retry_config = self.worker_registry.get_retry_config(model_id);
+        let retry_config = per_model_retry_config
+            .as_ref()
+            .unwrap_or(&self.retry_config);
+
         RetryExecutor::execute_response_with_retry(
-            &self.retry_config,
+            retry_config,
             |_attempt| {
                 let request = Arc::clone(&request);
                 let headers = headers_cloned.clone();


### PR DESCRIPTION
## Description

Part of the per-worker resilience refactor series: #799 → #803 → #821 → #836 → #875 → #881 → **this PR**.

### Problem

gRPC router uses a single global `retry_config` for all requests, ignoring per-model retry config set by workers.

### Solution

Look up per-model retry config from `WorkerRegistry` at request time for all 3 endpoints (chat, generate, messages), falling back to the router-level default.

Independent of #881 (HTTP router migration).

## Changes

- 3 call sites in `grpc/router.rs` updated to read from `WorkerRegistry`

## Test Plan

- `cargo test -p smg --lib` — all 450 tests pass
- Pre-commit hooks pass (rustfmt, clippy, codespell, DCO)

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: raw summary by coderabbit.ai -->
<!-- end of auto-generated comment: raw summary by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Refactor
* Retry configuration is now selected on a per-model basis for chat, generate, and messages routes instead of using a single router-level setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

<!-- This is an auto-generated comment: summary by coderabbit.ai -->
<!-- end of auto-generated comment: summary by coderabbit.ai -->