### PR TITLE
feat(mm): share multimodal config registry keyed by tokenizer UUID

### DIFF
--- a/model_gateway/src/app_context.rs
+++ b/model_gateway/src/app_context.rs
@@ -19,7 +19,10 @@ use crate::{
     middleware::TokenBucket,
     observability::inflight_tracker::InFlightRequestTracker,
     policies::PolicyRegistry,
-    routers::{openai::realtime::RealtimeRegistry, router_manager::RouterManager},
+    routers::{
+        grpc::multimodal::MultimodalConfigRegistry, openai::realtime::RealtimeRegistry,
+        router_manager::RouterManager,
+    },
     wasm::{config::WasmRuntimeConfig, module_manager::WasmModuleManager},
     worker::{KvEventMonitor, WorkerMonitor, WorkerRegistry, WorkerService},
     workflow::{JobQueue, WorkflowEngines},
@@ -49,6 +52,7 @@ pub struct AppContext {
     pub router_config: RouterConfig,
     pub rate_limiter: Option<Arc<TokenBucket>>,
     pub tokenizer_registry: Arc<TokenizerRegistry>,
+    pub multimodal_config_registry: Arc<MultimodalConfigRegistry>,
     pub reasoning_parser_factory: Option<ReasoningParserFactory>,
     pub tool_parser_factory: Option<ToolParserFactory>,
     pub worker_registry: Arc<WorkerRegistry>,
@@ -328,6 +332,7 @@ impl AppContextBuilder {
             tokenizer_registry: self
                 .tokenizer_registry
                 .ok_or(AppContextBuildError::MissingField("tokenizer_registry"))?,
+            multimodal_config_registry: Arc::new(MultimodalConfigRegistry::new()),
             reasoning_parser_factory: self.reasoning_parser_factory,
             tool_parser_factory: self.tool_parser_factory,
             worker_registry,

--- a/model_gateway/src/routers/grpc/multimodal.rs
+++ b/model_gateway/src/routers/grpc/multimodal.rs
@@ -42,6 +42,100 @@ pub(crate) struct MultimodalModelConfig {
     pub preprocessor_config: PreProcessorConfig,
 }
 
+/// Shared cache of multimodal model configuration files keyed by tokenizer UUID.
+///
+/// Sources of data:
+/// 1. Preloaded from `GetTokenizer` bundles during tokenizer registration.
+/// 2. Lazy-loaded from local disk / HF on first multimodal request.
+pub struct MultimodalConfigRegistry {
+    configs: DashMap<String, Arc<MultimodalModelConfig>>,
+}
+
+impl MultimodalConfigRegistry {
+    pub fn new() -> Self {
+        Self {
+            configs: DashMap::new(),
+        }
+    }
+
+    pub fn get(&self, tokenizer_id: &str) -> Option<Arc<MultimodalModelConfig>> {
+        self.configs.get(tokenizer_id).map(|r| r.clone())
+    }
+
+    pub fn insert(&self, tokenizer_id: String, config: Arc<MultimodalModelConfig>) {
+        self.configs.insert(tokenizer_id, config);
+    }
+
+    /// Return a cached config if present; otherwise load from `tokenizer_source`
+    /// (local dir or HF cache/download via `llm_multimodal::hub`), cache under
+    /// `tokenizer_id`, and return it.
+    pub async fn get_or_load(
+        &self,
+        tokenizer_id: &str,
+        tokenizer_source: &str,
+    ) -> Result<Arc<MultimodalModelConfig>> {
+        if let Some(cached) = self.get(tokenizer_id) {
+            debug!(%tokenizer_id, "multimodal config cache hit");
+            return Ok(cached);
+        }
+
+        debug!(
+            %tokenizer_id,
+            %tokenizer_source,
+            "multimodal config cache miss, loading"
+        );
+
+        let base_dir = llm_multimodal::hub::resolve_model_config_dir(tokenizer_source)
+            .await
+            .with_context(|| {
+                format!("Failed to resolve model config directory for '{tokenizer_source}'")
+            })?;
+
+        let config_path = base_dir.join("config.json");
+        let config: serde_json::Value = std::fs::read_to_string(&config_path)
+            .with_context(|| format!("Failed to read config.json at {}", config_path.display()))
+            .and_then(|s| {
+                serde_json::from_str(&s).with_context(|| {
+                    format!("Failed to parse config.json at {}", config_path.display())
+                })
+            })?;
+
+        let pp_config_path = base_dir.join("preprocessor_config.json");
+        let preprocessor_config = std::fs::read_to_string(&pp_config_path)
+            .with_context(|| {
+                format!(
+                    "Failed to read preprocessor_config.json at {}",
+                    pp_config_path.display()
+                )
+            })
+            .and_then(|s| {
+                PreProcessorConfig::from_json(&s).with_context(|| {
+                    format!(
+                        "Failed to parse preprocessor_config.json at {}",
+                        pp_config_path.display()
+                    )
+                })
+            })?;
+
+        let model_config = Arc::new(MultimodalModelConfig {
+            config,
+            preprocessor_config,
+        });
+
+        self.configs
+            .insert(tokenizer_id.to_string(), model_config.clone());
+
+        debug!(%tokenizer_id, "multimodal config loaded and cached");
+        Ok(model_config)
+    }
+}
+
+impl Default for MultimodalConfigRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Shared multimodal components injected at router creation time.
 pub(crate) struct MultimodalComponents {
     pub media_connector: Arc<MediaConnector>,
@@ -971,5 +1065,88 @@ mod tests {
         assert_eq!(parse_detail("LOW"), Some(ImageDetail::Low));
         assert_eq!(parse_detail("high"), Some(ImageDetail::High));
         assert_eq!(parse_detail("unknown"), None);
+    }
+
+    // ------------------------------------------------------------------
+    // MultimodalConfigRegistry tests
+    // ------------------------------------------------------------------
+
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn write_config_fixtures(dir: &std::path::Path) {
+        fs::write(
+            dir.join("config.json"),
+            r#"{"model_type":"phi3_v","image_token_index":32044}"#,
+        )
+        .unwrap();
+        fs::write(
+            dir.join("preprocessor_config.json"),
+            r#"{"image_processor_type":"Phi3VImageProcessor","image_mean":[0.48145466,0.4578275,0.40821073],"image_std":[0.26862954,0.26130258,0.27577711]}"#,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn registry_new_is_empty() {
+        let reg = MultimodalConfigRegistry::new();
+        assert!(reg.get("any-id").is_none());
+    }
+
+    #[test]
+    fn registry_insert_and_get_roundtrip() {
+        let reg = MultimodalConfigRegistry::new();
+        let cfg = Arc::new(MultimodalModelConfig {
+            config: serde_json::json!({"model_type":"phi3_v"}),
+            preprocessor_config: PreProcessorConfig::from_json(
+                r#"{"image_processor_type":"Phi3VImageProcessor"}"#,
+            )
+            .unwrap(),
+        });
+        reg.insert("tok-uuid-1".to_string(), cfg.clone());
+
+        let got = reg.get("tok-uuid-1").expect("entry present");
+        assert!(Arc::ptr_eq(&got, &cfg), "must return the same Arc");
+    }
+
+    #[tokio::test]
+    async fn registry_get_or_load_reads_from_local_dir_and_caches() {
+        let tmp = TempDir::new().unwrap();
+        write_config_fixtures(tmp.path());
+        let source = tmp.path().to_string_lossy().into_owned();
+
+        let reg = MultimodalConfigRegistry::new();
+        let first = reg.get_or_load("tok-uuid-2", &source).await.unwrap();
+        assert_eq!(first.config["model_type"].as_str(), Some("phi3_v"));
+
+        let second = reg.get_or_load("tok-uuid-2", &source).await.unwrap();
+        assert!(
+            Arc::ptr_eq(&first, &second),
+            "second call must hit cache and return same Arc"
+        );
+    }
+
+    #[tokio::test]
+    async fn registry_get_or_load_hits_preloaded_entry_without_touching_source() {
+        // Regression test for the IGW bug: preload populates the registry
+        // under the tokenizer UUID; `get_or_load` must return it without
+        // consulting `tokenizer_source` (which in IGW points to an
+        // unreachable worker-only path).
+        let reg = MultimodalConfigRegistry::new();
+        let cfg = Arc::new(MultimodalModelConfig {
+            config: serde_json::json!({"model_type":"phi3_v"}),
+            preprocessor_config: PreProcessorConfig::from_json(
+                r#"{"image_processor_type":"Phi3VImageProcessor"}"#,
+            )
+            .unwrap(),
+        });
+        reg.insert("tok-uuid-3".to_string(), cfg.clone());
+
+        let bad_source = "/nonexistent/worker-only/path-that-would-fail";
+        let got = reg
+            .get_or_load("tok-uuid-3", bad_source)
+            .await
+            .expect("preloaded entry must be returned without touching source");
+        assert!(Arc::ptr_eq(&got, &cfg));
     }
 }

--- a/model_gateway/src/routers/grpc/multimodal.rs
+++ b/model_gateway/src/routers/grpc/multimodal.rs
@@ -141,13 +141,14 @@ pub(crate) struct MultimodalComponents {
     pub media_connector: Arc<MediaConnector>,
     pub image_processor_registry: Arc<ImageProcessorRegistry>,
     pub model_registry: Arc<ModelRegistry>,
-    /// Lazily-loaded model configs, keyed by model_id.
-    pub model_configs: DashMap<String, Arc<MultimodalModelConfig>>,
+    /// Shared reference to the app-level multimodal config cache.
+    pub config_registry: Arc<MultimodalConfigRegistry>,
 }
 
 impl MultimodalComponents {
-    /// Create multimodal components with default registries.
-    pub fn new() -> Result<Self> {
+    /// Create multimodal components with default registries and a reference
+    /// to the shared `MultimodalConfigRegistry` owned by `AppContext`.
+    pub fn new(config_registry: Arc<MultimodalConfigRegistry>) -> Result<Self> {
         let client = reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(30))
             .build()
@@ -159,62 +160,8 @@ impl MultimodalComponents {
             media_connector: Arc::new(media_connector),
             image_processor_registry: Arc::new(ImageProcessorRegistry::with_defaults()),
             model_registry: Arc::new(ModelRegistry::default()),
-            model_configs: DashMap::new(),
+            config_registry,
         })
-    }
-
-    /// Load or retrieve cached model config for a given model and tokenizer source path.
-    pub async fn get_or_load_config(
-        &self,
-        model_id: &str,
-        tokenizer_source: &str,
-    ) -> Result<Arc<MultimodalModelConfig>> {
-        if let Some(cached) = self.model_configs.get(model_id) {
-            return Ok(cached.clone());
-        }
-
-        let base_dir = llm_multimodal::hub::resolve_model_config_dir(tokenizer_source)
-            .await
-            .with_context(|| {
-                format!("Failed to resolve model config directory for '{tokenizer_source}'")
-            })?;
-
-        // Load config.json
-        let config_path = base_dir.join("config.json");
-        let config: serde_json::Value = std::fs::read_to_string(&config_path)
-            .with_context(|| format!("Failed to read config.json at {}", config_path.display()))
-            .and_then(|s| {
-                serde_json::from_str(&s).with_context(|| {
-                    format!("Failed to parse config.json at {}", config_path.display())
-                })
-            })?;
-
-        // Load preprocessor_config.json
-        let pp_config_path = base_dir.join("preprocessor_config.json");
-        let preprocessor_config = std::fs::read_to_string(&pp_config_path)
-            .with_context(|| {
-                format!(
-                    "Failed to read preprocessor_config.json at {}",
-                    pp_config_path.display()
-                )
-            })
-            .and_then(|s| {
-                PreProcessorConfig::from_json(&s).with_context(|| {
-                    format!(
-                        "Failed to parse preprocessor_config.json at {}",
-                        pp_config_path.display()
-                    )
-                })
-            })?;
-
-        let model_config = Arc::new(MultimodalModelConfig {
-            config,
-            preprocessor_config,
-        });
-
-        self.model_configs
-            .insert(model_id.to_string(), model_config.clone());
-        Ok(model_config)
     }
 }
 
@@ -252,17 +199,20 @@ pub(crate) struct MultimodalIntermediate {
 
 /// Resolve the placeholder token string for a multimodal model.
 ///
-/// Loads the model config and looks up the model spec to get the placeholder
-/// token (e.g. `"<|image|>"` for Phi-3-vision). Returns `None` if the model
-/// is not recognized as multimodal.
+/// Loads the model config (via the shared registry, keyed by `tokenizer_id`)
+/// and looks up the model spec to get the placeholder token (e.g.
+/// `"<|image|>"` for Phi-3-vision). Returns `None` if the model is not
+/// recognized as multimodal.
 pub(crate) async fn resolve_placeholder_token(
     model_id: &str,
     tokenizer: &dyn TokenizerTrait,
     components: &MultimodalComponents,
+    tokenizer_id: &str,
     tokenizer_source: &str,
 ) -> Result<Option<String>> {
     let model_config = components
-        .get_or_load_config(model_id, tokenizer_source)
+        .config_registry
+        .get_or_load(tokenizer_id, tokenizer_source)
         .await?;
     let metadata = ModelMetadata {
         model_id,
@@ -409,15 +359,13 @@ fn extract_content_parts_messages(messages: &[InputMessage]) -> Vec<MediaContent
 }
 
 /// Process multimodal content from Messages API input messages.
-///
-/// Entry point for the messages preparation stage. Extracts image content parts
-/// from `InputMessage`, then delegates to the shared processing core.
 pub(crate) async fn process_multimodal_messages(
     messages: &[InputMessage],
     model_id: &str,
     tokenizer: &dyn TokenizerTrait,
     token_ids: Vec<u32>,
     components: &MultimodalComponents,
+    tokenizer_id: &str,
     tokenizer_source: &str,
 ) -> Result<MultimodalOutput> {
     let content_parts = extract_content_parts_messages(messages);
@@ -427,21 +375,20 @@ pub(crate) async fn process_multimodal_messages(
         tokenizer,
         token_ids,
         components,
+        tokenizer_id,
         tokenizer_source,
     )
     .await
 }
 
 /// Process multimodal content: fetch images, preprocess pixels, expand tokens, collect hashes.
-///
-/// Single entry point called from preparation.rs. Handles the full pipeline:
-/// extract content parts → fetch images → preprocess → expand tokens → collect hashes.
 pub(crate) async fn process_multimodal(
     messages: &[ChatMessage],
     model_id: &str,
     tokenizer: &dyn TokenizerTrait,
     token_ids: Vec<u32>,
     components: &MultimodalComponents,
+    tokenizer_id: &str,
     tokenizer_source: &str,
 ) -> Result<MultimodalOutput> {
     let content_parts = extract_content_parts(messages);
@@ -451,6 +398,7 @@ pub(crate) async fn process_multimodal(
         tokenizer,
         token_ids,
         components,
+        tokenizer_id,
         tokenizer_source,
     )
     .await
@@ -466,6 +414,7 @@ async fn process_multimodal_parts(
     tokenizer: &dyn TokenizerTrait,
     token_ids: Vec<u32>,
     components: &MultimodalComponents,
+    tokenizer_id: &str,
     tokenizer_source: &str,
 ) -> Result<MultimodalOutput> {
     let mut tracker = AsyncMultiModalTracker::new(components.media_connector.clone());
@@ -509,7 +458,8 @@ async fn process_multimodal_parts(
 
     // Step 2: Resolve model spec and preprocess images
     let model_config = components
-        .get_or_load_config(model_id, tokenizer_source)
+        .config_registry
+        .get_or_load(tokenizer_id, tokenizer_source)
         .await?;
     let model_type = model_config
         .config

--- a/model_gateway/src/routers/grpc/multimodal.rs
+++ b/model_gateway/src/routers/grpc/multimodal.rs
@@ -1022,6 +1022,7 @@ mod tests {
     // ------------------------------------------------------------------
 
     use std::fs;
+
     use tempfile::TempDir;
 
     fn write_config_fixtures(dir: &std::path::Path) {

--- a/model_gateway/src/routers/grpc/multimodal.rs
+++ b/model_gateway/src/routers/grpc/multimodal.rs
@@ -1099,4 +1099,38 @@ mod tests {
             .expect("preloaded entry must be returned without touching source");
         assert!(Arc::ptr_eq(&got, &cfg));
     }
+
+    #[tokio::test]
+    async fn multimodal_components_serves_preloaded_config_without_touching_source() {
+        // Simulates the IGW/K8s data path: GetTokenizer bundle is extracted,
+        // multimodal config is read, the bundle tempdir is cleaned up, and
+        // the parsed config is inserted into the shared registry under the
+        // tokenizer UUID. A later multimodal request must return the
+        // preloaded entry without attempting to re-read from `tokenizer_source`
+        // (which in IGW mode is an unreachable worker-only path).
+        let registry = Arc::new(MultimodalConfigRegistry::new());
+        let components = MultimodalComponents::new(registry.clone())
+            .expect("MultimodalComponents::new should succeed");
+
+        let cfg = Arc::new(MultimodalModelConfig {
+            config: serde_json::json!({"model_type":"phi3_v"}),
+            preprocessor_config: PreProcessorConfig::from_json(
+                r#"{"image_processor_type":"Phi3VImageProcessor"}"#,
+            )
+            .unwrap(),
+        });
+        registry.insert("tok-uuid-igw".to_string(), cfg.clone());
+
+        let bad_source = "/nonexistent/worker-only/path-that-would-fail";
+        let got = components
+            .config_registry
+            .get_or_load("tok-uuid-igw", bad_source)
+            .await
+            .expect("preloaded entry must be returned without touching source");
+
+        assert!(
+            Arc::ptr_eq(&got, &cfg),
+            "registry must return the exact Arc preloaded during registration"
+        );
+    }
 }

--- a/model_gateway/src/routers/grpc/multimodal.rs
+++ b/model_gateway/src/routers/grpc/multimodal.rs
@@ -52,24 +52,24 @@ pub struct MultimodalConfigRegistry {
 }
 
 impl MultimodalConfigRegistry {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             configs: DashMap::new(),
         }
     }
 
-    pub fn get(&self, tokenizer_id: &str) -> Option<Arc<MultimodalModelConfig>> {
+    pub(crate) fn get(&self, tokenizer_id: &str) -> Option<Arc<MultimodalModelConfig>> {
         self.configs.get(tokenizer_id).map(|r| r.clone())
     }
 
-    pub fn insert(&self, tokenizer_id: String, config: Arc<MultimodalModelConfig>) {
+    pub(crate) fn insert(&self, tokenizer_id: String, config: Arc<MultimodalModelConfig>) {
         self.configs.insert(tokenizer_id, config);
     }
 
     /// Return a cached config if present; otherwise load from `tokenizer_source`
     /// (local dir or HF cache/download via `llm_multimodal::hub`), cache under
     /// `tokenizer_id`, and return it.
-    pub async fn get_or_load(
+    pub(crate) async fn get_or_load(
         &self,
         tokenizer_id: &str,
         tokenizer_source: &str,

--- a/model_gateway/src/routers/grpc/pd_router.rs
+++ b/model_gateway/src/routers/grpc/pd_router.rs
@@ -55,7 +55,7 @@ impl GrpcPDRouter {
             .clone();
 
         // Create multimodal components (best-effort; non-fatal if initialization fails)
-        let multimodal = match MultimodalComponents::new() {
+        let multimodal = match MultimodalComponents::new(ctx.multimodal_config_registry.clone()) {
             Ok(mc) => Some(Arc::new(mc)),
             Err(e) => {
                 tracing::warn!("Multimodal components initialization failed (non-fatal): {e}");

--- a/model_gateway/src/routers/grpc/regular/stages/chat/preparation.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/chat/preparation.rs
@@ -57,30 +57,32 @@ impl ChatPreparationStage {
         let (image_placeholder, mm_context) = if is_multimodal {
             if let Some(mm_components) = ctx.components.multimodal.as_ref() {
                 let model_id = ctx.input.model_id.as_str();
-                let tokenizer_source = ctx
+                let entry = ctx
                     .components
                     .tokenizer_registry
                     .get_by_name(model_id)
-                    .or_else(|| ctx.components.tokenizer_registry.get_by_id(model_id))
-                    .map(|e| e.source)
-                    .unwrap_or_default();
+                    .or_else(|| ctx.components.tokenizer_registry.get_by_id(model_id));
 
-                if tokenizer_source.is_empty() {
-                    error!(
-                        function = "ChatPreparationStage::execute",
-                        model = %model_id,
-                        "Tokenizer source path not found for multimodal processing"
-                    );
-                    return Err(error::bad_request(
-                        "multimodal_config_missing",
-                        format!("Tokenizer source path not found for model: {model_id}"),
-                    ));
-                }
+                let (tokenizer_id, tokenizer_source) = match entry {
+                    Some(e) => (e.id.clone(), e.source.clone()),
+                    None => {
+                        error!(
+                            function = "ChatPreparationStage::execute",
+                            model = %model_id,
+                            "Tokenizer entry not found for multimodal processing"
+                        );
+                        return Err(error::bad_request(
+                            "multimodal_config_missing",
+                            format!("Tokenizer not found for model: {model_id}"),
+                        ));
+                    }
+                };
 
                 let placeholder = multimodal::resolve_placeholder_token(
                     model_id,
                     &*tokenizer,
                     mm_components,
+                    &tokenizer_id,
                     &tokenizer_source,
                 )
                 .await
@@ -99,7 +101,7 @@ impl ChatPreparationStage {
 
                 (
                     placeholder,
-                    Some((mm_components, model_id, tokenizer_source)),
+                    Some((mm_components, model_id, tokenizer_id, tokenizer_source)),
                 )
             } else {
                 error!(
@@ -144,13 +146,14 @@ impl ChatPreparationStage {
 
         // Step 4: Full multimodal processing (fetch + preprocess + expand tokens + hash)
         let mut multimodal_intermediate = None;
-        if let Some((mm_components, model_id, tokenizer_source)) = mm_context {
+        if let Some((mm_components, model_id, tokenizer_id, tokenizer_source)) = mm_context {
             match multimodal::process_multimodal(
                 &request.messages,
                 model_id,
                 &*tokenizer,
                 token_ids,
                 mm_components,
+                &tokenizer_id,
                 &tokenizer_source,
             )
             .await

--- a/model_gateway/src/routers/grpc/regular/stages/messages/preparation.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/messages/preparation.rs
@@ -79,30 +79,32 @@ impl MessagePreparationStage {
         let (image_placeholder, mm_context) = if is_multimodal {
             if let Some(mm_components) = ctx.components.multimodal.as_ref() {
                 let model_id = ctx.input.model_id.as_str();
-                let tokenizer_source = ctx
+                let entry = ctx
                     .components
                     .tokenizer_registry
                     .get_by_name(model_id)
-                    .or_else(|| ctx.components.tokenizer_registry.get_by_id(model_id))
-                    .map(|e| e.source)
-                    .unwrap_or_default();
+                    .or_else(|| ctx.components.tokenizer_registry.get_by_id(model_id));
 
-                if tokenizer_source.is_empty() {
-                    error!(
-                        function = "MessagePreparationStage::execute",
-                        model = %model_id,
-                        "Tokenizer source path not found for multimodal processing"
-                    );
-                    return Err(error::bad_request(
-                        "multimodal_config_missing",
-                        format!("Tokenizer source path not found for model: {model_id}"),
-                    ));
-                }
+                let (tokenizer_id, tokenizer_source) = match entry {
+                    Some(e) => (e.id.clone(), e.source.clone()),
+                    None => {
+                        error!(
+                            function = "MessagePreparationStage::execute",
+                            model = %model_id,
+                            "Tokenizer entry not found for multimodal processing"
+                        );
+                        return Err(error::bad_request(
+                            "multimodal_config_missing",
+                            format!("Tokenizer not found for model: {model_id}"),
+                        ));
+                    }
+                };
 
                 let placeholder = multimodal::resolve_placeholder_token(
                     model_id,
                     &*tokenizer,
                     mm_components,
+                    &tokenizer_id,
                     &tokenizer_source,
                 )
                 .await
@@ -121,7 +123,7 @@ impl MessagePreparationStage {
 
                 (
                     placeholder,
-                    Some((mm_components, model_id, tokenizer_source)),
+                    Some((mm_components, model_id, tokenizer_id, tokenizer_source)),
                 )
             } else {
                 error!(
@@ -167,13 +169,14 @@ impl MessagePreparationStage {
 
         // Step 4: Multimodal processing (fetch + preprocess + expand tokens + hash)
         let mut multimodal_intermediate = None;
-        if let Some((mm_components, model_id, tokenizer_source)) = mm_context {
+        if let Some((mm_components, model_id, tokenizer_id, tokenizer_source)) = mm_context {
             match multimodal::process_multimodal_messages(
                 &request.messages,
                 model_id,
                 &*tokenizer,
                 token_ids,
                 mm_components,
+                &tokenizer_id,
                 &tokenizer_source,
             )
             .await

--- a/model_gateway/src/routers/grpc/router.rs
+++ b/model_gateway/src/routers/grpc/router.rs
@@ -70,7 +70,7 @@ impl GrpcRouter {
         let _policy_registry = ctx.policy_registry.clone();
 
         // Create multimodal components (best-effort; non-fatal if initialization fails)
-        let multimodal = match MultimodalComponents::new() {
+        let multimodal = match MultimodalComponents::new(ctx.multimodal_config_registry.clone()) {
             Ok(mc) => Some(Arc::new(mc)),
             Err(e) => {
                 tracing::warn!("Multimodal components initialization failed (non-fatal): {e}");

--- a/model_gateway/src/service_discovery.rs
+++ b/model_gateway/src/service_discovery.rs
@@ -1274,6 +1274,9 @@ mod tests {
             workflow_engines: Arc::new(std::sync::OnceLock::new()),
             mcp_orchestrator: Arc::new(std::sync::OnceLock::new()),
             tokenizer_registry: Arc::new(llm_tokenizer::registry::TokenizerRegistry::new()),
+            multimodal_config_registry: Arc::new(
+                crate::routers::grpc::multimodal::MultimodalConfigRegistry::new(),
+            ),
             wasm_manager: None,
             worker_service: Arc::new(WorkerService::new(
                 worker_registry,

--- a/model_gateway/src/service_discovery.rs
+++ b/model_gateway/src/service_discovery.rs
@@ -1155,6 +1155,7 @@ mod tests {
     };
 
     use super::*;
+    use crate::routers::grpc::multimodal::MultimodalConfigRegistry;
 
     fn create_k8s_pod(
         name: Option<&str>,
@@ -1274,9 +1275,7 @@ mod tests {
             workflow_engines: Arc::new(std::sync::OnceLock::new()),
             mcp_orchestrator: Arc::new(std::sync::OnceLock::new()),
             tokenizer_registry: Arc::new(llm_tokenizer::registry::TokenizerRegistry::new()),
-            multimodal_config_registry: Arc::new(
-                crate::routers::grpc::multimodal::MultimodalConfigRegistry::new(),
-            ),
+            multimodal_config_registry: Arc::new(MultimodalConfigRegistry::new()),
             wasm_manager: None,
             worker_service: Arc::new(WorkerService::new(
                 worker_registry,

--- a/model_gateway/src/workflow/tokenizer_registration.rs
+++ b/model_gateway/src/workflow/tokenizer_registration.rs
@@ -25,7 +25,12 @@ use wfaas::{
 };
 
 use super::data::TokenizerWorkflowData;
-use crate::{app_context::AppContext, config::TokenizerCacheConfig, worker::ConnectionMode};
+use crate::{
+    app_context::AppContext,
+    config::TokenizerCacheConfig,
+    routers::grpc::multimodal::MultimodalModelConfig,
+    worker::ConnectionMode,
+};
 
 /// Configuration for adding a tokenizer
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -111,6 +116,7 @@ impl StepExecutor<TokenizerWorkflowData> for LoadTokenizerStep {
                 let cache_cfg = cache_config.clone();
                 let app_context = app_context.clone();
                 let name = name.clone();
+                let id = id.clone();
                 async move {
                     let base_tokenizer = match factory::create_tokenizer_async_with_chat_template(
                         &source,
@@ -125,7 +131,7 @@ impl StepExecutor<TokenizerWorkflowData> for LoadTokenizerStep {
                                 source, local_err
                             );
 
-                            fetch_tokenizer_from_worker(&app_context, &name).await.map_err(
+                            fetch_tokenizer_from_worker(&app_context, &id, &name).await.map_err(
                                 |worker_err| {
                                     format!(
                                         "Failed to load tokenizer locally ({local_err}) and remotely from worker ({worker_err})"
@@ -211,22 +217,87 @@ fn with_optional_cache(
     }
 }
 
-fn load_tokenizer_from_bundle(bundle: &StreamBundle) -> Result<Arc<dyn Tokenizer>, String> {
+fn load_tokenizer_from_bundle(
+    bundle: &StreamBundle,
+) -> Result<(Arc<dyn Tokenizer>, Option<MultimodalModelConfig>), String> {
     tokenizer_bundle::with_extracted_bundle(bundle, |tokenizer_dir| {
         let tokenizer_path = tokenizer_dir.to_string_lossy().into_owned();
         info!(
             "Tokenizer extracted from temporary path: {}",
             tokenizer_path
         );
-        factory::create_tokenizer_with_chat_template(&tokenizer_path, None)
-            .map_err(|e| format!("tokenizer load failed: {e}"))
+
+        let tokenizer = factory::create_tokenizer_with_chat_template(&tokenizer_path, None)
+            .map_err(|e| format!("tokenizer load failed: {e}"))?;
+
+        let mm_config = try_load_multimodal_config(tokenizer_dir);
+
+        Ok((tokenizer, mm_config))
     })
     .map_err(|e| format!("bundle extraction/load failed: {e}"))
+}
+
+/// Best-effort read of `config.json` + `preprocessor_config.json` from an
+/// extracted tokenizer bundle directory. Returns `None` if either file is
+/// missing or unparsable — text-only tokenizers legitimately ship without
+/// a `preprocessor_config.json`, and we do not want to fail tokenizer
+/// registration over multimodal artifacts.
+fn try_load_multimodal_config(
+    tokenizer_dir: &std::path::Path,
+) -> Option<MultimodalModelConfig> {
+    let config_path = tokenizer_dir.join("config.json");
+    let pp_config_path = tokenizer_dir.join("preprocessor_config.json");
+
+    if !config_path.exists() || !pp_config_path.exists() {
+        debug!(
+            "Bundle has no multimodal config (config.json present: {}, preprocessor_config.json present: {})",
+            config_path.exists(),
+            pp_config_path.exists()
+        );
+        return None;
+    }
+
+    let config_str = match std::fs::read_to_string(&config_path) {
+        Ok(s) => s,
+        Err(e) => {
+            warn!("Failed to read config.json from bundle: {e}");
+            return None;
+        }
+    };
+    let config: serde_json::Value = match serde_json::from_str(&config_str) {
+        Ok(v) => v,
+        Err(e) => {
+            warn!("Failed to parse config.json from bundle: {e}");
+            return None;
+        }
+    };
+
+    let pp_str = match std::fs::read_to_string(&pp_config_path) {
+        Ok(s) => s,
+        Err(e) => {
+            warn!("Failed to read preprocessor_config.json from bundle: {e}");
+            return None;
+        }
+    };
+    let preprocessor_config =
+        match llm_multimodal::PreProcessorConfig::from_json(&pp_str) {
+            Ok(c) => c,
+            Err(e) => {
+                warn!("Failed to parse preprocessor_config.json from bundle: {e}");
+                return None;
+            }
+        };
+
+    Some(MultimodalModelConfig {
+        config,
+        preprocessor_config,
+    })
 }
 
 /// Fetch a tokenizer from a healthy gRPC worker when local loading fails.
 async fn fetch_tokenizer_from_worker(
     app_context: &AppContext,
+    tokenizer_id: &str,
     model_id: &str,
 ) -> Result<Arc<dyn Tokenizer>, String> {
     let workers = app_context.worker_registry.get_workers_filtered(
@@ -305,7 +376,20 @@ async fn fetch_tokenizer_from_worker(
         );
 
         match load_tokenizer_from_bundle(&bundle) {
-            Ok(tokenizer) => return Ok(tokenizer),
+            Ok((tokenizer, mm_config)) => {
+                if let Some(cfg) = mm_config {
+                    app_context.multimodal_config_registry.insert(
+                        tokenizer_id.to_string(),
+                        Arc::new(cfg),
+                    );
+                    info!(
+                        tokenizer_id = %tokenizer_id,
+                        tokenizer_name = %model_id,
+                        "Preloaded multimodal config from GetTokenizer bundle"
+                    );
+                }
+                return Ok(tokenizer);
+            }
             Err(e) => failures.push(e),
         };
     }

--- a/model_gateway/src/workflow/tokenizer_registration.rs
+++ b/model_gateway/src/workflow/tokenizer_registration.rs
@@ -26,10 +26,8 @@ use wfaas::{
 
 use super::data::TokenizerWorkflowData;
 use crate::{
-    app_context::AppContext,
-    config::TokenizerCacheConfig,
-    routers::grpc::multimodal::MultimodalModelConfig,
-    worker::ConnectionMode,
+    app_context::AppContext, config::TokenizerCacheConfig,
+    routers::grpc::multimodal::MultimodalModelConfig, worker::ConnectionMode,
 };
 
 /// Configuration for adding a tokenizer
@@ -242,9 +240,7 @@ fn load_tokenizer_from_bundle(
 /// missing or unparsable — text-only tokenizers legitimately ship without
 /// a `preprocessor_config.json`, and we do not want to fail tokenizer
 /// registration over multimodal artifacts.
-fn try_load_multimodal_config(
-    tokenizer_dir: &std::path::Path,
-) -> Option<MultimodalModelConfig> {
+fn try_load_multimodal_config(tokenizer_dir: &std::path::Path) -> Option<MultimodalModelConfig> {
     let config_path = tokenizer_dir.join("config.json");
     let pp_config_path = tokenizer_dir.join("preprocessor_config.json");
 
@@ -279,14 +275,13 @@ fn try_load_multimodal_config(
             return None;
         }
     };
-    let preprocessor_config =
-        match llm_multimodal::PreProcessorConfig::from_json(&pp_str) {
-            Ok(c) => c,
-            Err(e) => {
-                warn!("Failed to parse preprocessor_config.json from bundle: {e}");
-                return None;
-            }
-        };
+    let preprocessor_config = match llm_multimodal::PreProcessorConfig::from_json(&pp_str) {
+        Ok(c) => c,
+        Err(e) => {
+            warn!("Failed to parse preprocessor_config.json from bundle: {e}");
+            return None;
+        }
+    };
 
     Some(MultimodalModelConfig {
         config,
@@ -378,10 +373,9 @@ async fn fetch_tokenizer_from_worker(
         match load_tokenizer_from_bundle(&bundle) {
             Ok((tokenizer, mm_config)) => {
                 if let Some(cfg) = mm_config {
-                    app_context.multimodal_config_registry.insert(
-                        tokenizer_id.to_string(),
-                        Arc::new(cfg),
-                    );
+                    app_context
+                        .multimodal_config_registry
+                        .insert(tokenizer_id.to_string(), Arc::new(cfg));
                     info!(
                         tokenizer_id = %tokenizer_id,
                         tokenizer_name = %model_id,


### PR DESCRIPTION
## Description

### Problem

In IGW/K8s mode the gateway loads tokenizers via `GetTokenizer` gRPC streaming. The bundle contains `config.json` and `preprocessor_config.json`, but those files are extracted to a tempdir that is deleted immediately after the tokenizer is loaded into memory.

When a multimodal request then arrives, `multimodal.rs` tries to read these files from disk using the tokenizer source — which in IGW is a worker-only path the gateway can't reach. The HF fallback also fails in air-gapped environments. Multimodal therefore breaks for any model whose tokenizer was loaded via `GetTokenizer`.

On top of that, the cache lived inside `MultimodalComponents` (per-router, unreachable from tokenizer registration) and was keyed by the request-time `model_id` — which is ambiguous because callers may pass either a tokenizer name or a tokenizer UUID.

### Solution

- New gateway-local `MultimodalConfigRegistry` owned by `AppContext`, keyed by `TokenizerEntry.id` (UUID).
- `MultimodalComponents` now holds an `Arc` reference to the shared registry instead of its own cache.
- `GetTokenizer` bundle extraction now reads both JSON files out of the tempdir before cleanup and inserts the parsed `MultimodalModelConfig` into the registry under the tokenizer UUID. Failure is non-fatal — text-only tokenizers legitimately have no `preprocessor_config.json`.
- Request-time code resolves the `TokenizerEntry` once at the preparation stage boundary and threads both `tokenizer_id` and `tokenizer_source` into the multimodal helpers.

## Changes

- `model_gateway/src/routers/grpc/multimodal.rs` — add `MultimodalConfigRegistry`; drop `model_configs` from `MultimodalComponents`; route multimodal lookups through the shared registry keyed by tokenizer UUID.
- `model_gateway/src/app_context.rs` — new `multimodal_config_registry: Arc<MultimodalConfigRegistry>` field initialized in `AppContextBuilder::build()`.
- `model_gateway/src/workflow/tokenizer_registration.rs` — read and parse mm config files inside the bundle-extraction closure (before tempdir cleanup); insert into the registry under the tokenizer UUID.
- `model_gateway/src/routers/grpc/router.rs` + `pd_router.rs` — pass the shared registry into `MultimodalComponents::new`.
- `model_gateway/src/routers/grpc/regular/stages/chat/preparation.rs` + `messages/preparation.rs` — resolve `TokenizerEntry` once; pass `tokenizer_id` + `tokenizer_source` downstream.
- `model_gateway/src/service_discovery.rs` — update test fixture for the new field.

## Test Plan

- [x] `cargo test -p smg --lib routers::grpc::multimodal::tests` — 14/14 passing.
- [x] `cargo test -p smg --lib` — full gateway library suite green.
- [x] `cargo check -p smg --all-targets` — clean.
- [x] `rg 'get_or_load_config|model_configs' model_gateway/src` — zero orphaned references.

New tests (all in \`model_gateway/src/routers/grpc/multimodal.rs\`):

- \`registry_new_is_empty\`, \`registry_insert_and_get_roundtrip\`, \`registry_get_or_load_reads_from_local_dir_and_caches\` — core registry behavior with tempdir fixtures.
- \`registry_get_or_load_hits_preloaded_entry_without_touching_source\` — unit-level regression fence: a preloaded entry is returned without consulting a deliberately unreachable \`tokenizer_source\`.
- \`multimodal_components_serves_preloaded_config_without_touching_source\` — integration-level regression fence: same invariant through \`MultimodalComponents::new(registry.clone())\`, confirming the \`AppContext\` wiring threads the same \`Arc\` end-to-end.

<details>
<summary>Checklist</summary>

- [x] \`cargo +nightly fmt\` passes
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Introduced centralized multimodal configuration registry for improved caching and resource sharing across the application
  * Changed configuration resolution from model-based to tokenizer-based lookup strategy
  * Enabled automatic preloading and caching of multimodal configurations when tokenizers are registered
  * Optimized configuration access patterns for multimodal processing components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->