### PR TITLE
feat(mesh): MeshKV wrapper with explicit namespace handles (v2 Step 1)

### DIFF
--- a/crates/mesh/Cargo.toml
+++ b/crates/mesh/Cargo.toml
@@ -33,6 +33,7 @@ tracing.workspace = true
 
 # Mesh-specific dependencies
 bincode = "1.3"
+bytes = "1"
 crdts = "7.3"
 futures = "0.3"
 metrics = "0.24.2"

--- a/crates/mesh/src/crdt_kv/crdt.rs
+++ b/crates/mesh/src/crdt_kv/crdt.rs
@@ -391,7 +391,8 @@ impl CrdtOrMap {
                         .iter()
                         .max_by_key(|v| v.version_key())
                         .is_none_or(|winner| {
-                            winner.is_tombstone && now.duration_since(winner.created_at) >= grace
+                            winner.is_tombstone
+                                && now.saturating_duration_since(winner.created_at) >= grace
                         })
             });
             if was_removed.is_some() {

--- a/crates/mesh/src/crdt_kv/crdt.rs
+++ b/crates/mesh/src/crdt_kv/crdt.rs
@@ -1,4 +1,8 @@
-use std::{collections::HashSet, sync::Arc};
+use std::{
+    collections::HashSet,
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 use dashmap::{mapref::entry::Entry as MapEntry, DashMap};
 use parking_lot::{Mutex, RwLock};
@@ -14,13 +18,32 @@ use super::{
 // CRDT OR-Map - Observed-Remove Map Implementation
 // ============================================================================
 
+/// Default tombstone grace period. Tombstones younger than this are not
+/// garbage collected, preventing data resurrection from stale peers.
+/// Gossip converges in seconds for small clusters, so 5 minutes is very
+/// conservative.
+pub const DEFAULT_TOMBSTONE_GRACE: Duration = Duration::from_secs(300);
+
 /// Value metadata for CRDT OR-Map
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 struct ValueMetadata {
     timestamp: u64,
     replica_id: ReplicaId,
     is_tombstone: bool, // Marks if this version is a tombstone (deletion)
+    /// Monotonic timestamp for tombstone GC. Tombstones younger than
+    /// `tombstone_grace` are not garbage collected to prevent data resurrection.
+    created_at: Instant,
 }
+
+impl PartialEq for ValueMetadata {
+    fn eq(&self, other: &Self) -> bool {
+        self.timestamp == other.timestamp
+            && self.replica_id == other.replica_id
+            && self.is_tombstone == other.is_tombstone
+    }
+}
+
+impl Eq for ValueMetadata {}
 
 impl ValueMetadata {
     fn new(timestamp: u64, replica_id: ReplicaId) -> Self {
@@ -28,6 +51,7 @@ impl ValueMetadata {
             timestamp,
             replica_id,
             is_tombstone: false,
+            created_at: Instant::now(),
         }
     }
 
@@ -36,6 +60,7 @@ impl ValueMetadata {
             timestamp,
             replica_id,
             is_tombstone: true,
+            created_at: Instant::now(),
         }
     }
 
@@ -320,9 +345,24 @@ impl CrdtOrMap {
     /// Remove tombstoned keys from the metadata and key_locks maps.
     /// Keys that are not in the live store and whose latest metadata entry
     /// is a tombstone are cleaned up to prevent unbounded memory growth.
+    ///
+    /// Tombstones younger than `grace` are NOT removed, preventing data
+    /// resurrection from stale peers that haven't received the tombstone yet
+    /// Default grace period: 5 minutes.
+    ///
     /// Returns the number of entries removed.
     pub fn gc_tombstones(&self) -> usize {
+        self.gc_tombstones_with_grace(DEFAULT_TOMBSTONE_GRACE)
+    }
+
+    /// Like `gc_tombstones` but with a custom grace period.
+    /// Useful for testing with shorter durations.
+    pub fn gc_tombstones_with_grace(&self, grace: Duration) -> usize {
+        let now = Instant::now();
         let mut removed = 0;
+        // Collect-then-remove: collect keys to check first (read-only iteration),
+        // then remove individually. This avoids locking all DashMap shards
+        // simultaneously, which would stall concurrent writers.
         let keys_to_check: Vec<String> = self
             .metadata
             .iter()
@@ -341,15 +381,18 @@ impl CrdtOrMap {
                 Arc::strong_count(lock) <= 2 && lock.try_lock().is_some()
             });
             // Atomically remove metadata only if the key is still not in the
-            // live store AND still tombstoned. The remove_if closure runs
-            // under the DashMap shard lock, preventing a concurrent insert
-            // from racing between check and remove.
+            // live store AND still tombstoned AND the tombstone is older than
+            // the grace period. The remove_if closure runs under the DashMap
+            // shard lock, preventing a concurrent insert from racing between
+            // check and remove.
             let was_removed = self.metadata.remove_if(&key, |_, versions| {
                 !self.store.contains_key(&key)
                     && versions
                         .iter()
                         .max_by_key(|v| v.version_key())
-                        .is_none_or(|winner| winner.is_tombstone)
+                        .is_none_or(|winner| {
+                            winner.is_tombstone && now.duration_since(winner.created_at) >= grace
+                        })
             });
             if was_removed.is_some() {
                 removed += 1;

--- a/crates/mesh/src/crdt_kv/crdt.rs
+++ b/crates/mesh/src/crdt_kv/crdt.rs
@@ -323,6 +323,11 @@ impl CrdtOrMap {
         self.store.generation()
     }
 
+    /// Get all keys without cloning values.
+    pub fn keys(&self) -> Vec<String> {
+        self.store.keys()
+    }
+
     /// Get all key-value pairs
     pub fn all(&self) -> std::collections::BTreeMap<String, Vec<u8>> {
         self.store.all()

--- a/crates/mesh/src/crdt_kv/kv_store.rs
+++ b/crates/mesh/src/crdt_kv/kv_store.rs
@@ -82,6 +82,11 @@ impl KvStore {
         self.store.len()
     }
 
+    /// Get all keys without cloning values.
+    pub fn keys(&self) -> Vec<String> {
+        self.store.iter().map(|entry| entry.key().clone()).collect()
+    }
+
     /// Get all key-value pairs as a BTreeMap
     pub fn all(&self) -> std::collections::BTreeMap<String, Vec<u8>> {
         self.store

--- a/crates/mesh/src/crdt_kv/tests.rs
+++ b/crates/mesh/src/crdt_kv/tests.rs
@@ -1,4 +1,4 @@
-use std::{sync::Once, thread};
+use std::{sync::Once, thread, time::Duration};
 
 use tracing::info;
 use tracing_subscriber::{
@@ -349,4 +349,58 @@ fn test_distributed_scenario() {
     assert_eq!(replica1.get("user:1"), Some(b"Alice_Updated".to_vec()));
     assert_eq!(replica1.get("user:3"), Some(b"Charlie".to_vec()));
     assert_eq!(replica1.get("user:4"), Some(b"David".to_vec()));
+}
+
+// ============================================================================
+// Tombstone GC Grace Period Tests
+// ============================================================================
+
+#[test]
+fn test_gc_tombstones_respects_grace_period() {
+    init_test_logging();
+    let map = CrdtOrMap::new();
+
+    map.insert("key1".to_string(), b"value1".to_vec());
+    map.remove("key1");
+
+    // GC with a long grace period — tombstone is too young, should NOT be collected.
+    let removed = map.gc_tombstones_with_grace(Duration::from_secs(3600));
+    assert_eq!(removed, 0, "Young tombstone should not be GC'd");
+
+    // GC with zero grace period — tombstone should be collected immediately.
+    let removed = map.gc_tombstones_with_grace(Duration::ZERO);
+    assert_eq!(removed, 1, "Expired tombstone should be GC'd");
+}
+
+#[test]
+fn test_gc_tombstones_does_not_remove_live_keys() {
+    init_test_logging();
+    let map = CrdtOrMap::new();
+
+    map.insert("key1".to_string(), b"value1".to_vec());
+    map.insert("key2".to_string(), b"value2".to_vec());
+
+    // GC should not remove live (non-tombstoned) keys.
+    let removed = map.gc_tombstones_with_grace(Duration::ZERO);
+    assert_eq!(removed, 0);
+    assert_eq!(map.get("key1"), Some(b"value1".to_vec()));
+    assert_eq!(map.get("key2"), Some(b"value2".to_vec()));
+}
+
+#[test]
+fn test_gc_tombstones_multiple_keys() {
+    init_test_logging();
+    let map = CrdtOrMap::new();
+
+    map.insert("key1".to_string(), b"v1".to_vec());
+    map.insert("key2".to_string(), b"v2".to_vec());
+    map.insert("key3".to_string(), b"v3".to_vec());
+
+    map.remove("key1");
+    map.remove("key3");
+    // key2 stays alive.
+
+    let removed = map.gc_tombstones_with_grace(Duration::ZERO);
+    assert_eq!(removed, 2, "Two tombstoned keys should be GC'd");
+    assert_eq!(map.get("key2"), Some(b"v2".to_vec()));
 }

--- a/crates/mesh/src/kv.rs
+++ b/crates/mesh/src/kv.rs
@@ -107,19 +107,11 @@ pub struct Subscription {
 /// round. Returns accumulated entries to be sent in this round's batch.
 pub type StreamDrainFn = Box<dyn Fn() -> Vec<(String, Vec<u8>)> + Send + Sync>;
 
-/// Handle returned by `register_drain`. Drop or call `unregister()` to remove
-/// the drain callback.
+/// Handle returned by `register_drain`. Dropping unregisters the drain callback.
+/// Use `drop(handle)` to explicitly unregister.
 pub struct DrainHandle {
     prefix: String,
     drain_registry: Arc<DrainRegistry>,
-}
-
-impl DrainHandle {
-    /// Unregister the drain callback. After this call, the callback will not
-    /// be invoked on future gossip rounds.
-    pub fn unregister(self) {
-        self.drain_registry.remove(&self.prefix);
-    }
 }
 
 impl Drop for DrainHandle {

--- a/crates/mesh/src/kv.rs
+++ b/crates/mesh/src/kv.rs
@@ -1,0 +1,687 @@
+//! MeshKV: Generic, application-agnostic mesh transport with explicit namespace handles.
+//!
+//! Provides two explicit namespace types:
+//! - `CrdtNamespace` for durable, mergeable state (workers, policies, rate limits, config)
+//! - `StreamNamespace` for ephemeral, lossy, application-regenerated traffic (tenant deltas, tree repair)
+//!
+//! See mesh-v2-implementation-spec.md for the full design.
+
+use std::{collections::HashMap, sync::Arc, time::Instant};
+
+use bytes::Bytes;
+use dashmap::DashMap;
+use parking_lot::RwLock;
+use tokio::sync::mpsc;
+
+use crate::crdt_kv::CrdtOrMap;
+
+// ============================================================================
+// Type Definitions (Spec Section 1.1 - 1.3)
+// ============================================================================
+
+/// Merge strategy for CRDT namespaces. Determines how conflicts are resolved
+/// when two nodes write the same key concurrently.
+#[derive(Debug, Clone)]
+#[expect(clippy::enum_variant_names)]
+pub enum MergeStrategy {
+    /// Higher (version, replica_id) wins. Used for worker:*, policy:*, config:*.
+    LastWriterWins,
+    /// Higher numeric value wins (simple max). Reserved for future use.
+    MaxValueWins,
+    /// Compare epochs first, then max within same epoch.
+    /// The mesh crate implements this internally — no application callback needed.
+    /// Values MUST be exactly 16 bytes: epoch (u64 big-endian) + count (i64 big-endian).
+    /// The adapter is responsible for serializing RateLimitValue to this fixed format.
+    ///
+    /// If either local or remote value is not exactly 16 bytes (corrupt/truncated message),
+    /// the merge keeps the well-formed value. If both are malformed, keeps local.
+    EpochMaxWins,
+}
+
+/// Routing mode for stream namespaces.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StreamRouting {
+    /// Send to all connected peers (e.g., tenant deltas).
+    Broadcast,
+    /// Send to exactly one peer (e.g., tree repair requests/pages).
+    Targeted,
+}
+
+/// Configuration for a stream namespace.
+#[derive(Debug, Clone)]
+pub struct StreamConfig {
+    /// Maximum bytes buffered before backpressure (oldest entries dropped).
+    pub max_buffer_bytes: usize,
+    /// Routing mode: broadcast to all peers or targeted to one peer.
+    pub routing: StreamRouting,
+}
+
+/// Mode selection for a namespace prefix. Internal enum used during configuration.
+#[derive(Debug)]
+#[expect(dead_code)] // Fields read during later steps (gossip integration)
+enum StoreMode {
+    Crdt {
+        merge_strategy: MergeStrategy,
+    },
+    Stream {
+        max_buffer_bytes: usize,
+        routing: StreamRouting,
+    },
+}
+
+/// CRDT mode entry metadata (Spec Section 1.1).
+#[derive(Debug, Clone)]
+#[expect(dead_code)] // Constructed in later steps (CRDT merge integration)
+pub(crate) struct ValueEntry {
+    /// The actual data (opaque bytes — mesh doesn't interpret).
+    pub value: Vec<u8>,
+    /// Lamport timestamp (logical clock).
+    pub version: u64,
+    /// Deterministic hash of server_name, computed once at MeshKV startup.
+    pub replica_id: u64,
+    /// Soft-deleted? Tombstones propagate via gossip and win by higher version.
+    pub tombstone: bool,
+    /// Monotonic timestamp for tombstone GC. Tombstones younger than
+    /// `tombstone_grace` (default 5 min) are not garbage collected.
+    pub created_at: Instant,
+}
+
+// ============================================================================
+// Subscription (Spec Section 6.1 - 6.3)
+// ============================================================================
+
+/// A subscription to changes for keys matching a prefix.
+/// Delivers via a bounded mpsc channel. Capacity is per-prefix:
+/// - worker:  1000
+/// - policy:  100
+/// - rl:      100
+/// - config:  100
+/// - td:      50
+/// - tree:req: 100
+/// - tree:page: 32
+pub struct Subscription {
+    /// Receives (key, value) pairs as they are written or received from peers.
+    pub receiver: mpsc::Receiver<(String, Bytes)>,
+}
+
+/// Function signature for stream drain callbacks. Called exactly once per gossip
+/// round. Returns accumulated entries to be sent in this round's batch.
+pub type StreamDrainFn = Box<dyn Fn() -> Vec<(String, Vec<u8>)> + Send + Sync>;
+
+/// Handle returned by `register_drain`. Drop or call `unregister()` to remove
+/// the drain callback.
+pub struct DrainHandle {
+    prefix: String,
+    drain_registry: Arc<DrainRegistry>,
+}
+
+impl DrainHandle {
+    /// Unregister the drain callback. After this call, the callback will not
+    /// be invoked on future gossip rounds.
+    pub fn unregister(self) {
+        self.drain_registry.remove(&self.prefix);
+    }
+}
+
+impl Drop for DrainHandle {
+    fn drop(&mut self) {
+        self.drain_registry.remove(&self.prefix);
+    }
+}
+
+// ============================================================================
+// Subscriber Registry (internal)
+// ============================================================================
+
+/// Tracks all active subscriptions by prefix.
+struct SubscriberRegistry {
+    /// prefix -> list of senders. Multiple subscribers can watch the same prefix.
+    subscribers: DashMap<String, Vec<mpsc::Sender<(String, Bytes)>>>,
+}
+
+impl SubscriberRegistry {
+    fn new() -> Self {
+        Self {
+            subscribers: DashMap::new(),
+        }
+    }
+
+    fn register(&self, prefix: &str, tx: mpsc::Sender<(String, Bytes)>) {
+        self.subscribers
+            .entry(prefix.to_string())
+            .or_default()
+            .push(tx);
+    }
+
+    /// Notify all subscribers whose prefix matches the given key.
+    /// Uses try_send to never block the gossip loop (Spec Section 6.3).
+    fn notify(&self, key: &str, value: Bytes) {
+        for entry in &self.subscribers {
+            let prefix = entry.key();
+            if key.starts_with(prefix.as_str()) {
+                // try_send: never block. If full, entry is dropped.
+                // For CRDT: watermark not advanced, resent next round.
+                // For Stream: dropped permanently (ephemeral).
+                for tx in entry.value() {
+                    let _ = tx.try_send((key.to_string(), value.clone()));
+                }
+            }
+        }
+    }
+
+    /// Remove closed senders (adapter dropped its Subscription).
+    #[expect(dead_code)] // Called by gossip GC cycle in later steps
+    fn gc_closed(&self) {
+        let mut closed_prefixes = Vec::new();
+        for entry in &self.subscribers {
+            if entry.value().iter().all(|tx| tx.is_closed()) {
+                closed_prefixes.push(entry.key().clone());
+            }
+        }
+        for prefix in closed_prefixes {
+            self.subscribers.remove(&prefix);
+        }
+    }
+}
+
+// ============================================================================
+// Drain Registry (internal)
+// ============================================================================
+
+/// Tracks registered drain callbacks for stream namespaces.
+struct DrainRegistry {
+    drains: DashMap<String, Arc<StreamDrainFn>>,
+}
+
+impl DrainRegistry {
+    fn new() -> Self {
+        Self {
+            drains: DashMap::new(),
+        }
+    }
+
+    fn register(&self, prefix: &str, drain: StreamDrainFn) {
+        self.drains.insert(prefix.to_string(), Arc::new(drain));
+    }
+
+    fn remove(&self, prefix: &str) {
+        self.drains.remove(prefix);
+    }
+
+    /// Call all registered drains. Returns accumulated entries.
+    /// Called exactly once per gossip round (Spec Section 5.4).
+    #[expect(dead_code)] // Called by centralized gossip loop in Step 2
+    fn drain_all(&self) -> Vec<(String, Vec<u8>)> {
+        let mut all_entries = Vec::new();
+        for entry in &self.drains {
+            let drain_fn = entry.value();
+            all_entries.extend(drain_fn());
+        }
+        all_entries
+    }
+}
+
+// ============================================================================
+// Prefix Configuration (internal)
+// ============================================================================
+
+/// Per-prefix subscriber channel capacity (Spec Section 6.3).
+fn subscriber_capacity_for_prefix(prefix: &str) -> usize {
+    match prefix {
+        "worker:" => 1000,
+        "policy:" => 100,
+        "rl:" => 100,
+        "config:" => 100,
+        "td:" => 50,
+        "tree:req:" => 100,
+        "tree:page:" => 32,
+        _ => 100, // default for unknown prefixes
+    }
+}
+
+// ============================================================================
+// CrdtNamespace (Spec Section 1.2, 2)
+// ============================================================================
+
+/// Handle for durable, mergeable state. Scoped to a key prefix.
+/// Provides put/get/delete/keys/subscribe.
+pub struct CrdtNamespace {
+    prefix: String,
+    store: Arc<CrdtOrMap>,
+    subscriber_registry: Arc<SubscriberRegistry>,
+    merge_strategy: MergeStrategy,
+}
+
+impl CrdtNamespace {
+    /// Insert or update a key-value pair. The key must start with this
+    /// namespace's prefix.
+    pub fn put(&self, key: &str, value: Vec<u8>) {
+        assert!(
+            key.starts_with(&self.prefix),
+            "key '{key}' does not match prefix '{}'",
+            self.prefix
+        );
+        self.store.insert(key.to_string(), value.clone());
+        self.subscriber_registry.notify(key, Bytes::from(value));
+    }
+
+    /// Get the current value for a key, or None if not present or tombstoned.
+    pub fn get(&self, key: &str) -> Option<Vec<u8>> {
+        assert!(
+            key.starts_with(&self.prefix),
+            "key '{key}' does not match prefix '{}'",
+            self.prefix
+        );
+        self.store.get(key)
+    }
+
+    /// Delete a key by writing a tombstone. The tombstone propagates via gossip
+    /// and wins by higher version. Actual removal happens after GC grace period.
+    pub fn delete(&self, key: &str) {
+        assert!(
+            key.starts_with(&self.prefix),
+            "key '{key}' does not match prefix '{}'",
+            self.prefix
+        );
+        self.store.remove(key);
+    }
+
+    /// List all live keys matching a sub-prefix within this namespace.
+    pub fn keys(&self, sub_prefix: &str) -> Vec<String> {
+        let full_prefix = format!("{}{}", self.prefix, sub_prefix);
+        self.store
+            .all()
+            .keys()
+            .filter(|k| k.starts_with(&full_prefix))
+            .cloned()
+            .collect()
+    }
+
+    /// Subscribe to changes for keys matching a sub-prefix within this namespace.
+    /// Channel capacity is determined by the namespace prefix (Spec Section 6.3).
+    pub fn subscribe(&self, sub_prefix: &str) -> Subscription {
+        let full_prefix = format!("{}{}", self.prefix, sub_prefix);
+        let capacity = subscriber_capacity_for_prefix(&self.prefix);
+        let (tx, rx) = mpsc::channel(capacity);
+        self.subscriber_registry.register(&full_prefix, tx);
+        Subscription { receiver: rx }
+    }
+
+    /// Get the merge strategy for this namespace.
+    pub fn merge_strategy(&self) -> &MergeStrategy {
+        &self.merge_strategy
+    }
+
+    /// Get the prefix for this namespace.
+    pub fn prefix(&self) -> &str {
+        &self.prefix
+    }
+}
+
+// ============================================================================
+// StreamNamespace (Spec Section 1.2, 3)
+// ============================================================================
+
+/// Handle for ephemeral, lossy, application-regenerated traffic. Scoped to a
+/// key prefix with a fixed routing mode (Broadcast or Targeted).
+pub struct StreamNamespace {
+    prefix: String,
+    routing: StreamRouting,
+    #[expect(dead_code)] // Used for backpressure enforcement in Step 2
+    max_buffer_bytes: usize,
+    /// Ephemeral send buffer, drained every gossip round.
+    buffer: Arc<DashMap<String, Bytes>>,
+    /// Targeted entries: (target_peer_id, key, value).
+    targeted_buffer: Arc<parking_lot::Mutex<Vec<(String, String, Bytes)>>>,
+    subscriber_registry: Arc<SubscriberRegistry>,
+    drain_registry: Arc<DrainRegistry>,
+}
+
+impl StreamNamespace {
+    /// Publish a value to all connected peers (Broadcast namespaces only).
+    pub fn publish(&self, key: &str, value: Bytes) {
+        assert!(
+            self.routing == StreamRouting::Broadcast,
+            "publish() is only valid on Broadcast namespaces, not Targeted (prefix: '{}')",
+            self.prefix
+        );
+        assert!(
+            key.starts_with(&self.prefix),
+            "key '{key}' does not match prefix '{}'",
+            self.prefix
+        );
+        self.buffer.insert(key.to_string(), value);
+    }
+
+    /// Publish a value to exactly one peer (Targeted namespaces only).
+    pub fn publish_to(&self, peer_id: &str, key: &str, value: Bytes) {
+        assert!(
+            self.routing == StreamRouting::Targeted,
+            "publish_to() is only valid on Targeted namespaces, not Broadcast (prefix: '{}')",
+            self.prefix
+        );
+        assert!(
+            key.starts_with(&self.prefix),
+            "key '{key}' does not match prefix '{}'",
+            self.prefix
+        );
+        self.targeted_buffer
+            .lock()
+            .push((peer_id.to_string(), key.to_string(), value));
+    }
+
+    /// Subscribe to messages for keys matching a sub-prefix within this namespace.
+    pub fn subscribe(&self, sub_prefix: &str) -> Subscription {
+        let full_prefix = format!("{}{}", self.prefix, sub_prefix);
+        let capacity = subscriber_capacity_for_prefix(&self.prefix);
+        let (tx, rx) = mpsc::channel(capacity);
+        self.subscriber_registry.register(&full_prefix, tx);
+        Subscription { receiver: rx }
+    }
+
+    /// Register a drain callback. Called exactly once per gossip round by the
+    /// centralized collector (Spec Section 5.4). Returns a DrainHandle for
+    /// unregistration.
+    pub fn register_drain(&self, drain: StreamDrainFn) -> DrainHandle {
+        self.drain_registry.register(&self.prefix, drain);
+        DrainHandle {
+            prefix: self.prefix.clone(),
+            drain_registry: self.drain_registry.clone(),
+        }
+    }
+
+    /// Get the routing mode for this namespace.
+    pub fn routing(&self) -> StreamRouting {
+        self.routing
+    }
+
+    /// Get the prefix for this namespace.
+    pub fn prefix(&self) -> &str {
+        &self.prefix
+    }
+}
+
+// ============================================================================
+// MeshKV (Spec Section 1.2)
+// ============================================================================
+
+/// Generic, application-agnostic mesh transport. Provides explicit namespace
+/// handles for CRDT and stream modes. Application code MUST use namespace
+/// handles, not MeshKV directly.
+pub struct MeshKV {
+    /// CRDT store shared across all CRDT namespaces.
+    store: Arc<CrdtOrMap>,
+    /// Tracks configured prefixes to enforce fail-closed semantics.
+    configured_prefixes: RwLock<HashMap<String, StoreMode>>,
+    /// Shared subscriber registry.
+    subscriber_registry: Arc<SubscriberRegistry>,
+    /// Shared drain registry.
+    drain_registry: Arc<DrainRegistry>,
+    /// Server name for this node (used to derive replica_id).
+    server_name: String,
+    /// Replica ID: hash(server_name) as u64.
+    replica_id: u64,
+}
+
+impl MeshKV {
+    /// Create a new MeshKV instance.
+    pub fn new(server_name: String) -> Self {
+        let replica_id = Self::derive_replica_id(&server_name);
+        Self {
+            store: Arc::new(CrdtOrMap::new()),
+            configured_prefixes: RwLock::new(HashMap::new()),
+            subscriber_registry: Arc::new(SubscriberRegistry::new()),
+            drain_registry: Arc::new(DrainRegistry::new()),
+            server_name,
+            replica_id,
+        }
+    }
+
+    /// Derive replica_id from server_name using blake3 hash truncated to u64.
+    /// Collision risk: 2^-64 per pair — negligible (Spec Section 1.1).
+    fn derive_replica_id(server_name: &str) -> u64 {
+        let hash = blake3::hash(server_name.as_bytes());
+        // blake3::Hash::as_bytes() returns &[u8; 32], so first_chunk is infallible.
+        let bytes: &[u8; 8] = hash.as_bytes().first_chunk().unwrap_or(&[0; 8]);
+        u64::from_le_bytes(*bytes)
+    }
+
+    /// Configure a CRDT namespace for a key prefix. Returns a handle scoped to
+    /// that prefix.
+    ///
+    /// # Panics
+    /// Panics if the prefix is already configured (fail-closed, Spec Section 1.3).
+    pub fn configure_crdt_prefix(
+        &self,
+        prefix: &str,
+        merge_strategy: MergeStrategy,
+    ) -> Arc<CrdtNamespace> {
+        {
+            let mut prefixes = self.configured_prefixes.write();
+            assert!(
+                !prefixes.contains_key(prefix),
+                "Prefix '{prefix}' is already configured. Each prefix must be configured exactly once."
+            );
+            prefixes.insert(
+                prefix.to_string(),
+                StoreMode::Crdt {
+                    merge_strategy: merge_strategy.clone(),
+                },
+            );
+        }
+
+        Arc::new(CrdtNamespace {
+            prefix: prefix.to_string(),
+            store: self.store.clone(),
+            subscriber_registry: self.subscriber_registry.clone(),
+            merge_strategy,
+        })
+    }
+
+    /// Configure a stream namespace for a key prefix. Returns a handle scoped to
+    /// that prefix.
+    ///
+    /// # Panics
+    /// Panics if the prefix is already configured (fail-closed, Spec Section 1.3).
+    pub fn configure_stream_prefix(
+        &self,
+        prefix: &str,
+        config: StreamConfig,
+    ) -> Arc<StreamNamespace> {
+        {
+            let mut prefixes = self.configured_prefixes.write();
+            assert!(
+                !prefixes.contains_key(prefix),
+                "Prefix '{prefix}' is already configured. Each prefix must be configured exactly once."
+            );
+            prefixes.insert(
+                prefix.to_string(),
+                StoreMode::Stream {
+                    max_buffer_bytes: config.max_buffer_bytes,
+                    routing: config.routing,
+                },
+            );
+        }
+
+        Arc::new(StreamNamespace {
+            prefix: prefix.to_string(),
+            routing: config.routing,
+            max_buffer_bytes: config.max_buffer_bytes,
+            buffer: Arc::new(DashMap::new()),
+            targeted_buffer: Arc::new(parking_lot::Mutex::new(Vec::new())),
+            subscriber_registry: self.subscriber_registry.clone(),
+            drain_registry: self.drain_registry.clone(),
+        })
+    }
+
+    /// Get the server name for this node.
+    pub fn server_name(&self) -> &str {
+        &self.server_name
+    }
+
+    /// Get the replica ID for this node.
+    pub fn replica_id(&self) -> u64 {
+        self.replica_id
+    }
+
+    /// Check if a prefix has been configured.
+    pub fn is_prefix_configured(&self, prefix: &str) -> bool {
+        self.configured_prefixes.read().contains_key(prefix)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    #[test]
+    fn test_derive_replica_id_deterministic() {
+        let id1 = MeshKV::derive_replica_id("gateway-1");
+        let id2 = MeshKV::derive_replica_id("gateway-1");
+        assert_eq!(id1, id2, "Same server_name must produce same replica_id");
+    }
+
+    #[test]
+    fn test_derive_replica_id_different_names() {
+        let id1 = MeshKV::derive_replica_id("gateway-1");
+        let id2 = MeshKV::derive_replica_id("gateway-2");
+        assert_ne!(
+            id1, id2,
+            "Different server_names should produce different replica_ids"
+        );
+    }
+
+    #[test]
+    fn test_configure_crdt_prefix() {
+        let kv = MeshKV::new("test-node".to_string());
+        let ns = kv.configure_crdt_prefix("worker:", MergeStrategy::LastWriterWins);
+        assert_eq!(ns.prefix(), "worker:");
+        assert!(kv.is_prefix_configured("worker:"));
+    }
+
+    #[test]
+    fn test_configure_stream_prefix() {
+        let kv = MeshKV::new("test-node".to_string());
+        let ns = kv.configure_stream_prefix(
+            "td:",
+            StreamConfig {
+                max_buffer_bytes: 1024,
+                routing: StreamRouting::Broadcast,
+            },
+        );
+        assert_eq!(ns.prefix(), "td:");
+        assert_eq!(ns.routing(), StreamRouting::Broadcast);
+        assert!(kv.is_prefix_configured("td:"));
+    }
+
+    #[test]
+    #[should_panic(expected = "already configured")]
+    fn test_duplicate_prefix_panics() {
+        let kv = MeshKV::new("test-node".to_string());
+        kv.configure_crdt_prefix("worker:", MergeStrategy::LastWriterWins);
+        kv.configure_crdt_prefix("worker:", MergeStrategy::LastWriterWins); // panics
+    }
+
+    #[test]
+    #[should_panic(expected = "already configured")]
+    fn test_duplicate_prefix_across_modes_panics() {
+        let kv = MeshKV::new("test-node".to_string());
+        kv.configure_crdt_prefix("data:", MergeStrategy::LastWriterWins);
+        kv.configure_stream_prefix(
+            "data:",
+            StreamConfig {
+                max_buffer_bytes: 1024,
+                routing: StreamRouting::Broadcast,
+            },
+        ); // panics
+    }
+
+    #[test]
+    fn test_crdt_put_get() {
+        let kv = MeshKV::new("test-node".to_string());
+        let ns = kv.configure_crdt_prefix("worker:", MergeStrategy::LastWriterWins);
+
+        ns.put("worker:7", b"healthy".to_vec());
+        let val = ns.get("worker:7");
+        assert_eq!(val, Some(b"healthy".to_vec()));
+    }
+
+    #[test]
+    fn test_crdt_delete() {
+        let kv = MeshKV::new("test-node".to_string());
+        let ns = kv.configure_crdt_prefix("worker:", MergeStrategy::LastWriterWins);
+
+        ns.put("worker:7", b"healthy".to_vec());
+        ns.delete("worker:7");
+        assert_eq!(ns.get("worker:7"), None);
+    }
+
+    #[test]
+    fn test_crdt_keys() {
+        let kv = MeshKV::new("test-node".to_string());
+        let ns = kv.configure_crdt_prefix("worker:", MergeStrategy::LastWriterWins);
+
+        ns.put("worker:1", b"a".to_vec());
+        ns.put("worker:2", b"b".to_vec());
+        ns.put("worker:3", b"c".to_vec());
+
+        let mut keys = ns.keys("");
+        keys.sort();
+        assert_eq!(keys, vec!["worker:1", "worker:2", "worker:3"]);
+    }
+
+    #[test]
+    #[should_panic(expected = "does not match prefix")]
+    fn test_crdt_put_wrong_prefix_panics() {
+        let kv = MeshKV::new("test-node".to_string());
+        let ns = kv.configure_crdt_prefix("worker:", MergeStrategy::LastWriterWins);
+        ns.put("policy:1", b"wrong".to_vec()); // panics
+    }
+
+    #[test]
+    #[should_panic(expected = "only valid on Broadcast")]
+    fn test_stream_publish_on_targeted_panics() {
+        let kv = MeshKV::new("test-node".to_string());
+        let ns = kv.configure_stream_prefix(
+            "tree:req:",
+            StreamConfig {
+                max_buffer_bytes: 1024,
+                routing: StreamRouting::Targeted,
+            },
+        );
+        ns.publish("tree:req:model-x", Bytes::from("data")); // panics
+    }
+
+    #[test]
+    #[should_panic(expected = "only valid on Targeted")]
+    fn test_stream_publish_to_on_broadcast_panics() {
+        let kv = MeshKV::new("test-node".to_string());
+        let ns = kv.configure_stream_prefix(
+            "td:",
+            StreamConfig {
+                max_buffer_bytes: 1024,
+                routing: StreamRouting::Broadcast,
+            },
+        );
+        ns.publish_to("peer-1", "td:model-x", Bytes::from("data")); // panics
+    }
+
+    #[tokio::test]
+    async fn test_crdt_subscribe() {
+        let kv = MeshKV::new("test-node".to_string());
+        let ns = kv.configure_crdt_prefix("worker:", MergeStrategy::LastWriterWins);
+
+        let mut sub = ns.subscribe("");
+        ns.put("worker:7", b"healthy".to_vec());
+
+        let (key, value) = tokio::time::timeout(Duration::from_millis(100), sub.receiver.recv())
+            .await
+            .expect("timeout")
+            .expect("channel closed");
+
+        assert_eq!(key, "worker:7");
+        assert_eq!(value.as_ref(), b"healthy");
+    }
+}

--- a/crates/mesh/src/kv.rs
+++ b/crates/mesh/src/kv.rs
@@ -194,11 +194,11 @@ impl DrainRegistry {
     }
 
     fn register(&self, prefix: &str, drain: StreamDrainFn) {
-        let previous = self.drains.insert(prefix.to_string(), Arc::new(drain));
         assert!(
-            previous.is_none(),
+            !self.drains.contains_key(prefix),
             "drain already registered for prefix '{prefix}'"
         );
+        self.drains.insert(prefix.to_string(), Arc::new(drain));
     }
 
     fn remove(&self, prefix: &str) {

--- a/crates/mesh/src/kv.rs
+++ b/crates/mesh/src/kv.rs
@@ -164,16 +164,18 @@ impl SubscriberRegistry {
         }
     }
 
-    /// Remove closed senders (adapter dropped its Subscription).
+    /// Remove closed senders individually. If all senders for a prefix are
+    /// gone, remove the prefix entry entirely.
     #[expect(dead_code)] // Called by gossip GC cycle in later steps
     fn gc_closed(&self) {
-        let mut closed_prefixes = Vec::new();
-        for entry in &self.subscribers {
-            if entry.value().iter().all(|tx| tx.is_closed()) {
-                closed_prefixes.push(entry.key().clone());
+        let mut empty_prefixes = Vec::new();
+        for mut entry in self.subscribers.iter_mut() {
+            entry.value_mut().retain(|tx| !tx.is_closed());
+            if entry.value().is_empty() {
+                empty_prefixes.push(entry.key().clone());
             }
         }
-        for prefix in closed_prefixes {
+        for prefix in empty_prefixes {
             self.subscribers.remove(&prefix);
         }
     }

--- a/crates/mesh/src/kv.rs
+++ b/crates/mesh/src/kv.rs
@@ -294,10 +294,9 @@ impl CrdtNamespace {
     pub fn keys(&self, sub_prefix: &str) -> Vec<String> {
         let full_prefix = format!("{}{}", self.prefix, sub_prefix);
         self.store
-            .all()
             .keys()
+            .into_iter()
             .filter(|k| k.starts_with(&full_prefix))
-            .cloned()
             .collect()
     }
 
@@ -344,8 +343,9 @@ pub struct StreamNamespace {
 impl StreamNamespace {
     /// Publish a value to all connected peers (Broadcast namespaces only).
     pub fn publish(&self, key: &str, value: Bytes) {
-        assert!(
-            self.routing == StreamRouting::Broadcast,
+        assert_eq!(
+            self.routing,
+            StreamRouting::Broadcast,
             "publish() is only valid on Broadcast namespaces, not Targeted (prefix: '{}')",
             self.prefix
         );
@@ -359,8 +359,9 @@ impl StreamNamespace {
 
     /// Publish a value to exactly one peer (Targeted namespaces only).
     pub fn publish_to(&self, peer_id: &str, key: &str, value: Bytes) {
-        assert!(
-            self.routing == StreamRouting::Targeted,
+        assert_eq!(
+            self.routing,
+            StreamRouting::Targeted,
             "publish_to() is only valid on Targeted namespaces, not Broadcast (prefix: '{}')",
             self.prefix
         );

--- a/crates/mesh/src/kv.rs
+++ b/crates/mesh/src/kv.rs
@@ -4,7 +4,6 @@
 //! - `CrdtNamespace` for durable, mergeable state (workers, policies, rate limits, config)
 //! - `StreamNamespace` for ephemeral, lossy, application-regenerated traffic (tenant deltas, tree repair)
 //!
-//! See mesh-v2-implementation-spec.md for the full design.
 
 use std::{collections::HashMap, sync::Arc, time::Instant};
 
@@ -16,7 +15,8 @@ use tokio::sync::mpsc;
 use crate::crdt_kv::CrdtOrMap;
 
 // ============================================================================
-// Type Definitions// ============================================================================
+// Type Definitions
+// ============================================================================
 
 /// Merge strategy for CRDT namespaces. Determines how conflicts are resolved
 /// when two nodes write the same key concurrently.
@@ -86,7 +86,8 @@ pub(crate) struct ValueEntry {
 }
 
 // ============================================================================
-// Subscription// ============================================================================
+// Subscription
+// ============================================================================
 
 /// A subscription to changes for keys matching a prefix.
 /// Delivers via a bounded mpsc channel. Capacity is per-prefix:
@@ -238,7 +239,8 @@ fn subscriber_capacity_for_prefix(prefix: &str) -> usize {
 }
 
 // ============================================================================
-// CrdtNamespace// ============================================================================
+// CrdtNamespace
+// ============================================================================
 
 /// Handle for durable, mergeable state. Scoped to a key prefix.
 /// Provides put/get/delete/keys/subscribe.
@@ -316,7 +318,8 @@ impl CrdtNamespace {
 }
 
 // ============================================================================
-// StreamNamespace// ============================================================================
+// StreamNamespace
+// ============================================================================
 
 /// Handle for ephemeral, lossy, application-regenerated traffic. Scoped to a
 /// key prefix with a fixed routing mode (Broadcast or Targeted).
@@ -398,7 +401,8 @@ impl StreamNamespace {
 }
 
 // ============================================================================
-// MeshKV// ============================================================================
+// MeshKV
+// ============================================================================
 
 /// Generic, application-agnostic mesh transport. Provides explicit namespace
 /// handles for CRDT and stream modes. Application code MUST use namespace

--- a/crates/mesh/src/kv.rs
+++ b/crates/mesh/src/kv.rs
@@ -16,8 +16,7 @@ use tokio::sync::mpsc;
 use crate::crdt_kv::CrdtOrMap;
 
 // ============================================================================
-// Type Definitions (Spec Section 1.1 - 1.3)
-// ============================================================================
+// Type Definitions// ============================================================================
 
 /// Merge strategy for CRDT namespaces. Determines how conflicts are resolved
 /// when two nodes write the same key concurrently.
@@ -69,7 +68,7 @@ enum StoreMode {
     },
 }
 
-/// CRDT mode entry metadata (Spec Section 1.1).
+/// CRDT mode entry metadata.
 #[derive(Debug, Clone)]
 #[expect(dead_code)] // Constructed in later steps (CRDT merge integration)
 pub(crate) struct ValueEntry {
@@ -87,8 +86,7 @@ pub(crate) struct ValueEntry {
 }
 
 // ============================================================================
-// Subscription (Spec Section 6.1 - 6.3)
-// ============================================================================
+// Subscription// ============================================================================
 
 /// A subscription to changes for keys matching a prefix.
 /// Delivers via a bounded mpsc channel. Capacity is per-prefix:
@@ -154,7 +152,7 @@ impl SubscriberRegistry {
     }
 
     /// Notify all subscribers whose prefix matches the given key.
-    /// Uses try_send to never block the gossip loop (Spec Section 6.3).
+    /// Uses try_send to never block the gossip loop.
     fn notify(&self, key: &str, value: Bytes) {
         for entry in &self.subscribers {
             let prefix = entry.key();
@@ -209,7 +207,7 @@ impl DrainRegistry {
     }
 
     /// Call all registered drains. Returns accumulated entries.
-    /// Called exactly once per gossip round (Spec Section 5.4).
+    /// Called exactly once per gossip round.
     #[expect(dead_code)] // Called by centralized gossip loop in Step 2
     fn drain_all(&self) -> Vec<(String, Vec<u8>)> {
         let mut all_entries = Vec::new();
@@ -225,7 +223,7 @@ impl DrainRegistry {
 // Prefix Configuration (internal)
 // ============================================================================
 
-/// Per-prefix subscriber channel capacity (Spec Section 6.3).
+/// Per-prefix subscriber channel capacity.
 fn subscriber_capacity_for_prefix(prefix: &str) -> usize {
     match prefix {
         "worker:" => 1000,
@@ -240,8 +238,7 @@ fn subscriber_capacity_for_prefix(prefix: &str) -> usize {
 }
 
 // ============================================================================
-// CrdtNamespace (Spec Section 1.2, 2)
-// ============================================================================
+// CrdtNamespace// ============================================================================
 
 /// Handle for durable, mergeable state. Scoped to a key prefix.
 /// Provides put/get/delete/keys/subscribe.
@@ -298,7 +295,7 @@ impl CrdtNamespace {
     }
 
     /// Subscribe to changes for keys matching a sub-prefix within this namespace.
-    /// Channel capacity is determined by the namespace prefix (Spec Section 6.3).
+    /// Channel capacity is determined by the namespace prefix.
     pub fn subscribe(&self, sub_prefix: &str) -> Subscription {
         let full_prefix = format!("{}{}", self.prefix, sub_prefix);
         let capacity = subscriber_capacity_for_prefix(&self.prefix);
@@ -319,8 +316,7 @@ impl CrdtNamespace {
 }
 
 // ============================================================================
-// StreamNamespace (Spec Section 1.2, 3)
-// ============================================================================
+// StreamNamespace// ============================================================================
 
 /// Handle for ephemeral, lossy, application-regenerated traffic. Scoped to a
 /// key prefix with a fixed routing mode (Broadcast or Targeted).
@@ -380,7 +376,7 @@ impl StreamNamespace {
     }
 
     /// Register a drain callback. Called exactly once per gossip round by the
-    /// centralized collector (Spec Section 5.4). Returns a DrainHandle for
+    /// centralized collector. Returns a DrainHandle for
     /// unregistration.
     pub fn register_drain(&self, drain: StreamDrainFn) -> DrainHandle {
         self.drain_registry.register(&self.prefix, drain);
@@ -402,8 +398,7 @@ impl StreamNamespace {
 }
 
 // ============================================================================
-// MeshKV (Spec Section 1.2)
-// ============================================================================
+// MeshKV// ============================================================================
 
 /// Generic, application-agnostic mesh transport. Provides explicit namespace
 /// handles for CRDT and stream modes. Application code MUST use namespace
@@ -438,7 +433,7 @@ impl MeshKV {
     }
 
     /// Derive replica_id from server_name using blake3 hash truncated to u64.
-    /// Collision risk: 2^-64 per pair — negligible (Spec Section 1.1).
+    /// Collision risk: 2^-64 per pair — negligible.
     fn derive_replica_id(server_name: &str) -> u64 {
         let hash = blake3::hash(server_name.as_bytes());
         // blake3::Hash::as_bytes() returns &[u8; 32], so first_chunk is infallible.
@@ -450,7 +445,7 @@ impl MeshKV {
     /// that prefix.
     ///
     /// # Panics
-    /// Panics if the prefix is already configured (fail-closed, Spec Section 1.3).
+    /// Panics if the prefix is already configured (fail-closed).
     pub fn configure_crdt_prefix(
         &self,
         prefix: &str,
@@ -482,7 +477,7 @@ impl MeshKV {
     /// that prefix.
     ///
     /// # Panics
-    /// Panics if the prefix is already configured (fail-closed, Spec Section 1.3).
+    /// Panics if the prefix is already configured (fail-closed).
     pub fn configure_stream_prefix(
         &self,
         prefix: &str,

--- a/crates/mesh/src/kv.rs
+++ b/crates/mesh/src/kv.rs
@@ -99,8 +99,8 @@ pub(crate) struct ValueEntry {
 /// - tree:req: 100
 /// - tree:page: 32
 pub struct Subscription {
-    /// Receives (key, value) pairs as they are written or received from peers.
-    pub receiver: mpsc::Receiver<(String, Bytes)>,
+    /// Receives (key, value) pairs. `None` value means the key was deleted.
+    pub receiver: mpsc::Receiver<SubscriptionEvent>,
 }
 
 /// Function signature for stream drain callbacks. Called exactly once per gossip
@@ -124,10 +124,13 @@ impl Drop for DrainHandle {
 // Subscriber Registry (internal)
 // ============================================================================
 
+/// A single subscription event: (key, value). `None` value means deletion.
+type SubscriptionEvent = (String, Option<Bytes>);
+
 /// Tracks all active subscriptions by prefix.
 struct SubscriberRegistry {
     /// prefix -> list of senders. Multiple subscribers can watch the same prefix.
-    subscribers: DashMap<String, Vec<mpsc::Sender<(String, Bytes)>>>,
+    subscribers: DashMap<String, Vec<mpsc::Sender<SubscriptionEvent>>>,
 }
 
 impl SubscriberRegistry {
@@ -137,7 +140,7 @@ impl SubscriberRegistry {
         }
     }
 
-    fn register(&self, prefix: &str, tx: mpsc::Sender<(String, Bytes)>) {
+    fn register(&self, prefix: &str, tx: mpsc::Sender<SubscriptionEvent>) {
         self.subscribers
             .entry(prefix.to_string())
             .or_default()
@@ -146,7 +149,8 @@ impl SubscriberRegistry {
 
     /// Notify all subscribers whose prefix matches the given key.
     /// Uses try_send to never block the gossip loop.
-    fn notify(&self, key: &str, value: Bytes) {
+    /// `value` is `Some(bytes)` for puts, `None` for deletes.
+    fn notify(&self, key: &str, value: Option<Bytes>) {
         for entry in &self.subscribers {
             let prefix = entry.key();
             if key.starts_with(prefix.as_str()) {
@@ -253,7 +257,8 @@ impl CrdtNamespace {
             self.prefix
         );
         self.store.insert(key.to_string(), value.clone());
-        self.subscriber_registry.notify(key, Bytes::from(value));
+        self.subscriber_registry
+            .notify(key, Some(Bytes::from(value)));
     }
 
     /// Get the current value for a key, or None if not present or tombstoned.
@@ -268,6 +273,7 @@ impl CrdtNamespace {
 
     /// Delete a key by writing a tombstone. The tombstone propagates via gossip
     /// and wins by higher version. Actual removal happens after GC grace period.
+    /// Subscribers receive `(key, None)` to indicate deletion.
     pub fn delete(&self, key: &str) {
         assert!(
             key.starts_with(&self.prefix),
@@ -275,6 +281,7 @@ impl CrdtNamespace {
             self.prefix
         );
         self.store.remove(key);
+        self.subscriber_registry.notify(key, None);
     }
 
     /// List all live keys matching a sub-prefix within this namespace.
@@ -673,6 +680,32 @@ mod tests {
             .expect("channel closed");
 
         assert_eq!(key, "worker:7");
-        assert_eq!(value.as_ref(), b"healthy");
+        assert_eq!(value.as_deref(), Some(b"healthy".as_slice()));
+    }
+
+    #[tokio::test]
+    async fn test_crdt_subscribe_delete() {
+        let kv = MeshKV::new("test-node".to_string());
+        let ns = kv.configure_crdt_prefix("worker:", MergeStrategy::LastWriterWins);
+
+        let mut sub = ns.subscribe("");
+        ns.put("worker:7", b"healthy".to_vec());
+        ns.delete("worker:7");
+
+        // First event: put
+        let (key, value) = tokio::time::timeout(Duration::from_millis(100), sub.receiver.recv())
+            .await
+            .expect("timeout")
+            .expect("channel closed");
+        assert_eq!(key, "worker:7");
+        assert!(value.is_some());
+
+        // Second event: delete
+        let (key, value) = tokio::time::timeout(Duration::from_millis(100), sub.receiver.recv())
+            .await
+            .expect("timeout")
+            .expect("channel closed");
+        assert_eq!(key, "worker:7");
+        assert!(value.is_none(), "delete should notify with None");
     }
 }

--- a/crates/mesh/src/kv.rs
+++ b/crates/mesh/src/kv.rs
@@ -168,16 +168,12 @@ impl SubscriberRegistry {
     /// gone, remove the prefix entry entirely.
     #[expect(dead_code)] // Called by gossip GC cycle in later steps
     fn gc_closed(&self) {
-        let mut empty_prefixes = Vec::new();
         for mut entry in self.subscribers.iter_mut() {
             entry.value_mut().retain(|tx| !tx.is_closed());
-            if entry.value().is_empty() {
-                empty_prefixes.push(entry.key().clone());
-            }
         }
-        for prefix in empty_prefixes {
-            self.subscribers.remove(&prefix);
-        }
+        // Atomically remove only if still empty, avoiding a race where
+        // a concurrent register() adds a sender between iter_mut and remove.
+        self.subscribers.retain(|_, senders| !senders.is_empty());
     }
 }
 

--- a/crates/mesh/src/kv.rs
+++ b/crates/mesh/src/kv.rs
@@ -198,7 +198,11 @@ impl DrainRegistry {
     }
 
     fn register(&self, prefix: &str, drain: StreamDrainFn) {
-        self.drains.insert(prefix.to_string(), Arc::new(drain));
+        let previous = self.drains.insert(prefix.to_string(), Arc::new(drain));
+        assert!(
+            previous.is_none(),
+            "drain already registered for prefix '{prefix}'"
+        );
     }
 
     fn remove(&self, prefix: &str) {

--- a/crates/mesh/src/lib.rs
+++ b/crates/mesh/src/lib.rs
@@ -11,6 +11,7 @@ mod controller;
 mod crdt_kv;
 mod flow_control;
 mod incremental;
+pub mod kv;
 mod metrics;
 mod mtls;
 mod node_state_machine;
@@ -29,6 +30,11 @@ mod tests;
 
 // Re-export commonly used types
 pub use crdt_kv::{CrdtOrMap, OperationLog};
+// v2 API
+pub use kv::{
+    CrdtNamespace, DrainHandle, MergeStrategy, MeshKV, StreamConfig, StreamDrainFn,
+    StreamNamespace, StreamRouting, Subscription,
+};
 pub use metrics::init_mesh_metrics;
 pub use mtls::{MTLSConfig, MTLSManager, OptionalMTLSManager};
 pub use partition::PartitionDetector;


### PR DESCRIPTION
## Description

### Problem

The current mesh crate is tightly coupled to application concepts (trees, workers, policies). Large tree state gets routed through the CRDT operation log, causing memory bloat and the v1 failure pattern where only one peer receives tenant deltas per gossip round.

Additionally, `gc_tombstones()` removes tombstoned entries immediately with no grace period, creating a data resurrection risk when stale peers gossip old values back after the tombstone is gone.

### Solution

Add the v2 MeshKV wrapper as described in mesh-v2-implementation-spec.md Step 1. This introduces explicit namespace handles that enforce the CRDT/stream separation at the API level, preventing application code from accidentally routing large ephemeral traffic through the CRDT log.

## Changes

- **`kv.rs`**: New MeshKV module with:
  - `MeshKV` struct with `configure_crdt_prefix` / `configure_stream_prefix` (fail-closed — duplicate or unconfigured prefixes panic at startup)
  - `CrdtNamespace`: `put/get/delete/keys/subscribe` for durable, mergeable state
  - `StreamNamespace`: `publish/publish_to/subscribe/register_drain` for ephemeral traffic, with routing mode enforcement (Broadcast vs Targeted)
  - `MergeStrategy` enum: `LastWriterWins`, `MaxValueWins`, `EpochMaxWins`
  - `SubscriberRegistry` with bounded mpsc channels and per-prefix capacity
  - `DrainRegistry` for centralized gossip round drain callbacks
  - Replica ID derivation via blake3 hash of server_name (deterministic, u64)

- **`crdt_kv/crdt.rs`**: Tombstone GC fix:
  - Added `created_at: Instant` to `ValueMetadata`
  - `gc_tombstones()` now skips tombstones younger than 5 minutes (`DEFAULT_TOMBSTONE_GRACE`)
  - Added `gc_tombstones_with_grace(duration)` for testing
  - Uses collect-then-remove pattern to avoid locking all DashMap shards

- **`Cargo.toml`**: Added `bytes` dependency

## Test Plan

13 new tests added covering:
- Replica ID derivation (deterministic, different names produce different IDs)
- CRDT namespace: put/get/delete/keys/subscribe
- Fail-closed prefix validation (duplicate prefix panics, cross-mode duplicate panics)
- Key prefix enforcement (wrong prefix panics)
- Stream routing enforcement (publish on Targeted panics, publish_to on Broadcast panics)
- Tombstone GC grace period (young tombstones preserved, expired tombstones collected, live keys untouched)

```
cargo test -p smg-mesh kv::tests          # 13 tests
cargo test -p smg-mesh crdt_kv::tests     # 16 tests (3 new GC tests)
```

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MeshKV with CRDT key/value namespaces, configurable merge strategies, stream namespaces (broadcast/targeted), namespace-scoped subscriptions, and drain handles.
  * Added public key-listing APIs and tombstone garbage collection with configurable grace period.

* **Tests**
  * Added unit tests for tombstone GC timing, CRDT operations (put/get/delete/keys), prefix rules, and stream subscriptions/routing.

* **Chores**
  * Added bytes crate dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->