### PR TITLE
fix(grpc_servicer): remove snapshot_download from vLLM GetTokenizer

### DIFF
--- a/grpc_servicer/smg_grpc_servicer/vllm/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/vllm/servicer.py
@@ -383,17 +383,10 @@ class VllmEngineServicer(vllm_engine_pb2_grpc.VllmEngineServicer):
                 grpc.StatusCode.FAILED_PRECONDITION,
                 "Tokenizer path is not configured on this server.",
             )
+        # TODO: model_config.tokenizer may be an HF model ID (e.g. "meta-llama/...")
+        # rather than a local path. vLLM does not resolve it on the config object.
+        # For now, GetTokenizer only works when vLLM is started with a local path.
         tokenizer_dir = Path(tokenizer_path)
-
-        # model_config.tokenizer may be an HF model ID (e.g. "meta-llama/...")
-        # rather than a local path. Resolve it to the HF cache directory.
-        if not tokenizer_dir.is_dir():
-            try:
-                from huggingface_hub import snapshot_download
-
-                tokenizer_dir = Path(snapshot_download(tokenizer_path, local_files_only=True))
-            except Exception:
-                pass  # Fall through to build_tokenizer_zip which will raise
 
         # Build ZIP archive in memory
         try:


### PR DESCRIPTION
## Description

### Problem

The `GetTokenizer` handler in the vLLM servicer was merged with a `snapshot_download(local_files_only=True)` call to resolve HF model IDs to local cache paths. This is not appropriate for K8s pods that may lack HuggingFace access.

### Solution

Remove the `snapshot_download` resolution and add a TODO noting the limitation. vLLM's `model_config.tokenizer` is never resolved to a local path on the config object — vLLM resolves it inline at each point of use (`weight_utils.py`, `tokenizers/registry.py`). There is no config field or utility we can reuse.

`GetTokenizer` currently only works when vLLM is started with a local model path (e.g., `--model /raid/models/...`), which is the standard K8s deployment pattern (PVC mounts).

## Changes

- Removed `snapshot_download` HF ID resolution from `GetTokenizer`
- Added TODO comment documenting the limitation

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Modified tokenizer retrieval behavior in the service. The system no longer automatically resolves and caches tokenizers from external sources; users must now supply direct local filesystem paths. This change affects service initialization and may require configuration updates if previously relying on automatic tokenizer resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->