### PR TITLE
feat(mlx): add MlxEngine gRPC proto and Rust client

### DIFF
--- a/crates/grpc_client/build.rs
+++ b/crates/grpc_client/build.rs
@@ -4,6 +4,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo:rerun-if-changed=proto/sglang_scheduler.proto");
     println!("cargo:rerun-if-changed=proto/vllm_engine.proto");
     println!("cargo:rerun-if-changed=proto/trtllm_service.proto");
+    println!("cargo:rerun-if-changed=proto/mlx_engine.proto");
 
     // Pass 1: compile shared message types (no gRPC service generation)
     tonic_prost_build::configure()
@@ -28,12 +29,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "trtllm.GetServerInfoResponse",
             "#[derive(serde::Serialize)]",
         )
+        .type_attribute(
+            "mlx.grpc.engine.GetServerInfoResponse",
+            "#[derive(serde::Serialize)]",
+        )
         .protoc_arg("--experimental_allow_proto3_optional")
         .compile_protos(
             &[
                 "proto/sglang_scheduler.proto",
                 "proto/vllm_engine.proto",
                 "proto/trtllm_service.proto",
+                "proto/mlx_engine.proto",
             ],
             &["proto"],
         )?;

--- a/crates/grpc_client/proto/mlx_engine.proto
+++ b/crates/grpc_client/proto/mlx_engine.proto
@@ -1,0 +1,116 @@
+syntax = "proto3";
+package mlx.grpc.engine;
+
+import "common.proto";
+
+service MlxEngine {
+  rpc Generate(GenerateRequest) returns (stream GenerateResponse);
+  rpc HealthCheck(HealthCheckRequest) returns (HealthCheckResponse);
+  rpc Abort(AbortRequest) returns (AbortResponse);
+  rpc GetModelInfo(GetModelInfoRequest) returns (GetModelInfoResponse);
+  rpc GetServerInfo(GetServerInfoRequest) returns (GetServerInfoResponse);
+  rpc GetTokenizer(smg.grpc.common.GetTokenizerRequest)
+      returns (stream smg.grpc.common.GetTokenizerChunk);
+}
+
+message GenerateRequest {
+  string request_id = 1;
+  oneof input {
+    TokenizedInput tokenized = 2;
+    string text = 3;
+  }
+  SamplingParams sampling_params = 4;
+  bool stream = 5;
+}
+
+message TokenizedInput {
+  string original_text = 1;
+  repeated uint32 input_ids = 2;
+}
+
+message SamplingParams {
+  optional float temperature = 1;
+  float top_p = 2;
+  uint32 top_k = 3;
+  float min_p = 4;
+  float repetition_penalty = 5;
+  float frequency_penalty = 6;
+  float presence_penalty = 7;
+  map<int32, float> logit_bias = 8;
+  optional uint32 max_tokens = 9;
+  repeated uint32 stop_token_ids = 10;
+  bool ignore_eos = 11;
+  optional int32 logprobs = 12;
+  optional int32 seed = 13;
+}
+
+message GenerateResponse {
+  oneof response {
+    GenerateStreamChunk chunk = 1;
+    GenerateComplete complete = 2;
+  }
+}
+
+message GenerateStreamChunk {
+  repeated uint32 token_ids = 1;
+  uint32 prompt_tokens = 2;
+  uint32 completion_tokens = 3;
+  uint32 cached_tokens = 4;
+  OutputLogProbs output_logprobs = 5;
+  uint32 index = 6;
+}
+
+message GenerateComplete {
+  repeated uint32 output_ids = 1;
+  string finish_reason = 2;
+  uint32 prompt_tokens = 3;
+  uint32 completion_tokens = 4;
+  uint32 cached_tokens = 5;
+  OutputLogProbs output_logprobs = 6;
+  uint32 index = 7;
+  optional uint32 matched_stop_token_id = 8;
+}
+
+message OutputLogProbs {
+  repeated float token_logprobs = 1;
+  repeated uint32 token_ids = 2;
+  repeated TopLogProbs top_logprobs = 3;
+}
+
+message TopLogProbs {
+  repeated float values = 1;
+  repeated uint32 token_ids = 2;
+}
+
+message HealthCheckRequest {}
+message HealthCheckResponse {
+  bool healthy = 1;
+  string message = 2;
+}
+
+message AbortRequest {
+  repeated string request_ids = 1;
+}
+message AbortResponse {}
+
+message GetModelInfoRequest {}
+message GetModelInfoResponse {
+  string model_path = 1;
+  bool is_generation = 2;
+  uint32 max_context_length = 3;
+  uint32 vocab_size = 4;
+  string served_model_name = 5;
+  string model_type = 6;
+  repeated string architectures = 7;
+  repeated uint32 eos_token_ids = 8;
+  uint32 pad_token_id = 9;
+  uint32 bos_token_id = 10;
+  uint32 max_req_input_len = 11;
+}
+
+message GetServerInfoRequest {}
+message GetServerInfoResponse {
+  string server_type = 1;
+  uint32 active_requests = 2;
+  double uptime_seconds = 3;
+}

--- a/crates/grpc_client/src/lib.rs
+++ b/crates/grpc_client/src/lib.rs
@@ -1,7 +1,7 @@
-//! gRPC clients for SGLang, vLLM, and TensorRT-LLM backends
+//! gRPC clients for SGLang, vLLM, TensorRT-LLM, and MLX backends
 //!
 //! This crate provides gRPC client implementations for communicating with
-//! SGLang scheduler, vLLM engine, and TensorRT-LLM engine backends.
+//! SGLang scheduler, vLLM engine, TensorRT-LLM engine, and MLX engine backends.
 
 pub mod common_proto {
     #![allow(clippy::all, clippy::absolute_paths, unused_qualifications)]
@@ -11,6 +11,7 @@ pub mod sglang_scheduler;
 pub mod tokenizer_bundle;
 pub mod trtllm_service;
 pub mod vllm_engine;
+pub mod mlx_engine;
 
 // Re-export clients
 use std::sync::Arc;
@@ -19,6 +20,7 @@ pub use sglang_scheduler::{proto as sglang_proto, SglangSchedulerClient};
 use tonic::metadata::MetadataMap;
 pub use trtllm_service::{proto as trtllm_proto, TrtllmServiceClient};
 pub use vllm_engine::{proto as vllm_proto, VllmEngineClient};
+pub use mlx_engine::{proto as mlx_proto, MlxEngineClient};
 
 /// Shared `get_tokenizer()` implementation for all engine clients.
 ///

--- a/crates/grpc_client/src/lib.rs
+++ b/crates/grpc_client/src/lib.rs
@@ -7,20 +7,20 @@ pub mod common_proto {
     #![allow(clippy::all, clippy::absolute_paths, unused_qualifications)]
     tonic::include_proto!("smg.grpc.common");
 }
+pub mod mlx_engine;
 pub mod sglang_scheduler;
 pub mod tokenizer_bundle;
 pub mod trtllm_service;
 pub mod vllm_engine;
-pub mod mlx_engine;
 
 // Re-export clients
 use std::sync::Arc;
 
+pub use mlx_engine::{proto as mlx_proto, MlxEngineClient};
 pub use sglang_scheduler::{proto as sglang_proto, SglangSchedulerClient};
 use tonic::metadata::MetadataMap;
 pub use trtllm_service::{proto as trtllm_proto, TrtllmServiceClient};
 pub use vllm_engine::{proto as vllm_proto, VllmEngineClient};
-pub use mlx_engine::{proto as mlx_proto, MlxEngineClient};
 
 /// Shared `get_tokenizer()` implementation for all engine clients.
 ///

--- a/crates/grpc_client/src/mlx_engine.rs
+++ b/crates/grpc_client/src/mlx_engine.rs
@@ -254,6 +254,15 @@ impl MlxEngineClient {
                 "MLX backend does not support response_format (structured outputs)".to_string(),
             );
         }
+        // MLX proto only supports stop_token_ids, not string stop sequences
+        if let Some(ref stop) = body.stop {
+            if !stop.is_empty() {
+                return Err(
+                    "MLX backend does not support string stop sequences (only stop_token_ids)"
+                        .to_string(),
+                );
+            }
+        }
 
         let sampling_params = Self::build_sampling_params_from_chat(body)?;
 
@@ -282,6 +291,14 @@ impl MlxEngineClient {
         original_text: String,
         token_ids: Vec<u32>,
     ) -> Result<proto::GenerateRequest, String> {
+        if let Some(ref stop) = body.stop {
+            if !stop.is_empty() {
+                return Err(
+                    "MLX backend does not support string stop sequences (only stop_token_ids)"
+                        .to_string(),
+                );
+            }
+        }
         let sampling_params = Self::build_sampling_params_from_completion(body)?;
 
         Ok(proto::GenerateRequest {
@@ -336,6 +353,16 @@ impl MlxEngineClient {
         original_text: Option<String>,
         token_ids: Vec<u32>,
     ) -> Result<proto::GenerateRequest, String> {
+        if let Some(ref sp) = body.sampling_params {
+            if let Some(ref stop) = sp.stop {
+                if !stop.is_empty() {
+                    return Err(
+                        "MLX backend does not support string stop sequences (only stop_token_ids)"
+                            .to_string(),
+                    );
+                }
+            }
+        }
         let sampling_params =
             Self::build_sampling_params_from_plain(body.sampling_params.as_ref())?;
 
@@ -458,6 +485,7 @@ impl MlxEngineClient {
         let mut sampling = proto::SamplingParams {
             temperature: Some(1.0),
             top_p: 1.0,
+            repetition_penalty: 1.0, // 1.0 = no penalty
             ..Default::default()
         };
 

--- a/crates/grpc_client/src/mlx_engine.rs
+++ b/crates/grpc_client/src/mlx_engine.rs
@@ -410,7 +410,7 @@ impl MlxEngineClient {
             ignore_eos: request.ignore_eos,
             logprobs,
             logit_bias: convert_logit_bias(&request.logit_bias),
-            seed: request.seed.map(|s| s as i32),
+            seed: request.seed.and_then(|s| i32::try_from(s).ok()),
         })
     }
 
@@ -432,7 +432,7 @@ impl MlxEngineClient {
             ignore_eos: request.ignore_eos,
             logprobs,
             logit_bias: convert_logit_bias(&request.logit_bias),
-            seed: request.seed.map(|s| s as i32),
+            seed: request.seed.and_then(|s| i32::try_from(s).ok()),
         })
     }
 
@@ -444,6 +444,7 @@ impl MlxEngineClient {
             top_p: request.top_p.unwrap_or(1.0) as f32,
             top_k: request.top_k.unwrap_or(0),
             max_tokens: Some(request.max_tokens),
+            repetition_penalty: 1.0, // 1.0 = no penalty (0.0 would penalize everything)
             ..Default::default()
         })
     }
@@ -492,7 +493,7 @@ impl MlxEngineClient {
             sampling.max_tokens = Some(max_new_tokens);
         }
         if let Some(seed) = p.sampling_seed {
-            sampling.seed = Some(seed as i32);
+            sampling.seed = i32::try_from(seed).ok();
         }
 
         Ok(sampling)
@@ -506,7 +507,7 @@ impl MlxEngineClient {
             top_p: request.top_p.unwrap_or(1.0),
             top_k: 0,
             min_p: 0.0,
-            repetition_penalty: 0.0,
+            repetition_penalty: 1.0, // 1.0 = no penalty
             frequency_penalty: 0.0,
             presence_penalty: 0.0,
             logit_bias: Default::default(),

--- a/crates/grpc_client/src/mlx_engine.rs
+++ b/crates/grpc_client/src/mlx_engine.rs
@@ -109,10 +109,6 @@ pub struct MlxEngineClient {
     trace_injector: BoxedTraceInjector,
 }
 
-#[expect(
-    clippy::unnecessary_wraps,
-    reason = "Result return kept for API consistency with other backends"
-)]
 impl MlxEngineClient {
     /// Create a new client and connect to the MLX server
     pub async fn connect(endpoint: &str) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
@@ -264,7 +260,7 @@ impl MlxEngineClient {
             }
         }
 
-        let sampling_params = Self::build_sampling_params_from_chat(body)?;
+        let sampling_params = Self::build_sampling_params_from_chat(body);
 
         Ok(proto::GenerateRequest {
             request_id,
@@ -299,7 +295,7 @@ impl MlxEngineClient {
                 );
             }
         }
-        let sampling_params = Self::build_sampling_params_from_completion(body)?;
+        let sampling_params = Self::build_sampling_params_from_completion(body);
 
         Ok(proto::GenerateRequest {
             request_id,
@@ -319,6 +315,10 @@ impl MlxEngineClient {
         clippy::unused_self,
         reason = "method receiver kept for consistent public API across gRPC backends"
     )]
+    #[expect(
+        clippy::unnecessary_wraps,
+        reason = "Result kept for consistent public API across gRPC backends"
+    )]
     pub fn build_generate_request_from_messages(
         &self,
         request_id: String,
@@ -326,7 +326,7 @@ impl MlxEngineClient {
         processed_text: String,
         token_ids: Vec<u32>,
     ) -> Result<proto::GenerateRequest, String> {
-        let sampling_params = Self::build_sampling_params_from_messages(body)?;
+        let sampling_params = Self::build_sampling_params_from_messages(body);
 
         Ok(proto::GenerateRequest {
             request_id,
@@ -363,8 +363,7 @@ impl MlxEngineClient {
                 }
             }
         }
-        let sampling_params =
-            Self::build_sampling_params_from_plain(body.sampling_params.as_ref())?;
+        let sampling_params = Self::build_sampling_params_from_plain(body.sampling_params.as_ref());
 
         Ok(proto::GenerateRequest {
             request_id,
@@ -400,7 +399,7 @@ impl MlxEngineClient {
             ));
         }
 
-        let sampling_params = Self::build_sampling_params_from_responses(body)?;
+        let sampling_params = Self::build_sampling_params_from_responses(body);
 
         Ok(proto::GenerateRequest {
             request_id,
@@ -418,16 +417,14 @@ impl MlxEngineClient {
     // ── Private sampling param builders ─────────────────────────────────
 
     #[expect(deprecated, reason = "seed is legacy but still forwarded to backends")]
-    fn build_sampling_params_from_chat(
-        request: &ChatCompletionRequest,
-    ) -> Result<proto::SamplingParams, String> {
+    fn build_sampling_params_from_chat(request: &ChatCompletionRequest) -> proto::SamplingParams {
         let logprobs = if request.logprobs {
             Some(request.top_logprobs.unwrap_or(1).min(20) as i32)
         } else {
             None
         };
 
-        Ok(proto::SamplingParams {
+        proto::SamplingParams {
             temperature: request.temperature,
             top_p: request.top_p.unwrap_or(1.0),
             top_k: request.top_k.map(|v| v.max(0) as u32).unwrap_or(0),
@@ -441,15 +438,13 @@ impl MlxEngineClient {
             logprobs,
             logit_bias: convert_logit_bias(request.logit_bias.as_ref()),
             seed: request.seed.and_then(|s| i32::try_from(s).ok()),
-        })
+        }
     }
 
-    fn build_sampling_params_from_completion(
-        request: &CompletionRequest,
-    ) -> Result<proto::SamplingParams, String> {
+    fn build_sampling_params_from_completion(request: &CompletionRequest) -> proto::SamplingParams {
         let logprobs = request.logprobs.map(|v| v.min(5) as i32);
 
-        Ok(proto::SamplingParams {
+        proto::SamplingParams {
             temperature: request.temperature,
             top_p: request.top_p.unwrap_or(1.0),
             top_k: request.top_k.map(|v| v.max(0) as u32).unwrap_or(0),
@@ -463,25 +458,25 @@ impl MlxEngineClient {
             logprobs,
             logit_bias: convert_logit_bias(request.logit_bias.as_ref()),
             seed: request.seed.and_then(|s| i32::try_from(s).ok()),
-        })
+        }
     }
 
     fn build_sampling_params_from_messages(
         request: &CreateMessageRequest,
-    ) -> Result<proto::SamplingParams, String> {
-        Ok(proto::SamplingParams {
+    ) -> proto::SamplingParams {
+        proto::SamplingParams {
             temperature: Some(request.temperature.unwrap_or(1.0) as f32),
             top_p: request.top_p.unwrap_or(1.0) as f32,
             top_k: request.top_k.unwrap_or(0),
             max_tokens: Some(request.max_tokens),
             repetition_penalty: 1.0, // 1.0 = no penalty (0.0 would penalize everything)
             ..Default::default()
-        })
+        }
     }
 
     fn build_sampling_params_from_plain(
         params: Option<&GenerateSamplingParams>,
-    ) -> Result<proto::SamplingParams, String> {
+    ) -> proto::SamplingParams {
         let mut sampling = proto::SamplingParams {
             temperature: Some(1.0),
             top_p: 1.0,
@@ -490,7 +485,7 @@ impl MlxEngineClient {
         };
 
         let Some(p) = params else {
-            return Ok(sampling);
+            return sampling;
         };
 
         if let Some(val) = p.temperature {
@@ -527,13 +522,11 @@ impl MlxEngineClient {
             sampling.seed = i32::try_from(seed).ok();
         }
 
-        Ok(sampling)
+        sampling
     }
 
-    fn build_sampling_params_from_responses(
-        request: &ResponsesRequest,
-    ) -> Result<proto::SamplingParams, String> {
-        Ok(proto::SamplingParams {
+    fn build_sampling_params_from_responses(request: &ResponsesRequest) -> proto::SamplingParams {
+        proto::SamplingParams {
             temperature: request.temperature,
             top_p: request.top_p.unwrap_or(1.0),
             top_k: 0,
@@ -547,7 +540,7 @@ impl MlxEngineClient {
             ignore_eos: false,
             logprobs: request.top_logprobs.map(|v| v as i32),
             seed: None,
-        })
+        }
     }
 }
 

--- a/crates/grpc_client/src/mlx_engine.rs
+++ b/crates/grpc_client/src/mlx_engine.rs
@@ -233,9 +233,15 @@ impl MlxEngineClient {
 
     // ── Unsupported feature validation ────────────────────────────────
     //
-    // MLX is a lightweight backend without constrained decoding, parallel
-    // samples, or string stop sequences.  All rejections live here so each
-    // public builder stays concise.
+    // TODO(mlx): These are mlx-lm engine limitations, not proto limitations.
+    // mlx-lm currently lacks:
+    //   - Constrained decoding (json_schema, regex, grammar, structural_tag)
+    //     — needs outlines/xgrammar integration in mlx-lm
+    //   - Parallel samples (n > 1) — BatchGenerator doesn't support it
+    //   - String stop sequences — only token ID stops via SequenceStateMachine
+    //   - response_format — same as constrained decoding
+    // These are the main gaps preventing feature parity with vLLM/SGLang.
+    // Track upstream: https://github.com/ml-explore/mlx-lm
 
     fn reject_constraint(constraint: Option<&(String, String)>) -> Result<(), String> {
         if let Some((kind, _)) = constraint {

--- a/crates/grpc_client/src/mlx_engine.rs
+++ b/crates/grpc_client/src/mlx_engine.rs
@@ -233,14 +233,19 @@ impl MlxEngineClient {
 
     // ── Unsupported feature validation ────────────────────────────────
     //
-    // TODO(mlx): These are mlx-lm engine limitations, not proto limitations.
-    // mlx-lm currently lacks:
+    // TODO(mlx): Gaps preventing feature parity with vLLM/SGLang:
+    //
+    // mlx-lm engine limitations:
     //   - Constrained decoding (json_schema, regex, grammar, structural_tag)
     //     — needs outlines/xgrammar integration in mlx-lm
-    //   - Parallel samples (n > 1) — BatchGenerator doesn't support it
-    //   - String stop sequences — only token ID stops via SequenceStateMachine
+    //   - Parallel samples (n > 1) — mlx-lm server doesn't expose this
     //   - response_format — same as constrained decoding
-    // These are the main gaps preventing feature parity with vLLM/SGLang.
+    //
+    // Servicer limitations (fixable without mlx-lm changes):
+    //   - String stop sequences — mlx-lm supports this via tokenizer.encode()
+    //     → SequenceStateMachine, but our gRPC servicer doesn't do the
+    //     string-to-token-ID conversion yet
+    //
     // Track upstream: https://github.com/ml-explore/mlx-lm
 
     fn reject_constraint(constraint: Option<&(String, String)>) -> Result<(), String> {

--- a/crates/grpc_client/src/mlx_engine.rs
+++ b/crates/grpc_client/src/mlx_engine.rs
@@ -242,9 +242,10 @@ impl MlxEngineClient {
     //   - response_format — same as constrained decoding
     //
     // Servicer limitations (fixable without mlx-lm changes):
-    //   - String stop sequences — mlx-lm supports this via tokenizer.encode()
-    //     → SequenceStateMachine, but our gRPC servicer doesn't do the
-    //     string-to-token-ID conversion yet
+    //   - TODO(mlx): String stop sequences — mlx-lm supports this via
+    //     tokenizer.encode() → SequenceStateMachine. Fix by converting stop
+    //     strings to token IDs in the preparation stage (which already has the
+    //     Rust tokenizer) and passing them as stop_token_ids in the proto.
     //
     // Track upstream: https://github.com/ml-explore/mlx-lm
 

--- a/crates/grpc_client/src/mlx_engine.rs
+++ b/crates/grpc_client/src/mlx_engine.rs
@@ -231,6 +231,60 @@ impl MlxEngineClient {
 
     // ── Request builders ────────────────────────────────────────────────
 
+    // ── Unsupported feature validation ────────────────────────────────
+    //
+    // MLX is a lightweight backend without constrained decoding, parallel
+    // samples, or string stop sequences.  All rejections live here so each
+    // public builder stays concise.
+
+    fn reject_constraint(constraint: Option<&(String, String)>) -> Result<(), String> {
+        if let Some((kind, _)) = constraint {
+            return Err(format!(
+                "MLX backend does not support structured output constraint: {kind}"
+            ));
+        }
+        Ok(())
+    }
+
+    fn reject_n(n: Option<u32>) -> Result<(), String> {
+        if n.is_some_and(|n| n > 1) {
+            return Err("MLX backend does not support n > 1 (parallel samples)".to_string());
+        }
+        Ok(())
+    }
+
+    fn reject_stop_strings(
+        stop: Option<&openai_protocol::common::StringOrArray>,
+    ) -> Result<(), String> {
+        if let Some(s) = stop {
+            if !s.is_empty() {
+                return Err(
+                    "MLX backend does not support string stop sequences (only stop_token_ids)"
+                        .to_string(),
+                );
+            }
+        }
+        Ok(())
+    }
+
+    fn reject_stop_string_list(stop: Option<&[String]>) -> Result<(), String> {
+        if let Some(s) = stop {
+            if !s.is_empty() {
+                return Err("MLX backend does not support string stop sequences".to_string());
+            }
+        }
+        Ok(())
+    }
+
+    fn reject_structured_outputs(params: &GenerateSamplingParams) -> Result<(), String> {
+        if params.json_schema.is_some() || params.regex.is_some() || params.ebnf.is_some() {
+            return Err("MLX backend does not support structured output constraints".to_string());
+        }
+        Ok(())
+    }
+
+    // ── Public request builders ────────────────────────────────────────
+
     /// Build a GenerateRequest from OpenAI ChatCompletionRequest
     #[expect(
         clippy::unused_self,
@@ -244,43 +298,23 @@ impl MlxEngineClient {
         token_ids: Vec<u32>,
         constraint: Option<(String, String)>,
     ) -> Result<proto::GenerateRequest, String> {
-        // MLX doesn't support backend-side constrained decoding
-        if let Some((constraint_type, _)) = &constraint {
-            return Err(format!(
-                "MLX backend does not support structured output constraint: {constraint_type}"
-            ));
-        }
+        Self::reject_constraint(constraint.as_ref())?;
+        Self::reject_n(body.n)?;
+        Self::reject_stop_strings(body.stop.as_ref())?;
         if body.response_format.is_some() {
             return Err(
                 "MLX backend does not support response_format (structured outputs)".to_string(),
             );
         }
-        if body.n.is_some_and(|n| n > 1) {
-            return Err("MLX backend does not support n > 1 (parallel samples)".to_string());
-        }
-        // MLX proto only supports stop_token_ids, not string stop sequences
-        if let Some(ref stop) = body.stop {
-            if !stop.is_empty() {
-                return Err(
-                    "MLX backend does not support string stop sequences (only stop_token_ids)"
-                        .to_string(),
-                );
-            }
-        }
 
         let sampling_params = Self::build_sampling_params_from_chat(body);
-
-        Ok(proto::GenerateRequest {
+        Ok(Self::make_generate_request(
             request_id,
-            input: Some(proto::generate_request::Input::Tokenized(
-                proto::TokenizedInput {
-                    original_text: processed_text,
-                    input_ids: token_ids,
-                },
-            )),
-            sampling_params: Some(sampling_params),
-            stream: body.stream,
-        })
+            processed_text,
+            token_ids,
+            sampling_params,
+            body.stream,
+        ))
     }
 
     /// Build a GenerateRequest from CompletionRequest (`/v1/completions`)
@@ -295,30 +329,17 @@ impl MlxEngineClient {
         original_text: String,
         token_ids: Vec<u32>,
     ) -> Result<proto::GenerateRequest, String> {
-        if body.n.is_some_and(|n| n > 1) {
-            return Err("MLX backend does not support n > 1 (parallel samples)".to_string());
-        }
-        if let Some(ref stop) = body.stop {
-            if !stop.is_empty() {
-                return Err(
-                    "MLX backend does not support string stop sequences (only stop_token_ids)"
-                        .to_string(),
-                );
-            }
-        }
-        let sampling_params = Self::build_sampling_params_from_completion(body);
+        Self::reject_n(body.n)?;
+        Self::reject_stop_strings(body.stop.as_ref())?;
 
-        Ok(proto::GenerateRequest {
+        let sampling_params = Self::build_sampling_params_from_completion(body);
+        Ok(Self::make_generate_request(
             request_id,
-            input: Some(proto::generate_request::Input::Tokenized(
-                proto::TokenizedInput {
-                    original_text,
-                    input_ids: token_ids,
-                },
-            )),
-            sampling_params: Some(sampling_params),
-            stream: body.stream,
-        })
+            original_text,
+            token_ids,
+            sampling_params,
+            body.stream,
+        ))
     }
 
     /// Build a GenerateRequest from CreateMessageRequest (Anthropic Messages API)
@@ -332,26 +353,19 @@ impl MlxEngineClient {
         body: &CreateMessageRequest,
         processed_text: String,
         token_ids: Vec<u32>,
+        constraint: Option<(String, String)>,
     ) -> Result<proto::GenerateRequest, String> {
-        if let Some(ref stop) = body.stop_sequences {
-            if !stop.is_empty() {
-                return Err("MLX backend does not support string stop sequences".to_string());
-            }
-        }
+        Self::reject_constraint(constraint.as_ref())?;
+        Self::reject_stop_string_list(body.stop_sequences.as_deref())?;
 
         let sampling_params = Self::build_sampling_params_from_messages(body);
-
-        Ok(proto::GenerateRequest {
+        Ok(Self::make_generate_request(
             request_id,
-            input: Some(proto::generate_request::Input::Tokenized(
-                proto::TokenizedInput {
-                    original_text: processed_text,
-                    input_ids: token_ids,
-                },
-            )),
-            sampling_params: Some(sampling_params),
-            stream: body.stream.unwrap_or(false),
-        })
+            processed_text,
+            token_ids,
+            sampling_params,
+            body.stream.unwrap_or(false),
+        ))
     }
 
     /// Build a basic GenerateRequest from the native GenerateRequest
@@ -367,38 +381,22 @@ impl MlxEngineClient {
         token_ids: Vec<u32>,
     ) -> Result<proto::GenerateRequest, String> {
         if let Some(ref sp) = body.sampling_params {
-            if sp.n.is_some_and(|n| n > 1) {
-                return Err("MLX backend does not support n > 1 (parallel samples)".to_string());
-            }
-            if sp.json_schema.is_some() || sp.regex.is_some() || sp.ebnf.is_some() {
-                return Err(
-                    "MLX backend does not support structured output constraints".to_string()
-                );
-            }
-            if let Some(ref stop) = sp.stop {
-                if !stop.is_empty() {
-                    return Err(
-                        "MLX backend does not support string stop sequences (only stop_token_ids)"
-                            .to_string(),
-                    );
-                }
-            }
+            Self::reject_n(sp.n)?;
+            Self::reject_stop_strings(sp.stop.as_ref())?;
+            Self::reject_structured_outputs(sp)?;
         }
-        let sampling_params = Self::build_sampling_params_from_plain(body.sampling_params.as_ref());
 
-        Ok(proto::GenerateRequest {
+        let sampling_params = Self::build_sampling_params_from_plain(body.sampling_params.as_ref());
+        Ok(Self::make_generate_request(
             request_id,
-            input: Some(proto::generate_request::Input::Tokenized(
-                proto::TokenizedInput {
-                    original_text: original_text.unwrap_or_default(),
-                    input_ids: token_ids,
-                },
-            )),
-            sampling_params: Some(sampling_params),
-            stream: body.stream,
-        })
+            original_text.unwrap_or_default(),
+            token_ids,
+            sampling_params,
+            body.stream,
+        ))
     }
 
+    /// Build a GenerateRequest from ResponsesRequest (OpenAI Responses API)
     #[expect(
         clippy::unused_self,
         reason = "method receiver kept for consistent public API across gRPC backends"
@@ -411,28 +409,37 @@ impl MlxEngineClient {
         token_ids: Vec<u32>,
         constraint: Option<(String, String)>,
     ) -> Result<proto::GenerateRequest, String> {
-        // MLX doesn't support backend-side structured output constraints
-        // (structural_tag, json_schema, etc.) — reject if constraint requested.
-        // Tool calling works via router-side parsing (no backend support needed).
-        if let Some((constraint_type, _)) = &constraint {
-            return Err(format!(
-                "MLX backend does not support structured output constraint: {constraint_type}"
-            ));
-        }
+        Self::reject_constraint(constraint.as_ref())?;
 
         let sampling_params = Self::build_sampling_params_from_responses(body);
+        Ok(Self::make_generate_request(
+            request_id,
+            processed_text,
+            token_ids,
+            sampling_params,
+            body.stream.unwrap_or(false),
+        ))
+    }
 
-        Ok(proto::GenerateRequest {
+    /// Shared helper to construct the proto GenerateRequest.
+    fn make_generate_request(
+        request_id: String,
+        text: String,
+        token_ids: Vec<u32>,
+        sampling_params: proto::SamplingParams,
+        stream: bool,
+    ) -> proto::GenerateRequest {
+        proto::GenerateRequest {
             request_id,
             input: Some(proto::generate_request::Input::Tokenized(
                 proto::TokenizedInput {
-                    original_text: processed_text,
+                    original_text: text,
                     input_ids: token_ids,
                 },
             )),
             sampling_params: Some(sampling_params),
-            stream: body.stream.unwrap_or(false),
-        })
+            stream,
+        }
     }
 
     // ── Private sampling param builders ─────────────────────────────────

--- a/crates/grpc_client/src/mlx_engine.rs
+++ b/crates/grpc_client/src/mlx_engine.rs
@@ -10,11 +10,8 @@ use std::{
 };
 
 use openai_protocol::{
-    chat::ChatCompletionRequest,
-    completion::CompletionRequest,
-    generate::GenerateRequest,
-    messages::CreateMessageRequest,
-    responses::ResponsesRequest,
+    chat::ChatCompletionRequest, completion::CompletionRequest, generate::GenerateRequest,
+    messages::CreateMessageRequest, responses::ResponsesRequest,
     sampling_params::SamplingParams as GenerateSamplingParams,
 };
 use tonic::{transport::Channel, Request, Streaming};
@@ -112,6 +109,10 @@ pub struct MlxEngineClient {
     trace_injector: BoxedTraceInjector,
 }
 
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "Result return kept for API consistency with other backends"
+)]
 impl MlxEngineClient {
     /// Create a new client and connect to the MLX server
     pub async fn connect(endpoint: &str) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
@@ -249,7 +250,9 @@ impl MlxEngineClient {
         // MLX doesn't support backend-side structured outputs (json_schema, etc.)
         // Tool calling works via router-side ToolParser (no backend support needed)
         if body.response_format.is_some() {
-            return Err("MLX backend does not support response_format (structured outputs)".to_string());
+            return Err(
+                "MLX backend does not support response_format (structured outputs)".to_string(),
+            );
         }
 
         let sampling_params = Self::build_sampling_params_from_chat(body)?;
@@ -409,7 +412,7 @@ impl MlxEngineClient {
             stop_token_ids: request.stop_token_ids.clone().unwrap_or_default(),
             ignore_eos: request.ignore_eos,
             logprobs,
-            logit_bias: convert_logit_bias(&request.logit_bias),
+            logit_bias: convert_logit_bias(request.logit_bias.as_ref()),
             seed: request.seed.and_then(|s| i32::try_from(s).ok()),
         })
     }
@@ -431,7 +434,7 @@ impl MlxEngineClient {
             stop_token_ids: request.stop_token_ids.clone().unwrap_or_default(),
             ignore_eos: request.ignore_eos,
             logprobs,
-            logit_bias: convert_logit_bias(&request.logit_bias),
+            logit_bias: convert_logit_bias(request.logit_bias.as_ref()),
             seed: request.seed.and_then(|s| i32::try_from(s).ok()),
         })
     }
@@ -521,7 +524,7 @@ impl MlxEngineClient {
 }
 
 /// Convert OpenAI-style logit_bias (String keys) to proto logit_bias (i32 keys).
-fn convert_logit_bias(bias: &Option<HashMap<String, f32>>) -> HashMap<i32, f32> {
+fn convert_logit_bias(bias: Option<&HashMap<String, f32>>) -> HashMap<i32, f32> {
     match bias {
         Some(map) => map
             .iter()

--- a/crates/grpc_client/src/mlx_engine.rs
+++ b/crates/grpc_client/src/mlx_engine.rs
@@ -276,8 +276,12 @@ impl MlxEngineClient {
         Ok(())
     }
 
-    fn reject_structured_outputs(params: &GenerateSamplingParams) -> Result<(), String> {
-        if params.json_schema.is_some() || params.regex.is_some() || params.ebnf.is_some() {
+    fn reject_if_any_constraint(
+        json_schema: Option<&String>,
+        regex: Option<&String>,
+        ebnf: Option<&String>,
+    ) -> Result<(), String> {
+        if json_schema.is_some() || regex.is_some() || ebnf.is_some() {
             return Err("MLX backend does not support structured output constraints".to_string());
         }
         Ok(())
@@ -331,6 +335,11 @@ impl MlxEngineClient {
     ) -> Result<proto::GenerateRequest, String> {
         Self::reject_n(body.n)?;
         Self::reject_stop_strings(body.stop.as_ref())?;
+        Self::reject_if_any_constraint(
+            body.json_schema.as_ref(),
+            body.regex.as_ref(),
+            body.ebnf.as_ref(),
+        )?;
 
         let sampling_params = Self::build_sampling_params_from_completion(body);
         Ok(Self::make_generate_request(
@@ -383,7 +392,11 @@ impl MlxEngineClient {
         if let Some(ref sp) = body.sampling_params {
             Self::reject_n(sp.n)?;
             Self::reject_stop_strings(sp.stop.as_ref())?;
-            Self::reject_structured_outputs(sp)?;
+            Self::reject_if_any_constraint(
+                sp.json_schema.as_ref(),
+                sp.regex.as_ref(),
+                sp.ebnf.as_ref(),
+            )?;
         }
 
         let sampling_params = Self::build_sampling_params_from_plain(body.sampling_params.as_ref());
@@ -410,6 +423,7 @@ impl MlxEngineClient {
         constraint: Option<(String, String)>,
     ) -> Result<proto::GenerateRequest, String> {
         Self::reject_constraint(constraint.as_ref())?;
+        Self::reject_stop_strings(body.stop.as_ref())?;
 
         let sampling_params = Self::build_sampling_params_from_responses(body);
         Ok(Self::make_generate_request(

--- a/crates/grpc_client/src/mlx_engine.rs
+++ b/crates/grpc_client/src/mlx_engine.rs
@@ -246,6 +246,12 @@ impl MlxEngineClient {
         processed_text: String,
         token_ids: Vec<u32>,
     ) -> Result<proto::GenerateRequest, String> {
+        // MLX doesn't support backend-side structured outputs (json_schema, etc.)
+        // Tool calling works via router-side ToolParser (no backend support needed)
+        if body.response_format.is_some() {
+            return Err("MLX backend does not support response_format (structured outputs)".to_string());
+        }
+
         let sampling_params = Self::build_sampling_params_from_chat(body)?;
 
         Ok(proto::GenerateRequest {
@@ -353,8 +359,17 @@ impl MlxEngineClient {
         body: &ResponsesRequest,
         processed_text: String,
         token_ids: Vec<u32>,
-        _constraint: Option<(String, String)>,
+        constraint: Option<(String, String)>,
     ) -> Result<proto::GenerateRequest, String> {
+        // MLX doesn't support backend-side structured output constraints
+        // (structural_tag, json_schema, etc.) — reject if constraint requested.
+        // Tool calling works via router-side parsing (no backend support needed).
+        if let Some((constraint_type, _)) = &constraint {
+            return Err(format!(
+                "MLX backend does not support structured output constraint: {constraint_type}"
+            ));
+        }
+
         let sampling_params = Self::build_sampling_params_from_responses(body)?;
 
         Ok(proto::GenerateRequest {

--- a/crates/grpc_client/src/mlx_engine.rs
+++ b/crates/grpc_client/src/mlx_engine.rs
@@ -1,0 +1,468 @@
+use std::{
+    collections::HashMap,
+    pin::Pin,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    task::{Context, Poll},
+    time::Duration,
+};
+
+use openai_protocol::{
+    chat::ChatCompletionRequest,
+    completion::CompletionRequest,
+    generate::GenerateRequest,
+    messages::CreateMessageRequest,
+    sampling_params::SamplingParams as GenerateSamplingParams,
+};
+use tonic::{transport::Channel, Request, Streaming};
+use tracing::{debug, warn};
+
+use crate::{BoxedTraceInjector, NoopTraceInjector};
+
+// Include the generated protobuf code
+#[expect(clippy::allow_attributes)]
+pub mod proto {
+    #![allow(clippy::all, clippy::absolute_paths, unused_qualifications)]
+    tonic::include_proto!("mlx.grpc.engine");
+}
+
+/// A smart wrapper around Streaming<GenerateResponse> that automatically
+/// sends abort when dropped (e.g., due to client disconnection or early termination).
+pub struct AbortOnDropStream {
+    inner: Streaming<proto::GenerateResponse>,
+    request_id: String,
+    client: MlxEngineClient,
+    aborted: Arc<AtomicBool>,
+}
+
+impl AbortOnDropStream {
+    /// Create a new auto-aborting stream wrapper
+    pub fn new(
+        stream: Streaming<proto::GenerateResponse>,
+        request_id: String,
+        client: MlxEngineClient,
+    ) -> Self {
+        debug!("Created AbortOnDropStream for request {}", request_id);
+        Self {
+            inner: stream,
+            request_id,
+            client,
+            aborted: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    /// Manually mark the request as completed to prevent abort on drop.
+    pub fn mark_completed(&self) {
+        self.aborted.store(true, Ordering::Release);
+        debug!("Request {} marked as completed", self.request_id);
+    }
+}
+
+impl Drop for AbortOnDropStream {
+    fn drop(&mut self) {
+        if self
+            .aborted
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return;
+        }
+
+        let client = self.client.clone();
+        let request_id = self.request_id.clone();
+
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "fire-and-forget abort on Drop is intentional"
+        )]
+        tokio::spawn(async move {
+            debug!(
+                "Stream dropped without completion for request {}, sending abort",
+                request_id
+            );
+            let request_id_for_log = request_id.clone();
+            if let Err(e) = client
+                .abort_request(request_id, "Stream dropped".to_string())
+                .await
+            {
+                warn!(
+                    "Failed to send abort on drop for request {}: {}",
+                    request_id_for_log, e
+                );
+            }
+        });
+    }
+}
+
+impl futures::Stream for AbortOnDropStream {
+    type Item = Result<proto::GenerateResponse, tonic::Status>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.inner).poll_next(cx)
+    }
+}
+
+/// gRPC client for MLX engine
+#[derive(Clone)]
+pub struct MlxEngineClient {
+    client: proto::mlx_engine_client::MlxEngineClient<Channel>,
+    trace_injector: BoxedTraceInjector,
+}
+
+impl MlxEngineClient {
+    /// Create a new client and connect to the MLX server
+    pub async fn connect(endpoint: &str) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        Self::connect_with_trace_injector(endpoint, Arc::new(NoopTraceInjector)).await
+    }
+
+    /// Create a new client with a custom trace injector
+    pub async fn connect_with_trace_injector(
+        endpoint: &str,
+        trace_injector: BoxedTraceInjector,
+    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        debug!("Connecting to MLX gRPC server at {}", endpoint);
+
+        let http_endpoint = if let Some(addr) = endpoint.strip_prefix("grpc://") {
+            format!("http://{addr}")
+        } else {
+            endpoint.to_string()
+        };
+
+        let channel = Channel::from_shared(http_endpoint)?
+            .http2_keep_alive_interval(Duration::from_secs(30))
+            .keep_alive_timeout(Duration::from_secs(10))
+            .keep_alive_while_idle(true)
+            .tcp_keepalive(Some(Duration::from_secs(60)))
+            .tcp_nodelay(true)
+            .http2_adaptive_window(true)
+            .initial_stream_window_size(Some(16 * 1024 * 1024))
+            .initial_connection_window_size(Some(32 * 1024 * 1024))
+            .connect()
+            .await?;
+
+        let client = proto::mlx_engine_client::MlxEngineClient::new(channel);
+
+        Ok(Self {
+            client,
+            trace_injector,
+        })
+    }
+
+    /// Set or replace the trace injector
+    #[must_use]
+    pub fn with_trace_injector(mut self, trace_injector: BoxedTraceInjector) -> Self {
+        self.trace_injector = trace_injector;
+        self
+    }
+
+    /// Submit a generation request (returns auto-aborting streaming response)
+    pub async fn generate(
+        &self,
+        req: proto::GenerateRequest,
+    ) -> Result<AbortOnDropStream, tonic::Status> {
+        let request_id = req.request_id.clone();
+        let mut client = self.client.clone();
+        let mut request = Request::new(req);
+
+        if let Err(e) = self.trace_injector.inject(request.metadata_mut()) {
+            warn!("Failed to inject trace context: {}", e);
+        }
+
+        let response = client.generate(request).await?;
+
+        Ok(AbortOnDropStream::new(
+            response.into_inner(),
+            request_id,
+            self.clone(),
+        ))
+    }
+
+    /// Perform health check
+    pub async fn health_check(&self) -> Result<proto::HealthCheckResponse, tonic::Status> {
+        debug!("Sending health check request");
+        let request = Request::new(proto::HealthCheckRequest {});
+
+        let mut client = self.client.clone();
+        let response = client.health_check(request).await?;
+        debug!("Health check response received");
+        Ok(response.into_inner())
+    }
+
+    /// Abort a request
+    pub async fn abort_request(
+        &self,
+        request_id: String,
+        _reason: String,
+    ) -> Result<(), tonic::Status> {
+        debug!("Sending abort request for {}", request_id);
+        let request = Request::new(proto::AbortRequest {
+            request_ids: vec![request_id.clone()],
+        });
+
+        let mut client = self.client.clone();
+        let _response = client.abort(request).await?;
+        debug!("Abort response received for {}", request_id);
+        Ok(())
+    }
+
+    /// Get model information
+    pub async fn get_model_info(&self) -> Result<proto::GetModelInfoResponse, tonic::Status> {
+        debug!("Requesting model info");
+        let request = Request::new(proto::GetModelInfoRequest {});
+
+        let mut client = self.client.clone();
+        let response = client.get_model_info(request).await?;
+        debug!("Model info response received");
+        Ok(response.into_inner())
+    }
+
+    /// Get server information
+    pub async fn get_server_info(&self) -> Result<proto::GetServerInfoResponse, tonic::Status> {
+        debug!("Requesting server info");
+        let request = Request::new(proto::GetServerInfoRequest {});
+
+        let mut client = self.client.clone();
+        let response = client.get_server_info(request).await?;
+        debug!("Server info response received");
+        Ok(response.into_inner())
+    }
+
+    crate::impl_get_tokenizer!();
+
+    // ── Request builders ────────────────────────────────────────────────
+
+    /// Build a GenerateRequest from OpenAI ChatCompletionRequest
+    #[expect(
+        clippy::unused_self,
+        reason = "method receiver kept for consistent public API across gRPC backends"
+    )]
+    pub fn build_generate_request_from_chat(
+        &self,
+        request_id: String,
+        body: &ChatCompletionRequest,
+        processed_text: String,
+        token_ids: Vec<u32>,
+    ) -> Result<proto::GenerateRequest, String> {
+        let sampling_params = Self::build_sampling_params_from_chat(body)?;
+
+        Ok(proto::GenerateRequest {
+            request_id,
+            input: Some(proto::generate_request::Input::Tokenized(
+                proto::TokenizedInput {
+                    original_text: processed_text,
+                    input_ids: token_ids,
+                },
+            )),
+            sampling_params: Some(sampling_params),
+            stream: body.stream,
+        })
+    }
+
+    /// Build a GenerateRequest from CompletionRequest (`/v1/completions`)
+    #[expect(
+        clippy::unused_self,
+        reason = "method receiver kept for consistent public API"
+    )]
+    pub fn build_generate_request_from_completion(
+        &self,
+        request_id: String,
+        body: &CompletionRequest,
+        original_text: String,
+        token_ids: Vec<u32>,
+    ) -> Result<proto::GenerateRequest, String> {
+        let sampling_params = Self::build_sampling_params_from_completion(body)?;
+
+        Ok(proto::GenerateRequest {
+            request_id,
+            input: Some(proto::generate_request::Input::Tokenized(
+                proto::TokenizedInput {
+                    original_text,
+                    input_ids: token_ids,
+                },
+            )),
+            sampling_params: Some(sampling_params),
+            stream: body.stream,
+        })
+    }
+
+    /// Build a GenerateRequest from CreateMessageRequest (Anthropic Messages API)
+    #[expect(
+        clippy::unused_self,
+        reason = "method receiver kept for consistent public API across gRPC backends"
+    )]
+    pub fn build_generate_request_from_messages(
+        &self,
+        request_id: String,
+        body: &CreateMessageRequest,
+        processed_text: String,
+        token_ids: Vec<u32>,
+    ) -> Result<proto::GenerateRequest, String> {
+        let sampling_params = Self::build_sampling_params_from_messages(body)?;
+
+        Ok(proto::GenerateRequest {
+            request_id,
+            input: Some(proto::generate_request::Input::Tokenized(
+                proto::TokenizedInput {
+                    original_text: processed_text,
+                    input_ids: token_ids,
+                },
+            )),
+            sampling_params: Some(sampling_params),
+            stream: body.stream.unwrap_or(false),
+        })
+    }
+
+    /// Build a basic GenerateRequest from the native GenerateRequest
+    #[expect(
+        clippy::unused_self,
+        reason = "method receiver kept for consistent public API across gRPC backends"
+    )]
+    pub fn build_plain_generate_request(
+        &self,
+        request_id: String,
+        body: &GenerateRequest,
+        original_text: Option<String>,
+        token_ids: Vec<u32>,
+    ) -> Result<proto::GenerateRequest, String> {
+        let sampling_params =
+            Self::build_sampling_params_from_plain(body.sampling_params.as_ref())?;
+
+        Ok(proto::GenerateRequest {
+            request_id,
+            input: Some(proto::generate_request::Input::Tokenized(
+                proto::TokenizedInput {
+                    original_text: original_text.unwrap_or_default(),
+                    input_ids: token_ids,
+                },
+            )),
+            sampling_params: Some(sampling_params),
+            stream: body.stream,
+        })
+    }
+
+    // ── Private sampling param builders ─────────────────────────────────
+
+    #[expect(deprecated, reason = "seed is legacy but still forwarded to backends")]
+    fn build_sampling_params_from_chat(
+        request: &ChatCompletionRequest,
+    ) -> Result<proto::SamplingParams, String> {
+        let logprobs = if request.logprobs {
+            Some(request.top_logprobs.unwrap_or(1).min(20) as i32)
+        } else {
+            None
+        };
+
+        Ok(proto::SamplingParams {
+            temperature: request.temperature,
+            top_p: request.top_p.unwrap_or(1.0),
+            top_k: request.top_k.map(|v| v.max(0) as u32).unwrap_or(0),
+            min_p: request.min_p.unwrap_or(0.0),
+            frequency_penalty: request.frequency_penalty.unwrap_or(0.0),
+            presence_penalty: request.presence_penalty.unwrap_or(0.0),
+            repetition_penalty: request.repetition_penalty.unwrap_or(1.0),
+            max_tokens: request.max_completion_tokens,
+            stop_token_ids: request.stop_token_ids.clone().unwrap_or_default(),
+            ignore_eos: request.ignore_eos,
+            logprobs,
+            logit_bias: convert_logit_bias(&request.logit_bias),
+            seed: request.seed.map(|s| s as i32),
+        })
+    }
+
+    fn build_sampling_params_from_completion(
+        request: &CompletionRequest,
+    ) -> Result<proto::SamplingParams, String> {
+        let logprobs = request.logprobs.map(|v| v.min(5) as i32);
+
+        Ok(proto::SamplingParams {
+            temperature: request.temperature,
+            top_p: request.top_p.unwrap_or(1.0),
+            top_k: request.top_k.map(|v| v.max(0) as u32).unwrap_or(0),
+            min_p: request.min_p.unwrap_or(0.0),
+            frequency_penalty: request.frequency_penalty.unwrap_or(0.0),
+            presence_penalty: request.presence_penalty.unwrap_or(0.0),
+            repetition_penalty: request.repetition_penalty.unwrap_or(1.0),
+            max_tokens: request.max_tokens,
+            stop_token_ids: request.stop_token_ids.clone().unwrap_or_default(),
+            ignore_eos: request.ignore_eos,
+            logprobs,
+            logit_bias: convert_logit_bias(&request.logit_bias),
+            seed: request.seed.map(|s| s as i32),
+        })
+    }
+
+    fn build_sampling_params_from_messages(
+        request: &CreateMessageRequest,
+    ) -> Result<proto::SamplingParams, String> {
+        Ok(proto::SamplingParams {
+            temperature: Some(request.temperature.unwrap_or(1.0) as f32),
+            top_p: request.top_p.unwrap_or(1.0) as f32,
+            top_k: request.top_k.unwrap_or(0),
+            max_tokens: Some(request.max_tokens),
+            ..Default::default()
+        })
+    }
+
+    fn build_sampling_params_from_plain(
+        params: Option<&GenerateSamplingParams>,
+    ) -> Result<proto::SamplingParams, String> {
+        let mut sampling = proto::SamplingParams {
+            temperature: Some(1.0),
+            top_p: 1.0,
+            ..Default::default()
+        };
+
+        let Some(p) = params else {
+            return Ok(sampling);
+        };
+
+        if let Some(val) = p.temperature {
+            sampling.temperature = Some(val);
+        }
+        if let Some(val) = p.top_p {
+            sampling.top_p = val;
+        }
+        if let Some(val) = p.top_k {
+            sampling.top_k = val.max(0) as u32;
+        }
+        if let Some(val) = p.frequency_penalty {
+            sampling.frequency_penalty = val;
+        }
+        if let Some(val) = p.presence_penalty {
+            sampling.presence_penalty = val;
+        }
+        if let Some(val) = p.repetition_penalty {
+            sampling.repetition_penalty = val;
+        }
+        if let Some(val) = p.min_p {
+            sampling.min_p = val;
+        }
+        if let Some(val) = p.ignore_eos {
+            sampling.ignore_eos = val;
+        }
+        if let Some(stop_token_ids) = &p.stop_token_ids {
+            sampling.stop_token_ids.clone_from(stop_token_ids);
+        }
+        if let Some(max_new_tokens) = p.max_new_tokens {
+            sampling.max_tokens = Some(max_new_tokens);
+        }
+        if let Some(seed) = p.sampling_seed {
+            sampling.seed = Some(seed as i32);
+        }
+
+        Ok(sampling)
+    }
+}
+
+/// Convert OpenAI-style logit_bias (String keys) to proto logit_bias (i32 keys).
+fn convert_logit_bias(bias: &Option<HashMap<String, f32>>) -> HashMap<i32, f32> {
+    match bias {
+        Some(map) => map
+            .iter()
+            .filter_map(|(k, v)| k.parse::<i32>().ok().map(|id| (id, *v)))
+            .collect(),
+        None => HashMap::new(),
+    }
+}

--- a/crates/grpc_client/src/mlx_engine.rs
+++ b/crates/grpc_client/src/mlx_engine.rs
@@ -242,9 +242,14 @@ impl MlxEngineClient {
         body: &ChatCompletionRequest,
         processed_text: String,
         token_ids: Vec<u32>,
+        constraint: Option<(String, String)>,
     ) -> Result<proto::GenerateRequest, String> {
-        // MLX doesn't support backend-side structured outputs (json_schema, etc.)
-        // Tool calling works via router-side ToolParser (no backend support needed)
+        // MLX doesn't support backend-side constrained decoding
+        if let Some((constraint_type, _)) = &constraint {
+            return Err(format!(
+                "MLX backend does not support structured output constraint: {constraint_type}"
+            ));
+        }
         if body.response_format.is_some() {
             return Err(
                 "MLX backend does not support response_format (structured outputs)".to_string(),

--- a/crates/grpc_client/src/mlx_engine.rs
+++ b/crates/grpc_client/src/mlx_engine.rs
@@ -560,11 +560,11 @@ impl MlxEngineClient {
         proto::SamplingParams {
             temperature: request.temperature,
             top_p: request.top_p.unwrap_or(1.0),
-            top_k: 0,
-            min_p: 0.0,
-            repetition_penalty: 1.0, // 1.0 = no penalty
-            frequency_penalty: 0.0,
-            presence_penalty: 0.0,
+            top_k: request.top_k.max(0) as u32,
+            min_p: request.min_p,
+            repetition_penalty: request.repetition_penalty,
+            frequency_penalty: request.frequency_penalty.unwrap_or(0.0),
+            presence_penalty: request.presence_penalty.unwrap_or(0.0),
             logit_bias: Default::default(),
             max_tokens: request.max_output_tokens,
             stop_token_ids: vec![],

--- a/crates/grpc_client/src/mlx_engine.rs
+++ b/crates/grpc_client/src/mlx_engine.rs
@@ -253,25 +253,18 @@ impl MlxEngineClient {
         Ok(())
     }
 
-    fn reject_stop_strings(
-        stop: Option<&openai_protocol::common::StringOrArray>,
-    ) -> Result<(), String> {
-        if let Some(s) = stop {
-            if !s.is_empty() {
-                return Err(
-                    "MLX backend does not support string stop sequences (only stop_token_ids)"
-                        .to_string(),
-                );
-            }
+    fn reject_stop_strings(has_stop_strings: bool) -> Result<(), String> {
+        if has_stop_strings {
+            return Err("MLX backend does not support string stop sequences".to_string());
         }
         Ok(())
     }
 
-    fn reject_stop_string_list(stop: Option<&[String]>) -> Result<(), String> {
-        if let Some(s) = stop {
-            if !s.is_empty() {
-                return Err("MLX backend does not support string stop sequences".to_string());
-            }
+    fn reject_response_format(has_response_format: bool) -> Result<(), String> {
+        if has_response_format {
+            return Err(
+                "MLX backend does not support response_format (structured outputs)".to_string(),
+            );
         }
         Ok(())
     }
@@ -304,12 +297,8 @@ impl MlxEngineClient {
     ) -> Result<proto::GenerateRequest, String> {
         Self::reject_constraint(constraint.as_ref())?;
         Self::reject_n(body.n)?;
-        Self::reject_stop_strings(body.stop.as_ref())?;
-        if body.response_format.is_some() {
-            return Err(
-                "MLX backend does not support response_format (structured outputs)".to_string(),
-            );
-        }
+        Self::reject_stop_strings(body.stop.as_ref().is_some_and(|s| !s.is_empty()))?;
+        Self::reject_response_format(body.response_format.is_some())?;
 
         let sampling_params = Self::build_sampling_params_from_chat(body);
         Ok(Self::make_generate_request(
@@ -334,7 +323,7 @@ impl MlxEngineClient {
         token_ids: Vec<u32>,
     ) -> Result<proto::GenerateRequest, String> {
         Self::reject_n(body.n)?;
-        Self::reject_stop_strings(body.stop.as_ref())?;
+        Self::reject_stop_strings(body.stop.as_ref().is_some_and(|s| !s.is_empty()))?;
         Self::reject_if_any_constraint(
             body.json_schema.as_ref(),
             body.regex.as_ref(),
@@ -365,7 +354,7 @@ impl MlxEngineClient {
         constraint: Option<(String, String)>,
     ) -> Result<proto::GenerateRequest, String> {
         Self::reject_constraint(constraint.as_ref())?;
-        Self::reject_stop_string_list(body.stop_sequences.as_deref())?;
+        Self::reject_stop_strings(body.stop_sequences.as_ref().is_some_and(|s| !s.is_empty()))?;
 
         let sampling_params = Self::build_sampling_params_from_messages(body);
         Ok(Self::make_generate_request(
@@ -391,7 +380,7 @@ impl MlxEngineClient {
     ) -> Result<proto::GenerateRequest, String> {
         if let Some(ref sp) = body.sampling_params {
             Self::reject_n(sp.n)?;
-            Self::reject_stop_strings(sp.stop.as_ref())?;
+            Self::reject_stop_strings(sp.stop.as_ref().is_some_and(|s| !s.is_empty()))?;
             Self::reject_if_any_constraint(
                 sp.json_schema.as_ref(),
                 sp.regex.as_ref(),
@@ -423,7 +412,7 @@ impl MlxEngineClient {
         constraint: Option<(String, String)>,
     ) -> Result<proto::GenerateRequest, String> {
         Self::reject_constraint(constraint.as_ref())?;
-        Self::reject_stop_strings(body.stop.as_ref())?;
+        Self::reject_stop_strings(body.stop.as_ref().is_some_and(|s| !s.is_empty()))?;
 
         let sampling_params = Self::build_sampling_params_from_responses(body);
         Ok(Self::make_generate_request(

--- a/crates/grpc_client/src/mlx_engine.rs
+++ b/crates/grpc_client/src/mlx_engine.rs
@@ -250,6 +250,9 @@ impl MlxEngineClient {
                 "MLX backend does not support response_format (structured outputs)".to_string(),
             );
         }
+        if body.n.is_some_and(|n| n > 1) {
+            return Err("MLX backend does not support n > 1 (parallel samples)".to_string());
+        }
         // MLX proto only supports stop_token_ids, not string stop sequences
         if let Some(ref stop) = body.stop {
             if !stop.is_empty() {

--- a/crates/grpc_client/src/mlx_engine.rs
+++ b/crates/grpc_client/src/mlx_engine.rs
@@ -14,6 +14,7 @@ use openai_protocol::{
     completion::CompletionRequest,
     generate::GenerateRequest,
     messages::CreateMessageRequest,
+    responses::ResponsesRequest,
     sampling_params::SamplingParams as GenerateSamplingParams,
 };
 use tonic::{transport::Channel, Request, Streaming};
@@ -342,6 +343,33 @@ impl MlxEngineClient {
         })
     }
 
+    #[expect(
+        clippy::unused_self,
+        reason = "method receiver kept for consistent public API across gRPC backends"
+    )]
+    pub fn build_generate_request_from_responses(
+        &self,
+        request_id: String,
+        body: &ResponsesRequest,
+        processed_text: String,
+        token_ids: Vec<u32>,
+        _constraint: Option<(String, String)>,
+    ) -> Result<proto::GenerateRequest, String> {
+        let sampling_params = Self::build_sampling_params_from_responses(body)?;
+
+        Ok(proto::GenerateRequest {
+            request_id,
+            input: Some(proto::generate_request::Input::Tokenized(
+                proto::TokenizedInput {
+                    original_text: processed_text,
+                    input_ids: token_ids,
+                },
+            )),
+            sampling_params: Some(sampling_params),
+            stream: body.stream.unwrap_or(false),
+        })
+    }
+
     // ── Private sampling param builders ─────────────────────────────────
 
     #[expect(deprecated, reason = "seed is legacy but still forwarded to backends")]
@@ -453,6 +481,26 @@ impl MlxEngineClient {
         }
 
         Ok(sampling)
+    }
+
+    fn build_sampling_params_from_responses(
+        request: &ResponsesRequest,
+    ) -> Result<proto::SamplingParams, String> {
+        Ok(proto::SamplingParams {
+            temperature: request.temperature,
+            top_p: request.top_p.unwrap_or(1.0),
+            top_k: 0,
+            min_p: 0.0,
+            repetition_penalty: 0.0,
+            frequency_penalty: 0.0,
+            presence_penalty: 0.0,
+            logit_bias: Default::default(),
+            max_tokens: request.max_output_tokens,
+            stop_token_ids: vec![],
+            ignore_eos: false,
+            logprobs: request.top_logprobs.map(|v| v as i32),
+            seed: None,
+        })
     }
 }
 

--- a/crates/grpc_client/src/mlx_engine.rs
+++ b/crates/grpc_client/src/mlx_engine.rs
@@ -295,6 +295,9 @@ impl MlxEngineClient {
         original_text: String,
         token_ids: Vec<u32>,
     ) -> Result<proto::GenerateRequest, String> {
+        if body.n.is_some_and(|n| n > 1) {
+            return Err("MLX backend does not support n > 1 (parallel samples)".to_string());
+        }
         if let Some(ref stop) = body.stop {
             if !stop.is_empty() {
                 return Err(
@@ -323,10 +326,6 @@ impl MlxEngineClient {
         clippy::unused_self,
         reason = "method receiver kept for consistent public API across gRPC backends"
     )]
-    #[expect(
-        clippy::unnecessary_wraps,
-        reason = "Result kept for consistent public API across gRPC backends"
-    )]
     pub fn build_generate_request_from_messages(
         &self,
         request_id: String,
@@ -334,6 +333,12 @@ impl MlxEngineClient {
         processed_text: String,
         token_ids: Vec<u32>,
     ) -> Result<proto::GenerateRequest, String> {
+        if let Some(ref stop) = body.stop_sequences {
+            if !stop.is_empty() {
+                return Err("MLX backend does not support string stop sequences".to_string());
+            }
+        }
+
         let sampling_params = Self::build_sampling_params_from_messages(body);
 
         Ok(proto::GenerateRequest {
@@ -362,6 +367,14 @@ impl MlxEngineClient {
         token_ids: Vec<u32>,
     ) -> Result<proto::GenerateRequest, String> {
         if let Some(ref sp) = body.sampling_params {
+            if sp.n.is_some_and(|n| n > 1) {
+                return Err("MLX backend does not support n > 1 (parallel samples)".to_string());
+            }
+            if sp.json_schema.is_some() || sp.regex.is_some() || sp.ebnf.is_some() {
+                return Err(
+                    "MLX backend does not support structured output constraints".to_string()
+                );
+            }
             if let Some(ref stop) = sp.stop {
                 if !stop.is_empty() {
                     return Err(

--- a/crates/protocols/src/worker.rs
+++ b/crates/protocols/src/worker.rs
@@ -125,6 +125,8 @@ pub enum RuntimeType {
     Vllm,
     /// TensorRT-LLM runtime.
     Trtllm,
+    /// MLX runtime (Apple Silicon).
+    Mlx,
     /// External OpenAI-compatible API (not local inference).
     External,
 }
@@ -143,6 +145,7 @@ impl std::fmt::Display for RuntimeType {
             RuntimeType::Sglang => write!(f, "sglang"),
             RuntimeType::Vllm => write!(f, "vllm"),
             RuntimeType::Trtllm => write!(f, "trtllm"),
+            RuntimeType::Mlx => write!(f, "mlx"),
             RuntimeType::External => write!(f, "external"),
         }
     }
@@ -160,6 +163,8 @@ impl std::str::FromStr for RuntimeType {
             Ok(RuntimeType::Vllm)
         } else if s.eq_ignore_ascii_case("trtllm") || s.eq_ignore_ascii_case("tensorrt-llm") {
             Ok(RuntimeType::Trtllm)
+        } else if s.eq_ignore_ascii_case("mlx") {
+            Ok(RuntimeType::Mlx)
         } else if s.eq_ignore_ascii_case("external") {
             Ok(RuntimeType::External)
         } else {

--- a/model_gateway/src/routers/grpc/client.rs
+++ b/model_gateway/src/routers/grpc/client.rs
@@ -380,6 +380,7 @@ impl GrpcClient {
                     body,
                     processed_text,
                     token_ids,
+                    tool_constraints, // MLX rejects constraints inside the builder
                 )?;
                 Ok(ProtoGenerateRequest::Mlx(Box::new(req)))
             }

--- a/model_gateway/src/routers/grpc/client.rs
+++ b/model_gateway/src/routers/grpc/client.rs
@@ -7,8 +7,8 @@ use openai_protocol::{
     messages::CreateMessageRequest, worker::WorkerLoadResponse,
 };
 use smg_grpc_client::{
-    tokenizer_bundle, tokenizer_bundle::StreamBundle, SglangSchedulerClient, TrtllmServiceClient,
-    VllmEngineClient,
+    tokenizer_bundle, tokenizer_bundle::StreamBundle, MlxEngineClient, SglangSchedulerClient,
+    TrtllmServiceClient, VllmEngineClient,
 };
 
 use crate::routers::grpc::{
@@ -23,12 +23,13 @@ pub struct HealthCheckResponse {
     pub message: String,
 }
 
-/// Polymorphic gRPC client that wraps SGLang, vLLM, or TensorRT-LLM
+/// Polymorphic gRPC client that wraps SGLang, vLLM, TensorRT-LLM, or MLX
 #[derive(Clone)]
 pub enum GrpcClient {
     Sglang(SglangSchedulerClient),
     Vllm(VllmEngineClient),
     Trtllm(TrtllmServiceClient),
+    Mlx(MlxEngineClient),
 }
 
 impl GrpcClient {
@@ -110,6 +111,32 @@ impl GrpcClient {
         matches!(self, Self::Trtllm(_))
     }
 
+    #[expect(
+        clippy::panic,
+        reason = "typed accessor: caller guarantees variant via is_mlx() check"
+    )]
+    pub fn as_mlx(&self) -> &MlxEngineClient {
+        match self {
+            Self::Mlx(client) => client,
+            _ => panic!("Expected MLX client"),
+        }
+    }
+
+    #[expect(
+        clippy::panic,
+        reason = "typed accessor: caller guarantees variant via is_mlx() check"
+    )]
+    pub fn as_mlx_mut(&mut self) -> &mut MlxEngineClient {
+        match self {
+            Self::Mlx(client) => client,
+            _ => panic!("Expected MLX client"),
+        }
+    }
+
+    pub fn is_mlx(&self) -> bool {
+        matches!(self, Self::Mlx(_))
+    }
+
     pub async fn connect(
         url: &str,
         runtime_type: &str,
@@ -118,6 +145,7 @@ impl GrpcClient {
             "sglang" => Ok(Self::Sglang(SglangSchedulerClient::connect(url).await?)),
             "vllm" => Ok(Self::Vllm(VllmEngineClient::connect(url).await?)),
             "trtllm" | "tensorrt-llm" => Ok(Self::Trtllm(TrtllmServiceClient::connect(url).await?)),
+            "mlx" => Ok(Self::Mlx(MlxEngineClient::connect(url).await?)),
             _ => Err(format!("Unknown runtime type: {runtime_type}").into()),
         }
     }
@@ -147,6 +175,13 @@ impl GrpcClient {
                     message: resp.status,
                 })
             }
+            Self::Mlx(client) => {
+                let resp = client.health_check().await?;
+                Ok(HealthCheckResponse {
+                    healthy: resp.healthy,
+                    message: resp.message,
+                })
+            }
         }
     }
 
@@ -155,6 +190,7 @@ impl GrpcClient {
             Self::Sglang(client) => Ok(ModelInfo::Sglang(Box::new(client.get_model_info().await?))),
             Self::Vllm(client) => Ok(ModelInfo::Vllm(client.get_model_info().await?)),
             Self::Trtllm(client) => Ok(ModelInfo::Trtllm(client.get_model_info().await?)),
+            Self::Mlx(client) => Ok(ModelInfo::Mlx(client.get_model_info().await?)),
         }
     }
 
@@ -181,6 +217,9 @@ impl GrpcClient {
             Self::Sglang(client) => client.subscribe_kv_events(start_seq).await,
             Self::Vllm(client) => client.subscribe_kv_events(start_seq).await,
             Self::Trtllm(client) => client.subscribe_kv_events(start_seq).await,
+            Self::Mlx(_) => Err(tonic::Status::unimplemented(
+                "SubscribeKvEvents RPC not supported for MLX backend",
+            )),
         }
     }
 
@@ -191,6 +230,7 @@ impl GrpcClient {
             ))),
             Self::Vllm(client) => Ok(ServerInfo::Vllm(client.get_server_info().await?)),
             Self::Trtllm(client) => Ok(ServerInfo::Trtllm(client.get_server_info().await?)),
+            Self::Mlx(client) => Ok(ServerInfo::Mlx(client.get_server_info().await?)),
         }
     }
 
@@ -202,6 +242,7 @@ impl GrpcClient {
             Self::Sglang(client) => client.get_tokenizer().await,
             Self::Vllm(client) => client.get_tokenizer().await,
             Self::Trtllm(client) => client.get_tokenizer().await,
+            Self::Mlx(client) => client.get_tokenizer().await,
         }?;
 
         tokenizer_bundle::validate_bundle_sha256(&bundle).map_err(|e| {
@@ -235,6 +276,10 @@ impl GrpcClient {
                 let stream = client.generate(*boxed_req).await?;
                 Ok(ProtoStream::Trtllm(stream))
             }
+            (Self::Mlx(client), ProtoGenerateRequest::Mlx(boxed_req)) => {
+                let stream = client.generate(*boxed_req).await?;
+                Ok(ProtoStream::Mlx(stream))
+            }
             #[expect(
                 clippy::panic,
                 reason = "client and request types are always matched by construction in the pipeline"
@@ -256,6 +301,9 @@ impl GrpcClient {
                 let resp = client.embed(*boxed_req).await?;
                 Ok(ProtoEmbedComplete::Vllm(resp))
             }
+            (Self::Mlx(_), _) => Err(tonic::Status::unimplemented(
+                "MLX backend does not support embedding",
+            )),
             #[expect(
                 clippy::panic,
                 reason = "client and request types are always matched by construction in the pipeline"
@@ -323,6 +371,18 @@ impl GrpcClient {
                 )?;
                 Ok(ProtoGenerateRequest::Trtllm(Box::new(req)))
             }
+            Self::Mlx(client) => {
+                if multimodal_inputs.is_some() {
+                    return Err("MLX backend does not support multimodal inputs".to_string());
+                }
+                let req = client.build_generate_request_from_chat(
+                    request_id,
+                    body,
+                    processed_text,
+                    token_ids,
+                )?;
+                Ok(ProtoGenerateRequest::Mlx(Box::new(req)))
+            }
         }
     }
 
@@ -385,6 +445,18 @@ impl GrpcClient {
                 )?;
                 Ok(ProtoGenerateRequest::Trtllm(Box::new(req)))
             }
+            Self::Mlx(client) => {
+                if multimodal_inputs.is_some() {
+                    return Err("MLX backend does not support multimodal inputs".to_string());
+                }
+                let req = client.build_generate_request_from_messages(
+                    request_id,
+                    body,
+                    processed_text,
+                    token_ids,
+                )?;
+                Ok(ProtoGenerateRequest::Mlx(Box::new(req)))
+            }
         }
     }
 
@@ -422,6 +494,15 @@ impl GrpcClient {
                     token_ids,
                 )?;
                 Ok(ProtoGenerateRequest::Trtllm(Box::new(req)))
+            }
+            Self::Mlx(client) => {
+                let req = client.build_generate_request_from_completion(
+                    request_id,
+                    body,
+                    original_text,
+                    token_ids,
+                )?;
+                Ok(ProtoGenerateRequest::Mlx(Box::new(req)))
             }
         }
     }
@@ -461,6 +542,15 @@ impl GrpcClient {
                 )?;
                 Ok(ProtoGenerateRequest::Trtllm(Box::new(req)))
             }
+            Self::Mlx(client) => {
+                let req = client.build_plain_generate_request(
+                    request_id,
+                    body,
+                    original_text,
+                    token_ids,
+                )?;
+                Ok(ProtoGenerateRequest::Mlx(Box::new(req)))
+            }
         }
     }
 }
@@ -473,12 +563,14 @@ pub enum ModelInfo {
     Sglang(Box<smg_grpc_client::sglang_proto::GetModelInfoResponse>),
     Vllm(smg_grpc_client::vllm_proto::GetModelInfoResponse),
     Trtllm(smg_grpc_client::trtllm_proto::GetModelInfoResponse),
+    Mlx(smg_grpc_client::mlx_proto::GetModelInfoResponse),
 }
 
 pub enum ServerInfo {
     Sglang(Box<smg_grpc_client::sglang_proto::GetServerInfoResponse>),
     Vllm(smg_grpc_client::vllm_proto::GetServerInfoResponse),
     Trtllm(smg_grpc_client::trtllm_proto::GetServerInfoResponse),
+    Mlx(smg_grpc_client::mlx_proto::GetServerInfoResponse),
 }
 
 impl ModelInfo {
@@ -487,6 +579,7 @@ impl ModelInfo {
             ModelInfo::Sglang(info) => flat_labels(info),
             ModelInfo::Vllm(info) => flat_labels(info),
             ModelInfo::Trtllm(info) => flat_labels(info),
+            ModelInfo::Mlx(info) => flat_labels(info),
         }
     }
 }
@@ -508,6 +601,7 @@ impl ServerInfo {
             }
             ServerInfo::Vllm(info) => flat_labels(info),
             ServerInfo::Trtllm(info) => flat_labels(info),
+            ServerInfo::Mlx(info) => flat_labels(info),
         }
     }
 }

--- a/model_gateway/src/routers/grpc/client.rs
+++ b/model_gateway/src/routers/grpc/client.rs
@@ -455,6 +455,7 @@ impl GrpcClient {
                     body,
                     processed_text,
                     token_ids,
+                    tool_constraints,
                 )?;
                 Ok(ProtoGenerateRequest::Mlx(Box::new(req)))
             }

--- a/model_gateway/src/routers/grpc/client.rs
+++ b/model_gateway/src/routers/grpc/client.rs
@@ -371,16 +371,14 @@ impl GrpcClient {
                 )?;
                 Ok(ProtoGenerateRequest::Trtllm(Box::new(req)))
             }
+            // MLX: caller stage rejects multimodal before reaching this path.
             Self::Mlx(client) => {
-                if multimodal_inputs.is_some() {
-                    return Err("MLX backend does not support multimodal inputs".to_string());
-                }
                 let req = client.build_generate_request_from_chat(
                     request_id,
                     body,
                     processed_text,
                     token_ids,
-                    tool_constraints, // MLX rejects constraints inside the builder
+                    tool_constraints,
                 )?;
                 Ok(ProtoGenerateRequest::Mlx(Box::new(req)))
             }
@@ -446,10 +444,8 @@ impl GrpcClient {
                 )?;
                 Ok(ProtoGenerateRequest::Trtllm(Box::new(req)))
             }
+            // MLX: caller stage rejects multimodal before reaching this path.
             Self::Mlx(client) => {
-                if multimodal_inputs.is_some() {
-                    return Err("MLX backend does not support multimodal inputs".to_string());
-                }
                 let req = client.build_generate_request_from_messages(
                     request_id,
                     body,

--- a/model_gateway/src/routers/grpc/common/stages/request_execution.rs
+++ b/model_gateway/src/routers/grpc/common/stages/request_execution.rs
@@ -113,6 +113,7 @@ impl PipelineStage for RequestExecutionStage {
                                 self.execute_dual_dispatch(req, clients, workers).await
                             }
                             Some(RuntimeType::Trtllm)
+                            | Some(RuntimeType::Mlx)
                             | Some(RuntimeType::External)
                             | Some(RuntimeType::Unspecified) => {
                                 error!(

--- a/model_gateway/src/routers/grpc/harmony/stages/request_building.rs
+++ b/model_gateway/src/routers/grpc/harmony/stages/request_building.rs
@@ -235,12 +235,18 @@ impl PipelineStage for HarmonyRequestBuildingStage {
                                 error::bad_request("invalid_request_parameters", format!("Invalid request parameters: {e}"))
                             })?
                     }
-                    RequestType::Responses(_) => {
-                        return Err(error::bad_request(
-                            "mlx_responses_not_supported",
-                            "Responses API is not supported with MLX backend".to_string(),
-                        ));
-                    }
+                    RequestType::Responses(request) => mlx_client
+                        .build_generate_request_from_responses(
+                            request_id,
+                            request.as_ref(),
+                            placeholder_processed_text,
+                            prep.token_ids.clone(),
+                            prep.tool_constraints.clone(),
+                        )
+                        .map_err(|e| {
+                            error!(function = "HarmonyRequestBuildingStage::execute", error = %e, "Failed to build MLX generate request from responses");
+                            error::bad_request("invalid_request_parameters", format!("Invalid request parameters: {e}"))
+                        })?,
                     RequestType::Embedding(_) => {
                         return Err(error::bad_request(
                             "harmony_embedding_not_supported",

--- a/model_gateway/src/routers/grpc/harmony/stages/request_building.rs
+++ b/model_gateway/src/routers/grpc/harmony/stages/request_building.rs
@@ -220,15 +220,6 @@ impl PipelineStage for HarmonyRequestBuildingStage {
                 ProtoGenerateRequest::Trtllm(Box::new(req))
             }
             GrpcClient::Mlx(mlx_client) => {
-                // MLX doesn't support backend-side constraints (structural_tag, json_schema)
-                // needed by Harmony for tool calling and structured outputs
-                if prep.tool_constraints.is_some() {
-                    return Err(error::bad_request(
-                        "mlx_constraints_not_supported",
-                        "MLX backend does not support Harmony structured output constraints (structural_tag). Tool calling and structured outputs in Harmony mode require a backend with constrained decoding support.".to_string(),
-                    ));
-                }
-
                 let req = match &ctx.input.request_type {
                     RequestType::Chat(request) => {
                         let body = prep.filtered_request.as_ref().unwrap_or_else(|| request.as_ref());
@@ -238,6 +229,7 @@ impl PipelineStage for HarmonyRequestBuildingStage {
                                 body,
                                 placeholder_processed_text,
                                 prep.token_ids.clone(),
+                                prep.tool_constraints.clone(),
                             )
                             .map_err(|e| {
                                 error!(function = "HarmonyRequestBuildingStage::execute", error = %e, "Failed to build MLX generate request");

--- a/model_gateway/src/routers/grpc/harmony/stages/request_building.rs
+++ b/model_gateway/src/routers/grpc/harmony/stages/request_building.rs
@@ -219,6 +219,43 @@ impl PipelineStage for HarmonyRequestBuildingStage {
                 };
                 ProtoGenerateRequest::Trtllm(Box::new(req))
             }
+            GrpcClient::Mlx(mlx_client) => {
+                let req = match &ctx.input.request_type {
+                    RequestType::Chat(request) => {
+                        let body = prep.filtered_request.as_ref().unwrap_or_else(|| request.as_ref());
+                        mlx_client
+                            .build_generate_request_from_chat(
+                                request_id,
+                                body,
+                                placeholder_processed_text,
+                                prep.token_ids.clone(),
+                            )
+                            .map_err(|e| {
+                                error!(function = "HarmonyRequestBuildingStage::execute", error = %e, "Failed to build MLX generate request");
+                                error::bad_request("invalid_request_parameters", format!("Invalid request parameters: {e}"))
+                            })?
+                    }
+                    RequestType::Responses(_) => {
+                        return Err(error::bad_request(
+                            "mlx_responses_not_supported",
+                            "Responses API is not supported with MLX backend".to_string(),
+                        ));
+                    }
+                    RequestType::Embedding(_) => {
+                        return Err(error::bad_request(
+                            "harmony_embedding_not_supported",
+                            "Embedding requests are not supported with Harmony models".to_string(),
+                        ));
+                    }
+                    _ => {
+                        return Err(error::bad_request(
+                            "unsupported_request_type",
+                            "Unsupported request type for Harmony models".to_string(),
+                        ));
+                    }
+                };
+                ProtoGenerateRequest::Mlx(Box::new(req))
+            }
         };
 
         // Inject Harmony stop token IDs into sampling params for ALL Harmony requests
@@ -254,6 +291,15 @@ impl PipelineStage for HarmonyRequestBuildingStage {
                         stop_token_count = harmony_stops.len(),
                         "Injected Harmony stop tokens into TensorRT-LLM stop_token_ids"
                     );
+                }
+                ProtoGenerateRequest::Mlx(req) => {
+                    if let Some(ref mut params) = req.sampling_params {
+                        params.stop_token_ids.extend_from_slice(harmony_stops);
+                        debug!(
+                            stop_token_count = harmony_stops.len(),
+                            "Injected Harmony stop tokens into MLX sampling params"
+                        );
+                    }
                 }
             }
         }

--- a/model_gateway/src/routers/grpc/harmony/stages/request_building.rs
+++ b/model_gateway/src/routers/grpc/harmony/stages/request_building.rs
@@ -220,6 +220,15 @@ impl PipelineStage for HarmonyRequestBuildingStage {
                 ProtoGenerateRequest::Trtllm(Box::new(req))
             }
             GrpcClient::Mlx(mlx_client) => {
+                // MLX doesn't support backend-side constraints (structural_tag, json_schema)
+                // needed by Harmony for tool calling and structured outputs
+                if prep.tool_constraints.is_some() {
+                    return Err(error::bad_request(
+                        "mlx_constraints_not_supported",
+                        "MLX backend does not support Harmony structured output constraints (structural_tag). Tool calling and structured outputs in Harmony mode require a backend with constrained decoding support.".to_string(),
+                    ));
+                }
+
                 let req = match &ctx.input.request_type {
                     RequestType::Chat(request) => {
                         let body = prep.filtered_request.as_ref().unwrap_or_else(|| request.as_ref());

--- a/model_gateway/src/routers/grpc/multimodal.rs
+++ b/model_gateway/src/routers/grpc/multimodal.rs
@@ -599,7 +599,10 @@ fn expand_tokens(
 /// Assemble backend-specific multimodal data from the intermediate.
 ///
 /// Called in request_building after worker selection, when the backend is known.
-#[expect(clippy::unreachable, reason = "MLX multimodal rejected by caller before reaching here")]
+#[expect(
+    clippy::unreachable,
+    reason = "MLX multimodal rejected by caller before reaching here"
+)]
 pub(crate) fn assemble_multimodal_data(
     intermediate: MultimodalIntermediate,
     client: &GrpcClient,
@@ -608,7 +611,9 @@ pub(crate) fn assemble_multimodal_data(
         GrpcClient::Sglang(_) => MultimodalData::Sglang(assemble_sglang(intermediate)),
         GrpcClient::Vllm(_) => MultimodalData::Vllm(assemble_vllm(intermediate)),
         GrpcClient::Trtllm(_) => MultimodalData::Trtllm(assemble_trtllm(intermediate)),
-        GrpcClient::Mlx(_) => unreachable!("caller rejects multimodal for MLX in build_chat_request/build_messages_request"),
+        GrpcClient::Mlx(_) => unreachable!(
+            "caller rejects multimodal for MLX in build_chat_request/build_messages_request"
+        ),
     }
 }
 

--- a/model_gateway/src/routers/grpc/multimodal.rs
+++ b/model_gateway/src/routers/grpc/multimodal.rs
@@ -607,6 +607,7 @@ pub(crate) fn assemble_multimodal_data(
         GrpcClient::Sglang(_) => MultimodalData::Sglang(assemble_sglang(intermediate)),
         GrpcClient::Vllm(_) => MultimodalData::Vllm(assemble_vllm(intermediate)),
         GrpcClient::Trtllm(_) => MultimodalData::Trtllm(assemble_trtllm(intermediate)),
+        GrpcClient::Mlx(_) => unreachable!("MLX backend does not support multimodal inputs"),
     }
 }
 

--- a/model_gateway/src/routers/grpc/multimodal.rs
+++ b/model_gateway/src/routers/grpc/multimodal.rs
@@ -602,12 +602,12 @@ fn expand_tokens(
 pub(crate) fn assemble_multimodal_data(
     intermediate: MultimodalIntermediate,
     client: &GrpcClient,
-) -> MultimodalData {
+) -> Result<MultimodalData, String> {
     match client {
-        GrpcClient::Sglang(_) => MultimodalData::Sglang(assemble_sglang(intermediate)),
-        GrpcClient::Vllm(_) => MultimodalData::Vllm(assemble_vllm(intermediate)),
-        GrpcClient::Trtllm(_) => MultimodalData::Trtllm(assemble_trtllm(intermediate)),
-        GrpcClient::Mlx(_) => unreachable!("MLX backend does not support multimodal inputs"),
+        GrpcClient::Sglang(_) => Ok(MultimodalData::Sglang(assemble_sglang(intermediate))),
+        GrpcClient::Vllm(_) => Ok(MultimodalData::Vllm(assemble_vllm(intermediate))),
+        GrpcClient::Trtllm(_) => Ok(MultimodalData::Trtllm(assemble_trtllm(intermediate))),
+        GrpcClient::Mlx(_) => Err("MLX backend does not support multimodal inputs".to_string()),
     }
 }
 

--- a/model_gateway/src/routers/grpc/multimodal.rs
+++ b/model_gateway/src/routers/grpc/multimodal.rs
@@ -599,15 +599,16 @@ fn expand_tokens(
 /// Assemble backend-specific multimodal data from the intermediate.
 ///
 /// Called in request_building after worker selection, when the backend is known.
+#[expect(clippy::unreachable, reason = "MLX multimodal rejected by caller before reaching here")]
 pub(crate) fn assemble_multimodal_data(
     intermediate: MultimodalIntermediate,
     client: &GrpcClient,
-) -> Result<MultimodalData, String> {
+) -> MultimodalData {
     match client {
-        GrpcClient::Sglang(_) => Ok(MultimodalData::Sglang(assemble_sglang(intermediate))),
-        GrpcClient::Vllm(_) => Ok(MultimodalData::Vllm(assemble_vllm(intermediate))),
-        GrpcClient::Trtllm(_) => Ok(MultimodalData::Trtllm(assemble_trtllm(intermediate))),
-        GrpcClient::Mlx(_) => Err("MLX backend does not support multimodal inputs".to_string()),
+        GrpcClient::Sglang(_) => MultimodalData::Sglang(assemble_sglang(intermediate)),
+        GrpcClient::Vllm(_) => MultimodalData::Vllm(assemble_vllm(intermediate)),
+        GrpcClient::Trtllm(_) => MultimodalData::Trtllm(assemble_trtllm(intermediate)),
+        GrpcClient::Mlx(_) => unreachable!("caller rejects multimodal for MLX in build_chat_request/build_messages_request"),
     }
 }
 

--- a/model_gateway/src/routers/grpc/proto_wrapper.rs
+++ b/model_gateway/src/routers/grpc/proto_wrapper.rs
@@ -7,6 +7,8 @@ use std::collections::HashMap;
 
 use futures_util::StreamExt;
 use smg_grpc_client::{
+    mlx_engine::AbortOnDropStream as MlxStream,
+    mlx_proto::{self as mlx},
     sglang_proto::{self as sglang, generate_complete::MatchedStop as SglangMatchedStop},
     sglang_scheduler::AbortOnDropStream as SglangStream,
     trtllm_proto::{self as trtllm, generate_complete::MatchedStop as TrtllmMatchedStop},
@@ -277,6 +279,7 @@ pub enum ProtoGenerateRequest {
     Sglang(Box<sglang::GenerateRequest>),
     Vllm(Box<vllm::GenerateRequest>),
     Trtllm(Box<trtllm::GenerateRequest>),
+    Mlx(Box<mlx::GenerateRequest>),
 }
 
 impl ProtoGenerateRequest {
@@ -382,7 +385,7 @@ impl ProtoGenerateRequest {
                     });
                 }
             }
-            _ => {
+            Self::Sglang(_) | Self::Trtllm(_) | Self::Mlx(_) => {
                 tracing::warn!("set_max_tokens_for_prefill called on non-vLLM request, ignoring");
             }
         }
@@ -394,6 +397,7 @@ impl ProtoGenerateRequest {
             Self::Vllm(req) => req.stream = stream,
             Self::Sglang(req) => req.stream = stream,
             Self::Trtllm(req) => req.streaming = stream,
+            Self::Mlx(req) => req.stream = stream,
         }
     }
 
@@ -408,6 +412,7 @@ impl ProtoGenerateRequest {
             Self::Sglang(req) => &req.request_id,
             Self::Vllm(req) => &req.request_id,
             Self::Trtllm(req) => &req.request_id,
+            Self::Mlx(req) => &req.request_id,
         }
     }
 
@@ -421,7 +426,7 @@ impl ProtoGenerateRequest {
                     remote_port,
                 });
             }
-            _ => {
+            Self::Sglang(_) | Self::Trtllm(_) | Self::Mlx(_) => {
                 tracing::warn!("set_kv_transfer_params called on non-vLLM request, ignoring");
             }
         }
@@ -433,6 +438,7 @@ pub enum ProtoGenerateResponse {
     Sglang(Box<sglang::GenerateResponse>),
     Vllm(Box<vllm::GenerateResponse>),
     Trtllm(Box<trtllm::GenerateResponse>),
+    Mlx(Box<mlx::GenerateResponse>),
 }
 
 impl ProtoGenerateResponse {
@@ -468,6 +474,15 @@ impl ProtoGenerateResponse {
                 }
                 None => ProtoResponseVariant::None,
             },
+            Self::Mlx(resp) => match resp.response {
+                Some(mlx::generate_response::Response::Chunk(chunk)) => {
+                    ProtoResponseVariant::Chunk(ProtoGenerateStreamChunk::Mlx(chunk))
+                }
+                Some(mlx::generate_response::Response::Complete(complete)) => {
+                    ProtoResponseVariant::Complete(ProtoGenerateComplete::Mlx(complete))
+                }
+                None => ProtoResponseVariant::None,
+            },
         }
     }
 }
@@ -485,6 +500,7 @@ pub enum ProtoGenerateStreamChunk {
     Sglang(sglang::GenerateStreamChunk),
     Vllm(vllm::GenerateStreamChunk),
     Trtllm(trtllm::GenerateStreamChunk),
+    Mlx(mlx::GenerateStreamChunk),
 }
 
 impl ProtoGenerateStreamChunk {
@@ -539,12 +555,18 @@ impl ProtoGenerateStreamChunk {
         matches!(self, Self::Trtllm(_))
     }
 
+    /// Check if this is MLX
+    pub fn is_mlx(&self) -> bool {
+        matches!(self, Self::Mlx(_))
+    }
+
     /// Get token IDs from chunk (common field)
     pub fn token_ids(&self) -> &[u32] {
         match self {
             Self::Sglang(c) => &c.token_ids,
             Self::Vllm(c) => &c.token_ids,
             Self::Trtllm(c) => &c.token_ids,
+            Self::Mlx(c) => &c.token_ids,
         }
     }
 
@@ -555,10 +577,11 @@ impl ProtoGenerateStreamChunk {
             Self::Sglang(c) => c.index,
             Self::Vllm(c) => c.index,
             Self::Trtllm(c) => c.sequence_index,
+            Self::Mlx(c) => c.index,
         }
     }
 
-    /// Get output logprobs (SGLang, vLLM, and TensorRT-LLM)
+    /// Get output logprobs (SGLang, vLLM, TensorRT-LLM, and MLX)
     pub fn output_logprobs(&self) -> Option<ProtoOutputLogProbs> {
         match self {
             Self::Sglang(c) => c
@@ -570,6 +593,10 @@ impl ProtoGenerateStreamChunk {
                 .as_ref()
                 .map(|lp| convert_output_logprobs!(lp)),
             Self::Trtllm(c) => convert_trtllm_output_logprobs(&c.logprobs),
+            Self::Mlx(c) => c
+                .output_logprobs
+                .as_ref()
+                .map(|lp| convert_output_logprobs!(lp)),
         }
     }
 
@@ -584,8 +611,8 @@ impl ProtoGenerateStreamChunk {
                 .input_logprobs
                 .as_ref()
                 .map(|lp| convert_input_logprobs!(lp)),
-            // TRT-LLM streaming chunks don't have prompt_logprobs
-            Self::Trtllm(_) => None,
+            // TRT-LLM and MLX streaming chunks don't have input_logprobs
+            Self::Trtllm(_) | Self::Mlx(_) => None,
         }
     }
 
@@ -595,6 +622,7 @@ impl ProtoGenerateStreamChunk {
             Self::Sglang(c) => c.prompt_tokens,
             Self::Vllm(c) => c.prompt_tokens,
             Self::Trtllm(c) => c.prompt_tokens,
+            Self::Mlx(c) => c.prompt_tokens,
         }
     }
 
@@ -604,6 +632,7 @@ impl ProtoGenerateStreamChunk {
             Self::Sglang(c) => c.completion_tokens,
             Self::Vllm(c) => c.completion_tokens,
             Self::Trtllm(c) => c.completion_tokens,
+            Self::Mlx(c) => c.completion_tokens,
         }
     }
 
@@ -613,6 +642,7 @@ impl ProtoGenerateStreamChunk {
             Self::Sglang(c) => c.cached_tokens,
             Self::Vllm(c) => c.cached_tokens,
             Self::Trtllm(c) => c.cached_tokens,
+            Self::Mlx(c) => c.cached_tokens,
         }
     }
 }
@@ -623,6 +653,7 @@ pub enum ProtoGenerateComplete {
     Sglang(sglang::GenerateComplete),
     Vllm(vllm::GenerateComplete),
     Trtllm(trtllm::GenerateComplete),
+    Mlx(mlx::GenerateComplete),
 }
 
 impl ProtoGenerateComplete {
@@ -689,12 +720,18 @@ impl ProtoGenerateComplete {
         matches!(self, Self::Trtllm(_))
     }
 
+    /// Check if this is MLX
+    pub fn is_mlx(&self) -> bool {
+        matches!(self, Self::Mlx(_))
+    }
+
     /// Get token IDs from either backend (output_ids in proto)
     pub fn token_ids(&self) -> &[u32] {
         match self {
             Self::Sglang(c) => &c.output_ids,
             Self::Vllm(c) => &c.output_ids,
             Self::Trtllm(c) => &c.output_token_ids,
+            Self::Mlx(c) => &c.output_ids,
         }
     }
 
@@ -704,6 +741,7 @@ impl ProtoGenerateComplete {
             Self::Sglang(c) => c.prompt_tokens,
             Self::Vllm(c) => c.prompt_tokens,
             Self::Trtllm(c) => c.prompt_tokens,
+            Self::Mlx(c) => c.prompt_tokens,
         }
     }
 
@@ -713,6 +751,7 @@ impl ProtoGenerateComplete {
             Self::Sglang(c) => c.completion_tokens,
             Self::Vllm(c) => c.completion_tokens,
             Self::Trtllm(c) => c.completion_tokens,
+            Self::Mlx(c) => c.completion_tokens,
         }
     }
 
@@ -722,6 +761,7 @@ impl ProtoGenerateComplete {
             Self::Sglang(c) => &c.finish_reason,
             Self::Vllm(c) => &c.finish_reason,
             Self::Trtllm(c) => &c.finish_reason,
+            Self::Mlx(c) => &c.finish_reason,
         }
     }
 
@@ -732,6 +772,7 @@ impl ProtoGenerateComplete {
             Self::Sglang(c) => c.index,
             Self::Vllm(c) => c.index,
             Self::Trtllm(c) => c.sequence_index,
+            Self::Mlx(c) => c.index,
         }
     }
 
@@ -766,6 +807,9 @@ impl ProtoGenerateComplete {
                 TrtllmMatchedStop::MatchedTokenId,
                 TrtllmMatchedStop::MatchedStopStr
             ),
+            Self::Mlx(c) => c
+                .matched_stop_token_id
+                .map(|id| serde_json::Value::Number(id.into())),
         }
     }
 
@@ -775,6 +819,7 @@ impl ProtoGenerateComplete {
             Self::Sglang(c) => &c.output_ids,
             Self::Vllm(c) => &c.output_ids,
             Self::Trtllm(c) => &c.output_token_ids,
+            Self::Mlx(c) => &c.output_ids,
         }
     }
 
@@ -784,6 +829,7 @@ impl ProtoGenerateComplete {
             Self::Sglang(c) => c.cached_tokens,
             Self::Vllm(c) => c.cached_tokens,
             Self::Trtllm(c) => c.cached_tokens,
+            Self::Mlx(c) => c.cached_tokens,
         }
     }
 
@@ -822,10 +868,12 @@ impl ProtoGenerateComplete {
                     })
                 }
             }
+            // MLX does not have input_logprobs
+            Self::Mlx(_) => None,
         }
     }
 
-    /// Get output logprobs (SGLang, vLLM, and TensorRT-LLM)
+    /// Get output logprobs (SGLang, vLLM, TensorRT-LLM, and MLX)
     pub fn output_logprobs(&self) -> Option<ProtoOutputLogProbs> {
         match self {
             Self::Sglang(c) => c
@@ -837,6 +885,10 @@ impl ProtoGenerateComplete {
                 .as_ref()
                 .map(|lp| convert_output_logprobs!(lp)),
             Self::Trtllm(c) => convert_trtllm_output_logprobs(&c.logprobs),
+            Self::Mlx(c) => c
+                .output_logprobs
+                .as_ref()
+                .map(|lp| convert_output_logprobs!(lp)),
         }
     }
 
@@ -848,7 +900,7 @@ impl ProtoGenerateComplete {
                 .kv_transfer_params
                 .as_ref()
                 .map(|params| (params.remote_host.clone(), params.remote_port)),
-            Self::Sglang(_) | Self::Trtllm(_) => None,
+            Self::Sglang(_) | Self::Trtllm(_) | Self::Mlx(_) => None,
         }
     }
 }
@@ -858,6 +910,7 @@ pub enum ProtoStream {
     Sglang(SglangStream),
     Vllm(VllmStream),
     Trtllm(TrtllmStream),
+    Mlx(MlxStream),
 }
 
 impl ProtoStream {
@@ -876,6 +929,10 @@ impl ProtoStream {
                 .next()
                 .await
                 .map(|result| result.map(|r| ProtoGenerateResponse::Trtllm(Box::new(r)))),
+            Self::Mlx(stream) => stream
+                .next()
+                .await
+                .map(|result| result.map(|r| ProtoGenerateResponse::Mlx(Box::new(r)))),
         }
     }
 
@@ -885,6 +942,7 @@ impl ProtoStream {
             Self::Sglang(stream) => stream.mark_completed(),
             Self::Vllm(stream) => stream.mark_completed(),
             Self::Trtllm(stream) => stream.mark_completed(),
+            Self::Mlx(stream) => stream.mark_completed(),
         }
     }
 }

--- a/model_gateway/src/routers/grpc/regular/stages/chat/request_building.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/chat/request_building.rs
@@ -75,6 +75,14 @@ impl PipelineStage for ChatRequestBuildingStage {
             )
         })?;
 
+        // Reject multimodal for backends that don't support it, before assembling
+        if processed_messages.multimodal_intermediate.is_some() && builder_client.is_mlx() {
+            return Err(error::bad_request(
+                "multimodal_not_supported",
+                "MLX backend does not support multimodal inputs".to_string(),
+            ));
+        }
+
         // Assemble backend-specific multimodal data now that the backend is known
         let multimodal_data = processed_messages
             .multimodal_intermediate

--- a/model_gateway/src/routers/grpc/regular/stages/chat/request_building.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/chat/request_building.rs
@@ -78,7 +78,9 @@ impl PipelineStage for ChatRequestBuildingStage {
         // Assemble backend-specific multimodal data now that the backend is known
         let multimodal_data = processed_messages
             .multimodal_intermediate
-            .map(|intermediate| assemble_multimodal_data(intermediate, builder_client));
+            .map(|intermediate| assemble_multimodal_data(intermediate, builder_client))
+            .transpose()
+            .map_err(|e| error::bad_request("multimodal_not_supported", e))?;
 
         let mut proto_request = builder_client
             .build_chat_request(

--- a/model_gateway/src/routers/grpc/regular/stages/chat/request_building.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/chat/request_building.rs
@@ -78,9 +78,7 @@ impl PipelineStage for ChatRequestBuildingStage {
         // Assemble backend-specific multimodal data now that the backend is known
         let multimodal_data = processed_messages
             .multimodal_intermediate
-            .map(|intermediate| assemble_multimodal_data(intermediate, builder_client))
-            .transpose()
-            .map_err(|e| error::bad_request("multimodal_not_supported", e))?;
+            .map(|intermediate| assemble_multimodal_data(intermediate, builder_client));
 
         let mut proto_request = builder_client
             .build_chat_request(

--- a/model_gateway/src/routers/grpc/regular/stages/embedding/request_building.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/embedding/request_building.rs
@@ -94,6 +94,16 @@ impl PipelineStage for EmbeddingRequestBuildingStage {
                     "TensorRT-LLM embedding is not yet supported via gRPC",
                 ));
             }
+            GrpcClient::Mlx(_) => {
+                error!(
+                    function = "EmbeddingRequestBuildingStage::execute",
+                    "MLX embedding not supported"
+                );
+                return Err(error::not_implemented(
+                    "unsupported_backend",
+                    "MLX embedding is not supported via gRPC",
+                ));
+            }
         };
 
         ctx.state.proto_request = Some(ProtoRequest::Embed(proto_req));

--- a/model_gateway/src/routers/grpc/regular/stages/messages/request_building.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/messages/request_building.rs
@@ -75,6 +75,14 @@ impl PipelineStage for MessageRequestBuildingStage {
             )
         })?;
 
+        // Reject multimodal for backends that don't support it, before assembling
+        if processed_messages.multimodal_intermediate.is_some() && builder_client.is_mlx() {
+            return Err(error::bad_request(
+                "multimodal_not_supported",
+                "MLX backend does not support multimodal inputs".to_string(),
+            ));
+        }
+
         // Assemble backend-specific multimodal data now that the backend is known
         let multimodal_data = processed_messages
             .multimodal_intermediate

--- a/model_gateway/src/routers/grpc/regular/stages/messages/request_building.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/messages/request_building.rs
@@ -78,7 +78,9 @@ impl PipelineStage for MessageRequestBuildingStage {
         // Assemble backend-specific multimodal data now that the backend is known
         let multimodal_data = processed_messages
             .multimodal_intermediate
-            .map(|intermediate| assemble_multimodal_data(intermediate, builder_client));
+            .map(|intermediate| assemble_multimodal_data(intermediate, builder_client))
+            .transpose()
+            .map_err(|e| error::bad_request("multimodal_not_supported", e))?;
 
         let mut proto_request = builder_client
             .build_messages_request(

--- a/model_gateway/src/routers/grpc/regular/stages/messages/request_building.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/messages/request_building.rs
@@ -78,9 +78,7 @@ impl PipelineStage for MessageRequestBuildingStage {
         // Assemble backend-specific multimodal data now that the backend is known
         let multimodal_data = processed_messages
             .multimodal_intermediate
-            .map(|intermediate| assemble_multimodal_data(intermediate, builder_client))
-            .transpose()
-            .map_err(|e| error::bad_request("multimodal_not_supported", e))?;
+            .map(|intermediate| assemble_multimodal_data(intermediate, builder_client));
 
         let mut proto_request = builder_client
             .build_messages_request(

--- a/model_gateway/src/workflow/steps/local/detect_backend.rs
+++ b/model_gateway/src/workflow/steps/local/detect_backend.rs
@@ -1,8 +1,8 @@
 //! Backend runtime detection step.
 //!
 //! Detects the runtime type (sglang, vllm, trtllm, mlx) for both HTTP and gRPC workers.
-//! - HTTP: probes `/v1/models` (owned_by field), falls back to unique endpoints.
-//! - gRPC: tries sglang → vllm → trtllm → mlx health checks sequentially.
+//! - HTTP: probes `/v1/models` (owned_by field), falls back to unique endpoints in parallel.
+//! - gRPC: probes all runtime health checks in parallel (`tokio::join!`).
 
 use std::time::Duration;
 
@@ -22,10 +22,11 @@ use crate::{
 
 // ─── gRPC backend detection ────────────────────────────────────────────────
 
-/// Detect gRPC backend by trying runtime-specific health checks sequentially.
+/// Detect gRPC backend by probing runtime-specific health checks in parallel.
 ///
 /// If `runtime_hint` is provided (from explicit config), tries that first.
-/// Otherwise tries sglang → vllm → trtllm → mlx.
+/// Otherwise probes all runtimes concurrently, returning the first match
+/// with priority: sglang > vllm > trtllm > mlx.
 async fn detect_grpc_backend(
     url: &str,
     timeout_secs: u64,

--- a/model_gateway/src/workflow/steps/local/detect_backend.rs
+++ b/model_gateway/src/workflow/steps/local/detect_backend.rs
@@ -1,8 +1,8 @@
 //! Backend runtime detection step.
 //!
 //! Detects the runtime type (sglang, vllm, trtllm, mlx) for both HTTP and gRPC workers.
-//! - HTTP: probes `/v1/models` (owned_by field), falls back to unique endpoints in parallel.
-//! - gRPC: probes all runtime health checks in parallel (`tokio::join!`).
+//! - HTTP: probes `/v1/models` (owned_by field), falls back to unique endpoints.
+//! - gRPC: tries sglang → vllm → trtllm → mlx health checks sequentially.
 
 use std::time::Duration;
 
@@ -22,11 +22,10 @@ use crate::{
 
 // ─── gRPC backend detection ────────────────────────────────────────────────
 
-/// Detect gRPC backend by probing runtime-specific health checks in parallel.
+/// Detect gRPC backend by trying runtime-specific health checks sequentially.
 ///
 /// If `runtime_hint` is provided (from explicit config), tries that first.
-/// Otherwise probes all runtimes concurrently, returning the first match
-/// with priority: sglang > vllm > trtllm > mlx.
+/// Otherwise tries sglang → vllm → trtllm → mlx.
 async fn detect_grpc_backend(
     url: &str,
     timeout_secs: u64,
@@ -44,25 +43,17 @@ async fn detect_grpc_backend(
         }
     }
 
-    // Probe all runtimes in parallel (most common first in result preference)
-    let (sglang, vllm, trtllm, mlx) = tokio::join!(
-        do_grpc_health_check(&grpc_url, timeout_secs, "sglang"),
-        do_grpc_health_check(&grpc_url, timeout_secs, "vllm"),
-        do_grpc_health_check(&grpc_url, timeout_secs, "trtllm"),
-        do_grpc_health_check(&grpc_url, timeout_secs, "mlx"),
-    );
-
-    if sglang.is_ok() {
-        return Ok("sglang".to_string());
-    }
-    if vllm.is_ok() {
-        return Ok("vllm".to_string());
-    }
-    if trtllm.is_ok() {
-        return Ok("trtllm".to_string());
-    }
-    if mlx.is_ok() {
-        return Ok("mlx".to_string());
+    // Try each runtime sequentially (most common first), skipping the hint we already tried
+    for runtime in &["sglang", "vllm", "trtllm", "mlx"] {
+        if Some(*runtime) == runtime_hint {
+            continue;
+        }
+        if do_grpc_health_check(&grpc_url, timeout_secs, runtime)
+            .await
+            .is_ok()
+        {
+            return Ok((*runtime).to_string());
+        }
     }
 
     Err(format!(

--- a/model_gateway/src/workflow/steps/local/detect_backend.rs
+++ b/model_gateway/src/workflow/steps/local/detect_backend.rs
@@ -1,8 +1,8 @@
 //! Backend runtime detection step.
 //!
-//! Detects the runtime type (sglang, vllm, trtllm) for both HTTP and gRPC workers.
+//! Detects the runtime type (sglang, vllm, trtllm, mlx) for both HTTP and gRPC workers.
 //! - HTTP: probes `/v1/models` (owned_by field), falls back to unique endpoints.
-//! - gRPC: tries sglang → vllm → trtllm health checks sequentially.
+//! - gRPC: tries sglang → vllm → trtllm → mlx health checks sequentially.
 
 use std::time::Duration;
 
@@ -25,7 +25,7 @@ use crate::{
 /// Detect gRPC backend by trying runtime-specific health checks sequentially.
 ///
 /// If `runtime_hint` is provided (from explicit config), tries that first.
-/// Otherwise tries sglang → vllm → trtllm.
+/// Otherwise tries sglang → vllm → trtllm → mlx.
 async fn detect_grpc_backend(
     url: &str,
     timeout_secs: u64,
@@ -44,7 +44,7 @@ async fn detect_grpc_backend(
     }
 
     // Try each runtime sequentially (most common first), skipping the hint we already tried
-    for runtime in &["sglang", "vllm", "trtllm"] {
+    for runtime in &["sglang", "vllm", "trtllm", "mlx"] {
         if Some(*runtime) == runtime_hint {
             continue;
         }
@@ -57,7 +57,7 @@ async fn detect_grpc_backend(
     }
 
     Err(format!(
-        "gRPC backend detection failed for {url} (tried sglang, vllm, trtllm)"
+        "gRPC backend detection failed for {url} (tried sglang, vllm, trtllm, mlx)"
     ))
 }
 
@@ -221,7 +221,7 @@ async fn detect_http_backend(
 
 // ─── Step implementation ───────────────────────────────────────────────────
 
-/// Step 2: Detect backend runtime type (sglang, vllm, trtllm).
+/// Step 2: Detect backend runtime type (sglang, vllm, trtllm, mlx).
 ///
 /// Runs after `detect_connection_mode` and before `discover_metadata`.
 /// Sets `detected_runtime_type` in workflow data for all downstream steps.

--- a/model_gateway/src/workflow/steps/local/detect_backend.rs
+++ b/model_gateway/src/workflow/steps/local/detect_backend.rs
@@ -33,7 +33,7 @@ async fn detect_grpc_backend(
 ) -> Result<String, String> {
     let grpc_url = grpc_base_url(url);
 
-    // If we have a hint, try it first
+    // If we have a hint, try it first (fast path)
     if let Some(hint) = runtime_hint {
         if do_grpc_health_check(&grpc_url, timeout_secs, hint)
             .await
@@ -43,17 +43,25 @@ async fn detect_grpc_backend(
         }
     }
 
-    // Try each runtime sequentially (most common first), skipping the hint we already tried
-    for runtime in &["sglang", "vllm", "trtllm", "mlx"] {
-        if Some(*runtime) == runtime_hint {
-            continue;
-        }
-        if do_grpc_health_check(&grpc_url, timeout_secs, runtime)
-            .await
-            .is_ok()
-        {
-            return Ok((*runtime).to_string());
-        }
+    // Probe all runtimes in parallel (most common first in result preference)
+    let (sglang, vllm, trtllm, mlx) = tokio::join!(
+        do_grpc_health_check(&grpc_url, timeout_secs, "sglang"),
+        do_grpc_health_check(&grpc_url, timeout_secs, "vllm"),
+        do_grpc_health_check(&grpc_url, timeout_secs, "trtllm"),
+        do_grpc_health_check(&grpc_url, timeout_secs, "mlx"),
+    );
+
+    if sglang.is_ok() {
+        return Ok("sglang".to_string());
+    }
+    if vllm.is_ok() {
+        return Ok("vllm".to_string());
+    }
+    if trtllm.is_ok() {
+        return Ok("trtllm".to_string());
+    }
+    if mlx.is_ok() {
+        return Ok("mlx".to_string());
     }
 
     Err(format!(

--- a/model_gateway/src/workflow/steps/util.rs
+++ b/model_gateway/src/workflow/steps/util.rs
@@ -88,16 +88,17 @@ pub(crate) async fn try_grpc_reachable(url: &str, timeout_secs: u64) -> Result<(
         format!("grpc://{}", strip_protocol(url))
     };
 
-    let (sglang, vllm, trtllm) = tokio::join!(
+    let (sglang, vllm, trtllm, mlx) = tokio::join!(
         do_grpc_health_check(&grpc_url, timeout_secs, "sglang"),
         do_grpc_health_check(&grpc_url, timeout_secs, "vllm"),
         do_grpc_health_check(&grpc_url, timeout_secs, "trtllm"),
+        do_grpc_health_check(&grpc_url, timeout_secs, "mlx"),
     );
 
-    match (sglang, vllm, trtllm) {
-        (Ok(()), _, _) | (_, Ok(()), _) | (_, _, Ok(())) => Ok(()),
-        (Err(e1), Err(e2), Err(e3)) => Err(format!(
-            "gRPC not reachable (tried sglang, vllm, trtllm): sglang={e1}, vllm={e2}, trtllm={e3}",
+    match (sglang, vllm, trtllm, mlx) {
+        (Ok(()), _, _, _) | (_, Ok(()), _, _) | (_, _, Ok(()), _) | (_, _, _, Ok(())) => Ok(()),
+        (Err(e1), Err(e2), Err(e3), Err(e4)) => Err(format!(
+            "gRPC not reachable (tried sglang, vllm, trtllm, mlx): sglang={e1}, vllm={e2}, trtllm={e3}, mlx={e4}",
         )),
     }
 }


### PR DESCRIPTION
## Description

### Problem

Every existing gRPC backend (vLLM, SGLang, TensorRT-LLM) requires NVIDIA GPUs. There is no way to use Apple Silicon (MLX) as an inference backend through SMG's gRPC pipeline. Additionally, reusing the VllmEngine proto for MLX would mix two unrelated backends and create confusion about supported capabilities.

### Solution

Add a dedicated `MlxEngine` gRPC service with its own proto, Rust client, and full pipeline integration. MLX gets a clean, minimal contract — only the RPCs and fields it actually supports, no vLLM baggage.

## Changes

- **New proto** (`mlx_engine.proto`): 6 RPCs (Generate, HealthCheck, Abort, GetModelInfo, GetServerInfo, GetTokenizer), 13-field SamplingParams matching mlx-lm capabilities
- **Rust client** (`mlx_engine.rs`): `MlxEngineClient` with `AbortOnDropStream`, request builders for chat/completion/messages/responses/generate endpoints, centralized validation helpers that reject unsupported features (n>1, structured outputs, string stop sequences, response_format, multimodal)
- **Pipeline integration**: `GrpcClient::Mlx` variant with all match arms across `client.rs`, `proto_wrapper.rs`, harmony, multimodal, embedding stages
- **Runtime detection**: `RuntimeType::Mlx` in openai-protocol, parallel gRPC health check probing via `tokio::join!` in both reachability and backend detection
- **Proto codegen**: `build.rs` updated for two-pass compilation, `smg-grpc-proto` Python package exports `mlx_engine_pb2`

### What's NOT in this PR

Python servicer implementation (separate PR after this merges).

## Test Plan

- `cargo build -p smg` compiles cleanly
- `cargo +nightly fmt -- --check` passes
- `cargo clippy --all-targets --all-features -- -D warnings` passes
- Existing tests still pass (no behavior change for existing backends)
- Python servicer PR will add E2E verification with actual MLX model

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>