### PR TITLE
fix(mesh): retain broadcast stream rounds until observed

### DIFF
--- a/crates/mesh/src/controller.rs
+++ b/crates/mesh/src/controller.rs
@@ -716,7 +716,45 @@ impl MeshController {
                                 next_broadcast_round_id = gap.resume_from_broadcast_round_id;
                             }
 
+                            let mut stream_backpressured = false;
                             for round in broadcast_poll.rounds {
+                                loop {
+                                    let targeted_round = match pending_targeted_round.take() {
+                                        Some(round) => round,
+                                        None => match targeted_subscription.receiver.try_recv() {
+                                            Ok(round) => round,
+                                            Err(mpsc::error::TryRecvError::Empty) => break,
+                                            Err(mpsc::error::TryRecvError::Disconnected) => break,
+                                        },
+                                    };
+
+                                    if targeted_round.dispatch_round_id >= round.dispatch_round_id {
+                                        pending_targeted_round = Some(targeted_round);
+                                        break;
+                                    }
+
+                                    match try_send_stream_round(
+                                        &tx_incremental,
+                                        &self_name_incremental,
+                                        &peer_name_incremental,
+                                        &shared_sequence,
+                                        targeted_round.entries.as_slice(),
+                                        "targeted",
+                                        targeted_round.dispatch_round_id,
+                                    ) {
+                                        StreamRoundSendOutcome::Sent => {}
+                                        StreamRoundSendOutcome::DroppedOnBackpressure => {
+                                            pending_targeted_round = Some(targeted_round);
+                                            stream_backpressured = true;
+                                            break;
+                                        }
+                                        StreamRoundSendOutcome::Closed => return,
+                                    }
+                                }
+                                if stream_backpressured {
+                                    break;
+                                }
+
                                 match try_send_stream_round(
                                     &tx_incremental,
                                     &self_name_incremental,
@@ -729,9 +767,47 @@ impl MeshController {
                                     StreamRoundSendOutcome::Sent => {
                                         next_broadcast_round_id = round.broadcast_round_id + 1;
                                     }
-                                    StreamRoundSendOutcome::DroppedOnBackpressure => break,
+                                    StreamRoundSendOutcome::DroppedOnBackpressure => {
+                                        stream_backpressured = true;
+                                        break;
+                                    }
                                     StreamRoundSendOutcome::Closed => return,
                                 }
+
+                                let targeted_round = match pending_targeted_round.take() {
+                                    Some(targeted_round)
+                                        if targeted_round.dispatch_round_id == round.dispatch_round_id =>
+                                    {
+                                        targeted_round
+                                    }
+                                    Some(targeted_round) => {
+                                        pending_targeted_round = Some(targeted_round);
+                                        continue;
+                                    }
+                                    None => continue,
+                                };
+
+                                match try_send_stream_round(
+                                    &tx_incremental,
+                                    &self_name_incremental,
+                                    &peer_name_incremental,
+                                    &shared_sequence,
+                                    targeted_round.entries.as_slice(),
+                                    "targeted",
+                                    targeted_round.dispatch_round_id,
+                                ) {
+                                    StreamRoundSendOutcome::Sent => {}
+                                    StreamRoundSendOutcome::DroppedOnBackpressure => {
+                                        pending_targeted_round = Some(targeted_round);
+                                        stream_backpressured = true;
+                                        break;
+                                    }
+                                    StreamRoundSendOutcome::Closed => return,
+                                }
+                            }
+
+                            if stream_backpressured {
+                                continue;
                             }
 
                             loop {

--- a/crates/mesh/src/controller.rs
+++ b/crates/mesh/src/controller.rs
@@ -31,15 +31,60 @@ use super::{
     sync::MeshSyncManager,
 };
 use crate::{
-    chunking::{
-        build_stream_batches, chunk_value, dispatch_stream_batch, next_generation,
-        DEFAULT_MAX_CHUNKS_PER_BATCH, MAX_STREAM_CHUNK_BYTES,
-    },
+    chunking::dispatch_stream_batch,
     collector::{CentralCollector, PeerWatermark, RoundBatch},
     flow_control::{MessageSizeValidator, MAX_MESSAGE_SIZE},
     metrics,
     service::gossip::IncrementalUpdate,
+    stream_dispatch::{encode_stream_batches, StreamDispatch, TargetedPeerSubscription},
 };
+
+enum StreamRoundSendOutcome {
+    Sent,
+    DroppedOnBackpressure,
+    Closed,
+}
+
+fn try_send_stream_round(
+    tx: &mpsc::Sender<StreamMessage>,
+    self_name: &str,
+    peer_name: &str,
+    sequence: &Arc<AtomicU64>,
+    entries: &[(String, Bytes)],
+    round_kind: &str,
+    round_id: u64,
+) -> StreamRoundSendOutcome {
+    for batch in encode_stream_batches(entries) {
+        let msg = StreamMessage {
+            message_type: StreamMessageType::StreamBatch as i32,
+            payload: Some(StreamPayload::StreamBatch(batch)),
+            sequence: sequence.fetch_add(1, Ordering::Relaxed),
+            peer_id: self_name.to_string(),
+        };
+        match tx.try_send(msg) {
+            Ok(()) => {}
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                log::debug!(
+                    peer = %peer_name,
+                    round_kind,
+                    round_id,
+                    "stream round dropped on backpressure"
+                );
+                return StreamRoundSendOutcome::DroppedOnBackpressure;
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                log::warn!(
+                    peer = %peer_name,
+                    round_kind,
+                    round_id,
+                    "stream sender: channel closed, stopping"
+                );
+                return StreamRoundSendOutcome::Closed;
+            }
+        }
+    }
+    StreamRoundSendOutcome::Sent
+}
 
 pub struct MeshController {
     state: ClusterState,
@@ -56,10 +101,10 @@ pub struct MeshController {
     /// Current round batch, updated once per round by the central collector.
     /// Per-peer senders read and apply their own watermark filtering.
     current_batch: Arc<parking_lot::RwLock<Arc<RoundBatch>>>,
-    /// Current stream round batch, drained once per round from MeshKV.
-    /// Per-peer senders read this and filter targeted entries to their
-    /// own peer; drain_entries are broadcast to every peer.
-    current_stream_batch: Arc<parking_lot::RwLock<Arc<crate::kv::RoundBatch>>>,
+    /// Shared transport state for drained stream rounds. Broadcast traffic
+    /// is retained in a small ring; targeted traffic is routed into
+    /// per-peer bounded queues.
+    stream_dispatch: Arc<StreamDispatch>,
     /// Node-wide MeshKV handle. Owns the stream buffers, subscriber
     /// registry, and chunk assembler shared with the server-side
     /// SyncStream handlers.
@@ -90,9 +135,7 @@ impl MeshController {
             sync_connections: Arc::new(Mutex::new(HashMap::new())),
             central_collector,
             current_batch: Arc::new(parking_lot::RwLock::new(Arc::new(RoundBatch::default()))),
-            current_stream_batch: Arc::new(parking_lot::RwLock::new(Arc::new(
-                crate::kv::RoundBatch::default(),
-            ))),
+            stream_dispatch: Arc::new(StreamDispatch::default()),
             mesh_kv: None,
         }
     }
@@ -112,11 +155,11 @@ impl MeshController {
         self.current_batch.clone()
     }
 
-    /// Get a handle to the shared stream RoundBatch. Used by GossipService
-    /// so server-side sync_stream handlers see the same drained stream
-    /// entries as client-side handlers.
-    pub fn current_stream_batch(&self) -> Arc<parking_lot::RwLock<Arc<crate::kv::RoundBatch>>> {
-        self.current_stream_batch.clone()
+    /// Get a handle to the shared stream dispatch state. Used by
+    /// GossipService so inbound and outbound SyncStream handlers consume
+    /// the same retained broadcast rounds and per-peer targeted queues.
+    pub fn stream_dispatch(&self) -> Arc<StreamDispatch> {
+        self.stream_dispatch.clone()
     }
 
     #[instrument(fields(name = %self.self_name), skip(self, signal))]
@@ -268,13 +311,13 @@ impl MeshController {
             }
 
             // Stream round collection: drain stream namespace buffers and
-            // drain callbacks exactly once per round (destructive). Per-peer
-            // senders filter targeted_entries by their own peer_id and
-            // broadcast drain_entries to all peers. Empty batch if no
+            // drain callbacks exactly once per round (destructive). The
+            // shared dispatch state retains a bounded broadcast ring and
+            // pushes targeted traffic into per-peer bounded queues. Empty if no
             // MeshKV is attached (legacy path pre-Step 3).
             if let Some(mesh_kv) = &self.mesh_kv {
                 let stream_batch = mesh_kv.collect_round_batch();
-                *self.current_stream_batch.write() = Arc::new(stream_batch);
+                self.stream_dispatch.publish_round(stream_batch);
             }
 
             tokio::select! {
@@ -495,7 +538,7 @@ impl MeshController {
         let sync_manager = self.sync_manager.clone();
         let sync_connections = self.sync_connections.clone();
         let current_batch = self.current_batch.clone();
-        let current_stream_batch = self.current_stream_batch.clone();
+        let stream_dispatch = self.stream_dispatch.clone();
         let mesh_kv = self.mesh_kv.clone();
 
         // Log connection lifecycle: spawn
@@ -551,14 +594,15 @@ impl MeshController {
                     let shared_sequence = sequence.clone();
                     let size_validator = MessageSizeValidator::default();
                     let batch_handle = current_batch.clone();
-                    let stream_batch_handle = current_stream_batch.clone();
+                    let stream_dispatch_handle = stream_dispatch.clone();
 
                     #[expect(clippy::disallowed_methods, reason = "incremental sender handle is stored and aborted when the parent sync_stream handler exits")]
                     tokio::spawn(async move {
                         let mut interval = tokio::time::interval(Duration::from_secs(1));
-                        // Skip re-emission of an unchanged stream batch (main
-                        // loop hasn't collected a new one since last tick).
-                        let mut last_stream_batch: Option<Arc<crate::kv::RoundBatch>> = None;
+                        let mut next_broadcast_round_id =
+                            stream_dispatch_handle.initial_broadcast_round_id();
+                        let mut targeted_subscription: TargetedPeerSubscription =
+                            stream_dispatch_handle.subscribe_targeted(&peer_name_incremental);
 
                         loop {
                             interval.tick().await;
@@ -652,74 +696,55 @@ impl MeshController {
                                 }
                             }
 
-                            // Stream batches: drain-portion (broadcast) +
-                            // targeted entries addressed to this peer. Each
-                            // entry is chunked if oversized. On channel
-                            // full, the round's stream traffic for this
-                            // peer is dropped — no retry (at-most-once).
-                            // Application regenerates on its own retry cycle.
-                            let stream_batch = stream_batch_handle.read().clone();
-                            let fresh_batch = last_stream_batch
-                                .as_ref()
-                                .is_none_or(|last| !Arc::ptr_eq(last, &stream_batch));
-                            if fresh_batch {
-                                last_stream_batch = Some(stream_batch.clone());
-                                let mut entries = Vec::new();
-                                // Drain entries are broadcast: every peer emits.
-                                // Generation is per-value so concurrent publishes
-                                // to the same key get distinct tags.
-                                for (key, value) in &stream_batch.drain_entries {
-                                    entries.extend(chunk_value(
-                                        key.clone(),
-                                        next_generation(),
-                                        Bytes::from(value.clone()),
-                                        MAX_STREAM_CHUNK_BYTES,
-                                    ));
-                                }
-                                // Targeted entries: only those addressed to this peer.
-                                for (target, key, value) in &stream_batch.targeted_entries {
-                                    if target == &peer_name_incremental {
-                                        entries.extend(chunk_value(
-                                            key.clone(),
-                                            next_generation(),
-                                            value.clone(),
-                                            MAX_STREAM_CHUNK_BYTES,
-                                        ));
+                            let broadcast_poll =
+                                stream_dispatch_handle.poll_broadcast_rounds(next_broadcast_round_id);
+                            if let Some(gap) = broadcast_poll.gap {
+                                log::warn!(
+                                    peer = %peer_name_incremental,
+                                    missing_rounds = gap.missing_rounds,
+                                    resume_from = gap.resume_from_broadcast_round_id,
+                                    "broadcast stream rounds dropped before observation"
+                                );
+                                next_broadcast_round_id = gap.resume_from_broadcast_round_id;
+                            }
+
+                            for round in broadcast_poll.rounds {
+                                match try_send_stream_round(
+                                    &tx_incremental,
+                                    &self_name_incremental,
+                                    &peer_name_incremental,
+                                    &shared_sequence,
+                                    round.entries.as_slice(),
+                                    "broadcast",
+                                    round.broadcast_round_id,
+                                ) {
+                                    StreamRoundSendOutcome::Sent
+                                    | StreamRoundSendOutcome::DroppedOnBackpressure => {
+                                        next_broadcast_round_id = round.broadcast_round_id + 1;
                                     }
+                                    StreamRoundSendOutcome::Closed => return,
                                 }
-                                if !entries.is_empty() {
-                                    for batch in build_stream_batches(
-                                        entries,
-                                        DEFAULT_MAX_CHUNKS_PER_BATCH,
-                                        MAX_STREAM_CHUNK_BYTES,
-                                    ) {
-                                        let msg = StreamMessage {
-                                            message_type: StreamMessageType::StreamBatch as i32,
-                                            payload: Some(StreamPayload::StreamBatch(batch)),
-                                            sequence: shared_sequence
-                                                .fetch_add(1, Ordering::Relaxed),
-                                            peer_id: self_name_incremental.clone(),
-                                        };
-                                        match tx_incremental.try_send(msg) {
-                                            Ok(()) => {}
-                                            Err(mpsc::error::TrySendError::Full(_)) => {
-                                                log::debug!(
-                                                    peer = %peer_name_incremental,
-                                                    "stream batch dropped on backpressure"
-                                                );
-                                                // TODO(metrics): bump
-                                                // stream_dropped_on_backpressure
-                                                break;
-                                            }
-                                            Err(mpsc::error::TrySendError::Closed(_)) => {
-                                                log::warn!(
-                                                    peer = %peer_name_incremental,
-                                                    "stream sender: channel closed, stopping"
-                                                );
-                                                return;
-                                            }
+                            }
+
+                            loop {
+                                match targeted_subscription.receiver.try_recv() {
+                                    Ok(round) => {
+                                        match try_send_stream_round(
+                                            &tx_incremental,
+                                            &self_name_incremental,
+                                            &peer_name_incremental,
+                                            &shared_sequence,
+                                            round.entries.as_slice(),
+                                            "targeted",
+                                            round.dispatch_round_id,
+                                        ) {
+                                            StreamRoundSendOutcome::Sent
+                                            | StreamRoundSendOutcome::DroppedOnBackpressure => {}
+                                            StreamRoundSendOutcome::Closed => return,
                                         }
                                     }
+                                    Err(mpsc::error::TryRecvError::Empty) => break,
+                                    Err(mpsc::error::TryRecvError::Disconnected) => break,
                                 }
                             }
 

--- a/crates/mesh/src/controller.rs
+++ b/crates/mesh/src/controller.rs
@@ -598,6 +598,8 @@ impl MeshController {
                     let size_validator = MessageSizeValidator::default();
                     let batch_handle = current_batch.clone();
                     let stream_dispatch_handle = stream_dispatch.clone();
+                    let targeted_subscription =
+                        stream_dispatch_handle.subscribe_targeted(&peer_name_incremental);
 
                     #[expect(clippy::disallowed_methods, reason = "incremental sender handle is stored and aborted when the parent sync_stream handler exits")]
                     tokio::spawn(async move {
@@ -605,7 +607,7 @@ impl MeshController {
                         let mut next_broadcast_round_id =
                             stream_dispatch_handle.initial_broadcast_round_id();
                         let mut targeted_subscription: TargetedPeerSubscription =
-                            stream_dispatch_handle.subscribe_targeted(&peer_name_incremental);
+                            targeted_subscription;
 
                         loop {
                             interval.tick().await;

--- a/crates/mesh/src/controller.rs
+++ b/crates/mesh/src/controller.rs
@@ -39,7 +39,9 @@ use crate::{
     flow_control::{MessageSizeValidator, MAX_MESSAGE_SIZE},
     metrics,
     service::gossip::IncrementalUpdate,
-    stream_dispatch::{encode_stream_batches, StreamDispatch, TargetedPeerSubscription},
+    stream_dispatch::{
+        encode_stream_batches, StreamDispatch, TargetedPeerSubscription, TargetedRound,
+    },
 };
 
 enum StreamRoundSendOutcome {
@@ -608,6 +610,7 @@ impl MeshController {
                             stream_dispatch_handle.initial_broadcast_round_id();
                         let mut targeted_subscription: TargetedPeerSubscription =
                             targeted_subscription;
+                        let mut pending_targeted_round: Option<Arc<TargetedRound>> = None;
 
                         loop {
                             interval.tick().await;
@@ -723,33 +726,39 @@ impl MeshController {
                                     "broadcast",
                                     round.broadcast_round_id,
                                 ) {
-                                    StreamRoundSendOutcome::Sent
-                                    | StreamRoundSendOutcome::DroppedOnBackpressure => {
+                                    StreamRoundSendOutcome::Sent => {
                                         next_broadcast_round_id = round.broadcast_round_id + 1;
                                     }
+                                    StreamRoundSendOutcome::DroppedOnBackpressure => break,
                                     StreamRoundSendOutcome::Closed => return,
                                 }
                             }
 
                             loop {
-                                match targeted_subscription.receiver.try_recv() {
-                                    Ok(round) => {
-                                        match try_send_stream_round(
-                                            &tx_incremental,
-                                            &self_name_incremental,
-                                            &peer_name_incremental,
-                                            &shared_sequence,
-                                            round.entries.as_slice(),
-                                            "targeted",
-                                            round.dispatch_round_id,
-                                        ) {
-                                            StreamRoundSendOutcome::Sent
-                                            | StreamRoundSendOutcome::DroppedOnBackpressure => {}
-                                            StreamRoundSendOutcome::Closed => return,
-                                        }
+                                let round = match pending_targeted_round.take() {
+                                    Some(round) => round,
+                                    None => match targeted_subscription.receiver.try_recv() {
+                                        Ok(round) => round,
+                                        Err(mpsc::error::TryRecvError::Empty) => break,
+                                        Err(mpsc::error::TryRecvError::Disconnected) => break,
+                                    },
+                                };
+
+                                match try_send_stream_round(
+                                    &tx_incremental,
+                                    &self_name_incremental,
+                                    &peer_name_incremental,
+                                    &shared_sequence,
+                                    round.entries.as_slice(),
+                                    "targeted",
+                                    round.dispatch_round_id,
+                                ) {
+                                    StreamRoundSendOutcome::Sent => {}
+                                    StreamRoundSendOutcome::DroppedOnBackpressure => {
+                                        pending_targeted_round = Some(round);
+                                        break;
                                     }
-                                    Err(mpsc::error::TryRecvError::Empty) => break,
-                                    Err(mpsc::error::TryRecvError::Disconnected) => break,
+                                    StreamRoundSendOutcome::Closed => return,
                                 }
                             }
 

--- a/crates/mesh/src/controller.rs
+++ b/crates/mesh/src/controller.rs
@@ -38,7 +38,7 @@ use crate::{
     collector::{CentralCollector, PeerWatermark, RoundBatch},
     flow_control::{MessageSizeValidator, MAX_MESSAGE_SIZE},
     metrics,
-    service::gossip::IncrementalUpdate,
+    service::{gossip::IncrementalUpdate, MESH_PEER_ID_HEADER},
     stream_dispatch::{
         encode_stream_batches, StreamDispatch, TargetedPeerSubscription, TargetedRound,
     },
@@ -1380,7 +1380,7 @@ impl MeshController {
             .map_err(|e| anyhow::anyhow!("Invalid sync_stream peer_id metadata: {e}"))?;
         request
             .metadata_mut()
-            .insert("x-mesh-peer-id", peer_id_header);
+            .insert(MESH_PEER_ID_HEADER, peer_id_header);
 
         let response = client.sync_stream(request).await.map_err(|e| {
             log::error!("Failed to establish sync_stream with {}: {}", peer_name, e);

--- a/crates/mesh/src/controller.rs
+++ b/crates/mesh/src/controller.rs
@@ -12,7 +12,10 @@ use anyhow::Result;
 use bytes::Bytes;
 use rand::seq::{IndexedRandom, SliceRandom};
 use tokio::sync::{mpsc, watch, Mutex};
-use tonic::transport::{ClientTlsConfig, Endpoint};
+use tonic::{
+    metadata::MetadataValue,
+    transport::{ClientTlsConfig, Endpoint},
+};
 use tracing as log;
 use tracing::{instrument, Instrument};
 
@@ -1285,7 +1288,14 @@ impl MeshController {
         let (tx, rx) = mpsc::channel::<StreamMessage>(128);
         let outgoing_stream = tokio_stream::wrappers::ReceiverStream::new(rx);
 
-        let response = client.sync_stream(outgoing_stream).await.map_err(|e| {
+        let mut request = tonic::Request::new(outgoing_stream);
+        let peer_id_header = MetadataValue::try_from(self.self_name.as_str())
+            .map_err(|e| anyhow::anyhow!("Invalid sync_stream peer_id metadata: {e}"))?;
+        request
+            .metadata_mut()
+            .insert("x-mesh-peer-id", peer_id_header);
+
+        let response = client.sync_stream(request).await.map_err(|e| {
             log::error!("Failed to establish sync_stream with {}: {}", peer_name, e);
             anyhow::anyhow!("sync_stream RPC failed: {e}")
         })?;

--- a/crates/mesh/src/lib.rs
+++ b/crates/mesh/src/lib.rs
@@ -22,6 +22,7 @@ mod ping_server;
 mod rate_limit_window;
 mod service;
 mod stores;
+mod stream_dispatch;
 mod sync;
 mod topology;
 mod tree_ops;

--- a/crates/mesh/src/ping_server.rs
+++ b/crates/mesh/src/ping_server.rs
@@ -36,7 +36,7 @@ use super::{
             SnapshotChunk, SnapshotRequest, StateUpdate, StreamAck, StreamMessage,
             StreamMessageType,
         },
-        try_ping, ClusterState,
+        try_ping, ClusterState, MESH_PEER_ID_HEADER,
     },
     stores::{StateStores, StoreType as LocalStoreType},
     sync::MeshSyncManager,
@@ -730,7 +730,7 @@ impl Gossip for GossipService {
     ) -> Result<Response<Self::SyncStreamStream>, Status> {
         let metadata_peer_id = request
             .metadata()
-            .get("x-mesh-peer-id")
+            .get(MESH_PEER_ID_HEADER)
             .and_then(|value| value.to_str().ok())
             .filter(|value| !value.is_empty())
             .map(str::to_owned);

--- a/crates/mesh/src/ping_server.rs
+++ b/crates/mesh/src/ping_server.rs
@@ -659,7 +659,11 @@ impl Gossip for GossipService {
                                                         e,
                                                         size_validator_clone.max_size()
                                                     );
-                                                    watermark.mark_sent(store_type, &updates);
+                                                    if !updates.iter().any(|update| {
+                                                        update.key.starts_with("tree:")
+                                                    }) {
+                                                        watermark.mark_sent(store_type, &updates);
+                                                    }
                                                     continue;
                                                 }
 

--- a/crates/mesh/src/ping_server.rs
+++ b/crates/mesh/src/ping_server.rs
@@ -592,13 +592,27 @@ impl Gossip for GossipService {
             }
 
             const STREAM_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
+            // Once learned, the remote peer_id is fixed for the life of this
+            // stream; subsequent changes are treated as protocol violations.
+            let mut peer_learned = false;
             loop {
                 match tokio::time::timeout(STREAM_IDLE_TIMEOUT, incoming.next()).await {
                     Ok(Some(Ok(msg))) => {
                         sequence += 1;
-                        peer_id.clone_from(&msg.peer_id);
 
-                        if incremental_sender_handle.is_none() {
+                        if !peer_learned && !msg.peer_id.is_empty() {
+                            peer_id.clone_from(&msg.peer_id);
+                            peer_learned = true;
+                        } else if peer_learned && msg.peer_id != peer_id {
+                            log::warn!(
+                                expected_peer_id = %peer_id,
+                                received_peer_id = %msg.peer_id,
+                                "peer_id changed mid-stream; closing sync_stream"
+                            );
+                            break;
+                        }
+
+                        if peer_learned && incremental_sender_handle.is_none() {
                             if let (Some(batch_handle), Some(stream_dispatch_handle)) =
                                 (current_batch.clone(), stream_dispatch.clone())
                             {

--- a/crates/mesh/src/ping_server.rs
+++ b/crates/mesh/src/ping_server.rs
@@ -94,6 +94,139 @@ fn try_send_stream_round(
     StreamRoundSendOutcome::Sent
 }
 
+#[expect(
+    clippy::disallowed_methods,
+    reason = "server-side incremental sender that runs for the lifetime of the sync_stream; terminates when the channel closes or handle is aborted"
+)]
+fn spawn_server_incremental_sender(
+    tx_incremental: mpsc::Sender<Result<StreamMessage, Status>>,
+    self_name_incremental: String,
+    peer_name_incremental: String,
+    size_validator_clone: MessageSizeValidator,
+    batch_handle: Arc<parking_lot::RwLock<Arc<RoundBatch>>>,
+    stream_dispatch_handle: Arc<StreamDispatch>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut watermark = PeerWatermark::new(peer_name_incremental.clone());
+        let mut interval = tokio::time::interval(Duration::from_secs(1));
+        let mut sequence_counter: u64 = 0;
+        let mut next_broadcast_round_id = stream_dispatch_handle.initial_broadcast_round_id();
+        let mut targeted_subscription: TargetedPeerSubscription =
+            stream_dispatch_handle.subscribe_targeted(&peer_name_incremental);
+
+        loop {
+            interval.tick().await;
+
+            let batch = batch_handle.read().clone();
+            let all_updates = watermark.filter(&batch);
+
+            if !all_updates.is_empty() {
+                for (store_type, updates) in all_updates {
+                    let proto_store_type = store_type.to_proto();
+
+                    sequence_counter += 1;
+                    let batch_size: usize = updates.iter().map(|u| u.value.len()).sum();
+
+                    if let Err(e) = size_validator_clone.validate(batch_size) {
+                        log::warn!(
+                            "Incremental update too large, skipping store {:?}: {} (max: {} bytes)",
+                            store_type,
+                            e,
+                            size_validator_clone.max_size()
+                        );
+                        if !updates.iter().any(|update| update.key.starts_with("tree:")) {
+                            watermark.mark_sent(store_type, &updates);
+                        }
+                        continue;
+                    }
+
+                    let incremental_update = StreamMessage {
+                        message_type: StreamMessageType::IncrementalUpdate as i32,
+                        payload: Some(gossip::stream_message::Payload::Incremental(
+                            IncrementalUpdate {
+                                store: proto_store_type,
+                                updates: updates.clone(),
+                                version: 0,
+                            },
+                        )),
+                        sequence: sequence_counter,
+                        peer_id: self_name_incremental.clone(),
+                    };
+
+                    match tx_incremental.try_send(Ok(incremental_update)) {
+                        Ok(()) => {
+                            record_batch_sent(&self_name_incremental, batch_size);
+                            watermark.mark_sent(store_type, &updates);
+                        }
+                        Err(mpsc::error::TrySendError::Full(_)) => {
+                            log::debug!(
+                                "Backpressure: channel full, skipping send (will retry next interval)"
+                            );
+                            continue;
+                        }
+                        Err(mpsc::error::TrySendError::Closed(_)) => {
+                            log::warn!("Channel closed, stopping incremental update sender");
+                            return;
+                        }
+                    }
+                }
+            }
+
+            let broadcast_poll =
+                stream_dispatch_handle.poll_broadcast_rounds(next_broadcast_round_id);
+            if let Some(gap) = broadcast_poll.gap {
+                log::warn!(
+                    peer = %peer_name_incremental,
+                    missing_rounds = gap.missing_rounds,
+                    resume_from = gap.resume_from_broadcast_round_id,
+                    "broadcast stream rounds dropped before observation"
+                );
+                next_broadcast_round_id = gap.resume_from_broadcast_round_id;
+            }
+
+            for round in broadcast_poll.rounds {
+                match try_send_stream_round(
+                    &tx_incremental,
+                    &self_name_incremental,
+                    &peer_name_incremental,
+                    &mut sequence_counter,
+                    round.entries.as_slice(),
+                    "broadcast",
+                    round.broadcast_round_id,
+                ) {
+                    StreamRoundSendOutcome::Sent
+                    | StreamRoundSendOutcome::DroppedOnBackpressure => {
+                        next_broadcast_round_id = round.broadcast_round_id + 1;
+                    }
+                    StreamRoundSendOutcome::Closed => return,
+                }
+            }
+
+            loop {
+                match targeted_subscription.receiver.try_recv() {
+                    Ok(round) => {
+                        match try_send_stream_round(
+                            &tx_incremental,
+                            &self_name_incremental,
+                            &peer_name_incremental,
+                            &mut sequence_counter,
+                            round.entries.as_slice(),
+                            "targeted",
+                            round.dispatch_round_id,
+                        ) {
+                            StreamRoundSendOutcome::Sent
+                            | StreamRoundSendOutcome::DroppedOnBackpressure => {}
+                            StreamRoundSendOutcome::Closed => return,
+                        }
+                    }
+                    Err(mpsc::error::TryRecvError::Empty) => break,
+                    Err(mpsc::error::TryRecvError::Disconnected) => break,
+                }
+            }
+        }
+    })
+}
+
 #[derive(Debug)]
 pub struct GossipService {
     state: ClusterState,
@@ -510,6 +643,12 @@ impl Gossip for GossipService {
         &self,
         request: tonic::Request<tonic::Streaming<StreamMessage>>,
     ) -> Result<Response<Self::SyncStreamStream>, Status> {
+        let metadata_peer_id = request
+            .metadata()
+            .get("x-mesh-peer-id")
+            .and_then(|value| value.to_str().ok())
+            .filter(|value| !value.is_empty())
+            .map(str::to_owned);
         let mut incoming = request.into_inner();
         let self_name = self.self_name.clone();
         let state = self.state.clone();
@@ -539,7 +678,7 @@ impl Gossip for GossipService {
             reason = "server-side stream handler that runs for the lifetime of the sync_stream gRPC connection; terminates when the stream closes"
         )]
         tokio::spawn(async move {
-            let mut peer_id = String::new();
+            let mut peer_id = metadata_peer_id.clone().unwrap_or_default();
             let mut incremental_sender_handle: Option<tokio::task::JoinHandle<()>> = None;
             update_peer_connections(&peer_id, true);
 
@@ -594,7 +733,21 @@ impl Gossip for GossipService {
             const STREAM_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
             // Once learned, the remote peer_id is fixed for the life of this
             // stream; subsequent changes are treated as protocol violations.
-            let mut peer_learned = false;
+            let mut peer_learned = metadata_peer_id.is_some();
+            if let (Some(peer_name_incremental), Some(batch_handle), Some(stream_dispatch_handle)) = (
+                metadata_peer_id.clone(),
+                current_batch.clone(),
+                stream_dispatch.clone(),
+            ) {
+                incremental_sender_handle = Some(spawn_server_incremental_sender(
+                    tx.clone(),
+                    self_name.clone(),
+                    peer_name_incremental,
+                    size_validator.clone(),
+                    batch_handle,
+                    stream_dispatch_handle,
+                ));
+            }
             loop {
                 match tokio::time::timeout(STREAM_IDLE_TIMEOUT, incoming.next()).await {
                     Ok(Some(Ok(msg))) => {
@@ -616,158 +769,14 @@ impl Gossip for GossipService {
                             if let (Some(batch_handle), Some(stream_dispatch_handle)) =
                                 (current_batch.clone(), stream_dispatch.clone())
                             {
-                                let tx_incremental = tx.clone();
-                                let self_name_incremental = self_name.clone();
-                                let peer_name_incremental = peer_id.clone();
-                                let size_validator_clone = size_validator.clone();
-                                #[expect(
-                                    clippy::disallowed_methods,
-                                    reason = "server-side incremental sender that runs for the lifetime of the sync_stream; terminates when the channel closes or handle is aborted"
-                                )]
-                                let handle = tokio::spawn(async move {
-                                    let mut watermark =
-                                        PeerWatermark::new(peer_name_incremental.clone());
-                                    let mut interval =
-                                        tokio::time::interval(Duration::from_secs(1));
-                                    let mut sequence_counter: u64 = 0;
-                                    let mut next_broadcast_round_id =
-                                        stream_dispatch_handle.initial_broadcast_round_id();
-                                    let mut targeted_subscription: TargetedPeerSubscription =
-                                        stream_dispatch_handle
-                                            .subscribe_targeted(&peer_name_incremental);
-
-                                    loop {
-                                        interval.tick().await;
-
-                                        let batch = batch_handle.read().clone();
-                                        let all_updates = watermark.filter(&batch);
-
-                                        if !all_updates.is_empty() {
-                                            for (store_type, updates) in all_updates {
-                                                let proto_store_type = store_type.to_proto();
-
-                                                sequence_counter += 1;
-                                                let batch_size: usize =
-                                                    updates.iter().map(|u| u.value.len()).sum();
-
-                                                if let Err(e) =
-                                                    size_validator_clone.validate(batch_size)
-                                                {
-                                                    log::warn!(
-                                                        "Incremental update too large, skipping store {:?}: {} (max: {} bytes)",
-                                                        store_type,
-                                                        e,
-                                                        size_validator_clone.max_size()
-                                                    );
-                                                    if !updates.iter().any(|update| {
-                                                        update.key.starts_with("tree:")
-                                                    }) {
-                                                        watermark.mark_sent(store_type, &updates);
-                                                    }
-                                                    continue;
-                                                }
-
-                                                let incremental_update = StreamMessage {
-                                                    message_type: StreamMessageType::IncrementalUpdate
-                                                        as i32,
-                                                    payload: Some(
-                                                        gossip::stream_message::Payload::Incremental(
-                                                            IncrementalUpdate {
-                                                                store: proto_store_type,
-                                                                updates: updates.clone(),
-                                                                version: 0,
-                                                            },
-                                                        ),
-                                                    ),
-                                                    sequence: sequence_counter,
-                                                    peer_id: self_name_incremental.clone(),
-                                                };
-
-                                                match tx_incremental
-                                                    .try_send(Ok(incremental_update))
-                                                {
-                                                    Ok(()) => {
-                                                        record_batch_sent(
-                                                            &self_name_incremental,
-                                                            batch_size,
-                                                        );
-                                                        watermark.mark_sent(store_type, &updates);
-                                                    }
-                                                    Err(mpsc::error::TrySendError::Full(_)) => {
-                                                        log::debug!(
-                                                            "Backpressure: channel full, skipping send (will retry next interval)"
-                                                        );
-                                                        continue;
-                                                    }
-                                                    Err(mpsc::error::TrySendError::Closed(_)) => {
-                                                        log::warn!(
-                                                            "Channel closed, stopping incremental update sender"
-                                                        );
-                                                        return;
-                                                    }
-                                                }
-                                            }
-                                        }
-
-                                        let broadcast_poll = stream_dispatch_handle
-                                            .poll_broadcast_rounds(next_broadcast_round_id);
-                                        if let Some(gap) = broadcast_poll.gap {
-                                            log::warn!(
-                                                peer = %peer_name_incremental,
-                                                missing_rounds = gap.missing_rounds,
-                                                resume_from = gap.resume_from_broadcast_round_id,
-                                                "broadcast stream rounds dropped before observation"
-                                            );
-                                            next_broadcast_round_id =
-                                                gap.resume_from_broadcast_round_id;
-                                        }
-
-                                        for round in broadcast_poll.rounds {
-                                            match try_send_stream_round(
-                                                &tx_incremental,
-                                                &self_name_incremental,
-                                                &peer_name_incremental,
-                                                &mut sequence_counter,
-                                                round.entries.as_slice(),
-                                                "broadcast",
-                                                round.broadcast_round_id,
-                                            ) {
-                                                StreamRoundSendOutcome::Sent
-                                                | StreamRoundSendOutcome::DroppedOnBackpressure => {
-                                                    next_broadcast_round_id =
-                                                        round.broadcast_round_id + 1;
-                                                }
-                                                StreamRoundSendOutcome::Closed => return,
-                                            }
-                                        }
-
-                                        loop {
-                                            match targeted_subscription.receiver.try_recv() {
-                                                Ok(round) => {
-                                                    match try_send_stream_round(
-                                                        &tx_incremental,
-                                                        &self_name_incremental,
-                                                        &peer_name_incremental,
-                                                        &mut sequence_counter,
-                                                        round.entries.as_slice(),
-                                                        "targeted",
-                                                        round.dispatch_round_id,
-                                                    ) {
-                                                        StreamRoundSendOutcome::Sent
-                                                        | StreamRoundSendOutcome::DroppedOnBackpressure => {
-                                                        }
-                                                        StreamRoundSendOutcome::Closed => return,
-                                                    }
-                                                }
-                                                Err(mpsc::error::TryRecvError::Empty) => break,
-                                                Err(mpsc::error::TryRecvError::Disconnected) => {
-                                                    break;
-                                                }
-                                            }
-                                        }
-                                    }
-                                });
-                                incremental_sender_handle = Some(handle);
+                                incremental_sender_handle = Some(spawn_server_incremental_sender(
+                                    tx.clone(),
+                                    self_name.clone(),
+                                    peer_id.clone(),
+                                    size_validator.clone(),
+                                    batch_handle,
+                                    stream_dispatch_handle,
+                                ));
                             }
                         }
 

--- a/crates/mesh/src/ping_server.rs
+++ b/crates/mesh/src/ping_server.rs
@@ -187,7 +187,45 @@ fn spawn_server_incremental_sender(
                 next_broadcast_round_id = gap.resume_from_broadcast_round_id;
             }
 
+            let mut stream_backpressured = false;
             for round in broadcast_poll.rounds {
+                loop {
+                    let targeted_round = match pending_targeted_round.take() {
+                        Some(round) => round,
+                        None => match targeted_subscription.receiver.try_recv() {
+                            Ok(round) => round,
+                            Err(mpsc::error::TryRecvError::Empty) => break,
+                            Err(mpsc::error::TryRecvError::Disconnected) => break,
+                        },
+                    };
+
+                    if targeted_round.dispatch_round_id >= round.dispatch_round_id {
+                        pending_targeted_round = Some(targeted_round);
+                        break;
+                    }
+
+                    match try_send_stream_round(
+                        &tx_incremental,
+                        &self_name_incremental,
+                        &peer_name_incremental,
+                        &mut sequence_counter,
+                        targeted_round.entries.as_slice(),
+                        "targeted",
+                        targeted_round.dispatch_round_id,
+                    ) {
+                        StreamRoundSendOutcome::Sent => {}
+                        StreamRoundSendOutcome::DroppedOnBackpressure => {
+                            pending_targeted_round = Some(targeted_round);
+                            stream_backpressured = true;
+                            break;
+                        }
+                        StreamRoundSendOutcome::Closed => return,
+                    }
+                }
+                if stream_backpressured {
+                    break;
+                }
+
                 match try_send_stream_round(
                     &tx_incremental,
                     &self_name_incremental,
@@ -200,9 +238,47 @@ fn spawn_server_incremental_sender(
                     StreamRoundSendOutcome::Sent => {
                         next_broadcast_round_id = round.broadcast_round_id + 1;
                     }
-                    StreamRoundSendOutcome::DroppedOnBackpressure => break,
+                    StreamRoundSendOutcome::DroppedOnBackpressure => {
+                        stream_backpressured = true;
+                        break;
+                    }
                     StreamRoundSendOutcome::Closed => return,
                 }
+
+                let targeted_round = match pending_targeted_round.take() {
+                    Some(targeted_round)
+                        if targeted_round.dispatch_round_id == round.dispatch_round_id =>
+                    {
+                        targeted_round
+                    }
+                    Some(targeted_round) => {
+                        pending_targeted_round = Some(targeted_round);
+                        continue;
+                    }
+                    None => continue,
+                };
+
+                match try_send_stream_round(
+                    &tx_incremental,
+                    &self_name_incremental,
+                    &peer_name_incremental,
+                    &mut sequence_counter,
+                    targeted_round.entries.as_slice(),
+                    "targeted",
+                    targeted_round.dispatch_round_id,
+                ) {
+                    StreamRoundSendOutcome::Sent => {}
+                    StreamRoundSendOutcome::DroppedOnBackpressure => {
+                        pending_targeted_round = Some(targeted_round);
+                        stream_backpressured = true;
+                        break;
+                    }
+                    StreamRoundSendOutcome::Closed => return,
+                }
+            }
+
+            if stream_backpressured {
+                continue;
             }
 
             loop {

--- a/crates/mesh/src/ping_server.rs
+++ b/crates/mesh/src/ping_server.rs
@@ -43,7 +43,9 @@ use super::{
 };
 use crate::{
     collector::{PeerWatermark, RoundBatch},
-    stream_dispatch::{encode_stream_batches, StreamDispatch, TargetedPeerSubscription},
+    stream_dispatch::{
+        encode_stream_batches, StreamDispatch, TargetedPeerSubscription, TargetedRound,
+    },
 };
 
 enum StreamRoundSendOutcome {
@@ -113,6 +115,7 @@ fn spawn_server_incremental_sender(
         let mut next_broadcast_round_id = stream_dispatch_handle.initial_broadcast_round_id();
         let mut targeted_subscription: TargetedPeerSubscription =
             stream_dispatch_handle.subscribe_targeted(&peer_name_incremental);
+        let mut pending_targeted_round: Option<Arc<TargetedRound>> = None;
 
         loop {
             interval.tick().await;
@@ -194,33 +197,39 @@ fn spawn_server_incremental_sender(
                     "broadcast",
                     round.broadcast_round_id,
                 ) {
-                    StreamRoundSendOutcome::Sent
-                    | StreamRoundSendOutcome::DroppedOnBackpressure => {
+                    StreamRoundSendOutcome::Sent => {
                         next_broadcast_round_id = round.broadcast_round_id + 1;
                     }
+                    StreamRoundSendOutcome::DroppedOnBackpressure => break,
                     StreamRoundSendOutcome::Closed => return,
                 }
             }
 
             loop {
-                match targeted_subscription.receiver.try_recv() {
-                    Ok(round) => {
-                        match try_send_stream_round(
-                            &tx_incremental,
-                            &self_name_incremental,
-                            &peer_name_incremental,
-                            &mut sequence_counter,
-                            round.entries.as_slice(),
-                            "targeted",
-                            round.dispatch_round_id,
-                        ) {
-                            StreamRoundSendOutcome::Sent
-                            | StreamRoundSendOutcome::DroppedOnBackpressure => {}
-                            StreamRoundSendOutcome::Closed => return,
-                        }
+                let round = match pending_targeted_round.take() {
+                    Some(round) => round,
+                    None => match targeted_subscription.receiver.try_recv() {
+                        Ok(round) => round,
+                        Err(mpsc::error::TryRecvError::Empty) => break,
+                        Err(mpsc::error::TryRecvError::Disconnected) => break,
+                    },
+                };
+
+                match try_send_stream_round(
+                    &tx_incremental,
+                    &self_name_incremental,
+                    &peer_name_incremental,
+                    &mut sequence_counter,
+                    round.entries.as_slice(),
+                    "targeted",
+                    round.dispatch_round_id,
+                ) {
+                    StreamRoundSendOutcome::Sent => {}
+                    StreamRoundSendOutcome::DroppedOnBackpressure => {
+                        pending_targeted_round = Some(round);
+                        break;
                     }
-                    Err(mpsc::error::TryRecvError::Empty) => break,
-                    Err(mpsc::error::TryRecvError::Disconnected) => break,
+                    StreamRoundSendOutcome::Closed => return,
                 }
             }
         }

--- a/crates/mesh/src/ping_server.rs
+++ b/crates/mesh/src/ping_server.rs
@@ -18,10 +18,7 @@ use tracing as log;
 use tracing::instrument;
 
 use super::{
-    chunking::{
-        build_stream_batches, chunk_value, dispatch_stream_batch, next_generation,
-        DEFAULT_MAX_CHUNKS_PER_BATCH, MAX_STREAM_CHUNK_BYTES,
-    },
+    chunking::dispatch_stream_batch,
     flow_control::{MessageSizeValidator, MAX_MESSAGE_SIZE},
     metrics::{
         record_ack, record_batch_sent, record_nack, record_peer_reconnect, record_snapshot_bytes,
@@ -44,7 +41,58 @@ use super::{
     stores::{StateStores, StoreType as LocalStoreType},
     sync::MeshSyncManager,
 };
-use crate::collector::{PeerWatermark, RoundBatch};
+use crate::{
+    collector::{PeerWatermark, RoundBatch},
+    stream_dispatch::{encode_stream_batches, StreamDispatch, TargetedPeerSubscription},
+};
+
+enum StreamRoundSendOutcome {
+    Sent,
+    DroppedOnBackpressure,
+    Closed,
+}
+
+fn try_send_stream_round(
+    tx: &mpsc::Sender<Result<StreamMessage, Status>>,
+    self_name: &str,
+    peer_name: &str,
+    sequence_counter: &mut u64,
+    entries: &[(String, Bytes)],
+    round_kind: &str,
+    round_id: u64,
+) -> StreamRoundSendOutcome {
+    for batch in encode_stream_batches(entries) {
+        *sequence_counter += 1;
+        let msg = StreamMessage {
+            message_type: StreamMessageType::StreamBatch as i32,
+            payload: Some(gossip::stream_message::Payload::StreamBatch(batch)),
+            sequence: *sequence_counter,
+            peer_id: self_name.to_string(),
+        };
+        match tx.try_send(Ok(msg)) {
+            Ok(()) => {}
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                log::debug!(
+                    peer = %peer_name,
+                    round_kind,
+                    round_id,
+                    "stream round dropped on backpressure"
+                );
+                return StreamRoundSendOutcome::DroppedOnBackpressure;
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                log::warn!(
+                    peer = %peer_name,
+                    round_kind,
+                    round_id,
+                    "stream sender: channel closed, stopping"
+                );
+                return StreamRoundSendOutcome::Closed;
+            }
+        }
+    }
+    StreamRoundSendOutcome::Sent
+}
 
 #[derive(Debug)]
 pub struct GossipService {
@@ -61,11 +109,10 @@ pub struct GossipService {
     /// the MeshController's central collector. Server-side sync_stream handlers
     /// read from this and apply per-peer watermark filtering.
     current_batch: Option<Arc<parking_lot::RwLock<Arc<RoundBatch>>>>,
-    /// Shared reference to the current stream RoundBatch, drained once
-    /// per round by the MeshController. Server-side handlers read
-    /// broadcast entries from this (drain_entries); targeted entries
-    /// are handled client-side where peer_name is known at spawn.
-    current_stream_batch: Option<Arc<parking_lot::RwLock<Arc<crate::kv::RoundBatch>>>>,
+    /// Shared stream dispatch state from the MeshController. Server-side
+    /// handlers consume retained broadcast rounds and per-peer targeted
+    /// queues from the same transport state as outbound handlers.
+    stream_dispatch: Option<Arc<StreamDispatch>>,
     /// Node-wide MeshKV handle. Owns the stream buffers, subscriber
     /// registry, and chunk assembler shared with the client-side
     /// SyncStream handlers.
@@ -296,7 +343,7 @@ impl GossipService {
             partition_detector: None,
             mtls_manager: None,
             current_batch: None,
-            current_stream_batch: None,
+            stream_dispatch: None,
             mesh_kv: None,
         }
     }
@@ -312,14 +359,11 @@ impl GossipService {
         self
     }
 
-    /// Attach the shared stream RoundBatch reference. Server-side
-    /// handlers emit broadcast drain_entries to their peer — targeted
-    /// entries stay on the client side where peer_name is known.
-    pub fn with_current_stream_batch(
-        mut self,
-        current_stream_batch: Arc<parking_lot::RwLock<Arc<crate::kv::RoundBatch>>>,
-    ) -> Self {
-        self.current_stream_batch = Some(current_stream_batch);
+    /// Attach the shared stream dispatch state. Server-side handlers use
+    /// the same retained broadcast rounds and per-peer targeted queues
+    /// as outbound sync_stream handlers.
+    pub fn with_stream_dispatch(mut self, stream_dispatch: Arc<StreamDispatch>) -> Self {
+        self.stream_dispatch = Some(stream_dispatch);
         self
     }
 
@@ -478,171 +522,6 @@ impl Gossip for GossipService {
         let (tx, rx) = mpsc::channel::<Result<StreamMessage, Status>>(CHANNEL_CAPACITY);
         let size_validator = MessageSizeValidator::default();
 
-        // Spawn task to periodically send incremental updates.
-        // Uses PeerWatermark reading from the shared RoundBatch (central collector).
-        // If current_batch is not set (e.g., temporary GossipService for snapshots),
-        // skip the sender task.
-        let incremental_sender_handle = if let Some(batch_handle) = self.current_batch.clone() {
-            let tx_incremental = tx.clone();
-            let self_name_incremental = self_name.clone();
-            let size_validator_clone = size_validator.clone();
-            // The remote peer's name isn't known until the first stream message
-            // arrives. Use a placeholder label for debug output — this doesn't
-            // affect filtering correctness (each task has its own watermark).
-            let peer_name_for_watermark = "server-inbound".to_string();
-            let stream_batch_handle = self.current_stream_batch.clone();
-            #[expect(
-                clippy::disallowed_methods,
-                reason = "server-side incremental sender that runs for the lifetime of the sync_stream; terminates when the channel closes or handle is aborted"
-            )]
-            Some(tokio::spawn(async move {
-                let mut watermark = PeerWatermark::new(peer_name_for_watermark);
-                let mut interval = tokio::time::interval(Duration::from_secs(1));
-                let mut sequence_counter: u64 = 0;
-                let mut last_stream_batch: Option<Arc<crate::kv::RoundBatch>> = None;
-
-                loop {
-                    interval.tick().await;
-
-                    // Read the centrally collected batch and filter by this peer's watermark.
-                    let batch = batch_handle.read().clone();
-                    let all_updates = watermark.filter(&batch);
-
-                    if !all_updates.is_empty() {
-                        for (store_type, updates) in all_updates {
-                            let proto_store_type = store_type.to_proto();
-
-                            sequence_counter += 1;
-                            let batch_size: usize = updates.iter().map(|u| u.value.len()).sum();
-
-                            // Validate message size
-                            if let Err(e) = size_validator_clone.validate(batch_size) {
-                                log::warn!(
-                                    "Incremental update too large, skipping store {:?}: {} (max: {} bytes)",
-                                    store_type,
-                                    e,
-                                    size_validator_clone.max_size()
-                                );
-                                // Mark as sent to prevent infinite retry loop.
-                                watermark.mark_sent(store_type, &updates);
-                                continue;
-                            }
-
-                            let incremental_update = StreamMessage {
-                                message_type: StreamMessageType::IncrementalUpdate as i32,
-                                payload: Some(gossip::stream_message::Payload::Incremental(
-                                    IncrementalUpdate {
-                                        store: proto_store_type,
-                                        updates: updates.clone(),
-                                        version: 0, // Version is tracked per key in StateUpdate
-                                    },
-                                )),
-                                sequence: sequence_counter,
-                                peer_id: self_name_incremental.clone(),
-                            };
-
-                            // Check backpressure using try_send
-                            match tx_incremental.try_send(Ok(incremental_update)) {
-                                Ok(()) => {
-                                    record_batch_sent(&self_name_incremental, batch_size);
-                                    watermark.mark_sent(store_type, &updates);
-                                }
-                                Err(mpsc::error::TrySendError::Full(_)) => {
-                                    log::debug!(
-                                        "Backpressure: channel full, skipping send (will retry next interval)"
-                                    );
-                                    continue;
-                                }
-                                Err(mpsc::error::TrySendError::Closed(_)) => {
-                                    log::warn!(
-                                        "Channel closed, stopping incremental update sender"
-                                    );
-                                    break;
-                                }
-                            }
-
-                            log::debug!(
-                                "Sent incremental update: store={:?}, {} updates",
-                                store_type,
-                                updates.len()
-                            );
-                        }
-                    }
-
-                    // Server-side stream emission: broadcast drain_entries
-                    // only. Targeted entries stay on the client-side
-                    // (controller.rs) where peer_name is known at task
-                    // spawn. At-most-once: on channel full, drop without
-                    // retry.
-                    if let Some(sbh) = &stream_batch_handle {
-                        let stream_batch = sbh.read().clone();
-                        let fresh_batch = last_stream_batch
-                            .as_ref()
-                            .is_none_or(|last| !Arc::ptr_eq(last, &stream_batch));
-                        if fresh_batch {
-                            // Advance the tracker for every fresh Arc, not just
-                            // ones that produced work — otherwise a batch with
-                            // empty drain_entries stays "fresh" across ticks and
-                            // we keep re-checking it.
-                            last_stream_batch = Some(stream_batch.clone());
-                        }
-                        if fresh_batch && !stream_batch.drain_entries.is_empty() {
-                            let mut entries = Vec::new();
-                            // Generation is per-value so concurrent publishes
-                            // to the same key get distinct tags.
-                            for (key, value) in &stream_batch.drain_entries {
-                                entries.extend(chunk_value(
-                                    key.clone(),
-                                    next_generation(),
-                                    Bytes::from(value.clone()),
-                                    MAX_STREAM_CHUNK_BYTES,
-                                ));
-                            }
-                            if !entries.is_empty() {
-                                for batch in build_stream_batches(
-                                    entries,
-                                    DEFAULT_MAX_CHUNKS_PER_BATCH,
-                                    MAX_STREAM_CHUNK_BYTES,
-                                ) {
-                                    sequence_counter += 1;
-                                    let msg = StreamMessage {
-                                        message_type: StreamMessageType::StreamBatch as i32,
-                                        payload: Some(
-                                            gossip::stream_message::Payload::StreamBatch(batch),
-                                        ),
-                                        sequence: sequence_counter,
-                                        peer_id: self_name_incremental.clone(),
-                                    };
-                                    match tx_incremental.try_send(Ok(msg)) {
-                                        Ok(()) => {}
-                                        Err(mpsc::error::TrySendError::Full(_)) => {
-                                            log::debug!(
-                                                "server-side stream batch dropped on backpressure"
-                                            );
-                                            // TODO(metrics): bump
-                                            // stream_dropped_on_backpressure
-                                            break;
-                                        }
-                                        Err(mpsc::error::TrySendError::Closed(_)) => {
-                                            log::warn!(
-                                                "server-side stream sender: channel closed, stopping"
-                                            );
-                                            return;
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    } else if last_stream_batch.is_some() {
-                        // If handle became None (shouldn't normally), clear state.
-                        last_stream_batch = None;
-                    }
-                }
-            }))
-        } else {
-            None
-        };
-
         // Spawn task to handle incoming messages
         let mut sequence: u64 = 0;
         let _convergence_tracker = ConvergenceTracker::new();
@@ -652,6 +531,8 @@ impl Gossip for GossipService {
         // replaces any incomplete previous attempt (prevents stale chunk mixing).
         use std::collections::HashMap;
         let mut snapshot_state: HashMap<LocalStoreType, (Vec<SnapshotChunk>, u64)> = HashMap::new();
+        let current_batch = self.current_batch.clone();
+        let stream_dispatch = self.stream_dispatch.clone();
 
         #[expect(
             clippy::disallowed_methods,
@@ -659,6 +540,7 @@ impl Gossip for GossipService {
         )]
         tokio::spawn(async move {
             let mut peer_id = String::new();
+            let mut incremental_sender_handle: Option<tokio::task::JoinHandle<()>> = None;
             update_peer_connections(&peer_id, true);
 
             // Check if we need to request snapshots on connection
@@ -715,6 +597,161 @@ impl Gossip for GossipService {
                     Ok(Some(Ok(msg))) => {
                         sequence += 1;
                         peer_id.clone_from(&msg.peer_id);
+
+                        if incremental_sender_handle.is_none() {
+                            if let (Some(batch_handle), Some(stream_dispatch_handle)) =
+                                (current_batch.clone(), stream_dispatch.clone())
+                            {
+                                let tx_incremental = tx.clone();
+                                let self_name_incremental = self_name.clone();
+                                let peer_name_incremental = peer_id.clone();
+                                let size_validator_clone = size_validator.clone();
+                                #[expect(
+                                    clippy::disallowed_methods,
+                                    reason = "server-side incremental sender that runs for the lifetime of the sync_stream; terminates when the channel closes or handle is aborted"
+                                )]
+                                let handle = tokio::spawn(async move {
+                                    let mut watermark =
+                                        PeerWatermark::new(peer_name_incremental.clone());
+                                    let mut interval =
+                                        tokio::time::interval(Duration::from_secs(1));
+                                    let mut sequence_counter: u64 = 0;
+                                    let mut next_broadcast_round_id =
+                                        stream_dispatch_handle.initial_broadcast_round_id();
+                                    let mut targeted_subscription: TargetedPeerSubscription =
+                                        stream_dispatch_handle
+                                            .subscribe_targeted(&peer_name_incremental);
+
+                                    loop {
+                                        interval.tick().await;
+
+                                        let batch = batch_handle.read().clone();
+                                        let all_updates = watermark.filter(&batch);
+
+                                        if !all_updates.is_empty() {
+                                            for (store_type, updates) in all_updates {
+                                                let proto_store_type = store_type.to_proto();
+
+                                                sequence_counter += 1;
+                                                let batch_size: usize =
+                                                    updates.iter().map(|u| u.value.len()).sum();
+
+                                                if let Err(e) =
+                                                    size_validator_clone.validate(batch_size)
+                                                {
+                                                    log::warn!(
+                                                        "Incremental update too large, skipping store {:?}: {} (max: {} bytes)",
+                                                        store_type,
+                                                        e,
+                                                        size_validator_clone.max_size()
+                                                    );
+                                                    watermark.mark_sent(store_type, &updates);
+                                                    continue;
+                                                }
+
+                                                let incremental_update = StreamMessage {
+                                                    message_type: StreamMessageType::IncrementalUpdate
+                                                        as i32,
+                                                    payload: Some(
+                                                        gossip::stream_message::Payload::Incremental(
+                                                            IncrementalUpdate {
+                                                                store: proto_store_type,
+                                                                updates: updates.clone(),
+                                                                version: 0,
+                                                            },
+                                                        ),
+                                                    ),
+                                                    sequence: sequence_counter,
+                                                    peer_id: self_name_incremental.clone(),
+                                                };
+
+                                                match tx_incremental
+                                                    .try_send(Ok(incremental_update))
+                                                {
+                                                    Ok(()) => {
+                                                        record_batch_sent(
+                                                            &self_name_incremental,
+                                                            batch_size,
+                                                        );
+                                                        watermark.mark_sent(store_type, &updates);
+                                                    }
+                                                    Err(mpsc::error::TrySendError::Full(_)) => {
+                                                        log::debug!(
+                                                            "Backpressure: channel full, skipping send (will retry next interval)"
+                                                        );
+                                                        continue;
+                                                    }
+                                                    Err(mpsc::error::TrySendError::Closed(_)) => {
+                                                        log::warn!(
+                                                            "Channel closed, stopping incremental update sender"
+                                                        );
+                                                        return;
+                                                    }
+                                                }
+                                            }
+                                        }
+
+                                        let broadcast_poll = stream_dispatch_handle
+                                            .poll_broadcast_rounds(next_broadcast_round_id);
+                                        if let Some(gap) = broadcast_poll.gap {
+                                            log::warn!(
+                                                peer = %peer_name_incremental,
+                                                missing_rounds = gap.missing_rounds,
+                                                resume_from = gap.resume_from_broadcast_round_id,
+                                                "broadcast stream rounds dropped before observation"
+                                            );
+                                            next_broadcast_round_id =
+                                                gap.resume_from_broadcast_round_id;
+                                        }
+
+                                        for round in broadcast_poll.rounds {
+                                            match try_send_stream_round(
+                                                &tx_incremental,
+                                                &self_name_incremental,
+                                                &peer_name_incremental,
+                                                &mut sequence_counter,
+                                                round.entries.as_slice(),
+                                                "broadcast",
+                                                round.broadcast_round_id,
+                                            ) {
+                                                StreamRoundSendOutcome::Sent
+                                                | StreamRoundSendOutcome::DroppedOnBackpressure => {
+                                                    next_broadcast_round_id =
+                                                        round.broadcast_round_id + 1;
+                                                }
+                                                StreamRoundSendOutcome::Closed => return,
+                                            }
+                                        }
+
+                                        loop {
+                                            match targeted_subscription.receiver.try_recv() {
+                                                Ok(round) => {
+                                                    match try_send_stream_round(
+                                                        &tx_incremental,
+                                                        &self_name_incremental,
+                                                        &peer_name_incremental,
+                                                        &mut sequence_counter,
+                                                        round.entries.as_slice(),
+                                                        "targeted",
+                                                        round.dispatch_round_id,
+                                                    ) {
+                                                        StreamRoundSendOutcome::Sent
+                                                        | StreamRoundSendOutcome::DroppedOnBackpressure => {
+                                                        }
+                                                        StreamRoundSendOutcome::Closed => return,
+                                                    }
+                                                }
+                                                Err(mpsc::error::TryRecvError::Empty) => break,
+                                                Err(mpsc::error::TryRecvError::Disconnected) => {
+                                                    break;
+                                                }
+                                            }
+                                        }
+                                    }
+                                });
+                                incremental_sender_handle = Some(handle);
+                            }
+                        }
 
                         match msg.message_type() {
                             StreamMessageType::IncrementalUpdate => {
@@ -1050,7 +1087,7 @@ impl Gossip for GossipService {
                                         partition_detector: None,
                                         mtls_manager: None,
                                         current_batch: None,
-                                        current_stream_batch: None,
+                                        stream_dispatch: None,
                                         mesh_kv: None,
                                     };
                                     let chunks = service.create_snapshot_chunks(store_type, 100); // chunk_size = 100 entries

--- a/crates/mesh/src/service.rs
+++ b/crates/mesh/src/service.rs
@@ -469,7 +469,7 @@ impl MeshServer {
         // Share the controller's current_batch so server-side sync_stream
         // handlers use the same centrally collected data as client-side.
         service = service.with_current_batch(controller.current_batch());
-        service = service.with_current_stream_batch(controller.current_stream_batch());
+        service = service.with_stream_dispatch(controller.stream_dispatch());
 
         // Add mTLS support if configured
         if let Some(mtls_manager) = self.mtls_manager.clone() {

--- a/crates/mesh/src/service.rs
+++ b/crates/mesh/src/service.rs
@@ -22,6 +22,10 @@ pub mod gossip {
     #![allow(clippy::trivially_copy_pass_by_ref, clippy::allow_attributes)]
     tonic::include_proto!("mesh.gossip");
 }
+
+/// gRPC metadata header the sync_stream client sets so the server can
+/// learn the remote peer identity before the first payload frame.
+pub const MESH_PEER_ID_HEADER: &str = "x-mesh-peer-id";
 use gossip::{
     gossip_client, gossip_message, GossipMessage, NodeState, NodeStatus, NodeUpdate, Ping,
     StateSync,

--- a/crates/mesh/src/stream_dispatch.rs
+++ b/crates/mesh/src/stream_dispatch.rs
@@ -170,6 +170,7 @@ impl StreamDispatch {
         let dispatch_round_id = self.next_dispatch_round_id.fetch_add(1, Ordering::Relaxed);
 
         if !batch.drain_entries.is_empty() {
+            let mut rounds = self.broadcast_rounds.write();
             let broadcast_round_id = self.next_broadcast_round_id.fetch_add(1, Ordering::Relaxed);
             let round = Arc::new(BroadcastRound {
                 broadcast_round_id,
@@ -180,7 +181,6 @@ impl StreamDispatch {
                     .map(|(key, value)| (key, Bytes::from(value)))
                     .collect(),
             });
-            let mut rounds = self.broadcast_rounds.write();
             rounds.push_back(round);
             while rounds.len() > self.broadcast_round_retention {
                 rounds.pop_front();

--- a/crates/mesh/src/stream_dispatch.rs
+++ b/crates/mesh/src/stream_dispatch.rs
@@ -261,3 +261,130 @@ pub fn encode_stream_batches(entries: &[(String, Bytes)]) -> Vec<StreamBatch> {
         MAX_STREAM_CHUNK_BYTES,
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    #[test]
+    fn poll_broadcast_rounds_reports_gap_from_oldest_retained_round() {
+        let dispatch = StreamDispatch::new(2, 2);
+
+        for idx in 1..=3 {
+            dispatch.publish_round(RoundBatch {
+                drain_entries: vec![(format!("td:{idx}"), vec![idx as u8])],
+                targeted_entries: Vec::new(),
+            });
+        }
+
+        let poll = dispatch.poll_broadcast_rounds(1);
+        let gap = poll.gap.expect("gap should be reported");
+        assert_eq!(gap.missing_rounds, 1);
+        assert_eq!(gap.resume_from_broadcast_round_id, 2);
+        assert_eq!(poll.rounds.len(), 2);
+        assert_eq!(poll.rounds[0].broadcast_round_id, 2);
+        assert_eq!(poll.rounds[1].broadcast_round_id, 3);
+    }
+
+    #[tokio::test]
+    async fn publish_round_groups_targeted_entries_once_per_peer() {
+        let dispatch = Arc::new(StreamDispatch::new(2, 2));
+        let mut peer_a = dispatch.subscribe_targeted("peer-A");
+        let mut peer_b = dispatch.subscribe_targeted("peer-B");
+
+        dispatch.publish_round(RoundBatch {
+            drain_entries: Vec::new(),
+            targeted_entries: vec![
+                (
+                    "peer-A".to_string(),
+                    "tree:req:a1".to_string(),
+                    Bytes::from("a1"),
+                ),
+                (
+                    "peer-A".to_string(),
+                    "tree:req:a2".to_string(),
+                    Bytes::from("a2"),
+                ),
+                (
+                    "peer-B".to_string(),
+                    "tree:req:b1".to_string(),
+                    Bytes::from("b1"),
+                ),
+            ],
+        });
+
+        let round_a = tokio::time::timeout(Duration::from_millis(100), peer_a.receiver.recv())
+            .await
+            .expect("peer A timeout")
+            .expect("peer A closed");
+        assert_eq!(round_a.entries.len(), 2);
+        assert_eq!(round_a.entries[0].0, "tree:req:a1");
+        assert_eq!(round_a.entries[1].0, "tree:req:a2");
+
+        let round_b = tokio::time::timeout(Duration::from_millis(100), peer_b.receiver.recv())
+            .await
+            .expect("peer B timeout")
+            .expect("peer B closed");
+        assert_eq!(round_b.entries.len(), 1);
+        assert_eq!(round_b.entries[0].0, "tree:req:b1");
+    }
+
+    #[tokio::test]
+    async fn dropping_older_subscription_does_not_unregister_newer_peer_queue() {
+        let dispatch = Arc::new(StreamDispatch::new(2, 2));
+        let stale = dispatch.subscribe_targeted("peer-A");
+        let mut active = dispatch.subscribe_targeted("peer-A");
+        drop(stale);
+
+        dispatch.publish_round(RoundBatch {
+            drain_entries: Vec::new(),
+            targeted_entries: vec![(
+                "peer-A".to_string(),
+                "tree:req:a1".to_string(),
+                Bytes::from("a1"),
+            )],
+        });
+
+        let round = tokio::time::timeout(Duration::from_millis(100), active.receiver.recv())
+            .await
+            .expect("active timeout")
+            .expect("active closed");
+        assert_eq!(round.entries.len(), 1);
+        assert_eq!(round.entries[0].0, "tree:req:a1");
+    }
+
+    #[tokio::test]
+    async fn targeted_rounds_drop_when_peer_queue_is_full() {
+        let dispatch = Arc::new(StreamDispatch::new(2, 1));
+        let mut peer = dispatch.subscribe_targeted("peer-A");
+
+        dispatch.publish_round(RoundBatch {
+            drain_entries: Vec::new(),
+            targeted_entries: vec![(
+                "peer-A".to_string(),
+                "tree:req:first".to_string(),
+                Bytes::from("first"),
+            )],
+        });
+        dispatch.publish_round(RoundBatch {
+            drain_entries: Vec::new(),
+            targeted_entries: vec![(
+                "peer-A".to_string(),
+                "tree:req:second".to_string(),
+                Bytes::from("second"),
+            )],
+        });
+
+        let first = tokio::time::timeout(Duration::from_millis(100), peer.receiver.recv())
+            .await
+            .expect("first timeout")
+            .expect("first closed");
+        assert_eq!(first.entries.len(), 1);
+        assert_eq!(first.entries[0].0, "tree:req:first");
+
+        let second = tokio::time::timeout(Duration::from_millis(100), peer.receiver.recv()).await;
+        assert!(second.is_err(), "second round should have been dropped");
+    }
+}

--- a/crates/mesh/src/stream_dispatch.rs
+++ b/crates/mesh/src/stream_dispatch.rs
@@ -1,0 +1,263 @@
+use std::{
+    collections::{HashMap, VecDeque},
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+};
+
+use bytes::Bytes;
+use parking_lot::{Mutex, RwLock};
+use tokio::sync::mpsc;
+use tracing as log;
+
+use crate::{
+    chunking::{
+        build_stream_batches, chunk_value, next_generation, DEFAULT_MAX_CHUNKS_PER_BATCH,
+        MAX_STREAM_CHUNK_BYTES,
+    },
+    kv::RoundBatch,
+    service::gossip::StreamBatch,
+};
+
+pub const DEFAULT_BROADCAST_ROUND_RETENTION: usize = 4;
+pub const DEFAULT_TARGETED_QUEUE_DEPTH: usize = 4;
+
+#[derive(Debug)]
+pub struct BroadcastRound {
+    /// Monotonic broadcast-only sequence used for per-peer gap detection.
+    pub broadcast_round_id: u64,
+    /// Monotonic stream-dispatch sequence for this collection round.
+    #[expect(
+        dead_code,
+        reason = "reserved for cross-queue ordering and diagnostics"
+    )]
+    pub dispatch_round_id: u64,
+    pub entries: Vec<(String, Bytes)>,
+}
+
+#[derive(Debug)]
+pub struct TargetedRound {
+    /// Monotonic stream-dispatch sequence for this collection round.
+    pub dispatch_round_id: u64,
+    pub entries: Vec<(String, Bytes)>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BroadcastGap {
+    pub missing_rounds: u64,
+    pub resume_from_broadcast_round_id: u64,
+}
+
+#[derive(Debug, Default)]
+pub struct BroadcastPoll {
+    pub rounds: Vec<Arc<BroadcastRound>>,
+    pub gap: Option<BroadcastGap>,
+}
+
+pub struct TargetedPeerSubscription {
+    dispatch: Arc<StreamDispatch>,
+    peer_id: String,
+    registration_id: u64,
+    pub receiver: mpsc::Receiver<Arc<TargetedRound>>,
+}
+
+type TargetedPeerSender = (u64, mpsc::Sender<Arc<TargetedRound>>);
+type TargetedPeerRegistry = HashMap<String, TargetedPeerSender>;
+
+impl Drop for TargetedPeerSubscription {
+    fn drop(&mut self) {
+        self.dispatch
+            .unregister_targeted_peer(&self.peer_id, self.registration_id);
+    }
+}
+
+#[derive(Debug)]
+pub struct StreamDispatch {
+    next_dispatch_round_id: AtomicU64,
+    next_broadcast_round_id: AtomicU64,
+    next_targeted_registration_id: AtomicU64,
+    broadcast_round_retention: usize,
+    broadcast_rounds: RwLock<VecDeque<Arc<BroadcastRound>>>,
+    targeted_queue_depth: usize,
+    targeted_peers: Mutex<TargetedPeerRegistry>,
+}
+
+impl Default for StreamDispatch {
+    fn default() -> Self {
+        Self::new(
+            DEFAULT_BROADCAST_ROUND_RETENTION,
+            DEFAULT_TARGETED_QUEUE_DEPTH,
+        )
+    }
+}
+
+impl StreamDispatch {
+    pub fn new(broadcast_round_retention: usize, targeted_queue_depth: usize) -> Self {
+        assert!(
+            broadcast_round_retention > 0,
+            "broadcast_round_retention must be non-zero"
+        );
+        assert!(
+            targeted_queue_depth > 0,
+            "targeted_queue_depth must be non-zero"
+        );
+        Self {
+            next_dispatch_round_id: AtomicU64::new(1),
+            next_broadcast_round_id: AtomicU64::new(1),
+            next_targeted_registration_id: AtomicU64::new(1),
+            broadcast_round_retention,
+            broadcast_rounds: RwLock::new(VecDeque::new()),
+            targeted_queue_depth,
+            targeted_peers: Mutex::new(HashMap::new()),
+        }
+    }
+
+    pub fn initial_broadcast_round_id(&self) -> u64 {
+        let rounds = self.broadcast_rounds.read();
+        rounds
+            .front()
+            .map(|round| round.broadcast_round_id)
+            .unwrap_or_else(|| self.next_broadcast_round_id.load(Ordering::Relaxed))
+    }
+
+    pub fn poll_broadcast_rounds(&self, next_broadcast_round_id: u64) -> BroadcastPoll {
+        let rounds = self.broadcast_rounds.read();
+        let Some(oldest) = rounds.front() else {
+            return BroadcastPoll::default();
+        };
+
+        let mut poll = BroadcastPoll::default();
+        let resume_from = if next_broadcast_round_id < oldest.broadcast_round_id {
+            poll.gap = Some(BroadcastGap {
+                missing_rounds: oldest.broadcast_round_id - next_broadcast_round_id,
+                resume_from_broadcast_round_id: oldest.broadcast_round_id,
+            });
+            oldest.broadcast_round_id
+        } else {
+            next_broadcast_round_id
+        };
+
+        poll.rounds = rounds
+            .iter()
+            .filter(|round| round.broadcast_round_id >= resume_from)
+            .cloned()
+            .collect();
+        poll
+    }
+
+    pub fn subscribe_targeted(self: &Arc<Self>, peer_id: &str) -> TargetedPeerSubscription {
+        let registration_id = self
+            .next_targeted_registration_id
+            .fetch_add(1, Ordering::Relaxed);
+        let (tx, rx) = mpsc::channel(self.targeted_queue_depth);
+        self.targeted_peers
+            .lock()
+            .insert(peer_id.to_string(), (registration_id, tx));
+        TargetedPeerSubscription {
+            dispatch: self.clone(),
+            peer_id: peer_id.to_string(),
+            registration_id,
+            receiver: rx,
+        }
+    }
+
+    pub fn publish_round(&self, batch: RoundBatch) {
+        if batch.drain_entries.is_empty() && batch.targeted_entries.is_empty() {
+            return;
+        }
+
+        let dispatch_round_id = self.next_dispatch_round_id.fetch_add(1, Ordering::Relaxed);
+
+        if !batch.drain_entries.is_empty() {
+            let broadcast_round_id = self.next_broadcast_round_id.fetch_add(1, Ordering::Relaxed);
+            let round = Arc::new(BroadcastRound {
+                broadcast_round_id,
+                dispatch_round_id,
+                entries: batch
+                    .drain_entries
+                    .into_iter()
+                    .map(|(key, value)| (key, Bytes::from(value)))
+                    .collect(),
+            });
+            let mut rounds = self.broadcast_rounds.write();
+            rounds.push_back(round);
+            while rounds.len() > self.broadcast_round_retention {
+                rounds.pop_front();
+            }
+        }
+
+        if batch.targeted_entries.is_empty() {
+            return;
+        }
+
+        let mut entries_by_peer: HashMap<String, Vec<(String, Bytes)>> = HashMap::new();
+        for (peer_id, key, value) in batch.targeted_entries {
+            entries_by_peer
+                .entry(peer_id)
+                .or_default()
+                .push((key, value));
+        }
+
+        let targeted_peers = self.targeted_peers.lock();
+        for (peer_id, entries) in entries_by_peer {
+            let Some((_, tx)) = targeted_peers.get(&peer_id) else {
+                log::debug!(
+                    peer = %peer_id,
+                    dispatch_round_id,
+                    "dropping targeted stream round without an active peer queue"
+                );
+                continue;
+            };
+
+            let round = Arc::new(TargetedRound {
+                dispatch_round_id,
+                entries,
+            });
+            match tx.try_send(round) {
+                Ok(()) => {}
+                Err(mpsc::error::TrySendError::Full(_)) => {
+                    log::debug!(
+                        peer = %peer_id,
+                        dispatch_round_id,
+                        "dropping targeted stream round on queue backpressure"
+                    );
+                }
+                Err(mpsc::error::TrySendError::Closed(_)) => {
+                    log::debug!(
+                        peer = %peer_id,
+                        dispatch_round_id,
+                        "dropping targeted stream round because the peer queue is closed"
+                    );
+                }
+            }
+        }
+    }
+
+    fn unregister_targeted_peer(&self, peer_id: &str, registration_id: u64) {
+        let mut peers = self.targeted_peers.lock();
+        if peers
+            .get(peer_id)
+            .is_some_and(|(current_id, _)| *current_id == registration_id)
+        {
+            peers.remove(peer_id);
+        }
+    }
+}
+
+pub fn encode_stream_batches(entries: &[(String, Bytes)]) -> Vec<StreamBatch> {
+    let mut chunked_entries = Vec::new();
+    for (key, value) in entries {
+        chunked_entries.extend(chunk_value(
+            key.clone(),
+            next_generation(),
+            value.clone(),
+            MAX_STREAM_CHUNK_BYTES,
+        ));
+    }
+    build_stream_batches(
+        chunked_entries,
+        DEFAULT_MAX_CHUNKS_PER_BATCH,
+        MAX_STREAM_CHUNK_BYTES,
+    )
+}

--- a/crates/mesh/src/stream_dispatch.rs
+++ b/crates/mesh/src/stream_dispatch.rs
@@ -28,10 +28,6 @@ pub struct BroadcastRound {
     /// Monotonic broadcast-only sequence used for per-peer gap detection.
     pub broadcast_round_id: u64,
     /// Monotonic stream-dispatch sequence for this collection round.
-    #[expect(
-        dead_code,
-        reason = "reserved for cross-queue ordering and diagnostics"
-    )]
     pub dispatch_round_id: u64,
     pub entries: Vec<(String, Bytes)>,
 }


### PR DESCRIPTION
## Description

### Problem

Two silently-incorrect behaviours flagged in the [PR #1254 review](https://github.com/lightseekorg/smg/pull/1254):

**1. Silent stream loss under collector / sender timing skew ([`r3112678510`](https://github.com/lightseekorg/smg/pull/1254#discussion_r3112678510))**
The mesh stream path drained ephemeral round data once per collection interval but only exposed a single shared `RoundBatch` slot to peer sender tasks. If a sender loop was delayed for more than one interval (e.g. while iterating a large incremental batch), newer drained rounds overwrote older ones before the sender observed them — stream entries were drained-and-lost **without any explicit backpressure signal**. Application-level retry eventually compensates, but the transport was operationally invisible.

**2. Targeted stream routing broken in one direction per peer pair ([`r3112387632`](https://github.com/lightseekorg/smg/pull/1254#discussion_r3112387632))**
The lexicographic-initiator rule means only one side of each peer pair runs a client-side `sync_stream` sender. The server-side sender (handling the reverse direction of the bidirectional gRPC stream) was emitting only broadcast `drain_entries` and ignoring `targeted_entries` entirely. Any `publish_to(initiator, ...)` from the non-initiator half of a pair was drained every round and silently dropped — broke tree repair whenever the responder happens to be the non-initiator.

### Solution

Replace the single shared stream slot with a shared dispatch transport:

- retain broadcast rounds in a bounded ring so active peers can observe every drained broadcast round until retention is exceeded
- queue targeted stream traffic in bounded per-peer channels so drops happen at an explicit queue boundary
- detect when a peer falls behind the retained broadcast window and log the gap instead of silently overwriting it
- route both outbound and inbound `SyncStream` senders through the same dispatch state
- preserve per-peer round ordering so earlier targeted work is emitted before later broadcasts, and matching targeted work is emitted immediately after its broadcast round

## Mechanism

`MeshKV::collect_round_batch()` still drains stream-mode data once per collection tick and returns one `RoundBatch`:

- `drain_entries`: broadcast stream payloads such as `td:*`
- `targeted_entries`: per-peer payloads such as `tree:req:*` / `tree:page:*`

`StreamDispatch` splits that single drained batch into two transport shapes:

- broadcast path: if `drain_entries` is non-empty, retain one `BroadcastRound` in a small shared ring
- targeted path: group `targeted_entries` by peer and push one `TargetedRound` into that peer's bounded MPSC queue

Round ids:

- `dispatch_round_id`: stamped on every non-empty drained round; used to keep targeted and broadcast emission ordered per peer
- `broadcast_round_id`: stamped only on retained broadcast rounds; used for gap detection if a sender falls behind the ring

Sender behavior:

1. poll retained broadcast rounds starting from the sender's next `broadcast_round_id`
2. before emitting broadcast round `K`, flush any pending targeted rounds with an older `dispatch_round_id`
3. emit broadcast round `K`
4. if there is a targeted round with the same `dispatch_round_id`, emit it immediately after broadcast `K`
5. if the local channel is full, keep the current round pending and retry next tick instead of silently advancing past it

## Peer identity handshake

- the sync-stream client sends `MESH_PEER_ID_HEADER` at stream open
- the server learns the peer identity from that header when present, otherwise from the first non-empty payload `peer_id`
- once learned, the sender task binds to that peer's targeted queue and rejects mid-stream peer-id changes

## Detailed Flow Examples

### Example A: one collection round has both broadcast and targeted work

```text
Collection tick T:
  collect_round_batch() returns
    drain_entries = [
      ("td:model-1", <tenant-delta-bytes>)
    ]
    targeted_entries = [
      ("peer-b", "tree:req:model-1", <tree-request-bytes>)
    ]

Dispatch publish:
  dispatch_round_id = 17
  broadcast_round_id = 17

  broadcast ring:
    [
      ..., 
      BroadcastRound {
        broadcast_round_id: 17,
        dispatch_round_id: 17,
        entries: [("td:model-1", ...)]
      }
    ]

  targeted queue for peer-b:
    [
      TargetedRound {
        dispatch_round_id: 17,
        entries: [("tree:req:model-1", ...)]
      }
    ]

Peer B sender state before poll:
  next_broadcast_round_id = 17
  pending_targeted_round = None

Peer B sender tick:
  1. poll_broadcast_rounds(17) -> [broadcast round 17]
  2. no older targeted round exists, so nothing is flushed first
  3. send broadcast round 17
  4. dequeue targeted round with dispatch_round_id = 17
  5. send targeted round 17 immediately after the matching broadcast

Wire order observed by peer B:
  broadcast(dispatch=17, broadcast=17)
  targeted(dispatch=17)
```

### Example B: targeted-only work exists before a later broadcast round

```text
Collection tick T1:
  collect_round_batch() returns
    drain_entries = []
    targeted_entries = [
      ("peer-b", "tree:page:model-1:0", <page-bytes>)
    ]

Dispatch publish:
  dispatch_round_id = 18
  no broadcast round is created
  targeted queue for peer-b += TargetedRound { dispatch_round_id: 18, ... }

Collection tick T2:
  collect_round_batch() returns
    drain_entries = [
      ("td:model-1", <tenant-delta-bytes>)
    ]
    targeted_entries = [
      ("peer-b", "tree:req:model-1", <tree-request-bytes>)
    ]

Dispatch publish:
  dispatch_round_id = 19
  broadcast_round_id = 17

  broadcast ring += BroadcastRound {
    broadcast_round_id: 17,
    dispatch_round_id: 19,
    entries: [("td:model-1", ...)]
  }

  targeted queue for peer-b += TargetedRound {
    dispatch_round_id: 19,
    entries: [("tree:req:model-1", ...)]
  }

Peer B sender state before processing broadcast round 17:
  next_broadcast_round_id = 17
  pending_targeted_round = TargetedRound { dispatch_round_id: 18, ... }

Peer B sender tick:
  1. sees upcoming broadcast with dispatch_round_id = 19
  2. flushes older targeted dispatch round 18 first
  3. sends broadcast round 17 / dispatch round 19
  4. sends targeted dispatch round 19 immediately after it

Wire order observed by peer B:
  targeted(dispatch=18)
  broadcast(dispatch=19, broadcast=17)
  targeted(dispatch=19)

This is the ordering fix in this PR relative to the older two-phase loop,
which could send the later broadcast before the older targeted round.
```

### Example C: sender falls behind the retained broadcast window

```text
Sender state before poll:
  next_broadcast_round_id = 20

Broadcast ring currently retains only:
  [22, 23, 24, 25]

Poll result:
  poll_broadcast_rounds(20) ->
    gap = {
      missing_rounds: 2,
      resume_from_broadcast_round_id: 22
    }
    rounds = [22, 23, 24, 25]

Sender behavior:
  1. log the gap
  2. advance next_broadcast_round_id to 22
  3. emit retained broadcast rounds 22, 23, 24, 25 in order
  4. continue from next_broadcast_round_id = 26 on the next tick

Effect:
  broadcast rounds 20 and 21 were lost because the sender lagged past the
  ring depth, but the loss is explicit and observable instead of being a
  silent overwrite of a single shared slot.
```

## Changes

- add `stream_dispatch.rs` with retained broadcast rounds, per-peer targeted subscriptions, and stream-batch encoding helpers
- update `MeshController` to publish drained stream rounds into the dispatch state instead of replacing a shared `Arc<RoundBatch>`
- update outbound `sync_stream` senders to consume retained broadcast rounds and targeted per-peer queues
- update server-side `sync_stream` senders to bind to the peer after the first inbound message and consume the same dispatch state
- preserve per-peer dispatch ordering in both sender loops by interleaving earlier targeted rounds before later broadcasts and matching targeted rounds immediately after their broadcast round
- share `MESH_PEER_ID_HEADER` between client and server so the handshake cannot drift via duplicated string literals
- add regression tests for retained-round gap detection, targeted per-peer grouping, subscription replacement, and targeted queue backpressure

## Test Plan

- `cargo +nightly fmt --all`
- `cargo check -p smg-mesh --lib`
- `cargo test -p smg-mesh stream_dispatch --lib`

**Not covered in this PR (tracked as follow-ups):**

- **mTLS-derived peer identity binding.** The `x-mesh-peer-id` header is still a self-reported field. Per mesh-v2 spec §12, mTLS (`require_client_cert: true` by default) is the cluster auth boundary, so the authoritative identity is the client cert subject. A tonic interceptor can validate the header against the cert subject before the handler runs; left as a separate change since it's independent of the dispatch rework.
- **×N per-peer chunking amplification.** `chunk_value` still runs once per peer-sender per round rather than once per round centrally. For large values with many peers this duplicates per-chunk work. The central-chunking hoist is more invasive than this PR should take on.
- **Integration test for sender-stall → retention absorb → catch-up.** Unit tests cover the `StreamDispatch` state machine end-to-end; an integration test that actually stalls a sender past the retention window and verifies the gap log + recovery path would exercise the full pipeline and is worth adding separately.
- **Integration test for `publish_to(initiator, ...)` over the server-side targeted path.** Needs a multi-node harness where the non-initiator half exercises the new server-side targeted subscription — better as a dedicated test PR.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
