### PR TITLE
docs(worker): strip redundant inline comments

### DIFF
--- a/model_gateway/src/worker/circuit_breaker.rs
+++ b/model_gateway/src/worker/circuit_breaker.rs
@@ -245,7 +245,6 @@ impl CircuitBreaker {
         self.consecutive_successes.store(0, Ordering::Release);
         let failures = self.consecutive_failures.fetch_add(1, Ordering::AcqRel) + 1;
 
-        // Update last failure time atomically
         self.last_failure_time_ms.store(now_ms(), Ordering::Release);
 
         let current_state = CircuitState::from_int(self.state.load(Ordering::Acquire));

--- a/model_gateway/src/worker/hash_ring.rs
+++ b/model_gateway/src/worker/hash_ring.rs
@@ -52,7 +52,6 @@ impl HashRing {
             Vec::with_capacity(lower.saturating_mul(VIRTUAL_NODES_PER_WORKER));
 
         for url in iter {
-            // Create Arc<str> once per worker, share across all virtual nodes.
             let url: Arc<str> = Arc::from(url.as_ref());
 
             for vnode in 0..VIRTUAL_NODES_PER_WORKER {
@@ -62,7 +61,6 @@ impl HashRing {
             }
         }
 
-        // Sort by ring position for binary search.
         entries.sort_unstable_by_key(|(pos, _)| *pos);
 
         Self {
@@ -78,7 +76,6 @@ impl HashRing {
     )]
     fn hash_position(s: &str) -> u64 {
         let hash = blake3::hash(s.as_bytes());
-        // Take first 8 bytes as u64.
         u64::from_le_bytes(
             hash.as_bytes()[..8]
                 .try_into()
@@ -108,7 +105,6 @@ impl HashRing {
 
         let key_pos = Self::hash_position(key);
 
-        // Binary search to find first entry at or after key_pos.
         let start = self.entries.partition_point(|(pos, _)| *pos < key_pos);
 
         // Walk clockwise from start, wrapping around. Track visited URLs to

--- a/model_gateway/src/worker/kv_event_monitor.rs
+++ b/model_gateway/src/worker/kv_event_monitor.rs
@@ -171,7 +171,6 @@ impl KvEventMonitor {
     /// Sends a graceful shutdown signal — the task cleans up its own
     /// `WorkerBlockMap` in the indexer before exiting.
     pub async fn on_worker_removed(&self, worker_url: &str) {
-        // Remove subscription from handles under lock.
         let subscription = {
             let mut handles = self.worker_handles.lock().await;
             handles.remove(worker_url)
@@ -840,7 +839,6 @@ mod tests {
         let w1 = indexer.intern_worker("http://w1:8000");
         let mut wb = WorkerBlockMap::default();
 
-        // Store first
         let stored_event = KvCacheEvent {
             event_id: 1,
             data: Some(kv_cache_event::Data::Stored(KvBlocksStored {
@@ -856,7 +854,6 @@ mod tests {
         };
         KvEventMonitor::apply_event(&stored_event, w1, &indexer, &mut wb);
 
-        // Remove
         let removed_event = KvCacheEvent {
             event_id: 2,
             data: Some(kv_cache_event::Data::Removed(KvBlocksRemoved {
@@ -874,7 +871,6 @@ mod tests {
         let w1 = indexer.intern_worker("http://w1:8000");
         let mut wb = WorkerBlockMap::default();
 
-        // Store first
         KvEventMonitor::apply_event(
             &KvCacheEvent {
                 event_id: 1,

--- a/model_gateway/src/worker/metrics_aggregator.rs
+++ b/model_gateway/src/worker/metrics_aggregator.rs
@@ -15,7 +15,7 @@ pub fn aggregate_metrics(metric_packs: Vec<MetricPack>) -> anyhow::Result<String
     let mut expositions = vec![];
     for metric_pack in metric_packs {
         let metrics_text = &metric_pack.metrics_text;
-        // openmetrics_parser doesn't handle colons in metric names; replace with underscores
+        // openmetrics_parser rejects colons in metric names.
         let metrics_text = metrics_text.replace(":", "_");
 
         let exposition = match openmetrics_parser::prometheus::parse_prometheus(&metrics_text) {

--- a/model_gateway/src/worker/registry.rs
+++ b/model_gateway/src/worker/registry.rs
@@ -295,36 +295,27 @@ impl WorkerRegistry {
             self.get_all()
         };
 
-        // Apply remaining filters
         workers
             .into_iter()
             .filter(|w| {
-                // Check worker_type if specified
                 if let Some(ref wtype) = worker_type {
                     if *w.worker_type() != *wtype {
                         return false;
                     }
                 }
-
-                // Check connection_mode if specified
                 if let Some(ref conn) = connection_mode {
                     if w.connection_mode() != conn {
                         return false;
                     }
                 }
-
-                // Check runtime_type if specified
                 if let Some(ref rt) = runtime_type {
                     if w.metadata().spec.runtime_type != *rt {
                         return false;
                     }
                 }
-
-                // Check health if required
                 if healthy_only && !w.is_healthy() {
                     return false;
                 }
-
                 true
             })
             .collect()
@@ -510,10 +501,7 @@ impl WorkerRegistry {
             .map(|v| v.len())
             .unwrap_or(0);
 
-        // Get total workers count efficiently from DashMap
         let total_workers = self.workers.len();
-
-        // PD workers are any workers that are not Regular
         let pd_count = total_workers.saturating_sub(regular_count);
 
         (regular_count, pd_count)
@@ -682,7 +670,6 @@ impl WorkerRegistry {
             self.rebuild_hash_ring(kept_model);
         }
 
-        // Update type index if changed
         if old_worker.worker_type() != new_worker.worker_type() {
             if let Some(mut type_workers) = self.type_workers.get_mut(old_worker.worker_type()) {
                 type_workers.retain(|id| id != worker_id);
@@ -693,7 +680,6 @@ impl WorkerRegistry {
                 .push(worker_id.clone());
         }
 
-        // Update connection mode index if changed
         if old_worker.connection_mode() != new_worker.connection_mode() {
             if let Some(mut conn_workers) = self
                 .connection_workers
@@ -897,27 +883,23 @@ impl WorkerRegistry {
         let _guard = lock.lock();
 
         if let Some((_, worker)) = self.workers.remove(worker_id) {
-            // Remove from URL mapping
             self.url_to_id.remove(worker.url());
-            // Clean up replace lock (after we release it)
-            // Note: we hold _guard, so drop the DashMap entry but the Mutex stays alive via Arc
+            // We hold _guard; drop the DashMap entry but the Mutex stays alive via Arc.
             self.worker_mutation_locks.remove(worker_id);
 
             for model_id in Self::worker_model_ids(&worker) {
                 self.remove_worker_from_model_index(&model_id, worker.url());
-                // Clean up per-model retry config when no workers remain for this model
+                // Drop the per-model retry config when the last worker leaves.
                 let model_empty = self.model_index.get(&model_id).is_none_or(|w| w.is_empty());
                 if model_empty {
                     self.model_retry_configs.remove(&model_id);
                 }
             }
 
-            // Remove from type index
             if let Some(mut type_workers) = self.type_workers.get_mut(worker.worker_type()) {
                 type_workers.retain(|id| id != worker_id);
             }
 
-            // Remove from connection mode index
             if let Some(mut conn_workers) =
                 self.connection_workers.get_mut(worker.connection_mode())
             {
@@ -1042,7 +1024,6 @@ impl WorkerRegistry {
             return None;
         }
 
-        // Store worker
         self.workers.insert(worker_id.clone(), worker.clone());
 
         // Update model index for O(1) lookups using copy-on-write.
@@ -1315,7 +1296,6 @@ mod tests {
     fn test_worker_registry() {
         let registry = WorkerRegistry::new();
 
-        // Create a worker with labels
         let mut labels = HashMap::new();
         labels.insert("model_id".to_string(), "llama-3-8b".to_string());
         labels.insert("priority".to_string(), "50".to_string());
@@ -1343,7 +1323,6 @@ mod tests {
         assert_eq!(stats.total_workers, 1);
         assert_eq!(stats.total_models, 1);
 
-        // Remove worker
         registry.remove(&worker_id);
         assert!(registry.get(&worker_id).is_none());
     }
@@ -1352,7 +1331,6 @@ mod tests {
     fn test_model_index_fast_lookup() {
         let registry = WorkerRegistry::new();
 
-        // Create workers for different models
         let mut labels1 = HashMap::new();
         labels1.insert("model_id".to_string(), "llama-3".to_string());
         let worker1: Box<dyn Worker> = Box::new(
@@ -1768,10 +1746,8 @@ mod tests {
     fn test_model_retry_config_last_write_wins() {
         let registry = WorkerRegistry::new();
 
-        // No config initially
         assert!(registry.get_retry_config("llama-3").is_none());
 
-        // Set config for a model (retries enabled)
         let config1 = RetryConfig {
             max_retries: 3,
             ..RetryConfig::default()
@@ -1823,7 +1799,6 @@ mod tests {
         let id1 = registry.register(worker1).unwrap();
         let id2 = registry.register(worker2).unwrap();
 
-        // Set retry config for the model
         registry.set_model_retry_config(
             "llama-3",
             RetryConfig {
@@ -1978,7 +1953,6 @@ mod tests {
         let registry = WorkerRegistry::new();
         let mut rx = registry.subscribe_events();
 
-        // Create and register a worker
         let mut labels = HashMap::new();
         labels.insert("model_id".to_string(), "test-model".to_string());
 
@@ -2002,7 +1976,6 @@ mod tests {
             other => panic!("Expected Registered event, got: {other:?}"),
         }
 
-        // Remove the worker
         registry.remove(&worker_id);
 
         // Should receive Removed event

--- a/model_gateway/src/worker/token_bucket.rs
+++ b/model_gateway/src/worker/token_bucket.rs
@@ -114,7 +114,6 @@ impl TokenBucket {
             );
 
             loop {
-                // Wait for notify signal from return_tokens()
                 self.notify.notified().await;
 
                 if self.try_acquire(tokens).is_ok() {
@@ -238,11 +237,10 @@ mod tests {
         // No more tokens available
         assert!(bucket.try_acquire(1.0).is_err());
 
-        // Wait - should NOT refill automatically
+        // refill_rate=0 should NOT refill automatically even after waiting
         tokio::time::sleep(Duration::from_millis(500)).await;
         assert!(bucket.try_acquire(1.0).is_err());
 
-        // Return a token - now we should be able to acquire
         bucket.return_tokens(1.0);
         assert!(bucket.try_acquire(1.0).is_ok());
 


### PR DESCRIPTION
## Summary

Audit of `worker/` inline comments found ~30 lines that restated what the next line of code already said — narration of the form \`// Increment counter\` above \`counter += 1\`. None encoded a non-obvious invariant, workaround, or design rationale.

Following the project rule **"default to writing no comments — only add one when the WHY is non-obvious"**, this PR removes them so the surviving comments in `worker/` are uniformly load-bearing.

## What was removed (per file)

### `worker/circuit_breaker.rs` (1)
- `// Update last failure time atomically` above an atomic store.

### `worker/hash_ring.rs` (4)
- `// Create Arc<str> once per worker, share across all virtual nodes.` — the extract-and-clone pattern speaks for itself
- `// Sort by ring position for binary search.` — `sort_unstable_by_key` on the position is self-evident
- `// Take first 8 bytes as u64.` — above `u64::from_le_bytes(hash[..8])`
- `// Binary search to find first entry at or after key_pos.` — `partition_point` IS binary search

**Kept**: the expanded `HashSet` rationale block at `find_healthy_url`. That block explains WHY the dedupe set exists and that its capacity is bounded by `worker_count`, which is load-bearing context for reviewers per the recent allocation-claim review on #1129.

### `worker/kv_event_monitor.rs` (4)
- `// Remove subscription from handles under lock.` in `on_worker_removed` — the lock-scoped block already shows it
- Three `// Store first` / `// Remove` narrations in the `apply_event` dispatch tests — variable names already say it

### `worker/metrics_aggregator.rs` (1, shortened)
- Tightened `openmetrics_parser doesn't handle colons in metric names; replace with underscores` → `openmetrics_parser rejects colons in metric names.` — the `.replace(":", "_")` right below is self-evident

### `worker/registry.rs` (~16)
- Filter method narration in `WorkerRegistry::list` — four `// Check X if specified` comments above their `if let Some(...)` filters
- `// Get total workers count efficiently from DashMap` above a plain `.len()` call (the "efficiently" claim wasn't even actionable — it just decorated the call)
- `// Update type/connection mode index if changed` above their `if old != new` blocks
- `// Remove from URL/type/connection mode mapping` narrations in the worker removal path
- `// Store worker` above `self.workers.insert(...)`. **Kept** the nearby copy-on-write rationale + DashMap-key-ownership notes because those encode WHY the clones are needed
- Test setup narration in five tests: `// Create a worker with labels`, `// Remove worker`, `// Create workers for different models`, `// Set config for a model`, `// Set retry config for the model`, `// Create and register a worker`, `// Remove the worker`. **Kept** the `Last write wins` / `Disable retries` / `Remove first|last worker — config should still exist|be cleaned up` comments because those state the test's expected behavior, not its mechanics

### `worker/token_bucket.rs` (3, one rewritten)
- `// Wait for notify signal from return_tokens()` above `notify.notified().await` — the function-level doc above already explains the `refill_rate=0` path
- `// Return a token - now we should be able to acquire` test narration above `bucket.return_tokens(1.0)`
- `// Wait - should NOT refill automatically` rewritten to `// refill_rate=0 should NOT refill automatically even after waiting` — keeps the assertion intent without narrating the sleep call

## What was deliberately KEPT

- All `///` doc comments and `//!` module docs (out of scope of this audit)
- Section-header comments in `worker.rs` that group trait methods (`// ── Health check counter accessors ──` etc.) — they add semantic grouping to a 2000-line file
- Comments explaining lock ordering, atomic ordering rationale, borrow-checker workarounds, mesh-sync ordering invariants, and test logic premises (`Last write wins`, `Should receive Removed event`)
- The 7 `//` comments in `registry.rs` that document non-obvious invariants (mesh sync ordering, replace lock lifecycle, model retry config cleanup intent, etc.)

## Net change

```
6 files changed, 4 insertions(+), 42 deletions(-)
```

## Test plan

- [x] `cargo clippy -p smg --all-targets -- -D warnings` — clean.
- [x] `cargo clippy -p smg-golang --all-targets -- -D warnings` — clean.
- [x] `cargo check -p smg-python` — clean.
- [x] `cargo test -p smg --lib` — **546 passed; 0 failed; 4 ignored**.
- [x] `make fmt` — clean (uses nightly).
- [x] `rustup run nightly cargo fmt -- --check` — EXIT=0 (matches what CI runs, learned from #1129's format failure).

This is a doc-only refactor. Zero behavior changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code documentation updates across worker modules for improved clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->