### PR TITLE
fix(protocol): honor OpenAI-style `reasoning: {enabled: bool}` on /v1/chat/completions

### DIFF
--- a/crates/protocols/src/chat.rs
+++ b/crates/protocols/src/chat.rs
@@ -136,6 +136,35 @@ impl MessageContent {
 }
 
 // ============================================================================
+// Reasoning Configuration (OpenAI-style)
+// ============================================================================
+
+/// Configuration for reasoning models on the Chat Completions API.
+///
+/// OpenAI clients send this as ``{"reasoning": {"enabled": bool}}`` to
+/// explicitly toggle thinking for reasoning-capable models such as
+/// Kimi-K2.5 or Qwen3.  The value is mapped to ``chat_template_kwargs``
+/// (``enable_thinking`` / ``thinking``) by ``ChatCompletionRequest::
+/// normalize()`` so the chat template sees the caller's intent.
+///
+/// Without this struct, serde silently drops the field and reasoning
+/// models think by default -- inflating output sequence length on
+/// traffic that explicitly disabled it.
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct ReasoningConfig {
+    /// Whether reasoning / thinking should run for this request.
+    pub enabled: bool,
+
+    /// Optional effort hint (``low`` / ``medium`` / ``high``).  Migrated
+    /// to the top-level ``reasoning_effort`` field by ``normalize()``
+    /// (which is the field ``chat_utils.rs`` forwards to the chat
+    /// template).  The top-level ``reasoning_effort`` wins when both
+    /// are set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effort: Option<String>,
+}
+
+// ============================================================================
 // Chat Completion Request
 // ============================================================================
 
@@ -200,6 +229,12 @@ pub struct ChatCompletionRequest {
 
     /// Effort level for reasoning models (low, medium, high)
     pub reasoning_effort: Option<String>,
+
+    /// OpenAI-style reasoning config, e.g. ``{"reasoning": {"enabled": false}}``.
+    /// Mapped to ``chat_template_kwargs`` (``enable_thinking`` /
+    /// ``thinking``) by ``normalize()`` so reasoning-capable chat
+    /// templates (Kimi-K2.5, Qwen3, etc.) respect the caller's intent.
+    pub reasoning: Option<ReasoningConfig>,
 
     /// An object specifying the format that the model must output
     pub response_format: Option<ResponseFormat>,
@@ -567,6 +602,23 @@ impl Normalizable for ChatCompletionRequest {
             self.function_call = None; // Clear deprecated field
         }
 
+        // Migrate OpenAI-style ``reasoning`` → ``chat_template_kwargs``
+        // and top-level ``reasoning_effort``.  ``.or_insert()`` preserves
+        // values the caller set directly, so the top-level
+        // ``reasoning_effort`` field wins over ``reasoning.effort``.
+        if let Some(ref reasoning) = self.reasoning {
+            let kwargs = self.chat_template_kwargs.get_or_insert_with(HashMap::new);
+            kwargs
+                .entry("enable_thinking".to_string())
+                .or_insert(Value::Bool(reasoning.enabled));
+            kwargs
+                .entry("thinking".to_string())
+                .or_insert(Value::Bool(reasoning.enabled));
+            if let Some(ref effort) = reasoning.effort {
+                self.reasoning_effort.get_or_insert_with(|| effort.clone());
+            }
+        }
+
         // Apply tool_choice defaults
         if self.tool_choice.is_none() {
             if let Some(tools) = &self.tools {
@@ -751,4 +803,111 @@ pub struct ChatStreamChoice {
     pub finish_reason: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub matched_stop: Option<Value>,
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Round-trip JSON body through serde + Normalizable; return the
+    /// resulting ``chat_template_kwargs``.  Exercises both the field's
+    /// presence on ``ChatCompletionRequest`` (so it isn't silently
+    /// dropped by serde) and the migration in ``normalize()``.
+    fn normalize_and_get_kwargs(body: &str) -> HashMap<String, Value> {
+        let mut req: ChatCompletionRequest =
+            serde_json::from_str(body).expect("valid request JSON");
+        req.normalize();
+        req.chat_template_kwargs.unwrap_or_default()
+    }
+
+    #[test]
+    fn reasoning_enabled_false_sets_kwargs() {
+        let kwargs = normalize_and_get_kwargs(
+            r#"{"model":"m","messages":[],"reasoning":{"enabled":false}}"#,
+        );
+        assert_eq!(kwargs.get("enable_thinking"), Some(&Value::Bool(false)));
+        assert_eq!(kwargs.get("thinking"), Some(&Value::Bool(false)));
+    }
+
+    #[test]
+    fn reasoning_enabled_true_sets_kwargs() {
+        let kwargs =
+            normalize_and_get_kwargs(r#"{"model":"m","messages":[],"reasoning":{"enabled":true}}"#);
+        assert_eq!(kwargs.get("enable_thinking"), Some(&Value::Bool(true)));
+        assert_eq!(kwargs.get("thinking"), Some(&Value::Bool(true)));
+    }
+
+    #[test]
+    fn reasoning_field_without_enabled_is_rejected() {
+        // Verify the ``enabled`` key is required; serde should surface
+        // a deserialization error rather than silently accepting {}.
+        let err = serde_json::from_str::<ChatCompletionRequest>(
+            r#"{"model":"m","messages":[],"reasoning":{}}"#,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("enabled"),
+            "expected error about missing `enabled`, got: {err}"
+        );
+    }
+
+    #[test]
+    fn reasoning_effort_migrates_to_top_level() {
+        // ``reasoning.effort`` MUST populate ``request.reasoning_effort``
+        // because the chat_utils consumer reads only the top-level field
+        // when forwarding to the chat template.  Without this, setting
+        // ``reasoning.effort`` would be silently dropped downstream.
+        let mut req: ChatCompletionRequest = serde_json::from_str(
+            r#"{"model":"m","messages":[],"reasoning":{"enabled":true,"effort":"low"}}"#,
+        )
+        .unwrap();
+        assert!(req.reasoning_effort.is_none());
+        req.normalize();
+        assert_eq!(req.reasoning_effort.as_deref(), Some("low"));
+    }
+
+    #[test]
+    fn top_level_reasoning_effort_wins_over_reasoning_effort() {
+        // Precedence: explicit top-level ``reasoning_effort`` is more
+        // specific and wins when both are sent.
+        let mut req: ChatCompletionRequest = serde_json::from_str(
+            r#"{
+                "model":"m","messages":[],
+                "reasoning_effort":"high",
+                "reasoning":{"enabled":true,"effort":"low"}
+            }"#,
+        )
+        .unwrap();
+        req.normalize();
+        assert_eq!(req.reasoning_effort.as_deref(), Some("high"));
+    }
+
+    #[test]
+    fn no_reasoning_field_leaves_kwargs_untouched() {
+        let mut req: ChatCompletionRequest =
+            serde_json::from_str(r#"{"model":"m","messages":[]}"#).unwrap();
+        assert!(req.reasoning.is_none());
+        req.normalize();
+        assert!(req.chat_template_kwargs.is_none());
+    }
+
+    #[test]
+    fn explicit_chat_template_kwargs_wins_over_reasoning() {
+        // ``.or_insert()`` contract: explicit operator overrides via
+        // ``chat_template_kwargs`` directly are preserved even when a
+        // reasoning field is also present.
+        let kwargs = normalize_and_get_kwargs(
+            r#"{
+                "model":"m","messages":[],
+                "reasoning":{"enabled":false},
+                "chat_template_kwargs":{"enable_thinking":true,"thinking":true}
+            }"#,
+        );
+        assert_eq!(kwargs.get("enable_thinking"), Some(&Value::Bool(true)));
+        assert_eq!(kwargs.get("thinking"), Some(&Value::Bool(true)));
+    }
 }


### PR DESCRIPTION

OpenAI clients send

    {"reasoning": {"enabled": false}}

on `/v1/chat/completions` to explicitly skip thinking for reasoning- capable models.  SMG had no matching struct field (the existing `reasoning_effort: Option<String>` only covers the sibling `effort` key), so serde silently dropped the object.

Downstream, the Kimi-K2.5 chat template defaults to injecting `<think>` and the model kept producing thinking tokens on traffic that had explicitly disabled reasoning.  This was the root cause of the SMG+TRT vs TGL output-sequence-length gap flagged during shadow traffic investigation (Peter Kim, OSL thread).

```rust
pub struct ChatCompletionRequest {
    pub reasoning_effort: Option<String>,  // only the effort string
    // ...no `reasoning: {enabled}` field...
}
```

With `#[serde(deny_unknown_fields)]` off (we keep OpenAI-compatible forward compatibility) the entire `reasoning` object was discarded.

- Add a new `ReasoningConfig { enabled: bool, effort: Option<String> }` type in `chat.rs`, colocated with its only use site.
- Add `reasoning: Option<ReasoningConfig>` on `ChatCompletionRequest`.
- In `Normalizable::normalize`, migrate it into `chat_template_kwargs` (`enable_thinking` / `thinking`).  `.or_insert()` leaves any value operators have placed in `chat_template_kwargs` directly untouched.

- Only the OpenAI Chat Completions API.  The Anthropic Messages API (`CreateMessageRequest`) has its own first-class `thinking` field already; the Responses API has `ResponseReasoningParam` already.
- No wrapper/delegation changes required: `Normalizable` is only implemented on `ChatCompletionRequest`, and `chat_template_kwargs` flows verbatim to the gRPC backend.

- 6 new unit tests in `chat.rs`:
  - `reasoning: {enabled: false}` sets `enable_thinking=false`
  - `reasoning: {enabled: true}` sets `enable_thinking=true`
  - `reasoning: {}` (missing `enabled`) is rejected by serde
  - `reasoning: {enabled: true, effort: "low"}` parses effort
  - No `reasoning` field leaves `chat_template_kwargs` untouched
  - Explicit `chat_template_kwargs` wins over `reasoning`
- `cargo test -p openai-protocol --lib` -> 61 passed
- `cargo clippy -p openai-protocol --all-features -- -D warnings` -> clean
- `cargo +nightly fmt --all` -> no diff
- End-to-end against SMG+TRT tp=4, Kimi-K2.5-NVFP4:

    # before fix (field silently dropped by serde)
    reasoning.enabled=false -> 54 completion tokens, reasoning_content populated

    # after fix
    reasoning.enabled=false -> 1 completion token, reasoning_content=''
    no `reasoning` field    -> 48 completion tokens (Kimi default thinking on)
    reasoning.enabled=true  -> 48 completion tokens

## Description

### Problem

<!-- What problem is this PR trying to solve? -->

### Solution

<!-- How does this PR solve the problem? -->

## Changes

<!-- - Describe your changes here. -->

## Test Plan

<!-- Provide a thorough reproducible test showing before and after behavior. -->

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reasoning configuration for chat completion requests, allowing users to enable/disable reasoning and optionally configure effort levels.

* **Tests**
  * Added unit tests validating reasoning configuration handling, including configuration precedence and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->