### PR TITLE
feat(tokenizer): load EOS token IDs from generation_config.json, strip in StopDecoder

### DIFF
--- a/bindings/golang/src/grpc_converter.rs
+++ b/bindings/golang/src/grpc_converter.rs
@@ -156,6 +156,7 @@ pub unsafe extern "C" fn sgl_grpc_response_converter_create(
             stop_token_ids.as_ref(),
             skip_special_tokens != 0,
             false, // no_stop_trim
+            false, // ignore_eos
         ))))
     } else {
         None

--- a/bindings/golang/src/grpc_converter.rs
+++ b/bindings/golang/src/grpc_converter.rs
@@ -148,20 +148,19 @@ pub unsafe extern "C" fn sgl_grpc_response_converter_create(
         serde_json::from_str::<Vec<u32>>(ids_str).ok()
     };
 
-    // Create stop decoder if needed (also when tokenizer has EOS tokens to strip)
-    let stop_decoder =
-        if stop.is_some() || stop_token_ids.is_some() || !tokenizer.eos_token_ids().is_empty() {
-            Some(Arc::new(TokioMutex::new(create_stop_decoder(
-                &tokenizer,
-                stop.as_ref(),
-                stop_token_ids.as_ref(),
-                skip_special_tokens != 0,
-                false, // no_stop_trim
-                false, // ignore_eos
-            ))))
-        } else {
-            None
-        };
+    // Create stop decoder if needed
+    let stop_decoder = if stop.is_some() || stop_token_ids.is_some() {
+        Some(Arc::new(TokioMutex::new(create_stop_decoder(
+            &tokenizer,
+            stop.as_ref(),
+            stop_token_ids.as_ref(),
+            skip_special_tokens != 0,
+            false, // no_stop_trim
+            false, // ignore_eos
+        ))))
+    } else {
+        None
+    };
 
     // Create tool parser if tools are provided
     let tool_parser = if tools.is_some() {

--- a/bindings/golang/src/grpc_converter.rs
+++ b/bindings/golang/src/grpc_converter.rs
@@ -148,19 +148,20 @@ pub unsafe extern "C" fn sgl_grpc_response_converter_create(
         serde_json::from_str::<Vec<u32>>(ids_str).ok()
     };
 
-    // Create stop decoder if needed
-    let stop_decoder = if stop.is_some() || stop_token_ids.is_some() {
-        Some(Arc::new(TokioMutex::new(create_stop_decoder(
-            &tokenizer,
-            stop.as_ref(),
-            stop_token_ids.as_ref(),
-            skip_special_tokens != 0,
-            false, // no_stop_trim
-            false, // ignore_eos
-        ))))
-    } else {
-        None
-    };
+    // Create stop decoder if needed (also when tokenizer has EOS tokens to strip)
+    let stop_decoder =
+        if stop.is_some() || stop_token_ids.is_some() || !tokenizer.eos_token_ids().is_empty() {
+            Some(Arc::new(TokioMutex::new(create_stop_decoder(
+                &tokenizer,
+                stop.as_ref(),
+                stop_token_ids.as_ref(),
+                skip_special_tokens != 0,
+                false, // no_stop_trim
+                false, // ignore_eos
+            ))))
+        } else {
+            None
+        };
 
     // Create tool parser if tools are provided
     let tool_parser = if tools.is_some() {

--- a/crates/tokenizer/src/cache/mod.rs
+++ b/crates/tokenizer/src/cache/mod.rs
@@ -284,6 +284,10 @@ impl Tokenizer for CachedTokenizer {
     fn think_in_prefill(&self) -> bool {
         self.inner.think_in_prefill()
     }
+
+    fn eos_token_ids(&self) -> &[TokenIdType] {
+        self.inner.eos_token_ids()
+    }
 }
 
 #[cfg(test)]

--- a/crates/tokenizer/src/eos.rs
+++ b/crates/tokenizer/src/eos.rs
@@ -1,0 +1,93 @@
+use std::{collections::BTreeSet, path::Path};
+
+use serde_json::Value;
+
+use crate::traits::TokenIdType;
+
+fn collect_eos_ids(cfg: &Value, ids: &mut BTreeSet<TokenIdType>) {
+    match cfg.get("eos_token_id") {
+        Some(Value::Number(n)) => {
+            if let Some(id) = n.as_u64() {
+                ids.insert(id as TokenIdType);
+            }
+        }
+        Some(Value::Array(arr)) => {
+            for v in arr {
+                if let Some(id) = v.as_u64() {
+                    ids.insert(id as TokenIdType);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Load and merge EOS token IDs from `config.json` and `generation_config.json`.
+///
+/// Models may define different EOS tokens in each file (e.g. Kimi-K2.5 uses
+/// `[EOS]` (163585) in config.json and `<|im_end|>` (163586) in
+/// generation_config.json). We merge both into a deduplicated, sorted list so
+/// the StopDecoder can strip any of them before decoding.
+///
+/// This matches how vllm and sglang resolve EOS:
+/// - vllm: `hf_config.eos_token_id` (from config.json via AutoConfig) +
+///   `generation_config.eos_token_id` (merged in `update_from_generation_config`)
+/// - sglang: `model_info["eos_token_ids"]` (from model config, includes both sources)
+pub fn load_eos_token_ids(dir: &Path) -> Vec<TokenIdType> {
+    let mut ids = BTreeSet::new();
+
+    for filename in ["config.json", "generation_config.json"] {
+        if let Ok(content) = std::fs::read_to_string(dir.join(filename)) {
+            if let Ok(cfg) = serde_json::from_str::<Value>(&content) {
+                collect_eos_ids(&cfg, &mut ids);
+            }
+        }
+    }
+
+    ids.into_iter().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_collect_single_int() {
+        let cfg: Value = serde_json::from_str(r#"{"eos_token_id": 42}"#).unwrap();
+        let mut ids = BTreeSet::new();
+        collect_eos_ids(&cfg, &mut ids);
+        assert_eq!(ids.into_iter().collect::<Vec<_>>(), vec![42]);
+    }
+
+    #[test]
+    fn test_collect_array() {
+        let cfg: Value = serde_json::from_str(r#"{"eos_token_id": [10, 20, 30]}"#).unwrap();
+        let mut ids = BTreeSet::new();
+        collect_eos_ids(&cfg, &mut ids);
+        assert_eq!(ids.into_iter().collect::<Vec<_>>(), vec![10, 20, 30]);
+    }
+
+    #[test]
+    fn test_collect_missing_field() {
+        let cfg: Value = serde_json::from_str(r#"{"model_type": "llama"}"#).unwrap();
+        let mut ids = BTreeSet::new();
+        collect_eos_ids(&cfg, &mut ids);
+        assert!(ids.is_empty());
+    }
+
+    #[test]
+    fn test_merge_deduplicates() {
+        let mut ids = BTreeSet::new();
+        let cfg1: Value = serde_json::from_str(r#"{"eos_token_id": 100}"#).unwrap();
+        let cfg2: Value = serde_json::from_str(r#"{"eos_token_id": [100, 200]}"#).unwrap();
+        collect_eos_ids(&cfg1, &mut ids);
+        collect_eos_ids(&cfg2, &mut ids);
+        assert_eq!(ids.into_iter().collect::<Vec<_>>(), vec![100, 200]);
+    }
+
+    #[test]
+    fn test_load_from_nonexistent_dir() {
+        let ids = load_eos_token_ids(Path::new("/nonexistent/path"));
+        assert!(ids.is_empty());
+    }
+}

--- a/crates/tokenizer/src/hub.rs
+++ b/crates/tokenizer/src/hub.rs
@@ -54,6 +54,8 @@ fn is_tokenizer_file(filename: &str) -> bool {
         || filename.ends_with("merges.txt")
         || filename.ends_with(".model")  // SentencePiece models
         || filename.ends_with(".tiktoken")
+        || filename == "config.json"
+        || filename == "generation_config.json"
         || is_chat_template_file(filename) // Include chat template files
 }
 

--- a/crates/tokenizer/src/hub.rs
+++ b/crates/tokenizer/src/hub.rs
@@ -54,8 +54,8 @@ fn is_tokenizer_file(filename: &str) -> bool {
         || filename.ends_with("merges.txt")
         || filename.ends_with(".model")  // SentencePiece models
         || filename.ends_with(".tiktoken")
-        || filename == "config.json"
-        || filename == "generation_config.json"
+        || filename.ends_with("config.json")
+        || filename.ends_with("generation_config.json")
         || is_chat_template_file(filename) // Include chat template files
 }
 

--- a/crates/tokenizer/src/hub.rs
+++ b/crates/tokenizer/src/hub.rs
@@ -300,6 +300,15 @@ mod tests {
         assert!(is_tokenizer_file("spiece.model"));
         assert!(is_tokenizer_file("chat_template.jinja"));
         assert!(is_tokenizer_file("template.jinja"));
+        // Config files for EOS loading
+        assert!(is_tokenizer_file("config.json"));
+        assert!(is_tokenizer_file("subfolder/config.json"));
+        assert!(is_tokenizer_file("generation_config.json"));
+        assert!(is_tokenizer_file("subfolder/generation_config.json"));
+        // Other *_config.json files must NOT match
+        assert!(!is_tokenizer_file("preprocessor_config.json"));
+        assert!(!is_tokenizer_file("quantize_config.json"));
+        assert!(!is_tokenizer_file("adapter_config.json"));
         assert!(!is_tokenizer_file("model.bin"));
         assert!(!is_tokenizer_file("README.md"));
     }

--- a/crates/tokenizer/src/hub.rs
+++ b/crates/tokenizer/src/hub.rs
@@ -54,8 +54,8 @@ fn is_tokenizer_file(filename: &str) -> bool {
         || filename.ends_with("merges.txt")
         || filename.ends_with(".model")  // SentencePiece models
         || filename.ends_with(".tiktoken")
-        || filename.ends_with("config.json")
-        || filename.ends_with("generation_config.json")
+        || filename == "config.json" || filename.ends_with("/config.json")
+        || filename == "generation_config.json" || filename.ends_with("/generation_config.json")
         || is_chat_template_file(filename) // Include chat template files
 }
 

--- a/crates/tokenizer/src/hub.rs
+++ b/crates/tokenizer/src/hub.rs
@@ -54,8 +54,6 @@ fn is_tokenizer_file(filename: &str) -> bool {
         || filename.ends_with("merges.txt")
         || filename.ends_with(".model")  // SentencePiece models
         || filename.ends_with(".tiktoken")
-        || filename == "config.json" || filename.ends_with("/config.json")
-        || filename == "generation_config.json" || filename.ends_with("/generation_config.json")
         || is_chat_template_file(filename) // Include chat template files
 }
 
@@ -134,6 +132,13 @@ pub async fn download_tokenizer_from_hf(model_id: impl AsRef<Path>) -> anyhow::R
         return Err(anyhow::anyhow!(
             "No tokenizer files could be downloaded for model '{model_name}'."
         ));
+    }
+
+    // Download config files for EOS token loading (best-effort, non-fatal).
+    // Downloaded separately by name to avoid matching nested files like
+    // 1_Pooling/config.json that would break cache_dir resolution.
+    for config_file in ["config.json", "generation_config.json"] {
+        let _ = repo.get(config_file).await;
     }
 
     match cache_dir {
@@ -300,15 +305,6 @@ mod tests {
         assert!(is_tokenizer_file("spiece.model"));
         assert!(is_tokenizer_file("chat_template.jinja"));
         assert!(is_tokenizer_file("template.jinja"));
-        // Config files for EOS loading
-        assert!(is_tokenizer_file("config.json"));
-        assert!(is_tokenizer_file("subfolder/config.json"));
-        assert!(is_tokenizer_file("generation_config.json"));
-        assert!(is_tokenizer_file("subfolder/generation_config.json"));
-        // Other *_config.json files must NOT match
-        assert!(!is_tokenizer_file("preprocessor_config.json"));
-        assert!(!is_tokenizer_file("quantize_config.json"));
-        assert!(!is_tokenizer_file("adapter_config.json"));
         assert!(!is_tokenizer_file("model.bin"));
         assert!(!is_tokenizer_file("README.md"));
     }

--- a/crates/tokenizer/src/huggingface.rs
+++ b/crates/tokenizer/src/huggingface.rs
@@ -84,7 +84,11 @@ impl HuggingFaceTokenizer {
             }
         }
 
-        let eos_token_ids = Self::resolve_eos_token_ids(file_path, &special_tokens, &vocab);
+        // Load merged EOS token IDs from config.json + generation_config.json
+        let eos_token_ids = std::path::Path::new(file_path)
+            .parent()
+            .map(crate::eos::load_eos_token_ids)
+            .unwrap_or_default();
 
         Ok(HuggingFaceTokenizer {
             tokenizer,
@@ -153,20 +157,13 @@ impl HuggingFaceTokenizer {
             .map(|(token, &id)| (id, token.clone()))
             .collect();
 
-        let mut eos_token_ids = Vec::new();
-        if let Some(ref eos_str) = special_tokens.eos_token {
-            if let Some(&id) = vocab.get(eos_str.as_str()) {
-                eos_token_ids.push(id);
-            }
-        }
-
         HuggingFaceTokenizer {
             tokenizer,
             special_tokens,
             vocab,
             reverse_vocab,
             chat_template: ChatTemplateState::empty(),
-            eos_token_ids,
+            eos_token_ids: Vec::new(), // No directory path in from_tokenizer
         }
     }
 
@@ -271,57 +268,6 @@ impl HuggingFaceTokenizer {
             })
         })()
         .unwrap_or_default()
-    }
-
-    /// Resolve all EOS token IDs from tokenizer_config.json and generation_config.json.
-    fn resolve_eos_token_ids(
-        tokenizer_path: &str,
-        special_tokens: &SpecialTokens,
-        vocab: &HashMap<String, TokenIdType>,
-    ) -> Vec<TokenIdType> {
-        let mut ids = Vec::new();
-
-        // 1. From tokenizer_config.json eos_token string
-        if let Some(ref eos_str) = special_tokens.eos_token {
-            if let Some(&id) = vocab.get(eos_str.as_str()) {
-                ids.push(id);
-            }
-        }
-
-        // 2. From generation_config.json eos_token_id (int or list)
-        if let Some(gen_ids) = Self::load_generation_config_eos(tokenizer_path) {
-            for id in gen_ids {
-                if !ids.contains(&id) {
-                    ids.push(id);
-                }
-            }
-        }
-
-        ids
-    }
-
-    /// Load `eos_token_id` from `generation_config.json`.
-    fn load_generation_config_eos(tokenizer_path: &str) -> Option<Vec<TokenIdType>> {
-        let path = std::path::Path::new(tokenizer_path);
-        let config_path = path.parent()?.join("generation_config.json");
-
-        if !config_path.exists() {
-            return None;
-        }
-
-        let content = std::fs::read_to_string(&config_path).ok()?;
-        let config: serde_json::Value = serde_json::from_str(&content).ok()?;
-
-        let eos = config.get("eos_token_id")?;
-        if let Some(id) = eos.as_u64() {
-            Some(vec![id as TokenIdType])
-        } else {
-            eos.as_array().map(|arr| {
-                arr.iter()
-                    .filter_map(|v| v.as_u64().map(|id| id as TokenIdType))
-                    .collect()
-            })
-        }
     }
 }
 

--- a/crates/tokenizer/src/huggingface.rs
+++ b/crates/tokenizer/src/huggingface.rs
@@ -22,6 +22,8 @@ pub struct HuggingFaceTokenizer {
     vocab: HashMap<String, TokenIdType>,
     reverse_vocab: HashMap<TokenIdType, String>,
     chat_template: ChatTemplateState,
+    /// EOS token IDs from tokenizer_config.json + generation_config.json
+    eos_token_ids: Vec<TokenIdType>,
 }
 
 impl HuggingFaceTokenizer {
@@ -82,12 +84,15 @@ impl HuggingFaceTokenizer {
             }
         }
 
+        let eos_token_ids = Self::resolve_eos_token_ids(file_path, &special_tokens, &vocab);
+
         Ok(HuggingFaceTokenizer {
             tokenizer,
             special_tokens,
             vocab,
             reverse_vocab,
             chat_template: ChatTemplateState::new(chat_template_str)?,
+            eos_token_ids,
         })
     }
 
@@ -148,12 +153,20 @@ impl HuggingFaceTokenizer {
             .map(|(token, &id)| (id, token.clone()))
             .collect();
 
+        let mut eos_token_ids = Vec::new();
+        if let Some(ref eos_str) = special_tokens.eos_token {
+            if let Some(&id) = vocab.get(eos_str.as_str()) {
+                eos_token_ids.push(id);
+            }
+        }
+
         HuggingFaceTokenizer {
             tokenizer,
             special_tokens,
             vocab,
             reverse_vocab,
             chat_template: ChatTemplateState::empty(),
+            eos_token_ids,
         }
     }
 
@@ -259,6 +272,57 @@ impl HuggingFaceTokenizer {
         })()
         .unwrap_or_default()
     }
+
+    /// Resolve all EOS token IDs from tokenizer_config.json and generation_config.json.
+    fn resolve_eos_token_ids(
+        tokenizer_path: &str,
+        special_tokens: &SpecialTokens,
+        vocab: &HashMap<String, TokenIdType>,
+    ) -> Vec<TokenIdType> {
+        let mut ids = Vec::new();
+
+        // 1. From tokenizer_config.json eos_token string
+        if let Some(ref eos_str) = special_tokens.eos_token {
+            if let Some(&id) = vocab.get(eos_str.as_str()) {
+                ids.push(id);
+            }
+        }
+
+        // 2. From generation_config.json eos_token_id (int or list)
+        if let Some(gen_ids) = Self::load_generation_config_eos(tokenizer_path) {
+            for id in gen_ids {
+                if !ids.contains(&id) {
+                    ids.push(id);
+                }
+            }
+        }
+
+        ids
+    }
+
+    /// Load `eos_token_id` from `generation_config.json`.
+    fn load_generation_config_eos(tokenizer_path: &str) -> Option<Vec<TokenIdType>> {
+        let path = std::path::Path::new(tokenizer_path);
+        let config_path = path.parent()?.join("generation_config.json");
+
+        if !config_path.exists() {
+            return None;
+        }
+
+        let content = std::fs::read_to_string(&config_path).ok()?;
+        let config: serde_json::Value = serde_json::from_str(&content).ok()?;
+
+        let eos = config.get("eos_token_id")?;
+        if let Some(id) = eos.as_u64() {
+            Some(vec![id as TokenIdType])
+        } else {
+            eos.as_array().map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_u64().map(|id| id as TokenIdType))
+                    .collect()
+            })
+        }
+    }
 }
 
 /// Special token strings read from tokenizer_config.json.
@@ -351,6 +415,10 @@ impl TokenizerTrait for HuggingFaceTokenizer {
 
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+
+    fn eos_token_ids(&self) -> &[TokenIdType] {
+        &self.eos_token_ids
     }
 
     fn apply_chat_template(

--- a/crates/tokenizer/src/huggingface.rs
+++ b/crates/tokenizer/src/huggingface.rs
@@ -22,7 +22,7 @@ pub struct HuggingFaceTokenizer {
     vocab: HashMap<String, TokenIdType>,
     reverse_vocab: HashMap<TokenIdType, String>,
     chat_template: ChatTemplateState,
-    /// EOS token IDs from tokenizer_config.json + generation_config.json
+    /// EOS token IDs from config.json + generation_config.json
     eos_token_ids: Vec<TokenIdType>,
 }
 

--- a/crates/tokenizer/src/lib.rs
+++ b/crates/tokenizer/src/lib.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use anyhow::Result;
 
 pub mod cache;
+pub mod eos;
 pub mod factory;
 pub mod hub;
 pub mod mock;

--- a/crates/tokenizer/src/tiktoken.rs
+++ b/crates/tokenizer/src/tiktoken.rs
@@ -130,6 +130,7 @@ pub struct TiktokenTokenizer {
     reverse_vocab: HashMap<TokenIdType, String>,
     vocab_size: usize,
     chat_template: ChatTemplateState,
+    eos_token_ids: Vec<TokenIdType>,
 }
 
 /// Supported Tiktoken models
@@ -178,6 +179,7 @@ impl TiktokenTokenizer {
             reverse_vocab: HashMap::new(),
             vocab_size,
             chat_template: ChatTemplateState::empty(),
+            eos_token_ids: Vec::new(), // No directory path in from_model
         })
     }
 
@@ -259,6 +261,9 @@ impl TiktokenTokenizer {
             })
         };
 
+        // Load merged EOS token IDs from config.json + generation_config.json
+        let eos_token_ids = crate::eos::load_eos_token_ids(dir);
+
         Ok(TiktokenTokenizer {
             tokenizer,
             special_tokens: config.special_tokens,
@@ -266,6 +271,7 @@ impl TiktokenTokenizer {
             reverse_vocab,
             vocab_size,
             chat_template: ChatTemplateState::new(chat_template)?,
+            eos_token_ids,
         })
     }
 
@@ -519,6 +525,10 @@ impl TokenizerTrait for TiktokenTokenizer {
     fn thinking_key_name(&self) -> Option<ThinkingKeyName> {
         self.chat_template.thinking_key_name()
     }
+    fn eos_token_ids(&self) -> &[TokenIdType] {
+        &self.eos_token_ids
+    }
+
     fn think_in_prefill(&self) -> bool {
         self.chat_template.think_in_prefill()
     }

--- a/crates/tokenizer/src/traits.rs
+++ b/crates/tokenizer/src/traits.rs
@@ -123,6 +123,15 @@ pub trait Tokenizer: Encoder + Decoder {
             "set_chat_template is not supported by this tokenizer"
         ))
     }
+
+    /// EOS token IDs for stop detection.
+    ///
+    /// Loaded from `tokenizer_config.json` (eos_token string → vocab lookup) and
+    /// `generation_config.json` (eos_token_id, can be int or list).
+    /// Models can have multiple EOS tokens (e.g., Llama 3: end_of_text + eom_id + eot_id).
+    fn eos_token_ids(&self) -> &[TokenIdType] {
+        &[]
+    }
 }
 
 /// Contains the results of tokenizing text: token IDs, string tokens, and their spans

--- a/crates/tokenizer/src/traits.rs
+++ b/crates/tokenizer/src/traits.rs
@@ -126,8 +126,7 @@ pub trait Tokenizer: Encoder + Decoder {
 
     /// EOS token IDs for stop detection.
     ///
-    /// Loaded from `tokenizer_config.json` (eos_token string → vocab lookup) and
-    /// `generation_config.json` (eos_token_id, can be int or list).
+    /// Merged from `config.json` and `generation_config.json` (eos_token_id, int or list).
     /// Models can have multiple EOS tokens (e.g., Llama 3: end_of_text + eom_id + eot_id).
     fn eos_token_ids(&self) -> &[TokenIdType] {
         &[]

--- a/e2e_test/chat_completions/test_validation.py
+++ b/e2e_test/chat_completions/test_validation.py
@@ -233,3 +233,111 @@ class TestGptOssValidation:
                 },
             )
         assert exc_info.value.status_code == 400
+
+
+# =============================================================================
+# EOS Token Stripping Tests (Llama 1B)
+# Verify that EOS tokens are stripped from output by StopDecoder even when
+# skip_special_tokens=false. Regression test for generation_config.json
+# EOS loading and StopDecoder EOS stripping.
+# =============================================================================
+
+
+@pytest.mark.engine("sglang", "vllm")
+@pytest.mark.gpu(1)
+@pytest.mark.model("meta-llama/Llama-3.2-1B-Instruct")
+@pytest.mark.gateway(extra_args=["--tool-call-parser", "llama", "--history-backend", "memory"])
+@pytest.mark.parametrize("setup_backend", ["grpc"], indirect=True)
+@pytest.mark.parametrize("api_client", ["openai", "smg"], indirect=True)
+class TestEosTokenStripping:
+    """Verify EOS tokens are stripped from output by StopDecoder.
+
+    gRPC backends return raw token IDs including EOS. The StopDecoder must
+    strip EOS at the token ID level before decoding, matching vllm/sglang
+    HTTP behavior. Without this fix, skip_special_tokens=false causes EOS
+    tokens like <|eom_id|> to appear in decoded text.
+    """
+
+    # Llama 3 EOS tokens that should never appear in output
+    EOS_TOKENS = ["<|eom_id|>", "<|eot_id|>", "<|end_of_text|>"]
+
+    def test_no_eos_in_content_default(self, model, api_client):
+        """With default settings, EOS tokens should not appear in content."""
+        response = api_client.chat.completions.create(
+            model=model,
+            messages=[
+                {"role": "user", "content": "Say hello in one sentence."},
+            ],
+            temperature=0,
+            max_tokens=50,
+            stream=False,
+        )
+        content = response.choices[0].message.content
+        assert content is not None
+        for eos in self.EOS_TOKENS:
+            assert eos not in content, f"EOS token {eos} leaked into content: {content}"
+
+    def test_no_eos_in_content_skip_special_false(self, model, api_client):
+        """With skip_special_tokens=false, EOS should still be stripped by StopDecoder."""
+        response = api_client.chat.completions.create(
+            model=model,
+            messages=[
+                {"role": "user", "content": "Say hello in one sentence."},
+            ],
+            temperature=0,
+            max_tokens=50,
+            stream=False,
+            extra_body={"skip_special_tokens": False},
+        )
+        content = response.choices[0].message.content
+        assert content is not None
+        for eos in self.EOS_TOKENS:
+            assert eos not in content, f"EOS token {eos} leaked into content: {content}"
+
+    def test_no_eos_in_tool_call_with_tools(self, model, api_client):
+        """With tools and skip_special_tokens=false, tool calls should not contain EOS."""
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "add",
+                    "description": "Compute the sum of two numbers",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "a": {"type": "integer", "description": "A number"},
+                            "b": {"type": "integer", "description": "A number"},
+                        },
+                        "required": ["a", "b"],
+                    },
+                },
+            }
+        ]
+        response = api_client.chat.completions.create(
+            model=model,
+            messages=[
+                {"role": "user", "content": "Compute (3+5)"},
+            ],
+            tools=tools,
+            tool_choice="required",
+            temperature=0,
+            max_tokens=200,
+            stream=False,
+            extra_body={"skip_special_tokens": False},
+        )
+        choice = response.choices[0]
+
+        # Check tool call arguments for EOS
+        if choice.message.tool_calls:
+            for tc in choice.message.tool_calls:
+                for eos in self.EOS_TOKENS:
+                    assert eos not in tc.function.arguments, (
+                        f"EOS token {eos} in tool call arguments: {tc.function.arguments}"
+                    )
+
+        # Check content for EOS (if model returned content instead of tool calls)
+        if choice.message.content:
+            for eos in self.EOS_TOKENS:
+                assert eos not in choice.message.content, (
+                    f"EOS token {eos} in content: {choice.message.content}"
+                )

--- a/e2e_test/chat_completions/test_validation.py
+++ b/e2e_test/chat_completions/test_validation.py
@@ -341,3 +341,44 @@ class TestEosTokenStripping:
                 assert eos not in choice.message.content, (
                     f"EOS token {eos} in content: {choice.message.content}"
                 )
+
+    def test_no_stop_trim_with_skip_special_true(self, model, api_client):
+        """With no_stop_trim=true and skip_special_tokens=true (default),
+        EOS should be kept in token list but invisible (decoded to empty)."""
+        response = api_client.chat.completions.create(
+            model=model,
+            messages=[
+                {"role": "user", "content": "Say hello in one sentence."},
+            ],
+            temperature=0,
+            max_tokens=50,
+            stream=False,
+            extra_body={"no_stop_trim": True},
+        )
+        content = response.choices[0].message.content
+        assert content is not None
+        for eos in self.EOS_TOKENS:
+            assert eos not in content, (
+                f"EOS token {eos} should be invisible with skip_special_tokens=true: {content}"
+            )
+
+    def test_no_stop_trim_with_skip_special_false(self, model, api_client):
+        """With no_stop_trim=true and skip_special_tokens=false,
+        EOS should be visible in output (matching sglang behavior)."""
+        response = api_client.chat.completions.create(
+            model=model,
+            messages=[
+                {"role": "user", "content": "Say hello in one sentence."},
+            ],
+            temperature=0,
+            max_tokens=50,
+            stream=False,
+            extra_body={"no_stop_trim": True, "skip_special_tokens": False},
+        )
+        content = response.choices[0].message.content
+        assert content is not None
+        # EOS should be visible when both no_stop_trim=true and skip_special_tokens=false
+        has_eos = any(eos in content for eos in self.EOS_TOKENS)
+        assert has_eos, (
+            f"EOS token should be visible with no_stop_trim=true + skip_special_tokens=false: {content}"
+        )

--- a/e2e_test/chat_completions/test_validation.py
+++ b/e2e_test/chat_completions/test_validation.py
@@ -377,6 +377,9 @@ class TestEosTokenStripping:
         )
         content = response.choices[0].message.content
         assert content is not None
+        assert response.choices[0].finish_reason == "stop", (
+            "Model hit max_tokens before EOS — test is inconclusive"
+        )
         # EOS should be visible when both no_stop_trim=true and skip_special_tokens=false
         has_eos = any(eos in content for eos in self.EOS_TOKENS)
         assert has_eos, (

--- a/model_gateway/src/routers/grpc/regular/stages/chat/preparation.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/chat/preparation.rs
@@ -195,6 +195,7 @@ impl ChatPreparationStage {
             request.stop_token_ids.as_ref(),
             request.skip_special_tokens,
             request.no_stop_trim,
+            request.ignore_eos,
         );
 
         let mut processed_messages = processed_messages;

--- a/model_gateway/src/routers/grpc/regular/stages/completion/preparation.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/completion/preparation.rs
@@ -54,6 +54,7 @@ impl PipelineStage for CompletionPreparationStage {
             request.stop_token_ids.as_ref(),
             request.skip_special_tokens,
             request.no_stop_trim,
+            request.ignore_eos,
         );
 
         ctx.state.preparation = Some(PreparationOutput {

--- a/model_gateway/src/routers/grpc/regular/stages/generate/preparation.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/generate/preparation.rs
@@ -66,6 +66,7 @@ impl GeneratePreparationStage {
             params.and_then(|p| p.stop_token_ids.as_ref()),
             params.and_then(|p| p.skip_special_tokens).unwrap_or(true),
             params.and_then(|p| p.no_stop_trim).unwrap_or(false),
+            params.and_then(|p| p.ignore_eos).unwrap_or(false),
         );
 
         ctx.state.preparation = Some(PreparationOutput {

--- a/model_gateway/src/routers/grpc/regular/stages/messages/preparation.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/messages/preparation.rs
@@ -228,6 +228,7 @@ impl MessagePreparationStage {
             None,  // no stop_token_ids in Messages API
             true,  // always skip special tokens — Messages API never exposes raw tokens
             false, // no_stop_trim default
+            false, // ignore_eos — not available in Messages API
         );
 
         let mut processed_messages = processed_messages;

--- a/model_gateway/src/routers/grpc/regular/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/streaming.rs
@@ -104,6 +104,7 @@ impl StreamingProcessor {
             chat_request.stop_token_ids.clone(),
             chat_request.skip_special_tokens,
             chat_request.no_stop_trim,
+            chat_request.ignore_eos,
         );
 
         // Create SSE channel
@@ -185,7 +186,7 @@ impl StreamingProcessor {
         mut grpc_stream: ProtoStream,
         dispatch: context::DispatchMetadata,
         tokenizer: Arc<dyn Tokenizer>,
-        stop_params: (Option<StringOrArray>, Option<Vec<u32>>, bool, bool),
+        stop_params: (Option<StringOrArray>, Option<Vec<u32>>, bool, bool, bool),
         original_request: Arc<ChatCompletionRequest>,
         tx: &UnboundedSender<Result<Bytes, io::Error>>,
     ) -> Result<(), String> {
@@ -298,14 +299,20 @@ impl StreamingProcessor {
 
                     // Get or create stop decoder for this index
                     let stop_decoder = stop_decoders.entry(index).or_insert_with(|| {
-                        let (ref stop, ref stop_token_ids, skip_special_tokens, no_stop_trim) =
-                            stop_params;
+                        let (
+                            ref stop,
+                            ref stop_token_ids,
+                            skip_special_tokens,
+                            no_stop_trim,
+                            ignore_eos,
+                        ) = stop_params;
                         utils::create_stop_decoder(
                             &tokenizer,
                             stop.as_ref(),
                             stop_token_ids.as_ref(),
                             skip_special_tokens,
                             no_stop_trim,
+                            ignore_eos,
                         )
                     });
 
@@ -588,7 +595,7 @@ impl StreamingProcessor {
         decode_stream: ProtoStream,
         dispatch: context::DispatchMetadata,
         tokenizer: Arc<dyn Tokenizer>,
-        stop_params: (Option<StringOrArray>, Option<Vec<u32>>, bool, bool),
+        stop_params: (Option<StringOrArray>, Option<Vec<u32>>, bool, bool, bool),
         original_request: Arc<ChatCompletionRequest>,
         tx: &UnboundedSender<Result<Bytes, io::Error>>,
     ) -> Result<(), String> {
@@ -1442,6 +1449,7 @@ impl StreamingProcessor {
             None::<Vec<u32>>, // No stop_token_ids in Messages API
             true,             // always skip special tokens
             false,            // no_stop_trim
+            false,            // ignore_eos — not available in Messages API
         );
 
         let (tx, rx) = mpsc::unbounded_channel::<Result<Bytes, io::Error>>();
@@ -1536,7 +1544,7 @@ impl StreamingProcessor {
         mut grpc_stream: ProtoStream,
         dispatch: context::DispatchMetadata,
         tokenizer: Arc<dyn Tokenizer>,
-        stop_params: (Option<StringOrArray>, Option<Vec<u32>>, bool, bool),
+        stop_params: (Option<StringOrArray>, Option<Vec<u32>>, bool, bool, bool),
         original_request: Arc<CreateMessageRequest>,
         tx: &UnboundedSender<Result<Bytes, io::Error>>,
     ) -> Result<(), String> {
@@ -1563,13 +1571,15 @@ impl StreamingProcessor {
 
         // Stop decoder
         let mut stop_decoder = {
-            let (ref stop, ref stop_token_ids, skip_special_tokens, no_stop_trim) = stop_params;
+            let (ref stop, ref stop_token_ids, skip_special_tokens, no_stop_trim, ignore_eos) =
+                stop_params;
             utils::create_stop_decoder(
                 &tokenizer,
                 stop.as_ref(),
                 stop_token_ids.as_ref(),
                 skip_special_tokens,
                 no_stop_trim,
+                ignore_eos,
             )
         };
 
@@ -2143,7 +2153,7 @@ impl StreamingProcessor {
         decode_stream: ProtoStream,
         dispatch: context::DispatchMetadata,
         tokenizer: Arc<dyn Tokenizer>,
-        stop_params: (Option<StringOrArray>, Option<Vec<u32>>, bool, bool),
+        stop_params: (Option<StringOrArray>, Option<Vec<u32>>, bool, bool, bool),
         original_request: Arc<CreateMessageRequest>,
         tx: &UnboundedSender<Result<Bytes, io::Error>>,
     ) -> Result<(), String> {
@@ -2192,6 +2202,7 @@ impl StreamingProcessor {
             completion_request.stop_token_ids.clone(),
             completion_request.skip_special_tokens,
             completion_request.no_stop_trim,
+            completion_request.ignore_eos,
         );
 
         let (tx, rx) = mpsc::unbounded_channel::<Result<Bytes, io::Error>>();
@@ -2271,7 +2282,7 @@ impl StreamingProcessor {
         mut grpc_stream: ProtoStream,
         dispatch: context::DispatchMetadata,
         tokenizer: Arc<dyn Tokenizer>,
-        stop_params: (Option<StringOrArray>, Option<Vec<u32>>, bool, bool),
+        stop_params: (Option<StringOrArray>, Option<Vec<u32>>, bool, bool, bool),
         completion_request: Arc<CompletionRequest>,
         tx: &UnboundedSender<Result<Bytes, io::Error>>,
     ) -> Result<(), String> {
@@ -2343,6 +2354,7 @@ impl StreamingProcessor {
                             stop_params.1.as_ref(),
                             stop_params.2,
                             stop_params.3,
+                            stop_params.4,
                         )
                     });
 
@@ -2595,7 +2607,7 @@ impl StreamingProcessor {
         decode_stream: ProtoStream,
         dispatch: context::DispatchMetadata,
         tokenizer: Arc<dyn Tokenizer>,
-        stop_params: (Option<StringOrArray>, Option<Vec<u32>>, bool, bool),
+        stop_params: (Option<StringOrArray>, Option<Vec<u32>>, bool, bool, bool),
         original_request: Arc<CompletionRequest>,
         tx: &UnboundedSender<Result<Bytes, io::Error>>,
     ) -> Result<(), String> {

--- a/model_gateway/src/routers/grpc/regular/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/streaming.rs
@@ -2348,13 +2348,20 @@ impl StreamingProcessor {
                     total_completion.record_chunk(&chunk);
 
                     let stop_decoder = stop_decoders.entry(index).or_insert_with(|| {
+                        let (
+                            ref stop,
+                            ref stop_token_ids,
+                            skip_special_tokens,
+                            no_stop_trim,
+                            ignore_eos,
+                        ) = stop_params;
                         utils::create_stop_decoder(
                             &tokenizer,
-                            stop_params.0.as_ref(),
-                            stop_params.1.as_ref(),
-                            stop_params.2,
-                            stop_params.3,
-                            stop_params.4,
+                            stop.as_ref(),
+                            stop_token_ids.as_ref(),
+                            skip_special_tokens,
+                            no_stop_trim,
+                            ignore_eos,
                         )
                     });
 

--- a/model_gateway/src/routers/grpc/utils/chat_utils.rs
+++ b/model_gateway/src/routers/grpc/utils/chat_utils.rs
@@ -509,25 +509,24 @@ pub fn create_stop_decoder(
         };
     }
 
-    // Add EOS token IDs from tokenizer (generation_config.json) as hidden stops.
-    // Skip when ignore_eos=true — the backend continues past EOS and the user
-    // expects EOS tokens to either be invisible (skip_special_tokens=true) or
-    // visible (skip_special_tokens=false), not cause early termination.
-    if !ignore_eos {
-        for &eos_id in tokenizer.eos_token_ids() {
-            builder = builder.stop_token(eos_id);
-        }
-    }
-
-    // Add user-provided stop token IDs (visible if no_stop_trim, hidden otherwise)
-    if let Some(token_ids) = stop_token_ids {
-        for &token_id in token_ids {
-            builder = if no_stop_trim {
-                builder.visible_stop_token(token_id)
-            } else {
-                builder.stop_token(token_id)
-            };
-        }
+    // Collect stop token IDs: EOS from tokenizer (unless ignore_eos) + user-provided.
+    // EOS tokens come from generation_config.json and are stripped at the token ID
+    // level before decoding, matching vllm/sglang behavior.
+    // When ignore_eos=true, EOS tokens are not added — the backend continues past EOS.
+    let eos_ids = if ignore_eos {
+        &[] as &[u32]
+    } else {
+        tokenizer.eos_token_ids()
+    };
+    for &token_id in eos_ids
+        .iter()
+        .chain(stop_token_ids.map(|ids| ids.as_slice()).unwrap_or_default())
+    {
+        builder = if no_stop_trim {
+            builder.visible_stop_token(token_id)
+        } else {
+            builder.stop_token(token_id)
+        };
     }
 
     builder.build()

--- a/model_gateway/src/routers/grpc/utils/chat_utils.rs
+++ b/model_gateway/src/routers/grpc/utils/chat_utils.rs
@@ -487,6 +487,7 @@ pub fn create_stop_decoder(
     stop_token_ids: Option<&Vec<u32>>,
     skip_special_tokens: bool,
     no_stop_trim: bool,
+    ignore_eos: bool,
 ) -> StopSequenceDecoder {
     // Extract stop sequences
     let stop_sequences: Vec<String> = match stop {
@@ -509,8 +510,13 @@ pub fn create_stop_decoder(
     }
 
     // Add EOS token IDs from tokenizer (generation_config.json) as hidden stops.
-    for &eos_id in tokenizer.eos_token_ids() {
-        builder = builder.stop_token(eos_id);
+    // Skip when ignore_eos=true — the backend continues past EOS and the user
+    // expects EOS tokens to either be invisible (skip_special_tokens=true) or
+    // visible (skip_special_tokens=false), not cause early termination.
+    if !ignore_eos {
+        for &eos_id in tokenizer.eos_token_ids() {
+            builder = builder.stop_token(eos_id);
+        }
     }
 
     // Add user-provided stop token IDs (visible if no_stop_trim, hidden otherwise)

--- a/model_gateway/src/routers/grpc/utils/chat_utils.rs
+++ b/model_gateway/src/routers/grpc/utils/chat_utils.rs
@@ -508,7 +508,12 @@ pub fn create_stop_decoder(
         };
     }
 
-    // Add stop token IDs (visible if no_stop_trim is true, hidden otherwise)
+    // Add EOS token IDs from tokenizer (generation_config.json) as hidden stops.
+    for &eos_id in tokenizer.eos_token_ids() {
+        builder = builder.stop_token(eos_id);
+    }
+
+    // Add user-provided stop token IDs (visible if no_stop_trim, hidden otherwise)
     if let Some(token_ids) = stop_token_ids {
         for &token_id in token_ids {
             builder = if no_stop_trim {


### PR DESCRIPTION
## Description

### Problem

SMG's StopDecoder does not strip EOS/stop tokens from output token IDs before decoding. gRPC backends (sglang, vllm) return raw token IDs including the EOS token that caused generation to stop. With `skip_special_tokens=true` (default), EOS tokens decode to empty string — invisible. With `skip_special_tokens=false`, they decode to strings like `<|eom_id|>` or `</s>` and appear in the output text, breaking tool parsers.

Both vllm and sglang strip EOS tokens **before** decoding:

**vllm** (`v1/engine/detokenizer.py:107-111`):
```python
if stop_terminated and not self.include_stop_str_in_output:
    skipped_stop_token_id = new_token_ids[-1]
    new_token_ids = new_token_ids[:-1]
```
The engine core sets `stop_terminated` via `finish_reason == FinishReason.STOP` when EOS is hit. The `eos_token_id` comes from the tokenizer + `generation_config.json`, loaded by `InputProcessor.update_from_generation_config()`.

**sglang** (`managers/detokenizer_manager.py:164-171`):
```python
def trim_matched_stop(self, output, finished_reason, no_stop_trim):
    if no_stop_trim or not finished_reason:
        return output
    matched = finished_reason.get("matched", None)
    if isinstance(matched, int) and isinstance(output, list):
        return output[:-1]  # strip last token (the EOS)
```

**TRT-LLM** (`executor/result.py:374`): Does NOT strip EOS for `END_ID` finish reason — relies on `skip_special_tokens=True` to hide it (same gap as SMG before this PR).

**EOS token sources vary by model.** Models define EOS tokens in different config files:

| Model | `config.json` | `generation_config.json` | `tokenizer_config.json` |
|---|---|---|---|
| Llama 3 | `128001` | `[128001, 128008, 128009]` | `<\|end_of_text\|>` (string) |
| Kimi-K2 | `163585` (`[EOS]`) | `163586` (`<\|im_end\|>`) | `[EOS]` (string) |

vllm reads from `hf_config.eos_token_id` (config.json via AutoConfig) + `generation_config.eos_token_id`. sglang reads from model config which merges both sources. We follow the same approach.

### Solution

**1. Load EOS token IDs from `config.json` + `generation_config.json`**

New `crates/tokenizer/src/eos.rs` module with `load_eos_token_ids(dir)` that reads and merges EOS IDs from both config files. Supports both single int and list formats. Used by both HuggingFace and Tiktoken tokenizers (Kimi-K2 uses tiktoken). Exposed via `Tokenizer::eos_token_ids()` trait method.

**2. Strip EOS in StopDecoder**

`create_stop_decoder` adds EOS token IDs as stop tokens. Behavior depends on request parameters:

| `ignore_eos` | `no_stop_trim` | EOS behavior |
|---|---|---|
| `false` (default) | `false` (default) | Hidden stop — EOS stripped entirely |
| `false` | `true` | Visible stop — EOS decoded per `skip_special_tokens` |
| `true` | any | Not added — backend continues past EOS |

This matches vllm's `include_stop_str_in_output` and sglang's `no_stop_trim` for EOS.

### Design choices

**EOS + user stop tokens share one loop.** Both EOS IDs (from tokenizer) and user-provided `stop_token_ids` use the same `no_stop_trim` logic via a single iterator chain. HashSet inside the builder handles dedup.

**Hidden stops take precedence.** When `no_stop_trim=false`, EOS is added to `stop_tokens` (hidden). The StopDecoder checks hidden stops before visible stops (`stop.rs:153` vs `stop.rs:165`), so EOS is always stripped when `no_stop_trim=false`.

**`config.json` + `generation_config.json`, not `tokenizer_config.json`.** EOS IDs are read as integers directly from JSON — no vocab string lookup needed. This matches vllm/sglang and works for both HuggingFace and tiktoken tokenizers.

## Changes

- **`crates/tokenizer/src/eos.rs`** (new): `load_eos_token_ids(dir)` reads and merges EOS from `config.json` + `generation_config.json`, with unit tests
- **`crates/tokenizer/src/traits.rs`**: Add `fn eos_token_ids(&self) -> &[TokenIdType]` to Tokenizer trait
- **`crates/tokenizer/src/huggingface.rs`**: Load EOS via `eos::load_eos_token_ids`, implement trait method
- **`crates/tokenizer/src/tiktoken.rs`**: Same — load EOS, implement trait method (for Kimi-K2)
- **`crates/tokenizer/src/cache/mod.rs`**: Forward `eos_token_ids()` through CachedTokenizer
- **`crates/tokenizer/src/hub.rs`**: Include `config.json` and `generation_config.json` in HF downloads
- **`model_gateway/src/routers/grpc/utils/chat_utils.rs`**: Add `ignore_eos` param to `create_stop_decoder`, add EOS as stop tokens with `no_stop_trim` awareness
- **`model_gateway/src/routers/grpc/regular/stages/*/preparation.rs`**: Pass `ignore_eos` to `create_stop_decoder`
- **`model_gateway/src/routers/grpc/regular/streaming.rs`**: Thread `ignore_eos` through stop_params tuples
- **`bindings/golang/src/grpc_converter.rs`**: Pass `false` for `ignore_eos`
- **`e2e_test/chat_completions/test_validation.py`**: Add `TestEosTokenStripping` (5 tests)

## Follow-up items

- **Blanket `skip_special_tokens=false` when tools present**: With EOS stripping in place, `false` is safe. Tool trigger tokens (`[TOOL_CALLS]`, `<|python_tag|>`) are preserved while EOS is stripped. Requires threading to streaming.rs. Currently Mistral tool parsing is broken on main because `[TOOL_CALLS]` (`special=true`) is stripped by `skip_special_tokens=true`.
- **Sampling defaults from generation_config**: Load temperature/top_p/etc. defaults via `GetModelInfo.default_sampling_params_json`. See plan doc.

## Test Plan

- Verify EOS token IDs are loaded from config.json + generation_config.json
- Verify StopDecoder strips EOS before decoding — no `<|eom_id|>` or `</s>` in output
- Verify `ignore_eos=true` allows generation past EOS
- Verify `no_stop_trim=true` + `skip_special_tokens=false` makes EOS visible (matching sglang)
- Verify `no_stop_trim=true` + `skip_special_tokens=true` keeps EOS invisible
- E2E tests: `TestEosTokenStripping` (5 tests covering all combinations)

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
