### PR TITLE
fix(multimodal): propagate placeholder resolution errors instead of swallowing

### DIFF
--- a/model_gateway/src/routers/grpc/regular/stages/chat/preparation.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/chat/preparation.rs
@@ -83,8 +83,18 @@ impl ChatPreparationStage {
                     &tokenizer_source,
                 )
                 .await
-                .ok()
-                .flatten();
+                .map_err(|e| {
+                    error!(
+                        function = "ChatPreparationStage::execute",
+                        model = %model_id,
+                        error = %e,
+                        "Failed to resolve multimodal placeholder token"
+                    );
+                    error::internal_error(
+                        "multimodal_placeholder_resolution_failed",
+                        format!("Failed to resolve multimodal placeholder token: {e}"),
+                    )
+                })?;
 
                 (
                     placeholder,

--- a/model_gateway/src/routers/grpc/regular/stages/messages/preparation.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/messages/preparation.rs
@@ -103,8 +103,18 @@ impl MessagePreparationStage {
                     &tokenizer_source,
                 )
                 .await
-                .ok()
-                .flatten();
+                .map_err(|e| {
+                    error!(
+                        function = "MessagePreparationStage::execute",
+                        model = %model_id,
+                        error = %e,
+                        "Failed to resolve multimodal placeholder token"
+                    );
+                    error::internal_error(
+                        "multimodal_placeholder_resolution_failed",
+                        format!("Failed to resolve multimodal placeholder token: {e}"),
+                    )
+                })?;
 
                 (
                     placeholder,


### PR DESCRIPTION
## Description

### Problem

`resolve_placeholder_token` errors in both preparation stages were silently converted to `None` via `.ok().flatten()`. This made real gateway-level failures (e.g. corrupt `config.json`, unreadable model directory) indistinguishable from `Ok(None)` (model not recognized as multimodal). The request would proceed without image placeholders, and the failure would surface later as a vague token expansion mismatch instead of a clear error.

Addresses review feedback from #942.

### Solution

Propagate the `Err` as a **500 Internal Server Error** immediately. This is a gateway-level preparation failure (config loading, spec lookup) — no worker/engine is involved at this point, so `record_outcome` is not affected.

`Ok(None)` (model not recognized as multimodal) still proceeds without placeholders, allowing text-only fallback for unknown models.

## Changes

- `chat/preparation.rs`: Replace `.ok().flatten()` with `.map_err(|e| error::internal_error(...))? `
- `messages/preparation.rs`: Same change for the Messages API path

## Test Plan

- Send a multimodal request with a valid model → works as before
- Simulate a broken `config.json` (e.g. rename it) → now returns 500 with `"multimodal_placeholder_resolution_failed"` instead of silently proceeding and failing downstream
- Send a text-only request → no change in behavior, multimodal block is skipped entirely

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling in multimodal request processing for placeholder resolution failures. Requests that encounter placeholder resolution issues now properly fail with detailed error messages and logging, rather than silently continuing with missing placeholders. This improves overall request reliability and provides clearer error diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->