### PR TITLE
refactor(worker): delete set_healthy and migrate every caller (PR 9)

### DIFF
--- a/bindings/golang/src/policy.rs
+++ b/bindings/golang/src/policy.rs
@@ -145,7 +145,8 @@ impl Worker for GrpcWorker {
     }
 
     // FFI workers don't run the state machine — these counters are unused.
-    // The Go SDK manages worker health via direct set_healthy() calls.
+    // The Go SDK manages worker health via direct set_status() calls
+    // through the `sgl_multi_client_set_worker_health` FFI entry point.
     fn consecutive_failures_increment(&self) -> usize {
         0
     }
@@ -444,7 +445,17 @@ pub unsafe extern "C" fn sgl_multi_client_set_worker_health(
     if worker_index >= client.grpc_workers.len() {
         return SglErrorCode::InvalidArgument;
     }
-    client.grpc_workers[worker_index].set_healthy(healthy);
+    // The Go SDK is the source of truth for FFI worker health, so we
+    // map its boolean directly without the legacy `set_healthy` guard
+    // (which only demoted from `Ready`). FFI workers never run the
+    // local state machine, so a `Pending` start state can be flipped
+    // straight to `Ready` or `NotReady` here.
+    let status = if healthy {
+        WorkerStatus::Ready
+    } else {
+        WorkerStatus::NotReady
+    };
+    client.grpc_workers[worker_index].set_status(status);
     SglErrorCode::Success
 }
 

--- a/model_gateway/benches/manual_policy_benchmark.rs
+++ b/model_gateway/benches/manual_policy_benchmark.rs
@@ -132,7 +132,7 @@ fn bench_failover(c: &mut Criterion) {
                         let policy = ManualPolicy::new();
                         let workers = create_workers(count);
                         let idx = select_with_key(&policy, &workers, "failover-test").unwrap();
-                        workers[idx].set_healthy(false);
+                        workers[idx].set_status(openai_protocol::worker::WorkerStatus::NotReady);
                         (policy, workers)
                     },
                     |(policy, workers)| {

--- a/model_gateway/src/observability/metrics_ws/collectors.rs
+++ b/model_gateway/src/observability/metrics_ws/collectors.rs
@@ -22,8 +22,9 @@ pub struct CollectorConfig {
     /// Interval for the metrics (Prometheus) collector.
     pub metrics_interval: Duration,
     /// Checkpoint interval for the worker collector.
-    /// Catches health changes that bypass the broadcast (e.g., `set_healthy()`
-    /// called directly by the health checker or circuit breaker).
+    /// Catches health changes that bypass the broadcast (e.g.,
+    /// `set_status()` called directly by FFI bindings, the registry
+    /// teardown path, or the mesh subscriber).
     pub worker_checkpoint_interval: Duration,
 }
 
@@ -80,9 +81,9 @@ pub fn start_collectors(
 // ── Event-driven collector ──────────────────────────────────────────────
 
 /// Listens on WorkerRegistry broadcast for instant push on register/remove.
-/// Also polls on a checkpoint interval to catch health changes that bypass
-/// the broadcast (e.g., `set_healthy()` called directly by health checker
-/// or circuit breaker).
+/// Also polls on a checkpoint interval to catch health changes that
+/// bypass the broadcast (e.g., `set_status()` called directly by FFI
+/// bindings, the registry teardown path, or the mesh subscriber).
 fn spawn_worker_collector(
     context: Arc<AppContext>,
     registry: Arc<WatchRegistry>,

--- a/model_gateway/src/policies/cache_aware.rs
+++ b/model_gateway/src/policies/cache_aware.rs
@@ -918,7 +918,7 @@ impl Default for CacheAwarePolicy {
 #[cfg(test)]
 mod tests {
     use kv_index::{compute_content_hash, SequenceHash, StoredBlock, WorkerBlockMap};
-    use openai_protocol::worker::HealthCheckConfig;
+    use openai_protocol::worker::{HealthCheckConfig, WorkerStatus};
 
     use super::*;
     use crate::worker::{BasicWorkerBuilder, WorkerType};
@@ -1076,7 +1076,7 @@ mod tests {
 
         // Remove a worker
         policy.remove_worker_by_url("http://w1:8000");
-        workers[0].set_healthy(false);
+        workers[0].set_status(WorkerStatus::NotReady);
 
         // All requests should now go to worker2
         let idx = policy

--- a/model_gateway/src/policies/consistent_hashing.rs
+++ b/model_gateway/src/policies/consistent_hashing.rs
@@ -198,7 +198,7 @@ impl LoadBalancingPolicy for ConsistentHashingPolicy {
 mod tests {
     use std::collections::HashMap;
 
-    use openai_protocol::worker::HealthCheckConfig;
+    use openai_protocol::worker::{HealthCheckConfig, WorkerStatus};
 
     use super::*;
     use crate::worker::{BasicWorkerBuilder, HashRing, WorkerType};
@@ -312,7 +312,7 @@ mod tests {
     fn test_target_worker_miss_unhealthy() {
         let policy = ConsistentHashingPolicy::new();
         let workers = create_workers(&["http://w1:8000", "http://w2:8000"]);
-        workers[1].set_healthy(false);
+        workers[1].set_status(WorkerStatus::NotReady);
 
         let headers = headers_with_target_worker(1);
         let info = SelectWorkerInfo {
@@ -370,7 +370,7 @@ mod tests {
     fn test_no_healthy_workers() {
         let policy = ConsistentHashingPolicy::new();
         let workers = create_workers(&["http://w1:8000"]);
-        workers[0].set_healthy(false);
+        workers[0].set_status(WorkerStatus::NotReady);
 
         let headers = headers_with_routing_key("test");
         let info = SelectWorkerInfo {
@@ -421,7 +421,7 @@ mod tests {
         }
 
         // Mark worker 1 as unhealthy
-        workers[1].set_healthy(false);
+        workers[1].set_status(WorkerStatus::NotReady);
 
         // Record new routing and count how many keys moved
         let mut moved_count = 0;
@@ -477,7 +477,7 @@ mod tests {
         let original_idx = result.unwrap();
 
         // Mark that worker unhealthy
-        workers[original_idx].set_healthy(false);
+        workers[original_idx].set_status(WorkerStatus::NotReady);
 
         // Key should now route to a different healthy worker
         let (failover_result, _) = policy.select_worker_impl(&workers, &info);
@@ -498,7 +498,7 @@ mod tests {
         }
 
         // Recover the original worker
-        workers[original_idx].set_healthy(true);
+        workers[original_idx].set_status(WorkerStatus::Ready);
 
         // Key should route back to original worker
         let (recovered_result, _) = policy.select_worker_impl(&workers, &info);

--- a/model_gateway/src/policies/manual.rs
+++ b/model_gateway/src/policies/manual.rs
@@ -299,7 +299,7 @@ fn min_group_select(workers: &[Arc<dyn Worker>], healthy_indices: &[usize]) -> u
 mod tests {
     use std::collections::HashMap;
 
-    use openai_protocol::worker::HealthCheckConfig;
+    use openai_protocol::worker::{HealthCheckConfig, WorkerStatus};
 
     use super::*;
     use crate::worker::{BasicWorkerBuilder, WorkerType};
@@ -402,7 +402,7 @@ mod tests {
         let policy = ManualPolicy::new();
         let workers = create_workers(&["http://w1:8000", "http://w2:8000"]);
 
-        workers[0].set_healthy(false);
+        workers[0].set_status(WorkerStatus::NotReady);
 
         let headers = headers_with_routing_key("test-routing-id");
         let info = SelectWorkerInfo {
@@ -426,7 +426,7 @@ mod tests {
         let policy = ManualPolicy::new();
         let workers = create_workers(&["http://w1:8000"]);
 
-        workers[0].set_healthy(false);
+        workers[0].set_status(WorkerStatus::NotReady);
         let headers = headers_with_routing_key("test");
         let info = SelectWorkerInfo {
             headers: Some(&headers),
@@ -478,7 +478,7 @@ mod tests {
         let first_idx = first_result.unwrap();
         assert_eq!(branch, ExecutionBranch::Vacant);
 
-        workers[first_idx].set_healthy(false);
+        workers[first_idx].set_status(WorkerStatus::NotReady);
 
         let (new_result, branch) = policy.select_worker_impl(&workers, &info);
         let new_idx = new_result.unwrap();
@@ -547,14 +547,14 @@ mod tests {
         let first_idx = first_result.unwrap();
         assert_eq!(branch, ExecutionBranch::Vacant);
 
-        workers[first_idx].set_healthy(false);
+        workers[first_idx].set_status(WorkerStatus::NotReady);
 
         let (second_result, branch) = policy.select_worker_impl(&workers, &info);
         let second_idx = second_result.unwrap();
         assert_ne!(second_idx, first_idx);
         assert_eq!(branch, ExecutionBranch::OccupiedMiss);
 
-        workers[first_idx].set_healthy(true);
+        workers[first_idx].set_status(WorkerStatus::Ready);
 
         let (after_recovery, branch) = policy.select_worker_impl(&workers, &info);
         assert_eq!(
@@ -580,14 +580,14 @@ mod tests {
         let first_idx = first_result.unwrap();
         assert_eq!(branch, ExecutionBranch::Vacant);
 
-        workers[first_idx].set_healthy(false);
+        workers[first_idx].set_status(WorkerStatus::NotReady);
 
         let (second_result, branch) = policy.select_worker_impl(&workers, &info);
         let second_idx = second_result.unwrap();
         assert_ne!(second_idx, first_idx);
         assert_eq!(branch, ExecutionBranch::OccupiedMiss);
 
-        workers[second_idx].set_healthy(false);
+        workers[second_idx].set_status(WorkerStatus::NotReady);
 
         let remaining_idx = (0..3).find(|&i| i != first_idx && i != second_idx).unwrap();
         let (third_result, branch) = policy.select_worker_impl(&workers, &info);
@@ -598,7 +598,7 @@ mod tests {
         );
         assert_eq!(branch, ExecutionBranch::OccupiedMiss);
 
-        workers[first_idx].set_healthy(true);
+        workers[first_idx].set_status(WorkerStatus::Ready);
 
         let (idx_after_restore, branch) = policy.select_worker_impl(&workers, &info);
         assert_ne!(
@@ -654,17 +654,17 @@ mod tests {
             "Should return first healthy worker in urls"
         );
 
-        workers[0].set_healthy(false);
+        workers[0].set_status(WorkerStatus::NotReady);
         let healthy_indices = vec![1, 2];
         let result = find_healthy_worker(&urls, &workers, &healthy_indices);
         assert_eq!(result, Some(1), "Should skip unhealthy and return next");
 
-        workers[1].set_healthy(false);
+        workers[1].set_status(WorkerStatus::NotReady);
         let healthy_indices = vec![2];
         let result = find_healthy_worker(&urls, &workers, &healthy_indices);
         assert_eq!(result, Some(2), "Should return last healthy worker");
 
-        workers[2].set_healthy(false);
+        workers[2].set_status(WorkerStatus::NotReady);
         let healthy_indices: Vec<usize> = vec![];
         let result = find_healthy_worker(&urls, &workers, &healthy_indices);
         assert_eq!(result, None, "Should return None when no healthy workers");
@@ -736,7 +736,7 @@ mod tests {
         std::thread::sleep(std::time::Duration::from_millis(10));
 
         // OccupiedMiss: worker becomes unhealthy
-        workers[first_idx].set_healthy(false);
+        workers[first_idx].set_status(WorkerStatus::NotReady);
         let (_, branch) = policy.select_worker_impl(&workers, &info);
         assert_eq!(branch, ExecutionBranch::OccupiedMiss);
         let access_after_miss = policy.routing_map.get(&routing_id).unwrap().last_access;

--- a/model_gateway/src/policies/mod.rs
+++ b/model_gateway/src/policies/mod.rs
@@ -182,7 +182,7 @@ pub struct SelectWorkerInfo<'a> {
 
 #[cfg(test)]
 mod tests {
-    use openai_protocol::worker::HealthCheckConfig;
+    use openai_protocol::worker::{HealthCheckConfig, WorkerStatus};
 
     use super::*;
     use crate::worker::{BasicWorkerBuilder, WorkerType};
@@ -225,7 +225,7 @@ mod tests {
         assert_eq!(indices, vec![0, 1, 2]);
 
         // Mark one unhealthy
-        workers[1].set_healthy(false);
+        workers[1].set_status(WorkerStatus::NotReady);
         let indices = get_healthy_worker_indices(&workers);
         assert_eq!(indices, vec![0, 2]);
     }

--- a/model_gateway/src/policies/prefix_hash.rs
+++ b/model_gateway/src/policies/prefix_hash.rs
@@ -239,7 +239,7 @@ impl LoadBalancingPolicy for PrefixHashPolicy {
 
 #[cfg(test)]
 mod tests {
-    use openai_protocol::worker::HealthCheckConfig;
+    use openai_protocol::worker::{HealthCheckConfig, WorkerStatus};
 
     use super::*;
     use crate::worker::{BasicWorkerBuilder, HashRing, WorkerType};
@@ -375,7 +375,7 @@ mod tests {
     fn test_no_healthy_workers() {
         let policy = PrefixHashPolicy::with_defaults();
         let workers = create_workers(&["http://w1:8000"]);
-        workers[0].set_healthy(false);
+        workers[0].set_status(WorkerStatus::NotReady);
 
         let ring = Arc::new(HashRing::new(&workers));
         let tokens: Vec<u32> = vec![1, 2, 3];

--- a/model_gateway/src/policies/random.rs
+++ b/model_gateway/src/policies/random.rs
@@ -50,7 +50,7 @@ impl LoadBalancingPolicy for RandomPolicy {
 mod tests {
     use std::collections::HashMap;
 
-    use openai_protocol::worker::HealthCheckConfig;
+    use openai_protocol::worker::{HealthCheckConfig, WorkerStatus};
 
     use super::*;
     use crate::worker::{BasicWorkerBuilder, WorkerType};
@@ -117,7 +117,7 @@ mod tests {
         ];
 
         // Mark first worker as unhealthy
-        workers[0].set_healthy(false);
+        workers[0].set_status(WorkerStatus::NotReady);
 
         // Should always select the healthy worker (index 1)
         for _ in 0..10 {
@@ -138,7 +138,7 @@ mod tests {
                 .build(),
         )];
 
-        workers[0].set_healthy(false);
+        workers[0].set_status(WorkerStatus::NotReady);
         assert_eq!(
             policy.select_worker(&workers, &SelectWorkerInfo::default()),
             None

--- a/model_gateway/src/policies/round_robin.rs
+++ b/model_gateway/src/policies/round_robin.rs
@@ -58,7 +58,7 @@ impl LoadBalancingPolicy for RoundRobinPolicy {
 
 #[cfg(test)]
 mod tests {
-    use openai_protocol::worker::HealthCheckConfig;
+    use openai_protocol::worker::{HealthCheckConfig, WorkerStatus};
 
     use super::*;
     use crate::worker::{BasicWorkerBuilder, WorkerType};
@@ -128,7 +128,7 @@ mod tests {
         ];
 
         // Mark middle worker as unhealthy
-        workers[1].set_healthy(false);
+        workers[1].set_status(WorkerStatus::NotReady);
 
         // Should skip unhealthy worker: 0, 2, 0, 2, ...
         let info = SelectWorkerInfo::default();

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -1435,7 +1435,12 @@ mod tests {
         let worker = BasicWorkerBuilder::new(url)
             .worker_type(worker_type)
             .build();
-        worker.set_healthy(healthy);
+        let status = if healthy {
+            openai_protocol::worker::WorkerStatus::Ready
+        } else {
+            openai_protocol::worker::WorkerStatus::NotReady
+        };
+        worker.set_status(status);
         Box::new(worker)
     }
 

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -823,7 +823,7 @@ mod tests {
     fn create_test_unhealthy_router() -> Router {
         let router = create_test_regular_router();
         let workers = router.worker_registry.get_all();
-        workers[0].set_healthy(false);
+        workers[0].set_status(openai_protocol::worker::WorkerStatus::NotReady);
         router
     }
 

--- a/model_gateway/src/worker/registry.rs
+++ b/model_gateway/src/worker/registry.rs
@@ -1041,7 +1041,16 @@ impl WorkerRegistry {
                 conn_workers.retain(|id| id != worker_id);
             }
 
-            worker.set_healthy(false);
+            // Mark the worker as not-ready before tearing down its
+            // metrics so any in-flight `is_healthy()` callers that
+            // still hold an `Arc` see the correct state. Skip the
+            // transition for `Pending` (hasn't proven itself) and
+            // `Failed` (already terminal); only Ready warrants the
+            // explicit demotion. Mirrors the legacy `set_healthy(false)`
+            // semantics without going through the deprecated shim.
+            if worker.status() == WorkerStatus::Ready {
+                worker.set_status(WorkerStatus::NotReady);
+            }
             Metrics::remove_worker_metrics(worker.url());
 
             // Sync removal to mesh if enabled (no-op if mesh is not enabled)
@@ -1308,11 +1317,20 @@ impl smg_mesh::WorkerStateSubscriber for WorkerRegistry {
     fn on_remote_worker_state(&self, state: &smg_mesh::WorkerState) {
         use openai_protocol::model_card::ModelCard;
 
-        // If worker already exists at this URL, update its health status
-        // from the mesh state. Don't re-register — the existing worker has
-        // full config from its creation workflow.
+        // If worker already exists at this URL, update its health
+        // status from the mesh state. Don't re-register — the existing
+        // worker has full config from its creation workflow. The
+        // transition rules mirror the legacy `set_healthy(state.health)`
+        // semantics intentionally: `true` always promotes to `Ready`,
+        // `false` only demotes from `Ready` to `NotReady` and leaves
+        // `Pending` / `Failed` alone (those are owned by the local
+        // state machine, not by mesh hints).
         if let Some(existing) = self.get_by_url(&state.url) {
-            existing.set_healthy(state.health);
+            if state.health {
+                existing.set_status(WorkerStatus::Ready);
+            } else if existing.status() == WorkerStatus::Ready {
+                existing.set_status(WorkerStatus::NotReady);
+            }
             tracing::debug!(
                 url = %state.url,
                 healthy = state.health,
@@ -1333,7 +1351,13 @@ impl smg_mesh::WorkerStateSubscriber for WorkerRegistry {
                 .build(),
         };
 
-        worker.set_healthy(state.health);
+        // Same legacy `set_healthy(state.health)` semantics for the
+        // pre-registration newly built worker: `true` → `Ready`,
+        // `false` → leave the builder default (typically `Pending`).
+        // The state machine takes over after registration.
+        if state.health {
+            worker.set_status(WorkerStatus::Ready);
+        }
 
         // `register_inner(worker, false)` skips OUTGOING mesh sync to
         // avoid a version-bump loop on the CRDT, but still publishes
@@ -2026,12 +2050,13 @@ mod tests {
     fn test_mesh_worker_state_update_is_silent_on_existing_worker() {
         use smg_mesh::{WorkerState, WorkerStateSubscriber};
 
-        // Health updates for an already-registered worker go through the
-        // compat shim (set_healthy) without emitting an event — the
-        // existing worker is already on WorkerManager's schedule, and
-        // local probes will reconcile the state on the next tick. We
-        // verify the no-event behavior so a future regression (e.g. adding
-        // a StatusChanged emit here) is caught.
+        // Health updates for an already-registered worker mutate the
+        // local status field directly (via `set_status`) without
+        // emitting an event — the existing worker is already on
+        // WorkerManager's schedule, and local probes will reconcile
+        // the state on the next tick. We verify the no-event behavior
+        // so a future regression (e.g. adding a `StatusChanged` emit
+        // here) is caught.
         let registry = WorkerRegistry::new();
 
         let worker: Arc<dyn Worker> = Arc::new(

--- a/model_gateway/src/worker/worker.rs
+++ b/model_gateway/src/worker/worker.rs
@@ -175,22 +175,6 @@ pub trait Worker: Send + Sync + fmt::Debug + 'static {
         self.status() == WorkerStatus::Ready
     }
 
-    /// Set the worker's health status (compatibility shim).
-    ///
-    /// Maps `true` → `Ready`, `false` → `NotReady`.
-    /// Prefer `set_status()` for explicit state transitions.
-    fn set_healthy(&self, healthy: bool) {
-        if healthy {
-            self.set_status(WorkerStatus::Ready);
-        } else {
-            // Only transition to NotReady if currently Ready.
-            // Don't transition Pending→NotReady (hasn't proven itself).
-            if self.status() == WorkerStatus::Ready {
-                self.set_status(WorkerStatus::NotReady);
-            }
-        }
-    }
-
     /// Perform an async health check on the worker.
     ///
     /// Pure probe — does not mutate worker status, does not increment
@@ -1325,11 +1309,11 @@ mod tests {
         assert!(worker.is_healthy());
         assert_eq!(worker.status(), WorkerStatus::Ready);
 
-        worker.set_healthy(false);
+        worker.set_status(WorkerStatus::NotReady);
         assert!(!worker.is_healthy());
         assert_eq!(worker.status(), WorkerStatus::NotReady);
 
-        worker.set_healthy(true);
+        worker.set_status(WorkerStatus::Ready);
         assert!(worker.is_healthy());
         assert_eq!(worker.status(), WorkerStatus::Ready);
     }
@@ -1344,15 +1328,6 @@ mod tests {
         assert_eq!(worker.status(), WorkerStatus::Pending);
         assert!(!worker.is_healthy()); // Pending is not routable
         assert!(!worker.is_available()); // Pending is not available
-
-        // set_healthy(false) on Pending is a no-op (hasn't proven itself)
-        worker.set_healthy(false);
-        assert_eq!(worker.status(), WorkerStatus::Pending);
-
-        // set_healthy(true) promotes Pending → Ready
-        worker.set_healthy(true);
-        assert_eq!(worker.status(), WorkerStatus::Ready);
-        assert!(worker.is_healthy());
     }
 
     #[test]
@@ -1480,7 +1455,12 @@ mod tests {
                 reason = "Test helper: short-lived tasks joined before test ends"
             )]
             let handle = tokio::spawn(async move {
-                worker_clone.set_healthy(i % 2 == 0);
+                let status = if i % 2 == 0 {
+                    WorkerStatus::Ready
+                } else {
+                    WorkerStatus::NotReady
+                };
+                worker_clone.set_status(status);
                 time::sleep(Duration::from_micros(10)).await;
             });
             handles.push(handle);
@@ -1682,7 +1662,7 @@ mod tests {
             .build();
 
         assert!(dp_worker.is_healthy());
-        dp_worker.set_healthy(false);
+        dp_worker.set_status(WorkerStatus::NotReady);
         assert!(!dp_worker.is_healthy());
 
         assert_eq!(dp_worker.load(), 0);

--- a/model_gateway/src/workflow/steps/shared/activate.rs
+++ b/model_gateway/src/workflow/steps/shared/activate.rs
@@ -1,6 +1,7 @@
 //! Unified worker activation step.
 
 use async_trait::async_trait;
+use openai_protocol::worker::WorkerStatus;
 use tracing::info;
 use wfaas::{
     StepExecutor, StepResult, WorkflowContext, WorkflowData, WorkflowError, WorkflowResult,
@@ -20,8 +21,8 @@ impl<D: WorkerRegistrationData + WorkflowData> StepExecutor<D> for ActivateWorke
             .ok_or_else(|| WorkflowError::ContextValueNotFound("workers".to_string()))?;
 
         for worker in workers {
-            if !worker.is_healthy() {
-                worker.set_healthy(true);
+            if worker.status() != WorkerStatus::Ready {
+                worker.set_status(WorkerStatus::Ready);
             }
         }
 


### PR DESCRIPTION
## Summary

Removes the legacy \`Worker::set_healthy(bool)\` compatibility shim and migrates every call site in the workspace — runtime, tests, benches, and the Go binding FFI — to \`set_status(WorkerStatus)\`. We control every caller, so deprecation buys nothing over deletion: the shim's behavioral guards are inlined where they actually matter, and the dead code goes away instead of lingering with a \`#[deprecated]\` tag.

This is PR 9 of the worker module deep refactor (tracked in \`.claude/plans/2026-04-09-worker-module-deep-refactor.md\`). Lands on top of #1118 (PR 8 — event-driven WorkerMonitor).

## What changed

### Runtime call sites (semantics preserved)

- \`model_gateway/src/worker/registry.rs\`
  - \`remove()\` — only demotes \`Ready → NotReady\` before tearing down metrics, mirroring the legacy \`set_healthy(false)\` no-op-on-Pending behavior.
  - \`WorkerStateSubscriber::on_remote_worker_state\` (existing-worker update) — \`state.health=true\` always promotes to \`Ready\`; \`false\` only demotes when currently \`Ready\`. \`Pending\` / \`NotReady\` / \`Failed\` stay where they are because the local state machine owns them. The "no event on update" invariant is unchanged and still covered by \`test_mesh_worker_state_update_is_silent_on_existing_worker\`.
  - \`WorkerStateSubscriber::on_remote_worker_state\` (newly built worker pre-registration) — \`state.health=true\` promotes to \`Ready\`; \`false\` leaves the builder default (\`Pending\`) alone, same as the legacy shim.
- \`model_gateway/src/workflow/steps/shared/activate.rs\` — \`ActivateWorkersStep\` flips non-\`Ready\` workers to \`Ready\` via \`set_status(WorkerStatus::Ready)\` directly.
- \`bindings/golang/src/policy.rs\` — \`sgl_multi_client_set_worker_health\` maps the FFI bool straight to \`WorkerStatus::Ready\` / \`WorkerStatus::NotReady\`. FFI workers are managed by the Go SDK and never run the local state machine, so the legacy "only demote from Ready" guard does not apply here — the bool is authoritative and a Pending FFI worker can be flipped straight to NotReady. The accompanying doc comment is refreshed to point at \`set_status\` instead of the deleted shim.

### Test sites (mechanical 1:1 mapping)

- All policy tests (\`cache_aware\`, \`consistent_hashing\`, \`manual\`, \`mod\`, \`prefix_hash\`, \`random\`, \`round_robin\`) — \`set_healthy(false)\` → \`set_status(WorkerStatus::NotReady)\`, \`set_healthy(true)\` → \`set_status(WorkerStatus::Ready)\`. Each affected test module gets \`WorkerStatus\` added to its existing \`openai_protocol::worker\` import.
- \`model_gateway/src/worker/worker.rs\`
  - \`test_health_status\` — migrated to \`set_status\` calls.
  - \`test_pending_worker_not_routable\` — the compat-shim assertions (Pending no-op + Pending → Ready promotion) are removed; the state-machine semantics they covered are exercised by the WorkerManager test suite, and the test's stated purpose is "Pending is not routable", which the surviving assertions still verify.
  - \`test_concurrent_health_updates\` — alternating bool replaced with an explicit \`Ready\` / \`NotReady\` ternary.
  - \`test_dp_aware_worker_delegated_methods\` — direct \`set_status\` call.
- \`model_gateway/src/routers/http/router.rs\` / \`pd_router.rs\` — test helpers rewritten to call \`set_status\`.
- \`model_gateway/benches/manual_policy_benchmark.rs\` — bench setup uses \`set_status\`.

### Observability

- \`model_gateway/src/observability/metrics_ws/collectors.rs\` — doc comments that mentioned the bypass-the-broadcast \`set_healthy()\` callers now point at the \`set_status()\` callers (FFI bindings, registry teardown, mesh subscriber).

### Trait change

- \`model_gateway/src/worker/worker.rs\` — \`Worker::set_healthy\` (default trait method) is **deleted entirely**. \`is_healthy()\` stays as the routing predicate (\`status() == Ready\`). No \`Worker\` impl overrode \`set_healthy\`, so deletion has no implementor fan-out.

## Why

The plan originally called for \`#[deprecated]\` on \`set_healthy\` plus migration of remaining callers. After staring at the migrated diff: every caller is in this repo, every caller has been migrated, and the Go SDK FFI is also under our control. A deprecation tag would just be dead code with a soft warning that nobody benefits from. Deletion is cleaner: smaller surface area, no shim semantics to keep in sync with the underlying state machine, no future regressions where someone reaches for \`set_healthy\` and reintroduces the "only demote from Ready" guard in a context where that guard is wrong.

The behavioral guards the legacy shim provided are still honored at the sites where they actually matter (registry teardown, mesh subscriber existing-worker update, mesh subscriber newly-built worker). The sites where the guard never made sense (Go SDK FFI, tests with \`disable_health_check\` workers) drop it.

## Test plan

- [x] \`cargo check --workspace\` — clean (smg + smg-golang + smg-python all build with no \`set_healthy\` references)
- [x] \`cargo clippy -p smg --lib --tests -- -D warnings\` — clean
- [x] \`cargo clippy -p smg --benches -- -D warnings\` — clean
- [x] \`cargo clippy -p smg-golang --lib -- -D warnings\` — clean
- [x] \`cargo fmt -p smg -- --check\` — clean
- [x] \`cargo test -p smg --lib\` — **538 passed, 0 failed, 4 ignored**
- [x] \`cargo test -p smg --tests\` — 16 integration binaries, **468 tests, 0 failed**
- [x] ripgrep for \`set_healthy(\` across the workspace: **zero hits**, only doc comments referring to the legacy name in migration notes remain

<details>
<summary>Checklist</summary>

- [x] Documentation updated (collectors doc comments, mesh subscriber test doc comment)
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified worker health state management by replacing boolean flags with explicit Ready/NotReady status transitions, providing clearer control over worker availability during registration, mesh synchronization, and activation workflows.

* **Tests**
  * Updated comprehensive test suites across load balancing policies, routing components, and worker management to align with the refined worker status API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->