### PR TITLE
feat(completions): wire Completion API pipeline into gRPC routers

### DIFF
--- a/model_gateway/src/routers/grpc/pd_router.rs
+++ b/model_gateway/src/routers/grpc/pd_router.rs
@@ -3,7 +3,8 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use axum::{http::HeaderMap, response::Response};
 use openai_protocol::{
-    chat::ChatCompletionRequest, generate::GenerateRequest, messages::CreateMessageRequest,
+    chat::ChatCompletionRequest, completion::CompletionRequest, generate::GenerateRequest,
+    messages::CreateMessageRequest,
 };
 use tracing::debug;
 
@@ -24,6 +25,7 @@ pub struct GrpcPDRouter {
     worker_registry: Arc<WorkerRegistry>,
     pipeline: RequestPipeline,
     messages_pipeline: RequestPipeline,
+    completion_pipeline: RequestPipeline,
     shared_components: Arc<SharedComponents>,
     retry_config: RetryConfig,
 }
@@ -86,10 +88,15 @@ impl GrpcPDRouter {
             ctx.configured_reasoning_parser.clone(),
         );
 
+        // Create Completion PD pipeline
+        let completion_pipeline =
+            RequestPipeline::new_completion_pd(worker_registry.clone(), policy_registry.clone());
+
         Ok(GrpcPDRouter {
             worker_registry,
             pipeline,
             messages_pipeline,
+            completion_pipeline,
             shared_components,
             retry_config: ctx.router_config.effective_retry_config(),
         })
@@ -211,6 +218,63 @@ impl GrpcPDRouter {
         .await
     }
 
+    /// Main route_completion implementation with PD dual dispatch
+    async fn route_completion_impl(
+        &self,
+        headers: Option<&HeaderMap>,
+        body: &CompletionRequest,
+        model_id: &str,
+    ) -> Response {
+        debug!(
+            "Processing completion request for model: {} (PD mode)",
+            model_id
+        );
+
+        let request = Arc::new(body.clone());
+        let headers_cloned = headers.cloned();
+        let model_id_cloned = model_id.to_string();
+        let components = self.shared_components.clone();
+        let pipeline = &self.completion_pipeline;
+
+        RetryExecutor::execute_response_with_retry(
+            &self.retry_config,
+            |_attempt| {
+                let request = Arc::clone(&request);
+                let headers = headers_cloned.clone();
+                let model_id = model_id_cloned.clone();
+                let components = Arc::clone(&components);
+                async move {
+                    pipeline
+                        .execute_completion(request, headers, model_id, components)
+                        .await
+                }
+            },
+            |res, _attempt| is_retryable_status(res.status()),
+            |delay, attempt| {
+                Metrics::record_worker_retry(
+                    metrics_labels::WORKER_PREFILL,
+                    metrics_labels::ENDPOINT_COMPLETIONS,
+                );
+                Metrics::record_worker_retry(
+                    metrics_labels::WORKER_DECODE,
+                    metrics_labels::ENDPOINT_COMPLETIONS,
+                );
+                Metrics::record_worker_retry_backoff(attempt, delay);
+            },
+            || {
+                Metrics::record_worker_retries_exhausted(
+                    metrics_labels::WORKER_PREFILL,
+                    metrics_labels::ENDPOINT_COMPLETIONS,
+                );
+                Metrics::record_worker_retries_exhausted(
+                    metrics_labels::WORKER_DECODE,
+                    metrics_labels::ENDPOINT_COMPLETIONS,
+                );
+            },
+        )
+        .await
+    }
+
     /// Main route_chat implementation with PD dual dispatch
     async fn route_chat_impl(
         &self,
@@ -315,6 +379,15 @@ impl RouterTrait for GrpcPDRouter {
         model_id: &str,
     ) -> Response {
         self.route_chat_impl(headers, body, model_id).await
+    }
+
+    async fn route_completion(
+        &self,
+        headers: Option<&HeaderMap>,
+        body: &CompletionRequest,
+        model_id: &str,
+    ) -> Response {
+        self.route_completion_impl(headers, body, model_id).await
     }
 
     async fn route_messages(

--- a/model_gateway/src/routers/grpc/pipeline.rs
+++ b/model_gateway/src/routers/grpc/pipeline.rs
@@ -18,7 +18,7 @@ use reasoning_parser::ParserFactory as ReasoningParserFactory;
 use tool_parser::ParserFactory as ToolParserFactory;
 use tracing::{debug, error};
 
-// Import embedding-specific, classify-specific, and messages-specific stages
+// Import embedding-specific, classify-specific, messages-specific, and completion-specific stages
 use super::regular::stages::classify::ClassifyResponseProcessingStage;
 use super::{
     common::{responses::ResponsesContext, stages::*},
@@ -27,6 +27,10 @@ use super::{
     regular::{
         processor,
         stages::{
+            completion::{
+                CompletionPreparationStage, CompletionRequestBuildingStage,
+                CompletionResponseProcessingStage,
+            },
             embedding::{
                 preparation::EmbeddingPreparationStage,
                 request_building::EmbeddingRequestBuildingStage,
@@ -401,6 +405,74 @@ impl RequestPipeline {
         }
     }
 
+    /// Create a Completion API pipeline (single-worker)
+    ///
+    /// Uses Completion-specific stages for preparation, request building, and response
+    /// processing. Shares worker selection, client acquisition, dispatch metadata,
+    /// and request execution stages with other pipelines.
+    pub fn new_completion(
+        worker_registry: Arc<WorkerRegistry>,
+        policy_registry: Arc<PolicyRegistry>,
+    ) -> Self {
+        let processor = processor::ResponseProcessor::new(
+            ToolParserFactory::default(),
+            ReasoningParserFactory::default(),
+            None,
+            None,
+        );
+
+        let stages: Vec<Box<dyn PipelineStage>> = vec![
+            Box::new(CompletionPreparationStage),
+            Box::new(WorkerSelectionStage::new(
+                worker_registry,
+                policy_registry,
+                WorkerSelectionMode::Regular,
+            )),
+            Box::new(ClientAcquisitionStage),
+            Box::new(CompletionRequestBuildingStage::new(false)), // No PD metadata
+            Box::new(DispatchMetadataStage),
+            Box::new(RequestExecutionStage::new(ExecutionMode::Single)),
+            Box::new(CompletionResponseProcessingStage::new(processor)),
+        ];
+
+        Self {
+            stages: Arc::new(stages),
+            backend_type: metrics_labels::BACKEND_REGULAR,
+        }
+    }
+
+    /// Create a Completion API PD (prefill-decode) pipeline
+    pub fn new_completion_pd(
+        worker_registry: Arc<WorkerRegistry>,
+        policy_registry: Arc<PolicyRegistry>,
+    ) -> Self {
+        let processor = processor::ResponseProcessor::new(
+            ToolParserFactory::default(),
+            ReasoningParserFactory::default(),
+            None,
+            None,
+        );
+
+        let stages: Vec<Box<dyn PipelineStage>> = vec![
+            Box::new(CompletionPreparationStage),
+            Box::new(WorkerSelectionStage::new(
+                worker_registry,
+                policy_registry,
+                WorkerSelectionMode::PrefillDecode,
+            )),
+            Box::new(ClientAcquisitionStage),
+            Box::new(CompletionRequestBuildingStage::new(true)), // Inject PD metadata
+            Box::new(DispatchMetadataStage),
+            Box::new(RequestExecutionStage::new(ExecutionMode::DualDispatch)),
+            Box::new(CompletionResponseProcessingStage::new(processor)),
+        ];
+
+        Self {
+            stages: Arc::new(stages),
+            backend_type: metrics_labels::BACKEND_PD,
+        }
+    }
+
     /// Execute the complete pipeline for a chat request
     pub async fn execute_chat(
         &self,
@@ -583,15 +655,11 @@ impl RequestPipeline {
     }
 
     /// Execute the complete pipeline for a completion request
-    #[expect(
-        dead_code,
-        reason = "Completion pipeline entrypoint is introduced before later stacked PRs wire the router to call it"
-    )]
     pub async fn execute_completion(
         &self,
         request: Arc<CompletionRequest>,
         headers: Option<http::HeaderMap>,
-        _model_id: Option<String>,
+        model_id: String,
         components: Arc<SharedComponents>,
     ) -> Response {
         let start = Instant::now();
@@ -607,7 +675,7 @@ impl RequestPipeline {
             bool_to_static_str(streaming),
         );
 
-        let mut ctx = RequestContext::for_completion(request, headers, model.clone(), components);
+        let mut ctx = RequestContext::for_completion(request, headers, model_id, components);
 
         for stage in self.stages.iter() {
             match stage.execute(&mut ctx).await {

--- a/model_gateway/src/routers/grpc/regular/stages/completion/mod.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/completion/mod.rs
@@ -1,9 +1,8 @@
 //! Completion API endpoint pipeline stages
 //!
-//! This module continues the native `/v1/completions` stage stack. With scaffolding
-//! in PR #840,preparation (#907), request building (#915), and now response processing,
-//! three of the four endpoint-specific pipeline stages are complete. The shared
-//! stages (worker selection, client acquisition, dispatch, execution) are reused
+//! This module contains the `/v1/completions` stage stack: preparation (#907),
+//! request building (#915), and response processing. The shared stages
+//! (worker selection, client acquisition, dispatch, execution) are reused
 //! from the existing pipeline.
 
 mod preparation;
@@ -11,7 +10,5 @@ mod request_building;
 mod response_processing;
 
 pub(crate) use preparation::CompletionPreparationStage;
-#[expect(unused_imports, reason = "wired in pipeline factory follow-up PR")]
 pub(crate) use request_building::CompletionRequestBuildingStage;
-#[expect(unused_imports, reason = "wired in pipeline factory follow-up PR")]
 pub(crate) use response_processing::CompletionResponseProcessingStage;

--- a/model_gateway/src/routers/grpc/regular/stages/completion/request_building.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/completion/request_building.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)]
 //! Completion request building stage: build proto GenerateRequest from CompletionRequest
 //!
 //! Stage 4 for the `/v1/completions` pipeline, parallel to `MessageRequestBuildingStage`

--- a/model_gateway/src/routers/grpc/router.rs
+++ b/model_gateway/src/routers/grpc/router.rs
@@ -6,8 +6,9 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use openai_protocol::{
-    chat::ChatCompletionRequest, classify::ClassifyRequest, embedding::EmbeddingRequest,
-    generate::GenerateRequest, messages::CreateMessageRequest, responses::ResponsesRequest,
+    chat::ChatCompletionRequest, classify::ClassifyRequest, completion::CompletionRequest,
+    embedding::EmbeddingRequest, generate::GenerateRequest, messages::CreateMessageRequest,
+    responses::ResponsesRequest,
 };
 use tracing::debug;
 
@@ -38,6 +39,7 @@ pub struct GrpcRouter {
     embedding_pipeline: RequestPipeline,
     classify_pipeline: RequestPipeline,
     messages_pipeline: RequestPipeline,
+    completion_pipeline: RequestPipeline,
     shared_components: Arc<SharedComponents>,
     responses_context: ResponsesContext,
     harmony_responses_context: ResponsesContext,
@@ -119,6 +121,10 @@ impl GrpcRouter {
             ctx.configured_reasoning_parser.clone(),
         );
 
+        // Create Completion pipeline
+        let completion_pipeline =
+            RequestPipeline::new_completion(worker_registry.clone(), _policy_registry.clone());
+
         // Extract shared dependencies for responses contexts
         let mcp_orchestrator = ctx
             .mcp_orchestrator
@@ -153,6 +159,7 @@ impl GrpcRouter {
             embedding_pipeline,
             classify_pipeline,
             messages_pipeline,
+            completion_pipeline,
             shared_components,
             responses_context,
             harmony_responses_context,
@@ -414,6 +421,57 @@ impl GrpcRouter {
         .await
     }
 
+    /// Main route_completion implementation
+    async fn route_completion_impl(
+        &self,
+        headers: Option<&HeaderMap>,
+        body: &CompletionRequest,
+        model_id: &str,
+    ) -> Response {
+        debug!("Processing completion request for model: {}", model_id);
+
+        let request = Arc::new(body.clone());
+        let headers_cloned = headers.cloned();
+        let model_id_cloned = model_id.to_string();
+        let components = self.shared_components.clone();
+        let pipeline = &self.completion_pipeline;
+
+        let per_model_retry_config = self.worker_registry.get_retry_config(model_id);
+        let retry_config = per_model_retry_config
+            .as_ref()
+            .unwrap_or(&self.retry_config);
+
+        RetryExecutor::execute_response_with_retry(
+            retry_config,
+            |_attempt| {
+                let request = Arc::clone(&request);
+                let headers = headers_cloned.clone();
+                let model_id = model_id_cloned.clone();
+                let components = Arc::clone(&components);
+                async move {
+                    pipeline
+                        .execute_completion(request, headers, model_id, components)
+                        .await
+                }
+            },
+            |res, _attempt| is_retryable_status(res.status()),
+            |delay, attempt| {
+                Metrics::record_worker_retry(
+                    metrics_labels::WORKER_REGULAR,
+                    metrics_labels::ENDPOINT_COMPLETIONS,
+                );
+                Metrics::record_worker_retry_backoff(attempt, delay);
+            },
+            || {
+                Metrics::record_worker_retries_exhausted(
+                    metrics_labels::WORKER_REGULAR,
+                    metrics_labels::ENDPOINT_COMPLETIONS,
+                );
+            },
+        )
+        .await
+    }
+
     /// Main route_classify implementation
     async fn route_classify_impl(
         &self,
@@ -496,6 +554,15 @@ impl RouterTrait for GrpcRouter {
         model_id: &str,
     ) -> Response {
         self.route_classify_impl(headers, body, model_id).await
+    }
+
+    async fn route_completion(
+        &self,
+        headers: Option<&HeaderMap>,
+        body: &CompletionRequest,
+        model_id: &str,
+    ) -> Response {
+        self.route_completion_impl(headers, body, model_id).await
     }
 
     async fn route_messages(


### PR DESCRIPTION
## Summary

Wire the Completion API pipeline into gRPC routers, enabling `/v1/completions` endpoint support
for both regular and PD (prefill-decode) modes. This is PR 5 in the Completions API gRPC series.

## What changed

**Pipeline factory** (`pipeline.rs`):
- `new_completion()` — dedicated Completion pipeline (single-worker) with `CompletionPreparationStage`,
  shared middleware stages (worker selection, client acquisition, dispatch metadata, request execution),
  and `CompletionResponseProcessingStage`
- `new_completion_pd()` — same pipeline configured for PD dual dispatch
  (`WorkerSelectionMode::PrefillDecode`, `ExecutionMode::DualDispatch`, PD metadata injection)
- `execute_completion()` — remove `#[expect(dead_code)]`, fix signature to `model_id: String`

**Router wiring** (`router.rs`):
- `completion_pipeline` field on `GrpcRouter`, created in `new()` via `new_completion()`
- `route_completion_impl()` with `RetryExecutor` retry wrapper and per-model retry config
- `RouterTrait::route_completion` override (was returning 501 Not Implemented)

**PD Router wiring** (`pd_router.rs`):
- `completion_pipeline` field on `GrpcPDRouter`, created in `new()` via `new_completion_pd()`
- `route_completion_impl()` with PD retry metrics (prefill + decode workers)
- `RouterTrait::route_completion` override

**Scaffolding cleanup**:
- Remove `#[expect(unused_imports)]` from `completion/mod.rs` re-exports
- Remove `#![allow(dead_code)]` from `completion/request_building.rs`
- Update `completion/mod.rs` doc comment

## Why

Previous PRs (#840, #907, #915, #953) built the individual Completion pipeline stages but left them
unwired. This PR composes them into a functional pipeline and connects it to the router layer, making
`/v1/completions` actually reachable on gRPC routers.

## How

Follows the same dedicated-pipeline pattern used by other gRPC endpoints in this repo — Completions
gets its own pipeline instance with endpoint-specific stages at positions 1, 4, 7 and shared stages
at positions 2, 3, 5, 6. Completions does not use tool/reasoning parsers, so the `ResponseProcessor`
is constructed with default factories and `None` parsers.

Both `GrpcRouter` (regular) and `GrpcPDRouter` (prefill-decode) get their own `completion_pipeline`
field and `route_completion_impl()` method, following the exact same retry + metrics patterns as the
other `route_*_impl()` methods in each router.

## Test plan

- `cargo clippy -p smg --all-targets --all-features -- -D warnings` — clean
- `cargo clippy -p smg-grpc-client --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --check` — clean
- Manual E2E: verified on GLM-5 (4×GPU, SGLang backend):
  - Basic completion (prompt + max_tokens) ✓
  - Multiple completions (n=2) ✓
  - Echo + suffix ✓
  - Stop sequences (finish_reason: stop) ✓

### Prior PRs in series

1. #840 — Scaffolding (`RequestType::Completion`, `FinalResponse::Completion`, `execute_completion`)
2. #907 — Stage 1: `CompletionPreparationStage`
3. #915 — Stage 4: `CompletionRequestBuildingStage` + backend sampling params
4. #953 — Stage 7: `CompletionResponseProcessingStage` (non-streaming)
5. **This PR** — Pipeline factory + Router wiring

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Completion requests now routed through gRPC with configurable per-model retry policies
  * Support for both standard and optimized prefill/decode execution modes
  * Automatic retry with backoff and detailed metrics tracking for completion operations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->