### PR TITLE
fix(metrics): engine metrics from PROMETHEUS_MULTIPROC_DIR + graceful bind

### DIFF
--- a/bindings/python/src/smg/serve.py
+++ b/bindings/python/src/smg/serve.py
@@ -11,7 +11,9 @@ import atexit
 import logging
 import os
 import random
+import shutil
 import signal
+import tempfile
 import socket
 import subprocess
 import sys
@@ -578,6 +580,7 @@ class ServeOrchestrator:
         self.launcher: WorkerLauncher = BACKEND_LAUNCHERS[backend]()
         self.workers: list[tuple[subprocess.Popen, int]] = []
         self._shutting_down = False
+        self._prometheus_dir: str | None = None
 
     # -- public API ---------------------------------------------------------
 
@@ -599,6 +602,15 @@ class ServeOrchestrator:
     def _launch_workers(self) -> None:
         ports = _find_available_ports(self.args.worker_base_port, self.args.data_parallel_size)
         host = self.args.worker_host
+
+        if getattr(self.args, "connection_mode", "grpc") == "grpc":
+            self._prometheus_dir = tempfile.mkdtemp(prefix="smg_prometheus_")
+            os.environ["PROMETHEUS_MULTIPROC_DIR"] = self._prometheus_dir
+            logger.info(
+                "Set PROMETHEUS_MULTIPROC_DIR=%s for gRPC metrics collection",
+                self._prometheus_dir,
+            )
+
         for dp_rank, port in enumerate(ports):
             env = self.launcher.gpu_env(self.args, dp_rank)
             proc = self.launcher.launch(self.args, self.backend_args, host, port, env)
@@ -668,6 +680,23 @@ class ServeOrchestrator:
                     os.killpg(proc.pid, signal.SIGKILL)
                 except (ProcessLookupError, OSError):
                     pass
+
+        self._cleanup_prometheus_dir()
+
+    def _cleanup_prometheus_dir(self) -> None:
+        """Remove the temporary prometheus multiprocess directory and its .db files."""
+        if self._prometheus_dir is None:
+            return
+        try:
+            shutil.rmtree(self._prometheus_dir)
+            logger.info("Cleaned up PROMETHEUS_MULTIPROC_DIR=%s", self._prometheus_dir)
+        except OSError as e:
+            logger.warning(
+                "Failed to clean up PROMETHEUS_MULTIPROC_DIR=%s: %s",
+                self._prometheus_dir,
+                e,
+            )
+        self._prometheus_dir = None
 
 
 # ---------------------------------------------------------------------------

--- a/grpc_servicer/smg_grpc_servicer/sglang/request_manager.py
+++ b/grpc_servicer/smg_grpc_servicer/sglang/request_manager.py
@@ -142,6 +142,7 @@ class GrpcReqState:
     # Metrics (same as TokenizerManager's ReqState)
     time_stats: APIServerReqTimeStats
     last_completion_tokens: int = 1
+    ttft_observed: bool = False
 
     # Streaming state
     stream_finished: bool = False
@@ -205,6 +206,33 @@ class GrpcRequestManager:
 
         # Metrics
         self.last_receive_tstamp = real_time()
+        self.metrics_collector = None
+        if server_args.enable_metrics:
+            try:
+                from sglang.srt.observability.metrics_collector import (
+                    TokenizerMetricsCollector,
+                )
+
+                labels = {
+                    "model_name": server_args.served_model_name,
+                }
+                self.metrics_collector = TokenizerMetricsCollector(
+                    server_args=server_args,
+                    labels=labels,
+                    bucket_time_to_first_token=server_args.bucket_time_to_first_token,
+                    bucket_e2e_request_latency=server_args.bucket_e2e_request_latency,
+                    bucket_inter_token_latency=getattr(
+                        server_args, "bucket_inter_token_latency", None
+                    ),
+                )
+                self._metrics_labels = labels
+                logger.info("TokenizerMetricsCollector initialized for gRPC request-level metrics")
+            except Exception:
+                logger.warning(
+                    "Failed to initialize TokenizerMetricsCollector, "
+                    "request-level metrics will be unavailable",
+                    exc_info=True,
+                )
 
         # Crash dump for debugging
         self.crash_dump_request_list = []
@@ -576,11 +604,33 @@ class GrpcRequestManager:
                 logger.debug(f"Skipping output for aborted request {rid}")
                 continue
 
-            # Update metrics
+            # Update timing
             if state.time_stats.first_token_time == 0.0:
                 state.time_stats.set_first_token_time()
             else:
                 state.time_stats.set_last_time()
+
+            # Observe request-level Prometheus metrics
+            if self.metrics_collector is not None:
+                completion_tokens = (
+                    batch_out.completion_tokens[i] if batch_out.completion_tokens else 0
+                )
+                labels = dict(self._metrics_labels)
+                if not state.ttft_observed:
+                    state.ttft_observed = True
+                    state.last_completion_tokens = completion_tokens
+                    self.metrics_collector.observe_time_to_first_token(
+                        labels, state.time_stats.get_first_token_latency()
+                    )
+                else:
+                    num_new_tokens = completion_tokens - state.last_completion_tokens
+                    if num_new_tokens > 0:
+                        self.metrics_collector.observe_inter_token_latency(
+                            labels,
+                            state.time_stats.get_interval(),
+                            num_new_tokens,
+                        )
+                        state.last_completion_tokens = completion_tokens
 
             # Extract output for this request
             output_data = {
@@ -670,6 +720,20 @@ class GrpcRequestManager:
                 state.time_stats.set_finished_time()
                 state.stream_finished = True
                 state.event.set()
+
+                if self.metrics_collector is not None:
+                    prompt_tokens = output_data["meta_info"].get("prompt_tokens", 0)
+                    compl_tokens = output_data["meta_info"].get("completion_tokens", 0)
+                    cached_tokens = output_data["meta_info"].get("cached_tokens", 0)
+                    self.metrics_collector.observe_one_finished_request(
+                        dict(self._metrics_labels),
+                        prompt_tokens,
+                        compl_tokens,
+                        cached_tokens,
+                        state.time_stats.get_e2e_latency(),
+                        False,
+                        0,
+                    )
 
                 # Remove from tracking after a delay
                 async def cleanup(request_id):

--- a/model_gateway/src/core/worker_manager.rs
+++ b/model_gateway/src/core/worker_manager.rs
@@ -111,8 +111,12 @@ async fn collect_prometheus_multiproc_metrics() -> Result<String, String> {
         return Err(format!("python3 prometheus collector failed: {stderr}"));
     }
 
-    String::from_utf8(output.stdout)
-        .map_err(|e| format!("prometheus collector output is not valid UTF-8: {e}"))
+    let text = String::from_utf8(output.stdout)
+        .map_err(|e| format!("prometheus collector output is not valid UTF-8: {e}"))?;
+    if text.trim().is_empty() {
+        return Err("no metrics available from gRPC workers yet".to_string());
+    }
+    Ok(text)
 }
 
 pub struct WorkerManager;
@@ -332,11 +336,14 @@ impl WorkerManager {
 
         if has_grpc {
             match collect_prometheus_multiproc_metrics().await {
-                Ok(text) => {
+                Ok(text) if !text.trim().is_empty() => {
                     metric_packs.push(MetricPack {
                         labels: vec![],
                         metrics_text: text,
                     });
+                }
+                Ok(_) => {
+                    // No metrics available yet from gRPC workers — skip silently
                 }
                 Err(e) => {
                     warn!(

--- a/model_gateway/src/core/worker_manager.rs
+++ b/model_gateway/src/core/worker_manager.rs
@@ -315,8 +315,7 @@ impl WorkerManager {
             .any(|w| matches!(w.connection_mode(), ConnectionMode::Grpc));
 
         if !http_workers.is_empty() {
-            let responses =
-                fan_out(&http_workers, client, "metrics", reqwest::Method::GET).await;
+            let responses = fan_out(&http_workers, client, "metrics", reqwest::Method::GET).await;
             for resp in responses {
                 if let Ok(r) = resp.result {
                     if r.status().is_success() {
@@ -340,7 +339,9 @@ impl WorkerManager {
                     });
                 }
                 Err(e) => {
-                    warn!("Failed to collect gRPC worker metrics from PROMETHEUS_MULTIPROC_DIR: {e}");
+                    warn!(
+                        "Failed to collect gRPC worker metrics from PROMETHEUS_MULTIPROC_DIR: {e}"
+                    );
                 }
             }
         }

--- a/model_gateway/src/core/worker_manager.rs
+++ b/model_gateway/src/core/worker_manager.rs
@@ -1,0 +1,606 @@
+//! Worker Management Module
+//!
+//! Provides worker lifecycle operations and fan-out request utilities.
+
+use std::{collections::HashMap, sync::Arc, time::Duration};
+
+use axum::response::{IntoResponse, Response};
+use futures::{
+    future,
+    stream::{self, StreamExt},
+};
+use http::StatusCode;
+use openai_protocol::worker::{
+    FlushCacheResult, WorkerGroupKey, WorkerLoadInfo, WorkerLoadResponse, WorkerLoadsResult,
+};
+use tokio::{
+    sync::{watch, Mutex},
+    task::JoinHandle,
+};
+use tracing::{debug, info, warn};
+
+use crate::{
+    core::{
+        metrics_aggregator::{self, MetricPack},
+        ConnectionMode, Worker, WorkerLoadManager, WorkerRegistry, WorkerType,
+    },
+    policies::PolicyRegistry,
+};
+
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+const MAX_CONCURRENT: usize = 32;
+
+/// Result of a fan-out request to a single worker
+struct WorkerResponse {
+    url: String,
+    result: Result<reqwest::Response, reqwest::Error>,
+}
+
+/// Fan out requests to workers in parallel
+async fn fan_out(
+    workers: &[Arc<dyn Worker>],
+    client: &reqwest::Client,
+    endpoint: &str,
+    method: reqwest::Method,
+) -> Vec<WorkerResponse> {
+    let futures: Vec<_> = workers
+        .iter()
+        .map(|worker| {
+            let client = client.clone();
+            let url = worker.url().to_string();
+            let full_url = format!("{url}/{endpoint}");
+            let api_key = worker.api_key().cloned();
+            let method = method.clone();
+
+            async move {
+                let mut req = client.request(method, &full_url).timeout(REQUEST_TIMEOUT);
+                if let Some(key) = api_key {
+                    req = req.bearer_auth(key);
+                }
+                WorkerResponse {
+                    url,
+                    result: req.send().await,
+                }
+            }
+        })
+        .collect();
+
+    stream::iter(futures)
+        .buffer_unordered(MAX_CONCURRENT)
+        .collect()
+        .await
+}
+
+pub enum EngineMetricsResult {
+    Ok(String),
+    Err(String),
+}
+
+impl IntoResponse for EngineMetricsResult {
+    fn into_response(self) -> Response {
+        match self {
+            Self::Ok(text) => (StatusCode::OK, text).into_response(),
+            Self::Err(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg).into_response(),
+        }
+    }
+}
+
+/// Collect gRPC worker metrics by aggregating `PROMETHEUS_MULTIPROC_DIR` via a python3 subprocess.
+async fn collect_prometheus_multiproc_metrics() -> Result<String, String> {
+    let dir = std::env::var("PROMETHEUS_MULTIPROC_DIR").map_err(|_| {
+        "PROMETHEUS_MULTIPROC_DIR not set; cannot collect metrics from gRPC workers".to_string()
+    })?;
+
+    let output = tokio::process::Command::new("python3")
+        .args([
+            "-c",
+            "import sys\n\
+             from prometheus_client import CollectorRegistry, generate_latest\n\
+             from prometheus_client.multiprocess import MultiProcessCollector\n\
+             registry = CollectorRegistry()\n\
+             MultiProcessCollector(registry)\n\
+             sys.stdout.buffer.write(generate_latest(registry))\n",
+        ])
+        .env("PROMETHEUS_MULTIPROC_DIR", &dir)
+        .output()
+        .await
+        .map_err(|e| format!("failed to run python3 prometheus collector: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("python3 prometheus collector failed: {stderr}"));
+    }
+
+    String::from_utf8(output.stdout)
+        .map_err(|e| format!("prometheus collector output is not valid UTF-8: {e}"))
+}
+
+pub struct WorkerManager;
+
+impl WorkerManager {
+    pub fn get_worker_urls(registry: &Arc<WorkerRegistry>) -> Vec<String> {
+        registry
+            .get_all()
+            .iter()
+            .map(|w| w.url().to_string())
+            .collect()
+    }
+
+    pub async fn flush_cache_all(
+        worker_registry: &WorkerRegistry,
+        client: &reqwest::Client,
+    ) -> FlushCacheResult {
+        let workers = worker_registry.get_all();
+        let total_workers = workers.len();
+
+        let http_workers: Vec<_> = workers
+            .into_iter()
+            .filter(|w| matches!(w.connection_mode(), ConnectionMode::Http))
+            .collect();
+
+        if http_workers.is_empty() {
+            return FlushCacheResult {
+                successful: vec![],
+                failed: vec![],
+                total_workers,
+                http_workers: 0,
+                message: "No HTTP workers available for cache flush".to_string(),
+            };
+        }
+
+        info!(
+            "Flushing cache on {} HTTP workers (out of {} total)",
+            http_workers.len(),
+            total_workers
+        );
+
+        let responses = fan_out(&http_workers, client, "flush_cache", reqwest::Method::POST).await;
+
+        let mut successful = Vec::new();
+        let mut failed = Vec::new();
+
+        for resp in responses {
+            match resp.result {
+                Ok(r) if r.status().is_success() => successful.push(resp.url),
+                Ok(r) => failed.push((resp.url, format!("HTTP {}", r.status()))),
+                Err(e) => failed.push((resp.url, e.to_string())),
+            }
+        }
+
+        let message = if failed.is_empty() {
+            format!(
+                "Successfully flushed cache on all {} HTTP workers",
+                successful.len()
+            )
+        } else {
+            format!(
+                "Cache flush: {} succeeded, {} failed",
+                successful.len(),
+                failed.len()
+            )
+        };
+
+        info!("{}", message);
+
+        FlushCacheResult {
+            successful,
+            failed,
+            total_workers,
+            http_workers: http_workers.len(),
+            message,
+        }
+    }
+
+    pub async fn get_all_worker_loads(
+        worker_registry: &WorkerRegistry,
+        client: &reqwest::Client,
+    ) -> WorkerLoadsResult {
+        let workers = worker_registry.get_all();
+        let total_workers = workers.len();
+
+        let futures: Vec<_> = workers
+            .iter()
+            .map(|worker| {
+                let worker_type = match worker.worker_type() {
+                    WorkerType::Regular => None,
+                    WorkerType::Prefill => Some("prefill".to_string()),
+                    WorkerType::Decode => Some("decode".to_string()),
+                };
+                let connection_mode = worker.connection_mode();
+                let client = client.clone();
+                let worker = Arc::clone(worker);
+
+                async move {
+                    let details = match connection_mode {
+                        ConnectionMode::Http => Self::fetch_http_load(&client, &worker).await,
+                        ConnectionMode::Grpc => Self::fetch_grpc_load(&worker).await,
+                    };
+                    let load = details
+                        .as_ref()
+                        .map(|d| d.total_used_tokens() as isize)
+                        .unwrap_or(-1);
+                    WorkerLoadInfo {
+                        worker: worker.url().to_string(),
+                        worker_type,
+                        load,
+                        details,
+                    }
+                }
+            })
+            .collect();
+
+        let loads = future::join_all(futures).await;
+        let successful = loads.iter().filter(|l| l.load >= 0).count();
+        let failed = loads.iter().filter(|l| l.load < 0).count();
+
+        WorkerLoadsResult {
+            loads,
+            total_workers,
+            successful,
+            failed,
+        }
+    }
+
+    /// Fetch load via HTTP using the /v1/loads endpoint.
+    /// Returns the full `WorkerLoadResponse` or `None` on failure.
+    async fn fetch_http_load(
+        client: &reqwest::Client,
+        worker: &Arc<dyn Worker>,
+    ) -> Option<WorkerLoadResponse> {
+        let url = worker.url();
+        let load_url = format!("{url}/v1/loads?include=core");
+        let mut req = client.get(&load_url).timeout(REQUEST_TIMEOUT);
+        if let Some(key) = worker.api_key() {
+            req = req.bearer_auth(key);
+        }
+
+        let resp = match req.send().await {
+            Ok(r) if r.status().is_success() => r,
+            _ => return None,
+        };
+
+        let response: WorkerLoadResponse = resp.json().await.ok()?;
+
+        if response.loads.is_empty() {
+            return None;
+        }
+
+        Some(response)
+    }
+
+    /// Fetch load via gRPC using the GetLoads RPC.
+    /// Only supported for SGLang backends.
+    async fn fetch_grpc_load(worker: &Arc<dyn Worker>) -> Option<WorkerLoadResponse> {
+        let grpc_client = match worker.get_grpc_client().await {
+            Ok(Some(client)) => client,
+            Ok(None) => {
+                debug!("No gRPC client for worker {}", worker.url());
+                return None;
+            }
+            Err(e) => {
+                debug!("Failed to get gRPC client for {}: {e}", worker.url());
+                return None;
+            }
+        };
+
+        match grpc_client.get_loads().await {
+            Ok(load) if !load.loads.is_empty() => Some(load),
+            Ok(_) => None,
+            Err(e) => {
+                debug!("gRPC GetLoads failed for {}: {e}", worker.url());
+                None
+            }
+        }
+    }
+
+    pub async fn get_engine_metrics(
+        worker_registry: &WorkerRegistry,
+        client: &reqwest::Client,
+    ) -> EngineMetricsResult {
+        let workers = worker_registry.get_all();
+
+        if workers.is_empty() {
+            return EngineMetricsResult::Err("No available workers".to_string());
+        }
+
+        let mut metric_packs = Vec::new();
+
+        let http_workers: Vec<_> = workers
+            .iter()
+            .filter(|w| matches!(w.connection_mode(), ConnectionMode::Http))
+            .cloned()
+            .collect();
+        let has_grpc = workers
+            .iter()
+            .any(|w| matches!(w.connection_mode(), ConnectionMode::Grpc));
+
+        if !http_workers.is_empty() {
+            let responses =
+                fan_out(&http_workers, client, "metrics", reqwest::Method::GET).await;
+            for resp in responses {
+                if let Ok(r) = resp.result {
+                    if r.status().is_success() {
+                        if let Ok(text) = r.text().await {
+                            metric_packs.push(MetricPack {
+                                labels: vec![("worker_addr".into(), resp.url)],
+                                metrics_text: text,
+                            });
+                        }
+                    }
+                }
+            }
+        }
+
+        if has_grpc {
+            match collect_prometheus_multiproc_metrics().await {
+                Ok(text) => {
+                    metric_packs.push(MetricPack {
+                        labels: vec![],
+                        metrics_text: text,
+                    });
+                }
+                Err(e) => {
+                    warn!("Failed to collect gRPC worker metrics from PROMETHEUS_MULTIPROC_DIR: {e}");
+                }
+            }
+        }
+
+        if metric_packs.is_empty() {
+            return EngineMetricsResult::Err("All backend requests failed".to_string());
+        }
+
+        match metrics_aggregator::aggregate_metrics(metric_packs) {
+            Ok(text) => EngineMetricsResult::Ok(text),
+            Err(e) => EngineMetricsResult::Err(format!("Failed to aggregate metrics: {e}")),
+        }
+    }
+}
+
+/// Load monitoring service that periodically fetches worker loads.
+///
+/// Maintains separate polling loops per worker group (model_id × worker_type × connection_mode).
+/// Groups are started/stopped automatically when workers are registered/removed.
+pub struct LoadMonitor {
+    worker_registry: Arc<WorkerRegistry>,
+    policy_registry: Arc<PolicyRegistry>,
+    pub worker_load_manager: Arc<WorkerLoadManager>,
+    client: reqwest::Client,
+    default_interval: Duration,
+    tx: watch::Sender<HashMap<String, WorkerLoadResponse>>,
+    rx: watch::Receiver<HashMap<String, WorkerLoadResponse>>,
+    /// Per-group polling handles
+    group_handles: Arc<Mutex<HashMap<WorkerGroupKey, JoinHandle<()>>>>,
+}
+
+impl LoadMonitor {
+    pub fn new(
+        worker_registry: Arc<WorkerRegistry>,
+        policy_registry: Arc<PolicyRegistry>,
+        client: reqwest::Client,
+        default_interval_secs: u64,
+    ) -> Self {
+        let (tx, rx) = watch::channel(HashMap::new());
+
+        Self {
+            worker_registry,
+            policy_registry,
+            worker_load_manager: Arc::new(WorkerLoadManager::new()),
+            client,
+            default_interval: Duration::from_secs(default_interval_secs),
+            tx,
+            rx,
+            group_handles: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Start polling for a worker group. If the group already has a running loop, this is a no-op.
+    ///
+    /// `interval` is the per-worker override from `WorkerSpec.load_monitor_interval_secs`.
+    /// Falls back to `self.default_interval` when `None`.
+    pub async fn on_group_added(&self, key: WorkerGroupKey, interval: Option<u64>) {
+        let mut handles = self.group_handles.lock().await;
+        if handles.contains_key(&key) {
+            debug!("Load monitor group already running: {key}");
+            return;
+        }
+
+        // Floor at 1s to prevent tight-loop DoS from a zero interval.
+        let interval = interval
+            .map(|s| Duration::from_secs(s.max(1)))
+            .unwrap_or(self.default_interval)
+            .max(Duration::from_secs(1));
+
+        info!("Starting load monitor for group {key} with interval {interval:?}");
+
+        let worker_registry = Arc::clone(&self.worker_registry);
+        let policy_registry = Arc::clone(&self.policy_registry);
+        let worker_load_manager = Arc::clone(&self.worker_load_manager);
+        let client = self.client.clone();
+        let tx = self.tx.clone();
+        let group_key = key.clone();
+
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "Load monitor loop: runs for the lifetime of the group, handle is stored and abort() is called on removal"
+        )]
+        let handle = tokio::spawn(async move {
+            Self::group_monitor_loop(
+                group_key,
+                worker_registry,
+                policy_registry,
+                worker_load_manager,
+                client,
+                interval,
+                tx,
+            )
+            .await;
+        });
+
+        handles.insert(key, handle);
+    }
+
+    /// Stop polling for a worker group and clean up its entries from the shared load map.
+    ///
+    /// `worker_urls` must be provided by the caller because this is called *after*
+    /// workers have been removed from the registry (so we can't look them up).
+    pub async fn on_group_removed(&self, key: &WorkerGroupKey, worker_urls: &[String]) {
+        let handle = {
+            let mut handles = self.group_handles.lock().await;
+            handles.remove(key)
+        };
+        if let Some(handle) = handle {
+            info!("Stopping load monitor for group {key}");
+            handle.abort();
+            let _ = handle.await;
+        }
+
+        // Remove stale load entries regardless of whether a handle was found,
+        // since entries could exist from a previous monitoring cycle.
+        if !worker_urls.is_empty() {
+            self.tx.send_modify(|map| {
+                for url in worker_urls {
+                    map.remove(url);
+                }
+            });
+            // Also remove from worker load manager's DP cached loads
+            self.worker_load_manager.remove_workers(worker_urls);
+        }
+    }
+
+    /// Stop all group polling loops.
+    pub async fn stop(&self) {
+        let handles: HashMap<WorkerGroupKey, JoinHandle<()>> = {
+            let mut guard = self.group_handles.lock().await;
+            std::mem::take(&mut *guard)
+        };
+
+        if handles.is_empty() {
+            return;
+        }
+
+        info!("Stopping all {} load monitor groups", handles.len());
+        for (key, handle) in handles {
+            debug!("Stopping load monitor group: {key}");
+            handle.abort();
+            let _ = handle.await;
+        }
+    }
+
+    pub fn subscribe(&self) -> watch::Receiver<HashMap<String, WorkerLoadResponse>> {
+        self.rx.clone()
+    }
+
+    /// Polling loop for a single worker group.
+    async fn group_monitor_loop(
+        group_key: WorkerGroupKey,
+        worker_registry: Arc<WorkerRegistry>,
+        policy_registry: Arc<PolicyRegistry>,
+        worker_load_manager: Arc<WorkerLoadManager>,
+        client: reqwest::Client,
+        interval: Duration,
+        tx: watch::Sender<HashMap<String, WorkerLoadResponse>>,
+    ) {
+        let mut interval_timer = tokio::time::interval(interval);
+
+        loop {
+            interval_timer.tick().await;
+
+            let power_of_two_policies = policy_registry.get_all_power_of_two_policies();
+            if power_of_two_policies.is_empty() && policy_registry.get_dp_rank_policy().is_none() {
+                debug!("No PowerOfTwo policies found, skipping load fetch for group {group_key}");
+                continue;
+            }
+
+            // Get workers for this specific group
+            let workers = worker_registry.get_workers_filtered(
+                Some(&group_key.model_id),
+                Some(group_key.worker_type),
+                Some(group_key.connection_mode),
+                None,
+                false,
+            );
+
+            if workers.is_empty() {
+                debug!("No workers in group {group_key}, skipping");
+                continue;
+            }
+
+            // Fetch loads for all workers in this group
+            let futures: Vec<_> = workers
+                .iter()
+                .map(|worker| {
+                    let client = client.clone();
+                    let worker = Arc::clone(worker);
+                    let connection_mode = group_key.connection_mode;
+
+                    async move {
+                        let response = match connection_mode {
+                            ConnectionMode::Http => {
+                                WorkerManager::fetch_http_load(&client, &worker).await
+                            }
+                            ConnectionMode::Grpc => WorkerManager::fetch_grpc_load(&worker).await,
+                        };
+                        (worker.url().to_string(), response)
+                    }
+                })
+                .collect();
+
+            let results = future::join_all(futures).await;
+
+            // Collect successful loads
+            let mut group_loads: HashMap<String, WorkerLoadResponse> = HashMap::new();
+            let mut group_dp_loads: HashMap<String, HashMap<isize, isize>> = HashMap::new();
+            for (url, response) in results {
+                if let Some(load) = response {
+                    group_loads.insert(url.clone(), load.clone());
+                    let dp_rank_loads = load.dp_rank_loads();
+                    group_dp_loads.insert(url, dp_rank_loads);
+                }
+            }
+
+            if group_loads.is_empty() {
+                debug!("No loads fetched for group {group_key}");
+                continue;
+            }
+
+            debug!(
+                "Fetched loads from {}/{} workers in group {group_key}",
+                group_loads.len(),
+                workers.len()
+            );
+
+            // Update policies with this group's loads
+            for policy in &power_of_two_policies {
+                policy.update_loads(&group_loads);
+            }
+            worker_load_manager.update_dp_loads(&group_dp_loads);
+
+            // Atomically merge into the shared watch channel.
+            // Remove all group URLs first to clear stale entries from workers
+            // that failed this tick, then insert successful loads.
+            let all_group_urls: Vec<String> = workers.iter().map(|w| w.url().to_string()).collect();
+            tx.send_modify(|map| {
+                for url in &all_group_urls {
+                    map.remove(url);
+                }
+                map.extend(group_loads);
+            });
+        }
+    }
+
+    /// Check if any group polling loop is running.
+    pub async fn is_running(&self) -> bool {
+        let handles = self.group_handles.lock().await;
+        !handles.is_empty()
+    }
+}
+
+impl Drop for LoadMonitor {
+    fn drop(&mut self) {
+        if let Ok(mut handles) = self.group_handles.try_lock() {
+            for (_, handle) in handles.drain() {
+                handle.abort();
+            }
+        }
+    }
+}

--- a/model_gateway/src/observability/metrics_server.rs
+++ b/model_gateway/src/observability/metrics_server.rs
@@ -1,9 +1,13 @@
 //! HTTP/WebSocket server for the Prometheus metrics endpoint (port 29000).
 //! Serves `GET /metrics` (Prometheus) and `WS /ws/metrics` (real-time state push).
+//!
+//! The `/metrics` endpoint returns both SMG's own metrics (`smg_*`) and engine
+//! metrics (`vllm_*`, `sglang_*`, `nv_trt_*`) in a single Prometheus text
+//! response, so Prometheus only needs one scrape target per pod.
 
 use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
-    sync::{atomic::AtomicUsize, Arc},
+    sync::{atomic::AtomicUsize, Arc, OnceLock},
     time::Duration,
 };
 
@@ -16,9 +20,31 @@ use super::{
     metrics::UPKEEP_INTERVAL_SECS,
     metrics_ws::{handler, registry::WatchRegistry},
 };
+use crate::worker::{
+    manager::{EngineMetricsResult, WorkerManager},
+    registry::WorkerRegistry,
+};
 
 /// Default maximum concurrent WebSocket connections on the metrics endpoint.
 pub const DEFAULT_MAX_WS_CONNECTIONS: usize = 32;
+
+/// Shared references for engine metrics collection, populated after app init.
+pub struct EngineMetricsDeps {
+    pub worker_registry: Arc<WorkerRegistry>,
+    pub client: reqwest::Client,
+}
+
+/// Global handle set once after AppContext is built.
+static ENGINE_METRICS_DEPS: OnceLock<EngineMetricsDeps> = OnceLock::new();
+
+/// Register the worker registry and HTTP client for engine metrics collection.
+/// Called once after AppContext is initialized.
+pub fn register_engine_metrics_deps(worker_registry: Arc<WorkerRegistry>, client: reqwest::Client) {
+    let _ = ENGINE_METRICS_DEPS.set(EngineMetricsDeps {
+        worker_registry,
+        client,
+    });
+}
 
 #[derive(Clone)]
 struct MetricsState {
@@ -26,12 +52,23 @@ struct MetricsState {
 }
 
 async fn prometheus_handler(State(state): State<MetricsState>) -> impl IntoResponse {
+    let smg_text = state.handle.render();
+
+    let engine_text = if let Some(deps) = ENGINE_METRICS_DEPS.get() {
+        match WorkerManager::get_engine_metrics(&deps.worker_registry, &deps.client).await {
+            EngineMetricsResult::Ok(text) => text,
+            EngineMetricsResult::Err(_) => String::new(),
+        }
+    } else {
+        String::new()
+    };
+
     (
         [(
             http::header::CONTENT_TYPE,
             "text/plain; version=0.0.4; charset=utf-8",
         )],
-        state.handle.render(),
+        format!("{smg_text}\n{engine_text}"),
     )
 }
 

--- a/model_gateway/src/observability/metrics_server.rs
+++ b/model_gateway/src/observability/metrics_server.rs
@@ -35,12 +35,8 @@ async fn prometheus_handler(State(state): State<MetricsState>) -> impl IntoRespo
     )
 }
 
-/// Start the metrics HTTP/WS server. Binds eagerly so callers fail fast on
-/// port conflicts or bad addresses.
-#[expect(
-    clippy::expect_used,
-    reason = "startup initialization — metrics server must bind or the process cannot serve metrics"
-)]
+/// Start the metrics HTTP/WS server. If the port is unavailable, logs an error
+/// and returns a no-op handle so the router can still operate.
 pub async fn start_metrics_server(
     handle: PrometheusHandle,
     host: String,
@@ -54,9 +50,17 @@ pub async fn start_metrics_server(
     });
     let addr = SocketAddr::new(ip_addr, port);
 
-    let listener = tokio::net::TcpListener::bind(addr)
-        .await
-        .expect("failed to bind metrics server");
+    let listener = match tokio::net::TcpListener::bind(addr).await {
+        Ok(l) => l,
+        Err(e) => {
+            error!("failed to bind metrics server on {addr}: {e} — metrics will be unavailable");
+            #[expect(
+                clippy::disallowed_methods,
+                reason = "no-op task for graceful degradation"
+            )]
+            return tokio::spawn(async {});
+        }
+    };
 
     info!("Metrics server listening on {addr} (/metrics + /ws/metrics)");
 

--- a/model_gateway/src/routers/grpc/common/stages/request_execution.rs
+++ b/model_gateway/src/routers/grpc/common/stages/request_execution.rs
@@ -1,8 +1,10 @@
 //! Request execution stage: Execute gRPC requests (single or dual dispatch)
 
+use std::time::Instant;
+
 use async_trait::async_trait;
 use axum::response::Response;
-use tracing::{debug, error, info_span, Instrument};
+use tracing::{debug, error, info, info_span, warn, Instrument};
 
 use super::PipelineStage;
 use crate::{
@@ -173,8 +175,31 @@ impl RequestExecutionStage {
             )
         })?;
 
+        let send_start = Instant::now();
         let result = client.generate(proto_request).await;
+        let backend_duration_ms = send_start.elapsed().as_millis() as u64;
         workers.record_outcome(result.cb_status_code());
+
+        let worker_url = workers.single().map(|w| w.url()).unwrap_or("unknown");
+        match &result {
+            Ok(_) => {
+                info!(
+                    target: "smg::upstream",
+                    worker_url,
+                    duration_ms = backend_duration_ms,
+                    "Backend request completed"
+                );
+            }
+            Err(e) => {
+                warn!(
+                    target: "smg::upstream",
+                    worker_url,
+                    duration_ms = backend_duration_ms,
+                    error = %e.message(),
+                    "Backend request failed"
+                );
+            }
+        }
 
         let stream = result.map_err(|e| {
             error!(function = "execute_single", error = %e, "Failed to start generation");

--- a/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
+++ b/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use axum::response::Response;
-use tracing::{error, warn};
+use tracing::{error, info, warn};
 
 use super::PipelineStage;
 use crate::{
@@ -182,6 +182,14 @@ impl WorkerSelectionStage {
             policy.name(),
         );
 
+        info!(
+            target: "smg::routing",
+            model_id = model_id,
+            policy = policy.name(),
+            selected_worker = selected.url(),
+            "Worker selected"
+        );
+
         Some(selected)
     }
 
@@ -300,6 +308,15 @@ impl WorkerSelectionStage {
             metrics_labels::CONNECTION_GRPC,
             model,
             policy_name,
+        );
+
+        info!(
+            target: "smg::routing",
+            model_id = model,
+            policy = policy_name,
+            prefill_worker = available_prefill[prefill_idx].url(),
+            decode_worker = available_decode[decode_idx].url(),
+            "PD pair selected"
         );
 
         Some((

--- a/model_gateway/src/routers/grpc/pd_router.rs
+++ b/model_gateway/src/routers/grpc/pd_router.rs
@@ -1,7 +1,11 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use axum::{http::HeaderMap, response::Response};
+use axum::{
+    body::Body,
+    http::{HeaderMap, Request, StatusCode},
+    response::{IntoResponse, Response},
+};
 use openai_protocol::{
     chat::ChatCompletionRequest, completion::CompletionRequest, generate::GenerateRequest,
     messages::CreateMessageRequest,
@@ -382,6 +386,36 @@ impl std::fmt::Debug for GrpcPDRouter {
 impl RouterTrait for GrpcPDRouter {
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+
+    async fn health_generate(&self, _req: Request<Body>) -> Response {
+        let workers = self.worker_registry.get_all();
+        if workers.is_empty() {
+            return (StatusCode::SERVICE_UNAVAILABLE, "No workers registered").into_response();
+        }
+        let (healthy, unhealthy): (Vec<_>, Vec<_>) = workers.iter().partition(|w| w.is_healthy());
+        if unhealthy.is_empty() {
+            (
+                StatusCode::OK,
+                format!("OK - {} workers healthy", healthy.len()),
+            )
+                .into_response()
+        } else {
+            let info: Vec<_> = unhealthy
+                .iter()
+                .map(|w| format!("{} ({})", w.model_id(), w.url()))
+                .collect();
+            (
+                StatusCode::SERVICE_UNAVAILABLE,
+                format!(
+                    "{}/{} workers unhealthy: {}",
+                    unhealthy.len(),
+                    workers.len(),
+                    info.join(", ")
+                ),
+            )
+                .into_response()
+        }
     }
 
     async fn route_generate(

--- a/model_gateway/src/routers/grpc/router.rs
+++ b/model_gateway/src/routers/grpc/router.rs
@@ -2,7 +2,8 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use axum::{
-    http::HeaderMap,
+    body::Body,
+    http::{HeaderMap, Request, StatusCode},
     response::{IntoResponse, Response},
 };
 use openai_protocol::{
@@ -508,6 +509,36 @@ impl std::fmt::Debug for GrpcRouter {
 impl RouterTrait for GrpcRouter {
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+
+    async fn health_generate(&self, _req: Request<Body>) -> Response {
+        let workers = self.worker_registry.get_all();
+        if workers.is_empty() {
+            return (StatusCode::SERVICE_UNAVAILABLE, "No workers registered").into_response();
+        }
+        let (healthy, unhealthy): (Vec<_>, Vec<_>) = workers.iter().partition(|w| w.is_healthy());
+        if unhealthy.is_empty() {
+            (
+                StatusCode::OK,
+                format!("OK - {} workers healthy", healthy.len()),
+            )
+                .into_response()
+        } else {
+            let info: Vec<_> = unhealthy
+                .iter()
+                .map(|w| format!("{} ({})", w.model_id(), w.url()))
+                .collect();
+            (
+                StatusCode::SERVICE_UNAVAILABLE,
+                format!(
+                    "{}/{} workers unhealthy: {}",
+                    unhealthy.len(),
+                    workers.len(),
+                    info.join(", ")
+                ),
+            )
+                .into_response()
+        }
     }
 
     async fn route_generate(

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -21,7 +21,7 @@ use serde::Serialize;
 use serde_json::{json, Value};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::UnboundedReceiverStream;
-use tracing::{debug, error, warn};
+use tracing::{debug, error, info, warn};
 
 use super::pd_types::api_path;
 use crate::{
@@ -638,16 +638,36 @@ impl PDRouter {
         // hits a transport error, the other is cancelled immediately — otherwise
         // the surviving request hangs waiting for a PD bootstrap that will never
         // come (see #831).
+        let send_start = Instant::now();
         let pd_result = tokio::try_join!(prefill_request.send(), decode_request.send());
+        let backend_duration_ms = send_start.elapsed().as_millis() as u64;
 
         events::RequestReceivedEvent {}.emit();
 
         let (prefill_response, decode_response) = match pd_result {
-            Ok((prefill_resp, decode_resp)) => (prefill_resp, decode_resp),
+            Ok((prefill_resp, decode_resp)) => {
+                info!(
+                    target: "smg::upstream",
+                    prefill_url = prefill.url(),
+                    decode_url = decode.url(),
+                    prefill_status = prefill_resp.status().as_u16(),
+                    decode_status = decode_resp.status().as_u16(),
+                    duration_ms = backend_duration_ms,
+                    streaming = context.is_stream,
+                    "PD backend request completed"
+                );
+                (prefill_resp, decode_resp)
+            }
             Err(e) => {
+                warn!(
+                    target: "smg::upstream",
+                    prefill_url = prefill.url(),
+                    decode_url = decode.url(),
+                    duration_ms = backend_duration_ms,
+                    error = %e,
+                    "PD backend request failed"
+                );
                 error!("PD request transport error, both sides aborted: {e}");
-                // Don't record_outcome here — the caller (execute_dual_dispatch)
-                // records outcomes from the response status after we return.
                 return error::bad_gateway(
                     "PD disaggregation request failed",
                     format!("Transport error: {e}"),
@@ -825,6 +845,16 @@ impl PDRouter {
             metrics_labels::CONNECTION_HTTP,
             model,
             decode_policy.name(),
+        );
+
+        info!(
+            target: "smg::routing",
+            model_id = model,
+            prefill_policy = prefill_policy.name(),
+            decode_policy = decode_policy.name(),
+            prefill_worker = prefill.url(),
+            decode_worker = decode.url(),
+            "PD pair selected"
         );
 
         Ok((prefill, decode))

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -21,7 +21,7 @@ use openai_protocol::{
 use reqwest::Client;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::UnboundedReceiverStream;
-use tracing::error;
+use tracing::{error, info, warn};
 
 use crate::{
     app_context::AppContext,
@@ -185,6 +185,14 @@ impl Router {
             policy.name(),
         );
 
+        info!(
+            target: "smg::routing",
+            model_id = model_id,
+            policy = policy.name(),
+            selected_worker = available[idx].url(),
+            "Worker selected"
+        );
+
         Some(available[idx].clone())
     }
 
@@ -321,6 +329,7 @@ impl Router {
         inject_trace_context_http(&mut headers_with_trace);
         let headers = Some(&headers_with_trace);
 
+        let send_start = Instant::now();
         let response = self
             .send_typed_request(
                 headers,
@@ -331,18 +340,35 @@ impl Router {
                 load_guard,
             )
             .await;
+        let backend_duration_ms = send_start.elapsed().as_millis() as u64;
 
         events::RequestReceivedEvent {}.emit();
 
         let status = response.status();
         worker.record_outcome(status.as_u16());
 
-        // Record worker errors for server errors (5xx)
         if status.is_server_error() {
             Metrics::record_worker_error(
                 metrics_labels::WORKER_REGULAR,
                 metrics_labels::CONNECTION_HTTP,
                 error_type_from_status(status),
+            );
+            warn!(
+                target: "smg::upstream",
+                worker_url = worker.url(),
+                status = status.as_u16(),
+                duration_ms = backend_duration_ms,
+                streaming = is_stream,
+                "Backend request failed"
+            );
+        } else {
+            info!(
+                target: "smg::upstream",
+                worker_url = worker.url(),
+                status = status.as_u16(),
+                duration_ms = backend_duration_ms,
+                streaming = is_stream,
+                "Backend request completed"
             );
         }
 

--- a/model_gateway/src/routers/openai/health.rs
+++ b/model_gateway/src/routers/openai/health.rs
@@ -1,7 +1,5 @@
 //! Health check and server info endpoints for the OpenAI router.
 
-use std::sync::Arc;
-
 use axum::{
     http::StatusCode,
     response::{IntoResponse, Response},
@@ -11,21 +9,13 @@ use serde_json::json;
 
 use crate::{
     routers::error,
-    worker::{RuntimeType, Worker, WorkerRegistry},
+    worker::registry::WorkerRegistry,
 };
 
-fn external_workers(registry: &WorkerRegistry) -> Vec<Arc<dyn Worker>> {
-    registry
-        .get_all()
-        .into_iter()
-        .filter(|w| w.metadata().spec.runtime_type == RuntimeType::External)
-        .collect()
-}
-
 pub(super) fn health_generate(registry: &WorkerRegistry) -> Response {
-    let workers = external_workers(registry);
+    let workers = registry.get_all();
     if workers.is_empty() {
-        return error::service_unavailable("service_unavailable", "No external workers registered");
+        return error::service_unavailable("service_unavailable", "No workers registered");
     }
 
     let (healthy, unhealthy): (Vec<_>, Vec<_>) = workers.iter().partition(|w| w.is_healthy());
@@ -55,13 +45,12 @@ pub(super) fn health_generate(registry: &WorkerRegistry) -> Response {
 
 pub(super) fn get_server_info(registry: &WorkerRegistry) -> Response {
     let stats = registry.stats();
-    let workers = external_workers(registry);
+    let workers = registry.get_all();
     let worker_urls: Vec<_> = workers.iter().map(|w| w.url()).collect();
 
     let info = json!({
         "router_type": "openai",
         "total_workers": stats.total_workers,
-        "external_workers": workers.len(),
         "healthy_workers": stats.healthy_workers,
         "total_models": stats.total_models,
         "worker_urls": worker_urls

--- a/model_gateway/src/routers/openai/health.rs
+++ b/model_gateway/src/routers/openai/health.rs
@@ -7,10 +7,7 @@ use axum::{
 };
 use serde_json::json;
 
-use crate::{
-    routers::error,
-    worker::registry::WorkerRegistry,
-};
+use crate::{routers::error, worker::registry::WorkerRegistry};
 
 pub(super) fn health_generate(registry: &WorkerRegistry) -> Response {
     let workers = registry.get_all();

--- a/model_gateway/src/server.rs
+++ b/model_gateway/src/server.rs
@@ -944,6 +944,10 @@ pub async fn startup(config: ServerConfig) -> Result<(), Box<dyn std::error::Err
 
     if config.prometheus_config.is_some() {
         app_context.inflight_tracker.start_sampler(20);
+        metrics_server::register_engine_metrics_deps(
+            app_context.worker_registry.clone(),
+            app_context.client.clone(),
+        );
     }
 
     // Start WS metrics collectors now that AppContext is available.

--- a/model_gateway/src/worker/manager.rs
+++ b/model_gateway/src/worker/manager.rs
@@ -823,8 +823,7 @@ impl WorkerManager {
             .collect();
 
         if !http_workers.is_empty() {
-            let responses =
-                fan_out(&http_workers, client, "metrics", reqwest::Method::GET).await;
+            let responses = fan_out(&http_workers, client, "metrics", reqwest::Method::GET).await;
             for resp in responses {
                 if let Ok(r) = resp.result {
                     if r.status().is_success() {
@@ -852,10 +851,7 @@ impl WorkerManager {
                     Ok(r) if r.status().is_success() => {
                         if let Ok(text) = r.text().await {
                             metric_packs.push(MetricPack {
-                                labels: vec![(
-                                    "worker_addr".into(),
-                                    worker.url().to_string(),
-                                )],
+                                labels: vec![("worker_addr".into(), worker.url().to_string())],
                                 metrics_text: text,
                             });
                         }

--- a/model_gateway/src/worker/manager.rs
+++ b/model_gateway/src/worker/manager.rs
@@ -808,17 +808,70 @@ impl WorkerManager {
             return EngineMetricsResult::Err("No available workers".to_string());
         }
 
-        let responses = fan_out(&workers, client, "metrics", reqwest::Method::GET).await;
-
         let mut metric_packs = Vec::new();
-        for resp in responses {
-            if let Ok(r) = resp.result {
-                if r.status().is_success() {
-                    if let Ok(text) = r.text().await {
-                        metric_packs.push(MetricPack {
-                            labels: vec![("worker_addr".into(), resp.url)],
-                            metrics_text: text,
-                        });
+
+        let http_workers: Vec<_> = workers
+            .iter()
+            .filter(|w| matches!(w.connection_mode(), ConnectionMode::Http))
+            .cloned()
+            .collect();
+
+        let grpc_workers: Vec<_> = workers
+            .iter()
+            .filter(|w| matches!(w.connection_mode(), ConnectionMode::Grpc))
+            .cloned()
+            .collect();
+
+        if !http_workers.is_empty() {
+            let responses =
+                fan_out(&http_workers, client, "metrics", reqwest::Method::GET).await;
+            for resp in responses {
+                if let Ok(r) = resp.result {
+                    if r.status().is_success() {
+                        if let Ok(text) = r.text().await {
+                            metric_packs.push(MetricPack {
+                                labels: vec![("worker_addr".into(), resp.url)],
+                                metrics_text: text,
+                            });
+                        }
+                    }
+                }
+            }
+        }
+
+        // gRPC workers expose Prometheus metrics on a separate HTTP port
+        // (gRPC port + 1) when --enable-metrics is passed to sglang.
+        for worker in &grpc_workers {
+            if let Some(metrics_url) = grpc_worker_metrics_url(worker.url()) {
+                match client
+                    .get(&metrics_url)
+                    .timeout(REQUEST_TIMEOUT)
+                    .send()
+                    .await
+                {
+                    Ok(r) if r.status().is_success() => {
+                        if let Ok(text) = r.text().await {
+                            metric_packs.push(MetricPack {
+                                labels: vec![(
+                                    "worker_addr".into(),
+                                    worker.url().to_string(),
+                                )],
+                                metrics_text: text,
+                            });
+                        }
+                    }
+                    Ok(r) => {
+                        warn!(
+                            "gRPC worker metrics endpoint {} returned {}",
+                            metrics_url,
+                            r.status()
+                        );
+                    }
+                    Err(e) => {
+                        warn!(
+                            "Failed to scrape gRPC worker metrics from {}: {e}",
+                            metrics_url
+                        );
                     }
                 }
             }
@@ -833,6 +886,20 @@ impl WorkerManager {
             Err(e) => EngineMetricsResult::Err(format!("Failed to aggregate metrics: {e}")),
         }
     }
+}
+
+/// Derive the HTTP metrics URL for a gRPC worker.
+///
+/// gRPC worker URLs use `grpc://host:port` (with optional `@dp_rank` suffix).
+/// The sglang metrics HTTP endpoint runs on port + 1.
+fn grpc_worker_metrics_url(worker_url: &str) -> Option<String> {
+    let stripped = worker_url
+        .strip_prefix("grpc://")
+        .or_else(|| worker_url.strip_prefix("grpcs://"))?;
+    let (host, port_and_suffix) = stripped.rsplit_once(':')?;
+    let port_str = port_and_suffix.split(['/', '@']).next()?;
+    let port: u16 = port_str.parse().ok()?;
+    Some(format!("http://{host}:{}/metrics", port + 1))
 }
 
 #[cfg(test)]
@@ -1128,5 +1195,24 @@ mod tests {
             registry.get(&worker_id).unwrap().status(),
             WorkerStatus::Ready
         );
+    }
+
+    #[test]
+    fn test_grpc_worker_metrics_url() {
+        assert_eq!(
+            grpc_worker_metrics_url("grpc://localhost:9001"),
+            Some("http://localhost:9002/metrics".to_string()),
+        );
+
+        assert_eq!(
+            grpc_worker_metrics_url("grpc://host:9001@2"),
+            Some("http://host:9002/metrics".to_string()),
+        );
+        assert_eq!(
+            grpc_worker_metrics_url("grpcs://host:443"),
+            Some("http://host:444/metrics".to_string()),
+        );
+        assert_eq!(grpc_worker_metrics_url("http://host:8080"), None);
+        assert_eq!(grpc_worker_metrics_url("invalid"), None);
     }
 }

--- a/model_gateway/src/worker/metrics_aggregator.rs
+++ b/model_gateway/src/worker/metrics_aggregator.rs
@@ -10,15 +10,19 @@ pub struct MetricPack {
 type PrometheusExposition = MetricsExposition<PrometheusType, PrometheusValue>;
 type PrometheusFamily = MetricFamily<PrometheusType, PrometheusValue>;
 
+// SAFETY: openmetrics_parser rejects colons in metric names. We encode colons to
+// this placeholder before parsing and decode back after serialization, preserving
+// the original `namespace:metric_name` colon format in the output.
+const COLON_SENTINEL: &str = "__smgcolon48f__";
+
 /// Aggregate Prometheus metrics scraped from multiple sources into a unified one
 pub fn aggregate_metrics(metric_packs: Vec<MetricPack>) -> anyhow::Result<String> {
     let mut expositions = vec![];
     for metric_pack in metric_packs {
         let metrics_text = &metric_pack.metrics_text;
-        // openmetrics_parser doesn't handle colons in metric names; replace with underscores
-        let metrics_text = metrics_text.replace(":", "_");
+        let encoded = metrics_text.replace(':', COLON_SENTINEL);
 
-        let exposition = match openmetrics_parser::prometheus::parse_prometheus(&metrics_text) {
+        let exposition = match openmetrics_parser::prometheus::parse_prometheus(&encoded) {
             Ok(x) => x,
             Err(err) => {
                 warn!(
@@ -33,7 +37,7 @@ pub fn aggregate_metrics(metric_packs: Vec<MetricPack>) -> anyhow::Result<String
     }
 
     let text = try_reduce(expositions.into_iter(), merge_exposition)?
-        .map(|x| format!("{x}"))
+        .map(|x| format!("{x}").replace(COLON_SENTINEL, ":"))
         .unwrap_or_default();
     Ok(text)
 }
@@ -114,4 +118,63 @@ where
     };
 
     Ok(Some(it.try_fold(first, f)?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn aggregate_preserves_colons_in_metric_names() {
+        let input = concat!(
+            "# HELP sglang:num_running_reqs Number of running requests.\n",
+            "# TYPE sglang:num_running_reqs gauge\n",
+            "sglang:num_running_reqs 42\n",
+        );
+        let packs = vec![MetricPack {
+            labels: vec![("worker".into(), "w0".into())],
+            metrics_text: input.into(),
+        }];
+        let output = aggregate_metrics(packs).unwrap();
+        assert!(
+            output.contains("sglang:num_running_reqs"),
+            "colon in metric name was lost: {output}"
+        );
+    }
+
+    #[test]
+    fn aggregate_preserves_colons_in_label_values() {
+        let input = concat!(
+            "# HELP up Target is up.\n",
+            "# TYPE up gauge\n",
+            "up{addr=\"grpc://host:9001\"} 1\n",
+        );
+        let packs = vec![MetricPack {
+            labels: vec![],
+            metrics_text: input.into(),
+        }];
+        let output = aggregate_metrics(packs).unwrap();
+        assert!(
+            output.contains("grpc://host:9001"),
+            "colon in label value was lost: {output}"
+        );
+    }
+
+    #[test]
+    fn aggregate_leaves_colonless_names_unchanged() {
+        let input = concat!(
+            "# HELP smg_http_requests_total Total HTTP requests.\n",
+            "# TYPE smg_http_requests_total counter\n",
+            "smg_http_requests_total 100\n",
+        );
+        let packs = vec![MetricPack {
+            labels: vec![],
+            metrics_text: input.into(),
+        }];
+        let output = aggregate_metrics(packs).unwrap();
+        assert!(
+            output.contains("smg_http_requests_total"),
+            "colonless metric name was mangled: {output}"
+        );
+    }
 }

--- a/model_gateway/tests/metrics_aggregator_test.rs
+++ b/model_gateway/tests/metrics_aggregator_test.rs
@@ -156,107 +156,107 @@ sglang:num_queue_reqs{model_name="meta-llama/Llama-3.1-8B-Instruct"} 2826.0
         metrics_text: pack1.metrics_text.clone(),
     };
     let result = aggregate_metrics(vec![pack1, pack2]).unwrap();
-    let expected = r#"# HELP sglang_token_usage The token usage
-# TYPE sglang_token_usage gauge
-sglang_token_usage{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker1"} 0.28
-sglang_token_usage{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker2"} 0.28
+    let expected = r#"# HELP sglang:token_usage The token usage
+# TYPE sglang:token_usage gauge
+sglang:token_usage{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker1"} 0.28
+sglang:token_usage{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker2"} 0.28
 
-# HELP sglang_time_to_first_token_seconds Histogram of time to first token in seconds.
-# TYPE sglang_time_to_first_token_seconds histogram
-sglang_time_to_first_token_seconds_bucket{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker1",le="0.001"} 0
-sglang_time_to_first_token_seconds_bucket{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker1",le="0.005"} 0
-sglang_time_to_first_token_seconds_bucket{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker1",le="0.01"} 0
-sglang_time_to_first_token_seconds_bucket{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker1",le="+Inf"} 11008
-sglang_time_to_first_token_seconds_sum{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker1"} 2351897.9474117756
-sglang_time_to_first_token_seconds_count{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker1"} 11008
-sglang_time_to_first_token_seconds_bucket{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker2",le="0.001"} 0
-sglang_time_to_first_token_seconds_bucket{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker2",le="0.005"} 0
-sglang_time_to_first_token_seconds_bucket{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker2",le="0.01"} 0
-sglang_time_to_first_token_seconds_bucket{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker2",le="+Inf"} 11008
-sglang_time_to_first_token_seconds_sum{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker2"} 2351897.9474117756
-sglang_time_to_first_token_seconds_count{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker2"} 11008
+# HELP sglang:time_to_first_token_seconds Histogram of time to first token in seconds.
+# TYPE sglang:time_to_first_token_seconds histogram
+sglang:time_to_first_token_seconds_bucket{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker1",le="0.001"} 0
+sglang:time_to_first_token_seconds_bucket{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker1",le="0.005"} 0
+sglang:time_to_first_token_seconds_bucket{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker1",le="0.01"} 0
+sglang:time_to_first_token_seconds_bucket{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker1",le="+Inf"} 11008
+sglang:time_to_first_token_seconds_sum{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker1"} 2351897.9474117756
+sglang:time_to_first_token_seconds_count{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker1"} 11008
+sglang:time_to_first_token_seconds_bucket{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker2",le="0.001"} 0
+sglang:time_to_first_token_seconds_bucket{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker2",le="0.005"} 0
+sglang:time_to_first_token_seconds_bucket{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker2",le="0.01"} 0
+sglang:time_to_first_token_seconds_bucket{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker2",le="+Inf"} 11008
+sglang:time_to_first_token_seconds_sum{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker2"} 2351897.9474117756
+sglang:time_to_first_token_seconds_count{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker2"} 11008
 
-# HELP sglang_time_per_output_token_seconds Histogram of time per output token in seconds.
-# TYPE sglang_time_per_output_token_seconds histogram
-sglang_time_per_output_token_seconds_bucket{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker1",le="0.005"} 1
-sglang_time_per_output_token_seconds_bucket{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker1",le="0.01"} 73
-sglang_time_per_output_token_seconds_bucket{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker1",le="0.015"} 382
-sglang_time_per_output_token_seconds_bucket{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker1",le="+Inf"} 7400757
-sglang_time_per_output_token_seconds_sum{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker1"} 866964.5791549598
-sglang_time_per_output_token_seconds_count{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker1"} 7400757
-sglang_time_per_output_token_seconds_bucket{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker2",le="0.005"} 1
-sglang_time_per_output_token_seconds_bucket{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker2",le="0.01"} 73
-sglang_time_per_output_token_seconds_bucket{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker2",le="0.015"} 382
-sglang_time_per_output_token_seconds_bucket{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker2",le="+Inf"} 7400757
-sglang_time_per_output_token_seconds_sum{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker2"} 866964.5791549598
-sglang_time_per_output_token_seconds_count{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker2"} 7400757
+# HELP sglang:time_per_output_token_seconds Histogram of time per output token in seconds.
+# TYPE sglang:time_per_output_token_seconds histogram
+sglang:time_per_output_token_seconds_bucket{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker1",le="0.005"} 1
+sglang:time_per_output_token_seconds_bucket{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker1",le="0.01"} 73
+sglang:time_per_output_token_seconds_bucket{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker1",le="0.015"} 382
+sglang:time_per_output_token_seconds_bucket{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker1",le="+Inf"} 7400757
+sglang:time_per_output_token_seconds_sum{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker1"} 866964.5791549598
+sglang:time_per_output_token_seconds_count{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker1"} 7400757
+sglang:time_per_output_token_seconds_bucket{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker2",le="0.005"} 1
+sglang:time_per_output_token_seconds_bucket{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker2",le="0.01"} 73
+sglang:time_per_output_token_seconds_bucket{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker2",le="0.015"} 382
+sglang:time_per_output_token_seconds_bucket{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker2",le="+Inf"} 7400757
+sglang:time_per_output_token_seconds_sum{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker2"} 866964.5791549598
+sglang:time_per_output_token_seconds_count{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker2"} 7400757
 
-# HELP sglang_func_latency_seconds Function latency in seconds
-# TYPE sglang_func_latency_seconds histogram
-sglang_func_latency_seconds_bucket{name="generate_request",source="worker1",le="0.05"} 14006
-sglang_func_latency_seconds_bucket{name="generate_request",source="worker1",le="0.07500000000000001"} 14006
-sglang_func_latency_seconds_bucket{name="generate_request",source="worker1",le="0.1125"} 14006
-sglang_func_latency_seconds_bucket{name="generate_request",source="worker1",le="0.16875"} 14006
-sglang_func_latency_seconds_bucket{name="generate_request",source="worker1",le="+Inf"} 14007
-sglang_func_latency_seconds_sum{name="generate_request",source="worker1"} 4.514771912145079
-sglang_func_latency_seconds_count{name="generate_request",source="worker1"} 14007
-sglang_func_latency_seconds_bucket{name="generate_request",source="worker2",le="0.05"} 14006
-sglang_func_latency_seconds_bucket{name="generate_request",source="worker2",le="0.07500000000000001"} 14006
-sglang_func_latency_seconds_bucket{name="generate_request",source="worker2",le="0.1125"} 14006
-sglang_func_latency_seconds_bucket{name="generate_request",source="worker2",le="0.16875"} 14006
-sglang_func_latency_seconds_bucket{name="generate_request",source="worker2",le="+Inf"} 14007
-sglang_func_latency_seconds_sum{name="generate_request",source="worker2"} 4.514771912145079
-sglang_func_latency_seconds_count{name="generate_request",source="worker2"} 14007
+# HELP sglang:func_latency_seconds Function latency in seconds
+# TYPE sglang:func_latency_seconds histogram
+sglang:func_latency_seconds_bucket{name="generate_request",source="worker1",le="0.05"} 14006
+sglang:func_latency_seconds_bucket{name="generate_request",source="worker1",le="0.07500000000000001"} 14006
+sglang:func_latency_seconds_bucket{name="generate_request",source="worker1",le="0.1125"} 14006
+sglang:func_latency_seconds_bucket{name="generate_request",source="worker1",le="0.16875"} 14006
+sglang:func_latency_seconds_bucket{name="generate_request",source="worker1",le="+Inf"} 14007
+sglang:func_latency_seconds_sum{name="generate_request",source="worker1"} 4.514771912145079
+sglang:func_latency_seconds_count{name="generate_request",source="worker1"} 14007
+sglang:func_latency_seconds_bucket{name="generate_request",source="worker2",le="0.05"} 14006
+sglang:func_latency_seconds_bucket{name="generate_request",source="worker2",le="0.07500000000000001"} 14006
+sglang:func_latency_seconds_bucket{name="generate_request",source="worker2",le="0.1125"} 14006
+sglang:func_latency_seconds_bucket{name="generate_request",source="worker2",le="0.16875"} 14006
+sglang:func_latency_seconds_bucket{name="generate_request",source="worker2",le="+Inf"} 14007
+sglang:func_latency_seconds_sum{name="generate_request",source="worker2"} 4.514771912145079
+sglang:func_latency_seconds_count{name="generate_request",source="worker2"} 14007
 
-# HELP sglang_num_used_tokens The number of used tokens
-# TYPE sglang_num_used_tokens gauge
-sglang_num_used_tokens{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker1"} 123859
-sglang_num_used_tokens{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker2"} 123859
+# HELP sglang:num_used_tokens The number of used tokens
+# TYPE sglang:num_used_tokens gauge
+sglang:num_used_tokens{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker1"} 123859
+sglang:num_used_tokens{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker2"} 123859
 
-# HELP sglang_cache_hit_rate The cache hit rate
-# TYPE sglang_cache_hit_rate gauge
-sglang_cache_hit_rate{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker1"} 0.007507552643049313
-sglang_cache_hit_rate{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker2"} 0.007507552643049313
+# HELP sglang:cache_hit_rate The cache hit rate
+# TYPE sglang:cache_hit_rate gauge
+sglang:cache_hit_rate{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker1"} 0.007507552643049313
+sglang:cache_hit_rate{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker2"} 0.007507552643049313
 
-# HELP sglang_num_queue_reqs The number of requests in the waiting queue
-# TYPE sglang_num_queue_reqs gauge
-sglang_num_queue_reqs{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker1"} 2826
-sglang_num_queue_reqs{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker2"} 2826
+# HELP sglang:num_queue_reqs The number of requests in the waiting queue
+# TYPE sglang:num_queue_reqs gauge
+sglang:num_queue_reqs{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker1"} 2826
+sglang:num_queue_reqs{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker2"} 2826
 
-# HELP sglang_generation_tokens_total Number of generation tokens processed.
-# TYPE sglang_generation_tokens_total counter
-sglang_generation_tokens_total{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker1"} 7557572
-sglang_generation_tokens_total{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker2"} 7557572
+# HELP sglang:generation_tokens_total Number of generation tokens processed.
+# TYPE sglang:generation_tokens_total counter
+sglang:generation_tokens_total{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker1"} 7557572
+sglang:generation_tokens_total{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker2"} 7557572
 
-# HELP sglang_num_running_reqs The number of running requests
-# TYPE sglang_num_running_reqs gauge
-sglang_num_running_reqs{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker1"} 162
-sglang_num_running_reqs{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker2"} 162
+# HELP sglang:num_running_reqs The number of running requests
+# TYPE sglang:num_running_reqs gauge
+sglang:num_running_reqs{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker1"} 162
+sglang:num_running_reqs{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker2"} 162
 
-# HELP sglang_e2e_request_latency_seconds Histogram of End-to-end request latency in seconds
-# TYPE sglang_e2e_request_latency_seconds histogram
-sglang_e2e_request_latency_seconds_bucket{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker1",le="0.3"} 0
-sglang_e2e_request_latency_seconds_bucket{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker1",le="0.5"} 6
-sglang_e2e_request_latency_seconds_bucket{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker1",le="0.8"} 6
-sglang_e2e_request_latency_seconds_bucket{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker1",le="+Inf"} 11228
-sglang_e2e_request_latency_seconds_sum{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker1"} 3116093.850019932
-sglang_e2e_request_latency_seconds_count{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker1"} 11228
-sglang_e2e_request_latency_seconds_bucket{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker2",le="0.3"} 0
-sglang_e2e_request_latency_seconds_bucket{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker2",le="0.5"} 6
-sglang_e2e_request_latency_seconds_bucket{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker2",le="0.8"} 6
-sglang_e2e_request_latency_seconds_bucket{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker2",le="+Inf"} 11228
-sglang_e2e_request_latency_seconds_sum{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker2"} 3116093.850019932
-sglang_e2e_request_latency_seconds_count{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker2"} 11228
+# HELP sglang:e2e_request_latency_seconds Histogram of End-to-end request latency in seconds
+# TYPE sglang:e2e_request_latency_seconds histogram
+sglang:e2e_request_latency_seconds_bucket{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker1",le="0.3"} 0
+sglang:e2e_request_latency_seconds_bucket{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker1",le="0.5"} 6
+sglang:e2e_request_latency_seconds_bucket{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker1",le="0.8"} 6
+sglang:e2e_request_latency_seconds_bucket{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker1",le="+Inf"} 11228
+sglang:e2e_request_latency_seconds_sum{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker1"} 3116093.850019932
+sglang:e2e_request_latency_seconds_count{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker1"} 11228
+sglang:e2e_request_latency_seconds_bucket{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker2",le="0.3"} 0
+sglang:e2e_request_latency_seconds_bucket{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker2",le="0.5"} 6
+sglang:e2e_request_latency_seconds_bucket{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker2",le="0.8"} 6
+sglang:e2e_request_latency_seconds_bucket{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker2",le="+Inf"} 11228
+sglang:e2e_request_latency_seconds_sum{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker2"} 3116093.850019932
+sglang:e2e_request_latency_seconds_count{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker2"} 11228
 
-# HELP sglang_gen_throughput The generate throughput (token/s)
-# TYPE sglang_gen_throughput gauge
-sglang_gen_throughput{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker1"} 86.50814177726902
-sglang_gen_throughput{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker2"} 86.50814177726902
+# HELP sglang:gen_throughput The generate throughput (token/s)
+# TYPE sglang:gen_throughput gauge
+sglang:gen_throughput{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker1"} 86.50814177726902
+sglang:gen_throughput{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker2"} 86.50814177726902
 
-# HELP sglang_prompt_tokens_total Number of prefill tokens processed.
-# TYPE sglang_prompt_tokens_total counter
-sglang_prompt_tokens_total{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker1"} 8128902
-sglang_prompt_tokens_total{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker2"} 8128902"#;
+# HELP sglang:prompt_tokens_total Number of prefill tokens processed.
+# TYPE sglang:prompt_tokens_total counter
+sglang:prompt_tokens_total{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker1"} 8128902
+sglang:prompt_tokens_total{model_name="meta-llama/Llama-3.1-8B-Instruct",source="worker2"} 8128902"#;
     // result output intentionally omitted for clippy compliance
     assert_eq_sorted(&result, expected);
 }


### PR DESCRIPTION
## Problem

1. In gRPC mode, engine-level metrics (TPS, queue depth, etc.) from the backend worker are not collected because the gateway doesn't read from `PROMETHEUS_MULTIPROC_DIR`.
2. Empty prometheus output during startup causes parse error log spam on every scrape interval.
3. Metrics server panics on port conflict instead of degrading gracefully.

## Solution

- Read and merge engine metrics from `PROMETHEUS_MULTIPROC_DIR` `.db` files in gRPC mode
- Guard against empty prometheus output at both collector and call site
- On bind failure, log error and return no-op handle instead of panicking

## Changes

- `bindings/python/src/smg/serve.py` — set `PROMETHEUS_MULTIPROC_DIR`
- `model_gateway/src/core/worker_manager.rs` — metrics collection + empty output guard
- `model_gateway/src/observability/metrics_server.rs` — graceful bind failure

Co-authored-by: Scott Lee <scott@together.ai>

Checklist:
- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Worker metrics & load monitoring with per-worker load collection, aggregated engine metrics, distributed cache flush, and new health endpoints for generation routes.

* **Bug Fixes**
  * Metrics endpoint now tolerates bind failures and engine-metrics errors; improved backend timing, selection logging, and request-level token timing (TTFT/inter-token) metrics.

* **Chores**
  * Temporary Prometheus multiprocess lifecycle support for gRPC workers (creation & cleanup).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->