### PR TITLE
docs(entrypoints): audit and fix top-level navigation, README, and getting-started

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ smg --worker-urls http://localhost:8000
 smg --worker-urls http://gpu1:8000 http://gpu2:8000 --policy cache_aware
 
 # With high availability mesh
-smg --worker-urls http://gpu1:8000 --ha-mesh --seeds 10.0.0.2:30001,10.0.0.3:30001
+smg --worker-urls http://gpu1:8000 --enable-mesh \
+  --mesh-advertise-host 10.0.0.1 --mesh-peer-urls 10.0.0.2:39527
 ```
 
 **Use** — send requests to the gateway:

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -10,7 +10,7 @@ Shepherd Model Gateway (SMG) routes and manages LLM traffic across workers. This
 
 === "pip (recommended)"
 
-    Pre-built wheels are available for Linux (x86_64, aarch64, musllinux), macOS (Apple Silicon), and Windows (x86_64), with Python 3.9–3.14.
+    Pre-built wheels are available for Linux (x86_64, aarch64, musllinux), macOS (Intel and Apple Silicon), and Windows (x86_64), with Python 3.9–3.14.
 
     ```bash
     pip install smg
@@ -37,7 +37,7 @@ Shepherd Model Gateway (SMG) routes and manages LLM traffic across workers. This
     docker pull lightseekorg/smg:latest
     ```
 
-    Available tags: `latest` (stable), `v1.3.x` (specific version), `nightly` (development, from `ghcr.io/lightseekorg/smg:nightly`).
+    Available tags: `latest` (stable), `v1.4.x` (specific version), `nightly` (development, from `ghcr.io/lightseekorg/smg:nightly`).
 
     **SMG + Engine** (all-in-one, ready to serve models):
 
@@ -45,13 +45,13 @@ Shepherd Model Gateway (SMG) routes and manages LLM traffic across workers. This
 
     ```bash
     # SGLang
-    docker pull ghcr.io/lightseekorg/smg:1.3.3-sglang-v0.5.9
+    docker pull ghcr.io/lightseekorg/smg:1.4.1-sglang-v0.5.10
 
     # vLLM
-    docker pull ghcr.io/lightseekorg/smg:1.3.3-vllm-v0.18.0
+    docker pull ghcr.io/lightseekorg/smg:1.4.1-vllm-v0.19.0
 
     # TensorRT-LLM
-    docker pull ghcr.io/lightseekorg/smg:1.3.3-trtllm-1.3.0rc8
+    docker pull ghcr.io/lightseekorg/smg:1.4.1-trtllm-1.3.0rc10
     ```
 
     Tag format: `{smg_version}-{engine}-{engine_version}`. Browse all tags at [ghcr.io/lightseekorg/smg](https://github.com/lightseekorg/smg/pkgs/container/smg).
@@ -247,7 +247,7 @@ Use these when workers are not started via `smg serve`.
 === "TensorRT-LLM (gRPC)"
 
     ```bash
-    python -m tensorrt_llm.commands.serve serve \
+    python -m tensorrt_llm.commands.serve \
       meta-llama/Llama-3.1-8B-Instruct \
       --grpc \
       --host 0.0.0.0 \
@@ -443,7 +443,7 @@ docker run -d --gpus all \
   --name smg \
   -p 30000:30000 \
   -v /path/to/models:/models \
-  ghcr.io/lightseekorg/smg:1.3.3-sglang-v0.5.9 \
+  ghcr.io/lightseekorg/smg:1.4.1-sglang-v0.5.10 \
   serve \
   --backend sglang \
   --model-path /models/meta-llama/Llama-3.1-8B-Instruct \

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -115,7 +115,7 @@ markdown_extensions:
   - pymdownx.magiclink:
       normalize_issue_symbols: true
       repo_url_shorthand: true
-      user: your-org
+      user: lightseekorg
       repo: smg
   - pymdownx.mark
   - pymdownx.smartsymbols
@@ -194,6 +194,7 @@ nav:
           - Gateway Extensions: reference/api/extensions.md
       - Configuration: reference/configuration.md
       - Metrics: reference/metrics.md
+      - Internal MCP Servers: reference/mcp-internal-servers.md
   - Contributing:
       - contributing/index.md
       - Development Setup: contributing/development.md


### PR DESCRIPTION
## Description

### Problem
Top-level entry points (`README.md`, `docs/index.md`, MkDocs nav,
getting-started) had drifted from the current codebase. Some CLI
flags in examples were fabricated (`--ha-mesh --seeds` — not a real
flag), engine image tags were a major version behind, and a doc
page (`reference/mcp-internal-servers.md`) existed but was orphaned
from the nav.

### Solution
Systematic audit of 7 entry-point files against current source code
(`main.rs`, `Cargo.toml`, `bindings/python/pyproject.toml`,
`.github/workflows/release-*.yml`, `bindings/python/src/smg/serve.py`).
Writer phase produced a claim-by-claim audit with code citations;
Tech Lead phase independently re-verified every change.

## Changes
- Verified 59 claims across 7 doc files
- Fixed 5 inaccuracies (mesh CLI flags, macOS wheels, TRT-LLM
  command, engine image tags, magiclink user)
- Updated 2 outdated engine versions (sglang 0.5.10, vllm 0.19.0,
  trtllm 1.3.0rc10; tag prefix 1.3.3 → 1.4.1)
- Documented 1 previously orphaned page in the MkDocs nav
  (`reference/mcp-internal-servers.md`)
- Full audit report: `docs/_audit/team-1.md`

## Out-of-scope findings (for follow-up)
The Writer flagged but did not touch: `parse_policy` in
`model_gateway/src/main.rs:877-908` silently falls `consistent_hashing`
and `bucket` through to `RoundRobin`. This is a code-level CLI bug
discovered during the audit — tracked for a separate PR.

## Test plan
- [x] Every fix cites a source code file:line reference
- [x] No source code modified (verified `git diff origin/main -- '*.rs' 'Cargo*'`)
- [x] `mkdocs build --strict --clean` passes
- [x] Tech Lead independently verified every change against cited source

<details><summary>Checklist</summary>

- [x] Documentation updated
- [ ] (Optional) Join `#sig-smg` on Slack to discuss

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated mesh configuration guidance with new command-line options
  * Refreshed getting-started examples with latest service versions (v1.4.1)
  * Expanded platform support information to include Intel and Apple Silicon
  * Added new reference documentation for internal MCP servers

* **Bug Fixes**
  * Corrected TensorRT-LLM worker invocation example
<!-- end of auto-generated comment: release notes by coderabbit.ai -->