### PR TITLE
test(embeddings): enable sglang embedding correctness on h100

### DIFF
--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -505,7 +505,7 @@ jobs:
     with:
       engine: ${{ matrix.engine }}
       gpu_tier: "1"
-      runner: 1-gpu
+      runner: 1-gpu-h100
       timeout: ${{ matrix.timeout }}
       test_dirs: e2e_test/embeddings
       extra_deps: "sentence-transformers"

--- a/e2e_test/embeddings/test_correctness.py
+++ b/e2e_test/embeddings/test_correctness.py
@@ -209,7 +209,6 @@ def hf_reference_embeddings(request):
 
 
 @pytest.mark.engine("sglang", "vllm")
-@pytest.mark.skip_for_runtime("sglang", reason="sglang embedding output diverges from HF reference")
 @pytest.mark.gpu(1)
 @pytest.mark.model("intfloat/e5-mistral-7b-instruct")
 @pytest.mark.e2e


### PR DESCRIPTION
## Description

### Problem

Two things prevent the sglang embedding correctness check from actually running:

1. `e2e-1gpu-embeddings` is pinned to the `1-gpu` runner pool, while `e2e-1gpu-completions` already runs on `1-gpu-h100`.
2. `TestEmbeddingCorrectness` carries a `skip_for_runtime("sglang", reason="sglang embedding output diverges from HF reference")` mark, so the sglang side of the comparison never executes.

### Solution

Move the embeddings job onto H100 nodes and drop the sglang skip so the gateway-vs-HF reference comparison runs end-to-end on sglang.

## Changes

- `.github/workflows/pr-test-rust.yml`: `e2e-1gpu-embeddings` runner `1-gpu` → `1-gpu-h100`.
- `e2e_test/embeddings/test_correctness.py`: remove `@pytest.mark.skip_for_runtime("sglang", ...)` on `TestEmbeddingCorrectness`.

## Test Plan

- [ ] CI on this PR runs `e2e-1gpu-embeddings (sglang)` on the `1-gpu-h100` pool.
- [ ] `TestEmbeddingCorrectness` executes for both `sglang` and `vllm` engines (no longer reported as skipped for sglang).
- [ ] If the sglang correctness assertion fails, the failure surfaces here rather than being silently skipped.

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes (N/A — no Rust changes)
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes (N/A — no Rust changes)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enabled embedding correctness validation tests that were previously skipped, improving test coverage and ensuring consistent embedding output quality across supported inference engines.

* **Chores**
  * Updated CI infrastructure and test runner specifications to use optimized GPU execution environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->