### PR TITLE
feat(gateway): add /v1/audio/transcriptions multipart route

### DIFF
--- a/crates/protocols/src/lib.rs
+++ b/crates/protocols/src/lib.rs
@@ -30,5 +30,6 @@ pub mod responses;
 pub mod sampling_params;
 pub mod skills;
 pub mod tokenize;
+pub mod transcription;
 pub mod validated;
 pub mod worker;

--- a/crates/protocols/src/transcription.rs
+++ b/crates/protocols/src/transcription.rs
@@ -1,0 +1,56 @@
+//! Audio transcription API protocol definitions.
+//!
+//! This module defines the request type for the OpenAI-compatible
+//! `/v1/audio/transcriptions` endpoint. The wire format is
+//! `multipart/form-data` (an audio file plus text form fields), so the
+//! struct below carries only the non-file fields; the file bytes travel
+//! through the router as a separate payload.
+
+use serde::{Deserialize, Serialize};
+
+use super::common::GenerationRequest;
+
+/// Transcription request - compatible with OpenAI's /v1/audio/transcriptions API.
+///
+/// The audio file itself is carried out-of-band because the endpoint uses
+/// multipart/form-data, not JSON.
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Clone, Default, Deserialize, Serialize, schemars::JsonSchema)]
+pub struct TranscriptionRequest {
+    /// ID of the model to use (e.g. "whisper-large-v3").
+    pub model: String,
+
+    /// Optional ISO-639-1 language hint for the input audio.
+    pub language: Option<String>,
+
+    /// Optional text prompt to guide the model's style / preserve continuity.
+    pub prompt: Option<String>,
+
+    /// Response format: `json` (default), `text`, `srt`, `verbose_json`, `vtt`.
+    pub response_format: Option<String>,
+
+    /// Sampling temperature (0..=1).
+    pub temperature: Option<f32>,
+
+    /// Timestamp granularities for verbose_json: `word`, `segment`.
+    pub timestamp_granularities: Option<Vec<String>>,
+
+    /// If true, stream partial transcription events as SSE.
+    pub stream: Option<bool>,
+}
+
+impl GenerationRequest for TranscriptionRequest {
+    fn is_stream(&self) -> bool {
+        self.stream.unwrap_or(false)
+    }
+
+    fn get_model(&self) -> Option<&str> {
+        Some(&self.model)
+    }
+
+    fn extract_text_for_routing(&self) -> String {
+        // Audio bytes are not visible here; use the optional prompt as a
+        // rough cache-aware routing hint when present.
+        self.prompt.clone().unwrap_or_default()
+    }
+}

--- a/model_gateway/Cargo.toml
+++ b/model_gateway/Cargo.toml
@@ -54,7 +54,7 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 
 # Workspace dependencies (with extra features)
-axum = { workspace = true, features = ["macros", "ws", "tracing"] }
+axum = { workspace = true, features = ["macros", "multipart", "ws", "tracing"] }
 bytemuck = { workspace = true, features = ["derive"] }
 reqwest = { workspace = true, features = ["stream", "blocking", "json", "rustls-tls", "multipart"] }
 serde = { workspace = true, features = ["derive"] }

--- a/model_gateway/src/observability/metrics.rs
+++ b/model_gateway/src/observability/metrics.rs
@@ -389,6 +389,7 @@ pub mod metrics_labels {
     pub const ENDPOINT_REALTIME_SESSIONS: &str = "realtime_sessions";
     pub const ENDPOINT_REALTIME_CLIENT_SECRETS: &str = "realtime_client_secrets";
     pub const ENDPOINT_REALTIME_TRANSCRIPTION: &str = "realtime_transcription";
+    pub const ENDPOINT_AUDIO_TRANSCRIPTIONS: &str = "audio_transcriptions";
 
     // Connection modes
     pub const CONNECTION_WEBSOCKET: &str = "websocket";

--- a/model_gateway/src/routers/grpc/utils/metrics.rs
+++ b/model_gateway/src/routers/grpc/utils/metrics.rs
@@ -12,6 +12,7 @@ pub(crate) fn route_to_endpoint(route: &str) -> &'static str {
         "/v1/completions" => metrics_labels::ENDPOINT_COMPLETIONS,
         "/v1/rerank" => metrics_labels::ENDPOINT_RERANK,
         "/v1/responses" => metrics_labels::ENDPOINT_RESPONSES,
+        "/v1/audio/transcriptions" => metrics_labels::ENDPOINT_AUDIO_TRANSCRIPTIONS,
         _ => "other",
     }
 }

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -490,6 +490,29 @@ impl Router {
             bool_to_static_str(is_stream),
         );
 
+        // Finalize router metrics for an early error that never reached an
+        // upstream worker (model_not_found, dp_aware_not_supported, no
+        // available workers, build failure). Without this, pre-send failures
+        // silently disappear from router_upstream_responses / router_error.
+        let record_pre_send_error = |response: &Response| {
+            let rstatus = response.status();
+            Metrics::record_router_upstream_response(
+                metrics_labels::ROUTER_HTTP,
+                rstatus.as_u16(),
+                extract_error_code_from_response(response),
+            );
+            if !is_retryable_status(rstatus) {
+                Metrics::record_router_error(
+                    metrics_labels::ROUTER_HTTP,
+                    metrics_labels::BACKEND_REGULAR,
+                    metrics_labels::CONNECTION_HTTP,
+                    model_id,
+                    endpoint,
+                    error_type_from_status(rstatus),
+                );
+            }
+        };
+
         // Multipart transcription can't route through `worker.prepare_request`,
         // which is the hook that injects `data_parallel_rank` for DP-aware
         // workers. Pre-filter DP-aware workers out of the candidate pool so
@@ -508,7 +531,9 @@ impl Router {
             false,
         );
         if all_workers.is_empty() {
-            return error::model_not_found(model_id);
+            let resp = error::model_not_found(model_id);
+            record_pre_send_error(&resp);
+            return resp;
         }
         let non_dp_workers: Vec<Arc<dyn Worker>> = all_workers
             .iter()
@@ -516,10 +541,12 @@ impl Router {
             .cloned()
             .collect();
         if non_dp_workers.is_empty() {
-            return error::bad_request(
+            let resp = error::bad_request(
                 "dp_aware_not_supported",
                 "/v1/audio/transcriptions does not yet support DP-aware workers",
             );
+            record_pre_send_error(&resp);
+            return resp;
         }
         let available: Vec<Arc<dyn Worker>> = non_dp_workers
             .iter()
@@ -527,10 +554,12 @@ impl Router {
             .cloned()
             .collect();
         if available.is_empty() {
-            return error::service_unavailable(
+            let resp = error::service_unavailable(
                 "no_available_workers",
                 "All workers are unavailable (circuit breaker open or unhealthy)",
             );
+            record_pre_send_error(&resp);
+            return resp;
         }
 
         let policy = self.policy_registry.get_policy_or_default(model_id);
@@ -546,10 +575,12 @@ impl Router {
         ) {
             Some(i) => i,
             None => {
-                return error::service_unavailable(
+                let resp = error::service_unavailable(
                     "no_available_workers",
                     "Policy returned no eligible worker",
                 );
+                record_pre_send_error(&resp);
+                return resp;
             }
         };
         Metrics::record_worker_selection(
@@ -573,7 +604,9 @@ impl Router {
         let form = match build_transcription_form(body, audio) {
             Ok(f) => f,
             Err(e) => {
-                return error::bad_request("multipart_build_failed", e);
+                let resp = error::bad_request("multipart_build_failed", e);
+                record_pre_send_error(&resp);
+                return resp;
             }
         };
 

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -699,12 +699,17 @@ impl Router {
             // chunks in memory.
             const STREAM_RELAY_BUFFER: usize = 32;
             let (tx, rx) = mpsc::channel::<Result<bytes::Bytes, String>>(STREAM_RELAY_BUFFER);
-            // Attribute stream outcome to the worker from inside the relay
-            // task: a mid-stream error after a 2xx header must mark the
-            // worker failed (502-synthetic) so the circuit breaker and
-            // worker-error metric track the transport failure.
+            // Attribute worker-level and router-level outcomes to the actual
+            // stream completion from inside the relay task: a mid-stream error
+            // after a 2xx header, or a non-streaming 5xx header returned under
+            // `stream=true`, must be visible to circuit-breaker + worker-error
+            // + router-error metrics. Recording only at header time would mis-
+            // classify those.
             let worker_for_stream = worker.clone();
-            let stream_header_status = status.as_u16();
+            let stream_header_status = status;
+            let stream_model_id = model_id.to_string();
+            let stream_endpoint = endpoint;
+            let stream_start = start;
             #[expect(
                 clippy::disallowed_methods,
                 reason = "fire-and-forget stream relay; gateway shutdown need not wait for individual stream forwarding"
@@ -726,17 +731,39 @@ impl Router {
                         }
                     }
                 }
-                let outcome_status = if stream_failed {
-                    StatusCode::BAD_GATEWAY.as_u16()
+                // Effective status = BAD_GATEWAY if the relay failed, else the
+                // worker's header status. Covers both "5xx header returned
+                // while stream=true" and "200 header then mid-stream break".
+                let effective_status = if stream_failed {
+                    StatusCode::BAD_GATEWAY
                 } else {
                     stream_header_status
                 };
-                worker_for_stream.record_outcome(outcome_status);
-                if stream_failed {
+                worker_for_stream.record_outcome(effective_status.as_u16());
+                if effective_status.is_server_error() {
                     Metrics::record_worker_error(
                         metrics_labels::WORKER_REGULAR,
                         metrics_labels::CONNECTION_HTTP,
-                        error_type_from_status(StatusCode::BAD_GATEWAY),
+                        error_type_from_status(effective_status),
+                    );
+                }
+                if effective_status.is_success() {
+                    Metrics::record_router_duration(
+                        metrics_labels::ROUTER_HTTP,
+                        metrics_labels::BACKEND_REGULAR,
+                        metrics_labels::CONNECTION_HTTP,
+                        &stream_model_id,
+                        stream_endpoint,
+                        stream_start.elapsed(),
+                    );
+                } else {
+                    Metrics::record_router_error(
+                        metrics_labels::ROUTER_HTTP,
+                        metrics_labels::BACKEND_REGULAR,
+                        metrics_labels::CONNECTION_HTTP,
+                        &stream_model_id,
+                        stream_endpoint,
+                        error_type_from_status(effective_status),
                     );
                 }
             });
@@ -765,15 +792,12 @@ impl Router {
             }
         };
 
-        // The non-streaming path can rewrite a 2xx upstream into a 5xx local
-        // response if reading the body fails. Classify metrics off the final
-        // response the client will actually see, not the upstream status.
-        let final_status = response.status();
+        // Non-streaming: classify metrics off the final response the client
+        // will actually see. A body-read failure can rewrite a 2xx upstream
+        // into a local 5xx, and we want the circuit breaker + metrics to see
+        // that. Streaming outcomes are owned by the relay task above.
         if !is_stream {
-            // Feed the final status into the circuit breaker / worker-error
-            // metric here — not at header time — so a body-read failure after
-            // a 2xx header is still attributed to the worker that produced
-            // it. Streaming outcomes are recorded inside the relay task.
+            let final_status = response.status();
             worker.record_outcome(final_status.as_u16());
             if final_status.is_server_error() {
                 Metrics::record_worker_error(
@@ -782,25 +806,25 @@ impl Router {
                     error_type_from_status(final_status),
                 );
             }
-        }
-        if final_status.is_success() {
-            Metrics::record_router_duration(
-                metrics_labels::ROUTER_HTTP,
-                metrics_labels::BACKEND_REGULAR,
-                metrics_labels::CONNECTION_HTTP,
-                model_id,
-                endpoint,
-                start.elapsed(),
-            );
-        } else {
-            Metrics::record_router_error(
-                metrics_labels::ROUTER_HTTP,
-                metrics_labels::BACKEND_REGULAR,
-                metrics_labels::CONNECTION_HTTP,
-                model_id,
-                endpoint,
-                error_type_from_status(final_status),
-            );
+            if final_status.is_success() {
+                Metrics::record_router_duration(
+                    metrics_labels::ROUTER_HTTP,
+                    metrics_labels::BACKEND_REGULAR,
+                    metrics_labels::CONNECTION_HTTP,
+                    model_id,
+                    endpoint,
+                    start.elapsed(),
+                );
+            } else {
+                Metrics::record_router_error(
+                    metrics_labels::ROUTER_HTTP,
+                    metrics_labels::BACKEND_REGULAR,
+                    metrics_labels::CONNECTION_HTTP,
+                    model_id,
+                    endpoint,
+                    error_type_from_status(final_status),
+                );
+            }
         }
 
         response

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -516,6 +516,17 @@ impl Router {
             }
         };
 
+        // Multipart transcription can't route through `worker.prepare_request`,
+        // which is the hook that injects `data_parallel_rank` for DP-aware
+        // workers. Fail loudly instead of silently sending to an arbitrary DP
+        // shard.
+        if worker.is_dp_aware() {
+            return error::bad_request(
+                "dp_aware_not_supported",
+                "/v1/audio/transcriptions does not yet support DP-aware workers",
+            );
+        }
+
         let policy = self.policy_registry.get_policy_or_default(model_id);
         let load_guard = ["cache_aware", "manual"]
             .contains(&policy.name())
@@ -829,7 +840,11 @@ fn build_transcription_form(body: &TranscriptionRequest, audio: AudioFile) -> Re
         content_type,
     } = audio;
 
-    let mut file_part = Part::bytes(bytes.to_vec()).file_name(file_name);
+    // Wrap the already-buffered Bytes in a reqwest Body (Arc refcount, no
+    // additional copy) instead of Part::bytes, which would force a Vec copy.
+    let file_len = bytes.len() as u64;
+    let mut file_part =
+        Part::stream_with_length(reqwest::Body::from(bytes), file_len).file_name(file_name);
     if let Some(ct) = content_type.as_deref() {
         file_part = file_part
             .mime_str(ct)

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -17,8 +17,12 @@ use openai_protocol::{
     generate::GenerateRequest,
     rerank::{RerankRequest, RerankResponse, RerankResult},
     responses::ResponsesRequest,
+    transcription::TranscriptionRequest,
 };
-use reqwest::Client;
+use reqwest::{
+    multipart::{Form, Part},
+    Client,
+};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::error;
@@ -39,7 +43,7 @@ use crate::{
         },
         error::{self, extract_error_code_from_response},
         grpc::utils::{error_type_from_status, route_to_endpoint},
-        RouterTrait,
+        AudioFile, RouterTrait,
     },
     worker::{AttachedBody, ConnectionMode, Worker, WorkerLoadGuard, WorkerRegistry, WorkerType},
 };
@@ -461,6 +465,209 @@ impl Router {
             .await
     }
 
+    /// Forward an audio transcription request to an audio-capable worker as
+    /// `multipart/form-data`. Separate from `route_typed_request` because the
+    /// endpoint is not JSON-bodied.
+    async fn route_multipart_transcription(
+        &self,
+        headers: Option<&HeaderMap>,
+        body: &TranscriptionRequest,
+        audio: AudioFile,
+        route: &'static str,
+        model_id: &str,
+    ) -> Response {
+        let start = Instant::now();
+        let is_stream = body.is_stream();
+        let text = body.extract_text_for_routing();
+        let endpoint = route_to_endpoint(route);
+
+        Metrics::record_router_request(
+            metrics_labels::ROUTER_HTTP,
+            metrics_labels::BACKEND_REGULAR,
+            metrics_labels::CONNECTION_HTTP,
+            model_id,
+            endpoint,
+            bool_to_static_str(is_stream),
+        );
+
+        let worker = match self.select_worker_for_model(model_id, Some(&text), headers) {
+            Some(w) => w,
+            None => {
+                let model_filter = if model_id == crate::worker::UNKNOWN_MODEL_ID {
+                    None
+                } else {
+                    Some(model_id)
+                };
+                let total = self.worker_registry.get_workers_filtered(
+                    model_filter,
+                    Some(WorkerType::Regular),
+                    Some(ConnectionMode::Http),
+                    None,
+                    false,
+                );
+                return if total.is_empty() {
+                    error::model_not_found(model_id)
+                } else {
+                    error::service_unavailable(
+                        "no_available_workers",
+                        "All workers are unavailable (circuit breaker open or unhealthy)",
+                    )
+                };
+            }
+        };
+
+        let policy = self.policy_registry.get_policy_or_default(model_id);
+        let load_guard = ["cache_aware", "manual"]
+            .contains(&policy.name())
+            .then(|| WorkerLoadGuard::new(worker.clone(), headers));
+
+        let mut headers_with_trace = headers.cloned().unwrap_or_default();
+        inject_trace_context_http(&mut headers_with_trace);
+        let headers = Some(&headers_with_trace);
+
+        events::RequestSentEvent { url: worker.url() }.emit();
+
+        let form = match build_transcription_form(body, audio) {
+            Ok(f) => f,
+            Err(e) => {
+                return error::bad_request("multipart_build_failed", e);
+            }
+        };
+
+        let endpoint_url = worker.endpoint_url(route);
+        let mut request_builder = self.client.post(&endpoint_url).multipart(form);
+
+        if let Some(key) = worker.api_key().cloned() {
+            let mut auth_header = String::with_capacity(7 + key.len());
+            auth_header.push_str("Bearer ");
+            auth_header.push_str(&key);
+            request_builder = request_builder.header("Authorization", auth_header);
+        }
+
+        if let Some(headers) = headers {
+            for (name, value) in headers {
+                // Skip Content-Type and Content-Length — reqwest sets the
+                // correct multipart boundary itself.
+                let name_str = name.as_str();
+                if name_str.eq_ignore_ascii_case("content-type")
+                    || name_str.eq_ignore_ascii_case("content-length")
+                {
+                    continue;
+                }
+                if header_utils::should_forward_request_header(name_str) {
+                    request_builder = request_builder.header(name, value);
+                }
+            }
+        }
+
+        let res = match request_builder.send().await {
+            Ok(res) => res,
+            Err(e) => {
+                error!(
+                    "Failed to send multipart transcription request worker_url={} route={} error={}",
+                    worker.url(),
+                    route,
+                    e
+                );
+                let err_resp = convert_reqwest_error(e);
+                Metrics::record_router_upstream_response(
+                    metrics_labels::ROUTER_HTTP,
+                    err_resp.status().as_u16(),
+                    extract_error_code_from_response(&err_resp),
+                );
+                return err_resp;
+            }
+        };
+
+        let status = StatusCode::from_u16(res.status().as_u16())
+            .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+
+        Metrics::record_router_upstream_response(metrics_labels::ROUTER_HTTP, status.as_u16(), "");
+
+        events::RequestReceivedEvent {}.emit();
+        worker.record_outcome(status.as_u16());
+
+        if status.is_server_error() {
+            Metrics::record_worker_error(
+                metrics_labels::WORKER_REGULAR,
+                metrics_labels::CONNECTION_HTTP,
+                error_type_from_status(status),
+            );
+        }
+
+        let response = if is_stream {
+            let mut response_headers = header_utils::preserve_response_headers(res.headers());
+            response_headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/event-stream"));
+            let stream = res.bytes_stream();
+            let (tx, rx) = mpsc::unbounded_channel();
+            #[expect(
+                clippy::disallowed_methods,
+                reason = "fire-and-forget stream relay; gateway shutdown need not wait for individual stream forwarding"
+            )]
+            tokio::spawn(async move {
+                let mut stream = stream;
+                while let Some(chunk) = stream.next().await {
+                    match chunk {
+                        Ok(bytes) => {
+                            if tx.send(Ok(bytes)).is_err() {
+                                break;
+                            }
+                        }
+                        Err(e) => {
+                            let _ = tx.send(Err(format!("Stream error: {e}")));
+                            break;
+                        }
+                    }
+                }
+            });
+            let stream = UnboundedReceiverStream::new(rx);
+            let body = Body::from_stream(stream);
+            let mut response = Response::new(body);
+            *response.status_mut() = status;
+            *response.headers_mut() = response_headers;
+            if let Some(guard) = load_guard {
+                response = AttachedBody::wrap_response(response, guard);
+            }
+            response
+        } else {
+            let response_headers = header_utils::preserve_response_headers(res.headers());
+            match res.bytes().await {
+                Ok(body) => {
+                    let mut response = Response::new(Body::from(body));
+                    *response.status_mut() = status;
+                    *response.headers_mut() = response_headers;
+                    response
+                }
+                Err(e) => error::internal_error(
+                    "read_response_body_failed",
+                    format!("Failed to read response body: {e}"),
+                ),
+            }
+        };
+
+        if status.is_success() {
+            Metrics::record_router_duration(
+                metrics_labels::ROUTER_HTTP,
+                metrics_labels::BACKEND_REGULAR,
+                metrics_labels::CONNECTION_HTTP,
+                model_id,
+                endpoint,
+                start.elapsed(),
+            );
+        } else {
+            Metrics::record_router_error(
+                metrics_labels::ROUTER_HTTP,
+                metrics_labels::BACKEND_REGULAR,
+                metrics_labels::CONNECTION_HTTP,
+                model_id,
+                endpoint,
+                error_type_from_status(status),
+            );
+        }
+
+        response
+    }
+
     // Send typed request directly without conversion
     async fn send_typed_request<T: serde::Serialize>(
         &self,
@@ -615,6 +822,48 @@ impl Router {
     }
 }
 
+fn build_transcription_form(body: &TranscriptionRequest, audio: AudioFile) -> Result<Form, String> {
+    let AudioFile {
+        bytes,
+        file_name,
+        content_type,
+    } = audio;
+
+    let mut file_part = Part::bytes(bytes.to_vec()).file_name(file_name);
+    if let Some(ct) = content_type.as_deref() {
+        file_part = file_part
+            .mime_str(ct)
+            .map_err(|e| format!("Invalid audio content-type '{ct}': {e}"))?;
+    }
+
+    let mut form = Form::new()
+        .part("file", file_part)
+        .text("model", body.model.clone());
+
+    if let Some(ref language) = body.language {
+        form = form.text("language", language.clone());
+    }
+    if let Some(ref prompt) = body.prompt {
+        form = form.text("prompt", prompt.clone());
+    }
+    if let Some(ref fmt) = body.response_format {
+        form = form.text("response_format", fmt.clone());
+    }
+    if let Some(temp) = body.temperature {
+        form = form.text("temperature", temp.to_string());
+    }
+    if let Some(ref grans) = body.timestamp_granularities {
+        for g in grans {
+            form = form.text("timestamp_granularities[]", g.clone());
+        }
+    }
+    if let Some(stream) = body.stream {
+        form = form.text("stream", stream.to_string());
+    }
+
+    Ok(form)
+}
+
 fn convert_reqwest_error(e: reqwest::Error) -> Response {
     let url = e
         .url()
@@ -750,6 +999,23 @@ impl RouterTrait for Router {
     ) -> Response {
         self.route_typed_request(headers, body, "/v1/classify", model_id)
             .await
+    }
+
+    async fn route_audio_transcriptions(
+        &self,
+        headers: Option<&HeaderMap>,
+        body: &TranscriptionRequest,
+        audio: AudioFile,
+        model_id: &str,
+    ) -> Response {
+        self.route_multipart_transcription(
+            headers,
+            body,
+            audio,
+            "/v1/audio/transcriptions",
+            model_id,
+        )
+        .await
     }
 
     async fn route_rerank(

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -24,7 +24,7 @@ use reqwest::{
     Client,
 };
 use tokio::sync::mpsc;
-use tokio_stream::wrappers::UnboundedReceiverStream;
+use tokio_stream::wrappers::{ReceiverStream, UnboundedReceiverStream};
 use tracing::error;
 
 use crate::{
@@ -620,7 +620,11 @@ impl Router {
             let mut response_headers = header_utils::preserve_response_headers(res.headers());
             response_headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/event-stream"));
             let stream = res.bytes_stream();
-            let (tx, rx) = mpsc::unbounded_channel();
+            // Bounded channel applies backpressure: if the downstream client
+            // is slow, the upstream relay awaits on `send` rather than piling
+            // chunks in memory.
+            const STREAM_RELAY_BUFFER: usize = 32;
+            let (tx, rx) = mpsc::channel::<Result<bytes::Bytes, String>>(STREAM_RELAY_BUFFER);
             #[expect(
                 clippy::disallowed_methods,
                 reason = "fire-and-forget stream relay; gateway shutdown need not wait for individual stream forwarding"
@@ -630,18 +634,18 @@ impl Router {
                 while let Some(chunk) = stream.next().await {
                     match chunk {
                         Ok(bytes) => {
-                            if tx.send(Ok(bytes)).is_err() {
+                            if tx.send(Ok(bytes)).await.is_err() {
                                 break;
                             }
                         }
                         Err(e) => {
-                            let _ = tx.send(Err(format!("Stream error: {e}")));
+                            let _ = tx.send(Err(format!("Stream error: {e}"))).await;
                             break;
                         }
                     }
                 }
             });
-            let stream = UnboundedReceiverStream::new(rx);
+            let stream = ReceiverStream::new(rx);
             let body = Body::from_stream(stream);
             let mut response = Response::new(body);
             *response.status_mut() = status;
@@ -666,7 +670,11 @@ impl Router {
             }
         };
 
-        if status.is_success() {
+        // The non-streaming path can rewrite a 2xx upstream into a 5xx local
+        // response if reading the body fails. Classify metrics off the final
+        // response the client will actually see, not the upstream status.
+        let final_status = response.status();
+        if final_status.is_success() {
             Metrics::record_router_duration(
                 metrics_labels::ROUTER_HTTP,
                 metrics_labels::BACKEND_REGULAR,
@@ -682,7 +690,7 @@ impl Router {
                 metrics_labels::CONNECTION_HTTP,
                 model_id,
                 endpoint,
-                error_type_from_status(status),
+                error_type_from_status(final_status),
             );
         }
 

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -586,6 +586,16 @@ impl Router {
                     err_resp.status().as_u16(),
                     extract_error_code_from_response(&err_resp),
                 );
+                // Mirror route_typed_request: a send failure must still bump
+                // the terminal router_error counter, not just upstream_response.
+                Metrics::record_router_error(
+                    metrics_labels::ROUTER_HTTP,
+                    metrics_labels::BACKEND_REGULAR,
+                    metrics_labels::CONNECTION_HTTP,
+                    model_id,
+                    endpoint,
+                    error_type_from_status(err_resp.status()),
+                );
                 return err_resp;
             }
         };

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -651,15 +651,6 @@ impl Router {
         Metrics::record_router_upstream_response(metrics_labels::ROUTER_HTTP, status.as_u16(), "");
 
         events::RequestReceivedEvent {}.emit();
-        worker.record_outcome(status.as_u16());
-
-        if status.is_server_error() {
-            Metrics::record_worker_error(
-                metrics_labels::WORKER_REGULAR,
-                metrics_labels::CONNECTION_HTTP,
-                error_type_from_status(status),
-            );
-        }
 
         let response = if is_stream {
             // Preserve the upstream content-type verbatim. A `stream=true`
@@ -724,6 +715,17 @@ impl Router {
         // response if reading the body fails. Classify metrics off the final
         // response the client will actually see, not the upstream status.
         let final_status = response.status();
+        // Feed the final status into the circuit breaker / worker-error
+        // metric here — not at header time — so a body-read failure after a
+        // 2xx header is still attributed to the worker that produced it.
+        worker.record_outcome(final_status.as_u16());
+        if final_status.is_server_error() {
+            Metrics::record_worker_error(
+                metrics_labels::WORKER_REGULAR,
+                metrics_labels::CONNECTION_HTTP,
+                error_type_from_status(final_status),
+            );
+        }
         if final_status.is_success() {
             Metrics::record_router_duration(
                 metrics_labels::ROUTER_HTTP,

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -662,8 +662,13 @@ impl Router {
         }
 
         let response = if is_stream {
-            let mut response_headers = header_utils::preserve_response_headers(res.headers());
-            response_headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/event-stream"));
+            // Preserve the upstream content-type verbatim. A `stream=true`
+            // hint from the client doesn't guarantee the worker actually
+            // streams — whisper backends may ignore it and return a normal
+            // JSON body (success or 4xx error). Don't relabel non-SSE
+            // responses as SSE; leave that judgment to whatever the worker
+            // set.
+            let response_headers = header_utils::preserve_response_headers(res.headers());
             let stream = res.bytes_stream();
             // Bounded channel applies backpressure: if the downstream client
             // is slow, the upstream relay awaits on `send` rather than piling

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -490,44 +490,76 @@ impl Router {
             bool_to_static_str(is_stream),
         );
 
-        let worker = match self.select_worker_for_model(model_id, Some(&text), headers) {
-            Some(w) => w,
-            None => {
-                let model_filter = if model_id == crate::worker::UNKNOWN_MODEL_ID {
-                    None
-                } else {
-                    Some(model_id)
-                };
-                let total = self.worker_registry.get_workers_filtered(
-                    model_filter,
-                    Some(WorkerType::Regular),
-                    Some(ConnectionMode::Http),
-                    None,
-                    false,
-                );
-                return if total.is_empty() {
-                    error::model_not_found(model_id)
-                } else {
-                    error::service_unavailable(
-                        "no_available_workers",
-                        "All workers are unavailable (circuit breaker open or unhealthy)",
-                    )
-                };
-            }
-        };
-
         // Multipart transcription can't route through `worker.prepare_request`,
         // which is the hook that injects `data_parallel_rank` for DP-aware
-        // workers. Fail loudly instead of silently sending to an arbitrary DP
-        // shard.
-        if worker.is_dp_aware() {
+        // workers. Pre-filter DP-aware workers out of the candidate pool so
+        // the policy can pick a non-DP worker when one exists; only fall back
+        // to model_not_found / 400 when every candidate is DP-aware.
+        let model_filter = if model_id == crate::worker::UNKNOWN_MODEL_ID {
+            None
+        } else {
+            Some(model_id)
+        };
+        let all_workers = self.worker_registry.get_workers_filtered(
+            model_filter,
+            Some(WorkerType::Regular),
+            Some(ConnectionMode::Http),
+            None,
+            false,
+        );
+        if all_workers.is_empty() {
+            return error::model_not_found(model_id);
+        }
+        let non_dp_workers: Vec<Arc<dyn Worker>> = all_workers
+            .iter()
+            .filter(|w| !w.is_dp_aware())
+            .cloned()
+            .collect();
+        if non_dp_workers.is_empty() {
             return error::bad_request(
                 "dp_aware_not_supported",
                 "/v1/audio/transcriptions does not yet support DP-aware workers",
             );
         }
+        let available: Vec<Arc<dyn Worker>> = non_dp_workers
+            .iter()
+            .filter(|w| w.is_available())
+            .cloned()
+            .collect();
+        if available.is_empty() {
+            return error::service_unavailable(
+                "no_available_workers",
+                "All workers are unavailable (circuit breaker open or unhealthy)",
+            );
+        }
 
         let policy = self.policy_registry.get_policy_or_default(model_id);
+        let hash_ring = self.worker_registry.get_hash_ring(model_id);
+        let idx = match policy.select_worker(
+            &available,
+            &SelectWorkerInfo {
+                request_text: Some(&text),
+                tokens: None,
+                headers,
+                hash_ring,
+            },
+        ) {
+            Some(i) => i,
+            None => {
+                return error::service_unavailable(
+                    "no_available_workers",
+                    "Policy returned no eligible worker",
+                );
+            }
+        };
+        Metrics::record_worker_selection(
+            metrics_labels::WORKER_REGULAR,
+            metrics_labels::CONNECTION_HTTP,
+            model_id,
+            policy.name(),
+        );
+        let worker = available[idx].clone();
+
         let load_guard = ["cache_aware", "manual"]
             .contains(&policy.name())
             .then(|| WorkerLoadGuard::new(worker.clone(), headers));
@@ -581,9 +613,22 @@ impl Router {
                     e
                 );
                 let err_resp = convert_reqwest_error(e);
+                let err_status = err_resp.status();
+                // Feed the synthetic status into the worker circuit breaker
+                // and worker-error metric; transport failures (timeouts,
+                // connect errors) must be visible to health tracking so the
+                // same bad worker isn't picked repeatedly.
+                worker.record_outcome(err_status.as_u16());
+                if err_status.is_server_error() {
+                    Metrics::record_worker_error(
+                        metrics_labels::WORKER_REGULAR,
+                        metrics_labels::CONNECTION_HTTP,
+                        error_type_from_status(err_status),
+                    );
+                }
                 Metrics::record_router_upstream_response(
                     metrics_labels::ROUTER_HTTP,
-                    err_resp.status().as_u16(),
+                    err_status.as_u16(),
                     extract_error_code_from_response(&err_resp),
                 );
                 // Mirror route_typed_request: a send failure must still bump
@@ -594,7 +639,7 @@ impl Router {
                     metrics_labels::CONNECTION_HTTP,
                     model_id,
                     endpoint,
-                    error_type_from_status(err_resp.status()),
+                    error_type_from_status(err_status),
                 );
                 return err_resp;
             }

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -699,12 +699,19 @@ impl Router {
             // chunks in memory.
             const STREAM_RELAY_BUFFER: usize = 32;
             let (tx, rx) = mpsc::channel::<Result<bytes::Bytes, String>>(STREAM_RELAY_BUFFER);
+            // Attribute stream outcome to the worker from inside the relay
+            // task: a mid-stream error after a 2xx header must mark the
+            // worker failed (502-synthetic) so the circuit breaker and
+            // worker-error metric track the transport failure.
+            let worker_for_stream = worker.clone();
+            let stream_header_status = status.as_u16();
             #[expect(
                 clippy::disallowed_methods,
                 reason = "fire-and-forget stream relay; gateway shutdown need not wait for individual stream forwarding"
             )]
             tokio::spawn(async move {
                 let mut stream = stream;
+                let mut stream_failed = false;
                 while let Some(chunk) = stream.next().await {
                     match chunk {
                         Ok(bytes) => {
@@ -713,10 +720,24 @@ impl Router {
                             }
                         }
                         Err(e) => {
+                            stream_failed = true;
                             let _ = tx.send(Err(format!("Stream error: {e}"))).await;
                             break;
                         }
                     }
+                }
+                let outcome_status = if stream_failed {
+                    StatusCode::BAD_GATEWAY.as_u16()
+                } else {
+                    stream_header_status
+                };
+                worker_for_stream.record_outcome(outcome_status);
+                if stream_failed {
+                    Metrics::record_worker_error(
+                        metrics_labels::WORKER_REGULAR,
+                        metrics_labels::CONNECTION_HTTP,
+                        error_type_from_status(StatusCode::BAD_GATEWAY),
+                    );
                 }
             });
             let stream = ReceiverStream::new(rx);
@@ -748,16 +769,19 @@ impl Router {
         // response if reading the body fails. Classify metrics off the final
         // response the client will actually see, not the upstream status.
         let final_status = response.status();
-        // Feed the final status into the circuit breaker / worker-error
-        // metric here — not at header time — so a body-read failure after a
-        // 2xx header is still attributed to the worker that produced it.
-        worker.record_outcome(final_status.as_u16());
-        if final_status.is_server_error() {
-            Metrics::record_worker_error(
-                metrics_labels::WORKER_REGULAR,
-                metrics_labels::CONNECTION_HTTP,
-                error_type_from_status(final_status),
-            );
+        if !is_stream {
+            // Feed the final status into the circuit breaker / worker-error
+            // metric here — not at header time — so a body-read failure after
+            // a 2xx header is still attributed to the worker that produced
+            // it. Streaming outcomes are recorded inside the relay task.
+            worker.record_outcome(final_status.as_u16());
+            if final_status.is_server_error() {
+                Metrics::record_worker_error(
+                    metrics_labels::WORKER_REGULAR,
+                    metrics_labels::CONNECTION_HTTP,
+                    error_type_from_status(final_status),
+                );
+            }
         }
         if final_status.is_success() {
             Metrics::record_router_duration(

--- a/model_gateway/src/routers/mod.rs
+++ b/model_gateway/src/routers/mod.rs
@@ -23,6 +23,7 @@ use openai_protocol::{
     },
     rerank::RerankRequest,
     responses::ResponsesRequest,
+    transcription::TranscriptionRequest,
 };
 
 pub mod anthropic;
@@ -43,6 +44,20 @@ pub mod tokenize;
 pub use factory::RouterFactory;
 // Re-export HTTP routers for convenience
 pub use http::{pd_router, pd_types, router};
+
+/// Binary audio payload for `/v1/audio/transcriptions`.
+///
+/// The transcription endpoint uses multipart/form-data, so the file bytes
+/// travel alongside the JSON-like `TranscriptionRequest` rather than inside it.
+#[derive(Debug, Clone)]
+pub struct AudioFile {
+    /// Raw audio bytes (wav/mp3/m4a/etc.).
+    pub bytes: bytes::Bytes,
+    /// Original filename from the multipart part. Forwarded verbatim to the worker.
+    pub file_name: String,
+    /// Original content-type of the audio part (e.g. `audio/wav`), if the client supplied one.
+    pub content_type: Option<String>,
+}
 
 /// Core trait for all router implementations
 ///
@@ -164,6 +179,26 @@ pub trait RouterTrait: Send + Sync + Debug {
         _model_id: &str,
     ) -> Response {
         (StatusCode::NOT_IMPLEMENTED, "Classify not implemented").into_response()
+    }
+
+    /// Route audio transcription requests (OpenAI-compatible /v1/audio/transcriptions).
+    ///
+    /// Unlike the JSON-bodied endpoints, `/v1/audio/transcriptions` uses
+    /// multipart/form-data: the server handler parses the form, packs text
+    /// fields into `body` and the audio part into `audio`, and routers forward
+    /// both to a worker capable of audio transcription.
+    async fn route_audio_transcriptions(
+        &self,
+        _headers: Option<&HeaderMap>,
+        _body: &TranscriptionRequest,
+        _audio: AudioFile,
+        _model_id: &str,
+    ) -> Response {
+        (
+            StatusCode::NOT_IMPLEMENTED,
+            "Audio transcriptions not implemented",
+        )
+            .into_response()
     }
 
     /// Route rerank requests

--- a/model_gateway/src/routers/router_manager.rs
+++ b/model_gateway/src/routers/router_manager.rs
@@ -33,6 +33,7 @@ use openai_protocol::{
     },
     rerank::RerankRequest,
     responses::ResponsesRequest,
+    transcription::TranscriptionRequest,
 };
 use serde_json::Value;
 use tracing::{debug, info, warn};
@@ -43,7 +44,7 @@ use crate::{
     routers::{
         common::header_utils::apply_provider_headers,
         factory::{router_ids, RouterId},
-        RouterFactory, RouterTrait,
+        AudioFile, RouterFactory, RouterTrait,
     },
     server::ServerConfig,
     worker::{ConnectionMode, ProviderType, RuntimeType, WorkerRegistry, WorkerType},
@@ -665,6 +666,28 @@ impl RouterTrait for RouterManager {
 
         if let Some(router) = router {
             router.route_classify(headers, body, model_id).await
+        } else {
+            (
+                StatusCode::NOT_FOUND,
+                format!("Model '{}' not found or no router available", body.model),
+            )
+                .into_response()
+        }
+    }
+
+    async fn route_audio_transcriptions(
+        &self,
+        headers: Option<&HeaderMap>,
+        body: &TranscriptionRequest,
+        audio: AudioFile,
+        model_id: &str,
+    ) -> Response {
+        let router = self.select_router_for_request(headers, Some(model_id));
+
+        if let Some(router) = router {
+            router
+                .route_audio_transcriptions(headers, body, audio, model_id)
+                .await
         } else {
             (
                 StatusCode::NOT_FOUND,

--- a/model_gateway/src/server.rs
+++ b/model_gateway/src/server.rs
@@ -365,10 +365,17 @@ async fn v1_audio_transcriptions(
                 Err(e) => return bad_text_field("timestamp_granularities", e),
             },
             "stream" => match field.text().await {
-                Ok(t) => {
-                    let truthy = matches!(t.as_str(), "true" | "1" | "True" | "TRUE");
-                    req.stream = Some(truthy);
-                }
+                Ok(t) => match t.as_str() {
+                    "true" | "True" | "TRUE" | "1" => req.stream = Some(true),
+                    "false" | "False" | "FALSE" | "0" => req.stream = Some(false),
+                    other => {
+                        return (
+                            StatusCode::BAD_REQUEST,
+                            format!("Invalid 'stream' value: '{other}' (expected true/false/1/0)"),
+                        )
+                            .into_response();
+                    }
+                },
                 Err(e) => return bad_text_field("stream", e),
             },
             _ => {

--- a/model_gateway/src/server.rs
+++ b/model_gateway/src/server.rs
@@ -396,11 +396,16 @@ async fn v1_audio_transcriptions(
         }
     }
 
-    if req.model.is_empty() {
+    // Reject blank/whitespace-only `model` before it reaches worker selection.
+    if req.model.trim().is_empty() {
         return (StatusCode::BAD_REQUEST, "Missing required 'model' field").into_response();
     }
+    req.model = req.model.trim().to_string();
     let bytes = match file_bytes {
-        Some(b) => b,
+        Some(b) if !b.is_empty() => b,
+        Some(_) => {
+            return (StatusCode::BAD_REQUEST, "Uploaded 'file' part is empty").into_response();
+        }
         None => {
             return (StatusCode::BAD_REQUEST, "Missing required 'file' part").into_response();
         }

--- a/model_gateway/src/server.rs
+++ b/model_gateway/src/server.rs
@@ -348,8 +348,19 @@ async fn v1_audio_transcriptions(
                 Err(e) => return bad_text_field("response_format", e),
             },
             "temperature" => match field.text().await {
-                Ok(t) => match t.parse::<f32>() {
-                    Ok(v) => req.temperature = Some(v),
+                Ok(t) => match t.trim().parse::<f32>() {
+                    Ok(v) if v.is_finite() && (0.0..=1.0).contains(&v) => {
+                        req.temperature = Some(v);
+                    }
+                    Ok(v) => {
+                        return (
+                            StatusCode::BAD_REQUEST,
+                            format!(
+                                "Invalid 'temperature' value: {v} (must be a finite number in [0.0, 1.0])"
+                            ),
+                        )
+                            .into_response();
+                    }
                     Err(e) => {
                         return (
                             StatusCode::BAD_REQUEST,
@@ -832,7 +843,6 @@ pub fn build_app(
         .route("/v1/messages", post(v1_messages))
         .route("/v1/interactions", post(v1_interactions))
         .route("/v1/classify", post(v1_classify))
-        .route("/v1/audio/transcriptions", post(v1_audio_transcriptions))
         // Tokenize / Detokenize endpoints
         .route("/v1/tokenize", post(v1_tokenize))
         .route("/v1/detokenize", post(v1_detokenize))
@@ -865,6 +875,22 @@ pub fn build_app(
     let realtime_routes = Router::new()
         .route("/v1/realtime", get(v1_realtime_ws))
         .route("/v1/realtime/calls", post(v1_realtime_webrtc))
+        .route_layer(axum::middleware::from_fn_with_state(
+            app_state.clone(),
+            middleware::concurrency_limit_middleware,
+        ))
+        .route_layer(axum::middleware::from_fn_with_state(
+            auth_config.clone(),
+            middleware::auth_middleware,
+        ));
+
+    // Multipart upload routes: auth + concurrency but NO WASM middleware.
+    // The WASM OnRequest phase buffers the full body into a `Vec<u8>` subject
+    // to the WASM manager's `max_body_size` (10MB default). Audio uploads
+    // routinely exceed that, so WASM middleware would reject them with 400
+    // before reaching the handler.
+    let multipart_upload_routes = Router::new()
+        .route("/v1/audio/transcriptions", post(v1_audio_transcriptions))
         .route_layer(axum::middleware::from_fn_with_state(
             app_state.clone(),
             middleware::concurrency_limit_middleware,
@@ -957,6 +983,7 @@ pub fn build_app(
     Router::new()
         .merge(protected_routes)
         .merge(realtime_routes)
+        .merge(multipart_upload_routes)
         .merge(public_routes)
         .merge(admin_routes)
         .merge(worker_routes)

--- a/model_gateway/src/server.rs
+++ b/model_gateway/src/server.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use axum::{
-    extract::{Path, Query, Request, State},
+    extract::{multipart::MultipartError, Multipart, Path, Query, Request, State},
     http::StatusCode,
     response::{IntoResponse, Response},
     routing::{delete, get, post},
@@ -30,6 +30,7 @@ use openai_protocol::{
     rerank::{RerankRequest, V1RerankReqInput},
     responses::ResponsesRequest,
     tokenize::{AddTokenizerRequest, DetokenizeRequest, TokenizeRequest},
+    transcription::TranscriptionRequest,
     validated::ValidatedJson,
     worker::{WorkerSpec, WorkerUpdateRequest},
 };
@@ -62,7 +63,7 @@ use crate::{
         openai::realtime::ws::RealtimeQueryParams,
         parse, responses as response_handlers,
         router_manager::RouterManager,
-        tokenize, RouterTrait,
+        tokenize, AudioFile, RouterTrait,
     },
     service_discovery::{start_service_discovery, ServiceDiscoveryConfig},
     wasm::route::{add_wasm_module, list_wasm_modules, remove_wasm_module},
@@ -288,6 +289,127 @@ async fn v1_classify(
         .router
         .route_classify(Some(&headers), &body, &body.model)
         .await
+}
+
+async fn v1_audio_transcriptions(
+    State(state): State<Arc<AppState>>,
+    headers: http::HeaderMap,
+    mut multipart: Multipart,
+) -> Response {
+    let mut file_bytes: Option<bytes::Bytes> = None;
+    let mut file_name: Option<String> = None;
+    let mut file_content_type: Option<String> = None;
+    let mut req = TranscriptionRequest::default();
+    let mut timestamp_granularities: Vec<String> = Vec::new();
+
+    loop {
+        let field = match multipart.next_field().await {
+            Ok(Some(f)) => f,
+            Ok(None) => break,
+            Err(e) => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    format!("Failed to read multipart field: {e}"),
+                )
+                    .into_response();
+            }
+        };
+
+        let name = field.name().unwrap_or("").to_string();
+        match name.as_str() {
+            "file" => {
+                file_name = field.file_name().map(str::to_string);
+                file_content_type = field.content_type().map(str::to_string);
+                match field.bytes().await {
+                    Ok(b) => file_bytes = Some(b),
+                    Err(e) => {
+                        return (
+                            StatusCode::BAD_REQUEST,
+                            format!("Failed to read audio file bytes: {e}"),
+                        )
+                            .into_response();
+                    }
+                }
+            }
+            "model" => match field.text().await {
+                Ok(t) => req.model = t,
+                Err(e) => return bad_text_field("model", e),
+            },
+            "language" => match field.text().await {
+                Ok(t) => req.language = Some(t),
+                Err(e) => return bad_text_field("language", e),
+            },
+            "prompt" => match field.text().await {
+                Ok(t) => req.prompt = Some(t),
+                Err(e) => return bad_text_field("prompt", e),
+            },
+            "response_format" => match field.text().await {
+                Ok(t) => req.response_format = Some(t),
+                Err(e) => return bad_text_field("response_format", e),
+            },
+            "temperature" => match field.text().await {
+                Ok(t) => match t.parse::<f32>() {
+                    Ok(v) => req.temperature = Some(v),
+                    Err(e) => {
+                        return (
+                            StatusCode::BAD_REQUEST,
+                            format!("Invalid 'temperature' value: {e}"),
+                        )
+                            .into_response();
+                    }
+                },
+                Err(e) => return bad_text_field("temperature", e),
+            },
+            "timestamp_granularities" | "timestamp_granularities[]" => match field.text().await {
+                Ok(t) => timestamp_granularities.push(t),
+                Err(e) => return bad_text_field("timestamp_granularities", e),
+            },
+            "stream" => match field.text().await {
+                Ok(t) => {
+                    let truthy = matches!(t.as_str(), "true" | "1" | "True" | "TRUE");
+                    req.stream = Some(truthy);
+                }
+                Err(e) => return bad_text_field("stream", e),
+            },
+            _ => {
+                // Unknown field; drain to free resources but otherwise ignore.
+                let _ = field.bytes().await;
+            }
+        }
+    }
+
+    if req.model.is_empty() {
+        return (StatusCode::BAD_REQUEST, "Missing required 'model' field").into_response();
+    }
+    let bytes = match file_bytes {
+        Some(b) => b,
+        None => {
+            return (StatusCode::BAD_REQUEST, "Missing required 'file' part").into_response();
+        }
+    };
+
+    if !timestamp_granularities.is_empty() {
+        req.timestamp_granularities = Some(timestamp_granularities);
+    }
+
+    let audio = AudioFile {
+        bytes,
+        file_name: file_name.unwrap_or_else(|| "audio".to_string()),
+        content_type: file_content_type,
+    };
+
+    state
+        .router
+        .route_audio_transcriptions(Some(&headers), &req, audio, &req.model)
+        .await
+}
+
+fn bad_text_field(field: &str, e: MultipartError) -> Response {
+    (
+        StatusCode::BAD_REQUEST,
+        format!("Failed to read '{field}' field: {e}"),
+    )
+        .into_response()
 }
 
 async fn v1_responses_get(
@@ -703,6 +825,7 @@ pub fn build_app(
         .route("/v1/messages", post(v1_messages))
         .route("/v1/interactions", post(v1_interactions))
         .route("/v1/classify", post(v1_classify))
+        .route("/v1/audio/transcriptions", post(v1_audio_transcriptions))
         // Tokenize / Detokenize endpoints
         .route("/v1/tokenize", post(v1_tokenize))
         .route("/v1/detokenize", post(v1_detokenize))


### PR DESCRIPTION
## Summary

Adds routing for the OpenAI-compatible `/v1/audio/transcriptions` endpoint so Whisper (on vLLM or SGLang) workers can be served from SMG alongside text models.

Follows the same topology as `/v1/embeddings` and `/v1/classify` — pick a worker by the `model` field, forward to the worker, return the response — but swaps the JSON body for `multipart/form-data` since the endpoint carries an audio file. Streaming is supported when `stream=true`.

## Changes

- **`crates/protocols/src/transcription.rs`** (new) — `TranscriptionRequest` with OpenAI-compatible fields (`model`, `language`, `prompt`, `response_format`, `temperature`, `timestamp_granularities`, `stream`). Audio bytes live out-of-band in an `AudioFile` payload since the wire format is multipart, not JSON. Implements `GenerationRequest` so it composes with existing worker-selection logic.
- **`model_gateway/src/routers/mod.rs`** — `AudioFile` struct (bytes + filename + content-type) and `RouterTrait::route_audio_transcriptions` with a default `NOT_IMPLEMENTED` impl.
- **`model_gateway/src/routers/http/router.rs`** — `route_multipart_transcription` helper and the trait impl. Reuses `select_worker_for_model`, load-guard policy, metrics, and the SSE passthrough machinery from `send_typed_request`. Builds `reqwest::multipart::Form` from the parsed request + file, skipping client-supplied `content-type`/`content-length` so reqwest can set the multipart boundary.
- **`model_gateway/src/routers/router_manager.rs`** — per-model router dispatch mirroring `route_classify`.
- **`model_gateway/src/server.rs`** — `v1_audio_transcriptions` axum handler using the `multipart` extractor. Parses known fields, drains unknown ones, validates that `model` and `file` are present, then calls the router. Route mounted next to `/v1/classify`.
- **`model_gateway/src/observability/metrics.rs`** and **`routers/grpc/utils/metrics.rs`** — `audio_transcriptions` endpoint label so router metrics don't bucket it into `other`.
- **`model_gateway/Cargo.toml`** — enable axum's `multipart` feature.

## Test plan

- [x] \`cargo check -p smg --all-targets\`
- [x] \`cargo clippy -p smg --lib --bins\` (clean)
- [x] \`cargo clippy -p openai-protocol --all-targets\` (clean)
- [ ] Integration: register a Whisper worker (vLLM `--task transcription` or SGLang whisper server) with an SMG instance; curl \`/v1/audio/transcriptions\` with a wav file and verify the JSON matches a direct worker call.
- [ ] Integration: \`stream=true\` mode forwards SSE chunks from the backend.
- [ ] Integration: missing \`model\` / missing \`file\` → 400 with a clear message.

## Notes

- The `ModelType::AUDIO` capability bit already exists, so worker filtering by audio capability is available once workers register with it.
- PD routers fall through to the trait's default `NOT_IMPLEMENTED` — transcription is a single forward pass so PD disaggregation doesn't apply.
- First-cut: no request-level retry for transcription (multi-MB audio bodies would need careful buffering to retry safely). Can be layered in later if desired.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added audio transcription endpoint (POST /v1/audio/transcriptions) with multipart/form-data audio upload, model selection, optional language, prompt, response format, temperature, timestamp granularity, and streaming/non-streaming responses. Validates inputs and returns clear 400s for malformed requests; returns 404/503 when no suitable worker is available. Endpoint is protected by auth and concurrency limits.
* **Observability**
  * Metrics extended to record audio transcription requests, outcomes, and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->