### PR TITLE
fix(multimodal): remove unused test_preprocessed helper

### DIFF
--- a/crates/multimodal/src/registry/mod.rs
+++ b/crates/multimodal/src/registry/mod.rs
@@ -151,11 +151,6 @@ pub(super) mod test_helpers {
         }
     }
 
-    /// Build a minimal `PreprocessedImages` for testing prompt_replacements.
-    pub fn test_preprocessed(image_sizes: &[ImageSize]) -> PreprocessedImages {
-        test_preprocessed_with_tokens(image_sizes, &vec![0; image_sizes.len()])
-    }
-
     pub fn test_preprocessed_with_tokens(
         image_sizes: &[ImageSize],
         num_img_tokens: &[usize],


### PR DESCRIPTION
## Description

### Problem

CI clippy fails on main with `dead_code` error for `test_preprocessed` after #957 and #958 both landed — #957 removed the last caller (phi3_v test) and #958 removed the llava caller, but neither removed the function itself.

### Solution

Remove the unused `test_preprocessed` function from `crates/multimodal/src/registry/mod.rs`.

## Changes

- `crates/multimodal/src/registry/mod.rs` -- Remove dead `test_preprocessed` helper.

## Test Plan

`cargo clippy --all-targets --all-features -- -D warnings` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed an internal test helper function to streamline test utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->