### PR TITLE
fix(python): add router arg fallback disable flag

### DIFF
--- a/bindings/python/src/smg/router_args.py
+++ b/bindings/python/src/smg/router_args.py
@@ -1118,9 +1118,7 @@ class RouterArgs:
         prefix = "router_" if use_router_prefix else ""
         cli_args_dict = vars(args)
         args_dict = {}
-        disable_arg_fallback = bool(
-            cli_args_dict.get(f"{prefix}disable_arg_fallback", False)
-        )
+        disable_arg_fallback = bool(cli_args_dict.get(f"{prefix}disable_arg_fallback", False))
 
         for attr in dataclasses.fields(cls):
             # Auto strip prefix from args.

--- a/bindings/python/src/smg/router_args.py
+++ b/bindings/python/src/smg/router_args.py
@@ -240,6 +240,17 @@ class RouterArgs:
             "Control Plane Authentication", "API key and JWT/OIDC authentication"
         )
 
+        if use_router_prefix:
+            parser.add_argument(
+                "--router-disable-arg-fallback",
+                action="store_true",
+                default=False,
+                help=(
+                    "When set, only use explicitly provided --router-* arguments and do not"
+                    " fall back to backend arguments with the same name."
+                ),
+            )
+
         # Worker configuration
         if not exclude_host_port:
             worker_group.add_argument(
@@ -1101,6 +1112,9 @@ class RouterArgs:
         prefix = "router_" if use_router_prefix else ""
         cli_args_dict = vars(args)
         args_dict = {}
+        disable_arg_fallback = bool(
+            cli_args_dict.get(f"{prefix}disable_arg_fallback", False)
+        )
 
         for attr in dataclasses.fields(cls):
             # Auto strip prefix from args.
@@ -1111,7 +1125,11 @@ class RouterArgs:
             prefixed_key = f"{prefix}{attr.name}"
             if prefixed_key in cli_args_dict and cli_args_dict[prefixed_key] is not None:
                 args_dict[attr.name] = cli_args_dict[prefixed_key]
-            elif attr.name in cli_args_dict and cli_args_dict[attr.name] not in (None, ""):
+            elif (
+                not disable_arg_fallback
+                and attr.name in cli_args_dict
+                and cli_args_dict[attr.name] not in (None, "")
+            ):
                 args_dict[attr.name] = cli_args_dict[attr.name]
 
             # Special handling for CLI args with dashes vs dataclass fields with underscores

--- a/bindings/python/tests/test_arg_parser.py
+++ b/bindings/python/tests/test_arg_parser.py
@@ -406,6 +406,52 @@ class TestRouterArgs:
         assert router_args.policy == "random"
         assert router_args.pd_disaggregation is False
 
+    def test_prefixed_args_fall_back_to_backend_args_by_default(self):
+        """Prefixed router args should still fall back to backend args unless disabled."""
+        args = SimpleNamespace(
+            router_model_path=None,
+            router_disable_arg_fallback=False,
+            model_path="backend/model",
+            router_tokenizer_path=None,
+            tokenizer_path="backend/tokenizer",
+            router_worker_urls=[],
+            worker_urls=[],
+            router_prefill=None,
+            router_decode=None,
+            router_selector=None,
+            router_prefill_selector=None,
+            router_decode_selector=None,
+            router_router_selector=None,
+        )
+
+        router_args = RouterArgs.from_cli_args(args, use_router_prefix=True)
+
+        assert router_args.model_path == "backend/model"
+        assert router_args.tokenizer_path == "backend/tokenizer"
+
+    def test_prefixed_args_can_disable_backend_fallback(self):
+        """When router fallback is disabled, backend args should not fill router args."""
+        args = SimpleNamespace(
+            router_model_path=None,
+            router_disable_arg_fallback=True,
+            model_path="backend/model",
+            router_tokenizer_path=None,
+            tokenizer_path="backend/tokenizer",
+            router_worker_urls=[],
+            worker_urls=[],
+            router_prefill=None,
+            router_decode=None,
+            router_selector=None,
+            router_prefill_selector=None,
+            router_decode_selector=None,
+            router_router_selector=None,
+        )
+
+        router_args = RouterArgs.from_cli_args(args, use_router_prefix=True)
+
+        assert router_args.model_path is None
+        assert router_args.tokenizer_path is None
+
 
 class TestPolicyFromStr:
     """Test policy string to enum conversion."""

--- a/bindings/python/tests/test_serve.py
+++ b/bindings/python/tests/test_serve.py
@@ -263,6 +263,17 @@ class TestParseServeArgs:
         )
         assert args.router_policy == "round_robin"
 
+    def test_trtllm_accepts_router_disable_arg_fallback_flag(self):
+        """--router-disable-arg-fallback should parse and be available on the namespace."""
+        _, args, _ = parse_serve_args(
+            [
+                "--backend",
+                "trtllm",
+                "--router-disable-arg-fallback",
+            ]
+        )
+        assert args.router_disable_arg_fallback is True
+
     def test_trtllm_router_args_defaults(self):
         """Router args should have sensible defaults."""
         _, args, _ = parse_serve_args(["--backend", "trtllm"])


### PR DESCRIPTION
## Summary
- add `--router-disable-arg-fallback` for `smg serve`
- when enabled, router args only come from explicit `--router-*` flags
- keep existing behavior unchanged unless this flag is set

## Why this is needed
In HTTP mode, `--tool-call-parser` and `--reasoning-parser` are meant for the backend engine. But SMG router could pick them up via argument fallback, which can cause parser-related errors. This flag lets us prevent router fallback so backend-only parser flags stay backend-only.

## Testing
- added unit tests for prefixed arg fallback default behavior
- added unit tests for disabling fallback
- added parse test to ensure `--router-disable-arg-fallback` is accepted in `smg serve`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI flag `--router-disable-arg-fallback` that, when enabled, prevents router-specific settings from inheriting unset values from backend configuration.

* **Tests**
  * Added tests ensuring the new flag is parsed correctly and that router argument fields do or do not fall back to backend values depending on the flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->