### PR TITLE
revert(ci): ci-approved fork PR trigger (security + stability)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -8,9 +8,6 @@ on:
       - 'docs/**'
       - '*.lock'
       - 'mkdocs.yml'
-  # Allow maintainers to trigger Claude review for fork PRs via 'ci-approved' label.
-  pull_request_target:
-    types: [labeled, synchronize]
   issue_comment:
     types: [created]
   pull_request_review_comment:
@@ -27,12 +24,10 @@ jobs:
   review:
     name: Claude PR Review
     if: >-
-      github.repository == 'lightseekorg/smg'
+      github.event_name == 'pull_request'
+      && github.repository == 'lightseekorg/smg'
       && github.actor != 'dependabot[bot]'
-      && (
-        (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork)
-        || (github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'ci-approved'))
-      )
+      && !github.event.pull_request.head.repo.fork
     runs-on: k8s-runner-cpu
     timeout-minutes: 30
     concurrency:
@@ -42,7 +37,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Export API key from pod env

--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -14,20 +14,14 @@ on:
       - "docs/**"
       - "mkdocs.yml"
       - "*.md"
-  # Allow maintainers to trigger CI for fork PRs by adding the 'ci-approved' label.
-  # pull_request_target runs in the base branch context, bypassing the fork approval gate.
-  # 'synchronize' re-runs CI on subsequent pushes while the label is present.
-  pull_request_target:
-    branches: [ main ]
-    types: [labeled, synchronize]
   workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: gateway-tests-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: gateway-tests-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   RUSTC_WRAPPER: sccache
@@ -35,25 +29,12 @@ env:
   GENAI_BENCH_IMAGE: ghcr.io/moirai-internal/genai-bench:0.0.4
 
 jobs:
-  # Gate job: for pull_request_target, only proceed if 'ci-approved' label is present.
-  # All other triggers (push, pull_request, workflow_dispatch) pass through unconditionally.
-  ci-gate:
-    runs-on: ubuntu-latest
-    if: >-
-      github.event_name != 'pull_request_target' ||
-      contains(github.event.pull_request.labels.*.name, 'ci-approved')
-    steps:
-      - run: echo "CI gate passed"
-
   pre-commit:
-    needs: [ci-gate]
     runs-on: k8s-runner-cpu
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -69,14 +50,11 @@ jobs:
         run: pre-commit run --all-files --show-diff-on-failure
 
   python-lint:
-    needs: [ci-gate]
     runs-on: k8s-runner-cpu
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -99,14 +77,11 @@ jobs:
         run: mypy bindings/python/ --config-file mypy.ini
 
   grpc-proto-build-check:
-    needs: [ci-gate]
     runs-on: k8s-runner-cpu
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -128,14 +103,11 @@ jobs:
           python -c "from smg_grpc_proto import sglang_scheduler_pb2; print('OK')"
 
   build-wheel:
-    needs: [ci-gate]
     runs-on: k8s-runner-gpu
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Cache wheel and Go FFI artifacts
         id: cache-wheel
@@ -261,14 +233,11 @@ jobs:
           pytest -q tests --cov=smg --cov-config=.coveragerc --cov-report=term-missing --cov-fail-under=80
 
   unit-tests:
-    needs: [ci-gate]
     runs-on: k8s-runner-cpu
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -390,9 +359,8 @@ jobs:
           retention-days: 7
 
   detect-changes:
-    needs: [ci-gate]
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
+    if: github.event_name == 'pull_request'
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -465,7 +465,6 @@ jobs:
       && needs.build-wheel.result == 'success'
       && github.actor != 'dependabot[bot]'
       && (github.event_name != 'pull_request'
-          && github.event_name != 'pull_request_target'
           || (needs.detect-changes.result == 'success'
               && (needs.detect-changes.outputs.common == 'true'
                   || needs.detect-changes.outputs.chat-completions == 'true')))
@@ -526,7 +525,6 @@ jobs:
       && needs.build-wheel.result == 'success'
       && github.actor != 'dependabot[bot]'
       && (github.event_name != 'pull_request'
-          && github.event_name != 'pull_request_target'
           || (needs.detect-changes.result == 'success'
               && (needs.detect-changes.outputs.common == 'true'
                   || needs.detect-changes.outputs.embeddings == 'true')))
@@ -557,7 +555,6 @@ jobs:
       && needs.build-wheel.result == 'success'
       && github.actor != 'dependabot[bot]'
       && (github.event_name != 'pull_request'
-          && github.event_name != 'pull_request_target'
           || (needs.detect-changes.result == 'success'
               && (needs.detect-changes.outputs.common == 'true'
                   || needs.detect-changes.outputs.chat-completions == 'true')))
@@ -611,7 +608,6 @@ jobs:
       && needs.build-wheel.result == 'success'
       && github.actor != 'dependabot[bot]'
       && (github.event_name != 'pull_request'
-          && github.event_name != 'pull_request_target'
           || (needs.detect-changes.result == 'success'
               && (needs.detect-changes.outputs.common == 'true'
                   || needs.detect-changes.outputs.agentic == 'true')))
@@ -633,7 +629,6 @@ jobs:
       && !cancelled()
       && needs.e2e-1gpu-gateway.result == 'success'
       && (github.event_name != 'pull_request'
-          && github.event_name != 'pull_request_target'
           || (needs.detect-changes.result == 'success'
               && (needs.detect-changes.outputs.common == 'true'
                   || needs.detect-changes.outputs.chat-completions == 'true')))
@@ -702,7 +697,6 @@ jobs:
       && needs.build-wheel.result == 'success'
       && github.actor != 'dependabot[bot]'
       && (github.event_name != 'pull_request'
-          && github.event_name != 'pull_request_target'
           || (needs.detect-changes.result == 'success'
               && (needs.detect-changes.outputs.common == 'true'
                   || needs.detect-changes.outputs.agentic == 'true')))
@@ -850,7 +844,6 @@ jobs:
       && needs.build-wheel.result == 'success'
       && github.actor != 'dependabot[bot]'
       && (github.event_name != 'pull_request'
-          && github.event_name != 'pull_request_target'
           || (needs.detect-changes.result == 'success'
               && (needs.detect-changes.outputs.common == 'true'
                   || needs.detect-changes.outputs.go-bindings == 'true')))


### PR DESCRIPTION
## Description

### Problem

Two recently-merged CI changes — #1095 (`ci: allow 'ci-approved' label to bypass fork PR approval gate`) and its follow-up #1104 (`ci: apply change detection to pull_request_target events`) — are causing two serious problems on `main` and all open PRs.

**1) Security: classic "pwn request" exposure.**

`pr-test-rust.yml` (and `claude-code-review.yml`) were wired with:

```yaml
pull_request_target:
  types: [labeled, synchronize]
```

plus a `ci-approved` label gate, and every job checks out `github.event.pull_request.head.sha` — i.e. the fork's code — while running with `pull_request_target` privileges (base-branch workflow context + access to repo secrets + self-hosted runner access).

Because `synchronize` is one of the trigger types, the exploit path is:

1. External contributor opens a fork PR with innocent-looking code.
2. Maintainer reviews the visible code and adds `ci-approved`.
3. Attacker force-pushes malicious code to the fork branch.
4. `synchronize` fires → label is still present → CI runs the new fork code on `k8s-runner-cpu` / `k8s-runner-gpu` with `GITHUB_TOKEN` and (via the Claude review workflow) `ANTHROPIC_API_KEY`.

Blast radius includes secret exfiltration plus potential pivot on the self-hosted runners. This is the pattern GitHub's [Security Lab post](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/) specifically warns against.

**2) CI instability on main and PRs.**

Internal (non-fork) PRs now fire BOTH `pull_request` and `pull_request_target` into the same concurrency group:

```yaml
concurrency:
  group: gateway-tests-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: true
```

The two event types race and cancel each other. Last 40 `pr-test-rust.yml` runs broke down as:

| event | success | failure | cancelled | action_required | in-progress |
|---|---|---|---|---|---|
| `pull_request` | 1 | 6 | 7 | 5 | 2 |
| `pull_request_target` | 3 | 3 | 12 | 0 | 0 |
| `push` | 0 | 0 | 1 | 0 | 0 |

So ~10% of runs complete successfully; the rest are cancelled mid-flight or need manual approval. This blocks both landing on `main` and validating feature PRs.

### Solution

Revert both PRs. The fork-PR CI convenience should be re-introduced later with a secure design (see Follow-up below) rather than patched in place.

## Changes

Two revert commits:

- `revert(ci): apply change detection to pull_request_target events (#1104)` — drops the 7 `&& github.event_name != 'pull_request_target'` guards from e2e job conditions (dead code once the trigger is removed).
- `revert(ci): allow 'ci-approved' label to bypass fork PR approval gate (#1095)` — removes the `pull_request_target` trigger, the `ci-gate` job and all `needs: [ci-gate]` edges, the per-job `ref: ${{ github.event.pull_request.head.sha || github.sha }}` overrides, and the equivalent changes in `.github/workflows/claude-code-review.yml`. Restores the original `concurrency` config.

Net diff: `+6 / -51` lines across two workflow files. No source code touched.

## Follow-up (NOT in this PR)

When we re-add fork-PR CI support, it must use one of these safer patterns:

1. **Two-workflow split.** Privileged tests stay on `pull_request` (untrusted code cannot access secrets). A separate `pull_request_target` workflow runs only read-only steps (labeler, PR comment, etc.) with narrow `permissions:`.
2. **SHA-pinned approval.** Record the approved head SHA in a comment or a store when `ci-approved` is added; only run CI for that exact SHA. Auto-remove the label on every new push so re-approval is required.
3. **Manual approval flow only** (the current GitHub default) — accept the UX cost.

## Test plan

- [x] YAML syntax validated locally for both workflow files
- [x] Post-revert grep confirms no `pull_request_target` / `ci-approved` / `ci-gate` references remain in either workflow
- [x] Revert applies cleanly (no conflicts with later commit `5319dc6e` which added `e2e-1gpu-completions`)
- [ ] After merge: confirm `pull_request` CI runs are no longer cancelled by a competing `pull_request_target` run
- [ ] After merge: confirm `main` push runs stop racing with PR runs

Refs: #1095, #1104

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Consolidated CI/CD workflow configuration to streamline pull request testing processes and improve execution consistency while maintaining comprehensive test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->