### PR TITLE
feat(skills): add create upload admin endpoints

### DIFF
--- a/crates/protocols/src/skills.rs
+++ b/crates/protocols/src/skills.rs
@@ -9,6 +9,15 @@ use serde::{
 };
 use serde_json::{Map, Value};
 
+/// Multipart field carrying the explicit admin target tenant id.
+pub const SKILLS_MULTIPART_TENANT_ID_FIELD: &str = "tenant_id";
+/// Multipart field for zip archive uploads.
+pub const SKILLS_MULTIPART_BUNDLE_FIELD: &str = "bundle";
+/// Alternate multipart field name accepted for zip archive uploads.
+pub const SKILLS_MULTIPART_FILE_FIELD: &str = "file";
+/// Multipart field for raw file uploads.
+pub const SKILLS_MULTIPART_FILES_FIELD: &str = "files[]";
+
 /// Accepted in `/v1/messages` -> `container.skills[]`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(tag = "type")]
@@ -102,6 +111,82 @@ pub enum SkillVersionRef {
     Integer(u32),
     /// Timestamp string (Anthropic-style).
     Timestamp(String),
+}
+
+/// Public skill object returned by CRUD/read endpoints.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct SkillResponse {
+    pub id: String,
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub short_description: Option<String>,
+    pub description: String,
+    pub source: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub latest_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_version: Option<String>,
+    pub has_code_files: bool,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+/// Public immutable skill-version object returned by CRUD/read endpoints.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct SkillVersionResponse {
+    pub skill_id: String,
+    pub version: String,
+    pub version_number: u32,
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub short_description: Option<String>,
+    pub description: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub interface: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dependencies: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub policy: Option<Value>,
+    pub deprecated: bool,
+    pub files: Vec<SkillVersionFileResponse>,
+    pub created_at: String,
+}
+
+/// Public file-manifest entry for a skill version.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct SkillVersionFileResponse {
+    pub path: String,
+    pub size_bytes: u64,
+}
+
+/// Non-fatal warning surfaced when a bundle was accepted with partial metadata salvage.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct SkillWarningResponse {
+    pub kind: String,
+    pub path: String,
+    pub message: String,
+}
+
+/// Success payload for skill create/upload mutations.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct SkillMutationResponse {
+    pub skill: SkillResponse,
+    pub version: SkillVersionResponse,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<SkillWarningResponse>,
+}
+
+/// Standard error envelope for skills CRUD endpoints.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct SkillsErrorEnvelope {
+    pub error: SkillsErrorBody,
+}
+
+/// Structured error body for skills CRUD endpoints.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct SkillsErrorBody {
+    pub code: String,
+    pub message: String,
 }
 
 impl Serialize for SkillVersionRef {

--- a/crates/protocols/tests/skills_protocol.rs
+++ b/crates/protocols/tests/skills_protocol.rs
@@ -3,7 +3,7 @@ use openai_protocol::{
     responses::{CodeInterpreterTool, ResponseTool},
     skills::{
         MessagesSkillRef, OpaqueOpenAIObject, ResponsesSkillEntry, ResponsesSkillRef,
-        SkillVersionRef,
+        SkillMutationResponse, SkillVersionRef, SkillsErrorEnvelope,
     },
 };
 use schemars::schema_for;
@@ -215,6 +215,52 @@ fn responses_code_interpreter_legacy_container_round_trips() {
 
     let tool: ResponseTool = serde_json::from_value(raw.clone()).unwrap();
     assert_eq!(serde_json::to_value(&tool).unwrap(), raw);
+}
+
+#[test]
+fn skill_mutation_response_round_trips() {
+    let raw = json!({
+        "skill": {
+            "id": "skill_01jw4v0w53k9mz4bzr0t7k8a9n",
+            "name": "acme:map",
+            "short_description": "Map it",
+            "description": "Map the repo",
+            "source": "custom",
+            "latest_version": "1759178010641129",
+            "default_version": "1759178010641129",
+            "has_code_files": true,
+            "created_at": "2026-03-16T00:00:00Z",
+            "updated_at": "2026-03-16T00:00:00Z"
+        },
+        "version": {
+            "skill_id": "skill_01jw4v0w53k9mz4bzr0t7k8a9n",
+            "version": "1759178010641129",
+            "version_number": 1,
+            "name": "acme:map",
+            "short_description": "Map it",
+            "description": "Map the repo",
+            "deprecated": false,
+            "files": [{"path": "SKILL.md", "size_bytes": 123}],
+            "created_at": "2026-03-16T00:00:00Z"
+        },
+        "warnings": [{"kind": "SidecarFileIgnored", "path": "agents/openai.yaml", "message": "ignored"}]
+    });
+
+    let parsed: SkillMutationResponse = serde_json::from_value(raw.clone()).unwrap();
+    assert_eq!(serde_json::to_value(&parsed).unwrap(), raw);
+}
+
+#[test]
+fn skills_error_envelope_round_trips() {
+    let raw = json!({
+        "error": {
+            "code": "missing_target_tenant",
+            "message": "target tenant id is required"
+        }
+    });
+
+    let parsed: SkillsErrorEnvelope = serde_json::from_value(raw.clone()).unwrap();
+    assert_eq!(serde_json::to_value(&parsed).unwrap(), raw);
 }
 
 #[test]

--- a/crates/skills/Cargo.toml
+++ b/crates/skills/Cargo.toml
@@ -24,6 +24,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_yml = "0.0.12"
 smg-blob-storage.workspace = true
 thiserror.workspace = true
+ulid = "1.2.1"
 zip = "8.1"
 
 [dev-dependencies]

--- a/crates/skills/src/api.rs
+++ b/crates/skills/src/api.rs
@@ -1,10 +1,28 @@
-use std::{fmt, sync::Arc};
+use std::{
+    collections::{BTreeMap, HashMap},
+    fmt,
+    io::{Cursor, Write},
+    sync::Arc,
+};
 
-use smg_blob_storage::BlobStore;
+use chrono::Utc;
+use smg_blob_storage::{BlobKey, BlobStore, BlobStoreError, PutBlobRequest};
+use ulid::Ulid;
+use zip::{write::SimpleFileOptions, CompressionMethod, ZipWriter};
 
 use crate::{
     memory::InMemorySkillStore,
-    storage::{BundleTokenStore, ContinuationCookieStore, SkillMetadataStore, TenantAliasStore},
+    storage::{
+        BundleTokenStore, ContinuationCookieStore, SkillMetadataStore, SkillsStoreError,
+        TenantAliasStore,
+    },
+    types::{
+        NormalizedSkillBundle, ParsedSkillBundle, SkillFileRecord, SkillParseWarning, SkillRecord,
+        SkillVersionRecord,
+    },
+    validation::{
+        normalize_skill_bundle_zip, parse_skill_bundle, SkillBundleArchiveError, SkillParseError,
+    },
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -37,6 +55,84 @@ impl fmt::Debug for SkillServiceInner {
 #[derive(Debug, Clone)]
 pub struct SkillService {
     inner: Arc<SkillServiceInner>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UploadedSkillFile {
+    pub relative_path: String,
+    pub contents: Vec<u8>,
+    pub media_type: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SkillUpload {
+    Zip(Vec<u8>),
+    Files(Vec<UploadedSkillFile>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CreateSkillRequest {
+    pub tenant_id: String,
+    pub upload: SkillUpload,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CreateSkillVersionRequest {
+    pub tenant_id: String,
+    pub skill_id: String,
+    pub upload: SkillUpload,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SkillCreateResult {
+    pub skill: SkillRecord,
+    pub version: SkillVersionRecord,
+    pub warnings: Vec<SkillParseWarning>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum SkillServiceError {
+    #[error("skills service is not available for {component}")]
+    MissingComponent { component: &'static str },
+
+    #[error("target tenant id is required")]
+    MissingTenantId,
+
+    #[error("skill id is required")]
+    MissingSkillId,
+
+    #[error("skill '{skill_id}' was not found for tenant '{tenant_id}'")]
+    SkillNotFound { tenant_id: String, skill_id: String },
+
+    #[error("multipart upload must contain either one zip archive or one or more files[] parts")]
+    MissingUploadParts,
+
+    #[error("multipart upload cannot mix zip archive and files[] parts")]
+    MixedUploadModes,
+
+    #[error("zip archive uploads must use a .zip filename or application/zip content type")]
+    InvalidZipUpload,
+
+    #[error("multipart file name is required for files[] uploads")]
+    MissingFileName,
+
+    #[error("SKILL.md must be valid UTF-8")]
+    SkillMdNotUtf8,
+
+    #[error(transparent)]
+    BundleArchive(#[from] SkillBundleArchiveError),
+
+    #[error(transparent)]
+    BundleParse(#[from] SkillParseError),
+
+    #[error(transparent)]
+    BlobStore(#[from] BlobStoreError),
+
+    #[error(transparent)]
+    Store(#[from] SkillsStoreError),
+
+    #[error("failed to build skill bundle: {0}")]
+    BundleBuild(String),
 }
 
 impl Default for SkillService {
@@ -112,6 +208,336 @@ impl SkillService {
     pub fn blob_store(&self) -> Option<Arc<dyn BlobStore>> {
         self.inner.blob_store.clone()
     }
+
+    pub async fn create_skill(
+        &self,
+        request: CreateSkillRequest,
+    ) -> Result<SkillCreateResult, SkillServiceError> {
+        let tenant_id =
+            normalize_required_value(request.tenant_id, SkillServiceError::MissingTenantId)?;
+        let metadata_store = self
+            .metadata_store()
+            .ok_or(SkillServiceError::MissingComponent {
+                component: "metadata_store",
+            })?;
+        let blob_store = self
+            .blob_store()
+            .ok_or(SkillServiceError::MissingComponent {
+                component: "blob_store",
+            })?;
+
+        let (bundle, media_types) = normalize_upload_bundle(request.upload)?;
+        let parsed_bundle = parse_bundle_contents(&bundle)?;
+        let skill_id = generate_skill_id();
+        let version = generate_version_id(&[]);
+        let now = Utc::now();
+        let file_manifest = persist_bundle_files(
+            &*blob_store,
+            &tenant_id,
+            &skill_id,
+            &version,
+            &bundle,
+            &media_types,
+        )
+        .await?;
+
+        let skill_record = SkillRecord {
+            tenant_id: tenant_id.clone(),
+            skill_id: skill_id.clone(),
+            name: parsed_bundle.name.clone(),
+            short_description: parsed_bundle.short_description.clone(),
+            description: Some(parsed_bundle.description.clone()),
+            source: "custom".to_string(),
+            has_code_files: bundle.has_code_files,
+            latest_version: Some(version.clone()),
+            default_version: Some(version.clone()),
+            created_at: now,
+            updated_at: now,
+        };
+        let version_record = SkillVersionRecord {
+            skill_id: skill_id.clone(),
+            version: version.clone(),
+            version_number: 1,
+            name: parsed_bundle.name.clone(),
+            short_description: parsed_bundle.short_description.clone(),
+            description: parsed_bundle.description.clone(),
+            interface: parsed_bundle.interface.clone(),
+            dependencies: parsed_bundle.dependencies.clone(),
+            policy: parsed_bundle.policy.clone(),
+            deprecated: false,
+            file_manifest,
+            instruction_token_counts: BTreeMap::new(),
+            created_at: now,
+        };
+
+        if let Err(error) = metadata_store.put_skill(skill_record.clone()).await {
+            cleanup_blobs(&*blob_store, &version_record.file_manifest).await;
+            return Err(error.into());
+        }
+
+        if let Err(error) = metadata_store
+            .put_skill_version(version_record.clone())
+            .await
+        {
+            let _ = metadata_store.delete_skill(&tenant_id, &skill_id).await;
+            cleanup_blobs(&*blob_store, &version_record.file_manifest).await;
+            return Err(error.into());
+        }
+
+        Ok(SkillCreateResult {
+            skill: skill_record,
+            version: version_record,
+            warnings: parsed_bundle.warnings,
+        })
+    }
+
+    pub async fn create_skill_version(
+        &self,
+        request: CreateSkillVersionRequest,
+    ) -> Result<SkillCreateResult, SkillServiceError> {
+        let tenant_id =
+            normalize_required_value(request.tenant_id, SkillServiceError::MissingTenantId)?;
+        let skill_id =
+            normalize_required_value(request.skill_id, SkillServiceError::MissingSkillId)?;
+        let metadata_store = self
+            .metadata_store()
+            .ok_or(SkillServiceError::MissingComponent {
+                component: "metadata_store",
+            })?;
+        let blob_store = self
+            .blob_store()
+            .ok_or(SkillServiceError::MissingComponent {
+                component: "blob_store",
+            })?;
+
+        let existing_skill = metadata_store
+            .get_skill(&tenant_id, &skill_id)
+            .await?
+            .ok_or_else(|| SkillServiceError::SkillNotFound {
+                tenant_id: tenant_id.clone(),
+                skill_id: skill_id.clone(),
+            })?;
+        let existing_versions = metadata_store.list_skill_versions(&skill_id).await?;
+
+        let (bundle, media_types) = normalize_upload_bundle(request.upload)?;
+        let parsed_bundle = parse_bundle_contents(&bundle)?;
+        let version = generate_version_id(&existing_versions);
+        let version_number = next_version_number(&existing_versions);
+        let now = Utc::now();
+        let file_manifest = persist_bundle_files(
+            &*blob_store,
+            &tenant_id,
+            &skill_id,
+            &version,
+            &bundle,
+            &media_types,
+        )
+        .await?;
+
+        let version_record = SkillVersionRecord {
+            skill_id: skill_id.clone(),
+            version: version.clone(),
+            version_number,
+            name: parsed_bundle.name.clone(),
+            short_description: parsed_bundle.short_description.clone(),
+            description: parsed_bundle.description.clone(),
+            interface: parsed_bundle.interface.clone(),
+            dependencies: parsed_bundle.dependencies.clone(),
+            policy: parsed_bundle.policy.clone(),
+            deprecated: false,
+            file_manifest,
+            instruction_token_counts: BTreeMap::new(),
+            created_at: now,
+        };
+
+        if let Err(error) = metadata_store
+            .put_skill_version(version_record.clone())
+            .await
+        {
+            cleanup_blobs(&*blob_store, &version_record.file_manifest).await;
+            return Err(error.into());
+        }
+
+        let mut updated_skill = existing_skill.clone();
+        updated_skill.name = parsed_bundle.name.clone();
+        updated_skill.short_description = parsed_bundle.short_description.clone();
+        updated_skill.description = Some(parsed_bundle.description.clone());
+        updated_skill.has_code_files = bundle.has_code_files;
+        updated_skill.latest_version = Some(version.clone());
+        if updated_skill.default_version.is_none() {
+            updated_skill.default_version = Some(version.clone());
+        }
+        updated_skill.updated_at = now;
+
+        if let Err(error) = metadata_store.put_skill(updated_skill.clone()).await {
+            let _ = metadata_store
+                .delete_skill_version(&skill_id, &version)
+                .await;
+            cleanup_blobs(&*blob_store, &version_record.file_manifest).await;
+            return Err(error.into());
+        }
+
+        Ok(SkillCreateResult {
+            skill: updated_skill,
+            version: version_record,
+            warnings: parsed_bundle.warnings,
+        })
+    }
+}
+
+fn normalize_required_value(
+    value: String,
+    error: SkillServiceError,
+) -> Result<String, SkillServiceError> {
+    let value = value.trim();
+    if value.is_empty() {
+        return Err(error);
+    }
+    Ok(value.to_string())
+}
+
+fn normalize_upload_bundle(
+    upload: SkillUpload,
+) -> Result<(NormalizedSkillBundle, HashMap<String, Option<String>>), SkillServiceError> {
+    match upload {
+        SkillUpload::Zip(bytes) => {
+            let bundle = normalize_skill_bundle_zip(&bytes)?;
+            Ok((bundle, HashMap::new()))
+        }
+        SkillUpload::Files(files) => {
+            if files.is_empty() {
+                return Err(SkillServiceError::MissingUploadParts);
+            }
+            let media_types = files
+                .iter()
+                .map(|file| (file.relative_path.clone(), file.media_type.clone()))
+                .collect::<HashMap<_, _>>();
+            let bundle = normalize_files_upload(&files)?;
+            Ok((bundle, media_types))
+        }
+    }
+}
+
+fn normalize_files_upload(
+    files: &[UploadedSkillFile],
+) -> Result<NormalizedSkillBundle, SkillServiceError> {
+    let mut buffer = Cursor::new(Vec::new());
+    {
+        let mut zip = ZipWriter::new(&mut buffer);
+        let options = SimpleFileOptions::default()
+            .compression_method(CompressionMethod::Stored)
+            .unix_permissions(0o644);
+        for file in files {
+            let entry_name = format!("bundle/{}", file.relative_path);
+            zip.start_file(entry_name, options)
+                .map_err(|error| SkillServiceError::BundleBuild(error.to_string()))?;
+            zip.write_all(&file.contents)
+                .map_err(|error| SkillServiceError::BundleBuild(error.to_string()))?;
+        }
+        zip.finish()
+            .map_err(|error| SkillServiceError::BundleBuild(error.to_string()))?;
+    }
+
+    normalize_skill_bundle_zip(buffer.get_ref()).map_err(Into::into)
+}
+
+fn parse_bundle_contents(
+    bundle: &NormalizedSkillBundle,
+) -> Result<ParsedSkillBundle, SkillServiceError> {
+    let skill_md_bytes = bundle
+        .files
+        .iter()
+        .find(|file| file.relative_path == bundle.skill_md_path)
+        .ok_or_else(|| {
+            SkillServiceError::BundleBuild("normalized bundle missing SKILL.md".to_string())
+        })?;
+    let skill_md = std::str::from_utf8(&skill_md_bytes.contents)
+        .map_err(|_| SkillServiceError::SkillMdNotUtf8)?;
+    let openai_yaml = bundle
+        .openai_sidecar_path
+        .as_ref()
+        .and_then(|path| bundle.files.iter().find(|file| &file.relative_path == path))
+        .and_then(|file| std::str::from_utf8(&file.contents).ok());
+
+    parse_skill_bundle(skill_md, openai_yaml).map_err(Into::into)
+}
+
+async fn persist_bundle_files(
+    blob_store: &dyn BlobStore,
+    tenant_id: &str,
+    skill_id: &str,
+    version: &str,
+    bundle: &NormalizedSkillBundle,
+    media_types: &HashMap<String, Option<String>>,
+) -> Result<Vec<SkillFileRecord>, SkillServiceError> {
+    let mut uploaded_keys = Vec::with_capacity(bundle.files.len());
+    let mut manifest = Vec::with_capacity(bundle.files.len());
+
+    for file in &bundle.files {
+        let blob_key = BlobKey(format!(
+            "tenants/{tenant_id}/skills/{skill_id}/{version}/{}",
+            file.relative_path
+        ));
+        let put_request = PutBlobRequest {
+            reader: Box::pin(Cursor::new(file.contents.clone())),
+            content_length: file.contents.len() as u64,
+            content_type: media_types.get(&file.relative_path).cloned().flatten(),
+        };
+
+        if let Err(error) = blob_store.put_stream(&blob_key, put_request).await {
+            cleanup_uploaded_keys(blob_store, &uploaded_keys).await;
+            return Err(error.into());
+        }
+
+        uploaded_keys.push(blob_key.clone());
+        manifest.push(SkillFileRecord {
+            relative_path: file.relative_path.clone(),
+            media_type: media_types.get(&file.relative_path).cloned().flatten(),
+            size_bytes: file.size_bytes(),
+            blob_key: Some(blob_key),
+        });
+    }
+
+    Ok(manifest)
+}
+
+async fn cleanup_blobs(blob_store: &dyn BlobStore, manifest: &[SkillFileRecord]) {
+    for entry in manifest {
+        if let Some(blob_key) = &entry.blob_key {
+            let _ = blob_store.delete(blob_key).await;
+        }
+    }
+}
+
+async fn cleanup_uploaded_keys(blob_store: &dyn BlobStore, uploaded_keys: &[BlobKey]) {
+    for blob_key in uploaded_keys {
+        let _ = blob_store.delete(blob_key).await;
+    }
+}
+
+fn generate_skill_id() -> String {
+    format!("skill_{}", Ulid::new().to_string().to_ascii_lowercase())
+}
+
+fn generate_version_id(existing_versions: &[SkillVersionRecord]) -> String {
+    let mut candidate = Utc::now().timestamp_micros();
+    let used_versions = existing_versions
+        .iter()
+        .map(|record| record.version.clone())
+        .collect::<std::collections::HashSet<_>>();
+    while used_versions.contains(&candidate.to_string()) {
+        candidate += 1;
+    }
+    candidate.to_string()
+}
+
+fn next_version_number(existing_versions: &[SkillVersionRecord]) -> u32 {
+    existing_versions
+        .iter()
+        .map(|record| record.version_number)
+        .max()
+        .unwrap_or(0)
+        .saturating_add(1)
 }
 
 #[cfg(test)]
@@ -122,7 +548,10 @@ mod tests {
     use smg_blob_storage::FilesystemBlobStore;
     use tempfile::TempDir;
 
-    use super::{SkillService, SkillServiceMode};
+    use super::{
+        CreateSkillRequest, CreateSkillVersionRequest, SkillService, SkillServiceMode, SkillUpload,
+        UploadedSkillFile,
+    };
 
     #[test]
     fn placeholder_service_reports_placeholder_mode() {
@@ -153,6 +582,106 @@ mod tests {
         service
             .blob_store()
             .ok_or_else(|| anyhow!("blob store missing"))?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn create_skill_persists_initial_version_and_bundle_blobs() -> Result<()> {
+        let root = TempDir::new()?;
+        let blob_store = Arc::new(FilesystemBlobStore::new(root.path())?);
+        let service = SkillService::in_memory(blob_store.clone());
+
+        let result = service
+            .create_skill(CreateSkillRequest {
+                tenant_id: "tenant-a".to_string(),
+                upload: SkillUpload::Files(vec![
+                    UploadedSkillFile {
+                        relative_path: "SKILL.md".to_string(),
+                        contents: b"---\nname: acme:map\ndescription: Map the repo\nmetadata:\n  short-description: Map it\n---\nUse rg.".to_vec(),
+                        media_type: Some("text/markdown".to_string()),
+                    },
+                    UploadedSkillFile {
+                        relative_path: "scripts/run.py".to_string(),
+                        contents: b"print('hi')".to_vec(),
+                        media_type: Some("text/x-python".to_string()),
+                    },
+                ]),
+            })
+            .await?;
+
+        assert_eq!(result.skill.tenant_id, "tenant-a");
+        assert_eq!(result.version.version_number, 1);
+        assert_eq!(result.version.file_manifest.len(), 2);
+        assert!(result
+            .version
+            .file_manifest
+            .iter()
+            .all(|entry| entry.blob_key.is_some()));
+        assert!(result.skill.has_code_files);
+
+        let metadata_store = service
+            .metadata_store()
+            .ok_or_else(|| anyhow!("metadata store missing"))?;
+        assert!(metadata_store
+            .get_skill("tenant-a", &result.skill.skill_id)
+            .await?
+            .is_some());
+        assert!(metadata_store
+            .get_skill_version(&result.skill.skill_id, &result.version.version)
+            .await?
+            .is_some());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn create_skill_version_increments_monotonic_version_number() -> Result<()> {
+        let root = TempDir::new()?;
+        let blob_store = Arc::new(FilesystemBlobStore::new(root.path())?);
+        let service = SkillService::in_memory(blob_store);
+
+        let created = service
+            .create_skill(CreateSkillRequest {
+                tenant_id: "tenant-a".to_string(),
+                upload: SkillUpload::Files(vec![UploadedSkillFile {
+                    relative_path: "SKILL.md".to_string(),
+                    contents: b"---\nname: acme:map\ndescription: Map the repo\n---\nUse rg."
+                        .to_vec(),
+                    media_type: Some("text/markdown".to_string()),
+                }]),
+            })
+            .await?;
+
+        let next = service
+            .create_skill_version(CreateSkillVersionRequest {
+                tenant_id: "tenant-a".to_string(),
+                skill_id: created.skill.skill_id.clone(),
+                upload: SkillUpload::Files(vec![
+                    UploadedSkillFile {
+                        relative_path: "SKILL.md".to_string(),
+                        contents: b"---\nname: acme:map\ndescription: Map the repo better\n---\nUse rg and fd.".to_vec(),
+                        media_type: Some("text/markdown".to_string()),
+                    },
+                    UploadedSkillFile {
+                        relative_path: "scripts/run.py".to_string(),
+                        contents: b"print('v2')".to_vec(),
+                        media_type: Some("text/x-python".to_string()),
+                    },
+                ]),
+            })
+            .await?;
+
+        assert_eq!(next.version.version_number, 2);
+        assert_ne!(next.version.version, created.version.version);
+        assert_eq!(
+            next.skill.latest_version,
+            Some(next.version.version.clone())
+        );
+        assert_eq!(
+            next.skill.default_version,
+            Some(created.version.version.clone())
+        );
+
         Ok(())
     }
 }

--- a/crates/skills/src/lib.rs
+++ b/crates/skills/src/lib.rs
@@ -11,7 +11,10 @@ pub mod storage;
 pub mod types;
 pub mod validation;
 
-pub use api::{SkillService, SkillServiceMode};
+pub use api::{
+    CreateSkillRequest, CreateSkillVersionRequest, SkillCreateResult, SkillService,
+    SkillServiceError, SkillServiceMode, SkillUpload, UploadedSkillFile,
+};
 pub use config::{
     SkillsAdminConfig, SkillsAdminOperation, SkillsBlobStoreBackend, SkillsBlobStoreConfig,
     SkillsBudgetLimit, SkillsCacheConfig, SkillsConfig, SkillsDependenciesConfig,

--- a/model_gateway/Cargo.toml
+++ b/model_gateway/Cargo.toml
@@ -146,6 +146,7 @@ kv-index.workspace = true
 wasmtime-wasi = { workspace = true }
 lru = { workspace = true }
 wat = "1.244"
+zip = "8.1"
 
 [[bench]]
 name = "wasm_middleware_latency"

--- a/model_gateway/src/routers/mod.rs
+++ b/model_gateway/src/routers/mod.rs
@@ -41,6 +41,7 @@ pub mod openai;
 pub mod parse;
 pub mod responses;
 pub mod router_manager;
+pub mod skills;
 pub mod tokenize;
 
 pub use factory::RouterFactory;

--- a/model_gateway/src/routers/skills/handlers.rs
+++ b/model_gateway/src/routers/skills/handlers.rs
@@ -1,0 +1,386 @@
+use axum::{
+    extract::{multipart::MultipartError, Multipart, Path, State},
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    Json,
+};
+use openai_protocol::skills::{
+    SkillMutationResponse, SkillResponse, SkillVersionFileResponse, SkillVersionResponse,
+    SkillWarningResponse, SkillsErrorBody, SkillsErrorEnvelope, SKILLS_MULTIPART_BUNDLE_FIELD,
+    SKILLS_MULTIPART_FILES_FIELD, SKILLS_MULTIPART_FILE_FIELD, SKILLS_MULTIPART_TENANT_ID_FIELD,
+};
+use serde_json::Value;
+use smg_skills::{
+    CreateSkillRequest, CreateSkillVersionRequest, SkillCreateResult, SkillServiceError,
+    SkillUpload, UploadedSkillFile,
+};
+
+use crate::{middleware::resolve_admin_target_tenant_key, server::AppState};
+
+#[derive(Debug)]
+struct ParsedSkillUpload {
+    tenant_id: String,
+    upload: SkillUpload,
+}
+
+#[derive(Debug)]
+enum SkillsApiError {
+    BadRequest { code: &'static str, message: String },
+    NotFound { code: &'static str, message: String },
+    Conflict { code: &'static str, message: String },
+    Internal { code: &'static str, message: String },
+}
+
+impl IntoResponse for SkillsApiError {
+    fn into_response(self) -> Response {
+        let (status, code, message) = match self {
+            Self::BadRequest { code, message } => (StatusCode::BAD_REQUEST, code, message),
+            Self::NotFound { code, message } => (StatusCode::NOT_FOUND, code, message),
+            Self::Conflict { code, message } => (StatusCode::CONFLICT, code, message),
+            Self::Internal { code, message } => (StatusCode::INTERNAL_SERVER_ERROR, code, message),
+        };
+
+        (
+            status,
+            Json(SkillsErrorEnvelope {
+                error: SkillsErrorBody {
+                    code: code.to_string(),
+                    message,
+                },
+            }),
+        )
+            .into_response()
+    }
+}
+
+impl From<SkillServiceError> for SkillsApiError {
+    fn from(error: SkillServiceError) -> Self {
+        match error {
+            SkillServiceError::MissingTenantId => Self::BadRequest {
+                code: "missing_target_tenant",
+                message: error.to_string(),
+            },
+            SkillServiceError::MissingSkillId => Self::BadRequest {
+                code: "missing_skill_id",
+                message: error.to_string(),
+            },
+            SkillServiceError::SkillNotFound { .. } => Self::NotFound {
+                code: "skill_not_found",
+                message: error.to_string(),
+            },
+            SkillServiceError::MissingUploadParts => Self::BadRequest {
+                code: "missing_upload_parts",
+                message: error.to_string(),
+            },
+            SkillServiceError::MixedUploadModes => Self::BadRequest {
+                code: "mixed_upload_modes",
+                message: error.to_string(),
+            },
+            SkillServiceError::InvalidZipUpload => Self::BadRequest {
+                code: "invalid_zip_upload",
+                message: error.to_string(),
+            },
+            SkillServiceError::MissingFileName => Self::BadRequest {
+                code: "missing_file_name",
+                message: error.to_string(),
+            },
+            SkillServiceError::SkillMdNotUtf8 => Self::BadRequest {
+                code: "skill_md_not_utf8",
+                message: error.to_string(),
+            },
+            SkillServiceError::BundleArchive(_) | SkillServiceError::BundleParse(_) => {
+                Self::BadRequest {
+                    code: "invalid_skill_bundle",
+                    message: error.to_string(),
+                }
+            }
+            SkillServiceError::Store(smg_skills::SkillsStoreError::InvalidData(_)) => {
+                Self::Conflict {
+                    code: "skills_conflict",
+                    message: error.to_string(),
+                }
+            }
+            SkillServiceError::BundleBuild(_)
+            | SkillServiceError::BlobStore(_)
+            | SkillServiceError::Store(_)
+            | SkillServiceError::MissingComponent { .. } => Self::Internal {
+                code: "skills_internal_error",
+                message: error.to_string(),
+            },
+        }
+    }
+}
+
+pub async fn create_skill(
+    State(state): State<std::sync::Arc<AppState>>,
+    multipart: Multipart,
+) -> Response {
+    match create_skill_impl(state, multipart).await {
+        Ok(response) => (StatusCode::CREATED, Json(response)).into_response(),
+        Err(error) => error.into_response(),
+    }
+}
+
+pub async fn create_skill_version(
+    State(state): State<std::sync::Arc<AppState>>,
+    Path(skill_id): Path<String>,
+    multipart: Multipart,
+) -> Response {
+    match create_skill_version_impl(state, skill_id, multipart).await {
+        Ok(response) => (StatusCode::CREATED, Json(response)).into_response(),
+        Err(error) => error.into_response(),
+    }
+}
+
+async fn create_skill_impl(
+    state: std::sync::Arc<AppState>,
+    multipart: Multipart,
+) -> Result<SkillMutationResponse, SkillsApiError> {
+    let skill_service =
+        state
+            .context
+            .skill_service
+            .clone()
+            .ok_or_else(|| SkillsApiError::Internal {
+                code: "skills_not_configured",
+                message: "skills service is not configured".to_string(),
+            })?;
+    let parsed = parse_skill_upload(multipart).await?;
+    let result = skill_service
+        .create_skill(CreateSkillRequest {
+            tenant_id: parsed.tenant_id,
+            upload: parsed.upload,
+        })
+        .await
+        .map_err(SkillsApiError::from)?;
+    build_mutation_response(result)
+}
+
+async fn create_skill_version_impl(
+    state: std::sync::Arc<AppState>,
+    skill_id: String,
+    multipart: Multipart,
+) -> Result<SkillMutationResponse, SkillsApiError> {
+    let skill_service =
+        state
+            .context
+            .skill_service
+            .clone()
+            .ok_or_else(|| SkillsApiError::Internal {
+                code: "skills_not_configured",
+                message: "skills service is not configured".to_string(),
+            })?;
+    let parsed = parse_skill_upload(multipart).await?;
+    let result = skill_service
+        .create_skill_version(CreateSkillVersionRequest {
+            tenant_id: parsed.tenant_id,
+            skill_id,
+            upload: parsed.upload,
+        })
+        .await
+        .map_err(SkillsApiError::from)?;
+    build_mutation_response(result)
+}
+
+async fn parse_skill_upload(mut multipart: Multipart) -> Result<ParsedSkillUpload, SkillsApiError> {
+    let mut tenant_id = None;
+    let mut zip_upload = None;
+    let mut files = Vec::new();
+
+    while let Some(field) = multipart
+        .next_field()
+        .await
+        .map_err(|error| invalid_multipart(format!("failed to read multipart field: {error}")))?
+    {
+        let field_name = field.name().unwrap_or_default().to_string();
+        match field_name.as_str() {
+            SKILLS_MULTIPART_TENANT_ID_FIELD => {
+                if tenant_id.is_some() {
+                    return Err(unexpected_field("tenant_id may only be provided once"));
+                }
+                let value = field
+                    .text()
+                    .await
+                    .map_err(|error| bad_text_field(SKILLS_MULTIPART_TENANT_ID_FIELD, error))?;
+                tenant_id = Some(
+                    resolve_admin_target_tenant_key(&value)
+                        .map_err(|error| SkillsApiError::BadRequest {
+                            code: "missing_target_tenant",
+                            message: error.to_string(),
+                        })?
+                        .to_string(),
+                );
+            }
+            SKILLS_MULTIPART_FILE_FIELD | SKILLS_MULTIPART_BUNDLE_FIELD => {
+                if zip_upload.is_some() || !files.is_empty() {
+                    return Err(SkillsApiError::BadRequest {
+                        code: "mixed_upload_modes",
+                        message: "multipart upload cannot mix zip archive and files[] parts"
+                            .to_string(),
+                    });
+                }
+                let file_name = field.file_name().map(str::to_string);
+                let content_type = field.content_type().map(str::to_string);
+                if !looks_like_zip_upload(file_name.as_deref(), content_type.as_deref()) {
+                    return Err(SkillsApiError::BadRequest {
+                        code: "invalid_zip_upload",
+                        message:
+                            "zip archive uploads must use a .zip filename or application/zip content type"
+                                .to_string(),
+                    });
+                }
+                let bytes = field.bytes().await.map_err(|error| {
+                    invalid_multipart(format!("failed to read zip upload: {error}"))
+                })?;
+                zip_upload = Some(bytes.to_vec());
+            }
+            "files" | SKILLS_MULTIPART_FILES_FIELD => {
+                if zip_upload.is_some() {
+                    return Err(SkillsApiError::BadRequest {
+                        code: "mixed_upload_modes",
+                        message: "multipart upload cannot mix zip archive and files[] parts"
+                            .to_string(),
+                    });
+                }
+                let relative_path = field.file_name().map(str::to_string).ok_or_else(|| {
+                    SkillsApiError::BadRequest {
+                        code: "missing_file_name",
+                        message: "multipart file name is required for files[] uploads".to_string(),
+                    }
+                })?;
+                let media_type = field.content_type().map(str::to_string);
+                let contents = field.bytes().await.map_err(|error| {
+                    invalid_multipart(format!("failed to read uploaded file bytes: {error}"))
+                })?;
+                files.push(UploadedSkillFile {
+                    relative_path,
+                    contents: contents.to_vec(),
+                    media_type,
+                });
+            }
+            _ => {
+                let _ = field.bytes().await;
+                return Err(unexpected_field(&format!(
+                    "unexpected multipart field '{field_name}'"
+                )));
+            }
+        }
+    }
+
+    let tenant_id = tenant_id.ok_or_else(|| SkillsApiError::BadRequest {
+        code: "missing_target_tenant",
+        message: "target tenant id is required".to_string(),
+    })?;
+    let upload = match (zip_upload, files.is_empty()) {
+        (Some(bytes), true) => SkillUpload::Zip(bytes),
+        (None, false) => SkillUpload::Files(files),
+        (Some(_), false) => {
+            return Err(SkillsApiError::BadRequest {
+                code: "mixed_upload_modes",
+                message: "multipart upload cannot mix zip archive and files[] parts".to_string(),
+            });
+        }
+        (None, true) => {
+            return Err(SkillsApiError::BadRequest {
+                code: "missing_upload_parts",
+                message:
+                    "multipart upload must contain either one zip archive or one or more files[] parts"
+                        .to_string(),
+            });
+        }
+    };
+
+    Ok(ParsedSkillUpload { tenant_id, upload })
+}
+
+fn looks_like_zip_upload(file_name: Option<&str>, content_type: Option<&str>) -> bool {
+    file_name.is_some_and(|name| name.to_ascii_lowercase().ends_with(".zip"))
+        || content_type.is_some_and(|value| {
+            value.eq_ignore_ascii_case("application/zip")
+                || value.eq_ignore_ascii_case("application/x-zip-compressed")
+        })
+}
+
+fn invalid_multipart(message: String) -> SkillsApiError {
+    SkillsApiError::BadRequest {
+        code: "invalid_multipart",
+        message,
+    }
+}
+
+fn unexpected_field(message: &str) -> SkillsApiError {
+    SkillsApiError::BadRequest {
+        code: "unexpected_field",
+        message: message.to_string(),
+    }
+}
+
+fn bad_text_field(field: &str, error: MultipartError) -> SkillsApiError {
+    SkillsApiError::BadRequest {
+        code: "invalid_multipart",
+        message: format!("failed to read '{field}' field: {error}"),
+    }
+}
+
+fn build_mutation_response(
+    value: SkillCreateResult,
+) -> Result<SkillMutationResponse, SkillsApiError> {
+    Ok(SkillMutationResponse {
+        skill: SkillResponse {
+            id: value.skill.skill_id.clone(),
+            name: value.skill.name.clone(),
+            short_description: value.skill.short_description.clone(),
+            description: value.skill.description.clone().unwrap_or_default(),
+            source: value.skill.source.clone(),
+            latest_version: value.skill.latest_version.clone(),
+            default_version: value.skill.default_version.clone(),
+            has_code_files: value.skill.has_code_files,
+            created_at: value.skill.created_at.to_rfc3339(),
+            updated_at: value.skill.updated_at.to_rfc3339(),
+        },
+        version: SkillVersionResponse {
+            skill_id: value.version.skill_id.clone(),
+            version: value.version.version.clone(),
+            version_number: value.version.version_number,
+            name: value.version.name.clone(),
+            short_description: value.version.short_description.clone(),
+            description: value.version.description.clone(),
+            interface: serialize_optional_json(value.version.interface.as_ref())?,
+            dependencies: serialize_optional_json(value.version.dependencies.as_ref())?,
+            policy: serialize_optional_json(value.version.policy.as_ref())?,
+            deprecated: value.version.deprecated,
+            files: value
+                .version
+                .file_manifest
+                .iter()
+                .map(|entry| SkillVersionFileResponse {
+                    path: entry.relative_path.clone(),
+                    size_bytes: entry.size_bytes,
+                })
+                .collect(),
+            created_at: value.version.created_at.to_rfc3339(),
+        },
+        warnings: value
+            .warnings
+            .into_iter()
+            .map(|warning| SkillWarningResponse {
+                kind: format!("{:?}", warning.kind),
+                path: warning.path,
+                message: warning.message,
+            })
+            .collect(),
+    })
+}
+
+fn serialize_optional_json<T: serde::Serialize>(
+    value: Option<&T>,
+) -> Result<Option<Value>, SkillsApiError> {
+    value
+        .map(|value| {
+            serde_json::to_value(value).map_err(|error| SkillsApiError::Internal {
+                code: "skills_internal_error",
+                message: format!("failed to serialize skills response payload: {error}"),
+            })
+        })
+        .transpose()
+}

--- a/model_gateway/src/routers/skills/mod.rs
+++ b/model_gateway/src/routers/skills/mod.rs
@@ -1,0 +1,3 @@
+mod handlers;
+
+pub use handlers::{create_skill, create_skill_version};

--- a/model_gateway/src/server.rs
+++ b/model_gateway/src/server.rs
@@ -63,7 +63,7 @@ use crate::{
         openai::realtime::ws::RealtimeQueryParams,
         parse, responses as response_handlers,
         router_manager::RouterManager,
-        tokenize, AudioFile, RouterTrait,
+        skills, tokenize, AudioFile, RouterTrait,
     },
     service_discovery::{start_service_discovery, ServiceDiscoveryConfig},
     wasm::route::{add_wasm_module, list_wasm_modules, remove_wasm_module},
@@ -789,6 +789,18 @@ async fn v1_tokenizers_remove(
     tokenize::remove_tokenizer(&state.context, &tokenizer_id).await
 }
 
+async fn v1_skills_create(State(state): State<Arc<AppState>>, multipart: Multipart) -> Response {
+    skills::create_skill(State(state), multipart).await
+}
+
+async fn v1_skills_create_version(
+    State(state): State<Arc<AppState>>,
+    Path(skill_id): Path<String>,
+    multipart: Multipart,
+) -> Response {
+    skills::create_skill_version(State(state), Path(skill_id), multipart).await
+}
+
 pub struct ServerConfig {
     pub host: String,
     pub port: u16,
@@ -952,7 +964,7 @@ pub fn build_app(
         .route("/get_server_info", get(get_server_info));
 
     // Build admin routes with control plane auth if configured, otherwise use simple API key auth
-    let admin_routes = Router::new()
+    let mut admin_routes = Router::new()
         .route("/flush_cache", post(flush_cache))
         .route("/get_loads", get(get_loads))
         .route("/parse/function_call", post(parse_function_call))
@@ -973,6 +985,23 @@ pub fn build_app(
             "/v1/tokenizers/{tokenizer_id}/status",
             get(v1_tokenizers_status),
         );
+
+    if app_state.context.router_config.skills_enabled
+        && app_state
+            .context
+            .router_config
+            .skills
+            .as_ref()
+            .is_some_and(|skills_config| skills_config.admin.enabled)
+        && app_state.context.skill_service.is_some()
+    {
+        admin_routes = admin_routes
+            .route("/v1/skills", post(v1_skills_create))
+            .route(
+                "/v1/skills/{skill_id}/versions",
+                post(v1_skills_create_version),
+            );
+    }
 
     // Build worker routes
     let worker_routes = Router::new()

--- a/model_gateway/tests/api/mod.rs
+++ b/model_gateway/tests/api/mod.rs
@@ -4,4 +4,5 @@ mod api_endpoints_test;
 mod parser_endpoints_test;
 mod request_formats_test;
 mod responses_api_test;
+mod skills_api_test;
 mod streaming_tests;

--- a/model_gateway/tests/api/skills_api_test.rs
+++ b/model_gateway/tests/api/skills_api_test.rs
@@ -1,0 +1,330 @@
+#![expect(
+    clippy::disallowed_methods,
+    clippy::expect_used,
+    reason = "integration test intentionally uses panic-on-failure helpers and a background test server task"
+)]
+
+use std::{
+    any::Any,
+    io::{Cursor, Write},
+    sync::Arc,
+};
+
+use async_trait::async_trait;
+use axum::{body::Body, extract::Request, response::Response, Router};
+use reqwest::multipart::{Form, Part};
+use serde_json::Value;
+use smg::{
+    app_context::AppContext,
+    config::{PolicyConfig, RouterConfig, RoutingMode},
+    routers::RouterTrait,
+};
+use smg_skills::SkillsConfig;
+use tempfile::TempDir;
+use zip::{write::SimpleFileOptions, CompressionMethod, ZipWriter};
+
+use crate::common::test_app::create_test_app_with_context;
+
+#[derive(Debug)]
+struct NoopRouter;
+
+#[async_trait]
+impl RouterTrait for NoopRouter {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn router_type(&self) -> &'static str {
+        "noop"
+    }
+
+    async fn health_generate(&self, _req: Request<Body>) -> Response {
+        Response::new(Body::empty())
+    }
+}
+
+fn skills_test_config(
+    blob_dir: &TempDir,
+    cache_dir: &TempDir,
+    admin_enabled: bool,
+) -> RouterConfig {
+    let mut config = RouterConfig::new(
+        RoutingMode::Regular {
+            worker_urls: vec!["http://worker1:8000".to_string()],
+        },
+        PolicyConfig::Random,
+    );
+    config.api_key = Some("test-admin-key".to_string());
+    config.skills_enabled = true;
+
+    let mut skills = SkillsConfig::default();
+    skills.admin.enabled = admin_enabled;
+    skills.blob_store.path = blob_dir.path().display().to_string();
+    skills.cache.path = cache_dir.path().display().to_string();
+    config.skills = Some(skills);
+
+    config
+}
+
+async fn create_skills_test_app(config: RouterConfig) -> Router {
+    let context = Arc::new(
+        AppContext::from_config(config, 60, None, None)
+            .await
+            .expect("build test app context"),
+    );
+    create_test_app_with_context(Arc::new(NoopRouter), context)
+}
+
+async fn spawn_app(app: Router) -> (String, tokio::task::JoinHandle<()>) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let addr = listener.local_addr().expect("listener addr");
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("serve test app");
+    });
+    (format!("http://{addr}"), handle)
+}
+
+fn build_skill_zip(skill_md: &[u8], extra_files: &[(&str, &[u8])]) -> Vec<u8> {
+    let cursor = Cursor::new(Vec::new());
+    let mut writer = ZipWriter::new(cursor);
+    let options = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+
+    writer
+        .start_file("bundle/SKILL.md", options)
+        .expect("start SKILL.md entry");
+    writer.write_all(skill_md).expect("write SKILL.md");
+
+    for (path, contents) in extra_files {
+        writer
+            .start_file(format!("bundle/{path}"), options)
+            .expect("start extra zip entry");
+        writer.write_all(contents).expect("write extra zip entry");
+    }
+
+    writer.finish().expect("finish zip writer").into_inner()
+}
+
+#[tokio::test]
+async fn create_skill_returns_created_skill_and_version() {
+    let blob_dir = tempfile::tempdir().expect("blob tempdir");
+    let cache_dir = tempfile::tempdir().expect("cache tempdir");
+    let app = create_skills_test_app(skills_test_config(&blob_dir, &cache_dir, true)).await;
+    let (base_url, server) = spawn_app(app).await;
+
+    let response = reqwest::Client::new()
+        .post(format!("{base_url}/v1/skills"))
+        .bearer_auth("test-admin-key")
+        .multipart(
+            Form::new()
+                .text("tenant_id", "tenant-a")
+                .part(
+                    "files[]",
+                    Part::bytes(
+                        b"---\nname: acme:map\ndescription: Map the repo\nmetadata:\n  short-description: Map it\n---\nUse rg."
+                            .to_vec(),
+                    )
+                    .file_name("SKILL.md")
+                    .mime_str("text/markdown")
+                    .expect("valid markdown mime"),
+                )
+                .part(
+                    "files[]",
+                    Part::bytes(b"print('hi')".to_vec())
+                        .file_name("scripts/run.py")
+                        .mime_str("text/x-python")
+                        .expect("valid python mime"),
+                ),
+        )
+        .send()
+        .await
+        .expect("send create skill request");
+
+    assert_eq!(response.status(), reqwest::StatusCode::CREATED);
+    let body: Value = response.json().await.expect("json response");
+    assert_eq!(body["skill"]["name"], "acme:map");
+    assert_eq!(body["version"]["version_number"], 1);
+    assert_eq!(body["version"]["files"].as_array().map(Vec::len), Some(2));
+    assert!(body["skill"]["id"]
+        .as_str()
+        .is_some_and(|id| id.starts_with("skill_") && id.len() == 32));
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn create_skill_accepts_zip_bundle_upload() {
+    let blob_dir = tempfile::tempdir().expect("blob tempdir");
+    let cache_dir = tempfile::tempdir().expect("cache tempdir");
+    let app = create_skills_test_app(skills_test_config(&blob_dir, &cache_dir, true)).await;
+    let (base_url, server) = spawn_app(app).await;
+
+    let bundle = build_skill_zip(
+        b"---\nname: acme:zip\ndescription: Zip based skill\nmetadata:\n  short-description: Zip it\n---\nUse zip uploads.",
+        &[("scripts/run.py", b"print('zip')")],
+    );
+
+    let response = reqwest::Client::new()
+        .post(format!("{base_url}/v1/skills"))
+        .bearer_auth("test-admin-key")
+        .multipart(
+            Form::new().text("tenant_id", "tenant-a").part(
+                "bundle",
+                Part::bytes(bundle)
+                    .file_name("acme-skill.zip")
+                    .mime_str("application/zip")
+                    .expect("valid zip mime"),
+            ),
+        )
+        .send()
+        .await
+        .expect("send create skill zip request");
+
+    assert_eq!(response.status(), reqwest::StatusCode::CREATED);
+    let body: Value = response.json().await.expect("json response");
+    assert_eq!(body["skill"]["name"], "acme:zip");
+    assert_eq!(body["version"]["version_number"], 1);
+    assert_eq!(body["version"]["files"].as_array().map(Vec::len), Some(2));
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn create_skill_rejects_missing_target_tenant() {
+    let blob_dir = tempfile::tempdir().expect("blob tempdir");
+    let cache_dir = tempfile::tempdir().expect("cache tempdir");
+    let app = create_skills_test_app(skills_test_config(&blob_dir, &cache_dir, true)).await;
+    let (base_url, server) = spawn_app(app).await;
+
+    let response = reqwest::Client::new()
+        .post(format!("{base_url}/v1/skills"))
+        .bearer_auth("test-admin-key")
+        .multipart(
+            Form::new().part(
+                "files[]",
+                Part::bytes(
+                    b"---\nname: acme:map\ndescription: Map the repo\n---\nUse rg.".to_vec(),
+                )
+                .file_name("SKILL.md")
+                .mime_str("text/markdown")
+                .expect("valid markdown mime"),
+            ),
+        )
+        .send()
+        .await
+        .expect("send create skill request");
+
+    assert_eq!(response.status(), reqwest::StatusCode::BAD_REQUEST);
+    let body: Value = response.json().await.expect("json response");
+    assert_eq!(body["error"]["code"], "missing_target_tenant");
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn create_skill_version_returns_incremented_version() {
+    let blob_dir = tempfile::tempdir().expect("blob tempdir");
+    let cache_dir = tempfile::tempdir().expect("cache tempdir");
+    let app = create_skills_test_app(skills_test_config(&blob_dir, &cache_dir, true)).await;
+    let (base_url, server) = spawn_app(app).await;
+    let client = reqwest::Client::new();
+
+    let create_response = client
+        .post(format!("{base_url}/v1/skills"))
+        .bearer_auth("test-admin-key")
+        .multipart(
+            Form::new().text("tenant_id", "tenant-a").part(
+                "files[]",
+                Part::bytes(
+                    b"---\nname: acme:map\ndescription: Map the repo\nmetadata:\n  short-description: Map it\n---\nUse rg."
+                        .to_vec(),
+                )
+                .file_name("SKILL.md")
+                .mime_str("text/markdown")
+                .expect("valid markdown mime"),
+            ),
+        )
+        .send()
+        .await
+        .expect("send create skill request");
+    assert_eq!(create_response.status(), reqwest::StatusCode::CREATED);
+    let create_body: Value = create_response.json().await.expect("json response");
+    let skill_id = create_body["skill"]["id"]
+        .as_str()
+        .expect("skill id in create response")
+        .to_string();
+
+    let version_response = client
+        .post(format!("{base_url}/v1/skills/{skill_id}/versions"))
+        .bearer_auth("test-admin-key")
+        .multipart(
+            Form::new()
+                .text("tenant_id", "tenant-a")
+                .part(
+                    "files[]",
+                    Part::bytes(
+                        b"---\nname: acme:map\ndescription: Updated mapping skill\nmetadata:\n  short-description: Map it better\n---\nUse rg --files."
+                            .to_vec(),
+                    )
+                    .file_name("SKILL.md")
+                    .mime_str("text/markdown")
+                    .expect("valid markdown mime"),
+                )
+                .part(
+                    "files[]",
+                    Part::bytes(b"print('updated')".to_vec())
+                        .file_name("scripts/run.py")
+                        .mime_str("text/x-python")
+                        .expect("valid python mime"),
+                ),
+        )
+        .send()
+        .await
+        .expect("send create skill version request");
+
+    assert_eq!(version_response.status(), reqwest::StatusCode::CREATED);
+    let version_body: Value = version_response.json().await.expect("json response");
+    assert_eq!(version_body["skill"]["id"], skill_id);
+    assert_eq!(
+        version_body["skill"]["latest_version"],
+        version_body["version"]["version"]
+    );
+    assert_eq!(version_body["version"]["version_number"], 2);
+    assert_eq!(
+        version_body["version"]["files"].as_array().map(Vec::len),
+        Some(2)
+    );
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn create_skill_route_is_not_mounted_when_skills_admin_is_disabled() {
+    let blob_dir = tempfile::tempdir().expect("blob tempdir");
+    let cache_dir = tempfile::tempdir().expect("cache tempdir");
+    let app = create_skills_test_app(skills_test_config(&blob_dir, &cache_dir, false)).await;
+    let (base_url, server) = spawn_app(app).await;
+
+    let response = reqwest::Client::new()
+        .post(format!("{base_url}/v1/skills"))
+        .bearer_auth("test-admin-key")
+        .multipart(
+            Form::new().text("tenant_id", "tenant-a").part(
+                "files[]",
+                Part::bytes(
+                    b"---\nname: acme:map\ndescription: Map the repo\n---\nUse rg.".to_vec(),
+                )
+                .file_name("SKILL.md")
+                .mime_str("text/markdown")
+                .expect("valid markdown mime"),
+            ),
+        )
+        .send()
+        .await
+        .expect("send create skill request");
+
+    assert_eq!(response.status(), reqwest::StatusCode::NOT_FOUND);
+
+    server.abort();
+}


### PR DESCRIPTION
## Summary
- add public skills CRUD wire types and multipart field constants in crates/protocols/src/skills.rs
- add skills service orchestration for initial create and create-version uploads in crates/skills
- add admin-gated POST /v1/skills and POST /v1/skills/{skill_id}/versions handlers, following the existing server wrapper pattern
- add protocol, service, and API tests for raw files upload, zip bundle upload, and version creation

## Verification
- cargo +nightly fmt --all --check
- cargo clippy --all-targets --all-features -- -D warnings
- env -u RUSTC_WRAPPER CARGO_BUILD_RUSTC_WRAPPER= cargo test

## Notes
- make python-dev was started but not completed because it was interrupted from the terminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Skills API endpoints to create and manage skills with support for ZIP archive and multi-file uploads
  * Implemented automatic version tracking for skill updates with monotonic version numbering
  * Structured error responses with detailed error codes and messages
  * Skills functionality can be conditionally enabled through configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->