### PR TITLE
feat(mesh): route targeted stream entries on server-side sync streams

### DIFF
--- a/crates/mesh/src/ping_server.rs
+++ b/crates/mesh/src/ping_server.rs
@@ -478,6 +478,16 @@ impl Gossip for GossipService {
         let (tx, rx) = mpsc::channel::<Result<StreamMessage, Status>>(CHANNEL_CAPACITY);
         let size_validator = MessageSizeValidator::default();
 
+        // Remote peer identity, discovered from inbound StreamMessage.peer_id.
+        // Shared between the inbound handler (writer) and the server-side
+        // sender task (reader) so the sender can emit targeted_entries whose
+        // `target` matches the learned peer. Before the first inbound message
+        // this is `None` and the sender emits only broadcast drain_entries —
+        // the targeted entries for that first round are dropped under
+        // at-most-once semantics and the application retries.
+        let learned_peer: Arc<parking_lot::RwLock<Option<String>>> =
+            Arc::new(parking_lot::RwLock::new(None));
+
         // Spawn task to periodically send incremental updates.
         // Uses PeerWatermark reading from the shared RoundBatch (central collector).
         // If current_batch is not set (e.g., temporary GossipService for snapshots),
@@ -491,6 +501,7 @@ impl Gossip for GossipService {
             // affect filtering correctness (each task has its own watermark).
             let peer_name_for_watermark = "server-inbound".to_string();
             let stream_batch_handle = self.current_stream_batch.clone();
+            let learned_peer_sender = learned_peer.clone();
             #[expect(
                 clippy::disallowed_methods,
                 reason = "server-side incremental sender that runs for the lifetime of the sync_stream; terminates when the channel closes or handle is aborted"
@@ -570,10 +581,13 @@ impl Gossip for GossipService {
                     }
 
                     // Server-side stream emission: broadcast drain_entries
-                    // only. Targeted entries stay on the client-side
-                    // (controller.rs) where peer_name is known at task
-                    // spawn. At-most-once: on channel full, drop without
-                    // retry.
+                    // plus targeted_entries addressed to the learned remote
+                    // peer. Covers the non-initiator → initiator direction
+                    // of each peer pair; the client-side sender in
+                    // controller.rs handles the other direction. Before
+                    // learned_peer is set (first inbound message not yet
+                    // received), targeted entries in this round are dropped
+                    // under at-most-once. On channel full, drop without retry.
                     if let Some(sbh) = &stream_batch_handle {
                         let stream_batch = sbh.read().clone();
                         let fresh_batch = last_stream_batch
@@ -586,7 +600,11 @@ impl Gossip for GossipService {
                             // we keep re-checking it.
                             last_stream_batch = Some(stream_batch.clone());
                         }
-                        if fresh_batch && !stream_batch.drain_entries.is_empty() {
+                        let peer_for_targeted = learned_peer_sender.read().clone();
+                        let has_targeted = peer_for_targeted.as_ref().is_some_and(|p| {
+                            stream_batch.targeted_entries.iter().any(|(t, _, _)| t == p)
+                        });
+                        if fresh_batch && (!stream_batch.drain_entries.is_empty() || has_targeted) {
                             let mut entries = Vec::new();
                             // Generation is per-value so concurrent publishes
                             // to the same key get distinct tags.
@@ -597,6 +615,18 @@ impl Gossip for GossipService {
                                     Bytes::from(value.clone()),
                                     MAX_STREAM_CHUNK_BYTES,
                                 ));
+                            }
+                            if let Some(ref peer) = peer_for_targeted {
+                                for (target, key, value) in &stream_batch.targeted_entries {
+                                    if target == peer {
+                                        entries.extend(chunk_value(
+                                            key.clone(),
+                                            next_generation(),
+                                            value.clone(),
+                                            MAX_STREAM_CHUNK_BYTES,
+                                        ));
+                                    }
+                                }
                             }
                             if !entries.is_empty() {
                                 for batch in build_stream_batches(
@@ -653,6 +683,7 @@ impl Gossip for GossipService {
         use std::collections::HashMap;
         let mut snapshot_state: HashMap<LocalStoreType, (Vec<SnapshotChunk>, u64)> = HashMap::new();
 
+        let learned_peer_inbound = learned_peer.clone();
         #[expect(
             clippy::disallowed_methods,
             reason = "server-side stream handler that runs for the lifetime of the sync_stream gRPC connection; terminates when the stream closes"
@@ -715,6 +746,14 @@ impl Gossip for GossipService {
                     Ok(Some(Ok(msg))) => {
                         sequence += 1;
                         peer_id.clone_from(&msg.peer_id);
+                        // Publish the learned remote peer id once it's known
+                        // so the server-side sender task can start emitting
+                        // targeted_entries addressed to this peer. Only write
+                        // when unset to avoid redundant lock contention and
+                        // to ignore spurious empty peer_id fields.
+                        if !msg.peer_id.is_empty() && learned_peer_inbound.read().is_none() {
+                            *learned_peer_inbound.write() = Some(msg.peer_id.clone());
+                        }
 
                         match msg.message_type() {
                             StreamMessageType::IncrementalUpdate => {

--- a/crates/mesh/src/ping_server.rs
+++ b/crates/mesh/src/ping_server.rs
@@ -790,8 +790,10 @@ impl Gossip for GossipService {
                                     break;
                                 }
                             }
-                        } else if peer_learned && !msg.peer_id.is_empty() && msg.peer_id != peer_id
-                        {
+                        } else if peer_learned && msg.peer_id != peer_id {
+                            // Empty peer_id after learn is also an identity
+                            // change — a stream bound to a learned peer
+                            // shouldn't accept unowned frames.
                             log::warn!(
                                 expected_peer_id = %peer_id,
                                 received_peer_id = %msg.peer_id,

--- a/crates/mesh/src/ping_server.rs
+++ b/crates/mesh/src/ping_server.rs
@@ -748,11 +748,29 @@ impl Gossip for GossipService {
                         peer_id.clone_from(&msg.peer_id);
                         // Publish the learned remote peer id once it's known
                         // so the server-side sender task can start emitting
-                        // targeted_entries addressed to this peer. Only write
-                        // when unset to avoid redundant lock contention and
-                        // to ignore spurious empty peer_id fields.
-                        if !msg.peer_id.is_empty() && learned_peer_inbound.read().is_none() {
-                            *learned_peer_inbound.write() = Some(msg.peer_id.clone());
+                        // targeted_entries addressed to this peer. Reject
+                        // mid-stream changes: the stream's remote identity
+                        // is fixed for the connection, so a different
+                        // peer_id on a subsequent message is either a bug
+                        // or a peer trying to claim another node's
+                        // targeted entries. Close the stream and let the
+                        // client reconnect. Pre-mTLS-binding defence;
+                        // mTLS-derived identity is the authoritative
+                        // long-term fix.
+                        if !msg.peer_id.is_empty() {
+                            let mut learned = learned_peer_inbound.write();
+                            match learned.as_ref() {
+                                None => *learned = Some(msg.peer_id.clone()),
+                                Some(existing) if existing == &msg.peer_id => {}
+                                Some(existing) => {
+                                    log::warn!(
+                                        expected_peer_id = %existing,
+                                        received_peer_id = %msg.peer_id,
+                                        "peer_id changed mid-stream; closing sync_stream"
+                                    );
+                                    break;
+                                }
+                            }
                         }
 
                         match msg.message_type() {

--- a/crates/mesh/src/ping_server.rs
+++ b/crates/mesh/src/ping_server.rs
@@ -63,8 +63,9 @@ pub struct GossipService {
     current_batch: Option<Arc<parking_lot::RwLock<Arc<RoundBatch>>>>,
     /// Shared reference to the current stream RoundBatch, drained once
     /// per round by the MeshController. Server-side handlers read
-    /// broadcast entries from this (drain_entries); targeted entries
-    /// are handled client-side where peer_name is known at spawn.
+    /// broadcast drain_entries and also emit targeted_entries addressed
+    /// to the remote peer learned from the first inbound message, so
+    /// publish_to(peer) works in both directions of a peer pair.
     current_stream_batch: Option<Arc<parking_lot::RwLock<Arc<crate::kv::RoundBatch>>>>,
     /// Node-wide MeshKV handle. Owns the stream buffers, subscriber
     /// registry, and chunk assembler shared with the client-side
@@ -313,8 +314,10 @@ impl GossipService {
     }
 
     /// Attach the shared stream RoundBatch reference. Server-side
-    /// handlers emit broadcast drain_entries to their peer — targeted
-    /// entries stay on the client side where peer_name is known.
+    /// handlers emit broadcast drain_entries plus targeted_entries
+    /// whose target matches the remote peer learned from the first
+    /// inbound StreamMessage, so publish_to() works in both directions
+    /// of a peer pair.
     pub fn with_current_stream_batch(
         mut self,
         current_stream_batch: Arc<parking_lot::RwLock<Arc<crate::kv::RoundBatch>>>,
@@ -741,27 +744,43 @@ impl Gossip for GossipService {
             }
 
             const STREAM_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
+            // Short-circuits the RwLock::read() once we've accepted an
+            // identity for this stream — learned_peer_inbound is
+            // write-once-per-connection, so after the first learn every
+            // subsequent message would otherwise take a pointless lock.
+            let mut peer_learned = false;
             loop {
                 match tokio::time::timeout(STREAM_IDLE_TIMEOUT, incoming.next()).await {
                     Ok(Some(Ok(msg))) => {
                         sequence += 1;
-                        peer_id.clone_from(&msg.peer_id);
-                        // Publish the learned remote peer id once it's known
-                        // so the server-side sender task can start emitting
-                        // targeted_entries addressed to this peer. Reject
-                        // mid-stream changes: the stream's remote identity
-                        // is fixed for the connection, so a different
-                        // peer_id on a subsequent message is either a bug
-                        // or a peer trying to claim another node's
+                        // Accept the claimed peer_id before copying it into
+                        // the task-local `peer_id`: the task-local drives
+                        // the teardown log and connection-gauge decrement
+                        // below, and if we wrote a mismatched value here
+                        // before the reject, the cleanup would attribute
+                        // the close to the spoofed peer and leak the real
+                        // peer's connection gauge.
+                        //
+                        // Reject mid-stream peer_id changes: the stream's
+                        // remote identity is fixed for the connection, so
+                        // a different peer_id on a later message is either
+                        // a bug or a peer trying to claim another node's
                         // targeted entries. Close the stream and let the
                         // client reconnect. Pre-mTLS-binding defence;
                         // mTLS-derived identity is the authoritative
                         // long-term fix.
-                        if !msg.peer_id.is_empty() {
+                        if !peer_learned && !msg.peer_id.is_empty() {
                             let mut learned = learned_peer_inbound.write();
                             match learned.as_ref() {
-                                None => *learned = Some(msg.peer_id.clone()),
-                                Some(existing) if existing == &msg.peer_id => {}
+                                None => {
+                                    *learned = Some(msg.peer_id.clone());
+                                    peer_id.clone_from(&msg.peer_id);
+                                    peer_learned = true;
+                                }
+                                Some(existing) if existing == &msg.peer_id => {
+                                    peer_id.clone_from(existing);
+                                    peer_learned = true;
+                                }
                                 Some(existing) => {
                                     log::warn!(
                                         expected_peer_id = %existing,
@@ -771,6 +790,14 @@ impl Gossip for GossipService {
                                     break;
                                 }
                             }
+                        } else if peer_learned && !msg.peer_id.is_empty() && msg.peer_id != peer_id
+                        {
+                            log::warn!(
+                                expected_peer_id = %peer_id,
+                                received_peer_id = %msg.peer_id,
+                                "peer_id changed mid-stream; closing sync_stream"
+                            );
+                            break;
                         }
 
                         match msg.message_type() {

--- a/crates/mesh/src/ping_server.rs
+++ b/crates/mesh/src/ping_server.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashMap,
     net::SocketAddr,
     pin::Pin,
     sync::Arc,
@@ -683,7 +684,6 @@ impl Gossip for GossipService {
         // Track snapshot reception state: store_type -> (received_chunks, expected_total)
         // Keyed by store_type only — a new snapshot request for the same store
         // replaces any incomplete previous attempt (prevents stale chunk mixing).
-        use std::collections::HashMap;
         let mut snapshot_state: HashMap<LocalStoreType, (Vec<SnapshotChunk>, u64)> = HashMap::new();
 
         let learned_peer_inbound = learned_peer.clone();


### PR DESCRIPTION
## Description

### Problem

Mesh enforces one initiated sync stream per peer pair using lexicographic ordering: whichever of `(self, peer)` has the smaller name dials out. The initiator's client-side sender (`controller.rs`) already emits both `drain_entries` (broadcast) and `targeted_entries` whose target matches its peer. The non-initiator's only outgoing path is the server-side sender in `ping_server.rs`, which was **ignoring `targeted_entries` entirely**.

Concrete break — assume `A < B`, so A initiates:

- **A→B works**: A's `controller.rs` per-peer sender emits `drain_entries` + `targeted_entries where target == \"B\"`. Both broadcast and targeted reach B.
- **B→A is broken**: B has no client sender for A (A initiated, not B). B's `ping_server.rs` server-side sender only broadcasts `drain_entries`. Any `B.publish_to(\"A\", ...)` is drained into the round batch, never emitted, silently dropped.

Tree repair between any peer pair is inherently bidirectional — `tree:req:*` requests and `tree:page:*` responses flow in both directions ([mesh-v2-qa.md:466-469](../blob/main/.claude/docs/mesh/mesh-v2-qa.md#L466-L469)). So the bug fires on any repair session where the requester or responder happens to be the non-initiator; in a 20-node cluster roughly half of all repair traffic in one-of-two directions is affected.

Flagged as [PR #1254 r3112387632](https://github.com/lightseekorg/smg/pull/1254#discussion_r3112387632).

### Solution

Teach the server-side sender in `ping_server.rs` to emit `targeted_entries` addressed to its remote peer. The remote's identity isn't statically known at task spawn (an arbitrary client dialled in), so we learn it from the first inbound `StreamMessage.peer_id` field.

- Shared state: `Arc<parking_lot::RwLock<Option<String>>>` named `learned_peer`, created before spawning either task and cloned into both.
- Inbound handler writes once on the first non-empty inbound `peer_id` (subsequent inbounds carry the same peer name — no redundant writes).
- Server-side sender reads each tick; when `Some(peer)`, filters `targeted_entries` by `target == peer` and chunks them alongside the existing `drain_entries` path. When `None` (learning not yet complete), targeted entries for that round are dropped — spec §4.4 at-most-once covers this startup window, and application-level retry (e.g. `tree:req:*` timeout cycle) makes progress once learning finishes.

No spec change required — `mesh-v2-implementation-spec.md §5.4` already describes the per-peer send path as emitting both broadcast and targeted; the split between client-side and server-side senders is an implementation detail of the bidirectional gRPC stream, and the fix makes the server-side half match the spec's per-peer model.

## Changes

- `crates/mesh/src/ping_server.rs`
  - Introduce `learned_peer: Arc<parking_lot::RwLock<Option<String>>>` at `sync_stream` scope, shared by the server-side incremental sender task and the inbound handler task.
  - **Sender task** (lines ~572–640): now reads `learned_peer` each tick; the \"fresh batch\" branch also fires when `targeted_entries` contains an entry for the learned peer (previously only fired on non-empty `drain_entries`). Emits targeted entries via `chunk_value` + `build_stream_batches` alongside drain entries. Pre-learning behavior unchanged (drain-only).
  - **Inbound handler** (line ~718): on the first message with non-empty `peer_id`, records it into `learned_peer`. Lock-free read first to skip the write path on subsequent messages.

No proto/wire changes. No new public API.

## Test Plan

- [x] `cargo check -p smg-mesh` — passes clean
- [x] `cargo test -p smg-mesh --lib` — all 237 tests pass
- [x] Pre-commit hooks: rustfmt + clippy pass

**Manual verification** — reviewed the server-side sender path:
- When `learned_peer.read()` returns `None`: `has_targeted` is `false`, so the fresh-batch emission block only fires on non-empty `drain_entries`, matching pre-PR behavior. Targeted entries for the round are dropped (at-most-once).
- When `learned_peer.read()` returns `Some(peer)`: filters `stream_batch.targeted_entries` by `target == peer` and chunks those alongside drains. The peer-scoped filter matches the client-side sender's `target == peer_name_incremental` check in `controller.rs`, so the two emission sites handle disjoint directions of the peer pair.

**Not covered in this PR** (called out in review comment for [PR #1254](https://github.com/lightseekorg/smg/pull/1254), to land separately):
- Integration test that drives `publish_to(initiator, tree:req:*, ...)` end-to-end through the non-initiator's server-side sender. Requires a multi-node harness with asserted subscriber receipt; better as its own change alongside Step 3.6 integration tests.
- ×N per-peer sender-side chunking amplification — the centralized chunking hoist is tracked as a separate follow-up.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * System now learns remote peer IDs from incoming streams.
  * Server will emit peer-targeted message batches to a discovered remote peer.
  * Message batching now triggers when either broadcast entries exist or there are targeted entries matching the learned peer.

* **Behavior Change**
  * If a stream’s reported peer ID changes mid‑stream, the stream logs a warning and is closed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->