### PR TITLE
chore: remove unnecessary result wrapping in pd_router

### DIFF
--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -635,7 +635,8 @@ impl PDRouter {
                 None
             };
 
-            let response_headers = header_utils::preserve_response_headers(decode_response.headers());
+            let response_headers =
+                header_utils::preserve_response_headers(decode_response.headers());
 
             self.create_streaming_response(
                 decode_response.bytes_stream(),
@@ -659,7 +660,8 @@ impl PDRouter {
                 .await
             } else {
                 // Direct passthrough when no logprobs needed
-                let response_headers = header_utils::preserve_response_headers(decode_response.headers());
+                let response_headers =
+                    header_utils::preserve_response_headers(decode_response.headers());
 
                 match decode_response.bytes().await {
                     Ok(decode_body) => {


### PR DESCRIPTION
small cleanup from https://github.com/lightseekorg/smg/pull/844, we don't need to do `Ok((prefill_resp, decode_resp)) => (Ok(prefill_resp), Ok(decode_resp))` since we already got `Ok`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified internal response and error-handling flow to reduce redundant branches and improve maintainability.
  * Streamlined processing of upstream responses so transport failures are handled consistently and decoding flow is clearer.
  * No user-facing behavior changes expected; improves reliability and makes future fixes easier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->