### PR TITLE
fix(bench): handle Compaction variant in routing_allocation_bench

### DIFF
--- a/model_gateway/benches/routing_allocation_bench.rs
+++ b/model_gateway/benches/routing_allocation_bench.rs
@@ -69,6 +69,7 @@ fn extract_text_for_routing_old(req: &ResponsesRequest) -> String {
                 ResponseInputOutputItem::McpApprovalRequest { .. } => None,
                 ResponseInputOutputItem::McpApprovalResponse { .. } => None,
                 ResponseInputOutputItem::ImageGenerationCall { .. } => None,
+                ResponseInputOutputItem::Compaction { .. } => None,
             })
             .collect::<Vec<String>>()
             .join(" "),


### PR DESCRIPTION
## Summary

PR #1302 (I3 compaction) added the `ResponseInputOutputItem::Compaction` variant but did not extend the exhaustive match in `routing_allocation_bench.rs`, breaking `cargo clippy --all-targets --all-features -- -D warnings` on main. This is the forced-cascade arm that should have shipped with #1302.

## Error on main

```
error[E0004]: non-exhaustive patterns: `&openai_protocol::responses::ResponseInputOutputItem::Compaction { .. }` not covered
   --> model_gateway/benches/routing_allocation_bench.rs:17:38
    |
 17 |             .filter_map(|item| match item {
    |                                      ^^^^ pattern `...::Compaction { .. }` not covered
```

All downstream PRs that run clippy are red because of this — e.g., PR #1330 `unit-tests` lane: https://github.com/lightseekorg/smg/actions/runs/24800464547/job/72581561317

## Change

Add a single arm returning `None` — Compaction carries only `encrypted_content`, no routable text to extract. Matches the neutral shape of the sibling `McpApprovalRequest` / `ImageGenerationCall` arms.

```diff
                ResponseInputOutputItem::ImageGenerationCall { .. } => None,
+               ResponseInputOutputItem::Compaction { .. } => None,
            })
```

## Test plan

- Local: `cargo clippy --all-targets --all-features -- -D warnings` completes clean (`Finished dev profile ... target(s) in 4m 56s`).
- No behavior change — bench was already returning `None` for all non-text-bearing variants; this adds the arm for the new Compaction variant following the same pattern.

## Follow-up

None required — this is a one-line forced-cascade fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined routing allocation item filtering to exclude inappropriate item types during text extraction, resulting in more accurate routing decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->