### PR TITLE
docs(reliability): audit and fix circuit breakers, rate limiting, health checks, graceful shutdown

### DIFF
--- a/docs/concepts/reliability/circuit-breakers.md
+++ b/docs/concepts/reliability/circuit-breakers.md
@@ -121,7 +121,7 @@ The circuit **opens** when:
 consecutive_failures >= failure_threshold
 ```
 
-Within the sliding window (`--cb-window-duration-secs`).
+A single successful request resets `consecutive_failures` to zero. `--cb-window-duration-secs` is accepted and validated but is not yet consumed by the state machine — failures are tracked via a running consecutive-failure counter rather than a sliding window.
 
 ### Open → Half-Open
 
@@ -155,7 +155,7 @@ smg \
 | `--cb-failure-threshold` | `10` | Consecutive failures before circuit opens |
 | `--cb-success-threshold` | `3` | Successes in half-open state to close circuit |
 | `--cb-timeout-duration-secs` | `60` | Seconds before open circuit transitions to half-open |
-| `--cb-window-duration-secs` | `120` | Sliding window for counting failures |
+| `--cb-window-duration-secs` | `120` | Accepted and validated (must be `> 0`) but not yet consumed by the state machine; see note under *Closed → Open* |
 | `--disable-circuit-breaker` | `false` | Disable circuit breakers entirely |
 
 ### Configuration Examples

--- a/docs/concepts/reliability/graceful-shutdown.md
+++ b/docs/concepts/reliability/graceful-shutdown.md
@@ -74,11 +74,11 @@ With graceful shutdown:
 
 ### Shutdown Sequence
 
-1. **Shutdown signal received** (SIGTERM, SIGINT, or API call)
-2. **Stop accepting new requests** - New connections are rejected with 503
-3. **Drain in-flight requests** - Existing requests continue processing
-4. **Grace period timer starts** - After `shutdown-grace-period-secs`, force shutdown
-5. **Clean exit** - Once all requests complete (or grace period expires)
+1. **Shutdown signal received** (SIGTERM or SIGINT). The mesh-only `/ha/shutdown` API triggers a separate mesh-level broadcast path and is not part of this signal-driven sequence.
+2. **Stop accepting new connections** — `axum_server`'s handle stops the TCP accept loop and marks the in-flight tracker as draining; new connections are refused at the socket level rather than receiving a 503 response.
+3. **Drain in-flight requests** — existing requests continue processing while the server waits on the in-flight tracker.
+4. **Grace period timer starts** — after `--shutdown-grace-period-secs`, the drain wait times out and the server forces shutdown with any remaining requests still in-flight.
+5. **Clean exit** — once all requests complete (or the grace period expires), background components (MCP orchestrator, etc.) are cleaned up and the process exits.
 
 ---
 
@@ -180,9 +180,11 @@ kill -INT <pid>
 ### Via API
 
 ```bash
-# Trigger graceful shutdown via HTTP
-curl -X POST http://gateway:3001/ha/shutdown
+# Trigger graceful shutdown via HTTP (mesh mode only)
+curl -X POST http://gateway:30000/ha/shutdown
 ```
+
+The `/ha/shutdown` endpoint lives on the main gateway port (default `30000`) and requires mesh mode (`--mesh-*` flags). Without mesh enabled the endpoint returns `503 Service Unavailable`. The mesh handler broadcasts a `LEAVING` status to peer nodes and stops the mesh rate-limit task — it does not share the same in-flight drain path used by the signal handler.
 
 ### Kubernetes Integration
 
@@ -260,17 +262,14 @@ The sleep allows the load balancer to stop sending new traffic before SMG begins
 
 ### Health Check Coordination
 
-During shutdown, SMG's health endpoint can return unhealthy to signal load balancers:
+SMG's `/health` (liveness) endpoint always returns `200 OK` — it does not switch to an unhealthy response during shutdown. To drain traffic cleanly, remove the pod from the load balancer before SMG begins its own drain (for example, with the Kubernetes `preStop` hook above, or an external control-plane deregister step).
 
 ```bash
-# Health check during normal operation
-curl http://gateway:3001/health
-# Returns 200 OK
-
-# During graceful shutdown
-curl http://gateway:3001/health
-# Returns 503 Service Unavailable
+curl http://gateway:30000/health
+# Returns 200 OK both during normal operation and throughout the drain
 ```
+
+`/readiness` can still return `503 Service Unavailable` when no healthy workers remain, but it reacts to worker state rather than to the shutdown signal itself.
 
 ---
 
@@ -280,19 +279,24 @@ curl http://gateway:3001/health
 
 Watch logs for shutdown-related messages:
 
-```bash
-# Graceful shutdown initiated
-[INFO] Received shutdown signal, starting graceful shutdown
-[INFO] Stopping new request acceptance
-[INFO] Waiting for 5 in-flight requests to complete
+```text
+# Signal received
+INFO Received Ctrl+C, starting graceful shutdown
+# or
+INFO Received terminate signal, starting graceful shutdown
 
-# Requests completing
-[INFO] In-flight requests: 5 -> 4
-[INFO] In-flight requests: 4 -> 3
-...
+# Gate — in-flight tracker is marked draining and the accept loop stops
+INFO Beginning graceful shutdown: gating new connections in_flight=5
 
-# Clean exit
-[INFO] All requests completed, shutting down
+# Drain completes within the grace period
+INFO All in-flight requests drained
+
+# Or the grace period expires with requests still running
+WARN Drain timed out, forcing shutdown with requests still in-flight remaining=2 timeout_secs=180
+
+# Component teardown
+INFO HTTP server stopped. Starting component cleanup...
+INFO Cleanup complete. Process exiting.
 ```
 
 ### Metrics During Shutdown

--- a/docs/concepts/reliability/health-checks.md
+++ b/docs/concepts/reliability/health-checks.md
@@ -72,18 +72,30 @@ SMG sends periodic HTTP requests to each worker's health endpoint:
   <img src="../../../assets/images/health-checks-flow.svg" alt="Health Check Sequence Diagram">
 </div>
 
-### Health States
+### Worker States
 
 | State | Meaning | Traffic |
 |-------|---------|---------|
-| **Healthy** | Passing health checks | Receives requests |
-| **Unhealthy** | Consecutive failures ≥ threshold | No requests |
+| **Pending** | Freshly registered, not yet verified | No requests |
+| **Ready** | Passing health checks | Receives requests |
+| **NotReady** | Consecutive probe failures reached the readiness threshold | No requests |
+| **Failed** | Consecutive failures reached the liveness threshold, or `Pending` ran out of probe attempts | Terminal — receives no requests and is not probed further |
+
+The `smg_worker_health` gauge collapses these to `1` (Ready) and `0` (anything else), so existing dashboards continue to work.
 
 ### State Transitions
 
-**Healthy → Unhealthy**: When consecutive failed health checks reach `--health-failure-threshold`
+**Pending → Ready**: When consecutive successful probes reach `--health-success-threshold`.
 
-**Unhealthy → Healthy**: When consecutive successful health checks reach `--health-success-threshold`
+**Pending → Failed**: If the worker accumulates `10 × failure_threshold` total probes without ever reaching the success threshold (prevents misconfigured URLs from lingering forever).
+
+**Ready → NotReady**: When consecutive failed probes reach `--health-failure-threshold`.
+
+**NotReady → Ready**: When consecutive successful probes reach `--health-success-threshold`.
+
+**NotReady → Failed**: When consecutive failures reach `3 × --health-failure-threshold` (the liveness threshold — analogous to a Kubernetes liveness probe, tolerating longer outages than the readiness threshold).
+
+**Failed is terminal**: Successful probes do not recover a `Failed` worker. A failed worker is removed via `--remove-unhealthy-workers` or requires manual re-registration.
 
 ---
 
@@ -109,7 +121,7 @@ smg \
 | `--health-check-timeout-secs` | `5` | Timeout for each health check request |
 | `--health-check-endpoint` | `/health` | Endpoint path for health checks |
 | `--disable-health-check` | `false` | Disable background health checks |
-| `--remove-unhealthy-workers` | `false` | Remove workers after being marked unhealthy |
+| `--remove-unhealthy-workers` | `false` | Submit a removal job when a worker reaches the terminal `Failed` state |
 
 ---
 

--- a/docs/concepts/reliability/rate-limiting.md
+++ b/docs/concepts/reliability/rate-limiting.md
@@ -99,8 +99,8 @@ smg \
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `--max-concurrent-requests` | `-1` (unlimited) | Maximum concurrent requests |
-| `--rate-limit-tokens-per-second` | none | Token refill rate (only active when explicitly set) |
+| `--max-concurrent-requests` | `-1` (disabled) | Token bucket capacity. When `<= 0` the limiter is disabled entirely and requests pass through. |
+| `--rate-limit-tokens-per-second` | unset (refills at `max_concurrent_requests`) | Token bucket refill rate in tokens per second. |
 | `--queue-size` | `100` | Maximum queued requests |
 | `--queue-timeout-secs` | `60` | Maximum queue wait time |
 
@@ -113,7 +113,7 @@ smg \
 | `--worker-startup-timeout-secs` | `1800` (30 min) | Timeout for worker startup/model loading |
 
 !!! note "Concurrency vs. Rate Limiting"
-    Setting `--max-concurrent-requests` alone enables **concurrency limiting** (bounds simultaneous requests). To enable **rate limiting** (bounds requests per second using a token bucket), you must explicitly set `--rate-limit-tokens-per-second`.
+    Setting `--max-concurrent-requests` alone creates a token bucket whose capacity *and* refill rate both equal `max_concurrent_requests`, so it enforces both burst capacity and a sustained rate. Set `--rate-limit-tokens-per-second` when you want the sustained rate to differ from the burst capacity (for example, capacity `100` with refill `50` allows short bursts of 100 while sustaining 50 req/s).
 
 ---
 
@@ -121,32 +121,18 @@ smg \
 
 | Code | Meaning | When |
 |------|---------|------|
-| **429** | Too Many Requests | Queue is full |
+| **429** | Too Many Requests | Queue is full, or queuing is disabled and no token is available |
 | **408** | Request Timeout | Queue wait exceeded timeout |
 
-### 429 Response
+The local rate limiter returns a status-only response with no JSON body (clients should read the HTTP status and `X-Request-Id` to distinguish cases). SMG does not currently emit a `Retry-After` header with the response.
+
+When the mesh global rate limit is enabled and exceeded, the 429 response carries a JSON body:
 
 ```json
 {
-  "error": {
-    "message": "Rate limit exceeded. Please retry later.",
-    "type": "rate_limit_error",
-    "code": "rate_limit_exceeded"
-  }
-}
-```
-
-Includes `Retry-After` header with recommended wait time.
-
-### 408 Response
-
-```json
-{
-  "error": {
-    "message": "Request timed out waiting in queue.",
-    "type": "timeout_error",
-    "code": "queue_timeout"
-  }
+  "error": "Rate limit exceeded",
+  "current_count": 123,
+  "limit": 100
 }
 ```
 
@@ -287,7 +273,7 @@ histogram_quantile(0.99,
 
 ### Retry Strategy
 
-Clients should implement exponential backoff when receiving 429:
+Clients should implement exponential backoff when receiving 429. SMG does not set a `Retry-After` header today, so clients must compute their own wait:
 
 ```python
 import time
@@ -298,8 +284,8 @@ def request_with_retry(url, data, max_retries=5):
         response = requests.post(url, json=data)
 
         if response.status_code == 429:
-            retry_after = int(response.headers.get('Retry-After', 2 ** attempt))
-            time.sleep(retry_after)
+            # SMG does not emit Retry-After; fall back to exponential backoff.
+            time.sleep(2 ** attempt)
             continue
 
         return response


### PR DESCRIPTION
## Description

### Problem
The reliability documentation had drifted from the current gateway
implementation: the circuit-breaker page promised sliding-window
semantics for a flag that is parsed and validated but never consumed
by the state machine; rate-limiting claimed structured JSON error
bodies and a `Retry-After` header that the middleware never emits;
health-checks described a 2-state Healthy/Unhealthy model that no
longer exists in `WorkerManager`; and graceful-shutdown described a
5-step sequence, default port, and log lines that did not match the
signal-driven `axum_server` + `InflightTracker` code path.

### Solution
Systematic audit of the reliability docs against the actual source in
`model_gateway/src/worker/{circuit_breaker,manager}.rs`,
`model_gateway/src/middleware/{concurrency,token_bucket}.rs`,
`model_gateway/src/routers/common/retry.rs`,
`model_gateway/src/server.rs` (shutdown phases + signal handler),
`model_gateway/src/routers/mesh/handlers.rs`,
`model_gateway/src/observability/{metrics,inflight_tracker}.rs`, and
`model_gateway/src/config/{types,validation}.rs`. Every surviving
claim was cross-checked against a specific line in code; every edit
is backed by a code reference. Changes were reviewed by a fresh Tech
Lead context that independently re-verified each citation before the
commit.

## Changes

- **`docs/concepts/reliability/circuit-breakers.md`**
  - Rewrote the "Closed -> Open" prose. The circuit opens on
    `consecutive_failures >= failure_threshold` tracked by an atomic
    counter that is reset by any success; there is no sliding window
    despite `--cb-window-duration-secs` existing as a flag
    (`model_gateway/src/worker/circuit_breaker.rs:221-263`).
  - Updated the `--cb-window-duration-secs` row in the parameters
    table to state that the value is accepted and validated
    (`>0`) but not yet consumed by the state machine
    (`model_gateway/src/config/validation.rs:570-576`).

- **`docs/concepts/reliability/rate-limiting.md`**
  - Corrected the `--max-concurrent-requests` description:
    `n <= 0` disables the limiter entirely and requests pass through
    (`model_gateway/src/app_context.rs:461-476`).
  - Corrected the `--rate-limit-tokens-per-second` default: when
    unset, the refill rate defaults to `max_concurrent_requests`
    (`model_gateway/src/app_context.rs:465-472`).
  - Rewrote the "Concurrency vs. Rate Limiting" callout: a token
    bucket is always created when `max_concurrent_requests > 0`, so
    setting only that flag gives you both capacity and sustained
    rate equal to that value
    (`model_gateway/src/middleware/token_bucket.rs:32-96`).
  - Replaced the fictional 429/408 JSON error bodies with a plain
    description: the local limiter returns a status-only response,
    and only the mesh-global path emits JSON
    (`{"error", "current_count", "limit"}`, `model_gateway/src/middleware/concurrency.rs:217-299`).
  - Removed the non-existent `Retry-After` header claim and
    updated the Python example to fall back to exponential backoff.
    `grep -r "Retry-After\|retry_after" model_gateway/src/` returns
    no matches.

- **`docs/concepts/reliability/health-checks.md`**
  - Replaced the 2-state (Healthy/Unhealthy) model with the real
    4-state machine `Pending`/`Ready`/`NotReady`/`Failed`
    (`model_gateway/src/worker/manager.rs:565-645`).
  - Documented all six transitions including the liveness
    threshold (`3 x failure_threshold`) for `NotReady -> Failed`
    and the pending cap (`10 x failure_threshold`) for
    `Pending -> Failed`, plus the fact that `Failed` is terminal.
  - Added a note that the `smg_worker_health` gauge collapses all
    non-`Ready` states to `0`
    (`model_gateway/src/observability/metrics.rs:942-949`).
  - Clarified `--remove-unhealthy-workers`: removal is only
    submitted on the `Failed` transition, not on `NotReady`
    (`model_gateway/src/worker/manager.rs:494-498`).

- **`docs/concepts/reliability/graceful-shutdown.md`**
  - Rewrote the 5-step shutdown sequence against the real code: the
    mesh-only `/ha/shutdown` branch is called out separately, the
    TCP accept loop is stopped via `axum_server::Handle::graceful_shutdown`
    (no 503 body), and clean exit performs background component
    teardown (`model_gateway/src/server.rs:1262-1328`).
  - Fixed the curl example port from `3001` to the real default
    `30000` (`model_gateway/src/main.rs:143-144`) and added a note
    that `/ha/shutdown` requires mesh mode and returns `503 Service
    Unavailable` with `{"error":"mesh not enabled"}` otherwise
    (`model_gateway/src/routers/mesh/handlers.rs:425-435`).
  - Removed the false claim that `/health` returns 503 during
    shutdown. `health()` delegates to `liveness()`, which is hard
    coded to `(StatusCode::OK, "OK")` regardless of shutdown state
    (`model_gateway/src/server.rs:105-107,155-157`). Documented the
    LB pre-stop hook pattern as the correct traffic-drain mechanism
    and noted that `/readiness` still depends on worker state.
  - Replaced the fictional log lines with the actual `tracing`
    strings from `model_gateway/src/server.rs:1266-1289,1317-1324,1352-1359`
    (`Received Ctrl+C, starting graceful shutdown`, `Beginning
    graceful shutdown: gating new connections in_flight=N`, `All
    in-flight requests drained`, `Drain timed out, forcing shutdown
    with requests still in-flight remaining=N timeout_secs=N`,
    `HTTP server stopped. Starting component cleanup...`, `Cleanup
    complete. Process exiting.`).

## Out-of-scope findings (for follow-up, NOT fixed in this PR)

- **`model_gateway/src/worker/circuit_breaker.rs`**:
  `CircuitBreakerConfig::window_duration` is currently a dead field.
  It is declared, defaulted, validated (`>0`), and plumbed all the
  way through `main.rs`, `RouterConfig`, `workflow/steps/.../create_worker.rs`,
  and `resilience.rs`, but no state-machine method reads it. This
  PR documents the current behavior rather than silently removing
  the flag; a follow-up engineering decision is needed to either
  implement the sliding-window algorithm or deprecate the flag.
- **`docs/reference/api/openai.md:371`** still lists `Retry-After`
  as a response header. This file is owned by Team 7 (API reference)
  and is intentionally left untouched by this PR.

## Test Plan

- [x] Every fix in this PR cites a specific source file and line
      (`file.rs:LINE`).
- [x] No source code was modified (`git diff origin/main -- '*.rs' 'Cargo*' 'crates/**' 'model_gateway/**'` is empty).
- [x] Circuit breaker state-machine claims re-verified against
      `model_gateway/src/worker/circuit_breaker.rs:221-263`
      (`record_success`, `record_failure`, `transition_to`).
- [x] Rate-limiter paths re-verified against
      `model_gateway/src/app_context.rs:461-476` and
      `model_gateway/src/middleware/concurrency.rs:130-299`.
- [x] Four-state health machine re-verified against
      `model_gateway/src/worker/manager.rs:494-645` and
      `model_gateway/src/observability/metrics.rs:942-949`.
- [x] Shutdown sequence re-verified against
      `model_gateway/src/server.rs:105-157,1262-1360`,
      `model_gateway/src/routers/mesh/handlers.rs:425-451`, and
      `model_gateway/src/main.rs:143-144`.
- [x] `grep -r "Retry-After\|retry_after" model_gateway/src/` -> no
      matches.
- [x] `mkdocs build --strict --clean --quiet` exits 0.
- [x] All internal `.md` cross-references in
      `docs/concepts/reliability/` still resolve after the edits.

<details>
<summary>Checklist</summary>

- [x] Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated circuit-breaker failure evaluation semantics for the Closed → Open transition.
  * Clarified graceful shutdown sequence, emphasizing signal-driven termination and socket-level connection handling.
  * Refined health-check state model and worker transition behavior for readiness and liveness semantics.
  * Revised rate-limiting token-bucket defaults and HTTP 429 response behavior, including client retry guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->