### PR TITLE
feat(protocols): P4 IncludeField web_search_call variants

### DIFF
--- a/crates/protocols/src/responses.rs
+++ b/crates/protocols/src/responses.rs
@@ -534,6 +534,10 @@ pub enum IncludeField {
     MessageOutputTextLogprobs,
     #[serde(rename = "reasoning.encrypted_content")]
     ReasoningEncryptedContent,
+    #[serde(rename = "web_search_call.action.sources")]
+    WebSearchCallActionSources,
+    #[serde(rename = "web_search_call.results")]
+    WebSearchCallResults,
 }
 
 // ============================================================================
@@ -1684,6 +1688,29 @@ mod tests {
                     "tool_names": ["ask_question", "read_wiki_structure"]
                 }
             })
+        );
+    }
+
+    #[test]
+    fn test_include_field_web_search_call_variants_round_trip() {
+        let fields: Vec<IncludeField> = serde_json::from_value(json!([
+            "web_search_call.action.sources",
+            "web_search_call.results",
+        ]))
+        .expect("include fields should deserialize");
+
+        assert_eq!(
+            fields,
+            vec![
+                IncludeField::WebSearchCallActionSources,
+                IncludeField::WebSearchCallResults,
+            ]
+        );
+
+        let serialized = serde_json::to_value(&fields).expect("include fields should serialize");
+        assert_eq!(
+            serialized,
+            json!(["web_search_call.action.sources", "web_search_call.results"])
         );
     }
 }


### PR DESCRIPTION
## Summary

Adds the two missing `web_search_call.*` variants to `IncludeField` in `crates/protocols/src/responses.rs`, bringing smg's Responses API top-level `include` enum to full spec parity (6 → 8 variants).

## What changed

`crates/protocols/src/responses.rs` (+27 / -0, single file):
- Added `IncludeField::WebSearchCallActionSources` with `#[serde(rename = "web_search_call.action.sources")]`.
- Added `IncludeField::WebSearchCallResults` with `#[serde(rename = "web_search_call.results")]`.
- Added `responses::tests::test_include_field_web_search_call_variants_round_trip` mirroring the existing `test_require_approval_*_round_trip` style: deserializes both spec strings into a `Vec<IncludeField>`, then re-serializes and asserts byte-identity.

No other files touched. No `Cargo.toml` / `Cargo.lock` changes.

## Why

OpenAI Responses API specifies 8 allowed values for the top-level `include` array (see `openai-responses-api-spec.md` §Create a model response / `include`, lines 71-79):

> Allowed values:
> - `"file_search_call.results"`
> - `"web_search_call.results"`            ← was missing
> - `"web_search_call.action.sources"`     ← was missing
> - `"message.input_image.image_url"`
> - `"computer_call_output.output.image_url"`
> - `"code_interpreter_call.outputs"`
> - `"reasoning.encrypted_content"`
> - `"message.output_text.logprobs"`

Prior to this change `IncludeField` modelled only 6 variants. Spec-valid payloads that set `include: ["web_search_call.results"]` or `include: ["web_search_call.action.sources"]` failed deserialization into `Option<Vec<IncludeField>>`, returning a 400-shaped error on otherwise-compliant clients. This also blocked audit task T3 (non-preview `web_search` tool), which depends on P4 landing first.

## Verification

- `cargo check -p openai-protocol` — green.
- `cargo test -p openai-protocol` — 83 tests pass, 0 failures. Includes the new round-trip test which deserializes `["web_search_call.action.sources", "web_search_call.results"]` into the new variants and asserts byte-identical re-serialization.
- `cargo clippy -p openai-protocol --all-targets --all-features -- -D warnings` — green.
- `cargo +nightly fmt --all -- --check` — clean.
- Tech Lead independent hand-built scratch test (outside the repo) round-tripped all 8 spec allowed-values through `serde_json::from_value` → `IncludeField` → `serde_json::to_value` and verified byte-identity per value; includes the 6 pre-existing variants, confirming zero regression on previously working wire values.
- Appendix A greps:
  - `grep -rn 'match.*IncludeField' crates/ model_gateway/ bindings/ e2e_test/` → zero hits. No exhaustive match needs updating.
  - `grep -rn 'IncludeField::' crates/ model_gateway/ bindings/ e2e_test/` → 4 hits total, all construction or `.contains(&IncludeField::…)`, all additive-safe.
  - `grep -rn 'IncludeField' bindings/` → zero. No Python/Go mirror to sync; wire values flow through JSON.
- Tech Lead verdict: APPROVE. Codex: unavailable in this environment (advisory reviewer not reachable from the harness); proceeded solo under playbook STEP 4 fallback because all checks passed independently.

## Blast radius

- **Touched:** `crates/protocols/src/responses.rs` only. Single file, purely additive.
- **Not touched (intentional):** `model_gateway/src/routers/grpc/common/responses/streaming.rs`, `model_gateway/src/routers/openai/responses/utils.rs`. The P4 audit entry's "Desired" prose suggested threading the new variants through these routers so opting in returns the data; verified those files currently have zero `IncludeField` consumption, so no compilation break. Actual gating/wiring of `web_search_call.results` and `web_search_call.action.sources` payloads in streaming / final-response rendering is owned by T3 (`web_search` non-preview), which the audit explicitly calls out as the dependent task.

## Out of scope

- T3-track plumbing of the new variants through the gRPC streaming pipeline and the OpenAI Responses rendering path. P4 is the protocol-additions unblocker; T3 owns the routing behavior.
- The other 6 `IncludeField` variants are untouched and pre-existed on `main`.

Refs: P4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new response field options for web search call data, including action sources and results.

* **Tests**
  * Added unit tests verifying JSON serialization and deserialization for new response fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->