### PR TITLE
feat(openai-router): use per-model retry config from WorkerRegistry

### DIFF
--- a/model_gateway/src/routers/openai/router.rs
+++ b/model_gateway/src/routers/openai/router.rs
@@ -144,11 +144,17 @@ impl crate::routers::RouterTrait for OpenAIRouter {
         body: &ChatCompletionRequest,
         model_id: &str,
     ) -> Response {
+        // Use per-model retry config if set by a worker, otherwise fall back to router default.
+        let per_model_retry_config = self.worker_registry.get_retry_config(model_id);
+        let retry_config = per_model_retry_config
+            .as_ref()
+            .unwrap_or(&self.retry_config);
+
         let deps = ChatRouterContext {
             worker_registry: &self.worker_registry,
             provider_registry: &self.provider_registry,
             shared_components: &self.shared_components,
-            retry_config: &self.retry_config,
+            retry_config,
         };
         chat::route_chat(&deps, headers, body, model_id).await
     }


### PR DESCRIPTION
## Description

Part of the per-worker resilience refactor series: #799 → #803 → #821 → #836 → #875 → #881 / #933 → **this PR**.

### Problem

OpenAI router uses a single global `retry_config` for all requests, ignoring per-model retry config set by workers.

### Solution

Resolve per-model retry config from `WorkerRegistry` in `route_chat()` before passing it to `ChatRouterContext`, falling back to the router-level default.

Independent of #881 (HTTP router) and #933 (gRPC router).

## Changes

- `route_chat()` in OpenAI router resolves retry config from `WorkerRegistry` per model ID

## Test Plan

- `cargo test -p smg --lib` — all 450 tests pass
- Pre-commit hooks pass (rustfmt, clippy, codespell, DCO)

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: raw summary by coderabbit.ai -->
<!-- end of auto-generated comment: raw summary by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced retry configuration handling by enabling per-model resolution. The system now applies model-specific retry configurations when available, with automatic fallback to default settings, improving overall reliability and resilience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

<!-- This is an auto-generated comment: summary by coderabbit.ai -->
<!-- end of auto-generated comment: summary by coderabbit.ai -->