### PR TITLE
fix(ci): resolve trtllm cuda-bindings conflict with torch 2.10

### DIFF
--- a/scripts/ci_install_trtllm.sh
+++ b/scripts/ci_install_trtllm.sh
@@ -16,6 +16,8 @@
 
 set -euo pipefail
 
+NCCL_VERSION_CONSTRAINT="nvidia-nccl-cu13>=2.28.9,<=2.29.2"
+
 # Activate venv if it exists
 if [ -f ".venv/bin/activate" ]; then
     source .venv/bin/activate
@@ -58,7 +60,7 @@ if [ -n "$CACHED_WHEEL" ] && [ -f "$CACHED_WHEEL" ]; then
 
     # ── Install pip and NCCL runtime ─────────────────────────────────────────
     pip install --upgrade pip
-    pip install --no-cache-dir "nvidia-nccl-cu13>=2.28.9,<=2.29.2"
+    pip install --no-cache-dir "$NCCL_VERSION_CONSTRAINT"
 
     # ── Install cached wheel ─────────────────────────────────────────────────
     # Use --extra-index-url for cu130 torch so pip resolves torch 2.10+cu130
@@ -186,7 +188,7 @@ fi
 # build_wheel.py runs pip install internally which can change the NCCL version.
 # Copy headers+libs to a fixed directory that pip can't overwrite, and point
 # NCCL_ROOT there for CMake.
-pip install --no-cache-dir --force-reinstall "nvidia-nccl-cu13>=2.28.9,<=2.29.2"
+pip install --no-cache-dir --force-reinstall "$NCCL_VERSION_CONSTRAINT"
 
 SITE_PACKAGES=$(python3 -c "import site; print(site.getsitepackages()[0])")
 NCCL_PIP_ROOT="$SITE_PACKAGES/nvidia/nccl"


### PR DESCRIPTION
## Description

### Problem

All trtllm CI e2e jobs fail at the "Setup TRT-LLM backend" step with a pip dependency conflict:
- `torch 2.10.0` (default PyPI, cu128) pins `cuda-bindings==12.9.4`
- `tensorrt-llm` requires `cuda-python>=13`, which needs `cuda-bindings~=13.x`
- No version of `cuda-bindings` satisfies both constraints

### Solution

Add `--extra-index-url https://download.pytorch.org/whl/cu130` when installing the cached TRT-LLM wheel so pip resolves `torch 2.10+cu130` (`cuda-bindings==13.x`) instead of the default PyPI torch. This matches what upstream TRT-LLM's own `requirements.txt` specifies.

## Changes

- Add `--extra-index-url` for cu130 torch on the cached wheel install path
- Align NCCL version pins to upstream (`>=2.28.9,<=2.29.2`)
- Remove stale NCCL constraint patching (upstream already updated the format)
- Bump cache version to 4, forcing a fresh wheel build from latest TRT-LLM main

## Test Plan

- CI trtllm e2e jobs pass (first run will rebuild from source due to cache bust)
- Subsequent runs use cached wheel with cu130 torch resolution

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved dependency installation to ensure the correct CUDA-specific PyTorch variant is selected during setup.
  * Tightened NCCL version constraints for more stable, predictable builds and consistent runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->