### PR TITLE
fix(multimodal): remove num_img_tokens fallback in Phi3VisionSpec

### DIFF
--- a/crates/multimodal/src/registry/phi3_v.rs
+++ b/crates/multimodal/src/registry/phi3_v.rs
@@ -10,14 +10,6 @@ use crate::{
 
 pub(super) struct Phi3VisionSpec;
 
-impl Phi3VisionSpec {
-    fn tokens_per_image(metadata: &ModelMetadata) -> usize {
-        metadata
-            .config_u32(&["img_processor", "num_img_tokens"])
-            .unwrap_or(256) as usize
-    }
-}
-
 impl ModelProcessorSpec for Phi3VisionSpec {
     fn name(&self) -> &'static str {
         "phi3_v"
@@ -64,14 +56,10 @@ impl ModelProcessorSpec for Phi3VisionSpec {
     ) -> RegistryResult<Vec<PromptReplacement>> {
         let token_id = self.placeholder_token_id(metadata)?;
         let token = self.placeholder_token(metadata)?;
-        let fallback = Self::tokens_per_image(metadata);
         Ok(preprocessed
             .num_img_tokens
             .iter()
-            .map(|&count| {
-                let n = if count > 0 { count } else { fallback };
-                PromptReplacement::repeated(Modality::Image, &token, token_id, n)
-            })
+            .map(|&count| PromptReplacement::repeated(Modality::Image, &token, token_id, count))
             .collect())
     }
 }


### PR DESCRIPTION
## Description

### Problem

`Phi3VisionSpec::prompt_replacements` had a fallback to the fixed config value (`img_processor.num_img_tokens = 144`) when `preprocessed.num_img_tokens[i]` was 0. This fallback was leftover from before #942 when the fixed config value was used for all images. If it ever triggered, it would silently produce wrong placeholder counts instead of surfacing the error.

Also removed the now-unused `tokens_per_image()` helper.

### Solution

Use `preprocessed.num_img_tokens` directly — the Phi3Vision preprocessor always computes per-image token counts via `calculate_num_tokens` for every image.

## Changes

- `crates/multimodal/src/registry/phi3_v.rs`: Remove fallback logic and `tokens_per_image()` helper

## Test Plan

- `cargo test -p llm-multimodal -- phi3` passes
- Existing golden tests cover the preprocessor token count computation

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified image token counting logic to directly use processed token values without conditional fallback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->