### PR TITLE
ci: move branch naming check from Mergify to GitHub Actions

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,33 +1,4 @@
-# post_check rule 'Enforce branch naming convention (internal)' was removed without replacement (no success_conditions or neutral_conditions to migrate)
 pull_request_rules:
-  - name: Enforce branch naming convention (internal)
-    description: Auto-close PRs from internal branches that don't follow naming convention
-    conditions:
-      - -head~=^[a-z0-9]([a-z0-9._-]*[a-z0-9])?(/[a-z0-9._-]+)+$
-      - head != main
-      - head-repo-full-name = lightseekorg/smg
-    actions:
-      comment:
-        message: |
-          Hi @{{author}}, the branch `{{head}}` does not follow our naming convention.
-
-          Please use one of the following formats:
-          - `<type>/<description>` — e.g. `feat/add-auth`, `fix/null-pointer`, `dependabot/cargo/pyo3-0.28.1`
-          - `<username>/<description>` — e.g. `changsu/fix-routing`
-
-          Allowed types: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `ci`, `perf`
-
-          > **Note:** PRs with non-conforming branch names **will be auto-closed**. Please follow the naming convention for all branches.
-      close:
-        message: |
-          Closing this PR because the branch name `{{head}}` does not follow the naming convention.
-
-          To fix this, please rename your branch locally, push the new branch, and open a new PR:
-          ```bash
-          git branch -m <new-branch-name>
-          git push origin -u <new-branch-name>
-          ```
-
   - name: Comment on DCO check failure
     description: Post fix instructions when DCO sign-off is missing
     conditions:

--- a/.github/workflows/pr-naming-check.yml
+++ b/.github/workflows/pr-naming-check.yml
@@ -9,6 +9,52 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  branch-naming:
+    name: Branch Naming Convention
+    runs-on: ubuntu-latest
+    # Only enforce on internal PRs, not forks
+    if: github.event.pull_request.head.repo.full_name == 'lightseekorg/smg' && github.head_ref != 'main'
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Validate branch name
+        env:
+          BRANCH: ${{ github.head_ref }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          REGEX='^[a-z0-9]([a-z0-9._-]*[a-z0-9])?(/[a-z0-9._-]+)+$'
+
+          if [[ "$BRANCH" =~ $REGEX ]]; then
+            echo "✅ Branch name is valid: '$BRANCH'"
+            exit 0
+          fi
+
+          # Post comment and close the PR
+          gh pr comment "$PR_NUMBER" \
+            --repo "${{ github.repository }}" \
+            --body "Hi @${PR_AUTHOR}, the branch \`${BRANCH}\` does not follow our naming convention.
+
+          Please use one of the following formats:
+          - \`<type>/<description>\` — e.g. \`feat/add-auth\`, \`fix/null-pointer\`, \`dependabot/cargo/pyo3-0.28.1\`
+          - \`<username>/<description>\` — e.g. \`changsu/fix-routing\`
+
+          Allowed types: \`feat\`, \`fix\`, \`chore\`, \`docs\`, \`refactor\`, \`test\`, \`ci\`, \`perf\`
+
+          To fix, rename your branch locally, push the new branch, and open a new PR:
+          \`\`\`bash
+          git branch -m <new-branch-name>
+          git push origin -u <new-branch-name>
+          \`\`\`"
+
+          gh pr close "$PR_NUMBER" \
+            --repo "${{ github.repository }}" \
+            --comment "Closing this PR because the branch name \`${BRANCH}\` does not follow the naming convention."
+
+          exit 1
+
   pr-validation:
     name: PR Title & Commit Messages
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

### Problem

Mergify's `pull_request_rules` creates a `post_check` status check on fork PRs even when the `head-repo-full-name = lightseekorg/smg` condition should exclude them. This produces noisy failing checks ("`Rule: Enforce branch naming convention (internal) (post_check)`") on external contributions.

Verified across 20 fork PRs — 3 had the spurious check (#1115, #1088, #1082), all with branch names that don't contain a `/`. The `details_url` on these checks points to the fork PR itself, confirming Mergify is directly evaluating the rule on forks (not SHA collision from another PR).

The `head-repo-full-name` condition correctly prevents the *actions* (close/comment) from firing on forks, but does **not** prevent the `post_check` from being created. This is Mergify's internal behavior and cannot be configured.

Additionally, the previously working `merge_protections` block (which used `if` guards to properly gate check creation) was removed by auto-generated PR #906 — Mergify's bot keeps opening PRs to "upgrade" the config and remove `merge_protections`, making it unsustainable to maintain.

### Solution

- **Remove** the branch naming `pull_request_rules` entry from Mergify (eliminates `post_check` noise entirely)
- **Add** a `branch-naming` job to the existing `pr-naming-check.yml` GitHub Actions workflow
- The GHA job uses `if: github.event.pull_request.head.repo.full_name == 'lightseekorg/smg'` — completely invisible to fork PRs (no skipped check, no noise)
- On failure, the job posts a comment explaining the naming convention and **auto-closes** the PR (matching previous Mergify behavior)

## Changes

- `.github/mergify.yml` — removed `Enforce branch naming convention (internal)` rule and stale auto-generated comment
- `.github/workflows/pr-naming-check.yml` — added `branch-naming` job with validation, comment, and auto-close

## Test Plan

1. **Internal PR with good branch name** (e.g. `feat/something`): `branch-naming` job should pass
2. **Internal PR with bad branch name** (e.g. `something`): job should fail, post comment, and auto-close the PR
3. **Fork PR** (any branch name): `branch-naming` job should not appear at all in checks — no "Skipped", no noise
4. Verify existing `pr-validation` job (PR title + commit message checks) still works unchanged

To test, push a branch with a bad name from the internal repo:
```bash
git checkout -b test-bad-branch-name origin/main
git commit --allow-empty -s -m "test: verify branch naming auto-close"
git push -u origin test-bad-branch-name
# open PR, observe it gets commented on and closed
# then delete the branch
git push origin --delete test-bad-branch-name
```

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes (no Rust changes)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (no Rust changes)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Migrated branch naming convention enforcement from Mergify to GitHub Actions for improved validation workflow consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->