### PR TITLE
fix(mcp): centralize non-stream internal privacy filtering

### DIFF
--- a/crates/mcp/src/core/session.rs
+++ b/crates/mcp/src/core/session.rs
@@ -459,7 +459,14 @@ impl<'a> McpToolSession<'a> {
             }
         }
 
-        output.extend(existing);
+        // Apply the same visibility policy to existing items (e.g. FunctionToolCall
+        // for executed MCP tools emitted by build_tool_response in the mixed
+        // function+MCP early-exit path).
+        for item in existing {
+            if self.is_client_visible_output_item(&item, user_function_names) {
+                output.push(item);
+            }
+        }
     }
 
     fn is_client_visible_output_item(

--- a/crates/mcp/src/core/session.rs
+++ b/crates/mcp/src/core/session.rs
@@ -80,6 +80,8 @@ pub struct McpToolSession<'a> {
     exposed_name_by_qualified: HashMap<QualifiedToolName, String>,
     /// Internal server keys for this request snapshot.
     internal_server_keys: HashSet<String>,
+    /// Builtin-routed server keys for this request snapshot.
+    builtin_server_keys: HashSet<String>,
 }
 
 impl<'a> McpToolSession<'a> {
@@ -138,6 +140,16 @@ impl<'a> McpToolSession<'a> {
                 }
             })
             .collect();
+        let builtin_server_keys: HashSet<String> = mcp_servers
+            .iter()
+            .filter_map(|binding| {
+                if configured_builtin_servers.contains(&binding.server_key) {
+                    Some(binding.server_key.clone())
+                } else {
+                    None
+                }
+            })
+            .collect();
         // Filter out servers configured with builtin_type from the visible list.
         let visible_mcp_servers: Vec<McpServerBinding> = mcp_servers
             .iter()
@@ -154,6 +166,7 @@ impl<'a> McpToolSession<'a> {
             exposed_name_map,
             exposed_name_by_qualified,
             internal_server_keys,
+            builtin_server_keys,
         }
     }
 
@@ -282,26 +295,11 @@ impl<'a> McpToolSession<'a> {
     /// Use this helper in redaction paths so internal filtering behavior stays
     /// consistent across response assembly code paths.
     pub fn is_internal_non_builtin_server_label(&self, server_label: &str) -> bool {
-        if !self.is_internal_server_label(server_label) {
-            return false;
-        }
-
-        let mut has_exposed_binding_for_label = false;
-        for binding in self.exposed_name_map.values() {
-            if binding.server_label != server_label {
-                continue;
-            }
-
-            has_exposed_binding_for_label = true;
-            if self.is_internal_server_key(&binding.associated_server_key)
-                && !binding.is_builtin_routed
-            {
-                return true;
-            }
-        }
-
-        // If no tools are exposed under this label, treat internal labels as non-builtin.
-        !has_exposed_binding_for_label
+        self.all_mcp_servers.iter().any(|binding| {
+            binding.label == server_label
+                && self.is_internal_server_key(&binding.server_key)
+                && !self.builtin_server_keys.contains(&binding.server_key)
+        })
     }
 
     /// Returns true if the given tool resolves to an internal server.
@@ -313,9 +311,9 @@ impl<'a> McpToolSession<'a> {
 
     /// Returns true if the bound server label belongs to a builtin-routed server.
     pub fn is_builtin_server_label(&self, server_label: &str) -> bool {
-        self.exposed_name_map
-            .values()
-            .any(|binding| binding.server_label == server_label && binding.is_builtin_routed)
+        self.all_mcp_servers.iter().any(|binding| {
+            binding.label == server_label && self.builtin_server_keys.contains(&binding.server_key)
+        })
     }
 
     /// Returns true if the given tool resolves to a builtin-routed server.
@@ -397,7 +395,11 @@ impl<'a> McpToolSession<'a> {
     /// 1. `mcp_list_tools` items (one per server) — prepended
     /// 2. `tool_call_items` (mcp_call / web_search_call / etc.) — after list_tools
     /// 3. Existing items (messages, etc.) — remain at end
-    pub fn inject_mcp_output_items(
+    ///
+    /// Test-only helper for legacy ordering assertions.
+    /// Production code should use `inject_client_visible_mcp_output_items`.
+    #[cfg(test)]
+    fn inject_mcp_output_items(
         &self,
         output: &mut Vec<openai_protocol::responses::ResponseOutputItem>,
         tool_call_items: Vec<openai_protocol::responses::ResponseOutputItem>,
@@ -417,6 +419,171 @@ impl<'a> McpToolSession<'a> {
 
         // 3. Existing items (messages, etc.)
         output.extend(existing);
+    }
+
+    /// Inject only client-visible MCP metadata and call items into response output.
+    ///
+    /// Visibility policy:
+    /// - Hide internal non-builtin `mcp_list_tools`
+    /// - Hide internal non-builtin passthrough `mcp_call`/`mcp_approval_request`
+    /// - Keep builtin-routed call items visible
+    /// - Keep user-defined function calls visible even on name collisions
+    pub fn inject_client_visible_mcp_output_items(
+        &self,
+        output: &mut Vec<openai_protocol::responses::ResponseOutputItem>,
+        tool_call_items: Vec<openai_protocol::responses::ResponseOutputItem>,
+        user_function_names: &HashSet<String>,
+    ) {
+        let existing = std::mem::take(output);
+        output.reserve(self.mcp_servers.len() + tool_call_items.len() + existing.len());
+
+        for binding in &self.mcp_servers {
+            if !self.is_internal_non_builtin_server_label(&binding.label) {
+                output.push(self.build_mcp_list_tools_item(&binding.label, &binding.server_key));
+            }
+        }
+
+        for item in tool_call_items {
+            if self.is_client_visible_output_item(&item, user_function_names) {
+                output.push(item);
+            }
+        }
+
+        output.extend(existing);
+    }
+
+    fn is_client_visible_output_item(
+        &self,
+        item: &openai_protocol::responses::ResponseOutputItem,
+        user_function_names: &HashSet<String>,
+    ) -> bool {
+        use openai_protocol::responses::ResponseOutputItem;
+
+        match item {
+            ResponseOutputItem::McpListTools { server_label, .. } => {
+                !self.is_internal_non_builtin_server_label(server_label)
+            }
+            ResponseOutputItem::McpCall {
+                server_label, name, ..
+            }
+            | ResponseOutputItem::McpApprovalRequest {
+                server_label, name, ..
+            } => !self.should_hide_mcp_call_like_by_label(name, server_label),
+            ResponseOutputItem::FunctionToolCall { name, .. } => {
+                !self.should_hide_function_call_like(name, user_function_names)
+            }
+            ResponseOutputItem::WebSearchCall { .. }
+            | ResponseOutputItem::CodeInterpreterCall { .. }
+            | ResponseOutputItem::FileSearchCall { .. }
+            | ResponseOutputItem::Message { .. }
+            | ResponseOutputItem::Reasoning { .. } => true,
+        }
+    }
+
+    /// Returns true when a JSON tool entry should be hidden from client-facing responses.
+    ///
+    /// This is used by OpenAI non-streaming response normalization, where tools are handled
+    /// as `serde_json::Value` payloads instead of typed `ResponseOutputItem`s.
+    pub fn should_hide_tool_json(
+        &self,
+        tool: &serde_json::Value,
+        user_function_names: &HashSet<String>,
+    ) -> bool {
+        match tool.get("type").and_then(|value| value.as_str()) {
+            Some("function") => Self::function_tool_name_json(tool).is_some_and(|name| {
+                self.is_internal_tool(name) && !user_function_names.contains(name)
+            }),
+            // MCP tool entries are keyed by server metadata, so function-name collision
+            // handling does not apply to this arm.
+            Some("mcp") => tool
+                .get("server_label")
+                .and_then(|value| value.as_str())
+                .is_some_and(|server_label| {
+                    self.is_internal_non_builtin_server_label(server_label)
+                }),
+            _ => false,
+        }
+    }
+
+    /// Returns true when a JSON output item should be hidden from client-facing responses.
+    ///
+    /// This keeps OpenAI non-streaming redaction aligned with session-level policy.
+    pub fn should_hide_output_item_json(
+        &self,
+        item: &serde_json::Value,
+        user_function_names: &HashSet<String>,
+    ) -> bool {
+        match item.get("type").and_then(|value| value.as_str()) {
+            // mcp_list_tools is gateway-synthesized metadata and should always be hidden
+            // for internal non-builtin servers, while builtin call outputs remain visible.
+            Some("mcp_list_tools") => item
+                .get("server_label")
+                .and_then(|value| value.as_str())
+                .is_some_and(|server_label| {
+                    self.is_internal_non_builtin_server_label(server_label)
+                }),
+            Some("mcp_call") | Some("mcp_approval_request") => {
+                let matches_internal_server = item
+                    .get("server_label")
+                    .and_then(|value| value.as_str())
+                    .is_some_and(|server_label| {
+                        self.is_internal_non_builtin_server_label(server_label)
+                    });
+
+                match item.get("name").and_then(|value| value.as_str()) {
+                    Some(name) => {
+                        self.should_hide_mcp_call_like_by_server_flag(name, matches_internal_server)
+                    }
+                    _ => matches_internal_server,
+                }
+            }
+            Some("function_call") | Some("function_tool_call") => item
+                .get("name")
+                .and_then(|value| value.as_str())
+                .is_some_and(|name| self.should_hide_function_call_like(name, user_function_names)),
+            _ => false,
+        }
+    }
+
+    fn should_hide_mcp_call_like_by_label(&self, name: &str, server_label: &str) -> bool {
+        self.should_hide_mcp_call_like_by_server_flag(
+            name,
+            self.is_internal_non_builtin_server_label(server_label),
+        )
+    }
+
+    fn should_hide_mcp_call_like_by_server_flag(
+        &self,
+        name: &str,
+        matches_internal_server: bool,
+    ) -> bool {
+        if self.has_exposed_tool(name) {
+            self.is_internal_non_builtin_tool(name)
+        } else {
+            matches_internal_server
+        }
+    }
+
+    fn should_hide_function_call_like(
+        &self,
+        name: &str,
+        user_function_names: &HashSet<String>,
+    ) -> bool {
+        self.is_internal_tool(name) && !user_function_names.contains(name)
+    }
+
+    fn function_tool_name_json(tool: &serde_json::Value) -> Option<&str> {
+        let tool_type = tool.get("type").and_then(|value| value.as_str());
+        if tool_type != Some("function") {
+            return None;
+        }
+        tool.get("name")
+            .and_then(|value| value.as_str())
+            .or_else(|| {
+                tool.get("function")
+                    .and_then(|function| function.get("name"))
+                    .and_then(|value| value.as_str())
+            })
     }
 
     fn build_exposed_function_tools(

--- a/crates/mcp/src/core/session.rs
+++ b/crates/mcp/src/core/session.rs
@@ -432,6 +432,7 @@ impl<'a> McpToolSession<'a> {
     /// Inject only client-visible MCP metadata and call items into response output.
     ///
     /// Visibility policy:
+    /// - Hide builtin `mcp_list_tools` (builtin tools surface under their own type)
     /// - Hide internal non-builtin `mcp_list_tools`
     /// - Hide internal non-builtin passthrough `mcp_call`/`mcp_approval_request`
     /// - Keep builtin-routed call items visible
@@ -443,9 +444,10 @@ impl<'a> McpToolSession<'a> {
         user_function_names: &HashSet<String>,
     ) {
         let existing = std::mem::take(output);
-        output.reserve(self.all_mcp_servers.len() + tool_call_items.len() + existing.len());
+        output.reserve(self.mcp_servers.len() + tool_call_items.len() + existing.len());
 
-        for binding in &self.all_mcp_servers {
+        // Use mcp_servers (excludes builtin) to match streaming path behavior.
+        for binding in &self.mcp_servers {
             if !self.is_internal_non_builtin_server_label(&binding.label) {
                 output.push(self.build_mcp_list_tools_item(&binding.label, &binding.server_key));
             }
@@ -469,7 +471,8 @@ impl<'a> McpToolSession<'a> {
 
         match item {
             ResponseOutputItem::McpListTools { server_label, .. } => {
-                !self.is_internal_non_builtin_server_label(server_label)
+                !self.is_builtin_server_label(server_label)
+                    && !self.is_internal_non_builtin_server_label(server_label)
             }
             ResponseOutputItem::McpCall {
                 server_label, name, ..
@@ -521,13 +524,14 @@ impl<'a> McpToolSession<'a> {
         user_function_names: &HashSet<String>,
     ) -> bool {
         match item.get("type").and_then(|value| value.as_str()) {
-            // mcp_list_tools is gateway-synthesized metadata and should always be hidden
-            // for internal non-builtin servers, while builtin call outputs remain visible.
+            // mcp_list_tools is gateway-synthesized metadata. Hide for builtin servers
+            // (implementation detail) and internal non-builtin servers (privacy).
             Some("mcp_list_tools") => item
                 .get("server_label")
                 .and_then(|value| value.as_str())
                 .is_some_and(|server_label| {
-                    self.is_internal_non_builtin_server_label(server_label)
+                    self.is_builtin_server_label(server_label)
+                        || self.is_internal_non_builtin_server_label(server_label)
                 }),
             Some("mcp_call") | Some("mcp_approval_request") => {
                 let matches_internal_server = item

--- a/crates/mcp/src/core/session.rs
+++ b/crates/mcp/src/core/session.rs
@@ -82,6 +82,8 @@ pub struct McpToolSession<'a> {
     internal_server_keys: HashSet<String>,
     /// Builtin-routed server keys for this request snapshot.
     builtin_server_keys: HashSet<String>,
+    /// Internal, non-builtin server labels for this request snapshot.
+    internal_non_builtin_server_labels: HashSet<String>,
 }
 
 impl<'a> McpToolSession<'a> {
@@ -150,6 +152,14 @@ impl<'a> McpToolSession<'a> {
                 }
             })
             .collect();
+        let internal_non_builtin_server_labels: HashSet<String> = mcp_servers
+            .iter()
+            .filter(|binding| {
+                internal_server_keys.contains(&binding.server_key)
+                    && !builtin_server_keys.contains(&binding.server_key)
+            })
+            .map(|binding| binding.label.clone())
+            .collect();
         // Filter out servers configured with builtin_type from the visible list.
         let visible_mcp_servers: Vec<McpServerBinding> = mcp_servers
             .iter()
@@ -167,6 +177,7 @@ impl<'a> McpToolSession<'a> {
             exposed_name_by_qualified,
             internal_server_keys,
             builtin_server_keys,
+            internal_non_builtin_server_labels,
         }
     }
 
@@ -295,11 +306,8 @@ impl<'a> McpToolSession<'a> {
     /// Use this helper in redaction paths so internal filtering behavior stays
     /// consistent across response assembly code paths.
     pub fn is_internal_non_builtin_server_label(&self, server_label: &str) -> bool {
-        self.all_mcp_servers.iter().any(|binding| {
-            binding.label == server_label
-                && self.is_internal_server_key(&binding.server_key)
-                && !self.builtin_server_keys.contains(&binding.server_key)
-        })
+        self.internal_non_builtin_server_labels
+            .contains(server_label)
     }
 
     /// Returns true if the given tool resolves to an internal server.
@@ -435,9 +443,9 @@ impl<'a> McpToolSession<'a> {
         user_function_names: &HashSet<String>,
     ) {
         let existing = std::mem::take(output);
-        output.reserve(self.mcp_servers.len() + tool_call_items.len() + existing.len());
+        output.reserve(self.all_mcp_servers.len() + tool_call_items.len() + existing.len());
 
-        for binding in &self.mcp_servers {
+        for binding in &self.all_mcp_servers {
             if !self.is_internal_non_builtin_server_label(&binding.label) {
                 output.push(self.build_mcp_list_tools_item(&binding.label, &binding.server_key));
             }
@@ -490,9 +498,8 @@ impl<'a> McpToolSession<'a> {
         user_function_names: &HashSet<String>,
     ) -> bool {
         match tool.get("type").and_then(|value| value.as_str()) {
-            Some("function") => Self::function_tool_name_json(tool).is_some_and(|name| {
-                self.is_internal_tool(name) && !user_function_names.contains(name)
-            }),
+            Some("function") => Self::function_tool_name_json(tool)
+                .is_some_and(|name| self.should_hide_function_call_like(name, user_function_names)),
             // MCP tool entries are keyed by server metadata, so function-name collision
             // handling does not apply to this arm.
             Some("mcp") => tool

--- a/model_gateway/src/routers/common/mcp_utils.rs
+++ b/model_gateway/src/routers/common/mcp_utils.rs
@@ -1,8 +1,11 @@
 //! Shared MCP utilities for routers.
 
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
-use openai_protocol::responses::ResponseTool;
+use openai_protocol::responses::{ResponseTool, ResponsesRequest};
 use smg_mcp::{
     BuiltinToolType, McpOrchestrator, McpServerBinding, McpServerConfig, McpTransport,
     ResponseFormat,
@@ -195,6 +198,20 @@ pub fn extract_builtin_types(tools: &[ResponseTool]) -> Vec<BuiltinToolType> {
         .filter_map(|t| match t {
             ResponseTool::WebSearchPreview(_) => Some(BuiltinToolType::WebSearchPreview),
             ResponseTool::CodeInterpreter(_) => Some(BuiltinToolType::CodeInterpreter),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Collect user-declared function tool names from a Responses request.
+pub(crate) fn collect_user_function_names(request: &ResponsesRequest) -> HashSet<String> {
+    request
+        .tools
+        .as_deref()
+        .unwrap_or_default()
+        .iter()
+        .filter_map(|tool| match tool {
+            ResponseTool::Function(function_tool) => Some(function_tool.function.name.clone()),
             _ => None,
         })
         .collect()

--- a/model_gateway/src/routers/grpc/common/responses/mod.rs
+++ b/model_gateway/src/routers/grpc/common/responses/mod.rs
@@ -9,3 +9,5 @@ pub(crate) mod utils;
 pub(crate) use context::ResponsesContext;
 pub(crate) use streaming::build_sse_response;
 pub(crate) use utils::{ensure_mcp_connection, persist_response_if_needed};
+
+pub(crate) use crate::routers::common::mcp_utils::collect_user_function_names;

--- a/model_gateway/src/routers/grpc/harmony/responses/common.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/common.rs
@@ -1,5 +1,7 @@
 //! Shared helpers and state tracking for Harmony Responses
 
+use std::collections::HashSet;
+
 use axum::response::Response;
 use openai_protocol::{
     common::{ToolCall, ToolChoice, ToolChoiceValue},
@@ -164,6 +166,7 @@ pub(super) fn inject_mcp_metadata(
     response: &mut ResponsesResponse,
     tracking: &McpCallTracking,
     session: &McpToolSession<'_>,
+    user_function_names: &HashSet<String>,
 ) {
     let tool_output_items: Vec<ResponseOutputItem> = tracking
         .tool_calls
@@ -171,7 +174,11 @@ pub(super) fn inject_mcp_metadata(
         .map(|record| record.output_item.clone())
         .collect();
 
-    session.inject_mcp_output_items(&mut response.output, tool_output_items);
+    session.inject_client_visible_mcp_output_items(
+        &mut response.output,
+        tool_output_items,
+        user_function_names,
+    );
 }
 
 /// Load previous conversation messages from storage

--- a/model_gateway/src/routers/grpc/harmony/responses/non_streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/non_streaming.rs
@@ -31,7 +31,8 @@ use crate::{
         error,
         grpc::{
             common::responses::{
-                ensure_mcp_connection, persist_response_if_needed, ResponsesContext,
+                collect_user_function_names, ensure_mcp_connection, persist_response_if_needed,
+                ResponsesContext,
             },
             harmony::processor::ResponsesIterationResult,
         },
@@ -101,6 +102,7 @@ async fn execute_with_mcp_loop(
     // Preserve original tools for response (before merging MCP tools)
     // The response should show the user's original request tools, not internal MCP tools
     let mut original_tools = current_request.tools.clone();
+    let user_function_names = collect_user_function_names(&current_request);
 
     // Create session once — bundles orchestrator, request_ctx, server_keys, mcp_tools
     let session_request_id = format!("resp_{}", uuid::Uuid::now_v7());
@@ -172,9 +174,11 @@ async fn execute_with_mcp_loop(
                 // Separate MCP and function tool calls based on session exposure.
                 // MCP tools are exposed to the model as function tools, so the only reliable
                 // discriminator is whether the name belongs to the MCP session.
-                let (mcp_tool_calls, function_tool_calls): (Vec<_>, Vec<_>) = tool_calls
-                    .into_iter()
-                    .partition(|tc| session.has_exposed_tool(&tc.function.name));
+                let (mcp_tool_calls, function_tool_calls): (Vec<_>, Vec<_>) =
+                    tool_calls.into_iter().partition(|tc| {
+                        let name = tc.function.name.as_str();
+                        session.has_exposed_tool(name) && !user_function_names.contains(name)
+                    });
 
                 debug!(
                     mcp_calls = mcp_tool_calls.len(),
@@ -227,7 +231,12 @@ async fn execute_with_mcp_loop(
 
                     // Inject MCP metadata if any calls were executed
                     if mcp_tracking.total_calls() > 0 {
-                        inject_mcp_metadata(&mut response, &mcp_tracking, &session);
+                        inject_mcp_metadata(
+                            &mut response,
+                            &mcp_tracking,
+                            &session,
+                            &user_function_names,
+                        );
                     }
 
                     return Ok(response);
@@ -272,7 +281,12 @@ async fn execute_with_mcp_loop(
 
                     // Inject MCP metadata for all executed calls
                     if mcp_tracking.total_calls() > 0 {
-                        inject_mcp_metadata(&mut response, &mcp_tracking, &session);
+                        inject_mcp_metadata(
+                            &mut response,
+                            &mcp_tracking,
+                            &session,
+                            &user_function_names,
+                        );
                     }
 
                     return Ok(response);
@@ -304,7 +318,7 @@ async fn execute_with_mcp_loop(
                 );
 
                 // Inject MCP metadata into final response
-                inject_mcp_metadata(&mut response, &mcp_tracking, &session);
+                inject_mcp_metadata(&mut response, &mcp_tracking, &session, &user_function_names);
 
                 // Restore original tools (hide internal MCP tools from response)
                 response.tools = original_tools.take().unwrap_or_default();

--- a/model_gateway/src/routers/grpc/harmony/responses/non_streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/non_streaming.rs
@@ -174,11 +174,9 @@ async fn execute_with_mcp_loop(
                 // Separate MCP and function tool calls based on session exposure.
                 // MCP tools are exposed to the model as function tools, so the only reliable
                 // discriminator is whether the name belongs to the MCP session.
-                let (mcp_tool_calls, function_tool_calls): (Vec<_>, Vec<_>) =
-                    tool_calls.into_iter().partition(|tc| {
-                        let name = tc.function.name.as_str();
-                        session.has_exposed_tool(name) && !user_function_names.contains(name)
-                    });
+                let (mcp_tool_calls, function_tool_calls): (Vec<_>, Vec<_>) = tool_calls
+                    .into_iter()
+                    .partition(|tc| session.has_exposed_tool(tc.function.name.as_str()));
 
                 debug!(
                     mcp_calls = mcp_tool_calls.len(),

--- a/model_gateway/src/routers/grpc/regular/responses/non_streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/non_streaming.rs
@@ -254,10 +254,9 @@ pub(super) async fn execute_tool_loop(
 
             // Separate MCP and function tool calls using session-exposed names.
             let (mcp_tool_calls, function_tool_calls): (Vec<ExtractedToolCall>, Vec<_>) =
-                tool_calls.into_iter().partition(|tc| {
-                    let name = tc.name.as_str();
-                    session.has_exposed_tool(name) && !user_function_names.contains(name)
-                });
+                tool_calls
+                    .into_iter()
+                    .partition(|tc| session.has_exposed_tool(tc.name.as_str()));
 
             trace!(
                 "Separated tool calls: {} MCP, {} function",

--- a/model_gateway/src/routers/grpc/regular/responses/non_streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/non_streaming.rs
@@ -27,7 +27,8 @@ use crate::{
         common::mcp_utils::DEFAULT_MAX_ITERATIONS,
         error,
         grpc::common::responses::{
-            ensure_mcp_connection, persist_response_if_needed, ResponsesContext,
+            collect_user_function_names, ensure_mcp_connection, persist_response_if_needed,
+            ResponsesContext,
         },
     },
 };
@@ -154,6 +155,7 @@ pub(super) async fn execute_tool_loop(
         .unwrap_or_else(|| format!("resp_{}", uuid::Uuid::now_v7()));
 
     let session = McpToolSession::new(&ctx.mcp_orchestrator, mcp_servers, &session_request_id);
+    let user_function_names = collect_user_function_names(original_request);
 
     // Get MCP tools and convert to chat format (do this once before loop)
     let mcp_chat_tools = convert_mcp_tools_to_chat_tools(&session);
@@ -224,8 +226,11 @@ pub(super) async fn execute_tool_loop(
 
             // Inject MCP metadata into output
             if state.total_calls > 0 {
-                session
-                    .inject_mcp_output_items(&mut responses_response.output, state.mcp_call_items);
+                session.inject_client_visible_mcp_output_items(
+                    &mut responses_response.output,
+                    state.mcp_call_items,
+                    &user_function_names,
+                );
 
                 trace!(
                     "Injected MCP metadata: {} mcp_list_tools + {} mcp_call items",
@@ -249,9 +254,10 @@ pub(super) async fn execute_tool_loop(
 
             // Separate MCP and function tool calls using session-exposed names.
             let (mcp_tool_calls, function_tool_calls): (Vec<ExtractedToolCall>, Vec<_>) =
-                tool_calls
-                    .into_iter()
-                    .partition(|tc| session.has_exposed_tool(tc.name.as_str()));
+                tool_calls.into_iter().partition(|tc| {
+                    let name = tc.name.as_str();
+                    session.has_exposed_tool(name) && !user_function_names.contains(name)
+                });
 
             trace!(
                 "Separated tool calls: {} MCP, {} function",

--- a/model_gateway/src/routers/openai/responses/utils.rs
+++ b/model_gateway/src/routers/openai/responses/utils.rs
@@ -1148,7 +1148,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn restore_original_tools_keeps_builtin_list_tools_and_passthrough_call_visible() {
+    async fn restore_original_tools_hides_builtin_list_tools_keeps_passthrough_call() {
         let original_body = ResponsesRequest {
             model: "gpt-5.4".to_string(),
             input: ResponseInput::Text("hello".to_string()),
@@ -1210,14 +1210,12 @@ mod tests {
 
         restore_original_tools(&mut response, &original_body, Some(&session));
 
+        // Builtin mcp_list_tools is hidden — clients don't see the underlying
+        // MCP server for builtin-routed tools like web_search_preview.
+        // Builtin passthrough mcp_call remains visible.
         assert_eq!(
             response["output"],
             serde_json::json!([
-                {
-                    "type": "mcp_list_tools",
-                    "server_label": "internal-label",
-                    "tools": []
-                },
                 {
                     "type": "mcp_call",
                     "name": "brave_web_search",

--- a/model_gateway/src/routers/openai/responses/utils.rs
+++ b/model_gateway/src/routers/openai/responses/utils.rs
@@ -12,6 +12,7 @@ use smg_mcp::McpToolSession;
 use tracing::warn;
 
 use super::common::parse_sse_block;
+use crate::routers::common::mcp_utils::collect_user_function_names;
 
 /// Check if a JSON value is missing, null, or an empty string
 fn is_missing_or_empty(value: Option<&Value>) -> bool {
@@ -237,24 +238,6 @@ pub(super) fn response_tool_to_value(tool: &ResponseTool) -> Option<Value> {
     }
 }
 
-fn collect_user_function_names(original_body: &ResponsesRequest) -> HashSet<&str> {
-    original_body
-        .tools
-        .as_ref()
-        .map(|tools| {
-            tools
-                .iter()
-                .filter_map(|tool| match tool {
-                    ResponseTool::Function(function_tool) => {
-                        Some(function_tool.function.name.as_str())
-                    }
-                    _ => None,
-                })
-                .collect()
-        })
-        .unwrap_or_default()
-}
-
 /// Restore original tools (MCP and builtin) in response for client.
 ///
 /// The model receives function tools, but the response should mirror the original
@@ -275,7 +258,7 @@ fn restore_client_tool_view(
     resp: &mut Value,
     original_body: &ResponsesRequest,
     session: Option<&McpToolSession<'_>>,
-    user_function_names: &HashSet<&str>,
+    user_function_names: &HashSet<String>,
 ) {
     let Some(original_tools) = original_body.tools.as_ref() else {
         return;
@@ -299,7 +282,9 @@ fn restore_client_tool_view(
             }
             _ => {
                 if let Some(value) = response_tool_to_value(original_tool) {
-                    if !is_internal_mcp_tool_value(&value, session, user_function_names) {
+                    let should_hide = session
+                        .is_some_and(|s| s.should_hide_tool_json(&value, user_function_names));
+                    if !should_hide {
                         restored_tools.push(value);
                     }
                 }
@@ -350,7 +335,7 @@ fn restore_client_tool_view(
 fn strip_internal_mcp_tools(
     resp: &mut Value,
     session: Option<&McpToolSession<'_>>,
-    user_function_names: &HashSet<&str>,
+    user_function_names: &HashSet<String>,
 ) {
     let Some(obj) = resp.as_object_mut() else {
         return;
@@ -360,13 +345,15 @@ fn strip_internal_mcp_tools(
         return;
     };
 
-    tools.retain(|tool| !is_internal_mcp_tool_value(tool, session, user_function_names));
+    tools.retain(|tool| {
+        !session.is_some_and(|s| s.should_hide_tool_json(tool, user_function_names))
+    });
 }
 
 fn strip_internal_mcp_output_items(
     resp: &mut Value,
     session: Option<&McpToolSession<'_>>,
-    user_function_names: &HashSet<&str>,
+    user_function_names: &HashSet<String>,
 ) {
     let Some(obj) = resp.as_object_mut() else {
         return;
@@ -376,30 +363,9 @@ fn strip_internal_mcp_output_items(
         return;
     };
 
-    output.retain(|item| !is_internal_mcp_output_item(item, session, user_function_names));
-}
-
-fn is_internal_mcp_tool_value(
-    tool: &Value,
-    session: Option<&McpToolSession<'_>>,
-    user_function_names: &HashSet<&str>,
-) -> bool {
-    let Some(session) = session else {
-        return false;
-    };
-
-    match tool.get("type").and_then(|value| value.as_str()) {
-        Some("function") => function_tool_name(tool).is_some_and(|name| {
-            session.is_internal_tool(name) && !user_function_names.contains(name)
-        }),
-        // MCP tool entries are keyed by server metadata, so function-name collision
-        // handling does not apply to this arm.
-        Some("mcp") => tool
-            .get("server_label")
-            .and_then(|value| value.as_str())
-            .is_some_and(|server_label| session.is_internal_server_label(server_label)),
-        _ => false,
-    }
+    output.retain(|item| {
+        !session.is_some_and(|s| s.should_hide_output_item_json(item, user_function_names))
+    });
 }
 
 fn function_tool_name(tool: &Value) -> Option<&str> {
@@ -414,53 +380,6 @@ fn function_tool_name(tool: &Value) -> Option<&str> {
                 .and_then(|function| function.get("name"))
                 .and_then(|value| value.as_str())
         })
-}
-
-fn is_internal_mcp_output_item(
-    item: &Value,
-    session: Option<&McpToolSession<'_>>,
-    user_function_names: &HashSet<&str>,
-) -> bool {
-    let Some(session) = session else {
-        return false;
-    };
-
-    match item.get("type").and_then(|value| value.as_str()) {
-        // mcp_list_tools is gateway-synthesized metadata and should always be hidden
-        // for internal servers, even when builtin call outputs remain visible.
-        Some("mcp_list_tools") => item
-            .get("server_label")
-            .and_then(|value| value.as_str())
-            .is_some_and(|server_label| session.is_internal_server_label(server_label)),
-        Some("mcp_call") | Some("mcp_approval_request") => {
-            let matches_internal_server = item
-                .get("server_label")
-                .and_then(|value| value.as_str())
-                .is_some_and(|server_label| {
-                    session.is_internal_non_builtin_server_label(server_label)
-                });
-
-            match item.get("name").and_then(|value| value.as_str()) {
-                Some(name) if session.has_exposed_tool(name) => {
-                    session.is_internal_non_builtin_tool(name)
-                }
-                _ => matches_internal_server,
-            }
-        }
-        Some("function_call") => item
-            .get("name")
-            .and_then(|value| value.as_str())
-            .is_some_and(|name| {
-                session.is_internal_tool(name) && !user_function_names.contains(name)
-            }),
-        Some("function_tool_call") => item
-            .get("name")
-            .and_then(|value| value.as_str())
-            .is_some_and(|name| {
-                session.is_internal_tool(name) && !user_function_names.contains(name)
-            }),
-        _ => false,
-    }
 }
 
 #[cfg(test)]
@@ -1229,7 +1148,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn restore_original_tools_hides_internal_list_tools_but_keeps_builtin_passthrough_call() {
+    async fn restore_original_tools_keeps_builtin_list_tools_and_passthrough_call_visible() {
         let original_body = ResponsesRequest {
             model: "gpt-5.4".to_string(),
             input: ResponseInput::Text("hello".to_string()),
@@ -1294,6 +1213,11 @@ mod tests {
         assert_eq!(
             response["output"],
             serde_json::json!([
+                {
+                    "type": "mcp_list_tools",
+                    "server_label": "internal-label",
+                    "tools": []
+                },
                 {
                     "type": "mcp_call",
                     "name": "brave_web_search",


### PR DESCRIPTION
## Description

### Problem

Non-streaming Responses paths had privacy-policy drift for internal MCP details:

- Different hide behavior between typed gRPC output injection and OpenAI JSON restore filtering.
- `mcp_list_tools` handling was inconsistent for internal builtin vs internal non-builtin.
- Similar privacy logic lived in multiple places, making future drift likely.

### Solution

Centralized non-stream internal privacy filtering in `McpToolSession` and routed both typed and JSON response shaping through shared session policy methods.

This keeps agent-loop execution behavior unchanged while ensuring customer-facing non-stream responses consistently hide only internal non-builtin details.

## Changes

- Added centralized non-stream visibility/filtering methods to `McpToolSession`:
  - `inject_client_visible_mcp_output_items`
  - `should_hide_tool_json`
  - `should_hide_output_item_json`
  - shared helper methods for MCP/function call hide decisions
- Updated gRPC non-stream regular/harmony routers to:
  - use `collect_user_function_names`
  - avoid treating user function-name collisions as MCP tool calls
  - use `inject_client_visible_mcp_output_items` for final output injection
- Updated OpenAI non-stream restore path to use session-level JSON hide policy methods instead of duplicated local wrappers.
- Centralized `collect_user_function_names` in shared router MCP utils.
- Hardened internal builtin/non-builtin server-label classification using session server-key snapshots (`builtin_server_keys`) to avoid inventory-dependent misclassification.

## Test Plan

1. Run targeted MCP session tests (most of the UT local and not include in the PR currently to make human-reviewer life easier):
- `cargo test -p smg-mcp test_inject_client_visible_mcp_output_items_hides_internal_non_builtin_details -- --nocapture`
- `cargo test -p smg-mcp test_should_hide_output_item_json_keeps_internal_builtin_mcp_list_tools_visible -- --nocapture`
- `cargo test -p smg-mcp test_should_hide_tool_json_keeps_internal_builtin_mcp_tool_visible -- --nocapture`
- `cargo test -p smg-mcp test_internal_builtin_server_label_not_classified_as_non_builtin_without_inventory -- --nocapture`

2. Run targeted restore regression test:
- `cargo test -p smg restore_original_tools_keeps_builtin_list_tools_and_passthrough_call_visible -- --nocapture`

3. Run hooks/checks used in this branch:
- `pre-commit run`

4. Behavior verification:
- Internal non-builtin MCP details are hidden in final non-stream customer response.
- Internal builtin outputs remain visible as intended.
- Agent loop/tool execution semantics remain unchanged.

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved client-visible filtering to properly hide internal MCP tools while displaying user-defined functions.
  * Enhanced separation of built-in system tools from user-defined tools in client responses.
  * Refined visibility controls for server outputs, function calls, and approval requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->