### PR TITLE
docs(config): audit and fix configuration reference + contributing docs

### DIFF
--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -130,8 +130,8 @@ cargo test test_round_robin
 # Run with output
 cargo test -- --nocapture
 
-# Run integration tests (requires Docker)
-cargo test --test integration
+# Run a specific integration test binary (files under model_gateway/tests/)
+cargo test --test routing_tests
 ```
 
 ### Linting and Formatting (Rust)
@@ -156,7 +156,9 @@ Python code in `e2e_test/`, `bindings/python/`, and `scripts/` is checked with
 [ruff](https://docs.astral.sh/ruff/) (linting + formatting) and
 [mypy](https://mypy-lang.org/) (type checking).
 
-**Pre-commit hooks** run these checks automatically on every commit. To set up:
+**Pre-commit hooks** run `rustfmt`, `clippy`, and `ruff` / `ruff-format`
+automatically on every commit. `mypy` is run manually or in CI (it is not
+wired into pre-commit). To set up:
 
 ```bash
 pip install pre-commit

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -100,6 +100,7 @@ Controls how requests are distributed across workers.
 | `--balance-rel-threshold` | Relative threshold for load balancing trigger | `1.5` |
 | `--eviction-interval` | Interval in seconds between cache eviction operations | `120` |
 | `--max-tree-size` | Maximum size of the approximation tree | `67108864` |
+| `--block-size` | KV cache block size for event-driven cache-aware routing | `16` |
 
 ### Prefix Hash Policy Options
 
@@ -127,6 +128,7 @@ Controls how requests are distributed across workers.
 | `--dp-aware` | Enable data parallelism aware scheduling | `false` |
 | `--enable-igw` | Enable IGW (Inference Gateway) mode for multi-model support | `false` |
 | `--dp-minimum-tokens-scheduler` | Enable minimum tokens scheduler for data parallel group | `false` |
+| `--load-monitor-interval` | Interval in seconds between load monitor checks for PowerOfTwo routing | `10` |
 
 ---
 
@@ -226,6 +228,18 @@ Note: Enabling service discovery automatically enables IGW mode.
 |--------|-------------|
 | `--prefill-selector` | Label selector for prefill server pods |
 | `--decode-selector` | Label selector for decode server pods |
+
+### HA Mesh Router Discovery
+
+| Option | Description |
+|--------|-------------|
+| `--router-selector` | Label selector for router pod discovery in HA mesh mode (format: `key=value`) |
+
+### Per-Worker Model ID Override
+
+| Option | Description |
+|--------|-------------|
+| `--model-id-from` | Override each worker's `model_id` from pod metadata. Accepted values: `namespace`, `label:<key>`, or `annotation:<key>`. |
 
 ---
 
@@ -344,6 +358,7 @@ Note: Enabling service discovery automatically enables IGW mode.
 | `--oracle-dsn` | `ATP_DSN` | Oracle connection descriptor/DSN |
 | `--oracle-user` | `ATP_USER` | Oracle database username |
 | `--oracle-password` | `ATP_PASSWORD` | Oracle database password |
+| `--oracle-external-auth` | `ATP_EXTERNAL_AUTH` | Enable Oracle external authentication (default: `false`) |
 | `--oracle-pool-min` | `ATP_POOL_MIN` | Minimum connection pool size (default: 1) |
 | `--oracle-pool-max` | `ATP_POOL_MAX` | Maximum connection pool size (default: 16) |
 | `--oracle-pool-timeout-secs` | `ATP_POOL_TIMEOUT_SECS` | Pool timeout in seconds (default: 30) |
@@ -374,6 +389,31 @@ Note: Enabling service discovery automatically enables IGW mode.
 | Environment | - |
 | Default | `false` |
 | Description | Enable WebAssembly support |
+
+### Storage Hook WASM Component
+
+| Option | `--storage-hook-wasm-path` |
+|--------|----------------------------|
+| Environment | - |
+| Default | None |
+| Description | Path to a WASM component implementing storage hooks. When set, wraps all storage backends with hook-based interceptors. |
+
+### Schema Config File
+
+| Option | `--schema-config` |
+|--------|-------------------|
+| Environment | - |
+| Default | None |
+| Description | Path to a YAML schema config file for storage table/column remapping. |
+
+---
+
+## WebRTC Configuration
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--webrtc-bind-addr` | Bind address for WebRTC UDP sockets (client-facing ICE candidate IP). Set to `127.0.0.1` for local development on the same machine. | `0.0.0.0` (auto-detect via routing table) |
+| `--webrtc-stun-server` | STUN server for ICE candidate gathering (`host:port`). Set to your own STUN server for enterprise deployments that restrict outbound traffic to external STUN servers. | `stun.l.google.com:19302` |
 
 ---
 
@@ -702,6 +742,14 @@ RUST_LOG=smg=debug,hyper=warn smg ...
 | Default | None (console only) |
 | Description | Directory to store log files |
 
+### JSON Logs
+
+| Option | `--log-json` |
+|--------|--------------|
+| Environment | - |
+| Default | `false` |
+| Description | Output logs as JSON (structured). Defaults to human-readable text logs. |
+
 ---
 
 ## Configuration Examples
@@ -846,6 +894,7 @@ smg \
 | `ATP_DSN` | `--oracle-dsn` | Oracle DSN |
 | `ATP_USER` | `--oracle-user` | Oracle username |
 | `ATP_PASSWORD` | `--oracle-password` | Oracle password |
+| `ATP_EXTERNAL_AUTH` | `--oracle-external-auth` | Enable Oracle external authentication |
 | `ATP_POOL_MIN` | `--oracle-pool-min` | Oracle min pool size |
 | `ATP_POOL_MAX` | `--oracle-pool-max` | Oracle max pool size |
 | `ATP_POOL_TIMEOUT_SECS` | `--oracle-pool-timeout-secs` | Oracle pool timeout |


### PR DESCRIPTION
## Description

### Problem
The master configuration reference (`docs/reference/configuration.md`)
and the contributing guides may be out of date, incorrect, or missing
content relative to the current codebase. New CLI flags landed over
recent releases (cache-aware event-driven routing, HA mesh router
discovery, per-worker model ID override, JSON logs, Oracle external
auth, storage hook WASM component, schema config, WebRTC transport)
without corresponding doc updates, and a couple of contributing-guide
commands drifted out of sync with the tree.

### Solution
Systematic audit of `docs/reference/configuration.md`,
`docs/contributing/index.md`, `docs/contributing/development.md`,
and `docs/contributing/code-style.md` against
`model_gateway/src/main.rs` (`CliArgs`),
`model_gateway/src/config/types.rs` (`RouterConfig` and friends),
`crates/data_connector/src/config.rs`, `Makefile`,
`.pre-commit-config.yaml`, `rustfmt.toml`, `clippy.toml`, and
`bindings/python/src/smg/router_args.py`.

Every claim (CLI flag names, defaults, env vars, section placements,
value enums, example commands) was verified against a code
reference. A tech lead agent then independently re-verified every
change before this commit. No source code was modified.

## Changes

### `docs/reference/configuration.md` (+49 lines)

10 previously undocumented CLI flags now documented:

| Flag | Added to section | Default | Source |
|------|------------------|---------|--------|
| `--block-size` | Cache-Aware Policy Options | `16` | `main.rs:176`, `types.rs:266,324` |
| `--load-monitor-interval` | Advanced Routing Options | `10` | `main.rs:233`, `types.rs:26,122` |
| `--router-selector` | HA Mesh Router Discovery (new subsection under Service Discovery) | — | `main.rs:270`, `types.rs:376` |
| `--model-id-from` | Per-Worker Model ID Override (new subsection under Service Discovery) | — | `main.rs:275`, `types.rs:382` |
| `--log-json` | JSON Logs (new subsection under Logging Configuration) | `false` | `main.rs:288` |
| `--oracle-external-auth` / `ATP_EXTERNAL_AUTH` | Oracle Database table + Environment Variable Reference | `false` | `main.rs:510-516`, `data_connector/src/config.rs:29` |
| `--storage-hook-wasm-path` | Storage Hook WASM Component (new subsection under WASM Configuration) | None | `main.rs:481`, `types.rs:104` |
| `--schema-config` | Schema Config File (new subsection under WASM Configuration) | None | `main.rs:485`, `main.rs:910-925` |
| `--webrtc-bind-addr` | WebRTC Configuration (new section) | `0.0.0.0` (auto-detect) | `main.rs:657` |
| `--webrtc-stun-server` | WebRTC Configuration (new section) | `stun.l.google.com:19302` | `main.rs:664` |

Additions are surgical: no existing sections were restructured, no
content was deleted, and all existing anchor targets
(`#worker-configuration`, `#rate-limiting-configuration`,
`#storage-configuration`, `#mcp-configuration`,
`#control-plane-authentication`, `#environment-variable-reference`)
still resolve. `mkdocs build --strict --clean` exits 0.

### `docs/contributing/development.md` (+5 / -3)

Two inaccuracies fixed:

- `cargo test --test integration` -> `cargo test --test routing_tests`.
  There is no `integration.rs` test binary under `model_gateway/tests/`;
  the actual integration test binaries include `routing_tests.rs`,
  `api_tests.rs`, `messages_test.rs`, etc. Changed to a real name and
  broadened the comment to "Run a specific integration test binary
  (files under model_gateway/tests/)" so readers know where to look
  for alternatives.
- The "pre-commit hooks run these checks automatically" sentence was
  overclaimed with respect to mypy. `.pre-commit-config.yaml:96-102`
  only wires `ruff` and `ruff-format` under astral-sh/ruff-pre-commit;
  there is no mypy hook. Doc now says rustfmt, clippy, ruff, and
  ruff-format run via pre-commit, and mypy is run manually or in CI.

### `docs/contributing/index.md`, `docs/contributing/code-style.md`

No changes. All verifiable claims in these two files are accurate
against current code (Rust version, workspace layout, rustfmt
directives, clippy gates, conventional commit policy). They are not
"exhaustive lint references", so we did not edit them to enumerate
every workspace `deny` rule.

## Out-of-scope findings

These were flagged during the audit but are **not fixed in this PR**
because the desired resolution is unclear and belongs to a follow-up:

1. **Postgres/Redis env vars are Python-launcher-only.**
   `docs/reference/configuration.md` documents `POSTGRES_DB_URL`,
   `POSTGRES_POOL_MAX`, `REDIS_URL`, `REDIS_POOL_MAX`, and
   `REDIS_RETENTION_DAYS` as mapping to `--postgres-*` / `--redis-*`
   flags in both the Storage Configuration table and the Environment
   Variable Reference table. These env vars ARE honored — but only by
   `bindings/python/src/smg/router_args.py:910-937`, which is the
   entry point for `smg serve` from the Python launcher. The native
   Rust CLI defined in `model_gateway/src/main.rs:532-550` has **no**
   `env=` attributes for these flags, so `smg launch` users binding
   directly to the Rust binary must pass `--postgres-db-url` /
   `--redis-url` explicitly. The doc mapping is correct for the
   Python-launcher path and could mislead direct-binary users. Fixing
   this is a judgment call: either add `env=...` to the Rust CLI
   (source change, out of scope for a docs audit) or label the env
   vars in the doc as "Python launcher only". Leaving the doc
   unchanged per the audit's "unsure -> leave it" rule.

## Test plan

- `mkdocs build --strict --clean --quiet` exits 0 on this branch
- Every added flag has a corresponding `file:line` code reference and
  was verified against `model_gateway/src/main.rs` and
  `model_gateway/src/config/types.rs` by the Tech Lead reviewer
  independently of the Writer's report
- Every existing cross-reference target
  (`configuration.md#rate-limiting-configuration`,
  `configuration.md#storage-configuration`,
  `configuration.md#mcp-configuration`,
  `configuration.md#control-plane-authentication`,
  `configuration.md#worker-configuration`,
  `configuration.md#environment-variable-reference`) was confirmed to
  still resolve after the edits
- No source code was modified (`git diff origin/main -- '*.rs' 'Cargo*'
  Makefile '.github/**' '.pre-commit-config.yaml'` is empty)
- Recent commits since 2026-04-01 on `main.rs`/`config/types.rs` were
  spot-checked (`d3fc32a2`, `8b19d6be`) and contain no new flags that
  this audit missed

<details>
<summary>Checklist</summary>

- [x] Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development guide with refined Rust test execution instructions
  * Expanded configuration reference with new command-line options for KV cache management, load monitoring, HA mesh discovery, per-worker model configuration, Oracle authentication, WASM storage integration, WebRTC connectivity, and JSON logging support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->