### PR TITLE
feat(helm): add worker deployment support with engine-specific images

### DIFF
--- a/deploy/helm/smg/README.md
+++ b/deploy/helm/smg/README.md
@@ -1,19 +1,51 @@
 # SMG Helm Chart
 
-Helm chart for deploying the Shepherd Model Gateway (SMG) — a high-performance inference router for LLM deployments.
+Helm chart for deploying the Shepherd Model Gateway (SMG) — a high-performance inference router for LLM deployments. Supports deploying the gateway with optional worker (inference engine) pods.
 
 ## Prerequisites
 
 - Kubernetes >= 1.26
 - Helm >= 3.12
+- GPU nodes with `nvidia.com/gpu` resource (for workers)
 
 ## Quick Start
+
+### Router only (external workers)
 
 ```bash
 helm install smg deploy/helm/smg \
   --set router.workerUrls[0]=http://worker-1:8000 \
   --set router.workerUrls[1]=http://worker-2:8000
 ```
+
+### Router + vLLM worker
+
+```bash
+helm install smg deploy/helm/smg \
+  -f deploy/helm/smg/examples/with-vllm-http.yaml \
+  --set huggingface.token=hf_xxx
+```
+
+### Router + SGLang worker
+
+```bash
+helm install smg deploy/helm/smg \
+  -f deploy/helm/smg/examples/with-sglang.yaml \
+  --set huggingface.token=hf_xxx
+```
+
+## Images
+
+The gateway image is on Docker Hub, engine images are on GitHub Container Registry:
+
+| Component | Registry | Image |
+|-----------|----------|-------|
+| Gateway | `docker.io` | `lightseekorg/smg:1.3.3` |
+| vLLM worker | `ghcr.io` | `lightseekorg/smg:1.3.3-vllm-v0.18.0` |
+| SGLang worker | `ghcr.io` | `lightseekorg/smg:1.3.3-sglang-v0.5.9` |
+| TRT-LLM worker | `ghcr.io` | `lightseekorg/smg:1.3.3-trtllm-1.3.0rc8` |
+
+Worker images default to `ghcr.io`. Set `workers[].image.tag` to the engine-specific tag.
 
 ## Configuration
 
@@ -25,6 +57,8 @@ See [`values.yaml`](values.yaml) for the full list of configurable parameters.
 |---------|-------------|
 | `global` | Image registry, pull secrets |
 | `router` | Router deployment, routing policy, networking, observability |
+| `workers` | Worker (inference engine) deployments |
+| `huggingface` | HuggingFace token for gated model downloads |
 | `auth` | API key authentication, rate limiting |
 | `history` | Storage backend (none/memory/postgres/redis/oracle) |
 | `serviceAccount` | Service account creation and annotations |
@@ -34,11 +68,72 @@ See [`values.yaml`](values.yaml) for the full list of configurable parameters.
 
 `cache_aware` (default), `round_robin`, `power_of_two`, `consistent_hashing`, `prefix_hash`, `manual`, `random`, `bucket`
 
+### Workers
+
+Each entry in `workers[]` creates a Deployment + Service:
+
+```yaml
+workers:
+  - name: llama-8b                    # unique name
+    engine: vllm                      # vllm or sglang
+    model: meta-llama/Llama-3.1-8B-Instruct
+    replicas: 1
+    connectionMode: http              # http or grpc
+    gpu:
+      count: 1                        # GPUs per replica (tensor parallel)
+    image:
+      tag: "1.3.3-vllm-v0.18.0"      # engine image tag
+```
+
+Workers are automatically wired to the router via `--worker-urls`. The URL scheme (`http://` or `grpc://`) is set based on `connectionMode`.
+
+#### Connection Modes
+
+| Mode | Description | Worker Command |
+|------|-------------|----------------|
+| `http` | OpenAI-compatible HTTP API | vLLM: `vllm.entrypoints.openai.api_server` |
+| `grpc` | SMG gRPC pipeline | vLLM: `vllm.entrypoints.grpc_server` |
+
+SGLang uses `sglang.launch_server` for both modes (adds `--grpc-mode` for gRPC).
+
+#### HuggingFace Token
+
+Gated models (e.g., Llama) require a HuggingFace token:
+
+```bash
+helm install smg deploy/helm/smg \
+  -f examples/with-vllm-http.yaml \
+  --set huggingface.token=hf_xxx
+```
+
+The token is stored in a Kubernetes Secret and injected as `HF_TOKEN` env var into both the router and worker pods.
+
+#### Startup Probes
+
+Model loading takes 60-300 seconds. Workers have startup probes with generous defaults:
+
+- HTTP mode: `httpGet /health` with `initialDelaySeconds: 60`, `failureThreshold: 30`
+- gRPC mode: `tcpSocket` probe (not all engines implement gRPC health checking yet)
+
+Override per worker:
+
+```yaml
+workers:
+  - name: large-model
+    startupProbe:
+      initialDelaySeconds: 180
+      failureThreshold: 60
+```
+
 ## Examples
 
 | File | Scenario |
 |------|----------|
 | [`router-only.yaml`](examples/router-only.yaml) | Minimal router with external workers |
+| [`with-vllm-http.yaml`](examples/with-vllm-http.yaml) | Router + vLLM worker (HTTP) |
+| [`with-vllm-grpc.yaml`](examples/with-vllm-grpc.yaml) | Router + vLLM worker (gRPC) |
+| [`with-sglang.yaml`](examples/with-sglang.yaml) | Router + SGLang worker |
+| [`with-multi-model.yaml`](examples/with-multi-model.yaml) | Multiple models on different engines |
 | [`with-postgres.yaml`](examples/with-postgres.yaml) | PostgreSQL history backend |
 | [`with-service-discovery.yaml`](examples/with-service-discovery.yaml) | K8s auto-discovery |
 | [`with-ingress.yaml`](examples/with-ingress.yaml) | Ingress with TLS |
@@ -50,13 +145,21 @@ See [`values.yaml`](values.yaml) for the full list of configurable parameters.
 helm test smg
 ```
 
-## Upgrading
-
-### 0.1.0
-
-Initial release.
-
 ## Troubleshooting
+
+### Worker not registering
+
+Check worker pod logs:
+
+```bash
+kubectl logs -l smg.lightseek.org/worker=<worker-name> -f
+```
+
+Model loading can take several minutes. The router will register the worker once it passes the startup probe.
+
+### Tokenizer download fails (read-only filesystem)
+
+The router sets `HF_HOME=/tmp/hf-cache` to use the writable `/tmp` mount. If you see "Read-only file system" errors, ensure the `tmp` volume is mounted.
 
 ### Service discovery not finding pods
 

--- a/deploy/helm/smg/examples/with-multi-model.yaml
+++ b/deploy/helm/smg/examples/with-multi-model.yaml
@@ -1,0 +1,55 @@
+# SMG gateway + multiple models on different engines
+# Usage: helm install smg deploy/helm/smg -f deploy/helm/smg/examples/with-multi-model.yaml
+#
+# Deploys two models:
+#   - Llama-3.1-8B on vLLM (1 GPU, HTTP)
+#   - Qwen3-VL-8B on SGLang (1 GPU, HTTP)
+#
+# Prerequisites:
+#   - At least 2 GPU nodes
+#   - HuggingFace token for gated models (set huggingface.token)
+
+global:
+  image:
+    registry: docker.io
+    repository: lightseekorg/smg
+    tag: "1.3.3"
+
+huggingface:
+  token: ""  # set via --set huggingface.token=hf_xxx
+
+router:
+  replicas: 1
+  policy: cache_aware
+  enableIgw: true  # required for multi-model routing
+  healthCheck:
+    enabled: false
+
+workers:
+  - name: llama-8b
+    engine: vllm
+    model: meta-llama/Llama-3.1-8B-Instruct
+    replicas: 1
+    connectionMode: http
+    gpu:
+      count: 1
+    image:
+      tag: "1.3.3-vllm-v0.18.0"
+    resources:
+      requests:
+        cpu: "4"
+        memory: 32Gi
+
+  - name: qwen-vl-8b
+    engine: sglang
+    model: Qwen/Qwen2.5-VL-7B-Instruct
+    replicas: 1
+    connectionMode: http
+    gpu:
+      count: 1
+    image:
+      tag: "1.3.3-sglang-v0.5.9"
+    resources:
+      requests:
+        cpu: "4"
+        memory: 32Gi

--- a/deploy/helm/smg/examples/with-sglang.yaml
+++ b/deploy/helm/smg/examples/with-sglang.yaml
@@ -1,0 +1,43 @@
+# SMG gateway + SGLang worker
+# Usage: helm install smg deploy/helm/smg -f deploy/helm/smg/examples/with-sglang.yaml
+#
+# Prerequisites:
+#   - GPU nodes with nvidia.com/gpu resource
+#   - HuggingFace token for gated models (set huggingface.token)
+
+global:
+  image:
+    registry: docker.io
+    repository: lightseekorg/smg
+    tag: "1.3.3"
+
+huggingface:
+  token: ""  # set via --set huggingface.token=hf_xxx
+
+router:
+  replicas: 1
+  policy: cache_aware
+  model: meta-llama/Llama-3.1-8B-Instruct
+  healthCheck:
+    enabled: false  # disable until workers are ready
+
+workers:
+  - name: llama-8b
+    engine: sglang
+    model: meta-llama/Llama-3.1-8B-Instruct
+    replicas: 1
+    connectionMode: http
+    gpu:
+      count: 1
+    image:
+      tag: "1.3.3-sglang-v0.5.9"
+    resources:
+      requests:
+        cpu: "4"
+        memory: 32Gi
+      limits:
+        memory: 64Gi
+    startupProbe:
+      initialDelaySeconds: 120
+      periodSeconds: 10
+      failureThreshold: 30

--- a/deploy/helm/smg/examples/with-vllm-grpc.yaml
+++ b/deploy/helm/smg/examples/with-vllm-grpc.yaml
@@ -1,0 +1,47 @@
+# SMG gateway + vLLM worker (gRPC mode)
+# Usage: helm install smg deploy/helm/smg -f deploy/helm/smg/examples/with-vllm-grpc.yaml
+#
+# gRPC mode enables the full SMG pipeline (tokenization, tool parsing,
+# reasoning parsing) on the gateway side. The worker runs vLLM's native
+# gRPC server.
+#
+# Prerequisites:
+#   - GPU nodes with nvidia.com/gpu resource
+#   - HuggingFace token for gated models (set huggingface.token)
+
+global:
+  image:
+    registry: docker.io
+    repository: lightseekorg/smg
+    tag: "1.3.3"
+
+huggingface:
+  token: ""  # set via --set huggingface.token=hf_xxx
+
+router:
+  replicas: 1
+  policy: cache_aware
+  model: meta-llama/Llama-3.1-8B-Instruct
+  healthCheck:
+    enabled: false  # disable until workers are ready
+
+workers:
+  - name: llama-8b
+    engine: vllm
+    model: meta-llama/Llama-3.1-8B-Instruct
+    replicas: 1
+    connectionMode: grpc
+    gpu:
+      count: 1
+    image:
+      tag: "1.3.3-vllm-v0.18.0"
+    resources:
+      requests:
+        cpu: "4"
+        memory: 32Gi
+      limits:
+        memory: 64Gi
+    startupProbe:
+      initialDelaySeconds: 120
+      periodSeconds: 10
+      failureThreshold: 30

--- a/deploy/helm/smg/examples/with-vllm-http.yaml
+++ b/deploy/helm/smg/examples/with-vllm-http.yaml
@@ -1,0 +1,43 @@
+# SMG gateway + vLLM worker (HTTP mode)
+# Usage: helm install smg deploy/helm/smg -f deploy/helm/smg/examples/with-vllm-http.yaml
+#
+# Prerequisites:
+#   - GPU nodes with nvidia.com/gpu resource
+#   - HuggingFace token for gated models (set huggingface.token)
+
+global:
+  image:
+    registry: docker.io
+    repository: lightseekorg/smg
+    tag: "1.3.3"
+
+huggingface:
+  token: ""  # set via --set huggingface.token=hf_xxx
+
+router:
+  replicas: 1
+  policy: cache_aware
+  model: meta-llama/Llama-3.1-8B-Instruct
+  healthCheck:
+    enabled: false  # disable until workers are ready
+
+workers:
+  - name: llama-8b
+    engine: vllm
+    model: meta-llama/Llama-3.1-8B-Instruct
+    replicas: 1
+    connectionMode: http
+    gpu:
+      count: 1
+    image:
+      tag: "1.3.3-vllm-v0.18.0"
+    resources:
+      requests:
+        cpu: "4"
+        memory: 32Gi
+      limits:
+        memory: 64Gi
+    startupProbe:
+      initialDelaySeconds: 120
+      periodSeconds: 10
+      failureThreshold: 30

--- a/deploy/helm/smg/templates/_helpers.tpl
+++ b/deploy/helm/smg/templates/_helpers.tpl
@@ -78,10 +78,25 @@ Called from the router Deployment template.
 - {{ .Values.router.port | quote }}
 - "--policy"
 - {{ .Values.router.policy | quote }}
+{{- if .Values.router.enableIgw }}
+- "--enable-igw"
+{{- end }}
 {{- if .Values.router.workerUrls }}
 - "--worker-urls"
 {{- range .Values.router.workerUrls }}
 - {{ . | quote }}
+{{- end }}
+{{- else if and .Values.workers (not .Values.router.serviceDiscovery.enabled) }}
+- "--worker-urls"
+{{- range $i, $worker := .Values.workers }}
+{{- $defaults := index $.Values.engineDefaults $worker.engine }}
+{{- $port := $worker.port | default $defaults.port }}
+{{- $mode := $worker.connectionMode | default "http" }}
+{{- $scheme := "http" }}
+{{- if eq $mode "grpc" }}
+{{- $scheme = "grpc" }}
+{{- end }}
+- "{{ $scheme }}://{{ include "smg.fullname" $ }}-worker-{{ $worker.name }}:{{ $port }}"
 {{- end }}
 {{- end }}
 {{- if .Values.router.serviceDiscovery.enabled }}
@@ -251,5 +266,100 @@ Called from the router Deployment template.
 {{- end }}
 {{- range .Values.router.extraArgs }}
 - {{ . | quote }}
+{{- end }}
+{{- end }}
+
+{{/*
+Worker image -- resolves the full image reference for a worker.
+Expects a dict with keys: worker, global, chart, defaults
+*/}}
+{{- define "smg.workerImage" -}}
+{{- $workerRegistry := "" -}}
+{{- $workerTag := "" -}}
+{{- if .worker.image -}}
+{{- $workerRegistry = .worker.image.registry | default "" -}}
+{{- $workerTag = .worker.image.tag | default "" -}}
+{{- end -}}
+{{/* Engine images default to ghcr.io (gateway image is on docker.io) */}}
+{{- $registry := $workerRegistry | default "ghcr.io" -}}
+{{- $repository := .global.image.repository -}}
+{{- $tag := $workerTag | default (.global.image.tag | default .chart.AppVersion) -}}
+{{- printf "%s/%s:%s" $registry $repository $tag -}}
+{{- end }}
+
+{{/*
+Worker command -- returns the command array based on engine + connectionMode.
+Expects a dict with keys: worker
+*/}}
+{{- define "smg.workerCommand" -}}
+{{- $engine := .worker.engine -}}
+{{- $mode := .worker.connectionMode | default "http" -}}
+{{- if eq $engine "vllm" -}}
+{{- if eq $mode "grpc" -}}
+["python3", "-m", "vllm.entrypoints.grpc_server"]
+{{- else -}}
+["python3", "-m", "vllm.entrypoints.openai.api_server"]
+{{- end -}}
+{{- else if eq $engine "sglang" -}}
+["python3", "-m", "sglang.launch_server"]
+{{- end -}}
+{{- end }}
+
+{{/*
+Worker args -- returns the args list based on engine.
+Expects a dict with keys: worker, defaults
+*/}}
+{{- define "smg.workerArgs" -}}
+{{- $worker := .worker -}}
+{{- $defaults := index .defaults $worker.engine -}}
+{{- $port := $worker.port | default $defaults.port -}}
+{{- $gpuCount := 1 -}}
+{{- if $worker.gpu -}}
+{{- $gpuCount = $worker.gpu.count | default 1 -}}
+{{- end -}}
+{{- $mode := $worker.connectionMode | default "http" }}
+{{- if eq $worker.engine "vllm" }}
+- "--model"
+- {{ $worker.model | quote }}
+- "--host"
+- "0.0.0.0"
+- "--port"
+- {{ $port | quote }}
+- "--tensor-parallel-size"
+- {{ $gpuCount | quote }}
+{{- else if eq $worker.engine "sglang" }}
+- "--model-path"
+- {{ $worker.model | quote }}
+- "--host"
+- "0.0.0.0"
+- "--port"
+- {{ $port | quote }}
+- "--tp-size"
+- {{ $gpuCount | quote }}
+{{- if eq $mode "grpc" }}
+- "--grpc-mode"
+{{- end }}
+{{- end }}
+{{- if $worker.extraArgs }}
+{{- range $worker.extraArgs }}
+- {{ . | quote }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Auto-generate --worker-urls from worker Services.
+Used by smg.routerArgs when workers are defined but workerUrls is empty.
+*/}}
+{{- define "smg.autoWorkerUrls" -}}
+{{- range $i, $worker := .Values.workers }}
+{{- $defaults := index $.Values.engineDefaults $worker.engine }}
+{{- $port := $worker.port | default $defaults.port }}
+{{- $mode := $worker.connectionMode | default "http" }}
+{{- $scheme := "http" }}
+{{- if eq $mode "grpc" }}
+{{- $scheme = "grpc" }}
+{{- end }}
+- "{{ $scheme }}://{{ include "smg.fullname" $ }}-worker-{{ $worker.name }}:{{ $port }}"
 {{- end }}
 {{- end }}

--- a/deploy/helm/smg/templates/deployment-router.yaml
+++ b/deploy/helm/smg/templates/deployment-router.yaml
@@ -64,10 +64,19 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.router.extraEnv }}
           env:
+            - name: HF_HOME
+              value: /tmp/hf-cache
+            {{- if .Values.huggingface.token }}
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "smg.fullname" . }}-hf-token
+                  key: token
+            {{- end }}
+            {{- with .Values.router.extraEnv }}
             {{- toYaml . | nindent 12 }}
-          {{- end }}
+            {{- end }}
           volumeMounts:
             - name: tmp
               mountPath: /tmp

--- a/deploy/helm/smg/templates/deployment-worker.yaml
+++ b/deploy/helm/smg/templates/deployment-worker.yaml
@@ -1,0 +1,118 @@
+{{- range $i, $worker := .Values.workers }}
+{{- $defaults := index $.Values.engineDefaults $worker.engine }}
+{{- $port := $worker.port | default $defaults.port }}
+{{- $gpuCount := 1 }}
+{{- $gpuType := "nvidia.com/gpu" }}
+{{- if $worker.gpu }}
+{{- $gpuCount = $worker.gpu.count | default 1 }}
+{{- $gpuType = $worker.gpu.type | default "nvidia.com/gpu" }}
+{{- end }}
+{{- $mode := $worker.connectionMode | default "http" }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "smg.fullname" $ }}-worker-{{ $worker.name }}
+  labels:
+    {{- include "smg.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: worker
+    smg.lightseek.org/engine: {{ $worker.engine }}
+    smg.lightseek.org/worker: {{ $worker.name }}
+spec:
+  replicas: {{ $worker.replicas | default 1 }}
+  selector:
+    matchLabels:
+      {{- include "smg.selectorLabels" $ | nindent 6 }}
+      app.kubernetes.io/component: worker
+      smg.lightseek.org/worker: {{ $worker.name }}
+  template:
+    metadata:
+      labels:
+        {{- include "smg.selectorLabels" $ | nindent 8 }}
+        app.kubernetes.io/component: worker
+        smg.lightseek.org/worker: {{ $worker.name }}
+        smg.lightseek.org/engine: {{ $worker.engine }}
+        {{- if $worker.workerType }}
+        smg.lightseek.org/worker-type: {{ $worker.workerType }}
+        {{- end }}
+    spec:
+      {{- with $.Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: worker
+          image: {{ include "smg.workerImage" (dict "worker" $worker "global" $.Values.global "chart" $.Chart "defaults" $.Values.engineDefaults) }}
+          imagePullPolicy: {{ $.Values.global.image.pullPolicy }}
+          command: {{- include "smg.workerCommand" (dict "worker" $worker) | trim | nindent 12 }}
+          args:
+            {{- include "smg.workerArgs" (dict "worker" $worker "defaults" $.Values.engineDefaults) | trim | nindent 12 }}
+          ports:
+            - name: serve
+              containerPort: {{ $port }}
+              protocol: TCP
+          {{- if $worker.resources }}
+          resources:
+            {{- $res := deepCopy $worker.resources }}
+            {{- if $res.limits }}
+            {{- $_ := set $res.limits $gpuType ($gpuCount | int) }}
+            {{- else }}
+            {{- $_ := set $res "limits" (dict $gpuType ($gpuCount | int)) }}
+            {{- end }}
+            {{- toYaml $res | nindent 12 }}
+          {{- else }}
+          resources:
+            limits:
+              {{ $gpuType }}: {{ $gpuCount }}
+          {{- end }}
+          {{- if or $.Values.huggingface.token $worker.extraEnv }}
+          env:
+            {{- if $.Values.huggingface.token }}
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "smg.fullname" $ }}-hf-token
+                  key: token
+            {{- end }}
+            {{- with $worker.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+          {{- if eq $mode "http" }}
+          startupProbe:
+            httpGet:
+              path: /health
+              port: serve
+            initialDelaySeconds: {{ ($worker.startupProbe).initialDelaySeconds | default 60 }}
+            periodSeconds: {{ ($worker.startupProbe).periodSeconds | default 10 }}
+            failureThreshold: {{ ($worker.startupProbe).failureThreshold | default 30 }}
+          {{- else }}
+          {{/* gRPC mode: use TCP socket probe since not all engines
+               implement the gRPC Health Checking Protocol yet */}}
+          startupProbe:
+            tcpSocket:
+              port: serve
+            initialDelaySeconds: {{ ($worker.startupProbe).initialDelaySeconds | default 60 }}
+            periodSeconds: {{ ($worker.startupProbe).periodSeconds | default 10 }}
+            failureThreshold: {{ ($worker.startupProbe).failureThreshold | default 30 }}
+          {{- end }}
+      {{- if or $worker.nodeSelector $worker.tolerations $worker.affinity (gt (int $gpuCount) 0) }}
+      {{- with $worker.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if $worker.tolerations }}
+      tolerations:
+        {{- toYaml $worker.tolerations | nindent 8 }}
+      {{- else if gt (int $gpuCount) 0 }}
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+      {{- end }}
+      {{- with $worker.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- end }}
+{{- end }}

--- a/deploy/helm/smg/templates/secret.yaml
+++ b/deploy/helm/smg/templates/secret.yaml
@@ -11,3 +11,15 @@ stringData:
   oracle-user: {{ .Values.history.oracle.user | quote }}
   oracle-password: {{ .Values.history.oracle.password | quote }}
 {{- end }}
+{{- if .Values.huggingface.token }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "smg.fullname" . }}-hf-token
+  labels:
+    {{- include "smg.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  token: {{ .Values.huggingface.token | quote }}
+{{- end }}

--- a/deploy/helm/smg/templates/service-worker.yaml
+++ b/deploy/helm/smg/templates/service-worker.yaml
@@ -1,0 +1,24 @@
+{{- range $i, $worker := .Values.workers }}
+{{- $defaults := index $.Values.engineDefaults $worker.engine }}
+{{- $port := $worker.port | default $defaults.port }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "smg.fullname" $ }}-worker-{{ $worker.name }}
+  labels:
+    {{- include "smg.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: worker
+    smg.lightseek.org/worker: {{ $worker.name }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ $port }}
+      targetPort: serve
+      protocol: TCP
+      name: serve
+  selector:
+    {{- include "smg.selectorLabels" $ | nindent 4 }}
+    app.kubernetes.io/component: worker
+    smg.lightseek.org/worker: {{ $worker.name }}
+{{- end }}

--- a/deploy/helm/smg/values.yaml
+++ b/deploy/helm/smg/values.yaml
@@ -20,6 +20,9 @@ router:
   # -- Routing policy: cache_aware, round_robin, power_of_two, manual, random, prefix_hash
   policy: cache_aware
 
+  # -- Enable IGW (Inference Gateway) mode for multi-model support
+  enableIgw: false
+
   # -- Explicit worker URLs
   workerUrls: []
   #   - http://worker-1:8000
@@ -179,6 +182,14 @@ router:
   toolCallParser: ""
 
 # =============================================================================
+# HuggingFace Configuration
+# =============================================================================
+huggingface:
+  # -- HuggingFace API token for downloading gated models (e.g., Llama).
+  #    Creates a Secret and injects HF_TOKEN into all worker pods.
+  token: ""
+
+# =============================================================================
 # Auth Configuration
 # =============================================================================
 auth:
@@ -234,6 +245,42 @@ grafana:
     enabled: false
     labels:
       grafana_dashboard: "1"
+
+# =============================================================================
+# Workers Configuration
+# =============================================================================
+# Each entry creates a Deployment + Service for one model/engine combo.
+# Workers are deployed as standalone engine processes (no SMG router).
+workers: []
+#   - name: llama-8b
+#     engine: vllm                      # vllm, sglang
+#     model: meta-llama/Llama-3.1-8B-Instruct
+#     replicas: 1
+#     workerType: regular               # regular (default), prefill, decode
+#     connectionMode: http              # http (default), grpc
+#     gpu:
+#       count: 1                        # GPUs per replica (tensor parallel size)
+#       type: nvidia.com/gpu            # resource name (default)
+#     image:
+#       tag: ""                         # engine-specific image tag (required)
+#     port: 8000                        # worker serving port
+#     resources: {}
+#     extraArgs: []                     # extra engine CLI args
+#     extraEnv: []
+#     nodeSelector: {}
+#     tolerations: []
+#     affinity: {}
+#     startupProbe:
+#       initialDelaySeconds: 60
+#       periodSeconds: 10
+#       failureThreshold: 30
+
+# Engine default ports (used when worker.port is not set)
+engineDefaults:
+  vllm:
+    port: 8000
+  sglang:
+    port: 30000
 
 # =============================================================================
 # Dependency Sub-Charts (overrides go here)


### PR DESCRIPTION
## Summary

Add inference engine worker deployment support to the SMG helm chart. A single `helm install` now deploys both the gateway and its workers.

## What Changed

### New files
- `templates/deployment-worker.yaml` — Creates a Deployment per worker with engine-specific command/args
- `templates/service-worker.yaml` — ClusterIP Service per worker
- `examples/with-vllm-http.yaml` — vLLM HTTP example
- `examples/with-vllm-grpc.yaml` — vLLM gRPC example
- `examples/with-sglang.yaml` — SGLang HTTP example
- `examples/with-multi-model.yaml` — Multi-model example

### Modified files
- `values.yaml` — Added `workers[]`, `huggingface.token`, `router.enableIgw`, `engineDefaults`
- `templates/_helpers.tpl` — Added `smg.workerImage`, `smg.workerCommand`, `smg.workerArgs`, `smg.autoWorkerUrls`, `enableIgw` conditional
- `templates/deployment-router.yaml` — Inject `HF_HOME=/tmp/hf-cache` and `HF_TOKEN` env vars
- `templates/secret.yaml` — HuggingFace token Secret
- `README.md` — Full documentation for workers, connection modes, examples

## Test Plan

Tested on K8s cluster (moirai-eu-frankfurt-1-dev) with real GPU nodes:

| Config | Result |
|--------|--------|
| vLLM HTTP (Llama-3.1-8B, 1 GPU) | Worker registered, requests served |
| vLLM gRPC (Llama-3.1-8B, 1 GPU) | Worker registered, connection_mode=grpc |
| SGLang HTTP (Llama-3.1-8B, 1 GPU) | Worker registered, runtime_type=sglang |
| SGLang gRPC | Image bug: grpcio version mismatch (separate fix) |

<details>
<summary>Checklist</summary>

- [x] Documentation updated (README.md, examples)
- [x] Tested on real K8s cluster with GPU
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for deploying inference engine workers (vLLM, SGLang) alongside the router for distributed model serving.
  * Enabled multi-model deployment with configurable routing policies.
  * Added HuggingFace token configuration for secure model access.
  * Implemented auto-generation of worker URLs with HTTP and gRPC connection modes.

* **Documentation**
  * Expanded deployment guide with Quick Start examples for various configurations.
  * Added troubleshooting section for worker registration and cache-related issues.
  * Provided new example configurations for multi-model, vLLM, and SGLang deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->