### PR TITLE
docs(workers): audit and fix worker setup, service discovery, external providers, HA

### DIFF
--- a/docs/concepts/architecture/high-availability.md
+++ b/docs/concepts/architecture/high-availability.md
@@ -127,12 +127,15 @@ smg --enable-mesh --mesh-host 0.0.0.0 --mesh-advertise-host 10.0.0.2 --mesh-port
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--enable-mesh` | `false` | Enable mesh networking for HA deployments |
-| `--mesh-server-name` | (auto) | Unique identifier for this node in the cluster |
+| `--mesh-server-name` | `Mesh_<4 random chars>` | Unique identifier for this node in the cluster |
 | `--mesh-host` | `0.0.0.0` | Bind address for mesh communication |
 | `--mesh-advertise-host` | `--mesh-host` | Routable address advertised to mesh peers |
 | `--mesh-port` | `39527` | Port for mesh gRPC communication |
-| `--mesh-peer-urls` | (none) | Initial peer URLs for cluster bootstrap |
+| `--mesh-peer-urls` | (none) | Initial peer URLs for cluster bootstrap; only the first entry is used as the bootstrap peer |
 | `--router-selector` | (none) | Label selector for Kubernetes pod discovery (e.g. `app=smg tier=router`) |
+
+!!! note "`--mesh-advertise-host` is required when `--mesh-host` is unspecified"
+    If `--mesh-host` is set to an unspecified bind address (for example `0.0.0.0`), the gateway refuses to start unless `--mesh-advertise-host` is set to a routable node IP. This prevents other peers from trying to dial an unroutable address.
 
 ### Python Entrypoint
 
@@ -191,25 +194,17 @@ smg --enable-mesh \
     --mesh-host 0.0.0.0 \
     --mesh-advertise-host 10.0.0.13 \
     --mesh-port 39527 \
-    --mesh-peer-urls "10.0.0.11:39527,10.0.0.12:39527" \
+    --mesh-peer-urls 10.0.0.11:39527 \
     --host 0.0.0.0 \
     --port 8000
 ```
 
-</div>
+!!! tip "Only the first peer bootstraps membership"
+    Later peers are learned via gossip after the initial connection. Pass exactly one reachable peer for cluster bootstrap — additional values on `--mesh-peer-urls` are currently ignored.
 
 </div>
 
-### Environment Variables
-
-```bash
-export SMG_ENABLE_MESH=true
-export SMG_MESH_SERVER_NAME=node1
-export SMG_MESH_HOST=0.0.0.0
-export SMG_MESH_ADVERTISE_HOST=10.0.0.11
-export SMG_MESH_PORT=39527
-export SMG_MESH_PEER_URLS="10.0.0.11:39527,10.0.0.12:39527"
-```
+</div>
 
 ---
 
@@ -303,12 +298,8 @@ Routing policy configuration and state.
 
 Cache-aware routing policy state is synchronized across mesh nodes. This ensures that KV cache routing decisions are consistent across all routers in the cluster, preventing redundant cache misses and enabling optimal prefix reuse regardless of which router handles the request.
 
-!!! info "Sync Endpoints"
-    The following endpoints expose cache-aware state across the mesh:
-
-    - `GET /mesh/cluster/status` — Cluster membership
-    - `GET /mesh/workers/state` — Worker state sync
-    - `GET /mesh/policies/state` — Policy state sync
+!!! info "Cluster introspection endpoints"
+    Use the HA management API under `/ha/*` (listed below) to inspect cluster membership, synchronized worker state, and policy state.
 
 ### CRDT Implementation
 
@@ -344,10 +335,10 @@ SMG uses several CRDT types for conflict-free synchronization:
 **Configuration**
 
 ```bash
-# All nodes
+# All nodes — point at one reachable peer for bootstrap
 smg --enable-mesh \
-    --mesh-peer-urls "node1:39527,node2:39527,node3:39527" \
-    --worker-urls http://worker1:8000,http://worker2:8000
+    --mesh-peer-urls node1:39527 \
+    --worker-urls http://worker1:8000 http://worker2:8000
 ```
 
 </div>
@@ -373,10 +364,10 @@ smg --enable-mesh \
 **Configuration**
 
 ```bash
-# All nodes
+# All nodes — point at one reachable peer for bootstrap
 smg --enable-mesh \
-    --mesh-peer-urls "node1:39527,node2:39527,node3:39527,node4:39527,node5:39527" \
-    --worker-urls http://worker1:8000,http://worker2:8000
+    --mesh-peer-urls node1:39527 \
+    --worker-urls http://worker1:8000 http://worker2:8000
 ```
 
 </div>
@@ -414,7 +405,7 @@ spec:
         - --mesh-host=0.0.0.0
         - --mesh-advertise-host=$(POD_IP)
         - --mesh-port=39527
-        - --mesh-peer-urls=smg-0.smg-mesh:39527,smg-1.smg-mesh:39527,smg-2.smg-mesh:39527
+        - --mesh-peer-urls=smg-0.smg-mesh:39527
         - --worker-urls=$(WORKER_URLS)
         env:
         - name: POD_NAME
@@ -479,16 +470,20 @@ smg --enable-mesh --service-discovery --router-selector app=smg tier=router
   "node_name": "node1",
   "node_count": 3,
   "nodes": [
-    {"name": "node1", "status": "ALIVE", "address": "node1:39527"},
-    {"name": "node2", "status": "ALIVE", "address": "node2:39527"},
-    {"name": "node3", "status": "ALIVE", "address": "node3:39527"}
+    {"name": "node1", "address": "node1:39527", "status": "1", "version": 1},
+    {"name": "node2", "address": "node2:39527", "status": "1", "version": 1},
+    {"name": "node3", "address": "node3:39527", "status": "1", "version": 1}
   ],
   "stores": {
-    "workers": {"entry_count": 5, "last_sync": "2024-01-15T10:30:00Z"},
-    "policies": {"entry_count": 2, "last_sync": "2024-01-15T10:30:00Z"}
+    "membership_count": 3,
+    "worker_count": 0,
+    "policy_count": 0,
+    "app_count": 0
   }
 }
 ```
+
+The `status` field is emitted as the stringified discriminant of the `NodeStatus` prost enum: `"0"` INIT, `"1"` ALIVE, `"2"` SUSPECTED, `"3"` DOWN, `"4"` LEAVING.
 
 ---
 

--- a/docs/concepts/architecture/service-discovery.md
+++ b/docs/concepts/architecture/service-discovery.md
@@ -85,15 +85,6 @@ smg \
 | `--service-discovery-namespace` | (all namespaces) | Kubernetes namespace to watch |
 | `--service-discovery-port` | `80` | Port to use for worker connections |
 
-### Environment Variables
-
-```bash
-export SMG_SERVICE_DISCOVERY=true
-export SMG_SELECTOR="app=sglang-worker"
-export SMG_SERVICE_DISCOVERY_NAMESPACE=inference
-export SMG_SERVICE_DISCOVERY_PORT=8000
-```
-
 ---
 
 ## Label Selectors
@@ -112,21 +103,13 @@ Matches pods with label `app=vllm`.
 
 ### Multiple Labels
 
-Match pods with multiple labels:
+Match pods that carry several labels by passing multiple `key=value` pairs:
 
 ```bash
-smg --service-discovery --selector "app=sglang,environment=production"
+smg --service-discovery --selector app=sglang environment=production
 ```
 
 Matches pods with both `app=sglang` AND `environment=production`.
-
-### Complex Selectors
-
-Use set-based selectors for more complex matching:
-
-```bash
-smg --service-discovery --selector "app in (sglang, vllm),tier=inference"
-```
 
 ---
 
@@ -140,8 +123,8 @@ For prefill-decode disaggregated deployments, use separate selectors for each wo
 smg \
   --service-discovery \
   --pd-disaggregation \
-  --prefill-selector "app=sglang,role=prefill" \
-  --decode-selector "app=sglang,role=decode" \
+  --prefill-selector app=sglang role=prefill \
+  --decode-selector app=sglang role=decode \
   --service-discovery-namespace inference
 ```
 
@@ -298,8 +281,6 @@ spec:
           ports:
             - containerPort: 8000
               name: http
-            - containerPort: 3001
-              name: admin
 ```
 
 !!! tip "Engine images"
@@ -342,7 +323,7 @@ spec:
 
 1. **Pod Created**: Kubernetes creates a new worker pod
 2. **Watch Event**: SMG receives the pod creation event
-3. **Capability Query**: SMG queries the worker's `/get_model_info` endpoint
+3. **Capability Query**: SMG queries the worker's `/model_info` endpoint (falling back to the deprecated `/get_model_info` if the new path returns 404)
 4. **Registration**: Worker is added to the registry
 5. **Health Check**: Background health checks begin
 
@@ -357,10 +338,10 @@ spec:
 
 | State | Description | Receives Traffic |
 |-------|-------------|------------------|
-| **Registering** | Querying capabilities | No |
-| **Ready** | Healthy and registered | Yes |
-| **Unhealthy** | Failing health checks | No |
-| **Draining** | Pending removal | No |
+| **Pending** | Just registered, not yet proven healthy locally | No |
+| **Ready** | Locally verified and passing health checks | Yes |
+| **NotReady** | Previously `Ready`, now failing readiness checks; not removed unless configured | No |
+| **Failed** | Sustained liveness failure; removed when `--remove-unhealthy-workers` is set | No |
 
 ---
 
@@ -373,6 +354,7 @@ spec:
 | `smg_discovery_workers_discovered` | Workers known via discovery |
 | `smg_discovery_registrations_total` | Worker registration events |
 | `smg_discovery_deregistrations_total` | Worker deregistration events |
+| `smg_discovery_sync_duration_seconds` | Duration of each periodic reconciliation cycle |
 
 ### Logs
 
@@ -406,7 +388,7 @@ Example log output:
 
 ```bash
 # Check discovered workers via admin API
-curl http://smg:3001/workers | jq
+curl http://smg:30000/workers | jq
 
 # Check pod labels match selector
 kubectl get pods -n inference -l app=sglang-worker

--- a/docs/getting-started/external-providers.md
+++ b/docs/getting-started/external-providers.md
@@ -24,9 +24,9 @@ SMG auto-detects the provider from the model name in each request and applies th
 | Provider | Auto-Detection | Header Format |
 |----------|---------------|---------------|
 | OpenAI | `gpt-*`, `o1-*`, `o3-*` models | `Authorization: Bearer` |
-| Anthropic | `claude-*` models | `x-api-key` |
+| Anthropic | `claude-*` models | `x-api-key` (plus `anthropic-version`) |
 | xAI | `grok-*` models | `Authorization: Bearer` |
-| Google Gemini | `gemini-*` models | `Authorization: Bearer` |
+| Google Gemini | `gemini-*` models | `x-goog-api-key` |
 
 ---
 
@@ -70,7 +70,7 @@ SMG supports fan-out model discovery across all registered external workers. Whe
 
 1. Fans out the request to all healthy external workers concurrently
 2. Forwards the caller's token to each upstream provider
-3. Aggregates and returns the discovered models from all providers
+3. Returns the first non-empty model inventory from the fanned-out upstream responses
 
 ```bash
 curl http://localhost:30000/v1/models \

--- a/docs/getting-started/multiple-workers.md
+++ b/docs/getting-started/multiple-workers.md
@@ -54,7 +54,7 @@ See [gRPC Workers](grpc-workers.md) for details on what gRPC mode enables.
 
 ## Cloud API Workers
 
-Route to cloud providers by setting `--backend openai` and passing the provider URL. API keys are read from environment variables. SMG auto-detects the provider (OpenAI, Anthropic, xAI, Gemini) from the model name and applies the correct API transformations.
+Route to cloud providers by setting `--backend` and passing the provider URL. API keys are either passed by the caller through the `Authorization` header (BYOK) or stored on the worker record when registering via the admin API. SMG auto-detects the provider (OpenAI, Anthropic, xAI, Gemini) from the model name and applies the correct API transformations.
 
 === "OpenAI"
 
@@ -164,7 +164,7 @@ The `POST /workers` endpoint accepts additional fields:
 |-------|---------|-------------|
 | `url` | (required) | Worker URL (`http://`, `grpc://`, or `https://` for cloud) |
 | `api_key` | — | API key for authenticated workers |
-| `runtime` | `sglang` | Runtime: `sglang`, `vllm`, `trtllm`, or `external` |
+| `runtime` | (auto-detect) | Runtime: `sglang`, `vllm`, `trtllm`, `mlx`, or `external` |
 | `worker_type` | `regular` | Type: `regular`, `prefill`, or `decode` |
 | `priority` | `50` | Routing priority (0–100, higher = preferred) |
 | `cost` | `1.0` | Cost multiplier for cost-aware routing |

--- a/docs/getting-started/service-discovery.md
+++ b/docs/getting-started/service-discovery.md
@@ -38,9 +38,10 @@ SMG watches for pods matching the selector and automatically adds or removes wor
 |-----------|---------|-------------|
 | `--service-discovery` | `false` | Enable Kubernetes service discovery |
 | `--selector` | — | Label selector for worker pods (required) |
-| `--service-discovery-namespace` | `default` | Kubernetes namespace to watch |
-| `--service-discovery-port` | `8000` | Port to use for worker connections |
-| `--service-discovery-protocol` | `http` | Protocol: `http` or `grpc` |
+| `--service-discovery-namespace` | (all namespaces) | Kubernetes namespace to watch |
+| `--service-discovery-port` | `80` | Port to use for worker connections |
+
+Connection mode (HTTP vs gRPC) is probed automatically during worker registration, so no protocol flag is required — the first protocol that responds successfully is used, with HTTP taking priority when both succeed.
 
 ---
 
@@ -54,17 +55,13 @@ smg --service-discovery --selector app=vllm
 
 ### Multiple Labels
 
-```bash
-smg --service-discovery --selector "app=sglang,environment=production"
-```
-
-Matches pods with both labels.
-
-### Set-Based Selectors
+Pass multiple `key=value` pairs separated by spaces:
 
 ```bash
-smg --service-discovery --selector "app in (sglang, vllm),tier=inference"
+smg --service-discovery --selector app=sglang environment=production
 ```
+
+Matches pods that carry every listed label.
 
 ---
 
@@ -76,8 +73,8 @@ For prefill-decode deployments, use separate selectors:
 smg \
   --service-discovery \
   --pd-disaggregation \
-  --prefill-selector "app=sglang,role=prefill" \
-  --decode-selector "app=sglang,role=decode" \
+  --prefill-selector app=sglang role=prefill \
+  --decode-selector app=sglang role=decode \
   --service-discovery-namespace inference
 ```
 


### PR DESCRIPTION
## Description

### Problem
Documentation for worker setup, service discovery, external cloud
provider routing, and high-availability mesh may be out of date,
incorrect, or missing content relative to the current codebase. Many
of the claims in these pages (defaults, flag names, headers, example
JSON responses, label-selector syntax, bootstrap semantics) were
never mechanically checked against source after recent refactors.

### Solution
Systematic audit of the following doc files against source code,
verifying every CLI flag default, endpoint path, request/response
field, header format, bootstrap recipe, and example command, then
fixing discrepancies in place while preserving the surrounding style:

- `docs/getting-started/multiple-workers.md`
- `docs/getting-started/service-discovery.md`
- `docs/getting-started/external-providers.md`
- `docs/concepts/architecture/service-discovery.md`
- `docs/concepts/architecture/high-availability.md`

Scoped to six doc files in total (including `docs/getting-started/
grpc-workers.md`, which was audited and found accurate — left
untouched). Every change cites a file:line reference in
`model_gateway/`, `crates/protocols/`, `crates/mesh/`, or
`crates/mesh/src/proto/gossip.proto`. Writer phase performed
inventory, verify, discover, and fix; Tech Lead phase independently
re-verified every change against cited source code, with an explicit
second review round to resolve three blocking items before shipping.

## Changes

- Verified ~110 claims across 6 doc files
- Fixed 18 inaccuracies across 5 touched doc files
- Updated 4 outdated items (runtime enum coverage including `mlx`,
  worker states table matching the `WorkerStatus` enum, discovery
  metrics table, service-discovery registration flow `/model_info`
  with documented `/get_model_info` 404 fallback)
- Documented 11 previously undocumented features (mesh bootstrap
  semantics, `--mesh-advertise-host` requirement on unspecified bind
  addresses, connection mode auto-probing during registration, the
  `NodeStatus` enum discriminant format used in `/ha/status`
  responses, and other small surfaces)
- Removed non-existent sections: Environment Variables blocks in
  `service-discovery.md` and `high-availability.md` (no service
  discovery or mesh CLI arg reads env vars), fabricated
  `containerPort: 3001 / name: admin` in a K8s example, stale
  `/mesh/cluster/status` sync endpoints admonition, and the
  non-existent `--service-discovery-protocol` row
- Corrected the `/ha/status` cluster status JSON example in
  `concepts/architecture/high-availability.md` to match the actual
  observable format emitted by the mesh status handler. `status` is
  produced by `format!("{:?}", node.status)` where `node.status` is
  the prost-generated `i32`, so Debug on `i32` emits the decimal
  discriminant (`"1"` for ALIVE) rather than the enum name. Also
  added the full discriminant mapping
  (`0` INIT / `1` ALIVE / `2` SUSPECTED / `3` DOWN / `4` LEAVING).
- Switched the PD `--prefill-selector` / `--decode-selector` examples
  in both service-discovery pages from broken quoted comma-separated
  form to the working space-separated `key=value` form, since
  `parse_selector` splits each element at the first `=` and the clap
  args use `num_args = 0..` for multi-value support.
- Switched the `--mesh-peer-urls` examples in three-node, five-node,
  and StatefulSet K8s configurations to a single bootstrap peer, and
  added an explanatory admonition documenting that only the first
  entry is used as the bootstrap peer with the rest learned via
  gossip.

## Test Plan

- Each fix cites a source code reference (file:line) in the commit
  message body and in the audit worksheet.
- `mkdocs build --strict --clean --quiet` runs cleanly on the PR tree.
- Two independent review rounds by the Tech Lead agent against cited
  source code, with a Round 1 punch list covering the three blocking
  items listed above and a Round 2 re-verification resolving them.
- No source code (Rust, Python bindings, Cargo, Makefile, GitHub
  workflows) was modified.
- Internal doc links in the touched files still resolve under
  `mkdocs --strict`.

<details>
<summary>Checklist</summary>

- [x] Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated HA mesh configuration guidance: default server names, bootstrap semantics, and simplified Kubernetes examples.
  * Clarified API response formats with numeric status discriminants and aggregated node counts.
  * Simplified service discovery: removed environment variables, updated CLI selector syntax to space-separated format, and auto-probed connection modes.
  * Updated external provider authentication requirements for Anthropic and Google Gemini.
  * Revised worker lifecycle states and Cloud API Workers setup instructions with flexible authentication options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->