### PR TITLE
feat(gateway): implement R1 OpenAI Responses content-part transformer regression coverage

### DIFF
--- a/model_gateway/src/routers/openai/provider.rs
+++ b/model_gateway/src/routers/openai/provider.rs
@@ -133,6 +133,15 @@ impl Provider for XAIProvider {
 }
 
 impl XAIProvider {
+    /// Rewrite Responses API input items to the shape xAI accepts today.
+    ///
+    /// The only content-part normalization xAI requires is `output_text →
+    /// input_text` on historical messages replayed from `previous_response_id`
+    /// chains. Every other content variant (`input_text`, `input_image`,
+    /// `input_file`, `refusal`) is passed through **verbatim** so that file
+    /// and image inputs reach the upstream provider unchanged — xAI, like
+    /// OpenAI, owns the `file_id` resolution surface (smg does not host a
+    /// Files API backend).
     fn transform_responses_input(obj: &mut serde_json::Map<String, Value>) {
         let Some(input_arr) = obj.get_mut("input").and_then(Value::as_array_mut) else {
             return;
@@ -247,5 +256,256 @@ impl ProviderRegistry {
 
     pub fn default_provider_arc(&self) -> Arc<dyn Provider> {
         Arc::clone(&self.default_provider)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! R1 contract: the OpenAI-compat Responses router MUST forward new
+    //! content-part variants (`input_image`, `input_file`, `refusal`) to the
+    //! upstream provider untouched. These tests lock that contract for both
+    //! the default `OpenAIProvider` (pure pass-through) and the `XAIProvider`
+    //! (which otherwise rewrites `output_text → input_text`).
+    use openai_protocol::{
+        common::Detail,
+        responses::{
+            Annotation, FileDetail, ResponseContentPart, ResponseInput, ResponseInputOutputItem,
+            ResponsesRequest,
+        },
+    };
+    use serde_json::{json, to_value};
+
+    use super::*;
+
+    /// Build a `ResponsesRequest` whose single input message carries every
+    /// variant `ResponseContentPart` exposes after P1, including a `refusal`
+    /// that came back from a prior turn via `previous_response_id` replay.
+    fn request_with_all_content_parts() -> ResponsesRequest {
+        ResponsesRequest {
+            model: "grok-4".to_string(),
+            input: ResponseInput::Items(vec![ResponseInputOutputItem::Message {
+                id: "msg_1".to_string(),
+                role: "user".to_string(),
+                content: vec![
+                    ResponseContentPart::InputText {
+                        text: "describe this".to_string(),
+                    },
+                    ResponseContentPart::InputImage {
+                        detail: Some(Detail::High),
+                        file_id: Some("file-abc".to_string()),
+                        image_url: Some("https://example.com/cat.png".to_string()),
+                    },
+                    ResponseContentPart::InputFile {
+                        detail: Some(FileDetail::Low),
+                        file_data: Some("JVBERi0xLjQK".to_string()),
+                        file_id: Some("file-xyz".to_string()),
+                        file_url: Some("https://example.com/menu.pdf".to_string()),
+                        filename: Some("menu.pdf".to_string()),
+                    },
+                    ResponseContentPart::Refusal {
+                        refusal: "I can't help with that.".to_string(),
+                    },
+                    ResponseContentPart::OutputText {
+                        text: "prior assistant turn".to_string(),
+                        annotations: vec![Annotation::FileCitation {
+                            file_id: "file-abc".to_string(),
+                            filename: "cat.png".to_string(),
+                            index: 0,
+                        }],
+                        logprobs: None,
+                    },
+                ],
+                status: Some("completed".to_string()),
+                phase: None,
+            }]),
+            ..Default::default()
+        }
+    }
+
+    fn first_content_array(payload: &Value) -> &Vec<Value> {
+        payload["input"][0]["content"]
+            .as_array()
+            .expect("content array present on first input item")
+    }
+
+    #[test]
+    fn openai_provider_passes_input_image_untouched() {
+        let req = request_with_all_content_parts();
+        let mut payload = to_value(&req).expect("serialize request");
+        let provider = OpenAIProvider;
+
+        provider
+            .transform_request(&mut payload, Endpoint::Responses)
+            .expect("default OpenAI transform is infallible");
+
+        let content = first_content_array(&payload);
+        assert_eq!(content[1]["type"], json!("input_image"));
+        assert_eq!(content[1]["detail"], json!("high"));
+        assert_eq!(content[1]["file_id"], json!("file-abc"));
+        assert_eq!(
+            content[1]["image_url"],
+            json!("https://example.com/cat.png")
+        );
+    }
+
+    #[test]
+    fn openai_provider_passes_input_file_untouched() {
+        let req = request_with_all_content_parts();
+        let mut payload = to_value(&req).expect("serialize request");
+        let provider = OpenAIProvider;
+
+        provider
+            .transform_request(&mut payload, Endpoint::Responses)
+            .expect("default OpenAI transform is infallible");
+
+        let content = first_content_array(&payload);
+        assert_eq!(content[2]["type"], json!("input_file"));
+        assert_eq!(content[2]["detail"], json!("low"));
+        assert_eq!(content[2]["file_data"], json!("JVBERi0xLjQK"));
+        assert_eq!(content[2]["file_id"], json!("file-xyz"));
+        assert_eq!(
+            content[2]["file_url"],
+            json!("https://example.com/menu.pdf")
+        );
+        assert_eq!(content[2]["filename"], json!("menu.pdf"));
+    }
+
+    #[test]
+    fn openai_provider_passes_refusal_untouched() {
+        let req = request_with_all_content_parts();
+        let mut payload = to_value(&req).expect("serialize request");
+        let provider = OpenAIProvider;
+
+        provider
+            .transform_request(&mut payload, Endpoint::Responses)
+            .expect("default OpenAI transform is infallible");
+
+        let content = first_content_array(&payload);
+        assert_eq!(content[3]["type"], json!("refusal"));
+        assert_eq!(content[3]["refusal"], json!("I can't help with that."));
+    }
+
+    #[test]
+    fn openai_provider_preserves_typed_annotations_on_output_text() {
+        let req = request_with_all_content_parts();
+        let mut payload = to_value(&req).expect("serialize request");
+        let provider = OpenAIProvider;
+
+        provider
+            .transform_request(&mut payload, Endpoint::Responses)
+            .expect("default OpenAI transform is infallible");
+
+        let content = first_content_array(&payload);
+        assert_eq!(content[4]["type"], json!("output_text"));
+        let annotations = content[4]["annotations"]
+            .as_array()
+            .expect("typed annotations survive pass-through");
+        assert_eq!(annotations.len(), 1);
+        assert_eq!(annotations[0]["type"], json!("file_citation"));
+        assert_eq!(annotations[0]["file_id"], json!("file-abc"));
+        assert_eq!(annotations[0]["filename"], json!("cat.png"));
+        assert_eq!(annotations[0]["index"], json!(0));
+    }
+
+    #[test]
+    fn xai_provider_passes_input_image_untouched() {
+        let req = request_with_all_content_parts();
+        let mut payload = to_value(&req).expect("serialize request");
+        let provider = XAIProvider;
+
+        provider
+            .transform_request(&mut payload, Endpoint::Responses)
+            .expect("xAI Responses transform succeeds");
+
+        let content = first_content_array(&payload);
+        assert_eq!(content[1]["type"], json!("input_image"));
+        assert_eq!(content[1]["detail"], json!("high"));
+        assert_eq!(content[1]["file_id"], json!("file-abc"));
+        assert_eq!(
+            content[1]["image_url"],
+            json!("https://example.com/cat.png")
+        );
+    }
+
+    #[test]
+    fn xai_provider_passes_input_file_untouched() {
+        let req = request_with_all_content_parts();
+        let mut payload = to_value(&req).expect("serialize request");
+        let provider = XAIProvider;
+
+        provider
+            .transform_request(&mut payload, Endpoint::Responses)
+            .expect("xAI Responses transform succeeds");
+
+        let content = first_content_array(&payload);
+        assert_eq!(content[2]["type"], json!("input_file"));
+        assert_eq!(content[2]["detail"], json!("low"));
+        assert_eq!(content[2]["file_data"], json!("JVBERi0xLjQK"));
+        assert_eq!(content[2]["file_id"], json!("file-xyz"));
+        assert_eq!(
+            content[2]["file_url"],
+            json!("https://example.com/menu.pdf")
+        );
+        assert_eq!(content[2]["filename"], json!("menu.pdf"));
+    }
+
+    #[test]
+    fn xai_provider_passes_refusal_untouched() {
+        let req = request_with_all_content_parts();
+        let mut payload = to_value(&req).expect("serialize request");
+        let provider = XAIProvider;
+
+        provider
+            .transform_request(&mut payload, Endpoint::Responses)
+            .expect("xAI Responses transform succeeds");
+
+        let content = first_content_array(&payload);
+        assert_eq!(content[3]["type"], json!("refusal"));
+        assert_eq!(content[3]["refusal"], json!("I can't help with that."));
+    }
+
+    #[test]
+    fn xai_provider_still_rewrites_output_text_to_input_text_and_keeps_other_variants() {
+        // xAI's historical behavior: replayed assistant `output_text` parts
+        // are rewritten to `input_text` so xAI's Responses backend accepts
+        // them. That rewrite MUST NOT touch `input_image`, `input_file`, or
+        // `refusal` parts — this test pins both halves of the contract.
+        let req = request_with_all_content_parts();
+        let mut payload = to_value(&req).expect("serialize request");
+        let provider = XAIProvider;
+
+        provider
+            .transform_request(&mut payload, Endpoint::Responses)
+            .expect("xAI Responses transform succeeds");
+
+        let content = first_content_array(&payload);
+        assert_eq!(content[0]["type"], json!("input_text"));
+        assert_eq!(content[1]["type"], json!("input_image"));
+        assert_eq!(content[2]["type"], json!("input_file"));
+        assert_eq!(content[3]["type"], json!("refusal"));
+        // output_text → input_text rewrite kicks in on index 4.
+        assert_eq!(content[4]["type"], json!("input_text"));
+        // The rewritten part still carries its annotations untouched.
+        let annotations = content[4]["annotations"]
+            .as_array()
+            .expect("annotations survive type rewrite");
+        assert_eq!(annotations.len(), 1);
+        assert_eq!(annotations[0]["type"], json!("file_citation"));
+    }
+
+    #[test]
+    fn xai_provider_is_noop_for_chat_endpoint() {
+        let req = request_with_all_content_parts();
+        let mut payload = to_value(&req).expect("serialize request");
+        let provider = XAIProvider;
+
+        provider
+            .transform_request(&mut payload, Endpoint::Chat)
+            .expect("xAI Chat transform succeeds");
+
+        // `input` field is untouched because the Responses-specific rewrite
+        // only fires for `Endpoint::Responses`.
+        let content = first_content_array(&payload);
+        assert_eq!(content[4]["type"], json!("output_text"));
     }
 }

--- a/model_gateway/src/routers/openai/responses/route.rs
+++ b/model_gateway/src/routers/openai/responses/route.rs
@@ -205,3 +205,188 @@ pub(in crate::routers::openai) async fn route_responses(
 
     response
 }
+
+#[cfg(test)]
+mod tests {
+    //! R1 wire-contract tests: the OpenAI-compat Responses router forwards
+    //! the caller's request body to the upstream provider by serialising the
+    //! `ResponsesRequest` value (see [`route_responses`] around the
+    //! `to_value(&request_body)` site). These tests lock the shape that the
+    //! post-P1 content-part variants produce, so any future change to the
+    //! serde layer surfaces here before it reaches an upstream.
+    use openai_protocol::{
+        common::Detail,
+        responses::{
+            Annotation, FileDetail, ResponseContentPart, ResponseInput, ResponseInputOutputItem,
+            ResponsesRequest,
+        },
+    };
+    use serde_json::{json, to_value};
+
+    fn build_request_with_mixed_content() -> ResponsesRequest {
+        ResponsesRequest {
+            model: "gpt-5.4".to_string(),
+            input: ResponseInput::Items(vec![ResponseInputOutputItem::Message {
+                id: "msg_r1".to_string(),
+                role: "user".to_string(),
+                content: vec![
+                    ResponseContentPart::InputText {
+                        text: "what is in this image and this file?".to_string(),
+                    },
+                    ResponseContentPart::InputImage {
+                        detail: Some(Detail::Auto),
+                        file_id: Some("file-img".to_string()),
+                        image_url: Some("https://example.com/dog.jpg".to_string()),
+                    },
+                    ResponseContentPart::InputFile {
+                        detail: Some(FileDetail::High),
+                        file_data: Some("JVBERi0xLjQK".to_string()),
+                        file_id: Some("file-pdf".to_string()),
+                        file_url: Some("https://example.com/report.pdf".to_string()),
+                        filename: Some("report.pdf".to_string()),
+                    },
+                    ResponseContentPart::Refusal {
+                        refusal: "I cannot process that request.".to_string(),
+                    },
+                ],
+                status: Some("completed".to_string()),
+                phase: None,
+            }]),
+            ..Default::default()
+        }
+    }
+
+    /// Exercises the exact `to_value(&request_body)` step `route_responses`
+    /// uses to build the upstream payload — see `route.rs` handler body.
+    fn serialize_like_router(req: &ResponsesRequest) -> serde_json::Value {
+        to_value(req).expect("router serializes ResponsesRequest without error")
+    }
+
+    #[test]
+    fn router_serialization_preserves_input_image_fields() {
+        let req = build_request_with_mixed_content();
+        let payload = serialize_like_router(&req);
+        let content = &payload["input"][0]["content"];
+
+        assert_eq!(content[1]["type"], json!("input_image"));
+        assert_eq!(content[1]["detail"], json!("auto"));
+        assert_eq!(content[1]["file_id"], json!("file-img"));
+        assert_eq!(
+            content[1]["image_url"],
+            json!("https://example.com/dog.jpg")
+        );
+    }
+
+    #[test]
+    fn router_serialization_preserves_input_file_fields() {
+        let req = build_request_with_mixed_content();
+        let payload = serialize_like_router(&req);
+        let content = &payload["input"][0]["content"];
+
+        assert_eq!(content[2]["type"], json!("input_file"));
+        assert_eq!(content[2]["detail"], json!("high"));
+        assert_eq!(content[2]["file_data"], json!("JVBERi0xLjQK"));
+        assert_eq!(content[2]["file_id"], json!("file-pdf"));
+        assert_eq!(
+            content[2]["file_url"],
+            json!("https://example.com/report.pdf")
+        );
+        assert_eq!(content[2]["filename"], json!("report.pdf"));
+    }
+
+    #[test]
+    fn router_serialization_preserves_refusal() {
+        let req = build_request_with_mixed_content();
+        let payload = serialize_like_router(&req);
+        let content = &payload["input"][0]["content"];
+
+        assert_eq!(content[3]["type"], json!("refusal"));
+        assert_eq!(
+            content[3]["refusal"],
+            json!("I cannot process that request.")
+        );
+    }
+
+    #[test]
+    fn router_serialization_omits_empty_input_image_fields() {
+        // `file_id` / `image_url` / `detail` are all optional; the wire
+        // payload must not carry `null`s when the caller leaves them unset
+        // (the #[serde(skip_serializing_if = "Option::is_none")] attributes
+        // on ResponseContentPart guarantee this).
+        let req = ResponsesRequest {
+            model: "gpt-5.4".to_string(),
+            input: ResponseInput::Items(vec![ResponseInputOutputItem::Message {
+                id: "msg_sparse".to_string(),
+                role: "user".to_string(),
+                content: vec![ResponseContentPart::InputImage {
+                    detail: None,
+                    file_id: Some("file-only".to_string()),
+                    image_url: None,
+                }],
+                status: None,
+                phase: None,
+            }]),
+            ..Default::default()
+        };
+        let payload = serialize_like_router(&req);
+        let image = &payload["input"][0]["content"][0];
+
+        assert_eq!(image["type"], json!("input_image"));
+        assert_eq!(image["file_id"], json!("file-only"));
+        assert!(
+            image.get("detail").is_none(),
+            "detail should be omitted when None"
+        );
+        assert!(
+            image.get("image_url").is_none(),
+            "image_url should be omitted when None"
+        );
+    }
+
+    #[test]
+    fn router_serialization_round_trips_typed_annotations_on_output_text() {
+        // Assistant turns replayed from storage carry `OutputText` with typed
+        // annotations. R1 must preserve the annotation union end-to-end.
+        let req = ResponsesRequest {
+            model: "gpt-5.4".to_string(),
+            input: ResponseInput::Items(vec![ResponseInputOutputItem::Message {
+                id: "msg_prior".to_string(),
+                role: "assistant".to_string(),
+                content: vec![ResponseContentPart::OutputText {
+                    text: "Here are three citations.".to_string(),
+                    annotations: vec![
+                        Annotation::FileCitation {
+                            file_id: "file-1".to_string(),
+                            filename: "spec.pdf".to_string(),
+                            index: 0,
+                        },
+                        Annotation::UrlCitation {
+                            url: "https://example.com".to_string(),
+                            title: "Example".to_string(),
+                            start_index: 10,
+                            end_index: 24,
+                        },
+                        Annotation::FilePath {
+                            file_id: "file-2".to_string(),
+                            index: 2,
+                        },
+                    ],
+                    logprobs: None,
+                }],
+                status: Some("completed".to_string()),
+                phase: None,
+            }]),
+            ..Default::default()
+        };
+
+        let payload = serialize_like_router(&req);
+        let annotations = &payload["input"][0]["content"][0]["annotations"];
+        assert_eq!(annotations[0]["type"], json!("file_citation"));
+        assert_eq!(annotations[0]["filename"], json!("spec.pdf"));
+        assert_eq!(annotations[1]["type"], json!("url_citation"));
+        assert_eq!(annotations[1]["url"], json!("https://example.com"));
+        assert_eq!(annotations[1]["start_index"], json!(10));
+        assert_eq!(annotations[2]["type"], json!("file_path"));
+        assert_eq!(annotations[2]["index"], json!(2));
+    }
+}


### PR DESCRIPTION
## Description

### Problem

Audit task **R1 — OpenAI-compat Responses router content-part transformer**
(Priority P0, blocks E1/E2) asks for a content-part rewriter before dispatch
in the OpenAI-compat Responses router so that the P1-introduced variants
(`input_image`, `input_file`, `refusal`) and the typed `Annotation` union
are forwarded to the upstream provider untouched, with all fields
(`file_id`, `file_url`, `file_data`, `filename`, `detail`, `image_url`,
`refusal`) preserved on the wire. smg does not host a Files API backend —
the upstream provider owns `file_id` resolution — so the contract is
**pure forwarding**, not rewriting.

The audit's discovery grep

    grep -rnE "image_url|file_id|file_data|file_url|input_image|input_file|base64" \
      model_gateway/src/routers/openai/responses/

returned zero hits (one unrelated comment in `streaming.rs:415`), so there
was no test coverage pinning the passthrough contract against regressions
as the router and providers evolve.

### Solution

Investigation of the router (`model_gateway/src/routers/openai/responses/
route.rs:136` — the `to_value(&request_body)` site that builds the upstream
payload), the provider trait (`model_gateway/src/routers/openai/provider.rs`),
and the `ResponseContentPart` protocol definition (`crates/protocols/src/
responses.rs:723-769`, `#[serde(tag = \"type\", rename_all = \"snake_case\")]`
with `#[serde(skip_serializing_if = \"Option::is_none\")]` on every optional
field) confirmed that the existing serialization path already forwards every
new variant verbatim:

  - `OpenAIProvider::transform_request` inherits the `Provider` trait default
    which only strips SGLang-specific fields from the top-level object and
    never walks content parts.
  - `XAIProvider::transform_responses_input` (`provider.rs:145-164`) iterates
    content arrays but its rewrite predicate `content["type"] == \"output_text\"`
    (line 159) excludes every new variant by construction — `input_image`,
    `input_file`, and `refusal` are untouched.
  - `serde_json::to_value(&ResponsesRequest)` emits spec-compliant tagged
    wire form (type discriminator + snake_case variant names) automatically.

Adding a new dead transformer helper purely to satisfy the letter of \"insert
a rewriter\" would violate KISS/YAGNI. Instead this PR adds exhaustive
**regression tests** that pin the passthrough contract so any future change
to the serde layer or provider transforms fails loudly before reaching an
upstream.

## Changes

Two files, +445 lines, **tests + doc comments only** — zero production
behavior change:

- `model_gateway/src/routers/openai/provider.rs`:
  - Doc comment on `XAIProvider::transform_responses_input` stating the
    explicit contract: only `output_text → input_text` is rewritten, every
    other content variant is forwarded verbatim.
  - 9 new tests in `mod tests`:
    - 4 `OpenAIProvider` passthrough tests (one per variant: `input_image`,
      `input_file`, `refusal`, typed annotations on `output_text`).
    - 3 `XAIProvider` passthrough tests for the same three new variants.
    - 1 `XAIProvider` regression guard proving the `output_text → input_text`
      rewrite still fires on index 4 while indices 1-3 (`input_image`,
      `input_file`, `refusal`) remain untouched.
    - 1 endpoint-dispatch guard proving the Responses-specific rewrite does
      not fire on `Endpoint::Chat`.

- `model_gateway/src/routers/openai/responses/route.rs`:
  - 5 wire-contract tests in `mod tests` that exercise the exact
    `to_value(&request_body)` step `route_responses` uses at `route.rs:136`:
    - `input_image` fields preserved (`type`, `detail`, `file_id`, `image_url`).
    - `input_file` fields preserved (`type`, `detail`, `file_data`, `file_id`,
      `file_url`, `filename`).
    - `refusal` preserved.
    - `skip_serializing_if` guarantee (None fields are absent from the wire
      payload, not serialized as `null`).
    - Typed `Annotation` union (`FileCitation`, `UrlCitation`, `FilePath`)
      round-trips on replayed `output_text` from prior assistant turns.

No new public items, no new files, no `Cargo.toml` changes.

### Scope honesty — what this PR is and isn't

This PR **does not add a content-part transformer helper function** — the
investigation found the existing router is already wire-correct for R1's
passthrough contract, and adding a no-op helper would be dead code. What
R1's \"Desired\" block asks for (\"forward all fields ... untouched\") is an
OUTCOME that the existing code already produces by construction; these
tests prove it and lock it against regression.

If a subsequent audit determines a dedicated helper is required for
readability or to centralise variant coverage before E1/E2 adds richer
file-handling, that change can layer on top of this contract test suite —
the 14 tests here remain the acceptance harness either way.

## Test Plan

Ran in this worktree with `CARGO_TARGET_DIR=/tmp/r1-lead-target`:

    cargo test -p smg --lib routers::openai::provider::tests
    # → 9 passed; 0 failed

    cargo test -p smg --lib routers::openai::responses::route::tests
    # → 5 passed; 0 failed

    cargo +nightly fmt --all -- --check
    # → clean

    cargo clippy -p smg --lib --all-features --tests -- -D warnings
    # → clean

    codespell model_gateway/src/routers/openai/provider.rs \
              model_gateway/src/routers/openai/responses/route.rs
    # → clean

Additionally, the reviewer constructed 8 independent hand-built
`ResponsesRequest` fixtures in a throwaway crate outside this repo
(URL-only `input_image`, `file_id + detail` image, base64 `file_data`
file, `file_url` file, `file_id` file, `refusal` in assistant-role
history, mixed all-variants message, and a round-trip subtree invariance
check). Every fixture produced spec-compliant wire JSON:
`type` discriminator present, all fields preserved, `None` fields
omitted (not emitted as `null`), round-trip bit-identical on the R1
content-part subtree.

Refs: R1

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for request transformation validation in cloud provider integrations to ensure proper content handling and data preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->