### PR TITLE
refactor(responses): split load/prepare for canonical agent-loop input

### DIFF
--- a/crates/protocols/src/responses.rs
+++ b/crates/protocols/src/responses.rs
@@ -1549,6 +1549,31 @@ pub enum ResponseInputOutputItem {
         #[serde(skip_serializing_if = "Option::is_none")]
         reason: Option<String>,
     },
+    /// Client-stitched MCP tool inventory item. Echoes the output-side
+    /// `mcp_list_tools` shape so a prior assistant turn can be replayed as
+    /// input.
+    #[serde(rename = "mcp_list_tools")]
+    McpListTools {
+        id: String,
+        server_label: String,
+        tools: Vec<McpToolInfo>,
+    },
+    /// Client-stitched completed MCP tool call. Echoes the output-side
+    /// `mcp_call` shape so a prior tool execution can be replayed as input
+    /// without re-executing the tool.
+    #[serde(rename = "mcp_call")]
+    McpCall {
+        id: String,
+        server_label: String,
+        name: String,
+        arguments: String,
+        output: String,
+        status: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        approval_request_id: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        error: Option<String>,
+    },
     /// `type: "image_generation_call"` — round-trip form for an image generated
     /// in a prior turn. Spec (OpenAI Responses API, multi-turn image-edit
     /// flow): clients may resubmit only `{ type, id }` to reference a prior
@@ -2944,6 +2969,8 @@ impl GenerationRequest for ResponsesRequest {
                         | ResponseInputOutputItem::FunctionCallOutput { .. }
                         | ResponseInputOutputItem::McpApprovalRequest { .. }
                         | ResponseInputOutputItem::McpApprovalResponse { .. }
+                        | ResponseInputOutputItem::McpListTools { .. }
+                        | ResponseInputOutputItem::McpCall { .. }
                         | ResponseInputOutputItem::ImageGenerationCall { .. }
                         | ResponseInputOutputItem::Compaction { .. }
                         | ResponseInputOutputItem::ComputerCall { .. }
@@ -3228,6 +3255,8 @@ fn validate_input_item(item: &ResponseInputOutputItem) -> Result<(), ValidationE
         ResponseInputOutputItem::FunctionToolCall { .. } => {}
         ResponseInputOutputItem::McpApprovalRequest { .. } => {}
         ResponseInputOutputItem::McpApprovalResponse { .. } => {}
+        ResponseInputOutputItem::McpListTools { .. } => {}
+        ResponseInputOutputItem::McpCall { .. } => {}
         ResponseInputOutputItem::ImageGenerationCall { .. } => {}
         ResponseInputOutputItem::Compaction { .. } => {}
         ResponseInputOutputItem::ComputerCall { .. } => {}

--- a/crates/protocols/tests/responses.rs
+++ b/crates/protocols/tests/responses.rs
@@ -2026,7 +2026,6 @@ fn test_custom_tool_call_output_validation_rejects_empty_text_and_parts() {
         ok_text.validate().is_ok(),
         "non-empty CustomToolCallOutput must validate",
     );
-
 }
 
 /// Client-stitched transcripts may carry `mcp_list_tools` and `mcp_call`

--- a/crates/protocols/tests/responses.rs
+++ b/crates/protocols/tests/responses.rs
@@ -2033,6 +2033,8 @@ fn test_custom_tool_call_output_validation_rejects_empty_text_and_parts() {
 /// structurally so the router-side preparation layer can normalize them.
 #[test]
 fn response_input_accepts_mcp_trace_items() {
+    use validator::Validate;
+
     let request: ResponsesRequest = serde_json::from_value(json!({
         "model": "gpt-5.4",
         "store": false,
@@ -2060,6 +2062,10 @@ fn response_input_accepts_mcp_trace_items() {
         ],
     }))
     .expect("request should deserialize");
+
+    request
+        .validate()
+        .expect("mcp trace items should pass structural validation");
 
     let ResponseInput::Items(items) = &request.input else {
         panic!("expected items input");

--- a/crates/protocols/tests/responses.rs
+++ b/crates/protocols/tests/responses.rs
@@ -2026,6 +2026,83 @@ fn test_custom_tool_call_output_validation_rejects_empty_text_and_parts() {
         ok_text.validate().is_ok(),
         "non-empty CustomToolCallOutput must validate",
     );
+
+}
+
+/// Client-stitched transcripts may carry `mcp_list_tools` and `mcp_call`
+/// items echoing prior output. Protocol validation must accept them
+/// structurally so the router-side preparation layer can normalize them.
+#[test]
+fn response_input_accepts_mcp_trace_items() {
+    let request: ResponsesRequest = serde_json::from_value(json!({
+        "model": "gpt-5.4",
+        "store": false,
+        "input": [
+            {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "search something"}],
+            },
+            {
+                "type": "mcp_list_tools",
+                "id": "mcpl_123",
+                "server_label": "deepwiki",
+                "tools": [],
+            },
+            {
+                "type": "mcp_call",
+                "id": "mcp_123",
+                "server_label": "deepwiki",
+                "name": "ask_question",
+                "arguments": "{\"query\":\"something\"}",
+                "output": "{\"result\":\"ok\"}",
+                "status": "completed",
+            },
+        ],
+    }))
+    .expect("request should deserialize");
+
+    let ResponseInput::Items(items) = &request.input else {
+        panic!("expected items input");
+    };
+
+    assert!(
+        items
+            .iter()
+            .any(|item| matches!(item, ResponseInputOutputItem::McpListTools { .. })),
+        "mcp_list_tools should deserialize as an input item",
+    );
+    assert!(
+        items
+            .iter()
+            .any(|item| matches!(item, ResponseInputOutputItem::McpCall { .. })),
+        "mcp_call should deserialize as an input item",
+    );
+
+    let serialized = serde_json::to_value(&request).expect("serialize");
+    assert_eq!(serialized["input"][1]["type"], json!("mcp_list_tools"));
+    assert_eq!(serialized["input"][2]["type"], json!("mcp_call"));
+}
+
+/// Optional fields on `mcp_call` (`approval_request_id`, `error`) should
+/// be omitted from serialized output when unset, matching the output-side
+/// contract and keeping spec parity on re-emit.
+#[test]
+fn mcp_call_input_omits_optional_fields_when_unset() {
+    let item = ResponseInputOutputItem::McpCall {
+        id: "mcp_abc".to_string(),
+        server_label: "deepwiki".to_string(),
+        name: "ask_question".to_string(),
+        arguments: "{}".to_string(),
+        output: "ok".to_string(),
+        status: "completed".to_string(),
+        approval_request_id: None,
+        error: None,
+    };
+
+    let v = serde_json::to_value(&item).expect("serialize");
+    assert!(v.get("approval_request_id").is_none());
+    assert!(v.get("error").is_none());
 }
 
 // ---------------------------------------------------------------------------

--- a/model_gateway/benches/routing_allocation_bench.rs
+++ b/model_gateway/benches/routing_allocation_bench.rs
@@ -68,6 +68,8 @@ fn extract_text_for_routing_old(req: &ResponsesRequest) -> String {
                 ResponseInputOutputItem::FunctionCallOutput { output, .. } => Some(output.clone()),
                 ResponseInputOutputItem::McpApprovalRequest { .. } => None,
                 ResponseInputOutputItem::McpApprovalResponse { .. } => None,
+                ResponseInputOutputItem::McpListTools { .. } => None,
+                ResponseInputOutputItem::McpCall { .. } => None,
                 ResponseInputOutputItem::ImageGenerationCall { .. } => None,
                 ResponseInputOutputItem::Compaction { .. } => None,
                 ResponseInputOutputItem::ComputerCall { .. } => None,

--- a/model_gateway/src/routers/grpc/harmony/builder.rs
+++ b/model_gateway/src/routers/grpc/harmony/builder.rs
@@ -495,8 +495,11 @@ impl HarmonyBuilder {
                 let mut prev_outputs: Vec<&ResponseInputOutputItem> = Vec::new();
 
                 for item in items {
-                    let msg = self.parse_response_item_to_harmony_message(item, &prev_outputs)?;
-                    all_messages.push(msg);
+                    if let Some(msg) =
+                        self.parse_response_item_to_harmony_message(item, &prev_outputs)?
+                    {
+                        all_messages.push(msg);
+                    }
 
                     // Track function tool calls so that function_call_output can find the name
                     if matches!(item, ResponseInputOutputItem::FunctionToolCall { .. }) {
@@ -529,7 +532,7 @@ impl HarmonyBuilder {
         &self,
         item: &ResponseInputOutputItem,
         prev_outputs: &[&ResponseInputOutputItem],
-    ) -> Result<HarmonyMessage, String> {
+    ) -> Result<Option<HarmonyMessage>, String> {
         match item {
             // Regular message (user or assistant)
             ResponseInputOutputItem::Message { role, content, .. } => {
@@ -558,7 +561,7 @@ impl HarmonyBuilder {
 
                 let text = text_parts.join("\n");
 
-                Ok(HarmonyMessage {
+                Ok(Some(HarmonyMessage {
                     author: Author {
                         role: harmony_role,
                         name: None,
@@ -567,7 +570,7 @@ impl HarmonyBuilder {
                     content: vec![Content::Text(TextContent { text })],
                     channel: None,
                     content_type: None,
-                })
+                }))
             }
 
             // Reasoning content (chain-of-thought)
@@ -583,7 +586,7 @@ impl HarmonyBuilder {
                 let text = reasoning_texts.join("\n");
 
                 // Reasoning goes in the "analysis" channel for Harmony
-                Ok(HarmonyMessage {
+                Ok(Some(HarmonyMessage {
                     author: Author {
                         role: Role::Assistant,
                         name: None,
@@ -592,7 +595,7 @@ impl HarmonyBuilder {
                     content: vec![Content::Text(TextContent { text })],
                     channel: Some("analysis".to_string()),
                     content_type: None,
-                })
+                }))
             }
 
             // Function tool call (with optional output)
@@ -615,7 +618,7 @@ impl HarmonyBuilder {
                         output_preview = %output_str.chars().take(100).collect::<String>(),
                         "Building tool result message with Tool role (recipient=assistant, no channel)"
                     );
-                    Ok(HarmonyMessage {
+                    Ok(Some(HarmonyMessage {
                         author: Author {
                             role: Role::Tool,
                             name: Some(author_name),
@@ -626,7 +629,7 @@ impl HarmonyBuilder {
                         })],
                         channel: None,
                         content_type: None,
-                    })
+                    }))
                 } else {
                     // Tool call - assistant message in commentary channel with recipient
                     // msg.with_channel("commentary").with_recipient(f"functions.{name}")
@@ -636,7 +639,7 @@ impl HarmonyBuilder {
                         recipient = %recipient,
                         "Building tool call message with recipient"
                     );
-                    Ok(HarmonyMessage {
+                    Ok(Some(HarmonyMessage {
                         author: Author {
                             role: Role::Assistant,
                             name: None,
@@ -647,7 +650,7 @@ impl HarmonyBuilder {
                         })],
                         channel: Some("commentary".to_string()),
                         content_type: Some("json".to_string()),
-                    })
+                    }))
                 }
             }
 
@@ -672,7 +675,7 @@ impl HarmonyBuilder {
                 // Create Tool message with "functions.{name}" prefix
                 // IMPORTANT: Must include recipient="assistant" for parser to recognize it.
                 // We keep channel=None to minimize what the model might copy.
-                Ok(HarmonyMessage {
+                Ok(Some(HarmonyMessage {
                     author: Author {
                         role: Role::Tool,
                         name: Some(format!("functions.{call}")),
@@ -683,7 +686,7 @@ impl HarmonyBuilder {
                     })],
                     channel: None,
                     content_type: None,
-                })
+                }))
             }
 
             // Simple input message (usually user message)
@@ -717,7 +720,7 @@ impl HarmonyBuilder {
                     }
                 };
 
-                Ok(HarmonyMessage {
+                Ok(Some(HarmonyMessage {
                     author: Author {
                         role: harmony_role,
                         name: None,
@@ -726,12 +729,21 @@ impl HarmonyBuilder {
                     content: vec![Content::Text(TextContent { text })],
                     channel: None,
                     content_type: None,
-                })
+                }))
             }
 
             ResponseInputOutputItem::McpApprovalResponse { .. }
             | ResponseInputOutputItem::McpApprovalRequest { .. }
-            | ResponseInputOutputItem::ComputerCall { .. }
+            | ResponseInputOutputItem::McpListTools { .. }
+            | ResponseInputOutputItem::McpCall { .. } => {
+                warn!(
+                    function = "parse_response_item_to_harmony_message",
+                    "Skipping replayed MCP trace item during Harmony conversion"
+                );
+                Ok(None)
+            }
+
+            ResponseInputOutputItem::ComputerCall { .. }
             | ResponseInputOutputItem::ComputerCallOutput { .. } => {
                 warn!(
                     function = "parse_response_item_to_harmony_message",
@@ -1042,5 +1054,77 @@ impl HarmonyBuilder {
 impl Default for HarmonyBuilder {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use openai_protocol::responses::{
+        ResponseContentPart, ResponseInput, ResponseInputOutputItem, ResponsesRequest,
+    };
+
+    use super::HarmonyBuilder;
+
+    #[test]
+    fn test_construct_input_messages_skips_replayed_mcp_trace_items() {
+        let request = ResponsesRequest {
+            previous_response_id: Some("resp_prev".to_string()),
+            input: ResponseInput::Items(vec![
+                ResponseInputOutputItem::Message {
+                    id: "msg_user".to_string(),
+                    role: "user".to_string(),
+                    content: vec![ResponseContentPart::InputText {
+                        text: "hello".to_string(),
+                    }],
+                    status: None,
+                    phase: None,
+                },
+                ResponseInputOutputItem::McpApprovalRequest {
+                    id: "mcpr_1".to_string(),
+                    server_label: "mock".to_string(),
+                    name: "brave_web_search".to_string(),
+                    arguments: "{\"query\":\"hello\"}".to_string(),
+                },
+                ResponseInputOutputItem::McpApprovalResponse {
+                    id: Some("mcprr_1".to_string()),
+                    approval_request_id: "mcpr_1".to_string(),
+                    approve: true,
+                    reason: None,
+                },
+                ResponseInputOutputItem::McpListTools {
+                    id: "mcp_list_1".to_string(),
+                    server_label: "mock".to_string(),
+                    tools: vec![],
+                },
+                ResponseInputOutputItem::McpCall {
+                    id: "mcp_1".to_string(),
+                    server_label: "mock".to_string(),
+                    name: "brave_web_search".to_string(),
+                    arguments: "{\"query\":\"hello\"}".to_string(),
+                    output: "{\"result\":\"world\"}".to_string(),
+                    status: "completed".to_string(),
+                    approval_request_id: None,
+                    error: None,
+                },
+                ResponseInputOutputItem::Message {
+                    id: "msg_assistant".to_string(),
+                    role: "assistant".to_string(),
+                    content: vec![ResponseContentPart::OutputText {
+                        text: "done".to_string(),
+                        annotations: vec![],
+                        logprobs: None,
+                    }],
+                    status: None,
+                    phase: None,
+                },
+            ]),
+            ..Default::default()
+        };
+
+        let messages = HarmonyBuilder::new()
+            .construct_input_messages_with_harmony(&request)
+            .expect("replayed MCP trace items are skipped");
+
+        assert_eq!(messages.len(), 2);
     }
 }

--- a/model_gateway/src/routers/grpc/regular/responses/conversions.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/conversions.rs
@@ -144,7 +144,16 @@ pub(crate) fn responses_to_chat(req: &ResponsesRequest) -> Result<ChatCompletion
                     }
                     ResponseInputOutputItem::McpApprovalResponse { .. }
                     | ResponseInputOutputItem::McpApprovalRequest { .. }
-                    | ResponseInputOutputItem::ComputerCall { .. }
+                    | ResponseInputOutputItem::McpListTools { .. }
+                    | ResponseInputOutputItem::McpCall { .. } => {
+                        warn!(
+                            function = "responses_to_chat",
+                            "Skipping replayed MCP trace item during chat conversion"
+                        );
+                        continue;
+                    }
+
+                    ResponseInputOutputItem::ComputerCall { .. }
                     | ResponseInputOutputItem::ComputerCallOutput { .. } => {
                         warn!(
                             function = "responses_to_chat",
@@ -547,5 +556,64 @@ mod tests {
         let chat_req = responses_to_chat(&req).unwrap();
         assert!(!chat_req.stream);
         assert!(chat_req.stream_options.is_none());
+    }
+
+    #[test]
+    fn test_replayed_mcp_trace_items_are_skipped() {
+        let req = ResponsesRequest {
+            input: ResponseInput::Items(vec![
+                ResponseInputOutputItem::Message {
+                    id: "msg_user".to_string(),
+                    role: "user".to_string(),
+                    content: vec![ResponseContentPart::InputText {
+                        text: "hello".to_string(),
+                    }],
+                    status: None,
+                    phase: None,
+                },
+                ResponseInputOutputItem::McpApprovalRequest {
+                    id: "mcpr_1".to_string(),
+                    server_label: "mock".to_string(),
+                    name: "brave_web_search".to_string(),
+                    arguments: "{\"query\":\"hello\"}".to_string(),
+                },
+                ResponseInputOutputItem::McpApprovalResponse {
+                    id: Some("mcprr_1".to_string()),
+                    approval_request_id: "mcpr_1".to_string(),
+                    approve: true,
+                    reason: None,
+                },
+                ResponseInputOutputItem::McpListTools {
+                    id: "mcp_list_1".to_string(),
+                    server_label: "mock".to_string(),
+                    tools: vec![],
+                },
+                ResponseInputOutputItem::McpCall {
+                    id: "mcp_1".to_string(),
+                    server_label: "mock".to_string(),
+                    name: "brave_web_search".to_string(),
+                    arguments: "{\"query\":\"hello\"}".to_string(),
+                    output: "{\"result\":\"world\"}".to_string(),
+                    status: "completed".to_string(),
+                    approval_request_id: None,
+                    error: None,
+                },
+                ResponseInputOutputItem::Message {
+                    id: "msg_assistant".to_string(),
+                    role: "assistant".to_string(),
+                    content: vec![ResponseContentPart::OutputText {
+                        text: "done".to_string(),
+                        annotations: vec![],
+                        logprobs: None,
+                    }],
+                    status: None,
+                    phase: None,
+                },
+            ]),
+            ..Default::default()
+        };
+
+        let chat_req = responses_to_chat(&req).expect("replayed MCP trace items are skipped");
+        assert_eq!(chat_req.messages.len(), 2);
     }
 }

--- a/model_gateway/src/routers/openai/context.rs
+++ b/model_gateway/src/routers/openai/context.rs
@@ -3,7 +3,10 @@
 use std::sync::Arc;
 
 use axum::http::HeaderMap;
-use openai_protocol::{chat::ChatCompletionRequest, responses::ResponsesRequest};
+use openai_protocol::{
+    chat::ChatCompletionRequest,
+    responses::{ResponseInput, ResponsesRequest},
+};
 use serde_json::Value;
 use smg_data_connector::{
     ConversationItemStorage, ConversationMemoryWriter, ConversationStorage,
@@ -131,6 +134,7 @@ pub struct PayloadState {
 #[derive(Default)]
 pub struct ResponsesPayloadState {
     pub previous_response_id: Option<String>,
+    pub upstream_input: Option<ResponseInput>,
     pub existing_mcp_list_tools_labels: Vec<String>,
 }
 
@@ -267,6 +271,7 @@ pub struct OwnedStreamingContext {
     pub payload: Value,
     pub original_body: ResponsesRequest,
     pub previous_response_id: Option<String>,
+    pub upstream_input: ResponseInput,
     pub existing_mcp_list_tools_labels: Vec<String>,
     pub storage: StorageHandles,
 }
@@ -279,6 +284,9 @@ impl RequestContext {
             .responses_request()
             .ok_or("Expected responses request")?
             .clone();
+        let upstream_input = responses_payload_state
+            .upstream_input
+            .unwrap_or_else(|| original_body.input.clone());
         let response = self
             .components
             .response_storage()
@@ -305,6 +313,7 @@ impl RequestContext {
             payload: payload_state.json,
             original_body,
             previous_response_id: responses_payload_state.previous_response_id,
+            upstream_input,
             existing_mcp_list_tools_labels: responses_payload_state.existing_mcp_list_tools_labels,
             storage: StorageHandles {
                 response,

--- a/model_gateway/src/routers/openai/mcp/tool_loop.rs
+++ b/model_gateway/src/routers/openai/mcp/tool_loop.rs
@@ -754,6 +754,7 @@ fn approval_prefix_items(
 
 pub(crate) struct ToolLoopExecutionContext<'a> {
     pub original_body: &'a ResponsesRequest,
+    pub upstream_input: &'a ResponseInput,
     pub existing_mcp_list_tools_labels: &'a [String],
     pub session: &'a McpToolSession<'a>,
 }
@@ -769,12 +770,13 @@ pub(crate) async fn execute_tool_loop(
 ) -> Result<Value, String> {
     let ToolLoopExecutionContext {
         original_body,
+        upstream_input,
         existing_mcp_list_tools_labels,
         session,
     } = tool_loop_ctx;
 
     let mut state = ToolLoopState::new(
-        original_body.input.clone(),
+        upstream_input.clone(),
         existing_mcp_list_tools_labels.to_vec(),
     );
     let max_tool_calls = original_body.max_tool_calls.map(|n| n as usize);

--- a/model_gateway/src/routers/openai/responses/history.rs
+++ b/model_gateway/src/routers/openai/responses/history.rs
@@ -382,7 +382,7 @@ fn append_current_input(
             });
         }
         ResponseInput::Items(current_items) => {
-            items.extend(current_items.iter().map(normalize_input_item));
+            items.extend(current_items.iter().cloned());
         }
     }
 }

--- a/model_gateway/src/routers/openai/responses/history.rs
+++ b/model_gateway/src/routers/openai/responses/history.rs
@@ -1,14 +1,24 @@
-//! Input history loading for the Responses API.
+//! Input history loading and normalization for the Responses API.
 //!
-//! Loads conversation history and/or previous response chains into the request
-//! input before forwarding to the upstream provider.
+//! Loading is split into two phases so that stitched `input` and
+//! server-replayed history go through the same normalization boundary:
+//!
+//! - [`load_input_history`] fetches server-managed transcript sources
+//!   (`conversation`, `previous_response_id`) and appends the incoming client
+//!   `input` to them. It is source-acquisition only.
+//! - [`prepare_agent_loop_input`] normalizes the combined transcript into an
+//!   upstream-consumable shape and records control signals (the set of
+//!   `mcp_list_tools` server labels already present in the transcript).
 
 use std::collections::HashSet;
 
 use axum::response::Response;
 use openai_protocol::{
     event_types::ItemType,
-    responses::{ResponseContentPart, ResponseInput, ResponseInputOutputItem, ResponsesRequest},
+    responses::{
+        normalize_input_item, ResponseContentPart, ResponseInput, ResponseInputOutputItem,
+        ResponsesRequest,
+    },
 };
 use serde_json::Value;
 use smg_data_connector::{ConversationId, ListParams, ResponseId, ResponseStorageError, SortOrder};
@@ -29,13 +39,26 @@ const MAX_CONVERSATION_HISTORY_ITEMS: usize = 100;
 
 pub(crate) struct LoadedInputHistory {
     pub previous_response_id: Option<String>,
+}
+
+/// Result of normalizing a Responses request transcript for the agent loop.
+///
+/// - `upstream_input` is the transcript in LLM-consumable form: message,
+///   reasoning, function_call, function_call_output, and approval items.
+/// - `existing_mcp_list_tools_labels` records server labels whose
+///   `mcp_list_tools` has already been surfaced in the transcript, so the
+///   loop can avoid re-emitting them.
+pub(crate) struct PreparedAgentLoopInput {
+    pub upstream_input: ResponseInput,
     pub existing_mcp_list_tools_labels: Vec<String>,
 }
 
 /// Load conversation history and/or previous response chain into request input.
 ///
-/// Mutates `request_body.input` with the loaded items.
-/// Returns `Ok(LoadedInputHistory)` on success, or `Err(response)` on validation failure.
+/// Mutates `request_body.input` with the loaded items. This function does
+/// source acquisition only — normalization (expanding `mcp_call` into
+/// function-call pairs, collecting `mcp_list_tools` labels, etc.) is the job
+/// of [`prepare_agent_loop_input`].
 pub(crate) async fn load_input_history(
     components: &ResponsesComponents,
     conversation: Option<&str>,
@@ -46,7 +69,6 @@ pub(crate) async fn load_input_history(
         .previous_response_id
         .take()
         .filter(|id| !id.is_empty());
-    let mut existing_mcp_list_tools_labels = HashSet::new();
 
     // Load items from previous response chain if specified
     let mut chain_items: Option<Vec<ResponseInputOutputItem>> = None;
@@ -58,12 +80,6 @@ pub(crate) async fn load_input_history(
             .await
         {
             Ok(chain) if !chain.responses.is_empty() => {
-                existing_mcp_list_tools_labels.extend(chain.responses.iter().flat_map(|stored| {
-                    extract_mcp_list_tools_labels(
-                        stored.raw_response.get("output").unwrap_or(&Value::Null),
-                    )
-                }));
-
                 let items: Vec<ResponseInputOutputItem> = chain
                     .responses
                     .iter()
@@ -234,8 +250,103 @@ pub(crate) async fn load_input_history(
 
     Ok(LoadedInputHistory {
         previous_response_id,
-        existing_mcp_list_tools_labels: existing_mcp_list_tools_labels.into_iter().collect(),
     })
+}
+
+/// Normalize a combined transcript into an upstream-consumable shape.
+///
+/// Called by the router after [`load_input_history`]. Both server-managed
+/// replay (via `previous_response_id` / `conversation`) and client-stitched
+/// `input` go through this single boundary.
+///
+/// Rules applied here:
+/// - `mcp_call` items are expanded into a `function_call` + `function_call_output`
+///   pair so the upstream model sees a replayable tool execution rather than
+///   a Responses-only wrapper that could be re-executed.
+/// - `mcp_list_tools` items are stripped from the upstream transcript — they
+///   are client-visible metadata, not LLM context — but their `server_label`
+///   is recorded so the loop can dedupe re-emission.
+/// - `SimpleInputMessage` is normalized to a full `Message` so downstream
+///   code sees a single shape.
+pub(crate) fn prepare_agent_loop_input(input: &ResponseInput) -> PreparedAgentLoopInput {
+    let items = match input {
+        ResponseInput::Text(_) => {
+            return PreparedAgentLoopInput {
+                upstream_input: input.clone(),
+                existing_mcp_list_tools_labels: Vec::new(),
+            };
+        }
+        ResponseInput::Items(items) => items,
+    };
+
+    let mut upstream_items = Vec::with_capacity(items.len());
+    let mut seen_labels: HashSet<String> = HashSet::new();
+    let mut existing_mcp_list_tools_labels = Vec::new();
+
+    for item in items {
+        match normalize_input_item(item) {
+            ResponseInputOutputItem::McpListTools { server_label, .. } => {
+                if seen_labels.insert(server_label.clone()) {
+                    existing_mcp_list_tools_labels.push(server_label);
+                }
+            }
+            ResponseInputOutputItem::McpCall {
+                id,
+                approval_request_id,
+                arguments,
+                name,
+                output,
+                error,
+                ..
+            } => {
+                let call_id = approval_request_id
+                    .as_deref()
+                    .map(approval_request_to_call_id)
+                    .unwrap_or_else(|| mcp_item_id_to_prefixed_id(&id, "call_"));
+                // A failed replayed call carries its diagnostic in `error`
+                // (with `output` often empty); surface it as the upstream
+                // function_call_output so the model sees the failure reason
+                // instead of a silently "successful" empty result.
+                let tool_output = error.unwrap_or(output);
+                upstream_items.push(ResponseInputOutputItem::FunctionToolCall {
+                    id: mcp_item_id_to_prefixed_id(&id, "fc_"),
+                    call_id: call_id.clone(),
+                    name,
+                    arguments,
+                    output: None,
+                    status: Some("completed".to_string()),
+                });
+                upstream_items.push(ResponseInputOutputItem::FunctionCallOutput {
+                    id: None,
+                    call_id,
+                    output: tool_output,
+                    status: Some("completed".to_string()),
+                });
+            }
+            normalized => upstream_items.push(normalized),
+        }
+    }
+
+    PreparedAgentLoopInput {
+        upstream_input: ResponseInput::Items(upstream_items),
+        existing_mcp_list_tools_labels,
+    }
+}
+
+/// Derive a `call_*` id from an `mcpr_*` approval-request id, preserving the
+/// suffix so the same correlation id flows through function-call replay.
+fn approval_request_to_call_id(approval_request_id: &str) -> String {
+    mcp_item_id_to_prefixed_id(approval_request_id, "call_")
+}
+
+/// Rewrite an MCP item id (`mcp_*` or `mcpr_*`) to an id with `prefix`,
+/// preserving the stable suffix so replayed items keep their correlation.
+fn mcp_item_id_to_prefixed_id(item_id: &str, prefix: &str) -> String {
+    let suffix = item_id
+        .strip_prefix("mcp_")
+        .or_else(|| item_id.strip_prefix("mcpr_"))
+        .unwrap_or(item_id);
+    format!("{prefix}{suffix}")
 }
 
 /// Deserialize ResponseInputOutputItems from a JSON array value
@@ -248,22 +359,6 @@ fn deserialize_items_from_array(array: &Value) -> Vec<ResponseInputOutputItem> {
                     serde_json::from_value::<ResponseInputOutputItem>(item.clone())
                         .map_err(|e| warn!("Failed to deserialize item: {}. Item: {}", e, item))
                         .ok()
-                })
-                .collect()
-        })
-        .unwrap_or_default()
-}
-
-fn extract_mcp_list_tools_labels(array: &Value) -> Vec<String> {
-    array
-        .as_array()
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|item| {
-                    (item.get("type").and_then(|t| t.as_str()) == Some(ItemType::MCP_LIST_TOOLS))
-                        .then(|| item.get("server_label").and_then(|v| v.as_str()))
-                        .flatten()
-                        .map(ToOwned::to_owned)
                 })
                 .collect()
         })
@@ -287,9 +382,7 @@ fn append_current_input(
             });
         }
         ResponseInput::Items(current_items) => {
-            for item in current_items {
-                items.push(openai_protocol::responses::normalize_input_item(item));
-            }
+            items.extend(current_items.iter().map(normalize_input_item));
         }
     }
 }
@@ -321,12 +414,246 @@ pub(crate) fn inject_memory_context(
 
 #[cfg(test)]
 mod tests {
-    use openai_protocol::responses::{ResponseInput, ResponsesRequest};
+    use openai_protocol::responses::{
+        ResponseContentPart, ResponseInput, ResponseInputOutputItem, ResponsesRequest,
+    };
 
-    use super::inject_memory_context;
+    use super::{inject_memory_context, prepare_agent_loop_input};
     use crate::routers::common::header_utils::{
         ConversationMemoryConfig, LongTermMemoryConfig, ShortTermMemoryConfig,
     };
+
+    /// Text input should pass through unchanged with no MCP labels recorded.
+    #[test]
+    fn prepare_agent_loop_input_passes_text_through() {
+        let prepared = prepare_agent_loop_input(&ResponseInput::Text("hello".to_string()));
+        match prepared.upstream_input {
+            ResponseInput::Text(text) => assert_eq!(text, "hello"),
+            ResponseInput::Items(_) => panic!("expected text input to remain text"),
+        }
+        assert!(prepared.existing_mcp_list_tools_labels.is_empty());
+    }
+
+    /// `mcp_call` must expand into a `function_call` + `function_call_output`
+    /// pair so the upstream transcript stays LLM-consumable. The correlation
+    /// id derived from `approval_request_id` (when present) or the `mcp_` id
+    /// must match on both items.
+    #[test]
+    fn prepare_agent_loop_input_expands_mcp_call_to_function_pair() {
+        let prepared = prepare_agent_loop_input(&ResponseInput::Items(vec![
+            ResponseInputOutputItem::Message {
+                id: "msg_1".to_string(),
+                role: "user".to_string(),
+                content: vec![ResponseContentPart::InputText {
+                    text: "find something".to_string(),
+                }],
+                status: None,
+                phase: None,
+            },
+            ResponseInputOutputItem::McpCall {
+                id: "mcp_abc".to_string(),
+                server_label: "deepwiki".to_string(),
+                name: "ask_question".to_string(),
+                arguments: "{\"q\":\"x\"}".to_string(),
+                output: "answer".to_string(),
+                status: "completed".to_string(),
+                approval_request_id: None,
+                error: None,
+            },
+        ]));
+
+        let ResponseInput::Items(items) = prepared.upstream_input else {
+            panic!("expected items upstream input");
+        };
+        assert_eq!(items.len(), 3, "expected message + function pair");
+
+        match (&items[1], &items[2]) {
+            (
+                ResponseInputOutputItem::FunctionToolCall {
+                    call_id: call_a,
+                    name,
+                    arguments,
+                    ..
+                },
+                ResponseInputOutputItem::FunctionCallOutput {
+                    call_id: call_b,
+                    output,
+                    ..
+                },
+            ) => {
+                assert_eq!(call_a, call_b, "call_id must pair the two items");
+                assert_eq!(call_a, "call_abc");
+                assert_eq!(name, "ask_question");
+                assert_eq!(arguments, "{\"q\":\"x\"}");
+                assert_eq!(output, "answer");
+            }
+            other => panic!("unexpected normalized pair: {other:?}"),
+        }
+    }
+
+    /// A failed replayed `mcp_call` carries its diagnostic in `error` with
+    /// `output` often empty; the normalized `function_call_output` must
+    /// surface that diagnostic so the upstream model sees the failure reason
+    /// rather than a silently "successful" empty tool result.
+    #[test]
+    fn prepare_agent_loop_input_folds_mcp_call_error_into_upstream_output() {
+        let prepared = prepare_agent_loop_input(&ResponseInput::Items(vec![
+            ResponseInputOutputItem::Message {
+                id: "msg_1".to_string(),
+                role: "user".to_string(),
+                content: vec![ResponseContentPart::InputText {
+                    text: "find something".to_string(),
+                }],
+                status: None,
+                phase: None,
+            },
+            ResponseInputOutputItem::McpCall {
+                id: "mcp_abc".to_string(),
+                server_label: "deepwiki".to_string(),
+                name: "ask_question".to_string(),
+                arguments: "{}".to_string(),
+                output: String::new(),
+                status: "failed".to_string(),
+                approval_request_id: None,
+                error: Some("upstream 5xx".to_string()),
+            },
+        ]));
+
+        let ResponseInput::Items(items) = prepared.upstream_input else {
+            panic!("expected items upstream input");
+        };
+        match &items[2] {
+            ResponseInputOutputItem::FunctionCallOutput { output, .. } => {
+                assert_eq!(output, "upstream 5xx");
+            }
+            other => panic!("expected FunctionCallOutput, got {other:?}"),
+        }
+    }
+
+    /// When an `mcp_call` was resumed from approval, its correlation id comes
+    /// from `approval_request_id` (`mcpr_*`) so later turns can still match
+    /// the originating approval request against the executed call.
+    #[test]
+    fn prepare_agent_loop_input_reuses_approval_request_id_for_call_id() {
+        let prepared = prepare_agent_loop_input(&ResponseInput::Items(vec![
+            ResponseInputOutputItem::Message {
+                id: "msg_1".to_string(),
+                role: "user".to_string(),
+                content: vec![ResponseContentPart::InputText {
+                    text: "continue".to_string(),
+                }],
+                status: None,
+                phase: None,
+            },
+            ResponseInputOutputItem::McpCall {
+                id: "mcp_resumed".to_string(),
+                server_label: "docs".to_string(),
+                name: "search".to_string(),
+                arguments: "{}".to_string(),
+                output: "ok".to_string(),
+                status: "completed".to_string(),
+                approval_request_id: Some("mcpr_xyz".to_string()),
+                error: None,
+            },
+        ]));
+
+        let ResponseInput::Items(items) = prepared.upstream_input else {
+            panic!("expected items upstream input");
+        };
+        match &items[1] {
+            ResponseInputOutputItem::FunctionToolCall { call_id, .. } => {
+                assert_eq!(call_id, "call_xyz");
+            }
+            other => panic!("expected FunctionToolCall, got {other:?}"),
+        }
+    }
+
+    /// `mcp_list_tools` items are client-visible metadata, not LLM context.
+    /// They must be stripped from the upstream transcript and their
+    /// `server_label` recorded for dedupe on output assembly.
+    #[test]
+    fn prepare_agent_loop_input_collects_list_tools_labels() {
+        let prepared = prepare_agent_loop_input(&ResponseInput::Items(vec![
+            ResponseInputOutputItem::Message {
+                id: "msg_1".to_string(),
+                role: "user".to_string(),
+                content: vec![ResponseContentPart::InputText {
+                    text: "hi".to_string(),
+                }],
+                status: None,
+                phase: None,
+            },
+            ResponseInputOutputItem::McpListTools {
+                id: "mcpl_1".to_string(),
+                server_label: "deepwiki".to_string(),
+                tools: vec![],
+            },
+            ResponseInputOutputItem::McpListTools {
+                id: "mcpl_2".to_string(),
+                server_label: "deepwiki".to_string(),
+                tools: vec![],
+            },
+            ResponseInputOutputItem::McpListTools {
+                id: "mcpl_3".to_string(),
+                server_label: "docs".to_string(),
+                tools: vec![],
+            },
+        ]));
+
+        let ResponseInput::Items(items) = prepared.upstream_input else {
+            panic!("expected items upstream input");
+        };
+        assert_eq!(
+            items.len(),
+            1,
+            "mcp_list_tools items must not be sent upstream"
+        );
+        assert_eq!(
+            prepared.existing_mcp_list_tools_labels,
+            vec!["deepwiki".to_string(), "docs".to_string()],
+            "labels should be deduped in first-seen order",
+        );
+    }
+
+    /// Approval items are passed through to the upstream transcript so OpenAI
+    /// can match an `mcp_approval_response` against its originating
+    /// `mcp_approval_request` and resume execution.
+    #[test]
+    fn prepare_agent_loop_input_preserves_approval_items_in_upstream() {
+        let prepared = prepare_agent_loop_input(&ResponseInput::Items(vec![
+            ResponseInputOutputItem::Message {
+                id: "msg_1".to_string(),
+                role: "user".to_string(),
+                content: vec![ResponseContentPart::InputText {
+                    text: "hi".to_string(),
+                }],
+                status: None,
+                phase: None,
+            },
+            ResponseInputOutputItem::McpApprovalRequest {
+                id: "mcpr_1".to_string(),
+                server_label: "docs".to_string(),
+                name: "search".to_string(),
+                arguments: "{}".to_string(),
+            },
+            ResponseInputOutputItem::McpApprovalResponse {
+                id: None,
+                approval_request_id: "mcpr_1".to_string(),
+                approve: true,
+                reason: None,
+            },
+        ]));
+
+        let ResponseInput::Items(items) = prepared.upstream_input else {
+            panic!("expected items upstream input");
+        };
+        assert!(items
+            .iter()
+            .any(|item| matches!(item, ResponseInputOutputItem::McpApprovalRequest { .. })),);
+        assert!(items
+            .iter()
+            .any(|item| matches!(item, ResponseInputOutputItem::McpApprovalResponse { .. })),);
+    }
 
     #[test]
     fn inject_memory_context_is_no_op_for_now() {

--- a/model_gateway/src/routers/openai/responses/non_streaming.rs
+++ b/model_gateway/src/routers/openai/responses/non_streaming.rs
@@ -39,6 +39,7 @@ pub async fn handle_non_streaming_response(mut ctx: RequestContext) -> Response 
     } = payload_state;
     let ResponsesPayloadState {
         previous_response_id,
+        upstream_input,
         existing_mcp_list_tools_labels,
     } = ctx.take_responses_payload().unwrap_or_default();
 
@@ -48,6 +49,7 @@ pub async fn handle_non_streaming_response(mut ctx: RequestContext) -> Response 
             return error::internal_error("internal_error", "Expected responses request");
         }
     };
+    let upstream_input = upstream_input.unwrap_or_else(|| original_body.input.clone());
     let worker = match ctx.worker() {
         Some(w) => w.clone(),
         None => {
@@ -89,6 +91,7 @@ pub async fn handle_non_streaming_response(mut ctx: RequestContext) -> Response 
             payload,
             ToolLoopExecutionContext {
                 original_body,
+                upstream_input: &upstream_input,
                 existing_mcp_list_tools_labels: &existing_mcp_list_tools_labels,
                 session: &session,
             },

--- a/model_gateway/src/routers/openai/responses/route.rs
+++ b/model_gateway/src/routers/openai/responses/route.rs
@@ -132,10 +132,14 @@ pub(in crate::routers::openai) async fn route_responses(
         super::history::inject_memory_context(&memory_config, &mut request_body);
     }
 
+    let prepared = super::history::prepare_agent_loop_input(&request_body.input);
+    request_body.input = prepared.upstream_input;
+
     request_body.store = Some(false);
     if let ResponseInput::Items(ref mut items) = request_body.input {
         items.retain(|item| !matches!(item, ResponseInputOutputItem::Reasoning { .. }));
     }
+    let upstream_input = request_body.input.clone();
 
     let mut payload = match to_value(&request_body) {
         Ok(v) => v,
@@ -168,8 +172,17 @@ pub(in crate::routers::openai) async fn route_responses(
         return error::bad_request("invalid_request", format!("Provider transform error: {e}"));
     }
 
+    // `ctx.responses_request()` must stay as the caller's request so
+    // persistence stores only this turn's input and metadata patching keeps the
+    // original conversation / previous_response_id semantics. The normalized
+    // upstream transcript is carried separately in `ResponsesPayloadState` for
+    // the tool loop's resume payload assembly.
+    let mut context_body = body.clone();
+    context_body.model = model_id.to_string();
+    context_body.previous_response_id = loaded_history.previous_response_id.clone();
+
     let mut ctx = RequestContext::for_responses(
-        Arc::new(body.clone()),
+        Arc::new(context_body),
         headers.cloned(),
         Some(model_id.to_string()),
         ComponentRefs::Responses(Arc::clone(deps.responses_components)),
@@ -188,7 +201,8 @@ pub(in crate::routers::openai) async fn route_responses(
     });
     ctx.state.responses_payload = Some(ResponsesPayloadState {
         previous_response_id: loaded_history.previous_response_id,
-        existing_mcp_list_tools_labels: loaded_history.existing_mcp_list_tools_labels,
+        upstream_input: Some(upstream_input),
+        existing_mcp_list_tools_labels: prepared.existing_mcp_list_tools_labels,
     });
 
     let response = if ctx.is_streaming() {

--- a/model_gateway/src/routers/openai/responses/streaming.rs
+++ b/model_gateway/src/routers/openai/responses/streaming.rs
@@ -674,6 +674,7 @@ pub(super) fn handle_streaming_with_tool_interception(
     let should_store = req.original_body.store.unwrap_or(true);
     let original_request = req.original_body;
     let previous_response_id = req.previous_response_id;
+    let upstream_input = req.upstream_input;
     let existing_mcp_list_tools_labels = req.existing_mcp_list_tools_labels;
     let url = req.url;
     let storage = req.storage;
@@ -689,10 +690,7 @@ pub(super) fn handle_streaming_with_tool_interception(
         reason = "fire-and-forget MCP tool loop; gateway shutdown need not wait for individual tool loops"
     )]
     tokio::spawn(async move {
-        let mut state = ToolLoopState::new(
-            original_request.input.clone(),
-            existing_mcp_list_tools_labels,
-        );
+        let mut state = ToolLoopState::new(upstream_input, existing_mcp_list_tools_labels);
         let max_tool_calls = original_request.max_tool_calls.map(|n| n as usize);
 
         // Create session inside spawned task (borrows from orchestrator_clone which lives in closure)

--- a/model_gateway/tests/api/responses_api_test.rs
+++ b/model_gateway/tests/api/responses_api_test.rs
@@ -660,18 +660,28 @@ async fn test_previous_response_id_does_not_repeat_mcp_list_tools_for_existing_b
     let output = body2_json["output"]
         .as_array()
         .expect("response output missing");
-    assert_eq!(
-        output.len(),
-        2,
-        "resume turn should return only current-turn MCP activity plus the final message: {body2_json}",
-    );
-    assert_eq!(output[0]["type"], "mcp_call");
-    assert_eq!(output[1]["type"], "message");
+    // Prior `mcp_call` history is normalized into `function_call` +
+    // `function_call_output` on the upstream transcript, so the mock model
+    // sees the prior tool result and does not re-execute the tool on resume.
+    // The invariant tested here is that `mcp_list_tools` is not repeated on a
+    // `previous_response_id` continuation for an existing binding.
     assert!(
         output
             .iter()
             .all(|item| item.get("type").and_then(|v| v.as_str()) != Some("mcp_list_tools")),
-        "existing bindings should not repeat mcp_list_tools on previous_response_id turns"
+        "existing bindings should not repeat mcp_list_tools on previous_response_id turns: {body2_json}"
+    );
+    assert!(
+        output
+            .iter()
+            .all(|item| item.get("type").and_then(|v| v.as_str()) != Some("mcp_call")),
+        "resume turn must consume the prior tool result without re-executing the MCP tool: {body2_json}"
+    );
+    assert!(
+        output
+            .iter()
+            .any(|item| item.get("type").and_then(|v| v.as_str()) == Some("message")),
+        "resume turn should still produce a final assistant message: {body2_json}"
     );
 
     worker.stop().await;

--- a/model_gateway/tests/routing/test_openai_routing.rs
+++ b/model_gateway/tests/routing/test_openai_routing.rs
@@ -283,7 +283,7 @@ async fn test_openai_router_responses_with_mock() {
     };
 
     let response3 = router
-        .route_responses(None, &request3, &request3.model)
+        .route_responses(None, &tenant_meta, &request3, &request3.model)
         .await;
     assert_eq!(response3.status(), StatusCode::OK);
     let body3_bytes = axum::body::to_bytes(response3.into_body(), usize::MAX)
@@ -307,6 +307,7 @@ async fn test_openai_router_responses_with_mock() {
     let empty_previous_response = router
         .route_responses(
             None,
+            &tenant_meta,
             &empty_previous_response_request,
             &empty_previous_response_request.model,
         )

--- a/model_gateway/tests/routing/test_openai_routing.rs
+++ b/model_gateway/tests/routing/test_openai_routing.rs
@@ -268,10 +268,63 @@ async fn test_openai_router_responses_with_mock() {
         .await
         .unwrap();
     let body2: serde_json::Value = serde_json::from_slice(&body2_bytes).unwrap();
-    let resp2_id = body2["id"].as_str().expect("second id missing");
+    let resp2_id = body2["id"].as_str().expect("second id missing").to_string();
     assert_eq!(
         body2["previous_response_id"].as_str(),
         Some(resp1_id.as_str())
+    );
+
+    let request3 = ResponsesRequest {
+        model: "gpt-4o-mini".to_string(),
+        input: ResponseInput::Text("Bye".to_string()),
+        store: Some(true),
+        previous_response_id: Some(resp2_id.clone()),
+        ..Default::default()
+    };
+
+    let response3 = router
+        .route_responses(None, &request3, &request3.model)
+        .await;
+    assert_eq!(response3.status(), StatusCode::OK);
+    let body3_bytes = axum::body::to_bytes(response3.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let body3: serde_json::Value = serde_json::from_slice(&body3_bytes).unwrap();
+    let resp3_id = body3["id"].as_str().expect("third id missing").to_string();
+    assert_eq!(
+        body3["previous_response_id"].as_str(),
+        Some(resp2_id.as_str())
+    );
+
+    let empty_previous_response_request = ResponsesRequest {
+        model: "gpt-4o-mini".to_string(),
+        input: ResponseInput::Text("Empty previous response id".to_string()),
+        store: Some(true),
+        previous_response_id: Some(String::new()),
+        ..Default::default()
+    };
+
+    let empty_previous_response = router
+        .route_responses(
+            None,
+            &empty_previous_response_request,
+            &empty_previous_response_request.model,
+        )
+        .await;
+    assert_eq!(empty_previous_response.status(), StatusCode::OK);
+    let empty_prev_body_bytes =
+        axum::body::to_bytes(empty_previous_response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+    let empty_prev_body: serde_json::Value =
+        serde_json::from_slice(&empty_prev_body_bytes).unwrap();
+    let empty_prev_resp_id = empty_prev_body["id"]
+        .as_str()
+        .expect("empty-prev response id missing")
+        .to_string();
+    assert_eq!(
+        empty_prev_body["previous_response_id"],
+        serde_json::Value::Null
     );
 
     let stored1 = storage
@@ -279,13 +332,42 @@ async fn test_openai_router_responses_with_mock() {
         .await
         .unwrap()
         .expect("first response missing");
-    // Input is now stored as a JSON array of items
-    assert!(stored1.input.is_array());
-    let input_items = stored1.input.as_array().unwrap();
-    assert_eq!(input_items.len(), 1);
-    assert_eq!(input_items[0]["type"], "message");
-    assert_eq!(input_items[0]["role"], "user");
-    assert_eq!(input_items[0]["content"][0]["text"], "Say hi");
+    let stored2 = storage
+        .get_response(&ResponseId::from(resp2_id.clone()))
+        .await
+        .unwrap()
+        .expect("second response missing");
+    let stored3 = storage
+        .get_response(&ResponseId::from(resp3_id.clone()))
+        .await
+        .unwrap()
+        .expect("third response missing");
+    let stored_empty_prev = storage
+        .get_response(&ResponseId::from(empty_prev_resp_id.clone()))
+        .await
+        .unwrap()
+        .expect("empty-prev response missing");
+
+    let assert_single_turn_input =
+        |stored: &StoredResponse, expected_text: &str, expected_prev: Option<&str>| {
+            let input_items = stored
+                .input
+                .as_array()
+                .expect("stored input should be an array");
+            assert_eq!(input_items.len(), 1);
+            assert_eq!(input_items[0]["type"], "message");
+            assert_eq!(input_items[0]["role"], "user");
+            assert_eq!(input_items[0]["content"][0]["text"], expected_text);
+            assert_eq!(
+                stored.previous_response_id.as_ref().map(|id| id.0.as_str()),
+                expected_prev
+            );
+        };
+
+    assert_single_turn_input(&stored1, "Say hi", None);
+    assert_single_turn_input(&stored2, "Thanks", Some(resp1_id.as_str()));
+    assert_single_turn_input(&stored3, "Bye", Some(resp2_id.as_str()));
+    assert_single_turn_input(&stored_empty_prev, "Empty previous response id", None);
 
     // Output is now stored in raw_response["output"] as a JSON array of items
     let output_val = &stored1.raw_response["output"];
@@ -294,15 +376,6 @@ async fn test_openai_router_responses_with_mock() {
     assert_eq!(output_items.len(), 1);
     assert_eq!(output_items[0]["content"][0]["text"], "mock_output_1");
 
-    assert!(stored1.previous_response_id.is_none());
-
-    let stored2 = storage
-        .get_response(&ResponseId::from(resp2_id))
-        .await
-        .unwrap()
-        .expect("second response missing");
-    assert_eq!(stored2.previous_response_id.unwrap().0, resp1_id);
-
     // Output is now stored in raw_response["output"] as a JSON array
     let output_val2 = &stored2.raw_response["output"];
     assert!(output_val2.is_array());
@@ -310,8 +383,16 @@ async fn test_openai_router_responses_with_mock() {
     assert_eq!(output_items2.len(), 1);
     assert_eq!(output_items2[0]["content"][0]["text"], "mock_output_2");
 
+    let output_val3 = &stored3.raw_response["output"];
+    assert!(output_val3.is_array());
+    let output_items3 = output_val3.as_array().unwrap();
+    assert_eq!(output_items3.len(), 1);
+    assert_eq!(output_items3[0]["content"][0]["text"], "mock_output_3");
+
     assert_eq!(stored1.raw_response, body1);
     assert_eq!(stored2.raw_response, body2);
+    assert_eq!(stored3.raw_response, body3);
+    assert_eq!(stored_empty_prev.raw_response, empty_prev_body);
 
     server.abort();
 }


### PR DESCRIPTION
Parent: #1316
Closes #1317

## Description

### Problem

Responses-side agentic control flow in SMG is spread across layers:

- The OpenAI Responses router (streaming + non-streaming), the gRPC regular Responses router, and the gRPC harmony Responses router each decide loop entry *outside* the loop — branching on "does this request carry MCP tools?" before calling surface-specific tool loops.
- Each surface re-implements history loading, upstream request rebuilding, final response assembly, persistence, and streaming completion handling.
- Three representations bleed together without explicit boundaries: the client-facing `ResponsesRequest` / `ResponsesResponse`, the upstream model payload, and the stored response chain used by `previous_response_id`.
- As a result, behaviors like approval continuation tend to be added as new loop-external patch points instead of extensions of one explicit state machine. The mismatch also causes observable parity drift against OpenAI — e.g. `previous_response_id` replay currently drops `mcp_list_tools` / `mcp_call` items (they fail to deserialize as input) and downstream MCP calls get re-executed.

### Solution

Introduce one shared agent loop used by every Responses surface. The loop decides the next action from state (`CallLlm` / `ExecuteTools` / `InterruptForApproval` / `Finish`). Every request enters the loop, even one with no MCP tools — it simply never produces an `ExecuteTools` action.

The plan formalizes three representation boundaries — the client-facing `ResponsesRequest` / `ResponsesResponse`, the canonical loop transcript, and the provider-specific upstream payload — and a surface-adapter contract covering history preparation, upstream request construction, turn ingestion, and final / interrupt / streaming rendering. MCP session state, `mcp_list_tools` emission dedupe, pending tool batches, approval interrupts, and `max_tool_calls` accounting all live on the loop state rather than being rediscovered at each patch point.

**This design has already been implemented end-to-end once** as a working prototype, with contract-level OpenAI parity checks for non-streaming and streaming MCP flows including approval interrupts. The expected outcome of the staged series below is to re-land that proven design on `main` in small, reviewable pieces without regressing anything along the way.

Staged PRs:

- **PR1 (this PR) — Canonical input preparation for OpenAI Responses.** Split history acquisition from normalization; accept input-side MCP trace items; upstream transcript is always LLM-consumable.
- PR2 — OpenAI non-streaming agent loop. Move to the `NextAction` driver; `previous_response_id` stops changing loop behavior after preparation; continuation is a loop transition, not a side path.
- PR3 — OpenAI streaming agent loop + stream sink. Same driver as non-streaming; `response.completed` assembled from loop state; sibling buffering for mixed gateway + user function calls.
- PR4 — OpenAI streaming approval parity. Streaming interrupt emits `mcp_approval_request` → `output_item.done` → `response.completed` → `[DONE]`; approved continuation obeys the same budget/error behavior as non-streaming.
- PR5 — Shared MCP presentation + visibility boundary. Centralize builtin `ResponseFormat` presentation and internal/hidden MCP filtering across streaming + non-streaming.
- PR6 — Extract `routers/common/agent_loop`. Move the OpenAI-proven abstractions behind a shared adapter trait.
- PR7 — Harmony adapter migration.
- PR8 — Regular (Chat-adapter) adapter migration.
- PR9 — Approval continuation generalization across surfaces.

## Changes

Scope of this PR: OpenAI Responses only; history loading + input normalization only. **Out of scope** (deferred to later PRs): `NextAction` loop driver, streaming loop rewrite, new approval workflow behavior.

- Protocol (`crates/protocols/src/responses.rs`): add `McpListTools` and `McpCall` as `ResponseInputOutputItem` variants. Structural validation only — continuation-specific semantics (e.g. pairing an approval response with its originating request) are left to the loop-entry layer in PR2.
- `model_gateway/src/routers/openai/responses/history.rs`:
  - `load_input_history` now does source acquisition only — it fetches `previous_response_id` / `conversation` history and appends client `input`; no label extraction, no normalization.
  - New `prepare_agent_loop_input` is the single transcript-normalization boundary. It expands `mcp_call` into `function_call` + `function_call_output` so the upstream model sees a replayable tool execution, strips `mcp_list_tools` from the upstream transcript while recording its `server_label` for dedupe, and passes approval items through unchanged so the existing approval continuation flow (merged in #1174) keeps working.
- `model_gateway/src/routers/openai/responses/route.rs`: calls the new preparation step between `load_input_history` and upstream request build; populates `ResponsesPayloadState.existing_mcp_list_tools_labels` from the preparation output.
- Touch-ups: exhaustive matchers in `grpc/harmony/builder.rs`, `grpc/regular/responses/conversions.rs`, and `model_gateway/benches/routing_allocation_bench.rs` include the two new enum variants (no behavior change).
- Updated `test_previous_response_id_does_not_repeat_mcp_list_tools_for_existing_binding` in `tests/api/responses_api_test.rs`: previously asserted the pre-normalization behavior where replay dropped MCP items and the mock had to re-execute the tool; now asserts the invariant — no repeated `mcp_list_tools` on a `previous_response_id` continuation for an existing binding, and a final `message` is still produced.

## Test Plan

Automated — all green:

```bash
cargo test -p openai-protocol --tests                                   # 43 pass (+2 new)
cargo test --lib --package smg routers::openai::responses::             # 24 pass (+5 new)
cargo test --test api_tests -- responses                                # 33 pass
pre-commit run --all-files                                              # 17 hooks green
```

New tests:

- `crates/protocols/tests/responses.rs::response_input_accepts_mcp_trace_items` — protocol accepts `mcp_list_tools` and `mcp_call` as input items.
- `crates/protocols/tests/responses.rs::mcp_call_input_omits_optional_fields_when_unset` — `approval_request_id` / `error` omitted on serialize when `None`.
- `openai::responses::history::tests::prepare_agent_loop_input_passes_text_through` — text input identity.
- `…::prepare_agent_loop_input_expands_mcp_call_to_function_pair` — `mcp_call` → paired `function_call` + `function_call_output` with matching `call_id`.
- `…::prepare_agent_loop_input_reuses_approval_request_id_for_call_id` — resumed call derives its `call_id` from the originating `mcpr_*`.
- `…::prepare_agent_loop_input_collects_list_tools_labels` — `mcp_list_tools` stripped from upstream, `server_label`s deduped in first-seen order.
- `…::prepare_agent_loop_input_preserves_approval_items_in_upstream` — approval items pass through so existing continuation keeps working.

Manual OpenAI parity — same style as PR #1174's test plan. Launched local `smg` in IGW mode and registered the upstream OpenAI worker:

```bash
cargo run --bin smg -- --enable-igw --port 9999

curl -X POST http://127.0.0.1:9999/workers \
  -H 'Content-Type: application/json' \
  -d '{"url":"https://api.openai.com","api_key":"<OPENAI_API_KEY>","runtime":"external","disable_health_check":true}'
```

Five scenarios exercised end-to-end against real OpenAI, all behaving as expected:

1. **Plain non-MCP request** (`gpt-5.4`, text input) — completes with a single `message`.
2. **MCP request** (`deepwiki`, `require_approval: never`) — output order: `mcp_list_tools` → `mcp_call` → (optional second `mcp_call`) → `message`.
3. **Stitched MCP input — the headline PR1 case.** `input` carries `message` + `mcp_list_tools` + `mcp_call` (with a canned tool result) + assistant message + new user message. Upstream sees the tool result normalized into `function_call` + `function_call_output` and answers directly without re-executing the tool; response output is a single `message` containing the summarized answer. Without this PR the stitched MCP items fail to deserialize on the input side and the tool gets re-executed.
4. **`previous_response_id` follow-up** (after a stored MCP turn) — response has no repeated `mcp_list_tools`, no `mcp_call`, just a final `message` that reuses the tool result from the stored transcript.
5. **Mixed approval** (`deepwiki: never` + `openai-developer-docs: always`) — output: two `mcp_list_tools`, deepwiki `mcp_call`, terminates at `mcp_approval_request` exactly as PR #1174 specified. Confirms the existing approval interrupt path is untouched.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated — the shared-loop design doc will land on `main` with the router-common extraction PR.
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Capture MCP tool listings and tool-call results in conversation transcripts.

* **Improvements**
  * Normalize MCP trace items before upstream routing: listings are stripped from prompt text and calls are expanded into correlated tool-call + output pairs.
  * MCP trace items are treated as non-text for routing and omitted from generated chat/harmony messages.
  * Preserve normalized upstream input for tool loops and resume flows.

* **Tests**
  * Added serialization, normalization, routing, and resume behavior tests for MCP traces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->