### PR TITLE
fix(headers): drop content-length in preserve_response_headers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,19 +4,19 @@ resolver = "2"
 
 [workspace.dependencies]
 # Internal workspace crates
-openai-protocol = { version = "1.7.0", path = "crates/protocols" }
-reasoning-parser = { version = "1.2.3", path = "crates/reasoning_parser" }
-tool-parser = { version = "1.2.0", path = "crates/tool_parser" }
-wfaas = { version = "1.0.3", path = "crates/workflow" }
-llm-tokenizer = { version = "1.3.2", path = "crates/tokenizer" }
-smg-auth = { version = "1.1.1", path = "crates/auth" }
-smg-mcp = { version = "2.2.0", path = "crates/mcp" }
-kv-index = { version = "1.2.0", path = "crates/kv_index" }
-smg-data-connector = { version = "2.2.0", path = "crates/data_connector", package = "data-connector" }
-llm-multimodal = { version = "1.5.0", path = "crates/multimodal" }
-smg-wasm = { version = "1.1.0", path = "crates/wasm", package = "smg-wasm" }
-smg-mesh = { version = "1.3.0", path = "crates/mesh", package = "smg-mesh" }
-smg-grpc-client = { version = "1.5.1", path = "crates/grpc_client" }
+openai-protocol = { version = "1.0.0", path = "crates/protocols" }
+reasoning-parser = { version = "1.0.0", path = "crates/reasoning_parser" }
+tool-parser = { version = "1.0.0", path = "crates/tool_parser" }
+wfaas = { version = "1.0.0", path = "crates/workflow" }
+llm-tokenizer = { version = "1.0.0", path = "crates/tokenizer" }
+smg-auth = { version = "1.0.0", path = "crates/auth" }
+smg-mcp = { version = "1.0.0", path = "crates/mcp" }
+kv-index = { version = "1.0.0", path = "crates/kv_index" }
+smg-data-connector = { version = "1.0.0", path = "crates/data_connector", package = "data-connector" }
+llm-multimodal = { version = "1.0.0", path = "crates/multimodal" }
+smg-wasm = { version = "1.0.0", path = "crates/wasm", package = "smg-wasm" }
+smg-mesh = { version = "1.0.0", path = "crates/mesh", package = "smg-mesh" }
+smg-grpc-client = { version = "1.0.0", path = "crates/grpc_client" }
 smg-tui = { version = "0.1.0", path = "tui" }
 
 # Shared dependencies

--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-auth"
-version = "1.1.1"
+version = "1.0.0"
 edition = "2021"
 description = "Authentication and authorization for control plane APIs"
 license = "Apache-2.0"

--- a/crates/grpc_client/Cargo.toml
+++ b/crates/grpc_client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-grpc-client"
-version = "1.5.1"
+version = "1.0.0"
 edition = "2021"
 description = "gRPC clients for SGLang and vLLM backends"
 license = "Apache-2.0"

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-mcp"
-version = "2.2.0"
+version = "1.0.0"
 edition = "2021"
 description = "Model Context Protocol (MCP) client implementation"
 license = "Apache-2.0"

--- a/crates/mesh/Cargo.toml
+++ b/crates/mesh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-mesh"
-version = "1.3.0"
+version = "1.0.0"
 edition = "2021"
 description = "Mesh gossip protocol and distributed state synchronization for Shepherd Model Gateway"
 license = "Apache-2.0"

--- a/crates/protocols/Cargo.toml
+++ b/crates/protocols/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openai-protocol"
-version = "1.7.0"
+version = "1.0.0"
 edition = "2021"
 description = "OpenAI-compatible API protocol definitions and types"
 license = "Apache-2.0"

--- a/crates/reasoning_parser/Cargo.toml
+++ b/crates/reasoning_parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reasoning-parser"
-version = "1.2.3"
+version = "1.0.0"
 edition = "2021"
 description = "Parser for AI model reasoning/thinking outputs (chain-of-thought, etc.)"
 license = "Apache-2.0"

--- a/crates/tokenizer/Cargo.toml
+++ b/crates/tokenizer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llm-tokenizer"
-version = "1.3.2"
+version = "1.0.0"
 edition = "2021"
 description = "LLM tokenizer library with caching and chat template support"
 license = "Apache-2.0"

--- a/crates/tool_parser/Cargo.toml
+++ b/crates/tool_parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tool-parser"
-version = "1.2.0"
+version = "1.0.0"
 edition = "2021"
 description = "Tool/function call parser for LLM model outputs"
 license = "Apache-2.0"

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smg-wasm"
-version = "1.1.0"
+version = "1.0.0"
 edition = "2021"
 description = "WebAssembly runtime and module management for Shepherd Model Gateway"
 license = "Apache-2.0"

--- a/model_gateway/src/routers/common/header_utils.rs
+++ b/model_gateway/src/routers/common/header_utils.rs
@@ -77,6 +77,7 @@ fn should_forward_header_no_alloc(name: &str) -> bool {
         || name.eq_ignore_ascii_case("transfer-encoding")
         || name.eq_ignore_ascii_case("upgrade")
         || name.eq_ignore_ascii_case("content-encoding")
+        || name.eq_ignore_ascii_case("content-length")
         || name.eq_ignore_ascii_case("host"))
 }
 


### PR DESCRIPTION
## Problem

`preserve_response_headers` (model_gateway/src/routers/common/header_utils.rs:52-81) forwards upstream response headers with a hop-by-hop filter, but doesn't strip `content-length`. If a caller modifies the response body while preserving the upstream's `content-length` header, clients see `peer closed connection without sending complete message body` when the two sizes don't match.

This is a latent defensive bug today: the PD merge path (`pd_router.rs:955-999`) builds a fresh `(status, body).into_response()` without attaching upstream headers, so hyper recomputes Content-Length from the `Vec<u8>` body. But any future caller that copies the passthrough idiom (e.g., from lines 720-730) into a body-mutating path would trigger the mismatch.

Observed downstream: sglang PD + logprob merging returning Content-Length = decode_body.len() but body = serde_json::to_vec(merged) — 4-byte-short truncation on every request when the merge changes the `input_token_logprobs` shape (e.g., `null → []` or `[0.0] → [0]`).

## Fix

One line added to the hop-by-hop drop list:

```diff
         || name.eq_ignore_ascii_case("content-encoding")
+        || name.eq_ignore_ascii_case("content-length")
         || name.eq_ignore_ascii_case("host"))
```

This is standard reverse-proxy hygiene: equivalent to nginx's `proxy_hide_header Content-Length`. Lets hyper set Content-Length from the actual returned body size, eliminating the mismatch class entirely regardless of which path mutates the body.

## Test plan

1. Unit test against `preserve_response_headers` verifying `content-length` is dropped.
2. Integration test: stand up mock prefill + decode via existing `model_gateway/tests/common/mock_worker.rs`, issue a PD chat request with `logprobs=true`, assert the response's `content-length` equals the actual body length.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized internal component versions to 1.0.0 across the workspace.

* **Bug Fixes**
  * Fixed header forwarding behavior to properly exclude the Content-Length header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->