### PR TITLE
feat(grpc_servicer): implement GetTokenizer RPC for SGLang backend

### DIFF
--- a/grpc_servicer/smg_grpc_servicer/sglang/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/sglang/servicer.py
@@ -602,23 +602,23 @@ class SGLangSchedulerServicer(sglang_scheduler_pb2_grpc.SglangSchedulerServicer)
             logger.error(f"Failed to build tokenizer ZIP: {e}\n{get_exception_traceback()}")
             await context.abort(grpc.StatusCode.INTERNAL, str(e))
 
-        zip_bytes = zip_buffer.getvalue()
-        sha256 = hashlib.sha256(zip_bytes).hexdigest()
+        zip_data = zip_buffer.getbuffer()
+        sha256 = hashlib.sha256(zip_data).hexdigest()
 
         logger.info(
             "Streaming tokenizer bundle: %d bytes, sha256=%s",
-            len(zip_bytes),
+            len(zip_data),
             sha256,
         )
 
         # Stream chunks; SHA-256 only on the final chunk
         offset = 0
-        total = len(zip_bytes)
+        total = len(zip_data)
         while offset < total:
             end = min(offset + _TOKENIZER_CHUNK_SIZE, total)
             is_last = end == total
             yield common_pb2.GetTokenizerChunk(
-                data=zip_bytes[offset:end],
+                data=bytes(zip_data[offset:end]),
                 sha256=sha256 if is_last else "",
             )
             offset = end

--- a/grpc_servicer/smg_grpc_servicer/sglang/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/sglang/servicer.py
@@ -628,29 +628,17 @@ class SGLangSchedulerServicer(sglang_scheduler_pb2_grpc.SglangSchedulerServicer)
         """Create an in-memory ZIP archive of tokenizer files from a directory."""
         buf = io.BytesIO()
         added: set[str] = set()
-        root = tokenizer_dir.resolve()
-
-        def _is_safe_file(path: Path) -> bool:
-            """Check file exists, is not a symlink, and resolves within root."""
-            if not path.is_file() or path.is_symlink():
-                return False
-            try:
-                path.resolve().relative_to(root)
-                return True
-            except ValueError:
-                return False
-
         with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
             # Exact-name files
             for name in _TOKENIZER_FILES:
                 filepath = tokenizer_dir / name
-                if _is_safe_file(filepath):
+                if filepath.is_file():
                     zf.write(filepath, name)
                     added.add(name)
             # Glob patterns (*.tiktoken, *.jinja, *.model)
             for pattern in _TOKENIZER_GLOBS:
                 for match in tokenizer_dir.glob(pattern):
-                    if match.name not in added and _is_safe_file(match):
+                    if match.is_file() and match.name not in added:
                         zf.write(match, match.name)
                         added.add(match.name)
         if not added:

--- a/grpc_servicer/smg_grpc_servicer/sglang/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/sglang/servicer.py
@@ -586,20 +586,21 @@ class SGLangSchedulerServicer(sglang_scheduler_pb2_grpc.SglangSchedulerServicer)
         """
         logger.info("Receive GetTokenizer request")
 
-        # server_args.tokenizer_path is guaranteed to be a resolved local path
-        # by ServerArgs.check_server_args() → _resolve_or_download().
-        tokenizer_dir = Path(self.server_args.tokenizer_path)
+        tokenizer_path = self.server_args.tokenizer_path
+        if not tokenizer_path:
+            await context.abort(
+                grpc.StatusCode.FAILED_PRECONDITION,
+                "Tokenizer path is not configured on this server.",
+            )
+            return
+        tokenizer_dir = Path(tokenizer_path)
 
         # Build ZIP archive in memory
         try:
             zip_buffer = self._build_tokenizer_zip(tokenizer_dir)
         except Exception as e:
-            logger.error(f"Failed to build tokenizer ZIP: {e}")
-            await context.abort(
-                grpc.StatusCode.INTERNAL,
-                f"Failed to build tokenizer archive: {e}",
-            )
-            return
+            logger.error(f"Failed to build tokenizer ZIP: {e}\n{get_exception_traceback()}")
+            await context.abort(grpc.StatusCode.INTERNAL, str(e))
 
         zip_bytes = zip_buffer.getvalue()
         sha256 = hashlib.sha256(zip_bytes).hexdigest()
@@ -627,17 +628,29 @@ class SGLangSchedulerServicer(sglang_scheduler_pb2_grpc.SglangSchedulerServicer)
         """Create an in-memory ZIP archive of tokenizer files from a directory."""
         buf = io.BytesIO()
         added: set[str] = set()
+        root = tokenizer_dir.resolve()
+
+        def _is_safe_file(path: Path) -> bool:
+            """Check file exists, is not a symlink, and resolves within root."""
+            if not path.is_file() or path.is_symlink():
+                return False
+            try:
+                path.resolve().relative_to(root)
+                return True
+            except ValueError:
+                return False
+
         with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
             # Exact-name files
             for name in _TOKENIZER_FILES:
                 filepath = tokenizer_dir / name
-                if filepath.is_file():
+                if _is_safe_file(filepath):
                     zf.write(filepath, name)
                     added.add(name)
             # Glob patterns (*.tiktoken, *.jinja, *.model)
             for pattern in _TOKENIZER_GLOBS:
                 for match in tokenizer_dir.glob(pattern):
-                    if match.is_file() and match.name not in added:
+                    if match.name not in added and _is_safe_file(match):
                         zf.write(match, match.name)
                         added.add(match.name)
         if not added:

--- a/grpc_servicer/smg_grpc_servicer/sglang/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/sglang/servicer.py
@@ -7,11 +7,15 @@ for orchestration without tokenization.
 
 import asyncio
 import dataclasses
+import hashlib
+import io
 import logging
 import os
 import time
+import zipfile
 from collections.abc import AsyncIterator
 from datetime import datetime, timezone
+from pathlib import Path
 
 import grpc
 import msgspec
@@ -54,6 +58,25 @@ from smg_grpc_servicer.sglang.utils import abort_code_from_output
 
 logger = logging.getLogger(__name__)
 HEALTH_CHECK_TIMEOUT = int(os.getenv("SGLANG_HEALTH_CHECK_TIMEOUT", 20))
+
+# Tokenizer bundle streaming constants (aligned with Rust grpc_client limits)
+_TOKENIZER_CHUNK_SIZE = 64 * 1024  # 64 KB per gRPC chunk
+# Files to include in the tokenizer ZIP bundle.
+# Aligned with crates/tokenizer/src/hub.rs:is_tokenizer_file() plus model config files.
+_TOKENIZER_FILES = [
+    "tokenizer.json",
+    "tokenizer_config.json",
+    "config.json",
+    "generation_config.json",
+    "special_tokens_map.json",
+    "vocab.json",
+    "merges.txt",
+    "tokenizer.model",  # SentencePiece
+    "tiktoken.model",  # tiktoken
+    "chat_template.json",
+]
+# Glob patterns for additional tokenizer-related files
+_TOKENIZER_GLOBS = ["*.tiktoken", "*.jinja", "*.model"]
 
 
 def _convert_loads_to_protobuf(
@@ -549,6 +572,77 @@ class SGLangSchedulerServicer(sglang_scheduler_pb2_grpc.SglangSchedulerServicer)
             loads=loads,
             aggregate=_compute_aggregate_protobuf(loads),
         )
+
+    async def GetTokenizer(
+        self,
+        request: common_pb2.GetTokenizerRequest,
+        context: grpc.aio.ServicerContext,
+    ) -> AsyncIterator[common_pb2.GetTokenizerChunk]:
+        """Stream tokenizer artifacts as a ZIP bundle.
+
+        Resolves the tokenizer directory from server_args, zips all relevant
+        tokenizer files, and streams them as GetTokenizerChunk messages.
+        The final chunk carries the SHA-256 fingerprint of the full archive.
+        """
+        logger.info("Receive GetTokenizer request")
+
+        # server_args.tokenizer_path is guaranteed to be a resolved local path
+        # by ServerArgs.check_server_args() → _resolve_or_download().
+        tokenizer_dir = Path(self.server_args.tokenizer_path)
+
+        # Build ZIP archive in memory
+        try:
+            zip_buffer = self._build_tokenizer_zip(tokenizer_dir)
+        except Exception as e:
+            logger.error(f"Failed to build tokenizer ZIP: {e}")
+            await context.abort(
+                grpc.StatusCode.INTERNAL,
+                f"Failed to build tokenizer archive: {e}",
+            )
+            return
+
+        zip_bytes = zip_buffer.getvalue()
+        sha256 = hashlib.sha256(zip_bytes).hexdigest()
+
+        logger.info(
+            "Streaming tokenizer bundle: %d bytes, sha256=%s",
+            len(zip_bytes),
+            sha256,
+        )
+
+        # Stream chunks; SHA-256 only on the final chunk
+        offset = 0
+        total = len(zip_bytes)
+        while offset < total:
+            end = min(offset + _TOKENIZER_CHUNK_SIZE, total)
+            is_last = end == total
+            yield common_pb2.GetTokenizerChunk(
+                data=zip_bytes[offset:end],
+                sha256=sha256 if is_last else "",
+            )
+            offset = end
+
+    @staticmethod
+    def _build_tokenizer_zip(tokenizer_dir: Path) -> io.BytesIO:
+        """Create an in-memory ZIP archive of tokenizer files from a directory."""
+        buf = io.BytesIO()
+        added: set[str] = set()
+        with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+            # Exact-name files
+            for name in _TOKENIZER_FILES:
+                filepath = tokenizer_dir / name
+                if filepath.is_file():
+                    zf.write(filepath, name)
+                    added.add(name)
+            # Glob patterns (*.tiktoken, *.jinja, *.model)
+            for pattern in _TOKENIZER_GLOBS:
+                for match in tokenizer_dir.glob(pattern):
+                    if match.is_file() and match.name not in added:
+                        zf.write(match, match.name)
+                        added.add(match.name)
+        if not added:
+            raise FileNotFoundError(f"No tokenizer files found in {tokenizer_dir}")
+        return buf
 
     async def SubscribeKvEvents(
         self,

--- a/grpc_servicer/smg_grpc_servicer/sglang/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/sglang/servicer.py
@@ -592,7 +592,6 @@ class SGLangSchedulerServicer(sglang_scheduler_pb2_grpc.SglangSchedulerServicer)
                 grpc.StatusCode.FAILED_PRECONDITION,
                 "Tokenizer path is not configured on this server.",
             )
-            return
         tokenizer_dir = Path(tokenizer_path)
 
         # Build ZIP archive in memory


### PR DESCRIPTION
## Description

### Problem

The SGLang gRPC servicer does not implement the `GetTokenizer` RPC, causing the gateway to receive `UNIMPLEMENTED` when it attempts to fetch tokenizer artifacts from a worker. In IGW/K8s deployments where the gateway runs on a separate node from the workers and has no local access to model files, the gateway cannot load the tokenizer at all.

### Solution

Implement the server-side `GetTokenizer` handler in the SGLang gRPC servicer. The handler:
1. Reads tokenizer files from `server_args.tokenizer_path` (already resolved by SGLang's `ServerArgs`)
2. Creates an in-memory ZIP archive containing tokenizer files (aligned with `crates/tokenizer/src/hub.rs:is_tokenizer_file()`)
3. Streams the archive as 64KB `GetTokenizerChunk` messages with SHA-256 fingerprint on the final chunk

## Changes

- Added `GetTokenizer` async generator method to `SGLangSchedulerServicer`
- Added `_build_tokenizer_zip` static method for ZIP archive creation
- Added `_TOKENIZER_FILES` allowlist and `_TOKENIZER_GLOBS` patterns for file selection
- Added imports: `hashlib`, `io`, `zipfile`, `Path`

## Test Plan

### Setup

```bash
# Start SGLang gRPC server
python3 -m sglang.launch_server \
  --model <model_path> \
  --port=8080 --tensor-parallel-size 1 --grpc-mode
```

### Test script

```python
import grpc, hashlib, io, json, zipfile
from pathlib import Path
from smg_grpc_proto import sglang_scheduler_pb2_grpc
from smg_grpc_proto.generated import common_pb2

MODEL_DIR = Path("<model_path>")

channel = grpc.insecure_channel("localhost:8080")
stub = sglang_scheduler_pb2_grpc.SglangSchedulerStub(channel)

chunks = list(stub.GetTokenizer(common_pb2.GetTokenizerRequest()))
data = b"".join(c.data for c in chunks)
sha256 = chunks[-1].sha256

# Verify SHA-256
computed = hashlib.sha256(data).hexdigest()
print(f"Got {len(data)} bytes in {len(chunks)} chunks")
print(f"Received SHA-256:  {sha256}")
print(f"Computed SHA-256:  {computed}")
print(f"Match: {computed == sha256}")

# Verify ZIP and compare against source directory
zf = zipfile.ZipFile(io.BytesIO(data))
print(f"\nArchive contains {len(zf.infolist())} files:")
all_match = True
for info in zf.infolist():
    source_file = MODEL_DIR / info.filename
    bundle_bytes = zf.read(info.filename)
    if source_file.exists():
        match = bundle_bytes == source_file.read_bytes()
        status = "OK" if match else "MISMATCH"
        if not match: all_match = False
    else:
        status = "NOT ON DISK"
        all_match = False
    print(f"  {info.filename}  ({info.file_size:,} bytes) — {status}")
print(f"\nAll files match source: {all_match}")

if "tokenizer.json" in zf.namelist():
    tok = json.loads(zf.read("tokenizer.json"))
    print(f"tokenizer.json OK, vocab size: {len(tok.get('model', {}).get('vocab', {}))}")
```

### Test 1: Llama-3.2-1B-Instruct

```
SGLang server logs:
[2026-04-14 19:16:03] Receive GetTokenizer request
[2026-04-14 19:16:03] Streaming tokenizer bundle: 2335038 bytes, sha256=74e6c5d5ee7a3f940366d9c589be986f1ff8955cbaafdd062602586d6666adb0

Test output:
Got 2335038 bytes in 36 chunks
Received SHA-256:  74e6c5d5ee7a3f940366d9c589be986f1ff8955cbaafdd062602586d6666adb0
Computed SHA-256:  74e6c5d5ee7a3f940366d9c589be986f1ff8955cbaafdd062602586d6666adb0
Match: True

Archive contains 5 files:
  tokenizer.json  (9,085,657 bytes) — OK
  tokenizer_config.json  (54,528 bytes) — OK
  config.json  (877 bytes) — OK
  generation_config.json  (189 bytes) — OK
  special_tokens_map.json  (296 bytes) — OK

All files match source: True
tokenizer.json OK, vocab size: 128000
```

### Test 2: Qwen3-30B-A3B-Instruct-2507

```
Got 3940000 bytes in 61 chunks
Received SHA-256:  6551d0201d21cf80c27103742fe0554b453bf4b09499c1642489de6ecfdafe75
Computed SHA-256:  6551d0201d21cf80c27103742fe0554b453bf4b09499c1642489de6ecfdafe75
Match: True

Archive contains 6 files:
  tokenizer.json  (11,422,654 bytes) — OK
  tokenizer_config.json  (9,377 bytes) — OK
  config.json  (963 bytes) — OK
  generation_config.json  (239 bytes) — OK
  vocab.json  (2,776,833 bytes) — OK
  merges.txt  (1,671,839 bytes) — OK

All files match source: True
tokenizer.json OK, vocab size: 151643
```

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] (Optional) Documentation updated

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a gRPC streaming endpoint to retrieve tokenizer artifacts as a compressed archive.
  * Tokenizer files are packaged and transmitted in fixed-size chunks for efficient delivery.
  * A SHA-256 checksum is provided to validate integrity after transfer.
  * Requests fail with a clear error if tokenizer artifacts are not configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->