### PR TITLE
ci: apply change detection to pull_request_target events

### DIFF
--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -460,6 +460,7 @@ jobs:
       && needs.build-wheel.result == 'success'
       && github.actor != 'dependabot[bot]'
       && (github.event_name != 'pull_request'
+          && github.event_name != 'pull_request_target'
           || (needs.detect-changes.result == 'success'
               && (needs.detect-changes.outputs.common == 'true'
                   || needs.detect-changes.outputs.chat-completions == 'true')))
@@ -491,6 +492,7 @@ jobs:
       && needs.build-wheel.result == 'success'
       && github.actor != 'dependabot[bot]'
       && (github.event_name != 'pull_request'
+          && github.event_name != 'pull_request_target'
           || (needs.detect-changes.result == 'success'
               && (needs.detect-changes.outputs.common == 'true'
                   || needs.detect-changes.outputs.embeddings == 'true')))
@@ -521,6 +523,7 @@ jobs:
       && needs.build-wheel.result == 'success'
       && github.actor != 'dependabot[bot]'
       && (github.event_name != 'pull_request'
+          && github.event_name != 'pull_request_target'
           || (needs.detect-changes.result == 'success'
               && (needs.detect-changes.outputs.common == 'true'
                   || needs.detect-changes.outputs.chat-completions == 'true')))
@@ -574,6 +577,7 @@ jobs:
       && needs.build-wheel.result == 'success'
       && github.actor != 'dependabot[bot]'
       && (github.event_name != 'pull_request'
+          && github.event_name != 'pull_request_target'
           || (needs.detect-changes.result == 'success'
               && (needs.detect-changes.outputs.common == 'true'
                   || needs.detect-changes.outputs.agentic == 'true')))
@@ -595,6 +599,7 @@ jobs:
       && !cancelled()
       && needs.e2e-1gpu-gateway.result == 'success'
       && (github.event_name != 'pull_request'
+          && github.event_name != 'pull_request_target'
           || (needs.detect-changes.result == 'success'
               && (needs.detect-changes.outputs.common == 'true'
                   || needs.detect-changes.outputs.chat-completions == 'true')))
@@ -663,6 +668,7 @@ jobs:
       && needs.build-wheel.result == 'success'
       && github.actor != 'dependabot[bot]'
       && (github.event_name != 'pull_request'
+          && github.event_name != 'pull_request_target'
           || (needs.detect-changes.result == 'success'
               && (needs.detect-changes.outputs.common == 'true'
                   || needs.detect-changes.outputs.agentic == 'true')))
@@ -810,6 +816,7 @@ jobs:
       && needs.build-wheel.result == 'success'
       && github.actor != 'dependabot[bot]'
       && (github.event_name != 'pull_request'
+          && github.event_name != 'pull_request_target'
           || (needs.detect-changes.result == 'success'
               && (needs.detect-changes.outputs.common == 'true'
                   || needs.detect-changes.outputs.go-bindings == 'true')))


### PR DESCRIPTION
## Summary

PR #1095 (commit 381c5f6f) implemented change detection for `ci-approved` fork PRs by adding `pull_request_target` to the `detect-changes` job. However, the 7 downstream e2e job conditions only check filter outputs for `pull_request` events. This PR extends them to also check for `pull_request_target`, so `ci-approved` fork PRs skip unrelated e2e categories — same as direct PRs.

## Changes

Added `&& github.event_name != 'pull_request_target'` to all 7 e2e job conditions so that path-based change detection applies equally to `ci-approved` fork PRs.

## Context

PR #1095 (commit 381c5f6f) implemented change detection for `ci-approved` fork PRs by adding `pull_request_target` to the workflow triggers, updating `detect-changes` to run for both event types, and adding `ci-gate` for label checking. This PR extends the same approach to the 7 downstream e2e job conditions.

cc @slin1237 — this extends your work in #1095.

## Test plan

- [x] pre-commit passes
- [x] YAML syntax valid (checked by `check yaml` hook)
- [ ] Verify on a real `ci-approved` fork PR that touches only one category's paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined GitHub Actions workflow conditions to improve pull request event handling and ensure proper CI/CD test execution across multiple workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->