### PR TITLE
feat(grpc_servicer): implement GetTokenizer RPC for vLLM backend

### DIFF
--- a/grpc_servicer/smg_grpc_servicer/sglang/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/sglang/servicer.py
@@ -8,11 +8,9 @@ for orchestration without tokenization.
 import asyncio
 import dataclasses
 import hashlib
-import io
 import logging
 import os
 import time
-import zipfile
 from collections.abc import AsyncIterator
 from datetime import datetime, timezone
 from pathlib import Path
@@ -55,28 +53,10 @@ from smg_grpc_proto.generated import common_pb2
 from smg_grpc_servicer.sglang.health_servicer import SGLangHealthServicer
 from smg_grpc_servicer.sglang.request_manager import GrpcRequestManager
 from smg_grpc_servicer.sglang.utils import abort_code_from_output
+from smg_grpc_servicer.tokenizer_bundle import CHUNK_SIZE, build_tokenizer_zip
 
 logger = logging.getLogger(__name__)
 HEALTH_CHECK_TIMEOUT = int(os.getenv("SGLANG_HEALTH_CHECK_TIMEOUT", 20))
-
-# Tokenizer bundle streaming constants (aligned with Rust grpc_client limits)
-_TOKENIZER_CHUNK_SIZE = 64 * 1024  # 64 KB per gRPC chunk
-# Files to include in the tokenizer ZIP bundle.
-# Aligned with crates/tokenizer/src/hub.rs:is_tokenizer_file() plus model config files.
-_TOKENIZER_FILES = [
-    "tokenizer.json",
-    "tokenizer_config.json",
-    "config.json",
-    "generation_config.json",
-    "special_tokens_map.json",
-    "vocab.json",
-    "merges.txt",
-    "tokenizer.model",  # SentencePiece
-    "tiktoken.model",  # tiktoken
-    "chat_template.json",
-]
-# Glob patterns for additional tokenizer-related files
-_TOKENIZER_GLOBS = ["*.tiktoken", "*.jinja", "*.model"]
 
 
 def _convert_loads_to_protobuf(
@@ -596,7 +576,7 @@ class SGLangSchedulerServicer(sglang_scheduler_pb2_grpc.SglangSchedulerServicer)
 
         # Build ZIP archive in memory
         try:
-            zip_buffer = self._build_tokenizer_zip(tokenizer_dir)
+            zip_buffer = build_tokenizer_zip(tokenizer_dir)
         except Exception as e:
             logger.error(f"Failed to build tokenizer ZIP: {e}\n{get_exception_traceback()}")
             await context.abort(grpc.StatusCode.INTERNAL, str(e))
@@ -614,35 +594,13 @@ class SGLangSchedulerServicer(sglang_scheduler_pb2_grpc.SglangSchedulerServicer)
         offset = 0
         total = len(zip_data)
         while offset < total:
-            end = min(offset + _TOKENIZER_CHUNK_SIZE, total)
+            end = min(offset + CHUNK_SIZE, total)
             is_last = end == total
             yield common_pb2.GetTokenizerChunk(
                 data=bytes(zip_data[offset:end]),
                 sha256=sha256 if is_last else "",
             )
             offset = end
-
-    @staticmethod
-    def _build_tokenizer_zip(tokenizer_dir: Path) -> io.BytesIO:
-        """Create an in-memory ZIP archive of tokenizer files from a directory."""
-        buf = io.BytesIO()
-        added: set[str] = set()
-        with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
-            # Exact-name files
-            for name in _TOKENIZER_FILES:
-                filepath = tokenizer_dir / name
-                if filepath.is_file():
-                    zf.write(filepath, name)
-                    added.add(name)
-            # Glob patterns (*.tiktoken, *.jinja, *.model)
-            for pattern in _TOKENIZER_GLOBS:
-                for match in tokenizer_dir.glob(pattern):
-                    if match.is_file() and match.name not in added:
-                        zf.write(match, match.name)
-                        added.add(match.name)
-        if not added:
-            raise FileNotFoundError(f"No tokenizer files found in {tokenizer_dir}")
-        return buf
 
     async def SubscribeKvEvents(
         self,

--- a/grpc_servicer/smg_grpc_servicer/tokenizer_bundle.py
+++ b/grpc_servicer/smg_grpc_servicer/tokenizer_bundle.py
@@ -50,4 +50,5 @@ def build_tokenizer_zip(tokenizer_dir: Path) -> io.BytesIO:
                     added.add(match.name)
     if not added:
         raise FileNotFoundError(f"No tokenizer files found in {tokenizer_dir}")
+    buf.seek(0)
     return buf

--- a/grpc_servicer/smg_grpc_servicer/tokenizer_bundle.py
+++ b/grpc_servicer/smg_grpc_servicer/tokenizer_bundle.py
@@ -1,0 +1,53 @@
+"""
+Shared tokenizer bundle utilities for gRPC servicers.
+
+Builds and streams tokenizer artifacts as ZIP bundles over gRPC.
+Used by both SGLang and vLLM servicers.
+"""
+
+import io
+import zipfile
+from pathlib import Path
+
+# Streaming chunk size (aligned with Rust grpc_client limits)
+CHUNK_SIZE = 64 * 1024  # 64 KB per gRPC chunk
+
+# Files to include in the tokenizer ZIP bundle.
+# Aligned with crates/tokenizer/src/hub.rs:is_tokenizer_file() plus model config files.
+TOKENIZER_FILES = [
+    "tokenizer.json",
+    "tokenizer_config.json",
+    "config.json",
+    "generation_config.json",
+    "special_tokens_map.json",
+    "vocab.json",
+    "merges.txt",
+    "tokenizer.model",  # SentencePiece
+    "tiktoken.model",  # tiktoken
+    "chat_template.json",
+]
+
+# Glob patterns for additional tokenizer-related files
+TOKENIZER_GLOBS = ["*.tiktoken", "*.jinja", "*.model"]
+
+
+def build_tokenizer_zip(tokenizer_dir: Path) -> io.BytesIO:
+    """Create an in-memory ZIP archive of tokenizer files from a directory."""
+    buf = io.BytesIO()
+    added: set[str] = set()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        # Exact-name files
+        for name in TOKENIZER_FILES:
+            filepath = tokenizer_dir / name
+            if filepath.is_file():
+                zf.write(filepath, name)
+                added.add(name)
+        # Glob patterns (*.tiktoken, *.jinja, *.model)
+        for pattern in TOKENIZER_GLOBS:
+            for match in tokenizer_dir.glob(pattern):
+                if match.is_file() and match.name not in added:
+                    zf.write(match, match.name)
+                    added.add(match.name)
+    if not added:
+        raise FileNotFoundError(f"No tokenizer files found in {tokenizer_dir}")
+    return buf

--- a/grpc_servicer/smg_grpc_servicer/vllm/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/vllm/servicer.py
@@ -6,10 +6,8 @@ Implements the VllmEngine gRPC service on top of vLLM's EngineClient.
 """
 
 import hashlib
-import io
 import itertools
 import time
-import zipfile
 from collections.abc import AsyncGenerator, AsyncIterator
 from pathlib import Path
 
@@ -32,26 +30,9 @@ from vllm.multimodal.inputs import (
 from vllm.outputs import CompletionOutput, RequestOutput
 from vllm.sampling_params import RequestOutputKind, StructuredOutputsParams
 
-logger = init_logger(__name__)
+from smg_grpc_servicer.tokenizer_bundle import CHUNK_SIZE, build_tokenizer_zip
 
-# Tokenizer bundle streaming constants (aligned with Rust grpc_client limits)
-_TOKENIZER_CHUNK_SIZE = 64 * 1024  # 64 KB per gRPC chunk
-# Files to include in the tokenizer ZIP bundle.
-# Aligned with crates/tokenizer/src/hub.rs:is_tokenizer_file() plus model config files.
-_TOKENIZER_FILES = [
-    "tokenizer.json",
-    "tokenizer_config.json",
-    "config.json",
-    "generation_config.json",
-    "special_tokens_map.json",
-    "vocab.json",
-    "merges.txt",
-    "tokenizer.model",  # SentencePiece
-    "tiktoken.model",  # tiktoken
-    "chat_template.json",
-]
-# Glob patterns for additional tokenizer-related files
-_TOKENIZER_GLOBS = ["*.tiktoken", "*.jinja", "*.model"]
+logger = init_logger(__name__)
 
 # Proto dtype string → torch dtype
 _PROTO_DTYPE_MAP: dict[str, torch.dtype] = {
@@ -406,7 +387,7 @@ class VllmEngineServicer(vllm_engine_pb2_grpc.VllmEngineServicer):
 
         # Build ZIP archive in memory
         try:
-            zip_buffer = self._build_tokenizer_zip(tokenizer_dir)
+            zip_buffer = build_tokenizer_zip(tokenizer_dir)
         except Exception as e:
             logger.exception("Failed to build tokenizer ZIP")
             await context.abort(grpc.StatusCode.INTERNAL, str(e))
@@ -424,35 +405,13 @@ class VllmEngineServicer(vllm_engine_pb2_grpc.VllmEngineServicer):
         offset = 0
         total = len(zip_data)
         while offset < total:
-            end = min(offset + _TOKENIZER_CHUNK_SIZE, total)
+            end = min(offset + CHUNK_SIZE, total)
             is_last = end == total
             yield common_pb2.GetTokenizerChunk(
                 data=bytes(zip_data[offset:end]),
                 sha256=sha256 if is_last else "",
             )
             offset = end
-
-    @staticmethod
-    def _build_tokenizer_zip(tokenizer_dir: Path) -> io.BytesIO:
-        """Create an in-memory ZIP archive of tokenizer files from a directory."""
-        buf = io.BytesIO()
-        added: set[str] = set()
-        with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
-            # Exact-name files
-            for name in _TOKENIZER_FILES:
-                filepath = tokenizer_dir / name
-                if filepath.is_file():
-                    zf.write(filepath, name)
-                    added.add(name)
-            # Glob patterns (*.tiktoken, *.jinja, *.model)
-            for pattern in _TOKENIZER_GLOBS:
-                for match in tokenizer_dir.glob(pattern):
-                    if match.is_file() and match.name not in added:
-                        zf.write(match, match.name)
-                        added.add(match.name)
-        if not added:
-            raise FileNotFoundError(f"No tokenizer files found in {tokenizer_dir}")
-        return buf
 
     # ========== Helper methods ==========
 

--- a/grpc_servicer/smg_grpc_servicer/vllm/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/vllm/servicer.py
@@ -5,13 +5,18 @@ vLLM gRPC Servicer
 Implements the VllmEngine gRPC service on top of vLLM's EngineClient.
 """
 
+import hashlib
+import io
 import itertools
 import time
-from collections.abc import AsyncGenerator
+import zipfile
+from collections.abc import AsyncGenerator, AsyncIterator
+from pathlib import Path
 
 import grpc
 import torch
 from smg_grpc_proto import vllm_engine_pb2, vllm_engine_pb2_grpc
+from smg_grpc_proto.generated import common_pb2
 from transformers import BatchFeature
 from vllm import PoolingParams, SamplingParams, TokensPrompt
 from vllm.engine.protocol import EngineClient
@@ -28,6 +33,25 @@ from vllm.outputs import CompletionOutput, RequestOutput
 from vllm.sampling_params import RequestOutputKind, StructuredOutputsParams
 
 logger = init_logger(__name__)
+
+# Tokenizer bundle streaming constants (aligned with Rust grpc_client limits)
+_TOKENIZER_CHUNK_SIZE = 64 * 1024  # 64 KB per gRPC chunk
+# Files to include in the tokenizer ZIP bundle.
+# Aligned with crates/tokenizer/src/hub.rs:is_tokenizer_file() plus model config files.
+_TOKENIZER_FILES = [
+    "tokenizer.json",
+    "tokenizer_config.json",
+    "config.json",
+    "generation_config.json",
+    "special_tokens_map.json",
+    "vocab.json",
+    "merges.txt",
+    "tokenizer.model",  # SentencePiece
+    "tiktoken.model",  # tiktoken
+    "chat_template.json",
+]
+# Glob patterns for additional tokenizer-related files
+_TOKENIZER_GLOBS = ["*.tiktoken", "*.jinja", "*.model"]
 
 # Proto dtype string → torch dtype
 _PROTO_DTYPE_MAP: dict[str, torch.dtype] = {
@@ -49,13 +73,14 @@ class VllmEngineServicer(vllm_engine_pb2_grpc.VllmEngineServicer):
     """
     gRPC servicer implementing the VllmEngine service.
 
-    Handles 6 RPCs:
+    Handles 7 RPCs:
     - Generate: Streaming text generation
     - Embed: Embeddings
     - HealthCheck: Health probe
     - Abort: Cancel requests out-of-band
     - GetModelInfo: Model metadata
     - GetServerInfo: Server state
+    - GetTokenizer: Stream tokenizer artifacts
     """
 
     def __init__(self, async_llm: EngineClient, start_time: float):
@@ -357,6 +382,77 @@ class VllmEngineServicer(vllm_engine_pb2_grpc.VllmEngineServicer):
             kv_connector=kv_connector,
             kv_role=kv_role,
         )
+
+    async def GetTokenizer(
+        self,
+        request: common_pb2.GetTokenizerRequest,
+        context: grpc.aio.ServicerContext,
+    ) -> AsyncIterator[common_pb2.GetTokenizerChunk]:
+        """Stream tokenizer artifacts as a ZIP bundle.
+
+        Resolves the tokenizer directory from model_config, zips all relevant
+        tokenizer files, and streams them as GetTokenizerChunk messages.
+        The final chunk carries the SHA-256 fingerprint of the full archive.
+        """
+        logger.info("Receive GetTokenizer request")
+
+        tokenizer_path = self.engine.model_config.tokenizer
+        if not tokenizer_path:
+            await context.abort(
+                grpc.StatusCode.FAILED_PRECONDITION,
+                "Tokenizer path is not configured on this server.",
+            )
+        tokenizer_dir = Path(tokenizer_path)
+
+        # Build ZIP archive in memory
+        try:
+            zip_buffer = self._build_tokenizer_zip(tokenizer_dir)
+        except Exception as e:
+            logger.exception("Failed to build tokenizer ZIP")
+            await context.abort(grpc.StatusCode.INTERNAL, str(e))
+
+        zip_data = zip_buffer.getbuffer()
+        sha256 = hashlib.sha256(zip_data).hexdigest()
+
+        logger.info(
+            "Streaming tokenizer bundle: %d bytes, sha256=%s",
+            len(zip_data),
+            sha256,
+        )
+
+        # Stream chunks; SHA-256 only on the final chunk
+        offset = 0
+        total = len(zip_data)
+        while offset < total:
+            end = min(offset + _TOKENIZER_CHUNK_SIZE, total)
+            is_last = end == total
+            yield common_pb2.GetTokenizerChunk(
+                data=bytes(zip_data[offset:end]),
+                sha256=sha256 if is_last else "",
+            )
+            offset = end
+
+    @staticmethod
+    def _build_tokenizer_zip(tokenizer_dir: Path) -> io.BytesIO:
+        """Create an in-memory ZIP archive of tokenizer files from a directory."""
+        buf = io.BytesIO()
+        added: set[str] = set()
+        with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+            # Exact-name files
+            for name in _TOKENIZER_FILES:
+                filepath = tokenizer_dir / name
+                if filepath.is_file():
+                    zf.write(filepath, name)
+                    added.add(name)
+            # Glob patterns (*.tiktoken, *.jinja, *.model)
+            for pattern in _TOKENIZER_GLOBS:
+                for match in tokenizer_dir.glob(pattern):
+                    if match.is_file() and match.name not in added:
+                        zf.write(match, match.name)
+                        added.add(match.name)
+        if not added:
+            raise FileNotFoundError(f"No tokenizer files found in {tokenizer_dir}")
+        return buf
 
     # ========== Helper methods ==========
 

--- a/grpc_servicer/smg_grpc_servicer/vllm/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/vllm/servicer.py
@@ -385,6 +385,16 @@ class VllmEngineServicer(vllm_engine_pb2_grpc.VllmEngineServicer):
             )
         tokenizer_dir = Path(tokenizer_path)
 
+        # model_config.tokenizer may be an HF model ID (e.g. "meta-llama/...")
+        # rather than a local path. Resolve it to the HF cache directory.
+        if not tokenizer_dir.is_dir():
+            try:
+                from huggingface_hub import snapshot_download
+
+                tokenizer_dir = Path(snapshot_download(tokenizer_path, local_files_only=True))
+            except Exception:
+                pass  # Fall through to build_tokenizer_zip which will raise
+
         # Build ZIP archive in memory
         try:
             zip_buffer = build_tokenizer_zip(tokenizer_dir)


### PR DESCRIPTION
## Description

### Problem

The vLLM gRPC servicer does not implement the `GetTokenizer` RPC, causing the gateway to receive `UNIMPLEMENTED` when it attempts to fetch tokenizer artifacts from a vLLM worker. In IGW/K8s deployments where gateway and workers run on separate nodes, the gateway cannot load the tokenizer.

### Solution

Implement the server-side `GetTokenizer` handler in the vLLM gRPC servicer, following the same pattern as the sglang implementation (#1136). The handler:
1. Reads tokenizer files from `model_config.tokenizer` (vLLM's equivalent of sglang's `server_args.tokenizer_path`)
2. Creates an in-memory ZIP archive containing tokenizer files (aligned with `crates/tokenizer/src/hub.rs:is_tokenizer_file()`)
3. Streams the archive as 64KB `GetTokenizerChunk` messages with SHA-256 fingerprint on the final chunk

## Changes

- Added `GetTokenizer` async generator method to `VllmEngineServicer`
- Added `_build_tokenizer_zip` static method for ZIP archive creation
- Added `_TOKENIZER_FILES` allowlist and `_TOKENIZER_GLOBS` patterns (same as sglang)
- Added imports: `hashlib`, `io`, `zipfile`, `Path`, `AsyncIterator`, `common_pb2`

## Test Plan

### Setup

```bash
# Remote machine: start vLLM gRPC server
vllm serve --model /raid/models/meta-llama/Llama-3.2-1B-Instruct \
  --tensor-parallel-size 1 --port 8080 --grpc

# Local machine: port-forward to remote
ssh -N -L 8080:localhost:8080 ubuntu@<remote-ip> -i ~/.ssh/key
```

### Test 1: Direct gRPC call to verify bundle integrity

<details>
<summary>Test script</summary>

```python
import grpc, hashlib, io, json, zipfile
from pathlib import Path
from smg_grpc_proto import vllm_engine_pb2_grpc
from smg_grpc_proto.generated import common_pb2

MODEL_DIR = Path("/models/meta-llama/Llama-3.2-1B-Instruct")

channel = grpc.insecure_channel("localhost:8080")
stub = vllm_engine_pb2_grpc.VllmEngineStub(channel)

chunks = list(stub.GetTokenizer(common_pb2.GetTokenizerRequest()))
data = b"".join(c.data for c in chunks)
sha256 = chunks[-1].sha256

computed = hashlib.sha256(data).hexdigest()
print(f"Got {len(data)} bytes in {len(chunks)} chunks")
print(f"Received SHA-256:  {sha256}")
print(f"Computed SHA-256:  {computed}")
print(f"Match: {computed == sha256}")

zf = zipfile.ZipFile(io.BytesIO(data))
print(f"\nArchive contains {len(zf.infolist())} files:")
all_match = True
for info in zf.infolist():
    source_file = MODEL_DIR / info.filename
    bundle_bytes = zf.read(info.filename)
    if source_file.exists():
        match = bundle_bytes == source_file.read_bytes()
        status = "OK" if match else "MISMATCH"
        if not match: all_match = False
    else:
        status = "NOT ON DISK"
        all_match = False
    print(f"  {info.filename}  ({info.file_size:,} bytes) — {status}")
print(f"\nAll files match source: {all_match}")

if "tokenizer.json" in zf.namelist():
    tok = json.loads(zf.read("tokenizer.json"))
    print(f"tokenizer.json OK, vocab size: {len(tok.get('model', {}).get('vocab', {}))}")
```

</details>

**vLLM server logs:**
```
INFO 04-14 20:59:43 [servicer.py:397] Receive GetTokenizer request
INFO 04-14 20:59:44 [servicer.py:417] Streaming tokenizer bundle: 2335038 bytes,
  sha256=74e6c5d5ee7a3f940366d9c589be986f1ff8955cbaafdd062602586d6666adb0
```

**Test output:**
```
Got 2335038 bytes in 36 chunks
Received SHA-256:  74e6c5d5ee7a3f940366d9c589be986f1ff8955cbaafdd062602586d6666adb0
Computed SHA-256:  74e6c5d5ee7a3f940366d9c589be986f1ff8955cbaafdd062602586d6666adb0
Match: True

Archive contains 5 files:
  tokenizer.json  (9,085,657 bytes) — OK
  tokenizer_config.json  (54,528 bytes) — OK
  config.json  (877 bytes) — OK
  generation_config.json  (189 bytes) — OK
  special_tokens_map.json  (296 bytes) — OK

All files match source: True
tokenizer.json OK, vocab size: 128000
```

### Test 2: Full end-to-end pipeline (cross-machine, vLLM)

Verified the complete `worker → GetTokenizer → gateway` flow using SSH port-forwarding to simulate the production IGW/K8s scenario.

```bash
# Local machine: start SMG (no --model-path, no local model files)
cargo run --bin smg -- --host 0.0.0.0 --port 3002 --prometheus-port 9322 \
  --worker-urls grpc://127.0.0.1:8080 --log-level info
```

<details>
<summary>SMG gateway logs (local machine — no model files on disk)</summary>

```
submit_tokenizer_job.rs:109: Submitting tokenizer registration job for model
  /raid/models/meta-llama/Llama-3.2-1B-Instruct from /raid/models/meta-llama/Llama-3.2-1B-Instruct

tokenizer_registration.rs:85: Loading tokenizer '/raid/models/meta-llama/Llama-3.2-1B-Instruct'
  from source: /raid/models/meta-llama/Llama-3.2-1B-Instruct

tokenizer_registration.rs:251: Fetching tokenizer from worker: grpc://127.0.0.1:8080 (runtime: vllm)

tokenizer_registration.rs:217: Tokenizer extracted from temporary path:
  /var/folders/z_/hgkqqcbs1nl4lb_fsgh24c100000gq/T/.tmpqQBQgb

tokenizer_registration.rs:155: Successfully loaded tokenizer
  '/raid/models/meta-llama/Llama-3.2-1B-Instruct' with vocab_size: Some(128000)
```

</details>

**Verified model is serving after GetTokenizer load:**
```bash
curl http://localhost:3002/v1/models | jq
{
  "object": "list",
  "data": [
    {
      "id": "/raid/models/meta-llama/Llama-3.2-1B-Instruct",
      "object": "model",
      "created": 0,
      "owned_by": "self_hosted"
    }
  ]
}
```

**Verified inference works end-to-end:**
```bash
curl -X POST http://localhost:3002/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model": "/raid/models/meta-llama/Llama-3.2-1B-Instruct",
       "messages": [{"role": "user", "content": "Hi"}],
       "max_completion_tokens": 10}' | jq '.choices[0].message.content'
"How can I assist you today?"
```

### Note on tokenizer lifecycle

Tokenizer files are **not persisted on disk** after loading. The flow: stream ZIP → extract to OS temp dir → load into memory → delete temp dir. The tokenizer lives only as `Arc<dyn Tokenizer>` in the `TokenizerRegistry`.

### Learnings applied from sglang PR review (#1136)
- No `_resolve_tokenizer_dir()` — runtime already resolves the path
- No symlink safety checks — breaks HuggingFace cache (uses symlinks)
- No `return` after `context.abort()` — it raises
- `getbuffer()` instead of `getvalue()` for zero-copy streaming
- `logger.exception()` for error logging (matching vLLM file conventions)
- Guard against None tokenizer path with `FAILED_PRECONDITION`

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a streaming GetTokenizer RPC to retrieve tokenizer artifacts as chunked archives with final integrity fingerprint.

* **Improvements**
  * Consolidated tokenizer bundling into a shared utility for consistent archive construction and chunk sizing across services.
  * Improved error handling when tokenizer artifacts are missing and ensured deduplication during archive creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->