### PR TITLE
refactor(gateway): strip scope-bleed guardrails from Wave-1/2 Responses router code

### DIFF
--- a/model_gateway/src/routers/grpc/harmony/stages/preparation.rs
+++ b/model_gateway/src/routers/grpc/harmony/stages/preparation.rs
@@ -174,11 +174,6 @@ impl HarmonyPreparationStage {
         // Step 1: Extract function tools with schemas from ResponseTools
         let mut function_tools = extract_tools_from_response_tools(request.tools.as_deref());
 
-        // Project the Responses `tool_choice` onto Chat Completions' shape so
-        // we can reuse the shared chat-utility helpers (filter + structural
-        // tag generator). Responses-only variants (hosted / mcp / custom /
-        // apply_patch / shell) collapse onto `auto` — the Harmony pipeline is
-        // chat-shaped and has no dedicated representation for them.
         let chat_tool_choice = request
             .tool_choice
             .as_ref()

--- a/model_gateway/src/routers/grpc/regular/responses/conversions.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/conversions.rs
@@ -151,12 +151,6 @@ pub(crate) fn responses_to_chat(req: &ResponsesRequest) -> Result<ChatCompletion
                         return Err("Unsupported input item type".to_string());
                     }
                     ResponseInputOutputItem::ImageGenerationCall { .. } => {
-                        // ImageGenerationCall round-trip items carry only base64
-                        // image bytes; no textual form to inject into a Chat
-                        // Completions transcript. Mirror the Harmony path
-                        // (see `harmony/builder.rs`) and reject loudly rather
-                        // than silently dropping — keeps both conversion paths
-                        // consistent with other non-text input items.
                         warn!(
                             function = "responses_to_chat",
                             "image_generation_call input item reached chat conversion"


### PR DESCRIPTION
## Summary
Wave 1+2 protocol PRs added defensive guardrails (pre-check blocks, Result refactors, tool_choice rejection, elaborative commentary, behaviour-changing data-constant additions) to router files beyond the forced compile-error minimum. This reverts those blocks, leaving only forced-cascade match arms and required field initialisers.

## Affected merged PRs (reverts router-side only, leaves protocol intact)
- #1272 T1 file_search — removed `file_search` from `BUILTIN_TOOLS` list
- #1275 P1 content parts — reverted `Refusal` text-propagation and the wordy `R1/R2/R3 will implement` comments in three content-part filter sites
- #1276 P7 ToolChoice — dropped the block-comment describing Responses->Chat tool_choice projection
- #1278 P2 top-level fields — replaced the six-field propagation block in `build_next_request` with `..Default::default()`; reverted `stream_options` preservation logic and removed the three newly-added tests asserting that behaviour
- #1281 P3 phase — removed `split_stored_message_content` helper, phase round-trip logic in `persistence_utils`/`regular`/`openai` history paths, phase destructure in `extract_input_items`, phase wrapper in `item_to_new_conversation_item`
- #1303 T4 image_generation — removed `image_generation` from `BUILTIN_TOOLS` list; trimmed the paragraph-length comment on the `ImageGenerationCall` match arm
- #1304 T3 web_search — removed `web_search` from `BUILTIN_TOOLS` list and the `| ResponseTool::WebSearch(_)` arm in the non-exhaustive `is_builtin` matches!

Every forced-cascade match arm (new enum variants needing an arm for exhaustiveness) and every required struct-field initialiser (new protocol-type fields) is preserved. `#[expect(...)]` not `#[allow(...)]` where applicable.

## Excluded
- #1306 P6 (`ConversationRef` union typing — legitimate type rename, kept as-is)
- #1300 R1 (OpenAI Responses content-part transformer regression coverage — router task by design, kept as-is)

## What changed
- `model_gateway/src/routers/grpc/harmony/builder.rs` — `BUILTIN_TOOLS` reduced to pre-Wave set; `is_builtin` matches! reduced; two `ResponseContentPart` filter_map blocks collapse `Refusal`/`InputImage`/`InputFile` into one neutral None arm
- `model_gateway/src/routers/grpc/harmony/stages/preparation.rs` — dropped the five-line block comment describing tool_choice projection rationale
- `model_gateway/src/routers/grpc/regular/responses/common.rs` — reverted `load_conversation_history` to parse `item.content` directly with `phase: None`; reverted `build_next_request` six-field propagation to `..Default::default()`
- `model_gateway/src/routers/grpc/regular/responses/conversions.rs` — restored `stream_options: Some(StreamOptions { include_usage: Some(true), ..Default::default() })` (the `..Default::default()` is compile-forced by P2's new `include_obfuscation` protocol field); reverted `extract_text_from_content` neutral drop; trimmed `ImageGenerationCall` comment; removed three stream_options tests
- `model_gateway/src/routers/openai/responses/history.rs` — reverted `load_input_history` message branch to parse `item.content` directly with `phase: None`
- `model_gateway/src/routers/common/persistence_utils.rs` — removed `split_stored_message_content` helper and its two call sites; reverted `extract_input_items` SimpleInputMessage destructure; reverted `item_to_new_conversation_item` phase wrapper branch

## Test plan
- `cargo check -p smg --lib` passes
- `cargo check -p openai-protocol --lib` passes
- `cargo clippy -p smg --lib --tests -- -D warnings` clean
- `cargo test -p smg --lib` — 579 passed, 0 failed
- `cargo test -p openai-protocol --lib` — 94 passed, 0 failed
- `cargo fmt --all -- --check` clean
- No protocol types modified; wire contract unchanged; behaviour reverted to pre-Wave-1 router neutrality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Internal code cleanup and documentation updates with no impact to user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->