### PR TITLE
fix(docker): install smg-grpc-servicer from source in engine images

### DIFF
--- a/docker/engine.Dockerfile
+++ b/docker/engine.Dockerfile
@@ -66,13 +66,4 @@ RUN case "${ENGINE}" in \
          bash /tmp/scripts/install-${ENGINE}.sh /opt/engine-src; \
        fi
 
-# Smoke-test that the engine-specific servicer imports cleanly against the
-# installed engine. Fails the build immediately if an upstream engine refactor
-# breaks our servicer (e.g. sglang moving symbols between submodules).
-RUN case "${ENGINE}" in \
-      sglang) python -c "from smg_grpc_servicer.sglang.servicer import SGLangSchedulerServicer" ;; \
-      vllm)   python -c "from smg_grpc_servicer.vllm.servicer import VllmEngineServicer" ;; \
-      *) ;; \
-    esac
-
 ENTRYPOINT ["smg"]

--- a/docker/engine.Dockerfile
+++ b/docker/engine.Dockerfile
@@ -64,9 +64,15 @@ RUN case "${ENGINE}" in \
     esac \
     && if [ -n "${ENGINE_REPO}" ]; then \
          bash /tmp/scripts/install-${ENGINE}.sh /opt/engine-src; \
-       fi \
-    && if [ "${ENGINE}" = "vllm" ]; then \
-         pip install --no-cache-dir smg-grpc-proto "smg-grpc-servicer[vllm]"; \
        fi
+
+# Smoke-test that the engine-specific servicer imports cleanly against the
+# installed engine. Fails the build immediately if an upstream engine refactor
+# breaks our servicer (e.g. sglang moving symbols between submodules).
+RUN case "${ENGINE}" in \
+      sglang) python -c "from smg_grpc_servicer.sglang.servicer import SGLangSchedulerServicer" ;; \
+      vllm)   python -c "from smg_grpc_servicer.vllm.servicer import VllmEngineServicer" ;; \
+      *) ;; \
+    esac
 
 ENTRYPOINT ["smg"]

--- a/scripts/installation/install-smg.sh
+++ b/scripts/installation/install-smg.sh
@@ -29,3 +29,11 @@ pip install --no-cache-dir --upgrade pip \
 cd "${SMG_SRC}/bindings/python"
 ulimit -n 65536 && maturin build --release --features vendored-openssl --out dist
 pip install --force-reinstall dist/*.whl
+
+# Install smg-grpc-proto and smg-grpc-servicer from source so the image stays
+# in sync with this repo. --force-reinstall overrides any stale version the
+# engine base image may have preinstalled (e.g. lmsysorg/sglang ships an older
+# smg-grpc-servicer pulled from PyPI at its own build time).
+pip install --no-cache-dir --force-reinstall \
+    "${SMG_SRC}/crates/grpc_client/python" \
+    "${SMG_SRC}/grpc_servicer"


### PR DESCRIPTION
## Description

### Problem

Engine images (`ghcr.io/lightseekorg/smg:*-sglang-v0.5.10`, etc.) shipped a stale `smg_grpc_servicer` inherited from whatever the base image (`lmsysorg/sglang:v0.5.10`) happened to preinstall from PyPI at its own build time — **not** the version in the SMG source tree being baked into the image.

When sglang v0.5.10 refactored `srt/utils.py` into the `srt/utils/` subpackage and moved `get_zmq_socket` into `srt/utils/network.py` without re-exporting it at package level, the bundled stale servicer broke at import time:

```
File "/usr/local/lib/python3.12/dist-packages/smg_grpc_servicer/sglang/request_manager.py", line 38
    from sglang.srt.utils import get_or_create_event_loop, get_zmq_socket, kill_process_tree
ImportError: cannot import name 'get_zmq_socket' from 'sglang.srt.utils'
    (/sgl-workspace/sglang/python/sglang/srt/utils/__init__.py)
```

This crash-looped engine pods in production despite the `v1.4.1` source tree already containing the correct import (commit 5321bce1, released as `smg-grpc-servicer 0.5.2` in #1078).

**Why CI didn't catch it:** `scripts/ci_install_sglang.sh` installs the servicer from source (`uv pip install -e grpc_servicer/`), so CI ran against the fixed code. The published Docker image ran against a stale PyPI snapshot baked into the base image. CI and the image were testing two different versions of the same package.

### Solution

Eliminate the PyPI path entirely for engine images. Always install both `smg-grpc-proto` and `smg-grpc-servicer` from the cloned source tree, using `--force-reinstall` to override anything the base image preinstalled. This makes the image a single source of truth that tracks the repo.

## Changes

- `scripts/installation/install-smg.sh`: after installing the `smg` wheel from `bindings/python`, also `pip install --no-cache-dir --force-reinstall` `crates/grpc_client/python` and `grpc_servicer` from the cloned source. No extras activated — engines are already in the base image and we don't want to reinstall `vllm`/`sglang`.
- `docker/engine.Dockerfile`: drop the now-redundant `ENGINE=vllm`-only `pip install smg-grpc-servicer[vllm]` block (covered uniformly by the source install).

## Test Plan

Reproduction **before** this PR (from a crashing pod running `ghcr.io/lightseekorg/smg:1.4.1-sglang-v0.5.10`):

```
$ kubectl run smg-debug --image=ghcr.io/lightseekorg/smg:1.4.1-sglang-v0.5.10 \
    --restart=Never --command -- python3 -c \
    "from smg_grpc_servicer.sglang.servicer import SGLangSchedulerServicer"
...
ImportError: cannot import name 'get_zmq_socket' from 'sglang.srt.utils'
```

**After this PR**, `install-smg.sh` reinstalls `smg-grpc-servicer` from `${SMG_SRC}/grpc_servicer` (which contains the fixed `from sglang.srt.utils.network import get_zmq_socket`) with `--force-reinstall`, overriding the base-image version.

Confirmation that the fix is actually live in the built image comes from the `release-sglang-docker.yml` PR dry-run on this branch: the initial build attempt (commit f091a017) successfully installed from source and got past `request_manager.py:38` — the line the original `get_zmq_socket` ImportError surfaced at — and only failed deeper in the chain at `sgl_kernel` loading (which requires libcuda.so.1 and a real GPU driver, unavailable on a build runner). If the stale base-image servicer had still been active, the failure would have matched the production traceback exactly. That it didn't is proof `--force-reinstall` from source is in effect.

### Note on defense-in-depth

I initially added a `RUN python -c "from smg_grpc_servicer.sglang.servicer import ..."` smoke test to the Dockerfile as defense-in-depth, but reverted it (commit 644980f9) once CI proved it unrunnable: the servicer's import chain transitively loads sglang's `sgl_kernel`, which `dlopen`s `libcuda.so.1` at module init time and requires an NVIDIA driver that doesn't exist on CPU-only docker build runners. The appropriate place for a full import smoke test is a post-build job in `release-sglang-docker.yml` that runs the built image on a GPU runner — that's a separate workflow change and out of scope for this PR.

### Local verification

- `bash -n scripts/installation/install-smg.sh` — syntax OK
- `shellcheck scripts/installation/install-smg.sh` — clean
- `pre-commit run --files docker/engine.Dockerfile scripts/installation/install-smg.sh` — all hooks pass
- `cargo +nightly fmt --all -- --check` — clean (Rust workspace unperturbed; no Rust files in diff)

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes (no-op — zero Rust changes)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (no-op — zero Rust changes)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build & Installation**
  * Removed a previous special-case dependency install for the vLLM engine from the final Docker stage.
  * Added a forced reinstall of gRPC-related Python packages from source after building bindings to ensure installed packages match the current codebase and avoid stale versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->