### PR TITLE
feat(routers): use per-model retry config for Gemini, gRPC PD, HTTP PD

### DIFF
--- a/model_gateway/src/routers/gemini/router.rs
+++ b/model_gateway/src/routers/gemini/router.rs
@@ -79,8 +79,15 @@ impl RouterTrait for GeminiRouter {
         let model_id_cloned = model_id.map(String::from);
         let components = self.shared_components.clone();
 
+        // Use per-model retry config if set by a worker, otherwise fall back to router default.
+        let per_model_retry_config =
+            model_id.and_then(|id| self.shared_components.worker_registry.get_retry_config(id));
+        let retry_config = per_model_retry_config
+            .as_ref()
+            .unwrap_or(&self.retry_config);
+
         RetryExecutor::execute_response_with_retry(
-            &self.retry_config,
+            retry_config,
             |_attempt| {
                 let request = Arc::clone(&request);
                 let headers = headers_cloned.clone();

--- a/model_gateway/src/routers/grpc/pd_router.rs
+++ b/model_gateway/src/routers/grpc/pd_router.rs
@@ -121,8 +121,14 @@ impl GrpcPDRouter {
         let components = self.shared_components.clone();
         let pipeline = &self.pipeline;
 
+        // Use per-model retry config if set by a worker, otherwise fall back to router default.
+        let per_model_retry_config = self.worker_registry.get_retry_config(model_id);
+        let retry_config = per_model_retry_config
+            .as_ref()
+            .unwrap_or(&self.retry_config);
+
         RetryExecutor::execute_response_with_retry(
-            &self.retry_config,
+            retry_config,
             |_attempt| {
                 let request = Arc::clone(&request);
                 let headers = headers_cloned.clone();
@@ -179,8 +185,14 @@ impl GrpcPDRouter {
         let components = self.shared_components.clone();
         let pipeline = &self.messages_pipeline;
 
+        // Use per-model retry config if set by a worker, otherwise fall back to router default.
+        let per_model_retry_config = self.worker_registry.get_retry_config(model_id);
+        let retry_config = per_model_retry_config
+            .as_ref()
+            .unwrap_or(&self.retry_config);
+
         RetryExecutor::execute_response_with_retry(
-            &self.retry_config,
+            retry_config,
             |_attempt| {
                 let request = Arc::clone(&request);
                 let headers = headers_cloned.clone();
@@ -294,8 +306,14 @@ impl GrpcPDRouter {
         let components = self.shared_components.clone();
         let pipeline = &self.pipeline;
 
+        // Use per-model retry config if set by a worker, otherwise fall back to router default.
+        let per_model_retry_config = self.worker_registry.get_retry_config(model_id);
+        let retry_config = per_model_retry_config
+            .as_ref()
+            .unwrap_or(&self.retry_config);
+
         RetryExecutor::execute_response_with_retry(
-            &self.retry_config,
+            retry_config,
             |_attempt| {
                 let request = Arc::clone(&request);
                 let headers = headers_cloned.clone();

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -299,8 +299,15 @@ impl PDRouter {
         // Clone request once outside the retry loop, then use Arc to share across attempts
         // This avoids O(retries) clones by sharing the same data
         let shared_request = Arc::new(original_request.clone());
+
+        // Use per-model retry config if set by a worker, otherwise fall back to router default.
+        let per_model_retry_config = self.worker_registry.get_retry_config(model);
+        let retry_config = per_model_retry_config
+            .as_ref()
+            .unwrap_or(&self.retry_config);
+
         let response = RetryExecutor::execute_response_with_retry(
-            &self.retry_config,
+            retry_config,
             {
                 move |attempt: u32| {
                     // Clone Arc (cheap reference count increment) instead of cloning the entire request


### PR DESCRIPTION
## Description

Part of the per-worker resilience refactor series: #799 → #803 → #821 → #836 → #875 → #881 / #933 / #935 → **this PR**.

### Problem

Gemini, gRPC PD, and HTTP PD routers use a single global `retry_config` for all requests, ignoring per-model retry config set by workers.

### Solution

All 3 remaining routers now look up per-model retry config from `WorkerRegistry` at request time, falling back to the router-level default.

This completes the retry config migration across all 6 routers.

## Changes

- Gemini router: 1 call site updated (handles `Option<model_id>` via `and_then`)
- gRPC PD router: 3 call sites updated (generate, messages, chat)
- HTTP PD router: 1 call site updated (dual dispatch)

## Test Plan

- `cargo test -p smg --lib` — all 450 tests pass
- Pre-commit hooks pass (rustfmt, clippy, codespell, DCO)

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: raw summary by coderabbit.ai -->
<!-- end of auto-generated comment: raw summary by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Retry configuration is now selected per request using model-specific settings when available, falling back to the router default otherwise. This per-request retry config is propagated into retry execution across routing layers (Gemini, gRPC, HTTP) while existing retry-control flow and retry-condition logic remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

<!-- This is an auto-generated comment: summary by coderabbit.ai -->
<!-- end of auto-generated comment: summary by coderabbit.ai -->