### PR TITLE
fix(responses): reject explicit MCP requests when any server connection fails

### DIFF
--- a/e2e_test/responses/test_tools_call.py
+++ b/e2e_test/responses/test_tools_call.py
@@ -13,7 +13,9 @@ import logging
 import time
 from concurrent.futures import ThreadPoolExecutor
 
+import openai
 import pytest
+import smg_client
 from infra import BRAVE_MCP_URL
 
 logger = logging.getLogger(__name__)
@@ -132,10 +134,19 @@ BRAVE_MCP_TOOL_REQUIRE_APPROVAL_ALWAYS = {
     "require_approval": "always",
 }
 
+BROKEN_MCP_TOOL = {
+    "type": "mcp",
+    "server_label": "broken",
+    "server_url": "http://127.0.0.1:1/mcp",
+    "require_approval": "never",
+}
+
 MCP_TEST_PROMPT = (
     "Search the web for 'Python programming language'. Set count to 1 to "
     "get only one result and return one sentence response."
 )
+
+MCP_FAILURE_TEST_PROMPT = "Use the available MCP tools and answer briefly."
 
 
 # =============================================================================
@@ -349,11 +360,42 @@ def assert_previous_response_id_mcp_binding_behavior_streaming(model, api_client
     assert mcp_list_tools_labels(completed_events[0].response.output) == ["deepwiki"]
 
 
+def assert_explicit_mcp_failure(model, api_client, *, stream):
+    """Assert that any explicit MCP connection failure fails the whole request."""
+
+    with pytest.raises(Exception) as exc_info:
+        response = api_client.responses.create(
+            model=model,
+            input=MCP_FAILURE_TEST_PROMPT,
+            tools=[BRAVE_MCP_TOOL, BROKEN_MCP_TOOL],
+            stream=stream,
+            reasoning={"effort": "low"},
+        )
+        if stream:
+            list(response)
+
+    exc = exc_info.value
+    assert isinstance(exc, (openai.APIStatusError, smg_client.ApiError))
+    assert exc.status_code == 424
+    assert exc.code == "http_error"
+    assert "Error retrieving tool list from MCP server: 'broken'" in str(exc)
+
+
 @pytest.mark.vendor("openai")
 @pytest.mark.gpu(0)
 @pytest.mark.parametrize("setup_backend", ["openai"], indirect=True)
 class TestToolCallingCloud:
     """Tool calling tests against cloud APIs."""
+
+    def test_mcp_multi_server_fails_if_any_server_is_unreachable(self, model, api_client):
+        """Test explicit MCP requests fail when any declared server cannot connect."""
+
+        assert_explicit_mcp_failure(model, api_client, stream=False)
+
+    def test_mcp_multi_server_streaming_fails_if_any_server_is_unreachable(self, model, api_client):
+        """Test streaming explicit MCP requests fail before execution if any server cannot connect."""
+
+        assert_explicit_mcp_failure(model, api_client, stream=True)
 
     def test_basic_function_call(self, model, api_client):
         """Test basic function calling workflow."""
@@ -773,6 +815,16 @@ class TestToolCallingCloud:
 class TestToolChoiceGptOss:
     """Tool choice tests against local gRPC backend with Harmony model."""
 
+    def test_mcp_multi_server_fails_if_any_server_is_unreachable(self, model, api_client):
+        """Test explicit MCP requests fail when any declared server cannot connect."""
+
+        assert_explicit_mcp_failure(model, api_client, stream=False)
+
+    def test_mcp_multi_server_streaming_fails_if_any_server_is_unreachable(self, model, api_client):
+        """Test streaming explicit MCP requests fail before execution if any server cannot connect."""
+
+        assert_explicit_mcp_failure(model, api_client, stream=True)
+
     def test_tool_choice_auto(self, model, api_client):
         """Test tool_choice="auto" allows model to decide whether to use tools."""
 
@@ -1137,6 +1189,16 @@ class TestToolChoiceGptOss:
 @pytest.mark.parametrize("api_client", ["openai", "smg"], indirect=True)
 class TestToolChoiceLocal:
     """Tool choice tests against local gRPC backend with Qwen model."""
+
+    def test_mcp_multi_server_fails_if_any_server_is_unreachable(self, model, api_client):
+        """Test explicit MCP requests fail when any declared server cannot connect."""
+
+        assert_explicit_mcp_failure(model, api_client, stream=False)
+
+    def test_mcp_multi_server_streaming_fails_if_any_server_is_unreachable(self, model, api_client):
+        """Test streaming explicit MCP requests fail before execution if any server cannot connect."""
+
+        assert_explicit_mcp_failure(model, api_client, stream=True)
 
     def test_tool_choice_auto(self, model, api_client):
         """Test tool_choice="auto" allows model to decide whether to use tools."""

--- a/model_gateway/src/routers/common/mcp_utils.rs
+++ b/model_gateway/src/routers/common/mcp_utils.rs
@@ -343,8 +343,7 @@ pub async fn ensure_request_mcp_client(
     }
 
     let builtin_types = extract_builtin_types(tools);
-    if let Some(builtin_servers) = ensure_mcp_servers(mcp_orchestrator, &[], &builtin_types).await
-    {
+    if let Some(builtin_servers) = ensure_mcp_servers(mcp_orchestrator, &[], &builtin_types).await {
         for binding in builtin_servers {
             if !mcp_servers
                 .iter()
@@ -826,6 +825,8 @@ mod tests {
                 server_description: None,
                 require_approval: None,
                 allowed_tools: None,
+                connector_id: None,
+                defer_loading: None,
             }),
             ResponseTool::Mcp(McpTool {
                 server_url: Some("http://127.0.0.1:1/mcp".to_string()),
@@ -835,6 +836,8 @@ mod tests {
                 server_description: None,
                 require_approval: None,
                 allowed_tools: None,
+                connector_id: None,
+                defer_loading: None,
             }),
         ];
 

--- a/model_gateway/src/routers/common/mcp_utils.rs
+++ b/model_gateway/src/routers/common/mcp_utils.rs
@@ -291,35 +291,75 @@ pub async fn ensure_mcp_servers(
     }
 }
 
-/// Convenience wrapper for OpenAI Responses API routers.
+/// Convenience wrapper for request-level MCP resolution.
 ///
-/// Extracts MCP server inputs and builtin types from `ResponseTool` array,
-/// then delegates to [`ensure_mcp_servers`].
+/// Explicit MCP tools are validated one server at a time so that any failure
+/// aborts the request. Built-in tool routing still uses the existing
+/// best-effort lookup.
+///
+/// Returns:
+/// - `Ok(Some(...))` when MCP interception should run with the returned bindings.
+/// - `Ok(None)` when no MCP interception is required and the request can continue upstream.
+/// - `Err(message)` when an explicit MCP server could not be connected.
 pub async fn ensure_request_mcp_client(
     mcp_orchestrator: &Arc<McpOrchestrator>,
     tools: &[ResponseTool],
-) -> Option<Vec<McpServerBinding>> {
-    let inputs: Vec<McpServerInput> = tools
-        .iter()
-        .filter_map(|tool| match tool {
-            ResponseTool::Mcp(mcp) => Some(McpServerInput {
-                label: mcp.server_label.clone(),
-                url: mcp.server_url.clone(),
-                authorization: mcp.authorization.clone(),
-                headers: mcp.headers.clone().unwrap_or_default(),
-                // T11: project the `allowed_tools` union (List | Filter) into
-                // the flat name list `McpServerInput` still expects. See
-                // [`project_allowed_tools`] for the mapping table and the
-                // rationale for the `read_only`-only fail-closed case.
-                allowed_tools: project_allowed_tools(mcp.allowed_tools.as_ref()),
-            }),
-            _ => None,
-        })
-        .collect();
+) -> Result<Option<Vec<McpServerBinding>>, String> {
+    let mut mcp_servers: Vec<McpServerBinding> = Vec::new();
+
+    for tool in tools {
+        let ResponseTool::Mcp(mcp) = tool else {
+            continue;
+        };
+
+        let input = McpServerInput {
+            label: mcp.server_label.clone(),
+            url: mcp.server_url.clone(),
+            authorization: mcp.authorization.clone(),
+            headers: mcp.headers.clone().unwrap_or_default(),
+            // T11: project the `allowed_tools` union (List | Filter) into
+            // the flat name list `McpServerInput` still expects. See
+            // [`project_allowed_tools`] for the mapping table and the
+            // rationale for the `read_only`-only fail-closed case.
+            allowed_tools: project_allowed_tools(mcp.allowed_tools.as_ref()),
+        };
+
+        let connected = connect_mcp_servers(mcp_orchestrator, std::slice::from_ref(&input)).await;
+        if connected.is_empty() {
+            return Err(format!(
+                "Error retrieving tool list from MCP server: '{}'. Check server_url and authorization.",
+                mcp.server_label
+            ));
+        }
+
+        for binding in connected {
+            if !mcp_servers
+                .iter()
+                .any(|existing| existing.server_key == binding.server_key)
+            {
+                mcp_servers.push(binding);
+            }
+        }
+    }
 
     let builtin_types = extract_builtin_types(tools);
+    if let Some(builtin_servers) = ensure_mcp_servers(mcp_orchestrator, &[], &builtin_types).await
+    {
+        for binding in builtin_servers {
+            if !mcp_servers
+                .iter()
+                .any(|existing| existing.server_key == binding.server_key)
+            {
+                mcp_servers.push(binding);
+            }
+        }
+    }
 
-    ensure_mcp_servers(mcp_orchestrator, &inputs, &builtin_types).await
+    if mcp_servers.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(mcp_servers))
+    }
 }
 
 #[cfg(test)]
@@ -632,9 +672,9 @@ mod tests {
         let result = ensure_request_mcp_client(&orchestrator, &tools).await;
 
         // Should return Some because built-in routing is configured
-        assert!(result.is_some());
+        assert!(result.is_ok());
 
-        let mcp_servers = result.unwrap();
+        let mcp_servers = result.unwrap().unwrap();
         assert_eq!(mcp_servers.len(), 1);
 
         // The server key should be the static server name
@@ -655,7 +695,7 @@ mod tests {
         let result = ensure_request_mcp_client(&orchestrator, &tools).await;
 
         // Should return None because no MCP or built-in routing is available
-        assert!(result.is_none());
+        assert!(matches!(result, Ok(None)));
     }
 
     #[tokio::test]
@@ -675,7 +715,7 @@ mod tests {
         let result = ensure_request_mcp_client(&orchestrator, &tools).await;
 
         // Should return None - function tools don't need MCP processing
-        assert!(result.is_none());
+        assert!(matches!(result, Ok(None)));
     }
 
     #[tokio::test]
@@ -699,9 +739,9 @@ mod tests {
         let result = ensure_request_mcp_client(&orchestrator, &tools).await;
 
         // Should return Some because web_search_preview has built-in routing
-        assert!(result.is_some());
+        assert!(result.is_ok());
 
-        let mcp_servers = result.unwrap();
+        let mcp_servers = result.unwrap().unwrap();
         assert_eq!(mcp_servers.len(), 1);
         assert_eq!(mcp_servers[0].label, "search-server");
     }
@@ -771,5 +811,40 @@ mod tests {
             tool_names: Some(vec!["mutating_tool".to_string()]),
         });
         assert_eq!(project_allowed_tools(Some(&value)), Some(Vec::new()));
+    }
+
+    #[tokio::test]
+    async fn test_ensure_request_mcp_client_fails_when_any_explicit_mcp_fails() {
+        let orchestrator = create_test_orchestrator_no_builtin().await;
+
+        let tools = vec![
+            ResponseTool::Mcp(McpTool {
+                server_url: None,
+                authorization: None,
+                headers: None,
+                server_label: "static-ok".to_string(),
+                server_description: None,
+                require_approval: None,
+                allowed_tools: None,
+            }),
+            ResponseTool::Mcp(McpTool {
+                server_url: Some("http://127.0.0.1:1/mcp".to_string()),
+                authorization: None,
+                headers: None,
+                server_label: "broken".to_string(),
+                server_description: None,
+                require_approval: None,
+                allowed_tools: None,
+            }),
+        ];
+
+        let result = ensure_request_mcp_client(&orchestrator, &tools).await;
+
+        assert!(matches!(
+            result,
+            Err(ref message)
+                if message
+                    == "Error retrieving tool list from MCP server: 'broken'. Check server_url and authorization."
+        ));
     }
 }

--- a/model_gateway/src/routers/grpc/common/responses/utils.rs
+++ b/model_gateway/src/routers/grpc/common/responses/utils.rs
@@ -73,28 +73,24 @@ pub(crate) async fn ensure_mcp_connection(
         // TODO: Thread real request headers through the gRPC responses path if/when
         // gRPC MCP flows need the same forwarded-header preservation contract.
         match ensure_request_mcp_client(mcp_orchestrator, tools).await {
-            Some(mcp_servers) => {
+            Ok(Some(mcp_servers)) => {
                 return Ok((true, mcp_servers));
             }
-            None => {
-                // No MCP servers available
-                if has_explicit_mcp_tools {
-                    // Explicit MCP tools MUST have working connections
-                    error!(
-                        function = "ensure_mcp_connection",
-                        "Failed to connect to MCP servers"
-                    );
-                    return Err(error::failed_dependency(
-                        "connect_mcp_server_failed",
-                        "Failed to connect to MCP servers. Check server_url and authorization.",
-                    ));
-                }
+            Ok(None) => {
                 // Builtin tools without MCP routing - pass through to model
                 debug!(
                     function = "ensure_mcp_connection",
                     "No MCP routing configured for builtin tools, passing through to model"
                 );
                 return Ok((false, Vec::new()));
+            }
+            Err(message) => {
+                debug_assert!(has_explicit_mcp_tools);
+                error!(
+                    function = "ensure_mcp_connection",
+                    "Failed to connect to MCP servers"
+                );
+                return Err(error::failed_dependency("http_error", message));
             }
         }
     }

--- a/model_gateway/src/routers/openai/responses/non_streaming.rs
+++ b/model_gateway/src/routers/openai/responses/non_streaming.rs
@@ -63,100 +63,106 @@ pub async fn handle_non_streaming_response(mut ctx: RequestContext) -> Response 
     };
 
     // Check for MCP tools and create session if needed
-    let mcp_servers = if let Some(tools) = original_body.tools.as_deref() {
+    let mcp_resolution = if let Some(tools) = original_body.tools.as_deref() {
         ensure_request_mcp_client(mcp_orchestrator, tools).await
     } else {
-        None
+        Ok(None)
     };
 
     let mut response_json: Value;
 
-    if let Some(mcp_servers) = mcp_servers {
-        let session_request_id = original_body
-            .request_id
-            .clone()
-            .unwrap_or_else(|| format!("req_{}", uuid::Uuid::now_v7()));
-        let forwarded_headers = extract_forwardable_request_headers(ctx.headers());
-        let mut session = McpToolSession::new_with_headers(
-            mcp_orchestrator,
-            mcp_servers,
-            &session_request_id,
-            forwarded_headers,
-        );
-        if let Some(tools) = original_body.tools.as_deref() {
-            session.configure_response_tools_approval(tools);
+    match mcp_resolution {
+        Ok(Some(mcp_servers)) => {
+            let session_request_id = original_body
+                .request_id
+                .clone()
+                .unwrap_or_else(|| format!("req_{}", uuid::Uuid::now_v7()));
+            let forwarded_headers = extract_forwardable_request_headers(ctx.headers());
+            let mut session = McpToolSession::new_with_headers(
+                mcp_orchestrator,
+                mcp_servers,
+                &session_request_id,
+                forwarded_headers,
+            );
+            if let Some(tools) = original_body.tools.as_deref() {
+                session.configure_response_tools_approval(tools);
+            }
+            prepare_mcp_tools_as_functions(&mut payload, &session);
+
+            match execute_tool_loop(
+                ctx.components.client(),
+                &url,
+                ctx.headers(),
+                worker.api_key(),
+                payload,
+                ToolLoopExecutionContext {
+                    original_body,
+                    existing_mcp_list_tools_labels: &existing_mcp_list_tools_labels,
+                    session: &session,
+                },
+            )
+            .await
+            {
+                Ok(resp) => {
+                    worker.record_outcome(200);
+                    response_json = resp;
+                }
+                Err(err) => {
+                    worker.record_outcome(502);
+                    return error::internal_error("upstream_error", err);
+                }
+            }
+
+            restore_original_tools(&mut response_json, original_body, Some(&session));
         }
-        prepare_mcp_tools_as_functions(&mut payload, &session);
+        Ok(None) => {
+            let mut request_builder = ctx.components.client().post(&url).json(&payload);
+            let provider = ApiProvider::from_url(&url);
+            let auth_header = provider.extract_auth_header(ctx.headers(), worker.api_key());
+            request_builder = provider.apply_headers(request_builder, auth_header.as_ref());
 
-        match execute_tool_loop(
-            ctx.components.client(),
-            &url,
-            ctx.headers(),
-            worker.api_key(),
-            payload,
-            ToolLoopExecutionContext {
-                original_body,
-                existing_mcp_list_tools_labels: &existing_mcp_list_tools_labels,
-                session: &session,
-            },
-        )
-        .await
-        {
-            Ok(resp) => {
-                worker.record_outcome(200);
-                response_json = resp;
+            let response = match request_builder.send().await {
+                Ok(r) => r,
+                Err(e) => {
+                    worker.record_outcome(502);
+                    tracing::error!(
+                        url = %url,
+                        error = %e,
+                        "Failed to forward request to OpenAI"
+                    );
+                    return error::bad_gateway(
+                        "upstream_error",
+                        format!("Failed to forward request to OpenAI: {e}"),
+                    );
+                }
+            };
+
+            let status = response.status();
+            worker.record_outcome(status.as_u16());
+
+            if !status.is_success() {
+                let status = StatusCode::from_u16(status.as_u16())
+                    .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+                let body = response.text().await.unwrap_or_default();
+                let body = error::sanitize_error_body(&body);
+                return (status, body).into_response();
             }
-            Err(err) => {
-                worker.record_outcome(502);
-                return error::internal_error("upstream_error", err);
-            }
+
+            response_json = match response.json::<Value>().await {
+                Ok(r) => r,
+                Err(e) => {
+                    return error::internal_error(
+                        "parse_error",
+                        format!("Failed to parse upstream response: {e}"),
+                    );
+                }
+            };
+
+            restore_original_tools(&mut response_json, original_body, None);
         }
-
-        restore_original_tools(&mut response_json, original_body, Some(&session));
-    } else {
-        let mut request_builder = ctx.components.client().post(&url).json(&payload);
-        let provider = ApiProvider::from_url(&url);
-        let auth_header = provider.extract_auth_header(ctx.headers(), worker.api_key());
-        request_builder = provider.apply_headers(request_builder, auth_header.as_ref());
-
-        let response = match request_builder.send().await {
-            Ok(r) => r,
-            Err(e) => {
-                worker.record_outcome(502);
-                tracing::error!(
-                    url = %url,
-                    error = %e,
-                    "Failed to forward request to OpenAI"
-                );
-                return error::bad_gateway(
-                    "upstream_error",
-                    format!("Failed to forward request to OpenAI: {e}"),
-                );
-            }
-        };
-
-        let status = response.status();
-        worker.record_outcome(status.as_u16());
-
-        if !status.is_success() {
-            let status =
-                StatusCode::from_u16(status.as_u16()).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
-            let body = response.text().await.unwrap_or_default();
-            let body = error::sanitize_error_body(&body);
-            return (status, body).into_response();
+        Err(message) => {
+            return error::failed_dependency("http_error", message);
         }
-
-        response_json = match response.json::<Value>().await {
-            Ok(r) => r,
-            Err(e) => {
-                return error::internal_error(
-                    "parse_error",
-                    format!("Failed to parse upstream response: {e}"),
-                );
-            }
-        };
-
-        restore_original_tools(&mut response_json, original_body, None);
     }
     patch_response_with_request_metadata(
         &mut response_json,

--- a/model_gateway/src/routers/openai/responses/streaming.rs
+++ b/model_gateway/src/routers/openai/responses/streaming.rs
@@ -49,7 +49,7 @@ use crate::{
             header_utils::{
                 extract_forwardable_request_headers, preserve_response_headers, ApiProvider,
             },
-            mcp_utils::DEFAULT_MAX_ITERATIONS,
+            mcp_utils::{ensure_request_mcp_client, DEFAULT_MAX_ITERATIONS},
             persistence_utils::persist_conversation_items,
         },
         error,
@@ -1062,8 +1062,6 @@ pub(super) fn handle_streaming_with_tool_interception(
 
 /// Main entry point for streaming responses
 pub async fn handle_streaming_response(ctx: RequestContext) -> Response {
-    use crate::routers::common::mcp_utils::ensure_request_mcp_client;
-
     let worker = match ctx.worker() {
         Some(w) => w.clone(),
         None => {
@@ -1085,10 +1083,15 @@ pub async fn handle_streaming_response(ctx: RequestContext) -> Response {
     };
 
     // Check for MCP tools and create request context if needed
-    let mcp_servers = if let Some(tools) = original_body.tools.as_deref() {
+    let mcp_resolution = if let Some(tools) = original_body.tools.as_deref() {
         ensure_request_mcp_client(&mcp_orchestrator, tools).await
     } else {
-        None
+        Ok(None)
+    };
+
+    let mcp_servers = match mcp_resolution {
+        Err(message) => return error::failed_dependency("http_error", message),
+        Ok(servers) => servers,
     };
 
     let client = ctx.components.client().clone();


### PR DESCRIPTION
## Description

### Problem

Explicit mcp tools could fall through as if no MCP routing was required when server connection setup failed. That let requests continue instead of failing fast, which diverged from expected behavior for explicit MCP dependencies.

### Solution

Tighten request-level MCP resolution so explicit mcp tools are validated one server at a time. If any explicit MCP server cannot be connected, the request now fails immediately with a 424 / http_error response. Builtin tool routing behavior remains unchanged.

## Changes

- Update ensure_request_mcp_client to return:
  - Ok(Some(...)) when MCP interception should run
  - Ok(None) when no MCP interception is needed
  - Err(message) when an explicit MCP server cannot be connected
- Make explicit MCP requests fail if any declared MCP server is unreachable
- Apply the same failure handling in:
  - OpenAI responses non-streaming
  - OpenAI responses streaming
  - gRPC shared responses MCP handling
- Add e2e coverage for explicit MCP multi-server failure behavior on:
  - OpenAI backend
  - gRPC Harmony backend
  - gRPC regular backend
- Verify both non-streaming and streaming requests fail before partial execution

## Test Plan

### Before:
- Send a request with one valid explicit MCP tool and one unreachable explicit MCP tool
- Observe that the request could continue instead of failing the whole request


### After:
- Send a request with one valid explicit MCP tool and one unreachable explicit MCP tool
- Verify request fails with:
   - HTTP status 424
   - error code http_error
   - message containing Error retrieving tool list from MCP server: 'broken'

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Requests that declare external tool/MCP servers now fail fast with a clear dependency error when any declared server is unreachable, for both streaming and non‑streaming flows, avoiding ambiguous or partial responses.

* **Tests**
  * Added end-to-end tests that verify multi‑server failure behavior for streaming and non‑streaming requests when any declared tool server is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->