### PR TITLE
fix(kv_index): prevent duplicate store events from inflating tree_sizes

### DIFF
--- a/crates/kv_index/src/event_tree.rs
+++ b/crates/kv_index/src/event_tree.rs
@@ -328,6 +328,7 @@ impl PositionalIndexer {
         };
 
         let mut prev_prefix = parent_prefix;
+        let mut num_new_blocks = 0usize;
         for (i, block) in blocks.iter().enumerate() {
             let position = start_pos + i;
             let content_hash = block.content_hash;
@@ -345,13 +346,21 @@ impl PositionalIndexer {
                 .and_modify(|entry| entry.insert(prefix_hash, worker_id))
                 .or_insert_with(|| SeqEntry::new(prefix_hash, worker_id));
 
-            worker_blocks.insert(block.seq_hash, (position, content_hash, prefix_hash));
+            // Only count genuinely new blocks — duplicate store events must not
+            // inflate tree_sizes, which would cause incorrect routing decisions.
+            if worker_blocks
+                .insert(block.seq_hash, (position, content_hash, prefix_hash))
+                .is_none()
+            {
+                num_new_blocks += 1;
+            }
             prev_prefix = Some(prefix_hash);
         }
 
         // Atomically update tree_sizes — lock-free array index.
-        let num_blocks = blocks.len();
-        self.tree_sizes[worker_id as usize].fetch_add(num_blocks, Ordering::Relaxed);
+        if num_new_blocks > 0 {
+            self.tree_sizes[worker_id as usize].fetch_add(num_new_blocks, Ordering::Relaxed);
+        }
 
         Ok(())
     }
@@ -1300,6 +1309,31 @@ mod tests {
         // Verify tree_sizes in query results
         let scores = indexer.find_matches(&hashes(&[10, 20, 30]), false);
         assert_eq!(scores.tree_sizes.get(&w1), Some(&3));
+    }
+
+    #[test]
+    fn test_duplicate_store_does_not_inflate_tree_size() {
+        let indexer = PositionalIndexer::new(64);
+        let blocks = make_blocks(&[10, 20, 30]);
+        let w1 = indexer.intern_worker("http://w1:8000");
+        let mut wb1 = WorkerBlockMap::default();
+
+        // First store: 3 new blocks
+        indexer.apply_stored(w1, &blocks, None, &mut wb1).unwrap();
+        let scores = indexer.find_matches(&hashes(&[10, 20, 30]), false);
+        assert_eq!(scores.tree_sizes.get(&w1), Some(&3));
+
+        // Replay the same store event — tree_size must not change
+        indexer.apply_stored(w1, &blocks, None, &mut wb1).unwrap();
+        let scores = indexer.find_matches(&hashes(&[10, 20, 30]), false);
+        assert_eq!(
+            scores.tree_sizes.get(&w1),
+            Some(&3),
+            "Duplicate store event must not inflate tree_size"
+        );
+
+        // Overlap scores should also be unchanged
+        assert_eq!(scores.scores.get(&w1), Some(&3));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fix a bug where duplicate KV cache store events permanently inflate the `tree_sizes` counter in `PositionalIndexer`, causing cache-aware routing to make incorrect decisions.

## Problem

When a backend retransmits a store event (reconnect, retry, or re-reports existing blocks), `apply_stored()` unconditionally adds `blocks.len()` to `tree_sizes`. The `worker_blocks.insert()` silently overwrites duplicate entries, but the counter doesn't account for this — it always increments by the full block count.

Over time, this inflates `tree_sizes` for workers that receive duplicate events. Since cache-aware routing uses `tree_sizes` for tie-breaking (smallest tree wins), inflated workers get deprioritized even when they have the best cache overlap.

## Fix

Check `worker_blocks.insert().is_none()` — only count blocks that are genuinely new (insert returned `None`, meaning no previous entry existed). The index entry itself (`DashMap` `and_modify`/`or_insert`) was already correct; only the `tree_sizes` counter was wrong.

## What changed

`crates/kv_index/src/event_tree.rs`:
- `apply_stored()`: Track `num_new_blocks` instead of using `blocks.len()`. Only increment `tree_sizes` for genuinely new blocks.
- New test `test_duplicate_store_does_not_inflate_tree_size`: Stores 3 blocks, replays the same event, verifies `tree_sizes` stays at 3.

## Test Plan

- [x] New test: duplicate store does not inflate tree_size
- [x] Existing tree_size tests pass (no regression)
- [x] Full kv-index test suite passes
- [x] Clippy clean

<details>
<summary>Checklist</summary>

- [x] Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where reprocessing duplicate stored events would incorrectly inflate internal measurements. The system now properly detects and handles duplicate events, ensuring accurate metrics and scoring calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->