### PR TITLE
refactor(routers): use worker.http_client() instead of shared AppContext.client

### DIFF
--- a/model_gateway/src/routers/anthropic/router.rs
+++ b/model_gateway/src/routers/anthropic/router.rs
@@ -142,10 +142,7 @@ impl RouterTrait for AnthropicRouter {
             "Processing Messages API request"
         );
 
-        let selector = WorkerSelector::new(
-            &self.router_ctx.worker_registry,
-            &self.router_ctx.http_client,
-        );
+        let selector = WorkerSelector::new(&self.router_ctx.worker_registry);
         let selected_worker = match selector
             .select_worker(&SelectWorkerRequest {
                 model_id,

--- a/model_gateway/src/routers/gemini/context.rs
+++ b/model_gateway/src/routers/gemini/context.rs
@@ -25,9 +25,6 @@ use crate::core::{Worker, WorkerRegistry};
 ///
 /// TODO: Create InteractionsStorage and add in context
 pub(crate) struct SharedComponents {
-    /// HTTP client for upstream requests.
-    pub client: reqwest::Client,
-
     /// Worker registry for model → worker resolution.
     pub worker_registry: Arc<WorkerRegistry>,
 

--- a/model_gateway/src/routers/gemini/router.rs
+++ b/model_gateway/src/routers/gemini/router.rs
@@ -40,7 +40,6 @@ impl GeminiRouter {
         let request_timeout = Duration::from_secs(ctx.router_config.request_timeout_secs);
 
         let shared_components = Arc::new(SharedComponents {
-            client: ctx.client.clone(),
             worker_registry: ctx.worker_registry.clone(),
             mcp_orchestrator,
             request_timeout,

--- a/model_gateway/src/routers/gemini/steps/non_stream_execution.rs
+++ b/model_gateway/src/routers/gemini/steps/non_stream_execution.rs
@@ -52,8 +52,8 @@ pub(crate) async fn non_stream_request_execution(
     let provider = ApiProvider::Gemini;
     let auth_header = provider.extract_auth_header(ctx.input.headers.as_ref(), worker.api_key());
     let request_builder = provider.apply_headers(
-        ctx.components
-            .client
+        worker
+            .http_client()
             .post(upstream_url)
             .json(&payload)
             .timeout(ctx.components.request_timeout),

--- a/model_gateway/src/routers/gemini/steps/worker_selection.rs
+++ b/model_gateway/src/routers/gemini/steps/worker_selection.rs
@@ -35,7 +35,7 @@ pub(crate) async fn worker_selection(ctx: &mut RequestContext) -> Result<StepRes
         }
     };
 
-    let selector = WorkerSelector::new(&ctx.components.worker_registry, &ctx.components.client);
+    let selector = WorkerSelector::new(&ctx.components.worker_registry);
     let worker = selector
         .select_worker(&SelectWorkerRequest {
             model_id: model,

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -70,10 +70,10 @@ impl PDRouter {
         headers: Option<Vec<(String, String)>>,
     ) -> Response {
         let workers = self.worker_registry.get_prefill_workers();
-        let first_worker_url = workers.first().map(|w| w.url().to_string());
 
-        if let Some(worker_url) = first_worker_url {
-            self.proxy_to_worker(worker_url, endpoint, headers).await
+        if let Some(worker) = workers.first() {
+            self.proxy_to_worker(worker.as_ref(), endpoint, headers)
+                .await
         } else {
             error::service_unavailable("no_prefill_servers", "No prefill servers available")
         }
@@ -81,12 +81,12 @@ impl PDRouter {
 
     async fn proxy_to_worker(
         &self,
-        worker_url: String,
+        worker: &dyn Worker,
         endpoint: &str,
         headers: Option<Vec<(String, String)>>,
     ) -> Response {
-        let url = format!("{worker_url}/{endpoint}");
-        let mut request_builder = self.client.get(&url);
+        let url = format!("{}/{endpoint}", worker.url());
+        let mut request_builder = worker.http_client().get(&url);
 
         if let Some(headers) = headers {
             for (name, value) in headers {
@@ -557,9 +557,9 @@ impl PDRouter {
         inject_trace_context_http(&mut headers_with_trace);
         let headers = Some(&headers_with_trace);
 
-        // Build both requests
+        // Build both requests using per-worker HTTP clients
         let prefill_request = self.build_post_with_headers(
-            &self.client,
+            prefill.http_client(),
             prefill.url(),
             context.route,
             &json_request,
@@ -567,7 +567,7 @@ impl PDRouter {
             false,
         );
         let decode_request = self.build_post_with_headers(
-            &self.client,
+            decode.http_client(),
             decode.url(),
             context.route,
             &json_request,
@@ -1143,10 +1143,13 @@ impl RouterTrait for PDRouter {
             }
         };
 
-        let prefill_url = format!("{}/health_generate", prefill.url());
         let (prefill_result, decode_result) = tokio::join!(
-            self.client.get(&prefill_url).send(),
-            self.client
+            prefill
+                .http_client()
+                .get(format!("{}/health_generate", prefill.url()))
+                .send(),
+            decode
+                .http_client()
                 .get(format!("{}/health_generate", decode.url()))
                 .send()
         );

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -47,7 +47,6 @@ use crate::{
 pub struct PDRouter {
     pub worker_registry: Arc<WorkerRegistry>,
     pub policy_registry: Arc<PolicyRegistry>,
-    pub client: Client,
     pub retry_config: RetryConfig,
     pub api_key: Option<String>,
 }
@@ -163,7 +162,6 @@ impl PDRouter {
         Ok(PDRouter {
             worker_registry: Arc::clone(&ctx.worker_registry),
             policy_registry: Arc::clone(&ctx.policy_registry),
-            client: ctx.client.clone(),
             retry_config: ctx.router_config.effective_retry_config(),
             api_key: ctx.router_config.api_key.clone(),
         })
@@ -1378,7 +1376,6 @@ mod tests {
         PDRouter {
             worker_registry,
             policy_registry,
-            client: Client::new(),
             retry_config: RetryConfig::default(),
             api_key: Some("test_api_key".to_string()),
         }

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -18,7 +18,6 @@ use openai_protocol::{
     rerank::{RerankRequest, RerankResponse, RerankResult},
     responses::ResponsesRequest,
 };
-use reqwest::Client;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::error;
@@ -47,7 +46,6 @@ use crate::{
 pub struct Router {
     worker_registry: Arc<WorkerRegistry>,
     policy_registry: Arc<PolicyRegistry>,
-    client: Client,
     retry_config: RetryConfig,
 }
 
@@ -56,7 +54,6 @@ impl std::fmt::Debug for Router {
         f.debug_struct("Router")
             .field("worker_registry", &self.worker_registry)
             .field("policy_registry", &self.policy_registry)
-            .field("client", &self.client)
             .field("retry_config", &self.retry_config)
             .finish()
     }
@@ -72,7 +69,6 @@ impl Router {
         Ok(Router {
             worker_registry: ctx.worker_registry.clone(),
             policy_registry: ctx.policy_registry.clone(),
-            client: ctx.client.clone(),
             retry_config: ctx.router_config.effective_retry_config(),
         })
     }
@@ -806,7 +802,6 @@ mod tests {
         Router {
             worker_registry,
             policy_registry,
-            client: Client::new(),
             retry_config: RetryConfig::default(),
         }
     }

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -77,13 +77,13 @@ impl Router {
         })
     }
 
-    fn select_first_worker(&self) -> Result<String, String> {
+    fn select_first_worker(&self) -> Result<Arc<dyn Worker>, String> {
         let workers = self.worker_registry.get_all();
         let healthy_workers: Vec<_> = workers.iter().filter(|w| w.is_healthy()).collect();
         if healthy_workers.is_empty() {
             Err("No workers are available".to_string())
         } else {
-            Ok(healthy_workers[0].url().to_string())
+            Ok(healthy_workers[0].clone())
         }
     }
 
@@ -91,8 +91,10 @@ impl Router {
         let headers = header_utils::copy_request_headers(&req);
 
         match self.select_first_worker() {
-            Ok(worker_url) => {
-                let mut request_builder = self.client.get(format!("{worker_url}/{endpoint}"));
+            Ok(worker) => {
+                let mut request_builder = worker
+                    .http_client()
+                    .get(format!("{}/{endpoint}", worker.url()));
                 for (name, value) in headers {
                     if header_utils::should_forward_request_header(&name) {
                         request_builder = request_builder.header(name, value);
@@ -374,7 +376,7 @@ impl Router {
             .into_iter()
             .map(|worker| {
                 let url = format!("{}/{}", worker.base_url(), endpoint);
-                let client = self.client.clone();
+                let client = worker.http_client().clone();
                 let method = method.clone();
 
                 let headers = filtered_headers.clone();
@@ -493,7 +495,7 @@ impl Router {
             }
         };
 
-        let mut request_builder = self.client.post(&endpoint_url).json(&json_val);
+        let mut request_builder = worker.http_client().post(&endpoint_url).json(&json_val);
 
         if let Some(key) = api_key {
             // Pre-allocate string with capacity to avoid reallocation
@@ -833,9 +835,9 @@ mod tests {
         let result = router.select_first_worker();
 
         assert!(result.is_ok());
-        let url = result.unwrap();
+        let worker = result.unwrap();
         // DashMap doesn't guarantee order, so just check we get one of the workers
-        assert!(url == "http://worker1:8080" || url == "http://worker2:8080");
+        assert!(worker.url() == "http://worker1:8080" || worker.url() == "http://worker2:8080");
     }
 
     #[test]
@@ -844,9 +846,7 @@ mod tests {
         let result = router.select_first_worker();
 
         assert!(result.is_ok());
-        let url = result.unwrap();
-
-        let worker = router.worker_registry.get_by_url(&url).unwrap();
+        let worker = result.unwrap();
         assert!(worker.is_healthy());
     }
 }

--- a/model_gateway/src/routers/openai/chat.rs
+++ b/model_gateway/src/routers/openai/chat.rs
@@ -141,7 +141,7 @@ pub(super) async fn route_chat(
     )]
     let payload_ref = ctx.payload().expect("Payload not prepared");
     let payload_json = Arc::new(payload_ref.json.clone());
-    let client = ctx.components.client().clone();
+    let client = worker.http_client().clone();
     let headers_cloned = Arc::new(ctx.headers().cloned());
     let worker_api_key = Arc::new(worker.api_key().cloned());
     let is_streaming = ctx.is_streaming();

--- a/model_gateway/src/routers/openai/chat.rs
+++ b/model_gateway/src/routers/openai/chat.rs
@@ -57,7 +57,7 @@ pub(super) async fn route_chat(
         bool_to_static_str(streaming),
     );
 
-    let selector = WorkerSelector::new(deps.worker_registry, &deps.shared_components.client);
+    let selector = WorkerSelector::new(deps.worker_registry);
     let worker = match selector
         .select_worker(&SelectWorkerRequest {
             model_id: model,

--- a/model_gateway/src/routers/openai/context.rs
+++ b/model_gateway/src/routers/openai/context.rs
@@ -34,9 +34,7 @@ pub enum RequestType {
 }
 
 #[derive(Clone)]
-pub struct SharedComponents {
-    pub client: reqwest::Client,
-}
+pub struct SharedComponents {}
 
 pub struct ResponsesComponents {
     pub shared: Arc<SharedComponents>,
@@ -52,13 +50,6 @@ pub enum ComponentRefs {
 }
 
 impl ComponentRefs {
-    pub fn client(&self) -> &reqwest::Client {
-        match self {
-            ComponentRefs::Shared(s) => &s.client,
-            ComponentRefs::Responses(r) => &r.shared.client,
-        }
-    }
-
     pub fn mcp_orchestrator(&self) -> Option<&Arc<McpOrchestrator>> {
         match self {
             ComponentRefs::Shared(_) => None,

--- a/model_gateway/src/routers/openai/realtime/rest.rs
+++ b/model_gateway/src/routers/openai/realtime/rest.rs
@@ -22,7 +22,6 @@ use crate::{
 /// The caller is responsible for worker selection; this function receives
 /// the pre-selected worker (or an error response).
 pub(crate) async fn forward_realtime_rest(
-    client: &reqwest::Client,
     worker: Result<Arc<dyn Worker>, Response>,
     headers: Option<&HeaderMap>,
     body: &(impl serde::Serialize + Sync),
@@ -76,7 +75,8 @@ pub(crate) async fn forward_realtime_rest(
 
     let upstream_url = format!("{}{endpoint}", worker.url().trim_end_matches('/'));
 
-    let result = client
+    let result = worker
+        .http_client()
         .post(&upstream_url)
         .header("Authorization", &auth)
         .json(body)

--- a/model_gateway/src/routers/openai/responses/non_streaming.rs
+++ b/model_gateway/src/routers/openai/responses/non_streaming.rs
@@ -75,7 +75,7 @@ pub async fn handle_non_streaming_response(mut ctx: RequestContext) -> Response 
         prepare_mcp_tools_as_functions(&mut payload, &session);
 
         match execute_tool_loop(
-            ctx.components.client(),
+            worker.http_client(),
             &url,
             ctx.headers(),
             payload,
@@ -94,7 +94,7 @@ pub async fn handle_non_streaming_response(mut ctx: RequestContext) -> Response 
             }
         }
     } else {
-        let mut request_builder = ctx.components.client().post(&url).json(&payload);
+        let mut request_builder = worker.http_client().post(&url).json(&payload);
         let auth_header = extract_auth_header(ctx.headers(), worker.api_key());
         request_builder = apply_provider_headers(request_builder, &url, auth_header.as_ref());
 

--- a/model_gateway/src/routers/openai/responses/route.rs
+++ b/model_gateway/src/routers/openai/responses/route.rs
@@ -56,17 +56,14 @@ pub(in crate::routers::openai) async fn route_responses(
         bool_to_static_str(streaming),
     );
 
-    let worker = match WorkerSelector::new(
-        deps.worker_registry,
-        &deps.responses_components.shared.client,
-    )
-    .select_worker(&SelectWorkerRequest {
-        model_id: model,
-        headers,
-        provider: Some(ProviderType::OpenAI),
-        ..Default::default()
-    })
-    .await
+    let worker = match WorkerSelector::new(deps.worker_registry)
+        .select_worker(&SelectWorkerRequest {
+            model_id: model,
+            headers,
+            provider: Some(ProviderType::OpenAI),
+            ..Default::default()
+        })
+        .await
     {
         Ok(w) => w,
         Err(response) => {

--- a/model_gateway/src/routers/openai/responses/streaming.rs
+++ b/model_gateway/src/routers/openai/responses/streaming.rs
@@ -1046,7 +1046,7 @@ pub async fn handle_streaming_response(ctx: RequestContext) -> Response {
         None
     };
 
-    let client = ctx.components.client().clone();
+    let client = worker.http_client().clone();
     let req = match ctx.into_streaming_context() {
         Ok(r) => r,
         Err(msg) => {

--- a/model_gateway/src/routers/openai/router.rs
+++ b/model_gateway/src/routers/openai/router.rs
@@ -85,9 +85,7 @@ impl OpenAIRouter {
             .ok_or_else(|| "MCP manager not initialized in AppContext".to_string())?
             .clone();
 
-        let shared_components = Arc::new(SharedComponents {
-            client: ctx.client.clone(),
-        });
+        let shared_components = Arc::new(SharedComponents {});
 
         let responses_components = Arc::new(ResponsesComponents {
             shared: Arc::clone(&shared_components),
@@ -182,7 +180,6 @@ impl crate::routers::RouterTrait for OpenAIRouter {
         let model = body.model.as_deref().unwrap_or_default();
         let worker = self.select_worker(model, headers).await;
         forward_realtime_rest(
-            &self.shared_components.client,
             worker,
             headers,
             body,
@@ -202,7 +199,6 @@ impl crate::routers::RouterTrait for OpenAIRouter {
         let model = body.session.model.as_deref().unwrap_or_default();
         let worker = self.select_worker(model, headers).await;
         forward_realtime_rest(
-            &self.shared_components.client,
             worker,
             headers,
             body,
@@ -221,7 +217,6 @@ impl crate::routers::RouterTrait for OpenAIRouter {
         let model = body.model.as_deref().unwrap_or_default();
         let worker = self.select_worker(model, headers).await;
         forward_realtime_rest(
-            &self.shared_components.client,
             worker,
             headers,
             body,

--- a/model_gateway/src/routers/openai/router.rs
+++ b/model_gateway/src/routers/openai/router.rs
@@ -113,7 +113,7 @@ impl OpenAIRouter {
         model_id: &str,
         headers: Option<&HeaderMap>,
     ) -> Result<Arc<dyn Worker>, Response> {
-        WorkerSelector::new(&self.worker_registry, &self.shared_components.client)
+        WorkerSelector::new(&self.worker_registry)
             .select_worker(&SelectWorkerRequest {
                 model_id,
                 headers,

--- a/model_gateway/src/routers/worker_selection.rs
+++ b/model_gateway/src/routers/worker_selection.rs
@@ -25,7 +25,6 @@ use crate::{
 /// reused across calls.
 pub struct WorkerSelector<'a> {
     registry: &'a WorkerRegistry,
-    client: &'a reqwest::Client,
 }
 
 /// Input for [`WorkerSelector::select_worker`].
@@ -58,8 +57,8 @@ pub struct SelectWorkerRequest<'a> {
 }
 
 impl<'a> WorkerSelector<'a> {
-    pub fn new(registry: &'a WorkerRegistry, client: &'a reqwest::Client) -> Self {
-        Self { registry, client }
+    pub fn new(registry: &'a WorkerRegistry) -> Self {
+        Self { registry }
     }
 
     /// Select the best worker for a model with refresh-on-miss.
@@ -174,7 +173,7 @@ impl<'a> WorkerSelector<'a> {
 
         let futures: Vec<_> = external_workers
             .iter()
-            .map(|w| refresh_worker_models(self.client, w, auth_header))
+            .map(|w| refresh_worker_models(w, auth_header))
             .collect();
 
         // Timeout prevents a slow/unresponsive worker from blocking all
@@ -218,12 +217,11 @@ fn filter_by_provider(
 /// Anthropic uses `x-api-key`, OpenAI uses `Authorization: Bearer`). The
 /// response is parsed via [`ListModelsResponse::parse_upstream`].
 async fn refresh_worker_models(
-    client: &reqwest::Client,
     worker: &Arc<dyn Worker>,
     auth_header: Option<&HeaderValue>,
 ) -> bool {
     let url = format!("{}/v1/models", worker.url());
-    let mut backend_req = client.get(&url);
+    let mut backend_req = worker.http_client().get(&url);
 
     // Use caller's auth if provided, otherwise fall back to worker's configured API key.
     // This matches how auth is handled in request routing (e.g. openai/router.rs).


### PR DESCRIPTION
## Description

Part of the per-worker resilience refactor series.

### Problem

All routers share a single `reqwest::Client` from `AppContext.client`. This means all workers share the same connection pool — one slow worker's connections affect others.

### Solution

Routers now use `worker.http_client()` for request routing. Each worker has its own isolated connection pool (configured via `HttpPoolConfig` at registration time).

The shared client is removed from `WorkerSelector` (model refresh now uses `worker.http_client()` too) and from Gemini `SharedComponents`. HTTP and HTTP PD routers still have `self.client` field but it's unused for request routing.

## Changes (one commit per router)

1. **worker_selection.rs**: Remove client from `WorkerSelector`, `refresh_worker_models` uses `worker.http_client()`
2. **OpenAI router**: `chat.rs`, `non_streaming.rs`, `streaming.rs` use `worker.http_client()` instead of `ctx.components.client()`
3. **HTTP router**: `proxy_get_request`, `route_simple_request`, `send_typed_request` use `worker.http_client()`. Changed `select_first_worker` to return `Arc<dyn Worker>` instead of String.
4. **Gemini router**: `non_stream_execution.rs` uses `worker.http_client()`. Removed `client` field from Gemini `SharedComponents`.
5. **HTTP PD router**: `proxy_to_worker`, `build_post_with_headers`, `health_generate` use per-worker clients. Changed `proxy_to_worker` to take `&dyn Worker` instead of URL string.

## Test Plan

- `cargo test -p smg --lib` — all 450 tests pass
- Pre-commit hooks pass (rustfmt, clippy, codespell, DCO)

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes

</details>

<!-- This is an auto-generated comment: raw summary by coderabbit.ai -->
<!-- end of auto-generated comment: raw summary by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched from a shared HTTP client to per-worker HTTP clients across routers and routing flows, improving request isolation and reliability.
* **Tests**
  * Updated unit tests to align with worker-based selection and per-worker HTTP client routing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

<!-- This is an auto-generated comment: summary by coderabbit.ai -->
<!-- end of auto-generated comment: summary by coderabbit.ai -->