### PR TITLE
fix(memory): skip memory injection when header is absent

### DIFF
--- a/model_gateway/src/routers/common/header_utils.rs
+++ b/model_gateway/src/routers/common/header_utils.rs
@@ -285,22 +285,20 @@ pub(crate) struct ShortTermMemoryConfig {
 
 /// Extract memory configuration from the `x-conversation-memory-config` JSON header.
 ///
-/// Returns defaults when the header is absent or unparsable.
+/// Returns `None` when the header is absent or unparsable — callers should skip
+/// memory injection entirely so the common (no-memory) path is zero-cost.
 pub(crate) fn extract_conversation_memory_config(
     headers: Option<&HeaderMap>,
-) -> ConversationMemoryConfig {
-    let Some(value) = headers.and_then(|h| h.get(&HEADER_CONVERSATION_MEMORY_CONFIG)) else {
-        return ConversationMemoryConfig::default();
-    };
+) -> Option<ConversationMemoryConfig> {
+    let value = headers.and_then(|h| h.get(&HEADER_CONVERSATION_MEMORY_CONFIG))?;
 
-    let Ok(raw) = value.to_str() else {
-        debug!("Invalid UTF-8 in x-conversation-memory-config header; using defaults");
-        return ConversationMemoryConfig::default();
+    let raw = match value.to_str() {
+        Ok(s) if !s.is_empty() => s,
+        _ => {
+            debug!("Invalid or empty x-conversation-memory-config header; ignoring");
+            return None;
+        }
     };
-
-    if raw.is_empty() {
-        return ConversationMemoryConfig::default();
-    }
 
     match serde_json::from_str::<ConversationMemoryConfig>(raw) {
         Ok(mut cfg) => {
@@ -312,11 +310,11 @@ pub(crate) fn extract_conversation_memory_config(
                 normalize_optional_string(cfg.long_term_memory.extraction_model_id);
             cfg.short_term_memory.condenser_model_id =
                 normalize_optional_string(cfg.short_term_memory.condenser_model_id);
-            cfg
+            Some(cfg)
         }
         Err(e) => {
-            debug!(error = %e, "Failed to parse x-conversation-memory-config header; using defaults");
-            ConversationMemoryConfig::default()
+            debug!(error = %e, "Failed to parse x-conversation-memory-config header; ignoring");
+            None
         }
     }
 }
@@ -436,24 +434,41 @@ mod tests {
                 .unwrap(),
         );
 
-        let cfg = extract_conversation_memory_config(Some(&headers));
+        let cfg = extract_conversation_memory_config(Some(&headers))
+            .expect("valid JSON must parse to Some");
 
         assert!(cfg.long_term_memory.enabled);
         assert_eq!(cfg.long_term_memory.subject_id.as_deref(), Some("sub-1"));
-        assert_eq!(cfg.long_term_memory.embedding_model_id.as_deref(), Some("emb-model"));
-        assert_eq!(cfg.long_term_memory.extraction_model_id.as_deref(), Some("ext-model"));
+        assert_eq!(
+            cfg.long_term_memory.embedding_model_id.as_deref(),
+            Some("emb-model")
+        );
+        assert_eq!(
+            cfg.long_term_memory.extraction_model_id.as_deref(),
+            Some("ext-model")
+        );
         assert!(cfg.short_term_memory.enabled);
-        assert_eq!(cfg.short_term_memory.condenser_model_id.as_deref(), Some("cond-model"));
+        assert_eq!(
+            cfg.short_term_memory.condenser_model_id.as_deref(),
+            Some("cond-model")
+        );
     }
 
     #[test]
-    fn extract_conversation_memory_config_with_invalid_json_returns_defaults() {
+    fn extract_conversation_memory_config_with_invalid_json_returns_none() {
         let mut headers = HeaderMap::new();
         headers.insert("x-conversation-memory-config", "not-json".parse().unwrap());
 
-        let cfg = extract_conversation_memory_config(Some(&headers));
+        assert!(extract_conversation_memory_config(Some(&headers)).is_none());
+    }
 
-        assert!(!cfg.long_term_memory.enabled);
-        assert!(!cfg.short_term_memory.enabled);
+    #[test]
+    fn extract_conversation_memory_config_with_absent_header_returns_none() {
+        assert!(extract_conversation_memory_config(Some(&HeaderMap::new())).is_none());
+    }
+
+    #[test]
+    fn extract_conversation_memory_config_with_no_headers_returns_none() {
+        assert!(extract_conversation_memory_config(None).is_none());
     }
 }

--- a/model_gateway/src/routers/openai/responses/route.rs
+++ b/model_gateway/src/routers/openai/responses/route.rs
@@ -124,8 +124,9 @@ pub(in crate::routers::openai) async fn route_responses(
         Err(response) => return response,
     };
 
-    let memory_config = extract_conversation_memory_config(headers);
-    super::history::inject_memory_context(&memory_config, &mut request_body);
+    if let Some(memory_config) = extract_conversation_memory_config(headers) {
+        super::history::inject_memory_context(&memory_config, &mut request_body);
+    }
 
     request_body.store = Some(false);
     if let ResponseInput::Items(ref mut items) = request_body.input {


### PR DESCRIPTION
extract_conversation_memory_config now returns Option<ConversationMemoryConfig> instead of an all-default struct. The call site only invokes inject_memory_context when Some is returned, so the common (no memory header) path costs a single hash lookup with no struct construction or function call overhead.

## Description

### Problem

On every request ConversationMemoryConfig struct was being injected to hot path, even when the header is not present.

### Solution

- Changed extract_conversation_memory_config to return Option<ConversationMemoryConfig>. 
- When the x-conversation-memory-config header is absent, the function returns None immediately. 
- The call site in route_responses wraps the call in if let Some(...), so inject_memory_context is only invoked when the header is actually present.


## Changes

- routers/common/header_utils.rs: extract_conversation_memory_config now returns Option<ConversationMemoryConfig> — None on absent/invalid header, Some(cfg) on valid JSON. Updated tests to reflect the new return type.
- routers/openai/responses/route.rs: Call site guarded with if let Some(memory_config) = extract_conversation_memory_config(headers) so memory injection is skipped entirely when the header is absent.

## Test Plan

Unit tests in header_utils.rs verify: valid JSON parses to Some, invalid JSON returns None, absent header returns None

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced conversation memory configuration handling. The system now properly validates memory configuration and only injects context when valid configuration is available, rather than applying default fallback values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->