### PR TITLE
[WIP] Connorli/fix func call for KimiK2.5

### DIFF
--- a/bindings/python/src/smg/serve.py
+++ b/bindings/python/src/smg/serve.py
@@ -11,7 +11,9 @@ import atexit
 import logging
 import os
 import random
+import shutil
 import signal
+import tempfile
 import socket
 import subprocess
 import sys
@@ -550,6 +552,7 @@ class ServeOrchestrator:
         self.launcher: WorkerLauncher = BACKEND_LAUNCHERS[backend]()
         self.workers: list[tuple[subprocess.Popen, int]] = []
         self._shutting_down = False
+        self._prometheus_dir: str | None = None
 
     # -- public API ---------------------------------------------------------
 
@@ -571,6 +574,15 @@ class ServeOrchestrator:
     def _launch_workers(self) -> None:
         ports = _find_available_ports(self.args.worker_base_port, self.args.data_parallel_size)
         host = self.args.worker_host
+
+        if getattr(self.args, "connection_mode", "grpc") == "grpc":
+            self._prometheus_dir = tempfile.mkdtemp(prefix="smg_prometheus_")
+            os.environ["PROMETHEUS_MULTIPROC_DIR"] = self._prometheus_dir
+            logger.info(
+                "Set PROMETHEUS_MULTIPROC_DIR=%s for gRPC metrics collection",
+                self._prometheus_dir,
+            )
+
         for dp_rank, port in enumerate(ports):
             env = self.launcher.gpu_env(self.args, dp_rank)
             proc = self.launcher.launch(self.args, self.backend_args, host, port, env)
@@ -640,6 +652,23 @@ class ServeOrchestrator:
                     os.killpg(proc.pid, signal.SIGKILL)
                 except (ProcessLookupError, OSError):
                     pass
+
+        self._cleanup_prometheus_dir()
+
+    def _cleanup_prometheus_dir(self) -> None:
+        """Remove the temporary prometheus multiprocess directory and its .db files."""
+        if self._prometheus_dir is None:
+            return
+        try:
+            shutil.rmtree(self._prometheus_dir)
+            logger.info("Cleaned up PROMETHEUS_MULTIPROC_DIR=%s", self._prometheus_dir)
+        except OSError as e:
+            logger.warning(
+                "Failed to clean up PROMETHEUS_MULTIPROC_DIR=%s: %s",
+                self._prometheus_dir,
+                e,
+            )
+        self._prometheus_dir = None
 
 
 # ---------------------------------------------------------------------------

--- a/crates/grpc_client/src/trtllm_service.rs
+++ b/crates/grpc_client/src/trtllm_service.rs
@@ -273,6 +273,7 @@ impl TrtllmServiceClient {
         token_ids: Vec<u32>,
         multimodal_input: Option<proto::MultimodalInput>,
         tool_call_constraint: Option<(String, String)>, // (constraint_type, constraint_value)
+        eos_token_ids: &[u32],
     ) -> Result<proto::GenerateRequest, String> {
         // Build sampling config
         let sampling_config = Self::build_sampling_config_from_chat(body);
@@ -283,16 +284,14 @@ impl TrtllmServiceClient {
         // Build guided decoding params if needed
         let guided_decoding = Self::build_guided_decoding_from_chat(body, tool_call_constraint)?;
 
-        let mut stop = Self::extract_stop_strings(body.stop.as_ref());
-        // TRT-LLM gRPC does not reliably apply generation_config.eos_token_id
-        // in its _setup() path.  Chatml models use <|im_end|> as the turn
-        // delimiter, which differs from tokenizer.eos_token_id.  Explicitly
-        // include it so the engine stops generating at turn boundaries.
-        if !stop.iter().any(|s| s == "<|im_end|>") {
-            stop.push("<|im_end|>".to_string());
-        }
+        let stop = Self::extract_stop_strings(body.stop.as_ref());
 
         let max_tokens = body.max_completion_tokens.unwrap_or(2048);
+
+        // Pass merged EOS token IDs from config.json + generation_config.json.
+        // TRT-LLM's gRPC path does not reliably merge these internally,
+        // so we provide them explicitly via the standard stop_token_ids field.
+        let stop_token_ids: Vec<u32> = eos_token_ids.to_vec();
 
         let grpc_request = proto::GenerateRequest {
             request_id,
@@ -306,7 +305,7 @@ impl TrtllmServiceClient {
             max_tokens,
             streaming: body.stream,
             stop,
-            stop_token_ids: vec![],
+            stop_token_ids,
             ignore_eos: body.ignore_eos,
             bad: vec![],
             bad_token_ids: vec![],
@@ -370,11 +369,8 @@ impl TrtllmServiceClient {
             .and_then(|p| p.max_new_tokens)
             .unwrap_or(2048);
 
-        let mut stop =
+        let stop =
             Self::extract_stop_strings(body.sampling_params.as_ref().and_then(|p| p.stop.as_ref()));
-        if !stop.iter().any(|s| s == "<|im_end|>") {
-            stop.push("<|im_end|>".to_string());
-        }
 
         let grpc_request = proto::GenerateRequest {
             request_id,

--- a/crates/grpc_client/src/trtllm_service.rs
+++ b/crates/grpc_client/src/trtllm_service.rs
@@ -265,6 +265,10 @@ impl TrtllmServiceClient {
         clippy::unused_self,
         reason = "method receiver kept for consistent public API across gRPC backends"
     )]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "mirrors vLLM backend API; refactoring to a params struct is tracked separately"
+    )]
     pub fn build_generate_request_from_chat(
         &self,
         request_id: String,

--- a/crates/grpc_client/src/trtllm_service.rs
+++ b/crates/grpc_client/src/trtllm_service.rs
@@ -283,7 +283,14 @@ impl TrtllmServiceClient {
         // Build guided decoding params if needed
         let guided_decoding = Self::build_guided_decoding_from_chat(body, tool_call_constraint)?;
 
-        let stop = Self::extract_stop_strings(body.stop.as_ref());
+        let mut stop = Self::extract_stop_strings(body.stop.as_ref());
+        // TRT-LLM gRPC does not reliably apply generation_config.eos_token_id
+        // in its _setup() path.  Chatml models use <|im_end|> as the turn
+        // delimiter, which differs from tokenizer.eos_token_id.  Explicitly
+        // include it so the engine stops generating at turn boundaries.
+        if !stop.iter().any(|s| s == "<|im_end|>") {
+            stop.push("<|im_end|>".to_string());
+        }
 
         let max_tokens = body.max_completion_tokens.unwrap_or(2048);
 
@@ -363,8 +370,11 @@ impl TrtllmServiceClient {
             .and_then(|p| p.max_new_tokens)
             .unwrap_or(2048);
 
-        let stop =
+        let mut stop =
             Self::extract_stop_strings(body.sampling_params.as_ref().and_then(|p| p.stop.as_ref()));
+        if !stop.iter().any(|s| s == "<|im_end|>") {
+            stop.push("<|im_end|>".to_string());
+        }
 
         let grpc_request = proto::GenerateRequest {
             request_id,

--- a/crates/multimodal/src/registry/kimi_k25.rs
+++ b/crates/multimodal/src/registry/kimi_k25.rs
@@ -1,0 +1,165 @@
+use std::collections::HashMap;
+
+use serde_json::{json, Value};
+
+use crate::{
+    registry::{ModelMetadata, ModelProcessorSpec, ModelRegistryError, RegistryResult},
+    types::{FieldLayout, Modality, PromptReplacement, TokenId},
+    vision::image_processor::PreprocessedImages,
+};
+
+pub(super) struct KimiK25Spec;
+
+impl KimiK25Spec {
+    fn media_placeholder_token_id(metadata: &ModelMetadata) -> RegistryResult<TokenId> {
+        metadata
+            .config_u32(&["media_placeholder_token_id"])
+            .map(|v| v as TokenId)
+            .ok_or_else(|| ModelRegistryError::MissingConfigField {
+                field: "media_placeholder_token_id".to_string(),
+            })
+    }
+}
+
+impl ModelProcessorSpec for KimiK25Spec {
+    fn name(&self) -> &'static str {
+        "kimi_k25"
+    }
+
+    fn matches(&self, metadata: &ModelMetadata) -> bool {
+        metadata
+            .config_model_type()
+            .is_some_and(|mt| mt == "kimi_k25")
+            || {
+                let id = metadata.model_id.to_ascii_lowercase();
+                id.contains("kimi") && (id.contains("k2.5") || id.contains("k25"))
+            }
+    }
+
+    fn placeholder_token(&self, _metadata: &ModelMetadata) -> RegistryResult<String> {
+        Ok("<|media_pad|>".to_string())
+    }
+
+    fn placeholder_token_id(&self, metadata: &ModelMetadata) -> RegistryResult<TokenId> {
+        Self::media_placeholder_token_id(metadata)
+    }
+
+    fn modality_limits(
+        &self,
+        _metadata: &ModelMetadata,
+    ) -> RegistryResult<HashMap<Modality, usize>> {
+        Ok(HashMap::from([(Modality::Image, 10)]))
+    }
+
+    fn processor_kwargs(&self, _metadata: &ModelMetadata) -> RegistryResult<Value> {
+        Ok(json!({}))
+    }
+
+    fn prompt_replacements(
+        &self,
+        metadata: &ModelMetadata,
+        preprocessed: &PreprocessedImages,
+    ) -> RegistryResult<Vec<PromptReplacement>> {
+        let pad_token_id = Self::media_placeholder_token_id(metadata)?;
+        let placeholder_token = self.placeholder_token(metadata)?;
+        // Keep 1 placeholder per image — TRT-LLM's KimiK25InputProcessor
+        // handles expansion to N vision tokens server-side based on grid_thws.
+        // SMG must NOT pre-expand or TRT-LLM will see N placeholders and
+        // attempt to expand each one again.
+        Ok(preprocessed
+            .num_img_tokens
+            .iter()
+            .map(|_| {
+                let tokens = vec![pad_token_id; 1];
+                PromptReplacement::sequence(Modality::Image, &placeholder_token, tokens)
+            })
+            .collect())
+    }
+
+    fn field_layouts(&self) -> HashMap<String, FieldLayout> {
+        // pixel_values is patchified: [total_patches, C, patch_h, patch_w].
+        // grid_thws is [num_images, 3] with (t, h, w) per image.
+        HashMap::from([
+            (
+                "pixel_values".to_string(),
+                FieldLayout::flat("patches_per_image"),
+            ),
+            ("grid_thws".to_string(), FieldLayout::Batched),
+            ("patches_per_image".to_string(), FieldLayout::Batched),
+        ])
+    }
+
+    fn keep_on_cpu_keys(&self) -> Vec<String> {
+        vec!["grid_thws".to_string()]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use crate::{
+        registry::{test_helpers::*, ModelMetadata, ModelRegistry},
+        types::ImageSize,
+    };
+
+    #[test]
+    fn kimi_k25_matches_by_model_type() {
+        let tokenizer = TestTokenizer::new(&[("<|media_pad|>", 163605)]);
+        let config = json!({
+            "model_type": "kimi_k25",
+            "media_placeholder_token_id": 163605,
+        });
+        let metadata = ModelMetadata {
+            model_id: "some-custom-name",
+            tokenizer: &tokenizer,
+            config: &config,
+        };
+        let registry = ModelRegistry::new();
+        let spec = registry.lookup(&metadata).expect("should match kimi_k25");
+        assert_eq!(spec.name(), "kimi_k25");
+    }
+
+    #[test]
+    fn kimi_k25_matches_by_model_id() {
+        let tokenizer = TestTokenizer::new(&[("<|media_pad|>", 163605)]);
+        let config = json!({
+            "model_type": "unknown",
+            "media_placeholder_token_id": 163605,
+        });
+        let metadata = ModelMetadata {
+            model_id: "nvidia/Kimi-K2.5-NVFP4",
+            tokenizer: &tokenizer,
+            config: &config,
+        };
+        let registry = ModelRegistry::new();
+        let spec = registry.lookup(&metadata).expect("should match kimi by name");
+        assert_eq!(spec.name(), "kimi_k25");
+    }
+
+    #[test]
+    fn kimi_k25_prompt_replacements() {
+        let tokenizer = TestTokenizer::new(&[("<|media_pad|>", 163605)]);
+        let config = json!({
+            "model_type": "kimi_k25",
+            "media_placeholder_token_id": 163605,
+        });
+        let metadata = ModelMetadata {
+            model_id: "nvidia/Kimi-K2.5-NVFP4",
+            tokenizer: &tokenizer,
+            config: &config,
+        };
+        let registry = ModelRegistry::new();
+        let spec = registry.lookup(&metadata).expect("kimi spec");
+        // 1 placeholder per image (TRT-LLM expands server-side)
+        let replacements = spec
+            .prompt_replacements(
+                &metadata,
+                &test_preprocessed_with_tokens(&[ImageSize::new(448, 448)], &[256]),
+            )
+            .unwrap();
+        assert_eq!(replacements.len(), 1);
+        assert_eq!(replacements[0].tokens.len(), 1);
+        assert_eq!(replacements[0].tokens[0], 163605);
+    }
+}

--- a/crates/multimodal/src/registry/kimi_k25.rs
+++ b/crates/multimodal/src/registry/kimi_k25.rs
@@ -133,7 +133,9 @@ mod tests {
             config: &config,
         };
         let registry = ModelRegistry::new();
-        let spec = registry.lookup(&metadata).expect("should match kimi by name");
+        let spec = registry
+            .lookup(&metadata)
+            .expect("should match kimi by name");
         assert_eq!(spec.name(), "kimi_k25");
     }
 

--- a/crates/multimodal/src/registry/mod.rs
+++ b/crates/multimodal/src/registry/mod.rs
@@ -1,3 +1,4 @@
+mod kimi_k25;
 mod llama4;
 mod llava;
 mod phi3_v;
@@ -5,6 +6,7 @@ mod qwen3_vl;
 mod qwen_vl;
 mod traits;
 
+use kimi_k25::KimiK25Spec;
 use llama4::Llama4Spec;
 use llava::{LlavaNextSpec, LlavaSpec};
 use once_cell::sync::Lazy;
@@ -22,6 +24,7 @@ impl ModelRegistry {
     pub fn new() -> Self {
         Self {
             specs: vec![
+                LazySpec::new("kimi_k25", || Box::new(KimiK25Spec)),
                 LazySpec::new("llama4", || Box::new(Llama4Spec)),
                 // LlavaNext must be registered before Llava so "llava_next" model_type matches first.
                 LazySpec::new("llava_next", || Box::new(LlavaNextSpec)),

--- a/crates/multimodal/src/registry/mod.rs
+++ b/crates/multimodal/src/registry/mod.rs
@@ -134,6 +134,7 @@ pub(super) mod test_helpers {
                 cls_token: None,
                 mask_token: None,
                 additional_special_tokens: vec![],
+                eos_token_ids: vec![],
             });
             &TOKENS
         }

--- a/crates/multimodal/src/vision/image_processor.rs
+++ b/crates/multimodal/src/vision/image_processor.rs
@@ -464,6 +464,12 @@ impl ImageProcessorRegistry {
             Box::new(super::processors::Llama4VisionProcessor::new()),
         );
 
+        // Register Kimi-K2.5 (MoonViT3d, NaViT-style)
+        registry.register(
+            "kimi",
+            Box::new(super::processors::KimiK25Processor::new()),
+        );
+
         registry
     }
 }

--- a/crates/multimodal/src/vision/image_processor.rs
+++ b/crates/multimodal/src/vision/image_processor.rs
@@ -465,10 +465,7 @@ impl ImageProcessorRegistry {
         );
 
         // Register Kimi-K2.5 (MoonViT3d, NaViT-style)
-        registry.register(
-            "kimi",
-            Box::new(super::processors::KimiK25Processor::new()),
-        );
+        registry.register("kimi", Box::new(super::processors::KimiK25Processor::new()));
 
         registry
     }

--- a/crates/multimodal/src/vision/processors/kimi_k25.rs
+++ b/crates/multimodal/src/vision/processors/kimi_k25.rs
@@ -1,0 +1,61 @@
+//! Kimi-K2.5 image processor.
+//!
+//! Kimi-K2.5 uses MoonViT3d with a NaViT-style architecture very similar
+//! to Qwen VL: patch_size=14, merge_kernel_size=(2,2), dynamic resolution.
+//! We reuse the QwenVLProcessorBase with Kimi-specific defaults.
+
+use image::DynamicImage;
+
+use super::qwen_vl_base::{QwenVLConfig, QwenVLProcessorBase};
+use crate::vision::{
+    image_processor::{ImagePreProcessor, PreprocessedImages},
+    preprocessor_config::PreProcessorConfig,
+    transforms::TransformError,
+};
+
+pub struct KimiK25Processor {
+    inner: QwenVLProcessorBase,
+}
+
+impl KimiK25Processor {
+    pub fn new() -> Self {
+        Self {
+            inner: QwenVLProcessorBase::new(QwenVLConfig {
+                patch_size: 14,
+                merge_size: 2,
+                min_pixels: 14 * 14 * 4,
+                max_pixels: 14 * 14 * 16384,
+                temporal_patch_size: 1,
+                mean: [0.5, 0.5, 0.5],
+                std: [0.5, 0.5, 0.5],
+                model_name: "kimi_k25",
+            }),
+        }
+    }
+}
+
+impl ImagePreProcessor for KimiK25Processor {
+    fn default_mean(&self) -> [f64; 3] {
+        [0.5, 0.5, 0.5]
+    }
+
+    fn default_std(&self) -> [f64; 3] {
+        [0.5, 0.5, 0.5]
+    }
+
+    fn preprocess(
+        &self,
+        images: &[DynamicImage],
+        config: &PreProcessorConfig,
+    ) -> Result<PreprocessedImages, TransformError> {
+        self.inner.preprocess(images, config)
+    }
+
+    fn calculate_num_tokens(&self, width: u32, height: u32, config: &PreProcessorConfig) -> usize {
+        self.inner.calculate_num_tokens(width, height, config)
+    }
+
+    fn model_name(&self) -> &'static str {
+        "kimi_k25"
+    }
+}

--- a/crates/multimodal/src/vision/processors/kimi_k25.rs
+++ b/crates/multimodal/src/vision/processors/kimi_k25.rs
@@ -17,6 +17,12 @@ pub struct KimiK25Processor {
     inner: QwenVLProcessorBase,
 }
 
+impl Default for KimiK25Processor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl KimiK25Processor {
     pub fn new() -> Self {
         Self {

--- a/crates/multimodal/src/vision/processors/mod.rs
+++ b/crates/multimodal/src/vision/processors/mod.rs
@@ -15,6 +15,7 @@
 //! - **LLaMA 4 Vision** (`llama4_vision`): Tile-based processing with 336x336 tiles and global tile
 //! - **Pixtral/Mistral3** (`pixtral`): CLIP-based preprocessing with dynamic resolution
 
+pub mod kimi_k25;
 pub mod llama4_vision;
 pub mod llava;
 pub mod phi3_vision;
@@ -24,6 +25,7 @@ pub mod qwen2_vl;
 pub mod qwen3_vl;
 pub mod qwen_vl_base;
 
+pub use kimi_k25::KimiK25Processor;
 pub use llama4_vision::Llama4VisionProcessor;
 pub use llava::{ImageAspectRatio, LlavaNextProcessor, LlavaProcessor};
 pub use phi3_vision::Phi3VisionProcessor;

--- a/crates/protocols/src/chat.rs
+++ b/crates/protocols/src/chat.rs
@@ -574,12 +574,20 @@ impl Normalizable for ChatCompletionRequest {
             let kwargs = self.chat_template_kwargs.get_or_insert_with(HashMap::new);
             match thinking {
                 ThinkingConfig::Enabled { .. } => {
-                    kwargs.entry("enable_thinking".to_string()).or_insert(Value::Bool(true));
-                    kwargs.entry("thinking".to_string()).or_insert(Value::Bool(true));
+                    kwargs
+                        .entry("enable_thinking".to_string())
+                        .or_insert(Value::Bool(true));
+                    kwargs
+                        .entry("thinking".to_string())
+                        .or_insert(Value::Bool(true));
                 }
                 ThinkingConfig::Disabled => {
-                    kwargs.entry("enable_thinking".to_string()).or_insert(Value::Bool(false));
-                    kwargs.entry("thinking".to_string()).or_insert(Value::Bool(false));
+                    kwargs
+                        .entry("enable_thinking".to_string())
+                        .or_insert(Value::Bool(false));
+                    kwargs
+                        .entry("thinking".to_string())
+                        .or_insert(Value::Bool(false));
                 }
             }
         }

--- a/crates/protocols/src/chat.rs
+++ b/crates/protocols/src/chat.rs
@@ -138,6 +138,35 @@ impl MessageContent {
 }
 
 // ============================================================================
+// Reasoning Configuration (OpenAI-style)
+// ============================================================================
+
+/// Configuration for reasoning models on the Chat Completions API.
+///
+/// OpenAI clients send this as ``{"reasoning": {"enabled": bool}}`` to
+/// explicitly toggle thinking for reasoning-capable models such as
+/// Kimi-K2.5 or Qwen3.  The value is mapped to ``chat_template_kwargs``
+/// (``enable_thinking`` / ``thinking``) by ``ChatCompletionRequest::
+/// normalize()`` so the chat template sees the caller's intent.
+///
+/// Without this struct, serde silently drops the field and reasoning
+/// models think by default -- inflating output sequence length on
+/// traffic that explicitly disabled it.
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct ReasoningConfig {
+    /// Whether reasoning / thinking should run for this request.
+    pub enabled: bool,
+
+    /// Optional effort hint (``low`` / ``medium`` / ``high``).  Migrated
+    /// to the top-level ``reasoning_effort`` field by ``normalize()``
+    /// (which is the field ``chat_utils.rs`` forwards to the chat
+    /// template).  The top-level ``reasoning_effort`` wins when both
+    /// are set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effort: Option<String>,
+}
+
+// ============================================================================
 // Chat Completion Request
 // ============================================================================
 
@@ -206,6 +235,12 @@ pub struct ChatCompletionRequest {
     /// Configuration for extended thinking (Anthropic-style).
     /// Maps to chat_template_kwargs for thinking-capable models.
     pub thinking: Option<ThinkingConfig>,
+
+    /// OpenAI-style reasoning config, e.g. ``{"reasoning": {"enabled": false}}``.
+    /// Mapped to ``chat_template_kwargs`` (``enable_thinking`` /
+    /// ``thinking``) by ``normalize()`` so reasoning-capable chat
+    /// templates (Kimi-K2.5, Qwen3, etc.) respect the caller's intent.
+    pub reasoning: Option<ReasoningConfig>,
 
     /// An object specifying the format that the model must output
     pub response_format: Option<ResponseFormat>,
@@ -569,7 +604,7 @@ impl Normalizable for ChatCompletionRequest {
             self.function_call = None; // Clear deprecated field
         }
 
-        // Migrate thinking → chat_template_kwargs
+        // Migrate Anthropic-style ``thinking`` → ``chat_template_kwargs``.
         if let Some(ref thinking) = self.thinking {
             let kwargs = self.chat_template_kwargs.get_or_insert_with(HashMap::new);
             match thinking {
@@ -589,6 +624,24 @@ impl Normalizable for ChatCompletionRequest {
                         .entry("thinking".to_string())
                         .or_insert(Value::Bool(false));
                 }
+            }
+        }
+
+        // Migrate OpenAI-style ``reasoning`` → ``chat_template_kwargs``
+        // and top-level ``reasoning_effort``.  ``.or_insert()`` preserves
+        // values the caller set directly, so the top-level
+        // ``reasoning_effort`` field wins over ``reasoning.effort``; when
+        // both ``thinking`` and ``reasoning`` are sent, ``thinking`` wins.
+        if let Some(ref reasoning) = self.reasoning {
+            let kwargs = self.chat_template_kwargs.get_or_insert_with(HashMap::new);
+            kwargs
+                .entry("enable_thinking".to_string())
+                .or_insert(Value::Bool(reasoning.enabled));
+            kwargs
+                .entry("thinking".to_string())
+                .or_insert(Value::Bool(reasoning.enabled));
+            if let Some(ref effort) = reasoning.effort {
+                self.reasoning_effort.get_or_insert_with(|| effort.clone());
             }
         }
 
@@ -776,4 +829,111 @@ pub struct ChatStreamChoice {
     pub finish_reason: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub matched_stop: Option<Value>,
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Round-trip JSON body through serde + Normalizable; return the
+    /// resulting ``chat_template_kwargs``.  Exercises both the field's
+    /// presence on ``ChatCompletionRequest`` (so it isn't silently
+    /// dropped by serde) and the migration in ``normalize()``.
+    fn normalize_and_get_kwargs(body: &str) -> HashMap<String, Value> {
+        let mut req: ChatCompletionRequest =
+            serde_json::from_str(body).expect("valid request JSON");
+        req.normalize();
+        req.chat_template_kwargs.unwrap_or_default()
+    }
+
+    #[test]
+    fn reasoning_enabled_false_sets_kwargs() {
+        let kwargs = normalize_and_get_kwargs(
+            r#"{"model":"m","messages":[],"reasoning":{"enabled":false}}"#,
+        );
+        assert_eq!(kwargs.get("enable_thinking"), Some(&Value::Bool(false)));
+        assert_eq!(kwargs.get("thinking"), Some(&Value::Bool(false)));
+    }
+
+    #[test]
+    fn reasoning_enabled_true_sets_kwargs() {
+        let kwargs =
+            normalize_and_get_kwargs(r#"{"model":"m","messages":[],"reasoning":{"enabled":true}}"#);
+        assert_eq!(kwargs.get("enable_thinking"), Some(&Value::Bool(true)));
+        assert_eq!(kwargs.get("thinking"), Some(&Value::Bool(true)));
+    }
+
+    #[test]
+    fn reasoning_field_without_enabled_is_rejected() {
+        // Verify the ``enabled`` key is required; serde should surface
+        // a deserialization error rather than silently accepting {}.
+        let err = serde_json::from_str::<ChatCompletionRequest>(
+            r#"{"model":"m","messages":[],"reasoning":{}}"#,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("enabled"),
+            "expected error about missing `enabled`, got: {err}"
+        );
+    }
+
+    #[test]
+    fn reasoning_effort_migrates_to_top_level() {
+        // ``reasoning.effort`` MUST populate ``request.reasoning_effort``
+        // because the chat_utils consumer reads only the top-level field
+        // when forwarding to the chat template.  Without this, setting
+        // ``reasoning.effort`` would be silently dropped downstream.
+        let mut req: ChatCompletionRequest = serde_json::from_str(
+            r#"{"model":"m","messages":[],"reasoning":{"enabled":true,"effort":"low"}}"#,
+        )
+        .unwrap();
+        assert!(req.reasoning_effort.is_none());
+        req.normalize();
+        assert_eq!(req.reasoning_effort.as_deref(), Some("low"));
+    }
+
+    #[test]
+    fn top_level_reasoning_effort_wins_over_reasoning_effort() {
+        // Precedence: explicit top-level ``reasoning_effort`` is more
+        // specific and wins when both are sent.
+        let mut req: ChatCompletionRequest = serde_json::from_str(
+            r#"{
+                "model":"m","messages":[],
+                "reasoning_effort":"high",
+                "reasoning":{"enabled":true,"effort":"low"}
+            }"#,
+        )
+        .unwrap();
+        req.normalize();
+        assert_eq!(req.reasoning_effort.as_deref(), Some("high"));
+    }
+
+    #[test]
+    fn no_reasoning_field_leaves_kwargs_untouched() {
+        let mut req: ChatCompletionRequest =
+            serde_json::from_str(r#"{"model":"m","messages":[]}"#).unwrap();
+        assert!(req.reasoning.is_none());
+        req.normalize();
+        assert!(req.chat_template_kwargs.is_none());
+    }
+
+    #[test]
+    fn explicit_chat_template_kwargs_wins_over_reasoning() {
+        // ``.or_insert()`` contract: explicit operator overrides via
+        // ``chat_template_kwargs`` directly are preserved even when a
+        // reasoning field is also present.
+        let kwargs = normalize_and_get_kwargs(
+            r#"{
+                "model":"m","messages":[],
+                "reasoning":{"enabled":false},
+                "chat_template_kwargs":{"enable_thinking":true,"thinking":true}
+            }"#,
+        );
+        assert_eq!(kwargs.get("enable_thinking"), Some(&Value::Bool(true)));
+        assert_eq!(kwargs.get("thinking"), Some(&Value::Bool(true)));
+    }
 }

--- a/crates/protocols/src/chat.rs
+++ b/crates/protocols/src/chat.rs
@@ -48,6 +48,7 @@ pub enum ChatMessage {
     Tool {
         content: MessageContent,
         tool_call_id: String,
+        name: Option<String>,
     },
     #[serde(rename = "function")]
     Function { content: String, name: String },

--- a/crates/protocols/src/chat.rs
+++ b/crates/protocols/src/chat.rs
@@ -11,6 +11,7 @@ use super::{
         StringOrArray, Tool, ToolCall, ToolCallDelta, ToolChoice, ToolChoiceValue, ToolReference,
         Usage,
     },
+    messages::ThinkingConfig,
     sampling_params::{validate_top_k_value, validate_top_p_value},
 };
 use crate::{
@@ -201,6 +202,10 @@ pub struct ChatCompletionRequest {
 
     /// Effort level for reasoning models (low, medium, high)
     pub reasoning_effort: Option<String>,
+
+    /// Configuration for extended thinking (Anthropic-style).
+    /// Maps to chat_template_kwargs for thinking-capable models.
+    pub thinking: Option<ThinkingConfig>,
 
     /// An object specifying the format that the model must output
     pub response_format: Option<ResponseFormat>,
@@ -562,6 +567,21 @@ impl Normalizable for ChatCompletionRequest {
                 },
             });
             self.function_call = None; // Clear deprecated field
+        }
+
+        // Migrate thinking → chat_template_kwargs
+        if let Some(ref thinking) = self.thinking {
+            let kwargs = self.chat_template_kwargs.get_or_insert_with(HashMap::new);
+            match thinking {
+                ThinkingConfig::Enabled { .. } => {
+                    kwargs.entry("enable_thinking".to_string()).or_insert(Value::Bool(true));
+                    kwargs.entry("thinking".to_string()).or_insert(Value::Bool(true));
+                }
+                ThinkingConfig::Disabled => {
+                    kwargs.entry("enable_thinking".to_string()).or_insert(Value::Bool(false));
+                    kwargs.entry("thinking".to_string()).or_insert(Value::Bool(false));
+                }
+            }
         }
 
         // Apply tool_choice defaults

--- a/crates/protocols/src/common.rs
+++ b/crates/protocols/src/common.rs
@@ -195,11 +195,61 @@ pub enum ContentPart {
     VideoUrl { video_url: VideoUrl },
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, schemars::JsonSchema)]
+#[derive(Debug, Clone, PartialEq, schemars::JsonSchema)]
 pub struct ImageUrl {
     pub url: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub detail: Option<String>, // "auto", "low", or "high"
+}
+
+impl Serialize for ImageUrl {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeStruct;
+        let field_count = 1 + self.detail.is_some() as usize;
+        let mut state = serializer.serialize_struct("ImageUrl", field_count)?;
+        state.serialize_field("url", &self.url)?;
+        if let Some(ref detail) = self.detail {
+            state.serialize_field("detail", detail)?;
+        }
+        state.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for ImageUrl {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        use serde::de;
+
+        struct ImageUrlVisitor;
+
+        impl<'de> de::Visitor<'de> for ImageUrlVisitor {
+            type Value = ImageUrl;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("a string URL or an object with url field")
+            }
+
+            fn visit_str<E: de::Error>(self, v: &str) -> Result<ImageUrl, E> {
+                Ok(ImageUrl { url: v.to_string(), detail: None })
+            }
+
+            fn visit_map<M: de::MapAccess<'de>>(self, mut map: M) -> Result<ImageUrl, M::Error> {
+                let mut url = None;
+                let mut detail = None;
+                while let Some(key) = map.next_key::<String>()? {
+                    match key.as_str() {
+                        "url" => url = Some(map.next_value()?),
+                        "detail" => detail = map.next_value()?,
+                        _ => { let _ = map.next_value::<de::IgnoredAny>()?; }
+                    }
+                }
+                Ok(ImageUrl {
+                    url: url.ok_or_else(|| de::Error::missing_field("url"))?,
+                    detail,
+                })
+            }
+        }
+
+        deserializer.deserialize_any(ImageUrlVisitor)
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, schemars::JsonSchema)]

--- a/crates/protocols/src/common.rs
+++ b/crates/protocols/src/common.rs
@@ -228,7 +228,10 @@ impl<'de> Deserialize<'de> for ImageUrl {
             }
 
             fn visit_str<E: de::Error>(self, v: &str) -> Result<ImageUrl, E> {
-                Ok(ImageUrl { url: v.to_string(), detail: None })
+                Ok(ImageUrl {
+                    url: v.to_string(),
+                    detail: None,
+                })
             }
 
             fn visit_map<M: de::MapAccess<'de>>(self, mut map: M) -> Result<ImageUrl, M::Error> {
@@ -238,7 +241,9 @@ impl<'de> Deserialize<'de> for ImageUrl {
                     match key.as_str() {
                         "url" => url = Some(map.next_value()?),
                         "detail" => detail = map.next_value()?,
-                        _ => { let _ = map.next_value::<de::IgnoredAny>()?; }
+                        _ => {
+                            let _ = map.next_value::<de::IgnoredAny>()?;
+                        }
                     }
                 }
                 Ok(ImageUrl {

--- a/crates/reasoning_parser/src/parsers/base.rs
+++ b/crates/reasoning_parser/src/parsers/base.rs
@@ -63,6 +63,12 @@ impl ReasoningParser for BaseReasoningParser {
             .to_string();
 
         if !processed_text.contains(&self.config.think_end_token) {
+            // Don't consume tool call markers as reasoning content
+            if let Some(tool_pos) = processed_text.find("<|tool_calls_section_begin|>") {
+                let reasoning_text = processed_text[..tool_pos].trim().to_string();
+                let normal_text = processed_text[tool_pos..].to_string();
+                return Ok(ParserResult::new(normal_text, reasoning_text));
+            }
             // Assume reasoning was truncated before end token
             return Ok(ParserResult::reasoning(processed_text));
         }
@@ -133,6 +139,14 @@ impl ReasoningParser for BaseReasoningParser {
 
         // Continue with reasoning content
         if self.in_reasoning && self.config.stream_reasoning {
+            // Some models skip </think> and go straight to tool calls
+            if let Some(tool_pos) = current_text.find("<|tool_calls_section_begin|>") {
+                let reasoning_text = current_text[..tool_pos].trim().to_string();
+                let normal_text = current_text[tool_pos..].to_string();
+                self.buffer.clear();
+                self.in_reasoning = false;
+                return Ok(ParserResult::new(normal_text, reasoning_text));
+            }
             // Stream the content immediately
             let reasoning_text = current_text;
             self.buffer.clear();

--- a/crates/tokenizer/src/huggingface.rs
+++ b/crates/tokenizer/src/huggingface.rs
@@ -82,6 +82,12 @@ impl HuggingFaceTokenizer {
             }
         }
 
+        // Load merged EOS token IDs from config.json + generation_config.json
+        let mut special_tokens = special_tokens;
+        if let Some(dir) = std::path::Path::new(file_path).parent() {
+            special_tokens.eos_token_ids = crate::tiktoken::load_eos_token_ids(dir);
+        }
+
         Ok(HuggingFaceTokenizer {
             tokenizer,
             special_tokens,
@@ -208,6 +214,7 @@ impl HuggingFaceTokenizer {
             cls_token: find_token(&["[CLS]", "<cls>", "<CLS>"]),
             mask_token: find_token(&["[MASK]", "<mask>", "<MASK>"]),
             additional_special_tokens,
+            ..Default::default()
         }
     }
 
@@ -382,6 +389,10 @@ impl TokenizerTrait for HuggingFaceTokenizer {
     }
     fn think_in_prefill(&self) -> bool {
         self.chat_template.think_in_prefill()
+    }
+
+    fn eos_token_ids(&self) -> &[TokenIdType] {
+        &self.special_tokens.eos_token_ids
     }
 
     fn set_chat_template(&mut self, template: String) -> Result<()> {

--- a/crates/tokenizer/src/mock.rs
+++ b/crates/tokenizer/src/mock.rs
@@ -51,11 +51,7 @@ impl MockTokenizer {
             bos_token: Some("<bos>".to_string()),
             eos_token: Some("<eos>".to_string()),
             unk_token: Some("<unk>".to_string()),
-            sep_token: None,
-            pad_token: None,
-            cls_token: None,
-            mask_token: None,
-            additional_special_tokens: vec![],
+            ..Default::default()
         };
 
         Self {

--- a/crates/tokenizer/src/tiktoken.rs
+++ b/crates/tokenizer/src/tiktoken.rs
@@ -520,7 +520,7 @@ impl Decoder for TiktokenTokenizer {
                     ._decode_native_and_split(token_ids.to_vec())
                     .flatten()
                     .collect();
-                tracing::warn!(
+                tracing::debug!(
                     error = %err,
                     token_count = token_ids.len(),
                     "tiktoken decode failed; returning lossy UTF-8 fallback"

--- a/crates/tokenizer/src/tiktoken.rs
+++ b/crates/tokenizer/src/tiktoken.rs
@@ -42,6 +42,60 @@ struct TiktokenConfig {
     chat_template: Option<String>,
 }
 
+/// Load merged EOS token IDs from config.json and generation_config.json.
+///
+/// Models may define different EOS tokens in each file (e.g. Kimi-K2.5 has
+/// `[EOS]` (163585) in config.json and `<|im_end|>` (163586) in
+/// generation_config.json).  We merge both into a deduplicated list so the
+/// engine can stop at any of them — matching SGLang's behaviour.
+pub fn load_eos_token_ids(dir: &Path) -> Vec<TokenIdType> {
+    let mut ids = std::collections::BTreeSet::new();
+
+    // config.json — eos_token_id can be int or list
+    if let Ok(content) = std::fs::read_to_string(dir.join("config.json")) {
+        if let Ok(cfg) = serde_json::from_str::<serde_json::Value>(&content) {
+            match cfg.get("eos_token_id") {
+                Some(serde_json::Value::Number(n)) => {
+                    if let Some(id) = n.as_u64() {
+                        ids.insert(id as TokenIdType);
+                    }
+                }
+                Some(serde_json::Value::Array(arr)) => {
+                    for v in arr {
+                        if let Some(id) = v.as_u64() {
+                            ids.insert(id as TokenIdType);
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    // generation_config.json — eos_token_id can be int or list
+    if let Ok(content) = std::fs::read_to_string(dir.join("generation_config.json")) {
+        if let Ok(cfg) = serde_json::from_str::<serde_json::Value>(&content) {
+            match cfg.get("eos_token_id") {
+                Some(serde_json::Value::Number(n)) => {
+                    if let Some(id) = n.as_u64() {
+                        ids.insert(id as TokenIdType);
+                    }
+                }
+                Some(serde_json::Value::Array(arr)) => {
+                    for v in arr {
+                        if let Some(id) = v.as_u64() {
+                            ids.insert(id as TokenIdType);
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    ids.into_iter().collect()
+}
+
 /// Parse `tokenizer_config.json` for tiktoken-based models.
 fn load_tiktoken_config(config_path: &Path) -> Result<TiktokenConfig> {
     let content = std::fs::read_to_string(config_path)?;
@@ -119,6 +173,7 @@ fn parse_special_tokens(config: &serde_json::Value) -> SpecialTokens {
         cls_token: get_str("cls_token"),
         mask_token: get_str("mask_token"),
         additional_special_tokens: additional,
+        ..Default::default()
     }
 }
 
@@ -259,9 +314,13 @@ impl TiktokenTokenizer {
             })
         };
 
+        // 6. Load merged EOS token IDs from config.json + generation_config.json
+        let mut special_tokens = config.special_tokens;
+        special_tokens.eos_token_ids = load_eos_token_ids(dir);
+
         Ok(TiktokenTokenizer {
             tokenizer,
-            special_tokens: config.special_tokens,
+            special_tokens,
             vocab,
             reverse_vocab,
             vocab_size,
@@ -308,27 +367,20 @@ impl TiktokenTokenizer {
             TiktokenModel::Cl100kBase => SpecialTokens {
                 bos_token: Some("<|endoftext|>".to_string()),
                 eos_token: Some("<|endoftext|>".to_string()),
-                unk_token: None,
-                sep_token: None,
                 pad_token: Some("<|endoftext|>".to_string()),
-                cls_token: None,
-                mask_token: None,
                 additional_special_tokens: vec![
                     "<|fim_prefix|>".to_string(),
                     "<|fim_middle|>".to_string(),
                     "<|fim_suffix|>".to_string(),
                     "<|endofprompt|>".to_string(),
                 ],
+                ..Default::default()
             },
             _ => SpecialTokens {
                 bos_token: Some("<|endoftext|>".to_string()),
                 eos_token: Some("<|endoftext|>".to_string()),
-                unk_token: None,
-                sep_token: None,
                 pad_token: Some("<|endoftext|>".to_string()),
-                cls_token: None,
-                mask_token: None,
-                additional_special_tokens: vec![],
+                ..Default::default()
             },
         }
     }
@@ -527,6 +579,10 @@ impl TokenizerTrait for TiktokenTokenizer {
     fn thinking_key_name(&self) -> Option<ThinkingKeyName> {
         self.chat_template.thinking_key_name()
     }
+    fn eos_token_ids(&self) -> &[TokenIdType] {
+        &self.special_tokens.eos_token_ids
+    }
+
     fn think_in_prefill(&self) -> bool {
         self.chat_template.think_in_prefill()
     }

--- a/crates/tokenizer/src/tiktoken.rs
+++ b/crates/tokenizer/src/tiktoken.rs
@@ -436,8 +436,16 @@ pub fn is_tiktoken_file(path: &Path) -> bool {
 }
 
 impl Encoder for TiktokenTokenizer {
-    fn encode(&self, input: &str, _add_special_tokens: bool) -> Result<Encoding> {
-        let tokens = self.tokenizer.encode_ordinary(input);
+    fn encode(&self, input: &str, add_special_tokens: bool) -> Result<Encoding> {
+        // When add_special_tokens is true, use encode_with_special_tokens to
+        // correctly handle tokens like <|im_system|>, <|im_end|>, <think>.
+        // This is needed for chat template output which contains these markers.
+        // When false, use encode_ordinary (default for stop sequences, etc.).
+        let tokens = if add_special_tokens {
+            self.tokenizer.encode_with_special_tokens(input)
+        } else {
+            self.tokenizer.encode_ordinary(input)
+        };
         Ok(Encoding::Tiktoken(tokens))
     }
 

--- a/crates/tokenizer/src/traits.rs
+++ b/crates/tokenizer/src/traits.rs
@@ -114,6 +114,12 @@ pub trait Tokenizer: Encoder + Decoder {
         false
     }
 
+    /// Merged EOS token IDs from config.json and generation_config.json.
+    /// Backends should stop generation when any of these tokens is produced.
+    fn eos_token_ids(&self) -> &[TokenIdType] {
+        &[]
+    }
+
     /// Set or override the chat template.
     ///
     /// Returns an error if the template fails to parse or the tokenizer
@@ -176,4 +182,9 @@ pub struct SpecialTokens {
     pub cls_token: Option<String>,
     pub mask_token: Option<String>,
     pub additional_special_tokens: Vec<String>,
+    /// Merged EOS token IDs from config.json + generation_config.json.
+    /// Models like Kimi-K2.5 define different EOS tokens in each file
+    /// (e.g. `[EOS]` in config.json, `<|im_end|>` in generation_config.json).
+    /// The engine must stop at any of these tokens.
+    pub eos_token_ids: Vec<TokenIdType>,
 }

--- a/crates/tool_parser/src/parsers/kimik2.rs
+++ b/crates/tool_parser/src/parsers/kimik2.rs
@@ -57,16 +57,15 @@ impl KimiK2Parser {
         reason = "regex patterns are compile-time string literals"
     )]
     pub fn new() -> Self {
-        // Pattern for complete tool calls
-        let tool_call_pattern = r"<\|tool_call_begin\|>\s*(?P<tool_call_id>[\w\.]+:\d+)\s*<\|tool_call_argument_begin\|>\s*(?P<function_arguments>\{.*?\})\s*<\|tool_call_end\|>";
+        // Supports alternative delimiters: <|func_start|>/<|func_end|>; (?s) for multi-line JSON
+        let tool_call_pattern = r"(?s)<\|tool_call_begin\|>\s*(?P<tool_call_id>[\w\.]+:\d+)\s*(?:<\|tool_call_argument_begin\|>\s*|<\|func_start\|>\s*)?(?P<function_arguments>\{.*?\})\s*(?:<\|tool_call_end\|>|<\|func_end\|>)";
         let tool_call_extractor = Regex::new(tool_call_pattern).expect("Valid regex pattern");
 
-        // Pattern for streaming (partial) tool calls
-        let stream_pattern = r"<\|tool_call_begin\|>\s*(?P<tool_call_id>[\w\.]+:\d+)\s*<\|tool_call_argument_begin\|>\s*(?P<function_arguments>\{.*)";
+        let stream_pattern = r"(?s)<\|tool_call_begin\|>\s*(?P<tool_call_id>[\w\.]+:\d+)\s*(?:<\|tool_call_argument_begin\|>\s*|<\|func_start\|>\s*)?(?P<function_arguments>\{.*)";
         let stream_tool_call_extractor = Regex::new(stream_pattern).expect("Valid regex pattern");
 
         // Pattern for removing completed tool calls
-        let end_pattern = r"<\|tool_call_begin\|>.*?<\|tool_call_end\|>";
+        let end_pattern = r"<\|tool_call_begin\|>.*?(?:<\|tool_call_end\|>|<\|func_end\|>)";
         let tool_call_end_pattern = Regex::new(end_pattern).expect("Valid regex pattern");
 
         // Robust parser for ids like "functions.search:0" or fallback "search:0"
@@ -181,7 +180,7 @@ impl ToolParser for KimiK2Parser {
             // No tool markers detected - return all buffered content as normal text
             let mut normal_text = std::mem::take(&mut self.buffer);
             // Remove end tokens if present
-            for e_token in ["<|tool_calls_section_end|>", "<|tool_call_end|>"] {
+            for e_token in ["<|tool_calls_section_end|>", "<|tool_call_end|>", "<|func_end|>"] {
                 normal_text = normal_text.replace(e_token, "");
             }
             return Ok(StreamingParseResult {
@@ -242,13 +241,14 @@ impl ToolParser for KimiK2Parser {
                             function_args
                         };
 
-                        // Split by end token before sending (like Python does)
-                        let parsed_args_diff =
-                            if let Some(pos) = argument_diff.find("<|tool_call_end|>") {
-                                &argument_diff[..pos]
-                            } else {
-                                argument_diff
-                            };
+                        // Split by end token before sending
+                        let end_pos = argument_diff.find("<|tool_call_end|>")
+                            .or_else(|| argument_diff.find("<|func_end|>"));
+                        let parsed_args_diff = if let Some(pos) = end_pos {
+                            &argument_diff[..pos]
+                        } else {
+                            argument_diff
+                        };
 
                         if !parsed_args_diff.is_empty() {
                             calls.push(ToolCallItem {
@@ -265,8 +265,9 @@ impl ToolParser for KimiK2Parser {
                         }
 
                         // Check completeness - split by end token first
-                        let parsed_args = if let Some(pos) = function_args.find("<|tool_call_end|>")
-                        {
+                        let end_pos2 = function_args.find("<|tool_call_end|>")
+                            .or_else(|| function_args.find("<|func_end|>"));
+                        let parsed_args = if let Some(pos) = end_pos2 {
                             &function_args[..pos]
                         } else {
                             function_args

--- a/crates/tool_parser/src/parsers/kimik2.rs
+++ b/crates/tool_parser/src/parsers/kimik2.rs
@@ -181,7 +181,11 @@ impl ToolParser for KimiK2Parser {
             // No tool markers detected - return all buffered content as normal text
             let mut normal_text = std::mem::take(&mut self.buffer);
             // Remove end tokens if present
-            for e_token in ["<|tool_calls_section_end|>", "<|tool_call_end|>", "<|func_end|>"] {
+            for e_token in [
+                "<|tool_calls_section_end|>",
+                "<|tool_call_end|>",
+                "<|func_end|>",
+            ] {
                 normal_text = normal_text.replace(e_token, "");
             }
             return Ok(StreamingParseResult {
@@ -243,7 +247,8 @@ impl ToolParser for KimiK2Parser {
                         };
 
                         // Split by end token before sending
-                        let end_pos = argument_diff.find("<|tool_call_end|>")
+                        let end_pos = argument_diff
+                            .find("<|tool_call_end|>")
                             .or_else(|| argument_diff.find("<|func_end|>"));
                         let parsed_args_diff = if let Some(pos) = end_pos {
                             &argument_diff[..pos]
@@ -266,7 +271,8 @@ impl ToolParser for KimiK2Parser {
                         }
 
                         // Check completeness - split by end token first
-                        let end_pos2 = function_args.find("<|tool_call_end|>")
+                        let end_pos2 = function_args
+                            .find("<|tool_call_end|>")
                             .or_else(|| function_args.find("<|func_end|>"));
                         let parsed_args = if let Some(pos) = end_pos2 {
                             &function_args[..pos]

--- a/crates/tool_parser/src/parsers/kimik2.rs
+++ b/crates/tool_parser/src/parsers/kimik2.rs
@@ -57,19 +57,20 @@ impl KimiK2Parser {
         reason = "regex patterns are compile-time string literals"
     )]
     pub fn new() -> Self {
-        // Supports alternative delimiters: <|func_start|>/<|func_end|>; (?s) for multi-line JSON
-        let tool_call_pattern = r"(?s)<\|tool_call_begin\|>\s*(?P<tool_call_id>[\w\.]+:\d+)\s*(?:<\|tool_call_argument_begin\|>\s*|<\|func_start\|>\s*)?(?P<function_arguments>\{.*?\})\s*(?:<\|tool_call_end\|>|<\|func_end\|>)";
+        // Supports alternative delimiters: <|func_start|>/<|func_end|>; (?s) for multi-line JSON.
+        // Tool call IDs may contain hyphens (e.g. "functions.execute-tool:0").
+        let tool_call_pattern = r"(?s)<\|tool_call_begin\|>\s*(?P<tool_call_id>[\w\.\-]+:\d+)\s*(?:<\|tool_call_argument_begin\|>\s*|<\|func_start\|>\s*)?(?P<function_arguments>\{.*?\})\s*(?:<\|tool_call_end\|>|<\|func_end\|>)";
         let tool_call_extractor = Regex::new(tool_call_pattern).expect("Valid regex pattern");
 
-        let stream_pattern = r"(?s)<\|tool_call_begin\|>\s*(?P<tool_call_id>[\w\.]+:\d+)\s*(?:<\|tool_call_argument_begin\|>\s*|<\|func_start\|>\s*)?(?P<function_arguments>\{.*)";
+        let stream_pattern = r"(?s)<\|tool_call_begin\|>\s*(?P<tool_call_id>[\w\.\-]+:\d+)\s*(?:<\|tool_call_argument_begin\|>\s*|<\|func_start\|>\s*)?(?P<function_arguments>\{.*)";
         let stream_tool_call_extractor = Regex::new(stream_pattern).expect("Valid regex pattern");
 
         // Pattern for removing completed tool calls
         let end_pattern = r"<\|tool_call_begin\|>.*?(?:<\|tool_call_end\|>|<\|func_end\|>)";
         let tool_call_end_pattern = Regex::new(end_pattern).expect("Valid regex pattern");
 
-        // Robust parser for ids like "functions.search:0" or fallback "search:0"
-        let id_pattern = r"^(?:functions\.)?(?P<name>[\w\.]+):(?P<index>\d+)$";
+        // Robust parser for ids like "functions.execute-tool:0" or fallback "search:0"
+        let id_pattern = r"^(?:functions\.)?(?P<name>[\w\.\-]+):(?P<index>\d+)$";
         let tool_call_id_regex = Regex::new(id_pattern).expect("Valid regex pattern");
 
         Self {

--- a/model_gateway/benches/wasm_middleware_latency.rs
+++ b/model_gateway/benches/wasm_middleware_latency.rs
@@ -75,6 +75,7 @@ fn bench_wasm_middleware_buffering(c: &mut Criterion) {
         concurrency_queue_tx: None,
         router_manager: None,
         mesh_handler: None,
+        api_port: 0,
     });
 
     c.bench_function("wasm_middleware_pre_fix_latency", |b| {

--- a/model_gateway/src/app_context.rs
+++ b/model_gateway/src/app_context.rs
@@ -1,5 +1,8 @@
 use std::{
-    sync::{Arc, OnceLock},
+    sync::{
+        atomic::AtomicU64,
+        Arc, OnceLock,
+    },
     time::Duration,
 };
 
@@ -68,6 +71,10 @@ pub struct AppContext {
     pub wasm_manager: Option<Arc<WasmModuleManager>>,
     pub worker_service: Arc<WorkerService>,
     pub inflight_tracker: Arc<InFlightRequestTracker>,
+    /// Unix timestamp (seconds) of the last token chunk forwarded to a client.
+    /// Zero means no tokens have been forwarded yet. Used by health_generate to
+    /// skip the real inference probe when traffic is flowing recently.
+    pub last_token_time: Arc<AtomicU64>,
     pub kv_event_monitor: Option<Arc<KvEventMonitor>>,
     pub realtime_registry: Arc<RealtimeRegistry>,
     /// Bind address for WebRTC UDP sockets (`None` = `0.0.0.0`, auto-detect).
@@ -359,6 +366,7 @@ impl AppContextBuilder {
             wasm_manager: self.wasm_manager,
             worker_service,
             inflight_tracker: InFlightRequestTracker::new(),
+            last_token_time: Arc::new(AtomicU64::new(0)),
             kv_event_monitor: self.kv_event_monitor,
             realtime_registry: Arc::new(RealtimeRegistry::new()),
             webrtc_bind_addr: self.webrtc_bind_addr,

--- a/model_gateway/src/core/worker_manager.rs
+++ b/model_gateway/src/core/worker_manager.rs
@@ -17,7 +17,7 @@ use tokio::{
     sync::{watch, Mutex},
     task::JoinHandle,
 };
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use crate::{
     core::{
@@ -83,6 +83,36 @@ impl IntoResponse for EngineMetricsResult {
             Self::Err(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg).into_response(),
         }
     }
+}
+
+/// Collect gRPC worker metrics by aggregating `PROMETHEUS_MULTIPROC_DIR` via a python3 subprocess.
+async fn collect_prometheus_multiproc_metrics() -> Result<String, String> {
+    let dir = std::env::var("PROMETHEUS_MULTIPROC_DIR").map_err(|_| {
+        "PROMETHEUS_MULTIPROC_DIR not set; cannot collect metrics from gRPC workers".to_string()
+    })?;
+
+    let output = tokio::process::Command::new("python3")
+        .args([
+            "-c",
+            "import sys\n\
+             from prometheus_client import CollectorRegistry, generate_latest\n\
+             from prometheus_client.multiprocess import MultiProcessCollector\n\
+             registry = CollectorRegistry()\n\
+             MultiProcessCollector(registry)\n\
+             sys.stdout.buffer.write(generate_latest(registry))\n",
+        ])
+        .env("PROMETHEUS_MULTIPROC_DIR", &dir)
+        .output()
+        .await
+        .map_err(|e| format!("failed to run python3 prometheus collector: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("python3 prometheus collector failed: {stderr}"));
+    }
+
+    String::from_utf8(output.stdout)
+        .map_err(|e| format!("prometheus collector output is not valid UTF-8: {e}"))
 }
 
 pub struct WorkerManager;
@@ -273,18 +303,44 @@ impl WorkerManager {
             return EngineMetricsResult::Err("No available workers".to_string());
         }
 
-        let responses = fan_out(&workers, client, "metrics", reqwest::Method::GET).await;
-
         let mut metric_packs = Vec::new();
-        for resp in responses {
-            if let Ok(r) = resp.result {
-                if r.status().is_success() {
-                    if let Ok(text) = r.text().await {
-                        metric_packs.push(MetricPack {
-                            labels: vec![("worker_addr".into(), resp.url)],
-                            metrics_text: text,
-                        });
+
+        let http_workers: Vec<_> = workers
+            .iter()
+            .filter(|w| matches!(w.connection_mode(), ConnectionMode::Http))
+            .cloned()
+            .collect();
+        let has_grpc = workers
+            .iter()
+            .any(|w| matches!(w.connection_mode(), ConnectionMode::Grpc));
+
+        if !http_workers.is_empty() {
+            let responses =
+                fan_out(&http_workers, client, "metrics", reqwest::Method::GET).await;
+            for resp in responses {
+                if let Ok(r) = resp.result {
+                    if r.status().is_success() {
+                        if let Ok(text) = r.text().await {
+                            metric_packs.push(MetricPack {
+                                labels: vec![("worker_addr".into(), resp.url)],
+                                metrics_text: text,
+                            });
+                        }
                     }
+                }
+            }
+        }
+
+        if has_grpc {
+            match collect_prometheus_multiproc_metrics().await {
+                Ok(text) => {
+                    metric_packs.push(MetricPack {
+                        labels: vec![],
+                        metrics_text: text,
+                    });
+                }
+                Err(e) => {
+                    warn!("Failed to collect gRPC worker metrics from PROMETHEUS_MULTIPROC_DIR: {e}");
                 }
             }
         }

--- a/model_gateway/src/core/worker_manager.rs
+++ b/model_gateway/src/core/worker_manager.rs
@@ -111,8 +111,12 @@ async fn collect_prometheus_multiproc_metrics() -> Result<String, String> {
         return Err(format!("python3 prometheus collector failed: {stderr}"));
     }
 
-    String::from_utf8(output.stdout)
-        .map_err(|e| format!("prometheus collector output is not valid UTF-8: {e}"))
+    let text = String::from_utf8(output.stdout)
+        .map_err(|e| format!("prometheus collector output is not valid UTF-8: {e}"))?;
+    if text.trim().is_empty() {
+        return Err("no metrics available from gRPC workers yet".to_string());
+    }
+    Ok(text)
 }
 
 pub struct WorkerManager;
@@ -332,11 +336,14 @@ impl WorkerManager {
 
         if has_grpc {
             match collect_prometheus_multiproc_metrics().await {
-                Ok(text) => {
+                Ok(text) if !text.trim().is_empty() => {
                     metric_packs.push(MetricPack {
                         labels: vec![],
                         metrics_text: text,
                     });
+                }
+                Ok(_) => {
+                    // No metrics available yet from gRPC workers — skip silently
                 }
                 Err(e) => {
                     warn!(

--- a/model_gateway/src/core/worker_manager.rs
+++ b/model_gateway/src/core/worker_manager.rs
@@ -315,8 +315,7 @@ impl WorkerManager {
             .any(|w| matches!(w.connection_mode(), ConnectionMode::Grpc));
 
         if !http_workers.is_empty() {
-            let responses =
-                fan_out(&http_workers, client, "metrics", reqwest::Method::GET).await;
+            let responses = fan_out(&http_workers, client, "metrics", reqwest::Method::GET).await;
             for resp in responses {
                 if let Ok(r) = resp.result {
                     if r.status().is_success() {
@@ -340,7 +339,9 @@ impl WorkerManager {
                     });
                 }
                 Err(e) => {
-                    warn!("Failed to collect gRPC worker metrics from PROMETHEUS_MULTIPROC_DIR: {e}");
+                    warn!(
+                        "Failed to collect gRPC worker metrics from PROMETHEUS_MULTIPROC_DIR: {e}"
+                    );
                 }
             }
         }

--- a/model_gateway/src/observability/metrics_server.rs
+++ b/model_gateway/src/observability/metrics_server.rs
@@ -1,8 +1,12 @@
 //! HTTP server for the Prometheus metrics endpoint (port 29000).
-//! Later PRs add `/ws/metrics` to this same server.
+//!
+//! The `/metrics` endpoint returns both SMG's own metrics (`smg_*`) and engine
+//! metrics (`vllm_*`, `sglang_*`, `nv_trt_*`) in a single Prometheus text
+//! response, so Prometheus only needs one scrape target per pod.
 
 use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
+    sync::{Arc, OnceLock},
     time::Duration,
 };
 
@@ -12,6 +16,28 @@ use tokio::task::JoinHandle;
 use tracing::{error, info};
 
 use super::metrics::UPKEEP_INTERVAL_SECS;
+use crate::core::{
+    worker_manager::{EngineMetricsResult, WorkerManager},
+    worker_registry::WorkerRegistry,
+};
+
+/// Shared references for engine metrics collection, populated after app init.
+pub struct EngineMetricsDeps {
+    pub worker_registry: Arc<WorkerRegistry>,
+    pub client: reqwest::Client,
+}
+
+/// Global handle set once after AppContext is built.
+static ENGINE_METRICS_DEPS: OnceLock<EngineMetricsDeps> = OnceLock::new();
+
+/// Register the worker registry and HTTP client for engine metrics collection.
+/// Called once after AppContext is initialized.
+pub fn register_engine_metrics_deps(worker_registry: Arc<WorkerRegistry>, client: reqwest::Client) {
+    let _ = ENGINE_METRICS_DEPS.set(EngineMetricsDeps {
+        worker_registry,
+        client,
+    });
+}
 
 #[derive(Clone)]
 struct MetricsState {
@@ -19,12 +45,23 @@ struct MetricsState {
 }
 
 async fn prometheus_handler(State(state): State<MetricsState>) -> impl IntoResponse {
+    let smg_text = state.handle.render();
+
+    let engine_text = if let Some(deps) = ENGINE_METRICS_DEPS.get() {
+        match WorkerManager::get_engine_metrics(&deps.worker_registry, &deps.client).await {
+            EngineMetricsResult::Ok(text) => text,
+            EngineMetricsResult::Err(_) => String::new(),
+        }
+    } else {
+        String::new()
+    };
+
     (
         [(
             http::header::CONTENT_TYPE,
             "text/plain; version=0.0.4; charset=utf-8",
         )],
-        state.handle.render(),
+        format!("{smg_text}\n{engine_text}"),
     )
 }
 
@@ -45,7 +82,10 @@ pub async fn start_metrics_server(
         Ok(l) => l,
         Err(e) => {
             error!("failed to bind metrics server on {addr}: {e} — metrics will be unavailable");
-            // Return a no-op handle so the router can still operate
+            #[expect(
+                clippy::disallowed_methods,
+                reason = "no-op task for graceful degradation"
+            )]
             return tokio::spawn(async {});
         }
     };
@@ -66,9 +106,8 @@ pub async fn start_metrics_server(
     });
 
     let state = MetricsState { handle };
-    let app = Router::new()
-        .route("/metrics", get(prometheus_handler))
-        .with_state(state);
+
+    let app = Router::new().route("/metrics", get(prometheus_handler).with_state(state));
 
     #[expect(
         clippy::disallowed_methods,

--- a/model_gateway/src/observability/metrics_server.rs
+++ b/model_gateway/src/observability/metrics_server.rs
@@ -28,12 +28,8 @@ async fn prometheus_handler(State(state): State<MetricsState>) -> impl IntoRespo
     )
 }
 
-/// Start the metrics HTTP server. Binds eagerly so callers fail fast on
-/// port conflicts or bad addresses.
-#[expect(
-    clippy::expect_used,
-    reason = "startup initialization — metrics server must bind or the process cannot serve metrics"
-)]
+/// Start the metrics HTTP server. If the port is unavailable, logs an error
+/// and returns a no-op handle so the router can still operate.
 pub async fn start_metrics_server(
     handle: PrometheusHandle,
     host: String,
@@ -45,9 +41,14 @@ pub async fn start_metrics_server(
     });
     let addr = SocketAddr::new(ip_addr, port);
 
-    let listener = tokio::net::TcpListener::bind(addr)
-        .await
-        .expect("failed to bind metrics server");
+    let listener = match tokio::net::TcpListener::bind(addr).await {
+        Ok(l) => l,
+        Err(e) => {
+            error!("failed to bind metrics server on {addr}: {e} — metrics will be unavailable");
+            // Return a no-op handle so the router can still operate
+            return tokio::spawn(async {});
+        }
+    };
 
     info!("Metrics server listening on {addr}");
 

--- a/model_gateway/src/routers/grpc/client.rs
+++ b/model_gateway/src/routers/grpc/client.rs
@@ -276,6 +276,7 @@ impl GrpcClient {
         token_ids: Vec<u32>,
         multimodal_inputs: Option<MultimodalData>,
         tool_constraints: Option<(String, String)>,
+        eos_token_ids: &[u32],
     ) -> Result<ProtoGenerateRequest, String> {
         match self {
             Self::Sglang(client) => {
@@ -320,6 +321,7 @@ impl GrpcClient {
                     token_ids,
                     trtllm_mm,
                     tool_constraints,
+                    eos_token_ids,
                 )?;
                 Ok(ProtoGenerateRequest::Trtllm(Box::new(req)))
             }

--- a/model_gateway/src/routers/grpc/client.rs
+++ b/model_gateway/src/routers/grpc/client.rs
@@ -268,6 +268,10 @@ impl GrpcClient {
         clippy::unreachable,
         reason = "assembly stage guarantees matching MultimodalData variant for each backend"
     )]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "mirrors per-backend build methods; params struct tracked separately"
+    )]
     pub fn build_chat_request(
         &self,
         request_id: String,

--- a/model_gateway/src/routers/grpc/common/responses/mod.rs
+++ b/model_gateway/src/routers/grpc/common/responses/mod.rs
@@ -7,5 +7,5 @@ pub(crate) mod utils;
 
 // Re-export commonly used items
 pub(crate) use context::ResponsesContext;
-pub(crate) use streaming::build_sse_response;
+pub(crate) use streaming::{build_sse_response, build_tracked_sse_response};
 pub(crate) use utils::{ensure_mcp_connection, persist_response_if_needed};

--- a/model_gateway/src/routers/grpc/common/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/common/responses/streaming.rs
@@ -1,5 +1,7 @@
 //! Streaming infrastructure for /v1/responses endpoint
 
+use std::sync::{atomic::AtomicU64, Arc};
+
 use axum::{body::Body, http::StatusCode, response::Response};
 use bytes::Bytes;
 use http::header::{HeaderValue, CONTENT_TYPE};
@@ -17,7 +19,7 @@ use openai_protocol::{
 use serde_json::json;
 use smg_mcp::{self as mcp, ResponseFormat};
 use tokio::sync::mpsc;
-use tokio_stream::wrappers::UnboundedReceiverStream;
+use tokio_stream::{wrappers::UnboundedReceiverStream, StreamExt};
 use tracing::warn;
 use uuid::Uuid;
 
@@ -996,6 +998,42 @@ pub(crate) fn build_sse_response(
         .expect("infallible: static headers and valid status code")
 }
 
+/// Like `build_sse_response` but atomically records the current time whenever a
+/// chunk is successfully written, allowing the health check to skip its inference
+/// probe when tokens have flowed recently.
+#[expect(
+    clippy::expect_used,
+    reason = "Response::builder with static headers and valid status code is infallible"
+)]
+pub(crate) fn build_tracked_sse_response(
+    rx: mpsc::UnboundedReceiver<Result<Bytes, std::io::Error>>,
+    last_token_time: &Arc<AtomicU64>,
+) -> Response {
+    use std::sync::atomic::Ordering;
+
+    let last_token_time = last_token_time.clone();
+    let stream = UnboundedReceiverStream::new(rx).map(move |result| {
+        if result.is_ok() {
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+            last_token_time.store(now, Ordering::Relaxed);
+        }
+        result
+    });
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(
+            CONTENT_TYPE,
+            HeaderValue::from_static("text/event-stream; charset=utf-8"),
+        )
+        .header("Cache-Control", HeaderValue::from_static("no-cache"))
+        .header("Connection", HeaderValue::from_static("keep-alive"))
+        .body(Body::from_stream(stream))
+        .expect("infallible: static headers and valid status code")
+}
+
 /// Attach `server_label` to an MCP tool-call JSON item.
 ///
 /// Only sets the field when `response_format` indicates a passthrough (mcp_call)
@@ -1008,5 +1046,60 @@ pub(crate) fn attach_mcp_server_label(
 ) {
     if let (Some(label), Some(ResponseFormat::Passthrough)) = (server_label, response_format) {
         item["server_label"] = json!(label);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{atomic::{AtomicU64, Ordering}, Arc};
+
+    use axum::{body::to_bytes, http::StatusCode};
+    use bytes::Bytes;
+    use tokio::sync::mpsc;
+
+    use super::build_tracked_sse_response;
+
+    #[tokio::test]
+    async fn tracked_sse_response_updates_timestamp_on_ok_chunk() {
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        let last_token_time = Arc::new(AtomicU64::new(0));
+        let (tx, rx) = mpsc::unbounded_channel::<Result<Bytes, std::io::Error>>();
+
+        let resp = build_tracked_sse_response(rx, &last_token_time);
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let before = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+
+        tx.send(Ok(Bytes::from("data: hello\n\n"))).unwrap();
+        drop(tx);
+
+        let _ = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+
+        let stored = last_token_time.load(Ordering::Relaxed);
+        assert!(stored >= before, "timestamp should be >= before: {stored} < {before}");
+        assert!(stored <= before + 5, "timestamp should be within 5s: {stored}");
+    }
+
+    #[tokio::test]
+    async fn tracked_sse_response_does_not_update_timestamp_on_error_chunk() {
+        let last_token_time = Arc::new(AtomicU64::new(0));
+        let (tx, rx) = mpsc::unbounded_channel::<Result<Bytes, std::io::Error>>();
+
+        let resp = build_tracked_sse_response(rx, &last_token_time);
+
+        tx.send(Err(std::io::Error::other("stream error"))).unwrap();
+        drop(tx);
+
+        let _ = to_bytes(resp.into_body(), usize::MAX).await;
+
+        assert_eq!(
+            last_token_time.load(Ordering::Relaxed),
+            0,
+            "error chunk should not update the timestamp"
+        );
     }
 }

--- a/model_gateway/src/routers/grpc/common/stages/request_execution.rs
+++ b/model_gateway/src/routers/grpc/common/stages/request_execution.rs
@@ -1,8 +1,10 @@
 //! Request execution stage: Execute gRPC requests (single or dual dispatch)
 
+use std::time::Instant;
+
 use async_trait::async_trait;
 use axum::response::Response;
-use tracing::{debug, error, info_span, Instrument};
+use tracing::{debug, error, info, info_span, warn, Instrument};
 
 use super::PipelineStage;
 use crate::{
@@ -172,8 +174,31 @@ impl RequestExecutionStage {
             )
         })?;
 
+        let send_start = Instant::now();
         let result = client.generate(proto_request).await;
+        let backend_duration_ms = send_start.elapsed().as_millis() as u64;
         workers.record_outcome(result.cb_status_code());
+
+        let worker_url = workers.single().map(|w| w.url()).unwrap_or("unknown");
+        match &result {
+            Ok(_) => {
+                info!(
+                    target: "smg::upstream",
+                    worker_url,
+                    duration_ms = backend_duration_ms,
+                    "Backend request completed"
+                );
+            }
+            Err(e) => {
+                warn!(
+                    target: "smg::upstream",
+                    worker_url,
+                    duration_ms = backend_duration_ms,
+                    error = %e.message(),
+                    "Backend request failed"
+                );
+            }
+        }
 
         let stream = result.map_err(|e| {
             error!(function = "execute_single", error = %e, "Failed to start generation");

--- a/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
+++ b/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use axum::response::Response;
-use tracing::{error, warn};
+use tracing::{error, info, warn};
 
 use super::PipelineStage;
 use crate::{
@@ -182,6 +182,14 @@ impl WorkerSelectionStage {
             policy.name(),
         );
 
+        info!(
+            target: "smg::routing",
+            model_id = model_id,
+            policy = policy.name(),
+            selected_worker = selected.url(),
+            "Worker selected"
+        );
+
         Some(selected)
     }
 
@@ -300,6 +308,15 @@ impl WorkerSelectionStage {
             metrics_labels::CONNECTION_GRPC,
             model,
             policy_name,
+        );
+
+        info!(
+            target: "smg::routing",
+            model_id = model,
+            policy = policy_name,
+            prefill_worker = available_prefill[prefill_idx].url(),
+            decode_worker = available_decode[decode_idx].url(),
+            "PD pair selected"
         );
 
         Some((

--- a/model_gateway/src/routers/grpc/harmony/builder.rs
+++ b/model_gateway/src/routers/grpc/harmony/builder.rs
@@ -876,6 +876,7 @@ impl HarmonyBuilder {
                 ChatMessage::Tool {
                     content,
                     tool_call_id,
+                    ..
                 } => {
                     // Look up the function name from the tool_call_id
                     let function_name = tool_call_map

--- a/model_gateway/src/routers/grpc/harmony/stages/request_building.rs
+++ b/model_gateway/src/routers/grpc/harmony/stages/request_building.rs
@@ -175,6 +175,10 @@ impl PipelineStage for HarmonyRequestBuildingStage {
                 ProtoGenerateRequest::Vllm(Box::new(req))
             }
             GrpcClient::Trtllm(trtllm_client) => {
+                let eos_ids = ctx
+                    .tokenizer_arc()
+                    .map(|t| t.eos_token_ids().to_vec())
+                    .unwrap_or_default();
                 let req = match &ctx.input.request_type {
                     RequestType::Chat(request) => {
                         let body = prep.filtered_request.as_ref().unwrap_or_else(|| request.as_ref());
@@ -186,6 +190,7 @@ impl PipelineStage for HarmonyRequestBuildingStage {
                                 prep.token_ids.clone(),
                                 None, // No multimodal in Harmony pipeline
                                 prep.tool_constraints.clone(),
+                                &eos_ids,
                             )
                             .map_err(|e| {
                                 error!(function = "HarmonyRequestBuildingStage::execute", error = %e, "Failed to build TensorRT-LLM generate request");

--- a/model_gateway/src/routers/grpc/multimodal.rs
+++ b/model_gateway/src/routers/grpc/multimodal.rs
@@ -191,6 +191,7 @@ pub(crate) fn has_multimodal_content(messages: &[ChatMessage]) -> bool {
             ChatMessage::User { content, .. } => Some(content),
             ChatMessage::System { content, .. } => Some(content),
             ChatMessage::Developer { content, .. } => Some(content),
+            ChatMessage::Tool { content, .. } => Some(content),
             _ => None,
         };
         content.is_some_and(|c| match c {
@@ -212,6 +213,7 @@ fn extract_content_parts(messages: &[ChatMessage]) -> Vec<MediaContentPart> {
             ChatMessage::User { content, .. } => Some(content),
             ChatMessage::System { content, .. } => Some(content),
             ChatMessage::Developer { content, .. } => Some(content),
+            ChatMessage::Tool { content, .. } => Some(content),
             _ => None,
         };
 

--- a/model_gateway/src/routers/grpc/pd_router.rs
+++ b/model_gateway/src/routers/grpc/pd_router.rs
@@ -80,6 +80,7 @@ impl GrpcPDRouter {
             reasoning_parser_factory.clone(),
             ctx.configured_tool_parser.clone(),
             ctx.configured_reasoning_parser.clone(),
+            ctx.last_token_time.clone(),
         );
 
         // Create Messages PD pipeline
@@ -90,11 +91,15 @@ impl GrpcPDRouter {
             reasoning_parser_factory.clone(),
             ctx.configured_tool_parser.clone(),
             ctx.configured_reasoning_parser.clone(),
+            ctx.last_token_time.clone(),
         );
 
         // Create Completion PD pipeline
-        let completion_pipeline =
-            RequestPipeline::new_completion_pd(worker_registry.clone(), policy_registry.clone());
+        let completion_pipeline = RequestPipeline::new_completion_pd(
+            worker_registry.clone(),
+            policy_registry.clone(),
+            ctx.last_token_time.clone(),
+        );
 
         Ok(GrpcPDRouter {
             worker_registry,

--- a/model_gateway/src/routers/grpc/pd_router.rs
+++ b/model_gateway/src/routers/grpc/pd_router.rs
@@ -1,7 +1,11 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use axum::{http::HeaderMap, response::Response};
+use axum::{
+    body::Body,
+    http::{HeaderMap, Request, StatusCode},
+    response::{IntoResponse, Response},
+};
 use openai_protocol::{
     chat::ChatCompletionRequest, completion::CompletionRequest, generate::GenerateRequest,
     messages::CreateMessageRequest,
@@ -379,6 +383,36 @@ impl std::fmt::Debug for GrpcPDRouter {
 impl RouterTrait for GrpcPDRouter {
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+
+    async fn health_generate(&self, _req: Request<Body>) -> Response {
+        let workers = self.worker_registry.get_all();
+        if workers.is_empty() {
+            return (StatusCode::SERVICE_UNAVAILABLE, "No workers registered").into_response();
+        }
+        let (healthy, unhealthy): (Vec<_>, Vec<_>) = workers.iter().partition(|w| w.is_healthy());
+        if unhealthy.is_empty() {
+            (
+                StatusCode::OK,
+                format!("OK - {} workers healthy", healthy.len()),
+            )
+                .into_response()
+        } else {
+            let info: Vec<_> = unhealthy
+                .iter()
+                .map(|w| format!("{} ({})", w.model_id(), w.url()))
+                .collect();
+            (
+                StatusCode::SERVICE_UNAVAILABLE,
+                format!(
+                    "{}/{} workers unhealthy: {}",
+                    unhealthy.len(),
+                    workers.len(),
+                    info.join(", ")
+                ),
+            )
+                .into_response()
+        }
     }
 
     async fn route_generate(

--- a/model_gateway/src/routers/grpc/pipeline.rs
+++ b/model_gateway/src/routers/grpc/pipeline.rs
@@ -3,7 +3,7 @@
 //! This module defines the RequestPipeline orchestrator that coordinates
 //! the execution of pipeline stages from request preparation to response delivery.
 
-use std::{sync::Arc, time::Instant};
+use std::{sync::{atomic::AtomicU64, Arc}, time::Instant};
 
 use axum::response::{IntoResponse, Response};
 use openai_protocol::{
@@ -109,6 +109,7 @@ impl RequestPipeline {
     }
 
     /// Create a regular (single-worker) pipeline
+    #[expect(clippy::too_many_arguments, reason = "all params are distinct required dependencies")]
     pub fn new_regular(
         worker_registry: Arc<WorkerRegistry>,
         policy_registry: Arc<PolicyRegistry>,
@@ -116,6 +117,7 @@ impl RequestPipeline {
         reasoning_parser_factory: ReasoningParserFactory,
         configured_tool_parser: Option<String>,
         configured_reasoning_parser: Option<String>,
+        last_token_time: Arc<AtomicU64>,
     ) -> Self {
         let processor = processor::ResponseProcessor::new(
             tool_parser_factory.clone(),
@@ -130,6 +132,7 @@ impl RequestPipeline {
             configured_tool_parser,
             configured_reasoning_parser,
             metrics_labels::BACKEND_REGULAR,
+            last_token_time,
         ));
 
         let stages: Vec<Box<dyn PipelineStage>> = vec![
@@ -215,6 +218,7 @@ impl RequestPipeline {
     }
 
     /// Create a PD (prefill-decode) pipeline
+    #[expect(clippy::too_many_arguments, reason = "all params are distinct required dependencies")]
     pub fn new_pd(
         worker_registry: Arc<WorkerRegistry>,
         policy_registry: Arc<PolicyRegistry>,
@@ -222,6 +226,7 @@ impl RequestPipeline {
         reasoning_parser_factory: ReasoningParserFactory,
         configured_tool_parser: Option<String>,
         configured_reasoning_parser: Option<String>,
+        last_token_time: Arc<AtomicU64>,
     ) -> Self {
         let processor = processor::ResponseProcessor::new(
             tool_parser_factory.clone(),
@@ -236,6 +241,7 @@ impl RequestPipeline {
             configured_tool_parser,
             configured_reasoning_parser,
             metrics_labels::BACKEND_PD,
+            last_token_time,
         ));
 
         let stages: Vec<Box<dyn PipelineStage>> = vec![
@@ -319,6 +325,7 @@ impl RequestPipeline {
     /// Uses Messages-specific stages for preparation, request building, and response
     /// processing. Shares worker selection, client acquisition, dispatch metadata,
     /// and request execution stages with other pipelines.
+    #[expect(clippy::too_many_arguments, reason = "all params are distinct required dependencies")]
     pub fn new_messages(
         worker_registry: Arc<WorkerRegistry>,
         policy_registry: Arc<PolicyRegistry>,
@@ -326,6 +333,7 @@ impl RequestPipeline {
         reasoning_parser_factory: ReasoningParserFactory,
         configured_tool_parser: Option<String>,
         configured_reasoning_parser: Option<String>,
+        last_token_time: Arc<AtomicU64>,
     ) -> Self {
         let processor = processor::ResponseProcessor::new(
             tool_parser_factory.clone(),
@@ -340,6 +348,7 @@ impl RequestPipeline {
             configured_tool_parser,
             configured_reasoning_parser,
             metrics_labels::BACKEND_REGULAR,
+            last_token_time,
         ));
 
         let stages: Vec<Box<dyn PipelineStage>> = vec![
@@ -366,6 +375,7 @@ impl RequestPipeline {
     }
 
     /// Create a Messages API PD (prefill-decode) pipeline
+    #[expect(clippy::too_many_arguments, reason = "all params are distinct required dependencies")]
     pub fn new_messages_pd(
         worker_registry: Arc<WorkerRegistry>,
         policy_registry: Arc<PolicyRegistry>,
@@ -373,6 +383,7 @@ impl RequestPipeline {
         reasoning_parser_factory: ReasoningParserFactory,
         configured_tool_parser: Option<String>,
         configured_reasoning_parser: Option<String>,
+        last_token_time: Arc<AtomicU64>,
     ) -> Self {
         let processor = processor::ResponseProcessor::new(
             tool_parser_factory.clone(),
@@ -387,6 +398,7 @@ impl RequestPipeline {
             configured_tool_parser,
             configured_reasoning_parser,
             metrics_labels::BACKEND_PD,
+            last_token_time,
         ));
 
         let stages: Vec<Box<dyn PipelineStage>> = vec![
@@ -420,6 +432,7 @@ impl RequestPipeline {
     pub fn new_completion(
         worker_registry: Arc<WorkerRegistry>,
         policy_registry: Arc<PolicyRegistry>,
+        last_token_time: Arc<AtomicU64>,
     ) -> Self {
         let processor = processor::ResponseProcessor::new(
             ToolParserFactory::default(),
@@ -434,6 +447,7 @@ impl RequestPipeline {
             None,
             None,
             metrics_labels::BACKEND_REGULAR,
+            last_token_time,
         ));
 
         let stages: Vec<Box<dyn PipelineStage>> = vec![
@@ -463,6 +477,7 @@ impl RequestPipeline {
     pub fn new_completion_pd(
         worker_registry: Arc<WorkerRegistry>,
         policy_registry: Arc<PolicyRegistry>,
+        last_token_time: Arc<AtomicU64>,
     ) -> Self {
         let processor = processor::ResponseProcessor::new(
             ToolParserFactory::default(),
@@ -477,6 +492,7 @@ impl RequestPipeline {
             None,
             None,
             metrics_labels::BACKEND_PD,
+            last_token_time,
         ));
 
         let stages: Vec<Box<dyn PipelineStage>> = vec![

--- a/model_gateway/src/routers/grpc/regular/processor.rs
+++ b/model_gateway/src/routers/grpc/regular/processor.rs
@@ -254,13 +254,29 @@ impl ResponseProcessor {
                 let mut escape = false;
                 let mut json_end = None;
                 for (i, ch) in processed_text.char_indices() {
-                    if escape { escape = false; continue; }
-                    if ch == '\\' && in_string { escape = true; continue; }
-                    if ch == '"' { in_string = !in_string; continue; }
-                    if in_string { continue; }
-                    if ch == '{' { depth += 1; } else if ch == '}' {
+                    if escape {
+                        escape = false;
+                        continue;
+                    }
+                    if ch == '\\' && in_string {
+                        escape = true;
+                        continue;
+                    }
+                    if ch == '"' {
+                        in_string = !in_string;
+                        continue;
+                    }
+                    if in_string {
+                        continue;
+                    }
+                    if ch == '{' {
+                        depth += 1;
+                    } else if ch == '}' {
                         depth -= 1;
-                        if depth == 0 { json_end = Some(i + 1); break; }
+                        if depth == 0 {
+                            json_end = Some(i + 1);
+                            break;
+                        }
                     }
                 }
                 if let Some(end) = json_end {

--- a/model_gateway/src/routers/grpc/regular/processor.rs
+++ b/model_gateway/src/routers/grpc/regular/processor.rs
@@ -148,7 +148,16 @@ impl ResponseProcessor {
                 _ => false,
             };
 
-            if used_json_schema {
+            if self.configured_tool_parser.is_some() && tool_parser_available {
+                // Explicitly configured parser takes priority (models may emit native tokens regardless of tool_choice)
+                (tool_calls, processed_text) = self
+                    .parse_tool_calls(
+                        &processed_text,
+                        &original_request.model,
+                        history_tool_calls_count,
+                    )
+                    .await;
+            } else if used_json_schema {
                 (tool_calls, processed_text) = utils::parse_json_schema_response(
                     &processed_text,
                     original_request.tool_choice.as_ref(),
@@ -183,7 +192,58 @@ impl ResponseProcessor {
             utils::convert_proto_to_openai_logprobs(proto_logprobs, tokenizer)
         });
 
-        // Step 5: Build ChatCompletionMessage (proper response message type)
+        // Strip leaked chatml tokens only when a model-specific parser is configured
+        if self.configured_tool_parser.is_some() || self.configured_reasoning_parser.is_some() {
+            for token in [
+                "<|im_end|>",
+                "<|im_start|>",
+                "<|im_user|>",
+                "<|im_assistant|>",
+                "<|im_system|>",
+                "<|im_middle|>",
+            ] {
+                processed_text = processed_text.replace(token, "");
+            }
+            processed_text = processed_text.trim().to_string();
+        }
+
+        let is_json_response = matches!(
+            &original_request.response_format,
+            Some(openai_protocol::common::ResponseFormat::JsonObject)
+                | Some(openai_protocol::common::ResponseFormat::JsonSchema { .. })
+        );
+        if is_json_response {
+            if processed_text.starts_with("```json") || processed_text.starts_with("```JSON") {
+                if let Some(start) = processed_text.find('\n') {
+                    let inner = &processed_text[start + 1..];
+                    if let Some(end) = inner.rfind("```") {
+                        processed_text = inner[..end].trim().to_string();
+                    }
+                }
+            }
+
+            if processed_text.starts_with('{') {
+                let mut depth = 0i32;
+                let mut in_string = false;
+                let mut escape = false;
+                let mut json_end = None;
+                for (i, ch) in processed_text.char_indices() {
+                    if escape { escape = false; continue; }
+                    if ch == '\\' && in_string { escape = true; continue; }
+                    if ch == '"' { in_string = !in_string; continue; }
+                    if in_string { continue; }
+                    if ch == '{' { depth += 1; } else if ch == '}' {
+                        depth -= 1;
+                        if depth == 0 { json_end = Some(i + 1); break; }
+                    }
+                }
+                if let Some(end) = json_end {
+                    processed_text = processed_text[..end].to_string();
+                }
+            }
+        }
+
+        // Build ChatCompletionMessage (proper response message type)
         let chat_message = ChatCompletionMessage {
             role: "assistant".to_string(),
             content: if processed_text.is_empty() {
@@ -621,7 +681,17 @@ impl ResponseProcessor {
                 Some(messages::ToolChoice::Tool { .. } | messages::ToolChoice::Any { .. })
             );
 
-            if used_json_schema {
+            if self.configured_tool_parser.is_some() && tool_parser_available {
+                (tool_calls, processed_text) = self
+                    .parse_tool_calls(
+                        &processed_text,
+                        &messages_request.model,
+                        utils::message_utils::get_history_tool_calls_count_messages(
+                            &messages_request,
+                        ),
+                    )
+                    .await;
+            } else if used_json_schema {
                 // Bridge Messages ToolChoice to Chat ToolChoice for reuse
                 let chat_tool_choice = messages_request
                     .tool_choice
@@ -647,7 +717,22 @@ impl ResponseProcessor {
             }
         }
 
-        // Step 3: Build content blocks
+        // Strip leaked chatml tokens only when a model-specific parser is configured
+        if self.configured_tool_parser.is_some() || self.configured_reasoning_parser.is_some() {
+            for token in [
+                "<|im_end|>",
+                "<|im_start|>",
+                "<|im_user|>",
+                "<|im_assistant|>",
+                "<|im_system|>",
+                "<|im_middle|>",
+            ] {
+                processed_text = processed_text.replace(token, "");
+            }
+            processed_text = processed_text.trim().to_string();
+        }
+
+        // Build content blocks
         let mut content_blocks: Vec<messages::ContentBlock> = Vec::new();
 
         // Thinking block first (if present)

--- a/model_gateway/src/routers/grpc/regular/processor.rs
+++ b/model_gateway/src/routers/grpc/regular/processor.rs
@@ -97,18 +97,22 @@ impl ResponseProcessor {
         let mut processed_text = final_text;
 
         // Skip reasoning parsing when the output is constrained (specific
-        // tool_choice or structured response_format).  Constrained decoding
-        // forces the model to emit pure JSON without <think>...</think>
-        // wrappers, so the reasoning parser would incorrectly swallow the
-        // entire output as reasoning content.
-        let output_is_constrained = matches!(
-            &original_request.tool_choice,
-            Some(ToolChoice::Function { .. })
-        ) || matches!(
-            &original_request.response_format,
-            Some(openai_protocol::common::ResponseFormat::JsonObject)
-                | Some(openai_protocol::common::ResponseFormat::JsonSchema { .. })
-        );
+        // tool_choice or structured response_format) AND reasoning is not
+        // expected.  When separate_reasoning is true the chat template
+        // injects <think> in the prompt, so the model WILL emit thinking
+        // content regardless of backend constraints (TRT-LLM does not have
+        // TGL's ReasonerGrammarObject that defers the constraint).  The
+        // reasoning parser must run to strip it before JSON/tool
+        // post-processing.
+        let output_is_constrained = !original_request.separate_reasoning
+            && (matches!(
+                &original_request.tool_choice,
+                Some(ToolChoice::Function { .. })
+            ) || matches!(
+                &original_request.response_format,
+                Some(openai_protocol::common::ResponseFormat::JsonObject)
+                    | Some(openai_protocol::common::ResponseFormat::JsonSchema { .. })
+            ));
 
         if original_request.separate_reasoning
             && reasoning_parser_available

--- a/model_gateway/src/routers/grpc/regular/processor.rs
+++ b/model_gateway/src/routers/grpc/regular/processor.rs
@@ -96,7 +96,24 @@ impl ResponseProcessor {
         let mut reasoning_text: Option<String> = None;
         let mut processed_text = final_text;
 
-        if original_request.separate_reasoning && reasoning_parser_available {
+        // Skip reasoning parsing when the output is constrained (specific
+        // tool_choice or structured response_format).  Constrained decoding
+        // forces the model to emit pure JSON without <think>...</think>
+        // wrappers, so the reasoning parser would incorrectly swallow the
+        // entire output as reasoning content.
+        let output_is_constrained = matches!(
+            &original_request.tool_choice,
+            Some(ToolChoice::Function { .. })
+        ) || matches!(
+            &original_request.response_format,
+            Some(openai_protocol::common::ResponseFormat::JsonObject)
+                | Some(openai_protocol::common::ResponseFormat::JsonSchema { .. })
+        );
+
+        if original_request.separate_reasoning
+            && reasoning_parser_available
+            && !output_is_constrained
+        {
             let pooled_parser = utils::get_reasoning_parser(
                 &self.reasoning_parser_factory,
                 self.configured_reasoning_parser.as_deref(),
@@ -148,8 +165,11 @@ impl ResponseProcessor {
                 _ => false,
             };
 
-            if self.configured_tool_parser.is_some() && tool_parser_available {
-                // Explicitly configured parser takes priority (models may emit native tokens regardless of tool_choice)
+            if self.configured_tool_parser.is_some()
+                && tool_parser_available
+                && !output_is_constrained
+            {
+                // Configured parser for native tool call tokens (auto/required modes)
                 (tool_calls, processed_text) = self
                     .parse_tool_calls(
                         &processed_text,
@@ -157,14 +177,20 @@ impl ResponseProcessor {
                         history_tool_calls_count,
                     )
                     .await;
-            } else if used_json_schema {
+            }
+
+            if tool_calls.is_none() && used_json_schema {
+                // Constrained decoding output: pure JSON wrapped as a tool call
                 (tool_calls, processed_text) = utils::parse_json_schema_response(
                     &processed_text,
                     original_request.tool_choice.as_ref(),
                     &original_request.model,
                     history_tool_calls_count,
                 );
-            } else if tool_parser_available {
+            }
+
+            if tool_calls.is_none() && tool_parser_available {
+                // Fallback: auto-detected parser
                 (tool_calls, processed_text) = self
                     .parse_tool_calls(
                         &processed_text,

--- a/model_gateway/src/routers/grpc/regular/responses/conversions.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/conversions.rs
@@ -113,6 +113,7 @@ pub(crate) fn responses_to_chat(req: &ResponsesRequest) -> Result<ChatCompletion
                             messages.push(ChatMessage::Tool {
                                 content: MessageContent::Text(output_text.clone()),
                                 tool_call_id: id.clone(),
+                                name: None,
                             });
                         }
                     }
@@ -142,6 +143,7 @@ pub(crate) fn responses_to_chat(req: &ResponsesRequest) -> Result<ChatCompletion
                         messages.push(ChatMessage::Tool {
                             content: MessageContent::Text(output.clone()),
                             tool_call_id: call_id.clone(),
+                            name: None,
                         });
                     }
                     ResponseInputOutputItem::McpApprovalResponse { .. }

--- a/model_gateway/src/routers/grpc/regular/stages/chat/preparation.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/chat/preparation.rs
@@ -5,7 +5,7 @@ use std::borrow::Cow;
 use async_trait::async_trait;
 use axum::response::Response;
 use openai_protocol::chat::ChatCompletionRequest;
-use tracing::{debug, error, warn};
+use tracing::{debug, error};
 
 use crate::routers::{
     error,
@@ -101,11 +101,14 @@ impl ChatPreparationStage {
                     Some((mm_components, model_id, tokenizer_source)),
                 )
             } else {
-                warn!(
+                error!(
                     function = "ChatPreparationStage::execute",
-                    "Multimodal content detected but multimodal components not initialized; image content will be stripped"
+                    "Multimodal content detected but multimodal components not initialized"
                 );
-                (None, None)
+                return Err(error::bad_request(
+                    "multimodal_not_supported",
+                    "Multimodal content detected but multimodal processing is not available",
+                ));
             }
         } else {
             (None, None)
@@ -148,7 +151,7 @@ impl ChatPreparationStage {
                 &request.messages,
                 model_id,
                 &*tokenizer,
-                token_ids.clone(),
+                token_ids,
                 mm_components,
                 &tokenizer_source,
             )
@@ -164,11 +167,15 @@ impl ChatPreparationStage {
                     multimodal_intermediate = Some(output.intermediate);
                 }
                 Err(e) => {
-                    warn!(
+                    error!(
                         function = "ChatPreparationStage::execute",
                         error = %e,
-                        "Multimodal processing failed; proceeding with text-only content"
+                        "Multimodal processing failed"
                     );
+                    return Err(error::bad_request(
+                        "multimodal_processing_failed",
+                        format!("Multimodal processing failed: {e}"),
+                    ));
                 }
             }
         }

--- a/model_gateway/src/routers/grpc/regular/stages/chat/preparation.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/chat/preparation.rs
@@ -5,7 +5,7 @@ use std::borrow::Cow;
 use async_trait::async_trait;
 use axum::response::Response;
 use openai_protocol::chat::ChatCompletionRequest;
-use tracing::{debug, error};
+use tracing::{debug, error, warn};
 
 use crate::routers::{
     error,
@@ -101,14 +101,11 @@ impl ChatPreparationStage {
                     Some((mm_components, model_id, tokenizer_source)),
                 )
             } else {
-                error!(
+                warn!(
                     function = "ChatPreparationStage::execute",
-                    "Multimodal content detected but multimodal components not initialized"
+                    "Multimodal content detected but multimodal components not initialized; image content will be stripped"
                 );
-                return Err(error::bad_request(
-                    "multimodal_not_supported",
-                    "Multimodal content detected but multimodal processing is not available",
-                ));
+                (None, None)
             }
         } else {
             (None, None)
@@ -151,7 +148,7 @@ impl ChatPreparationStage {
                 &request.messages,
                 model_id,
                 &*tokenizer,
-                token_ids,
+                token_ids.clone(),
                 mm_components,
                 &tokenizer_source,
             )
@@ -167,15 +164,11 @@ impl ChatPreparationStage {
                     multimodal_intermediate = Some(output.intermediate);
                 }
                 Err(e) => {
-                    error!(
+                    warn!(
                         function = "ChatPreparationStage::execute",
                         error = %e,
-                        "Multimodal processing failed"
+                        "Multimodal processing failed; proceeding with text-only content"
                     );
-                    return Err(error::bad_request(
-                        "multimodal_processing_failed",
-                        format!("Multimodal processing failed: {e}"),
-                    ));
                 }
             }
         }

--- a/model_gateway/src/routers/grpc/regular/stages/chat/preparation.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/chat/preparation.rs
@@ -127,8 +127,11 @@ impl ChatPreparationStage {
             }
         };
 
-        // Step 3: Tokenize the processed text (no special tokens - chat template already handles them)
-        let encoding = match tokenizer.encode(&processed_messages.text, false) {
+        // Step 3: Tokenize the processed text.
+        // Use add_special_tokens=true so the tokenizer recognizes special tokens
+        // (e.g. <|im_system|>, <|im_end|>, <think>) embedded in the chat template
+        // output as single token IDs rather than splitting them into characters.
+        let encoding = match tokenizer.encode(&processed_messages.text, true) {
             Ok(encoding) => encoding,
             Err(e) => {
                 error!(function = "ChatPreparationStage::execute", error = %e, "Tokenization failed");

--- a/model_gateway/src/routers/grpc/regular/stages/chat/request_building.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/chat/request_building.rs
@@ -80,6 +80,11 @@ impl PipelineStage for ChatRequestBuildingStage {
             .multimodal_intermediate
             .map(|intermediate| assemble_multimodal_data(intermediate, builder_client));
 
+        let eos_token_ids = ctx
+            .tokenizer_arc()
+            .map(|t| t.eos_token_ids().to_vec())
+            .unwrap_or_default();
+
         let mut proto_request = builder_client
             .build_chat_request(
                 request_id,
@@ -88,6 +93,7 @@ impl PipelineStage for ChatRequestBuildingStage {
                 prep.token_ids,
                 multimodal_data,
                 prep.tool_constraints,
+                &eos_token_ids,
             )
             .map_err(|e| {
                 error!(function = "ChatRequestBuildingStage::execute", error = %e, "Failed to build generate request");

--- a/model_gateway/src/routers/grpc/regular/stages/messages/preparation.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/messages/preparation.rs
@@ -3,7 +3,7 @@
 use async_trait::async_trait;
 use axum::response::Response;
 use openai_protocol::{common::StringOrArray, messages::CreateMessageRequest};
-use tracing::{debug, error, warn};
+use tracing::{debug, error};
 
 use crate::routers::{
     error,
@@ -121,11 +121,14 @@ impl MessagePreparationStage {
                     Some((mm_components, model_id, tokenizer_source)),
                 )
             } else {
-                warn!(
+                error!(
                     function = "MessagePreparationStage::execute",
-                    "Multimodal content detected but multimodal components not initialized; image content will be stripped"
+                    "Multimodal content detected but multimodal components not initialized"
                 );
-                (None, None)
+                return Err(error::bad_request(
+                    "multimodal_not_supported",
+                    "Multimodal content detected but multimodal processing is not available",
+                ));
             }
         } else {
             (None, None)
@@ -166,7 +169,7 @@ impl MessagePreparationStage {
                 &request.messages,
                 model_id,
                 &*tokenizer,
-                token_ids.clone(),
+                token_ids,
                 mm_components,
                 &tokenizer_source,
             )
@@ -182,11 +185,15 @@ impl MessagePreparationStage {
                     multimodal_intermediate = Some(output.intermediate);
                 }
                 Err(e) => {
-                    warn!(
+                    error!(
                         function = "MessagePreparationStage::execute",
                         error = %e,
-                        "Multimodal processing failed; proceeding with text-only content"
+                        "Multimodal processing failed"
                     );
+                    return Err(error::bad_request(
+                        "multimodal_processing_failed",
+                        format!("Multimodal processing failed: {e}"),
+                    ));
                 }
             }
         }

--- a/model_gateway/src/routers/grpc/regular/stages/messages/preparation.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/messages/preparation.rs
@@ -148,8 +148,8 @@ impl MessagePreparationStage {
             }
         };
 
-        // Step 3: Tokenize the processed text
-        let encoding = match tokenizer.encode(&processed_messages.text, false) {
+        // Step 3: Tokenize the processed text (with special token recognition)
+        let encoding = match tokenizer.encode(&processed_messages.text, true) {
             Ok(encoding) => encoding,
             Err(e) => {
                 error!(function = "MessagePreparationStage::execute", error = %e, "Tokenization failed");

--- a/model_gateway/src/routers/grpc/regular/stages/messages/preparation.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/messages/preparation.rs
@@ -3,7 +3,7 @@
 use async_trait::async_trait;
 use axum::response::Response;
 use openai_protocol::{common::StringOrArray, messages::CreateMessageRequest};
-use tracing::{debug, error};
+use tracing::{debug, error, warn};
 
 use crate::routers::{
     error,
@@ -121,14 +121,11 @@ impl MessagePreparationStage {
                     Some((mm_components, model_id, tokenizer_source)),
                 )
             } else {
-                error!(
+                warn!(
                     function = "MessagePreparationStage::execute",
-                    "Multimodal content detected but multimodal components not initialized"
+                    "Multimodal content detected but multimodal components not initialized; image content will be stripped"
                 );
-                return Err(error::bad_request(
-                    "multimodal_not_supported",
-                    "Multimodal content detected but multimodal processing is not available",
-                ));
+                (None, None)
             }
         } else {
             (None, None)
@@ -169,7 +166,7 @@ impl MessagePreparationStage {
                 &request.messages,
                 model_id,
                 &*tokenizer,
-                token_ids,
+                token_ids.clone(),
                 mm_components,
                 &tokenizer_source,
             )
@@ -185,15 +182,11 @@ impl MessagePreparationStage {
                     multimodal_intermediate = Some(output.intermediate);
                 }
                 Err(e) => {
-                    error!(
+                    warn!(
                         function = "MessagePreparationStage::execute",
                         error = %e,
-                        "Multimodal processing failed"
+                        "Multimodal processing failed; proceeding with text-only content"
                     );
-                    return Err(error::bad_request(
-                        "multimodal_processing_failed",
-                        format!("Multimodal processing failed: {e}"),
-                    ));
                 }
             }
         }

--- a/model_gateway/src/routers/grpc/regular/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/streaming.rs
@@ -5,7 +5,10 @@
 use std::{
     collections::{HashMap, HashSet},
     io,
-    sync::Arc,
+    sync::{
+        atomic::AtomicU64,
+        Arc,
+    },
     time::Instant,
 };
 
@@ -36,7 +39,10 @@ use tracing::{debug, error, warn};
 use crate::{
     observability::metrics::{metrics_labels, Metrics, StreamingMetricsParams},
     routers::grpc::{
-        common::{response_formatting::CompletionTokenTracker, responses::build_sse_response},
+        common::{
+            response_formatting::CompletionTokenTracker,
+            responses::build_tracked_sse_response,
+        },
         context,
         proto_wrapper::{ProtoResponseVariant, ProtoStream},
         utils,
@@ -52,6 +58,7 @@ pub(crate) struct StreamingProcessor {
     configured_tool_parser: Option<String>,
     configured_reasoning_parser: Option<String>,
     backend_type: &'static str,
+    last_token_time: Arc<AtomicU64>,
 }
 
 /// Context for generate endpoint streaming - groups config params to reduce function arguments
@@ -70,6 +77,7 @@ impl StreamingProcessor {
         configured_tool_parser: Option<String>,
         configured_reasoning_parser: Option<String>,
         backend_type: &'static str,
+        last_token_time: Arc<AtomicU64>,
     ) -> Self {
         Self {
             tool_parser_factory,
@@ -77,6 +85,7 @@ impl StreamingProcessor {
             configured_tool_parser,
             configured_reasoning_parser,
             backend_type,
+            last_token_time,
         }
     }
 
@@ -176,7 +185,7 @@ impl StreamingProcessor {
         }
 
         // Return SSE response
-        build_sse_response(rx)
+        build_tracked_sse_response(rx, &self.last_token_time)
     }
 
     /// Process streaming chunks from a single stream (Regular mode)
@@ -771,7 +780,7 @@ impl StreamingProcessor {
         }
 
         // Return SSE response
-        build_sse_response(rx)
+        build_tracked_sse_response(rx, &self.last_token_time)
     }
 
     /// Process streaming chunks for generate endpoint (no tool/reasoning parsing)
@@ -1615,7 +1624,7 @@ impl StreamingProcessor {
             }
         }
 
-        build_sse_response(rx)
+        build_tracked_sse_response(rx, &self.last_token_time)
     }
 
     /// Process Messages API streaming chunks from a single stream.
@@ -2351,7 +2360,7 @@ impl StreamingProcessor {
             }
         }
 
-        build_sse_response(rx)
+        build_tracked_sse_response(rx, &self.last_token_time)
     }
 
     /// Process completion streaming chunks from a single stream.

--- a/model_gateway/src/routers/grpc/regular/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/streaming.rs
@@ -260,15 +260,17 @@ impl StreamingProcessor {
         // Check if this is the specific function case (LLM generates parameters only, no name field)
         let is_specific_function = matches!(tool_choice, Some(ToolChoice::Function { .. }));
 
-        // Skip reasoning parsing when constrained decoding is active.
-        // The model emits pure JSON without <think> wrappers, so the
-        // reasoning parser would swallow the output as reasoning content.
-        let output_is_constrained = is_specific_function
-            || matches!(
-                &original_request.response_format,
-                Some(openai_protocol::common::ResponseFormat::JsonObject)
-                    | Some(openai_protocol::common::ResponseFormat::JsonSchema { .. })
-            );
+        // Skip reasoning parsing when constrained decoding is active AND
+        // reasoning is not expected.  When separate_reasoning is true the
+        // chat template injects <think>, so the model emits thinking
+        // content even with constraints.  The reasoning parser must run.
+        let output_is_constrained = !separate_reasoning
+            && (is_specific_function
+                || matches!(
+                    &original_request.response_format,
+                    Some(openai_protocol::common::ResponseFormat::JsonObject)
+                        | Some(openai_protocol::common::ResponseFormat::JsonSchema { .. })
+                ));
 
         let tool_parser_available = tools.is_some()
             && utils::check_tool_parser_availability(
@@ -407,6 +409,14 @@ impl StreamingProcessor {
                                     history_tool_calls_count,
                                 )
                             } else {
+                                // When reasoning is active the backend may
+                                // not enforce constrained decoding, so the
+                                // model can emit native tool-call tags.
+                                // Use the native parser instead of JSON.
+                                let effective_json_parser = used_json_schema
+                                    && !(separate_reasoning
+                                        && self.configured_tool_parser.is_some()
+                                        && tool_parser_available);
                                 self.process_tool_calls_stream(
                                     &delta,
                                     index,
@@ -418,7 +428,7 @@ impl StreamingProcessor {
                                     created,
                                     system_fingerprint,
                                     history_tool_calls_count,
-                                    used_json_schema,
+                                    effective_json_parser,
                                 )
                                 .await
                             };
@@ -452,6 +462,28 @@ impl StreamingProcessor {
                             delta = delta.replace(token, "");
                         }
                     }
+
+                    // Strip markdown code fences for JSON responses so
+                    // streamed content is directly parseable.
+                    let is_json_response = matches!(
+                        &original_request.response_format,
+                        Some(openai_protocol::common::ResponseFormat::JsonObject)
+                            | Some(openai_protocol::common::ResponseFormat::JsonSchema { .. })
+                    );
+                    if is_json_response {
+                        delta = delta
+                            .replace("```json", "")
+                            .replace("```JSON", "")
+                            .replace("```", "");
+                        // Fence tokens may split across chunks (e.g.
+                        // "```" in one delta, "json\n" in the next).
+                        // Drop residual language tags left over.
+                        let trimmed = delta.trim();
+                        if trimmed == "json" || trimmed == "JSON" {
+                            delta = String::new();
+                        }
+                    }
+
                     if !delta.is_empty() {
                         let content_chunk =
                             ChatCompletionStreamResponse::builder(request_id, model)

--- a/model_gateway/src/routers/grpc/regular/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/streaming.rs
@@ -435,15 +435,19 @@ impl StreamingProcessor {
                         }
                     }
 
-                    // Strip leaked chatml/think tokens when a parser is configured
-                    let mut delta = delta;
                     if self.configured_tool_parser.is_some()
                         || self.configured_reasoning_parser.is_some()
                     {
                         for token in [
-                            "<|im_end|>", "<|im_start|>", "<|im_user|>",
-                            "<|im_assistant|>", "<|im_system|>", "<|im_middle|>",
-                            "</think>", "[EOS]", "[BOS]",
+                            "<|im_end|>",
+                            "<|im_start|>",
+                            "<|im_user|>",
+                            "<|im_assistant|>",
+                            "<|im_system|>",
+                            "<|im_middle|>",
+                            "</think>",
+                            "[EOS]",
+                            "[BOS]",
                         ] {
                             delta = delta.replace(token, "");
                         }
@@ -1220,7 +1224,9 @@ impl StreamingProcessor {
                 "<|im_assistant|>",
                 "<|im_system|>",
                 "<|im_middle|>",
-                "</think>", "[EOS]", "[BOS]",
+                "</think>",
+                "[EOS]",
+                "[BOS]",
             ] {
                 clean_delta = clean_delta.replace(token, "");
             }
@@ -1286,8 +1292,12 @@ impl StreamingProcessor {
                         || self.configured_reasoning_parser.is_some()
                     {
                         for token in [
-                            "<|im_end|>", "<|im_start|>", "<|im_user|>",
-                            "<|im_assistant|>", "<|im_system|>", "<|im_middle|>",
+                            "<|im_end|>",
+                            "<|im_start|>",
+                            "<|im_user|>",
+                            "<|im_assistant|>",
+                            "<|im_system|>",
+                            "<|im_middle|>",
                         ] {
                             normal_text = normal_text.replace(token, "");
                         }

--- a/model_gateway/src/routers/grpc/regular/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/streaming.rs
@@ -377,8 +377,10 @@ impl StreamingProcessor {
                             && tool_choice_enabled
                             && (tool_parser_available || used_json_schema)
                         {
-                            let tool_chunks = if is_specific_function {
-                                // Handle specific function case - emit tool call deltas with arguments
+                            let tool_chunks = if is_specific_function
+                                && !(self.configured_tool_parser.is_some()
+                                    && tool_parser_available)
+                            {
                                 Self::process_specific_function_stream(
                                     &delta,
                                     index,
@@ -391,7 +393,6 @@ impl StreamingProcessor {
                                     history_tool_calls_count,
                                 )
                             } else {
-                                // Use incremental parser for regular/required modes
                                 self.process_tool_calls_stream(
                                     &delta,
                                     index,
@@ -420,7 +421,19 @@ impl StreamingProcessor {
                         }
                     }
 
-                    // Regular content emission
+                    // Strip leaked chatml/think tokens when a parser is configured
+                    let mut delta = delta;
+                    if self.configured_tool_parser.is_some()
+                        || self.configured_reasoning_parser.is_some()
+                    {
+                        for token in [
+                            "<|im_end|>", "<|im_start|>", "<|im_user|>",
+                            "<|im_assistant|>", "<|im_system|>", "<|im_middle|>",
+                            "</think>",
+                        ] {
+                            delta = delta.replace(token, "");
+                        }
+                    }
                     if !delta.is_empty() {
                         let content_chunk =
                             ChatCompletionStreamResponse::builder(request_id, model)
@@ -1242,7 +1255,17 @@ impl StreamingProcessor {
 
             match parser.parse_incremental(delta, tools).await {
                 Ok(StreamingParseResult { normal_text, calls }) => {
-                    // Emit normal text if present
+                    let mut normal_text = normal_text;
+                    if self.configured_tool_parser.is_some()
+                        || self.configured_reasoning_parser.is_some()
+                    {
+                        for token in [
+                            "<|im_end|>", "<|im_start|>", "<|im_user|>",
+                            "<|im_assistant|>", "<|im_system|>", "<|im_middle|>",
+                        ] {
+                            normal_text = normal_text.replace(token, "");
+                        }
+                    }
                     if !normal_text.is_empty() {
                         chunks.push(
                             ChatCompletionStreamResponse::builder(request_id, model)
@@ -1753,7 +1776,9 @@ impl StreamingProcessor {
 
                     // Tool call handling: incremental streaming parser
                     if !in_reasoning && streaming_tool_parser.is_some() {
-                        if is_specific_function {
+                        if is_specific_function
+                            && !(self.configured_tool_parser.is_some() && tool_parser_available)
+                        {
                             // Specific function: entire output is arguments for one tool
                             if !has_tool_calls {
                                 has_tool_calls = true;

--- a/model_gateway/src/routers/grpc/regular/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/streaming.rs
@@ -443,7 +443,7 @@ impl StreamingProcessor {
                         for token in [
                             "<|im_end|>", "<|im_start|>", "<|im_user|>",
                             "<|im_assistant|>", "<|im_system|>", "<|im_middle|>",
-                            "</think>",
+                            "</think>", "[EOS]", "[BOS]",
                         ] {
                             delta = delta.replace(token, "");
                         }
@@ -1220,7 +1220,7 @@ impl StreamingProcessor {
                 "<|im_assistant|>",
                 "<|im_system|>",
                 "<|im_middle|>",
-                "</think>",
+                "</think>", "[EOS]", "[BOS]",
             ] {
                 clean_delta = clean_delta.replace(token, "");
             }

--- a/model_gateway/src/routers/grpc/regular/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/streaming.rs
@@ -260,6 +260,16 @@ impl StreamingProcessor {
         // Check if this is the specific function case (LLM generates parameters only, no name field)
         let is_specific_function = matches!(tool_choice, Some(ToolChoice::Function { .. }));
 
+        // Skip reasoning parsing when constrained decoding is active.
+        // The model emits pure JSON without <think> wrappers, so the
+        // reasoning parser would swallow the output as reasoning content.
+        let output_is_constrained = is_specific_function
+            || matches!(
+                &original_request.response_format,
+                Some(openai_protocol::common::ResponseFormat::JsonObject)
+                    | Some(openai_protocol::common::ResponseFormat::JsonSchema { .. })
+            );
+
         let tool_parser_available = tools.is_some()
             && utils::check_tool_parser_availability(
                 &self.tool_parser_factory,
@@ -343,7 +353,10 @@ impl StreamingProcessor {
                     stream_buffer.push_str(&delta);
 
                     // Reasoning content handling
-                    let in_reasoning = if separate_reasoning && reasoning_parser_available {
+                    let in_reasoning = if separate_reasoning
+                        && reasoning_parser_available
+                        && !output_is_constrained
+                    {
                         let (normal_text, reasoning_chunk, in_reasoning) = self
                             .process_reasoning_stream(
                                 &delta,
@@ -378,8 +391,9 @@ impl StreamingProcessor {
                             && (tool_parser_available || used_json_schema)
                         {
                             let tool_chunks = if is_specific_function
-                                && !(self.configured_tool_parser.is_some()
-                                    && tool_parser_available)
+                                && (output_is_constrained
+                                    || !(self.configured_tool_parser.is_some()
+                                        && tool_parser_available))
                             {
                                 Self::process_specific_function_stream(
                                     &delta,
@@ -1197,12 +1211,24 @@ impl StreamingProcessor {
                 );
             }
 
-            // Emit arguments delta
-            if !delta.is_empty() {
+            // Emit arguments delta, stripping any chatml tokens
+            let mut clean_delta = delta.to_string();
+            for token in [
+                "<|im_end|>",
+                "<|im_start|>",
+                "<|im_user|>",
+                "<|im_assistant|>",
+                "<|im_system|>",
+                "<|im_middle|>",
+                "</think>",
+            ] {
+                clean_delta = clean_delta.replace(token, "");
+            }
+            if !clean_delta.is_empty() {
                 chunks.push(
                     ChatCompletionStreamResponse::builder(request_id, model)
                         .created(created)
-                        .add_choice_tool_args(index, delta.to_string())
+                        .add_choice_tool_args(index, clean_delta)
                         .maybe_system_fingerprint(system_fingerprint)
                         .build(),
                 );

--- a/model_gateway/src/routers/grpc/router.rs
+++ b/model_gateway/src/routers/grpc/router.rs
@@ -92,6 +92,7 @@ impl GrpcRouter {
             reasoning_parser_factory.clone(),
             ctx.configured_tool_parser.clone(),
             ctx.configured_reasoning_parser.clone(),
+            ctx.last_token_time.clone(),
         );
 
         // Create Harmony pipelines
@@ -120,11 +121,15 @@ impl GrpcRouter {
             reasoning_parser_factory.clone(),
             ctx.configured_tool_parser.clone(),
             ctx.configured_reasoning_parser.clone(),
+            ctx.last_token_time.clone(),
         );
 
         // Create Completion pipeline
-        let completion_pipeline =
-            RequestPipeline::new_completion(worker_registry.clone(), _policy_registry.clone());
+        let completion_pipeline = RequestPipeline::new_completion(
+            worker_registry.clone(),
+            _policy_registry.clone(),
+            ctx.last_token_time.clone(),
+        );
 
         // Extract shared dependencies for responses contexts
         let mcp_orchestrator = ctx

--- a/model_gateway/src/routers/grpc/router.rs
+++ b/model_gateway/src/routers/grpc/router.rs
@@ -2,7 +2,8 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use axum::{
-    http::HeaderMap,
+    body::Body,
+    http::{HeaderMap, Request, StatusCode},
     response::{IntoResponse, Response},
 };
 use openai_protocol::{
@@ -505,6 +506,36 @@ impl std::fmt::Debug for GrpcRouter {
 impl RouterTrait for GrpcRouter {
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+
+    async fn health_generate(&self, _req: Request<Body>) -> Response {
+        let workers = self.worker_registry.get_all();
+        if workers.is_empty() {
+            return (StatusCode::SERVICE_UNAVAILABLE, "No workers registered").into_response();
+        }
+        let (healthy, unhealthy): (Vec<_>, Vec<_>) = workers.iter().partition(|w| w.is_healthy());
+        if unhealthy.is_empty() {
+            (
+                StatusCode::OK,
+                format!("OK - {} workers healthy", healthy.len()),
+            )
+                .into_response()
+        } else {
+            let info: Vec<_> = unhealthy
+                .iter()
+                .map(|w| format!("{} ({})", w.model_id(), w.url()))
+                .collect();
+            (
+                StatusCode::SERVICE_UNAVAILABLE,
+                format!(
+                    "{}/{} workers unhealthy: {}",
+                    unhealthy.len(),
+                    workers.len(),
+                    info.join(", ")
+                ),
+            )
+                .into_response()
+        }
     }
 
     async fn route_generate(

--- a/model_gateway/src/routers/grpc/utils/chat_utils.rs
+++ b/model_gateway/src/routers/grpc/utils/chat_utils.rs
@@ -110,9 +110,7 @@ pub(crate) fn process_tool_call_arguments(messages: &mut [Value]) -> Result<(), 
             };
 
             if serde_json::from_str::<Value>(args_str).is_err() {
-                return Err(format!(
-                    "Invalid JSON in tool call arguments: '{args_str}'"
-                ));
+                return Err(format!("Invalid JSON in tool call arguments: '{args_str}'"));
             }
         }
     }
@@ -414,10 +412,8 @@ pub fn process_chat_messages(
             if !tools.is_empty() {
                 let ts_str = tools_to_typescript(tools);
                 if !ts_str.is_empty() {
-                    combined_template_kwargs.insert(
-                        "tools_ts_str".to_string(),
-                        Value::String(ts_str),
-                    );
+                    combined_template_kwargs
+                        .insert("tools_ts_str".to_string(), Value::String(ts_str));
                 }
             }
         }
@@ -715,6 +711,206 @@ pub(crate) fn parse_finish_reason(
     }
 }
 
+// ============================================================================
+// TypeScript-style tool declaration generator
+// ============================================================================
+
+/// Convert OpenAI tools to TypeScript-style declaration string.
+///
+/// Produces the format expected by models like Kimi K2.5, whose chat templates
+/// check for a `tools_ts_str` variable and prefer it over raw JSON.
+///
+/// Example output:
+/// ```text
+/// # Tools
+///
+/// ## functions
+/// namespace functions {
+/// // Get the current weather
+/// type getCurrentWeather = (_: {
+///   // The city and state
+///   location: string,
+///   unit?: "celsius" | "fahrenheit"
+/// }) => any;
+/// }
+/// ```
+pub fn tools_to_typescript(tools: &[Tool]) -> String {
+    let mut functions = Vec::new();
+
+    for tool in tools {
+        if tool.tool_type != "function" {
+            continue;
+        }
+        functions.push(function_to_typescript(&tool.function));
+    }
+
+    if functions.is_empty() {
+        return String::new();
+    }
+
+    let mut result = String::from("# Tools\n\n## functions\nnamespace functions {\n");
+    result.push_str(&functions.join("\n"));
+    result.push_str("\n}\n");
+    result
+}
+
+fn function_to_typescript(func: &openai_protocol::common::Function) -> String {
+    let mut out = String::new();
+
+    // Description comment
+    if let Some(ref desc) = func.description {
+        for line in desc.lines() {
+            if line.is_empty() {
+                out.push('\n');
+            } else {
+                out.push_str(&format!("// {line}\n"));
+            }
+        }
+    }
+
+    // Parameters
+    let params_str =
+        if func.parameters.is_null() || func.parameters == Value::Object(Default::default()) {
+            "{}".to_string()
+        } else {
+            schema_to_typescript(&func.parameters, "", &[])
+        };
+
+    out.push_str(&format!("type {} = (_: {params_str}) => any;", func.name));
+    out
+}
+
+fn schema_to_typescript(schema: &Value, indent: &str, _required: &[&str]) -> String {
+    match schema.get("type").and_then(|t| t.as_str()) {
+        Some("object") => object_to_typescript(schema, indent),
+        Some("array") => array_to_typescript(schema, indent),
+        Some("string") => {
+            if let Some(enum_vals) = schema.get("enum").and_then(|e| e.as_array()) {
+                enum_to_typescript(enum_vals)
+            } else {
+                "string".to_string()
+            }
+        }
+        Some("integer" | "number") => "number".to_string(),
+        Some("boolean") => "boolean".to_string(),
+        Some("null") => "null".to_string(),
+        _ => {
+            // Handle enum without type
+            if let Some(enum_vals) = schema.get("enum").and_then(|e| e.as_array()) {
+                return enum_to_typescript(enum_vals);
+            }
+            // Handle anyOf
+            if let Some(any_of) = schema.get("anyOf").and_then(|a| a.as_array()) {
+                let types: Vec<String> = any_of
+                    .iter()
+                    .map(|t| schema_to_typescript(t, indent, &[]))
+                    .collect();
+                return types.join(" | ");
+            }
+            "any".to_string()
+        }
+    }
+}
+
+fn object_to_typescript(schema: &Value, indent: &str) -> String {
+    let properties = match schema.get("properties").and_then(|p| p.as_object()) {
+        Some(p) => p,
+        None => return "{}".to_string(),
+    };
+
+    let required_fields: Vec<&str> = schema
+        .get("required")
+        .and_then(|r| r.as_array())
+        .map(|arr| arr.iter().filter_map(|v| v.as_str()).collect())
+        .unwrap_or_default();
+
+    let child_indent = format!("{indent}  ");
+
+    // Sort: required first, then optional, both alphabetically
+    let mut required_params: Vec<(&String, &Value)> = Vec::new();
+    let mut optional_params: Vec<(&String, &Value)> = Vec::new();
+
+    for (name, prop) in properties {
+        if required_fields.contains(&name.as_str()) {
+            required_params.push((name, prop));
+        } else {
+            optional_params.push((name, prop));
+        }
+    }
+    required_params.sort_by_key(|(n, _)| *n);
+    optional_params.sort_by_key(|(n, _)| *n);
+
+    let mut params: Vec<(&String, &Value, bool)> = Vec::new();
+    for (n, v) in required_params {
+        params.push((n, v, false));
+    }
+    for (n, v) in optional_params {
+        params.push((n, v, true));
+    }
+
+    if params.is_empty() {
+        return "{}".to_string();
+    }
+
+    let mut parts = Vec::new();
+    for (name, prop, optional) in &params {
+        let mut part = String::new();
+
+        // Description comment
+        if let Some(desc) = prop.get("description").and_then(|d| d.as_str()) {
+            for line in desc.lines() {
+                if line.is_empty() {
+                    part.push('\n');
+                } else {
+                    part.push_str(&format!("{child_indent}// {line}\n"));
+                }
+            }
+        }
+
+        let type_str = schema_to_typescript(prop, &child_indent, &[]);
+        let opt_marker = if *optional { "?" } else { "" };
+        part.push_str(&format!("{child_indent}{name}{opt_marker}: {type_str}"));
+        parts.push(part);
+    }
+
+    format!("{{\n{}\n{indent}}}", parts.join(",\n"))
+}
+
+fn array_to_typescript(schema: &Value, indent: &str) -> String {
+    let items = schema.get("items");
+    let item_type = match items {
+        Some(item_schema) => {
+            let child_indent = format!("{indent}  ");
+            // Check if item has description
+            let item_desc = item_schema.get("description").and_then(|d| d.as_str());
+            let type_str = schema_to_typescript(item_schema, &child_indent, &[]);
+
+            if let Some(desc) = item_desc {
+                return format!(
+                    "Array<\n{child_indent}// {desc}\n{child_indent}{type_str}\n{indent}>"
+                );
+            }
+            type_str
+        }
+        None => "any".to_string(),
+    };
+    format!("Array<{item_type}>")
+}
+
+fn enum_to_typescript(values: &[Value]) -> String {
+    let parts: Vec<String> = values
+        .iter()
+        .map(|v| match v {
+            Value::String(s) => format!("\"{s}\""),
+            Value::Number(n) => n.to_string(),
+            Value::Bool(b) => b.to_string(),
+            Value::Null => "null".to_string(),
+            _ => "any".to_string(),
+        })
+        .collect();
+    parts.join(" | ")
+}
+
 #[cfg(test)]
 mod tests {
     use llm_tokenizer::chat_template::ChatTemplateContentFormat;
@@ -915,207 +1111,4 @@ mod tests {
         assert_eq!(content_array[0]["type"], "text");
         assert_eq!(content_array[1], json!({"type": "image"}));
     }
-}
-
-// ============================================================================
-// TypeScript-style tool declaration generator
-// ============================================================================
-
-/// Convert OpenAI tools to TypeScript-style declaration string.
-///
-/// Produces the format expected by models like Kimi K2.5, whose chat templates
-/// check for a `tools_ts_str` variable and prefer it over raw JSON.
-///
-/// Example output:
-/// ```text
-/// # Tools
-///
-/// ## functions
-/// namespace functions {
-/// // Get the current weather
-/// type getCurrentWeather = (_: {
-///   // The city and state
-///   location: string,
-///   unit?: "celsius" | "fahrenheit"
-/// }) => any;
-/// }
-/// ```
-pub fn tools_to_typescript(tools: &[Tool]) -> String {
-    let mut functions = Vec::new();
-
-    for tool in tools {
-        if tool.tool_type != "function" {
-            continue;
-        }
-        functions.push(function_to_typescript(&tool.function));
-    }
-
-    if functions.is_empty() {
-        return String::new();
-    }
-
-    let mut result = String::from("# Tools\n\n## functions\nnamespace functions {\n");
-    result.push_str(&functions.join("\n"));
-    result.push_str("\n}\n");
-    result
-}
-
-fn function_to_typescript(
-    func: &openai_protocol::common::Function,
-) -> String {
-    let mut out = String::new();
-
-    // Description comment
-    if let Some(ref desc) = func.description {
-        for line in desc.lines() {
-            if line.is_empty() {
-                out.push('\n');
-            } else {
-                out.push_str(&format!("// {line}\n"));
-            }
-        }
-    }
-
-    // Parameters
-    let params_str = if func.parameters.is_null() || func.parameters == Value::Object(Default::default()) {
-        "{}".to_string()
-    } else {
-        schema_to_typescript(&func.parameters, "", &[])
-    };
-
-    out.push_str(&format!("type {} = (_: {params_str}) => any;", func.name));
-    out
-}
-
-fn schema_to_typescript(schema: &Value, indent: &str, required: &[&str]) -> String {
-    match schema.get("type").and_then(|t| t.as_str()) {
-        Some("object") => object_to_typescript(schema, indent),
-        Some("array") => array_to_typescript(schema, indent),
-        Some("string") => {
-            if let Some(enum_vals) = schema.get("enum").and_then(|e| e.as_array()) {
-                enum_to_typescript(enum_vals)
-            } else {
-                "string".to_string()
-            }
-        }
-        Some("integer" | "number") => "number".to_string(),
-        Some("boolean") => "boolean".to_string(),
-        Some("null") => "null".to_string(),
-        _ => {
-            // Handle enum without type
-            if let Some(enum_vals) = schema.get("enum").and_then(|e| e.as_array()) {
-                return enum_to_typescript(enum_vals);
-            }
-            // Handle anyOf
-            if let Some(any_of) = schema.get("anyOf").and_then(|a| a.as_array()) {
-                let types: Vec<String> = any_of
-                    .iter()
-                    .map(|t| schema_to_typescript(t, indent, &[]))
-                    .collect();
-                return types.join(" | ");
-            }
-            "any".to_string()
-        }
-    }
-}
-
-fn object_to_typescript(schema: &Value, indent: &str) -> String {
-    let properties = match schema.get("properties").and_then(|p| p.as_object()) {
-        Some(p) => p,
-        None => return "{}".to_string(),
-    };
-
-    let required_fields: Vec<&str> = schema
-        .get("required")
-        .and_then(|r| r.as_array())
-        .map(|arr| arr.iter().filter_map(|v| v.as_str()).collect())
-        .unwrap_or_default();
-
-    let child_indent = format!("{indent}  ");
-
-    // Sort: required first, then optional, both alphabetically
-    let mut required_params: Vec<(&String, &Value)> = Vec::new();
-    let mut optional_params: Vec<(&String, &Value)> = Vec::new();
-
-    for (name, prop) in properties {
-        if required_fields.contains(&name.as_str()) {
-            required_params.push((name, prop));
-        } else {
-            optional_params.push((name, prop));
-        }
-    }
-    required_params.sort_by_key(|(n, _)| *n);
-    optional_params.sort_by_key(|(n, _)| *n);
-
-    let mut params: Vec<(&String, &Value, bool)> = Vec::new();
-    for (n, v) in required_params {
-        params.push((n, v, false));
-    }
-    for (n, v) in optional_params {
-        params.push((n, v, true));
-    }
-
-    if params.is_empty() {
-        return "{}".to_string();
-    }
-
-    let mut parts = Vec::new();
-    for (name, prop, optional) in &params {
-        let mut part = String::new();
-
-        // Description comment
-        if let Some(desc) = prop.get("description").and_then(|d| d.as_str()) {
-            for line in desc.lines() {
-                if line.is_empty() {
-                    part.push('\n');
-                } else {
-                    part.push_str(&format!("{child_indent}// {line}\n"));
-                }
-            }
-        }
-
-        let type_str = schema_to_typescript(prop, &child_indent, &[]);
-        let opt_marker = if *optional { "?" } else { "" };
-        part.push_str(&format!("{child_indent}{name}{opt_marker}: {type_str}"));
-        parts.push(part);
-    }
-
-    format!("{{\n{}\n{indent}}}", parts.join(",\n"))
-}
-
-fn array_to_typescript(schema: &Value, indent: &str) -> String {
-    let items = schema.get("items");
-    let item_type = match items {
-        Some(item_schema) => {
-            let child_indent = format!("{indent}  ");
-            // Check if item has description
-            let item_desc = item_schema
-                .get("description")
-                .and_then(|d| d.as_str());
-            let type_str = schema_to_typescript(item_schema, &child_indent, &[]);
-
-            if let Some(desc) = item_desc {
-                return format!(
-                    "Array<\n{child_indent}// {desc}\n{child_indent}{type_str}\n{indent}>"
-                );
-            }
-            type_str
-        }
-        None => "any".to_string(),
-    };
-    format!("Array<{item_type}>")
-}
-
-fn enum_to_typescript(values: &[Value]) -> String {
-    let parts: Vec<String> = values
-        .iter()
-        .map(|v| match v {
-            Value::String(s) => format!("\"{s}\""),
-            Value::Number(n) => n.to_string(),
-            Value::Bool(b) => b.to_string(),
-            Value::Null => "null".to_string(),
-            _ => "any".to_string(),
-        })
-        .collect();
-    parts.join(" | ")
 }

--- a/model_gateway/src/routers/grpc/utils/chat_utils.rs
+++ b/model_gateway/src/routers/grpc/utils/chat_utils.rs
@@ -544,7 +544,7 @@ pub(crate) fn parse_json_schema_response(
     model: &str,
     history_tool_calls_count: usize,
 ) -> (Option<Vec<ToolCall>>, String) {
-    // Strip chatml tokens that may trail the constrained JSON output
+    // Strip chatml / special tokens that may trail the constrained JSON output
     let mut clean = processed_text.to_string();
     for token in [
         "<|im_end|>",
@@ -554,6 +554,8 @@ pub(crate) fn parse_json_schema_response(
         "<|im_system|>",
         "<|im_middle|>",
         "</think>",
+        "[EOS]",
+        "[BOS]",
     ] {
         clean = clean.replace(token, "");
     }

--- a/model_gateway/src/routers/grpc/utils/chat_utils.rs
+++ b/model_gateway/src/routers/grpc/utils/chat_utils.rs
@@ -83,35 +83,36 @@ pub(crate) fn resolve_tokenizer(
 /// Process tool call arguments in messages
 /// Per Transformers docs, tool call arguments in assistant messages should be dicts
 pub(crate) fn process_tool_call_arguments(messages: &mut [Value]) -> Result<(), String> {
+    // Validate that arguments are valid JSON but keep them as strings.
+    // The chat template handles both string and object arguments:
+    //   {% if ... is string %}{{ args }}{% else %}{{ args | tojson }}{% endif %}
+    // Keeping strings preserves original formatting (e.g. spacing),
+    // matching the behavior of Python/TGL which passes arguments through as-is.
     for msg in messages {
         let role = msg.get("role").and_then(|v| v.as_str());
         if role != Some("assistant") {
             continue;
         }
 
-        let Some(tool_calls) = msg.get_mut("tool_calls").and_then(|tc| tc.as_array_mut()) else {
+        let Some(tool_calls) = msg.get("tool_calls").and_then(|tc| tc.as_array()) else {
             continue;
         };
 
         for call in tool_calls {
-            let Some(function) = call.get_mut("function") else {
+            let Some(function) = call.get("function") else {
                 continue;
             };
-            let Some(args) = function.get_mut("arguments") else {
+            let Some(args) = function.get("arguments") else {
                 continue;
             };
             let Some(args_str) = args.as_str() else {
                 continue;
             };
 
-            // Parse JSON string to object (like Python json.loads)
-            match serde_json::from_str::<Value>(args_str) {
-                Ok(parsed) => *args = parsed,
-                Err(e) => {
-                    return Err(format!(
-                        "Failed to parse tool call arguments as JSON: '{args_str}'. Error: {e}"
-                    ))
-                }
+            if serde_json::from_str::<Value>(args_str).is_err() {
+                return Err(format!(
+                    "Invalid JSON in tool call arguments: '{args_str}'"
+                ));
             }
         }
     }
@@ -404,8 +405,22 @@ pub fn process_chat_messages(
             .transpose()
             .map_err(|e| format!("Failed to serialize tools: {e}"))?;
 
-        let kwargs_capacity = 1 + request.chat_template_kwargs.as_ref().map_or(0, |k| k.len());
+        let kwargs_capacity = 2 + request.chat_template_kwargs.as_ref().map_or(0, |k| k.len());
         let mut combined_template_kwargs = HashMap::with_capacity(kwargs_capacity);
+
+        // Generate TypeScript-style tool declarations for models that use it
+        // (e.g., Kimi K2.5 chat template checks for tools_ts_str)
+        if let Some(ref tools) = request.tools {
+            if !tools.is_empty() {
+                let ts_str = tools_to_typescript(tools);
+                if !ts_str.is_empty() {
+                    combined_template_kwargs.insert(
+                        "tools_ts_str".to_string(),
+                        Value::String(ts_str),
+                    );
+                }
+            }
+        }
 
         // Add reasoning_effort if present (like Python does)
         if let Some(reasoning_effort) = &request.reasoning_effort {
@@ -529,10 +544,25 @@ pub(crate) fn parse_json_schema_response(
     model: &str,
     history_tool_calls_count: usize,
 ) -> (Option<Vec<ToolCall>>, String) {
+    // Strip chatml tokens that may trail the constrained JSON output
+    let mut clean = processed_text.to_string();
+    for token in [
+        "<|im_end|>",
+        "<|im_start|>",
+        "<|im_user|>",
+        "<|im_assistant|>",
+        "<|im_system|>",
+        "<|im_middle|>",
+        "</think>",
+    ] {
+        clean = clean.replace(token, "");
+    }
+    let clean = clean.trim();
+
     match tool_choice {
         Some(ToolChoice::Function { function, .. }) => {
             // Specific function: Parse parameters directly
-            match serde_json::from_str::<Value>(processed_text) {
+            match serde_json::from_str::<Value>(clean) {
                 Ok(params) => {
                     let tool_call = ToolCall {
                         id: generate_tool_call_id(
@@ -553,14 +583,14 @@ pub(crate) fn parse_json_schema_response(
                 }
                 Err(e) => {
                     error!("Failed to parse specific function parameters: {}", e);
-                    (None, processed_text.to_string())
+                    (None, clean.to_string())
                 }
             }
         }
         Some(ToolChoice::Value(ToolChoiceValue::Required))
         | Some(ToolChoice::AllowedTools { .. }) => {
             // Required mode: Parse array of tool calls
-            match serde_json::from_str::<Vec<Value>>(processed_text) {
+            match serde_json::from_str::<Vec<Value>>(clean) {
                 Ok(parsed_array) => {
                     let spec_tool_calls: Vec<ToolCall> = parsed_array
                         .into_iter()
@@ -592,11 +622,11 @@ pub(crate) fn parse_json_schema_response(
                 }
                 Err(e) => {
                     error!("Failed to parse required tool call array: {}", e);
-                    (None, processed_text.to_string())
+                    (None, clean.to_string())
                 }
             }
         }
-        _ => (None, processed_text.to_string()),
+        _ => (None, clean.to_string()),
     }
 }
 
@@ -883,4 +913,207 @@ mod tests {
         assert_eq!(content_array[0]["type"], "text");
         assert_eq!(content_array[1], json!({"type": "image"}));
     }
+}
+
+// ============================================================================
+// TypeScript-style tool declaration generator
+// ============================================================================
+
+/// Convert OpenAI tools to TypeScript-style declaration string.
+///
+/// Produces the format expected by models like Kimi K2.5, whose chat templates
+/// check for a `tools_ts_str` variable and prefer it over raw JSON.
+///
+/// Example output:
+/// ```text
+/// # Tools
+///
+/// ## functions
+/// namespace functions {
+/// // Get the current weather
+/// type getCurrentWeather = (_: {
+///   // The city and state
+///   location: string,
+///   unit?: "celsius" | "fahrenheit"
+/// }) => any;
+/// }
+/// ```
+pub fn tools_to_typescript(tools: &[Tool]) -> String {
+    let mut functions = Vec::new();
+
+    for tool in tools {
+        if tool.tool_type != "function" {
+            continue;
+        }
+        functions.push(function_to_typescript(&tool.function));
+    }
+
+    if functions.is_empty() {
+        return String::new();
+    }
+
+    let mut result = String::from("# Tools\n\n## functions\nnamespace functions {\n");
+    result.push_str(&functions.join("\n"));
+    result.push_str("\n}\n");
+    result
+}
+
+fn function_to_typescript(
+    func: &openai_protocol::common::Function,
+) -> String {
+    let mut out = String::new();
+
+    // Description comment
+    if let Some(ref desc) = func.description {
+        for line in desc.lines() {
+            if line.is_empty() {
+                out.push('\n');
+            } else {
+                out.push_str(&format!("// {line}\n"));
+            }
+        }
+    }
+
+    // Parameters
+    let params_str = if func.parameters.is_null() || func.parameters == Value::Object(Default::default()) {
+        "{}".to_string()
+    } else {
+        schema_to_typescript(&func.parameters, "", &[])
+    };
+
+    out.push_str(&format!("type {} = (_: {params_str}) => any;", func.name));
+    out
+}
+
+fn schema_to_typescript(schema: &Value, indent: &str, required: &[&str]) -> String {
+    match schema.get("type").and_then(|t| t.as_str()) {
+        Some("object") => object_to_typescript(schema, indent),
+        Some("array") => array_to_typescript(schema, indent),
+        Some("string") => {
+            if let Some(enum_vals) = schema.get("enum").and_then(|e| e.as_array()) {
+                enum_to_typescript(enum_vals)
+            } else {
+                "string".to_string()
+            }
+        }
+        Some("integer" | "number") => "number".to_string(),
+        Some("boolean") => "boolean".to_string(),
+        Some("null") => "null".to_string(),
+        _ => {
+            // Handle enum without type
+            if let Some(enum_vals) = schema.get("enum").and_then(|e| e.as_array()) {
+                return enum_to_typescript(enum_vals);
+            }
+            // Handle anyOf
+            if let Some(any_of) = schema.get("anyOf").and_then(|a| a.as_array()) {
+                let types: Vec<String> = any_of
+                    .iter()
+                    .map(|t| schema_to_typescript(t, indent, &[]))
+                    .collect();
+                return types.join(" | ");
+            }
+            "any".to_string()
+        }
+    }
+}
+
+fn object_to_typescript(schema: &Value, indent: &str) -> String {
+    let properties = match schema.get("properties").and_then(|p| p.as_object()) {
+        Some(p) => p,
+        None => return "{}".to_string(),
+    };
+
+    let required_fields: Vec<&str> = schema
+        .get("required")
+        .and_then(|r| r.as_array())
+        .map(|arr| arr.iter().filter_map(|v| v.as_str()).collect())
+        .unwrap_or_default();
+
+    let child_indent = format!("{indent}  ");
+
+    // Sort: required first, then optional, both alphabetically
+    let mut required_params: Vec<(&String, &Value)> = Vec::new();
+    let mut optional_params: Vec<(&String, &Value)> = Vec::new();
+
+    for (name, prop) in properties {
+        if required_fields.contains(&name.as_str()) {
+            required_params.push((name, prop));
+        } else {
+            optional_params.push((name, prop));
+        }
+    }
+    required_params.sort_by_key(|(n, _)| *n);
+    optional_params.sort_by_key(|(n, _)| *n);
+
+    let mut params: Vec<(&String, &Value, bool)> = Vec::new();
+    for (n, v) in required_params {
+        params.push((n, v, false));
+    }
+    for (n, v) in optional_params {
+        params.push((n, v, true));
+    }
+
+    if params.is_empty() {
+        return "{}".to_string();
+    }
+
+    let mut parts = Vec::new();
+    for (name, prop, optional) in &params {
+        let mut part = String::new();
+
+        // Description comment
+        if let Some(desc) = prop.get("description").and_then(|d| d.as_str()) {
+            for line in desc.lines() {
+                if line.is_empty() {
+                    part.push('\n');
+                } else {
+                    part.push_str(&format!("{child_indent}// {line}\n"));
+                }
+            }
+        }
+
+        let type_str = schema_to_typescript(prop, &child_indent, &[]);
+        let opt_marker = if *optional { "?" } else { "" };
+        part.push_str(&format!("{child_indent}{name}{opt_marker}: {type_str}"));
+        parts.push(part);
+    }
+
+    format!("{{\n{}\n{indent}}}", parts.join(",\n"))
+}
+
+fn array_to_typescript(schema: &Value, indent: &str) -> String {
+    let items = schema.get("items");
+    let item_type = match items {
+        Some(item_schema) => {
+            let child_indent = format!("{indent}  ");
+            // Check if item has description
+            let item_desc = item_schema
+                .get("description")
+                .and_then(|d| d.as_str());
+            let type_str = schema_to_typescript(item_schema, &child_indent, &[]);
+
+            if let Some(desc) = item_desc {
+                return format!(
+                    "Array<\n{child_indent}// {desc}\n{child_indent}{type_str}\n{indent}>"
+                );
+            }
+            type_str
+        }
+        None => "any".to_string(),
+    };
+    format!("Array<{item_type}>")
+}
+
+fn enum_to_typescript(values: &[Value]) -> String {
+    let parts: Vec<String> = values
+        .iter()
+        .map(|v| match v {
+            Value::String(s) => format!("\"{s}\""),
+            Value::Number(n) => n.to_string(),
+            Value::Bool(b) => b.to_string(),
+            Value::Null => "null".to_string(),
+            _ => "any".to_string(),
+        })
+        .collect();
+    parts.join(" | ")
 }

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -21,7 +21,7 @@ use serde::Serialize;
 use serde_json::{json, Value};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::UnboundedReceiverStream;
-use tracing::{debug, error, warn};
+use tracing::{debug, error, info, warn};
 
 use super::pd_types::api_path;
 use crate::{
@@ -587,16 +587,36 @@ impl PDRouter {
         // hits a transport error, the other is cancelled immediately — otherwise
         // the surviving request hangs waiting for a PD bootstrap that will never
         // come (see #831).
+        let send_start = Instant::now();
         let pd_result = tokio::try_join!(prefill_request.send(), decode_request.send());
+        let backend_duration_ms = send_start.elapsed().as_millis() as u64;
 
         events::RequestReceivedEvent {}.emit();
 
         let (prefill_response, decode_response) = match pd_result {
-            Ok((prefill_resp, decode_resp)) => (prefill_resp, decode_resp),
+            Ok((prefill_resp, decode_resp)) => {
+                info!(
+                    target: "smg::upstream",
+                    prefill_url = prefill.url(),
+                    decode_url = decode.url(),
+                    prefill_status = prefill_resp.status().as_u16(),
+                    decode_status = decode_resp.status().as_u16(),
+                    duration_ms = backend_duration_ms,
+                    streaming = context.is_stream,
+                    "PD backend request completed"
+                );
+                (prefill_resp, decode_resp)
+            }
             Err(e) => {
+                warn!(
+                    target: "smg::upstream",
+                    prefill_url = prefill.url(),
+                    decode_url = decode.url(),
+                    duration_ms = backend_duration_ms,
+                    error = %e,
+                    "PD backend request failed"
+                );
                 error!("PD request transport error, both sides aborted: {e}");
-                // Don't record_outcome here — the caller (execute_dual_dispatch)
-                // records outcomes from the response status after we return.
                 return error::bad_gateway(
                     "PD disaggregation request failed",
                     format!("Transport error: {e}"),
@@ -774,6 +794,16 @@ impl PDRouter {
             metrics_labels::CONNECTION_HTTP,
             model,
             decode_policy.name(),
+        );
+
+        info!(
+            target: "smg::routing",
+            model_id = model,
+            prefill_policy = prefill_policy.name(),
+            decode_policy = decode_policy.name(),
+            prefill_worker = prefill.url(),
+            decode_worker = decode.url(),
+            "PD pair selected"
         );
 
         Ok((prefill, decode))

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -21,7 +21,7 @@ use openai_protocol::{
 use reqwest::Client;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::UnboundedReceiverStream;
-use tracing::error;
+use tracing::{error, info, warn};
 
 use crate::{
     app_context::AppContext,
@@ -184,6 +184,14 @@ impl Router {
             policy.name(),
         );
 
+        info!(
+            target: "smg::routing",
+            model_id = model_id,
+            policy = policy.name(),
+            selected_worker = available[idx].url(),
+            "Worker selected"
+        );
+
         Some(available[idx].clone())
     }
 
@@ -320,6 +328,7 @@ impl Router {
         inject_trace_context_http(&mut headers_with_trace);
         let headers = Some(&headers_with_trace);
 
+        let send_start = Instant::now();
         let response = self
             .send_typed_request(
                 headers,
@@ -330,18 +339,35 @@ impl Router {
                 load_guard,
             )
             .await;
+        let backend_duration_ms = send_start.elapsed().as_millis() as u64;
 
         events::RequestReceivedEvent {}.emit();
 
         let status = response.status();
         worker.record_outcome(status.as_u16());
 
-        // Record worker errors for server errors (5xx)
         if status.is_server_error() {
             Metrics::record_worker_error(
                 metrics_labels::WORKER_REGULAR,
                 metrics_labels::CONNECTION_HTTP,
                 error_type_from_status(status),
+            );
+            warn!(
+                target: "smg::upstream",
+                worker_url = worker.url(),
+                status = status.as_u16(),
+                duration_ms = backend_duration_ms,
+                streaming = is_stream,
+                "Backend request failed"
+            );
+        } else {
+            info!(
+                target: "smg::upstream",
+                worker_url = worker.url(),
+                status = status.as_u16(),
+                duration_ms = backend_duration_ms,
+                streaming = is_stream,
+                "Backend request completed"
             );
         }
 

--- a/model_gateway/src/routers/openai/chat.rs
+++ b/model_gateway/src/routers/openai/chat.rs
@@ -47,6 +47,7 @@ pub(super) async fn route_chat(
     let start = Instant::now();
     let model = model_id;
     let streaming = body.stream;
+    let last_token_time = deps.shared_components.last_token_time.clone();
 
     Metrics::record_router_request(
         metrics_labels::ROUTER_OPENAI,
@@ -155,6 +156,7 @@ pub(super) async fn route_chat(
             let headers = Arc::clone(&headers_cloned);
             let worker_api_key = Arc::clone(&worker_api_key);
             let worker = Arc::clone(&worker);
+            let last_token_time = last_token_time.clone();
 
             async move {
                 let mut req = client.post(&url).json(&*payload);
@@ -191,6 +193,7 @@ pub(super) async fn route_chat(
                     let (tx, rx) = mpsc::unbounded_channel();
                     #[expect(clippy::disallowed_methods, reason = "fire-and-forget stream relay; gateway shutdown need not wait for individual stream forwarding")]
                     tokio::spawn(async move {
+                        use std::sync::atomic::Ordering;
                         let mut s = stream;
                         while let Some(chunk) = s.next().await {
                             match chunk {
@@ -198,6 +201,11 @@ pub(super) async fn route_chat(
                                     if tx.send(Ok(bytes)).is_err() {
                                         break;
                                     }
+                                    let now = std::time::SystemTime::now()
+                                        .duration_since(std::time::UNIX_EPOCH)
+                                        .unwrap_or_default()
+                                        .as_secs();
+                                    last_token_time.store(now, Ordering::Relaxed);
                                 }
                                 Err(e) => {
                                     let _ = tx.send(Err(format!("Stream error: {e}")));

--- a/model_gateway/src/routers/openai/context.rs
+++ b/model_gateway/src/routers/openai/context.rs
@@ -1,6 +1,9 @@
 //! Request context types for OpenAI router pipeline.
 
-use std::sync::Arc;
+use std::sync::{
+    atomic::AtomicU64,
+    Arc,
+};
 
 use axum::http::HeaderMap;
 use openai_protocol::{chat::ChatCompletionRequest, responses::ResponsesRequest};
@@ -36,6 +39,7 @@ pub enum RequestType {
 #[derive(Clone)]
 pub struct SharedComponents {
     pub client: reqwest::Client,
+    pub last_token_time: Arc<AtomicU64>,
 }
 
 pub struct ResponsesComponents {

--- a/model_gateway/src/routers/openai/health.rs
+++ b/model_gateway/src/routers/openai/health.rs
@@ -1,7 +1,5 @@
 //! Health check and server info endpoints for the OpenAI router.
 
-use std::sync::Arc;
-
 use axum::{
     http::StatusCode,
     response::{IntoResponse, Response},
@@ -9,23 +7,12 @@ use axum::{
 };
 use serde_json::json;
 
-use crate::{
-    core::{RuntimeType, Worker, WorkerRegistry},
-    routers::error,
-};
-
-fn external_workers(registry: &WorkerRegistry) -> Vec<Arc<dyn Worker>> {
-    registry
-        .get_all()
-        .into_iter()
-        .filter(|w| w.metadata().spec.runtime_type == RuntimeType::External)
-        .collect()
-}
+use crate::{core::WorkerRegistry, routers::error};
 
 pub(super) fn health_generate(registry: &WorkerRegistry) -> Response {
-    let workers = external_workers(registry);
+    let workers = registry.get_all();
     if workers.is_empty() {
-        return error::service_unavailable("service_unavailable", "No external workers registered");
+        return error::service_unavailable("service_unavailable", "No workers registered");
     }
 
     let (healthy, unhealthy): (Vec<_>, Vec<_>) = workers.iter().partition(|w| w.is_healthy());
@@ -55,13 +42,12 @@ pub(super) fn health_generate(registry: &WorkerRegistry) -> Response {
 
 pub(super) fn get_server_info(registry: &WorkerRegistry) -> Response {
     let stats = registry.stats();
-    let workers = external_workers(registry);
+    let workers = registry.get_all();
     let worker_urls: Vec<_> = workers.iter().map(|w| w.url()).collect();
 
     let info = json!({
         "router_type": "openai",
         "total_workers": stats.total_workers,
-        "external_workers": workers.len(),
         "healthy_workers": stats.healthy_workers,
         "total_models": stats.total_models,
         "worker_urls": worker_urls

--- a/model_gateway/src/routers/openai/router.rs
+++ b/model_gateway/src/routers/openai/router.rs
@@ -87,6 +87,7 @@ impl OpenAIRouter {
 
         let shared_components = Arc::new(SharedComponents {
             client: ctx.client.clone(),
+            last_token_time: ctx.last_token_time.clone(),
         });
 
         let responses_components = Arc::new(ResponsesComponents {

--- a/model_gateway/src/server.rs
+++ b/model_gateway/src/server.rs
@@ -938,6 +938,10 @@ pub async fn startup(config: ServerConfig) -> Result<(), Box<dyn std::error::Err
 
     if config.prometheus_config.is_some() {
         app_context.inflight_tracker.start_sampler(20);
+        metrics_server::register_engine_metrics_deps(
+            app_context.worker_registry.clone(),
+            app_context.client.clone(),
+        );
     }
 
     let weak_context = Arc::downgrade(&app_context);

--- a/model_gateway/src/server.rs
+++ b/model_gateway/src/server.rs
@@ -155,7 +155,10 @@ async fn health(_state: State<Arc<AppState>>) -> Response {
 }
 
 async fn health_generate(State(state): State<Arc<AppState>>, _req: Request) -> Response {
-    use std::time::Instant;
+    use std::{
+        sync::atomic::Ordering,
+        time::{Instant, SystemTime, UNIX_EPOCH},
+    };
 
     let registry = &state.context.worker_registry;
     let workers = registry.get_all();
@@ -170,6 +173,35 @@ async fn health_generate(State(state): State<Arc<AppState>>, _req: Request) -> R
             StatusCode::SERVICE_UNAVAILABLE,
             format!("0/{} workers healthy: {}", workers.len(), info.join(", ")),
         ).into_response();
+    }
+
+    // Fast path: if a token was forwarded within the last 10 seconds, skip the
+    // probe entirely. Under high load this avoids adding a synthetic request that
+    // could tip the backend over its concurrency limit.
+    let last_token_unix = state.context.last_token_time.load(Ordering::Relaxed);
+    if last_token_unix > 0 {
+        let now_unix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let age_secs = now_unix.saturating_sub(last_token_unix);
+        if age_secs < 10 {
+            info!(
+                target: "smg::health",
+                workers = healthy.len(),
+                last_token_age_secs = age_secs,
+                "health_generate: skipping probe — token forwarded recently"
+            );
+            return (
+                StatusCode::OK,
+                format!(
+                    "OK - {} workers healthy, last token {}s ago (probe skipped)",
+                    healthy.len(),
+                    age_secs
+                ),
+            )
+                .into_response();
+        }
     }
 
     let model_id = healthy[0].model_id().to_string();

--- a/model_gateway/src/server.rs
+++ b/model_gateway/src/server.rs
@@ -79,6 +79,7 @@ pub struct AppState {
     pub concurrency_queue_tx: Option<mpsc::Sender<QueuedRequest>>,
     pub router_manager: Option<Arc<RouterManager>>,
     pub mesh_handler: Option<Arc<MeshServerHandler>>,
+    pub api_port: u16,
 }
 
 async fn parse_function_call(
@@ -153,8 +154,100 @@ async fn health(_state: State<Arc<AppState>>) -> Response {
     liveness().await
 }
 
-async fn health_generate(State(state): State<Arc<AppState>>, req: Request) -> Response {
-    state.router.health_generate(req).await
+async fn health_generate(State(state): State<Arc<AppState>>, _req: Request) -> Response {
+    use std::time::Instant;
+
+    let registry = &state.context.worker_registry;
+    let workers = registry.get_all();
+    if workers.is_empty() {
+        return (StatusCode::SERVICE_UNAVAILABLE, "No workers registered").into_response();
+    }
+
+    let healthy: Vec<_> = workers.iter().filter(|w| w.is_healthy()).collect();
+    if healthy.is_empty() {
+        let info: Vec<_> = workers.iter().map(|w| format!("{} ({})", w.model_id(), w.url())).collect();
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            format!("0/{} workers healthy: {}", workers.len(), info.join(", ")),
+        ).into_response();
+    }
+
+    let model_id = healthy[0].model_id().to_string();
+    let probe_url = format!("http://127.0.0.1:{}/v1/chat/completions", state.api_port);
+    let probe_body = serde_json::json!({
+        "model": model_id,
+        "messages": [{"role": "user", "content": "ping"}],
+        "max_tokens": 1,
+        "stream": false,
+        "temperature": 0
+    });
+
+    info!(
+        target: "smg::health",
+        model = %model_id,
+        probe_url = %probe_url,
+        max_tokens = 1,
+        "health_generate: sending real inference probe"
+    );
+
+    let start = Instant::now();
+    let probe_result = state.context.client
+        .post(&probe_url)
+        .json(&probe_body)
+        .timeout(std::time::Duration::from_secs(3))
+        .send()
+        .await;
+    let duration_ms = start.elapsed().as_millis();
+
+    match probe_result {
+        Ok(resp) if resp.status().is_success() => {
+            info!(
+                target: "smg::health",
+                model = %model_id,
+                duration_ms = %duration_ms,
+                workers = healthy.len(),
+                "health_generate: probe succeeded"
+            );
+            (
+                StatusCode::OK,
+                format!(
+                    "OK - {} workers healthy, probe succeeded in {}ms (model: {})",
+                    healthy.len(), duration_ms, model_id
+                ),
+            ).into_response()
+        }
+        Ok(resp) => {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            warn!(
+                target: "smg::health",
+                model = %model_id,
+                status = %status,
+                duration_ms = %duration_ms,
+                "health_generate: probe failed (backend error)"
+            );
+            (
+                StatusCode::SERVICE_UNAVAILABLE,
+                format!(
+                    "Probe failed: backend returned {} in {}ms — {}",
+                    status, duration_ms, body
+                ),
+            ).into_response()
+        }
+        Err(e) => {
+            warn!(
+                target: "smg::health",
+                model = %model_id,
+                error = %e,
+                duration_ms = %duration_ms,
+                "health_generate: probe failed (transport error)"
+            );
+            (
+                StatusCode::SERVICE_UNAVAILABLE,
+                format!("Probe failed: {} in {}ms", e, duration_ms),
+            ).into_response()
+        }
+    }
 }
 
 async fn engine_metrics(State(state): State<Arc<AppState>>) -> Response {
@@ -1160,6 +1253,7 @@ pub async fn startup(config: ServerConfig) -> Result<(), Box<dyn std::error::Err
         concurrency_queue_tx: limiter.queue_tx.clone(),
         router_manager: Some(router_manager),
         mesh_handler,
+        api_port: config.port,
     });
     if let Some(service_discovery_config) = config.service_discovery_config {
         if service_discovery_config.enabled {

--- a/model_gateway/src/server.rs
+++ b/model_gateway/src/server.rs
@@ -194,7 +194,7 @@ async fn health_generate(State(state): State<Arc<AppState>>, _req: Request) -> R
     let probe_result = state.context.client
         .post(&probe_url)
         .json(&probe_body)
-        .timeout(std::time::Duration::from_secs(3))
+        .timeout(std::time::Duration::from_secs(60))
         .send()
         .await;
     let duration_ms = start.elapsed().as_millis();

--- a/model_gateway/src/service_discovery.rs
+++ b/model_gateway/src/service_discovery.rs
@@ -884,6 +884,8 @@ mod tests {
     }
 
     fn create_test_app_context() -> Arc<AppContext> {
+        use std::sync::atomic::AtomicU64;
+
         use crate::{
             config::RouterConfig, core::WorkerService, middleware::TokenBucket,
             observability::inflight_tracker::InFlightRequestTracker,
@@ -929,6 +931,7 @@ mod tests {
                 router_config,
             )),
             inflight_tracker: InFlightRequestTracker::new(),
+            last_token_time: Arc::new(AtomicU64::new(0)),
             kv_event_monitor: None,
             realtime_registry: Arc::new(RealtimeRegistry::new()),
             webrtc_bind_addr: None,

--- a/model_gateway/tests/api/api_endpoints_test.rs
+++ b/model_gateway/tests/api/api_endpoints_test.rs
@@ -112,6 +112,9 @@ mod health_tests {
 
     #[tokio::test]
     async fn test_health_generate_endpoint() {
+        use std::sync::atomic::Ordering;
+        use std::time::{SystemTime, UNIX_EPOCH};
+
         let ctx = AppTestContext::new(vec![MockWorkerConfig {
             port: 18005,
             worker_type: WorkerType::Regular,
@@ -120,6 +123,16 @@ mod health_tests {
             fail_rate: 0.0,
         }])
         .await;
+
+        // Simulate recent traffic so the fast path fires and avoids
+        // a real probe (which would fail since api_port=0 in tests).
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        ctx.app_context
+            .last_token_time
+            .store(now, Ordering::Relaxed);
 
         let app = ctx.create_app();
 
@@ -135,8 +148,124 @@ mod health_tests {
         let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
             .await
             .unwrap();
-        let body_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
-        assert!(body_json.is_object());
+        let body_str = String::from_utf8_lossy(&body);
+        assert!(
+            body_str.contains("workers healthy"),
+            "Expected workers healthy in body, got: {body_str}"
+        );
+
+        ctx.shutdown().await;
+    }
+
+    /// Fast path: if last_token_time is recent (< 10s), the probe is skipped.
+    #[tokio::test]
+    async fn test_health_generate_fast_path_skips_probe() {
+        use std::sync::atomic::Ordering;
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        let ctx = AppTestContext::new(vec![MockWorkerConfig {
+            port: 18006,
+            worker_type: WorkerType::Regular,
+            health_status: HealthStatus::Healthy,
+            response_delay_ms: 0,
+            fail_rate: 0.0,
+        }])
+        .await;
+
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        ctx.app_context
+            .last_token_time
+            .store(now, Ordering::Relaxed);
+
+        let app = ctx.create_app();
+
+        let req = Request::builder()
+            .method("GET")
+            .uri("/health_generate")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body_str = String::from_utf8_lossy(&body);
+        assert!(
+            body_str.contains("probe skipped"),
+            "Expected 'probe skipped' in body, got: {body_str}"
+        );
+
+        ctx.shutdown().await;
+    }
+
+    /// Stale fast path: last_token_time older than 10s falls through to the probe.
+    /// The probe will fail (no real server at api_port=0), returning 503.
+    #[tokio::test]
+    async fn test_health_generate_stale_token_falls_through_to_probe() {
+        use std::sync::atomic::Ordering;
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        let ctx = AppTestContext::new(vec![MockWorkerConfig {
+            port: 18007,
+            worker_type: WorkerType::Regular,
+            health_status: HealthStatus::Healthy,
+            response_delay_ms: 0,
+            fail_rate: 0.0,
+        }])
+        .await;
+
+        let stale = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            .saturating_sub(30);
+        ctx.app_context
+            .last_token_time
+            .store(stale, Ordering::Relaxed);
+
+        let app = ctx.create_app();
+
+        let req = Request::builder()
+            .method("GET")
+            .uri("/health_generate")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        // Probe to api_port=0 will fail → 503
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body_str = String::from_utf8_lossy(&body);
+        assert!(
+            !body_str.contains("probe skipped"),
+            "Stale token should not skip probe, got: {body_str}"
+        );
+
+        ctx.shutdown().await;
+    }
+
+    /// No workers → 503 immediately, no probe attempted.
+    #[tokio::test]
+    async fn test_health_generate_no_workers() {
+        let ctx = AppTestContext::new(vec![]).await;
+        let app = ctx.create_app();
+
+        let req = Request::builder()
+            .method("GET")
+            .uri("/health_generate")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
 
         ctx.shutdown().await;
     }

--- a/model_gateway/tests/common/test_app.rs
+++ b/model_gateway/tests/common/test_app.rs
@@ -93,6 +93,7 @@ pub fn create_test_app(
         concurrency_queue_tx: None,
         router_manager: None,
         mesh_handler: None,
+        api_port: 0,
     });
 
     // Configure request ID headers (use defaults if not specified)
@@ -130,6 +131,7 @@ pub fn create_test_app_with_context(
         concurrency_queue_tx: None,
         router_manager: None,
         mesh_handler: None,
+        api_port: 0,
     });
 
     // Get config from the context

--- a/model_gateway/tests/spec/chat_message.rs
+++ b/model_gateway/tests/spec/chat_message.rs
@@ -66,6 +66,7 @@ fn test_chat_message_tagged_by_role_tool() {
         ChatMessage::Tool {
             content,
             tool_call_id,
+            ..
         } => {
             match content {
                 MessageContent::Text(text) => {

--- a/model_gateway/tests/wasm_test.rs
+++ b/model_gateway/tests/wasm_test.rs
@@ -183,6 +183,7 @@ async fn create_test_app_with_wasm() -> (axum::Router, Arc<AppContext>, TempDir)
         concurrency_queue_tx: None,
         router_manager: None,
         mesh_handler: None,
+        api_port: 0,
     });
 
     let request_id_headers = vec!["x-request-id".to_string(), "x-correlation-id".to_string()];


### PR DESCRIPTION
## Description

> **Note**: This PR is for record-keeping purposes. The changes will be systematically split into separate PRs for review and merging.

### Problem

Function calling with Kimi-K2.5 (NVFP4) is severely broken on SMG — fc-dash scores 44/60 (SMG+SGLang) and 18/60 (SMG+TRT-LLM) vs 58/60 on pure SGLang direct. Multiple stages in the SMG inference pipeline have issues that compound to produce wrong or missing tool calls, empty structured outputs, and native token leaks.

### Solution

Fix function calling across the full SMG inference pipeline, organized by stage:

**1. Input Tokenization** — Fix Rust tiktoken encoder to use `encode_with_special_tokens` for chat template output, ensuring special tokens like `<|im_system|>`, `<|im_end|>` are encoded as single token IDs instead of being split into character-level BPE tokens (`tiktoken.rs`, `preparation.rs`)

**2. Chat Template Rendering** — Add `name: Option<String>` to `ChatMessage::Tool` so the Jinja2 template resolves `message.get('name')` correctly (e.g. tool role renders as function name instead of literal `"tool"`). Keep tool call arguments as strings instead of parsing to `serde_json::Value` to preserve original formatting like `{"query": "weather"}` vs `{"query":"weather"}` (`chat.rs`, `chat_utils.rs`)

**3. Reasoning Parser** — Skip reasoning parsing when output is constrained (specific `tool_choice` or `response_format: json_object/json_schema`), preventing the parser from swallowing constrained JSON output as reasoning content. Add `<|tool_calls_section_begin|>` detection as a split point when `</think>` is absent (`processor.rs`, `streaming.rs`, `base.rs`)

**4. Tool Call Parser** — Support hyphens in KimiK2 tool call IDs (e.g. `functions.execute-tool:0`) and alternative delimiters `<|func_start|>`/`<|func_end|>`. Add fallback from configured parser to JSON schema parser for `tool_choice=specific_function` when native tokens are absent (`kimik2.rs`, `processor.rs`)

**5. Stop Token / EOS Handling** — Load merged EOS token IDs from both `config.json` (`[EOS]=163585`) and `generation_config.json` (`<|im_end|>=163586`), matching SGLang's `_get_hf_eos_token_id()` merge logic. Expose `eos_token_ids()` on the `Tokenizer` trait and pass them as `stop_token_ids` in TRT-LLM gRPC requests. This fixes TRT-LLM generating past turn boundaries (18/60 → 55/60) (`tiktoken.rs`, `traits.rs`, `trtllm_service.rs`)

**6. Output Cleanup** — Strip leaked chatml tokens and `[EOS]`/`[BOS]` text from both streaming and non-streaming output paths, conditioned on parser configuration (`processor.rs`, `streaming.rs`, `chat_utils.rs`)

**Other (separate concern)**: Graceful metrics server bind failure — log error instead of panicking when port is in use (`metrics_server.rs`). This should be a separate PR.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Kimi-K2.5 multimodal model and image processor support
  * Tokenizers now expose merged EOS token IDs
  * Tool messages may include an optional tool name

* **Bug Fixes**
  * Metrics server no longer crashes if metrics port bind fails
  * Reasoning parser no longer consumes constrained JSON outputs

* **Improvements**
  * More reliable EOS/stop-token handling for generation
  * Safer gRPC metrics aggregation and streaming token scrubbing
  * Special-token recognition enabled during tokenization
<!-- end of auto-generated comment: release notes by coderabbit.ai -->