### PR TITLE
refactor(worker): canonical runtime API on WorkerRuntime (Finding 4 Part B)

### DIFF
--- a/model_gateway/src/worker/worker.rs
+++ b/model_gateway/src/worker/worker.rs
@@ -192,9 +192,6 @@ pub trait Worker: Send + Sync + fmt::Debug + 'static {
     /// Decrement the load counter
     fn decrement_load(&self);
 
-    /// Reset the load counter to 0 (for sync/recovery)
-    fn reset_load(&self) {}
-
     /// Get the current routing-key load cardinality.
     fn routing_key_load(&self) -> usize;
 
@@ -588,20 +585,96 @@ impl WorkerRuntime {
         }
     }
 
-    fn status(&self) -> WorkerStatus {
+    // ── Lifecycle status ────────────────────────────────────────────
+
+    pub fn status(&self) -> WorkerStatus {
         WorkerStatus::from_u8(self.status.load(Ordering::Acquire))
     }
 
-    fn set_status(&self, status: WorkerStatus) {
+    pub fn set_status(&self, status: WorkerStatus) {
         self.status.store(status as u8, Ordering::Release);
     }
 
-    fn revision(&self) -> u64 {
+    pub fn revision(&self) -> u64 {
         self.revision.load(Ordering::Acquire)
     }
 
-    fn bump_revision(&self) -> u64 {
+    pub fn bump_revision(&self) -> u64 {
         self.revision.fetch_add(1, Ordering::AcqRel) + 1
+    }
+
+    // ── Health-check counters ───────────────────────────────────────
+
+    pub fn consecutive_failures_increment(&self) -> usize {
+        self.consecutive_failures.fetch_add(1, Ordering::AcqRel) + 1
+    }
+
+    pub fn consecutive_failures_reset(&self) {
+        self.consecutive_failures.store(0, Ordering::Release);
+    }
+
+    pub fn consecutive_successes_increment(&self) -> usize {
+        self.consecutive_successes.fetch_add(1, Ordering::AcqRel) + 1
+    }
+
+    pub fn consecutive_successes_reset(&self) {
+        self.consecutive_successes.store(0, Ordering::Release);
+    }
+
+    pub fn total_pending_probes(&self) -> usize {
+        self.total_pending_probes.load(Ordering::Relaxed)
+    }
+
+    pub fn total_pending_probes_increment(&self) -> usize {
+        self.total_pending_probes.fetch_add(1, Ordering::Relaxed) + 1
+    }
+
+    pub fn total_pending_probes_reset(&self) {
+        self.total_pending_probes.store(0, Ordering::Relaxed);
+    }
+
+    // ── Load counter ────────────────────────────────────────────────
+
+    pub fn load(&self) -> usize {
+        self.load_counter.load(Ordering::Relaxed)
+    }
+
+    pub fn increment_load(&self) {
+        self.load_counter.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Saturating decrement. Returns `true` if the counter was decremented,
+    /// `false` if it was already zero — callers can log when that happens.
+    pub fn try_decrement_load(&self) -> bool {
+        self.load_counter
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+                current.checked_sub(1)
+            })
+            .is_ok()
+    }
+
+    // ── Routing-key load ────────────────────────────────────────────
+
+    pub fn routing_key_load(&self) -> usize {
+        self.worker_routing_key_load.value()
+    }
+
+    pub fn increment_routing_key_load(&self, routing_key: &str) {
+        self.worker_routing_key_load.increment(routing_key);
+    }
+
+    pub fn decrement_routing_key_load(&self, routing_key: &str) {
+        self.worker_routing_key_load.decrement(routing_key);
+    }
+
+    // ── Processed-request counter ───────────────────────────────────
+
+    pub fn processed_requests(&self) -> usize {
+        self.processed_counter.load(Ordering::Relaxed)
+    }
+
+    pub fn increment_processed(&self) {
+        self.processed_counter.fetch_add(1, Ordering::Relaxed);
     }
 }
 
@@ -739,78 +812,44 @@ impl Worker for BasicWorker {
     }
 
     fn consecutive_failures_increment(&self) -> usize {
-        self.runtime
-            .load()
-            .consecutive_failures
-            .fetch_add(1, Ordering::AcqRel)
-            + 1
+        self.runtime.load().consecutive_failures_increment()
     }
 
     fn consecutive_failures_reset(&self) {
-        self.runtime
-            .load()
-            .consecutive_failures
-            .store(0, Ordering::Release);
+        self.runtime.load().consecutive_failures_reset();
     }
 
     fn consecutive_successes_increment(&self) -> usize {
-        self.runtime
-            .load()
-            .consecutive_successes
-            .fetch_add(1, Ordering::AcqRel)
-            + 1
+        self.runtime.load().consecutive_successes_increment()
     }
 
     fn consecutive_successes_reset(&self) {
-        self.runtime
-            .load()
-            .consecutive_successes
-            .store(0, Ordering::Release);
+        self.runtime.load().consecutive_successes_reset();
     }
 
     fn total_pending_probes(&self) -> usize {
-        self.runtime
-            .load()
-            .total_pending_probes
-            .load(Ordering::Relaxed)
+        self.runtime.load().total_pending_probes()
     }
 
     fn total_pending_probes_increment(&self) -> usize {
-        self.runtime
-            .load()
-            .total_pending_probes
-            .fetch_add(1, Ordering::Relaxed)
-            + 1
+        self.runtime.load().total_pending_probes_increment()
     }
 
     fn total_pending_probes_reset(&self) {
-        self.runtime
-            .load()
-            .total_pending_probes
-            .store(0, Ordering::Relaxed);
+        self.runtime.load().total_pending_probes_reset();
     }
 
     fn load(&self) -> usize {
-        self.runtime.load().load_counter.load(Ordering::Relaxed)
+        self.runtime.load().load()
     }
 
     fn increment_load(&self) {
-        self.runtime
-            .load()
-            .load_counter
-            .fetch_add(1, Ordering::Relaxed);
+        self.runtime.load().increment_load();
         self.update_running_requests_metrics();
     }
 
     fn decrement_load(&self) {
-        let runtime = self.runtime.load();
-        if runtime
-            .load_counter
-            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
-                current.checked_sub(1)
-            })
-            .is_err()
-        {
+        if !self.runtime.load().try_decrement_load() {
             tracing::warn!(
                 worker_url = %self.metadata.spec.url,
                 "Attempted to decrement load counter that is already at 0"
@@ -819,41 +858,24 @@ impl Worker for BasicWorker {
         self.update_running_requests_metrics();
     }
 
-    fn reset_load(&self) {
-        self.runtime.load().load_counter.store(0, Ordering::Relaxed);
-        self.update_running_requests_metrics();
-    }
-
     fn routing_key_load(&self) -> usize {
-        self.runtime.load().worker_routing_key_load.value()
+        self.runtime.load().routing_key_load()
     }
 
     fn increment_routing_key_load(&self, routing_key: &str) {
-        self.runtime
-            .load()
-            .worker_routing_key_load
-            .increment(routing_key);
+        self.runtime.load().increment_routing_key_load(routing_key);
     }
 
     fn decrement_routing_key_load(&self, routing_key: &str) {
-        self.runtime
-            .load()
-            .worker_routing_key_load
-            .decrement(routing_key);
+        self.runtime.load().decrement_routing_key_load(routing_key);
     }
 
     fn processed_requests(&self) -> usize {
-        self.runtime
-            .load()
-            .processed_counter
-            .load(Ordering::Relaxed)
+        self.runtime.load().processed_requests()
     }
 
     fn increment_processed(&self) {
-        self.runtime
-            .load()
-            .processed_counter
-            .fetch_add(1, Ordering::Relaxed);
+        self.runtime.load().increment_processed();
     }
 
     fn metadata(&self) -> &WorkerMetadata {


### PR DESCRIPTION
## Summary

Part B of the Worker trait trim outlined in `.claude/plans/2026-04-14-worker-module-followup-cleanup.md` (Finding 4, categories B + C). Follows the same **Option 2** principle that landed in Part A (#1127): canonical implementation on the underlying struct, trait surface preserved so callers don't churn, only delete truly dead methods.

Part A consolidated the metadata delegates onto `WorkerMetadata`. Part B does the equivalent consolidation for runtime state, so the atomic bookkeeping (orderings, post-increment adjustments, saturating decrements) lives in exactly one place: `impl WorkerRuntime`.

## What changed

All edits live in `model_gateway/src/worker/worker.rs`:

- **Delete dead `Worker::reset_load`.** `grep -rn reset_load` confirmed 0 callers anywhere in the tree (trait default was a no-op `{}`, and the only override was in `BasicWorker`). Dead code removed, not deprecated.
- **Promote `WorkerRuntime`'s lifecycle methods to `pub`.** `status`, `set_status`, `revision`, `bump_revision` were all private on `impl WorkerRuntime` — promoted to `pub fn` so callers can reach them through a single accessor without bouncing through the `Worker` trait.
- **Add canonical counter methods on `impl WorkerRuntime`** as the single source of truth for runtime state:
  - Health counters: `consecutive_failures_increment/_reset`, `consecutive_successes_increment/_reset`, `total_pending_probes/_increment/_reset`
  - Load counter: `load`, `increment_load`, new `try_decrement_load() -> bool` (returns `false` on underflow so callers can warn)
  - Routing-key load: `routing_key_load`, `increment_routing_key_load`, `decrement_routing_key_load`
  - Processed counter: `processed_requests`, `increment_processed`
- **Rewrite the 15 counter methods on `impl Worker for BasicWorker`** so each is a one-line forward of the form `self.runtime.load().method()`. BasicWorker-specific side effects (`update_running_requests_metrics()` after every load mutation, `Metrics::set_worker_health` after `set_status`) stay at the forwarding layer — only the atomic bookkeeping moves to `WorkerRuntime`.

**Not touched (already Option 2-compliant):**
- Category C (circuit breaker) — the six BasicWorker wrappers (`circuit_breaker_state`, `circuit_breaker_can_execute`, `record_circuit_breaker_outcome`, plus the `is_available` / `record_outcome` default impls and the `resilience` accessor) already forward to `CircuitBreaker::state()`, `.can_execute()`, `.record_outcome()` which own the canonical implementation in `worker/circuit_breaker.rs`. No changes needed.
- The `GrpcWorker` Worker impl in `bindings/golang/src/policy.rs` — this one carries its own raw atomics with comments saying the counters are intentionally no-ops ("FFI workers don't run the state machine — these counters are unused"). Consolidating it onto `Arc<WorkerRuntime>` is a bigger cross-crate change and belongs to a separate PR. This PR leaves it alone and verifies it still compiles against the trimmed trait.

## Why

Before this PR, every counter mutation on `BasicWorker` went through a ~6-line block that reached into `WorkerRuntime`'s internal atomic fields directly (e.g. `self.runtime.load().consecutive_failures.fetch_add(1, Ordering::AcqRel) + 1`). Consequences:

1. The struct fields had to be `pub` for the trait impl to touch them, which leaked implementation details.
2. Each atomic ordering choice (`AcqRel` for health counters, `Relaxed` for load/processed, `Release`/`Acquire` for status) was duplicated at every call site. If we ever need to reason about memory ordering or benchmark alternatives, we'd have to hunt 15+ call sites.
3. The post-increment `+ 1` and the saturating `fetch_update` idiom lived inside the trait impl.

Collapsing the implementation onto `WorkerRuntime` keeps precisely one copy of each atomic ordering choice, and lets future `Worker` implementations (e.g. the FFI `GrpcWorker`) adopt the canonical runtime wholesale without duplicating the memory-ordering rules.

`reset_load` had no callers anywhere — keeping it in the trait just added noise. Deleting dead methods keeps the trait definition honest.

## How — Option 2 principle

Trait methods stay (so callers still write `worker.load()`, `worker.increment_processed()`, etc. — **zero churn** across `routers/` and `workflow/`). The impl on `BasicWorker` becomes one-line forwards. The canonical code lives in exactly one place: `impl WorkerRuntime`.

Before / after on a representative method (`consecutive_failures_increment`):

```rust
// Before — BasicWorker reaches into WorkerRuntime internals
fn consecutive_failures_increment(&self) -> usize {
    self.runtime
        .load()
        .consecutive_failures
        .fetch_add(1, Ordering::AcqRel)
        + 1
}

// After — canonical impl on WorkerRuntime, BasicWorker forwards
fn consecutive_failures_increment(&self) -> usize {
    self.runtime.load().consecutive_failures_increment()
}
```

`decrement_load` is the one method with non-trivial BasicWorker-side behavior (it logs when the counter is already zero). The new split is:

```rust
// On WorkerRuntime — pure atomic bookkeeping
pub fn try_decrement_load(&self) -> bool {
    self.load_counter
        .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |c| c.checked_sub(1))
        .is_ok()
}

// On BasicWorker — logging + metric export stay here
fn decrement_load(&self) {
    if !self.runtime.load().try_decrement_load() {
        tracing::warn!(
            worker_url = %self.metadata.spec.url,
            "Attempted to decrement load counter that is already at 0"
        );
    }
    self.update_running_requests_metrics();
}
```

## Test plan

- [x] `cargo check -p smg` — clean.
- [x] `cargo clippy -p smg --all-targets -- -D warnings` — clean.
- [x] `cargo clippy -p smg-golang --all-targets -- -D warnings` — clean (`GrpcWorker` in `bindings/golang` still compiles against the trimmed trait).
- [x] `cargo check -p smg-python` — clean.
- [x] `cargo test -p smg --lib` — **538 passed; 0 failed; 4 ignored** (no test changes were required — the existing worker counter tests in `worker::worker::tests` exercise the new forwarding code path transparently through the same trait methods).

Refs: `.claude/plans/2026-04-14-worker-module-followup-cleanup.md` (Finding 4 Part B)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced worker runtime infrastructure with improved health-check monitoring and state tracking capabilities
  * Improved load management with safer operations to prevent counter overflow
  * Expanded internal counters for tracking worker failures, successes, and pending operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->