### PR TITLE
feat(protocols): BGM-PR-01 extend Responses API types for background mode

### DIFF
--- a/crates/protocols/src/builders/responses/response.rs
+++ b/crates/protocols/src/builders/responses/response.rs
@@ -17,9 +17,12 @@ pub struct ResponsesResponseBuilder {
     id: String,
     object: String,
     created_at: i64,
+    completed_at: Option<i64>,
+    background: Option<bool>,
+    conversation: Option<String>,
     status: ResponseStatus,
     error: Option<Value>,
-    incomplete_details: Option<Value>,
+    incomplete_details: Option<IncompleteDetails>,
     instructions: Option<String>,
     max_output_tokens: Option<u32>,
     model: String,
@@ -51,6 +54,9 @@ impl ResponsesResponseBuilder {
             id: id.into(),
             object: "response".to_string(),
             created_at: chrono::Utc::now().timestamp(),
+            completed_at: None,
+            background: None,
+            conversation: None,
             status: ResponseStatus::InProgress,
             error: None,
             incomplete_details: None,
@@ -90,6 +96,8 @@ impl ResponsesResponseBuilder {
         self.previous_response_id
             .clone_from(&request.previous_response_id);
         self.store = request.store.unwrap_or(true);
+        self.background = request.background;
+        self.conversation.clone_from(&request.conversation);
         self.temperature = request.temperature;
         self.tool_choice = if let Some(ref tc) = request.tool_choice {
             serde_json::to_string(tc).unwrap_or_else(|_| "auto".to_string())
@@ -115,6 +123,26 @@ impl ResponsesResponseBuilder {
         self
     }
 
+    /// Set the completion timestamp. Should be populated when the response
+    /// reaches a terminal status (`completed`, `incomplete`, `failed`,
+    /// `cancelled`).
+    pub fn completed_at(mut self, timestamp: i64) -> Self {
+        self.completed_at = Some(timestamp);
+        self
+    }
+
+    /// Mark the response as created in background mode.
+    pub fn background(mut self, background: bool) -> Self {
+        self.background = Some(background);
+        self
+    }
+
+    /// Set the linked conversation ID.
+    pub fn conversation(mut self, conversation: impl Into<String>) -> Self {
+        self.conversation = Some(conversation.into());
+        self
+    }
+
     /// Set the response status
     pub fn status(mut self, status: ResponseStatus) -> Self {
         self.status = status;
@@ -127,8 +155,8 @@ impl ResponsesResponseBuilder {
         self
     }
 
-    /// Set incomplete details (if response was truncated)
-    pub fn incomplete_details(mut self, details: Value) -> Self {
+    /// Set incomplete details (if response terminated with `status = incomplete`)
+    pub fn incomplete_details(mut self, details: IncompleteDetails) -> Self {
         self.incomplete_details = Some(details);
         self
     }
@@ -271,6 +299,9 @@ impl ResponsesResponseBuilder {
             id: self.id,
             object: self.object,
             created_at: self.created_at,
+            completed_at: self.completed_at,
+            background: self.background,
+            conversation: self.conversation,
             status: self.status,
             error: self.error,
             incomplete_details: self.incomplete_details,

--- a/crates/protocols/src/responses.rs
+++ b/crates/protocols/src/responses.rs
@@ -179,6 +179,11 @@ pub enum ResponseInputOutputItem {
         #[serde(skip_serializing_if = "Vec::is_empty")]
         #[serde(default)]
         content: Vec<ResponseReasoningContent>,
+        /// Encrypted reasoning payload for gpt-5 / o-series round-trip via
+        /// `previous_response_id`. Opaque to SMG; must be preserved intact.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default)]
+        encrypted_content: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         status: Option<String>,
     },
@@ -281,6 +286,11 @@ pub enum ResponseOutputItem {
         id: String,
         summary: Vec<String>,
         content: Vec<ResponseReasoningContent>,
+        /// Encrypted reasoning payload for gpt-5 / o-series round-trip.
+        /// Opaque to SMG; must be preserved intact.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default)]
+        encrypted_content: Option<String>,
         status: Option<String>,
     },
     #[serde(rename = "function_call")]
@@ -453,8 +463,29 @@ pub enum ResponseStatus {
     Queued,
     InProgress,
     Completed,
+    Incomplete,
     Failed,
     Cancelled,
+}
+
+/// Reason why a response terminated with `status = incomplete`.
+///
+/// Matches the OpenAI Responses API `incomplete_details.reason` field, which is
+/// restricted to exactly these two values. Other termination causes
+/// (wall-clock timeout, `max_tool_calls`, provider errors) map to
+/// `ResponseStatus::Failed` with an `error.code`, not to `Incomplete`.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, schemars::JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum IncompleteReason {
+    MaxOutputTokens,
+    ContentFilter,
+}
+
+/// Details accompanying a response with `status = incomplete`.
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, schemars::JsonSchema)]
+pub struct IncompleteDetails {
+    pub reason: IncompleteReason,
 }
 
 #[serde_with::skip_serializing_none]
@@ -1077,10 +1108,20 @@ fn validate_responses_cross_parameters(request: &ResponsesRequest) -> Result<(),
         }
     }
 
-    // 3. Validate background/stream conflict
-    if request.background == Some(true) && request.stream == Some(true) {
-        let mut e = ValidationError::new("background_conflicts_with_stream");
-        e.message = Some("Cannot use background mode with streaming".into());
+    // 3. Validate background + store interaction.
+    //
+    // OpenAI's Responses API defaults `store=true`; SMG's request type keeps
+    // `store: Option<bool>`, so `None` means "caller did not specify" and is
+    // treated as the OpenAI default (stored). Only an explicit `store=false`
+    // combined with `background=true` is rejected: a background response must
+    // be durably retrievable via `GET /v1/responses/{id}`.
+    //
+    // Note: `background=true` with `stream=true` IS allowed, matching the
+    // OpenAI SDK which issues a streaming background create.
+    if request.background == Some(true) && request.store == Some(false) {
+        let mut e = ValidationError::new("background_requires_store");
+        e.message =
+            Some("background=true requires store=true (or unset, which defaults to true)".into());
         return Err(e);
     }
 
@@ -1298,8 +1339,24 @@ pub struct ResponsesResponse {
     #[serde(default = "default_object_type")]
     pub object: String,
 
-    /// Creation timestamp
+    /// Creation timestamp (unix seconds)
     pub created_at: i64,
+
+    /// Completion timestamp (unix seconds). `None` until the response reaches
+    /// a terminal state (`completed`, `incomplete`, `failed`, `cancelled`).
+    #[serde(default)]
+    pub completed_at: Option<i64>,
+
+    /// Whether the response was created in background mode.
+    #[serde(default)]
+    pub background: Option<bool>,
+
+    /// Conversation this response is linked to, if any. Mirrors the request's
+    /// `conversation` field; cleared to `None` if conversation linkage was
+    /// skipped (e.g. the conversation was deleted between enqueue and
+    /// finalize).
+    #[serde(default)]
+    pub conversation: Option<String>,
 
     /// Response status
     pub status: ResponseStatus,
@@ -1307,8 +1364,8 @@ pub struct ResponsesResponse {
     /// Error information if status is failed
     pub error: Option<Value>,
 
-    /// Incomplete details if response was truncated
-    pub incomplete_details: Option<Value>,
+    /// Incomplete details if response truncated with `status = incomplete`
+    pub incomplete_details: Option<IncompleteDetails>,
 
     /// System instructions used
     pub instructions: Option<String>,
@@ -1399,6 +1456,11 @@ impl ResponsesResponse {
     pub fn is_failed(&self) -> bool {
         matches!(self.status, ResponseStatus::Failed)
     }
+
+    /// Check if the response terminated as incomplete (max_output_tokens / content_filter)
+    pub fn is_incomplete(&self) -> bool {
+        matches!(self.status, ResponseStatus::Incomplete)
+    }
 }
 
 impl ResponseOutputItem {
@@ -1417,7 +1479,10 @@ impl ResponseOutputItem {
         }
     }
 
-    /// Create a new reasoning output item
+    /// Create a new reasoning output item.
+    ///
+    /// `encrypted_content` defaults to `None`; use [`Self::new_reasoning_encrypted`]
+    /// when round-tripping gpt-5 / o-series encrypted reasoning.
     pub fn new_reasoning(
         id: String,
         summary: Vec<String>,
@@ -1428,6 +1493,24 @@ impl ResponseOutputItem {
             id,
             summary,
             content,
+            encrypted_content: None,
+            status,
+        }
+    }
+
+    /// Create a new reasoning output item carrying an encrypted reasoning payload.
+    pub fn new_reasoning_encrypted(
+        id: String,
+        summary: Vec<String>,
+        content: Vec<ResponseReasoningContent>,
+        encrypted_content: Option<String>,
+        status: Option<String>,
+    ) -> Self {
+        Self::Reasoning {
+            id,
+            summary,
+            content,
+            encrypted_content,
             status,
         }
     }

--- a/crates/protocols/tests/background_mode_protocol.rs
+++ b/crates/protocols/tests/background_mode_protocol.rs
@@ -1,0 +1,247 @@
+//! Protocol-surface contract tests for background-mode responses (BGM-PR-01).
+//!
+//! These cover the public wire/Rust API the background-mode design relies on:
+//!
+//! - `ResponseStatus::Incomplete` exists and serializes as `"incomplete"`.
+//! - `incomplete_details` is typed with `reason ∈ {max_output_tokens, content_filter}`.
+//! - `reasoning` items round-trip `encrypted_content`.
+//! - Request validation accepts `background=true` with `stream=true`, accepts
+//!   `background=true` with `store` unset or `store=true`, rejects
+//!   `background=true` with `store=false`.
+//! - `ResponsesResponse` exposes `background`, `completed_at`, and
+//!   `conversation` fields and round-trips them through serde.
+
+use openai_protocol::responses::{
+    IncompleteDetails, IncompleteReason, ResponseInputOutputItem, ResponseOutputItem,
+    ResponseReasoningContent, ResponseStatus, ResponsesRequest, ResponsesResponse,
+};
+use serde_json::{json, Value};
+use validator::Validate;
+
+// ---------------------------------------------------------------------------
+// Status + incomplete_details
+// ---------------------------------------------------------------------------
+
+#[test]
+fn response_status_incomplete_serializes_snake_case() {
+    let s = serde_json::to_string(&ResponseStatus::Incomplete).expect("serialize");
+    assert_eq!(s, "\"incomplete\"");
+
+    let back: ResponseStatus = serde_json::from_str("\"incomplete\"").expect("deserialize");
+    assert_eq!(back, ResponseStatus::Incomplete);
+}
+
+#[test]
+fn incomplete_details_round_trip_both_reasons() {
+    for (reason, wire) in [
+        (IncompleteReason::MaxOutputTokens, "max_output_tokens"),
+        (IncompleteReason::ContentFilter, "content_filter"),
+    ] {
+        let expected_debug = format!("{reason:?}");
+        let v = serde_json::to_value(IncompleteDetails { reason }).expect("serialize");
+        assert_eq!(v, json!({ "reason": wire }));
+        let back: IncompleteDetails = serde_json::from_value(v).expect("deserialize");
+        assert_eq!(format!("{:?}", back.reason), expected_debug);
+    }
+}
+
+#[test]
+fn incomplete_details_rejects_unknown_reason() {
+    // The OpenAI spec restricts `reason` to `max_output_tokens` / `content_filter`.
+    // Historical SMG code set `max_tool_calls` here; the typed form must reject
+    // that so the protocol cannot silently emit a spec-violating payload.
+    let err = serde_json::from_value::<IncompleteDetails>(json!({
+        "reason": "max_tool_calls"
+    }))
+    .expect_err("unknown reason must fail to deserialize");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("max_output_tokens") || msg.contains("variant"),
+        "error message should reference allowed variants: {msg}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Reasoning encrypted_content round-trip
+// ---------------------------------------------------------------------------
+
+#[test]
+fn reasoning_output_item_round_trips_encrypted_content() {
+    let item = ResponseOutputItem::new_reasoning_encrypted(
+        "r_1".to_string(),
+        vec!["thought summary".to_string()],
+        vec![ResponseReasoningContent::ReasoningText {
+            text: "inner thought".to_string(),
+        }],
+        Some("opaque-ciphertext-xyz".to_string()),
+        Some("completed".to_string()),
+    );
+
+    let v = serde_json::to_value(&item).expect("serialize");
+    assert_eq!(v["encrypted_content"], "opaque-ciphertext-xyz");
+
+    let back: ResponseOutputItem = serde_json::from_value(v).expect("deserialize");
+    match back {
+        ResponseOutputItem::Reasoning {
+            encrypted_content, ..
+        } => {
+            assert_eq!(encrypted_content.as_deref(), Some("opaque-ciphertext-xyz"));
+        }
+        _ => panic!("expected Reasoning variant"),
+    }
+}
+
+#[test]
+fn reasoning_input_item_deserializes_encrypted_content() {
+    let item: ResponseInputOutputItem = serde_json::from_value(json!({
+        "type": "reasoning",
+        "id": "r_1",
+        "summary": [],
+        "encrypted_content": "ct-abc",
+    }))
+    .expect("deserialize");
+    match item {
+        ResponseInputOutputItem::Reasoning {
+            encrypted_content, ..
+        } => assert_eq!(encrypted_content.as_deref(), Some("ct-abc")),
+        _ => panic!("expected Reasoning variant"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Validator: background + stream + store interactions
+// ---------------------------------------------------------------------------
+
+#[test]
+fn validator_accepts_background_with_stream() {
+    let req: ResponsesRequest = serde_json::from_value(json!({
+        "model": "gpt-5.4",
+        "input": "hello",
+        "background": true,
+        "stream": true,
+    }))
+    .expect("deserialize");
+    req.validate()
+        .expect("background=true + stream=true is valid");
+}
+
+#[test]
+fn validator_accepts_background_with_store_unset() {
+    let req: ResponsesRequest = serde_json::from_value(json!({
+        "model": "gpt-5.4",
+        "input": "hello",
+        "background": true,
+    }))
+    .expect("deserialize");
+    req.validate()
+        .expect("background=true with store unset defaults to stored");
+}
+
+#[test]
+fn validator_accepts_background_with_store_true() {
+    let req: ResponsesRequest = serde_json::from_value(json!({
+        "model": "gpt-5.4",
+        "input": "hello",
+        "background": true,
+        "store": true,
+    }))
+    .expect("deserialize");
+    req.validate().expect("background=true + store=true valid");
+}
+
+#[test]
+fn validator_rejects_background_with_store_false() {
+    let req: ResponsesRequest = serde_json::from_value(json!({
+        "model": "gpt-5.4",
+        "input": "hello",
+        "background": true,
+        "store": false,
+    }))
+    .expect("deserialize");
+    let err = req
+        .validate()
+        .expect_err("background=true + store=false must fail");
+    assert!(
+        format!("{err:?}").contains("background_requires_store"),
+        "expected background_requires_store code, got {err:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// ResponsesResponse: background, completed_at, conversation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn responses_response_serializes_new_fields() {
+    let resp = ResponsesResponse::builder("resp_xyz", "gpt-5.4")
+        .status(ResponseStatus::Completed)
+        .background(true)
+        .completed_at(1_700_000_000)
+        .conversation("conv_123")
+        .build();
+
+    let v = serde_json::to_value(&resp).expect("serialize");
+    assert_eq!(v["background"], true);
+    assert_eq!(v["completed_at"], 1_700_000_000);
+    assert_eq!(v["conversation"], "conv_123");
+}
+
+#[test]
+fn responses_response_round_trips_incomplete_status_and_details() {
+    let resp = ResponsesResponse::builder("resp_xyz", "gpt-5.4")
+        .status(ResponseStatus::Incomplete)
+        .incomplete_details(IncompleteDetails {
+            reason: IncompleteReason::MaxOutputTokens,
+        })
+        .build();
+
+    let v = serde_json::to_value(&resp).expect("serialize");
+    assert_eq!(v["status"], "incomplete");
+    assert_eq!(v["incomplete_details"]["reason"], "max_output_tokens");
+
+    let back: ResponsesResponse = serde_json::from_value(v).expect("deserialize");
+    assert_eq!(back.status, ResponseStatus::Incomplete);
+    let details = back.incomplete_details.expect("details present");
+    assert_eq!(details.reason, IncompleteReason::MaxOutputTokens);
+}
+
+#[test]
+fn responses_response_omits_background_and_completed_at_when_unset() {
+    let resp = ResponsesResponse::builder("resp_xyz", "gpt-5.4")
+        .status(ResponseStatus::InProgress)
+        .build();
+
+    let v = serde_json::to_value(&resp).expect("serialize");
+    // The new fields default to `None`; serde emits them as `null`. What
+    // matters is that the server did not invent values — a newly-built
+    // non-background response has no background / completed / conversation.
+    assert_eq!(v["background"], Value::Null);
+    assert_eq!(v["completed_at"], Value::Null);
+    assert_eq!(v["conversation"], Value::Null);
+}
+
+#[test]
+fn copy_from_request_propagates_background_and_conversation() {
+    let request: ResponsesRequest = serde_json::from_value(json!({
+        "model": "gpt-5.4",
+        "input": "hello",
+        "background": true,
+        "conversation": "conv_abc",
+    }))
+    .expect("deserialize");
+    let resp = ResponsesResponse::builder("resp_xyz", "gpt-5.4")
+        .copy_from_request(&request)
+        .build();
+    assert_eq!(resp.background, Some(true));
+    assert_eq!(resp.conversation.as_deref(), Some("conv_abc"));
+}
+
+#[test]
+fn is_incomplete_helper() {
+    let resp = ResponsesResponse::builder("resp_xyz", "gpt-5.4")
+        .status(ResponseStatus::Incomplete)
+        .build();
+    assert!(resp.is_incomplete());
+    assert!(!resp.is_complete());
+    assert!(!resp.is_failed());
+}

--- a/model_gateway/src/routers/grpc/harmony/processor.rs
+++ b/model_gateway/src/routers/grpc/harmony/processor.rs
@@ -270,6 +270,7 @@ impl HarmonyResponseProcessor {
                 id: format!("reasoning_{}", dispatch.request_id),
                 summary: vec![],
                 content: vec![ResponseReasoningContent::ReasoningText { text: analysis }],
+                encrypted_content: None,
                 status: Some("completed".to_string()),
             };
             output.push(reasoning_item);

--- a/model_gateway/src/routers/grpc/harmony/responses/common.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/common.rs
@@ -93,6 +93,7 @@ pub(super) fn build_next_request_with_tools(
             content: vec![ResponseReasoningContent::ReasoningText {
                 text: analysis_text,
             }],
+            encrypted_content: None,
             status: Some("completed".to_string()),
         });
     }

--- a/model_gateway/src/routers/grpc/harmony/responses/non_streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/non_streaming.rs
@@ -223,9 +223,11 @@ async fn execute_with_mcp_loop(
                         Arc::new(response_request),
                     );
 
-                    // Mark as completed with incomplete_details
-                    response.status = ResponseStatus::Completed;
-                    response.incomplete_details = Some(json!({ "reason": "max_tool_calls" }));
+                    // `max_tool_calls` exhaustion is not an OpenAI-valid `incomplete` reason
+                    // (spec restricts to `max_output_tokens` / `content_filter`). Surface as
+                    // `failed` with an explicit error code instead.
+                    response.status = ResponseStatus::Failed;
+                    response.error = Some(json!({ "code": "max_tool_calls_exceeded" }));
 
                     // Inject MCP metadata if any calls were executed
                     if mcp_tracking.total_calls() > 0 {
@@ -404,6 +406,7 @@ fn build_tool_response(
             content: vec![ResponseReasoningContent::ReasoningText {
                 text: analysis_text,
             }],
+            encrypted_content: None,
             status: Some("completed".to_string()),
         });
     }

--- a/model_gateway/src/routers/grpc/regular/responses/conversions.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/conversions.rs
@@ -315,6 +315,7 @@ pub(crate) fn chat_to_responses(
                 content: vec![ReasoningText {
                     text: reasoning.clone(),
                 }],
+                encrypted_content: None,
                 status: Some("completed".to_string()),
             });
         }

--- a/model_gateway/src/routers/grpc/regular/responses/non_streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/non_streaming.rs
@@ -326,9 +326,11 @@ pub(super) async fn execute_tool_loop(
                     )
                 })?;
 
-                // Mark as completed but with incomplete details
-                responses_response.status = ResponseStatus::Completed;
-                responses_response.incomplete_details = Some(json!({ "reason": "max_tool_calls" }));
+                // `max_tool_calls` exhaustion is not an OpenAI-valid `incomplete` reason
+                // (spec restricts to `max_output_tokens` / `content_filter`). Surface as
+                // `failed` with an explicit error code instead.
+                responses_response.status = ResponseStatus::Failed;
+                responses_response.error = Some(json!({ "code": "max_tool_calls_exceeded" }));
 
                 return Ok(responses_response);
             }

--- a/model_gateway/src/routers/grpc/regular/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/streaming.rs
@@ -375,6 +375,7 @@ impl StreamingResponseAccumulator {
                 content: vec![ResponseReasoningContent::ReasoningText {
                     text: self.reasoning_buffer,
                 }],
+                encrypted_content: None,
                 status: Some("completed".to_string()),
             });
         }

--- a/model_gateway/tests/spec/responses.rs
+++ b/model_gateway/tests/spec/responses.rs
@@ -862,29 +862,37 @@ fn test_validate_top_logprobs_requires_include() {
     );
 }
 
-/// Test background/stream conflict
+/// Background mode with streaming is now allowed (BGM-PR-01) — the OpenAI
+/// SDK issues streaming background creates, so rejecting the combo broke
+/// SDK parity. The new rule is `background=true` requires `store != false`.
 #[test]
-fn test_validate_background_stream_conflict() {
-    // Invalid: both background and stream enabled
+fn test_validate_background_with_stream_allowed() {
     let request = ResponsesRequest {
         input: ResponseInput::Text("test".to_string()),
         background: Some(true),
         stream: Some(true),
         ..Default::default()
     };
-    let result = request.validate();
-    assert!(
-        result.is_err(),
-        "background=true with stream=true should be invalid"
-    );
+    request
+        .validate()
+        .expect("background=true + stream=true should be accepted");
+}
 
-    if let Err(errors) = result {
-        let error_msg = errors.to_string();
-        assert!(
-            error_msg.contains("background") || error_msg.contains("stream"),
-            "Error should mention background/stream conflict"
-        );
-    }
+#[test]
+fn test_validate_background_requires_store() {
+    let request = ResponsesRequest {
+        input: ResponseInput::Text("test".to_string()),
+        background: Some(true),
+        store: Some(false),
+        ..Default::default()
+    };
+    let err = request
+        .validate()
+        .expect_err("background=true with store=false must be rejected");
+    assert!(
+        format!("{err:?}").contains("background_requires_store"),
+        "expected background_requires_store error code, got {err:?}"
+    );
 }
 
 /// Test previous_response_id format validation


### PR DESCRIPTION
## Description

### Problem

The background-mode design (`.claude/designs/background-mode/draft.md`) needs a protocol surface that matches the OpenAI Responses API and is strict enough to refuse spec-violating payloads. Today:

- `ResponseStatus` (`crates/protocols/src/responses.rs:429-435`) is `{Queued, InProgress, Completed, Failed, Cancelled}` — missing `Incomplete`, so the wire contract cannot represent OpenAI's `incomplete` termination class.
- `incomplete_details: Option<Value>` (same file, line 1288) is untyped, which is how two SMG call sites ended up emitting `{"reason": "max_tool_calls"}` — a reason the OpenAI SDK does not accept (SDK restricts `reason` to `{max_output_tokens, content_filter}`).
- `Reasoning` items (input and output variants) do not carry `encrypted_content`, so gpt-5 / o-series encrypted reasoning cannot round-trip via `previous_response_id` chaining.
- `validate_responses_cross_parameters` rejects `background=true` with `stream=true` outright, contradicting OpenAI's SDK which issues streaming background creates. It also does not enforce `background` requires `store`.
- `ResponsesResponse` has no `background`, `completed_at`, or `conversation` fields, so a background response cannot surface its mode / terminal time / conversation linkage on the wire.

### Solution

Extend `openai-protocol` to represent the full background-mode contract. No runtime behavior change — the create / claim / resume paths land in BGM-PR-02..15. Router code is touched only where the new type shapes force it (struct-literal plumbing plus the two spec-violating `max_tool_calls` sites).

## Changes

**Protocol types** (`crates/protocols/src/responses.rs`):
- Add `ResponseStatus::Incomplete` plus `ResponsesResponse::is_incomplete()`.
- Introduce typed `IncompleteDetails { reason: IncompleteReason }` with `IncompleteReason ∈ {MaxOutputTokens, ContentFilter}` (strict — unknown reasons fail deserialization). Replace `incomplete_details: Option<Value>` with `Option<IncompleteDetails>` on `ResponsesResponse`.
- Add optional `encrypted_content: Option<String>` to both `ResponseInputOutputItem::Reasoning` and `ResponseOutputItem::Reasoning`. New constructor `ResponseOutputItem::new_reasoning_encrypted`.
- Replace the `background_conflicts_with_stream` validator with `background_requires_store`: `background=true` with explicit `store=false` is rejected; `store` unset is treated as the OpenAI default (true). `background=true` with `stream=true` is now accepted.
- Add `background: Option<bool>`, `completed_at: Option<i64>`, `conversation: Option<String>` to `ResponsesResponse`.

**Builder** (`crates/protocols/src/builders/responses/response.rs`):
- New setters: `.background()`, `.completed_at()`, `.conversation()`.
- `.incomplete_details()` now takes `IncompleteDetails`.
- `copy_from_request` propagates `background` and `conversation` from the request.

**Router plumbing** (`model_gateway/src/routers/grpc/…`):
- Five existing `Reasoning { ... }` construction sites gain `encrypted_content: None` so the tree compiles against the new variant shape. No behavioral change.
- Two sites that emitted the spec-violating `status=Completed + incomplete_details{reason: max_tool_calls}` now emit `status=Failed + error.code=max_tool_calls_exceeded` (regular and harmony `non_streaming.rs`). This aligns with `draft.md:320-325` and with the OpenAI `incomplete_details.reason` set.

**Tests**:
- New integration test file `crates/protocols/tests/background_mode_protocol.rs` — 14 contract tests (status serialization, `IncompleteDetails` round-trip + unknown-reason rejection, `encrypted_content` round-trip on both reasoning variants, validator accept/reject matrix for `background × stream × store`, `ResponsesResponse` new-field round-trip, `copy_from_request` propagation, `is_incomplete` helper).
- `model_gateway/tests/spec/responses.rs`: replace `test_validate_background_stream_conflict` with `test_validate_background_with_stream_allowed` + `test_validate_background_requires_store`.

## Test Plan

All five pre-PR gates run on the final diff:

1. `cargo +nightly fmt --all -- --check` → silent success.
2. `cargo clippy --all-targets --all-features -- -D warnings` → 0 warnings, 0 errors.
3. `cargo test` (full workspace) → all test binaries pass; the 14 new `background_mode_protocol` tests pass; the two rewritten spec tests pass.
4. `cargo check -p smg-python` → compiles clean; no Python binding struct literal uses any of the affected types (verified with grep), so no `maturin develop` regression.
5. Commit: conventional `feat(protocols):`, DCO sign-off via `git commit -s`, no AI attribution.

Additional targeted runs:
- `cargo test -p openai-protocol --test background_mode_protocol` → 14/14 pass.
- `cargo test -p smg --test spec_test` → pass (includes the two new validator tests).
- Verified the pre-existing `background_conflicts_with_stream` validator in `crates/protocols/src/interactions.rs:1109` is NOT the one touched here — it governs the Anthropic-style Interactions API and is intentionally left alone.

Out of scope (land in later PRs per `2026-04-17-background-mode-task-breakdown.md`): repository trait, schema, migrations, router entry points, scheduler, worker, stream persistence, conversation linkage.

<details>
<summary>Checklist</summary>

- [x] \`cargo +nightly fmt\` passes
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` passes
- [x] Documentation updated (integration test file doc comment enumerates the covered contract)
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

Refs: BGM-PR-01

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Background response mode updated: now allowed with streaming and includes stricter validation when storage is disabled
  * New "Incomplete" response status with detailed reasons and structured incomplete metadata
  * Optional encrypted reasoning payload support and new response metadata: completion timestamp, background flag, conversation reference

* **Bug Fixes**
  * Tool-call limit breach now returns a failed response with an explicit error code instead of marking it incomplete
<!-- end of auto-generated comment: release notes by coderabbit.ai -->