### PR TITLE
ci: run full PR test suite for dependabot PRs

### DIFF
--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -286,7 +286,6 @@ jobs:
 
   benchmarks:
     needs: build-wheel
-    if: github.actor != 'dependabot[bot]'
     runs-on: 4-gpu-h100
     timeout-minutes: 30
     permissions:
@@ -432,7 +431,6 @@ jobs:
       always()
       && !cancelled()
       && needs.build-wheel.result == 'success'
-      && github.actor != 'dependabot[bot]'
       && (github.event_name != 'pull_request'
           || (needs.detect-changes.result == 'success'
               && (needs.detect-changes.outputs.common == 'true'
@@ -463,7 +461,6 @@ jobs:
       always()
       && !cancelled()
       && needs.build-wheel.result == 'success'
-      && github.actor != 'dependabot[bot]'
       && (github.event_name != 'pull_request'
           || (needs.detect-changes.result == 'success'
               && (needs.detect-changes.outputs.common == 'true'
@@ -492,7 +489,6 @@ jobs:
       always()
       && !cancelled()
       && needs.build-wheel.result == 'success'
-      && github.actor != 'dependabot[bot]'
       && (github.event_name != 'pull_request'
           || (needs.detect-changes.result == 'success'
               && (needs.detect-changes.outputs.common == 'true'
@@ -522,7 +518,6 @@ jobs:
       always()
       && !cancelled()
       && needs.build-wheel.result == 'success'
-      && github.actor != 'dependabot[bot]'
       && (github.event_name != 'pull_request'
           || (needs.detect-changes.result == 'success'
               && (needs.detect-changes.outputs.common == 'true'
@@ -575,7 +570,6 @@ jobs:
       always()
       && !cancelled()
       && needs.build-wheel.result == 'success'
-      && github.actor != 'dependabot[bot]'
       && (github.event_name != 'pull_request'
           || (needs.detect-changes.result == 'success'
               && (needs.detect-changes.outputs.common == 'true'
@@ -664,7 +658,6 @@ jobs:
       always()
       && !cancelled()
       && needs.build-wheel.result == 'success'
-      && github.actor != 'dependabot[bot]'
       && (github.event_name != 'pull_request'
           || (needs.detect-changes.result == 'success'
               && (needs.detect-changes.outputs.common == 'true'
@@ -811,7 +804,6 @@ jobs:
       always()
       && !cancelled()
       && needs.build-wheel.result == 'success'
-      && github.actor != 'dependabot[bot]'
       && (github.event_name != 'pull_request'
           || (needs.detect-changes.result == 'success'
               && (needs.detect-changes.outputs.common == 'true'


### PR DESCRIPTION
## Description

### Problem

`pr-test-rust.yml` skipped benchmarks, all GPU e2e jobs, the vendor matrix, and the Go bindings e2e job whenever `github.actor == 'dependabot[bot]'`. That guard existed because the runner nodes didn't have the env vars / credentials those jobs need, so dependabot PRs couldn't execute them. As a result, dependency bumps shipped with far less coverage than a regular PR.

### Solution

The required envs are now configured on the runner nodes, so the skip is no longer needed. Drop every `github.actor != 'dependabot[bot]'` check in `pr-test-rust.yml` so dependabot PRs run the same jobs as everyone else.

## Changes

- Remove standalone `if: github.actor != 'dependabot[bot]'` from the `benchmarks` job.
- Remove `&& github.actor != 'dependabot[bot]'` from the `if:` of the following jobs:
  - `e2e-1gpu-chat`, `e2e-1gpu-completions`, `e2e-1gpu-embeddings`, `e2e-1gpu-gateway`
  - `e2e-2gpu-responses`
  - `e2e-vendor`
  - `go-bindings-e2e`

No other behavior changes — every other condition in each `if:` is preserved.

Note: `claude-code-review.yml` still skips the Claude auto-review for dependabot. That one isn't a test and was left alone; happy to remove it in a follow-up if desired.

## Test Plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/pr-test-rust.yml'))"` → `YAML valid`
- [ ] This PR itself will exercise the change: the listed jobs should now run on any future dependabot PR.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes (N/A — CI YAML only)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (N/A — CI YAML only)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>