### PR TITLE
feat(skills): parse SKILL.md and sidecar metadata

### DIFF
--- a/crates/skills/Cargo.toml
+++ b/crates/skills/Cargo.toml
@@ -18,8 +18,11 @@ name = "smg_skills"
 
 [dependencies]
 serde = { workspace = true, features = ["derive"] }
+serde_yml = "0.0.12"
+thiserror.workspace = true
 
 [dev-dependencies]
+anyhow.workspace = true
 serde_json.workspace = true
 
 [lints]

--- a/crates/skills/src/lib.rs
+++ b/crates/skills/src/lib.rs
@@ -18,4 +18,9 @@ pub use config::{
     SkillsResolutionMode, SkillsRetentionConfig, SkillsRetentionMode, SkillsTenancyConfig,
     SkillsToolLoopConfig, SkillsZdrConfig,
 };
-pub use types::{SkillFileRecord, SkillRecord, SkillVersionRecord};
+pub use types::{
+    ParsedSkillBundle, SkillDependencyTool, SkillFileRecord, SkillInterfaceMetadata,
+    SkillParseWarning, SkillParseWarningKind, SkillPolicyMetadata, SkillRecord,
+    SkillSidecarDependencies, SkillVersionRecord,
+};
+pub use validation::{parse_skill_bundle, SkillParseError};

--- a/crates/skills/src/types.rs
+++ b/crates/skills/src/types.rs
@@ -22,3 +22,85 @@ pub struct SkillFileRecord {
     pub media_type: Option<String>,
     pub size_bytes: u64,
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ParsedSkillBundle {
+    pub name: String,
+    pub description: String,
+    pub short_description: Option<String>,
+    pub instructions_body: String,
+    pub interface: Option<SkillInterfaceMetadata>,
+    pub dependencies: Option<SkillSidecarDependencies>,
+    pub policy: Option<SkillPolicyMetadata>,
+    pub warnings: Vec<SkillParseWarning>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct SkillInterfaceMetadata {
+    pub display_name: Option<String>,
+    pub short_description: Option<String>,
+    pub icon_small: Option<String>,
+    pub icon_large: Option<String>,
+    pub brand_color: Option<String>,
+    pub default_prompt: Option<String>,
+}
+
+impl SkillInterfaceMetadata {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.display_name.is_none()
+            && self.short_description.is_none()
+            && self.icon_small.is_none()
+            && self.icon_large.is_none()
+            && self.brand_color.is_none()
+            && self.default_prompt.is_none()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct SkillSidecarDependencies {
+    pub tools: Vec<SkillDependencyTool>,
+}
+
+impl SkillSidecarDependencies {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.tools.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SkillDependencyTool {
+    pub tool_type: String,
+    pub value: String,
+    pub description: Option<String>,
+    pub transport: Option<String>,
+    pub command: Option<String>,
+    pub url: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct SkillPolicyMetadata {
+    pub allow_implicit_invocation: Option<bool>,
+    pub products: Vec<String>,
+}
+
+impl SkillPolicyMetadata {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.allow_implicit_invocation.is_none() && self.products.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SkillParseWarning {
+    pub kind: SkillParseWarningKind,
+    pub path: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum SkillParseWarningKind {
+    SidecarFileIgnored,
+    SidecarFieldIgnored,
+}

--- a/crates/skills/src/validation.rs
+++ b/crates/skills/src/validation.rs
@@ -10,6 +10,7 @@ use crate::types::{
 };
 
 const MAX_NAME_LEN: usize = 64;
+const MAX_DISPLAY_NAME_LEN: usize = 64;
 const MAX_DESCRIPTION_LEN: usize = 1024;
 const MAX_SIDECAR_STRING_LEN: usize = 1024;
 const RESERVED_SKILL_NAMES: [&str; 3] = ["anthropic", "claude", "openai"];
@@ -163,17 +164,16 @@ fn validate_name(name: &str) -> Result<(), SkillParseError> {
             message: format!("must be at most {MAX_NAME_LEN} characters"),
         });
     }
-    if RESERVED_SKILL_NAMES
-        .iter()
-        .any(|reserved| reserved.eq_ignore_ascii_case(name))
-    {
-        return Err(SkillParseError::InvalidField {
-            field: "name",
-            message: "is reserved".to_owned(),
-        });
-    }
-
     for segment in name.split(':') {
+        if RESERVED_SKILL_NAMES
+            .iter()
+            .any(|reserved| reserved.eq_ignore_ascii_case(segment))
+        {
+            return Err(SkillParseError::InvalidField {
+                field: "name",
+                message: "is reserved".to_owned(),
+            });
+        }
         if segment.is_empty() {
             return Err(SkillParseError::InvalidField {
                 field: "name",
@@ -182,12 +182,7 @@ fn validate_name(name: &str) -> Result<(), SkillParseError> {
         }
 
         let mut chars = segment.chars();
-        let Some(first) = chars.next() else {
-            return Err(SkillParseError::InvalidField {
-                field: "name",
-                message: "must not contain empty namespace segments".to_owned(),
-            });
-        };
+        let first = chars.next().unwrap_or('\0');
 
         if !first.is_ascii_lowercase() && !first.is_ascii_digit() {
             return Err(SkillParseError::InvalidField {
@@ -232,7 +227,7 @@ fn validate_length(
     value: &str,
     max_len: usize,
 ) -> Result<(), SkillParseError> {
-    if value.len() > max_len {
+    if value.chars().count() > max_len {
         return Err(SkillParseError::InvalidField {
             field,
             message: format!("must be at most {max_len} characters"),
@@ -245,16 +240,37 @@ fn contains_xml_like_tag(value: &str) -> bool {
     let bytes = value.as_bytes();
     let mut index = 0;
     while index < bytes.len() {
-        if bytes[index] == b'<' {
-            let next_index = index + 1;
-            if next_index < bytes.len()
-                && (bytes[next_index].is_ascii_alphabetic() || bytes[next_index] == b'/')
-                && bytes[next_index..].contains(&b'>')
-            {
-                return true;
+        if bytes[index] != b'<' {
+            index += 1;
+            continue;
+        }
+
+        let mut tag_index = index + 1;
+        if tag_index < bytes.len() && bytes[tag_index] == b'/' {
+            tag_index += 1;
+        }
+
+        if tag_index >= bytes.len() || !bytes[tag_index].is_ascii_alphabetic() {
+            index += 1;
+            continue;
+        }
+
+        tag_index += 1;
+        while tag_index < bytes.len() {
+            match bytes[tag_index] {
+                b'>' => return true,
+                b'<' => break,
+                _ => {
+                    tag_index += 1;
+                }
             }
         }
-        index += 1;
+
+        if tag_index >= bytes.len() {
+            return false;
+        }
+
+        index = tag_index;
     }
     false
 }
@@ -326,7 +342,9 @@ fn parse_interface(
             "display_name",
             "agents/openai.yaml.interface.display_name",
             warnings,
-            |value| validate_sidecar_string_len("interface.display_name", value, 64),
+            |value| {
+                validate_sidecar_string_len("interface.display_name", value, MAX_DISPLAY_NAME_LEN)
+            },
         ),
         short_description: parse_string_field(
             mapping,
@@ -632,7 +650,7 @@ fn push_field_warning(warnings: &mut Vec<SkillParseWarning>, path: &str, message
 }
 
 fn validate_sidecar_string_len(field: &str, value: &str, max_len: usize) -> Result<(), String> {
-    if value.len() > max_len {
+    if value.chars().count() > max_len {
         return Err(format!("{field} must be at most {max_len} characters"));
     }
     Ok(())
@@ -664,13 +682,23 @@ fn validate_sidecar_path(value: &str) -> Result<(), String> {
         return Err("path must use forward slashes".to_owned());
     }
 
-    for segment in value.split('/') {
+    let mut segments = value.split('/').peekable();
+    let mut index = 0;
+    while let Some(segment) = segments.next() {
         if segment.is_empty() {
             return Err("path must not contain empty segments".to_owned());
         }
-        if segment == "." || segment == ".." {
+        if segment == "." {
+            if index == 0 && segments.peek().is_some() {
+                index += 1;
+                continue;
+            }
+            return Err("path must not contain standalone current-directory segments".to_owned());
+        }
+        if segment == ".." {
             return Err("path must not contain traversal segments".to_owned());
         }
+        index += 1;
     }
 
     Ok(())

--- a/crates/skills/src/validation.rs
+++ b/crates/skills/src/validation.rs
@@ -1,4 +1,677 @@
-/// Placeholder validation surface. Parsing and bundle validation land in
-/// follow-up PRs once the crate boundary is established.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub struct ValidationScaffold;
+use std::fmt::Write as _;
+
+use serde::Deserialize;
+use serde_yml::{Mapping, Value};
+use thiserror::Error;
+
+use crate::types::{
+    ParsedSkillBundle, SkillDependencyTool, SkillInterfaceMetadata, SkillParseWarning,
+    SkillParseWarningKind, SkillPolicyMetadata, SkillSidecarDependencies,
+};
+
+const MAX_NAME_LEN: usize = 64;
+const MAX_DESCRIPTION_LEN: usize = 1024;
+const MAX_SIDECAR_STRING_LEN: usize = 1024;
+const RESERVED_SKILL_NAMES: [&str; 3] = ["anthropic", "claude", "openai"];
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum SkillParseError {
+    #[error("SKILL.md must begin with a YAML frontmatter block delimited by --- lines")]
+    MissingFrontmatter,
+    #[error("SKILL.md frontmatter is missing a closing --- delimiter")]
+    MissingFrontmatterTerminator,
+    #[error("SKILL.md frontmatter YAML is invalid: {message}")]
+    InvalidFrontmatterYaml { message: String },
+    #[error("SKILL.md field `{field}` is required")]
+    MissingRequiredField { field: &'static str },
+    #[error("SKILL.md field `{field}` is invalid: {message}")]
+    InvalidField {
+        field: &'static str,
+        message: String,
+    },
+}
+
+#[derive(Debug, Deserialize)]
+struct SkillFrontmatter {
+    name: Option<String>,
+    description: Option<String>,
+    #[serde(default)]
+    metadata: SkillFrontmatterMetadata,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct SkillFrontmatterMetadata {
+    #[serde(rename = "short-description")]
+    short_description: Option<String>,
+}
+
+pub fn parse_skill_bundle(
+    skill_md: &str,
+    openai_yaml: Option<&str>,
+) -> Result<ParsedSkillBundle, SkillParseError> {
+    let (frontmatter_yaml, instructions_body) = split_frontmatter(skill_md)?;
+    let frontmatter: SkillFrontmatter = serde_yml::from_str(frontmatter_yaml).map_err(|error| {
+        SkillParseError::InvalidFrontmatterYaml {
+            message: error.to_string(),
+        }
+    })?;
+
+    let name = validate_required_name(frontmatter.name)?;
+    let description = validate_required_description(frontmatter.description)?;
+    let metadata_short_description = validate_optional_short_description(
+        frontmatter.metadata.short_description,
+        "metadata.short-description",
+    )?;
+
+    let mut warnings = Vec::new();
+    let sidecar = parse_openai_sidecar(openai_yaml, &mut warnings);
+    let short_description = sidecar
+        .interface
+        .as_ref()
+        .and_then(|interface| interface.short_description.clone())
+        .or(metadata_short_description);
+
+    Ok(ParsedSkillBundle {
+        name,
+        description,
+        short_description,
+        instructions_body: instructions_body.to_owned(),
+        interface: sidecar.interface,
+        dependencies: sidecar.dependencies,
+        policy: sidecar.policy,
+        warnings,
+    })
+}
+
+fn split_frontmatter(skill_md: &str) -> Result<(&str, &str), SkillParseError> {
+    let Some(first_line_end) = find_line_end(skill_md, 0) else {
+        return Err(SkillParseError::MissingFrontmatter);
+    };
+
+    if trim_line_ending(&skill_md[..first_line_end]) != "---" {
+        return Err(SkillParseError::MissingFrontmatter);
+    }
+
+    let yaml_start = first_line_end;
+    let mut cursor = yaml_start;
+    while cursor < skill_md.len() {
+        let next_line_end = find_line_end(skill_md, cursor).unwrap_or(skill_md.len());
+        let line = trim_line_ending(&skill_md[cursor..next_line_end]);
+        if line == "---" {
+            let body = &skill_md[next_line_end..];
+            let frontmatter = &skill_md[yaml_start..cursor];
+            return Ok((frontmatter, body));
+        }
+        cursor = next_line_end;
+    }
+
+    Err(SkillParseError::MissingFrontmatterTerminator)
+}
+
+fn find_line_end(content: &str, start: usize) -> Option<usize> {
+    if start >= content.len() {
+        return None;
+    }
+
+    content[start..]
+        .find('\n')
+        .map(|offset| start + offset + 1)
+        .or(Some(content.len()))
+}
+
+fn trim_line_ending(line: &str) -> &str {
+    line.trim_end_matches(['\n', '\r'])
+}
+
+fn validate_required_name(name: Option<String>) -> Result<String, SkillParseError> {
+    let name = name.ok_or(SkillParseError::MissingRequiredField { field: "name" })?;
+    validate_name(&name)?;
+    Ok(name)
+}
+
+fn validate_required_description(description: Option<String>) -> Result<String, SkillParseError> {
+    let description = description.ok_or(SkillParseError::MissingRequiredField {
+        field: "description",
+    })?;
+    validate_description(&description)?;
+    Ok(description)
+}
+
+fn validate_optional_short_description(
+    value: Option<String>,
+    field: &'static str,
+) -> Result<Option<String>, SkillParseError> {
+    match value {
+        Some(short_description) => {
+            validate_length(field, &short_description, MAX_DESCRIPTION_LEN)?;
+            Ok(Some(short_description))
+        }
+        None => Ok(None),
+    }
+}
+
+fn validate_name(name: &str) -> Result<(), SkillParseError> {
+    if name.is_empty() {
+        return Err(SkillParseError::InvalidField {
+            field: "name",
+            message: "must not be empty".to_owned(),
+        });
+    }
+    if name.len() > MAX_NAME_LEN {
+        return Err(SkillParseError::InvalidField {
+            field: "name",
+            message: format!("must be at most {MAX_NAME_LEN} characters"),
+        });
+    }
+    if RESERVED_SKILL_NAMES
+        .iter()
+        .any(|reserved| reserved.eq_ignore_ascii_case(name))
+    {
+        return Err(SkillParseError::InvalidField {
+            field: "name",
+            message: "is reserved".to_owned(),
+        });
+    }
+
+    for segment in name.split(':') {
+        if segment.is_empty() {
+            return Err(SkillParseError::InvalidField {
+                field: "name",
+                message: "must not contain empty namespace segments".to_owned(),
+            });
+        }
+
+        let mut chars = segment.chars();
+        let Some(first) = chars.next() else {
+            return Err(SkillParseError::InvalidField {
+                field: "name",
+                message: "must not contain empty namespace segments".to_owned(),
+            });
+        };
+
+        if !first.is_ascii_lowercase() && !first.is_ascii_digit() {
+            return Err(SkillParseError::InvalidField {
+                field: "name",
+                message: "must start each namespace segment with a lowercase letter or digit"
+                    .to_owned(),
+            });
+        }
+
+        if chars.any(|ch| !ch.is_ascii_lowercase() && !ch.is_ascii_digit() && ch != '-') {
+            return Err(SkillParseError::InvalidField {
+                field: "name",
+                message:
+                    "may only contain lowercase letters, digits, hyphens, and namespace colons"
+                        .to_owned(),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_description(description: &str) -> Result<(), SkillParseError> {
+    if description.trim().is_empty() {
+        return Err(SkillParseError::InvalidField {
+            field: "description",
+            message: "must not be empty".to_owned(),
+        });
+    }
+    validate_length("description", description, MAX_DESCRIPTION_LEN)?;
+    if contains_xml_like_tag(description) {
+        return Err(SkillParseError::InvalidField {
+            field: "description",
+            message: "must not contain XML-like tags".to_owned(),
+        });
+    }
+    Ok(())
+}
+
+fn validate_length(
+    field: &'static str,
+    value: &str,
+    max_len: usize,
+) -> Result<(), SkillParseError> {
+    if value.len() > max_len {
+        return Err(SkillParseError::InvalidField {
+            field,
+            message: format!("must be at most {max_len} characters"),
+        });
+    }
+    Ok(())
+}
+
+fn contains_xml_like_tag(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'<' {
+            let next_index = index + 1;
+            if next_index < bytes.len()
+                && (bytes[next_index].is_ascii_alphabetic() || bytes[next_index] == b'/')
+                && bytes[next_index..].contains(&b'>')
+            {
+                return true;
+            }
+        }
+        index += 1;
+    }
+    false
+}
+
+#[derive(Default)]
+struct ParsedOpenAISidecar {
+    interface: Option<SkillInterfaceMetadata>,
+    dependencies: Option<SkillSidecarDependencies>,
+    policy: Option<SkillPolicyMetadata>,
+}
+
+fn parse_openai_sidecar(
+    openai_yaml: Option<&str>,
+    warnings: &mut Vec<SkillParseWarning>,
+) -> ParsedOpenAISidecar {
+    let Some(openai_yaml) = openai_yaml else {
+        return ParsedOpenAISidecar::default();
+    };
+
+    let value = match serde_yml::from_str::<Value>(openai_yaml) {
+        Ok(value) => value,
+        Err(error) => {
+            warnings.push(SkillParseWarning {
+                kind: SkillParseWarningKind::SidecarFileIgnored,
+                path: "agents/openai.yaml".to_owned(),
+                message: format!("ignored invalid YAML: {error}"),
+            });
+            return ParsedOpenAISidecar::default();
+        }
+    };
+
+    let Some(mapping) = value.as_mapping() else {
+        warnings.push(SkillParseWarning {
+            kind: SkillParseWarningKind::SidecarFieldIgnored,
+            path: "agents/openai.yaml".to_owned(),
+            message: "expected a mapping at the YAML document root".to_owned(),
+        });
+        return ParsedOpenAISidecar::default();
+    };
+
+    let interface = parse_interface(mapping_get(mapping, "interface"), warnings);
+    let dependencies = parse_dependencies(mapping_get(mapping, "dependencies"), warnings);
+    let policy = parse_policy(mapping_get(mapping, "policy"), warnings);
+
+    ParsedOpenAISidecar {
+        interface,
+        dependencies,
+        policy,
+    }
+}
+
+fn parse_interface(
+    value: Option<&Value>,
+    warnings: &mut Vec<SkillParseWarning>,
+) -> Option<SkillInterfaceMetadata> {
+    let value = value?;
+    let Some(mapping) = value.as_mapping() else {
+        push_field_warning(
+            warnings,
+            "agents/openai.yaml.interface",
+            "expected a mapping",
+        );
+        return None;
+    };
+
+    let interface = SkillInterfaceMetadata {
+        display_name: parse_string_field(
+            mapping,
+            "display_name",
+            "agents/openai.yaml.interface.display_name",
+            warnings,
+            |value| validate_sidecar_string_len("interface.display_name", value, 64),
+        ),
+        short_description: parse_string_field(
+            mapping,
+            "short_description",
+            "agents/openai.yaml.interface.short_description",
+            warnings,
+            |value| {
+                validate_sidecar_string_len(
+                    "interface.short_description",
+                    value,
+                    MAX_SIDECAR_STRING_LEN,
+                )
+            },
+        ),
+        icon_small: parse_string_field(
+            mapping,
+            "icon_small",
+            "agents/openai.yaml.interface.icon_small",
+            warnings,
+            validate_sidecar_path,
+        ),
+        icon_large: parse_string_field(
+            mapping,
+            "icon_large",
+            "agents/openai.yaml.interface.icon_large",
+            warnings,
+            validate_sidecar_path,
+        ),
+        brand_color: parse_string_field(
+            mapping,
+            "brand_color",
+            "agents/openai.yaml.interface.brand_color",
+            warnings,
+            validate_brand_color,
+        ),
+        default_prompt: parse_string_field(
+            mapping,
+            "default_prompt",
+            "agents/openai.yaml.interface.default_prompt",
+            warnings,
+            |value| {
+                validate_sidecar_string_len(
+                    "interface.default_prompt",
+                    value,
+                    MAX_SIDECAR_STRING_LEN,
+                )
+            },
+        ),
+    };
+
+    (!interface.is_empty()).then_some(interface)
+}
+
+fn parse_dependencies(
+    value: Option<&Value>,
+    warnings: &mut Vec<SkillParseWarning>,
+) -> Option<SkillSidecarDependencies> {
+    let value = value?;
+    let Some(mapping) = value.as_mapping() else {
+        push_field_warning(
+            warnings,
+            "agents/openai.yaml.dependencies",
+            "expected a mapping",
+        );
+        return None;
+    };
+
+    let tools_value = mapping_get(mapping, "tools")?;
+    let Some(sequence) = tools_value.as_sequence() else {
+        push_field_warning(
+            warnings,
+            "agents/openai.yaml.dependencies.tools",
+            "expected a sequence",
+        );
+        return None;
+    };
+
+    let tools = sequence
+        .iter()
+        .enumerate()
+        .filter_map(|(index, value)| parse_dependency_tool(value, index, warnings))
+        .collect::<Vec<_>>();
+
+    let dependencies = SkillSidecarDependencies { tools };
+    (!dependencies.is_empty()).then_some(dependencies)
+}
+
+fn parse_dependency_tool(
+    value: &Value,
+    index: usize,
+    warnings: &mut Vec<SkillParseWarning>,
+) -> Option<SkillDependencyTool> {
+    let Some(mapping) = value.as_mapping() else {
+        push_field_warning(
+            warnings,
+            &format!("agents/openai.yaml.dependencies.tools[{index}]"),
+            "expected a mapping",
+        );
+        return None;
+    };
+
+    let path = format!("agents/openai.yaml.dependencies.tools[{index}]");
+    let tool_type = parse_required_string_field(mapping, "type", &path, warnings, |value| {
+        validate_sidecar_string_len("dependencies.tools[].type", value, MAX_SIDECAR_STRING_LEN)
+    })?;
+    let value = parse_required_string_field(mapping, "value", &path, warnings, |value| {
+        validate_sidecar_string_len("dependencies.tools[].value", value, MAX_SIDECAR_STRING_LEN)
+    })?;
+
+    Some(SkillDependencyTool {
+        tool_type,
+        value,
+        description: parse_string_field(
+            mapping,
+            "description",
+            &format!("{path}.description"),
+            warnings,
+            |value| {
+                validate_sidecar_string_len(
+                    "dependencies.tools[].description",
+                    value,
+                    MAX_SIDECAR_STRING_LEN,
+                )
+            },
+        ),
+        transport: parse_string_field(
+            mapping,
+            "transport",
+            &format!("{path}.transport"),
+            warnings,
+            |value| {
+                validate_sidecar_string_len(
+                    "dependencies.tools[].transport",
+                    value,
+                    MAX_SIDECAR_STRING_LEN,
+                )
+            },
+        ),
+        command: parse_string_field(
+            mapping,
+            "command",
+            &format!("{path}.command"),
+            warnings,
+            |value| {
+                validate_sidecar_string_len(
+                    "dependencies.tools[].command",
+                    value,
+                    MAX_SIDECAR_STRING_LEN,
+                )
+            },
+        ),
+        url: parse_string_field(mapping, "url", &format!("{path}.url"), warnings, |value| {
+            validate_sidecar_string_len("dependencies.tools[].url", value, MAX_SIDECAR_STRING_LEN)
+        }),
+    })
+}
+
+fn parse_policy(
+    value: Option<&Value>,
+    warnings: &mut Vec<SkillParseWarning>,
+) -> Option<SkillPolicyMetadata> {
+    let value = value?;
+    let Some(mapping) = value.as_mapping() else {
+        push_field_warning(warnings, "agents/openai.yaml.policy", "expected a mapping");
+        return None;
+    };
+
+    let allow_implicit_invocation = parse_bool_field(
+        mapping,
+        "allow_implicit_invocation",
+        "agents/openai.yaml.policy.allow_implicit_invocation",
+        warnings,
+    );
+    let products = parse_string_sequence_field(
+        mapping,
+        "products",
+        "agents/openai.yaml.policy.products",
+        warnings,
+    );
+
+    let policy = SkillPolicyMetadata {
+        allow_implicit_invocation,
+        products,
+    };
+    (!policy.is_empty()).then_some(policy)
+}
+
+fn parse_string_field<F>(
+    mapping: &Mapping,
+    key: &str,
+    path: &str,
+    warnings: &mut Vec<SkillParseWarning>,
+    validator: F,
+) -> Option<String>
+where
+    F: Fn(&str) -> Result<(), String>,
+{
+    let value = mapping_get(mapping, key)?;
+    match value {
+        Value::String(string_value) => match validator(string_value) {
+            Ok(()) => Some(string_value.clone()),
+            Err(message) => {
+                push_field_warning(warnings, path, &message);
+                None
+            }
+        },
+        _ => {
+            push_field_warning(warnings, path, "expected a string");
+            None
+        }
+    }
+}
+
+fn parse_required_string_field<F>(
+    mapping: &Mapping,
+    key: &str,
+    parent_path: &str,
+    warnings: &mut Vec<SkillParseWarning>,
+    validator: F,
+) -> Option<String>
+where
+    F: Fn(&str) -> Result<(), String>,
+{
+    let mut field_path = String::from(parent_path);
+    let _ = write!(&mut field_path, ".{key}");
+    let Some(value) = mapping_get(mapping, key) else {
+        push_field_warning(warnings, &field_path, "missing required field");
+        return None;
+    };
+    match value {
+        Value::String(string_value) => match validator(string_value) {
+            Ok(()) => Some(string_value.clone()),
+            Err(message) => {
+                push_field_warning(warnings, &field_path, &message);
+                None
+            }
+        },
+        _ => {
+            push_field_warning(warnings, &field_path, "expected a string");
+            None
+        }
+    }
+}
+
+fn parse_bool_field(
+    mapping: &Mapping,
+    key: &str,
+    path: &str,
+    warnings: &mut Vec<SkillParseWarning>,
+) -> Option<bool> {
+    let value = mapping_get(mapping, key)?;
+    match value {
+        Value::Bool(boolean_value) => Some(*boolean_value),
+        _ => {
+            push_field_warning(warnings, path, "expected a boolean");
+            None
+        }
+    }
+}
+
+fn parse_string_sequence_field(
+    mapping: &Mapping,
+    key: &str,
+    path: &str,
+    warnings: &mut Vec<SkillParseWarning>,
+) -> Vec<String> {
+    let Some(value) = mapping_get(mapping, key) else {
+        return Vec::new();
+    };
+    let Some(sequence) = value.as_sequence() else {
+        push_field_warning(warnings, path, "expected a sequence");
+        return Vec::new();
+    };
+
+    sequence
+        .iter()
+        .enumerate()
+        .filter_map(|(index, value)| match value {
+            Value::String(string_value) => Some(string_value.clone()),
+            _ => {
+                push_field_warning(warnings, &format!("{path}[{index}]"), "expected a string");
+                None
+            }
+        })
+        .collect()
+}
+
+fn mapping_get<'a>(mapping: &'a Mapping, key: &str) -> Option<&'a Value> {
+    mapping.iter().find_map(|(candidate, value)| {
+        candidate
+            .as_str()
+            .filter(|candidate_key| *candidate_key == key)
+            .map(|_| value)
+    })
+}
+
+fn push_field_warning(warnings: &mut Vec<SkillParseWarning>, path: &str, message: &str) {
+    warnings.push(SkillParseWarning {
+        kind: SkillParseWarningKind::SidecarFieldIgnored,
+        path: path.to_owned(),
+        message: message.to_owned(),
+    });
+}
+
+fn validate_sidecar_string_len(field: &str, value: &str, max_len: usize) -> Result<(), String> {
+    if value.len() > max_len {
+        return Err(format!("{field} must be at most {max_len} characters"));
+    }
+    Ok(())
+}
+
+fn validate_brand_color(value: &str) -> Result<(), String> {
+    if value.len() != 7 {
+        return Err("brand color must be a CSS hex color like #1D4ED8".to_owned());
+    }
+    let bytes = value.as_bytes();
+    if bytes.first() != Some(&b'#') || bytes[1..].iter().any(|byte| !byte.is_ascii_hexdigit()) {
+        return Err("brand color must be a CSS hex color like #1D4ED8".to_owned());
+    }
+    Ok(())
+}
+
+fn validate_sidecar_path(value: &str) -> Result<(), String> {
+    validate_sidecar_string_len("interface.icon", value, MAX_SIDECAR_STRING_LEN)?;
+    if value.is_empty() {
+        return Err("path must not be empty".to_owned());
+    }
+    if value.starts_with('/') || value.starts_with('\\') {
+        return Err("path must be relative to the skill root".to_owned());
+    }
+    if value.contains('\0') {
+        return Err("path must not contain NUL bytes".to_owned());
+    }
+    if value.contains('\\') {
+        return Err("path must use forward slashes".to_owned());
+    }
+
+    for segment in value.split('/') {
+        if segment.is_empty() {
+            return Err("path must not contain empty segments".to_owned());
+        }
+        if segment == "." || segment == ".." {
+            return Err("path must not contain traversal segments".to_owned());
+        }
+    }
+
+    Ok(())
+}

--- a/crates/skills/tests/skill_bundle_parsing.rs
+++ b/crates/skills/tests/skill_bundle_parsing.rs
@@ -1,0 +1,244 @@
+use anyhow::{anyhow, bail, Result};
+use smg_skills::{parse_skill_bundle, ParsedSkillBundle, SkillParseError, SkillParseWarningKind};
+
+fn parse_valid_bundle(openai_yaml: Option<&str>) -> Result<ParsedSkillBundle, SkillParseError> {
+    parse_skill_bundle(
+        r"---
+name: github:gh-fix-ci
+description: Diagnose and fix CI failures for an attached PR.
+metadata:
+  short-description: Base short description from SKILL.md
+---
+
+## Instructions
+
+Read the failing logs first.
+",
+        openai_yaml,
+    )
+}
+
+#[test]
+fn parses_skill_md_and_projects_sidecar_short_description() -> Result<()> {
+    let parsed = parse_valid_bundle(Some(
+        r##"
+interface:
+  display_name: GitHub CI Fixer
+  short_description: Diagnose failing GitHub Actions runs
+  icon_small: assets/icon-small.png
+  icon_large: assets/icon-large.png
+  brand_color: "#1D4ED8"
+  default_prompt: Start with the failing workflow run.
+dependencies:
+  tools:
+    - type: mcp
+      value: github
+      description: GitHub access
+      transport: streamable_http
+      url: https://example.invalid/mcp
+policy:
+  allow_implicit_invocation: true
+  products:
+    - codex
+    - smg
+"##,
+    ))?;
+
+    assert_eq!(parsed.name, "github:gh-fix-ci");
+    assert_eq!(
+        parsed.description,
+        "Diagnose and fix CI failures for an attached PR."
+    );
+    assert_eq!(
+        parsed.short_description.as_deref(),
+        Some("Diagnose failing GitHub Actions runs")
+    );
+    assert_eq!(
+        parsed.instructions_body,
+        "\n## Instructions\n\nRead the failing logs first.\n"
+    );
+    assert!(parsed.warnings.is_empty());
+
+    let interface = parsed
+        .interface
+        .ok_or_else(|| anyhow!("expected interface metadata"))?;
+    assert_eq!(interface.display_name.as_deref(), Some("GitHub CI Fixer"));
+    assert_eq!(
+        interface.icon_small.as_deref(),
+        Some("assets/icon-small.png")
+    );
+    assert_eq!(interface.brand_color.as_deref(), Some("#1D4ED8"));
+
+    let dependencies = parsed
+        .dependencies
+        .ok_or_else(|| anyhow!("expected dependency metadata"))?
+        .tools;
+    assert_eq!(dependencies.len(), 1);
+    assert_eq!(dependencies[0].tool_type, "mcp");
+    assert_eq!(dependencies[0].value, "github");
+
+    let policy = parsed
+        .policy
+        .ok_or_else(|| anyhow!("expected policy metadata"))?;
+    assert_eq!(policy.allow_implicit_invocation, Some(true));
+    assert_eq!(policy.products, vec!["codex", "smg"]);
+    Ok(())
+}
+
+#[test]
+fn rejects_skill_md_missing_name() -> Result<()> {
+    let error = match parse_skill_bundle(
+        r"---
+description: Diagnose and fix CI failures for an attached PR.
+---
+instructions
+",
+        None,
+    ) {
+        Ok(bundle) => bail!("missing name must fail, got {bundle:?}"),
+        Err(error) => error,
+    };
+
+    assert_eq!(
+        error,
+        SkillParseError::MissingRequiredField { field: "name" }
+    );
+    Ok(())
+}
+
+#[test]
+fn rejects_skill_md_missing_description() -> Result<()> {
+    let error = match parse_skill_bundle(
+        r"---
+name: github:gh-fix-ci
+---
+instructions
+",
+        None,
+    ) {
+        Ok(bundle) => bail!("missing description must fail, got {bundle:?}"),
+        Err(error) => error,
+    };
+
+    assert_eq!(
+        error,
+        SkillParseError::MissingRequiredField {
+            field: "description"
+        }
+    );
+    Ok(())
+}
+
+#[test]
+fn rejects_invalid_frontmatter_yaml() -> Result<()> {
+    let error = match parse_skill_bundle(
+        r"---
+name: github:gh-fix-ci
+description: [unterminated
+---
+instructions
+",
+        None,
+    ) {
+        Ok(bundle) => bail!("invalid frontmatter YAML must fail, got {bundle:?}"),
+        Err(error) => error,
+    };
+
+    match error {
+        SkillParseError::InvalidFrontmatterYaml { message } => {
+            assert!(!message.is_empty());
+        }
+        other => bail!("expected invalid frontmatter YAML error, got {other:?}"),
+    }
+    Ok(())
+}
+
+#[test]
+fn ignores_invalid_sidecar_yaml_at_file_level() -> Result<()> {
+    let parsed = parse_valid_bundle(Some("interface: [broken"))?;
+
+    assert_eq!(
+        parsed.short_description.as_deref(),
+        Some("Base short description from SKILL.md")
+    );
+    assert!(parsed.interface.is_none());
+    assert!(parsed.dependencies.is_none());
+    assert!(parsed.policy.is_none());
+    assert_eq!(parsed.warnings.len(), 1);
+    assert_eq!(
+        parsed.warnings[0].kind,
+        SkillParseWarningKind::SidecarFileIgnored
+    );
+    assert_eq!(parsed.warnings[0].path, "agents/openai.yaml");
+    Ok(())
+}
+
+#[test]
+fn salvages_valid_sidecar_fields_after_successful_parse() -> Result<()> {
+    let parsed = parse_valid_bundle(Some(
+        r"
+interface:
+  display_name: GitHub CI Fixer
+  short_description: 7
+  icon_small: ../assets/icon-small.png
+  icon_large: assets/icon-large.png
+  brand_color: blue
+  default_prompt: Start with the failing workflow run.
+dependencies:
+  tools:
+    - type: mcp
+      value: github
+      description: GitHub access
+    - type: 42
+      value: broken
+    - value: missing-type
+policy:
+  allow_implicit_invocation: true
+  products:
+    - codex
+    - 123
+",
+    ))?;
+
+    assert_eq!(
+        parsed.short_description.as_deref(),
+        Some("Base short description from SKILL.md")
+    );
+
+    let interface = parsed
+        .interface
+        .ok_or_else(|| anyhow!("expected salvaged interface"))?;
+    assert_eq!(interface.display_name.as_deref(), Some("GitHub CI Fixer"));
+    assert_eq!(
+        interface.icon_large.as_deref(),
+        Some("assets/icon-large.png")
+    );
+    assert_eq!(
+        interface.default_prompt.as_deref(),
+        Some("Start with the failing workflow run.")
+    );
+    assert!(interface.short_description.is_none());
+    assert!(interface.icon_small.is_none());
+    assert!(interface.brand_color.is_none());
+
+    let dependencies = parsed
+        .dependencies
+        .ok_or_else(|| anyhow!("expected salvaged dependency metadata"))?
+        .tools;
+    assert_eq!(dependencies.len(), 1);
+    assert_eq!(dependencies[0].tool_type, "mcp");
+    assert_eq!(dependencies[0].value, "github");
+
+    let policy = parsed
+        .policy
+        .ok_or_else(|| anyhow!("expected salvaged policy metadata"))?;
+    assert_eq!(policy.allow_implicit_invocation, Some(true));
+    assert_eq!(policy.products, vec!["codex"]);
+
+    assert_eq!(parsed.warnings.len(), 6);
+    assert!(parsed
+        .warnings
+        .iter()
+        .all(|warning| warning.kind == SkillParseWarningKind::SidecarFieldIgnored));
+    Ok(())
+}

--- a/crates/skills/tests/skill_bundle_parsing.rs
+++ b/crates/skills/tests/skill_bundle_parsing.rs
@@ -174,6 +174,111 @@ fn ignores_invalid_sidecar_yaml_at_file_level() -> Result<()> {
 }
 
 #[test]
+fn rejects_reserved_namespace_segment_in_name() -> Result<()> {
+    let error = match parse_skill_bundle(
+        r"---
+name: anthropic:gh-fix-ci
+description: Diagnose and fix CI failures for an attached PR.
+---
+instructions
+",
+        None,
+    ) {
+        Ok(bundle) => bail!("reserved namespace segment must fail, got {bundle:?}"),
+        Err(error) => error,
+    };
+
+    assert_eq!(
+        error,
+        SkillParseError::InvalidField {
+            field: "name",
+            message: "is reserved".to_owned(),
+        }
+    );
+    Ok(())
+}
+
+#[test]
+fn accepts_character_based_description_length_limit() -> Result<()> {
+    let description = "😀".repeat(1024);
+    let skill_md =
+        format!("---\nname: github:gh-fix-ci\ndescription: {description}\n---\ninstructions\n");
+
+    let parsed = parse_skill_bundle(&skill_md, None)?;
+    assert_eq!(parsed.description.chars().count(), 1024);
+    Ok(())
+}
+
+#[test]
+fn accepts_dot_slash_prefixed_icon_paths() -> Result<()> {
+    let parsed = parse_valid_bundle(Some(
+        r"
+interface:
+  icon_small: ./assets/icon-small.png
+  icon_large: ./assets/icon-large.png
+",
+    ))?;
+
+    let interface = parsed
+        .interface
+        .ok_or_else(|| anyhow!("expected interface metadata"))?;
+    assert_eq!(
+        interface.icon_small.as_deref(),
+        Some("./assets/icon-small.png")
+    );
+    assert_eq!(
+        interface.icon_large.as_deref(),
+        Some("./assets/icon-large.png")
+    );
+    assert!(parsed.warnings.is_empty());
+    Ok(())
+}
+
+#[test]
+fn does_not_treat_nested_angle_brackets_as_xml_tag() -> Result<()> {
+    let parsed = parse_skill_bundle(
+        r"---
+name: github:gh-fix-ci
+description: Compare <emphasis and < later > symbols literally.
+---
+instructions
+",
+        None,
+    )?;
+
+    assert_eq!(
+        parsed.description,
+        "Compare <emphasis and < later > symbols literally."
+    );
+    Ok(())
+}
+
+#[test]
+fn rejects_actual_xml_like_tag_in_description() -> Result<()> {
+    let error = match parse_skill_bundle(
+        r"---
+name: github:gh-fix-ci
+description: Render <em>highlighted</em> text.
+---
+instructions
+",
+        None,
+    ) {
+        Ok(bundle) => bail!("xml-like tag must fail, got {bundle:?}"),
+        Err(error) => error,
+    };
+
+    assert_eq!(
+        error,
+        SkillParseError::InvalidField {
+            field: "description",
+            message: "must not contain XML-like tags".to_owned(),
+        }
+    );
+    Ok(())
+}
+
+#[test]
 fn salvages_valid_sidecar_fields_after_successful_parse() -> Result<()> {
     let parsed = parse_valid_bundle(Some(
         r"


### PR DESCRIPTION
## Description

### Problem

SMG had the `crates/skills` scaffold from SKL-PR-03, but it still could not parse the canonical `SKILL.md` metadata or the optional `agents/openai.yaml` compatibility sidecar needed for later upload and resolution work.

### Solution

Implement deterministic parsing in `smg-skills` for required `SKILL.md` frontmatter and optional `agents/openai.yaml` metadata.

## Changes

- add parsed bundle/domain types for skill metadata, interface metadata, dependencies, policy, and parse warnings
- implement `parse_skill_bundle` with strict `SKILL.md` frontmatter splitting and validation for required `name` and `description`
- parse optional `metadata.short-description` and project the final `short_description` with precedence `interface.short_description -> metadata.short-description`
- implement fail-open `agents/openai.yaml` parsing that ignores unreadable YAML files but salvages valid known fields from successfully parsed sidecars
- validate known sidecar fields including display-name length, short-description/default-prompt length, relative icon paths, and hex brand colors
- add integration tests covering valid bundles, missing fields, invalid frontmatter YAML, invalid sidecar YAML, and partial sidecar salvage

Closes #1180

## Test Plan

- `cargo +nightly fmt --all`
- `env -u RUSTC_WRAPPER CARGO_BUILD_RUSTC_WRAPPER= cargo clippy --all-targets --all-features --target-dir /tmp/smg-gate-target -- -D warnings`
- `env -u RUSTC_WRAPPER CARGO_BUILD_RUSTC_WRAPPER= cargo test -p smg-skills --target-dir /tmp/smg-sk4-target`
- `env -u RUSTC_WRAPPER CARGO_BUILD_RUSTC_WRAPPER= cargo test --target-dir /tmp/smg-gate-target`
  Fails in unrelated existing test `llm-tokenizer::factory::tests::test_download_tokenizer_from_hf` on this macOS host with `system-configuration` panic `Attempted to create a NULL object` while building the HF client proxy stack. This branch does not touch `crates/tokenizer`.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Skill bundle parsing and validation with YAML frontmatter support and clearer parse errors
  * Re-exported validation APIs and parsed bundle metadata for easier consumption
  * Extended metadata support (interface display, dependency tools, policy settings) and structured parse warnings

* **Behavior**
  * Sidecar files are handled gracefully: non-fatal issues emit warnings and invalid sidecar fields are ignored

* **Tests**
  * Comprehensive tests covering parsing success, failure modes, and sidecar warning behavior

* **Chores**
  * Updated crate dependency declarations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->