### PR TITLE
feat(protocols): add serde(flatten) to ChatCompletionRequest for engine-specific fields

### DIFF
--- a/crates/protocols/src/chat.rs
+++ b/crates/protocols/src/chat.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde_json::{Map, Value};
 use validator::Validate;
 
 use super::{
@@ -316,6 +316,10 @@ pub struct ChatCompletionRequest {
 
     /// Random seed for sampling for deterministic outputs
     pub sampling_seed: Option<u64>,
+
+    /// Additional fields not explicitly defined above (e.g. engine-specific parameters)
+    #[serde(flatten)]
+    pub other: Map<String, Value>,
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Adds `#[serde(flatten)]` catch-all to `ChatCompletionRequest` so unknown engine-specific JSON properties (e.g. sglang's `return_routed_experts` for MoE routing replay) are preserved during deserialization and forwarded to backend workers rather than silently dropped.

`CompletionRequest` already has this flatten catch-all via its `other` field. This change makes `ChatCompletionRequest` consistent with that pattern.

Fixes #22740 (upstream SGLang issue).

## Note

This replaces #1119, which had a non-conforming branch name. All CI checks (DCO, conventional commit title, unit/integration/e2e tests) passed on the prior PR except for unrelated flaky MCP tool-calling tests.