### PR TITLE
fix(workflow): skip tokenizer autoload for HTTP-mode workers

### DIFF
--- a/model_gateway/src/workflow/steps/local/submit_tokenizer_job.rs
+++ b/model_gateway/src/workflow/steps/local/submit_tokenizer_job.rs
@@ -9,9 +9,12 @@ use llm_tokenizer::TokenizerRegistry;
 use tracing::{debug, info, warn};
 use wfaas::{StepExecutor, StepResult, WorkflowContext, WorkflowError, WorkflowResult};
 
-use crate::workflow::{
-    data::{WorkerKind, WorkerWorkflowData},
-    Job, TokenizerConfigRequest,
+use crate::{
+    worker::ConnectionMode,
+    workflow::{
+        data::{WorkerKind, WorkerWorkflowData},
+        Job, TokenizerConfigRequest,
+    },
 };
 
 /// Step: Submit tokenizer registration job for the worker's model
@@ -28,6 +31,11 @@ impl StepExecutor<WorkerWorkflowData> for SubmitTokenizerJobStep {
         context: &mut WorkflowContext<WorkerWorkflowData>,
     ) -> WorkflowResult<StepResult> {
         if context.data.worker_kind != Some(WorkerKind::Local) {
+            return Ok(StepResult::Skip);
+        }
+
+        // HTTP mode has no gRPC fallback and doesn't consult the tokenizer registry.
+        if context.data.connection_mode == Some(ConnectionMode::Http) {
             return Ok(StepResult::Skip);
         }
 


### PR DESCRIPTION
Closes #1263

## Description

### Problem

When a Local worker is registered in HTTP mode (`ConnectionMode::Http`), the tokenizer autoload workflow runs but has no viable path to succeed:

- `fetch_tokenizer_from_worker` (`model_gateway/src/workflow/tokenizer_registration.rs`, ~L235) hard-filters on `ConnectionMode::Grpc`, so the remote-fetch fallback is unreachable for HTTP workers by design.
- The HTTP request path (`model_gateway/src/routers/http/*`) does not consult the tokenizer registry. Cache-aware and prefix-hash policies also do not reference it.

When the tokenizer path comes from worker labels (e.g. `model_path=/mnt/data/models/<ocid>` in a typical OCI / Kubernetes deployment where model files are mounted into the worker pod only), the router hits the local path, fails to find it on its own filesystem, treats it as a HuggingFace ID, 404s, then falls back to the non-existent gRPC path and surfaces a misleading error on every registration:

```
ERROR Failed to load tokenizer 'vllm-model': Failed to load tokenizer locally
  (... 404 Not Found ...) and remotely from worker
  (No healthy gRPC worker available to fetch tokenizer for model 'vllm-model')
```

### Solution

Gate `SubmitTokenizerJobStep` on `ConnectionMode::Http` and skip, mirroring the existing `WorkerKind::Local` gate just above it. The gRPC-mode path, the external-worker path, and the startup `--tokenizer-path` / `--model-path` path are all untouched. Operators who need a router-side tokenizer in HTTP mode can still register one via the explicit `AddTokenizer` API.

## Changes

- `model_gateway/src/workflow/steps/local/submit_tokenizer_job.rs`: add an early-return skip when `connection_mode == Some(ConnectionMode::Http)`; import `ConnectionMode` from `crate::worker`.

## Test Plan

**Before**: deploy SMG with an HTTP-mode vLLM worker whose model lives on the worker's filesystem only. On worker registration, the router emits `ERROR Failed to load tokenizer ...` + `WARN Failed job: type=AddTokenizer ...` and retries.

**After**: `SubmitTokenizerJobStep` returns `StepResult::Skip` before submitting the job. No `AddTokenizer` failure, no retry, no error logs. HTTP request routing is unaffected (registry was never consulted on that path).

Verification run locally:

```
cargo check -p smg                                       # clean
cargo clippy -p smg --all-targets -- -D warnings         # clean
cargo +nightly fmt -p smg -- --check                     # clean
pre-commit run --all-files                               # all Passed
```

gRPC-mode worker behavior is exercised by the existing workflow tests and is unchanged.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of HTTP-mode local worker connections to prevent unnecessary tokenizer operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->