### PR TITLE
fix(multimodal): fix phi3_v test broken by num_img_tokens fallback removal

### DIFF
--- a/crates/multimodal/src/registry/phi3_v.rs
+++ b/crates/multimodal/src/registry/phi3_v.rs
@@ -88,7 +88,10 @@ mod tests {
         let registry = ModelRegistry::new();
         let spec = registry.lookup(&metadata).expect("phi3 spec");
         let replacements = spec
-            .prompt_replacements(&metadata, &test_preprocessed(&[ImageSize::new(336, 336)]))
+            .prompt_replacements(
+                &metadata,
+                &test_preprocessed_with_tokens(&[ImageSize::new(336, 336)], &[144]),
+            )
             .unwrap();
         assert_eq!(replacements[0].tokens.len(), 144);
         assert_eq!(replacements[0].tokens[0], 555);


### PR DESCRIPTION
## Description

### Problem

#955 removed the `num_img_tokens` fallback in `Phi3VisionSpec::prompt_replacements`, but the test `phi3_uses_num_img_tokens` used `test_preprocessed()` which initializes `num_img_tokens` to `[0]`. This caused the test to produce 0-length replacements instead of 144.

### Solution

Use `test_preprocessed_with_tokens(&[ImageSize::new(336, 336)], &[144])` to explicitly set the expected token count.

## Changes

- `crates/multimodal/src/registry/phi3_v.rs`: Update test to use `test_preprocessed_with_tokens`

## Test Plan

```
cargo test -p llm-multimodal -- phi3
```

All 24 phi3 tests pass.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for vision model token handling with explicit image token count validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->