### PR TITLE
refactor(protocols): restore Chat/Responses ToolChoice separation invariant

### DIFF
--- a/crates/protocols/src/responses.rs
+++ b/crates/protocols/src/responses.rs
@@ -174,6 +174,12 @@ impl<'de> Deserialize<'de> for ResponsesFunctionToolChoice {
 /// whose `type` does not belong to that variant. Without the tag pinning,
 /// the `#[serde(untagged)]` enum would accept any object shape that
 /// happened to fit the field set of an earlier variant.
+///
+/// NOTE: kept separate from `common::ToolChoice`. Chat Completions uses
+/// a different `Function` wire shape (nested `{"function": {"name": ...}}`)
+/// and does not accept the `Types` / `Mcp` / `Custom` / `ApplyPatch` /
+/// `Shell` variants; sharing one enum would let `/v1/chat/completions`
+/// silently accept spec-invalid payloads.
 #[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
 #[serde(untagged)]
 pub enum ResponsesToolChoice {


### PR DESCRIPTION
## Summary

Follow-up to #1310. Restores an architectural invariant that was over-pruned in that PR: the \`NOTE\` explaining that \`ResponsesToolChoice\` must remain separate from \`common::ToolChoice\` because Chat Completions has different \`Function\` wire shape and does not accept Responses-specific variants (\`Types\`/\`Mcp\`/\`Custom\`/\`ApplyPatch\`/\`Shell\`).

gemini-code-assist raised this as a medium-priority concern on #1310 after that PR was already merged, flagging that losing this context could let future refactors merge the two enums and silently accept spec-invalid payloads on \`/v1/chat/completions\`.

## Why

The original paragraph in #1310 was dropped as \"deliberately\" / \"PR-body-in-source\" prose. But it also carried a real invariant a future reader would miss. Per C2's own PRUNE rule (\"shorten without deleting\"), the correct outcome is a condensed NOTE that keeps the invariant and drops the audit framing.

## What

One 5-line \`NOTE:\` block added above the \`ResponsesToolChoice\` derives:

\`\`\`rust
/// NOTE: kept separate from \`common::ToolChoice\`. Chat Completions uses
/// a different \`Function\` wire shape (nested \`{\"function\": {\"name\": ...}}\`)
/// and does not accept the \`Types\` / \`Mcp\` / \`Custom\` / \`ApplyPatch\` /
/// \`Shell\` variants; sharing one enum would let \`/v1/chat/completions\`
/// silently accept spec-invalid payloads.
\`\`\`

## Acceptance

- cargo check -p openai-protocol --lib --tests: green
- cargo clippy -p openai-protocol --lib --tests -- -D warnings: green
- cargo test -p openai-protocol --lib --tests: all pass (18 lib + 41 integration + 94 on responses)
- No semantic changes. Doc comment only.

Refs: #1310

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal documentation to clarify design rationale for API response structures.

**Note:** This release contains no user-visible changes or functional updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->