### PR TITLE
docs(extensibility): audit and fix tokenizer cache, MCP, WASM plugin docs

### DIFF
--- a/docs/concepts/extensibility/mcp.md
+++ b/docs/concepts/extensibility/mcp.md
@@ -238,13 +238,19 @@ policy:
       trust_level: trusted
 ```
 
-### Environment Variable Expansion
+### Keeping Credentials Out of Config Files
 
-Tokens support `${VAR_NAME}` syntax to keep credentials out of config files:
+SMG parses `mcp.yaml` as plain YAML and does not expand environment
+variables inside server `token` values. To keep credentials out of the
+checked-in config, substitute placeholders before the gateway loads the
+file — for example, render the YAML through `envsubst` from a shell
+wrapper, use a templating tool (Helm, Kustomize, Jinja), or inject the
+final config via a secret mount.
 
-```yaml
-token: "${BRAVE_API_KEY}"
-```
+For MCP-specific HTTP proxy configuration, SMG does read the
+`MCP_HTTP_PROXY`, `MCP_HTTPS_PROXY`, and `MCP_NO_PROXY` environment
+variables (falling back to `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY`)
+when no `proxy:` block is set in `mcp.yaml`.
 
 ---
 

--- a/docs/concepts/extensibility/wasm-plugins.md
+++ b/docs/concepts/extensibility/wasm-plugins.md
@@ -77,6 +77,16 @@ Plugins register at specific points in the request lifecycle:
 | **OnRequest** | Before forwarding to worker | Authentication, rate limiting, validation, header injection |
 | **OnResponse** | After receiving worker response | Response transformation, error normalization, logging |
 
+!!! warning "Streaming responses bypass OnResponse"
+    To avoid buffering entire streams into memory, SMG skips the
+    **OnResponse** phase when the upstream reply is streaming — that is,
+    when the response uses `Content-Type: text/event-stream`,
+    `Content-Type: application/x-ndjson`, or a chunked
+    `Transfer-Encoding`. The gateway logs a warning and passes the
+    streaming response through untouched, so plugins attached only at
+    OnResponse will not observe streaming traffic. OnRequest runs
+    normally for streaming endpoints.
+
 ---
 
 ## Example Plugins

--- a/docs/concepts/performance/tokenizer-caching.md
+++ b/docs/concepts/performance/tokenizer-caching.md
@@ -211,11 +211,11 @@ smg --model-path /models/llama-3.1-8b-instruct ...
 smg --model-path /models/llama-3.1-8b-instruct/tokenizer.json ...
 ```
 
-When pointing to a directory, SMG automatically searches for:
-
-1. `tokenizer.json` (HuggingFace fast tokenizer format)
-2. `tokenizer_config.json` (fallback)
-3. `vocab.json` (fallback)
+When pointing to a local directory, SMG looks for either a HuggingFace
+`tokenizer.json` or a tiktoken file (`tiktoken.model` or `*.tiktoken`). When
+pulling from the HuggingFace Hub, SMG additionally falls back to
+`tokenizer_config.json` and `vocab.json` in the downloaded snapshot if a
+primary tokenizer file is not present.
 
 #### `--tokenizer-path`
 
@@ -302,7 +302,7 @@ Chat templates use Jinja2 syntax with access to:
 
 {{ message.content }}<|eot_id|>
 {% endfor %}
-{% if add_generation_prompt %}<|start_header_id|>assistant<|end_header_id|}
+{% if add_generation_prompt %}<|start_header_id|>assistant<|end_header_id|>
 
 {% endif %}
 ```
@@ -547,58 +547,25 @@ smg \
 
 ## Monitoring & Observability
 
-SMG exposes comprehensive Prometheus metrics for cache monitoring:
+The cache implementation tracks per-level hit/miss counters and L1 memory
+usage internally (`CacheStats` and `L1CacheStats` in the `tokenizer` crate).
+These statistics are not currently exported to the gateway's Prometheus
+`/metrics` endpoint, so hit-rate monitoring must rely on application-level
+logging or benchmark runs until dedicated metrics are wired up.
 
-### Cache Metrics
+### Sizing Signals to Watch
 
-| Metric | Description |
-|--------|-------------|
-| `smg_tokenizer_cache_l0_hits_total` | L0 cache hit count |
-| `smg_tokenizer_cache_l0_misses_total` | L0 cache miss count |
-| `smg_tokenizer_cache_l0_entries` | Current L0 cache entries |
-| `smg_tokenizer_cache_l1_hits_total` | L1 cache hit count |
-| `smg_tokenizer_cache_l1_misses_total` | L1 cache miss count |
-| `smg_tokenizer_cache_l1_memory_bytes` | Current L1 memory usage |
+Without dedicated cache metrics, use these indirect signals when tuning
+`--tokenizer-cache-l0-max-entries` and `--tokenizer-cache-l1-max-memory`:
 
-### Useful PromQL Queries
-
-<div class="grid" markdown>
-
-<div class="card" markdown>
-
-#### L0 Hit Rate
-
-```promql
-rate(smg_tokenizer_cache_l0_hits_total[5m]) /
-(rate(smg_tokenizer_cache_l0_hits_total[5m]) +
- rate(smg_tokenizer_cache_l0_misses_total[5m]))
-```
-
-</div>
-
-<div class="card" markdown>
-
-#### Combined Hit Rate
-
-```promql
-(rate(smg_tokenizer_cache_l0_hits_total[5m]) +
- rate(smg_tokenizer_cache_l1_hits_total[5m])) /
-(rate(smg_tokenizer_cache_l0_hits_total[5m]) +
- rate(smg_tokenizer_cache_l0_misses_total[5m]))
-```
-
-</div>
-
-</div>
-
-### Alert Thresholds
-
-| Metric | Warning | Critical | Action |
-|--------|---------|----------|--------|
-| L0 hit rate | <50% | <30% | Review prompt patterns |
-| L1 hit rate | <30% | <15% | Check conversation patterns |
-| L0 entries | >90% capacity | >95% | Increase `max-entries` |
-| L1 memory | >80% limit | >90% | Increase `max-memory` |
+- Rising tokenization latency at steady request rate suggests more unique
+  prompts than L0 can retain — increase `max-entries`.
+- Multi-turn chat traffic with growing context benefits from larger L1
+  memory budgets; set L1 based on the estimate of ~1 KB per active
+  conversation described in [L1 Cache Sizing](#l1-cache-sizing).
+- Resident process memory approaching the sum of L0 (~2.2 KB per entry)
+  plus L1 (`max-memory`) bounds indicates you are near the configured
+  cache budget.
 
 ---
 

--- a/docs/getting-started/mcp.md
+++ b/docs/getting-started/mcp.md
@@ -24,7 +24,7 @@ servers:
   - name: brave
     protocol: sse
     url: "https://mcp.brave.com/sse"
-    token: "${BRAVE_API_KEY}"
+    token: "${BRAVE_API_KEY}"  # literal placeholder — substitute before loading
     required: true
 
     tools:
@@ -49,6 +49,14 @@ servers:
 #     brave:
 #       trust_level: trusted
 ```
+
+SMG parses `mcp.yaml` as plain YAML and does not expand `${VAR}`
+placeholders inside server `token` values. Substitute credentials
+externally before the gateway loads the file — for example, render the
+YAML through `envsubst` from a shell wrapper, use a templating tool
+(Helm, Kustomize, Jinja), or inject the final config via a secret mount.
+See [Keeping Credentials Out of Config Files](../concepts/extensibility/mcp.md#keeping-credentials-out-of-config-files)
+for details.
 
 ---
 


### PR DESCRIPTION
## Description

### Problem
Documentation for tokenization, tokenizer caching, MCP configuration, and
WASM plugin extensibility had drifted from the current implementation in
`crates/tokenizer`, `crates/mcp`, `crates/wasm`, and the model gateway
middleware. Several claims (Prometheus metric names, MCP config loader
behavior, WASM response lifecycle, local tokenizer fallbacks) were either
inaccurate or fabricated, and the MCP quickstart implied `${VAR}`
expansion that the loader does not perform.

### Solution
Systematic audit of 9 tokenization/parsing/MCP/WASM/data-storage doc
files against source code, verifying every claim (CLI flags, config
fields, file discovery rules, env-var handling, plugin hook behavior,
metric names) and fixing discrepancies. Writer phase performed
inventory, verify, discover, and fix. Tech Lead phase independently
re-verified every change against the cited source code before shipping.

## Changes
- Verified ~105 claims across 9 doc files
- Fixed 4 inaccuracies + 1 Jinja typo across 4 doc files
- **`docs/concepts/performance/tokenizer-caching.md`**
  - Removed a fabricated **Monitoring & Observability** section that
    claimed SMG exports `smg_tokenizer_cache_{l0,l1}_{hits,misses}_total`,
    `smg_tokenizer_cache_l0_entries`, and `smg_tokenizer_cache_l1_memory_bytes`.
    None of these metrics exist in `model_gateway/src/observability/metrics.rs`;
    the in-memory counters live only inside `CacheStats`/`L1CacheStats`
    in the `tokenizer` crate and are not exported. Replaced with a
    "Sizing Signals to Watch" subsection that lists indirect indicators.
  - Corrected the local-directory tokenizer discovery description to
    distinguish between local paths (HuggingFace `tokenizer.json` /
    `tiktoken.model` / `*.tiktoken`) and HuggingFace Hub snapshots
    (additional `tokenizer_config.json` / `vocab.json` fallbacks),
    matching `crates/tokenizer/src/factory.rs`.
  - Fixed a Llama 3 chat-template Jinja typo:
    `<|end_header_id|}` → `<|end_header_id|>`.
- **`docs/concepts/extensibility/mcp.md`**
  - Replaced the misleading "Environment Variable Expansion" subsection
    with "Keeping Credentials Out of Config Files", clarifying that
    `McpConfig::from_file` in `crates/mcp/src/core/config.rs` calls
    `serde_yaml::from_str` directly with no placeholder substitution,
    and suggesting `envsubst`/Helm/Kustomize/secret mounts instead.
  - Documented the MCP-specific proxy environment variables that SMG
    actually honors: `MCP_HTTP_PROXY`, `MCP_HTTPS_PROXY`, `MCP_NO_PROXY`
    (falling back to `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY`) via
    `McpProxyConfig::from_env` when no `proxy:` block is set in `mcp.yaml`.
- **`docs/getting-started/mcp.md`**
  - Updated the quickstart YAML to annotate `token: "${BRAVE_API_KEY}"`
    as a literal placeholder and added a short paragraph explaining
    that the value must be substituted externally (via `envsubst`,
    templating, or a secret mount) before SMG loads the file. Links
    through to the concepts-doc section for the full explanation.
- **`docs/concepts/extensibility/wasm-plugins.md`**
  - Added a warning admonition documenting that SMG skips the
    **OnResponse** phase for streaming upstreams (Content-Type
    `text/event-stream` or `application/x-ndjson`, or chunked
    `Transfer-Encoding`), per `model_gateway/src/middleware/wasm.rs`.
    **OnRequest** still runs for streaming endpoints.

## Test plan
- Each fix cites an exact source reference (file:line) — see the
  Round 1 and Round 2 review notes in the Tech Lead re-verification
- `mkdocs build --strict --clean --quiet` — exit 0 with no warnings;
  all internal links (including the new
  `#keeping-credentials-out-of-config-files` crosslink from the
  getting-started quickstart to the concepts section) resolve
- Regression check: the three Round 1 files are byte-identical to the
  Tech Lead's Round 1 APPROVE state; only the getting-started doc
  changed in Round 2
- No source code was modified
  (`git diff origin/main -- '*.rs' 'Cargo*' Makefile '.github/**'` empty)
- All changes reviewed by a tech lead agent before commit (two review
  rounds; first round rejected a cross-doc inconsistency in the
  quickstart YAML, second round approved after the fix)

### Out-of-scope findings (undocumented features, not touched in this PR)
The Writer's discovery phase flagged six undocumented surfaces that fall
outside the fix-small-and-surgical mandate for this audit. They are
recorded here so a follow-up PR can pick them up:

- **WASM `OnError` plugin phase** — `model_gateway/src/middleware/wasm.rs`
  exposes an error-handling hook that is not mentioned in
  `docs/concepts/extensibility/wasm-plugins.md`.
- **WASM runtime tunables** — fuel limits, epoch interruption, and
  instance memory caps configurable via the `wasm` config block are
  not documented.
- **MCP `warmup` option** — the per-server `warmup` flag that triggers
  eager tool-list discovery on gateway startup is not documented.
- **MCP `refresh_on_error` option** — the per-server flag controlling
  whether SMG re-runs `list_tools` after a tool invocation fails is
  not documented.
- **`mcp_list_tools` conversation item type** — the Responses API emits
  this item during MCP tool discovery; `docs/reference/api/responses.md`
  does not describe it.
- **MCP proxy fallback ordering** — while this PR documents the
  `MCP_*_PROXY` variables, the full precedence rules between
  `mcp.yaml proxy:` and env vars deserve a dedicated subsection in
  a future operations/security pass.

<details>
<summary>Checklist</summary>

- [x] Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>