### PR TITLE
feat(responses): continue approved MCP calls

### DIFF
--- a/crates/mcp/src/core/orchestrator.rs
+++ b/crates/mcp/src/core/orchestrator.rs
@@ -1061,6 +1061,88 @@ impl McpOrchestrator {
         }
     }
 
+    /// Continue a previously approved resolved tool call without re-entering approval.
+    pub async fn continue_tool_resolved_execution(
+        &self,
+        input: ToolExecutionInput,
+        server_key: &str,
+        server_label: &str,
+    ) -> ToolExecutionOutput {
+        let start = Instant::now();
+        let arguments_str = input.arguments.to_string();
+
+        let qualified = QualifiedToolName::new(server_key, &input.tool_name);
+        let entry = self.tool_inventory.get_entry(server_key, &input.tool_name);
+
+        match entry {
+            Some(entry) => {
+                self.active_executions.fetch_add(1, Ordering::SeqCst);
+                let _guard = scopeguard::guard(Arc::clone(&self.active_executions), |count| {
+                    count.fetch_sub(1, Ordering::SeqCst);
+                });
+                self.metrics.record_call_start(&qualified);
+                let call_start_time = Instant::now();
+                let response_format = entry.response_format.clone();
+
+                let output = match self
+                    .execute_tool_with_reconnect(&entry, input.arguments)
+                    .await
+                {
+                    Ok(raw_result) => ToolExecutionOutput {
+                        call_id: input.call_id,
+                        tool_name: input.tool_name,
+                        server_key: server_key.to_string(),
+                        server_label: server_label.to_string(),
+                        arguments_str,
+                        output: Self::call_result_to_json(&raw_result),
+                        is_error: raw_result.is_error.unwrap_or(false),
+                        error_message: None,
+                        response_format: response_format.clone(),
+                        duration: call_start_time.elapsed(),
+                    },
+                    Err(e) => {
+                        let err = format!("Tool call failed: {e}");
+                        ToolExecutionOutput {
+                            call_id: input.call_id,
+                            tool_name: input.tool_name,
+                            server_key: server_key.to_string(),
+                            server_label: server_label.to_string(),
+                            arguments_str,
+                            output: serde_json::json!({ "error": &err }),
+                            is_error: true,
+                            error_message: Some(err),
+                            response_format,
+                            duration: call_start_time.elapsed(),
+                        }
+                    }
+                };
+
+                let duration_ms = output.duration.as_millis() as u64;
+                self.metrics
+                    .record_call_end(&qualified, !output.is_error, duration_ms);
+                output
+            }
+            None => {
+                let err = format!(
+                    "Tool '{}' not found on server '{}'",
+                    input.tool_name, server_key
+                );
+                ToolExecutionOutput {
+                    call_id: input.call_id,
+                    tool_name: input.tool_name,
+                    server_key: server_key.to_string(),
+                    server_label: server_label.to_string(),
+                    arguments_str,
+                    output: serde_json::json!({ "error": &err }),
+                    is_error: true,
+                    error_message: Some(err),
+                    response_format: ResponseFormat::Passthrough,
+                    duration: start.elapsed(),
+                }
+            }
+        }
+    }
+
     async fn execute_tool_entry_result(
         &self,
         entry: &ToolEntry,

--- a/crates/mcp/src/core/session.rs
+++ b/crates/mcp/src/core/session.rs
@@ -305,6 +305,50 @@ impl<'a> McpToolSession<'a> {
         }
     }
 
+    /// Continue a previously approved tool call without re-entering approval.
+    pub async fn continue_tool_execution(&self, input: ToolExecutionInput) -> ToolExecutionOutput {
+        let invoked_name = input.tool_name.clone();
+        let arguments_str = input.arguments.to_string();
+
+        if let Some(binding) = self.exposed_name_map.get(&invoked_name) {
+            let resolved_tool_name = binding.resolved_tool_name.clone();
+            let mut output = self
+                .orchestrator
+                .continue_tool_resolved_execution(
+                    ToolExecutionInput {
+                        call_id: input.call_id,
+                        tool_name: resolved_tool_name,
+                        arguments: input.arguments,
+                    },
+                    &binding.server_key,
+                    &binding.server_label,
+                )
+                .await;
+            output.tool_name = invoked_name;
+            output
+        } else {
+            let fallback_label = self
+                .all_mcp_servers
+                .first()
+                .map(|b| b.label.as_str())
+                .unwrap_or(DEFAULT_SERVER_LABEL)
+                .to_string();
+            let err = format!("Tool '{invoked_name}' is not in this session's exposed tool map");
+            ToolExecutionOutput {
+                call_id: input.call_id,
+                tool_name: invoked_name,
+                server_key: UNKNOWN_SERVER_KEY.to_string(),
+                server_label: fallback_label,
+                arguments_str,
+                output: serde_json::json!({ "error": &err }),
+                is_error: true,
+                error_message: Some(err),
+                response_format: ResponseFormat::Passthrough,
+                duration: std::time::Duration::default(),
+            }
+        }
+    }
+
     /// Resolve the user-facing server label for a tool.
     ///
     /// Uses the orchestrator inventory to find the tool's server key, then maps

--- a/crates/protocols/src/responses.rs
+++ b/crates/protocols/src/responses.rs
@@ -1102,7 +1102,16 @@ fn validate_responses_cross_parameters(request: &ResponsesRequest) -> Result<(),
             )
         });
 
-        if !has_valid_input {
+        let is_approval_only_continuation = !request.stream.unwrap_or(false)
+            && request
+                .previous_response_id
+                .as_ref()
+                .is_some_and(|id| !id.is_empty())
+            && items
+                .iter()
+                .all(|item| matches!(item, ResponseInputOutputItem::McpApprovalResponse { .. }));
+
+        if !has_valid_input && !is_approval_only_continuation {
             let mut e = ValidationError::new("input_missing_user_message");
             e.message = Some("Input items must contain at least one message".into());
             return Err(e);

--- a/e2e_test/responses/test_tools_call.py
+++ b/e2e_test/responses/test_tools_call.py
@@ -559,7 +559,7 @@ class TestToolCallingCloud:
         assert len(final_text) > 0, "Final text should not be empty"
 
     def test_mcp_approval_required_interrupts_and_resumes(self, model, api_client):
-        """Test MCP approval-required workflow eventually supports interruption and resume."""
+        """Test MCP approval-required workflow interrupts and resumes."""
 
         time.sleep(2)  # Avoid rate limiting
 
@@ -579,8 +579,31 @@ class TestToolCallingCloud:
 
         assert_mcp_approval_interruption_non_streaming(resp)
 
-        # TODO: extend this same test in a follow-up PR with the approval continuation
-        # request and assert the resumed turn emits mcp_call plus the final assistant output.
+        approval_request = next(item for item in resp.output if item.type == "mcp_approval_request")
+        resumed = api_client.responses.create(
+            model=model,
+            previous_response_id=resp.id,
+            input=[
+                {
+                    "type": "mcp_approval_response",
+                    "approval_request_id": approval_request.id,
+                    "approve": True,
+                }
+            ],
+            tools=[DEEPWIKI_MCP_TOOL, BRAVE_MCP_TOOL_REQUIRE_APPROVAL_ALWAYS],
+            stream=False,
+            reasoning={"effort": "low"},
+        )
+
+        assert resumed.error is None
+        assert resumed.status == "completed"
+        resumed_mcp_calls = [item for item in resumed.output if item.type == "mcp_call"]
+        assert len(resumed_mcp_calls) > 0
+        brave_calls = [item for item in resumed_mcp_calls if item.server_label == "brave"]
+        assert len(brave_calls) > 0, "Expected resumed brave mcp_call output"
+        assert all(call.approval_request_id == approval_request.id for call in brave_calls)
+        assert all(item.type != "mcp_approval_request" for item in resumed.output)
+        assert len(resumed.output_text) > 0
 
     def test_mcp_multi_server_tool_call(self, model, api_client):
         """Test MCP tool call with multiple MCP servers (non-streaming)."""

--- a/model_gateway/src/routers/openai/mcp/tool_loop.rs
+++ b/model_gateway/src/routers/openai/mcp/tool_loop.rs
@@ -17,7 +17,9 @@ use openai_protocol::{
         is_function_call_type, CodeInterpreterCallEvent, FileSearchCallEvent, ItemType, McpEvent,
         OutputItemEvent, WebSearchCallEvent,
     },
-    responses::{generate_id, ResponseInput, ResponseTool, ResponsesRequest},
+    responses::{
+        generate_id, ResponseInput, ResponseInputOutputItem, ResponseTool, ResponsesRequest,
+    },
 };
 use serde_json::{json, to_value, Value};
 use smg_mcp::{
@@ -50,6 +52,13 @@ pub(crate) struct ToolLoopState {
     pub existing_mcp_list_tools_labels: HashSet<String>,
     /// Transformed output items (mcp_call, web_search_call, etc.) - stored to avoid reconstruction
     pub mcp_call_items: Vec<Value>,
+}
+
+struct ApprovedToolContinuation {
+    approval_request_id: String,
+    tool_name: String,
+    arguments: Value,
+    arguments_str: String,
 }
 
 impl ToolLoopState {
@@ -329,6 +338,9 @@ pub(crate) fn build_resume_payload(
         .as_object_mut()
         .ok_or_else(|| "payload not an object".to_string())?;
 
+    obj.remove("tools");
+    obj.remove("tool_choice");
+
     let mut input_array = Vec::with_capacity(1 + conversation_history.len());
 
     match original_input {
@@ -341,8 +353,14 @@ pub(crate) fn build_resume_payload(
             input_array.push(user_item);
         }
         ResponseInput::Items(items) => {
-            let items_value =
-                to_value(items).map_err(|e| format!("Failed to serialize input items: {e}"))?;
+            let replay_items = items
+                .iter()
+                .filter(|item| !matches!(item, ResponseInputOutputItem::McpApprovalRequest { .. }))
+                .filter(|item| !matches!(item, ResponseInputOutputItem::McpApprovalResponse { .. }))
+                .cloned()
+                .collect::<Vec<_>>();
+            let items_value = to_value(replay_items)
+                .map_err(|e| format!("Failed to serialize input items: {e}"))?;
             if let Some(items_arr) = items_value.as_array() {
                 input_array.extend_from_slice(items_arr);
             }
@@ -585,6 +603,81 @@ fn approval_request_item_id_source(item_id: &str) -> String {
     normalize_tool_item_id_with_prefix(item_id, "mcpr_")
 }
 
+fn approval_continuation_call_id(approval_request_id: &str) -> String {
+    let suffix = approval_request_id
+        .strip_prefix("mcpr_")
+        .unwrap_or(approval_request_id);
+    format!("call_{suffix}")
+}
+
+fn approval_continuation_item_id(approval_request_id: &str) -> String {
+    let suffix = approval_request_id
+        .strip_prefix("mcpr_")
+        .unwrap_or(approval_request_id);
+    format!("fc_{suffix}")
+}
+
+fn payload_input(payload: &Value) -> Option<ResponseInput> {
+    payload
+        .get("input")
+        .cloned()
+        .and_then(|input| serde_json::from_value(input).ok())
+}
+
+fn extract_approved_tool_continuation(
+    current_input: &ResponseInput,
+    payload: &Value,
+) -> Option<ApprovedToolContinuation> {
+    let ResponseInput::Items(current_items) = current_input else {
+        return None;
+    };
+
+    let approval_response_id = current_items.iter().rev().find_map(|item| match item {
+        ResponseInputOutputItem::McpApprovalResponse {
+            approval_request_id,
+            approve,
+            ..
+        } if *approve => Some(approval_request_id.clone()),
+        _ => None,
+    })?;
+
+    let input = payload_input(payload)?;
+    let ResponseInput::Items(items) = input else {
+        return None;
+    };
+
+    items.iter().rev().find_map(|item| match item {
+        ResponseInputOutputItem::McpApprovalRequest {
+            id,
+            name,
+            arguments,
+            ..
+        } if id == &approval_response_id => {
+            serde_json::from_str(arguments)
+                .ok()
+                .map(|arguments_json| ApprovedToolContinuation {
+                    approval_request_id: approval_response_id.clone(),
+                    tool_name: name.clone(),
+                    arguments: arguments_json,
+                    arguments_str: arguments.clone(),
+                })
+        }
+        _ => None,
+    })
+}
+
+fn set_mcp_call_approval_request_id(item: &mut Value, approval_request_id: &str) {
+    let Some(obj) = item.as_object_mut() else {
+        return;
+    };
+    if obj.get("type").and_then(|value| value.as_str()) == Some(ItemType::MCP_CALL) {
+        obj.insert(
+            "approval_request_id".to_string(),
+            Value::String(approval_request_id.to_string()),
+        );
+    }
+}
+
 pub(crate) fn mcp_list_tools_bindings_to_emit(
     existing_labels: &HashSet<String>,
     bindings: &[McpServerBinding],
@@ -769,6 +862,78 @@ pub(crate) async fn execute_tool_loop(
     let base_payload = initial_payload.clone();
     let tools_json = base_payload.get("tools").cloned().unwrap_or(json!([]));
     let mut current_payload = initial_payload;
+
+    if let Some(continuation) =
+        extract_approved_tool_continuation(&original_body.input, &current_payload)
+    {
+        state.original_input =
+            payload_input(&current_payload).unwrap_or_else(|| original_body.input.clone());
+        state.iteration += 1;
+        state.total_calls += 1;
+
+        let effective_limit = match max_tool_calls {
+            Some(user_max) => user_max.min(DEFAULT_MAX_ITERATIONS),
+            None => DEFAULT_MAX_ITERATIONS,
+        };
+        if state.total_calls > effective_limit {
+            return Err("approved tool continuation exceeded max_tool_calls".to_string());
+        }
+
+        let call_id = approval_continuation_call_id(&continuation.approval_request_id);
+        let item_id = approval_continuation_item_id(&continuation.approval_request_id);
+        let tool_output = session
+            .continue_tool_execution(ToolExecutionInput {
+                call_id: call_id.clone(),
+                tool_name: continuation.tool_name.clone(),
+                arguments: continuation.arguments,
+            })
+            .await;
+
+        Metrics::record_mcp_tool_iteration(&original_body.model);
+        Metrics::record_mcp_tool_duration(
+            &original_body.model,
+            &tool_output.tool_name,
+            tool_output.duration,
+        );
+        Metrics::record_mcp_tool_call(
+            &original_body.model,
+            &tool_output.tool_name,
+            if tool_output.is_error {
+                metrics_labels::RESULT_ERROR
+            } else {
+                metrics_labels::RESULT_SUCCESS
+            },
+        );
+
+        let response_format = session.tool_response_format(&continuation.tool_name);
+        let tool_item_id = non_streaming_tool_item_id_source(&item_id, &response_format);
+        let mut transformed_item = build_transformed_mcp_call_item(
+            &tool_output.output,
+            &response_format,
+            &tool_item_id,
+            &tool_output.server_label,
+            &continuation.tool_name,
+            &continuation.arguments_str,
+        );
+        set_mcp_call_approval_request_id(&mut transformed_item, &continuation.approval_request_id);
+
+        state.record_call(
+            session.is_builtin_tool(&continuation.tool_name),
+            call_id,
+            continuation.tool_name,
+            continuation.arguments_str,
+            tool_output.output.to_string(),
+            transformed_item,
+        );
+
+        current_payload = build_resume_payload(
+            &base_payload,
+            &state.conversation_history,
+            &state.original_input,
+            &json!([]),
+            false,
+        )?;
+    }
 
     info!(
         "Starting tool loop: max_tool_calls={:?}, max_iterations={}",
@@ -1201,6 +1366,7 @@ fn extract_function_calls(resp: &Value) -> Vec<ExtractedFunctionCall> {
 mod tests {
     use std::collections::HashSet;
 
+    use openai_protocol::event_types::ItemType;
     use serde_json::json;
     use smg_mcp::{
         BuiltinToolType, McpConfig, McpOrchestrator, McpServerBinding, McpServerConfig,
@@ -1208,9 +1374,9 @@ mod tests {
     };
 
     use super::{
-        build_transformed_mcp_call_item, extract_openai_response_output_items,
-        is_internal_mcp_response_item, mcp_list_tools_bindings_to_emit, ResponseInput,
-        ToolLoopState,
+        build_resume_payload, build_transformed_mcp_call_item,
+        extract_openai_response_output_items, is_internal_mcp_response_item,
+        mcp_list_tools_bindings_to_emit, ResponseInput, ResponseInputOutputItem, ToolLoopState,
     };
 
     fn test_tool(name: &str) -> Tool {
@@ -1514,5 +1680,59 @@ mod tests {
         let output = r#"[{"type":"text","text":"{\"openai_response\":null}"}]"#;
         let extracted = extract_openai_response_output_items(output);
         assert!(extracted.is_empty());
+    }
+
+    #[test]
+    fn build_resume_payload_strips_approval_items_from_replayed_input() {
+        let base_payload = json!({
+            "model": "gpt-5.4",
+            "input": []
+        });
+        let original_input = ResponseInput::Items(vec![
+            ResponseInputOutputItem::Message {
+                id: "msg_1".to_string(),
+                role: "user".to_string(),
+                content: vec![openai_protocol::responses::ResponseContentPart::InputText {
+                    text: "hello".to_string(),
+                }],
+                status: Some("completed".to_string()),
+            },
+            ResponseInputOutputItem::McpApprovalRequest {
+                id: "mcpr_1".to_string(),
+                arguments: "{}".to_string(),
+                name: "ask_question".to_string(),
+                server_label: "deepwiki".to_string(),
+            },
+            ResponseInputOutputItem::McpApprovalResponse {
+                id: None,
+                approval_request_id: "mcpr_1".to_string(),
+                approve: true,
+                reason: None,
+            },
+        ]);
+
+        let payload = build_resume_payload(
+            &base_payload,
+            &[json!({
+                "type": ItemType::FUNCTION_CALL_OUTPUT,
+                "call_id": "call_1",
+                "output": "ok"
+            })],
+            &original_input,
+            &json!([]),
+            false,
+        )
+        .expect("resume payload");
+
+        let input = payload["input"].as_array().expect("input array");
+        assert_eq!(input.len(), 2);
+        assert_eq!(input[0]["type"], "message");
+        assert_eq!(input[1]["type"], ItemType::FUNCTION_CALL_OUTPUT);
+        assert!(input
+            .iter()
+            .all(|item| item["type"] != "mcp_approval_request"));
+        assert!(input
+            .iter()
+            .all(|item| item["type"] != "mcp_approval_response"));
     }
 }

--- a/model_gateway/src/routers/openai/responses/history.rs
+++ b/model_gateway/src/routers/openai/responses/history.rs
@@ -42,6 +42,9 @@ pub(crate) async fn load_input_history(
         .take()
         .filter(|id| !id.is_empty());
     let mut existing_mcp_list_tools_labels = HashSet::new();
+    let approval_only_continuation = previous_response_id.is_some()
+        && matches!(request_body.input, ResponseInput::Items(ref items) if !items.is_empty()
+            && items.iter().all(|item| matches!(item, ResponseInputOutputItem::McpApprovalResponse { .. })));
 
     // Load items from previous response chain if specified
     let mut chain_items: Option<Vec<ResponseInputOutputItem>> = None;
@@ -63,13 +66,14 @@ pub(crate) async fn load_input_history(
                     .responses
                     .iter()
                     .flat_map(|stored| {
-                        deserialize_items_from_array(&stored.input)
+                        deserialize_input_items_from_array(&stored.input)
                             .into_iter()
-                            .chain(deserialize_items_from_array(
+                            .chain(deserialize_output_items_from_array(
                                 stored
                                     .raw_response
                                     .get("output")
                                     .unwrap_or(&Value::Array(vec![])),
+                                approval_only_continuation,
                             ))
                     })
                     .collect();
@@ -226,12 +230,37 @@ pub(crate) async fn load_input_history(
     })
 }
 
-/// Deserialize ResponseInputOutputItems from a JSON array value
-fn deserialize_items_from_array(array: &Value) -> Vec<ResponseInputOutputItem> {
+fn deserialize_input_items_from_array(array: &Value) -> Vec<ResponseInputOutputItem> {
     array
         .as_array()
         .map(|arr| {
             arr.iter()
+                .filter(|item| {
+                    item.get("type").and_then(|v| v.as_str()) != Some("mcp_approval_response")
+                })
+                .filter_map(|item| {
+                    serde_json::from_value::<ResponseInputOutputItem>(item.clone())
+                        .map_err(|e| warn!("Failed to deserialize item: {}. Item: {}", e, item))
+                        .ok()
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn deserialize_output_items_from_array(
+    array: &Value,
+    keep_approval_requests: bool,
+) -> Vec<ResponseInputOutputItem> {
+    array
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter(|item| match item.get("type").and_then(|v| v.as_str()) {
+                    Some(ItemType::MCP_LIST_TOOLS) | Some(ItemType::MCP_CALL) => false,
+                    Some("mcp_approval_request") => keep_approval_requests,
+                    _ => true,
+                })
                 .filter_map(|item| {
                     serde_json::from_value::<ResponseInputOutputItem>(item.clone())
                         .map_err(|e| warn!("Failed to deserialize item: {}. Item: {}", e, item))

--- a/model_gateway/tests/api/responses_api_test.rs
+++ b/model_gateway/tests/api/responses_api_test.rs
@@ -5,8 +5,8 @@ use openai_protocol::{
     common::{GenerationRequest, ToolChoice, ToolChoiceValue, UsageInfo},
     responses::{
         CodeInterpreterTool, McpTool, ReasoningEffort, RequireApproval, RequireApprovalMode,
-        ResponseInput, ResponseReasoningParam, ResponseTool, ResponsesRequest, ServiceTier,
-        Truncation, WebSearchPreviewTool,
+        ResponseInput, ResponseInputOutputItem, ResponseReasoningParam, ResponseTool,
+        ResponsesRequest, ServiceTier, Truncation, WebSearchPreviewTool,
     },
 };
 use smg::{
@@ -338,6 +338,263 @@ async fn test_non_streaming_mcp_returns_approval_request_when_required() {
             .iter()
             .all(|entry| entry.get("type") != Some(&serde_json::Value::String("mcp_call".into()))),
         "response should interrupt before emitting mcp_call"
+    );
+
+    worker.stop().await;
+    mcp.stop().await;
+}
+
+#[tokio::test]
+async fn test_non_streaming_mcp_approval_continuation_uses_previous_response_id() {
+    let mut mcp = MockMCPServer::start().await.expect("start mcp");
+
+    let mcp_yaml = format!(
+        "servers:\n  - name: mock\n    protocol: streamable\n    url: {}\n",
+        mcp.url()
+    );
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let cfg_path = dir.path().join("mcp.yaml");
+    std::fs::write(&cfg_path, mcp_yaml).expect("write mcp cfg");
+
+    let mut worker = MockWorker::new(MockWorkerConfig {
+        port: 0,
+        worker_type: WorkerType::Regular,
+        health_status: HealthStatus::Healthy,
+        response_delay_ms: 0,
+        fail_rate: 0.0,
+    });
+    let worker_url = worker.start().await.expect("start worker");
+
+    let router_cfg = RouterConfig::builder()
+        .openai_mode(vec![worker_url])
+        .random_policy()
+        .host("127.0.0.1")
+        .port(0)
+        .max_payload_size(8 * 1024 * 1024)
+        .request_timeout_secs(60)
+        .worker_startup_timeout_secs(5)
+        .worker_startup_check_interval_secs(1)
+        .log_level("warn")
+        .max_concurrent_requests(32)
+        .queue_timeout_secs(5)
+        .build_unchecked();
+
+    let ctx =
+        crate::common::create_test_context_with_mcp_config(router_cfg, cfg_path.to_str().unwrap())
+            .await;
+    let router = RouterFactory::create_router(&ctx).await.expect("router");
+
+    let mcp_tool = ResponseTool::Mcp(McpTool {
+        server_url: Some(mcp.url()),
+        authorization: None,
+        headers: None,
+        server_label: "mock".to_string(),
+        server_description: None,
+        require_approval: Some(RequireApproval::Mode(RequireApprovalMode::Always)),
+        allowed_tools: None,
+    });
+
+    let req1 = ResponsesRequest {
+        background: Some(false),
+        include: None,
+        input: ResponseInput::Text("search something".to_string()),
+        instructions: Some("Be brief".to_string()),
+        max_output_tokens: Some(64),
+        max_tool_calls: None,
+        metadata: None,
+        model: "mock-model".to_string(),
+        parallel_tool_calls: Some(true),
+        previous_response_id: None,
+        reasoning: None,
+        service_tier: Some(ServiceTier::Auto),
+        store: Some(true),
+        stream: Some(false),
+        temperature: Some(0.2),
+        tool_choice: Some(ToolChoice::default()),
+        tools: Some(vec![mcp_tool.clone()]),
+        top_logprobs: Some(0),
+        top_p: None,
+        truncation: Some(Truncation::Disabled),
+        text: None,
+        user: None,
+        request_id: Some("resp_test_mcp_approval_continue_turn_1".to_string()),
+        priority: 0,
+        frequency_penalty: Some(0.0),
+        presence_penalty: Some(0.0),
+        stop: None,
+        top_k: -1,
+        min_p: 0.0,
+        repetition_penalty: 1.0,
+        conversation: None,
+    };
+
+    let resp1 = router
+        .route_responses(None, &req1, req1.model.as_str())
+        .await;
+    assert_eq!(resp1.status(), StatusCode::OK);
+
+    let body1 = axum::body::to_bytes(resp1.into_body(), usize::MAX)
+        .await
+        .expect("Failed to read response body");
+    let body1_json: serde_json::Value =
+        serde_json::from_slice(&body1).expect("Failed to parse response JSON");
+
+    let response_id = body1_json["id"]
+        .as_str()
+        .expect("first response should have id")
+        .to_string();
+    let approval_request = body1_json["output"]
+        .as_array()
+        .expect("first response output missing")
+        .iter()
+        .find(|entry| {
+            entry.get("type") == Some(&serde_json::Value::String("mcp_approval_request".into()))
+        })
+        .expect("missing mcp_approval_request output item");
+    let approval_request_id = approval_request["id"]
+        .as_str()
+        .expect("approval request should have id")
+        .to_string();
+
+    let req2 = ResponsesRequest {
+        background: Some(false),
+        include: None,
+        input: ResponseInput::Items(vec![ResponseInputOutputItem::McpApprovalResponse {
+            id: None,
+            approval_request_id: approval_request_id.clone(),
+            approve: true,
+            reason: None,
+        }]),
+        instructions: Some("Be brief".to_string()),
+        max_output_tokens: Some(64),
+        max_tool_calls: None,
+        metadata: None,
+        model: "mock-model".to_string(),
+        parallel_tool_calls: Some(true),
+        previous_response_id: Some(response_id),
+        reasoning: None,
+        service_tier: Some(ServiceTier::Auto),
+        store: Some(true),
+        stream: Some(false),
+        temperature: Some(0.2),
+        tool_choice: Some(ToolChoice::default()),
+        tools: Some(vec![mcp_tool.clone()]),
+        top_logprobs: Some(0),
+        top_p: None,
+        truncation: Some(Truncation::Disabled),
+        text: None,
+        user: None,
+        request_id: Some("resp_test_mcp_approval_continue_turn_2".to_string()),
+        priority: 0,
+        frequency_penalty: Some(0.0),
+        presence_penalty: Some(0.0),
+        stop: None,
+        top_k: -1,
+        min_p: 0.0,
+        repetition_penalty: 1.0,
+        conversation: None,
+    };
+
+    let resp2 = router
+        .route_responses(None, &req2, req2.model.as_str())
+        .await;
+    assert_eq!(resp2.status(), StatusCode::OK);
+
+    let body2 = axum::body::to_bytes(resp2.into_body(), usize::MAX)
+        .await
+        .expect("Failed to read response body");
+    let body2_json: serde_json::Value =
+        serde_json::from_slice(&body2).expect("Failed to parse response JSON");
+    let response2_id = body2_json["id"]
+        .as_str()
+        .expect("second response should have id")
+        .to_string();
+
+    let output = body2_json["output"]
+        .as_array()
+        .expect("response output missing");
+    assert_eq!(
+        output.len(),
+        2,
+        "expected resumed mcp_call plus final message"
+    );
+    assert_eq!(output[0]["type"], "mcp_call");
+    assert_eq!(output[0]["approval_request_id"], approval_request_id);
+    assert_eq!(output[0]["server_label"], "mock");
+    assert_eq!(output[0]["status"], "completed");
+    assert_eq!(output[1]["type"], "message");
+    assert!(
+        output
+            .iter()
+            .all(|entry| entry.get("type") != Some(&serde_json::Value::String("mcp_approval_request".into()))),
+        "continuation response should resume the approved tool instead of emitting another approval request"
+    );
+
+    let final_text = output[1]["content"][0]["text"]
+        .as_str()
+        .expect("final assistant message missing text");
+    assert_eq!(
+        final_text,
+        "Tool result consumed; here is the final answer."
+    );
+
+    let req3 = ResponsesRequest {
+        background: Some(false),
+        include: None,
+        input: ResponseInput::Text("search something again".to_string()),
+        instructions: Some("Be brief".to_string()),
+        max_output_tokens: Some(64),
+        max_tool_calls: None,
+        metadata: None,
+        model: "mock-model".to_string(),
+        parallel_tool_calls: Some(true),
+        previous_response_id: Some(response2_id),
+        reasoning: None,
+        service_tier: Some(ServiceTier::Auto),
+        store: Some(true),
+        stream: Some(false),
+        temperature: Some(0.2),
+        tool_choice: Some(ToolChoice::default()),
+        tools: Some(vec![mcp_tool]),
+        top_logprobs: Some(0),
+        top_p: None,
+        truncation: Some(Truncation::Disabled),
+        text: None,
+        user: None,
+        request_id: Some("resp_test_mcp_approval_continue_turn_3".to_string()),
+        priority: 0,
+        frequency_penalty: Some(0.0),
+        presence_penalty: Some(0.0),
+        stop: None,
+        top_k: -1,
+        min_p: 0.0,
+        repetition_penalty: 1.0,
+        conversation: None,
+    };
+
+    let resp3 = router
+        .route_responses(None, &req3, req3.model.as_str())
+        .await;
+    assert_eq!(resp3.status(), StatusCode::OK);
+
+    let body3 = axum::body::to_bytes(resp3.into_body(), usize::MAX)
+        .await
+        .expect("Failed to read response body");
+    let body3_json: serde_json::Value =
+        serde_json::from_slice(&body3).expect("Failed to parse response JSON");
+
+    let output3 = body3_json["output"]
+        .as_array()
+        .expect("third response output missing");
+    let approval_request3 = output3
+        .iter()
+        .find(|entry| entry.get("type") == Some(&serde_json::Value::String("mcp_approval_request".into())))
+        .expect("third response should request fresh approval instead of replaying the prior approval response");
+    assert_ne!(approval_request3["id"], approval_request_id);
+    assert!(
+        output3.iter().all(|entry| entry.get("approval_request_id")
+            != Some(&serde_json::Value::String(approval_request_id.clone()))),
+        "third response should not replay the prior approval continuation"
     );
 
     worker.stop().await;

--- a/model_gateway/tests/common/mock_worker.rs
+++ b/model_gateway/tests/common/mock_worker.rs
@@ -1048,7 +1048,7 @@ async fn responses_handler(
                 "usage": null
             }))
             .into_response()
-        } else if has_tools && has_prior_tool_context {
+        } else if has_prior_tool_context {
             Json(json!({
                 "id": format!("resp-{}", Uuid::now_v7()),
                 "object": "response",

--- a/model_gateway/tests/spec/responses.rs
+++ b/model_gateway/tests/spec/responses.rs
@@ -1008,6 +1008,47 @@ fn test_validate_input_items_structure() {
         result.is_err(),
         "Input items without messages should be invalid"
     );
+
+    // Valid: approval-only continuation with previous_response_id
+    let request = ResponsesRequest {
+        input: ResponseInput::Items(vec![ResponseInputOutputItem::McpApprovalResponse {
+            id: None,
+            approval_request_id: "mcpr_123".to_string(),
+            approve: true,
+            reason: None,
+        }]),
+        previous_response_id: Some("resp_123".to_string()),
+        ..Default::default()
+    };
+    assert!(
+        request.validate().is_ok(),
+        "Approval-only continuation should be valid when previous_response_id is set"
+    );
+
+    let request = ResponsesRequest {
+        input: ResponseInput::Items(vec![ResponseInputOutputItem::McpApprovalResponse {
+            id: None,
+            approval_request_id: "mcpr_123".to_string(),
+            approve: true,
+            reason: None,
+        }]),
+        previous_response_id: Some(String::new()),
+        ..Default::default()
+    };
+    assert!(request.validate().is_err());
+
+    let request = ResponsesRequest {
+        input: ResponseInput::Items(vec![ResponseInputOutputItem::McpApprovalResponse {
+            id: None,
+            approval_request_id: "mcpr_123".to_string(),
+            approve: true,
+            reason: None,
+        }]),
+        previous_response_id: Some("resp_123".to_string()),
+        stream: Some(true),
+        ..Default::default()
+    };
+    assert!(request.validate().is_err());
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- continue approved MCP calls for OpenAI `/v1/responses` non-streaming requests by resuming the approved tool locally and replaying only upstream-safe context
- allow approval-only continuation requests when paired with `previous_response_id`, and sanitize replayed history so later `previous_response_id` turns do not resend local `mcp_*` items upstream
- extend API/spec/e2e coverage and verify real `smg` behavior against OpenAI, including 6-turn `previous_response_id` flows for `require_approval: \"always\"` and `\"never\"`

## Validation
- `pre-commit run --all-files`
- `cargo test --package smg --test api_tests test_non_streaming_mcp_approval_continuation_uses_previous_response_id -- --nocapture`
- `cargo test --package smg --test spec_test test_validate_input_items_structure -- --nocapture`
- real HTTP verification against OpenAI + DeepWiki through `smg`, including:
  - first-turn approval interruption parity
  - second-turn approval continuation parity
  - 6-turn `previous_response_id` follow-up flows confirming the model retains the original MCP result for both `require_approval: \"always\"` and `\"never\"`

## Notes
- scope remains intentionally narrow: non-streaming OpenAI Responses continuation only
- streaming approval continuation is still out of scope

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * MCP tool approval continuations: users can now approve requested tools and seamlessly resume execution in subsequent requests without interrupting workflows.
  * Non-streaming conversation continuity: maintain full conversation history and context when resuming with approval responses.

* **Tests**
  * Added comprehensive integration tests for MCP approval continuations and related validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->