### PR TITLE
docs(routing): audit and fix PD disaggregation, routing policies, gRPC pipeline

### DIFF
--- a/docs/concepts/architecture/grpc-pipeline.md
+++ b/docs/concepts/architecture/grpc-pipeline.md
@@ -99,7 +99,6 @@ Reasoning parsers extract chain-of-thought content from model outputs. Essential
 
 | Option | `--reasoning-parser` |
 |--------|---------------------|
-| Environment | `SMG_REASONING_PARSER` |
 | Default | Auto-detected from model name |
 
 ### Supported Parsers
@@ -202,7 +201,6 @@ Tool call parsers extract function calls from model output and validate argument
 
 | Option | `--tool-call-parser` |
 |--------|----------------|
-| Environment | `SMG_TOOL_CALL_PARSER` |
 | Default | Auto-detected from model name |
 
 ### Supported Parsers
@@ -376,10 +374,7 @@ smg \
 
 | Metric | Description |
 |--------|-------------|
-| `smg_pipeline_stage_duration_seconds` | Time spent in each pipeline stage |
-| `smg_reasoning_extractions_total` | Reasoning tokens extracted |
-| `smg_tool_calls_total` | Tool calls parsed by type |
-| `smg_tool_execution_duration_seconds` | Tool execution time |
+| `smg_router_stage_duration_seconds` | Time spent in each pipeline stage |
 | `smg_mcp_tool_calls_total` | MCP tool invocations |
 
 ### Debug Logging

--- a/docs/concepts/routing/cache-aware.md
+++ b/docs/concepts/routing/cache-aware.md
@@ -152,8 +152,8 @@ Cache-aware routing operates in two states based on system load:
 When workers are evenly loaded:
 
 1. Search radix tree for longest matching prefix
-2. If match ratio ≥ `cache-threshold` → route to matched worker
-3. If match ratio < threshold → route to worker with most cache capacity
+2. If match ratio > `cache-threshold` → route to matched worker
+3. If match ratio ≤ threshold → route to least-loaded healthy worker
 
 **Goal**: Maximize KV cache hit rate
 

--- a/docs/concepts/routing/pd-disaggregation.md
+++ b/docs/concepts/routing/pd-disaggregation.md
@@ -209,8 +209,8 @@ Use label selectors to automatically discover prefill and decode workers.
 smg \
   --service-discovery \
   --pd-disaggregation \
-  --prefill-selector "app=sglang,role=prefill" \
-  --decode-selector "app=sglang,role=decode" \
+  --prefill-selector app=sglang role=prefill \
+  --decode-selector app=sglang role=decode \
   --service-discovery-namespace inference
 ```
 
@@ -440,8 +440,8 @@ curl http://smg:3001/workers | jq '.[] | {url, role}'
 smg \
   --service-discovery \
   --pd-disaggregation \
-  --prefill-selector "app=sglang,role=prefill" \
-  --decode-selector "app=sglang,role=decode" \
+  --prefill-selector app=sglang role=prefill \
+  --decode-selector app=sglang role=decode \
   --prefill-policy cache_aware \
   --decode-policy power_of_two \
   --cb-failure-threshold 3 \

--- a/docs/getting-started/load-balancing.md
+++ b/docs/getting-started/load-balancing.md
@@ -51,7 +51,7 @@ smg \
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `--cache-threshold` | `0.3` | Minimum prefix match ratio (0.0–1.0) to route to highest-match worker. Below this, routes to worker with most available cache space |
+| `--cache-threshold` | `0.3` | Minimum prefix match ratio (0.0–1.0) to route to highest-match worker. At or below this threshold, routes to the least-loaded healthy worker |
 | `--balance-abs-threshold` | `64` | Absolute load difference threshold — triggers load balancing when exceeded |
 | `--balance-rel-threshold` | `1.5` | Relative load ratio threshold — triggers load balancing when max_load > min_load × ratio |
 | `--eviction-interval` | `120` | Seconds between LRU eviction cycles for the radix trees |


### PR DESCRIPTION
## Description

### Problem
Documentation for PD disaggregation, routing policies, and the gRPC
pipeline had drifted from the current `model_gateway` codebase. The
cache-aware routing description used the wrong threshold operator and
the wrong fallback branch; the gRPC pipeline "monitoring metrics" table
listed four metrics that are not registered anywhere in the binary;
the reasoning/tool-call parser docs referenced `SMG_*` environment
variables that clap does not actually read; and the service-discovery
examples for PD mode used a `--prefill-selector "k1=v1,k2=v2"` form
that is silently wrong because `parse_selector` splits on the first
`=` only.

### Solution
Systematic audit of 6 documentation files in this area against the
source code, verifying every CLI flag, default, metric name, env var,
and routing-behavior claim. 6 fixes applied across 4 files. Every
change cites a `file.rs:LINE` reference in the commit body. A Tech
Lead pass independently re-verified each change against cited source
code before this PR was opened.

## Changes
- **Verified ~90 claims across 6 doc files** (cache-aware, prefix_hash,
  manual, consistent_hashing, bucket, power_of_two, round_robin,
  random policies; PD disaggregation flags; reasoning + tool-call
  parser tables; pipeline metrics).
- **Fixed 6 inaccuracies across 4 files**:
  - `docs/concepts/routing/cache-aware.md` (1 edit): match-rate threshold
    uses strict `>` and fallback is least-loaded healthy worker
    (`model_gateway/src/policies/cache_aware.rs:802, 811, 863, 872`).
  - `docs/getting-started/load-balancing.md` (1 edit): same correction
    in the `--cache-threshold` table description.
  - `docs/concepts/architecture/grpc-pipeline.md` (3 edits):
    - Replaced four phantom metric rows
      (`smg_pipeline_stage_duration_seconds`,
      `smg_reasoning_extractions_total`, `smg_tool_calls_total`,
      `smg_tool_execution_duration_seconds`) with the real
      `smg_router_stage_duration_seconds`
      (`observability/metrics.rs:190, 622`). Kept the verified
      `smg_mcp_tool_calls_total` row.
    - Removed the `Environment` rows for `SMG_REASONING_PARSER` and
      `SMG_TOOL_CALL_PARSER` from the reasoning/tool-call parser
      configuration tables. The `--reasoning-parser` /
      `--tool-call-parser` clap args (`main.rs:455-461`) carry no
      `env = ...` attribute, and a repo-wide grep confirmed no code
      path reads those env vars.
  - `docs/concepts/routing/pd-disaggregation.md` (2 edits): rewrote
    both occurrences of `--prefill-selector "app=sglang,role=prefill"`
    to the space-separated form `--prefill-selector app=sglang role=prefill`.
    The `parse_selector` function (`main.rs:793-803`) splits each
    selector value on its first `=` only, and the flag declares
    `num_args = 0..` (`main.rs:262, 266`), so the comma-joined form
    silently drops the second label. The corrected form matches the
    already-correct usage in
    `docs/concepts/architecture/high-availability.md:455`.
- **No source code modified.**
- **Two files in scope** (`docs/getting-started/pd-disaggregation.md`,
  `docs/concepts/routing/load-balancing.md`) needed no edits after
  full verification. Their claims about policy enums, PD CLI flags,
  headers, assignment modes, virtual nodes, and the `HashRing`
  signature (`worker/hash_ring.rs:44-48`) all match the current code.

## Test Plan
- Every fix cites a source code reference (`file.rs:LINE`) in the
  commit body and in the Tech Lead review notes.
- `mkdocs build --strict --clean --quiet` exits 0 at HEAD on this
  branch (pre-existing unrelated anchor warnings in
  `getting-started/tokenization-and-parsing.md` remain, untouched by
  this PR).
- Tech Lead phase independently re-verified each edit against the
  cited source code in `model_gateway/src/policies/cache_aware.rs`,
  `model_gateway/src/observability/metrics.rs`,
  `model_gateway/src/main.rs` (parse_selector, parser args), and
  repo-wide grep for the removed metric names and env vars.
- No source code was modified.

<details>
<summary>Checklist</summary>

- [x] Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated gRPC pipeline architecture documentation with revised configuration and monitoring guidance
* Clarified cache-aware routing behavior, including threshold comparisons and worker selection logic
* Updated Kubernetes label selector syntax examples for disaggregated prefill/decode setup
* Refined cache-threshold parameter documentation for improved load-balancing clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->