### PR TITLE
feat(worker): Handle model alias for worker selection

### DIFF
--- a/crates/protocols/src/model_card.rs
+++ b/crates/protocols/src/model_card.rs
@@ -21,6 +21,14 @@ fn is_zero(n: &u32) -> bool {
     *n == 0
 }
 
+#[expect(
+    clippy::trivially_copy_pass_by_ref,
+    reason = "serde skip_serializing_if passes &T"
+)]
+fn is_zero_u64(n: &u64) -> bool {
+    *n == 0
+}
+
 fn default_model_type() -> ModelType {
     ModelType::LLM
 }
@@ -56,6 +64,12 @@ pub struct ModelCard {
     /// Alternative names/aliases for this model
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub aliases: Vec<String>,
+
+    /// Unix timestamp when this model was created (0 = unknown).
+    /// Used to prefer the newest prefix-matched variant when providers only
+    /// expose versioned model IDs upstream.
+    #[serde(default, skip_serializing_if = "is_zero_u64")]
+    pub created_at: u64,
 
     // === Capabilities ===
     /// Supported endpoint types (bitflags)
@@ -120,6 +134,7 @@ impl ModelCard {
             id: id.into(),
             display_name: None,
             aliases: Vec::new(),
+            created_at: 0,
             model_type: ModelType::LLM,
             hf_model_type: None,
             architectures: Vec::new(),
@@ -152,6 +167,12 @@ impl ModelCard {
     /// Add multiple aliases
     pub fn with_aliases(mut self, aliases: impl IntoIterator<Item = impl Into<String>>) -> Self {
         self.aliases.extend(aliases.into_iter().map(|a| a.into()));
+        self
+    }
+
+    /// Set the creation timestamp from the upstream `/v1/models` response.
+    pub fn with_created_at(mut self, ts: u64) -> Self {
+        self.created_at = ts;
         self
     }
 
@@ -301,10 +322,11 @@ impl ModelCard {
     /// consuming `self` to avoid cloning the model ID.
     pub fn into_model_object(self) -> ModelObject {
         let owned_by = self.owned_by().to_owned();
+        let created = i64::try_from(self.created_at).unwrap_or(i64::MAX);
         ModelObject {
             id: self.id,
             object: "model".to_owned(),
-            created: 0,
+            created,
             owned_by,
         }
     }
@@ -327,6 +349,24 @@ impl ModelCard {
 impl Default for ModelCard {
     fn default() -> Self {
         Self::new(super::UNKNOWN_MODEL_ID)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ModelCard;
+    use crate::worker::ProviderType;
+
+    #[test]
+    fn into_model_object_preserves_created_at_and_provider() {
+        let model = ModelCard::new("grok-4-0709")
+            .with_created_at(1_752_019_200)
+            .with_provider(ProviderType::XAI)
+            .into_model_object();
+
+        assert_eq!(model.id, "grok-4-0709");
+        assert_eq!(model.created, 1_752_019_200);
+        assert_eq!(model.owned_by, "xai");
     }
 }
 

--- a/crates/protocols/src/worker.rs
+++ b/crates/protocols/src/worker.rs
@@ -434,6 +434,10 @@ pub enum WorkerModels {
 }
 
 impl WorkerModels {
+    fn allows_prefix_fallback(id: &str) -> bool {
+        id.contains('-') || id.contains('.') || id.bytes().any(|b| b.is_ascii_digit())
+    }
+
     /// Returns `true` if this is a wildcard (accepts any model).
     pub fn is_wildcard(&self) -> bool {
         matches!(self, Self::Wildcard)
@@ -457,13 +461,37 @@ impl WorkerModels {
         }
     }
 
-    /// Find a model by ID (checks aliases via `ModelCard::matches`).
+    /// Find a model by ID.
+    ///
+    /// Lookup order:
+    /// 1. Exact ID or alias match via `ModelCard::matches`
+    /// 2. Prefix fallback for versioned variants like `grok-4-0709` or
+    ///    `grok-4.20-0309-reasoning`, preferring the shortest matching ID
+    ///    first and then the highest `created_at` as a tiebreaker among cards
+    ///    whose IDs start with `{id}-` or `{id}.`
     pub fn find(&self, id: &str) -> Option<&ModelCard> {
-        match self {
+        let exact = match self {
             Self::Wildcard => None,
             Self::Single(card) => card.matches(id).then_some(card.as_ref()),
             Self::Multi(cards) => cards.iter().find(|m| m.matches(id)),
+        };
+        if exact.is_some() {
+            return exact;
         }
+
+        let candidates = self.all();
+        if candidates.is_empty() || !Self::allows_prefix_fallback(id) {
+            return None;
+        }
+
+        candidates
+            .iter()
+            .filter(|card| {
+                card.id
+                    .strip_prefix(id)
+                    .is_some_and(|rest| rest.starts_with('-') || rest.starts_with('.'))
+            })
+            .min_by_key(|card| (card.id.len(), std::cmp::Reverse(card.created_at)))
     }
 
     /// Returns `true` if the worker supports the given model ID.
@@ -519,6 +547,85 @@ impl JsonSchema for WorkerModels {
 
     fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
         Vec::<ModelCard>::json_schema(gen)
+    }
+}
+
+#[cfg(test)]
+mod worker_models_tests {
+    use super::WorkerModels;
+    use crate::model_card::ModelCard;
+
+    fn card(id: &str, created_at: u64) -> ModelCard {
+        ModelCard::new(id).with_created_at(created_at)
+    }
+
+    #[test]
+    fn find_prefers_exact_alias_match_before_prefix_fallback() {
+        let models = WorkerModels::from(vec![ModelCard::new("grok-4-0709").with_alias("grok-4")]);
+
+        let result = models.find("grok-4").expect("alias match");
+
+        assert_eq!(result.id, "grok-4-0709");
+    }
+
+    #[test]
+    fn find_uses_prefix_fallback_for_versioned_models() {
+        let models = WorkerModels::from(vec![card("grok-4-0709", 1_752_019_200)]);
+
+        let result = models.find("grok-4").expect("prefix fallback");
+
+        assert_eq!(result.id, "grok-4-0709");
+    }
+
+    #[test]
+    fn find_prefix_fallback_picks_latest_created_variant() {
+        let models = WorkerModels::from(vec![
+            card("grok-4-fast-v1", 1_756_944_000),
+            card("grok-4-fast-v2", 1_756_944_001),
+        ]);
+
+        let result = models.find("grok-4-fast").expect("latest prefix match");
+
+        assert_eq!(result.id, "grok-4-fast-v2");
+    }
+
+    #[test]
+    fn find_prefix_fallback_prefers_shortest_direct_descendant() {
+        let models = WorkerModels::from(vec![
+            card("grok-4-0709", 1_752_019_200),
+            card("grok-4.20-0309-reasoning", 1_773_014_400),
+            card("grok-4.20-0309-non-reasoning", 1_773_014_399),
+        ]);
+
+        let result = models.find("grok-4").expect("shortest prefix match");
+
+        assert_eq!(result.id, "grok-4-0709");
+    }
+
+    #[test]
+    fn find_prefix_fallback_allows_dot_variants() {
+        let models = WorkerModels::from(vec![
+            card("grok-4.20-0309-reasoning", 1_773_014_400),
+            card("grok-4.20-0309-non-reasoning", 1_773_014_399),
+        ]);
+
+        let result = models.find("grok-4.20").expect("dot prefix match");
+
+        assert_eq!(result.id, "grok-4.20-0309-reasoning");
+    }
+
+    #[test]
+    fn find_prefix_fallback_rejects_false_positive_family_match() {
+        let models = WorkerModels::from(vec![card("grok-40", 100)]);
+
+        assert!(models.find("grok-4").is_none());
+    }
+
+    #[test]
+    fn find_prefix_fallback_rejects_truncated_family_name() {
+        let models = WorkerModels::from(vec![card("grok-4-0709", 1_752_019_200)]);
+
+        assert!(models.find("grok").is_none());
     }
 }
 

--- a/crates/protocols/src/worker.rs
+++ b/crates/protocols/src/worker.rs
@@ -583,33 +583,18 @@ mod worker_models_tests {
     }
 
     #[test]
-    fn find_prefers_alias_match_before_prefix_fallback() {
-        let models = WorkerModels::from(vec![ModelCard::new("grok-4-0709").with_alias("grok-4")]);
-
-        let result = models.find("grok-4").expect("alias match");
-
-        assert_eq!(result.id, "grok-4-0709");
-    }
-
-    #[test]
-    fn find_prefers_exact_id_over_alias_match() {
+    fn find_exact_and_alias_matches_beat_prefix_fallback() {
         let models = WorkerModels::from(vec![
             ModelCard::new("grok-4-0709").with_alias("grok-4"),
             card("grok-4", 1_752_019_201),
+            ModelCard::new("grok-4-fast-v1").with_alias("grok-4-fast"),
         ]);
 
-        let result = models.find("grok-4").expect("exact id match");
-
-        assert_eq!(result.id, "grok-4");
-    }
-
-    #[test]
-    fn find_uses_prefix_fallback_for_versioned_models() {
-        let models = WorkerModels::from(vec![card("grok-4-0709", 1_752_019_200)]);
-
-        let result = models.find("grok-4").expect("prefix fallback");
-
-        assert_eq!(result.id, "grok-4-0709");
+        assert_eq!(models.find("grok-4").expect("exact id match").id, "grok-4");
+        assert_eq!(
+            models.find("grok-4-fast").expect("alias match").id,
+            "grok-4-fast-v1"
+        );
     }
 
     #[test]
@@ -637,41 +622,22 @@ mod worker_models_tests {
     }
 
     #[test]
-    fn find_prefix_fallback_prefers_shortest_direct_descendant() {
+    fn find_prefix_fallback_handles_shortest_dot_and_guard_cases() {
         let models = WorkerModels::from(vec![
             card("grok-4-0709", 1_752_019_200),
             card("grok-4.20-0309-reasoning", 1_773_014_400),
-            card("grok-4.20-0309-non-reasoning", 1_773_014_399),
+            card("grok-40", 1_773_014_399),
         ]);
 
-        let result = models.find("grok-4").expect("shortest prefix match");
-
-        assert_eq!(result.id, "grok-4-0709");
-    }
-
-    #[test]
-    fn find_prefix_fallback_allows_dot_variants() {
-        let models = WorkerModels::from(vec![
-            card("grok-4.20-0309-reasoning", 1_773_014_400),
-            card("grok-4.20-0309-non-reasoning", 1_773_014_399),
-        ]);
-
-        let result = models.find("grok-4.20").expect("dot prefix match");
-
-        assert_eq!(result.id, "grok-4.20-0309-reasoning");
-    }
-
-    #[test]
-    fn find_prefix_fallback_rejects_false_positive_family_match() {
-        let models = WorkerModels::from(vec![card("grok-40", 100)]);
-
-        assert!(models.find("grok-4").is_none());
-    }
-
-    #[test]
-    fn find_prefix_fallback_rejects_truncated_family_name() {
-        let models = WorkerModels::from(vec![card("grok-4-0709", 1_752_019_200)]);
-
+        assert_eq!(
+            models.find("grok-4").expect("shortest prefix match").id,
+            "grok-4-0709"
+        );
+        assert_eq!(
+            models.find("grok-4.20").expect("dot prefix match").id,
+            "grok-4.20-0309-reasoning"
+        );
+        assert!(models.find("grok-4x").is_none());
         assert!(models.find("grok").is_none());
     }
 }

--- a/crates/protocols/src/worker.rs
+++ b/crates/protocols/src/worker.rs
@@ -610,18 +610,6 @@ mod worker_models_tests {
     }
 
     #[test]
-    fn find_prefix_fallback_uses_lexical_id_as_stable_final_tiebreaker() {
-        let models = WorkerModels::from(vec![
-            card("grok-4-fast-ab", 1_756_944_000),
-            card("grok-4-fast-aa", 1_756_944_000),
-        ]);
-
-        let result = models.find("grok-4-fast").expect("stable prefix match");
-
-        assert_eq!(result.id, "grok-4-fast-aa");
-    }
-
-    #[test]
     fn find_prefix_fallback_handles_shortest_dot_and_guard_cases() {
         let models = WorkerModels::from(vec![
             card("grok-4-0709", 1_752_019_200),

--- a/crates/protocols/src/worker.rs
+++ b/crates/protocols/src/worker.rs
@@ -464,19 +464,36 @@ impl WorkerModels {
     /// Find a model by ID.
     ///
     /// Lookup order:
-    /// 1. Exact ID or alias match via `ModelCard::matches`
-    /// 2. Prefix fallback for versioned variants like `grok-4-0709` or
+    /// 1. Exact ID match
+    /// 2. Alias match
+    /// 3. Prefix fallback for versioned variants like `grok-4-0709` or
     ///    `grok-4.20-0309-reasoning`, preferring the shortest matching ID
     ///    first and then the highest `created_at` as a tiebreaker among cards
-    ///    whose IDs start with `{id}-` or `{id}.`
+    ///    whose IDs start with `{id}-` or `{id}.`, with lexical ID ordering
+    ///    as a final stable tiebreaker.
     pub fn find(&self, id: &str) -> Option<&ModelCard> {
         let exact = match self {
             Self::Wildcard => None,
-            Self::Single(card) => card.matches(id).then_some(card.as_ref()),
-            Self::Multi(cards) => cards.iter().find(|m| m.matches(id)),
+            Self::Single(card) => (card.id == id).then_some(card.as_ref()),
+            Self::Multi(cards) => cards.iter().find(|card| card.id == id),
         };
         if exact.is_some() {
             return exact;
+        }
+
+        let alias = match self {
+            Self::Wildcard => None,
+            Self::Single(card) => card
+                .aliases
+                .iter()
+                .any(|alias| alias == id)
+                .then_some(card.as_ref()),
+            Self::Multi(cards) => cards
+                .iter()
+                .find(|card| card.aliases.iter().any(|alias| alias == id)),
+        };
+        if alias.is_some() {
+            return alias;
         }
 
         let candidates = self.all();
@@ -491,7 +508,13 @@ impl WorkerModels {
                     .strip_prefix(id)
                     .is_some_and(|rest| rest.starts_with('-') || rest.starts_with('.'))
             })
-            .min_by_key(|card| (card.id.len(), std::cmp::Reverse(card.created_at)))
+            .min_by_key(|card| {
+                (
+                    card.id.len(),
+                    std::cmp::Reverse(card.created_at),
+                    card.id.as_str(),
+                )
+            })
     }
 
     /// Returns `true` if the worker supports the given model ID.
@@ -560,12 +583,24 @@ mod worker_models_tests {
     }
 
     #[test]
-    fn find_prefers_exact_alias_match_before_prefix_fallback() {
+    fn find_prefers_alias_match_before_prefix_fallback() {
         let models = WorkerModels::from(vec![ModelCard::new("grok-4-0709").with_alias("grok-4")]);
 
         let result = models.find("grok-4").expect("alias match");
 
         assert_eq!(result.id, "grok-4-0709");
+    }
+
+    #[test]
+    fn find_prefers_exact_id_over_alias_match() {
+        let models = WorkerModels::from(vec![
+            ModelCard::new("grok-4-0709").with_alias("grok-4"),
+            card("grok-4", 1_752_019_201),
+        ]);
+
+        let result = models.find("grok-4").expect("exact id match");
+
+        assert_eq!(result.id, "grok-4");
     }
 
     #[test]
@@ -587,6 +622,18 @@ mod worker_models_tests {
         let result = models.find("grok-4-fast").expect("latest prefix match");
 
         assert_eq!(result.id, "grok-4-fast-v2");
+    }
+
+    #[test]
+    fn find_prefix_fallback_uses_lexical_id_as_stable_final_tiebreaker() {
+        let models = WorkerModels::from(vec![
+            card("grok-4-fast-ab", 1_756_944_000),
+            card("grok-4-fast-aa", 1_756_944_000),
+        ]);
+
+        let result = models.find("grok-4-fast").expect("stable prefix match");
+
+        assert_eq!(result.id, "grok-4-fast-aa");
     }
 
     #[test]

--- a/model_gateway/src/routers/common/worker_selection.rs
+++ b/model_gateway/src/routers/common/worker_selection.rs
@@ -16,7 +16,7 @@ use crate::{
         error,
     },
     worker::{ConnectionMode, ProviderType, RuntimeType, Worker, WorkerRegistry, WorkerType},
-    workflow::steps::external::{group_models_into_cards, ModelsResponse},
+    workflow::steps::external::{apply_provider_hint, group_models_into_cards, ModelsResponse},
 };
 
 /// Holds references to shared infrastructure needed for worker selection.
@@ -244,12 +244,7 @@ async fn refresh_worker_models(
                 Ok(resp) => {
                     let provider = ProviderType::from_url(&url);
                     let mut model_cards = group_models_into_cards(resp.data);
-
-                    if let Some(ref provider) = provider {
-                        for card in &mut model_cards {
-                            card.provider = Some(provider.clone());
-                        }
-                    }
+                    apply_provider_hint(&mut model_cards, provider.as_ref());
 
                     if !model_cards.is_empty() {
                         tracing::info!(

--- a/model_gateway/src/routers/common/worker_selection.rs
+++ b/model_gateway/src/routers/common/worker_selection.rs
@@ -9,7 +9,6 @@ use axum::{
     response::Response,
 };
 use futures_util::future::join_all;
-use openai_protocol::models::ListModelsResponse;
 
 use crate::{
     routers::{
@@ -17,6 +16,7 @@ use crate::{
         error,
     },
     worker::{ConnectionMode, ProviderType, RuntimeType, Worker, WorkerRegistry, WorkerType},
+    workflow::steps::external::{group_models_into_cards, ModelsResponse},
 };
 
 /// Holds references to shared infrastructure needed for worker selection.
@@ -216,7 +216,9 @@ fn filter_by_provider(
 ///
 /// Auth headers are adapted per-vendor via [`apply_provider_headers`] (e.g.
 /// Anthropic uses `x-api-key`, OpenAI uses `Authorization: Bearer`). The
-/// response is parsed via [`ListModelsResponse::parse_upstream`].
+/// response is rebuilt with the same model-card construction path used during
+/// external-worker registration so aliases and creation timestamps stay
+/// consistent after refresh-on-miss.
 async fn refresh_worker_models(
     client: &reqwest::Client,
     worker: &Arc<dyn Worker>,
@@ -238,14 +240,20 @@ async fn refresh_worker_models(
 
     match backend_req.send().await {
         Ok(response) if response.status().is_success() => {
-            match response.json::<serde_json::Value>().await {
-                Ok(json) => {
+            match response.json::<ModelsResponse>().await {
+                Ok(resp) => {
                     let provider = ProviderType::from_url(&url);
-                    let model_cards = ListModelsResponse::parse_upstream(&json, provider);
+                    let mut model_cards = group_models_into_cards(resp.data);
+
+                    if let Some(ref provider) = provider {
+                        for card in &mut model_cards {
+                            card.provider = Some(provider.clone());
+                        }
+                    }
 
                     if !model_cards.is_empty() {
                         tracing::info!(
-                            "Model refresh: found {} models from {}",
+                            "Model refresh: found {} model cards from {}",
                             model_cards.len(),
                             url
                         );

--- a/model_gateway/src/routers/router_manager.rs
+++ b/model_gateway/src/routers/router_manager.rs
@@ -71,10 +71,10 @@ fn collect_alias_fallback_workers(
             continue;
         }
 
-        if worker.metadata().is_wildcard() {
-            wildcard_matches.push(worker);
-        } else {
+        if worker.has_models_discovered() {
             specific_matches.push(worker);
+        } else {
+            wildcard_matches.push(worker);
         }
     }
 
@@ -213,11 +213,18 @@ impl RouterManager {
     }
 
     pub fn get_router_for_model(&self, model_id: &str) -> Option<Arc<dyn RouterTrait>> {
-        let workers = self.worker_registry.get_by_model(model_id);
-        let alias_workers = workers
+        let indexed_workers = self.worker_registry.get_by_model(model_id);
+        let supported_indexed_workers: Vec<_> = indexed_workers
+            .iter()
+            .filter(|worker| worker.supports_model(model_id))
+            .cloned()
+            .collect();
+        let alias_workers = supported_indexed_workers
             .is_empty()
             .then(|| collect_alias_fallback_workers(self.worker_registry.get_all(), model_id));
-        let workers = alias_workers.as_deref().unwrap_or(&workers);
+        let workers = alias_workers
+            .as_deref()
+            .unwrap_or(&supported_indexed_workers);
 
         // Find the best router ID based on worker capabilities
         // Priority: external (provider-specific) > grpc-pd > http-pd > grpc-regular > http-regular
@@ -907,6 +914,29 @@ mod tests {
     }
 
     #[test]
+    fn collect_alias_fallback_workers_treats_discovered_models_as_specific_matches() {
+        let wildcard = ready_external_worker(
+            "https://api.openai.com",
+            ProviderType::OpenAI,
+            openai_protocol::worker::WorkerModels::Wildcard,
+        );
+        let discovered = ready_external_worker(
+            "https://api.anthropic.com",
+            ProviderType::Anthropic,
+            openai_protocol::worker::WorkerModels::Wildcard,
+        );
+        discovered.set_models(vec![
+            ModelCard::new("claude-3-7-sonnet-20250219").with_alias("claude-3-7-sonnet")
+        ]);
+
+        let selected =
+            collect_alias_fallback_workers(vec![wildcard, discovered.clone()], "claude-3-7-sonnet");
+
+        assert_eq!(selected.len(), 1);
+        assert_eq!(selected[0].url(), discovered.url());
+    }
+
+    #[test]
     fn get_router_for_model_prefers_specific_provider_router_over_wildcard_router() {
         let worker_registry = Arc::new(WorkerRegistry::new());
         worker_registry.register(ready_external_worker(
@@ -914,6 +944,36 @@ mod tests {
             ProviderType::OpenAI,
             openai_protocol::worker::WorkerModels::Wildcard,
         ));
+        worker_registry.register(ready_external_worker(
+            "https://api.anthropic.com",
+            ProviderType::Anthropic,
+            vec![ModelCard::new("claude-3-7-sonnet-20250219").with_alias("claude-3-7-sonnet")],
+        ));
+
+        let manager = RouterManager::new(worker_registry, reqwest::Client::new());
+        manager.register_router(router_ids::HTTP_OPENAI, Arc::new(FakeRouter("openai")));
+        manager.register_router(
+            router_ids::HTTP_ANTHROPIC,
+            Arc::new(FakeRouter("anthropic")),
+        );
+
+        let router = manager
+            .get_router_for_model("claude-3-7-sonnet")
+            .expect("router for alias model");
+
+        assert_eq!(router.router_type(), "anthropic");
+    }
+
+    #[test]
+    fn get_router_for_model_ignores_stale_indexed_workers_before_alias_fallback() {
+        let worker_registry = Arc::new(WorkerRegistry::new());
+        let stale_indexed = ready_external_worker(
+            "https://api.openai.com",
+            ProviderType::OpenAI,
+            vec![ModelCard::new("claude-3-7-sonnet")],
+        );
+        stale_indexed.set_models(vec![ModelCard::new("gpt-4o-mini")]);
+        worker_registry.register(stale_indexed);
         worker_registry.register(ready_external_worker(
             "https://api.anthropic.com",
             ProviderType::Anthropic,

--- a/model_gateway/src/routers/router_manager.rs
+++ b/model_gateway/src/routers/router_manager.rs
@@ -889,8 +889,11 @@ mod tests {
         let specific = ready_external_worker(
             "https://api.anthropic.com",
             ProviderType::Anthropic,
-            vec![ModelCard::new("claude-3-7-sonnet-20250219").with_alias("claude-3-7-sonnet")],
+            openai_protocol::worker::WorkerModels::Wildcard,
         );
+        specific.set_models(vec![
+            ModelCard::new("claude-3-7-sonnet-20250219").with_alias("claude-3-7-sonnet")
+        ]);
 
         let selected =
             collect_alias_fallback_workers(vec![wildcard, specific.clone()], "claude-3-7-sonnet");
@@ -911,57 +914,6 @@ mod tests {
 
         assert_eq!(selected.len(), 1);
         assert_eq!(selected[0].url(), wildcard.url());
-    }
-
-    #[test]
-    fn collect_alias_fallback_workers_treats_discovered_models_as_specific_matches() {
-        let wildcard = ready_external_worker(
-            "https://api.openai.com",
-            ProviderType::OpenAI,
-            openai_protocol::worker::WorkerModels::Wildcard,
-        );
-        let discovered = ready_external_worker(
-            "https://api.anthropic.com",
-            ProviderType::Anthropic,
-            openai_protocol::worker::WorkerModels::Wildcard,
-        );
-        discovered.set_models(vec![
-            ModelCard::new("claude-3-7-sonnet-20250219").with_alias("claude-3-7-sonnet")
-        ]);
-
-        let selected =
-            collect_alias_fallback_workers(vec![wildcard, discovered.clone()], "claude-3-7-sonnet");
-
-        assert_eq!(selected.len(), 1);
-        assert_eq!(selected[0].url(), discovered.url());
-    }
-
-    #[test]
-    fn get_router_for_model_prefers_specific_provider_router_over_wildcard_router() {
-        let worker_registry = Arc::new(WorkerRegistry::new());
-        worker_registry.register(ready_external_worker(
-            "https://api.openai.com",
-            ProviderType::OpenAI,
-            openai_protocol::worker::WorkerModels::Wildcard,
-        ));
-        worker_registry.register(ready_external_worker(
-            "https://api.anthropic.com",
-            ProviderType::Anthropic,
-            vec![ModelCard::new("claude-3-7-sonnet-20250219").with_alias("claude-3-7-sonnet")],
-        ));
-
-        let manager = RouterManager::new(worker_registry, reqwest::Client::new());
-        manager.register_router(router_ids::HTTP_OPENAI, Arc::new(FakeRouter("openai")));
-        manager.register_router(
-            router_ids::HTTP_ANTHROPIC,
-            Arc::new(FakeRouter("anthropic")),
-        );
-
-        let router = manager
-            .get_router_for_model("claude-3-7-sonnet")
-            .expect("router for alias model");
-
-        assert_eq!(router.router_type(), "anthropic");
     }
 
     #[test]

--- a/model_gateway/src/routers/router_manager.rs
+++ b/model_gateway/src/routers/router_manager.rs
@@ -188,6 +188,14 @@ impl RouterManager {
 
     pub fn get_router_for_model(&self, model_id: &str) -> Option<Arc<dyn RouterTrait>> {
         let workers = self.worker_registry.get_by_model(model_id);
+        let alias_workers = workers.is_empty().then(|| {
+            self.worker_registry
+                .get_all()
+                .into_iter()
+                .filter(|worker| worker.supports_model(model_id))
+                .collect::<Vec<_>>()
+        });
+        let workers = alias_workers.as_deref().unwrap_or(&workers);
 
         // Find the best router ID based on worker capabilities
         // Priority: external (provider-specific) > grpc-pd > http-pd > grpc-regular > http-regular

--- a/model_gateway/src/routers/router_manager.rs
+++ b/model_gateway/src/routers/router_manager.rs
@@ -59,6 +59,32 @@ pub struct RouterManager {
     enable_igw: bool,
 }
 
+fn collect_alias_fallback_workers(
+    workers: impl IntoIterator<Item = Arc<dyn crate::worker::Worker>>,
+    model_id: &str,
+) -> Vec<Arc<dyn crate::worker::Worker>> {
+    let mut specific_matches = Vec::new();
+    let mut wildcard_matches = Vec::new();
+
+    for worker in workers {
+        if !worker.supports_model(model_id) {
+            continue;
+        }
+
+        if worker.metadata().is_wildcard() {
+            wildcard_matches.push(worker);
+        } else {
+            specific_matches.push(worker);
+        }
+    }
+
+    if specific_matches.is_empty() {
+        wildcard_matches
+    } else {
+        specific_matches
+    }
+}
+
 impl RouterManager {
     pub fn new(worker_registry: Arc<WorkerRegistry>, client: reqwest::Client) -> Self {
         Self {
@@ -188,13 +214,9 @@ impl RouterManager {
 
     pub fn get_router_for_model(&self, model_id: &str) -> Option<Arc<dyn RouterTrait>> {
         let workers = self.worker_registry.get_by_model(model_id);
-        let alias_workers = workers.is_empty().then(|| {
-            self.worker_registry
-                .get_all()
-                .into_iter()
-                .filter(|worker| worker.supports_model(model_id))
-                .collect::<Vec<_>>()
-        });
+        let alias_workers = workers
+            .is_empty()
+            .then(|| collect_alias_fallback_workers(self.worker_registry.get_all(), model_id));
         let workers = alias_workers.as_deref().unwrap_or(&workers);
 
         // Find the best router ID based on worker capabilities
@@ -799,5 +821,116 @@ impl std::fmt::Debug for RouterManager {
             .field("workers_count", &self.worker_registry.get_all().len())
             .field("default_router", &*default_router)
             .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{any::Any, sync::Arc};
+
+    use async_trait::async_trait;
+    use openai_protocol::worker::{HealthCheckConfig, WorkerSpec};
+
+    use super::*;
+    use crate::{
+        routers::{factory::router_ids, RouterTrait},
+        worker::{BasicWorkerBuilder, Worker},
+    };
+
+    #[derive(Debug)]
+    struct FakeRouter(&'static str);
+
+    #[async_trait]
+    impl RouterTrait for FakeRouter {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+
+        fn router_type(&self) -> &'static str {
+            self.0
+        }
+    }
+
+    fn ready_external_worker(
+        url: &str,
+        provider: ProviderType,
+        models: impl Into<openai_protocol::worker::WorkerModels>,
+    ) -> Arc<dyn Worker> {
+        let mut spec = WorkerSpec::new(url);
+        spec.runtime_type = RuntimeType::External;
+        spec.worker_type = WorkerType::Regular;
+        spec.provider = Some(provider);
+        spec.models = models.into();
+
+        Arc::new(
+            BasicWorkerBuilder::from_spec(spec)
+                .health_config(HealthCheckConfig {
+                    disable_health_check: true,
+                    ..Default::default()
+                })
+                .build(),
+        )
+    }
+
+    #[test]
+    fn collect_alias_fallback_workers_prefers_specific_matches_over_wildcards() {
+        let wildcard = ready_external_worker(
+            "https://api.openai.com",
+            ProviderType::OpenAI,
+            openai_protocol::worker::WorkerModels::Wildcard,
+        );
+        let specific = ready_external_worker(
+            "https://api.anthropic.com",
+            ProviderType::Anthropic,
+            vec![ModelCard::new("claude-3-7-sonnet-20250219").with_alias("claude-3-7-sonnet")],
+        );
+
+        let selected =
+            collect_alias_fallback_workers(vec![wildcard, specific.clone()], "claude-3-7-sonnet");
+
+        assert_eq!(selected.len(), 1);
+        assert_eq!(selected[0].url(), specific.url());
+    }
+
+    #[test]
+    fn collect_alias_fallback_workers_keeps_wildcards_when_no_specific_match_exists() {
+        let wildcard = ready_external_worker(
+            "https://api.openai.com",
+            ProviderType::OpenAI,
+            openai_protocol::worker::WorkerModels::Wildcard,
+        );
+
+        let selected = collect_alias_fallback_workers(vec![wildcard.clone()], "unknown-model");
+
+        assert_eq!(selected.len(), 1);
+        assert_eq!(selected[0].url(), wildcard.url());
+    }
+
+    #[test]
+    fn get_router_for_model_prefers_specific_provider_router_over_wildcard_router() {
+        let worker_registry = Arc::new(WorkerRegistry::new());
+        worker_registry.register(ready_external_worker(
+            "https://api.openai.com",
+            ProviderType::OpenAI,
+            openai_protocol::worker::WorkerModels::Wildcard,
+        ));
+        worker_registry.register(ready_external_worker(
+            "https://api.anthropic.com",
+            ProviderType::Anthropic,
+            vec![ModelCard::new("claude-3-7-sonnet-20250219").with_alias("claude-3-7-sonnet")],
+        ));
+
+        let manager = RouterManager::new(worker_registry, reqwest::Client::new());
+        manager.register_router(router_ids::HTTP_OPENAI, Arc::new(FakeRouter("openai")));
+        manager.register_router(
+            router_ids::HTTP_ANTHROPIC,
+            Arc::new(FakeRouter("anthropic")),
+        );
+
+        let router = manager
+            .get_router_for_model("claude-3-7-sonnet")
+            .expect("router for alias model");
+
+        assert_eq!(router.router_type(), "anthropic");
     }
 }

--- a/model_gateway/src/routers/router_manager.rs
+++ b/model_gateway/src/routers/router_manager.rs
@@ -903,20 +903,6 @@ mod tests {
     }
 
     #[test]
-    fn collect_alias_fallback_workers_keeps_wildcards_when_no_specific_match_exists() {
-        let wildcard = ready_external_worker(
-            "https://api.openai.com",
-            ProviderType::OpenAI,
-            openai_protocol::worker::WorkerModels::Wildcard,
-        );
-
-        let selected = collect_alias_fallback_workers(vec![wildcard.clone()], "unknown-model");
-
-        assert_eq!(selected.len(), 1);
-        assert_eq!(selected[0].url(), wildcard.url());
-    }
-
-    #[test]
     fn get_router_for_model_ignores_stale_indexed_workers_before_alias_fallback() {
         let worker_registry = Arc::new(WorkerRegistry::new());
         let stale_indexed = ready_external_worker(

--- a/model_gateway/src/workflow/steps/external/discover_models.rs
+++ b/model_gateway/src/workflow/steps/external/discover_models.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use once_cell::sync::Lazy;
 use openai_protocol::{model_card::ModelCard, model_type::ModelType, worker::ProviderType};
 use reqwest::Client;
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 use tracing::{debug, info};
 use wfaas::{StepExecutor, StepId, StepResult, WorkflowContext, WorkflowError, WorkflowResult};
 
@@ -36,7 +36,7 @@ pub struct ModelsResponse {
 #[derive(Debug, Clone, Deserialize)]
 pub struct ModelInfo {
     pub id: String,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_aliases")]
     pub aliases: Vec<String>,
     #[serde(default)]
     pub object: String,
@@ -44,6 +44,24 @@ pub struct ModelInfo {
     pub created: Option<u64>,
     #[serde(default)]
     pub owned_by: Option<String>,
+}
+
+fn deserialize_aliases<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum AliasesField {
+        Values(Vec<String>),
+        Null(Option<()>),
+        Other(serde::de::IgnoredAny),
+    }
+
+    Ok(match AliasesField::deserialize(deserializer)? {
+        AliasesField::Values(values) => values,
+        AliasesField::Null(_) | AliasesField::Other(_) => Vec::new(),
+    })
 }
 
 /// Convert a flat upstream `/v1/models` list into `ModelCard`s.
@@ -323,10 +341,11 @@ impl StepExecutor<WorkerWorkflowData> for DiscoverModelsStep {
 #[cfg(test)]
 mod tests {
     use openai_protocol::{model_type::ModelType, worker::ProviderType};
+    use serde_json::json;
 
     use super::{
         apply_provider_hint, build_model_cards, group_models_into_cards, infer_model_type_from_id,
-        ModelInfo,
+        ModelInfo, ModelsResponse,
     };
 
     #[test]
@@ -402,5 +421,41 @@ mod tests {
         apply_provider_hint(&mut cards, Some(&ProviderType::Gemini));
 
         assert_eq!(cards[0].provider, Some(ProviderType::Gemini));
+    }
+
+    #[test]
+    fn models_response_tolerates_null_aliases() {
+        let response: ModelsResponse = serde_json::from_value(json!({
+            "data": [
+                {
+                    "id": "grok-4-0709",
+                    "aliases": null,
+                    "object": "model",
+                    "created": 1_752_019_200
+                }
+            ],
+            "object": "list"
+        }))
+        .expect("null aliases should deserialize");
+
+        assert_eq!(response.data[0].aliases, Vec::<String>::new());
+    }
+
+    #[test]
+    fn models_response_ignores_malformed_aliases_field() {
+        let response: ModelsResponse = serde_json::from_value(json!({
+            "data": [
+                {
+                    "id": "grok-4-0709",
+                    "aliases": "grok-4",
+                    "object": "model",
+                    "created": 1_752_019_200
+                }
+            ],
+            "object": "list"
+        }))
+        .expect("malformed aliases should not fail discovery");
+
+        assert_eq!(response.data[0].aliases, Vec::<String>::new());
     }
 }

--- a/model_gateway/src/workflow/steps/external/discover_models.rs
+++ b/model_gateway/src/workflow/steps/external/discover_models.rs
@@ -1,11 +1,10 @@
 //! Model discovery step for external API endpoints.
 
-use std::{collections::HashMap, time::Duration};
+use std::time::Duration;
 
 use async_trait::async_trait;
 use once_cell::sync::Lazy;
 use openai_protocol::{model_card::ModelCard, model_type::ModelType, worker::ProviderType};
-use regex::Regex;
 use reqwest::Client;
 use serde::Deserialize;
 use tracing::{debug, info};
@@ -25,14 +24,6 @@ static HTTP_CLIENT: Lazy<Client> = Lazy::new(|| {
         .expect("Failed to create HTTP client")
 });
 
-// Regex to strip date suffix: -YYYY-MM-DD or -YYYY-MM
-#[expect(
-    clippy::expect_used,
-    reason = "Lazy static initialization — compile-time constant regex pattern cannot fail"
-)]
-static DATE_SUFFIX_PATTERN: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"-\d{4}-\d{2}(-\d{2})?$").expect("Invalid date regex"));
-
 /// OpenAI /v1/models response format.
 #[derive(Debug, Clone, Deserialize)]
 pub struct ModelsResponse {
@@ -46,6 +37,8 @@ pub struct ModelsResponse {
 pub struct ModelInfo {
     pub id: String,
     #[serde(default)]
+    pub aliases: Vec<String>,
+    #[serde(default)]
     pub object: String,
     #[serde(default)]
     pub created: Option<u64>,
@@ -53,43 +46,40 @@ pub struct ModelInfo {
     pub owned_by: Option<String>,
 }
 
-/// Group models by base name (stripping date suffixes) and create ModelCards with aliases.
+/// Convert a flat upstream `/v1/models` list into `ModelCard`s.
 ///
-/// # Example
-/// Input:  `["gpt-4o", "gpt-4o-2024-05-13", "gpt-4o-2024-08-06", "gpt-4o-2024-11-20"]`
-/// Output: `ModelCard { id: "gpt-4o", aliases: ["gpt-4o-2024-05-13", "gpt-4o-2024-08-06", "gpt-4o-2024-11-20"] }`
-pub fn group_models_into_cards(models: Vec<ModelInfo>) -> Vec<ModelCard> {
-    // Group model IDs by base name (with date stripped)
-    let mut groups: HashMap<String, Vec<String>> = HashMap::new();
-    for model in &models {
-        let base = DATE_SUFFIX_PATTERN.replace(&model.id, "").to_string();
-        groups.entry(base).or_default().push(model.id.clone());
-    }
+/// Upstream IDs are preserved as-is. Virtual short aliases like `grok-4` are
+/// resolved later by `WorkerModels::find` via prefix fallback.
+pub fn build_model_cards(models: Vec<ModelInfo>) -> Vec<ModelCard> {
+    models
+        .into_iter()
+        .map(|model| {
+            let mut card = ModelCard::new(&model.id)
+                .with_model_type(infer_model_type_from_id(&model.id))
+                .with_created_at(model.created.unwrap_or(0));
 
-    // Create ModelCard for each group
-    groups
-        .into_values()
-        .map(|mut variants| {
-            // Sort: shortest first (base name), then alphabetically
-            variants.sort_by(|a, b| a.len().cmp(&b.len()).then_with(|| a.cmp(b)));
-
-            let primary_id = variants.remove(0); // shortest = primary ID
-            let aliases = variants; // rest = aliases
-
-            let model_type = infer_model_type_from_id(&primary_id);
-            let provider = infer_provider_from_id(&primary_id);
-
-            let mut card = ModelCard::new(&primary_id)
-                .with_aliases(aliases)
-                .with_model_type(model_type);
-
-            if let Some(p) = provider {
-                card = card.with_provider(p);
+            if !model.aliases.is_empty() {
+                card = card.with_aliases(model.aliases);
             }
 
+            card.provider = infer_provider_from_id(&card.id);
             card
         })
         .collect()
+}
+
+fn apply_provider_hint(model_cards: &mut [ModelCard], provider: Option<&ProviderType>) {
+    if let Some(provider) = provider {
+        for card in model_cards {
+            card.provider = Some(provider.clone());
+        }
+    }
+}
+
+/// Kept for backwards compatibility with existing call sites.
+#[inline]
+pub fn group_models_into_cards(models: Vec<ModelInfo>) -> Vec<ModelCard> {
+    build_model_cards(models)
 }
 
 /// Infer ModelType from model ID string.
@@ -129,13 +119,23 @@ pub fn infer_model_type_from_id(id: &str) -> ModelType {
         return ModelType::MODERATION_MODEL;
     }
 
+    // Reasoning models
+    let is_reasoning = id_lower.starts_with("o1")
+        || id_lower.starts_with("o3")
+        || (id_lower.contains("reasoning") && !id_lower.contains("non-reasoning"));
+
     // Vision LLM
-    if id_lower.contains("vision") || id_lower.contains("4o") {
+    let is_vision = id_lower.contains("vision") || id_lower.contains("4o");
+
+    if is_reasoning && is_vision {
+        return ModelType::FULL_LLM;
+    }
+
+    if is_vision {
         return ModelType::VISION_LLM;
     }
 
-    // Reasoning models
-    if id_lower.starts_with("o1") || id_lower.starts_with("o3") {
+    if is_reasoning {
         return ModelType::REASONING_LLM;
     }
 
@@ -247,7 +247,8 @@ async fn fetch_models(
         url
     );
 
-    let model_cards = group_models_into_cards(models_response.data);
+    let mut model_cards = group_models_into_cards(models_response.data);
+    apply_provider_hint(&mut model_cards, provider);
 
     debug!(
         "Grouped into {} model cards with aliases",
@@ -316,5 +317,90 @@ impl StepExecutor<WorkerWorkflowData> for DiscoverModelsStep {
 
     fn is_retryable(&self, _error: &WorkflowError) -> bool {
         true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use openai_protocol::{model_type::ModelType, worker::ProviderType};
+
+    use super::{
+        apply_provider_hint, build_model_cards, group_models_into_cards, infer_model_type_from_id,
+        ModelInfo,
+    };
+
+    #[test]
+    fn group_models_into_cards_preserves_created_at_and_aliases() {
+        let cards = group_models_into_cards(vec![ModelInfo {
+            id: "grok-4-0709".to_string(),
+            aliases: vec!["grok-4".to_string()],
+            object: "model".to_string(),
+            created: Some(1_752_019_200),
+            owned_by: None,
+        }]);
+
+        assert_eq!(cards.len(), 1);
+        assert_eq!(cards[0].id, "grok-4-0709");
+        assert_eq!(cards[0].aliases, vec!["grok-4"]);
+        assert_eq!(cards[0].provider, Some(ProviderType::XAI));
+        assert_eq!(cards[0].model_type, ModelType::LLM);
+        assert_eq!(cards[0].created_at, 1_752_019_200);
+    }
+
+    #[test]
+    fn build_model_cards_keeps_flat_ids_for_prefix_fallback_lookup() {
+        let cards = build_model_cards(vec![
+            ModelInfo {
+                id: "gpt-4o-2024-05-13".to_string(),
+                aliases: Vec::new(),
+                object: "model".to_string(),
+                created: Some(1_715_000_000),
+                owned_by: None,
+            },
+            ModelInfo {
+                id: "gpt-4o-2024-11-20".to_string(),
+                aliases: Vec::new(),
+                object: "model".to_string(),
+                created: Some(1_732_000_000),
+                owned_by: None,
+            },
+        ]);
+
+        assert_eq!(cards.len(), 2);
+        assert_eq!(cards[0].aliases, Vec::<String>::new());
+        assert_eq!(cards[1].aliases, Vec::<String>::new());
+    }
+
+    #[test]
+    fn infer_model_type_marks_reasoning_before_visionish_suffixes() {
+        assert_eq!(
+            infer_model_type_from_id("grok-4-fast-reasoning"),
+            ModelType::REASONING_LLM
+        );
+    }
+
+    #[test]
+    fn infer_model_type_preserves_vision_when_reasoning_and_vision_both_match() {
+        assert_eq!(
+            infer_model_type_from_id("gpt-4o-reasoning-preview"),
+            ModelType::FULL_LLM
+        );
+    }
+
+    #[test]
+    fn apply_provider_hint_uses_worker_provider_for_prefixed_ids() {
+        let mut cards = build_model_cards(vec![ModelInfo {
+            id: "models/gemini-2.5-pro".to_string(),
+            aliases: Vec::new(),
+            object: "model".to_string(),
+            created: Some(1_752_019_200),
+            owned_by: None,
+        }]);
+
+        assert_eq!(cards[0].provider, None);
+
+        apply_provider_hint(&mut cards, Some(&ProviderType::Gemini));
+
+        assert_eq!(cards[0].provider, Some(ProviderType::Gemini));
     }
 }

--- a/model_gateway/src/workflow/steps/external/discover_models.rs
+++ b/model_gateway/src/workflow/steps/external/discover_models.rs
@@ -370,31 +370,13 @@ mod tests {
     };
 
     #[test]
-    fn group_models_into_cards_preserves_created_at_and_aliases() {
-        let cards = group_models_into_cards(vec![ModelInfo {
-            id: "grok-4-0709".to_string(),
-            aliases: vec!["grok-4".to_string()],
-            object: "model".to_string(),
-            created: Some(1_752_019_200),
-            owned_by: None,
-        }]);
-
-        assert_eq!(cards.len(), 1);
-        assert_eq!(cards[0].id, "grok-4-0709");
-        assert_eq!(cards[0].aliases, vec!["grok-4"]);
-        assert_eq!(cards[0].provider, Some(ProviderType::XAI));
-        assert_eq!(cards[0].model_type, ModelType::LLM);
-        assert_eq!(cards[0].created_at, 1_752_019_200);
-    }
-
-    #[test]
-    fn build_model_cards_keeps_flat_ids_for_prefix_fallback_lookup() {
-        let cards = build_model_cards(vec![
+    fn group_models_into_cards_preserves_flat_ids_and_metadata() {
+        let cards = group_models_into_cards(vec![
             ModelInfo {
-                id: "gpt-4o-2024-05-13".to_string(),
-                aliases: Vec::new(),
+                id: "grok-4-0709".to_string(),
+                aliases: vec!["grok-4".to_string()],
                 object: "model".to_string(),
-                created: Some(1_715_000_000),
+                created: Some(1_752_019_200),
                 owned_by: None,
             },
             ModelInfo {
@@ -407,20 +389,20 @@ mod tests {
         ]);
 
         assert_eq!(cards.len(), 2);
-        assert_eq!(cards[0].aliases, Vec::<String>::new());
+        assert_eq!(cards[0].id, "grok-4-0709");
+        assert_eq!(cards[0].aliases, vec!["grok-4"]);
+        assert_eq!(cards[0].provider, Some(ProviderType::XAI));
+        assert_eq!(cards[0].model_type, ModelType::LLM);
+        assert_eq!(cards[0].created_at, 1_752_019_200);
         assert_eq!(cards[1].aliases, Vec::<String>::new());
     }
 
     #[test]
-    fn infer_model_type_marks_reasoning_before_visionish_suffixes() {
+    fn infer_model_type_handles_reasoning_and_vision_overlap() {
         assert_eq!(
             infer_model_type_from_id("grok-4-fast-reasoning"),
             ModelType::REASONING_LLM
         );
-    }
-
-    #[test]
-    fn infer_model_type_preserves_vision_when_reasoning_and_vision_both_match() {
         assert_eq!(
             infer_model_type_from_id("gpt-4o-reasoning-preview"),
             ModelType::FULL_LLM
@@ -445,7 +427,7 @@ mod tests {
     }
 
     #[test]
-    fn models_response_tolerates_null_aliases() {
+    fn models_response_tolerates_malformed_aliases_and_skips_bad_rows() {
         let response: ModelsResponse = serde_json::from_value(json!({
             "data": [
                 {
@@ -453,60 +435,27 @@ mod tests {
                     "aliases": null,
                     "object": "model",
                     "created": 1_752_019_200
-                }
-            ],
-            "object": "list"
-        }))
-        .expect("null aliases should deserialize");
-
-        assert_eq!(response.data[0].aliases, Vec::<String>::new());
-    }
-
-    #[test]
-    fn models_response_ignores_malformed_aliases_field() {
-        let response: ModelsResponse = serde_json::from_value(json!({
-            "data": [
+                },
                 {
-                    "id": "grok-4-0709",
+                    "id": "grok-4-fast-reasoning",
                     "aliases": "grok-4",
                     "object": "model",
                     "created": 1_752_019_200
-                }
-            ],
-            "object": "list"
-        }))
-        .expect("malformed aliases should not fail discovery");
-
-        assert_eq!(response.data[0].aliases, Vec::<String>::new());
-    }
-
-    #[test]
-    fn models_response_skips_malformed_rows_but_keeps_valid_models() {
-        let response: ModelsResponse = serde_json::from_value(json!({
-            "data": [
+                },
                 {
                     "id": 42,
                     "object": "model",
                     "created": 1_752_019_199
-                },
-                {
-                    "id": "grok-4-0709",
-                    "aliases": ["grok-4"],
-                    "object": "model",
-                    "created": 1_752_019_200
-                },
-                {
-                    "id": "grok-4-fast-reasoning",
-                    "object": "model",
-                    "created": "bad"
                 }
             ],
             "object": "list"
         }))
-        .expect("bad rows should be skipped, not fail the response");
+        .expect("bad rows should be skipped and bad aliases tolerated");
 
-        assert_eq!(response.data.len(), 1);
+        assert_eq!(response.data.len(), 2);
         assert_eq!(response.data[0].id, "grok-4-0709");
-        assert_eq!(response.data[0].aliases, vec!["grok-4"]);
+        assert_eq!(response.data[0].aliases, Vec::<String>::new());
+        assert_eq!(response.data[1].id, "grok-4-fast-reasoning");
+        assert_eq!(response.data[1].aliases, Vec::<String>::new());
     }
 }

--- a/model_gateway/src/workflow/steps/external/discover_models.rs
+++ b/model_gateway/src/workflow/steps/external/discover_models.rs
@@ -27,6 +27,7 @@ static HTTP_CLIENT: Lazy<Client> = Lazy::new(|| {
 /// OpenAI /v1/models response format.
 #[derive(Debug, Clone, Deserialize)]
 pub struct ModelsResponse {
+    #[serde(default, deserialize_with = "deserialize_model_rows")]
     pub data: Vec<ModelInfo>,
     #[serde(default)]
     pub object: String,
@@ -64,6 +65,26 @@ where
     })
 }
 
+fn deserialize_model_rows<'de, D>(deserializer: D) -> Result<Vec<ModelInfo>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum DataField {
+        Rows(Vec<serde_json::Value>),
+        Other(serde::de::IgnoredAny),
+    }
+
+    Ok(match DataField::deserialize(deserializer)? {
+        DataField::Rows(rows) => rows
+            .into_iter()
+            .filter_map(|row| serde_json::from_value::<ModelInfo>(row).ok())
+            .collect(),
+        DataField::Other(_) => Vec::new(),
+    })
+}
+
 /// Convert a flat upstream `/v1/models` list into `ModelCard`s.
 ///
 /// Upstream IDs are preserved as-is. Virtual short aliases like `grok-4` are
@@ -86,7 +107,7 @@ pub fn build_model_cards(models: Vec<ModelInfo>) -> Vec<ModelCard> {
         .collect()
 }
 
-fn apply_provider_hint(model_cards: &mut [ModelCard], provider: Option<&ProviderType>) {
+pub(crate) fn apply_provider_hint(model_cards: &mut [ModelCard], provider: Option<&ProviderType>) {
     if let Some(provider) = provider {
         for card in model_cards {
             card.provider = Some(provider.clone());
@@ -457,5 +478,35 @@ mod tests {
         .expect("malformed aliases should not fail discovery");
 
         assert_eq!(response.data[0].aliases, Vec::<String>::new());
+    }
+
+    #[test]
+    fn models_response_skips_malformed_rows_but_keeps_valid_models() {
+        let response: ModelsResponse = serde_json::from_value(json!({
+            "data": [
+                {
+                    "id": 42,
+                    "object": "model",
+                    "created": 1_752_019_199
+                },
+                {
+                    "id": "grok-4-0709",
+                    "aliases": ["grok-4"],
+                    "object": "model",
+                    "created": 1_752_019_200
+                },
+                {
+                    "id": "grok-4-fast-reasoning",
+                    "object": "model",
+                    "created": "bad"
+                }
+            ],
+            "object": "list"
+        }))
+        .expect("bad rows should be skipped, not fail the response");
+
+        assert_eq!(response.data.len(), 1);
+        assert_eq!(response.data[0].id, "grok-4-0709");
+        assert_eq!(response.data[0].aliases, vec!["grok-4"]);
     }
 }

--- a/model_gateway/src/workflow/steps/external/discover_models.rs
+++ b/model_gateway/src/workflow/steps/external/discover_models.rs
@@ -361,53 +361,10 @@ impl StepExecutor<WorkerWorkflowData> for DiscoverModelsStep {
 
 #[cfg(test)]
 mod tests {
-    use openai_protocol::{model_type::ModelType, worker::ProviderType};
+    use openai_protocol::worker::ProviderType;
     use serde_json::json;
 
-    use super::{
-        apply_provider_hint, build_model_cards, group_models_into_cards, infer_model_type_from_id,
-        ModelInfo, ModelsResponse,
-    };
-
-    #[test]
-    fn group_models_into_cards_preserves_flat_ids_and_metadata() {
-        let cards = group_models_into_cards(vec![
-            ModelInfo {
-                id: "grok-4-0709".to_string(),
-                aliases: vec!["grok-4".to_string()],
-                object: "model".to_string(),
-                created: Some(1_752_019_200),
-                owned_by: None,
-            },
-            ModelInfo {
-                id: "gpt-4o-2024-11-20".to_string(),
-                aliases: Vec::new(),
-                object: "model".to_string(),
-                created: Some(1_732_000_000),
-                owned_by: None,
-            },
-        ]);
-
-        assert_eq!(cards.len(), 2);
-        assert_eq!(cards[0].id, "grok-4-0709");
-        assert_eq!(cards[0].aliases, vec!["grok-4"]);
-        assert_eq!(cards[0].provider, Some(ProviderType::XAI));
-        assert_eq!(cards[0].model_type, ModelType::LLM);
-        assert_eq!(cards[0].created_at, 1_752_019_200);
-        assert_eq!(cards[1].aliases, Vec::<String>::new());
-    }
-
-    #[test]
-    fn infer_model_type_handles_reasoning_and_vision_overlap() {
-        assert_eq!(
-            infer_model_type_from_id("grok-4-fast-reasoning"),
-            ModelType::REASONING_LLM
-        );
-        assert_eq!(
-            infer_model_type_from_id("gpt-4o-reasoning-preview"),
-            ModelType::FULL_LLM
-        );
-    }
+    use super::{apply_provider_hint, build_model_cards, ModelInfo, ModelsResponse};
 
     #[test]
     fn apply_provider_hint_uses_worker_provider_for_prefixed_ids() {

--- a/model_gateway/src/workflow/steps/external/mod.rs
+++ b/model_gateway/src/workflow/steps/external/mod.rs
@@ -7,6 +7,7 @@ mod create_workers;
 mod discover_models;
 
 pub use create_workers::CreateExternalWorkersStep;
+pub(crate) use discover_models::apply_provider_hint;
 pub use discover_models::{
     group_models_into_cards, infer_model_type_from_id, DiscoverModelsStep, ModelInfo,
     ModelsResponse,

--- a/model_gateway/tests/routing/test_openai_routing.rs
+++ b/model_gateway/tests/routing/test_openai_routing.rs
@@ -318,99 +318,36 @@ async fn test_openai_router_responses_refreshes_versioned_xai_model_alias() {
     let addr = listener.local_addr().unwrap();
     let models_counter = Arc::new(AtomicUsize::new(0));
     let responses_counter = Arc::new(AtomicUsize::new(0));
+    let models_payload = json!({
+        "object": "list",
+        "data": [
+            {
+                "id": "grok-4-0709",
+                "created": 1_752_019_200u64,
+                "object": "model",
+                "owned_by": "xai"
+            },
+            {
+                "id": "grok-4.20-0309-reasoning",
+                "created": 1_773_014_400u64,
+                "object": "model",
+                "owned_by": "xai"
+            }
+        ]
+    });
 
     let app = Router::new()
         .route(
             "/v1/models",
             get({
                 let models_counter = Arc::clone(&models_counter);
+                let models_payload = models_payload.clone();
                 move || {
                     let models_counter = Arc::clone(&models_counter);
+                    let models_payload = models_payload.clone();
                     async move {
                         models_counter.fetch_add(1, Ordering::SeqCst);
-                        Json(json!({
-                            "object": "list",
-                            "data": [
-                                {
-                                    "id": "grok-3",
-                                    "created": 1_743_724_800u64,
-                                    "object": "model",
-                                    "owned_by": "xai"
-                                },
-                                {
-                                    "id": "grok-3-mini",
-                                    "created": 1_743_724_800u64,
-                                    "object": "model",
-                                    "owned_by": "xai"
-                                },
-                                {
-                                    "id": "grok-4-0709",
-                                    "created": 1_752_019_200u64,
-                                    "object": "model",
-                                    "owned_by": "xai"
-                                },
-                                {
-                                    "id": "grok-4-1-fast-non-reasoning",
-                                    "created": 1_763_510_400u64,
-                                    "object": "model",
-                                    "owned_by": "xai"
-                                },
-                                {
-                                    "id": "grok-4-1-fast-reasoning",
-                                    "created": 1_763_510_400u64,
-                                    "object": "model",
-                                    "owned_by": "xai"
-                                },
-                                {
-                                    "id": "grok-4-fast-non-reasoning",
-                                    "created": 1_756_944_000u64,
-                                    "object": "model",
-                                    "owned_by": "xai"
-                                },
-                                {
-                                    "id": "grok-4-fast-reasoning",
-                                    "created": 1_756_944_000u64,
-                                    "object": "model",
-                                    "owned_by": "xai"
-                                },
-                                {
-                                    "id": "grok-4.20-0309-non-reasoning",
-                                    "created": 1_773_014_400u64,
-                                    "object": "model",
-                                    "owned_by": "xai"
-                                },
-                                {
-                                    "id": "grok-4.20-0309-reasoning",
-                                    "created": 1_773_014_400u64,
-                                    "object": "model",
-                                    "owned_by": "xai"
-                                },
-                                {
-                                    "id": "grok-4.20-multi-agent-0309",
-                                    "created": 1_773_014_400u64,
-                                    "object": "model",
-                                    "owned_by": "xai"
-                                },
-                                {
-                                    "id": "grok-code-fast-1",
-                                    "created": 1_756_339_200u64,
-                                    "object": "model",
-                                    "owned_by": "xai"
-                                },
-                                {
-                                    "id": "grok-imagine-image",
-                                    "created": 1_769_558_400u64,
-                                    "object": "model",
-                                    "owned_by": "xai"
-                                },
-                                {
-                                    "id": "grok-imagine-video",
-                                    "created": 1_769_558_400u64,
-                                    "object": "model",
-                                    "owned_by": "xai"
-                                }
-                            ]
-                        }))
+                        Json(models_payload)
                     }
                 }
             }),
@@ -491,24 +428,11 @@ async fn test_openai_router_responses_refreshes_versioned_xai_model_alias() {
     assert_eq!(models_counter.load(Ordering::SeqCst), 1);
     assert_eq!(responses_counter.load(Ordering::SeqCst), 1);
 
-    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
-        .await
-        .unwrap();
-    let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
-    assert_eq!(body["model"], "grok-4");
-    assert_eq!(body["output"][0]["content"][0]["text"], "grok alias ok");
-
     let worker = ctx
         .worker_registry
         .get_by_url(&base_url)
         .expect("refreshed worker should still exist");
-    let refreshed_models = worker.models();
-    assert_eq!(refreshed_models.len(), 13);
-    assert!(worker.supports_model("grok-4"));
-    assert!(refreshed_models
-        .iter()
-        .any(|card| card.id == "grok-4.20-0309-reasoning"));
-    let refreshed_lookup = WorkerModels::from(refreshed_models);
+    let refreshed_lookup = WorkerModels::from(worker.models());
     assert_eq!(
         refreshed_lookup
             .find("grok-4")

--- a/model_gateway/tests/routing/test_openai_routing.rs
+++ b/model_gateway/tests/routing/test_openai_routing.rs
@@ -13,7 +13,7 @@ use axum::{
     extract::Request,
     http::{Method, StatusCode},
     response::Response,
-    routing::post,
+    routing::{get, post},
     Json, Router,
 };
 use openai_protocol::{
@@ -21,7 +21,9 @@ use openai_protocol::{
     common::StringOrArray,
     completion::CompletionRequest,
     generate::GenerateRequest,
+    model_card::ModelCard,
     responses::{ResponseInput, ResponsesRequest},
+    worker::{WorkerModels, WorkerSpec},
 };
 use serde_json::json;
 use smg::{
@@ -30,7 +32,7 @@ use smg::{
         factory::router_ids, openai::OpenAIRouter, router_manager::RouterManager, RouterFactory,
         RouterTrait,
     },
-    worker::{BasicWorkerBuilder, RuntimeType, Worker, WorkerType},
+    worker::{BasicWorkerBuilder, ProviderType, RuntimeType, Worker, WorkerType},
 };
 use smg_data_connector::{ResponseId, StoredResponse};
 use tokio::{
@@ -305,6 +307,215 @@ async fn test_openai_router_responses_with_mock() {
 
     assert_eq!(stored1.raw_response, body1);
     assert_eq!(stored2.raw_response, body2);
+
+    server.abort();
+}
+
+#[expect(clippy::disallowed_methods, reason = "test infrastructure")]
+#[tokio::test]
+async fn test_openai_router_responses_refreshes_versioned_xai_model_alias() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let models_counter = Arc::new(AtomicUsize::new(0));
+    let responses_counter = Arc::new(AtomicUsize::new(0));
+
+    let app = Router::new()
+        .route(
+            "/v1/models",
+            get({
+                let models_counter = Arc::clone(&models_counter);
+                move || {
+                    let models_counter = Arc::clone(&models_counter);
+                    async move {
+                        models_counter.fetch_add(1, Ordering::SeqCst);
+                        Json(json!({
+                            "object": "list",
+                            "data": [
+                                {
+                                    "id": "grok-3",
+                                    "created": 1_743_724_800u64,
+                                    "object": "model",
+                                    "owned_by": "xai"
+                                },
+                                {
+                                    "id": "grok-3-mini",
+                                    "created": 1_743_724_800u64,
+                                    "object": "model",
+                                    "owned_by": "xai"
+                                },
+                                {
+                                    "id": "grok-4-0709",
+                                    "created": 1_752_019_200u64,
+                                    "object": "model",
+                                    "owned_by": "xai"
+                                },
+                                {
+                                    "id": "grok-4-1-fast-non-reasoning",
+                                    "created": 1_763_510_400u64,
+                                    "object": "model",
+                                    "owned_by": "xai"
+                                },
+                                {
+                                    "id": "grok-4-1-fast-reasoning",
+                                    "created": 1_763_510_400u64,
+                                    "object": "model",
+                                    "owned_by": "xai"
+                                },
+                                {
+                                    "id": "grok-4-fast-non-reasoning",
+                                    "created": 1_756_944_000u64,
+                                    "object": "model",
+                                    "owned_by": "xai"
+                                },
+                                {
+                                    "id": "grok-4-fast-reasoning",
+                                    "created": 1_756_944_000u64,
+                                    "object": "model",
+                                    "owned_by": "xai"
+                                },
+                                {
+                                    "id": "grok-4.20-0309-non-reasoning",
+                                    "created": 1_773_014_400u64,
+                                    "object": "model",
+                                    "owned_by": "xai"
+                                },
+                                {
+                                    "id": "grok-4.20-0309-reasoning",
+                                    "created": 1_773_014_400u64,
+                                    "object": "model",
+                                    "owned_by": "xai"
+                                },
+                                {
+                                    "id": "grok-4.20-multi-agent-0309",
+                                    "created": 1_773_014_400u64,
+                                    "object": "model",
+                                    "owned_by": "xai"
+                                },
+                                {
+                                    "id": "grok-code-fast-1",
+                                    "created": 1_756_339_200u64,
+                                    "object": "model",
+                                    "owned_by": "xai"
+                                },
+                                {
+                                    "id": "grok-imagine-image",
+                                    "created": 1_769_558_400u64,
+                                    "object": "model",
+                                    "owned_by": "xai"
+                                },
+                                {
+                                    "id": "grok-imagine-video",
+                                    "created": 1_769_558_400u64,
+                                    "object": "model",
+                                    "owned_by": "xai"
+                                }
+                            ]
+                        }))
+                    }
+                }
+            }),
+        )
+        .route(
+            "/v1/responses",
+            post({
+                let responses_counter = Arc::clone(&responses_counter);
+                move |Json(request): Json<serde_json::Value>| {
+                    let responses_counter = Arc::clone(&responses_counter);
+                    async move {
+                        responses_counter.fetch_add(1, Ordering::SeqCst);
+                        let model = request
+                            .get("model")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("grok-4")
+                            .to_string();
+
+                        Json(json!({
+                            "id": "resp_grok_alias",
+                            "object": "response",
+                            "created_at": 1_752_019_201,
+                            "status": "completed",
+                            "model": model,
+                            "output": [{
+                                "type": "message",
+                                "id": "msg_grok_alias",
+                                "role": "assistant",
+                                "status": "completed",
+                                "content": [{
+                                    "type": "output_text",
+                                    "text": "grok alias ok",
+                                    "annotations": []
+                                }]
+                            }],
+                            "metadata": {}
+                        }))
+                    }
+                }
+            }),
+        );
+
+    let server = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    let base_url = format!("http://{addr}");
+
+    let ctx = create_test_app_context().await;
+    // Register as an OpenAI-compatible external worker so the OpenAI router's
+    // refresh path will probe it, while refreshed model cards still infer xAI
+    // from the upstream model IDs.
+    let mut spec = WorkerSpec::new(&base_url);
+    spec.runtime_type = RuntimeType::External;
+    spec.worker_type = WorkerType::Regular;
+    spec.provider = Some(ProviderType::OpenAI);
+    spec.models = vec![ModelCard::new("placeholder-model")].into();
+
+    let worker: Arc<dyn Worker> = Arc::new(
+        BasicWorkerBuilder::from_spec(spec)
+            .health_config(openai_protocol::worker::HealthCheckConfig {
+                disable_health_check: true,
+                ..Default::default()
+            })
+            .build(),
+    );
+    ctx.worker_registry.register(worker);
+    let router = OpenAIRouter::new(&ctx).await.unwrap();
+
+    let request = ResponsesRequest {
+        model: "grok-4".to_string(),
+        input: ResponseInput::Text("Tell me about Quang Nam".to_string()),
+        ..Default::default()
+    };
+
+    let response = router.route_responses(None, &request, &request.model).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(models_counter.load(Ordering::SeqCst), 1);
+    assert_eq!(responses_counter.load(Ordering::SeqCst), 1);
+
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+    assert_eq!(body["model"], "grok-4");
+    assert_eq!(body["output"][0]["content"][0]["text"], "grok alias ok");
+
+    let worker = ctx
+        .worker_registry
+        .get_by_url(&base_url)
+        .expect("refreshed worker should still exist");
+    let refreshed_models = worker.models();
+    assert_eq!(refreshed_models.len(), 13);
+    assert!(worker.supports_model("grok-4"));
+    assert!(refreshed_models
+        .iter()
+        .any(|card| card.id == "grok-4.20-0309-reasoning"));
+    let refreshed_lookup = WorkerModels::from(refreshed_models);
+    assert_eq!(
+        refreshed_lookup
+            .find("grok-4")
+            .expect("grok-4 should resolve after refresh")
+            .id,
+        "grok-4-0709"
+    );
 
     server.abort();
 }


### PR DESCRIPTION
## Description


### Problem
When the external worker (xAI in this case) is queried via refresh_external_models, the parse_upstream function only captures the model id from the upstream response — it does not capture any aliases. So when you request grok-4, there's no worker registered with that model ID (only grok-4-0709 is registered).

Registration time (DiscoverModelsStep): Uses group_models_into_cards() which correctly strips date suffixes and creates aliases (e.g., grok-4 → primary, grok-4-0709 → alias).
Runtime refresh (refresh_external_models in worker_selection.rs): Uses ListModelsResponse::parse_upstream() which does NOT group models into aliases — it just creates a flat list of ModelCard each with only an id and no aliases.
<!-- What problem is this PR trying to solve? -->

### Solution

```
Request arrives with model="grok-4"
    │
    ▼
router_manager: look up router for "grok-4"
    │  registry index miss (only "grok-4-0709" is indexed)
    │
    ▼
router_manager: fallback → scan workers, call supports_model("grok-4")
    │
    ▼
WorkerModels::find("grok-4")
    │  Stage 1: exact match → none
    │  Stage 2: alias match → none
    │  Stage 3: prefix fallback
    │    candidates: ["grok-4-0709", "grok-4-fast-reasoning", ...]
    │    filter: strip_prefix("grok-4") + separator check
    │    sort: shortest ID first → "grok-4-0709" wins
    │
    ▼
Returns ModelCard { id: "grok-4-0709" }
    │
    ▼
Request forwarded to xAI with model="grok-4-0709"
    │
    ▼
HTTP 200 ✅
```
## PR Deep Dive

### 1. `crates/protocols/src/model_card.rs` — data structure change

`ModelCard` is the struct that represents a single model a worker can serve.
Before this PR it had no concept of *when* the model was created. This PR adds:

```rust
pub created_at: u64,  // Unix timestamp from upstream /v1/models
```

And propagates it into the `/v1/models` API response:

```rust
// Before: hardcoded zero
created: 0,

// After: real timestamp from upstream
let created = i64::try_from(self.created_at).unwrap_or(i64::MAX);
```

**Why it matters:** The prefix fallback needs to pick *one* model when multiple
candidates match. `grok-4-fast-v1` and `grok-4-fast-v2` are both valid prefixes
of `grok-4-fast` — `created_at` is how you pick `v2` as the newer one.

---

### 2. `crates/protocols/src/worker.rs` — the core algorithm change

This is the heart of the PR. `WorkerModels::find` is the function every routing
decision flows through. It previously only did an exact match:

```rust
// Before: one match, exact only
match self {
    Self::Single(card) => card.matches(id).then_some(card.as_ref()),
    Self::Multi(cards) => cards.iter().find(|m| m.matches(id)),
}
```

After this PR, `find` has three stages:

**Stage 1 — Exact ID match**

```rust
Self::Single(card) => (card.id == id).then_some(card.as_ref()),
Self::Multi(cards) => cards.iter().find(|card| card.id == id),
```

`grok-4-0709` requested → `grok-4-0709` card found. Done. Zero extra cost.

**Stage 2 — Alias match**

```rust
card.aliases.iter().any(|alias| alias == id)
```

If someone manually configured `grok-4` as an alias of `grok-4-0709`, this
catches it. Takes priority over prefix fallback.

**Stage 3 — Prefix fallback** *(the new thing)*

```rust
candidates
    .iter()
    .filter(|card| {
        card.id
            .strip_prefix(id)
            .is_some_and(|rest| rest.starts_with('-') || rest.starts_with('.'))
    })
    .min_by_key(|card| (
        card.id.len(),
        std::cmp::Reverse(card.created_at),
        card.id.as_str(),
    ))
```

Walk through this line by line:

- `strip_prefix(id)` — does `card.id` start with the requested `id`?
- `.is_some_and(|rest| rest.starts_with('-') || rest.starts_with('.'))` — the
  character immediately after must be `-` or `.`. This is the **separator
  guard**. It prevents `grok-4` from matching `grok-40`.
- `min_by_key` with `(card.id.len(), Reverse(created_at), card.id)` —
  three-level sort:
  1. **Shortest ID wins** — `grok-4-0709` (len 12) beats
     `grok-4.20-0309-reasoning` (len 24) for query `grok-4`
  2. **Newest wins among equal length** — `grok-4-fast-v2` beats
     `grok-4-fast-v1` if same length
  3. **Lexical order as stable tiebreaker** — deterministic when everything
     else ties

The gate `allows_prefix_fallback(id)` checks the requested ID contains `-`, `.`
or a digit — this prevents bare names like `grok` from accidentally matching
everything.

---

### 3. `model_gateway/src/routers/common/worker_selection.rs` — fixing the two-path bug

This is the original bug fix. There were two places that populated a worker's
model list:

- **Registration time** (`DiscoverModelsStep`) → called
  `group_models_into_cards()`, preserved `created_at` and aliases.
- **Runtime cache-miss refresh** → called
  `ListModelsResponse::parse_upstream()`, which produced a flat list with no
  `created_at` and no aliases.

The fix replaces the broken path:

```rust
// Before: flat parse, loses all metadata
let model_cards = ListModelsResponse::parse_upstream(&json, provider);

// After: same path as registration
match response.json::<ModelsResponse>().await {
    Ok(resp) => {
        let mut model_cards = group_models_into_cards(resp.data);
        apply_provider_hint(&mut model_cards, provider.as_ref());
```

`ModelsResponse` is the typed struct (not raw JSON), so `created` and `aliases`
fields are properly deserialized. `apply_provider_hint` stamps the URL-derived
provider onto cards that didn't get one from the ID inference heuristic.

---

### 4. `model_gateway/src/workflow/steps/external/discover_models.rs` — simplifying discovery

The original `group_models_into_cards` used a date-suffix regex to group models:

```rust
// Before: regex strips "-YYYY-MM-DD" suffix, groups by base name
static DATE_SUFFIX_PATTERN: Lazy<Regex> =
    Lazy::new(|| Regex::new(r"-\d{4}-\d{2}(-\d{2})?$")...);
```

This broke for `grok-4-fast-reasoning`, `grok-4.20-0309-reasoning`, etc. —
none of them match a date suffix.

The new approach is simpler: **store every model ID flat, one card per ID, with
its `created_at`**. No grouping at all. Alias resolution happens at lookup time
in `WorkerModels::find` instead of at discovery time.

```rust
// After: flat, one card per model ID
models.into_iter().map(|m| {
    ModelCard::new(&m.id)
        .with_model_type(infer_model_type_from_id(&m.id))
        .with_created_at(m.created.unwrap_or(0))
}).collect()
```

`ModelInfo` also gains an `aliases` field — if xAI or OpenAI ever returns
explicit aliases in their response, they are stored directly and take priority
over the prefix fallback.

---

### 5. `model_gateway/src/routers/router_manager.rs` — registry fallback

A smaller fix. The router manager looks up workers by model ID in a registry
index. If the registry has no exact entry for `grok-4` (because only
`grok-4-0709` was registered), it now falls back to scanning all workers by
capability:

```rust
// If registry index misses, scan workers by supports_model()
// which now calls WorkerModels::find() including the prefix fallback
```

This ensures the prefix fallback is reachable even at the router selection
layer, not just inside per-worker model matching.

<!-- How does this PR solve the problem? -->


<!-- - Describe your changes here. -->

## Test Plan
Before
khoatran@Khoas-MacBook-Pro khoa-git % curl -i http://localhost:9999/v1/responses \                        
  -H "Content-Type: application/json" \
  -H "opc-conversation-store-id: test-store-0326-01" \
  -H "Authorization: Bearer " \
  -d '{                                                                                
    "model": "grok-4",    
    "input": "Tell me about quang nam, vietnam"
  }'
HTTP/1.1 404 Not Found
content-type: application/json
x-smg-error-code: model_not_found
x-request-id: resp-1um1xAt9dH6i7K06DF1rDO0H
vary: origin, access-control-request-method, access-control-request-headers
access-control-allow-origin: *
access-control-expose-headers: *
content-length: 119
date: Mon, 13 Apr 2026 21:41:12 GMT

{"error":{"type":"Not Found","code":"model_not_found","message":"No worker available for model 'grok-4'","param":null}}%              

========
After                                                                                                                    
khoatran@Khoas-MacBook-Pro khoa-git % curl -i http://localhost:9999/v1/responses \                        
  -H "Content-Type: application/json" \
  -H "opc-conversation-store-id: test-store-0326-01" \
  -H "Authorization: Bearer " \
  -d '{
    "model": "grok-4-0709",
    "input": "Tell me about quang nam, vietnam"
  }'
HTTP/1.1 200 OK
content-type: application/json
x-request-id: resp-r0QcepBPFqZTRTS7fml8XePJ
vary: origin, access-control-request-method, access-control-request-headers
access-control-allow-origin: *
access-control-expose-headers: *
content-length: 4933
date: Mon, 13 Apr 2026 21:41:50 GMT

{"created_at":1776116496,"completed_at":1776116510,"id":"2ad40d62-c655-d5c3-e03b-ffe19aa3fceb","max_output_tokens":null,"model":"grok-4-0709","object":"response","output":[{"content":[{"type":"output_text","text":"### Overview of Quang Nam Province, Vietnam\n\nQuang Nam (often spelled Quảng Nam in Vietnamese) is a coastal province in central Vietnam, located in the ....."}]}]}

<!-- Provide a thorough reproducible test showing before and after behavior. -->

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Model creation timestamps are now tracked and preserved across discovery and routing.
  * Discovery now preserves each upstream model as a separate card, tolerantly parses aliases, and supports provider hint overrides.
  * Worker/model lookup gained an improved prefix-aware fallback that deterministically selects the best match.

* **Bug Fixes**
  * Improved alias and router selection to prefer specific provider matches and ignore stale indexed workers.

* **Tests**
  * Added unit and integration tests covering lookup precedence, fallback tie‑breaking, discovery parsing, and routing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->