### PR TITLE
feat(skills): add in-memory runtime and filesystem blob cache

### DIFF
--- a/crates/blob_storage/Cargo.toml
+++ b/crates/blob_storage/Cargo.toml
@@ -18,10 +18,19 @@ name = "smg_blob_storage"
 
 [dependencies]
 async-trait.workspace = true
+blake3.workspace = true
 chrono = { workspace = true, features = ["serde"] }
+lru.workspace = true
+parking_lot.workspace = true
 serde = { workspace = true, features = ["derive"] }
 thiserror.workspace = true
-tokio = { workspace = true, features = ["io-util"] }
+tokio = { workspace = true, features = ["fs", "io-util"] }
+uuid = { workspace = true, features = ["v7"] }
+
+[dev-dependencies]
+anyhow.workspace = true
+tempfile = "3.15"
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [lints]
 workspace = true

--- a/crates/blob_storage/src/cache.rs
+++ b/crates/blob_storage/src/cache.rs
@@ -282,17 +282,21 @@ impl BlobStore for CachedBlobStore {
         key: &BlobKey,
         request: PutBlobRequest,
     ) -> Result<BlobMetadata, BlobStoreError> {
-        self.cache.invalidate(key).await?;
+        let _ = self.cache.invalidate(key).await;
         self.inner.put_stream(key, request).await
     }
 
     async fn get(&self, key: &BlobKey) -> Result<GetBlobResponse, BlobStoreError> {
-        if let Some(response) = self.cache.get(key).await? {
-            return Ok(response);
+        match self.cache.get(key).await {
+            Ok(Some(response)) => return Ok(response),
+            Ok(None) | Err(_) => {}
         }
 
         let response = self.inner.get(key).await?;
-        self.cache.insert(key, response).await
+        match self.cache.insert(key, response).await {
+            Ok(cached) => Ok(cached),
+            Err(_) => self.inner.get(key).await,
+        }
     }
 
     async fn head(&self, key: &BlobKey) -> Result<Option<BlobMetadata>, BlobStoreError> {
@@ -300,7 +304,7 @@ impl BlobStore for CachedBlobStore {
     }
 
     async fn delete(&self, key: &BlobKey) -> Result<(), BlobStoreError> {
-        self.cache.invalidate(key).await?;
+        let _ = self.cache.invalidate(key).await;
         self.inner.delete(key).await
     }
 

--- a/crates/blob_storage/src/cache.rs
+++ b/crates/blob_storage/src/cache.rs
@@ -287,9 +287,8 @@ impl BlobStore for CachedBlobStore {
     }
 
     async fn get(&self, key: &BlobKey) -> Result<GetBlobResponse, BlobStoreError> {
-        match self.cache.get(key).await {
-            Ok(Some(response)) => return Ok(response),
-            Ok(None) | Err(_) => {}
+        if let Ok(Some(response)) = self.cache.get(key).await {
+            return Ok(response);
         }
 
         let response = self.inner.get(key).await?;

--- a/crates/blob_storage/src/cache.rs
+++ b/crates/blob_storage/src/cache.rs
@@ -1,0 +1,324 @@
+use std::{
+    fmt,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+use async_trait::async_trait;
+use lru::LruCache;
+use parking_lot::Mutex;
+use tokio::{fs, fs::File};
+use uuid::Uuid;
+
+use crate::{
+    config::BlobCacheConfig,
+    factory::BlobStoreInitError,
+    store::{BlobStore, BlobStoreError},
+    types::{BlobKey, BlobMetadata, BlobPrefix, GetBlobResponse, ListBlobsPage, PutBlobRequest},
+};
+
+#[derive(Debug)]
+struct CacheEntry {
+    logical_key: String,
+    path: PathBuf,
+    size_bytes: u64,
+    metadata: BlobMetadata,
+}
+
+#[derive(Debug)]
+struct CacheState {
+    current_size_bytes: u64,
+    entries: LruCache<String, CacheEntry>,
+}
+
+impl Default for CacheState {
+    fn default() -> Self {
+        Self {
+            current_size_bytes: 0,
+            entries: LruCache::unbounded(),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct LocalBlobCache {
+    cache_dir: PathBuf,
+    max_size_bytes: u64,
+    state: Mutex<CacheState>,
+}
+
+impl LocalBlobCache {
+    fn new(config: &BlobCacheConfig) -> Result<Self, BlobStoreInitError> {
+        let cache_dir = PathBuf::from(&config.path);
+        if cache_dir.as_os_str().is_empty() {
+            return Err(BlobStoreInitError::InvalidConfig {
+                message: "blob cache path must not be empty".to_string(),
+            });
+        }
+        std::fs::create_dir_all(&cache_dir).map_err(|error| BlobStoreInitError::Io {
+            path: cache_dir.display().to_string(),
+            message: error.to_string(),
+        })?;
+
+        Ok(Self {
+            cache_dir,
+            max_size_bytes: config.max_size_bytes(),
+            state: Mutex::new(CacheState {
+                current_size_bytes: 0,
+                entries: LruCache::unbounded(),
+            }),
+        })
+    }
+
+    async fn get(&self, key: &BlobKey) -> Result<Option<GetBlobResponse>, BlobStoreError> {
+        let cache_key = cache_key_for(key, None);
+        let cached = {
+            let mut state = self.state.lock();
+            state.entries.get(&cache_key).map(|entry| CachedLookup {
+                path: entry.path.clone(),
+                metadata: entry.metadata.clone(),
+            })
+        };
+
+        let Some(cached) = cached else {
+            return Ok(None);
+        };
+
+        match File::open(&cached.path).await {
+            Ok(file) => Ok(Some(GetBlobResponse {
+                reader: Box::pin(file),
+                metadata: cached.metadata,
+            })),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                self.remove_cache_key(&cache_key).await?;
+                Ok(None)
+            }
+            Err(error) => Err(BlobStoreError::Operation {
+                operation: "cache_open",
+                message: error.to_string(),
+            }),
+        }
+    }
+
+    async fn insert(
+        &self,
+        key: &BlobKey,
+        response: GetBlobResponse,
+    ) -> Result<GetBlobResponse, BlobStoreError> {
+        let cache_key = cache_key_for(key, response.metadata.etag.as_deref());
+        let cache_path = cache_path_for(&self.cache_dir, &cache_key);
+        let temp_path = cache_path.with_extension(format!("{}.tmp", Uuid::now_v7()));
+
+        let mut reader = response.reader;
+        let mut file =
+            File::create(&temp_path)
+                .await
+                .map_err(|error| BlobStoreError::Operation {
+                    operation: "cache_create",
+                    message: error.to_string(),
+                })?;
+        let copied = tokio::io::copy(&mut reader, &mut file)
+            .await
+            .map_err(|error| BlobStoreError::Operation {
+                operation: "cache_write",
+                message: error.to_string(),
+            })?;
+        file.sync_all()
+            .await
+            .map_err(|error| BlobStoreError::Operation {
+                operation: "cache_sync_all",
+                message: error.to_string(),
+            })?;
+        drop(file);
+
+        fs::rename(&temp_path, &cache_path)
+            .await
+            .map_err(|error| BlobStoreError::Operation {
+                operation: "cache_rename",
+                message: error.to_string(),
+            })?;
+
+        let mut metadata = response.metadata;
+        metadata.size_bytes = copied;
+
+        {
+            let mut state = self.state.lock();
+            if let Some(previous) = state.entries.put(
+                cache_key.clone(),
+                CacheEntry {
+                    logical_key: key.0.clone(),
+                    path: cache_path.clone(),
+                    size_bytes: copied,
+                    metadata: metadata.clone(),
+                },
+            ) {
+                state.current_size_bytes =
+                    state.current_size_bytes.saturating_sub(previous.size_bytes);
+            }
+            state.current_size_bytes = state.current_size_bytes.saturating_add(copied);
+        }
+
+        self.evict_if_needed().await?;
+
+        let file = File::open(&cache_path)
+            .await
+            .map_err(|error| BlobStoreError::Operation {
+                operation: "cache_open",
+                message: error.to_string(),
+            })?;
+
+        Ok(GetBlobResponse {
+            reader: Box::pin(file),
+            metadata,
+        })
+    }
+
+    async fn invalidate(&self, key: &BlobKey) -> Result<(), BlobStoreError> {
+        let cache_keys = {
+            let state = self.state.lock();
+            state
+                .entries
+                .iter()
+                .filter(|(_, entry)| entry.logical_key == key.0)
+                .map(|(cache_key, _)| cache_key.clone())
+                .collect::<Vec<_>>()
+        };
+
+        for cache_key in cache_keys {
+            self.remove_cache_key(&cache_key).await?;
+        }
+
+        Ok(())
+    }
+
+    async fn evict_if_needed(&self) -> Result<(), BlobStoreError> {
+        loop {
+            let evicted = {
+                let mut state = self.state.lock();
+                if state.current_size_bytes <= self.max_size_bytes {
+                    None
+                } else {
+                    state.entries.pop_lru().map(|(_, entry)| {
+                        state.current_size_bytes =
+                            state.current_size_bytes.saturating_sub(entry.size_bytes);
+                        entry
+                    })
+                }
+            };
+
+            let Some(entry) = evicted else {
+                return Ok(());
+            };
+
+            remove_file_if_present(&entry.path).await?;
+        }
+    }
+
+    async fn remove_cache_key(&self, cache_key: &str) -> Result<(), BlobStoreError> {
+        let removed = {
+            let mut state = self.state.lock();
+            state.entries.pop(cache_key).inspect(|entry| {
+                state.current_size_bytes =
+                    state.current_size_bytes.saturating_sub(entry.size_bytes);
+            })
+        };
+
+        if let Some(entry) = removed {
+            remove_file_if_present(&entry.path).await?;
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+struct CachedLookup {
+    path: PathBuf,
+    metadata: BlobMetadata,
+}
+
+/// Generic local read-cache wrapper layered in front of any blob store.
+pub struct CachedBlobStore {
+    inner: Arc<dyn BlobStore>,
+    cache: LocalBlobCache,
+}
+
+impl fmt::Debug for CachedBlobStore {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CachedBlobStore").finish_non_exhaustive()
+    }
+}
+
+impl CachedBlobStore {
+    pub fn new(
+        inner: Arc<dyn BlobStore>,
+        config: &BlobCacheConfig,
+    ) -> Result<Self, BlobStoreInitError> {
+        Ok(Self {
+            inner,
+            cache: LocalBlobCache::new(config)?,
+        })
+    }
+}
+
+#[async_trait]
+impl BlobStore for CachedBlobStore {
+    async fn put_stream(
+        &self,
+        key: &BlobKey,
+        request: PutBlobRequest,
+    ) -> Result<BlobMetadata, BlobStoreError> {
+        self.cache.invalidate(key).await?;
+        self.inner.put_stream(key, request).await
+    }
+
+    async fn get(&self, key: &BlobKey) -> Result<GetBlobResponse, BlobStoreError> {
+        if let Some(response) = self.cache.get(key).await? {
+            return Ok(response);
+        }
+
+        let response = self.inner.get(key).await?;
+        self.cache.insert(key, response).await
+    }
+
+    async fn head(&self, key: &BlobKey) -> Result<Option<BlobMetadata>, BlobStoreError> {
+        self.inner.head(key).await
+    }
+
+    async fn delete(&self, key: &BlobKey) -> Result<(), BlobStoreError> {
+        self.cache.invalidate(key).await?;
+        self.inner.delete(key).await
+    }
+
+    async fn list_prefix(
+        &self,
+        prefix: &BlobPrefix,
+        cursor: Option<String>,
+        limit: usize,
+    ) -> Result<ListBlobsPage, BlobStoreError> {
+        self.inner.list_prefix(prefix, cursor, limit).await
+    }
+}
+
+async fn remove_file_if_present(path: &Path) -> Result<(), BlobStoreError> {
+    match fs::remove_file(path).await {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(BlobStoreError::Operation {
+            operation: "cache_remove_file",
+            message: error.to_string(),
+        }),
+    }
+}
+
+fn cache_key_for(key: &BlobKey, etag: Option<&str>) -> String {
+    match etag {
+        Some(etag) => format!("{}#{etag}", key.0),
+        None => key.0.clone(),
+    }
+}
+
+fn cache_path_for(cache_dir: &Path, cache_key: &str) -> PathBuf {
+    let digest = blake3::hash(cache_key.as_bytes());
+    cache_dir.join(digest.to_hex().as_str())
+}

--- a/crates/blob_storage/src/cache.rs
+++ b/crates/blob_storage/src/cache.rs
@@ -19,7 +19,6 @@ use crate::{
 
 #[derive(Debug)]
 struct CacheEntry {
-    logical_key: String,
     path: PathBuf,
     size_bytes: u64,
     metadata: BlobMetadata,
@@ -55,6 +54,11 @@ impl LocalBlobCache {
                 message: "blob cache path must not be empty".to_string(),
             });
         }
+        if config.max_size_bytes() == 0 {
+            return Err(BlobStoreInitError::InvalidConfig {
+                message: "blob cache max_size_mb must be greater than zero".to_string(),
+            });
+        }
         std::fs::create_dir_all(&cache_dir).map_err(|error| BlobStoreInitError::Io {
             path: cache_dir.display().to_string(),
             message: error.to_string(),
@@ -71,7 +75,7 @@ impl LocalBlobCache {
     }
 
     async fn get(&self, key: &BlobKey) -> Result<Option<GetBlobResponse>, BlobStoreError> {
-        let cache_key = cache_key_for(key, None);
+        let cache_key = cache_key_for(key);
         let cached = {
             let mut state = self.state.lock();
             state.entries.get(&cache_key).map(|entry| CachedLookup {
@@ -105,38 +109,50 @@ impl LocalBlobCache {
         key: &BlobKey,
         response: GetBlobResponse,
     ) -> Result<GetBlobResponse, BlobStoreError> {
-        let cache_key = cache_key_for(key, response.metadata.etag.as_deref());
+        let cache_key = cache_key_for(key);
         let cache_path = cache_path_for(&self.cache_dir, &cache_key);
         let temp_path = cache_path.with_extension(format!("{}.tmp", Uuid::now_v7()));
 
         let mut reader = response.reader;
-        let mut file =
-            File::create(&temp_path)
+        let copied_result = async {
+            let mut file =
+                File::create(&temp_path)
+                    .await
+                    .map_err(|error| BlobStoreError::Operation {
+                        operation: "cache_create",
+                        message: error.to_string(),
+                    })?;
+            let copied = tokio::io::copy(&mut reader, &mut file)
                 .await
                 .map_err(|error| BlobStoreError::Operation {
-                    operation: "cache_create",
+                    operation: "cache_write",
                     message: error.to_string(),
                 })?;
-        let copied = tokio::io::copy(&mut reader, &mut file)
-            .await
-            .map_err(|error| BlobStoreError::Operation {
-                operation: "cache_write",
-                message: error.to_string(),
-            })?;
-        file.sync_all()
-            .await
-            .map_err(|error| BlobStoreError::Operation {
-                operation: "cache_sync_all",
-                message: error.to_string(),
-            })?;
-        drop(file);
+            file.sync_all()
+                .await
+                .map_err(|error| BlobStoreError::Operation {
+                    operation: "cache_sync_all",
+                    message: error.to_string(),
+                })?;
+            drop(file);
 
-        fs::rename(&temp_path, &cache_path)
-            .await
-            .map_err(|error| BlobStoreError::Operation {
-                operation: "cache_rename",
-                message: error.to_string(),
+            fs::rename(&temp_path, &cache_path).await.map_err(|error| {
+                BlobStoreError::Operation {
+                    operation: "cache_rename",
+                    message: error.to_string(),
+                }
             })?;
+
+            Ok::<u64, BlobStoreError>(copied)
+        }
+        .await;
+        let copied = match copied_result {
+            Ok(copied) => copied,
+            Err(error) => {
+                let _ = remove_file_if_present(&temp_path).await;
+                return Err(error);
+            }
+        };
 
         let mut metadata = response.metadata;
         metadata.size_bytes = copied;
@@ -146,7 +162,6 @@ impl LocalBlobCache {
             if let Some(previous) = state.entries.put(
                 cache_key.clone(),
                 CacheEntry {
-                    logical_key: key.0.clone(),
                     path: cache_path.clone(),
                     size_bytes: copied,
                     metadata: metadata.clone(),
@@ -158,7 +173,7 @@ impl LocalBlobCache {
             state.current_size_bytes = state.current_size_bytes.saturating_add(copied);
         }
 
-        self.evict_if_needed().await?;
+        self.evict_if_needed(Some(&cache_key)).await?;
 
         let file = File::open(&cache_path)
             .await
@@ -174,35 +189,34 @@ impl LocalBlobCache {
     }
 
     async fn invalidate(&self, key: &BlobKey) -> Result<(), BlobStoreError> {
-        let cache_keys = {
-            let state = self.state.lock();
-            state
-                .entries
-                .iter()
-                .filter(|(_, entry)| entry.logical_key == key.0)
-                .map(|(cache_key, _)| cache_key.clone())
-                .collect::<Vec<_>>()
-        };
-
-        for cache_key in cache_keys {
-            self.remove_cache_key(&cache_key).await?;
-        }
-
-        Ok(())
+        self.remove_cache_key(&cache_key_for(key)).await
     }
 
-    async fn evict_if_needed(&self) -> Result<(), BlobStoreError> {
+    async fn evict_if_needed(
+        &self,
+        protected_cache_key: Option<&str>,
+    ) -> Result<(), BlobStoreError> {
         loop {
             let evicted = {
                 let mut state = self.state.lock();
                 if state.current_size_bytes <= self.max_size_bytes {
                     None
                 } else {
-                    state.entries.pop_lru().map(|(_, entry)| {
-                        state.current_size_bytes =
-                            state.current_size_bytes.saturating_sub(entry.size_bytes);
-                        entry
-                    })
+                    match state.entries.pop_lru() {
+                        Some((cache_key, entry))
+                            if protected_cache_key
+                                .is_some_and(|protected| protected == cache_key) =>
+                        {
+                            state.entries.put(cache_key, entry);
+                            None
+                        }
+                        Some((_, entry)) => {
+                            state.current_size_bytes =
+                                state.current_size_bytes.saturating_sub(entry.size_bytes);
+                            Some(entry)
+                        }
+                        None => None,
+                    }
                 }
             };
 
@@ -311,11 +325,12 @@ async fn remove_file_if_present(path: &Path) -> Result<(), BlobStoreError> {
     }
 }
 
-fn cache_key_for(key: &BlobKey, etag: Option<&str>) -> String {
-    match etag {
-        Some(etag) => format!("{}#{etag}", key.0),
-        None => key.0.clone(),
-    }
+fn cache_key_for(key: &BlobKey) -> String {
+    // This local cache is invalidation-driven within the current process, so it
+    // keys by the logical blob key rather than embedding the backend etag.
+    // Doing otherwise makes cached etag-bearing reads unreachable because the
+    // lookup path does not know the current etag ahead of time.
+    key.0.clone()
 }
 
 fn cache_path_for(cache_dir: &Path, cache_key: &str) -> PathBuf {

--- a/crates/blob_storage/src/config.rs
+++ b/crates/blob_storage/src/config.rs
@@ -44,3 +44,32 @@ impl Default for BlobStoreConfig {
         }
     }
 }
+
+/// Local read-cache configuration layered in front of blob reads.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct BlobCacheConfig {
+    pub path: String,
+    pub max_size_mb: usize,
+}
+
+impl BlobCacheConfig {
+    #[must_use]
+    pub fn max_size_bytes(&self) -> u64 {
+        self.max_size_mb as u64 * 1024 * 1024
+    }
+
+    #[must_use]
+    pub fn enabled(&self) -> bool {
+        self.max_size_mb > 0
+    }
+}
+
+impl Default for BlobCacheConfig {
+    fn default() -> Self {
+        Self {
+            path: "/var/smg/cache/skills".to_string(),
+            max_size_mb: 1024,
+        }
+    }
+}

--- a/crates/blob_storage/src/config.rs
+++ b/crates/blob_storage/src/config.rs
@@ -46,6 +46,9 @@ impl Default for BlobStoreConfig {
 }
 
 /// Local read-cache configuration layered in front of blob reads.
+///
+/// The cache stays disabled by default until the operator opts in with a
+/// positive `max_size_mb`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(default)]
 pub struct BlobCacheConfig {
@@ -69,7 +72,7 @@ impl Default for BlobCacheConfig {
     fn default() -> Self {
         Self {
             path: "/var/smg/cache/skills".to_string(),
-            max_size_mb: 1024,
+            max_size_mb: 0,
         }
     }
 }

--- a/crates/blob_storage/src/config.rs
+++ b/crates/blob_storage/src/config.rs
@@ -56,7 +56,7 @@ pub struct BlobCacheConfig {
 impl BlobCacheConfig {
     #[must_use]
     pub fn max_size_bytes(&self) -> u64 {
-        self.max_size_mb as u64 * 1024 * 1024
+        (self.max_size_mb as u64).saturating_mul(1024 * 1024)
     }
 
     #[must_use]

--- a/crates/blob_storage/src/factory.rs
+++ b/crates/blob_storage/src/factory.rs
@@ -1,0 +1,40 @@
+use std::sync::Arc;
+
+use thiserror::Error;
+
+use crate::{
+    cache::CachedBlobStore,
+    config::{BlobCacheConfig, BlobStoreBackend, BlobStoreConfig},
+    filesystem::FilesystemBlobStore,
+    store::BlobStore,
+};
+
+/// Initialization-time failures for blob-store construction.
+#[derive(Debug, Error)]
+pub enum BlobStoreInitError {
+    #[error("blob store backend `{backend:?}` is not implemented yet")]
+    UnsupportedBackend { backend: BlobStoreBackend },
+
+    #[error("invalid blob store configuration: {message}")]
+    InvalidConfig { message: String },
+
+    #[error("blob store initialization failed at `{path}`: {message}")]
+    Io { path: String, message: String },
+}
+
+/// Build the configured blob store, optionally layering in the local read
+/// cache for successful blob reads.
+pub fn create_blob_store(
+    store_config: &BlobStoreConfig,
+    cache_config: Option<&BlobCacheConfig>,
+) -> Result<Arc<dyn BlobStore>, BlobStoreInitError> {
+    let backend: Arc<dyn BlobStore> = match store_config.backend {
+        BlobStoreBackend::Filesystem => Arc::new(FilesystemBlobStore::new(&store_config.path)?),
+        backend => return Err(BlobStoreInitError::UnsupportedBackend { backend }),
+    };
+
+    match cache_config.filter(|config| config.enabled()) {
+        Some(config) => Ok(Arc::new(CachedBlobStore::new(backend, config)?)),
+        None => Ok(backend),
+    }
+}

--- a/crates/blob_storage/src/filesystem.rs
+++ b/crates/blob_storage/src/filesystem.rs
@@ -1,0 +1,317 @@
+use std::{
+    path::{Path, PathBuf},
+    time::SystemTime,
+};
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use tokio::fs::{self, File};
+use uuid::Uuid;
+
+use crate::{
+    factory::BlobStoreInitError,
+    store::{BlobStore, BlobStoreError},
+    types::{BlobKey, BlobMetadata, BlobPrefix, GetBlobResponse, ListBlobsPage, PutBlobRequest},
+};
+
+/// Local filesystem-backed blob store used for development and early testing.
+#[derive(Debug, Clone)]
+pub struct FilesystemBlobStore {
+    root_dir: PathBuf,
+}
+
+impl FilesystemBlobStore {
+    pub fn new(root_dir: impl AsRef<Path>) -> Result<Self, BlobStoreInitError> {
+        let root_dir = root_dir.as_ref();
+        if root_dir.as_os_str().is_empty() {
+            return Err(BlobStoreInitError::InvalidConfig {
+                message: "filesystem blob-store path must not be empty".to_string(),
+            });
+        }
+
+        std::fs::create_dir_all(root_dir).map_err(|error| BlobStoreInitError::Io {
+            path: root_dir.display().to_string(),
+            message: error.to_string(),
+        })?;
+
+        Ok(Self {
+            root_dir: root_dir.to_path_buf(),
+        })
+    }
+
+    fn resolve_blob_path(&self, key: &BlobKey) -> Result<PathBuf, BlobStoreError> {
+        validate_blob_key(&key.0)?;
+        let mut path = self.root_dir.clone();
+        for segment in key.0.split('/') {
+            path.push(segment);
+        }
+        Ok(path)
+    }
+
+    fn metadata_for_path(key: &BlobKey, metadata: std::fs::Metadata) -> BlobMetadata {
+        BlobMetadata {
+            key: key.clone(),
+            size_bytes: metadata.len(),
+            etag: None,
+            last_modified: metadata.modified().ok().map(to_utc),
+        }
+    }
+}
+
+#[async_trait]
+impl BlobStore for FilesystemBlobStore {
+    async fn put_stream(
+        &self,
+        key: &BlobKey,
+        mut request: PutBlobRequest,
+    ) -> Result<BlobMetadata, BlobStoreError> {
+        let path = self.resolve_blob_path(key)?;
+        let parent = path.parent().ok_or_else(|| BlobStoreError::InvalidKey {
+            key: key.0.clone(),
+            message: "blob key must contain at least one path segment".to_string(),
+        })?;
+
+        fs::create_dir_all(parent)
+            .await
+            .map_err(|error| BlobStoreError::Operation {
+                operation: "create_dir_all",
+                message: error.to_string(),
+            })?;
+
+        let temp_path = path.with_extension(format!("{}.tmp", Uuid::now_v7()));
+        let mut file =
+            File::create(&temp_path)
+                .await
+                .map_err(|error| BlobStoreError::Operation {
+                    operation: "create",
+                    message: error.to_string(),
+                })?;
+
+        let copied = tokio::io::copy(&mut request.reader, &mut file)
+            .await
+            .map_err(|error| BlobStoreError::Operation {
+                operation: "write",
+                message: error.to_string(),
+            })?;
+        file.sync_all()
+            .await
+            .map_err(|error| BlobStoreError::Operation {
+                operation: "sync_all",
+                message: error.to_string(),
+            })?;
+        drop(file);
+
+        fs::rename(&temp_path, &path)
+            .await
+            .map_err(|error| BlobStoreError::Operation {
+                operation: "rename",
+                message: error.to_string(),
+            })?;
+
+        let metadata = fs::metadata(&path)
+            .await
+            .map_err(|error| BlobStoreError::Operation {
+                operation: "metadata",
+                message: error.to_string(),
+            })?;
+        let mut blob_metadata = Self::metadata_for_path(key, metadata);
+        blob_metadata.size_bytes = copied;
+        Ok(blob_metadata)
+    }
+
+    async fn get(&self, key: &BlobKey) -> Result<GetBlobResponse, BlobStoreError> {
+        let path = self.resolve_blob_path(key)?;
+        let file = File::open(&path).await.map_err(|error| {
+            if error.kind() == std::io::ErrorKind::NotFound {
+                BlobStoreError::NotFound { key: key.0.clone() }
+            } else {
+                BlobStoreError::Operation {
+                    operation: "open",
+                    message: error.to_string(),
+                }
+            }
+        })?;
+        let metadata = fs::metadata(&path)
+            .await
+            .map_err(|error| BlobStoreError::Operation {
+                operation: "metadata",
+                message: error.to_string(),
+            })?;
+
+        Ok(GetBlobResponse {
+            reader: Box::pin(file),
+            metadata: Self::metadata_for_path(key, metadata),
+        })
+    }
+
+    async fn head(&self, key: &BlobKey) -> Result<Option<BlobMetadata>, BlobStoreError> {
+        let path = self.resolve_blob_path(key)?;
+        match fs::metadata(&path).await {
+            Ok(metadata) => Ok(Some(Self::metadata_for_path(key, metadata))),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(error) => Err(BlobStoreError::Operation {
+                operation: "metadata",
+                message: error.to_string(),
+            }),
+        }
+    }
+
+    async fn delete(&self, key: &BlobKey) -> Result<(), BlobStoreError> {
+        let path = self.resolve_blob_path(key)?;
+        fs::remove_file(&path).await.map_err(|error| {
+            if error.kind() == std::io::ErrorKind::NotFound {
+                BlobStoreError::NotFound { key: key.0.clone() }
+            } else {
+                BlobStoreError::Operation {
+                    operation: "remove_file",
+                    message: error.to_string(),
+                }
+            }
+        })?;
+        Ok(())
+    }
+
+    async fn list_prefix(
+        &self,
+        prefix: &BlobPrefix,
+        cursor: Option<String>,
+        limit: usize,
+    ) -> Result<ListBlobsPage, BlobStoreError> {
+        let normalized_prefix = normalize_prefix(&prefix.0)?;
+        let mut blob_keys = Vec::new();
+        collect_blob_keys(&self.root_dir, &self.root_dir, &mut blob_keys).await?;
+        blob_keys.retain(|key| key.starts_with(&normalized_prefix));
+        blob_keys.sort();
+
+        let start_index = cursor
+            .as_ref()
+            .and_then(|cursor_key| blob_keys.iter().position(|key| key > cursor_key))
+            .unwrap_or(0);
+
+        let end_index =
+            start_index.saturating_add(limit.min(blob_keys.len().saturating_sub(start_index)));
+        let page_keys = &blob_keys[start_index..end_index];
+
+        let mut blobs = Vec::with_capacity(page_keys.len());
+        for key_str in page_keys {
+            let key = BlobKey(key_str.clone());
+            if let Some(metadata) = self.head(&key).await? {
+                blobs.push(metadata);
+            }
+        }
+
+        let next_cursor = if end_index < blob_keys.len() && end_index > start_index {
+            blob_keys.get(end_index - 1).cloned()
+        } else {
+            None
+        };
+
+        Ok(ListBlobsPage { blobs, next_cursor })
+    }
+}
+
+async fn collect_blob_keys(
+    root_dir: &Path,
+    current_dir: &Path,
+    blob_keys: &mut Vec<String>,
+) -> Result<(), BlobStoreError> {
+    let mut entries =
+        fs::read_dir(current_dir)
+            .await
+            .map_err(|error| BlobStoreError::Operation {
+                operation: "read_dir",
+                message: error.to_string(),
+            })?;
+
+    while let Some(entry) =
+        entries
+            .next_entry()
+            .await
+            .map_err(|error| BlobStoreError::Operation {
+                operation: "read_dir",
+                message: error.to_string(),
+            })?
+    {
+        let file_type = entry
+            .file_type()
+            .await
+            .map_err(|error| BlobStoreError::Operation {
+                operation: "file_type",
+                message: error.to_string(),
+            })?;
+        let path = entry.path();
+        if file_type.is_dir() {
+            Box::pin(collect_blob_keys(root_dir, &path, blob_keys)).await?;
+            continue;
+        }
+        if !file_type.is_file() {
+            continue;
+        }
+
+        let relative_path =
+            path.strip_prefix(root_dir)
+                .map_err(|error| BlobStoreError::Operation {
+                    operation: "strip_prefix",
+                    message: error.to_string(),
+                })?;
+        let key = relative_path
+            .iter()
+            .map(|segment| segment.to_string_lossy())
+            .collect::<Vec<_>>()
+            .join("/");
+        blob_keys.push(key);
+    }
+
+    Ok(())
+}
+
+fn validate_blob_key(raw_key: &str) -> Result<(), BlobStoreError> {
+    if raw_key.is_empty() {
+        return Err(BlobStoreError::InvalidKey {
+            key: raw_key.to_string(),
+            message: "blob key must not be empty".to_string(),
+        });
+    }
+    if raw_key.starts_with('/') {
+        return Err(BlobStoreError::InvalidKey {
+            key: raw_key.to_string(),
+            message: "blob key must be relative".to_string(),
+        });
+    }
+
+    for segment in raw_key.split('/') {
+        if segment.is_empty() {
+            return Err(BlobStoreError::InvalidKey {
+                key: raw_key.to_string(),
+                message: "blob key must not contain empty path segments".to_string(),
+            });
+        }
+        if matches!(segment, "." | "..") {
+            return Err(BlobStoreError::InvalidKey {
+                key: raw_key.to_string(),
+                message: "blob key must not contain traversal segments".to_string(),
+            });
+        }
+        if segment.contains('\\') || segment.contains('\0') {
+            return Err(BlobStoreError::InvalidKey {
+                key: raw_key.to_string(),
+                message: "blob key contains unsupported path characters".to_string(),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+fn normalize_prefix(raw_prefix: &str) -> Result<String, BlobStoreError> {
+    let trimmed = raw_prefix.trim_matches('/');
+    if trimmed.is_empty() {
+        return Ok(String::new());
+    }
+    validate_blob_key(trimmed)?;
+    Ok(trimmed.to_string())
+}
+
+fn to_utc(system_time: SystemTime) -> DateTime<Utc> {
+    DateTime::<Utc>::from(system_time)
+}

--- a/crates/blob_storage/src/filesystem.rs
+++ b/crates/blob_storage/src/filesystem.rs
@@ -218,10 +218,18 @@ impl BlobStore for FilesystemBlobStore {
         blob_keys.retain(|key| key.starts_with(&normalized_prefix));
         blob_keys.sort();
 
-        let start_index = cursor
-            .as_ref()
-            .and_then(|cursor_key| blob_keys.iter().position(|key| key > cursor_key))
-            .unwrap_or(0);
+        let start_index = match cursor.as_ref() {
+            Some(cursor_key) => match blob_keys.iter().position(|key| key > cursor_key) {
+                Some(index) => index,
+                None => {
+                    return Ok(ListBlobsPage {
+                        blobs: Vec::new(),
+                        next_cursor: None,
+                    });
+                }
+            },
+            None => 0,
+        };
 
         let end_index =
             start_index.saturating_add(limit.min(blob_keys.len().saturating_sub(start_index)));
@@ -350,12 +358,23 @@ fn validate_blob_key(raw_key: &str) -> Result<(), BlobStoreError> {
 }
 
 fn normalize_prefix(raw_prefix: &str) -> Result<String, BlobStoreError> {
-    let trimmed = raw_prefix.trim_matches('/');
+    let trimmed = raw_prefix.trim_start_matches('/');
     if trimmed.is_empty() {
         return Ok(String::new());
     }
-    validate_blob_key(trimmed)?;
-    Ok(trimmed.to_string())
+
+    let has_trailing_slash = trimmed.ends_with('/');
+    let core = trimmed.trim_end_matches('/');
+    if core.is_empty() {
+        return Ok(String::new());
+    }
+
+    validate_blob_key(core)?;
+    if has_trailing_slash {
+        Ok(format!("{core}/"))
+    } else {
+        Ok(core.to_string())
+    }
 }
 
 fn to_utc(system_time: SystemTime) -> DateTime<Utc> {

--- a/crates/blob_storage/src/filesystem.rs
+++ b/crates/blob_storage/src/filesystem.rs
@@ -79,34 +79,46 @@ impl BlobStore for FilesystemBlobStore {
             })?;
 
         let temp_path = path.with_extension(format!("{}.tmp", Uuid::now_v7()));
-        let mut file =
-            File::create(&temp_path)
+        let copied_result = async {
+            let mut file =
+                File::create(&temp_path)
+                    .await
+                    .map_err(|error| BlobStoreError::Operation {
+                        operation: "create",
+                        message: error.to_string(),
+                    })?;
+
+            let copied = tokio::io::copy(&mut request.reader, &mut file)
                 .await
                 .map_err(|error| BlobStoreError::Operation {
-                    operation: "create",
+                    operation: "write",
+                    message: error.to_string(),
+                })?;
+            file.sync_all()
+                .await
+                .map_err(|error| BlobStoreError::Operation {
+                    operation: "sync_all",
+                    message: error.to_string(),
+                })?;
+            drop(file);
+
+            fs::rename(&temp_path, &path)
+                .await
+                .map_err(|error| BlobStoreError::Operation {
+                    operation: "rename",
                     message: error.to_string(),
                 })?;
 
-        let copied = tokio::io::copy(&mut request.reader, &mut file)
-            .await
-            .map_err(|error| BlobStoreError::Operation {
-                operation: "write",
-                message: error.to_string(),
-            })?;
-        file.sync_all()
-            .await
-            .map_err(|error| BlobStoreError::Operation {
-                operation: "sync_all",
-                message: error.to_string(),
-            })?;
-        drop(file);
-
-        fs::rename(&temp_path, &path)
-            .await
-            .map_err(|error| BlobStoreError::Operation {
-                operation: "rename",
-                message: error.to_string(),
-            })?;
+            Ok::<u64, BlobStoreError>(copied)
+        }
+        .await;
+        let copied = match copied_result {
+            Ok(copied) => copied,
+            Err(error) => {
+                let _ = fs::remove_file(&temp_path).await;
+                return Err(error);
+            }
+        };
 
         let metadata = fs::metadata(&path)
             .await
@@ -179,7 +191,30 @@ impl BlobStore for FilesystemBlobStore {
     ) -> Result<ListBlobsPage, BlobStoreError> {
         let normalized_prefix = normalize_prefix(&prefix.0)?;
         let mut blob_keys = Vec::new();
-        collect_blob_keys(&self.root_dir, &self.root_dir, &mut blob_keys).await?;
+        let search_root = search_root_for_prefix(&self.root_dir, &normalized_prefix);
+        match fs::metadata(&search_root).await {
+            Ok(metadata) if metadata.is_dir() => {
+                collect_blob_keys(&self.root_dir, &search_root, &mut blob_keys).await?;
+            }
+            Ok(_) => {
+                return Ok(ListBlobsPage {
+                    blobs: Vec::new(),
+                    next_cursor: None,
+                });
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(ListBlobsPage {
+                    blobs: Vec::new(),
+                    next_cursor: None,
+                });
+            }
+            Err(error) => {
+                return Err(BlobStoreError::Operation {
+                    operation: "metadata",
+                    message: error.to_string(),
+                });
+            }
+        }
         blob_keys.retain(|key| key.starts_with(&normalized_prefix));
         blob_keys.sort();
 
@@ -208,6 +243,17 @@ impl BlobStore for FilesystemBlobStore {
 
         Ok(ListBlobsPage { blobs, next_cursor })
     }
+}
+
+fn search_root_for_prefix(root_dir: &Path, normalized_prefix: &str) -> PathBuf {
+    let Some((parent_prefix, _)) = normalized_prefix.rsplit_once('/') else {
+        return root_dir.to_path_buf();
+    };
+    let mut path = root_dir.to_path_buf();
+    for segment in parent_prefix.split('/') {
+        path.push(segment);
+    }
+    path
 }
 
 async fn collect_blob_keys(

--- a/crates/blob_storage/src/lib.rs
+++ b/crates/blob_storage/src/lib.rs
@@ -1,14 +1,20 @@
 //! Generic blob/object storage contracts for the skills subsystem.
 //!
-//! This crate intentionally defines only backend-neutral configuration and
-//! trait types. Concrete filesystem and cloud-provider implementations land in
-//! later PRs.
+//! This crate defines the backend-neutral contract plus the first concrete
+//! single-process implementation path: filesystem-backed blobs with a local
+//! read cache.
 
+mod cache;
 mod config;
+mod factory;
+mod filesystem;
 mod store;
 mod types;
 
-pub use config::{BlobStoreBackend, BlobStoreConfig};
+pub use cache::CachedBlobStore;
+pub use config::{BlobCacheConfig, BlobStoreBackend, BlobStoreConfig};
+pub use factory::{create_blob_store, BlobStoreInitError};
+pub use filesystem::FilesystemBlobStore;
 pub use store::{BlobStore, BlobStoreError};
 pub use types::{
     BlobKey, BlobMetadata, BlobPrefix, GetBlobResponse, ListBlobsPage, PutBlobRequest,

--- a/crates/blob_storage/tests/filesystem_blob_store.rs
+++ b/crates/blob_storage/tests/filesystem_blob_store.rs
@@ -85,6 +85,7 @@ async fn filesystem_store_rejects_invalid_blob_keys() -> Result<()> {
 struct CountingBlobStore {
     inner: FilesystemBlobStore,
     get_calls: AtomicUsize,
+    etag: Option<&'static str>,
 }
 
 #[async_trait]
@@ -102,7 +103,9 @@ impl BlobStore for CountingBlobStore {
         key: &BlobKey,
     ) -> Result<GetBlobResponse, smg_blob_storage::BlobStoreError> {
         self.get_calls.fetch_add(1, Ordering::SeqCst);
-        self.inner.get(key).await
+        let mut response = self.inner.get(key).await?;
+        response.metadata.etag = self.etag.map(str::to_string);
+        Ok(response)
     }
 
     async fn head(
@@ -133,6 +136,7 @@ async fn cached_store_avoids_repeated_backend_reads() -> Result<()> {
     let inner = Arc::new(CountingBlobStore {
         inner: FilesystemBlobStore::new(blob_root.path())?,
         get_calls: AtomicUsize::new(0),
+        etag: None,
     });
     let key = BlobKey::from("skills/t1/s1/v1/scripts/run.py");
 
@@ -155,6 +159,89 @@ async fn cached_store_avoids_repeated_backend_reads() -> Result<()> {
 
     assert_eq!(first, b"print('cached')");
     assert_eq!(second, b"print('cached')");
+    assert_eq!(inner.get_calls.load(Ordering::SeqCst), 1);
+    Ok(())
+}
+
+#[test]
+fn cached_store_rejects_zero_sized_cache_config() -> Result<()> {
+    let blob_root = TempDir::new()?;
+    let inner = Arc::new(FilesystemBlobStore::new(blob_root.path())?) as Arc<dyn BlobStore>;
+    let cache_root = TempDir::new()?;
+
+    let error = smg_blob_storage::CachedBlobStore::new(
+        inner,
+        &BlobCacheConfig {
+            path: cache_root.path().display().to_string(),
+            max_size_mb: 0,
+        },
+    )
+    .expect_err("zero-sized cache config should be rejected");
+
+    assert!(matches!(
+        error,
+        smg_blob_storage::BlobStoreInitError::InvalidConfig { .. }
+    ));
+    Ok(())
+}
+
+#[tokio::test]
+async fn cached_store_keeps_oversized_latest_blob_readable() -> Result<()> {
+    let blob_root = TempDir::new()?;
+    let cache_root = TempDir::new()?;
+    let inner = Arc::new(CountingBlobStore {
+        inner: FilesystemBlobStore::new(blob_root.path())?,
+        get_calls: AtomicUsize::new(0),
+        etag: None,
+    });
+    let key = BlobKey::from("skills/t1/s1/v1/large.bin");
+    let payload = vec![b'x'; 2 * 1024 * 1024];
+
+    inner.put_stream(&key, put_request(&payload)).await?;
+
+    let store = Arc::new(smg_blob_storage::CachedBlobStore::new(
+        inner.clone() as Arc<dyn BlobStore>,
+        &BlobCacheConfig {
+            path: cache_root.path().display().to_string(),
+            max_size_mb: 1,
+        },
+    )?) as Arc<dyn BlobStore>;
+
+    let first = read_all(store.get(&key).await?).await?;
+    let second = read_all(store.get(&key).await?).await?;
+
+    assert_eq!(first.len(), payload.len());
+    assert_eq!(second.len(), payload.len());
+    assert_eq!(inner.get_calls.load(Ordering::SeqCst), 1);
+    Ok(())
+}
+
+#[tokio::test]
+async fn cached_store_hits_when_backend_returns_etag_metadata() -> Result<()> {
+    let blob_root = TempDir::new()?;
+    let cache_root = TempDir::new()?;
+    let inner = Arc::new(CountingBlobStore {
+        inner: FilesystemBlobStore::new(blob_root.path())?,
+        get_calls: AtomicUsize::new(0),
+        etag: Some("etag-v1"),
+    });
+    let key = BlobKey::from("skills/t1/s1/v1/SKILL.md");
+
+    inner.put_stream(&key, put_request(b"etagged")).await?;
+
+    let store = Arc::new(smg_blob_storage::CachedBlobStore::new(
+        inner.clone() as Arc<dyn BlobStore>,
+        &BlobCacheConfig {
+            path: cache_root.path().display().to_string(),
+            max_size_mb: 8,
+        },
+    )?) as Arc<dyn BlobStore>;
+
+    let first = read_all(store.get(&key).await?).await?;
+    let second = read_all(store.get(&key).await?).await?;
+
+    assert_eq!(first, b"etagged");
+    assert_eq!(second, b"etagged");
     assert_eq!(inner.get_calls.load(Ordering::SeqCst), 1);
     Ok(())
 }

--- a/crates/blob_storage/tests/filesystem_blob_store.rs
+++ b/crates/blob_storage/tests/filesystem_blob_store.rs
@@ -1,0 +1,160 @@
+use std::{
+    io::Cursor,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+};
+
+use anyhow::Result;
+use async_trait::async_trait;
+use smg_blob_storage::{
+    BlobCacheConfig, BlobKey, BlobMetadata, BlobPrefix, BlobStore, FilesystemBlobStore,
+    GetBlobResponse, ListBlobsPage, PutBlobRequest,
+};
+use tempfile::TempDir;
+use tokio::io::AsyncReadExt;
+
+fn put_request(bytes: &[u8]) -> PutBlobRequest {
+    PutBlobRequest {
+        reader: Box::pin(Cursor::new(bytes.to_vec())),
+        content_length: bytes.len() as u64,
+        content_type: None,
+    }
+}
+
+async fn read_all(response: GetBlobResponse) -> Result<Vec<u8>> {
+    let mut reader = response.reader;
+    let mut buffer = Vec::new();
+    reader.read_to_end(&mut buffer).await?;
+    Ok(buffer)
+}
+
+#[tokio::test]
+async fn filesystem_store_round_trips_and_lists_prefixes() -> Result<()> {
+    let root = TempDir::new()?;
+    let store = FilesystemBlobStore::new(root.path())?;
+    let key = BlobKey::from("skills/t1/s1/v1/SKILL.md");
+    let aux_key = BlobKey::from("skills/t1/s1/v1/scripts/run.py");
+
+    let metadata = store.put_stream(&key, put_request(b"hello skill")).await?;
+    assert_eq!(metadata.key, key);
+    assert_eq!(metadata.size_bytes, 11);
+
+    store
+        .put_stream(&aux_key, put_request(b"print('hi')"))
+        .await?;
+
+    let head = store
+        .head(&key)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("missing head"))?;
+    assert_eq!(head.size_bytes, 11);
+
+    let body = read_all(store.get(&key).await?).await?;
+    assert_eq!(body, b"hello skill");
+
+    let page = store
+        .list_prefix(&BlobPrefix::from("skills/t1/s1"), None, 10)
+        .await?;
+    assert_eq!(page.blobs.len(), 2);
+
+    store.delete(&key).await?;
+    assert!(store.head(&key).await?.is_none());
+    Ok(())
+}
+
+#[tokio::test]
+async fn filesystem_store_rejects_invalid_blob_keys() -> Result<()> {
+    let root = TempDir::new()?;
+    let store = FilesystemBlobStore::new(root.path())?;
+
+    let error = store
+        .put_stream(&BlobKey::from("../escape"), put_request(b"bad"))
+        .await;
+    let Err(error) = error else {
+        return Err(anyhow::anyhow!("invalid blob key should fail"));
+    };
+    assert!(matches!(
+        error,
+        smg_blob_storage::BlobStoreError::InvalidKey { .. }
+    ));
+    Ok(())
+}
+
+struct CountingBlobStore {
+    inner: FilesystemBlobStore,
+    get_calls: AtomicUsize,
+}
+
+#[async_trait]
+impl BlobStore for CountingBlobStore {
+    async fn put_stream(
+        &self,
+        key: &BlobKey,
+        request: PutBlobRequest,
+    ) -> Result<BlobMetadata, smg_blob_storage::BlobStoreError> {
+        self.inner.put_stream(key, request).await
+    }
+
+    async fn get(
+        &self,
+        key: &BlobKey,
+    ) -> Result<GetBlobResponse, smg_blob_storage::BlobStoreError> {
+        self.get_calls.fetch_add(1, Ordering::SeqCst);
+        self.inner.get(key).await
+    }
+
+    async fn head(
+        &self,
+        key: &BlobKey,
+    ) -> Result<Option<BlobMetadata>, smg_blob_storage::BlobStoreError> {
+        self.inner.head(key).await
+    }
+
+    async fn delete(&self, key: &BlobKey) -> Result<(), smg_blob_storage::BlobStoreError> {
+        self.inner.delete(key).await
+    }
+
+    async fn list_prefix(
+        &self,
+        prefix: &BlobPrefix,
+        cursor: Option<String>,
+        limit: usize,
+    ) -> Result<ListBlobsPage, smg_blob_storage::BlobStoreError> {
+        self.inner.list_prefix(prefix, cursor, limit).await
+    }
+}
+
+#[tokio::test]
+async fn cached_store_avoids_repeated_backend_reads() -> Result<()> {
+    let blob_root = TempDir::new()?;
+    let cache_root = TempDir::new()?;
+    let inner = Arc::new(CountingBlobStore {
+        inner: FilesystemBlobStore::new(blob_root.path())?,
+        get_calls: AtomicUsize::new(0),
+    });
+    let key = BlobKey::from("skills/t1/s1/v1/scripts/run.py");
+
+    inner
+        .put_stream(&key, put_request(b"print('cached')"))
+        .await?;
+
+    // Replace the factory-created backend with the counting backend so the test
+    // can prove the cache short-circuits the second read.
+    let store = Arc::new(smg_blob_storage::CachedBlobStore::new(
+        inner.clone() as Arc<dyn BlobStore>,
+        &BlobCacheConfig {
+            path: cache_root.path().display().to_string(),
+            max_size_mb: 8,
+        },
+    )?) as Arc<dyn BlobStore>;
+
+    let first = read_all(store.get(&key).await?).await?;
+    let second = read_all(store.get(&key).await?).await?;
+
+    assert_eq!(first, b"print('cached')");
+    assert_eq!(second, b"print('cached')");
+    assert_eq!(inner.get_calls.load(Ordering::SeqCst), 1);
+    Ok(())
+}

--- a/crates/blob_storage/tests/filesystem_blob_store.rs
+++ b/crates/blob_storage/tests/filesystem_blob_store.rs
@@ -1,9 +1,6 @@
-use std::{
-    io::Cursor,
-    sync::{
-        atomic::{AtomicUsize, Ordering},
-        Arc,
-    },
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
 };
 
 use anyhow::Result;
@@ -13,22 +10,11 @@ use smg_blob_storage::{
     GetBlobResponse, ListBlobsPage, PutBlobRequest,
 };
 use tempfile::TempDir;
-use tokio::io::AsyncReadExt;
 
-fn put_request(bytes: &[u8]) -> PutBlobRequest {
-    PutBlobRequest {
-        reader: Box::pin(Cursor::new(bytes.to_vec())),
-        content_length: bytes.len() as u64,
-        content_type: None,
-    }
-}
+#[path = "../../../test_support/blob_test_utils.rs"]
+mod blob_test_utils;
 
-async fn read_all(response: GetBlobResponse) -> Result<Vec<u8>> {
-    let mut reader = response.reader;
-    let mut buffer = Vec::new();
-    reader.read_to_end(&mut buffer).await?;
-    Ok(buffer)
-}
+use blob_test_utils::{put_request, read_all};
 
 #[tokio::test]
 async fn filesystem_store_round_trips_and_lists_prefixes() -> Result<()> {
@@ -61,6 +47,52 @@ async fn filesystem_store_round_trips_and_lists_prefixes() -> Result<()> {
 
     store.delete(&key).await?;
     assert!(store.head(&key).await?.is_none());
+    Ok(())
+}
+
+#[tokio::test]
+async fn filesystem_store_returns_empty_page_for_stale_cursor() -> Result<()> {
+    let root = TempDir::new()?;
+    let store = FilesystemBlobStore::new(root.path())?;
+
+    store
+        .put_stream(&BlobKey::from("skills/t1/a.txt"), put_request(b"a"))
+        .await?;
+    store
+        .put_stream(&BlobKey::from("skills/t1/b.txt"), put_request(b"b"))
+        .await?;
+
+    let page = store
+        .list_prefix(
+            &BlobPrefix::from("skills/t1"),
+            Some("skills/t1/z.txt".to_string()),
+            10,
+        )
+        .await?;
+
+    assert!(page.blobs.is_empty());
+    assert!(page.next_cursor.is_none());
+    Ok(())
+}
+
+#[tokio::test]
+async fn filesystem_store_preserves_trailing_slash_prefix_boundaries() -> Result<()> {
+    let root = TempDir::new()?;
+    let store = FilesystemBlobStore::new(root.path())?;
+
+    store
+        .put_stream(&BlobKey::from("skills/t1/file.txt"), put_request(b"one"))
+        .await?;
+    store
+        .put_stream(&BlobKey::from("skills/t10/file.txt"), put_request(b"ten"))
+        .await?;
+
+    let page = store
+        .list_prefix(&BlobPrefix::from("skills/t1/"), None, 10)
+        .await?;
+
+    assert_eq!(page.blobs.len(), 1);
+    assert_eq!(page.blobs[0].key, BlobKey::from("skills/t1/file.txt"));
     Ok(())
 }
 
@@ -243,5 +275,35 @@ async fn cached_store_hits_when_backend_returns_etag_metadata() -> Result<()> {
     assert_eq!(first, b"etagged");
     assert_eq!(second, b"etagged");
     assert_eq!(inner.get_calls.load(Ordering::SeqCst), 1);
+    Ok(())
+}
+
+#[tokio::test]
+async fn cached_store_returns_backend_payload_when_cache_population_fails() -> Result<()> {
+    let blob_root = TempDir::new()?;
+    let cache_root = TempDir::new()?;
+    let inner = Arc::new(CountingBlobStore {
+        inner: FilesystemBlobStore::new(blob_root.path())?,
+        get_calls: AtomicUsize::new(0),
+        etag: None,
+    });
+    let key = BlobKey::from("skills/t1/s1/v1/fallback.txt");
+
+    inner.put_stream(&key, put_request(b"fallback")).await?;
+
+    let store = Arc::new(smg_blob_storage::CachedBlobStore::new(
+        inner.clone() as Arc<dyn BlobStore>,
+        &BlobCacheConfig {
+            path: cache_root.path().display().to_string(),
+            max_size_mb: 8,
+        },
+    )?) as Arc<dyn BlobStore>;
+
+    std::fs::remove_dir_all(cache_root.path())?;
+
+    let body = read_all(store.get(&key).await?).await?;
+
+    assert_eq!(body, b"fallback");
+    assert_eq!(inner.get_calls.load(Ordering::SeqCst), 2);
     Ok(())
 }

--- a/crates/skills/Cargo.toml
+++ b/crates/skills/Cargo.toml
@@ -19,6 +19,7 @@ name = "smg_skills"
 [dependencies]
 async-trait.workspace = true
 chrono = { workspace = true, features = ["serde"] }
+parking_lot.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_yml = "0.0.12"
 smg-blob-storage.workspace = true
@@ -28,6 +29,8 @@ zip = "8.1"
 [dev-dependencies]
 anyhow.workspace = true
 serde_json.workspace = true
+tempfile = "3.15"
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [lints]
 workspace = true

--- a/crates/skills/src/api.rs
+++ b/crates/skills/src/api.rs
@@ -1,21 +1,48 @@
-use std::sync::Arc;
+use std::{fmt, sync::Arc};
+
+use smg_blob_storage::BlobStore;
+
+use crate::{
+    memory::InMemorySkillStore,
+    storage::{BundleTokenStore, ContinuationCookieStore, SkillMetadataStore, TenantAliasStore},
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum SkillServiceMode {
     #[default]
     Placeholder,
+    SingleProcess,
 }
 
-#[derive(Debug, Default)]
 struct SkillServiceInner {
     mode: SkillServiceMode,
+    metadata_store: Option<Arc<dyn SkillMetadataStore>>,
+    tenant_alias_store: Option<Arc<dyn TenantAliasStore>>,
+    bundle_token_store: Option<Arc<dyn BundleTokenStore>>,
+    continuation_cookie_store: Option<Arc<dyn ContinuationCookieStore>>,
+    blob_store: Option<Arc<dyn BlobStore>>,
 }
 
-/// Placeholder service hook used to establish the app-context boundary before
-/// the CRUD, storage, and resolution logic lands in later PRs.
-#[derive(Debug, Clone, Default)]
+impl fmt::Debug for SkillServiceInner {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SkillServiceInner")
+            .field("mode", &self.mode)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Skills service boundary used by the gateway. This PR introduces a concrete
+/// single-process mode backed by in-memory metadata stores and a generic blob
+/// store.
+#[derive(Debug, Clone)]
 pub struct SkillService {
     inner: Arc<SkillServiceInner>,
+}
+
+impl Default for SkillService {
+    fn default() -> Self {
+        Self::placeholder()
+    }
 }
 
 impl SkillService {
@@ -23,22 +50,109 @@ impl SkillService {
         Self {
             inner: Arc::new(SkillServiceInner {
                 mode: SkillServiceMode::Placeholder,
+                metadata_store: None,
+                tenant_alias_store: None,
+                bundle_token_store: None,
+                continuation_cookie_store: None,
+                blob_store: None,
             }),
         }
+    }
+
+    pub fn single_process(
+        metadata_store: Arc<dyn SkillMetadataStore>,
+        tenant_alias_store: Arc<dyn TenantAliasStore>,
+        bundle_token_store: Arc<dyn BundleTokenStore>,
+        continuation_cookie_store: Arc<dyn ContinuationCookieStore>,
+        blob_store: Arc<dyn BlobStore>,
+    ) -> Self {
+        Self {
+            inner: Arc::new(SkillServiceInner {
+                mode: SkillServiceMode::SingleProcess,
+                metadata_store: Some(metadata_store),
+                tenant_alias_store: Some(tenant_alias_store),
+                bundle_token_store: Some(bundle_token_store),
+                continuation_cookie_store: Some(continuation_cookie_store),
+                blob_store: Some(blob_store),
+            }),
+        }
+    }
+
+    pub fn in_memory(blob_store: Arc<dyn BlobStore>) -> Self {
+        let store = Arc::new(InMemorySkillStore::default());
+        Self::single_process(
+            store.clone(),
+            store.clone(),
+            store.clone(),
+            store,
+            blob_store,
+        )
     }
 
     pub fn mode(&self) -> SkillServiceMode {
         self.inner.mode
     }
+
+    pub fn metadata_store(&self) -> Option<Arc<dyn SkillMetadataStore>> {
+        self.inner.metadata_store.clone()
+    }
+
+    pub fn tenant_alias_store(&self) -> Option<Arc<dyn TenantAliasStore>> {
+        self.inner.tenant_alias_store.clone()
+    }
+
+    pub fn bundle_token_store(&self) -> Option<Arc<dyn BundleTokenStore>> {
+        self.inner.bundle_token_store.clone()
+    }
+
+    pub fn continuation_cookie_store(&self) -> Option<Arc<dyn ContinuationCookieStore>> {
+        self.inner.continuation_cookie_store.clone()
+    }
+
+    pub fn blob_store(&self) -> Option<Arc<dyn BlobStore>> {
+        self.inner.blob_store.clone()
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use anyhow::{anyhow, Result};
+    use smg_blob_storage::FilesystemBlobStore;
+    use tempfile::TempDir;
+
     use super::{SkillService, SkillServiceMode};
 
     #[test]
     fn placeholder_service_reports_placeholder_mode() {
         let service = SkillService::placeholder();
         assert_eq!(service.mode(), SkillServiceMode::Placeholder);
+        assert!(service.metadata_store().is_none());
+    }
+
+    #[test]
+    fn single_process_service_exposes_all_stores() -> Result<()> {
+        let root = TempDir::new()?;
+        let blob_store = Arc::new(FilesystemBlobStore::new(root.path())?);
+        let service = SkillService::in_memory(blob_store.clone());
+
+        assert_eq!(service.mode(), SkillServiceMode::SingleProcess);
+        service
+            .metadata_store()
+            .ok_or_else(|| anyhow!("metadata store missing"))?;
+        service
+            .tenant_alias_store()
+            .ok_or_else(|| anyhow!("tenant alias store missing"))?;
+        service
+            .bundle_token_store()
+            .ok_or_else(|| anyhow!("bundle token store missing"))?;
+        service
+            .continuation_cookie_store()
+            .ok_or_else(|| anyhow!("continuation cookie store missing"))?;
+        service
+            .blob_store()
+            .ok_or_else(|| anyhow!("blob store missing"))?;
+        Ok(())
     }
 }

--- a/crates/skills/src/config.rs
+++ b/crates/skills/src/config.rs
@@ -5,7 +5,8 @@ use serde::{
     Deserialize, Deserializer, Serialize, Serializer,
 };
 pub use smg_blob_storage::{
-    BlobStoreBackend as SkillsBlobStoreBackend, BlobStoreConfig as SkillsBlobStoreConfig,
+    BlobCacheConfig as SkillsCacheConfig, BlobStoreBackend as SkillsBlobStoreBackend,
+    BlobStoreConfig as SkillsBlobStoreConfig,
 };
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
@@ -222,22 +223,6 @@ impl Default for SkillsAdminConfig {
                 SkillsAdminOperation::CreateAlias,
                 SkillsAdminOperation::ExecuteMigration,
             ],
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(default)]
-pub struct SkillsCacheConfig {
-    pub path: String,
-    pub max_size_mb: usize,
-}
-
-impl Default for SkillsCacheConfig {
-    fn default() -> Self {
-        Self {
-            path: "/var/smg/cache/skills".to_string(),
-            max_size_mb: 1024,
         }
     }
 }

--- a/crates/skills/src/config.rs
+++ b/crates/skills/src/config.rs
@@ -410,6 +410,7 @@ mod tests {
         let skills = SkillsConfig::default();
         assert_eq!(skills.resolution_mode, SkillsResolutionMode::Auto);
         assert_eq!(skills.max_skills_per_request, 8);
+        assert_eq!(skills.cache.max_size_mb, 0);
     }
 
     #[test]
@@ -436,6 +437,6 @@ mod tests {
             Some("http://executor.internal")
         );
         assert_eq!(parsed.tool_loop.max_steps, 8);
-        assert_eq!(parsed.cache.max_size_mb, 1024);
+        assert_eq!(parsed.cache.max_size_mb, 0);
     }
 }

--- a/crates/skills/src/lib.rs
+++ b/crates/skills/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod api;
 pub mod config;
+pub mod memory;
 pub mod storage;
 pub mod types;
 pub mod validation;
@@ -19,6 +20,7 @@ pub use config::{
     SkillsResolutionMode, SkillsRetentionConfig, SkillsRetentionMode, SkillsTenancyConfig,
     SkillsToolLoopConfig, SkillsZdrConfig,
 };
+pub use memory::InMemorySkillStore;
 pub use storage::{
     BundleTokenStore, ContinuationCookieStore, SkillMetadataStore, SkillsStoreError,
     SkillsStoreResult, TenantAliasStore,

--- a/crates/skills/src/memory.rs
+++ b/crates/skills/src/memory.rs
@@ -85,11 +85,17 @@ impl SkillMetadataStore for InMemorySkillStore {
             return Ok(false);
         }
 
-        if let Some(versions) = state.skill_versions_by_skill.remove(skill_id) {
-            for version in versions {
-                state
-                    .skill_versions
-                    .remove(&(skill_id.to_string(), version));
+        let skill_still_referenced = state
+            .skills
+            .keys()
+            .any(|(_, existing_skill_id)| existing_skill_id == skill_id);
+        if !skill_still_referenced {
+            if let Some(versions) = state.skill_versions_by_skill.remove(skill_id) {
+                for version in versions {
+                    state
+                        .skill_versions
+                        .remove(&(skill_id.to_string(), version));
+                }
             }
         }
 
@@ -203,12 +209,21 @@ impl TenantAliasStore for InMemorySkillStore {
 impl BundleTokenStore for InMemorySkillStore {
     async fn put_bundle_token(&self, claim: BundleTokenClaim) -> SkillsStoreResult<()> {
         let mut state = self.state.write();
+        let token_hash = claim.token_hash.clone();
+        let exec_id = claim.exec_id.clone();
+        if let Some(previous) = state.bundle_tokens.insert(token_hash.clone(), claim) {
+            if let Some(tokens) = state.bundle_tokens_by_exec.get_mut(&previous.exec_id) {
+                tokens.remove(&token_hash);
+                if tokens.is_empty() {
+                    state.bundle_tokens_by_exec.remove(&previous.exec_id);
+                }
+            }
+        }
         state
             .bundle_tokens_by_exec
-            .entry(claim.exec_id.clone())
+            .entry(exec_id)
             .or_default()
-            .insert(claim.token_hash.clone());
-        state.bundle_tokens.insert(claim.token_hash.clone(), claim);
+            .insert(token_hash);
         Ok(())
     }
 
@@ -253,14 +268,27 @@ impl ContinuationCookieStore for InMemorySkillStore {
         claim: ContinuationCookieClaim,
     ) -> SkillsStoreResult<()> {
         let mut state = self.state.write();
+        let cookie_hash = claim.cookie_hash.clone();
+        let exec_id = claim.exec_id.clone();
+        if let Some(previous) = state
+            .continuation_cookies
+            .insert(cookie_hash.clone(), claim)
+        {
+            if let Some(cookies) = state
+                .continuation_cookies_by_exec
+                .get_mut(&previous.exec_id)
+            {
+                cookies.remove(&cookie_hash);
+                if cookies.is_empty() {
+                    state.continuation_cookies_by_exec.remove(&previous.exec_id);
+                }
+            }
+        }
         state
             .continuation_cookies_by_exec
-            .entry(claim.exec_id.clone())
+            .entry(exec_id)
             .or_default()
-            .insert(claim.cookie_hash.clone());
-        state
-            .continuation_cookies
-            .insert(claim.cookie_hash.clone(), claim);
+            .insert(cookie_hash);
         Ok(())
     }
 

--- a/crates/skills/src/memory.rs
+++ b/crates/skills/src/memory.rs
@@ -1,0 +1,298 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use async_trait::async_trait;
+use parking_lot::RwLock;
+
+use crate::{
+    storage::{
+        BundleTokenStore, ContinuationCookieStore, SkillMetadataStore, SkillsStoreResult,
+        TenantAliasStore,
+    },
+    types::{
+        BundleTokenClaim, ContinuationCookieClaim, SkillRecord, SkillVersionRecord,
+        TenantAliasRecord,
+    },
+};
+
+#[derive(Debug, Default)]
+struct InMemorySkillState {
+    skills: BTreeMap<(String, String), SkillRecord>,
+    skill_versions: BTreeMap<(String, String), SkillVersionRecord>,
+    skill_versions_by_skill: BTreeMap<String, BTreeSet<String>>,
+    tenant_aliases: BTreeMap<String, TenantAliasRecord>,
+    bundle_tokens: BTreeMap<String, BundleTokenClaim>,
+    bundle_tokens_by_exec: BTreeMap<String, BTreeSet<String>>,
+    continuation_cookies: BTreeMap<String, ContinuationCookieClaim>,
+    continuation_cookies_by_exec: BTreeMap<String, BTreeSet<String>>,
+}
+
+/// Single-process in-memory skills persistence used for local development and
+/// early end-to-end testing.
+#[derive(Debug, Default)]
+pub struct InMemorySkillStore {
+    state: RwLock<InMemorySkillState>,
+}
+
+#[async_trait]
+impl SkillMetadataStore for InMemorySkillStore {
+    async fn put_skill(&self, record: SkillRecord) -> SkillsStoreResult<()> {
+        let key = (record.tenant_id.clone(), record.skill_id.clone());
+        self.state.write().skills.insert(key, record);
+        Ok(())
+    }
+
+    async fn get_skill(
+        &self,
+        tenant_id: &str,
+        skill_id: &str,
+    ) -> SkillsStoreResult<Option<SkillRecord>> {
+        Ok(self
+            .state
+            .read()
+            .skills
+            .get(&(tenant_id.to_string(), skill_id.to_string()))
+            .cloned())
+    }
+
+    async fn list_skills(&self, tenant_id: &str) -> SkillsStoreResult<Vec<SkillRecord>> {
+        let mut skills = self
+            .state
+            .read()
+            .skills
+            .values()
+            .filter(|record| record.tenant_id == tenant_id)
+            .cloned()
+            .collect::<Vec<_>>();
+        skills.sort_by(|left, right| {
+            left.name
+                .cmp(&right.name)
+                .then(left.skill_id.cmp(&right.skill_id))
+        });
+        Ok(skills)
+    }
+
+    async fn delete_skill(&self, tenant_id: &str, skill_id: &str) -> SkillsStoreResult<bool> {
+        let mut state = self.state.write();
+        let removed = state
+            .skills
+            .remove(&(tenant_id.to_string(), skill_id.to_string()))
+            .is_some();
+        if !removed {
+            return Ok(false);
+        }
+
+        if let Some(versions) = state.skill_versions_by_skill.remove(skill_id) {
+            for version in versions {
+                state
+                    .skill_versions
+                    .remove(&(skill_id.to_string(), version));
+            }
+        }
+
+        Ok(true)
+    }
+
+    async fn put_skill_version(&self, record: SkillVersionRecord) -> SkillsStoreResult<()> {
+        let key = (record.skill_id.clone(), record.version.clone());
+        let mut state = self.state.write();
+        state
+            .skill_versions_by_skill
+            .entry(record.skill_id.clone())
+            .or_default()
+            .insert(record.version.clone());
+        state.skill_versions.insert(key, record);
+        Ok(())
+    }
+
+    async fn get_skill_version(
+        &self,
+        skill_id: &str,
+        version: &str,
+    ) -> SkillsStoreResult<Option<SkillVersionRecord>> {
+        Ok(self
+            .state
+            .read()
+            .skill_versions
+            .get(&(skill_id.to_string(), version.to_string()))
+            .cloned())
+    }
+
+    async fn list_skill_versions(
+        &self,
+        skill_id: &str,
+    ) -> SkillsStoreResult<Vec<SkillVersionRecord>> {
+        let mut versions = self
+            .state
+            .read()
+            .skill_versions
+            .values()
+            .filter(|record| record.skill_id == skill_id)
+            .cloned()
+            .collect::<Vec<_>>();
+        versions.sort_by(|left, right| {
+            left.version_number
+                .cmp(&right.version_number)
+                .then(left.version.cmp(&right.version))
+        });
+        Ok(versions)
+    }
+
+    async fn delete_skill_version(&self, skill_id: &str, version: &str) -> SkillsStoreResult<bool> {
+        let mut state = self.state.write();
+        let removed = state
+            .skill_versions
+            .remove(&(skill_id.to_string(), version.to_string()))
+            .is_some();
+        if !removed {
+            return Ok(false);
+        }
+
+        if let Some(versions) = state.skill_versions_by_skill.get_mut(skill_id) {
+            versions.remove(version);
+            if versions.is_empty() {
+                state.skill_versions_by_skill.remove(skill_id);
+            }
+        }
+
+        Ok(true)
+    }
+}
+
+#[async_trait]
+impl TenantAliasStore for InMemorySkillStore {
+    async fn put_tenant_alias(&self, record: TenantAliasRecord) -> SkillsStoreResult<()> {
+        self.state
+            .write()
+            .tenant_aliases
+            .insert(record.alias_tenant_id.clone(), record);
+        Ok(())
+    }
+
+    async fn get_tenant_alias(
+        &self,
+        alias_tenant_id: &str,
+    ) -> SkillsStoreResult<Option<TenantAliasRecord>> {
+        Ok(self
+            .state
+            .read()
+            .tenant_aliases
+            .get(alias_tenant_id)
+            .cloned())
+    }
+
+    async fn delete_tenant_alias(&self, alias_tenant_id: &str) -> SkillsStoreResult<bool> {
+        Ok(self
+            .state
+            .write()
+            .tenant_aliases
+            .remove(alias_tenant_id)
+            .is_some())
+    }
+}
+
+#[async_trait]
+impl BundleTokenStore for InMemorySkillStore {
+    async fn put_bundle_token(&self, claim: BundleTokenClaim) -> SkillsStoreResult<()> {
+        let mut state = self.state.write();
+        state
+            .bundle_tokens_by_exec
+            .entry(claim.exec_id.clone())
+            .or_default()
+            .insert(claim.token_hash.clone());
+        state.bundle_tokens.insert(claim.token_hash.clone(), claim);
+        Ok(())
+    }
+
+    async fn get_bundle_token(
+        &self,
+        token_hash: &str,
+    ) -> SkillsStoreResult<Option<BundleTokenClaim>> {
+        Ok(self.state.read().bundle_tokens.get(token_hash).cloned())
+    }
+
+    async fn revoke_bundle_token(&self, token_hash: &str) -> SkillsStoreResult<bool> {
+        let mut state = self.state.write();
+        let Some(claim) = state.bundle_tokens.remove(token_hash) else {
+            return Ok(false);
+        };
+        if let Some(tokens) = state.bundle_tokens_by_exec.get_mut(&claim.exec_id) {
+            tokens.remove(token_hash);
+            if tokens.is_empty() {
+                state.bundle_tokens_by_exec.remove(&claim.exec_id);
+            }
+        }
+        Ok(true)
+    }
+
+    async fn revoke_bundle_tokens_for_exec(&self, exec_id: &str) -> SkillsStoreResult<usize> {
+        let mut state = self.state.write();
+        let Some(tokens) = state.bundle_tokens_by_exec.remove(exec_id) else {
+            return Ok(0);
+        };
+        let removed = tokens.len();
+        for token_hash in tokens {
+            state.bundle_tokens.remove(&token_hash);
+        }
+        Ok(removed)
+    }
+}
+
+#[async_trait]
+impl ContinuationCookieStore for InMemorySkillStore {
+    async fn put_continuation_cookie(
+        &self,
+        claim: ContinuationCookieClaim,
+    ) -> SkillsStoreResult<()> {
+        let mut state = self.state.write();
+        state
+            .continuation_cookies_by_exec
+            .entry(claim.exec_id.clone())
+            .or_default()
+            .insert(claim.cookie_hash.clone());
+        state
+            .continuation_cookies
+            .insert(claim.cookie_hash.clone(), claim);
+        Ok(())
+    }
+
+    async fn get_continuation_cookie(
+        &self,
+        cookie_hash: &str,
+    ) -> SkillsStoreResult<Option<ContinuationCookieClaim>> {
+        Ok(self
+            .state
+            .read()
+            .continuation_cookies
+            .get(cookie_hash)
+            .cloned())
+    }
+
+    async fn revoke_continuation_cookie(&self, cookie_hash: &str) -> SkillsStoreResult<bool> {
+        let mut state = self.state.write();
+        let Some(claim) = state.continuation_cookies.remove(cookie_hash) else {
+            return Ok(false);
+        };
+        if let Some(cookies) = state.continuation_cookies_by_exec.get_mut(&claim.exec_id) {
+            cookies.remove(cookie_hash);
+            if cookies.is_empty() {
+                state.continuation_cookies_by_exec.remove(&claim.exec_id);
+            }
+        }
+        Ok(true)
+    }
+
+    async fn revoke_continuation_cookies_for_exec(
+        &self,
+        exec_id: &str,
+    ) -> SkillsStoreResult<usize> {
+        let mut state = self.state.write();
+        let Some(cookies) = state.continuation_cookies_by_exec.remove(exec_id) else {
+            return Ok(0);
+        };
+        let removed = cookies.len();
+        for cookie_hash in cookies {
+            state.continuation_cookies.remove(&cookie_hash);
+        }
+        Ok(removed)
+    }
+}

--- a/crates/skills/src/memory.rs
+++ b/crates/skills/src/memory.rs
@@ -1,4 +1,7 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    ops::Bound::Included,
+};
 
 use async_trait::async_trait;
 use parking_lot::RwLock;
@@ -55,13 +58,14 @@ impl SkillMetadataStore for InMemorySkillStore {
     }
 
     async fn list_skills(&self, tenant_id: &str) -> SkillsStoreResult<Vec<SkillRecord>> {
+        let start = (tenant_id.to_string(), String::new());
+        let end = (tenant_id.to_string(), max_sort_key());
         let mut skills = self
             .state
             .read()
             .skills
-            .values()
-            .filter(|record| record.tenant_id == tenant_id)
-            .cloned()
+            .range((Included(start), Included(end)))
+            .map(|(_, record)| record.clone())
             .collect::<Vec<_>>();
         skills.sort_by(|left, right| {
             left.name
@@ -121,13 +125,14 @@ impl SkillMetadataStore for InMemorySkillStore {
         &self,
         skill_id: &str,
     ) -> SkillsStoreResult<Vec<SkillVersionRecord>> {
+        let start = (skill_id.to_string(), String::new());
+        let end = (skill_id.to_string(), max_sort_key());
         let mut versions = self
             .state
             .read()
             .skill_versions
-            .values()
-            .filter(|record| record.skill_id == skill_id)
-            .cloned()
+            .range((Included(start), Included(end)))
+            .map(|(_, record)| record.clone())
             .collect::<Vec<_>>();
         versions.sort_by(|left, right| {
             left.version_number
@@ -156,6 +161,10 @@ impl SkillMetadataStore for InMemorySkillStore {
 
         Ok(true)
     }
+}
+
+fn max_sort_key() -> String {
+    char::MAX.to_string()
 }
 
 #[async_trait]

--- a/crates/skills/tests/in_memory_runtime.rs
+++ b/crates/skills/tests/in_memory_runtime.rs
@@ -1,0 +1,202 @@
+use std::io::Cursor;
+
+use anyhow::{anyhow, Result};
+use chrono::Utc;
+use smg_blob_storage::{
+    create_blob_store, BlobCacheConfig, BlobKey, BlobStoreBackend, BlobStoreConfig,
+    GetBlobResponse, PutBlobRequest,
+};
+use smg_skills::{
+    BundleTokenClaim, ContinuationCookieClaim, NormalizedSkillBundle, NormalizedSkillFile,
+    SkillRecord, SkillService, SkillVersionRecord, TenantAliasRecord,
+};
+use tempfile::TempDir;
+use tokio::io::AsyncReadExt;
+
+fn put_request(bytes: &[u8]) -> PutBlobRequest {
+    PutBlobRequest {
+        reader: Box::pin(Cursor::new(bytes.to_vec())),
+        content_length: bytes.len() as u64,
+        content_type: None,
+    }
+}
+
+async fn read_all(response: GetBlobResponse) -> Result<Vec<u8>> {
+    let mut reader = response.reader;
+    let mut buffer = Vec::new();
+    reader.read_to_end(&mut buffer).await?;
+    Ok(buffer)
+}
+
+#[tokio::test]
+async fn in_memory_service_supports_metadata_tokens_and_filesystem_blob_reads() -> Result<()> {
+    let blob_root = TempDir::new()?;
+    let cache_root = TempDir::new()?;
+    let blob_store = create_blob_store(
+        &BlobStoreConfig {
+            backend: BlobStoreBackend::Filesystem,
+            path: blob_root.path().display().to_string(),
+            ..BlobStoreConfig::default()
+        },
+        Some(&BlobCacheConfig {
+            path: cache_root.path().display().to_string(),
+            max_size_mb: 16,
+        }),
+    )?;
+    let service = SkillService::in_memory(blob_store);
+    let now = Utc::now();
+
+    let metadata_store = service
+        .metadata_store()
+        .ok_or_else(|| anyhow!("metadata store missing"))?;
+    metadata_store
+        .put_skill(SkillRecord {
+            tenant_id: "tenant-a".to_string(),
+            skill_id: "skill-1".to_string(),
+            name: "map".to_string(),
+            short_description: Some("Map the codebase".to_string()),
+            description: Some("Reads and maps the codebase".to_string()),
+            source: "custom".to_string(),
+            has_code_files: true,
+            latest_version: Some("20260420".to_string()),
+            default_version: Some("20260420".to_string()),
+            created_at: now,
+            updated_at: now,
+        })
+        .await?;
+    metadata_store
+        .put_skill_version(SkillVersionRecord {
+            skill_id: "skill-1".to_string(),
+            version: "20260420".to_string(),
+            version_number: 20260420,
+            name: "map".to_string(),
+            short_description: Some("Map the codebase".to_string()),
+            description: "Reads and maps the codebase".to_string(),
+            interface: None,
+            dependencies: None,
+            policy: None,
+            deprecated: false,
+            file_manifest: Vec::new(),
+            instruction_token_counts: Default::default(),
+            created_at: now,
+        })
+        .await?;
+
+    let listed = metadata_store.list_skills("tenant-a").await?;
+    assert_eq!(listed.len(), 1);
+    let version = metadata_store
+        .get_skill_version("skill-1", "20260420")
+        .await?
+        .ok_or_else(|| anyhow!("skill version missing"))?;
+    assert_eq!(version.version_number, 20260420);
+
+    let alias_store = service
+        .tenant_alias_store()
+        .ok_or_else(|| anyhow!("alias store missing"))?;
+    alias_store
+        .put_tenant_alias(TenantAliasRecord {
+            alias_tenant_id: "tenant-alias".to_string(),
+            canonical_tenant_id: "tenant-a".to_string(),
+            created_at: now,
+            expires_at: None,
+        })
+        .await?;
+    assert_eq!(
+        alias_store
+            .get_tenant_alias("tenant-alias")
+            .await?
+            .ok_or_else(|| anyhow!("tenant alias missing"))?
+            .canonical_tenant_id,
+        "tenant-a"
+    );
+
+    let bundle_token_store = service
+        .bundle_token_store()
+        .ok_or_else(|| anyhow!("bundle token store missing"))?;
+    bundle_token_store
+        .put_bundle_token(BundleTokenClaim {
+            token_hash: "tokhash".to_string(),
+            tenant_id: "tenant-a".to_string(),
+            exec_id: "exec-1".to_string(),
+            skill_id: "skill-1".to_string(),
+            skill_version: "20260420".to_string(),
+            created_at: now,
+            expires_at: now,
+        })
+        .await?;
+    assert!(bundle_token_store
+        .get_bundle_token("tokhash")
+        .await?
+        .is_some());
+    assert_eq!(
+        bundle_token_store
+            .revoke_bundle_tokens_for_exec("exec-1")
+            .await?,
+        1
+    );
+
+    let continuation_cookie_store = service
+        .continuation_cookie_store()
+        .ok_or_else(|| anyhow!("continuation cookie store missing"))?;
+    continuation_cookie_store
+        .put_continuation_cookie(ContinuationCookieClaim {
+            cookie_hash: "cookiehash".to_string(),
+            tenant_id: "tenant-a".to_string(),
+            exec_id: "exec-2".to_string(),
+            request_id: "req-1".to_string(),
+            created_at: now,
+            expires_at: now,
+        })
+        .await?;
+    assert_eq!(
+        continuation_cookie_store
+            .revoke_continuation_cookies_for_exec("exec-2")
+            .await?,
+        1
+    );
+
+    let bundle = NormalizedSkillBundle {
+        files: vec![
+            NormalizedSkillFile {
+                relative_path: "SKILL.md".to_string(),
+                contents: b"---\nname: map\ndescription: test\n---\nbody".to_vec(),
+            },
+            NormalizedSkillFile {
+                relative_path: "scripts/run.py".to_string(),
+                contents: b"print('mapped')".to_vec(),
+            },
+        ],
+        skill_md_path: "SKILL.md".to_string(),
+        openai_sidecar_path: None,
+        has_code_files: true,
+    };
+    let mut manifest = bundle.file_manifest();
+    for entry in &mut manifest {
+        entry.blob_key = Some(BlobKey(format!(
+            "skills/tenant-a/skill-1/20260420/{}",
+            entry.relative_path
+        )));
+    }
+
+    let blob_store = service
+        .blob_store()
+        .ok_or_else(|| anyhow!("blob store missing"))?;
+    for (file, entry) in bundle.files.iter().zip(&manifest) {
+        let blob_key = entry
+            .blob_key
+            .as_ref()
+            .ok_or_else(|| anyhow!("blob key missing from manifest"))?;
+        blob_store
+            .put_stream(blob_key, put_request(&file.contents))
+            .await?;
+    }
+
+    let script_key = manifest[1]
+        .blob_key
+        .as_ref()
+        .ok_or_else(|| anyhow!("script blob key missing"))?;
+    let script_bytes = read_all(blob_store.get(script_key).await?).await?;
+    assert_eq!(script_bytes, b"print('mapped')");
+
+    Ok(())
+}

--- a/crates/skills/tests/in_memory_runtime.rs
+++ b/crates/skills/tests/in_memory_runtime.rs
@@ -1,32 +1,18 @@
-use std::io::Cursor;
-
 use anyhow::{anyhow, Result};
 use chrono::Utc;
 use smg_blob_storage::{
     create_blob_store, BlobCacheConfig, BlobKey, BlobStoreBackend, BlobStoreConfig,
-    GetBlobResponse, PutBlobRequest,
 };
 use smg_skills::{
     BundleTokenClaim, ContinuationCookieClaim, NormalizedSkillBundle, NormalizedSkillFile,
     SkillRecord, SkillService, SkillVersionRecord, TenantAliasRecord,
 };
 use tempfile::TempDir;
-use tokio::io::AsyncReadExt;
 
-fn put_request(bytes: &[u8]) -> PutBlobRequest {
-    PutBlobRequest {
-        reader: Box::pin(Cursor::new(bytes.to_vec())),
-        content_length: bytes.len() as u64,
-        content_type: None,
-    }
-}
+#[path = "../../../test_support/blob_test_utils.rs"]
+mod blob_test_utils;
 
-async fn read_all(response: GetBlobResponse) -> Result<Vec<u8>> {
-    let mut reader = response.reader;
-    let mut buffer = Vec::new();
-    reader.read_to_end(&mut buffer).await?;
-    Ok(buffer)
-}
+use blob_test_utils::{put_request, read_all};
 
 #[tokio::test]
 async fn in_memory_service_supports_metadata_tokens_and_filesystem_blob_reads() -> Result<()> {
@@ -294,6 +280,190 @@ async fn in_memory_service_scopes_listings_to_exact_tenant_and_skill() -> Result
     let skill_1_versions = metadata_store.list_skill_versions("skill-1").await?;
     assert_eq!(skill_1_versions.len(), 1);
     assert_eq!(skill_1_versions[0].skill_id, "skill-1");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn in_memory_service_only_deletes_versions_when_last_tenant_mapping_is_removed() -> Result<()>
+{
+    let blob_root = TempDir::new()?;
+    let blob_store = create_blob_store(
+        &BlobStoreConfig {
+            backend: BlobStoreBackend::Filesystem,
+            path: blob_root.path().display().to_string(),
+            ..BlobStoreConfig::default()
+        },
+        None,
+    )?;
+    let service = SkillService::in_memory(blob_store);
+    let now = Utc::now();
+    let metadata_store = service
+        .metadata_store()
+        .ok_or_else(|| anyhow!("metadata store missing"))?;
+
+    for tenant_id in ["tenant-a", "tenant-b"] {
+        metadata_store
+            .put_skill(SkillRecord {
+                tenant_id: tenant_id.to_string(),
+                skill_id: "shared-skill".to_string(),
+                name: "map".to_string(),
+                short_description: None,
+                description: None,
+                source: "custom".to_string(),
+                has_code_files: false,
+                latest_version: Some("1".to_string()),
+                default_version: Some("1".to_string()),
+                created_at: now,
+                updated_at: now,
+            })
+            .await?;
+    }
+    metadata_store
+        .put_skill_version(SkillVersionRecord {
+            skill_id: "shared-skill".to_string(),
+            version: "1".to_string(),
+            version_number: 1,
+            name: "map".to_string(),
+            short_description: None,
+            description: "map".to_string(),
+            interface: None,
+            dependencies: None,
+            policy: None,
+            deprecated: false,
+            file_manifest: Vec::new(),
+            instruction_token_counts: Default::default(),
+            created_at: now,
+        })
+        .await?;
+
+    assert!(
+        metadata_store
+            .delete_skill("tenant-a", "shared-skill")
+            .await?
+    );
+    assert!(metadata_store
+        .get_skill_version("shared-skill", "1")
+        .await?
+        .is_some());
+
+    assert!(
+        metadata_store
+            .delete_skill("tenant-b", "shared-skill")
+            .await?
+    );
+    assert!(metadata_store
+        .get_skill_version("shared-skill", "1")
+        .await?
+        .is_none());
+    Ok(())
+}
+
+#[tokio::test]
+async fn in_memory_service_reindexes_reused_bundle_and_cookie_hashes() -> Result<()> {
+    let blob_root = TempDir::new()?;
+    let blob_store = create_blob_store(
+        &BlobStoreConfig {
+            backend: BlobStoreBackend::Filesystem,
+            path: blob_root.path().display().to_string(),
+            ..BlobStoreConfig::default()
+        },
+        None,
+    )?;
+    let service = SkillService::in_memory(blob_store);
+    let now = Utc::now();
+
+    let bundle_token_store = service
+        .bundle_token_store()
+        .ok_or_else(|| anyhow!("bundle token store missing"))?;
+    bundle_token_store
+        .put_bundle_token(BundleTokenClaim {
+            token_hash: "tokhash".to_string(),
+            tenant_id: "tenant-a".to_string(),
+            exec_id: "exec-1".to_string(),
+            skill_id: "skill-1".to_string(),
+            skill_version: "1".to_string(),
+            created_at: now,
+            expires_at: now,
+        })
+        .await?;
+    bundle_token_store
+        .put_bundle_token(BundleTokenClaim {
+            token_hash: "tokhash".to_string(),
+            tenant_id: "tenant-a".to_string(),
+            exec_id: "exec-2".to_string(),
+            skill_id: "skill-1".to_string(),
+            skill_version: "1".to_string(),
+            created_at: now,
+            expires_at: now,
+        })
+        .await?;
+
+    assert_eq!(
+        bundle_token_store
+            .revoke_bundle_tokens_for_exec("exec-1")
+            .await?,
+        0
+    );
+    assert_eq!(
+        bundle_token_store
+            .get_bundle_token("tokhash")
+            .await?
+            .ok_or_else(|| anyhow!("bundle token missing"))?
+            .exec_id,
+        "exec-2"
+    );
+    assert_eq!(
+        bundle_token_store
+            .revoke_bundle_tokens_for_exec("exec-2")
+            .await?,
+        1
+    );
+
+    let continuation_cookie_store = service
+        .continuation_cookie_store()
+        .ok_or_else(|| anyhow!("continuation cookie store missing"))?;
+    continuation_cookie_store
+        .put_continuation_cookie(ContinuationCookieClaim {
+            cookie_hash: "cookiehash".to_string(),
+            tenant_id: "tenant-a".to_string(),
+            exec_id: "exec-3".to_string(),
+            request_id: "req-1".to_string(),
+            created_at: now,
+            expires_at: now,
+        })
+        .await?;
+    continuation_cookie_store
+        .put_continuation_cookie(ContinuationCookieClaim {
+            cookie_hash: "cookiehash".to_string(),
+            tenant_id: "tenant-a".to_string(),
+            exec_id: "exec-4".to_string(),
+            request_id: "req-1".to_string(),
+            created_at: now,
+            expires_at: now,
+        })
+        .await?;
+
+    assert_eq!(
+        continuation_cookie_store
+            .revoke_continuation_cookies_for_exec("exec-3")
+            .await?,
+        0
+    );
+    assert_eq!(
+        continuation_cookie_store
+            .get_continuation_cookie("cookiehash")
+            .await?
+            .ok_or_else(|| anyhow!("continuation cookie missing"))?
+            .exec_id,
+        "exec-4"
+    );
+    assert_eq!(
+        continuation_cookie_store
+            .revoke_continuation_cookies_for_exec("exec-4")
+            .await?,
+        1
+    );
 
     Ok(())
 }

--- a/crates/skills/tests/in_memory_runtime.rs
+++ b/crates/skills/tests/in_memory_runtime.rs
@@ -200,3 +200,100 @@ async fn in_memory_service_supports_metadata_tokens_and_filesystem_blob_reads() 
 
     Ok(())
 }
+
+#[tokio::test]
+async fn in_memory_service_scopes_listings_to_exact_tenant_and_skill() -> Result<()> {
+    let blob_root = TempDir::new()?;
+    let cache_root = TempDir::new()?;
+    let blob_store = create_blob_store(
+        &BlobStoreConfig {
+            backend: BlobStoreBackend::Filesystem,
+            path: blob_root.path().display().to_string(),
+            ..BlobStoreConfig::default()
+        },
+        Some(&BlobCacheConfig {
+            path: cache_root.path().display().to_string(),
+            max_size_mb: 16,
+        }),
+    )?;
+    let service = SkillService::in_memory(blob_store);
+    let now = Utc::now();
+    let metadata_store = service
+        .metadata_store()
+        .ok_or_else(|| anyhow!("metadata store missing"))?;
+
+    metadata_store
+        .put_skill(SkillRecord {
+            tenant_id: "tenant-a".to_string(),
+            skill_id: "skill-1".to_string(),
+            name: "map".to_string(),
+            short_description: None,
+            description: None,
+            source: "custom".to_string(),
+            has_code_files: false,
+            latest_version: Some("1".to_string()),
+            default_version: Some("1".to_string()),
+            created_at: now,
+            updated_at: now,
+        })
+        .await?;
+    metadata_store
+        .put_skill(SkillRecord {
+            tenant_id: "tenant-b".to_string(),
+            skill_id: "skill-2".to_string(),
+            name: "review".to_string(),
+            short_description: None,
+            description: None,
+            source: "custom".to_string(),
+            has_code_files: false,
+            latest_version: Some("1".to_string()),
+            default_version: Some("1".to_string()),
+            created_at: now,
+            updated_at: now,
+        })
+        .await?;
+    metadata_store
+        .put_skill_version(SkillVersionRecord {
+            skill_id: "skill-1".to_string(),
+            version: "1".to_string(),
+            version_number: 1,
+            name: "map".to_string(),
+            short_description: None,
+            description: "map".to_string(),
+            interface: None,
+            dependencies: None,
+            policy: None,
+            deprecated: false,
+            file_manifest: Vec::new(),
+            instruction_token_counts: Default::default(),
+            created_at: now,
+        })
+        .await?;
+    metadata_store
+        .put_skill_version(SkillVersionRecord {
+            skill_id: "skill-10".to_string(),
+            version: "1".to_string(),
+            version_number: 1,
+            name: "map-10".to_string(),
+            short_description: None,
+            description: "map-10".to_string(),
+            interface: None,
+            dependencies: None,
+            policy: None,
+            deprecated: false,
+            file_manifest: Vec::new(),
+            instruction_token_counts: Default::default(),
+            created_at: now,
+        })
+        .await?;
+
+    let tenant_a_skills = metadata_store.list_skills("tenant-a").await?;
+    assert_eq!(tenant_a_skills.len(), 1);
+    assert_eq!(tenant_a_skills[0].skill_id, "skill-1");
+
+    let skill_1_versions = metadata_store.list_skill_versions("skill-1").await?;
+    assert_eq!(skill_1_versions.len(), 1);
+    assert_eq!(skill_1_versions[0].skill_id, "skill-1");
+
+    Ok(())
+}

--- a/model_gateway/Cargo.toml
+++ b/model_gateway/Cargo.toml
@@ -77,6 +77,7 @@ smg-wasm = { workspace = true, features = ["storage-hooks"] }
 smg-mesh.workspace = true
 smg-grpc-client.workspace = true
 smg-skills.workspace = true
+smg-blob-storage.workspace = true
 
 # External dependencies (not in workspace)
 bincode = "1.3"

--- a/model_gateway/src/app_context.rs
+++ b/model_gateway/src/app_context.rs
@@ -6,6 +6,7 @@ use std::{
 use llm_tokenizer::registry::TokenizerRegistry;
 use reasoning_parser::ParserFactory as ReasoningParserFactory;
 use reqwest::Client;
+use smg_blob_storage::create_blob_store;
 use smg_data_connector::{
     create_storage, ConversationItemStorage, ConversationStorage, ResponseStorage,
     StorageFactoryConfig,
@@ -392,7 +393,7 @@ impl AppContextBuilder {
             .with_workflow_engines()
             .with_mcp_orchestrator(&router_config)
             .await?
-            .with_skill_service(&router_config)
+            .with_skill_service(&router_config)?
             .with_wasm_manager(&router_config)
             .with_kv_event_monitor(&router_config)
             .webrtc_bind_addr(webrtc_bind_addr)
@@ -627,10 +628,22 @@ impl AppContextBuilder {
         Ok(self)
     }
 
-    fn with_skill_service(mut self, config: &RouterConfig) -> Self {
-        self.skill_service = (config.skills_enabled && config.skills.is_some())
-            .then(|| Arc::new(SkillService::placeholder()));
-        self
+    fn with_skill_service(mut self, config: &RouterConfig) -> Result<Self, String> {
+        if !config.skills_enabled {
+            self.skill_service = None;
+            return Ok(self);
+        }
+
+        let Some(skills_config) = config.skills.as_ref() else {
+            self.skill_service = None;
+            return Ok(self);
+        };
+
+        let blob_store =
+            create_blob_store(&skills_config.blob_store, Some(&skills_config.cache))
+                .map_err(|error| format!("Failed to initialize skills blob store: {error}"))?;
+        self.skill_service = Some(Arc::new(SkillService::in_memory(blob_store)));
+        Ok(self)
     }
 
     /// Create KV event monitor for event-driven cache-aware routing.
@@ -676,5 +689,37 @@ impl AppContextBuilder {
 impl Default for AppContextBuilder {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::{anyhow, Result};
+    use smg_skills::{SkillServiceMode, SkillsConfig};
+    use tempfile::TempDir;
+
+    use super::AppContextBuilder;
+    use crate::config::RouterConfig;
+
+    #[test]
+    fn with_skill_service_builds_single_process_service_when_enabled() -> Result<()> {
+        let blob_root = TempDir::new()?;
+        let cache_root = TempDir::new()?;
+        let mut config = RouterConfig::default();
+        config.skills_enabled = true;
+        let mut skills = SkillsConfig::default();
+        skills.blob_store.path = blob_root.path().display().to_string();
+        skills.cache.path = cache_root.path().display().to_string();
+        config.skills = Some(skills);
+
+        let builder = AppContextBuilder::new()
+            .with_skill_service(&config)
+            .map_err(anyhow::Error::msg)?;
+        let service = builder
+            .skill_service
+            .ok_or_else(|| anyhow!("skill service should be built"))?;
+
+        assert_eq!(service.mode(), SkillServiceMode::SingleProcess);
+        Ok(())
     }
 }

--- a/model_gateway/src/app_context.rs
+++ b/model_gateway/src/app_context.rs
@@ -705,8 +705,10 @@ mod tests {
     fn with_skill_service_builds_single_process_service_when_enabled() -> Result<()> {
         let blob_root = TempDir::new()?;
         let cache_root = TempDir::new()?;
-        let mut config = RouterConfig::default();
-        config.skills_enabled = true;
+        let mut config = RouterConfig {
+            skills_enabled: true,
+            ..RouterConfig::default()
+        };
         let mut skills = SkillsConfig::default();
         skills.blob_store.path = blob_root.path().display().to_string();
         skills.cache.path = cache_root.path().display().to_string();

--- a/test_support/blob_test_utils.rs
+++ b/test_support/blob_test_utils.rs
@@ -1,0 +1,20 @@
+use std::io::Cursor;
+
+use anyhow::Result;
+use smg_blob_storage::{GetBlobResponse, PutBlobRequest};
+use tokio::io::AsyncReadExt;
+
+pub fn put_request(bytes: &[u8]) -> PutBlobRequest {
+    PutBlobRequest {
+        reader: Box::pin(Cursor::new(bytes.to_vec())),
+        content_length: bytes.len() as u64,
+        content_type: None,
+    }
+}
+
+pub async fn read_all(response: GetBlobResponse) -> Result<Vec<u8>> {
+    let mut reader = response.reader;
+    let mut buffer = Vec::new();
+    reader.read_to_end(&mut buffer).await?;
+    Ok(buffer)
+}


### PR DESCRIPTION
## Description

### Problem

`SKL-PR-07` needs a working single-process implementation path for local development and early end-to-end testing.

### Solution

Add an in-memory skills persistence implementation, a filesystem-backed blob store, a local read cache layered in front of blob reads, and gateway wiring that builds the single-process skills service from config.

Tracks the skills work under #1176.

## Changes

- add `FilesystemBlobStore`, `CachedBlobStore`, and blob-store factory wiring in `smg-blob-storage`
- add `BlobCacheConfig` and re-export it through the skills config surface
- add `InMemorySkillStore` implementing metadata, tenant-alias, bundle-token, and continuation-cookie traits
- extend `SkillService` with a concrete `SingleProcess` mode backed by generic trait objects plus blob storage
- wire `AppContext` to build the single-process skills service when skills are enabled and configured
- add integration tests for filesystem blob operations, cache hits, and in-memory runtime behavior

## Test Plan

- `cargo +nightly fmt --all`
- `env -u RUSTC_WRAPPER CARGO_BUILD_RUSTC_WRAPPER= cargo test -p smg-blob-storage -p smg-skills --target-dir /tmp/smg-sk7e-target`
- full workspace `cargo clippy --all-targets --all-features -- -D warnings` is still running locally
- full workspace `cargo test` is still running locally

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Local on-disk read-cache for blob storage to speed repeated reads
  * Filesystem-backed blob storage with configurable cache (path and max size; cache disabled by default)
  * Single-process in-memory skills service with convenience constructors and accessors
  * Service initialization now fails fast if blob store initialization fails

* **Tests**
  * Extensive end-to-end tests for blob storage, cache behavior, filesystem backend, in-memory skill runtime, and new test utilities
<!-- end of auto-generated comment: release notes by coderabbit.ai -->