### PR TITLE
ci(pr-naming): allow uppercase letters in branch names

### DIFF
--- a/.github/workflows/pr-naming-check.yml
+++ b/.github/workflows/pr-naming-check.yml
@@ -25,7 +25,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
-          REGEX='^[a-z0-9]([a-z0-9._-]*[a-z0-9])?(/[a-z0-9._-]+)+$'
+          REGEX='^[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?(/[a-zA-Z0-9._-]+)+$'
 
           if [[ "$BRANCH" =~ $REGEX ]]; then
             echo "✅ Branch name is valid: '$BRANCH'"


### PR DESCRIPTION
## Summary
- The branch-name validator in `.github/workflows/pr-naming-check.yml` rejects any uppercase letter, auto-closing legitimate PRs such as `feat/audit-P4-include-field` (see #1271).
- Widens the two character classes from `[a-z0-9]` → `[a-zA-Z0-9]`. Structural rules (must contain a `/`, must start/end on alphanumeric) are unchanged; the allowed-types list is advisory in the error comment, not enforced by the regex, so this change is purely additive permissiveness.

## Test plan
- [x] Sanity-checked the new regex locally:
  - Passes: `feat/audit-P4-include-field`, `feat/add-auth`, `fix/null-pointer`, `changsu/fix-routing`, `dependabot/cargo/pyo3-0.28.1`, `feat/CAPS`
  - Still rejects: `BADSTART` (no slash)
- [ ] CI `Branch Naming Convention` check on this PR is green (branch `fix/pr-naming-allow-uppercase` is all-lowercase, so it validates under both old and new regex).

Refs: #1271

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated branch naming validation to accept uppercase letters and digits in addition to lowercase letters, providing more flexible branch naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->