### PR TITLE
fix(protocols): implement P8 Reasoning.summary SummaryTextContent

### DIFF
--- a/crates/protocols/src/responses.rs
+++ b/crates/protocols/src/responses.rs
@@ -186,6 +186,7 @@ pub enum ResponseInputOutputItem {
     #[non_exhaustive]
     Reasoning {
         id: String,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
         summary: Vec<SummaryTextContent>,
         #[serde(skip_serializing_if = "Vec::is_empty")]
         #[serde(default)]
@@ -309,6 +310,7 @@ pub enum ResponseOutputItem {
     #[non_exhaustive]
     Reasoning {
         id: String,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
         summary: Vec<SummaryTextContent>,
         content: Vec<ResponseReasoningContent>,
         /// Encrypted reasoning payload for gpt-5 / o-series round-trip.
@@ -1631,6 +1633,16 @@ mod tests {
         assert_eq!(
             v["summary"],
             json!([{"text": "step 1", "type": "summary_text"}])
+        );
+    }
+
+    #[test]
+    fn legacy_vec_string_summary_fails_to_deserialize() {
+        let legacy = r#"{"type":"reasoning","id":"r_x","summary":["text"]}"#;
+        let result: Result<ResponseInputOutputItem, _> = serde_json::from_str(legacy);
+        assert!(
+            result.is_err(),
+            "legacy Vec<String> summary must no longer deserialize"
         );
     }
 

--- a/crates/protocols/src/responses.rs
+++ b/crates/protocols/src/responses.rs
@@ -186,7 +186,7 @@ pub enum ResponseInputOutputItem {
     #[non_exhaustive]
     Reasoning {
         id: String,
-        summary: Vec<String>,
+        summary: Vec<SummaryTextContent>,
         #[serde(skip_serializing_if = "Vec::is_empty")]
         #[serde(default)]
         content: Vec<ResponseReasoningContent>,
@@ -270,6 +270,19 @@ pub enum ResponseReasoningContent {
     ReasoningText { text: String },
 }
 
+/// Tagged content element carried in `Reasoning.summary`.
+///
+/// OpenAI spec: `summary: array of SummaryTextContent { text, type: "summary_text" }`.
+/// Replaces the prior `Vec<String>` wire-type that broke bidirectional
+/// interoperability with spec-compliant clients.
+#[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
+#[serde(tag = "type")]
+#[serde(rename_all = "snake_case")]
+pub enum SummaryTextContent {
+    #[serde(rename = "summary_text")]
+    SummaryText { text: String },
+}
+
 /// MCP Tool information for the mcp_list_tools output item
 #[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
@@ -296,7 +309,7 @@ pub enum ResponseOutputItem {
     #[non_exhaustive]
     Reasoning {
         id: String,
-        summary: Vec<String>,
+        summary: Vec<SummaryTextContent>,
         content: Vec<ResponseReasoningContent>,
         /// Encrypted reasoning payload for gpt-5 / o-series round-trip.
         /// Opaque to SMG; preserved verbatim.
@@ -1452,7 +1465,7 @@ impl ResponseInputOutputItem {
     /// o-series encrypted reasoning.
     pub fn new_reasoning(
         id: String,
-        summary: Vec<String>,
+        summary: Vec<SummaryTextContent>,
         content: Vec<ResponseReasoningContent>,
         status: Option<String>,
     ) -> Self {
@@ -1470,7 +1483,7 @@ impl ResponseInputOutputItem {
     /// ciphertext.
     pub fn new_reasoning_encrypted(
         id: String,
-        summary: Vec<String>,
+        summary: Vec<SummaryTextContent>,
         content: Vec<ResponseReasoningContent>,
         encrypted_content: String,
         status: Option<String>,
@@ -1508,7 +1521,7 @@ impl ResponseOutputItem {
     /// encrypted reasoning.
     pub fn new_reasoning(
         id: String,
-        summary: Vec<String>,
+        summary: Vec<SummaryTextContent>,
         content: Vec<ResponseReasoningContent>,
         status: Option<String>,
     ) -> Self {
@@ -1528,7 +1541,7 @@ impl ResponseOutputItem {
     /// without ciphertext should use [`Self::new_reasoning`] instead.
     pub fn new_reasoning_encrypted(
         id: String,
-        summary: Vec<String>,
+        summary: Vec<SummaryTextContent>,
         content: Vec<ResponseReasoningContent>,
         encrypted_content: String,
         status: Option<String>,
@@ -1589,6 +1602,37 @@ mod tests {
     use serde_json::json;
 
     use super::*;
+
+    #[test]
+    fn summary_text_content_round_trips_spec_shape() {
+        // Spec: `summary: array of SummaryTextContent { text, type: "summary_text" }`.
+        let item: ResponseOutputItem = serde_json::from_value(json!({
+            "type": "reasoning",
+            "id": "r_1",
+            "summary": [{"text": "step 1", "type": "summary_text"}],
+            "content": [],
+            "status": "completed",
+        }))
+        .expect("spec-shape reasoning should deserialize");
+
+        match &item {
+            ResponseOutputItem::Reasoning { summary, .. } => {
+                assert_eq!(summary.len(), 1);
+                match &summary[0] {
+                    SummaryTextContent::SummaryText { text } => {
+                        assert_eq!(text, "step 1");
+                    }
+                }
+            }
+            _ => panic!("expected Reasoning variant"),
+        }
+
+        let v = serde_json::to_value(&item).expect("serialize");
+        assert_eq!(
+            v["summary"],
+            json!([{"text": "step 1", "type": "summary_text"}])
+        );
+    }
 
     #[test]
     fn test_responses_request_omitted_top_p_deserializes_to_none() {

--- a/crates/protocols/tests/background_mode_protocol.rs
+++ b/crates/protocols/tests/background_mode_protocol.rs
@@ -17,7 +17,7 @@
 
 use openai_protocol::responses::{
     ResponseInputOutputItem, ResponseOutputItem, ResponseReasoningContent, ResponseStatus,
-    ResponsesRequest, ResponsesResponse,
+    ResponsesRequest, ResponsesResponse, SummaryTextContent,
 };
 use serde_json::json;
 
@@ -42,7 +42,9 @@ fn response_status_incomplete_serializes_snake_case() {
 fn reasoning_output_item_round_trips_encrypted_content() {
     let item = ResponseOutputItem::new_reasoning_encrypted(
         "r_1".to_string(),
-        vec!["thought summary".to_string()],
+        vec![SummaryTextContent::SummaryText {
+            text: "thought summary".to_string(),
+        }],
         vec![ResponseReasoningContent::ReasoningText {
             text: "inner thought".to_string(),
         }],


### PR DESCRIPTION
## Summary
Implements audit task **P8**: hard wire-format fix for `Reasoning.summary`. Previously `Vec<String>`; spec requires an array of tagged `SummaryTextContent { text, type: "summary_text" }` objects. This PR introduces the typed content enum and threads it through both Reasoning item variants and their constructors.

## What changed
- `crates/protocols/src/responses.rs` (+54 / -8):
  - New `pub enum SummaryTextContent` tagged with `#[serde(tag = "type")]`, single variant `SummaryText { text: String }`, wire tag `summary_text`.
  - `ResponseInputOutputItem::Reasoning.summary`: `Vec<String>` → `Vec<SummaryTextContent>`.
  - `ResponseOutputItem::Reasoning.summary`: `Vec<String>` → `Vec<SummaryTextContent>`.
  - Updated 4 constructor signatures (`new_reasoning`, `new_reasoning_encrypted` on both item enums).
  - New serde round-trip test `summary_text_content_round_trips_spec_shape` covering the spec payload shape.
- `crates/protocols/tests/background_mode_protocol.rs` (+4 / -2): existing test fixture updated from `vec!["thought summary".to_string()]` to `vec![SummaryTextContent::SummaryText { text: "thought summary".into() }]` (compile-forced; the `Reasoning` type requires the new type).

## Why
OpenAI Responses API spec (see `.claude/_audit/openai-responses-api-spec.md:197-198`) requires `Reasoning.summary` to be an array of `SummaryTextContent { text, type: "summary_text" }` tagged objects. smg's previous `Vec<String>` was a **hard wire-format break** in both directions:
- A spec-valid payload `{"summary": [{"text":"...", "type":"summary_text"}]}` failed smg's `Vec<String>` deserialization.
- smg-emitted `{"summary": ["text"]}` failed spec-compliant client parsing.

This is not a typing nicety; it's closing a real spec-divergence bug.

## Verification
- [x] `cargo check -p openai-protocol` clean (isolated `CARGO_TARGET_DIR=/tmp/p8-target`)
- [x] `cargo check -p smg` clean (4m 21s full build)
- [x] `cargo test -p openai-protocol --lib` → 56 pass (isolated target), including new `summary_text_content_round_trips_spec_shape`
- [x] `cargo test -p openai-protocol --test background_mode_protocol` → 8 pass (isolated target), including updated `reasoning_output_item_round_trips_encrypted_content`
- [x] Tech Lead hand-built 5 spec fixtures (including spec-shape deserialize, byte-identical emit, full Reasoning output/input roundtrip with 2-element summary, and critically `old_vec_string_summary_must_fail` rejecting the old shape) — all PASS
- [x] Scrutiny: 5 call sites in `model_gateway/src/routers/{grpc/regular/responses, grpc/harmony/{processor, responses/{common, non_streaming}}, grpc/regular/responses/streaming}.rs` all pass empty `vec![]` → type inference handles transparently; no router edits required (verified by revert test in isolated target dir)
- [x] Python bindings grep: no `Reasoning`/`SummaryText` mirror, no sync needed
- [x] Codex review: `unavailable` (harness skill permission; Lead proceeded solo per playbook §8 fallback after own 5 fixtures passed)

## Blast radius
2 files: `responses.rs` (schema + constructors) + `background_mode_protocol.rs` (forced test-fixture update). Matches audit Blast Radius — no router wiring needed because all existing call sites pass empty vecs.

## Out of scope
- Router-level emission of reasoning summary content from upstream (populating non-empty vecs) — future follow-up, not required for wire compat.
- `#[non_exhaustive]` on `SummaryTextContent` (gemini-bot suggestion) — can be added later if needed; defer.

Refs: audit task **P8** · `.claude/_audit/responses-api-gap-audit.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Reasoning summaries now use a typed content structure rather than plain strings, changing the serialized shape for reasoning items; empty summaries default/omit from output.

* **Tests**
  * Updated tests to validate the new summary structure’s serialization and deserialization, including a round-trip check and a legacy-format failure case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->