### PR TITLE
ci: gate expensive jobs on 'ci-approved' label for fork PRs

### DIFF
--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -103,6 +103,14 @@ jobs:
           python -c "from smg_grpc_proto import sglang_scheduler_pb2; print('OK')"
 
   build-wheel:
+    # Fork PRs must be labeled with 'ci-approved' for expensive jobs to run.
+    # Internal PRs (non-fork) run unconditionally. build-wheel is the
+    # first-tier expensive job; benchmarks, e2e-*, e2e-vendor, python-unit-tests,
+    # go-unit-tests, and go-bindings-e2e all chain off it via `needs:` and
+    # inherit the gate transitively.
+    if: >-
+      !github.event.pull_request.head.repo.fork ||
+      contains(github.event.pull_request.labels.*.name, 'ci-approved')
     runs-on: k8s-runner-gpu
     permissions:
       contents: read


### PR DESCRIPTION
## Description

### Problem

After #1175 reverted `pull_request_target` and removed the `ci-approved` gate entirely, fork PRs that pass the one-time "Approve and run" check now run the **full** expensive tier on every push — GPU runners (`build-wheel`, `benchmarks`, all `e2e-*`, `go-bindings-e2e`) and **paid third-party APIs** (`e2e-vendor` hits Anthropic, OpenAI, xAI). That's uncapped cost exposure on approved-but-not-yet-reviewed fork contributions.

### Solution

Gate the first-tier expensive job (`build-wheel`) on a `ci-approved` label for fork PRs. Everything downstream inherits the gate via `needs: build-wheel`. Internal (non-fork) PRs run unconditionally — no behavior change for maintainers.

Minimal, additive change only. Does not reintroduce `pull_request_target`, the prior `ci-gate` job, or any `labeled`-type trigger.

## Changes

- **`pr-test-rust.yml`** — single `if:` on `build-wheel`:
  ```yaml
  if: >-
    !github.event.pull_request.head.repo.fork ||
    contains(github.event.pull_request.labels.*.name, 'ci-approved')
  ```

Behavior matrix:

| PR type | `ci-approved` label | build-wheel + downstream |
|---|---|---|
| Internal (not fork) | — | runs |
| Fork | absent | skipped |
| Fork | present | runs |

### Trigger timing for fork PRs

Adding the `ci-approved` label alone does **not** re-trigger CI (this PR intentionally does not add `labeled` to `types:`, to avoid skipped-run noise on unrelated labels). To kick off expensive jobs after labeling:

- Contributor pushes another commit (`synchronize` event fires, `if:` picks up the label), **or**
- Maintainer clicks "Re-run all jobs" in the Actions UI.

### Recommended companion setting (repo admin)

**Settings → Actions → General → Fork pull request workflows from outside collaborators**: change from "Require approval for all outside collaborators" to "Require approval for first-time contributors". Without this, returning fork contributors still need a manual "Approve and run" click on every push.

## Test Plan

- [ ] This PR's own CI runs normally (internal PR; `if:` short-circuits on `!fork == true`).
- [ ] Post-merge: on the next fork PR without `ci-approved`, verify `build-wheel` and everything downstream show as `skipped`.
- [ ] Post-merge: add `ci-approved` to that fork PR and verify (after a new push or manual Re-run) the full tier runs.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes (N/A — YAML-only change)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (N/A — YAML-only change)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to optimize testing efficiency for pull requests based on approval status and repository context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->