### PR TITLE
feat(responses): continue approved MCP calls for non-streaming flows

### DIFF
--- a/crates/mcp/src/core/orchestrator.rs
+++ b/crates/mcp/src/core/orchestrator.rs
@@ -254,6 +254,14 @@ pub enum ToolExecutionResult {
     PendingApproval(PendingToolExecution),
 }
 
+#[derive(Clone, Copy)]
+pub(crate) enum ResolvedToolExecutionMode<'a> {
+    RespectApproval(&'a McpRequestContext<'a>),
+    // INVARIANT: only use this for a stored approval request that has already
+    // been validated as still pending and still bound to the current request.
+    BypassApproval,
+}
+
 /// Pending approval from resolved tool execution.
 #[derive(Debug, Clone)]
 pub struct PendingToolExecution {
@@ -999,18 +1007,23 @@ impl McpOrchestrator {
         server_label: &str,
         request_ctx: &McpRequestContext<'_>,
     ) -> ToolExecutionOutput {
-        self.execute_tool_resolved_result(input, server_key, server_label, request_ctx)
-            .await
-            .into_output()
+        self.execute_tool_resolved_result(
+            input,
+            server_key,
+            server_label,
+            ResolvedToolExecutionMode::RespectApproval(request_ctx),
+        )
+        .await
+        .into_output()
     }
 
     /// Execute a single resolved tool while preserving pending approval state.
-    pub async fn execute_tool_resolved_result(
+    pub(crate) async fn execute_tool_resolved_result(
         &self,
         input: ToolExecutionInput,
         server_key: &str,
         server_label: &str,
-        request_ctx: &McpRequestContext<'_>,
+        execution_mode: ResolvedToolExecutionMode<'_>,
     ) -> ToolExecutionResult {
         let start = Instant::now();
         let arguments_str = input.arguments.to_string();
@@ -1020,7 +1033,7 @@ impl McpOrchestrator {
 
         match entry {
             Some(entry) => match self
-                .execute_tool_entry_result(&entry, qualified, input.arguments, request_ctx)
+                .execute_tool_entry_result(&entry, qualified, input.arguments, execution_mode)
                 .await
             {
                 ToolExecutionResult::Executed(mut output) => {
@@ -1066,7 +1079,7 @@ impl McpOrchestrator {
         entry: &ToolEntry,
         qualified: QualifiedToolName,
         arguments: Value,
-        request_ctx: &McpRequestContext<'_>,
+        execution_mode: ResolvedToolExecutionMode<'_>,
     ) -> ToolExecutionResult {
         self.active_executions.fetch_add(1, Ordering::SeqCst);
         let _guard = scopeguard::guard(Arc::clone(&self.active_executions), |count| {
@@ -1076,10 +1089,20 @@ impl McpOrchestrator {
         let call_start_time = Instant::now();
         let response_format = entry.response_format.clone();
 
-        let result = match self
-            .execute_tool_with_approval_raw_internal(entry, arguments, request_ctx)
-            .await
-        {
+        let execution_result = match execution_mode {
+            ResolvedToolExecutionMode::RespectApproval(request_ctx) => {
+                self.execute_tool_with_approval_raw_internal(entry, arguments, request_ctx)
+                    .await
+            }
+            // INVARIANT: callers only reach this branch after validating that
+            // the approval request came from persisted history and is safe to resume.
+            ResolvedToolExecutionMode::BypassApproval => self
+                .execute_tool_with_reconnect(entry, arguments)
+                .await
+                .map(ApprovalExecutionResult::Success),
+        };
+
+        let result = match execution_result {
             Ok(ApprovalExecutionResult::Success(raw_result)) => {
                 ToolExecutionResult::Executed(ToolExecutionOutput {
                     call_id: String::new(),

--- a/crates/mcp/src/core/session.rs
+++ b/crates/mcp/src/core/session.rs
@@ -16,8 +16,8 @@ use openai_protocol::responses::{
 use super::{
     config::BuiltinToolType,
     orchestrator::{
-        McpOrchestrator, McpRequestContext, ToolExecutionInput, ToolExecutionOutput,
-        ToolExecutionResult,
+        McpOrchestrator, McpRequestContext, ResolvedToolExecutionMode, ToolExecutionInput,
+        ToolExecutionOutput, ToolExecutionResult,
     },
     UNKNOWN_SERVER_KEY,
 };
@@ -266,24 +266,26 @@ impl<'a> McpToolSession<'a> {
         self.execute_tool_result(input).await.into_output()
     }
 
-    /// Execute a single tool while preserving pending approval state.
-    pub async fn execute_tool_result(&self, input: ToolExecutionInput) -> ToolExecutionResult {
+    async fn execute_tool_result_with_mode(
+        &self,
+        input: ToolExecutionInput,
+        execution_mode: ResolvedToolExecutionMode<'_>,
+    ) -> ToolExecutionResult {
         let invoked_name = input.tool_name.clone();
 
         if let Some(binding) = self.exposed_name_map.get(&invoked_name) {
             let resolved_tool_name = binding.resolved_tool_name.clone();
-            let request_ctx = self.request_ctx_for(binding.approval_mode);
             let mut result = self
                 .orchestrator
                 .execute_tool_resolved_result(
                     ToolExecutionInput {
                         call_id: input.call_id,
-                        tool_name: resolved_tool_name.clone(),
+                        tool_name: resolved_tool_name,
                         arguments: input.arguments,
                     },
                     &binding.server_key,
                     &binding.server_label,
-                    &request_ctx,
+                    execution_mode,
                 )
                 .await;
 
@@ -307,7 +309,7 @@ impl<'a> McpToolSession<'a> {
             let err = format!("Tool '{invoked_name}' is not in this session's exposed tool map");
             ToolExecutionResult::Executed(ToolExecutionOutput {
                 call_id: input.call_id,
-                tool_name: invoked_name.clone(),
+                tool_name: invoked_name,
                 server_key: UNKNOWN_SERVER_KEY.to_string(),
                 server_label: fallback_label,
                 arguments_str: input.arguments.to_string(),
@@ -318,6 +320,31 @@ impl<'a> McpToolSession<'a> {
                 duration: std::time::Duration::default(),
             })
         }
+    }
+
+    /// Execute a single tool while preserving pending approval state.
+    pub async fn execute_tool_result(&self, input: ToolExecutionInput) -> ToolExecutionResult {
+        let approval_mode = self
+            .exposed_name_map
+            .get(&input.tool_name)
+            .map(|binding| binding.approval_mode)
+            .unwrap_or(ApprovalMode::PolicyOnly);
+        let request_ctx = self.request_ctx_for(approval_mode);
+        self.execute_tool_result_with_mode(
+            input,
+            ResolvedToolExecutionMode::RespectApproval(&request_ctx),
+        )
+        .await
+    }
+
+    /// Execute a previously-approved tool without re-entering approval flow.
+    ///
+    /// INVARIANT: callers must only use this after resolving a persisted,
+    /// still-pending approval request against the current request's tool set.
+    pub async fn execute_approved_tool(&self, input: ToolExecutionInput) -> ToolExecutionOutput {
+        self.execute_tool_result_with_mode(input, ResolvedToolExecutionMode::BypassApproval)
+            .await
+            .into_output()
     }
 
     /// Resolve the user-facing server label for a tool.

--- a/crates/protocols/src/responses.rs
+++ b/crates/protocols/src/responses.rs
@@ -3333,16 +3333,44 @@ fn validate_responses_cross_parameters(request: &ResponsesRequest) -> Result<(),
 
     // 5. Validate input items structure
     if let ResponseInput::Items(items) = &request.input {
-        // Check for at least one valid input message
-        let has_valid_input = items.iter().any(|item| {
+        let has_empty_mcp_approval_response_id = items.iter().any(|item| {
             matches!(
                 item,
-                ResponseInputOutputItem::Message { .. }
-                    | ResponseInputOutputItem::SimpleInputMessage { .. }
+                ResponseInputOutputItem::McpApprovalResponse {
+                    approval_request_id,
+                    ..
+                } if approval_request_id.is_empty()
             )
         });
+        if has_empty_mcp_approval_response_id {
+            let mut e = ValidationError::new("invalid_mcp_approval_response");
+            e.message = Some("mcp_approval_response.approval_request_id must be non-empty".into());
+            return Err(e);
+        }
 
-        if !has_valid_input {
+        let mcp_approval_response_count = items
+            .iter()
+            .filter(|item| matches!(item, ResponseInputOutputItem::McpApprovalResponse { .. }))
+            .count();
+        if mcp_approval_response_count > 1 {
+            let mut e = ValidationError::new("multiple_mcp_approval_responses_unsupported");
+            e.message = Some("Only one mcp_approval_response item is supported per request".into());
+            return Err(e);
+        }
+
+        let is_approval_only_continuation = !request.stream.unwrap_or(false)
+            && request
+                .previous_response_id
+                .as_ref()
+                .is_some_and(|id| !id.is_empty())
+            && matches!(
+                items.as_slice(),
+                [ResponseInputOutputItem::McpApprovalResponse { .. }]
+            );
+
+        let has_valid_input = items_contain_message(items);
+
+        if !(has_valid_input || is_approval_only_continuation) {
             let mut e = ValidationError::new("input_missing_user_message");
             e.message = Some("Input items must contain at least one message".into());
             return Err(e);
@@ -3354,6 +3382,16 @@ fn validate_responses_cross_parameters(request: &ResponsesRequest) -> Result<(),
     // but this is here for completeness and future-proofing
 
     Ok(())
+}
+
+fn items_contain_message(items: &[ResponseInputOutputItem]) -> bool {
+    items.iter().any(|item| {
+        matches!(
+            item,
+            ResponseInputOutputItem::Message { .. }
+                | ResponseInputOutputItem::SimpleInputMessage { .. }
+        )
+    })
 }
 
 // ============================================================================
@@ -3743,7 +3781,33 @@ impl ResponsesResponse {
     }
 }
 
+/// Re-prefix an MCP item id (`mcp_*` or `mcpr_*`) with `prefix`.
+/// If the id has neither prefix it is appended verbatim after `prefix`.
+pub fn mcp_item_id_to_prefixed_id(item_id: &str, prefix: &str) -> String {
+    item_id
+        .strip_prefix("mcp_")
+        .or_else(|| item_id.strip_prefix("mcpr_"))
+        .map(|stripped| format!("{prefix}{stripped}"))
+        .unwrap_or_else(|| format!("{prefix}{item_id}"))
+}
+
+/// Convert an `mcpr_*` approval-request id to its matching `call_*` id.
+pub fn approval_request_id_to_call_id(approval_request_id: &str) -> String {
+    mcp_item_id_to_prefixed_id(approval_request_id, "call_")
+}
+
 impl ResponseInputOutputItem {
+    /// Build a `user` message item from a single text string.
+    pub fn new_user_text(text: String) -> Self {
+        Self::Message {
+            id: generate_id("msg"),
+            role: "user".to_string(),
+            content: vec![ResponseContentPart::InputText { text }],
+            status: Some("completed".to_string()),
+            phase: None,
+        }
+    }
+
     /// Create a new reasoning input/output item.
     ///
     /// `encrypted_content` defaults to `None`; use
@@ -3881,5 +3945,171 @@ impl ResponseReasoningContent {
     /// Create a new reasoning text content
     pub fn new_reasoning_text(text: String) -> Self {
         Self::ReasoningText { text }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_previous_response_continuation_allows_approval_response_without_message() {
+        let request = ResponsesRequest {
+            input: ResponseInput::Items(vec![ResponseInputOutputItem::McpApprovalResponse {
+                id: None,
+                approval_request_id: "mcpr_123".to_string(),
+                approve: true,
+                reason: None,
+            }]),
+            previous_response_id: Some("resp_123".to_string()),
+            ..Default::default()
+        };
+
+        assert!(
+            request.validate().is_ok(),
+            "previous_response_id continuations should allow approval response input without a new message"
+        );
+    }
+
+    #[test]
+    fn test_input_items_without_message_still_fail_without_previous_response_id() {
+        let request = ResponsesRequest {
+            input: ResponseInput::Items(vec![ResponseInputOutputItem::McpApprovalResponse {
+                id: None,
+                approval_request_id: "mcpr_123".to_string(),
+                approve: true,
+                reason: None,
+            }]),
+            ..Default::default()
+        };
+
+        assert!(
+            request.validate().is_err(),
+            "non-continuation requests should still require at least one message"
+        );
+    }
+
+    #[test]
+    fn test_previous_response_continuation_still_requires_actual_continuation_input() {
+        let request = ResponsesRequest {
+            input: ResponseInput::Items(vec![ResponseInputOutputItem::Reasoning {
+                id: "rs_123".to_string(),
+                summary: vec![],
+                content: vec![],
+                encrypted_content: None,
+                status: None,
+            }]),
+            previous_response_id: Some("resp_123".to_string()),
+            ..Default::default()
+        };
+
+        assert!(
+            request.validate().is_err(),
+            "previous_response_id without a message should still require a continuation input item"
+        );
+    }
+
+    #[test]
+    fn test_previous_response_continuation_does_not_allow_function_call_output_without_message() {
+        let request = ResponsesRequest {
+            input: ResponseInput::Items(vec![ResponseInputOutputItem::FunctionCallOutput {
+                id: None,
+                call_id: "call_123".to_string(),
+                output: "ok".to_string(),
+                status: Some("completed".to_string()),
+            }]),
+            previous_response_id: Some("resp_123".to_string()),
+            ..Default::default()
+        };
+
+        assert!(
+            request.validate().is_err(),
+            "function_call_output-only previous_response_id requests should remain invalid in non-streaming approval scope"
+        );
+    }
+
+    #[test]
+    fn test_streaming_previous_response_continuation_does_not_allow_approval_only_input() {
+        let request = ResponsesRequest {
+            input: ResponseInput::Items(vec![ResponseInputOutputItem::McpApprovalResponse {
+                id: None,
+                approval_request_id: "mcpr_123".to_string(),
+                approve: true,
+                reason: None,
+            }]),
+            previous_response_id: Some("resp_123".to_string()),
+            stream: Some(true),
+            ..Default::default()
+        };
+
+        assert!(
+            request.validate().is_err(),
+            "streaming approval-only continuation should remain invalid until streaming continuation support exists"
+        );
+    }
+
+    #[test]
+    fn test_previous_response_continuation_allows_denied_approval_without_message() {
+        let request = ResponsesRequest {
+            input: ResponseInput::Items(vec![ResponseInputOutputItem::McpApprovalResponse {
+                id: None,
+                approval_request_id: "mcpr_123".to_string(),
+                approve: false,
+                reason: Some("no".to_string()),
+            }]),
+            previous_response_id: Some("resp_123".to_string()),
+            ..Default::default()
+        };
+
+        assert!(
+            request.validate().is_ok(),
+            "protocol validation should allow approval-only previous_response_id continuations regardless of approve value"
+        );
+    }
+
+    #[test]
+    fn test_multiple_mcp_approval_responses_are_rejected() {
+        let request = ResponsesRequest {
+            input: ResponseInput::Items(vec![
+                ResponseInputOutputItem::McpApprovalResponse {
+                    id: None,
+                    approval_request_id: "mcpr_123".to_string(),
+                    approve: true,
+                    reason: None,
+                },
+                ResponseInputOutputItem::McpApprovalResponse {
+                    id: None,
+                    approval_request_id: "mcpr_456".to_string(),
+                    approve: true,
+                    reason: None,
+                },
+            ]),
+            previous_response_id: Some("resp_123".to_string()),
+            ..Default::default()
+        };
+
+        assert!(
+            request.validate().is_err(),
+            "multiple mcp_approval_response items should be rejected until multi-approval continuation is supported"
+        );
+    }
+
+    #[test]
+    fn test_mcp_approval_response_requires_non_empty_approval_request_id() {
+        let request = ResponsesRequest {
+            input: ResponseInput::Items(vec![ResponseInputOutputItem::McpApprovalResponse {
+                id: None,
+                approval_request_id: String::new(),
+                approve: true,
+                reason: None,
+            }]),
+            previous_response_id: Some("resp_123".to_string()),
+            ..Default::default()
+        };
+
+        assert!(
+            request.validate().is_err(),
+            "mcp_approval_response should require a non-empty approval_request_id"
+        );
     }
 }

--- a/e2e_test/responses/test_tools_call.py
+++ b/e2e_test/responses/test_tools_call.py
@@ -579,8 +579,46 @@ class TestToolCallingCloud:
 
         assert_mcp_approval_interruption_non_streaming(resp)
 
-        # TODO: extend this same test in a follow-up PR with the approval continuation
-        # request and assert the resumed turn emits mcp_call plus the final assistant output.
+        approval_request = next(
+            item
+            for item in resp.output
+            if item.type == "mcp_approval_request" and item.server_label == "brave"
+        )
+
+        resumed = api_client.responses.create(
+            model=model,
+            input=[
+                {
+                    "type": "mcp_approval_response",
+                    "approval_request_id": approval_request.id,
+                    "approve": True,
+                }
+            ],
+            previous_response_id=resp.id,
+            tools=[DEEPWIKI_MCP_TOOL, BRAVE_MCP_TOOL_REQUIRE_APPROVAL_ALWAYS],
+            stream=False,
+            reasoning={"effort": "low"},
+        )
+
+        assert resumed.error is None
+        assert resumed.id is not None
+        assert resumed.status == "completed"
+        assert resumed.output is not None
+
+        resumed_output_types = [item.type for item in resumed.output]
+        assert "mcp_approval_request" not in resumed_output_types
+        assert "mcp_list_tools" not in resumed_output_types
+        assert "message" in resumed_output_types
+
+        resumed_mcp_calls = [item for item in resumed.output if item.type == "mcp_call"]
+        assert len(resumed_mcp_calls) > 0, "Expected resumed response to emit mcp_call"
+        brave_calls = [item for item in resumed_mcp_calls if item.server_label == "brave"]
+        assert len(brave_calls) > 0, "Expected resumed response to emit brave mcp_call"
+        for mcp_call in brave_calls:
+            assert mcp_call.approval_request_id == approval_request.id
+            assert mcp_call.id is not None
+            assert mcp_call.id.startswith("mcp_")
+            assert mcp_call.output is not None
 
     def test_mcp_multi_server_tool_call(self, model, api_client):
         """Test MCP tool call with multiple MCP servers (non-streaming)."""

--- a/model_gateway/src/routers/openai/context.rs
+++ b/model_gateway/src/routers/openai/context.rs
@@ -3,7 +3,10 @@
 use std::sync::Arc;
 
 use axum::http::HeaderMap;
-use openai_protocol::{chat::ChatCompletionRequest, responses::ResponsesRequest};
+use openai_protocol::{
+    chat::ChatCompletionRequest,
+    responses::{ResponseInput, ResponsesRequest},
+};
 use serde_json::Value;
 use smg_data_connector::{
     ConversationItemStorage, ConversationMemoryWriter, ConversationStorage,
@@ -11,7 +14,7 @@ use smg_data_connector::{
 };
 use smg_mcp::{McpOrchestrator, McpToolSession};
 
-use super::provider::Provider;
+use super::{provider::Provider, responses::approval_continuation::ApprovalContinuation};
 use crate::{
     config::RouterConfig, memory::MemoryExecutionContext, middleware,
     middleware::TenantRequestMeta, worker::Worker,
@@ -115,7 +118,7 @@ impl ComponentRefs {
 pub struct ProcessingState {
     pub worker: Option<WorkerSelection>,
     pub payload: Option<PayloadState>,
-    pub responses_payload: Option<ResponsesPayloadState>,
+    pub(crate) responses_payload: Option<ResponsesPayloadState>,
 }
 
 pub struct WorkerSelection {
@@ -128,10 +131,11 @@ pub struct PayloadState {
     pub url: String,
 }
 
-#[derive(Default)]
-pub struct ResponsesPayloadState {
-    pub previous_response_id: Option<String>,
-    pub existing_mcp_list_tools_labels: Vec<String>,
+pub(crate) struct ResponsesPayloadState {
+    pub(crate) previous_response_id: Option<String>,
+    pub(crate) existing_mcp_list_tools_labels: Vec<String>,
+    pub(crate) approval_continuation: Option<ApprovalContinuation>,
+    pub(crate) upstream_input: ResponseInput,
 }
 
 impl RequestContext {
@@ -247,7 +251,7 @@ impl RequestContext {
         self.state.payload.take()
     }
 
-    pub fn take_responses_payload(&mut self) -> Option<ResponsesPayloadState> {
+    pub(crate) fn take_responses_payload(&mut self) -> Option<ResponsesPayloadState> {
         self.state.responses_payload.take()
     }
 }
@@ -274,7 +278,9 @@ pub struct OwnedStreamingContext {
 impl RequestContext {
     pub fn into_streaming_context(mut self) -> Result<OwnedStreamingContext, &'static str> {
         let payload_state = self.take_payload().ok_or("Payload not prepared")?;
-        let responses_payload_state = self.take_responses_payload().unwrap_or_default();
+        let responses_payload_state = self
+            .take_responses_payload()
+            .ok_or("Responses payload not prepared")?;
         let original_body = self
             .responses_request()
             .ok_or("Expected responses request")?

--- a/model_gateway/src/routers/openai/mcp/mod.rs
+++ b/model_gateway/src/routers/openai/mcp/mod.rs
@@ -12,5 +12,5 @@ pub(crate) use tool_handler::{StreamAction, StreamingToolHandler};
 pub(crate) use tool_loop::{
     build_resume_payload, execute_streaming_tool_calls, execute_tool_loop,
     inject_mcp_metadata_streaming, mcp_list_tools_bindings_to_emit, prepare_mcp_tools_as_functions,
-    send_mcp_list_tools_events, ToolLoopExecutionContext, ToolLoopState,
+    send_mcp_list_tools_events, ToolLoopError, ToolLoopExecutionContext, ToolLoopState,
 };

--- a/model_gateway/src/routers/openai/mcp/tool_loop.rs
+++ b/model_gateway/src/routers/openai/mcp/tool_loop.rs
@@ -34,8 +34,16 @@ use crate::{
     routers::{
         common::{header_utils::ApiProvider, mcp_utils::DEFAULT_MAX_ITERATIONS},
         error,
+        openai::responses::approval_continuation::ApprovalContinuation,
     },
 };
+
+#[derive(Debug)]
+pub(crate) enum ToolLoopError {
+    InvalidApprovalResponse(String),
+    MaxToolCallsExceeded(String),
+    Execution(String),
+}
 
 /// State for tracking multi-turn tool calling loop
 pub(crate) struct ToolLoopState {
@@ -385,6 +393,150 @@ pub(crate) fn build_resume_payload(
     obj.insert("store".to_string(), Value::Bool(false));
 
     Ok(payload)
+}
+
+fn attach_approval_request_id(item: &mut Value, approval_request_id: &str) {
+    let Some(obj) = item.as_object_mut() else {
+        return;
+    };
+
+    if obj.get("type").and_then(|value| value.as_str()) == Some(ItemType::MCP_CALL) {
+        obj.insert(
+            "approval_request_id".to_string(),
+            Value::String(approval_request_id.to_string()),
+        );
+    }
+}
+
+struct ApprovedToolReplayContext<'a> {
+    base_payload: &'a Value,
+    tools_json: &'a Value,
+    session: &'a McpToolSession<'a>,
+    model_id: &'a str,
+    effective_limit: usize,
+}
+
+async fn maybe_resume_approved_tool_call(
+    state: &mut ToolLoopState,
+    current_payload: &mut Value,
+    continuation: Option<&ApprovalContinuation>,
+    replay_ctx: ApprovedToolReplayContext<'_>,
+) -> Result<(), ToolLoopError> {
+    let Some(continuation) = continuation else {
+        return Ok(());
+    };
+
+    if !replay_ctx.session.has_exposed_tool(&continuation.tool_name) {
+        return Err(ToolLoopError::InvalidApprovalResponse(format!(
+            "approved tool '{}' (approval_request_id={}) is not available in this request",
+            continuation.tool_name, continuation.approval_request_id
+        )));
+    }
+
+    // Binding integrity: the stored `mcp_approval_request.server_label` must
+    // still map to the same MCP backend in the current session. Without this
+    // check, a client could rebind the same tool name to a different server
+    // between the approval and the continuation, causing the approved call to
+    // dispatch to a backend the user never approved.
+    let current_server_label = replay_ctx
+        .session
+        .resolve_tool_server_label(&continuation.tool_name);
+    if current_server_label != continuation.server_label {
+        return Err(ToolLoopError::InvalidApprovalResponse(format!(
+            "approved tool '{}' (approval_request_id={}) is now bound to server '{}', but was approved against '{}'",
+            continuation.tool_name,
+            continuation.approval_request_id,
+            current_server_label,
+            continuation.server_label
+        )));
+    }
+
+    // Count approved replay against the current response's tool-call budget:
+    // a resumed, previously-approved MCP execution still consumes one
+    // `max_tool_calls` slot for this response.
+    if state.total_calls + 1 > replay_ctx.effective_limit {
+        return Err(ToolLoopError::MaxToolCallsExceeded(format!(
+            "approved MCP continuation for approval_request_id '{}' would exceed max_tool_calls limit ({})",
+            continuation.approval_request_id, replay_ctx.effective_limit
+        )));
+    }
+
+    let (output_str, transformed_item, result_label) =
+        match serde_json::from_str::<Value>(&continuation.arguments) {
+            Ok(arguments) => {
+                let tool_output = replay_ctx
+                    .session
+                    .execute_approved_tool(ToolExecutionInput {
+                        call_id: continuation.call_id.clone(),
+                        tool_name: continuation.tool_name.clone(),
+                        arguments,
+                    })
+                    .await;
+
+                Metrics::record_mcp_tool_duration(
+                    replay_ctx.model_id,
+                    &tool_output.tool_name,
+                    tool_output.duration,
+                );
+
+                let label = if tool_output.is_error {
+                    metrics_labels::RESULT_ERROR
+                } else {
+                    metrics_labels::RESULT_SUCCESS
+                };
+                let transformed = build_transformed_mcp_call_item(
+                    &tool_output.output,
+                    &tool_output.response_format,
+                    &continuation.call_id,
+                    &tool_output.server_label,
+                    &continuation.tool_name,
+                    &continuation.arguments,
+                );
+                (tool_output.output.to_string(), transformed, label)
+            }
+            Err(e) => {
+                let error_output = format!("Invalid tool arguments: {e}");
+                let transformed = build_transformed_mcp_call_item(
+                    &json!({ "error": &error_output }),
+                    &replay_ctx
+                        .session
+                        .tool_response_format(&continuation.tool_name),
+                    &continuation.call_id,
+                    &replay_ctx
+                        .session
+                        .resolve_tool_server_label(&continuation.tool_name),
+                    &continuation.tool_name,
+                    &continuation.arguments,
+                );
+                (error_output, transformed, metrics_labels::RESULT_ERROR)
+            }
+        };
+
+    let mut transformed_item = transformed_item;
+    attach_approval_request_id(&mut transformed_item, &continuation.approval_request_id);
+
+    Metrics::record_mcp_tool_call(replay_ctx.model_id, &continuation.tool_name, result_label);
+
+    state.total_calls += 1;
+    state.record_call(
+        replay_ctx.session.is_builtin_tool(&continuation.tool_name),
+        continuation.call_id.clone(),
+        continuation.tool_name.clone(),
+        continuation.arguments.clone(),
+        output_str,
+        transformed_item,
+    );
+
+    *current_payload = build_resume_payload(
+        replay_ctx.base_payload,
+        &state.conversation_history,
+        &state.original_input,
+        replay_ctx.tools_json,
+        false,
+    )
+    .map_err(ToolLoopError::Execution)?;
+
+    Ok(())
 }
 
 /// Send mcp_list_tools events to client at the start of streaming
@@ -778,7 +930,9 @@ fn approval_prefix_items(
 
 pub(crate) struct ToolLoopExecutionContext<'a> {
     pub original_body: &'a ResponsesRequest,
+    pub upstream_input: &'a ResponseInput,
     pub existing_mcp_list_tools_labels: &'a [String],
+    pub approval_continuation: Option<&'a ApprovalContinuation>,
     pub session: &'a McpToolSession<'a>,
 }
 
@@ -790,18 +944,24 @@ pub(crate) async fn execute_tool_loop(
     worker_api_key: Option<&String>,
     initial_payload: Value,
     tool_loop_ctx: ToolLoopExecutionContext<'_>,
-) -> Result<Value, String> {
+) -> Result<Value, ToolLoopError> {
     let ToolLoopExecutionContext {
         original_body,
+        upstream_input,
         existing_mcp_list_tools_labels,
+        approval_continuation,
         session,
     } = tool_loop_ctx;
 
     let mut state = ToolLoopState::new(
-        original_body.input.clone(),
+        upstream_input.clone(),
         existing_mcp_list_tools_labels.to_vec(),
     );
     let max_tool_calls = original_body.max_tool_calls.map(|n| n as usize);
+    let effective_limit = match max_tool_calls {
+        Some(user_max) => user_max.min(DEFAULT_MAX_ITERATIONS),
+        None => DEFAULT_MAX_ITERATIONS,
+    };
     let base_payload = initial_payload.clone();
     let tools_json = base_payload.get("tools").cloned().unwrap_or(json!([]));
     let mut current_payload = initial_payload;
@@ -813,6 +973,20 @@ pub(crate) async fn execute_tool_loop(
     let provider = ApiProvider::from_url(url);
     let auth_header = provider.extract_auth_header(headers, worker_api_key);
 
+    maybe_resume_approved_tool_call(
+        &mut state,
+        &mut current_payload,
+        approval_continuation,
+        ApprovedToolReplayContext {
+            base_payload: &base_payload,
+            tools_json: &tools_json,
+            session,
+            model_id: &original_body.model,
+            effective_limit,
+        },
+    )
+    .await?;
+
     loop {
         let request_builder = client.post(url).json(&current_payload);
         let request_builder = provider.apply_headers(request_builder, auth_header.as_ref());
@@ -820,19 +994,21 @@ pub(crate) async fn execute_tool_loop(
         let response = request_builder
             .send()
             .await
-            .map_err(|e| format!("upstream request failed: {e}"))?;
+            .map_err(|e| ToolLoopError::Execution(format!("upstream request failed: {e}")))?;
 
         if !response.status().is_success() {
             let status = response.status();
             let body = response.text().await.unwrap_or_default();
             let body = error::sanitize_error_body(&body);
-            return Err(format!("upstream error {status}: {body}"));
+            return Err(ToolLoopError::Execution(format!(
+                "upstream error {status}: {body}"
+            )));
         }
 
         let mut response_json = response
             .json::<Value>()
             .await
-            .map_err(|e| format!("parse response: {e}"))?;
+            .map_err(|e| ToolLoopError::Execution(format!("parse response: {e}")))?;
 
         let function_calls = extract_function_calls(&response_json);
         if function_calls.is_empty() {
@@ -855,11 +1031,6 @@ pub(crate) async fn execute_tool_loop(
             function_calls.len()
         );
 
-        let effective_limit = match max_tool_calls {
-            Some(user_max) => user_max.min(DEFAULT_MAX_ITERATIONS),
-            None => DEFAULT_MAX_ITERATIONS,
-        };
-
         for call in function_calls {
             state.total_calls += 1;
 
@@ -874,7 +1045,8 @@ pub(crate) async fn execute_tool_loop(
                     "max_tool_calls",
                     session,
                     original_body,
-                );
+                )
+                .map_err(ToolLoopError::Execution);
             }
             let mut arguments: Value = match serde_json::from_str(&call.arguments) {
                 Ok(v) => v,
@@ -969,7 +1141,8 @@ pub(crate) async fn execute_tool_loop(
                         session,
                         original_body,
                         approval_item,
-                    );
+                    )
+                    .map_err(ToolLoopError::Execution);
                 }
             };
 
@@ -1014,7 +1187,8 @@ pub(crate) async fn execute_tool_loop(
             &state.original_input,
             &tools_json,
             false,
-        )?;
+        )
+        .map_err(ToolLoopError::Execution)?;
     }
 }
 

--- a/model_gateway/src/routers/openai/responses/approval_continuation.rs
+++ b/model_gateway/src/routers/openai/responses/approval_continuation.rs
@@ -1,0 +1,139 @@
+//! Helpers for non-streaming MCP approval continuations on the Responses API.
+//!
+//! This module keeps two concerns together:
+//! 1. Build the sanitized input we forward upstream.
+//! 2. Parse the current turn's `mcp_approval_response` into a concrete
+//!    continuation we can execute locally.
+
+use openai_protocol::responses::{
+    approval_request_id_to_call_id, normalize_input_item, ResponseInput, ResponseInputOutputItem,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ApprovalContinuation {
+    pub approval_request_id: String,
+    pub call_id: String,
+    pub tool_name: String,
+    /// Captured from the stored `mcp_approval_request.server_label` so replay
+    /// can reject a continuation that rebinds the same tool name to a
+    /// different MCP backend between turns.
+    pub server_label: String,
+    pub arguments: String,
+}
+
+pub(crate) struct PreparedResponsesInput {
+    pub upstream_input: ResponseInput,
+    pub approval_continuation: Option<ApprovalContinuation>,
+}
+
+pub(crate) fn prepare_responses_input(
+    merged_input: &ResponseInput,
+    pending_mcp_approval_requests: &[ResponseInputOutputItem],
+    is_streaming: bool,
+) -> Result<PreparedResponsesInput, String> {
+    let approval_continuation =
+        extract_approval_continuation(merged_input, pending_mcp_approval_requests, is_streaming)?;
+
+    Ok(PreparedResponsesInput {
+        upstream_input: sanitize_input_for_upstream(merged_input),
+        approval_continuation,
+    })
+}
+
+pub(crate) fn sanitize_input_for_upstream(input: &ResponseInput) -> ResponseInput {
+    match input {
+        ResponseInput::Text(text) => ResponseInput::Text(text.clone()),
+        ResponseInput::Items(items) => ResponseInput::Items(
+            items
+                .iter()
+                .map(normalize_input_item)
+                .filter(|item| {
+                    !matches!(
+                        item,
+                        ResponseInputOutputItem::McpApprovalRequest { .. }
+                            | ResponseInputOutputItem::McpApprovalResponse { .. }
+                    )
+                })
+                .collect(),
+        ),
+    }
+}
+
+fn extract_approval_continuation(
+    merged_input: &ResponseInput,
+    pending_mcp_approval_requests: &[ResponseInputOutputItem],
+    is_streaming: bool,
+) -> Result<Option<ApprovalContinuation>, String> {
+    let approval_responses = normalized_input_items(merged_input)
+        .into_iter()
+        .filter_map(|item| match item {
+            ResponseInputOutputItem::McpApprovalResponse {
+                approval_request_id,
+                approve,
+                ..
+            } => Some((approval_request_id, approve)),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+
+    if approval_responses.is_empty() {
+        return Ok(None);
+    }
+
+    // Defensive check: protocol validation already rejects streaming
+    // approval-only continuations at the HTTP boundary.
+    if is_streaming {
+        return Err(
+            "mcp_approval_response is not supported for streaming responses requests".to_string(),
+        );
+    }
+
+    // Defensive check: protocol validation already enforces a single
+    // `mcp_approval_response` item per request.
+    if approval_responses.len() > 1 {
+        return Err("Only one mcp_approval_response item is supported per request".to_string());
+    }
+
+    let (approval_request_id, approve) = &approval_responses[0];
+    if !approve {
+        return Err(
+            "mcp_approval_response.approve=false is not supported for previous_response_id continuations"
+                .to_string(),
+        );
+    }
+
+    let Some((tool_name, server_label, arguments)) = pending_mcp_approval_requests
+        .iter()
+        .rev()
+        .find_map(|item| match item {
+            ResponseInputOutputItem::McpApprovalRequest {
+                id,
+                name,
+                server_label,
+                arguments,
+            } if id == approval_request_id => {
+                Some((name.clone(), server_label.clone(), arguments.clone()))
+            }
+            _ => None,
+        })
+    else {
+        return Err(format!(
+            "mcp_approval_response.approval_request_id '{approval_request_id}' does not match any pending mcp_approval_request"
+        ));
+    };
+
+    Ok(Some(ApprovalContinuation {
+        approval_request_id: approval_request_id.clone(),
+        call_id: approval_request_id_to_call_id(approval_request_id),
+        tool_name,
+        server_label,
+        arguments,
+    }))
+}
+
+fn normalized_input_items(input: &ResponseInput) -> Vec<ResponseInputOutputItem> {
+    match input {
+        ResponseInput::Text(_) => Vec::new(),
+        ResponseInput::Items(items) => items.iter().map(normalize_input_item).collect(),
+    }
+}

--- a/model_gateway/src/routers/openai/responses/history.rs
+++ b/model_gateway/src/routers/openai/responses/history.rs
@@ -8,7 +8,10 @@ use std::collections::HashSet;
 use axum::response::Response;
 use openai_protocol::{
     event_types::ItemType,
-    responses::{ResponseContentPart, ResponseInput, ResponseInputOutputItem, ResponsesRequest},
+    responses::{
+        approval_request_id_to_call_id, mcp_item_id_to_prefixed_id, normalize_input_item,
+        ResponseContentPart, ResponseInput, ResponseInputOutputItem, ResponsesRequest,
+    },
 };
 use serde_json::Value;
 use smg_data_connector::{ConversationId, ListParams, ResponseId, ResponseStorageError, SortOrder};
@@ -30,6 +33,7 @@ const MAX_CONVERSATION_HISTORY_ITEMS: usize = 100;
 pub(crate) struct LoadedInputHistory {
     pub previous_response_id: Option<String>,
     pub existing_mcp_list_tools_labels: Vec<String>,
+    pub pending_mcp_approval_requests: Vec<ResponseInputOutputItem>,
 }
 
 /// Load conversation history and/or previous response chain into request input.
@@ -47,6 +51,7 @@ pub(crate) async fn load_input_history(
         .take()
         .filter(|id| !id.is_empty());
     let mut existing_mcp_list_tools_labels = HashSet::new();
+    let mut pending_mcp_approval_requests = Vec::new();
 
     // Load items from previous response chain if specified
     let mut chain_items: Option<Vec<ResponseInputOutputItem>> = None;
@@ -64,13 +69,45 @@ pub(crate) async fn load_input_history(
                     )
                 }));
 
+                let consumed_mcp_approval_request_ids = chain
+                    .responses
+                    .iter()
+                    .flat_map(|stored| {
+                        extract_consumed_mcp_approval_request_ids_from_array(
+                            stored
+                                .raw_response
+                                .get("output")
+                                .unwrap_or(&Value::Array(vec![])),
+                        )
+                    })
+                    .collect::<HashSet<_>>();
+
+                pending_mcp_approval_requests = chain
+                    .responses
+                    .iter()
+                    .flat_map(|stored| {
+                        extract_mcp_approval_requests_from_array(
+                            stored
+                                .raw_response
+                                .get("output")
+                                .unwrap_or(&Value::Array(vec![])),
+                        )
+                    })
+                    .filter(|item| match item {
+                        ResponseInputOutputItem::McpApprovalRequest { id, .. } => {
+                            !consumed_mcp_approval_request_ids.contains(id)
+                        }
+                        _ => true,
+                    })
+                    .collect();
+
                 let items: Vec<ResponseInputOutputItem> = chain
                     .responses
                     .iter()
                     .flat_map(|stored| {
-                        deserialize_items_from_array(&stored.input)
+                        deserialize_upstream_input_items(&stored.input)
                             .into_iter()
-                            .chain(deserialize_items_from_array(
+                            .chain(deserialize_upstream_output_items_from_array(
                                 stored
                                     .raw_response
                                     .get("output")
@@ -235,23 +272,193 @@ pub(crate) async fn load_input_history(
     Ok(LoadedInputHistory {
         previous_response_id,
         existing_mcp_list_tools_labels: existing_mcp_list_tools_labels.into_iter().collect(),
+        pending_mcp_approval_requests,
     })
 }
 
-/// Deserialize ResponseInputOutputItems from a JSON array value
-fn deserialize_items_from_array(array: &Value) -> Vec<ResponseInputOutputItem> {
+fn extract_consumed_mcp_approval_request_ids_from_array(array: &Value) -> Vec<String> {
+    let Some(arr) = array.as_array() else {
+        return Vec::new();
+    };
+
+    arr.iter()
+        .filter_map(|item| {
+            (item.get("type").and_then(|value| value.as_str()) == Some(ItemType::MCP_CALL))
+                .then(|| {
+                    item.get("approval_request_id")
+                        .and_then(|value| value.as_str())
+                })
+                .flatten()
+                .map(ToOwned::to_owned)
+        })
+        .collect()
+}
+
+fn extract_mcp_approval_requests_from_array(array: &Value) -> Vec<ResponseInputOutputItem> {
+    let Some(arr) = array.as_array() else {
+        return Vec::new();
+    };
+    arr.iter()
+        .filter(|item| {
+            item.get("type").and_then(|value| value.as_str()) == Some("mcp_approval_request")
+        })
+        .filter_map(|item| {
+            serde_json::from_value::<ResponseInputOutputItem>(item.clone())
+                .map_err(|e| warn!("Failed to deserialize mcp_approval_request for replay: {e}"))
+                .ok()
+        })
+        .collect()
+}
+
+fn deserialize_upstream_input_items(input: &Value) -> Vec<ResponseInputOutputItem> {
+    match input {
+        Value::String(text) => vec![ResponseInputOutputItem::new_user_text(text.clone())],
+        Value::Array(arr) => arr
+            .iter()
+            .flat_map(upstream_input_items_from_value)
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+fn deserialize_upstream_output_items_from_array(array: &Value) -> Vec<ResponseInputOutputItem> {
     array
         .as_array()
         .map(|arr| {
             arr.iter()
-                .filter_map(|item| {
-                    serde_json::from_value::<ResponseInputOutputItem>(item.clone())
-                        .map_err(|e| warn!("Failed to deserialize item: {}. Item: {}", e, item))
-                        .ok()
-                })
+                .flat_map(upstream_output_items_from_value)
                 .collect()
         })
         .unwrap_or_default()
+}
+
+fn upstream_input_items_from_value(item: &Value) -> Vec<ResponseInputOutputItem> {
+    let parsed = match serde_json::from_value::<ResponseInputOutputItem>(item.clone()) {
+        Ok(parsed) => parsed,
+        Err(e) => {
+            warn!(
+                error = %e,
+                item_type = replay_item_type(item),
+                item_id = replay_item_id(item),
+                "Failed to deserialize input item for upstream replay"
+            );
+            return Vec::new();
+        }
+    };
+
+    match normalize_input_item(&parsed) {
+        ResponseInputOutputItem::McpApprovalRequest { .. }
+        | ResponseInputOutputItem::McpApprovalResponse { .. } => Vec::new(),
+        item => vec![item],
+    }
+}
+
+fn upstream_output_items_from_value(item: &Value) -> Vec<ResponseInputOutputItem> {
+    match item.get("type").and_then(|value| value.as_str()) {
+        Some(ItemType::MCP_LIST_TOOLS) | Some("mcp_approval_request") => Vec::new(),
+        Some(ItemType::MCP_CALL) => mcp_call_output_to_upstream_items(item),
+        _ => upstream_input_items_from_value(item),
+    }
+}
+
+fn mcp_call_output_to_upstream_items(item: &Value) -> Vec<ResponseInputOutputItem> {
+    let Some(id) = item.get("id").and_then(|value| value.as_str()) else {
+        warn!(
+            item_type = replay_item_type(item),
+            item_id = replay_item_id(item),
+            "Skipping mcp_call without id during upstream replay"
+        );
+        return Vec::new();
+    };
+    let Some(name) = item.get("name").and_then(|value| value.as_str()) else {
+        warn!(
+            item_type = replay_item_type(item),
+            item_id = replay_item_id(item),
+            "Skipping mcp_call without name during upstream replay"
+        );
+        return Vec::new();
+    };
+    let Some(arguments) = item.get("arguments").and_then(|value| value.as_str()) else {
+        warn!(
+            item_type = replay_item_type(item),
+            item_id = replay_item_id(item),
+            "Skipping mcp_call without arguments during upstream replay"
+        );
+        return Vec::new();
+    };
+
+    let status = normalize_replayed_tool_status(
+        item.get("status")
+            .and_then(|value| value.as_str())
+            .unwrap_or("completed"),
+    );
+    let output = mcp_call_output_string(item);
+
+    let call_id = item
+        .get("approval_request_id")
+        .and_then(|value| value.as_str())
+        .map(approval_request_id_to_call_id)
+        .unwrap_or_else(|| mcp_item_id_to_prefixed_id(id, "call_"));
+
+    vec![
+        ResponseInputOutputItem::FunctionToolCall {
+            id: mcp_item_id_to_prefixed_id(id, "fc_"),
+            call_id: call_id.clone(),
+            name: name.to_string(),
+            arguments: arguments.to_string(),
+            output: None,
+            status: Some(status.clone()),
+        },
+        ResponseInputOutputItem::FunctionCallOutput {
+            id: None,
+            call_id,
+            output,
+            status: Some(status),
+        },
+    ]
+}
+
+fn mcp_call_output_string(item: &Value) -> String {
+    let output = item.get("output").cloned().unwrap_or(Value::Null);
+    let error = item.get("error").cloned().unwrap_or(Value::Null);
+
+    if error.is_null() {
+        return match output {
+            Value::String(text) => text,
+            other => other.to_string(),
+        };
+    }
+
+    json_output_with_error(output, error).to_string()
+}
+
+fn normalize_replayed_tool_status(status: &str) -> String {
+    match status {
+        // Persisted MCP calls should already be terminal. If a non-terminal
+        // status somehow lands in storage, normalize it back to `completed`
+        // so upstream replay does not resurrect an in-progress tool call.
+        "completed" | "failed" | "incomplete" | "cancelled" => status.to_string(),
+        _ => "completed".to_string(),
+    }
+}
+
+fn json_output_with_error(output: Value, error: Value) -> Value {
+    serde_json::json!({
+        "output": output,
+        "error": error,
+    })
+}
+
+fn replay_item_type(item: &Value) -> &str {
+    item.get("type")
+        .and_then(|value| value.as_str())
+        .unwrap_or("unknown")
+}
+
+fn replay_item_id(item: &Value) -> &str {
+    item.get("id")
+        .and_then(|value| value.as_str())
+        .unwrap_or("unknown")
 }
 
 fn extract_mcp_list_tools_labels(array: &Value) -> Vec<String> {
@@ -287,9 +494,7 @@ fn append_current_input(
             });
         }
         ResponseInput::Items(current_items) => {
-            for item in current_items {
-                items.push(openai_protocol::responses::normalize_input_item(item));
-            }
+            items.extend(current_items.iter().map(normalize_input_item));
         }
     }
 }
@@ -321,9 +526,13 @@ pub(crate) fn inject_memory_context(
 
 #[cfg(test)]
 mod tests {
-    use openai_protocol::responses::{ResponseInput, ResponsesRequest};
+    use openai_protocol::responses::{ResponseInput, ResponseInputOutputItem, ResponsesRequest};
+    use serde_json::{json, Value};
 
-    use super::inject_memory_context;
+    use super::{
+        inject_memory_context, mcp_call_output_string, mcp_call_output_to_upstream_items,
+        normalize_replayed_tool_status,
+    };
     use crate::routers::common::header_utils::{
         ConversationMemoryConfig, LongTermMemoryConfig, ShortTermMemoryConfig,
     };
@@ -355,6 +564,89 @@ mod tests {
             ResponseInput::Items(_) => {
                 panic!("request input should remain unchanged for no-op hook")
             }
+        }
+    }
+
+    #[test]
+    fn mcp_call_output_string_wraps_error_with_output() {
+        let item = json!({
+            "type": "mcp_call",
+            "output": "partial output",
+            "error": "boom",
+        });
+
+        let output = mcp_call_output_string(&item);
+        let parsed: Value = serde_json::from_str(&output).expect("wrapped output should be json");
+        assert_eq!(
+            parsed,
+            json!({
+                "output": "partial output",
+                "error": "boom",
+            })
+        );
+    }
+
+    #[test]
+    fn mcp_call_output_string_preserves_output_when_error_missing() {
+        let item = json!({
+            "type": "mcp_call",
+            "output": "plain output",
+        });
+
+        assert_eq!(mcp_call_output_string(&item), "plain output");
+    }
+
+    #[test]
+    fn normalize_replayed_tool_status_falls_back_to_completed_for_non_terminal_values() {
+        assert_eq!(normalize_replayed_tool_status("in_progress"), "completed");
+        assert_eq!(normalize_replayed_tool_status("queued"), "completed");
+    }
+
+    #[test]
+    fn mcp_call_output_to_upstream_items_keeps_terminal_status_and_normalizes_non_terminal() {
+        let terminal = json!({
+            "type": "mcp_call",
+            "id": "mcp_123",
+            "name": "tool",
+            "arguments": "{}",
+            "output": "ok",
+            "status": "failed",
+        });
+        let terminal_items = mcp_call_output_to_upstream_items(&terminal);
+        assert_eq!(terminal_items.len(), 2);
+        match &terminal_items[0] {
+            ResponseInputOutputItem::FunctionToolCall { status, .. } => {
+                assert_eq!(status.as_deref(), Some("failed"));
+            }
+            other => panic!("expected function_call, got {other:?}"),
+        }
+        match &terminal_items[1] {
+            ResponseInputOutputItem::FunctionCallOutput { status, .. } => {
+                assert_eq!(status.as_deref(), Some("failed"));
+            }
+            other => panic!("expected function_call_output, got {other:?}"),
+        }
+
+        let non_terminal = json!({
+            "type": "mcp_call",
+            "id": "mcp_456",
+            "name": "tool",
+            "arguments": "{}",
+            "output": "ok",
+            "status": "in_progress",
+        });
+        let non_terminal_items = mcp_call_output_to_upstream_items(&non_terminal);
+        match &non_terminal_items[0] {
+            ResponseInputOutputItem::FunctionToolCall { status, .. } => {
+                assert_eq!(status.as_deref(), Some("completed"));
+            }
+            other => panic!("expected function_call, got {other:?}"),
+        }
+        match &non_terminal_items[1] {
+            ResponseInputOutputItem::FunctionCallOutput { status, .. } => {
+                assert_eq!(status.as_deref(), Some("completed"));
+            }
+            other => panic!("expected function_call_output, got {other:?}"),
         }
     }
 }

--- a/model_gateway/src/routers/openai/responses/mod.rs
+++ b/model_gateway/src/routers/openai/responses/mod.rs
@@ -10,6 +10,7 @@
 //! - Shared helpers for response retrieval-related logic
 
 mod accumulator;
+pub(crate) mod approval_continuation;
 mod common;
 pub(crate) mod history;
 mod non_streaming;

--- a/model_gateway/src/routers/openai/responses/non_streaming.rs
+++ b/model_gateway/src/routers/openai/responses/non_streaming.rs
@@ -21,7 +21,10 @@ use crate::routers::{
     error,
     openai::{
         context::{PayloadState, RequestContext, ResponsesPayloadState},
-        mcp::{execute_tool_loop, prepare_mcp_tools_as_functions, ToolLoopExecutionContext},
+        mcp::{
+            execute_tool_loop, prepare_mcp_tools_as_functions, ToolLoopError,
+            ToolLoopExecutionContext,
+        },
     },
 };
 
@@ -41,7 +44,14 @@ pub async fn handle_non_streaming_response(mut ctx: RequestContext) -> Response 
     let ResponsesPayloadState {
         previous_response_id,
         existing_mcp_list_tools_labels,
-    } = ctx.take_responses_payload().unwrap_or_default();
+        approval_continuation,
+        upstream_input,
+    } = match ctx.take_responses_payload() {
+        Some(state) => state,
+        None => {
+            return error::internal_error("internal_error", "Responses payload not prepared");
+        }
+    };
 
     let original_body = match ctx.responses_request() {
         Some(r) => r,
@@ -68,6 +78,19 @@ pub async fn handle_non_streaming_response(mut ctx: RequestContext) -> Response 
     } else {
         None
     };
+
+    if let Some(continuation) = approval_continuation
+        .as_ref()
+        .filter(|_| mcp_servers.is_none())
+    {
+        return error::bad_request(
+            "invalid_mcp_approval_response",
+            format!(
+                "approved tool '{}' (approval_request_id={}) is not available in this request",
+                continuation.tool_name, continuation.approval_request_id
+            ),
+        );
+    }
 
     let mut response_json: Value;
 
@@ -96,7 +119,9 @@ pub async fn handle_non_streaming_response(mut ctx: RequestContext) -> Response 
             payload,
             ToolLoopExecutionContext {
                 original_body,
+                upstream_input: &upstream_input,
                 existing_mcp_list_tools_labels: &existing_mcp_list_tools_labels,
+                approval_continuation: approval_continuation.as_ref(),
                 session: &session,
             },
         )
@@ -106,7 +131,13 @@ pub async fn handle_non_streaming_response(mut ctx: RequestContext) -> Response 
                 worker.record_outcome(200);
                 response_json = resp;
             }
-            Err(err) => {
+            Err(ToolLoopError::InvalidApprovalResponse(err)) => {
+                return error::bad_request("invalid_mcp_approval_response", err);
+            }
+            Err(ToolLoopError::MaxToolCallsExceeded(err)) => {
+                return error::bad_request("max_tool_calls_exceeded", err);
+            }
+            Err(ToolLoopError::Execution(err)) => {
                 worker.record_outcome(502);
                 return error::internal_error("upstream_error", err);
             }

--- a/model_gateway/src/routers/openai/responses/route.rs
+++ b/model_gateway/src/routers/openai/responses/route.rs
@@ -19,6 +19,7 @@ use super::{
         provider::ProviderRegistry,
         router::resolve_provider,
     },
+    approval_continuation::prepare_responses_input,
     handle_non_streaming_response, handle_streaming_response,
 };
 use crate::{
@@ -136,6 +137,25 @@ pub(in crate::routers::openai) async fn route_responses(
     if let ResponseInput::Items(ref mut items) = request_body.input {
         items.retain(|item| !matches!(item, ResponseInputOutputItem::Reasoning { .. }));
     }
+    let prepared_input = match prepare_responses_input(
+        &request_body.input,
+        &loaded_history.pending_mcp_approval_requests,
+        streaming,
+    ) {
+        Ok(prepared) => prepared,
+        Err(e) => {
+            Metrics::record_router_error(
+                metrics_labels::ROUTER_OPENAI,
+                metrics_labels::BACKEND_EXTERNAL,
+                metrics_labels::CONNECTION_HTTP,
+                model,
+                metrics_labels::ENDPOINT_RESPONSES,
+                metrics_labels::ERROR_VALIDATION,
+            );
+            return error::bad_request("invalid_mcp_approval_response", e);
+        }
+    };
+    request_body.input = prepared_input.upstream_input;
 
     let mut payload = match to_value(&request_body) {
         Ok(v) => v,
@@ -154,6 +174,7 @@ pub(in crate::routers::openai) async fn route_responses(
             );
         }
     };
+    let upstream_input = request_body.input.clone();
 
     let provider = resolve_provider(deps.provider_registry, worker.as_ref(), model);
     if let Err(e) = provider.transform_request(&mut payload, Endpoint::Responses) {
@@ -189,6 +210,8 @@ pub(in crate::routers::openai) async fn route_responses(
     ctx.state.responses_payload = Some(ResponsesPayloadState {
         previous_response_id: loaded_history.previous_response_id,
         existing_mcp_list_tools_labels: loaded_history.existing_mcp_list_tools_labels,
+        approval_continuation: prepared_input.approval_continuation,
+        upstream_input,
     });
 
     let response = if ctx.is_streaming() {

--- a/model_gateway/tests/api/responses_api_test.rs
+++ b/model_gateway/tests/api/responses_api_test.rs
@@ -4,9 +4,10 @@ use axum::http::{HeaderMap, HeaderValue, StatusCode};
 use openai_protocol::{
     common::{GenerationRequest, UsageInfo},
     responses::{
-        CodeInterpreterTool, McpTool, ReasoningEffort, RequireApproval, RequireApprovalMode,
-        ResponseInput, ResponseReasoningParam, ResponseTool, ResponsesRequest, ResponsesToolChoice,
-        ServiceTier, ToolChoiceOptions, Truncation, WebSearchPreviewTool,
+        CodeInterpreterTool, McpAllowedTools, McpTool, ReasoningEffort, RequireApproval,
+        RequireApprovalMode, ResponseInput, ResponseInputOutputItem, ResponseReasoningParam,
+        ResponseTool, ResponsesRequest, ResponsesToolChoice, ServiceTier, ToolChoiceOptions,
+        Truncation, WebSearchPreviewTool,
     },
 };
 use smg::{
@@ -25,6 +26,58 @@ const TEST_INTERNAL_MCP_ERROR_MARKER: &str = "internal-mcp-failure-marker";
 
 fn test_tenant_meta() -> smg::middleware::TenantRequestMeta {
     RouteRequestMeta::new(TenantKey::from("test-tenant"))
+}
+
+fn build_required_approval_request(mcp_url: &str, request_id: &str) -> ResponsesRequest {
+    ResponsesRequest {
+        background: Some(false),
+        include: None,
+        input: ResponseInput::Text("search something".to_string()),
+        instructions: Some("Be brief".to_string()),
+        max_output_tokens: Some(64),
+        max_tool_calls: None,
+        metadata: None,
+        model: "mock-model".to_string(),
+        parallel_tool_calls: Some(true),
+        previous_response_id: None,
+        reasoning: None,
+        service_tier: Some(ServiceTier::Auto),
+        store: Some(true),
+        stream: Some(false),
+        temperature: Some(0.2),
+        tool_choice: Some(ResponsesToolChoice::default()),
+        tools: Some(vec![ResponseTool::Mcp(McpTool {
+            server_url: Some(mcp_url.to_string()),
+            authorization: None,
+            headers: None,
+            server_label: "mock".to_string(),
+            server_description: None,
+            require_approval: Some(RequireApproval::Mode(RequireApprovalMode::Always)),
+            allowed_tools: None,
+            connector_id: None,
+            defer_loading: None,
+        })]),
+        top_logprobs: Some(0),
+        top_p: None,
+        truncation: Some(Truncation::Disabled),
+        text: None,
+        user: None,
+        request_id: Some(request_id.to_string()),
+        priority: 0,
+        frequency_penalty: Some(0.0),
+        presence_penalty: Some(0.0),
+        stop: None,
+        prompt: None,
+        prompt_cache_key: None,
+        prompt_cache_retention: None,
+        safety_identifier: None,
+        stream_options: None,
+        context_management: None,
+        top_k: -1,
+        min_p: 0.0,
+        repetition_penalty: 1.0,
+        conversation: None,
+    }
 }
 
 #[tokio::test]
@@ -516,6 +569,667 @@ async fn test_non_streaming_mcp_returns_approval_request_when_required() {
 }
 
 #[tokio::test]
+async fn test_non_streaming_mcp_approval_continues_with_previous_response_id() {
+    let mut mcp = MockMCPServer::start().await.expect("start mcp");
+
+    let mcp_yaml = format!(
+        "servers:\n  - name: mock\n    protocol: streamable\n    url: {}\n",
+        mcp.url()
+    );
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let cfg_path = dir.path().join("mcp.yaml");
+    std::fs::write(&cfg_path, mcp_yaml).expect("write mcp cfg");
+
+    let mut worker = MockWorker::new(MockWorkerConfig {
+        port: 0,
+        worker_type: WorkerType::Regular,
+        health_status: HealthStatus::Healthy,
+        response_delay_ms: 0,
+        fail_rate: 0.0,
+    });
+    let worker_url = worker.start().await.expect("start worker");
+
+    let router_cfg = RouterConfig::builder()
+        .openai_mode(vec![worker_url])
+        .random_policy()
+        .host("127.0.0.1")
+        .port(0)
+        .max_payload_size(8 * 1024 * 1024)
+        .request_timeout_secs(60)
+        .worker_startup_timeout_secs(5)
+        .worker_startup_check_interval_secs(1)
+        .log_level("warn")
+        .max_concurrent_requests(32)
+        .queue_timeout_secs(5)
+        .build_unchecked();
+
+    let ctx =
+        crate::common::create_test_context_with_mcp_config(router_cfg, cfg_path.to_str().unwrap())
+            .await;
+    let router = RouterFactory::create_router(&ctx).await.expect("router");
+
+    let req1 = build_required_approval_request(
+        mcp.url().as_str(),
+        "resp_test_mcp_approval_interrupt_prev_1",
+    );
+
+    let tenant_meta_prev = test_tenant_meta();
+    let resp1 = router
+        .route_responses(None, &tenant_meta_prev, &req1, req1.model.as_str())
+        .await;
+    assert_eq!(resp1.status(), StatusCode::OK);
+
+    let body1_bytes = axum::body::to_bytes(resp1.into_body(), usize::MAX)
+        .await
+        .expect("Failed to read response body");
+    let body1_json: serde_json::Value =
+        serde_json::from_slice(&body1_bytes).expect("Failed to parse response JSON");
+
+    let approval_item = body1_json["output"]
+        .as_array()
+        .expect("response output missing")
+        .iter()
+        .find(|entry| entry.get("type").and_then(|v| v.as_str()) == Some("mcp_approval_request"))
+        .expect("missing mcp_approval_request output item");
+    let approval_request_id = approval_item["id"]
+        .as_str()
+        .expect("approval request should have id")
+        .to_string();
+    let first_response_id = body1_json["id"]
+        .as_str()
+        .expect("first response should have id")
+        .to_string();
+
+    let req2 = ResponsesRequest {
+        input: ResponseInput::Items(vec![ResponseInputOutputItem::McpApprovalResponse {
+            id: None,
+            approval_request_id: approval_request_id.clone(),
+            approve: true,
+            reason: None,
+        }]),
+        previous_response_id: Some(first_response_id),
+        request_id: Some("resp_test_mcp_approval_interrupt_prev_2".to_string()),
+        ..req1.clone()
+    };
+
+    let resp2 = router
+        .route_responses(None, &tenant_meta_prev, &req2, req2.model.as_str())
+        .await;
+    assert_eq!(resp2.status(), StatusCode::OK);
+
+    let body2_bytes = axum::body::to_bytes(resp2.into_body(), usize::MAX)
+        .await
+        .expect("Failed to read response body");
+    let body2_json: serde_json::Value =
+        serde_json::from_slice(&body2_bytes).expect("Failed to parse response JSON");
+
+    assert_eq!(body2_json["status"], "completed");
+
+    let output = body2_json["output"]
+        .as_array()
+        .expect("response output missing");
+    assert!(
+        output
+            .iter()
+            .all(|entry| entry.get("type").and_then(|v| v.as_str()) != Some("mcp_approval_request")),
+        "resumed response should not emit another approval request"
+    );
+    assert!(
+        output
+            .iter()
+            .all(|entry| entry.get("type").and_then(|v| v.as_str()) != Some("mcp_list_tools")),
+        "previous_response_id resume should not repeat mcp_list_tools"
+    );
+
+    let mcp_call = output
+        .iter()
+        .find(|entry| entry.get("type").and_then(|v| v.as_str()) == Some("mcp_call"))
+        .expect("missing resumed mcp_call output item");
+    assert_eq!(
+        mcp_call.get("approval_request_id").and_then(|v| v.as_str()),
+        Some(approval_request_id.as_str())
+    );
+    assert_eq!(
+        mcp_call.get("server_label").and_then(|v| v.as_str()),
+        Some("mock")
+    );
+    assert_eq!(
+        mcp_call.get("name").and_then(|v| v.as_str()),
+        Some("brave_web_search")
+    );
+    assert!(mcp_call
+        .get("id")
+        .and_then(|v| v.as_str())
+        .is_some_and(|id| id.starts_with("mcp_")));
+    assert!(
+        output
+            .iter()
+            .any(|entry| entry.get("type").and_then(|v| v.as_str()) == Some("message")),
+        "resumed response should include the final assistant message"
+    );
+
+    worker.stop().await;
+    mcp.stop().await;
+}
+
+#[tokio::test]
+async fn test_non_streaming_mcp_approval_rejects_denied_previous_response_id() {
+    let mut mcp = MockMCPServer::start().await.expect("start mcp");
+
+    let mcp_yaml = format!(
+        "servers:\n  - name: mock\n    protocol: streamable\n    url: {}\n",
+        mcp.url()
+    );
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let cfg_path = dir.path().join("mcp.yaml");
+    std::fs::write(&cfg_path, mcp_yaml).expect("write mcp cfg");
+
+    let mut worker = MockWorker::new(MockWorkerConfig {
+        port: 0,
+        worker_type: WorkerType::Regular,
+        health_status: HealthStatus::Healthy,
+        response_delay_ms: 0,
+        fail_rate: 0.0,
+    });
+    let worker_url = worker.start().await.expect("start worker");
+
+    let router_cfg = RouterConfig::builder()
+        .openai_mode(vec![worker_url])
+        .random_policy()
+        .host("127.0.0.1")
+        .port(0)
+        .max_payload_size(8 * 1024 * 1024)
+        .request_timeout_secs(60)
+        .worker_startup_timeout_secs(5)
+        .worker_startup_check_interval_secs(1)
+        .log_level("warn")
+        .max_concurrent_requests(32)
+        .queue_timeout_secs(5)
+        .build_unchecked();
+
+    let ctx =
+        crate::common::create_test_context_with_mcp_config(router_cfg, cfg_path.to_str().unwrap())
+            .await;
+    let router = RouterFactory::create_router(&ctx).await.expect("router");
+
+    let req1 =
+        build_required_approval_request(mcp.url().as_str(), "resp_test_mcp_approval_deny_prev_1");
+    let tenant_meta = test_tenant_meta();
+    let resp1 = router
+        .route_responses(None, &tenant_meta, &req1, req1.model.as_str())
+        .await;
+    assert_eq!(resp1.status(), StatusCode::OK);
+
+    let body1 = axum::body::to_bytes(resp1.into_body(), usize::MAX)
+        .await
+        .expect("read body");
+    let body1_json: serde_json::Value = serde_json::from_slice(&body1).expect("parse body");
+    let approval_request_id = body1_json["output"]
+        .as_array()
+        .expect("response output missing")
+        .iter()
+        .find(|entry| entry.get("type").and_then(|v| v.as_str()) == Some("mcp_approval_request"))
+        .and_then(|entry| entry.get("id"))
+        .and_then(|v| v.as_str())
+        .expect("approval request should have id")
+        .to_string();
+    let first_response_id = body1_json["id"]
+        .as_str()
+        .expect("first response should have id")
+        .to_string();
+
+    let req2 = ResponsesRequest {
+        input: ResponseInput::Items(vec![ResponseInputOutputItem::McpApprovalResponse {
+            id: None,
+            approval_request_id,
+            approve: false,
+            reason: Some("no".to_string()),
+        }]),
+        previous_response_id: Some(first_response_id),
+        request_id: Some("resp_test_mcp_approval_deny_prev_2".to_string()),
+        ..req1.clone()
+    };
+
+    let resp2 = router
+        .route_responses(None, &tenant_meta, &req2, req2.model.as_str())
+        .await;
+    assert_eq!(resp2.status(), StatusCode::BAD_REQUEST);
+
+    let body2 = axum::body::to_bytes(resp2.into_body(), usize::MAX)
+        .await
+        .expect("read body");
+    let body2_json: serde_json::Value = serde_json::from_slice(&body2).expect("parse body");
+    assert_eq!(body2_json["error"]["code"], "invalid_mcp_approval_response");
+    assert!(body2_json["error"]["message"]
+        .as_str()
+        .is_some_and(|msg| msg.contains("approve=false")));
+
+    worker.stop().await;
+    mcp.stop().await;
+}
+
+#[tokio::test]
+async fn test_non_streaming_mcp_approval_rejects_consumed_approval_request_id() {
+    let mut mcp = MockMCPServer::start().await.expect("start mcp");
+
+    let mcp_yaml = format!(
+        "servers:\n  - name: mock\n    protocol: streamable\n    url: {}\n",
+        mcp.url()
+    );
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let cfg_path = dir.path().join("mcp.yaml");
+    std::fs::write(&cfg_path, mcp_yaml).expect("write mcp cfg");
+
+    let mut worker = MockWorker::new(MockWorkerConfig {
+        port: 0,
+        worker_type: WorkerType::Regular,
+        health_status: HealthStatus::Healthy,
+        response_delay_ms: 0,
+        fail_rate: 0.0,
+    });
+    let worker_url = worker.start().await.expect("start worker");
+
+    let router_cfg = RouterConfig::builder()
+        .openai_mode(vec![worker_url])
+        .random_policy()
+        .host("127.0.0.1")
+        .port(0)
+        .max_payload_size(8 * 1024 * 1024)
+        .request_timeout_secs(60)
+        .worker_startup_timeout_secs(5)
+        .worker_startup_check_interval_secs(1)
+        .log_level("warn")
+        .max_concurrent_requests(32)
+        .queue_timeout_secs(5)
+        .build_unchecked();
+
+    let ctx =
+        crate::common::create_test_context_with_mcp_config(router_cfg, cfg_path.to_str().unwrap())
+            .await;
+    let router = RouterFactory::create_router(&ctx).await.expect("router");
+
+    let req1 = build_required_approval_request(
+        mcp.url().as_str(),
+        "resp_test_mcp_approval_consumed_prev_1",
+    );
+    let tenant_meta = test_tenant_meta();
+    let resp1 = router
+        .route_responses(None, &tenant_meta, &req1, req1.model.as_str())
+        .await;
+    assert_eq!(resp1.status(), StatusCode::OK);
+
+    let body1 = axum::body::to_bytes(resp1.into_body(), usize::MAX)
+        .await
+        .expect("read body");
+    let body1_json: serde_json::Value = serde_json::from_slice(&body1).expect("parse body");
+    let approval_request_id = body1_json["output"]
+        .as_array()
+        .expect("response output missing")
+        .iter()
+        .find(|entry| entry.get("type").and_then(|v| v.as_str()) == Some("mcp_approval_request"))
+        .and_then(|entry| entry.get("id"))
+        .and_then(|v| v.as_str())
+        .expect("approval request should have id")
+        .to_string();
+    let first_response_id = body1_json["id"]
+        .as_str()
+        .expect("first response should have id")
+        .to_string();
+
+    let req2 = ResponsesRequest {
+        input: ResponseInput::Items(vec![ResponseInputOutputItem::McpApprovalResponse {
+            id: None,
+            approval_request_id: approval_request_id.clone(),
+            approve: true,
+            reason: None,
+        }]),
+        previous_response_id: Some(first_response_id),
+        request_id: Some("resp_test_mcp_approval_consumed_prev_2".to_string()),
+        ..req1.clone()
+    };
+
+    let resp2 = router
+        .route_responses(None, &tenant_meta, &req2, req2.model.as_str())
+        .await;
+    assert_eq!(resp2.status(), StatusCode::OK);
+
+    let body2 = axum::body::to_bytes(resp2.into_body(), usize::MAX)
+        .await
+        .expect("read body");
+    let body2_json: serde_json::Value = serde_json::from_slice(&body2).expect("parse body");
+    let second_response_id = body2_json["id"]
+        .as_str()
+        .expect("second response should have id")
+        .to_string();
+
+    let req3 = ResponsesRequest {
+        input: ResponseInput::Items(vec![ResponseInputOutputItem::McpApprovalResponse {
+            id: None,
+            approval_request_id,
+            approve: true,
+            reason: None,
+        }]),
+        previous_response_id: Some(second_response_id),
+        request_id: Some("resp_test_mcp_approval_consumed_prev_3".to_string()),
+        ..req1.clone()
+    };
+
+    let resp3 = router
+        .route_responses(None, &tenant_meta, &req3, req3.model.as_str())
+        .await;
+    assert_eq!(resp3.status(), StatusCode::BAD_REQUEST);
+
+    let body3 = axum::body::to_bytes(resp3.into_body(), usize::MAX)
+        .await
+        .expect("read body");
+    let body3_json: serde_json::Value = serde_json::from_slice(&body3).expect("parse body");
+    assert_eq!(body3_json["error"]["code"], "invalid_mcp_approval_response");
+    assert!(body3_json["error"]["message"]
+        .as_str()
+        .is_some_and(|msg| msg.contains("does not match any pending mcp_approval_request")));
+
+    worker.stop().await;
+    mcp.stop().await;
+}
+
+#[tokio::test]
+async fn test_non_streaming_mcp_approval_rejects_unknown_approval_request_id() {
+    let mut mcp = MockMCPServer::start().await.expect("start mcp");
+
+    let mcp_yaml = format!(
+        "servers:\n  - name: mock\n    protocol: streamable\n    url: {}\n",
+        mcp.url()
+    );
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let cfg_path = dir.path().join("mcp.yaml");
+    std::fs::write(&cfg_path, mcp_yaml).expect("write mcp cfg");
+
+    let mut worker = MockWorker::new(MockWorkerConfig {
+        port: 0,
+        worker_type: WorkerType::Regular,
+        health_status: HealthStatus::Healthy,
+        response_delay_ms: 0,
+        fail_rate: 0.0,
+    });
+    let worker_url = worker.start().await.expect("start worker");
+
+    let router_cfg = RouterConfig::builder()
+        .openai_mode(vec![worker_url])
+        .random_policy()
+        .host("127.0.0.1")
+        .port(0)
+        .max_payload_size(8 * 1024 * 1024)
+        .request_timeout_secs(60)
+        .worker_startup_timeout_secs(5)
+        .worker_startup_check_interval_secs(1)
+        .log_level("warn")
+        .max_concurrent_requests(32)
+        .queue_timeout_secs(5)
+        .build_unchecked();
+
+    let ctx =
+        crate::common::create_test_context_with_mcp_config(router_cfg, cfg_path.to_str().unwrap())
+            .await;
+    let router = RouterFactory::create_router(&ctx).await.expect("router");
+
+    let req1 = build_required_approval_request(
+        mcp.url().as_str(),
+        "resp_test_mcp_approval_unknown_prev_1",
+    );
+    let tenant_meta = test_tenant_meta();
+    let resp1 = router
+        .route_responses(None, &tenant_meta, &req1, req1.model.as_str())
+        .await;
+    assert_eq!(resp1.status(), StatusCode::OK);
+
+    let body1 = axum::body::to_bytes(resp1.into_body(), usize::MAX)
+        .await
+        .expect("read body");
+    let body1_json: serde_json::Value = serde_json::from_slice(&body1).expect("parse body");
+    let first_response_id = body1_json["id"]
+        .as_str()
+        .expect("first response should have id")
+        .to_string();
+
+    let req2 = ResponsesRequest {
+        input: ResponseInput::Items(vec![ResponseInputOutputItem::McpApprovalResponse {
+            id: None,
+            approval_request_id: "mcpr_does_not_exist".to_string(),
+            approve: true,
+            reason: None,
+        }]),
+        previous_response_id: Some(first_response_id),
+        request_id: Some("resp_test_mcp_approval_unknown_prev_2".to_string()),
+        ..req1.clone()
+    };
+
+    let resp2 = router
+        .route_responses(None, &tenant_meta, &req2, req2.model.as_str())
+        .await;
+    assert_eq!(resp2.status(), StatusCode::BAD_REQUEST);
+
+    let body2 = axum::body::to_bytes(resp2.into_body(), usize::MAX)
+        .await
+        .expect("read body");
+    let body2_json: serde_json::Value = serde_json::from_slice(&body2).expect("parse body");
+    assert_eq!(body2_json["error"]["code"], "invalid_mcp_approval_response");
+    assert!(body2_json["error"]["message"]
+        .as_str()
+        .is_some_and(|msg| msg.contains("does not match any pending mcp_approval_request")));
+
+    worker.stop().await;
+    mcp.stop().await;
+}
+
+#[tokio::test]
+async fn test_non_streaming_mcp_approval_rejects_removed_tool_binding() {
+    let mut mcp = MockMCPServer::start().await.expect("start mcp");
+
+    let mcp_yaml = format!(
+        "servers:\n  - name: mock\n    protocol: streamable\n    url: {}\n",
+        mcp.url()
+    );
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let cfg_path = dir.path().join("mcp.yaml");
+    std::fs::write(&cfg_path, mcp_yaml).expect("write mcp cfg");
+
+    let mut worker = MockWorker::new(MockWorkerConfig {
+        port: 0,
+        worker_type: WorkerType::Regular,
+        health_status: HealthStatus::Healthy,
+        response_delay_ms: 0,
+        fail_rate: 0.0,
+    });
+    let worker_url = worker.start().await.expect("start worker");
+
+    let router_cfg = RouterConfig::builder()
+        .openai_mode(vec![worker_url])
+        .random_policy()
+        .host("127.0.0.1")
+        .port(0)
+        .max_payload_size(8 * 1024 * 1024)
+        .request_timeout_secs(60)
+        .worker_startup_timeout_secs(5)
+        .worker_startup_check_interval_secs(1)
+        .log_level("warn")
+        .max_concurrent_requests(32)
+        .queue_timeout_secs(5)
+        .build_unchecked();
+
+    let ctx =
+        crate::common::create_test_context_with_mcp_config(router_cfg, cfg_path.to_str().unwrap())
+            .await;
+    let router = RouterFactory::create_router(&ctx).await.expect("router");
+
+    let req1 = build_required_approval_request(
+        mcp.url().as_str(),
+        "resp_test_mcp_approval_removed_prev_1",
+    );
+    let tenant_meta = test_tenant_meta();
+    let resp1 = router
+        .route_responses(None, &tenant_meta, &req1, req1.model.as_str())
+        .await;
+    assert_eq!(resp1.status(), StatusCode::OK);
+
+    let body1 = axum::body::to_bytes(resp1.into_body(), usize::MAX)
+        .await
+        .expect("read body");
+    let body1_json: serde_json::Value = serde_json::from_slice(&body1).expect("parse body");
+    let approval_request_id = body1_json["output"]
+        .as_array()
+        .expect("response output missing")
+        .iter()
+        .find(|entry| entry.get("type").and_then(|v| v.as_str()) == Some("mcp_approval_request"))
+        .and_then(|entry| entry.get("id"))
+        .and_then(|v| v.as_str())
+        .expect("approval request should have id")
+        .to_string();
+    let first_response_id = body1_json["id"]
+        .as_str()
+        .expect("first response should have id")
+        .to_string();
+
+    let req2 = ResponsesRequest {
+        input: ResponseInput::Items(vec![ResponseInputOutputItem::McpApprovalResponse {
+            id: None,
+            approval_request_id,
+            approve: true,
+            reason: None,
+        }]),
+        previous_response_id: Some(first_response_id),
+        tools: Some(vec![ResponseTool::Mcp(McpTool {
+            server_url: Some(mcp.url()),
+            authorization: None,
+            headers: None,
+            server_label: "mock".to_string(),
+            server_description: None,
+            require_approval: Some(RequireApproval::Mode(RequireApprovalMode::Always)),
+            allowed_tools: Some(McpAllowedTools::List(vec![
+                "not_brave_web_search".to_string()
+            ])),
+            connector_id: None,
+            defer_loading: None,
+        })]),
+        request_id: Some("resp_test_mcp_approval_removed_prev_2".to_string()),
+        ..req1.clone()
+    };
+
+    let resp2 = router
+        .route_responses(None, &tenant_meta, &req2, req2.model.as_str())
+        .await;
+    assert_eq!(resp2.status(), StatusCode::BAD_REQUEST);
+
+    let body2 = axum::body::to_bytes(resp2.into_body(), usize::MAX)
+        .await
+        .expect("read body");
+    let body2_json: serde_json::Value = serde_json::from_slice(&body2).expect("parse body");
+    assert_eq!(body2_json["error"]["code"], "invalid_mcp_approval_response");
+    assert!(body2_json["error"]["message"]
+        .as_str()
+        .is_some_and(|msg| msg.contains("is not available in this request")));
+
+    worker.stop().await;
+    mcp.stop().await;
+}
+
+#[tokio::test]
+async fn test_non_streaming_mcp_approval_rejects_replay_beyond_max_tool_calls() {
+    let mut mcp = MockMCPServer::start().await.expect("start mcp");
+
+    let mcp_yaml = format!(
+        "servers:\n  - name: mock\n    protocol: streamable\n    url: {}\n",
+        mcp.url()
+    );
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let cfg_path = dir.path().join("mcp.yaml");
+    std::fs::write(&cfg_path, mcp_yaml).expect("write mcp cfg");
+
+    let mut worker = MockWorker::new(MockWorkerConfig {
+        port: 0,
+        worker_type: WorkerType::Regular,
+        health_status: HealthStatus::Healthy,
+        response_delay_ms: 0,
+        fail_rate: 0.0,
+    });
+    let worker_url = worker.start().await.expect("start worker");
+
+    let router_cfg = RouterConfig::builder()
+        .openai_mode(vec![worker_url])
+        .random_policy()
+        .host("127.0.0.1")
+        .port(0)
+        .max_payload_size(8 * 1024 * 1024)
+        .request_timeout_secs(60)
+        .worker_startup_timeout_secs(5)
+        .worker_startup_check_interval_secs(1)
+        .log_level("warn")
+        .max_concurrent_requests(32)
+        .queue_timeout_secs(5)
+        .build_unchecked();
+
+    let ctx =
+        crate::common::create_test_context_with_mcp_config(router_cfg, cfg_path.to_str().unwrap())
+            .await;
+    let router = RouterFactory::create_router(&ctx).await.expect("router");
+
+    let req1 =
+        build_required_approval_request(mcp.url().as_str(), "resp_test_mcp_approval_limit_prev_1");
+    let tenant_meta = test_tenant_meta();
+    let resp1 = router
+        .route_responses(None, &tenant_meta, &req1, req1.model.as_str())
+        .await;
+    assert_eq!(resp1.status(), StatusCode::OK);
+
+    let body1 = axum::body::to_bytes(resp1.into_body(), usize::MAX)
+        .await
+        .expect("read body");
+    let body1_json: serde_json::Value = serde_json::from_slice(&body1).expect("parse body");
+    let approval_request_id = body1_json["output"]
+        .as_array()
+        .expect("response output missing")
+        .iter()
+        .find(|entry| entry.get("type").and_then(|v| v.as_str()) == Some("mcp_approval_request"))
+        .and_then(|entry| entry.get("id"))
+        .and_then(|v| v.as_str())
+        .expect("approval request should have id")
+        .to_string();
+    let first_response_id = body1_json["id"]
+        .as_str()
+        .expect("first response should have id")
+        .to_string();
+
+    let req2 = ResponsesRequest {
+        input: ResponseInput::Items(vec![ResponseInputOutputItem::McpApprovalResponse {
+            id: None,
+            approval_request_id,
+            approve: true,
+            reason: None,
+        }]),
+        previous_response_id: Some(first_response_id),
+        max_tool_calls: Some(0),
+        request_id: Some("resp_test_mcp_approval_limit_prev_2".to_string()),
+        ..req1.clone()
+    };
+
+    let resp2 = router
+        .route_responses(None, &tenant_meta, &req2, req2.model.as_str())
+        .await;
+    assert_eq!(resp2.status(), StatusCode::BAD_REQUEST);
+
+    let body2 = axum::body::to_bytes(resp2.into_body(), usize::MAX)
+        .await
+        .expect("read body");
+    let body2_json: serde_json::Value = serde_json::from_slice(&body2).expect("parse body");
+    assert_eq!(body2_json["error"]["code"], "max_tool_calls_exceeded");
+    assert!(body2_json["error"]["message"]
+        .as_str()
+        .is_some_and(|msg| msg.contains("would exceed max_tool_calls")));
+
+    worker.stop().await;
+    mcp.stop().await;
+}
+
+#[tokio::test]
 async fn test_final_response_hides_internal_mcp_trace_items() {
     let mut mcp = MockMCPServer::start().await.expect("start mcp");
 
@@ -812,18 +1526,24 @@ async fn test_previous_response_id_does_not_repeat_mcp_list_tools_for_existing_b
     let output = body2_json["output"]
         .as_array()
         .expect("response output missing");
-    assert_eq!(
-        output.len(),
-        2,
-        "resume turn should return only current-turn MCP activity plus the final message: {body2_json}",
-    );
-    assert_eq!(output[0]["type"], "mcp_call");
-    assert_eq!(output[1]["type"], "message");
+    assert_eq!(body2_json["status"], "completed");
     assert!(
         output
             .iter()
             .all(|item| item.get("type").and_then(|v| v.as_str()) != Some("mcp_list_tools")),
         "existing bindings should not repeat mcp_list_tools on previous_response_id turns"
+    );
+    assert!(
+        output
+            .iter()
+            .all(|item| item.get("type").and_then(|v| v.as_str()) != Some("mcp_approval_request")),
+        "existing bindings should not emit a fresh mcp_approval_request on previous_response_id turns"
+    );
+    assert!(
+        output
+            .iter()
+            .any(|item| item.get("type").and_then(|v| v.as_str()) == Some("message")),
+        "resume turn should include a final assistant message: {body2_json}"
     );
 
     worker.stop().await;


### PR DESCRIPTION
## Description

### Problem

When a Responses-API client approves a pending MCP tool call by sending `mcp_approval_response` with `previous_response_id`, the request is rejected ("input must contain at least one message") and the approved tool never runs — there is no way to resume the turn.

### Solution

Wire the `mcp_approval_response` + `previous_response_id` continuation end-to-end for non-streaming requests:

1. Protocol validation now accepts a single-item `mcp_approval_response` continuation when `previous_response_id` is set (streaming still rejected).
2. New `responses/approval_continuation.rs` extracts the approval from the current turn and matches it against the trusted `prior_mcp_approval_requests` loaded from the stored response chain — user input is only trusted for the `McpApprovalResponse` side.
3. `McpToolSession::execute_approved_tool` runs the resolved tool without re-entering the approval flow (`ResolvedToolExecutionMode::BypassApproval`).
4. The replayed result is spliced into the history as a synthesized `function_call` / `function_call_output` pair, so the upstream model sees the same shape it would have without the approval interruption.

## Changes

- **`crates/protocols`** — accept single approval-only continuation; helpers `approval_request_id_to_call_id`, `mcp_item_id_to_prefixed_id`, `ResponseInputOutputItem::new_user_text`, `impl Default for ResponseInput`.
- **`crates/mcp`** — `ResolvedToolExecutionMode::{RespectApproval, BypassApproval}` plumbed through `execute_tool_resolved_result`; `McpToolSession::execute_approved_tool` for the bypass path.
- **`model_gateway/src/routers/openai/responses`**
  - New `approval_continuation.rs`: `prepare_responses_input`, `extract_approval_continuation`, `sanitize_input_for_upstream`.
  - `history.rs`: load prior `mcp_approval_request`s from the stored chain; stored `mcp_call` items get rewritten into `function_call` / `function_call_output` pairs (with `error` round-trip).
  - `route.rs` / `non_streaming.rs`: feed the prepared input + continuation into the tool loop; map the new errors to proper HTTP codes.
- **`model_gateway/src/routers/openai/mcp/tool_loop.rs`**
  - `ToolLoopError::{InvalidApprovalResponse, MaxToolCallsExceeded, Execution}` so validation errors surface as 400, not 502.
  - `maybe_resume_approved_tool_call` executes the approved tool before the main loop, attaches `approval_request_id` to the emitted `mcp_call`.

## Test Plan

- `cargo test -p openai-protocol responses::tests` — 7 new validation tests (approval-only continuation accepted; streaming / multi-approval / empty-id / function-call-output-only / reasoning-only rejected).
- `cargo test -p smg --test api_tests` — 5 new integration tests against mock MCP + mock worker:
  - Happy path: approved continuation resumes, emits `mcp_call` with `approval_request_id` round-tripped and the final assistant message.
  - `approve: false` → 400 `invalid_mcp_approval_response`.
  - Unknown `approval_request_id` → 400.
  - Approved tool no longer in current `tools` list → 400.
  - `max_tool_calls=0` replay → 400 `max_tool_calls_exceeded`.
- `e2e_test/responses/test_tools_call.py::TestToolCallingCloud::test_mcp_approval_interrupt_non_streaming` extended to drive the approval continuation turn and assert the resumed output.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Resume MCP tool executions by approving continuation responses so previously-interrupted tool calls can complete.
  * Addition of an approval-continuation mechanism that replays approved tool calls upstream.

* **Bug Fixes / Validation**
  * Stricter validation of approval responses (reject empty/duplicate or malformed approvals) and clearer error mapping for invalid approval states.

* **Tests**
  * Expanded end-to-end and unit tests covering approval continuation, negative paths, and replay behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->