### PR TITLE
fix(mesh): enforce GC contract — rate_limit tombstones, stale tree entries, partition last_seen

### DIFF
--- a/crates/mesh/src/controller.rs
+++ b/crates/mesh/src/controller.rs
@@ -128,6 +128,11 @@ impl MeshController {
                 if removed > 0 {
                     log::info!("GC: removed {removed} tombstoned CRDT metadata entries");
                 }
+                // Clean stale tree_versions/tree_ops_pending for removed models
+                let tree_removed = self.stores.gc_stale_tree_entries();
+                if tree_removed > 0 {
+                    log::info!("GC: removed {tree_removed} stale tree entries");
+                }
                 // Checkpoint pending tree ops into config blobs
                 self.sync_manager.checkpoint_tree_states();
                 // Record store sizes for monitoring

--- a/crates/mesh/src/partition.rs
+++ b/crates/mesh/src/partition.rs
@@ -68,8 +68,19 @@ impl PartitionDetector {
         last_seen.insert(node_name.to_string(), Instant::now());
     }
 
+    /// Remove `last_seen` entries for nodes no longer in the cluster state.
+    pub fn prune_departed(&self, cluster_state: &BTreeMap<String, NodeState>) {
+        self.last_seen
+            .write()
+            .retain(|name, _| cluster_state.contains_key(name));
+    }
+
     /// Detect partition based on current cluster state
     pub fn detect_partition(&self, cluster_state: &BTreeMap<String, NodeState>) -> PartitionState {
+        // Prune entries for nodes no longer in cluster state to
+        // prevent unbounded growth from peer churn.
+        self.prune_departed(cluster_state);
+
         let now = Instant::now();
         let last_seen = self.last_seen.read();
 

--- a/crates/mesh/src/stores.rs
+++ b/crates/mesh/src/stores.rs
@@ -707,6 +707,11 @@ impl RateLimitStore {
 
         affected_keys
     }
+
+    /// Remove tombstoned CRDT metadata from the underlying counter store.
+    pub fn gc_tombstones(&self) -> usize {
+        self.counters.gc_tombstones()
+    }
 }
 
 impl Default for RateLimitStore {
@@ -813,6 +818,21 @@ impl StateStores {
             + self.app.gc_tombstones()
             + self.worker.gc_tombstones()
             + self.policy.gc_tombstones()
+            + self.rate_limit.gc_tombstones()
+    }
+
+    /// Remove stale tree entries for models that no longer have pending
+    /// ops or a policy store entry.  Called from the GC block.
+    pub fn gc_stale_tree_entries(&self) -> usize {
+        let before = self.tree_versions.len() + self.tree_ops_pending.len();
+        self.tree_versions.retain(|k, _| {
+            self.tree_ops_pending.get(k).is_some_and(|v| !v.is_empty())
+                || self.policy.get(k).is_some()
+        });
+        self.tree_ops_pending
+            .retain(|k, v| !v.is_empty() || self.policy.get(k).is_some());
+        let after = self.tree_versions.len() + self.tree_ops_pending.len();
+        before.saturating_sub(after)
     }
 }
 


### PR DESCRIPTION
## Summary

- Add `gc_tombstones()` to `RateLimitStore` — previously only 4 of 5 CRDT stores were garbage collected
- Add `gc_stale_tree_entries()` to clean `tree_versions` and `tree_ops_pending` entries for removed models
- Add `prune_departed()` to partition detector to remove `last_seen` entries for nodes no longer in cluster state

Part of the mesh structural hardening plan (`.claude/plans/2026-03-27-mesh-structural-hardening.md`), addressing findings M3, C2.1-C2.2, C2.4, L4.

## What Changed

### `crates/mesh/src/stores.rs`
- `RateLimitStore::gc_tombstones()`: New method delegating to `self.counters.gc_tombstones()`. Without this, tombstoned CRDT metadata for removed rate-limit counter shards accumulated indefinitely.
- `StateStores::gc_tombstones()`: Now includes `self.rate_limit.gc_tombstones()` in the total.
- `StateStores::gc_stale_tree_entries()`: New method that removes `tree_versions` and `tree_ops_pending` DashMap entries where the pending buffer is empty AND no policy store entry exists. Returns count of removed entries.

### `crates/mesh/src/controller.rs`
- GC block (every 60 rounds): Added call to `self.stores.gc_stale_tree_entries()` with logging.

### `crates/mesh/src/partition.rs`
- `PartitionDetector::prune_departed()`: New method that retains only `last_seen` entries for nodes still in cluster state.
- `detect_partition()`: Calls `prune_departed()` on every invocation to self-clean. This prevents unbounded growth of the `last_seen` BTreeMap from peer churn.

## Why

The mesh crate had no consistent GC contract:
- 4 of 5 CRDT stores had `gc_tombstones()` called, but `rate_limit` was missed
- `tree_versions` and `tree_ops_pending` DashMaps accumulated entries for decommissioned models forever
- `partition.rs` `last_seen` BTreeMap grew unboundedly with every peer ever seen

## Test Plan

- `cargo test -p smg-mesh`: 177 passed, 0 failed
- `cargo clippy -p smg-mesh --all-targets --all-features -- -D warnings`: clean
- `cargo +nightly fmt --all`: clean
- `cargo check -p smg`: clean
- Benchmark (200 rps, 500-char prompts, 2 gateways, 20 workers, 2 min): 20,955 requests, 0 errors, 0 retries

<details>
<summary>Checklist</summary>

- [x] Documentation updated (code comments)
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized garbage collection to remove stale tree entries and tombstoned rate-limit metadata.
  * Cluster state management automatically cleans up data for departed cluster members.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->