### PR TITLE
fix(serve): filter empty-string backend defaults in CLI arg fallback

### DIFF
--- a/bindings/python/src/smg/router_args.py
+++ b/bindings/python/src/smg/router_args.py
@@ -1111,7 +1111,7 @@ class RouterArgs:
             prefixed_key = f"{prefix}{attr.name}"
             if prefixed_key in cli_args_dict and cli_args_dict[prefixed_key] is not None:
                 args_dict[attr.name] = cli_args_dict[prefixed_key]
-            elif attr.name in cli_args_dict:
+            elif attr.name in cli_args_dict and cli_args_dict[attr.name] not in (None, ""):
                 args_dict[attr.name] = cli_args_dict[attr.name]
 
             # Special handling for CLI args with dashes vs dataclass fields with underscores


### PR DESCRIPTION
## Description

### Problem

`smg serve --backend vllm` crashes with `RuntimeError: Invalid configuration: unknown reasoning parser ''` when no `--router-reasoning-parser` is explicitly set.

vLLM's `StructuredOutputsConfig` defaults `reasoning_parser` to `""` (empty string) instead of `None`. The `RouterArgs.from_cli_args` fallback logic picks up this empty string from the unprefixed backend arg when the prefixed `router_reasoning_parser` is `None`, passing `Some("")` to the Rust router which rejects it as an unknown parser name.

### Solution

Filter out empty strings (in addition to `None`) in the unprefixed fallback path of `from_cli_args`, so backend sentinel values like `""` don't leak into `RouterArgs`.

## Changes

- `bindings/python/src/smg/router_args.py`: Add `not in (None, "")` guard to the unprefixed arg fallback in `from_cli_args`.

## Test Plan

1. `smg serve --backend vllm --connection-mode grpc` with vLLM v0.18.0 without `--router-reasoning-parser` — router should start without crashing.
2. `smg serve --backend vllm --router-reasoning-parser deepseek_r1` — explicit parser should still be picked up correctly.
3. `smg serve --backend vllm --router-tool-call-parser pythonic` — non-empty unprefixed fallback (e.g. `tool_call_parser`) should still work.

<img width="2122" height="1164" alt="Screenshot 2026-03-26 at 1 04 41 PM" src="https://github.com/user-attachments/assets/4fe32977-c272-496f-9429-fc6041334d61" />

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI argument handling to preserve default field values when arguments are empty or unspecified, ensuring more predictable behavior when processing command-line inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->