### PR TITLE
feat(protocols): implement P6 ConversationRef union typing

### DIFF
--- a/crates/protocols/src/builders/responses/response.rs
+++ b/crates/protocols/src/builders/responses/response.rs
@@ -100,10 +100,7 @@ impl ResponsesResponseBuilder {
         // ResponsesResponse stores `conversation` as a plain `Option<String>`
         // (response side per spec is `optional { id }` only); flatten the
         // request's union-typed reference down to its underlying id string.
-        self.conversation = request
-            .conversation
-            .as_ref()
-            .map(|c| c.as_id().to_string());
+        self.conversation = request.conversation.as_ref().map(|c| c.as_id().to_string());
         self.temperature = request.temperature;
         self.tool_choice = if let Some(ref tc) = request.tool_choice {
             serde_json::to_string(tc).unwrap_or_else(|_| "auto".to_string())

--- a/crates/protocols/src/builders/responses/response.rs
+++ b/crates/protocols/src/builders/responses/response.rs
@@ -97,7 +97,13 @@ impl ResponsesResponseBuilder {
             .clone_from(&request.previous_response_id);
         self.store = request.store.unwrap_or(true);
         self.background = request.background;
-        self.conversation.clone_from(&request.conversation);
+        // ResponsesResponse stores `conversation` as a plain `Option<String>`
+        // (response side per spec is `optional { id }` only); flatten the
+        // request's union-typed reference down to its underlying id string.
+        self.conversation = request
+            .conversation
+            .as_ref()
+            .map(|c| c.as_id().to_string());
         self.temperature = request.temperature;
         self.tool_choice = if let Some(ref tc) = request.tool_choice {
             serde_json::to_string(tc).unwrap_or_else(|_| "auto".to_string())

--- a/crates/protocols/src/common.rs
+++ b/crates/protocols/src/common.rs
@@ -762,6 +762,50 @@ pub enum ContextManagementType {
     Compaction,
 }
 
+// ============================================================================
+// Responses API: conversation reference
+// ============================================================================
+
+/// Reference to a conversation the response belongs to.
+///
+/// Spec: `conversation: string | ResponseConversationParam { id: string }`.
+/// Variant order matters for `#[serde(untagged)]`: a bare JSON string succeeds
+/// as `Id`; an object falls through to `Object`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(untagged)]
+pub enum ConversationRef {
+    Id(String),
+    Object { id: String },
+}
+
+impl ConversationRef {
+    /// Return the underlying conversation id regardless of the wire shape.
+    pub fn as_id(&self) -> &str {
+        match self {
+            Self::Id(id) | Self::Object { id } => id.as_str(),
+        }
+    }
+
+    /// `true` when the underlying conversation id is the empty string.
+    /// Mirrors `String::is_empty` for callers that previously treated
+    /// `Option<String>` empty values as "unset".
+    pub fn is_empty(&self) -> bool {
+        self.as_id().is_empty()
+    }
+}
+
+impl From<String> for ConversationRef {
+    fn from(id: String) -> Self {
+        Self::Id(id)
+    }
+}
+
+impl From<&str> for ConversationRef {
+    fn from(id: &str) -> Self {
+        Self::Id(id.to_string())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use serde::Deserialize;
@@ -793,5 +837,35 @@ mod tests {
     fn test_deserialize_null_as_false_rejects_non_bool() {
         let result = serde_json::from_value::<NullableBoolTest>(json!({"field": "yes"}));
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn conversation_ref_deserializes_bare_string() {
+        let v = json!("conv_abc");
+        let r: ConversationRef = serde_json::from_value(v).expect("string form");
+        assert!(matches!(r, ConversationRef::Id(ref s) if s == "conv_abc"));
+        assert_eq!(r.as_id(), "conv_abc");
+        // Bare string round-trips back to a JSON string.
+        assert_eq!(serde_json::to_value(&r).unwrap(), json!("conv_abc"));
+    }
+
+    #[test]
+    fn conversation_ref_deserializes_object() {
+        let v = json!({"id": "conv_xyz"});
+        let r: ConversationRef = serde_json::from_value(v).expect("object form");
+        assert!(matches!(r, ConversationRef::Object { ref id } if id == "conv_xyz"));
+        assert_eq!(r.as_id(), "conv_xyz");
+        // Object round-trips back to an object.
+        assert_eq!(
+            serde_json::to_value(&r).unwrap(),
+            json!({"id": "conv_xyz"})
+        );
+    }
+
+    #[test]
+    fn conversation_ref_is_empty() {
+        assert!(ConversationRef::from("").is_empty());
+        assert!(!ConversationRef::from("conv_1").is_empty());
+        assert!(ConversationRef::Object { id: String::new() }.is_empty());
     }
 }

--- a/crates/protocols/src/common.rs
+++ b/crates/protocols/src/common.rs
@@ -794,18 +794,6 @@ impl ConversationRef {
     }
 }
 
-impl From<String> for ConversationRef {
-    fn from(id: String) -> Self {
-        Self::Id(id)
-    }
-}
-
-impl From<&str> for ConversationRef {
-    fn from(id: &str) -> Self {
-        Self::Id(id.to_string())
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use serde::Deserialize;
@@ -856,16 +844,13 @@ mod tests {
         assert!(matches!(r, ConversationRef::Object { ref id } if id == "conv_xyz"));
         assert_eq!(r.as_id(), "conv_xyz");
         // Object round-trips back to an object.
-        assert_eq!(
-            serde_json::to_value(&r).unwrap(),
-            json!({"id": "conv_xyz"})
-        );
+        assert_eq!(serde_json::to_value(&r).unwrap(), json!({"id": "conv_xyz"}));
     }
 
     #[test]
     fn conversation_ref_is_empty() {
-        assert!(ConversationRef::from("").is_empty());
-        assert!(!ConversationRef::from("conv_1").is_empty());
+        assert!(ConversationRef::Id(String::new()).is_empty());
+        assert!(!ConversationRef::Id("conv_1".to_string()).is_empty());
         assert!(ConversationRef::Object { id: String::new() }.is_empty());
     }
 }

--- a/crates/protocols/src/responses.rs
+++ b/crates/protocols/src/responses.rs
@@ -9,11 +9,10 @@ use validator::{Validate, ValidationError};
 
 use super::{
     common::{
-        default_true, validate_stop, ChatLogProbs, ContextManagementEntry, ConversationRef,
-        Detail, Function, FunctionChoice, GenerationRequest, PromptCacheRetention,
-        PromptTokenUsageInfo, ResponsePrompt, StreamOptions, StringOrArray,
-        ToolChoice as ChatToolChoice, ToolChoiceValue as ChatToolChoiceValue, ToolReference,
-        UsageInfo,
+        default_true, validate_stop, ChatLogProbs, ContextManagementEntry, ConversationRef, Detail,
+        Function, FunctionChoice, GenerationRequest, PromptCacheRetention, PromptTokenUsageInfo,
+        ResponsePrompt, StreamOptions, StringOrArray, ToolChoice as ChatToolChoice,
+        ToolChoiceValue as ChatToolChoiceValue, ToolReference, UsageInfo,
     },
     sampling_params::{validate_top_k_value, validate_top_p_value},
 };

--- a/crates/protocols/src/responses.rs
+++ b/crates/protocols/src/responses.rs
@@ -9,10 +9,11 @@ use validator::{Validate, ValidationError};
 
 use super::{
     common::{
-        default_true, validate_stop, ChatLogProbs, ContextManagementEntry, Detail, Function,
-        FunctionChoice, GenerationRequest, PromptCacheRetention, PromptTokenUsageInfo,
-        ResponsePrompt, StreamOptions, StringOrArray, ToolChoice as ChatToolChoice,
-        ToolChoiceValue as ChatToolChoiceValue, ToolReference, UsageInfo,
+        default_true, validate_stop, ChatLogProbs, ContextManagementEntry, ConversationRef,
+        Detail, Function, FunctionChoice, GenerationRequest, PromptCacheRetention,
+        PromptTokenUsageInfo, ResponsePrompt, StreamOptions, StringOrArray,
+        ToolChoice as ChatToolChoice, ToolChoiceValue as ChatToolChoiceValue, ToolReference,
+        UsageInfo,
     },
     sampling_params::{validate_top_k_value, validate_top_p_value},
 };
@@ -1226,10 +1227,15 @@ pub struct ResponsesRequest {
     /// Model to use
     pub model: String,
 
-    /// Optional conversation id to persist input/output as items
+    /// Optional conversation reference to persist input/output as items.
+    ///
+    /// Spec: `conversation` accepts either a bare ID string or
+    /// `ResponseConversationParam { id }`. Both wire shapes deserialize into
+    /// [`ConversationRef`]; downstream code reads the id via
+    /// [`ConversationRef::as_id`].
     #[serde(skip_serializing_if = "Option::is_none")]
     #[validate(custom(function = "validate_conversation_id"))]
-    pub conversation: Option<String>,
+    pub conversation: Option<ConversationRef>,
 
     /// Whether to enable parallel tool calls
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1539,8 +1545,15 @@ impl GenerationRequest for ResponsesRequest {
     }
 }
 
-/// Validate conversation ID format
-pub fn validate_conversation_id(conv_id: &str) -> Result<(), ValidationError> {
+/// Validate the conversation reference's ID format.
+///
+/// The validator crate auto-unwraps `Option<ConversationRef>` for the
+/// `#[validate(custom(...))]` attribute, so this function only runs when
+/// the field is present. Both wire shapes (bare string or `{ id }` object)
+/// are validated against the same rule by extracting the underlying id via
+/// [`ConversationRef::as_id`].
+pub fn validate_conversation_id(conv: &ConversationRef) -> Result<(), ValidationError> {
+    let conv_id = conv.as_id();
     if !conv_id.starts_with("conv_") {
         let mut error = ValidationError::new("invalid_conversation_id");
         error.message = Some(std::borrow::Cow::Owned(format!(

--- a/crates/protocols/tests/background_mode_protocol.rs
+++ b/crates/protocols/tests/background_mode_protocol.rs
@@ -169,6 +169,23 @@ fn copy_from_request_propagates_background_and_conversation() {
 }
 
 #[test]
+fn copy_from_request_accepts_conversation_object_form() {
+    // P6: `conversation` accepts the spec's object form
+    // `{ id: string }` (ResponseConversationParam). The ResponsesResponse
+    // builder flattens either wire shape down to the underlying id.
+    let request: ResponsesRequest = serde_json::from_value(json!({
+        "model": "gpt-5.4",
+        "input": "hello",
+        "conversation": { "id": "conv_obj" },
+    }))
+    .expect("deserialize object form");
+    let resp = ResponsesResponse::builder("resp_xyz", "gpt-5.4")
+        .copy_from_request(&request)
+        .build();
+    assert_eq!(resp.conversation.as_deref(), Some("conv_obj"));
+}
+
+#[test]
 fn is_incomplete_helper() {
     let resp = ResponsesResponse::builder("resp_xyz", "gpt-5.4")
         .status(ResponseStatus::Incomplete)

--- a/model_gateway/src/routers/common/persistence_utils.rs
+++ b/model_gateway/src/routers/common/persistence_utils.rs
@@ -180,9 +180,12 @@ pub fn build_stored_response(
     stored.model = get_string(response_json, "model").or_else(|| Some(original_body.model.clone()));
 
     stored.safety_identifier.clone_from(&original_body.user);
-    stored
-        .conversation_id
-        .clone_from(&original_body.conversation);
+    // `StoredResponse.conversation_id` is `Option<String>`; flatten the
+    // request's `Option<ConversationRef>` union down to its underlying id.
+    stored.conversation_id = original_body
+        .conversation
+        .as_ref()
+        .map(|c| c.as_id().to_string());
 
     stored.previous_response_id = get_string(response_json, "previous_response_id")
         .map(|s| ResponseId::from(s.as_str()))
@@ -436,8 +439,8 @@ async fn persist_conversation_items_inner(
         .map_err(|e| format!("Failed to store response: {e}"))?;
 
     // Check if conversation is provided and validate it exists
-    let conv_id_opt = if let Some(id) = &original_body.conversation {
-        let conv_id = ConversationId::from(id.as_str());
+    let conv_id_opt = if let Some(conv_ref) = &original_body.conversation {
+        let conv_id = ConversationId::from(conv_ref.as_id());
         match conversation_storage.get_conversation(&conv_id).await {
             Ok(Some(_)) => Some(conv_id),
             Ok(None) => {

--- a/model_gateway/src/routers/grpc/regular/responses/common.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/common.rs
@@ -231,8 +231,9 @@ pub(super) async fn load_conversation_history(
     }
 
     // Handle conversation by loading conversation history
-    if let Some(ref conv_id_str) = request.conversation {
-        let conv_id = ConversationId::from(conv_id_str.as_str());
+    if let Some(ref conv_ref) = request.conversation {
+        let conv_id_str = conv_ref.as_id();
+        let conv_id = ConversationId::from(conv_id_str);
 
         // Check if conversation exists - return error if not found
         let conversation = ctx

--- a/model_gateway/src/routers/openai/responses/route.rs
+++ b/model_gateway/src/routers/openai/responses/route.rs
@@ -87,8 +87,10 @@ pub(in crate::routers::openai) async fn route_responses(
     };
 
     // Validate mutual exclusivity of conversation and previous_response_id
-    // Treat empty strings as unset to match other metadata paths
-    let conversation = body.conversation.as_ref().filter(|s| !s.is_empty());
+    // Treat empty strings as unset to match other metadata paths. The
+    // `conversation` field is a `Option<ConversationRef>` union (bare string
+    // or `{ id }` object); `ConversationRef::is_empty` covers both shapes.
+    let conversation = body.conversation.as_ref().filter(|c| !c.is_empty());
     let has_previous_response = body
         .previous_response_id
         .as_ref()
@@ -114,7 +116,7 @@ pub(in crate::routers::openai) async fn route_responses(
 
     let loaded_history = match super::history::load_input_history(
         deps.responses_components,
-        conversation.map(String::as_str),
+        conversation.map(|c| c.as_id()),
         &mut request_body,
         model,
     )

--- a/model_gateway/src/routers/openai/responses/utils.rs
+++ b/model_gateway/src/routers/openai/responses/utils.rs
@@ -100,8 +100,11 @@ pub(super) fn patch_response_with_request_metadata(
     // Attach conversation id for client response. Unwrap via `as_id()` so we
     // emit a flat `{ "id": "conv_..." }` object regardless of whether the
     // original request used the string or object variant of `ConversationRef`.
-    if let Some(conv_id) = &original_body.conversation {
-        obj.insert("conversation".to_string(), json!({ "id": conv_id.as_id() }));
+    if let Some(conv_ref) = &original_body.conversation {
+        obj.insert(
+            "conversation".to_string(),
+            json!({ "id": conv_ref.as_id() }),
+        );
     }
 }
 
@@ -177,8 +180,11 @@ pub(super) fn rewrite_streaming_block(
     // Attach conversation id. Unwrap via `as_id()` so the SSE payload emits a
     // flat `{ "id": "conv_..." }` even when the original request used the
     // object form of `ConversationRef`.
-    if let Some(conv_id) = &original_body.conversation {
-        response_obj.insert("conversation".to_string(), json!({ "id": conv_id.as_id() }));
+    if let Some(conv_ref) = &original_body.conversation {
+        response_obj.insert(
+            "conversation".to_string(),
+            json!({ "id": conv_ref.as_id() }),
+        );
         changed = true;
     }
 

--- a/model_gateway/src/routers/openai/responses/utils.rs
+++ b/model_gateway/src/routers/openai/responses/utils.rs
@@ -97,9 +97,11 @@ pub(super) fn patch_response_with_request_metadata(
         }
     }
 
-    // Attach conversation id for client response
+    // Attach conversation id for client response. Unwrap via `as_id()` so we
+    // emit a flat `{ "id": "conv_..." }` object regardless of whether the
+    // original request used the string or object variant of `ConversationRef`.
     if let Some(conv_id) = &original_body.conversation {
-        obj.insert("conversation".to_string(), json!({ "id": conv_id }));
+        obj.insert("conversation".to_string(), json!({ "id": conv_id.as_id() }));
     }
 }
 
@@ -172,9 +174,11 @@ pub(super) fn rewrite_streaming_block(
         }
     }
 
-    // Attach conversation id
+    // Attach conversation id. Unwrap via `as_id()` so the SSE payload emits a
+    // flat `{ "id": "conv_..." }` even when the original request used the
+    // object form of `ConversationRef`.
     if let Some(conv_id) = &original_body.conversation {
-        response_obj.insert("conversation".to_string(), json!({ "id": conv_id }));
+        response_obj.insert("conversation".to_string(), json!({ "id": conv_id.as_id() }));
         changed = true;
     }
 
@@ -386,7 +390,7 @@ fn function_tool_name(tool: &Value) -> Option<&str> {
 #[cfg(test)]
 mod tests {
     use openai_protocol::{
-        common::Function,
+        common::{ConversationRef, Function},
         responses::{FunctionTool, McpTool, ResponseInput, ResponseTool, ResponsesRequest},
     };
     use serde_json::json;
@@ -395,7 +399,9 @@ mod tests {
         McpToolSession, McpTransport, Tool, ToolEntry,
     };
 
-    use super::restore_original_tools;
+    use super::{
+        patch_response_with_request_metadata, restore_original_tools, rewrite_streaming_block,
+    };
 
     fn test_tool(name: &str) -> Tool {
         let mut schema = serde_json::Map::new();
@@ -1228,6 +1234,83 @@ mod tests {
                     "content": [{"type": "output_text", "text": "visible"}]
                 }
             ])
+        );
+    }
+
+    /// Regression: when the client sends `conversation` as an object
+    /// (`ConversationRef::Object { id }`), the non-streaming response patcher
+    /// must emit a flat `{ "conversation": { "id": "conv_..." } }`. Before the
+    /// `as_id()` fix, the old code interpolated the whole `ConversationRef`,
+    /// serializing the `Object` variant as `{"id": "conv_..."}` and producing
+    /// a nested `{"conversation": {"id": {"id": "conv_..."}}}`.
+    #[test]
+    fn patch_response_flattens_object_conversation_ref() {
+        let original_body = ResponsesRequest {
+            model: "gpt-5.4".to_string(),
+            input: ResponseInput::Text("hello".to_string()),
+            conversation: Some(ConversationRef::Object {
+                id: "conv_abc".to_string(),
+            }),
+            ..Default::default()
+        };
+        let mut response = json!({});
+        patch_response_with_request_metadata(&mut response, &original_body, None);
+
+        assert_eq!(
+            response.get("conversation"),
+            Some(&json!({ "id": "conv_abc" })),
+            "object-form conversation must emit flat {{id}}, not nested {{id:{{id}}}}"
+        );
+        // Negative guard: the inner value must be a string, not an object.
+        let inner = response
+            .get("conversation")
+            .and_then(|v| v.get("id"))
+            .expect("conversation.id present");
+        assert!(
+            inner.is_string(),
+            "conversation.id must be a plain string, got {inner:?}"
+        );
+    }
+
+    /// Regression: same invariant for the streaming SSE rewriter.
+    #[test]
+    fn rewrite_streaming_block_flattens_object_conversation_ref() {
+        let original_body = ResponsesRequest {
+            model: "gpt-5.4".to_string(),
+            input: ResponseInput::Text("hello".to_string()),
+            conversation: Some(ConversationRef::Object {
+                id: "conv_xyz".to_string(),
+            }),
+            ..Default::default()
+        };
+
+        // Minimal response.created SSE block with a `response` object to patch.
+        let block = "event: response.created\n\
+                     data: {\"type\":\"response.created\",\"response\":{}}\n";
+
+        let rewritten =
+            rewrite_streaming_block(block, &original_body, None).expect("block rewritten");
+
+        // Extract the `data:` line payload and re-parse it.
+        let data_line = rewritten
+            .lines()
+            .find(|l| l.starts_with("data: "))
+            .expect("data line");
+        let payload: serde_json::Value =
+            serde_json::from_str(data_line.trim_start_matches("data: ")).expect("json");
+        let conv = payload
+            .get("response")
+            .and_then(|r| r.get("conversation"))
+            .expect("conversation attached");
+
+        assert_eq!(
+            conv,
+            &json!({ "id": "conv_xyz" }),
+            "streaming payload must flatten object-form conversation"
+        );
+        assert!(
+            conv.get("id").unwrap().is_string(),
+            "conversation.id must be a plain string, got {conv:?}"
         );
     }
 }

--- a/model_gateway/tests/spec/responses.rs
+++ b/model_gateway/tests/spec/responses.rs
@@ -1,5 +1,5 @@
 use openai_protocol::{
-    common::{Function, StringOrArray},
+    common::{ConversationRef, Function, StringOrArray},
     responses::{
         FunctionTool, IncludeField, McpTool, ResponseInput, ResponseInputOutputItem, ResponseTool,
         ResponsesRequest, ResponsesToolChoice, StringOrContentParts, TextConfig, TextFormat,
@@ -23,7 +23,7 @@ fn test_validate_conversation_id_valid() {
 
     for id in valid_ids {
         let request = ResponsesRequest {
-            conversation: Some(id.to_string()),
+            conversation: Some(ConversationRef::Id(id.to_string())),
             input: ResponseInput::Text("test".to_string()),
             ..Default::default()
         };
@@ -72,7 +72,7 @@ fn test_validate_conversation_id_invalid() {
 
     for id in invalid_ids {
         let request = ResponsesRequest {
-            conversation: Some(id.to_string()),
+            conversation: Some(ConversationRef::Id(id.to_string())),
             input: ResponseInput::Text("test".to_string()),
             ..Default::default()
         };
@@ -133,7 +133,7 @@ fn test_validate_conversation_id_none() {
 fn test_validate_conversation_id_error_message_format() {
     let invalid_id = "conv_.test-conv-streaming";
     let request = ResponsesRequest {
-        conversation: Some(invalid_id.to_string()),
+        conversation: Some(ConversationRef::Id(invalid_id.to_string())),
         input: ResponseInput::Text("test".to_string()),
         ..Default::default()
     };
@@ -171,7 +171,7 @@ fn test_validate_conversation_id_error_message_format() {
 fn test_validate_conversation_id_missing_prefix() {
     let invalid_id = "test-conv-streaming";
     let request = ResponsesRequest {
-        conversation: Some(invalid_id.to_string()),
+        conversation: Some(ConversationRef::Id(invalid_id.to_string())),
         input: ResponseInput::Text("test".to_string()),
         ..Default::default()
     };
@@ -933,7 +933,7 @@ fn test_validate_conversation_previous_response_mutual_exclusion() {
     // Valid: only conversation
     let request = ResponsesRequest {
         input: ResponseInput::Text("test".to_string()),
-        conversation: Some("conv_123".to_string()),
+        conversation: Some(ConversationRef::Id("conv_123".to_string())),
         previous_response_id: None,
         ..Default::default()
     };
@@ -957,7 +957,7 @@ fn test_validate_conversation_previous_response_mutual_exclusion() {
     // Invalid: both conversation and previous_response_id
     let request = ResponsesRequest {
         input: ResponseInput::Text("test".to_string()),
-        conversation: Some("conv_123".to_string()),
+        conversation: Some(ConversationRef::Id("conv_123".to_string())),
         previous_response_id: Some("resp_123".to_string()),
         ..Default::default()
     };

--- a/model_gateway/tests/spec/responses.rs
+++ b/model_gateway/tests/spec/responses.rs
@@ -35,6 +35,62 @@ fn test_validate_conversation_id_valid() {
     }
 }
 
+/// Object-form `{"conversation": {"id": "conv_abc"}}` must deserialize into
+/// `ConversationRef::Object { .. }` and pass the same validation as the
+/// string-form.
+#[test]
+fn test_validate_conversation_id_object_form_valid() {
+    let v = json!({
+        "input": "test",
+        "model": "gpt-4",
+        "conversation": { "id": "conv_abc" },
+    });
+    let request: ResponsesRequest =
+        serde_json::from_value(v).expect("object-form conversation should deserialize");
+    assert!(
+        matches!(
+            request.conversation,
+            Some(ConversationRef::Object { ref id }) if id == "conv_abc"
+        ),
+        "Expected ConversationRef::Object variant, got {:?}",
+        request.conversation
+    );
+    assert!(
+        request.validate().is_ok(),
+        "Valid object-form conversation should pass validation, got: {:?}",
+        request.validate().err()
+    );
+}
+
+/// Object-form with an empty id must fail validation with the same
+/// `invalid_conversation_id` error code used for the string-form.
+#[test]
+fn test_validate_conversation_id_object_form_empty_invalid() {
+    let v = json!({
+        "input": "test",
+        "model": "gpt-4",
+        "conversation": { "id": "" },
+    });
+    let request: ResponsesRequest =
+        serde_json::from_value(v).expect("object-form conversation should deserialize");
+    let result = request.validate();
+    assert!(
+        result.is_err(),
+        "Object-form conversation with empty id should fail validation"
+    );
+    let errors = result.unwrap_err();
+    let field_errors = errors.field_errors();
+    let conversation_errors = field_errors
+        .get("conversation")
+        .expect("Expected error for 'conversation' field");
+    let code = conversation_errors.first().map(|e| e.code.as_ref());
+    assert_eq!(
+        code,
+        Some("invalid_conversation_id"),
+        "Expected 'invalid_conversation_id' error code, got: {code:?}"
+    );
+}
+
 /// Test that invalid conversation IDs fail validation
 #[test]
 fn test_validate_conversation_id_invalid() {


### PR DESCRIPTION
## Description

### Problem
The OpenAI Responses API spec defines the request-side `conversation` field as a union: either a bare string id or an object of shape `{ id: string }`. The existing protocol type used `Option<String>`, which silently dropped the object form during deserialization and then failed the regex/length validator downstream. There was no typed representation of the union, no helper to flatten it to the underlying id, and response-shaping code assumed the string form only.

### Solution
Introduce a `ConversationRef` union type with `serde(untagged)` variants `Id(String)` and `Object { id }`, retarget the validator at the underlying id via a new `as_id()` helper, and wire the type through every request-path callsite that reads `request.conversation`. Response-path writers flatten the union to its underlying id so the emitted payload is always `{ "conversation": { "id": "conv_..." } }` regardless of input shape.

Reviewed across two cycles: cycle-1 introduced the union + boundary wiring; Lead cycle-1 REJECT flagged (a) a production regression where the two response patchers interpolated the whole enum instead of its id, producing a nested `{ "id": { "id": "..." } }` payload, and (b) two dead `From` impls. Cycle-2 fixes both blockers and adds regression tests proven to fail on cycle-1 code.

## Changes

### Cycle 1 (`6bf57abb`)
- `crates/protocols/src/common.rs`: Added `pub enum ConversationRef { Id(String), Object { id: String } }` with `#[serde(untagged)]`, `as_id(&self) -> &str`, `is_empty(&self) -> bool`, and round-trip tests for both variants.
- `crates/protocols/src/responses.rs`: Changed `ResponsesRequest.conversation` from `Option<String>` to `Option<ConversationRef>`; retargeted the `#[validate]` attribute at `validate_conversation_id(&ConversationRef)` which calls `as_id()` before running the regex/length check.
- `crates/protocols/src/builders/responses/response.rs`: Flattens the union via `c.as_id().to_string()` when building the response-side `Option<String>` (response side per spec is `{ id }`-only).
- `model_gateway/src/routers/common/persistence_utils.rs`, `model_gateway/src/routers/grpc/regular/responses/common.rs`, `model_gateway/src/routers/openai/responses/route.rs`: Updated all request-path readers to call `as_id()` / `is_empty()` on the union.
- `model_gateway/tests/spec/responses.rs`: Migrated existing tests to `ConversationRef::Id(...)` explicit construction.

### Cycle 2 (`863c2034`) — addresses cycle-1 Lead REJECT
- `model_gateway/src/routers/openai/responses/utils.rs:104` (`patch_response_with_request_metadata`) and `:181` (`rewrite_streaming_block`): Switched from `json!({ "id": conv_id })` to `json!({ "id": conv_id.as_id() })`. Before the fix, interpolating the whole `ConversationRef::Object { id }` variant serialized as `{"id":"..."}` and produced a nested `{"conversation": {"id": {"id": "..."}}}` on both non-streaming and SSE paths. Now both paths emit a flat `{"conversation": {"id": "..."}}` regardless of input variant.
- `model_gateway/src/routers/openai/responses/utils.rs` (tests): Added `patch_response_flattens_object_conversation_ref` and `rewrite_streaming_block_flattens_object_conversation_ref` — both construct a `ConversationRef::Object { id }` request, drive it through the respective function, and assert the emitted shape is a flat `{"id": "conv_..."}` with a string-typed inner `id`. Both tests were verified to FAIL on cycle-1 code with the exact diagnostic `left: Object {"id": Object {"id": String("conv_abc")}}` vs `right: Object {"id": String("conv_abc")}`, and PASS on cycle-2.
- `crates/protocols/src/common.rs`: Removed `impl From<String> for ConversationRef` and `impl From<&str> for ConversationRef` (zero non-test callsites; flagged as §7 dead code). Updated the in-crate `conversation_ref_is_empty` test to construct variants explicitly (`ConversationRef::Id(String::new())`, `ConversationRef::Id("conv_1".to_string())`).
- `crates/protocols/src/builders/responses/response.rs`, `crates/protocols/src/responses.rs`, `crates/protocols/src/common.rs`: Incidental `cargo +nightly fmt` re-wrap of pre-existing whitespace drift so `fmt --check` stays green. Token-identical to the cycle-1 content (verified).

## Test Plan
- `cargo test -p smg --lib flattens_object_conversation_ref` passes both new tests (570 filtered out, 2 passed).
- Revert-verify gold-standard: temporarily reverted both `as_id()` calls to the pre-fix `conv_id` interpolation, re-ran both tests, confirmed failure with the exact nested `{"id": {"id": "..."}}` shape, restored, re-ran PASS. This closes the cycle-1 Lead blocker.
- `cargo +nightly fmt --all -- --check` clean.
- `cargo clippy -p smg -p openai-protocol --all-targets --no-deps -- -D warnings` clean.
- `codespell` findings on `common.rs:430` and `responses.rs:411-419` are pre-existing (`serde::ser` import; `Nin` spec-level filter variant) and unrelated to P6 delta.
- All existing `ResponsesRequest` spec tests continue to pass after the `Option<String>` to `Option<ConversationRef>` migration.

Refs: P6

<details>
<summary>Checklist</summary>

- [x] Union type + helpers land in `openai-protocol`
- [x] Validator retargeted to `ConversationRef::as_id()`
- [x] All request-path readers use `as_id()` / `is_empty()`
- [x] Response-path writers flatten to underlying id (both non-streaming and SSE)
- [x] Regression tests exist for the nested-id bug and proven to fail on unfixed code
- [x] Dead `From` impls removed (§7)
- [x] fmt / clippy / codespell gates green on delta
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Responses API accepts conversation IDs as either a bare string or an object with an "id" field and normalizes them into a single ID form across requests and responses.

* **Bug Fixes**
  * Conversation identifiers are consistently flattened and preserved when building responses, persisting items, loading history, and streaming/patching payloads.

* **Tests**
  * Added tests covering deserialization, validation, round-trips, and regression cases for both wire formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->