### PR TITLE
fix(multimodal): use preprocessor token counts in LlavaSpec prompt replacements

### DIFF
--- a/crates/multimodal/src/registry/llava.rs
+++ b/crates/multimodal/src/registry/llava.rs
@@ -3,28 +3,13 @@ use std::collections::HashMap;
 use serde_json::{json, Value};
 
 use crate::{
-    registry::{image_sizes_hw, ModelMetadata, ModelProcessorSpec, RegistryResult},
-    types::{FieldLayout, ImageSize, Modality, PromptReplacement, TokenId},
+    registry::{ModelMetadata, ModelProcessorSpec, RegistryResult},
+    types::{FieldLayout, Modality, PromptReplacement, TokenId},
     vision::image_processor::PreprocessedImages,
 };
 
 pub(super) struct LlavaSpec;
 pub(super) struct LlavaNextSpec;
-
-impl LlavaSpec {
-    fn patch_size(metadata: &ModelMetadata) -> u32 {
-        metadata
-            .config_u32(&["vision_config", "patch_size"])
-            .unwrap_or(14)
-    }
-
-    fn tokens_per_image(metadata: &ModelMetadata, size: ImageSize) -> usize {
-        let patch = Self::patch_size(metadata);
-        let cols = size.width.div_ceil(patch) as usize;
-        let rows = size.height.div_ceil(patch) as usize;
-        cols * rows
-    }
-}
 
 impl ModelProcessorSpec for LlavaSpec {
     fn name(&self) -> &'static str {
@@ -73,14 +58,17 @@ impl ModelProcessorSpec for LlavaSpec {
     ) -> RegistryResult<Vec<PromptReplacement>> {
         let token_id = self.placeholder_token_id(metadata)?;
         let token = self.placeholder_token(metadata)?;
-        let image_sizes = image_sizes_hw(preprocessed);
-        Ok(image_sizes
-            .iter()
-            .map(|size| {
-                let count = Self::tokens_per_image(metadata, *size);
-                PromptReplacement::repeated(Modality::Image, &token, token_id, count)
-            })
-            .collect())
+        if let Some(&count) = preprocessed.num_img_tokens.first() {
+            // For LLaVA 1.5, all images produce the same number of tokens.
+            let replacement = PromptReplacement::repeated(Modality::Image, &token, token_id, count);
+            debug_assert!(
+                preprocessed.num_img_tokens.iter().all(|&c| c == count),
+                "LlavaSpec assumes all images produce the same number of tokens"
+            );
+            Ok(vec![replacement; preprocessed.num_img_tokens.len()])
+        } else {
+            Ok(vec![])
+        }
     }
 }
 
@@ -152,7 +140,7 @@ mod tests {
     };
 
     #[test]
-    fn llava_prompt_replacement_uses_config_ids() {
+    fn llava_prompt_replacement_uses_preprocessed_tokens() {
         let tokenizer = TestTokenizer::new(&[("<image>", 32000)]);
         let config = json!({
             "model_type": "llava",
@@ -166,9 +154,10 @@ mod tests {
         };
         let registry = ModelRegistry::new();
         let spec = registry.lookup(&metadata).expect("llava spec");
-        let replacements = spec
-            .prompt_replacements(&metadata, &test_preprocessed(&[ImageSize::new(336, 336)]))
-            .unwrap();
+        // Token count comes from preprocessed.num_img_tokens (set by
+        // LlavaProcessor::calculate_num_tokens), not from image dimensions.
+        let preprocessed = test_preprocessed_with_tokens(&[ImageSize::new(336, 336)], &[576]);
+        let replacements = spec.prompt_replacements(&metadata, &preprocessed).unwrap();
         assert_eq!(replacements[0].tokens.len(), 576);
     }
 

--- a/crates/multimodal/src/registry/mod.rs
+++ b/crates/multimodal/src/registry/mod.rs
@@ -11,8 +11,6 @@ use once_cell::sync::Lazy;
 use phi3_v::Phi3VisionSpec;
 use qwen3_vl::Qwen3VLVisionSpec;
 use qwen_vl::QwenVLVisionSpec;
-// Re-export for use by spec modules within the crate.
-pub(crate) use traits::image_sizes_hw;
 // Re-export public API from traits.
 pub use traits::{ModelMetadata, ModelProcessorSpec, ModelRegistryError, RegistryResult};
 

--- a/crates/multimodal/src/registry/traits.rs
+++ b/crates/multimodal/src/registry/traits.rs
@@ -5,7 +5,7 @@ use serde_json::Value;
 use thiserror::Error;
 
 use crate::{
-    types::{FieldLayout, ImageSize, Modality, PromptReplacement, TokenId},
+    types::{FieldLayout, Modality, PromptReplacement, TokenId},
     vision::image_processor::PreprocessedImages,
 };
 
@@ -92,16 +92,4 @@ pub trait ModelProcessorSpec: Send + Sync {
     fn keep_on_cpu_keys(&self) -> Vec<String> {
         vec![]
     }
-}
-
-/// Convert preprocessor `(height, width)` tuples to `ImageSize` values.
-pub fn image_sizes_hw(preprocessed: &PreprocessedImages) -> Vec<ImageSize> {
-    preprocessed
-        .image_sizes
-        .iter()
-        .map(|&(h, w)| ImageSize {
-            width: w,
-            height: h,
-        })
-        .collect()
 }


### PR DESCRIPTION
## Description

### Problem

`LlavaSpec.prompt_replacements()` recomputed token counts from original image dimensions using `(w/patch_size) * (h/patch_size)`. For non-square images (e.g. 300x200), this produces 330 tokens instead of the correct 576 — the LLaVA 1.5 preprocessor always resizes to 336x336 before ViT processing, so the token count is always `(336/14)^2 = 576` regardless of input dimensions.

### Solution

Use `preprocessed.num_img_tokens` directly (already computed correctly by `LlavaProcessor::calculate_num_tokens`), matching what `LlavaNextSpec` already does. Remove the now-unused `tokens_per_image`, `image_sizes_hw` helpers.

**Note on LLaVA 1.5 chat template:** This model ships with HuggingFace `{% generation %}` / `{% endgeneration %}` Jinja extension tags in its `chat_template.jinja` that minijinja cannot parse. These tags are an HF transformers extension (`AssistantTracker`) for SFT training token masking — they are no-ops for inference rendering. To use LLaVA 1.5 with SMG, pass a cleaned template via `--chat-template` with those tags removed.

## Changes

- `crates/multimodal/src/registry/llava.rs` -- Use `preprocessed.num_img_tokens` in `LlavaSpec.prompt_replacements()`; remove `tokens_per_image` and `patch_size` helpers.
- `crates/multimodal/src/registry/traits.rs` -- Remove unused `image_sizes_hw` function.
- `crates/multimodal/src/registry/mod.rs` -- Remove unused `image_sizes_hw` re-export.

## Test Plan

<details>
<summary>Unit tests</summary>

```
cargo test -p llm-multimodal
test result: ok. 135 passed; 0 failed
```

```
cargo test --workspace 2>&1 | tail -30)

     failures:

     ---- core::worker_registry::tests::test_health_checker_removes_unhealthy_workers stdout ----

     thread 'core::worker_registry::tests::test_health_checker_removes_unhealthy_workers' (1664711) panicked at model_gateway/src/core/worker_registry.rs:1267:9:
     assertion `left == right` failed: Unhealthy worker should have been removed from the registry
       left: 1
      right: 0


     failures:
         core::worker_registry::tests::test_health_checker_removes_unhealthy_workers

     test result: FAILED. 449 passed; 1 failed; 4 ignored; 0 measured; 0 filtered out; finished in 35.07s

     error: test failed, to rerun pass `-p smg --lib`
```
</details>

<details>
<summary>End-to-end: LLaVA 1.5 via vLLM gRPC</summary>

**Setup:**
```bash
# vLLM backend
vllm serve --model /raid/models/llava-hf/llava-1.5-7b-hf --tensor-parallel-size 1 --port 8080 --grpc

# Clean chat template (strip {% generation %} tags)
sed 's/{% generation %}//g; s/{% endgeneration %}//g' \
  /raid/models/llava-hf/llava-1.5-7b-hf/chat_template.jinja > /tmp/llava15_clean.jinja

# SMG router with custom template
cargo run --bin smg -- --host 0.0.0.0 --port 3002 \
  --worker-urls grpc://127.0.0.1:8080 \
  --model-path /raid/models/llava-hf/llava-1.5-7b-hf \
  --chat-template /tmp/llava15_clean.jinja --log-level debug
```

**Single image test:**
```python
from openai import OpenAI
client = OpenAI(base_url="http://localhost:3002/v1", api_key="test")
response = client.chat.completions.create(
    model="/raid/models/llava-hf/llava-1.5-7b-hf",
    messages=[{"role": "user", "content": [
        {"type": "text", "text": "What is in this image? Describe it briefly."},
        {"type": "image_url", "image_url": {"url": "https://picsum.photos/id/237/300/200"}},
    ]}],
    max_tokens=200,
)
```

**Result:**
```
The image features a close-up of a black dog's face, with his eyes looking
deep into the camera. The dog is sitting on the floor, possibly on a wooden
surface like a tabletop.
```

**Multi-image test:**
```python
response = client.chat.completions.create(
    model="/raid/models/llava-hf/llava-1.5-7b-hf",
    messages=[{"role": "user", "content": [
        {"type": "text", "text": "Describe each image briefly. How many images did I send?"},
        {"type": "image_url", "image_url": {"url": "https://picsum.photos/id/237/300/200"}},
        {"type": "image_url", "image_url": {"url": "https://picsum.photos/id/1025/300/200"}},
    ]}],
    max_tokens=200,
)
```

**Result:**
```
I received several images depicting black dogs. In the first image, a cute
black puppy is wrapped up warm in a towel or cloth and placed in the woods
on a dirt trail. The second image has a black puppy sitting on a blanket
next to a tree...
```

**SMG log confirms correct token count:**
```
Image preprocessing complete num_images=1 total_tokens=576
```

**Before fix:** `total_tokens=330` (wrong, computed from original 300x200 dimensions).
</details>

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined token counting mechanism for image processing in multimodal models by consolidating how image token information is sourced and validated.
  * Simplified internal helper functions and updated related test coverage accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->