### PR TITLE
feat(skills): add crate and config scaffolding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["model_gateway", "crates/protocols", "crates/reasoning_parser", "crates/tool_parser", "crates/workflow", "crates/tokenizer", "crates/auth", "crates/mcp", "crates/kv_index", "crates/data_connector", "crates/multimodal", "crates/wasm", "crates/mesh", "crates/grpc_client", "bindings/python", "bindings/golang", "clients/rust", "clients/openapi-gen", "tui"]
+members = ["model_gateway", "crates/protocols", "crates/reasoning_parser", "crates/tool_parser", "crates/workflow", "crates/tokenizer", "crates/auth", "crates/mcp", "crates/kv_index", "crates/data_connector", "crates/multimodal", "crates/wasm", "crates/mesh", "crates/grpc_client", "crates/skills", "bindings/python", "bindings/golang", "clients/rust", "clients/openapi-gen", "tui"]
 resolver = "2"
 
 [workspace.dependencies]
@@ -17,6 +17,7 @@ llm-multimodal = { version = "1.5.0", path = "crates/multimodal" }
 smg-wasm = { version = "1.1.0", path = "crates/wasm", package = "smg-wasm" }
 smg-mesh = { version = "1.3.0", path = "crates/mesh", package = "smg-mesh" }
 smg-grpc-client = { version = "1.5.1", path = "crates/grpc_client" }
+smg-skills = { version = "0.1.0", path = "crates/skills" }
 smg-tui = { version = "0.1.0", path = "tui" }
 
 # Shared dependencies

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1131,7 +1131,7 @@ impl Router {
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
 
         runtime.block_on(async move {
-            server::startup(server::ServerConfig {
+            Box::pin(server::startup(server::ServerConfig {
                 host: self.host.clone(),
                 port: self.port,
                 router_config,
@@ -1197,7 +1197,7 @@ impl Router {
                 },
                 webrtc_bind_addr: None,
                 webrtc_stun_server: None,
-            })
+            }))
             .await
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))
         })

--- a/crates/skills/Cargo.toml
+++ b/crates/skills/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "smg-skills"
+version = "0.1.0"
+edition = "2021"
+description = "Skills domain types and service scaffolding for SMG"
+license = "Apache-2.0"
+repository = "https://github.com/lightseekorg/smg"
+authors = [
+    "Simo Lin <linsimo.mark@gmail.com>",
+    "Chang Su <mckvtl@gmail.com>",
+    "Keyang Ru <rukeyang@gmail.com>",
+]
+keywords = ["skills", "agents", "gateway"]
+categories = ["web-programming", "network-programming"]
+
+[lib]
+name = "smg_skills"
+
+[dependencies]
+serde = { workspace = true, features = ["derive"] }
+
+[dev-dependencies]
+serde_json.workspace = true
+
+[lints]
+workspace = true

--- a/crates/skills/src/api.rs
+++ b/crates/skills/src/api.rs
@@ -1,0 +1,44 @@
+use std::sync::Arc;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SkillServiceMode {
+    #[default]
+    Placeholder,
+}
+
+#[derive(Debug, Default)]
+struct SkillServiceInner {
+    mode: SkillServiceMode,
+}
+
+/// Placeholder service hook used to establish the app-context boundary before
+/// the CRUD, storage, and resolution logic lands in later PRs.
+#[derive(Debug, Clone, Default)]
+pub struct SkillService {
+    inner: Arc<SkillServiceInner>,
+}
+
+impl SkillService {
+    pub fn placeholder() -> Self {
+        Self {
+            inner: Arc::new(SkillServiceInner {
+                mode: SkillServiceMode::Placeholder,
+            }),
+        }
+    }
+
+    pub fn mode(&self) -> SkillServiceMode {
+        self.inner.mode
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SkillService, SkillServiceMode};
+
+    #[test]
+    fn placeholder_service_reports_placeholder_mode() {
+        let service = SkillService::placeholder();
+        assert_eq!(service.mode(), SkillServiceMode::Placeholder);
+    }
+}

--- a/crates/skills/src/config.rs
+++ b/crates/skills/src/config.rs
@@ -1,0 +1,492 @@
+use std::{fmt, str::FromStr};
+
+use serde::{
+    de::{self, Visitor},
+    Deserialize, Deserializer, Serialize, Serializer,
+};
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum SkillsBlobStoreBackend {
+    #[default]
+    Filesystem,
+    S3,
+    Gcs,
+    Azure,
+    Oci,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum SkillsMissingMcpPolicy {
+    #[default]
+    Warn,
+    Reject,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum SkillsResolutionMode {
+    ToolLoop,
+    Eager,
+    #[default]
+    Auto,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum SkillsExecutionAsyncMode {
+    #[default]
+    PauseTurn,
+    PollAndWait,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SkillsAdminOperation {
+    ReadAnyTenant,
+    DeleteAnyTenant,
+    CreateAlias,
+    ExecuteMigration,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum SkillsRetentionMode {
+    #[default]
+    Standard,
+    NoContentLogs,
+    Zdr,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SkillsBudgetLimit {
+    Tokens(u32),
+    Unlimited,
+}
+
+impl Default for SkillsBudgetLimit {
+    fn default() -> Self {
+        Self::Tokens(16_000)
+    }
+}
+
+impl FromStr for SkillsBudgetLimit {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        if value.eq_ignore_ascii_case("unlimited") {
+            return Ok(Self::Unlimited);
+        }
+
+        value
+            .parse::<u32>()
+            .map(Self::Tokens)
+            .map_err(|_| "expected an integer token count or 'unlimited'".to_string())
+    }
+}
+
+impl Serialize for SkillsBudgetLimit {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::Tokens(tokens) => serializer.serialize_u32(*tokens),
+            Self::Unlimited => serializer.serialize_str("unlimited"),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for SkillsBudgetLimit {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct SkillsBudgetLimitVisitor;
+
+        impl<'de> Visitor<'de> for SkillsBudgetLimitVisitor {
+            type Value = SkillsBudgetLimit;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("an integer token count or the string 'unlimited'")
+            }
+
+            fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                let tokens = u32::try_from(value)
+                    .map_err(|_| E::custom("token count must fit within u32"))?;
+                Ok(SkillsBudgetLimit::Tokens(tokens))
+            }
+
+            fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                if value < 0 {
+                    return Err(E::custom("token count must be non-negative"));
+                }
+
+                self.visit_u64(value as u64)
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                SkillsBudgetLimit::from_str(value).map_err(E::custom)
+            }
+
+            fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                self.visit_str(&value)
+            }
+        }
+
+        deserializer.deserialize_any(SkillsBudgetLimitVisitor)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct SkillsConfig {
+    pub tenancy: SkillsTenancyConfig,
+    pub admin: SkillsAdminConfig,
+    pub blob_store: SkillsBlobStoreConfig,
+    pub cache: SkillsCacheConfig,
+    pub max_upload_size_mb: usize,
+    pub max_files_per_version: usize,
+    pub max_file_size_mb: usize,
+    pub tenant_storage_quota_mb: usize,
+    pub tenant_skill_count_quota: usize,
+    pub rate_limits: SkillsRateLimitsConfig,
+    pub dependencies: SkillsDependenciesConfig,
+    pub instruction_budget: SkillsInstructionBudgetConfig,
+    pub resolution_mode: SkillsResolutionMode,
+    pub tool_loop: SkillsToolLoopConfig,
+    pub max_skills_per_request: usize,
+    pub execution: SkillsExecutionConfig,
+    pub retention: SkillsRetentionConfig,
+}
+
+impl Default for SkillsConfig {
+    fn default() -> Self {
+        Self {
+            tenancy: SkillsTenancyConfig::default(),
+            admin: SkillsAdminConfig::default(),
+            blob_store: SkillsBlobStoreConfig::default(),
+            cache: SkillsCacheConfig::default(),
+            max_upload_size_mb: 30,
+            max_files_per_version: 500,
+            max_file_size_mb: 25,
+            tenant_storage_quota_mb: 1024,
+            tenant_skill_count_quota: 1000,
+            rate_limits: SkillsRateLimitsConfig::default(),
+            dependencies: SkillsDependenciesConfig::default(),
+            instruction_budget: SkillsInstructionBudgetConfig::default(),
+            resolution_mode: SkillsResolutionMode::Auto,
+            tool_loop: SkillsToolLoopConfig::default(),
+            max_skills_per_request: 8,
+            execution: SkillsExecutionConfig::default(),
+            retention: SkillsRetentionConfig::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct SkillsTenancyConfig {
+    pub trust_external_tenant_header: bool,
+    pub external_tenant_header_name: String,
+}
+
+impl Default for SkillsTenancyConfig {
+    fn default() -> Self {
+        Self {
+            trust_external_tenant_header: false,
+            external_tenant_header_name: "X-SMG-Tenant-Id".to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct SkillsAdminConfig {
+    pub enabled: bool,
+    pub allowed_operations: Vec<SkillsAdminOperation>,
+}
+
+impl Default for SkillsAdminConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            allowed_operations: vec![
+                SkillsAdminOperation::ReadAnyTenant,
+                SkillsAdminOperation::DeleteAnyTenant,
+                SkillsAdminOperation::CreateAlias,
+                SkillsAdminOperation::ExecuteMigration,
+            ],
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct SkillsBlobStoreConfig {
+    pub backend: SkillsBlobStoreBackend,
+    pub path: String,
+    pub bucket: Option<String>,
+    pub prefix: Option<String>,
+    pub region: Option<String>,
+    pub endpoint: Option<String>,
+    pub read_retry_window_ms: u64,
+    pub read_retry_max_attempts: u32,
+}
+
+impl Default for SkillsBlobStoreConfig {
+    fn default() -> Self {
+        Self {
+            backend: SkillsBlobStoreBackend::Filesystem,
+            path: "/var/smg/skills".to_string(),
+            bucket: None,
+            prefix: None,
+            region: None,
+            endpoint: None,
+            read_retry_window_ms: 2000,
+            read_retry_max_attempts: 3,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct SkillsCacheConfig {
+    pub path: String,
+    pub max_size_mb: usize,
+}
+
+impl Default for SkillsCacheConfig {
+    fn default() -> Self {
+        Self {
+            path: "/var/smg/cache/skills".to_string(),
+            max_size_mb: 1024,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct SkillsRateLimitsConfig {
+    pub create_per_min: u32,
+    pub create_per_day: u32,
+    pub delete_per_min: u32,
+    pub list_per_min: u32,
+}
+
+impl Default for SkillsRateLimitsConfig {
+    fn default() -> Self {
+        Self {
+            create_per_min: 10,
+            create_per_day: 300,
+            delete_per_min: 30,
+            list_per_min: 120,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct SkillsDependenciesConfig {
+    pub missing_mcp_policy: SkillsMissingMcpPolicy,
+}
+
+impl Default for SkillsDependenciesConfig {
+    fn default() -> Self {
+        Self {
+            missing_mcp_policy: SkillsMissingMcpPolicy::Warn,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct SkillsInstructionBudgetConfig {
+    pub per_skill_tokens: u32,
+    pub per_request_tokens: SkillsBudgetLimit,
+}
+
+impl Default for SkillsInstructionBudgetConfig {
+    fn default() -> Self {
+        Self {
+            per_skill_tokens: 4000,
+            per_request_tokens: SkillsBudgetLimit::Tokens(16_000),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct SkillsToolLoopConfig {
+    pub require_tool_support: bool,
+    pub max_steps: u32,
+    pub max_seconds: u64,
+    pub max_cumulative_tokens: u64,
+    pub heartbeat_secs: u64,
+    pub max_result_bytes: usize,
+}
+
+impl Default for SkillsToolLoopConfig {
+    fn default() -> Self {
+        Self {
+            require_tool_support: true,
+            max_steps: 8,
+            max_seconds: 300,
+            max_cumulative_tokens: 200_000,
+            heartbeat_secs: 2,
+            max_result_bytes: 262_144,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct SkillsExecutionModeOverrides {
+    pub messages: SkillsExecutionAsyncMode,
+    pub responses: SkillsExecutionAsyncMode,
+}
+
+impl Default for SkillsExecutionModeOverrides {
+    fn default() -> Self {
+        Self {
+            messages: SkillsExecutionAsyncMode::PauseTurn,
+            responses: SkillsExecutionAsyncMode::PauseTurn,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct SkillsExecutionConfig {
+    pub executor_url: Option<String>,
+    pub executor_api_key: Option<String>,
+    pub timeout_secs: u64,
+    pub async_mode: SkillsExecutionAsyncMode,
+    pub max_wait_secs: u64,
+    pub max_poll_attempts: u32,
+    pub poll_interval_ms: u64,
+    pub connect_timeout_ms: u64,
+    pub read_timeout_ms: u64,
+    pub retry_max: u32,
+    pub retry_base_ms: u64,
+    pub retry_max_ms: u64,
+    pub bundle_token_ttl_secs: u64,
+    pub enable_streaming: bool,
+    pub async_mode_overrides: SkillsExecutionModeOverrides,
+    pub cancel_endpoint_path: String,
+    pub cancel_fire_and_forget_timeout_ms: u64,
+    pub max_output_file_bytes: usize,
+    pub max_output_bytes: usize,
+}
+
+impl Default for SkillsExecutionConfig {
+    fn default() -> Self {
+        Self {
+            executor_url: None,
+            executor_api_key: None,
+            timeout_secs: 30,
+            async_mode: SkillsExecutionAsyncMode::PauseTurn,
+            max_wait_secs: 60,
+            max_poll_attempts: 60,
+            poll_interval_ms: 1000,
+            connect_timeout_ms: 2000,
+            read_timeout_ms: 30_000,
+            retry_max: 3,
+            retry_base_ms: 500,
+            retry_max_ms: 8000,
+            bundle_token_ttl_secs: 600,
+            enable_streaming: true,
+            async_mode_overrides: SkillsExecutionModeOverrides::default(),
+            cancel_endpoint_path: "/cancel".to_string(),
+            cancel_fire_and_forget_timeout_ms: 500,
+            max_output_file_bytes: 65_536,
+            max_output_bytes: 131_072,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct SkillsRetentionConfig {
+    pub default_mode: SkillsRetentionMode,
+    pub allow_per_tenant_override: bool,
+    pub zdr: SkillsZdrConfig,
+}
+
+impl Default for SkillsRetentionConfig {
+    fn default() -> Self {
+        Self {
+            default_mode: SkillsRetentionMode::Standard,
+            allow_per_tenant_override: true,
+            zdr: SkillsZdrConfig::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct SkillsZdrConfig {
+    pub response_state_ttl_hours: u64,
+    pub require_byok: bool,
+}
+
+impl Default for SkillsZdrConfig {
+    fn default() -> Self {
+        Self {
+            response_state_ttl_hours: 1,
+            require_byok: true,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SkillsBudgetLimit, SkillsConfig, SkillsResolutionMode};
+
+    #[test]
+    fn skills_config_defaults_are_safe() {
+        let skills = SkillsConfig::default();
+        assert_eq!(skills.resolution_mode, SkillsResolutionMode::Auto);
+        assert_eq!(skills.max_skills_per_request, 8);
+    }
+
+    #[test]
+    fn skills_budget_limit_round_trips_unlimited() {
+        let json = "\"unlimited\"";
+        let parsed: SkillsBudgetLimit = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed, SkillsBudgetLimit::Unlimited);
+        assert_eq!(serde_json::to_string(&parsed).unwrap(), json);
+    }
+
+    #[test]
+    fn partial_skills_config_uses_nested_defaults() {
+        let parsed: SkillsConfig = serde_json::from_str(
+            r#"{
+                "execution": {
+                    "executor_url": "http://executor.internal"
+                }
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            parsed.execution.executor_url.as_deref(),
+            Some("http://executor.internal")
+        );
+        assert_eq!(parsed.tool_loop.max_steps, 8);
+        assert_eq!(parsed.cache.max_size_mb, 1024);
+    }
+}

--- a/crates/skills/src/lib.rs
+++ b/crates/skills/src/lib.rs
@@ -1,0 +1,21 @@
+//! Skills domain types and service scaffolding.
+//!
+//! This crate intentionally starts small. The first integration step only
+//! establishes the stable crate boundary that later PRs will fill in with
+//! parsing, storage, CRUD, and execution logic.
+
+pub mod api;
+pub mod config;
+pub mod types;
+pub mod validation;
+
+pub use api::{SkillService, SkillServiceMode};
+pub use config::{
+    SkillsAdminConfig, SkillsAdminOperation, SkillsBlobStoreBackend, SkillsBlobStoreConfig,
+    SkillsBudgetLimit, SkillsCacheConfig, SkillsConfig, SkillsDependenciesConfig,
+    SkillsExecutionAsyncMode, SkillsExecutionConfig, SkillsExecutionModeOverrides,
+    SkillsInstructionBudgetConfig, SkillsMissingMcpPolicy, SkillsRateLimitsConfig,
+    SkillsResolutionMode, SkillsRetentionConfig, SkillsRetentionMode, SkillsTenancyConfig,
+    SkillsToolLoopConfig, SkillsZdrConfig,
+};
+pub use types::{SkillFileRecord, SkillRecord, SkillVersionRecord};

--- a/crates/skills/src/types.rs
+++ b/crates/skills/src/types.rs
@@ -1,0 +1,24 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SkillRecord {
+    pub tenant_id: String,
+    pub skill_id: String,
+    pub display_name: String,
+    pub default_version: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SkillVersionRecord {
+    pub skill_id: String,
+    pub version: String,
+    pub version_number: u32,
+    pub has_code_files: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SkillFileRecord {
+    pub relative_path: String,
+    pub media_type: Option<String>,
+    pub size_bytes: u64,
+}

--- a/crates/skills/src/validation.rs
+++ b/crates/skills/src/validation.rs
@@ -1,0 +1,4 @@
+/// Placeholder validation surface. Parsing and bundle validation land in
+/// follow-up PRs once the crate boundary is established.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct ValidationScaffold;

--- a/model_gateway/Cargo.toml
+++ b/model_gateway/Cargo.toml
@@ -76,6 +76,7 @@ llm-multimodal.workspace = true
 smg-wasm = { workspace = true, features = ["storage-hooks"] }
 smg-mesh.workspace = true
 smg-grpc-client.workspace = true
+smg-skills.workspace = true
 
 # External dependencies (not in workspace)
 bincode = "1.3"

--- a/model_gateway/src/app_context.rs
+++ b/model_gateway/src/app_context.rs
@@ -11,6 +11,7 @@ use smg_data_connector::{
     StorageFactoryConfig,
 };
 use smg_mcp::McpOrchestrator;
+use smg_skills::SkillService;
 use tool_parser::ParserFactory as ToolParserFactory;
 use tracing::debug;
 
@@ -63,6 +64,7 @@ pub struct AppContext {
     pub worker_job_queue: Arc<OnceLock<Arc<JobQueue>>>,
     pub workflow_engines: Arc<OnceLock<WorkflowEngines>>,
     pub mcp_orchestrator: Arc<OnceLock<Arc<McpOrchestrator>>>,
+    pub skill_service: Option<Arc<SkillService>>,
     pub wasm_manager: Option<Arc<WasmModuleManager>>,
     pub worker_service: Arc<WorkerService>,
     pub inflight_tracker: Arc<InFlightRequestTracker>,
@@ -99,6 +101,7 @@ pub struct AppContextBuilder {
     worker_job_queue: Option<Arc<OnceLock<Arc<JobQueue>>>>,
     workflow_engines: Option<Arc<OnceLock<WorkflowEngines>>>,
     mcp_orchestrator: Option<Arc<OnceLock<Arc<McpOrchestrator>>>>,
+    skill_service: Option<Arc<SkillService>>,
     wasm_manager: Option<Arc<WasmModuleManager>>,
     kv_event_monitor: Option<Arc<KvEventMonitor>>,
     webrtc_bind_addr: Option<std::net::IpAddr>,
@@ -151,6 +154,7 @@ impl AppContextBuilder {
             worker_job_queue: None,
             workflow_engines: None,
             mcp_orchestrator: None,
+            skill_service: None,
             wasm_manager: None,
             kv_event_monitor: None,
             webrtc_bind_addr: None,
@@ -354,6 +358,7 @@ impl AppContextBuilder {
             mcp_orchestrator: self
                 .mcp_orchestrator
                 .ok_or(AppContextBuildError::MissingField("mcp_orchestrator"))?,
+            skill_service: self.skill_service,
             wasm_manager: self.wasm_manager,
             worker_service,
             inflight_tracker: InFlightRequestTracker::new(),
@@ -387,6 +392,7 @@ impl AppContextBuilder {
             .with_workflow_engines()
             .with_mcp_orchestrator(&router_config)
             .await?
+            .with_skill_service(&router_config)
             .with_wasm_manager(&router_config)
             .with_kv_event_monitor(&router_config)
             .webrtc_bind_addr(webrtc_bind_addr)
@@ -619,6 +625,12 @@ impl AppContextBuilder {
 
         self.mcp_orchestrator = Some(mcp_orchestrator_lock);
         Ok(self)
+    }
+
+    fn with_skill_service(mut self, config: &RouterConfig) -> Self {
+        self.skill_service = (config.skills_enabled && config.skills.is_some())
+            .then(|| Arc::new(SkillService::placeholder()));
+        self
     }
 
     /// Create KV event monitor for event-driven cache-aware routing.

--- a/model_gateway/src/config/builder.rs
+++ b/model_gateway/src/config/builder.rs
@@ -5,7 +5,7 @@ use smg_mcp::McpConfig;
 use super::{
     CircuitBreakerConfig, ConfigError, ConfigResult, DiscoveryConfig, HealthCheckConfig,
     HistoryBackend, MetricsConfig, OracleConfig, PolicyConfig, PostgresConfig, RedisConfig,
-    RetryConfig, RouterConfig, RoutingMode, TokenizerCacheConfig, TraceConfig,
+    RetryConfig, RouterConfig, RoutingMode, SkillsConfig, TokenizerCacheConfig, TraceConfig,
 };
 use crate::worker::ConnectionMode;
 
@@ -21,6 +21,7 @@ pub struct RouterConfigBuilder {
     server_cert_path: Option<String>,
     server_key_path: Option<String>,
     mcp_config_path: Option<String>,
+    skills_config_path: Option<String>,
 }
 
 impl RouterConfigBuilder {
@@ -38,6 +39,7 @@ impl RouterConfigBuilder {
             server_cert_path: None,
             server_key_path: None,
             mcp_config_path: None,
+            skills_config_path: None,
         }
     }
 
@@ -676,6 +678,30 @@ impl RouterConfigBuilder {
         self
     }
 
+    // ==================== Skills ====================
+
+    pub fn skills_enabled(mut self, enabled: bool) -> Self {
+        self.config.skills_enabled = enabled;
+        self
+    }
+
+    pub fn skills_config(mut self, skills: SkillsConfig) -> Self {
+        self.config.skills = Some(skills);
+        self
+    }
+
+    /// Config file loaded during build() when skills are enabled.
+    pub fn skills_config_path<S: Into<String>>(mut self, path: S) -> Self {
+        self.skills_config_path = Some(path.into());
+        self
+    }
+
+    /// Config file loaded during build() when skills are enabled.
+    pub fn maybe_skills_config_path(mut self, path: Option<impl Into<String>>) -> Self {
+        self.skills_config_path = path.map(|p| p.into());
+        self
+    }
+
     // ==================== Build ====================
 
     pub fn build(self) -> ConfigResult<RouterConfig> {
@@ -695,6 +721,9 @@ impl RouterConfigBuilder {
 
         // Read MCP config from path if provided
         self = self.read_mcp_config()?;
+
+        // Read skills config from path if provided
+        self = self.read_skills_config()?;
 
         let config: RouterConfig = self.into();
         if validate {
@@ -793,6 +822,35 @@ impl RouterConfigBuilder {
 
         Ok(self)
     }
+
+    /// Internal method to read skills config from path.
+    fn read_skills_config(mut self) -> ConfigResult<Self> {
+        if !self.config.skills_enabled {
+            self.config.skills = None;
+            return Ok(self);
+        }
+
+        if self.config.skills.is_some() {
+            return Ok(self);
+        }
+
+        if let Some(skills_config_path) = &self.skills_config_path {
+            let contents = std::fs::read_to_string(skills_config_path).map_err(|e| {
+                ConfigError::ValidationFailed {
+                    reason: format!("Failed to read skills config from {skills_config_path}: {e}"),
+                }
+            })?;
+            let skills_config: SkillsConfig =
+                serde_yaml::from_str(&contents).map_err(|e| ConfigError::ValidationFailed {
+                    reason: format!("Failed to parse skills config from {skills_config_path}: {e}"),
+                })?;
+            self.config.skills = Some(skills_config);
+        } else {
+            self.config.skills = Some(SkillsConfig::default());
+        }
+
+        Ok(self)
+    }
 }
 
 impl From<RouterConfigBuilder> for RouterConfig {
@@ -815,7 +873,9 @@ impl RouterConfig {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::{collections::HashMap, io::Write};
+
+    use tempfile::NamedTempFile;
 
     use super::*;
 
@@ -887,5 +947,51 @@ mod tests {
             .unwrap();
 
         assert_eq!(config.storage_context_headers, headers);
+    }
+
+    #[test]
+    fn test_builder_loads_skills_config_from_yaml() {
+        let mut skills_config = NamedTempFile::new().unwrap();
+        writeln!(
+            skills_config,
+            "max_skills_per_request: 3\nexecution:\n  executor_url: http://executor.internal\n"
+        )
+        .unwrap();
+
+        let config = RouterConfigBuilder::new()
+            .regular_mode(vec!["http://worker1:8000".to_string()])
+            .skills_enabled(true)
+            .skills_config_path(skills_config.path().to_str().unwrap())
+            .build()
+            .unwrap();
+
+        assert!(config.skills_enabled);
+        assert_eq!(config.skills.as_ref().unwrap().max_skills_per_request, 3);
+        assert_eq!(
+            config
+                .skills
+                .as_ref()
+                .unwrap()
+                .execution
+                .executor_url
+                .as_deref(),
+            Some("http://executor.internal")
+        );
+    }
+
+    #[test]
+    fn test_builder_ignores_skills_path_when_disabled() {
+        let mut skills_config = NamedTempFile::new().unwrap();
+        writeln!(skills_config, "max_skills_per_request: 2").unwrap();
+
+        let config = RouterConfigBuilder::new()
+            .regular_mode(vec!["http://worker1:8000".to_string()])
+            .skills_enabled(false)
+            .skills_config_path(skills_config.path().to_str().unwrap())
+            .build()
+            .unwrap();
+
+        assert!(!config.skills_enabled);
+        assert!(config.skills.is_none());
     }
 }

--- a/model_gateway/src/config/mod.rs
+++ b/model_gateway/src/config/mod.rs
@@ -3,6 +3,7 @@ pub mod types;
 pub(crate) mod validation;
 
 pub use builder::*;
+pub use smg_skills::SkillsConfig;
 pub use types::*;
 
 #[derive(Debug, thiserror::Error)]

--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -7,7 +7,7 @@ pub use smg_data_connector::{
     HistoryBackend, OracleConfig, PostgresConfig, RedisConfig, SchemaConfig,
 };
 
-use super::{validation::ConfigValidator, ConfigResult};
+use super::{validation::ConfigValidator, ConfigResult, SkillsConfig};
 use crate::worker::ConnectionMode;
 
 /// Main router configuration
@@ -95,6 +95,13 @@ pub struct RouterConfig {
     /// Loaded from mcp_config_path during config creation
     #[serde(skip)]
     pub mcp_config: Option<smg_mcp::McpConfig>,
+    /// Enables the skills subsystem without forcing the nested skills
+    /// configuration tree into CLI flags.
+    #[serde(default)]
+    pub skills_enabled: bool,
+    /// Loaded from skills_config_path during config creation.
+    #[serde(skip)]
+    pub skills: Option<SkillsConfig>,
     /// Enable WASM support
     #[serde(default)]
     pub enable_wasm: bool,
@@ -573,6 +580,8 @@ impl Default for RouterConfig {
             client_identity: None,
             ca_certificates: vec![],
             mcp_config: None,
+            skills_enabled: false,
+            skills: None,
             enable_wasm: false,
             storage_hook_wasm_path: None,
             server_cert: None,
@@ -673,6 +682,8 @@ mod tests {
         assert!(config.trace_config.is_none());
         assert!(config.log_dir.is_none());
         assert!(config.log_level.is_none());
+        assert!(!config.skills_enabled);
+        assert!(config.skills.is_none());
     }
 
     #[test]
@@ -720,6 +731,57 @@ mod tests {
         assert!(deserialized.discovery.is_none());
         assert!(deserialized.metrics.is_none());
         assert!(deserialized.trace_config.is_none());
+        assert!(!deserialized.skills_enabled);
+        assert!(deserialized.skills.is_none());
+    }
+
+    #[test]
+    fn test_router_config_deserializes_skills_enabled_flag() {
+        let deserialized: RouterConfig = serde_json::from_str(
+            r#"{
+                "mode": { "type": "regular", "worker_urls": [] },
+                "policy": { "type": "random" },
+                "host": "0.0.0.0",
+                "port": 3001,
+                "max_payload_size": 1024,
+                "request_timeout_secs": 30,
+                "worker_startup_timeout_secs": 30,
+                "worker_startup_check_interval_secs": 5,
+                "dp_aware": false,
+                "api_key": null,
+                "max_concurrent_requests": -1,
+                "queue_size": 10,
+                "queue_timeout_secs": 5,
+                "cors_allowed_origins": [],
+                "retry": {
+                    "max_retries": 3,
+                    "initial_backoff_ms": 100,
+                    "max_backoff_ms": 1000,
+                    "backoff_multiplier": 2.0,
+                    "jitter_factor": 0.1
+                },
+                "circuit_breaker": {
+                    "failure_threshold": 5,
+                    "success_threshold": 2,
+                    "timeout_duration_secs": 30,
+                    "window_duration_secs": 60
+                },
+                "health_check": {
+                    "failure_threshold": 3,
+                    "success_threshold": 2,
+                    "timeout_secs": 10,
+                    "check_interval_secs": 30,
+                    "endpoint": "/health",
+                    "disable_health_check": false,
+                    "remove_unhealthy_workers": false
+                },
+                "skills_enabled": true
+            }"#,
+        )
+        .unwrap();
+
+        assert!(deserialized.skills_enabled);
+        assert!(deserialized.skills.is_none());
     }
 
     #[test]

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -464,6 +464,21 @@ struct CliArgs {
     #[arg(long, help_heading = "Parsers")]
     mcp_config_path: Option<String>,
 
+    // ==================== Skills ====================
+    /// Enable the skills subsystem scaffolding.
+    #[arg(
+        long,
+        num_args = 0..=1,
+        default_missing_value = "true",
+        value_parser = clap::value_parser!(bool),
+        help_heading = "Skills"
+    )]
+    skills_enabled: Option<bool>,
+
+    /// Path to a YAML file with the nested skills configuration.
+    #[arg(long, help_heading = "Skills")]
+    skills_config_path: Option<String>,
+
     // ==================== Backend ====================
     /// Backend runtime to use (auto-detected if not specified)
     #[arg(long, value_enum, alias = "runtime", help_heading = "Backend")]
@@ -1157,6 +1172,10 @@ impl CliArgs {
             _ => (None, None, None),
         };
 
+        let skills_enabled = self
+            .skills_enabled
+            .unwrap_or_else(|| self.skills_config_path.is_some());
+
         let builder = RouterConfig::builder()
             .mode(mode)
             .policy(policy)
@@ -1225,6 +1244,8 @@ impl CliArgs {
             .maybe_reasoning_parser(self.reasoning_parser.as_ref())
             .maybe_tool_call_parser(self.tool_call_parser.as_ref())
             .maybe_mcp_config_path(self.mcp_config_path.as_ref())
+            .skills_enabled(skills_enabled)
+            .maybe_skills_config_path(self.skills_config_path.as_ref())
             .dp_aware(self.dp_aware)
             .retries(!self.disable_retries)
             .circuit_breaker(!self.disable_circuit_breaker)
@@ -1418,9 +1439,86 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let server_config = cli_args.to_server_config(router_config)?;
     let runtime = tokio::runtime::Runtime::new()?;
-    runtime.block_on(async move { server::startup(server_config).await })?;
+    runtime.block_on(Box::pin(server::startup(server_config)))?;
     if is_otel_enabled() {
         shutdown_otel();
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use clap::Parser;
+    use tempfile::NamedTempFile;
+
+    use super::{Cli, Commands};
+
+    #[test]
+    fn skills_flags_flow_into_router_config() {
+        let mut skills_config = NamedTempFile::new().unwrap();
+        writeln!(
+            skills_config,
+            "max_skills_per_request: 4\nexecution:\n  executor_url: http://executor.internal\n"
+        )
+        .unwrap();
+
+        let cli = Cli::try_parse_from([
+            "smg",
+            "--worker-urls",
+            "http://worker1:8000",
+            "--skills-enabled",
+            "--skills-config-path",
+            skills_config.path().to_str().unwrap(),
+        ])
+        .unwrap();
+
+        let args = match cli.command {
+            Some(Commands::Launch { args }) => args,
+            None => cli.router_args,
+        };
+
+        let router_config = args.to_router_config(Vec::new()).unwrap();
+
+        assert!(router_config.skills_enabled);
+        let skills = router_config.skills.as_ref().unwrap();
+        assert_eq!(skills.max_skills_per_request, 4);
+        assert_eq!(
+            skills.execution.executor_url.as_deref(),
+            Some("http://executor.internal")
+        );
+    }
+
+    #[test]
+    fn skills_config_path_enables_skills_by_default() {
+        let mut skills_config = NamedTempFile::new().unwrap();
+        writeln!(skills_config, "max_skills_per_request: 2").unwrap();
+
+        let cli = Cli::try_parse_from([
+            "smg",
+            "--worker-urls",
+            "http://worker1:8000",
+            "--skills-config-path",
+            skills_config.path().to_str().unwrap(),
+        ])
+        .unwrap();
+
+        let args = match cli.command {
+            Some(Commands::Launch { args }) => args,
+            None => cli.router_args,
+        };
+
+        let router_config = args.to_router_config(Vec::new()).unwrap();
+
+        assert!(router_config.skills_enabled);
+        assert_eq!(
+            router_config
+                .skills
+                .as_ref()
+                .unwrap()
+                .max_skills_per_request,
+            2
+        );
+    }
 }

--- a/model_gateway/src/service_discovery.rs
+++ b/model_gateway/src/service_discovery.rs
@@ -1274,6 +1274,7 @@ mod tests {
             workflow_engines: Arc::new(std::sync::OnceLock::new()),
             mcp_orchestrator: Arc::new(std::sync::OnceLock::new()),
             tokenizer_registry: Arc::new(llm_tokenizer::registry::TokenizerRegistry::new()),
+            skill_service: None,
             wasm_manager: None,
             worker_service: Arc::new(WorkerService::new(
                 worker_registry,


### PR DESCRIPTION
## Description

### Problem

The skills work needed a dedicated crate boundary and minimal gateway plumbing, but the earlier direction was over-scoped: it pushed a large `--skills-*` CLI surface and mixed config concerns into the main router CLI.

### Solution

This PR introduces the `crates/skills` scaffold and wires the gateway to a minimal skills surface only:
- `skills_enabled` on `RouterConfig`
- runtime-loaded `skills: Option<SkillsConfig>`
- `--skills-enabled`
- `--skills-config-path`
- YAML loading during config build
- placeholder `SkillService` injection in `AppContext`

It deliberately does not add CRUD routes, blob storage backends, executor integration, or a separate control-plane port.

Refs #1179

## Changes

- add `crates/skills` with config/types/service/validation scaffolding
- add workspace and gateway dependency wiring for `smg-skills`
- add `skills_enabled` and runtime-loaded `skills` to `RouterConfig`
- load nested skills config from a separate YAML file in `RouterConfigBuilder`
- keep CLI surface minimal with `--skills-enabled` and `--skills-config-path`
- add placeholder `SkillService` wiring in `AppContext`
- add focused tests for config loading and CLI propagation
- fix existing `large_futures` clippy findings in `model_gateway/src/main.rs` and `bindings/python/src/lib.rs`

## Test Plan

Reproduced on this branch:

- `cargo +nightly fmt --all`
- `env -u RUSTC_WRAPPER CARGO_BUILD_RUSTC_WRAPPER= cargo clippy --all-targets --all-features --target-dir /tmp/smg-sk3-target -- -D warnings`
- `env -u RUSTC_WRAPPER CARGO_BUILD_RUSTC_WRAPPER= cargo test -p smg-skills --target-dir /tmp/smg-skills-target`
- `env -u RUSTC_WRAPPER CARGO_BUILD_RUSTC_WRAPPER= cargo test -p smg --target-dir /tmp/smg-sk3-target`
- `env -u RUSTC_WRAPPER CARGO_BUILD_RUSTC_WRAPPER= cargo test -p smg --bin smg skills_ --target-dir /tmp/smg-sk3-target -- --nocapture`
- `source /tmp/smg-python-dev-venv/bin/activate && /opt/homebrew/bin/maturin develop`

Notes:
- `cargo test -p smg` still has many pre-existing failures in the library suite on this machine. The first reproduced failure is `policies::bucket::tests::test_adjust_boundary_1`, which panics inside `system-configuration` while building proxy settings (`Attempted to create a NULL object`).
- The new skills-related library tests passed inside that run before the unrelated failure set began.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Introduced a new skills subsystem with comprehensive configuration support, enabling users to enable or disable skills functionality and customize execution behavior through configuration files or command-line options.

## Chores
* Expanded workspace structure to support the skills module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->