### PR TITLE
feat(skills): add storage contracts and schema migrations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["model_gateway", "crates/protocols", "crates/reasoning_parser", "crates/tool_parser", "crates/workflow", "crates/tokenizer", "crates/auth", "crates/mcp", "crates/kv_index", "crates/data_connector", "crates/multimodal", "crates/wasm", "crates/mesh", "crates/grpc_client", "crates/skills", "bindings/python", "bindings/golang", "clients/rust", "clients/openapi-gen", "tui"]
+members = ["model_gateway", "crates/protocols", "crates/reasoning_parser", "crates/tool_parser", "crates/workflow", "crates/tokenizer", "crates/auth", "crates/mcp", "crates/kv_index", "crates/data_connector", "crates/multimodal", "crates/wasm", "crates/mesh", "crates/grpc_client", "crates/skills", "crates/blob_storage", "bindings/python", "bindings/golang", "clients/rust", "clients/openapi-gen", "tui"]
 resolver = "2"
 
 [workspace.dependencies]
@@ -18,6 +18,7 @@ smg-wasm = { version = "1.1.0", path = "crates/wasm", package = "smg-wasm" }
 smg-mesh = { version = "1.3.0", path = "crates/mesh", package = "smg-mesh" }
 smg-grpc-client = { version = "1.5.1", path = "crates/grpc_client" }
 smg-skills = { version = "0.1.0", path = "crates/skills" }
+smg-blob-storage = { version = "0.1.0", path = "crates/blob_storage" }
 smg-tui = { version = "0.1.0", path = "tui" }
 
 # Shared dependencies

--- a/crates/blob_storage/Cargo.toml
+++ b/crates/blob_storage/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "smg-skills"
+name = "smg-blob-storage"
 version = "0.1.0"
 edition = "2021"
-description = "Skills domain types and service scaffolding for SMG"
+description = "Generic blob/object storage contracts for SMG"
 license = "Apache-2.0"
 repository = "https://github.com/lightseekorg/smg"
 authors = [
@@ -10,24 +10,18 @@ authors = [
     "Chang Su <mckvtl@gmail.com>",
     "Keyang Ru <rukeyang@gmail.com>",
 ]
-keywords = ["skills", "agents", "gateway"]
-categories = ["web-programming", "network-programming"]
+keywords = ["blob", "storage", "s3", "gcs", "azure"]
+categories = ["filesystem", "web-programming"]
 
 [lib]
-name = "smg_skills"
+name = "smg_blob_storage"
 
 [dependencies]
 async-trait.workspace = true
 chrono = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
-serde_yml = "0.0.12"
-smg-blob-storage.workspace = true
 thiserror.workspace = true
-zip = "8.1"
-
-[dev-dependencies]
-anyhow.workspace = true
-serde_json.workspace = true
+tokio = { workspace = true, features = ["io-util"] }
 
 [lints]
 workspace = true

--- a/crates/blob_storage/src/config.rs
+++ b/crates/blob_storage/src/config.rs
@@ -1,0 +1,46 @@
+use serde::{Deserialize, Serialize};
+
+/// Supported blob-store backend families.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum BlobStoreBackend {
+    #[default]
+    Filesystem,
+    S3,
+    Gcs,
+    Azure,
+    Oci,
+}
+
+/// Backend-neutral blob-store configuration shared by the skills subsystem.
+///
+/// The fields stay intentionally small in this first PR and cover the existing
+/// skills config surface. Provider-specific auth and richer backend configs
+/// arrive with the concrete backend implementations.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct BlobStoreConfig {
+    pub backend: BlobStoreBackend,
+    pub path: String,
+    pub bucket: Option<String>,
+    pub prefix: Option<String>,
+    pub region: Option<String>,
+    pub endpoint: Option<String>,
+    pub read_retry_window_ms: u64,
+    pub read_retry_max_attempts: u32,
+}
+
+impl Default for BlobStoreConfig {
+    fn default() -> Self {
+        Self {
+            backend: BlobStoreBackend::Filesystem,
+            path: "/var/smg/skills".to_string(),
+            bucket: None,
+            prefix: None,
+            region: None,
+            endpoint: None,
+            read_retry_window_ms: 2000,
+            read_retry_max_attempts: 3,
+        }
+    }
+}

--- a/crates/blob_storage/src/lib.rs
+++ b/crates/blob_storage/src/lib.rs
@@ -1,0 +1,15 @@
+//! Generic blob/object storage contracts for the skills subsystem.
+//!
+//! This crate intentionally defines only backend-neutral configuration and
+//! trait types. Concrete filesystem and cloud-provider implementations land in
+//! later PRs.
+
+mod config;
+mod store;
+mod types;
+
+pub use config::{BlobStoreBackend, BlobStoreConfig};
+pub use store::{BlobStore, BlobStoreError};
+pub use types::{
+    BlobKey, BlobMetadata, BlobPrefix, GetBlobResponse, ListBlobsPage, PutBlobRequest,
+};

--- a/crates/blob_storage/src/store.rs
+++ b/crates/blob_storage/src/store.rs
@@ -1,0 +1,44 @@
+use async_trait::async_trait;
+
+use crate::types::{
+    BlobKey, BlobMetadata, BlobPrefix, GetBlobResponse, ListBlobsPage, PutBlobRequest,
+};
+
+/// Blob/object-store error surface used by the skills subsystem.
+#[derive(Debug, thiserror::Error)]
+pub enum BlobStoreError {
+    #[error("blob not found: {key}")]
+    NotFound { key: String },
+
+    #[error("invalid blob key `{key}`: {message}")]
+    InvalidKey { key: String, message: String },
+
+    #[error("blob store operation `{operation}` failed: {message}")]
+    Operation {
+        operation: &'static str,
+        message: String,
+    },
+}
+
+/// Backend-neutral blob/object storage contract.
+#[async_trait]
+pub trait BlobStore: Send + Sync + 'static {
+    async fn put_stream(
+        &self,
+        key: &BlobKey,
+        request: PutBlobRequest,
+    ) -> Result<BlobMetadata, BlobStoreError>;
+
+    async fn get(&self, key: &BlobKey) -> Result<GetBlobResponse, BlobStoreError>;
+
+    async fn head(&self, key: &BlobKey) -> Result<Option<BlobMetadata>, BlobStoreError>;
+
+    async fn delete(&self, key: &BlobKey) -> Result<(), BlobStoreError>;
+
+    async fn list_prefix(
+        &self,
+        prefix: &BlobPrefix,
+        cursor: Option<String>,
+        limit: usize,
+    ) -> Result<ListBlobsPage, BlobStoreError>;
+}

--- a/crates/blob_storage/src/types.rs
+++ b/crates/blob_storage/src/types.rs
@@ -5,6 +5,10 @@ use serde::{Deserialize, Serialize};
 use tokio::io::AsyncRead;
 
 /// Canonical blob key used across blob-store backends.
+///
+/// This type is an opaque label, not a validated filesystem path. Concrete
+/// backends are responsible for validating and rejecting dangerous keys such as
+/// traversal attempts or absolute paths before using them.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct BlobKey(pub String);
 

--- a/crates/blob_storage/src/types.rs
+++ b/crates/blob_storage/src/types.rs
@@ -1,0 +1,66 @@
+use std::pin::Pin;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use tokio::io::AsyncRead;
+
+/// Canonical blob key used across blob-store backends.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct BlobKey(pub String);
+
+impl From<String> for BlobKey {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
+impl From<&str> for BlobKey {
+    fn from(value: &str) -> Self {
+        Self(value.to_string())
+    }
+}
+
+/// Prefix used for paginated blob listings.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct BlobPrefix(pub String);
+
+impl From<String> for BlobPrefix {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
+impl From<&str> for BlobPrefix {
+    fn from(value: &str) -> Self {
+        Self(value.to_string())
+    }
+}
+
+/// Backend-neutral blob metadata.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BlobMetadata {
+    pub key: BlobKey,
+    pub size_bytes: u64,
+    pub etag: Option<String>,
+    pub last_modified: Option<DateTime<Utc>>,
+}
+
+/// Streaming upload request for a single blob.
+pub struct PutBlobRequest {
+    pub reader: Pin<Box<dyn AsyncRead + Send>>,
+    pub content_length: u64,
+    pub content_type: Option<String>,
+}
+
+/// Streaming download response for a single blob.
+pub struct GetBlobResponse {
+    pub reader: Pin<Box<dyn AsyncRead + Send>>,
+    pub metadata: BlobMetadata,
+}
+
+/// One page of blob-listing results.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ListBlobsPage {
+    pub blobs: Vec<BlobMetadata>,
+    pub next_cursor: Option<String>,
+}

--- a/crates/data_connector/src/oracle_migrations.rs
+++ b/crates/data_connector/src/oracle_migrations.rs
@@ -120,29 +120,35 @@ fn oracle_v3_up(schema: &SchemaConfig) -> Vec<String> {
         .collect()
 }
 
+fn oracle_idempotent_ddl(ddl: &str) -> String {
+    let escaped = ddl.replace('\'', "''");
+    format!(
+        "BEGIN EXECUTE IMMEDIATE '{escaped}'; \
+         EXCEPTION WHEN OTHERS THEN IF SQLCODE != -955 THEN RAISE; END IF; END;"
+    )
+}
+
 fn oracle_v4_up(schema: &SchemaConfig) -> Vec<String> {
     let table = oracle_qualified_name(schema, "SKILLS");
     let index = oracle_qualified_name(schema, "IDX_SKILLS_TENANT_NAME");
     vec![
-        format!(
-            "BEGIN EXECUTE IMMEDIATE 'CREATE TABLE {table} (\
-             ID VARCHAR2(64) PRIMARY KEY, \
-             TENANT_ID VARCHAR2(64) NOT NULL, \
-             NAME VARCHAR2(64) NOT NULL, \
-             SHORT_DESCRIPTION CLOB, \
-             DESCRIPTION CLOB, \
-             SOURCE VARCHAR2(64) DEFAULT ''custom'' NOT NULL, \
-             HAS_CODE_FILES NUMBER(1) DEFAULT 0 NOT NULL, \
-             LATEST_VERSION VARCHAR2(64), \
-             DEFAULT_VERSION VARCHAR2(64), \
-             CREATED_AT TIMESTAMP WITH TIME ZONE NOT NULL, \
-             UPDATED_AT TIMESTAMP WITH TIME ZONE NOT NULL)'; \
-             EXCEPTION WHEN OTHERS THEN IF SQLCODE != -955 THEN RAISE; END IF; END;"
-        ),
-        format!(
-            "BEGIN EXECUTE IMMEDIATE 'CREATE INDEX {index} ON {table} (TENANT_ID, NAME)'; \
-             EXCEPTION WHEN OTHERS THEN IF SQLCODE != -955 THEN RAISE; END IF; END;"
-        ),
+        oracle_idempotent_ddl(&format!(
+            "CREATE TABLE {table} (\
+             SKILL_ID VARCHAR2(64) PRIMARY KEY, \
+            TENANT_ID VARCHAR2(64) NOT NULL, \
+            NAME VARCHAR2(64) NOT NULL, \
+            SHORT_DESCRIPTION CLOB, \
+            DESCRIPTION CLOB, \
+            SOURCE VARCHAR2(64) DEFAULT 'custom' NOT NULL, \
+            HAS_CODE_FILES NUMBER(1) DEFAULT 0 NOT NULL, \
+            LATEST_VERSION VARCHAR2(64), \
+            DEFAULT_VERSION VARCHAR2(64), \
+            CREATED_AT TIMESTAMP WITH TIME ZONE NOT NULL, \
+             UPDATED_AT TIMESTAMP WITH TIME ZONE NOT NULL)"
+        )),
+        oracle_idempotent_ddl(&format!(
+            "CREATE INDEX {index} ON {table} (TENANT_ID, NAME)"
+        )),
     ]
 }
 
@@ -151,8 +157,8 @@ fn oracle_v5_up(schema: &SchemaConfig) -> Vec<String> {
     let table = oracle_qualified_name(schema, "SKILL_VERSIONS");
     let index = oracle_qualified_name(schema, "IDX_SKILL_VERSION_NUMBER");
     vec![
-        format!(
-            "BEGIN EXECUTE IMMEDIATE 'CREATE TABLE {table} (\
+        oracle_idempotent_ddl(&format!(
+            "CREATE TABLE {table} (\
              SKILL_ID VARCHAR2(64) NOT NULL, \
              VERSION VARCHAR2(64) NOT NULL, \
              VERSION_NUMBER NUMBER(10) NOT NULL, \
@@ -167,13 +173,11 @@ fn oracle_v5_up(schema: &SchemaConfig) -> Vec<String> {
              INSTRUCTION_TOKEN_COUNTS CLOB NOT NULL CHECK (INSTRUCTION_TOKEN_COUNTS IS JSON), \
              CREATED_AT TIMESTAMP WITH TIME ZONE NOT NULL, \
              CONSTRAINT PK_SKILL_VERSIONS PRIMARY KEY (SKILL_ID, VERSION), \
-             CONSTRAINT FK_SKILL_VERSIONS_SKILL FOREIGN KEY (SKILL_ID) REFERENCES {skills_table}(ID) ON DELETE CASCADE)'; \
-             EXCEPTION WHEN OTHERS THEN IF SQLCODE != -955 THEN RAISE; END IF; END;"
-        ),
-        format!(
-            "BEGIN EXECUTE IMMEDIATE 'CREATE UNIQUE INDEX {index} ON {table} (SKILL_ID, VERSION_NUMBER)'; \
-             EXCEPTION WHEN OTHERS THEN IF SQLCODE != -955 THEN RAISE; END IF; END;"
-        ),
+             CONSTRAINT FK_SKILL_VERSIONS_SKILL FOREIGN KEY (SKILL_ID) REFERENCES {skills_table}(SKILL_ID) ON DELETE CASCADE)"
+        )),
+        oracle_idempotent_ddl(&format!(
+            "CREATE UNIQUE INDEX {index} ON {table} (SKILL_ID, VERSION_NUMBER)"
+        )),
     ]
 }
 
@@ -181,18 +185,16 @@ fn oracle_v6_up(schema: &SchemaConfig) -> Vec<String> {
     let table = oracle_qualified_name(schema, "TENANT_ALIASES");
     let index = oracle_qualified_name(schema, "IDX_TENANT_ALIASES_CANONICAL");
     vec![
-        format!(
-            "BEGIN EXECUTE IMMEDIATE 'CREATE TABLE {table} (\
+        oracle_idempotent_ddl(&format!(
+            "CREATE TABLE {table} (\
              ALIAS_TENANT_ID VARCHAR2(64) PRIMARY KEY, \
              CANONICAL_TENANT_ID VARCHAR2(64) NOT NULL, \
              CREATED_AT TIMESTAMP WITH TIME ZONE NOT NULL, \
-             EXPIRES_AT TIMESTAMP WITH TIME ZONE)'; \
-             EXCEPTION WHEN OTHERS THEN IF SQLCODE != -955 THEN RAISE; END IF; END;"
-        ),
-        format!(
-            "BEGIN EXECUTE IMMEDIATE 'CREATE INDEX {index} ON {table} (CANONICAL_TENANT_ID)'; \
-             EXCEPTION WHEN OTHERS THEN IF SQLCODE != -955 THEN RAISE; END IF; END;"
-        ),
+             EXPIRES_AT TIMESTAMP WITH TIME ZONE)"
+        )),
+        oracle_idempotent_ddl(&format!(
+            "CREATE INDEX {index} ON {table} (CANONICAL_TENANT_ID)"
+        )),
     ]
 }
 
@@ -201,25 +203,20 @@ fn oracle_v7_up(schema: &SchemaConfig) -> Vec<String> {
     let exec_index = oracle_qualified_name(schema, "IDX_BUNDLE_TOKENS_EXEC_ID");
     let expires_index = oracle_qualified_name(schema, "IDX_BUNDLE_TOKENS_EXPIRES_AT");
     vec![
-        format!(
-            "BEGIN EXECUTE IMMEDIATE 'CREATE TABLE {table} (\
+        oracle_idempotent_ddl(&format!(
+            "CREATE TABLE {table} (\
              TOKEN_HASH VARCHAR2(64) PRIMARY KEY, \
              TENANT_ID VARCHAR2(64) NOT NULL, \
              EXEC_ID VARCHAR2(64) NOT NULL, \
              SKILL_ID VARCHAR2(64) NOT NULL, \
              SKILL_VERSION VARCHAR2(64) NOT NULL, \
              CREATED_AT TIMESTAMP WITH TIME ZONE NOT NULL, \
-             EXPIRES_AT TIMESTAMP WITH TIME ZONE NOT NULL)'; \
-             EXCEPTION WHEN OTHERS THEN IF SQLCODE != -955 THEN RAISE; END IF; END;"
-        ),
-        format!(
-            "BEGIN EXECUTE IMMEDIATE 'CREATE INDEX {exec_index} ON {table} (EXEC_ID)'; \
-             EXCEPTION WHEN OTHERS THEN IF SQLCODE != -955 THEN RAISE; END IF; END;"
-        ),
-        format!(
-            "BEGIN EXECUTE IMMEDIATE 'CREATE INDEX {expires_index} ON {table} (EXPIRES_AT)'; \
-             EXCEPTION WHEN OTHERS THEN IF SQLCODE != -955 THEN RAISE; END IF; END;"
-        ),
+             EXPIRES_AT TIMESTAMP WITH TIME ZONE NOT NULL)"
+        )),
+        oracle_idempotent_ddl(&format!("CREATE INDEX {exec_index} ON {table} (EXEC_ID)")),
+        oracle_idempotent_ddl(&format!(
+            "CREATE INDEX {expires_index} ON {table} (EXPIRES_AT)"
+        )),
     ]
 }
 
@@ -228,24 +225,19 @@ fn oracle_v8_up(schema: &SchemaConfig) -> Vec<String> {
     let exec_index = oracle_qualified_name(schema, "IDX_CONTINUATION_COOKIES_EXEC");
     let expires_index = oracle_qualified_name(schema, "IDX_CONTINUATION_COOKIES_EXP");
     vec![
-        format!(
-            "BEGIN EXECUTE IMMEDIATE 'CREATE TABLE {table} (\
+        oracle_idempotent_ddl(&format!(
+            "CREATE TABLE {table} (\
              COOKIE_HASH VARCHAR2(64) PRIMARY KEY, \
              TENANT_ID VARCHAR2(64) NOT NULL, \
              EXEC_ID VARCHAR2(64) NOT NULL, \
              REQUEST_ID VARCHAR2(64) NOT NULL, \
              CREATED_AT TIMESTAMP WITH TIME ZONE NOT NULL, \
-             EXPIRES_AT TIMESTAMP WITH TIME ZONE NOT NULL)'; \
-             EXCEPTION WHEN OTHERS THEN IF SQLCODE != -955 THEN RAISE; END IF; END;"
-        ),
-        format!(
-            "BEGIN EXECUTE IMMEDIATE 'CREATE INDEX {exec_index} ON {table} (EXEC_ID)'; \
-             EXCEPTION WHEN OTHERS THEN IF SQLCODE != -955 THEN RAISE; END IF; END;"
-        ),
-        format!(
-            "BEGIN EXECUTE IMMEDIATE 'CREATE INDEX {expires_index} ON {table} (EXPIRES_AT)'; \
-             EXCEPTION WHEN OTHERS THEN IF SQLCODE != -955 THEN RAISE; END IF; END;"
-        ),
+             EXPIRES_AT TIMESTAMP WITH TIME ZONE NOT NULL)"
+        )),
+        oracle_idempotent_ddl(&format!("CREATE INDEX {exec_index} ON {table} (EXEC_ID)")),
+        oracle_idempotent_ddl(&format!(
+            "CREATE INDEX {expires_index} ON {table} (EXPIRES_AT)"
+        )),
     ]
 }
 
@@ -366,6 +358,7 @@ mod tests {
         let stmts = oracle_v4_up(&schema);
         assert_eq!(stmts.len(), 2);
         assert!(stmts[0].contains("CREATE TABLE SKILLS"));
+        assert!(stmts[0].contains("SKILL_ID VARCHAR2(64) PRIMARY KEY"));
         assert!(stmts[0].contains("SOURCE VARCHAR2(64) DEFAULT ''custom'' NOT NULL"));
         assert!(stmts[0].contains("CREATED_AT TIMESTAMP WITH TIME ZONE NOT NULL"));
         assert!(stmts[0].contains("UPDATED_AT TIMESTAMP WITH TIME ZONE NOT NULL"));
@@ -379,7 +372,7 @@ mod tests {
         assert_eq!(stmts.len(), 2);
         assert!(stmts[0].contains("CREATE TABLE SKILL_VERSIONS"));
         assert!(stmts[0].contains("CHECK (FILE_MANIFEST IS JSON)"));
-        assert!(stmts[0].contains("REFERENCES SKILLS(ID) ON DELETE CASCADE"));
+        assert!(stmts[0].contains("REFERENCES SKILLS(SKILL_ID) ON DELETE CASCADE"));
         assert!(stmts[0].contains("CREATED_AT TIMESTAMP WITH TIME ZONE NOT NULL"));
         assert!(stmts[1].contains("IDX_SKILL_VERSION_NUMBER"));
     }
@@ -419,5 +412,53 @@ mod tests {
         assert!(stmts[0].contains("EXPIRES_AT TIMESTAMP WITH TIME ZONE NOT NULL"));
         assert!(stmts[1].contains("IDX_CONTINUATION_COOKIES_EXEC"));
         assert!(stmts[2].contains("IDX_CONTINUATION_COOKIES_EXP"));
+    }
+
+    #[test]
+    fn oracle_idempotent_ddl_escapes_single_quotes() {
+        let stmt = oracle_idempotent_ddl("CREATE TABLE T (SOURCE VARCHAR2(64) DEFAULT 'custom')");
+        assert!(stmt.contains("DEFAULT ''custom''"));
+        assert!(stmt.contains("SQLCODE != -955"));
+    }
+
+    #[test]
+    fn oracle_v4_to_v8_qualify_objects_with_owner() {
+        let schema = SchemaConfig {
+            owner: Some("OWNER".to_string()),
+            ..Default::default()
+        };
+
+        let v4 = oracle_v4_up(&schema);
+        assert!(v4[0].contains("CREATE TABLE OWNER.SKILLS"));
+        assert!(v4[1].contains("CREATE INDEX OWNER.IDX_SKILLS_TENANT_NAME ON OWNER.SKILLS"));
+
+        let v5 = oracle_v5_up(&schema);
+        assert!(v5[0].contains("CREATE TABLE OWNER.SKILL_VERSIONS"));
+        assert!(v5[0].contains("REFERENCES OWNER.SKILLS(SKILL_ID) ON DELETE CASCADE"));
+        assert!(v5[1].contains(
+            "CREATE UNIQUE INDEX OWNER.IDX_SKILL_VERSION_NUMBER ON OWNER.SKILL_VERSIONS"
+        ));
+
+        let v6 = oracle_v6_up(&schema);
+        assert!(v6[0].contains("CREATE TABLE OWNER.TENANT_ALIASES"));
+        assert!(v6[1]
+            .contains("CREATE INDEX OWNER.IDX_TENANT_ALIASES_CANONICAL ON OWNER.TENANT_ALIASES"));
+
+        let v7 = oracle_v7_up(&schema);
+        assert!(v7[0].contains("CREATE TABLE OWNER.BUNDLE_TOKENS"));
+        assert!(
+            v7[1].contains("CREATE INDEX OWNER.IDX_BUNDLE_TOKENS_EXEC_ID ON OWNER.BUNDLE_TOKENS")
+        );
+        assert!(v7[2]
+            .contains("CREATE INDEX OWNER.IDX_BUNDLE_TOKENS_EXPIRES_AT ON OWNER.BUNDLE_TOKENS"));
+
+        let v8 = oracle_v8_up(&schema);
+        assert!(v8[0].contains("CREATE TABLE OWNER.CONTINUATION_COOKIES"));
+        assert!(v8[1].contains(
+            "CREATE INDEX OWNER.IDX_CONTINUATION_COOKIES_EXEC ON OWNER.CONTINUATION_COOKIES"
+        ));
+        assert!(v8[2].contains(
+            "CREATE INDEX OWNER.IDX_CONTINUATION_COOKIES_EXP ON OWNER.CONTINUATION_COOKIES"
+        ));
     }
 }

--- a/crates/data_connector/src/oracle_migrations.rs
+++ b/crates/data_connector/src/oracle_migrations.rs
@@ -7,7 +7,7 @@
 use crate::{schema::SchemaConfig, versioning::Migration};
 
 /// Oracle migration list. Append new migrations here.
-pub(crate) static ORACLE_MIGRATIONS: [Migration; 3] = [
+pub(crate) static ORACLE_MIGRATIONS: [Migration; 8] = [
     Migration {
         version: 1,
         description: "Add safety_identifier column to responses",
@@ -23,6 +23,31 @@ pub(crate) static ORACLE_MIGRATIONS: [Migration; 3] = [
         description:
             "Drop redundant output, metadata, instructions, tool_calls columns from responses",
         up: oracle_v3_up,
+    },
+    Migration {
+        version: 4,
+        description: "Create skills table",
+        up: oracle_v4_up,
+    },
+    Migration {
+        version: 5,
+        description: "Create skill_versions table",
+        up: oracle_v5_up,
+    },
+    Migration {
+        version: 6,
+        description: "Create tenant_aliases table",
+        up: oracle_v6_up,
+    },
+    Migration {
+        version: 7,
+        description: "Create bundle_tokens table",
+        up: oracle_v7_up,
+    },
+    Migration {
+        version: 8,
+        description: "Create continuation_cookies table",
+        up: oracle_v8_up,
     },
 ];
 
@@ -93,6 +118,149 @@ fn oracle_v3_up(schema: &SchemaConfig) -> Vec<String> {
             }
         })
         .collect()
+}
+
+fn oracle_v4_up(schema: &SchemaConfig) -> Vec<String> {
+    let table = oracle_qualified_table(schema, "SKILLS");
+    let index = oracle_qualified_object(schema, "IDX_SKILLS_TENANT_NAME");
+    vec![
+        format!(
+            "BEGIN EXECUTE IMMEDIATE 'CREATE TABLE {table} (\
+             ID VARCHAR2(64) PRIMARY KEY, \
+             TENANT_ID VARCHAR2(64) NOT NULL, \
+             NAME VARCHAR2(64) NOT NULL, \
+             SHORT_DESCRIPTION CLOB, \
+             DESCRIPTION CLOB, \
+             SOURCE VARCHAR2(16) DEFAULT ''custom'' NOT NULL, \
+             HAS_CODE_FILES NUMBER(1) DEFAULT 0 NOT NULL, \
+             LATEST_VERSION VARCHAR2(64), \
+             DEFAULT_VERSION VARCHAR2(64), \
+             CREATED_AT TIMESTAMP NOT NULL, \
+             UPDATED_AT TIMESTAMP NOT NULL)'; \
+             EXCEPTION WHEN OTHERS THEN IF SQLCODE != -955 THEN RAISE; END IF; END;"
+        ),
+        format!(
+            "BEGIN EXECUTE IMMEDIATE 'CREATE INDEX {index} ON {table} (TENANT_ID, NAME)'; \
+             EXCEPTION WHEN OTHERS THEN IF SQLCODE != -955 THEN RAISE; END IF; END;"
+        ),
+    ]
+}
+
+fn oracle_v5_up(schema: &SchemaConfig) -> Vec<String> {
+    let skills_table = oracle_qualified_table(schema, "SKILLS");
+    let table = oracle_qualified_table(schema, "SKILL_VERSIONS");
+    let index = oracle_qualified_object(schema, "IDX_SKILL_VERSION_NUMBER");
+    vec![
+        format!(
+            "BEGIN EXECUTE IMMEDIATE 'CREATE TABLE {table} (\
+             SKILL_ID VARCHAR2(64) NOT NULL, \
+             VERSION VARCHAR2(64) NOT NULL, \
+             VERSION_NUMBER NUMBER(10) NOT NULL, \
+             NAME VARCHAR2(64) NOT NULL, \
+             SHORT_DESCRIPTION CLOB, \
+             DESCRIPTION CLOB NOT NULL, \
+             INTERFACE CLOB CHECK (INTERFACE IS JSON), \
+             DEPENDENCIES CLOB CHECK (DEPENDENCIES IS JSON), \
+             POLICY CLOB CHECK (POLICY IS JSON), \
+             DEPRECATED NUMBER(1) DEFAULT 0 NOT NULL, \
+             FILE_MANIFEST CLOB NOT NULL CHECK (FILE_MANIFEST IS JSON), \
+             INSTRUCTION_TOKEN_COUNTS CLOB NOT NULL CHECK (INSTRUCTION_TOKEN_COUNTS IS JSON), \
+             CREATED_AT TIMESTAMP NOT NULL, \
+             CONSTRAINT PK_SKILL_VERSIONS PRIMARY KEY (SKILL_ID, VERSION), \
+             CONSTRAINT FK_SKILL_VERSIONS_SKILL FOREIGN KEY (SKILL_ID) REFERENCES {skills_table}(ID) ON DELETE CASCADE)'; \
+             EXCEPTION WHEN OTHERS THEN IF SQLCODE != -955 THEN RAISE; END IF; END;"
+        ),
+        format!(
+            "BEGIN EXECUTE IMMEDIATE 'CREATE UNIQUE INDEX {index} ON {table} (SKILL_ID, VERSION_NUMBER)'; \
+             EXCEPTION WHEN OTHERS THEN IF SQLCODE != -955 THEN RAISE; END IF; END;"
+        ),
+    ]
+}
+
+fn oracle_v6_up(schema: &SchemaConfig) -> Vec<String> {
+    let table = oracle_qualified_table(schema, "TENANT_ALIASES");
+    let index = oracle_qualified_object(schema, "IDX_TENANT_ALIASES_CANONICAL");
+    vec![
+        format!(
+            "BEGIN EXECUTE IMMEDIATE 'CREATE TABLE {table} (\
+             ALIAS_TENANT_ID VARCHAR2(64) PRIMARY KEY, \
+             CANONICAL_TENANT_ID VARCHAR2(64) NOT NULL, \
+             CREATED_AT TIMESTAMP NOT NULL, \
+             EXPIRES_AT TIMESTAMP)'; \
+             EXCEPTION WHEN OTHERS THEN IF SQLCODE != -955 THEN RAISE; END IF; END;"
+        ),
+        format!(
+            "BEGIN EXECUTE IMMEDIATE 'CREATE INDEX {index} ON {table} (CANONICAL_TENANT_ID)'; \
+             EXCEPTION WHEN OTHERS THEN IF SQLCODE != -955 THEN RAISE; END IF; END;"
+        ),
+    ]
+}
+
+fn oracle_v7_up(schema: &SchemaConfig) -> Vec<String> {
+    let table = oracle_qualified_table(schema, "BUNDLE_TOKENS");
+    let exec_index = oracle_qualified_object(schema, "IDX_BUNDLE_TOKENS_EXEC_ID");
+    let expires_index = oracle_qualified_object(schema, "IDX_BUNDLE_TOKENS_EXPIRES_AT");
+    vec![
+        format!(
+            "BEGIN EXECUTE IMMEDIATE 'CREATE TABLE {table} (\
+             TOKEN VARCHAR2(64) PRIMARY KEY, \
+             TENANT_ID VARCHAR2(64) NOT NULL, \
+             EXEC_ID VARCHAR2(64) NOT NULL, \
+             SKILL_ID VARCHAR2(64) NOT NULL, \
+             SKILL_VERSION VARCHAR2(64) NOT NULL, \
+             CREATED_AT TIMESTAMP NOT NULL, \
+             EXPIRES_AT TIMESTAMP NOT NULL)'; \
+             EXCEPTION WHEN OTHERS THEN IF SQLCODE != -955 THEN RAISE; END IF; END;"
+        ),
+        format!(
+            "BEGIN EXECUTE IMMEDIATE 'CREATE INDEX {exec_index} ON {table} (EXEC_ID)'; \
+             EXCEPTION WHEN OTHERS THEN IF SQLCODE != -955 THEN RAISE; END IF; END;"
+        ),
+        format!(
+            "BEGIN EXECUTE IMMEDIATE 'CREATE INDEX {expires_index} ON {table} (EXPIRES_AT)'; \
+             EXCEPTION WHEN OTHERS THEN IF SQLCODE != -955 THEN RAISE; END IF; END;"
+        ),
+    ]
+}
+
+fn oracle_v8_up(schema: &SchemaConfig) -> Vec<String> {
+    let table = oracle_qualified_table(schema, "CONTINUATION_COOKIES");
+    let exec_index = oracle_qualified_object(schema, "IDX_CONTINUATION_COOKIES_EXEC");
+    let expires_index = oracle_qualified_object(schema, "IDX_CONTINUATION_COOKIES_EXP");
+    vec![
+        format!(
+            "BEGIN EXECUTE IMMEDIATE 'CREATE TABLE {table} (\
+             COOKIE VARCHAR2(64) PRIMARY KEY, \
+             TENANT_ID VARCHAR2(64) NOT NULL, \
+             EXEC_ID VARCHAR2(64) NOT NULL, \
+             REQUEST_ID VARCHAR2(64) NOT NULL, \
+             CREATED_AT TIMESTAMP NOT NULL, \
+             EXPIRES_AT TIMESTAMP NOT NULL)'; \
+             EXCEPTION WHEN OTHERS THEN IF SQLCODE != -955 THEN RAISE; END IF; END;"
+        ),
+        format!(
+            "BEGIN EXECUTE IMMEDIATE 'CREATE INDEX {exec_index} ON {table} (EXEC_ID)'; \
+             EXCEPTION WHEN OTHERS THEN IF SQLCODE != -955 THEN RAISE; END IF; END;"
+        ),
+        format!(
+            "BEGIN EXECUTE IMMEDIATE 'CREATE INDEX {expires_index} ON {table} (EXPIRES_AT)'; \
+             EXCEPTION WHEN OTHERS THEN IF SQLCODE != -955 THEN RAISE; END IF; END;"
+        ),
+    ]
+}
+
+fn oracle_qualified_table(schema: &SchemaConfig, table: &str) -> String {
+    match &schema.owner {
+        Some(owner) => format!("{owner}.{table}"),
+        None => table.to_string(),
+    }
+}
+
+fn oracle_qualified_object(schema: &SchemaConfig, object_name: &str) -> String {
+    match &schema.owner {
+        Some(owner) => format!("{owner}.{object_name}"),
+        None => object_name.to_string(),
+    }
 }
 
 // ── Tests ──────────────────────────────────────────────────────────────────
@@ -197,5 +365,55 @@ mod tests {
                 "should skip OUTPUT when mapped: {stmt}"
             );
         }
+    }
+
+    #[test]
+    fn oracle_v4_up_creates_skills_table_and_index() {
+        let schema = SchemaConfig::default();
+        let stmts = oracle_v4_up(&schema);
+        assert_eq!(stmts.len(), 2);
+        assert!(stmts[0].contains("CREATE TABLE SKILLS"));
+        assert!(stmts[0].contains("SOURCE VARCHAR2(16) DEFAULT ''custom'' NOT NULL"));
+        assert!(stmts[1].contains("IDX_SKILLS_TENANT_NAME"));
+    }
+
+    #[test]
+    fn oracle_v5_up_creates_skill_versions_table_and_index() {
+        let schema = SchemaConfig::default();
+        let stmts = oracle_v5_up(&schema);
+        assert_eq!(stmts.len(), 2);
+        assert!(stmts[0].contains("CREATE TABLE SKILL_VERSIONS"));
+        assert!(stmts[0].contains("CHECK (FILE_MANIFEST IS JSON)"));
+        assert!(stmts[0].contains("REFERENCES SKILLS(ID) ON DELETE CASCADE"));
+        assert!(stmts[1].contains("IDX_SKILL_VERSION_NUMBER"));
+    }
+
+    #[test]
+    fn oracle_v6_up_creates_tenant_aliases_table() {
+        let schema = SchemaConfig::default();
+        let stmts = oracle_v6_up(&schema);
+        assert_eq!(stmts.len(), 2);
+        assert!(stmts[0].contains("CREATE TABLE TENANT_ALIASES"));
+        assert!(stmts[1].contains("IDX_TENANT_ALIASES_CANONICAL"));
+    }
+
+    #[test]
+    fn oracle_v7_up_creates_bundle_tokens_table() {
+        let schema = SchemaConfig::default();
+        let stmts = oracle_v7_up(&schema);
+        assert_eq!(stmts.len(), 3);
+        assert!(stmts[0].contains("CREATE TABLE BUNDLE_TOKENS"));
+        assert!(stmts[1].contains("IDX_BUNDLE_TOKENS_EXEC_ID"));
+        assert!(stmts[2].contains("IDX_BUNDLE_TOKENS_EXPIRES_AT"));
+    }
+
+    #[test]
+    fn oracle_v8_up_creates_continuation_cookies_table() {
+        let schema = SchemaConfig::default();
+        let stmts = oracle_v8_up(&schema);
+        assert_eq!(stmts.len(), 3);
+        assert!(stmts[0].contains("CREATE TABLE CONTINUATION_COOKIES"));
+        assert!(stmts[1].contains("IDX_CONTINUATION_COOKIES_EXEC"));
+        assert!(stmts[2].contains("IDX_CONTINUATION_COOKIES_EXP"));
     }
 }

--- a/crates/data_connector/src/oracle_migrations.rs
+++ b/crates/data_connector/src/oracle_migrations.rs
@@ -121,8 +121,8 @@ fn oracle_v3_up(schema: &SchemaConfig) -> Vec<String> {
 }
 
 fn oracle_v4_up(schema: &SchemaConfig) -> Vec<String> {
-    let table = oracle_qualified_table(schema, "SKILLS");
-    let index = oracle_qualified_object(schema, "IDX_SKILLS_TENANT_NAME");
+    let table = oracle_qualified_name(schema, "SKILLS");
+    let index = oracle_qualified_name(schema, "IDX_SKILLS_TENANT_NAME");
     vec![
         format!(
             "BEGIN EXECUTE IMMEDIATE 'CREATE TABLE {table} (\
@@ -131,12 +131,12 @@ fn oracle_v4_up(schema: &SchemaConfig) -> Vec<String> {
              NAME VARCHAR2(64) NOT NULL, \
              SHORT_DESCRIPTION CLOB, \
              DESCRIPTION CLOB, \
-             SOURCE VARCHAR2(16) DEFAULT ''custom'' NOT NULL, \
+             SOURCE VARCHAR2(64) DEFAULT ''custom'' NOT NULL, \
              HAS_CODE_FILES NUMBER(1) DEFAULT 0 NOT NULL, \
              LATEST_VERSION VARCHAR2(64), \
              DEFAULT_VERSION VARCHAR2(64), \
-             CREATED_AT TIMESTAMP NOT NULL, \
-             UPDATED_AT TIMESTAMP NOT NULL)'; \
+             CREATED_AT TIMESTAMP WITH TIME ZONE NOT NULL, \
+             UPDATED_AT TIMESTAMP WITH TIME ZONE NOT NULL)'; \
              EXCEPTION WHEN OTHERS THEN IF SQLCODE != -955 THEN RAISE; END IF; END;"
         ),
         format!(
@@ -147,9 +147,9 @@ fn oracle_v4_up(schema: &SchemaConfig) -> Vec<String> {
 }
 
 fn oracle_v5_up(schema: &SchemaConfig) -> Vec<String> {
-    let skills_table = oracle_qualified_table(schema, "SKILLS");
-    let table = oracle_qualified_table(schema, "SKILL_VERSIONS");
-    let index = oracle_qualified_object(schema, "IDX_SKILL_VERSION_NUMBER");
+    let skills_table = oracle_qualified_name(schema, "SKILLS");
+    let table = oracle_qualified_name(schema, "SKILL_VERSIONS");
+    let index = oracle_qualified_name(schema, "IDX_SKILL_VERSION_NUMBER");
     vec![
         format!(
             "BEGIN EXECUTE IMMEDIATE 'CREATE TABLE {table} (\
@@ -165,7 +165,7 @@ fn oracle_v5_up(schema: &SchemaConfig) -> Vec<String> {
              DEPRECATED NUMBER(1) DEFAULT 0 NOT NULL, \
              FILE_MANIFEST CLOB NOT NULL CHECK (FILE_MANIFEST IS JSON), \
              INSTRUCTION_TOKEN_COUNTS CLOB NOT NULL CHECK (INSTRUCTION_TOKEN_COUNTS IS JSON), \
-             CREATED_AT TIMESTAMP NOT NULL, \
+             CREATED_AT TIMESTAMP WITH TIME ZONE NOT NULL, \
              CONSTRAINT PK_SKILL_VERSIONS PRIMARY KEY (SKILL_ID, VERSION), \
              CONSTRAINT FK_SKILL_VERSIONS_SKILL FOREIGN KEY (SKILL_ID) REFERENCES {skills_table}(ID) ON DELETE CASCADE)'; \
              EXCEPTION WHEN OTHERS THEN IF SQLCODE != -955 THEN RAISE; END IF; END;"
@@ -178,15 +178,15 @@ fn oracle_v5_up(schema: &SchemaConfig) -> Vec<String> {
 }
 
 fn oracle_v6_up(schema: &SchemaConfig) -> Vec<String> {
-    let table = oracle_qualified_table(schema, "TENANT_ALIASES");
-    let index = oracle_qualified_object(schema, "IDX_TENANT_ALIASES_CANONICAL");
+    let table = oracle_qualified_name(schema, "TENANT_ALIASES");
+    let index = oracle_qualified_name(schema, "IDX_TENANT_ALIASES_CANONICAL");
     vec![
         format!(
             "BEGIN EXECUTE IMMEDIATE 'CREATE TABLE {table} (\
              ALIAS_TENANT_ID VARCHAR2(64) PRIMARY KEY, \
              CANONICAL_TENANT_ID VARCHAR2(64) NOT NULL, \
-             CREATED_AT TIMESTAMP NOT NULL, \
-             EXPIRES_AT TIMESTAMP)'; \
+             CREATED_AT TIMESTAMP WITH TIME ZONE NOT NULL, \
+             EXPIRES_AT TIMESTAMP WITH TIME ZONE)'; \
              EXCEPTION WHEN OTHERS THEN IF SQLCODE != -955 THEN RAISE; END IF; END;"
         ),
         format!(
@@ -197,9 +197,9 @@ fn oracle_v6_up(schema: &SchemaConfig) -> Vec<String> {
 }
 
 fn oracle_v7_up(schema: &SchemaConfig) -> Vec<String> {
-    let table = oracle_qualified_table(schema, "BUNDLE_TOKENS");
-    let exec_index = oracle_qualified_object(schema, "IDX_BUNDLE_TOKENS_EXEC_ID");
-    let expires_index = oracle_qualified_object(schema, "IDX_BUNDLE_TOKENS_EXPIRES_AT");
+    let table = oracle_qualified_name(schema, "BUNDLE_TOKENS");
+    let exec_index = oracle_qualified_name(schema, "IDX_BUNDLE_TOKENS_EXEC_ID");
+    let expires_index = oracle_qualified_name(schema, "IDX_BUNDLE_TOKENS_EXPIRES_AT");
     vec![
         format!(
             "BEGIN EXECUTE IMMEDIATE 'CREATE TABLE {table} (\
@@ -208,8 +208,8 @@ fn oracle_v7_up(schema: &SchemaConfig) -> Vec<String> {
              EXEC_ID VARCHAR2(64) NOT NULL, \
              SKILL_ID VARCHAR2(64) NOT NULL, \
              SKILL_VERSION VARCHAR2(64) NOT NULL, \
-             CREATED_AT TIMESTAMP NOT NULL, \
-             EXPIRES_AT TIMESTAMP NOT NULL)'; \
+             CREATED_AT TIMESTAMP WITH TIME ZONE NOT NULL, \
+             EXPIRES_AT TIMESTAMP WITH TIME ZONE NOT NULL)'; \
              EXCEPTION WHEN OTHERS THEN IF SQLCODE != -955 THEN RAISE; END IF; END;"
         ),
         format!(
@@ -224,9 +224,9 @@ fn oracle_v7_up(schema: &SchemaConfig) -> Vec<String> {
 }
 
 fn oracle_v8_up(schema: &SchemaConfig) -> Vec<String> {
-    let table = oracle_qualified_table(schema, "CONTINUATION_COOKIES");
-    let exec_index = oracle_qualified_object(schema, "IDX_CONTINUATION_COOKIES_EXEC");
-    let expires_index = oracle_qualified_object(schema, "IDX_CONTINUATION_COOKIES_EXP");
+    let table = oracle_qualified_name(schema, "CONTINUATION_COOKIES");
+    let exec_index = oracle_qualified_name(schema, "IDX_CONTINUATION_COOKIES_EXEC");
+    let expires_index = oracle_qualified_name(schema, "IDX_CONTINUATION_COOKIES_EXP");
     vec![
         format!(
             "BEGIN EXECUTE IMMEDIATE 'CREATE TABLE {table} (\
@@ -234,8 +234,8 @@ fn oracle_v8_up(schema: &SchemaConfig) -> Vec<String> {
              TENANT_ID VARCHAR2(64) NOT NULL, \
              EXEC_ID VARCHAR2(64) NOT NULL, \
              REQUEST_ID VARCHAR2(64) NOT NULL, \
-             CREATED_AT TIMESTAMP NOT NULL, \
-             EXPIRES_AT TIMESTAMP NOT NULL)'; \
+             CREATED_AT TIMESTAMP WITH TIME ZONE NOT NULL, \
+             EXPIRES_AT TIMESTAMP WITH TIME ZONE NOT NULL)'; \
              EXCEPTION WHEN OTHERS THEN IF SQLCODE != -955 THEN RAISE; END IF; END;"
         ),
         format!(
@@ -249,14 +249,7 @@ fn oracle_v8_up(schema: &SchemaConfig) -> Vec<String> {
     ]
 }
 
-fn oracle_qualified_table(schema: &SchemaConfig, table: &str) -> String {
-    match &schema.owner {
-        Some(owner) => format!("{owner}.{table}"),
-        None => table.to_string(),
-    }
-}
-
-fn oracle_qualified_object(schema: &SchemaConfig, object_name: &str) -> String {
+fn oracle_qualified_name(schema: &SchemaConfig, object_name: &str) -> String {
     match &schema.owner {
         Some(owner) => format!("{owner}.{object_name}"),
         None => object_name.to_string(),
@@ -373,7 +366,9 @@ mod tests {
         let stmts = oracle_v4_up(&schema);
         assert_eq!(stmts.len(), 2);
         assert!(stmts[0].contains("CREATE TABLE SKILLS"));
-        assert!(stmts[0].contains("SOURCE VARCHAR2(16) DEFAULT ''custom'' NOT NULL"));
+        assert!(stmts[0].contains("SOURCE VARCHAR2(64) DEFAULT ''custom'' NOT NULL"));
+        assert!(stmts[0].contains("CREATED_AT TIMESTAMP WITH TIME ZONE NOT NULL"));
+        assert!(stmts[0].contains("UPDATED_AT TIMESTAMP WITH TIME ZONE NOT NULL"));
         assert!(stmts[1].contains("IDX_SKILLS_TENANT_NAME"));
     }
 
@@ -385,6 +380,7 @@ mod tests {
         assert!(stmts[0].contains("CREATE TABLE SKILL_VERSIONS"));
         assert!(stmts[0].contains("CHECK (FILE_MANIFEST IS JSON)"));
         assert!(stmts[0].contains("REFERENCES SKILLS(ID) ON DELETE CASCADE"));
+        assert!(stmts[0].contains("CREATED_AT TIMESTAMP WITH TIME ZONE NOT NULL"));
         assert!(stmts[1].contains("IDX_SKILL_VERSION_NUMBER"));
     }
 
@@ -394,6 +390,8 @@ mod tests {
         let stmts = oracle_v6_up(&schema);
         assert_eq!(stmts.len(), 2);
         assert!(stmts[0].contains("CREATE TABLE TENANT_ALIASES"));
+        assert!(stmts[0].contains("CREATED_AT TIMESTAMP WITH TIME ZONE NOT NULL"));
+        assert!(stmts[0].contains("EXPIRES_AT TIMESTAMP WITH TIME ZONE"));
         assert!(stmts[1].contains("IDX_TENANT_ALIASES_CANONICAL"));
     }
 
@@ -403,6 +401,8 @@ mod tests {
         let stmts = oracle_v7_up(&schema);
         assert_eq!(stmts.len(), 3);
         assert!(stmts[0].contains("CREATE TABLE BUNDLE_TOKENS"));
+        assert!(stmts[0].contains("CREATED_AT TIMESTAMP WITH TIME ZONE NOT NULL"));
+        assert!(stmts[0].contains("EXPIRES_AT TIMESTAMP WITH TIME ZONE NOT NULL"));
         assert!(stmts[1].contains("IDX_BUNDLE_TOKENS_EXEC_ID"));
         assert!(stmts[2].contains("IDX_BUNDLE_TOKENS_EXPIRES_AT"));
     }
@@ -413,6 +413,8 @@ mod tests {
         let stmts = oracle_v8_up(&schema);
         assert_eq!(stmts.len(), 3);
         assert!(stmts[0].contains("CREATE TABLE CONTINUATION_COOKIES"));
+        assert!(stmts[0].contains("CREATED_AT TIMESTAMP WITH TIME ZONE NOT NULL"));
+        assert!(stmts[0].contains("EXPIRES_AT TIMESTAMP WITH TIME ZONE NOT NULL"));
         assert!(stmts[1].contains("IDX_CONTINUATION_COOKIES_EXEC"));
         assert!(stmts[2].contains("IDX_CONTINUATION_COOKIES_EXP"));
     }

--- a/crates/data_connector/src/oracle_migrations.rs
+++ b/crates/data_connector/src/oracle_migrations.rs
@@ -203,7 +203,7 @@ fn oracle_v7_up(schema: &SchemaConfig) -> Vec<String> {
     vec![
         format!(
             "BEGIN EXECUTE IMMEDIATE 'CREATE TABLE {table} (\
-             TOKEN VARCHAR2(64) PRIMARY KEY, \
+             TOKEN_HASH VARCHAR2(64) PRIMARY KEY, \
              TENANT_ID VARCHAR2(64) NOT NULL, \
              EXEC_ID VARCHAR2(64) NOT NULL, \
              SKILL_ID VARCHAR2(64) NOT NULL, \
@@ -230,7 +230,7 @@ fn oracle_v8_up(schema: &SchemaConfig) -> Vec<String> {
     vec![
         format!(
             "BEGIN EXECUTE IMMEDIATE 'CREATE TABLE {table} (\
-             COOKIE VARCHAR2(64) PRIMARY KEY, \
+             COOKIE_HASH VARCHAR2(64) PRIMARY KEY, \
              TENANT_ID VARCHAR2(64) NOT NULL, \
              EXEC_ID VARCHAR2(64) NOT NULL, \
              REQUEST_ID VARCHAR2(64) NOT NULL, \
@@ -401,6 +401,7 @@ mod tests {
         let stmts = oracle_v7_up(&schema);
         assert_eq!(stmts.len(), 3);
         assert!(stmts[0].contains("CREATE TABLE BUNDLE_TOKENS"));
+        assert!(stmts[0].contains("TOKEN_HASH VARCHAR2(64) PRIMARY KEY"));
         assert!(stmts[0].contains("CREATED_AT TIMESTAMP WITH TIME ZONE NOT NULL"));
         assert!(stmts[0].contains("EXPIRES_AT TIMESTAMP WITH TIME ZONE NOT NULL"));
         assert!(stmts[1].contains("IDX_BUNDLE_TOKENS_EXEC_ID"));
@@ -413,6 +414,7 @@ mod tests {
         let stmts = oracle_v8_up(&schema);
         assert_eq!(stmts.len(), 3);
         assert!(stmts[0].contains("CREATE TABLE CONTINUATION_COOKIES"));
+        assert!(stmts[0].contains("COOKIE_HASH VARCHAR2(64) PRIMARY KEY"));
         assert!(stmts[0].contains("CREATED_AT TIMESTAMP WITH TIME ZONE NOT NULL"));
         assert!(stmts[0].contains("EXPIRES_AT TIMESTAMP WITH TIME ZONE NOT NULL"));
         assert!(stmts[1].contains("IDX_CONTINUATION_COOKIES_EXEC"));

--- a/crates/data_connector/src/postgres_migrations.rs
+++ b/crates/data_connector/src/postgres_migrations.rs
@@ -120,7 +120,7 @@ fn pg_v4_up(schema: &SchemaConfig) -> Vec<String> {
     vec![
         format!(
             "CREATE TABLE IF NOT EXISTS {table} (\
-             id VARCHAR(64) PRIMARY KEY, \
+             skill_id VARCHAR(64) PRIMARY KEY, \
              tenant_id VARCHAR(64) NOT NULL, \
              name VARCHAR(64) NOT NULL, \
              short_description TEXT, \
@@ -142,7 +142,7 @@ fn pg_v5_up(schema: &SchemaConfig) -> Vec<String> {
     vec![
         format!(
             "CREATE TABLE IF NOT EXISTS {table} (\
-             skill_id VARCHAR(64) NOT NULL REFERENCES {skills_table}(id) ON DELETE CASCADE, \
+             skill_id VARCHAR(64) NOT NULL REFERENCES {skills_table}(skill_id) ON DELETE CASCADE, \
              version VARCHAR(64) NOT NULL, \
              version_number INTEGER NOT NULL, \
              name VARCHAR(64) NOT NULL, \
@@ -367,6 +367,7 @@ mod tests {
         let stmts = pg_v4_up(&schema);
         assert_eq!(stmts.len(), 2);
         assert!(stmts[0].contains("CREATE TABLE IF NOT EXISTS skills"));
+        assert!(stmts[0].contains("skill_id VARCHAR(64) PRIMARY KEY"));
         assert!(stmts[0].contains("source VARCHAR(64) NOT NULL DEFAULT 'custom'"));
         assert!(stmts[1].contains("idx_skills_tenant_name"));
     }
@@ -377,7 +378,7 @@ mod tests {
         let stmts = pg_v5_up(&schema);
         assert_eq!(stmts.len(), 2);
         assert!(stmts[0].contains("CREATE TABLE IF NOT EXISTS skill_versions"));
-        assert!(stmts[0].contains("REFERENCES skills(id) ON DELETE CASCADE"));
+        assert!(stmts[0].contains("REFERENCES skills(skill_id) ON DELETE CASCADE"));
         assert!(stmts[0].contains("file_manifest JSONB NOT NULL"));
         assert!(stmts[0].contains("instruction_token_counts JSONB NOT NULL"));
         assert!(stmts[1].contains("idx_skill_version_number"));

--- a/crates/data_connector/src/postgres_migrations.rs
+++ b/crates/data_connector/src/postgres_migrations.rs
@@ -7,7 +7,7 @@
 use crate::{schema::SchemaConfig, versioning::Migration};
 
 /// Postgres migration list. Append new migrations here.
-pub(crate) static POSTGRES_MIGRATIONS: [Migration; 3] = [
+pub(crate) static POSTGRES_MIGRATIONS: [Migration; 8] = [
     Migration {
         version: 1,
         description: "Add safety_identifier column to responses",
@@ -23,6 +23,31 @@ pub(crate) static POSTGRES_MIGRATIONS: [Migration; 3] = [
         description:
             "Drop redundant output, metadata, instructions, tool_calls columns from responses",
         up: pg_v3_up,
+    },
+    Migration {
+        version: 4,
+        description: "Create skills table",
+        up: pg_v4_up,
+    },
+    Migration {
+        version: 5,
+        description: "Create skill_versions table",
+        up: pg_v5_up,
+    },
+    Migration {
+        version: 6,
+        description: "Create tenant_aliases table",
+        up: pg_v6_up,
+    },
+    Migration {
+        version: 7,
+        description: "Create bundle_tokens table",
+        up: pg_v7_up,
+    },
+    Migration {
+        version: 8,
+        description: "Create continuation_cookies table",
+        up: pg_v8_up,
     },
 ];
 
@@ -88,6 +113,114 @@ fn pg_v3_up(schema: &SchemaConfig) -> Vec<String> {
     }
 
     vec![format!("ALTER TABLE {table} {}", cols_to_drop.join(", "))]
+}
+
+fn pg_v4_up(schema: &SchemaConfig) -> Vec<String> {
+    let table = pg_qualified_table(schema, "skills");
+    vec![
+        format!(
+            "CREATE TABLE IF NOT EXISTS {table} (\
+             id VARCHAR(64) PRIMARY KEY, \
+             tenant_id VARCHAR(64) NOT NULL, \
+             name VARCHAR(64) NOT NULL, \
+             short_description TEXT, \
+             description TEXT, \
+             source VARCHAR(16) NOT NULL DEFAULT 'custom', \
+             has_code_files BOOLEAN NOT NULL DEFAULT false, \
+             latest_version VARCHAR(64), \
+             default_version VARCHAR(64), \
+             created_at TIMESTAMPTZ NOT NULL, \
+             updated_at TIMESTAMPTZ NOT NULL)"
+        ),
+        format!("CREATE INDEX IF NOT EXISTS idx_skills_tenant_name ON {table}(tenant_id, name)"),
+    ]
+}
+
+fn pg_v5_up(schema: &SchemaConfig) -> Vec<String> {
+    let skills_table = pg_qualified_table(schema, "skills");
+    let table = pg_qualified_table(schema, "skill_versions");
+    vec![
+        format!(
+            "CREATE TABLE IF NOT EXISTS {table} (\
+             skill_id VARCHAR(64) NOT NULL REFERENCES {skills_table}(id) ON DELETE CASCADE, \
+             version VARCHAR(64) NOT NULL, \
+             version_number INTEGER NOT NULL, \
+             name VARCHAR(64) NOT NULL, \
+             short_description TEXT, \
+             description TEXT NOT NULL, \
+             interface JSONB, \
+             dependencies JSONB, \
+             policy JSONB, \
+             deprecated BOOLEAN NOT NULL DEFAULT false, \
+             file_manifest JSONB NOT NULL, \
+             instruction_token_counts JSONB NOT NULL, \
+             created_at TIMESTAMPTZ NOT NULL, \
+             PRIMARY KEY (skill_id, version))"
+        ),
+        format!(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_skill_version_number ON {table}(skill_id, version_number)"
+        ),
+    ]
+}
+
+fn pg_v6_up(schema: &SchemaConfig) -> Vec<String> {
+    let table = pg_qualified_table(schema, "tenant_aliases");
+    vec![
+        format!(
+            "CREATE TABLE IF NOT EXISTS {table} (\
+             alias_tenant_id VARCHAR(64) PRIMARY KEY, \
+             canonical_tenant_id VARCHAR(64) NOT NULL, \
+             created_at TIMESTAMPTZ NOT NULL, \
+             expires_at TIMESTAMPTZ)"
+        ),
+        format!(
+            "CREATE INDEX IF NOT EXISTS idx_tenant_aliases_canonical ON {table}(canonical_tenant_id)"
+        ),
+    ]
+}
+
+fn pg_v7_up(schema: &SchemaConfig) -> Vec<String> {
+    let table = pg_qualified_table(schema, "bundle_tokens");
+    vec![
+        format!(
+            "CREATE TABLE IF NOT EXISTS {table} (\
+             token VARCHAR(64) PRIMARY KEY, \
+             tenant_id VARCHAR(64) NOT NULL, \
+             exec_id VARCHAR(64) NOT NULL, \
+             skill_id VARCHAR(64) NOT NULL, \
+             skill_version VARCHAR(64) NOT NULL, \
+             created_at TIMESTAMPTZ NOT NULL, \
+             expires_at TIMESTAMPTZ NOT NULL)"
+        ),
+        format!("CREATE INDEX IF NOT EXISTS idx_bundle_tokens_exec_id ON {table}(exec_id)"),
+        format!("CREATE INDEX IF NOT EXISTS idx_bundle_tokens_expires_at ON {table}(expires_at)"),
+    ]
+}
+
+fn pg_v8_up(schema: &SchemaConfig) -> Vec<String> {
+    let table = pg_qualified_table(schema, "continuation_cookies");
+    vec![
+        format!(
+            "CREATE TABLE IF NOT EXISTS {table} (\
+             cookie VARCHAR(64) PRIMARY KEY, \
+             tenant_id VARCHAR(64) NOT NULL, \
+             exec_id VARCHAR(64) NOT NULL, \
+             request_id VARCHAR(64) NOT NULL, \
+             created_at TIMESTAMPTZ NOT NULL, \
+             expires_at TIMESTAMPTZ NOT NULL)"
+        ),
+        format!("CREATE INDEX IF NOT EXISTS idx_continuation_cookies_exec_id ON {table}(exec_id)"),
+        format!(
+            "CREATE INDEX IF NOT EXISTS idx_continuation_cookies_expires_at ON {table}(expires_at)"
+        ),
+    ]
+}
+
+fn pg_qualified_table(schema: &SchemaConfig, table: &str) -> String {
+    match schema.owner.as_deref() {
+        Some(owner) => format!("{owner}.{table}"),
+        None => table.to_string(),
+    }
 }
 
 // ── Tests ──────────────────────────────────────────────────────────────────
@@ -226,5 +359,56 @@ mod tests {
             !stmts[0].contains("EXISTS output"),
             "should not use logical name: {stmts:?}"
         );
+    }
+
+    #[test]
+    fn pg_v4_up_creates_skills_table_and_index() {
+        let schema = SchemaConfig::default();
+        let stmts = pg_v4_up(&schema);
+        assert_eq!(stmts.len(), 2);
+        assert!(stmts[0].contains("CREATE TABLE IF NOT EXISTS skills"));
+        assert!(stmts[0].contains("source VARCHAR(16) NOT NULL DEFAULT 'custom'"));
+        assert!(stmts[1].contains("idx_skills_tenant_name"));
+    }
+
+    #[test]
+    fn pg_v5_up_creates_skill_versions_table_and_index() {
+        let schema = SchemaConfig::default();
+        let stmts = pg_v5_up(&schema);
+        assert_eq!(stmts.len(), 2);
+        assert!(stmts[0].contains("CREATE TABLE IF NOT EXISTS skill_versions"));
+        assert!(stmts[0].contains("REFERENCES skills(id) ON DELETE CASCADE"));
+        assert!(stmts[0].contains("file_manifest JSONB NOT NULL"));
+        assert!(stmts[0].contains("instruction_token_counts JSONB NOT NULL"));
+        assert!(stmts[1].contains("idx_skill_version_number"));
+    }
+
+    #[test]
+    fn pg_v6_up_creates_tenant_aliases_table() {
+        let schema = SchemaConfig::default();
+        let stmts = pg_v6_up(&schema);
+        assert_eq!(stmts.len(), 2);
+        assert!(stmts[0].contains("CREATE TABLE IF NOT EXISTS tenant_aliases"));
+        assert!(stmts[1].contains("idx_tenant_aliases_canonical"));
+    }
+
+    #[test]
+    fn pg_v7_up_creates_bundle_tokens_table() {
+        let schema = SchemaConfig::default();
+        let stmts = pg_v7_up(&schema);
+        assert_eq!(stmts.len(), 3);
+        assert!(stmts[0].contains("CREATE TABLE IF NOT EXISTS bundle_tokens"));
+        assert!(stmts[1].contains("idx_bundle_tokens_exec_id"));
+        assert!(stmts[2].contains("idx_bundle_tokens_expires_at"));
+    }
+
+    #[test]
+    fn pg_v8_up_creates_continuation_cookies_table() {
+        let schema = SchemaConfig::default();
+        let stmts = pg_v8_up(&schema);
+        assert_eq!(stmts.len(), 3);
+        assert!(stmts[0].contains("CREATE TABLE IF NOT EXISTS continuation_cookies"));
+        assert!(stmts[1].contains("idx_continuation_cookies_exec_id"));
+        assert!(stmts[2].contains("idx_continuation_cookies_expires_at"));
     }
 }

--- a/crates/data_connector/src/postgres_migrations.rs
+++ b/crates/data_connector/src/postgres_migrations.rs
@@ -125,7 +125,7 @@ fn pg_v4_up(schema: &SchemaConfig) -> Vec<String> {
              name VARCHAR(64) NOT NULL, \
              short_description TEXT, \
              description TEXT, \
-             source VARCHAR(16) NOT NULL DEFAULT 'custom', \
+             source VARCHAR(64) NOT NULL DEFAULT 'custom', \
              has_code_files BOOLEAN NOT NULL DEFAULT false, \
              latest_version VARCHAR(64), \
              default_version VARCHAR(64), \
@@ -367,7 +367,7 @@ mod tests {
         let stmts = pg_v4_up(&schema);
         assert_eq!(stmts.len(), 2);
         assert!(stmts[0].contains("CREATE TABLE IF NOT EXISTS skills"));
-        assert!(stmts[0].contains("source VARCHAR(16) NOT NULL DEFAULT 'custom'"));
+        assert!(stmts[0].contains("source VARCHAR(64) NOT NULL DEFAULT 'custom'"));
         assert!(stmts[1].contains("idx_skills_tenant_name"));
     }
 

--- a/crates/data_connector/src/postgres_migrations.rs
+++ b/crates/data_connector/src/postgres_migrations.rs
@@ -184,7 +184,7 @@ fn pg_v7_up(schema: &SchemaConfig) -> Vec<String> {
     vec![
         format!(
             "CREATE TABLE IF NOT EXISTS {table} (\
-             token VARCHAR(64) PRIMARY KEY, \
+             token_hash VARCHAR(64) PRIMARY KEY, \
              tenant_id VARCHAR(64) NOT NULL, \
              exec_id VARCHAR(64) NOT NULL, \
              skill_id VARCHAR(64) NOT NULL, \
@@ -202,7 +202,7 @@ fn pg_v8_up(schema: &SchemaConfig) -> Vec<String> {
     vec![
         format!(
             "CREATE TABLE IF NOT EXISTS {table} (\
-             cookie VARCHAR(64) PRIMARY KEY, \
+             cookie_hash VARCHAR(64) PRIMARY KEY, \
              tenant_id VARCHAR(64) NOT NULL, \
              exec_id VARCHAR(64) NOT NULL, \
              request_id VARCHAR(64) NOT NULL, \
@@ -398,6 +398,7 @@ mod tests {
         let stmts = pg_v7_up(&schema);
         assert_eq!(stmts.len(), 3);
         assert!(stmts[0].contains("CREATE TABLE IF NOT EXISTS bundle_tokens"));
+        assert!(stmts[0].contains("token_hash VARCHAR(64) PRIMARY KEY"));
         assert!(stmts[1].contains("idx_bundle_tokens_exec_id"));
         assert!(stmts[2].contains("idx_bundle_tokens_expires_at"));
     }
@@ -408,6 +409,7 @@ mod tests {
         let stmts = pg_v8_up(&schema);
         assert_eq!(stmts.len(), 3);
         assert!(stmts[0].contains("CREATE TABLE IF NOT EXISTS continuation_cookies"));
+        assert!(stmts[0].contains("cookie_hash VARCHAR(64) PRIMARY KEY"));
         assert!(stmts[1].contains("idx_continuation_cookies_exec_id"));
         assert!(stmts[2].contains("idx_continuation_cookies_expires_at"));
     }

--- a/crates/data_connector/src/versioning.rs
+++ b/crates/data_connector/src/versioning.rs
@@ -5,6 +5,10 @@
 //! (DDL syntax differs across databases) and migrations reference
 //! [`SchemaConfig`] so they work correctly even with custom table/column names.
 //!
+//! SMG migrations are intentionally forward-only. The runner records applied
+//! versions and can auto-apply pending `up` steps, but it does not model or
+//! execute down-migrations.
+//!
 //! # Version tracking
 //!
 //! A `_schema_versions` table records which migrations have been applied.
@@ -30,7 +34,7 @@ use crate::schema::SchemaConfig;
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
-/// A single schema migration.
+/// A single forward-only schema migration.
 ///
 /// Migrations are functions (not static SQL strings) so they can reference
 /// [`SchemaConfig`] for table/column names. `up` returns a `Vec<String>`

--- a/crates/skills/src/config.rs
+++ b/crates/skills/src/config.rs
@@ -4,17 +4,9 @@ use serde::{
     de::{self, Visitor},
     Deserialize, Deserializer, Serialize, Serializer,
 };
-
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
-#[serde(rename_all = "snake_case")]
-pub enum SkillsBlobStoreBackend {
-    #[default]
-    Filesystem,
-    S3,
-    Gcs,
-    Azure,
-    Oci,
-}
+pub use smg_blob_storage::{
+    BlobStoreBackend as SkillsBlobStoreBackend, BlobStoreConfig as SkillsBlobStoreConfig,
+};
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
@@ -230,34 +222,6 @@ impl Default for SkillsAdminConfig {
                 SkillsAdminOperation::CreateAlias,
                 SkillsAdminOperation::ExecuteMigration,
             ],
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(default)]
-pub struct SkillsBlobStoreConfig {
-    pub backend: SkillsBlobStoreBackend,
-    pub path: String,
-    pub bucket: Option<String>,
-    pub prefix: Option<String>,
-    pub region: Option<String>,
-    pub endpoint: Option<String>,
-    pub read_retry_window_ms: u64,
-    pub read_retry_max_attempts: u32,
-}
-
-impl Default for SkillsBlobStoreConfig {
-    fn default() -> Self {
-        Self {
-            backend: SkillsBlobStoreBackend::Filesystem,
-            path: "/var/smg/skills".to_string(),
-            bucket: None,
-            prefix: None,
-            region: None,
-            endpoint: None,
-            read_retry_window_ms: 2000,
-            read_retry_max_attempts: 3,
         }
     }
 }

--- a/crates/skills/src/lib.rs
+++ b/crates/skills/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod api;
 pub mod config;
+pub mod storage;
 pub mod types;
 pub mod validation;
 
@@ -18,10 +19,15 @@ pub use config::{
     SkillsResolutionMode, SkillsRetentionConfig, SkillsRetentionMode, SkillsTenancyConfig,
     SkillsToolLoopConfig, SkillsZdrConfig,
 };
+pub use storage::{
+    BundleTokenStore, ContinuationCookieStore, SkillMetadataStore, SkillsStoreError,
+    SkillsStoreResult, TenantAliasStore,
+};
 pub use types::{
-    NormalizedSkillBundle, NormalizedSkillFile, ParsedSkillBundle, SkillDependencyTool,
-    SkillFileRecord, SkillInterfaceMetadata, SkillParseWarning, SkillParseWarningKind,
-    SkillPolicyMetadata, SkillRecord, SkillSidecarDependencies, SkillVersionRecord,
+    BundleTokenClaim, ContinuationCookieClaim, NormalizedSkillBundle, NormalizedSkillFile,
+    ParsedSkillBundle, SkillDependencyTool, SkillFileRecord, SkillInterfaceMetadata,
+    SkillParseWarning, SkillParseWarningKind, SkillPolicyMetadata, SkillRecord,
+    SkillSidecarDependencies, SkillVersionRecord, TenantAliasRecord,
 };
 pub use validation::{
     is_code_file_path, normalize_skill_bundle_zip, parse_skill_bundle, SkillBundleArchiveError,

--- a/crates/skills/src/storage.rs
+++ b/crates/skills/src/storage.rs
@@ -1,0 +1,93 @@
+use async_trait::async_trait;
+
+use crate::types::{
+    BundleTokenClaim, ContinuationCookieClaim, SkillRecord, SkillVersionRecord, TenantAliasRecord,
+};
+
+/// Shared error type for skills metadata/token persistence contracts.
+#[derive(Debug, thiserror::Error)]
+pub enum SkillsStoreError {
+    #[error("storage error: {0}")]
+    Storage(String),
+
+    #[error("invalid data: {0}")]
+    InvalidData(String),
+}
+
+/// Result alias for skills persistence operations.
+pub type SkillsStoreResult<T> = Result<T, SkillsStoreError>;
+
+/// Persistence contract for skill metadata rows and immutable version rows.
+#[async_trait]
+pub trait SkillMetadataStore: Send + Sync + 'static {
+    async fn put_skill(&self, record: SkillRecord) -> SkillsStoreResult<()>;
+
+    async fn get_skill(
+        &self,
+        tenant_id: &str,
+        skill_id: &str,
+    ) -> SkillsStoreResult<Option<SkillRecord>>;
+
+    async fn list_skills(&self, tenant_id: &str) -> SkillsStoreResult<Vec<SkillRecord>>;
+
+    async fn delete_skill(&self, tenant_id: &str, skill_id: &str) -> SkillsStoreResult<bool>;
+
+    async fn put_skill_version(&self, record: SkillVersionRecord) -> SkillsStoreResult<()>;
+
+    async fn get_skill_version(
+        &self,
+        skill_id: &str,
+        version: &str,
+    ) -> SkillsStoreResult<Option<SkillVersionRecord>>;
+
+    async fn list_skill_versions(
+        &self,
+        skill_id: &str,
+    ) -> SkillsStoreResult<Vec<SkillVersionRecord>>;
+
+    async fn delete_skill_version(&self, skill_id: &str, version: &str) -> SkillsStoreResult<bool>;
+}
+
+/// Persistence contract for tenant-alias rows.
+#[async_trait]
+pub trait TenantAliasStore: Send + Sync + 'static {
+    async fn put_tenant_alias(&self, record: TenantAliasRecord) -> SkillsStoreResult<()>;
+
+    async fn get_tenant_alias(
+        &self,
+        alias_tenant_id: &str,
+    ) -> SkillsStoreResult<Option<TenantAliasRecord>>;
+
+    async fn delete_tenant_alias(&self, alias_tenant_id: &str) -> SkillsStoreResult<bool>;
+}
+
+/// Persistence contract for opaque bundle-token claims.
+#[async_trait]
+pub trait BundleTokenStore: Send + Sync + 'static {
+    async fn put_bundle_token(&self, claim: BundleTokenClaim) -> SkillsStoreResult<()>;
+
+    async fn get_bundle_token(&self, token: &str) -> SkillsStoreResult<Option<BundleTokenClaim>>;
+
+    async fn revoke_bundle_token(&self, token: &str) -> SkillsStoreResult<bool>;
+
+    async fn revoke_bundle_tokens_for_exec(&self, exec_id: &str) -> SkillsStoreResult<usize>;
+}
+
+/// Persistence contract for opaque continuation-cookie claims.
+#[async_trait]
+pub trait ContinuationCookieStore: Send + Sync + 'static {
+    async fn put_continuation_cookie(
+        &self,
+        claim: ContinuationCookieClaim,
+    ) -> SkillsStoreResult<()>;
+
+    async fn get_continuation_cookie(
+        &self,
+        cookie: &str,
+    ) -> SkillsStoreResult<Option<ContinuationCookieClaim>>;
+
+    async fn revoke_continuation_cookie(&self, cookie: &str) -> SkillsStoreResult<bool>;
+
+    async fn revoke_continuation_cookies_for_exec(&self, exec_id: &str)
+        -> SkillsStoreResult<usize>;
+}

--- a/crates/skills/src/storage.rs
+++ b/crates/skills/src/storage.rs
@@ -61,19 +61,28 @@ pub trait TenantAliasStore: Send + Sync + 'static {
     async fn delete_tenant_alias(&self, alias_tenant_id: &str) -> SkillsStoreResult<bool>;
 }
 
-/// Persistence contract for opaque bundle-token claims.
+/// Persistence contract for bundle-token rows keyed by a deterministic secret hash.
+///
+/// Callers are expected to hash the presented bearer secret before invoking the
+/// lookup and revoke methods on this contract.
 #[async_trait]
 pub trait BundleTokenStore: Send + Sync + 'static {
     async fn put_bundle_token(&self, claim: BundleTokenClaim) -> SkillsStoreResult<()>;
 
-    async fn get_bundle_token(&self, token: &str) -> SkillsStoreResult<Option<BundleTokenClaim>>;
+    async fn get_bundle_token(
+        &self,
+        token_hash: &str,
+    ) -> SkillsStoreResult<Option<BundleTokenClaim>>;
 
-    async fn revoke_bundle_token(&self, token: &str) -> SkillsStoreResult<bool>;
+    async fn revoke_bundle_token(&self, token_hash: &str) -> SkillsStoreResult<bool>;
 
     async fn revoke_bundle_tokens_for_exec(&self, exec_id: &str) -> SkillsStoreResult<usize>;
 }
 
-/// Persistence contract for opaque continuation-cookie claims.
+/// Persistence contract for continuation-cookie rows keyed by a deterministic secret hash.
+///
+/// Callers are expected to hash the presented continuation secret before
+/// invoking the lookup and revoke methods on this contract.
 #[async_trait]
 pub trait ContinuationCookieStore: Send + Sync + 'static {
     async fn put_continuation_cookie(
@@ -83,10 +92,10 @@ pub trait ContinuationCookieStore: Send + Sync + 'static {
 
     async fn get_continuation_cookie(
         &self,
-        cookie: &str,
+        cookie_hash: &str,
     ) -> SkillsStoreResult<Option<ContinuationCookieClaim>>;
 
-    async fn revoke_continuation_cookie(&self, cookie: &str) -> SkillsStoreResult<bool>;
+    async fn revoke_continuation_cookie(&self, cookie_hash: &str) -> SkillsStoreResult<bool>;
 
     async fn revoke_continuation_cookies_for_exec(&self, exec_id: &str)
         -> SkillsStoreResult<usize>;

--- a/crates/skills/src/types.rs
+++ b/crates/skills/src/types.rs
@@ -1,7 +1,8 @@
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, fmt};
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use smg_blob_storage::BlobKey;
 
 /// Top-level skill metadata stored in the control-plane database.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -43,7 +44,7 @@ pub struct SkillFileRecord {
     pub relative_path: String,
     pub media_type: Option<String>,
     pub size_bytes: u64,
-    pub blob_key: Option<String>,
+    pub blob_key: Option<BlobKey>,
 }
 
 /// Tenant-alias mapping for request-time tenant resolution.
@@ -56,7 +57,7 @@ pub struct TenantAliasRecord {
 }
 
 /// Opaque bundle-token claims used for executor bundle downloads.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BundleTokenClaim {
     pub token: String,
     pub tenant_id: String,
@@ -68,7 +69,7 @@ pub struct BundleTokenClaim {
 }
 
 /// Opaque continuation-cookie claims used for pause-turn resumption.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ContinuationCookieClaim {
     pub cookie: String,
     pub tenant_id: String,
@@ -85,6 +86,33 @@ pub struct NormalizedSkillBundle {
     pub skill_md_path: String,
     pub openai_sidecar_path: Option<String>,
     pub has_code_files: bool,
+}
+
+impl fmt::Debug for BundleTokenClaim {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("BundleTokenClaim")
+            .field("token", &"<redacted>")
+            .field("tenant_id", &self.tenant_id)
+            .field("exec_id", &self.exec_id)
+            .field("skill_id", &self.skill_id)
+            .field("skill_version", &self.skill_version)
+            .field("created_at", &self.created_at)
+            .field("expires_at", &self.expires_at)
+            .finish()
+    }
+}
+
+impl fmt::Debug for ContinuationCookieClaim {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ContinuationCookieClaim")
+            .field("cookie", &"<redacted>")
+            .field("tenant_id", &self.tenant_id)
+            .field("exec_id", &self.exec_id)
+            .field("request_id", &self.request_id)
+            .field("created_at", &self.created_at)
+            .field("expires_at", &self.expires_at)
+            .finish()
+    }
 }
 
 impl NormalizedSkillBundle {

--- a/crates/skills/src/types.rs
+++ b/crates/skills/src/types.rs
@@ -1,3 +1,6 @@
+use std::collections::BTreeMap;
+
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 /// Top-level skill metadata stored in the control-plane database.
@@ -5,8 +8,15 @@ use serde::{Deserialize, Serialize};
 pub struct SkillRecord {
     pub tenant_id: String,
     pub skill_id: String,
-    pub display_name: String,
+    pub name: String,
+    pub short_description: Option<String>,
+    pub description: Option<String>,
+    pub source: String,
+    pub has_code_files: bool,
+    pub latest_version: Option<String>,
     pub default_version: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
 }
 
 /// Metadata for a single immutable skill version.
@@ -15,7 +25,16 @@ pub struct SkillVersionRecord {
     pub skill_id: String,
     pub version: String,
     pub version_number: u32,
-    pub has_code_files: bool,
+    pub name: String,
+    pub short_description: Option<String>,
+    pub description: String,
+    pub interface: Option<SkillInterfaceMetadata>,
+    pub dependencies: Option<SkillSidecarDependencies>,
+    pub policy: Option<SkillPolicyMetadata>,
+    pub deprecated: bool,
+    pub file_manifest: Vec<SkillFileRecord>,
+    pub instruction_token_counts: BTreeMap<String, u32>,
+    pub created_at: DateTime<Utc>,
 }
 
 /// File-level manifest entry stored alongside a normalized skill bundle.
@@ -24,6 +43,39 @@ pub struct SkillFileRecord {
     pub relative_path: String,
     pub media_type: Option<String>,
     pub size_bytes: u64,
+    pub blob_key: Option<String>,
+}
+
+/// Tenant-alias mapping for request-time tenant resolution.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TenantAliasRecord {
+    pub alias_tenant_id: String,
+    pub canonical_tenant_id: String,
+    pub created_at: DateTime<Utc>,
+    pub expires_at: Option<DateTime<Utc>>,
+}
+
+/// Opaque bundle-token claims used for executor bundle downloads.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BundleTokenClaim {
+    pub token: String,
+    pub tenant_id: String,
+    pub exec_id: String,
+    pub skill_id: String,
+    pub skill_version: String,
+    pub created_at: DateTime<Utc>,
+    pub expires_at: DateTime<Utc>,
+}
+
+/// Opaque continuation-cookie claims used for pause-turn resumption.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ContinuationCookieClaim {
+    pub cookie: String,
+    pub tenant_id: String,
+    pub exec_id: String,
+    pub request_id: String,
+    pub created_at: DateTime<Utc>,
+    pub expires_at: DateTime<Utc>,
 }
 
 /// Canonical in-memory representation of a validated skill bundle.
@@ -45,6 +97,7 @@ impl NormalizedSkillBundle {
                 relative_path: file.relative_path.clone(),
                 media_type: None,
                 size_bytes: file.size_bytes(),
+                blob_key: None,
             })
             .collect()
     }

--- a/crates/skills/src/types.rs
+++ b/crates/skills/src/types.rs
@@ -56,10 +56,10 @@ pub struct TenantAliasRecord {
     pub expires_at: Option<DateTime<Utc>>,
 }
 
-/// Opaque bundle-token claims used for executor bundle downloads.
+/// Persisted bundle-token claims keyed by a deterministic secret hash.
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BundleTokenClaim {
-    pub token: String,
+    pub token_hash: String,
     pub tenant_id: String,
     pub exec_id: String,
     pub skill_id: String,
@@ -68,10 +68,10 @@ pub struct BundleTokenClaim {
     pub expires_at: DateTime<Utc>,
 }
 
-/// Opaque continuation-cookie claims used for pause-turn resumption.
+/// Persisted continuation-cookie claims keyed by a deterministic secret hash.
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ContinuationCookieClaim {
-    pub cookie: String,
+    pub cookie_hash: String,
     pub tenant_id: String,
     pub exec_id: String,
     pub request_id: String,
@@ -91,7 +91,7 @@ pub struct NormalizedSkillBundle {
 impl fmt::Debug for BundleTokenClaim {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("BundleTokenClaim")
-            .field("token", &"<redacted>")
+            .field("token_hash", &"<redacted>")
             .field("tenant_id", &self.tenant_id)
             .field("exec_id", &self.exec_id)
             .field("skill_id", &self.skill_id)
@@ -105,7 +105,7 @@ impl fmt::Debug for BundleTokenClaim {
 impl fmt::Debug for ContinuationCookieClaim {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ContinuationCookieClaim")
-            .field("cookie", &"<redacted>")
+            .field("cookie_hash", &"<redacted>")
             .field("tenant_id", &self.tenant_id)
             .field("exec_id", &self.exec_id)
             .field("request_id", &self.request_id)


### PR DESCRIPTION
## Description

### Problem

`SKL-PR-06` needs the storage substrate for the skills system: a clean blob/object storage boundary, shared persistence contracts for skill metadata and token state, and additive schema migrations for the new skills tables. Without that foundation, later CRUD, resolution, and executor work has no stable interfaces or schema to build on.

### Solution

- add a new `smg-blob-storage` crate with backend-neutral config, types, and trait surface
- add shared skills persistence contracts and row/claim types for metadata, tenant aliases, bundle tokens, and continuation cookies
- move the existing skills blob-store config surface onto the new blob-storage crate and alias it back through `smg-skills`
- add additive Postgres and Oracle migrations for `skills`, `skill_versions`, `tenant_aliases`, `bundle_tokens`, and `continuation_cookies`
- explicitly document `data_connector` migrations as forward-only

Closes #1182.

## Changes

- add `crates/blob_storage` with `BlobStore`, `BlobStoreConfig`, `BlobKey`, `BlobMetadata`, `PutBlobRequest`, `GetBlobResponse`, and `ListBlobsPage`
- add `crates/skills/src/storage.rs` with `SkillMetadataStore`, `TenantAliasStore`, `BundleTokenStore`, and `ContinuationCookieStore`
- extend `smg-skills` shared types with skill version manifests, tenant alias rows, bundle token claims, and continuation cookie claims
- add Postgres migrations `v4` through `v8` for the new skills tables and indexes
- add Oracle migrations `v4` through `v8` for the same logical schema, using Oracle-native JSON/CLOB and idempotent DDL wrappers

## Test Plan

- `cargo +nightly fmt --all`
- `env -u RUSTC_WRAPPER CARGO_BUILD_RUSTC_WRAPPER= cargo clippy -p smg-blob-storage -p smg-skills -p data-connector --all-targets --all-features --target-dir /tmp/smg-sk6-target -- -D warnings`
- `env -u RUSTC_WRAPPER CARGO_BUILD_RUSTC_WRAPPER= cargo test -p smg-blob-storage -p smg-skills -p data-connector --target-dir /tmp/smg-sk6-target`
- repo-wide `cargo test` remains affected on this macOS host by the existing unrelated tokenizer/proxy failure path; scoped tests for the changed crates are clean

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy -p smg-blob-storage -p smg-skills -p data-connector --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-backend blob storage support with sensible defaults and new blob types/APIs.
  * Expanded skills metadata and versioning (richer names, descriptions, timestamps, file blob references).
  * New storage APIs and public store types for skills, tenant aliases, bundle tokens, and continuation cookies.

* **Database**
  * Added forward-only migrations to create tables and indexes for skills, versions, tenant aliases, bundle tokens, and continuation cookies.

* **Documentation**
  * Clarified that migrations are forward-only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->