### PR TITLE
feat(smg): add tenant resolution request metadata

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -400,6 +400,8 @@ struct Router {
     request_timeout_secs: u64,
     shutdown_grace_period_secs: u64,
     request_id_headers: Option<Vec<String>>,
+    trust_tenant_header: bool,
+    tenant_header_name: String,
     storage_context_headers: HashMap<String, String>,
     pd_disaggregation: bool,
     bucket_adjust_interval_secs: usize,
@@ -712,6 +714,8 @@ impl Router {
             .maybe_log_dir(self.log_dir.as_ref())
             .maybe_log_level(self.log_level.as_ref())
             .maybe_request_id_headers(self.request_id_headers.clone())
+            .trust_tenant_header(self.trust_tenant_header)
+            .tenant_header_name(&self.tenant_header_name)
             .maybe_storage_context_headers(
                 (!self.storage_context_headers.is_empty())
                     .then(|| self.storage_context_headers.clone()),
@@ -786,6 +790,8 @@ impl Router {
         request_timeout_secs = 1800,
         shutdown_grace_period_secs = 180,
         request_id_headers = None,
+        trust_tenant_header = false,
+        tenant_header_name = String::from("x-smg-tenant-id"),
         storage_context_headers = HashMap::new(),
         pd_disaggregation = false,
         bucket_adjust_interval_secs = 5,
@@ -893,6 +899,8 @@ impl Router {
         request_timeout_secs: u64,
         shutdown_grace_period_secs: u64,
         request_id_headers: Option<Vec<String>>,
+        trust_tenant_header: bool,
+        tenant_header_name: String,
         storage_context_headers: HashMap<String, String>,
         pd_disaggregation: bool,
         bucket_adjust_interval_secs: usize,
@@ -1009,6 +1017,8 @@ impl Router {
             request_timeout_secs,
             shutdown_grace_period_secs,
             request_id_headers,
+            trust_tenant_header,
+            tenant_header_name,
             storage_context_headers,
             pd_disaggregation,
             bucket_adjust_interval_secs,

--- a/model_gateway/benches/wasm_middleware_latency.rs
+++ b/model_gateway/benches/wasm_middleware_latency.rs
@@ -11,8 +11,11 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use http_body_util::BodyExt;
 use openai_protocol::chat::ChatCompletionRequest;
 use smg::{
-    app_context::AppContext, config::RouterConfig, middleware::wasm_middleware,
-    routers::RouterTrait, server::AppState,
+    app_context::AppContext,
+    config::RouterConfig,
+    middleware::{wasm_middleware, TenantRequestMeta},
+    routers::RouterTrait,
+    server::AppState,
 };
 use tokio::{runtime::Runtime, sync::mpsc};
 use tower::{Layer, Service};
@@ -28,6 +31,7 @@ impl RouterTrait for MockRouter {
     async fn route_chat(
         &self,
         _headers: Option<&HeaderMap>,
+        _tenant_meta: &TenantRequestMeta,
         _body: &ChatCompletionRequest,
         _model_id: &str,
     ) -> Response<Body> {

--- a/model_gateway/src/config/builder.rs
+++ b/model_gateway/src/config/builder.rs
@@ -362,6 +362,16 @@ impl RouterConfigBuilder {
         self
     }
 
+    pub fn trust_tenant_header(mut self, trust: bool) -> Self {
+        self.config.tenant_resolution.trust_tenant_header = trust;
+        self
+    }
+
+    pub fn tenant_header_name<S: Into<String>>(mut self, header_name: S) -> Self {
+        self.config.tenant_resolution.tenant_header_name = header_name.into();
+        self
+    }
+
     // ==================== IGW Mode ====================
 
     pub fn enable_igw(mut self) -> Self {
@@ -555,6 +565,13 @@ impl RouterConfigBuilder {
         headers: Option<HashMap<String, String>>,
     ) -> Self {
         self.config.storage_context_headers = headers.unwrap_or_default();
+        self
+    }
+
+    pub fn maybe_tenant_header_name(mut self, header_name: Option<impl Into<String>>) -> Self {
+        if let Some(header_name) = header_name {
+            self.config.tenant_resolution.tenant_header_name = header_name.into();
+        }
         self
     }
 

--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -47,6 +47,7 @@ pub struct RouterConfig {
     pub storage_context_headers: HashMap<String, String>,
     #[serde(default)]
     pub memory_runtime: MemoryRuntimeConfig,
+    #[serde(default)]
     pub tenant_resolution: TenantResolutionConfig,
     /// Set to -1 to disable rate limiting
     pub max_concurrent_requests: i32,
@@ -816,6 +817,11 @@ mod tests {
 
         assert!(deserialized.skills_enabled);
         assert!(deserialized.skills.is_none());
+        assert!(!deserialized.tenant_resolution.trust_tenant_header);
+        assert_eq!(
+            deserialized.tenant_resolution.tenant_header_name,
+            DEFAULT_TENANT_HEADER_NAME
+        );
     }
 
     #[test]

--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -8,7 +8,7 @@ pub use smg_data_connector::{
 };
 
 use super::{validation::ConfigValidator, ConfigResult, SkillsConfig};
-use crate::worker::ConnectionMode;
+use crate::{tenant::DEFAULT_TENANT_HEADER_NAME, worker::ConnectionMode};
 
 /// Runtime feature flags for memory behavior.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -47,6 +47,7 @@ pub struct RouterConfig {
     pub storage_context_headers: HashMap<String, String>,
     #[serde(default)]
     pub memory_runtime: MemoryRuntimeConfig,
+    pub tenant_resolution: TenantResolutionConfig,
     /// Set to -1 to disable rate limiting
     pub max_concurrent_requests: i32,
     pub queue_size: usize,
@@ -119,6 +120,22 @@ pub struct RouterConfig {
     /// When set, wraps all storage backends with hook-based interceptors.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub storage_hook_wasm_path: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct TenantResolutionConfig {
+    pub trust_tenant_header: bool,
+    pub tenant_header_name: String,
+}
+
+impl Default for TenantResolutionConfig {
+    fn default() -> Self {
+        Self {
+            trust_tenant_header: false,
+            tenant_header_name: DEFAULT_TENANT_HEADER_NAME.to_string(),
+        }
+    }
 }
 
 /// Tokenizer cache configuration
@@ -565,6 +582,7 @@ impl Default for RouterConfig {
             request_id_headers: None,
             storage_context_headers: HashMap::new(),
             memory_runtime: MemoryRuntimeConfig::default(),
+            tenant_resolution: TenantResolutionConfig::default(),
             max_concurrent_requests: -1,
             queue_size: 100,
             queue_timeout_secs: 60,
@@ -693,6 +711,11 @@ mod tests {
         assert!(config.trace_config.is_none());
         assert!(config.log_dir.is_none());
         assert!(config.log_level.is_none());
+        assert!(!config.tenant_resolution.trust_tenant_header);
+        assert_eq!(
+            config.tenant_resolution.tenant_header_name,
+            DEFAULT_TENANT_HEADER_NAME
+        );
         assert!(!config.skills_enabled);
         assert!(config.skills.is_none());
     }

--- a/model_gateway/src/config/validation.rs
+++ b/model_gateway/src/config/validation.rs
@@ -1,3 +1,5 @@
+use axum::http::HeaderName;
+
 use super::*;
 
 /// Configuration validator
@@ -9,6 +11,7 @@ impl ConfigValidator {
         Self::validate_policy(&config.policy)?;
         Self::validate_server_settings(config)?;
         Self::validate_storage_context_headers(config)?;
+        Self::validate_tenant_resolution(config)?;
         if let Some(discovery) = &config.discovery {
             Self::validate_discovery(discovery, &config.mode)?;
         }
@@ -166,6 +169,23 @@ impl ConfigValidator {
                 });
             }
         }
+
+        Ok(())
+    }
+
+    fn validate_tenant_resolution(config: &RouterConfig) -> ConfigResult<()> {
+        let header_name = config.tenant_resolution.tenant_header_name.trim();
+        if header_name.is_empty() {
+            return Err(ConfigError::ValidationFailed {
+                reason: "tenant_resolution.tenant_header_name must not be empty".to_string(),
+            });
+        }
+
+        HeaderName::try_from(header_name).map_err(|e| ConfigError::ValidationFailed {
+            reason: format!(
+                "tenant_resolution.tenant_header_name must be a valid HTTP header name: {e}"
+            ),
+        })?;
 
         Ok(())
     }

--- a/model_gateway/src/lib.rs
+++ b/model_gateway/src/lib.rs
@@ -7,6 +7,7 @@ pub mod policies;
 pub mod routers;
 pub mod server;
 pub mod service_discovery;
+pub mod tenant;
 pub mod version;
 pub mod wasm;
 pub mod worker;

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -310,6 +310,18 @@ struct CliArgs {
     #[arg(long, num_args = 0.., help_heading = "Request Handling")]
     storage_context_headers: Vec<String>,
 
+    /// Trust an upstream-provided tenant header for canonical tenant resolution.
+    #[arg(long, default_value_t = false, help_heading = "Request Handling")]
+    trust_tenant_header: bool,
+
+    /// Header name to use when --trust-tenant-header is enabled.
+    #[arg(
+        long,
+        default_value = "x-smg-tenant-id",
+        help_heading = "Request Handling"
+    )]
+    tenant_header_name: String,
+
     /// Request timeout in seconds
     #[arg(long, default_value_t = 1800, help_heading = "Request Handling")]
     request_timeout_secs: u64,
@@ -1234,6 +1246,8 @@ impl CliArgs {
                 (!self.storage_context_headers.is_empty())
                     .then(|| Self::parse_selector(&self.storage_context_headers)),
             )
+            .trust_tenant_header(self.trust_tenant_header)
+            .tenant_header_name(&self.tenant_header_name)
             .maybe_rate_limit_tokens_per_second(self.rate_limit_tokens_per_second)
             .maybe_model_path(self.model_path.as_ref())
             .maybe_tokenizer_path(self.tokenizer_path.as_ref())

--- a/model_gateway/src/middleware/auth.rs
+++ b/model_gateway/src/middleware/auth.rs
@@ -13,6 +13,8 @@ use axum::{
 use sha2::{Digest, Sha256};
 use subtle::ConstantTimeEq;
 
+use crate::tenant::DataPlaneCaller;
+
 #[derive(Clone)]
 pub struct AuthConfig {
     /// Precomputed SHA-256 hash of the API key, used for constant-time comparison
@@ -32,25 +34,31 @@ impl AuthConfig {
 /// Only active when router has an API key configured.
 pub async fn auth_middleware(
     State(auth_config): State<AuthConfig>,
-    request: Request<Body>,
+    mut request: Request<Body>,
     next: Next,
 ) -> Response {
     if let Some(expected_hash) = &auth_config.api_key_hash {
-        let token = request
+        let token_hash = request
             .headers()
             .get(header::AUTHORIZATION)
             .and_then(|h| h.to_str().ok())
-            .and_then(|h| h.strip_prefix("Bearer "));
+            .and_then(|h| h.strip_prefix("Bearer "))
+            .map(|token| {
+                let digest: [u8; 32] = Sha256::digest(token.as_bytes()).into();
+                digest
+            });
 
-        let authorized = token.is_some_and(|t| {
-            Sha256::digest(t.as_bytes())
-                .as_slice()
-                .ct_eq(expected_hash)
-                .unwrap_u8()
-                == 1
-        });
+        let authorized = token_hash
+            .as_ref()
+            .is_some_and(|digest| digest.ct_eq(expected_hash).unwrap_u8() == 1);
         if !authorized {
             return StatusCode::UNAUTHORIZED.into_response();
+        }
+
+        if let Some(token_hash) = token_hash {
+            request
+                .extensions_mut()
+                .insert(DataPlaneCaller::authenticated_from_sha256(token_hash));
         }
     }
 

--- a/model_gateway/src/middleware/mod.rs
+++ b/model_gateway/src/middleware/mod.rs
@@ -10,6 +10,7 @@ pub mod logging;
 pub mod metrics;
 pub mod request_id;
 pub mod storage_context;
+pub mod tenant_resolution;
 pub mod token_bucket;
 pub mod wasm;
 
@@ -22,5 +23,17 @@ pub use metrics::{HttpMetricsLayer, HttpMetricsMiddleware};
 pub use request_id::{RequestId, RequestIdLayer, RequestIdMiddleware};
 pub(crate) use storage_context::build_memory_execution_context;
 pub use storage_context::storage_context_middleware;
+pub use tenant_resolution::{
+    ordinary_tenant_resolution_middleware, route_request_meta_middleware, TenantResolutionState,
+};
 pub use token_bucket::TokenBucket;
 pub use wasm::wasm_middleware;
+
+pub use crate::tenant::{
+    resolve_admin_target_tenant_id, resolve_admin_target_tenant_key, DataPlaneCaller,
+    RouteRequestMeta, TenantIdentity, TenantKey, TenantResolutionError,
+};
+
+/// Backward-compatible alias for the older tenant metadata name used in a few
+/// router-path tests and plumbing call sites.
+pub type TenantRequestMeta = RouteRequestMeta;

--- a/model_gateway/src/middleware/tenant_resolution.rs
+++ b/model_gateway/src/middleware/tenant_resolution.rs
@@ -1,0 +1,221 @@
+//! Tenant resolution and request-meta insertion for serving paths.
+
+use std::{net::SocketAddr, sync::Arc};
+
+use axum::{
+    body::Body,
+    extract::{connect_info::ConnectInfo, Request, State},
+    http::{header::InvalidHeaderName, HeaderMap, HeaderName},
+    middleware::Next,
+    response::Response,
+};
+
+use crate::{
+    config::{RouterConfig, TenantResolutionConfig},
+    tenant::{canonical_tenant_key, DataPlaneCaller, RouteRequestMeta, TenantIdentity, TenantKey},
+};
+
+#[derive(Clone)]
+pub struct TenantResolutionState {
+    trust_tenant_header: bool,
+    trusted_tenant_header_name: HeaderName,
+}
+
+impl TenantResolutionState {
+    pub fn new(config: &RouterConfig) -> Result<Self, InvalidHeaderName> {
+        Self::from_config(&config.tenant_resolution)
+    }
+
+    pub fn from_config(config: &TenantResolutionConfig) -> Result<Self, InvalidHeaderName> {
+        let trusted_tenant_header_name: HeaderName = config.tenant_header_name.parse()?;
+
+        Ok(Self {
+            trust_tenant_header: config.trust_tenant_header,
+            trusted_tenant_header_name,
+        })
+    }
+}
+
+fn resolve_tenant_key(state: &TenantResolutionState, request: &Request<Body>) -> TenantKey {
+    if let Some(caller) = request.extensions().get::<DataPlaneCaller>() {
+        return caller.tenant_key().clone();
+    }
+
+    if state.trust_tenant_header {
+        if let Some(tenant_id) = extract_trusted_tenant_id(state, request.headers()) {
+            return canonical_tenant_key(TenantIdentity::Header(Arc::from(tenant_id)));
+        }
+    }
+
+    if let Some(ConnectInfo(addr)) = request.extensions().get::<ConnectInfo<SocketAddr>>() {
+        return canonical_tenant_key(TenantIdentity::IpAddress(addr.ip()));
+    }
+
+    canonical_tenant_key(TenantIdentity::Anonymous)
+}
+
+fn extract_trusted_tenant_id<'a>(
+    state: &TenantResolutionState,
+    headers: &'a HeaderMap,
+) -> Option<&'a str> {
+    headers
+        .get(&state.trusted_tenant_header_name)
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+#[must_use]
+pub fn resolve_route_request_meta(
+    state: &TenantResolutionState,
+    request: &Request<Body>,
+) -> RouteRequestMeta {
+    RouteRequestMeta::new(resolve_tenant_key(state, request))
+}
+
+pub async fn route_request_meta_middleware(
+    State(state): State<TenantResolutionState>,
+    mut request: Request<Body>,
+    next: Next,
+) -> Response {
+    let request_meta = resolve_route_request_meta(&state, &request);
+    request.extensions_mut().insert(request_meta);
+    next.run(request).await
+}
+
+/// Backward-compatible name while the older skills task breakdown still uses
+/// the original tenant-resolution terminology.
+pub async fn ordinary_tenant_resolution_middleware(
+    state: State<TenantResolutionState>,
+    request: Request<Body>,
+    next: Next,
+) -> Response {
+    route_request_meta_middleware(state, request, next).await
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        extract::connect_info::ConnectInfo,
+        http::{header, HeaderValue, Request, StatusCode},
+        middleware::from_fn_with_state,
+        response::IntoResponse,
+        routing::get,
+        Router,
+    };
+    use tower::ServiceExt;
+
+    use super::*;
+    use crate::{
+        config::{PolicyConfig, RouterConfig, RoutingMode},
+        middleware::TenantRequestMeta,
+        tenant::DEFAULT_TENANT_HEADER_NAME,
+    };
+
+    fn resolution_state() -> TenantResolutionState {
+        TenantResolutionState::new(&RouterConfig::new(
+            RoutingMode::Regular {
+                worker_urls: vec!["http://worker1:8000".to_string()],
+            },
+            PolicyConfig::Random,
+        ))
+        .unwrap()
+    }
+
+    #[test]
+    fn request_meta_prefers_authenticated_data_plane_identity() {
+        let state = resolution_state();
+        let mut request = Request::builder().uri("/").body(Body::empty()).unwrap();
+        request
+            .extensions_mut()
+            .insert(DataPlaneCaller::new(TenantKey::from("auth:b3c2")));
+        request
+            .extensions_mut()
+            .insert(ConnectInfo("127.0.0.1:8080".parse::<SocketAddr>().unwrap()));
+
+        let request_meta = resolve_route_request_meta(&state, &request);
+        assert_eq!(request_meta.tenant_key().as_str(), "auth:b3c2");
+    }
+
+    #[test]
+    fn request_meta_uses_trusted_header_when_enabled() {
+        let mut config = RouterConfig::new(
+            RoutingMode::Regular {
+                worker_urls: vec!["http://worker1:8000".to_string()],
+            },
+            PolicyConfig::Random,
+        );
+        config.tenant_resolution.trust_tenant_header = true;
+        let state = TenantResolutionState::new(&config).unwrap();
+
+        let request = Request::builder()
+            .uri("/")
+            .header(DEFAULT_TENANT_HEADER_NAME, "team-red")
+            .body(Body::empty())
+            .unwrap();
+
+        let request_meta = resolve_route_request_meta(&state, &request);
+        assert_eq!(request_meta.tenant_key().as_str(), "header:team-red");
+    }
+
+    #[test]
+    fn request_meta_falls_back_to_client_ip() {
+        let state = resolution_state();
+        let mut request = Request::builder().uri("/").body(Body::empty()).unwrap();
+        request.extensions_mut().insert(ConnectInfo(
+            "203.0.113.42:443".parse::<SocketAddr>().unwrap(),
+        ));
+
+        let request_meta = resolve_route_request_meta(&state, &request);
+        assert_eq!(request_meta.tenant_key().as_str(), "ip:203.0.113.42");
+    }
+
+    #[test]
+    fn request_meta_falls_back_to_anonymous_without_identity_sources() {
+        let state = resolution_state();
+        let request = Request::builder().uri("/").body(Body::empty()).unwrap();
+
+        let request_meta = resolve_route_request_meta(&state, &request);
+        assert_eq!(request_meta.tenant_key().as_str(), "anonymous");
+    }
+
+    #[tokio::test]
+    async fn middleware_attaches_request_meta_extension() {
+        async fn handler(request: Request<Body>) -> impl IntoResponse {
+            request
+                .extensions()
+                .get::<TenantRequestMeta>()
+                .map(|meta| meta.tenant_key().to_string())
+                .unwrap_or_else(|| "missing".to_string())
+        }
+
+        let app = Router::new()
+            .route("/", get(handler))
+            .route_layer(from_fn_with_state(
+                resolution_state(),
+                route_request_meta_middleware,
+            ));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .header(
+                        header::AUTHORIZATION,
+                        HeaderValue::from_static("Bearer ignored"),
+                    )
+                    .extension(DataPlaneCaller::new(TenantKey::from("auth:tenant-a")))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert_eq!(std::str::from_utf8(&body).unwrap(), "auth:tenant-a");
+    }
+}

--- a/model_gateway/src/routers/anthropic/context.rs
+++ b/model_gateway/src/routers/anthropic/context.rs
@@ -9,7 +9,10 @@ use axum::http::HeaderMap;
 use openai_protocol::messages::CreateMessageRequest;
 use smg_mcp::{McpOrchestrator, McpServerBinding};
 
-use crate::worker::{Worker, WorkerRegistry};
+use crate::{
+    middleware::TenantRequestMeta,
+    worker::{Worker, WorkerRegistry},
+};
 
 /// Shared context passed to all Anthropic handler functions.
 #[derive(Clone)]
@@ -25,6 +28,12 @@ pub(crate) struct RequestContext {
     pub request: CreateMessageRequest,
     pub headers: Option<HeaderMap>,
     pub model_id: String,
+    /// Explicit tenant identity resolved once at the HTTP boundary.
+    #[expect(
+        dead_code,
+        reason = "tenant-scoped Anthropic consumers land after the shared serving-path plumbing"
+    )]
+    pub tenant_request_meta: TenantRequestMeta,
     /// Connected MCP server keys, present when the request includes `mcp_toolset` tools.
     pub mcp_servers: Option<Vec<McpServerBinding>>,
     /// Worker selected once in `route_messages`, reused for all iterations.

--- a/model_gateway/src/routers/anthropic/router.rs
+++ b/model_gateway/src/routers/anthropic/router.rs
@@ -18,6 +18,7 @@ use super::{
 };
 use crate::{
     app_context::AppContext,
+    middleware::TenantRequestMeta,
     routers::{
         common::{
             header_utils, mcp_utils,
@@ -90,6 +91,7 @@ impl RouterTrait for AnthropicRouter {
     async fn route_messages(
         &self,
         headers: Option<&HeaderMap>,
+        tenant_meta: &TenantRequestMeta,
         body: &CreateMessageRequest,
         model_id: &str,
     ) -> Response {
@@ -165,6 +167,7 @@ impl RouterTrait for AnthropicRouter {
             request,
             headers: headers_owned,
             model_id: model_id.to_string(),
+            tenant_request_meta: tenant_meta.clone(),
             mcp_servers,
             worker: selected_worker,
         };

--- a/model_gateway/src/routers/gemini/context.rs
+++ b/model_gateway/src/routers/gemini/context.rs
@@ -12,7 +12,10 @@ use serde_json::Value;
 use smg_mcp::McpOrchestrator;
 
 use super::state::RequestState;
-use crate::worker::{Worker, WorkerRegistry};
+use crate::{
+    middleware::TenantRequestMeta,
+    worker::{Worker, WorkerRegistry},
+};
 
 // ============================================================================
 // SharedComponents (per-router)
@@ -77,6 +80,11 @@ pub(crate) struct RequestInput {
     /// Optional model ID override (e.g. from URL path or query parameter).
     /// When set, takes precedence over `original_request.model`.
     pub model_id: Option<String>,
+    #[expect(
+        dead_code,
+        reason = "tenant-aware Gemini consumers land after the shared routing contract"
+    )]
+    pub tenant_request_meta: TenantRequestMeta,
 }
 
 /// Mutable processing state populated incrementally by steps.
@@ -101,6 +109,7 @@ impl RequestContext {
         original_request: Arc<InteractionsRequest>,
         headers: Option<HeaderMap>,
         model_id: Option<String>,
+        tenant_request_meta: TenantRequestMeta,
         components: Arc<SharedComponents>,
     ) -> Self {
         Self {
@@ -108,6 +117,7 @@ impl RequestContext {
                 original_request,
                 headers,
                 model_id,
+                tenant_request_meta,
             },
             components,
             state: RequestState::SelectWorker,

--- a/model_gateway/src/routers/gemini/router.rs
+++ b/model_gateway/src/routers/gemini/router.rs
@@ -13,6 +13,7 @@ use super::{
 use crate::{
     app_context::AppContext,
     config::types::RetryConfig,
+    middleware::TenantRequestMeta,
     routers::{
         common::retry::{is_retryable_status, RetryExecutor},
         RouterTrait,
@@ -73,6 +74,7 @@ impl RouterTrait for GeminiRouter {
     async fn route_interactions(
         &self,
         headers: Option<&HeaderMap>,
+        tenant_meta: &TenantRequestMeta,
         body: &InteractionsRequest,
         model_id: Option<&str>,
     ) -> Response {
@@ -95,8 +97,10 @@ impl RouterTrait for GeminiRouter {
                 let headers = headers_cloned.clone();
                 let model_id = model_id_cloned.clone();
                 let components = Arc::clone(&components);
+                let tenant_meta = tenant_meta.clone();
                 async move {
-                    let mut ctx = RequestContext::new(request, headers, model_id, components);
+                    let mut ctx =
+                        RequestContext::new(request, headers, model_id, tenant_meta, components);
                     driver::execute(&mut ctx).await
                 }
             },

--- a/model_gateway/src/routers/grpc/context.rs
+++ b/model_gateway/src/routers/grpc/context.rs
@@ -26,7 +26,10 @@ use super::{
     multimodal::MultimodalComponents,
     proto_wrapper::{ProtoEmbedComplete, ProtoRequest, ProtoStream},
 };
-use crate::worker::{RuntimeType, Worker, WorkerLoadGuard};
+use crate::{
+    middleware::TenantRequestMeta,
+    worker::{RuntimeType, Worker, WorkerLoadGuard},
+};
 
 /// Main request processing context
 ///
@@ -44,6 +47,7 @@ pub(crate) struct RequestInput {
     pub request_type: RequestType,
     pub headers: Option<HeaderMap>,
     pub model_id: String,
+    pub tenant_request_meta: Option<TenantRequestMeta>,
 }
 
 /// Request type variants
@@ -291,6 +295,7 @@ impl RequestContext {
                 request_type: RequestType::Chat(request),
                 headers,
                 model_id,
+                tenant_request_meta: None,
             },
             components,
             state: ProcessingState::default(),
@@ -309,6 +314,7 @@ impl RequestContext {
                 request_type: RequestType::Generate(request),
                 headers,
                 model_id,
+                tenant_request_meta: None,
             },
             components,
             state: ProcessingState::default(),
@@ -327,6 +333,7 @@ impl RequestContext {
                 request_type: RequestType::Completion(request),
                 headers,
                 model_id,
+                tenant_request_meta: None,
             },
             components,
             state: ProcessingState::default(),
@@ -345,6 +352,7 @@ impl RequestContext {
                 request_type: RequestType::Responses(request),
                 headers,
                 model_id,
+                tenant_request_meta: None,
             },
             components,
             state: ProcessingState::default(),
@@ -363,6 +371,7 @@ impl RequestContext {
                 request_type: RequestType::Embedding(request),
                 headers,
                 model_id,
+                tenant_request_meta: None,
             },
             components,
             state: ProcessingState::default(),
@@ -381,6 +390,7 @@ impl RequestContext {
                 request_type: RequestType::Classify(request),
                 headers,
                 model_id,
+                tenant_request_meta: None,
             },
             components,
             state: ProcessingState::default(),
@@ -399,6 +409,7 @@ impl RequestContext {
                 request_type: RequestType::Messages(request),
                 headers,
                 model_id,
+                tenant_request_meta: None,
             },
             components,
             state: ProcessingState::default(),

--- a/model_gateway/src/routers/grpc/harmony/responses/non_streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/non_streaming.rs
@@ -25,6 +25,7 @@ use super::{
     execution::{convert_mcp_tools_to_response_tools, execute_mcp_tools, ToolResult},
 };
 use crate::{
+    middleware::TenantRequestMeta,
     observability::metrics::Metrics,
     routers::{
         common::mcp_utils::DEFAULT_MAX_ITERATIONS,
@@ -52,6 +53,7 @@ use crate::{
 pub(crate) async fn serve_harmony_responses(
     ctx: &ResponsesContext,
     request: ResponsesRequest,
+    tenant_request_meta: TenantRequestMeta,
 ) -> Result<ResponsesResponse, Response> {
     // Clone request for persistence
     let original_request = request.clone();
@@ -64,10 +66,16 @@ pub(crate) async fn serve_harmony_responses(
         ensure_mcp_connection(&ctx.mcp_orchestrator, current_request.tools.as_deref()).await?;
 
     let response = if has_mcp_tools {
-        execute_with_mcp_loop(ctx, current_request, mcp_servers).await?
+        execute_with_mcp_loop(
+            ctx,
+            current_request,
+            tenant_request_meta.clone(),
+            mcp_servers,
+        )
+        .await?
     } else {
         // No MCP tools - execute pipeline once (may have function tools or no tools)
-        execute_without_mcp_loop(ctx, current_request).await?
+        execute_without_mcp_loop(ctx, current_request, tenant_request_meta).await?
     };
 
     // Persist response to storage if store=true
@@ -90,6 +98,7 @@ pub(crate) async fn serve_harmony_responses(
 async fn execute_with_mcp_loop(
     ctx: &ResponsesContext,
     mut current_request: ResponsesRequest,
+    tenant_request_meta: TenantRequestMeta,
     mcp_servers: Vec<McpServerBinding>,
 ) -> Result<ResponsesResponse, Response> {
     let mut iteration_count = 0;
@@ -153,7 +162,7 @@ async fn execute_with_mcp_loop(
         // Execute through full pipeline
         let iteration_result = ctx
             .pipeline
-            .execute_harmony_responses(&current_request, ctx)
+            .execute_harmony_responses(&current_request, ctx, Some(tenant_request_meta.clone()))
             .await?;
 
         match iteration_result {
@@ -340,13 +349,14 @@ async fn execute_with_mcp_loop(
 async fn execute_without_mcp_loop(
     ctx: &ResponsesContext,
     current_request: ResponsesRequest,
+    tenant_request_meta: TenantRequestMeta,
 ) -> Result<ResponsesResponse, Response> {
     debug!("Executing Harmony Responses without MCP loop");
 
     // Execute pipeline once
     let iteration_result = ctx
         .pipeline
-        .execute_harmony_responses(&current_request, ctx)
+        .execute_harmony_responses(&current_request, ctx, Some(tenant_request_meta))
         .await?;
 
     match iteration_result {

--- a/model_gateway/src/routers/grpc/harmony/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/streaming.rs
@@ -16,6 +16,7 @@ use super::{
     execution::{convert_mcp_tools_to_response_tools, execute_mcp_tools},
 };
 use crate::{
+    middleware::TenantRequestMeta,
     observability::metrics::Metrics,
     routers::{
         common::mcp_utils::DEFAULT_MAX_ITERATIONS,
@@ -40,6 +41,7 @@ use crate::{
 pub(crate) async fn serve_harmony_responses_stream(
     ctx: &ResponsesContext,
     request: ResponsesRequest,
+    tenant_request_meta: TenantRequestMeta,
 ) -> Response {
     // Load previous conversation history if previous_response_id is set
     let current_request = match load_previous_messages(ctx, request.clone()).await {
@@ -95,13 +97,22 @@ pub(crate) async fn serve_harmony_responses_stream(
                 ctx,
                 current_request,
                 &request,
+                tenant_request_meta.clone(),
                 mcp_servers,
                 &mut emitter,
                 &tx,
             )
             .await;
         } else {
-            execute_without_mcp_streaming(ctx, &current_request, &request, &mut emitter, &tx).await;
+            execute_without_mcp_streaming(
+                ctx,
+                &current_request,
+                &request,
+                tenant_request_meta,
+                &mut emitter,
+                &tx,
+            )
+            .await;
         }
     });
 
@@ -121,6 +132,7 @@ async fn execute_mcp_tool_loop_streaming(
     ctx: &ResponsesContext,
     mut current_request: ResponsesRequest,
     original_request: &ResponsesRequest,
+    tenant_request_meta: TenantRequestMeta,
     mcp_servers: Vec<McpServerBinding>,
     emitter: &mut ResponseStreamEventEmitter,
     tx: &mpsc::UnboundedSender<Result<Bytes, std::io::Error>>,
@@ -195,7 +207,11 @@ async fn execute_mcp_tool_loop_streaming(
         // Execute pipeline and get stream + load guards
         let (execution_result, _load_guards) = match ctx
             .pipeline
-            .execute_harmony_responses_streaming(&current_request, ctx)
+            .execute_harmony_responses_streaming(
+                &current_request,
+                ctx,
+                Some(tenant_request_meta.clone()),
+            )
             .await
         {
             Ok(result) => result,
@@ -394,6 +410,7 @@ async fn execute_without_mcp_streaming(
     ctx: &ResponsesContext,
     current_request: &ResponsesRequest,
     original_request: &ResponsesRequest,
+    tenant_request_meta: TenantRequestMeta,
     emitter: &mut ResponseStreamEventEmitter,
     tx: &mpsc::UnboundedSender<Result<Bytes, std::io::Error>>,
 ) {
@@ -402,7 +419,7 @@ async fn execute_without_mcp_streaming(
     // Execute pipeline and get stream + load guards
     let (execution_result, _load_guards) = match ctx
         .pipeline
-        .execute_harmony_responses_streaming(current_request, ctx)
+        .execute_harmony_responses_streaming(current_request, ctx, Some(tenant_request_meta))
         .await
     {
         Ok(result) => result,

--- a/model_gateway/src/routers/grpc/pd_router.rs
+++ b/model_gateway/src/routers/grpc/pd_router.rs
@@ -14,6 +14,7 @@ use super::{
 use crate::{
     app_context::AppContext,
     config::types::RetryConfig,
+    middleware::TenantRequestMeta,
     observability::metrics::{metrics_labels, Metrics},
     routers::{
         common::retry::{is_retryable_status, RetryExecutor},
@@ -110,6 +111,7 @@ impl GrpcPDRouter {
     async fn route_generate_impl(
         &self,
         headers: Option<&HeaderMap>,
+        tenant_meta: &TenantRequestMeta,
         body: &GenerateRequest,
         model_id: &str,
     ) -> Response {
@@ -123,6 +125,7 @@ impl GrpcPDRouter {
         let headers_cloned = headers.cloned();
         let model_id_cloned = model_id.to_string();
         let components = self.shared_components.clone();
+        let tenant_meta_cloned = tenant_meta.clone();
         let pipeline = &self.pipeline;
 
         // Use per-model retry config if set by a worker, otherwise fall back to router default.
@@ -138,9 +141,10 @@ impl GrpcPDRouter {
                 let headers = headers_cloned.clone();
                 let model_id = model_id_cloned.clone();
                 let components = Arc::clone(&components);
+                let tenant_meta = tenant_meta_cloned.clone();
                 async move {
                     pipeline
-                        .execute_generate(request, headers, model_id, components)
+                        .execute_generate(request, headers, model_id, components, Some(tenant_meta))
                         .await
                 }
             },
@@ -174,6 +178,7 @@ impl GrpcPDRouter {
     async fn route_messages_impl(
         &self,
         headers: Option<&HeaderMap>,
+        tenant_meta: &TenantRequestMeta,
         body: &CreateMessageRequest,
         model_id: &str,
     ) -> Response {
@@ -187,6 +192,7 @@ impl GrpcPDRouter {
         let headers_cloned = headers.cloned();
         let model_id_cloned = model_id.to_string();
         let components = self.shared_components.clone();
+        let tenant_meta_cloned = tenant_meta.clone();
         let pipeline = &self.messages_pipeline;
 
         // Use per-model retry config if set by a worker, otherwise fall back to router default.
@@ -202,9 +208,10 @@ impl GrpcPDRouter {
                 let headers = headers_cloned.clone();
                 let model_id = model_id_cloned.clone();
                 let components = Arc::clone(&components);
+                let tenant_meta = tenant_meta_cloned.clone();
                 async move {
                     pipeline
-                        .execute_messages(request, headers, model_id, components)
+                        .execute_messages(request, headers, model_id, components, Some(tenant_meta))
                         .await
                 }
             },
@@ -238,6 +245,7 @@ impl GrpcPDRouter {
     async fn route_completion_impl(
         &self,
         headers: Option<&HeaderMap>,
+        tenant_meta: &TenantRequestMeta,
         body: &CompletionRequest,
         model_id: &str,
     ) -> Response {
@@ -250,6 +258,7 @@ impl GrpcPDRouter {
         let headers_cloned = headers.cloned();
         let model_id_cloned = model_id.to_string();
         let components = self.shared_components.clone();
+        let tenant_meta_cloned = tenant_meta.clone();
         let pipeline = &self.completion_pipeline;
 
         RetryExecutor::execute_response_with_retry(
@@ -259,9 +268,16 @@ impl GrpcPDRouter {
                 let headers = headers_cloned.clone();
                 let model_id = model_id_cloned.clone();
                 let components = Arc::clone(&components);
+                let tenant_meta = tenant_meta_cloned.clone();
                 async move {
                     pipeline
-                        .execute_completion(request, headers, model_id, components)
+                        .execute_completion(
+                            request,
+                            headers,
+                            model_id,
+                            components,
+                            Some(tenant_meta),
+                        )
                         .await
                 }
             },
@@ -295,6 +311,7 @@ impl GrpcPDRouter {
     async fn route_chat_impl(
         &self,
         headers: Option<&HeaderMap>,
+        tenant_meta: &TenantRequestMeta,
         body: &ChatCompletionRequest,
         model_id: &str,
     ) -> Response {
@@ -308,6 +325,7 @@ impl GrpcPDRouter {
         let headers_cloned = headers.cloned();
         let model_id_cloned = model_id.to_string();
         let components = self.shared_components.clone();
+        let tenant_meta_cloned = tenant_meta.clone();
         let pipeline = &self.pipeline;
 
         // Use per-model retry config if set by a worker, otherwise fall back to router default.
@@ -323,9 +341,10 @@ impl GrpcPDRouter {
                 let headers = headers_cloned.clone();
                 let model_id = model_id_cloned.clone();
                 let components = Arc::clone(&components);
+                let tenant_meta = tenant_meta_cloned.clone();
                 async move {
                     pipeline
-                        .execute_chat(request, headers, model_id, components)
+                        .execute_chat(request, headers, model_id, components, Some(tenant_meta))
                         .await
                 }
             },
@@ -388,37 +407,45 @@ impl RouterTrait for GrpcPDRouter {
     async fn route_generate(
         &self,
         headers: Option<&HeaderMap>,
+        tenant_meta: &TenantRequestMeta,
         body: &GenerateRequest,
         model_id: &str,
     ) -> Response {
-        self.route_generate_impl(headers, body, model_id).await
+        self.route_generate_impl(headers, tenant_meta, body, model_id)
+            .await
     }
 
     async fn route_chat(
         &self,
         headers: Option<&HeaderMap>,
+        tenant_meta: &TenantRequestMeta,
         body: &ChatCompletionRequest,
         model_id: &str,
     ) -> Response {
-        self.route_chat_impl(headers, body, model_id).await
+        self.route_chat_impl(headers, tenant_meta, body, model_id)
+            .await
     }
 
     async fn route_completion(
         &self,
         headers: Option<&HeaderMap>,
+        tenant_meta: &TenantRequestMeta,
         body: &CompletionRequest,
         model_id: &str,
     ) -> Response {
-        self.route_completion_impl(headers, body, model_id).await
+        self.route_completion_impl(headers, tenant_meta, body, model_id)
+            .await
     }
 
     async fn route_messages(
         &self,
         headers: Option<&HeaderMap>,
+        tenant_meta: &TenantRequestMeta,
         body: &CreateMessageRequest,
         model_id: &str,
     ) -> Response {
-        self.route_messages_impl(headers, body, model_id).await
+        self.route_messages_impl(headers, tenant_meta, body, model_id)
+            .await
     }
 
     fn router_type(&self) -> &'static str {

--- a/model_gateway/src/routers/grpc/pipeline.rs
+++ b/model_gateway/src/routers/grpc/pipeline.rs
@@ -48,6 +48,7 @@ use super::{
     utils::error_type_from_status,
 };
 use crate::{
+    middleware::TenantRequestMeta,
     observability::metrics::{bool_to_static_str, metrics_labels, Metrics},
     policies::PolicyRegistry,
     routers::error,
@@ -509,6 +510,7 @@ impl RequestPipeline {
         headers: Option<http::HeaderMap>,
         model_id: String,
         components: Arc<SharedComponents>,
+        tenant_request_meta: Option<TenantRequestMeta>,
     ) -> Response {
         let start = Instant::now();
         // Clone Arc for metrics (cheap atomic increment) to avoid borrow issues
@@ -526,6 +528,7 @@ impl RequestPipeline {
         );
 
         let mut ctx = RequestContext::for_chat(request, headers, model_id, components);
+        ctx.input.tenant_request_meta = tenant_request_meta;
 
         for stage in self.stages.iter() {
             match stage.execute(&mut ctx).await {
@@ -601,6 +604,7 @@ impl RequestPipeline {
         headers: Option<http::HeaderMap>,
         model_id: String,
         components: Arc<SharedComponents>,
+        tenant_request_meta: Option<TenantRequestMeta>,
     ) -> Response {
         let start = Instant::now();
         let streaming = request.stream;
@@ -616,6 +620,7 @@ impl RequestPipeline {
         );
 
         let mut ctx = RequestContext::for_generate(request, headers, model_id.clone(), components);
+        ctx.input.tenant_request_meta = tenant_request_meta;
 
         for stage in self.stages.iter() {
             match stage.execute(&mut ctx).await {
@@ -690,6 +695,7 @@ impl RequestPipeline {
         headers: Option<http::HeaderMap>,
         model_id: String,
         components: Arc<SharedComponents>,
+        tenant_request_meta: Option<TenantRequestMeta>,
     ) -> Response {
         let start = Instant::now();
         let model = request.model.clone();
@@ -705,6 +711,7 @@ impl RequestPipeline {
         );
 
         let mut ctx = RequestContext::for_completion(request, headers, model_id, components);
+        ctx.input.tenant_request_meta = tenant_request_meta;
 
         for stage in self.stages.iter() {
             match stage.execute(&mut ctx).await {
@@ -779,6 +786,7 @@ impl RequestPipeline {
         headers: Option<http::HeaderMap>,
         model_id: String,
         components: Arc<SharedComponents>,
+        tenant_request_meta: Option<TenantRequestMeta>,
     ) -> Response {
         debug!(
             "execute_embeddings: Starting execution for model: {}",
@@ -797,6 +805,7 @@ impl RequestPipeline {
         );
 
         let mut ctx = RequestContext::for_embedding(request, headers, model_id.clone(), components);
+        ctx.input.tenant_request_meta = tenant_request_meta;
 
         for stage in self.stages.iter() {
             debug!("execute_embeddings: Executing stage: {}", stage.name());
@@ -879,6 +888,7 @@ impl RequestPipeline {
         headers: Option<http::HeaderMap>,
         model_id: String,
         components: Arc<SharedComponents>,
+        tenant_request_meta: Option<TenantRequestMeta>,
     ) -> Response {
         debug!(
             "execute_classify: Starting execution for model: {}",
@@ -897,6 +907,7 @@ impl RequestPipeline {
         );
 
         let mut ctx = RequestContext::for_classify(request, headers, model_id.clone(), components);
+        ctx.input.tenant_request_meta = tenant_request_meta;
 
         for stage in self.stages.iter() {
             debug!("execute_classify: Executing stage: {}", stage.name());
@@ -979,6 +990,7 @@ impl RequestPipeline {
         headers: Option<http::HeaderMap>,
         model_id: String,
         components: Arc<SharedComponents>,
+        tenant_request_meta: Option<TenantRequestMeta>,
     ) -> Response {
         let start = Instant::now();
         let streaming = request.stream.unwrap_or(false);
@@ -994,6 +1006,7 @@ impl RequestPipeline {
         );
 
         let mut ctx = RequestContext::for_messages(request.clone(), headers, model_id, components);
+        ctx.input.tenant_request_meta = tenant_request_meta;
 
         for stage in self.stages.iter() {
             match stage.execute(&mut ctx).await {
@@ -1074,8 +1087,10 @@ impl RequestPipeline {
         headers: Option<http::HeaderMap>,
         model_id: String,
         components: Arc<SharedComponents>,
+        tenant_request_meta: Option<TenantRequestMeta>,
     ) -> Result<ChatCompletionResponse, Response> {
         let mut ctx = RequestContext::for_chat(request, headers, model_id, components);
+        ctx.input.tenant_request_meta = tenant_request_meta;
 
         for (idx, stage) in self.stages.iter().enumerate() {
             match stage.execute(&mut ctx).await {
@@ -1154,6 +1169,7 @@ impl RequestPipeline {
         &self,
         request: &openai_protocol::responses::ResponsesRequest,
         harmony_ctx: &ResponsesContext,
+        tenant_request_meta: Option<TenantRequestMeta>,
     ) -> Result<harmony::ResponsesIterationResult, Response> {
         // Create RequestContext for this Responses request
         let mut ctx = RequestContext::for_responses(
@@ -1162,6 +1178,7 @@ impl RequestPipeline {
             request.model.clone(), // Model ID from request
             harmony_ctx.components.clone(),
         );
+        ctx.input.tenant_request_meta = tenant_request_meta;
 
         for (idx, stage) in self.stages.iter().enumerate() {
             match stage.execute(&mut ctx).await {
@@ -1217,6 +1234,7 @@ impl RequestPipeline {
         &self,
         request: &openai_protocol::responses::ResponsesRequest,
         harmony_ctx: &ResponsesContext,
+        tenant_request_meta: Option<TenantRequestMeta>,
     ) -> Result<(ExecutionResult, Option<LoadGuards>), Response> {
         // Create RequestContext for this Responses request
         let mut ctx = RequestContext::for_responses(
@@ -1225,6 +1243,7 @@ impl RequestPipeline {
             request.model.clone(),
             harmony_ctx.components.clone(),
         );
+        ctx.input.tenant_request_meta = tenant_request_meta;
 
         for (idx, stage) in self.stages.iter().enumerate() {
             match stage.execute(&mut ctx).await {

--- a/model_gateway/src/routers/grpc/regular/responses/common.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/common.rs
@@ -21,9 +21,12 @@ use smg_data_connector::{
 use smg_mcp::McpToolSession;
 use tracing::{debug, warn};
 
-use crate::routers::{
-    common::persistence_utils::split_stored_message_content, error,
-    grpc::common::responses::ResponsesContext,
+use crate::{
+    middleware::TenantRequestMeta,
+    routers::{
+        common::persistence_utils::split_stored_message_content, error,
+        grpc::common::responses::ResponsesContext,
+    },
 };
 
 // ============================================================================
@@ -45,6 +48,7 @@ pub(super) struct ResponsesCallContext {
     pub headers: Option<http::HeaderMap>,
     pub model_id: String,
     pub response_id: Option<String>,
+    pub tenant_request_meta: TenantRequestMeta,
 }
 
 impl ToolLoopState {

--- a/model_gateway/src/routers/grpc/regular/responses/handlers.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/handlers.rs
@@ -51,6 +51,7 @@ pub(crate) async fn route_responses(
     ctx: &ResponsesContext,
     request: Arc<ResponsesRequest>,
     headers: Option<http::HeaderMap>,
+    tenant_request_meta: crate::middleware::TenantRequestMeta,
     model_id: String,
 ) -> Response {
     // 1. Reject background mode (no longer supported)
@@ -69,6 +70,7 @@ pub(crate) async fn route_responses(
             headers,
             model_id,
             response_id: None,
+            tenant_request_meta,
         };
         route_responses_streaming(ctx, request, params).await
     } else {
@@ -76,6 +78,7 @@ pub(crate) async fn route_responses(
             headers,
             model_id,
             response_id: Some(format!("resp_{}", Uuid::now_v7())),
+            tenant_request_meta,
         };
         route_responses_sync(ctx, request, params).await
     }

--- a/model_gateway/src/routers/grpc/regular/responses/non_streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/non_streaming.rs
@@ -104,6 +104,7 @@ pub(super) async fn execute_without_mcp(
             params.headers,
             params.model_id,
             ctx.components.clone(),
+            Some(params.tenant_request_meta),
         )
         .await?; // Preserve the Response error as-is
 
@@ -190,6 +191,7 @@ pub(super) async fn execute_tool_loop(
                 params.headers.clone(),
                 params.model_id.clone(),
                 ctx.components.clone(),
+                Some(params.tenant_request_meta.clone()),
             )
             .await?;
 

--- a/model_gateway/src/routers/grpc/regular/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/streaming.rs
@@ -90,6 +90,7 @@ pub(super) async fn convert_chat_stream_to_responses_stream(
             params.headers,
             params.model_id,
             ctx.components.clone(),
+            Some(params.tenant_request_meta),
         )
         .await;
 
@@ -575,6 +576,7 @@ async fn execute_tool_loop_streaming_internal(
                 params.headers.clone(),
                 params.model_id.clone(),
                 ctx.components.clone(),
+                Some(params.tenant_request_meta.clone()),
             )
             .await;
 

--- a/model_gateway/src/routers/grpc/router.rs
+++ b/model_gateway/src/routers/grpc/router.rs
@@ -25,6 +25,7 @@ use super::{
 use crate::{
     app_context::AppContext,
     config::types::RetryConfig,
+    middleware::TenantRequestMeta,
     observability::metrics::{metrics_labels, Metrics},
     routers::{
         common::retry::{is_retryable_status, RetryExecutor},
@@ -176,6 +177,7 @@ impl GrpcRouter {
     async fn route_chat_impl(
         &self,
         headers: Option<&HeaderMap>,
+        tenant_meta: &TenantRequestMeta,
         body: &ChatCompletionRequest,
         model_id: &str,
     ) -> Response {
@@ -199,6 +201,7 @@ impl GrpcRouter {
         let headers_cloned = headers.cloned();
         let model_id_cloned = model_id.to_string();
         let components = self.shared_components.clone();
+        let tenant_meta_cloned = tenant_meta.clone();
 
         // Use per-model retry config if set by a worker, otherwise fall back to router default.
         let per_model_retry_config = self.worker_registry.get_retry_config(model_id);
@@ -214,9 +217,10 @@ impl GrpcRouter {
                 let headers = headers_cloned.clone();
                 let model_id = model_id_cloned.clone();
                 let components = Arc::clone(&components);
+                let tenant_meta = tenant_meta_cloned.clone();
                 async move {
                     pipeline
-                        .execute_chat(request, headers, model_id, components)
+                        .execute_chat(request, headers, model_id, components, Some(tenant_meta))
                         .await
                 }
             },
@@ -245,6 +249,7 @@ impl GrpcRouter {
     async fn route_generate_impl(
         &self,
         headers: Option<&HeaderMap>,
+        tenant_meta: &TenantRequestMeta,
         body: &GenerateRequest,
         model_id: &str,
     ) -> Response {
@@ -255,6 +260,7 @@ impl GrpcRouter {
         let headers_cloned = headers.cloned();
         let model_id_cloned = model_id.to_string();
         let components = self.shared_components.clone();
+        let tenant_meta_cloned = tenant_meta.clone();
         let pipeline = &self.pipeline;
 
         // Use per-model retry config if set by a worker, otherwise fall back to router default.
@@ -271,9 +277,10 @@ impl GrpcRouter {
                 let headers = headers_cloned.clone();
                 let model_id = model_id_cloned.clone();
                 let components = Arc::clone(&components);
+                let tenant_meta = tenant_meta_cloned.clone();
                 async move {
                     pipeline
-                        .execute_generate(request, headers, model_id, components)
+                        .execute_generate(request, headers, model_id, components, Some(tenant_meta))
                         .await
                 }
             },
@@ -304,6 +311,7 @@ impl GrpcRouter {
     async fn route_responses_impl(
         &self,
         headers: Option<&HeaderMap>,
+        tenant_meta: &TenantRequestMeta,
         body: &ResponsesRequest,
         model_id: &str,
     ) -> Response {
@@ -339,9 +347,11 @@ impl GrpcRouter {
             );
 
             if body.stream.unwrap_or(false) {
-                serve_harmony_responses_stream(&harmony_ctx, body.clone()).await
+                serve_harmony_responses_stream(&harmony_ctx, body.clone(), tenant_meta.clone())
+                    .await
             } else {
-                match serve_harmony_responses(&harmony_ctx, body.clone()).await {
+                match serve_harmony_responses(&harmony_ctx, body.clone(), tenant_meta.clone()).await
+                {
                     Ok(response) => axum::Json(response).into_response(),
                     Err(error_response) => error_response,
                 }
@@ -351,6 +361,7 @@ impl GrpcRouter {
                 &self.responses_context,
                 Arc::new(body.clone()),
                 headers.cloned(),
+                tenant_meta.clone(),
                 model_id.to_string(),
             )
             .await
@@ -361,6 +372,7 @@ impl GrpcRouter {
     async fn route_embeddings_impl(
         &self,
         headers: Option<&HeaderMap>,
+        tenant_meta: &TenantRequestMeta,
         body: &EmbeddingRequest,
         model_id: &str,
     ) -> Response {
@@ -372,6 +384,7 @@ impl GrpcRouter {
                 headers.cloned(),
                 model_id.to_string(),
                 self.shared_components.clone(),
+                Some(tenant_meta.clone()),
             )
             .await
     }
@@ -380,6 +393,7 @@ impl GrpcRouter {
     async fn route_messages_impl(
         &self,
         headers: Option<&HeaderMap>,
+        tenant_meta: &TenantRequestMeta,
         body: &CreateMessageRequest,
         model_id: &str,
     ) -> Response {
@@ -390,6 +404,7 @@ impl GrpcRouter {
         let headers_cloned = headers.cloned();
         let model_id_cloned = model_id.to_string();
         let components = self.shared_components.clone();
+        let tenant_meta_cloned = tenant_meta.clone();
         let pipeline = &self.messages_pipeline;
 
         // Use per-model retry config if set by a worker, otherwise fall back to router default.
@@ -405,9 +420,10 @@ impl GrpcRouter {
                 let headers = headers_cloned.clone();
                 let model_id = model_id_cloned.clone();
                 let components = Arc::clone(&components);
+                let tenant_meta = tenant_meta_cloned.clone();
                 async move {
                     pipeline
-                        .execute_messages(request, headers, model_id, components)
+                        .execute_messages(request, headers, model_id, components, Some(tenant_meta))
                         .await
                 }
             },
@@ -433,6 +449,7 @@ impl GrpcRouter {
     async fn route_completion_impl(
         &self,
         headers: Option<&HeaderMap>,
+        tenant_meta: &TenantRequestMeta,
         body: &CompletionRequest,
         model_id: &str,
     ) -> Response {
@@ -442,6 +459,7 @@ impl GrpcRouter {
         let headers_cloned = headers.cloned();
         let model_id_cloned = model_id.to_string();
         let components = self.shared_components.clone();
+        let tenant_meta_cloned = tenant_meta.clone();
         let pipeline = &self.completion_pipeline;
 
         let per_model_retry_config = self.worker_registry.get_retry_config(model_id);
@@ -456,9 +474,16 @@ impl GrpcRouter {
                 let headers = headers_cloned.clone();
                 let model_id = model_id_cloned.clone();
                 let components = Arc::clone(&components);
+                let tenant_meta = tenant_meta_cloned.clone();
                 async move {
                     pipeline
-                        .execute_completion(request, headers, model_id, components)
+                        .execute_completion(
+                            request,
+                            headers,
+                            model_id,
+                            components,
+                            Some(tenant_meta),
+                        )
                         .await
                 }
             },
@@ -484,6 +509,7 @@ impl GrpcRouter {
     async fn route_classify_impl(
         &self,
         headers: Option<&HeaderMap>,
+        tenant_meta: &TenantRequestMeta,
         body: &ClassifyRequest,
         model_id: &str,
     ) -> Response {
@@ -495,6 +521,7 @@ impl GrpcRouter {
                 headers.cloned(),
                 model_id.to_string(),
                 self.shared_components.clone(),
+                Some(tenant_meta.clone()),
             )
             .await
     }
@@ -518,28 +545,34 @@ impl RouterTrait for GrpcRouter {
     async fn route_generate(
         &self,
         headers: Option<&HeaderMap>,
+        tenant_meta: &TenantRequestMeta,
         body: &GenerateRequest,
         model_id: &str,
     ) -> Response {
-        self.route_generate_impl(headers, body, model_id).await
+        self.route_generate_impl(headers, tenant_meta, body, model_id)
+            .await
     }
 
     async fn route_chat(
         &self,
         headers: Option<&HeaderMap>,
+        tenant_meta: &TenantRequestMeta,
         body: &ChatCompletionRequest,
         model_id: &str,
     ) -> Response {
-        self.route_chat_impl(headers, body, model_id).await
+        self.route_chat_impl(headers, tenant_meta, body, model_id)
+            .await
     }
 
     async fn route_responses(
         &self,
         headers: Option<&HeaderMap>,
+        tenant_meta: &TenantRequestMeta,
         body: &ResponsesRequest,
         model_id: &str,
     ) -> Response {
-        self.route_responses_impl(headers, body, model_id).await
+        self.route_responses_impl(headers, tenant_meta, body, model_id)
+            .await
     }
 
     async fn cancel_response(&self, _headers: Option<&HeaderMap>, response_id: &str) -> Response {
@@ -549,37 +582,45 @@ impl RouterTrait for GrpcRouter {
     async fn route_embeddings(
         &self,
         headers: Option<&HeaderMap>,
+        tenant_meta: &TenantRequestMeta,
         body: &EmbeddingRequest,
         model_id: &str,
     ) -> Response {
-        self.route_embeddings_impl(headers, body, model_id).await
+        self.route_embeddings_impl(headers, tenant_meta, body, model_id)
+            .await
     }
 
     async fn route_classify(
         &self,
         headers: Option<&HeaderMap>,
+        tenant_meta: &TenantRequestMeta,
         body: &ClassifyRequest,
         model_id: &str,
     ) -> Response {
-        self.route_classify_impl(headers, body, model_id).await
+        self.route_classify_impl(headers, tenant_meta, body, model_id)
+            .await
     }
 
     async fn route_completion(
         &self,
         headers: Option<&HeaderMap>,
+        tenant_meta: &TenantRequestMeta,
         body: &CompletionRequest,
         model_id: &str,
     ) -> Response {
-        self.route_completion_impl(headers, body, model_id).await
+        self.route_completion_impl(headers, tenant_meta, body, model_id)
+            .await
     }
 
     async fn route_messages(
         &self,
         headers: Option<&HeaderMap>,
+        tenant_meta: &TenantRequestMeta,
         body: &CreateMessageRequest,
         model_id: &str,
     ) -> Response {
-        self.route_messages_impl(headers, body, model_id).await
+        self.route_messages_impl(headers, tenant_meta, body, model_id)
+            .await
     }
 
     fn router_type(&self) -> &'static str {

--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -26,6 +26,7 @@ use tracing::{debug, error, warn};
 use super::pd_types::api_path;
 use crate::{
     config::types::RetryConfig,
+    middleware::TenantRequestMeta,
     observability::{
         events::{self, Event},
         metrics::{bool_to_static_str, metrics_labels, Metrics},
@@ -1277,6 +1278,7 @@ impl RouterTrait for PDRouter {
     async fn route_generate(
         &self,
         headers: Option<&HeaderMap>,
+        _tenant_meta: &TenantRequestMeta,
         body: &GenerateRequest,
         model_id: &str,
     ) -> Response {
@@ -1307,6 +1309,7 @@ impl RouterTrait for PDRouter {
     async fn route_chat(
         &self,
         headers: Option<&HeaderMap>,
+        _tenant_meta: &TenantRequestMeta,
         body: &ChatCompletionRequest,
         model_id: &str,
     ) -> Response {
@@ -1349,6 +1352,7 @@ impl RouterTrait for PDRouter {
     async fn route_completion(
         &self,
         headers: Option<&HeaderMap>,
+        _tenant_meta: &TenantRequestMeta,
         body: &CompletionRequest,
         model_id: &str,
     ) -> Response {
@@ -1383,6 +1387,7 @@ impl RouterTrait for PDRouter {
     async fn route_rerank(
         &self,
         headers: Option<&HeaderMap>,
+        _tenant_meta: &TenantRequestMeta,
         body: &RerankRequest,
         model_id: &str,
     ) -> Response {

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -30,6 +30,7 @@ use tracing::error;
 use crate::{
     app_context::AppContext,
     config::types::RetryConfig,
+    middleware::TenantRequestMeta,
     observability::{
         events::{self, Event},
         metrics::{bool_to_static_str, metrics_labels, Metrics},
@@ -1105,6 +1106,7 @@ impl RouterTrait for Router {
     async fn route_generate(
         &self,
         headers: Option<&HeaderMap>,
+        _tenant_meta: &TenantRequestMeta,
         body: &GenerateRequest,
         model_id: &str,
     ) -> Response {
@@ -1115,6 +1117,7 @@ impl RouterTrait for Router {
     async fn route_chat(
         &self,
         headers: Option<&HeaderMap>,
+        _tenant_meta: &TenantRequestMeta,
         body: &ChatCompletionRequest,
         model_id: &str,
     ) -> Response {
@@ -1125,6 +1128,7 @@ impl RouterTrait for Router {
     async fn route_completion(
         &self,
         headers: Option<&HeaderMap>,
+        _tenant_meta: &TenantRequestMeta,
         body: &CompletionRequest,
         model_id: &str,
     ) -> Response {
@@ -1135,6 +1139,7 @@ impl RouterTrait for Router {
     async fn route_responses(
         &self,
         headers: Option<&HeaderMap>,
+        _tenant_meta: &TenantRequestMeta,
         body: &ResponsesRequest,
         model_id: &str,
     ) -> Response {
@@ -1150,6 +1155,7 @@ impl RouterTrait for Router {
     async fn route_embeddings(
         &self,
         headers: Option<&HeaderMap>,
+        _tenant_meta: &TenantRequestMeta,
         body: &EmbeddingRequest,
         model_id: &str,
     ) -> Response {
@@ -1160,6 +1166,7 @@ impl RouterTrait for Router {
     async fn route_classify(
         &self,
         headers: Option<&HeaderMap>,
+        _tenant_meta: &TenantRequestMeta,
         body: &ClassifyRequest,
         model_id: &str,
     ) -> Response {
@@ -1170,6 +1177,7 @@ impl RouterTrait for Router {
     async fn route_audio_transcriptions(
         &self,
         headers: Option<&HeaderMap>,
+        _tenant_meta: &TenantRequestMeta,
         body: &TranscriptionRequest,
         audio: AudioFile,
         model_id: &str,
@@ -1187,6 +1195,7 @@ impl RouterTrait for Router {
     async fn route_rerank(
         &self,
         headers: Option<&HeaderMap>,
+        _tenant_meta: &TenantRequestMeta,
         body: &RerankRequest,
         model_id: &str,
     ) -> Response {

--- a/model_gateway/src/routers/mod.rs
+++ b/model_gateway/src/routers/mod.rs
@@ -26,6 +26,8 @@ use openai_protocol::{
     transcription::TranscriptionRequest,
 };
 
+use crate::middleware::TenantRequestMeta;
+
 pub mod anthropic;
 pub mod common;
 pub mod conversations;
@@ -100,6 +102,7 @@ pub trait RouterTrait: Send + Sync + Debug {
     async fn route_generate(
         &self,
         _headers: Option<&HeaderMap>,
+        _tenant_meta: &TenantRequestMeta,
         _body: &GenerateRequest,
         _model_id: &str,
     ) -> Response {
@@ -114,6 +117,7 @@ pub trait RouterTrait: Send + Sync + Debug {
     async fn route_chat(
         &self,
         _headers: Option<&HeaderMap>,
+        _tenant_meta: &TenantRequestMeta,
         _body: &ChatCompletionRequest,
         _model_id: &str,
     ) -> Response {
@@ -128,6 +132,7 @@ pub trait RouterTrait: Send + Sync + Debug {
     async fn route_completion(
         &self,
         _headers: Option<&HeaderMap>,
+        _tenant_meta: &TenantRequestMeta,
         _body: &CompletionRequest,
         _model_id: &str,
     ) -> Response {
@@ -142,6 +147,7 @@ pub trait RouterTrait: Send + Sync + Debug {
     async fn route_responses(
         &self,
         _headers: Option<&HeaderMap>,
+        _tenant_meta: &TenantRequestMeta,
         _body: &ResponsesRequest,
         _model_id: &str,
     ) -> Response {
@@ -165,6 +171,7 @@ pub trait RouterTrait: Send + Sync + Debug {
     async fn route_embeddings(
         &self,
         _headers: Option<&HeaderMap>,
+        _tenant_meta: &TenantRequestMeta,
         _body: &EmbeddingRequest,
         _model_id: &str,
     ) -> Response {
@@ -175,6 +182,7 @@ pub trait RouterTrait: Send + Sync + Debug {
     async fn route_classify(
         &self,
         _headers: Option<&HeaderMap>,
+        _tenant_meta: &TenantRequestMeta,
         _body: &ClassifyRequest,
         _model_id: &str,
     ) -> Response {
@@ -190,6 +198,7 @@ pub trait RouterTrait: Send + Sync + Debug {
     async fn route_audio_transcriptions(
         &self,
         _headers: Option<&HeaderMap>,
+        _tenant_meta: &TenantRequestMeta,
         _body: &TranscriptionRequest,
         _audio: AudioFile,
         _model_id: &str,
@@ -205,6 +214,7 @@ pub trait RouterTrait: Send + Sync + Debug {
     async fn route_rerank(
         &self,
         _headers: Option<&HeaderMap>,
+        _tenant_meta: &TenantRequestMeta,
         _body: &RerankRequest,
         _model_id: &str,
     ) -> Response {
@@ -215,6 +225,7 @@ pub trait RouterTrait: Send + Sync + Debug {
     async fn route_messages(
         &self,
         _headers: Option<&HeaderMap>,
+        _tenant_meta: &TenantRequestMeta,
         _body: &CreateMessageRequest,
         _model_id: &str,
     ) -> Response {
@@ -229,6 +240,7 @@ pub trait RouterTrait: Send + Sync + Debug {
     async fn route_interactions(
         &self,
         _headers: Option<&HeaderMap>,
+        _tenant_meta: &TenantRequestMeta,
         _body: &InteractionsRequest,
         _model_id: Option<&str>,
     ) -> Response {

--- a/model_gateway/src/routers/openai/chat.rs
+++ b/model_gateway/src/routers/openai/chat.rs
@@ -20,6 +20,7 @@ use super::{
 };
 use crate::{
     config::types::RetryConfig,
+    middleware::TenantRequestMeta,
     observability::metrics::{bool_to_static_str, metrics_labels, Metrics},
     routers::{
         common::{
@@ -44,6 +45,7 @@ pub(super) struct ChatRouterContext<'a> {
 pub(super) async fn route_chat(
     deps: &ChatRouterContext<'_>,
     headers: Option<&HeaderMap>,
+    tenant_meta: &TenantRequestMeta,
     body: &ChatCompletionRequest,
     model_id: &str,
 ) -> Response {
@@ -124,6 +126,7 @@ pub(super) async fn route_chat(
         Some(model_id.to_string()),
         ComponentRefs::Shared(Arc::clone(deps.shared_components)),
     );
+    ctx.tenant_request_meta = Some(tenant_meta.clone());
 
     ctx.state.worker = Some(WorkerSelection {
         worker: Arc::clone(&worker),

--- a/model_gateway/src/routers/openai/context.rs
+++ b/model_gateway/src/routers/openai/context.rs
@@ -12,7 +12,10 @@ use smg_data_connector::{
 use smg_mcp::{McpOrchestrator, McpToolSession};
 
 use super::provider::Provider;
-use crate::{config::RouterConfig, memory::MemoryExecutionContext, middleware, worker::Worker};
+use crate::{
+    config::RouterConfig, memory::MemoryExecutionContext, middleware,
+    middleware::TenantRequestMeta, worker::Worker,
+};
 
 pub struct RequestContext {
     pub input: RequestInput,
@@ -20,6 +23,8 @@ pub struct RequestContext {
     pub state: ProcessingState,
     pub storage_request_context: Option<StorageRequestContext>,
     pub memory_execution_context: MemoryExecutionContext,
+    /// Explicit tenant identity resolved at the HTTP boundary.
+    pub tenant_request_meta: Option<TenantRequestMeta>,
 }
 
 pub struct RequestInput {
@@ -154,6 +159,7 @@ impl RequestContext {
             state: ProcessingState::default(),
             storage_request_context: None,
             memory_execution_context,
+            tenant_request_meta: None,
         }
     }
 
@@ -175,6 +181,7 @@ impl RequestContext {
             storage_request_context: None,
             // Memory execution is currently scoped to Responses flows.
             memory_execution_context: MemoryExecutionContext::default(),
+            tenant_request_meta: None,
         }
     }
 }

--- a/model_gateway/src/routers/openai/responses/route.rs
+++ b/model_gateway/src/routers/openai/responses/route.rs
@@ -22,6 +22,7 @@ use super::{
     handle_non_streaming_response, handle_streaming_response,
 };
 use crate::{
+    middleware::TenantRequestMeta,
     observability::metrics::{bool_to_static_str, metrics_labels, Metrics},
     routers::{
         common::{
@@ -44,6 +45,7 @@ pub(in crate::routers::openai) struct ResponsesRouterContext<'a> {
 pub(in crate::routers::openai) async fn route_responses(
     deps: &ResponsesRouterContext<'_>,
     headers: Option<&HeaderMap>,
+    tenant_meta: &TenantRequestMeta,
     body: &ResponsesRequest,
     model_id: &str,
 ) -> Response {
@@ -173,6 +175,7 @@ pub(in crate::routers::openai) async fn route_responses(
         ComponentRefs::Responses(Arc::clone(deps.responses_components)),
     );
     ctx.storage_request_context = smg_data_connector::current_request_context();
+    ctx.tenant_request_meta = Some(tenant_meta.clone());
 
     ctx.state.worker = Some(WorkerSelection {
         worker: Arc::clone(&worker),

--- a/model_gateway/src/routers/openai/router.rs
+++ b/model_gateway/src/routers/openai/router.rs
@@ -23,6 +23,7 @@ use super::{
 use crate::{
     app_context::AppContext,
     config::types::RetryConfig,
+    middleware::TenantRequestMeta,
     observability::metrics::{metrics_labels, Metrics},
     routers::{
         common::{
@@ -145,6 +146,7 @@ impl crate::routers::RouterTrait for OpenAIRouter {
     async fn route_chat(
         &self,
         headers: Option<&HeaderMap>,
+        tenant_meta: &TenantRequestMeta,
         body: &ChatCompletionRequest,
         model_id: &str,
     ) -> Response {
@@ -160,12 +162,13 @@ impl crate::routers::RouterTrait for OpenAIRouter {
             shared_components: &self.shared_components,
             retry_config,
         };
-        chat::route_chat(&deps, headers, body, model_id).await
+        chat::route_chat(&deps, headers, tenant_meta, body, model_id).await
     }
 
     async fn route_responses(
         &self,
         headers: Option<&HeaderMap>,
+        tenant_meta: &TenantRequestMeta,
         body: &ResponsesRequest,
         model_id: &str,
     ) -> Response {
@@ -174,7 +177,7 @@ impl crate::routers::RouterTrait for OpenAIRouter {
             provider_registry: &self.provider_registry,
             responses_components: &self.responses_components,
         };
-        responses_route::route_responses(&deps, headers, body, model_id).await
+        responses_route::route_responses(&deps, headers, tenant_meta, body, model_id).await
     }
 
     async fn route_realtime_session(

--- a/model_gateway/src/routers/router_manager.rs
+++ b/model_gateway/src/routers/router_manager.rs
@@ -41,6 +41,7 @@ use tracing::{debug, info, warn};
 use crate::{
     app_context::AppContext,
     config::RoutingMode,
+    middleware::TenantRequestMeta,
     routers::{
         common::header_utils::apply_provider_headers,
         factory::{router_ids, RouterId},
@@ -510,13 +511,16 @@ impl RouterTrait for RouterManager {
     async fn route_generate(
         &self,
         headers: Option<&HeaderMap>,
+        tenant_meta: &TenantRequestMeta,
         body: &GenerateRequest,
         model_id: &str,
     ) -> Response {
         let router = self.select_router_for_request(headers, Some(model_id));
 
         if let Some(router) = router {
-            router.route_generate(headers, body, model_id).await
+            router
+                .route_generate(headers, tenant_meta, body, model_id)
+                .await
         } else {
             (
                 StatusCode::NOT_FOUND,
@@ -529,13 +533,16 @@ impl RouterTrait for RouterManager {
     async fn route_chat(
         &self,
         headers: Option<&HeaderMap>,
+        tenant_meta: &TenantRequestMeta,
         body: &ChatCompletionRequest,
         model_id: &str,
     ) -> Response {
         let router = self.select_router_for_request(headers, Some(model_id));
 
         if let Some(router) = router {
-            router.route_chat(headers, body, model_id).await
+            router
+                .route_chat(headers, tenant_meta, body, model_id)
+                .await
         } else {
             (
                 StatusCode::NOT_FOUND,
@@ -548,13 +555,16 @@ impl RouterTrait for RouterManager {
     async fn route_completion(
         &self,
         headers: Option<&HeaderMap>,
+        tenant_meta: &TenantRequestMeta,
         body: &CompletionRequest,
         model_id: &str,
     ) -> Response {
         let router = self.select_router_for_request(headers, Some(model_id));
 
         if let Some(router) = router {
-            router.route_completion(headers, body, model_id).await
+            router
+                .route_completion(headers, tenant_meta, body, model_id)
+                .await
         } else {
             (
                 StatusCode::NOT_FOUND,
@@ -567,13 +577,16 @@ impl RouterTrait for RouterManager {
     async fn route_messages(
         &self,
         headers: Option<&HeaderMap>,
+        tenant_meta: &TenantRequestMeta,
         body: &CreateMessageRequest,
         model_id: &str,
     ) -> Response {
         let router = self.select_router_for_request(headers, Some(model_id));
 
         if let Some(router) = router {
-            router.route_messages(headers, body, model_id).await
+            router
+                .route_messages(headers, tenant_meta, body, model_id)
+                .await
         } else {
             (
                 StatusCode::NOT_FOUND,
@@ -586,13 +599,16 @@ impl RouterTrait for RouterManager {
     async fn route_responses(
         &self,
         headers: Option<&HeaderMap>,
+        tenant_meta: &TenantRequestMeta,
         body: &ResponsesRequest,
         model_id: &str,
     ) -> Response {
         let router = self.select_router_for_request(headers, Some(model_id));
 
         if let Some(router) = router {
-            router.route_responses(headers, body, model_id).await
+            router
+                .route_responses(headers, tenant_meta, body, model_id)
+                .await
         } else {
             (
                 StatusCode::NOT_FOUND,
@@ -605,6 +621,7 @@ impl RouterTrait for RouterManager {
     async fn route_interactions(
         &self,
         headers: Option<&HeaderMap>,
+        tenant_meta: &TenantRequestMeta,
         body: &InteractionsRequest,
         model_id: Option<&str>,
     ) -> Response {
@@ -613,7 +630,7 @@ impl RouterTrait for RouterManager {
 
         if let Some(router) = router {
             router
-                .route_interactions(headers, body, selected_model)
+                .route_interactions(headers, tenant_meta, body, selected_model)
                 .await
         } else {
             (
@@ -640,13 +657,16 @@ impl RouterTrait for RouterManager {
     async fn route_embeddings(
         &self,
         headers: Option<&HeaderMap>,
+        tenant_meta: &TenantRequestMeta,
         body: &EmbeddingRequest,
         model_id: &str,
     ) -> Response {
         let router = self.select_router_for_request(headers, Some(model_id));
 
         if let Some(router) = router {
-            router.route_embeddings(headers, body, model_id).await
+            router
+                .route_embeddings(headers, tenant_meta, body, model_id)
+                .await
         } else {
             (
                 StatusCode::NOT_FOUND,
@@ -659,13 +679,16 @@ impl RouterTrait for RouterManager {
     async fn route_classify(
         &self,
         headers: Option<&HeaderMap>,
+        tenant_meta: &TenantRequestMeta,
         body: &ClassifyRequest,
         model_id: &str,
     ) -> Response {
         let router = self.select_router_for_request(headers, Some(model_id));
 
         if let Some(router) = router {
-            router.route_classify(headers, body, model_id).await
+            router
+                .route_classify(headers, tenant_meta, body, model_id)
+                .await
         } else {
             (
                 StatusCode::NOT_FOUND,
@@ -678,6 +701,7 @@ impl RouterTrait for RouterManager {
     async fn route_audio_transcriptions(
         &self,
         headers: Option<&HeaderMap>,
+        tenant_meta: &TenantRequestMeta,
         body: &TranscriptionRequest,
         audio: AudioFile,
         model_id: &str,
@@ -686,7 +710,7 @@ impl RouterTrait for RouterManager {
 
         if let Some(router) = router {
             router
-                .route_audio_transcriptions(headers, body, audio, model_id)
+                .route_audio_transcriptions(headers, tenant_meta, body, audio, model_id)
                 .await
         } else {
             (
@@ -700,13 +724,16 @@ impl RouterTrait for RouterManager {
     async fn route_rerank(
         &self,
         headers: Option<&HeaderMap>,
+        tenant_meta: &TenantRequestMeta,
         body: &RerankRequest,
         model_id: &str,
     ) -> Response {
         let router = self.select_router_for_request(headers, Some(model_id));
 
         if let Some(router) = router {
-            router.route_rerank(headers, body, model_id).await
+            router
+                .route_rerank(headers, tenant_meta, body, model_id)
+                .await
         } else {
             (
                 StatusCode::NOT_FOUND,

--- a/model_gateway/src/server.rs
+++ b/model_gateway/src/server.rs
@@ -7,8 +7,8 @@ use std::{
 };
 
 use axum::{
-    extract::{multipart::MultipartError, Multipart, Path, Query, Request, State},
-    http::StatusCode,
+    extract::{multipart::MultipartError, Extension, Multipart, Path, Query, Request, State},
+    http::{header::InvalidHeaderName, StatusCode},
     response::{IntoResponse, Response},
     routing::{delete, get, post},
     Json, Router,
@@ -182,118 +182,134 @@ async fn get_model_info(State(state): State<Arc<AppState>>, req: Request) -> Res
 async fn generate(
     State(state): State<Arc<AppState>>,
     headers: http::HeaderMap,
+    Extension(tenant_meta): Extension<middleware::TenantRequestMeta>,
     Json(body): Json<GenerateRequest>,
 ) -> Response {
     state
         .router
-        .route_generate(Some(&headers), &body, &body.model)
+        .route_generate(Some(&headers), &tenant_meta, &body, &body.model)
         .await
 }
 
 async fn v1_chat_completions(
     State(state): State<Arc<AppState>>,
     headers: http::HeaderMap,
+    Extension(tenant_meta): Extension<middleware::TenantRequestMeta>,
     ValidatedJson(body): ValidatedJson<ChatCompletionRequest>,
 ) -> Response {
     state
         .router
-        .route_chat(Some(&headers), &body, &body.model)
+        .route_chat(Some(&headers), &tenant_meta, &body, &body.model)
         .await
 }
 
 async fn v1_completions(
     State(state): State<Arc<AppState>>,
     headers: http::HeaderMap,
+    Extension(tenant_meta): Extension<middleware::TenantRequestMeta>,
     ValidatedJson(body): ValidatedJson<CompletionRequest>,
 ) -> Response {
     state
         .router
-        .route_completion(Some(&headers), &body, &body.model)
+        .route_completion(Some(&headers), &tenant_meta, &body, &body.model)
         .await
 }
 
 async fn rerank(
     State(state): State<Arc<AppState>>,
     headers: http::HeaderMap,
+    Extension(tenant_meta): Extension<middleware::TenantRequestMeta>,
     ValidatedJson(body): ValidatedJson<RerankRequest>,
 ) -> Response {
     state
         .router
-        .route_rerank(Some(&headers), &body, &body.model)
+        .route_rerank(Some(&headers), &tenant_meta, &body, &body.model)
         .await
 }
 
 async fn v1_rerank(
     State(state): State<Arc<AppState>>,
     headers: http::HeaderMap,
+    Extension(tenant_meta): Extension<middleware::TenantRequestMeta>,
     Json(body): Json<V1RerankReqInput>,
 ) -> Response {
     let rerank_body: RerankRequest = body.into();
     state
         .router
-        .route_rerank(Some(&headers), &rerank_body, &rerank_body.model)
+        .route_rerank(
+            Some(&headers),
+            &tenant_meta,
+            &rerank_body,
+            &rerank_body.model,
+        )
         .await
 }
 
 async fn v1_responses(
     State(state): State<Arc<AppState>>,
     headers: http::HeaderMap,
+    Extension(tenant_meta): Extension<middleware::TenantRequestMeta>,
     ValidatedJson(body): ValidatedJson<ResponsesRequest>,
 ) -> Response {
     state
         .router
-        .route_responses(Some(&headers), &body, &body.model)
+        .route_responses(Some(&headers), &tenant_meta, &body, &body.model)
         .await
 }
 
 async fn v1_interactions(
     State(state): State<Arc<AppState>>,
     headers: http::HeaderMap,
+    Extension(tenant_meta): Extension<middleware::TenantRequestMeta>,
     ValidatedJson(body): ValidatedJson<InteractionsRequest>,
 ) -> Response {
     let model_id = body.model.as_deref().or(body.agent.as_deref());
     state
         .router
-        .route_interactions(Some(&headers), &body, model_id)
+        .route_interactions(Some(&headers), &tenant_meta, &body, model_id)
         .await
 }
 
 async fn v1_embeddings(
     State(state): State<Arc<AppState>>,
     headers: http::HeaderMap,
+    Extension(tenant_meta): Extension<middleware::TenantRequestMeta>,
     Json(body): Json<EmbeddingRequest>,
 ) -> Response {
     state
         .router
-        .route_embeddings(Some(&headers), &body, &body.model)
+        .route_embeddings(Some(&headers), &tenant_meta, &body, &body.model)
         .await
 }
 
 async fn v1_messages(
     State(state): State<Arc<AppState>>,
     headers: http::HeaderMap,
+    Extension(tenant_meta): Extension<middleware::TenantRequestMeta>,
     ValidatedJson(body): ValidatedJson<CreateMessageRequest>,
 ) -> Response {
     state
         .router
-        .route_messages(Some(&headers), &body, &body.model)
+        .route_messages(Some(&headers), &tenant_meta, &body, &body.model)
         .await
 }
 
 async fn v1_classify(
     State(state): State<Arc<AppState>>,
     headers: http::HeaderMap,
+    Extension(tenant_meta): Extension<middleware::TenantRequestMeta>,
     Json(body): Json<ClassifyRequest>,
 ) -> Response {
     state
         .router
-        .route_classify(Some(&headers), &body, &body.model)
+        .route_classify(Some(&headers), &tenant_meta, &body, &body.model)
         .await
 }
 
 async fn v1_audio_transcriptions(
     State(state): State<Arc<AppState>>,
     headers: http::HeaderMap,
+    Extension(tenant_meta): Extension<middleware::TenantRequestMeta>,
     mut multipart: Multipart,
 ) -> Response {
     let mut file_bytes: Option<bytes::Bytes> = None;
@@ -423,7 +439,7 @@ async fn v1_audio_transcriptions(
 
     state
         .router
-        .route_audio_transcriptions(Some(&headers), &req, audio, &req.model)
+        .route_audio_transcriptions(Some(&headers), &tenant_meta, &req, audio, &req.model)
         .await
 }
 
@@ -804,7 +820,7 @@ pub fn build_app(
     max_payload_size: usize,
     request_id_headers: Vec<String>,
     cors_allowed_origins: Vec<String>,
-) -> Router {
+) -> Result<Router, InvalidHeaderName> {
     // Pending (upgrade not completed): 30s TTL
     // Disconnected: 60 min TTL
     app_state.context.realtime_registry.start_reaper(
@@ -812,6 +828,9 @@ pub fn build_app(
         Duration::from_secs(30),
         Duration::from_secs(60),
     );
+
+    let tenant_resolution_state =
+        middleware::TenantResolutionState::new(&app_state.context.router_config)?;
 
     let protected_routes = Router::new()
         .route("/v1/responses", post(v1_responses))
@@ -871,6 +890,10 @@ pub fn build_app(
             middleware::concurrency_limit_middleware,
         ))
         .route_layer(axum::middleware::from_fn_with_state(
+            tenant_resolution_state.clone(),
+            middleware::route_request_meta_middleware,
+        ))
+        .route_layer(axum::middleware::from_fn_with_state(
             auth_config.clone(),
             middleware::auth_middleware,
         ))
@@ -890,6 +913,10 @@ pub fn build_app(
             middleware::concurrency_limit_middleware,
         ))
         .route_layer(axum::middleware::from_fn_with_state(
+            tenant_resolution_state.clone(),
+            middleware::route_request_meta_middleware,
+        ))
+        .route_layer(axum::middleware::from_fn_with_state(
             auth_config.clone(),
             middleware::auth_middleware,
         ));
@@ -904,6 +931,10 @@ pub fn build_app(
         .route_layer(axum::middleware::from_fn_with_state(
             app_state.clone(),
             middleware::concurrency_limit_middleware,
+        ))
+        .route_layer(axum::middleware::from_fn_with_state(
+            tenant_resolution_state,
+            middleware::route_request_meta_middleware,
         ))
         .route_layer(axum::middleware::from_fn_with_state(
             auth_config.clone(),
@@ -990,7 +1021,7 @@ pub fn build_app(
             middleware::auth_middleware,
         ));
 
-    Router::new()
+    Ok(Router::new()
         .merge(protected_routes)
         .merge(realtime_routes)
         .merge(multipart_upload_routes)
@@ -1009,7 +1040,7 @@ pub fn build_app(
         .layer(middleware::RequestIdLayer::new(request_id_headers))
         .layer(create_cors_layer(cors_allowed_origins))
         .fallback(sink_handler)
-        .with_state(app_state)
+        .with_state(app_state))
 }
 
 pub async fn startup(config: ServerConfig) -> Result<(), Box<dyn std::error::Error>> {
@@ -1407,7 +1438,7 @@ pub async fn startup(config: ServerConfig) -> Result<(), Box<dyn std::error::Err
         config.max_payload_size,
         request_id_headers,
         config.router_config.cors_allowed_origins.clone(),
-    );
+    )?;
 
     // TcpListener::bind accepts &str and handles IPv4/IPv6 via ToSocketAddrs
     let bind_addr = format!("{}:{}", config.host, config.port);
@@ -1470,12 +1501,12 @@ pub async fn startup(config: ServerConfig) -> Result<(), Box<dyn std::error::Err
 
         axum_server::bind_rustls(addr, tls_config)
             .handle(handle)
-            .serve(app.into_make_service())
+            .serve(app.into_make_service_with_connect_info::<std::net::SocketAddr>())
             .await
     } else {
         axum_server::bind(addr)
             .handle(handle)
-            .serve(app.into_make_service())
+            .serve(app.into_make_service_with_connect_info::<std::net::SocketAddr>())
             .await
     };
 

--- a/model_gateway/src/tenant.rs
+++ b/model_gateway/src/tenant.rs
@@ -1,0 +1,155 @@
+//! Canonical tenant identity and per-request metadata for serving paths.
+
+use std::{net::IpAddr, sync::Arc};
+
+use uuid::Uuid;
+
+pub const DEFAULT_TENANT_HEADER_NAME: &str = "x-smg-tenant-id";
+const HEX_DIGITS: &[u8; 16] = b"0123456789abcdef";
+
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+pub enum TenantIdentity {
+    Authenticated(Arc<str>),
+    Header(Arc<str>),
+    IpAddress(IpAddr),
+    Anonymous,
+    Explicit(Arc<str>),
+}
+
+impl TenantIdentity {
+    #[must_use]
+    pub fn into_key(self) -> TenantKey {
+        let key = match self {
+            Self::Authenticated(id) => format!("auth:{id}"),
+            Self::Header(id) => format!("header:{id}"),
+            Self::IpAddress(addr) => format!("ip:{addr}"),
+            Self::Anonymous => "anonymous".to_string(),
+            Self::Explicit(key) => key.to_string(),
+        };
+        TenantKey::from(key)
+    }
+}
+
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+pub struct TenantKey(Arc<str>);
+
+impl TenantKey {
+    #[must_use]
+    pub fn new(key: impl AsRef<str>) -> Self {
+        Self(Arc::from(key.as_ref()))
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for TenantKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<String> for TenantKey {
+    fn from(value: String) -> Self {
+        Self(Arc::from(value))
+    }
+}
+
+impl From<&str> for TenantKey {
+    fn from(value: &str) -> Self {
+        Self(Arc::from(value))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DataPlaneCaller {
+    tenant_key: TenantKey,
+}
+
+impl DataPlaneCaller {
+    #[must_use]
+    pub fn new(tenant_key: TenantKey) -> Self {
+        Self { tenant_key }
+    }
+
+    #[must_use]
+    pub fn tenant_key(&self) -> &TenantKey {
+        &self.tenant_key
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn authenticated_from_sha256(hash: [u8; 32]) -> Self {
+        Self::new(authenticated_tenant_key_from_sha256(hash))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RouteRequestMeta {
+    pub tenant_key: TenantKey,
+    pub request_charge_id: Uuid,
+}
+
+impl RouteRequestMeta {
+    #[must_use]
+    pub fn new(tenant_key: TenantKey) -> Self {
+        Self {
+            tenant_key,
+            request_charge_id: Uuid::now_v7(),
+        }
+    }
+
+    #[must_use]
+    pub fn tenant_key(&self) -> &TenantKey {
+        &self.tenant_key
+    }
+
+    #[must_use]
+    pub fn request_charge_id(&self) -> Uuid {
+        self.request_charge_id
+    }
+}
+
+#[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
+pub enum TenantResolutionError {
+    #[error("admin routes require an explicit target tenant id")]
+    MissingTargetTenant,
+}
+
+#[must_use]
+pub fn canonical_tenant_key(identity: TenantIdentity) -> TenantKey {
+    identity.into_key()
+}
+
+#[inline]
+#[must_use]
+pub fn authenticated_tenant_key_from_sha256(hash: [u8; 32]) -> TenantKey {
+    let mut key = String::with_capacity(5 + hash.len() * 2);
+    key.push_str("auth:");
+    for byte in hash {
+        key.push(HEX_DIGITS[(byte >> 4) as usize] as char);
+        key.push(HEX_DIGITS[(byte & 0x0f) as usize] as char);
+    }
+    TenantKey::from(key)
+}
+
+pub fn resolve_admin_target_tenant_key(
+    tenant_key: &str,
+) -> Result<TenantKey, TenantResolutionError> {
+    let tenant_key = tenant_key.trim();
+    if tenant_key.is_empty() {
+        return Err(TenantResolutionError::MissingTargetTenant);
+    }
+
+    Ok(canonical_tenant_key(TenantIdentity::Explicit(Arc::from(
+        tenant_key,
+    ))))
+}
+
+pub fn resolve_admin_target_tenant_id(
+    tenant_key: &str,
+) -> Result<RouteRequestMeta, TenantResolutionError> {
+    resolve_admin_target_tenant_key(tenant_key).map(RouteRequestMeta::new)
+}

--- a/model_gateway/tests/api/responses_api_test.rs
+++ b/model_gateway/tests/api/responses_api_test.rs
@@ -12,6 +12,7 @@ use openai_protocol::{
 use smg::{
     config::RouterConfig,
     routers::{conversations, RouterFactory},
+    tenant::{RouteRequestMeta, TenantKey},
 };
 
 use crate::common::{
@@ -21,6 +22,10 @@ use crate::common::{
 
 const TEST_INTERNAL_MCP_SERVER_LABEL: &str = "internal-mock";
 const TEST_INTERNAL_MCP_ERROR_MARKER: &str = "internal-mcp-failure-marker";
+
+fn test_tenant_meta() -> smg::middleware::TenantRequestMeta {
+    RouteRequestMeta::new(TenantKey::from("test-tenant"))
+}
 
 #[tokio::test]
 async fn test_non_streaming_mcp_minimal_e2e_with_persistence() {
@@ -116,7 +121,10 @@ async fn test_non_streaming_mcp_minimal_e2e_with_persistence() {
         conversation: None,
     };
 
-    let resp = router.route_responses(None, &req, req.model.as_str()).await;
+    let tenant_meta = test_tenant_meta();
+    let resp = router
+        .route_responses(None, &tenant_meta, &req, req.model.as_str())
+        .await;
 
     assert_eq!(resp.status(), StatusCode::OK);
 
@@ -314,7 +322,10 @@ async fn test_non_streaming_mcp_returns_approval_request_when_required() {
         conversation: None,
     };
 
-    let resp = router.route_responses(None, &req, req.model.as_str()).await;
+    let tenant_meta = test_tenant_meta();
+    let resp = router
+        .route_responses(None, &tenant_meta, &req, req.model.as_str())
+        .await;
     assert_eq!(resp.status(), StatusCode::OK);
 
     let body_bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
@@ -444,7 +455,10 @@ async fn test_final_response_hides_internal_mcp_trace_items() {
         conversation: None,
     };
 
-    let resp = router.route_responses(None, &req, req.model.as_str()).await;
+    let tenant_meta = test_tenant_meta();
+    let resp = router
+        .route_responses(None, &tenant_meta, &req, req.model.as_str())
+        .await;
     assert_eq!(resp.status(), StatusCode::OK);
 
     let body_bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
@@ -575,8 +589,9 @@ async fn test_previous_response_id_does_not_repeat_mcp_list_tools_for_existing_b
         conversation: None,
     };
 
+    let tenant_meta = test_tenant_meta();
     let resp1 = router
-        .route_responses(None, &req1, req1.model.as_str())
+        .route_responses(None, &tenant_meta, &req1, req1.model.as_str())
         .await;
     assert_eq!(resp1.status(), StatusCode::OK);
 
@@ -630,8 +645,9 @@ async fn test_previous_response_id_does_not_repeat_mcp_list_tools_for_existing_b
         conversation: None,
     };
 
+    let tenant_meta = test_tenant_meta();
     let resp2 = router
-        .route_responses(None, &req2, req2.model.as_str())
+        .route_responses(None, &tenant_meta, &req2, req2.model.as_str())
         .await;
     assert_eq!(resp2.status(), StatusCode::OK);
 
@@ -752,7 +768,10 @@ async fn test_final_response_hides_internal_mcp_error_details() {
         conversation: None,
     };
 
-    let resp = router.route_responses(None, &req, req.model.as_str()).await;
+    let tenant_meta = test_tenant_meta();
+    let resp = router
+        .route_responses(None, &tenant_meta, &req, req.model.as_str())
+        .await;
     assert_eq!(resp.status(), StatusCode::OK);
 
     let body_bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
@@ -1204,7 +1223,10 @@ async fn test_multi_turn_loop_with_mcp() {
     };
 
     // Execute the request (this should trigger the multi-turn loop)
-    let response = router.route_responses(None, &req, req.model.as_str()).await;
+    let tenant_meta = test_tenant_meta();
+    let response = router
+        .route_responses(None, &tenant_meta, &req, req.model.as_str())
+        .await;
 
     // Check status
     assert_eq!(response.status(), StatusCode::OK, "Request should succeed");
@@ -1362,7 +1384,10 @@ async fn test_max_tool_calls_limit() {
         conversation: None,
     };
 
-    let response = router.route_responses(None, &req, req.model.as_str()).await;
+    let tenant_meta = test_tenant_meta();
+    let response = router
+        .route_responses(None, &tenant_meta, &req, req.model.as_str())
+        .await;
     assert_eq!(response.status(), StatusCode::OK);
 
     use axum::body::to_bytes;
@@ -1548,7 +1573,10 @@ async fn test_streaming_with_mcp_tool_calls() {
         conversation: None,
     };
 
-    let response = router.route_responses(None, &req, req.model.as_str()).await;
+    let tenant_meta = test_tenant_meta();
+    let response = router
+        .route_responses(None, &tenant_meta, &req, req.model.as_str())
+        .await;
 
     // Verify streaming response
     assert_eq!(
@@ -1832,7 +1860,10 @@ async fn test_streaming_multi_turn_with_mcp() {
         conversation: None,
     };
 
-    let response = router.route_responses(None, &req, req.model.as_str()).await;
+    let tenant_meta = test_tenant_meta();
+    let response = router
+        .route_responses(None, &tenant_meta, &req, req.model.as_str())
+        .await;
     assert_eq!(response.status(), StatusCode::OK);
 
     use axum::body::to_bytes;

--- a/model_gateway/tests/common/test_app.rs
+++ b/model_gateway/tests/common/test_app.rs
@@ -121,6 +121,10 @@ pub fn create_test_app(
     let auth_config = AuthConfig::new(router_config.api_key.clone());
 
     // Use the actual server's build_app function
+    #[expect(
+        clippy::expect_used,
+        reason = "test helper assumes router config is already validated"
+    )]
     build_app(
         app_state,
         auth_config,
@@ -129,6 +133,7 @@ pub fn create_test_app(
         request_id_headers,
         router_config.cors_allowed_origins.clone(),
     )
+    .expect("valid tenant resolution config")
 }
 
 /// Create a test Axum application with an existing AppContext
@@ -161,6 +166,10 @@ pub fn create_test_app_with_context(
     let auth_config = AuthConfig::new(router_config.api_key.clone());
 
     // Use the actual server's build_app function
+    #[expect(
+        clippy::expect_used,
+        reason = "test helper assumes router config is already validated"
+    )]
     build_app(
         app_state,
         auth_config,
@@ -169,6 +178,7 @@ pub fn create_test_app_with_context(
         request_id_headers,
         router_config.cors_allowed_origins.clone(),
     )
+    .expect("valid tenant resolution config")
 }
 
 /// Create a minimal test AppContext for unit tests

--- a/model_gateway/tests/routing/test_openai_routing.rs
+++ b/model_gateway/tests/routing/test_openai_routing.rs
@@ -30,6 +30,7 @@ use smg::{
         factory::router_ids, openai::OpenAIRouter, router_manager::RouterManager, RouterFactory,
         RouterTrait,
     },
+    tenant::{RouteRequestMeta, TenantKey},
     worker::{BasicWorkerBuilder, RuntimeType, Worker, WorkerType},
 };
 use smg_data_connector::{ResponseId, StoredResponse};
@@ -95,6 +96,10 @@ fn create_minimal_completion_request() -> CompletionRequest {
         sampling_seed: None,
         other: serde_json::Map::new(),
     }
+}
+
+fn test_tenant_meta() -> smg::middleware::TenantRequestMeta {
+    RouteRequestMeta::new(TenantKey::from("test-tenant"))
 }
 
 /// Test basic OpenAI router creation and configuration
@@ -234,8 +239,9 @@ async fn test_openai_router_responses_with_mock() {
         ..Default::default()
     };
 
+    let tenant_meta = test_tenant_meta();
     let response1 = router
-        .route_responses(None, &request1, &request1.model)
+        .route_responses(None, &tenant_meta, &request1, &request1.model)
         .await;
     assert_eq!(response1.status(), StatusCode::OK);
     let body1_bytes = axum::body::to_bytes(response1.into_body(), usize::MAX)
@@ -253,8 +259,9 @@ async fn test_openai_router_responses_with_mock() {
         ..Default::default()
     };
 
+    let tenant_meta = test_tenant_meta();
     let response2 = router
-        .route_responses(None, &request2, &request2.model)
+        .route_responses(None, &tenant_meta, &request2, &request2.model)
         .await;
     assert_eq!(response2.status(), StatusCode::OK);
     let body2_bytes = axum::body::to_bytes(response2.into_body(), usize::MAX)
@@ -501,7 +508,10 @@ async fn test_openai_router_responses_streaming_with_mock() {
         ..Default::default()
     };
 
-    let response = router.route_responses(None, &request, &request.model).await;
+    let tenant_meta = test_tenant_meta();
+    let response = router
+        .route_responses(None, &tenant_meta, &request, &request.model)
+        .await;
     assert_eq!(response.status(), StatusCode::OK);
 
     let headers = response.headers();
@@ -639,14 +649,26 @@ async fn test_unsupported_endpoints() {
         rid: None,
     };
 
+    let tenant_meta = test_tenant_meta();
     let response = router
-        .route_generate(None, &generate_request, &generate_request.model)
+        .route_generate(
+            None,
+            &tenant_meta,
+            &generate_request,
+            &generate_request.model,
+        )
         .await;
     assert_eq!(response.status(), StatusCode::NOT_IMPLEMENTED);
 
     let completion_request = create_minimal_completion_request();
+    let tenant_meta = test_tenant_meta();
     let response = router
-        .route_completion(None, &completion_request, &completion_request.model)
+        .route_completion(
+            None,
+            &tenant_meta,
+            &completion_request,
+            &completion_request.model,
+        )
         .await;
     assert_eq!(response.status(), StatusCode::NOT_IMPLEMENTED);
 }
@@ -672,8 +694,9 @@ async fn test_openai_router_chat_completion_with_mock() {
     chat_request.temperature = Some(0.7);
 
     // Route the request
+    let tenant_meta = test_tenant_meta();
     let response = router
-        .route_chat(None, &chat_request, &chat_request.model)
+        .route_chat(None, &tenant_meta, &chat_request, &chat_request.model)
         .await;
 
     // Should get a successful response from mock server
@@ -716,8 +739,14 @@ async fn test_openai_e2e_with_server() {
                     let chat_request: ChatCompletionRequest =
                         serde_json::from_str(&body_str).unwrap();
 
+                    let tenant_meta = test_tenant_meta();
                     router
-                        .route_chat(Some(&parts.headers), &chat_request, &chat_request.model)
+                        .route_chat(
+                            Some(&parts.headers),
+                            &tenant_meta,
+                            &chat_request,
+                            &chat_request.model,
+                        )
                         .await
                 }
             }
@@ -777,8 +806,9 @@ async fn test_openai_router_chat_streaming_with_mock() {
     });
     let chat_request: ChatCompletionRequest = serde_json::from_value(val).unwrap();
 
+    let tenant_meta = test_tenant_meta();
     let response = router
-        .route_chat(None, &chat_request, &chat_request.model)
+        .route_chat(None, &tenant_meta, &chat_request, &chat_request.model)
         .await;
     assert_eq!(response.status(), StatusCode::OK);
 
@@ -812,8 +842,9 @@ async fn test_openai_router_circuit_breaker() {
 
     // First few requests should fail and record failures
     for _ in 0..3 {
+        let tenant_meta = test_tenant_meta();
         let response = router
-            .route_chat(None, &chat_request, &chat_request.model)
+            .route_chat(None, &tenant_meta, &chat_request, &chat_request.model)
             .await;
         // Should get either an error or circuit breaker response
         assert!(

--- a/model_gateway/tests/wasm_test.rs
+++ b/model_gateway/tests/wasm_test.rs
@@ -200,6 +200,10 @@ async fn create_test_app_with_wasm() -> (axum::Router, Arc<AppContext>, TempDir)
 
     let request_id_headers = vec!["x-request-id".to_string(), "x-correlation-id".to_string()];
 
+    #[expect(
+        clippy::expect_used,
+        reason = "test helper assumes router config is already validated"
+    )]
     let app = build_app(
         app_state,
         smg::middleware::AuthConfig::new(None),
@@ -207,7 +211,8 @@ async fn create_test_app_with_wasm() -> (axum::Router, Arc<AppContext>, TempDir)
         256 * 1024 * 1024,
         request_id_headers,
         vec![], // cors_allowed_origins
-    );
+    )
+    .expect("valid tenant resolution config");
 
     (app, app_context, temp_dir)
 }


### PR DESCRIPTION
## Summary
- add a tenant-resolution core with canonical tenant keys and per-request charge metadata
- propagate request metadata across inference router paths and contexts
- collapse auth + tenant key construction into a single cheap authenticated path
- hard-fail invalid tenant header configuration instead of silently falling back
- wire the new config through CLI and Python bindings

## Verification
- cargo +nightly fmt --all
- cargo check -p smg --lib
- cargo clippy --all-targets --all-features --target-dir /tmp/tenant-core-clippy -- -D warnings

## Notes
- full cargo test was started with an isolated target dir, but it was interrupted before completion
- make python-dev hits the repo's sccache setup in this sandbox; the Python and Go bindings still compiled successfully during the all-targets clippy run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multitenancy: identity resolution from authenticated callers, optional configured header, or client IP; tenant metadata flows through routing and pipelines.

* **Configuration**
  * CLI flags and config options to enable/trust and name the tenant header.
  * Python binding updated to accept tenant-header options with sensible defaults.

* **Validation**
  * Tenant header name is trimmed and validated at startup.

* **Tests**
  * Integration and routing tests updated to provide tenant metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->