### PR TITLE
feat(mesh): auto-register config: CRDT prefix and mirror v1 AppStore on receive

### DIFF
--- a/crates/mesh/src/controller.rs
+++ b/crates/mesh/src/controller.rs
@@ -785,6 +785,21 @@ impl MeshController {
                                                         let dominated = stores.app.get(&app_state.key)
                                                             .is_some_and(|existing| existing.version >= app_state.version);
                                                         if !dominated {
+                                                            // Mirror into the v2 `config:` CRDT
+                                                            // namespace so v2-only readers can
+                                                            // reach the same value during a
+                                                            // rolling upgrade, even when the
+                                                            // source is a v1 node still writing
+                                                            // to AppStore.
+                                                            if let Some(ref kv) = mesh_kv {
+                                                                kv.configs().put(
+                                                                    &format!(
+                                                                        "config:{}",
+                                                                        app_state.key
+                                                                    ),
+                                                                    app_state.value.clone(),
+                                                                );
+                                                            }
                                                             if let Err(err) = stores.app.insert(
                                                                 app_state.key.clone(),
                                                                 app_state,

--- a/crates/mesh/src/kv.rs
+++ b/crates/mesh/src/kv.rs
@@ -473,6 +473,14 @@ pub struct MeshKV {
     /// Receiver-side chunk reassembly buffer shared across all inbound
     /// SyncStream connections on this node.
     chunk_assembler: Arc<ChunkAssembler>,
+    /// Auto-registered `config:` CRDT namespace (LastWriterWins).
+    /// Pre-created at `new()` time so every gateway (admin API,
+    /// middleware, adapters) can read and write config without the
+    /// application having to remember to `configure_crdt_prefix`
+    /// explicitly. Also used by the gossip receive path to mirror
+    /// incoming v1 `StoreType::App` entries into `config:{key}` for
+    /// rolling-upgrade compatibility.
+    configs: Arc<CrdtNamespace>,
     /// Server name for this node (used to derive replica_id).
     server_name: String,
     /// Replica ID: hash(server_name) as u64.
@@ -480,19 +488,46 @@ pub struct MeshKV {
 }
 
 impl MeshKV {
-    /// Create a new MeshKV instance.
+    /// Create a new MeshKV instance. Auto-registers the `config:`
+    /// CRDT namespace (LastWriterWins) so gateway readers and the
+    /// gossip receive path can always reach the config store via
+    /// `mesh_kv.configs()` without a separate wiring step.
     pub fn new(server_name: String) -> Self {
         let replica_id = Self::derive_replica_id(&server_name);
+        let store = Arc::new(CrdtOrMap::new());
+        let subscriber_registry = Arc::new(SubscriberRegistry::new());
+        let mut configured_prefixes = HashMap::new();
+        configured_prefixes.insert(
+            "config:".to_string(),
+            StoreMode::Crdt {
+                merge_strategy: MergeStrategy::LastWriterWins,
+            },
+        );
+        let configs = Arc::new(CrdtNamespace {
+            prefix: "config:".to_string(),
+            store: store.clone(),
+            subscriber_registry: subscriber_registry.clone(),
+            merge_strategy: MergeStrategy::LastWriterWins,
+        });
         Self {
-            store: Arc::new(CrdtOrMap::new()),
-            configured_prefixes: RwLock::new(HashMap::new()),
+            store,
+            configured_prefixes: RwLock::new(configured_prefixes),
             stream_namespaces: RwLock::new(Vec::new()),
-            subscriber_registry: Arc::new(SubscriberRegistry::new()),
+            subscriber_registry,
             drain_registry: Arc::new(DrainRegistry::new()),
             chunk_assembler: Arc::new(ChunkAssembler::new()),
+            configs,
             server_name,
             replica_id,
         }
+    }
+
+    /// Shared handle to the auto-registered `config:` CRDT namespace.
+    /// Gateway middleware, admin API, and the gossip receive path use
+    /// this to read and write cluster-wide configuration (rate-limit
+    /// limits, feature flags, etc.) with LastWriterWins merge.
+    pub fn configs(&self) -> Arc<CrdtNamespace> {
+        self.configs.clone()
     }
 
     /// Handle to the node-wide chunk reassembly buffer. Used by the
@@ -655,6 +690,41 @@ mod tests {
         let ns = kv.configure_crdt_prefix("worker:", MergeStrategy::LastWriterWins);
         assert_eq!(ns.prefix(), "worker:");
         assert!(kv.is_prefix_configured("worker:"));
+    }
+
+    #[test]
+    fn test_configs_prefix_auto_registered() {
+        // The `config:` prefix is always registered at construction;
+        // gateway code must not have to call configure_crdt_prefix for
+        // it, and a redundant call would panic per the one-configure-
+        // per-prefix rule.
+        let kv = MeshKV::new("test-node".to_string());
+        assert!(kv.is_prefix_configured("config:"));
+        let configs = kv.configs();
+        assert_eq!(configs.prefix(), "config:");
+    }
+
+    #[test]
+    fn test_configs_put_get_round_trip() {
+        let kv = MeshKV::new("test-node".to_string());
+        let configs = kv.configs();
+        configs.put("config:rate_limit", b"100".to_vec());
+        assert_eq!(
+            configs.get("config:rate_limit"),
+            Some(b"100".to_vec()),
+            "config namespace round-trips through the shared CRDT store"
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "already configured")]
+    fn test_configure_config_prefix_twice_panics() {
+        // Application code must not try to reconfigure `config:` — the
+        // auto-registration at MeshKV::new() already owns the slot.
+        // This guards against accidental reconfiguration that would
+        // replace the merge strategy or subscriber capacity.
+        let kv = MeshKV::new("test-node".to_string());
+        kv.configure_crdt_prefix("config:", MergeStrategy::LastWriterWins);
     }
 
     #[test]

--- a/crates/mesh/src/ping_server.rs
+++ b/crates/mesh/src/ping_server.rs
@@ -1015,6 +1015,21 @@ impl Gossip for GossipService {
                                                                         >= app_state.version
                                                                 });
                                                             if !dominated {
+                                                                // Mirror into the v2 `config:` CRDT
+                                                                // namespace so v2-only readers can
+                                                                // reach the same value during a
+                                                                // rolling upgrade, even when the
+                                                                // source is a v1 node still
+                                                                // writing to AppStore.
+                                                                if let Some(ref kv) = mesh_kv {
+                                                                    kv.configs().put(
+                                                                        &format!(
+                                                                            "config:{}",
+                                                                            app_state.key
+                                                                        ),
+                                                                        app_state.value.clone(),
+                                                                    );
+                                                                }
                                                                 if let Err(err) = stores.app.insert(
                                                                     app_state.key.clone(),
                                                                     app_state,
@@ -1305,6 +1320,16 @@ impl Gossip for GossipService {
                                                                     let dominated = stores.app.get(&key)
                                                                         .is_some_and(|existing| existing.version >= app_state.version);
                                                                     if !dominated {
+                                                                        // Mirror into the v2 `config:` CRDT
+                                                                        // namespace so v2-only readers can
+                                                                        // reach values a v1 snapshot sender
+                                                                        // is still populating via AppStore.
+                                                                        if let Some(ref kv) = mesh_kv {
+                                                                            kv.configs().put(
+                                                                                &format!("config:{}", app_state.key),
+                                                                                app_state.value.clone(),
+                                                                            );
+                                                                        }
                                                                         let _ = stores.app.insert(key, app_state);
                                                                     }
                                                                 }


### PR DESCRIPTION
## Description

### Problem

Second step of Step 4 (gateway adapters) in the mesh-v2 implementation plan, covering spec §7.4 "Config Distribution (App Store Migration)".

The v2 mesh represents cluster-wide configuration (rate-limit limits, feature flags, global kill-switches) as LastWriterWins CRDT entries under a `config:` key prefix. Two things need to exist before any v2 reader or adapter can use it:

1. The `config:` prefix has to be registered as a CRDT namespace on `MeshKV`. The existing `configure_crdt_prefix` API is opt-in and panics on double-configure, so every call site would need to know to register it exactly once — easy to miss, expensive to recover from.
2. During a rolling upgrade, v1 nodes are still writing their config through the v1 `AppStore` path (`StoreType::App` `IncrementalUpdate` messages with keys like `"global_rate_limit"`). v2 readers that only look at `configs.get("config:...")` wouldn't see those writes until every v1 node was upgraded.

The second point is the operationally urgent one: without receive-side translation, a v2-first cluster member can't read a rate-limit update pushed by a v1 node, and rate limiting silently desynchronises across the rolling-upgrade window.

### Solution

Two paired changes in `crates/mesh/src/kv.rs` and the three gossip receive sites.

**Auto-register `config:` at `MeshKV::new()`.** The CRDT namespace is built once during construction and stashed on `MeshKV` as a new `configs: Arc<CrdtNamespace>` field. A new accessor `MeshKV::configs()` returns the shared handle so callers never need to worry about the one-configure-per-prefix invariant. A new `#[should_panic]` test guards against a caller accidentally calling `configure_crdt_prefix("config:", ...)` on top — the auto-registration already owns the slot, and silently losing a different merge strategy would be worse than panicking.

**Mirror `StoreType::App` receives into `config:{key}`.** Each of the three sites that currently apply an incoming `AppState` also calls `mesh_kv.configs().put(&format!("config:{}", app_state.key), app_state.value.clone())` if the handler has a `mesh_kv` handle. The mirror is write-through: the v1 `stores.app` path is preserved exactly (v1 readers keep working), and the value is additionally visible to any v2 reader under the `config:` prefix. The key translation is verbatim — v1 `"global_rate_limit"` becomes v2 `"config:global_rate_limit"`, matching the spec's "map incoming `StoreType::APP` entries to the `config:` prefix: `config:{key}`".

No write-side changes in this PR. Native v2 writes (`configs.put("config:...")` from admin API or `RateLimitSyncAdapter`) arrive in follow-up PRs in the Step 4 sequence.

## Changes

- `crates/mesh/src/kv.rs`
  - Add `configs: Arc<CrdtNamespace>` field to `MeshKV`.
  - `MeshKV::new()` pre-registers `config:` as a `LastWriterWins` CRDT prefix and stashes the namespace.
  - New accessor `MeshKV::configs() -> Arc<CrdtNamespace>`.
  - Three new unit tests: `test_configs_prefix_auto_registered`, `test_configs_put_get_round_trip`, `test_configure_config_prefix_twice_panics` (`#[should_panic]`).
- `crates/mesh/src/ping_server.rs`
  - Inbound `sync_stream` `StoreType::App` branch: mirror the accepted `AppState` into `config:{key}` before writing to `stores.app`.
  - Snapshot-apply `StoreType::App` branch: same mirror.
- `crates/mesh/src/controller.rs`
  - Client-side `sync_stream` receive `StoreType::App` branch: same mirror.

No wire-format changes. No public API removals. If `mesh_kv` isn't attached to a handler (legacy path pre-v2-wiring), the mirror is a no-op and the v1 receive behaviour is exactly as before.

## Test Plan

- [x] `cargo check -p smg-mesh` clean
- [x] `cargo test -p smg-mesh --lib` — **259/259 pass** (was 256, +3 new tests in `kv::tests`)
- [x] Pre-commit: rustfmt + clippy clean

**Not covered in this PR (tracked as follow-ups):**
- Native v2 writes from admin API / middleware — depends on an admin-API PR that hasn't been scoped here yet.
- `RateLimitSyncAdapter` reading `config:rate_limit` — lands with that adapter PR in the Step 4 outer sequence.
- v1-format *send* translation (v2 node writing → emit a `StoreType::App` `IncrementalUpdate` for v1 peers). Spec §2.5 calls this out as a dual-write during Phase B of rolling upgrade; it's a separate PR so the receive-side can land first and give us operational visibility before we change what v1 peers see from v2.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration updates now automatically synchronize across system storage components.
  * Added dedicated namespace for enhanced configuration management.

* **Tests**
  * Added tests for automatic configuration synchronization and namespace registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->