### PR TITLE
fix(codeowners): correct grpc_servicer path and ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,7 +30,6 @@
 /crates/grpc_client @CatherineSue @slin1237
 /crates/grpc_client/proto/vllm_engine.proto @njhill @CatherineSue @slin1237
 /crates/grpc_client/proto/common.proto @njhill @CatherineSue @slin1237
-/crates/grpc_servicer @njhill @CatherineSue
 /crates/kv_index @slin1237
 /crates/mcp @key4ng @CatherineSue @slin1237
 /crates/mesh @tonyluj @llfl @slin1237
@@ -41,6 +40,10 @@
 /crates/tool_parser @slin1237 @CatherineSue
 /crates/wasm @slin1237 @tonyluj
 /crates/workflow @slin1237 @CatherineSue
+
+# gRPC servicer
+/grpc_servicer @CatherineSue @slin1237
+/grpc_servicer/smg_grpc_servicer/vllm @njhill @CatherineSue @slin1237
 
 # Examples
 /examples/wasm @tonyluj @slin1237


### PR DESCRIPTION
## Description

### Problem

The CODEOWNERS entry for `grpc_servicer` used the incorrect path `/crates/grpc_servicer`, which does not exist. `grpc_servicer` is a top-level directory.

### Solution

Fix the path to `/grpc_servicer` with correct owners, and add a sub-path entry for the vllm subdirectory.

## Changes

- Removed stale `/crates/grpc_servicer` entry
- Added `/grpc_servicer` owned by @CatherineSue @slin1237
- Added `/grpc_servicer/smg_grpc_servicer/vllm` owned by @njhill @CatherineSue @slin1237

## Test Plan

- Verified `/grpc_servicer/` exists as a top-level directory
- Verified `/crates/grpc_servicer/` does not exist

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code ownership configuration to reflect organizational changes.

**Note:** This release includes no user-facing changes. This is an internal administrative update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->