### PR TITLE
fix(protocols): Reasoning.summary uses SummaryTextContent (spec wire-shape)

### DIFF
--- a/crates/protocols/src/responses.rs
+++ b/crates/protocols/src/responses.rs
@@ -186,7 +186,7 @@ pub enum ResponseInputOutputItem {
     #[non_exhaustive]
     Reasoning {
         id: String,
-        summary: Vec<String>,
+        summary: Vec<SummaryTextContent>,
         #[serde(skip_serializing_if = "Vec::is_empty")]
         #[serde(default)]
         content: Vec<ResponseReasoningContent>,
@@ -270,6 +270,19 @@ pub enum ResponseReasoningContent {
     ReasoningText { text: String },
 }
 
+/// Tagged content element carried in `Reasoning.summary`.
+///
+/// OpenAI spec: `summary: array of SummaryTextContent { text, type: "summary_text" }`.
+/// Replaces the prior `Vec<String>` wire-type that broke bidirectional
+/// interoperability with spec-compliant clients.
+#[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
+#[serde(tag = "type")]
+#[serde(rename_all = "snake_case")]
+pub enum SummaryTextContent {
+    #[serde(rename = "summary_text")]
+    SummaryText { text: String },
+}
+
 /// MCP Tool information for the mcp_list_tools output item
 #[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
@@ -296,7 +309,7 @@ pub enum ResponseOutputItem {
     #[non_exhaustive]
     Reasoning {
         id: String,
-        summary: Vec<String>,
+        summary: Vec<SummaryTextContent>,
         content: Vec<ResponseReasoningContent>,
         /// Encrypted reasoning payload for gpt-5 / o-series round-trip.
         /// Opaque to SMG; preserved verbatim.
@@ -1452,7 +1465,7 @@ impl ResponseInputOutputItem {
     /// o-series encrypted reasoning.
     pub fn new_reasoning(
         id: String,
-        summary: Vec<String>,
+        summary: Vec<SummaryTextContent>,
         content: Vec<ResponseReasoningContent>,
         status: Option<String>,
     ) -> Self {
@@ -1470,7 +1483,7 @@ impl ResponseInputOutputItem {
     /// ciphertext.
     pub fn new_reasoning_encrypted(
         id: String,
-        summary: Vec<String>,
+        summary: Vec<SummaryTextContent>,
         content: Vec<ResponseReasoningContent>,
         encrypted_content: String,
         status: Option<String>,
@@ -1508,7 +1521,7 @@ impl ResponseOutputItem {
     /// encrypted reasoning.
     pub fn new_reasoning(
         id: String,
-        summary: Vec<String>,
+        summary: Vec<SummaryTextContent>,
         content: Vec<ResponseReasoningContent>,
         status: Option<String>,
     ) -> Self {
@@ -1528,7 +1541,7 @@ impl ResponseOutputItem {
     /// without ciphertext should use [`Self::new_reasoning`] instead.
     pub fn new_reasoning_encrypted(
         id: String,
-        summary: Vec<String>,
+        summary: Vec<SummaryTextContent>,
         content: Vec<ResponseReasoningContent>,
         encrypted_content: String,
         status: Option<String>,
@@ -1589,6 +1602,37 @@ mod tests {
     use serde_json::json;
 
     use super::*;
+
+    #[test]
+    fn summary_text_content_round_trips_spec_shape() {
+        // Spec: `summary: array of SummaryTextContent { text, type: "summary_text" }`.
+        let item: ResponseOutputItem = serde_json::from_value(json!({
+            "type": "reasoning",
+            "id": "r_1",
+            "summary": [{"text": "step 1", "type": "summary_text"}],
+            "content": [],
+            "status": "completed",
+        }))
+        .expect("spec-shape reasoning should deserialize");
+
+        match &item {
+            ResponseOutputItem::Reasoning { summary, .. } => {
+                assert_eq!(summary.len(), 1);
+                match &summary[0] {
+                    SummaryTextContent::SummaryText { text } => {
+                        assert_eq!(text, "step 1");
+                    }
+                }
+            }
+            _ => panic!("expected Reasoning variant"),
+        }
+
+        let v = serde_json::to_value(&item).expect("serialize");
+        assert_eq!(
+            v["summary"],
+            json!([{"text": "step 1", "type": "summary_text"}])
+        );
+    }
 
     #[test]
     fn test_responses_request_omitted_top_p_deserializes_to_none() {

--- a/crates/protocols/tests/background_mode_protocol.rs
+++ b/crates/protocols/tests/background_mode_protocol.rs
@@ -17,7 +17,7 @@
 
 use openai_protocol::responses::{
     ResponseInputOutputItem, ResponseOutputItem, ResponseReasoningContent, ResponseStatus,
-    ResponsesRequest, ResponsesResponse,
+    ResponsesRequest, ResponsesResponse, SummaryTextContent,
 };
 use serde_json::json;
 
@@ -42,7 +42,9 @@ fn response_status_incomplete_serializes_snake_case() {
 fn reasoning_output_item_round_trips_encrypted_content() {
     let item = ResponseOutputItem::new_reasoning_encrypted(
         "r_1".to_string(),
-        vec!["thought summary".to_string()],
+        vec![SummaryTextContent::SummaryText {
+            text: "thought summary".to_string(),
+        }],
         vec![ResponseReasoningContent::ReasoningText {
             text: "inner thought".to_string(),
         }],


### PR DESCRIPTION
## Summary

Fix a hard bidirectional wire-format break on `Reasoning.summary`. The OpenAI
Responses API spec defines the field as an array of `SummaryTextContent`
objects, but smg previously serialized/deserialized as `Vec<String>`. Outgoing
payloads failed spec-compliant parsers; incoming spec-valid requests failed smg
deserialization at the `Vec<String>` boundary.

## What changed

- `crates/protocols/src/responses.rs`
  - New `SummaryTextContent` tagged enum (`#[serde(tag = "type")]`) with a
    single `SummaryText { text }` variant, renamed to `"summary_text"` on the
    wire.
  - `summary: Vec<String>` changed to `summary: Vec<SummaryTextContent>` on
    both `ResponseInputOutputItem::Reasoning` and
    `ResponseOutputItem::Reasoning`.
  - Four `new_reasoning` / `new_reasoning_encrypted` constructor signatures
    updated to take `Vec<SummaryTextContent>`.
  - New `#[cfg(test)]` round-trip `summary_text_content_round_trips_spec_shape`
    that deserializes `{"text":"step 1","type":"summary_text"}` and
    re-serializes byte-identically.
- `crates/protocols/tests/background_mode_protocol.rs`
  - Forced-compile edit: the existing encrypted-reasoning roundtrip test
    constructs a `SummaryTextContent::SummaryText` instead of a raw string so
    the new signature compiles.

## Why

Spec (OpenAI Responses API):

> **Reasoning** `object { id, summary, type, content, encrypted_content, status }`
> - `summary: array of SummaryTextContent { text, type: "summary_text" }`
> - `type: "reasoning"`

The previous `Vec<String>` shape was bidirectionally incompatible with every
spec-compliant OpenAI Responses API client. Fixing the wire type is
non-optional for interop.

## Verification

- `CARGO_TARGET_DIR=/tmp/p8-target cargo +nightly fmt --all -- --check` —
  clean.
- `CARGO_TARGET_DIR=/tmp/p8-target cargo clippy --all-targets --all-features
  -- -D warnings` — clean.
- `CARGO_TARGET_DIR=/tmp/p8-target cargo test -p openai-protocol` — 18 unit
  + 8 `background_mode_protocol` integration tests green, including the new
  spec-shape roundtrip.
- `CARGO_TARGET_DIR=/tmp/p8-target cargo check --workspace` — clean (confirms
  all five existing gRPC router call sites that build reasoning items with
  `vec![]` still compile under the new `Vec<SummaryTextContent>` signature via
  type inference).
- Tech-lead hand-built byte-on-the-wire fixtures (scratch test, not
  committed) confirmed: spec shape round-trips byte-identical; emitted JSON
  contains exactly `{text, type}` with `type == "summary_text"`; old
  `Vec<String>` shape is rejected (no silent compat shim).

Isolated `CARGO_TARGET_DIR` used throughout to avoid cross-worktree target
contamination.

## Blast radius

- Wire-format break by design: any caller/consumer still expecting
  `Vec<String>` will break, which is the correct behavior for spec conformance.
- All five in-tree call sites (`model_gateway/src/routers/grpc/{regular,harmony}/...`)
  pass empty `vec![]` and re-type-infer cleanly; no router edits needed.
- No Python or Go binding mirrors exist for `Reasoning` (verified via grep on
  `bindings/`); no binding edits needed.
- History persistence (`model_gateway/src/routers/openai/responses/history.rs`)
  does not currently store non-empty reasoning summaries, and the one raw
  `json!("summary": [])` emission in `grpc/common/responses/streaming.rs:722`
  is already an empty array that is valid under both old and new schemas.
  No migration shim required for current stored shape.

## Out of scope

- Adding a `#[serde(deserialize_with = ...)]` shim that accepts old
  `Vec<String>` as input for backwards compatibility — deferred; current
  storage does not require it and the audit lists it as optional ("if there's
  stored data"). Can be added in a follow-up if a concrete migration need
  arises.
- Expanding `SummaryTextContent` with additional variants — the spec's union
  currently has exactly one variant; leave the enum shape future-proof but
  don't speculate on unspecified types.

Refs: P8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the structure of reasoning summaries in API responses to use a typed content format instead of plain string values.

* **Tests**
  * Added test validation for reasoning summary serialization and deserialization with the updated structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->