### PR TITLE
fix(e2e): pin oracle-custom schema to latest migration

### DIFF
--- a/scripts/oracle_flyway/schema-config.yaml
+++ b/scripts/oracle_flyway/schema-config.yaml
@@ -1,5 +1,10 @@
 # SMG SchemaConfig for genai-data-plane Oracle tables (Flyway-managed)
-version: 3
+#
+# This schema is owned by Flyway, so the gateway must not try to apply its own
+# forward migrations during e2e startup. Keep this pinned to the latest router
+# migration version unless the Flyway-managed schema begins exercising those
+# new tables directly.
+version: 8
 auto_migrate: false
 
 conversations:


### PR DESCRIPTION
## Description

### Problem

The `oracle-custom` e2e path launches the gateway with the Flyway-managed Oracle schema config pinned to `version: 3`.

After the recent skills migrations raised the router-side latest schema version to `8`, gateway startup now fails before the tests run with:

`Schema migration required (current version: 3, latest version: 8)`

This breaks Oracle-backed Responses e2e tests even though that Flyway-managed schema path is not trying to exercise the new skills tables.

Refs: #1176

### Solution

Pin the Flyway-managed Oracle schema config to `version: 8` while keeping `auto_migrate: false`.

That keeps the `oracle-custom` test path non-migrating and prevents the gateway from trying to apply router-managed migrations during e2e startup.

## Changes

- update `scripts/oracle_flyway/schema-config.yaml` from `version: 3` to `version: 8`
- add a comment explaining why the Flyway-managed schema should stay pinned to the router's latest migration version unless that schema begins using the new tables directly

## Test Plan

- Reproduced the failure from CI logs: `Schema migration required (current version: 3, latest version: 8)` during `oracle-custom` gateway startup
- Did not run the Oracle e2e suite locally because it requires the external `oracle-custom` / Flyway / ATP environment used in CI
- Expected verification is a rerun of the failing `oracle-custom` Responses e2e job

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database schema configuration version to maintain compatibility and ensure proper migration handling during application startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->