### PR TITLE
feat(mesh): stream chunking wiring in gossip loop (v2 Step 3 part 2)

### DIFF
--- a/crates/mesh/src/chunk_assembler.rs
+++ b/crates/mesh/src/chunk_assembler.rs
@@ -259,6 +259,16 @@ impl ChunkAssembler {
             .collect()
     }
 
+    /// Invalidate any pending partial assembly for `(peer_id, key)`.
+    /// The single-chunk fast path calls this so a fresh value replaces
+    /// leftover fragments from an older multi-chunk publish under the
+    /// same key, instead of waiting for the 30 s GC to clean them up.
+    /// No-op if no entry exists.
+    pub fn drop_pending(&self, peer_id: &str, key: &str) {
+        let asm_key: AssemblyKey = (peer_id.to_string(), key.to_string());
+        self.assemblies.remove(&asm_key);
+    }
+
     fn remove_stale(&self, keys: &[AssemblyKey], timeout: Duration) {
         for key in keys {
             self.assemblies.remove_if(key, |_, state| {
@@ -746,6 +756,43 @@ mod tests {
             .receive_chunk("peer", "b", 1, 1, 2, b"b1".to_vec())
             .unwrap();
         assert_eq!(flatten(&b), b"b0b1");
+        assert_eq!(asm.in_flight(), 0);
+    }
+
+    #[test]
+    fn test_drop_pending_removes_only_matching_entry() {
+        let asm = ChunkAssembler::new();
+        // Start a multi-chunk assembly for (peer, "k") and an unrelated
+        // one for (peer, "other") + (other_peer, "k").
+        assert!(asm
+            .receive_chunk("peer", "k", 1, 0, 2, b"aa".to_vec())
+            .is_none());
+        assert!(asm
+            .receive_chunk("peer", "other", 1, 0, 2, b"bb".to_vec())
+            .is_none());
+        assert!(asm
+            .receive_chunk("other_peer", "k", 1, 0, 2, b"cc".to_vec())
+            .is_none());
+        assert_eq!(asm.in_flight(), 3);
+
+        asm.drop_pending("peer", "k");
+        assert_eq!(
+            asm.in_flight(),
+            2,
+            "only (peer, k) should be gone; other entries spared"
+        );
+
+        // Completing the spared entries still works.
+        let out = asm
+            .receive_chunk("peer", "other", 1, 1, 2, b"22".to_vec())
+            .unwrap();
+        assert_eq!(flatten(&out), b"bb22");
+    }
+
+    #[test]
+    fn test_drop_pending_on_missing_key_is_noop() {
+        let asm = ChunkAssembler::new();
+        asm.drop_pending("peer", "nonexistent");
         assert_eq!(asm.in_flight(), 0);
     }
 }

--- a/crates/mesh/src/chunk_assembler.rs
+++ b/crates/mesh/src/chunk_assembler.rs
@@ -80,10 +80,7 @@ impl AssemblyState {
 
     /// Return the assembled chunks as a fragmented buffer: each chunk
     /// is zero-copy wrapped in a `Bytes` (no contiguous memcpy of the
-    /// full payload). Avoids the ~2× peak that a `Vec<u8>` concat path
-    /// imposed — the byte cap now bounds real memory, not payload-plus-
-    /// contiguous-copy. Subscribers that need contiguous bytes can
-    /// concat at their own discretion.
+    /// full payload).
     fn assemble(self) -> Vec<Bytes> {
         self.chunks.into_iter().flatten().map(Bytes::from).collect()
     }

--- a/crates/mesh/src/chunk_assembler.rs
+++ b/crates/mesh/src/chunk_assembler.rs
@@ -105,6 +105,12 @@ impl ChunkAssembler {
     /// Record an incoming chunk. Returns `Some(assembled)` once all chunks
     /// for the current generation have arrived; returns `None` otherwise.
     ///
+    /// Assemblies are scoped by `(peer_id, key)` so two senders streaming
+    /// chunked values under the same key don't collide through the
+    /// generation compare. A single node-wide assembler serves all
+    /// inbound streams; the peer-scope prevents one peer's newer-
+    /// generation reset from wiping another peer's in-flight partial.
+    ///
     /// Generation handling is a three-way compare: a newer generation
     /// resets the state (older partials discarded), an older generation
     /// is dropped (newer state kept), equal continues recording.
@@ -112,6 +118,7 @@ impl ChunkAssembler {
     /// `total > MAX_TOTAL_CHUNKS`, or `index >= total`.
     pub fn receive_chunk(
         &self,
+        peer_id: &str,
         key: &str,
         generation: u64,
         index: u32,
@@ -122,13 +129,18 @@ impl ChunkAssembler {
             return None;
         }
 
+        // Scope the assembly by sender. '\0' isn't a legal character in
+        // proto string fields (peer_id / subscriber keys), so there's no
+        // collision between scoped keys and any unscoped application key.
+        let scoped_key = format!("{peer_id}\0{key}");
+
         // Record the chunk under the shard lock. Assembly happens outside
         // the guard so the lock is not held during the allocation+copy of
         // the full reassembled buffer.
         let completed = {
             let mut entry = self
                 .assemblies
-                .entry(key.to_string())
+                .entry(scoped_key.clone())
                 .or_insert_with(|| AssemblyState::new(generation, total));
 
             match generation.cmp(&entry.generation) {
@@ -163,7 +175,7 @@ impl ChunkAssembler {
         // (newer generation reset the state after our chunk landed), we
         // return None — the newer generation is what matters now.
         self.assemblies
-            .remove_if(key, |_, state| {
+            .remove_if(&scoped_key, |_, state| {
                 state.generation == generation && state.is_complete()
             })
             .map(|(_, state)| state.assemble())
@@ -287,7 +299,9 @@ mod tests {
     #[test]
     fn test_single_chunk_round_trip() {
         let asm = ChunkAssembler::new();
-        let out = asm.receive_chunk("k", 1, 0, 1, b"hello".to_vec()).unwrap();
+        let out = asm
+            .receive_chunk("peer", "k", 1, 0, 1, b"hello".to_vec())
+            .unwrap();
         assert_eq!(flatten(&out), b"hello");
         assert_eq!(asm.in_flight(), 0, "completed assembly should be removed");
     }
@@ -295,9 +309,15 @@ mod tests {
     #[test]
     fn test_multi_chunk_in_order() {
         let asm = ChunkAssembler::new();
-        assert!(asm.receive_chunk("k", 1, 0, 3, b"aaa".to_vec()).is_none());
-        assert!(asm.receive_chunk("k", 1, 1, 3, b"bbb".to_vec()).is_none());
-        let out = asm.receive_chunk("k", 1, 2, 3, b"ccc".to_vec()).unwrap();
+        assert!(asm
+            .receive_chunk("peer", "k", 1, 0, 3, b"aaa".to_vec())
+            .is_none());
+        assert!(asm
+            .receive_chunk("peer", "k", 1, 1, 3, b"bbb".to_vec())
+            .is_none());
+        let out = asm
+            .receive_chunk("peer", "k", 1, 2, 3, b"ccc".to_vec())
+            .unwrap();
         assert_eq!(flatten(&out), b"aaabbbccc");
         assert_eq!(asm.in_flight(), 0);
     }
@@ -305,9 +325,15 @@ mod tests {
     #[test]
     fn test_multi_chunk_out_of_order() {
         let asm = ChunkAssembler::new();
-        assert!(asm.receive_chunk("k", 1, 2, 3, b"ccc".to_vec()).is_none());
-        assert!(asm.receive_chunk("k", 1, 0, 3, b"aaa".to_vec()).is_none());
-        let out = asm.receive_chunk("k", 1, 1, 3, b"bbb".to_vec()).unwrap();
+        assert!(asm
+            .receive_chunk("peer", "k", 1, 2, 3, b"ccc".to_vec())
+            .is_none());
+        assert!(asm
+            .receive_chunk("peer", "k", 1, 0, 3, b"aaa".to_vec())
+            .is_none());
+        let out = asm
+            .receive_chunk("peer", "k", 1, 1, 3, b"bbb".to_vec())
+            .unwrap();
         assert_eq!(
             flatten(&out),
             b"aaabbbccc",
@@ -318,11 +344,19 @@ mod tests {
     #[test]
     fn test_generation_reset_discards_older_partials() {
         let asm = ChunkAssembler::new();
-        assert!(asm.receive_chunk("k", 5, 0, 3, b"old-0".to_vec()).is_none());
-        assert!(asm.receive_chunk("k", 5, 1, 3, b"old-1".to_vec()).is_none());
+        assert!(asm
+            .receive_chunk("peer", "k", 5, 0, 3, b"old-0".to_vec())
+            .is_none());
+        assert!(asm
+            .receive_chunk("peer", "k", 5, 1, 3, b"old-1".to_vec())
+            .is_none());
 
-        assert!(asm.receive_chunk("k", 6, 0, 2, b"new-0".to_vec()).is_none());
-        let out = asm.receive_chunk("k", 6, 1, 2, b"new-1".to_vec()).unwrap();
+        assert!(asm
+            .receive_chunk("peer", "k", 6, 0, 2, b"new-0".to_vec())
+            .is_none());
+        let out = asm
+            .receive_chunk("peer", "k", 6, 1, 2, b"new-1".to_vec())
+            .unwrap();
         assert_eq!(flatten(&out), b"new-0new-1");
     }
 
@@ -330,15 +364,19 @@ mod tests {
     fn test_delayed_older_generation_chunk_is_dropped() {
         let asm = ChunkAssembler::new();
         // gen=6 starts and records one chunk.
-        assert!(asm.receive_chunk("k", 6, 0, 2, b"new-0".to_vec()).is_none());
+        assert!(asm
+            .receive_chunk("peer", "k", 6, 0, 2, b"new-0".to_vec())
+            .is_none());
 
         // A delayed gen=5 chunk arrives — must NOT reset the gen=6 state.
         assert!(asm
-            .receive_chunk("k", 5, 0, 3, b"stale-0".to_vec())
+            .receive_chunk("peer", "k", 5, 0, 3, b"stale-0".to_vec())
             .is_none());
 
         // Completing gen=6 must still yield the gen=6 payload.
-        let out = asm.receive_chunk("k", 6, 1, 2, b"new-1".to_vec()).unwrap();
+        let out = asm
+            .receive_chunk("peer", "k", 6, 1, 2, b"new-1".to_vec())
+            .unwrap();
         assert_eq!(
             flatten(&out),
             b"new-0new-1",
@@ -349,7 +387,9 @@ mod tests {
     #[test]
     fn test_gc_removes_stale_partials() {
         let asm = ChunkAssembler::new();
-        assert!(asm.receive_chunk("k", 1, 0, 3, b"aaa".to_vec()).is_none());
+        assert!(asm
+            .receive_chunk("peer", "k", 1, 0, 3, b"aaa".to_vec())
+            .is_none());
         assert_eq!(asm.in_flight(), 1);
 
         thread::sleep(Duration::from_millis(50));
@@ -360,7 +400,9 @@ mod tests {
     #[test]
     fn test_gc_keeps_recent_partials() {
         let asm = ChunkAssembler::new();
-        assert!(asm.receive_chunk("k", 1, 0, 3, b"aaa".to_vec()).is_none());
+        assert!(asm
+            .receive_chunk("peer", "k", 1, 0, 3, b"aaa".to_vec())
+            .is_none());
         asm.gc(Duration::from_secs(10));
         assert_eq!(asm.in_flight(), 1, "recent partial should survive gc");
     }
@@ -437,8 +479,12 @@ mod tests {
     #[test]
     fn test_malformed_chunk_is_dropped() {
         let asm = ChunkAssembler::new();
-        assert!(asm.receive_chunk("k", 1, 0, 0, b"x".to_vec()).is_none());
-        assert!(asm.receive_chunk("k", 1, 5, 3, b"x".to_vec()).is_none());
+        assert!(asm
+            .receive_chunk("peer", "k", 1, 0, 0, b"x".to_vec())
+            .is_none());
+        assert!(asm
+            .receive_chunk("peer", "k", 1, 5, 3, b"x".to_vec())
+            .is_none());
         assert_eq!(asm.in_flight(), 0);
     }
 
@@ -447,11 +493,11 @@ mod tests {
         let asm = ChunkAssembler::new();
         // total = u32::MAX would trigger multi-GB allocation if admitted.
         assert!(asm
-            .receive_chunk("k", 1, 0, u32::MAX, b"x".to_vec())
+            .receive_chunk("peer", "k", 1, 0, u32::MAX, b"x".to_vec())
             .is_none());
         // Just past the cap is also rejected.
         assert!(asm
-            .receive_chunk("k", 1, 0, MAX_TOTAL_CHUNKS + 1, b"x".to_vec())
+            .receive_chunk("peer", "k", 1, 0, MAX_TOTAL_CHUNKS + 1, b"x".to_vec())
             .is_none());
         assert_eq!(
             asm.in_flight(),
@@ -466,7 +512,7 @@ mod tests {
         // 4 partials against a cap of 3 — oldest must be evicted.
         for i in 0..4 {
             assert!(asm
-                .receive_chunk(&format!("k{i}"), 1, 0, 2, vec![0u8; 10])
+                .receive_chunk("peer", &format!("k{i}"), 1, 0, 2, vec![0u8; 10])
                 .is_none());
             thread::sleep(Duration::from_millis(1));
         }
@@ -484,13 +530,13 @@ mod tests {
         let cap = 10_000;
         let asm = ChunkAssembler::with_limits(usize::MAX, cap);
         assert!(asm
-            .receive_chunk("k_small", 1, 0, 2, vec![0u8; 2_000])
+            .receive_chunk("peer", "k_small", 1, 0, 2, vec![0u8; 2_000])
             .is_none());
         assert!(asm
-            .receive_chunk("k_med", 1, 0, 2, vec![0u8; 3_000])
+            .receive_chunk("peer", "k_med", 1, 0, 2, vec![0u8; 3_000])
             .is_none());
         assert!(asm
-            .receive_chunk("k_big", 1, 0, 2, vec![0u8; 6_000])
+            .receive_chunk("peer", "k_big", 1, 0, 2, vec![0u8; 6_000])
             .is_none());
 
         assert!(
@@ -671,7 +717,7 @@ mod tests {
         // still be returned regardless of size.
         let asm = ChunkAssembler::with_limits(usize::MAX, 10);
         let out = asm
-            .receive_chunk("k", 1, 0, 1, vec![0u8; 500])
+            .receive_chunk("peer", "k", 1, 0, 1, vec![0u8; 500])
             .expect("single-chunk completion returns bytes");
         assert_eq!(out.len(), 1, "single-chunk result is one Bytes fragment");
         assert_eq!(out[0].len(), 500);
@@ -681,15 +727,23 @@ mod tests {
     #[test]
     fn test_multiple_keys_independent() {
         let asm = ChunkAssembler::new();
-        assert!(asm.receive_chunk("a", 1, 0, 2, b"a0".to_vec()).is_none());
-        assert!(asm.receive_chunk("b", 1, 0, 2, b"b0".to_vec()).is_none());
+        assert!(asm
+            .receive_chunk("peer", "a", 1, 0, 2, b"a0".to_vec())
+            .is_none());
+        assert!(asm
+            .receive_chunk("peer", "b", 1, 0, 2, b"b0".to_vec())
+            .is_none());
         assert_eq!(asm.in_flight(), 2);
 
-        let a = asm.receive_chunk("a", 1, 1, 2, b"a1".to_vec()).unwrap();
+        let a = asm
+            .receive_chunk("peer", "a", 1, 1, 2, b"a1".to_vec())
+            .unwrap();
         assert_eq!(flatten(&a), b"a0a1");
         assert_eq!(asm.in_flight(), 1, "completing a should not touch b");
 
-        let b = asm.receive_chunk("b", 1, 1, 2, b"b1".to_vec()).unwrap();
+        let b = asm
+            .receive_chunk("peer", "b", 1, 1, 2, b"b1".to_vec())
+            .unwrap();
         assert_eq!(flatten(&b), b"b0b1");
         assert_eq!(asm.in_flight(), 0);
     }

--- a/crates/mesh/src/chunk_assembler.rs
+++ b/crates/mesh/src/chunk_assembler.rs
@@ -10,17 +10,13 @@
 //! is GC'd after `timeout`, and the application regenerates the value
 //! on its next retry cycle. No retries or watermarks.
 
-// Items are wired into the gossip receive path in a follow-up commit in
-// this Step 3 PR. Allow (not expect) because tests already exercise the
-// items, which makes `#[expect(dead_code)]` unfulfilled under test cfg.
-#![allow(dead_code)]
-
 use std::{
     cmp::Ordering,
     mem::size_of,
     time::{Duration, Instant},
 };
 
+use bytes::Bytes;
 use dashmap::DashMap;
 
 /// Max concurrent in-flight assemblies. Prevents a peer from flooding
@@ -82,13 +78,14 @@ impl AssemblyState {
         payload + overhead
     }
 
-    fn assemble(self) -> Vec<u8> {
-        let total_size: usize = self.chunks.iter().flatten().map(|c| c.len()).sum();
-        let mut out = Vec::with_capacity(total_size);
-        for chunk in self.chunks.into_iter().flatten() {
-            out.extend_from_slice(&chunk);
-        }
-        out
+    /// Return the assembled chunks as a fragmented buffer: each chunk
+    /// is zero-copy wrapped in a `Bytes` (no contiguous memcpy of the
+    /// full payload). Avoids the ~2× peak that a `Vec<u8>` concat path
+    /// imposed — the byte cap now bounds real memory, not payload-plus-
+    /// contiguous-copy. Subscribers that need contiguous bytes can
+    /// concat at their own discretion.
+    fn assemble(self) -> Vec<Bytes> {
+        self.chunks.into_iter().flatten().map(Bytes::from).collect()
     }
 }
 
@@ -123,7 +120,7 @@ impl ChunkAssembler {
         index: u32,
         total: u32,
         data: Vec<u8>,
-    ) -> Option<Vec<u8>> {
+    ) -> Option<Vec<Bytes>> {
         if total == 0 || total > MAX_TOTAL_CHUNKS || index >= total {
             return None;
         }
@@ -283,11 +280,18 @@ mod tests {
 
     use super::*;
 
+    /// Flatten a fragmented assembly result into a contiguous Vec<u8>
+    /// for test assertions only. Production callers handle fragments
+    /// directly (zero-copy fan-out).
+    fn flatten(bs: &[Bytes]) -> Vec<u8> {
+        bs.iter().flat_map(|b| b.iter().copied()).collect()
+    }
+
     #[test]
     fn test_single_chunk_round_trip() {
         let asm = ChunkAssembler::new();
-        let out = asm.receive_chunk("k", 1, 0, 1, b"hello".to_vec());
-        assert_eq!(out.as_deref(), Some(b"hello".as_slice()));
+        let out = asm.receive_chunk("k", 1, 0, 1, b"hello".to_vec()).unwrap();
+        assert_eq!(flatten(&out), b"hello");
         assert_eq!(asm.in_flight(), 0, "completed assembly should be removed");
     }
 
@@ -297,7 +301,7 @@ mod tests {
         assert!(asm.receive_chunk("k", 1, 0, 3, b"aaa".to_vec()).is_none());
         assert!(asm.receive_chunk("k", 1, 1, 3, b"bbb".to_vec()).is_none());
         let out = asm.receive_chunk("k", 1, 2, 3, b"ccc".to_vec()).unwrap();
-        assert_eq!(out, b"aaabbbccc");
+        assert_eq!(flatten(&out), b"aaabbbccc");
         assert_eq!(asm.in_flight(), 0);
     }
 
@@ -307,7 +311,11 @@ mod tests {
         assert!(asm.receive_chunk("k", 1, 2, 3, b"ccc".to_vec()).is_none());
         assert!(asm.receive_chunk("k", 1, 0, 3, b"aaa".to_vec()).is_none());
         let out = asm.receive_chunk("k", 1, 1, 3, b"bbb".to_vec()).unwrap();
-        assert_eq!(out, b"aaabbbccc", "chunks must assemble in index order");
+        assert_eq!(
+            flatten(&out),
+            b"aaabbbccc",
+            "chunks must assemble in index order"
+        );
     }
 
     #[test]
@@ -318,7 +326,7 @@ mod tests {
 
         assert!(asm.receive_chunk("k", 6, 0, 2, b"new-0".to_vec()).is_none());
         let out = asm.receive_chunk("k", 6, 1, 2, b"new-1".to_vec()).unwrap();
-        assert_eq!(out, b"new-0new-1");
+        assert_eq!(flatten(&out), b"new-0new-1");
     }
 
     #[test]
@@ -335,7 +343,8 @@ mod tests {
         // Completing gen=6 must still yield the gen=6 payload.
         let out = asm.receive_chunk("k", 6, 1, 2, b"new-1".to_vec()).unwrap();
         assert_eq!(
-            out, b"new-0new-1",
+            flatten(&out),
+            b"new-0new-1",
             "stale older chunk must not overwrite newer state"
         );
     }
@@ -667,7 +676,8 @@ mod tests {
         let out = asm
             .receive_chunk("k", 1, 0, 1, vec![0u8; 500])
             .expect("single-chunk completion returns bytes");
-        assert_eq!(out.len(), 500);
+        assert_eq!(out.len(), 1, "single-chunk result is one Bytes fragment");
+        assert_eq!(out[0].len(), 500);
         assert_eq!(asm.in_flight(), 0);
     }
 
@@ -679,11 +689,11 @@ mod tests {
         assert_eq!(asm.in_flight(), 2);
 
         let a = asm.receive_chunk("a", 1, 1, 2, b"a1".to_vec()).unwrap();
-        assert_eq!(a, b"a0a1");
+        assert_eq!(flatten(&a), b"a0a1");
         assert_eq!(asm.in_flight(), 1, "completing a should not touch b");
 
         let b = asm.receive_chunk("b", 1, 1, 2, b"b1".to_vec()).unwrap();
-        assert_eq!(b, b"b0b1");
+        assert_eq!(flatten(&b), b"b0b1");
         assert_eq!(asm.in_flight(), 0);
     }
 }

--- a/crates/mesh/src/chunk_assembler.rs
+++ b/crates/mesh/src/chunk_assembler.rs
@@ -36,8 +36,12 @@ pub const DEFAULT_MAX_ASSEMBLER_BYTES: usize = 512 * 1024 * 1024;
 /// per-assembly vector overhead stays under ~25 KB.
 pub const MAX_TOTAL_CHUNKS: u32 = 1024;
 
+/// Composite key scoping an assembly by sender peer + application key.
+/// Two peers chunking the same key in flight don't collide.
+type AssemblyKey = (String, String);
+
 pub struct ChunkAssembler {
-    assemblies: DashMap<String, AssemblyState>,
+    assemblies: DashMap<AssemblyKey, AssemblyState>,
     max_concurrent: usize,
     max_bytes: usize,
 }
@@ -129,10 +133,7 @@ impl ChunkAssembler {
             return None;
         }
 
-        // Scope the assembly by sender. '\0' isn't a legal character in
-        // proto string fields (peer_id / subscriber keys), so there's no
-        // collision between scoped keys and any unscoped application key.
-        let scoped_key = format!("{peer_id}\0{key}");
+        let asm_key: AssemblyKey = (peer_id.to_string(), key.to_string());
 
         // Record the chunk under the shard lock. Assembly happens outside
         // the guard so the lock is not held during the allocation+copy of
@@ -140,7 +141,7 @@ impl ChunkAssembler {
         let completed = {
             let mut entry = self
                 .assemblies
-                .entry(scoped_key.clone())
+                .entry(asm_key.clone())
                 .or_insert_with(|| AssemblyState::new(generation, total));
 
             match generation.cmp(&entry.generation) {
@@ -175,7 +176,7 @@ impl ChunkAssembler {
         // (newer generation reset the state after our chunk landed), we
         // return None — the newer generation is what matters now.
         self.assemblies
-            .remove_if(&scoped_key, |_, state| {
+            .remove_if(&asm_key, |_, state| {
                 state.generation == generation && state.is_complete()
             })
             .map(|(_, state)| state.assemble())
@@ -218,12 +219,12 @@ impl ChunkAssembler {
             .sum()
     }
 
-    fn try_evict_stale(&self, key: &str, gen: u64) {
+    fn try_evict_stale(&self, key: &AssemblyKey, gen: u64) {
         self.assemblies
             .remove_if(key, |_, s| s.generation == gen && !s.is_complete());
     }
 
-    fn oldest_incomplete(&self) -> Option<(String, u64)> {
+    fn oldest_incomplete(&self) -> Option<(AssemblyKey, u64)> {
         self.assemblies
             .iter()
             .filter(|e| !e.value().is_complete())
@@ -231,7 +232,7 @@ impl ChunkAssembler {
             .map(|e| (e.key().clone(), e.value().generation))
     }
 
-    fn largest_incomplete(&self) -> Option<(String, u64)> {
+    fn largest_incomplete(&self) -> Option<(AssemblyKey, u64)> {
         self.assemblies
             .iter()
             .filter(|e| !e.value().is_complete())
@@ -250,7 +251,7 @@ impl ChunkAssembler {
         self.remove_stale(&expired, timeout);
     }
 
-    fn collect_expired(&self, timeout: Duration) -> Vec<String> {
+    fn collect_expired(&self, timeout: Duration) -> Vec<AssemblyKey> {
         self.assemblies
             .iter()
             .filter(|e| e.value().created_at.elapsed() >= timeout && !e.value().is_complete())
@@ -258,7 +259,7 @@ impl ChunkAssembler {
             .collect()
     }
 
-    fn remove_stale(&self, keys: &[String], timeout: Duration) {
+    fn remove_stale(&self, keys: &[AssemblyKey], timeout: Duration) {
         for key in keys {
             self.assemblies.remove_if(key, |_, state| {
                 state.created_at.elapsed() >= timeout && !state.is_complete()
@@ -414,8 +415,9 @@ mod tests {
         // the timeout would otherwise apply.
         let asm = ChunkAssembler::new();
         let old = Instant::now() - Duration::from_secs(60);
+        let k: AssemblyKey = ("peer".into(), "complete".into());
         asm.assemblies.insert(
-            "complete".to_string(),
+            k.clone(),
             AssemblyState {
                 generation: 1,
                 received_count: 2,
@@ -425,7 +427,7 @@ mod tests {
         );
         asm.gc(Duration::from_secs(1));
         assert!(
-            asm.assemblies.contains_key("complete"),
+            asm.assemblies.contains_key(&k),
             "gc must not remove a complete assembly"
         );
     }
@@ -437,9 +439,10 @@ mod tests {
         // remove_if timeout re-check must spare the fresh state.
         let asm = ChunkAssembler::new();
         let timeout = Duration::from_secs(1);
+        let k: AssemblyKey = ("peer".into(), "k".into());
 
         asm.assemblies.insert(
-            "k".to_string(),
+            k.clone(),
             AssemblyState {
                 generation: 1,
                 received_count: 0,
@@ -450,12 +453,12 @@ mod tests {
 
         // Phase 1: collect sees the expired entry.
         let expired = asm.collect_expired(timeout);
-        assert_eq!(expired, vec!["k".to_string()]);
+        assert_eq!(expired, vec![k.clone()]);
 
-        // Race: a concurrent receive_chunk resets "k" to a fresh
+        // Race: a concurrent receive_chunk resets the entry to a fresh
         // generation before gc's remove phase fires.
         asm.assemblies.insert(
-            "k".to_string(),
+            k.clone(),
             AssemblyState {
                 generation: 2,
                 received_count: 0,
@@ -469,7 +472,7 @@ mod tests {
         // and the fresh state is spared.
         asm.remove_stale(&expired, timeout);
 
-        let survived = asm.assemblies.get("k").expect("fresh entry must survive");
+        let survived = asm.assemblies.get(&k).expect("fresh entry must survive");
         assert_eq!(
             survived.generation, 2,
             "gc evicted the fresh replacement instead of sparing it"
@@ -518,7 +521,7 @@ mod tests {
         }
         assert_eq!(asm.in_flight(), 3, "concurrent cap enforced");
         assert!(
-            !asm.assemblies.contains_key("k0"),
+            !asm.assemblies.contains_key(&("peer".into(), "k0".into())),
             "oldest partial (k0) should be evicted"
         );
     }
@@ -545,7 +548,8 @@ mod tests {
             asm.total_bytes()
         );
         assert!(
-            !asm.assemblies.contains_key("k_big"),
+            !asm.assemblies
+                .contains_key(&("peer".into(), "k_big".into())),
             "largest partial (k_big) should be evicted"
         );
     }
@@ -556,8 +560,11 @@ mod tests {
         // so enforce_bounds must evict one. The complete must not be
         // picked even though it is the oldest by created_at.
         let asm = ChunkAssembler::with_limits(1, usize::MAX);
+        let k_complete: AssemblyKey = ("peer".into(), "complete".into());
+        let k_partial_a: AssemblyKey = ("peer".into(), "partial_a".into());
+        let k_partial_b: AssemblyKey = ("peer".into(), "partial_b".into());
         asm.assemblies.insert(
-            "complete".to_string(),
+            k_complete.clone(),
             AssemblyState {
                 generation: 1,
                 received_count: 2,
@@ -566,7 +573,7 @@ mod tests {
             },
         );
         asm.assemblies.insert(
-            "partial_a".to_string(),
+            k_partial_a.clone(),
             AssemblyState {
                 generation: 1,
                 received_count: 0,
@@ -575,7 +582,7 @@ mod tests {
             },
         );
         asm.assemblies.insert(
-            "partial_b".to_string(),
+            k_partial_b.clone(),
             AssemblyState {
                 generation: 1,
                 received_count: 0,
@@ -587,15 +594,15 @@ mod tests {
         asm.enforce_bounds();
 
         assert!(
-            asm.assemblies.contains_key("complete"),
+            asm.assemblies.contains_key(&k_complete),
             "complete (even oldest) must not be evicted"
         );
         assert!(
-            !asm.assemblies.contains_key("partial_a"),
+            !asm.assemblies.contains_key(&k_partial_a),
             "oldest incomplete should be evicted"
         );
         assert!(
-            asm.assemblies.contains_key("partial_b"),
+            asm.assemblies.contains_key(&k_partial_b),
             "newer incomplete survives"
         );
     }
@@ -608,8 +615,10 @@ mod tests {
         // see 1 incomplete (<=1), not 2 total, and leave the partial
         // alone.
         let asm = ChunkAssembler::with_limits(1, usize::MAX);
+        let k_complete: AssemblyKey = ("peer".into(), "complete".into());
+        let k_partial: AssemblyKey = ("peer".into(), "partial".into());
         asm.assemblies.insert(
-            "complete".to_string(),
+            k_complete.clone(),
             AssemblyState {
                 generation: 1,
                 received_count: 2,
@@ -618,7 +627,7 @@ mod tests {
             },
         );
         asm.assemblies.insert(
-            "partial".to_string(),
+            k_partial.clone(),
             AssemblyState {
                 generation: 1,
                 received_count: 1,
@@ -626,15 +635,6 @@ mod tests {
                 created_at: Instant::now(),
             },
         );
-
-        // Triggering enforce_bounds from the !completed branch by
-        // receiving a new chunk on a third key would add another
-        // partial and push us over. Instead, exercise enforce_bounds
-        // directly via a receive that creates a partial but doesn't
-        // complete — against cap=1, two incompletes should evict one.
-        // But with the transient "complete" entry counted: previous
-        // logic would evict *partial* (as oldest incomplete) when it
-        // saw len=2 > 1, even though the real incomplete count was 1.
 
         // Build the initial state manually so we can observe the
         // filter-based count without triggering a receive.
@@ -650,11 +650,11 @@ mod tests {
         asm.enforce_bounds();
 
         assert!(
-            asm.assemblies.contains_key("complete"),
+            asm.assemblies.contains_key(&k_complete),
             "complete assembly still present"
         );
         assert!(
-            asm.assemblies.contains_key("partial"),
+            asm.assemblies.contains_key(&k_partial),
             "partial must not be evicted — real incomplete count was under cap"
         );
     }
@@ -667,10 +667,11 @@ mod tests {
         // must spare the replacement. We emulate the race in-process
         // by splitting selection from removal via the private helper.
         let asm = ChunkAssembler::with_limits(1, usize::MAX);
+        let k: AssemblyKey = ("peer".into(), "k".into());
 
         // Insert a stale generation-5 partial as the eviction target.
         asm.assemblies.insert(
-            "k".to_string(),
+            k.clone(),
             AssemblyState {
                 generation: 5,
                 received_count: 0,
@@ -680,13 +681,13 @@ mod tests {
         );
 
         // Enforcement picks this key + generation.
-        let (k, gen) = asm.oldest_incomplete().expect("have an incomplete");
-        assert_eq!(k, "k");
+        let (picked_key, gen) = asm.oldest_incomplete().expect("have an incomplete");
+        assert_eq!(picked_key, k);
         assert_eq!(gen, 5);
 
         // Racing thread replaces the state with a fresh generation-6.
         asm.assemblies.insert(
-            "k".to_string(),
+            k.clone(),
             AssemblyState {
                 generation: 6,
                 received_count: 0,
@@ -696,13 +697,13 @@ mod tests {
         );
 
         // The delayed remove_if must NOT evict the generation-6 state.
-        asm.assemblies.remove_if(&k, |_, state| {
+        asm.assemblies.remove_if(&picked_key, |_, state| {
             state.generation == gen && !state.is_complete()
         });
 
         let survived = asm
             .assemblies
-            .get("k")
+            .get(&k)
             .expect("newer-generation replacement must survive");
         assert_eq!(
             survived.generation, 6,

--- a/crates/mesh/src/chunking.rs
+++ b/crates/mesh/src/chunking.rs
@@ -1,14 +1,13 @@
-//! Sender-side stream chunking helpers.
+//! Sender-side stream chunking helpers and receiver-side dispatch.
 //!
-//! Splits oversized stream values into bounded `StreamEntry` messages
-//! that fit the gRPC per-message budget. Single-message values pass
-//! through as `(total_chunks=1, chunk_index=0)`; values exceeding
-//! `max_chunk_bytes` are split into N chunks.
+//! Sender: [`chunk_value`] splits an oversized value into a sequence
+//! of `StreamEntry`s; [`build_stream_batches`] packs them into
+//! `StreamBatch` messages respecting a per-batch cap.
 //!
-//! Tree repair pages (`tree:page:*`) are bounded at 2 MB by the
-//! TreeSyncAdapter contract (spec §4.1) and therefore always take the
-//! single-chunk fast path. A debug assertion in [`chunk_value`] catches
-//! any regression that would route a tree page through the split path.
+//! Receiver: [`dispatch_stream_batch`] routes inbound entries —
+//! single-chunk entries fire subscribers directly, multi-chunk entries
+//! go through the [`ChunkAssembler`](crate::chunk_assembler::ChunkAssembler)
+//! and fire subscribers only on full reassembly.
 
 use bytes::Bytes;
 
@@ -26,11 +25,8 @@ pub const DEFAULT_MAX_CHUNKS_PER_ROUND: usize = 5;
 /// Values with `value.len() <= max_chunk_bytes` produce a single entry
 /// with `total_chunks = 1`. Larger values split into
 /// `ceil(len / max_chunk_bytes)` chunks of at most `max_chunk_bytes`
-/// bytes each. Chunks are emitted in index order 0..N.
-///
-/// `generation` is a per-publish monotonic tag chosen by the caller.
-/// The spec uses nanosecond wall-clock timestamps so that generations
-/// remain monotonic across sender restarts.
+/// bytes each. Chunks are emitted in index order 0..N. `generation` is
+/// a per-publish monotonic tag chosen by the caller.
 pub fn chunk_value(
     key: String,
     generation: u64,
@@ -40,10 +36,6 @@ pub fn chunk_value(
     assert!(max_chunk_bytes > 0, "max_chunk_bytes must be non-zero");
 
     if value.len() <= max_chunk_bytes {
-        debug_assert!(
-            !key.starts_with("tree:page:") || value.len() <= max_chunk_bytes,
-            "tree:page:* entries must fit in a single gRPC message"
-        );
         return vec![StreamEntry {
             key,
             generation,

--- a/crates/mesh/src/chunking.rs
+++ b/crates/mesh/src/chunking.rs
@@ -130,6 +130,10 @@ pub fn dispatch_stream_batch(
 ) {
     for entry in entries {
         if entry.total_chunks == 1 {
+            // A fresh single-chunk value supersedes any in-flight
+            // multi-chunk assembly for the same (peer, key); drop the
+            // stale fragments so they don't wait for GC.
+            mesh_kv.chunk_assembler().drop_pending(peer_id, &entry.key);
             mesh_kv.notify_subscribers(&entry.key, Some(vec![Bytes::from(entry.data)]));
         } else {
             let key = entry.key.clone();

--- a/crates/mesh/src/chunking.rs
+++ b/crates/mesh/src/chunking.rs
@@ -17,9 +17,15 @@ use crate::{
     service::gossip::{StreamBatch, StreamEntry},
 };
 
-/// Per-round cap on chunks emitted across all stream entries. Prevents
-/// a burst of large values from monopolising the gossip channel.
-pub const DEFAULT_MAX_CHUNKS_PER_ROUND: usize = 5;
+/// Maximum chunks packed into a single `StreamBatch` message. This is
+/// a message-shape cap, not a bandwidth throttle: `build_stream_batches`
+/// emits multiple batches as needed to carry every entry in the round.
+/// The 128-slot sync channel's backpressure provides rate limiting;
+/// there is no explicit per-round chunk budget in this iteration (spec
+/// §10 contemplates one as `max_chunks_per_round`, but a hard round
+/// cap combined with §4.4's drained-per-round buffer would make any
+/// value with more chunks than the cap permanently undeliverable).
+pub const DEFAULT_MAX_CHUNKS_PER_BATCH: usize = 5;
 
 /// Headroom reserved below `MAX_MESSAGE_SIZE` for protobuf envelope
 /// overhead (StreamMessage wrapper, StreamEntry metadata, per-field
@@ -125,7 +131,7 @@ pub fn build_stream_batches(
     debug_assert!(
         max_chunks_per_batch > 0,
         "max_chunks_per_batch must be non-zero; callers should pass \
-         DEFAULT_MAX_CHUNKS_PER_ROUND or another positive cap"
+         DEFAULT_MAX_CHUNKS_PER_BATCH or another positive cap"
     );
     if max_chunks_per_batch == 0 || entries.is_empty() {
         return Vec::new();

--- a/crates/mesh/src/chunking.rs
+++ b/crates/mesh/src/chunking.rs
@@ -9,6 +9,11 @@
 //! go through the [`ChunkAssembler`](crate::chunk_assembler::ChunkAssembler)
 //! and fire subscribers only on full reassembly.
 
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    LazyLock,
+};
+
 use bytes::Bytes;
 
 use crate::{
@@ -16,6 +21,29 @@ use crate::{
     kv::MeshKV,
     service::gossip::{StreamBatch, StreamEntry},
 };
+
+/// Monotonic generation counter for stream-batch values. Seeded from
+/// wall-clock nanos on first use so a process restart starts at a
+/// value that almost certainly exceeds any generation emitted before
+/// the restart (receivers holding stale assembler state won't accept
+/// a smaller tag). Subsequent calls are pure atomic increments, so
+/// NTP steps or clock drift mid-process can't rewind the counter.
+static STREAM_GENERATION: LazyLock<AtomicU64> = LazyLock::new(|| {
+    let seed = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0);
+    AtomicU64::new(seed)
+});
+
+/// Returns the next monotonic generation tag for a stream-batch value.
+/// Call this once per published value — every chunk of that value
+/// shares the tag so the receiver's assembler can group them, and
+/// concurrent publishes to the same key get distinct tags so stale
+/// fragments don't mix into a fresh value.
+pub fn next_generation() -> u64 {
+    STREAM_GENERATION.fetch_add(1, Ordering::Relaxed)
+}
 
 /// Maximum chunks packed into a single `StreamBatch` message. This is
 /// a message-shape cap, not a bandwidth throttle: `build_stream_batches`
@@ -150,6 +178,14 @@ pub fn build_stream_batches(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn next_generation_is_strictly_monotonic() {
+        let a = next_generation();
+        let b = next_generation();
+        let c = next_generation();
+        assert!(a < b && b < c, "{a} < {b} < {c}");
+    }
 
     #[test]
     fn test_single_chunk_fast_path() {

--- a/crates/mesh/src/chunking.rs
+++ b/crates/mesh/src/chunking.rs
@@ -147,30 +147,50 @@ pub fn dispatch_stream_batch(
     }
 }
 
-/// Pack `StreamEntry`s into one or more `StreamBatch`es of at most
-/// `max_chunks_per_batch` entries each. Every entry is emitted —
-/// truncating mid-sequence would strand trailing chunks of a value
-/// undeliverable (receiver never completes reassembly; buffer was
+/// Pack `StreamEntry`s into one or more `StreamBatch`es, flushing
+/// the current batch whenever adding the next entry would exceed
+/// either `max_chunks_per_batch` (count) or `max_bytes_per_batch`
+/// (total payload bytes). An entry that on its own exceeds the byte
+/// cap still goes out as a single-entry batch — dropping would
+/// strand downstream chunks undeliverable (at-most-once; buffer is
 /// already drained so the sender has nothing to retry with).
 pub fn build_stream_batches(
     entries: Vec<StreamEntry>,
     max_chunks_per_batch: usize,
+    max_bytes_per_batch: usize,
 ) -> Vec<StreamBatch> {
     debug_assert!(
         max_chunks_per_batch > 0,
         "max_chunks_per_batch must be non-zero; callers should pass \
          DEFAULT_MAX_CHUNKS_PER_BATCH or another positive cap"
     );
-    if max_chunks_per_batch == 0 || entries.is_empty() {
+    debug_assert!(
+        max_bytes_per_batch > 0,
+        "max_bytes_per_batch must be non-zero; callers should pass \
+         MAX_STREAM_CHUNK_BYTES or another positive cap"
+    );
+    if max_chunks_per_batch == 0 || max_bytes_per_batch == 0 || entries.is_empty() {
         return Vec::new();
     }
     let mut out = Vec::new();
-    let mut iter = entries.into_iter().peekable();
-    while iter.peek().is_some() {
-        let batch: Vec<StreamEntry> = iter.by_ref().take(max_chunks_per_batch).collect();
-        if !batch.is_empty() {
-            out.push(StreamBatch { entries: batch });
+    let mut current: Vec<StreamEntry> = Vec::new();
+    let mut current_bytes: usize = 0;
+    for entry in entries {
+        let entry_bytes = entry.data.len();
+        let at_count_cap = current.len() >= max_chunks_per_batch;
+        let would_exceed_bytes =
+            !current.is_empty() && current_bytes.saturating_add(entry_bytes) > max_bytes_per_batch;
+        if at_count_cap || would_exceed_bytes {
+            out.push(StreamBatch {
+                entries: std::mem::take(&mut current),
+            });
+            current_bytes = 0;
         }
+        current_bytes = current_bytes.saturating_add(entry_bytes);
+        current.push(entry);
+    }
+    if !current.is_empty() {
+        out.push(StreamBatch { entries: current });
     }
     out
 }
@@ -281,7 +301,7 @@ mod tests {
 
     #[test]
     fn test_build_stream_batches_empty() {
-        assert!(build_stream_batches(vec![], 5).is_empty());
+        assert!(build_stream_batches(vec![], 5, 1024).is_empty());
     }
 
     #[test]
@@ -302,7 +322,7 @@ mod tests {
                 data: vec![2],
             },
         ];
-        let batches = build_stream_batches(entries, 5);
+        let batches = build_stream_batches(entries, 5, 1024);
         assert_eq!(batches.len(), 1);
         assert_eq!(batches[0].entries.len(), 2);
     }
@@ -319,7 +339,7 @@ mod tests {
             })
             .collect();
         // 10 entries, cap=3 → 3 + 3 + 3 + 1 = 4 batches. No entry dropped.
-        let batches = build_stream_batches(entries, 3);
+        let batches = build_stream_batches(entries, 3, 1024);
         assert_eq!(batches.len(), 4);
         assert_eq!(batches[0].entries.len(), 3);
         assert_eq!(batches[1].entries.len(), 3);
@@ -327,6 +347,44 @@ mod tests {
         assert_eq!(batches[3].entries.len(), 1);
         let total: usize = batches.iter().map(|b| b.entries.len()).sum();
         assert_eq!(total, 10, "every entry must be emitted (no truncation)");
+    }
+
+    #[test]
+    fn test_build_stream_batches_bytes_cap_splits_before_count_cap() {
+        // 4 entries × 100 bytes = 400 bytes. Count cap = 10 (not hit).
+        // Bytes cap = 250 → first batch holds 2 entries (200 ≤ 250;
+        // adding a 3rd would push to 300 > 250), second holds the rest.
+        let entries: Vec<StreamEntry> = (0..4)
+            .map(|i| StreamEntry {
+                key: format!("k{i}"),
+                generation: 1,
+                chunk_index: 0,
+                total_chunks: 1,
+                data: vec![0u8; 100],
+            })
+            .collect();
+        let batches = build_stream_batches(entries, 10, 250);
+        assert_eq!(batches.len(), 2);
+        assert_eq!(batches[0].entries.len(), 2);
+        assert_eq!(batches[1].entries.len(), 2);
+    }
+
+    #[test]
+    fn test_build_stream_batches_oversized_entry_still_emitted() {
+        // Single entry above the byte cap must still ship (at-most-once;
+        // dropping would strand the value undeliverable). Emits as a
+        // single-entry batch even though it exceeds max_bytes_per_batch.
+        let entries = vec![StreamEntry {
+            key: "big".into(),
+            generation: 1,
+            chunk_index: 0,
+            total_chunks: 1,
+            data: vec![0u8; 500],
+        }];
+        let batches = build_stream_batches(entries, 10, 100);
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].entries.len(), 1);
+        assert_eq!(batches[0].entries[0].data.len(), 500);
     }
 
     #[test]
@@ -341,7 +399,21 @@ mod tests {
             total_chunks: 1,
             data: vec![1],
         }];
-        let out = build_stream_batches(entries, 0);
+        let out = build_stream_batches(entries, 0, 1024);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    #[cfg_attr(debug_assertions, should_panic(expected = "max_bytes_per_batch"))]
+    fn test_build_stream_batches_zero_bytes_cap() {
+        let entries = vec![StreamEntry {
+            key: "k".into(),
+            generation: 1,
+            chunk_index: 0,
+            total_chunks: 1,
+            data: vec![1],
+        }];
+        let out = build_stream_batches(entries, 5, 0);
         assert!(out.is_empty());
     }
 }

--- a/crates/mesh/src/chunking.rs
+++ b/crates/mesh/src/chunking.rs
@@ -100,23 +100,27 @@ pub fn dispatch_stream_batch<'a>(
     }
 }
 
-/// Pack `StreamEntry`s into `StreamBatch`es respecting a per-round
-/// chunk cap. If the flat entries exceed the cap, the trailing entries
-/// are dropped — this is at-most-once (§4.4); the sender's buffer is
-/// already drained and the application will re-publish on its next
-/// retry cycle.
+/// Pack `StreamEntry`s into one or more `StreamBatch`es of at most
+/// `max_chunks_per_batch` entries each. Every entry is emitted —
+/// truncating mid-sequence would strand trailing chunks of a value
+/// undeliverable (receiver never completes reassembly; buffer was
+/// already drained so the sender has nothing to retry with).
 pub fn build_stream_batches(
     entries: Vec<StreamEntry>,
-    max_chunks_per_round: usize,
+    max_chunks_per_batch: usize,
 ) -> Vec<StreamBatch> {
-    if entries.is_empty() {
+    if max_chunks_per_batch == 0 || entries.is_empty() {
         return Vec::new();
     }
-    let taken: Vec<StreamEntry> = entries.into_iter().take(max_chunks_per_round).collect();
-    if taken.is_empty() {
-        return Vec::new();
+    let mut out = Vec::new();
+    let mut iter = entries.into_iter().peekable();
+    while iter.peek().is_some() {
+        let batch: Vec<StreamEntry> = iter.by_ref().take(max_chunks_per_batch).collect();
+        if !batch.is_empty() {
+            out.push(StreamBatch { entries: batch });
+        }
     }
-    vec![StreamBatch { entries: taken }]
+    out
 }
 
 #[cfg(test)]
@@ -244,7 +248,7 @@ mod tests {
     }
 
     #[test]
-    fn test_build_stream_batches_truncates_over_cap() {
+    fn test_build_stream_batches_packs_over_cap() {
         let entries: Vec<StreamEntry> = (0..10)
             .map(|i| StreamEntry {
                 key: format!("k{i}"),
@@ -254,8 +258,26 @@ mod tests {
                 data: vec![i as u8],
             })
             .collect();
+        // 10 entries, cap=3 → 3 + 3 + 3 + 1 = 4 batches. No entry dropped.
         let batches = build_stream_batches(entries, 3);
-        assert_eq!(batches.len(), 1);
-        assert_eq!(batches[0].entries.len(), 3, "cap enforced at 3");
+        assert_eq!(batches.len(), 4);
+        assert_eq!(batches[0].entries.len(), 3);
+        assert_eq!(batches[1].entries.len(), 3);
+        assert_eq!(batches[2].entries.len(), 3);
+        assert_eq!(batches[3].entries.len(), 1);
+        let total: usize = batches.iter().map(|b| b.entries.len()).sum();
+        assert_eq!(total, 10, "every entry must be emitted (no truncation)");
+    }
+
+    #[test]
+    fn test_build_stream_batches_zero_cap_returns_empty() {
+        let entries = vec![StreamEntry {
+            key: "k".into(),
+            generation: 1,
+            chunk_index: 0,
+            total_chunks: 1,
+            data: vec![1],
+        }];
+        assert!(build_stream_batches(entries, 0).is_empty());
     }
 }

--- a/crates/mesh/src/chunking.rs
+++ b/crates/mesh/src/chunking.rs
@@ -1,0 +1,235 @@
+//! Sender-side stream chunking helpers.
+//!
+//! Splits oversized stream values into bounded `StreamEntry` messages
+//! that fit the gRPC per-message budget. Single-message values pass
+//! through as `(total_chunks=1, chunk_index=0)`; values exceeding
+//! `max_chunk_bytes` are split into N chunks.
+//!
+//! Tree repair pages (`tree:page:*`) are bounded at 2 MB by the
+//! TreeSyncAdapter contract (spec §4.1) and therefore always take the
+//! single-chunk fast path. A debug assertion in [`chunk_value`] catches
+//! any regression that would route a tree page through the split path.
+
+#![allow(dead_code)]
+
+use bytes::Bytes;
+
+use crate::service::gossip::{StreamBatch, StreamEntry};
+
+/// Per-round cap on chunks emitted across all stream entries. Prevents
+/// a burst of large values from monopolising the gossip channel.
+pub const DEFAULT_MAX_CHUNKS_PER_ROUND: usize = 5;
+
+/// Split a stream value into one or more `StreamEntry`s.
+///
+/// Values with `value.len() <= max_chunk_bytes` produce a single entry
+/// with `total_chunks = 1`. Larger values split into
+/// `ceil(len / max_chunk_bytes)` chunks of at most `max_chunk_bytes`
+/// bytes each. Chunks are emitted in index order 0..N.
+///
+/// `generation` is a per-publish monotonic tag chosen by the caller.
+/// The spec uses nanosecond wall-clock timestamps so that generations
+/// remain monotonic across sender restarts.
+pub fn chunk_value(
+    key: String,
+    generation: u64,
+    value: Bytes,
+    max_chunk_bytes: usize,
+) -> Vec<StreamEntry> {
+    assert!(max_chunk_bytes > 0, "max_chunk_bytes must be non-zero");
+
+    if value.len() <= max_chunk_bytes {
+        debug_assert!(
+            !key.starts_with("tree:page:") || value.len() <= max_chunk_bytes,
+            "tree:page:* entries must fit in a single gRPC message"
+        );
+        return vec![StreamEntry {
+            key,
+            generation,
+            chunk_index: 0,
+            total_chunks: 1,
+            data: value.to_vec(),
+        }];
+    }
+
+    debug_assert!(
+        !key.starts_with("tree:page:"),
+        "tree:page:* values must be bounded by max_tree_repair_page_bytes \
+         and never enter the multi-chunk split path"
+    );
+
+    let total_chunks = value.len().div_ceil(max_chunk_bytes);
+    let mut entries = Vec::with_capacity(total_chunks);
+    for index in 0..total_chunks {
+        let start = index * max_chunk_bytes;
+        let end = (start + max_chunk_bytes).min(value.len());
+        entries.push(StreamEntry {
+            key: key.clone(),
+            generation,
+            chunk_index: index as u32,
+            total_chunks: total_chunks as u32,
+            data: value.slice(start..end).to_vec(),
+        });
+    }
+    entries
+}
+
+/// Pack `StreamEntry`s into `StreamBatch`es respecting a per-round
+/// chunk cap. If the flat entries exceed the cap, the trailing entries
+/// are dropped — this is at-most-once (§4.4); the sender's buffer is
+/// already drained and the application will re-publish on its next
+/// retry cycle.
+pub fn build_stream_batches(
+    entries: Vec<StreamEntry>,
+    max_chunks_per_round: usize,
+) -> Vec<StreamBatch> {
+    if entries.is_empty() {
+        return Vec::new();
+    }
+    let taken: Vec<StreamEntry> = entries.into_iter().take(max_chunks_per_round).collect();
+    if taken.is_empty() {
+        return Vec::new();
+    }
+    vec![StreamBatch { entries: taken }]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_single_chunk_fast_path() {
+        let value = Bytes::from(vec![0u8; 100]);
+        let entries = chunk_value("key".into(), 42, value.clone(), 1024);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].key, "key");
+        assert_eq!(entries[0].generation, 42);
+        assert_eq!(entries[0].chunk_index, 0);
+        assert_eq!(entries[0].total_chunks, 1);
+        assert_eq!(entries[0].data, value.to_vec());
+    }
+
+    #[test]
+    fn test_empty_value_is_single_chunk() {
+        let entries = chunk_value("k".into(), 1, Bytes::new(), 1024);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].total_chunks, 1);
+        assert!(entries[0].data.is_empty());
+    }
+
+    #[test]
+    fn test_multi_chunk_split_even_boundary() {
+        // 3 × 10 bytes = 30 bytes total, max_chunk_bytes = 10 → 3 chunks
+        let value = Bytes::from((0u8..30).collect::<Vec<_>>());
+        let entries = chunk_value("k".into(), 7, value.clone(), 10);
+        assert_eq!(entries.len(), 3);
+        for (i, e) in entries.iter().enumerate() {
+            assert_eq!(e.chunk_index, i as u32);
+            assert_eq!(e.total_chunks, 3);
+            assert_eq!(e.generation, 7);
+        }
+        let reassembled: Vec<u8> = entries.iter().flat_map(|e| e.data.clone()).collect();
+        assert_eq!(reassembled, value.to_vec());
+    }
+
+    #[test]
+    fn test_multi_chunk_split_uneven_boundary() {
+        // 25 bytes, max_chunk_bytes = 10 → 3 chunks (10+10+5)
+        let value = Bytes::from((0u8..25).collect::<Vec<_>>());
+        let entries = chunk_value("k".into(), 1, value.clone(), 10);
+        assert_eq!(entries.len(), 3);
+        assert_eq!(entries[0].data.len(), 10);
+        assert_eq!(entries[1].data.len(), 10);
+        assert_eq!(entries[2].data.len(), 5);
+        let reassembled: Vec<u8> = entries.iter().flat_map(|e| e.data.clone()).collect();
+        assert_eq!(reassembled, value.to_vec());
+    }
+
+    #[test]
+    fn test_chunk_at_exact_boundary() {
+        // Value exactly equals max_chunk_bytes → single chunk (fast path).
+        let value = Bytes::from(vec![0u8; 10]);
+        let entries = chunk_value("k".into(), 1, value, 10);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].total_chunks, 1);
+    }
+
+    #[test]
+    fn test_one_byte_over_boundary_splits() {
+        let value = Bytes::from(vec![0u8; 11]);
+        let entries = chunk_value("k".into(), 1, value, 10);
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].data.len(), 10);
+        assert_eq!(entries[1].data.len(), 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "max_chunk_bytes must be non-zero")]
+    fn test_zero_max_chunk_bytes_panics() {
+        let _ = chunk_value("k".into(), 1, Bytes::from_static(b"x"), 0);
+    }
+
+    #[test]
+    fn test_tree_page_fast_path() {
+        // tree:page:* stays under max_chunk_bytes by contract (2 MB vs 10 MB),
+        // so it takes the single-chunk path and the debug_assert does not fire.
+        let value = Bytes::from(vec![0u8; 1_000_000]);
+        let entries = chunk_value("tree:page:model1:0".into(), 1, value, 10 * 1024 * 1024);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].total_chunks, 1);
+    }
+
+    #[test]
+    #[cfg_attr(debug_assertions, should_panic(expected = "tree:page:*"))]
+    fn test_tree_page_split_panics_in_debug() {
+        // If a tree page ever grows past max_chunk_bytes, debug build
+        // catches it. Release build would just emit the split (valid
+        // semantically, but violates the tree-sync contract).
+        let value = Bytes::from(vec![0u8; 20]);
+        let _ = chunk_value("tree:page:model1:0".into(), 1, value, 10);
+    }
+
+    #[test]
+    fn test_build_stream_batches_empty() {
+        assert!(build_stream_batches(vec![], 5).is_empty());
+    }
+
+    #[test]
+    fn test_build_stream_batches_under_cap() {
+        let entries = vec![
+            StreamEntry {
+                key: "a".into(),
+                generation: 1,
+                chunk_index: 0,
+                total_chunks: 1,
+                data: vec![1],
+            },
+            StreamEntry {
+                key: "b".into(),
+                generation: 1,
+                chunk_index: 0,
+                total_chunks: 1,
+                data: vec![2],
+            },
+        ];
+        let batches = build_stream_batches(entries, 5);
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].entries.len(), 2);
+    }
+
+    #[test]
+    fn test_build_stream_batches_truncates_over_cap() {
+        let entries: Vec<StreamEntry> = (0..10)
+            .map(|i| StreamEntry {
+                key: format!("k{i}"),
+                generation: 1,
+                chunk_index: 0,
+                total_chunks: 1,
+                data: vec![i as u8],
+            })
+            .collect();
+        let batches = build_stream_batches(entries, 3);
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].entries.len(), 3, "cap enforced at 3");
+    }
+}

--- a/crates/mesh/src/chunking.rs
+++ b/crates/mesh/src/chunking.rs
@@ -10,11 +10,12 @@
 //! single-chunk fast path. A debug assertion in [`chunk_value`] catches
 //! any regression that would route a tree page through the split path.
 
-#![allow(dead_code)]
-
 use bytes::Bytes;
 
-use crate::service::gossip::{StreamBatch, StreamEntry};
+use crate::{
+    kv::MeshKV,
+    service::gossip::{StreamBatch, StreamEntry},
+};
 
 /// Per-round cap on chunks emitted across all stream entries. Prevents
 /// a burst of large values from monopolising the gossip channel.
@@ -72,6 +73,31 @@ pub fn chunk_value(
         });
     }
     entries
+}
+
+/// Receiver-side dispatch for `StreamBatch` entries. Single-chunk
+/// entries (`total_chunks == 1`) fire subscribers directly — no state
+/// in the chunk assembler. Multi-chunk entries route through the
+/// assembler and fire subscribers only on full reassembly. Fires go
+/// through `MeshKV::notify_subscribers` with a fragmented `Vec<Bytes>`
+/// payload so fan-out is zero-copy.
+pub fn dispatch_stream_batch<'a>(
+    mesh_kv: &MeshKV,
+    entries: impl IntoIterator<Item = &'a StreamEntry>,
+) {
+    for entry in entries {
+        if entry.total_chunks == 1 {
+            mesh_kv.notify_subscribers(&entry.key, Some(vec![Bytes::from(entry.data.clone())]));
+        } else if let Some(fragments) = mesh_kv.chunk_assembler().receive_chunk(
+            &entry.key,
+            entry.generation,
+            entry.chunk_index,
+            entry.total_chunks,
+            entry.data.clone(),
+        ) {
+            mesh_kv.notify_subscribers(&entry.key, Some(fragments));
+        }
+    }
 }
 
 /// Pack `StreamEntry`s into `StreamBatch`es respecting a per-round

--- a/crates/mesh/src/chunking.rs
+++ b/crates/mesh/src/chunking.rs
@@ -109,6 +109,11 @@ pub fn build_stream_batches(
     entries: Vec<StreamEntry>,
     max_chunks_per_batch: usize,
 ) -> Vec<StreamBatch> {
+    debug_assert!(
+        max_chunks_per_batch > 0,
+        "max_chunks_per_batch must be non-zero; callers should pass \
+         DEFAULT_MAX_CHUNKS_PER_ROUND or another positive cap"
+    );
     if max_chunks_per_batch == 0 || entries.is_empty() {
         return Vec::new();
     }
@@ -270,7 +275,10 @@ mod tests {
     }
 
     #[test]
-    fn test_build_stream_batches_zero_cap_returns_empty() {
+    #[cfg_attr(debug_assertions, should_panic(expected = "max_chunks_per_batch"))]
+    fn test_build_stream_batches_zero_cap() {
+        // Debug build: assert fires (contract violation).
+        // Release build: runtime zero-check still returns empty as a safety net.
         let entries = vec![StreamEntry {
             key: "k".into(),
             generation: 1,
@@ -278,6 +286,7 @@ mod tests {
             total_chunks: 1,
             data: vec![1],
         }];
-        assert!(build_stream_batches(entries, 0).is_empty());
+        let out = build_stream_batches(entries, 0);
+        assert!(out.is_empty());
     }
 }

--- a/crates/mesh/src/chunking.rs
+++ b/crates/mesh/src/chunking.rs
@@ -78,24 +78,25 @@ pub fn chunk_value(
 /// Receiver-side dispatch for `StreamBatch` entries. Single-chunk
 /// entries (`total_chunks == 1`) fire subscribers directly — no state
 /// in the chunk assembler. Multi-chunk entries route through the
-/// assembler and fire subscribers only on full reassembly. Fires go
-/// through `MeshKV::notify_subscribers` with a fragmented `Vec<Bytes>`
-/// payload so fan-out is zero-copy.
-pub fn dispatch_stream_batch<'a>(
-    mesh_kv: &MeshKV,
-    entries: impl IntoIterator<Item = &'a StreamEntry>,
-) {
+/// assembler and fire subscribers only on full reassembly.
+///
+/// Takes ownership of the entries so chunk payloads move into `Bytes`
+/// without cloning.
+pub fn dispatch_stream_batch(mesh_kv: &MeshKV, entries: impl IntoIterator<Item = StreamEntry>) {
     for entry in entries {
         if entry.total_chunks == 1 {
-            mesh_kv.notify_subscribers(&entry.key, Some(vec![Bytes::from(entry.data.clone())]));
-        } else if let Some(fragments) = mesh_kv.chunk_assembler().receive_chunk(
-            &entry.key,
-            entry.generation,
-            entry.chunk_index,
-            entry.total_chunks,
-            entry.data.clone(),
-        ) {
-            mesh_kv.notify_subscribers(&entry.key, Some(fragments));
+            mesh_kv.notify_subscribers(&entry.key, Some(vec![Bytes::from(entry.data)]));
+        } else {
+            let key = entry.key.clone();
+            if let Some(fragments) = mesh_kv.chunk_assembler().receive_chunk(
+                &key,
+                entry.generation,
+                entry.chunk_index,
+                entry.total_chunks,
+                entry.data,
+            ) {
+                mesh_kv.notify_subscribers(&key, Some(fragments));
+            }
         }
     }
 }

--- a/crates/mesh/src/chunking.rs
+++ b/crates/mesh/src/chunking.rs
@@ -81,14 +81,21 @@ pub fn chunk_value(
 /// assembler and fire subscribers only on full reassembly.
 ///
 /// Takes ownership of the entries so chunk payloads move into `Bytes`
-/// without cloning.
-pub fn dispatch_stream_batch(mesh_kv: &MeshKV, entries: impl IntoIterator<Item = StreamEntry>) {
+/// without cloning. The chunk assembler scopes in-flight state by
+/// `peer_id` so concurrent chunked values from different senders under
+/// the same key don't collide.
+pub fn dispatch_stream_batch(
+    mesh_kv: &MeshKV,
+    peer_id: &str,
+    entries: impl IntoIterator<Item = StreamEntry>,
+) {
     for entry in entries {
         if entry.total_chunks == 1 {
             mesh_kv.notify_subscribers(&entry.key, Some(vec![Bytes::from(entry.data)]));
         } else {
             let key = entry.key.clone();
             if let Some(fragments) = mesh_kv.chunk_assembler().receive_chunk(
+                peer_id,
                 &key,
                 entry.generation,
                 entry.chunk_index,

--- a/crates/mesh/src/chunking.rs
+++ b/crates/mesh/src/chunking.rs
@@ -12,6 +12,7 @@
 use bytes::Bytes;
 
 use crate::{
+    flow_control::MAX_MESSAGE_SIZE,
     kv::MeshKV,
     service::gossip::{StreamBatch, StreamEntry},
 };
@@ -19,6 +20,18 @@ use crate::{
 /// Per-round cap on chunks emitted across all stream entries. Prevents
 /// a burst of large values from monopolising the gossip channel.
 pub const DEFAULT_MAX_CHUNKS_PER_ROUND: usize = 5;
+
+/// Headroom reserved below `MAX_MESSAGE_SIZE` for protobuf envelope
+/// overhead (StreamMessage wrapper, StreamEntry metadata, per-field
+/// tags and length prefixes). Without this margin a chunk sized
+/// exactly at `MAX_MESSAGE_SIZE` pushes the serialised message past
+/// the receiver's `max_decoding_message_size` and tonic rejects it.
+pub const STREAM_CHUNK_OVERHEAD_MARGIN: usize = 64 * 1024;
+
+/// Maximum payload bytes per `StreamEntry`. Callers pass this to
+/// [`chunk_value`] so every emitted entry leaves room for the
+/// protobuf envelope within the gRPC message budget.
+pub const MAX_STREAM_CHUNK_BYTES: usize = MAX_MESSAGE_SIZE - STREAM_CHUNK_OVERHEAD_MARGIN;
 
 /// Split a stream value into one or more `StreamEntry`s.
 ///

--- a/crates/mesh/src/controller.rs
+++ b/crates/mesh/src/controller.rs
@@ -1011,6 +1011,14 @@ impl MeshController {
                                         peer_name
                                     );
                                 }
+                                StreamMessageType::StreamBatch => {
+                                    // Wiring lands in Step 3.5.
+                                    log::trace!(
+                                        "Received StreamBatch from {} (seq: {}) — handler not yet wired",
+                                        peer_name,
+                                        msg.sequence
+                                    );
+                                }
                             }
                         }
                         Ok(Some(Err(e))) => {

--- a/crates/mesh/src/controller.rs
+++ b/crates/mesh/src/controller.rs
@@ -51,6 +51,10 @@ pub struct MeshController {
     /// Current round batch, updated once per round by the central collector.
     /// Per-peer senders read and apply their own watermark filtering.
     current_batch: Arc<parking_lot::RwLock<Arc<RoundBatch>>>,
+    /// Node-wide MeshKV handle. Owns the stream buffers, subscriber
+    /// registry, and chunk assembler shared with the server-side
+    /// SyncStream handlers.
+    mesh_kv: Option<Arc<crate::kv::MeshKV>>,
 }
 
 impl MeshController {
@@ -77,7 +81,17 @@ impl MeshController {
             sync_connections: Arc::new(Mutex::new(HashMap::new())),
             central_collector,
             current_batch: Arc::new(parking_lot::RwLock::new(Arc::new(RoundBatch::default()))),
+            mesh_kv: None,
         }
+    }
+
+    /// Attach the node-wide MeshKV handle. Plumbed from the server
+    /// builder so stream buffers, subscribers, and the chunk assembler
+    /// are shared between client-side (outbound) and server-side
+    /// (inbound) SyncStream handlers.
+    pub fn with_mesh_kv(mut self, mesh_kv: Arc<crate::kv::MeshKV>) -> Self {
+        self.mesh_kv = Some(mesh_kv);
+        self
     }
 
     /// Get a handle to the shared RoundBatch. Used by GossipService to

--- a/crates/mesh/src/controller.rs
+++ b/crates/mesh/src/controller.rs
@@ -31,7 +31,9 @@ use super::{
     sync::MeshSyncManager,
 };
 use crate::{
-    chunking::{build_stream_batches, chunk_value, DEFAULT_MAX_CHUNKS_PER_ROUND},
+    chunking::{
+        build_stream_batches, chunk_value, dispatch_stream_batch, DEFAULT_MAX_CHUNKS_PER_ROUND,
+    },
     collector::{CentralCollector, PeerWatermark, RoundBatch},
     flow_control::{MessageSizeValidator, MAX_MESSAGE_SIZE},
     metrics,
@@ -174,6 +176,17 @@ impl MeshController {
             // This keeps the periodic structure snapshot fresh.
             if cnt.is_multiple_of(10) {
                 self.sync_manager.checkpoint_tree_states();
+            }
+
+            // Chunk assembler GC: every 5 rounds (~5s), drop partial
+            // assemblies older than 30s per spec §4.4. Partial chunks
+            // the receiver has been holding for a full assembly timeout
+            // are assumed lost; the sender will re-publish on its own
+            // retry cycle with a fresh generation.
+            if cnt.is_multiple_of(5) {
+                if let Some(mesh_kv) = &self.mesh_kv {
+                    mesh_kv.chunk_assembler().gc(Duration::from_secs(30));
+                }
             }
 
             // Periodic GC: clean up tombstoned CRDT metadata every 60 rounds (~60s)
@@ -482,6 +495,7 @@ impl MeshController {
         let sync_connections = self.sync_connections.clone();
         let current_batch = self.current_batch.clone();
         let current_stream_batch = self.current_stream_batch.clone();
+        let mesh_kv = self.mesh_kv.clone();
 
         // Log connection lifecycle: spawn
         log::debug!(
@@ -1120,12 +1134,13 @@ impl MeshController {
                                     );
                                 }
                                 StreamMessageType::StreamBatch => {
-                                    // Wiring lands in Step 3.5.
-                                    log::trace!(
-                                        "Received StreamBatch from {} (seq: {}) — handler not yet wired",
-                                        peer_name,
-                                        msg.sequence
-                                    );
+                                    if let (
+                                        Some(StreamPayload::StreamBatch(batch)),
+                                        Some(mesh_kv),
+                                    ) = (&msg.payload, &mesh_kv)
+                                    {
+                                        dispatch_stream_batch(mesh_kv, batch.entries.iter());
+                                    }
                                 }
                             }
                         }

--- a/crates/mesh/src/controller.rs
+++ b/crates/mesh/src/controller.rs
@@ -1138,7 +1138,11 @@ impl MeshController {
                                         if let Some(StreamPayload::StreamBatch(batch)) =
                                             msg.payload
                                         {
-                                            dispatch_stream_batch(mesh_kv, batch.entries);
+                                            dispatch_stream_batch(
+                                                mesh_kv,
+                                                &msg.peer_id,
+                                                batch.entries,
+                                            );
                                         }
                                     }
                                 }

--- a/crates/mesh/src/controller.rs
+++ b/crates/mesh/src/controller.rs
@@ -692,6 +692,7 @@ impl MeshController {
                                     for batch in build_stream_batches(
                                         entries,
                                         DEFAULT_MAX_CHUNKS_PER_BATCH,
+                                        MAX_STREAM_CHUNK_BYTES,
                                     ) {
                                         let msg = StreamMessage {
                                             message_type: StreamMessageType::StreamBatch as i32,

--- a/crates/mesh/src/controller.rs
+++ b/crates/mesh/src/controller.rs
@@ -32,8 +32,8 @@ use super::{
 };
 use crate::{
     chunking::{
-        build_stream_batches, chunk_value, dispatch_stream_batch, DEFAULT_MAX_CHUNKS_PER_BATCH,
-        MAX_STREAM_CHUNK_BYTES,
+        build_stream_batches, chunk_value, dispatch_stream_batch, next_generation,
+        DEFAULT_MAX_CHUNKS_PER_BATCH, MAX_STREAM_CHUNK_BYTES,
     },
     collector::{CentralCollector, PeerWatermark, RoundBatch},
     flow_control::{MessageSizeValidator, MAX_MESSAGE_SIZE},
@@ -665,16 +665,14 @@ impl MeshController {
                                 .is_none_or(|last| !Arc::ptr_eq(last, &stream_batch));
                             if fresh_batch {
                                 last_stream_batch = Some(stream_batch.clone());
-                                let generation = std::time::SystemTime::now()
-                                    .duration_since(std::time::UNIX_EPOCH)
-                                    .map(|d| d.as_nanos() as u64)
-                                    .unwrap_or(0);
                                 let mut entries = Vec::new();
                                 // Drain entries are broadcast: every peer emits.
+                                // Generation is per-value so concurrent publishes
+                                // to the same key get distinct tags.
                                 for (key, value) in &stream_batch.drain_entries {
                                     entries.extend(chunk_value(
                                         key.clone(),
-                                        generation,
+                                        next_generation(),
                                         Bytes::from(value.clone()),
                                         MAX_STREAM_CHUNK_BYTES,
                                     ));
@@ -684,7 +682,7 @@ impl MeshController {
                                     if target == &peer_name_incremental {
                                         entries.extend(chunk_value(
                                             key.clone(),
-                                            generation,
+                                            next_generation(),
                                             value.clone(),
                                             MAX_STREAM_CHUNK_BYTES,
                                         ));

--- a/crates/mesh/src/controller.rs
+++ b/crates/mesh/src/controller.rs
@@ -32,7 +32,7 @@ use super::{
 };
 use crate::{
     chunking::{
-        build_stream_batches, chunk_value, dispatch_stream_batch, DEFAULT_MAX_CHUNKS_PER_ROUND,
+        build_stream_batches, chunk_value, dispatch_stream_batch, DEFAULT_MAX_CHUNKS_PER_BATCH,
         MAX_STREAM_CHUNK_BYTES,
     },
     collector::{CentralCollector, PeerWatermark, RoundBatch},
@@ -693,7 +693,7 @@ impl MeshController {
                                 if !entries.is_empty() {
                                     for batch in build_stream_batches(
                                         entries,
-                                        DEFAULT_MAX_CHUNKS_PER_ROUND,
+                                        DEFAULT_MAX_CHUNKS_PER_BATCH,
                                     ) {
                                         let msg = StreamMessage {
                                             message_type: StreamMessageType::StreamBatch as i32,

--- a/crates/mesh/src/controller.rs
+++ b/crates/mesh/src/controller.rs
@@ -9,6 +9,7 @@ use std::{
 };
 
 use anyhow::Result;
+use bytes::Bytes;
 use rand::seq::{IndexedRandom, SliceRandom};
 use tokio::sync::{mpsc, watch, Mutex};
 use tonic::transport::{ClientTlsConfig, Endpoint};
@@ -30,6 +31,7 @@ use super::{
     sync::MeshSyncManager,
 };
 use crate::{
+    chunking::{build_stream_batches, chunk_value, DEFAULT_MAX_CHUNKS_PER_ROUND},
     collector::{CentralCollector, PeerWatermark, RoundBatch},
     flow_control::{MessageSizeValidator, MAX_MESSAGE_SIZE},
     metrics,
@@ -51,6 +53,10 @@ pub struct MeshController {
     /// Current round batch, updated once per round by the central collector.
     /// Per-peer senders read and apply their own watermark filtering.
     current_batch: Arc<parking_lot::RwLock<Arc<RoundBatch>>>,
+    /// Current stream round batch, drained once per round from MeshKV.
+    /// Per-peer senders read this and filter targeted entries to their
+    /// own peer; drain_entries are broadcast to every peer.
+    current_stream_batch: Arc<parking_lot::RwLock<Arc<crate::kv::RoundBatch>>>,
     /// Node-wide MeshKV handle. Owns the stream buffers, subscriber
     /// registry, and chunk assembler shared with the server-side
     /// SyncStream handlers.
@@ -81,6 +87,9 @@ impl MeshController {
             sync_connections: Arc::new(Mutex::new(HashMap::new())),
             central_collector,
             current_batch: Arc::new(parking_lot::RwLock::new(Arc::new(RoundBatch::default()))),
+            current_stream_batch: Arc::new(parking_lot::RwLock::new(Arc::new(
+                crate::kv::RoundBatch::default(),
+            ))),
             mesh_kv: None,
         }
     }
@@ -98,6 +107,13 @@ impl MeshController {
     /// share the centrally collected batch with server-side sync_stream handlers.
     pub fn current_batch(&self) -> Arc<parking_lot::RwLock<Arc<RoundBatch>>> {
         self.current_batch.clone()
+    }
+
+    /// Get a handle to the shared stream RoundBatch. Used by GossipService
+    /// so server-side sync_stream handlers see the same drained stream
+    /// entries as client-side handlers.
+    pub fn current_stream_batch(&self) -> Arc<parking_lot::RwLock<Arc<crate::kv::RoundBatch>>> {
+        self.current_stream_batch.clone()
     }
 
     #[instrument(fields(name = %self.self_name), skip(self, signal))]
@@ -235,6 +251,16 @@ impl MeshController {
                 let batch = self.central_collector.collect();
                 *self.current_batch.write() = Arc::new(batch);
                 self.central_collector.advance_generations();
+            }
+
+            // Stream round collection: drain stream namespace buffers and
+            // drain callbacks exactly once per round (destructive). Per-peer
+            // senders filter targeted_entries by their own peer_id and
+            // broadcast drain_entries to all peers. Empty batch if no
+            // MeshKV is attached (legacy path pre-Step 3).
+            if let Some(mesh_kv) = &self.mesh_kv {
+                let stream_batch = mesh_kv.collect_round_batch();
+                *self.current_stream_batch.write() = Arc::new(stream_batch);
             }
 
             tokio::select! {
@@ -455,6 +481,7 @@ impl MeshController {
         let sync_manager = self.sync_manager.clone();
         let sync_connections = self.sync_connections.clone();
         let current_batch = self.current_batch.clone();
+        let current_stream_batch = self.current_stream_batch.clone();
 
         // Log connection lifecycle: spawn
         log::debug!(
@@ -509,10 +536,14 @@ impl MeshController {
                     let shared_sequence = sequence.clone();
                     let size_validator = MessageSizeValidator::default();
                     let batch_handle = current_batch.clone();
+                    let stream_batch_handle = current_stream_batch.clone();
 
                     #[expect(clippy::disallowed_methods, reason = "incremental sender handle is stored and aborted when the parent sync_stream handler exits")]
                     tokio::spawn(async move {
                         let mut interval = tokio::time::interval(Duration::from_secs(1));
+                        // Skip re-emission of an unchanged stream batch (main
+                        // loop hasn't collected a new one since last tick).
+                        let mut last_stream_batch: Option<Arc<crate::kv::RoundBatch>> = None;
 
                         loop {
                             interval.tick().await;
@@ -600,6 +631,69 @@ impl MeshController {
                                             log::warn!(
                                                 "Channel closed, stopping incremental update sender"
                                             );
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+
+                            // Stream batches: drain-portion (broadcast) +
+                            // targeted entries addressed to this peer. Each
+                            // entry is chunked if oversized. On channel
+                            // full, the round's stream traffic for this
+                            // peer is dropped — no retry (at-most-once,
+                            // spec §4.4). Application regenerates on its
+                            // own retry cycle.
+                            let stream_batch = stream_batch_handle.read().clone();
+                            let fresh_batch = last_stream_batch
+                                .as_ref()
+                                .is_none_or(|last| !Arc::ptr_eq(last, &stream_batch));
+                            if fresh_batch {
+                                last_stream_batch = Some(stream_batch.clone());
+                                let generation = std::time::SystemTime::now()
+                                    .duration_since(std::time::UNIX_EPOCH)
+                                    .map(|d| d.as_nanos() as u64)
+                                    .unwrap_or(0);
+                                let mut entries = Vec::new();
+                                // Drain entries are broadcast: every peer emits.
+                                for (key, value) in &stream_batch.drain_entries {
+                                    entries.extend(chunk_value(
+                                        key.clone(),
+                                        generation,
+                                        Bytes::from(value.clone()),
+                                        MAX_MESSAGE_SIZE,
+                                    ));
+                                }
+                                // Targeted entries: only those addressed to this peer.
+                                for (target, key, value) in &stream_batch.targeted_entries {
+                                    if target == &peer_name_incremental {
+                                        entries.extend(chunk_value(
+                                            key.clone(),
+                                            generation,
+                                            value.clone(),
+                                            MAX_MESSAGE_SIZE,
+                                        ));
+                                    }
+                                }
+                                if !entries.is_empty() {
+                                    for batch in build_stream_batches(
+                                        entries,
+                                        DEFAULT_MAX_CHUNKS_PER_ROUND,
+                                    ) {
+                                        let msg = StreamMessage {
+                                            message_type: StreamMessageType::StreamBatch as i32,
+                                            payload: Some(StreamPayload::StreamBatch(batch)),
+                                            sequence: shared_sequence
+                                                .fetch_add(1, Ordering::Relaxed),
+                                            peer_id: self_name_incremental.clone(),
+                                        };
+                                        if let Err(e) = tx_incremental.try_send(msg) {
+                                            log::debug!(
+                                                peer = %peer_name_incremental,
+                                                error = ?e,
+                                                "stream batch dropped on backpressure"
+                                            );
+                                            // TODO(metrics): bump stream_dropped_on_backpressure
                                             break;
                                         }
                                     }

--- a/crates/mesh/src/controller.rs
+++ b/crates/mesh/src/controller.rs
@@ -702,14 +702,24 @@ impl MeshController {
                                                 .fetch_add(1, Ordering::Relaxed),
                                             peer_id: self_name_incremental.clone(),
                                         };
-                                        if let Err(e) = tx_incremental.try_send(msg) {
-                                            log::debug!(
-                                                peer = %peer_name_incremental,
-                                                error = ?e,
-                                                "stream batch dropped on backpressure"
-                                            );
-                                            // TODO(metrics): bump stream_dropped_on_backpressure
-                                            break;
+                                        match tx_incremental.try_send(msg) {
+                                            Ok(()) => {}
+                                            Err(mpsc::error::TrySendError::Full(_)) => {
+                                                log::debug!(
+                                                    peer = %peer_name_incremental,
+                                                    "stream batch dropped on backpressure"
+                                                );
+                                                // TODO(metrics): bump
+                                                // stream_dropped_on_backpressure
+                                                break;
+                                            }
+                                            Err(mpsc::error::TrySendError::Closed(_)) => {
+                                                log::warn!(
+                                                    peer = %peer_name_incremental,
+                                                    "stream sender: channel closed, stopping"
+                                                );
+                                                return;
+                                            }
                                         }
                                     }
                                 }

--- a/crates/mesh/src/controller.rs
+++ b/crates/mesh/src/controller.rs
@@ -1134,12 +1134,12 @@ impl MeshController {
                                     );
                                 }
                                 StreamMessageType::StreamBatch => {
-                                    if let (
-                                        Some(StreamPayload::StreamBatch(batch)),
-                                        Some(mesh_kv),
-                                    ) = (&msg.payload, &mesh_kv)
-                                    {
-                                        dispatch_stream_batch(mesh_kv, batch.entries.iter());
+                                    if let Some(mesh_kv) = &mesh_kv {
+                                        if let Some(StreamPayload::StreamBatch(batch)) =
+                                            msg.payload
+                                        {
+                                            dispatch_stream_batch(mesh_kv, batch.entries);
+                                        }
                                     }
                                 }
                             }

--- a/crates/mesh/src/controller.rs
+++ b/crates/mesh/src/controller.rs
@@ -33,6 +33,7 @@ use super::{
 use crate::{
     chunking::{
         build_stream_batches, chunk_value, dispatch_stream_batch, DEFAULT_MAX_CHUNKS_PER_ROUND,
+        MAX_STREAM_CHUNK_BYTES,
     },
     collector::{CentralCollector, PeerWatermark, RoundBatch},
     flow_control::{MessageSizeValidator, MAX_MESSAGE_SIZE},
@@ -675,7 +676,7 @@ impl MeshController {
                                         key.clone(),
                                         generation,
                                         Bytes::from(value.clone()),
-                                        MAX_MESSAGE_SIZE,
+                                        MAX_STREAM_CHUNK_BYTES,
                                     ));
                                 }
                                 // Targeted entries: only those addressed to this peer.
@@ -685,7 +686,7 @@ impl MeshController {
                                             key.clone(),
                                             generation,
                                             value.clone(),
-                                            MAX_MESSAGE_SIZE,
+                                            MAX_STREAM_CHUNK_BYTES,
                                         ));
                                     }
                                 }

--- a/crates/mesh/src/kv.rs
+++ b/crates/mesh/src/kv.rs
@@ -132,7 +132,15 @@ impl Drop for DrainHandle {
 // ============================================================================
 
 /// A single subscription event: (key, value). `None` value means deletion.
-type SubscriptionEvent = (String, Option<Bytes>);
+///
+/// Values are a `Vec<Bytes>` — a list of zero-copy buffer fragments. For
+/// single-value writes this is a 1-element Vec; for reassembled chunked
+/// stream receives it is an N-element Vec where each element wraps one
+/// chunk's original allocation. Subscribers that need a contiguous buffer
+/// can concat; those that fan out further can clone the Bytes cheaply.
+/// The fragmented shape avoids the 2× peak a contiguous reassembly would
+/// impose when a near-cap multi-chunk value completes.
+type SubscriptionEvent = (String, Option<Vec<Bytes>>);
 
 /// Tracks all active subscriptions by prefix.
 struct SubscriberRegistry {
@@ -157,7 +165,7 @@ impl SubscriberRegistry {
     /// Notify all subscribers whose prefix matches the given key.
     /// Uses try_send to never block the gossip loop.
     /// `value` is `Some(bytes)` for puts, `None` for deletes.
-    fn notify(&self, key: &str, value: Option<Bytes>) {
+    fn notify(&self, key: &str, value: Option<Vec<Bytes>>) {
         for entry in &self.subscribers {
             let prefix = entry.key();
             if key.starts_with(prefix.as_str()) {
@@ -267,7 +275,7 @@ impl CrdtNamespace {
         );
         self.store.insert(key.to_string(), value.clone());
         self.subscriber_registry
-            .notify(key, Some(Bytes::from(value)));
+            .notify(key, Some(vec![Bytes::from(value)]));
     }
 
     /// Get the current value for a key, or None if not present or tombstoned.
@@ -492,7 +500,7 @@ impl MeshKV {
     /// receive path when a chunked value completes (or a single-chunk
     /// entry arrives), so handlers can deliver into adapter-owned
     /// mpsc channels without reaching into internal registries.
-    pub fn notify_subscribers(&self, key: &str, value: Option<Bytes>) {
+    pub fn notify_subscribers(&self, key: &str, value: Option<Vec<Bytes>>) {
         self.subscriber_registry.notify(key, value);
     }
 
@@ -750,7 +758,9 @@ mod tests {
             .expect("channel closed");
 
         assert_eq!(key, "worker:7");
-        assert_eq!(value.as_deref(), Some(b"healthy".as_slice()));
+        let frags = value.expect("put yields Some");
+        assert_eq!(frags.len(), 1, "single local write is a single fragment");
+        assert_eq!(frags[0].as_ref(), b"healthy");
     }
 
     #[tokio::test]

--- a/crates/mesh/src/kv.rs
+++ b/crates/mesh/src/kv.rs
@@ -492,7 +492,7 @@ impl MeshKV {
     /// Handle to the node-wide chunk reassembly buffer. Used by the
     /// gossip receive path to route `StreamBatch` chunks through
     /// reassembly before firing subscribers.
-    pub fn chunk_assembler(&self) -> Arc<ChunkAssembler> {
+    pub(crate) fn chunk_assembler(&self) -> Arc<ChunkAssembler> {
         self.chunk_assembler.clone()
     }
 
@@ -500,7 +500,7 @@ impl MeshKV {
     /// receive path when a chunked value completes (or a single-chunk
     /// entry arrives), so handlers can deliver into adapter-owned
     /// mpsc channels without reaching into internal registries.
-    pub fn notify_subscribers(&self, key: &str, value: Option<Vec<Bytes>>) {
+    pub(crate) fn notify_subscribers(&self, key: &str, value: Option<Vec<Bytes>>) {
         self.subscriber_registry.notify(key, value);
     }
 

--- a/crates/mesh/src/kv.rs
+++ b/crates/mesh/src/kv.rs
@@ -19,7 +19,7 @@ use dashmap::{mapref::entry::Entry as DashMapEntry, DashMap};
 use parking_lot::RwLock;
 use tokio::sync::mpsc;
 
-use crate::crdt_kv::CrdtOrMap;
+use crate::{chunk_assembler::ChunkAssembler, crdt_kv::CrdtOrMap};
 
 // ============================================================================
 // Type Definitions
@@ -436,6 +436,15 @@ pub struct RoundBatch {
 /// Generic, application-agnostic mesh transport. Provides explicit namespace
 /// handles for CRDT and stream modes. Application code MUST use namespace
 /// handles, not MeshKV directly.
+impl std::fmt::Debug for MeshKV {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MeshKV")
+            .field("server_name", &self.server_name)
+            .field("replica_id", &self.replica_id)
+            .finish_non_exhaustive()
+    }
+}
+
 pub struct MeshKV {
     /// CRDT store shared across all CRDT namespaces.
     store: Arc<CrdtOrMap>,
@@ -447,6 +456,9 @@ pub struct MeshKV {
     subscriber_registry: Arc<SubscriberRegistry>,
     /// Shared drain registry.
     drain_registry: Arc<DrainRegistry>,
+    /// Receiver-side chunk reassembly buffer shared across all inbound
+    /// SyncStream connections on this node.
+    chunk_assembler: Arc<ChunkAssembler>,
     /// Server name for this node (used to derive replica_id).
     server_name: String,
     /// Replica ID: hash(server_name) as u64.
@@ -463,9 +475,25 @@ impl MeshKV {
             stream_namespaces: RwLock::new(Vec::new()),
             subscriber_registry: Arc::new(SubscriberRegistry::new()),
             drain_registry: Arc::new(DrainRegistry::new()),
+            chunk_assembler: Arc::new(ChunkAssembler::new()),
             server_name,
             replica_id,
         }
+    }
+
+    /// Handle to the node-wide chunk reassembly buffer. Used by the
+    /// gossip receive path to route `StreamBatch` chunks through
+    /// reassembly before firing subscribers.
+    pub fn chunk_assembler(&self) -> Arc<ChunkAssembler> {
+        self.chunk_assembler.clone()
+    }
+
+    /// Fire subscribers whose prefix matches `key`. Used by the gossip
+    /// receive path when a chunked value completes (or a single-chunk
+    /// entry arrives), so handlers can deliver into adapter-owned
+    /// mpsc channels without reaching into internal registries.
+    pub fn notify_subscribers(&self, key: &str, value: Option<Bytes>) {
+        self.subscriber_registry.notify(key, value);
     }
 
     /// Derive replica_id from server_name using blake3 hash truncated to u64.

--- a/crates/mesh/src/kv.rs
+++ b/crates/mesh/src/kv.rs
@@ -424,7 +424,7 @@ impl StreamNamespace {
 // ============================================================================
 
 /// A batch of entries collected once per gossip round by the central collector.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct RoundBatch {
     /// Targeted stream entries: (peer_id, key, value). Sent to one specific peer.
     pub targeted_entries: Vec<(String, String, Bytes)>,

--- a/crates/mesh/src/lib.rs
+++ b/crates/mesh/src/lib.rs
@@ -7,6 +7,7 @@
 //! - Partition detection and recovery
 
 mod chunk_assembler;
+mod chunking;
 mod collector;
 mod consistent_hash;
 mod controller;

--- a/crates/mesh/src/ping_server.rs
+++ b/crates/mesh/src/ping_server.rs
@@ -1337,12 +1337,13 @@ impl Gossip for GossipService {
                                 }
                             }
                             StreamMessageType::StreamBatch => {
-                                if let (
-                                    Some(gossip::stream_message::Payload::StreamBatch(batch)),
-                                    Some(mesh_kv),
-                                ) = (&msg.payload, &mesh_kv)
-                                {
-                                    dispatch_stream_batch(mesh_kv, batch.entries.iter());
+                                if let Some(mesh_kv) = &mesh_kv {
+                                    if let Some(gossip::stream_message::Payload::StreamBatch(
+                                        batch,
+                                    )) = msg.payload
+                                    {
+                                        dispatch_stream_batch(mesh_kv, batch.entries);
+                                    }
                                 }
                             }
                             _ => {

--- a/crates/mesh/src/ping_server.rs
+++ b/crates/mesh/src/ping_server.rs
@@ -19,8 +19,8 @@ use tracing::instrument;
 
 use super::{
     chunking::{
-        build_stream_batches, chunk_value, dispatch_stream_batch, DEFAULT_MAX_CHUNKS_PER_BATCH,
-        MAX_STREAM_CHUNK_BYTES,
+        build_stream_batches, chunk_value, dispatch_stream_batch, next_generation,
+        DEFAULT_MAX_CHUNKS_PER_BATCH, MAX_STREAM_CHUNK_BYTES,
     },
     flow_control::{MessageSizeValidator, MAX_MESSAGE_SIZE},
     metrics::{
@@ -581,15 +581,13 @@ impl Gossip for GossipService {
                             .is_none_or(|last| !Arc::ptr_eq(last, &stream_batch));
                         if fresh_batch && !stream_batch.drain_entries.is_empty() {
                             last_stream_batch = Some(stream_batch.clone());
-                            let generation = std::time::SystemTime::now()
-                                .duration_since(std::time::UNIX_EPOCH)
-                                .map(|d| d.as_nanos() as u64)
-                                .unwrap_or(0);
                             let mut entries = Vec::new();
+                            // Generation is per-value so concurrent publishes
+                            // to the same key get distinct tags.
                             for (key, value) in &stream_batch.drain_entries {
                                 entries.extend(chunk_value(
                                     key.clone(),
-                                    generation,
+                                    next_generation(),
                                     Bytes::from(value.clone()),
                                     MAX_STREAM_CHUNK_BYTES,
                                 ));

--- a/crates/mesh/src/ping_server.rs
+++ b/crates/mesh/src/ping_server.rs
@@ -593,9 +593,11 @@ impl Gossip for GossipService {
                                 ));
                             }
                             if !entries.is_empty() {
-                                for batch in
-                                    build_stream_batches(entries, DEFAULT_MAX_CHUNKS_PER_BATCH)
-                                {
+                                for batch in build_stream_batches(
+                                    entries,
+                                    DEFAULT_MAX_CHUNKS_PER_BATCH,
+                                    MAX_STREAM_CHUNK_BYTES,
+                                ) {
                                     sequence_counter += 1;
                                     let msg = StreamMessage {
                                         message_type: StreamMessageType::StreamBatch as i32,

--- a/crates/mesh/src/ping_server.rs
+++ b/crates/mesh/src/ping_server.rs
@@ -1342,7 +1342,7 @@ impl Gossip for GossipService {
                                         batch,
                                     )) = msg.payload
                                     {
-                                        dispatch_stream_batch(mesh_kv, batch.entries);
+                                        dispatch_stream_batch(mesh_kv, &msg.peer_id, batch.entries);
                                     }
                                 }
                             }

--- a/crates/mesh/src/ping_server.rs
+++ b/crates/mesh/src/ping_server.rs
@@ -579,8 +579,14 @@ impl Gossip for GossipService {
                         let fresh_batch = last_stream_batch
                             .as_ref()
                             .is_none_or(|last| !Arc::ptr_eq(last, &stream_batch));
-                        if fresh_batch && !stream_batch.drain_entries.is_empty() {
+                        if fresh_batch {
+                            // Advance the tracker for every fresh Arc, not just
+                            // ones that produced work — otherwise a batch with
+                            // empty drain_entries stays "fresh" across ticks and
+                            // we keep re-checking it.
                             last_stream_batch = Some(stream_batch.clone());
+                        }
+                        if fresh_batch && !stream_batch.drain_entries.is_empty() {
                             let mut entries = Vec::new();
                             // Generation is per-value so concurrent publishes
                             // to the same key get distinct tags.

--- a/crates/mesh/src/ping_server.rs
+++ b/crates/mesh/src/ping_server.rs
@@ -1242,6 +1242,14 @@ impl Gossip for GossipService {
                                     break;
                                 }
                             }
+                            StreamMessageType::StreamBatch => {
+                                // Wiring lands in Step 3.5.
+                                log::trace!(
+                                    "Received StreamBatch from {} (seq: {}) — handler not yet wired",
+                                    peer_id,
+                                    msg.sequence
+                                );
+                            }
                             _ => {
                                 log::warn!(
                                     "Unknown message type from {}: {:?}",

--- a/crates/mesh/src/ping_server.rs
+++ b/crates/mesh/src/ping_server.rs
@@ -607,13 +607,22 @@ impl Gossip for GossipService {
                                         sequence: sequence_counter,
                                         peer_id: self_name_incremental.clone(),
                                     };
-                                    if let Err(e) = tx_incremental.try_send(Ok(msg)) {
-                                        log::debug!(
-                                            error = ?e,
-                                            "server-side stream batch dropped on backpressure"
-                                        );
-                                        // TODO(metrics): bump stream_dropped_on_backpressure
-                                        break;
+                                    match tx_incremental.try_send(Ok(msg)) {
+                                        Ok(()) => {}
+                                        Err(mpsc::error::TrySendError::Full(_)) => {
+                                            log::debug!(
+                                                "server-side stream batch dropped on backpressure"
+                                            );
+                                            // TODO(metrics): bump
+                                            // stream_dropped_on_backpressure
+                                            break;
+                                        }
+                                        Err(mpsc::error::TrySendError::Closed(_)) => {
+                                            log::warn!(
+                                                "server-side stream sender: channel closed, stopping"
+                                            );
+                                            return;
+                                        }
                                     }
                                 }
                             }

--- a/crates/mesh/src/ping_server.rs
+++ b/crates/mesh/src/ping_server.rs
@@ -20,6 +20,7 @@ use tracing::instrument;
 use super::{
     chunking::{
         build_stream_batches, chunk_value, dispatch_stream_batch, DEFAULT_MAX_CHUNKS_PER_ROUND,
+        MAX_STREAM_CHUNK_BYTES,
     },
     flow_control::{MessageSizeValidator, MAX_MESSAGE_SIZE},
     metrics::{
@@ -590,7 +591,7 @@ impl Gossip for GossipService {
                                     key.clone(),
                                     generation,
                                     Bytes::from(value.clone()),
-                                    MAX_MESSAGE_SIZE,
+                                    MAX_STREAM_CHUNK_BYTES,
                                 ));
                             }
                             if !entries.is_empty() {

--- a/crates/mesh/src/ping_server.rs
+++ b/crates/mesh/src/ping_server.rs
@@ -56,6 +56,10 @@ pub struct GossipService {
     /// the MeshController's central collector. Server-side sync_stream handlers
     /// read from this and apply per-peer watermark filtering.
     current_batch: Option<Arc<parking_lot::RwLock<Arc<RoundBatch>>>>,
+    /// Node-wide MeshKV handle. Owns the stream buffers, subscriber
+    /// registry, and chunk assembler shared with the client-side
+    /// SyncStream handlers.
+    mesh_kv: Option<Arc<crate::kv::MeshKV>>,
 }
 
 impl GossipService {
@@ -282,6 +286,7 @@ impl GossipService {
             partition_detector: None,
             mtls_manager: None,
             current_batch: None,
+            mesh_kv: None,
         }
     }
 
@@ -293,6 +298,15 @@ impl GossipService {
         current_batch: Arc<parking_lot::RwLock<Arc<RoundBatch>>>,
     ) -> Self {
         self.current_batch = Some(current_batch);
+        self
+    }
+
+    /// Attach the node-wide MeshKV handle. Plumbed from the server
+    /// builder so stream buffers, subscribers, and the chunk assembler
+    /// are shared between the client-side (outbound) and server-side
+    /// (inbound) SyncStream handlers.
+    pub fn with_mesh_kv(mut self, mesh_kv: Arc<crate::kv::MeshKV>) -> Self {
+        self.mesh_kv = Some(mesh_kv);
         self
     }
 
@@ -942,6 +956,7 @@ impl Gossip for GossipService {
                                         partition_detector: None,
                                         mtls_manager: None,
                                         current_batch: None,
+                                        mesh_kv: None,
                                     };
                                     let chunks = service.create_snapshot_chunks(store_type, 100); // chunk_size = 100 entries
                                     let total_chunks = chunks.len() as u64;

--- a/crates/mesh/src/ping_server.rs
+++ b/crates/mesh/src/ping_server.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 use anyhow::Result;
+use bytes::Bytes;
 use futures::Stream;
 use tokio::sync::mpsc;
 use tokio_stream::StreamExt;
@@ -17,6 +18,7 @@ use tracing as log;
 use tracing::instrument;
 
 use super::{
+    chunking::{build_stream_batches, chunk_value, DEFAULT_MAX_CHUNKS_PER_ROUND},
     flow_control::{MessageSizeValidator, MAX_MESSAGE_SIZE},
     metrics::{
         record_ack, record_batch_sent, record_nack, record_peer_reconnect, record_snapshot_bytes,
@@ -56,6 +58,11 @@ pub struct GossipService {
     /// the MeshController's central collector. Server-side sync_stream handlers
     /// read from this and apply per-peer watermark filtering.
     current_batch: Option<Arc<parking_lot::RwLock<Arc<RoundBatch>>>>,
+    /// Shared reference to the current stream RoundBatch, drained once
+    /// per round by the MeshController. Server-side handlers read
+    /// broadcast entries from this (drain_entries); targeted entries
+    /// are handled client-side where peer_name is known at spawn.
+    current_stream_batch: Option<Arc<parking_lot::RwLock<Arc<crate::kv::RoundBatch>>>>,
     /// Node-wide MeshKV handle. Owns the stream buffers, subscriber
     /// registry, and chunk assembler shared with the client-side
     /// SyncStream handlers.
@@ -286,6 +293,7 @@ impl GossipService {
             partition_detector: None,
             mtls_manager: None,
             current_batch: None,
+            current_stream_batch: None,
             mesh_kv: None,
         }
     }
@@ -298,6 +306,17 @@ impl GossipService {
         current_batch: Arc<parking_lot::RwLock<Arc<RoundBatch>>>,
     ) -> Self {
         self.current_batch = Some(current_batch);
+        self
+    }
+
+    /// Attach the shared stream RoundBatch reference. Server-side
+    /// handlers emit broadcast drain_entries to their peer — targeted
+    /// entries stay on the client side where peer_name is known.
+    pub fn with_current_stream_batch(
+        mut self,
+        current_stream_batch: Arc<parking_lot::RwLock<Arc<crate::kv::RoundBatch>>>,
+    ) -> Self {
+        self.current_stream_batch = Some(current_stream_batch);
         self
     }
 
@@ -467,6 +486,7 @@ impl Gossip for GossipService {
             // arrives. Use a placeholder label for debug output — this doesn't
             // affect filtering correctness (each task has its own watermark).
             let peer_name_for_watermark = "server-inbound".to_string();
+            let stream_batch_handle = self.current_stream_batch.clone();
             #[expect(
                 clippy::disallowed_methods,
                 reason = "server-side incremental sender that runs for the lifetime of the sync_stream; terminates when the channel closes or handle is aborted"
@@ -475,6 +495,7 @@ impl Gossip for GossipService {
                 let mut watermark = PeerWatermark::new(peer_name_for_watermark);
                 let mut interval = tokio::time::interval(Duration::from_secs(1));
                 let mut sequence_counter: u64 = 0;
+                let mut last_stream_batch: Option<Arc<crate::kv::RoundBatch>> = None;
 
                 loop {
                     interval.tick().await;
@@ -542,6 +563,60 @@ impl Gossip for GossipService {
                                 updates.len()
                             );
                         }
+                    }
+
+                    // Server-side stream emission: broadcast drain_entries
+                    // only. Targeted entries stay on the client-side
+                    // (controller.rs) where peer_name is known at task
+                    // spawn. At-most-once: on channel full, drop without
+                    // retry (spec §4.4).
+                    if let Some(sbh) = &stream_batch_handle {
+                        let stream_batch = sbh.read().clone();
+                        let fresh_batch = last_stream_batch
+                            .as_ref()
+                            .is_none_or(|last| !Arc::ptr_eq(last, &stream_batch));
+                        if fresh_batch && !stream_batch.drain_entries.is_empty() {
+                            last_stream_batch = Some(stream_batch.clone());
+                            let generation = std::time::SystemTime::now()
+                                .duration_since(std::time::UNIX_EPOCH)
+                                .map(|d| d.as_nanos() as u64)
+                                .unwrap_or(0);
+                            let mut entries = Vec::new();
+                            for (key, value) in &stream_batch.drain_entries {
+                                entries.extend(chunk_value(
+                                    key.clone(),
+                                    generation,
+                                    Bytes::from(value.clone()),
+                                    MAX_MESSAGE_SIZE,
+                                ));
+                            }
+                            if !entries.is_empty() {
+                                for batch in
+                                    build_stream_batches(entries, DEFAULT_MAX_CHUNKS_PER_ROUND)
+                                {
+                                    sequence_counter += 1;
+                                    let msg = StreamMessage {
+                                        message_type: StreamMessageType::StreamBatch as i32,
+                                        payload: Some(
+                                            gossip::stream_message::Payload::StreamBatch(batch),
+                                        ),
+                                        sequence: sequence_counter,
+                                        peer_id: self_name_incremental.clone(),
+                                    };
+                                    if let Err(e) = tx_incremental.try_send(Ok(msg)) {
+                                        log::debug!(
+                                            error = ?e,
+                                            "server-side stream batch dropped on backpressure"
+                                        );
+                                        // TODO(metrics): bump stream_dropped_on_backpressure
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                    } else if last_stream_batch.is_some() {
+                        // If handle became None (shouldn't normally), clear state.
+                        last_stream_batch = None;
                     }
                 }
             }))
@@ -956,6 +1031,7 @@ impl Gossip for GossipService {
                                         partition_detector: None,
                                         mtls_manager: None,
                                         current_batch: None,
+                                        current_stream_batch: None,
                                         mesh_kv: None,
                                     };
                                     let chunks = service.create_snapshot_chunks(store_type, 100); // chunk_size = 100 entries

--- a/crates/mesh/src/ping_server.rs
+++ b/crates/mesh/src/ping_server.rs
@@ -18,7 +18,9 @@ use tracing as log;
 use tracing::instrument;
 
 use super::{
-    chunking::{build_stream_batches, chunk_value, DEFAULT_MAX_CHUNKS_PER_ROUND},
+    chunking::{
+        build_stream_batches, chunk_value, dispatch_stream_batch, DEFAULT_MAX_CHUNKS_PER_ROUND,
+    },
     flow_control::{MessageSizeValidator, MAX_MESSAGE_SIZE},
     metrics::{
         record_ack, record_batch_sent, record_nack, record_peer_reconnect, record_snapshot_bytes,
@@ -468,6 +470,7 @@ impl Gossip for GossipService {
         let state = self.state.clone();
         let stores = self.stores.clone();
         let sync_manager = self.sync_manager.clone();
+        let mesh_kv = self.mesh_kv.clone();
 
         // Create output stream with flow control
         const CHANNEL_CAPACITY: usize = 128;
@@ -1334,12 +1337,13 @@ impl Gossip for GossipService {
                                 }
                             }
                             StreamMessageType::StreamBatch => {
-                                // Wiring lands in Step 3.5.
-                                log::trace!(
-                                    "Received StreamBatch from {} (seq: {}) — handler not yet wired",
-                                    peer_id,
-                                    msg.sequence
-                                );
+                                if let (
+                                    Some(gossip::stream_message::Payload::StreamBatch(batch)),
+                                    Some(mesh_kv),
+                                ) = (&msg.payload, &mesh_kv)
+                                {
+                                    dispatch_stream_batch(mesh_kv, batch.entries.iter());
+                                }
                             }
                             _ => {
                                 log::warn!(

--- a/crates/mesh/src/ping_server.rs
+++ b/crates/mesh/src/ping_server.rs
@@ -19,7 +19,7 @@ use tracing::instrument;
 
 use super::{
     chunking::{
-        build_stream_batches, chunk_value, dispatch_stream_batch, DEFAULT_MAX_CHUNKS_PER_ROUND,
+        build_stream_batches, chunk_value, dispatch_stream_batch, DEFAULT_MAX_CHUNKS_PER_BATCH,
         MAX_STREAM_CHUNK_BYTES,
     },
     flow_control::{MessageSizeValidator, MAX_MESSAGE_SIZE},
@@ -596,7 +596,7 @@ impl Gossip for GossipService {
                             }
                             if !entries.is_empty() {
                                 for batch in
-                                    build_stream_batches(entries, DEFAULT_MAX_CHUNKS_PER_ROUND)
+                                    build_stream_batches(entries, DEFAULT_MAX_CHUNKS_PER_BATCH)
                                 {
                                     sequence_counter += 1;
                                     let msg = StreamMessage {

--- a/crates/mesh/src/proto/gossip.proto
+++ b/crates/mesh/src/proto/gossip.proto
@@ -63,6 +63,7 @@ enum StreamMessageType {
   ACK = 4;
   NACK = 5;
   HEARTBEAT = 6;
+  STREAM_BATCH = 7;
 }
 
 message StreamMessage {

--- a/crates/mesh/src/service.rs
+++ b/crates/mesh/src/service.rs
@@ -457,6 +457,7 @@ impl MeshServer {
         // Share the controller's current_batch so server-side sync_stream
         // handlers use the same centrally collected data as client-side.
         service = service.with_current_batch(controller.current_batch());
+        service = service.with_current_stream_batch(controller.current_stream_batch());
 
         // Add mTLS support if configured
         if let Some(mtls_manager) = self.mtls_manager.clone() {

--- a/crates/mesh/src/service.rs
+++ b/crates/mesh/src/service.rs
@@ -321,6 +321,7 @@ impl MeshServerBuilder {
         ));
         // Initialize rate-limit hash ring with current membership
         sync_manager.update_rate_limit_membership();
+        let mesh_kv = Arc::new(crate::kv::MeshKV::new(self.self_name.clone()));
         (
             MeshServer {
                 state: self.state.clone(),
@@ -333,6 +334,7 @@ impl MeshServerBuilder {
                 signal_rx,
                 partition_detector: Some(partition_detector.clone()),
                 mtls_manager: self.mtls_manager.clone(),
+                mesh_kv,
             },
             MeshServerHandler {
                 state: self.state.clone(),
@@ -375,6 +377,8 @@ pub struct MeshServer {
     signal_rx: watch::Receiver<bool>,
     partition_detector: Option<Arc<PartitionDetector>>,
     mtls_manager: Option<Arc<MTLSManager>>,
+    /// Node-wide MeshKV handle shared by controller + ping_server.
+    mesh_kv: Arc<crate::kv::MeshKV>,
 }
 
 impl MeshServer {
@@ -385,6 +389,7 @@ impl MeshServer {
             self.advertise_addr,
             &self.self_name,
         )
+        .with_mesh_kv(self.mesh_kv.clone())
     }
 
     fn build_controller(&self) -> MeshController {
@@ -397,6 +402,7 @@ impl MeshServer {
             self.sync_manager.clone(),
             self.mtls_manager.clone(),
         )
+        .with_mesh_kv(self.mesh_kv.clone())
     }
 
     pub async fn start(self) -> Result<()> {

--- a/crates/mesh/src/service.rs
+++ b/crates/mesh/src/service.rs
@@ -61,6 +61,10 @@ pub struct MeshServerHandler {
     partition_detector: Option<Arc<PartitionDetector>>,
     state_machine: Option<Arc<NodeStateMachine>>,
     rate_limit_task_handle: std::sync::Mutex<Option<tokio::task::JoinHandle<()>>>,
+    /// Shared with the MeshServer so adapters can subscribe to stream
+    /// namespaces (broadcast/targeted) and publish values that reach
+    /// peers via the gossip loop.
+    mesh_kv: Arc<crate::kv::MeshKV>,
 }
 
 impl MeshServerHandler {
@@ -262,6 +266,13 @@ impl MeshServerHandler {
         // Merge operation log into our app store using CRDT merge
         self.stores.app.merge(log);
     }
+
+    /// Shared MeshKV handle — adapters subscribe to stream namespaces
+    /// and publish values through this. The handle is Arc-cloned, so
+    /// subscribers created here see the same events as the gossip loop.
+    pub fn mesh_kv(&self) -> &Arc<crate::kv::MeshKV> {
+        &self.mesh_kv
+    }
 }
 
 pub struct MeshServerBuilder {
@@ -334,7 +345,7 @@ impl MeshServerBuilder {
                 signal_rx,
                 partition_detector: Some(partition_detector.clone()),
                 mtls_manager: self.mtls_manager.clone(),
-                mesh_kv,
+                mesh_kv: mesh_kv.clone(),
             },
             MeshServerHandler {
                 state: self.state.clone(),
@@ -346,6 +357,7 @@ impl MeshServerBuilder {
                 partition_detector: Some(partition_detector),
                 state_machine: Some(state_machine),
                 rate_limit_task_handle: std::sync::Mutex::new(None),
+                mesh_kv,
             },
         )
     }


### PR DESCRIPTION
## Description

### Problem

PR #1173 landed Part 1 of Step 3: the self-contained `ChunkAssembler` (receiver-side reassembly algorithm), memory bounds, and `StreamEntry`/`StreamBatch` proto messages. Nothing was wired to the gossip loop yet — the assembler was dead code, the proto had a `StreamBatch` variant on `StreamMessage.payload` but no `StreamMessageType` discriminator, and no path existed for stream values to actually ride the bidirectional `SyncStream` between peers.

This PR wires it end-to-end: sender-side chunking, receiver-side routing, subscriber fan-out. After this merges, any value published through a `StreamNamespace` buffer or emitted via `register_drain` flows through the mesh to every connected peer's subscribers.

### Solution

Five focused commits:

1. **Extend `StreamMessageType`** with `STREAM_BATCH = 7` and add stub match arms in both `controller.rs` and `ping_server.rs`. Closes Codex P1 from PR #1173.
2. **Plumb `Arc<MeshKV>`** from `MeshServerBuilder` into both `MeshController` and `GossipService` via `with_mesh_kv()`. `ChunkAssembler` now lives on `MeshKV` alongside the subscriber registry — they travel together.
3. **`chunking.rs` helper module**: `chunk_value(key, generation, Bytes, max_chunk_bytes)` splits oversized values into `StreamEntry`s (single-chunk fast path for values ≤ 10 MB); `build_stream_batches` packs and caps at `max_chunks_per_round`. 12 unit tests covering split boundaries, empty/zero edge cases, tree-page invariant. `#[debug_assert]` catches any `tree:page:*` entry that would go multi-chunk (spec §4.1 invariant).
4. **Sender integration**: `MeshController` collects the stream round-batch alongside the CRDT batch once per second. Both sender tasks (controller.rs client-side, ping_server.rs server-side) read the shared `current_stream_batch`, chunk via `chunk_value`, and emit `StreamBatch` messages. Client-side handles both broadcast and targeted entries; server-side handles broadcast only (peer_name isn't known at server-task spawn). Generation is wall-clock nanoseconds (monotonic across restarts). At-most-once per §4.4: on channel full, the round's stream traffic is dropped — no NACK, no retry.
5. **Receiver integration + fragmented-buffer API**: new `dispatch_stream_batch` helper handles both fast-path (total_chunks=1) and chunked entries. Fires subscribers via `MeshKV::notify_subscribers`. Periodic chunk-assembler GC from the main event loop (every 5s, 30s timeout). Subscriber API changes to `Option<Vec<Bytes>>` so zero-copy fan-out survives all the way to adapter channels — closes the Codex-deferred "2× payload during assembly" concern from PR #1173 (receiver now peaks at P bytes, not 2P, because no contiguous concat happens).

## Changes

- `crates/mesh/src/proto/gossip.proto`: `StreamMessageType::STREAM_BATCH` variant.
- `crates/mesh/src/chunking.rs`: new module with `chunk_value`, `build_stream_batches`, `dispatch_stream_batch` + 12 unit tests.
- `crates/mesh/src/chunk_assembler.rs`: `assemble()` now returns `Vec<Bytes>` (zero-copy fragmented). `receive_chunk` signature updated. Dropped the `#![allow(dead_code)]`.
- `crates/mesh/src/kv.rs`: `Arc<ChunkAssembler>` field on `MeshKV`. `notify_subscribers(&str, Option<Vec<Bytes>>)` accessor. `SubscriptionEvent` / `SubscriberRegistry::notify` signatures updated to fragmented buffers. `CrdtNamespace::put` wraps single local writes in a 1-element Vec. `RoundBatch` derives `Default`. Manual `Debug` impl for `MeshKV`.
- `crates/mesh/src/controller.rs`: `current_stream_batch` field + accessor, per-round collection in event loop, per-peer sender emits `StreamBatch` (broadcast + targeted), receiver fills `StreamMessageType::StreamBatch` arm, periodic chunk-assembler GC.
- `crates/mesh/src/ping_server.rs`: `current_stream_batch` + `mesh_kv` fields, `with_current_stream_batch` / `with_mesh_kv` builders, server-side sender emits broadcast stream batches, receiver fills `StreamMessageType::StreamBatch` arm.
- `crates/mesh/src/service.rs`: creates `Arc<MeshKV>` in `build()` and plumbs into both controller and service.
- `crates/mesh/src/lib.rs`: `mod chunking`.

## Test Plan

Before this PR: stream values had no transport path; any `publish_to` or drain-callback output sat in in-memory buffers and never reached other nodes.

After this PR:

```
$ cargo test -p smg-mesh --lib
    test result: ok. 230 passed; 0 failed; 2 ignored

$ cargo clippy -p smg-mesh --all-targets --all-features -- -D warnings
    Finished dev [unoptimized + debuginfo]

$ cargo +nightly fmt
    (clean)
```

Coverage:
- **chunk_value**: single-chunk fast path, empty, even/uneven split boundaries, exact-boundary, one-byte-over, zero-max-panic, tree-page fast-path, tree-page debug-assert panic on multi-chunk.
- **build_stream_batches**: empty, under-cap, over-cap truncation.
- **ChunkAssembler** (now returning Vec<Bytes>): all prior tests updated with a flatten test-helper; 18 tests pass.
- **kv subscribe**: fragment-aware assertion on single-element Vec for local writes.

Integration tests for multi-node round-trip, partial-delivery timeout, concurrent generations, and multi-model concurrent assembly land in follow-up commits (Step 3.6 + 3.7) on a fresh branch after this merges — those touch `tests/comprehensive.rs` and don't overlap with the files changed here.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] (Optional) Documentation updated — inline module docs on chunking.rs; chunk_assembler.rs public contract note on fragmented return
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chunked streaming for large values with batch packing, dispatch, and automatic reassembly.
  * Controller/server now coordinate and emit stream batches during rounds; peers receive and apply batches, notifying subscribers only on full reassembly.

* **Refactor**
  * Subscription events and messaging use fragmented payloads (vectors of fragments) for delivery.
  * In-flight assemblies are tracked per-sender to isolate concurrent streams and avoid cross-peer collisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->