### PR TITLE
refactor(grpc): remove filtered_request from Chat PreparationOutput

### DIFF
--- a/model_gateway/src/routers/grpc/context.rs
+++ b/model_gateway/src/routers/grpc/context.rs
@@ -134,7 +134,6 @@ pub(crate) enum PreparationOutput {
         token_ids: Vec<u32>,
         processed_messages: super::ProcessedMessages,
         tool_constraints: Option<(String, String)>,
-        filtered_request: Option<Box<ChatCompletionRequest>>,
     },
     Messages {
         token_ids: Vec<u32>,
@@ -157,7 +156,8 @@ pub(crate) enum PreparationOutput {
         token_ids: Vec<u32>,
         selection_text: String,
         tool_constraints: Option<(String, String)>,
-        filtered_request: Option<Box<ChatCompletionRequest>>,
+        /// Request with response_format cleared (when converted to structural tag)
+        modified_request: Option<Box<ChatCompletionRequest>>,
         #[expect(dead_code, reason = "stored for future Harmony history tracking")]
         harmony_messages: Vec<super::harmony::HarmonyMessage>,
         harmony_stop_ids: Vec<u32>,

--- a/model_gateway/src/routers/grpc/harmony/stages/preparation.rs
+++ b/model_gateway/src/routers/grpc/harmony/stages/preparation.rs
@@ -146,7 +146,7 @@ impl HarmonyPreparationStage {
             token_ids: build_output.input_ids,
             selection_text: build_output.selection_text,
             tool_constraints: constraint,
-            filtered_request: if matches!(body_ref, Cow::Owned(_)) {
+            modified_request: if matches!(body_ref, Cow::Owned(_)) {
                 Some(Box::new(body_ref.into_owned()))
             } else {
                 None
@@ -224,7 +224,7 @@ impl HarmonyPreparationStage {
             token_ids: build_output.input_ids,
             selection_text: build_output.selection_text,
             tool_constraints: constraint,
-            filtered_request: None,
+            modified_request: None,
             harmony_messages: build_output.harmony_messages,
             harmony_stop_ids: build_output.stop_token_ids,
         });

--- a/model_gateway/src/routers/grpc/harmony/stages/request_building.rs
+++ b/model_gateway/src/routers/grpc/harmony/stages/request_building.rs
@@ -44,7 +44,7 @@ impl PipelineStage for HarmonyRequestBuildingStage {
         let PreparationOutput::Harmony {
             token_ids,
             tool_constraints,
-            filtered_request,
+            modified_request,
             harmony_stop_ids,
             ..
         } = prep
@@ -101,7 +101,7 @@ impl PipelineStage for HarmonyRequestBuildingStage {
             GrpcClient::Sglang(sglang_client) => {
                 let req = match &ctx.input.request_type {
                     RequestType::Chat(request) => {
-                        let body = filtered_request.as_deref().unwrap_or_else(|| request.as_ref());
+                        let body = modified_request.as_deref().unwrap_or_else(|| request.as_ref());
                         sglang_client
                             .build_generate_request_from_chat(
                                 request_id,
@@ -146,7 +146,7 @@ impl PipelineStage for HarmonyRequestBuildingStage {
             GrpcClient::Vllm(vllm_client) => {
                 let req = match &ctx.input.request_type {
                     RequestType::Chat(request) => {
-                        let body = filtered_request.as_deref().unwrap_or_else(|| request.as_ref());
+                        let body = modified_request.as_deref().unwrap_or_else(|| request.as_ref());
                         vllm_client
                             .build_generate_request_from_chat(
                                 request_id,
@@ -191,7 +191,7 @@ impl PipelineStage for HarmonyRequestBuildingStage {
             GrpcClient::Trtllm(trtllm_client) => {
                 let req = match &ctx.input.request_type {
                     RequestType::Chat(request) => {
-                        let body = filtered_request.as_deref().unwrap_or_else(|| request.as_ref());
+                        let body = modified_request.as_deref().unwrap_or_else(|| request.as_ref());
                         trtllm_client
                             .build_generate_request_from_chat(
                                 request_id,
@@ -236,7 +236,7 @@ impl PipelineStage for HarmonyRequestBuildingStage {
             GrpcClient::Mlx(mlx_client) => {
                 let req = match &ctx.input.request_type {
                     RequestType::Chat(request) => {
-                        let body = filtered_request.as_deref().unwrap_or_else(|| request.as_ref());
+                        let body = modified_request.as_deref().unwrap_or_else(|| request.as_ref());
                         mlx_client
                             .build_generate_request_from_chat(
                                 request_id,

--- a/model_gateway/src/routers/grpc/regular/stages/chat/preparation.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/chat/preparation.rs
@@ -1,7 +1,5 @@
 //! Chat preparation stage: Filter tools, process messages, tokenize, build constraints
 
-use std::borrow::Cow;
-
 use async_trait::async_trait;
 use axum::response::Response;
 use openai_protocol::chat::ChatCompletionRequest;
@@ -206,11 +204,6 @@ impl ChatPreparationStage {
             token_ids,
             processed_messages,
             tool_constraints: tool_call_constraint,
-            filtered_request: if matches!(body_ref, Cow::Owned(_)) {
-                Some(Box::new(body_ref.into_owned()))
-            } else {
-                None
-            },
         });
 
         // Store stop decoder for reuse in response processing

--- a/model_gateway/src/routers/grpc/regular/stages/chat/request_building.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/chat/request_building.rs
@@ -63,7 +63,6 @@ impl PipelineStage for ChatRequestBuildingStage {
             token_ids,
             processed_messages,
             tool_constraints,
-            filtered_request,
         } = prep
         else {
             debug_assert!(false, "pipeline guarantees Chat variant");
@@ -75,7 +74,6 @@ impl PipelineStage for ChatRequestBuildingStage {
 
         // Build chat request
         let request_id = format!("chatcmpl-{}", Uuid::now_v7());
-        let body_ref = filtered_request.as_deref().unwrap_or(&chat_request);
 
         // Reject multimodal for backends that don't support it, before assembling
         if processed_messages.multimodal_intermediate.is_some() && builder_client.is_mlx() {
@@ -93,7 +91,7 @@ impl PipelineStage for ChatRequestBuildingStage {
         let mut proto_request = builder_client
             .build_chat_request(
                 request_id,
-                body_ref,
+                &chat_request,
                 processed_messages.text,
                 token_ids,
                 multimodal_data,


### PR DESCRIPTION
## Description

### Problem

The `filtered_request` field in `PreparationOutput::Chat` stored a clone of `ChatCompletionRequest` with tools filtered by `tool_choice`. However, the build methods (`build_generate_request_from_chat`) never read `request.tools` — they only read sampling params, stop sequences, `response_format`, and the separately-passed `tool_constraints`. The tool filtering is consumed entirely by the preparation stage (template rendering + constraint generation).

### Solution

Remove `filtered_request` from `PreparationOutput::Chat`. The build method now uses the original `chat_request` directly. This eliminates a ~1.4KB `Box<ChatCompletionRequest>` clone on every chat request with tool_choice filtering.

Harmony keeps the field (renamed to `modified_request`) because it clears `response_format` when converting it to a structural tag — a modification the build method needs to see to avoid creating a duplicate constraint.

## Changes

- **context.rs**: Remove `filtered_request` from `Chat` variant, rename to `modified_request` in `Harmony`
- **chat/preparation.rs**: Remove `filtered_request` construction and `Cow` import
- **chat/request_building.rs**: Use `&chat_request` directly instead of `filtered_request.as_deref().unwrap_or()`
- **harmony/preparation.rs**: Rename field to `modified_request`
- **harmony/request_building.rs**: Rename field to `modified_request`

## Test Plan

All existing tests pass. No behavioral change — build methods never read the `tools` field that was being filtered.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal request handling logic by removing redundant data storage and simplifying field management in the request preparation pipeline.
  * Improved code clarity through internal naming updates and eliminated unused conditional logic across multiple request processing stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->