### PR TITLE
feat(metrics): add serving metrics to gRPC request manager

### DIFF
--- a/grpc_servicer/smg_grpc_servicer/sglang/request_manager.py
+++ b/grpc_servicer/smg_grpc_servicer/sglang/request_manager.py
@@ -215,8 +215,18 @@ class GrpcRequestManager:
         self.enable_metrics = server_args.enable_metrics
         self.metrics_collector = None
         if self.enable_metrics and TokenizerMetricsCollector is not None:
+            # Derive engine_type from disaggregation_mode, matching
+            # SchedulerMetricsCollector (scheduler_metrics_mixin.py).
+            if server_args.disaggregation_mode == "prefill":
+                engine_type = "prefill"
+            elif server_args.disaggregation_mode == "decode":
+                engine_type = "decode"
+            else:
+                engine_type = "unified"
+
             labels = {
                 "model_name": server_args.served_model_name or server_args.model_path,
+                "engine_type": engine_type,
             }
             self.metrics_collector = TokenizerMetricsCollector(
                 server_args=server_args,
@@ -226,7 +236,10 @@ class GrpcRequestManager:
                 bucket_e2e_request_latency=server_args.bucket_e2e_request_latency,
                 collect_tokens_histogram=server_args.collect_tokens_histogram,
             )
-            logger.info("TokenizerMetricsCollector initialized for gRPC mode")
+            logger.info(
+                f"TokenizerMetricsCollector initialized for gRPC mode "
+                f"(engine_type={engine_type})"
+            )
 
         # Crash dump for debugging
         self.crash_dump_request_list = []
@@ -599,28 +612,33 @@ class GrpcRequestManager:
                 continue
 
             # Update timing and record per-token metrics
+            # Mirrors TokenizerManager.collect_metrics() logic exactly.
             completion_tokens = (
                 batch_out.completion_tokens[i] if batch_out.completion_tokens else 0
             )
             if state.time_stats.first_token_time == 0.0:
                 state.time_stats.set_first_token_time()
+            if (
+                not state.ttft_observed
+                and self.disaggregation_mode != DisaggregationMode.PREFILL
+            ):
+                state.ttft_observed = True
                 state.last_completion_tokens = completion_tokens
                 if self.metrics_collector is not None:
                     self.metrics_collector.observe_time_to_first_token(
                         self.metrics_collector.labels,
                         state.time_stats.get_first_token_latency(),
                     )
-                state.ttft_observed = True
             else:
                 num_new_tokens = completion_tokens - state.last_completion_tokens
-                if num_new_tokens > 0 and self.metrics_collector is not None:
+                if num_new_tokens and self.metrics_collector is not None:
                     self.metrics_collector.observe_inter_token_latency(
                         self.metrics_collector.labels,
                         state.time_stats.get_interval(),
                         num_new_tokens,
                     )
-                state.time_stats.set_last_time()
-                state.last_completion_tokens = completion_tokens
+                    state.time_stats.set_last_time()
+                    state.last_completion_tokens = completion_tokens
 
             # Extract output for this request
             output_data = {

--- a/grpc_servicer/smg_grpc_servicer/sglang/request_manager.py
+++ b/grpc_servicer/smg_grpc_servicer/sglang/request_manager.py
@@ -215,19 +215,11 @@ class GrpcRequestManager:
         self.enable_metrics = server_args.enable_metrics
         self.metrics_collector = None
         if self.enable_metrics and TokenizerMetricsCollector is not None:
-            # Derive engine_type from disaggregation_mode, matching
-            # SchedulerMetricsCollector (scheduler_metrics_mixin.py).
-            if server_args.disaggregation_mode == "prefill":
-                engine_type = "prefill"
-            elif server_args.disaggregation_mode == "decode":
-                engine_type = "decode"
-            else:
-                engine_type = "unified"
-
             labels = {
-                "model_name": server_args.served_model_name or server_args.model_path,
-                "engine_type": engine_type,
+                "model_name": server_args.served_model_name,
             }
+            if server_args.extra_metric_labels:
+                labels.update(server_args.extra_metric_labels)
             self.metrics_collector = TokenizerMetricsCollector(
                 server_args=server_args,
                 labels=labels,
@@ -236,10 +228,7 @@ class GrpcRequestManager:
                 bucket_e2e_request_latency=server_args.bucket_e2e_request_latency,
                 collect_tokens_histogram=server_args.collect_tokens_histogram,
             )
-            logger.info(
-                f"TokenizerMetricsCollector initialized for gRPC mode "
-                f"(engine_type={engine_type})"
-            )
+            logger.info("TokenizerMetricsCollector initialized for gRPC mode")
 
         # Crash dump for debugging
         self.crash_dump_request_list = []
@@ -613,15 +602,10 @@ class GrpcRequestManager:
 
             # Update timing and record per-token metrics
             # Mirrors TokenizerManager.collect_metrics() logic exactly.
-            completion_tokens = (
-                batch_out.completion_tokens[i] if batch_out.completion_tokens else 0
-            )
+            completion_tokens = batch_out.completion_tokens[i] if batch_out.completion_tokens else 0
             if state.time_stats.first_token_time == 0.0:
                 state.time_stats.set_first_token_time()
-            if (
-                not state.ttft_observed
-                and self.disaggregation_mode != DisaggregationMode.PREFILL
-            ):
+            if not state.ttft_observed and self.disaggregation_mode != DisaggregationMode.PREFILL:
                 state.ttft_observed = True
                 state.last_completion_tokens = completion_tokens
                 if self.metrics_collector is not None:
@@ -744,9 +728,7 @@ class GrpcRequestManager:
         if put_tasks:
             await asyncio.gather(*put_tasks, return_exceptions=True)
 
-    def _collect_metrics(
-        self, state: GrpcReqState, batch_out: BatchTokenIDOutput, i: int
-    ):
+    def _collect_metrics(self, state: GrpcReqState, batch_out: BatchTokenIDOutput, i: int):
         """Record serving metrics for a finished request.
 
         Mirrors TokenizerManager.collect_metrics() — records E2E latency,
@@ -758,9 +740,7 @@ class GrpcRequestManager:
             return
 
         labels = self.metrics_collector.labels
-        completion_tokens = (
-            batch_out.completion_tokens[i] if batch_out.completion_tokens else 0
-        )
+        completion_tokens = batch_out.completion_tokens[i] if batch_out.completion_tokens else 0
         prompt_tokens = batch_out.prompt_tokens[i] if batch_out.prompt_tokens else 0
         cached_tokens = batch_out.cached_tokens[i] if batch_out.cached_tokens else 0
 
@@ -772,10 +752,7 @@ class GrpcRequestManager:
         )
 
         cached_tokens_details = None
-        if (
-            hasattr(batch_out, "cached_tokens_details")
-            and batch_out.cached_tokens_details
-        ):
+        if hasattr(batch_out, "cached_tokens_details") and batch_out.cached_tokens_details:
             cached_tokens_details = batch_out.cached_tokens_details[i]
 
         self.metrics_collector.observe_one_finished_request(

--- a/grpc_servicer/smg_grpc_servicer/sglang/request_manager.py
+++ b/grpc_servicer/smg_grpc_servicer/sglang/request_manager.py
@@ -38,6 +38,13 @@ from sglang.srt.server_args import PortArgs, ServerArgs
 from sglang.srt.utils import get_or_create_event_loop, get_zmq_socket, kill_process_tree
 from sglang.utils import get_exception_traceback
 
+# Conditional import — metrics collector is only available when --enable-metrics is set
+# and PROMETHEUS_MULTIPROC_DIR is configured.
+try:
+    from sglang.srt.observability.metrics_collector import TokenizerMetricsCollector
+except ImportError:
+    TokenizerMetricsCollector = None
+
 logger = logging.getLogger(__name__)
 
 
@@ -141,6 +148,7 @@ class GrpcReqState:
     # Metrics (same as TokenizerManager's ReqState)
     time_stats: APIServerReqTimeStats
     last_completion_tokens: int = 1
+    ttft_observed: bool = False
 
     # Streaming state
     stream_finished: bool = False
@@ -204,6 +212,21 @@ class GrpcRequestManager:
 
         # Metrics
         self.last_receive_tstamp = real_time()
+        self.enable_metrics = server_args.enable_metrics
+        self.metrics_collector = None
+        if self.enable_metrics and TokenizerMetricsCollector is not None:
+            labels = {
+                "model_name": server_args.served_model_name or server_args.model_path,
+            }
+            self.metrics_collector = TokenizerMetricsCollector(
+                server_args=server_args,
+                labels=labels,
+                bucket_time_to_first_token=server_args.bucket_time_to_first_token,
+                bucket_inter_token_latency=server_args.bucket_inter_token_latency,
+                bucket_e2e_request_latency=server_args.bucket_e2e_request_latency,
+                collect_tokens_histogram=server_args.collect_tokens_histogram,
+            )
+            logger.info("TokenizerMetricsCollector initialized for gRPC mode")
 
         # Crash dump for debugging
         self.crash_dump_request_list = []
@@ -575,11 +598,29 @@ class GrpcRequestManager:
                 logger.debug(f"Skipping output for aborted request {rid}")
                 continue
 
-            # Update metrics
+            # Update timing and record per-token metrics
+            completion_tokens = (
+                batch_out.completion_tokens[i] if batch_out.completion_tokens else 0
+            )
             if state.time_stats.first_token_time == 0.0:
                 state.time_stats.set_first_token_time()
+                state.last_completion_tokens = completion_tokens
+                if self.metrics_collector is not None:
+                    self.metrics_collector.observe_time_to_first_token(
+                        self.metrics_collector.labels,
+                        state.time_stats.get_first_token_latency(),
+                    )
+                state.ttft_observed = True
             else:
+                num_new_tokens = completion_tokens - state.last_completion_tokens
+                if num_new_tokens > 0 and self.metrics_collector is not None:
+                    self.metrics_collector.observe_inter_token_latency(
+                        self.metrics_collector.labels,
+                        state.time_stats.get_interval(),
+                        num_new_tokens,
+                    )
                 state.time_stats.set_last_time()
+                state.last_completion_tokens = completion_tokens
 
             # Extract output for this request
             output_data = {
@@ -670,6 +711,9 @@ class GrpcRequestManager:
                 state.stream_finished = True
                 state.event.set()
 
+                # Record serving metrics (TTFT, ITL, E2E, token counts)
+                self._collect_metrics(state, batch_out, i)
+
                 # Remove from tracking after a delay
                 async def cleanup(request_id):
                     await asyncio.sleep(5.0)
@@ -681,6 +725,51 @@ class GrpcRequestManager:
         # Execute all queue.put() operations in parallel
         if put_tasks:
             await asyncio.gather(*put_tasks, return_exceptions=True)
+
+    def _collect_metrics(
+        self, state: GrpcReqState, batch_out: BatchTokenIDOutput, i: int
+    ):
+        """Record serving metrics for a finished request.
+
+        Mirrors TokenizerManager.collect_metrics() — records E2E latency,
+        prompt/completion token counts, and cached token counts into the
+        shared Prometheus multiprocess directory so they appear on the
+        engine's /metrics endpoint.
+        """
+        if self.metrics_collector is None:
+            return
+
+        labels = self.metrics_collector.labels
+        completion_tokens = (
+            batch_out.completion_tokens[i] if batch_out.completion_tokens else 0
+        )
+        prompt_tokens = batch_out.prompt_tokens[i] if batch_out.prompt_tokens else 0
+        cached_tokens = batch_out.cached_tokens[i] if batch_out.cached_tokens else 0
+
+        retraction_count = (
+            batch_out.retraction_counts[i]
+            if getattr(batch_out, "retraction_counts", None)
+            and i < len(batch_out.retraction_counts)
+            else 0
+        )
+
+        cached_tokens_details = None
+        if (
+            hasattr(batch_out, "cached_tokens_details")
+            and batch_out.cached_tokens_details
+        ):
+            cached_tokens_details = batch_out.cached_tokens_details[i]
+
+        self.metrics_collector.observe_one_finished_request(
+            labels,
+            prompt_tokens,
+            completion_tokens,
+            cached_tokens,
+            state.time_stats.get_e2e_latency(),
+            False,  # has_grammar — not tracked in gRPC mode
+            retraction_count,
+            cached_tokens_details,
+        )
 
     async def _handle_embedding_output(self, batch_out: BatchEmbeddingOutput):
         """Handle batch embedding output from scheduler."""


### PR DESCRIPTION
## Summary

- Add TTFT, inter-token latency, and E2E serving metrics to `GrpcRequestManager`, mirroring the existing HTTP `TokenizerManager` metrics collection logic
- Initialize `TokenizerMetricsCollector` with proper `engine_type` label (prefill/decode/unified) derived from disaggregation mode
- Record per-token TTFT/ITL observations during streaming and final request metrics (prompt/completion/cached tokens, E2E latency) on request completion

## Details

The gRPC path was missing Prometheus serving metrics that the HTTP `TokenizerManager` already collects. This PR brings parity by:

1. **Conditional import** of `TokenizerMetricsCollector` — gracefully no-ops when `--enable-metrics` is not set
2. **TTFT tracking** with a `ttft_observed` flag on `GrpcReqState`, skipping observation in prefill-only disaggregation mode (matching HTTP behavior)
3. **ITL tracking** using `completion_tokens` delta between consecutive outputs
4. **E2E metrics** via `_collect_metrics()` called on stream completion, recording prompt/completion/cached token counts and end-to-end latency

All metric recording mirrors `TokenizerManager.collect_metrics()` exactly so dashboards see consistent data regardless of transport.

## Test plan

- [ ] Verify metrics endpoint includes `sglang:time_to_first_token_seconds`, `sglang:inter_token_latency_seconds`, `sglang:e2e_request_latency_seconds` when using gRPC with `--enable-metrics`
- [ ] Verify `engine_type` label is correct for unified / prefill / decode modes
- [ ] Verify no metrics are emitted when `--enable-metrics` is not set
- [ ] Confirm HTTP metrics remain unchanged (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced performance monitoring with automatic tracking of time-to-first-token (TTFT), inter-token latency, and end-to-end latency per request.
  * Added finished-request metrics including prompt/completion token counts, cached-token details, and retraction counts.
  * Metrics are optional and gracefully disabled when the metrics collector is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->