### PR TITLE
docs(contributing): add Code of Conduct and root CONTRIBUTING guide

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# SMG Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socioeconomic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline/IRL event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement in the
+`#code-of-conduct` channel in the
+[Lightseek Slack](https://slack.lightseek.org).
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/),
+version 2.1, available at
+[v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/inclusion).
+
+For answers to common questions about this code of conduct, see the
+[Contributor Covenant FAQ](https://www.contributor-covenant.org/faq). Translations are available at
+[Contributor Covenant translations](https://www.contributor-covenant.org/translations).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,145 @@
+# Contributing to SMG
+
+Thank you for your interest in contributing to Shepherd Model Gateway. This
+document is the front door. The detailed guides live under
+[`docs/contributing/`](./docs/contributing/) and are served at
+<https://lightseekorg.github.io/smg/contributing/>.
+
+- **Code of Conduct**: [`CODE_OF_CONDUCT.md`](./CODE_OF_CONDUCT.md) — applies to
+  every interaction in this repo and in community spaces.
+- **How to contribute code**: [`docs/contributing/index.md`](./docs/contributing/index.md)
+- **Development environment**: [`docs/contributing/development.md`](./docs/contributing/development.md)
+- **Code style**: [`docs/contributing/code-style.md`](./docs/contributing/code-style.md)
+- **Review guidelines**: [`REVIEW.md`](./REVIEW.md)
+- **PR template**: [`.github/PULL_REQUEST_TEMPLATE.md`](./.github/PULL_REQUEST_TEMPLATE.md)
+
+---
+
+## Quick start
+
+```bash
+# 1. Fork on GitHub, then clone your fork
+git clone git@github.com:<your-user>/smg.git
+cd smg
+
+# 2. Install toolchain
+rustup toolchain install nightly
+rustup component add rustfmt --toolchain nightly
+rustup component add clippy rustfmt
+
+# 3. Install pre-commit hooks (enforces rustfmt, clippy, DCO, no-AI-attribution, branch naming)
+pip install pre-commit
+pre-commit install
+pre-commit install --hook-type commit-msg
+
+# 4. Create a branch (must match <type>/<desc> or <username>/<desc>)
+git checkout -b feat/my-change
+
+# 5. Build and test
+cargo build
+cargo test
+```
+
+Full setup details are in [`docs/contributing/development.md`](./docs/contributing/development.md).
+
+---
+
+## The pre-PR gate
+
+Every PR must pass these five checks **locally** before requesting review:
+
+| # | Command | Expectation |
+|---|---------|-------------|
+| 1 | `cargo +nightly fmt --all` | No output (silent success) |
+| 2 | `cargo clippy --all-targets --all-features -- -D warnings` | Zero warnings, zero errors |
+| 3 | `cargo test` | `test result: ok` with 0 failures |
+| 4 | `make python-dev` *(if `config/types.rs`, `protocols/`, or `bindings/` changed)* | Successful compilation |
+| 5 | Commit format | Conventional commit, DCO sign-off present, no AI attribution |
+
+"Probably passes" is not passing. Paste the output or re-run.
+
+---
+
+## Commits
+
+We use [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>(<scope>): <short summary>
+
+<optional body explaining why>
+
+Signed-off-by: Your Name <your.email@example.com>
+```
+
+- **Types**: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`, `ci`
+- **Scope**: the crate or subsystem (`mesh`, `grpc_client`, `worker`, `protocols`, …)
+- **One logical change per commit.** Prefer many small commits to one mega-commit.
+- **Every commit must be DCO-signed.** Use `git commit -s`. The
+  [DCO](https://developercertificate.org/) certifies that you wrote the code or
+  have the right to submit it.
+- **No AI attribution.** `Co-Authored-By: Claude` / `noreply@anthropic.com` and
+  similar are rejected by the `no-ai-co-author` pre-commit hook.
+
+---
+
+## Pull requests
+
+- **Fill in the [PR template](./.github/PULL_REQUEST_TEMPLATE.md)** — especially
+  the `Test Plan` section. "Ran `cargo test`" is not a test plan; name the
+  scenarios the reviewer can reproduce.
+- **Keep PRs small.** Aim for ≤400 lines changed. Above that, split or coordinate
+  with reviewers in advance.
+- **One concern per PR.** Refactor *or* feature — not both.
+- **Link the issue.** `Closes #1234` or `Refs: #1234`.
+- **Respond to review comments with a commit SHA and a one-line reason.**
+  Example: `Fixed in abc1234 — capped total_chunks at 1024 before allocation`.
+  Silence or "Fixed!" makes reviewers re-hunt your work.
+
+---
+
+## Using code agents (Claude Code, Cursor, Copilot, etc.)
+
+Agents are welcome and useful. Three ground rules:
+
+1. **You own the PR, not the agent.** Read every line before opening.
+2. **Show the gate output.** The agent must paste real `cargo fmt` / `clippy` /
+   `test` output, not "I have run the tests."
+3. **No AI attribution in commits, PR bodies, or review replies.** The hook
+   will reject it; so will the reviewer.
+
+---
+
+## Reviewing
+
+- Use the severity markers from [`REVIEW.md`](./REVIEW.md): 🔴 Important, 🟡 Nit,
+  🟣 Pre-existing.
+- Cite `file:line` in every substantive comment.
+- Run `/smg:review-pr` to map changed files to subsystem checklists before you
+  start.
+- Approve small clean PRs fast; the faster turnaround, the fewer giant PRs
+  reviewers face later.
+
+---
+
+## Reporting security issues
+
+Please do **not** open a public issue for security vulnerabilities. Contact the
+maintainers privately — see [`CODEOWNERS`](./.github/CODEOWNERS) for the current
+maintainer list, or reach out in the `#security` channel of the
+[Lightseek Slack](https://slack.lightseek.org).
+
+---
+
+## Getting help
+
+- **Questions**: [GitHub Discussions](https://github.com/lightseekorg/smg/discussions)
+- **Bugs**: [GitHub Issues](https://github.com/lightseekorg/smg/issues/new)
+- **Chat**: [Slack](https://slack.lightseek.org) · [Discord](https://discord.gg/wkQ73CVTvR)
+
+---
+
+## License
+
+By contributing to SMG, you agree that your contributions will be licensed under
+the [Apache License 2.0](./LICENSE).


### PR DESCRIPTION
## Description

### Problem

The repository is missing two files that GitHub expects at the repo root and that a visible open-source project should have:

- **`CODE_OF_CONDUCT.md`** — `docs/contributing/index.md:152` already links to `https://github.com/lightseekorg/smg/blob/main/CODE_OF_CONDUCT.md`, which is a 404 today.
- **`CONTRIBUTING.md`** — GitHub surfaces this inline in the issue- and PR-create flow. Without it, first-time contributors do not see the pre-PR gate, the DCO requirement, or the no-AI-attribution rule until CI rejects their commit.

### Solution

Add both files at the repository root, keeping the detailed guides where they already live (`docs/contributing/*`, `REVIEW.md`) and treating the root files as the front-door pointers.

## Changes

- **`CODE_OF_CONDUCT.md`** (new, repo root)
  - Contributor Covenant v2.1 verbatim text (standard pledge, standards, scope, enforcement).
  - Mozilla-inspired enforcement ladder (Correction / Warning / Temporary Ban / Permanent Ban) kept.
  - Enforcement channel: `#code-of-conduct` in the [Lightseek Slack](https://slack.lightseek.org).
  - Attribution preserved as required by the Contributor Covenant license.
  - Side effect: fixes the dead link in `docs/contributing/index.md:152`.

- **`CONTRIBUTING.md`** (new, repo root)
  - Points to the full hosted guide at <https://lightseek.org/smg/contributing/> and the existing sources under `docs/contributing/`.
  - Inlines the 5-step pre-PR gate from `smg:contribute`, so contributors do not need to click out for the basics:
    1. `cargo +nightly fmt --all`
    2. `cargo clippy --all-targets --all-features -- -D warnings`
    3. `cargo test`
    4. `make python-dev` (when `config/types.rs` / `protocols/` / `bindings/` change)
    5. Conventional commit + DCO sign-off + no AI attribution
  - Documents the conventional-commit types and scopes we already use (`feat`, `fix`, `docs`, `refactor`, `perf`, `test`, `chore`, `ci`, `style`).
  - Explicit DCO and `no-ai-co-author` reminders that match the pre-commit hooks in `.pre-commit-config.yaml`.
  - Three-rule summary for code-agent usage (own the PR, show the gate output, no AI attribution).
  - Reviewer guidance points to `REVIEW.md` severity markers.
  - Security reporting channel: `CODEOWNERS` + `#security` in the Lightseek Slack — no broken link to a not-yet-written `SECURITY.md`.

No Rust, config, protocol, or binding files touched.

## Test Plan

Docs-only change at the repository root. Verified with:

- `cargo +nightly fmt --all -- --check` — silent success (nothing to format; confirms no accidental Rust edits).
- Pre-commit hooks ran on commit and passed: `trailing-whitespace`, `end-of-file-fixer`, `check-yaml`, `check-toml`, `check-added-large-files`, `check-merge-conflict`, `detect-private-key`, `mixed-line-ending`, `no-commit-to-branch`, `codespell`, `rustfmt` (no Rust diff), `clippy` (no Rust diff), `branch-name-check` (branch matches `<type>/<desc>`), `dco-check` (sign-off matches `git config user.{name,email}`), `no-ai-co-author` (no Claude / `noreply@anthropic.com` attribution), `ruff` (no Python diff), `ruff-format` (no Python diff).
- Manually re-read both rendered files for: correct links (internal paths resolve, `slack.lightseek.org` / `discord.gg/wkQ73CVTvR` match `README.md`), no broken references to the removed DO/DO-NOT draft, Contributor Covenant attribution block intact.
- `docs/contributing/index.md:152` link target (`CODE_OF_CONDUCT.md` at repo root) now exists — dead link resolved.

Not applicable for this diff: `cargo clippy`, `cargo test`, `make python-dev` (no Rust / config / protocol / binding changes).

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (no Rust diff)
- [x] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Established Code of Conduct defining community participation standards, expected behaviors, unacceptable conduct, and enforcement procedures to maintain a welcoming, inclusive environment.
  * Added Contributing guide documenting development setup, workflow requirements, commit message standards, pull request guidelines, and expectations for code contributors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->