### PR TITLE
feat(tokenizer): detect tool call arguments format from chat template

### DIFF
--- a/crates/tokenizer/src/cache/mod.rs
+++ b/crates/tokenizer/src/cache/mod.rs
@@ -27,7 +27,7 @@ pub use l1::{L1Cache, L1CacheStats};
 use rayon::prelude::*;
 
 use crate::{
-    chat_template::{ChatTemplateContentFormat, ChatTemplateParams},
+    chat_template::{ChatTemplateContentFormat, ChatTemplateParams, ToolCallArgumentsFormat},
     traits::{Decoder, Encoder, Encoding, SpecialTokens, TokenIdType, Tokenizer},
 };
 
@@ -270,6 +270,10 @@ impl Tokenizer for CachedTokenizer {
 
     fn chat_template_content_format(&self) -> ChatTemplateContentFormat {
         self.inner.chat_template_content_format()
+    }
+
+    fn tool_call_arguments_format(&self) -> ToolCallArgumentsFormat {
+        self.inner.tool_call_arguments_format()
     }
 }
 

--- a/crates/tokenizer/src/chat_template.rs
+++ b/crates/tokenizer/src/chat_template.rs
@@ -82,32 +82,25 @@ pub fn detect_template_formats(
 }
 
 /// Lightweight string-scan detection of tool call arguments format.
+///
+/// Dict is the Transformers convention and the overwhelming majority of models.
+/// Only DeepSeek V3/R1 family templates use plain string concatenation.
+/// So we detect the string pattern and default to dict.
 fn detect_arguments_format_from_text(template: &str) -> ToolCallArgumentsFormat {
-    // No mention of arguments at all → default to dict (Transformers convention)
+    // No mention of arguments at all → default to dict
     if !template.contains("arguments") {
         return ToolCallArgumentsFormat::Dict;
     }
 
-    // Check for dict-consuming filters applied to arguments.
-    // These patterns indicate the template expects arguments as a dict/object.
-    //
-    // In Jinja templates, the expression accessing arguments may look like:
-    //   tool['function']['arguments']|tojson
-    //   tool['function']['arguments'] | tojson
-    //   tool_call.arguments|items
-    // So after "arguments" there may be closing brackets/quotes before the pipe.
-    // We scan forward from each "arguments" occurrence, skip closing syntax chars
-    // and whitespace, then look for "|" followed by a dict filter.
-    const DICT_FILTERS: &[&str] = &[
-        "tojson", "items", "dictsort", "to_json", "pprint", "xmlattr",
-    ];
-
+    // Detect the string-concat pattern: `arguments` followed (after closing
+    // brackets/quotes/whitespace) by `+` (Jinja string concatenation).
+    // All known DeepSeek templates use: tool['function']['arguments'] + '...'
     let bytes = template.as_bytes();
     let mut pos = 0;
     while let Some(idx) = template[pos..].find("arguments") {
         let start = pos + idx + "arguments".len();
         let mut i = start;
-        // Skip closing syntax chars: ']  '  "  )  }  and whitespace
+        // Skip closing syntax chars: ] ' " ) } and whitespace
         while i < bytes.len()
             && matches!(
                 bytes[i],
@@ -116,65 +109,14 @@ fn detect_arguments_format_from_text(template: &str) -> ToolCallArgumentsFormat 
         {
             i += 1;
         }
-        // Check for pipe "|"
-        if i < bytes.len() && bytes[i] == b'|' {
-            i += 1;
-            // Skip whitespace after "|"
-            while i < bytes.len() && bytes[i].is_ascii_whitespace() {
-                i += 1;
-            }
-            // Check if the next chars match a dict filter
-            let remaining = &template[i..];
-            if DICT_FILTERS.iter().any(|f| remaining.starts_with(f)) {
-                return ToolCallArgumentsFormat::Dict;
-            }
+        if i < bytes.len() && bytes[i] == b'+' {
+            return ToolCallArgumentsFormat::String;
         }
         pos = start;
     }
 
-    // Pattern 2: Direct dict iteration without pipe filter (Llama 4 style)
-    //   {% for param in tool_call.arguments %}  →  iterates over dict keys
-    // We check that " in " (or " in\t") appears immediately before the
-    // dot-access chain ending in "arguments" (e.g. " in tool_call.arguments").
-    // We scan backwards from each "arguments" occurrence: first skip the
-    // identifier.dot prefix (e.g. "tool_call."), then check for " in ".
-    {
-        let mut pos2 = 0;
-        while let Some(idx) = template[pos2..].find("arguments") {
-            let arg_start = pos2 + idx;
-            // Walk backwards over the dot-access prefix: identifiers and dots
-            // e.g. "tool_call." in "tool_call.arguments"
-            let prefix = &template.as_bytes()[..arg_start];
-            let mut back = arg_start;
-            while back > 0
-                && (prefix[back - 1].is_ascii_alphanumeric()
-                    || prefix[back - 1] == b'_'
-                    || prefix[back - 1] == b'.')
-            {
-                back -= 1;
-            }
-            // Now check if the chars before the dot-access are " in "
-            // back points to the first char of the dot-access prefix
-            if back >= 4 {
-                let before = &template[back.saturating_sub(4)..back];
-                if before == " in " || before.ends_with(" in ") {
-                    return ToolCallArgumentsFormat::Dict;
-                }
-            }
-            pos2 = arg_start + "arguments".len();
-        }
-    }
-
-    // Pattern 3: Alias-then-dict-method pattern (GLM, MiniMax style)
-    //   {% set _args = tc.arguments %} ... _args.items()
-    // If the template mentions both "arguments" and ".items()" it's treating
-    // arguments as a dict through an intermediate variable.
-    if template.contains(".items()") {
-        return ToolCallArgumentsFormat::Dict;
-    }
-
-    // Template mentions `arguments` but doesn't use dict filters or iteration → string concat
-    ToolCallArgumentsFormat::String
+    // Default: dict (Transformers convention, used by Llama, Qwen, GLM, MiniMax, etc.)
+    ToolCallArgumentsFormat::Dict
 }
 
 /// Detect the content format expected by a Jinja2 chat template
@@ -952,39 +894,19 @@ mod tests {
     }
 
     #[test]
-    fn test_args_format_tojson_filter() {
-        // Llama-style: arguments|tojson
-        let template = r"{{ tool['function']['arguments']|tojson }}";
-        assert_eq!(
-            detect_tool_call_arguments_format(template),
-            ToolCallArgumentsFormat::Dict,
-        );
-    }
-
-    #[test]
-    fn test_args_format_tojson_with_spaces() {
-        // arguments | tojson (with spaces around pipe)
-        let template = r"{{ tool['function']['arguments'] | tojson }}";
-        assert_eq!(
-            detect_tool_call_arguments_format(template),
-            ToolCallArgumentsFormat::Dict,
-        );
-    }
-
-    #[test]
-    fn test_args_format_items_filter() {
-        // Qwen3.5-style: arguments|items
-        let template = r"{%- for args_name, args_value in tool_call.arguments|items %}";
-        assert_eq!(
-            detect_tool_call_arguments_format(template),
-            ToolCallArgumentsFormat::Dict,
-        );
-    }
-
-    #[test]
-    fn test_args_format_plain_string_concat() {
-        // DeepSeek V3.1-style: plain string concatenation, no filter
+    fn test_args_format_string_concat_deepseek() {
+        // DeepSeek V3.1-style: plain string concatenation
         let template = r"tool['function']['arguments'] + '\n'";
+        assert_eq!(
+            detect_tool_call_arguments_format(template),
+            ToolCallArgumentsFormat::String,
+        );
+    }
+
+    #[test]
+    fn test_args_format_string_concat_real_deepseek() {
+        // Real DeepSeek single-line template snippet with for-loop and arguments + concat
+        let template = "{%- for tool in message['tool_calls'] %}{%- if not ns.is_first %}{%- if message['content'] is none %}{{'<tool_calls_begin>' + tool['function']['name'] + '\\n' + '```json' + '\\n' + tool['function']['arguments'] + '\\n' + '```'}}{%- endif %}{%- endfor %}";
         assert_eq!(
             detect_tool_call_arguments_format(template),
             ToolCallArgumentsFormat::String,
@@ -1000,45 +922,23 @@ mod tests {
     }
 
     #[test]
-    fn test_args_format_direct_dict_iteration_llama4() {
-        // Llama 4 style: iterates directly over dict keys, no |items filter
+    fn test_args_format_dict_tojson() {
+        // Llama/Qwen style: arguments|tojson → defaults to dict (no + concat)
+        let template = r"{{ tool['function']['arguments']|tojson }}";
+        assert_eq!(
+            detect_tool_call_arguments_format(template),
+            ToolCallArgumentsFormat::Dict,
+        );
+    }
+
+    #[test]
+    fn test_args_format_dict_iteration() {
+        // Llama 4 / GLM / MiniMax: dict iteration → defaults to dict (no + concat)
         let template =
             r"{%- for param in tool_call.arguments %}{{ tool_call.arguments[param] }}{%- endfor %}";
         assert_eq!(
             detect_tool_call_arguments_format(template),
             ToolCallArgumentsFormat::Dict,
-        );
-    }
-
-    #[test]
-    fn test_args_format_alias_then_items_glm() {
-        // GLM-4.6/minimax-m2 style: alias to local var, then .items()
-        let template = r"{% set _args = tc.arguments %}{% for k, v in _args.items() %}{{ k }}={{ v }}{% endfor %}";
-        assert_eq!(
-            detect_tool_call_arguments_format(template),
-            ToolCallArgumentsFormat::Dict,
-        );
-    }
-
-    #[test]
-    fn test_args_format_is_string_check_qwen3() {
-        // Qwen3 style: checks if arguments is string, falls back to |tojson
-        let template = r"{%- if tool_call.arguments is string %}{{ tool_call.arguments }}{%- else %}{{ tool_call.arguments | tojson }}{%- endif %}";
-        assert_eq!(
-            detect_tool_call_arguments_format(template),
-            ToolCallArgumentsFormat::Dict,
-        );
-    }
-
-    #[test]
-    fn test_args_format_deepseek_single_line_no_false_positive() {
-        // DeepSeek V3.1 template is a single long line. It has:
-        //   {%- for tool in message['tool_calls'] %} ... tool['function']['arguments'] + ...
-        // Pattern 2 must NOT match: the "for ... in ..." loop is over tool_calls, not arguments.
-        let template = "{%- for tool in message['tool_calls'] %}{%- if not ns.is_first %}{%- if message['content'] is none %}{{'<tool_calls_begin>' + tool['function']['name'] + '\\n' + '```json' + '\\n' + tool['function']['arguments'] + '\\n' + '```'}}{%- endif %}{%- endfor %}";
-        assert_eq!(
-            detect_tool_call_arguments_format(template),
-            ToolCallArgumentsFormat::String,
         );
     }
 }

--- a/crates/tokenizer/src/chat_template.rs
+++ b/crates/tokenizer/src/chat_template.rs
@@ -29,6 +29,23 @@ pub enum ChatTemplateContentFormat {
     OpenAI,
 }
 
+/// Tool call arguments format expected by the chat template.
+///
+/// Per Transformers/HuggingFace guidance, new templates should expect arguments
+/// as dicts and render them with `|tojson`. However, some templates (DeepSeek V3.1)
+/// still use plain string concatenation and expect arguments to be JSON strings.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ToolCallArgumentsFormat {
+    /// Arguments should be passed as parsed JSON objects (dicts).
+    /// Templates use `|tojson` or `|items` to render them.
+    /// This is the Transformers convention and the default.
+    #[default]
+    Dict,
+    /// Arguments should be left as JSON strings.
+    /// Templates use plain string concatenation (e.g., DeepSeek V3.1).
+    String,
+}
+
 impl std::fmt::Display for ChatTemplateContentFormat {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -36,6 +53,87 @@ impl std::fmt::Display for ChatTemplateContentFormat {
             Self::OpenAI => write!(f, "openai"),
         }
     }
+}
+
+/// Detect the tool call arguments format expected by a Jinja2 chat template.
+///
+/// Inspects the template text for how `arguments` is used:
+/// - If a dict-consuming filter (`|tojson`, `|items`, `|dictsort`, `|tojson(...)`) is applied,
+///   the template expects arguments as dicts → return `Dict`.
+/// - If `arguments` appears in the template without such filters (plain string concatenation),
+///   the template expects arguments as JSON strings → return `String`.
+/// - If `arguments` does not appear at all (no tool support), default to `Dict`
+///   (the Transformers convention).
+pub fn detect_tool_call_arguments_format(template: &str) -> ToolCallArgumentsFormat {
+    detect_template_formats(template).1
+}
+
+/// Detect both content format and tool call arguments format in a single pass.
+///
+/// The content format detection parses the AST, while the arguments format
+/// detection is a lightweight string scan. Combining them avoids redundant work
+/// when both are needed (e.g., during tokenizer initialization).
+pub fn detect_template_formats(
+    template: &str,
+) -> (ChatTemplateContentFormat, ToolCallArgumentsFormat) {
+    let content_format = detect_chat_template_content_format(template);
+    let arguments_format = detect_arguments_format_from_text(template);
+    (content_format, arguments_format)
+}
+
+/// Lightweight string-scan detection of tool call arguments format.
+fn detect_arguments_format_from_text(template: &str) -> ToolCallArgumentsFormat {
+    // No mention of arguments at all → default to dict (Transformers convention)
+    if !template.contains("arguments") {
+        return ToolCallArgumentsFormat::Dict;
+    }
+
+    // Check for dict-consuming filters applied to arguments.
+    // These patterns indicate the template expects arguments as a dict/object.
+    //
+    // In Jinja templates, the expression accessing arguments may look like:
+    //   tool['function']['arguments']|tojson
+    //   tool['function']['arguments'] | tojson
+    //   tool_call.arguments|items
+    // So after "arguments" there may be closing brackets/quotes before the pipe.
+    // We scan forward from each "arguments" occurrence, skip closing syntax chars
+    // and whitespace, then look for "|" followed by a dict filter.
+    const DICT_FILTERS: &[&str] = &[
+        "tojson", "items", "dictsort", "to_json", "pprint", "xmlattr",
+    ];
+
+    let bytes = template.as_bytes();
+    let mut pos = 0;
+    while let Some(idx) = template[pos..].find("arguments") {
+        let start = pos + idx + "arguments".len();
+        let mut i = start;
+        // Skip closing syntax chars: ']  '  "  )  }  and whitespace
+        while i < bytes.len()
+            && matches!(
+                bytes[i],
+                b']' | b'\'' | b'"' | b')' | b'}' | b' ' | b'\t' | b'\n' | b'\r'
+            )
+        {
+            i += 1;
+        }
+        // Check for pipe "|"
+        if i < bytes.len() && bytes[i] == b'|' {
+            i += 1;
+            // Skip whitespace after "|"
+            while i < bytes.len() && bytes[i].is_ascii_whitespace() {
+                i += 1;
+            }
+            // Check if the next chars match a dict filter
+            let remaining = &template[i..];
+            if DICT_FILTERS.iter().any(|f| remaining.starts_with(f)) {
+                return ToolCallArgumentsFormat::Dict;
+            }
+        }
+        pos = start;
+    }
+
+    // Template mentions `arguments` but doesn't use dict filters → string concat style
+    ToolCallArgumentsFormat::String
 }
 
 /// Detect the content format expected by a Jinja2 chat template
@@ -630,6 +728,7 @@ pub struct ChatTemplateState {
     /// Cached, fully-configured environment. `None` when no template is set.
     env: Option<Environment<'static>>,
     content_format: ChatTemplateContentFormat,
+    arguments_format: ToolCallArgumentsFormat,
 }
 
 impl std::fmt::Debug for ChatTemplateState {
@@ -637,20 +736,22 @@ impl std::fmt::Debug for ChatTemplateState {
         f.debug_struct("ChatTemplateState")
             .field("has_template", &self.env.is_some())
             .field("content_format", &self.content_format)
+            .field("arguments_format", &self.arguments_format)
             .finish()
     }
 }
 
 impl ChatTemplateState {
     pub fn new(template: Option<String>) -> Result<Self> {
-        let content_format = template
+        let (content_format, arguments_format) = template
             .as_ref()
-            .map(|t| detect_chat_template_content_format(t))
+            .map(|t| detect_template_formats(t))
             .unwrap_or_default();
         let env = template.map(build_environment).transpose()?;
         Ok(Self {
             env,
             content_format,
+            arguments_format,
         })
     }
 
@@ -662,6 +763,7 @@ impl ChatTemplateState {
         Self {
             env: None,
             content_format: ChatTemplateContentFormat::default(),
+            arguments_format: ToolCallArgumentsFormat::default(),
         }
     }
 
@@ -682,15 +784,20 @@ impl ChatTemplateState {
     }
 
     pub fn set(&mut self, template: String) -> Result<()> {
-        let content_format = detect_chat_template_content_format(&template);
+        let (content_format, arguments_format) = detect_template_formats(&template);
         let env = build_environment(template)?;
         self.content_format = content_format;
+        self.arguments_format = arguments_format;
         self.env = Some(env);
         Ok(())
     }
 
     pub fn content_format(&self) -> ChatTemplateContentFormat {
         self.content_format
+    }
+
+    pub fn arguments_format(&self) -> ToolCallArgumentsFormat {
+        self.arguments_format
     }
 }
 
@@ -787,5 +894,77 @@ mod tests {
             .unwrap();
 
         assert_eq!(result, "<s>hello");
+    }
+
+    // ========================================================================
+    // Tool call arguments format detection tests
+    // ========================================================================
+
+    #[test]
+    fn test_args_format_no_arguments_keyword() {
+        // Template with no mention of "arguments" → default to Dict
+        let template = "{% for message in messages %}{{ message.content }}{% endfor %}";
+        assert_eq!(
+            detect_tool_call_arguments_format(template),
+            ToolCallArgumentsFormat::Dict,
+        );
+    }
+
+    #[test]
+    fn test_args_format_tojson_filter() {
+        // Llama-style: arguments|tojson
+        let template = r"{{ tool['function']['arguments']|tojson }}";
+        assert_eq!(
+            detect_tool_call_arguments_format(template),
+            ToolCallArgumentsFormat::Dict,
+        );
+    }
+
+    #[test]
+    fn test_args_format_tojson_with_spaces() {
+        // arguments | tojson (with spaces around pipe)
+        let template = r"{{ tool['function']['arguments'] | tojson }}";
+        assert_eq!(
+            detect_tool_call_arguments_format(template),
+            ToolCallArgumentsFormat::Dict,
+        );
+    }
+
+    #[test]
+    fn test_args_format_items_filter() {
+        // Qwen3.5-style: arguments|items
+        let template = r"{%- for args_name, args_value in tool_call.arguments|items %}";
+        assert_eq!(
+            detect_tool_call_arguments_format(template),
+            ToolCallArgumentsFormat::Dict,
+        );
+    }
+
+    #[test]
+    fn test_args_format_plain_string_concat() {
+        // DeepSeek V3.1-style: plain string concatenation, no filter
+        let template = r"tool['function']['arguments'] + '\n'";
+        assert_eq!(
+            detect_tool_call_arguments_format(template),
+            ToolCallArgumentsFormat::String,
+        );
+    }
+
+    #[test]
+    fn test_args_format_deepseek_real_snippet() {
+        // Real DeepSeek V3 template snippet
+        let template = r"'```json' + '\n' + tool['function']['arguments'] + '\n' + '```'";
+        assert_eq!(
+            detect_tool_call_arguments_format(template),
+            ToolCallArgumentsFormat::String,
+        );
+    }
+
+    #[test]
+    fn test_args_format_empty_template() {
+        assert_eq!(
+            detect_tool_call_arguments_format(""),
+            ToolCallArgumentsFormat::Dict,
+        );
     }
 }

--- a/crates/tokenizer/src/chat_template.rs
+++ b/crates/tokenizer/src/chat_template.rs
@@ -134,18 +134,32 @@ fn detect_arguments_format_from_text(template: &str) -> ToolCallArgumentsFormat 
 
     // Pattern 2: Direct dict iteration without pipe filter (Llama 4 style)
     //   {% for param in tool_call.arguments %}  →  iterates over dict keys
-    // We look for "in" followed by something ending in "arguments" then "%}"
-    // This catches: `for X in tool_call.arguments`, `for X in tc.arguments`, etc.
-    if template.contains("in") {
+    // We check that " in " (or " in\t") appears immediately before the
+    // dot-access chain ending in "arguments" (e.g. " in tool_call.arguments").
+    // We scan backwards from each "arguments" occurrence: first skip the
+    // identifier.dot prefix (e.g. "tool_call."), then check for " in ".
+    {
         let mut pos2 = 0;
         while let Some(idx) = template[pos2..].find("arguments") {
             let arg_start = pos2 + idx;
-            // Look backwards from "arguments" for "in " preceded by a variable name and "for "
-            // We just need to verify this "arguments" is preceded by " in " somewhere on the same line
-            let line_start = template[..arg_start].rfind('\n').map_or(0, |p| p + 1);
-            let line_before = &template[line_start..arg_start];
-            if line_before.contains(" in ") && line_before.contains("for ") {
-                return ToolCallArgumentsFormat::Dict;
+            // Walk backwards over the dot-access prefix: identifiers and dots
+            // e.g. "tool_call." in "tool_call.arguments"
+            let prefix = &template.as_bytes()[..arg_start];
+            let mut back = arg_start;
+            while back > 0
+                && (prefix[back - 1].is_ascii_alphanumeric()
+                    || prefix[back - 1] == b'_'
+                    || prefix[back - 1] == b'.')
+            {
+                back -= 1;
+            }
+            // Now check if the chars before the dot-access are " in "
+            // back points to the first char of the dot-access prefix
+            if back >= 4 {
+                let before = &template[back.saturating_sub(4)..back];
+                if before == " in " || before.ends_with(" in ") {
+                    return ToolCallArgumentsFormat::Dict;
+                }
             }
             pos2 = arg_start + "arguments".len();
         }
@@ -978,16 +992,6 @@ mod tests {
     }
 
     #[test]
-    fn test_args_format_deepseek_real_snippet() {
-        // Real DeepSeek V3 template snippet
-        let template = r"'```json' + '\n' + tool['function']['arguments'] + '\n' + '```'";
-        assert_eq!(
-            detect_tool_call_arguments_format(template),
-            ToolCallArgumentsFormat::String,
-        );
-    }
-
-    #[test]
     fn test_args_format_empty_template() {
         assert_eq!(
             detect_tool_call_arguments_format(""),
@@ -1023,6 +1027,18 @@ mod tests {
         assert_eq!(
             detect_tool_call_arguments_format(template),
             ToolCallArgumentsFormat::Dict,
+        );
+    }
+
+    #[test]
+    fn test_args_format_deepseek_single_line_no_false_positive() {
+        // DeepSeek V3.1 template is a single long line. It has:
+        //   {%- for tool in message['tool_calls'] %} ... tool['function']['arguments'] + ...
+        // Pattern 2 must NOT match: the "for ... in ..." loop is over tool_calls, not arguments.
+        let template = "{%- for tool in message['tool_calls'] %}{%- if not ns.is_first %}{%- if message['content'] is none %}{{'<tool_calls_begin>' + tool['function']['name'] + '\\n' + '```json' + '\\n' + tool['function']['arguments'] + '\\n' + '```'}}{%- endif %}{%- endfor %}";
+        assert_eq!(
+            detect_tool_call_arguments_format(template),
+            ToolCallArgumentsFormat::String,
         );
     }
 }

--- a/crates/tokenizer/src/chat_template.rs
+++ b/crates/tokenizer/src/chat_template.rs
@@ -9,7 +9,7 @@ use anyhow::{anyhow, Result};
 use minijinja::{
     context,
     machinery::{
-        ast::{Expr, Stmt},
+        ast::{BinOpKind, Expr, Stmt},
         parse, WhitespaceConfig,
     },
     syntax::SyntaxConfig,
@@ -57,66 +57,20 @@ impl std::fmt::Display for ChatTemplateContentFormat {
 
 /// Detect the tool call arguments format expected by a Jinja2 chat template.
 ///
-/// Inspects the template text for how `arguments` is used:
-/// - If a dict-consuming filter (`|tojson`, `|items`, `|dictsort`, `|tojson(...)`) is applied,
-///   the template expects arguments as dicts → return `Dict`.
-/// - If `arguments` appears in the template without such filters (plain string concatenation),
-///   the template expects arguments as JSON strings → return `String`.
-/// - If `arguments` does not appear at all (no tool support), default to `Dict`
-///   (the Transformers convention).
+/// Uses AST parsing to check if `arguments` is used in a string concatenation
+/// (`+` operator). If so, returns `String`. Otherwise defaults to `Dict`
+/// (the Transformers convention, used by 22+ models).
+///
+/// Only DeepSeek V3/R1 family templates use string concatenation for arguments.
 pub fn detect_tool_call_arguments_format(template: &str) -> ToolCallArgumentsFormat {
     detect_template_formats(template).1
 }
 
-/// Detect both content format and tool call arguments format in a single pass.
-///
-/// The content format detection parses the AST, while the arguments format
-/// detection is a lightweight string scan. Combining them avoids redundant work
-/// when both are needed (e.g., during tokenizer initialization).
+/// Detect both content format and tool call arguments format in a single AST pass.
 pub fn detect_template_formats(
     template: &str,
 ) -> (ChatTemplateContentFormat, ToolCallArgumentsFormat) {
-    let content_format = detect_chat_template_content_format(template);
-    let arguments_format = detect_arguments_format_from_text(template);
-    (content_format, arguments_format)
-}
-
-/// Lightweight string-scan detection of tool call arguments format.
-///
-/// Dict is the Transformers convention and the overwhelming majority of models.
-/// Only DeepSeek V3/R1 family templates use plain string concatenation.
-/// So we detect the string pattern and default to dict.
-fn detect_arguments_format_from_text(template: &str) -> ToolCallArgumentsFormat {
-    // No mention of arguments at all → default to dict
-    if !template.contains("arguments") {
-        return ToolCallArgumentsFormat::Dict;
-    }
-
-    // Detect the string-concat pattern: `arguments` followed (after closing
-    // brackets/quotes/whitespace) by `+` (Jinja string concatenation).
-    // All known DeepSeek templates use: tool['function']['arguments'] + '...'
-    let bytes = template.as_bytes();
-    let mut pos = 0;
-    while let Some(idx) = template[pos..].find("arguments") {
-        let start = pos + idx + "arguments".len();
-        let mut i = start;
-        // Skip closing syntax chars: ] ' " ) } and whitespace
-        while i < bytes.len()
-            && matches!(
-                bytes[i],
-                b']' | b'\'' | b'"' | b')' | b'}' | b' ' | b'\t' | b'\n' | b'\r'
-            )
-        {
-            i += 1;
-        }
-        if i < bytes.len() && bytes[i] == b'+' {
-            return ToolCallArgumentsFormat::String;
-        }
-        pos = start;
-    }
-
-    // Default: dict (Transformers convention, used by Llama, Qwen, GLM, MiniMax, etc.)
-    ToolCallArgumentsFormat::Dict
+    detect_formats_with_ast(template)
 }
 
 /// Detect the content format expected by a Jinja2 chat template
@@ -158,6 +112,8 @@ struct Detector<'a> {
     scope: std::collections::VecDeque<String>,
     scope_set: std::collections::HashSet<String>,
     flags: Flags,
+    /// Whether `arguments` is used in a `+` or `~` concatenation (DeepSeek pattern)
+    args_concat: bool,
 }
 
 impl<'a> Detector<'a> {
@@ -167,12 +123,13 @@ impl<'a> Detector<'a> {
             scope: std::collections::VecDeque::new(),
             scope_set: std::collections::HashSet::new(),
             flags: Flags::default(),
+            args_concat: false,
         }
     }
 
-    fn run(mut self) -> Flags {
+    fn run(mut self) -> (Flags, bool) {
         self.walk_stmt(self.ast);
-        self.flags
+        (self.flags, self.args_concat)
     }
 
     fn push_scope(&mut self, var: String) {
@@ -237,9 +194,43 @@ impl<'a> Detector<'a> {
         }
     }
 
+    /// Check if an expression accesses "arguments" via `.arguments` or `['arguments']`
+    fn accesses_arguments(expr: &Expr) -> bool {
+        match expr {
+            Expr::GetAttr(g) => g.name == "arguments",
+            Expr::GetItem(g) => Self::is_const_str(&g.subscript_expr, "arguments"),
+            _ => false,
+        }
+    }
+
+    /// Recursively check if any sub-expression in a tree accesses "arguments"
+    fn tree_accesses_arguments(expr: &Expr) -> bool {
+        if Self::accesses_arguments(expr) {
+            return true;
+        }
+        match expr {
+            Expr::BinOp(op) => {
+                Self::tree_accesses_arguments(&op.left) || Self::tree_accesses_arguments(&op.right)
+            }
+            Expr::Filter(f) => f
+                .expr
+                .as_ref()
+                .is_some_and(|e| Self::tree_accesses_arguments(e)),
+            Expr::GetAttr(g) => Self::tree_accesses_arguments(&g.expr),
+            Expr::GetItem(g) => Self::tree_accesses_arguments(&g.expr),
+            _ => false,
+        }
+    }
+
+    /// Check if a BinOp uses `+` or `~` with an `arguments` access on either side
+    fn is_args_concat(op: &minijinja::machinery::ast::BinOp) -> bool {
+        matches!(op.op, BinOpKind::Add | BinOpKind::Concat)
+            && (Self::tree_accesses_arguments(&op.left) || Self::tree_accesses_arguments(&op.right))
+    }
+
     fn walk_stmt(&mut self, stmt: &Stmt) {
-        // Early exit if we've already detected an OpenAI pattern
-        if self.flags.any() {
+        // Early exit only when both detections are complete
+        if self.flags.any() && self.args_concat {
             return;
         }
 
@@ -292,6 +283,9 @@ impl<'a> Detector<'a> {
             }
             Stmt::EmitExpr(e) => {
                 self.inspect_expr_for_structure(&e.expr);
+                if !self.args_concat {
+                    self.check_expr_for_args_concat(&e.expr);
+                }
             }
             // {% set content = message.content %}
             Stmt::Set(s) => {
@@ -366,6 +360,25 @@ impl<'a> Detector<'a> {
         }
     }
 
+    /// Recursively check if an expression contains `arguments` used in `+` or `~` concat.
+    fn check_expr_for_args_concat(&mut self, expr: &Expr) {
+        if self.args_concat {
+            return;
+        }
+        match expr {
+            Expr::BinOp(op) => {
+                if Self::is_args_concat(op) {
+                    self.args_concat = true;
+                } else {
+                    self.check_expr_for_args_concat(&op.left);
+                    self.check_expr_for_args_concat(&op.right);
+                }
+            }
+            Expr::Const(_) => {}
+            _ => {}
+        }
+    }
+
     fn scan_macro_body(body: &[Stmt], has_type_check: &mut bool, has_loop: &mut bool) {
         for s in body {
             if *has_type_check && *has_loop {
@@ -396,6 +409,11 @@ impl<'a> Detector<'a> {
 /// AST-based detection using minijinja's unstable machinery
 /// Single-pass detector with scope tracking
 fn detect_format_with_ast(template: &str) -> ChatTemplateContentFormat {
+    detect_formats_with_ast(template).0
+}
+
+/// Parse the template AST once and detect both content format and arguments format.
+fn detect_formats_with_ast(template: &str) -> (ChatTemplateContentFormat, ToolCallArgumentsFormat) {
     let ast = match parse(
         template,
         "template",
@@ -403,15 +421,55 @@ fn detect_format_with_ast(template: &str) -> ChatTemplateContentFormat {
         WhitespaceConfig::default(),
     ) {
         Ok(ast) => ast,
-        Err(_) => return ChatTemplateContentFormat::String,
+        Err(_) => {
+            // AST parse failed (e.g. incomplete template snippet).
+            // Fall back to string scan for arguments format.
+            return (
+                ChatTemplateContentFormat::String,
+                detect_arguments_format_fallback(template),
+            );
+        }
     };
 
-    let flags = Detector::new(&ast).run();
-    if flags.any() {
+    let (flags, args_concat) = Detector::new(&ast).run();
+
+    let content_format = if flags.any() {
         ChatTemplateContentFormat::OpenAI
     } else {
         ChatTemplateContentFormat::String
+    };
+
+    let arguments_format = if args_concat {
+        ToolCallArgumentsFormat::String
+    } else {
+        ToolCallArgumentsFormat::Dict
+    };
+
+    (content_format, arguments_format)
+}
+
+/// Fallback string-scan for arguments format when AST parsing fails.
+/// Only used when the template cannot be parsed (rare).
+fn detect_arguments_format_fallback(template: &str) -> ToolCallArgumentsFormat {
+    if !template.contains("arguments") {
+        return ToolCallArgumentsFormat::Dict;
     }
+    let bytes = template.as_bytes();
+    let mut pos = 0;
+    while let Some(idx) = template[pos..].find("arguments") {
+        let start = pos + idx + "arguments".len();
+        let mut i = start;
+        while i < bytes.len()
+            && matches!(bytes[i], b']' | b'\'' | b'"' | b' ' | b'\t' | b'\n' | b'\r')
+        {
+            i += 1;
+        }
+        if i < bytes.len() && bytes[i] == b'+' {
+            return ToolCallArgumentsFormat::String;
+        }
+        pos = start;
+    }
+    ToolCallArgumentsFormat::Dict
 }
 
 /// Parameters for chat template application
@@ -894,9 +952,19 @@ mod tests {
     }
 
     #[test]
-    fn test_args_format_string_concat_real_deepseek() {
-        // Real DeepSeek template snippet: arguments used with + string concat
-        let template = "{%- for tool in message['tool_calls'] %}{%- if not ns.is_first %}{%- if message['content'] is none %}{{'<tool_calls_begin>' + tool['function']['name'] + '\\n' + '```json' + '\\n' + tool['function']['arguments'] + '\\n' + '```'}}{%- endif %}{%- endfor %}";
+    fn test_args_format_string_concat_ast() {
+        // Complete parseable DeepSeek-style template: arguments in + concat (AST path)
+        let template = "{% for message in messages %}{% for tool in message['tool_calls'] %}{{ tool['function']['arguments'] + '\\n' }}{% endfor %}{% endfor %}";
+        assert_eq!(
+            detect_tool_call_arguments_format(template),
+            ToolCallArgumentsFormat::String,
+        );
+    }
+
+    #[test]
+    fn test_args_format_string_concat_fallback() {
+        // Incomplete template snippet that fails AST parse → exercises fallback
+        let template = "{%- for tool in message['tool_calls'] %}{{'```json' + '\\n' + tool['function']['arguments'] + '\\n' + '```'}}{%- endfor %}";
         assert_eq!(
             detect_tool_call_arguments_format(template),
             ToolCallArgumentsFormat::String,
@@ -905,8 +973,8 @@ mod tests {
 
     #[test]
     fn test_args_format_dict_tojson() {
-        // Llama/Qwen style: arguments|tojson → defaults to dict (no + concat)
-        let template = r"{{ tool['function']['arguments']|tojson }}";
+        // Llama/Qwen style: arguments|tojson (AST path, no + concat)
+        let template = "{% for message in messages %}{% for tool in message['tool_calls'] %}{{ tool['function']['arguments']|tojson }}{% endfor %}{% endfor %}";
         assert_eq!(
             detect_tool_call_arguments_format(template),
             ToolCallArgumentsFormat::Dict,
@@ -915,9 +983,8 @@ mod tests {
 
     #[test]
     fn test_args_format_dict_iteration() {
-        // Llama 4 / GLM / MiniMax: dict iteration → defaults to dict (no + concat)
-        let template =
-            r"{%- for param in tool_call.arguments %}{{ tool_call.arguments[param] }}{%- endfor %}";
+        // Llama 4 style: direct dict iteration (AST path, no + concat)
+        let template = "{% for message in messages %}{% for param in message.arguments %}{{ message.arguments[param] }}{% endfor %}{% endfor %}";
         assert_eq!(
             detect_tool_call_arguments_format(template),
             ToolCallArgumentsFormat::Dict,

--- a/crates/tokenizer/src/chat_template.rs
+++ b/crates/tokenizer/src/chat_template.rs
@@ -132,7 +132,34 @@ fn detect_arguments_format_from_text(template: &str) -> ToolCallArgumentsFormat 
         pos = start;
     }
 
-    // Template mentions `arguments` but doesn't use dict filters → string concat style
+    // Pattern 2: Direct dict iteration without pipe filter (Llama 4 style)
+    //   {% for param in tool_call.arguments %}  →  iterates over dict keys
+    // We look for "in" followed by something ending in "arguments" then "%}"
+    // This catches: `for X in tool_call.arguments`, `for X in tc.arguments`, etc.
+    if template.contains("in") {
+        let mut pos2 = 0;
+        while let Some(idx) = template[pos2..].find("arguments") {
+            let arg_start = pos2 + idx;
+            // Look backwards from "arguments" for "in " preceded by a variable name and "for "
+            // We just need to verify this "arguments" is preceded by " in " somewhere on the same line
+            let line_start = template[..arg_start].rfind('\n').map_or(0, |p| p + 1);
+            let line_before = &template[line_start..arg_start];
+            if line_before.contains(" in ") && line_before.contains("for ") {
+                return ToolCallArgumentsFormat::Dict;
+            }
+            pos2 = arg_start + "arguments".len();
+        }
+    }
+
+    // Pattern 3: Alias-then-dict-method pattern (GLM, MiniMax style)
+    //   {% set _args = tc.arguments %} ... _args.items()
+    // If the template mentions both "arguments" and ".items()" it's treating
+    // arguments as a dict through an intermediate variable.
+    if template.contains(".items()") {
+        return ToolCallArgumentsFormat::Dict;
+    }
+
+    // Template mentions `arguments` but doesn't use dict filters or iteration → string concat
     ToolCallArgumentsFormat::String
 }
 
@@ -964,6 +991,37 @@ mod tests {
     fn test_args_format_empty_template() {
         assert_eq!(
             detect_tool_call_arguments_format(""),
+            ToolCallArgumentsFormat::Dict,
+        );
+    }
+
+    #[test]
+    fn test_args_format_direct_dict_iteration_llama4() {
+        // Llama 4 style: iterates directly over dict keys, no |items filter
+        let template =
+            r"{%- for param in tool_call.arguments %}{{ tool_call.arguments[param] }}{%- endfor %}";
+        assert_eq!(
+            detect_tool_call_arguments_format(template),
+            ToolCallArgumentsFormat::Dict,
+        );
+    }
+
+    #[test]
+    fn test_args_format_alias_then_items_glm() {
+        // GLM-4.6/minimax-m2 style: alias to local var, then .items()
+        let template = r"{% set _args = tc.arguments %}{% for k, v in _args.items() %}{{ k }}={{ v }}{% endfor %}";
+        assert_eq!(
+            detect_tool_call_arguments_format(template),
+            ToolCallArgumentsFormat::Dict,
+        );
+    }
+
+    #[test]
+    fn test_args_format_is_string_check_qwen3() {
+        // Qwen3 style: checks if arguments is string, falls back to |tojson
+        let template = r"{%- if tool_call.arguments is string %}{{ tool_call.arguments }}{%- else %}{{ tool_call.arguments | tojson }}{%- endif %}";
+        assert_eq!(
+            detect_tool_call_arguments_format(template),
             ToolCallArgumentsFormat::Dict,
         );
     }

--- a/crates/tokenizer/src/chat_template.rs
+++ b/crates/tokenizer/src/chat_template.rs
@@ -894,30 +894,12 @@ mod tests {
     }
 
     #[test]
-    fn test_args_format_string_concat_deepseek() {
-        // DeepSeek V3.1-style: plain string concatenation
-        let template = r"tool['function']['arguments'] + '\n'";
-        assert_eq!(
-            detect_tool_call_arguments_format(template),
-            ToolCallArgumentsFormat::String,
-        );
-    }
-
-    #[test]
     fn test_args_format_string_concat_real_deepseek() {
-        // Real DeepSeek single-line template snippet with for-loop and arguments + concat
+        // Real DeepSeek template snippet: arguments used with + string concat
         let template = "{%- for tool in message['tool_calls'] %}{%- if not ns.is_first %}{%- if message['content'] is none %}{{'<tool_calls_begin>' + tool['function']['name'] + '\\n' + '```json' + '\\n' + tool['function']['arguments'] + '\\n' + '```'}}{%- endif %}{%- endfor %}";
         assert_eq!(
             detect_tool_call_arguments_format(template),
             ToolCallArgumentsFormat::String,
-        );
-    }
-
-    #[test]
-    fn test_args_format_empty_template() {
-        assert_eq!(
-            detect_tool_call_arguments_format(""),
-            ToolCallArgumentsFormat::Dict,
         );
     }
 

--- a/crates/tokenizer/src/huggingface.rs
+++ b/crates/tokenizer/src/huggingface.rs
@@ -10,7 +10,7 @@ use tracing::debug;
 use crate::{
     chat_template::{
         load_chat_template_from_file, ChatTemplateContentFormat, ChatTemplateParams,
-        ChatTemplateState,
+        ChatTemplateState, ToolCallArgumentsFormat,
     },
     traits::{Decoder, Encoder, Encoding, SpecialTokens, TokenIdType, Tokenizer as TokenizerTrait},
 };
@@ -371,6 +371,10 @@ impl TokenizerTrait for HuggingFaceTokenizer {
 
     fn chat_template_content_format(&self) -> ChatTemplateContentFormat {
         self.chat_template.content_format()
+    }
+
+    fn tool_call_arguments_format(&self) -> ToolCallArgumentsFormat {
+        self.chat_template.arguments_format()
     }
 
     fn set_chat_template(&mut self, template: String) -> Result<()> {

--- a/crates/tokenizer/src/tiktoken.rs
+++ b/crates/tokenizer/src/tiktoken.rs
@@ -11,7 +11,7 @@ use tiktoken_rs::{cl100k_base, p50k_base, p50k_edit, r50k_base, CoreBPE};
 use crate::{
     chat_template::{
         load_chat_template_from_file, ChatTemplateContentFormat, ChatTemplateParams,
-        ChatTemplateState,
+        ChatTemplateState, ToolCallArgumentsFormat,
     },
     factory::discover_chat_template_in_dir,
     traits::{Decoder, Encoder, Encoding, SpecialTokens, TokenIdType, Tokenizer as TokenizerTrait},
@@ -510,6 +510,10 @@ impl TokenizerTrait for TiktokenTokenizer {
 
     fn chat_template_content_format(&self) -> ChatTemplateContentFormat {
         self.chat_template.content_format()
+    }
+
+    fn tool_call_arguments_format(&self) -> ToolCallArgumentsFormat {
+        self.chat_template.arguments_format()
     }
 
     fn set_chat_template(&mut self, template: String) -> Result<()> {

--- a/crates/tokenizer/src/traits.rs
+++ b/crates/tokenizer/src/traits.rs
@@ -5,7 +5,9 @@ use std::{
 
 use anyhow::Result;
 
-use crate::chat_template::{ChatTemplateContentFormat, ChatTemplateParams};
+use crate::chat_template::{
+    ChatTemplateContentFormat, ChatTemplateParams, ToolCallArgumentsFormat,
+};
 
 /// Type alias for token IDs
 pub type TokenIdType = u32;
@@ -95,6 +97,11 @@ pub trait Tokenizer: Encoder + Decoder {
     /// Get the content format expected by the chat template.
     fn chat_template_content_format(&self) -> ChatTemplateContentFormat {
         ChatTemplateContentFormat::default()
+    }
+
+    /// Get the tool call arguments format expected by the chat template.
+    fn tool_call_arguments_format(&self) -> ToolCallArgumentsFormat {
+        ToolCallArgumentsFormat::default()
     }
 
     /// Set or override the chat template.

--- a/model_gateway/src/routers/grpc/utils/chat_utils.rs
+++ b/model_gateway/src/routers/grpc/utils/chat_utils.rs
@@ -5,7 +5,7 @@ use std::{collections::HashMap, io, sync::Arc};
 use axum::response::Response;
 use bytes::Bytes;
 use llm_tokenizer::{
-    chat_template::{ChatTemplateContentFormat, ChatTemplateParams},
+    chat_template::{ChatTemplateContentFormat, ChatTemplateParams, ToolCallArgumentsFormat},
     stop::StopSequenceDecoderBuilder,
     traits::Tokenizer,
     StopSequenceDecoder,
@@ -388,8 +388,11 @@ pub fn process_chat_messages(
         let mut transformed_messages =
             process_content_format(&request.messages, content_format, image_placeholder)?;
 
-        // Process tool call arguments in assistant messages
-        process_tool_call_arguments(&mut transformed_messages)?;
+        // Process tool call arguments in assistant messages (string→dict)
+        // only when the chat template expects dict arguments (uses |tojson etc.)
+        if tokenizer.tool_call_arguments_format() == ToolCallArgumentsFormat::Dict {
+            process_tool_call_arguments(&mut transformed_messages)?;
+        }
 
         // Convert tools to JSON values for template processing
         let tools_json: Option<Vec<Value>> = request

--- a/model_gateway/src/routers/grpc/utils/message_utils.rs
+++ b/model_gateway/src/routers/grpc/utils/message_utils.rs
@@ -8,7 +8,7 @@
 use std::collections::HashMap;
 
 use llm_tokenizer::{
-    chat_template::{ChatTemplateContentFormat, ChatTemplateParams},
+    chat_template::{ChatTemplateContentFormat, ChatTemplateParams, ToolCallArgumentsFormat},
     traits::Tokenizer,
 };
 use openai_protocol::{
@@ -57,8 +57,11 @@ pub fn process_messages(
         transformed_messages.insert(0, json!({"role": "system", "content": system_text}));
     }
 
-    // Step 3: Process tool call arguments in assistant messages (reuse from chat_utils)
-    chat_utils::process_tool_call_arguments(&mut transformed_messages)?;
+    // Step 3: Process tool call arguments in assistant messages (string→dict)
+    // only when the chat template expects dict arguments (uses |tojson etc.)
+    if tokenizer.tool_call_arguments_format() == ToolCallArgumentsFormat::Dict {
+        chat_utils::process_tool_call_arguments(&mut transformed_messages)?;
+    }
 
     // Step 4: Serialize tools to JSON values for template processing
     let tools_json: Option<Vec<Value>> = chat_tools


### PR DESCRIPTION
## Description

### Problem

`process_tool_call_arguments()` unconditionally converts tool_call arguments from JSON string to dict before passing them to the chat template. This follows the [Transformers/HuggingFace guidance](https://github.com/vllm-project/vllm/blob/a26e8dc7f/vllm/entrypoints/chat_utils.py#L1555-L1558) that templates should expect dict arguments.

However, DeepSeek V3/R1 family templates use plain string concatenation for arguments (e.g. `tool['function']['arguments'] + '\n'`), which crashes when given a dict:

```
can only concatenate str (not "dict") to str
```

vLLM has the same issue and works around it by shipping [override templates](https://github.com/vllm-project/vllm/blob/main/examples/tool_chat_template_deepseekr1.jinja) that add `|tojson`. This requires users to manually pass `--chat-template`.

### Solution

Detect the expected arguments format from the chat template at tokenizer init time and conditionally apply `process_tool_call_arguments()`.

An exhaustive audit of 25+ model chat templates across `/raid/models`, HuggingFace, and e2e test models found:
- **22 models** expect dict arguments (Llama, Qwen, GLM, MiniMax, Nemotron, Kimi-K2, gpt-oss, etc.)
- **3 models** expect string arguments (all DeepSeek: V3-0324, R1-0528, R1-Distill)

Since dict is the overwhelming majority, the detection is flipped: **detect the string-concat pattern** (`arguments` followed by `+`) and default to dict. This is a ~20-line O(n) string scan, no regex or AST parsing needed.

## Changes

- `crates/tokenizer/src/chat_template.rs`: Add `ToolCallArgumentsFormat` enum (`Dict` | `String`) and `detect_tool_call_arguments_format()` detection function. Integrate into `ChatTemplateState` alongside existing content format detection.
- `crates/tokenizer/src/traits.rs`: Add `tool_call_arguments_format()` to `Tokenizer` trait.
- `crates/tokenizer/src/huggingface.rs`, `tiktoken.rs`, `cache/mod.rs`: Implement the new trait method.
- `model_gateway/src/routers/grpc/utils/chat_utils.rs`: Make `process_tool_call_arguments()` conditional on `ToolCallArgumentsFormat::Dict`.
- `model_gateway/src/routers/grpc/utils/message_utils.rs`: Same conditional for Messages API path.

## Test Plan

- 4 unit tests covering: no arguments keyword (→Dict), real DeepSeek template snippet (→String), tojson filter (→Dict), direct dict iteration (→Dict).
- Validated detection against all models in `/raid/models` and HuggingFace (DeepSeek-V3-0324, V3.1, R1-0528, R1-Distill-Qwen-7B, R1-Distill-Qwen-32B all correctly detected as String).

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detect and support two tool-call argument formats in chat templates: dict and string.
  * Tokenizers now expose the detected tool-call argument format.

* **Improvements**
  * Message processing now conditionally parses tool-call arguments only when the detected format requires it.

* **Tests**
  * Added unit tests covering format detection and fallback behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->