### PR TITLE
feat(grpc_servicer): extensible health-check registry + prefill bootstrap-queue stall checker

### DIFF
--- a/grpc_servicer/smg_grpc_servicer/sglang/health_checks/__init__.py
+++ b/grpc_servicer/smg_grpc_servicer/sglang/health_checks/__init__.py
@@ -1,0 +1,5 @@
+"""Pluggable health checks for the SGLang gRPC health servicer."""
+
+from smg_grpc_servicer.sglang.health_checks.base import HealthChecker
+
+__all__ = ["HealthChecker"]

--- a/grpc_servicer/smg_grpc_servicer/sglang/health_checks/base.py
+++ b/grpc_servicer/smg_grpc_servicer/sglang/health_checks/base.py
@@ -1,0 +1,34 @@
+"""Pluggable health check protocol for SGLangHealthServicer.
+
+Checkers are focused predicates that inspect scheduler state and decide
+whether the engine is healthy. The servicer aggregates registered
+checkers: any one checker reporting unhealthy flips the gRPC
+Health.Check response to NOT_SERVING.
+"""
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class HealthChecker(Protocol):
+    """A single health predicate.
+
+    Implementations must:
+
+    * Set ``name`` to a short stable identifier used in logs and
+      diagnostics (e.g. ``"scheduler_stall"``, ``"decoder_backpressure"``).
+    * Make ``is_unhealthy`` idempotent and cheap — the servicer may call
+      it as often as every K8s probe arrives. If the underlying signal
+      is expensive to read, maintain an internal TTL cache.
+    * Return ``None`` when the component is healthy.
+    * Return a free-form diagnostic dict when the component is unhealthy.
+      The dict is logged on transitions and surfaced to operators.
+    * Raise on "unable to determine" conditions (IPC error, timeout,
+      schema drift, etc.). The servicer catches all exceptions centrally,
+      counts consecutive failures, and fails-safe to SERVING. Cancellation
+      must propagate.
+    """
+
+    name: str
+
+    async def is_unhealthy(self) -> dict | None: ...

--- a/grpc_servicer/smg_grpc_servicer/sglang/health_checks/prefill_bootstrap_queue.py
+++ b/grpc_servicer/smg_grpc_servicer/sglang/health_checks/prefill_bootstrap_queue.py
@@ -1,0 +1,138 @@
+"""Prefill bootstrap-queue stall detector.
+
+Detects when a disaggregation-prefill engine's bootstrap queue is
+saturated with no forward progress: every queued request is stuck in
+bootstrap and the inflight/waiting queues are both empty. A healthy
+busy server at its queue cap always has inflight > 0 because real
+transfers are completing, so the all-zero-except-bootstrap tuple is an
+unambiguous "pipeline stalled" signature under the current sglang
+transports.
+
+The check is cause-agnostic — it observes that forward progress has
+stopped, not why. Common causes include transport-level failures (any
+KV-transfer engine), decoder-side slot-allocation backpressure, ZMQ
+control-channel breakage, or a decoder OOM. Operators inspecting the
+diagnostics can correlate with transport / scheduler / network
+telemetry to identify the specific root cause for a given incident.
+"""
+
+import asyncio
+import logging
+import time
+
+logger = logging.getLogger(__name__)
+
+# Cache TTL for the scheduler get_loads IPC call. Kubernetes liveness
+# probes and the SMG router both probe the health endpoint at high
+# frequency; caching the result within this window avoids stampeding
+# the scheduler with redundant IPCs.
+_GET_LOADS_CACHE_TTL_SEC = 1.0
+
+# Hard timeout on the scheduler IPC. A wedged scheduler is itself a
+# failure mode the checker should surface (as a raised exception, which
+# the servicer's central fail-safe handles). Deliberately larger than
+# the cache TTL so cache hits are cheap.
+_GET_LOADS_IPC_TIMEOUT_SEC = 5.0
+
+
+class PrefillBootstrapQueueStalledChecker:
+    """HealthChecker detecting a stalled prefill bootstrap pipeline.
+
+    Active only when ``server_args.disaggregation_mode == "prefill"`` and
+    ``server_args.max_queued_requests`` is a positive int; otherwise
+    always returns None (healthy). Cause-agnostic: fires on the stall
+    signature regardless of which sub-system caused it.
+    """
+
+    name = "prefill_bootstrap_queue_stalled"
+
+    def __init__(self, request_manager, server_args):
+        """
+        Args:
+            request_manager: GrpcRequestManager instance used to poll
+                scheduler/DP-rank load state via ``get_loads(["disagg"])``.
+            server_args: sglang ServerArgs. Read for ``disaggregation_mode``
+                (must be "prefill" for the checker to activate) and
+                ``max_queued_requests`` (the bootstrap queue cap against
+                which the stall signature is compared).
+        """
+        self._request_manager = request_manager
+        self._server_args = server_args
+        self._cache: list | None = None
+        self._cache_ts: float = 0.0
+        self._warned_all_ranks_missing_disagg: bool = False
+
+    async def is_unhealthy(self) -> dict | None:
+        sa = self._server_args
+        if getattr(sa, "disaggregation_mode", "null") != "prefill":
+            return None
+        limit = getattr(sa, "max_queued_requests", None)
+        if not isinstance(limit, int) or limit <= 0:
+            return None
+
+        loads = await self._get_loads_cached()
+        if not loads:
+            return None
+
+        # A stall on ANY scheduler/DP rank is enough to declare the pod
+        # unhealthy — once one rank's bootstrap queue is wedged, new
+        # requests scheduled to it will stall indefinitely.
+        ranks_with_disagg = 0
+        for load in loads:
+            disagg = getattr(load, "disaggregation", None)
+            if disagg is None:
+                continue
+            ranks_with_disagg += 1
+            bootstrap = getattr(disagg, "prefill_prealloc_queue_reqs", 0)
+            inflight = getattr(disagg, "prefill_inflight_queue_reqs", 0)
+            # num_waiting_reqs sums waiting_queue + disagg_prefill_bootstrap_queue
+            # on the prefill side (see sglang scheduler_metrics_mixin.py),
+            # so subtract to recover the real main-queue wait count. Clamp
+            # at zero to guard against skew from independent counter reads.
+            num_waiting_reqs = getattr(load, "num_waiting_reqs", 0)
+            waiting = max(0, num_waiting_reqs - bootstrap)
+
+            if bootstrap >= limit and inflight == 0 and waiting == 0:
+                return {
+                    "dp_rank": getattr(load, "dp_rank", None),
+                    "bootstrap": bootstrap,
+                    "inflight": inflight,
+                    "waiting": waiting,
+                    "limit": limit,
+                }
+
+        # Schema-drift canary: if we got load replies but no rank exposed
+        # the disaggregation struct, the checker is effectively disabled.
+        # Warn once so the silent-failure mode surfaces.
+        if ranks_with_disagg == 0 and not self._warned_all_ranks_missing_disagg:
+            logger.warning(
+                "%s: received %d load replies but NONE contained a "
+                "disaggregation struct. Either ['disagg'] stats were not "
+                "requested, or the upstream GetLoadsReqOutput schema has "
+                "changed. Checker disabled until fixed.",
+                self.name,
+                len(loads),
+            )
+            self._warned_all_ranks_missing_disagg = True
+
+        return None
+
+    async def _get_loads_cached(self) -> list:
+        """TTL-cached, timeout-bounded wrapper around get_loads(["disagg"]).
+
+        Under asyncio the ``await`` inside the refresh is the only
+        suspension point, so two concurrent probes can both observe a
+        stale cache and both issue IPCs — still a massive reduction vs.
+        every probe. Correctness of the stall signature does not depend
+        on strong cache consistency.
+        """
+        now = time.monotonic()
+        if self._cache is not None and (now - self._cache_ts) < _GET_LOADS_CACHE_TTL_SEC:
+            return self._cache
+        loads = await asyncio.wait_for(
+            self._request_manager.get_loads(include=["disagg"]),
+            timeout=_GET_LOADS_IPC_TIMEOUT_SEC,
+        )
+        self._cache = loads
+        self._cache_ts = now
+        return loads

--- a/grpc_servicer/smg_grpc_servicer/sglang/health_servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/sglang/health_servicer.py
@@ -1,18 +1,28 @@
-"""
-Standard gRPC health check service implementation for Kubernetes probes.
+"""Standard gRPC health check service implementation for Kubernetes probes.
 
-This module implements the grpc.health.v1.Health service protocol, enabling
-native Kubernetes gRPC health probes for liveness and readiness checks.
+Implements grpc.health.v1.Health and layers an extensible checker
+registry on top. Registered HealthChecker predicates can flip Check() to
+NOT_SERVING when they observe engine-level failures that the base
+serving-status flags (startup / shutdown) don't catch — dead scheduler
+threads, pipeline deadlocks, backpressure starvation, etc.
 """
 
+import asyncio
 import logging
 import time
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Sequence
 
 import grpc
 from grpc_health.v1 import health_pb2, health_pb2_grpc
 
+from smg_grpc_servicer.sglang.health_checks import HealthChecker
+
 logger = logging.getLogger(__name__)
+
+# Escalate per-checker exception logs at these consecutive-failure counts
+# so a silent dependency outage surfaces at WARNING instead of hiding at
+# DEBUG, without flooding the log at probe rate.
+_CHECKER_FAILURE_LOG_STEPS = (1, 10, 100)
 
 
 class SGLangHealthServicer(health_pb2_grpc.HealthServicer):
@@ -24,32 +34,76 @@ class SGLangHealthServicer(health_pb2_grpc.HealthServicer):
     1. Overall server health (service="") - for liveness probes
     2. SGLang service health (service="sglang.grpc.scheduler.SglangScheduler") - for readiness probes
 
-    Health status lifecycle:
+    Base health status lifecycle:
     - NOT_SERVING: Initial state, model loading, or shutting down
     - SERVING: Model loaded and ready to serve requests
+
+    Beyond the base status, registered HealthChecker instances can
+    override a SERVING response with NOT_SERVING when they observe an
+    engine-level failure (e.g. a stalled pipeline). The first checker
+    returning an unhealthy result wins.
     """
 
     # Service names we support
     OVERALL_SERVER = ""  # Empty string for overall server health
     SGLANG_SERVICE = "sglang.grpc.scheduler.SglangScheduler"
 
-    def __init__(self, request_manager, scheduler_info: dict):
+    def __init__(
+        self,
+        request_manager,
+        scheduler_info: dict,
+        checkers: Sequence[HealthChecker] | None = None,
+    ):
         """
         Initialize health servicer.
 
         Args:
             request_manager: GrpcRequestManager instance for checking server state
             scheduler_info: Dict containing scheduler metadata
+            checkers: Optional sequence of HealthChecker predicates. Each
+                is polled on every Check() that would otherwise return
+                SERVING; the first one returning an unhealthy diagnostic
+                flips the response to NOT_SERVING. An empty sequence
+                preserves legacy behavior verbatim.
         """
         self.request_manager = request_manager
         self.scheduler_info = scheduler_info
+        self._checkers: list[HealthChecker] = list(checkers) if checkers else []
         self._serving_status = {}
 
         # Initially set to NOT_SERVING until model is loaded
         self._serving_status[self.OVERALL_SERVER] = health_pb2.HealthCheckResponse.NOT_SERVING
         self._serving_status[self.SGLANG_SERVICE] = health_pb2.HealthCheckResponse.NOT_SERVING
 
+        # Aggregate transition state: True iff the most recent determined
+        # checker run saw any checker unhealthy. Starts False so the first
+        # real detection emits a transition warning (covers the "pod came
+        # up already unhealthy" case).
+        self._any_checker_unhealthy: bool = False
+
+        # Per-checker consecutive-failure counts to escalate exception
+        # log level without flooding at probe rate.
+        self._checker_failure_counts: dict[str, int] = {c.name: 0 for c in self._checkers}
+
+        self._log_checker_registration()
+
         logger.info("Standard gRPC health service initialized")
+
+    def _log_checker_registration(self) -> None:
+        """Describe the registered checker set at startup so a missing
+        checker (e.g. caller forgot to wire one up) is visible in logs
+        instead of silently leaving the feature disabled for the life of
+        the pod.
+        """
+        if not self._checkers:
+            logger.info("Health-check registry: 0 checkers registered")
+            return
+        names = ", ".join(c.name for c in self._checkers)
+        logger.info(
+            "Health-check registry: %d checker(s) registered: [%s]",
+            len(self._checkers),
+            names,
+        )
 
     def set_serving(self):
         """Mark services as SERVING - call this after model is loaded."""
@@ -91,6 +145,11 @@ class SGLangHealthServicer(health_pb2_grpc.HealthServicer):
             status = self._serving_status.get(
                 self.OVERALL_SERVER, health_pb2.HealthCheckResponse.NOT_SERVING
             )
+            if (
+                status == health_pb2.HealthCheckResponse.SERVING
+                and await self._any_unhealthy_checker()
+            ):
+                status = health_pb2.HealthCheckResponse.NOT_SERVING
             logger.debug(
                 f"Overall health check: {health_pb2.HealthCheckResponse.ServingStatus.Name(status)}"
             )
@@ -123,6 +182,13 @@ class SGLangHealthServicer(health_pb2_grpc.HealthServicer):
                     f"({time_since_last_receive:.1f}s since last receive, "
                     f"{len(self.request_manager.rid_to_state)} pending requests)"
                 )
+                return health_pb2.HealthCheckResponse(
+                    status=health_pb2.HealthCheckResponse.NOT_SERVING
+                )
+
+            # Poll registered HealthChecker predicates. Any one reporting
+            # unhealthy flips the response to NOT_SERVING.
+            if await self._any_unhealthy_checker():
                 return health_pb2.HealthCheckResponse(
                     status=health_pb2.HealthCheckResponse.NOT_SERVING
                 )
@@ -160,9 +226,89 @@ class SGLangHealthServicer(health_pb2_grpc.HealthServicer):
         service_name = request.service
         logger.debug(f"Health watch request for service: '{service_name}'")
 
-        # Send current status
+        # Send current status. Because this delegates to Check(), the
+        # registered checkers apply uniformly to the single emitted frame.
+        # A fuller Watch implementation that streams transitions is future work.
         response = await self.Check(request, context)
         yield response
 
         # Note: Full Watch implementation would monitor status changes
         # and stream updates. For K8s probes, Check is sufficient.
+
+    async def _any_unhealthy_checker(self) -> tuple[str, dict] | None:
+        """Run registered checkers in order. Return (name, diagnostics)
+        on the first unhealthy result; None if all healthy, all failed
+        to determine, or none registered.
+
+        Fail-safe: exceptions from a checker are logged (with consecutive-
+        failure escalation) and the iteration continues. Cancellation
+        propagates unchanged.
+
+        Aggregate transition state is updated only when at least one
+        checker produced a determined result; all-raise cycles do not
+        flip state, which keeps transient IPC outages from oscillating
+        the logged state.
+        """
+        if not self._checkers:
+            return None
+
+        unhealthy: tuple[str, dict] | None = None
+        any_determined = False
+        for checker in self._checkers:
+            try:
+                result = await checker.is_unhealthy()
+            except asyncio.CancelledError:
+                # Never swallow cancellation — callers (gRPC cancels,
+                # graceful shutdown) rely on it propagating.
+                raise
+            except Exception as e:
+                self._register_checker_failure(checker.name, e)
+                continue
+            self._register_checker_success(checker.name)
+            any_determined = True
+            if result is not None:
+                unhealthy = (checker.name, result)
+                break
+
+        if any_determined:
+            self._update_aggregate_state(unhealthy)
+        return unhealthy
+
+    def _register_checker_failure(self, name: str, exc: BaseException) -> None:
+        count = self._checker_failure_counts.get(name, 0) + 1
+        self._checker_failure_counts[name] = count
+        if count in _CHECKER_FAILURE_LOG_STEPS or count % 1000 == 0:
+            logger.warning(
+                "Health checker %r failed (%d consecutive failures): %s",
+                name,
+                count,
+                exc,
+            )
+
+    def _register_checker_success(self, name: str) -> None:
+        prior = self._checker_failure_counts.get(name, 0)
+        if prior:
+            logger.info(
+                "Health checker %r recovered after %d consecutive failures",
+                name,
+                prior,
+            )
+            self._checker_failure_counts[name] = 0
+
+    def _update_aggregate_state(self, unhealthy: tuple[str, dict] | None) -> None:
+        """Log SERVING <-> NOT_SERVING transitions only; probe-rate
+        steady-state logs would drown out everything else.
+        """
+        is_unhealthy = unhealthy is not None
+        if is_unhealthy == self._any_checker_unhealthy:
+            return
+        if is_unhealthy:
+            name, diag = unhealthy  # type: ignore[misc]
+            logger.warning(
+                "Health checker %r reporting unhealthy; responding NOT_SERVING. Diagnostics: %s",
+                name,
+                diag,
+            )
+        else:
+            logger.warning("All health checkers reporting healthy; responding SERVING.")
+        self._any_checker_unhealthy = is_unhealthy

--- a/grpc_servicer/smg_grpc_servicer/sglang/server.py
+++ b/grpc_servicer/smg_grpc_servicer/sglang/server.py
@@ -26,6 +26,9 @@ from sglang.utils import get_exception_traceback
 from smg_grpc_proto import sglang_scheduler_pb2, sglang_scheduler_pb2_grpc
 
 from smg_grpc_servicer.sglang.health_checks import HealthChecker
+from smg_grpc_servicer.sglang.health_checks.prefill_bootstrap_queue import (
+    PrefillBootstrapQueueStalledChecker,
+)
 from smg_grpc_servicer.sglang.health_servicer import SGLangHealthServicer
 from smg_grpc_servicer.sglang.request_manager import GrpcRequestManager
 from smg_grpc_servicer.sglang.scheduler_launcher import launch_scheduler_process_only
@@ -123,8 +126,18 @@ async def serve_grpc(
     # Create standard health service (for Kubernetes probes). Register
     # engine-level health checkers so they can override a SERVING base
     # status when they observe a stall the base status can't see.
-    # Specific checker implementations are wired up below as they apply.
     health_checkers: list[HealthChecker] = []
+    if (
+        server_args.disaggregation_mode == "prefill"
+        and isinstance(getattr(server_args, "max_queued_requests", None), int)
+        and server_args.max_queued_requests > 0
+    ):
+        health_checkers.append(
+            PrefillBootstrapQueueStalledChecker(
+                request_manager=request_manager,
+                server_args=server_args,
+            )
+        )
     health_servicer = SGLangHealthServicer(
         request_manager=request_manager,
         scheduler_info=scheduler_info,

--- a/grpc_servicer/smg_grpc_servicer/sglang/server.py
+++ b/grpc_servicer/smg_grpc_servicer/sglang/server.py
@@ -25,6 +25,7 @@ from sglang.srt.utils import kill_process_tree
 from sglang.utils import get_exception_traceback
 from smg_grpc_proto import sglang_scheduler_pb2, sglang_scheduler_pb2_grpc
 
+from smg_grpc_servicer.sglang.health_checks import HealthChecker
 from smg_grpc_servicer.sglang.health_servicer import SGLangHealthServicer
 from smg_grpc_servicer.sglang.request_manager import GrpcRequestManager
 from smg_grpc_servicer.sglang.scheduler_launcher import launch_scheduler_process_only
@@ -119,10 +120,15 @@ async def serve_grpc(
         ],
     )
 
-    # Create standard health service (for Kubernetes probes)
+    # Create standard health service (for Kubernetes probes). Register
+    # engine-level health checkers so they can override a SERVING base
+    # status when they observe a stall the base status can't see.
+    # Specific checker implementations are wired up below as they apply.
+    health_checkers: list[HealthChecker] = []
     health_servicer = SGLangHealthServicer(
         request_manager=request_manager,
         scheduler_info=scheduler_info,
+        checkers=health_checkers,
     )
     health_pb2_grpc.add_HealthServicer_to_server(health_servicer, server)
 

--- a/grpc_servicer/tests/test_health_servicer.py
+++ b/grpc_servicer/tests/test_health_servicer.py
@@ -1,0 +1,251 @@
+"""Unit tests for SGLangHealthServicer's generic health-check registry.
+
+Covers the checker-agnostic plumbing: aggregation, fail-safe on exception,
+consecutive-failure escalation, transition-only logging, and the two
+service-name branches of Check(). Concrete checkers are tested in their
+own files.
+
+Stdlib-only (unittest + unittest.mock). Run with:
+    python -m unittest grpc_servicer.tests.test_health_servicer
+"""
+
+import asyncio
+import importlib.util
+import pathlib
+import sys
+import time
+import types
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from grpc_health.v1 import health_pb2
+
+# Import health_servicer directly by file path. The package __init__
+# imports servicer.py, which pulls in msgspec/sglang/etc. — heavy deps
+# that aren't needed for this unit test. Direct import keeps the test
+# runnable with only grpcio-health-checking available.
+_PKG_ROOT = pathlib.Path(__file__).resolve().parents[1] / "smg_grpc_servicer" / "sglang"
+
+
+def _load_module(module_name: str, file_path: pathlib.Path):
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _install_stub_packages() -> type:
+    """Register lightweight stubs for the smg_grpc_servicer package tree so
+    health_servicer's ``from smg_grpc_servicer.sglang.health_checks import
+    HealthChecker`` resolves without dragging in the real package __init__
+    (which imports msgspec/sglang).
+    """
+    base = _load_module("_smg_health_checks_base", _PKG_ROOT / "health_checks" / "base.py")
+    stub_pkg = types.ModuleType("smg_grpc_servicer")
+    stub_pkg.__path__ = []
+    stub_sglang = types.ModuleType("smg_grpc_servicer.sglang")
+    stub_sglang.__path__ = []
+    stub_health_checks = types.ModuleType("smg_grpc_servicer.sglang.health_checks")
+    stub_health_checks.HealthChecker = base.HealthChecker
+    sys.modules.setdefault("smg_grpc_servicer", stub_pkg)
+    sys.modules.setdefault("smg_grpc_servicer.sglang", stub_sglang)
+    sys.modules.setdefault("smg_grpc_servicer.sglang.health_checks", stub_health_checks)
+    return base.HealthChecker
+
+
+HealthChecker = _install_stub_packages()
+_servicer_module = _load_module("_smg_health_servicer_under_test", _PKG_ROOT / "health_servicer.py")
+SGLangHealthServicer = _servicer_module.SGLangHealthServicer
+
+
+class _FakeChecker:
+    """Minimal HealthChecker Protocol implementation for tests."""
+
+    def __init__(self, name, results=None, exc=None):
+        self.name = name
+        # results: callable returning the next result; or a fixed value.
+        self._results = results
+        self._exc = exc
+        self.call_count = 0
+
+    async def is_unhealthy(self):
+        self.call_count += 1
+        if self._exc is not None:
+            raise self._exc
+        if callable(self._results):
+            return self._results()
+        return self._results
+
+
+def _make_servicer(checkers=()):
+    request_manager = SimpleNamespace(
+        gracefully_exit=False,
+        last_receive_tstamp=time.time(),
+        rid_to_state={},
+    )
+    servicer = SGLangHealthServicer(
+        request_manager=request_manager,
+        scheduler_info={},
+        checkers=checkers,
+    )
+    # Check()'s checker branches run only after the base SERVING check passes.
+    servicer.set_serving()
+    return servicer, request_manager
+
+
+class AggregationTests(unittest.IsolatedAsyncioTestCase):
+    async def test_no_checkers_is_healthy(self):
+        servicer, _ = _make_servicer(checkers=[])
+        self.assertIsNone(await servicer._any_unhealthy_checker())
+
+    async def test_single_healthy_checker_returns_none(self):
+        c = _FakeChecker("scheduler_stall", results=None)
+        servicer, _ = _make_servicer(checkers=[c])
+        self.assertIsNone(await servicer._any_unhealthy_checker())
+        self.assertEqual(c.call_count, 1)
+
+    async def test_single_unhealthy_checker_returns_diagnostic(self):
+        c = _FakeChecker("scheduler_stall", results={"reason": "stuck for 10m"})
+        servicer, _ = _make_servicer(checkers=[c])
+        result = await servicer._any_unhealthy_checker()
+        self.assertEqual(result, ("scheduler_stall", {"reason": "stuck for 10m"}))
+
+    async def test_first_unhealthy_short_circuits(self):
+        """Subsequent checkers are not polled once one reports unhealthy."""
+        a = _FakeChecker("a", results={"why": "bad"})
+        b = _FakeChecker("b", results=None)
+        servicer, _ = _make_servicer(checkers=[a, b])
+        result = await servicer._any_unhealthy_checker()
+        self.assertEqual(result[0], "a")
+        self.assertEqual(a.call_count, 1)
+        self.assertEqual(b.call_count, 0)
+
+    async def test_all_healthy_returns_none(self):
+        a = _FakeChecker("a", results=None)
+        b = _FakeChecker("b", results=None)
+        servicer, _ = _make_servicer(checkers=[a, b])
+        self.assertIsNone(await servicer._any_unhealthy_checker())
+        self.assertEqual(a.call_count, 1)
+        self.assertEqual(b.call_count, 1)
+
+
+class FailSafeTests(unittest.IsolatedAsyncioTestCase):
+    async def test_checker_exception_is_swallowed(self):
+        """Exceptions do not propagate out of _any_unhealthy_checker."""
+        c = _FakeChecker("flaky", exc=RuntimeError("boom"))
+        servicer, _ = _make_servicer(checkers=[c])
+        self.assertIsNone(await servicer._any_unhealthy_checker())
+
+    async def test_exception_does_not_block_subsequent_checkers(self):
+        a = _FakeChecker("raises", exc=RuntimeError("boom"))
+        b = _FakeChecker("reports", results={"why": "bad"})
+        servicer, _ = _make_servicer(checkers=[a, b])
+        result = await servicer._any_unhealthy_checker()
+        self.assertEqual(result[0], "reports")
+
+    async def test_cancelled_error_propagates(self):
+        c = _FakeChecker("cancelled", exc=asyncio.CancelledError())
+        servicer, _ = _make_servicer(checkers=[c])
+        with self.assertRaises(asyncio.CancelledError):
+            await servicer._any_unhealthy_checker()
+
+    async def test_all_exceptions_do_not_flip_aggregate_state(self):
+        """Transient IPC outages shouldn't oscillate the aggregate state."""
+        c = _FakeChecker("flaky", exc=TimeoutError("slow"))
+        servicer, _ = _make_servicer(checkers=[c])
+        # Seed prior state as "unhealthy" to prove it's not reset to healthy
+        # by an all-raise cycle.
+        servicer._any_checker_unhealthy = True
+        self.assertIsNone(await servicer._any_unhealthy_checker())
+        self.assertTrue(servicer._any_checker_unhealthy)
+
+
+class FailureEscalationTests(unittest.IsolatedAsyncioTestCase):
+    async def test_failure_count_increments_and_resets_on_success(self):
+        """Escalation counter tracks consecutive failures per checker."""
+        fail_first = {"n": 3}
+
+        def results():
+            fail_first["n"] -= 1
+            if fail_first["n"] >= 0:
+                raise RuntimeError("boom")
+            return None
+
+        c = _FakeChecker("recoverer", results=results)
+        servicer, _ = _make_servicer(checkers=[c])
+
+        for _ in range(3):
+            await servicer._any_unhealthy_checker()
+        self.assertEqual(servicer._checker_failure_counts["recoverer"], 3)
+
+        # Successful call resets the counter.
+        await servicer._any_unhealthy_checker()
+        self.assertEqual(servicer._checker_failure_counts["recoverer"], 0)
+
+
+class TransitionLoggingTests(unittest.IsolatedAsyncioTestCase):
+    async def test_first_unhealthy_detection_updates_state(self):
+        c = _FakeChecker("a", results={"why": "bad"})
+        servicer, _ = _make_servicer(checkers=[c])
+        self.assertFalse(servicer._any_checker_unhealthy)
+        await servicer._any_unhealthy_checker()
+        self.assertTrue(servicer._any_checker_unhealthy)
+
+    async def test_recovery_clears_state(self):
+        calls = {"n": 0}
+
+        def results():
+            calls["n"] += 1
+            return {"why": "bad"} if calls["n"] == 1 else None
+
+        c = _FakeChecker("a", results=results)
+        servicer, _ = _make_servicer(checkers=[c])
+        await servicer._any_unhealthy_checker()
+        self.assertTrue(servicer._any_checker_unhealthy)
+        await servicer._any_unhealthy_checker()
+        self.assertFalse(servicer._any_checker_unhealthy)
+
+
+class CheckResponseTests(unittest.IsolatedAsyncioTestCase):
+    """End-to-end through Check() for both service-name branches."""
+
+    async def test_overall_server_not_serving_when_checker_unhealthy(self):
+        c = _FakeChecker("a", results={"why": "bad"})
+        servicer, _ = _make_servicer(checkers=[c])
+        request = health_pb2.HealthCheckRequest(service=SGLangHealthServicer.OVERALL_SERVER)
+        response = await servicer.Check(request, context=None)
+        self.assertEqual(response.status, health_pb2.HealthCheckResponse.NOT_SERVING)
+
+    async def test_overall_server_serving_when_all_healthy(self):
+        c = _FakeChecker("a", results=None)
+        servicer, _ = _make_servicer(checkers=[c])
+        request = health_pb2.HealthCheckRequest(service=SGLangHealthServicer.OVERALL_SERVER)
+        response = await servicer.Check(request, context=None)
+        self.assertEqual(response.status, health_pb2.HealthCheckResponse.SERVING)
+
+    async def test_sglang_service_not_serving_when_checker_unhealthy(self):
+        c = _FakeChecker("a", results={"why": "bad"})
+        servicer, _ = _make_servicer(checkers=[c])
+        request = health_pb2.HealthCheckRequest(service=SGLangHealthServicer.SGLANG_SERVICE)
+        response = await servicer.Check(request, context=None)
+        self.assertEqual(response.status, health_pb2.HealthCheckResponse.NOT_SERVING)
+
+    async def test_sglang_service_serving_when_no_checkers_registered(self):
+        """Empty registry preserves legacy behavior."""
+        servicer, _ = _make_servicer(checkers=[])
+        request = health_pb2.HealthCheckRequest(service=SGLangHealthServicer.SGLANG_SERVICE)
+        response = await servicer.Check(request, context=None)
+        self.assertEqual(response.status, health_pb2.HealthCheckResponse.SERVING)
+
+    async def test_unknown_service_returns_service_unknown(self):
+        servicer, _ = _make_servicer(checkers=[])
+        request = health_pb2.HealthCheckRequest(service="not.a.real.service")
+        context = Mock()
+        response = await servicer.Check(request, context=context)
+        self.assertEqual(response.status, health_pb2.HealthCheckResponse.SERVICE_UNKNOWN)
+        context.set_code.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/grpc_servicer/tests/test_prefill_bootstrap_queue_stalled.py
+++ b/grpc_servicer/tests/test_prefill_bootstrap_queue_stalled.py
@@ -1,0 +1,209 @@
+"""Unit tests for PrefillBootstrapQueueStalledChecker.
+
+The checker detects when a disaggregation-prefill engine's bootstrap
+queue is saturated with no forward progress — signature:
+``bootstrap >= limit AND inflight == 0 AND waiting == 0`` on any
+scheduler/DP rank. Cause-agnostic: any sub-system that stalls the
+bootstrap pipeline (transport failure, decoder backpressure, control-
+channel breakage, decoder OOM, etc.) produces this signature.
+
+Stdlib-only (unittest + unittest.mock). Run with:
+    python -m unittest grpc_servicer.tests.test_prefill_bootstrap_queue_stalled
+"""
+
+import importlib.util
+import pathlib
+import time
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+# Direct-import the checker module to avoid pulling sglang/msgspec.
+_PKG_ROOT = pathlib.Path(__file__).resolve().parents[1] / "smg_grpc_servicer" / "sglang"
+_spec = importlib.util.spec_from_file_location(
+    "_smg_prefill_bootstrap_queue_under_test",
+    _PKG_ROOT / "health_checks" / "prefill_bootstrap_queue.py",
+)
+_module = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_module)
+PrefillBootstrapQueueStalledChecker = _module.PrefillBootstrapQueueStalledChecker
+
+
+def _make_load(*, bootstrap, inflight, waiting, dp_rank=0):
+    """Build a load object that looks like GetLoadsReqOutput.
+
+    The checker reads prefill counts through ``.disaggregation`` and
+    computes the real waiting count as
+    ``num_waiting_reqs - prefill_prealloc_queue_reqs`` because sglang
+    includes the bootstrap queue in the waiting total on the prefill side.
+    """
+    return SimpleNamespace(
+        dp_rank=dp_rank,
+        num_waiting_reqs=bootstrap + waiting,
+        num_running_reqs=inflight,
+        disaggregation=SimpleNamespace(
+            prefill_prealloc_queue_reqs=bootstrap,
+            prefill_inflight_queue_reqs=inflight,
+        ),
+    )
+
+
+def _make_checker(*, mode, limit, loads_result=None, loads_side_effect=None):
+    request_manager = SimpleNamespace()
+    request_manager.get_loads = AsyncMock(return_value=loads_result, side_effect=loads_side_effect)
+    server_args = SimpleNamespace(disaggregation_mode=mode, max_queued_requests=limit)
+    return (
+        PrefillBootstrapQueueStalledChecker(
+            request_manager=request_manager, server_args=server_args
+        ),
+        request_manager,
+    )
+
+
+class ActivationGuardTests(unittest.IsolatedAsyncioTestCase):
+    async def test_non_disaggregation_mode_is_healthy(self):
+        """Monolithic (non-PD) servers must never trip the checker."""
+        checker, rm = _make_checker(mode="null", limit=16, loads_result=[])
+        self.assertIsNone(await checker.is_unhealthy())
+        rm.get_loads.assert_not_called()
+
+    async def test_decoder_mode_is_healthy(self):
+        """The stall signature is meaningful only for prefill-mode engines."""
+        checker, rm = _make_checker(mode="decode", limit=16, loads_result=[])
+        self.assertIsNone(await checker.is_unhealthy())
+        rm.get_loads.assert_not_called()
+
+    async def test_missing_max_queued_requests_is_healthy(self):
+        """Without a positive queue cap there's no 'at limit' condition."""
+        checker, _ = _make_checker(mode="prefill", limit=None, loads_result=[])
+        self.assertIsNone(await checker.is_unhealthy())
+
+        checker, _ = _make_checker(mode="prefill", limit=0, loads_result=[])
+        self.assertIsNone(await checker.is_unhealthy())
+
+
+class SignatureTests(unittest.IsolatedAsyncioTestCase):
+    async def test_idle_is_healthy(self):
+        loads = [_make_load(bootstrap=0, inflight=0, waiting=0)]
+        checker, _ = _make_checker(mode="prefill", limit=16, loads_result=loads)
+        self.assertIsNone(await checker.is_unhealthy())
+
+    async def test_busy_but_healthy_returns_none(self):
+        """Queue at cap but inflight > 0 means real work is flowing."""
+        loads = [_make_load(bootstrap=16, inflight=8, waiting=0)]
+        checker, _ = _make_checker(mode="prefill", limit=16, loads_result=loads)
+        self.assertIsNone(await checker.is_unhealthy())
+
+    async def test_stalled_returns_diagnostics(self):
+        """The exact stall pattern: slots full, zero flowing."""
+        loads = [_make_load(bootstrap=16, inflight=0, waiting=0, dp_rank=2)]
+        checker, _ = _make_checker(mode="prefill", limit=16, loads_result=loads)
+        result = await checker.is_unhealthy()
+        self.assertEqual(
+            result,
+            {"dp_rank": 2, "bootstrap": 16, "inflight": 0, "waiting": 0, "limit": 16},
+        )
+
+    async def test_boundary_below_limit_is_healthy(self):
+        """Bootstrap one under the limit must NOT trip — guards `bootstrap >= limit`."""
+        loads = [_make_load(bootstrap=15, inflight=0, waiting=0)]
+        checker, _ = _make_checker(mode="prefill", limit=16, loads_result=loads)
+        self.assertIsNone(await checker.is_unhealthy())
+
+    async def test_waiting_positive_is_healthy(self):
+        """Real main-queue wait > 0 means forward progress will happen.
+
+        Constructs ``num_waiting_reqs`` directly (not via _make_load) so
+        the ``waiting = max(0, num_waiting_reqs - bootstrap)`` subtraction
+        is actually exercised rather than baked into the fixture.
+        """
+        load = SimpleNamespace(
+            dp_rank=0,
+            num_waiting_reqs=20,
+            num_running_reqs=0,
+            disaggregation=SimpleNamespace(
+                prefill_prealloc_queue_reqs=16,
+                prefill_inflight_queue_reqs=0,
+            ),
+        )
+        checker, _ = _make_checker(mode="prefill", limit=16, loads_result=[load])
+        self.assertIsNone(await checker.is_unhealthy())
+
+
+class MultiDPTests(unittest.IsolatedAsyncioTestCase):
+    async def test_any_rank_stalled_trips_checker(self):
+        """Multi-DP: one stuck rank is enough — future requests to it will hang."""
+        loads = [
+            _make_load(bootstrap=4, inflight=2, waiting=0, dp_rank=0),
+            _make_load(bootstrap=16, inflight=0, waiting=0, dp_rank=1),
+        ]
+        checker, _ = _make_checker(mode="prefill", limit=16, loads_result=loads)
+        result = await checker.is_unhealthy()
+        self.assertEqual(result["dp_rank"], 1)
+
+    async def test_all_ranks_healthy_multi_dp_returns_none(self):
+        """Symmetric counterpart — pins the loop semantics."""
+        loads = [
+            _make_load(bootstrap=4, inflight=2, waiting=0, dp_rank=0),
+            _make_load(bootstrap=16, inflight=4, waiting=0, dp_rank=1),
+            _make_load(bootstrap=8, inflight=1, waiting=0, dp_rank=2),
+        ]
+        checker, _ = _make_checker(mode="prefill", limit=16, loads_result=loads)
+        self.assertIsNone(await checker.is_unhealthy())
+
+
+class IPCErrorPropagationTests(unittest.IsolatedAsyncioTestCase):
+    """The checker does NOT catch IPC errors; the servicer handles them centrally."""
+
+    async def test_ipc_runtime_error_propagates(self):
+        checker, _ = _make_checker(
+            mode="prefill", limit=16, loads_side_effect=RuntimeError("scheduler down")
+        )
+        with self.assertRaises(RuntimeError):
+            await checker.is_unhealthy()
+
+    async def test_ipc_timeout_propagates(self):
+        checker, _ = _make_checker(mode="prefill", limit=16, loads_side_effect=TimeoutError("slow"))
+        with self.assertRaises(TimeoutError):
+            await checker.is_unhealthy()
+
+
+class SchemaDriftCanaryTests(unittest.IsolatedAsyncioTestCase):
+    async def test_all_ranks_missing_disagg_warns_once(self):
+        """Schema-drift canary: non-empty loads with no `.disaggregation`."""
+        loads = [SimpleNamespace(dp_rank=0, num_waiting_reqs=0, num_running_reqs=0)]
+        checker, _ = _make_checker(mode="prefill", limit=16, loads_result=loads)
+
+        self.assertIsNone(await checker.is_unhealthy())
+        self.assertTrue(checker._warned_all_ranks_missing_disagg)
+
+        # Second call must not re-warn (latched).
+        self.assertIsNone(await checker.is_unhealthy())
+        self.assertTrue(checker._warned_all_ranks_missing_disagg)
+
+
+class TTLCacheTests(unittest.IsolatedAsyncioTestCase):
+    async def test_repeated_calls_within_ttl_hit_cache(self):
+        loads = [_make_load(bootstrap=16, inflight=0, waiting=0)]
+        checker, rm = _make_checker(mode="prefill", limit=16, loads_result=loads)
+
+        await checker.is_unhealthy()
+        await checker.is_unhealthy()
+        await checker.is_unhealthy()
+
+        self.assertEqual(rm.get_loads.call_count, 1)
+
+    async def test_call_after_ttl_expiry_refreshes(self):
+        loads = [_make_load(bootstrap=16, inflight=0, waiting=0)]
+        checker, rm = _make_checker(mode="prefill", limit=16, loads_result=loads)
+
+        await checker.is_unhealthy()
+        # Force expiry by rewinding the cache timestamp past the TTL.
+        checker._cache_ts = time.monotonic() - 10.0
+        await checker.is_unhealthy()
+
+        self.assertEqual(rm.get_loads.call_count, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

### Problem

The gRPC `Health.v1.Check` handler in `SGLangHealthServicer` today only reflects startup / shutdown flags. Many engine-level failure modes leave the process and gRPC server responsive while inference traffic is 100% rejected:

- dead scheduler threads
- KV-transfer pipeline deadlocks (any transport)
- decoder-side backpressure or OOM
- control-channel (ZMQ) breakage between prefill and decoder pods

In all of these cases both the SMG router and Kubernetes-native `grpc:` liveness probes see a SERVING response and keep sending traffic to an effectively dead pod. There's no hook today to teach the handler about these deeper failure signals.

### Solution

Two commits:

1. **`feat(grpc_servicer): extensible health-check registry for SGLangHealthServicer`** — carve out a `HealthChecker` protocol and let the servicer aggregate a sequence of registered checkers. Any one reporting unhealthy overrides a SERVING base status. Fail-safe on exception, consecutive-failure log escalation, transition-only state logging, cancellation propagation. No specific failure mode committed to.

2. **`feat(grpc_servicer): detect prefill bootstrap-queue stall via health registry`** — first concrete checker landing on top of the registry. Detects `bootstrap >= limit AND inflight == 0 AND waiting == 0` on any scheduler/DP rank of a disaggregation-prefill engine. Cause-agnostic signature: any sub-system that stalls the bootstrap pipeline (transport, decoder, control-channel, network) produces this pattern.

## Changes

### Commit 1 — Registry

**`grpc_servicer/smg_grpc_servicer/sglang/health_checks/base.py`** (new): `HealthChecker(Protocol)` with `name` + `async is_unhealthy() -> dict | None`. Returning `None` = healthy; returning a dict = unhealthy (dict is a free-form diagnostic payload); raising = "cannot determine" (servicer catches centrally).

**`grpc_servicer/smg_grpc_servicer/sglang/health_servicer.py`**: accepts `checkers: Sequence[HealthChecker]`. New `_any_unhealthy_checker()` helper iterates with first-wins semantics, per-checker consecutive-failure counters with escalating WARN logs (1/10/100/1000), `asyncio.CancelledError` explicit re-raise, aggregate state transitions logged exactly once on SERVING↔NOT_SERVING flips, all-exception cycles do not flip state.

**`grpc_servicer/smg_grpc_servicer/sglang/server.py`**: introduces `health_checkers: list[HealthChecker] = []` and threads it into `SGLangHealthServicer(checkers=...)`. No concrete checkers registered in this commit — back-compat preserved for non-PD and non-prefill engines.

**17 unit tests** covering aggregation, fail-safe, cancellation propagation, counter escalation/reset, transition logging, Check() end-to-end for both service-name branches, and SERVICE_UNKNOWN for unknown names.

### Commit 2 — Prefill stall checker

**`grpc_servicer/smg_grpc_servicer/sglang/health_checks/prefill_bootstrap_queue.py`** (new): `PrefillBootstrapQueueStalledChecker`. Active only when `server_args.disaggregation_mode == "prefill"` and `max_queued_requests > 0`. Reads queue state via existing `request_manager.get_loads(include=["disagg"])` — no sglang change required. Fields `prefill_prealloc_queue_reqs`, `prefill_inflight_queue_reqs`, `num_waiting_reqs` are already exposed. 1s TTL cache to absorb K8s/router probe rates. Hard `asyncio.wait_for(5s)` IPC timeout so a wedged scheduler can't hang the probe handler. Schema-drift canary (one-shot WARN) if load replies arrive but no rank exposes the disaggregation struct — catches renames or a misconfigured `include=` that would otherwise silently disable the checker.

**`server.py`**: conditionally registers the checker when the engine is in prefill mode with a configured queue cap. Misconfiguration (prefill mode + missing `max_queued_requests`) remains visible because the startup registry log lists 0 checkers registered.

**15 unit tests** covering activation guards, signature (idle / busy-healthy / stalled / `bootstrap==limit-1` boundary / `waiting > 0`), multi-DP semantics, IPC error propagation, schema-drift canary, TTL cache.

## Test Plan

All 32 stdlib-only unittest cases (17 registry + 15 checker) pass locally:

```
$ cd grpc_servicer && python -m unittest tests.test_health_servicer tests.test_prefill_bootstrap_queue_stalled
Ran 32 tests in 0.021s
OK
```

Pre-commit clean on all touched files:

```
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
codespell................................................................Passed
```

### End-to-end validation (separate follow-up)

Planned verification on a real PD-disaggregated deployment:

1. Deploy an image built from this branch.
2. Configure the prefill pod's K8s `livenessProbe` as `grpc:` on port 30000.
3. Force a bootstrap-pipeline stall (e.g. `iptables` DROP on the RDMA path, or decoder-side resource starvation) and confirm: (a) `Check()` flips to NOT_SERVING within the TTL, (b) kubelet restarts the pod within `periodSeconds * failureThreshold`, (c) no restarts occur in the steady-state busy-healthy case.

## Future checkers

The registry intentionally keeps the door open for additional engine-level predicates without touching the servicer. Candidates seen in production:

- `scheduler_stall` — `rid_to_state` non-empty + last scheduler heartbeat > N seconds
- `decoder_mem_pressure` — KV cache high-water eviction rate above threshold
- `worker_rank_missing` — expected DP rank count vs observed

Each would ship as its own checker + test file + optional registration guard.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes (no Rust changes)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (no Rust changes)
- [x] Python: `ruff` and `ruff format` clean
- [x] Unit tests passing (32/32)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>