### PR TITLE
refactor(grpc): replace PreparationOutput struct with typed enum

### DIFF
--- a/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
+++ b/model_gateway/src/routers/grpc/common/stages/worker_selection.rs
@@ -62,20 +62,11 @@ impl PipelineStage for WorkerSelectionStage {
             )
         })?;
 
-        // For Harmony, use selection_text produced during Harmony encoding
-        // Otherwise, use original_text from regular preparation
-        let text = if prep.harmony_mode {
-            prep.selection_text.as_deref()
-        } else {
-            prep.original_text.as_deref()
-        };
+        let text = prep.routing_text();
 
         // Get tokens for PrefixHash policy support
-        let tokens = if prep.token_ids.is_empty() {
-            None
-        } else {
-            Some(prep.token_ids.as_slice())
-        };
+        let ids = prep.token_ids();
+        let tokens = if ids.is_empty() { None } else { Some(ids) };
 
         let headers = ctx.input.headers.as_ref();
 

--- a/model_gateway/src/routers/grpc/context.rs
+++ b/model_gateway/src/routers/grpc/context.rs
@@ -126,35 +126,74 @@ pub(crate) struct ProcessingState {
 }
 
 /// Output from preparation stage (Step 1)
-pub(crate) struct PreparationOutput {
-    /// Original text (for chat) or resolved text (for generate)
-    pub original_text: Option<String>,
+///
+/// Each request type produces its own variant, eliminating optional fields
+/// that are always None for certain pipelines.
+pub(crate) enum PreparationOutput {
+    Chat {
+        token_ids: Vec<u32>,
+        processed_messages: super::ProcessedMessages,
+        tool_constraints: Option<(String, String)>,
+        filtered_request: Option<Box<ChatCompletionRequest>>,
+    },
+    Messages {
+        token_ids: Vec<u32>,
+        processed_messages: super::ProcessedMessages,
+        tool_constraints: Option<(String, String)>,
+    },
+    Completion {
+        original_text: String,
+        token_ids: Vec<u32>,
+    },
+    Generate {
+        original_text: Option<String>,
+        token_ids: Vec<u32>,
+    },
+    Embedding {
+        original_text: String,
+        token_ids: Vec<u32>,
+    },
+    Harmony {
+        token_ids: Vec<u32>,
+        selection_text: String,
+        tool_constraints: Option<(String, String)>,
+        filtered_request: Option<Box<ChatCompletionRequest>>,
+        #[expect(dead_code, reason = "stored for future Harmony history tracking")]
+        harmony_messages: Vec<super::harmony::HarmonyMessage>,
+        harmony_stop_ids: Vec<u32>,
+    },
+}
 
-    /// Tokenized input
-    pub token_ids: Vec<u32>,
+impl PreparationOutput {
+    /// Token IDs (common to all variants)
+    pub fn token_ids(&self) -> &[u32] {
+        match self {
+            Self::Chat { token_ids, .. }
+            | Self::Messages { token_ids, .. }
+            | Self::Completion { token_ids, .. }
+            | Self::Generate { token_ids, .. }
+            | Self::Embedding { token_ids, .. }
+            | Self::Harmony { token_ids, .. } => token_ids,
+        }
+    }
 
-    /// Processed messages (chat only)
-    pub processed_messages: Option<super::ProcessedMessages>,
-
-    /// Tool call constraints (if applicable)
-    pub tool_constraints: Option<(String, String)>,
-
-    /// Filtered request (if tools were filtered)
-    pub filtered_request: Option<ChatCompletionRequest>,
-
-    // Harmony-specific fields
-    /// Whether this is a Harmony request (default: false)
-    pub harmony_mode: bool,
-
-    /// Selection text for worker routing (Harmony only)
-    pub selection_text: Option<String>,
-
-    /// Harmony messages for history tracking (Harmony only)
-    #[expect(dead_code)]
-    pub harmony_messages: Option<Vec<super::harmony::HarmonyMessage>>,
-
-    /// Stop token IDs for Harmony models
-    pub harmony_stop_ids: Option<Vec<u32>>,
+    /// Text for worker routing: original_text for regular pipelines, selection_text for Harmony.
+    /// Chat/Messages borrow from processed_messages.text to avoid a redundant clone.
+    pub fn routing_text(&self) -> Option<&str> {
+        match self {
+            Self::Chat {
+                processed_messages, ..
+            }
+            | Self::Messages {
+                processed_messages, ..
+            } => Some(&processed_messages.text),
+            Self::Completion { original_text, .. } | Self::Embedding { original_text, .. } => {
+                Some(original_text)
+            }
+            Self::Generate { original_text, .. } => original_text.as_deref(),
+            Self::Harmony { selection_text, .. } => Some(selection_text),
+        }
+    }
 }
 
 /// Worker selection (Step 2)

--- a/model_gateway/src/routers/grpc/harmony/stages/preparation.rs
+++ b/model_gateway/src/routers/grpc/harmony/stages/preparation.rs
@@ -142,20 +142,17 @@ impl HarmonyPreparationStage {
         })?;
 
         // Step 4: Store results
-        ctx.state.preparation = Some(PreparationOutput {
-            original_text: None,
+        ctx.state.preparation = Some(PreparationOutput::Harmony {
             token_ids: build_output.input_ids,
-            processed_messages: None,
+            selection_text: build_output.selection_text,
             tool_constraints: constraint,
             filtered_request: if matches!(body_ref, Cow::Owned(_)) {
-                Some(body_ref.into_owned())
+                Some(Box::new(body_ref.into_owned()))
             } else {
                 None
             },
-            harmony_mode: true,
-            selection_text: Some(build_output.selection_text),
-            harmony_messages: Some(build_output.harmony_messages),
-            harmony_stop_ids: Some(build_output.stop_token_ids),
+            harmony_messages: build_output.harmony_messages,
+            harmony_stop_ids: build_output.stop_token_ids,
         });
 
         Ok(None)
@@ -223,16 +220,13 @@ impl HarmonyPreparationStage {
         })?;
 
         // Step 4: Store results with constraint
-        ctx.state.preparation = Some(PreparationOutput {
-            original_text: None,
+        ctx.state.preparation = Some(PreparationOutput::Harmony {
             token_ids: build_output.input_ids,
-            processed_messages: None,
+            selection_text: build_output.selection_text,
             tool_constraints: constraint,
             filtered_request: None,
-            harmony_mode: true,
-            selection_text: Some(build_output.selection_text),
-            harmony_messages: Some(build_output.harmony_messages),
-            harmony_stop_ids: Some(build_output.stop_token_ids),
+            harmony_messages: build_output.harmony_messages,
+            harmony_stop_ids: build_output.stop_token_ids,
         });
 
         Ok(None)

--- a/model_gateway/src/routers/grpc/harmony/stages/request_building.rs
+++ b/model_gateway/src/routers/grpc/harmony/stages/request_building.rs
@@ -10,7 +10,7 @@ use crate::routers::{
     grpc::{
         client::GrpcClient,
         common::stages::{helpers, PipelineStage},
-        context::{ClientSelection, RequestContext, RequestType},
+        context::{ClientSelection, PreparationOutput, RequestContext, RequestType},
         proto_wrapper::{ProtoGenerateRequest, ProtoRequest},
     },
 };
@@ -33,14 +33,28 @@ impl HarmonyRequestBuildingStage {
 #[async_trait]
 impl PipelineStage for HarmonyRequestBuildingStage {
     async fn execute(&self, ctx: &mut RequestContext) -> Result<Option<Response>, Response> {
-        // Get preparation output
-        let prep = ctx.state.preparation.as_ref().ok_or_else(|| {
+        // Take preparation output (last consumer — worker_selection already ran)
+        let prep = ctx.state.preparation.take().ok_or_else(|| {
             error!(
                 function = "HarmonyRequestBuildingStage::execute",
                 "Preparation stage not completed"
             );
             error::internal_error("preparation_not_completed", "Preparation not completed")
         })?;
+        let PreparationOutput::Harmony {
+            token_ids,
+            tool_constraints,
+            filtered_request,
+            harmony_stop_ids,
+            ..
+        } = prep
+        else {
+            debug_assert!(false, "pipeline guarantees Harmony variant");
+            return Err(error::internal_error(
+                "wrong_preparation_type",
+                "Expected Harmony preparation output",
+            ));
+        };
 
         // Get clients
         let clients = ctx.state.clients.as_ref().ok_or_else(|| {
@@ -87,15 +101,15 @@ impl PipelineStage for HarmonyRequestBuildingStage {
             GrpcClient::Sglang(sglang_client) => {
                 let req = match &ctx.input.request_type {
                     RequestType::Chat(request) => {
-                        let body = prep.filtered_request.as_ref().unwrap_or_else(|| request.as_ref());
+                        let body = filtered_request.as_deref().unwrap_or_else(|| request.as_ref());
                         sglang_client
                             .build_generate_request_from_chat(
                                 request_id,
                                 body,
                                 placeholder_processed_text,
-                                prep.token_ids.clone(),
+                                token_ids,
                                 None,
-                                prep.tool_constraints.clone(),
+                                tool_constraints,
                             )
                             .map_err(|e| {
                                 error!(function = "HarmonyRequestBuildingStage::execute", error = %e, "Failed to build SGLang generate request");
@@ -107,8 +121,8 @@ impl PipelineStage for HarmonyRequestBuildingStage {
                             request_id,
                             request.as_ref(),
                             placeholder_processed_text,
-                            prep.token_ids.clone(),
-                            prep.tool_constraints.clone(),
+                            token_ids,
+                            tool_constraints,
                         )
                         .map_err(|e| {
                             error!(function = "HarmonyRequestBuildingStage::execute", error = %e, "Failed to build SGLang generate request from responses");
@@ -132,15 +146,15 @@ impl PipelineStage for HarmonyRequestBuildingStage {
             GrpcClient::Vllm(vllm_client) => {
                 let req = match &ctx.input.request_type {
                     RequestType::Chat(request) => {
-                        let body = prep.filtered_request.as_ref().unwrap_or_else(|| request.as_ref());
+                        let body = filtered_request.as_deref().unwrap_or_else(|| request.as_ref());
                         vllm_client
                             .build_generate_request_from_chat(
                                 request_id,
                                 body,
                                 placeholder_processed_text,
-                                prep.token_ids.clone(),
+                                token_ids,
                                 None, // No multimodal in Harmony pipeline
-                                prep.tool_constraints.clone(),
+                                tool_constraints,
                             )
                             .map_err(|e| {
                                 error!(function = "HarmonyRequestBuildingStage::execute", error = %e, "Failed to build vLLM generate request");
@@ -152,8 +166,8 @@ impl PipelineStage for HarmonyRequestBuildingStage {
                             request_id,
                             request.as_ref(),
                             placeholder_processed_text,
-                            prep.token_ids.clone(),
-                            prep.tool_constraints.clone(),
+                            token_ids,
+                            tool_constraints,
                         )
                         .map_err(|e| {
                             error!(function = "HarmonyRequestBuildingStage::execute", error = %e, "Failed to build vLLM generate request from responses");
@@ -177,15 +191,15 @@ impl PipelineStage for HarmonyRequestBuildingStage {
             GrpcClient::Trtllm(trtllm_client) => {
                 let req = match &ctx.input.request_type {
                     RequestType::Chat(request) => {
-                        let body = prep.filtered_request.as_ref().unwrap_or_else(|| request.as_ref());
+                        let body = filtered_request.as_deref().unwrap_or_else(|| request.as_ref());
                         trtllm_client
                             .build_generate_request_from_chat(
                                 request_id,
                                 body,
                                 placeholder_processed_text,
-                                prep.token_ids.clone(),
+                                token_ids,
                                 None, // No multimodal in Harmony pipeline
-                                prep.tool_constraints.clone(),
+                                tool_constraints,
                             )
                             .map_err(|e| {
                                 error!(function = "HarmonyRequestBuildingStage::execute", error = %e, "Failed to build TensorRT-LLM generate request");
@@ -197,8 +211,8 @@ impl PipelineStage for HarmonyRequestBuildingStage {
                             request_id,
                             request.as_ref(),
                             placeholder_processed_text,
-                            prep.token_ids.clone(),
-                            prep.tool_constraints.clone(),
+                            token_ids,
+                            tool_constraints,
                         )
                         .map_err(|e| {
                             error!(function = "HarmonyRequestBuildingStage::execute", error = %e, "Failed to build TensorRT-LLM generate request from responses");
@@ -222,14 +236,14 @@ impl PipelineStage for HarmonyRequestBuildingStage {
             GrpcClient::Mlx(mlx_client) => {
                 let req = match &ctx.input.request_type {
                     RequestType::Chat(request) => {
-                        let body = prep.filtered_request.as_ref().unwrap_or_else(|| request.as_ref());
+                        let body = filtered_request.as_deref().unwrap_or_else(|| request.as_ref());
                         mlx_client
                             .build_generate_request_from_chat(
                                 request_id,
                                 body,
                                 placeholder_processed_text,
-                                prep.token_ids.clone(),
-                                prep.tool_constraints.clone(),
+                                token_ids,
+                                tool_constraints,
                             )
                             .map_err(|e| {
                                 error!(function = "HarmonyRequestBuildingStage::execute", error = %e, "Failed to build MLX generate request");
@@ -241,8 +255,8 @@ impl PipelineStage for HarmonyRequestBuildingStage {
                             request_id,
                             request.as_ref(),
                             placeholder_processed_text,
-                            prep.token_ids.clone(),
-                            prep.tool_constraints.clone(),
+                            token_ids,
+                            tool_constraints,
                         )
                         .map_err(|e| {
                             error!(function = "HarmonyRequestBuildingStage::execute", error = %e, "Failed to build MLX generate request from responses");
@@ -268,42 +282,42 @@ impl PipelineStage for HarmonyRequestBuildingStage {
         // Inject Harmony stop token IDs into sampling params for ALL Harmony requests
         // These stop tokens (<|return|> and <|call|>) prevent the model from generating
         // malformed Harmony sequences
-        if let Some(harmony_stops) = &prep.harmony_stop_ids {
+        if !harmony_stop_ids.is_empty() {
             match &mut proto_request {
                 ProtoGenerateRequest::Sglang(req) => {
                     if let Some(params) = req.sampling_params.as_mut() {
-                        params.stop_token_ids.extend_from_slice(harmony_stops);
+                        params.stop_token_ids.extend_from_slice(&harmony_stop_ids);
                         debug!(
-                            stop_token_count = harmony_stops.len(),
+                            stop_token_count = harmony_stop_ids.len(),
                             "Injected Harmony stop tokens into SGLang sampling params"
                         );
                     }
                 }
                 ProtoGenerateRequest::Vllm(req) => {
                     if let Some(params) = req.sampling_params.as_mut() {
-                        params.stop_token_ids.extend_from_slice(harmony_stops);
+                        params.stop_token_ids.extend_from_slice(&harmony_stop_ids);
                         debug!(
-                            stop_token_count = harmony_stops.len(),
+                            stop_token_count = harmony_stop_ids.len(),
                             "Injected Harmony stop tokens into vLLM sampling params"
                         );
                     }
                 }
                 ProtoGenerateRequest::Trtllm(req) => {
-                    req.stop_token_ids.extend_from_slice(harmony_stops);
+                    req.stop_token_ids.extend_from_slice(&harmony_stop_ids);
                     // TRT-LLM strips stop tokens from output by default, but
                     // the Harmony parser needs them to detect channel boundaries
                     // (e.g. <|call|> marks the tool-call channel transition).
                     req.include_stop_token_in_output = true;
                     debug!(
-                        stop_token_count = harmony_stops.len(),
+                        stop_token_count = harmony_stop_ids.len(),
                         "Injected Harmony stop tokens into TensorRT-LLM stop_token_ids"
                     );
                 }
                 ProtoGenerateRequest::Mlx(req) => {
                     if let Some(ref mut params) = req.sampling_params {
-                        params.stop_token_ids.extend_from_slice(harmony_stops);
+                        params.stop_token_ids.extend_from_slice(&harmony_stop_ids);
                         debug!(
-                            stop_token_count = harmony_stops.len(),
+                            stop_token_count = harmony_stop_ids.len(),
                             "Injected Harmony stop tokens into MLX sampling params"
                         );
                     }

--- a/model_gateway/src/routers/grpc/regular/stages/chat/preparation.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/chat/preparation.rs
@@ -202,21 +202,15 @@ impl ChatPreparationStage {
         processed_messages.multimodal_intermediate = multimodal_intermediate;
 
         // Store results in context
-        ctx.state.preparation = Some(PreparationOutput {
-            original_text: Some(processed_messages.text.clone()),
+        ctx.state.preparation = Some(PreparationOutput::Chat {
             token_ids,
-            processed_messages: Some(processed_messages),
+            processed_messages,
             tool_constraints: tool_call_constraint,
             filtered_request: if matches!(body_ref, Cow::Owned(_)) {
-                Some(body_ref.into_owned())
+                Some(Box::new(body_ref.into_owned()))
             } else {
                 None
             },
-            // Harmony fields (not used for regular preparation)
-            harmony_mode: false,
-            selection_text: None,
-            harmony_messages: None,
-            harmony_stop_ids: None,
         });
 
         // Store stop decoder for reuse in response processing

--- a/model_gateway/src/routers/grpc/regular/stages/chat/request_building.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/chat/request_building.rs
@@ -9,7 +9,7 @@ use crate::routers::{
     error,
     grpc::{
         common::stages::{helpers, PipelineStage},
-        context::{ClientSelection, RequestContext},
+        context::{ClientSelection, PreparationOutput, RequestContext},
         multimodal::assemble_multimodal_data,
         proto_wrapper::ProtoRequest,
     },
@@ -59,21 +59,23 @@ impl PipelineStage for ChatRequestBuildingStage {
             ClientSelection::Dual { prefill, .. } => prefill,
         };
 
+        let PreparationOutput::Chat {
+            token_ids,
+            processed_messages,
+            tool_constraints,
+            filtered_request,
+        } = prep
+        else {
+            debug_assert!(false, "pipeline guarantees Chat variant");
+            return Err(error::internal_error(
+                "wrong_preparation_type",
+                "Expected Chat preparation output",
+            ));
+        };
+
         // Build chat request
         let request_id = format!("chatcmpl-{}", Uuid::now_v7());
-        let body_ref = prep.filtered_request.as_ref().unwrap_or(&chat_request);
-
-        // Build proto request — take ownership of preparation fields (no clones needed)
-        let processed_messages = prep.processed_messages.ok_or_else(|| {
-            error!(
-                function = "ChatRequestBuildingStage::execute",
-                "processed_messages not set in preparation state"
-            );
-            error::internal_error(
-                "processed_messages_missing",
-                "processed_messages not set - this is a bug in the pipeline",
-            )
-        })?;
+        let body_ref = filtered_request.as_deref().unwrap_or(&chat_request);
 
         // Reject multimodal for backends that don't support it, before assembling
         if processed_messages.multimodal_intermediate.is_some() && builder_client.is_mlx() {
@@ -93,9 +95,9 @@ impl PipelineStage for ChatRequestBuildingStage {
                 request_id,
                 body_ref,
                 processed_messages.text,
-                prep.token_ids,
+                token_ids,
                 multimodal_data,
-                prep.tool_constraints,
+                tool_constraints,
             )
             .map_err(|e| {
                 error!(function = "ChatRequestBuildingStage::execute", error = %e, "Failed to build generate request");

--- a/model_gateway/src/routers/grpc/regular/stages/completion/preparation.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/completion/preparation.rs
@@ -57,16 +57,9 @@ impl PipelineStage for CompletionPreparationStage {
             request.ignore_eos,
         );
 
-        ctx.state.preparation = Some(PreparationOutput {
-            original_text: Some(prompt_text),
+        ctx.state.preparation = Some(PreparationOutput::Completion {
+            original_text: prompt_text,
             token_ids: encoding.token_ids().to_vec(),
-            processed_messages: None,
-            tool_constraints: None,
-            filtered_request: None,
-            harmony_mode: false,
-            selection_text: None,
-            harmony_messages: None,
-            harmony_stop_ids: None,
         });
 
         ctx.state.response.stop_decoder = Some(stop_decoder);

--- a/model_gateway/src/routers/grpc/regular/stages/completion/request_building.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/completion/request_building.rs
@@ -67,8 +67,8 @@ impl PipelineStage for CompletionRequestBuildingStage {
             .build_completion_request(
                 request_id,
                 &completion_request,
-                prep.original_text.clone().unwrap_or_default(),
-                prep.token_ids.clone(),
+                prep.routing_text().unwrap_or_default().to_string(),
+                prep.token_ids().to_vec(),
             )
             .map_err(|e| {
                 error!(

--- a/model_gateway/src/routers/grpc/regular/stages/completion/response_processing.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/completion/response_processing.rs
@@ -116,7 +116,7 @@ impl PipelineStage for CompletionResponseProcessingStage {
             .state
             .preparation
             .as_ref()
-            .and_then(|p| p.original_text.as_deref())
+            .and_then(|p| p.routing_text())
             .unwrap_or("");
 
         let response = self

--- a/model_gateway/src/routers/grpc/regular/stages/embedding/preparation.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/embedding/preparation.rs
@@ -67,16 +67,9 @@ impl PipelineStage for EmbeddingPreparationStage {
             .to_vec();
 
         // Store preparation output
-        ctx.state.preparation = Some(PreparationOutput {
-            original_text: Some(text),
+        ctx.state.preparation = Some(PreparationOutput::Embedding {
+            original_text: text,
             token_ids,
-            processed_messages: None,
-            tool_constraints: None,
-            filtered_request: None,
-            harmony_mode: false,
-            selection_text: None,
-            harmony_messages: None,
-            harmony_stop_ids: None,
         });
 
         Ok(None)

--- a/model_gateway/src/routers/grpc/regular/stages/embedding/request_building.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/embedding/request_building.rs
@@ -63,25 +63,17 @@ impl PipelineStage for EmbeddingRequestBuildingStage {
             _ => format!("embed-{}", Uuid::now_v7()), // fallback
         };
 
-        // Extract original text
-        let original_text = prep_output.original_text.clone();
-
         // Build backend-specific embed request
+        let original_text = prep_output.routing_text().map(String::from);
+        let token_ids = prep_output.token_ids().to_vec();
+
         let proto_req = match client {
             GrpcClient::Sglang(c) => {
-                let req = c.build_embed_request(
-                    request_id.clone(),
-                    original_text,
-                    prep_output.token_ids.clone(),
-                );
+                let req = c.build_embed_request(request_id.clone(), original_text, token_ids);
                 ProtoEmbedRequest::Sglang(Box::new(req))
             }
             GrpcClient::Vllm(c) => {
-                let req = c.build_embed_request(
-                    request_id.clone(),
-                    original_text,
-                    prep_output.token_ids.clone(),
-                );
+                let req = c.build_embed_request(request_id.clone(), original_text, token_ids);
                 ProtoEmbedRequest::Vllm(Box::new(req))
             }
             GrpcClient::Trtllm(_) => {

--- a/model_gateway/src/routers/grpc/regular/stages/generate/preparation.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/generate/preparation.rs
@@ -69,17 +69,9 @@ impl GeneratePreparationStage {
             params.and_then(|p| p.ignore_eos).unwrap_or(false),
         );
 
-        ctx.state.preparation = Some(PreparationOutput {
+        ctx.state.preparation = Some(PreparationOutput::Generate {
             original_text,
             token_ids,
-            processed_messages: None,
-            tool_constraints: None,
-            filtered_request: None,
-            // Harmony fields (not used for generate requests)
-            harmony_mode: false,
-            selection_text: None,
-            harmony_messages: None,
-            harmony_stop_ids: None,
         });
 
         // Store stop decoder

--- a/model_gateway/src/routers/grpc/regular/stages/generate/request_building.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/generate/request_building.rs
@@ -68,8 +68,8 @@ impl PipelineStage for GenerateRequestBuildingStage {
             .build_generate_request(
                 request_id,
                 &generate_request,
-                prep.original_text.clone(),
-                prep.token_ids.clone(),
+                prep.routing_text().map(String::from),
+                prep.token_ids().to_vec(),
             )
             .map_err(|e| {
                 error!(function = "GenerateRequestBuildingStage::execute", error = %e, "Failed to build generate request");

--- a/model_gateway/src/routers/grpc/regular/stages/messages/preparation.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/messages/preparation.rs
@@ -235,17 +235,10 @@ impl MessagePreparationStage {
         processed_messages.multimodal_intermediate = multimodal_intermediate;
 
         // Store results in context
-        ctx.state.preparation = Some(PreparationOutput {
-            original_text: Some(processed_messages.text.clone()),
+        ctx.state.preparation = Some(PreparationOutput::Messages {
             token_ids,
-            processed_messages: Some(processed_messages),
+            processed_messages,
             tool_constraints: tool_call_constraint,
-            filtered_request: None, // Messages doesn't use Cow<ChatCompletionRequest> pattern
-            // Harmony fields (not used for messages)
-            harmony_mode: false,
-            selection_text: None,
-            harmony_messages: None,
-            harmony_stop_ids: None,
         });
 
         // Store stop decoder for reuse in response processing

--- a/model_gateway/src/routers/grpc/regular/stages/messages/request_building.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/messages/request_building.rs
@@ -9,7 +9,7 @@ use crate::routers::{
     error,
     grpc::{
         common::stages::{helpers, PipelineStage},
-        context::{ClientSelection, RequestContext},
+        context::{ClientSelection, PreparationOutput, RequestContext},
         multimodal::assemble_multimodal_data,
         proto_wrapper::ProtoRequest,
     },
@@ -60,20 +60,21 @@ impl PipelineStage for MessageRequestBuildingStage {
             ClientSelection::Dual { prefill, .. } => prefill,
         };
 
+        let PreparationOutput::Messages {
+            token_ids,
+            processed_messages,
+            tool_constraints,
+        } = prep
+        else {
+            debug_assert!(false, "pipeline guarantees Messages variant");
+            return Err(error::internal_error(
+                "wrong_preparation_type",
+                "Expected Messages preparation output",
+            ));
+        };
+
         // Build message request
         let request_id = format!("msg_{}", Uuid::now_v7());
-
-        // Build proto request — take ownership of preparation fields (no clones needed)
-        let processed_messages = prep.processed_messages.ok_or_else(|| {
-            error!(
-                function = "MessageRequestBuildingStage::execute",
-                "processed_messages not set in preparation state"
-            );
-            error::internal_error(
-                "processed_messages_missing",
-                "processed_messages not set - this is a bug in the pipeline",
-            )
-        })?;
 
         // Reject multimodal for backends that don't support it, before assembling
         if processed_messages.multimodal_intermediate.is_some() && builder_client.is_mlx() {
@@ -93,9 +94,9 @@ impl PipelineStage for MessageRequestBuildingStage {
                 request_id,
                 &messages_request,
                 processed_messages.text,
-                prep.token_ids,
+                token_ids,
                 multimodal_data,
-                prep.tool_constraints,
+                tool_constraints,
             )
             .map_err(|e| {
                 error!(function = "MessageRequestBuildingStage::execute", error = %e, "Failed to build generate request");


### PR DESCRIPTION
## Description

### Problem

`PreparationOutput` is a flat struct with 9 fields, many of which are always `None` for certain request types. For example, Completion/Generate/Embedding never use `processed_messages`, `tool_constraints`, `filtered_request`, or `harmony_*` fields — yet they must set them all to `None`. This wastes memory (the enum is sized to its largest field, `ChatCompletionRequest` at ~1448 bytes) and provides no type-level guarantee that required fields are present.

### Solution

Replace the struct with a 6-variant enum (`Chat`, `Messages`, `Completion`, `Generate`, `Embedding`, `Harmony`), where each variant carries only the fields relevant to its pipeline. Add helper methods (`token_ids()`, `routing_text()`) for cross-variant access used by worker selection and simple request builders.

## Changes

- **context.rs**: `PreparationOutput` struct → enum with 6 variants + helper methods
- **7 preparation stages**: construct their specific variant, eliminating boilerplate `None` fields
- **6 request_building stages**: pattern-match destructuring for type-specific fields; helpers for simple cases
- **worker_selection**: `routing_text()` replaces `if harmony_mode { selection_text } else { original_text }`
- **completion/response_processing**: `routing_text()` replaces `original_text.as_deref()`

Key improvements:
- `processed_messages` is non-optional in Chat/Messages (type-guaranteed, removes runtime `.ok_or_else()` check)
- Chat/Messages no longer clone `original_text` (`routing_text()` borrows from `processed_messages.text`)
- Harmony request_building uses `.take()` + move instead of `.as_ref()` + clone
- `Box<ChatCompletionRequest>` in Chat/Harmony variants reduces enum size for Completion/Generate/Embedding paths
- `debug_assert` + graceful gRPC error replaces `unreachable!()` for variant checks

## Test Plan

All existing tests pass (1015 tests across workspace). This is a purely mechanical refactor — no behavioral changes.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal data model for request preparation across multiple request types (chat, messages, completion, generate, embedding, and harmony). Improved data handling and encapsulation through new accessor methods, ensuring more explicit type-safety and cleaner code organization throughout the request processing pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->