### PR TITLE
refactor(worker): replace healthy AtomicBool with status AtomicU8

### DIFF
--- a/bindings/golang/src/policy.rs
+++ b/bindings/golang/src/policy.rs
@@ -10,7 +10,7 @@ use std::{
     os::raw::c_char,
     ptr,
     sync::{
-        atomic::{AtomicBool, AtomicUsize, Ordering},
+        atomic::{AtomicU8, AtomicUsize, Ordering},
         Arc,
     },
 };
@@ -19,7 +19,7 @@ use async_trait::async_trait;
 use llm_tokenizer::{create_tokenizer_from_file, traits::Tokenizer};
 use openai_protocol::{
     chat::ChatCompletionRequest,
-    worker::{HealthCheckConfig, WorkerSpec},
+    worker::{HealthCheckConfig, WorkerSpec, WorkerStatus},
 };
 use smg::{
     policies::{
@@ -54,7 +54,7 @@ use super::{
 pub struct GrpcWorker {
     pub(crate) client: Arc<SglangSchedulerClient>,
     pub(crate) endpoint: String,
-    pub(crate) healthy: AtomicBool,
+    pub(crate) status: AtomicU8,
     pub(crate) load: AtomicUsize,
     pub(crate) processed: AtomicUsize,
     pub(crate) circuit_breaker: CircuitBreaker,
@@ -80,7 +80,7 @@ impl GrpcWorker {
             client,
             routing_key_load: WorkerRoutingKeyLoad::new(&endpoint),
             endpoint,
-            healthy: AtomicBool::new(true),
+            status: AtomicU8::new(WorkerStatus::Ready as u8),
             load: AtomicUsize::new(0),
             processed: AtomicUsize::new(0),
             circuit_breaker: CircuitBreaker::new(),
@@ -96,7 +96,10 @@ impl std::fmt::Debug for GrpcWorker {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("GrpcWorker")
             .field("endpoint", &self.endpoint)
-            .field("healthy", &self.healthy.load(Ordering::Relaxed))
+            .field(
+                "status",
+                &WorkerStatus::from_u8(self.status.load(Ordering::Relaxed)),
+            )
             .finish()
     }
 }
@@ -119,12 +122,12 @@ impl Worker for GrpcWorker {
         &self.metadata.spec.connection_mode
     }
 
-    fn is_healthy(&self) -> bool {
-        self.healthy.load(Ordering::Relaxed)
+    fn status(&self) -> WorkerStatus {
+        WorkerStatus::from_u8(self.status.load(Ordering::Relaxed))
     }
 
-    fn set_healthy(&self, healthy: bool) {
-        self.healthy.store(healthy, Ordering::Relaxed);
+    fn set_status(&self, status: WorkerStatus) {
+        self.status.store(status as u8, Ordering::Relaxed);
     }
 
     async fn check_health_async(&self) -> WorkerResult<()> {
@@ -178,11 +181,11 @@ impl Worker for GrpcWorker {
     }
 
     async fn grpc_health_check(&self) -> WorkerResult<bool> {
-        Ok(self.healthy.load(Ordering::Relaxed))
+        Ok(self.is_healthy())
     }
 
     async fn http_health_check(&self) -> WorkerResult<bool> {
-        Ok(self.healthy.load(Ordering::Relaxed))
+        Ok(self.is_healthy())
     }
 }
 
@@ -377,7 +380,7 @@ pub unsafe extern "C" fn sgl_multi_client_healthy_count(
     (*handle)
         .grpc_workers
         .iter()
-        .filter(|w| w.healthy.load(Ordering::Relaxed))
+        .filter(|w| w.is_healthy())
         .count()
 }
 
@@ -398,9 +401,7 @@ pub unsafe extern "C" fn sgl_multi_client_set_worker_health(
     if worker_index >= client.grpc_workers.len() {
         return SglErrorCode::InvalidArgument;
     }
-    client.grpc_workers[worker_index]
-        .healthy
-        .store(healthy, Ordering::Relaxed);
+    client.grpc_workers[worker_index].set_healthy(healthy);
     SglErrorCode::Success
 }
 

--- a/model_gateway/src/worker/builder.rs
+++ b/model_gateway/src/worker/builder.rs
@@ -207,7 +207,7 @@ impl BasicWorkerBuilder {
     /// Build the BasicWorker instance
     pub fn build(mut self) -> BasicWorker {
         use std::sync::{
-            atomic::{AtomicBool, AtomicUsize},
+            atomic::{AtomicU8, AtomicUsize},
             Arc,
         };
 
@@ -239,8 +239,10 @@ impl BasicWorkerBuilder {
             None => OnceCell::new(),
         });
 
-        let healthy = true;
-        Metrics::set_worker_health(&metadata.spec.url, healthy);
+        // Workers start Ready (routable). PR 6b will change this to Pending
+        // for health-checked workers.
+        let initial_status = openai_protocol::worker::WorkerStatus::Ready;
+        Metrics::set_worker_health(&metadata.spec.url, true);
 
         let http_client = self.http_client.unwrap_or_else(|| {
             reqwest::Client::builder()
@@ -258,7 +260,7 @@ impl BasicWorkerBuilder {
             load_counter: Arc::new(AtomicUsize::new(0)),
             worker_routing_key_load: Arc::new(WorkerRoutingKeyLoad::new(&metadata.spec.url)),
             processed_counter: Arc::new(AtomicUsize::new(0)),
-            healthy: Arc::new(AtomicBool::new(healthy)),
+            status: Arc::new(AtomicU8::new(initial_status as u8)),
             consecutive_failures: Arc::new(AtomicUsize::new(0)),
             consecutive_successes: Arc::new(AtomicUsize::new(0)),
             circuit_breaker: CircuitBreaker::with_config_and_label(

--- a/model_gateway/src/worker/worker.rs
+++ b/model_gateway/src/worker/worker.rs
@@ -1,7 +1,7 @@
 use std::{
     fmt,
     sync::{
-        atomic::{AtomicBool, AtomicUsize, Ordering},
+        atomic::{AtomicU8, AtomicUsize, Ordering},
         Arc, LazyLock,
     },
     time::Duration,
@@ -141,11 +141,35 @@ pub trait Worker: Send + Sync + fmt::Debug {
         self.metadata().spec.bootstrap_port
     }
 
-    /// Check if the worker is currently healthy
-    fn is_healthy(&self) -> bool;
+    /// Get the worker's lifecycle status.
+    fn status(&self) -> WorkerStatus;
 
-    /// Set the worker's health status
-    fn set_healthy(&self, healthy: bool);
+    /// Set the worker's lifecycle status.
+    fn set_status(&self, status: WorkerStatus);
+
+    /// Check if the worker is currently healthy (status == Ready).
+    ///
+    /// This is a routing predicate — returns true only for `Ready` workers.
+    /// A `Pending` worker is not "unhealthy", just unverified.
+    fn is_healthy(&self) -> bool {
+        self.status() == WorkerStatus::Ready
+    }
+
+    /// Set the worker's health status (compatibility shim).
+    ///
+    /// Maps `true` → `Ready`, `false` → `NotReady`.
+    /// Prefer `set_status()` for explicit state transitions.
+    fn set_healthy(&self, healthy: bool) {
+        if healthy {
+            self.set_status(WorkerStatus::Ready);
+        } else {
+            // Only transition to NotReady if currently Ready.
+            // Don't transition Pending→NotReady (hasn't proven itself).
+            if self.status() == WorkerStatus::Ready {
+                self.set_status(WorkerStatus::NotReady);
+            }
+        }
+    }
 
     /// Perform an async health check on the worker
     async fn check_health_async(&self) -> WorkerResult<()>;
@@ -500,7 +524,7 @@ pub struct BasicWorker {
     pub load_counter: Arc<AtomicUsize>,
     pub worker_routing_key_load: Arc<WorkerRoutingKeyLoad>,
     pub processed_counter: Arc<AtomicUsize>,
-    pub healthy: Arc<AtomicBool>,
+    pub status: Arc<AtomicU8>,
     pub consecutive_failures: Arc<AtomicUsize>,
     pub consecutive_successes: Arc<AtomicUsize>,
     pub circuit_breaker: CircuitBreaker,
@@ -521,7 +545,10 @@ impl fmt::Debug for BasicWorker {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("BasicWorker")
             .field("metadata", &self.metadata)
-            .field("healthy", &self.healthy.load(Ordering::Relaxed))
+            .field(
+                "status",
+                &WorkerStatus::from_u8(self.status.load(Ordering::Relaxed)),
+            )
             .field("circuit_breaker", &self.circuit_breaker)
             .field("grpc_client", &"<OnceCell>")
             .finish()
@@ -553,13 +580,13 @@ impl Worker for BasicWorker {
         &self.metadata.spec.connection_mode
     }
 
-    fn is_healthy(&self) -> bool {
-        self.healthy.load(Ordering::Acquire)
+    fn status(&self) -> WorkerStatus {
+        WorkerStatus::from_u8(self.status.load(Ordering::Acquire))
     }
 
-    fn set_healthy(&self, healthy: bool) {
-        self.healthy.store(healthy, Ordering::Release);
-        Metrics::set_worker_health(self.url(), healthy);
+    fn set_status(&self, status: WorkerStatus) {
+        self.status.store(status as u8, Ordering::Release);
+        Metrics::set_worker_health(self.url(), status == WorkerStatus::Ready);
     }
 
     async fn check_health_async(&self) -> WorkerResult<()> {


### PR DESCRIPTION
## Description

### Problem
Worker health is stored as a single `Arc<AtomicBool>` — can only represent healthy/unhealthy. The `WorkerStatus` enum (PR #1093) defines four states (Pending, Ready, NotReady, Failed) but has no storage backing.

### Solution
Replace `Arc<AtomicBool>` with `Arc<AtomicU8>` storing `WorkerStatus` as u8. Add `status()`/`set_status()` to the Worker trait. Make `is_healthy()`/`set_healthy()` default implementations that delegate to the new methods.

## Changes
- **`worker.rs`**: `healthy: Arc<AtomicBool>` → `status: Arc<AtomicU8>`. Added `status()` and `set_status()` as required trait methods. `is_healthy()` and `set_healthy()` become default impls. `set_healthy(false)` guards Pending→NotReady (only Ready→NotReady is valid).
- **`builder.rs`**: Initializes with `WorkerStatus::Ready` (preserves current behavior).
- **`bindings/golang/src/policy.rs`**: Same swap for `GrpcWorker` FFI binding.

## Design notes
- `is_healthy()` = `status() == Ready` — it's a routing predicate, not a health assessment. A Pending worker isn't unhealthy, just unverified.
- `set_healthy(false)` only transitions `Ready→NotReady`, never `Pending→NotReady`. A worker that hasn't proven itself shouldn't be marked as "was ready, now failing".
- Workers still start `Ready` — PR 6b will change this to `Pending` for health-checked workers.
- All ~40 `is_healthy()` and ~15 `set_healthy()` call sites continue working unchanged through trait defaults.

## Test Plan
- `cargo check --package smg --package smg-golang` — clean
- `cargo test --package smg --lib worker::` — 133 tests pass
- `cargo test --package smg --test api_tests` — 100 integration tests pass
- No behavioral changes

Refs: worker-module-deep-refactor plan (PR 6a)

<details>
<summary>Checklist</summary>

- [x] Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Worker health representation changed from a simple boolean to a lifecycle-style status. Health checks, multi-worker health reporting, metrics, and diagnostic output now use the new status values (with compatibility shims for boolean checks), providing more granular visibility into worker lifecycle states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->