### PR TITLE
fix(mcp): avoid relisting tools on resumed responses

### DIFF
--- a/e2e_test/responses/test_tools_call.py
+++ b/e2e_test/responses/test_tools_call.py
@@ -1058,6 +1058,7 @@ class TestToolChoiceGptOss:
         for mcp_call in mcp_calls:
             assert mcp_call.server_label == "brave"
 
+
 # =============================================================================
 # Local Backend Tests (gRPC with Qwen model) - Tool Choice
 # =============================================================================

--- a/e2e_test/responses/test_tools_call.py
+++ b/e2e_test/responses/test_tools_call.py
@@ -191,6 +191,124 @@ def assert_streaming_mcp_call_ids_match(events):
     assert set(final_mcp_ids) == expected_ids
 
 
+def mcp_list_tools_labels(output):
+    return [item.server_label for item in output if item.type == "mcp_list_tools"]
+
+
+def streaming_added_mcp_list_tools_labels(events):
+    return [
+        event.item.server_label
+        for event in events
+        if event.type == "response.output_item.added"
+        and event.item is not None
+        and event.item.type == "mcp_list_tools"
+    ]
+
+
+def assert_previous_response_id_mcp_binding_behavior_non_streaming(model, api_client):
+    time.sleep(2)
+
+    resp1 = api_client.responses.create(
+        model=model,
+        input=MCP_TEST_PROMPT,
+        tools=[BRAVE_MCP_TOOL],
+        stream=False,
+        reasoning={"effort": "low"},
+    )
+    assert resp1.error is None
+    assert resp1.status == "completed"
+    assert mcp_list_tools_labels(resp1.output) == ["brave"]
+
+    resp2 = api_client.responses.create(
+        model=model,
+        input=(
+            "Search the web for 'Rust programming language'. Set count to 1 and return one "
+            "sentence response."
+        ),
+        previous_response_id=resp1.id,
+        tools=[BRAVE_MCP_TOOL],
+        stream=False,
+        reasoning={"effort": "low"},
+    )
+    assert resp2.error is None
+    assert resp2.status == "completed"
+    assert mcp_list_tools_labels(resp2.output) == []
+    assert any(item.type == "mcp_call" for item in resp2.output)
+
+    resp3 = api_client.responses.create(
+        model=model,
+        input=(
+            "Use deepwiki to tell me which transport protocols the 2025-03-26 MCP spec "
+            "supports, and also use brave_web_search to search the web for 'Rust programming "
+            "language'. Return exactly two bullet points."
+        ),
+        previous_response_id=resp2.id,
+        tools=[BRAVE_MCP_TOOL, DEEPWIKI_MCP_TOOL],
+        stream=False,
+        reasoning={"effort": "low"},
+    )
+    assert resp3.error is None
+    assert resp3.status == "completed"
+    assert mcp_list_tools_labels(resp3.output) == ["deepwiki"]
+    assert any(item.type == "mcp_call" for item in resp3.output)
+
+
+def assert_previous_response_id_mcp_binding_behavior_streaming(model, api_client):
+    time.sleep(2)
+
+    events1 = list(
+        api_client.responses.create(
+            model=model,
+            input=MCP_TEST_PROMPT,
+            tools=[BRAVE_MCP_TOOL],
+            stream=True,
+            reasoning={"effort": "low"},
+        )
+    )
+    assert streaming_added_mcp_list_tools_labels(events1) == ["brave"]
+
+    events2 = list(
+        api_client.responses.create(
+            model=model,
+            input=(
+                "Search the web for 'Rust programming language'. Set count to 1 and return one "
+                "sentence response."
+            ),
+            previous_response_id=[e for e in events1 if e.type == "response.completed"][
+                0
+            ].response.id,
+            tools=[BRAVE_MCP_TOOL],
+            stream=True,
+            reasoning={"effort": "low"},
+        )
+    )
+    assert streaming_added_mcp_list_tools_labels(events2) == []
+    assert any(event.type == "response.mcp_call.completed" for event in events2)
+
+    events3 = list(
+        api_client.responses.create(
+            model=model,
+            input=(
+                "Use deepwiki to tell me which transport protocols the 2025-03-26 MCP spec "
+                "supports, and also use brave_web_search to search the web for 'Rust programming "
+                "language'. Return exactly two bullet points."
+            ),
+            previous_response_id=[e for e in events2 if e.type == "response.completed"][
+                0
+            ].response.id,
+            tools=[BRAVE_MCP_TOOL, DEEPWIKI_MCP_TOOL],
+            stream=True,
+            reasoning={"effort": "low"},
+        )
+    )
+    assert streaming_added_mcp_list_tools_labels(events3) == ["deepwiki"]
+    assert [e.type for e in events3].count("response.mcp_list_tools.in_progress") == 1
+    assert [e.type for e in events3].count("response.mcp_list_tools.completed") == 1
+    completed_events = [e for e in events3 if e.type == "response.completed"]
+    assert len(completed_events) == 1
+    assert mcp_list_tools_labels(completed_events[0].response.output) == ["deepwiki"]
+
+
 @pytest.mark.vendor("openai")
 @pytest.mark.gpu(0)
 @pytest.mark.parametrize("setup_backend", ["openai"], indirect=True)
@@ -469,6 +587,16 @@ class TestToolCallingCloud:
         assert len(mcp_calls) > 0
         for mcp_call in mcp_calls:
             assert mcp_call.server_label == "brave"
+
+    def test_previous_response_id_mcp_binding_behavior(self, model, api_client):
+        """Resumed turns should not relist existing MCP bindings."""
+
+        assert_previous_response_id_mcp_binding_behavior_non_streaming(model, api_client)
+
+    def test_previous_response_id_mcp_binding_behavior_streaming(self, model, api_client):
+        """Streaming resumed turns should only list newly added MCP bindings."""
+
+        assert_previous_response_id_mcp_binding_behavior_streaming(model, api_client)
 
     def test_concurrent_mcp_different_servers(self, model, api_client):
         """Concurrent non-streaming requests with different MCP servers don't contaminate each other."""
@@ -929,7 +1057,6 @@ class TestToolChoiceGptOss:
         assert len(mcp_calls) > 0
         for mcp_call in mcp_calls:
             assert mcp_call.server_label == "brave"
-
 
 # =============================================================================
 # Local Backend Tests (gRPC with Qwen model) - Tool Choice

--- a/model_gateway/src/routers/openai/chat.rs
+++ b/model_gateway/src/routers/openai/chat.rs
@@ -134,8 +134,6 @@ pub(super) async fn route_chat(
     ctx.state.payload = Some(PayloadState {
         json: payload,
         url: url.clone(),
-        previous_response_id: None,
-        existing_mcp_list_tools_labels: Vec::new(),
     });
 
     // Wrap values in Arc to avoid cloning large objects on each retry attempt

--- a/model_gateway/src/routers/openai/chat.rs
+++ b/model_gateway/src/routers/openai/chat.rs
@@ -135,6 +135,7 @@ pub(super) async fn route_chat(
         json: payload,
         url: url.clone(),
         previous_response_id: None,
+        existing_mcp_list_tools_labels: Vec::new(),
     });
 
     // Wrap values in Arc to avoid cloning large objects on each retry attempt

--- a/model_gateway/src/routers/openai/context.rs
+++ b/model_gateway/src/routers/openai/context.rs
@@ -103,6 +103,7 @@ pub struct PayloadState {
     pub json: Value,
     pub url: String,
     pub previous_response_id: Option<String>,
+    pub existing_mcp_list_tools_labels: Vec<String>,
 }
 
 impl RequestContext {
@@ -202,6 +203,7 @@ pub struct OwnedStreamingContext {
     pub payload: Value,
     pub original_body: ResponsesRequest,
     pub previous_response_id: Option<String>,
+    pub existing_mcp_list_tools_labels: Vec<String>,
     pub storage: StorageHandles,
 }
 
@@ -233,6 +235,7 @@ impl RequestContext {
             payload: payload_state.json,
             original_body,
             previous_response_id: payload_state.previous_response_id,
+            existing_mcp_list_tools_labels: payload_state.existing_mcp_list_tools_labels,
             storage: StorageHandles {
                 response,
                 conversation,

--- a/model_gateway/src/routers/openai/context.rs
+++ b/model_gateway/src/routers/openai/context.rs
@@ -92,6 +92,7 @@ impl ComponentRefs {
 pub struct ProcessingState {
     pub worker: Option<WorkerSelection>,
     pub payload: Option<PayloadState>,
+    pub responses_payload: Option<ResponsesPayloadState>,
 }
 
 pub struct WorkerSelection {
@@ -102,6 +103,10 @@ pub struct WorkerSelection {
 pub struct PayloadState {
     pub json: Value,
     pub url: String,
+}
+
+#[derive(Default)]
+pub struct ResponsesPayloadState {
     pub previous_response_id: Option<String>,
     pub existing_mcp_list_tools_labels: Vec<String>,
 }
@@ -189,6 +194,10 @@ impl RequestContext {
     pub fn take_payload(&mut self) -> Option<PayloadState> {
         self.state.payload.take()
     }
+
+    pub fn take_responses_payload(&mut self) -> Option<ResponsesPayloadState> {
+        self.state.responses_payload.take()
+    }
 }
 
 pub struct StorageHandles {
@@ -210,6 +219,7 @@ pub struct OwnedStreamingContext {
 impl RequestContext {
     pub fn into_streaming_context(mut self) -> Result<OwnedStreamingContext, &'static str> {
         let payload_state = self.take_payload().ok_or("Payload not prepared")?;
+        let responses_payload_state = self.take_responses_payload().unwrap_or_default();
         let original_body = self
             .responses_request()
             .ok_or("Expected responses request")?
@@ -234,8 +244,8 @@ impl RequestContext {
             url: payload_state.url,
             payload: payload_state.json,
             original_body,
-            previous_response_id: payload_state.previous_response_id,
-            existing_mcp_list_tools_labels: payload_state.existing_mcp_list_tools_labels,
+            previous_response_id: responses_payload_state.previous_response_id,
+            existing_mcp_list_tools_labels: responses_payload_state.existing_mcp_list_tools_labels,
             storage: StorageHandles {
                 response,
                 conversation,

--- a/model_gateway/src/routers/openai/mcp/mod.rs
+++ b/model_gateway/src/routers/openai/mcp/mod.rs
@@ -11,6 +11,6 @@ pub(crate) use tool_handler::{StreamAction, StreamingToolHandler};
 // Re-export functions used by responses/streaming.rs and responses/non_streaming.rs
 pub(crate) use tool_loop::{
     build_resume_payload, execute_streaming_tool_calls, execute_tool_loop,
-    inject_mcp_metadata_streaming, prepare_mcp_tools_as_functions, send_mcp_list_tools_events,
-    ToolLoopState,
+    inject_mcp_metadata_streaming, mcp_list_tools_bindings_to_emit, prepare_mcp_tools_as_functions,
+    send_mcp_list_tools_events, ToolLoopExecutionContext, ToolLoopState,
 };

--- a/model_gateway/src/routers/openai/mcp/tool_loop.rs
+++ b/model_gateway/src/routers/openai/mcp/tool_loop.rs
@@ -54,10 +54,9 @@ pub(crate) struct ToolLoopState {
 
 impl ToolLoopState {
     pub fn new(original_input: ResponseInput, prior_mcp_list_tools_labels: Vec<String>) -> Self {
-        let mut known_labels = prior_mcp_list_tools_labels
+        let known_labels = prior_mcp_list_tools_labels
             .into_iter()
             .collect::<HashSet<_>>();
-        known_labels.extend(existing_mcp_list_tools_labels(&original_input));
 
         Self {
             iteration: 0,
@@ -529,28 +528,6 @@ fn non_streaming_tool_item_id_source(item_id: &str, response_format: &ResponseFo
             .unwrap_or(item_id)
             .to_string(),
     }
-}
-
-fn existing_mcp_list_tools_labels(input: &ResponseInput) -> HashSet<String> {
-    let ResponseInput::Items(items) = input else {
-        return HashSet::new();
-    };
-
-    let Ok(items_value) = to_value(items) else {
-        return HashSet::new();
-    };
-
-    items_value
-        .as_array()
-        .into_iter()
-        .flatten()
-        .filter_map(|item| {
-            (item.get("type").and_then(|t| t.as_str()) == Some(ItemType::MCP_LIST_TOOLS))
-                .then(|| item.get("server_label").and_then(|v| v.as_str()))
-                .flatten()
-                .map(ToOwned::to_owned)
-        })
-        .collect()
 }
 
 pub(crate) fn mcp_list_tools_bindings_to_emit(

--- a/model_gateway/src/routers/openai/mcp/tool_loop.rs
+++ b/model_gateway/src/routers/openai/mcp/tool_loop.rs
@@ -8,7 +8,7 @@
 //! - Payload transformation for MCP tool interception
 //! - Metadata injection for MCP operations
 
-use std::io;
+use std::{collections::HashSet, io};
 
 use axum::http::HeaderMap;
 use bytes::Bytes;
@@ -21,7 +21,8 @@ use openai_protocol::{
 };
 use serde_json::{json, to_value, Value};
 use smg_mcp::{
-    mcp_response_item_id, McpToolSession, ResponseFormat, ResponseTransformer, ToolExecutionInput,
+    mcp_response_item_id, McpServerBinding, McpToolSession, ResponseFormat, ResponseTransformer,
+    ToolExecutionInput,
 };
 use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
@@ -45,17 +46,25 @@ pub(crate) struct ToolLoopState {
     pub conversation_history: Vec<Value>,
     /// Original user input (preserved for building resume payloads)
     pub original_input: ResponseInput,
+    /// MCP bindings already represented by historical `mcp_list_tools` items.
+    pub existing_mcp_list_tools_labels: HashSet<String>,
     /// Transformed output items (mcp_call, web_search_call, etc.) - stored to avoid reconstruction
     pub mcp_call_items: Vec<Value>,
 }
 
 impl ToolLoopState {
-    pub fn new(original_input: ResponseInput) -> Self {
+    pub fn new(original_input: ResponseInput, prior_mcp_list_tools_labels: Vec<String>) -> Self {
+        let mut known_labels = prior_mcp_list_tools_labels
+            .into_iter()
+            .collect::<HashSet<_>>();
+        known_labels.extend(existing_mcp_list_tools_labels(&original_input));
+
         Self {
             iteration: 0,
             total_calls: 0,
             conversation_history: Vec::new(),
             original_input,
+            existing_mcp_list_tools_labels: known_labels,
             mcp_call_items: Vec::new(),
         }
     }
@@ -522,23 +531,59 @@ fn non_streaming_tool_item_id_source(item_id: &str, response_format: &ResponseFo
     }
 }
 
+fn existing_mcp_list_tools_labels(input: &ResponseInput) -> HashSet<String> {
+    let ResponseInput::Items(items) = input else {
+        return HashSet::new();
+    };
+
+    let Ok(items_value) = to_value(items) else {
+        return HashSet::new();
+    };
+
+    items_value
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(|item| {
+            (item.get("type").and_then(|t| t.as_str()) == Some(ItemType::MCP_LIST_TOOLS))
+                .then(|| item.get("server_label").and_then(|v| v.as_str()))
+                .flatten()
+                .map(ToOwned::to_owned)
+        })
+        .collect()
+}
+
+pub(crate) fn mcp_list_tools_bindings_to_emit(
+    existing_labels: &HashSet<String>,
+    bindings: &[McpServerBinding],
+) -> Vec<(String, String)> {
+    bindings
+        .iter()
+        .filter(|binding| !existing_labels.contains(&binding.label))
+        .map(|binding| (binding.label.clone(), binding.server_key.clone()))
+        .collect()
+}
+
 /// Inject MCP metadata into a streaming response
 pub(crate) fn inject_mcp_metadata_streaming(
     response: &mut Value,
     state: &ToolLoopState,
     session: &McpToolSession<'_>,
 ) {
-    let mcp_servers = session.mcp_servers();
+    let list_tools_bindings = mcp_list_tools_bindings_to_emit(
+        &state.existing_mcp_list_tools_labels,
+        session.mcp_servers(),
+    );
 
     if let Some(output_array) = response.get_mut("output").and_then(|v| v.as_array_mut()) {
         output_array.retain(|item| {
             item.get("type").and_then(|t| t.as_str()) != Some(ItemType::MCP_LIST_TOOLS)
         });
 
-        let mut prefix = Vec::with_capacity(mcp_servers.len() + state.mcp_call_items.len());
-        for binding in mcp_servers {
-            if !session.is_internal_server_label(&binding.label) {
-                prefix.push(session.build_mcp_list_tools_json(&binding.label, &binding.server_key));
+        let mut prefix = Vec::with_capacity(list_tools_bindings.len() + state.mcp_call_items.len());
+        for (server_label, server_key) in &list_tools_bindings {
+            if !session.is_internal_server_label(server_label) {
+                prefix.push(session.build_mcp_list_tools_json(server_label, server_key));
             }
         }
         prefix.extend(
@@ -551,10 +596,9 @@ pub(crate) fn inject_mcp_metadata_streaming(
         output_array.splice(0..0, prefix);
     } else if let Some(obj) = response.as_object_mut() {
         let mut output_items = Vec::new();
-        for binding in mcp_servers {
-            if !session.is_internal_server_label(&binding.label) {
-                output_items
-                    .push(session.build_mcp_list_tools_json(&binding.label, &binding.server_key));
+        for (server_label, server_key) in &list_tools_bindings {
+            if !session.is_internal_server_label(server_label) {
+                output_items.push(session.build_mcp_list_tools_json(server_label, server_key));
             }
         }
         // Use stored transformed items (no reconstruction needed)
@@ -569,6 +613,12 @@ pub(crate) fn inject_mcp_metadata_streaming(
     }
 }
 
+pub(crate) struct ToolLoopExecutionContext<'a> {
+    pub original_body: &'a ResponsesRequest,
+    pub existing_mcp_list_tools_labels: &'a [String],
+    pub session: &'a McpToolSession<'a>,
+}
+
 /// Execute the tool calling loop
 pub(crate) async fn execute_tool_loop(
     client: &reqwest::Client,
@@ -576,10 +626,18 @@ pub(crate) async fn execute_tool_loop(
     headers: Option<&HeaderMap>,
     worker_api_key: Option<&String>,
     initial_payload: Value,
-    original_body: &ResponsesRequest,
-    session: &McpToolSession<'_>,
+    tool_loop_ctx: ToolLoopExecutionContext<'_>,
 ) -> Result<Value, String> {
-    let mut state = ToolLoopState::new(original_body.input.clone());
+    let ToolLoopExecutionContext {
+        original_body,
+        existing_mcp_list_tools_labels,
+        session,
+    } = tool_loop_ctx;
+
+    let mut state = ToolLoopState::new(
+        original_body.input.clone(),
+        existing_mcp_list_tools_labels.to_vec(),
+    );
     let max_tool_calls = original_body.max_tool_calls.map(|n| n as usize);
     let base_payload = initial_payload.clone();
     let tools_json = base_payload.get("tools").cloned().unwrap_or(json!([]));
@@ -770,9 +828,12 @@ fn build_incomplete_response(
         json!({ "reason": reason }),
     );
 
-    let mcp_servers = session.mcp_servers();
+    let list_tools_bindings = mcp_list_tools_bindings_to_emit(
+        &state.existing_mcp_list_tools_labels,
+        session.mcp_servers(),
+    );
 
-    let user_function_names: std::collections::HashSet<&str> = original_body
+    let user_function_names: HashSet<&str> = original_body
         .tools
         .as_deref()
         .map(|tools| {
@@ -822,13 +883,11 @@ fn build_incomplete_response(
         // Add mcp_list_tools and executed mcp_call items at the beginning
         if state.total_calls > 0 || !incomplete_items.is_empty() {
             let mut prefix = Vec::with_capacity(
-                mcp_servers.len() + state.mcp_call_items.len() + incomplete_items.len(),
+                list_tools_bindings.len() + state.mcp_call_items.len() + incomplete_items.len(),
             );
-            for binding in mcp_servers {
-                if !session.is_internal_server_label(&binding.label) {
-                    prefix.push(
-                        session.build_mcp_list_tools_json(&binding.label, &binding.server_key),
-                    );
+            for (server_label, server_key) in &list_tools_bindings {
+                if !session.is_internal_server_label(server_label) {
+                    prefix.push(session.build_mcp_list_tools_json(server_label, server_key));
                 }
             }
             prefix.extend(
@@ -975,13 +1034,18 @@ fn extract_function_calls(resp: &Value) -> Vec<ExtractedFunctionCall> {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
     use serde_json::json;
     use smg_mcp::{
         BuiltinToolType, McpConfig, McpOrchestrator, McpServerBinding, McpServerConfig,
         McpToolSession, McpTransport, ResponseFormat, Tool, ToolEntry,
     };
 
-    use super::{build_transformed_mcp_call_item, is_internal_mcp_response_item};
+    use super::{
+        build_transformed_mcp_call_item, is_internal_mcp_response_item,
+        mcp_list_tools_bindings_to_emit,
+    };
 
     fn test_tool(name: &str) -> Tool {
         let mut schema = serde_json::Map::new();
@@ -1131,5 +1195,46 @@ mod tests {
             &internal_non_builtin_item,
             &session
         ));
+    }
+
+    #[test]
+    fn emits_only_new_binding_when_resume_adds_second_tool_block() {
+        let existing_labels = HashSet::from(["deepwiki_ask".to_string()]);
+        let bindings = vec![
+            McpServerBinding {
+                label: "deepwiki_ask".to_string(),
+                server_key: "server-ask".to_string(),
+                allowed_tools: Some(vec!["ask_question".to_string()]),
+            },
+            McpServerBinding {
+                label: "deepwiki_read".to_string(),
+                server_key: "server-read".to_string(),
+                allowed_tools: Some(vec!["read_wiki_structure".to_string()]),
+            },
+        ];
+
+        let bindings_to_emit = mcp_list_tools_bindings_to_emit(&existing_labels, &bindings);
+
+        assert_eq!(
+            bindings_to_emit,
+            vec![("deepwiki_read".to_string(), "server-read".to_string())]
+        );
+    }
+
+    #[test]
+    fn emits_all_bindings_when_no_prior_mcp_list_tools_exist() {
+        let existing_labels = HashSet::new();
+        let bindings = vec![McpServerBinding {
+            label: "deepwiki_ask".to_string(),
+            server_key: "server-ask".to_string(),
+            allowed_tools: Some(vec!["ask_question".to_string()]),
+        }];
+
+        let bindings_to_emit = mcp_list_tools_bindings_to_emit(&existing_labels, &bindings);
+
+        assert_eq!(
+            bindings_to_emit,
+            vec![("deepwiki_ask".to_string(), "server-ask".to_string())]
+        );
     }
 }

--- a/model_gateway/src/routers/openai/responses/history.rs
+++ b/model_gateway/src/routers/openai/responses/history.rs
@@ -3,6 +3,8 @@
 //! Loads conversation history and/or previous response chains into the request
 //! input before forwarding to the upstream provider.
 
+use std::collections::HashSet;
+
 use axum::response::Response;
 use openai_protocol::{
     event_types::ItemType,
@@ -20,20 +22,26 @@ use crate::{
 
 const MAX_CONVERSATION_HISTORY_ITEMS: usize = 100;
 
+pub(crate) struct LoadedInputHistory {
+    pub previous_response_id: Option<String>,
+    pub existing_mcp_list_tools_labels: Vec<String>,
+}
+
 /// Load conversation history and/or previous response chain into request input.
 ///
 /// Mutates `request_body.input` with the loaded items.
-/// Returns `Ok(original_previous_response_id)` on success, or `Err(response)` on validation failure.
+/// Returns `Ok(LoadedInputHistory)` on success, or `Err(response)` on validation failure.
 pub(crate) async fn load_input_history(
     components: &ResponsesComponents,
     conversation: Option<&str>,
     request_body: &mut ResponsesRequest,
     model: &str,
-) -> Result<Option<String>, Response> {
+) -> Result<LoadedInputHistory, Response> {
     let previous_response_id = request_body
         .previous_response_id
         .take()
         .filter(|id| !id.is_empty());
+    let mut existing_mcp_list_tools_labels = HashSet::new();
 
     // Load items from previous response chain if specified
     let mut chain_items: Option<Vec<ResponseInputOutputItem>> = None;
@@ -45,6 +53,12 @@ pub(crate) async fn load_input_history(
             .await
         {
             Ok(chain) if !chain.responses.is_empty() => {
+                existing_mcp_list_tools_labels.extend(chain.responses.iter().flat_map(|stored| {
+                    extract_mcp_list_tools_labels(
+                        stored.raw_response.get("output").unwrap_or(&Value::Null),
+                    )
+                }));
+
                 let items: Vec<ResponseInputOutputItem> = chain
                     .responses
                     .iter()
@@ -206,7 +220,10 @@ pub(crate) async fn load_input_history(
         request_body.input = ResponseInput::Items(items);
     }
 
-    Ok(previous_response_id)
+    Ok(LoadedInputHistory {
+        previous_response_id,
+        existing_mcp_list_tools_labels: existing_mcp_list_tools_labels.into_iter().collect(),
+    })
 }
 
 /// Deserialize ResponseInputOutputItems from a JSON array value
@@ -219,6 +236,22 @@ fn deserialize_items_from_array(array: &Value) -> Vec<ResponseInputOutputItem> {
                     serde_json::from_value::<ResponseInputOutputItem>(item.clone())
                         .map_err(|e| warn!("Failed to deserialize item: {}. Item: {}", e, item))
                         .ok()
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn extract_mcp_list_tools_labels(array: &Value) -> Vec<String> {
+    array
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|item| {
+                    (item.get("type").and_then(|t| t.as_str()) == Some(ItemType::MCP_LIST_TOOLS))
+                        .then(|| item.get("server_label").and_then(|v| v.as_str()))
+                        .flatten()
+                        .map(ToOwned::to_owned)
                 })
                 .collect()
         })

--- a/model_gateway/src/routers/openai/responses/non_streaming.rs
+++ b/model_gateway/src/routers/openai/responses/non_streaming.rs
@@ -20,7 +20,7 @@ use crate::routers::{
     error,
     openai::{
         context::{PayloadState, RequestContext},
-        mcp::{execute_tool_loop, prepare_mcp_tools_as_functions},
+        mcp::{execute_tool_loop, prepare_mcp_tools_as_functions, ToolLoopExecutionContext},
     },
 };
 
@@ -37,6 +37,7 @@ pub async fn handle_non_streaming_response(mut ctx: RequestContext) -> Response 
         json: mut payload,
         url,
         previous_response_id,
+        existing_mcp_list_tools_labels,
     } = payload_state;
 
     let original_body = match ctx.responses_request() {
@@ -81,8 +82,11 @@ pub async fn handle_non_streaming_response(mut ctx: RequestContext) -> Response 
             ctx.headers(),
             worker.api_key(),
             payload,
-            original_body,
-            &session,
+            ToolLoopExecutionContext {
+                original_body,
+                existing_mcp_list_tools_labels: &existing_mcp_list_tools_labels,
+                session: &session,
+            },
         )
         .await
         {

--- a/model_gateway/src/routers/openai/responses/non_streaming.rs
+++ b/model_gateway/src/routers/openai/responses/non_streaming.rs
@@ -19,7 +19,7 @@ use crate::routers::{
     },
     error,
     openai::{
-        context::{PayloadState, RequestContext},
+        context::{PayloadState, RequestContext, ResponsesPayloadState},
         mcp::{execute_tool_loop, prepare_mcp_tools_as_functions, ToolLoopExecutionContext},
     },
 };
@@ -36,9 +36,11 @@ pub async fn handle_non_streaming_response(mut ctx: RequestContext) -> Response 
     let PayloadState {
         json: mut payload,
         url,
+    } = payload_state;
+    let ResponsesPayloadState {
         previous_response_id,
         existing_mcp_list_tools_labels,
-    } = payload_state;
+    } = ctx.take_responses_payload().unwrap_or_default();
 
     let original_body = match ctx.responses_request() {
         Some(r) => r,

--- a/model_gateway/src/routers/openai/responses/route.rs
+++ b/model_gateway/src/routers/openai/responses/route.rs
@@ -13,7 +13,8 @@ use serde_json::to_value;
 use super::{
     super::{
         context::{
-            ComponentRefs, PayloadState, RequestContext, ResponsesComponents, WorkerSelection,
+            ComponentRefs, PayloadState, RequestContext, ResponsesComponents,
+            ResponsesPayloadState, WorkerSelection,
         },
         provider::ProviderRegistry,
         router::resolve_provider,
@@ -172,6 +173,8 @@ pub(in crate::routers::openai) async fn route_responses(
     ctx.state.payload = Some(PayloadState {
         json: payload,
         url: format!("{}/v1/responses", worker.url()),
+    });
+    ctx.state.responses_payload = Some(ResponsesPayloadState {
         previous_response_id: loaded_history.previous_response_id,
         existing_mcp_list_tools_labels: loaded_history.existing_mcp_list_tools_labels,
     });

--- a/model_gateway/src/routers/openai/responses/route.rs
+++ b/model_gateway/src/routers/openai/responses/route.rs
@@ -108,7 +108,7 @@ pub(in crate::routers::openai) async fn route_responses(
     request_body.model = model_id.to_string();
     request_body.conversation = None;
 
-    let original_previous_response_id = match super::history::load_input_history(
+    let loaded_history = match super::history::load_input_history(
         deps.responses_components,
         conversation.map(String::as_str),
         &mut request_body,
@@ -172,7 +172,8 @@ pub(in crate::routers::openai) async fn route_responses(
     ctx.state.payload = Some(PayloadState {
         json: payload,
         url: format!("{}/v1/responses", worker.url()),
-        previous_response_id: original_previous_response_id,
+        previous_response_id: loaded_history.previous_response_id,
+        existing_mcp_list_tools_labels: loaded_history.existing_mcp_list_tools_labels,
     });
 
     let response = if ctx.is_streaming() {

--- a/model_gateway/src/routers/openai/responses/streaming.rs
+++ b/model_gateway/src/routers/openai/responses/streaming.rs
@@ -54,8 +54,8 @@ use crate::{
             context::{RequestContext, StreamingEventContext, StreamingRequest},
             mcp::{
                 build_resume_payload, execute_streaming_tool_calls, inject_mcp_metadata_streaming,
-                prepare_mcp_tools_as_functions, send_mcp_list_tools_events, StreamAction,
-                StreamingToolHandler, ToolLoopState,
+                mcp_list_tools_bindings_to_emit, prepare_mcp_tools_as_functions,
+                send_mcp_list_tools_events, StreamAction, StreamingToolHandler, ToolLoopState,
             },
         },
     },
@@ -674,6 +674,7 @@ pub(super) fn handle_streaming_with_tool_interception(
     let should_store = req.original_body.store.unwrap_or(true);
     let original_request = req.original_body;
     let previous_response_id = req.previous_response_id;
+    let existing_mcp_list_tools_labels = req.existing_mcp_list_tools_labels;
     let url = req.url;
     let storage = req.storage;
 
@@ -688,7 +689,10 @@ pub(super) fn handle_streaming_with_tool_interception(
         reason = "fire-and-forget MCP tool loop; gateway shutdown need not wait for individual tool loops"
     )]
     tokio::spawn(async move {
-        let mut state = ToolLoopState::new(original_request.input.clone());
+        let mut state = ToolLoopState::new(
+            original_request.input.clone(),
+            existing_mcp_list_tools_labels,
+        );
         let max_tool_calls = original_request.max_tool_calls.map(|n| n as usize);
 
         // Create session inside spawned task (borrows from orchestrator_clone which lives in closure)
@@ -707,6 +711,10 @@ pub(super) fn handle_streaming_with_tool_interception(
         let mut sequence_number: u64 = 0;
         let mut next_output_index: usize = 0;
         let mut preserved_response_id: Option<String> = None;
+        let list_tools_bindings = mcp_list_tools_bindings_to_emit(
+            &state.existing_mcp_list_tools_labels,
+            session.mcp_servers(),
+        );
 
         let streaming_ctx = StreamingEventContext {
             original_request: &original_request,
@@ -815,16 +823,16 @@ pub(super) fn handle_streaming_with_tool_interception(
                                     if is_in_progress {
                                         seen_in_progress = true;
                                         if !mcp_list_tools_sent {
-                                            for binding in session.mcp_servers() {
+                                            for (server_label, server_key) in &list_tools_bindings {
                                                 let list_tools_index =
                                                     handler.allocate_synthetic_output_index();
                                                 if !send_mcp_list_tools_events(
                                                     &tx,
                                                     &session,
-                                                    &binding.label,
+                                                    server_label,
                                                     list_tools_index,
                                                     &mut sequence_number,
-                                                    &binding.server_key,
+                                                    server_key,
                                                 ) {
                                                     // Client disconnected
                                                     return;

--- a/model_gateway/tests/api/responses_api_test.rs
+++ b/model_gateway/tests/api/responses_api_test.rs
@@ -427,7 +427,9 @@ async fn test_previous_response_id_does_not_repeat_mcp_list_tools_for_existing_b
         conversation: None,
     };
 
-    let resp1 = router.route_responses(None, &req1, req1.model.as_str()).await;
+    let resp1 = router
+        .route_responses(None, &req1, req1.model.as_str())
+        .await;
     assert_eq!(resp1.status(), StatusCode::OK);
 
     let body1 = axum::body::to_bytes(resp1.into_body(), usize::MAX)
@@ -474,7 +476,9 @@ async fn test_previous_response_id_does_not_repeat_mcp_list_tools_for_existing_b
         conversation: None,
     };
 
-    let resp2 = router.route_responses(None, &req2, req2.model.as_str()).await;
+    let resp2 = router
+        .route_responses(None, &req2, req2.model.as_str())
+        .await;
     assert_eq!(resp2.status(), StatusCode::OK);
 
     let body2 = axum::body::to_bytes(resp2.into_body(), usize::MAX)

--- a/model_gateway/tests/api/responses_api_test.rs
+++ b/model_gateway/tests/api/responses_api_test.rs
@@ -344,6 +344,167 @@ async fn test_final_response_hides_internal_mcp_trace_items() {
 }
 
 #[tokio::test]
+async fn test_previous_response_id_does_not_repeat_mcp_list_tools_for_existing_binding() {
+    let mut mcp = MockMCPServer::start().await.expect("start mcp");
+
+    let mcp_yaml = format!(
+        "servers:\n  - name: mock\n    protocol: streamable\n    url: {}\n",
+        mcp.url()
+    );
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let cfg_path = dir.path().join("mcp.yaml");
+    std::fs::write(&cfg_path, mcp_yaml).expect("write mcp cfg");
+
+    let mut worker = MockWorker::new(MockWorkerConfig {
+        port: 0,
+        worker_type: WorkerType::Regular,
+        health_status: HealthStatus::Healthy,
+        response_delay_ms: 0,
+        fail_rate: 0.0,
+    });
+    let worker_url = worker.start().await.expect("start worker");
+
+    let router_cfg = RouterConfig::builder()
+        .openai_mode(vec![worker_url])
+        .random_policy()
+        .host("127.0.0.1")
+        .port(0)
+        .max_payload_size(8 * 1024 * 1024)
+        .request_timeout_secs(60)
+        .worker_startup_timeout_secs(5)
+        .worker_startup_check_interval_secs(1)
+        .log_level("warn")
+        .max_concurrent_requests(32)
+        .queue_timeout_secs(5)
+        .build_unchecked();
+
+    let ctx =
+        crate::common::create_test_context_with_mcp_config(router_cfg, cfg_path.to_str().unwrap())
+            .await;
+    let router = RouterFactory::create_router(&ctx).await.expect("router");
+
+    let mcp_tool = ResponseTool::Mcp(McpTool {
+        server_url: Some(mcp.url()),
+        authorization: None,
+        headers: None,
+        server_label: "mock".to_string(),
+        server_description: None,
+        require_approval: Some(RequireApproval::Never),
+        allowed_tools: None,
+    });
+
+    let req1 = ResponsesRequest {
+        background: Some(false),
+        include: None,
+        input: ResponseInput::Text("search something".to_string()),
+        instructions: Some("Be brief".to_string()),
+        max_output_tokens: Some(64),
+        max_tool_calls: None,
+        metadata: None,
+        model: "mock-model".to_string(),
+        parallel_tool_calls: Some(true),
+        previous_response_id: None,
+        reasoning: None,
+        service_tier: Some(ServiceTier::Auto),
+        store: Some(true),
+        stream: Some(false),
+        temperature: Some(0.2),
+        tool_choice: Some(ToolChoice::default()),
+        tools: Some(vec![mcp_tool.clone()]),
+        top_logprobs: Some(0),
+        top_p: None,
+        truncation: Some(Truncation::Disabled),
+        text: None,
+        user: None,
+        request_id: Some("resp_prev_id_turn_1".to_string()),
+        priority: 0,
+        frequency_penalty: Some(0.0),
+        presence_penalty: Some(0.0),
+        stop: None,
+        top_k: -1,
+        min_p: 0.0,
+        repetition_penalty: 1.0,
+        conversation: None,
+    };
+
+    let resp1 = router.route_responses(None, &req1, req1.model.as_str()).await;
+    assert_eq!(resp1.status(), StatusCode::OK);
+
+    let body1 = axum::body::to_bytes(resp1.into_body(), usize::MAX)
+        .await
+        .expect("Failed to read response body");
+    let body1_json: serde_json::Value =
+        serde_json::from_slice(&body1).expect("Failed to parse response JSON");
+    let first_response_id = body1_json["id"]
+        .as_str()
+        .expect("first response should have id")
+        .to_string();
+
+    let req2 = ResponsesRequest {
+        background: Some(false),
+        include: None,
+        input: ResponseInput::Text("Summarize that in five words".to_string()),
+        instructions: Some("Be brief".to_string()),
+        max_output_tokens: Some(64),
+        max_tool_calls: None,
+        metadata: None,
+        model: "mock-model".to_string(),
+        parallel_tool_calls: Some(true),
+        previous_response_id: Some(first_response_id),
+        reasoning: None,
+        service_tier: Some(ServiceTier::Auto),
+        store: Some(true),
+        stream: Some(false),
+        temperature: Some(0.2),
+        tool_choice: Some(ToolChoice::default()),
+        tools: Some(vec![mcp_tool]),
+        top_logprobs: Some(0),
+        top_p: None,
+        truncation: Some(Truncation::Disabled),
+        text: None,
+        user: None,
+        request_id: Some("resp_prev_id_turn_2".to_string()),
+        priority: 0,
+        frequency_penalty: Some(0.0),
+        presence_penalty: Some(0.0),
+        stop: None,
+        top_k: -1,
+        min_p: 0.0,
+        repetition_penalty: 1.0,
+        conversation: None,
+    };
+
+    let resp2 = router.route_responses(None, &req2, req2.model.as_str()).await;
+    assert_eq!(resp2.status(), StatusCode::OK);
+
+    let body2 = axum::body::to_bytes(resp2.into_body(), usize::MAX)
+        .await
+        .expect("Failed to read response body");
+    let body2_json: serde_json::Value =
+        serde_json::from_slice(&body2).expect("Failed to parse response JSON");
+
+    let output = body2_json["output"]
+        .as_array()
+        .expect("response output missing");
+    assert_eq!(
+        output.len(),
+        2,
+        "resume turn should return only current-turn MCP activity plus the final message: {body2_json}",
+    );
+    assert_eq!(output[0]["type"], "mcp_call");
+    assert_eq!(output[1]["type"], "message");
+    assert!(
+        output
+            .iter()
+            .all(|item| item.get("type").and_then(|v| v.as_str()) != Some("mcp_list_tools")),
+        "existing bindings should not repeat mcp_list_tools on previous_response_id turns"
+    );
+
+    worker.stop().await;
+    mcp.stop().await;
+}
+
+#[tokio::test]
 async fn test_final_response_hides_internal_mcp_error_details() {
     let mut mcp = MockFailingMCPServer::start(TEST_INTERNAL_MCP_ERROR_MARKER)
         .await

--- a/model_gateway/tests/common/mock_worker.rs
+++ b/model_gateway/tests/common/mock_worker.rs
@@ -666,8 +666,25 @@ async fn responses_handler(
                 })
             })
             .unwrap_or(false);
+        let has_mcp_history = payload
+            .get("input")
+            .and_then(|v| v.as_array())
+            .map(|items| {
+                items.iter().any(|item| {
+                    item.get("type")
+                        .and_then(|t| t.as_str())
+                        .is_some_and(|t| t == "mcp_list_tools" || t == "mcp_call")
+                })
+            })
+            .unwrap_or(false);
+        let has_previous_response_id = payload
+            .get("previous_response_id")
+            .and_then(|v| v.as_str())
+            .is_some_and(|id| !id.is_empty());
+        let has_prior_tool_context =
+            has_function_output || has_previous_response_id || has_mcp_history;
 
-        if has_tools && !has_function_output {
+        if has_tools && !has_prior_tool_context {
             // First turn: emit streaming tool call events using OpenAI-style function_call ids
             let call_id = format!("call_{}", &Uuid::now_v7().simple().to_string()[..24]);
             let item_id = format!("fc_{}", Uuid::now_v7().simple());
@@ -814,8 +831,8 @@ async fn responses_handler(
             Sse::new(stream)
                 .keep_alive(KeepAlive::default())
                 .into_response()
-        } else if has_tools && has_function_output {
-            // Second turn: emit streaming text response
+        } else if has_tools && has_prior_tool_context {
+            // Resume turn: emit streaming text response
             let rid = request_id.clone();
             let msg_id = format!("msg_{}", &Uuid::now_v7().simple().to_string()[..24]);
 
@@ -1024,8 +1041,25 @@ async fn responses_handler(
                 })
             })
             .unwrap_or(false);
+        let has_mcp_history = payload
+            .get("input")
+            .and_then(|v| v.as_array())
+            .map(|items| {
+                items.iter().any(|item| {
+                    item.get("type")
+                        .and_then(|t| t.as_str())
+                        .is_some_and(|t| t == "mcp_list_tools" || t == "mcp_call")
+                })
+            })
+            .unwrap_or(false);
+        let has_previous_response_id = payload
+            .get("previous_response_id")
+            .and_then(|v| v.as_str())
+            .is_some_and(|id| !id.is_empty());
+        let has_prior_tool_context =
+            has_function_output || has_previous_response_id || has_mcp_history;
 
-        if has_tools && !has_function_output {
+        if has_tools && !has_prior_tool_context {
             let rid = format!("resp-{}", Uuid::now_v7());
             let call_id = format!("call_{}", &Uuid::now_v7().simple().to_string()[..24]);
             let item_id = format!("fc_{}", Uuid::now_v7().simple());
@@ -1046,7 +1080,7 @@ async fn responses_handler(
                 "usage": null
             }))
             .into_response()
-        } else if has_tools && has_function_output {
+        } else if has_tools && has_prior_tool_context {
             Json(json!({
                 "id": format!("resp-{}", Uuid::now_v7()),
                 "object": "response",

--- a/model_gateway/tests/common/mock_worker.rs
+++ b/model_gateway/tests/common/mock_worker.rs
@@ -666,23 +666,7 @@ async fn responses_handler(
                 })
             })
             .unwrap_or(false);
-        let has_mcp_history = payload
-            .get("input")
-            .and_then(|v| v.as_array())
-            .map(|items| {
-                items.iter().any(|item| {
-                    item.get("type")
-                        .and_then(|t| t.as_str())
-                        .is_some_and(|t| t == "mcp_list_tools" || t == "mcp_call")
-                })
-            })
-            .unwrap_or(false);
-        let has_previous_response_id = payload
-            .get("previous_response_id")
-            .and_then(|v| v.as_str())
-            .is_some_and(|id| !id.is_empty());
-        let has_prior_tool_context =
-            has_function_output || has_previous_response_id || has_mcp_history;
+        let has_prior_tool_context = has_function_output;
 
         if has_tools && !has_prior_tool_context {
             // First turn: emit streaming tool call events using OpenAI-style function_call ids
@@ -1041,23 +1025,7 @@ async fn responses_handler(
                 })
             })
             .unwrap_or(false);
-        let has_mcp_history = payload
-            .get("input")
-            .and_then(|v| v.as_array())
-            .map(|items| {
-                items.iter().any(|item| {
-                    item.get("type")
-                        .and_then(|t| t.as_str())
-                        .is_some_and(|t| t == "mcp_list_tools" || t == "mcp_call")
-                })
-            })
-            .unwrap_or(false);
-        let has_previous_response_id = payload
-            .get("previous_response_id")
-            .and_then(|v| v.as_str())
-            .is_some_and(|id| !id.is_empty());
-        let has_prior_tool_context =
-            has_function_output || has_previous_response_id || has_mcp_history;
+        let has_prior_tool_context = has_function_output;
 
         if has_tools && !has_prior_tool_context {
             let rid = format!("resp-{}", Uuid::now_v7());


### PR DESCRIPTION
## Description

### Problem

When `/v1/responses` resumed a prior turn with `previous_response_id`, SMG re-emitted `mcp_list_tools` for MCP bindings that were already established in earlier turns.

That differs from OpenAI behavior. On follow-up turns, OpenAI does not repeat `mcp_list_tools` for existing bindings. It only emits a new `mcp_list_tools` item when the request adds a new MCP binding.

This PR intentionally scopes the fix to the OpenAI Responses router path first. The gRPC Responses paths will be handled in a follow-up PR.

### Solution

SMG now reads prior response history for `mcp_list_tools.server_label` values and treats those bindings as already known.

On resumed turns:

- existing MCP bindings do not get a repeated `mcp_list_tools`
- newly added MCP bindings get exactly one new `mcp_list_tools`
- normal `mcp_call` behavior is unchanged for the current turn

This first PR only applies that behavior to the OpenAI Responses router path. A follow-up PR will align the gRPC Responses paths.

## Changes

- load existing MCP binding labels from stored response history referenced by `previous_response_id`
- pass existing binding labels through Responses routing, non-streaming, and streaming paths
- emit `mcp_list_tools` only for bindings not already seen in prior response output
- add regression coverage for resumed MCP flows in router/unit tests and e2e tests
- scope this PR to the OpenAI Responses router path only
- leave gRPC Responses alignment for a follow-up PR

## Test Plan

### Before This Change

First request:

```bash
curl "$BASE_URL" \
  -H "Content-Type: application/json" \
  -d '{
    "model": "gpt-5.4",
    "input": "Search the web for Python programming language.",
    "tools": [
      {
        "type": "mcp",
        "server_label": "brave",
        "server_url": "http://127.0.0.1:8080/mcp",
        "require_approval": "never",
        "allowed_tools": ["brave_web_search"]
      }
    ]
  }'
```

Example response shape:

```json
{
  "id": "resp_1",
  "output": [
    {
      "type": "mcp_list_tools",
      "server_label": "brave"
    },
    {
      "type": "mcp_call",
      "server_label": "brave"
    },
    {
      "type": "message"
    }
  ]
}
```

Second request with the same MCP binding and `previous_response_id`:

```bash
curl "$BASE_URL" \
  -H "Content-Type: application/json" \
  -d '{
    "model": "gpt-5.4",
    "input": "Search the web for Rust programming language.",
    "previous_response_id": "resp_1",
    "tools": [
      {
        "type": "mcp",
        "server_label": "brave",
        "server_url": "http://127.0.0.1:8080/mcp",
        "require_approval": "never",
        "allowed_tools": ["brave_web_search"]
      }
    ]
  }'
```

Problematic response shape before this change:

```json
{
  "id": "resp_2",
  "output": [
    {
      "type": "mcp_list_tools",
      "server_label": "brave"
    },
    {
      "type": "mcp_call",
      "server_label": "brave"
    },
    {
      "type": "message"
    }
  ]
}
```

Why this is wrong:

- `brave` was already listed in the first turn
- resumed turn should not emit another `mcp_list_tools` for the same binding

Third request adds a new MCP binding:

```bash
curl "$BASE_URL" \
  -H "Content-Type: application/json" \
  -d '{
    "model": "gpt-5.4",
    "input": "Use deepwiki and brave to answer.",
    "previous_response_id": "resp_2",
    "tools": [
      {
        "type": "mcp",
        "server_label": "brave",
        "server_url": "http://127.0.0.1:8080/mcp",
        "require_approval": "never",
        "allowed_tools": ["brave_web_search"]
      },
      {
        "type": "mcp",
        "server_label": "deepwiki",
        "server_url": "https://mcp.deepwiki.com/mcp",
        "require_approval": "never"
      }
    ]
  }'
```

Problematic response shape before this change:

```json
{
  "id": "resp_3",
  "output": [
    {
      "type": "mcp_list_tools",
      "server_label": "brave"
    },
    {
      "type": "mcp_list_tools",
      "server_label": "deepwiki"
    },
    {
      "type": "mcp_call",
      "server_label": "brave"
    },
    {
      "type": "mcp_call",
      "server_label": "deepwiki"
    },
    {
      "type": "message"
    }
  ]
}
```

Why this is wrong:

- only `deepwiki` is new
- `brave` should not be relisted again

### After This Change

First request stays the same:

```json
{
  "id": "resp_1",
  "output": [
    {
      "type": "mcp_list_tools",
      "server_label": "brave"
    },
    {
      "type": "mcp_call",
      "server_label": "brave"
    },
    {
      "type": "message"
    }
  ]
}
```

Second request with the same binding now returns:

```json
{
  "id": "resp_2",
  "output": [
    {
      "type": "mcp_call",
      "server_label": "brave"
    },
    {
      "type": "message"
    }
  ]
}
```

Key change:

- no repeated `mcp_list_tools` for `brave`

Third request with a newly added binding now returns:

```json
{
  "id": "resp_3",
  "output": [
    {
      "type": "mcp_list_tools",
      "server_label": "deepwiki"
    },
    {
      "type": "mcp_call",
      "server_label": "brave"
    },
    {
      "type": "mcp_call",
      "server_label": "deepwiki"
    },
    {
      "type": "message"
    }
  ]
}
```

Key change:

- only the newly added `deepwiki` binding gets a new `mcp_list_tools`
- existing `brave` binding is not relisted

### Streaming Check

The same rule also applies to SSE event flow:

- before: resumed streams could emit `response.mcp_list_tools.in_progress` and `response.mcp_list_tools.completed` again for existing bindings
- after: resumed streams emit those events only for newly added bindings

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Resumption now preserves previously listed tools and only emits newly introduced tool listings when resuming.

* **Bug Fixes**
  * Resumed non-streaming and streaming responses no longer repeat already-seen tool-list emissions while still producing expected tool calls and completions.

* **Tests**
  * Added end-to-end and integration tests validating resumed behavior for streaming and non-streaming flows, exact listing, call, and completion events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->