### PR TITLE
refactor(protocols): add WorkerStatus enum to protocol crate

### DIFF
--- a/crates/protocols/src/worker.rs
+++ b/crates/protocols/src/worker.rs
@@ -134,12 +134,12 @@ impl WorkerStatus {
     /// Convert a `u8` discriminant to a `WorkerStatus`, falling back to
     /// `Pending` for unrecognized values (with a debug assertion).
     pub fn from_u8(value: u8) -> Self {
-        let status = Self::try_from_u8(value).unwrap_or(Self::Pending);
+        let maybe = Self::try_from_u8(value);
         debug_assert!(
-            Self::try_from_u8(value).is_some(),
+            maybe.is_some(),
             "invalid WorkerStatus discriminant: {value}"
         );
-        status
+        maybe.unwrap_or(Self::Pending)
     }
 
     /// Returns `true` if the worker is routable (only `Ready`).

--- a/crates/protocols/src/worker.rs
+++ b/crates/protocols/src/worker.rs
@@ -89,6 +89,76 @@ impl std::fmt::Display for ConnectionMode {
     }
 }
 
+/// Worker lifecycle status, modeled after Kubernetes pod conditions.
+///
+/// Separates "starting up" from "can serve traffic" from "broken" to prevent
+/// premature removal of workers that haven't been locally verified.
+///
+/// Uses `#[repr(u8)]` with explicit discriminants so atomic storage
+/// (`AtomicU8`) and wire compatibility do not depend on enum ordering.
+#[repr(u8)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default, schemars::JsonSchema,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkerStatus {
+    /// Just registered, not yet proven healthy locally.
+    /// Not routable. Health checker probes until first success.
+    #[default]
+    Pending = 0,
+
+    /// Locally verified and passing health checks. Routable.
+    Ready = 1,
+
+    /// Was Ready, now failing readiness checks. Not routable.
+    /// NOT removed — may recover. Health checker continues probing.
+    NotReady = 2,
+
+    /// Sustained liveness failure. Will be removed if `--remove-unhealthy-workers`.
+    Failed = 3,
+}
+
+impl WorkerStatus {
+    /// Try to convert a `u8` discriminant to a `WorkerStatus`.
+    /// Returns `None` for unrecognized values.
+    pub fn try_from_u8(value: u8) -> Option<Self> {
+        match value {
+            0 => Some(Self::Pending),
+            1 => Some(Self::Ready),
+            2 => Some(Self::NotReady),
+            3 => Some(Self::Failed),
+            _ => None,
+        }
+    }
+
+    /// Convert a `u8` discriminant to a `WorkerStatus`, falling back to
+    /// `Pending` for unrecognized values (with a debug assertion).
+    pub fn from_u8(value: u8) -> Self {
+        let status = Self::try_from_u8(value).unwrap_or(Self::Pending);
+        debug_assert!(
+            Self::try_from_u8(value).is_some(),
+            "invalid WorkerStatus discriminant: {value}"
+        );
+        status
+    }
+
+    /// Returns `true` if the worker is routable (only `Ready`).
+    pub fn is_routable(self) -> bool {
+        matches!(self, Self::Ready)
+    }
+}
+
+impl std::fmt::Display for WorkerStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            WorkerStatus::Pending => write!(f, "pending"),
+            WorkerStatus::Ready => write!(f, "ready"),
+            WorkerStatus::NotReady => write!(f, "not_ready"),
+            WorkerStatus::Failed => write!(f, "failed"),
+        }
+    }
+}
+
 /// Composite key identifying a group of workers with the same characteristics.
 ///
 /// Groups workers by `(model_id, worker_type, connection_mode)` — the natural
@@ -609,6 +679,11 @@ pub struct WorkerInfo {
     /// Whether the worker is healthy.
     pub is_healthy: bool,
 
+    /// Worker lifecycle status (Pending, Ready, NotReady, Failed).
+    /// Present alongside `is_healthy` for backward compatibility.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<WorkerStatus>,
+
     /// Current load on the worker.
     pub load: usize,
 
@@ -624,6 +699,7 @@ impl WorkerInfo {
             model_id: None,
             spec: WorkerSpec::new(url),
             is_healthy: false,
+            status: Some(WorkerStatus::Pending),
             load: 0,
             job_status,
         }

--- a/model_gateway/src/worker/worker.rs
+++ b/model_gateway/src/worker/worker.rs
@@ -965,13 +965,14 @@ impl Drop for HealthChecker {
 pub fn worker_to_info(worker: &Arc<dyn Worker>) -> WorkerInfo {
     let metadata = worker.metadata();
     let spec = metadata.spec.clone();
+    let is_healthy = worker.is_healthy();
 
     WorkerInfo {
         id: worker.url().to_string(),
         model_id: spec.models.primary().map(|m| m.id.clone()),
         spec,
-        is_healthy: worker.is_healthy(),
-        status: Some(if worker.is_healthy() {
+        is_healthy,
+        status: Some(if is_healthy {
             WorkerStatus::Ready
         } else {
             WorkerStatus::NotReady

--- a/model_gateway/src/worker/worker.rs
+++ b/model_gateway/src/worker/worker.rs
@@ -15,7 +15,7 @@ pub use openai_protocol::worker::{ConnectionMode, RuntimeType, WorkerType};
 use openai_protocol::{
     model_card::ModelCard,
     model_type::{Endpoint, ModelType},
-    worker::{HealthCheckConfig, ProviderType, WorkerInfo, WorkerModels, WorkerSpec},
+    worker::{HealthCheckConfig, ProviderType, WorkerInfo, WorkerModels, WorkerSpec, WorkerStatus},
 };
 use tokio::{sync::OnceCell, time};
 
@@ -971,6 +971,11 @@ pub fn worker_to_info(worker: &Arc<dyn Worker>) -> WorkerInfo {
         model_id: spec.models.primary().map(|m| m.id.clone()),
         spec,
         is_healthy: worker.is_healthy(),
+        status: Some(if worker.is_healthy() {
+            WorkerStatus::Ready
+        } else {
+            WorkerStatus::NotReady
+        }),
         load: worker.load(),
         job_status: None,
     }


### PR DESCRIPTION
## Description

### Problem
Worker health is a single `bool` — conflates "starting up" (Pending), "can serve traffic" (Ready), and "broken" (Failed). This is the root cause of the mesh sync 500/503 bug and prevents proper lifecycle state machine implementation.

### Solution
Add a four-state `WorkerStatus` enum to `crates/protocols/src/worker.rs`, modeled after Kubernetes pod conditions. This is the foundational type for the worker module deep refactor — all subsequent PRs (state machine, WorkerManager extraction, mesh sync) depend on it.

## Changes
- **`crates/protocols/src/worker.rs`**:
  - Added `WorkerStatus` enum: `Pending(0)`, `Ready(1)`, `NotReady(2)`, `Failed(3)`
  - `#[repr(u8)]` with explicit discriminants for `AtomicU8` storage
  - `try_from_u8()` / `from_u8()` for safe conversion from atomic values
  - `is_routable()` helper (only `Ready` is routable)
  - `Default` (Pending), `Display`, serde (`snake_case`), schemars
  - Added optional `status: Option<WorkerStatus>` to `WorkerInfo` (backward compatible — `skip_serializing_if`)
  - `WorkerInfo::pending()` now sets `status: Some(Pending)`
- **`model_gateway/src/worker/worker.rs`**:
  - `worker_to_info()` populates the new `status` field based on `is_healthy()`
  - Imported `WorkerStatus`

## Why this design
- **`#[repr(u8)]` + explicit discriminants**: wire compatibility and atomic storage don't depend on enum ordering
- **`from_u8()` with debug_assert fallback**: safe in release (falls back to Pending), catches bugs in tests
- **Optional field in WorkerInfo**: fully backward compatible — old consumers ignore it, new consumers can opt in
- **Placed alongside WorkerType, ConnectionMode, RuntimeType**: natural home for worker identity/state types

## Test Plan
- `cargo check --package openai-protocol` — clean
- `cargo check --package smg` — clean
- `cargo test --package smg --lib worker::` — all 133 tests pass
- `cargo test --package openai-protocol` — all tests pass
- `cargo test --package smg --test api_tests` — all 97 integration tests pass
- No behavioral changes — `is_healthy` still drives routing

Refs: worker-module-deep-refactor plan (PR 2)

<details>
<summary>Checklist</summary>

- [x] Documentation updated (inline doc comments)
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced worker status tracking with four states: pending, ready, not_ready, failed.
  * Worker records now include an optional status field (pending by default for new entries).
  * System reports status automatically based on operational health (ready vs not_ready).
  * Only workers in the ready state are considered routable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->