### PR TITLE
test(embeddings): restore skip_for_runtime("sglang") on correctness test

### DIFF
--- a/e2e_test/embeddings/test_correctness.py
+++ b/e2e_test/embeddings/test_correctness.py
@@ -209,6 +209,7 @@ def hf_reference_embeddings(request):
 
 
 @pytest.mark.engine("sglang", "vllm")
+@pytest.mark.skip_for_runtime("sglang", reason="sglang embedding output diverges from HF reference")
 @pytest.mark.gpu(1)
 @pytest.mark.model("intfloat/e5-mistral-7b-instruct")
 @pytest.mark.e2e


### PR DESCRIPTION
## Summary

Reverts #1326 to restore the `@pytest.mark.skip_for_runtime("sglang", reason="sglang embedding output diverges from HF reference")` decorator on `test_correctness.py` and put the embeddings matrix back on the `1-gpu` runner pool.

## Why

#1326 removed the skip on the hypothesis that switching to H100 hardware (also introduced in #1326) would close the sglang vs HuggingFace reference gap for `intfloat/e5-mistral-7b-instruct`. Empirically it does not:

- PR #1329 CI (commit `e39ede16`, sglang `0.5.10.post1`, H100 `arc-runner-1-gpu-h100-gwjtg-*`):
  - `FAILED test_semantic_similarity[grpc]` — `AssertionError: Set 1, text 1: similarity 0.3342 not close to 1.0`
  - `FAILED test_relevance_scores[grpc]` — `AssertionError: Scores differ beyond tolerance`
  - `FAILED test_relevance_scores[http]` — same
- Both sglang `0.5.10` and `0.5.10.post1` produce identical divergence. The patch release does not touch the embedding path for this model family.
- vllm embeddings on H100 passes cleanly (PR #1329 CI: `e2e-1gpu-embeddings (vllm) / run` SUCCESS).

`0.3342` is an order of magnitude off `1.0`, well beyond numerical-noise territory. Likely structural root cause (out of scope for this revert, to be investigated separately):

1. Pooling strategy mismatch — E5-Mistral expects last-token pooling; sglang may be emitting mean-pooled output or vice versa.
2. L2 normalization applied on one side only.
3. Instruction-prefix handling (`"Instruct: ...\nQuery: "`) applied asymmetrically.

Since H100 alone does not fix this, the skip should be restored to unblock the sglang embeddings lane while the divergence is diagnosed by someone with context on sglang's embedding endpoint.

## Changes

- `.github/workflows/pr-test-rust.yml`: `runner: 1-gpu-h100` → `runner: 1-gpu`
- `e2e_test/embeddings/test_correctness.py`: re-add the `skip_for_runtime("sglang", ...)` decorator

## Test plan

- Revert only — bit-for-bit inverse of #1326.
- `cargo`/`python` test suites untouched.
- Once merged, sglang embeddings lane returns to skipping `test_correctness.py` on sglang and passing `test_basic.py` as before.

## Follow-up

Worth opening a separate issue for the underlying sglang E5-Mistral embedding divergence so someone with sglang embedding-endpoint context can investigate pooling / normalization / prompt-formatting parity with the HF reference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Embeddings correctness tests are now conditionally skipped for the sglang runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->