### PR TITLE
feat(protocols): add skills core types

### DIFF
--- a/crates/protocols/src/lib.rs
+++ b/crates/protocols/src/lib.rs
@@ -28,6 +28,7 @@ pub mod realtime_session;
 pub mod rerank;
 pub mod responses;
 pub mod sampling_params;
+pub mod skills;
 pub mod tokenize;
 pub mod validated;
 pub mod worker;

--- a/crates/protocols/src/skills.rs
+++ b/crates/protocols/src/skills.rs
@@ -52,7 +52,7 @@ pub enum ResponsesSkillRef {
 /// One entry in `/v1/responses` -> `tools[].environment.skills[]`.
 ///
 /// SMG interprets the typed subset directly and preserves all other JSON
-/// entries as opaque provider-owned payloads.
+/// object entries as opaque provider-owned payloads.
 #[derive(Debug, Clone, PartialEq, Serialize, schemars::JsonSchema)]
 #[serde(untagged)]
 pub enum ResponsesSkillEntry {
@@ -66,6 +66,12 @@ impl<'de> Deserialize<'de> for ResponsesSkillEntry {
         D: Deserializer<'de>,
     {
         let value = Value::deserialize(deserializer)?;
+
+        if !value.is_object() {
+            return Err(de::Error::custom(
+                "responses skill entries must be JSON objects",
+            ));
+        }
 
         if matches_typed_responses_skill_ref(&value) {
             return serde_json::from_value::<ResponsesSkillRef>(value)
@@ -195,22 +201,30 @@ impl schemars::JsonSchema for SkillVersionRef {
     }
 }
 
+#[expect(
+    dead_code,
+    reason = "Skill resolution lands in follow-up PRs, but these internal protocol-side types stay crate-private now"
+)]
 #[derive(Debug, Clone, PartialEq)]
-pub struct ResolvedSkillRef {
-    pub public_skill_id: String,
-    pub origin: SkillOrigin,
-    pub requested_version: Option<SkillVersionRef>,
-    pub pinned: Option<PinnedSkillVersion>,
+pub(crate) struct ResolvedSkillRef {
+    pub(crate) public_skill_id: String,
+    pub(crate) origin: SkillOrigin,
+    pub(crate) requested_version: Option<SkillVersionRef>,
+    pub(crate) pinned: Option<PinnedSkillVersion>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct PinnedSkillVersion {
-    pub version: String,
-    pub version_number: u32,
+pub(crate) struct PinnedSkillVersion {
+    pub(crate) version: String,
+    pub(crate) version_number: u32,
 }
 
+#[expect(
+    dead_code,
+    reason = "Skill resolution lands in follow-up PRs, but origin tracking belongs with the other crate-private resolver types"
+)]
 #[derive(Debug, Clone, PartialEq)]
-pub enum SkillOrigin {
+pub(crate) enum SkillOrigin {
     AnthropicProvider {
         skill_id: String,
         raw_version: Option<String>,

--- a/crates/protocols/src/skills.rs
+++ b/crates/protocols/src/skills.rs
@@ -1,0 +1,271 @@
+//! Skill protocol types shared across API surfaces.
+//!
+//! This module keeps wire-facing request fragments separate from the
+//! request-local/internal types the router resolves after attach time.
+
+use serde::{
+    de::{self, Visitor},
+    Deserialize, Deserializer, Serialize, Serializer,
+};
+use serde_json::Value;
+
+/// Accepted in `/v1/messages` -> `container.skills[]`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(tag = "type")]
+pub enum MessagesSkillRef {
+    /// Anthropic-curated skill that SMG passes through unchanged.
+    #[serde(rename = "anthropic")]
+    Anthropic {
+        skill_id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        version: Option<String>,
+    },
+    /// SMG-managed skill resolved from storage.
+    #[serde(rename = "custom")]
+    Custom {
+        skill_id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        version: Option<SkillVersionRef>,
+    },
+}
+
+/// Accepted in `/v1/responses` -> `tools[].environment.skills[]`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(tag = "type")]
+pub enum ResponsesSkillRef {
+    /// Hosted skill reference. Ownership is decided by storage lookup, not id shape.
+    #[serde(rename = "skill_reference")]
+    Reference {
+        skill_id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        version: Option<SkillVersionRef>,
+    },
+    /// Client-local path. SMG never resolves or inspects this payload.
+    #[serde(rename = "local")]
+    Local {
+        name: String,
+        description: String,
+        path: String,
+    },
+}
+
+/// One entry in `/v1/responses` -> `tools[].environment.skills[]`.
+///
+/// SMG interprets the typed subset directly and preserves all other JSON
+/// entries as opaque provider-owned payloads.
+#[derive(Debug, Clone, PartialEq, Serialize, schemars::JsonSchema)]
+#[serde(untagged)]
+pub enum ResponsesSkillEntry {
+    Typed(ResponsesSkillRef),
+    OpaqueOpenAI(Value),
+}
+
+impl<'de> Deserialize<'de> for ResponsesSkillEntry {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = Value::deserialize(deserializer)?;
+
+        if matches_typed_responses_skill_ref(&value) {
+            return serde_json::from_value::<ResponsesSkillRef>(value)
+                .map(Self::Typed)
+                .map_err(de::Error::custom);
+        }
+
+        Ok(Self::OpaqueOpenAI(value))
+    }
+}
+
+/// Accepted in `X-SMG-Skills` for `/v1/chat/completions`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(tag = "type")]
+pub enum ChatCompletionsSkillRef {
+    #[serde(rename = "custom")]
+    Custom {
+        skill_id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        version: Option<SkillVersionRef>,
+    },
+    #[serde(rename = "openai")]
+    OpenAI {
+        skill_id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        version: Option<String>,
+    },
+    #[serde(rename = "anthropic")]
+    Anthropic {
+        skill_id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        version: Option<String>,
+    },
+}
+
+/// Version reference accepted by skill attachment surfaces.
+///
+/// Deserialization is intentionally manual to reject ambiguous numeric strings
+/// like `"2"` rather than guessing between integer and timestamp semantics.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SkillVersionRef {
+    /// The literal string `"latest"`.
+    Latest,
+    /// Integer reference (OpenAI-style).
+    Integer(u32),
+    /// Timestamp string (Anthropic-style).
+    Timestamp(String),
+}
+
+impl Serialize for SkillVersionRef {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::Latest => serializer.serialize_str("latest"),
+            Self::Integer(version) => serializer.serialize_u32(*version),
+            Self::Timestamp(version) => serializer.serialize_str(version),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for SkillVersionRef {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct SkillVersionRefVisitor;
+
+        impl<'de> Visitor<'de> for SkillVersionRefVisitor {
+            type Value = SkillVersionRef;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str(
+                    "the string `latest`, an integer version, or a 10+ digit timestamp string",
+                )
+            }
+
+            fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                let value = u32::try_from(value).map_err(|_| {
+                    E::custom(format!(
+                        "skill version integer is out of range for u32: {value}"
+                    ))
+                })?;
+                Ok(SkillVersionRef::Integer(value))
+            }
+
+            fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                if value < 0 {
+                    return Err(E::custom("skill version integer must be non-negative"));
+                }
+                self.visit_u64(value as u64)
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                parse_skill_version_str(value).map_err(E::custom)
+            }
+
+            fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                self.visit_str(&value)
+            }
+        }
+
+        deserializer.deserialize_any(SkillVersionRefVisitor)
+    }
+}
+
+impl schemars::JsonSchema for SkillVersionRef {
+    fn schema_name() -> String {
+        "SkillVersionRef".to_string()
+    }
+
+    fn json_schema(r#gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        SkillVersionRefWire::json_schema(r#gen)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResolvedSkillRef {
+    pub public_skill_id: String,
+    pub origin: SkillOrigin,
+    pub requested_version: Option<SkillVersionRef>,
+    pub pinned: Option<PinnedSkillVersion>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PinnedSkillVersion {
+    pub version: String,
+    pub version_number: u32,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum SkillOrigin {
+    AnthropicProvider {
+        skill_id: String,
+        raw_version: Option<String>,
+    },
+    OpenAIProvider {
+        skill_id: String,
+        raw_version: Option<String>,
+    },
+    OpenAIOpaquePassThrough {
+        raw: Value,
+    },
+    SmgStorage {
+        skill_id: String,
+    },
+    ClientLocalPath {
+        name: String,
+        description: String,
+        path: String,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(untagged)]
+enum SkillVersionRefWire {
+    String(String),
+    Integer(u32),
+}
+
+fn matches_typed_responses_skill_ref(value: &Value) -> bool {
+    matches!(
+        value.get("type").and_then(Value::as_str),
+        Some("skill_reference" | "local")
+    )
+}
+
+fn parse_skill_version_str(value: &str) -> Result<SkillVersionRef, String> {
+    if value == "latest" {
+        return Ok(SkillVersionRef::Latest);
+    }
+
+    if !value.is_empty() && value.bytes().all(|byte| byte.is_ascii_digit()) {
+        if value.len() <= 9 {
+            return Err(format!(
+                "ambiguous skill version string `{value}`: use a JSON number for integer versions or a 10+ digit string for timestamps"
+            ));
+        }
+
+        if value.bytes().all(|byte| byte == b'0') {
+            return Err("timestamp skill version string must be a positive integer".to_string());
+        }
+
+        return Ok(SkillVersionRef::Timestamp(value.to_string()));
+    }
+
+    Err(format!(
+        "invalid skill version string `{value}`: expected `latest` or a 10+ digit timestamp string"
+    ))
+}

--- a/crates/protocols/src/skills.rs
+++ b/crates/protocols/src/skills.rs
@@ -7,7 +7,7 @@ use serde::{
     de::{self, Visitor},
     Deserialize, Deserializer, Serialize, Serializer,
 };
-use serde_json::Value;
+use serde_json::{Map, Value};
 
 /// Accepted in `/v1/messages` -> `container.skills[]`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
@@ -49,6 +49,14 @@ pub enum ResponsesSkillRef {
     },
 }
 
+/// Opaque provider-owned Responses skill payload.
+///
+/// This wrapper keeps the public type aligned with the runtime contract:
+/// opaque skill entries must still be JSON objects.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(transparent)]
+pub struct OpaqueOpenAIObject(pub Map<String, Value>);
+
 /// One entry in `/v1/responses` -> `tools[].environment.skills[]`.
 ///
 /// SMG interprets the typed subset directly and preserves all other JSON
@@ -57,7 +65,7 @@ pub enum ResponsesSkillRef {
 #[serde(untagged)]
 pub enum ResponsesSkillEntry {
     Typed(ResponsesSkillRef),
-    OpaqueOpenAI(Value),
+    OpaqueOpenAI(OpaqueOpenAIObject),
 }
 
 impl<'de> Deserialize<'de> for ResponsesSkillEntry {
@@ -66,20 +74,19 @@ impl<'de> Deserialize<'de> for ResponsesSkillEntry {
         D: Deserializer<'de>,
     {
         let value = Value::deserialize(deserializer)?;
-
-        if !value.is_object() {
+        let Value::Object(object) = value else {
             return Err(de::Error::custom(
                 "responses skill entries must be JSON objects",
             ));
-        }
+        };
 
-        if matches_typed_responses_skill_ref(&value) {
-            return serde_json::from_value::<ResponsesSkillRef>(value)
+        if matches_typed_responses_skill_ref(&object) {
+            return serde_json::from_value::<ResponsesSkillRef>(Value::Object(object.clone()))
                 .map(Self::Typed)
                 .map_err(de::Error::custom);
         }
 
-        Ok(Self::OpaqueOpenAI(value))
+        Ok(Self::OpaqueOpenAI(OpaqueOpenAIObject(object)))
     }
 }
 
@@ -196,8 +203,39 @@ impl schemars::JsonSchema for SkillVersionRef {
         "SkillVersionRef".to_string()
     }
 
-    fn json_schema(r#gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        SkillVersionRefWire::json_schema(r#gen)
+    fn json_schema(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        use schemars::schema::*;
+
+        let latest_schema = SchemaObject {
+            instance_type: Some(InstanceType::String.into()),
+            enum_values: Some(vec!["latest".into()]),
+            ..Default::default()
+        };
+        let integer_schema = SchemaObject {
+            instance_type: Some(InstanceType::Integer.into()),
+            ..Default::default()
+        };
+        let timestamp_schema = SchemaObject {
+            instance_type: Some(InstanceType::String.into()),
+            string: Some(Box::new(StringValidation {
+                pattern: Some("^[1-9][0-9]{9,}$".to_string()),
+                ..Default::default()
+            })),
+            ..Default::default()
+        };
+
+        SchemaObject {
+            subschemas: Some(Box::new(SubschemaValidation {
+                one_of: Some(vec![
+                    latest_schema.into(),
+                    integer_schema.into(),
+                    timestamp_schema.into(),
+                ]),
+                ..Default::default()
+            })),
+            ..Default::default()
+        }
+        .into()
     }
 }
 
@@ -246,18 +284,18 @@ pub(crate) enum SkillOrigin {
     },
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
-#[serde(untagged)]
-enum SkillVersionRefWire {
-    String(String),
-    Integer(u32),
+fn matches_typed_responses_skill_ref(value: &Map<String, Value>) -> bool {
+    // Keep this tag/field matching in sync with ResponsesSkillRef's
+    // `#[serde(rename = "...")]` values and allowed field sets.
+    match value.get("type").and_then(Value::as_str) {
+        Some("skill_reference") => has_only_keys(value, &["type", "skill_id", "version"]),
+        Some("local") => has_only_keys(value, &["type", "name", "description", "path"]),
+        _ => false,
+    }
 }
 
-fn matches_typed_responses_skill_ref(value: &Value) -> bool {
-    matches!(
-        value.get("type").and_then(Value::as_str),
-        Some("skill_reference" | "local")
-    )
+fn has_only_keys(value: &Map<String, Value>, allowed_keys: &[&str]) -> bool {
+    value.keys().all(|key| allowed_keys.contains(&key.as_str()))
 }
 
 fn parse_skill_version_str(value: &str) -> Result<SkillVersionRef, String> {
@@ -272,14 +310,16 @@ fn parse_skill_version_str(value: &str) -> Result<SkillVersionRef, String> {
             ));
         }
 
-        if value.bytes().all(|byte| byte == b'0') {
-            return Err("timestamp skill version string must be a positive integer".to_string());
+        if value.starts_with('0') {
+            return Err(format!(
+                "ambiguous skill version string `{value}`: leading zeros are not allowed in timestamp strings"
+            ));
         }
 
         return Ok(SkillVersionRef::Timestamp(value.to_string()));
     }
 
     Err(format!(
-        "invalid skill version string `{value}`: expected `latest` or a 10+ digit timestamp string"
+        "invalid skill version string `{value}`: expected `latest` or a 10+ digit timestamp string without leading zeros"
     ))
 }

--- a/crates/protocols/tests/skills_protocol.rs
+++ b/crates/protocols/tests/skills_protocol.rs
@@ -1,4 +1,7 @@
-use openai_protocol::skills::{ResponsesSkillEntry, ResponsesSkillRef, SkillVersionRef};
+use openai_protocol::skills::{
+    OpaqueOpenAIObject, ResponsesSkillEntry, ResponsesSkillRef, SkillVersionRef,
+};
+use schemars::schema_for;
 use serde::Deserialize;
 use serde_json::json;
 
@@ -43,6 +46,14 @@ fn skill_version_ref_rejects_unknown_string() {
 }
 
 #[test]
+fn skill_version_ref_rejects_zero_padded_timestamp_string() {
+    let err = serde_json::from_value::<SkillVersionRef>(json!("0000000001")).unwrap_err();
+    assert!(err
+        .to_string()
+        .contains("leading zeros are not allowed in timestamp strings"));
+}
+
+#[test]
 fn optional_skill_version_ref_accepts_null_and_absent() {
     let null_value: OptionalVersionHolder =
         serde_json::from_value(json!({"version": null})).unwrap();
@@ -72,6 +83,27 @@ fn responses_skill_entry_deserializes_typed_reference() {
 }
 
 #[test]
+fn responses_skill_entry_deserializes_typed_local_reference() {
+    let raw = json!({
+        "type": "local",
+        "name": "map",
+        "description": "Map the codebase",
+        "path": "./skills/map"
+    });
+
+    let parsed: ResponsesSkillEntry = serde_json::from_value(raw.clone()).unwrap();
+    assert_eq!(
+        parsed,
+        ResponsesSkillEntry::Typed(ResponsesSkillRef::Local {
+            name: "map".to_string(),
+            description: "Map the codebase".to_string(),
+            path: "./skills/map".to_string(),
+        })
+    );
+    assert_eq!(serde_json::to_value(&parsed).unwrap(), raw);
+}
+
+#[test]
 fn responses_skill_entry_round_trips_opaque_openai_entry() {
     let raw = json!({
         "type": "inline_skill",
@@ -81,7 +113,29 @@ fn responses_skill_entry_round_trips_opaque_openai_entry() {
     });
 
     let parsed: ResponsesSkillEntry = serde_json::from_value(raw.clone()).unwrap();
-    assert_eq!(parsed, ResponsesSkillEntry::OpaqueOpenAI(raw.clone()));
+    let expected = ResponsesSkillEntry::OpaqueOpenAI(
+        serde_json::from_value::<OpaqueOpenAIObject>(raw.clone()).unwrap(),
+    );
+    assert_eq!(parsed, expected);
+    assert_eq!(serde_json::to_value(&parsed).unwrap(), raw);
+}
+
+#[test]
+fn responses_skill_entry_preserves_provider_fields_on_typed_tags() {
+    let raw = json!({
+        "type": "skill_reference",
+        "skill_id": "skill_123",
+        "version": 2,
+        "provider_feature": true,
+        "custom_config": {"trace": "abc"}
+    });
+
+    let parsed: ResponsesSkillEntry = serde_json::from_value(raw.clone()).unwrap();
+
+    let expected = ResponsesSkillEntry::OpaqueOpenAI(
+        serde_json::from_value::<OpaqueOpenAIObject>(raw.clone()).unwrap(),
+    );
+    assert_eq!(parsed, expected);
     assert_eq!(serde_json::to_value(&parsed).unwrap(), raw);
 }
 
@@ -103,4 +157,24 @@ fn responses_skill_entry_rejects_non_object_payloads() {
             .to_string()
             .contains("responses skill entries must be JSON objects"));
     }
+}
+
+#[test]
+fn skill_version_ref_schema_matches_runtime_contract() {
+    let schema = serde_json::to_value(schema_for!(SkillVersionRef)).unwrap();
+    let one_of = schema
+        .get("oneOf")
+        .and_then(serde_json::Value::as_array)
+        .unwrap();
+
+    assert!(one_of
+        .iter()
+        .any(|branch| branch.get("enum") == Some(&json!(["latest"]))));
+    assert!(one_of
+        .iter()
+        .any(|branch| branch.get("type") == Some(&json!("integer"))));
+    assert!(one_of.iter().any(|branch| {
+        branch.get("type") == Some(&json!("string"))
+            && branch.get("pattern") == Some(&json!("^[1-9][0-9]{9,}$"))
+    }));
 }

--- a/crates/protocols/tests/skills_protocol.rs
+++ b/crates/protocols/tests/skills_protocol.rs
@@ -94,3 +94,13 @@ fn responses_skill_entry_rejects_malformed_typed_reference() {
 
     assert!(err.to_string().contains("missing field `skill_id`"));
 }
+
+#[test]
+fn responses_skill_entry_rejects_non_object_payloads() {
+    for raw in [json!(null), json!("inline_skill"), json!(["inline_skill"])] {
+        let err = serde_json::from_value::<ResponsesSkillEntry>(raw).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("responses skill entries must be JSON objects"));
+    }
+}

--- a/crates/protocols/tests/skills_protocol.rs
+++ b/crates/protocols/tests/skills_protocol.rs
@@ -1,0 +1,96 @@
+use openai_protocol::skills::{ResponsesSkillEntry, ResponsesSkillRef, SkillVersionRef};
+use serde::Deserialize;
+use serde_json::json;
+
+#[derive(Debug, Deserialize)]
+struct OptionalVersionHolder {
+    version: Option<SkillVersionRef>,
+}
+
+#[test]
+fn skill_version_ref_deserializes_latest() {
+    let parsed: SkillVersionRef = serde_json::from_value(json!("latest")).unwrap();
+    assert_eq!(parsed, SkillVersionRef::Latest);
+}
+
+#[test]
+fn skill_version_ref_deserializes_integer_from_number() {
+    let parsed: SkillVersionRef = serde_json::from_value(json!(2)).unwrap();
+    assert_eq!(parsed, SkillVersionRef::Integer(2));
+}
+
+#[test]
+fn skill_version_ref_rejects_ambiguous_numeric_string() {
+    let err = serde_json::from_value::<SkillVersionRef>(json!("2")).unwrap_err();
+    assert!(err
+        .to_string()
+        .contains("use a JSON number for integer versions"));
+}
+
+#[test]
+fn skill_version_ref_deserializes_timestamp_string() {
+    let parsed: SkillVersionRef = serde_json::from_value(json!("1759178010641129")).unwrap();
+    assert_eq!(
+        parsed,
+        SkillVersionRef::Timestamp("1759178010641129".to_string())
+    );
+}
+
+#[test]
+fn skill_version_ref_rejects_unknown_string() {
+    let err = serde_json::from_value::<SkillVersionRef>(json!("some-other-string")).unwrap_err();
+    assert!(err.to_string().contains("invalid skill version string"));
+}
+
+#[test]
+fn optional_skill_version_ref_accepts_null_and_absent() {
+    let null_value: OptionalVersionHolder =
+        serde_json::from_value(json!({"version": null})).unwrap();
+    assert_eq!(null_value.version, None);
+
+    let absent_value: OptionalVersionHolder = serde_json::from_value(json!({})).unwrap();
+    assert_eq!(absent_value.version, None);
+}
+
+#[test]
+fn responses_skill_entry_deserializes_typed_reference() {
+    let raw = json!({
+        "type": "skill_reference",
+        "skill_id": "skill_123",
+        "version": "latest"
+    });
+
+    let parsed: ResponsesSkillEntry = serde_json::from_value(raw.clone()).unwrap();
+    assert_eq!(
+        parsed,
+        ResponsesSkillEntry::Typed(ResponsesSkillRef::Reference {
+            skill_id: "skill_123".to_string(),
+            version: Some(SkillVersionRef::Latest),
+        })
+    );
+    assert_eq!(serde_json::to_value(&parsed).unwrap(), raw);
+}
+
+#[test]
+fn responses_skill_entry_round_trips_opaque_openai_entry() {
+    let raw = json!({
+        "type": "inline_skill",
+        "name": "map",
+        "description": "Map the codebase",
+        "instructions": "Read the crate map before implementing changes."
+    });
+
+    let parsed: ResponsesSkillEntry = serde_json::from_value(raw.clone()).unwrap();
+    assert_eq!(parsed, ResponsesSkillEntry::OpaqueOpenAI(raw.clone()));
+    assert_eq!(serde_json::to_value(&parsed).unwrap(), raw);
+}
+
+#[test]
+fn responses_skill_entry_rejects_malformed_typed_reference() {
+    let err = serde_json::from_value::<ResponsesSkillEntry>(json!({
+        "type": "skill_reference"
+    }))
+    .unwrap_err();
+
+    assert!(err.to_string().contains("missing field `skill_id`"));
+}


### PR DESCRIPTION
Refs #1177
Part of #1176

## Description

### Problem

SMG does not yet have a protocol-layer representation for skills across the request surfaces that will consume them. Before request wiring, routing, or storage can be added, the shared types need to exist in `crates/protocols` with stable serde behavior.

### Solution

Add a standalone `skills` protocol module and keep this PR scoped to the protocol layer only.

The new module defines:

- wire types for Messages, Responses, and Chat Completions skill references
- internal resolved skill types used by later request-time resolution work
- manual `SkillVersionRef` serde to reject ambiguous string forms such as `"2"`
- `ResponsesSkillEntry` support for typed entries plus opaque OpenAI-owned pass-through JSON

## Changes

- export a new `skills` module from `crates/protocols/src/lib.rs`
- add `crates/protocols/src/skills.rs` with the core skill wire/internal types
- add protocol integration coverage in `crates/protocols/tests/skills_protocol.rs`
- keep `messages.rs` and `responses.rs` request-struct wiring out of scope for this PR

## Test Plan

- `cargo +nightly fmt --all`
- `env -u RUSTC_WRAPPER cargo clippy --all-targets --all-features --target-dir /tmp/smg-gate-target -- -D warnings`
- `env -u RUSTC_WRAPPER cargo test --target-dir /tmp/smg-gate-target`
- `make python-dev` was attempted because this PR changes `crates/protocols`, but it failed in the local environment because `maturin develop` requires an active virtualenv/conda env (or repo `.venv`) and none is configured here

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added skills support across multiple endpoints, allowing integration with custom, OpenAI, and Anthropic skills and new typed/opaque skill entry handling.
  * Added flexible skill versioning: "latest", explicit numeric versions, and timestamp-based references with strict validation and descriptive errors.

* **Tests**
  * Added comprehensive tests for skills protocol serialization/deserialization, covering version parsing, optional handling, typed vs. opaque entries, round-trip behavior, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->