### PR TITLE
feat(ci): add Devstral 2 nightly benchmark

### DIFF
--- a/.github/workflows/nightly-benchmark.yml
+++ b/.github/workflows/nightly-benchmark.yml
@@ -348,6 +348,9 @@ jobs:
       matrix:
         model:
           - { id: meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8, slug: meta-llama-Llama-4-Maverick-17B-128E-Instruct-FP8, test_class: TestNightlyLlama4MaverickSingle }
+          - id: mistralai/Devstral-2-123B-Instruct-2512
+            slug: mistralai-Devstral-2-123B-Instruct-2512
+            test_class: TestNightlyDevstral123bSingle
           # Pausing MiniMax M2 nightly benchmark
           # - { id: minimaxai/minimax-m2, slug: minimaxai-minimax-m2, test_class: TestNightlyMinimaxM2Single }
         variant:

--- a/e2e_test/benchmarks/test_nightly_perf.py
+++ b/e2e_test/benchmarks/test_nightly_perf.py
@@ -102,6 +102,7 @@ _NIGHTLY_MODELS: list[tuple[str, str, int, list[str], dict]] = [
     ("Qwen/Qwen3-30B-A3B", "Qwen30b", 4, ["http", "grpc"], {}),
     ("openai/gpt-oss-20b", "GptOss20b", 1, ["http", "grpc"], {}),
     ("minimaxai/minimax-m2", "MinimaxM2", 1, ["http", "grpc"], {}),
+    ("mistralai/Devstral-2-123B-Instruct-2512", "Devstral123b", 1, ["http", "grpc"], {}),
     (
         "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8",
         "Llama4Maverick",

--- a/e2e_test/infra/model_specs.py
+++ b/e2e_test/infra/model_specs.py
@@ -77,6 +77,15 @@ MODEL_SPECS: dict[str, dict] = {
             '{"disable_any_whitespace": true, "backend": "xgrammar"}',
         ],
     },
+    # Devstral 2 - nightly benchmarks
+    "mistralai/Devstral-2-123B-Instruct-2512": {
+        "model": _resolve_model_path("mistralai/Devstral-2-123B-Instruct-2512"),
+        "tp": 8,
+        "features": ["chat", "streaming", "function_calling"],
+        "worker_args": ["--tool-call-parser", "mistral"],
+        "vllm_args": ["--tool-call-parser", "mistral", "--enable-auto-tool-choice"],
+        "startup_timeout": 1200,
+    },
     # Embedding model
     "intfloat/e5-mistral-7b-instruct": {
         "model": _resolve_model_path("intfloat/e5-mistral-7b-instruct"),


### PR DESCRIPTION
## Description

### Problem

The nightly benchmark workflow does not currently include coverage for `mistralai/Devstral-2-123B-Instruct-2512`, so regressions for that model are not captured in nightly benchmarking.

### Solution

Add `mistralai/Devstral-2-123B-Instruct-2512` to the H200 single-worker nightly benchmark matrix and register its benchmark/test configuration in the e2e model specs.

## Changes

  - Added `mistralai/Devstral-2-123B-Instruct-2512` to the nightly benchmark workflow.
  - Added a nightly benchmark test entry for Devstral.
  - Added a model spec for Devstral with `tp: 8`, tool-calling runtime args, and an extended startup timeout.

## Test Plan

  - Run `python3 -m py_compile e2e_test/benchmarks/test_nightly_perf.py e2e_test/infra/model_specs.py`
  - Parse the workflow locally to confirm valid YAML:
    `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/nightly-benchmark.yml"); puts "yaml ok"'`
  - Trigger the nightly benchmark workflow with the Devstral model selected.
  - Confirm the workflow schedules `TestNightlyDevstral123bSingle`.
  - Verify the model resolves correctly from `MODEL_SPECS` with `tp=8`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Extended nightly benchmark and test infrastructure to include the mistralai/Devstral-2-123B-Instruct-2512 model with single-worker testing across HTTP and gRPC backends.
* **New Features**
  * Declared support for chat, streaming, and function-calling capabilities for the added model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->