### PR TITLE
refactor(tool_parser): rename qwen_coder to qwen_xml and fix model mappings

### DIFF
--- a/crates/tool_parser/README.md
+++ b/crates/tool_parser/README.md
@@ -9,7 +9,7 @@ Parser library for extracting tool/function calls from LLM model outputs. Suppor
 | `CohereParser` | Cohere Command (CMD3/CMD4) | `<\|START_ACTION\|>{...}<\|END_ACTION\|>` |
 | `MistralParser` | Mistral, Mixtral | `[TOOL_CALLS][{...}]` |
 | `QwenParser` | Qwen 2/2.5/3 | `<tool_call>{...}</tool_call>` |
-| `QwenCoderParser` | Qwen Coder | `<tool_call><function=name>...</function></tool_call>` |
+| `QwenXmlParser` | Qwen3-Coder, Qwen3.5+ | `<tool_call><function=name>...</function></tool_call>` |
 | `LlamaParser` | Llama 3.2 | `<\|python_tag\|>{...}` |
 | `PythonicParser` | Llama 4, DeepSeek R1 | `[func_name(arg="val")]` |
 | `DeepSeekParser` | DeepSeek V3 | `<\|tool▁calls▁begin\|>...<\|tool▁calls▁end\|>` |

--- a/crates/tool_parser/src/factory.rs
+++ b/crates/tool_parser/src/factory.rs
@@ -11,7 +11,7 @@ use crate::{
     parsers::{
         CohereParser, DeepSeek31Parser, DeepSeekParser, Glm4MoeParser, JsonParser, KimiK2Parser,
         LlamaParser, MinimaxM2Parser, MistralParser, PassthroughParser, PythonicParser,
-        QwenCoderParser, QwenParser, Step3Parser,
+        QwenParser, QwenXmlParser, Step3Parser,
     },
     traits::ToolParser,
 };
@@ -310,7 +310,7 @@ impl ParserFactory {
             MistralParser::build_structural_tag,
         );
         registry.register_parser("qwen", || Box::new(QwenParser::new()));
-        registry.register_parser("qwen_coder", || Box::new(QwenCoderParser::new()));
+        registry.register_parser("qwen_xml", || Box::new(QwenXmlParser::new()));
         registry.register_parser("pythonic", || Box::new(PythonicParser::new()));
         registry.register_parser("llama", || Box::new(LlamaParser::new()));
         registry.register_parser("deepseek", || Box::new(DeepSeekParser::new()));
@@ -346,14 +346,14 @@ impl ParserFactory {
         registry.map_model("mixtral-*", "mistral");
 
         // Qwen models (more specific patterns first - longer patterns take precedence)
-        // Qwen Coder models use XML format: <tool_call><function=name><parameter=key>value</parameter></function></tool_call>
-        registry.map_model("Qwen/Qwen3-Coder*", "qwen_coder");
-        registry.map_model("Qwen3-Coder*", "qwen_coder");
-        registry.map_model("qwen3-coder*", "qwen_coder");
-        registry.map_model("Qwen/Qwen2.5-Coder*", "qwen_coder");
-        registry.map_model("Qwen2.5-Coder*", "qwen_coder");
-        registry.map_model("qwen2.5-coder*", "qwen_coder");
-        // Generic Qwen models use JSON format
+        // Qwen3.5+ and Qwen3-Coder use XML format: <tool_call><function=name><parameter=key>value</parameter></function></tool_call>
+        registry.map_model("Qwen/Qwen3.5*", "qwen_xml");
+        registry.map_model("Qwen3.5*", "qwen_xml");
+        registry.map_model("qwen3.5*", "qwen_xml");
+        registry.map_model("Qwen/Qwen3-Coder*", "qwen_xml");
+        registry.map_model("Qwen3-Coder*", "qwen_xml");
+        registry.map_model("qwen3-coder*", "qwen_xml");
+        // Qwen3 and earlier (including Qwen2.5-Coder) use JSON format
         registry.map_model("qwen*", "qwen");
         registry.map_model("Qwen*", "qwen");
 

--- a/crates/tool_parser/src/factory.rs
+++ b/crates/tool_parser/src/factory.rs
@@ -311,6 +311,7 @@ impl ParserFactory {
         );
         registry.register_parser("qwen", || Box::new(QwenParser::new()));
         registry.register_parser("qwen_xml", || Box::new(QwenXmlParser::new()));
+        registry.register_parser("qwen_coder", || Box::new(QwenXmlParser::new()));
         registry.register_parser("pythonic", || Box::new(PythonicParser::new()));
         registry.register_parser("llama", || Box::new(LlamaParser::new()));
         registry.register_parser("deepseek", || Box::new(DeepSeekParser::new()));

--- a/crates/tool_parser/src/factory.rs
+++ b/crates/tool_parser/src/factory.rs
@@ -10,8 +10,8 @@ use tokio::sync::Mutex;
 use crate::{
     parsers::{
         CohereParser, DeepSeek31Parser, DeepSeekParser, Glm4MoeParser, JsonParser, KimiK2Parser,
-        LlamaParser, MinimaxM2Parser, MistralParser, PassthroughParser, PythonicParser,
-        QwenParser, QwenXmlParser, Step3Parser,
+        LlamaParser, MinimaxM2Parser, MistralParser, PassthroughParser, PythonicParser, QwenParser,
+        QwenXmlParser, Step3Parser,
     },
     traits::ToolParser,
 };

--- a/crates/tool_parser/src/factory.rs
+++ b/crates/tool_parser/src/factory.rs
@@ -351,9 +351,11 @@ impl ParserFactory {
         registry.map_model("Qwen/Qwen3.5*", "qwen_xml");
         registry.map_model("Qwen3.5*", "qwen_xml");
         registry.map_model("qwen3.5*", "qwen_xml");
+        registry.map_model("qwen/qwen3.5*", "qwen_xml");
         registry.map_model("Qwen/Qwen3-Coder*", "qwen_xml");
         registry.map_model("Qwen3-Coder*", "qwen_xml");
         registry.map_model("qwen3-coder*", "qwen_xml");
+        registry.map_model("qwen/qwen3-coder*", "qwen_xml");
         // Qwen3 and earlier (including Qwen2.5-Coder) use JSON format
         registry.map_model("qwen*", "qwen");
         registry.map_model("Qwen*", "qwen");

--- a/crates/tool_parser/src/parsers/mod.rs
+++ b/crates/tool_parser/src/parsers/mod.rs
@@ -15,7 +15,7 @@ pub mod mistral;
 pub mod passthrough;
 pub mod pythonic;
 pub mod qwen;
-pub mod qwen_coder;
+pub mod qwen_xml;
 pub mod step3;
 
 // Shared helpers and utilities
@@ -34,5 +34,5 @@ pub use mistral::MistralParser;
 pub(crate) use passthrough::PassthroughParser;
 pub use pythonic::PythonicParser;
 pub use qwen::QwenParser;
-pub use qwen_coder::QwenCoderParser;
+pub use qwen_xml::QwenXmlParser;
 pub use step3::Step3Parser;

--- a/crates/tool_parser/src/parsers/mod.rs
+++ b/crates/tool_parser/src/parsers/mod.rs
@@ -35,6 +35,4 @@ pub(crate) use passthrough::PassthroughParser;
 pub use pythonic::PythonicParser;
 pub use qwen::QwenParser;
 pub use qwen_xml::QwenXmlParser;
-#[deprecated(note = "Renamed to QwenXmlParser")]
-pub use qwen_xml::QwenXmlParser as QwenCoderParser;
 pub use step3::Step3Parser;

--- a/crates/tool_parser/src/parsers/mod.rs
+++ b/crates/tool_parser/src/parsers/mod.rs
@@ -35,4 +35,6 @@ pub(crate) use passthrough::PassthroughParser;
 pub use pythonic::PythonicParser;
 pub use qwen::QwenParser;
 pub use qwen_xml::QwenXmlParser;
+#[deprecated(note = "Renamed to QwenXmlParser")]
+pub use qwen_xml::QwenXmlParser as QwenCoderParser;
 pub use step3::Step3Parser;

--- a/crates/tool_parser/src/parsers/qwen_xml.rs
+++ b/crates/tool_parser/src/parsers/qwen_xml.rs
@@ -10,9 +10,9 @@ use crate::{
     types::{FunctionCall, StreamingParseResult, ToolCall, ToolCallItem},
 };
 
-/// Qwen Coder format parser for tool calls
+/// Qwen XML format parser for tool calls
 ///
-/// Handles the Qwen Coder specific XML format:
+/// Handles the Qwen XML specific XML format:
 /// `<tool_call>\n<function=name>\n<parameter=key>value</parameter>\n</function>\n</tool_call>`
 ///
 /// Features:
@@ -21,7 +21,7 @@ use crate::{
 /// - XML-style parameters: `<parameter=key>value</parameter>`
 ///
 /// Reference: https://huggingface.co/Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8?chat_template=default
-pub struct QwenCoderParser {
+pub struct QwenXmlParser {
     /// Regex for extracting tool calls in parse_complete
     extractor: Regex,
 
@@ -153,8 +153,8 @@ fn safe_val(raw: &str) -> Value {
     Value::String(unescaped)
 }
 
-impl QwenCoderParser {
-    /// Create a new Qwen Coder parser
+impl QwenXmlParser {
+    /// Create a new Qwen XML parser
     #[expect(
         clippy::expect_used,
         reason = "regex patterns are compile-time string literals"
@@ -314,16 +314,16 @@ impl QwenCoderParser {
     }
 }
 
-impl Default for QwenCoderParser {
+impl Default for QwenXmlParser {
     fn default() -> Self {
         Self::new()
     }
 }
 
 #[async_trait]
-impl ToolParser for QwenCoderParser {
+impl ToolParser for QwenXmlParser {
     async fn parse_complete(&self, text: &str) -> ParserResult<(String, Vec<ToolCall>)> {
-        // Check if text contains Qwen Coder format
+        // Check if text contains Qwen XML format
         if !self.has_tool_markers(text) {
             return Ok((text.to_string(), vec![]));
         }

--- a/crates/tool_parser/src/tests.rs
+++ b/crates/tool_parser/src/tests.rs
@@ -735,3 +735,52 @@ mod qwen_xml_tests {
         );
     }
 }
+
+#[cfg(test)]
+mod qwen_mapping_tests {
+    use crate::factory::ParserFactory;
+
+    #[test]
+    fn test_qwen_xml_model_mappings() {
+        let factory = ParserFactory::new();
+        let registry = factory.registry();
+
+        for model in [
+            "Qwen3.5-32B",
+            "Qwen/Qwen3.5-4B",
+            "qwen3.5-72b",
+            "qwen/qwen3.5-32b",
+            "Qwen3-Coder-480B",
+            "Qwen/Qwen3-Coder-480B-A35B-Instruct",
+            "qwen3-coder-7b",
+            "qwen/qwen3-coder-32b",
+        ] {
+            assert_eq!(
+                registry.resolve_model_to_parser(model),
+                Some("qwen_xml".to_string()),
+                "{model} should resolve to qwen_xml"
+            );
+        }
+    }
+
+    #[test]
+    fn test_qwen_json_model_mappings() {
+        let factory = ParserFactory::new();
+        let registry = factory.registry();
+
+        for model in [
+            "Qwen2.5-72B-Instruct",
+            "Qwen2.5-Coder-32B-Instruct",
+            "qwen2.5-coder-7b",
+            "Qwen3-32B",
+            "Qwen/Qwen3-235B-A22B",
+            "qwen3-8b",
+        ] {
+            assert_eq!(
+                registry.resolve_model_to_parser(model),
+                Some("qwen".to_string()),
+                "{model} should resolve to qwen"
+            );
+        }
+    }
+}

--- a/crates/tool_parser/src/tests.rs
+++ b/crates/tool_parser/src/tests.rs
@@ -2,7 +2,7 @@ use openai_protocol::common::{Function, Tool};
 
 use super::*;
 use crate::{
-    parsers::{JsonParser, QwenCoderParser},
+    parsers::{JsonParser, QwenXmlParser},
     partial_json::PartialJson,
     traits::ToolParser,
 };
@@ -574,7 +574,7 @@ mod stress_tests {
 }
 
 #[cfg(test)]
-mod qwen_coder_tests {
+mod qwen_xml_tests {
     use super::*;
 
     fn create_test_tools() -> Vec<Tool> {
@@ -596,8 +596,8 @@ mod qwen_coder_tests {
     }
 
     #[tokio::test]
-    async fn test_qwen_coder_incremental_parameter_streaming() {
-        let mut parser = QwenCoderParser::new();
+    async fn test_qwen_xml_incremental_parameter_streaming() {
+        let mut parser = QwenXmlParser::new();
         let tools = create_test_tools();
 
         let chunks = [
@@ -651,8 +651,8 @@ mod qwen_coder_tests {
     }
 
     #[tokio::test]
-    async fn test_qwen_coder_incremental_parameter_streaming_with_partial_values() {
-        let mut parser = QwenCoderParser::new();
+    async fn test_qwen_xml_incremental_parameter_streaming_with_partial_values() {
+        let mut parser = QwenXmlParser::new();
         let tools = create_test_tools();
 
         // Test with parameter values that arrive in multiple chunks
@@ -691,8 +691,8 @@ mod qwen_coder_tests {
     }
 
     #[tokio::test]
-    async fn test_qwen_coder_nested_json_parameter() {
-        let mut parser = QwenCoderParser::new();
+    async fn test_qwen_xml_nested_json_parameter() {
+        let mut parser = QwenXmlParser::new();
         let tools = vec![Tool {
             tool_type: "function".to_string(),
             function: Function {

--- a/crates/tool_parser/tests/tool_parser_qwen_xml.rs
+++ b/crates/tool_parser/tests/tool_parser_qwen_xml.rs
@@ -1,16 +1,16 @@
-//! Qwen Coder Parser Integration Tests
+//! Qwen XML Parser Integration Tests
 //!
-//! Tests for the Qwen Coder parser which handles XML format:
+//! Tests for the Qwen XML parser which handles XML format:
 //! <tool_call>\n<function=name>\n<parameter=key>value</parameter>\n</function>\n</tool_call>
 mod common;
 
 use common::{create_test_tools, streaming_helpers};
 use serde_json::json;
-use tool_parser::{parsers::QwenCoderParser, traits::ToolParser};
+use tool_parser::{parsers::QwenXmlParser, traits::ToolParser};
 
 #[tokio::test]
-async fn test_qwen_coder_single_tool() {
-    let parser = QwenCoderParser::new();
+async fn test_qwen_xml_single_tool() {
+    let parser = QwenXmlParser::new();
     let input = r"<tool_call>
 <function=get_weather>
 <parameter=city>Beijing</parameter>
@@ -28,8 +28,8 @@ async fn test_qwen_coder_single_tool() {
 }
 
 #[tokio::test]
-async fn test_qwen_coder_multiple_sequential_tools() {
-    let parser = QwenCoderParser::new();
+async fn test_qwen_xml_multiple_sequential_tools() {
+    let parser = QwenXmlParser::new();
     let input = r"Let me help you with that.
 <tool_call>
 <function=search>
@@ -51,8 +51,8 @@ async fn test_qwen_coder_multiple_sequential_tools() {
 }
 
 #[tokio::test]
-async fn test_qwen_coder_nested_json_in_parameters() {
-    let parser = QwenCoderParser::new();
+async fn test_qwen_xml_nested_json_in_parameters() {
+    let parser = QwenXmlParser::new();
     let input = r#"<tool_call>
 <function=process_data>
 <parameter=config>{"nested": {"value": [1, 2, 3]}}</parameter>
@@ -71,8 +71,8 @@ async fn test_qwen_coder_nested_json_in_parameters() {
 }
 
 #[tokio::test]
-async fn test_qwen_coder_string_parameters() {
-    let parser = QwenCoderParser::new();
+async fn test_qwen_xml_string_parameters() {
+    let parser = QwenXmlParser::new();
     let input = r"<tool_call>
 <function=process>
 <parameter=text>Hello World</parameter>
@@ -90,8 +90,8 @@ async fn test_qwen_coder_string_parameters() {
 }
 
 #[tokio::test]
-async fn test_qwen_coder_empty_arguments() {
-    let parser = QwenCoderParser::new();
+async fn test_qwen_xml_empty_arguments() {
+    let parser = QwenXmlParser::new();
     let input = r"<tool_call>
 <function=get_time>
 </function>
@@ -106,8 +106,8 @@ async fn test_qwen_coder_empty_arguments() {
 }
 
 #[tokio::test]
-async fn test_qwen_coder_multiline_parameter_values() {
-    let parser = QwenCoderParser::new();
+async fn test_qwen_xml_multiline_parameter_values() {
+    let parser = QwenXmlParser::new();
     let input = r"<tool_call>
 <function=write_file>
 <parameter=content>Line 1
@@ -126,8 +126,8 @@ Line 3</parameter>
 }
 
 #[tokio::test]
-async fn test_qwen_coder_format_detection() {
-    let parser = QwenCoderParser::new();
+async fn test_qwen_xml_format_detection() {
+    let parser = QwenXmlParser::new();
 
     assert!(parser.has_tool_markers("<tool_call>"));
     assert!(parser.has_tool_markers("Some text <tool_call>"));
@@ -136,8 +136,8 @@ async fn test_qwen_coder_format_detection() {
 }
 
 #[tokio::test]
-async fn test_qwen_coder_incomplete_tags() {
-    let parser = QwenCoderParser::new();
+async fn test_qwen_xml_incomplete_tags() {
+    let parser = QwenXmlParser::new();
 
     // Missing closing tag
     let input = r"<tool_call>
@@ -155,8 +155,8 @@ async fn test_qwen_coder_incomplete_tags() {
 }
 
 #[tokio::test]
-async fn test_qwen_coder_streaming_basic() {
-    let mut parser = QwenCoderParser::new();
+async fn test_qwen_xml_streaming_basic() {
+    let mut parser = QwenXmlParser::new();
     let tools = create_test_tools();
 
     // Simulate streaming chunks
@@ -191,8 +191,8 @@ async fn test_qwen_coder_streaming_basic() {
 }
 
 #[tokio::test]
-async fn test_qwen_coder_streaming_incremental_json() {
-    let mut parser = QwenCoderParser::new();
+async fn test_qwen_xml_streaming_incremental_json() {
+    let mut parser = QwenXmlParser::new();
     let tools = create_test_tools();
 
     let chunks = vec![
@@ -234,8 +234,8 @@ async fn test_qwen_coder_streaming_incremental_json() {
 }
 
 #[tokio::test]
-async fn test_qwen_coder_streaming_partial_tags() {
-    let mut parser = QwenCoderParser::new();
+async fn test_qwen_xml_streaming_partial_tags() {
+    let mut parser = QwenXmlParser::new();
     let tools = create_test_tools();
 
     // Chunks split mid-tag
@@ -271,8 +271,8 @@ async fn test_qwen_coder_streaming_partial_tags() {
 }
 
 #[tokio::test]
-async fn test_qwen_coder_multiple_tools_boundary() {
-    let mut parser = QwenCoderParser::new();
+async fn test_qwen_xml_multiple_tools_boundary() {
+    let mut parser = QwenXmlParser::new();
     let tools = create_test_tools();
 
     // Tool boundary at chunk boundary
@@ -299,8 +299,8 @@ async fn test_qwen_coder_multiple_tools_boundary() {
 }
 
 #[tokio::test]
-async fn test_qwen_coder_invalid_function_name() {
-    let mut parser = QwenCoderParser::new();
+async fn test_qwen_xml_invalid_function_name() {
+    let mut parser = QwenXmlParser::new();
     let tools = create_test_tools();
 
     let chunks = vec![
@@ -329,8 +329,8 @@ async fn test_qwen_coder_invalid_function_name() {
 }
 
 #[tokio::test]
-async fn test_qwen_coder_type_conversion() {
-    let parser = QwenCoderParser::new();
+async fn test_qwen_xml_type_conversion() {
+    let parser = QwenXmlParser::new();
 
     let input = r"<tool_call>
 <function=process>
@@ -355,8 +355,8 @@ async fn test_qwen_coder_type_conversion() {
 }
 
 #[tokio::test]
-async fn test_qwen_coder_special_characters_in_values() {
-    let parser = QwenCoderParser::new();
+async fn test_qwen_xml_special_characters_in_values() {
+    let parser = QwenXmlParser::new();
 
     let input = r#"<tool_call>
 <function=process>
@@ -376,8 +376,8 @@ async fn test_qwen_coder_special_characters_in_values() {
 }
 
 #[tokio::test]
-async fn test_qwen_coder_whitespace_handling() {
-    let parser = QwenCoderParser::new();
+async fn test_qwen_xml_whitespace_handling() {
+    let parser = QwenXmlParser::new();
 
     // Test with various whitespace scenarios
     let input = r"<tool_call>
@@ -401,9 +401,9 @@ async fn test_qwen_coder_whitespace_handling() {
 }
 
 #[tokio::test]
-async fn test_qwen_coder_no_tools() {
+async fn test_qwen_xml_no_tools() {
     // Test input with no tool calls at all
-    let parser = QwenCoderParser::new();
+    let parser = QwenXmlParser::new();
 
     let input = r"This is just a normal response without any tool calls.
 I can provide information directly without using any tools.
@@ -427,8 +427,8 @@ they are not actual tool calls unless properly formatted.";
 }
 
 #[tokio::test]
-async fn test_qwen_coder_streaming_state_reset() {
-    let mut parser = QwenCoderParser::new();
+async fn test_qwen_xml_streaming_state_reset() {
+    let mut parser = QwenXmlParser::new();
     let tools = create_test_tools();
 
     // First tool
@@ -463,9 +463,9 @@ async fn test_qwen_coder_streaming_state_reset() {
 }
 
 #[tokio::test]
-async fn test_qwen_coder_realistic_chunks() {
+async fn test_qwen_xml_realistic_chunks() {
     let tools = create_test_tools();
-    let mut parser = QwenCoderParser::new();
+    let mut parser = QwenXmlParser::new();
 
     let input = r"<tool_call>
 <function=get_weather>
@@ -493,9 +493,9 @@ async fn test_qwen_coder_realistic_chunks() {
 }
 
 #[tokio::test]
-async fn test_qwen_coder_xml_tag_arrives_in_parts() {
+async fn test_qwen_xml_xml_tag_arrives_in_parts() {
     let tools = create_test_tools();
-    let mut parser = QwenCoderParser::new();
+    let mut parser = QwenXmlParser::new();
 
     let chunks = vec![
         "<to", "ol_", "cal", "l>", "<fun", "cti", "on=", "get", "_we", "ath", "er>", "<par", "ame",
@@ -519,8 +519,8 @@ async fn test_qwen_coder_xml_tag_arrives_in_parts() {
 }
 
 #[tokio::test]
-async fn test_qwen_coder_content_before_and_after_tool_calls() {
-    let parser = QwenCoderParser::new();
+async fn test_qwen_xml_content_before_and_after_tool_calls() {
+    let parser = QwenXmlParser::new();
 
     let input = r"I'll analyze the weather for you now.
 <tool_call>
@@ -548,8 +548,8 @@ Based on the analysis, here's what I found.";
 }
 
 #[tokio::test]
-async fn test_qwen_coder_incomplete_tool_call() {
-    let parser = QwenCoderParser::new();
+async fn test_qwen_xml_incomplete_tool_call() {
+    let parser = QwenXmlParser::new();
 
     // Incomplete tool call - missing closing tag
     let input = r"<tool_call>
@@ -564,8 +564,8 @@ async fn test_qwen_coder_incomplete_tool_call() {
 }
 
 #[tokio::test]
-async fn test_qwen_coder_malformed_function_tag() {
-    let parser = QwenCoderParser::new();
+async fn test_qwen_xml_malformed_function_tag() {
+    let parser = QwenXmlParser::new();
 
     // Malformed function tag - missing name attribute
     let input = r"<tool_call>
@@ -582,8 +582,8 @@ async fn test_qwen_coder_malformed_function_tag() {
 }
 
 #[tokio::test]
-async fn test_qwen_coder_many_parameters() {
-    let parser = QwenCoderParser::new();
+async fn test_qwen_xml_many_parameters() {
+    let parser = QwenXmlParser::new();
 
     let mut params_xml = String::new();
     for i in 1..=20 {
@@ -620,8 +620,8 @@ async fn test_qwen_coder_many_parameters() {
 // ============================================================================
 
 #[tokio::test]
-async fn test_qwen_coder_malformed_xml_missing_parameter_close() {
-    let parser = QwenCoderParser::new();
+async fn test_qwen_xml_malformed_xml_missing_parameter_close() {
+    let parser = QwenXmlParser::new();
 
     // Missing </parameter> closing tag - parser regex won't match incomplete parameter
     let input = r"<tool_call>
@@ -645,8 +645,8 @@ async fn test_qwen_coder_malformed_xml_missing_parameter_close() {
 }
 
 #[tokio::test]
-async fn test_qwen_coder_malformed_xml_unclosed_function() {
-    let parser = QwenCoderParser::new();
+async fn test_qwen_xml_malformed_xml_unclosed_function() {
+    let parser = QwenXmlParser::new();
 
     // Missing </function> closing tag
     let input = r"<tool_call>
@@ -663,8 +663,8 @@ async fn test_qwen_coder_malformed_xml_unclosed_function() {
 }
 
 #[tokio::test]
-async fn test_qwen_coder_malformed_xml_nested_tool_calls() {
-    let parser = QwenCoderParser::new();
+async fn test_qwen_xml_malformed_xml_nested_tool_calls() {
+    let parser = QwenXmlParser::new();
 
     // Nested tool_call tags (invalid)
     let input = r"<tool_call>
@@ -684,8 +684,8 @@ async fn test_qwen_coder_malformed_xml_nested_tool_calls() {
 }
 
 #[tokio::test]
-async fn test_qwen_coder_unicode_parameter_names() {
-    let parser = QwenCoderParser::new();
+async fn test_qwen_xml_unicode_parameter_names() {
+    let parser = QwenXmlParser::new();
 
     // Unicode characters in parameter names (Chinese, Japanese, emoji)
     let input = r"<tool_call>
@@ -707,8 +707,8 @@ async fn test_qwen_coder_unicode_parameter_names() {
 }
 
 #[tokio::test]
-async fn test_qwen_coder_unicode_function_name() {
-    let parser = QwenCoderParser::new();
+async fn test_qwen_xml_unicode_function_name() {
+    let parser = QwenXmlParser::new();
 
     // Unicode function name
     let input = r"<tool_call>
@@ -726,8 +726,8 @@ async fn test_qwen_coder_unicode_function_name() {
 }
 
 #[tokio::test]
-async fn test_qwen_coder_very_large_parameter_value() {
-    let parser = QwenCoderParser::new();
+async fn test_qwen_xml_very_large_parameter_value() {
+    let parser = QwenXmlParser::new();
 
     // Generate a large parameter value (100KB)
     let large_value: String = "x".repeat(100_000);
@@ -749,8 +749,8 @@ async fn test_qwen_coder_very_large_parameter_value() {
 }
 
 #[tokio::test]
-async fn test_qwen_coder_very_large_nested_json_parameter() {
-    let parser = QwenCoderParser::new();
+async fn test_qwen_xml_very_large_nested_json_parameter() {
+    let parser = QwenXmlParser::new();
 
     // Generate moderately nested JSON structure (10 levels to avoid stack overflow)
     let mut nested_json = String::from(r#"{"level": 0}"#);
@@ -777,8 +777,8 @@ async fn test_qwen_coder_very_large_nested_json_parameter() {
 }
 
 #[tokio::test]
-async fn test_qwen_coder_streaming_malformed_recovery() {
-    let mut parser = QwenCoderParser::new();
+async fn test_qwen_xml_streaming_malformed_recovery() {
+    let mut parser = QwenXmlParser::new();
     let tools = create_test_tools();
 
     // First: malformed tool call (invalid function name)
@@ -808,8 +808,8 @@ async fn test_qwen_coder_streaming_malformed_recovery() {
 }
 
 #[tokio::test]
-async fn test_qwen_coder_parameter_with_xml_like_content() {
-    let parser = QwenCoderParser::new();
+async fn test_qwen_xml_parameter_with_xml_like_content() {
+    let parser = QwenXmlParser::new();
 
     // Parameter value contains XML-like content that shouldn't be parsed as tags
     let input = r#"<tool_call>
@@ -834,8 +834,8 @@ async fn test_qwen_coder_parameter_with_xml_like_content() {
 }
 
 #[tokio::test]
-async fn test_qwen_coder_empty_parameter_value() {
-    let parser = QwenCoderParser::new();
+async fn test_qwen_xml_empty_parameter_value() {
+    let parser = QwenXmlParser::new();
 
     let input = r"<tool_call>
 <function=process>
@@ -859,8 +859,8 @@ async fn test_qwen_coder_empty_parameter_value() {
 // ============================================================================
 
 #[tokio::test]
-async fn test_qwen_coder_html_entity_decoding() {
-    let parser = QwenCoderParser::new();
+async fn test_qwen_xml_html_entity_decoding() {
+    let parser = QwenXmlParser::new();
 
     // Test HTML entities in parameter values
     let input = r"<tool_call>
@@ -881,8 +881,8 @@ async fn test_qwen_coder_html_entity_decoding() {
 }
 
 #[tokio::test]
-async fn test_qwen_coder_html_numeric_entities() {
-    let parser = QwenCoderParser::new();
+async fn test_qwen_xml_html_numeric_entities() {
+    let parser = QwenXmlParser::new();
 
     // Test numeric HTML entities
     let input = r"<tool_call>
@@ -901,8 +901,8 @@ async fn test_qwen_coder_html_numeric_entities() {
 }
 
 #[tokio::test]
-async fn test_qwen_coder_python_literals() {
-    let parser = QwenCoderParser::new();
+async fn test_qwen_xml_python_literals() {
+    let parser = QwenXmlParser::new();
 
     // Test Python-style literals (True, False, None)
     let input = r"<tool_call>
@@ -931,8 +931,8 @@ async fn test_qwen_coder_python_literals() {
 }
 
 #[tokio::test]
-async fn test_qwen_coder_mixed_html_and_json() {
-    let parser = QwenCoderParser::new();
+async fn test_qwen_xml_mixed_html_and_json() {
+    let parser = QwenXmlParser::new();
 
     // Test HTML entities within JSON structures
     let input = r#"<tool_call>

--- a/docs/concepts/architecture/grpc-pipeline.md
+++ b/docs/concepts/architecture/grpc-pipeline.md
@@ -267,7 +267,7 @@ Qwen Coder XML format with parameter tags.
 | `json` | `gpt-*`, `claude-*`, `gemini-*` | Standard JSON function calls |
 | `mistral` | `mistral-*`, `mixtral-*` | Mistral-specific format |
 | `qwen` | `qwen*`, `Qwen*` | JSON tool calls |
-| `qwen_coder` | `Qwen*-Coder*`, `qwen*-coder*` | XML with parameter tags |
+| `qwen_xml` | `Qwen3-Coder*`, `Qwen3.5*` | XML with parameter tags |
 | `pythonic` | `llama-4*`, `deepseek-*` | Python-style function syntax |
 | `llama` | `llama-3.2*` | Python tag with JSON |
 | `deepseek` | `deepseek-v3*` | XML with function syntax |

--- a/docs/concepts/architecture/grpc-pipeline.md
+++ b/docs/concepts/architecture/grpc-pipeline.md
@@ -247,9 +247,9 @@ Qwen model JSON tool calling format.
 
 <div class="card" markdown>
 
-**Qwen Coder**
+**Qwen XML**
 
-Qwen Coder XML format with parameter tags.
+Qwen3-Coder / Qwen3.5+ XML format with parameter tags.
 
 ```xml
 <tool_call><function=get_weather><parameter=location>NYC</parameter></function></tool_call>

--- a/docs/getting-started/grpc-workers.md
+++ b/docs/getting-started/grpc-workers.md
@@ -195,7 +195,7 @@ Auto-detected from the model name. Override with `--tool-call-parser` if needed.
 | `deepseek` | DeepSeek-V3 |
 | `mistral` | Mistral, Mixtral |
 | `qwen` | Qwen |
-| `qwen_coder` | Qwen3-Coder, Qwen2.5-Coder |
+| `qwen_xml` | Qwen3-Coder, Qwen3.5+ |
 | `glm45_moe` | GLM-4.5, GLM-4.6 |
 | `glm47_moe` | GLM-4.7 |
 | `step3` | Step-3 |


### PR DESCRIPTION
## Description

### Problem

The `qwen_coder` tool parser name was misleading — Qwen3.5 base (non-Coder) models also use the XML `<function=name><parameter=key>value</parameter>` format. Additionally, Qwen2.5-Coder was incorrectly mapped to the XML parser when Huggingface chat templates confirm it uses JSON format.

### Solution

Rename `qwen_coder` → `qwen_xml` and fix model-to-parser mappings based on validated Huggingface chat templates.

## Huggingface Chat Template Validation

Downloaded and analyzed `tokenizer_config.json` from Huggingface for every major Qwen model family to determine the correct tool call format:

| Model | HF Source | Tool Call Format | Correct Parser |
|---|---|---|---|
| Qwen2-72B-Instruct | [link](https://huggingface.co/Qwen/Qwen2-72B-Instruct) | No tool call support in template | N/A |
| Qwen2.5-7B-Instruct | [link](https://huggingface.co/Qwen/Qwen2.5-7B-Instruct) | JSON: `{"name": "...", "arguments": {...}}` in `<tool_call>` tags | `qwen` |
| Qwen2.5-72B-Instruct | [link](https://huggingface.co/Qwen/Qwen2.5-72B-Instruct) | JSON: `{"name": "...", "arguments": {...}}` in `<tool_call>` tags | `qwen` |
| **Qwen2.5-Coder-32B-Instruct** | [link](https://huggingface.co/Qwen/Qwen2.5-Coder-32B-Instruct) | **JSON** (not XML!) in `<tool_call>` tags | `qwen` (**was `qwen_coder` — bug fix**) |
| Qwen3-8B | [link](https://huggingface.co/Qwen/Qwen3-8B) | JSON: `{"name": "...", "arguments": {...}}` in `<tool_call>` tags | `qwen` |
| Qwen3-32B | [link](https://huggingface.co/Qwen/Qwen3-32B) | JSON in `<tool_call>` tags | `qwen` |
| Qwen3-235B-A22B | [link](https://huggingface.co/Qwen/Qwen3-235B-A22B) | JSON in `<tool_call>` tags | `qwen` |
| Qwen3-Coder-480B-A35B-Instruct | [link](https://huggingface.co/Qwen/Qwen3-Coder-480B-A35B-Instruct) | XML: `<function=name><parameter=key>value</parameter>` | `qwen_xml` |
| Qwen3.5-4B | [link](https://huggingface.co/Qwen/Qwen3.5-4B) | XML: `<function=name><parameter=key>value</parameter>` | `qwen_xml` |

### Key finding

The XML tool call format first appeared in **Qwen3-Coder** and became the default for **Qwen3.5+** (including non-Coder variants). All models before that (Qwen2.5, Qwen2.5-Coder, Qwen3 base) use JSON format.

## Changes

- Rename `qwen_coder.rs` → `qwen_xml.rs`, `QwenCoderParser` → `QwenXmlParser`
- Register parser as `qwen_xml` instead of `qwen_coder`
- Fix mappings: remove incorrect `Qwen2.5-Coder*` → `qwen_coder`, add `Qwen3.5*` → `qwen_xml`
- Update tests, docs, and README

### New mapping table

| Pattern | Parser | Format |
|---|---|---|
| `Qwen3.5*` | `qwen_xml` | XML: `<function=name><parameter=key>value</parameter>` |
| `Qwen3-Coder*` | `qwen_xml` | XML: `<function=name><parameter=key>value</parameter>` |
| `qwen*` / `Qwen*` (catch-all) | `qwen` | JSON: `{"name": "...", "arguments": {...}}` |

## Test Plan

- [x] `cargo check -p tool-parser` passes
- [x] `cargo test -p tool-parser` — all 357 tests pass
- [x] `cargo clippy -p tool-parser --all-targets --all-features -- -D warnings` clean
- [x] `cargo check` full workspace compiles
- [x] No remaining references to `qwen_coder` or `QwenCoderParser` in codebase

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Qwen tool parser now exposes an XML-based parser targeting Qwen3-Coder and Qwen3.5+ model families.

* **Documentation**
  * Updated parser names and model-pattern mappings across docs and README to reflect the XML-based Qwen parser.

* **Tests**
  * Updated unit and integration tests to exercise the XML-based Qwen parser and verify model-to-parser resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->