### PR TITLE
docs(api-ref): audit and fix OpenAI, Responses, Admin, Extensions API reference

### DIFF
--- a/docs/reference/api/admin.md
+++ b/docs/reference/api/admin.md
@@ -42,7 +42,7 @@ Adds a new tokenizer from a local path or HuggingFace model ID.
 {
   "id": "550e8400-e29b-41d4-a716-446655440000",
   "status": "pending",
-  "message": "Tokenizer loading initiated"
+  "message": "Tokenizer 'llama3-tokenizer' registration job submitted. Loading from: meta-llama/Meta-Llama-3-8B"
 }
 ```
 
@@ -94,8 +94,8 @@ Returns details for a specific tokenizer.
 ```json
 {
   "error": {
-    "message": "Tokenizer not found",
-    "type": "not_found"
+    "message": "Tokenizer 'llama3-tokenizer' not found",
+    "type": "tokenizer_not_found"
   }
 }
 ```
@@ -115,7 +115,7 @@ Returns the loading status of a tokenizer.
 {
   "id": "550e8400-e29b-41d4-a716-446655440000",
   "status": "completed",
-  "message": "Tokenizer loaded successfully",
+  "message": "Tokenizer 'llama3-tokenizer' is loaded and ready",
   "vocab_size": 128256
 }
 ```
@@ -141,7 +141,7 @@ Removes a tokenizer.
 ```json
 {
   "success": true,
-  "message": "Tokenizer removed successfully"
+  "message": "Tokenizer 'llama3-tokenizer' removed successfully"
 }
 ```
 
@@ -176,7 +176,7 @@ Registers a new backend worker.
 | `url` | string | Yes | Worker base URL |
 | `worker_type` | string | No | `regular`, `prefill`, or `decode` (default: `regular`) |
 | `connection_mode` | string | No | `http` or `grpc` (default: `http`) |
-| `runtime_type` | string | No | `sglang`, `vllm`, `trtllm`, or `external` (default: auto-detect) |
+| `runtime_type` | string | No | `sglang`, `vllm`, `trtllm`, `mlx`, `external`, or `unspecified` (default: `unspecified`, which triggers auto-detection) |
 | `models` | array | No | Model cards served by this worker (empty = wildcard) |
 | `api_key` | string | No | API key for worker authentication |
 | `priority` | integer | No | Routing priority (higher = preferred, default: 50) |
@@ -194,13 +194,13 @@ Registers a new backend worker.
 
 ---
 
-### Update Worker
+### Update Worker (partial)
 
 ```
-PUT /workers/{worker_id}
+PATCH /workers/{worker_id}
 ```
 
-Updates worker configuration.
+Partially updates worker configuration. Only the fields you include are changed.
 
 **Request Body:**
 ```json
@@ -216,6 +216,7 @@ Updates worker configuration.
 | `cost` | number | New cost factor |
 | `labels` | object | Updated labels |
 | `api_key` | string | New API key (for key rotation) |
+| `health` | object | Partial health-check overrides (`timeout_secs`, `check_interval_secs`, `success_threshold`, `failure_threshold`, `disable_health_check`) |
 
 **Response:** `202 Accepted`
 ```json
@@ -225,6 +226,18 @@ Updates worker configuration.
   "message": "Worker update queued for background processing"
 }
 ```
+
+---
+
+### Replace Worker (full)
+
+```
+PUT /workers/{worker_id}
+```
+
+Re-runs the full worker registration workflow (model discovery and all). The request body must be a complete `WorkerSpec` whose `url` matches the existing worker's URL — URL changes are not supported via `PUT`; use `DELETE` + `POST` instead.
+
+**Response:** `202 Accepted` with the same shape as `PATCH`.
 
 ---
 
@@ -257,15 +270,20 @@ Manage the routing cache and load information.
 POST /flush_cache
 ```
 
-Flushes the KV cache on all workers.
+Flushes the KV cache on all HTTP workers. gRPC workers are skipped. The response status is `200 OK` on full success and `206 Partial Content` when some workers fail.
 
 **Response:** `200 OK`
 ```json
 {
-  "flushed_workers": 3,
-  "success": true
+  "status": "success",
+  "message": "Successfully flushed cache on all 3 HTTP workers",
+  "workers_flushed": 3,
+  "total_http_workers": 3,
+  "total_workers": 3
 }
 ```
+
+On partial failure, the response additionally includes `successful` (list of worker URLs) and `failed` (list of `{worker, error}` entries), and `status` becomes `"partial_success"`.
 
 ---
 
@@ -275,18 +293,34 @@ Flushes the KV cache on all workers.
 GET /get_loads
 ```
 
-Returns current load distribution across workers.
+Returns the current load distribution across workers. The gateway fans out to every registered worker (HTTP and gRPC) and returns whatever each backend reports. The `load` field is the total number of KV-cache tokens in use across all data-parallel ranks for that worker; `-1` indicates the worker failed to respond.
 
 **Response:** `200 OK`
 ```json
 {
-  "loads": [
+  "workers": [
     {
-      "worker_id": "worker-1",
-      "url": "http://gpu1:8000",
-      "active_requests": 5,
-      "queue_depth": 2,
-      "cache_utilization": 0.75
+      "worker": "http://gpu1:8000",
+      "load": 1234,
+      "details": {
+        "timestamp": "2024-01-15T12:00:00Z",
+        "dp_rank_count": 1,
+        "loads": [
+          {
+            "dp_rank": 0,
+            "num_running_reqs": 5,
+            "num_waiting_reqs": 2,
+            "num_total_reqs": 7,
+            "num_used_tokens": 1234,
+            "max_total_num_tokens": 16384,
+            "token_usage": 0.075,
+            "gen_throughput": 45.2,
+            "cache_hit_rate": 0.82,
+            "utilization": 0.31,
+            "max_running_requests": 256
+          }
+        ]
+      }
     }
   ]
 }
@@ -363,7 +397,7 @@ Returns server information (proxied to workers).
 
 ## WASM Module Management
 
-Manage WebAssembly plugins.
+Manage WebAssembly plugins. Modules are registered from files accessible to the gateway process; the request body contains descriptors with paths, not binary payloads.
 
 ### Add WASM Module
 
@@ -371,16 +405,45 @@ Manage WebAssembly plugins.
 POST /wasm
 ```
 
-Uploads and registers a WASM module.
+Registers one or more WASM modules.
 
-**Request:** Multipart form with WASM binary
-
-**Response:** `201 Created`
+**Request Body:** JSON `WasmModuleAddRequest`
 ```json
 {
-  "id": "550e8400-e29b-41d4-a716-446655440000",
-  "name": "custom-filter",
-  "status": "loaded"
+  "modules": [
+    {
+      "name": "custom-middleware",
+      "file_path": "/etc/smg/wasm/custom-middleware.wasm",
+      "module_type": "Middleware",
+      "attach_points": [
+        {"Middleware": "OnRequest"},
+        {"Middleware": "OnResponse"}
+      ]
+    }
+  ]
+}
+```
+
+The only supported `module_type` today is `Middleware`. Valid `Middleware` attach points are `OnRequest`, `OnResponse`, and `OnError`.
+
+**Response:** `200 OK` on full success, `400 Bad Request` if any module failed to register. The response body echoes every requested module with an `add_result` field indicating success (carrying the assigned UUID) or failure (carrying the error message).
+
+```json
+{
+  "modules": [
+    {
+      "name": "custom-middleware",
+      "file_path": "/etc/smg/wasm/custom-middleware.wasm",
+      "module_type": "Middleware",
+      "attach_points": [
+        {"Middleware": "OnRequest"},
+        {"Middleware": "OnResponse"}
+      ],
+      "add_result": {
+        "Success": "550e8400-e29b-41d4-a716-446655440000"
+      }
+    }
+  ]
 }
 ```
 
@@ -392,18 +455,36 @@ Uploads and registers a WASM module.
 GET /wasm
 ```
 
-Returns all registered WASM modules.
+Returns all registered WASM modules together with aggregate execution metrics.
 
 **Response:** `200 OK`
 ```json
 {
   "modules": [
     {
-      "id": "550e8400-e29b-41d4-a716-446655440000",
-      "name": "custom-filter",
-      "status": "loaded"
+      "module_uuid": "550e8400-e29b-41d4-a716-446655440000",
+      "module_meta": {
+        "name": "custom-middleware",
+        "file_path": "/etc/smg/wasm/custom-middleware.wasm",
+        "sha256_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "size_bytes": 65536,
+        "created_at": "2024-01-15T12:00:00.000000000Z",
+        "last_accessed_at": "2024-01-15T12:05:00.000000000Z",
+        "access_count": 42,
+        "attach_points": [
+          {"Middleware": "OnRequest"}
+        ]
+      }
     }
-  ]
+  ],
+  "metrics": {
+    "total_executions": 42,
+    "successful_executions": 42,
+    "failed_executions": 0,
+    "total_execution_time_ms": 125,
+    "max_execution_time_ms": 8,
+    "average_execution_time_ms": 2.97
+  }
 }
 ```
 
@@ -415,15 +496,14 @@ Returns all registered WASM modules.
 DELETE /wasm/{module_uuid}
 ```
 
-Removes a WASM module.
+Removes a WASM module. The body is a plain text status message, not JSON.
 
 **Response:** `200 OK`
-```json
-{
-  "success": true,
-  "message": "Module removed successfully"
-}
 ```
+Module removed successfully
+```
+
+On failure returns `400 Bad Request` with the error text as the body.
 
 ---
 

--- a/docs/reference/api/extensions.md
+++ b/docs/reference/api/extensions.md
@@ -69,7 +69,7 @@ These endpoints are for gateway operations and administration.
 | Method | Path |
 |---|---|
 | `GET`, `POST` | `/workers` |
-| `GET`, `PUT`, `DELETE` | `/workers/{worker_id}` |
+| `GET`, `PUT`, `PATCH`, `DELETE` | `/workers/{worker_id}` |
 
 ### Tokenizer Management
 

--- a/docs/reference/api/openai.md
+++ b/docs/reference/api/openai.md
@@ -51,10 +51,11 @@ POST /v1/chat/completions
 |-------|------|----------|-------------|
 | `model` | string | Yes | Model identifier |
 | `messages` | array | Yes | Array of message objects |
-| `max_tokens` | integer | No | Maximum tokens to generate |
+| `max_completion_tokens` | integer | No | Upper bound on generated completion tokens |
+| `max_tokens` | integer | No | Deprecated — use `max_completion_tokens`. Still accepted and transparently migrated |
 | `temperature` | number | No | Sampling temperature (0-2) |
 | `top_p` | number | No | Nucleus sampling parameter |
-| `n` | integer | No | Number of completions to generate |
+| `n` | integer | No | Number of completions to generate (1-10) |
 | `stream` | boolean | No | Enable streaming responses |
 | `stop` | string/array | No | Stop sequences |
 | `presence_penalty` | number | No | Presence penalty (-2 to 2) |
@@ -65,7 +66,7 @@ POST /v1/chat/completions
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `role` | string | Yes | `system`, `user`, or `assistant` |
+| `role` | string | Yes | `system`, `user`, `assistant`, `tool`, `function`, or `developer` |
 | `content` | string | Yes | Message content |
 
 #### Example Request
@@ -220,39 +221,14 @@ curl http://localhost:30000/v1/models
     {
       "id": "meta-llama/Llama-3.1-8B-Instruct",
       "object": "model",
-      "created": 1705312345,
-      "owned_by": "organization"
+      "created": 0,
+      "owned_by": "self_hosted"
     }
   ]
 }
 ```
 
----
-
-### Retrieve Model
-
-Get details about a specific model.
-
-```
-GET /v1/models/{model_id}
-```
-
-#### Example Request
-
-```bash
-curl http://localhost:30000/v1/models/meta-llama/Llama-3.1-8B-Instruct
-```
-
-#### Response
-
-```json
-{
-  "id": "meta-llama/Llama-3.1-8B-Instruct",
-  "object": "model",
-  "created": 1705312345,
-  "owned_by": "organization"
-}
-```
+`owned_by` is `self_hosted` for locally hosted workers, or the provider name (for example `openai`, `anthropic`, `xai`, `gemini`) for upstream providers.
 
 ---
 

--- a/docs/reference/api/responses.md
+++ b/docs/reference/api/responses.md
@@ -60,7 +60,7 @@ POST /v1/responses
 | `max_output_tokens` | integer | No | Maximum tokens to generate |
 | `max_tool_calls` | integer | No | Maximum number of tool calls per request |
 | `temperature` | number | No | Sampling temperature (0-2), default: 1.0 |
-| `top_p` | number | No | Nucleus sampling parameter (0-1), default: 1.0 |
+| `top_p` | number | No | Nucleus sampling parameter (0-1) |
 | `stream` | boolean | No | Enable streaming responses |
 | `store` | boolean | No | Store response for later retrieval, default: true |
 | `tools` | array | No | Available tools (function, mcp, web_search_preview, code_interpreter) |


### PR DESCRIPTION
## Description

### Problem
Documentation for the OpenAI-compatible, Responses, Admin, and Extensions API surface in `docs/reference/api/` was out of date relative to the current request/response types in `crates/protocols/src/` and the route registrations in `model_gateway/src/server.rs` / `model_gateway/src/routers/`. Several JSON examples, field names, HTTP methods, and enum variants no longer matched what the server actually returns.

### Solution
Systematic audit of the five API reference files against the cited source code, verifying every endpoint path, HTTP method, request/response field, and enum variant. Writer phase performed inventory, verify, discover, and fix; the Tech Lead phase independently re-verified every change against the cited source before shipping.

## Changes
Verified ~170 claims across 5 API reference files (`openai.md`, `responses.md`, `messages.md`, `admin.md`, `extensions.md`) and applied 17 surgical edits in 4 files. `messages.md` was re-verified and remains unchanged.

### `openai.md`
- **Chat Completions**: added `max_completion_tokens` row, marked `max_tokens` as deprecated with a note that it is still transparently migrated (`crates/protocols/src/chat.rs:172-179`, `chat.rs:532-536`).
- **Chat Completions `n`**: documented the 1-10 validation bound (`chat.rs:188-189`).
- **Message Object**: expanded `role` from 3 values to the full 6 serde variants `system | user | assistant | tool | function | developer` (`chat.rs:27-59`).
- **List Models example**: `owned_by` corrected from `"organization"` to `"self_hosted"` and `created` from a fake Unix timestamp to `0` (`crates/protocols/src/model_card.rs:293-298`, `model_card.rs:307`), plus a one-line explanation of how the provider string maps.
- **Retrieve Model**: removed the entire `GET /v1/models/{model_id}` section. That route is not registered anywhere in `model_gateway/src/server.rs` (only `GET /v1/models` at `server.rs:753`).

### `responses.md`
- **Request body table**: removed the incorrect `top_p` "default: 1.0" claim. `ResponsesRequest.top_p` is `Option<f32>` with no `#[serde(default)]` (`crates/protocols/src/responses.rs:704-706`).

### `admin.md`
- **Add Tokenizer response example**: updated the `message` string to match the actual format `"Tokenizer '{name}' registration job submitted. Loading from: {source}"` (`model_gateway/src/routers/tokenize/handlers.rs:253-255`).
- **Get Tokenizer 404**: corrected the error `type` from `"not_found"` to `"tokenizer_not_found"` and updated the message (`tokenize/handlers.rs:346-351`).
- **Get Tokenizer Status example**: updated the `message` string to match `"Tokenizer '{name}' is loaded and ready"` (`tokenize/handlers.rs:368`).
- **Remove Tokenizer**: updated the `message` string to include the tokenizer name (`tokenize/handlers.rs:308-309`).
- **Create Worker `runtime_type`**: corrected the enum list to include all 6 variants (`sglang`, `vllm`, `trtllm`, `mlx`, `external`, `unspecified`) and fixed the default to `unspecified` (auto-detect happens when unset), matching `RuntimeType` in `crates/protocols/src/worker.rs:183-202`.
- **Update Worker**: split into two sections — **`PATCH /workers/{worker_id}`** (partial update using `WorkerUpdateRequest` at `worker.rs:922-939`, now also documenting the `health` field which wraps `HealthCheckUpdate` at `worker.rs:803-809`) and **`PUT /workers/{worker_id}`** (full replace via `replace_worker` at `model_gateway/src/worker/service.rs:284-323`, whose body must be a complete `WorkerSpec` with a matching `url`; URL changes require `DELETE` + `POST`).
- **`POST /flush_cache`**: rewrote the response example to match the real `FlushCacheResult::into_response` shape (`crates/protocols/src/worker.rs:1044-1071`) — fields are `status`, `message`, `workers_flushed`, `total_http_workers`, `total_workers`, with `successful` / `failed` arrays appearing only on partial failures. Noted that gRPC workers are skipped and the response becomes `206 Partial Content` on partial failure.
- **`GET /get_loads`**: rewrote the response example to match `WorkerLoadsResult::into_response` (`worker.rs:1073-1089`) — top-level `workers[]` with `worker` (URL), `load` (i64 token count, `-1` on failure), and `details` carrying a full `WorkerLoadResponse` including the 11 `SchedulerLoadSnapshot` fields (`worker.rs:985-998`). Fan-out behavior verified against `model_gateway/src/worker/manager.rs:768-799`.
- **`POST /wasm`**: rewrote the section. The real handler takes `Json<WasmModuleAddRequest>` (`model_gateway/src/wasm/route.rs:77-159`), not multipart. Documented the request as `WasmModuleAddRequest { modules: [{ name, file_path, module_type, attach_points }] }` (`crates/wasm/src/module.rs:127-200`). The only supported `module_type` is `Middleware`, and the valid attach points are `OnRequest`, `OnResponse`, `OnError` (`module.rs:172-189`). Success returns `200 OK` with `WasmModuleAddResponse` echoing each descriptor with an `add_result` of `Success(uuid)` or `Error(message)`; any failure returns `400`.
- **`GET /wasm`**: rewrote the response example to match `WasmModuleListResponse` (`module.rs:202-206`) with `modules[].module_meta` carrying `sha256_hash` (hex), `size_bytes`, RFC 3339 timestamps, `access_count`, and `attach_points`, plus the top-level `metrics` block with `total_executions`, `successful_executions`, `failed_executions`, `total_execution_time_ms`, `max_execution_time_ms`, `average_execution_time_ms` (`module.rs:209-217`).
- **`DELETE /wasm/{module_uuid}`**: documented that the body is plain text (`"Module removed successfully"`), not JSON, and that failures return `400` with the error text as the body (`wasm/route.rs:193-195`).

### `extensions.md`
- **Worker Management table**: added `PATCH` to the `/workers/{worker_id}` method list to match the route registration at `model_gateway/src/server.rs:783-789`.

## Out-of-scope findings
The audit surfaced several additional issues that were deliberately left unchanged, per the "leave uncertain claims alone" rule. These are candidates for follow-up PRs:

- **Error-type tables** in `openai.md` and `admin.md`: the `type` field values are inconsistent across paths. Native gateway errors use `StatusCode::canonical_reason()` (`"Bad Request"`, `"Not Found"`, etc.) per `model_gateway/src/routers/error.rs:91-95`, while request-validation and some conversation-handler errors use `"invalid_request_error"`. Upstream OpenAI-compatible backends passed through unchanged use the OpenAI types. Documenting this faithfully needs a narrative explanation, not a simple table fix.
- **Rate limit headers** (`X-RateLimit-*`, `Retry-After`): not verified against the middleware implementation.
- **`X-Request-ID` header**: not verified against `RequestIdLayer` at `model_gateway/src/server.rs`.
- **Conversation item soft-delete** claim in `responses.md`: the storage-layer semantics at `model_gateway/src/routers/conversations/handlers.rs:539` were not traced into the storage backend.
- **HTTP 408 `timeout_error`** in `openai.md` error table: no native code path returns 408 with that type (`gateway_timeout` returns 504 per `routers/error.rs:55`).
- **Undocumented request fields**: `ChatCompletionRequest` and `CompletionRequest` carry many SGLang and OpenAI extension fields (`logprobs`, `response_format`, `tools`, `seed`, `top_k`, `min_p`, `repetition_penalty`, etc.) that would require new sub-sections rather than surgical edits.
- **Undocumented endpoints**: `POST /v1/interactions`, `POST /v1/embeddings` schema, `POST /v1/classify` schema, `POST /generate` schema, and the `v1/realtime/*` family are registered in `server.rs` but have no documented body shapes.

## Test plan
- Every edit has a file:line citation against the current `crates/protocols` / `model_gateway` source.
- Every JSON example in the touched files was machine-validated (45 blocks parsed cleanly).
- `mkdocs build --strict --clean` exits 0 with no new warnings.
- Tech Lead phase independently re-verified each of the 17 edits against the cited source, including reading `replace_worker` vs `update_worker`, the serde derivations of `FlushCacheResult` / `WorkerLoadsResult`, and the `WasmModuleAttachPoint` / `WasmModuleType` serialization shape.
- No source code was modified.

<details>
<summary>Checklist</summary>

- [x] Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Admin API documentation for tokenizer management, including improved error messages with tokenizer names and types
  * Expanded worker management API to support `PATCH` operations for partial updates and clarified `PUT` for full replacement workflows
  * Enhanced cache operations documentation with updated response schemas and partial-success handling
  * Revised WASM module management API to support file-path-based registration with new request/response formats
  * Updated Chat Completions API documentation with new role options and parameter guidance
  * Clarified Models API response fields and metadata

<!-- end of auto-generated comment: release notes by coderabbit.ai -->