### PR TITLE
feat(responses): interrupt approval-required MCP tool calls

### DIFF
--- a/crates/mcp/src/core/mod.rs
+++ b/crates/mcp/src/core/mod.rs
@@ -22,7 +22,8 @@ pub use config::{
 pub use handler::{HandlerRequestContext, RefreshRequest, SmgClientHandler};
 pub use metrics::{LatencySnapshot, McpMetrics, MetricsSnapshot};
 pub use orchestrator::{
-    McpOrchestrator, McpRequestContext, ToolCallResult, ToolExecutionInput, ToolExecutionOutput,
+    McpOrchestrator, McpRequestContext, PendingToolExecution, ToolCallResult, ToolExecutionInput,
+    ToolExecutionOutput, ToolExecutionResult,
 };
 pub use pool::{McpConnectionPool, PoolKey};
 pub use reconnect::ReconnectionManager;

--- a/crates/mcp/src/core/orchestrator.rs
+++ b/crates/mcp/src/core/orchestrator.rs
@@ -247,6 +247,52 @@ pub struct ToolExecutionOutput {
     pub duration: Duration,
 }
 
+/// Result from resolved tool execution that preserves interactive approval state.
+#[derive(Debug, Clone)]
+pub enum ToolExecutionResult {
+    Executed(ToolExecutionOutput),
+    PendingApproval(PendingToolExecution),
+}
+
+/// Pending approval from resolved tool execution.
+#[derive(Debug, Clone)]
+pub struct PendingToolExecution {
+    pub call_id: String,
+    pub tool_name: String,
+    pub server_key: String,
+    pub server_label: String,
+    pub arguments_str: String,
+    pub approval_request: McpApprovalRequest,
+    pub response_format: ResponseFormat,
+    pub duration: Duration,
+}
+
+impl ToolExecutionResult {
+    /// Convert the result to the legacy flattened output shape.
+    #[must_use]
+    pub fn into_output(self) -> ToolExecutionOutput {
+        match self {
+            Self::Executed(output) => output,
+            Self::PendingApproval(pending) => ToolExecutionOutput {
+                call_id: pending.call_id,
+                tool_name: pending.tool_name,
+                server_key: pending.server_key,
+                server_label: pending.server_label,
+                arguments_str: pending.arguments_str,
+                output: serde_json::json!({
+                    "error": "Tool requires approval (not supported in this context)"
+                }),
+                is_error: true,
+                error_message: Some(
+                    "Tool requires approval (not supported in this context)".to_string(),
+                ),
+                response_format: pending.response_format,
+                duration: pending.duration,
+            },
+        }
+    }
+}
+
 impl ToolExecutionOutput {
     /// Get the transformed ResponseOutputItem.
     ///
@@ -953,99 +999,141 @@ impl McpOrchestrator {
         server_label: &str,
         request_ctx: &McpRequestContext<'_>,
     ) -> ToolExecutionOutput {
+        self.execute_tool_resolved_result(input, server_key, server_label, request_ctx)
+            .await
+            .into_output()
+    }
+
+    /// Execute a single resolved tool while preserving pending approval state.
+    pub async fn execute_tool_resolved_result(
+        &self,
+        input: ToolExecutionInput,
+        server_key: &str,
+        server_label: &str,
+        request_ctx: &McpRequestContext<'_>,
+    ) -> ToolExecutionResult {
         let start = Instant::now();
         let arguments_str = input.arguments.to_string();
 
         let qualified = QualifiedToolName::new(server_key, &input.tool_name);
         let entry = self.tool_inventory.get_entry(server_key, &input.tool_name);
 
-        let (response_format, output, is_error, error_message) = match entry {
-            Some(entry) => {
-                self.execute_tool_entry(&entry, qualified, input.arguments, request_ctx)
-                    .await
-            }
+        match entry {
+            Some(entry) => match self
+                .execute_tool_entry_result(&entry, qualified, input.arguments, request_ctx)
+                .await
+            {
+                ToolExecutionResult::Executed(mut output) => {
+                    output.call_id = input.call_id;
+                    output.tool_name = input.tool_name;
+                    output.server_key = server_key.to_string();
+                    output.server_label = server_label.to_string();
+                    output.arguments_str = arguments_str;
+                    ToolExecutionResult::Executed(output)
+                }
+                ToolExecutionResult::PendingApproval(mut pending) => {
+                    pending.call_id = input.call_id;
+                    pending.tool_name = input.tool_name;
+                    pending.server_key = server_key.to_string();
+                    pending.server_label = server_label.to_string();
+                    pending.arguments_str = arguments_str;
+                    ToolExecutionResult::PendingApproval(pending)
+                }
+            },
             None => {
                 let err = format!(
                     "Tool '{}' not found on server '{}'",
                     input.tool_name, server_key
                 );
-                (
-                    ResponseFormat::Passthrough,
-                    serde_json::json!({ "error": &err }),
-                    true,
-                    Some(err),
-                )
+                ToolExecutionResult::Executed(ToolExecutionOutput {
+                    call_id: input.call_id,
+                    tool_name: input.tool_name,
+                    server_key: server_key.to_string(),
+                    server_label: server_label.to_string(),
+                    arguments_str,
+                    output: serde_json::json!({ "error": &err }),
+                    is_error: true,
+                    error_message: Some(err),
+                    response_format: ResponseFormat::Passthrough,
+                    duration: start.elapsed(),
+                })
             }
-        };
-
-        ToolExecutionOutput {
-            call_id: input.call_id,
-            tool_name: input.tool_name,
-            server_key: server_key.to_string(),
-            server_label: server_label.to_string(),
-            arguments_str,
-            output,
-            is_error,
-            error_message,
-            response_format,
-            duration: start.elapsed(),
         }
     }
 
-    async fn execute_tool_entry(
+    async fn execute_tool_entry_result(
         &self,
         entry: &ToolEntry,
         qualified: QualifiedToolName,
         arguments: Value,
         request_ctx: &McpRequestContext<'_>,
-    ) -> (ResponseFormat, Value, bool, Option<String>) {
+    ) -> ToolExecutionResult {
         self.active_executions.fetch_add(1, Ordering::SeqCst);
         let _guard = scopeguard::guard(Arc::clone(&self.active_executions), |count| {
             count.fetch_sub(1, Ordering::SeqCst);
         });
         self.metrics.record_call_start(&qualified);
         let call_start_time = Instant::now();
+        let response_format = entry.response_format.clone();
 
-        let raw_result = self
-            .execute_tool_with_approval_raw(entry, arguments, request_ctx)
-            .await;
-
-        let duration_ms = call_start_time.elapsed().as_millis() as u64;
-        self.metrics
-            .record_call_end(&qualified, raw_result.is_ok(), duration_ms);
-
-        match raw_result {
-            Ok(Some(raw_result)) => (
-                entry.response_format.clone(),
-                Self::call_result_to_json(&raw_result),
-                raw_result.is_error.unwrap_or(false),
-                None,
-            ),
-            Ok(None) => {
-                let err = "Tool requires approval (not supported in this context)".to_string();
-                (
-                    entry.response_format.clone(),
-                    serde_json::json!({ "error": &err }),
-                    true,
-                    Some(err),
-                )
+        let result = match self
+            .execute_tool_with_approval_raw_internal(entry, arguments, request_ctx)
+            .await
+        {
+            Ok(ApprovalExecutionResult::Success(raw_result)) => {
+                ToolExecutionResult::Executed(ToolExecutionOutput {
+                    call_id: String::new(),
+                    tool_name: entry.tool_name().to_string(),
+                    server_key: entry.server_key().to_string(),
+                    server_label: entry.server_key().to_string(),
+                    arguments_str: String::new(),
+                    output: Self::call_result_to_json(&raw_result),
+                    is_error: raw_result.is_error.unwrap_or(false),
+                    error_message: None,
+                    response_format: response_format.clone(),
+                    duration: call_start_time.elapsed(),
+                })
+            }
+            Ok(ApprovalExecutionResult::PendingApproval(approval_request)) => {
+                ToolExecutionResult::PendingApproval(PendingToolExecution {
+                    call_id: String::new(),
+                    tool_name: entry.tool_name().to_string(),
+                    server_key: entry.server_key().to_string(),
+                    server_label: entry.server_key().to_string(),
+                    arguments_str: String::new(),
+                    approval_request,
+                    response_format,
+                    duration: call_start_time.elapsed(),
+                })
             }
             Err(e) => {
                 let err = format!("Tool call failed: {e}");
-                (
-                    entry.response_format.clone(),
-                    serde_json::json!({ "error": &err }),
-                    true,
-                    Some(err),
-                )
+                ToolExecutionResult::Executed(ToolExecutionOutput {
+                    call_id: String::new(),
+                    tool_name: entry.tool_name().to_string(),
+                    server_key: entry.server_key().to_string(),
+                    server_label: entry.server_key().to_string(),
+                    arguments_str: String::new(),
+                    output: serde_json::json!({ "error": &err }),
+                    is_error: true,
+                    error_message: Some(err),
+                    response_format,
+                    duration: call_start_time.elapsed(),
+                })
             }
-        }
+        };
+
+        let succeeded =
+            !matches!(&result, ToolExecutionResult::Executed(output) if output.is_error);
+        let duration_ms = call_start_time.elapsed().as_millis() as u64;
+        self.metrics
+            .record_call_end(&qualified, succeeded, duration_ms);
+        result
     }
 
     /// Execute tool with approval checking.
     ///
     /// Returns a transformed `ToolCallResult` ready for API responses.
-    /// For raw results without transformation, use `execute_tool_with_approval_raw`.
     ///
     /// # Arguments
     /// * `entry` - Tool entry to execute
@@ -1078,26 +1166,6 @@ impl McpOrchestrator {
             ApprovalExecutionResult::PendingApproval(approval_request) => {
                 Ok(ToolCallResult::PendingApproval(approval_request))
             }
-        }
-    }
-
-    /// Execute tool with approval, returning raw CallToolResult.
-    ///
-    /// Returns the raw output before transformation.
-    /// Returns `Ok(Some(result))` on success, `Ok(None)` if pending approval,
-    /// or `Err` on failure.
-    async fn execute_tool_with_approval_raw(
-        &self,
-        entry: &ToolEntry,
-        arguments: Value,
-        request_ctx: &McpRequestContext<'_>,
-    ) -> McpResult<Option<CallToolResult>> {
-        match self
-            .execute_tool_with_approval_raw_internal(entry, arguments, request_ctx)
-            .await?
-        {
-            ApprovalExecutionResult::Success(result) => Ok(Some(result)),
-            ApprovalExecutionResult::PendingApproval(_) => Ok(None),
         }
     }
 

--- a/crates/mcp/src/core/session.rs
+++ b/crates/mcp/src/core/session.rs
@@ -9,11 +9,14 @@
 use std::collections::{HashMap, HashSet};
 
 use futures::stream::{self, StreamExt};
-use openai_protocol::responses::ResponseTool;
+use openai_protocol::responses::{RequireApproval, RequireApprovalMode, ResponseTool};
 
 use super::{
     config::BuiltinToolType,
-    orchestrator::{McpOrchestrator, McpRequestContext, ToolExecutionInput, ToolExecutionOutput},
+    orchestrator::{
+        McpOrchestrator, McpRequestContext, ToolExecutionInput, ToolExecutionOutput,
+        ToolExecutionResult,
+    },
     UNKNOWN_SERVER_KEY,
 };
 use crate::{
@@ -60,6 +63,7 @@ struct ExposedToolBinding {
     resolved_tool_name: String,
     is_builtin_routed: bool,
     response_format: ResponseFormat,
+    approval_mode: ApprovalMode,
 }
 
 /// Bundles all MCP execution state for a single request.
@@ -70,7 +74,8 @@ struct ExposedToolBinding {
 /// and `mcp_tools`.
 pub struct McpToolSession<'a> {
     orchestrator: &'a McpOrchestrator,
-    request_ctx: McpRequestContext<'a>,
+    request_id: String,
+    tenant_ctx: TenantContext,
     /// All MCP servers in this session (including builtin).
     all_mcp_servers: Vec<McpServerBinding>,
     /// Non-builtin MCP servers only — used for `mcp_list_tools` output.
@@ -92,11 +97,8 @@ impl<'a> McpToolSession<'a> {
         mcp_servers: Vec<McpServerBinding>,
         request_id: impl Into<String>,
     ) -> Self {
-        let request_ctx = orchestrator.create_request_context(
-            request_id,
-            TenantContext::default(),
-            ApprovalMode::PolicyOnly,
-        );
+        let request_id = request_id.into();
+        let tenant_ctx = TenantContext::default();
         let server_keys: Vec<String> = mcp_servers.iter().map(|b| b.server_key.clone()).collect();
         let mut mcp_tools = Self::collect_visible_mcp_tools(orchestrator, &server_keys);
 
@@ -147,7 +149,8 @@ impl<'a> McpToolSession<'a> {
 
         Self {
             orchestrator,
-            request_ctx,
+            request_id,
+            tenant_ctx,
             all_mcp_servers: mcp_servers,
             mcp_servers: visible_mcp_servers,
             mcp_tools,
@@ -163,8 +166,8 @@ impl<'a> McpToolSession<'a> {
         self.orchestrator
     }
 
-    pub fn request_ctx(&self) -> &McpRequestContext<'a> {
-        &self.request_ctx
+    pub fn request_id(&self) -> &str {
+        &self.request_id
     }
 
     /// Returns only non-builtin MCP servers
@@ -199,9 +202,21 @@ impl<'a> McpToolSession<'a> {
     ///
     /// Uses `buffered()` to cap in-flight requests while preserving input ordering.
     pub async fn execute_tools(&self, inputs: Vec<ToolExecutionInput>) -> Vec<ToolExecutionOutput> {
+        self.execute_tool_results(inputs)
+            .await
+            .into_iter()
+            .map(ToolExecutionResult::into_output)
+            .collect()
+    }
+
+    /// Execute multiple tools concurrently while preserving pending approval state.
+    pub async fn execute_tool_results(
+        &self,
+        inputs: Vec<ToolExecutionInput>,
+    ) -> Vec<ToolExecutionResult> {
         const MAX_IN_FLIGHT_TOOL_CALLS: usize = 8;
         stream::iter(inputs)
-            .map(|input| self.execute_tool(input))
+            .map(|input| self.execute_tool_result(input))
             .buffered(MAX_IN_FLIGHT_TOOL_CALLS)
             .collect()
             .await
@@ -209,13 +224,19 @@ impl<'a> McpToolSession<'a> {
 
     /// Execute a single tool using this session's exposed-name mapping.
     pub async fn execute_tool(&self, input: ToolExecutionInput) -> ToolExecutionOutput {
+        self.execute_tool_result(input).await.into_output()
+    }
+
+    /// Execute a single tool while preserving pending approval state.
+    pub async fn execute_tool_result(&self, input: ToolExecutionInput) -> ToolExecutionResult {
         let invoked_name = input.tool_name.clone();
 
         if let Some(binding) = self.exposed_name_map.get(&invoked_name) {
             let resolved_tool_name = binding.resolved_tool_name.clone();
-            let mut output = self
+            let request_ctx = self.request_ctx_for(binding.approval_mode);
+            let mut result = self
                 .orchestrator
-                .execute_tool_resolved(
+                .execute_tool_resolved_result(
                     ToolExecutionInput {
                         call_id: input.call_id,
                         tool_name: resolved_tool_name.clone(),
@@ -223,12 +244,20 @@ impl<'a> McpToolSession<'a> {
                     },
                     &binding.server_key,
                     &binding.server_label,
-                    &self.request_ctx,
+                    &request_ctx,
                 )
                 .await;
 
-            output.tool_name = invoked_name;
-            output
+            match &mut result {
+                ToolExecutionResult::Executed(output) => {
+                    output.tool_name = invoked_name;
+                }
+                ToolExecutionResult::PendingApproval(pending) => {
+                    pending.tool_name = invoked_name;
+                }
+            }
+
+            result
         } else {
             let fallback_label = self
                 .all_mcp_servers
@@ -237,7 +266,7 @@ impl<'a> McpToolSession<'a> {
                 .unwrap_or(DEFAULT_SERVER_LABEL)
                 .to_string();
             let err = format!("Tool '{invoked_name}' is not in this session's exposed tool map");
-            ToolExecutionOutput {
+            ToolExecutionResult::Executed(ToolExecutionOutput {
                 call_id: input.call_id,
                 tool_name: invoked_name.clone(),
                 server_key: UNKNOWN_SERVER_KEY.to_string(),
@@ -248,7 +277,7 @@ impl<'a> McpToolSession<'a> {
                 error_message: Some(err),
                 response_format: ResponseFormat::Passthrough,
                 duration: std::time::Duration::default(),
-            }
+            })
         }
     }
 
@@ -268,6 +297,42 @@ impl<'a> McpToolSession<'a> {
             .get(tool_name)
             .map(|binding| binding.server_label.clone())
             .unwrap_or_else(|| fallback_label.to_string())
+    }
+
+    /// Apply request-time approval configuration to exposed tools in this session.
+    pub fn configure_response_tools_approval(&mut self, tools: &[ResponseTool]) {
+        for tool in tools {
+            let ResponseTool::Mcp(mcp_tool) = tool else {
+                continue;
+            };
+
+            let approval_mode = match mcp_tool.require_approval.as_ref() {
+                Some(RequireApproval::Mode(RequireApprovalMode::Always)) => {
+                    ApprovalMode::Interactive
+                }
+                _ => ApprovalMode::PolicyOnly,
+            };
+
+            if approval_mode == ApprovalMode::PolicyOnly {
+                continue;
+            }
+
+            let allowed_tool_names = mcp_tool.allowed_tools.as_ref();
+            for binding in self.exposed_name_map.values_mut() {
+                if binding.server_label != mcp_tool.server_label {
+                    continue;
+                }
+                if let Some(allowed_tool_names) = allowed_tool_names {
+                    if !allowed_tool_names
+                        .iter()
+                        .any(|allowed_tool_name| allowed_tool_name == &binding.resolved_tool_name)
+                    {
+                        continue;
+                    }
+                }
+                binding.approval_mode = approval_mode;
+            }
+        }
     }
 
     /// Returns true if the bound server label belongs to an internal server.
@@ -489,6 +554,7 @@ impl<'a> McpToolSession<'a> {
                     resolved_tool_name,
                     is_builtin_routed,
                     response_format: entry.response_format.clone(),
+                    approval_mode: ApprovalMode::PolicyOnly,
                 },
             );
         }
@@ -583,6 +649,14 @@ impl<'a> McpToolSession<'a> {
             .unwrap_or(&entry.qualified_name);
         builtin_tool_bindings.contains(target)
     }
+
+    fn request_ctx_for(&self, approval_mode: ApprovalMode) -> McpRequestContext<'a> {
+        self.orchestrator.create_request_context(
+            self.request_id.clone(),
+            self.tenant_ctx.clone(),
+            approval_mode,
+        )
+    }
 }
 
 fn sanitize_tool_token(input: &str) -> String {
@@ -606,6 +680,8 @@ fn sanitize_tool_token(input: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    use serde_json::json;
+
     use super::*;
     use crate::core::config::Tool as McpTool;
 
@@ -639,6 +715,14 @@ mod tests {
 
         assert!(session.mcp_servers().is_empty());
         assert!(session.mcp_tools().is_empty());
+    }
+
+    #[test]
+    fn test_session_creation_keeps_request_id() {
+        let orchestrator = McpOrchestrator::new_test();
+        let session = McpToolSession::new(&orchestrator, vec![], "test-request");
+
+        assert_eq!(session.request_id(), "test-request");
     }
 
     #[test]
@@ -707,6 +791,58 @@ mod tests {
 
         assert!(session.has_exposed_tool("test_tool"));
         assert_eq!(session.mcp_tools().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_execute_tool_result_preserves_pending_approval() {
+        let orchestrator = McpOrchestrator::new_test();
+
+        let tool = create_test_tool("test_tool");
+        let entry = ToolEntry::from_server_tool("server1", tool);
+        orchestrator.tool_inventory().insert_entry(entry);
+
+        let mut session = McpToolSession::new(
+            &orchestrator,
+            vec![McpServerBinding {
+                label: "label1".to_string(),
+                server_key: "server1".to_string(),
+                allowed_tools: None,
+            }],
+            "test-request",
+        );
+        session.configure_response_tools_approval(&[ResponseTool::Mcp(
+            openai_protocol::responses::McpTool {
+                server_url: Some("http://example.com/mcp".to_string()),
+                authorization: None,
+                headers: None,
+                server_label: "label1".to_string(),
+                server_description: None,
+                require_approval: Some(RequireApproval::Mode(RequireApprovalMode::Always)),
+                allowed_tools: None,
+            },
+        )]);
+
+        let result = session
+            .execute_tool_result(ToolExecutionInput {
+                call_id: "call-1".to_string(),
+                tool_name: "test_tool".to_string(),
+                arguments: json!({"hello": "world"}),
+            })
+            .await;
+
+        match result {
+            ToolExecutionResult::PendingApproval(pending) => {
+                assert_eq!(pending.call_id, "call-1");
+                assert_eq!(pending.tool_name, "test_tool");
+                assert_eq!(pending.server_key, "server1");
+                assert_eq!(pending.server_label, "label1");
+                assert_eq!(pending.approval_request.server_key, "server1");
+                assert_eq!(pending.approval_request.tool_name, "test_tool");
+            }
+            ToolExecutionResult::Executed(output) => {
+                panic!("expected pending approval, got executed result: {output:?}")
+            }
+        }
     }
 
     #[test]

--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -30,10 +30,10 @@ pub use core::{config, pool as connection_pool};
 pub use core::{
     ArgMappingConfig, BuiltinToolType, ConfigValidationError, HandlerRequestContext,
     LatencySnapshot, McpConfig, McpMetrics, McpOrchestrator, McpRequestContext, McpServerBinding,
-    McpServerConfig, McpToolSession, McpTransport, MetricsSnapshot, PolicyConfig,
-    PolicyDecisionConfig, PoolKey, RefreshRequest, ResponseFormatConfig, ServerPolicyConfig,
-    SmgClientHandler, Tool, ToolCallResult, ToolConfig, ToolExecutionInput, ToolExecutionOutput,
-    TrustLevelConfig, DEFAULT_SERVER_LABEL,
+    McpServerConfig, McpToolSession, McpTransport, MetricsSnapshot, PendingToolExecution,
+    PolicyConfig, PolicyDecisionConfig, PoolKey, RefreshRequest, ResponseFormatConfig,
+    ServerPolicyConfig, SmgClientHandler, Tool, ToolCallResult, ToolConfig, ToolExecutionInput,
+    ToolExecutionOutput, ToolExecutionResult, TrustLevelConfig, DEFAULT_SERVER_LABEL,
 };
 
 // Re-export shared types

--- a/crates/protocols/src/responses.rs
+++ b/crates/protocols/src/responses.rs
@@ -82,10 +82,33 @@ pub struct CodeInterpreterTool {
 
 /// `require_approval` values.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, schemars::JsonSchema)]
-#[serde(rename_all = "snake_case")]
+#[serde(untagged)]
 pub enum RequireApproval {
+    Mode(RequireApprovalMode),
+    Rules(RequireApprovalRules),
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, schemars::JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum RequireApprovalMode {
     Always,
     Never,
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct RequireApprovalRules {
+    pub always: Option<RequireApprovalFilter>,
+    pub never: Option<RequireApprovalFilter>,
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct RequireApprovalFilter {
+    pub tool_names: Option<Vec<String>>,
+    pub read_only: Option<bool>,
 }
 
 // ============================================================================
@@ -1496,5 +1519,61 @@ mod tests {
         .expect("request should deserialize");
 
         assert_eq!(request.top_p, Some(0.9));
+    }
+
+    #[test]
+    fn test_require_approval_string_round_trip() {
+        let tool: McpTool = serde_json::from_value(json!({
+            "server_label": "deepwiki",
+            "require_approval": "never"
+        }))
+        .expect("mcp tool should deserialize");
+
+        assert_eq!(
+            tool.require_approval,
+            Some(RequireApproval::Mode(RequireApprovalMode::Never))
+        );
+
+        let serialized = serde_json::to_value(&tool).expect("mcp tool should serialize");
+        assert_eq!(serialized["require_approval"], json!("never"));
+    }
+
+    #[test]
+    fn test_require_approval_object_round_trip() {
+        let tool: McpTool = serde_json::from_value(json!({
+            "server_label": "deepwiki",
+            "require_approval": {
+                "always": null,
+                "never": {
+                    "tool_names": ["ask_question", "read_wiki_structure"],
+                    "read_only": null
+                }
+            }
+        }))
+        .expect("mcp tool should deserialize");
+
+        assert_eq!(
+            tool.require_approval,
+            Some(RequireApproval::Rules(RequireApprovalRules {
+                always: None,
+                never: Some(RequireApprovalFilter {
+                    tool_names: Some(vec![
+                        "ask_question".to_string(),
+                        "read_wiki_structure".to_string()
+                    ]),
+                    read_only: None,
+                }),
+            }))
+        );
+
+        let serialized = serde_json::to_value(&tool).expect("mcp tool should serialize");
+        assert_eq!(
+            serialized["require_approval"],
+            json!({
+                "never": {
+                    "tool_names": ["ask_question", "read_wiki_structure"]
+                }
+            })
+        );
     }
 }

--- a/e2e_test/responses/test_tools_call.py
+++ b/e2e_test/responses/test_tools_call.py
@@ -127,6 +127,11 @@ DEEPWIKI_MCP_TOOL = {
     "require_approval": "never",
 }
 
+BRAVE_MCP_TOOL_REQUIRE_APPROVAL_ALWAYS = {
+    **BRAVE_MCP_TOOL,
+    "require_approval": "always",
+}
+
 MCP_TEST_PROMPT = (
     "Search the web for 'Python programming language'. Set count to 1 to "
     "get only one result and return one sentence response."
@@ -203,6 +208,41 @@ def streaming_added_mcp_list_tools_labels(events):
         and event.item is not None
         and event.item.type == "mcp_list_tools"
     ]
+
+
+def assert_mcp_approval_interruption_non_streaming(resp):
+    assert resp.error is None
+    assert resp.id is not None
+    assert resp.status == "completed"
+    assert resp.output is not None
+
+    output_types = [item.type for item in resp.output]
+    assert "mcp_call" in output_types
+    assert "mcp_approval_request" in output_types
+
+    mcp_calls = [item for item in resp.output if item.type == "mcp_call"]
+    deepwiki_calls = [item for item in mcp_calls if item.server_label == "deepwiki"]
+    assert len(deepwiki_calls) > 0, "Expected at least one deepwiki mcp_call item"
+    for mcp_call in deepwiki_calls:
+        assert mcp_call.id is not None
+        assert mcp_call.id.startswith("mcp_")
+        assert mcp_call.name is not None
+        assert mcp_call.arguments is not None
+        assert mcp_call.output is not None
+
+    approval_requests = [item for item in resp.output if item.type == "mcp_approval_request"]
+    brave_approval_requests = [item for item in approval_requests if item.server_label == "brave"]
+    assert len(brave_approval_requests) > 0, "Expected at least one brave mcp_approval_request"
+    for approval_request in brave_approval_requests:
+        assert approval_request.id is not None
+        assert approval_request.id.startswith("mcpr_")
+        assert approval_request.name is not None
+        assert approval_request.arguments is not None
+
+    assert all(item.server_label != "brave" for item in mcp_calls), (
+        "Expected approval-required brave tools to stop at mcp_approval_request "
+        "instead of emitting mcp_call"
+    )
 
 
 def assert_previous_response_id_mcp_binding_behavior_non_streaming(model, api_client):
@@ -517,6 +557,30 @@ class TestToolCallingCloud:
 
         final_text = text_done_events[0].text
         assert len(final_text) > 0, "Final text should not be empty"
+
+    def test_mcp_approval_required_interrupts_and_resumes(self, model, api_client):
+        """Test MCP approval-required workflow eventually supports interruption and resume."""
+
+        time.sleep(2)  # Avoid rate limiting
+
+        resp = api_client.responses.create(
+            model=model,
+            input=(
+                "First use deepwiki's ask_question tool with repoName "
+                "'modelcontextprotocol/specification' to answer: 'According to the 2025-03-26 "
+                "MCP specification, what transport protocols are supported?' in one short "
+                "sentence. Then use brave_web_search to search for 'Python programming "
+                "language' with count set to 1."
+            ),
+            tools=[DEEPWIKI_MCP_TOOL, BRAVE_MCP_TOOL_REQUIRE_APPROVAL_ALWAYS],
+            stream=False,
+            reasoning={"effort": "low"},
+        )
+
+        assert_mcp_approval_interruption_non_streaming(resp)
+
+        # TODO: extend this same test in a follow-up PR with the approval continuation
+        # request and assert the resumed turn emits mcp_call plus the final assistant output.
 
     def test_mcp_multi_server_tool_call(self, model, api_client):
         """Test MCP tool call with multiple MCP servers (non-streaming)."""

--- a/model_gateway/src/routers/openai/mcp/tool_loop.rs
+++ b/model_gateway/src/routers/openai/mcp/tool_loop.rs
@@ -22,7 +22,7 @@ use openai_protocol::{
 use serde_json::{json, to_value, Value};
 use smg_mcp::{
     extract_embedded_openai_responses, mcp_response_item_id, McpServerBinding, McpToolSession,
-    ResponseFormat, ResponseTransformer, ToolExecutionInput,
+    ResponseFormat, ResponseTransformer, ToolExecutionInput, ToolExecutionResult,
 };
 use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
@@ -581,6 +581,10 @@ fn non_streaming_tool_item_id_source(item_id: &str, response_format: &ResponseFo
     }
 }
 
+fn approval_request_item_id_source(item_id: &str) -> String {
+    normalize_tool_item_id_with_prefix(item_id, "mcpr_")
+}
+
 pub(crate) fn mcp_list_tools_bindings_to_emit(
     existing_labels: &HashSet<String>,
     bindings: &[McpServerBinding],
@@ -639,6 +643,101 @@ pub(crate) fn inject_mcp_metadata_streaming(
         );
         obj.insert("output".to_string(), Value::Array(output_items));
     }
+}
+
+fn build_approval_response(
+    mut response: Value,
+    state: ToolLoopState,
+    session: &McpToolSession<'_>,
+    original_body: &ResponsesRequest,
+    approval_item: Value,
+) -> Result<Value, String> {
+    let obj = response
+        .as_object_mut()
+        .ok_or_else(|| "response not an object".to_string())?;
+    obj.insert("status".to_string(), Value::String("completed".to_string()));
+
+    let list_tools_bindings = mcp_list_tools_bindings_to_emit(
+        &state.existing_mcp_list_tools_labels,
+        session.mcp_servers(),
+    );
+
+    match obj.get_mut("output").and_then(|v| v.as_array_mut()) {
+        Some(output_array) => {
+            let retained_items = retained_output_items(output_array, original_body);
+            let prefix =
+                approval_prefix_items(&state, session, &list_tools_bindings, approval_item);
+
+            output_array.clear();
+            output_array.extend(prefix);
+            output_array.extend(retained_items);
+        }
+        None => {
+            let output_items =
+                approval_prefix_items(&state, session, &list_tools_bindings, approval_item);
+            obj.insert("output".to_string(), Value::Array(output_items));
+        }
+    }
+
+    Ok(response)
+}
+
+fn retained_output_items(output_array: &[Value], original_body: &ResponsesRequest) -> Vec<Value> {
+    let user_function_names: HashSet<&str> = original_body
+        .tools
+        .as_deref()
+        .map(|tools| {
+            tools
+                .iter()
+                .filter_map(|tool| match tool {
+                    ResponseTool::Function(function_tool) => {
+                        Some(function_tool.function.name.as_str())
+                    }
+                    _ => None,
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    output_array
+        .iter()
+        .filter(|item| {
+            let item_type = item.get("type").and_then(|value| value.as_str());
+            if !item_type.is_some_and(is_function_call_type) {
+                return true;
+            }
+
+            item.get("name")
+                .and_then(|value| value.as_str())
+                .is_some_and(|name| user_function_names.contains(name))
+        })
+        .cloned()
+        .collect()
+}
+
+fn approval_prefix_items(
+    state: &ToolLoopState,
+    session: &McpToolSession<'_>,
+    list_tools_bindings: &[(String, String)],
+    approval_item: Value,
+) -> Vec<Value> {
+    let mut prefix = Vec::with_capacity(list_tools_bindings.len() + state.mcp_call_items.len() + 1);
+    for (list_server_label, server_key) in list_tools_bindings {
+        if !session.is_internal_server_label(list_server_label) {
+            prefix.push(session.build_mcp_list_tools_json(list_server_label, server_key));
+        }
+    }
+    prefix.extend(
+        state
+            .mcp_call_items
+            .iter()
+            .filter(|item| !is_internal_mcp_response_item(item, session))
+            .cloned(),
+    );
+    if !is_internal_mcp_response_item(&approval_item, session) {
+        prefix.push(approval_item);
+    }
+    prefix
 }
 
 pub(crate) struct ToolLoopExecutionContext<'a> {
@@ -782,13 +881,37 @@ pub(crate) async fn execute_tool_loop(
                 "Calling MCP tool '{}' with args: {}",
                 call.name, call.arguments
             );
-            let tool_output = session
-                .execute_tool(ToolExecutionInput {
+            let tool_result = session
+                .execute_tool_result(ToolExecutionInput {
                     call_id: call.call_id.clone(),
                     tool_name: call.name.clone(),
                     arguments,
                 })
                 .await;
+
+            let response_format = session.tool_response_format(&call.name);
+            let server_label = session.resolve_tool_server_label(&call.name);
+            let tool_item_id = non_streaming_tool_item_id_source(&call.item_id, &response_format);
+            let approval_request_id = approval_request_item_id_source(&call.item_id);
+
+            let tool_output = match tool_result {
+                ToolExecutionResult::Executed(tool_output) => tool_output,
+                ToolExecutionResult::PendingApproval(pending) => {
+                    let approval_item = build_mcp_approval_request_item(
+                        &approval_request_id,
+                        &pending.tool_name,
+                        &call.arguments,
+                        &server_label,
+                    );
+                    return build_approval_response(
+                        response_json,
+                        state,
+                        session,
+                        original_body,
+                        approval_item,
+                    );
+                }
+            };
 
             Metrics::record_mcp_tool_duration(
                 &original_body.model,
@@ -806,9 +929,6 @@ pub(crate) async fn execute_tool_loop(
             );
 
             let output_str = tool_output.output.to_string();
-            let response_format = session.tool_response_format(&call.name);
-            let server_label = session.resolve_tool_server_label(&call.name);
-            let tool_item_id = non_streaming_tool_item_id_source(&call.item_id, &response_format);
             let transformed_item = build_transformed_mcp_call_item(
                 &tool_output.output,
                 &response_format,
@@ -986,6 +1106,21 @@ fn build_mcp_call_item(
         "name": tool_name,
         "output": output,
         "server_label": server_label
+    })
+}
+
+fn build_mcp_approval_request_item(
+    approval_request_id: &str,
+    tool_name: &str,
+    arguments: &str,
+    server_label: &str,
+) -> Value {
+    json!({
+        "id": approval_request_id,
+        "type": "mcp_approval_request",
+        "arguments": arguments,
+        "name": tool_name,
+        "server_label": server_label,
     })
 }
 

--- a/model_gateway/src/routers/openai/responses/non_streaming.rs
+++ b/model_gateway/src/routers/openai/responses/non_streaming.rs
@@ -75,7 +75,10 @@ pub async fn handle_non_streaming_response(mut ctx: RequestContext) -> Response 
             .request_id
             .clone()
             .unwrap_or_else(|| format!("req_{}", uuid::Uuid::now_v7()));
-        let session = McpToolSession::new(mcp_orchestrator, mcp_servers, &session_request_id);
+        let mut session = McpToolSession::new(mcp_orchestrator, mcp_servers, &session_request_id);
+        if let Some(tools) = original_body.tools.as_deref() {
+            session.configure_response_tools_approval(tools);
+        }
         prepare_mcp_tools_as_functions(&mut payload, &session);
 
         match execute_tool_loop(

--- a/model_gateway/tests/api/responses_api_test.rs
+++ b/model_gateway/tests/api/responses_api_test.rs
@@ -4,9 +4,9 @@ use axum::http::StatusCode;
 use openai_protocol::{
     common::{GenerationRequest, ToolChoice, ToolChoiceValue, UsageInfo},
     responses::{
-        CodeInterpreterTool, McpTool, ReasoningEffort, RequireApproval, ResponseInput,
-        ResponseReasoningParam, ResponseTool, ResponsesRequest, ServiceTier, Truncation,
-        WebSearchPreviewTool,
+        CodeInterpreterTool, McpTool, ReasoningEffort, RequireApproval, RequireApprovalMode,
+        ResponseInput, ResponseReasoningParam, ResponseTool, ResponsesRequest, ServiceTier,
+        Truncation, WebSearchPreviewTool,
     },
 };
 use smg::{
@@ -221,6 +221,130 @@ async fn test_non_streaming_mcp_minimal_e2e_with_persistence() {
 }
 
 #[tokio::test]
+async fn test_non_streaming_mcp_returns_approval_request_when_required() {
+    let mut mcp = MockMCPServer::start().await.expect("start mcp");
+
+    let mcp_yaml = format!(
+        "servers:\n  - name: mock\n    protocol: streamable\n    url: {}\n",
+        mcp.url()
+    );
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let cfg_path = dir.path().join("mcp.yaml");
+    std::fs::write(&cfg_path, mcp_yaml).expect("write mcp cfg");
+
+    let mut worker = MockWorker::new(MockWorkerConfig {
+        port: 0,
+        worker_type: WorkerType::Regular,
+        health_status: HealthStatus::Healthy,
+        response_delay_ms: 0,
+        fail_rate: 0.0,
+    });
+    let worker_url = worker.start().await.expect("start worker");
+
+    let router_cfg = RouterConfig::builder()
+        .openai_mode(vec![worker_url])
+        .random_policy()
+        .host("127.0.0.1")
+        .port(0)
+        .max_payload_size(8 * 1024 * 1024)
+        .request_timeout_secs(60)
+        .worker_startup_timeout_secs(5)
+        .worker_startup_check_interval_secs(1)
+        .log_level("warn")
+        .max_concurrent_requests(32)
+        .queue_timeout_secs(5)
+        .build_unchecked();
+
+    let ctx =
+        crate::common::create_test_context_with_mcp_config(router_cfg, cfg_path.to_str().unwrap())
+            .await;
+    let router = RouterFactory::create_router(&ctx).await.expect("router");
+
+    let req = ResponsesRequest {
+        background: Some(false),
+        include: None,
+        input: ResponseInput::Text("search something".to_string()),
+        instructions: Some("Be brief".to_string()),
+        max_output_tokens: Some(64),
+        max_tool_calls: None,
+        metadata: None,
+        model: "mock-model".to_string(),
+        parallel_tool_calls: Some(true),
+        previous_response_id: None,
+        reasoning: None,
+        service_tier: Some(ServiceTier::Auto),
+        store: Some(true),
+        stream: Some(false),
+        temperature: Some(0.2),
+        tool_choice: Some(ToolChoice::default()),
+        tools: Some(vec![ResponseTool::Mcp(McpTool {
+            server_url: Some(mcp.url()),
+            authorization: None,
+            headers: None,
+            server_label: "mock".to_string(),
+            server_description: None,
+            require_approval: Some(RequireApproval::Mode(RequireApprovalMode::Always)),
+            allowed_tools: None,
+        })]),
+        top_logprobs: Some(0),
+        top_p: None,
+        truncation: Some(Truncation::Disabled),
+        text: None,
+        user: None,
+        request_id: Some("resp_test_mcp_approval_interrupt".to_string()),
+        priority: 0,
+        frequency_penalty: Some(0.0),
+        presence_penalty: Some(0.0),
+        stop: None,
+        top_k: -1,
+        min_p: 0.0,
+        repetition_penalty: 1.0,
+        conversation: None,
+    };
+
+    let resp = router.route_responses(None, &req, req.model.as_str()).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body_bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .expect("Failed to read response body");
+    let body_json: serde_json::Value =
+        serde_json::from_slice(&body_bytes).expect("Failed to parse response JSON");
+
+    assert_eq!(body_json["status"], "completed");
+
+    let output = body_json["output"]
+        .as_array()
+        .expect("response output missing");
+
+    let approval_item = output
+        .iter()
+        .find(|entry| {
+            entry.get("type") == Some(&serde_json::Value::String("mcp_approval_request".into()))
+        })
+        .expect("missing mcp_approval_request output item");
+
+    assert_eq!(
+        approval_item.get("server_label").and_then(|v| v.as_str()),
+        Some("mock")
+    );
+    assert_eq!(
+        approval_item.get("name").and_then(|v| v.as_str()),
+        Some("brave_web_search")
+    );
+    assert!(approval_item.get("arguments").is_some());
+    assert!(
+        output
+            .iter()
+            .all(|entry| entry.get("type") != Some(&serde_json::Value::String("mcp_call".into()))),
+        "response should interrupt before emitting mcp_call"
+    );
+
+    worker.stop().await;
+    mcp.stop().await;
+}
+
+#[tokio::test]
 async fn test_final_response_hides_internal_mcp_trace_items() {
     let mut mcp = MockMCPServer::start().await.expect("start mcp");
 
@@ -389,7 +513,7 @@ async fn test_previous_response_id_does_not_repeat_mcp_list_tools_for_existing_b
         headers: None,
         server_label: "mock".to_string(),
         server_description: None,
-        require_approval: Some(RequireApproval::Never),
+        require_approval: Some(RequireApproval::Mode(RequireApprovalMode::Never)),
         allowed_tools: None,
     });
 
@@ -1000,7 +1124,7 @@ async fn test_multi_turn_loop_with_mcp() {
             headers: None,
             server_label: "mock".to_string(),
             server_description: Some("Mock MCP server for testing".to_string()),
-            require_approval: Some(RequireApproval::Never),
+            require_approval: Some(RequireApproval::Mode(RequireApprovalMode::Never)),
             allowed_tools: None,
         })]),
         top_logprobs: Some(0),
@@ -1333,7 +1457,7 @@ async fn test_streaming_with_mcp_tool_calls() {
             headers: None,
             server_label: "mock".to_string(),
             server_description: Some("Mock MCP for streaming test".to_string()),
-            require_approval: Some(RequireApproval::Never),
+            require_approval: Some(RequireApproval::Mode(RequireApprovalMode::Never)),
             allowed_tools: None,
         })]),
         top_logprobs: Some(0),


### PR DESCRIPTION
## Description

### Problem

SMG's Responses API MCP flow did not expose approval-required interruptions in a way that matches OpenAI. Even when a tool required approval, the router continued to emit `mcp_call` output instead of stopping at an approval request. The protocol layer also could not round-trip OpenAI's richer `require_approval` shape.

### Solution

This PR adds the protocol and MCP core support needed for approval-aware execution, then wires the OpenAI non-streaming Responses path to stop on pending approval and emit `mcp_approval_request` instead of continuing to `mcp_call`.

Current scope note: the router interruption behavior in this PR is intentionally limited to explicit `require_approval: \"always\"`. Object-form `require_approval` rules are supported at the protocol round-trip level, but their runtime semantics are left to a follow-up PR. The non-streaming interruption behavior is also scoped per tool call rather than blanket-enabling interactive approval for the whole request.

## Changes

- extend `require_approval` in `crates/protocols/src/responses.rs` to support both string and object forms
- add protocol round-trip tests for `require_approval`
- expose pending approval from MCP core via `ToolExecutionResult` and configurable session approval mode
- keep legacy MCP execution helpers working by flattening pending approval only for old callers
- update OpenAI non-streaming Responses handling to use interactive approval only for MCP tool calls that explicitly request `require_approval: \"always\"`
- keep a single MCP session for the request and record approval mode per exposed tool, selecting approval behavior per tool call
- interrupt the non-streaming MCP tool loop with `mcp_approval_request` output instead of emitting `mcp_call`
- leave object-form `require_approval` rule semantics for a follow-up PR
- add router/integration coverage for approval-required interruption
- add e2e coverage for the OpenAI cloud Responses path, with follow-up notes to extend the same test for approval continuation later

## Test Plan

```bash
cargo run --bin smg -- --enable-igw --port 9999
```

In another shell, register an OpenAI worker without inlining secrets in the command:

```bash
curl -X POST http://localhost:9999/workers \
  -H "Content-Type: application/json" \
  -d '{
    "url": "https://api.openai.com",
    "api_key": "<OPENAI_API_KEY>",
    "runtime": "external",
    "disable_health_check": true
  }'
```

Then send a mixed-tool Responses request where one MCP tool should execute immediately and another should interrupt for approval:

```bash
curl http://localhost:9999/v1/responses \
  -H "Content-Type: application/json" \
  -d '{
    "model": "gpt-5.4",
    "store": false,
    "tools": [
      {
        "type": "mcp",
        "server_label": "deepwiki",
        "server_url": "https://mcp.deepwiki.com/mcp",
        "require_approval": "never"
      },
      {
        "type": "mcp",
        "server_label": "openai-developer-docs",
        "server_url": "https://developers.openai.com/mcp",
        "require_approval": "always"
      }
    ],
    "input": "First use deepwiki to answer what transport protocols are supported by the 2025-03-26 MCP specification in one short sentence. Then use openai developer docs to find the Responses API approvals documentation and summarize it in one sentence."
  }'
```

Expected behavior for this PR:

```json
{
  "status": "completed",
  "output": [
    {
      "type": "mcp_list_tools",
      "server_label": "deepwiki"
    },
    {
      "type": "mcp_list_tools",
      "server_label": "openai-developer-docs"
    },
    {
      "type": "mcp_call",
      "id": "mcp_...",
      "server_label": "deepwiki",
      "name": "ask_question",
      "arguments": "{...}",
      "output": ...
    },
    {
      "type": "mcp_approval_request",
      "id": "mcpr_...",
      "server_label": "openai-developer-docs",
      "name": "search_openai_docs",
      "arguments": "{...}"
    }
  ]
}
```

The response should allow the `deepwiki` tool to emit `mcp_call`, then stop at `openai-developer-docs`'s `mcp_approval_request` without emitting an `openai-developer-docs` `mcp_call` yet.

This PR does not yet validate object-form `require_approval` rules at runtime; that behavior is deferred to a follow-up PR.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MCP tool approval workflow: executions can pause and return an approval request (stopping execution) and later resume.
  * Per-tool approval configuration: require-approval can be set per tool and filtered by mode or rules; non-streaming calls honor these settings.
  * Require-approval accepts either simple string or structured object forms.

* **Tests**
  * Added integration and e2e tests validating approval interruption behavior and serde round-trips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->