### PR TITLE
fix(model-gateway): format conversation memory header assertions

### DIFF
--- a/model_gateway/src/routers/common/header_utils.rs
+++ b/model_gateway/src/routers/common/header_utils.rs
@@ -440,10 +440,19 @@ mod tests {
 
         assert!(cfg.long_term_memory.enabled);
         assert_eq!(cfg.long_term_memory.subject_id.as_deref(), Some("sub-1"));
-        assert_eq!(cfg.long_term_memory.embedding_model_id.as_deref(), Some("emb-model"));
-        assert_eq!(cfg.long_term_memory.extraction_model_id.as_deref(), Some("ext-model"));
+        assert_eq!(
+            cfg.long_term_memory.embedding_model_id.as_deref(),
+            Some("emb-model")
+        );
+        assert_eq!(
+            cfg.long_term_memory.extraction_model_id.as_deref(),
+            Some("ext-model")
+        );
         assert!(cfg.short_term_memory.enabled);
-        assert_eq!(cfg.short_term_memory.condenser_model_id.as_deref(), Some("cond-model"));
+        assert_eq!(
+            cfg.short_term_memory.condenser_model_id.as_deref(),
+            Some("cond-model")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description

### Problem

The merged conversation memory header contract change introduced a `rustfmt` failure in `model_gateway/src/routers/common/header_utils.rs`, which causes the `unit-tests` workflow's `cargo +nightly fmt -- --check` step to fail.

### Solution

Apply the nightly `rustfmt` rewrite to the affected test assertions so the file matches CI formatting expectations.

## Changes

- Reformat the long `assert_eq!` assertions in `extract_conversation_memory_config_with_valid_json_populates_all_fields`
- No behavioral changes

## Test Plan

- `cargo +nightly fmt -- --check`
- Commit hook passed locally, including `rustfmt` and `clippy`

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Reformatted test assertions for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->