### PR TITLE
fix(protocols): implement P5 fail-fast on unknown content/items

### DIFF
--- a/crates/protocols/src/responses.rs
+++ b/crates/protocols/src/responses.rs
@@ -665,9 +665,13 @@ pub enum ResponseInputOutputItem {
     SimpleInputMessage {
         content: StringOrContentParts,
         role: String,
-        #[serde(skip_serializing_if = "Option::is_none")]
+        /// Spec: `EasyInputMessage.type` is `optional "message"`. Constrained
+        /// to a single-value tag enum so payloads with an unknown `type`
+        /// (e.g. `"input_file"`, `"totally_made_up"`) do not silently land
+        /// in this untagged catch-all variant — P5 fail-fast contract.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         #[serde(rename = "type")]
-        r#type: Option<String>,
+        r#type: Option<SimpleInputMessageTypeTag>,
         /// Optional phase label (spec: EasyInputMessage.phase).
         ///
         /// Preserved through conversation storage so gpt-5.3-codex+ does not
@@ -675,6 +679,17 @@ pub enum ResponseInputOutputItem {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         phase: Option<MessagePhase>,
     },
+}
+
+/// Single-value tag enum pinning `EasyInputMessage.type` to the spec's only
+/// permitted value, `"message"`. Used to keep [`ResponseInputOutputItem::SimpleInputMessage`]
+/// — which is the `#[serde(untagged)]` fallback in the outer `type`-tagged enum
+/// — from silently swallowing payloads whose `type` discriminator is unknown
+/// (P5 fail-fast contract).
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, schemars::JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum SimpleInputMessageTypeTag {
+    Message,
 }
 
 /// Detail level for [`ResponseContentPart::InputFile`]. Spec restricts this
@@ -2695,6 +2710,84 @@ mod tests {
             msg.contains("totally_made_up") || msg.contains("unknown variant"),
             "error should mention the unknown variant, got: {msg}"
         );
+    }
+
+    // ------------------------------------------------------------------
+    // P5: ResponseInputOutputItem fail-fast on unknown `type` discriminator
+    //
+    // `ResponseInputOutputItem` is `#[serde(tag = "type")]` with a single
+    // `#[serde(untagged)] SimpleInputMessage` fallback. Before P5, that
+    // fallback accepted any `{role, content, type: "<anything>"}` payload
+    // because `type` was `Option<String>`. The spec (EasyInputMessage.type)
+    // constrains `type` to absent or `"message"`, so P5 replaces the loose
+    // `Option<String>` with `Option<SimpleInputMessageTypeTag>` — unknown
+    // discriminators must now return a deserialize error (→ 400).
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn input_item_unknown_type_fails_fast() {
+        // Spec-invalid discriminator must NOT silently fall into
+        // SimpleInputMessage. Previously `type: "totally_made_up"` deserialized
+        // cleanly because `r#type` was `Option<String>`.
+        let raw = json!({
+            "type": "totally_made_up",
+            "role": "user",
+            "content": "hello"
+        });
+        let err = serde_json::from_value::<ResponseInputOutputItem>(raw)
+            .expect_err("unknown input-item type must fail");
+        let msg = err.to_string();
+        assert!(
+            !msg.is_empty(),
+            "deserialize error must carry a message, got empty: {msg}"
+        );
+    }
+
+    #[test]
+    fn simple_input_message_without_type_still_deserializes() {
+        // Per spec, `EasyInputMessage.type` is optional. Omitting it must
+        // continue to route to the untagged SimpleInputMessage variant.
+        let raw = json!({
+            "role": "user",
+            "content": "hello"
+        });
+        let item: ResponseInputOutputItem =
+            serde_json::from_value(raw).expect("missing type must still deserialize");
+        match item {
+            ResponseInputOutputItem::SimpleInputMessage {
+                role,
+                content,
+                r#type,
+                ..
+            } => {
+                assert_eq!(role, "user");
+                assert!(matches!(content, StringOrContentParts::String(ref s) if s == "hello"));
+                assert!(r#type.is_none(), "absent type must deserialize as None");
+            }
+            other => panic!("expected SimpleInputMessage, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn simple_input_message_with_type_message_deserializes() {
+        // Per spec, `type: "message"` is the only non-null value permitted on
+        // EasyInputMessage. Round-trip it intact.
+        let raw = json!({
+            "type": "message",
+            "role": "user",
+            "content": "hi"
+        });
+        let item: ResponseInputOutputItem =
+            serde_json::from_value(raw.clone()).expect("`type: message` must deserialize");
+        match &item {
+            ResponseInputOutputItem::SimpleInputMessage { r#type, .. } => {
+                assert_eq!(*r#type, Some(SimpleInputMessageTypeTag::Message));
+            }
+            other => panic!("expected SimpleInputMessage, got {other:?}"),
+        }
+        // Serializes back to the same wire bytes (canonical shape).
+        let roundtripped = serde_json::to_value(&item).expect("serialize");
+        assert_eq!(roundtripped, raw);
     }
 
     // ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Close the last silent-swallow hole on Responses API input items: a payload whose
top-level discriminator is unknown (e.g. `{\"type\": \"input_file\", ...}`) used
to fall through the outer `#[serde(tag = \"type\")]` enum into the
`#[serde(untagged)] SimpleInputMessage` variant because that variant's `r#type`
was `Option<String>` and accepted any string. Spec (EasyInputMessage.type)
constrains the field to absent or `\"message\"` only. P5 tightens
`SimpleInputMessage.type` from `Option<String>` to
`Option<SimpleInputMessageTypeTag>`, making serde reject any other discriminator
→ 400 at the wire boundary.

## What changed

- `crates/protocols/src/responses.rs` (+95 / -2, single file):
  - New `SimpleInputMessageTypeTag` single-value tag enum (`Message` only,
    `rename_all = \"snake_case\"`).
  - `ResponseInputOutputItem::SimpleInputMessage.type` narrowed from
    `Option<String>` to `Option<SimpleInputMessageTypeTag>`; `#[serde(default,
    skip_serializing_if = \"Option::is_none\")]` so absent-on-wire is still
    accepted per spec.
  - Three new focused `#[test]`s in `mod tests`:
    - `input_item_unknown_type_fails_fast` — asserts `\"type\":
      \"totally_made_up\"` rejects on deserialize.
    - `simple_input_message_without_type_still_deserializes` — asserts absent
      `type` routes to `SimpleInputMessage` with `r#type: None`.
    - `simple_input_message_with_type_message_deserializes` — asserts canonical
      `\"type\": \"message\"` payload round-trips byte-identical.

## Why

Spec §EasyInputMessage: the `type` field is `optional \"message\"`. Before P5,
the outer discriminated enum's `#[serde(untagged)]` fallback silently absorbed
every spec-invalid `type` because the fallback variant's own `type` was a loose
`Option<String>`. P1 removed `ResponseContentPart::Unknown`; P5 closes the
matching hole on input items so downstream code never sees a payload the spec
forbids.

## Verification

- `cargo test -p openai-protocol --lib` — 3 new tests plus all existing
  responses tests pass.
- `cargo +nightly fmt --all -- --check` — clean.
- `cargo clippy -p openai-protocol --tests -- -D warnings` — clean.
- `pre-commit run codespell --all-files` — pass.
- Independent scratch crate: confirmed tag enum serializes lowercase
  `\"message\"`, rejects `\"input_file\"`, absent type → `None`, and
  `{\"type\":\"message\",\"role\":\"user\",\"content\":\"hi\"}` round-trips
  byte-identical.

### Scope classification summary

Audited all 44 `#[serde(other|untagged)]` attributes in `crates/protocols/src`
against the P5 fail-fast contract. Only the above one was a gap. Notable
intentional KEEPs:

- `ResponsesToolChoice` (`responses.rs:185`) — untagged outer enum where each
  object variant pins its discriminator via per-variant single-value tag enums
  (`FunctionToolChoiceTag`, `McpToolChoiceTag`, etc.) from P7, so the outer
  enum cannot match a payload whose `type` is unknown.
- `StringOrContentParts`, `ResponseInput`, `ResponsesUsage` — legitimate
  untagged unions between disjoint JSON shapes (String vs Array, Vec vs String,
  field-disjoint structs).
- `ClientEvent::Unknown` / `ServerEvent::Unknown` in `realtime_events.rs` —
  intentional WebSocket forward-compat for proxy use (explicit doc comment); out
  of scope for the Responses API HTTP request path.

## Blast radius

- One file (`crates/protocols/src/responses.rs`), protocol-layer only.
- All 15 callsites that construct or pattern-match `SimpleInputMessage` already
  use `r#type: None` or `..` destructuring; the narrower type compiles cleanly
  everywhere (verified across `crates/protocols`, `model_gateway`, tests, and
  benches).
- Behavior change: previously-accepted bogus discriminators now 400 instead of
  silently routing to the fallback variant — this is the intentional spec
  tightening described above.

## Out of scope

- `ClientEvent::Unknown` / `ServerEvent::Unknown` in `realtime_events.rs`: the
  Realtime API runs over a WebSocket/WebRTC/SIP connection where a proxy must
  be able to forward unrecognized frames verbatim. This is explicitly documented
  on the variants and is not part of the Responses HTTP request path P5 governs.

Refs: P5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced validation for input message format processing to better detect and reject malformed or invalid requests.

* **Tests**
  * Added comprehensive test coverage for message deserialization and validation, including edge cases for missing or unknown message type values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->