### PR TITLE
chore(codeowners): add @zhoug9127 and @zhaowenzi to mcp and data_connector

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,12 +26,12 @@
 
 # Workspace crates
 /crates/auth @slin1237
-/crates/data_connector @key4ng
+/crates/data_connector @key4ng @zhoug9127 @zhaowenzi
 /crates/grpc_client @CatherineSue @slin1237
 /crates/grpc_client/proto/vllm_engine.proto @njhill @CatherineSue @slin1237
 /crates/grpc_client/proto/common.proto @njhill @CatherineSue @slin1237
 /crates/kv_index @slin1237
-/crates/mcp @key4ng @CatherineSue @slin1237
+/crates/mcp @key4ng @CatherineSue @slin1237 @zhoug9127 @zhaowenzi
 /crates/mesh @tonyluj @llfl @slin1237
 /crates/multimodal @slin1237 @CatherineSue
 /crates/protocols @CatherineSue @key4ng


### PR DESCRIPTION
## Description

### Problem

`/crates/mcp` and `/crates/data_connector` are driven primarily by Daisy and Ziwen, but neither is listed in `CODEOWNERS`. PRs in these areas miss them as auto-reviewers.

### Solution

Add both to the two paths.

## Changes

- `/crates/data_connector`: add `@zhoug9127`, `@zhaowenzi`
- `/crates/mcp`: add `@zhoug9127`, `@zhaowenzi`

Authorship evidence:
- **@zhoug9127 (Daisy)**: #1168, #1149, #1065, #1061, #976 — mcp + data_connector.
- **@zhaowenzi (Ziwen)**: #1174, #1163, #1123 — mcp.

## Test Plan

- `.github/CODEOWNERS` syntax: two lines edited, each `<path> <@owners...>` (unchanged format).
- No Rust / config / protocol / binding files touched → clippy/test/bindings gate not applicable.
- `cargo +nightly fmt --all -- --check` — silent success.
- Pre-commit hooks ran on commit and passed (DCO, no-AI-attribution, branch-name, codespell).

<details>
<summary>Checklist</summary>

- [x] \`cargo +nightly fmt\` passes
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` passes (no Rust diff)
- [x] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code ownership assignments for internal workspace organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->