### PR TITLE
fix(multimodal): extract images from tool role messages

### DIFF
--- a/model_gateway/src/routers/grpc/multimodal.rs
+++ b/model_gateway/src/routers/grpc/multimodal.rs
@@ -191,6 +191,7 @@ pub(crate) fn has_multimodal_content(messages: &[ChatMessage]) -> bool {
             ChatMessage::User { content, .. } => Some(content),
             ChatMessage::System { content, .. } => Some(content),
             ChatMessage::Developer { content, .. } => Some(content),
+            ChatMessage::Tool { content, .. } => Some(content),
             _ => None,
         };
         content.is_some_and(|c| match c {
@@ -212,6 +213,7 @@ fn extract_content_parts(messages: &[ChatMessage]) -> Vec<MediaContentPart> {
             ChatMessage::User { content, .. } => Some(content),
             ChatMessage::System { content, .. } => Some(content),
             ChatMessage::Developer { content, .. } => Some(content),
+            ChatMessage::Tool { content, .. } => Some(content),
             _ => None,
         };
 


### PR DESCRIPTION
## Problem

`has_multimodal_content` and `extract_content_parts` only match `User`/`System`/`Developer` messages, silently dropping images in `Tool` role messages. This causes:

- **Tool-only image**: model sees `<|media_pad|>` placeholder but receives no pixel data → replies "I don't see any image"
- **User + tool images**: 2 placeholders vs 1 extracted image → TRT-LLM 400 `"More media placeholder tokens (2) than media items (1)"`

## Fix

Add `ChatMessage::Tool { content, .. } => Some(content)` to both match arms. `Tool.content` is `MessageContent` — same type as User/System/Developer. 2-line change.

## Note

OpenAI Chat Completions spec limits tool content to text-only, but their newer Responses API supports images in tool output. SMG's protocol layer already deserializes image parts in tool messages, and Kimi's chat template generates placeholders for all roles — this closes the gap in the extraction layer.

## Verified

E2E on Kimi K2.5 NVFP4 TP=4 TRT-LLM:

| Request | Before | After |
|---|---|---|
| Tool-only image | "I don't see any screenshot" | `extracted 1 multimodal images` |
| User + tool images | Only 1 image extracted; prod 400 | `extracted 2 multimodal images` |
| User-only image (control) | Works | Still works |



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced multimodal content detection and extraction for OpenAI ChatMessage Tool variants, ensuring images and text content within Tool messages are properly identified and processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->