### PR TITLE
feat(mesh): retain broadcast rounds + per-peer targeted queues for stream traffic

### DIFF
--- a/crates/mesh/src/controller.rs
+++ b/crates/mesh/src/controller.rs
@@ -38,7 +38,8 @@ use crate::{
     collector::{CentralCollector, PeerWatermark, RoundBatch},
     flow_control::{MessageSizeValidator, MAX_MESSAGE_SIZE},
     metrics,
-    service::gossip::IncrementalUpdate,
+    service::{gossip::IncrementalUpdate, MESH_PEER_ID_HEADER},
+    stream_dispatch::StreamDispatch,
 };
 
 pub struct MeshController {
@@ -56,10 +57,12 @@ pub struct MeshController {
     /// Current round batch, updated once per round by the central collector.
     /// Per-peer senders read and apply their own watermark filtering.
     current_batch: Arc<parking_lot::RwLock<Arc<RoundBatch>>>,
-    /// Current stream round batch, drained once per round from MeshKV.
-    /// Per-peer senders read this and filter targeted entries to their
-    /// own peer; drain_entries are broadcast to every peer.
-    current_stream_batch: Arc<parking_lot::RwLock<Arc<crate::kv::RoundBatch>>>,
+    /// Handoff transport between the central collector and per-peer
+    /// sender tasks for stream traffic. Broadcast drain entries ride a
+    /// retention ring; targeted entries fan out into bounded per-peer
+    /// queues. Replaces the single-slot `Arc<RoundBatch>` that could
+    /// silently drop rounds when a sender task tick was delayed.
+    stream_dispatch: Arc<StreamDispatch>,
     /// Node-wide MeshKV handle. Owns the stream buffers, subscriber
     /// registry, and chunk assembler shared with the server-side
     /// SyncStream handlers.
@@ -90,9 +93,7 @@ impl MeshController {
             sync_connections: Arc::new(Mutex::new(HashMap::new())),
             central_collector,
             current_batch: Arc::new(parking_lot::RwLock::new(Arc::new(RoundBatch::default()))),
-            current_stream_batch: Arc::new(parking_lot::RwLock::new(Arc::new(
-                crate::kv::RoundBatch::default(),
-            ))),
+            stream_dispatch: Arc::new(StreamDispatch::new()),
             mesh_kv: None,
         }
     }
@@ -112,11 +113,11 @@ impl MeshController {
         self.current_batch.clone()
     }
 
-    /// Get a handle to the shared stream RoundBatch. Used by GossipService
-    /// so server-side sync_stream handlers see the same drained stream
-    /// entries as client-side handlers.
-    pub fn current_stream_batch(&self) -> Arc<parking_lot::RwLock<Arc<crate::kv::RoundBatch>>> {
-        self.current_stream_batch.clone()
+    /// Get a handle to the shared stream dispatch transport. Used by
+    /// GossipService so server-side sync_stream handlers subscribe to
+    /// the same broadcast ring and targeted queues as client-side.
+    pub fn stream_dispatch(&self) -> Arc<StreamDispatch> {
+        self.stream_dispatch.clone()
     }
 
     #[instrument(fields(name = %self.self_name), skip(self, signal))]
@@ -267,14 +268,23 @@ impl MeshController {
                 self.central_collector.advance_generations();
             }
 
-            // Stream round collection: drain stream namespace buffers and
-            // drain callbacks exactly once per round (destructive). Per-peer
-            // senders filter targeted_entries by their own peer_id and
-            // broadcast drain_entries to all peers. Empty batch if no
-            // MeshKV is attached (legacy path pre-Step 3).
+            // Stream round collection: drain stream namespace buffers
+            // and drain callbacks exactly once per round (destructive),
+            // then publish one round into the StreamDispatch transport.
+            // drain_entries convert Vec<u8> → Bytes here so the broadcast
+            // ring retains one shared allocation per round; targeted
+            // entries are grouped by target peer inside publish_round
+            // into one TargetedRound per peer per round. Empty round if
+            // no MeshKV is attached (legacy path pre-Step 3).
             if let Some(mesh_kv) = &self.mesh_kv {
                 let stream_batch = mesh_kv.collect_round_batch();
-                *self.current_stream_batch.write() = Arc::new(stream_batch);
+                let drain_entries: Vec<(String, Bytes)> = stream_batch
+                    .drain_entries
+                    .into_iter()
+                    .map(|(k, v)| (k, Bytes::from(v)))
+                    .collect();
+                self.stream_dispatch
+                    .publish_round(drain_entries, stream_batch.targeted_entries);
             }
 
             tokio::select! {
@@ -495,7 +505,7 @@ impl MeshController {
         let sync_manager = self.sync_manager.clone();
         let sync_connections = self.sync_connections.clone();
         let current_batch = self.current_batch.clone();
-        let current_stream_batch = self.current_stream_batch.clone();
+        let stream_dispatch = self.stream_dispatch.clone();
         let mesh_kv = self.mesh_kv.clone();
 
         // Log connection lifecycle: spawn
@@ -551,14 +561,27 @@ impl MeshController {
                     let shared_sequence = sequence.clone();
                     let size_validator = MessageSizeValidator::default();
                     let batch_handle = current_batch.clone();
-                    let stream_batch_handle = current_stream_batch.clone();
+                    let stream_dispatch_handle = stream_dispatch.clone();
 
                     #[expect(clippy::disallowed_methods, reason = "incremental sender handle is stored and aborted when the parent sync_stream handler exits")]
                     tokio::spawn(async move {
                         let mut interval = tokio::time::interval(Duration::from_secs(1));
-                        // Skip re-emission of an unchanged stream batch (main
-                        // loop hasn't collected a new one since last tick).
-                        let mut last_stream_batch: Option<Arc<crate::kv::RoundBatch>> = None;
+                        // Stream-dispatch subscriptions. Broadcast cursor
+                        // starts one past the newest retained round so this
+                        // sender only emits rounds published after it
+                        // subscribed. Targeted rounds for this peer arrive
+                        // on the per-peer MPSC receiver.
+                        let mut broadcast_cursor =
+                            stream_dispatch_handle.initial_broadcast_cursor();
+                        let mut targeted_rx =
+                            stream_dispatch_handle.subscribe_targeted(&peer_name_incremental);
+                        // Stash a targeted round whose round_id is ahead
+                        // of our current broadcast cursor so we emit it
+                        // after the matching broadcast round rather than
+                        // standalone.
+                        let mut stashed_targeted: Option<
+                            Arc<crate::stream_dispatch::TargetedRound>,
+                        > = None;
 
                         loop {
                             interval.tick().await;
@@ -652,50 +675,83 @@ impl MeshController {
                                 }
                             }
 
-                            // Stream batches: drain-portion (broadcast) +
-                            // targeted entries addressed to this peer. Each
-                            // entry is chunked if oversized. On channel
-                            // full, the round's stream traffic for this
-                            // peer is dropped — no retry (at-most-once).
-                            // Application regenerates on its own retry cycle.
-                            let stream_batch = stream_batch_handle.read().clone();
-                            let fresh_batch = last_stream_batch
-                                .as_ref()
-                                .is_none_or(|last| !Arc::ptr_eq(last, &stream_batch));
-                            if fresh_batch {
-                                last_stream_batch = Some(stream_batch.clone());
-                                let mut entries = Vec::new();
-                                // Drain entries are broadcast: every peer emits.
-                                // Generation is per-value so concurrent publishes
-                                // to the same key get distinct tags.
-                                for (key, value) in &stream_batch.drain_entries {
-                                    entries.extend(chunk_value(
+                            // Stream rounds via the dispatch transport.
+                            // Each retained broadcast round emits its
+                            // drain entries first; the matching targeted
+                            // round (same round_id) follows so order is
+                            // preserved per-round. Targeted entries
+                            // whose round_id is older than our current
+                            // broadcast cursor are orphaned (their
+                            // broadcast was evicted from the ring) and
+                            // are discarded to preserve the ordering
+                            // invariant. On channel Full we break out
+                            // of this tick's emission; the retained
+                            // ring will let us resume where we left off
+                            // on the next tick. On Closed we exit the
+                            // sender task entirely.
+                            let poll = stream_dispatch_handle
+                                .poll_broadcast_rounds(broadcast_cursor);
+                            if poll.skipped > 0 {
+                                log::warn!(
+                                    peer = %peer_name_incremental,
+                                    skipped = poll.skipped,
+                                    new_cursor = poll.new_cursor,
+                                    "broadcast ring evicted rounds before this \
+                                     sender observed them"
+                                );
+                            }
+                            for bc_round in poll.rounds {
+                                // Purge any stashed / queued targeted
+                                // rounds that predate this broadcast
+                                // round — their matching broadcast was
+                                // evicted, so emitting them alone
+                                // would violate round ordering.
+                                loop {
+                                    let candidate = match stashed_targeted.take() {
+                                        Some(s) => s,
+                                        None => match targeted_rx.try_recv() {
+                                            Ok(r) => r,
+                                            Err(_) => break,
+                                        },
+                                    };
+                                    if candidate.round_id < bc_round.round_id {
+                                        log::debug!(
+                                            peer = %peer_name_incremental,
+                                            round_id = candidate.round_id,
+                                            "targeted round orphaned — matching \
+                                             broadcast already evicted"
+                                        );
+                                        continue;
+                                    }
+                                    // >= current broadcast round: stash for
+                                    // alignment below.
+                                    stashed_targeted = Some(candidate);
+                                    break;
+                                }
+
+                                // Chunk + emit broadcast entries.
+                                let mut broadcast_entries = Vec::new();
+                                for (key, value) in &bc_round.entries {
+                                    broadcast_entries.extend(chunk_value(
                                         key.clone(),
                                         next_generation(),
-                                        Bytes::from(value.clone()),
+                                        value.clone(),
                                         MAX_STREAM_CHUNK_BYTES,
                                     ));
                                 }
-                                // Targeted entries: only those addressed to this peer.
-                                for (target, key, value) in &stream_batch.targeted_entries {
-                                    if target == &peer_name_incremental {
-                                        entries.extend(chunk_value(
-                                            key.clone(),
-                                            next_generation(),
-                                            value.clone(),
-                                            MAX_STREAM_CHUNK_BYTES,
-                                        ));
-                                    }
-                                }
-                                if !entries.is_empty() {
+                                if !broadcast_entries.is_empty() {
+                                    let mut backpressured = false;
                                     for batch in build_stream_batches(
-                                        entries,
+                                        broadcast_entries,
                                         DEFAULT_MAX_CHUNKS_PER_BATCH,
                                         MAX_STREAM_CHUNK_BYTES,
                                     ) {
                                         let msg = StreamMessage {
-                                            message_type: StreamMessageType::StreamBatch as i32,
-                                            payload: Some(StreamPayload::StreamBatch(batch)),
+                                            message_type:
+                                                StreamMessageType::StreamBatch as i32,
+                                            payload: Some(StreamPayload::StreamBatch(
+                                                batch,
+                                            )),
                                             sequence: shared_sequence
                                                 .fetch_add(1, Ordering::Relaxed),
                                             peer_id: self_name_incremental.clone(),
@@ -705,22 +761,97 @@ impl MeshController {
                                             Err(mpsc::error::TrySendError::Full(_)) => {
                                                 log::debug!(
                                                     peer = %peer_name_incremental,
-                                                    "stream batch dropped on backpressure"
+                                                    round_id = bc_round.round_id,
+                                                    "broadcast batch dropped on \
+                                                     backpressure"
                                                 );
-                                                // TODO(metrics): bump
-                                                // stream_dropped_on_backpressure
+                                                backpressured = true;
                                                 break;
                                             }
-                                            Err(mpsc::error::TrySendError::Closed(_)) => {
+                                            Err(mpsc::error::TrySendError::Closed(
+                                                _,
+                                            )) => {
                                                 log::warn!(
                                                     peer = %peer_name_incremental,
-                                                    "stream sender: channel closed, stopping"
+                                                    "stream sender: channel closed, \
+                                                     stopping"
+                                                );
+                                                return;
+                                            }
+                                        }
+                                    }
+                                    if backpressured {
+                                        // Don't advance cursor — retry this
+                                        // round on the next tick while the
+                                        // ring still retains it.
+                                        break;
+                                    }
+                                }
+
+                                // Emit the matching targeted round if
+                                // present (same round_id). If stashed's
+                                // round_id is strictly greater than this
+                                // broadcast round, leave it for later.
+                                let targeted_for_round = match stashed_targeted
+                                    .as_ref()
+                                    .map(|s| s.round_id)
+                                {
+                                    Some(id) if id == bc_round.round_id => {
+                                        stashed_targeted.take()
+                                    }
+                                    _ => None,
+                                };
+                                if let Some(tr) = targeted_for_round {
+                                    let mut targeted_entries = Vec::new();
+                                    for (key, value) in &tr.entries {
+                                        targeted_entries.extend(chunk_value(
+                                            key.clone(),
+                                            next_generation(),
+                                            value.clone(),
+                                            MAX_STREAM_CHUNK_BYTES,
+                                        ));
+                                    }
+                                    for batch in build_stream_batches(
+                                        targeted_entries,
+                                        DEFAULT_MAX_CHUNKS_PER_BATCH,
+                                        MAX_STREAM_CHUNK_BYTES,
+                                    ) {
+                                        let msg = StreamMessage {
+                                            message_type:
+                                                StreamMessageType::StreamBatch as i32,
+                                            payload: Some(StreamPayload::StreamBatch(
+                                                batch,
+                                            )),
+                                            sequence: shared_sequence
+                                                .fetch_add(1, Ordering::Relaxed),
+                                            peer_id: self_name_incremental.clone(),
+                                        };
+                                        match tx_incremental.try_send(msg) {
+                                            Ok(()) => {}
+                                            Err(mpsc::error::TrySendError::Full(_)) => {
+                                                log::debug!(
+                                                    peer = %peer_name_incremental,
+                                                    round_id = tr.round_id,
+                                                    "targeted batch dropped on \
+                                                     backpressure"
+                                                );
+                                                break;
+                                            }
+                                            Err(mpsc::error::TrySendError::Closed(
+                                                _,
+                                            )) => {
+                                                log::warn!(
+                                                    peer = %peer_name_incremental,
+                                                    "stream sender: channel closed, \
+                                                     stopping"
                                                 );
                                                 return;
                                             }
                                         }
                                     }
                                 }
+
+                                broadcast_cursor = bc_round.round_id + 1;
                             }
 
                             let round_elapsed = round_start.elapsed();
@@ -1260,7 +1391,16 @@ impl MeshController {
         let (tx, rx) = mpsc::channel::<StreamMessage>(128);
         let outgoing_stream = tokio_stream::wrappers::ReceiverStream::new(rx);
 
-        let response = client.sync_stream(outgoing_stream).await.map_err(|e| {
+        // Advertise our peer_id via gRPC metadata so the server learns
+        // the remote identity at stream open, before any payload frame.
+        // The server can then register this peer with StreamDispatch
+        // eagerly and emit targeted rounds on the first tick instead of
+        // waiting for the first inbound payload message.
+        let mut request = tonic::Request::new(outgoing_stream);
+        if let Ok(value) = tonic::metadata::MetadataValue::try_from(self.self_name.as_str()) {
+            request.metadata_mut().insert(MESH_PEER_ID_HEADER, value);
+        }
+        let response = client.sync_stream(request).await.map_err(|e| {
             log::error!("Failed to establish sync_stream with {}: {}", peer_name, e);
             anyhow::anyhow!("sync_stream RPC failed: {e}")
         })?;

--- a/crates/mesh/src/lib.rs
+++ b/crates/mesh/src/lib.rs
@@ -22,6 +22,7 @@ mod ping_server;
 mod rate_limit_window;
 mod service;
 mod stores;
+mod stream_dispatch;
 mod sync;
 mod topology;
 mod tree_ops;

--- a/crates/mesh/src/ping_server.rs
+++ b/crates/mesh/src/ping_server.rs
@@ -6,7 +6,6 @@ use std::{
 };
 
 use anyhow::Result;
-use bytes::Bytes;
 use futures::Stream;
 use tokio::sync::mpsc;
 use tokio_stream::StreamExt;
@@ -39,12 +38,15 @@ use super::{
             SnapshotChunk, SnapshotRequest, StateUpdate, StreamAck, StreamMessage,
             StreamMessageType,
         },
-        try_ping, ClusterState,
+        try_ping, ClusterState, MESH_PEER_ID_HEADER,
     },
     stores::{StateStores, StoreType as LocalStoreType},
     sync::MeshSyncManager,
 };
-use crate::collector::{PeerWatermark, RoundBatch};
+use crate::{
+    collector::{PeerWatermark, RoundBatch},
+    stream_dispatch::StreamDispatch,
+};
 
 #[derive(Debug)]
 pub struct GossipService {
@@ -61,11 +63,12 @@ pub struct GossipService {
     /// the MeshController's central collector. Server-side sync_stream handlers
     /// read from this and apply per-peer watermark filtering.
     current_batch: Option<Arc<parking_lot::RwLock<Arc<RoundBatch>>>>,
-    /// Shared reference to the current stream RoundBatch, drained once
-    /// per round by the MeshController. Server-side handlers read
-    /// broadcast entries from this (drain_entries); targeted entries
-    /// are handled client-side where peer_name is known at spawn.
-    current_stream_batch: Option<Arc<parking_lot::RwLock<Arc<crate::kv::RoundBatch>>>>,
+    /// Shared stream dispatch transport. Server-side sync_stream
+    /// handlers subscribe to the broadcast ring (all peers) and to
+    /// their remote peer's targeted queue after learning the peer
+    /// identity from the `x-mesh-peer-id` request header or the
+    /// first inbound StreamMessage.
+    stream_dispatch: Option<Arc<StreamDispatch>>,
     /// Node-wide MeshKV handle. Owns the stream buffers, subscriber
     /// registry, and chunk assembler shared with the client-side
     /// SyncStream handlers.
@@ -296,7 +299,7 @@ impl GossipService {
             partition_detector: None,
             mtls_manager: None,
             current_batch: None,
-            current_stream_batch: None,
+            stream_dispatch: None,
             mesh_kv: None,
         }
     }
@@ -312,14 +315,12 @@ impl GossipService {
         self
     }
 
-    /// Attach the shared stream RoundBatch reference. Server-side
-    /// handlers emit broadcast drain_entries to their peer — targeted
-    /// entries stay on the client side where peer_name is known.
-    pub fn with_current_stream_batch(
-        mut self,
-        current_stream_batch: Arc<parking_lot::RwLock<Arc<crate::kv::RoundBatch>>>,
-    ) -> Self {
-        self.current_stream_batch = Some(current_stream_batch);
+    /// Attach the shared StreamDispatch transport. Server-side
+    /// handlers subscribe to the same broadcast ring and per-peer
+    /// targeted queues as client-side senders, so targeted delivery
+    /// works in both directions of every peer pair.
+    pub fn with_stream_dispatch(mut self, stream_dispatch: Arc<StreamDispatch>) -> Self {
+        self.stream_dispatch = Some(stream_dispatch);
         self
     }
 
@@ -466,6 +467,15 @@ impl Gossip for GossipService {
         &self,
         request: tonic::Request<tonic::Streaming<StreamMessage>>,
     ) -> Result<Response<Self::SyncStreamStream>, Status> {
+        // Pull the peer-id header off before consuming `request` via
+        // into_inner() — learned upfront when a modern client sets it,
+        // falling back to the payload-learning path (below) otherwise.
+        let header_peer_id = request
+            .metadata()
+            .get(MESH_PEER_ID_HEADER)
+            .and_then(|v| v.to_str().ok())
+            .filter(|s| !s.is_empty())
+            .map(str::to_string);
         let mut incoming = request.into_inner();
         let self_name = self.self_name.clone();
         let state = self.state.clone();
@@ -478,11 +488,24 @@ impl Gossip for GossipService {
         let (tx, rx) = mpsc::channel::<Result<StreamMessage, Status>>(CHANNEL_CAPACITY);
         let size_validator = MessageSizeValidator::default();
 
+        // Remote peer identity. Set once — either at stream open from
+        // the `x-mesh-peer-id` request header (modern client), or on
+        // the first inbound StreamMessage carrying a non-empty
+        // peer_id field (legacy client). Shared between the inbound
+        // handler (writer) and the server-side sender task (reader)
+        // so the sender can subscribe to its remote peer's targeted
+        // queue once the identity is known.
+        let learned_peer: Arc<parking_lot::RwLock<Option<String>>> =
+            Arc::new(parking_lot::RwLock::new(header_peer_id));
+
         // Spawn task to periodically send incremental updates.
         // Uses PeerWatermark reading from the shared RoundBatch (central collector).
         // If current_batch is not set (e.g., temporary GossipService for snapshots),
         // skip the sender task.
-        let incremental_sender_handle = if let Some(batch_handle) = self.current_batch.clone() {
+
+        let incremental_sender_handle = if let (Some(batch_handle), Some(dispatch)) =
+            (self.current_batch.clone(), self.stream_dispatch.clone())
+        {
             let tx_incremental = tx.clone();
             let self_name_incremental = self_name.clone();
             let size_validator_clone = size_validator.clone();
@@ -490,7 +513,8 @@ impl Gossip for GossipService {
             // arrives. Use a placeholder label for debug output — this doesn't
             // affect filtering correctness (each task has its own watermark).
             let peer_name_for_watermark = "server-inbound".to_string();
-            let stream_batch_handle = self.current_stream_batch.clone();
+            let dispatch_handle = dispatch.clone();
+            let learned_peer_sender = learned_peer.clone();
             #[expect(
                 clippy::disallowed_methods,
                 reason = "server-side incremental sender that runs for the lifetime of the sync_stream; terminates when the channel closes or handle is aborted"
@@ -499,7 +523,18 @@ impl Gossip for GossipService {
                 let mut watermark = PeerWatermark::new(peer_name_for_watermark);
                 let mut interval = tokio::time::interval(Duration::from_secs(1));
                 let mut sequence_counter: u64 = 0;
-                let mut last_stream_batch: Option<Arc<crate::kv::RoundBatch>> = None;
+                // Broadcast cursor starts one past the newest retained
+                // round: a fresh server-side sender only emits rounds
+                // published after it started, not historical retained ones.
+                let mut broadcast_cursor = dispatch_handle.initial_broadcast_cursor();
+                // Targeted subscription is deferred until peer_id is
+                // learned (either upfront from the header or from the
+                // first inbound payload message).
+                let mut targeted_sub: Option<(
+                    String,
+                    mpsc::Receiver<Arc<crate::stream_dispatch::TargetedRound>>,
+                    Option<Arc<crate::stream_dispatch::TargetedRound>>,
+                )> = None;
 
                 loop {
                     interval.tick().await;
@@ -569,73 +604,166 @@ impl Gossip for GossipService {
                         }
                     }
 
-                    // Server-side stream emission: broadcast drain_entries
-                    // only. Targeted entries stay on the client-side
-                    // (controller.rs) where peer_name is known at task
-                    // spawn. At-most-once: on channel full, drop without
-                    // retry.
-                    if let Some(sbh) = &stream_batch_handle {
-                        let stream_batch = sbh.read().clone();
-                        let fresh_batch = last_stream_batch
-                            .as_ref()
-                            .is_none_or(|last| !Arc::ptr_eq(last, &stream_batch));
-                        if fresh_batch {
-                            // Advance the tracker for every fresh Arc, not just
-                            // ones that produced work — otherwise a batch with
-                            // empty drain_entries stays "fresh" across ticks and
-                            // we keep re-checking it.
-                            last_stream_batch = Some(stream_batch.clone());
+                    // Lazy targeted subscription: once the inbound
+                    // handler has set learned_peer (or we got it
+                    // upfront from the header), subscribe to the
+                    // matching per-peer targeted queue.
+                    if targeted_sub.is_none() {
+                        if let Some(peer) = learned_peer_sender.read().clone() {
+                            let rx = dispatch_handle.subscribe_targeted(&peer);
+                            targeted_sub = Some((peer, rx, None));
                         }
-                        if fresh_batch && !stream_batch.drain_entries.is_empty() {
-                            let mut entries = Vec::new();
-                            // Generation is per-value so concurrent publishes
-                            // to the same key get distinct tags.
-                            for (key, value) in &stream_batch.drain_entries {
-                                entries.extend(chunk_value(
-                                    key.clone(),
-                                    next_generation(),
-                                    Bytes::from(value.clone()),
-                                    MAX_STREAM_CHUNK_BYTES,
-                                ));
+                    }
+
+                    // Stream rounds via the dispatch transport. Mirrors
+                    // the client-side sender: poll retained broadcast
+                    // rounds, align targeted-K to broadcast-K, purge
+                    // orphaned targeted whose broadcast was evicted.
+                    let poll = dispatch_handle.poll_broadcast_rounds(broadcast_cursor);
+                    if poll.skipped > 0 {
+                        log::warn!(
+                            skipped = poll.skipped,
+                            new_cursor = poll.new_cursor,
+                            "server-side broadcast ring evicted rounds before this \
+                             sender observed them"
+                        );
+                    }
+                    for bc_round in poll.rounds {
+                        // Purge stashed / queued targeted rounds older
+                        // than this broadcast round — matching broadcast
+                        // was evicted, so emitting targeted standalone
+                        // would violate ordering.
+                        if let Some((peer, rx, stash)) = targeted_sub.as_mut() {
+                            loop {
+                                let candidate = match stash.take() {
+                                    Some(s) => s,
+                                    None => match rx.try_recv() {
+                                        Ok(r) => r,
+                                        Err(_) => break,
+                                    },
+                                };
+                                if candidate.round_id < bc_round.round_id {
+                                    log::debug!(
+                                        peer = %peer,
+                                        round_id = candidate.round_id,
+                                        "server-side targeted round orphaned — matching \
+                                         broadcast already evicted"
+                                    );
+                                    continue;
+                                }
+                                *stash = Some(candidate);
+                                break;
                             }
-                            if !entries.is_empty() {
-                                for batch in build_stream_batches(
-                                    entries,
-                                    DEFAULT_MAX_CHUNKS_PER_BATCH,
-                                    MAX_STREAM_CHUNK_BYTES,
-                                ) {
-                                    sequence_counter += 1;
-                                    let msg = StreamMessage {
-                                        message_type: StreamMessageType::StreamBatch as i32,
-                                        payload: Some(
-                                            gossip::stream_message::Payload::StreamBatch(batch),
-                                        ),
-                                        sequence: sequence_counter,
-                                        peer_id: self_name_incremental.clone(),
-                                    };
-                                    match tx_incremental.try_send(Ok(msg)) {
-                                        Ok(()) => {}
-                                        Err(mpsc::error::TrySendError::Full(_)) => {
-                                            log::debug!(
-                                                "server-side stream batch dropped on backpressure"
-                                            );
-                                            // TODO(metrics): bump
-                                            // stream_dropped_on_backpressure
-                                            break;
-                                        }
-                                        Err(mpsc::error::TrySendError::Closed(_)) => {
-                                            log::warn!(
-                                                "server-side stream sender: channel closed, stopping"
-                                            );
-                                            return;
-                                        }
+                        }
+
+                        // Chunk + emit broadcast.
+                        let mut broadcast_entries = Vec::new();
+                        for (key, value) in &bc_round.entries {
+                            broadcast_entries.extend(chunk_value(
+                                key.clone(),
+                                next_generation(),
+                                value.clone(),
+                                MAX_STREAM_CHUNK_BYTES,
+                            ));
+                        }
+                        let mut backpressured = false;
+                        if !broadcast_entries.is_empty() {
+                            for batch in build_stream_batches(
+                                broadcast_entries,
+                                DEFAULT_MAX_CHUNKS_PER_BATCH,
+                                MAX_STREAM_CHUNK_BYTES,
+                            ) {
+                                sequence_counter += 1;
+                                let msg = StreamMessage {
+                                    message_type: StreamMessageType::StreamBatch as i32,
+                                    payload: Some(gossip::stream_message::Payload::StreamBatch(
+                                        batch,
+                                    )),
+                                    sequence: sequence_counter,
+                                    peer_id: self_name_incremental.clone(),
+                                };
+                                match tx_incremental.try_send(Ok(msg)) {
+                                    Ok(()) => {}
+                                    Err(mpsc::error::TrySendError::Full(_)) => {
+                                        log::debug!(
+                                            round_id = bc_round.round_id,
+                                            "server-side broadcast batch dropped on \
+                                             backpressure"
+                                        );
+                                        backpressured = true;
+                                        break;
+                                    }
+                                    Err(mpsc::error::TrySendError::Closed(_)) => {
+                                        log::warn!(
+                                            "server-side stream sender: channel closed, \
+                                             stopping"
+                                        );
+                                        return;
                                     }
                                 }
                             }
                         }
-                    } else if last_stream_batch.is_some() {
-                        // If handle became None (shouldn't normally), clear state.
-                        last_stream_batch = None;
+                        if backpressured {
+                            // Don't advance cursor; retry next tick.
+                            break;
+                        }
+
+                        // Emit matching targeted-K.
+                        let targeted_for_round = match targeted_sub.as_mut() {
+                            Some((_, _, stash))
+                                if stash.as_ref().map(|s| s.round_id)
+                                    == Some(bc_round.round_id) =>
+                            {
+                                stash.take()
+                            }
+                            _ => None,
+                        };
+                        if let Some(tr) = targeted_for_round {
+                            let mut targeted_entries = Vec::new();
+                            for (key, value) in &tr.entries {
+                                targeted_entries.extend(chunk_value(
+                                    key.clone(),
+                                    next_generation(),
+                                    value.clone(),
+                                    MAX_STREAM_CHUNK_BYTES,
+                                ));
+                            }
+                            for batch in build_stream_batches(
+                                targeted_entries,
+                                DEFAULT_MAX_CHUNKS_PER_BATCH,
+                                MAX_STREAM_CHUNK_BYTES,
+                            ) {
+                                sequence_counter += 1;
+                                let msg = StreamMessage {
+                                    message_type: StreamMessageType::StreamBatch as i32,
+                                    payload: Some(gossip::stream_message::Payload::StreamBatch(
+                                        batch,
+                                    )),
+                                    sequence: sequence_counter,
+                                    peer_id: self_name_incremental.clone(),
+                                };
+                                match tx_incremental.try_send(Ok(msg)) {
+                                    Ok(()) => {}
+                                    Err(mpsc::error::TrySendError::Full(_)) => {
+                                        log::debug!(
+                                            round_id = tr.round_id,
+                                            "server-side targeted batch dropped on \
+                                             backpressure"
+                                        );
+                                        break;
+                                    }
+                                    Err(mpsc::error::TrySendError::Closed(_)) => {
+                                        log::warn!(
+                                            "server-side stream sender: channel closed, \
+                                             stopping"
+                                        );
+                                        return;
+                                    }
+                                }
+                            }
+                        }
+
+                        broadcast_cursor = bc_round.round_id + 1;
                     }
                 }
             }))
@@ -653,12 +781,18 @@ impl Gossip for GossipService {
         use std::collections::HashMap;
         let mut snapshot_state: HashMap<LocalStoreType, (Vec<SnapshotChunk>, u64)> = HashMap::new();
 
+        let learned_peer_inbound = learned_peer.clone();
         #[expect(
             clippy::disallowed_methods,
             reason = "server-side stream handler that runs for the lifetime of the sync_stream gRPC connection; terminates when the stream closes"
         )]
         tokio::spawn(async move {
-            let mut peer_id = String::new();
+            let mut peer_id = learned_peer_inbound.read().clone().unwrap_or_default();
+            // Short-circuits the RwLock::read() once we've accepted an
+            // identity for this stream — learned_peer is write-once
+            // per connection, so after the first learn every
+            // subsequent message would otherwise take a pointless lock.
+            let mut peer_learned = !peer_id.is_empty();
             update_peer_connections(&peer_id, true);
 
             // Check if we need to request snapshots on connection
@@ -714,7 +848,54 @@ impl Gossip for GossipService {
                 match tokio::time::timeout(STREAM_IDLE_TIMEOUT, incoming.next()).await {
                     Ok(Some(Ok(msg))) => {
                         sequence += 1;
-                        peer_id.clone_from(&msg.peer_id);
+                        // Accept the claimed peer_id before copying it
+                        // into the task-local `peer_id`. The task-local
+                        // drives the teardown log and connection-gauge
+                        // decrement at stream end; writing a mismatched
+                        // value into it would attribute the close to a
+                        // spoofed peer and leak the real peer's gauge.
+                        //
+                        // Reject mid-stream peer_id changes: the
+                        // stream's remote identity is fixed for the
+                        // connection, so a different peer_id on a later
+                        // message is either a bug or a peer trying to
+                        // claim another node's targeted entries. Close
+                        // and let the client reconnect. Pre-mTLS-binding
+                        // defence; mTLS-derived identity is the
+                        // authoritative long-term fix.
+                        if !peer_learned && !msg.peer_id.is_empty() {
+                            let mut learned = learned_peer_inbound.write();
+                            match learned.as_ref() {
+                                None => {
+                                    *learned = Some(msg.peer_id.clone());
+                                    peer_id.clone_from(&msg.peer_id);
+                                    peer_learned = true;
+                                }
+                                Some(existing) if existing == &msg.peer_id => {
+                                    peer_id.clone_from(existing);
+                                    peer_learned = true;
+                                }
+                                Some(existing) => {
+                                    log::warn!(
+                                        expected_peer_id = %existing,
+                                        received_peer_id = %msg.peer_id,
+                                        "peer_id changed mid-stream; closing sync_stream"
+                                    );
+                                    break;
+                                }
+                            }
+                        } else if peer_learned && msg.peer_id != peer_id {
+                            // Empty peer_id after learn is also a
+                            // changed identity — a stream bound to a
+                            // learned peer shouldn't accept unowned
+                            // frames.
+                            log::warn!(
+                                expected_peer_id = %peer_id,
+                                received_peer_id = %msg.peer_id,
+                                "peer_id changed mid-stream; closing sync_stream"
+                            );
+                            break;
+                        }
 
                         match msg.message_type() {
                             StreamMessageType::IncrementalUpdate => {
@@ -1050,7 +1231,7 @@ impl Gossip for GossipService {
                                         partition_detector: None,
                                         mtls_manager: None,
                                         current_batch: None,
-                                        current_stream_batch: None,
+                                        stream_dispatch: None,
                                         mesh_kv: None,
                                     };
                                     let chunks = service.create_snapshot_chunks(store_type, 100); // chunk_size = 100 entries

--- a/crates/mesh/src/service.rs
+++ b/crates/mesh/src/service.rs
@@ -22,6 +22,14 @@ pub mod gossip {
     #![allow(clippy::trivially_copy_pass_by_ref, clippy::allow_attributes)]
     tonic::include_proto!("mesh.gossip");
 }
+
+/// gRPC request-metadata header the sync_stream client sets so the
+/// server can learn the remote peer identity at stream open, before
+/// any payload frames. A single constant on both sides avoids typo
+/// drift (e.g. `x-mesh-peer_id` vs `x-mesh-peer-id`) silently
+/// breaking the handshake and falling back to payload learning.
+/// Name lower-cased because HTTP/2 mandates lowercase header names.
+pub const MESH_PEER_ID_HEADER: &str = "x-mesh-peer-id";
 use gossip::{
     gossip_client, gossip_message, GossipMessage, NodeState, NodeStatus, NodeUpdate, Ping,
     StateSync,
@@ -469,7 +477,10 @@ impl MeshServer {
         // Share the controller's current_batch so server-side sync_stream
         // handlers use the same centrally collected data as client-side.
         service = service.with_current_batch(controller.current_batch());
-        service = service.with_current_stream_batch(controller.current_stream_batch());
+        // Share the controller's StreamDispatch so server-side handlers
+        // subscribe to the same broadcast ring and targeted queues as
+        // the client-side per-peer senders.
+        service = service.with_stream_dispatch(controller.stream_dispatch());
 
         // Add mTLS support if configured
         if let Some(mtls_manager) = self.mtls_manager.clone() {

--- a/crates/mesh/src/stream_dispatch.rs
+++ b/crates/mesh/src/stream_dispatch.rs
@@ -1,0 +1,461 @@
+//! Handoff transport between the central round collector and
+//! per-peer SyncStream sender tasks for stream-mode traffic.
+//!
+//! Broadcast drain entries ride a retention ring so an active sender
+//! still observes past rounds up to the ring depth even if its task
+//! tick was delayed longer than the collection interval. Rounds that
+//! roll off the back of the ring before a sender observed them
+//! surface as an explicit gap log on the next poll instead of a
+//! silent overwrite.
+//!
+//! Targeted entries fan out into bounded per-peer MPSC queues keyed
+//! by the target peer id. A sender task subscribes once (on peer-id
+//! learn, either from the inbound stream header or the first payload
+//! message) and owns its own queue. Full queue or missing subscriber
+//! on publish → drop + log at the dispatch boundary: explicit
+//! at-most-once where the previous replace-the-Arc model was
+//! silently lossy under any timing skew between the collector and
+//! sender tasks.
+//!
+//! Both pipes stamp each round with the same monotonic `round_id`
+//! so per-peer senders can align emission order: broadcast-K must
+//! precede targeted-K for the same round. Targeted rounds older than
+//! the peer's current broadcast position are dropped — if the
+//! matching broadcast round was evicted from the ring, emitting the
+//! targeted portion alone would violate the ordering invariant.
+
+use std::{
+    collections::{HashMap, VecDeque},
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+};
+
+use bytes::Bytes;
+use parking_lot::RwLock;
+use tokio::sync::mpsc;
+use tracing as log;
+
+/// Broadcast ring depth. 4 rounds at a 1 Hz collection tick absorb
+/// transient sender stalls up to ~4 s while capping steady-state
+/// memory to `depth × average_round_size`.
+pub const DEFAULT_BROADCAST_RING_DEPTH: usize = 4;
+
+/// Per-peer targeted queue depth. 4 rounds of targeted payloads per
+/// peer; full queue → drop with explicit log (at-most-once).
+pub const DEFAULT_TARGETED_QUEUE_DEPTH: usize = 4;
+
+/// One round of drained broadcast entries. Shared via `Arc` so a
+/// single allocation is reused across every subscribed peer — the
+/// "one payload copy + O(peers) metadata" property from the design
+/// spec.
+#[derive(Debug)]
+pub struct BroadcastRound {
+    pub round_id: u64,
+    pub entries: Vec<(String, Bytes)>,
+}
+
+/// One round of drained targeted entries for a specific peer.
+/// Exactly one `TargetedRound` is enqueued per peer per collection
+/// round (never per entry), so queue depth is bounded in *rounds*
+/// rather than entry count — one large round costs the same slot as
+/// a small one.
+#[derive(Debug)]
+pub struct TargetedRound {
+    pub round_id: u64,
+    pub entries: Vec<(String, Bytes)>,
+}
+
+/// Shared dispatch transport between the central collector and
+/// per-peer sender tasks.
+#[derive(Debug)]
+pub struct StreamDispatch {
+    next_round_id: AtomicU64,
+    broadcast: RwLock<BroadcastRing>,
+    targeted: RwLock<HashMap<String, mpsc::Sender<Arc<TargetedRound>>>>,
+    targeted_depth: usize,
+}
+
+#[derive(Debug)]
+struct BroadcastRing {
+    depth: usize,
+    rounds: VecDeque<Arc<BroadcastRound>>,
+}
+
+impl BroadcastRing {
+    fn push(&mut self, round: Arc<BroadcastRound>) {
+        if self.rounds.len() >= self.depth {
+            self.rounds.pop_front();
+        }
+        self.rounds.push_back(round);
+    }
+
+    fn newest_id(&self) -> Option<u64> {
+        self.rounds.back().map(|r| r.round_id)
+    }
+
+    fn oldest_id(&self) -> Option<u64> {
+        self.rounds.front().map(|r| r.round_id)
+    }
+
+    /// Collect retained rounds with `round_id >= since`. If the
+    /// oldest retained round is newer than `since`, returns
+    /// `Some(oldest)` as the gap-adjusted start so the caller can
+    /// log the jump and advance its cursor accordingly.
+    fn rounds_since(&self, since: u64) -> (Vec<Arc<BroadcastRound>>, Option<u64>) {
+        let Some(oldest) = self.oldest_id() else {
+            return (Vec::new(), None);
+        };
+        let (start, gap_advance) = if oldest > since {
+            (oldest, Some(oldest))
+        } else {
+            (since, None)
+        };
+        let rounds: Vec<_> = self
+            .rounds
+            .iter()
+            .skip_while(|r| r.round_id < start)
+            .cloned()
+            .collect();
+        (rounds, gap_advance)
+    }
+}
+
+/// Result of polling the broadcast ring. `skipped` counts rounds
+/// the caller lost (ring rolled past their cursor).
+#[derive(Debug)]
+pub struct BroadcastPoll {
+    pub rounds: Vec<Arc<BroadcastRound>>,
+    pub new_cursor: u64,
+    pub skipped: u64,
+}
+
+impl StreamDispatch {
+    pub fn new() -> Self {
+        Self::with_capacity(DEFAULT_BROADCAST_RING_DEPTH, DEFAULT_TARGETED_QUEUE_DEPTH)
+    }
+
+    pub fn with_capacity(broadcast_depth: usize, targeted_depth: usize) -> Self {
+        Self {
+            next_round_id: AtomicU64::new(1),
+            broadcast: RwLock::new(BroadcastRing {
+                depth: broadcast_depth,
+                rounds: VecDeque::with_capacity(broadcast_depth),
+            }),
+            targeted: RwLock::new(HashMap::new()),
+            targeted_depth,
+        }
+    }
+
+    /// Publish one drained collection round into the dispatch
+    /// transport. `drain_entries` become a single broadcast round
+    /// retained in the ring; `targeted_entries` are grouped by
+    /// target peer into one `TargetedRound` per peer and enqueued
+    /// into each target's per-peer queue (dropped + logged if the
+    /// peer has no subscriber or its queue is full).
+    ///
+    /// Returns the `round_id` stamped on this round, so callers can
+    /// log or correlate it.
+    pub fn publish_round(
+        &self,
+        drain_entries: Vec<(String, Bytes)>,
+        targeted_entries: Vec<(String, String, Bytes)>,
+    ) -> u64 {
+        let round_id = self.next_round_id.fetch_add(1, Ordering::Relaxed);
+
+        let broadcast_round = Arc::new(BroadcastRound {
+            round_id,
+            entries: drain_entries,
+        });
+        self.broadcast.write().push(broadcast_round);
+
+        if targeted_entries.is_empty() {
+            return round_id;
+        }
+
+        let mut per_peer: HashMap<String, Vec<(String, Bytes)>> = HashMap::new();
+        for (target, key, value) in targeted_entries {
+            per_peer.entry(target).or_default().push((key, value));
+        }
+
+        // Hold the write guard while publishing so we can evict
+        // subscribers whose receivers were dropped (Closed) without a
+        // separate round-trip through the lock. subscribe / unsubscribe
+        // on other senders wait briefly but are themselves rare.
+        let mut subscribers = self.targeted.write();
+        for (target, entries) in per_peer {
+            let round = Arc::new(TargetedRound { round_id, entries });
+            let Some(tx) = subscribers.get(&target) else {
+                log::debug!(
+                    peer = %target,
+                    round_id,
+                    "targeted round dropped: peer has no subscriber"
+                );
+                continue;
+            };
+            match tx.try_send(round) {
+                Ok(()) => {}
+                Err(mpsc::error::TrySendError::Full(_)) => {
+                    log::debug!(
+                        peer = %target,
+                        round_id,
+                        "targeted round dropped: peer queue full"
+                    );
+                }
+                Err(mpsc::error::TrySendError::Closed(_)) => {
+                    log::debug!(
+                        peer = %target,
+                        round_id,
+                        "targeted round dropped: receiver gone, evicting subscriber"
+                    );
+                    subscribers.remove(&target);
+                }
+            }
+        }
+
+        round_id
+    }
+
+    /// Register a peer for targeted delivery. Returns the receiver
+    /// half; the caller owns it for the lifetime of its sender task.
+    /// A second subscription for the same peer replaces the first
+    /// (the prior receiver sees `None` on its next `recv`, which
+    /// the prior task treats as a shutdown signal).
+    pub fn subscribe_targeted(&self, peer_id: &str) -> mpsc::Receiver<Arc<TargetedRound>> {
+        let (tx, rx) = mpsc::channel(self.targeted_depth);
+        self.targeted.write().insert(peer_id.to_string(), tx);
+        rx
+    }
+
+    /// Drop a peer's targeted subscription (e.g. on stream teardown).
+    /// No-op if the peer wasn't subscribed. Normally not needed —
+    /// `publish_round` already evicts entries whose receiver has been
+    /// dropped on the next targeted round attempt — but exposed for
+    /// tests and for explicit cleanup.
+    #[cfg(test)]
+    pub fn unsubscribe_targeted(&self, peer_id: &str) {
+        self.targeted.write().remove(peer_id);
+    }
+
+    /// Starting broadcast cursor for a new subscriber. Set to one
+    /// past the newest retained round so a fresh peer only observes
+    /// rounds published after they subscribed — retained rounds
+    /// exist to absorb sender delays for already-subscribed peers,
+    /// not to replay history to newcomers (streams are at-most-once
+    /// and ephemeral by design).
+    pub fn initial_broadcast_cursor(&self) -> u64 {
+        self.broadcast
+            .read()
+            .newest_id()
+            .map(|id| id + 1)
+            .unwrap_or(1)
+    }
+
+    /// Poll the broadcast ring for retained rounds at or after
+    /// `next_round_id`. If the ring's oldest retained round is
+    /// newer than the caller's cursor, the caller lost rounds —
+    /// `skipped` reports how many and `new_cursor` jumps to the
+    /// oldest retained id. Callers log the gap and advance; retained
+    /// rounds then emit in `round_id` order.
+    pub fn poll_broadcast_rounds(&self, next_round_id: u64) -> BroadcastPoll {
+        let ring = self.broadcast.read();
+        let (rounds, gap_advance) = ring.rounds_since(next_round_id);
+        let skipped = gap_advance.map_or(0, |a| a.saturating_sub(next_round_id));
+        let new_cursor = rounds
+            .last()
+            .map(|r| r.round_id + 1)
+            .or_else(|| gap_advance.or_else(|| ring.newest_id().map(|id| id + 1)))
+            .unwrap_or(next_round_id);
+        BroadcastPoll {
+            rounds,
+            new_cursor,
+            skipped,
+        }
+    }
+}
+
+impl Default for StreamDispatch {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bs(s: &str) -> Bytes {
+        Bytes::copy_from_slice(s.as_bytes())
+    }
+
+    #[test]
+    fn test_publish_stamps_monotonic_round_ids() {
+        let d = StreamDispatch::new();
+        let r1 = d.publish_round(vec![], vec![]);
+        let r2 = d.publish_round(vec![], vec![]);
+        let r3 = d.publish_round(vec![], vec![]);
+        assert_eq!(r1, 1);
+        assert_eq!(r2, 2);
+        assert_eq!(r3, 3);
+    }
+
+    #[test]
+    fn test_new_subscriber_skips_pre_subscription_rounds() {
+        let d = StreamDispatch::new();
+        d.publish_round(vec![("k".into(), bs("v"))], vec![]);
+        d.publish_round(vec![("k".into(), bs("v"))], vec![]);
+        // Fresh subscriber starts at newest+1: no replay.
+        let cursor = d.initial_broadcast_cursor();
+        let poll = d.poll_broadcast_rounds(cursor);
+        assert!(poll.rounds.is_empty());
+        assert_eq!(poll.skipped, 0);
+    }
+
+    #[test]
+    fn test_poll_returns_retained_rounds_in_order() {
+        let d = StreamDispatch::new();
+        let cursor = d.initial_broadcast_cursor();
+        d.publish_round(vec![("a".into(), bs("1"))], vec![]);
+        d.publish_round(vec![("b".into(), bs("2"))], vec![]);
+        d.publish_round(vec![("c".into(), bs("3"))], vec![]);
+        let poll = d.poll_broadcast_rounds(cursor);
+        assert_eq!(poll.rounds.len(), 3);
+        assert_eq!(poll.rounds[0].entries[0].0, "a");
+        assert_eq!(poll.rounds[1].entries[0].0, "b");
+        assert_eq!(poll.rounds[2].entries[0].0, "c");
+        assert_eq!(poll.skipped, 0);
+        assert_eq!(poll.new_cursor, poll.rounds[2].round_id + 1);
+    }
+
+    #[test]
+    fn test_gap_detection_on_ring_overflow() {
+        // Depth 2 → publish 5 rounds → ring retains 4..5.
+        let d = StreamDispatch::with_capacity(2, 4);
+        let cursor = d.initial_broadcast_cursor();
+        for i in 0..5 {
+            d.publish_round(vec![(format!("k{i}"), bs("v"))], vec![]);
+        }
+        let poll = d.poll_broadcast_rounds(cursor);
+        assert_eq!(
+            poll.rounds.len(),
+            2,
+            "only depth=2 rounds retained: ids 4 and 5"
+        );
+        assert!(poll.skipped > 0, "gap must be reported");
+        assert_eq!(
+            poll.rounds[0].round_id,
+            cursor + poll.skipped,
+            "first emitted round equals cursor advanced past the gap"
+        );
+        assert_eq!(
+            poll.new_cursor,
+            poll.rounds.last().unwrap().round_id + 1,
+            "new_cursor parks one past the last emitted round"
+        );
+    }
+
+    #[test]
+    fn test_advancing_cursor_past_newest_reports_no_skip() {
+        let d = StreamDispatch::new();
+        let cursor = d.initial_broadcast_cursor();
+        d.publish_round(vec![("k".into(), bs("v"))], vec![]);
+        let poll = d.poll_broadcast_rounds(cursor);
+        assert_eq!(poll.rounds.len(), 1);
+        // Second poll at new_cursor should get nothing and no skip.
+        let poll2 = d.poll_broadcast_rounds(poll.new_cursor);
+        assert!(poll2.rounds.is_empty());
+        assert_eq!(poll2.skipped, 0);
+    }
+
+    #[tokio::test]
+    async fn test_targeted_round_reaches_subscribed_peer_only() {
+        let d = StreamDispatch::new();
+        let mut rx_a = d.subscribe_targeted("A");
+        let mut rx_b = d.subscribe_targeted("B");
+        d.publish_round(
+            vec![],
+            vec![
+                ("A".into(), "k1".into(), bs("for-a")),
+                ("B".into(), "k2".into(), bs("for-b")),
+                ("A".into(), "k3".into(), bs("also-for-a")),
+            ],
+        );
+
+        let ra = rx_a.recv().await.unwrap();
+        assert_eq!(ra.entries.len(), 2, "both A-entries grouped in one round");
+        assert_eq!(ra.entries[0].1, bs("for-a"));
+
+        let rb = rx_b.recv().await.unwrap();
+        assert_eq!(rb.entries.len(), 1);
+        assert_eq!(rb.entries[0].1, bs("for-b"));
+
+        assert_eq!(ra.round_id, rb.round_id, "same round_id stamped on both");
+    }
+
+    #[tokio::test]
+    async fn test_targeted_without_subscriber_is_dropped() {
+        let d = StreamDispatch::new();
+        // No subscription for "nobody"; publish_round logs + drops.
+        let round_id = d.publish_round(vec![], vec![("nobody".into(), "k".into(), bs("orphan"))]);
+        assert_eq!(round_id, 1);
+    }
+
+    #[tokio::test]
+    async fn test_targeted_queue_full_drops_without_blocking() {
+        let d = StreamDispatch::with_capacity(4, 1);
+        let mut rx = d.subscribe_targeted("A");
+        // Fill the queue with a round that won't be drained.
+        d.publish_round(vec![], vec![("A".into(), "k1".into(), bs("v1"))]);
+        // Next round for A — queue full, should be dropped + logged.
+        d.publish_round(vec![], vec![("A".into(), "k2".into(), bs("v2"))]);
+
+        let first = rx.recv().await.unwrap();
+        assert_eq!(first.entries[0].0, "k1");
+
+        // Ensure a third publish (now with capacity) lands.
+        d.publish_round(vec![], vec![("A".into(), "k3".into(), bs("v3"))]);
+        let third = rx.recv().await.unwrap();
+        assert_eq!(third.entries[0].0, "k3");
+    }
+
+    #[tokio::test]
+    async fn test_resubscribe_closes_prior_subscription() {
+        let d = StreamDispatch::new();
+        let mut rx_old = d.subscribe_targeted("A");
+        d.publish_round(vec![], vec![("A".into(), "k1".into(), bs("v1"))]);
+        let _ = rx_old.recv().await.unwrap();
+
+        let mut rx_new = d.subscribe_targeted("A");
+        // Old receiver now sees channel closed (sender dropped on
+        // hashmap replace).
+        assert!(rx_old.recv().await.is_none());
+
+        d.publish_round(vec![], vec![("A".into(), "k2".into(), bs("v2"))]);
+        let r = rx_new.recv().await.unwrap();
+        assert_eq!(r.entries[0].0, "k2");
+    }
+
+    #[tokio::test]
+    async fn test_unsubscribe_removes_peer() {
+        let d = StreamDispatch::new();
+        let _rx = d.subscribe_targeted("A");
+        d.unsubscribe_targeted("A");
+        // Publishing after unsubscribe drops the targeted round.
+        d.publish_round(vec![], vec![("A".into(), "k".into(), bs("v"))]);
+    }
+
+    #[test]
+    fn test_broadcast_and_targeted_share_round_id() {
+        let d = StreamDispatch::new();
+        let cursor = d.initial_broadcast_cursor();
+        let _rx = d.subscribe_targeted("A");
+        let round_id = d.publish_round(
+            vec![("b".into(), bs("bcast"))],
+            vec![("A".into(), "t".into(), bs("tgt"))],
+        );
+        let poll = d.poll_broadcast_rounds(cursor);
+        assert_eq!(poll.rounds.len(), 1);
+        assert_eq!(poll.rounds[0].round_id, round_id);
+    }
+}


### PR DESCRIPTION
## Description

### Problem

The mesh stream-mode path had a silent-loss regression window flagged in [PR #1254 review `r3112678510`](https://github.com/lightseekorg/smg/pull/1254#discussion_r3112678510): the central round collector replaced a single shared `Arc<RoundBatch>` slot each tick, and per-peer sender tasks compared pointer identity to decide whether to emit. If any sender loop was delayed for more than one collection interval (for example while chunking a large incremental batch on the prior tick), the next collection **overwrote** the pending round before any sender observed it. The stream entries for that round were drained from their buffers and lost permanently — **without any backpressure signal firing**.

Layered on top of that: server-side `sync_stream` handlers were emitting only broadcast `drain_entries` and ignoring `targeted_entries`, so `publish_to(initiator, ...)` was broken in one direction of every peer pair ([PR #1254 `r3112387632`](https://github.com/lightseekorg/smg/pull/1254#discussion_r3112387632)). Tree repair relies on bidirectional targeted routing, so the bug fires on any repair session whose responder happens to be the non-initiator side of the peer pair.

### Solution

Replace the single-slot `Arc<RoundBatch>` handoff with a dedicated dispatch transport in a new `stream_dispatch.rs`, and push server-side peer identity discovery up to the stream-open gRPC metadata so targeted routing can subscribe immediately.

**Broadcast ring** (`BroadcastRound`)
- Retains the last N (default 4) drained rounds.
- `drain_entries` convert `Vec<u8>` → `Bytes` once at the central boundary, then fan out as one `Arc<BroadcastRound>` shared across every subscribed peer reader — preserves the "one payload copy + O(peers) metadata" property from the design spec.
- Per-peer cursor walks the retained range. When `ring.front() > cursor` the sender skipped rounds; we log the skip count and advance past the gap.

**Per-peer targeted MPSCs** (`TargetedRound`)
- One `tokio::sync::mpsc::Sender<Arc<TargetedRound>>` per subscribed peer, default queue depth 4.
- `targeted_entries` grouped by target peer inside `publish_round`: one `TargetedRound` per peer per collection tick, **not** one per entry — queue depth bounds rounds, not entry count.
- Full queue / missing subscriber / receiver gone = drop + log + evict at the dispatch boundary. Explicit at-most-once where the old model was silently lossy under any timing skew.

**Round-id alignment**
- Both pipes stamp each round with the same monotonic `round_id` (a single `AtomicU64::fetch_add(1)`).
- Per-peer senders emit broadcast-K before targeted-K and discard targeted rounds whose matching broadcast was evicted from the ring — preserves ordering and prevents orphan targeted entries from masquerading as fresh.

**Server-side peer identity**
- New `MESH_PEER_ID_HEADER = "x-mesh-peer-id"` constant (shared by client + server in `service.rs`) — avoids typo drift from a raw string literal on each side.
- Client sets the header on every `sync_stream` RPC open. Server reads it from `request.metadata()` before consuming `request.into_inner()`, so the targeted subscription can start on the first tick.
- Older clients without the header still work: server falls back to the legacy payload-learning path (`msg.peer_id` on the first inbound message).

**Server-side peer-id hardening** (folds in [PR #1260](https://github.com/lightseekorg/smg/pull/1260))
- Mid-stream `peer_id` changes close the stream (reject the swap, don't silently reroute).
- Empty `peer_id` after learn is also an identity change and triggers the same close.
- `clone_from(&msg.peer_id)` happens **inside the accept arms** only. On reject, the task-local `peer_id` still holds the identity we locked in, so the teardown log at the end of the task and `update_peer_connections(&peer_id, false)` attribute the close to the real peer — fixes the phantom-connection-gauge leak.
- `peer_learned: bool` short-circuits the `RwLock::read()` after first learn; `learned_peer` is write-once per connection, so subsequent inbound messages skip the lock entirely.

## Changes

- **`crates/mesh/src/stream_dispatch.rs`** (new, 392 lines) — `StreamDispatch`, `BroadcastRound`, `TargetedRound`, `BroadcastPoll`, `DEFAULT_BROADCAST_RING_DEPTH = 4`, `DEFAULT_TARGETED_QUEUE_DEPTH = 4`. 11 unit tests covering monotonic ids, fresh-subscriber cursor semantics, retention ring ordering, gap detection on overflow, per-peer targeted isolation, drop-on-missing-subscriber, drop-on-full-queue, resubscribe closes prior, round-id alignment.
- **`crates/mesh/src/service.rs`** — add `pub const MESH_PEER_ID_HEADER: &str = "x-mesh-peer-id"`; wire `controller.stream_dispatch()` into `GossipService::with_stream_dispatch(...)` in the builder path.
- **`crates/mesh/src/controller.rs`**
  - Drop `current_stream_batch: Arc<RwLock<Arc<kv::RoundBatch>>>` field + accessor.
  - Add `stream_dispatch: Arc<StreamDispatch>` + `stream_dispatch()` accessor.
  - Central `event_loop` converts `drain_entries` `Vec<u8>` → `Bytes` once and calls `self.stream_dispatch.publish_round(drain_bytes, targeted_entries)`.
  - Client-side `sync_stream` opens with `MESH_PEER_ID_HEADER` metadata set to `self.self_name`.
  - Per-peer sender loop rewritten: subscribe targeted, initialize broadcast cursor at `initial_broadcast_cursor()`, poll retained rounds each tick, emit broadcast-K then targeted-K in round-id order, discard orphans, log gap on ring overflow, backpressure on channel Full retries next tick without advancing cursor.
- **`crates/mesh/src/ping_server.rs`**
  - Drop `current_stream_batch` field + `with_current_stream_batch` builder.
  - Add `stream_dispatch: Option<Arc<StreamDispatch>>` field + `with_stream_dispatch` builder.
  - Read `x-mesh-peer-id` header off `request` before `into_inner()`, seed `learned_peer: Arc<RwLock<Option<String>>>`.
  - Server-side sender loop: lazy targeted subscribe (once `learned_peer` is set), same poll/emit/gap/orphan-discard structure as the client side.
  - Inbound loop: clone_from-into-accept-arms + mid-stream reject + empty-reject + peer_learned lock-skip, seeded from header if present.
- **`crates/mesh/src/lib.rs`** — register `mod stream_dispatch;`.

## Test Plan

- [x] `cargo check -p smg-mesh` — clean
- [x] `cargo test -p smg-mesh --lib` — **248 tests pass**, 2 ignored (was 237; 11 new `stream_dispatch::tests::*`)
- [x] New unit tests cover the dispatch-level invariants end-to-end: monotonic `round_id`, fresh-subscriber skips pre-subscription retained rounds, poll returns rounds in order, gap detection on ring overflow, targeted only reaches subscribed peer, missing-subscriber drop is non-fatal, full-queue drop doesn't block publishers, resubscribe closes prior receiver, round-id shared across broadcast/targeted publish.
- [x] Full gossip integration suite (`tests::comprehensive::*`) passes — including `test_multi_peer_tenant_delta_broadcast` which exercises broadcast fan-out through the new ring path.
- [x] Pre-commit: rustfmt + clippy pass.

**Not covered in this PR** (tracked as follow-ups):
- Integration test that forces a sender stall longer than a collection interval and asserts the delayed sender still observes the missed rounds via the retention ring.
- End-to-end test for `publish_to(initiator, ...)` over the server-side targeted path (needs a multi-node harness where the non-initiator half exercises the new server-side subscription).
- mTLS cert subject → `learned_peer` authoritative binding via a tonic interceptor. The `x-mesh-peer-id` header seam gives us the natural insertion point — the interceptor validates the header against the TLS cert before the handler runs. Mesh-v2 spec already treats mTLS (`require_client_cert: true`) as the cluster auth boundary, so this is purely a verification step on top of what's already deployed.
- Hoisting `chunk_value` into a central stage so each round's `Vec<StreamEntry>` is computed once rather than once per peer sender (×N amplification).

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Restructured internal message delivery system for broadcast and targeted peer communication with improved ring buffer management
  * Enhanced peer identification during stream connection setup using request metadata headers
  * Updated backpressure behavior to prevent message loss during high throughput scenarios by deferring emission rather than dropping entries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->