### PR TITLE
feat(protocols): implement P3 EasyInputMessage.phase

### DIFF
--- a/crates/mcp/src/core/session.rs
+++ b/crates/mcp/src/core/session.rs
@@ -1598,12 +1598,14 @@ mod tests {
             role: "assistant".to_string(),
             content: vec![],
             status: "completed".to_string(),
+            phase: None,
         };
         let existing_2 = ResponseOutputItem::Message {
             id: "msg_existing_2".to_string(),
             role: "assistant".to_string(),
             content: vec![],
             status: "completed".to_string(),
+            phase: None,
         };
 
         // Tool call items injected by the router.

--- a/crates/protocols/src/builders/responses/response.rs
+++ b/crates/protocols/src/builders/responses/response.rs
@@ -416,12 +416,14 @@ mod tests {
                 role: "assistant".to_string(),
                 content: vec![],
                 status: "completed".to_string(),
+                phase: None,
             })
             .add_output(ResponseOutputItem::Message {
                 id: "msg_2".to_string(),
                 role: "assistant".to_string(),
                 content: vec![],
                 status: "completed".to_string(),
+                phase: None,
             })
             .build();
 

--- a/crates/protocols/src/responses.rs
+++ b/crates/protocols/src/responses.rs
@@ -1538,23 +1538,6 @@ impl ResponseOutputItem {
         }
     }
 
-    /// Create a new message output item with a phase label.
-    pub fn new_message_with_phase(
-        id: String,
-        role: String,
-        content: Vec<ResponseContentPart>,
-        status: String,
-        phase: Option<MessagePhase>,
-    ) -> Self {
-        Self::Message {
-            id,
-            role,
-            content,
-            status,
-            phase,
-        }
-    }
-
     /// Create a new reasoning output item.
     ///
     /// `encrypted_content` defaults to `None`; use

--- a/crates/protocols/src/responses.rs
+++ b/crates/protocols/src/responses.rs
@@ -170,6 +170,20 @@ pub enum StringOrContentParts {
     Array(Vec<ResponseContentPart>),
 }
 
+/// Phase label for assistant messages in the Responses API.
+///
+/// For gpt-5.3-codex+ multi-turn conversations, preserving and resending the
+/// original `phase` value avoids quality / latency degradation — the model
+/// relies on it to disambiguate commentary-style reasoning from the final
+/// answer. Opaque to SMG otherwise; preserved verbatim through store+retrieve,
+/// SSE output, and upstream passthrough.
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, schemars::JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum MessagePhase {
+    Commentary,
+    FinalAnswer,
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
 #[serde(tag = "type")]
 #[serde(rename_all = "snake_case")]
@@ -181,6 +195,10 @@ pub enum ResponseInputOutputItem {
         content: Vec<ResponseContentPart>,
         #[serde(skip_serializing_if = "Option::is_none")]
         status: Option<String>,
+        /// Optional phase label, preserved from previous assistant output so
+        /// gpt-5.3-codex+ multi-turn does not degrade (spec: ResponseOutputMessage.phase).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        phase: Option<MessagePhase>,
     },
     #[serde(rename = "reasoning")]
     #[non_exhaustive]
@@ -240,6 +258,12 @@ pub enum ResponseInputOutputItem {
         #[serde(skip_serializing_if = "Option::is_none")]
         #[serde(rename = "type")]
         r#type: Option<String>,
+        /// Optional phase label (spec: EasyInputMessage.phase).
+        ///
+        /// Preserved through conversation storage so gpt-5.3-codex+ does not
+        /// lose the commentary/final_answer distinction across turns.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        phase: Option<MessagePhase>,
     },
 }
 
@@ -291,6 +315,12 @@ pub enum ResponseOutputItem {
         role: String,
         content: Vec<ResponseContentPart>,
         status: String,
+        /// Optional phase label (spec: ResponseOutputMessage.phase).
+        ///
+        /// Labels assistant messages; for gpt-5.3-codex+ we must preserve and
+        /// resend this on subsequent turns to avoid perf degradation.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        phase: Option<MessagePhase>,
     },
     #[serde(rename = "reasoning")]
     #[non_exhaustive]
@@ -1283,7 +1313,12 @@ fn validate_text_format(text: &TextConfig) -> Result<(), ValidationError> {
 /// A normalized ResponseInputOutputItem (either Message if converted, or original if not SimpleInputMessage)
 pub fn normalize_input_item(item: &ResponseInputOutputItem) -> ResponseInputOutputItem {
     match item {
-        ResponseInputOutputItem::SimpleInputMessage { content, role, .. } => {
+        ResponseInputOutputItem::SimpleInputMessage {
+            content,
+            role,
+            phase,
+            ..
+        } => {
             let content_vec = match content {
                 StringOrContentParts::String(s) => {
                     vec![ResponseContentPart::InputText { text: s.clone() }]
@@ -1296,6 +1331,7 @@ pub fn normalize_input_item(item: &ResponseInputOutputItem) -> ResponseInputOutp
                 role: role.clone(),
                 content: content_vec,
                 status: Some("completed".to_string()),
+                phase: *phase,
             }
         }
         _ => item.clone(),
@@ -1486,7 +1522,7 @@ impl ResponseInputOutputItem {
 }
 
 impl ResponseOutputItem {
-    /// Create a new message output item
+    /// Create a new message output item (no phase).
     pub fn new_message(
         id: String,
         role: String,
@@ -1498,6 +1534,24 @@ impl ResponseOutputItem {
             role,
             content,
             status,
+            phase: None,
+        }
+    }
+
+    /// Create a new message output item with a phase label.
+    pub fn new_message_with_phase(
+        id: String,
+        role: String,
+        content: Vec<ResponseContentPart>,
+        status: String,
+        phase: Option<MessagePhase>,
+    ) -> Self {
+        Self::Message {
+            id,
+            role,
+            content,
+            status,
+            phase,
         }
     }
 

--- a/model_gateway/benches/routing_allocation_bench.rs
+++ b/model_gateway/benches/routing_allocation_bench.rs
@@ -92,6 +92,7 @@ fn create_bench_request() -> ResponsesRequest {
             role: "user".to_string(),
             content,
             status: None,
+            phase: None,
         });
     }
 

--- a/model_gateway/src/routers/common/persistence_utils.rs
+++ b/model_gateway/src/routers/common/persistence_utils.rs
@@ -4,7 +4,8 @@ use std::sync::Arc;
 
 use chrono::Utc;
 use openai_protocol::responses::{
-    generate_id, ResponseInput, ResponseInputOutputItem, ResponsesRequest, StringOrContentParts,
+    generate_id, MessagePhase, ResponseInput, ResponseInputOutputItem, ResponsesRequest,
+    StringOrContentParts,
 };
 use serde_json::{json, Value};
 use smg_data_connector::{
@@ -66,6 +67,18 @@ pub fn item_to_json(item: &ConversationItem) -> Value {
                 }
             }
         }
+    } else if item.item_type == "message" {
+        // Message items may store either a bare content array (legacy) or an
+        // object `{content: [...], phase: "..."}` when the message carried a
+        // phase label (P3). Either way, expose `content` and hoist `phase`
+        // back to the message level so round-trip is transparent to callers.
+        let (content_value, phase) = split_stored_message_content(item.content.clone());
+        obj.insert("content".to_string(), content_value);
+        if let Some(phase) = phase {
+            if let Ok(phase_value) = serde_json::to_value(phase) {
+                obj.insert("phase".to_string(), phase_value);
+            }
+        }
     } else {
         // Default: include content as-is
         obj.insert("content".to_string(), item.content.clone());
@@ -76,6 +89,30 @@ pub fn item_to_json(item: &ConversationItem) -> Value {
     }
 
     Value::Object(obj)
+}
+
+/// Split stored message content into (content_parts_value, phase).
+///
+/// Legacy messages were stored with their `content` field directly (an array of
+/// content parts). When a message carries a `phase` label (P3), persistence
+/// wraps it as `{"content": [...], "phase": "..."}`. This helper accepts both
+/// shapes so callers can round-trip phase without breaking existing rows.
+pub fn split_stored_message_content(raw: Value) -> (Value, Option<MessagePhase>) {
+    if let Value::Object(mut map) = raw {
+        // Only treat objects with an explicit `content` key as the wrapped
+        // shape; any other object is either malformed or a future extension
+        // and is returned unchanged so the caller's error path surfaces it.
+        if map.contains_key("content") {
+            let content = map.remove("content").unwrap_or(Value::Array(Vec::new()));
+            let phase = map
+                .get("phase")
+                .cloned()
+                .and_then(|v| serde_json::from_value::<MessagePhase>(v).ok());
+            return (content, phase);
+        }
+        return (Value::Object(map), None);
+    }
+    (raw, None)
 }
 
 // ============================================================================
@@ -183,7 +220,12 @@ fn extract_input_items(input: &ResponseInput) -> Result<Vec<Value>, String> {
                 .iter()
                 .map(|item| {
                     match item {
-                        ResponseInputOutputItem::SimpleInputMessage { content, role, .. } => {
+                        ResponseInputOutputItem::SimpleInputMessage {
+                            content,
+                            role,
+                            phase,
+                            ..
+                        } => {
                             // Convert SimpleInputMessage to standard message format with ID
                             let content_json = match content {
                                 StringOrContentParts::String(s) => {
@@ -195,13 +237,23 @@ fn extract_input_items(input: &ResponseInput) -> Result<Vec<Value>, String> {
                                 }
                             };
 
-                            Ok(json!({
+                            let mut msg = json!({
                                 "id": generate_id("msg"),
                                 "type": "message",
                                 "role": role,
                                 "content": content_json,
                                 "status": "completed"
-                            }))
+                            });
+                            // Preserve phase so it round-trips through
+                            // conversation storage (P3).
+                            if let Some(phase) = phase {
+                                if let (Some(obj), Ok(phase_val)) =
+                                    (msg.as_object_mut(), serde_json::to_value(phase))
+                                {
+                                    obj.insert("phase".to_string(), phase_val);
+                                }
+                            }
+                            Ok(msg)
                         }
                         _ => {
                             // For other item types, serialize and ensure ID
@@ -263,6 +315,17 @@ fn item_to_new_conversation_item(
 
     let content = if store_whole_item {
         item_value.clone()
+    } else if item_type == "message"
+        && item_value
+            .get("phase")
+            .is_some_and(|v| !v.is_null())
+    {
+        // Message carries a phase label: wrap the content array alongside
+        // `phase` so multi-turn retrieval preserves it (P3). `item_to_json`
+        // and the history load paths both recognize this shape.
+        let content_value = item_value.get("content").cloned().unwrap_or(json!([]));
+        let phase_value = item_value.get("phase").cloned().unwrap_or(Value::Null);
+        json!({ "content": content_value, "phase": phase_value })
     } else {
         item_value.get("content").cloned().unwrap_or(json!([]))
     };

--- a/model_gateway/src/routers/common/persistence_utils.rs
+++ b/model_gateway/src/routers/common/persistence_utils.rs
@@ -315,11 +315,7 @@ fn item_to_new_conversation_item(
 
     let content = if store_whole_item {
         item_value.clone()
-    } else if item_type == "message"
-        && item_value
-            .get("phase")
-            .is_some_and(|v| !v.is_null())
-    {
+    } else if item_type == "message" && item_value.get("phase").is_some_and(|v| !v.is_null()) {
         // Message carries a phase label: wrap the content array alongside
         // `phase` so multi-turn retrieval preserves it (P3). `item_to_json`
         // and the history load paths both recognize this shape.

--- a/model_gateway/src/routers/grpc/harmony/processor.rs
+++ b/model_gateway/src/routers/grpc/harmony/processor.rs
@@ -292,6 +292,7 @@ impl HarmonyResponseProcessor {
                     logprobs,
                 }],
                 status: "completed".to_string(),
+                phase: None,
             };
             output.push(message_item);
         }

--- a/model_gateway/src/routers/grpc/harmony/responses/common.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/common.rs
@@ -77,6 +77,7 @@ pub(super) fn build_next_request_with_tools(
                 content: StringOrContentParts::String(text),
                 role: "user".to_string(),
                 r#type: None,
+                phase: None,
             }]
         }
     };
@@ -108,6 +109,7 @@ pub(super) fn build_next_request_with_tools(
                 logprobs: None,
             }],
             status: Some("completed".to_string()),
+            phase: None,
         });
     }
 
@@ -285,6 +287,7 @@ pub(super) async fn load_previous_messages(
                 content: StringOrContentParts::String(text),
                 role: "user".to_string(),
                 r#type: None,
+                phase: None,
             });
             history_items
         }

--- a/model_gateway/src/routers/grpc/harmony/responses/non_streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/non_streaming.rs
@@ -419,6 +419,7 @@ fn build_tool_response(
                 logprobs: None,
             }],
             status: "completed".to_string(),
+            phase: None,
         });
     }
 

--- a/model_gateway/src/routers/grpc/regular/responses/common.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/common.rs
@@ -21,7 +21,10 @@ use smg_data_connector::{
 use smg_mcp::McpToolSession;
 use tracing::{debug, warn};
 
-use crate::routers::{error, grpc::common::responses::ResponsesContext};
+use crate::routers::{
+    common::persistence_utils::split_stored_message_content, error,
+    grpc::common::responses::ResponsesContext,
+};
 
 // ============================================================================
 // Tool Loop State
@@ -269,14 +272,20 @@ pub(super) async fn load_conversation_history(
                 let mut items: Vec<ResponseInputOutputItem> = Vec::new();
                 for item in stored_items {
                     if item.item_type == "message" {
+                        // Stored content may be either the raw content array
+                        // (legacy) or an object `{content: [...], phase: ...}`
+                        // when the message carried a phase label (P3).
+                        let (content_value, stored_phase) =
+                            split_stored_message_content(item.content.clone());
                         if let Ok(content_parts) =
-                            serde_json::from_value::<Vec<ResponseContentPart>>(item.content.clone())
+                            serde_json::from_value::<Vec<ResponseContentPart>>(content_value)
                         {
                             items.push(ResponseInputOutputItem::Message {
                                 id: item.id.0.clone(),
                                 role: item.role.clone().unwrap_or_else(|| "user".to_string()),
                                 content: content_parts,
                                 status: item.status.clone(),
+                                phase: stored_phase,
                             });
                         }
                     }
@@ -290,6 +299,7 @@ pub(super) async fn load_conversation_history(
                             role: "user".to_string(),
                             content: vec![ResponseContentPart::InputText { text: text.clone() }],
                             status: Some("completed".to_string()),
+                            phase: None,
                         });
                     }
                     ResponseInput::Items(current_items) => {
@@ -322,6 +332,7 @@ pub(super) async fn load_conversation_history(
                     role: "user".to_string(),
                     content: vec![ResponseContentPart::InputText { text: text.clone() }],
                     status: Some("completed".to_string()),
+                    phase: None,
                 });
             }
             ResponseInput::Items(current_items) => {
@@ -357,6 +368,7 @@ pub(super) fn build_next_request(
             role: "user".to_string(),
             content: vec![ResponseContentPart::InputText { text: text.clone() }],
             status: Some("completed".to_string()),
+            phase: None,
         }],
         ResponseInput::Items(items) => items.iter().map(responses::normalize_input_item).collect(),
     };

--- a/model_gateway/src/routers/grpc/regular/responses/conversions.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/conversions.rs
@@ -302,6 +302,7 @@ pub(crate) fn chat_to_responses(
                     logprobs: choice.logprobs.clone(),
                 }],
                 status: "completed".to_string(),
+                phase: None,
             });
         }
     }
@@ -400,6 +401,7 @@ mod tests {
                         text: "Hello!".to_string(),
                     }],
                     status: None,
+                    phase: None,
                 },
                 ResponseInputOutputItem::Message {
                     id: "msg_2".to_string(),
@@ -410,6 +412,7 @@ mod tests {
                         logprobs: None,
                     }],
                     status: None,
+                    phase: None,
                 },
             ]),
             ..Default::default()

--- a/model_gateway/src/routers/grpc/regular/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/streaming.rs
@@ -364,6 +364,7 @@ impl StreamingResponseAccumulator {
                     logprobs: None,
                 }],
                 status: "completed".to_string(),
+                phase: None,
             });
         }
 

--- a/model_gateway/src/routers/openai/responses/history.rs
+++ b/model_gateway/src/routers/openai/responses/history.rs
@@ -17,7 +17,12 @@ use tracing::{debug, warn};
 use super::super::context::ResponsesComponents;
 use crate::{
     observability::metrics::{metrics_labels, Metrics},
-    routers::{common::header_utils::ConversationMemoryConfig, error},
+    routers::{
+        common::{
+            header_utils::ConversationMemoryConfig, persistence_utils::split_stored_message_content,
+        },
+        error,
+    },
 };
 
 const MAX_CONVERSATION_HISTORY_ITEMS: usize = 100;
@@ -149,7 +154,13 @@ pub(crate) async fn load_input_history(
                 for item in stored_items {
                     match item.item_type.as_str() {
                         "message" => {
-                            match serde_json::from_value::<Vec<ResponseContentPart>>(item.content) {
+                            // Stored content may be either the raw content array
+                            // (legacy shape) or an object `{content: [...], phase: ...}`
+                            // when the message carried a phase label (P3).
+                            let (content_value, stored_phase) =
+                                split_stored_message_content(item.content);
+                            match serde_json::from_value::<Vec<ResponseContentPart>>(content_value)
+                            {
                                 Ok(content_parts) => {
                                     items.push(ResponseInputOutputItem::Message {
                                         id: item.id.0.clone(),
@@ -159,6 +170,7 @@ pub(crate) async fn load_input_history(
                                             .unwrap_or_else(|| "user".to_string()),
                                         content: content_parts,
                                         status: item.status.clone(),
+                                        phase: stored_phase,
                                     });
                                 }
                                 Err(e) => {
@@ -271,6 +283,7 @@ fn append_current_input(
                 role: "user".to_string(),
                 content: vec![ResponseContentPart::InputText { text: text.clone() }],
                 status: Some("completed".to_string()),
+                phase: None,
             });
         }
         ResponseInput::Items(current_items) => {

--- a/model_gateway/tests/spec/responses.rs
+++ b/model_gateway/tests/spec/responses.rs
@@ -525,6 +525,7 @@ fn test_validate_input_items_empty_content() {
             content: StringOrContentParts::String(String::new()),
             role: "user".to_string(),
             r#type: None,
+            phase: None,
         }]),
         ..Default::default()
     };
@@ -985,6 +986,7 @@ fn test_validate_input_items_structure() {
             content: StringOrContentParts::String("Hello".to_string()),
             role: "user".to_string(),
             r#type: None,
+            phase: None,
         }]),
         ..Default::default()
     };


### PR DESCRIPTION
## Summary
Implements audit task **P3**: add the typed `phase` field (`MessagePhase { Commentary, FinalAnswer }`) to `EasyInputMessage` / `ResponseInputOutputItem::Message` / `ResponseOutputItem::Message` per spec, and thread it end-to-end through conversation persistence so `phase` survives multi-turn store + retrieve round-trips. Unblocks audit task **I1** (which depends on the typed Message variant distinction).

## What changed
Commits on branch (`main..HEAD`):
- `b4ca9343` — `feat(protocols): implement P3 EasyInputMessage.phase` (substance)
- `e2d308fc` — `refactor(protocols): drop dead new_message_with_phase helper (P3 cycle 2)` (cycle-1 REJECT remediation — removed 0-callsite `pub fn` per §7)
- `668cdcc5` — `style(protocols): rustfmt remediation for P3 cycle-1 persistence_utils` (cycle-2 fmt fix for a cycle-1 artifact caught by the cycle-2 Lead-requested gate expansion)

Diff totals (vs main): 13 files, +146 / -10.

- `crates/protocols/src/responses.rs`: `MessagePhase` enum (`commentary | final_answer` with serde renames), `phase: Option<MessagePhase>` added to 3 message variants per spec, `normalize_input_item` forwards phase, `new_message` builder preserves signature (`phase: None` default), 2 existing constructor helpers threaded through.
- `crates/protocols/src/builders/responses/response.rs`: 2 test-literal `phase: None` additions (compile-forced).
- `crates/mcp/src/core/session.rs`: 2 test-literal `phase: None` additions in `#[cfg(test)]` block (compile-forced).
- `model_gateway/benches/routing_allocation_bench.rs`: 1 `phase: None` in bench (verified compile-forced by revert → `error[E0063]: missing field 'phase'`).
- `model_gateway/tests/spec/responses.rs`: 2 test-literal `phase: None` additions (compile-forced).
- `model_gateway/src/routers/grpc/harmony/{processor.rs, responses/common.rs, responses/non_streaming.rs}`: 5 `phase: None` additions (compile-forced).
- `model_gateway/src/routers/grpc/regular/responses/{common.rs, conversions.rs, streaming.rs}`: 7 `phase: None` additions + load path via `split_stored_message_content` (compile-forced + AC-required).
- `model_gateway/src/routers/openai/responses/history.rs`: load path via `split_stored_message_content` + 1 `phase: None` (AC-required + compile-forced).
- `model_gateway/src/routers/common/persistence_utils.rs`: `split_stored_message_content` helper (3 callsites → §7 passes) + wrapping-object persistence to carry `phase` alongside content array + cycle-2 rustfmt on let-chain at L315.

## Why
OpenAI Responses API spec requires `phase ∈ {commentary, final_answer}` on message items to distinguish intermediate scaffolding text from the final answer surface. smg previously had no such field, so round-tripping a spec-compliant assistant message through conversation storage lost the phase tag silently. This PR:
- Adds the typed field to all three message variants.
- Wraps stored messages as `{"content":[...], "phase":"..."}` when phase is present, with a backward-compat decode path for legacy bare-array rows (zero-schema-migration on the data-connector side; content column stays a `Value` blob).
- Uses `#[serde(default, skip_serializing_if = "Option::is_none")]` so absent phase never emits `"phase": null` onto user/system messages (verified via 6/6 spec roundtrips including a dedicated user-role-no-phase fixture).

Storage wrapping was evaluated as the minimum-scope alternative to a `data_connector` schema migration (which would have been far larger blast radius). Legacy bare-array rows still decode via the new `split_stored_message_content` helper; no data migration required.

## Verification
- [x] `cargo check --workspace --tests --benches` clean (isolated `CARGO_TARGET_DIR=/tmp/p3-c2-lead-target` to avoid worktree cache collision)
- [x] `cargo test -p openai-protocol` → 82/82 (55 + 8 + 18 + 1)
- [x] `cargo test -p smg --lib` → 553/0 (4 ignored)
- [x] `cargo test -p smg-mcp --lib` → 177/0
- [x] `cargo clippy -p openai-protocol -p smg -p smg-mcp --lib --bins --tests -- -D warnings` clean
- [x] `cargo +nightly fmt --all -- --check` silent (cycle-2 commit B addresses cycle-1 persistence_utils.rs:315 let-chain artifact)
- [x] Tech Lead cycle-1 spec-roundtrip fixtures (6/6 pass): commentary/final_answer positive, user-simple-no-phase, tagged-user-no-phase, SimpleInputMessage-with-phase, unknown-phase=`"thinking"` → rejects at deserialize (no silent `#[serde(other)]` swallow)
- [x] Tech Lead cycle-2 re-verified same fixtures post-deletion → still byte-identical
- [x] Bench edit revert test: `routing_allocation_bench.rs:95` without `phase: None` → `error[E0063]: missing field 'phase' in initializer of ResponseInputOutputItem` → confirmed compile-forced
- [x] `split_stored_message_content` has 3 prod callsites (persistence_utils internal + openai/responses/history.rs:156 + grpc/regular/responses/common.rs:279) → §7 "no new helper used by one callsite" PASSES
- [x] `new_message_with_phase` removed (was 0 callsites; cycle-1 §7 blocker) → `grep -rn 'new_message_with_phase'` zero hits
- [x] Codex review: `unavailable` (harness skill permission; Lead proceeded solo per playbook §8 fallback after own fixtures passed both cycles)

## Blast radius
13 files. Breakdown: protocols schema (2: responses.rs, builders/responses/response.rs), gateway routers + persistence (6), tests + bench (3: mcp session, bench, spec test), rustfmt cleanup (1: persistence_utils.rs).

Every non-responses.rs edit verified compile-forced via revert-and-test, or justified as AC-required (persistence wrapping for "phase survives store+retrieve"). No forbidden files touched.

## Out of scope
- **Runtime population** of `phase` from upstream SGLang/vLLM harmonizer → future follow-up tied to backend-specific structural tag emission.
- **Strict role-gating** on the untyped `Message` variant (spec distinguishes tagged `Message` user/system/developer vs tagged `ResponseOutputMessage` assistant-with-phase) → **I1's scope**, not P3.
- **Schema migration** in `data_connector` to make phase a first-class column → evaluated and rejected as over-scope; wrapping-object persistence with legacy decode is the minimum path.

Refs: audit task **P3** · `.claude/_audit/responses-api-gap-audit.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Messages now include an optional phase: Commentary or FinalAnswer for clearer response classification.

* **Chores**
  * Serialization, persistence, loading, and conversion updated across response pipelines to carry phase information.

* **Tests**
  * Updated unit tests and benchmarks to include the new message phase field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->