### PR TITLE
feat(mesh): stream buffer integration with backpressure (v2 Step 2a)

### DIFF
--- a/crates/mesh/src/kv.rs
+++ b/crates/mesh/src/kv.rs
@@ -399,20 +399,22 @@ impl StreamNamespace {
         }
     }
 
-    /// Drop oldest broadcast buffer entries until within `max_buffer_bytes`.
+    /// Drop broadcast buffer entries until within `max_buffer_bytes`.
+    /// DashMap has no ordering, so dropped entries are arbitrary.
     fn enforce_broadcast_limit(&self) {
-        while self.buffer_bytes.load(Ordering::Relaxed) > self.max_buffer_bytes {
-            // DashMap doesn't have ordered iteration, so pick an arbitrary entry to drop.
-            // This is acceptable — broadcast entries are ephemeral and at-most-once.
-            if let Some(entry) = self.buffer.iter().next() {
-                let key = entry.key().clone();
-                drop(entry);
-                if let Some((_, removed)) = self.buffer.remove(&key) {
-                    self.buffer_bytes
-                        .fetch_sub(removed.len(), Ordering::Relaxed);
-                }
-            } else {
+        if self.buffer_bytes.load(Ordering::Relaxed) <= self.max_buffer_bytes {
+            return;
+        }
+        // Collect keys to remove, then remove them. Avoids holding DashMap
+        // iterator while mutating.
+        let keys_to_drop: Vec<String> = self.buffer.iter().map(|e| e.key().clone()).collect();
+        for key in keys_to_drop {
+            if self.buffer_bytes.load(Ordering::Relaxed) <= self.max_buffer_bytes {
                 break;
+            }
+            if let Some((_, removed)) = self.buffer.remove(&key) {
+                self.buffer_bytes
+                    .fetch_sub(removed.len(), Ordering::Relaxed);
             }
         }
     }
@@ -820,5 +822,172 @@ mod tests {
             .expect("channel closed");
         assert_eq!(key, "worker:7");
         assert!(value.is_none(), "delete should notify with None");
+    }
+
+    #[test]
+    fn test_broadcast_backpressure_drops_entries() {
+        let kv = MeshKV::new("test-node".to_string());
+        let ns = kv.configure_stream_prefix(
+            "td:",
+            StreamConfig {
+                max_buffer_bytes: 20, // tiny limit
+                routing: StreamRouting::Broadcast,
+            },
+        );
+
+        // Publish entries that exceed the buffer limit.
+        ns.publish("td:model-1", Bytes::from("aaaaaaaaaa")); // 10 bytes
+        ns.publish("td:model-2", Bytes::from("bbbbbbbbbb")); // 10 bytes, total=20, at limit
+        ns.publish("td:model-3", Bytes::from("cccccccccc")); // 10 bytes, total=30, over limit
+
+        // Buffer should have dropped an entry to stay within 20 bytes.
+        let drained = ns.drain_broadcast_buffer();
+        let total_bytes: usize = drained.iter().map(|(_, v)| v.len()).sum();
+        assert!(
+            total_bytes <= 20,
+            "buffer should be within limit, got {total_bytes}"
+        );
+    }
+
+    #[test]
+    fn test_targeted_backpressure_drops_oldest() {
+        let kv = MeshKV::new("test-node".to_string());
+        let ns = kv.configure_stream_prefix(
+            "tree:page:",
+            StreamConfig {
+                max_buffer_bytes: 20, // tiny limit
+                routing: StreamRouting::Targeted,
+            },
+        );
+
+        ns.publish_to("peer-A", "tree:page:m1", Bytes::from("aaaaaaaaaa")); // 10 bytes
+        ns.publish_to("peer-A", "tree:page:m2", Bytes::from("bbbbbbbbbb")); // 10 bytes
+        ns.publish_to("peer-A", "tree:page:m3", Bytes::from("cccccccccc")); // over limit
+
+        let drained = ns.drain_targeted_buffer();
+        let total_bytes: usize = drained.iter().map(|(_, _, v)| v.len()).sum();
+        assert!(
+            total_bytes <= 20,
+            "buffer should be within limit, got {total_bytes}"
+        );
+        // Oldest entry (m1) should have been dropped, keeping m2 and m3.
+        assert_eq!(drained.len(), 2);
+        assert_eq!(drained[0].1, "tree:page:m2");
+        assert_eq!(drained[1].1, "tree:page:m3");
+    }
+
+    #[test]
+    fn test_drain_broadcast_buffer() {
+        let kv = MeshKV::new("test-node".to_string());
+        let ns = kv.configure_stream_prefix(
+            "td:",
+            StreamConfig {
+                max_buffer_bytes: 1024,
+                routing: StreamRouting::Broadcast,
+            },
+        );
+
+        ns.publish("td:model-1", Bytes::from("delta1"));
+        ns.publish("td:model-2", Bytes::from("delta2"));
+
+        let entries = ns.drain_broadcast_buffer();
+        assert_eq!(entries.len(), 2);
+
+        // Buffer should be empty after drain.
+        let entries2 = ns.drain_broadcast_buffer();
+        assert!(entries2.is_empty());
+    }
+
+    #[test]
+    fn test_drain_targeted_buffer() {
+        let kv = MeshKV::new("test-node".to_string());
+        let ns = kv.configure_stream_prefix(
+            "tree:page:",
+            StreamConfig {
+                max_buffer_bytes: 1024,
+                routing: StreamRouting::Targeted,
+            },
+        );
+
+        ns.publish_to("peer-A", "tree:page:m1", Bytes::from("page1"));
+        ns.publish_to("peer-B", "tree:page:m2", Bytes::from("page2"));
+
+        let entries = ns.drain_targeted_buffer();
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].0, "peer-A");
+        assert_eq!(entries[1].0, "peer-B");
+
+        // Buffer should be empty after drain.
+        let entries2 = ns.drain_targeted_buffer();
+        assert!(entries2.is_empty());
+    }
+
+    #[test]
+    fn test_collect_round_batch() {
+        let kv = MeshKV::new("test-node".to_string());
+        let broadcast_ns = kv.configure_stream_prefix(
+            "td:",
+            StreamConfig {
+                max_buffer_bytes: 1024,
+                routing: StreamRouting::Broadcast,
+            },
+        );
+        let targeted_ns = kv.configure_stream_prefix(
+            "tree:page:",
+            StreamConfig {
+                max_buffer_bytes: 1024,
+                routing: StreamRouting::Targeted,
+            },
+        );
+
+        broadcast_ns.publish("td:model-1", Bytes::from("delta"));
+        targeted_ns.publish_to("peer-A", "tree:page:m1", Bytes::from("page"));
+
+        let batch = kv.collect_round_batch();
+        assert_eq!(batch.broadcast_entries.len(), 1);
+        assert_eq!(batch.targeted_entries.len(), 1);
+        assert_eq!(batch.broadcast_entries[0].0, "td:model-1");
+        assert_eq!(batch.targeted_entries[0].0, "peer-A");
+
+        // Second collect should be empty (buffers drained).
+        let batch2 = kv.collect_round_batch();
+        assert!(batch2.broadcast_entries.is_empty());
+        assert!(batch2.targeted_entries.is_empty());
+    }
+
+    #[test]
+    fn test_collect_round_batch_with_drain_callback() {
+        let kv = MeshKV::new("test-node".to_string());
+        let ns = kv.configure_stream_prefix(
+            "td:",
+            StreamConfig {
+                max_buffer_bytes: 1024,
+                routing: StreamRouting::Broadcast,
+            },
+        );
+
+        let _handle = ns.register_drain(Box::new(|| {
+            vec![("td:from-drain".to_string(), b"drain-data".to_vec())]
+        }));
+
+        let batch = kv.collect_round_batch();
+        assert_eq!(batch.drain_entries.len(), 1);
+        assert_eq!(batch.drain_entries[0].0, "td:from-drain");
+    }
+
+    #[test]
+    #[should_panic(expected = "drain already registered")]
+    fn test_duplicate_drain_registration_panics() {
+        let kv = MeshKV::new("test-node".to_string());
+        let ns = kv.configure_stream_prefix(
+            "td:",
+            StreamConfig {
+                max_buffer_bytes: 1024,
+                routing: StreamRouting::Broadcast,
+            },
+        );
+
+        let _h1 = ns.register_drain(Box::new(Vec::new));
+        let _h2 = ns.register_drain(Box::new(Vec::new)); // panics
     }
 }

--- a/crates/mesh/src/kv.rs
+++ b/crates/mesh/src/kv.rs
@@ -334,10 +334,6 @@ pub struct StreamNamespace {
     prefix: String,
     routing: StreamRouting,
     max_buffer_bytes: usize,
-    /// Ephemeral send buffer, drained every gossip round.
-    buffer: DashMap<String, Bytes>,
-    /// Current total bytes in the broadcast buffer.
-    buffer_bytes: AtomicUsize,
     /// Targeted entries: (target_peer_id, key, value). VecDeque for O(1) FIFO eviction.
     targeted_buffer: parking_lot::Mutex<VecDeque<(String, String, Bytes)>>,
     /// Current total bytes in the targeted buffer.
@@ -347,50 +343,6 @@ pub struct StreamNamespace {
 }
 
 impl StreamNamespace {
-    /// Publish a value to all connected peers (Broadcast namespaces only).
-    /// If the buffer exceeds `max_buffer_bytes`, arbitrary entries are dropped
-    /// until within limit (DashMap iteration is unordered).
-    pub fn publish(&self, key: &str, value: Bytes) {
-        assert_eq!(
-            self.routing,
-            StreamRouting::Broadcast,
-            "publish() is only valid on Broadcast namespaces, not Targeted (prefix: '{}')",
-            self.prefix
-        );
-        assert!(
-            key.starts_with(&self.prefix),
-            "key '{key}' does not match prefix '{}'",
-            self.prefix
-        );
-        let value_len = value.len();
-        // Use entry API to couple byte accounting with the map mutation,
-        // preventing concurrent publishes to the same key from underflowing
-        // the counter via unsynchronized subtract-then-add.
-        match self.buffer.entry(key.to_string()) {
-            DashMapEntry::Occupied(mut entry) => {
-                let old_len = entry.get().len();
-                entry.insert(value);
-                // Net change: add new, subtract old. Single atomic update
-                // avoids transient underflow.
-                if value_len >= old_len {
-                    self.buffer_bytes
-                        .fetch_add(value_len - old_len, Ordering::Relaxed);
-                } else {
-                    self.buffer_bytes
-                        .fetch_sub(old_len - value_len, Ordering::Relaxed);
-                }
-            }
-            DashMapEntry::Vacant(entry) => {
-                // Increment counter BEFORE insert. entry.insert() releases
-                // the shard lock, so a concurrent drain could see the key
-                // and fetch_sub before we fetch_add — underflowing the counter.
-                self.buffer_bytes.fetch_add(value_len, Ordering::Relaxed);
-                entry.insert(value);
-            }
-        }
-        self.enforce_broadcast_limit();
-    }
-
     /// Publish a value to exactly one peer (Targeted namespaces only).
     /// If the buffer exceeds `max_buffer_bytes`, the oldest entries are dropped.
     pub fn publish_to(&self, peer_id: &str, key: &str, value: Bytes) {
@@ -421,27 +373,6 @@ impl StreamNamespace {
         }
     }
 
-    /// Drop broadcast buffer entries until within `max_buffer_bytes`.
-    /// DashMap has no ordering, so dropped entries are arbitrary.
-    fn enforce_broadcast_limit(&self) {
-        if self.buffer_bytes.load(Ordering::Relaxed) <= self.max_buffer_bytes {
-            return;
-        }
-        // Collect all keys upfront so the iterator is fully dropped before
-        // any remove() call. DashMap iter() and remove() can deadlock on the
-        // same shard if the iterator ref is held during remove.
-        let keys: Vec<String> = self.buffer.iter().map(|e| e.key().clone()).collect();
-        for key in keys {
-            if self.buffer_bytes.load(Ordering::Relaxed) <= self.max_buffer_bytes {
-                break;
-            }
-            if let Some((_, removed)) = self.buffer.remove(&key) {
-                self.buffer_bytes
-                    .fetch_sub(removed.len(), Ordering::Relaxed);
-            }
-        }
-    }
-
     /// Subscribe to messages for keys matching a sub-prefix within this namespace.
     pub fn subscribe(&self, sub_prefix: &str) -> Subscription {
         let full_prefix = format!("{}{}", self.prefix, sub_prefix);
@@ -460,23 +391,6 @@ impl StreamNamespace {
             prefix: self.prefix.clone(),
             drain_registry: self.drain_registry.clone(),
         }
-    }
-
-    /// Drain all broadcast buffer entries. Returns (key, value) pairs and
-    /// resets the buffer. Called by the gossip loop once per round.
-    pub fn drain_broadcast_buffer(&self) -> Vec<(String, Bytes)> {
-        let mut entries = Vec::new();
-        let mut drained_bytes = 0usize;
-        // Use retain(false) to drain all entries atomically per shard,
-        // avoiding intermediate Vec<String> allocation for keys.
-        self.buffer.retain(|k, v| {
-            drained_bytes += v.len();
-            entries.push((k.clone(), v.clone()));
-            false // remove all
-        });
-        self.buffer_bytes
-            .fetch_sub(drained_bytes, Ordering::Relaxed);
-        entries
     }
 
     /// Drain all targeted buffer entries. Returns (peer_id, key, value) tuples
@@ -505,11 +419,10 @@ impl StreamNamespace {
 /// A batch of entries collected once per gossip round by the central collector.
 #[derive(Debug)]
 pub struct RoundBatch {
-    /// Broadcast stream entries: (key, value). Sent to ALL connected peers.
-    pub broadcast_entries: Vec<(String, Bytes)>,
     /// Targeted stream entries: (peer_id, key, value). Sent to one specific peer.
     pub targeted_entries: Vec<(String, String, Bytes)>,
     /// Entries from registered drain callbacks (e.g., TreeSyncAdapter pending deltas).
+    /// Broadcast traffic (td:*) flows through this path, not through a buffer.
     pub drain_entries: Vec<(String, Vec<u8>)>,
 }
 
@@ -618,8 +531,6 @@ impl MeshKV {
             prefix: prefix.to_string(),
             routing: config.routing,
             max_buffer_bytes: config.max_buffer_bytes,
-            buffer: DashMap::new(),
-            buffer_bytes: AtomicUsize::new(0),
             targeted_buffer: parking_lot::Mutex::new(VecDeque::new()),
             targeted_buffer_bytes: AtomicUsize::new(0),
             subscriber_registry: self.subscriber_registry.clone(),
@@ -643,20 +554,18 @@ impl MeshKV {
     /// per round by the centralized gossip loop. Drains all stream buffers
     /// and calls all registered drain callbacks.
     pub fn collect_round_batch(&self) -> RoundBatch {
-        let mut broadcast_entries = Vec::new();
         let mut targeted_entries = Vec::new();
 
-        // Drain all stream namespace buffers.
+        // Drain targeted stream namespace buffers.
         for ns in self.stream_namespaces.read().iter() {
-            broadcast_entries.extend(ns.drain_broadcast_buffer());
             targeted_entries.extend(ns.drain_targeted_buffer());
         }
 
-        // Call registered drain callbacks (e.g., adapter pending deltas).
+        // Call registered drain callbacks (e.g., TreeSyncAdapter pending deltas).
+        // Broadcast traffic (td:*) flows through this path.
         let drain_entries = self.drain_registry.drain_all();
 
         RoundBatch {
-            broadcast_entries,
             targeted_entries,
             drain_entries,
         }
@@ -779,20 +688,6 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "only valid on Broadcast")]
-    fn test_stream_publish_on_targeted_panics() {
-        let kv = MeshKV::new("test-node".to_string());
-        let ns = kv.configure_stream_prefix(
-            "tree:req:",
-            StreamConfig {
-                max_buffer_bytes: 1024,
-                routing: StreamRouting::Targeted,
-            },
-        );
-        ns.publish("tree:req:model-x", Bytes::from("data")); // panics
-    }
-
-    #[test]
     #[should_panic(expected = "only valid on Targeted")]
     fn test_stream_publish_to_on_broadcast_panics() {
         let kv = MeshKV::new("test-node".to_string());
@@ -850,31 +745,6 @@ mod tests {
     }
 
     #[test]
-    fn test_broadcast_backpressure_drops_entries() {
-        let kv = MeshKV::new("test-node".to_string());
-        let ns = kv.configure_stream_prefix(
-            "td:",
-            StreamConfig {
-                max_buffer_bytes: 20, // tiny limit
-                routing: StreamRouting::Broadcast,
-            },
-        );
-
-        // Publish entries that exceed the buffer limit.
-        ns.publish("td:model-1", Bytes::from("aaaaaaaaaa")); // 10 bytes
-        ns.publish("td:model-2", Bytes::from("bbbbbbbbbb")); // 10 bytes, total=20, at limit
-        ns.publish("td:model-3", Bytes::from("cccccccccc")); // 10 bytes, total=30, over limit
-
-        // Buffer should have dropped an entry to stay within 20 bytes.
-        let drained = ns.drain_broadcast_buffer();
-        let total_bytes: usize = drained.iter().map(|(_, v)| v.len()).sum();
-        assert!(
-            total_bytes <= 20,
-            "buffer should be within limit, got {total_bytes}"
-        );
-    }
-
-    #[test]
     fn test_targeted_backpressure_drops_oldest() {
         let kv = MeshKV::new("test-node".to_string());
         let ns = kv.configure_stream_prefix(
@@ -899,28 +769,6 @@ mod tests {
         assert_eq!(drained.len(), 2);
         assert_eq!(drained[0].1, "tree:page:m2");
         assert_eq!(drained[1].1, "tree:page:m3");
-    }
-
-    #[test]
-    fn test_drain_broadcast_buffer() {
-        let kv = MeshKV::new("test-node".to_string());
-        let ns = kv.configure_stream_prefix(
-            "td:",
-            StreamConfig {
-                max_buffer_bytes: 1024,
-                routing: StreamRouting::Broadcast,
-            },
-        );
-
-        ns.publish("td:model-1", Bytes::from("delta1"));
-        ns.publish("td:model-2", Bytes::from("delta2"));
-
-        let entries = ns.drain_broadcast_buffer();
-        assert_eq!(entries.len(), 2);
-
-        // Buffer should be empty after drain.
-        let entries2 = ns.drain_broadcast_buffer();
-        assert!(entries2.is_empty());
     }
 
     #[test]
@@ -950,13 +798,6 @@ mod tests {
     #[test]
     fn test_collect_round_batch() {
         let kv = MeshKV::new("test-node".to_string());
-        let broadcast_ns = kv.configure_stream_prefix(
-            "td:",
-            StreamConfig {
-                max_buffer_bytes: 1024,
-                routing: StreamRouting::Broadcast,
-            },
-        );
         let targeted_ns = kv.configure_stream_prefix(
             "tree:page:",
             StreamConfig {
@@ -965,18 +806,14 @@ mod tests {
             },
         );
 
-        broadcast_ns.publish("td:model-1", Bytes::from("delta"));
         targeted_ns.publish_to("peer-A", "tree:page:m1", Bytes::from("page"));
 
         let batch = kv.collect_round_batch();
-        assert_eq!(batch.broadcast_entries.len(), 1);
         assert_eq!(batch.targeted_entries.len(), 1);
-        assert_eq!(batch.broadcast_entries[0].0, "td:model-1");
         assert_eq!(batch.targeted_entries[0].0, "peer-A");
 
         // Second collect should be empty (buffers drained).
         let batch2 = kv.collect_round_batch();
-        assert!(batch2.broadcast_entries.is_empty());
         assert!(batch2.targeted_entries.is_empty());
     }
 

--- a/crates/mesh/src/kv.rs
+++ b/crates/mesh/src/kv.rs
@@ -8,7 +8,7 @@
 use std::{collections::HashMap, sync::Arc, time::Instant};
 
 use bytes::Bytes;
-use dashmap::DashMap;
+use dashmap::{mapref::entry::Entry as DashMapEntry, DashMap};
 use parking_lot::RwLock;
 use tokio::sync::mpsc;
 
@@ -194,11 +194,12 @@ impl DrainRegistry {
     }
 
     fn register(&self, prefix: &str, drain: StreamDrainFn) {
+        let entry = self.drains.entry(prefix.to_string());
         assert!(
-            !self.drains.contains_key(prefix),
+            matches!(&entry, DashMapEntry::Vacant(_)),
             "drain already registered for prefix '{prefix}'"
         );
-        self.drains.insert(prefix.to_string(), Arc::new(drain));
+        entry.or_insert(Arc::new(drain));
     }
 
     fn remove(&self, prefix: &str) {

--- a/crates/mesh/src/kv.rs
+++ b/crates/mesh/src/kv.rs
@@ -402,13 +402,11 @@ impl StreamNamespace {
     /// Drop broadcast buffer entries until within `max_buffer_bytes`.
     /// DashMap has no ordering, so dropped entries are arbitrary.
     fn enforce_broadcast_limit(&self) {
-        if self.buffer_bytes.load(Ordering::Relaxed) <= self.max_buffer_bytes {
-            return;
-        }
-        // Collect keys to remove, then remove them. Avoids holding DashMap
-        // iterator while mutating.
-        let keys_to_drop: Vec<String> = self.buffer.iter().map(|e| e.key().clone()).collect();
-        for key in keys_to_drop {
+        // Collect all keys upfront so the iterator is fully dropped before
+        // any remove() call. DashMap iter() and remove() can deadlock on the
+        // same shard if the iterator ref is held during remove.
+        let keys: Vec<String> = self.buffer.iter().map(|e| e.key().clone()).collect();
+        for key in keys {
             if self.buffer_bytes.load(Ordering::Relaxed) <= self.max_buffer_bytes {
                 break;
             }

--- a/crates/mesh/src/kv.rs
+++ b/crates/mesh/src/kv.rs
@@ -499,6 +499,7 @@ impl StreamNamespace {
 // ============================================================================
 
 /// A batch of entries collected once per gossip round by the central collector.
+#[derive(Debug)]
 pub struct RoundBatch {
     /// Broadcast stream entries: (key, value). Sent to ALL connected peers.
     pub broadcast_entries: Vec<(String, Bytes)>,

--- a/crates/mesh/src/kv.rs
+++ b/crates/mesh/src/kv.rs
@@ -380,8 +380,11 @@ impl StreamNamespace {
                 }
             }
             DashMapEntry::Vacant(entry) => {
-                entry.insert(value);
+                // Increment counter BEFORE insert. entry.insert() releases
+                // the shard lock, so a concurrent drain could see the key
+                // and fetch_sub before we fetch_add — underflowing the counter.
                 self.buffer_bytes.fetch_add(value_len, Ordering::Relaxed);
+                entry.insert(value);
             }
         }
         self.enforce_broadcast_limit();

--- a/crates/mesh/src/kv.rs
+++ b/crates/mesh/src/kv.rs
@@ -438,6 +438,30 @@ impl StreamNamespace {
         }
     }
 
+    /// Drain all broadcast buffer entries. Returns (key, value) pairs and
+    /// resets the buffer. Called by the gossip loop once per round.
+    pub fn drain_broadcast_buffer(&self) -> Vec<(String, Bytes)> {
+        let mut entries = Vec::new();
+        // Collect all entries, then clear. DashMap doesn't have drain(),
+        // so we iterate and remove.
+        let keys: Vec<String> = self.buffer.iter().map(|e| e.key().clone()).collect();
+        for key in keys {
+            if let Some((k, v)) = self.buffer.remove(&key) {
+                entries.push((k, v));
+            }
+        }
+        self.buffer_bytes.store(0, Ordering::Relaxed);
+        entries
+    }
+
+    /// Drain all targeted buffer entries. Returns (peer_id, key, value) tuples
+    /// and resets the buffer. Called by the gossip loop once per round.
+    pub fn drain_targeted_buffer(&self) -> Vec<(String, String, Bytes)> {
+        let mut buf = self.targeted_buffer.lock();
+        self.targeted_buffer_bytes.store(0, Ordering::Relaxed);
+        std::mem::take(&mut *buf)
+    }
+
     /// Get the routing mode for this namespace.
     pub fn routing(&self) -> StreamRouting {
         self.routing

--- a/crates/mesh/src/kv.rs
+++ b/crates/mesh/src/kv.rs
@@ -335,13 +335,13 @@ pub struct StreamNamespace {
     routing: StreamRouting,
     max_buffer_bytes: usize,
     /// Ephemeral send buffer, drained every gossip round.
-    buffer: Arc<DashMap<String, Bytes>>,
+    buffer: DashMap<String, Bytes>,
     /// Current total bytes in the broadcast buffer.
-    buffer_bytes: Arc<AtomicUsize>,
+    buffer_bytes: AtomicUsize,
     /// Targeted entries: (target_peer_id, key, value). VecDeque for O(1) FIFO eviction.
-    targeted_buffer: Arc<parking_lot::Mutex<VecDeque<(String, String, Bytes)>>>,
+    targeted_buffer: parking_lot::Mutex<VecDeque<(String, String, Bytes)>>,
     /// Current total bytes in the targeted buffer.
-    targeted_buffer_bytes: Arc<AtomicUsize>,
+    targeted_buffer_bytes: AtomicUsize,
     subscriber_registry: Arc<SubscriberRegistry>,
     drain_registry: Arc<DrainRegistry>,
 }
@@ -614,10 +614,10 @@ impl MeshKV {
             prefix: prefix.to_string(),
             routing: config.routing,
             max_buffer_bytes: config.max_buffer_bytes,
-            buffer: Arc::new(DashMap::new()),
-            buffer_bytes: Arc::new(AtomicUsize::new(0)),
-            targeted_buffer: Arc::new(parking_lot::Mutex::new(VecDeque::new())),
-            targeted_buffer_bytes: Arc::new(AtomicUsize::new(0)),
+            buffer: DashMap::new(),
+            buffer_bytes: AtomicUsize::new(0),
+            targeted_buffer: parking_lot::Mutex::new(VecDeque::new()),
+            targeted_buffer_bytes: AtomicUsize::new(0),
             subscriber_registry: self.subscriber_registry.clone(),
             drain_registry: self.drain_registry.clone(),
         });

--- a/crates/mesh/src/kv.rs
+++ b/crates/mesh/src/kv.rs
@@ -348,7 +348,8 @@ pub struct StreamNamespace {
 
 impl StreamNamespace {
     /// Publish a value to all connected peers (Broadcast namespaces only).
-    /// If the buffer exceeds `max_buffer_bytes`, the oldest entry is dropped.
+    /// If the buffer exceeds `max_buffer_bytes`, arbitrary entries are dropped
+    /// until within limit (DashMap iteration is unordered).
     pub fn publish(&self, key: &str, value: Bytes) {
         assert_eq!(
             self.routing,

--- a/crates/mesh/src/kv.rs
+++ b/crates/mesh/src/kv.rs
@@ -362,11 +362,28 @@ impl StreamNamespace {
             self.prefix
         );
         let value_len = value.len();
-        // If this key already exists, subtract the old value's size.
-        if let Some(old) = self.buffer.insert(key.to_string(), value) {
-            self.buffer_bytes.fetch_sub(old.len(), Ordering::Relaxed);
+        // Use entry API to couple byte accounting with the map mutation,
+        // preventing concurrent publishes to the same key from underflowing
+        // the counter via unsynchronized subtract-then-add.
+        match self.buffer.entry(key.to_string()) {
+            DashMapEntry::Occupied(mut entry) => {
+                let old_len = entry.get().len();
+                entry.insert(value);
+                // Net change: add new, subtract old. Single atomic update
+                // avoids transient underflow.
+                if value_len >= old_len {
+                    self.buffer_bytes
+                        .fetch_add(value_len - old_len, Ordering::Relaxed);
+                } else {
+                    self.buffer_bytes
+                        .fetch_sub(old_len - value_len, Ordering::Relaxed);
+                }
+            }
+            DashMapEntry::Vacant(entry) => {
+                entry.insert(value);
+                self.buffer_bytes.fetch_add(value_len, Ordering::Relaxed);
+            }
         }
-        self.buffer_bytes.fetch_add(value_len, Ordering::Relaxed);
         self.enforce_broadcast_limit();
     }
 

--- a/crates/mesh/src/kv.rs
+++ b/crates/mesh/src/kv.rs
@@ -383,9 +383,16 @@ impl StreamNamespace {
     }
 
     /// Register a drain callback. Called exactly once per gossip round by the
-    /// centralized collector. Returns a DrainHandle for
-    /// unregistration.
+    /// centralized collector. Only valid on Broadcast namespaces — drain entries
+    /// carry (key, value) without peer_id, so targeted routing is not possible.
+    /// Returns a DrainHandle for unregistration.
     pub fn register_drain(&self, drain: StreamDrainFn) -> DrainHandle {
+        assert_eq!(
+            self.routing,
+            StreamRouting::Broadcast,
+            "register_drain() is only valid on Broadcast namespaces (prefix: '{}')",
+            self.prefix
+        );
         self.drain_registry.register(&self.prefix, drain);
         DrainHandle {
             prefix: self.prefix.clone(),

--- a/crates/mesh/src/kv.rs
+++ b/crates/mesh/src/kv.rs
@@ -441,15 +441,16 @@ impl StreamNamespace {
     /// resets the buffer. Called by the gossip loop once per round.
     pub fn drain_broadcast_buffer(&self) -> Vec<(String, Bytes)> {
         let mut entries = Vec::new();
-        // Collect all entries, then clear. DashMap doesn't have drain(),
-        // so we iterate and remove.
-        let keys: Vec<String> = self.buffer.iter().map(|e| e.key().clone()).collect();
-        for key in keys {
-            if let Some((k, v)) = self.buffer.remove(&key) {
-                entries.push((k, v));
-            }
-        }
-        self.buffer_bytes.store(0, Ordering::Relaxed);
+        let mut drained_bytes = 0usize;
+        // Use retain(false) to drain all entries atomically per shard,
+        // avoiding intermediate Vec<String> allocation for keys.
+        self.buffer.retain(|k, v| {
+            drained_bytes += v.len();
+            entries.push((k.clone(), v.clone()));
+            false // remove all
+        });
+        self.buffer_bytes
+            .fetch_sub(drained_bytes, Ordering::Relaxed);
         entries
     }
 

--- a/crates/mesh/src/kv.rs
+++ b/crates/mesh/src/kv.rs
@@ -476,9 +476,6 @@ impl StreamNamespace {
 // MeshKV
 // ============================================================================
 
-/// Generic, application-agnostic mesh transport. Provides explicit namespace
-/// handles for CRDT and stream modes. Application code MUST use namespace
-/// handles, not MeshKV directly.
 /// A batch of entries collected once per gossip round by the central collector.
 pub struct RoundBatch {
     /// Broadcast stream entries: (key, value). Sent to ALL connected peers.
@@ -489,6 +486,9 @@ pub struct RoundBatch {
     pub drain_entries: Vec<(String, Vec<u8>)>,
 }
 
+/// Generic, application-agnostic mesh transport. Provides explicit namespace
+/// handles for CRDT and stream modes. Application code MUST use namespace
+/// handles, not MeshKV directly.
 pub struct MeshKV {
     /// CRDT store shared across all CRDT namespaces.
     store: Arc<CrdtOrMap>,

--- a/crates/mesh/src/kv.rs
+++ b/crates/mesh/src/kv.rs
@@ -6,7 +6,7 @@
 //!
 
 use std::{
-    collections::HashMap,
+    collections::{HashMap, VecDeque},
     sync::{
         atomic::{AtomicUsize, Ordering},
         Arc,
@@ -338,8 +338,8 @@ pub struct StreamNamespace {
     buffer: Arc<DashMap<String, Bytes>>,
     /// Current total bytes in the broadcast buffer.
     buffer_bytes: Arc<AtomicUsize>,
-    /// Targeted entries: (target_peer_id, key, value).
-    targeted_buffer: Arc<parking_lot::Mutex<Vec<(String, String, Bytes)>>>,
+    /// Targeted entries: (target_peer_id, key, value). VecDeque for O(1) FIFO eviction.
+    targeted_buffer: Arc<parking_lot::Mutex<VecDeque<(String, String, Bytes)>>>,
     /// Current total bytes in the targeted buffer.
     targeted_buffer_bytes: Arc<AtomicUsize>,
     subscriber_registry: Arc<SubscriberRegistry>,
@@ -386,16 +386,17 @@ impl StreamNamespace {
         );
         let value_len = value.len();
         let mut buf = self.targeted_buffer.lock();
-        buf.push((peer_id.to_string(), key.to_string(), value));
+        buf.push_back((peer_id.to_string(), key.to_string(), value));
         self.targeted_buffer_bytes
             .fetch_add(value_len, Ordering::Relaxed);
-        // Drop oldest entries while over limit.
+        // Drop the oldest entries (FIFO) while over limit. O(1) per pop_front.
         while self.targeted_buffer_bytes.load(Ordering::Relaxed) > self.max_buffer_bytes
             && !buf.is_empty()
         {
-            let (_, _, dropped) = buf.remove(0);
-            self.targeted_buffer_bytes
-                .fetch_sub(dropped.len(), Ordering::Relaxed);
+            if let Some((_, _, dropped)) = buf.pop_front() {
+                self.targeted_buffer_bytes
+                    .fetch_sub(dropped.len(), Ordering::Relaxed);
+            }
         }
     }
 
@@ -459,7 +460,7 @@ impl StreamNamespace {
     pub fn drain_targeted_buffer(&self) -> Vec<(String, String, Bytes)> {
         let mut buf = self.targeted_buffer.lock();
         self.targeted_buffer_bytes.store(0, Ordering::Relaxed);
-        std::mem::take(&mut *buf)
+        std::mem::take(&mut *buf).into()
     }
 
     /// Get the routing mode for this namespace.
@@ -594,7 +595,7 @@ impl MeshKV {
             max_buffer_bytes: config.max_buffer_bytes,
             buffer: Arc::new(DashMap::new()),
             buffer_bytes: Arc::new(AtomicUsize::new(0)),
-            targeted_buffer: Arc::new(parking_lot::Mutex::new(Vec::new())),
+            targeted_buffer: Arc::new(parking_lot::Mutex::new(VecDeque::new())),
             targeted_buffer_bytes: Arc::new(AtomicUsize::new(0)),
             subscriber_registry: self.subscriber_registry.clone(),
             drain_registry: self.drain_registry.clone(),

--- a/crates/mesh/src/kv.rs
+++ b/crates/mesh/src/kv.rs
@@ -420,6 +420,9 @@ impl StreamNamespace {
     /// Drop broadcast buffer entries until within `max_buffer_bytes`.
     /// DashMap has no ordering, so dropped entries are arbitrary.
     fn enforce_broadcast_limit(&self) {
+        if self.buffer_bytes.load(Ordering::Relaxed) <= self.max_buffer_bytes {
+            return;
+        }
         // Collect all keys upfront so the iterator is fully dropped before
         // any remove() call. DashMap iter() and remove() can deadlock on the
         // same shard if the iterator ref is held during remove.

--- a/crates/mesh/src/kv.rs
+++ b/crates/mesh/src/kv.rs
@@ -5,7 +5,14 @@
 //! - `StreamNamespace` for ephemeral, lossy, application-regenerated traffic (tenant deltas, tree repair)
 //!
 
-use std::{collections::HashMap, sync::Arc, time::Instant};
+use std::{
+    collections::HashMap,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    time::Instant,
+};
 
 use bytes::Bytes;
 use dashmap::{mapref::entry::Entry as DashMapEntry, DashMap};
@@ -327,18 +334,22 @@ impl CrdtNamespace {
 pub struct StreamNamespace {
     prefix: String,
     routing: StreamRouting,
-    #[expect(dead_code)] // Used for backpressure enforcement in Step 2
     max_buffer_bytes: usize,
     /// Ephemeral send buffer, drained every gossip round.
     buffer: Arc<DashMap<String, Bytes>>,
+    /// Current total bytes in the broadcast buffer.
+    buffer_bytes: Arc<AtomicUsize>,
     /// Targeted entries: (target_peer_id, key, value).
     targeted_buffer: Arc<parking_lot::Mutex<Vec<(String, String, Bytes)>>>,
+    /// Current total bytes in the targeted buffer.
+    targeted_buffer_bytes: Arc<AtomicUsize>,
     subscriber_registry: Arc<SubscriberRegistry>,
     drain_registry: Arc<DrainRegistry>,
 }
 
 impl StreamNamespace {
     /// Publish a value to all connected peers (Broadcast namespaces only).
+    /// If the buffer exceeds `max_buffer_bytes`, the oldest entry is dropped.
     pub fn publish(&self, key: &str, value: Bytes) {
         assert_eq!(
             self.routing,
@@ -351,10 +362,17 @@ impl StreamNamespace {
             "key '{key}' does not match prefix '{}'",
             self.prefix
         );
-        self.buffer.insert(key.to_string(), value);
+        let value_len = value.len();
+        // If this key already exists, subtract the old value's size.
+        if let Some(old) = self.buffer.insert(key.to_string(), value) {
+            self.buffer_bytes.fetch_sub(old.len(), Ordering::Relaxed);
+        }
+        self.buffer_bytes.fetch_add(value_len, Ordering::Relaxed);
+        self.enforce_broadcast_limit();
     }
 
     /// Publish a value to exactly one peer (Targeted namespaces only).
+    /// If the buffer exceeds `max_buffer_bytes`, the oldest entries are dropped.
     pub fn publish_to(&self, peer_id: &str, key: &str, value: Bytes) {
         assert_eq!(
             self.routing,
@@ -367,9 +385,37 @@ impl StreamNamespace {
             "key '{key}' does not match prefix '{}'",
             self.prefix
         );
-        self.targeted_buffer
-            .lock()
-            .push((peer_id.to_string(), key.to_string(), value));
+        let value_len = value.len();
+        let mut buf = self.targeted_buffer.lock();
+        buf.push((peer_id.to_string(), key.to_string(), value));
+        self.targeted_buffer_bytes
+            .fetch_add(value_len, Ordering::Relaxed);
+        // Drop oldest entries while over limit.
+        while self.targeted_buffer_bytes.load(Ordering::Relaxed) > self.max_buffer_bytes
+            && !buf.is_empty()
+        {
+            let (_, _, dropped) = buf.remove(0);
+            self.targeted_buffer_bytes
+                .fetch_sub(dropped.len(), Ordering::Relaxed);
+        }
+    }
+
+    /// Drop oldest broadcast buffer entries until within `max_buffer_bytes`.
+    fn enforce_broadcast_limit(&self) {
+        while self.buffer_bytes.load(Ordering::Relaxed) > self.max_buffer_bytes {
+            // DashMap doesn't have ordered iteration, so pick an arbitrary entry to drop.
+            // This is acceptable — broadcast entries are ephemeral and at-most-once.
+            if let Some(entry) = self.buffer.iter().next() {
+                let key = entry.key().clone();
+                drop(entry);
+                if let Some((_, removed)) = self.buffer.remove(&key) {
+                    self.buffer_bytes
+                        .fetch_sub(removed.len(), Ordering::Relaxed);
+                }
+            } else {
+                break;
+            }
+        }
     }
 
     /// Subscribe to messages for keys matching a sub-prefix within this namespace.
@@ -510,7 +556,9 @@ impl MeshKV {
             routing: config.routing,
             max_buffer_bytes: config.max_buffer_bytes,
             buffer: Arc::new(DashMap::new()),
+            buffer_bytes: Arc::new(AtomicUsize::new(0)),
             targeted_buffer: Arc::new(parking_lot::Mutex::new(Vec::new())),
+            targeted_buffer_bytes: Arc::new(AtomicUsize::new(0)),
             subscriber_registry: self.subscriber_registry.clone(),
             drain_registry: self.drain_registry.clone(),
         })

--- a/crates/mesh/src/kv.rs
+++ b/crates/mesh/src/kv.rs
@@ -215,7 +215,6 @@ impl DrainRegistry {
 
     /// Call all registered drains. Returns accumulated entries.
     /// Called exactly once per gossip round.
-    #[expect(dead_code)] // Called by centralized gossip loop in Step 2
     fn drain_all(&self) -> Vec<(String, Vec<u8>)> {
         let mut all_entries = Vec::new();
         for entry in &self.drains {
@@ -480,11 +479,23 @@ impl StreamNamespace {
 /// Generic, application-agnostic mesh transport. Provides explicit namespace
 /// handles for CRDT and stream modes. Application code MUST use namespace
 /// handles, not MeshKV directly.
+/// A batch of entries collected once per gossip round by the central collector.
+pub struct RoundBatch {
+    /// Broadcast stream entries: (key, value). Sent to ALL connected peers.
+    pub broadcast_entries: Vec<(String, Bytes)>,
+    /// Targeted stream entries: (peer_id, key, value). Sent to one specific peer.
+    pub targeted_entries: Vec<(String, String, Bytes)>,
+    /// Entries from registered drain callbacks (e.g., TreeSyncAdapter pending deltas).
+    pub drain_entries: Vec<(String, Vec<u8>)>,
+}
+
 pub struct MeshKV {
     /// CRDT store shared across all CRDT namespaces.
     store: Arc<CrdtOrMap>,
     /// Tracks configured prefixes to enforce fail-closed semantics.
     configured_prefixes: RwLock<HashMap<String, StoreMode>>,
+    /// Stream namespaces, stored for round batch collection.
+    stream_namespaces: RwLock<Vec<Arc<StreamNamespace>>>,
     /// Shared subscriber registry.
     subscriber_registry: Arc<SubscriberRegistry>,
     /// Shared drain registry.
@@ -502,6 +513,7 @@ impl MeshKV {
         Self {
             store: Arc::new(CrdtOrMap::new()),
             configured_prefixes: RwLock::new(HashMap::new()),
+            stream_namespaces: RwLock::new(Vec::new()),
             subscriber_registry: Arc::new(SubscriberRegistry::new()),
             drain_registry: Arc::new(DrainRegistry::new()),
             server_name,
@@ -575,7 +587,7 @@ impl MeshKV {
             );
         }
 
-        Arc::new(StreamNamespace {
+        let ns = Arc::new(StreamNamespace {
             prefix: prefix.to_string(),
             routing: config.routing,
             max_buffer_bytes: config.max_buffer_bytes,
@@ -585,7 +597,9 @@ impl MeshKV {
             targeted_buffer_bytes: Arc::new(AtomicUsize::new(0)),
             subscriber_registry: self.subscriber_registry.clone(),
             drain_registry: self.drain_registry.clone(),
-        })
+        });
+        self.stream_namespaces.write().push(ns.clone());
+        ns
     }
 
     /// Get the server name for this node.
@@ -596,6 +610,29 @@ impl MeshKV {
     /// Get the replica ID for this node.
     pub fn replica_id(&self) -> u64 {
         self.replica_id
+    }
+
+    /// Collect all stream entries for one gossip round. Called exactly once
+    /// per round by the centralized gossip loop. Drains all stream buffers
+    /// and calls all registered drain callbacks.
+    pub fn collect_round_batch(&self) -> RoundBatch {
+        let mut broadcast_entries = Vec::new();
+        let mut targeted_entries = Vec::new();
+
+        // Drain all stream namespace buffers.
+        for ns in self.stream_namespaces.read().iter() {
+            broadcast_entries.extend(ns.drain_broadcast_buffer());
+            targeted_entries.extend(ns.drain_targeted_buffer());
+        }
+
+        // Call registered drain callbacks (e.g., adapter pending deltas).
+        let drain_entries = self.drain_registry.drain_all();
+
+        RoundBatch {
+            broadcast_entries,
+            targeted_entries,
+            drain_entries,
+        }
     }
 
     /// Check if a prefix has been configured.


### PR DESCRIPTION
## Description

### Problem

Stream buffers added in Step 1 needed lifecycle management: targeted buffers had no backpressure, drain registration had a TOCTOU race, and there was no API for the gossip loop to collect all buffered stream entries in one pass. Additionally, the broadcast buffer (DashMap for publish()) had no consumer — td:* uses register_drain, not publish().

### Solution

Wire up targeted stream buffer lifecycle: size tracking, backpressure enforcement, drain methods, and centralized round batch collection. Remove the unused broadcast buffer since broadcast traffic flows through drain callbacks, not publish(). Fix the drain registration race from Step 1 PR review.

## Changes

- **TOCTOU fix**: Replace `contains_key` + `insert` in `DrainRegistry::register` with atomic DashMap `entry` API
- **Targeted backpressure**: Track buffer size via `AtomicUsize`. On `publish_to()`, drop oldest entries (FIFO via `VecDeque`) when over `max_buffer_bytes`
- **Drain methods**: Add `drain_targeted_buffer()` to `StreamNamespace` for gossip loop consumption
- **Round batch collection**: Add `RoundBatch` struct and `MeshKV::collect_round_batch()` — single entry point the gossip loop calls once per round to collect targeted entries + drain callback entries
- **Remove unused broadcast buffer**: `publish()`, `enforce_broadcast_limit()`, `drain_broadcast_buffer()`, and the DashMap broadcast buffer had no consumer. Broadcast traffic (td:*) flows through `register_drain` callbacks, not `publish()`
- **Review fixes**: Doc comment separation, `fetch_sub` instead of `store(0)` in drain, entry API for atomic byte accounting, early-return guard, redundant inner Arcs removed, Debug derive on RoundBatch

## Test Plan

34 tests total (4 new, 3 broadcast tests removed):
- Targeted backpressure drops oldest (FIFO order preserved)
- Targeted buffer drain and reset
- Round batch collection from targeted namespaces
- Round batch includes drain callback entries
- Duplicate drain registration panics

```
cargo test -p smg-mesh kv::tests    # 34 tests
```

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added round-level batch collection API and explicit draining for targeted stream buffers.

* **Improvements**
  * Per-stream FIFO targeted buffering with atomic byte accounting and configurable limits; oldest entries are evicted when full.
  * Duplicate drain registration still triggers a panic to prevent double-registration.

* **Tests**
  * Added unit tests for buffer backpressure/eviction, targeted draining, batch collection, and duplicate registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->