### PR TITLE
refactor(worker): extract HashRing into its own module (Finding 5)

### DIFF
--- a/model_gateway/src/policies/consistent_hashing.rs
+++ b/model_gateway/src/policies/consistent_hashing.rs
@@ -404,7 +404,7 @@ mod tests {
             "http://w2:8000",
             "http://w3:8000",
         ]);
-        let ring = Arc::new(HashRing::new(&workers));
+        let ring = Arc::new(HashRing::new(workers.iter().map(|w| w.url())));
 
         // Record which worker each key routes to with all workers healthy
         let mut key_to_worker_before: HashMap<String, usize> = HashMap::new();
@@ -463,7 +463,7 @@ mod tests {
         // and when it recovers, keys return to the original worker
         let policy = ConsistentHashingPolicy::new();
         let workers = create_workers(&["http://w0:8000", "http://w1:8000", "http://w2:8000"]);
-        let ring = Arc::new(HashRing::new(&workers));
+        let ring = Arc::new(HashRing::new(workers.iter().map(|w| w.url())));
 
         // Find which worker a key routes to when all are healthy
         let test_key = "session-abc-123";

--- a/model_gateway/src/policies/prefix_hash.rs
+++ b/model_gateway/src/policies/prefix_hash.rs
@@ -264,7 +264,7 @@ mod tests {
     fn test_prefix_hash_consistent_routing() {
         let policy = PrefixHashPolicy::with_defaults();
         let workers = create_workers(&["http://w1:8000", "http://w2:8000", "http://w3:8000"]);
-        let ring = Arc::new(HashRing::new(&workers));
+        let ring = Arc::new(HashRing::new(workers.iter().map(|w| w.url())));
 
         // Same tokens should always route to same worker
         let tokens: Vec<u32> = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
@@ -288,7 +288,7 @@ mod tests {
     fn test_different_prefixes_distribute() {
         let policy = PrefixHashPolicy::with_defaults();
         let workers = create_workers(&["http://w1:8000", "http://w2:8000", "http://w3:8000"]);
-        let ring = Arc::new(HashRing::new(&workers));
+        let ring = Arc::new(HashRing::new(workers.iter().map(|w| w.url())));
 
         let mut distribution = std::collections::HashMap::new();
 
@@ -318,7 +318,7 @@ mod tests {
             ..Default::default()
         });
         let workers = create_workers(&["http://w1:8000", "http://w2:8000", "http://w3:8000"]);
-        let ring = Arc::new(HashRing::new(&workers));
+        let ring = Arc::new(HashRing::new(workers.iter().map(|w| w.url())));
 
         // Two sequences with same first 5 tokens should route to same worker
         let tokens1: Vec<u32> = vec![1, 2, 3, 4, 5, 100, 200, 300];
@@ -345,7 +345,7 @@ mod tests {
     fn test_no_tokens_returns_none() {
         let policy = PrefixHashPolicy::with_defaults();
         let workers = create_workers(&["http://w1:8000"]);
-        let ring = Arc::new(HashRing::new(&workers));
+        let ring = Arc::new(HashRing::new(workers.iter().map(|w| w.url())));
 
         // Empty tokens
         let tokens: Vec<u32> = vec![];
@@ -377,7 +377,7 @@ mod tests {
         let workers = create_workers(&["http://w1:8000"]);
         workers[0].set_status(WorkerStatus::NotReady);
 
-        let ring = Arc::new(HashRing::new(&workers));
+        let ring = Arc::new(HashRing::new(workers.iter().map(|w| w.url())));
         let tokens: Vec<u32> = vec![1, 2, 3];
         let info = SelectWorkerInfo {
             tokens: Some(&tokens),

--- a/model_gateway/src/worker/hash_ring.rs
+++ b/model_gateway/src/worker/hash_ring.rs
@@ -2,7 +2,9 @@
 //!
 //! The ring maps a routing key to a worker URL using consistent hashing over
 //! virtual nodes. The registry rebuilds one ring per model when workers are
-//! added or removed, so lookups stay allocation-free on the request path.
+//! added or removed, so the build cost is amortized — individual lookups only
+//! pay an `O(log n)` binary search plus a small bounded dedupe set to skip
+//! virtual-node duplicates. See [`HashRing::find_healthy_url`] for details.
 //!
 //! The type intentionally has no dependency on the `Worker` trait — it is
 //! constructed from URLs — so policies and tests can build rings without
@@ -84,10 +86,15 @@ impl HashRing {
         )
     }
 
-    /// Find worker URL for a key using consistent hashing.
+    /// Find a worker URL for a key using consistent hashing.
     ///
     /// Returns the first healthy worker URL at or after the key's position
     /// (clockwise). Skips virtual nodes for workers already checked.
+    ///
+    /// Cost per call: `O(log n)` binary search to find the start position
+    /// plus one small `HashSet` allocation bounded by
+    /// `min(worker_count(), 16)` slots to dedupe virtual-node hits while
+    /// walking clockwise. The dedupe set is dropped before return.
     ///
     /// - `key`: The routing key to hash
     /// - `is_healthy`: Function to check if a worker URL is healthy
@@ -105,7 +112,10 @@ impl HashRing {
         let start = self.entries.partition_point(|(pos, _)| *pos < key_pos);
 
         // Walk clockwise from start, wrapping around. Track visited URLs to
-        // avoid checking the same worker multiple times (virtual nodes).
+        // avoid calling `is_healthy` multiple times for the same worker when
+        // we hit its virtual nodes. Capacity is bounded by the physical worker
+        // count — typically a handful of entries — so the per-lookup
+        // allocation is negligible relative to the hashing itself.
         let mut checked_urls = HashSet::with_capacity(self.worker_count().min(16));
 
         for i in 0..self.entries.len() {

--- a/model_gateway/src/worker/hash_ring.rs
+++ b/model_gateway/src/worker/hash_ring.rs
@@ -1,0 +1,192 @@
+//! Consistent hash ring for O(log n) worker selection.
+//!
+//! The ring maps a routing key to a worker URL using consistent hashing over
+//! virtual nodes. The registry rebuilds one ring per model when workers are
+//! added or removed, so lookups stay allocation-free on the request path.
+//!
+//! The type intentionally has no dependency on the `Worker` trait — it is
+//! constructed from URLs — so policies and tests can build rings without
+//! materializing fake workers.
+
+use std::{collections::HashSet, sync::Arc};
+
+/// Number of virtual nodes per physical worker for even distribution.
+/// 150 is a common choice that provides good balance between memory and distribution.
+const VIRTUAL_NODES_PER_WORKER: usize = 150;
+
+/// Consistent hash ring for O(log n) worker selection.
+///
+/// Each worker is placed at multiple positions (virtual nodes) on the ring
+/// based on `hash(worker_url + vnode_index)`. This provides:
+/// - Even key distribution across workers
+/// - Minimal key redistribution when workers are added/removed (~1/N keys move)
+/// - O(log n) lookup via binary search
+///
+/// Uses blake3 for stable, fast hashing that is consistent across Rust versions.
+#[derive(Debug, Clone)]
+pub struct HashRing {
+    /// Sorted list of `(ring_position, worker_url)`.
+    ///
+    /// Multiple entries per worker (virtual nodes) for even distribution.
+    /// Uses `Arc<str>` to share each URL across all of its virtual nodes
+    /// (150 refs vs 150 copies).
+    entries: Arc<[(u64, Arc<str>)]>,
+}
+
+impl HashRing {
+    /// Build a hash ring from a collection of worker URLs.
+    ///
+    /// Creates `VIRTUAL_NODES_PER_WORKER` entries per URL for even distribution.
+    /// Accepts any iterable of string-like items, so callers can pass the
+    /// output of `workers.iter().map(|w| w.url())` without allocating a Vec.
+    pub fn new<I>(urls: I) -> Self
+    where
+        I: IntoIterator,
+        I::Item: AsRef<str>,
+    {
+        let iter = urls.into_iter();
+        let (lower, _) = iter.size_hint();
+        let mut entries: Vec<(u64, Arc<str>)> =
+            Vec::with_capacity(lower.saturating_mul(VIRTUAL_NODES_PER_WORKER));
+
+        for url in iter {
+            // Create Arc<str> once per worker, share across all virtual nodes.
+            let url: Arc<str> = Arc::from(url.as_ref());
+
+            for vnode in 0..VIRTUAL_NODES_PER_WORKER {
+                let vnode_key = format!("{url}#{vnode}");
+                let pos = Self::hash_position(&vnode_key);
+                entries.push((pos, Arc::clone(&url)));
+            }
+        }
+
+        // Sort by ring position for binary search.
+        entries.sort_unstable_by_key(|(pos, _)| *pos);
+
+        Self {
+            entries: Arc::from(entries.into_boxed_slice()),
+        }
+    }
+
+    /// Hash a string to a ring position using blake3 (stable across versions).
+    #[inline]
+    #[expect(
+        clippy::expect_used,
+        reason = "blake3 always produces 32 bytes — converting a fixed 8-byte slice to [u8; 8] is infallible"
+    )]
+    fn hash_position(s: &str) -> u64 {
+        let hash = blake3::hash(s.as_bytes());
+        // Take first 8 bytes as u64.
+        u64::from_le_bytes(
+            hash.as_bytes()[..8]
+                .try_into()
+                .expect("blake3 hash is always 32 bytes, slicing first 8 is infallible"),
+        )
+    }
+
+    /// Find worker URL for a key using consistent hashing.
+    ///
+    /// Returns the first healthy worker URL at or after the key's position
+    /// (clockwise). Skips virtual nodes for workers already checked.
+    ///
+    /// - `key`: The routing key to hash
+    /// - `is_healthy`: Function to check if a worker URL is healthy
+    pub fn find_healthy_url<F>(&self, key: &str, is_healthy: F) -> Option<&str>
+    where
+        F: Fn(&str) -> bool,
+    {
+        if self.entries.is_empty() {
+            return None;
+        }
+
+        let key_pos = Self::hash_position(key);
+
+        // Binary search to find first entry at or after key_pos.
+        let start = self.entries.partition_point(|(pos, _)| *pos < key_pos);
+
+        // Walk clockwise from start, wrapping around. Track visited URLs to
+        // avoid checking the same worker multiple times (virtual nodes).
+        let mut checked_urls = HashSet::with_capacity(self.worker_count().min(16));
+
+        for i in 0..self.entries.len() {
+            let (_, url) = &self.entries[(start + i) % self.entries.len()];
+            let url_str: &str = url;
+
+            if !checked_urls.insert(url_str) {
+                continue;
+            }
+
+            if is_healthy(url_str) {
+                return Some(url_str);
+            }
+        }
+
+        None
+    }
+
+    /// Check if the ring is empty.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Get the number of entries in the ring (including virtual nodes).
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Get the number of unique workers in the ring.
+    pub fn worker_count(&self) -> usize {
+        self.entries.len() / VIRTUAL_NODES_PER_WORKER.max(1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_ring_returns_none() {
+        let ring = HashRing::new(std::iter::empty::<&str>());
+        assert!(ring.is_empty());
+        assert_eq!(ring.len(), 0);
+        assert_eq!(ring.worker_count(), 0);
+        assert_eq!(ring.find_healthy_url("any-key", |_| true), None);
+    }
+
+    #[test]
+    fn len_scales_with_virtual_nodes() {
+        let ring = HashRing::new(["http://a", "http://b", "http://c"]);
+        assert!(!ring.is_empty());
+        assert_eq!(ring.len(), 3 * VIRTUAL_NODES_PER_WORKER);
+        assert_eq!(ring.worker_count(), 3);
+    }
+
+    #[test]
+    fn find_healthy_url_is_deterministic() {
+        let ring = HashRing::new(["http://a", "http://b", "http://c"]);
+        let first = ring.find_healthy_url("routing-key", |_| true).unwrap();
+        for _ in 0..10 {
+            assert_eq!(ring.find_healthy_url("routing-key", |_| true), Some(first));
+        }
+    }
+
+    #[test]
+    fn find_healthy_url_skips_unhealthy() {
+        let ring = HashRing::new(["http://a", "http://b", "http://c"]);
+        let picked = ring.find_healthy_url("routing-key", |url| url != "http://a");
+        assert!(matches!(picked, Some("http://b") | Some("http://c")));
+    }
+
+    #[test]
+    fn find_healthy_url_returns_none_when_all_unhealthy() {
+        let ring = HashRing::new(["http://a", "http://b"]);
+        assert_eq!(ring.find_healthy_url("k", |_| false), None);
+    }
+
+    #[test]
+    fn accepts_owned_string_iterators() {
+        let urls = vec!["http://a".to_string(), "http://b".to_string()];
+        let ring = HashRing::new(urls);
+        assert_eq!(ring.worker_count(), 2);
+    }
+}

--- a/model_gateway/src/worker/mod.rs
+++ b/model_gateway/src/worker/mod.rs
@@ -4,6 +4,7 @@ pub mod builder;
 pub mod circuit_breaker;
 pub mod error;
 pub mod event;
+pub mod hash_ring;
 pub mod http_client;
 pub mod kv_event_monitor;
 pub mod manager;
@@ -37,7 +38,8 @@ pub use openai_protocol::{
     model_type::{Endpoint, ModelType},
     worker::{ProviderType, WorkerGroupKey},
 };
-pub use registry::{HashRing, WorkerRegistry};
+pub use hash_ring::HashRing;
+pub use registry::WorkerRegistry;
 pub use resilience::{resolve_resilience, ResolvedResilience, DEFAULT_RETRYABLE_STATUS_CODES};
 pub use service::WorkerService;
 pub use worker::{

--- a/model_gateway/src/worker/mod.rs
+++ b/model_gateway/src/worker/mod.rs
@@ -27,6 +27,7 @@ pub mod worker;
 pub use builder::BasicWorkerBuilder;
 pub use circuit_breaker::{CircuitBreaker, CircuitBreakerConfig};
 pub use error::{WorkerError, WorkerResult};
+pub use hash_ring::HashRing;
 pub use http_client::build_worker_http_client;
 pub use kv_event_monitor::KvEventMonitor;
 pub use manager::WorkerManager;
@@ -38,7 +39,6 @@ pub use openai_protocol::{
     model_type::{Endpoint, ModelType},
     worker::{ProviderType, WorkerGroupKey},
 };
-pub use hash_ring::HashRing;
 pub use registry::WorkerRegistry;
 pub use resilience::{resolve_resilience, ResolvedResilience, DEFAULT_RETRYABLE_STATUS_CODES};
 pub use service::WorkerService;

--- a/model_gateway/src/worker/registry.rs
+++ b/model_gateway/src/worker/registry.rs
@@ -1,15 +1,16 @@
 //! Worker Registry for multi-router support
 //!
-//! Provides centralized registry for workers with model-based indexing
+//! Provides centralized registry for workers with model-based indexing.
 //!
 //! # Performance Optimizations
 //! The model index uses immutable Arc snapshots instead of RwLock for lock-free reads.
 //! This is critical for high-concurrency scenarios where many requests query the same model.
 //!
 //! # Consistent Hash Ring
-//! The registry maintains a pre-computed hash ring per model for O(log n) consistent hashing.
-//! The ring is rebuilt only when workers are added/removed, not per-request.
-//! Uses virtual nodes (150 per worker) for even distribution and blake3 for stable hashing.
+//! The registry maintains a pre-computed [`HashRing`] per model for O(log n)
+//! consistent hashing. The ring is rebuilt only when workers are added or
+//! removed, not per request. See [`crate::worker::hash_ring`] for the ring
+//! itself — this file only wires registry events to ring rebuilds.
 
 use std::{collections::HashSet, sync::Arc};
 
@@ -26,129 +27,11 @@ use crate::{
     worker::{
         circuit_breaker::CircuitState,
         event::WorkerEvent,
+        hash_ring::HashRing,
         worker::{RuntimeType, WorkerType},
         ConnectionMode, Worker,
     },
 };
-
-/// Number of virtual nodes per physical worker for even distribution.
-/// 150 is a common choice that provides good balance between memory and distribution.
-const VIRTUAL_NODES_PER_WORKER: usize = 150;
-
-/// Consistent hash ring for O(log n) worker selection.
-///
-/// Each worker is placed at multiple positions (virtual nodes) on the ring
-/// based on hash(worker_url + vnode_index). This provides:
-/// - Even key distribution across workers
-/// - Minimal key redistribution when workers are added/removed (~1/N keys move)
-/// - O(log n) lookup via binary search
-///
-/// Uses blake3 for stable, fast hashing that's consistent across Rust versions.
-#[derive(Debug, Clone)]
-pub struct HashRing {
-    /// Sorted list of (ring_position, worker_url)
-    /// Multiple entries per worker (virtual nodes) for even distribution.
-    /// Uses Arc<str> to share URL across all virtual nodes (150 refs vs 150 copies).
-    entries: Arc<[(u64, Arc<str>)]>,
-}
-
-impl HashRing {
-    /// Build a hash ring from a list of workers.
-    /// Creates VIRTUAL_NODES_PER_WORKER entries per worker for even distribution.
-    pub fn new(workers: &[Arc<dyn Worker>]) -> Self {
-        let mut entries: Vec<(u64, Arc<str>)> =
-            Vec::with_capacity(workers.len() * VIRTUAL_NODES_PER_WORKER);
-
-        for worker in workers {
-            // Create Arc<str> once per worker, share across all virtual nodes
-            let url: Arc<str> = Arc::from(worker.url());
-
-            // Create multiple virtual nodes per worker
-            for vnode in 0..VIRTUAL_NODES_PER_WORKER {
-                let vnode_key = format!("{url}#{vnode}");
-                let pos = Self::hash_position(&vnode_key);
-                entries.push((pos, Arc::clone(&url)));
-            }
-        }
-
-        // Sort by ring position for binary search
-        entries.sort_unstable_by_key(|(pos, _)| *pos);
-
-        Self {
-            entries: Arc::from(entries.into_boxed_slice()),
-        }
-    }
-
-    /// Hash a string to a ring position using blake3 (stable across versions).
-    #[inline]
-    #[expect(
-        clippy::expect_used,
-        reason = "blake3 always produces 32 bytes — converting a fixed 8-byte slice to [u8; 8] is infallible"
-    )]
-    fn hash_position(s: &str) -> u64 {
-        let hash = blake3::hash(s.as_bytes());
-        // Take first 8 bytes as u64
-        u64::from_le_bytes(
-            hash.as_bytes()[..8]
-                .try_into()
-                .expect("blake3 hash is always 32 bytes, slicing first 8 is infallible"),
-        )
-    }
-
-    /// Find worker URL for a key using consistent hashing.
-    /// Returns the first healthy worker URL at or after the key's position (clockwise).
-    ///
-    /// - `key`: The routing key to hash
-    /// - `is_healthy`: Function to check if a worker URL is healthy
-    pub fn find_healthy_url<F>(&self, key: &str, is_healthy: F) -> Option<&str>
-    where
-        F: Fn(&str) -> bool,
-    {
-        if self.entries.is_empty() {
-            return None;
-        }
-
-        let key_pos = Self::hash_position(key);
-
-        // Binary search to find first entry at or after key_pos
-        let start = self.entries.partition_point(|(pos, _)| *pos < key_pos);
-
-        // Walk clockwise from start, wrapping around
-        // Track visited URLs to avoid checking same worker multiple times (virtual nodes)
-        let mut checked_urls = HashSet::with_capacity(self.worker_count().min(16));
-
-        for i in 0..self.entries.len() {
-            let (_, url) = &self.entries[(start + i) % self.entries.len()];
-            let url_str: &str = url;
-
-            // Skip if we already checked this worker (from another virtual node)
-            if !checked_urls.insert(url_str) {
-                continue;
-            }
-
-            if is_healthy(url_str) {
-                return Some(url_str);
-            }
-        }
-
-        None
-    }
-
-    /// Check if the ring is empty
-    pub fn is_empty(&self) -> bool {
-        self.entries.is_empty()
-    }
-
-    /// Get the number of entries in the ring (including virtual nodes)
-    pub fn len(&self) -> usize {
-        self.entries.len()
-    }
-
-    /// Get the number of unique workers in the ring
-    pub fn worker_count(&self) -> usize {
-        self.entries.len() / VIRTUAL_NODES_PER_WORKER.max(1)
-    }
-}
 
 /// Unique identifier for a worker
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
@@ -1210,7 +1093,7 @@ impl WorkerRegistry {
     /// Rebuild the hash ring for a model based on current workers in the model index.
     fn rebuild_hash_ring(&self, model_id: &str) {
         if let Some(workers) = self.model_index.get(model_id) {
-            let ring = HashRing::new(&workers);
+            let ring = HashRing::new(workers.value().iter().map(|w| w.url()));
             self.hash_rings.insert(model_id.to_string(), Arc::new(ring));
         } else {
             // No workers for this model, remove the ring


### PR DESCRIPTION
## Summary

Finding 5 from `.claude/plans/2026-04-14-worker-module-followup-cleanup.md`. Pulls the 118-line consistent-hash-ring data structure out of the 2134-line `registry.rs` into a focused `worker/hash_ring.rs`, and narrows its public API so the type no longer depends on the `Worker` trait.

This is a pure organizational refactor — zero behavior changes, no hot-path allocation regression, and the new file ships with six direct unit tests that fill a previously-empty test coverage gap for the ring.

## What changed

**New file `model_gateway/src/worker/hash_ring.rs`** (~190 lines incl. tests):
- `VIRTUAL_NODES_PER_WORKER` const
- `HashRing` struct + impl (`new`, `find_healthy_url`, `is_empty`, `len`, `worker_count`, private `hash_position`)
- `#[cfg(test)] mod tests` — six new unit tests: empty ring, length-scales-with-virtual-nodes, deterministic lookup, unhealthy-worker skip, all-unhealthy fallback, owned-String iterator input

**`model_gateway/src/worker/registry.rs`**:
- Delete the 118-line `HashRing` block (struct + impl + const)
- Update the file-header doc comment to reference the new module
- Import `hash_ring::HashRing` from the sibling module
- Update `rebuild_hash_ring` to construct the ring from a URL iterator: `HashRing::new(workers.value().iter().map(|w| w.url()))` instead of `HashRing::new(&workers)`

**`model_gateway/src/worker/mod.rs`**:
- Register `pub mod hash_ring;`
- Split the re-export so downstream callers still write `use crate::worker::HashRing` without touching their imports:
  ```rust
  pub use hash_ring::HashRing;
  pub use registry::WorkerRegistry;
  ```

**Caller updates** (7 test sites total):
- `model_gateway/src/policies/prefix_hash.rs` — 5 test sites
- `model_gateway/src/policies/consistent_hashing.rs` — 2 test sites

All changed from `HashRing::new(&workers)` to `HashRing::new(workers.iter().map(|w| w.url()))`.

## API change: `HashRing::new`

```rust
// Before
pub fn new(workers: &[Arc<dyn Worker>]) -> Self

// After
pub fn new<I>(urls: I) -> Self
where
    I: IntoIterator,
    I::Item: AsRef<str>,
```

Accepts `&[&str]`, `&[String]`, owned `Vec<String>`, or any iterator of string-like items. The rebuild path in `registry.rs` feeds URLs directly from the model index without allocating an intermediate Vec, matching the previous zero-alloc hot path.

## Why

- **Decoupling.** `HashRing`'s only dependency on the `Worker` trait was `worker.url()` in its constructor. Threading the full trait object through the signature coupled a pure consistent-hash data structure to the gateway's worker abstraction. Narrowing the constructor to a URL iterator removes that coupling so `HashRing` could, in a later PR, move to a shared `common/` crate if the gossip/mesh layers ever need the same ring.
- **File weight.** `registry.rs` had grown to 2134 lines mixing the ring implementation with worker-registry wiring, model index management, and the state subscriber. Extracting the ring drops `registry.rs` by ~115 net lines and gives reviewers a focused 190-line file to touch when tuning the ring.
- **Test coverage.** The inline test module on `hash_ring.rs` fills a real coverage gap — the ring previously had zero direct tests (the policy tests exercised it transitively, but a broken ring would surface in policy-level assertions, not as a localized failure).

## Test plan

- [x] `cargo check -p smg` — clean.
- [x] `cargo clippy -p smg --all-targets -- -D warnings` — clean.
- [x] `cargo clippy -p smg-golang --all-targets -- -D warnings` — clean.
- [x] `cargo check -p smg-python` — clean.
- [x] `cargo test -p smg --lib` — **544 passed; 0 failed; 4 ignored** (+6 new HashRing unit tests compared to main's 538).

Refs: Finding 5 in `.claude/plans/2026-04-14-worker-module-followup-cleanup.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Moved and reorganized the consistent hashing implementation into a dedicated internal module to improve maintainability and reliability of worker selection.
* **Tests**
  * Updated test setups to align with the new hashing interface, preserving existing routing and health-check behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->