### PR TITLE
feat(model_gateway): support custom tool in OpenAI responses API

### DIFF
--- a/crates/data_connector/src/core.rs
+++ b/crates/data_connector/src/core.rs
@@ -723,6 +723,21 @@ mod tests {
     }
 
     #[test]
+    fn make_item_id_custom_tool_call_prefix() {
+        let id = make_item_id("custom_tool_call");
+        assert!(
+            id.0.starts_with("ctc_"),
+            "custom_tool_call type should produce 'ctc_' prefix, got: {id}"
+        );
+        assert_eq!(
+            id.0.len(),
+            54, // "ctc_" (4) + 50 hex
+            "custom_tool_call ID should be 54 chars, got {} chars: {id}",
+            id.0.len()
+        );
+    }
+
+    #[test]
     fn make_item_id_unknown_type_uses_first_3_chars() {
         let id = make_item_id("custom_type");
         assert!(
@@ -749,6 +764,7 @@ mod tests {
             ("mcp_call", "mcp_"),
             ("mcp_list_tools", "mcpl_"),
             ("function_call", "fc_"),
+            ("custom_tool_call", "ctc_"),
         ];
 
         for (item_type, prefix) in test_cases {

--- a/crates/data_connector/src/core.rs
+++ b/crates/data_connector/src/core.rs
@@ -293,6 +293,7 @@ pub fn make_item_id(item_type: &str) -> ConversationItemId {
         "mcp_call" => "mcp",
         "mcp_list_tools" => "mcpl",
         "function_call" => "fc",
+        "custom_tool_call" => "ctc",
         other => {
             // Fallback: first 3 letters of type or "itm"
             let fallback: String = other.chars().take(3).collect();

--- a/crates/protocols/src/event_types.rs
+++ b/crates/protocols/src/event_types.rs
@@ -642,3 +642,94 @@ pub fn is_function_call_type(item_type: &str) -> bool {
 pub fn is_custom_tool_call_type(item_type: &str) -> bool {
     item_type == ItemType::CUSTOM_TOOL_CALL
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ========================================================================
+    // CustomToolCallEvent tests
+    // ========================================================================
+
+    #[test]
+    fn custom_tool_call_event_input_delta_str() {
+        assert_eq!(
+            CustomToolCallEvent::InputDelta.as_str(),
+            "response.custom_tool_call_input.delta"
+        );
+    }
+
+    #[test]
+    fn custom_tool_call_event_input_done_str() {
+        assert_eq!(
+            CustomToolCallEvent::InputDone.as_str(),
+            "response.custom_tool_call_input.done"
+        );
+    }
+
+    #[test]
+    fn custom_tool_call_event_display() {
+        assert_eq!(
+            CustomToolCallEvent::InputDelta.to_string(),
+            "response.custom_tool_call_input.delta"
+        );
+        assert_eq!(
+            CustomToolCallEvent::InputDone.to_string(),
+            "response.custom_tool_call_input.done"
+        );
+    }
+
+    // ========================================================================
+    // ItemType tests for CustomToolCall
+    // ========================================================================
+
+    #[test]
+    fn item_type_custom_tool_call_str() {
+        assert_eq!(ItemType::CustomToolCall.as_str(), "custom_tool_call");
+    }
+
+    #[test]
+    fn item_type_custom_tool_call_constants() {
+        assert_eq!(ItemType::CUSTOM_TOOL_CALL, "custom_tool_call");
+        assert_eq!(ItemType::CUSTOM_TOOL_CALL_OUTPUT, "custom_tool_call_output");
+    }
+
+    #[test]
+    fn item_type_custom_tool_call_is_custom() {
+        assert!(ItemType::CustomToolCall.is_custom_tool_call());
+        assert!(!ItemType::FunctionCall.is_custom_tool_call());
+        assert!(!ItemType::McpCall.is_custom_tool_call());
+    }
+
+    #[test]
+    fn item_type_custom_tool_call_not_function_call() {
+        assert!(!ItemType::CustomToolCall.is_function_call());
+    }
+
+    #[test]
+    fn item_type_custom_tool_call_not_builtin() {
+        assert!(!ItemType::CustomToolCall.is_builtin_tool_call());
+    }
+
+    // ========================================================================
+    // Helper function tests
+    // ========================================================================
+
+    #[test]
+    fn is_custom_tool_call_type_matches() {
+        assert!(is_custom_tool_call_type("custom_tool_call"));
+    }
+
+    #[test]
+    fn is_custom_tool_call_type_rejects_others() {
+        assert!(!is_custom_tool_call_type("function_call"));
+        assert!(!is_custom_tool_call_type("mcp_call"));
+        assert!(!is_custom_tool_call_type("custom_tool_call_output"));
+        assert!(!is_custom_tool_call_type(""));
+    }
+
+    #[test]
+    fn is_function_call_type_rejects_custom() {
+        assert!(!is_function_call_type("custom_tool_call"));
+    }
+}

--- a/crates/protocols/src/event_types.rs
+++ b/crates/protocols/src/event_types.rs
@@ -263,11 +263,37 @@ impl fmt::Display for FileSearchCallEvent {
     }
 }
 
+/// Custom tool call input streaming events
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CustomToolCallEvent {
+    InputDelta,
+    InputDone,
+}
+
+impl CustomToolCallEvent {
+    pub const INPUT_DELTA: &'static str = "response.custom_tool_call_input.delta";
+    pub const INPUT_DONE: &'static str = "response.custom_tool_call_input.done";
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::InputDelta => Self::INPUT_DELTA,
+            Self::InputDone => Self::INPUT_DONE,
+        }
+    }
+}
+
+impl fmt::Display for CustomToolCallEvent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 /// Item type discriminators used in output items
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ItemType {
     FunctionCall,
     FunctionToolCall,
+    CustomToolCall,
     McpCall,
     Function,
     McpListTools,
@@ -280,6 +306,8 @@ impl ItemType {
     pub const FUNCTION_CALL: &'static str = "function_call";
     pub const FUNCTION_CALL_OUTPUT: &'static str = "function_call_output";
     pub const FUNCTION_TOOL_CALL: &'static str = "function_tool_call";
+    pub const CUSTOM_TOOL_CALL: &'static str = "custom_tool_call";
+    pub const CUSTOM_TOOL_CALL_OUTPUT: &'static str = "custom_tool_call_output";
     pub const MCP_CALL: &'static str = "mcp_call";
     pub const FUNCTION: &'static str = "function";
     pub const MCP_LIST_TOOLS: &'static str = "mcp_list_tools";
@@ -291,6 +319,7 @@ impl ItemType {
         match self {
             Self::FunctionCall => Self::FUNCTION_CALL,
             Self::FunctionToolCall => Self::FUNCTION_TOOL_CALL,
+            Self::CustomToolCall => Self::CUSTOM_TOOL_CALL,
             Self::McpCall => Self::MCP_CALL,
             Self::Function => Self::FUNCTION,
             Self::McpListTools => Self::MCP_LIST_TOOLS,
@@ -303,6 +332,11 @@ impl ItemType {
     /// Check if this is a function call variant (FunctionCall or FunctionToolCall)
     pub const fn is_function_call(self) -> bool {
         matches!(self, Self::FunctionCall | Self::FunctionToolCall)
+    }
+
+    /// Check if this is a custom tool call variant
+    pub const fn is_custom_tool_call(self) -> bool {
+        matches!(self, Self::CustomToolCall)
     }
 
     /// Check if this is a builtin tool call variant
@@ -602,4 +636,9 @@ pub fn is_response_event(event_type: &str) -> bool {
 /// Check if an item type string is a function call variant
 pub fn is_function_call_type(item_type: &str) -> bool {
     item_type == ItemType::FUNCTION_CALL || item_type == ItemType::FUNCTION_TOOL_CALL
+}
+
+/// Check if an item type string is a custom tool call variant
+pub fn is_custom_tool_call_type(item_type: &str) -> bool {
+    item_type == ItemType::CUSTOM_TOOL_CALL
 }

--- a/crates/protocols/src/responses.rs
+++ b/crates/protocols/src/responses.rs
@@ -963,9 +963,7 @@ impl GenerationRequest for ResponsesRequest {
                     ResponseInputOutputItem::FunctionCallOutput { output, .. } => {
                         Some(output.clone())
                     }
-                    ResponseInputOutputItem::CustomToolCall { input, .. } => {
-                        Some(input.clone())
-                    }
+                    ResponseInputOutputItem::CustomToolCall { input, .. } => Some(input.clone()),
                     ResponseInputOutputItem::CustomToolCallOutput { output, .. } => {
                         Some(output.clone())
                     }
@@ -1240,9 +1238,8 @@ fn validate_response_tools(tools: &[ResponseTool]) -> Result<(), ValidationError
         if let ResponseTool::Custom(custom) = tool {
             if custom.name.is_empty() {
                 let mut e = ValidationError::new("missing_required_parameter");
-                e.message = Some(
-                    format!("Missing required parameter: 'tools[{idx}].name'.").into(),
-                );
+                e.message =
+                    Some(format!("Missing required parameter: 'tools[{idx}].name'.").into());
                 return Err(e);
             }
         }

--- a/crates/protocols/src/responses.rs
+++ b/crates/protocols/src/responses.rs
@@ -39,6 +39,10 @@ pub enum ResponseTool {
     /// MCP server tool.
     #[serde(rename = "mcp")]
     Mcp(McpTool),
+
+    /// Custom tool (arbitrary text input with optional grammar constraints).
+    #[serde(rename = "custom")]
+    Custom(CustomTool),
 }
 
 #[serde_with::skip_serializing_none]
@@ -78,6 +82,25 @@ pub struct WebSearchPreviewTool {
 #[serde(deny_unknown_fields)]
 pub struct CodeInterpreterTool {
     pub container: Option<Value>,
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct CustomTool {
+    pub name: String,
+    pub description: Option<String>,
+    pub format: Option<CustomToolFormat>,
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct CustomToolFormat {
+    #[serde(rename = "type")]
+    pub format_type: String,
+    pub syntax: String,
+    pub definition: String,
 }
 
 /// `require_approval` values.
@@ -178,6 +201,25 @@ pub enum ResponseInputOutputItem {
         #[serde(skip_serializing_if = "Option::is_none")]
         status: Option<String>,
     },
+    #[serde(rename = "custom_tool_call")]
+    CustomToolCall {
+        id: String,
+        call_id: String,
+        name: String,
+        input: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        output: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        status: Option<String>,
+    },
+    #[serde(rename = "custom_tool_call_output")]
+    CustomToolCallOutput {
+        id: Option<String>,
+        call_id: String,
+        output: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        status: Option<String>,
+    },
     #[serde(rename = "mcp_approval_request")]
     McpApprovalRequest {
         id: String,
@@ -266,6 +308,15 @@ pub enum ResponseOutputItem {
         call_id: String,
         name: String,
         arguments: String,
+        output: Option<String>,
+        status: String,
+    },
+    #[serde(rename = "custom_tool_call")]
+    CustomToolCall {
+        id: String,
+        call_id: String,
+        name: String,
+        input: String,
         output: Option<String>,
         status: String,
     },
@@ -912,6 +963,12 @@ impl GenerationRequest for ResponsesRequest {
                     ResponseInputOutputItem::FunctionCallOutput { output, .. } => {
                         Some(output.clone())
                     }
+                    ResponseInputOutputItem::CustomToolCall { input, .. } => {
+                        Some(input.clone())
+                    }
+                    ResponseInputOutputItem::CustomToolCallOutput { output, .. } => {
+                        Some(output.clone())
+                    }
                     ResponseInputOutputItem::McpApprovalRequest { .. } => None,
                     ResponseInputOutputItem::McpApprovalResponse { .. } => None,
                 })
@@ -976,6 +1033,7 @@ fn validate_tool_choice_with_tools(request: &ResponsesRequest) -> Result<(), Val
         .iter()
         .filter_map(|t| match t {
             ResponseTool::Function(ft) => Some(ft.function.name.as_str()),
+            ResponseTool::Custom(ct) => Some(ct.name.as_str()),
             _ => None,
         })
         .collect();
@@ -1159,6 +1217,14 @@ fn validate_input_item(item: &ResponseInputOutputItem) -> Result<(), ValidationE
             }
         }
         ResponseInputOutputItem::FunctionToolCall { .. } => {}
+        ResponseInputOutputItem::CustomToolCall { .. } => {}
+        ResponseInputOutputItem::CustomToolCallOutput { output, .. } => {
+            if output.is_empty() {
+                let mut e = ValidationError::new("custom_tool_output_empty");
+                e.message = Some("Custom tool call output cannot be empty".into());
+                return Err(e);
+            }
+        }
         ResponseInputOutputItem::McpApprovalRequest { .. } => {}
         ResponseInputOutputItem::McpApprovalResponse { .. } => {}
     }
@@ -1171,6 +1237,15 @@ fn validate_response_tools(tools: &[ResponseTool]) -> Result<(), ValidationError
     let mut seen_mcp_labels: HashSet<String> = HashSet::new();
 
     for (idx, tool) in tools.iter().enumerate() {
+        if let ResponseTool::Custom(custom) = tool {
+            if custom.name.is_empty() {
+                let mut e = ValidationError::new("missing_required_parameter");
+                e.message = Some(
+                    format!("Missing required parameter: 'tools[{idx}].name'.").into(),
+                );
+                return Err(e);
+            }
+        }
         if let ResponseTool::Mcp(mcp) = tool {
             let raw_label = mcp.server_label.as_str();
             if raw_label.is_empty() {

--- a/model_gateway/src/routers/grpc/common/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/common/responses/streaming.rs
@@ -7,8 +7,9 @@ use openai_protocol::{
     chat::ChatCompletionStreamResponse,
     common::{Usage, UsageInfo},
     event_types::{
-        CodeInterpreterCallEvent, ContentPartEvent, FileSearchCallEvent, FunctionCallEvent,
-        McpEvent, OutputItemEvent, OutputTextEvent, ResponseEvent, WebSearchCallEvent,
+        CodeInterpreterCallEvent, ContentPartEvent, CustomToolCallEvent, FileSearchCallEvent,
+        FunctionCallEvent, McpEvent, OutputItemEvent, OutputTextEvent, ResponseEvent,
+        WebSearchCallEvent,
     },
     responses::{
         ResponseOutputItem, ResponseStatus, ResponsesRequest, ResponsesResponse, ResponsesUsage,
@@ -28,6 +29,7 @@ pub(crate) enum OutputItemType {
     McpListTools,
     McpCall,
     FunctionCall,
+    CustomToolCall,
     Reasoning,
     WebSearchCall,
     CodeInterpreterCall,
@@ -573,6 +575,40 @@ impl ResponseStreamEventEmitter {
     }
 
     // ========================================================================
+    // Custom Tool Call Event Emission Methods
+    // ========================================================================
+
+    pub fn emit_custom_tool_call_input_delta(
+        &mut self,
+        output_index: usize,
+        item_id: &str,
+        delta: &str,
+    ) -> serde_json::Value {
+        json!({
+            "type": CustomToolCallEvent::INPUT_DELTA,
+            "sequence_number": self.next_sequence(),
+            "output_index": output_index,
+            "item_id": item_id,
+            "delta": delta
+        })
+    }
+
+    pub fn emit_custom_tool_call_input_done(
+        &mut self,
+        output_index: usize,
+        item_id: &str,
+        input: &str,
+    ) -> serde_json::Value {
+        json!({
+            "type": CustomToolCallEvent::INPUT_DONE,
+            "sequence_number": self.next_sequence(),
+            "output_index": output_index,
+            "item_id": item_id,
+            "input": input
+        })
+    }
+
+    // ========================================================================
     // Output Item Wrapper Events
     // ========================================================================
 
@@ -621,6 +657,7 @@ impl ResponseStreamEventEmitter {
             OutputItemType::McpListTools => "mcpl",
             OutputItemType::McpCall => "mcp",
             OutputItemType::FunctionCall => "fc",
+            OutputItemType::CustomToolCall => "ctc",
             OutputItemType::Message => "msg",
             OutputItemType::Reasoning => "rs",
             OutputItemType::WebSearchCall => "ws",

--- a/model_gateway/src/routers/grpc/common/responses/utils.rs
+++ b/model_gateway/src/routers/grpc/common/responses/utils.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use axum::response::Response;
 use openai_protocol::{
-    common::Tool,
+    common::{Function, Tool},
     responses::{ResponseTool, ResponsesRequest, ResponsesResponse},
 };
 use serde_json::to_value;
@@ -124,6 +124,15 @@ pub(crate) fn extract_tools_from_response_tools(
             ResponseTool::Function(ft) => Some(Tool {
                 tool_type: "function".to_string(),
                 function: ft.function.clone(),
+            }),
+            ResponseTool::Custom(ct) => Some(Tool {
+                tool_type: "function".to_string(),
+                function: Function {
+                    name: ct.name.clone(),
+                    description: ct.description.clone(),
+                    parameters: serde_json::json!({}),
+                    strict: None,
+                },
             }),
             _ => None,
         })

--- a/model_gateway/src/routers/grpc/harmony/builder.rs
+++ b/model_gateway/src/routers/grpc/harmony/builder.rs
@@ -722,9 +722,7 @@ impl HarmonyBuilder {
                         } if item_call_id == call_id => Some(name.clone()),
                         _ => None,
                     })
-                    .ok_or_else(|| {
-                        format!("No custom tool call found for call_id: {call_id}")
-                    })?;
+                    .ok_or_else(|| format!("No custom tool call found for call_id: {call_id}"))?;
 
                 Ok(HarmonyMessage {
                     author: Author {

--- a/model_gateway/src/routers/grpc/harmony/builder.rs
+++ b/model_gateway/src/routers/grpc/harmony/builder.rs
@@ -107,7 +107,7 @@ impl ToolLike for ResponseTool {
     }
 
     fn is_custom(&self) -> bool {
-        matches!(self, ResponseTool::Function(_))
+        matches!(self, ResponseTool::Function(_) | ResponseTool::Custom(_))
     }
 
     fn to_tool_description(&self) -> Option<ToolDescription> {
@@ -116,6 +116,11 @@ impl ToolLike for ResponseTool {
                 ft.function.name.clone(),
                 ft.function.description.clone().unwrap_or_default(),
                 Some(ft.function.parameters.clone()),
+            )),
+            ResponseTool::Custom(ct) => Some(ToolDescription::new(
+                ct.name.clone(),
+                ct.description.clone().unwrap_or_default(),
+                None,
             )),
             _ => None,
         }
@@ -423,6 +428,7 @@ impl HarmonyBuilder {
                         .iter()
                         .map(|tool| match tool {
                             ResponseTool::Function(_) => "function",
+                            ResponseTool::Custom(_) => "custom",
                             ResponseTool::WebSearchPreview(_) => "web_search_preview",
                             ResponseTool::CodeInterpreter(_) => "code_interpreter",
                             ResponseTool::Mcp(_) => "mcp",
@@ -477,8 +483,12 @@ impl HarmonyBuilder {
                     let msg = self.parse_response_item_to_harmony_message(item, &prev_outputs)?;
                     all_messages.push(msg);
 
-                    // Track function tool calls so that function_call_output can find the name
-                    if matches!(item, ResponseInputOutputItem::FunctionToolCall { .. }) {
+                    // Track function/custom tool calls so that output items can find the name
+                    if matches!(
+                        item,
+                        ResponseInputOutputItem::FunctionToolCall { .. }
+                            | ResponseInputOutputItem::CustomToolCall { .. }
+                    ) {
                         prev_outputs.push(item);
                     }
                 }
@@ -645,6 +655,77 @@ impl HarmonyBuilder {
                 // Create Tool message with "functions.{name}" prefix
                 // IMPORTANT: Must include recipient="assistant" for parser to recognize it.
                 // We keep channel=None to minimize what the model might copy.
+                Ok(HarmonyMessage {
+                    author: Author {
+                        role: Role::Tool,
+                        name: Some(format!("functions.{call}")),
+                    },
+                    recipient: Some("assistant".to_string()),
+                    content: vec![Content::Text(TextContent {
+                        text: output.clone(),
+                    })],
+                    channel: None,
+                    content_type: None,
+                })
+            }
+
+            // Custom tool call (with optional output) - treated like function tool call
+            ResponseInputOutputItem::CustomToolCall {
+                name,
+                input,
+                output,
+                ..
+            } => {
+                if let Some(output_str) = output {
+                    let author_name = format!("functions.{name}");
+                    Ok(HarmonyMessage {
+                        author: Author {
+                            role: Role::Tool,
+                            name: Some(author_name),
+                        },
+                        recipient: Some("assistant".to_string()),
+                        content: vec![Content::Text(TextContent {
+                            text: output_str.clone(),
+                        })],
+                        channel: None,
+                        content_type: None,
+                    })
+                } else {
+                    let recipient = format!("functions.{name}");
+                    Ok(HarmonyMessage {
+                        author: Author {
+                            role: Role::Assistant,
+                            name: None,
+                        },
+                        recipient: Some(recipient),
+                        content: vec![Content::Text(TextContent {
+                            text: input.clone(),
+                        })],
+                        channel: Some("commentary".to_string()),
+                        content_type: None,
+                    })
+                }
+            }
+
+            // Custom tool call output (separate from call)
+            ResponseInputOutputItem::CustomToolCallOutput {
+                call_id, output, ..
+            } => {
+                let call = prev_outputs
+                    .iter()
+                    .rev()
+                    .find_map(|item| match item {
+                        ResponseInputOutputItem::CustomToolCall {
+                            call_id: item_call_id,
+                            name,
+                            ..
+                        } if item_call_id == call_id => Some(name.clone()),
+                        _ => None,
+                    })
+                    .ok_or_else(|| {
+                        format!("No custom tool call found for call_id: {call_id}")
+                    })?;
+
                 Ok(HarmonyMessage {
                     author: Author {
                         role: Role::Tool,

--- a/model_gateway/src/routers/grpc/harmony/responses/non_streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/non_streaming.rs
@@ -10,7 +10,7 @@ use openai_protocol::{
     common::{ToolCall, Usage},
     responses::{
         InputTokensDetails, OutputTokensDetails, ResponseContentPart, ResponseOutputItem,
-        ResponseReasoningContent, ResponseStatus, ResponseUsage, ResponsesRequest,
+        ResponseReasoningContent, ResponseStatus, ResponseTool, ResponseUsage, ResponsesRequest,
         ResponsesResponse, ResponsesUsage,
     },
 };
@@ -430,18 +430,45 @@ fn build_tool_response(
         });
     }
 
-    // Add function tool calls WITHOUT output (need caller execution)
+    // Collect custom tool names from the original request
+    let custom_tool_names: std::collections::HashSet<&str> = responses_request
+        .tools
+        .as_ref()
+        .map(|tools| {
+            tools
+                .iter()
+                .filter_map(|t| match t {
+                    ResponseTool::Custom(ct) => Some(ct.name.as_str()),
+                    _ => None,
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    // Add function/custom tool calls WITHOUT output (need caller execution)
     for tool_call in function_tool_calls {
         let call_id = tool_call.id.clone();
-        let arguments = tool_call.function.arguments.unwrap_or_default();
-        output.push(ResponseOutputItem::FunctionToolCall {
-            id: tool_call.id,
-            call_id,
-            name: tool_call.function.name,
-            arguments,
-            output: None, // No output = needs execution
-            status: "completed".to_string(),
-        });
+        let input_or_args = tool_call.function.arguments.unwrap_or_default();
+
+        if custom_tool_names.contains(tool_call.function.name.as_str()) {
+            output.push(ResponseOutputItem::CustomToolCall {
+                id: tool_call.id,
+                call_id,
+                name: tool_call.function.name,
+                input: input_or_args,
+                output: None,
+                status: "completed".to_string(),
+            });
+        } else {
+            output.push(ResponseOutputItem::FunctionToolCall {
+                id: tool_call.id,
+                call_id,
+                name: tool_call.function.name,
+                arguments: input_or_args,
+                output: None,
+                status: "completed".to_string(),
+            });
+        }
     }
 
     // Build ResponsesResponse with Completed status

--- a/model_gateway/src/routers/grpc/regular/responses/conversions.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/conversions.rs
@@ -14,7 +14,7 @@ use openai_protocol::{
     },
     responses::{
         ResponseContentPart, ResponseInput, ResponseInputOutputItem, ResponseOutputItem,
-        ResponseReasoningContent::ReasoningText, ResponseStatus, ResponsesRequest,
+        ResponseReasoningContent::ReasoningText, ResponseStatus, ResponseTool, ResponsesRequest,
         ResponsesResponse, ResponsesUsage, StringOrContentParts, TextConfig, TextFormat,
     },
     UNKNOWN_MODEL_ID,
@@ -131,6 +131,43 @@ pub(crate) fn responses_to_chat(req: &ResponsesRequest) -> Result<ChatCompletion
                             name: None,
                             tool_calls: None,
                             reasoning_content: Some(reasoning_text),
+                        });
+                    }
+                    ResponseInputOutputItem::CustomToolCall {
+                        id,
+                        name,
+                        input,
+                        output,
+                        ..
+                    } => {
+                        // Custom tool call from history - convert to function tool call format
+                        messages.push(ChatMessage::Assistant {
+                            content: None,
+                            name: None,
+                            tool_calls: Some(vec![ToolCall {
+                                id: id.clone(),
+                                tool_type: "function".to_string(),
+                                function: FunctionCallResponse {
+                                    name: name.clone(),
+                                    arguments: Some(input.clone()),
+                                },
+                            }]),
+                            reasoning_content: None,
+                        });
+
+                        if let Some(output_text) = output {
+                            messages.push(ChatMessage::Tool {
+                                content: MessageContent::Text(output_text.clone()),
+                                tool_call_id: id.clone(),
+                            });
+                        }
+                    }
+                    ResponseInputOutputItem::CustomToolCallOutput {
+                        call_id, output, ..
+                    } => {
+                        messages.push(ChatMessage::Tool {
+                            content: MessageContent::Text(output.clone()),
+                            tool_call_id: call_id.clone(),
                         });
                     }
                     ResponseInputOutputItem::FunctionCallOutput {
@@ -322,15 +359,43 @@ pub(crate) fn chat_to_responses(
 
     // Convert tool calls if present
     if let Some(tool_calls) = &choice.message.tool_calls {
+        // Collect custom tool names from the original request
+        let custom_tool_names: std::collections::HashSet<&str> = original_req
+            .tools
+            .as_ref()
+            .map(|tools| {
+                tools
+                    .iter()
+                    .filter_map(|t| match t {
+                        ResponseTool::Custom(ct) => Some(ct.name.as_str()),
+                        _ => None,
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
         for tool_call in tool_calls {
-            output.push(ResponseOutputItem::FunctionToolCall {
-                id: tool_call.id.clone(),
-                call_id: tool_call.id.clone(),
-                name: tool_call.function.name.clone(),
-                arguments: tool_call.function.arguments.clone().unwrap_or_default(),
-                output: None, // Tool hasn't been executed yet
-                status: "in_progress".to_string(),
-            });
+            let input_or_args = tool_call.function.arguments.clone().unwrap_or_default();
+
+            if custom_tool_names.contains(tool_call.function.name.as_str()) {
+                output.push(ResponseOutputItem::CustomToolCall {
+                    id: tool_call.id.clone(),
+                    call_id: tool_call.id.clone(),
+                    name: tool_call.function.name.clone(),
+                    input: input_or_args,
+                    output: None,
+                    status: "in_progress".to_string(),
+                });
+            } else {
+                output.push(ResponseOutputItem::FunctionToolCall {
+                    id: tool_call.id.clone(),
+                    call_id: tool_call.id.clone(),
+                    name: tool_call.function.name.clone(),
+                    arguments: input_or_args,
+                    output: None,
+                    status: "in_progress".to_string(),
+                });
+            }
         }
     }
 

--- a/model_gateway/src/routers/grpc/regular/responses/conversions.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/conversions.rs
@@ -495,4 +495,149 @@ mod tests {
         let result = responses_to_chat(&req);
         assert!(result.is_ok());
     }
+
+    #[test]
+    fn test_custom_tool_extracted_as_function_tool() {
+        use openai_protocol::responses::CustomTool;
+
+        let req = ResponsesRequest {
+            input: ResponseInput::Text("test".to_string()),
+            tools: Some(vec![ResponseTool::Custom(CustomTool {
+                name: "code_exec".to_string(),
+                description: Some("Executes code".to_string()),
+                format: None,
+            })]),
+            ..Default::default()
+        };
+
+        let chat_req = responses_to_chat(&req).unwrap();
+        // Custom tools should be converted to function tools for the backend
+        assert!(chat_req.tools.is_some());
+        let tools = chat_req.tools.unwrap();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].function.name, "code_exec");
+        assert_eq!(tools[0].tool_type, "function");
+    }
+
+    #[test]
+    fn test_custom_tool_call_input_item_conversion() {
+        let req = ResponsesRequest {
+            input: ResponseInput::Items(vec![
+                ResponseInputOutputItem::Message {
+                    id: "msg_1".to_string(),
+                    role: "user".to_string(),
+                    content: vec![ResponseContentPart::InputText {
+                        text: "Use code_exec".to_string(),
+                    }],
+                    status: None,
+                },
+                ResponseInputOutputItem::CustomToolCall {
+                    id: "ctc_1".to_string(),
+                    call_id: "ctc_1".to_string(),
+                    name: "code_exec".to_string(),
+                    input: "print('hello')".to_string(),
+                    output: Some("hello".to_string()),
+                    status: Some("completed".to_string()),
+                },
+            ]),
+            ..Default::default()
+        };
+
+        let chat_req = responses_to_chat(&req).unwrap();
+        // Should produce: user message + assistant tool_call + tool result = 3 messages
+        assert_eq!(chat_req.messages.len(), 3);
+    }
+
+    #[test]
+    fn test_custom_tool_call_output_item_conversion() {
+        let req = ResponsesRequest {
+            input: ResponseInput::Items(vec![
+                ResponseInputOutputItem::Message {
+                    id: "msg_1".to_string(),
+                    role: "user".to_string(),
+                    content: vec![ResponseContentPart::InputText {
+                        text: "test".to_string(),
+                    }],
+                    status: None,
+                },
+                ResponseInputOutputItem::CustomToolCall {
+                    id: "ctc_1".to_string(),
+                    call_id: "ctc_1".to_string(),
+                    name: "code_exec".to_string(),
+                    input: "print('hi')".to_string(),
+                    output: None,
+                    status: Some("completed".to_string()),
+                },
+                ResponseInputOutputItem::CustomToolCallOutput {
+                    id: Some("ctc_2".to_string()),
+                    call_id: "ctc_1".to_string(),
+                    output: "hi".to_string(),
+                    status: Some("completed".to_string()),
+                },
+            ]),
+            ..Default::default()
+        };
+
+        let chat_req = responses_to_chat(&req).unwrap();
+        // user message + assistant tool_call + tool result = 3 messages
+        assert_eq!(chat_req.messages.len(), 3);
+    }
+
+    #[test]
+    fn test_chat_to_responses_custom_tool_call() {
+        use openai_protocol::chat::ChatCompletionMessage;
+        use openai_protocol::responses::CustomTool;
+
+        let original_req = ResponsesRequest {
+            input: ResponseInput::Text("test".to_string()),
+            model: "test-model".to_string(),
+            tools: Some(vec![ResponseTool::Custom(CustomTool {
+                name: "code_exec".to_string(),
+                description: None,
+                format: None,
+            })]),
+            ..Default::default()
+        };
+
+        let chat_resp = ChatCompletionResponse {
+            id: "resp_1".to_string(),
+            object: "chat.completion".to_string(),
+            created: 1234567890,
+            model: "test-model".to_string(),
+            choices: vec![openai_protocol::chat::ChatChoice {
+                index: 0,
+                message: ChatCompletionMessage {
+                    role: "assistant".to_string(),
+                    content: None,
+                    tool_calls: Some(vec![ToolCall {
+                        id: "call_1".to_string(),
+                        tool_type: "function".to_string(),
+                        function: FunctionCallResponse {
+                            name: "code_exec".to_string(),
+                            arguments: Some("print('hello')".to_string()),
+                        },
+                    }]),
+                    reasoning_content: None,
+                },
+                finish_reason: Some("tool_calls".to_string()),
+                logprobs: None,
+                matched_stop: None,
+                hidden_states: None,
+            }],
+            usage: None,
+            system_fingerprint: None,
+        };
+
+        let resp = chat_to_responses(&chat_resp, &original_req, None).unwrap();
+        // Should contain a CustomToolCall output item (not FunctionToolCall)
+        let has_custom = resp.output.iter().any(|item| {
+            matches!(item, ResponseOutputItem::CustomToolCall { name, input, .. }
+                if name == "code_exec" && input == "print('hello')")
+        });
+        assert!(
+            has_custom,
+            "Response should contain CustomToolCall output item, got: {:?}",
+            resp.output
+        );
+    }
 }

--- a/model_gateway/src/routers/grpc/regular/responses/conversions.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/conversions.rs
@@ -585,8 +585,7 @@ mod tests {
 
     #[test]
     fn test_chat_to_responses_custom_tool_call() {
-        use openai_protocol::chat::ChatCompletionMessage;
-        use openai_protocol::responses::CustomTool;
+        use openai_protocol::{chat::ChatCompletionMessage, responses::CustomTool};
 
         let original_req = ResponsesRequest {
             input: ResponseInput::Text("test".to_string()),

--- a/model_gateway/src/routers/grpc/regular/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/streaming.rs
@@ -26,7 +26,7 @@ use openai_protocol::{
     common::{FunctionCallResponse, ToolCall, Usage, UsageInfo},
     responses::{
         ResponseContentPart, ResponseOutputItem, ResponseReasoningContent, ResponseStatus,
-        ResponsesRequest, ResponsesResponse, ResponsesUsage,
+        ResponseTool, ResponsesRequest, ResponsesResponse, ResponsesUsage,
     },
 };
 use serde_json::{json, Value};
@@ -379,8 +379,44 @@ impl StreamingResponseAccumulator {
             });
         }
 
-        // Add tool calls
-        output.extend(self.tool_calls);
+        // Add tool calls (convert custom tools from FunctionToolCall to CustomToolCall)
+        let custom_tool_names: std::collections::HashSet<&str> = self
+            .original_request
+            .tools
+            .as_ref()
+            .map(|tools| {
+                tools
+                    .iter()
+                    .filter_map(|t| match t {
+                        ResponseTool::Custom(ct) => Some(ct.name.as_str()),
+                        _ => None,
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        for tc in self.tool_calls {
+            match tc {
+                ResponseOutputItem::FunctionToolCall {
+                    id,
+                    call_id,
+                    name,
+                    arguments,
+                    output: tc_output,
+                    status,
+                } if custom_tool_names.contains(name.as_str()) => {
+                    output.push(ResponseOutputItem::CustomToolCall {
+                        id,
+                        call_id,
+                        name,
+                        input: arguments,
+                        output: tc_output,
+                        status,
+                    });
+                }
+                other => output.push(other),
+            }
+        }
 
         // Determine final status
         let status = match self.finish_reason.as_deref() {
@@ -813,50 +849,93 @@ async fn execute_tool_loop_streaming_internal(
                     function_tool_calls.len()
                 );
 
-                // Emit function_tool_call events for each function tool
-                for tool_call in function_tool_calls {
-                    // Allocate output_index for this function_tool_call item
-                    let (output_index, item_id) =
-                        emitter.allocate_output_index(OutputItemType::FunctionCall);
+                // Collect custom tool names from the original request
+                let custom_tool_names: std::collections::HashSet<&str> = original_request
+                    .tools
+                    .as_ref()
+                    .map(|tools| {
+                        tools
+                            .iter()
+                            .filter_map(|t| match t {
+                                ResponseTool::Custom(ct) => Some(ct.name.as_str()),
+                                _ => None,
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default();
 
-                    // Build initial function_call item
+                // Emit function/custom tool call events for each tool
+                for tool_call in function_tool_calls {
+                    let is_custom = custom_tool_names.contains(tool_call.name.as_str());
+
+                    // Allocate output_index with appropriate type
+                    let item_type = if is_custom {
+                        OutputItemType::CustomToolCall
+                    } else {
+                        OutputItemType::FunctionCall
+                    };
+                    let (output_index, item_id) = emitter.allocate_output_index(item_type);
+
+                    let type_str = if is_custom {
+                        "custom_tool_call"
+                    } else {
+                        "function_call"
+                    };
+                    let data_field = if is_custom { "input" } else { "arguments" };
+
+                    // Build initial item
                     let item = json!({
                         "id": item_id,
-                        "type": "function_call",
+                        "type": type_str,
                         "call_id": tool_call.call_id,
                         "name": tool_call.name,
                         "status": "in_progress",
-                        "arguments": ""
+                        data_field: ""
                     });
 
                     // Emit output_item.added
                     let event = emitter.emit_output_item_added(output_index, &item);
                     emitter.send_event(&event, &tx)?;
 
-                    // Emit function_call_arguments.delta
-                    let event = emitter.emit_function_call_arguments_delta(
-                        output_index,
-                        &item_id,
-                        &tool_call.arguments,
-                    );
-                    emitter.send_event(&event, &tx)?;
+                    // Emit arguments/input delta and done
+                    if is_custom {
+                        let event = emitter.emit_custom_tool_call_input_delta(
+                            output_index,
+                            &item_id,
+                            &tool_call.arguments,
+                        );
+                        emitter.send_event(&event, &tx)?;
 
-                    // Emit function_call_arguments.done
-                    let event = emitter.emit_function_call_arguments_done(
-                        output_index,
-                        &item_id,
-                        &tool_call.arguments,
-                    );
-                    emitter.send_event(&event, &tx)?;
+                        let event = emitter.emit_custom_tool_call_input_done(
+                            output_index,
+                            &item_id,
+                            &tool_call.arguments,
+                        );
+                        emitter.send_event(&event, &tx)?;
+                    } else {
+                        let event = emitter.emit_function_call_arguments_delta(
+                            output_index,
+                            &item_id,
+                            &tool_call.arguments,
+                        );
+                        emitter.send_event(&event, &tx)?;
+
+                        let event = emitter.emit_function_call_arguments_done(
+                            output_index,
+                            &item_id,
+                            &tool_call.arguments,
+                        );
+                        emitter.send_event(&event, &tx)?;
+                    }
 
                     // Build complete item
                     let item_complete = json!({
                         "id": item_id,
-                        "type": "function_call",
+                        "type": type_str,
                         "call_id": tool_call.call_id,
                         "name": tool_call.name,
                         "status": "completed",
-                        "arguments": tool_call.arguments
+                        data_field: tool_call.arguments
                     });
 
                     // Emit output_item.done

--- a/model_gateway/src/routers/openai/responses/history.rs
+++ b/model_gateway/src/routers/openai/responses/history.rs
@@ -180,6 +180,18 @@ pub(crate) async fn load_input_history(
                                 }
                             }
                         }
+                        ItemType::CUSTOM_TOOL_CALL | ItemType::CUSTOM_TOOL_CALL_OUTPUT => {
+                            match serde_json::from_value::<ResponseInputOutputItem>(item.content) {
+                                Ok(custom_call) => items.push(custom_call),
+                                Err(e) => {
+                                    tracing::error!(
+                                        "Failed to deserialize {}: {}",
+                                        item.item_type,
+                                        e
+                                    );
+                                }
+                            }
+                        }
                         "reasoning" => {}
                         _ => {
                             warn!("Unknown item type in conversation: {}", item.item_type);

--- a/model_gateway/src/routers/openai/responses/streaming.rs
+++ b/model_gateway/src/routers/openai/responses/streaming.rs
@@ -18,9 +18,9 @@ use bytes::Bytes;
 use futures_util::StreamExt;
 use openai_protocol::{
     event_types::{
-        is_function_call_type, is_response_event, CodeInterpreterCallEvent,
-        CustomToolCallEvent, FileSearchCallEvent, FunctionCallEvent, ItemType, McpEvent,
-        OutputItemEvent, ResponseEvent, WebSearchCallEvent,
+        is_function_call_type, is_response_event, CodeInterpreterCallEvent, CustomToolCallEvent,
+        FileSearchCallEvent, FunctionCallEvent, ItemType, McpEvent, OutputItemEvent, ResponseEvent,
+        WebSearchCallEvent,
     },
     responses::{ResponseTool, ResponsesRequest},
 };
@@ -151,7 +151,9 @@ pub(super) fn apply_event_transformations_inplace(
                             item["type"] = json!(ItemType::CUSTOM_TOOL_CALL);
 
                             // Rename arguments → input
-                            if let Some(args) = item.as_object_mut().and_then(|o| o.remove("arguments")) {
+                            if let Some(args) =
+                                item.as_object_mut().and_then(|o| o.remove("arguments"))
+                            {
                                 item["input"] = args;
                             }
 
@@ -201,19 +203,21 @@ pub(super) fn apply_event_transformations_inplace(
                 .get("name")
                 .and_then(|v| v.as_str())
                 .is_some_and(|name| {
-                    ctx.original_request
-                        .tools
-                        .as_ref()
-                        .is_some_and(|tools| {
-                            tools.iter().any(|t| matches!(t, ResponseTool::Custom(ct) if ct.name == name))
-                        })
+                    ctx.original_request.tools.as_ref().is_some_and(|tools| {
+                        tools
+                            .iter()
+                            .any(|t| matches!(t, ResponseTool::Custom(ct) if ct.name == name))
+                    })
                 });
 
             if is_custom {
                 parsed_data["type"] = json!(CustomToolCallEvent::INPUT_DONE);
 
                 // Rename arguments → input
-                if let Some(args) = parsed_data.as_object_mut().and_then(|o| o.remove("arguments")) {
+                if let Some(args) = parsed_data
+                    .as_object_mut()
+                    .and_then(|o| o.remove("arguments"))
+                {
                     parsed_data["input"] = args;
                 }
 

--- a/model_gateway/src/routers/openai/responses/streaming.rs
+++ b/model_gateway/src/routers/openai/responses/streaming.rs
@@ -18,8 +18,9 @@ use bytes::Bytes;
 use futures_util::StreamExt;
 use openai_protocol::{
     event_types::{
-        is_function_call_type, is_response_event, CodeInterpreterCallEvent, FileSearchCallEvent,
-        FunctionCallEvent, ItemType, McpEvent, OutputItemEvent, ResponseEvent, WebSearchCallEvent,
+        is_function_call_type, is_response_event, CodeInterpreterCallEvent,
+        CustomToolCallEvent, FileSearchCallEvent, FunctionCallEvent, ItemType, McpEvent,
+        OutputItemEvent, ResponseEvent, WebSearchCallEvent,
     },
     responses::{ResponseTool, ResponsesRequest},
 };
@@ -136,10 +137,36 @@ pub(super) fn apply_event_transformations_inplace(
                             .unwrap_or("")
                             .to_string();
 
-                        // Only transform if this is an MCP tool; keep function_call unchanged
-                        if let Some(session) =
+                        // Check if this is a custom tool from the original request
+                        let is_custom_tool = ctx
+                            .original_request
+                            .tools
+                            .as_ref()
+                            .is_some_and(|tools| {
+                                tools.iter().any(|t| matches!(t, ResponseTool::Custom(ct) if ct.name == tool_name))
+                            });
+
+                        if is_custom_tool {
+                            // Transform function_call → custom_tool_call
+                            item["type"] = json!(ItemType::CUSTOM_TOOL_CALL);
+
+                            // Rename arguments → input
+                            if let Some(args) = item.as_object_mut().and_then(|o| o.remove("arguments")) {
+                                item["input"] = args;
+                            }
+
+                            // Transform ID from fc_* to ctc_*
+                            if let Some(id) = item.get("id").and_then(|v| v.as_str()) {
+                                if let Some(stripped) = id.strip_prefix("fc_") {
+                                    item["id"] = json!(format!("ctc_{stripped}"));
+                                }
+                            }
+
+                            changed = true;
+                        } else if let Some(session) =
                             ctx.session.filter(|s| s.has_exposed_tool(&tool_name))
                         {
+                            // Only transform if this is an MCP tool; keep function_call unchanged
                             let response_format = session.tool_response_format(&tool_name);
 
                             // Determine item type and ID prefix based on response_format
@@ -169,13 +196,42 @@ pub(super) fn apply_event_transformations_inplace(
             }
         }
         FunctionCallEvent::ARGUMENTS_DONE => {
-            parsed_data["type"] = json!(McpEvent::CALL_ARGUMENTS_DONE);
+            // Check if this belongs to a custom tool by looking up the tool name
+            let is_custom = parsed_data
+                .get("name")
+                .and_then(|v| v.as_str())
+                .is_some_and(|name| {
+                    ctx.original_request
+                        .tools
+                        .as_ref()
+                        .is_some_and(|tools| {
+                            tools.iter().any(|t| matches!(t, ResponseTool::Custom(ct) if ct.name == name))
+                        })
+                });
 
-            // Transform item_id from fc_* to mcp_*
-            if let Some(item_id) = parsed_data.get("item_id").and_then(|v| v.as_str()) {
-                if let Some(stripped) = item_id.strip_prefix("fc_") {
-                    let new_id = format!("mcp_{stripped}");
-                    parsed_data["item_id"] = json!(new_id);
+            if is_custom {
+                parsed_data["type"] = json!(CustomToolCallEvent::INPUT_DONE);
+
+                // Rename arguments → input
+                if let Some(args) = parsed_data.as_object_mut().and_then(|o| o.remove("arguments")) {
+                    parsed_data["input"] = args;
+                }
+
+                // Transform item_id from fc_* to ctc_*
+                if let Some(item_id) = parsed_data.get("item_id").and_then(|v| v.as_str()) {
+                    if let Some(stripped) = item_id.strip_prefix("fc_") {
+                        parsed_data["item_id"] = json!(format!("ctc_{stripped}"));
+                    }
+                }
+            } else {
+                parsed_data["type"] = json!(McpEvent::CALL_ARGUMENTS_DONE);
+
+                // Transform item_id from fc_* to mcp_*
+                if let Some(item_id) = parsed_data.get("item_id").and_then(|v| v.as_str()) {
+                    if let Some(stripped) = item_id.strip_prefix("fc_") {
+                        let new_id = format!("mcp_{stripped}");
+                        parsed_data["item_id"] = json!(new_id);
+                    }
                 }
             }
 

--- a/model_gateway/src/routers/openai/responses/utils.rs
+++ b/model_gateway/src/routers/openai/responses/utils.rs
@@ -231,6 +231,7 @@ pub(super) fn response_tool_to_value(tool: &ResponseTool) -> Option<Value> {
         ResponseTool::WebSearchPreview(_) => serde_json::to_value(tool).ok(),
         ResponseTool::CodeInterpreter(_) => serde_json::to_value(tool).ok(),
         ResponseTool::Function(_) => None,
+        ResponseTool::Custom(_) => None,
     }
 }
 

--- a/model_gateway/src/routers/persistence_utils.rs
+++ b/model_gateway/src/routers/persistence_utils.rs
@@ -34,6 +34,8 @@ pub const ITEM_TYPE_FIELDS: &[(&str, &[&str])] = &[
     ("mcp_list_tools", &["tools", "server_label"]),
     ("function_call", &["call_id", "name", "arguments", "output"]),
     ("function_call_output", &["call_id", "output"]),
+    ("custom_tool_call", &["call_id", "name", "input", "output"]),
+    ("custom_tool_call_output", &["call_id", "output"]),
 ];
 
 // ============================================================================
@@ -222,6 +224,7 @@ fn extract_input_items(input: &ResponseInput) -> Result<Vec<Value>, String> {
                                         obj.get("type").and_then(|v| v.as_str()).unwrap_or("item");
                                     let prefix = match item_type {
                                         "function_call" | "function_call_output" => "fc",
+                                        "custom_tool_call" | "custom_tool_call_output" => "ctc",
                                         "message" => "msg",
                                         _ => "item",
                                     };
@@ -256,7 +259,10 @@ fn item_to_new_conversation_item(
 
     // Determine if we should store the whole item or just the content field
     let store_whole_item = if is_input {
-        item_type == "function_call" || item_type == "function_call_output"
+        item_type == "function_call"
+            || item_type == "function_call_output"
+            || item_type == "custom_tool_call"
+            || item_type == "custom_tool_call_output"
     } else {
         item_type != "message"
     };

--- a/model_gateway/tests/spec/responses.rs
+++ b/model_gateway/tests/spec/responses.rs
@@ -2,8 +2,8 @@ use openai_protocol::{
     common::{Function, StringOrArray, ToolChoice, ToolChoiceValue},
     responses::{
         CustomTool, CustomToolFormat, FunctionTool, IncludeField, McpTool, ResponseInput,
-        ResponseInputOutputItem, ResponseOutputItem, ResponseTool,
-        ResponsesRequest, StringOrContentParts, TextConfig, TextFormat,
+        ResponseInputOutputItem, ResponseOutputItem, ResponseTool, ResponsesRequest,
+        StringOrContentParts, TextConfig, TextFormat,
     },
 };
 use serde_json::json;
@@ -1522,14 +1522,12 @@ fn test_validate_mixed_custom_and_function_tools() {
 #[test]
 fn test_validate_custom_tool_call_output_empty() {
     let request = ResponsesRequest {
-        input: ResponseInput::Items(vec![
-            ResponseInputOutputItem::CustomToolCallOutput {
-                id: Some("ctc_123".to_string()),
-                call_id: "call_1".to_string(),
-                output: String::new(),
-                status: None,
-            },
-        ]),
+        input: ResponseInput::Items(vec![ResponseInputOutputItem::CustomToolCallOutput {
+            id: Some("ctc_123".to_string()),
+            call_id: "call_1".to_string(),
+            output: String::new(),
+            status: None,
+        }]),
         ..Default::default()
     };
     let result = request.validate();

--- a/model_gateway/tests/spec/responses.rs
+++ b/model_gateway/tests/spec/responses.rs
@@ -1,7 +1,8 @@
 use openai_protocol::{
     common::{Function, StringOrArray, ToolChoice, ToolChoiceValue},
     responses::{
-        FunctionTool, IncludeField, McpTool, ResponseInput, ResponseInputOutputItem, ResponseTool,
+        CustomTool, CustomToolFormat, FunctionTool, IncludeField, McpTool, ResponseInput,
+        ResponseInputOutputItem, ResponseOutputItem, ResponseTool,
         ResponsesRequest, StringOrContentParts, TextConfig, TextFormat,
     },
 };
@@ -1223,4 +1224,366 @@ fn test_normalize_store_no_override() {
         Some(false),
         "store should not be overridden if already set to false"
     );
+}
+
+// ============================================================================
+// Custom Tool Tests
+// ============================================================================
+
+/// Test that a valid custom tool passes validation
+#[test]
+fn test_validate_custom_tool_valid() {
+    let request = ResponsesRequest {
+        input: ResponseInput::Text("test".to_string()),
+        tools: Some(vec![ResponseTool::Custom(CustomTool {
+            name: "code_exec".to_string(),
+            description: Some("Executes arbitrary Python code.".to_string()),
+            format: None,
+        })]),
+        ..Default::default()
+    };
+    assert!(
+        request.validate().is_ok(),
+        "Valid custom tool should be accepted"
+    );
+}
+
+/// Test that a custom tool with grammar format passes validation
+#[test]
+fn test_validate_custom_tool_with_grammar() {
+    let request = ResponsesRequest {
+        input: ResponseInput::Text("test".to_string()),
+        tools: Some(vec![ResponseTool::Custom(CustomTool {
+            name: "math_exp".to_string(),
+            description: Some("Creates valid mathematical expressions".to_string()),
+            format: Some(CustomToolFormat {
+                format_type: "grammar".to_string(),
+                syntax: "lark".to_string(),
+                definition: "start: expr\nexpr: INT\n%import common.INT".to_string(),
+            }),
+        })]),
+        ..Default::default()
+    };
+    assert!(
+        request.validate().is_ok(),
+        "Custom tool with grammar format should be accepted"
+    );
+}
+
+/// Test that a custom tool with empty name fails validation
+#[test]
+fn test_validate_custom_tool_empty_name() {
+    let request = ResponsesRequest {
+        input: ResponseInput::Text("test".to_string()),
+        tools: Some(vec![ResponseTool::Custom(CustomTool {
+            name: String::new(),
+            description: None,
+            format: None,
+        })]),
+        ..Default::default()
+    };
+    let result = request.validate();
+    assert!(
+        result.is_err(),
+        "Custom tool with empty name should be invalid"
+    );
+}
+
+/// Test that custom tool serialization produces correct JSON
+#[test]
+fn test_custom_tool_serialization() {
+    let tool = ResponseTool::Custom(CustomTool {
+        name: "code_exec".to_string(),
+        description: Some("Executes Python code.".to_string()),
+        format: None,
+    });
+    let json_val = serde_json::to_value(&tool).unwrap();
+    assert_eq!(json_val["type"], "custom");
+    assert_eq!(json_val["name"], "code_exec");
+    assert_eq!(json_val["description"], "Executes Python code.");
+}
+
+/// Test that custom tool deserialization works from JSON
+#[test]
+fn test_custom_tool_deserialization() {
+    let v = json!({
+        "type": "custom",
+        "name": "code_exec",
+        "description": "Executes arbitrary Python code."
+    });
+    let tool: ResponseTool = serde_json::from_value(v).unwrap();
+    assert!(
+        matches!(tool, ResponseTool::Custom(ref ct) if ct.name == "code_exec"),
+        "Should deserialize as Custom tool"
+    );
+}
+
+/// Test that custom tool with grammar deserializes correctly
+#[test]
+fn test_custom_tool_grammar_deserialization() {
+    let v = json!({
+        "type": "custom",
+        "name": "math_exp",
+        "description": "Creates valid mathematical expressions",
+        "format": {
+            "type": "grammar",
+            "syntax": "lark",
+            "definition": "start: INT\n%import common.INT"
+        }
+    });
+    let tool: ResponseTool = serde_json::from_value(v).unwrap();
+    match tool {
+        ResponseTool::Custom(ct) => {
+            assert_eq!(ct.name, "math_exp");
+            let fmt = ct.format.unwrap();
+            assert_eq!(fmt.format_type, "grammar");
+            assert_eq!(fmt.syntax, "lark");
+        }
+        _ => panic!("Expected Custom tool"),
+    }
+}
+
+/// Test that custom tool with regex grammar deserializes correctly
+#[test]
+fn test_custom_tool_regex_grammar_deserialization() {
+    let v = json!({
+        "type": "custom",
+        "name": "timestamp",
+        "description": "Saves a timestamp",
+        "format": {
+            "type": "grammar",
+            "syntax": "regex",
+            "definition": r"^(?P<month>January|February)\s+(?P<day>\d{1,2})$"
+        }
+    });
+    let tool: ResponseTool = serde_json::from_value(v).unwrap();
+    match tool {
+        ResponseTool::Custom(ct) => {
+            let fmt = ct.format.unwrap();
+            assert_eq!(fmt.syntax, "regex");
+        }
+        _ => panic!("Expected Custom tool"),
+    }
+}
+
+/// Test CustomToolCall output item serialization
+#[test]
+fn test_custom_tool_call_output_item_serialization() {
+    let item = ResponseOutputItem::CustomToolCall {
+        id: "ctc_abc123".to_string(),
+        call_id: "call_xyz".to_string(),
+        name: "code_exec".to_string(),
+        input: "print(\"hello world\")".to_string(),
+        output: None,
+        status: "completed".to_string(),
+    };
+    let json_val = serde_json::to_value(&item).unwrap();
+    assert_eq!(json_val["type"], "custom_tool_call");
+    assert_eq!(json_val["id"], "ctc_abc123");
+    assert_eq!(json_val["input"], "print(\"hello world\")");
+    assert_eq!(json_val["name"], "code_exec");
+    // Should NOT have "arguments" field
+    assert!(json_val.get("arguments").is_none());
+}
+
+/// Test CustomToolCall input item serialization
+#[test]
+fn test_custom_tool_call_input_item_serialization() {
+    let item = ResponseInputOutputItem::CustomToolCall {
+        id: "ctc_abc123".to_string(),
+        call_id: "call_xyz".to_string(),
+        name: "code_exec".to_string(),
+        input: "print(\"hello\")".to_string(),
+        output: Some("hello".to_string()),
+        status: Some("completed".to_string()),
+    };
+    let json_val = serde_json::to_value(&item).unwrap();
+    assert_eq!(json_val["type"], "custom_tool_call");
+    assert_eq!(json_val["input"], "print(\"hello\")");
+    assert_eq!(json_val["output"], "hello");
+}
+
+/// Test CustomToolCallOutput input item serialization
+#[test]
+fn test_custom_tool_call_output_input_item_serialization() {
+    let item = ResponseInputOutputItem::CustomToolCallOutput {
+        id: Some("ctc_abc123".to_string()),
+        call_id: "call_xyz".to_string(),
+        output: "result text".to_string(),
+        status: Some("completed".to_string()),
+    };
+    let json_val = serde_json::to_value(&item).unwrap();
+    assert_eq!(json_val["type"], "custom_tool_call_output");
+    assert_eq!(json_val["output"], "result text");
+}
+
+/// Test CustomToolCall deserialization from JSON
+#[test]
+fn test_custom_tool_call_deserialization() {
+    let v = json!({
+        "type": "custom_tool_call",
+        "id": "ctc_abc123",
+        "call_id": "call_xyz",
+        "name": "code_exec",
+        "input": "4 + 4",
+        "status": "completed"
+    });
+    let item: ResponseOutputItem = serde_json::from_value(v).unwrap();
+    match item {
+        ResponseOutputItem::CustomToolCall {
+            id, name, input, ..
+        } => {
+            assert_eq!(id, "ctc_abc123");
+            assert_eq!(name, "code_exec");
+            assert_eq!(input, "4 + 4");
+        }
+        _ => panic!("Expected CustomToolCall"),
+    }
+}
+
+/// Test tool_choice validation includes custom tools
+#[test]
+fn test_validate_tool_choice_with_custom_tool() {
+    let request = ResponsesRequest {
+        input: ResponseInput::Text("test".to_string()),
+        tools: Some(vec![ResponseTool::Custom(CustomTool {
+            name: "code_exec".to_string(),
+            description: None,
+            format: None,
+        })]),
+        tool_choice: Some(ToolChoice::Function {
+            tool_type: "function".to_string(),
+            function: openai_protocol::common::FunctionChoice {
+                name: "code_exec".to_string(),
+            },
+        }),
+        ..Default::default()
+    };
+    assert!(
+        request.validate().is_ok(),
+        "tool_choice referencing a custom tool by name should be valid"
+    );
+}
+
+/// Test tool_choice fails for non-existent custom tool
+#[test]
+fn test_validate_tool_choice_custom_tool_not_found() {
+    let request = ResponsesRequest {
+        input: ResponseInput::Text("test".to_string()),
+        tools: Some(vec![ResponseTool::Custom(CustomTool {
+            name: "code_exec".to_string(),
+            description: None,
+            format: None,
+        })]),
+        tool_choice: Some(ToolChoice::Function {
+            tool_type: "function".to_string(),
+            function: openai_protocol::common::FunctionChoice {
+                name: "nonexistent".to_string(),
+            },
+        }),
+        ..Default::default()
+    };
+    let result = request.validate();
+    assert!(
+        result.is_err(),
+        "tool_choice referencing non-existent tool should be invalid"
+    );
+}
+
+/// Test custom tool alongside function tool
+#[test]
+fn test_validate_mixed_custom_and_function_tools() {
+    let request = ResponsesRequest {
+        input: ResponseInput::Text("test".to_string()),
+        tools: Some(vec![
+            ResponseTool::Function(FunctionTool {
+                function: Function {
+                    name: "get_weather".to_string(),
+                    description: None,
+                    parameters: json!({}),
+                    strict: None,
+                },
+            }),
+            ResponseTool::Custom(CustomTool {
+                name: "code_exec".to_string(),
+                description: Some("Executes code.".to_string()),
+                format: None,
+            }),
+        ]),
+        ..Default::default()
+    };
+    assert!(
+        request.validate().is_ok(),
+        "Mixed function and custom tools should be valid"
+    );
+}
+
+/// Test custom tool input item validation - empty output rejected
+#[test]
+fn test_validate_custom_tool_call_output_empty() {
+    let request = ResponsesRequest {
+        input: ResponseInput::Items(vec![
+            ResponseInputOutputItem::CustomToolCallOutput {
+                id: Some("ctc_123".to_string()),
+                call_id: "call_1".to_string(),
+                output: String::new(),
+                status: None,
+            },
+        ]),
+        ..Default::default()
+    };
+    let result = request.validate();
+    assert!(
+        result.is_err(),
+        "CustomToolCallOutput with empty output should be invalid"
+    );
+}
+
+/// Test normalization sets tool_choice=auto for custom tools
+#[test]
+fn test_normalize_tool_choice_with_custom_tool() {
+    use openai_protocol::validated::Normalizable;
+
+    let mut request = ResponsesRequest {
+        input: ResponseInput::Text("test".to_string()),
+        tools: Some(vec![ResponseTool::Custom(CustomTool {
+            name: "code_exec".to_string(),
+            description: None,
+            format: None,
+        })]),
+        tool_choice: None,
+        ..Default::default()
+    };
+
+    request.normalize();
+
+    assert!(
+        matches!(
+            request.tool_choice,
+            Some(ToolChoice::Value(ToolChoiceValue::Auto))
+        ),
+        "tool_choice should default to auto when custom tools are present"
+    );
+}
+
+/// Test full request deserialization with custom tool (matching OpenAI format)
+#[test]
+fn test_full_request_deserialization_with_custom_tool() {
+    let v = json!({
+        "model": "gpt-5",
+        "input": "Use the code_exec tool to print hello world.",
+        "tools": [
+            {
+                "type": "custom",
+                "name": "code_exec",
+                "description": "Executes arbitrary Python code."
+            }
+        ]
+    });
+    let request: ResponsesRequest = serde_json::from_value(v).unwrap();
+    assert_eq!(request.tools.as_ref().unwrap().len(), 1);
+    assert!(matches!(
+        &request.tools.as_ref().unwrap()[0],
+        ResponseTool::Custom(ct) if ct.name == "code_exec"
+    ));
 }


### PR DESCRIPTION
## Description                                                                                                                                                                                                                                                                                                            
 Feature Request: https://github.com/lightseekorg/smg/issues/998 

### Problem                                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                             
  OpenAI's Responses API supports a `custom` tool type that allows models to return arbitrary text input (not JSON) to client-defined tools, with optional grammar constraints (Lark CFG or Regex). SMG currently only supports `function`, `web_search_preview`, `code_interpreter`, and `mcp` tool types, so requests with
   `"type": "custom"` tools are rejected or unrecognized.
                                                                                                                                                                                                                                                                                                                            
### Solution                                                                                                                                                                                                                                                                                                            

  Add end-to-end `CustomToolCall` support to the OpenAI Responses API pipeline. Custom tools are sent to backends as function tools (with empty parameters), and responses are transformed back to the `custom_tool_call` format with `ctc_` ID prefix and `input` field (instead of `arguments`). This implementation      
  supports both HTTP proxy (cloud OpenAI) and gRPC (self-hosted SGLang/vLLM) backends.
                                                                                                                                                                                                                                                                                                                             ## Changes                                                                                                                                                                                                                                                                                                              

  **Protocol Types** (`crates/protocols/src/`):                                                                                                                                                                                                                                                                             
  - Add `Custom(CustomTool)` variant to `ResponseTool` enum with `CustomTool` and `CustomToolFormat` structs
  - Add `CustomToolCall` and `CustomToolCallOutput` variants to `ResponseInputOutputItem` and `ResponseOutputItem`                                                                                                                                                                                                          
  - Add `CustomToolCallEvent` (input delta/done) and `ItemType::CustomToolCall` to event types                                                                                                                                                                                                                              
  - Add `is_custom_tool_call_type()` helper function                                                                                                                                                                                                                                                                        
  - Update validation: custom tool name required, tool_choice includes custom tools, empty output rejected                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                            
  **ID Generation & Persistence** (`crates/data_connector/`, `model_gateway/src/routers/persistence_utils.rs`):                                                                                                                                                                                                             
  - Add `"custom_tool_call" => "ctc"` prefix mapping in `make_item_id()`                                                                                                                                                                                                                                                    
  - Add `ITEM_TYPE_FIELDS` entries and whole-item storage for custom tool call types                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                            
  **Backend Conversion** (`model_gateway/src/routers/grpc/`):                                                                                                                                                                                                                                                               
  - `extract_tools_from_response_tools()` converts custom tools to function tools (empty params) for backends                                                                                                                                                                                                               
  - `ToolLike` impl handles `Custom` variant for Harmony builder                                                                                                                                                                                                                                                            
  - `build_tool_response()` and `chat_to_responses()` emit `CustomToolCall` output items                                                                                                                                                                                                                                    
  - Harmony and Regular builders handle `CustomToolCall`/`CustomToolCallOutput` input items in conversation history                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                            
  **Streaming** (`model_gateway/src/routers/openai/responses/`, `grpc/common/responses/streaming.rs`):                                                                                                                                                                                                                      
  - Transform `function_call` → `custom_tool_call` in streaming events, rename `arguments` → `input`, transform `fc_` → `ctc_` ID prefix                                                                                                                                                                                    
  - Add `emit_custom_tool_call_input_delta/done()` methods to event emitter                                                                                                                                                                                                                                                 
  - Add `CustomToolCall` to `OutputItemType` with `ctc_` prefix                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                            
  **History** (`model_gateway/src/routers/openai/responses/history.rs`):                                                                                                                                                                                                                                                    
  - Load `custom_tool_call` and `custom_tool_call_output` items from conversation storage                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                            
  **Unit Tests** (30 new tests):                                                                                                                                                                                                                                                                                            
  - Protocol: serialization, deserialization, validation, tool_choice, normalization
  - Event types: constants, Display, classification helpers                                                                                                                                                                                                                                                                 
  - Data connector: `ctc_` prefix generation                                                                                                                                                                                                                                                                                
  - Conversions: custom tool extraction, input/output item conversion, `chat_to_responses` output                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                            
  ## Test Plan                                                                                                                                                                                                                                                                                                            

  **Unit tests:**
  ```bash
  cargo test -- custom_tool    # 30 tests across 4 packages                                                                                                                                                                                                                                                                 
  cargo test --package openai-protocol   # 59 passed                                                                                                                                                                                                                                                                        
  cargo test --package data-connector    # 216 passed                                                                                                                                                                                                                                                                       
  cargo test --package smg --test spec_test -- responses  # 57 passed                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                            
  Local E2E test (cloud OpenAI backend):                                                                                                                                                                                                                                                                                    
  # Start gateway                                                                                                                                                                                                                                                                                                           
  OPENAI_API_KEY="sk-proj-***" python3 -m smg.launch_router \                                                                                                                                                                                                                                                               
    --backend openai --model-path gpt-5.4 \                                                                                                                                                                                                                                                                               
    --worker-urls https://api.openai.com \                                                                                                                                                                                                                                                                                  
    --history-backend memory --log-level debug --disable-health-check                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                            
  # Send custom tool request                                                                                                                                                                                                                                                                                                
  curl -X POST http://localhost:30000/v1/responses \                                                                                                                                                                                                                                                                        
    -H "Content-Type: application/json" \                                                                                                                                                                                                                                                                                 
    -H "Authorization: Bearer sk-proj-***" \                                                                                                                                                                                                                                                                                
    -d '{"model":"gpt-5.4","input":"Use the code_exec tool to print hello world.","tools":[{"type":"custom","name":"code_exec","description":"Executes arbitrary Python code."}]}'
                                                                                                                                                                                                                                                                                                                            
  Verified response:                                                                                                                                                                                                                                                                                                        
  {
    "output": [                                                                                                                                                                                                                                                                                                             
      {                                                                                                                                                                                                                                                                                                                   
        "id": "ctc_0a1b7cf6...",
        "type": "custom_tool_call",
        "status": "completed",     
        "call_id": "call_kVP4S2j7...",                                                                                                                                                                                                                                                                                      
        "input": "print(\"hello world\")\n",
        "name": "code_exec"                                                                                                                                                                                                                                                                                                 
      }                                                                                                                                                                                                                                                                                                                   
    ],                                                                                                                                                                                                                                                                                                                      
    "tools": [                                                                                                                                                                                                                                                                                                              
      {       
        "type": "custom",                                                                                                                                                                                                                                                                                                   
        "name": "code_exec",                                                                                                                                                                                                                                                                                              
        "description": "Executes arbitrary Python code."                                                                                                                                                                                                                                                                    
      }
    ]                                                                                                                                                                                                                                                                                                                       
  }    

<!-- Provide a thorough reproducible test showing before and after behavior. -->

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] (Optional) Documentation updated: https://developers.openai.com/api/docs/guides/function-calling#custom-tools
- [x] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for custom tools, enabling users to define and invoke custom tool integrations alongside standard function tools.
  * Custom tools now integrate seamlessly with conversation streaming and chat responses, with full support for inputs, outputs, and status tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->