### PR TITLE
fix: grpc_servicer add check empty input and centralize tokenized validation

### DIFF
--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -247,7 +247,7 @@ jobs:
       - name: Run grpc_servicer unit tests
         run: |
           python3 -m pip install pytest
-          PYTHONPATH=grpc_servicer pytest -q grpc_servicer/tests/test_sglang_validation.py
+          PYTHONPATH=grpc_servicer pytest -q grpc_servicer/tests/
 
   unit-tests:
     runs-on: k8s-runner-cpu

--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -232,6 +232,24 @@ jobs:
           python3 -m pip install pytest pytest-cov pytest-xdist
           pytest -q tests --cov=smg --cov-config=.coveragerc --cov-report=term-missing --cov-fail-under=80
 
+  grpc-servicer-unit-tests:
+    runs-on: k8s-runner-cpu
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Run grpc_servicer unit tests
+        run: |
+          python3 -m pip install pytest
+          cd grpc_servicer
+          pytest -q tests/test_sglang_validation.py
+
   unit-tests:
     runs-on: k8s-runner-cpu
     permissions:

--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -888,7 +888,7 @@ jobs:
           path: benchmark_go_bindings/
 
   finish:
-    needs: [pre-commit, python-lint, grpc-proto-build-check, build-wheel, python-unit-tests, unit-tests, benchmarks, e2e-1gpu-chat, e2e-1gpu-embeddings, e2e-1gpu-gateway, e2e-2gpu-chat, e2e-2gpu-responses, e2e-2gpu-pd, e2e-4gpu-chat, e2e-4gpu-gateway, e2e-vendor, go-unit-tests, go-bindings-e2e]
+    needs: [pre-commit, python-lint, grpc-proto-build-check, build-wheel, python-unit-tests, grpc-servicer-unit-tests, unit-tests, benchmarks, e2e-1gpu-chat, e2e-1gpu-embeddings, e2e-1gpu-gateway, e2e-2gpu-chat, e2e-2gpu-responses, e2e-2gpu-pd, e2e-4gpu-chat, e2e-4gpu-gateway, e2e-vendor, go-unit-tests, go-bindings-e2e]
     if: always()
     runs-on: k8s-runner-cpu
     permissions: {}
@@ -900,6 +900,7 @@ jobs:
                 "${{ needs.grpc-proto-build-check.result }}" == "failure" || \
                 "${{ needs.build-wheel.result }}" == "failure" || \
                 "${{ needs.python-unit-tests.result }}" == "failure" || \
+                "${{ needs.grpc-servicer-unit-tests.result }}" == "failure" || \
                 "${{ needs.unit-tests.result }}" == "failure" || \
                 "${{ needs.benchmarks.result }}" == "failure" || \
                 "${{ needs.e2e-1gpu-chat.result }}" == "failure" || \

--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -247,8 +247,7 @@ jobs:
       - name: Run grpc_servicer unit tests
         run: |
           python3 -m pip install pytest
-          cd grpc_servicer
-          pytest -q tests/test_sglang_validation.py
+          PYTHONPATH=grpc_servicer pytest -q grpc_servicer/tests/test_sglang_validation.py
 
   unit-tests:
     runs-on: k8s-runner-cpu

--- a/grpc_servicer/smg_grpc_servicer/sglang/__init__.py
+++ b/grpc_servicer/smg_grpc_servicer/sglang/__init__.py
@@ -4,6 +4,7 @@ __all__ = ["SGLangSchedulerServicer"]
 
 
 def __getattr__(name: str):
+    """Lazily expose `SGLangSchedulerServicer` to avoid eager heavy imports."""
     if name == "SGLangSchedulerServicer":
         from smg_grpc_servicer.sglang.servicer import SGLangSchedulerServicer
 

--- a/grpc_servicer/smg_grpc_servicer/sglang/__init__.py
+++ b/grpc_servicer/smg_grpc_servicer/sglang/__init__.py
@@ -1,5 +1,11 @@
-"""SGLang gRPC servicer — implements SglangScheduler proto service."""
-
-from smg_grpc_servicer.sglang.servicer import SGLangSchedulerServicer
+"""SGLang gRPC servicer package."""
 
 __all__ = ["SGLangSchedulerServicer"]
+
+
+def __getattr__(name: str):
+    if name == "SGLangSchedulerServicer":
+        from smg_grpc_servicer.sglang.servicer import SGLangSchedulerServicer
+
+        return SGLangSchedulerServicer
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/grpc_servicer/smg_grpc_servicer/sglang/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/sglang/servicer.py
@@ -47,6 +47,7 @@ from smg_grpc_proto.generated import common_pb2
 from smg_grpc_servicer.sglang.health_servicer import SGLangHealthServicer
 from smg_grpc_servicer.sglang.request_manager import GrpcRequestManager
 from smg_grpc_servicer.sglang.utils import abort_code_from_output
+from smg_grpc_servicer.sglang.validation import validate_tokenized_input
 
 logger = logging.getLogger(__name__)
 HEALTH_CHECK_TIMEOUT = int(os.getenv("SGLANG_HEALTH_CHECK_TIMEOUT", 20))
@@ -699,12 +700,8 @@ class SGLangSchedulerServicer(sglang_scheduler_pb2_grpc.SglangSchedulerServicer)
     ) -> TokenizedGenerateReqInput:
         """Convert gRPC GenerateRequest to internal format."""
 
-        # Extract tokenized input
-        if not grpc_req.HasField("tokenized"):
-            raise ValueError("Tokenized input must be provided")
-
-        input_text = grpc_req.tokenized.original_text
-        input_ids = list(grpc_req.tokenized.input_ids)
+        # Extract and validate tokenized input
+        input_text, input_ids = validate_tokenized_input(grpc_req, "generate")
 
         # Convert sampling params
         sampling_params = self._convert_sampling_params(grpc_req.sampling_params)
@@ -805,12 +802,8 @@ class SGLangSchedulerServicer(sglang_scheduler_pb2_grpc.SglangSchedulerServicer)
     ) -> TokenizedEmbeddingReqInput:
         """Convert gRPC EmbedRequest to internal format."""
 
-        # Extract tokenized input
-        if not grpc_req.HasField("tokenized"):
-            raise ValueError("Tokenized input must be provided")
-
-        input_text = grpc_req.tokenized.original_text
-        input_ids = list(grpc_req.tokenized.input_ids)
+        # Extract and validate tokenized input
+        input_text, input_ids = validate_tokenized_input(grpc_req, "embed")
 
         # Convert sampling params
         sampling_params = self._convert_sampling_params(grpc_req.sampling_params)

--- a/grpc_servicer/smg_grpc_servicer/sglang/validation.py
+++ b/grpc_servicer/smg_grpc_servicer/sglang/validation.py
@@ -1,0 +1,16 @@
+"""Validation helpers for SGLang gRPC request payloads."""
+
+from typing import Any
+
+
+def validate_tokenized_input(grpc_req: Any, request_kind: str) -> tuple[str, list[int]]:
+    """Validate tokenized field and return (original_text, input_ids)."""
+    if not grpc_req.HasField("tokenized"):
+        raise ValueError("Tokenized input must be provided")
+
+    input_text = grpc_req.tokenized.original_text
+    input_ids = list(grpc_req.tokenized.input_ids)
+    if not input_ids:
+        raise ValueError(f"input_ids cannot be empty for {request_kind} requests")
+
+    return input_text, input_ids

--- a/grpc_servicer/tests/test_sglang_validation.py
+++ b/grpc_servicer/tests/test_sglang_validation.py
@@ -1,0 +1,52 @@
+"""
+Unit tests for SGLang request validation helpers.
+
+These tests focus on validating tokenized request input in isolation.
+"""
+
+import pytest
+
+from smg_grpc_servicer.sglang.validation import validate_tokenized_input
+
+
+class _Tokenized:
+    def __init__(self, original_text: str, input_ids: list[int]):
+        self.original_text = original_text
+        self.input_ids = input_ids
+
+
+class _GrpcReqStub:
+    def __init__(self, tokenized: _Tokenized | None):
+        self.tokenized = tokenized
+
+    def HasField(self, field_name: str) -> bool:  # noqa: N802
+        return field_name == "tokenized" and self.tokenized is not None
+
+
+class TestSGLangValidation:
+    """Test tokenized input validation behavior."""
+
+    def test_validate_tokenized_input_rejects_missing_tokenized(self):
+        """Reject requests without tokenized payload."""
+        req = _GrpcReqStub(tokenized=None)
+        with pytest.raises(ValueError, match="Tokenized input must be provided"):
+            validate_tokenized_input(req, "generate")
+
+    def test_validate_tokenized_input_rejects_empty_generate(self):
+        """Reject generate requests with empty input_ids."""
+        req = _GrpcReqStub(tokenized=_Tokenized("hello", []))
+        with pytest.raises(ValueError, match="input_ids cannot be empty for generate requests"):
+            validate_tokenized_input(req, "generate")
+
+    def test_validate_tokenized_input_rejects_empty_embed(self):
+        """Reject embed requests with empty input_ids."""
+        req = _GrpcReqStub(tokenized=_Tokenized("hello", []))
+        with pytest.raises(ValueError, match="input_ids cannot be empty for embed requests"):
+            validate_tokenized_input(req, "embed")
+
+    def test_validate_tokenized_input_returns_text_and_ids(self):
+        """Return original text and ids for valid tokenized payload."""
+        req = _GrpcReqStub(tokenized=_Tokenized("hello", [1, 2]))
+        input_text, input_ids = validate_tokenized_input(req, "embed")
+        assert input_text == "hello"
+        assert input_ids == [1, 2]

--- a/grpc_servicer/tests/test_sglang_validation.py
+++ b/grpc_servicer/tests/test_sglang_validation.py
@@ -49,3 +49,10 @@ class TestSGLangValidation:
         input_text, input_ids = validate_tokenized_input(req, "embed")
         assert input_text == "hello"
         assert input_ids == [1, 2]
+
+    def test_validate_tokenized_input_returns_text_and_ids_generate(self):
+        """Return original text and ids for valid generate tokenized payload."""
+        req = _GrpcReqStub(tokenized=_Tokenized("world", [3, 4, 5]))
+        input_text, input_ids = validate_tokenized_input(req, "generate")
+        assert input_text == "world"
+        assert input_ids == [3, 4, 5]

--- a/grpc_servicer/tests/test_sglang_validation.py
+++ b/grpc_servicer/tests/test_sglang_validation.py
@@ -5,7 +5,6 @@ These tests focus on validating tokenized request input in isolation.
 """
 
 import pytest
-
 from smg_grpc_servicer.sglang.validation import validate_tokenized_input
 
 

--- a/grpc_servicer/tests/test_sglang_validation.py
+++ b/grpc_servicer/tests/test_sglang_validation.py
@@ -10,15 +10,18 @@ from smg_grpc_servicer.sglang.validation import validate_tokenized_input
 
 class _Tokenized:
     def __init__(self, original_text: str, input_ids: list[int]):
+        """Store tokenized payload fields used by validation tests."""
         self.original_text = original_text
         self.input_ids = input_ids
 
 
 class _GrpcReqStub:
     def __init__(self, tokenized: _Tokenized | None):
+        """Mimic a protobuf request object with an optional `tokenized` field."""
         self.tokenized = tokenized
 
     def HasField(self, field_name: str) -> bool:  # noqa: N802
+        """Match protobuf HasField behavior for the `tokenized` presence check."""
         return field_name == "tokenized" and self.tokenized is not None
 
 


### PR DESCRIPTION
## Summary
- extract SGLang tokenized request validation into a lightweight module: `smg_grpc_servicer/sglang/validation.py`
- update SGLang servicer request conversion paths to reuse `validate_tokenized_input` for both Generate and Embed requests
- add unit tests for tokenized validation behavior in `grpc_servicer/tests/test_sglang_validation.py`
- wire this test into PR CI by adding `grpc-servicer-unit-tests` in `.github/workflows/pr-test-rust.yml`

## What Changed
- validation now consistently enforces:
  - `tokenized` field must be present
  - `input_ids` must be non-empty (request-kind-specific error)
- duplicated inline validation logic in `servicer.py` is removed

## Test Plan
- local checks:
  - `python3 -m py_compile grpc_servicer/smg_grpc_servicer/sglang/servicer.py`
  - `python3 -m py_compile grpc_servicer/smg_grpc_servicer/sglang/validation.py`
  - `python3 -m py_compile grpc_servicer/tests/test_sglang_validation.py`
- CI:
  - `grpc-servicer-unit-tests` runs `pytest -q grpc_servicer/tests/test_sglang_validation.py`

## Notes
- this keeps validation directly importable for unit tests without importing heavy `servicer.py` runtime dependencies


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests for tokenized-input validation.
  * CI now runs these tests on PRs and fails the pipeline if they fail.

* **Chores**
  * Centralized and tightened tokenized input validation and error messages.

* **Refactor**
  * Deferred loading of a service class to improve import/startup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->