### PR TITLE
feat: support engine metrics from PROMETHEUS_MULTIPROC_DIR in grpc mode

### DIFF
--- a/bindings/python/src/smg/serve.py
+++ b/bindings/python/src/smg/serve.py
@@ -11,7 +11,9 @@ import atexit
 import logging
 import os
 import random
+import shutil
 import signal
+import tempfile
 import socket
 import subprocess
 import sys
@@ -550,6 +552,7 @@ class ServeOrchestrator:
         self.launcher: WorkerLauncher = BACKEND_LAUNCHERS[backend]()
         self.workers: list[tuple[subprocess.Popen, int]] = []
         self._shutting_down = False
+        self._prometheus_dir: str | None = None
 
     # -- public API ---------------------------------------------------------
 
@@ -571,6 +574,15 @@ class ServeOrchestrator:
     def _launch_workers(self) -> None:
         ports = _find_available_ports(self.args.worker_base_port, self.args.data_parallel_size)
         host = self.args.worker_host
+
+        if getattr(self.args, "connection_mode", "grpc") == "grpc":
+            self._prometheus_dir = tempfile.mkdtemp(prefix="smg_prometheus_")
+            os.environ["PROMETHEUS_MULTIPROC_DIR"] = self._prometheus_dir
+            logger.info(
+                "Set PROMETHEUS_MULTIPROC_DIR=%s for gRPC metrics collection",
+                self._prometheus_dir,
+            )
+
         for dp_rank, port in enumerate(ports):
             env = self.launcher.gpu_env(self.args, dp_rank)
             proc = self.launcher.launch(self.args, self.backend_args, host, port, env)
@@ -640,6 +652,23 @@ class ServeOrchestrator:
                     os.killpg(proc.pid, signal.SIGKILL)
                 except (ProcessLookupError, OSError):
                     pass
+
+        self._cleanup_prometheus_dir()
+
+    def _cleanup_prometheus_dir(self) -> None:
+        """Remove the temporary prometheus multiprocess directory and its .db files."""
+        if self._prometheus_dir is None:
+            return
+        try:
+            shutil.rmtree(self._prometheus_dir)
+            logger.info("Cleaned up PROMETHEUS_MULTIPROC_DIR=%s", self._prometheus_dir)
+        except OSError as e:
+            logger.warning(
+                "Failed to clean up PROMETHEUS_MULTIPROC_DIR=%s: %s",
+                self._prometheus_dir,
+                e,
+            )
+        self._prometheus_dir = None
 
 
 # ---------------------------------------------------------------------------

--- a/model_gateway/src/core/worker_manager.rs
+++ b/model_gateway/src/core/worker_manager.rs
@@ -17,7 +17,7 @@ use tokio::{
     sync::{watch, Mutex},
     task::JoinHandle,
 };
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use crate::{
     core::{
@@ -83,6 +83,36 @@ impl IntoResponse for EngineMetricsResult {
             Self::Err(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg).into_response(),
         }
     }
+}
+
+/// Collect gRPC worker metrics by aggregating `PROMETHEUS_MULTIPROC_DIR` via a python3 subprocess.
+async fn collect_prometheus_multiproc_metrics() -> Result<String, String> {
+    let dir = std::env::var("PROMETHEUS_MULTIPROC_DIR").map_err(|_| {
+        "PROMETHEUS_MULTIPROC_DIR not set; cannot collect metrics from gRPC workers".to_string()
+    })?;
+
+    let output = tokio::process::Command::new("python3")
+        .args([
+            "-c",
+            "import sys\n\
+             from prometheus_client import CollectorRegistry, generate_latest\n\
+             from prometheus_client.multiprocess import MultiProcessCollector\n\
+             registry = CollectorRegistry()\n\
+             MultiProcessCollector(registry)\n\
+             sys.stdout.buffer.write(generate_latest(registry))\n",
+        ])
+        .env("PROMETHEUS_MULTIPROC_DIR", &dir)
+        .output()
+        .await
+        .map_err(|e| format!("failed to run python3 prometheus collector: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("python3 prometheus collector failed: {stderr}"));
+    }
+
+    String::from_utf8(output.stdout)
+        .map_err(|e| format!("prometheus collector output is not valid UTF-8: {e}"))
 }
 
 pub struct WorkerManager;
@@ -273,18 +303,44 @@ impl WorkerManager {
             return EngineMetricsResult::Err("No available workers".to_string());
         }
 
-        let responses = fan_out(&workers, client, "metrics", reqwest::Method::GET).await;
-
         let mut metric_packs = Vec::new();
-        for resp in responses {
-            if let Ok(r) = resp.result {
-                if r.status().is_success() {
-                    if let Ok(text) = r.text().await {
-                        metric_packs.push(MetricPack {
-                            labels: vec![("worker_addr".into(), resp.url)],
-                            metrics_text: text,
-                        });
+
+        let http_workers: Vec<_> = workers
+            .iter()
+            .filter(|w| matches!(w.connection_mode(), ConnectionMode::Http))
+            .cloned()
+            .collect();
+        let has_grpc = workers
+            .iter()
+            .any(|w| matches!(w.connection_mode(), ConnectionMode::Grpc));
+
+        if !http_workers.is_empty() {
+            let responses =
+                fan_out(&http_workers, client, "metrics", reqwest::Method::GET).await;
+            for resp in responses {
+                if let Ok(r) = resp.result {
+                    if r.status().is_success() {
+                        if let Ok(text) = r.text().await {
+                            metric_packs.push(MetricPack {
+                                labels: vec![("worker_addr".into(), resp.url)],
+                                metrics_text: text,
+                            });
+                        }
                     }
+                }
+            }
+        }
+
+        if has_grpc {
+            match collect_prometheus_multiproc_metrics().await {
+                Ok(text) => {
+                    metric_packs.push(MetricPack {
+                        labels: vec![],
+                        metrics_text: text,
+                    });
+                }
+                Err(e) => {
+                    warn!("Failed to collect gRPC worker metrics from PROMETHEUS_MULTIPROC_DIR: {e}");
                 }
             }
         }

--- a/model_gateway/src/core/worker_manager.rs
+++ b/model_gateway/src/core/worker_manager.rs
@@ -111,8 +111,12 @@ async fn collect_prometheus_multiproc_metrics() -> Result<String, String> {
         return Err(format!("python3 prometheus collector failed: {stderr}"));
     }
 
-    String::from_utf8(output.stdout)
-        .map_err(|e| format!("prometheus collector output is not valid UTF-8: {e}"))
+    let text = String::from_utf8(output.stdout)
+        .map_err(|e| format!("prometheus collector output is not valid UTF-8: {e}"))?;
+    if text.trim().is_empty() {
+        return Err("no metrics available from gRPC workers yet".to_string());
+    }
+    Ok(text)
 }
 
 pub struct WorkerManager;
@@ -332,11 +336,14 @@ impl WorkerManager {
 
         if has_grpc {
             match collect_prometheus_multiproc_metrics().await {
-                Ok(text) => {
+                Ok(text) if !text.trim().is_empty() => {
                     metric_packs.push(MetricPack {
                         labels: vec![],
                         metrics_text: text,
                     });
+                }
+                Ok(_) => {
+                    // No metrics available yet from gRPC workers — skip silently
                 }
                 Err(e) => {
                     warn!(

--- a/model_gateway/src/core/worker_manager.rs
+++ b/model_gateway/src/core/worker_manager.rs
@@ -315,8 +315,7 @@ impl WorkerManager {
             .any(|w| matches!(w.connection_mode(), ConnectionMode::Grpc));
 
         if !http_workers.is_empty() {
-            let responses =
-                fan_out(&http_workers, client, "metrics", reqwest::Method::GET).await;
+            let responses = fan_out(&http_workers, client, "metrics", reqwest::Method::GET).await;
             for resp in responses {
                 if let Ok(r) = resp.result {
                     if r.status().is_success() {
@@ -340,7 +339,9 @@ impl WorkerManager {
                     });
                 }
                 Err(e) => {
-                    warn!("Failed to collect gRPC worker metrics from PROMETHEUS_MULTIPROC_DIR: {e}");
+                    warn!(
+                        "Failed to collect gRPC worker metrics from PROMETHEUS_MULTIPROC_DIR: {e}"
+                    );
                 }
             }
         }


### PR DESCRIPTION
## Description

### Problem

When TensorRT-LLM (or any backend) runs in gRPC mode, the SMG router cannot collect engine metrics via `/engine_metrics`. HTTP-mode workers expose a `/metrics` endpoint that the router scrapes directly, but gRPC workers have no HTTP endpoint. The router returns `500 All backend requests failed`.

### Solution

Use the `prometheus_client` multiprocess pattern (same approach sglang uses):

1. **Python orchestrator** (`serve.py`): Create a temporary `PROMETHEUS_MULTIPROC_DIR` before launching workers, so worker processes inherit it and write `.db` files there.
2. **Rust router** (`worker_manager.rs`): For gRPC workers, read `PROMETHEUS_MULTIPROC_DIR` and spawn a `python3` subprocess that aggregates the `.db` files via `MultiProcessCollector` and returns standard prometheus text format.

### Changes

- `bindings/python/src/smg/serve.py`: Set `PROMETHEUS_MULTIPROC_DIR` env var in `_launch_workers()` when `connection_mode == "grpc"`. Clean up the temp directory on shutdown.
- `model_gateway/src/core/worker_manager.rs`: Add `collect_prometheus_multiproc_metrics()` for gRPC workers. Split `get_engine_metrics()` into HTTP (fan-out to `/metrics`) and gRPC (read from `PROMETHEUS_MULTIPROC_DIR`) paths.

## Test Plan

Tested end-to-end with TensorRT-LLM (Qwen3-0.6B, pytorch backend) in gRPC mode:

```bash
# Start SMG + trtllm gRPC worker
smg serve --model Qwen/Qwen3-0.6B --backend trtllm --connection-mode grpc --port 8992

# Send requests
curl http://localhost:8992/v1/chat/completions \
  -X POST -H "Content-Type: application/json" \
  -d '{"model":"Qwen3-0.6B","messages":[{"role":"user","content":"hi"}],"max_tokens":5}'

# Before this PR: 500
# After this PR:  200 with prometheus metrics
curl http://localhost:8992/engine_metrics
# trtllm_request_success_total{engine_type="grpc",finished_reason="length",...} 3.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Prometheus metrics support for gRPC workers so gRPC-based processes are included in monitoring.

* **Improvements**
  * Consolidated metrics aggregation across worker types for more complete reporting.
  * Added safer cleanup and error handling around temporary metrics data to reduce resource leaks and surface warnings on failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->