### PR TITLE
feat(data_connector): Update redis dependency

### DIFF
--- a/crates/data_connector/Cargo.toml
+++ b/crates/data_connector/Cargo.toml
@@ -29,9 +29,9 @@ url = "2.5"
 # Database backends
 deadpool = { version = "0.12", features = ["managed", "rt_tokio_1"] }
 deadpool-postgres = "0.14.1"
-deadpool-redis = "0.18.0"
+deadpool-redis = "0.23"
 oracle = { version = "0.6.3", features = ["chrono"] }
-redis = { version = "0.27.6", features = ["tokio-comp", "json", "connection-manager"] }
+redis = { version = "1", features = ["tokio-comp", "json", "connection-manager"] }
 tokio-postgres = { version = "0.7.15", features = ["runtime", "with-chrono-0_4", "with-serde_json-1", "array-impls"] }
 
 [dev-dependencies]


### PR DESCRIPTION
The old version is old and unsupported.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped Redis connection pool dependency to 0.23.
  * Bumped Redis client dependency to 1.
  * Dependency version updates only; no public API or behavioral changes introduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->