### PR TITLE
feat(protocols): integrate skills request surfaces

### DIFF
--- a/crates/protocols/src/messages.rs
+++ b/crates/protocols/src/messages.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use validator::Validate;
 
-use crate::validated::Normalizable;
+use crate::{skills::MessagesSkillRef, validated::Normalizable};
 
 // ============================================================================
 // Request Types
@@ -1074,7 +1074,7 @@ pub struct ContainerConfig {
     pub id: Option<String>,
 
     /// Skills to be loaded in the container
-    pub skills: Option<Vec<String>>,
+    pub skills: Option<Vec<MessagesSkillRef>>,
 }
 
 /// MCP server configuration (beta)

--- a/crates/protocols/src/responses.rs
+++ b/crates/protocols/src/responses.rs
@@ -14,7 +14,9 @@ use super::{
     },
     sampling_params::{validate_top_k_value, validate_top_p_value},
 };
-use crate::{builders::ResponsesResponseBuilder, validated::Normalizable};
+use crate::{
+    builders::ResponsesResponseBuilder, skills::ResponsesSkillEntry, validated::Normalizable,
+};
 
 // ============================================================================
 // Response Tools (MCP and others)
@@ -78,6 +80,14 @@ pub struct WebSearchPreviewTool {
 #[serde(deny_unknown_fields)]
 pub struct CodeInterpreterTool {
     pub container: Option<Value>,
+    pub environment: Option<ResponseToolEnvironment>,
+}
+
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Clone, Deserialize, Serialize, Default, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ResponseToolEnvironment {
+    pub skills: Option<Vec<ResponsesSkillEntry>>,
 }
 
 /// `require_approval` values.

--- a/crates/protocols/src/skills.rs
+++ b/crates/protocols/src/skills.rs
@@ -114,6 +114,15 @@ pub enum ChatCompletionsSkillRef {
     },
 }
 
+/// Decoded payload carried in the `X-SMG-Skills` header for `/v1/chat/completions`.
+///
+/// On the wire the header value is a URL-safe base64 encoded JSON array of
+/// `ChatCompletionsSkillRef` entries. This wrapper models the decoded protocol
+/// payload before header encoding/after header decoding.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(transparent)]
+pub struct ChatCompletionsSkillsHeader(pub Vec<ChatCompletionsSkillRef>);
+
 /// Version reference accepted by skill attachment surfaces.
 ///
 /// Deserialization is intentionally manual to reject ambiguous numeric strings

--- a/crates/protocols/src/skills.rs
+++ b/crates/protocols/src/skills.rs
@@ -90,39 +90,6 @@ impl<'de> Deserialize<'de> for ResponsesSkillEntry {
     }
 }
 
-/// Accepted in `X-SMG-Skills` for `/v1/chat/completions`.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
-#[serde(tag = "type")]
-pub enum ChatCompletionsSkillRef {
-    #[serde(rename = "custom")]
-    Custom {
-        skill_id: String,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        version: Option<SkillVersionRef>,
-    },
-    #[serde(rename = "openai")]
-    OpenAI {
-        skill_id: String,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        version: Option<String>,
-    },
-    #[serde(rename = "anthropic")]
-    Anthropic {
-        skill_id: String,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        version: Option<String>,
-    },
-}
-
-/// Decoded payload carried in the `X-SMG-Skills` header for `/v1/chat/completions`.
-///
-/// On the wire the header value is a URL-safe base64 encoded JSON array of
-/// `ChatCompletionsSkillRef` entries. This wrapper models the decoded protocol
-/// payload before header encoding/after header decoding.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
-#[serde(transparent)]
-pub struct ChatCompletionsSkillsHeader(pub Vec<ChatCompletionsSkillRef>);
-
 /// Version reference accepted by skill attachment surfaces.
 ///
 /// Deserialization is intentionally manual to reject ambiguous numeric strings

--- a/crates/protocols/tests/skills_protocol.rs
+++ b/crates/protocols/tests/skills_protocol.rs
@@ -1,5 +1,10 @@
-use openai_protocol::skills::{
-    OpaqueOpenAIObject, ResponsesSkillEntry, ResponsesSkillRef, SkillVersionRef,
+use openai_protocol::{
+    messages::CreateMessageRequest,
+    responses::{CodeInterpreterTool, ResponseTool},
+    skills::{
+        ChatCompletionsSkillRef, ChatCompletionsSkillsHeader, MessagesSkillRef, OpaqueOpenAIObject,
+        ResponsesSkillEntry, ResponsesSkillRef, SkillVersionRef,
+    },
 };
 use schemars::schema_for;
 use serde::Deserialize;
@@ -61,6 +66,45 @@ fn optional_skill_version_ref_accepts_null_and_absent() {
 
     let absent_value: OptionalVersionHolder = serde_json::from_value(json!({})).unwrap();
     assert_eq!(absent_value.version, None);
+}
+
+#[test]
+fn messages_container_skills_use_typed_skill_refs() {
+    let raw = json!({
+        "model": "claude-test",
+        "messages": [{"role": "user", "content": "hello"}],
+        "max_tokens": 16,
+        "container": {
+            "id": "container_123",
+            "skills": [
+                {
+                    "type": "custom",
+                    "skill_id": "skill_123",
+                    "version": "latest"
+                },
+                {
+                    "type": "anthropic",
+                    "skill_id": "claude-search",
+                    "version": "20260301"
+                }
+            ]
+        }
+    });
+
+    let request: CreateMessageRequest = serde_json::from_value(raw.clone()).unwrap();
+    let container = request.container.as_ref().unwrap();
+    let expected = vec![
+        MessagesSkillRef::Custom {
+            skill_id: "skill_123".to_string(),
+            version: Some(SkillVersionRef::Latest),
+        },
+        MessagesSkillRef::Anthropic {
+            skill_id: "claude-search".to_string(),
+            version: Some("20260301".to_string()),
+        },
+    ];
+    assert_eq!(container.skills.as_ref().unwrap(), &expected);
+    assert_eq!(serde_json::to_value(&request).unwrap(), raw);
 }
 
 #[test]
@@ -160,6 +204,60 @@ fn responses_skill_entry_rejects_non_object_payloads() {
 }
 
 #[test]
+fn responses_code_interpreter_legacy_container_round_trips() {
+    let raw = json!({
+        "type": "code_interpreter",
+        "container": {
+            "type": "auto",
+            "runtime": "python"
+        }
+    });
+
+    let tool: ResponseTool = serde_json::from_value(raw.clone()).unwrap();
+    assert_eq!(serde_json::to_value(&tool).unwrap(), raw);
+}
+
+#[test]
+fn responses_code_interpreter_environment_skills_round_trip() {
+    let raw = json!({
+        "type": "code_interpreter",
+        "container": {
+            "type": "auto"
+        },
+        "environment": {
+            "skills": [
+                {
+                    "type": "skill_reference",
+                    "skill_id": "skill_123",
+                    "version": "latest"
+                },
+                {
+                    "type": "inline_skill",
+                    "name": "map",
+                    "description": "Map the codebase",
+                    "instructions": "Read the crate map before implementing changes."
+                }
+            ]
+        }
+    });
+
+    let tool: ResponseTool = serde_json::from_value(raw.clone()).unwrap();
+    assert_eq!(serde_json::to_value(&tool).unwrap(), raw);
+}
+
+#[test]
+fn code_interpreter_tool_schema_keeps_container_and_adds_environment() {
+    let schema = serde_json::to_value(schema_for!(CodeInterpreterTool)).unwrap();
+    let properties = schema
+        .get("properties")
+        .and_then(serde_json::Value::as_object)
+        .unwrap();
+
+    assert!(properties.contains_key("container"));
+    assert!(properties.contains_key("environment"));
+}
+
+#[test]
 fn skill_version_ref_schema_matches_runtime_contract() {
     let schema = serde_json::to_value(schema_for!(SkillVersionRef)).unwrap();
     let one_of = schema
@@ -177,4 +275,36 @@ fn skill_version_ref_schema_matches_runtime_contract() {
         branch.get("type") == Some(&json!("string"))
             && branch.get("pattern") == Some(&json!("^[1-9][0-9]{9,}$"))
     }));
+}
+
+#[test]
+fn chat_completions_skills_header_round_trips_decoded_payload() {
+    let raw = json!([
+        {
+            "type": "custom",
+            "skill_id": "skill_123",
+            "version": "latest"
+        },
+        {
+            "type": "openai",
+            "skill_id": "openai-spreadsheets",
+            "version": "2026-03-01"
+        }
+    ]);
+
+    let header: ChatCompletionsSkillsHeader = serde_json::from_value(raw.clone()).unwrap();
+    assert_eq!(
+        header,
+        ChatCompletionsSkillsHeader(vec![
+            ChatCompletionsSkillRef::Custom {
+                skill_id: "skill_123".to_string(),
+                version: Some(SkillVersionRef::Latest),
+            },
+            ChatCompletionsSkillRef::OpenAI {
+                skill_id: "openai-spreadsheets".to_string(),
+                version: Some("2026-03-01".to_string()),
+            }
+        ])
+    );
+    assert_eq!(serde_json::to_value(&header).unwrap(), raw);
 }

--- a/crates/protocols/tests/skills_protocol.rs
+++ b/crates/protocols/tests/skills_protocol.rs
@@ -2,8 +2,8 @@ use openai_protocol::{
     messages::CreateMessageRequest,
     responses::{CodeInterpreterTool, ResponseTool},
     skills::{
-        ChatCompletionsSkillRef, ChatCompletionsSkillsHeader, MessagesSkillRef, OpaqueOpenAIObject,
-        ResponsesSkillEntry, ResponsesSkillRef, SkillVersionRef,
+        MessagesSkillRef, OpaqueOpenAIObject, ResponsesSkillEntry, ResponsesSkillRef,
+        SkillVersionRef,
     },
 };
 use schemars::schema_for;
@@ -275,36 +275,4 @@ fn skill_version_ref_schema_matches_runtime_contract() {
         branch.get("type") == Some(&json!("string"))
             && branch.get("pattern") == Some(&json!("^[1-9][0-9]{9,}$"))
     }));
-}
-
-#[test]
-fn chat_completions_skills_header_round_trips_decoded_payload() {
-    let raw = json!([
-        {
-            "type": "custom",
-            "skill_id": "skill_123",
-            "version": "latest"
-        },
-        {
-            "type": "openai",
-            "skill_id": "openai-spreadsheets",
-            "version": "2026-03-01"
-        }
-    ]);
-
-    let header: ChatCompletionsSkillsHeader = serde_json::from_value(raw.clone()).unwrap();
-    assert_eq!(
-        header,
-        ChatCompletionsSkillsHeader(vec![
-            ChatCompletionsSkillRef::Custom {
-                skill_id: "skill_123".to_string(),
-                version: Some(SkillVersionRef::Latest),
-            },
-            ChatCompletionsSkillRef::OpenAI {
-                skill_id: "openai-spreadsheets".to_string(),
-                version: Some("2026-03-01".to_string()),
-            }
-        ])
-    );
-    assert_eq!(serde_json::to_value(&header).unwrap(), raw);
 }


### PR DESCRIPTION
## Description

### Problem

`SKL-PR-02` requires the protocol layer to expose typed skills attachment surfaces for Messages and Responses without regressing existing request payloads.

### Solution

Wire the new skills protocol types into the request models while preserving backward-compatible request shapes:
- use typed `MessagesSkillRef` entries for `container.skills`
- add typed `tools[].environment.skills[]` support for Responses without breaking `code_interpreter.container`
- cover the new and legacy payloads with serde/schema tests

## Changes

- update `ContainerConfig.skills` to `Vec<MessagesSkillRef>`
- add `ResponseToolEnvironment` and `CodeInterpreterTool.environment`
- add integration coverage for Messages and Responses request-surface round trips
- keep Chat Completions out of the skills protocol surface

Closes #1178

## Test Plan

1. `cargo +nightly fmt --all`
2. `env -u RUSTC_WRAPPER cargo clippy --all-targets --all-features --target-dir /tmp/smg-gate-target -- -D warnings`
3. `env -u RUSTC_WRAPPER cargo test --target-dir /tmp/smg-gate-target`
4. `source /tmp/smg-python-dev-venv/bin/activate && env -u RUSTC_WRAPPER CARGO_BUILD_RUSTC_WRAPPER= /opt/homebrew/bin/maturin develop` (run from `bindings/python`)
5. Verified serde/schema scenarios for:
   - typed `container.skills` in Messages
   - legacy Responses `code_interpreter.container` round-trip
   - new Responses `code_interpreter.environment.skills` round-trip


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Code interpreter tools can include an optional environment object that carries skill entries.

* **Updates**
  * Skills references in message containers now use typed skill references instead of raw strings.
  * Container and tool schemas/serialization refined for stricter validation.

* **Removals**
  * Deprecated chat-completions skill enum removed.

* **Tests**
  * Added round-trip and schema tests covering typed skills and environment handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->