### PR TITLE
fix(grpc_client): warn instead of error on conflicting constraints

### DIFF
--- a/crates/grpc_client/src/sglang_scheduler.rs
+++ b/crates/grpc_client/src/sglang_scheduler.rs
@@ -512,21 +512,26 @@ impl SglangSchedulerClient {
             constraints.push(proto::sampling_params::Constraint::Regex(regex.clone()));
         }
 
-        // Handle tool call constraint from preparation stage
+        // Handle tool call constraint from preparation stage.
+        // If response_format already set a constraint, drop the tool constraint
+        // (matches SGLang HTTP behavior where response_format takes priority).
         if let Some((constraint_type, constraint_value)) = tool_call_constraint {
-            if !constraints.is_empty() {
-                return Err("Constrained decoding is not compatible with tool calls.".to_string());
+            if constraints.is_empty() {
+                let tool_constraint = match constraint_type.as_str() {
+                    "structural_tag" => {
+                        proto::sampling_params::Constraint::StructuralTag(constraint_value)
+                    }
+                    "json_schema" => {
+                        proto::sampling_params::Constraint::JsonSchema(constraint_value)
+                    }
+                    "ebnf" => proto::sampling_params::Constraint::EbnfGrammar(constraint_value),
+                    "regex" => proto::sampling_params::Constraint::Regex(constraint_value),
+                    _ => return Err(format!("Unknown constraint type: {constraint_type}")),
+                };
+                constraints.push(tool_constraint);
+            } else {
+                warn!("Constrained decoding is not compatible with tool calls, dropping tool constraint");
             }
-            let tool_constraint = match constraint_type.as_str() {
-                "structural_tag" => {
-                    proto::sampling_params::Constraint::StructuralTag(constraint_value)
-                }
-                "json_schema" => proto::sampling_params::Constraint::JsonSchema(constraint_value),
-                "ebnf" => proto::sampling_params::Constraint::EbnfGrammar(constraint_value),
-                "regex" => proto::sampling_params::Constraint::Regex(constraint_value),
-                _ => return Err(format!("Unknown constraint type: {constraint_type}")),
-            };
-            constraints.push(tool_constraint);
         }
 
         match constraints.len() {

--- a/crates/grpc_client/src/trtllm_service.rs
+++ b/crates/grpc_client/src/trtllm_service.rs
@@ -524,59 +524,69 @@ impl TrtllmServiceClient {
         request: &ChatCompletionRequest,
         tool_call_constraint: Option<(String, String)>,
     ) -> Result<Option<proto::GuidedDecodingParams>, String> {
-        // Handle tool call constraint first
-        if let Some((constraint_type, constraint_value)) = tool_call_constraint {
-            let guide_type = match constraint_type.as_str() {
-                "structural_tag" => proto::guided_decoding_params::GuideType::StructuralTag,
-                "json_schema" => proto::guided_decoding_params::GuideType::JsonSchema,
-                "ebnf" | "grammar" => proto::guided_decoding_params::GuideType::EbnfGrammar,
-                "regex" => proto::guided_decoding_params::GuideType::Regex,
-                _ => return Err(format!("Unknown constraint type: {constraint_type}")),
-            };
-            return Ok(Some(proto::GuidedDecodingParams {
-                guide_type: guide_type as i32,
-                guide: constraint_value,
-            }));
-        }
+        // Collect non-tool constraint (response_format, ebnf, regex)
+        let mut guided = None;
 
-        // Handle response_format
         match &request.response_format {
             Some(ResponseFormat::JsonObject) => {
                 let schema = serde_json::json!({"type": "object"});
                 let schema_str = serde_json::to_string(&schema)
                     .map_err(|e| format!("Failed to serialize JSON schema: {e}"))?;
-                return Ok(Some(proto::GuidedDecodingParams {
+                guided = Some(proto::GuidedDecodingParams {
                     guide_type: proto::guided_decoding_params::GuideType::JsonSchema as i32,
                     guide: schema_str,
-                }));
+                });
             }
             Some(ResponseFormat::JsonSchema { json_schema }) => {
                 let schema_str = serde_json::to_string(&json_schema.schema)
                     .map_err(|e| format!("Failed to serialize JSON schema: {e}"))?;
-                return Ok(Some(proto::GuidedDecodingParams {
+                guided = Some(proto::GuidedDecodingParams {
                     guide_type: proto::guided_decoding_params::GuideType::JsonSchema as i32,
                     guide: schema_str,
-                }));
+                });
             }
             Some(ResponseFormat::Text) | None => {}
         }
 
-        // Handle ebnf/regex from request
-        if let Some(ebnf) = &request.ebnf {
-            return Ok(Some(proto::GuidedDecodingParams {
-                guide_type: proto::guided_decoding_params::GuideType::EbnfGrammar as i32,
-                guide: ebnf.clone(),
-            }));
+        if guided.is_none() {
+            if let Some(ebnf) = &request.ebnf {
+                guided = Some(proto::GuidedDecodingParams {
+                    guide_type: proto::guided_decoding_params::GuideType::EbnfGrammar as i32,
+                    guide: ebnf.clone(),
+                });
+            }
         }
 
-        if let Some(regex) = &request.regex {
-            return Ok(Some(proto::GuidedDecodingParams {
-                guide_type: proto::guided_decoding_params::GuideType::Regex as i32,
-                guide: regex.clone(),
-            }));
+        if guided.is_none() {
+            if let Some(regex) = &request.regex {
+                guided = Some(proto::GuidedDecodingParams {
+                    guide_type: proto::guided_decoding_params::GuideType::Regex as i32,
+                    guide: regex.clone(),
+                });
+            }
         }
 
-        Ok(None)
+        // Tool call constraint — drop if another constraint already set
+        // (matches TRT-LLM HTTP behavior where response_format takes priority)
+        if let Some((constraint_type, constraint_value)) = tool_call_constraint {
+            if guided.is_some() {
+                warn!("Constrained decoding is not compatible with tool calls, dropping tool constraint");
+            } else {
+                let guide_type = match constraint_type.as_str() {
+                    "structural_tag" => proto::guided_decoding_params::GuideType::StructuralTag,
+                    "json_schema" => proto::guided_decoding_params::GuideType::JsonSchema,
+                    "ebnf" | "grammar" => proto::guided_decoding_params::GuideType::EbnfGrammar,
+                    "regex" => proto::guided_decoding_params::GuideType::Regex,
+                    _ => return Err(format!("Unknown constraint type: {constraint_type}")),
+                };
+                guided = Some(proto::GuidedDecodingParams {
+                    guide_type: guide_type as i32,
+                    guide: constraint_value,
+                });
+            }
+        }
+
+        Ok(guided)
     }
 
     /// Build SamplingConfig from ResponsesRequest

--- a/crates/grpc_client/src/vllm_engine.rs
+++ b/crates/grpc_client/src/vllm_engine.rs
@@ -449,10 +449,15 @@ impl VllmEngineClient {
             constraints.push(proto::sampling_params::Constraint::Regex(regex.clone()));
         }
 
-        // Handle tool call constraint from preparation stage
+        // Handle tool call constraint from preparation stage.
+        // If response_format already set a constraint, clear it — tool constraint wins
+        // (matches vLLM HTTP behavior where tool calling overrides response_format).
         if let Some((constraint_type, constraint_value)) = tool_call_constraint {
             if !constraints.is_empty() {
-                return Err("Constrained decoding is not compatible with tool calls.".to_string());
+                warn!(
+                    "Constrained decoding is not compatible with tool calls, using tool constraint"
+                );
+                constraints.clear();
             }
             let tool_constraint = match constraint_type.as_str() {
                 "structural_tag" => {


### PR DESCRIPTION
## Description

### Problem

When both `response_format` and `tool_call_constraint` are present, the gRPC clients return a hard error (`"Constrained decoding is not compatible with tool calls."`). However, the HTTP serving layers in all three backends handle this as a non-fatal conflict:

| Backend | HTTP behavior |
|---|---|
| **SGLang** | `logger.warning(...)`, response_format wins, tool constraint dropped |
| **vLLM** | Silently clears `response_format`, tool constraint wins |
| **TRT-LLM** | Silently skips tool constraint if `guided_decoding` already set by response_format |

The gRPC path should match the HTTP behavior rather than being stricter.

Additionally, TRT-LLM's gRPC client had the opposite priority order from its HTTP layer (tool constraint won instead of response_format).

### Solution

Change each gRPC client to warn and resolve the conflict matching its HTTP backend:

- **SGLang**: response_format wins, tool constraint dropped (warning logged)
- **vLLM**: tool constraint wins, response_format cleared (warning logged)
- **TRT-LLM**: response_format wins, tool constraint skipped (warning logged). Also fixes priority order to match HTTP behavior.

## Changes

- `sglang_scheduler.rs`: `Err(...)` → warn + drop tool constraint
- `vllm_engine.rs`: `Err(...)` → warn + `constraints.clear()` + push tool constraint
- `trtllm_service.rs`: flip priority so response_format is checked first, warn if both present

## Test Plan

Existing tests pass. This is an edge case (users rarely send both response_format and tools), but now the gRPC path matches the HTTP path instead of erroring.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * No longer error when tool calls are used alongside other response-format/structured constraints. Conflicts are now resolved deterministically: in some flows the tool constraint is ignored (with a warning), in others it takes precedence (with a warning). Unknown tool-call types still produce an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->