### PR TITLE
feat(protocols): add serde(flatten) to ChatCompletionRequest for engine-specific fields

### DIFF
--- a/crates/protocols/src/chat.rs
+++ b/crates/protocols/src/chat.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde_json::{Map, Value};
 use validator::Validate;
 
 use super::{
@@ -316,6 +316,10 @@ pub struct ChatCompletionRequest {
 
     /// Random seed for sampling for deterministic outputs
     pub sampling_seed: Option<u64>,
+
+    /// Additional fields not explicitly defined above (e.g. engine-specific parameters)
+    #[serde(flatten)]
+    pub other: Map<String, Value>,
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- `ChatCompletionRequest` silently drops request fields not explicitly defined in the struct. This prevents engine-specific parameters (e.g. sglang's `return_routed_experts` for MoE routing replay) from passing through the gateway to backend workers.
- `CompletionRequest` already has a `#[serde(flatten)] pub other: Map<String, Value>` catch-all. This PR makes `ChatCompletionRequest` consistent by adding the same pattern.
- All existing construction sites use `..Default::default()`, so the new field is automatically initialized to an empty map with no code changes needed elsewhere.

Fixes: https://github.com/sgl-project/sglang/issues/22740

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat completion requests and responses now accept and include additional engine-specific JSON properties. This improves compatibility with varied chat engines, lets custom parameters pass through unchanged, and increases flexibility without altering existing validation or normalization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->