### PR TITLE
fix(grpc): forward scheduler load info for DP-aware load balancing

### DIFF
--- a/grpc_servicer/smg_grpc_servicer/sglang/request_manager.py
+++ b/grpc_servicer/smg_grpc_servicer/sglang/request_manager.py
@@ -28,6 +28,7 @@ from sglang.srt.managers.io_struct import (
     HealthCheckOutput,
     TokenizedEmbeddingReqInput,
     TokenizedGenerateReqInput,
+    WatchLoadUpdateReq,
 )
 from sglang.srt.observability.req_time_stats import (
     APIServerReqTimeStats,
@@ -678,6 +679,17 @@ class GrpcRequestManager:
                         del self.rid_to_state[request_id]
 
                 cleanup_tasks.append(asyncio.create_task(cleanup(rid)))
+
+        # Forward load info to DataParallelController for token-aware balancing.
+        # Mirrors TokenizerManager._handle_batch_output logic: when dp_size > 1,
+        # each scheduler piggybacks its load (num_reqs, num_tokens) on batch output.
+        # Without this, DPBudget stays at zero and total_tokens/total_requests
+        # policies degenerate to always picking rank 0.
+        if self.server_args.dp_size > 1 and batch_out.load is not None:
+            try:
+                await self._send_to_scheduler(WatchLoadUpdateReq(loads=[batch_out.load]))
+            except Exception as e:
+                logger.warning("Failed to forward DP load update: %s", e)
 
         # Execute all queue.put() operations in parallel
         if put_tasks:


### PR DESCRIPTION
## Summary

- In gRPC mode, `GrpcRequestManager` receives `BatchTokenIDOutput` from the scheduler but drops the piggybacked load info (`num_reqs`, `num_tokens` per DP rank), causing `total_tokens` and `total_requests` DP load balance policies to see all-zero budgets and always pick rank 0
- Mirror the `TokenizerManager` pattern: forward `WatchLoadUpdateReq` back to the `DataParallelController` when `dp_size > 1`
- Use `_send_to_scheduler` helper (consistent with the rest of the class) with best-effort error handling to avoid disrupting batch output delivery

## Context

In PD disaggregated serving with DP=8 decode engines, we observed severe DP rank imbalance (e.g., decoder-1 DP2 processed 93,904 tokens while DP7 processed 7). The `round_robin` policy distributes requests evenly by count but is blind to KV cache pressure from long-running sequences. Switching to `total_tokens` requires this load feedback loop to function.

## Test plan

- [ ] Deploy with `--load-balance-method total_tokens` on a DP=8 decode engine in gRPC mode
- [ ] Verify `DPBudget` receives non-zero load updates (check scheduler debug logs)
- [ ] Confirm DP ranks show balanced `sglang_decode_sum_seq_lens` under mixed-length workloads
- [ ] Verify no regression with `round_robin` (load forwarding is a no-op when `dp_size == 1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)