### PR TITLE
fix(skills): tighten local storage semantics

### DIFF
--- a/crates/blob_storage/src/cache.rs
+++ b/crates/blob_storage/src/cache.rs
@@ -48,8 +48,8 @@ struct LocalBlobCache {
 
 impl LocalBlobCache {
     fn new(config: &BlobCacheConfig) -> Result<Self, BlobStoreInitError> {
-        let cache_dir = PathBuf::from(&config.path);
-        if cache_dir.as_os_str().is_empty() {
+        let cache_root = PathBuf::from(&config.path);
+        if cache_root.as_os_str().is_empty() {
             return Err(BlobStoreInitError::InvalidConfig {
                 message: "blob cache path must not be empty".to_string(),
             });
@@ -59,19 +59,13 @@ impl LocalBlobCache {
                 message: "blob cache max_size_mb must be greater than zero".to_string(),
             });
         }
-        // This cache is invalidation-driven and process-local. Start from an
-        // empty directory so stale hashed files from earlier runs never count
-        // against the current budget or get mistaken for live entries.
-        match std::fs::remove_dir_all(&cache_dir) {
-            Ok(()) => {}
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-            Err(error) => {
-                return Err(BlobStoreInitError::Io {
-                    path: cache_dir.display().to_string(),
-                    message: error.to_string(),
-                });
-            }
-        }
+        std::fs::create_dir_all(&cache_root).map_err(|error| BlobStoreInitError::Io {
+            path: cache_root.display().to_string(),
+            message: error.to_string(),
+        })?;
+        // Keep cache state process-local without deleting the configured root.
+        // Each instance gets its own empty subdirectory under that root.
+        let cache_dir = cache_root.join(format!("instance-{}", Uuid::now_v7()));
         std::fs::create_dir_all(&cache_dir).map_err(|error| BlobStoreInitError::Io {
             path: cache_dir.display().to_string(),
             message: error.to_string(),

--- a/crates/blob_storage/src/cache.rs
+++ b/crates/blob_storage/src/cache.rs
@@ -59,6 +59,19 @@ impl LocalBlobCache {
                 message: "blob cache max_size_mb must be greater than zero".to_string(),
             });
         }
+        // This cache is invalidation-driven and process-local. Start from an
+        // empty directory so stale hashed files from earlier runs never count
+        // against the current budget or get mistaken for live entries.
+        match std::fs::remove_dir_all(&cache_dir) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(BlobStoreInitError::Io {
+                    path: cache_dir.display().to_string(),
+                    message: error.to_string(),
+                });
+            }
+        }
         std::fs::create_dir_all(&cache_dir).map_err(|error| BlobStoreInitError::Io {
             path: cache_dir.display().to_string(),
             message: error.to_string(),
@@ -109,6 +122,10 @@ impl LocalBlobCache {
         key: &BlobKey,
         response: GetBlobResponse,
     ) -> Result<GetBlobResponse, BlobStoreError> {
+        if response.metadata.size_bytes > self.max_size_bytes {
+            return Ok(response);
+        }
+
         let cache_key = cache_key_for(key);
         let cache_path = cache_path_for(&self.cache_dir, &cache_key);
         let temp_path = cache_path.with_extension(format!("{}.tmp", Uuid::now_v7()));

--- a/crates/blob_storage/src/filesystem.rs
+++ b/crates/blob_storage/src/filesystem.rs
@@ -190,11 +190,11 @@ impl BlobStore for FilesystemBlobStore {
         limit: usize,
     ) -> Result<ListBlobsPage, BlobStoreError> {
         let normalized_prefix = normalize_prefix(&prefix.0)?;
-        let mut blobs = Vec::new();
+        let mut blob_entries = Vec::new();
         let search_root = search_root_for_prefix(&self.root_dir, &normalized_prefix);
         match fs::metadata(&search_root).await {
             Ok(metadata) if metadata.is_dir() => {
-                collect_blob_metadata(&self.root_dir, &search_root, &mut blobs).await?;
+                collect_blob_entries(&self.root_dir, &search_root, &mut blob_entries).await?;
             }
             Ok(_) => {
                 return Ok(ListBlobsPage {
@@ -215,13 +215,13 @@ impl BlobStore for FilesystemBlobStore {
                 });
             }
         }
-        blobs.retain(|metadata| metadata.key.0.starts_with(&normalized_prefix));
-        blobs.sort_by(|left, right| left.key.0.cmp(&right.key.0));
+        blob_entries.retain(|entry| entry.key.starts_with(&normalized_prefix));
+        blob_entries.sort_by(|left, right| left.key.cmp(&right.key));
 
         let start_index = match cursor.as_ref() {
-            Some(cursor_key) => match blobs
+            Some(cursor_key) => match blob_entries
                 .iter()
-                .position(|metadata| metadata.key.0 > *cursor_key)
+                .position(|entry| entry.key > *cursor_key)
             {
                 Some(index) => index,
                 None => {
@@ -235,21 +235,35 @@ impl BlobStore for FilesystemBlobStore {
         };
 
         let end_index =
-            start_index.saturating_add(limit.min(blobs.len().saturating_sub(start_index)));
-        let page_blobs = blobs[start_index..end_index].to_vec();
+            start_index.saturating_add(limit.min(blob_entries.len().saturating_sub(start_index)));
+        let mut blobs = Vec::with_capacity(end_index.saturating_sub(start_index));
+        for entry in &blob_entries[start_index..end_index] {
+            match fs::metadata(&entry.path).await {
+                Ok(metadata) => {
+                    blobs.push(Self::metadata_for_path(
+                        &BlobKey(entry.key.clone()),
+                        metadata,
+                    ));
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(error) => {
+                    return Err(BlobStoreError::Operation {
+                        operation: "metadata",
+                        message: error.to_string(),
+                    });
+                }
+            }
+        }
 
-        let next_cursor = if end_index < blobs.len() && end_index > start_index {
-            blobs
+        let next_cursor = if end_index < blob_entries.len() && end_index > start_index {
+            blob_entries
                 .get(end_index - 1)
-                .map(|metadata| metadata.key.0.clone())
+                .map(|entry| entry.key.clone())
         } else {
             None
         };
 
-        Ok(ListBlobsPage {
-            blobs: page_blobs,
-            next_cursor,
-        })
+        Ok(ListBlobsPage { blobs, next_cursor })
     }
 }
 
@@ -264,10 +278,16 @@ fn search_root_for_prefix(root_dir: &Path, normalized_prefix: &str) -> PathBuf {
     path
 }
 
-async fn collect_blob_metadata(
+#[derive(Debug, Clone)]
+struct BlobListEntry {
+    key: String,
+    path: PathBuf,
+}
+
+async fn collect_blob_entries(
     root_dir: &Path,
     current_dir: &Path,
-    blobs: &mut Vec<BlobMetadata>,
+    blob_entries: &mut Vec<BlobListEntry>,
 ) -> Result<(), BlobStoreError> {
     let mut entries =
         fs::read_dir(current_dir)
@@ -286,16 +306,19 @@ async fn collect_blob_metadata(
                 message: error.to_string(),
             })?
     {
-        let file_type = entry
-            .file_type()
-            .await
-            .map_err(|error| BlobStoreError::Operation {
-                operation: "file_type",
-                message: error.to_string(),
-            })?;
         let path = entry.path();
+        let file_type = match entry.file_type().await {
+            Ok(file_type) => file_type,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => {
+                return Err(BlobStoreError::Operation {
+                    operation: "file_type",
+                    message: error.to_string(),
+                });
+            }
+        };
         if file_type.is_dir() {
-            Box::pin(collect_blob_metadata(root_dir, &path, blobs)).await?;
+            Box::pin(collect_blob_entries(root_dir, &path, blob_entries)).await?;
             continue;
         }
         if !file_type.is_file() {
@@ -308,21 +331,12 @@ async fn collect_blob_metadata(
                     operation: "strip_prefix",
                     message: error.to_string(),
                 })?;
-        let key = BlobKey(
-            relative_path
-                .iter()
-                .map(|segment| segment.to_string_lossy())
-                .collect::<Vec<_>>()
-                .join("/"),
-        );
-        let metadata = entry
-            .metadata()
-            .await
-            .map_err(|error| BlobStoreError::Operation {
-                operation: "metadata",
-                message: error.to_string(),
-            })?;
-        blobs.push(FilesystemBlobStore::metadata_for_path(&key, metadata));
+        let key = relative_path
+            .iter()
+            .map(|segment| segment.to_string_lossy())
+            .collect::<Vec<_>>()
+            .join("/");
+        blob_entries.push(BlobListEntry { key, path });
     }
 
     Ok(())

--- a/crates/blob_storage/src/filesystem.rs
+++ b/crates/blob_storage/src/filesystem.rs
@@ -190,11 +190,11 @@ impl BlobStore for FilesystemBlobStore {
         limit: usize,
     ) -> Result<ListBlobsPage, BlobStoreError> {
         let normalized_prefix = normalize_prefix(&prefix.0)?;
-        let mut blob_keys = Vec::new();
+        let mut blobs = Vec::new();
         let search_root = search_root_for_prefix(&self.root_dir, &normalized_prefix);
         match fs::metadata(&search_root).await {
             Ok(metadata) if metadata.is_dir() => {
-                collect_blob_keys(&self.root_dir, &search_root, &mut blob_keys).await?;
+                collect_blob_metadata(&self.root_dir, &search_root, &mut blobs).await?;
             }
             Ok(_) => {
                 return Ok(ListBlobsPage {
@@ -215,11 +215,14 @@ impl BlobStore for FilesystemBlobStore {
                 });
             }
         }
-        blob_keys.retain(|key| key.starts_with(&normalized_prefix));
-        blob_keys.sort();
+        blobs.retain(|metadata| metadata.key.0.starts_with(&normalized_prefix));
+        blobs.sort_by(|left, right| left.key.0.cmp(&right.key.0));
 
         let start_index = match cursor.as_ref() {
-            Some(cursor_key) => match blob_keys.iter().position(|key| key > cursor_key) {
+            Some(cursor_key) => match blobs
+                .iter()
+                .position(|metadata| metadata.key.0 > *cursor_key)
+            {
                 Some(index) => index,
                 None => {
                     return Ok(ListBlobsPage {
@@ -232,24 +235,21 @@ impl BlobStore for FilesystemBlobStore {
         };
 
         let end_index =
-            start_index.saturating_add(limit.min(blob_keys.len().saturating_sub(start_index)));
-        let page_keys = &blob_keys[start_index..end_index];
+            start_index.saturating_add(limit.min(blobs.len().saturating_sub(start_index)));
+        let page_blobs = blobs[start_index..end_index].to_vec();
 
-        let mut blobs = Vec::with_capacity(page_keys.len());
-        for key_str in page_keys {
-            let key = BlobKey(key_str.clone());
-            if let Some(metadata) = self.head(&key).await? {
-                blobs.push(metadata);
-            }
-        }
-
-        let next_cursor = if end_index < blob_keys.len() && end_index > start_index {
-            blob_keys.get(end_index - 1).cloned()
+        let next_cursor = if end_index < blobs.len() && end_index > start_index {
+            blobs
+                .get(end_index - 1)
+                .map(|metadata| metadata.key.0.clone())
         } else {
             None
         };
 
-        Ok(ListBlobsPage { blobs, next_cursor })
+        Ok(ListBlobsPage {
+            blobs: page_blobs,
+            next_cursor,
+        })
     }
 }
 
@@ -264,10 +264,10 @@ fn search_root_for_prefix(root_dir: &Path, normalized_prefix: &str) -> PathBuf {
     path
 }
 
-async fn collect_blob_keys(
+async fn collect_blob_metadata(
     root_dir: &Path,
     current_dir: &Path,
-    blob_keys: &mut Vec<String>,
+    blobs: &mut Vec<BlobMetadata>,
 ) -> Result<(), BlobStoreError> {
     let mut entries =
         fs::read_dir(current_dir)
@@ -295,7 +295,7 @@ async fn collect_blob_keys(
             })?;
         let path = entry.path();
         if file_type.is_dir() {
-            Box::pin(collect_blob_keys(root_dir, &path, blob_keys)).await?;
+            Box::pin(collect_blob_metadata(root_dir, &path, blobs)).await?;
             continue;
         }
         if !file_type.is_file() {
@@ -308,12 +308,21 @@ async fn collect_blob_keys(
                     operation: "strip_prefix",
                     message: error.to_string(),
                 })?;
-        let key = relative_path
-            .iter()
-            .map(|segment| segment.to_string_lossy())
-            .collect::<Vec<_>>()
-            .join("/");
-        blob_keys.push(key);
+        let key = BlobKey(
+            relative_path
+                .iter()
+                .map(|segment| segment.to_string_lossy())
+                .collect::<Vec<_>>()
+                .join("/"),
+        );
+        let metadata = entry
+            .metadata()
+            .await
+            .map_err(|error| BlobStoreError::Operation {
+                operation: "metadata",
+                message: error.to_string(),
+            })?;
+        blobs.push(FilesystemBlobStore::metadata_for_path(&key, metadata));
     }
 
     Ok(())

--- a/crates/blob_storage/tests/filesystem_blob_store.rs
+++ b/crates/blob_storage/tests/filesystem_blob_store.rs
@@ -218,7 +218,7 @@ fn cached_store_rejects_zero_sized_cache_config() -> Result<()> {
 }
 
 #[tokio::test]
-async fn cached_store_keeps_oversized_latest_blob_readable() -> Result<()> {
+async fn cached_store_skips_oversized_blobs() -> Result<()> {
     let blob_root = TempDir::new()?;
     let cache_root = TempDir::new()?;
     let inner = Arc::new(CountingBlobStore {
@@ -244,7 +244,7 @@ async fn cached_store_keeps_oversized_latest_blob_readable() -> Result<()> {
 
     assert_eq!(first.len(), payload.len());
     assert_eq!(second.len(), payload.len());
-    assert_eq!(inner.get_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(inner.get_calls.load(Ordering::SeqCst), 2);
     Ok(())
 }
 
@@ -304,6 +304,42 @@ async fn cached_store_returns_backend_payload_when_cache_population_fails() -> R
     let body = read_all(store.get(&key).await?).await?;
 
     assert_eq!(body, b"fallback");
+    assert_eq!(inner.get_calls.load(Ordering::SeqCst), 2);
+    Ok(())
+}
+
+#[tokio::test]
+async fn cached_store_starts_from_an_empty_process_local_directory() -> Result<()> {
+    let blob_root = TempDir::new()?;
+    let cache_root = TempDir::new()?;
+    let inner = Arc::new(CountingBlobStore {
+        inner: FilesystemBlobStore::new(blob_root.path())?,
+        get_calls: AtomicUsize::new(0),
+        etag: None,
+    });
+    let key = BlobKey::from("skills/t1/s1/v1/restart.txt");
+
+    inner.put_stream(&key, put_request(b"restart")).await?;
+
+    let first_store = Arc::new(smg_blob_storage::CachedBlobStore::new(
+        inner.clone() as Arc<dyn BlobStore>,
+        &BlobCacheConfig {
+            path: cache_root.path().display().to_string(),
+            max_size_mb: 8,
+        },
+    )?) as Arc<dyn BlobStore>;
+    assert_eq!(read_all(first_store.get(&key).await?).await?, b"restart");
+    drop(first_store);
+
+    let second_store = Arc::new(smg_blob_storage::CachedBlobStore::new(
+        inner.clone() as Arc<dyn BlobStore>,
+        &BlobCacheConfig {
+            path: cache_root.path().display().to_string(),
+            max_size_mb: 8,
+        },
+    )?) as Arc<dyn BlobStore>;
+    assert_eq!(read_all(second_store.get(&key).await?).await?, b"restart");
+
     assert_eq!(inner.get_calls.load(Ordering::SeqCst), 2);
     Ok(())
 }

--- a/crates/blob_storage/tests/filesystem_blob_store.rs
+++ b/crates/blob_storage/tests/filesystem_blob_store.rs
@@ -343,3 +343,48 @@ async fn cached_store_starts_from_an_empty_process_local_directory() -> Result<(
     assert_eq!(inner.get_calls.load(Ordering::SeqCst), 2);
     Ok(())
 }
+
+#[tokio::test]
+async fn cached_store_instances_with_shared_root_do_not_clobber_each_other() -> Result<()> {
+    let blob_root = TempDir::new()?;
+    let cache_root = TempDir::new()?;
+    let inner = Arc::new(CountingBlobStore {
+        inner: FilesystemBlobStore::new(blob_root.path())?,
+        get_calls: AtomicUsize::new(0),
+        etag: None,
+    });
+    let key = BlobKey::from("skills/t1/s1/v1/shared-root.txt");
+
+    inner.put_stream(&key, put_request(b"shared-root")).await?;
+
+    let first_store = Arc::new(smg_blob_storage::CachedBlobStore::new(
+        inner.clone() as Arc<dyn BlobStore>,
+        &BlobCacheConfig {
+            path: cache_root.path().display().to_string(),
+            max_size_mb: 8,
+        },
+    )?) as Arc<dyn BlobStore>;
+    assert_eq!(
+        read_all(first_store.get(&key).await?).await?,
+        b"shared-root"
+    );
+
+    let second_store = Arc::new(smg_blob_storage::CachedBlobStore::new(
+        inner.clone() as Arc<dyn BlobStore>,
+        &BlobCacheConfig {
+            path: cache_root.path().display().to_string(),
+            max_size_mb: 8,
+        },
+    )?) as Arc<dyn BlobStore>;
+    assert_eq!(
+        read_all(second_store.get(&key).await?).await?,
+        b"shared-root"
+    );
+    assert_eq!(
+        read_all(first_store.get(&key).await?).await?,
+        b"shared-root"
+    );
+
+    assert_eq!(inner.get_calls.load(Ordering::SeqCst), 2);
+    Ok(())
+}

--- a/crates/skills/src/memory.rs
+++ b/crates/skills/src/memory.rs
@@ -19,7 +19,8 @@ use crate::{
 
 #[derive(Debug, Default)]
 struct InMemorySkillState {
-    skills: BTreeMap<(String, String), SkillRecord>,
+    skills: BTreeMap<String, SkillRecord>,
+    skill_ids_by_tenant: BTreeMap<String, BTreeSet<String>>,
     skill_versions: BTreeMap<(String, String), SkillVersionRecord>,
     skill_versions_by_skill: BTreeMap<String, BTreeSet<String>>,
     tenant_aliases: BTreeMap<String, TenantAliasRecord>,
@@ -39,8 +40,22 @@ pub struct InMemorySkillStore {
 #[async_trait]
 impl SkillMetadataStore for InMemorySkillStore {
     async fn put_skill(&self, record: SkillRecord) -> SkillsStoreResult<()> {
-        let key = (record.tenant_id.clone(), record.skill_id.clone());
-        self.state.write().skills.insert(key, record);
+        let mut state = self.state.write();
+        if let Some(existing) = state.skills.get(&record.skill_id) {
+            if existing.tenant_id != record.tenant_id {
+                return Err(crate::storage::SkillsStoreError::InvalidData(format!(
+                    "skill_id '{}' already belongs to tenant '{}'",
+                    record.skill_id, existing.tenant_id
+                )));
+            }
+        }
+
+        state
+            .skill_ids_by_tenant
+            .entry(record.tenant_id.clone())
+            .or_default()
+            .insert(record.skill_id.clone());
+        state.skills.insert(record.skill_id.clone(), record);
         Ok(())
     }
 
@@ -53,19 +68,19 @@ impl SkillMetadataStore for InMemorySkillStore {
             .state
             .read()
             .skills
-            .get(&(tenant_id.to_string(), skill_id.to_string()))
-            .cloned())
+            .get(skill_id)
+            .and_then(|record| (record.tenant_id == tenant_id).then(|| record.clone())))
     }
 
     async fn list_skills(&self, tenant_id: &str) -> SkillsStoreResult<Vec<SkillRecord>> {
-        let start = (tenant_id.to_string(), String::new());
-        let end = (tenant_id.to_string(), max_sort_key());
-        let mut skills = self
-            .state
-            .read()
-            .skills
-            .range((Included(start), Included(end)))
-            .map(|(_, record)| record.clone())
+        let state = self.state.read();
+        let mut skills = state
+            .skill_ids_by_tenant
+            .get(tenant_id)
+            .into_iter()
+            .flat_map(|skill_ids| skill_ids.iter())
+            .filter_map(|skill_id| state.skills.get(skill_id))
+            .cloned()
             .collect::<Vec<_>>();
         skills.sort_by(|left, right| {
             left.name
@@ -77,25 +92,25 @@ impl SkillMetadataStore for InMemorySkillStore {
 
     async fn delete_skill(&self, tenant_id: &str, skill_id: &str) -> SkillsStoreResult<bool> {
         let mut state = self.state.write();
-        let removed = state
-            .skills
-            .remove(&(tenant_id.to_string(), skill_id.to_string()))
-            .is_some();
-        if !removed {
+        let Some(record) = state.skills.get(skill_id) else {
+            return Ok(false);
+        };
+        if record.tenant_id != tenant_id {
             return Ok(false);
         }
 
-        let skill_still_referenced = state
-            .skills
-            .keys()
-            .any(|(_, existing_skill_id)| existing_skill_id == skill_id);
-        if !skill_still_referenced {
-            if let Some(versions) = state.skill_versions_by_skill.remove(skill_id) {
-                for version in versions {
-                    state
-                        .skill_versions
-                        .remove(&(skill_id.to_string(), version));
-                }
+        state.skills.remove(skill_id);
+        if let Some(skill_ids) = state.skill_ids_by_tenant.get_mut(tenant_id) {
+            skill_ids.remove(skill_id);
+            if skill_ids.is_empty() {
+                state.skill_ids_by_tenant.remove(tenant_id);
+            }
+        }
+        if let Some(versions) = state.skill_versions_by_skill.remove(skill_id) {
+            for version in versions {
+                state
+                    .skill_versions
+                    .remove(&(skill_id.to_string(), version));
             }
         }
 
@@ -105,6 +120,12 @@ impl SkillMetadataStore for InMemorySkillStore {
     async fn put_skill_version(&self, record: SkillVersionRecord) -> SkillsStoreResult<()> {
         let key = (record.skill_id.clone(), record.version.clone());
         let mut state = self.state.write();
+        if !state.skills.contains_key(&record.skill_id) {
+            return Err(crate::storage::SkillsStoreError::InvalidData(format!(
+                "skill_id '{}' must exist before inserting a version",
+                record.skill_id
+            )));
+        }
         state
             .skill_versions_by_skill
             .entry(record.skill_id.clone())

--- a/crates/skills/src/memory.rs
+++ b/crates/skills/src/memory.rs
@@ -100,11 +100,15 @@ impl SkillMetadataStore for InMemorySkillStore {
         }
 
         state.skills.remove(skill_id);
-        if let Some(skill_ids) = state.skill_ids_by_tenant.get_mut(tenant_id) {
-            skill_ids.remove(skill_id);
-            if skill_ids.is_empty() {
-                state.skill_ids_by_tenant.remove(tenant_id);
-            }
+        let tenant_has_no_skills =
+            if let Some(skill_ids) = state.skill_ids_by_tenant.get_mut(tenant_id) {
+                skill_ids.remove(skill_id);
+                skill_ids.is_empty()
+            } else {
+                false
+            };
+        if tenant_has_no_skills {
+            state.skill_ids_by_tenant.remove(tenant_id);
         }
         if let Some(versions) = state.skill_versions_by_skill.remove(skill_id) {
             for version in versions {

--- a/crates/skills/tests/in_memory_runtime.rs
+++ b/crates/skills/tests/in_memory_runtime.rs
@@ -239,6 +239,21 @@ async fn in_memory_service_scopes_listings_to_exact_tenant_and_skill() -> Result
         })
         .await?;
     metadata_store
+        .put_skill(SkillRecord {
+            tenant_id: "tenant-b".to_string(),
+            skill_id: "skill-10".to_string(),
+            name: "map-10".to_string(),
+            short_description: None,
+            description: None,
+            source: "custom".to_string(),
+            has_code_files: false,
+            latest_version: Some("1".to_string()),
+            default_version: Some("1".to_string()),
+            created_at: now,
+            updated_at: now,
+        })
+        .await?;
+    metadata_store
         .put_skill_version(SkillVersionRecord {
             skill_id: "skill-1".to_string(),
             version: "1".to_string(),
@@ -285,8 +300,7 @@ async fn in_memory_service_scopes_listings_to_exact_tenant_and_skill() -> Result
 }
 
 #[tokio::test]
-async fn in_memory_service_only_deletes_versions_when_last_tenant_mapping_is_removed() -> Result<()>
-{
+async fn in_memory_service_rejects_cross_tenant_skill_id_reuse() -> Result<()> {
     let blob_root = TempDir::new()?;
     let blob_store = create_blob_store(
         &BlobStoreConfig {
@@ -302,26 +316,124 @@ async fn in_memory_service_only_deletes_versions_when_last_tenant_mapping_is_rem
         .metadata_store()
         .ok_or_else(|| anyhow!("metadata store missing"))?;
 
-    for tenant_id in ["tenant-a", "tenant-b"] {
-        metadata_store
-            .put_skill(SkillRecord {
-                tenant_id: tenant_id.to_string(),
-                skill_id: "shared-skill".to_string(),
-                name: "map".to_string(),
-                short_description: None,
-                description: None,
-                source: "custom".to_string(),
-                has_code_files: false,
-                latest_version: Some("1".to_string()),
-                default_version: Some("1".to_string()),
-                created_at: now,
-                updated_at: now,
-            })
-            .await?;
-    }
+    metadata_store
+        .put_skill(SkillRecord {
+            tenant_id: "tenant-a".to_string(),
+            skill_id: "shared-skill".to_string(),
+            name: "map".to_string(),
+            short_description: None,
+            description: None,
+            source: "custom".to_string(),
+            has_code_files: false,
+            latest_version: Some("1".to_string()),
+            default_version: Some("1".to_string()),
+            created_at: now,
+            updated_at: now,
+        })
+        .await?;
+
+    let error = metadata_store
+        .put_skill(SkillRecord {
+            tenant_id: "tenant-b".to_string(),
+            skill_id: "shared-skill".to_string(),
+            name: "map".to_string(),
+            short_description: None,
+            description: None,
+            source: "custom".to_string(),
+            has_code_files: false,
+            latest_version: Some("1".to_string()),
+            default_version: Some("1".to_string()),
+            created_at: now,
+            updated_at: now,
+        })
+        .await
+        .expect_err("cross-tenant skill_id reuse should fail");
+    assert!(matches!(
+        error,
+        smg_skills::SkillsStoreError::InvalidData(_)
+    ));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn in_memory_service_requires_parent_skill_before_writing_versions() -> Result<()> {
+    let blob_root = TempDir::new()?;
+    let blob_store = create_blob_store(
+        &BlobStoreConfig {
+            backend: BlobStoreBackend::Filesystem,
+            path: blob_root.path().display().to_string(),
+            ..BlobStoreConfig::default()
+        },
+        None,
+    )?;
+    let service = SkillService::in_memory(blob_store);
+    let metadata_store = service
+        .metadata_store()
+        .ok_or_else(|| anyhow!("metadata store missing"))?;
+
+    let error = metadata_store
+        .put_skill_version(SkillVersionRecord {
+            skill_id: "missing-skill".to_string(),
+            version: "1".to_string(),
+            version_number: 1,
+            name: "map".to_string(),
+            short_description: None,
+            description: "map".to_string(),
+            interface: None,
+            dependencies: None,
+            policy: None,
+            deprecated: false,
+            file_manifest: Vec::new(),
+            instruction_token_counts: Default::default(),
+            created_at: Utc::now(),
+        })
+        .await
+        .expect_err("writing a version without a parent skill should fail");
+
+    assert!(matches!(
+        error,
+        smg_skills::SkillsStoreError::InvalidData(_)
+    ));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn in_memory_service_deletes_versions_with_their_parent_skill() -> Result<()> {
+    let blob_root = TempDir::new()?;
+    let blob_store = create_blob_store(
+        &BlobStoreConfig {
+            backend: BlobStoreBackend::Filesystem,
+            path: blob_root.path().display().to_string(),
+            ..BlobStoreConfig::default()
+        },
+        None,
+    )?;
+    let service = SkillService::in_memory(blob_store);
+    let now = Utc::now();
+    let metadata_store = service
+        .metadata_store()
+        .ok_or_else(|| anyhow!("metadata store missing"))?;
+
+    metadata_store
+        .put_skill(SkillRecord {
+            tenant_id: "tenant-a".to_string(),
+            skill_id: "skill-1".to_string(),
+            name: "map".to_string(),
+            short_description: None,
+            description: None,
+            source: "custom".to_string(),
+            has_code_files: false,
+            latest_version: Some("1".to_string()),
+            default_version: Some("1".to_string()),
+            created_at: now,
+            updated_at: now,
+        })
+        .await?;
     metadata_store
         .put_skill_version(SkillVersionRecord {
-            skill_id: "shared-skill".to_string(),
+            skill_id: "skill-1".to_string(),
             version: "1".to_string(),
             version_number: 1,
             name: "map".to_string(),
@@ -337,25 +449,16 @@ async fn in_memory_service_only_deletes_versions_when_last_tenant_mapping_is_rem
         })
         .await?;
 
-    assert!(
-        metadata_store
-            .delete_skill("tenant-a", "shared-skill")
-            .await?
-    );
+    assert!(metadata_store.delete_skill("tenant-a", "skill-1").await?);
     assert!(metadata_store
-        .get_skill_version("shared-skill", "1")
-        .await?
-        .is_some());
-
-    assert!(
-        metadata_store
-            .delete_skill("tenant-b", "shared-skill")
-            .await?
-    );
-    assert!(metadata_store
-        .get_skill_version("shared-skill", "1")
+        .get_skill("tenant-a", "skill-1")
         .await?
         .is_none());
+    assert!(metadata_store
+        .get_skill_version("skill-1", "1")
+        .await?
+        .is_none());
+
     Ok(())
 }
 


### PR DESCRIPTION
## Description

### Problem

The first local storage landing still left a few local-only behaviors that drifted from the real storage contracts:
- the in-memory skills store could represent `skill_id` ownership states the database schema cannot
- the in-memory store allowed orphan skill versions that production storage would reject
- the local blob cache treated stale on-disk cache files as if they did not exist in memory, and it still attempted to cache blobs that were already known to exceed capacity
- filesystem prefix listing did an extra metadata pass through `head()` for each returned entry

### Solution

Tighten the local storage implementations so they better match production semantics and remove a couple of unnecessary local inefficiencies.

## Changes

- reject cross-tenant reuse of a global `skill_id` in `InMemorySkillStore`
- require a parent skill before inserting a skill version in the in-memory backend
- cascade-delete in-memory skill versions when the owning skill is deleted
- make the local blob cache start from an empty process-local view and skip caching already-oversized blobs
- reuse collected filesystem metadata during `list_prefix()` instead of re-reading each returned key with `head()`
- add regression tests for the corrected in-memory and cache behaviors

## Test Plan

- `cargo +nightly fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `env -u RUSTC_WRAPPER CARGO_BUILD_RUSTC_WRAPPER= cargo test -p smg-blob-storage -p smg-skills --target-dir /tmp/smg-followup-target`
- `env -u RUSTC_WRAPPER CARGO_BUILD_RUSTC_WRAPPER= cargo test --target-dir /tmp/smg-followup-target-full`
  - started on this host and left running deep in the workspace test tail without surfacing a failure in the touched crates, so this PR is draft until that full repo-wide signal is clean

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Blob cache now skips oversized blobs and won't serve them from cache
  * Skills service prevents reusing the same skill ID across different tenants
  * Skills service requires a parent skill exist before creating a version

* **New Features**
  * Cache now creates isolated per-process instance directories under the configured cache root, preventing instances from clobbering each other

* **Performance**
  * Improved blob listing performance by reducing per-item filesystem calls during traversal

* **Tests**
  * Added tests validating per-process cache isolation and shared-root safety
<!-- end of auto-generated comment: release notes by coderabbit.ai -->