### PR TITLE
ci(benchmarks): add Devstral 2 to H100 nightly benchmarks

### DIFF
--- a/.github/workflows/nightly-benchmark.yml
+++ b/.github/workflows/nightly-benchmark.yml
@@ -3,6 +3,7 @@ name: Nightly Benchmark
 on:
   schedule:
     - cron: '0 8 * * *'
+  pull_request:
   workflow_dispatch:
     inputs:
       models:
@@ -117,14 +118,14 @@ jobs:
       max-parallel: 8
       matrix:
         model:
-          - { id: meta-llama/Llama-3.1-8B-Instruct, slug: meta-llama-Llama-3.1-8B-Instruct, test_class: TestNightlyLlama8bSingle }
-          - { id: Qwen/Qwen2.5-7B-Instruct, slug: Qwen-Qwen2.5-7B-Instruct, test_class: TestNightlyQwen7bSingle }
-          - { id: Qwen/Qwen3-30B-A3B, slug: Qwen-Qwen3-30B-A3B, test_class: TestNightlyQwen30bSingle }
-          - { id: openai/gpt-oss-20b, slug: openai-gpt-oss-20b, test_class: TestNightlyGptOss20bSingle }
+          # - { id: meta-llama/Llama-3.1-8B-Instruct, slug: meta-llama-Llama-3.1-8B-Instruct, test_class: TestNightlyLlama8bSingle }
+          # - { id: Qwen/Qwen2.5-7B-Instruct, slug: Qwen-Qwen2.5-7B-Instruct, test_class: TestNightlyQwen7bSingle }
+          # - { id: Qwen/Qwen3-30B-A3B, slug: Qwen-Qwen3-30B-A3B, test_class: TestNightlyQwen30bSingle }
+          # - { id: openai/gpt-oss-20b, slug: openai-gpt-oss-20b, test_class: TestNightlyGptOss20bSingle }
           - { id: mistralai/Devstral-2-123B-Instruct-2512, slug: mistralai-Devstral-2-123B-Instruct-2512, test_class: TestNightlyDevstral2Single }
-          - { id: meta-llama/Llama-4-Scout-17B-16E-Instruct, slug: meta-llama-Llama-4-Scout-17B-16E-Instruct, test_class: TestNightlyLlama4ScoutSingle }
-          - { id: meta-llama/Llama-3.3-70B-Instruct, slug: meta-llama-Llama-3.3-70B-Instruct, test_class: TestNightlyLlama70bSingle }
-          - { id: RedHatAI/Llama-3.3-70B-Instruct-FP8-dynamic, slug: RedHatAI-Llama-3.3-70B-Instruct-FP8-dynamic, test_class: TestNightlyLlama70bFp8Single }
+          # - { id: meta-llama/Llama-4-Scout-17B-16E-Instruct, slug: meta-llama-Llama-4-Scout-17B-16E-Instruct, test_class: TestNightlyLlama4ScoutSingle }
+          # - { id: meta-llama/Llama-3.3-70B-Instruct, slug: meta-llama-Llama-3.3-70B-Instruct, test_class: TestNightlyLlama70bSingle }
+          # - { id: RedHatAI/Llama-3.3-70B-Instruct-FP8-dynamic, slug: RedHatAI-Llama-3.3-70B-Instruct-FP8-dynamic, test_class: TestNightlyLlama70bFp8Single }
         variant:
           - { id: sglang, runtime: sglang, grpc_only: "false", setup_vllm: false, setup_trtllm: false }
           - { id: vllm,   runtime: vllm,   grpc_only: "false", setup_vllm: true, setup_trtllm: false }
@@ -226,7 +227,7 @@ jobs:
   multi-worker:
     name: "${{ matrix.model.id }} / multi-${{ matrix.variant.id }}"
     needs: build-wheel
-    if: ${{ !cancelled() }}
+    if: false
     runs-on: 4-gpu-h100
     timeout-minutes: 1440
     strategy:
@@ -340,7 +341,7 @@ jobs:
   single-worker-h200:
     name: "${{ matrix.model.id }} / single-${{ matrix.variant.id }}"
     needs: build-wheel
-    if: ${{ !cancelled() }}
+    if: false
     runs-on: ["8-gpu-h200"]
     timeout-minutes: 1440
     strategy:

--- a/.github/workflows/nightly-benchmark.yml
+++ b/.github/workflows/nightly-benchmark.yml
@@ -3,7 +3,6 @@ name: Nightly Benchmark
 on:
   schedule:
     - cron: '0 8 * * *'
-  pull_request:
   workflow_dispatch:
     inputs:
       models:
@@ -118,14 +117,14 @@ jobs:
       max-parallel: 8
       matrix:
         model:
-          # - { id: meta-llama/Llama-3.1-8B-Instruct, slug: meta-llama-Llama-3.1-8B-Instruct, test_class: TestNightlyLlama8bSingle }
-          # - { id: Qwen/Qwen2.5-7B-Instruct, slug: Qwen-Qwen2.5-7B-Instruct, test_class: TestNightlyQwen7bSingle }
-          # - { id: Qwen/Qwen3-30B-A3B, slug: Qwen-Qwen3-30B-A3B, test_class: TestNightlyQwen30bSingle }
-          # - { id: openai/gpt-oss-20b, slug: openai-gpt-oss-20b, test_class: TestNightlyGptOss20bSingle }
+          - { id: meta-llama/Llama-3.1-8B-Instruct, slug: meta-llama-Llama-3.1-8B-Instruct, test_class: TestNightlyLlama8bSingle }
+          - { id: Qwen/Qwen2.5-7B-Instruct, slug: Qwen-Qwen2.5-7B-Instruct, test_class: TestNightlyQwen7bSingle }
+          - { id: Qwen/Qwen3-30B-A3B, slug: Qwen-Qwen3-30B-A3B, test_class: TestNightlyQwen30bSingle }
+          - { id: openai/gpt-oss-20b, slug: openai-gpt-oss-20b, test_class: TestNightlyGptOss20bSingle }
           - { id: mistralai/Devstral-2-123B-Instruct-2512, slug: mistralai-Devstral-2-123B-Instruct-2512, test_class: TestNightlyDevstral2Single }
-          # - { id: meta-llama/Llama-4-Scout-17B-16E-Instruct, slug: meta-llama-Llama-4-Scout-17B-16E-Instruct, test_class: TestNightlyLlama4ScoutSingle }
-          # - { id: meta-llama/Llama-3.3-70B-Instruct, slug: meta-llama-Llama-3.3-70B-Instruct, test_class: TestNightlyLlama70bSingle }
-          # - { id: RedHatAI/Llama-3.3-70B-Instruct-FP8-dynamic, slug: RedHatAI-Llama-3.3-70B-Instruct-FP8-dynamic, test_class: TestNightlyLlama70bFp8Single }
+          - { id: meta-llama/Llama-4-Scout-17B-16E-Instruct, slug: meta-llama-Llama-4-Scout-17B-16E-Instruct, test_class: TestNightlyLlama4ScoutSingle }
+          - { id: meta-llama/Llama-3.3-70B-Instruct, slug: meta-llama-Llama-3.3-70B-Instruct, test_class: TestNightlyLlama70bSingle }
+          - { id: RedHatAI/Llama-3.3-70B-Instruct-FP8-dynamic, slug: RedHatAI-Llama-3.3-70B-Instruct-FP8-dynamic, test_class: TestNightlyLlama70bFp8Single }
         variant:
           - { id: sglang, runtime: sglang, grpc_only: "false", setup_vllm: false, setup_trtllm: false }
           - { id: vllm,   runtime: vllm,   grpc_only: "false", setup_vllm: true, setup_trtllm: false }
@@ -227,7 +226,7 @@ jobs:
   multi-worker:
     name: "${{ matrix.model.id }} / multi-${{ matrix.variant.id }}"
     needs: build-wheel
-    if: false
+    if: ${{ !cancelled() }}
     runs-on: 4-gpu-h100
     timeout-minutes: 1440
     strategy:
@@ -341,7 +340,7 @@ jobs:
   single-worker-h200:
     name: "${{ matrix.model.id }} / single-${{ matrix.variant.id }}"
     needs: build-wheel
-    if: false
+    if: ${{ !cancelled() }}
     runs-on: ["8-gpu-h200"]
     timeout-minutes: 1440
     strategy:

--- a/.github/workflows/nightly-benchmark.yml
+++ b/.github/workflows/nightly-benchmark.yml
@@ -121,6 +121,7 @@ jobs:
           - { id: Qwen/Qwen2.5-7B-Instruct, slug: Qwen-Qwen2.5-7B-Instruct, test_class: TestNightlyQwen7bSingle }
           - { id: Qwen/Qwen3-30B-A3B, slug: Qwen-Qwen3-30B-A3B, test_class: TestNightlyQwen30bSingle }
           - { id: openai/gpt-oss-20b, slug: openai-gpt-oss-20b, test_class: TestNightlyGptOss20bSingle }
+          - { id: mistralai/Devstral-2-123B-Instruct-2512, slug: mistralai-Devstral-2-123B-Instruct-2512, test_class: TestNightlyDevstral2Single }
           - { id: meta-llama/Llama-4-Scout-17B-16E-Instruct, slug: meta-llama-Llama-4-Scout-17B-16E-Instruct, test_class: TestNightlyLlama4ScoutSingle }
           - { id: meta-llama/Llama-3.3-70B-Instruct, slug: meta-llama-Llama-3.3-70B-Instruct, test_class: TestNightlyLlama70bSingle }
           - { id: RedHatAI/Llama-3.3-70B-Instruct-FP8-dynamic, slug: RedHatAI-Llama-3.3-70B-Instruct-FP8-dynamic, test_class: TestNightlyLlama70bFp8Single }

--- a/e2e_test/benchmarks/test_nightly_perf.py
+++ b/e2e_test/benchmarks/test_nightly_perf.py
@@ -139,10 +139,6 @@ _NIGHTLY_MODELS: list[tuple[str, str, int, list[str], dict]] = [
     ),
 ]
 
-_SINGLE_ONLY_NIGHTLY_MODELS = {
-    "mistralai/Devstral-2-123B-Instruct-2512",
-}
-
 # ---------------------------------------------------------------------------
 # Dynamic test class generation
 # ---------------------------------------------------------------------------
@@ -173,10 +169,7 @@ def _make_test_class(model_id, worker_count, backends, extra_kwargs):
 
 
 for _model_id, _name, _multi_workers, _backends, _extra in _NIGHTLY_MODELS:
-    _variants = [("Single", 1)]
-    if _model_id not in _SINGLE_ONLY_NIGHTLY_MODELS:
-        _variants.append(("Multi", _multi_workers))
-    for _suffix, _count in _variants:
+    for _suffix, _count in [("Single", 1), ("Multi", _multi_workers)]:
         _cls_name = f"TestNightly{_name}{_suffix}"
         _cls = _make_test_class(_model_id, _count, _backends, _extra)
         _cls.__name__ = _cls_name

--- a/e2e_test/benchmarks/test_nightly_perf.py
+++ b/e2e_test/benchmarks/test_nightly_perf.py
@@ -103,6 +103,13 @@ _NIGHTLY_MODELS: list[tuple[str, str, int, list[str], dict]] = [
     ("openai/gpt-oss-20b", "GptOss20b", 1, ["http", "grpc"], {}),
     ("minimaxai/minimax-m2", "MinimaxM2", 1, ["http", "grpc"], {}),
     (
+        "mistralai/Devstral-2-123B-Instruct-2512",
+        "Devstral2",
+        1,
+        ["http", "grpc"],
+        {},
+    ),
+    (
         "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8",
         "Llama4Maverick",
         1,
@@ -132,6 +139,9 @@ _NIGHTLY_MODELS: list[tuple[str, str, int, list[str], dict]] = [
     ),
 ]
 
+_SINGLE_ONLY_NIGHTLY_MODELS = {
+    "mistralai/Devstral-2-123B-Instruct-2512",
+}
 
 # ---------------------------------------------------------------------------
 # Dynamic test class generation
@@ -163,7 +173,10 @@ def _make_test_class(model_id, worker_count, backends, extra_kwargs):
 
 
 for _model_id, _name, _multi_workers, _backends, _extra in _NIGHTLY_MODELS:
-    for _suffix, _count in [("Single", 1), ("Multi", _multi_workers)]:
+    _variants = [("Single", 1)]
+    if _model_id not in _SINGLE_ONLY_NIGHTLY_MODELS:
+        _variants.append(("Multi", _multi_workers))
+    for _suffix, _count in _variants:
         _cls_name = f"TestNightly{_name}{_suffix}"
         _cls = _make_test_class(_model_id, _count, _backends, _extra)
         _cls.__name__ = _cls_name

--- a/e2e_test/infra/model_specs.py
+++ b/e2e_test/infra/model_specs.py
@@ -114,6 +114,15 @@ MODEL_SPECS: dict[str, dict] = {
         "sglang_args": ["--trust-remote-code"],
         "vllm_args": ["--trust-remote-code"],
     },
+    # Devstral 2 123B - Nightly benchmarks
+    "mistralai/Devstral-2-123B-Instruct-2512": {
+        "model": _resolve_model_path("mistralai/Devstral-2-123B-Instruct-2512"),
+        "tp": 4,
+        "features": ["chat", "streaming", "function_calling", "reasoning"],
+        "startup_timeout": 1200,
+        "sglang_args": ["--trust-remote-code"],
+        "vllm_args": ["--trust-remote-code"],
+    },
     # Vision-language model for multimodal benchmarks (MMMU)
     "Qwen/Qwen3-VL-8B-Instruct": {
         "model": _resolve_model_path("Qwen/Qwen3-VL-8B-Instruct"),


### PR DESCRIPTION
## Description

## Summary

Add `mistralai/Devstral-2-123B-Instruct-2512` to the nightly benchmark coverage on H100 for both `sglang` and `vllm`.

## Changes
  - add Devstral 2 to `MODEL_SPECS` with nightly benchmark metadata
  - set Devstral 2 tensor parallelism to `4`
  - register nightly benchmark test classes for Devstral 2
  - add Devstral 2 to the `single-worker-h100` workflow matrix
  - place the workflow entry immediately after the commented-out `minimax-m2` benchmark entry

  ## Notes

  - this enables nightly H100 runs for both `sglang` and `vllm`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for mistralai/Devstral-2-123B-Instruct-2512 with chat, streaming, function-calling, and reasoning.

* **Tests**
  * Integrated the new model into nightly performance and benchmark tests (single-worker) for HTTP and gRPC backends.

* **Chores**
  * Updated nightly benchmark configuration to include the new model and its startup/timeout settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->