### PR TITLE
feat(skills): normalize skill bundle zip archives

### DIFF
--- a/crates/skills/Cargo.toml
+++ b/crates/skills/Cargo.toml
@@ -20,6 +20,7 @@ name = "smg_skills"
 serde = { workspace = true, features = ["derive"] }
 serde_yml = "0.0.12"
 thiserror.workspace = true
+zip = "8.1"
 
 [dev-dependencies]
 anyhow.workspace = true

--- a/crates/skills/src/lib.rs
+++ b/crates/skills/src/lib.rs
@@ -19,8 +19,11 @@ pub use config::{
     SkillsToolLoopConfig, SkillsZdrConfig,
 };
 pub use types::{
-    ParsedSkillBundle, SkillDependencyTool, SkillFileRecord, SkillInterfaceMetadata,
-    SkillParseWarning, SkillParseWarningKind, SkillPolicyMetadata, SkillRecord,
-    SkillSidecarDependencies, SkillVersionRecord,
+    NormalizedSkillBundle, NormalizedSkillFile, ParsedSkillBundle, SkillDependencyTool,
+    SkillFileRecord, SkillInterfaceMetadata, SkillParseWarning, SkillParseWarningKind,
+    SkillPolicyMetadata, SkillRecord, SkillSidecarDependencies, SkillVersionRecord,
 };
-pub use validation::{parse_skill_bundle, SkillParseError};
+pub use validation::{
+    is_code_file_path, normalize_skill_bundle_zip, parse_skill_bundle, SkillBundleArchiveError,
+    SkillParseError,
+};

--- a/crates/skills/src/types.rs
+++ b/crates/skills/src/types.rs
@@ -23,6 +23,35 @@ pub struct SkillFileRecord {
     pub size_bytes: u64,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NormalizedSkillBundle {
+    pub files: Vec<NormalizedSkillFile>,
+    pub skill_md_path: String,
+    pub openai_sidecar_path: Option<String>,
+    pub has_code_files: bool,
+}
+
+impl NormalizedSkillBundle {
+    #[must_use]
+    pub fn file_manifest(&self) -> Vec<SkillFileRecord> {
+        self.files
+            .iter()
+            .map(|file| SkillFileRecord {
+                relative_path: file.relative_path.clone(),
+                media_type: None,
+                size_bytes: file.size_bytes,
+            })
+            .collect()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NormalizedSkillFile {
+    pub relative_path: String,
+    pub contents: Vec<u8>,
+    pub size_bytes: u64,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ParsedSkillBundle {
     pub name: String,

--- a/crates/skills/src/types.rs
+++ b/crates/skills/src/types.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+/// Top-level skill metadata stored in the control-plane database.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SkillRecord {
     pub tenant_id: String,
@@ -8,6 +9,7 @@ pub struct SkillRecord {
     pub default_version: Option<String>,
 }
 
+/// Metadata for a single immutable skill version.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SkillVersionRecord {
     pub skill_id: String,
@@ -16,6 +18,7 @@ pub struct SkillVersionRecord {
     pub has_code_files: bool,
 }
 
+/// File-level manifest entry stored alongside a normalized skill bundle.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SkillFileRecord {
     pub relative_path: String,
@@ -23,6 +26,7 @@ pub struct SkillFileRecord {
     pub size_bytes: u64,
 }
 
+/// Canonical in-memory representation of a validated skill bundle.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NormalizedSkillBundle {
     pub files: Vec<NormalizedSkillFile>,
@@ -32,6 +36,7 @@ pub struct NormalizedSkillBundle {
 }
 
 impl NormalizedSkillBundle {
+    /// Project the in-memory bundle into a stable file manifest.
     #[must_use]
     pub fn file_manifest(&self) -> Vec<SkillFileRecord> {
         self.files
@@ -39,19 +44,28 @@ impl NormalizedSkillBundle {
             .map(|file| SkillFileRecord {
                 relative_path: file.relative_path.clone(),
                 media_type: None,
-                size_bytes: file.size_bytes,
+                size_bytes: file.size_bytes(),
             })
             .collect()
     }
 }
 
+/// Canonical skill-bundle file with a skill-root-relative path.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NormalizedSkillFile {
     pub relative_path: String,
     pub contents: Vec<u8>,
-    pub size_bytes: u64,
 }
 
+impl NormalizedSkillFile {
+    /// Return the canonical uncompressed size of this file in bytes.
+    #[must_use]
+    pub fn size_bytes(&self) -> u64 {
+        self.contents.len() as u64
+    }
+}
+
+/// Parsed `SKILL.md` plus any successfully recovered OpenAI sidecar metadata.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ParsedSkillBundle {
     pub name: String,
@@ -64,6 +78,7 @@ pub struct ParsedSkillBundle {
     pub warnings: Vec<SkillParseWarning>,
 }
 
+/// Optional interface metadata sourced from `agents/openai.yaml`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct SkillInterfaceMetadata {
     pub display_name: Option<String>,
@@ -75,6 +90,7 @@ pub struct SkillInterfaceMetadata {
 }
 
 impl SkillInterfaceMetadata {
+    /// Return whether this interface block contains any usable fields.
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.display_name.is_none()
@@ -86,18 +102,21 @@ impl SkillInterfaceMetadata {
     }
 }
 
+/// Optional dependency metadata sourced from `agents/openai.yaml`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct SkillSidecarDependencies {
     pub tools: Vec<SkillDependencyTool>,
 }
 
 impl SkillSidecarDependencies {
+    /// Return whether the dependencies block contains any tool declarations.
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.tools.is_empty()
     }
 }
 
+/// A single dependency tool declaration from `agents/openai.yaml`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SkillDependencyTool {
     pub tool_type: String,
@@ -108,6 +127,7 @@ pub struct SkillDependencyTool {
     pub url: Option<String>,
 }
 
+/// Optional invocation-policy metadata sourced from `agents/openai.yaml`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct SkillPolicyMetadata {
     pub allow_implicit_invocation: Option<bool>,
@@ -115,12 +135,14 @@ pub struct SkillPolicyMetadata {
 }
 
 impl SkillPolicyMetadata {
+    /// Return whether the policy block contains any usable settings.
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.allow_implicit_invocation.is_none() && self.products.is_empty()
     }
 }
 
+/// Warning produced while salvaging optional sidecar metadata.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SkillParseWarning {
     pub kind: SkillParseWarningKind,
@@ -128,6 +150,7 @@ pub struct SkillParseWarning {
     pub message: String,
 }
 
+/// Kinds of non-fatal sidecar parsing warnings.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum SkillParseWarningKind {
     SidecarFileIgnored,

--- a/crates/skills/src/validation.rs
+++ b/crates/skills/src/validation.rs
@@ -19,7 +19,10 @@ const MAX_NAME_LEN: usize = 64;
 const MAX_DISPLAY_NAME_LEN: usize = 64;
 const MAX_DESCRIPTION_LEN: usize = 1024;
 const MAX_SIDECAR_STRING_LEN: usize = 1024;
+const MAX_BUNDLE_ARCHIVE_ENTRY_COUNT: usize = 1024;
 const MAX_BUNDLE_FILE_COUNT: usize = 500;
+const MAX_BUNDLE_FILE_SIZE_BYTES: u64 = 25 * 1024 * 1024;
+const MAX_BUNDLE_TOTAL_SIZE_BYTES: u64 = 30 * 1024 * 1024;
 const RESERVED_SKILL_NAMES: [&str; 3] = ["anthropic", "claude", "openai"];
 const SKILL_MD_PATH: &str = "SKILL.md";
 const OPENAI_SIDECAR_PATH: &str = "agents/openai.yaml";
@@ -37,6 +40,7 @@ const NON_CODE_FILE_EXTENSIONS: &[&str] = &[
 const CODE_FILE_BASENAMES: &[&str] = &["Dockerfile", "Makefile"];
 const CODE_FILE_PREFIXES: &[&str] = &["run.", "main.", "exec."];
 
+/// Errors returned while parsing `SKILL.md` and its optional OpenAI sidecar.
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum SkillParseError {
     #[error("SKILL.md must begin with a YAML frontmatter block delimited by --- lines")]
@@ -54,6 +58,8 @@ pub enum SkillParseError {
     },
 }
 
+/// Errors returned while validating and normalizing uploaded skill-bundle zip
+/// archives.
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum SkillBundleArchiveError {
     #[error("skill bundle zip archive is invalid: {message}")]
@@ -66,8 +72,16 @@ pub enum SkillBundleArchiveError {
     DuplicateNormalizedPath { path: String },
     #[error("skill bundle contains unsupported entry type `{entry_type}` at `{path}`")]
     UnsupportedEntryType { path: String, entry_type: String },
+    #[error("skill bundle contains more than {max_entries} archive entries")]
+    TooManyEntries { max_entries: usize },
     #[error("skill bundle contains more than {max_files} regular files")]
     TooManyFiles { max_files: usize },
+    #[error(
+        "skill bundle entry `{path}` exceeds the maximum uncompressed size of {max_bytes} bytes"
+    )]
+    EntryTooLarge { path: String, max_bytes: u64 },
+    #[error("skill bundle exceeds the maximum total uncompressed size of {max_bytes} bytes")]
+    BundleTooLarge { max_bytes: u64 },
     #[error("skill bundle must contain exactly one root-level SKILL.md file")]
     MissingSkillMd,
     #[error("skill bundle contains multiple root-level SKILL.md files: `{first}` and `{second}`")]
@@ -90,6 +104,10 @@ struct SkillFrontmatterMetadata {
     short_description: Option<String>,
 }
 
+/// Parse a root-level `SKILL.md` plus optional `agents/openai.yaml` sidecar.
+///
+/// The sidecar is fail-open: invalid sidecar content is ignored and surfaced as
+/// warnings instead of making the entire bundle invalid.
 pub fn parse_skill_bundle(
     skill_md: &str,
     openai_yaml: Option<&str>,
@@ -128,6 +146,11 @@ pub fn parse_skill_bundle(
     })
 }
 
+/// Normalize an uploaded skill-bundle zip archive into skill-root-relative files.
+///
+/// This strips the single required top-level directory, rejects unsafe entries,
+/// and produces the canonical manifest shape used by later storage and upload
+/// steps.
 pub fn normalize_skill_bundle_zip(
     zip_bytes: &[u8],
 ) -> Result<NormalizedSkillBundle, SkillBundleArchiveError> {
@@ -136,15 +159,21 @@ pub fn normalize_skill_bundle_zip(
             message: error.to_string(),
         }
     })?;
+    if archive.len() > MAX_BUNDLE_ARCHIVE_ENTRY_COUNT {
+        return Err(SkillBundleArchiveError::TooManyEntries {
+            max_entries: MAX_BUNDLE_ARCHIVE_ENTRY_COUNT,
+        });
+    }
 
     let mut top_level_dir: Option<String> = None;
     let mut seen_relative_paths = HashSet::new();
     let mut files = Vec::new();
     let mut skill_md_path: Option<String> = None;
     let mut openai_sidecar_path = None;
+    let mut total_uncompressed_size_bytes: u64 = 0;
 
     for index in 0..archive.len() {
-        let mut entry =
+        let entry =
             archive
                 .by_index(index)
                 .map_err(|error| SkillBundleArchiveError::InvalidZip {
@@ -199,14 +228,56 @@ pub fn normalize_skill_bundle_zip(
                     });
                 }
 
-                let size_bytes = entry.size();
+                let advertised_size_bytes = entry.size();
+                if advertised_size_bytes > MAX_BUNDLE_FILE_SIZE_BYTES {
+                    return Err(SkillBundleArchiveError::EntryTooLarge {
+                        path: relative_path,
+                        max_bytes: MAX_BUNDLE_FILE_SIZE_BYTES,
+                    });
+                }
+
+                let remaining_bundle_bytes = MAX_BUNDLE_TOTAL_SIZE_BYTES
+                    .checked_sub(total_uncompressed_size_bytes)
+                    .ok_or(SkillBundleArchiveError::BundleTooLarge {
+                        max_bytes: MAX_BUNDLE_TOTAL_SIZE_BYTES,
+                    })?;
+                if advertised_size_bytes > remaining_bundle_bytes {
+                    return Err(SkillBundleArchiveError::BundleTooLarge {
+                        max_bytes: MAX_BUNDLE_TOTAL_SIZE_BYTES,
+                    });
+                }
+
+                let max_read_bytes = remaining_bundle_bytes.min(MAX_BUNDLE_FILE_SIZE_BYTES);
                 let mut contents = Vec::new();
-                entry.read_to_end(&mut contents).map_err(|error| {
+                let mut limited_entry = entry.take(max_read_bytes + 1);
+                limited_entry.read_to_end(&mut contents).map_err(|error| {
                     SkillBundleArchiveError::ReadEntry {
                         path: relative_path.clone(),
                         message: error.to_string(),
                     }
                 })?;
+                let actual_size_bytes = u64::try_from(contents.len()).map_err(|_| {
+                    SkillBundleArchiveError::ReadEntry {
+                        path: relative_path.clone(),
+                        message: "decompressed entry size overflowed u64".to_owned(),
+                    }
+                })?;
+                if actual_size_bytes > MAX_BUNDLE_FILE_SIZE_BYTES {
+                    return Err(SkillBundleArchiveError::EntryTooLarge {
+                        path: relative_path,
+                        max_bytes: MAX_BUNDLE_FILE_SIZE_BYTES,
+                    });
+                }
+                total_uncompressed_size_bytes = total_uncompressed_size_bytes
+                    .checked_add(actual_size_bytes)
+                    .ok_or(SkillBundleArchiveError::BundleTooLarge {
+                        max_bytes: MAX_BUNDLE_TOTAL_SIZE_BYTES,
+                    })?;
+                if total_uncompressed_size_bytes > MAX_BUNDLE_TOTAL_SIZE_BYTES {
+                    return Err(SkillBundleArchiveError::BundleTooLarge {
+                        max_bytes: MAX_BUNDLE_TOTAL_SIZE_BYTES,
+                    });
+                }
 
                 if relative_path.eq_ignore_ascii_case(SKILL_MD_PATH) {
                     if let Some(existing) = &skill_md_path {
@@ -218,14 +289,13 @@ pub fn normalize_skill_bundle_zip(
                     skill_md_path = Some(relative_path.clone());
                 }
 
-                if relative_path == OPENAI_SIDECAR_PATH {
+                if relative_path.eq_ignore_ascii_case(OPENAI_SIDECAR_PATH) {
                     openai_sidecar_path = Some(relative_path.clone());
                 }
 
                 files.push(NormalizedSkillFile {
                     relative_path,
                     contents,
-                    size_bytes,
                 });
             }
         }
@@ -245,6 +315,12 @@ pub fn normalize_skill_bundle_zip(
     })
 }
 
+/// Deterministically classify whether a bundle file should count as code for
+/// `has_code_files`.
+///
+/// This intentionally errs on the side of false positives: basename matches for
+/// `run.*`, `main.*`, and `exec.*` win even if the extension would otherwise be
+/// considered non-code.
 pub fn is_code_file_path(path: &str) -> bool {
     let basename = path.rsplit('/').next().unwrap_or(path);
     if CODE_FILE_BASENAMES

--- a/crates/skills/src/validation.rs
+++ b/crates/skills/src/validation.rs
@@ -1,19 +1,41 @@
-use std::fmt::Write as _;
+use std::{
+    collections::HashSet,
+    fmt::Write as _,
+    io::{Cursor, Read},
+};
 
 use serde::Deserialize;
 use serde_yml::{Mapping, Value};
 use thiserror::Error;
+use zip::ZipArchive;
 
 use crate::types::{
-    ParsedSkillBundle, SkillDependencyTool, SkillInterfaceMetadata, SkillParseWarning,
-    SkillParseWarningKind, SkillPolicyMetadata, SkillSidecarDependencies,
+    NormalizedSkillBundle, NormalizedSkillFile, ParsedSkillBundle, SkillDependencyTool,
+    SkillInterfaceMetadata, SkillParseWarning, SkillParseWarningKind, SkillPolicyMetadata,
+    SkillSidecarDependencies,
 };
 
 const MAX_NAME_LEN: usize = 64;
 const MAX_DISPLAY_NAME_LEN: usize = 64;
 const MAX_DESCRIPTION_LEN: usize = 1024;
 const MAX_SIDECAR_STRING_LEN: usize = 1024;
+const MAX_BUNDLE_FILE_COUNT: usize = 500;
 const RESERVED_SKILL_NAMES: [&str; 3] = ["anthropic", "claude", "openai"];
+const SKILL_MD_PATH: &str = "SKILL.md";
+const OPENAI_SIDECAR_PATH: &str = "agents/openai.yaml";
+const UNIX_FILE_TYPE_MASK: u32 = 0o170000;
+const UNIX_FILE_TYPE_DIRECTORY: u32 = 0o040000;
+const UNIX_FILE_TYPE_REGULAR: u32 = 0o100000;
+const CODE_FILE_EXTENSIONS: &[&str] = &[
+    "py", "sh", "bash", "zsh", "js", "mjs", "cjs", "ts", "mts", "cts", "rb", "lua", "pl", "php",
+    "wasm", "r", "jl", "scala", "go", "rs",
+];
+const NON_CODE_FILE_EXTENSIONS: &[&str] = &[
+    "md", "txt", "csv", "json", "yaml", "yml", "toml", "xml", "html", "css", "png", "jpg", "jpeg",
+    "gif", "webp", "svg", "ico", "bmp", "tiff", "ttf", "otf", "woff", "woff2",
+];
+const CODE_FILE_BASENAMES: &[&str] = &["Dockerfile", "Makefile"];
+const CODE_FILE_PREFIXES: &[&str] = &["run.", "main.", "exec."];
 
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum SkillParseError {
@@ -30,6 +52,28 @@ pub enum SkillParseError {
         field: &'static str,
         message: String,
     },
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum SkillBundleArchiveError {
+    #[error("skill bundle zip archive is invalid: {message}")]
+    InvalidZip { message: String },
+    #[error("skill bundle path `{path}` is invalid: {message}")]
+    InvalidPath { path: String, message: String },
+    #[error("skill bundle has multiple top-level directories: `{first}` and `{second}`")]
+    MultipleTopLevelDirectories { first: String, second: String },
+    #[error("skill bundle contains duplicate normalized path `{path}`")]
+    DuplicateNormalizedPath { path: String },
+    #[error("skill bundle contains unsupported entry type `{entry_type}` at `{path}`")]
+    UnsupportedEntryType { path: String, entry_type: String },
+    #[error("skill bundle contains more than {max_files} regular files")]
+    TooManyFiles { max_files: usize },
+    #[error("skill bundle must contain exactly one root-level SKILL.md file")]
+    MissingSkillMd,
+    #[error("skill bundle contains multiple root-level SKILL.md files: `{first}` and `{second}`")]
+    MultipleSkillMd { first: String, second: String },
+    #[error("failed to read skill bundle entry `{path}`: {message}")]
+    ReadEntry { path: String, message: String },
 }
 
 #[derive(Debug, Deserialize)]
@@ -82,6 +126,298 @@ pub fn parse_skill_bundle(
         policy: sidecar.policy,
         warnings,
     })
+}
+
+pub fn normalize_skill_bundle_zip(
+    zip_bytes: &[u8],
+) -> Result<NormalizedSkillBundle, SkillBundleArchiveError> {
+    let mut archive = ZipArchive::new(Cursor::new(zip_bytes)).map_err(|error| {
+        SkillBundleArchiveError::InvalidZip {
+            message: error.to_string(),
+        }
+    })?;
+
+    let mut top_level_dir: Option<String> = None;
+    let mut seen_relative_paths = HashSet::new();
+    let mut files = Vec::new();
+    let mut skill_md_path: Option<String> = None;
+    let mut openai_sidecar_path = None;
+
+    for index in 0..archive.len() {
+        let mut entry =
+            archive
+                .by_index(index)
+                .map_err(|error| SkillBundleArchiveError::InvalidZip {
+                    message: format!("failed to read zip entry {index}: {error}"),
+                })?;
+
+        let original_path = entry.name().to_owned();
+        let normalized_segments = normalize_zip_entry_path(entry.name_raw(), &original_path)?;
+        if normalized_segments.is_empty() {
+            continue;
+        }
+
+        let current_top_level = normalized_segments[0].clone();
+        match &top_level_dir {
+            Some(existing) if existing != &current_top_level => {
+                return Err(SkillBundleArchiveError::MultipleTopLevelDirectories {
+                    first: existing.clone(),
+                    second: current_top_level,
+                });
+            }
+            None => top_level_dir = Some(current_top_level),
+            Some(_) => {}
+        }
+
+        let entry_type = classify_zip_entry_type(&entry, &original_path)?;
+        let relative_segments = &normalized_segments[1..];
+        if relative_segments.is_empty() {
+            if matches!(entry_type, ZipEntryType::Directory) {
+                continue;
+            }
+            return Err(SkillBundleArchiveError::InvalidPath {
+                path: original_path,
+                message: "archive entries must live under a single top-level directory".to_owned(),
+            });
+        }
+
+        let relative_path = relative_segments.join("/");
+        validate_special_bundle_paths(&relative_path)?;
+
+        if !seen_relative_paths.insert(relative_path.clone()) {
+            return Err(SkillBundleArchiveError::DuplicateNormalizedPath {
+                path: relative_path,
+            });
+        }
+
+        match entry_type {
+            ZipEntryType::Directory => continue,
+            ZipEntryType::RegularFile => {
+                if files.len() >= MAX_BUNDLE_FILE_COUNT {
+                    return Err(SkillBundleArchiveError::TooManyFiles {
+                        max_files: MAX_BUNDLE_FILE_COUNT,
+                    });
+                }
+
+                let size_bytes = entry.size();
+                let mut contents = Vec::new();
+                entry.read_to_end(&mut contents).map_err(|error| {
+                    SkillBundleArchiveError::ReadEntry {
+                        path: relative_path.clone(),
+                        message: error.to_string(),
+                    }
+                })?;
+
+                if relative_path.eq_ignore_ascii_case(SKILL_MD_PATH) {
+                    if let Some(existing) = &skill_md_path {
+                        return Err(SkillBundleArchiveError::MultipleSkillMd {
+                            first: existing.clone(),
+                            second: relative_path.clone(),
+                        });
+                    }
+                    skill_md_path = Some(relative_path.clone());
+                }
+
+                if relative_path == OPENAI_SIDECAR_PATH {
+                    openai_sidecar_path = Some(relative_path.clone());
+                }
+
+                files.push(NormalizedSkillFile {
+                    relative_path,
+                    contents,
+                    size_bytes,
+                });
+            }
+        }
+    }
+
+    let skill_md_path = skill_md_path.ok_or(SkillBundleArchiveError::MissingSkillMd)?;
+    files.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
+    let has_code_files = files
+        .iter()
+        .any(|file| is_code_file_path(&file.relative_path));
+
+    Ok(NormalizedSkillBundle {
+        files,
+        skill_md_path,
+        openai_sidecar_path,
+        has_code_files,
+    })
+}
+
+pub fn is_code_file_path(path: &str) -> bool {
+    let basename = path.rsplit('/').next().unwrap_or(path);
+    if CODE_FILE_BASENAMES
+        .iter()
+        .any(|candidate| basename.eq_ignore_ascii_case(candidate))
+        || CODE_FILE_PREFIXES.iter().any(|prefix| {
+            basename.len() > prefix.len()
+                && basename
+                    .get(..prefix.len())
+                    .is_some_and(|candidate| candidate.eq_ignore_ascii_case(prefix))
+        })
+    {
+        return true;
+    }
+
+    let Some((_, extension)) = basename.rsplit_once('.') else {
+        return false;
+    };
+
+    if NON_CODE_FILE_EXTENSIONS
+        .iter()
+        .any(|candidate| extension.eq_ignore_ascii_case(candidate))
+    {
+        return false;
+    }
+
+    CODE_FILE_EXTENSIONS
+        .iter()
+        .any(|candidate| extension.eq_ignore_ascii_case(candidate))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ZipEntryType {
+    Directory,
+    RegularFile,
+}
+
+fn normalize_zip_entry_path(
+    raw_name: &[u8],
+    display_name: &str,
+) -> Result<Vec<String>, SkillBundleArchiveError> {
+    if raw_name.contains(&0) {
+        return Err(SkillBundleArchiveError::InvalidPath {
+            path: display_name.to_owned(),
+            message: "must not contain NUL bytes".to_owned(),
+        });
+    }
+
+    let normalized_name = display_name.replace('\\', "/");
+    if normalized_name.starts_with('/') {
+        return Err(SkillBundleArchiveError::InvalidPath {
+            path: display_name.to_owned(),
+            message: "must not be absolute".to_owned(),
+        });
+    }
+
+    let segments = normalized_name.split('/').collect::<Vec<_>>();
+    let trailing_empty_segments = segments
+        .iter()
+        .rev()
+        .take_while(|segment| segment.is_empty())
+        .count();
+    if trailing_empty_segments > 1 {
+        return Err(SkillBundleArchiveError::InvalidPath {
+            path: display_name.to_owned(),
+            message: "must not contain empty path segments".to_owned(),
+        });
+    }
+
+    let meaningful_len = segments.len().saturating_sub(trailing_empty_segments);
+    if meaningful_len == 0 {
+        return Ok(Vec::new());
+    }
+
+    let mut normalized_segments = Vec::with_capacity(meaningful_len);
+    for segment in &segments[..meaningful_len] {
+        match *segment {
+            "" => {
+                return Err(SkillBundleArchiveError::InvalidPath {
+                    path: display_name.to_owned(),
+                    message: "must not contain empty path segments".to_owned(),
+                });
+            }
+            "." => continue,
+            ".." => {
+                return Err(SkillBundleArchiveError::InvalidPath {
+                    path: display_name.to_owned(),
+                    message: "must not contain path traversal".to_owned(),
+                });
+            }
+            _ if is_windows_drive_prefix(segment) => {
+                return Err(SkillBundleArchiveError::InvalidPath {
+                    path: display_name.to_owned(),
+                    message: "must not be absolute".to_owned(),
+                });
+            }
+            _ => normalized_segments.push((*segment).to_owned()),
+        }
+    }
+
+    if normalized_segments.is_empty() {
+        return Err(SkillBundleArchiveError::InvalidPath {
+            path: display_name.to_owned(),
+            message: "must not resolve to an empty path".to_owned(),
+        });
+    }
+
+    Ok(normalized_segments)
+}
+
+fn classify_zip_entry_type<R: Read + ?Sized>(
+    entry: &zip::read::ZipFile<'_, R>,
+    original_path: &str,
+) -> Result<ZipEntryType, SkillBundleArchiveError> {
+    if entry.is_dir() {
+        return Ok(ZipEntryType::Directory);
+    }
+    if entry.is_symlink() {
+        return Err(SkillBundleArchiveError::UnsupportedEntryType {
+            path: original_path.to_owned(),
+            entry_type: "symbolic link".to_owned(),
+        });
+    }
+    if let Some(mode) = entry.unix_mode() {
+        match mode & UNIX_FILE_TYPE_MASK {
+            0 => {}
+            UNIX_FILE_TYPE_DIRECTORY => return Ok(ZipEntryType::Directory),
+            UNIX_FILE_TYPE_REGULAR => {}
+            file_type => {
+                return Err(SkillBundleArchiveError::UnsupportedEntryType {
+                    path: original_path.to_owned(),
+                    entry_type: describe_unix_file_type(file_type).to_owned(),
+                });
+            }
+        }
+    }
+    if entry.is_file() {
+        return Ok(ZipEntryType::RegularFile);
+    }
+
+    Err(SkillBundleArchiveError::UnsupportedEntryType {
+        path: original_path.to_owned(),
+        entry_type: "non-regular file".to_owned(),
+    })
+}
+
+fn validate_special_bundle_paths(relative_path: &str) -> Result<(), SkillBundleArchiveError> {
+    let basename = relative_path.rsplit('/').next().unwrap_or(relative_path);
+    if basename.eq_ignore_ascii_case(SKILL_MD_PATH)
+        && !relative_path.eq_ignore_ascii_case(SKILL_MD_PATH)
+    {
+        return Err(SkillBundleArchiveError::InvalidPath {
+            path: relative_path.to_owned(),
+            message: "SKILL.md must live at the skill root".to_owned(),
+        });
+    }
+    Ok(())
+}
+
+fn is_windows_drive_prefix(segment: &str) -> bool {
+    segment.len() == 2
+        && segment.as_bytes()[0].is_ascii_alphabetic()
+        && segment.as_bytes()[1] == b':'
+}
+
+fn describe_unix_file_type(file_type: u32) -> &'static str {
+    match file_type {
+        0o020000 => "character device",
+        0o060000 => "block device",
+        0o010000 => "named pipe",
+        0o140000 => "socket",
+        _ => "non-regular file",
+    }
 }
 
 fn split_frontmatter(skill_md: &str) -> Result<(&str, &str), SkillParseError> {

--- a/crates/skills/src/validation.rs
+++ b/crates/skills/src/validation.rs
@@ -167,6 +167,7 @@ pub fn normalize_skill_bundle_zip(
 
     let mut top_level_dir: Option<String> = None;
     let mut seen_relative_paths = HashSet::new();
+    let mut seen_folded_relative_paths = HashSet::new();
     let mut files = Vec::new();
     let mut skill_md_path: Option<String> = None;
     let mut openai_sidecar_path = None;
@@ -212,8 +213,22 @@ pub fn normalize_skill_bundle_zip(
 
         let relative_path = relative_segments.join("/");
         validate_special_bundle_paths(&relative_path)?;
+        let is_skill_md = relative_path.eq_ignore_ascii_case(SKILL_MD_PATH);
 
         if !seen_relative_paths.insert(relative_path.clone()) {
+            return Err(SkillBundleArchiveError::DuplicateNormalizedPath {
+                path: relative_path,
+            });
+        }
+        if !seen_folded_relative_paths.insert(relative_path.to_ascii_lowercase()) {
+            if is_skill_md {
+                if let Some(existing) = &skill_md_path {
+                    return Err(SkillBundleArchiveError::MultipleSkillMd {
+                        first: existing.clone(),
+                        second: relative_path,
+                    });
+                }
+            }
             return Err(SkillBundleArchiveError::DuplicateNormalizedPath {
                 path: relative_path,
             });
@@ -279,7 +294,7 @@ pub fn normalize_skill_bundle_zip(
                     });
                 }
 
-                if relative_path.eq_ignore_ascii_case(SKILL_MD_PATH) {
+                if is_skill_md {
                     if let Some(existing) = &skill_md_path {
                         return Err(SkillBundleArchiveError::MultipleSkillMd {
                             first: existing.clone(),

--- a/crates/skills/tests/skill_bundle_normalization.rs
+++ b/crates/skills/tests/skill_bundle_normalization.rs
@@ -254,6 +254,35 @@ fn rejects_duplicate_normalized_paths() {
 }
 
 #[test]
+fn rejects_case_only_duplicate_normalized_paths() {
+    let error = normalize(&[
+        TestZipEntry::File {
+            path: "gh-fix-ci/SKILL.md",
+            contents: b"skill body",
+            unix_mode: Some(0o100644),
+        },
+        TestZipEntry::File {
+            path: "gh-fix-ci/scripts/Run.py",
+            contents: b"print('one')",
+            unix_mode: Some(0o100755),
+        },
+        TestZipEntry::File {
+            path: "gh-fix-ci/scripts/run.py",
+            contents: b"print('two')",
+            unix_mode: Some(0o100755),
+        },
+    ])
+    .expect_err("case-only duplicate normalized path must fail");
+
+    assert_eq!(
+        error,
+        SkillBundleArchiveError::DuplicateNormalizedPath {
+            path: "scripts/run.py".to_owned(),
+        }
+    );
+}
+
+#[test]
 fn rejects_symlinks() {
     let symlink = normalize(&[
         TestZipEntry::File {

--- a/crates/skills/tests/skill_bundle_normalization.rs
+++ b/crates/skills/tests/skill_bundle_normalization.rs
@@ -129,6 +129,28 @@ fn normalizes_zip_paths_to_skill_root_manifest() -> Result<()> {
 }
 
 #[test]
+fn recognizes_openai_sidecar_case_insensitively() -> Result<()> {
+    let normalized = normalize(&[
+        TestZipEntry::File {
+            path: "gh-fix-ci/SKILL.md",
+            contents: b"skill body",
+            unix_mode: Some(0o100644),
+        },
+        TestZipEntry::File {
+            path: "gh-fix-ci/agents/OpenAI.YAML",
+            contents: b"interface: {}",
+            unix_mode: Some(0o100644),
+        },
+    ])?;
+
+    assert_eq!(
+        normalized.openai_sidecar_path.as_deref(),
+        Some("agents/OpenAI.YAML")
+    );
+    Ok(())
+}
+
+#[test]
 fn rejects_archives_without_a_single_top_level_directory() {
     let error = normalize(&[
         TestZipEntry::File {
@@ -311,16 +333,18 @@ fn rejects_archives_without_root_level_skill_md() {
 
 #[test]
 fn rejects_more_than_max_regular_files() {
+    let dynamic_paths = (0..500)
+        .map(|index| format!("gh-fix-ci/assets/file-{index}.txt"))
+        .collect::<Vec<_>>();
     let mut entries = Vec::with_capacity(501);
     entries.push(TestZipEntry::File {
         path: "gh-fix-ci/SKILL.md",
         contents: b"skill body",
         unix_mode: Some(0o100644),
     });
-    for index in 0..500 {
-        let path = format!("gh-fix-ci/assets/file-{index}.txt");
+    for path in &dynamic_paths {
         entries.push(TestZipEntry::File {
-            path: Box::leak(path.into_boxed_str()),
+            path,
             contents: b"payload",
             unix_mode: Some(0o100644),
         });
@@ -330,6 +354,82 @@ fn rejects_more_than_max_regular_files() {
     assert_eq!(
         error,
         SkillBundleArchiveError::TooManyFiles { max_files: 500 }
+    );
+}
+
+#[test]
+fn rejects_too_many_archive_entries() -> Result<()> {
+    let cursor = Cursor::new(Vec::new());
+    let mut writer = ZipWriter::new(cursor);
+    let options = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+    for index in 0..1024 {
+        writer.add_directory(format!("gh-fix-ci/dir-{index}/"), options)?;
+    }
+    writer.start_file("gh-fix-ci/SKILL.md", options)?;
+    writer.write_all(b"skill body")?;
+
+    let zip_bytes = writer.finish()?.into_inner();
+    let error = normalize_skill_bundle_zip(&zip_bytes).expect_err("entry count limit must fail");
+    assert_eq!(
+        error,
+        SkillBundleArchiveError::TooManyEntries { max_entries: 1024 }
+    );
+    Ok(())
+}
+
+#[test]
+fn rejects_entry_larger_than_max_uncompressed_size() {
+    let oversized = vec![b'x'; 25 * 1024 * 1024 + 1];
+    let error = normalize(&[
+        TestZipEntry::File {
+            path: "gh-fix-ci/SKILL.md",
+            contents: b"skill body",
+            unix_mode: Some(0o100644),
+        },
+        TestZipEntry::File {
+            path: "gh-fix-ci/assets/huge.bin",
+            contents: &oversized,
+            unix_mode: Some(0o100644),
+        },
+    ])
+    .expect_err("oversized entry must fail");
+
+    assert_eq!(
+        error,
+        SkillBundleArchiveError::EntryTooLarge {
+            path: "assets/huge.bin".to_owned(),
+            max_bytes: 25 * 1024 * 1024,
+        }
+    );
+}
+
+#[test]
+fn rejects_total_uncompressed_bundle_size_larger_than_limit() {
+    let large_payload = vec![b'x'; 15 * 1024 * 1024];
+    let error = normalize(&[
+        TestZipEntry::File {
+            path: "gh-fix-ci/SKILL.md",
+            contents: b"skill body",
+            unix_mode: Some(0o100644),
+        },
+        TestZipEntry::File {
+            path: "gh-fix-ci/assets/part-1.bin",
+            contents: &large_payload,
+            unix_mode: Some(0o100644),
+        },
+        TestZipEntry::File {
+            path: "gh-fix-ci/assets/part-2.bin",
+            contents: &large_payload,
+            unix_mode: Some(0o100644),
+        },
+    ])
+    .expect_err("oversized bundle must fail");
+
+    assert_eq!(
+        error,
+        SkillBundleArchiveError::BundleTooLarge {
+            max_bytes: 30 * 1024 * 1024,
+        }
     );
 }
 

--- a/crates/skills/tests/skill_bundle_normalization.rs
+++ b/crates/skills/tests/skill_bundle_normalization.rs
@@ -1,0 +1,386 @@
+use std::io::{Cursor, Write};
+
+use anyhow::{bail, Result};
+use smg_skills::{
+    is_code_file_path, normalize_skill_bundle_zip, NormalizedSkillBundle, SkillBundleArchiveError,
+};
+use zip::{write::SimpleFileOptions, CompressionMethod, ZipWriter};
+
+enum TestZipEntry<'a> {
+    File {
+        path: &'a str,
+        contents: &'a [u8],
+        unix_mode: Option<u32>,
+    },
+    Directory {
+        path: &'a str,
+        unix_mode: Option<u32>,
+    },
+    Symlink {
+        path: &'a str,
+        target: &'a str,
+    },
+}
+
+fn build_zip(entries: &[TestZipEntry<'_>]) -> Result<Vec<u8>> {
+    let cursor = Cursor::new(Vec::new());
+    let mut writer = ZipWriter::new(cursor);
+
+    for entry in entries {
+        match entry {
+            TestZipEntry::File {
+                path,
+                contents,
+                unix_mode,
+            } => {
+                let mut options =
+                    SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+                if let Some(mode) = unix_mode {
+                    options = options.unix_permissions(*mode);
+                }
+                writer.start_file(path, options)?;
+                writer.write_all(contents)?;
+            }
+            TestZipEntry::Directory { path, unix_mode } => {
+                let mut options =
+                    SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+                if let Some(mode) = unix_mode {
+                    options = options.unix_permissions(*mode);
+                }
+                writer.add_directory(*path, options)?;
+            }
+            TestZipEntry::Symlink { path, target } => {
+                let options =
+                    SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+                writer.add_symlink(path, target, options)?;
+            }
+        }
+    }
+
+    Ok(writer.finish()?.into_inner())
+}
+
+fn normalize(
+    entries: &[TestZipEntry<'_>],
+) -> Result<NormalizedSkillBundle, SkillBundleArchiveError> {
+    let zip_bytes = build_zip(entries).map_err(|error| SkillBundleArchiveError::InvalidZip {
+        message: error.to_string(),
+    })?;
+    normalize_skill_bundle_zip(&zip_bytes)
+}
+
+#[test]
+fn normalizes_zip_paths_to_skill_root_manifest() -> Result<()> {
+    let normalized = normalize(&[
+        TestZipEntry::Directory {
+            path: "gh-fix-ci/",
+            unix_mode: Some(0o040755),
+        },
+        TestZipEntry::File {
+            path: "gh-fix-ci/SKILL.md",
+            contents: b"skill body",
+            unix_mode: Some(0o100644),
+        },
+        TestZipEntry::File {
+            path: "gh-fix-ci/agents/openai.yaml",
+            contents: b"interface: {}",
+            unix_mode: Some(0o100644),
+        },
+        TestZipEntry::File {
+            path: "gh-fix-ci/scripts/analyze.py",
+            contents: b"print('hello')",
+            unix_mode: Some(0o100755),
+        },
+        TestZipEntry::File {
+            path: "gh-fix-ci/assets/readme.txt",
+            contents: b"not code",
+            unix_mode: Some(0o100644),
+        },
+    ])?;
+
+    let paths = normalized
+        .files
+        .iter()
+        .map(|file| file.relative_path.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        paths,
+        vec![
+            "SKILL.md",
+            "agents/openai.yaml",
+            "assets/readme.txt",
+            "scripts/analyze.py",
+        ]
+    );
+    assert_eq!(normalized.skill_md_path, "SKILL.md");
+    assert_eq!(
+        normalized.openai_sidecar_path.as_deref(),
+        Some("agents/openai.yaml")
+    );
+    assert!(normalized.has_code_files);
+
+    let manifest_paths = normalized
+        .file_manifest()
+        .into_iter()
+        .map(|file| file.relative_path)
+        .collect::<Vec<_>>();
+    assert_eq!(manifest_paths, paths);
+    Ok(())
+}
+
+#[test]
+fn rejects_archives_without_a_single_top_level_directory() {
+    let error = normalize(&[
+        TestZipEntry::File {
+            path: "first/SKILL.md",
+            contents: b"skill body",
+            unix_mode: Some(0o100644),
+        },
+        TestZipEntry::File {
+            path: "second/scripts/analyze.py",
+            contents: b"print('hello')",
+            unix_mode: Some(0o100755),
+        },
+    ])
+    .expect_err("multiple top-level directories must fail");
+
+    assert_eq!(
+        error,
+        SkillBundleArchiveError::MultipleTopLevelDirectories {
+            first: "first".to_owned(),
+            second: "second".to_owned(),
+        }
+    );
+}
+
+#[test]
+fn rejects_root_level_files_without_top_level_directory() {
+    let error = normalize(&[TestZipEntry::File {
+        path: "SKILL.md",
+        contents: b"skill body",
+        unix_mode: Some(0o100644),
+    }])
+    .expect_err("root-level file must fail");
+
+    assert_eq!(
+        error,
+        SkillBundleArchiveError::InvalidPath {
+            path: "SKILL.md".to_owned(),
+            message: "archive entries must live under a single top-level directory".to_owned(),
+        }
+    );
+}
+
+#[test]
+fn rejects_path_traversal_and_absolute_paths() {
+    let traversal = normalize(&[TestZipEntry::File {
+        path: "gh-fix-ci/../SKILL.md",
+        contents: b"skill body",
+        unix_mode: Some(0o100644),
+    }])
+    .expect_err("path traversal must fail");
+    assert_eq!(
+        traversal,
+        SkillBundleArchiveError::InvalidPath {
+            path: "gh-fix-ci/../SKILL.md".to_owned(),
+            message: "must not contain path traversal".to_owned(),
+        }
+    );
+
+    let absolute = normalize(&[TestZipEntry::File {
+        path: "/gh-fix-ci/SKILL.md",
+        contents: b"skill body",
+        unix_mode: Some(0o100644),
+    }])
+    .expect_err("absolute path must fail");
+    assert_eq!(
+        absolute,
+        SkillBundleArchiveError::InvalidPath {
+            path: "/gh-fix-ci/SKILL.md".to_owned(),
+            message: "must not be absolute".to_owned(),
+        }
+    );
+}
+
+#[test]
+fn rejects_duplicate_normalized_paths() {
+    let error = normalize(&[
+        TestZipEntry::File {
+            path: "gh-fix-ci/SKILL.md",
+            contents: b"skill body",
+            unix_mode: Some(0o100644),
+        },
+        TestZipEntry::File {
+            path: "gh-fix-ci\\scripts\\analyze.py",
+            contents: b"print('one')",
+            unix_mode: Some(0o100755),
+        },
+        TestZipEntry::File {
+            path: "gh-fix-ci/scripts/analyze.py",
+            contents: b"print('two')",
+            unix_mode: Some(0o100755),
+        },
+    ])
+    .expect_err("duplicate normalized path must fail");
+
+    assert_eq!(
+        error,
+        SkillBundleArchiveError::DuplicateNormalizedPath {
+            path: "scripts/analyze.py".to_owned(),
+        }
+    );
+}
+
+#[test]
+fn rejects_symlinks() {
+    let symlink = normalize(&[
+        TestZipEntry::File {
+            path: "gh-fix-ci/SKILL.md",
+            contents: b"skill body",
+            unix_mode: Some(0o100644),
+        },
+        TestZipEntry::Symlink {
+            path: "gh-fix-ci/scripts/link.py",
+            target: "../scripts/analyze.py",
+        },
+    ])
+    .expect_err("symlink must fail");
+    assert_eq!(
+        symlink,
+        SkillBundleArchiveError::UnsupportedEntryType {
+            path: "gh-fix-ci/scripts/link.py".to_owned(),
+            entry_type: "symbolic link".to_owned(),
+        }
+    );
+}
+
+#[test]
+fn rejects_multiple_root_level_skill_md_files_case_insensitively() {
+    let error = normalize(&[
+        TestZipEntry::File {
+            path: "gh-fix-ci/SKILL.md",
+            contents: b"skill body",
+            unix_mode: Some(0o100644),
+        },
+        TestZipEntry::File {
+            path: "gh-fix-ci/skill.md",
+            contents: b"duplicate",
+            unix_mode: Some(0o100644),
+        },
+    ])
+    .expect_err("duplicate root-level SKILL.md must fail");
+
+    assert_eq!(
+        error,
+        SkillBundleArchiveError::MultipleSkillMd {
+            first: "SKILL.md".to_owned(),
+            second: "skill.md".to_owned(),
+        }
+    );
+}
+
+#[test]
+fn rejects_nested_skill_md() {
+    let error = normalize(&[TestZipEntry::File {
+        path: "gh-fix-ci/docs/SKILL.md",
+        contents: b"skill body",
+        unix_mode: Some(0o100644),
+    }])
+    .expect_err("nested SKILL.md must fail");
+
+    assert_eq!(
+        error,
+        SkillBundleArchiveError::InvalidPath {
+            path: "docs/SKILL.md".to_owned(),
+            message: "SKILL.md must live at the skill root".to_owned(),
+        }
+    );
+}
+
+#[test]
+fn rejects_archives_without_root_level_skill_md() {
+    let error = normalize(&[TestZipEntry::File {
+        path: "gh-fix-ci/notes.txt",
+        contents: b"docs only",
+        unix_mode: Some(0o100644),
+    }])
+    .expect_err("missing SKILL.md must fail");
+
+    assert_eq!(error, SkillBundleArchiveError::MissingSkillMd);
+}
+
+#[test]
+fn rejects_more_than_max_regular_files() {
+    let mut entries = Vec::with_capacity(501);
+    entries.push(TestZipEntry::File {
+        path: "gh-fix-ci/SKILL.md",
+        contents: b"skill body",
+        unix_mode: Some(0o100644),
+    });
+    for index in 0..500 {
+        let path = format!("gh-fix-ci/assets/file-{index}.txt");
+        entries.push(TestZipEntry::File {
+            path: Box::leak(path.into_boxed_str()),
+            contents: b"payload",
+            unix_mode: Some(0o100644),
+        });
+    }
+
+    let error = normalize(&entries).expect_err("file count limit must fail");
+    assert_eq!(
+        error,
+        SkillBundleArchiveError::TooManyFiles { max_files: 500 }
+    );
+}
+
+#[test]
+fn classifies_code_files_deterministically() -> Result<()> {
+    let positives = [
+        "scripts/analyze.py",
+        "scripts/ANALYZE.PY",
+        "src/tool.rs",
+        "assets/module.wasm",
+        "Dockerfile",
+        "dockerfile",
+        "Makefile",
+        "config/run.json",
+        "images/main.svg",
+        "notes/exec.txt",
+    ];
+    for path in positives {
+        if !is_code_file_path(path) {
+            bail!("expected `{path}` to classify as code");
+        }
+    }
+
+    let negatives = [
+        "SKILL.md",
+        "agents/openai.yaml",
+        "docs/readme.txt",
+        "assets/data.json",
+        "assets/logo.png",
+        "styles/site.css",
+        "notes/report",
+        "assets/😀.txt",
+    ];
+    for path in negatives {
+        if is_code_file_path(path) {
+            bail!("expected `{path}` to classify as non-code");
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn surfaces_invalid_zip_payloads() -> Result<()> {
+    let error = normalize_skill_bundle_zip(b"not-a-zip").expect_err("invalid zip must fail");
+    match error {
+        SkillBundleArchiveError::InvalidZip { message } => {
+            if message.is_empty() {
+                bail!("expected zip error message");
+            }
+        }
+        other => bail!("expected invalid zip error, got {other:?}"),
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Description

### Problem

Closes #1181.

The skills crate could parse `SKILL.md`, but it still had no canonical zip normalization step for uploaded bundles. That meant there was no single place enforcing one logical top-level directory, relative manifest paths, rejection of unsafe archive entries, or the deterministic `has_code_files` classification required by the skills design.

### Solution

Add zip bundle normalization directly to `smg-skills`, alongside explicit archive error types and normalized bundle domain types. The new path normalizer strips the single top-level directory, rejects traversal / duplicates / unsupported entry types, requires exactly one root-level `SKILL.md`, and computes `has_code_files` with the deterministic extension and basename classifier from the design.

## Changes

- add `NormalizedSkillBundle` and `NormalizedSkillFile` types to the skills crate
- add `normalize_skill_bundle_zip` and `SkillBundleArchiveError`
- enforce strict zip path normalization and one-top-level-directory validation
- reject duplicate normalized paths, root-level files, nested `SKILL.md`, symlinks, and other unsupported archive entries
- add `is_code_file_path` and compute `has_code_files` during normalization
- add integration tests for rejection cases, manifest projection, and the classifier matrix

## Test Plan

- `cargo +nightly fmt --all`
- `env -u RUSTC_WRAPPER cargo clippy --all-targets --all-features --target-dir /tmp/smg-gate-target -- -D warnings`
- `env -u RUSTC_WRAPPER cargo test --target-dir /tmp/smg-gate-target`

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ZIP-based skill bundle upload with in-memory normalization, robust validation, deterministic root handling, manifest generation (per-file sizes) and automatic detection of code files; clearer error reporting for malformed or unsafe archives

* **Tests**
  * Comprehensive tests covering normalization, path rules, size/count limits, duplicate detection, code-file classification, and error cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->