### PR TITLE
perf(mesh): carry drain stream entries as Bytes through RoundBatch

### DIFF
--- a/crates/mesh/src/controller.rs
+++ b/crates/mesh/src/controller.rs
@@ -9,7 +9,6 @@ use std::{
 };
 
 use anyhow::Result;
-use bytes::Bytes;
 use rand::seq::{IndexedRandom, SliceRandom};
 use tokio::sync::{mpsc, watch, Mutex};
 use tonic::transport::{ClientTlsConfig, Endpoint};
@@ -672,7 +671,7 @@ impl MeshController {
                                     entries.extend(chunk_value(
                                         key.clone(),
                                         next_generation(),
-                                        Bytes::from(value.clone()),
+                                        value.clone(),
                                         MAX_STREAM_CHUNK_BYTES,
                                     ));
                                 }

--- a/crates/mesh/src/kv.rs
+++ b/crates/mesh/src/kv.rs
@@ -110,9 +110,13 @@ pub struct Subscription {
     pub receiver: mpsc::Receiver<SubscriptionEvent>,
 }
 
-/// Function signature for stream drain callbacks. Called exactly once per gossip
-/// round. Returns accumulated entries to be sent in this round's batch.
-pub type StreamDrainFn = Box<dyn Fn() -> Vec<(String, Vec<u8>)> + Send + Sync>;
+/// Function signature for stream drain callbacks. Called exactly once per
+/// gossip round. Returns accumulated entries to be sent in this round's
+/// batch. Values are `Bytes` so fan-out to N peers is an Arc refcount bump
+/// per peer rather than N heap copies — keeps a single ~1.5 GB tenant-delta
+/// round from ballooning to 20 × 1.5 GB when chunked across every peer's
+/// sender task.
+pub type StreamDrainFn = Box<dyn Fn() -> Vec<(String, Bytes)> + Send + Sync>;
 
 /// Handle returned by `register_drain`. Dropping unregisters the drain callback.
 /// Use `drop(handle)` to explicitly unregister.
@@ -223,7 +227,7 @@ impl DrainRegistry {
 
     /// Call all registered drains. Returns accumulated entries.
     /// Called exactly once per gossip round.
-    fn drain_all(&self) -> Vec<(String, Vec<u8>)> {
+    fn drain_all(&self) -> Vec<(String, Bytes)> {
         let mut all_entries = Vec::new();
         for entry in &self.drains {
             let drain_fn = entry.value();
@@ -438,7 +442,9 @@ pub struct RoundBatch {
     pub targeted_entries: Vec<(String, String, Bytes)>,
     /// Entries from registered drain callbacks (e.g., TreeSyncAdapter pending deltas).
     /// Broadcast traffic (td:*) flows through this path, not through a buffer.
-    pub drain_entries: Vec<(String, Vec<u8>)>,
+    /// Values are `Bytes` so per-peer senders clone by Arc-refcount bump when
+    /// fanning out, not by a full heap copy per peer.
+    pub drain_entries: Vec<(String, Bytes)>,
 }
 
 /// Generic, application-agnostic mesh transport. Provides explicit namespace
@@ -874,7 +880,10 @@ mod tests {
         );
 
         let _handle = ns.register_drain(Box::new(|| {
-            vec![("td:from-drain".to_string(), b"drain-data".to_vec())]
+            vec![(
+                "td:from-drain".to_string(),
+                Bytes::from_static(b"drain-data"),
+            )]
         }));
 
         let batch = kv.collect_round_batch();

--- a/crates/mesh/src/ping_server.rs
+++ b/crates/mesh/src/ping_server.rs
@@ -7,7 +7,6 @@ use std::{
 };
 
 use anyhow::Result;
-use bytes::Bytes;
 use futures::Stream;
 use tokio::sync::mpsc;
 use tokio_stream::StreamExt;
@@ -616,7 +615,7 @@ impl Gossip for GossipService {
                                 entries.extend(chunk_value(
                                     key.clone(),
                                     next_generation(),
-                                    Bytes::from(value.clone()),
+                                    value.clone(),
                                     MAX_STREAM_CHUNK_BYTES,
                                 ));
                             }


### PR DESCRIPTION
## Description

### Problem

The drain-callback → `RoundBatch.drain_entries` → per-peer sender path carried broadcast stream payloads as `Vec<u8>` at the `MeshKV` boundary, even after PR #1259 made the rest of the chunking path zero-copy via `bytes::Bytes`.

The result is an **×N heap copy per round** on broadcast traffic. In the per-peer sender loop (`controller.rs:675`, `ping_server.rs:619`):

```rust
for (key, value) in &stream_batch.drain_entries {
    entries.extend(chunk_value(
        key.clone(),
        next_generation(),
        Bytes::from(value.clone()),  // ← full heap copy of Vec<u8>
        MAX_STREAM_CHUNK_BYTES,
    ));
}
```

`value: &Vec<u8>` → `value.clone()` allocates a new `Vec<u8>` and memcpys the payload → `Bytes::from(Vec<u8>)` takes ownership. Every subscribed peer's sender task does this independently per round. A 1.5 GB tenant-delta broadcast round hitting 20 peers transiently allocates ~30 GB even though all 20 peers receive identical bytes.

This is the residual half of the "×N per-peer chunking amplification" concern first flagged during the PR #1254 review cycle (the other half — `chunk_value` itself copying via `slice(..).to_vec()` — was closed by #1259 switching `StreamEntry.data` to `Bytes`). `chunk_value` now slices zero-copy; only the `Vec<u8>` → `Bytes` conversion at the caller remained.

### Solution

Move the conversion **once** to the drain-callback boundary: change `StreamDrainFn` to return `Vec<(String, Bytes)>` instead of `Vec<(String, Vec<u8>)>`, so `RoundBatch.drain_entries` is `Vec<(String, Bytes)>`. The per-peer sender can then `value.clone()` (an `Arc` refcount bump, not a heap copy) and all N peers share the same underlying allocation.

Memory per round for a broadcast value of size *V* served to *N* peers:

| | Before | After |
|---|---|---|
| Source buffer | *V* | *V* |
| Per-peer transient | *N* × *V* | 0 |
| Total transient | **(N + 1) × V** | ***V*** |

For the 1.5 GB / 20-peer case: ~30 GB → ~1.5 GB. Chunking CPU is unchanged (`chunk_value` still runs once per peer but is O(chunks) with zero-copy slicing).

No adapter in-tree registers drain callbacks yet (verified with `git grep register_drain` — only `kv.rs`'s own tests), so the `StreamDrainFn` signature change is contained to this crate.

## Changes

- `crates/mesh/src/kv.rs`
  - `StreamDrainFn: Box<dyn Fn() -> Vec<(String, Vec<u8>)>>` → `Vec<(String, Bytes)>`
  - `RoundBatch.drain_entries: Vec<(String, Vec<u8>)>` → `Vec<(String, Bytes)>`
  - `DrainRegistry::drain_all()` return type follows
  - `test_collect_round_batch_with_drain_callback` produces `Bytes::from_static(...)` instead of `b"...".to_vec()`
- `crates/mesh/src/controller.rs` — drop `Bytes::from(value.clone())` wrapper in client-side per-peer stream emission (line 675); use `value.clone()` directly; remove now-unused `use bytes::Bytes`
- `crates/mesh/src/ping_server.rs` — same change on the server-side per-peer stream emission (line 619); remove now-unused `use bytes::Bytes`

No wire-format changes. No public-API changes observable outside the `smg-mesh` crate. No test reshaping required — the existing drain-callback test already exercises both the callback and the collector sides.

## Test Plan

- [x] `cargo check -p smg-mesh` — clean
- [x] `cargo test -p smg-mesh --lib` — **237 tests pass**, 2 ignored
- [x] Pre-commit: `cargo +nightly fmt`, `cargo clippy --all-targets --all-features -- -D warnings` both clean

**Manual verification of the memory property** (reasoning, not an executable benchmark in this PR):
- `Bytes::clone()` on an owned `Bytes` is a single atomic refcount increment; no allocation. Verified by the `bytes` crate docs and the `Arc<Vec<u8>>` backing store.
- Prior code did `Vec<u8>::clone()` → `Bytes::from(Vec<u8>)`. The Vec clone unconditionally allocates and memcpys; `Bytes::from(Vec<u8>)` wraps the Vec without further copying. So the prior per-peer cost was exactly one full heap copy of the payload; new cost is a single refcount bump. The reduction matches the table above.

**Not covered in this PR (tracked separately):**
- Benchmark harness that measures transient RSS during a large-value broadcast round — valuable for tracking regressions but out of scope for a type-shape fix.
- Converting other `Vec<u8>` hotspots (`StateUpdate.value`, snapshot chunks) to `Bytes`. Those paths don't currently fan out across N peer tasks, so the same amplification doesn't apply — left unchanged.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized internal data representation for stream batch operations to improve code consistency and maintainability across the mesh module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->