### PR TITLE
feat(python/serve): disable router retries and circuit breaker by default when dp<=1

### DIFF
--- a/bindings/python/src/smg/serve.py
+++ b/bindings/python/src/smg/serve.py
@@ -635,6 +635,22 @@ class ServeOrchestrator:
         ]
         router_args = RouterArgs.from_cli_args(self.args, use_router_prefix=True)
         router_args.worker_urls = worker_urls
+        # Router-level retries and circuit breaker are redundant when there is a
+        # single worker — per-worker resilience already handles failures — so
+        # disable them by default for dp<=1. Users who want them must run dp>1.
+        if self.args.data_parallel_size <= 1:
+            if not router_args.disable_retries:
+                logger.info(
+                    "dp=%d: disabling router-level retries (per-worker resilience handles failures)",
+                    self.args.data_parallel_size,
+                )
+                router_args.disable_retries = True
+            if not router_args.disable_circuit_breaker:
+                logger.info(
+                    "dp=%d: disabling router-level circuit breaker (per-worker resilience handles failures)",
+                    self.args.data_parallel_size,
+                )
+                router_args.disable_circuit_breaker = True
         return router_args
 
     def _signal_handler(self, signum: int, frame: object) -> None:

--- a/bindings/python/tests/test_serve.py
+++ b/bindings/python/tests/test_serve.py
@@ -1037,6 +1037,7 @@ def _make_args(**overrides):
         "router_policy": "cache_aware",
         "router_pd_disaggregation": False,
         "router_disable_retries": False,
+        "router_disable_circuit_breaker": False,
     }
     defaults.update(overrides)
     return argparse.Namespace(**defaults)
@@ -1101,6 +1102,52 @@ class TestServeOrchestrator:
             "grpc://127.0.0.1:32000",
             "grpc://127.0.0.1:32003",
         ]
+
+    def test_build_router_args_dp1_disables_retries_and_cb(self):
+        """With dp<=1, router-level retries and circuit breaker are auto-disabled."""
+        from types import SimpleNamespace
+
+        args = _make_args(data_parallel_size=1)
+        orch = ServeOrchestrator("sglang", args, ["--model-path", "/tmp/model"])
+        orch.workers = [(MagicMock(), 31000)]
+
+        router_args = SimpleNamespace(disable_retries=False, disable_circuit_breaker=False)
+        with patch("smg.serve.RouterArgs.from_cli_args", return_value=router_args):
+            result = orch._build_router_args()
+
+        assert result.disable_retries is True
+        assert result.disable_circuit_breaker is True
+        assert result.worker_urls == ["grpc://127.0.0.1:31000"]
+
+    def test_build_router_args_dp2_preserves_retries_and_cb(self):
+        """With dp>1, router-level retries and circuit breaker are left untouched."""
+        from types import SimpleNamespace
+
+        args = _make_args(data_parallel_size=2)
+        orch = ServeOrchestrator("sglang", args, ["--model-path", "/tmp/model"])
+        orch.workers = [(MagicMock(), 31000), (MagicMock(), 31003)]
+
+        router_args = SimpleNamespace(disable_retries=False, disable_circuit_breaker=False)
+        with patch("smg.serve.RouterArgs.from_cli_args", return_value=router_args):
+            result = orch._build_router_args()
+
+        assert result.disable_retries is False
+        assert result.disable_circuit_breaker is False
+
+    def test_build_router_args_dp1_respects_explicit_disable(self):
+        """dp=1 auto-disable is a no-op when user already disabled retries/cb."""
+        from types import SimpleNamespace
+
+        args = _make_args(data_parallel_size=1)
+        orch = ServeOrchestrator("sglang", args, ["--model-path", "/tmp/model"])
+        orch.workers = [(MagicMock(), 31000)]
+
+        router_args = SimpleNamespace(disable_retries=True, disable_circuit_breaker=True)
+        with patch("smg.serve.RouterArgs.from_cli_args", return_value=router_args):
+            result = orch._build_router_args()
+
+        assert result.disable_retries is True
+        assert result.disable_circuit_breaker is True
 
     def test_cleanup_workers_handles_already_dead_process(self):
         args = _make_args()


### PR DESCRIPTION
## Summary

- In the Python bindings `serve` command, auto-disable router-level `disable_retries` and `disable_circuit_breaker` when `--data-parallel-size` (aka `--dp-size`) is 1 or left at its default. Retry/CB logic was recently enabled at the per-worker level, so keeping router-level resilience on for single-worker setups stacks two layers of handling on top of each other with no benefit.
- The override lives inside `ServeOrchestrator._build_router_args()` so the existing CLI surface is untouched and non-serve callers of `RouterArgs` (`launch_router`, direct `Router` construction) keep their current defaults.
- Explicit user input still wins: if the operator passes `--router-disable-retries` or `--router-disable-circuit-breaker`, the auto-flip is skipped and we just log the already-disabled state through.

## What changed

- `bindings/python/src/smg/serve.py`
  - `ServeOrchestrator._build_router_args()` now checks `self.args.data_parallel_size <= 1` after constructing `RouterArgs`. When true, it sets `disable_retries=True` and `disable_circuit_breaker=True` on the router args and emits an `INFO` log line for each flip so worker startup output makes the behavior auditable. No-op whenever the user already disabled either flag explicitly.
- `bindings/python/tests/test_serve.py`
  - Added 3 `TestServeOrchestrator` cases:
    - `test_build_router_args_dp1_disables_retries_and_cb` — dp=1 with both flags initially False → both flipped to True and worker URLs still injected.
    - `test_build_router_args_dp2_preserves_retries_and_cb` — dp=2 → the auto-flip branch is not entered; flags remain False.
    - `test_build_router_args_dp1_respects_explicit_disable` — dp=1 with both flags already True → no-op, flags remain True.
  - Extended the `_make_args` fixture with `router_disable_circuit_breaker=False` to mirror the new code path.

## Why

Router-level retries and circuit breaker were useful when the router was the only place resilience was enforced. We recently moved that logic down to the per-worker layer so every worker handles its own failures. For single-worker setups (which is the default `serve` configuration with `dp=1`), that means the router-level retry loop and circuit breaker no longer add value — they just duplicate work and can mask per-worker failure signals. Flipping the serve defaults so `dp<=1` ships with these off brings fresh `smg serve` invocations in line with the new per-worker resilience model and keeps single-worker behavior predictable out of the box.

## How

- Applied the override inside `_build_router_args()` rather than `parse_serve_args()` so the CLI parser remains a pure translation layer and the new default only applies to the `serve` orchestrator path. This deliberately avoids changing `RouterArgs` defaults or `launch_router`, since those are used by callers beyond `serve`.
- Guarded each flip with `if not router_args.disable_retries` / `if not router_args.disable_circuit_breaker` so we never clobber explicit user intent and only log when the default actually changes state.
- Emitted `INFO` logs for each auto-flip, including the observed `dp` value and the rationale (per-worker resilience handles failures), so operators debugging worker startup can see exactly why the router flags were suppressed.

## Test plan

- [x] Added 3 unit tests in `TestServeOrchestrator` that patch `RouterArgs.from_cli_args` to return a `SimpleNamespace` and assert the expected flag state for dp=1 auto-disable, dp=2 pass-through, and dp=1 explicit-disable no-op.
- [x] Ran `pytest tests/test_serve.py::TestServeOrchestrator` against the Python bindings — all 13 orchestrator tests pass (10 existing + 3 new).
- [x] Pre-commit hooks (ruff, ruff format, codespell, trailing-whitespace, end-of-file-fixer, mixed-line-ending, etc.) run clean on both modified files.
- [ ] Manual smoke: `smg serve --backend sglang --model-path <m>` with no `--dp-size` should log the two new `disabling router-level ...` info lines and start successfully — left for reviewer validation on a GPU box.

Refs: per-worker retry/circuit-breaker enablement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic configuration optimization: Router-level retry and circuit breaker controls are now automatically disabled when deploying the system with a single worker process, reducing unnecessary overhead with detailed logging for monitoring.

* **Tests**
  * Added comprehensive test coverage validating automatic control disable behavior for single-process deployments and verifying that multi-process deployments correctly preserve user-specified configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->