### PR TITLE
feat(mesh): centralized gossip loop (v2 Step 2b)

### DIFF
--- a/crates/mesh/src/controller.rs
+++ b/crates/mesh/src/controller.rs
@@ -44,9 +44,11 @@ pub struct MeshController {
     mtls_manager: Option<Arc<MTLSManager>>,
     // Track active sync_stream connections
     sync_connections: Arc<Mutex<HashMap<String, tokio::task::JoinHandle<()>>>>,
-    /// Shared central deltas reference. The event loop writes drained tenant
-    /// deltas here once per round; all per-peer collectors read from it.
-    central_deltas: Arc<parking_lot::RwLock<Option<super::incremental::DrainedTenantDeltas>>>,
+    /// Central collector that runs once per gossip round.
+    central_collector: Arc<super::incremental::CentralCollector>,
+    /// Current round batch, updated once per round by the central collector.
+    /// Per-peer senders read and apply their own watermark filtering.
+    current_batch: Arc<parking_lot::RwLock<Arc<super::incremental::RoundBatch>>>,
 }
 
 impl MeshController {
@@ -60,6 +62,10 @@ impl MeshController {
         sync_manager: Arc<MeshSyncManager>,
         mtls_manager: Option<Arc<MTLSManager>>,
     ) -> Self {
+        let central_collector = Arc::new(super::incremental::CentralCollector::new(
+            stores.clone(),
+            self_name.to_string(),
+        ));
         Self {
             state,
             self_name: self_name.to_string(),
@@ -69,7 +75,10 @@ impl MeshController {
             sync_manager,
             mtls_manager,
             sync_connections: Arc::new(Mutex::new(HashMap::new())),
-            central_deltas: Arc::new(parking_lot::RwLock::new(None)),
+            central_collector,
+            current_batch: Arc::new(parking_lot::RwLock::new(Arc::new(
+                super::incremental::RoundBatch::default(),
+            ))),
         }
     }
 
@@ -201,13 +210,13 @@ impl MeshController {
                 retry_managers.retain(|peer_name, _| map.contains_key(peer_name));
             }
 
-            // Central tenant delta drain: run once per round, before per-peer
-            // senders collect. All per-peer collectors read from the shared
-            // central_deltas instead of destructively draining the DashMap.
+            // Central collection: run once per round. Drains tenant deltas
+            // (destructive) and collects all store changes into one batch.
+            // Per-peer senders read this batch and filter by their watermarks.
             {
-                let drained =
-                    super::incremental::drain_tenant_deltas_central(&self.stores, &self.self_name);
-                *self.central_deltas.write() = Some(drained);
+                let batch = self.central_collector.collect();
+                *self.current_batch.write() = Arc::new(batch);
+                self.central_collector.advance_generations();
             }
 
             tokio::select! {
@@ -427,7 +436,7 @@ impl MeshController {
         let stores = self.stores.clone();
         let sync_manager = self.sync_manager.clone();
         let sync_connections = self.sync_connections.clone();
-        let central_deltas = self.central_deltas.clone();
+        let current_batch = self.current_batch.clone();
 
         // Log connection lifecycle: spawn
         log::debug!(
@@ -468,26 +477,24 @@ impl MeshController {
                     return;
                 }
 
-                // Spawn a task to periodically send incremental updates (client-side sender)
+                // Spawn a task to periodically send incremental updates (client-side sender).
+                // Uses PeerWatermark to filter the centrally collected batch.
                 let incremental_sender_handle = {
                     use super::{
-                        incremental::IncrementalUpdateCollector, service::gossip::IncrementalUpdate,
+                        incremental::PeerWatermark, service::gossip::IncrementalUpdate,
                     };
 
-                    let collector = Arc::new(IncrementalUpdateCollector::with_shared_central_deltas(
-                        stores.clone(),
-                        self_name.clone(),
-                        central_deltas.clone(),
-                    ));
+                    let mut watermark = PeerWatermark::new(peer_name.clone());
                     log::debug!(
                         peer = %peer_name,
-                        "IncrementalUpdateCollector created"
+                        "PeerWatermark created for centralized gossip"
                     );
                     let tx_incremental = tx.clone();
                     let self_name_incremental = self_name.clone();
                     let peer_name_incremental = peer_name.clone();
                     let shared_sequence = sequence.clone();
                     let size_validator = MessageSizeValidator::default();
+                    let batch_handle = current_batch.clone();
 
                     #[expect(clippy::disallowed_methods, reason = "incremental sender handle is stored and aborted when the parent sync_stream handler exits")]
                     tokio::spawn(async move {
@@ -498,8 +505,10 @@ impl MeshController {
 
                             let round_start = std::time::Instant::now();
 
-                            // Collect all incremental updates
-                            let all_updates = collector.collect_all_updates();
+                            // Read the centrally collected batch and filter by
+                            // this peer's watermark. No collection happens here.
+                            let batch = batch_handle.read().clone();
+                            let all_updates = watermark.filter(&batch);
 
                             let collect_elapsed = round_start.elapsed();
 
@@ -531,13 +540,11 @@ impl MeshController {
                                             size_validator.max_size()
                                         );
                                         // Mark non-tree stores as sent to prevent infinite
-                                        // retry loops (PR #808). Tree updates (tenant deltas,
-                                        // structure snapshots) are retried next round with
-                                        // updated data from the live tree.
+                                        // retry loops. Tree updates are retried next round.
                                         let is_tree_update =
                                             updates.iter().any(|u| u.key.starts_with("tree:"));
                                         if !is_tree_update {
-                                            collector.mark_sent(*store_type, updates);
+                                            watermark.mark_sent(*store_type, updates);
                                         }
                                         continue;
                                     }
@@ -567,7 +574,7 @@ impl MeshController {
                                     match tx_incremental.try_send(incremental_update) {
                                         Ok(()) => {
                                             // Mark as sent after successful transmission
-                                            collector.mark_sent(*store_type, updates);
+                                            watermark.mark_sent(*store_type, updates);
                                         }
                                         Err(mpsc::error::TrySendError::Full(_)) => {
                                             log::debug!(

--- a/crates/mesh/src/controller.rs
+++ b/crates/mesh/src/controller.rs
@@ -31,7 +31,9 @@ use super::{
 };
 use crate::{
     flow_control::{MessageSizeValidator, MAX_MESSAGE_SIZE},
+    incremental::{CentralCollector, PeerWatermark, RoundBatch},
     metrics,
+    service::gossip::IncrementalUpdate,
 };
 
 pub struct MeshController {
@@ -45,10 +47,10 @@ pub struct MeshController {
     // Track active sync_stream connections
     sync_connections: Arc<Mutex<HashMap<String, tokio::task::JoinHandle<()>>>>,
     /// Central collector that runs once per gossip round.
-    central_collector: Arc<super::incremental::CentralCollector>,
+    central_collector: Arc<CentralCollector>,
     /// Current round batch, updated once per round by the central collector.
     /// Per-peer senders read and apply their own watermark filtering.
-    current_batch: Arc<parking_lot::RwLock<Arc<super::incremental::RoundBatch>>>,
+    current_batch: Arc<parking_lot::RwLock<Arc<RoundBatch>>>,
 }
 
 impl MeshController {
@@ -62,10 +64,8 @@ impl MeshController {
         sync_manager: Arc<MeshSyncManager>,
         mtls_manager: Option<Arc<MTLSManager>>,
     ) -> Self {
-        let central_collector = Arc::new(super::incremental::CentralCollector::new(
-            stores.clone(),
-            self_name.to_string(),
-        ));
+        let central_collector =
+            Arc::new(CentralCollector::new(stores.clone(), self_name.to_string()));
         Self {
             state,
             self_name: self_name.to_string(),
@@ -76,15 +76,13 @@ impl MeshController {
             mtls_manager,
             sync_connections: Arc::new(Mutex::new(HashMap::new())),
             central_collector,
-            current_batch: Arc::new(parking_lot::RwLock::new(Arc::new(
-                super::incremental::RoundBatch::default(),
-            ))),
+            current_batch: Arc::new(parking_lot::RwLock::new(Arc::new(RoundBatch::default()))),
         }
     }
 
     /// Get a handle to the shared RoundBatch. Used by GossipService to
     /// share the centrally collected batch with server-side sync_stream handlers.
-    pub fn current_batch(&self) -> Arc<parking_lot::RwLock<Arc<super::incremental::RoundBatch>>> {
+    pub fn current_batch(&self) -> Arc<parking_lot::RwLock<Arc<RoundBatch>>> {
         self.current_batch.clone()
     }
 
@@ -486,10 +484,6 @@ impl MeshController {
                 // Spawn a task to periodically send incremental updates (client-side sender).
                 // Uses PeerWatermark to filter the centrally collected batch.
                 let incremental_sender_handle = {
-                    use super::{
-                        incremental::PeerWatermark, service::gossip::IncrementalUpdate,
-                    };
-
                     let mut watermark = PeerWatermark::new(peer_name.clone());
                     log::debug!(
                         peer = %peer_name,

--- a/crates/mesh/src/controller.rs
+++ b/crates/mesh/src/controller.rs
@@ -82,6 +82,12 @@ impl MeshController {
         }
     }
 
+    /// Get a handle to the shared RoundBatch. Used by GossipService to
+    /// share the centrally collected batch with server-side sync_stream handlers.
+    pub fn current_batch(&self) -> Arc<parking_lot::RwLock<Arc<super::incremental::RoundBatch>>> {
+        self.current_batch.clone()
+    }
+
     #[instrument(fields(name = %self.self_name), skip(self, signal))]
     pub async fn event_loop(self, mut signal: watch::Receiver<bool>) -> Result<()> {
         let init_state = self.state.clone();

--- a/crates/mesh/src/controller.rs
+++ b/crates/mesh/src/controller.rs
@@ -44,6 +44,9 @@ pub struct MeshController {
     mtls_manager: Option<Arc<MTLSManager>>,
     // Track active sync_stream connections
     sync_connections: Arc<Mutex<HashMap<String, tokio::task::JoinHandle<()>>>>,
+    /// Shared central deltas reference. The event loop writes drained tenant
+    /// deltas here once per round; all per-peer collectors read from it.
+    central_deltas: Arc<parking_lot::RwLock<Option<super::incremental::DrainedTenantDeltas>>>,
 }
 
 impl MeshController {
@@ -66,6 +69,7 @@ impl MeshController {
             sync_manager,
             mtls_manager,
             sync_connections: Arc::new(Mutex::new(HashMap::new())),
+            central_deltas: Arc::new(parking_lot::RwLock::new(None)),
         }
     }
 
@@ -195,6 +199,15 @@ impl MeshController {
 
                 // Clean up retry managers for peers no longer in cluster state
                 retry_managers.retain(|peer_name, _| map.contains_key(peer_name));
+            }
+
+            // Central tenant delta drain: run once per round, before per-peer
+            // senders collect. All per-peer collectors read from the shared
+            // central_deltas instead of destructively draining the DashMap.
+            {
+                let drained =
+                    super::incremental::drain_tenant_deltas_central(&self.stores, &self.self_name);
+                *self.central_deltas.write() = Some(drained);
             }
 
             tokio::select! {
@@ -414,6 +427,7 @@ impl MeshController {
         let stores = self.stores.clone();
         let sync_manager = self.sync_manager.clone();
         let sync_connections = self.sync_connections.clone();
+        let central_deltas = self.central_deltas.clone();
 
         // Log connection lifecycle: spawn
         log::debug!(
@@ -460,9 +474,10 @@ impl MeshController {
                         incremental::IncrementalUpdateCollector, service::gossip::IncrementalUpdate,
                     };
 
-                    let collector = Arc::new(IncrementalUpdateCollector::new(
+                    let collector = Arc::new(IncrementalUpdateCollector::with_shared_central_deltas(
                         stores.clone(),
                         self_name.clone(),
+                        central_deltas.clone(),
                     ));
                     log::debug!(
                         peer = %peer_name,

--- a/crates/mesh/src/incremental.rs
+++ b/crates/mesh/src/incremental.rs
@@ -64,7 +64,7 @@ struct LastSentVersions {
 }
 
 /// Tracks store generation to skip unchanged stores
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Copy, Default)]
 struct LastScannedGenerations {
     worker: u64,
     policy: u64,
@@ -715,8 +715,11 @@ pub struct CentralCollector {
     self_name: String,
     /// Generation tracking to skip unchanged stores between rounds.
     last_scanned: RwLock<LastScannedGenerations>,
-    /// Snapshot of tree_generation from the last collection.
-    collected_tree_gen: RwLock<u64>,
+    /// Generations observed during the most recent `collect()`. Used by
+    /// `advance_generations()` to avoid a TOCTOU race where a concurrent
+    /// write between collect and advance would cause the new entries to
+    /// be skipped on the next round.
+    collected_generations: RwLock<LastScannedGenerations>,
 }
 
 impl CentralCollector {
@@ -725,7 +728,7 @@ impl CentralCollector {
             stores,
             self_name,
             last_scanned: RwLock::new(LastScannedGenerations::default()),
-            collected_tree_gen: RwLock::new(0),
+            collected_generations: RwLock::new(LastScannedGenerations::default()),
         }
     }
 
@@ -734,6 +737,19 @@ impl CentralCollector {
     pub fn collect(&self) -> RoundBatch {
         let mut all_updates = Vec::new();
 
+        // Snapshot all generations UP FRONT, before any reads. This locks in
+        // the values we'll use for skip checks AND for advance_generations,
+        // so concurrent writes between here and advance() aren't silently
+        // skipped on the next round.
+        let snapshot = LastScannedGenerations {
+            worker: self.stores.worker.generation(),
+            policy: self.stores.policy.generation(),
+            app: self.stores.app.generation(),
+            membership: self.stores.membership.generation(),
+            tree: self.stores.tree_generation.load(Ordering::Acquire),
+        };
+        *self.collected_generations.write() = snapshot;
+
         for store_type in [
             StoreType::Worker,
             StoreType::Policy,
@@ -741,7 +757,7 @@ impl CentralCollector {
             StoreType::Membership,
             StoreType::RateLimit,
         ] {
-            let updates = self.collect_store(store_type);
+            let updates = self.collect_store(store_type, &snapshot);
             if !updates.is_empty() {
                 all_updates.push((store_type, updates));
             }
@@ -752,27 +768,29 @@ impl CentralCollector {
         }
     }
 
-    /// Record the current generation after a successful round so the next
-    /// round can skip unchanged stores.
+    /// Record the generations observed during the last `collect()` so the next
+    /// round can skip unchanged stores. Uses the captured snapshot (not a
+    /// re-read) to avoid a TOCTOU race.
     pub fn advance_generations(&self) {
-        let mut last_scanned = self.last_scanned.write();
-        last_scanned.worker = self.stores.worker.generation();
-        last_scanned.policy = self.stores.policy.generation();
-        last_scanned.app = self.stores.app.generation();
-        last_scanned.membership = self.stores.membership.generation();
-        last_scanned.tree = *self.collected_tree_gen.read();
+        let collected = *self.collected_generations.read();
+        *self.last_scanned.write() = collected;
     }
 
     /// Collect all entries for a store type. No watermark filtering — includes
-    /// ALL current entries from stores that changed since last round.
-    fn collect_store(&self, store_type: StoreType) -> Vec<StateUpdate> {
+    /// ALL current entries from stores that changed since last round. Uses
+    /// the pre-captured `snapshot` for skip checks so the values are consistent
+    /// with what `advance_generations` will record.
+    fn collect_store(
+        &self,
+        store_type: StoreType,
+        snapshot: &LastScannedGenerations,
+    ) -> Vec<StateUpdate> {
         let last_scanned = self.last_scanned.read();
         let timestamp = current_timestamp();
 
         match store_type {
             StoreType::Worker => {
-                let gen = self.stores.worker.generation();
-                if gen == last_scanned.worker {
+                if snapshot.worker == last_scanned.worker {
                     return vec![];
                 }
                 self.collect_serializable_store(
@@ -783,17 +801,13 @@ impl CentralCollector {
                 )
             }
             StoreType::Policy => {
-                let policy_gen = self.stores.policy.generation();
-                let tree_gen = self.stores.tree_generation.load(Ordering::Acquire);
-                if policy_gen == last_scanned.policy && tree_gen == last_scanned.tree {
+                if snapshot.policy == last_scanned.policy && snapshot.tree == last_scanned.tree {
                     return vec![];
                 }
-                *self.collected_tree_gen.write() = tree_gen;
-                self.collect_policy_store(timestamp, tree_gen != last_scanned.tree)
+                self.collect_policy_store(timestamp, snapshot.tree != last_scanned.tree)
             }
             StoreType::App => {
-                let gen = self.stores.app.generation();
-                if gen == last_scanned.app {
+                if snapshot.app == last_scanned.app {
                     return vec![];
                 }
                 self.collect_serializable_store(
@@ -804,8 +818,7 @@ impl CentralCollector {
                 )
             }
             StoreType::Membership => {
-                let gen = self.stores.membership.generation();
-                if gen == last_scanned.membership {
+                if snapshot.membership == last_scanned.membership {
                     return vec![];
                 }
                 self.collect_serializable_store(

--- a/crates/mesh/src/incremental.rs
+++ b/crates/mesh/src/incremental.rs
@@ -927,18 +927,29 @@ impl CentralCollector {
         updates.extend(drained.updates);
         emitted_tree_keys.extend(drained.emitted_tree_keys);
 
-        // Phase 2: tree_configs scan for keys not emitted as deltas
-        for entry in &self.stores.tree_configs {
-            let key = entry.key();
+        // Phase 2: tree_configs scan for keys not emitted as deltas.
+        //
+        // Collect (key, value) snapshots FIRST so DashMap shard locks are
+        // released before the slow per-entry work (TreeSnapshot/TreeState
+        // parsing + lz4_compress). Holding shard locks across those would
+        // block concurrent writers to tree_configs and risk deadlock on any
+        // nested map operation.
+        let tree_entries: Vec<(String, Vec<u8>)> = self
+            .stores
+            .tree_configs
+            .iter()
+            .map(|e| (e.key().clone(), e.value().clone()))
+            .collect();
+
+        for (key, config_bytes) in tree_entries {
             if emitted_tree_keys.contains(key.as_str()) {
                 continue;
             }
-            let model_id = key.strip_prefix("tree:").unwrap_or(key).to_string();
-            let config_bytes = entry.value().clone();
             if config_bytes.is_empty() {
                 continue;
             }
-            let current_version = self.stores.tree_version(key);
+            let model_id = key.strip_prefix("tree:").unwrap_or(&key).to_string();
+            let current_version = self.stores.tree_version(&key);
             let tree_version = if let Ok(ts) = TreeState::from_bytes(&config_bytes) {
                 ts.version
             } else if kv_index::snapshot::TreeSnapshot::from_bytes(&config_bytes).is_ok() {
@@ -964,7 +975,7 @@ impl CentralCollector {
             };
             if let Ok(serialized) = bincode::serialize(&full_state) {
                 updates.push(StateUpdate {
-                    key: key.clone(),
+                    key,
                     value: serialized,
                     version: current_version,
                     actor: self.self_name.clone(),

--- a/crates/mesh/src/incremental.rs
+++ b/crates/mesh/src/incremental.rs
@@ -118,11 +118,6 @@ pub struct IncrementalUpdateCollector {
     collected_tree_gen: Arc<RwLock<u64>>,
     /// Counter for gossip rounds since last full structure snapshot per model.
     rounds_since_snapshot: Arc<RwLock<HashMap<String, u64>>>,
-    /// Shared reference to centrally drained tenant deltas. When the inner
-    /// Option is Some, Policy Phase 0 uses these instead of destructively
-    /// draining from the shared DashMap. Set by the gossip event loop once
-    /// per round, read by all per-peer collectors.
-    central_deltas: Arc<RwLock<Option<DrainedTenantDeltas>>>,
 }
 
 impl IncrementalUpdateCollector {
@@ -134,7 +129,6 @@ impl IncrementalUpdateCollector {
             last_scanned: Arc::new(RwLock::new(LastScannedGenerations::default())),
             collected_tree_gen: Arc::new(RwLock::new(0)),
             rounds_since_snapshot: Arc::new(RwLock::new(HashMap::new())),
-            central_deltas: Arc::new(RwLock::new(None)),
         }
     }
 
@@ -256,137 +250,89 @@ impl IncrementalUpdateCollector {
                 if tree_changed {
                     let mut emitted_tree_keys = std::collections::HashSet::new();
 
-                    // Phase 0: Tenant delta collection.
-                    //
-                    // v2 FIX: If central deltas are available (set by the gossip
-                    // event loop via set_central_deltas), use them directly instead
-                    // of destructively draining the shared DashMap. This fixes the
-                    // v1 bug where only the first per-peer collector receives
-                    // tenant deltas.
-                    //
-                    // When central_deltas is None (legacy path), fall back to the
-                    // per-collector destructive drain for backward compatibility.
+                    // Phase 0: Tenant delta collection (v1 legacy destructive drain).
+                    // v2 production code uses `CentralCollector` which drains once
+                    // per round. This path is only reachable from sync.rs tests.
                     {
-                        let central = self.central_deltas.read();
-                        if let Some(ref drained) = *central {
-                            // Use pre-drained deltas from central drain.
-                            updates.extend(drained.updates.clone());
-                            emitted_tree_keys.extend(drained.emitted_tree_keys.clone());
-                            // Use the central drain's tree_gen snapshot for mark_sent
-                            *self.collected_tree_gen.write() = drained.tree_gen_snapshot;
+                        let models_with_inserts: Vec<String> = self
+                            .stores
+                            .tenant_delta_inserts
+                            .iter()
+                            .filter(|entry| !entry.value().is_empty())
+                            .map(|entry| entry.key().clone())
+                            .collect();
+                        let models_with_evictions: Vec<String> = self
+                            .stores
+                            .tenant_delta_evictions
+                            .iter()
+                            .filter(|entry| !entry.value().is_empty())
+                            .map(|entry| entry.key().clone())
+                            .collect();
 
-                            let phase0_count = drained.updates.len();
-                            if phase0_count > 0 {
-                                let phase0_total_bytes: usize =
-                                    drained.updates.iter().map(|u| u.value.len()).sum();
-                                debug!(
-                                    phase0_updates = phase0_count,
-                                    phase0_total_bytes,
-                                    "Phase 0: used centrally drained tenant deltas"
-                                );
-                            }
-                        } else {
-                            // Legacy path: per-collector destructive drain.
-                            // TODO(v2): Remove this path once all callers use
-                            // set_central_deltas.
-                            let models_with_inserts: Vec<String> = self
+                        let all_models: std::collections::HashSet<String> = models_with_inserts
+                            .into_iter()
+                            .chain(models_with_evictions)
+                            .collect();
+
+                        let mut rounds = self.rounds_since_snapshot.write();
+
+                        for model_id in all_models {
+                            let key = format!("tree:{model_id}");
+
+                            let round_count = rounds.entry(model_id.clone()).or_insert(0);
+                            *round_count += 1;
+                            let _ = round_count; // tracked for future Layer 2
+
+                            let current_version = self.stores.tree_version(&key);
+
+                            let inserts = self
                                 .stores
                                 .tenant_delta_inserts
-                                .iter()
-                                .filter(|entry| !entry.value().is_empty())
-                                .map(|entry| entry.key().clone())
-                                .collect();
-                            let models_with_evictions: Vec<String> = self
+                                .remove(&model_id)
+                                .map(|(_, v)| v)
+                                .unwrap_or_default();
+                            let evictions = self
                                 .stores
                                 .tenant_delta_evictions
-                                .iter()
-                                .filter(|entry| !entry.value().is_empty())
-                                .map(|entry| entry.key().clone())
-                                .collect();
+                                .remove(&model_id)
+                                .map(|(_, v)| v)
+                                .unwrap_or_default();
 
-                            let all_models: std::collections::HashSet<String> = models_with_inserts
-                                .into_iter()
-                                .chain(models_with_evictions)
-                                .collect();
-
-                            let mut rounds = self.rounds_since_snapshot.write();
-
-                            for model_id in all_models {
-                                let key = format!("tree:{model_id}");
-
-                                let round_count = rounds.entry(model_id.clone()).or_insert(0);
-                                *round_count += 1;
-                                let _ = round_count; // tracked for future Layer 2
-
-                                let current_version = self.stores.tree_version(&key);
-
-                                let inserts = self
-                                    .stores
-                                    .tenant_delta_inserts
-                                    .remove(&model_id)
-                                    .map(|(_, v)| v)
-                                    .unwrap_or_default();
-                                let evictions = self
-                                    .stores
-                                    .tenant_delta_evictions
-                                    .remove(&model_id)
-                                    .map(|(_, v)| v)
-                                    .unwrap_or_default();
-
-                                if inserts.is_empty() && evictions.is_empty() {
-                                    continue;
-                                }
-
-                                let delta = TenantDelta {
-                                    model_id: model_id.clone(),
-                                    version: current_version,
-                                    inserts,
-                                    evictions,
-                                };
-
-                                if let Ok(delta_bytes) = delta.to_bytes() {
-                                    let delta_policy = PolicyState {
-                                        model_id: model_id.clone(),
-                                        policy_type: "tenant_delta".to_string(),
-                                        config: delta_bytes,
-                                        version: current_version,
-                                    };
-                                    if let Ok(serialized) = bincode::serialize(&delta_policy) {
-                                        updates.push(StateUpdate {
-                                            key: key.clone(),
-                                            value: serialized,
-                                            version: current_version,
-                                            actor: self.self_name.clone(),
-                                            timestamp,
-                                        });
-                                        debug!(
-                                            "Collected tenant delta: {} ({} inserts, {} evictions, version: {})",
-                                            model_id,
-                                            delta.inserts.len(),
-                                            delta.evictions.len(),
-                                            current_version,
-                                        );
-                                        emitted_tree_keys.insert(key);
-                                    }
-                                }
+                            if inserts.is_empty() && evictions.is_empty() {
+                                continue;
                             }
 
-                            // Phase 0 summary
-                            let phase0_total_bytes: usize = updates
-                                .iter()
-                                .filter(|u| u.key.starts_with("tree:"))
-                                .map(|u| u.value.len())
-                                .sum();
-                            let phase0_count = updates
-                                .iter()
-                                .filter(|u| u.key.starts_with("tree:"))
-                                .count();
-                            if phase0_count > 0 {
-                                debug!(
-                                    phase0_updates = phase0_count,
-                                    phase0_total_bytes,
-                                    "Phase 0: tenant delta buffer drain produced updates (legacy path)"
-                                );
+                            let delta = TenantDelta {
+                                model_id: model_id.clone(),
+                                version: current_version,
+                                inserts,
+                                evictions,
+                            };
+
+                            if let Ok(delta_bytes) = delta.to_bytes() {
+                                let delta_policy = PolicyState {
+                                    model_id: model_id.clone(),
+                                    policy_type: "tenant_delta".to_string(),
+                                    config: delta_bytes,
+                                    version: current_version,
+                                };
+                                if let Ok(serialized) = bincode::serialize(&delta_policy) {
+                                    updates.push(StateUpdate {
+                                        key: key.clone(),
+                                        value: serialized,
+                                        version: current_version,
+                                        actor: self.self_name.clone(),
+                                        timestamp,
+                                    });
+                                    debug!(
+                                        "Collected tenant delta: {} ({} inserts, {} evictions, version: {})",
+                                        model_id,
+                                        delta.inserts.len(),
+                                        delta.evictions.len(),
+                                        current_version,
+                                    );
+                                    emitted_tree_keys.insert(key);
+                                }
                             }
                         }
                     }
@@ -641,27 +587,23 @@ impl IncrementalUpdateCollector {
 // Central Tenant Delta Drain (v2 bug fix)
 // ============================================================================
 
-/// Tenant delta updates drained once per gossip round. Shared with all per-peer
-/// collector instances so they all see the same deltas instead of racing to drain
-/// the shared DashMap (v1 bug where only the first peer receives deltas).
+/// Tenant delta updates drained once per gossip round. Used by
+/// `CentralCollector` to drain the shared DashMap exactly once per round
+/// (v1 bug fix where destructive drain races left later peers empty-handed).
 #[derive(Debug, Clone, Default)]
 pub struct DrainedTenantDeltas {
     /// Tenant delta StateUpdates collected from the destructive drain.
     /// These are Policy-type updates with key "tree:{model_id}".
     pub updates: Vec<StateUpdate>,
-    /// Set of tree keys emitted as deltas. Per-peer collectors use this to
-    /// skip these keys in Phase 2 (tree_configs full-state scan).
+    /// Set of tree keys emitted as deltas. Used to skip these keys in
+    /// Phase 2 (tree_configs full-state scan) so the same model isn't sent twice.
     pub emitted_tree_keys: std::collections::HashSet<String>,
-    /// Tree generation snapshot at drain time. Per-peer collectors use this
-    /// for mark_sent to avoid advancing past the batch boundary.
-    pub tree_gen_snapshot: u64,
 }
 
 /// Drains tenant delta buffers exactly once per gossip round. The result is
 /// stored in a shared location so all per-peer collectors can include the
 /// same deltas without racing on the destructive DashMap remove.
 pub fn drain_tenant_deltas_central(stores: &StateStores, self_name: &str) -> DrainedTenantDeltas {
-    let tree_gen = stores.tree_generation.load(Ordering::Acquire);
     let timestamp = current_timestamp();
     let mut updates = Vec::new();
     let mut emitted_tree_keys = std::collections::HashSet::new();
@@ -749,7 +691,6 @@ pub fn drain_tenant_deltas_central(stores: &StateStores, self_name: &str) -> Dra
     DrainedTenantDeltas {
         updates,
         emitted_tree_keys,
-        tree_gen_snapshot: tree_gen,
     }
 }
 

--- a/crates/mesh/src/incremental.rs
+++ b/crates/mesh/src/incremental.rs
@@ -4,10 +4,7 @@
 //!
 //! v1 `IncrementalUpdateCollector` is kept only for tests in sync.rs until
 //! Step 2c migrates them. Production code uses `CentralCollector` +
-//! `PeerWatermark`. The module-level allow below silences dead-code warnings
-//! for the legacy collector without disabling the lint elsewhere.
-
-#![cfg_attr(not(test), allow(dead_code, clippy::allow_attributes))]
+//! `PeerWatermark`.
 
 use std::{
     collections::HashMap,
@@ -107,6 +104,14 @@ pub(crate) fn rate_limit_last_sent_key(key: &str, actor: &str) -> String {
 /// Incremental update collector (v1 legacy, kept for sync.rs and incremental.rs tests).
 /// v2 production code uses `CentralCollector` + `PeerWatermark` instead.
 /// TODO(Step 2c): migrate tests to CentralCollector, then delete this struct.
+#[cfg_attr(
+    not(test),
+    allow(
+        dead_code,
+        clippy::allow_attributes,
+        reason = "v1 legacy kept for tests"
+    )
+)]
 pub struct IncrementalUpdateCollector {
     stores: Arc<StateStores>,
     self_name: String,
@@ -120,6 +125,14 @@ pub struct IncrementalUpdateCollector {
     rounds_since_snapshot: Arc<RwLock<HashMap<String, u64>>>,
 }
 
+#[cfg_attr(
+    not(test),
+    allow(
+        dead_code,
+        clippy::allow_attributes,
+        reason = "v1 legacy kept for tests"
+    )
+)]
 impl IncrementalUpdateCollector {
     pub fn new(stores: Arc<StateStores>, self_name: String) -> Self {
         Self {

--- a/crates/mesh/src/incremental.rs
+++ b/crates/mesh/src/incremental.rs
@@ -1,6 +1,13 @@
 //! Incremental update collection and batching
 //!
-//! Collects local state changes and batches them for efficient transmission
+//! Collects local state changes and batches them for efficient transmission.
+//!
+//! v1 `IncrementalUpdateCollector` is kept only for tests in sync.rs until
+//! Step 2c migrates them. Production code uses `CentralCollector` +
+//! `PeerWatermark`. The module-level allow below silences dead-code warnings
+//! for the legacy collector without disabling the lint elsewhere.
+
+#![cfg_attr(not(test), allow(dead_code, clippy::allow_attributes))]
 
 use std::{
     collections::HashMap,
@@ -79,7 +86,27 @@ struct LastScannedGenerations {
 #[expect(dead_code, reason = "Reserved for Layer 2 snapshot interval")]
 const STRUCTURE_SNAPSHOT_INTERVAL: u64 = 30;
 
-/// Incremental update collector
+/// Get current timestamp in nanoseconds. Module-level so both the legacy
+/// IncrementalUpdateCollector and the new CentralCollector can use it.
+#[expect(
+    clippy::expect_used,
+    reason = "system clock before UNIX epoch is a fatal misconfiguration that must not silently produce timestamp=0"
+)]
+pub(crate) fn current_timestamp() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before UNIX_EPOCH; cannot generate valid timestamps")
+        .as_nanos() as u64
+}
+
+/// Build the per-actor last-sent key for rate limit shards.
+pub(crate) fn rate_limit_last_sent_key(key: &str, actor: &str) -> String {
+    format!("{key}::actor:{actor}")
+}
+
+/// Incremental update collector (v1 legacy, kept for sync.rs and incremental.rs tests).
+/// v2 production code uses `CentralCollector` + `PeerWatermark` instead.
+/// TODO(Step 2c): migrate tests to CentralCollector, then delete this struct.
 pub struct IncrementalUpdateCollector {
     stores: Arc<StateStores>,
     self_name: String,
@@ -111,22 +138,6 @@ impl IncrementalUpdateCollector {
         }
     }
 
-    /// Get current timestamp in nanoseconds
-    #[expect(
-        clippy::expect_used,
-        reason = "system clock before UNIX epoch is a fatal misconfiguration that must not silently produce timestamp=0"
-    )]
-    fn current_timestamp() -> u64 {
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("system clock before UNIX_EPOCH; cannot generate valid timestamps")
-            .as_nanos() as u64
-    }
-
-    pub(crate) fn rate_limit_last_sent_key(key: &str, actor: &str) -> String {
-        format!("{key}::actor:{actor}")
-    }
-
     /// Helper function to collect updates for stores with serializable state
     fn collect_serializable_updates<S>(
         &self,
@@ -139,7 +150,7 @@ impl IncrementalUpdateCollector {
         S: serde::Serialize + Versioned,
     {
         let mut updates = Vec::new();
-        let timestamp = Self::current_timestamp();
+        let timestamp = current_timestamp();
 
         for (key, state) in all_items {
             let current_version = state.version();
@@ -202,7 +213,7 @@ impl IncrementalUpdateCollector {
                 // between collection and mark_sent.
                 *self.collected_tree_gen.write() = tree_gen;
 
-                let timestamp = Self::current_timestamp();
+                let timestamp = current_timestamp();
 
                 // --- Policy store scan (only if CRDT generation changed) ---
                 // Handles non-tree policy keys only. Tree keys are stored
@@ -514,14 +525,14 @@ impl IncrementalUpdateCollector {
                 );
             }
             StoreType::RateLimit => {
-                let current_timestamp = Self::current_timestamp();
+                let current_timestamp = current_timestamp();
 
                 for (key, actor, counter_value) in self.stores.rate_limit.all_shards() {
                     if !self.stores.rate_limit.is_owner(&key) {
                         continue;
                     }
 
-                    let shard_last_sent_key = Self::rate_limit_last_sent_key(&key, &actor);
+                    let shard_last_sent_key = rate_limit_last_sent_key(&key, &actor);
                     let last_sent_timestamp = last_sent
                         .rate_limit
                         .get(&shard_last_sent_key)
@@ -618,7 +629,7 @@ impl IncrementalUpdateCollector {
                         .insert(update.key.clone(), update.version);
                 }
                 StoreType::RateLimit => {
-                    let shard_key = Self::rate_limit_last_sent_key(&update.key, &update.actor);
+                    let shard_key = rate_limit_last_sent_key(&update.key, &update.actor);
                     last_sent.rate_limit.insert(shard_key, update.version);
                 }
             }
@@ -651,7 +662,7 @@ pub struct DrainedTenantDeltas {
 /// same deltas without racing on the destructive DashMap remove.
 pub fn drain_tenant_deltas_central(stores: &StateStores, self_name: &str) -> DrainedTenantDeltas {
     let tree_gen = stores.tree_generation.load(Ordering::Acquire);
-    let timestamp = IncrementalUpdateCollector::current_timestamp();
+    let timestamp = current_timestamp();
     let mut updates = Vec::new();
     let mut emitted_tree_keys = std::collections::HashSet::new();
 
@@ -815,7 +826,7 @@ impl CentralCollector {
     /// ALL current entries from stores that changed since last round.
     fn collect_store(&self, store_type: StoreType) -> Vec<StateUpdate> {
         let last_scanned = self.last_scanned.read();
-        let timestamp = IncrementalUpdateCollector::current_timestamp();
+        let timestamp = current_timestamp();
 
         match store_type {
             StoreType::Worker => {
@@ -864,7 +875,7 @@ impl CentralCollector {
                 )
             }
             StoreType::RateLimit => {
-                let current_timestamp = IncrementalUpdateCollector::current_timestamp();
+                let current_timestamp = current_timestamp();
                 let mut updates = Vec::new();
                 for (key, actor, counter_value) in self.stores.rate_limit.all_shards() {
                     if !self.stores.rate_limit.is_owner(&key) {
@@ -1060,10 +1071,7 @@ impl PeerWatermark {
                         .insert(update.key.clone(), update.version);
                 }
                 StoreType::RateLimit => {
-                    let shard_key = IncrementalUpdateCollector::rate_limit_last_sent_key(
-                        &update.key,
-                        &update.actor,
-                    );
+                    let shard_key = rate_limit_last_sent_key(&update.key, &update.actor);
                     self.last_sent.rate_limit.insert(shard_key, update.version);
                 }
             }
@@ -1082,10 +1090,7 @@ impl PeerWatermark {
                 .copied()
                 .unwrap_or(0),
             StoreType::RateLimit => {
-                let shard_key = IncrementalUpdateCollector::rate_limit_last_sent_key(
-                    &update.key,
-                    &update.actor,
-                );
+                let shard_key = rate_limit_last_sent_key(&update.key, &update.actor);
                 self.last_sent
                     .rate_limit
                     .get(&shard_key)

--- a/crates/mesh/src/incremental.rs
+++ b/crates/mesh/src/incremental.rs
@@ -111,25 +111,6 @@ impl IncrementalUpdateCollector {
         }
     }
 
-    /// Create a collector that shares a central deltas reference with other
-    /// collectors. The gossip event loop sets deltas on the shared reference
-    /// once per round; all collectors see the same data.
-    pub fn with_shared_central_deltas(
-        stores: Arc<StateStores>,
-        self_name: String,
-        central_deltas: Arc<RwLock<Option<DrainedTenantDeltas>>>,
-    ) -> Self {
-        Self {
-            stores,
-            self_name,
-            last_sent: Arc::new(RwLock::new(LastSentVersions::default())),
-            last_scanned: Arc::new(RwLock::new(LastScannedGenerations::default())),
-            collected_tree_gen: Arc::new(RwLock::new(0)),
-            rounds_since_snapshot: Arc::new(RwLock::new(HashMap::new())),
-            central_deltas,
-        }
-    }
-
     /// Get current timestamp in nanoseconds
     #[expect(
         clippy::expect_used,
@@ -142,7 +123,7 @@ impl IncrementalUpdateCollector {
             .as_nanos() as u64
     }
 
-    fn rate_limit_last_sent_key(key: &str, actor: &str) -> String {
+    pub(crate) fn rate_limit_last_sent_key(key: &str, actor: &str) -> String {
         format!("{key}::actor:{actor}")
     }
 
@@ -758,6 +739,361 @@ pub fn drain_tenant_deltas_central(stores: &StateStores, self_name: &str) -> Dra
         updates,
         emitted_tree_keys,
         tree_gen_snapshot: tree_gen,
+    }
+}
+
+// ============================================================================
+// CentralCollector + PeerWatermark (v2 architecture)
+// ============================================================================
+
+/// A round batch produced by the central collector. Contains ALL updates from
+/// this round, organized by store type. Per-peer watermark filtering happens
+/// at send time via `PeerWatermark::filter()`.
+#[derive(Debug, Clone, Default)]
+pub struct RoundBatch {
+    pub updates: Vec<(StoreType, Vec<StateUpdate>)>,
+}
+
+/// Central collector that runs once per gossip round. Produces a `RoundBatch`
+/// containing all changed entries across all stores. Destructive operations
+/// (tenant delta drain) happen here exactly once. Per-peer watermark filtering
+/// is NOT done here — that's `PeerWatermark`'s job.
+pub struct CentralCollector {
+    stores: Arc<StateStores>,
+    self_name: String,
+    /// Generation tracking to skip unchanged stores between rounds.
+    last_scanned: RwLock<LastScannedGenerations>,
+    /// Snapshot of tree_generation from the last collection.
+    collected_tree_gen: RwLock<u64>,
+}
+
+impl CentralCollector {
+    pub fn new(stores: Arc<StateStores>, self_name: String) -> Self {
+        Self {
+            stores,
+            self_name,
+            last_scanned: RwLock::new(LastScannedGenerations::default()),
+            collected_tree_gen: RwLock::new(0),
+        }
+    }
+
+    /// Collect all changes for this round. Called exactly once per gossip round
+    /// by the event loop. Returns a `RoundBatch` that per-peer watermarks filter.
+    pub fn collect(&self) -> RoundBatch {
+        let mut all_updates = Vec::new();
+
+        for store_type in [
+            StoreType::Worker,
+            StoreType::Policy,
+            StoreType::App,
+            StoreType::Membership,
+            StoreType::RateLimit,
+        ] {
+            let updates = self.collect_store(store_type);
+            if !updates.is_empty() {
+                all_updates.push((store_type, updates));
+            }
+        }
+
+        RoundBatch {
+            updates: all_updates,
+        }
+    }
+
+    /// Record the current generation after a successful round so the next
+    /// round can skip unchanged stores.
+    pub fn advance_generations(&self) {
+        let mut last_scanned = self.last_scanned.write();
+        last_scanned.worker = self.stores.worker.generation();
+        last_scanned.policy = self.stores.policy.generation();
+        last_scanned.app = self.stores.app.generation();
+        last_scanned.membership = self.stores.membership.generation();
+        last_scanned.tree = *self.collected_tree_gen.read();
+    }
+
+    /// Collect all entries for a store type. No watermark filtering — includes
+    /// ALL current entries from stores that changed since last round.
+    fn collect_store(&self, store_type: StoreType) -> Vec<StateUpdate> {
+        let last_scanned = self.last_scanned.read();
+        let timestamp = IncrementalUpdateCollector::current_timestamp();
+
+        match store_type {
+            StoreType::Worker => {
+                let gen = self.stores.worker.generation();
+                if gen == last_scanned.worker {
+                    return vec![];
+                }
+                self.collect_serializable_store(
+                    self.stores.worker.all(),
+                    "worker",
+                    timestamp,
+                    |s: &WorkerState| s.worker_id.clone(),
+                )
+            }
+            StoreType::Policy => {
+                let policy_gen = self.stores.policy.generation();
+                let tree_gen = self.stores.tree_generation.load(Ordering::Acquire);
+                if policy_gen == last_scanned.policy && tree_gen == last_scanned.tree {
+                    return vec![];
+                }
+                *self.collected_tree_gen.write() = tree_gen;
+                self.collect_policy_store(timestamp, tree_gen != last_scanned.tree)
+            }
+            StoreType::App => {
+                let gen = self.stores.app.generation();
+                if gen == last_scanned.app {
+                    return vec![];
+                }
+                self.collect_serializable_store(
+                    self.stores.app.all(),
+                    "app",
+                    timestamp,
+                    |s: &AppState| s.key.clone(),
+                )
+            }
+            StoreType::Membership => {
+                let gen = self.stores.membership.generation();
+                if gen == last_scanned.membership {
+                    return vec![];
+                }
+                self.collect_serializable_store(
+                    self.stores.membership.all(),
+                    "membership",
+                    timestamp,
+                    |s: &MembershipState| s.name.clone(),
+                )
+            }
+            StoreType::RateLimit => {
+                let current_timestamp = IncrementalUpdateCollector::current_timestamp();
+                let mut updates = Vec::new();
+                for (key, actor, counter_value) in self.stores.rate_limit.all_shards() {
+                    if !self.stores.rate_limit.is_owner(&key) {
+                        continue;
+                    }
+                    if let Ok(serialized) = bincode::serialize(&counter_value) {
+                        updates.push(StateUpdate {
+                            key,
+                            value: serialized,
+                            version: current_timestamp,
+                            actor,
+                            timestamp: current_timestamp,
+                        });
+                    }
+                }
+                updates
+            }
+        }
+    }
+
+    /// Collect all entries from a serializable store. No watermark filtering.
+    fn collect_serializable_store<S>(
+        &self,
+        all_items: std::collections::BTreeMap<String, S>,
+        store_name: &str,
+        timestamp: u64,
+        get_id: impl Fn(&S) -> String,
+    ) -> Vec<StateUpdate>
+    where
+        S: serde::Serialize + Versioned,
+    {
+        let mut updates = Vec::new();
+        for (key, state) in all_items {
+            if let Ok(serialized) = bincode::serialize(&state) {
+                debug!(
+                    "Central collect {} update: {} (version: {})",
+                    store_name,
+                    get_id(&state),
+                    state.version(),
+                );
+                updates.push(StateUpdate {
+                    key,
+                    value: serialized,
+                    version: state.version(),
+                    actor: self.self_name.clone(),
+                    timestamp,
+                });
+            }
+        }
+        updates
+    }
+
+    /// Collect policy store entries + tenant deltas + tree_configs.
+    /// Tenant deltas are destructively drained (safe because this runs once).
+    fn collect_policy_store(&self, timestamp: u64, tree_changed: bool) -> Vec<StateUpdate> {
+        let mut updates = Vec::new();
+        let mut emitted_tree_keys = std::collections::HashSet::new();
+
+        // Non-tree policy entries
+        let all_policies = self.stores.policy.all();
+        for (key, state) in &all_policies {
+            if key.starts_with("tree:") {
+                continue;
+            }
+            if let Ok(serialized) = bincode::serialize(state) {
+                updates.push(StateUpdate {
+                    key: key.clone(),
+                    value: serialized,
+                    version: state.version(),
+                    actor: self.self_name.clone(),
+                    timestamp,
+                });
+            }
+        }
+
+        if !tree_changed {
+            return updates;
+        }
+
+        // Phase 0: Drain tenant deltas (destructive, runs once)
+        let drained = drain_tenant_deltas_central(&self.stores, &self.self_name);
+        updates.extend(drained.updates);
+        emitted_tree_keys.extend(drained.emitted_tree_keys);
+
+        // Phase 2: tree_configs scan for keys not emitted as deltas
+        for entry in &self.stores.tree_configs {
+            let key = entry.key();
+            if emitted_tree_keys.contains(key.as_str()) {
+                continue;
+            }
+            let model_id = key.strip_prefix("tree:").unwrap_or(key).to_string();
+            let config_bytes = entry.value().clone();
+            if config_bytes.is_empty() {
+                continue;
+            }
+            let current_version = self.stores.tree_version(key);
+            let tree_version = if let Ok(ts) = TreeState::from_bytes(&config_bytes) {
+                ts.version
+            } else if kv_index::snapshot::TreeSnapshot::from_bytes(&config_bytes).is_ok() {
+                current_version
+            } else {
+                continue;
+            };
+            let compressed = lz4_compress(&config_bytes);
+            const MAX_SNAPSHOT_BYTES: usize = 8 * 1024 * 1024;
+            if compressed.len() > MAX_SNAPSHOT_BYTES {
+                debug!(
+                    key = %key,
+                    compressed_bytes = compressed.len(),
+                    "Skipping oversized tree snapshot"
+                );
+                continue;
+            }
+            let full_state = PolicyState {
+                model_id,
+                policy_type: "tree_state_lz4".to_string(),
+                config: compressed,
+                version: tree_version,
+            };
+            if let Ok(serialized) = bincode::serialize(&full_state) {
+                updates.push(StateUpdate {
+                    key: key.clone(),
+                    value: serialized,
+                    version: current_version,
+                    actor: self.self_name.clone(),
+                    timestamp,
+                });
+            }
+        }
+
+        updates
+    }
+}
+
+/// Per-peer watermark tracker. Filters a centrally collected `RoundBatch` to
+/// include only entries this peer hasn't seen yet, and tracks what was sent.
+#[derive(Debug)]
+pub struct PeerWatermark {
+    /// Peer name, used for Debug output.
+    _peer_name: String,
+    last_sent: LastSentVersions,
+}
+
+impl PeerWatermark {
+    pub fn new(peer_name: String) -> Self {
+        Self {
+            _peer_name: peer_name,
+            last_sent: LastSentVersions::default(),
+        }
+    }
+
+    /// Filter a round batch to include only entries this peer hasn't received.
+    /// Returns updates organized by store type, ready to send.
+    pub fn filter(&self, batch: &RoundBatch) -> Vec<(StoreType, Vec<StateUpdate>)> {
+        let mut filtered = Vec::new();
+
+        for (store_type, updates) in &batch.updates {
+            let peer_updates: Vec<StateUpdate> = updates
+                .iter()
+                .filter(|u| self.should_send(*store_type, u))
+                .cloned()
+                .collect();
+            if !peer_updates.is_empty() {
+                filtered.push((*store_type, peer_updates));
+            }
+        }
+
+        filtered
+    }
+
+    /// Mark updates as successfully sent to this peer. Advances watermark.
+    pub fn mark_sent(&mut self, store_type: StoreType, updates: &[StateUpdate]) {
+        for update in updates {
+            match store_type {
+                StoreType::Worker => {
+                    self.last_sent
+                        .worker
+                        .insert(update.key.clone(), update.version);
+                }
+                StoreType::Policy => {
+                    self.last_sent
+                        .policy
+                        .insert(update.key.clone(), update.version);
+                }
+                StoreType::App => {
+                    self.last_sent
+                        .app
+                        .insert(update.key.clone(), update.version);
+                }
+                StoreType::Membership => {
+                    self.last_sent
+                        .membership
+                        .insert(update.key.clone(), update.version);
+                }
+                StoreType::RateLimit => {
+                    let shard_key = IncrementalUpdateCollector::rate_limit_last_sent_key(
+                        &update.key,
+                        &update.actor,
+                    );
+                    self.last_sent.rate_limit.insert(shard_key, update.version);
+                }
+            }
+        }
+    }
+
+    fn should_send(&self, store_type: StoreType, update: &StateUpdate) -> bool {
+        let last_sent_version = match store_type {
+            StoreType::Worker => self.last_sent.worker.get(&update.key).copied().unwrap_or(0),
+            StoreType::Policy => self.last_sent.policy.get(&update.key).copied().unwrap_or(0),
+            StoreType::App => self.last_sent.app.get(&update.key).copied().unwrap_or(0),
+            StoreType::Membership => self
+                .last_sent
+                .membership
+                .get(&update.key)
+                .copied()
+                .unwrap_or(0),
+            StoreType::RateLimit => {
+                let shard_key = IncrementalUpdateCollector::rate_limit_last_sent_key(
+                    &update.key,
+                    &update.actor,
+                );
+                self.last_sent
+                    .rate_limit
+                    .get(&shard_key)
+                    .copied()
+                    .unwrap_or(0)
+            }
+        };
+        update.version > last_sent_version
     }
 }
 

--- a/crates/mesh/src/incremental.rs
+++ b/crates/mesh/src/incremental.rs
@@ -814,10 +814,12 @@ impl CentralCollector {
                 )
             }
             StoreType::Policy => {
-                if snapshot.policy == last_scanned.policy && snapshot.tree == last_scanned.tree {
+                let policy_changed = snapshot.policy != last_scanned.policy;
+                let tree_changed = snapshot.tree != last_scanned.tree;
+                if !policy_changed && !tree_changed {
                     return vec![];
                 }
-                self.collect_policy_store(timestamp, snapshot.tree != last_scanned.tree)
+                self.collect_policy_store(timestamp, policy_changed, tree_changed)
             }
             StoreType::App => {
                 if snapshot.app == last_scanned.app {
@@ -897,24 +899,36 @@ impl CentralCollector {
 
     /// Collect policy store entries + tenant deltas + tree_configs.
     /// Tenant deltas are destructively drained (safe because this runs once).
-    fn collect_policy_store(&self, timestamp: u64, tree_changed: bool) -> Vec<StateUpdate> {
+    /// `policy_changed` gates the non-tree policy scan; `tree_changed` gates
+    /// the tenant delta drain + tree_configs scan. A tenant-delta-only round
+    /// skips the full policy.all() sweep, which can be expensive.
+    fn collect_policy_store(
+        &self,
+        timestamp: u64,
+        policy_changed: bool,
+        tree_changed: bool,
+    ) -> Vec<StateUpdate> {
         let mut updates = Vec::new();
         let mut emitted_tree_keys = std::collections::HashSet::new();
 
-        // Non-tree policy entries
-        let all_policies = self.stores.policy.all();
-        for (key, state) in &all_policies {
-            if key.starts_with("tree:") {
-                continue;
-            }
-            if let Ok(serialized) = bincode::serialize(state) {
-                updates.push(StateUpdate {
-                    key: key.clone(),
-                    value: serialized,
-                    version: state.version(),
-                    actor: self.self_name.clone(),
-                    timestamp,
-                });
+        // Non-tree policy entries — only scan when the policy CRDT generation
+        // has changed since last round. Gating avoids O(policy_count) work
+        // on every tenant-delta round.
+        if policy_changed {
+            let all_policies = self.stores.policy.all();
+            for (key, state) in &all_policies {
+                if key.starts_with("tree:") {
+                    continue;
+                }
+                if let Ok(serialized) = bincode::serialize(state) {
+                    updates.push(StateUpdate {
+                        key: key.clone(),
+                        value: serialized,
+                        version: state.version(),
+                        actor: self.self_name.clone(),
+                        timestamp,
+                    });
+                }
             }
         }
 

--- a/crates/mesh/src/incremental.rs
+++ b/crates/mesh/src/incremental.rs
@@ -91,6 +91,10 @@ pub struct IncrementalUpdateCollector {
     collected_tree_gen: Arc<RwLock<u64>>,
     /// Counter for gossip rounds since last full structure snapshot per model.
     rounds_since_snapshot: Arc<RwLock<HashMap<String, u64>>>,
+    /// Pre-drained tenant deltas from the central drain. When set, the Policy
+    /// Phase 0 uses these instead of destructively draining from the shared
+    /// DashMap. This fixes the v1 bug where only the first peer receives deltas.
+    central_deltas: Arc<RwLock<Option<DrainedTenantDeltas>>>,
 }
 
 impl IncrementalUpdateCollector {
@@ -102,7 +106,29 @@ impl IncrementalUpdateCollector {
             last_scanned: Arc::new(RwLock::new(LastScannedGenerations::default())),
             collected_tree_gen: Arc::new(RwLock::new(0)),
             rounds_since_snapshot: Arc::new(RwLock::new(HashMap::new())),
+            central_deltas: Arc::new(RwLock::new(None)),
         }
+    }
+
+    /// Set pre-drained tenant deltas from the central drain. Called once per
+    /// gossip round BEFORE per-peer collection runs. All per-peer collectors
+    /// sharing this instance will use these deltas instead of draining the
+    /// shared DashMap.
+    #[expect(
+        dead_code,
+        reason = "wired up in controller.rs central drain (Step 2b)"
+    )]
+    pub fn set_central_deltas(&self, deltas: DrainedTenantDeltas) {
+        *self.central_deltas.write() = Some(deltas);
+    }
+
+    /// Clear the central deltas after all per-peer senders have consumed them.
+    #[expect(
+        dead_code,
+        reason = "wired up in controller.rs central drain (Step 2b)"
+    )]
+    pub fn clear_central_deltas(&self) {
+        *self.central_deltas.write() = None;
     }
 
     /// Get current timestamp in nanoseconds
@@ -239,118 +265,138 @@ impl IncrementalUpdateCollector {
                 if tree_changed {
                     let mut emitted_tree_keys = std::collections::HashSet::new();
 
-                    // Phase 0: Drain tenant delta buffers — lightweight per-gossip-round sync.
-                    // Each TenantDelta is ~100 bytes per insert vs ~200KB for full TreeOperation.
-                    // Models emitted here are skipped in Phase 1 (no need for heavy ops).
+                    // Phase 0: Tenant delta collection.
                     //
-                    // Every STRUCTURE_SNAPSHOT_INTERVAL rounds, skip Phase 0 for a model
-                    // and let Phase 1/2 emit a full TreeState for convergence.
+                    // v2 FIX: If central deltas are available (set by the gossip
+                    // event loop via set_central_deltas), use them directly instead
+                    // of destructively draining the shared DashMap. This fixes the
+                    // v1 bug where only the first per-peer collector receives
+                    // tenant deltas.
+                    //
+                    // When central_deltas is None (legacy path), fall back to the
+                    // per-collector destructive drain for backward compatibility.
                     {
-                        let models_with_inserts: Vec<String> = self
-                            .stores
-                            .tenant_delta_inserts
-                            .iter()
-                            .filter(|entry| !entry.value().is_empty())
-                            .map(|entry| entry.key().clone())
-                            .collect();
-                        let models_with_evictions: Vec<String> = self
-                            .stores
-                            .tenant_delta_evictions
-                            .iter()
-                            .filter(|entry| !entry.value().is_empty())
-                            .map(|entry| entry.key().clone())
-                            .collect();
+                        let central = self.central_deltas.read();
+                        if let Some(ref drained) = *central {
+                            // Use pre-drained deltas from central drain.
+                            updates.extend(drained.updates.clone());
+                            emitted_tree_keys.extend(drained.emitted_tree_keys.clone());
+                            // Use the central drain's tree_gen snapshot for mark_sent
+                            *self.collected_tree_gen.write() = drained.tree_gen_snapshot;
 
-                        let all_models: std::collections::HashSet<String> = models_with_inserts
-                            .into_iter()
-                            .chain(models_with_evictions)
-                            .collect();
-
-                        let mut rounds = self.rounds_since_snapshot.write();
-
-                        for model_id in all_models {
-                            let key = format!("tree:{model_id}");
-
-                            // Check if it's time for a full structure snapshot
-                            let round_count = rounds.entry(model_id.clone()).or_insert(0);
-                            *round_count += 1;
-                            // FIXME: When Layer 2 is implemented, skip tenant delta
-                            // every STRUCTURE_SNAPSHOT_INTERVAL rounds and emit a
-                            // full structure snapshot instead. Currently checkpoint
-                            // is a no-op, so never skip — always send tenant deltas.
-                            let _ = round_count; // tracked for future Layer 2
-
-                            let current_version = self.stores.tree_version(&key);
-
-                            let inserts = self
+                            let phase0_count = drained.updates.len();
+                            if phase0_count > 0 {
+                                let phase0_total_bytes: usize =
+                                    drained.updates.iter().map(|u| u.value.len()).sum();
+                                debug!(
+                                    phase0_updates = phase0_count,
+                                    phase0_total_bytes,
+                                    "Phase 0: used centrally drained tenant deltas"
+                                );
+                            }
+                        } else {
+                            // Legacy path: per-collector destructive drain.
+                            // TODO(v2): Remove this path once all callers use
+                            // set_central_deltas.
+                            let models_with_inserts: Vec<String> = self
                                 .stores
                                 .tenant_delta_inserts
-                                .remove(&model_id)
-                                .map(|(_, v)| v)
-                                .unwrap_or_default();
-                            let evictions = self
+                                .iter()
+                                .filter(|entry| !entry.value().is_empty())
+                                .map(|entry| entry.key().clone())
+                                .collect();
+                            let models_with_evictions: Vec<String> = self
                                 .stores
                                 .tenant_delta_evictions
-                                .remove(&model_id)
-                                .map(|(_, v)| v)
-                                .unwrap_or_default();
+                                .iter()
+                                .filter(|entry| !entry.value().is_empty())
+                                .map(|entry| entry.key().clone())
+                                .collect();
 
-                            if inserts.is_empty() && evictions.is_empty() {
-                                continue;
-                            }
+                            let all_models: std::collections::HashSet<String> = models_with_inserts
+                                .into_iter()
+                                .chain(models_with_evictions)
+                                .collect();
 
-                            let delta = TenantDelta {
-                                model_id: model_id.clone(),
-                                version: current_version,
-                                inserts,
-                                evictions,
-                            };
+                            let mut rounds = self.rounds_since_snapshot.write();
 
-                            if let Ok(delta_bytes) = delta.to_bytes() {
-                                let delta_policy = PolicyState {
+                            for model_id in all_models {
+                                let key = format!("tree:{model_id}");
+
+                                let round_count = rounds.entry(model_id.clone()).or_insert(0);
+                                *round_count += 1;
+                                let _ = round_count; // tracked for future Layer 2
+
+                                let current_version = self.stores.tree_version(&key);
+
+                                let inserts = self
+                                    .stores
+                                    .tenant_delta_inserts
+                                    .remove(&model_id)
+                                    .map(|(_, v)| v)
+                                    .unwrap_or_default();
+                                let evictions = self
+                                    .stores
+                                    .tenant_delta_evictions
+                                    .remove(&model_id)
+                                    .map(|(_, v)| v)
+                                    .unwrap_or_default();
+
+                                if inserts.is_empty() && evictions.is_empty() {
+                                    continue;
+                                }
+
+                                let delta = TenantDelta {
                                     model_id: model_id.clone(),
-                                    policy_type: "tenant_delta".to_string(),
-                                    config: delta_bytes,
                                     version: current_version,
+                                    inserts,
+                                    evictions,
                                 };
-                                if let Ok(serialized) = bincode::serialize(&delta_policy) {
-                                    updates.push(StateUpdate {
-                                        key: key.clone(),
-                                        value: serialized,
+
+                                if let Ok(delta_bytes) = delta.to_bytes() {
+                                    let delta_policy = PolicyState {
+                                        model_id: model_id.clone(),
+                                        policy_type: "tenant_delta".to_string(),
+                                        config: delta_bytes,
                                         version: current_version,
-                                        actor: self.self_name.clone(),
-                                        timestamp,
-                                    });
-                                    debug!(
-                                        "Collected tenant delta: {} ({} inserts, {} evictions, version: {})",
-                                        model_id,
-                                        delta.inserts.len(),
-                                        delta.evictions.len(),
-                                        current_version,
-                                    );
-                                    emitted_tree_keys.insert(key);
+                                    };
+                                    if let Ok(serialized) = bincode::serialize(&delta_policy) {
+                                        updates.push(StateUpdate {
+                                            key: key.clone(),
+                                            value: serialized,
+                                            version: current_version,
+                                            actor: self.self_name.clone(),
+                                            timestamp,
+                                        });
+                                        debug!(
+                                            "Collected tenant delta: {} ({} inserts, {} evictions, version: {})",
+                                            model_id,
+                                            delta.inserts.len(),
+                                            delta.evictions.len(),
+                                            current_version,
+                                        );
+                                        emitted_tree_keys.insert(key);
+                                    }
                                 }
                             }
-                        }
-                    }
 
-                    // Phase 0 summary: log total serialized size of tenant delta updates
-                    {
-                        let phase0_total_bytes: usize = updates
-                            .iter()
-                            .filter(|u| u.key.starts_with("tree:"))
-                            .map(|u| u.value.len())
-                            .sum();
-                        let phase0_count = updates
-                            .iter()
-                            .filter(|u| u.key.starts_with("tree:"))
-                            .count();
-                        if phase0_count > 0 {
-                            debug!(
-                                phase0_updates = phase0_count,
-                                phase0_total_bytes,
-                                "Phase 0: tenant delta buffer drain produced updates"
-                            );
+                            // Phase 0 summary
+                            let phase0_total_bytes: usize = updates
+                                .iter()
+                                .filter(|u| u.key.starts_with("tree:"))
+                                .map(|u| u.value.len())
+                                .sum();
+                            let phase0_count = updates
+                                .iter()
+                                .filter(|u| u.key.starts_with("tree:"))
+                                .count();
+                            if phase0_count > 0 {
+                                debug!(
+                                    phase0_updates = phase0_count,
+                                    phase0_total_bytes,
+                                    "Phase 0: tenant delta buffer drain produced updates (legacy path)"
+                                );
+                            }
                         }
                     }
 
@@ -597,6 +643,123 @@ impl IncrementalUpdateCollector {
                 }
             }
         }
+    }
+}
+
+// ============================================================================
+// Central Tenant Delta Drain (v2 bug fix)
+// ============================================================================
+
+/// Tenant delta updates drained once per gossip round. Shared with all per-peer
+/// collector instances so they all see the same deltas instead of racing to drain
+/// the shared DashMap (v1 bug where only the first peer receives deltas).
+#[derive(Debug, Clone, Default)]
+pub struct DrainedTenantDeltas {
+    /// Tenant delta StateUpdates collected from the destructive drain.
+    /// These are Policy-type updates with key "tree:{model_id}".
+    pub updates: Vec<StateUpdate>,
+    /// Set of tree keys emitted as deltas. Per-peer collectors use this to
+    /// skip these keys in Phase 2 (tree_configs full-state scan).
+    pub emitted_tree_keys: std::collections::HashSet<String>,
+    /// Tree generation snapshot at drain time. Per-peer collectors use this
+    /// for mark_sent to avoid advancing past the batch boundary.
+    pub tree_gen_snapshot: u64,
+}
+
+/// Drains tenant delta buffers exactly once per gossip round. The result is
+/// stored in a shared location so all per-peer collectors can include the
+/// same deltas without racing on the destructive DashMap remove.
+#[expect(dead_code, reason = "wired up in controller.rs event loop (Step 2b)")]
+pub fn drain_tenant_deltas_central(stores: &StateStores, self_name: &str) -> DrainedTenantDeltas {
+    let tree_gen = stores.tree_generation.load(Ordering::Acquire);
+    let timestamp = IncrementalUpdateCollector::current_timestamp();
+    let mut updates = Vec::new();
+    let mut emitted_tree_keys = std::collections::HashSet::new();
+
+    let models_with_inserts: Vec<String> = stores
+        .tenant_delta_inserts
+        .iter()
+        .filter(|entry| !entry.value().is_empty())
+        .map(|entry| entry.key().clone())
+        .collect();
+    let models_with_evictions: Vec<String> = stores
+        .tenant_delta_evictions
+        .iter()
+        .filter(|entry| !entry.value().is_empty())
+        .map(|entry| entry.key().clone())
+        .collect();
+
+    let all_models: std::collections::HashSet<String> = models_with_inserts
+        .into_iter()
+        .chain(models_with_evictions)
+        .collect();
+
+    for model_id in all_models {
+        let key = format!("tree:{model_id}");
+        let current_version = stores.tree_version(&key);
+
+        let inserts = stores
+            .tenant_delta_inserts
+            .remove(&model_id)
+            .map(|(_, v)| v)
+            .unwrap_or_default();
+        let evictions = stores
+            .tenant_delta_evictions
+            .remove(&model_id)
+            .map(|(_, v)| v)
+            .unwrap_or_default();
+
+        if inserts.is_empty() && evictions.is_empty() {
+            continue;
+        }
+
+        let delta = TenantDelta {
+            model_id: model_id.clone(),
+            version: current_version,
+            inserts,
+            evictions,
+        };
+
+        if let Ok(delta_bytes) = delta.to_bytes() {
+            let delta_policy = PolicyState {
+                model_id: model_id.clone(),
+                policy_type: "tenant_delta".to_string(),
+                config: delta_bytes,
+                version: current_version,
+            };
+            if let Ok(serialized) = bincode::serialize(&delta_policy) {
+                updates.push(StateUpdate {
+                    key: key.clone(),
+                    value: serialized,
+                    version: current_version,
+                    actor: self_name.to_string(),
+                    timestamp,
+                });
+                debug!(
+                    "Central drain: tenant delta {} ({} inserts, {} evictions, version: {})",
+                    model_id,
+                    delta.inserts.len(),
+                    delta.evictions.len(),
+                    current_version,
+                );
+                emitted_tree_keys.insert(key);
+            }
+        }
+    }
+
+    if !updates.is_empty() {
+        let total_bytes: usize = updates.iter().map(|u| u.value.len()).sum();
+        debug!(
+            "Central drain: {} tenant delta updates ({} bytes total)",
+            updates.len(),
+            total_bytes,
+        );
+    }
+
+    DrainedTenantDeltas {
+        updates,
+        emitted_tree_keys,
+        tree_gen_snapshot: tree_gen,
     }
 }
 

--- a/crates/mesh/src/incremental.rs
+++ b/crates/mesh/src/incremental.rs
@@ -91,9 +91,10 @@ pub struct IncrementalUpdateCollector {
     collected_tree_gen: Arc<RwLock<u64>>,
     /// Counter for gossip rounds since last full structure snapshot per model.
     rounds_since_snapshot: Arc<RwLock<HashMap<String, u64>>>,
-    /// Pre-drained tenant deltas from the central drain. When set, the Policy
-    /// Phase 0 uses these instead of destructively draining from the shared
-    /// DashMap. This fixes the v1 bug where only the first peer receives deltas.
+    /// Shared reference to centrally drained tenant deltas. When the inner
+    /// Option is Some, Policy Phase 0 uses these instead of destructively
+    /// draining from the shared DashMap. Set by the gossip event loop once
+    /// per round, read by all per-peer collectors.
     central_deltas: Arc<RwLock<Option<DrainedTenantDeltas>>>,
 }
 
@@ -110,25 +111,23 @@ impl IncrementalUpdateCollector {
         }
     }
 
-    /// Set pre-drained tenant deltas from the central drain. Called once per
-    /// gossip round BEFORE per-peer collection runs. All per-peer collectors
-    /// sharing this instance will use these deltas instead of draining the
-    /// shared DashMap.
-    #[expect(
-        dead_code,
-        reason = "wired up in controller.rs central drain (Step 2b)"
-    )]
-    pub fn set_central_deltas(&self, deltas: DrainedTenantDeltas) {
-        *self.central_deltas.write() = Some(deltas);
-    }
-
-    /// Clear the central deltas after all per-peer senders have consumed them.
-    #[expect(
-        dead_code,
-        reason = "wired up in controller.rs central drain (Step 2b)"
-    )]
-    pub fn clear_central_deltas(&self) {
-        *self.central_deltas.write() = None;
+    /// Create a collector that shares a central deltas reference with other
+    /// collectors. The gossip event loop sets deltas on the shared reference
+    /// once per round; all collectors see the same data.
+    pub fn with_shared_central_deltas(
+        stores: Arc<StateStores>,
+        self_name: String,
+        central_deltas: Arc<RwLock<Option<DrainedTenantDeltas>>>,
+    ) -> Self {
+        Self {
+            stores,
+            self_name,
+            last_sent: Arc::new(RwLock::new(LastSentVersions::default())),
+            last_scanned: Arc::new(RwLock::new(LastScannedGenerations::default())),
+            collected_tree_gen: Arc::new(RwLock::new(0)),
+            rounds_since_snapshot: Arc::new(RwLock::new(HashMap::new())),
+            central_deltas,
+        }
     }
 
     /// Get current timestamp in nanoseconds
@@ -669,7 +668,6 @@ pub struct DrainedTenantDeltas {
 /// Drains tenant delta buffers exactly once per gossip round. The result is
 /// stored in a shared location so all per-peer collectors can include the
 /// same deltas without racing on the destructive DashMap remove.
-#[expect(dead_code, reason = "wired up in controller.rs event loop (Step 2b)")]
 pub fn drain_tenant_deltas_central(stores: &StateStores, self_name: &str) -> DrainedTenantDeltas {
     let tree_gen = stores.tree_generation.load(Ordering::Acquire);
     let timestamp = IncrementalUpdateCollector::current_timestamp();

--- a/crates/mesh/src/incremental.rs
+++ b/crates/mesh/src/incremental.rs
@@ -1387,4 +1387,243 @@ mod tests {
         let version3 = updates3[0].version;
         assert_eq!(version3, 3);
     }
+
+    // ========================================================================
+    // Multi-peer delivery tests (v2 bug fix verification)
+    // ========================================================================
+
+    use crate::tree_ops::TenantInsert;
+
+    fn insert_tenant_delta(stores: &StateStores, model_id: &str, hash: u64) {
+        stores
+            .tenant_delta_inserts
+            .entry(model_id.to_string())
+            .or_default()
+            .push(TenantInsert {
+                node_path_hash: hash,
+                worker_url: "http://w1:8000".to_string(),
+                epoch: 0,
+            });
+        stores.bump_tree_version(&format!("tree:{model_id}"));
+    }
+
+    /// Regression test for v1 per-peer collector bug: tenant deltas were
+    /// destructively drained from the shared DashMap, so only the first peer's
+    /// collector received them. This test verifies that with CentralCollector
+    /// + PeerWatermark, ALL peers see the same deltas.
+    #[test]
+    fn test_all_peers_receive_tenant_deltas() {
+        let stores = Arc::new(StateStores::with_self_name("node1".to_string()));
+
+        // Simulate a tree insert producing a tenant delta
+        insert_tenant_delta(&stores, "model-x", 0xABCD);
+        insert_tenant_delta(&stores, "model-x", 0xBEEF);
+        insert_tenant_delta(&stores, "model-y", 0xDEAD);
+
+        // Central collector runs once per round
+        let central = CentralCollector::new(stores.clone(), "node1".to_string());
+        let batch = central.collect();
+
+        // Three simulated peers, each with their own watermark
+        let mut peer_a = PeerWatermark::new("peer-a".to_string());
+        let mut peer_b = PeerWatermark::new("peer-b".to_string());
+        let mut peer_c = PeerWatermark::new("peer-c".to_string());
+
+        // All three peers see the same tenant delta updates from the batch
+        let a_updates = peer_a.filter(&batch);
+        let b_updates = peer_b.filter(&batch);
+        let c_updates = peer_c.filter(&batch);
+
+        // Helper: count tree:* entries (tenant deltas)
+        let count_tree_updates = |updates: &[(StoreType, Vec<StateUpdate>)]| -> usize {
+            updates
+                .iter()
+                .flat_map(|(_, v)| v.iter())
+                .filter(|u| u.key.starts_with("tree:"))
+                .count()
+        };
+
+        let a_tree = count_tree_updates(&a_updates);
+        let b_tree = count_tree_updates(&b_updates);
+        let c_tree = count_tree_updates(&c_updates);
+
+        assert_eq!(
+            a_tree, 2,
+            "peer-a should see 2 tenant deltas (model-x and model-y)"
+        );
+        assert_eq!(
+            b_tree, 2,
+            "peer-b should see 2 tenant deltas (v1 bug: only peer-a would see them)"
+        );
+        assert_eq!(c_tree, 2, "peer-c should see 2 tenant deltas");
+
+        // After each peer marks their updates as sent, a second collect
+        // (no new changes) should return nothing for those peers.
+        for (store_type, updates) in &a_updates {
+            peer_a.mark_sent(*store_type, updates);
+        }
+        for (store_type, updates) in &b_updates {
+            peer_b.mark_sent(*store_type, updates);
+        }
+        for (store_type, updates) in &c_updates {
+            peer_c.mark_sent(*store_type, updates);
+        }
+    }
+
+    #[test]
+    fn test_peer_watermark_filters_by_version() {
+        let stores = Arc::new(StateStores::with_self_name("node1".to_string()));
+
+        let _ = stores.worker.insert(
+            "worker:1".to_string(),
+            WorkerState {
+                worker_id: "worker:1".to_string(),
+                model_id: "model1".to_string(),
+                url: "http://localhost:8000".to_string(),
+                health: true,
+                load: 0.0,
+                version: 5,
+                spec: vec![],
+            },
+        );
+
+        let central = CentralCollector::new(stores.clone(), "node1".to_string());
+        let batch = central.collect();
+
+        let mut peer_a = PeerWatermark::new("peer-a".to_string());
+
+        // First filter: peer-a has no watermark, gets the update
+        let updates1 = peer_a.filter(&batch);
+        assert_eq!(updates1.len(), 1);
+        assert_eq!(updates1[0].1.len(), 1);
+        assert_eq!(updates1[0].1[0].version, 5);
+
+        // Mark sent: peer-a's watermark is now at version 5
+        for (store_type, updates) in &updates1 {
+            peer_a.mark_sent(*store_type, updates);
+        }
+
+        // Second filter: peer-a already has version 5, filtered out
+        let updates2 = peer_a.filter(&batch);
+        assert_eq!(
+            updates2.iter().flat_map(|(_, v)| v.iter()).count(),
+            0,
+            "peer-a should filter out already-sent versions"
+        );
+    }
+
+    #[test]
+    fn test_peers_with_different_watermarks() {
+        let stores = Arc::new(StateStores::with_self_name("node1".to_string()));
+
+        // Two workers, one at version 3, one at version 7
+        let _ = stores.worker.insert(
+            "worker:1".to_string(),
+            WorkerState {
+                worker_id: "worker:1".to_string(),
+                model_id: "m1".to_string(),
+                url: "http://w1:8000".to_string(),
+                health: true,
+                load: 0.0,
+                version: 3,
+                spec: vec![],
+            },
+        );
+        let _ = stores.worker.insert(
+            "worker:2".to_string(),
+            WorkerState {
+                worker_id: "worker:2".to_string(),
+                model_id: "m2".to_string(),
+                url: "http://w2:8000".to_string(),
+                health: true,
+                load: 0.0,
+                version: 7,
+                spec: vec![],
+            },
+        );
+
+        let central = CentralCollector::new(stores.clone(), "node1".to_string());
+        let batch = central.collect();
+
+        // peer-a is at worker:1 v=3, worker:2 v=0 (new)
+        // peer-b is at worker:1 v=0 (new), worker:2 v=7 (caught up)
+        let mut peer_a = PeerWatermark::new("peer-a".to_string());
+        let mut peer_b = PeerWatermark::new("peer-b".to_string());
+
+        // Seed peer_a's watermark: already has worker:1 v=3, missing worker:2
+        peer_a.mark_sent(
+            StoreType::Worker,
+            &[StateUpdate {
+                key: "worker:1".to_string(),
+                value: vec![],
+                version: 3,
+                actor: "node1".to_string(),
+                timestamp: 0,
+            }],
+        );
+        // Seed peer_b's watermark: already has worker:2 v=7, missing worker:1
+        peer_b.mark_sent(
+            StoreType::Worker,
+            &[StateUpdate {
+                key: "worker:2".to_string(),
+                value: vec![],
+                version: 7,
+                actor: "node1".to_string(),
+                timestamp: 0,
+            }],
+        );
+
+        let a_updates = peer_a.filter(&batch);
+        let b_updates = peer_b.filter(&batch);
+
+        // peer_a: only worker:2 is new (v=7 > 0)
+        let a_keys: Vec<String> = a_updates
+            .iter()
+            .flat_map(|(_, v)| v.iter().map(|u| u.key.clone()))
+            .collect();
+        assert_eq!(a_keys, vec!["worker:2"], "peer-a should only get worker:2");
+
+        // peer_b: only worker:1 is new (v=3 > 0)
+        let b_keys: Vec<String> = b_updates
+            .iter()
+            .flat_map(|(_, v)| v.iter().map(|u| u.key.clone()))
+            .collect();
+        assert_eq!(b_keys, vec!["worker:1"], "peer-b should only get worker:1");
+    }
+
+    #[test]
+    fn test_central_collector_drains_tenant_deltas_once() {
+        let stores = Arc::new(StateStores::with_self_name("node1".to_string()));
+        insert_tenant_delta(&stores, "model-x", 0xABCD);
+
+        let central = CentralCollector::new(stores.clone(), "node1".to_string());
+
+        // First collect: drains tenant deltas
+        let batch1 = central.collect();
+        let tree_updates_1: usize = batch1
+            .updates
+            .iter()
+            .flat_map(|(_, v)| v.iter())
+            .filter(|u| u.key.starts_with("tree:"))
+            .count();
+        assert_eq!(
+            tree_updates_1, 1,
+            "first collect should drain the tenant delta"
+        );
+
+        // Second collect (no new changes): tenant deltas already drained, so no tree updates
+        // (but generation hasn't changed, so Policy store is skipped entirely)
+        central.advance_generations();
+        let batch2 = central.collect();
+        let tree_updates_2: usize = batch2
+            .updates
+            .iter()
+            .flat_map(|(_, v)| v.iter())
+            .filter(|u| u.key.starts_with("tree:"))
+            .count();
+        assert_eq!(
+            tree_updates_2, 0,
+            "second collect should have no tenant deltas"
+        );
+    }
 }

--- a/crates/mesh/src/ping_server.rs
+++ b/crates/mesh/src/ping_server.rs
@@ -449,7 +449,10 @@ impl Gossip for GossipService {
             let tx_incremental = tx.clone();
             let self_name_incremental = self_name.clone();
             let size_validator_clone = size_validator.clone();
-            let peer_name_for_watermark = self_name.clone();
+            // The remote peer's name isn't known until the first stream message
+            // arrives. Use a placeholder label for debug output — this doesn't
+            // affect filtering correctness (each task has its own watermark).
+            let peer_name_for_watermark = "server-inbound".to_string();
             #[expect(
                 clippy::disallowed_methods,
                 reason = "server-side incremental sender that runs for the lifetime of the sync_stream; terminates when the channel closes or handle is aborted"

--- a/crates/mesh/src/ping_server.rs
+++ b/crates/mesh/src/ping_server.rs
@@ -39,6 +39,7 @@ use super::{
     stores::{StateStores, StoreType as LocalStoreType},
     sync::MeshSyncManager,
 };
+use crate::incremental::{PeerWatermark, RoundBatch};
 
 #[derive(Debug)]
 pub struct GossipService {
@@ -54,7 +55,7 @@ pub struct GossipService {
     /// Shared reference to the current RoundBatch, updated once per round by
     /// the MeshController's central collector. Server-side sync_stream handlers
     /// read from this and apply per-peer watermark filtering.
-    current_batch: Option<Arc<parking_lot::RwLock<Arc<super::incremental::RoundBatch>>>>,
+    current_batch: Option<Arc<parking_lot::RwLock<Arc<RoundBatch>>>>,
 }
 
 impl GossipService {
@@ -289,7 +290,7 @@ impl GossipService {
     /// their own IncrementalUpdateCollector.
     pub fn with_current_batch(
         mut self,
-        current_batch: Arc<parking_lot::RwLock<Arc<super::incremental::RoundBatch>>>,
+        current_batch: Arc<parking_lot::RwLock<Arc<RoundBatch>>>,
     ) -> Self {
         self.current_batch = Some(current_batch);
         self
@@ -454,8 +455,6 @@ impl Gossip for GossipService {
                 reason = "server-side incremental sender that runs for the lifetime of the sync_stream; terminates when the channel closes or handle is aborted"
             )]
             Some(tokio::spawn(async move {
-                use super::incremental::PeerWatermark;
-
                 let mut watermark = PeerWatermark::new(peer_name_for_watermark);
                 let mut interval = tokio::time::interval(Duration::from_secs(1));
                 let mut sequence_counter: u64 = 0;

--- a/crates/mesh/src/ping_server.rs
+++ b/crates/mesh/src/ping_server.rs
@@ -18,7 +18,6 @@ use tracing::instrument;
 
 use super::{
     flow_control::{MessageSizeValidator, MAX_MESSAGE_SIZE},
-    incremental::IncrementalUpdateCollector,
     metrics::{
         record_ack, record_batch_sent, record_nack, record_peer_reconnect, record_snapshot_bytes,
         record_snapshot_duration, record_snapshot_trigger, update_peer_connections,
@@ -52,6 +51,10 @@ pub struct GossipService {
     state_machine: Option<Arc<NodeStateMachine>>,
     partition_detector: Option<Arc<PartitionDetector>>,
     mtls_manager: Option<Arc<MTLSManager>>,
+    /// Shared reference to the current RoundBatch, updated once per round by
+    /// the MeshController's central collector. Server-side sync_stream handlers
+    /// read from this and apply per-peer watermark filtering.
+    current_batch: Option<Arc<parking_lot::RwLock<Arc<super::incremental::RoundBatch>>>>,
 }
 
 impl GossipService {
@@ -277,7 +280,19 @@ impl GossipService {
             state_machine: None,
             partition_detector: None,
             mtls_manager: None,
+            current_batch: None,
         }
+    }
+
+    /// Attach the shared RoundBatch reference from the MeshController.
+    /// Server-side sync_stream handlers will use this instead of creating
+    /// their own IncrementalUpdateCollector.
+    pub fn with_current_batch(
+        mut self,
+        current_batch: Arc<parking_lot::RwLock<Arc<super::incremental::RoundBatch>>>,
+    ) -> Self {
+        self.current_batch = Some(current_batch);
+        self
     }
 
     pub fn with_stores(mut self, stores: Arc<StateStores>) -> Self {
@@ -425,33 +440,32 @@ impl Gossip for GossipService {
         let (tx, rx) = mpsc::channel::<Result<StreamMessage, Status>>(CHANNEL_CAPACITY);
         let size_validator = MessageSizeValidator::default();
 
-        // Create incremental update collector if stores are available
-        let collector = stores.as_ref().map(|stores| {
-            Arc::new(IncrementalUpdateCollector::new(
-                stores.clone(),
-                self_name.clone(),
-            ))
-        });
-
-        // Spawn task to periodically send incremental updates
-        let incremental_sender_handle = if let Some(collector) = collector {
+        // Spawn task to periodically send incremental updates.
+        // Uses PeerWatermark reading from the shared RoundBatch (central collector).
+        // If current_batch is not set (e.g., temporary GossipService for snapshots),
+        // skip the sender task.
+        let incremental_sender_handle = if let Some(batch_handle) = self.current_batch.clone() {
             let tx_incremental = tx.clone();
             let self_name_incremental = self_name.clone();
             let size_validator_clone = size_validator.clone();
+            let peer_name_for_watermark = self_name.clone();
             #[expect(
                 clippy::disallowed_methods,
                 reason = "server-side incremental sender that runs for the lifetime of the sync_stream; terminates when the channel closes or handle is aborted"
             )]
             Some(tokio::spawn(async move {
-                // Use 1 second interval for rate limit counter sync (faster than other stores)
-                let mut interval = tokio::time::interval(Duration::from_secs(1)); // Send every 1 second
+                use super::incremental::PeerWatermark;
+
+                let mut watermark = PeerWatermark::new(peer_name_for_watermark);
+                let mut interval = tokio::time::interval(Duration::from_secs(1));
                 let mut sequence_counter: u64 = 0;
 
                 loop {
                     interval.tick().await;
 
-                    // Collect all incremental updates
-                    let all_updates = collector.collect_all_updates();
+                    // Read the centrally collected batch and filter by this peer's watermark.
+                    let batch = batch_handle.read().clone();
+                    let all_updates = watermark.filter(&batch);
 
                     if !all_updates.is_empty() {
                         for (store_type, updates) in all_updates {
@@ -469,10 +483,7 @@ impl Gossip for GossipService {
                                     size_validator_clone.max_size()
                                 );
                                 // Mark as sent to prevent infinite retry loop.
-                                // Without this, the same oversized update is re-collected,
-                                // re-serialized, and re-skipped every second forever,
-                                // burning CPU and memory.
-                                collector.mark_sent(store_type, &updates);
+                                watermark.mark_sent(store_type, &updates);
                                 continue;
                             }
 
@@ -489,20 +500,16 @@ impl Gossip for GossipService {
                                 peer_id: self_name_incremental.clone(),
                             };
 
-                            // Check backpressure using try_send (mpsc::Sender doesn't have len())
+                            // Check backpressure using try_send
                             match tx_incremental.try_send(Ok(incremental_update)) {
                                 Ok(()) => {
-                                    // Successfully queued
-                                    // Record metrics
                                     record_batch_sent(&self_name_incremental, batch_size);
-                                    // Mark as sent after successful transmission
-                                    collector.mark_sent(store_type, &updates);
+                                    watermark.mark_sent(store_type, &updates);
                                 }
                                 Err(mpsc::error::TrySendError::Full(_)) => {
                                     log::debug!(
                                         "Backpressure: channel full, skipping send (will retry next interval)"
                                     );
-                                    // Don't mark as sent, will retry next interval
                                     continue;
                                 }
                                 Err(mpsc::error::TrySendError::Closed(_)) => {
@@ -932,6 +939,7 @@ impl Gossip for GossipService {
                                         state_machine: None,
                                         partition_detector: None,
                                         mtls_manager: None,
+                                        current_batch: None,
                                     };
                                     let chunks = service.create_snapshot_chunks(store_type, 100); // chunk_size = 100 entries
                                     let total_chunks = chunks.len() as u64;

--- a/crates/mesh/src/service.rs
+++ b/crates/mesh/src/service.rs
@@ -435,6 +435,12 @@ impl MeshServer {
             .clone()
             .expect("partition detector missing");
 
+        // Build controller first so we can share its current_batch with the
+        // server-side sync_stream handlers. This ensures both client-side
+        // (outgoing connections) and server-side (incoming connections) use
+        // the same centrally collected RoundBatch.
+        let controller = self.build_controller();
+
         let mut service = self.build_ping_server();
         service = service.with_stores(self.stores.clone());
 
@@ -442,12 +448,14 @@ impl MeshServer {
 
         service = service.with_partition_detector(partition_detector);
 
+        // Share the controller's current_batch so server-side sync_stream
+        // handlers use the same centrally collected data as client-side.
+        service = service.with_current_batch(controller.current_batch());
+
         // Add mTLS support if configured
         if let Some(mtls_manager) = self.mtls_manager.clone() {
             service = service.with_mtls_manager(mtls_manager);
         }
-
-        let controller = self.build_controller();
 
         let mut service_shutdown = self.signal_rx.clone();
 

--- a/crates/mesh/src/sync.rs
+++ b/crates/mesh/src/sync.rs
@@ -885,9 +885,13 @@ mod tests {
     };
 
     use super::*;
-    use crate::stores::{
-        AppState, MembershipState, RateLimitConfig, StateStores, GLOBAL_RATE_LIMIT_COUNTER_KEY,
-        GLOBAL_RATE_LIMIT_KEY,
+    use crate::{
+        incremental::CentralCollector,
+        service::gossip::StateUpdate,
+        stores::{
+            AppState, MembershipState, RateLimitConfig, StateStores, StoreType,
+            GLOBAL_RATE_LIMIT_COUNTER_KEY, GLOBAL_RATE_LIMIT_KEY,
+        },
     };
 
     fn create_test_sync_manager() -> MeshSyncManager {
@@ -1831,11 +1835,22 @@ mod tests {
         );
     }
 
+    /// Test-only helper: collect Policy updates via CentralCollector.
+    /// Skips PeerWatermark since these tests don't exercise watermark filtering.
+    fn collect_policy_updates(stores: Arc<StateStores>, self_name: &str) -> Vec<StateUpdate> {
+        let central = CentralCollector::new(stores, self_name.to_string());
+        let batch = central.collect();
+        batch
+            .updates
+            .into_iter()
+            .find(|(t, _)| *t == StoreType::Policy)
+            .map(|(_, v)| v)
+            .unwrap_or_default()
+    }
+
     #[test]
     fn test_collector_sends_tenant_delta() {
-        use crate::{
-            incremental::IncrementalUpdateCollector, stores::StoreType, tree_ops::TenantDelta,
-        };
+        use crate::tree_ops::TenantDelta;
 
         let stores = Arc::new(StateStores::with_self_name("node1".to_string()));
         let manager = MeshSyncManager::new(stores.clone(), "node1".to_string());
@@ -1848,8 +1863,7 @@ mod tests {
             )
             .unwrap();
 
-        let collector = IncrementalUpdateCollector::new(stores.clone(), "node1".to_string());
-        let updates = collector.collect_updates_for_store(StoreType::Policy);
+        let updates = collect_policy_updates(stores.clone(), "node1");
 
         assert!(!updates.is_empty(), "expected at least one policy update");
 
@@ -1881,8 +1895,6 @@ mod tests {
 
     #[test]
     fn test_collector_falls_back_to_full_state() {
-        use crate::{incremental::IncrementalUpdateCollector, stores::StoreType};
-
         let stores = Arc::new(StateStores::with_self_name("node1".to_string()));
 
         // Directly insert a tree state into tree_configs WITHOUT going through
@@ -1899,8 +1911,7 @@ mod tests {
         // Bump tree_generation so the collector's tree_changed check fires.
         stores.bump_tree_version("tree:model1");
 
-        let collector = IncrementalUpdateCollector::new(stores.clone(), "node1".to_string());
-        let updates = collector.collect_updates_for_store(StoreType::Policy);
+        let updates = collect_policy_updates(stores.clone(), "node1");
 
         assert!(!updates.is_empty(), "expected at least one policy update");
 
@@ -1984,8 +1995,6 @@ mod tests {
         // Simulate a reconnected peer scenario: tree_configs has a materialized
         // tree state but tenant delta buffers are empty.  The collector should
         // produce a full PolicyState (lz4-compressed), not a delta.
-        use crate::{incremental::IncrementalUpdateCollector, stores::StoreType};
-
         let stores = Arc::new(StateStores::with_self_name("node1".to_string()));
 
         // Directly insert a tree state into tree_configs (simulating a
@@ -2005,9 +2014,8 @@ mod tests {
         stores.tenant_delta_inserts.remove("model1");
         stores.tenant_delta_evictions.remove("model1");
 
-        // New collector (simulating reconnected peer)
-        let collector = IncrementalUpdateCollector::new(stores.clone(), "node1".to_string());
-        let updates = collector.collect_updates_for_store(StoreType::Policy);
+        // Collect via v2 central collector (simulating reconnected peer)
+        let updates = collect_policy_updates(stores.clone(), "node1");
 
         assert!(!updates.is_empty(), "expected at least one update");
 
@@ -2147,8 +2155,6 @@ mod tests {
         // Simultaneously run the collector.  The collector should get a
         // consistent snapshot — either some ops or all ops, but never
         // corrupted data.
-        use crate::{incremental::IncrementalUpdateCollector, stores::StoreType};
-
         let stores = Arc::new(StateStores::with_self_name("node1".to_string()));
         let manager = Arc::new(MeshSyncManager::new(stores.clone(), "node1".to_string()));
 
@@ -2167,8 +2173,7 @@ mod tests {
         // Collect multiple times while writer is active
         let mut collected_any = false;
         for _ in 0..10 {
-            let collector = IncrementalUpdateCollector::new(stores.clone(), "node1".to_string());
-            let updates = collector.collect_updates_for_store(StoreType::Policy);
+            let updates = collect_policy_updates(stores.clone(), "node1");
             for update in &updates {
                 if update.key.starts_with("tree:") {
                     // Verify the data deserializes without corruption
@@ -2198,8 +2203,7 @@ mod tests {
         writer.join().unwrap();
 
         // After writer finishes, one final collect should succeed
-        let collector = IncrementalUpdateCollector::new(stores.clone(), "node1".to_string());
-        let final_updates = collector.collect_updates_for_store(StoreType::Policy);
+        let final_updates = collect_policy_updates(stores.clone(), "node1");
         if !collected_any {
             // Writer may have been too fast; at least final collection must succeed
             assert!(

--- a/crates/mesh/src/sync.rs
+++ b/crates/mesh/src/sync.rs
@@ -885,13 +885,9 @@ mod tests {
     };
 
     use super::*;
-    use crate::{
-        incremental::CentralCollector,
-        service::gossip::StateUpdate,
-        stores::{
-            AppState, MembershipState, RateLimitConfig, StateStores, StoreType,
-            GLOBAL_RATE_LIMIT_COUNTER_KEY, GLOBAL_RATE_LIMIT_KEY,
-        },
+    use crate::stores::{
+        AppState, MembershipState, RateLimitConfig, StateStores, GLOBAL_RATE_LIMIT_COUNTER_KEY,
+        GLOBAL_RATE_LIMIT_KEY,
     };
 
     fn create_test_sync_manager() -> MeshSyncManager {
@@ -1835,22 +1831,11 @@ mod tests {
         );
     }
 
-    /// Test-only helper: collect Policy updates via CentralCollector.
-    /// Skips PeerWatermark since these tests don't exercise watermark filtering.
-    fn collect_policy_updates(stores: Arc<StateStores>, self_name: &str) -> Vec<StateUpdate> {
-        let central = CentralCollector::new(stores, self_name.to_string());
-        let batch = central.collect();
-        batch
-            .updates
-            .into_iter()
-            .find(|(t, _)| *t == StoreType::Policy)
-            .map(|(_, v)| v)
-            .unwrap_or_default()
-    }
-
     #[test]
     fn test_collector_sends_tenant_delta() {
-        use crate::tree_ops::TenantDelta;
+        use crate::{
+            incremental::IncrementalUpdateCollector, stores::StoreType, tree_ops::TenantDelta,
+        };
 
         let stores = Arc::new(StateStores::with_self_name("node1".to_string()));
         let manager = MeshSyncManager::new(stores.clone(), "node1".to_string());
@@ -1863,7 +1848,8 @@ mod tests {
             )
             .unwrap();
 
-        let updates = collect_policy_updates(stores.clone(), "node1");
+        let collector = IncrementalUpdateCollector::new(stores.clone(), "node1".to_string());
+        let updates = collector.collect_updates_for_store(StoreType::Policy);
 
         assert!(!updates.is_empty(), "expected at least one policy update");
 
@@ -1895,6 +1881,8 @@ mod tests {
 
     #[test]
     fn test_collector_falls_back_to_full_state() {
+        use crate::{incremental::IncrementalUpdateCollector, stores::StoreType};
+
         let stores = Arc::new(StateStores::with_self_name("node1".to_string()));
 
         // Directly insert a tree state into tree_configs WITHOUT going through
@@ -1911,7 +1899,8 @@ mod tests {
         // Bump tree_generation so the collector's tree_changed check fires.
         stores.bump_tree_version("tree:model1");
 
-        let updates = collect_policy_updates(stores.clone(), "node1");
+        let collector = IncrementalUpdateCollector::new(stores.clone(), "node1".to_string());
+        let updates = collector.collect_updates_for_store(StoreType::Policy);
 
         assert!(!updates.is_empty(), "expected at least one policy update");
 
@@ -1995,6 +1984,8 @@ mod tests {
         // Simulate a reconnected peer scenario: tree_configs has a materialized
         // tree state but tenant delta buffers are empty.  The collector should
         // produce a full PolicyState (lz4-compressed), not a delta.
+        use crate::{incremental::IncrementalUpdateCollector, stores::StoreType};
+
         let stores = Arc::new(StateStores::with_self_name("node1".to_string()));
 
         // Directly insert a tree state into tree_configs (simulating a
@@ -2014,8 +2005,9 @@ mod tests {
         stores.tenant_delta_inserts.remove("model1");
         stores.tenant_delta_evictions.remove("model1");
 
-        // Collect via v2 central collector (simulating reconnected peer)
-        let updates = collect_policy_updates(stores.clone(), "node1");
+        // New collector (simulating reconnected peer)
+        let collector = IncrementalUpdateCollector::new(stores.clone(), "node1".to_string());
+        let updates = collector.collect_updates_for_store(StoreType::Policy);
 
         assert!(!updates.is_empty(), "expected at least one update");
 
@@ -2155,6 +2147,8 @@ mod tests {
         // Simultaneously run the collector.  The collector should get a
         // consistent snapshot — either some ops or all ops, but never
         // corrupted data.
+        use crate::{incremental::IncrementalUpdateCollector, stores::StoreType};
+
         let stores = Arc::new(StateStores::with_self_name("node1".to_string()));
         let manager = Arc::new(MeshSyncManager::new(stores.clone(), "node1".to_string()));
 
@@ -2173,7 +2167,8 @@ mod tests {
         // Collect multiple times while writer is active
         let mut collected_any = false;
         for _ in 0..10 {
-            let updates = collect_policy_updates(stores.clone(), "node1");
+            let collector = IncrementalUpdateCollector::new(stores.clone(), "node1".to_string());
+            let updates = collector.collect_updates_for_store(StoreType::Policy);
             for update in &updates {
                 if update.key.starts_with("tree:") {
                     // Verify the data deserializes without corruption
@@ -2203,7 +2198,8 @@ mod tests {
         writer.join().unwrap();
 
         // After writer finishes, one final collect should succeed
-        let final_updates = collect_policy_updates(stores.clone(), "node1");
+        let collector = IncrementalUpdateCollector::new(stores.clone(), "node1".to_string());
+        let final_updates = collector.collect_updates_for_store(StoreType::Policy);
         if !collected_any {
             // Writer may have been too fast; at least final collection must succeed
             assert!(


### PR DESCRIPTION
## Description

### Problem

The current mesh gossip code uses **per-peer sender tasks** — each connected peer has its own `IncrementalUpdateCollector` that independently collects and sends updates. This causes a critical bug: tenant deltas are destructively drained from shared DashMaps (`tenant_delta_inserts`, `tenant_delta_evictions`), so only the **first** peer's collector gets them. Other peers miss deltas entirely and rely on the full tree_configs snapshot (Phase 2) for convergence.

#### The v1 bug — per-peer collectors race on a shared DashMap:

```
Shared DashMap (one per gateway node):
  "td:model-x" -> delta_bytes_1
  "td:model-y" -> delta_bytes_2

Three peers connected: B, C, D
Each has its own collector task.

T=1.000s  Collector-for-B runs first
          Drains DashMap -> gets delta_bytes_1, delta_bytes_2
          DashMap is now EMPTY
          Sends deltas to peer B                    ✓

T=1.001s  Collector-for-C runs next
          Drains DashMap -> gets NOTHING (already empty!)
          Sends nothing to peer C                   ✗ missed!

T=1.002s  Collector-for-D runs next
          Drains DashMap -> gets NOTHING
          Sends nothing to peer D                   ✗ missed!
```

Source: spec section 5.4.

### Solution

Refactor to a **centralized gossip loop** following spec section 5.4:
- One `CentralCollector` runs per round, constructs one `RoundBatch`.
- Per-peer senders use `PeerWatermark` to filter the shared batch.
- The destructive tenant delta drain happens exactly once per round.
- Per-peer watermarks still apply (each peer's \"what I already sent you\" stays independent).

#### v2 centralized fix — collect once, fan out to all peers:

```
Every 1 second on Gateway A:

  [CENTRAL - one pass]
  1. Drain DashMap ONCE -> get all deltas
  2. Collect all store changes -> build RoundBatch
  3. Store RoundBatch in shared Arc<RwLock<Arc<RoundBatch>>>

  [PER-PEER - just filter and send, no collection]
  to B: PeerWatermark filters batch by B's watermark → send
  to C: PeerWatermark filters batch by C's watermark → send
  to D: PeerWatermark filters batch by D's watermark → send

  All three peers see the same deltas because the batch is shared.
```

#### How per-peer watermarks work:

Each peer has a different view of what they've already received. The central batch has everything; each peer filters to their own delta:

```
Central batch this round:
  worker:7 version=5
  worker:3 version=8
  rl:global version=12

Peer A's watermark: {worker:7: 5, worker:3: 6, rl:global: 10}
  → send worker:3 (8 > 6) and rl:global (12 > 10)
  → skip worker:7 (5 = 5, already sent)

Peer B's watermark: {worker:7: 3, worker:3: 8, rl:global: 12}
  → send worker:7 (5 > 3)
  → skip worker:3 and rl:global (already sent)
```

#### \"Central\" means one per gateway node, NOT one for the whole cluster:

Each gateway runs its own central collector independently. There's no leader, no single point of coordination:

```
Gateway A                    Gateway B                    Gateway C
  |                            |                            |
  Central Collector A          Central Collector B          Central Collector C
  (runs every 1s)              (runs every 1s)              (runs every 1s)
  |                            |                            |
  Drains A's local             Drains B's local             Drains C's local
  changes, sends               changes, sends               changes, sends
  to B and C                   to A and C                   to A and B
```

If Gateway A dies: B and C detect it via SWIM, keep gossiping with each other using their own collectors.

## Changes

- **`incremental.rs`**:
  - New `CentralCollector` struct: collects from all stores once per round. Produces a `RoundBatch`.
  - New `PeerWatermark` struct: filters a `RoundBatch` by per-peer last-sent versions, tracks `mark_sent`.
  - New `RoundBatch` type: shared batch of updates organized by store type.
  - Legacy `IncrementalUpdateCollector` kept behind `cfg_attr(not(test), allow(dead_code))` for sync.rs tests; TODO to migrate in Step 2c.
  - `current_timestamp()` and `rate_limit_last_sent_key()` lifted to module-level so both legacy and v2 code share them.
- **`controller.rs`**:
  - `MeshController` holds `Arc<CentralCollector>` and `Arc<RwLock<Arc<RoundBatch>>>`.
  - Event loop calls `central_collector.collect()` once per round, stores result in `current_batch`, then `advance_generations()`.
  - `spawn_sync_stream_handler` uses `PeerWatermark` reading from the shared batch instead of creating a per-peer `IncrementalUpdateCollector`.
  - Exposes `current_batch()` getter for sharing with `GossipService`.
- **`ping_server.rs`**:
  - `GossipService` has optional `current_batch` field + `with_current_batch()` builder.
  - Server-side sync_stream handler uses `PeerWatermark` reading from the shared batch.
- **`service.rs`**:
  - `MeshServer::start_inner` builds the controller first, then shares `controller.current_batch()` with the `GossipService` so client-side (outgoing) and server-side (incoming) handlers see the same centrally collected data.

## Test Plan

4 new tests in \`incremental::tests\`:
- \`test_all_peers_receive_tenant_deltas\`: regression test for the v1 bug. Verifies three peers all see the same tenant deltas from one central collect.
- \`test_peer_watermark_filters_by_version\`: PeerWatermark filters out already-sent versions.
- \`test_peers_with_different_watermarks\`: two peers at different watermark positions receive only the entries they're missing.
- \`test_central_collector_drains_tenant_deltas_once\`: tenant deltas drained exactly once per round.

\`\`\`
cargo test -p smg-mesh     # 199 tests passing (up from 195)
cargo clippy -p smg-mesh -- -D warnings    # clean
\`\`\`

<details>
<summary>Checklist</summary>

- [x] \`cargo +nightly fmt\` passes
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Sync now uses a single centrally-collected round batch shared by outgoing and incoming handlers, eliminating duplicate per-peer collection and ensuring consistent per-round state.
  * Per-peer senders compute incremental updates by filtering that shared batch with per-peer watermarks and advance watermarks on send.

* **New Features**
  * Server-side sync handlers can opt into the shared round batch to receive centrally batched updates.

* **Tests**
  * Added multi-peer regression tests validating delta visibility, per-peer watermark/version filtering, and single-round draining.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->