### PR TITLE
 Optimize TTFT in PD Disaggregation: Decouple prefill response and decode streaming

### DIFF
--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -626,110 +626,209 @@ impl PDRouter {
             false,
         );
 
-        // Send both requests concurrently and wait for both
-        // Note: Using borrowed references avoids heap allocation
+        // Send both requests concurrently
         events::RequestPDSentEvent {
             prefill_url: prefill.url(),
             decode_url: decode.url(),
         }
         .emit();
 
-        // Send both requests concurrently. Use try_join so that if either side
-        // hits a transport error, the other is cancelled immediately — otherwise
-        // the surviving request hangs waiting for a PD bootstrap that will never
-        // come (see #831).
-        let pd_result = tokio::try_join!(prefill_request.send(), decode_request.send());
+        // TTFT Optimization: For streaming requests without logprobs (the common case),
+        // fire prefill in background and only await decode's response.
+        // This avoids blocking the decode stream proxy on prefill's HTTP response latency.
+        if context.is_stream && !context.return_logprob {
+            // Send prefill request in background — don't block decode's stream on it
+            let prefill_url_for_log = prefill.url().to_string();
+            #[expect(
+                clippy::disallowed_methods,
+                reason = "fire-and-forget prefill; gateway shutdown need not wait for prefill response"
+            )]
+            tokio::spawn(async move {
+                match prefill_request.send().await {
+                    Ok(res) => {
+                        let status = res.status();
+                        if !status.is_success() {
+                            error!(
+                                "Prefill server returned error (background) prefill_url={} status={}",
+                                prefill_url_for_log, status
+                            );
+                        }
+                        // Consume response body to release the HTTP connection back to pool
+                        let _ = res.bytes().await;
+                    }
+                    Err(e) => {
+                        error!(
+                            "Prefill request failed (background) prefill_url={} error={}",
+                            prefill_url_for_log, e
+                        );
+                    }
+                }
+            });
 
-        events::RequestReceivedEvent {}.emit();
+            // Only await decode response — start proxying immediately
+            let decode_result = decode_request.send().await;
 
-        let (prefill_response, decode_response) = match pd_result {
-            Ok((prefill_resp, decode_resp)) => (prefill_resp, decode_resp),
-            Err(e) => {
-                error!("PD request transport error, both sides aborted: {e}");
-                // Don't record_outcome here — the caller (execute_dual_dispatch)
-                // records outcomes from the response status after we return.
-                return error::bad_gateway(
-                    "PD disaggregation request failed",
-                    format!("Transport error: {e}"),
-                );
+            events::RequestReceivedEvent {}.emit();
+
+            match decode_result {
+                Ok(res) => {
+                    let status = StatusCode::from_u16(res.status().as_u16())
+                        .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+                    debug!("Decode response status (fast path): {}", status);
+
+                    if !status.is_success() {
+                        error!(
+                            "Decode server returned error decode_url={} status={}",
+                            decode.url(),
+                            status
+                        );
+                        return self
+                            .handle_decode_error_response(res, &context, prefill, decode)
+                            .await;
+                    }
+
+                    let response_headers = header_utils::preserve_response_headers(res.headers());
+
+                    self.create_streaming_response(
+                        res.bytes_stream(),
+                        status,
+                        None,
+                        false,
+                        None,
+                        Some(response_headers),
+                        prefill,
+                        decode,
+                    )
+                }
+                Err(e) => {
+                    error!(
+                        decode_url = %decode.url(),
+                        error = %e,
+                        "Decode request failed"
+                    );
+                    error::bad_gateway(
+                        "decode_server_error",
+                        format!("Decode server error: {}", e),
+                    )
+                }
             }
-        };
+        } else {
+            // Original path: wait for both prefill and decode responses.
+            // Used for non-streaming requests and streaming requests with logprobs
+            // (which need prefill's response body for logprob merging).
+            //
+            // Use try_join so that if either side hits a transport error, the other
+            // is cancelled immediately — otherwise the surviving request hangs
+            // waiting for a PD bootstrap that will never come (see #831).
+            let pd_result = tokio::try_join!(prefill_request.send(), decode_request.send());
 
-        // Process decode response
-        let status = StatusCode::from_u16(decode_response.status().as_u16())
-            .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
-        debug!("Decode response status: {}", status);
+            events::RequestReceivedEvent {}.emit();
 
-        if !status.is_success() {
-            error!(
-                "Decode server returned error status decode_url={} status={}",
-                decode.url(),
-                status
-            );
-
-            return self
-                .handle_decode_error_response(decode_response, &context, prefill, decode)
-                .await;
-        }
-
-        // Process prefill response
-        let prefill_body = match self
-            .process_prefill_response(prefill_response, prefill.url(), context.return_logprob)
-            .await
-        {
-            Ok((_, body)) => body,
-            Err(error_response) => return error_response,
-        };
-
-        if context.is_stream {
-            // Streaming response
-            let prefill_logprobs = if context.return_logprob {
-                prefill_body
-                    .as_ref()
-                    .and_then(|body| serde_json::from_slice::<Value>(body).ok())
-                    .and_then(|json| json.pointer("/meta_info/input_token_logprobs").cloned())
-            } else {
-                None
+            let (prefill_response, decode_response) = match pd_result {
+                Ok((prefill_resp, decode_resp)) => (prefill_resp, decode_resp),
+                Err(e) => {
+                    error!("PD request transport error, both sides aborted: {e}");
+                    // Don't record_outcome here — the caller (execute_dual_dispatch)
+                    // records outcomes from the response status after we return.
+                    return error::bad_gateway(
+                        "PD disaggregation request failed",
+                        format!("Transport error: {e}"),
+                    );
+                }
             };
 
-            let response_headers =
-                header_utils::preserve_response_headers(decode_response.headers());
+            // Process decode response
+            let status = StatusCode::from_u16(decode_response.status().as_u16())
+                .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+            debug!("Decode response status: {}", status);
 
-            self.create_streaming_response(
-                decode_response.bytes_stream(),
-                status,
-                prefill_logprobs,
-                context.return_logprob,
-                None,
-                Some(response_headers),
-                prefill,
-                decode,
-            )
-        } else {
-            // Non-streaming response
-            if context.return_logprob {
-                self.process_non_streaming_response(
-                    decode_response,
-                    status,
-                    context.return_logprob,
-                    prefill_body,
-                )
-                .await
+            if !status.is_success() {
+                error!(
+                    "Decode server returned error status decode_url={} status={}",
+                    decode.url(),
+                    status
+                );
+
+                return self
+                    .handle_decode_error_response(decode_response, &context, prefill, decode)
+                    .await;
+            }
+
+            // Process prefill response
+            let prefill_body = if context.return_logprob {
+                match self
+                    .process_prefill_response(
+                        prefill_response,
+                        prefill.url(),
+                        context.return_logprob,
+                    )
+                    .await
+                {
+                    Ok((_, body)) => body,
+                    Err(error_response) => return error_response,
+                }
             } else {
-                // Direct passthrough when no logprobs needed
+                // Even if we don't need logprobs, we should check prefill status
+                match self
+                    .process_prefill_response(prefill_response, prefill.url(), false)
+                    .await
+                {
+                    Ok((_, body)) => body,
+                    Err(error_response) => return error_response,
+                }
+            };
+
+            if context.is_stream {
+                // Streaming response with logprobs
+                let prefill_logprobs = prefill_body
+                    .as_ref()
+                    .and_then(|body| serde_json::from_slice::<Value>(body).ok())
+                    .and_then(|json| {
+                        json.pointer("/meta_info/input_token_logprobs").cloned()
+                    });
+
                 let response_headers =
                     header_utils::preserve_response_headers(decode_response.headers());
 
-                match decode_response.bytes().await {
-                    Ok(decode_body) => {
-                        let mut response = Response::new(Body::from(decode_body));
-                        *response.status_mut() = status;
-                        *response.headers_mut() = response_headers;
-                        response
-                    }
-                    Err(e) => {
-                        error!("Failed to read decode response: {}", e);
-                        error::internal_error("read_response_failed", "Failed to read response")
+                self.create_streaming_response(
+                    decode_response.bytes_stream(),
+                    status,
+                    prefill_logprobs,
+                    context.return_logprob,
+                    None,
+                    Some(response_headers),
+                    prefill,
+                    decode,
+                )
+            } else {
+                // Non-streaming response
+                if context.return_logprob {
+                    self.process_non_streaming_response(
+                        decode_response,
+                        status,
+                        context.return_logprob,
+                        prefill_body,
+                    )
+                    .await
+                } else {
+                    // Direct passthrough when no logprobs needed
+                    let response_headers =
+                        header_utils::preserve_response_headers(decode_response.headers());
+
+                    match decode_response.bytes().await {
+                        Ok(decode_body) => {
+                            let mut response = Response::new(Body::from(decode_body));
+                            *response.status_mut() = status;
+                            *response.headers_mut() = response_headers;
+                            response
+                        }
+                        Err(e) => {
+                            error!("Failed to read decode response: {}", e);
+                            error::internal_error(
+                                "read_response_failed",
+                                "Failed to read response",
+                            )
+                        }
                     }
                 }
             }

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -706,10 +706,7 @@ impl PDRouter {
                         error = %e,
                         "Decode request failed"
                     );
-                    error::bad_gateway(
-                        "decode_server_error",
-                        format!("Decode server error: {e}"),
-                    )
+                    error::bad_gateway("decode_server_error", format!("Decode server error: {e}"))
                 }
             }
         } else {
@@ -783,9 +780,7 @@ impl PDRouter {
                 let prefill_logprobs = prefill_body
                     .as_ref()
                     .and_then(|body| serde_json::from_slice::<Value>(body).ok())
-                    .and_then(|json| {
-                        json.pointer("/meta_info/input_token_logprobs").cloned()
-                    });
+                    .and_then(|json| json.pointer("/meta_info/input_token_logprobs").cloned());
 
                 let response_headers =
                     header_utils::preserve_response_headers(decode_response.headers());
@@ -824,10 +819,7 @@ impl PDRouter {
                         }
                         Err(e) => {
                             error!("Failed to read decode response: {}", e);
-                            error::internal_error(
-                                "read_response_failed",
-                                "Failed to read response",
-                            )
+                            error::internal_error("read_response_failed", "Failed to read response")
                         }
                     }
                 }

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -708,7 +708,7 @@ impl PDRouter {
                     );
                     error::bad_gateway(
                         "decode_server_error",
-                        format!("Decode server error: {}", e),
+                        format!("Decode server error: {e}"),
                     )
                 }
             }


### PR DESCRIPTION
## Description

### Problem
This PR improves the TTFT of PD HTTP routing in the common streaming path.
In the previous implementation of `execute_dual_dispatch_internal`, the router waited for both prefill and decode HTTP responses before starting to proxy the decode stream. This adds avoidable latency to the first streamed token for the common case where:
* the request is streaming, and
* input logprobs are not requested.
Since input logprob merging is only needed when return_logprob=true, waiting for the prefill HTTP response in the no-logprob streaming path does not provide value on the critical path, but does delay stream startup.

The goal of this PR is to reduce that overhead and improve end-to-end streaming responsiveness in PD mode.


### Solution


This PR updates the PD HTTP router in pd_router.rs:

* Added a fast path in [execute_dual_dispatch_internal()](vscode-webview://03hgedb0gcobonia4pisqfi8qgriano10tbqlibain2qjqsl3mib/sgl-model-gateway/src/routers/http/pd_router.rs:533-794) for: context.is_stream == true context.return_logprob == false
* In this fast path: the prefill request is dispatched in the background; the router only waits for the decode response,
decode streaming is proxied to the client as soon as the decode side is ready.
* Kept the original behavior for: non-streaming requests and streaming requests with logprobs
* Preserved prefill response consumption in the background path so the HTTP connection can still be released back to the pool.
* Kept logprob-dependent behavior unchanged by continuing to use `process_prefill_response()` and the original dual-response path when return_logprob=true.

In short, this change narrows the optimization to the most common latency-sensitive streaming scenario while keeping the logprob path and non-streaming path behavior unchanged.



## Test Plan

<!-- Provide a thorough reproducible test showing before and after behavior. -->

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized streaming request handling for improved response delivery times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->