### PR TITLE
refactor(worker): expand WorkerEvent with richer payloads

### DIFF
--- a/model_gateway/src/observability/metrics_ws/collectors.rs
+++ b/model_gateway/src/observability/metrics_ws/collectors.rs
@@ -110,7 +110,7 @@ fn spawn_worker_collector(
                             debug!("worker event: {event:?}");
                             publish_workers(&context, &registry);
                             // Only publish models on membership changes, not health
-                            if matches!(event, WorkerEvent::Registered { .. } | WorkerEvent::Removed { .. }) {
+                            if matches!(event, WorkerEvent::Registered { .. } | WorkerEvent::Removed { .. } | WorkerEvent::Replaced { .. }) {
                                 publish_models(&context, &registry);
                             }
                         }

--- a/model_gateway/src/worker/event.rs
+++ b/model_gateway/src/worker/event.rs
@@ -1,12 +1,46 @@
 //! Events emitted by [`WorkerRegistry`] on state mutations.
 
+use std::sync::Arc;
+
+use openai_protocol::worker::WorkerStatus;
+
+use super::{registry::WorkerId, worker::Worker};
+
 /// Events broadcast when worker state changes.
+///
+/// Subscribers (WorkerManager, WorkerMonitor, WorkerSyncAdapter) use these for
+/// incremental updates. Events carry `Arc<dyn Worker>` so subscribers can access
+/// any worker data they need without re-querying the registry.
+///
+/// For `Removed`, the worker Arc is a pre-removal snapshot — the worker is
+/// already gone from the registry when the event fires.
 #[derive(Debug, Clone)]
 pub enum WorkerEvent {
-    /// A worker was registered.
-    Registered { url: String },
-    /// A worker was removed.
-    Removed { url: String },
-    /// A worker's health status changed.
-    HealthChanged { url: String, healthy: bool },
+    /// A worker was added to the registry.
+    Registered {
+        worker_id: WorkerId,
+        worker: Arc<dyn Worker>,
+    },
+
+    /// A worker was removed from the registry.
+    /// The worker Arc is a pre-removal snapshot.
+    Removed {
+        worker_id: WorkerId,
+        worker: Arc<dyn Worker>,
+    },
+
+    /// A worker was replaced (same URL, new worker object — e.g. property update).
+    Replaced {
+        worker_id: WorkerId,
+        old: Arc<dyn Worker>,
+        new: Arc<dyn Worker>,
+    },
+
+    /// A worker's lifecycle status changed (Pending→Ready, Ready→NotReady, etc.)
+    StatusChanged {
+        worker_id: WorkerId,
+        worker: Arc<dyn Worker>,
+        old_status: WorkerStatus,
+        new_status: WorkerStatus,
+    },
 }

--- a/model_gateway/src/worker/registry.rs
+++ b/model_gateway/src/worker/registry.rs
@@ -372,7 +372,8 @@ impl WorkerRegistry {
         }
 
         let _ = self.event_tx.send(WorkerEvent::Registered {
-            url: worker.url().to_string(),
+            worker_id: worker_id.clone(),
+            worker: worker.clone(),
         });
 
         Some(worker_id)
@@ -520,8 +521,10 @@ impl WorkerRegistry {
             }
         }
 
-        let _ = self.event_tx.send(WorkerEvent::Registered {
-            url: new_worker.url().to_string(),
+        let _ = self.event_tx.send(WorkerEvent::Replaced {
+            worker_id: worker_id.clone(),
+            old: old_worker,
+            new: new_worker,
         });
 
         true
@@ -636,7 +639,8 @@ impl WorkerRegistry {
             }
 
             let _ = self.event_tx.send(WorkerEvent::Removed {
-                url: worker.url().to_string(),
+                worker_id: worker_id.clone(),
+                worker: worker.clone(),
             });
 
             Some(worker)
@@ -1588,8 +1592,8 @@ mod tests {
         // Should receive Registered event
         let event = rx.try_recv().unwrap();
         match event {
-            WorkerEvent::Registered { url } => {
-                assert_eq!(url, "http://event-worker:8080");
+            WorkerEvent::Registered { worker, .. } => {
+                assert_eq!(worker.url(), "http://event-worker:8080");
             }
             other => panic!("Expected Registered event, got: {other:?}"),
         }
@@ -1600,8 +1604,8 @@ mod tests {
         // Should receive Removed event
         let event = rx.try_recv().unwrap();
         match event {
-            WorkerEvent::Removed { url } => {
-                assert_eq!(url, "http://event-worker:8080");
+            WorkerEvent::Removed { worker, .. } => {
+                assert_eq!(worker.url(), "http://event-worker:8080");
             }
             other => panic!("Expected Removed event, got: {other:?}"),
         }


### PR DESCRIPTION
## Description

### Problem
`WorkerEvent` only carries a `url: String` — subscribers can't react to events without re-querying the registry. `replace()` incorrectly emits `Registered` instead of its own event type. `HealthChanged` exists but is never emitted consistently.

### Solution
Expand `WorkerEvent` to carry `Arc<dyn Worker>` and add proper `Replaced`/`StatusChanged` variants.

## Changes
- **`event.rs`**: `Registered`/`Removed` now carry `(worker_id, Arc<dyn Worker>)`. New `Replaced { old, new }` variant. New `StatusChanged { old_status, new_status }` variant replacing `HealthChanged`.
- **`registry.rs`**: `register()` populates worker Arc in event. `replace()` emits `Replaced` instead of `Registered`. `remove()` carries pre-removal worker snapshot.
- **`collectors.rs`**: Pattern match updated to include `Replaced` for model list updates.

## Design decision
Events carry `Arc<dyn Worker>` rather than flattened fields because future subscribers (WorkerManager, WorkerMonitor, WorkerSyncAdapter) each need different subsets of worker data. Arc clone is cheap and avoids maintaining a parallel field list.

`StatusChanged` is defined but not emitted yet — no callers exist until WorkerManager extraction (PR 7). `transition_status()` was intentionally NOT added to the registry — status transitions are business logic that belongs in WorkerManager, not in the collection.

## Test Plan
- `cargo check --package smg` — clean, no warnings
- `cargo test --package smg --lib worker::` — all 133 tests pass
- `cargo test --package smg --test api_tests` — all 100 integration tests pass

Refs: worker-module-deep-refactor plan (PR 5)

<details>
<summary>Checklist</summary>

- [x] Documentation updated (doc comments on WorkerEvent variants)
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced worker event tracking to include complete worker snapshots and replacement events, enabling more comprehensive observability of worker lifecycle changes.

* **Bug Fixes**
  * Fixed model publication logic to properly trigger when workers are replaced, ensuring consistent model state tracking across all worker state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->