### PR TITLE
feat(smg): validate skills startup config

### DIFF
--- a/model_gateway/src/app_context.rs
+++ b/model_gateway/src/app_context.rs
@@ -635,8 +635,10 @@ impl AppContextBuilder {
         }
 
         let Some(skills_config) = config.skills.as_ref() else {
-            self.skill_service = None;
-            return Ok(self);
+            return Err(
+                "Skills are enabled but no validated skills config was loaded at startup"
+                    .to_string(),
+            );
         };
 
         let blob_store =

--- a/model_gateway/src/config/builder.rs
+++ b/model_gateway/src/config/builder.rs
@@ -846,7 +846,10 @@ impl RouterConfigBuilder {
                 })?;
             self.config.skills = Some(skills_config);
         } else {
-            self.config.skills = Some(SkillsConfig::default());
+            return Err(ConfigError::ValidationFailed {
+                reason: "skills are enabled but no skills config was provided; set --skills-config-path or preload RouterConfig.skills"
+                    .to_string(),
+            });
         }
 
         Ok(self)
@@ -954,7 +957,7 @@ mod tests {
         let mut skills_config = NamedTempFile::new().unwrap();
         writeln!(
             skills_config,
-            "max_skills_per_request: 3\nexecution:\n  executor_url: http://executor.internal\n"
+            "max_skills_per_request: 3\nexecution:\n  executor_url: http://executor.internal\n  executor_api_key: secret\n"
         )
         .unwrap();
 
@@ -977,6 +980,16 @@ mod tests {
                 .as_deref(),
             Some("http://executor.internal")
         );
+        assert_eq!(
+            config
+                .skills
+                .as_ref()
+                .unwrap()
+                .execution
+                .executor_api_key
+                .as_deref(),
+            Some("secret")
+        );
     }
 
     #[test]
@@ -993,5 +1006,18 @@ mod tests {
 
         assert!(!config.skills_enabled);
         assert!(config.skills.is_none());
+    }
+
+    #[test]
+    fn test_builder_rejects_enabled_skills_without_nested_config() {
+        let error = RouterConfigBuilder::new()
+            .regular_mode(vec!["http://worker1:8000".to_string()])
+            .skills_enabled(true)
+            .build()
+            .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("skills are enabled but no skills config was provided"));
     }
 }

--- a/model_gateway/src/config/validation.rs
+++ b/model_gateway/src/config/validation.rs
@@ -41,6 +41,99 @@ impl ConfigValidator {
         }
 
         Self::validate_tokenizer_cache(&config.tokenizer_cache)?;
+        Self::validate_skills(config)?;
+
+        Ok(())
+    }
+
+    fn validate_skills(config: &RouterConfig) -> ConfigResult<()> {
+        if !config.skills_enabled {
+            return Ok(());
+        }
+
+        let skills = config.skills.as_ref().ok_or_else(|| ConfigError::ValidationFailed {
+            reason: "skills are enabled but no skills config was provided; set --skills-config-path or preload RouterConfig.skills"
+                .to_string(),
+        })?;
+
+        Self::validate_skills_config(skills)
+    }
+
+    fn validate_skills_config(skills: &SkillsConfig) -> ConfigResult<()> {
+        if skills.blob_store.path.trim().is_empty() {
+            return Err(ConfigError::InvalidValue {
+                field: "skills.blob_store.path".to_string(),
+                value: skills.blob_store.path.clone(),
+                reason: "filesystem blob-store path must not be empty".to_string(),
+            });
+        }
+
+        if skills.cache.enabled() && skills.cache.path.trim().is_empty() {
+            return Err(ConfigError::InvalidValue {
+                field: "skills.cache.path".to_string(),
+                value: skills.cache.path.clone(),
+                reason: "enabled blob cache path must not be empty".to_string(),
+            });
+        }
+
+        if skills.max_upload_size_mb == 0 {
+            return Err(ConfigError::InvalidValue {
+                field: "skills.max_upload_size_mb".to_string(),
+                value: skills.max_upload_size_mb.to_string(),
+                reason: "Must be > 0".to_string(),
+            });
+        }
+
+        if skills.max_file_size_mb == 0 {
+            return Err(ConfigError::InvalidValue {
+                field: "skills.max_file_size_mb".to_string(),
+                value: skills.max_file_size_mb.to_string(),
+                reason: "Must be > 0".to_string(),
+            });
+        }
+
+        if skills.max_file_size_mb > skills.max_upload_size_mb {
+            return Err(ConfigError::InvalidValue {
+                field: "skills.max_file_size_mb".to_string(),
+                value: skills.max_file_size_mb.to_string(),
+                reason: "Must be <= skills.max_upload_size_mb".to_string(),
+            });
+        }
+
+        if skills.max_files_per_version == 0 {
+            return Err(ConfigError::InvalidValue {
+                field: "skills.max_files_per_version".to_string(),
+                value: skills.max_files_per_version.to_string(),
+                reason: "Must be > 0".to_string(),
+            });
+        }
+
+        if skills.max_skills_per_request == 0 {
+            return Err(ConfigError::InvalidValue {
+                field: "skills.max_skills_per_request".to_string(),
+                value: skills.max_skills_per_request.to_string(),
+                reason: "Must be > 0".to_string(),
+            });
+        }
+
+        let has_executor_url = skills
+            .execution
+            .executor_url
+            .as_deref()
+            .is_some_and(|url| !url.trim().is_empty());
+        let has_executor_api_key = skills
+            .execution
+            .executor_api_key
+            .as_deref()
+            .is_some_and(|key| !key.trim().is_empty());
+
+        if has_executor_url && !has_executor_api_key {
+            return Err(ConfigError::ValidationFailed {
+                reason:
+                    "skills execution is enabled but skills.execution.executor_api_key is missing"
+                        .to_string(),
+            });
+        }
 
         Ok(())
     }
@@ -1133,5 +1226,57 @@ mod tests {
 
         let result = ConfigValidator::validate(&config);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_skills_enabled_requires_nested_config() {
+        let mut config = RouterConfig::new(
+            RoutingMode::Regular {
+                worker_urls: vec!["http://worker1:8000".to_string()],
+            },
+            PolicyConfig::Random,
+        );
+        config.skills_enabled = true;
+
+        let error = ConfigValidator::validate(&config).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("skills are enabled but no skills config was provided"));
+    }
+
+    #[test]
+    fn test_validate_skills_execution_requires_api_key() {
+        let mut config = RouterConfig::new(
+            RoutingMode::Regular {
+                worker_urls: vec!["http://worker1:8000".to_string()],
+            },
+            PolicyConfig::Random,
+        );
+        config.skills_enabled = true;
+        let mut skills = SkillsConfig::default();
+        skills.execution.executor_url = Some("http://executor.internal".to_string());
+        config.skills = Some(skills);
+
+        let error = ConfigValidator::validate(&config).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("skills.execution.executor_api_key is missing"));
+    }
+
+    #[test]
+    fn test_validate_skills_blob_store_path_must_not_be_empty() {
+        let mut config = RouterConfig::new(
+            RoutingMode::Regular {
+                worker_urls: vec!["http://worker1:8000".to_string()],
+            },
+            PolicyConfig::Random,
+        );
+        config.skills_enabled = true;
+        let mut skills = SkillsConfig::default();
+        skills.blob_store.path.clear();
+        config.skills = Some(skills);
+
+        let error = ConfigValidator::validate(&config).unwrap_err();
+        assert!(error.to_string().contains("skills.blob_store.path"));
     }
 }

--- a/model_gateway/src/server.rs
+++ b/model_gateway/src/server.rs
@@ -965,6 +965,8 @@ pub fn build_app(
     };
     let admin_routes = apply_control_plane_auth(admin_routes);
     let worker_routes = apply_control_plane_auth(worker_routes);
+    // Reserve the existing admin-gated surface for future skills CRUD/internal routes.
+    let skills_admin_routes = apply_control_plane_auth(Router::new());
 
     // HA management routes
     let mesh_routes = Router::new()
@@ -991,6 +993,7 @@ pub fn build_app(
         .merge(multipart_upload_routes)
         .merge(public_routes)
         .merge(admin_routes)
+        .merge(skills_admin_routes)
         .merge(worker_routes)
         .merge(mesh_routes)
         .layer(axum::extract::DefaultBodyLimit::max(max_payload_size))

--- a/model_gateway/src/server.rs
+++ b/model_gateway/src/server.rs
@@ -965,8 +965,6 @@ pub fn build_app(
     };
     let admin_routes = apply_control_plane_auth(admin_routes);
     let worker_routes = apply_control_plane_auth(worker_routes);
-    // Reserve the existing admin-gated surface for future skills CRUD/internal routes.
-    let skills_admin_routes = apply_control_plane_auth(Router::new());
 
     // HA management routes
     let mesh_routes = Router::new()
@@ -993,7 +991,6 @@ pub fn build_app(
         .merge(multipart_upload_routes)
         .merge(public_routes)
         .merge(admin_routes)
-        .merge(skills_admin_routes)
         .merge(worker_routes)
         .merge(mesh_routes)
         .layer(axum::extract::DefaultBodyLimit::max(max_payload_size))


### PR DESCRIPTION
## Summary
- fail fast when `skills_enabled=true` but no nested skills config is loaded
- validate core skills startup invariants before serving traffic
- make skills blob/cache initialization errors fatal at startup instead of silently disabling the service
- reserve an empty admin-gated skills router slot without adding any public skills routes

## Verification
- `cargo +nightly fmt --all`
- `cargo clippy -p smg --all-targets --all-features --target-dir target/sk8-clippy -- -D warnings`
- `cargo test -p smg --lib --target-dir target/sk8-test`
  - new skills-related tests passed
  - the broader `smg` lib suite still has many unrelated pre-existing failures on this host outside the skills changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added admin-authenticated endpoints for skills administration.
  * Skills configuration validation now enforces required settings for storage paths, file limits, and credentials, providing specific guidance when configuration is incomplete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->