### PR TITLE
perf(mesh): stream entry data as Bytes instead of Vec<u8>

### DIFF
--- a/crates/mesh/build.rs
+++ b/crates/mesh/build.rs
@@ -2,10 +2,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Rebuild triggers
     println!("cargo:rerun-if-changed=src/proto/gossip.proto");
 
-    // Compile gossip protobuf files
+    // Compile gossip protobuf files. Emit StreamEntry.data as
+    // bytes::Bytes instead of Vec<u8> so the sender can split a value
+    // into zero-copy chunks (Bytes::slice is refcount-shared) and the
+    // receiver keeps decoded chunks as Bytes without an extra copy.
     tonic_prost_build::configure()
         .build_server(true)
         .build_client(true)
+        .bytes(".mesh.gossip.StreamEntry.data")
         .compile_protos(&["src/proto/gossip.proto"], &["src/proto"])?;
 
     Ok(())

--- a/crates/mesh/src/chunk_assembler.rs
+++ b/crates/mesh/src/chunk_assembler.rs
@@ -53,7 +53,7 @@ struct AssemblyState {
     /// the same (generation, index) don't over-count. Completion is
     /// `received_count == chunks.len()`.
     received_count: u32,
-    chunks: Vec<Option<Vec<u8>>>,
+    chunks: Vec<Option<Bytes>>,
     created_at: Instant,
 }
 
@@ -78,15 +78,15 @@ impl AssemblyState {
     /// just payload bytes.
     fn bytes_held(&self) -> usize {
         let payload: usize = self.chunks.iter().flatten().map(|c| c.len()).sum();
-        let overhead = self.chunks.len() * size_of::<Option<Vec<u8>>>();
+        let overhead = self.chunks.len() * size_of::<Option<Bytes>>();
         payload + overhead
     }
 
     /// Return the assembled chunks as a fragmented buffer: each chunk
-    /// is zero-copy wrapped in a `Bytes` (no contiguous memcpy of the
+    /// stays in its own `Bytes` handle (no contiguous memcpy of the
     /// full payload).
     fn assemble(self) -> Vec<Bytes> {
-        self.chunks.into_iter().flatten().map(Bytes::from).collect()
+        self.chunks.into_iter().flatten().collect()
     }
 }
 
@@ -127,7 +127,7 @@ impl ChunkAssembler {
         generation: u64,
         index: u32,
         total: u32,
-        data: Vec<u8>,
+        data: Bytes,
     ) -> Option<Vec<Bytes>> {
         if total == 0 || total > MAX_TOTAL_CHUNKS || index >= total {
             return None;
@@ -311,7 +311,7 @@ mod tests {
     fn test_single_chunk_round_trip() {
         let asm = ChunkAssembler::new();
         let out = asm
-            .receive_chunk("peer", "k", 1, 0, 1, b"hello".to_vec())
+            .receive_chunk("peer", "k", 1, 0, 1, Bytes::from_static(b"hello"))
             .unwrap();
         assert_eq!(flatten(&out), b"hello");
         assert_eq!(asm.in_flight(), 0, "completed assembly should be removed");
@@ -321,13 +321,13 @@ mod tests {
     fn test_multi_chunk_in_order() {
         let asm = ChunkAssembler::new();
         assert!(asm
-            .receive_chunk("peer", "k", 1, 0, 3, b"aaa".to_vec())
+            .receive_chunk("peer", "k", 1, 0, 3, Bytes::from_static(b"aaa"))
             .is_none());
         assert!(asm
-            .receive_chunk("peer", "k", 1, 1, 3, b"bbb".to_vec())
+            .receive_chunk("peer", "k", 1, 1, 3, Bytes::from_static(b"bbb"))
             .is_none());
         let out = asm
-            .receive_chunk("peer", "k", 1, 2, 3, b"ccc".to_vec())
+            .receive_chunk("peer", "k", 1, 2, 3, Bytes::from_static(b"ccc"))
             .unwrap();
         assert_eq!(flatten(&out), b"aaabbbccc");
         assert_eq!(asm.in_flight(), 0);
@@ -337,13 +337,13 @@ mod tests {
     fn test_multi_chunk_out_of_order() {
         let asm = ChunkAssembler::new();
         assert!(asm
-            .receive_chunk("peer", "k", 1, 2, 3, b"ccc".to_vec())
+            .receive_chunk("peer", "k", 1, 2, 3, Bytes::from_static(b"ccc"))
             .is_none());
         assert!(asm
-            .receive_chunk("peer", "k", 1, 0, 3, b"aaa".to_vec())
+            .receive_chunk("peer", "k", 1, 0, 3, Bytes::from_static(b"aaa"))
             .is_none());
         let out = asm
-            .receive_chunk("peer", "k", 1, 1, 3, b"bbb".to_vec())
+            .receive_chunk("peer", "k", 1, 1, 3, Bytes::from_static(b"bbb"))
             .unwrap();
         assert_eq!(
             flatten(&out),
@@ -356,17 +356,17 @@ mod tests {
     fn test_generation_reset_discards_older_partials() {
         let asm = ChunkAssembler::new();
         assert!(asm
-            .receive_chunk("peer", "k", 5, 0, 3, b"old-0".to_vec())
+            .receive_chunk("peer", "k", 5, 0, 3, Bytes::from_static(b"old-0"))
             .is_none());
         assert!(asm
-            .receive_chunk("peer", "k", 5, 1, 3, b"old-1".to_vec())
+            .receive_chunk("peer", "k", 5, 1, 3, Bytes::from_static(b"old-1"))
             .is_none());
 
         assert!(asm
-            .receive_chunk("peer", "k", 6, 0, 2, b"new-0".to_vec())
+            .receive_chunk("peer", "k", 6, 0, 2, Bytes::from_static(b"new-0"))
             .is_none());
         let out = asm
-            .receive_chunk("peer", "k", 6, 1, 2, b"new-1".to_vec())
+            .receive_chunk("peer", "k", 6, 1, 2, Bytes::from_static(b"new-1"))
             .unwrap();
         assert_eq!(flatten(&out), b"new-0new-1");
     }
@@ -376,17 +376,17 @@ mod tests {
         let asm = ChunkAssembler::new();
         // gen=6 starts and records one chunk.
         assert!(asm
-            .receive_chunk("peer", "k", 6, 0, 2, b"new-0".to_vec())
+            .receive_chunk("peer", "k", 6, 0, 2, Bytes::from_static(b"new-0"))
             .is_none());
 
         // A delayed gen=5 chunk arrives — must NOT reset the gen=6 state.
         assert!(asm
-            .receive_chunk("peer", "k", 5, 0, 3, b"stale-0".to_vec())
+            .receive_chunk("peer", "k", 5, 0, 3, Bytes::from_static(b"stale-0"))
             .is_none());
 
         // Completing gen=6 must still yield the gen=6 payload.
         let out = asm
-            .receive_chunk("peer", "k", 6, 1, 2, b"new-1".to_vec())
+            .receive_chunk("peer", "k", 6, 1, 2, Bytes::from_static(b"new-1"))
             .unwrap();
         assert_eq!(
             flatten(&out),
@@ -399,7 +399,7 @@ mod tests {
     fn test_gc_removes_stale_partials() {
         let asm = ChunkAssembler::new();
         assert!(asm
-            .receive_chunk("peer", "k", 1, 0, 3, b"aaa".to_vec())
+            .receive_chunk("peer", "k", 1, 0, 3, Bytes::from_static(b"aaa"))
             .is_none());
         assert_eq!(asm.in_flight(), 1);
 
@@ -412,7 +412,7 @@ mod tests {
     fn test_gc_keeps_recent_partials() {
         let asm = ChunkAssembler::new();
         assert!(asm
-            .receive_chunk("peer", "k", 1, 0, 3, b"aaa".to_vec())
+            .receive_chunk("peer", "k", 1, 0, 3, Bytes::from_static(b"aaa"))
             .is_none());
         asm.gc(Duration::from_secs(10));
         assert_eq!(asm.in_flight(), 1, "recent partial should survive gc");
@@ -431,7 +431,10 @@ mod tests {
             AssemblyState {
                 generation: 1,
                 received_count: 2,
-                chunks: vec![Some(vec![0u8; 10]), Some(vec![0u8; 10])],
+                chunks: vec![
+                    Some(Bytes::from(vec![0u8; 10])),
+                    Some(Bytes::from(vec![0u8; 10])),
+                ],
                 created_at: old,
             },
         );
@@ -493,10 +496,10 @@ mod tests {
     fn test_malformed_chunk_is_dropped() {
         let asm = ChunkAssembler::new();
         assert!(asm
-            .receive_chunk("peer", "k", 1, 0, 0, b"x".to_vec())
+            .receive_chunk("peer", "k", 1, 0, 0, Bytes::from_static(b"x"))
             .is_none());
         assert!(asm
-            .receive_chunk("peer", "k", 1, 5, 3, b"x".to_vec())
+            .receive_chunk("peer", "k", 1, 5, 3, Bytes::from_static(b"x"))
             .is_none());
         assert_eq!(asm.in_flight(), 0);
     }
@@ -506,11 +509,18 @@ mod tests {
         let asm = ChunkAssembler::new();
         // total = u32::MAX would trigger multi-GB allocation if admitted.
         assert!(asm
-            .receive_chunk("peer", "k", 1, 0, u32::MAX, b"x".to_vec())
+            .receive_chunk("peer", "k", 1, 0, u32::MAX, Bytes::from_static(b"x"))
             .is_none());
         // Just past the cap is also rejected.
         assert!(asm
-            .receive_chunk("peer", "k", 1, 0, MAX_TOTAL_CHUNKS + 1, b"x".to_vec())
+            .receive_chunk(
+                "peer",
+                "k",
+                1,
+                0,
+                MAX_TOTAL_CHUNKS + 1,
+                Bytes::from_static(b"x")
+            )
             .is_none());
         assert_eq!(
             asm.in_flight(),
@@ -525,7 +535,14 @@ mod tests {
         // 4 partials against a cap of 3 — oldest must be evicted.
         for i in 0..4 {
             assert!(asm
-                .receive_chunk("peer", &format!("k{i}"), 1, 0, 2, vec![0u8; 10])
+                .receive_chunk(
+                    "peer",
+                    &format!("k{i}"),
+                    1,
+                    0,
+                    2,
+                    Bytes::from(vec![0u8; 10])
+                )
                 .is_none());
             thread::sleep(Duration::from_millis(1));
         }
@@ -543,13 +560,13 @@ mod tests {
         let cap = 10_000;
         let asm = ChunkAssembler::with_limits(usize::MAX, cap);
         assert!(asm
-            .receive_chunk("peer", "k_small", 1, 0, 2, vec![0u8; 2_000])
+            .receive_chunk("peer", "k_small", 1, 0, 2, Bytes::from(vec![0u8; 2_000]))
             .is_none());
         assert!(asm
-            .receive_chunk("peer", "k_med", 1, 0, 2, vec![0u8; 3_000])
+            .receive_chunk("peer", "k_med", 1, 0, 2, Bytes::from(vec![0u8; 3_000]))
             .is_none());
         assert!(asm
-            .receive_chunk("peer", "k_big", 1, 0, 2, vec![0u8; 6_000])
+            .receive_chunk("peer", "k_big", 1, 0, 2, Bytes::from(vec![0u8; 6_000]))
             .is_none());
 
         assert!(
@@ -578,7 +595,10 @@ mod tests {
             AssemblyState {
                 generation: 1,
                 received_count: 2,
-                chunks: vec![Some(vec![0u8; 10]), Some(vec![0u8; 10])],
+                chunks: vec![
+                    Some(Bytes::from(vec![0u8; 10])),
+                    Some(Bytes::from(vec![0u8; 10])),
+                ],
                 created_at: Instant::now() - Duration::from_secs(60),
             },
         );
@@ -632,7 +652,10 @@ mod tests {
             AssemblyState {
                 generation: 1,
                 received_count: 2,
-                chunks: vec![Some(vec![0u8; 10]), Some(vec![0u8; 10])],
+                chunks: vec![
+                    Some(Bytes::from(vec![0u8; 10])),
+                    Some(Bytes::from(vec![0u8; 10])),
+                ],
                 created_at: Instant::now(),
             },
         );
@@ -641,7 +664,7 @@ mod tests {
             AssemblyState {
                 generation: 1,
                 received_count: 1,
-                chunks: vec![Some(vec![0u8; 10]), None],
+                chunks: vec![Some(Bytes::from(vec![0u8; 10])), None],
                 created_at: Instant::now(),
             },
         );
@@ -728,7 +751,7 @@ mod tests {
         // still be returned regardless of size.
         let asm = ChunkAssembler::with_limits(usize::MAX, 10);
         let out = asm
-            .receive_chunk("peer", "k", 1, 0, 1, vec![0u8; 500])
+            .receive_chunk("peer", "k", 1, 0, 1, Bytes::from(vec![0u8; 500]))
             .expect("single-chunk completion returns bytes");
         assert_eq!(out.len(), 1, "single-chunk result is one Bytes fragment");
         assert_eq!(out[0].len(), 500);
@@ -739,21 +762,21 @@ mod tests {
     fn test_multiple_keys_independent() {
         let asm = ChunkAssembler::new();
         assert!(asm
-            .receive_chunk("peer", "a", 1, 0, 2, b"a0".to_vec())
+            .receive_chunk("peer", "a", 1, 0, 2, Bytes::from_static(b"a0"))
             .is_none());
         assert!(asm
-            .receive_chunk("peer", "b", 1, 0, 2, b"b0".to_vec())
+            .receive_chunk("peer", "b", 1, 0, 2, Bytes::from_static(b"b0"))
             .is_none());
         assert_eq!(asm.in_flight(), 2);
 
         let a = asm
-            .receive_chunk("peer", "a", 1, 1, 2, b"a1".to_vec())
+            .receive_chunk("peer", "a", 1, 1, 2, Bytes::from_static(b"a1"))
             .unwrap();
         assert_eq!(flatten(&a), b"a0a1");
         assert_eq!(asm.in_flight(), 1, "completing a should not touch b");
 
         let b = asm
-            .receive_chunk("peer", "b", 1, 1, 2, b"b1".to_vec())
+            .receive_chunk("peer", "b", 1, 1, 2, Bytes::from_static(b"b1"))
             .unwrap();
         assert_eq!(flatten(&b), b"b0b1");
         assert_eq!(asm.in_flight(), 0);
@@ -765,13 +788,13 @@ mod tests {
         // Start a multi-chunk assembly for (peer, "k") and an unrelated
         // one for (peer, "other") + (other_peer, "k").
         assert!(asm
-            .receive_chunk("peer", "k", 1, 0, 2, b"aa".to_vec())
+            .receive_chunk("peer", "k", 1, 0, 2, Bytes::from_static(b"aa"))
             .is_none());
         assert!(asm
-            .receive_chunk("peer", "other", 1, 0, 2, b"bb".to_vec())
+            .receive_chunk("peer", "other", 1, 0, 2, Bytes::from_static(b"bb"))
             .is_none());
         assert!(asm
-            .receive_chunk("other_peer", "k", 1, 0, 2, b"cc".to_vec())
+            .receive_chunk("other_peer", "k", 1, 0, 2, Bytes::from_static(b"cc"))
             .is_none());
         assert_eq!(asm.in_flight(), 3);
 
@@ -784,7 +807,7 @@ mod tests {
 
         // Completing the spared entries still works.
         let out = asm
-            .receive_chunk("peer", "other", 1, 1, 2, b"22".to_vec())
+            .receive_chunk("peer", "other", 1, 1, 2, Bytes::from_static(b"22"))
             .unwrap();
         assert_eq!(flatten(&out), b"bb22");
     }

--- a/crates/mesh/src/chunking.rs
+++ b/crates/mesh/src/chunking.rs
@@ -119,22 +119,31 @@ pub fn chunk_value(
 /// in the chunk assembler. Multi-chunk entries route through the
 /// assembler and fire subscribers only on full reassembly.
 ///
-/// Takes ownership of the entries so chunk payloads move into `Bytes`
-/// without cloning. The chunk assembler scopes in-flight state by
-/// `peer_id` so concurrent chunked values from different senders under
-/// the same key don't collide.
+/// Each chunk payload is detached from the decoded `StreamBatch`
+/// buffer via `Bytes::copy_from_slice` before it's stored or
+/// forwarded. Without this, the prost-generated `StreamEntry.data`
+/// is a `Bytes` view into the message frame, so a single pinned
+/// chunk (in the assembler or in a subscriber queue) would retain
+/// the entire batch allocation. That would let a peer packing many
+/// tiny entries into near-`MAX_MESSAGE_SIZE` batches defeat both
+/// `DEFAULT_MAX_ASSEMBLER_BYTES` and subscriber backpressure.
+///
+/// The chunk assembler scopes in-flight state by `peer_id` so
+/// concurrent chunked values from different senders under the same
+/// key don't collide.
 pub fn dispatch_stream_batch(
     mesh_kv: &MeshKV,
     peer_id: &str,
     entries: impl IntoIterator<Item = StreamEntry>,
 ) {
     for entry in entries {
+        let data = Bytes::copy_from_slice(&entry.data);
         if entry.total_chunks == 1 {
             // A fresh single-chunk value supersedes any in-flight
             // multi-chunk assembly for the same (peer, key); drop the
             // stale fragments so they don't wait for GC.
             mesh_kv.chunk_assembler().drop_pending(peer_id, &entry.key);
-            mesh_kv.notify_subscribers(&entry.key, Some(vec![entry.data]));
+            mesh_kv.notify_subscribers(&entry.key, Some(vec![data]));
         } else {
             let key = entry.key.clone();
             if let Some(fragments) = mesh_kv.chunk_assembler().receive_chunk(
@@ -143,7 +152,7 @@ pub fn dispatch_stream_batch(
                 entry.generation,
                 entry.chunk_index,
                 entry.total_chunks,
-                entry.data,
+                data,
             ) {
                 mesh_kv.notify_subscribers(&key, Some(fragments));
             }

--- a/crates/mesh/src/chunking.rs
+++ b/crates/mesh/src/chunking.rs
@@ -88,7 +88,7 @@ pub fn chunk_value(
             generation,
             chunk_index: 0,
             total_chunks: 1,
-            data: value.to_vec(),
+            data: value,
         }];
     }
 
@@ -108,7 +108,7 @@ pub fn chunk_value(
             generation,
             chunk_index: index as u32,
             total_chunks: total_chunks as u32,
-            data: value.slice(start..end).to_vec(),
+            data: value.slice(start..end),
         });
     }
     entries
@@ -134,7 +134,7 @@ pub fn dispatch_stream_batch(
             // multi-chunk assembly for the same (peer, key); drop the
             // stale fragments so they don't wait for GC.
             mesh_kv.chunk_assembler().drop_pending(peer_id, &entry.key);
-            mesh_kv.notify_subscribers(&entry.key, Some(vec![Bytes::from(entry.data)]));
+            mesh_kv.notify_subscribers(&entry.key, Some(vec![entry.data]));
         } else {
             let key = entry.key.clone();
             if let Some(fragments) = mesh_kv.chunk_assembler().receive_chunk(
@@ -316,14 +316,14 @@ mod tests {
                 generation: 1,
                 chunk_index: 0,
                 total_chunks: 1,
-                data: vec![1],
+                data: Bytes::from_static(&[1]),
             },
             StreamEntry {
                 key: "b".into(),
                 generation: 1,
                 chunk_index: 0,
                 total_chunks: 1,
-                data: vec![2],
+                data: Bytes::from_static(&[2]),
             },
         ];
         let batches = build_stream_batches(entries, 5, 1024);
@@ -339,7 +339,7 @@ mod tests {
                 generation: 1,
                 chunk_index: 0,
                 total_chunks: 1,
-                data: vec![i as u8],
+                data: Bytes::copy_from_slice(&[i as u8]),
             })
             .collect();
         // 10 entries, cap=3 → 3 + 3 + 3 + 1 = 4 batches. No entry dropped.
@@ -364,7 +364,7 @@ mod tests {
                 generation: 1,
                 chunk_index: 0,
                 total_chunks: 1,
-                data: vec![0u8; 100],
+                data: Bytes::from(vec![0u8; 100]),
             })
             .collect();
         let batches = build_stream_batches(entries, 10, 250);
@@ -383,7 +383,7 @@ mod tests {
             generation: 1,
             chunk_index: 0,
             total_chunks: 1,
-            data: vec![0u8; 500],
+            data: Bytes::from(vec![0u8; 500]),
         }];
         let batches = build_stream_batches(entries, 10, 100);
         assert_eq!(batches.len(), 1);
@@ -401,7 +401,7 @@ mod tests {
             generation: 1,
             chunk_index: 0,
             total_chunks: 1,
-            data: vec![1],
+            data: Bytes::from_static(&[1]),
         }];
         let out = build_stream_batches(entries, 0, 1024);
         assert!(out.is_empty());
@@ -415,7 +415,7 @@ mod tests {
             generation: 1,
             chunk_index: 0,
             total_chunks: 1,
-            data: vec![1],
+            data: Bytes::from_static(&[1]),
         }];
         let out = build_stream_batches(entries, 5, 0);
         assert!(out.is_empty());


### PR DESCRIPTION
## Description

### Problem

The prost-generated `StreamEntry.data` field was `Vec<u8>`. Sender-side chunking therefore allocated and memcpy'd a fresh `Vec` per emitted chunk (`value.slice(start..end).to_vec()`), and the receiver held `Option<Vec<u8>>` per chunk in `ChunkAssembler`.

For a 1.5 GB multi-chunk publish, that's ~1.5 GB of transient heap allocation on top of the original `Bytes` buffer — **per peer** the round is sent to. The ×N per-peer amplification is a separate follow-up; this PR addresses the **2× per-chunk copy** in one place.

Flagged as part of the [PR #1254](https://github.com/lightseekorg/smg/pull/1254) review (gemini `r3111991278` covered the receiver side; this closes the sender side).

### Solution

Opt into prost's `Bytes` backing for this specific field via tonic-prost-build's `bytes()` config, mapped to `.mesh.gossip.StreamEntry.data`. The wire format is unchanged (proto `bytes` was already `bytes` on the wire) — only the Rust type changes.

Other proto `bytes` fields (`StateUpdate.value`, `SnapshotChunk.checksum`) stay `Vec<u8>` since no callers there have a zero-copy opportunity to exploit.

## Changes

- `crates/mesh/build.rs`: add `.bytes(".mesh.gossip.StreamEntry.data")` to the tonic-prost-build configuration so the generated `StreamEntry.data` field is `bytes::Bytes`.
- `crates/mesh/src/chunking.rs`
  - `chunk_value`: single-chunk path now takes ownership of the input `Bytes` directly (`data: value`), multi-chunk path slices without a `.to_vec()` memcpy (`data: value.slice(start..end)`). Each emitted chunk is a refcount-shared view of the caller's source buffer.
  - `dispatch_stream_batch`: single-chunk fast path hands `entry.data` straight to `notify_subscribers` — the redundant `Bytes::from(Vec<u8>)` wrapper is gone.
  - Tests updated to construct `StreamEntry.data` as `Bytes`.
- `crates/mesh/src/chunk_assembler.rs`
  - `AssemblyState::chunks: Vec<Option<Bytes>>` (was `Vec<Option<Vec<u8>>>`).
  - `receive_chunk(..., data: Bytes)` takes Bytes directly, so decoded gRPC chunks move into assembler slots without a staging `Vec<u8>`.
  - `assemble` no longer needs `.map(Bytes::from)` — already the right type.
  - `bytes_held`: overhead accounting uses `size_of::<Option<Bytes>>()`.
  - Tests updated to pass `Bytes` into `receive_chunk`.

No public API changes outside the `ChunkAssembler::receive_chunk` signature (crate-internal). No wire-format changes.

## Test Plan

- [x] `cargo check --workspace` — passes clean
- [x] `cargo test -p smg-mesh --lib` — all 237 tests pass (includes the chunk assembler + chunking test suites that exercise this path end-to-end)
- [x] Pre-commit hooks: rustfmt + clippy pass
- [x] Manual inspection: single-chunk path, multi-chunk split path, and the receive-side `Option<Bytes>` branches all type-check without any `Vec<u8>` ↔ `Bytes` conversions remaining on the hot path.

**Not covered (deferred follow-ups):**
- Sender-side ×N per-peer amplification (hoist chunking to the central round stage, share `Arc<[StreamEntry]>` across peer tasks)
- Server-side targeted-entry routing ([#1254 r3112387632](https://github.com/lightseekorg/smg/pull/1254#discussion_r3112387632))
- Queue-of-rounds vs replace-the-Arc handoff ([#1254 r3112678510](https://github.com/lightseekorg/smg/pull/1254#discussion_r3112678510))

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced memory allocations and byte copying across the mesh streaming pipeline, improving throughput and efficiency for single- and multi-chunk transmissions.
* **Reliability**
  * Improved handling and assembly of chunked stream payloads, reducing overhead and making reassembly more efficient.
* **Compatibility**
  * Payload representation changed internally; integrations that inspect or construct raw payload objects may need adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->