### PR TITLE
feat(protocols): add serde(flatten) to chat response structs for engine-specific fields

### DIFF
--- a/crates/protocols/src/chat.rs
+++ b/crates/protocols/src/chat.rs
@@ -669,6 +669,10 @@ pub struct ChatCompletionResponse {
     pub choices: Vec<ChatChoice>,
     pub usage: Option<Usage>,
     pub system_fingerprint: Option<String>,
+
+    /// Additional fields not explicitly defined above (e.g. engine-specific parameters)
+    #[serde(flatten)]
+    pub other: Map<String, Value>,
 }
 
 impl ChatCompletionResponse {
@@ -692,6 +696,10 @@ pub struct ChatCompletionMessage {
     pub reasoning_content: Option<String>,
     // Note: function_call is deprecated and not included
     // Note: refusal, annotations, audio are not added yet
+
+    /// Additional fields not explicitly defined above (e.g. engine-specific parameters)
+    #[serde(flatten)]
+    pub other: Map<String, Value>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
@@ -707,6 +715,10 @@ pub struct ChatChoice {
     /// Hidden states from the model (SGLang extension)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hidden_states: Option<Vec<f32>>,
+
+    /// Additional fields not explicitly defined above (e.g. engine-specific parameters)
+    #[serde(flatten)]
+    pub other: Map<String, Value>,
 }
 
 #[serde_with::skip_serializing_none]
@@ -719,6 +731,10 @@ pub struct ChatCompletionStreamResponse {
     pub system_fingerprint: Option<String>,
     pub choices: Vec<ChatStreamChoice>,
     pub usage: Option<Usage>,
+
+    /// Additional fields not explicitly defined above (e.g. engine-specific parameters)
+    #[serde(flatten)]
+    pub other: Map<String, Value>,
 }
 
 impl ChatCompletionStreamResponse {
@@ -741,6 +757,10 @@ pub struct ChatMessageDelta {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_calls: Option<Vec<ToolCallDelta>>,
     pub reasoning_content: Option<String>,
+
+    /// Additional fields not explicitly defined above (e.g. engine-specific parameters)
+    #[serde(flatten)]
+    pub other: Map<String, Value>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
@@ -751,4 +771,8 @@ pub struct ChatStreamChoice {
     pub finish_reason: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub matched_stop: Option<Value>,
+
+    /// Additional fields not explicitly defined above (e.g. engine-specific parameters)
+    #[serde(flatten)]
+    pub other: Map<String, Value>,
 }


### PR DESCRIPTION
## Summary
Mirrors the request-side flatten pattern landed in #1130 for \`ChatCompletionRequest\`, extending \`#[serde(flatten)] pub other: Map<String, Value>\` to the response-side structs in \`crates/protocols/src/chat.rs\`:

- \`ChatCompletionResponse\`
- \`ChatCompletionMessage\`
- \`ChatChoice\`
- \`ChatCompletionStreamResponse\`
- \`ChatMessageDelta\`
- \`ChatStreamChoice\`

Needed so engine-specific response fields (e.g. SGLang's \`routed_experts\`, \`completion_token_ids\`) round-trip through the smg gateway without being silently dropped by serde's default unknown-field behavior on the response path.

This is the paired follow-on to #1130. Same pattern, same doc comment, same idiom.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved chat response compatibility by adding support for additional engine-specific and unmodeled JSON fields. Chat API responses with extra data will now be properly preserved during serialization and deserialization, enabling better integration with diverse chat platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->