### PR TITLE
chore(mesh): drop spec section refs from code comments

### DIFF
--- a/crates/mesh/src/chunking.rs
+++ b/crates/mesh/src/chunking.rs
@@ -48,11 +48,10 @@ pub fn next_generation() -> u64 {
 /// Maximum chunks packed into a single `StreamBatch` message. This is
 /// a message-shape cap, not a bandwidth throttle: `build_stream_batches`
 /// emits multiple batches as needed to carry every entry in the round.
-/// The 128-slot sync channel's backpressure provides rate limiting;
-/// there is no explicit per-round chunk budget in this iteration (spec
-/// §10 contemplates one as `max_chunks_per_round`, but a hard round
-/// cap combined with §4.4's drained-per-round buffer would make any
-/// value with more chunks than the cap permanently undeliverable).
+/// The 128-slot sync channel's backpressure provides rate limiting.
+/// A hard per-round chunk cap would combine with the drained-per-round
+/// buffer to make any value with more chunks than the cap permanently
+/// undeliverable, so none is enforced here.
 pub const DEFAULT_MAX_CHUNKS_PER_BATCH: usize = 5;
 
 /// Headroom reserved below `MAX_MESSAGE_SIZE` for protobuf envelope

--- a/crates/mesh/src/chunking.rs
+++ b/crates/mesh/src/chunking.rs
@@ -48,7 +48,7 @@ pub fn next_generation() -> u64 {
 /// Maximum chunks packed into a single `StreamBatch` message. This is
 /// a message-shape cap, not a bandwidth throttle: `build_stream_batches`
 /// emits multiple batches as needed to carry every entry in the round.
-/// The 128-slot sync channel's backpressure provides rate limiting.
+/// The bounded channel's backpressure provides rate limiting.
 /// A hard per-round chunk cap would combine with the drained-per-round
 /// buffer to make any value with more chunks than the cap permanently
 /// undeliverable, so none is enforced here.

--- a/crates/mesh/src/controller.rs
+++ b/crates/mesh/src/controller.rs
@@ -180,10 +180,10 @@ impl MeshController {
             }
 
             // Chunk assembler GC: every 5 rounds (~5s), drop partial
-            // assemblies older than 30s per spec §4.4. Partial chunks
-            // the receiver has been holding for a full assembly timeout
-            // are assumed lost; the sender will re-publish on its own
-            // retry cycle with a fresh generation.
+            // assemblies older than 30s. Partial chunks the receiver has
+            // been holding for a full assembly timeout are assumed lost;
+            // the sender will re-publish on its own retry cycle with a
+            // fresh generation.
             if cnt.is_multiple_of(5) {
                 if let Some(mesh_kv) = &self.mesh_kv {
                     mesh_kv.chunk_assembler().gc(Duration::from_secs(30));
@@ -656,9 +656,8 @@ impl MeshController {
                             // targeted entries addressed to this peer. Each
                             // entry is chunked if oversized. On channel
                             // full, the round's stream traffic for this
-                            // peer is dropped — no retry (at-most-once,
-                            // spec §4.4). Application regenerates on its
-                            // own retry cycle.
+                            // peer is dropped — no retry (at-most-once).
+                            // Application regenerates on its own retry cycle.
                             let stream_batch = stream_batch_handle.read().clone();
                             let fresh_batch = last_stream_batch
                                 .as_ref()

--- a/crates/mesh/src/ping_server.rs
+++ b/crates/mesh/src/ping_server.rs
@@ -573,7 +573,7 @@ impl Gossip for GossipService {
                     // only. Targeted entries stay on the client-side
                     // (controller.rs) where peer_name is known at task
                     // spawn. At-most-once: on channel full, drop without
-                    // retry (spec §4.4).
+                    // retry.
                     if let Some(sbh) = &stream_batch_handle {
                         let stream_batch = sbh.read().clone();
                         let fresh_batch = last_stream_batch


### PR DESCRIPTION
## Description

### Problem

Four code comments in the mesh transport path cited the design spec by section number ("spec §4.4", "§10"). These references point at the mesh-v2 implementation spec to explain at-most-once / drained-per-round / no-retry semantics. They rot as the spec evolves and don't help someone reading the code — the behaviour is already explained inline in each comment, so the citation is pure noise.

### Solution

Rewrote each comment to state the property directly, without the section number. Behaviour is unchanged; only comment text differs.

## Changes

- `crates/mesh/src/chunking.rs` — `DEFAULT_MAX_CHUNKS_PER_BATCH` doc: reworded the "no per-round cap" rationale without the "§10" / "§4.4" citations.
- `crates/mesh/src/controller.rs`
  - Chunk assembler GC comment: drop "per spec §4.4".
  - Stream-batch sender comment: drop "(at-most-once, spec §4.4)" parenthetical in favour of a plain "at-most-once" sentence.
- `crates/mesh/src/ping_server.rs` — server-side stream emission comment: drop "(spec §4.4)".

## Test Plan

- [x] `cargo check -p smg-mesh` passes clean
- [x] Pre-commit hooks: rustfmt + clippy pass
- [x] `grep -rn 'spec §\|§[0-9]' crates/mesh/src` returns no matches

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal documentation clarifications for chunk batching, data control flow, and backpressure behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->