### PR TITLE
ci: allow 'ci-approved' label to bypass fork PR approval gate

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -8,6 +8,9 @@ on:
       - 'docs/**'
       - '*.lock'
       - 'mkdocs.yml'
+  # Allow maintainers to trigger Claude review for fork PRs via 'ci-approved' label.
+  pull_request_target:
+    types: [labeled, synchronize]
   issue_comment:
     types: [created]
   pull_request_review_comment:
@@ -24,10 +27,12 @@ jobs:
   review:
     name: Claude PR Review
     if: >-
-      github.event_name == 'pull_request'
-      && github.repository == 'lightseekorg/smg'
+      github.repository == 'lightseekorg/smg'
       && github.actor != 'dependabot[bot]'
-      && !github.event.pull_request.head.repo.fork
+      && (
+        (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork)
+        || (github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'ci-approved'))
+      )
     runs-on: k8s-runner-cpu
     timeout-minutes: 30
     concurrency:
@@ -37,6 +42,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Export API key from pod env

--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -14,14 +14,20 @@ on:
       - "docs/**"
       - "mkdocs.yml"
       - "*.md"
+  # Allow maintainers to trigger CI for fork PRs by adding the 'ci-approved' label.
+  # pull_request_target runs in the base branch context, bypassing the fork approval gate.
+  # 'synchronize' re-runs CI on subsequent pushes while the label is present.
+  pull_request_target:
+    branches: [ main ]
+    types: [labeled, synchronize]
   workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: gateway-tests-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: gateway-tests-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 env:
   RUSTC_WRAPPER: sccache
@@ -29,12 +35,25 @@ env:
   GENAI_BENCH_IMAGE: ghcr.io/moirai-internal/genai-bench:0.0.4
 
 jobs:
+  # Gate job: for pull_request_target, only proceed if 'ci-approved' label is present.
+  # All other triggers (push, pull_request, workflow_dispatch) pass through unconditionally.
+  ci-gate:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name != 'pull_request_target' ||
+      contains(github.event.pull_request.labels.*.name, 'ci-approved')
+    steps:
+      - run: echo "CI gate passed"
+
   pre-commit:
+    needs: [ci-gate]
     runs-on: k8s-runner-cpu
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -50,11 +69,14 @@ jobs:
         run: pre-commit run --all-files --show-diff-on-failure
 
   python-lint:
+    needs: [ci-gate]
     runs-on: k8s-runner-cpu
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -77,11 +99,14 @@ jobs:
         run: mypy bindings/python/ --config-file mypy.ini
 
   grpc-proto-build-check:
+    needs: [ci-gate]
     runs-on: k8s-runner-cpu
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -103,11 +128,14 @@ jobs:
           python -c "from smg_grpc_proto import sglang_scheduler_pb2; print('OK')"
 
   build-wheel:
+    needs: [ci-gate]
     runs-on: k8s-runner-gpu
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Cache wheel and Go FFI artifacts
         id: cache-wheel
@@ -233,11 +261,14 @@ jobs:
           pytest -q tests --cov=smg --cov-config=.coveragerc --cov-report=term-missing --cov-fail-under=80
 
   unit-tests:
+    needs: [ci-gate]
     runs-on: k8s-runner-cpu
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -359,8 +390,9 @@ jobs:
           retention-days: 7
 
   detect-changes:
+    needs: [ci-gate]
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
     permissions:
       contents: read
       pull-requests: read


### PR DESCRIPTION
## Summary

Add `ci-approved` label support so maintainers can trigger CI on fork PRs without clicking the manual approval button.

## Problem

Fork PRs from external contributors require manual approval before any CI runs (GitHub's default for public repos). This adds friction — maintainers have to click "Approve and run" for every push, and contributors wait with no feedback.

## Solution

Add `pull_request_target` trigger with a `ci-approved` label gate to the two main CI workflows:

**`pr-test-rust.yml`:**
- New `ci-gate` job: passes unconditionally for `push`/`pull_request`/`workflow_dispatch`, requires `ci-approved` label for `pull_request_target`
- All root jobs (`pre-commit`, `python-lint`, `grpc-proto-build-check`, `build-wheel`, `unit-tests`, `detect-changes`) depend on `ci-gate`
- All checkouts use `github.event.pull_request.head.sha` to ensure fork code is checked out (not base branch)

**`claude-code-review.yml`:**
- Review job condition: `pull_request` (non-fork, existing behavior) OR `pull_request_target` with `ci-approved` label
- Checkout uses `github.event.pull_request.head.sha`

## Usage

1. External contributor opens a fork PR
2. Maintainer reviews the code
3. Maintainer adds `ci-approved` label
4. CI + Claude review run automatically

## Security

`pull_request_target` runs in the base branch context with access to repo secrets. The `ci-approved` label is the human gate — only collaborators with write access can add labels. This is the standard pattern used by Kubernetes, Envoy, and other large OSS projects for fork CI.

Maintainers should review fork code before adding the label, same as clicking "Approve and run".

## Test plan

- [ ] Internal PR (non-fork): CI runs as before, no change
- [ ] Fork PR without label: CI stays pending (requires manual approval)
- [ ] Fork PR with `ci-approved` label: CI runs automatically
- [ ] Verify `ci-gate` job blocks when label is absent on `pull_request_target`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added label-based PR triggers and an approval gate for certain workflows to refine when CI jobs run.
  * Standardized checkout to pin the PR head commit, introduced gated prerequisite jobs, and updated concurrency handling to reduce redundant runs and improve CI consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->