### PR TITLE
feat(mesh): ChunkAssembler with memory bounds and proto wire-format (v2 Step 3 part 1)

### DIFF
--- a/crates/mesh/src/chunk_assembler.rs
+++ b/crates/mesh/src/chunk_assembler.rs
@@ -15,7 +15,10 @@
 // items, which makes `#[expect(dead_code)]` unfulfilled under test cfg.
 #![allow(dead_code)]
 
-use std::time::{Duration, Instant};
+use std::{
+    cmp::Ordering,
+    time::{Duration, Instant},
+};
 
 use dashmap::DashMap;
 
@@ -119,8 +122,18 @@ impl ChunkAssembler {
                 .entry(key.to_string())
                 .or_insert_with(|| AssemblyState::new(generation, total));
 
-            if entry.generation != generation || entry.chunks.len() != total as usize {
-                *entry = AssemblyState::new(generation, total);
+            match generation.cmp(&entry.generation) {
+                Ordering::Greater => {
+                    *entry = AssemblyState::new(generation, total);
+                }
+                Ordering::Less => {
+                    return None;
+                }
+                Ordering::Equal => {
+                    if entry.chunks.len() != total as usize {
+                        return None;
+                    }
+                }
             }
 
             entry.received[index as usize] = true;
@@ -256,6 +269,25 @@ mod tests {
         assert!(asm.receive_chunk("k", 6, 0, 2, b"new-0".to_vec()).is_none());
         let out = asm.receive_chunk("k", 6, 1, 2, b"new-1".to_vec()).unwrap();
         assert_eq!(out, b"new-0new-1");
+    }
+
+    #[test]
+    fn test_delayed_older_generation_chunk_is_dropped() {
+        let asm = ChunkAssembler::new();
+        // gen=6 starts and records one chunk.
+        assert!(asm.receive_chunk("k", 6, 0, 2, b"new-0".to_vec()).is_none());
+
+        // A delayed gen=5 chunk arrives — must NOT reset the gen=6 state.
+        assert!(asm
+            .receive_chunk("k", 5, 0, 3, b"stale-0".to_vec())
+            .is_none());
+
+        // Completing gen=6 must still yield the gen=6 payload.
+        let out = asm.receive_chunk("k", 6, 1, 2, b"new-1".to_vec()).unwrap();
+        assert_eq!(
+            out, b"new-0new-1",
+            "stale older chunk must not overwrite newer state"
+        );
     }
 
     #[test]

--- a/crates/mesh/src/chunk_assembler.rs
+++ b/crates/mesh/src/chunk_assembler.rs
@@ -48,7 +48,11 @@ pub struct ChunkAssembler {
 
 struct AssemblyState {
     generation: u64,
-    received: Vec<bool>,
+    /// Count of distinct chunk indices recorded so far. Incremented only
+    /// when a previously-empty slot is filled, so repeated receives of
+    /// the same (generation, index) don't over-count. Completion is
+    /// `received_count == chunks.len()`.
+    received_count: u32,
     chunks: Vec<Option<Vec<u8>>>,
     created_at: Instant,
 }
@@ -58,23 +62,23 @@ impl AssemblyState {
         let n = total as usize;
         Self {
             generation,
-            received: vec![false; n],
+            received_count: 0,
             chunks: vec![None; n],
             created_at: Instant::now(),
         }
     }
 
     fn is_complete(&self) -> bool {
-        self.received.iter().all(|&r| r)
+        self.received_count as usize == self.chunks.len()
     }
 
     /// Total receiver-side memory footprint of this assembly — chunk
-    /// payloads plus the per-slot overhead of the `received` and
-    /// `chunks` vectors. Included in the byte cap so the cap bounds
-    /// real memory, not just payload bytes.
+    /// payloads plus the per-slot overhead of the `chunks` vector.
+    /// Included in the byte cap so the cap bounds real memory, not
+    /// just payload bytes.
     fn bytes_held(&self) -> usize {
         let payload: usize = self.chunks.iter().flatten().map(|c| c.len()).sum();
-        let overhead = self.chunks.len() * (size_of::<bool>() + size_of::<Option<Vec<u8>>>());
+        let overhead = self.chunks.len() * size_of::<Option<Vec<u8>>>();
         payload + overhead
     }
 
@@ -147,7 +151,9 @@ impl ChunkAssembler {
                 }
             }
 
-            entry.received[index as usize] = true;
+            if entry.chunks[index as usize].is_none() {
+                entry.received_count += 1;
+            }
             entry.chunks[index as usize] = Some(data);
 
             entry.is_complete()
@@ -349,7 +355,7 @@ mod tests {
             "complete".to_string(),
             AssemblyState {
                 generation: 1,
-                received: vec![true, true],
+                received_count: 2,
                 chunks: vec![Some(vec![0u8; 10]), Some(vec![0u8; 10])],
                 created_at: old,
             },
@@ -374,7 +380,7 @@ mod tests {
             "k".to_string(),
             AssemblyState {
                 generation: 1,
-                received: vec![false, false],
+                received_count: 0,
                 chunks: vec![None, None],
                 created_at: old,
             },
@@ -386,7 +392,7 @@ mod tests {
             "k".to_string(),
             AssemblyState {
                 generation: 2,
-                received: vec![false, false],
+                received_count: 0,
                 chunks: vec![None, None],
                 created_at: Instant::now(),
             },
@@ -480,7 +486,7 @@ mod tests {
             "complete".to_string(),
             AssemblyState {
                 generation: 1,
-                received: vec![true, true],
+                received_count: 2,
                 chunks: vec![Some(vec![0u8; 10]), Some(vec![0u8; 10])],
                 created_at: old,
             },

--- a/crates/mesh/src/chunk_assembler.rs
+++ b/crates/mesh/src/chunk_assembler.rs
@@ -181,14 +181,17 @@ impl ChunkAssembler {
     /// after each non-completing receive; the completing path removes its
     /// own entry before returning, so no enforcement is needed there.
     fn enforce_bounds(&self) {
-        // Eviction candidates: only partial assemblies. Completed ones are
-        // owned by a concurrent receive_chunk that is about to extract
-        // them via remove_if; evicting them here would silently swallow a
-        // fully-assembled payload. The remove_if predicate additionally
-        // gates on the generation observed at selection time, so a
-        // concurrent generation bump that substitutes a new incomplete
-        // state does not get evicted by mistake.
-        while self.assemblies.len() > self.max_concurrent {
+        // Cap checks and eviction target only incomplete assemblies;
+        // transiently-complete entries awaiting remove_if must not count.
+        loop {
+            let incomplete = self
+                .assemblies
+                .iter()
+                .filter(|e| !e.value().is_complete())
+                .count();
+            if incomplete <= self.max_concurrent {
+                break;
+            }
             match self.oldest_incomplete() {
                 Some((k, gen)) => {
                     self.assemblies.remove_if(&k, |_, state| {
@@ -199,7 +202,12 @@ impl ChunkAssembler {
             }
         }
         loop {
-            let total: usize = self.assemblies.iter().map(|e| e.value().bytes_held()).sum();
+            let total: usize = self
+                .assemblies
+                .iter()
+                .filter(|e| !e.value().is_complete())
+                .map(|e| e.value().bytes_held())
+                .sum();
             if total <= self.max_bytes {
                 break;
             }
@@ -481,34 +489,110 @@ mod tests {
 
     #[test]
     fn test_enforce_bounds_skips_complete_assemblies() {
-        // Simulate the race window: a just-completed assembly sits in
-        // the map (before the owning receive_chunk extracts it), and a
-        // concurrent receive_chunk on a different key triggers
-        // enforce_bounds. The complete one must survive.
+        // cap=1, one complete + two partials. Real incomplete=2 > 1,
+        // so enforce_bounds must evict one. The complete must not be
+        // picked even though it is the oldest by created_at.
         let asm = ChunkAssembler::with_limits(1, usize::MAX);
-        let old = Instant::now() - Duration::from_secs(60);
         asm.assemblies.insert(
             "complete".to_string(),
             AssemblyState {
                 generation: 1,
                 received_count: 2,
                 chunks: vec![Some(vec![0u8; 10]), Some(vec![0u8; 10])],
-                created_at: old,
+                created_at: Instant::now() - Duration::from_secs(60),
             },
         );
-        // Add a partial — this is over the cap=1, so enforce_bounds runs
-        // (via the !completed branch of receive_chunk).
-        assert!(asm
-            .receive_chunk("partial", 1, 0, 2, vec![0u8; 10])
-            .is_none());
+        asm.assemblies.insert(
+            "partial_a".to_string(),
+            AssemblyState {
+                generation: 1,
+                received_count: 0,
+                chunks: vec![None, None],
+                created_at: Instant::now() - Duration::from_secs(30),
+            },
+        );
+        asm.assemblies.insert(
+            "partial_b".to_string(),
+            AssemblyState {
+                generation: 1,
+                received_count: 0,
+                chunks: vec![None, None],
+                created_at: Instant::now(),
+            },
+        );
+
+        asm.enforce_bounds();
 
         assert!(
             asm.assemblies.contains_key("complete"),
-            "complete assembly must not be evicted"
+            "complete (even oldest) must not be evicted"
         );
         assert!(
-            !asm.assemblies.contains_key("partial"),
-            "partial (the only incomplete candidate) should be evicted"
+            !asm.assemblies.contains_key("partial_a"),
+            "oldest incomplete should be evicted"
+        );
+        assert!(
+            asm.assemblies.contains_key("partial_b"),
+            "newer incomplete survives"
+        );
+    }
+
+    #[test]
+    fn test_enforce_bounds_cap_counts_only_incomplete() {
+        // Transient complete-but-unextracted entries must not push the
+        // incomplete population over cap. Here the cap is 1, and we
+        // preload a complete entry + a partial. enforce_bounds should
+        // see 1 incomplete (<=1), not 2 total, and leave the partial
+        // alone.
+        let asm = ChunkAssembler::with_limits(1, usize::MAX);
+        asm.assemblies.insert(
+            "complete".to_string(),
+            AssemblyState {
+                generation: 1,
+                received_count: 2,
+                chunks: vec![Some(vec![0u8; 10]), Some(vec![0u8; 10])],
+                created_at: Instant::now(),
+            },
+        );
+        asm.assemblies.insert(
+            "partial".to_string(),
+            AssemblyState {
+                generation: 1,
+                received_count: 1,
+                chunks: vec![Some(vec![0u8; 10]), None],
+                created_at: Instant::now(),
+            },
+        );
+
+        // Triggering enforce_bounds from the !completed branch by
+        // receiving a new chunk on a third key would add another
+        // partial and push us over. Instead, exercise enforce_bounds
+        // directly via a receive that creates a partial but doesn't
+        // complete — against cap=1, two incompletes should evict one.
+        // But with the transient "complete" entry counted: previous
+        // logic would evict *partial* (as oldest incomplete) when it
+        // saw len=2 > 1, even though the real incomplete count was 1.
+
+        // Build the initial state manually so we can observe the
+        // filter-based count without triggering a receive.
+        let incomplete_count = asm
+            .assemblies
+            .iter()
+            .filter(|e| !e.value().is_complete())
+            .count();
+        assert_eq!(incomplete_count, 1, "only 'partial' is incomplete");
+
+        // Call enforce_bounds directly (via a no-op receive path).
+        // With the fix: incomplete=1 <= cap=1, so no eviction.
+        asm.enforce_bounds();
+
+        assert!(
+            asm.assemblies.contains_key("complete"),
+            "complete assembly still present"
+        );
+        assert!(
+            asm.assemblies.contains_key("partial"),
+            "partial must not be evicted — real incomplete count was under cap"
         );
     }
 

--- a/crates/mesh/src/chunk_assembler.rs
+++ b/crates/mesh/src/chunk_assembler.rs
@@ -23,8 +23,8 @@ use std::{
 
 use dashmap::DashMap;
 
-/// Max concurrent in-flight assemblies. Caps the fan-out a misbehaving
-/// peer can induce by streaming chunks for unlimited unique keys.
+/// Max concurrent in-flight assemblies. Prevents a peer from flooding
+/// the map with partial assemblies for unique keys that never complete.
 pub const DEFAULT_MAX_CONCURRENT_ASSEMBLIES: usize = 20;
 
 /// Max total bytes held across all in-flight assemblies. Caps the
@@ -107,10 +107,11 @@ impl ChunkAssembler {
     /// Record an incoming chunk. Returns `Some(assembled)` once all chunks
     /// for the current generation have arrived; returns `None` otherwise.
     ///
-    /// A chunk whose `generation` differs from the in-flight state resets
-    /// the assembly — older-generation partials are discarded in favour
-    /// of the new version. Malformed chunks are dropped silently:
-    /// `total == 0`, `total > MAX_TOTAL_CHUNKS`, or `index >= total`.
+    /// Generation handling is a three-way compare: a newer generation
+    /// resets the state (older partials discarded), an older generation
+    /// is dropped (newer state kept), equal continues recording.
+    /// Malformed chunks are dropped silently: `total == 0`,
+    /// `total > MAX_TOTAL_CHUNKS`, or `index >= total`.
     pub fn receive_chunk(
         &self,
         key: &str,

--- a/crates/mesh/src/chunk_assembler.rs
+++ b/crates/mesh/src/chunk_assembler.rs
@@ -174,10 +174,15 @@ impl ChunkAssembler {
     /// after each non-completing receive; the completing path removes its
     /// own entry before returning, so no enforcement is needed there.
     fn enforce_bounds(&self) {
+        // Eviction candidates: only partial assemblies. Completed ones are
+        // owned by a concurrent receive_chunk that is about to extract
+        // them via remove_if; evicting them here would silently swallow a
+        // fully-assembled payload.
         while self.assemblies.len() > self.max_concurrent {
-            match self.oldest_key() {
+            match self.oldest_incomplete_key() {
                 Some(k) => {
-                    self.assemblies.remove(&k);
+                    self.assemblies
+                        .remove_if(&k, |_, state| !state.is_complete());
                 }
                 None => break,
             }
@@ -187,25 +192,28 @@ impl ChunkAssembler {
             if total <= self.max_bytes {
                 break;
             }
-            match self.largest_key() {
+            match self.largest_incomplete_key() {
                 Some(k) => {
-                    self.assemblies.remove(&k);
+                    self.assemblies
+                        .remove_if(&k, |_, state| !state.is_complete());
                 }
                 None => break,
             }
         }
     }
 
-    fn oldest_key(&self) -> Option<String> {
+    fn oldest_incomplete_key(&self) -> Option<String> {
         self.assemblies
             .iter()
+            .filter(|e| !e.value().is_complete())
             .min_by_key(|e| e.value().created_at)
             .map(|e| e.key().clone())
     }
 
-    fn largest_key(&self) -> Option<String> {
+    fn largest_incomplete_key(&self) -> Option<String> {
         self.assemblies
             .iter()
+            .filter(|e| !e.value().is_complete())
             .max_by_key(|e| e.value().bytes_held())
             .map(|e| e.key().clone())
     }
@@ -390,6 +398,39 @@ mod tests {
         assert!(
             !asm.assemblies.contains_key("k_big"),
             "largest partial (k_big) should be evicted"
+        );
+    }
+
+    #[test]
+    fn test_enforce_bounds_skips_complete_assemblies() {
+        // Simulate the race window: a just-completed assembly sits in
+        // the map (before the owning receive_chunk extracts it), and a
+        // concurrent receive_chunk on a different key triggers
+        // enforce_bounds. The complete one must survive.
+        let asm = ChunkAssembler::with_limits(1, usize::MAX);
+        let old = Instant::now() - Duration::from_secs(60);
+        asm.assemblies.insert(
+            "complete".to_string(),
+            AssemblyState {
+                generation: 1,
+                received: vec![true, true],
+                chunks: vec![Some(vec![0u8; 10]), Some(vec![0u8; 10])],
+                created_at: old,
+            },
+        );
+        // Add a partial — this is over the cap=1, so enforce_bounds runs
+        // (via the !completed branch of receive_chunk).
+        assert!(asm
+            .receive_chunk("partial", 1, 0, 2, vec![0u8; 10])
+            .is_none());
+
+        assert!(
+            asm.assemblies.contains_key("complete"),
+            "complete assembly must not be evicted"
+        );
+        assert!(
+            !asm.assemblies.contains_key("partial"),
+            "partial (the only incomplete candidate) should be evicted"
         );
     }
 

--- a/crates/mesh/src/chunk_assembler.rs
+++ b/crates/mesh/src/chunk_assembler.rs
@@ -184,12 +184,16 @@ impl ChunkAssembler {
         // Eviction candidates: only partial assemblies. Completed ones are
         // owned by a concurrent receive_chunk that is about to extract
         // them via remove_if; evicting them here would silently swallow a
-        // fully-assembled payload.
+        // fully-assembled payload. The remove_if predicate additionally
+        // gates on the generation observed at selection time, so a
+        // concurrent generation bump that substitutes a new incomplete
+        // state does not get evicted by mistake.
         while self.assemblies.len() > self.max_concurrent {
-            match self.oldest_incomplete_key() {
-                Some(k) => {
-                    self.assemblies
-                        .remove_if(&k, |_, state| !state.is_complete());
+            match self.oldest_incomplete() {
+                Some((k, gen)) => {
+                    self.assemblies.remove_if(&k, |_, state| {
+                        state.generation == gen && !state.is_complete()
+                    });
                 }
                 None => break,
             }
@@ -199,30 +203,31 @@ impl ChunkAssembler {
             if total <= self.max_bytes {
                 break;
             }
-            match self.largest_incomplete_key() {
-                Some(k) => {
-                    self.assemblies
-                        .remove_if(&k, |_, state| !state.is_complete());
+            match self.largest_incomplete() {
+                Some((k, gen)) => {
+                    self.assemblies.remove_if(&k, |_, state| {
+                        state.generation == gen && !state.is_complete()
+                    });
                 }
                 None => break,
             }
         }
     }
 
-    fn oldest_incomplete_key(&self) -> Option<String> {
+    fn oldest_incomplete(&self) -> Option<(String, u64)> {
         self.assemblies
             .iter()
             .filter(|e| !e.value().is_complete())
             .min_by_key(|e| e.value().created_at)
-            .map(|e| e.key().clone())
+            .map(|e| (e.key().clone(), e.value().generation))
     }
 
-    fn largest_incomplete_key(&self) -> Option<String> {
+    fn largest_incomplete(&self) -> Option<(String, u64)> {
         self.assemblies
             .iter()
             .filter(|e| !e.value().is_complete())
             .max_by_key(|e| e.value().bytes_held())
-            .map(|e| e.key().clone())
+            .map(|e| (e.key().clone(), e.value().generation))
     }
 
     /// Drop partial assemblies older than `timeout`. Collect-then-remove
@@ -504,6 +509,57 @@ mod tests {
         assert!(
             !asm.assemblies.contains_key("partial"),
             "partial (the only incomplete candidate) should be evicted"
+        );
+    }
+
+    #[test]
+    fn test_enforce_bounds_spares_newer_generation_replacement() {
+        // Simulate the race: enforce_bounds selects key "k" with
+        // generation 5, but before the remove_if fires, another thread
+        // resets "k" to generation 6. The generation-gated predicate
+        // must spare the replacement. We emulate the race in-process
+        // by splitting selection from removal via the private helper.
+        let asm = ChunkAssembler::with_limits(1, usize::MAX);
+
+        // Insert a stale generation-5 partial as the eviction target.
+        asm.assemblies.insert(
+            "k".to_string(),
+            AssemblyState {
+                generation: 5,
+                received_count: 0,
+                chunks: vec![None, None],
+                created_at: Instant::now() - Duration::from_secs(60),
+            },
+        );
+
+        // Enforcement picks this key + generation.
+        let (k, gen) = asm.oldest_incomplete().expect("have an incomplete");
+        assert_eq!(k, "k");
+        assert_eq!(gen, 5);
+
+        // Racing thread replaces the state with a fresh generation-6.
+        asm.assemblies.insert(
+            "k".to_string(),
+            AssemblyState {
+                generation: 6,
+                received_count: 0,
+                chunks: vec![None, None],
+                created_at: Instant::now(),
+            },
+        );
+
+        // The delayed remove_if must NOT evict the generation-6 state.
+        asm.assemblies.remove_if(&k, |_, state| {
+            state.generation == gen && !state.is_complete()
+        });
+
+        let survived = asm
+            .assemblies
+            .get("k")
+            .expect("newer-generation replacement must survive");
+        assert_eq!(
+            survived.generation, 6,
+            "evicted stale gen 5 instead of sparing gen 6"
         );
     }
 

--- a/crates/mesh/src/chunk_assembler.rs
+++ b/crates/mesh/src/chunk_assembler.rs
@@ -19,8 +19,18 @@ use std::time::{Duration, Instant};
 
 use dashmap::DashMap;
 
+/// Max concurrent in-flight assemblies. Caps the fan-out a misbehaving
+/// peer can induce by streaming chunks for unlimited unique keys.
+pub const DEFAULT_MAX_CONCURRENT_ASSEMBLIES: usize = 20;
+
+/// Max total bytes held across all in-flight assemblies. Caps the
+/// receiver-side memory independently of any sender-side payload choice.
+pub const DEFAULT_MAX_ASSEMBLER_BYTES: usize = 512 * 1024 * 1024;
+
 pub struct ChunkAssembler {
     assemblies: DashMap<String, AssemblyState>,
+    max_concurrent: usize,
+    max_bytes: usize,
 }
 
 struct AssemblyState {
@@ -45,8 +55,12 @@ impl AssemblyState {
         self.received.iter().all(|&r| r)
     }
 
+    fn bytes_held(&self) -> usize {
+        self.chunks.iter().flatten().map(|c| c.len()).sum()
+    }
+
     fn assemble(&self) -> Vec<u8> {
-        let total_size: usize = self.chunks.iter().flatten().map(|c| c.len()).sum();
+        let total_size: usize = self.bytes_held();
         let mut out = Vec::with_capacity(total_size);
         for chunk in self.chunks.iter().flatten() {
             out.extend_from_slice(chunk);
@@ -57,8 +71,17 @@ impl AssemblyState {
 
 impl ChunkAssembler {
     pub fn new() -> Self {
+        Self::with_limits(
+            DEFAULT_MAX_CONCURRENT_ASSEMBLIES,
+            DEFAULT_MAX_ASSEMBLER_BYTES,
+        )
+    }
+
+    pub fn with_limits(max_concurrent: usize, max_bytes: usize) -> Self {
         Self {
             assemblies: DashMap::new(),
+            max_concurrent,
+            max_bytes,
         }
     }
 
@@ -103,8 +126,52 @@ impl ChunkAssembler {
 
         if assembled.is_some() {
             self.assemblies.remove(key);
+        } else {
+            self.enforce_bounds();
         }
         assembled
+    }
+
+    /// Evict partials until the receiver-side memory bounds are satisfied.
+    /// Over the concurrent-assembly cap: drop the oldest (by created_at).
+    /// Over the byte cap: drop the largest (by total bytes held). Checked
+    /// after each non-completing receive; the completing path removes its
+    /// own entry before returning, so no enforcement is needed there.
+    fn enforce_bounds(&self) {
+        while self.assemblies.len() > self.max_concurrent {
+            match self.oldest_key() {
+                Some(k) => {
+                    self.assemblies.remove(&k);
+                }
+                None => break,
+            }
+        }
+        loop {
+            let total: usize = self.assemblies.iter().map(|e| e.value().bytes_held()).sum();
+            if total <= self.max_bytes {
+                break;
+            }
+            match self.largest_key() {
+                Some(k) => {
+                    self.assemblies.remove(&k);
+                }
+                None => break,
+            }
+        }
+    }
+
+    fn oldest_key(&self) -> Option<String> {
+        self.assemblies
+            .iter()
+            .min_by_key(|e| e.value().created_at)
+            .map(|e| e.key().clone())
+    }
+
+    fn largest_key(&self) -> Option<String> {
+        self.assemblies
+            .iter()
+            .max_by_key(|e| e.value().bytes_held())
+            .map(|e| e.key().clone())
     }
 
     /// Drop partial assemblies older than `timeout`. Collect-then-remove
@@ -124,6 +191,11 @@ impl ChunkAssembler {
     #[cfg(test)]
     pub(crate) fn in_flight(&self) -> usize {
         self.assemblies.len()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn total_bytes(&self) -> usize {
+        self.assemblies.iter().map(|e| e.value().bytes_held()).sum()
     }
 }
 
@@ -201,6 +273,58 @@ mod tests {
         let asm = ChunkAssembler::new();
         assert!(asm.receive_chunk("k", 1, 0, 0, b"x".to_vec()).is_none());
         assert!(asm.receive_chunk("k", 1, 5, 3, b"x".to_vec()).is_none());
+        assert_eq!(asm.in_flight(), 0);
+    }
+
+    #[test]
+    fn test_bounds_evict_oldest_when_too_many_concurrent() {
+        let asm = ChunkAssembler::with_limits(3, usize::MAX);
+        // 4 partials against a cap of 3 — oldest must be evicted.
+        for i in 0..4 {
+            assert!(asm
+                .receive_chunk(&format!("k{i}"), 1, 0, 2, vec![0u8; 10])
+                .is_none());
+            thread::sleep(Duration::from_millis(1));
+        }
+        assert_eq!(asm.in_flight(), 3, "concurrent cap enforced");
+        assert!(
+            !asm.assemblies.contains_key("k0"),
+            "oldest partial (k0) should be evicted"
+        );
+    }
+
+    #[test]
+    fn test_bounds_evict_largest_when_over_byte_cap() {
+        let asm = ChunkAssembler::with_limits(usize::MAX, 100);
+        // Build three partials: k_big is the largest (60 bytes),
+        // k_med is 30, k_small is 20. Total 110 > cap 100.
+        assert!(asm
+            .receive_chunk("k_small", 1, 0, 2, vec![0u8; 20])
+            .is_none());
+        assert!(asm.receive_chunk("k_med", 1, 0, 2, vec![0u8; 30]).is_none());
+        assert!(asm.receive_chunk("k_big", 1, 0, 2, vec![0u8; 60]).is_none());
+
+        assert!(
+            asm.total_bytes() <= 100,
+            "byte cap enforced, total = {}",
+            asm.total_bytes()
+        );
+        assert!(
+            !asm.assemblies.contains_key("k_big"),
+            "largest partial (k_big) should be evicted"
+        );
+    }
+
+    #[test]
+    fn test_bounds_not_enforced_on_completion() {
+        // If receive_chunk completes an assembly, the entry leaves the
+        // map before bounds are checked — the just-completed value must
+        // still be returned regardless of size.
+        let asm = ChunkAssembler::with_limits(usize::MAX, 10);
+        let out = asm
+            .receive_chunk("k", 1, 0, 1, vec![0u8; 500])
+            .expect("single-chunk completion returns bytes");
+        assert_eq!(out.len(), 500);
         assert_eq!(asm.in_flight(), 0);
     }
 

--- a/crates/mesh/src/chunk_assembler.rs
+++ b/crates/mesh/src/chunk_assembler.rs
@@ -219,16 +219,22 @@ impl ChunkAssembler {
     }
 
     /// Drop partial assemblies older than `timeout`. Collect-then-remove
-    /// to avoid holding DashMap shard locks during mutation.
+    /// to avoid holding DashMap shard locks during mutation, and each
+    /// removal re-checks the timeout so a concurrent receive that reset
+    /// the entry to a new generation (fresh created_at) is spared.
+    /// Complete assemblies are also skipped — they belong to an in-flight
+    /// receive_chunk that is about to extract them via remove_if.
     pub fn gc(&self, timeout: Duration) {
         let expired: Vec<String> = self
             .assemblies
             .iter()
-            .filter(|e| e.value().created_at.elapsed() >= timeout)
+            .filter(|e| e.value().created_at.elapsed() >= timeout && !e.value().is_complete())
             .map(|e| e.key().clone())
             .collect();
         for key in expired {
-            self.assemblies.remove(&key);
+            self.assemblies.remove_if(&key, |_, state| {
+                state.created_at.elapsed() >= timeout && !state.is_complete()
+            });
         }
     }
 
@@ -329,6 +335,66 @@ mod tests {
         assert!(asm.receive_chunk("k", 1, 0, 3, b"aaa".to_vec()).is_none());
         asm.gc(Duration::from_secs(10));
         assert_eq!(asm.in_flight(), 1, "recent partial should survive gc");
+    }
+
+    #[test]
+    fn test_gc_skips_complete_assemblies() {
+        // A complete assembly sitting in the map (before its owning
+        // receive_chunk extracts it) must not be removed by gc even if
+        // the timeout would otherwise apply.
+        let asm = ChunkAssembler::new();
+        let old = Instant::now() - Duration::from_secs(60);
+        asm.assemblies.insert(
+            "complete".to_string(),
+            AssemblyState {
+                generation: 1,
+                received: vec![true, true],
+                chunks: vec![Some(vec![0u8; 10]), Some(vec![0u8; 10])],
+                created_at: old,
+            },
+        );
+        asm.gc(Duration::from_secs(1));
+        assert!(
+            asm.assemblies.contains_key("complete"),
+            "gc must not remove a complete assembly"
+        );
+    }
+
+    #[test]
+    fn test_gc_rechecks_timeout_at_remove() {
+        // After the collect phase marks a key as expired, simulate a
+        // concurrent receive_chunk replacing that entry with fresh
+        // created_at by inserting a young state under the same key
+        // between collect and remove. The remove_if predicate re-checks
+        // timeout and spares the young entry.
+        let asm = ChunkAssembler::new();
+        let old = Instant::now() - Duration::from_secs(60);
+        asm.assemblies.insert(
+            "k".to_string(),
+            AssemblyState {
+                generation: 1,
+                received: vec![false, false],
+                chunks: vec![None, None],
+                created_at: old,
+            },
+        );
+        // Simulate the concurrent reset before gc fires by overwriting
+        // with a fresh state — this is what the TOCTOU window allowed
+        // before the fix.
+        asm.assemblies.insert(
+            "k".to_string(),
+            AssemblyState {
+                generation: 2,
+                received: vec![false, false],
+                chunks: vec![None, None],
+                created_at: Instant::now(),
+            },
+        );
+        asm.gc(Duration::from_secs(1));
+        assert!(
+            asm.assemblies.contains_key("k"),
+            "freshly-reset entry must survive gc"
+        );
     }
 
     #[test]

--- a/crates/mesh/src/chunk_assembler.rs
+++ b/crates/mesh/src/chunk_assembler.rs
@@ -1,0 +1,222 @@
+//! Receiver-side chunk reassembly for oversized stream entries.
+//!
+//! Stream values that exceed the gRPC message size budget are split into
+//! bounded chunks on the sender and reassembled here on the receiver.
+//! Tree repair pages do NOT use this path — they are emitted already
+//! bounded (≤ max_tree_repair_page_bytes) and ride the single-message
+//! fast path.
+//!
+//! Semantics are at-most-once: if a chunk is lost, the partial assembly
+//! is GC'd after `timeout`, and the application regenerates the value
+//! on its next retry cycle. No retries or watermarks.
+
+// Items are wired into the gossip receive path in a follow-up commit in
+// this Step 3 PR. Allow (not expect) because tests already exercise the
+// items, which makes `#[expect(dead_code)]` unfulfilled under test cfg.
+#![allow(dead_code)]
+
+use std::time::{Duration, Instant};
+
+use dashmap::DashMap;
+
+pub struct ChunkAssembler {
+    assemblies: DashMap<String, AssemblyState>,
+}
+
+struct AssemblyState {
+    generation: u64,
+    received: Vec<bool>,
+    chunks: Vec<Option<Vec<u8>>>,
+    created_at: Instant,
+}
+
+impl AssemblyState {
+    fn new(generation: u64, total: u32) -> Self {
+        let n = total as usize;
+        Self {
+            generation,
+            received: vec![false; n],
+            chunks: vec![None; n],
+            created_at: Instant::now(),
+        }
+    }
+
+    fn is_complete(&self) -> bool {
+        self.received.iter().all(|&r| r)
+    }
+
+    fn assemble(&self) -> Vec<u8> {
+        let total_size: usize = self.chunks.iter().flatten().map(|c| c.len()).sum();
+        let mut out = Vec::with_capacity(total_size);
+        for chunk in self.chunks.iter().flatten() {
+            out.extend_from_slice(chunk);
+        }
+        out
+    }
+}
+
+impl ChunkAssembler {
+    pub fn new() -> Self {
+        Self {
+            assemblies: DashMap::new(),
+        }
+    }
+
+    /// Record an incoming chunk. Returns `Some(assembled)` once all chunks
+    /// for the current generation have arrived; returns `None` otherwise.
+    ///
+    /// A chunk whose `generation` differs from the in-flight state resets
+    /// the assembly — older-generation partials are discarded in favour
+    /// of the new version. Malformed chunks (total == 0, index >= total)
+    /// are dropped silently.
+    pub fn receive_chunk(
+        &self,
+        key: &str,
+        generation: u64,
+        index: u32,
+        total: u32,
+        data: Vec<u8>,
+    ) -> Option<Vec<u8>> {
+        if total == 0 || index >= total {
+            return None;
+        }
+
+        let assembled = {
+            let mut entry = self
+                .assemblies
+                .entry(key.to_string())
+                .or_insert_with(|| AssemblyState::new(generation, total));
+
+            if entry.generation != generation || entry.chunks.len() != total as usize {
+                *entry = AssemblyState::new(generation, total);
+            }
+
+            entry.received[index as usize] = true;
+            entry.chunks[index as usize] = Some(data);
+
+            if entry.is_complete() {
+                Some(entry.assemble())
+            } else {
+                None
+            }
+        };
+
+        if assembled.is_some() {
+            self.assemblies.remove(key);
+        }
+        assembled
+    }
+
+    /// Drop partial assemblies older than `timeout`. Collect-then-remove
+    /// to avoid holding DashMap shard locks during mutation.
+    pub fn gc(&self, timeout: Duration) {
+        let expired: Vec<String> = self
+            .assemblies
+            .iter()
+            .filter(|e| e.value().created_at.elapsed() >= timeout)
+            .map(|e| e.key().clone())
+            .collect();
+        for key in expired {
+            self.assemblies.remove(&key);
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn in_flight(&self) -> usize {
+        self.assemblies.len()
+    }
+}
+
+impl Default for ChunkAssembler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{thread, time::Duration};
+
+    use super::*;
+
+    #[test]
+    fn test_single_chunk_round_trip() {
+        let asm = ChunkAssembler::new();
+        let out = asm.receive_chunk("k", 1, 0, 1, b"hello".to_vec());
+        assert_eq!(out.as_deref(), Some(b"hello".as_slice()));
+        assert_eq!(asm.in_flight(), 0, "completed assembly should be removed");
+    }
+
+    #[test]
+    fn test_multi_chunk_in_order() {
+        let asm = ChunkAssembler::new();
+        assert!(asm.receive_chunk("k", 1, 0, 3, b"aaa".to_vec()).is_none());
+        assert!(asm.receive_chunk("k", 1, 1, 3, b"bbb".to_vec()).is_none());
+        let out = asm.receive_chunk("k", 1, 2, 3, b"ccc".to_vec()).unwrap();
+        assert_eq!(out, b"aaabbbccc");
+        assert_eq!(asm.in_flight(), 0);
+    }
+
+    #[test]
+    fn test_multi_chunk_out_of_order() {
+        let asm = ChunkAssembler::new();
+        assert!(asm.receive_chunk("k", 1, 2, 3, b"ccc".to_vec()).is_none());
+        assert!(asm.receive_chunk("k", 1, 0, 3, b"aaa".to_vec()).is_none());
+        let out = asm.receive_chunk("k", 1, 1, 3, b"bbb".to_vec()).unwrap();
+        assert_eq!(out, b"aaabbbccc", "chunks must assemble in index order");
+    }
+
+    #[test]
+    fn test_generation_reset_discards_older_partials() {
+        let asm = ChunkAssembler::new();
+        assert!(asm.receive_chunk("k", 5, 0, 3, b"old-0".to_vec()).is_none());
+        assert!(asm.receive_chunk("k", 5, 1, 3, b"old-1".to_vec()).is_none());
+
+        assert!(asm.receive_chunk("k", 6, 0, 2, b"new-0".to_vec()).is_none());
+        let out = asm.receive_chunk("k", 6, 1, 2, b"new-1".to_vec()).unwrap();
+        assert_eq!(out, b"new-0new-1");
+    }
+
+    #[test]
+    fn test_gc_removes_stale_partials() {
+        let asm = ChunkAssembler::new();
+        assert!(asm.receive_chunk("k", 1, 0, 3, b"aaa".to_vec()).is_none());
+        assert_eq!(asm.in_flight(), 1);
+
+        thread::sleep(Duration::from_millis(50));
+        asm.gc(Duration::from_millis(30));
+        assert_eq!(asm.in_flight(), 0, "stale partial should be GC'd");
+    }
+
+    #[test]
+    fn test_gc_keeps_recent_partials() {
+        let asm = ChunkAssembler::new();
+        assert!(asm.receive_chunk("k", 1, 0, 3, b"aaa".to_vec()).is_none());
+        asm.gc(Duration::from_secs(10));
+        assert_eq!(asm.in_flight(), 1, "recent partial should survive gc");
+    }
+
+    #[test]
+    fn test_malformed_chunk_is_dropped() {
+        let asm = ChunkAssembler::new();
+        assert!(asm.receive_chunk("k", 1, 0, 0, b"x".to_vec()).is_none());
+        assert!(asm.receive_chunk("k", 1, 5, 3, b"x".to_vec()).is_none());
+        assert_eq!(asm.in_flight(), 0);
+    }
+
+    #[test]
+    fn test_multiple_keys_independent() {
+        let asm = ChunkAssembler::new();
+        assert!(asm.receive_chunk("a", 1, 0, 2, b"a0".to_vec()).is_none());
+        assert!(asm.receive_chunk("b", 1, 0, 2, b"b0".to_vec()).is_none());
+        assert_eq!(asm.in_flight(), 2);
+
+        let a = asm.receive_chunk("a", 1, 1, 2, b"a1".to_vec()).unwrap();
+        assert_eq!(a, b"a0a1");
+        assert_eq!(asm.in_flight(), 1, "completing a should not touch b");
+
+        let b = asm.receive_chunk("b", 1, 1, 2, b"b1".to_vec()).unwrap();
+        assert_eq!(b, b"b0b1");
+        assert_eq!(asm.in_flight(), 0);
+    }
+}

--- a/crates/mesh/src/chunk_assembler.rs
+++ b/crates/mesh/src/chunk_assembler.rs
@@ -183,43 +183,38 @@ impl ChunkAssembler {
     fn enforce_bounds(&self) {
         // Cap checks and eviction target only incomplete assemblies;
         // transiently-complete entries awaiting remove_if must not count.
-        loop {
-            let incomplete = self
-                .assemblies
-                .iter()
-                .filter(|e| !e.value().is_complete())
-                .count();
-            if incomplete <= self.max_concurrent {
+        while self.incomplete_count() > self.max_concurrent {
+            let Some((k, gen)) = self.oldest_incomplete() else {
                 break;
-            }
-            match self.oldest_incomplete() {
-                Some((k, gen)) => {
-                    self.assemblies.remove_if(&k, |_, state| {
-                        state.generation == gen && !state.is_complete()
-                    });
-                }
-                None => break,
-            }
+            };
+            self.try_evict_stale(&k, gen);
         }
-        loop {
-            let total: usize = self
-                .assemblies
-                .iter()
-                .filter(|e| !e.value().is_complete())
-                .map(|e| e.value().bytes_held())
-                .sum();
-            if total <= self.max_bytes {
+        while self.incomplete_bytes() > self.max_bytes {
+            let Some((k, gen)) = self.largest_incomplete() else {
                 break;
-            }
-            match self.largest_incomplete() {
-                Some((k, gen)) => {
-                    self.assemblies.remove_if(&k, |_, state| {
-                        state.generation == gen && !state.is_complete()
-                    });
-                }
-                None => break,
-            }
+            };
+            self.try_evict_stale(&k, gen);
         }
+    }
+
+    fn incomplete_count(&self) -> usize {
+        self.assemblies
+            .iter()
+            .filter(|e| !e.value().is_complete())
+            .count()
+    }
+
+    fn incomplete_bytes(&self) -> usize {
+        self.assemblies
+            .iter()
+            .filter(|e| !e.value().is_complete())
+            .map(|e| e.value().bytes_held())
+            .sum()
+    }
+
+    fn try_evict_stale(&self, key: &str, gen: u64) {
+        self.assemblies
+            .remove_if(key, |_, s| s.generation == gen && !s.is_complete());
     }
 
     fn oldest_incomplete(&self) -> Option<(String, u64)> {

--- a/crates/mesh/src/chunk_assembler.rs
+++ b/crates/mesh/src/chunk_assembler.rs
@@ -32,8 +32,8 @@ pub const DEFAULT_MAX_CONCURRENT_ASSEMBLIES: usize = 20;
 pub const DEFAULT_MAX_ASSEMBLER_BYTES: usize = 512 * 1024 * 1024;
 
 /// Hard cap on the chunk count advertised by a single chunk header.
-/// AssemblyState allocates `received`/`chunks` vectors sized to `total`,
-/// so an unvalidated peer-supplied `total = u32::MAX` would trigger a
+/// AssemblyState allocates a `chunks` vector sized to `total`, so an
+/// unvalidated peer-supplied `total = u32::MAX` would trigger a
 /// multi-GB allocation before the byte-cap enforcer can react. 1024
 /// chunks × 10 MB/chunk is 10 GB of assembled payload — well past the
 /// byte cap, so bounds still catch any realistic traffic, while the

--- a/crates/mesh/src/chunk_assembler.rs
+++ b/crates/mesh/src/chunk_assembler.rs
@@ -17,6 +17,7 @@
 
 use std::{
     cmp::Ordering,
+    mem::size_of,
     time::{Duration, Instant},
 };
 
@@ -67,8 +68,14 @@ impl AssemblyState {
         self.received.iter().all(|&r| r)
     }
 
+    /// Total receiver-side memory footprint of this assembly — chunk
+    /// payloads plus the per-slot overhead of the `received` and
+    /// `chunks` vectors. Included in the byte cap so the cap bounds
+    /// real memory, not just payload bytes.
     fn bytes_held(&self) -> usize {
-        self.chunks.iter().flatten().map(|c| c.len()).sum()
+        let payload: usize = self.chunks.iter().flatten().map(|c| c.len()).sum();
+        let overhead = self.chunks.len() * (size_of::<bool>() + size_of::<Option<Vec<u8>>>());
+        payload + overhead
     }
 
     fn assemble(self) -> Vec<u8> {
@@ -361,17 +368,22 @@ mod tests {
 
     #[test]
     fn test_bounds_evict_largest_when_over_byte_cap() {
-        let asm = ChunkAssembler::with_limits(usize::MAX, 100);
-        // Build three partials: k_big is the largest (60 bytes),
-        // k_med is 30, k_small is 20. Total 110 > cap 100.
+        // Use payloads large enough that per-assembly vec overhead
+        // (~25 bytes × total_chunks) is negligible relative to payload.
+        let cap = 10_000;
+        let asm = ChunkAssembler::with_limits(usize::MAX, cap);
         assert!(asm
-            .receive_chunk("k_small", 1, 0, 2, vec![0u8; 20])
+            .receive_chunk("k_small", 1, 0, 2, vec![0u8; 2_000])
             .is_none());
-        assert!(asm.receive_chunk("k_med", 1, 0, 2, vec![0u8; 30]).is_none());
-        assert!(asm.receive_chunk("k_big", 1, 0, 2, vec![0u8; 60]).is_none());
+        assert!(asm
+            .receive_chunk("k_med", 1, 0, 2, vec![0u8; 3_000])
+            .is_none());
+        assert!(asm
+            .receive_chunk("k_big", 1, 0, 2, vec![0u8; 6_000])
+            .is_none());
 
         assert!(
-            asm.total_bytes() <= 100,
+            asm.total_bytes() <= cap,
             "byte cap enforced, total = {}",
             asm.total_bytes()
         );

--- a/crates/mesh/src/chunk_assembler.rs
+++ b/crates/mesh/src/chunk_assembler.rs
@@ -245,14 +245,21 @@ impl ChunkAssembler {
     /// Complete assemblies are also skipped — they belong to an in-flight
     /// receive_chunk that is about to extract them via remove_if.
     pub fn gc(&self, timeout: Duration) {
-        let expired: Vec<String> = self
-            .assemblies
+        let expired = self.collect_expired(timeout);
+        self.remove_stale(&expired, timeout);
+    }
+
+    fn collect_expired(&self, timeout: Duration) -> Vec<String> {
+        self.assemblies
             .iter()
             .filter(|e| e.value().created_at.elapsed() >= timeout && !e.value().is_complete())
             .map(|e| e.key().clone())
-            .collect();
-        for key in expired {
-            self.assemblies.remove_if(&key, |_, state| {
+            .collect()
+    }
+
+    fn remove_stale(&self, keys: &[String], timeout: Duration) {
+        for key in keys {
+            self.assemblies.remove_if(key, |_, state| {
                 state.created_at.elapsed() >= timeout && !state.is_complete()
             });
         }
@@ -382,25 +389,28 @@ mod tests {
 
     #[test]
     fn test_gc_rechecks_timeout_at_remove() {
-        // After the collect phase marks a key as expired, simulate a
-        // concurrent receive_chunk replacing that entry with fresh
-        // created_at by inserting a young state under the same key
-        // between collect and remove. The remove_if predicate re-checks
-        // timeout and spares the young entry.
+        // Exercise the real collect→remove race window by driving the
+        // two phases manually. Overwrite the entry between phases; the
+        // remove_if timeout re-check must spare the fresh state.
         let asm = ChunkAssembler::new();
-        let old = Instant::now() - Duration::from_secs(60);
+        let timeout = Duration::from_secs(1);
+
         asm.assemblies.insert(
             "k".to_string(),
             AssemblyState {
                 generation: 1,
                 received_count: 0,
                 chunks: vec![None, None],
-                created_at: old,
+                created_at: Instant::now() - Duration::from_secs(60),
             },
         );
-        // Simulate the concurrent reset before gc fires by overwriting
-        // with a fresh state — this is what the TOCTOU window allowed
-        // before the fix.
+
+        // Phase 1: collect sees the expired entry.
+        let expired = asm.collect_expired(timeout);
+        assert_eq!(expired, vec!["k".to_string()]);
+
+        // Race: a concurrent receive_chunk resets "k" to a fresh
+        // generation before gc's remove phase fires.
         asm.assemblies.insert(
             "k".to_string(),
             AssemblyState {
@@ -410,10 +420,16 @@ mod tests {
                 created_at: Instant::now(),
             },
         );
-        asm.gc(Duration::from_secs(1));
-        assert!(
-            asm.assemblies.contains_key("k"),
-            "freshly-reset entry must survive gc"
+
+        // Phase 2: remove_stale re-checks the timeout predicate; the
+        // fresh entry's created_at is <1s ago, so the predicate fails
+        // and the fresh state is spared.
+        asm.remove_stale(&expired, timeout);
+
+        let survived = asm.assemblies.get("k").expect("fresh entry must survive");
+        assert_eq!(
+            survived.generation, 2,
+            "gc evicted the fresh replacement instead of sparing it"
         );
     }
 

--- a/crates/mesh/src/chunk_assembler.rs
+++ b/crates/mesh/src/chunk_assembler.rs
@@ -27,6 +27,15 @@ pub const DEFAULT_MAX_CONCURRENT_ASSEMBLIES: usize = 20;
 /// receiver-side memory independently of any sender-side payload choice.
 pub const DEFAULT_MAX_ASSEMBLER_BYTES: usize = 512 * 1024 * 1024;
 
+/// Hard cap on the chunk count advertised by a single chunk header.
+/// AssemblyState allocates `received`/`chunks` vectors sized to `total`,
+/// so an unvalidated peer-supplied `total = u32::MAX` would trigger a
+/// multi-GB allocation before the byte-cap enforcer can react. 1024
+/// chunks × 10 MB/chunk is 10 GB of assembled payload — well past the
+/// byte cap, so bounds still catch any realistic traffic, while the
+/// per-assembly vector overhead stays under ~25 KB.
+pub const MAX_TOTAL_CHUNKS: u32 = 1024;
+
 pub struct ChunkAssembler {
     assemblies: DashMap<String, AssemblyState>,
     max_concurrent: usize,
@@ -90,8 +99,8 @@ impl ChunkAssembler {
     ///
     /// A chunk whose `generation` differs from the in-flight state resets
     /// the assembly — older-generation partials are discarded in favour
-    /// of the new version. Malformed chunks (total == 0, index >= total)
-    /// are dropped silently.
+    /// of the new version. Malformed chunks are dropped silently:
+    /// `total == 0`, `total > MAX_TOTAL_CHUNKS`, or `index >= total`.
     pub fn receive_chunk(
         &self,
         key: &str,
@@ -100,7 +109,7 @@ impl ChunkAssembler {
         total: u32,
         data: Vec<u8>,
     ) -> Option<Vec<u8>> {
-        if total == 0 || index >= total {
+        if total == 0 || total > MAX_TOTAL_CHUNKS || index >= total {
             return None;
         }
 
@@ -274,6 +283,24 @@ mod tests {
         assert!(asm.receive_chunk("k", 1, 0, 0, b"x".to_vec()).is_none());
         assert!(asm.receive_chunk("k", 1, 5, 3, b"x".to_vec()).is_none());
         assert_eq!(asm.in_flight(), 0);
+    }
+
+    #[test]
+    fn test_oversized_total_chunks_is_rejected() {
+        let asm = ChunkAssembler::new();
+        // total = u32::MAX would trigger multi-GB allocation if admitted.
+        assert!(asm
+            .receive_chunk("k", 1, 0, u32::MAX, b"x".to_vec())
+            .is_none());
+        // Just past the cap is also rejected.
+        assert!(asm
+            .receive_chunk("k", 1, 0, MAX_TOTAL_CHUNKS + 1, b"x".to_vec())
+            .is_none());
+        assert_eq!(
+            asm.in_flight(),
+            0,
+            "oversized total must not allocate an AssemblyState"
+        );
     }
 
     #[test]

--- a/crates/mesh/src/chunk_assembler.rs
+++ b/crates/mesh/src/chunk_assembler.rs
@@ -71,11 +71,11 @@ impl AssemblyState {
         self.chunks.iter().flatten().map(|c| c.len()).sum()
     }
 
-    fn assemble(&self) -> Vec<u8> {
-        let total_size: usize = self.bytes_held();
+    fn assemble(self) -> Vec<u8> {
+        let total_size: usize = self.chunks.iter().flatten().map(|c| c.len()).sum();
         let mut out = Vec::with_capacity(total_size);
-        for chunk in self.chunks.iter().flatten() {
-            out.extend_from_slice(chunk);
+        for chunk in self.chunks.into_iter().flatten() {
+            out.extend_from_slice(&chunk);
         }
         out
     }
@@ -116,7 +116,10 @@ impl ChunkAssembler {
             return None;
         }
 
-        let assembled = {
+        // Record the chunk under the shard lock. Assembly happens outside
+        // the guard so the lock is not held during the allocation+copy of
+        // the full reassembled buffer.
+        let completed = {
             let mut entry = self
                 .assemblies
                 .entry(key.to_string())
@@ -139,19 +142,23 @@ impl ChunkAssembler {
             entry.received[index as usize] = true;
             entry.chunks[index as usize] = Some(data);
 
-            if entry.is_complete() {
-                Some(entry.assemble())
-            } else {
-                None
-            }
+            entry.is_complete()
         };
 
-        if assembled.is_some() {
-            self.assemblies.remove(key);
-        } else {
+        if !completed {
             self.enforce_bounds();
+            return None;
         }
-        assembled
+
+        // Atomically take ownership only if the state is still our
+        // generation and still complete. If another thread has moved on
+        // (newer generation reset the state after our chunk landed), we
+        // return None — the newer generation is what matters now.
+        self.assemblies
+            .remove_if(key, |_, state| {
+                state.generation == generation && state.is_complete()
+            })
+            .map(|(_, state)| state.assemble())
     }
 
     /// Evict partials until the receiver-side memory bounds are satisfied.

--- a/crates/mesh/src/lib.rs
+++ b/crates/mesh/src/lib.rs
@@ -6,6 +6,7 @@
 //! - Consistent hashing for request routing
 //! - Partition detection and recovery
 
+mod chunk_assembler;
 mod collector;
 mod consistent_hash;
 mod controller;

--- a/crates/mesh/src/proto/gossip.proto
+++ b/crates/mesh/src/proto/gossip.proto
@@ -72,6 +72,7 @@ message StreamMessage {
     SnapshotRequest snapshot_request = 3;
     SnapshotChunk snapshot_chunk = 4;
     StreamAck ack = 5;
+    StreamBatch stream_batch = 8;
   }
   uint64 sequence = 6; // Sequence number for ordering
   string peer_id = 7;   // Sender peer ID
@@ -111,6 +112,24 @@ message StreamAck {
   uint64 sequence = 1;
   bool success = 2;
   string error_message = 3;
+}
+
+// One stream value for a single key. Values that fit in a single gRPC
+// message use total_chunks = 1 and chunk_index = 0. Values exceeding
+// max_message_size are split into N chunks with chunk_index in
+// [0, total_chunks). The receiver reassembles via ChunkAssembler.
+// Tree repair pages MUST stay bounded and always use total_chunks = 1.
+message StreamEntry {
+  string key = 1;
+  uint64 generation = 2;
+  uint32 chunk_index = 3;
+  uint32 total_chunks = 4;
+  bytes data = 5;
+}
+
+// One or more stream entries delivered in a single gossip round.
+message StreamBatch {
+  repeated StreamEntry entries = 1;
 }
 
 enum StoreType {


### PR DESCRIPTION
## Description

### Problem

Step 3 of the mesh v2 migration adds generic transport-level chunking so future stream values that exceed `max_message_size` can ride the mesh (spec §4). Tree repair pages intentionally stay off this path — they're emitted already bounded at ≤ 2 MB per `max_tree_repair_page_bytes`.

The full Step 3 scope spans algorithm, wire format, sender chunking, receiver wiring, and integration tests. This PR lands **Part 1**: the self-contained algorithm and wire-format data contract. Reviewers can assess the reassembly semantics and proto schema without the noise of gossip-loop integration.

### Solution

- **ChunkAssembler** (`chunk_assembler.rs`): receiver-side reassembly buffer per spec §4.3. DashMap keyed by message key; `receive_chunk(key, generation, index, total, data)` returns `Some(assembled)` once all chunks for the current generation land. Generation tag lets the receiver discard older-generation partials mid-flight. Collect-then-remove GC avoids holding DashMap shard locks across mutations.
- **Memory bounds** per spec §4.3 lines 542-553: `MAX_CONCURRENT_ASSEMBLIES = 20` (fan-out cap) and `MAX_ASSEMBLER_BYTES = 512 MB` (total memory cap). Over cap → evict oldest / largest. Iterative until under both bounds.
- **Proto wire format** (`gossip.proto`): `StreamEntry` (key, generation, chunk_index, total_chunks, data) and `StreamBatch` (repeated StreamEntry). Added as a new variant on `StreamMessage.payload` at field 8; existing matches are unaffected.

> **Part 2** (follow-up PR off main after this merges) will add: sender-side chunking in the gossip loop, receiver routing through the assembler, subscriber fire on full assembly, integration tests (large-value round-trip, partial-delivery timeout, concurrent generations, multi-model concurrent assembly), and the tree-path bypass assertion.

## Changes

- `crates/mesh/src/chunk_assembler.rs`: new module, 348 lines. `ChunkAssembler` with `receive_chunk`, `gc(timeout)`, `enforce_bounds`. `AssemblyState` with generation, received bitset, chunks vec, created_at. Module-level `#![allow(dead_code)]` with comment noting the wiring lands in a follow-up commit — tests already exercise every item, so `#[expect(dead_code)]` is unfulfilled under test cfg.
- `crates/mesh/src/lib.rs`: register `chunk_assembler` module.
- `crates/mesh/src/proto/gossip.proto`: add `StreamEntry` / `StreamBatch` messages, add `StreamBatch stream_batch = 8;` to the `StreamMessage.payload` oneof.

## Test Plan

Before this PR: no chunked-value transport existed. Stream values > 10 MB would fail at the gRPC layer.

After this PR:

```
$ cargo test -p smg-mesh chunk_assembler
    running 11 tests
    test ... test_single_chunk_round_trip ... ok
    test ... test_multi_chunk_in_order ... ok
    test ... test_multi_chunk_out_of_order ... ok
    test ... test_generation_reset_discards_older_partials ... ok
    test ... test_gc_removes_stale_partials ... ok
    test ... test_gc_keeps_recent_partials ... ok
    test ... test_malformed_chunk_is_dropped ... ok
    test ... test_multiple_keys_independent ... ok
    test ... test_bounds_evict_oldest_when_too_many_concurrent ... ok
    test ... test_bounds_evict_largest_when_over_byte_cap ... ok
    test ... test_bounds_not_enforced_on_completion ... ok
    test result: ok. 11 passed; 0 failed

$ cargo test -p smg-mesh --lib
    test result: ok. 211 passed; 0 failed; 2 ignored
```

Unit coverage includes:
- Basic round-trip (single- and multi-chunk, in-order and out-of-order).
- Generation reset: older-generation partials discarded when a newer generation starts on the same key.
- GC: stale partials removed past timeout; recent partials retained.
- Bounds enforcement: over concurrent cap evicts oldest, over byte cap evicts largest, completion path bypasses bounds (just-completed value is returned regardless of size).
- Malformed input (total == 0, index ≥ total) dropped silently.
- Multi-key independence.

Integration tests covering the wire-format path land in Part 2 alongside the gossip-loop wiring.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] (Optional) Documentation updated (inline module docs in `chunk_assembler.rs`)
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reassemble oversized streamed values sent as bounded chunks into complete payloads.
  * Streaming protocol extended to carry chunked batches for segmented delivery.
  * Configurable concurrency and memory limits for in-flight assemblies, with automatic eviction and garbage collection of stale or oversized partial assemblies.

* **Tests**
  * Unit tests added covering ordering, generation resets, malformed/oversized chunks, GC, eviction caps, completion, concurrency, and multi-key behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->