### PR TITLE
fix(metrics): add path label to HTTP response metrics

### DIFF
--- a/docs/getting-started/monitoring.md
+++ b/docs/getting-started/monitoring.md
@@ -129,7 +129,7 @@ spec:
 |--------|------|-------------|
 | `smg_http_requests_total` | Counter | Requests by method, path |
 | `smg_http_request_duration_seconds` | Histogram | Request latency |
-| `smg_http_responses_total` | Counter | Responses by status_code, error_code |
+| `smg_http_responses_total` | Counter | Responses by path, status_code, error_code |
 | `smg_http_connections_active` | Gauge | Active connections |
 | `smg_http_rate_limit_total` | Counter | Rate limit decisions |
 
@@ -182,6 +182,12 @@ histogram_quantile(0.99, rate(smg_http_request_duration_seconds_bucket[5m]))
 ```promql
 sum(rate(smg_http_responses_total{status_code=~"5.."}[5m]))
 / sum(rate(smg_http_responses_total[5m]))
+```
+
+**`/v1/responses` Success Rate**
+```promql
+sum(rate(smg_http_responses_total{path="/v1/responses",status_code=~"2.."}[5m]))
+/ sum(rate(smg_http_responses_total{path="/v1/responses"}[5m]))
 ```
 
 **Time to First Token (TTFT)**

--- a/docs/getting-started/monitoring.md
+++ b/docs/getting-started/monitoring.md
@@ -185,6 +185,7 @@ sum(rate(smg_http_responses_total{status_code=~"5.."}[5m]))
 ```
 
 **`/v1/responses` Success Rate**
+
 ```promql
 sum(rate(smg_http_responses_total{path="/v1/responses",status_code=~"2.."}[5m]))
 / sum(rate(smg_http_responses_total{path="/v1/responses"}[5m]))

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -69,11 +69,11 @@ rate(smg_http_request_duration_seconds_sum[5m]) / rate(smg_http_request_duration
 
 ### `smg_http_responses_total`
 
-HTTP responses by status and error code.
+HTTP responses by path, status, and error code.
 
 | Type | Labels |
 |------|--------|
-| Counter | `status_code`, `error_code` |
+| Counter | `path`, `status_code`, `error_code` |
 
 ```promql
 # Error rate (5xx responses)
@@ -81,6 +81,11 @@ sum(rate(smg_http_responses_total{status_code=~"5.."}[5m])) / sum(rate(smg_http_
 
 # Success rate
 sum(rate(smg_http_responses_total{status_code="200"}[5m])) / sum(rate(smg_http_responses_total[5m]))
+
+# Success rate for /v1/responses
+sum(rate(smg_http_responses_total{path="/v1/responses",status_code=~"2.."}[5m]))
+/
+sum(rate(smg_http_responses_total{path="/v1/responses"}[5m]))
 ```
 
 ---

--- a/model_gateway/src/middleware/logging.rs
+++ b/model_gateway/src/middleware/logging.rs
@@ -12,12 +12,9 @@ use tracing::{error, field::Empty, info, info_span, warn, Span};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 use super::{metrics::normalize_path_for_metrics, request_id::RequestId};
-use crate::{
-    observability::{
-        metrics::{method_to_static_str, Metrics},
-        otel_trace::extract_trace_context_http,
-    },
-    routers::error::extract_error_code_from_response,
+use crate::observability::{
+    metrics::{method_to_static_str, Metrics},
+    otel_trace::extract_trace_context_http,
 };
 
 /// Custom span maker that includes request ID
@@ -84,11 +81,6 @@ impl<B> OnResponse<B> for ResponseLogger {
     fn on_response(self, response: &Response<B>, latency: Duration, span: &Span) {
         let status = response.status();
         let status_code = status.as_u16();
-
-        let error_code = extract_error_code_from_response(response);
-
-        // Layer 1: HTTP metrics
-        Metrics::record_http_response(status_code, error_code);
 
         // Record these in the span for structured logging/observability tools
         span.record("status_code", status_code);

--- a/model_gateway/src/middleware/metrics.rs
+++ b/model_gateway/src/middleware/metrics.rs
@@ -15,9 +15,12 @@ use std::{
 use axum::{extract::Request, response::Response};
 use tower::{Layer, Service};
 
-use crate::observability::{
-    inflight_tracker::InFlightRequestTracker,
-    metrics::{method_to_static_str, Metrics},
+use crate::{
+    observability::{
+        inflight_tracker::InFlightRequestTracker,
+        metrics::{method_to_static_str, Metrics},
+    },
+    routers::error::extract_error_code_from_response,
 };
 
 /// Tower Layer for HTTP metrics collection (SMG Layer 1 metrics)
@@ -86,6 +89,11 @@ where
             let response = result?;
 
             let duration = start.elapsed();
+            Metrics::record_http_response(
+                &path,
+                response.status().as_u16(),
+                extract_error_code_from_response(&response),
+            );
             Metrics::record_http_duration(method, &path, duration);
 
             Ok(response)

--- a/model_gateway/src/observability/metrics.rs
+++ b/model_gateway/src/observability/metrics.rs
@@ -162,7 +162,7 @@ pub(crate) fn init_metrics() {
     );
     describe_counter!(
         "smg_http_responses_total",
-        "Total HTTP responses by status_code and error_code"
+        "Total HTTP responses by path, status_code and error_code"
     );
     describe_gauge!(
         "smg_http_connections_active",
@@ -516,11 +516,13 @@ impl Metrics {
     }
 
     /// Record HTTP response.
-    pub fn record_http_response(status_code: u16, error_code: &str) {
+    pub fn record_http_response(path: &str, status_code: u16, error_code: &str) {
+        let path_interned = intern_string(path);
         let status_str: Cow<'static, str> = status_code_to_cow(status_code);
         let error_interned = intern_string(error_code);
         counter!(
             "smg_http_responses_total",
+            "path" => path_interned,
             "status_code" => status_str,
             "error_code" => error_interned
         )


### PR DESCRIPTION
## Description

### Problem

`/v1/responses` success rate could not be computed from the existing HTTP metrics.

The main issue was that `smg_http_requests_total` already exposed a normalized `path` label, but `smg_http_responses_total` only exposed `status_code` and `error_code`. That meant we could count requests for `/v1/responses`, and we could count responses globally, but we could not slice response outcomes on the same path dimension to build a correct numerator and denominator for a `/v1/responses` success-rate query.

Existing error-count metrics were not a reliable substitute:

- `smg_http_responses_total{status_code=~"5.."}` only gave a global HTTP error count, not a per-path error count, so it could not isolate `/v1/responses` failures.
- `smg_router_request_errors_total{endpoint="responses"}` was also not a reliable source of truth for this use case. Responses API traffic is not uniformly represented by router-level error metrics across implementations, so pairing router-level error counts with edge HTTP request counts would produce an incomplete and potentially misleading success-rate calculation.

Because of that, the dedicated error-count metrics could show that failures existed, but they still could not answer the actual question: what is the HTTP success rate for `/v1/responses`?

### Solution

Add the normalized HTTP `path` label to `smg_http_responses_total` and emit the response metric from `HttpMetricsLayer`, where both the normalized request path and the final HTTP response are available together.

This keeps request, response, and latency metrics aligned on the same path dimension and makes `/v1/responses` success-rate queries possible directly from Layer 1 HTTP metrics.

## Changes

- add `path` to `smg_http_responses_total`
- change `Metrics::record_http_response(...)` to record `path`, `status_code`, and `error_code`
- move HTTP response metric emission out of the logging layer and into `HttpMetricsLayer`
- keep response-path normalization aligned with the existing request metric path normalization
- update metrics and monitoring docs with a `/v1/responses` success-rate query example
- document why the existing error-count metrics were insufficient for calculating `/v1/responses` success rate

## Test Plan

Before this change, the following query was not possible because `smg_http_responses_total` did not have a `path` label:

```promql
sum(rate(smg_http_responses_total{path="/v1/responses",status_code=~"2.."}[5m]))
/
sum(rate(smg_http_responses_total{path="/v1/responses"}[5m]))
```

After this change:

1. start SMG with Prometheus metrics enabled
2. send traffic to `POST /v1/responses`
3. verify that `smg_http_responses_total` now includes `path="/v1/responses"`
4. run the query above and confirm it returns a per-path success rate

Validation run for this PR:

- `cargo test -p smg test_normalize_path_with_prefixed_id --lib`
- `pre-commit run --all-files` (with only the branch-protection hook skipped on `main`)

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
