### PR TITLE
test(responses): add annotation round-trip tests (E5)

### DIFF
--- a/e2e_test/responses/test_annotations.py
+++ b/e2e_test/responses/test_annotations.py
@@ -347,6 +347,30 @@ def _create_code_interpreter_response(api_client, model, stream):
     )
 
 
+_CODE_INTERPRETER_UNAVAILABLE_MARKERS = (
+    "code_interpreter",
+    "code interpreter",
+    "tool is not supported",
+    "not supported",
+    "unsupported tool",
+    "unknown tool",
+    "not enabled",
+)
+
+
+def _is_code_interpreter_unavailable(exc: openai.BadRequestError) -> bool:
+    """Narrow the BadRequest catch to genuine "tool unavailable" signals.
+
+    A bare ``except openai.BadRequestError`` would also swallow 400s from a
+    broken request path (gateway payload bug, rejected schema, etc.), which
+    is exactly the kind of regression this test exists to catch. Restrict
+    the skip to responses whose error message explicitly mentions that the
+    code_interpreter tool itself is unavailable on the target model.
+    """
+    message = (getattr(exc, "message", None) or str(exc) or "").lower()
+    return any(marker in message for marker in _CODE_INTERPRETER_UNAVAILABLE_MARKERS)
+
+
 @pytest.fixture(scope="class")
 def code_interpreter_response_pair(setup_backend):
     """Run code_interpreter twice (non-stream + stream) and cache both outputs.
@@ -369,14 +393,18 @@ def code_interpreter_response_pair(setup_backend):
     try:
         non_stream_resp = _create_code_interpreter_response(api_client, model, stream=False)
     except openai.BadRequestError as exc:
-        pytest.skip(f"code_interpreter unavailable on this model: {exc}")
+        if _is_code_interpreter_unavailable(exc):
+            pytest.skip(f"code_interpreter unavailable on this model: {exc}")
+        raise
     assert non_stream_resp.error is None, f"Response error: {non_stream_resp.error}"
 
     time.sleep(_API_RATE_LIMIT_DELAY)
     try:
         stream_resp = _create_code_interpreter_response(api_client, model, stream=True)
     except openai.BadRequestError as exc:
-        pytest.skip(f"code_interpreter unavailable on this model: {exc}")
+        if _is_code_interpreter_unavailable(exc):
+            pytest.skip(f"code_interpreter unavailable on this model: {exc}")
+        raise
     streaming_output = _stream_to_final_output(stream_resp)
 
     return {

--- a/e2e_test/responses/test_annotations.py
+++ b/e2e_test/responses/test_annotations.py
@@ -1,0 +1,437 @@
+"""Annotation round-trip tests for Response API.
+
+Task E5 (from the Responses API gap audit): verify that
+``message.output_text.annotations`` carries typed ``FileCitation``,
+``URLCitation``, ``ContainerFileCitation`` and ``FilePath`` variants across
+both streaming and non-streaming responses.
+
+Protocol types landed in P1 (``crates/protocols/src/responses.rs``); this
+test file only exercises the gateway's surfacing of annotations end-to-end
+and makes no assumption about which backend produced them.
+
+The tests run against the OpenAI cloud backend (``@pytest.mark.vendor("openai")``)
+because the built-in tools that emit typed annotations (``web_search_preview``,
+``file_search``, ``code_interpreter``) are hosted upstream. Each annotation
+variant has its own class with both a non-streaming and a streaming case.
+Tests that require extra external setup (uploading a file for file_search)
+create that setup directly against the OpenAI API and clean it up at
+teardown; tests that depend on model-driven output shape (code_interpreter
+producing container_file_citation / file_path) validate the variant
+structurally only if the model actually produced it, otherwise they skip
+with an explanation rather than falsely fail.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import os
+import time
+from collections.abc import Iterable
+
+import openai
+import pytest
+
+logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# Shared helpers
+# =============================================================================
+
+
+_WEB_SEARCH_PROMPT = (
+    "Search the web for the latest stable release of the Rust programming language "
+    "and cite the official source in one sentence."
+)
+
+
+def _iter_output_text_parts(output: Iterable) -> Iterable:
+    """Yield every output_text content part across all message items."""
+    for item in output:
+        # ``item`` is a ResponseOutputItem; only ``message`` items carry content.
+        item_type = getattr(item, "type", None)
+        if item_type != "message":
+            continue
+        content = getattr(item, "content", None) or []
+        for part in content:
+            if getattr(part, "type", None) == "output_text":
+                yield part
+
+
+def _collect_annotations(output: Iterable) -> list:
+    """Flatten annotations from all output_text parts in a response's output."""
+    annotations = []
+    for part in _iter_output_text_parts(output):
+        anns = getattr(part, "annotations", None) or []
+        annotations.extend(anns)
+    return annotations
+
+
+def _stream_to_final_output(resp) -> list:
+    """Iterate a streaming Responses SDK object and return the final output list.
+
+    The OpenAI SDK emits discrete events; the final output array lives on the
+    ``response.completed`` event's nested ``response.output`` field. Iterating
+    the full event stream also forces the SDK to deserialize every intermediate
+    ``output_item.done`` / ``content_part.done`` / ``content_part.added`` event
+    through its discriminated annotation union — that would raise on an unknown
+    ``type`` string, so a clean iteration is itself a round-trip assertion.
+    """
+    events = list(resp)
+    assert events, "Streaming response produced no events"
+
+    completed = [e for e in events if getattr(e, "type", None) == "response.completed"]
+    assert len(completed) == 1, (
+        f"Expected exactly one response.completed event, got {len(completed)}"
+    )
+    final_output = completed[0].response.output
+    assert isinstance(final_output, list)
+    return final_output
+
+
+def _assert_annotation_structurally_valid(ann) -> None:
+    """Sanity-check an annotation object against its spec-required fields.
+
+    The OpenAI SDK already discriminates on ``type`` and deserializes into the
+    matching typed class; re-checking the required fields here catches both
+    regressions in smg's gateway (e.g., dropping a field) and drift in the
+    upstream wire contract.
+    """
+    ann_type = getattr(ann, "type", None)
+    if ann_type == "file_citation":
+        assert isinstance(ann.file_id, str) and ann.file_id, "file_citation.file_id missing"
+        assert isinstance(ann.filename, str) and ann.filename, "file_citation.filename missing"
+        assert isinstance(ann.index, int) and ann.index >= 0, "file_citation.index missing"
+    elif ann_type == "url_citation":
+        assert isinstance(ann.url, str) and ann.url.startswith(("http://", "https://")), (
+            f"url_citation.url invalid: {ann.url!r}"
+        )
+        assert isinstance(ann.title, str), "url_citation.title missing"
+        assert isinstance(ann.start_index, int) and ann.start_index >= 0
+        assert isinstance(ann.end_index, int) and ann.end_index >= ann.start_index
+    elif ann_type == "container_file_citation":
+        assert isinstance(ann.container_id, str) and ann.container_id
+        assert isinstance(ann.file_id, str) and ann.file_id
+        assert isinstance(ann.filename, str) and ann.filename
+        assert isinstance(ann.start_index, int) and ann.start_index >= 0
+        assert isinstance(ann.end_index, int) and ann.end_index >= ann.start_index
+    elif ann_type == "file_path":
+        assert isinstance(ann.file_id, str) and ann.file_id, "file_path.file_id missing"
+        assert isinstance(ann.index, int) and ann.index >= 0, "file_path.index missing"
+    else:
+        pytest.fail(
+            f"Annotation type {ann_type!r} is not one of the spec variants "
+            "(file_citation | url_citation | container_file_citation | file_path)"
+        )
+
+
+# =============================================================================
+# URL citation (web_search_preview)
+# =============================================================================
+
+
+@pytest.mark.vendor("openai")
+@pytest.mark.gpu(0)
+@pytest.mark.parametrize("setup_backend", ["openai"], indirect=True)
+class TestUrlCitationAnnotation:
+    """Verify ``url_citation`` annotations round-trip from the web_search tool."""
+
+    def _create_web_search_response(self, api_client, model, stream):
+        return api_client.responses.create(
+            model=model,
+            input=_WEB_SEARCH_PROMPT,
+            tools=[{"type": "web_search_preview"}],
+            stream=stream,
+        )
+
+    def test_url_citation_non_streaming(self, model, api_client):
+        time.sleep(2)
+        resp = self._create_web_search_response(api_client, model, stream=False)
+        assert resp.error is None, f"Response error: {resp.error}"
+        assert resp.output is not None
+
+        annotations = _collect_annotations(resp.output)
+        url_citations = [a for a in annotations if getattr(a, "type", None) == "url_citation"]
+        assert url_citations, (
+            "Expected at least one url_citation annotation from web_search_preview; "
+            f"got annotations: {[getattr(a, 'type', None) for a in annotations]}"
+        )
+        for ann in url_citations:
+            _assert_annotation_structurally_valid(ann)
+
+    def test_url_citation_streaming(self, model, api_client):
+        time.sleep(2)
+        resp = self._create_web_search_response(api_client, model, stream=True)
+        final_output = _stream_to_final_output(resp)
+
+        annotations = _collect_annotations(final_output)
+        url_citations = [a for a in annotations if getattr(a, "type", None) == "url_citation"]
+        assert url_citations, (
+            "Expected at least one url_citation annotation in streaming response; "
+            f"got annotations: {[getattr(a, 'type', None) for a in annotations]}"
+        )
+        for ann in url_citations:
+            _assert_annotation_structurally_valid(ann)
+
+
+# =============================================================================
+# File citation (file_search)
+# =============================================================================
+
+
+_FILE_SEARCH_DOC = (
+    "Project Astra uses the Pulsar-7 reactor core. "
+    "The reactor operates at a nominal temperature of 842 Kelvin. "
+    "Maintenance protocol AST-42 requires quarterly coolant flush. "
+)
+
+
+@pytest.fixture(scope="class")
+def openai_direct_client():
+    """Direct OpenAI client for out-of-band setup that smg does not proxy.
+
+    smg's gateway does not mount ``/v1/files`` or ``/v1/vector_stores``, so we
+    create the vector store directly against the OpenAI API and then pass the
+    resulting ID through the gateway when calling ``responses.create`` with the
+    ``file_search`` tool. This keeps the smg-under-test path exercised for the
+    annotation round-trip while sidestepping a hard dependency on endpoint
+    coverage that is out of scope for E5.
+    """
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        pytest.skip("OPENAI_API_KEY not set — cannot create a vector store for file_search")
+    client = openai.OpenAI(api_key=api_key)
+    yield client
+
+
+@pytest.fixture(scope="class")
+def file_search_vector_store(openai_direct_client):
+    """Create + populate a vector store, then tear it down at class scope."""
+    client = openai_direct_client
+    file_obj = None
+    vs = None
+    try:
+        buf = io.BytesIO(_FILE_SEARCH_DOC.encode("utf-8"))
+        buf.name = "project_astra.txt"
+        try:
+            file_obj = client.files.create(file=buf, purpose="assistants")
+        except openai.OpenAIError as exc:
+            pytest.skip(f"Unable to upload file for file_search: {exc}")
+
+        try:
+            vs = client.vector_stores.create(name="smg-e5-annotations-test")
+        except openai.OpenAIError as exc:
+            pytest.skip(f"Unable to create vector store for file_search: {exc}")
+
+        try:
+            client.vector_stores.files.create_and_poll(vector_store_id=vs.id, file_id=file_obj.id)
+        except openai.OpenAIError as exc:
+            pytest.skip(f"Unable to index file into vector store: {exc}")
+
+        yield vs.id
+    finally:
+        if vs is not None:
+            try:
+                client.vector_stores.delete(vector_store_id=vs.id)
+            except openai.OpenAIError:
+                pass
+        if file_obj is not None:
+            try:
+                client.files.delete(file_id=file_obj.id)
+            except openai.OpenAIError:
+                pass
+
+
+@pytest.mark.vendor("openai")
+@pytest.mark.gpu(0)
+@pytest.mark.parametrize("setup_backend", ["openai"], indirect=True)
+class TestFileCitationAnnotation:
+    """Verify ``file_citation`` annotations round-trip from the file_search tool."""
+
+    _PROMPT = (
+        "Using the attached project documentation, what is the nominal operating "
+        "temperature of the Pulsar-7 reactor core? Cite the document."
+    )
+
+    def _create_file_search_response(self, api_client, model, vector_store_id, stream):
+        return api_client.responses.create(
+            model=model,
+            input=self._PROMPT,
+            tools=[
+                {
+                    "type": "file_search",
+                    "vector_store_ids": [vector_store_id],
+                }
+            ],
+            include=["file_search_call.results"],
+            stream=stream,
+        )
+
+    def test_file_citation_non_streaming(self, model, api_client, file_search_vector_store):
+        time.sleep(2)
+        resp = self._create_file_search_response(
+            api_client, model, file_search_vector_store, stream=False
+        )
+        assert resp.error is None, f"Response error: {resp.error}"
+        assert resp.output is not None
+
+        annotations = _collect_annotations(resp.output)
+        file_citations = [a for a in annotations if getattr(a, "type", None) == "file_citation"]
+        if not file_citations:
+            pytest.skip(
+                "Model did not emit file_citation annotations for this prompt; "
+                "annotation structural check is skipped. "
+                f"Annotations observed: {[getattr(a, 'type', None) for a in annotations]}"
+            )
+        for ann in file_citations:
+            _assert_annotation_structurally_valid(ann)
+
+    def test_file_citation_streaming(self, model, api_client, file_search_vector_store):
+        time.sleep(2)
+        resp = self._create_file_search_response(
+            api_client, model, file_search_vector_store, stream=True
+        )
+        final_output = _stream_to_final_output(resp)
+
+        annotations = _collect_annotations(final_output)
+        file_citations = [a for a in annotations if getattr(a, "type", None) == "file_citation"]
+        if not file_citations:
+            pytest.skip(
+                "Model did not emit file_citation annotations for this prompt in "
+                "streaming mode; annotation structural check is skipped. "
+                f"Annotations observed: {[getattr(a, 'type', None) for a in annotations]}"
+            )
+        for ann in file_citations:
+            _assert_annotation_structurally_valid(ann)
+
+
+# =============================================================================
+# Container file citation + File path (code_interpreter)
+# =============================================================================
+
+
+_CODE_INTERPRETER_PROMPT = (
+    "Write a tiny CSV file named 'sample.csv' with the columns 'id,value' and "
+    "three rows (1,'apple'; 2,'banana'; 3,'cherry'). Then read the file back "
+    "and answer: which row has id=2? Reference the file explicitly in your "
+    "response so it appears as a citation."
+)
+
+
+def _create_code_interpreter_response(api_client, model, stream):
+    return api_client.responses.create(
+        model=model,
+        input=_CODE_INTERPRETER_PROMPT,
+        tools=[
+            {
+                "type": "code_interpreter",
+                "container": {"type": "auto"},
+            }
+        ],
+        stream=stream,
+    )
+
+
+@pytest.mark.vendor("openai")
+@pytest.mark.gpu(0)
+@pytest.mark.parametrize("setup_backend", ["openai"], indirect=True)
+class TestContainerFileCitationAnnotation:
+    """Verify ``container_file_citation`` annotations from code_interpreter.
+
+    The container_file_citation variant is produced when the model cites a
+    file that lives inside the code_interpreter container. Whether the model
+    emits one is model-dependent; the tests validate the wire shape when the
+    annotation is present and skip (rather than fail) when it is not, so that
+    regressions in the typed round-trip are caught while not tying the suite
+    to model-prompt sensitivity.
+    """
+
+    def test_container_file_citation_non_streaming(self, model, api_client):
+        time.sleep(2)
+        try:
+            resp = _create_code_interpreter_response(api_client, model, stream=False)
+        except openai.BadRequestError as exc:
+            pytest.skip(f"code_interpreter unavailable on this model: {exc}")
+        assert resp.error is None, f"Response error: {resp.error}"
+
+        annotations = _collect_annotations(resp.output)
+        container_citations = [
+            a for a in annotations if getattr(a, "type", None) == "container_file_citation"
+        ]
+        if not container_citations:
+            pytest.skip(
+                "Model did not emit container_file_citation annotations; "
+                f"annotations observed: {[getattr(a, 'type', None) for a in annotations]}"
+            )
+        for ann in container_citations:
+            _assert_annotation_structurally_valid(ann)
+
+    def test_container_file_citation_streaming(self, model, api_client):
+        time.sleep(2)
+        try:
+            resp = _create_code_interpreter_response(api_client, model, stream=True)
+        except openai.BadRequestError as exc:
+            pytest.skip(f"code_interpreter unavailable on this model: {exc}")
+        final_output = _stream_to_final_output(resp)
+
+        annotations = _collect_annotations(final_output)
+        container_citations = [
+            a for a in annotations if getattr(a, "type", None) == "container_file_citation"
+        ]
+        if not container_citations:
+            pytest.skip(
+                "Model did not emit container_file_citation annotations in streaming mode; "
+                f"annotations observed: {[getattr(a, 'type', None) for a in annotations]}"
+            )
+        for ann in container_citations:
+            _assert_annotation_structurally_valid(ann)
+
+
+@pytest.mark.vendor("openai")
+@pytest.mark.gpu(0)
+@pytest.mark.parametrize("setup_backend", ["openai"], indirect=True)
+class TestFilePathAnnotation:
+    """Verify ``file_path`` annotations round-trip from generated files.
+
+    ``file_path`` is emitted when the model references a generated file by
+    path (e.g., a CSV or image generated during a code_interpreter turn).
+    As with ``container_file_citation``, the presence of the annotation is
+    model-driven; the test validates the wire shape when present.
+    """
+
+    def test_file_path_non_streaming(self, model, api_client):
+        time.sleep(2)
+        try:
+            resp = _create_code_interpreter_response(api_client, model, stream=False)
+        except openai.BadRequestError as exc:
+            pytest.skip(f"code_interpreter unavailable on this model: {exc}")
+        assert resp.error is None, f"Response error: {resp.error}"
+
+        annotations = _collect_annotations(resp.output)
+        file_paths = [a for a in annotations if getattr(a, "type", None) == "file_path"]
+        if not file_paths:
+            pytest.skip(
+                "Model did not emit file_path annotations; "
+                f"annotations observed: {[getattr(a, 'type', None) for a in annotations]}"
+            )
+        for ann in file_paths:
+            _assert_annotation_structurally_valid(ann)
+
+    def test_file_path_streaming(self, model, api_client):
+        time.sleep(2)
+        try:
+            resp = _create_code_interpreter_response(api_client, model, stream=True)
+        except openai.BadRequestError as exc:
+            pytest.skip(f"code_interpreter unavailable on this model: {exc}")
+        final_output = _stream_to_final_output(resp)
+
+        annotations = _collect_annotations(final_output)
+        file_paths = [a for a in annotations if getattr(a, "type", None) == "file_path"]
+        if not file_paths:
+            pytest.skip(
+                "Model did not emit file_path annotations in streaming mode; "
+                f"annotations observed: {[getattr(a, 'type', None) for a in annotations]}"
+            )
+        for ann in file_paths:
+            _assert_annotation_structurally_valid(ann)

--- a/e2e_test/responses/test_annotations.py
+++ b/e2e_test/responses/test_annotations.py
@@ -348,18 +348,23 @@ def _create_code_interpreter_response(api_client, model, stream):
 
 
 @pytest.fixture(scope="class")
-def code_interpreter_response_pair(model, api_client):
+def code_interpreter_response_pair(setup_backend):
     """Run code_interpreter twice (non-stream + stream) and cache both outputs.
 
     Both the ``container_file_citation`` and the ``file_path`` assertions
     inspect the same code_interpreter output for different annotation
     variants, so running the tool four times (2 variants × 2 stream modes)
     when two invocations suffice would needlessly burn quota. The fixture is
-    class-scoped and returns a
+    class-scoped and pulls ``api_client`` / ``model`` out of
+    ``setup_backend`` (also class-scoped) rather than via the shared
+    function-scoped fixtures so that scope resolution is consistent with the
+    class-scoped request. Returns a
     ``{"non_streaming": final_output, "streaming": final_output}`` dict of
     already-resolved output arrays for the four tests in
     ``TestCodeInterpreterAnnotations`` to share.
     """
+    _, model, api_client, _ = setup_backend
+
     time.sleep(_API_RATE_LIMIT_DELAY)
     try:
         non_stream_resp = _create_code_interpreter_response(api_client, model, stream=False)

--- a/e2e_test/responses/test_annotations.py
+++ b/e2e_test/responses/test_annotations.py
@@ -12,13 +12,18 @@ and makes no assumption about which backend produced them.
 The tests run against the OpenAI cloud backend (``@pytest.mark.vendor("openai")``)
 because the built-in tools that emit typed annotations (``web_search_preview``,
 ``file_search``, ``code_interpreter``) are hosted upstream. Each annotation
-variant has its own class with both a non-streaming and a streaming case.
-Tests that require extra external setup (uploading a file for file_search)
-create that setup directly against the OpenAI API and clean it up at
-teardown; tests that depend on model-driven output shape (code_interpreter
-producing container_file_citation / file_path) validate the variant
-structurally only if the model actually produced it, otherwise they skip
-with an explanation rather than falsely fail.
+variant has its own test case with both a non-streaming and a streaming
+parametrization.
+
+Guaranteed-annotation tests (``url_citation`` via web_search_preview,
+``file_citation`` via file_search against a controlled vector store indexed
+from a document whose text uniquely answers the prompt) assert the annotation
+is present — a silent skip on these variants would mask exactly the regression
+E5 is meant to catch. Model-driven annotation variants
+(``container_file_citation`` / ``file_path`` from code_interpreter) validate
+the wire shape only when the model actually emitted one, because their
+presence depends on model behavior that is not deterministic enough to gate a
+test suite on.
 """
 
 from __future__ import annotations
@@ -33,6 +38,11 @@ import openai
 import pytest
 
 logger = logging.getLogger(__name__)
+
+# Throttle between successive OpenAI API calls in this file. External APIs
+# rate-limit aggressively on rapid-fire requests; 2s is generous enough for
+# CI runs while staying cheap locally.
+_API_RATE_LIMIT_DELAY = 2
 
 
 # =============================================================================
@@ -146,7 +156,7 @@ class TestUrlCitationAnnotation:
         )
 
     def test_url_citation_non_streaming(self, model, api_client):
-        time.sleep(2)
+        time.sleep(_API_RATE_LIMIT_DELAY)
         resp = self._create_web_search_response(api_client, model, stream=False)
         assert resp.error is None, f"Response error: {resp.error}"
         assert resp.output is not None
@@ -161,7 +171,7 @@ class TestUrlCitationAnnotation:
             _assert_annotation_structurally_valid(ann)
 
     def test_url_citation_streaming(self, model, api_client):
-        time.sleep(2)
+        time.sleep(_API_RATE_LIMIT_DELAY)
         resp = self._create_web_search_response(api_client, model, stream=True)
         final_output = _stream_to_final_output(resp)
 
@@ -196,58 +206,66 @@ def openai_direct_client():
     resulting ID through the gateway when calling ``responses.create`` with the
     ``file_search`` tool. This keeps the smg-under-test path exercised for the
     annotation round-trip while sidestepping a hard dependency on endpoint
-    coverage that is out of scope for E5.
+    coverage that is out of scope for E5. A missing ``OPENAI_API_KEY`` is a hard
+    misconfiguration for ``@pytest.mark.vendor("openai")`` tests — fail loudly
+    rather than silently skipping the only coverage for ``file_citation``.
     """
     api_key = os.environ.get("OPENAI_API_KEY")
     if not api_key:
-        pytest.skip("OPENAI_API_KEY not set — cannot create a vector store for file_search")
+        pytest.fail(
+            "OPENAI_API_KEY is required for TestFileCitationAnnotation "
+            "(file_search setup needs direct /v1/files + /v1/vector_stores access)."
+        )
     client = openai.OpenAI(api_key=api_key)
     yield client
 
 
 @pytest.fixture(scope="class")
 def file_search_vector_store(openai_direct_client):
-    """Create + populate a vector store, then tear it down at class scope."""
+    """Create + populate a vector store, then tear it down at class scope.
+
+    Teardown failures are logged with the resource id so a leak (and its
+    associated cost / quota regression) is visible in CI output rather than
+    silently absorbed.
+    """
     client = openai_direct_client
     file_obj = None
     vs = None
     try:
         buf = io.BytesIO(_FILE_SEARCH_DOC.encode("utf-8"))
         buf.name = "project_astra.txt"
-        try:
-            file_obj = client.files.create(file=buf, purpose="assistants")
-        except openai.OpenAIError as exc:
-            pytest.skip(f"Unable to upload file for file_search: {exc}")
-
-        try:
-            vs = client.vector_stores.create(name="smg-e5-annotations-test")
-        except openai.OpenAIError as exc:
-            pytest.skip(f"Unable to create vector store for file_search: {exc}")
-
-        try:
-            client.vector_stores.files.create_and_poll(vector_store_id=vs.id, file_id=file_obj.id)
-        except openai.OpenAIError as exc:
-            pytest.skip(f"Unable to index file into vector store: {exc}")
-
+        file_obj = client.files.create(file=buf, purpose="assistants")
+        vs = client.vector_stores.create(name="smg-e5-annotations-test")
+        client.vector_stores.files.create_and_poll(vector_store_id=vs.id, file_id=file_obj.id)
         yield vs.id
     finally:
         if vs is not None:
             try:
                 client.vector_stores.delete(vector_store_id=vs.id)
-            except openai.OpenAIError:
-                pass
+            except openai.OpenAIError as exc:
+                logger.warning("Leaked vector store %s on teardown: %s", vs.id, exc)
         if file_obj is not None:
             try:
                 client.files.delete(file_id=file_obj.id)
-            except openai.OpenAIError:
-                pass
+            except openai.OpenAIError as exc:
+                logger.warning("Leaked file %s on teardown: %s", file_obj.id, exc)
 
 
 @pytest.mark.vendor("openai")
 @pytest.mark.gpu(0)
 @pytest.mark.parametrize("setup_backend", ["openai"], indirect=True)
 class TestFileCitationAnnotation:
-    """Verify ``file_citation`` annotations round-trip from the file_search tool."""
+    """Verify ``file_citation`` annotations round-trip from the file_search tool.
+
+    The indexed document mentions the Pulsar-7 reactor core's nominal
+    temperature (842 K) exactly once. The prompt asks for that value and
+    instructs the model to cite the document — under these conditions OpenAI's
+    ``file_search`` tool reliably emits ``file_citation`` annotations for
+    modern models (gpt-4o-mini and newer). Missing citations would indicate a
+    gateway surfacing regression (annotations typed into ``Unknown`` or
+    stripped in the OpenAI-compat router), which is exactly what E5 guards
+    against; treat that as a test failure rather than a skip.
+    """
 
     _PROMPT = (
         "Using the attached project documentation, what is the nominal operating "
@@ -269,7 +287,7 @@ class TestFileCitationAnnotation:
         )
 
     def test_file_citation_non_streaming(self, model, api_client, file_search_vector_store):
-        time.sleep(2)
+        time.sleep(_API_RATE_LIMIT_DELAY)
         resp = self._create_file_search_response(
             api_client, model, file_search_vector_store, stream=False
         )
@@ -278,17 +296,15 @@ class TestFileCitationAnnotation:
 
         annotations = _collect_annotations(resp.output)
         file_citations = [a for a in annotations if getattr(a, "type", None) == "file_citation"]
-        if not file_citations:
-            pytest.skip(
-                "Model did not emit file_citation annotations for this prompt; "
-                "annotation structural check is skipped. "
-                f"Annotations observed: {[getattr(a, 'type', None) for a in annotations]}"
-            )
+        assert file_citations, (
+            "Expected at least one file_citation annotation from file_search; "
+            f"got annotations: {[getattr(a, 'type', None) for a in annotations]}"
+        )
         for ann in file_citations:
             _assert_annotation_structurally_valid(ann)
 
     def test_file_citation_streaming(self, model, api_client, file_search_vector_store):
-        time.sleep(2)
+        time.sleep(_API_RATE_LIMIT_DELAY)
         resp = self._create_file_search_response(
             api_client, model, file_search_vector_store, stream=True
         )
@@ -296,12 +312,10 @@ class TestFileCitationAnnotation:
 
         annotations = _collect_annotations(final_output)
         file_citations = [a for a in annotations if getattr(a, "type", None) == "file_citation"]
-        if not file_citations:
-            pytest.skip(
-                "Model did not emit file_citation annotations for this prompt in "
-                "streaming mode; annotation structural check is skipped. "
-                f"Annotations observed: {[getattr(a, 'type', None) for a in annotations]}"
-            )
+        assert file_citations, (
+            "Expected at least one file_citation annotation in streaming response; "
+            f"got annotations: {[getattr(a, 'type', None) for a in annotations]}"
+        )
         for ann in file_citations:
             _assert_annotation_structurally_valid(ann)
 
@@ -333,29 +347,57 @@ def _create_code_interpreter_response(api_client, model, stream):
     )
 
 
+@pytest.fixture(scope="class")
+def code_interpreter_response_pair(model, api_client):
+    """Run code_interpreter twice (non-stream + stream) and cache both outputs.
+
+    Both the ``container_file_citation`` and the ``file_path`` assertions
+    inspect the same code_interpreter output for different annotation
+    variants, so running the tool four times (2 variants × 2 stream modes)
+    when two invocations suffice would needlessly burn quota. The fixture is
+    class-scoped and returns a
+    ``{"non_streaming": final_output, "streaming": final_output}`` dict of
+    already-resolved output arrays for the four tests in
+    ``TestCodeInterpreterAnnotations`` to share.
+    """
+    time.sleep(_API_RATE_LIMIT_DELAY)
+    try:
+        non_stream_resp = _create_code_interpreter_response(api_client, model, stream=False)
+    except openai.BadRequestError as exc:
+        pytest.skip(f"code_interpreter unavailable on this model: {exc}")
+    assert non_stream_resp.error is None, f"Response error: {non_stream_resp.error}"
+
+    time.sleep(_API_RATE_LIMIT_DELAY)
+    try:
+        stream_resp = _create_code_interpreter_response(api_client, model, stream=True)
+    except openai.BadRequestError as exc:
+        pytest.skip(f"code_interpreter unavailable on this model: {exc}")
+    streaming_output = _stream_to_final_output(stream_resp)
+
+    return {
+        "non_streaming": non_stream_resp.output,
+        "streaming": streaming_output,
+    }
+
+
 @pytest.mark.vendor("openai")
 @pytest.mark.gpu(0)
 @pytest.mark.parametrize("setup_backend", ["openai"], indirect=True)
-class TestContainerFileCitationAnnotation:
-    """Verify ``container_file_citation`` annotations from code_interpreter.
+class TestCodeInterpreterAnnotations:
+    """Verify ``container_file_citation`` + ``file_path`` from code_interpreter.
 
-    The container_file_citation variant is produced when the model cites a
-    file that lives inside the code_interpreter container. Whether the model
-    emits one is model-dependent; the tests validate the wire shape when the
-    annotation is present and skip (rather than fail) when it is not, so that
-    regressions in the typed round-trip are caught while not tying the suite
-    to model-prompt sensitivity.
+    Both variants share a single prompt and a single pair of
+    code_interpreter invocations (one non-streaming, one streaming) via the
+    ``code_interpreter_response_pair`` fixture. Whether either variant
+    actually appears is model-dependent — the tests validate the wire shape
+    when the annotation is present and skip (rather than fail) when it is
+    not, so that regressions in the typed round-trip are caught without
+    tying the suite to model-prompt sensitivity.
     """
 
-    def test_container_file_citation_non_streaming(self, model, api_client):
-        time.sleep(2)
-        try:
-            resp = _create_code_interpreter_response(api_client, model, stream=False)
-        except openai.BadRequestError as exc:
-            pytest.skip(f"code_interpreter unavailable on this model: {exc}")
-        assert resp.error is None, f"Response error: {resp.error}"
-
-        annotations = _collect_annotations(resp.output)
+    def test_container_file_citation_non_streaming(self, code_interpreter_response_pair):
+        output = code_interpreter_response_pair["non_streaming"]
+        annotations = _collect_annotations(output)
         container_citations = [
             a for a in annotations if getattr(a, "type", None) == "container_file_citation"
         ]
@@ -367,15 +409,9 @@ class TestContainerFileCitationAnnotation:
         for ann in container_citations:
             _assert_annotation_structurally_valid(ann)
 
-    def test_container_file_citation_streaming(self, model, api_client):
-        time.sleep(2)
-        try:
-            resp = _create_code_interpreter_response(api_client, model, stream=True)
-        except openai.BadRequestError as exc:
-            pytest.skip(f"code_interpreter unavailable on this model: {exc}")
-        final_output = _stream_to_final_output(resp)
-
-        annotations = _collect_annotations(final_output)
+    def test_container_file_citation_streaming(self, code_interpreter_response_pair):
+        output = code_interpreter_response_pair["streaming"]
+        annotations = _collect_annotations(output)
         container_citations = [
             a for a in annotations if getattr(a, "type", None) == "container_file_citation"
         ]
@@ -387,28 +423,9 @@ class TestContainerFileCitationAnnotation:
         for ann in container_citations:
             _assert_annotation_structurally_valid(ann)
 
-
-@pytest.mark.vendor("openai")
-@pytest.mark.gpu(0)
-@pytest.mark.parametrize("setup_backend", ["openai"], indirect=True)
-class TestFilePathAnnotation:
-    """Verify ``file_path`` annotations round-trip from generated files.
-
-    ``file_path`` is emitted when the model references a generated file by
-    path (e.g., a CSV or image generated during a code_interpreter turn).
-    As with ``container_file_citation``, the presence of the annotation is
-    model-driven; the test validates the wire shape when present.
-    """
-
-    def test_file_path_non_streaming(self, model, api_client):
-        time.sleep(2)
-        try:
-            resp = _create_code_interpreter_response(api_client, model, stream=False)
-        except openai.BadRequestError as exc:
-            pytest.skip(f"code_interpreter unavailable on this model: {exc}")
-        assert resp.error is None, f"Response error: {resp.error}"
-
-        annotations = _collect_annotations(resp.output)
+    def test_file_path_non_streaming(self, code_interpreter_response_pair):
+        output = code_interpreter_response_pair["non_streaming"]
+        annotations = _collect_annotations(output)
         file_paths = [a for a in annotations if getattr(a, "type", None) == "file_path"]
         if not file_paths:
             pytest.skip(
@@ -418,15 +435,9 @@ class TestFilePathAnnotation:
         for ann in file_paths:
             _assert_annotation_structurally_valid(ann)
 
-    def test_file_path_streaming(self, model, api_client):
-        time.sleep(2)
-        try:
-            resp = _create_code_interpreter_response(api_client, model, stream=True)
-        except openai.BadRequestError as exc:
-            pytest.skip(f"code_interpreter unavailable on this model: {exc}")
-        final_output = _stream_to_final_output(resp)
-
-        annotations = _collect_annotations(final_output)
+    def test_file_path_streaming(self, code_interpreter_response_pair):
+        output = code_interpreter_response_pair["streaming"]
+        annotations = _collect_annotations(output)
         file_paths = [a for a in annotations if getattr(a, "type", None) == "file_path"]
         if not file_paths:
             pytest.skip(

--- a/e2e_test/responses/test_annotations.py
+++ b/e2e_test/responses/test_annotations.py
@@ -61,7 +61,7 @@ def _iter_output_text_parts(output: Iterable) -> Iterable:
 
 def _collect_annotations(output: Iterable) -> list:
     """Flatten annotations from all output_text parts in a response's output."""
-    annotations = []
+    annotations: list = []
     for part in _iter_output_text_parts(output):
         anns = getattr(part, "annotations", None) or []
         annotations.extend(anns)


### PR DESCRIPTION
## Summary

Adds `e2e_test/responses/test_annotations.py` with eight tests that verify the typed annotation round-trip on the Responses API per **gap audit §E5**. Each of the four spec variants (`FileCitation`, `URLCitation`, `ContainerFileCitation`, `FilePath`) has its own class with both a non-streaming and a streaming case.

Refs: Responses API gap audit §E5 at `.claude/_audit/responses-api-gap-audit.md` (pending, unblocked by P1 `#1275`).

## What changed

One new file: `e2e_test/responses/test_annotations.py` (437 lines). No protocol, router, or fixture code was modified.

Four test classes, eight tests total:

| Class | Annotation | Source | Non-stream | Stream |
|---|---|---|---|---|
| `TestUrlCitationAnnotation` | `url_citation` | `web_search_preview` | yes | yes |
| `TestFileCitationAnnotation` | `file_citation` | `file_search` (vector store created out-of-band via OpenAI API, since smg does not mount `/v1/files` or `/v1/vector_stores`) | yes | yes |
| `TestContainerFileCitationAnnotation` | `container_file_citation` | `code_interpreter` (structural check when produced) | yes | yes |
| `TestFilePathAnnotation` | `file_path` | `code_interpreter` (structural check when produced) | yes | yes |

Shared helpers (`_iter_output_text_parts`, `_collect_annotations`, `_stream_to_final_output`, `_assert_annotation_structurally_valid`) walk `output[].content[]` on non-streaming responses and on the `response.completed.response.output` payload on streaming responses, then assert every spec-required field on each annotation object. Iterating the full SSE event list also forces the SDK's discriminated annotation union to deserialize every intermediate `content_part.added` / `content_part.done` / `output_item.done` event — a clean iteration is itself a round-trip assertion.

## Why

Audit §E5 calls for end-to-end verification that `message.output_text.annotations` carries the four typed variants across both stream shapes. Protocol support landed in P1 (`crates/protocols/src/responses.rs:1283-1308`); until this PR there was no e2e coverage that the router actually surfaces the typed wire shape rather than dropping it onto the untyped `Vec<String>` stub that existed before P1.

## How

- Each test class parametrizes `setup_backend=[\"openai\"]` via the shared `e2e_test/conftest.py` fixtures (`model`, `api_client`, `setup_backend`), matching the conventions used by `test_basic_crud.py`, `test_builtin_tools.py`, etc. Tests run on the `gpu=0` cloud lane with `@pytest.mark.vendor(\"openai\")`.
- Tests whose annotation type is *guaranteed* by the upstream tool (`url_citation` from `web_search_preview`; `file_citation` from `file_search` after a vector store is indexed) **assert** that annotations exist and structurally validate every required field (file_id, filename, index, start/end_index, url, title, container_id) according to the `Annotation` enum in `crates/protocols/src/responses.rs:1283-1308`.
- Tests whose annotation type is *model-driven* (`container_file_citation`, `file_path` from `code_interpreter`) **skip** rather than fail when the model did not emit one, so a regression in the typed round-trip is still caught without tying the suite to model-prompt sensitivity. If the variant is present, all its required fields are validated.
- The `file_search` path creates its vector store + uploads a small text doc directly against `https://api.openai.com` (skipping the gateway for setup), then passes the resulting `vector_store_id` through the smg gateway for the actual `responses.create(tools=[file_search])` call. This keeps the smg router the unit under test for the annotation round-trip while sidestepping a hard dependency on `/v1/files` / `/v1/vector_stores` endpoint coverage, which is out of scope for E5.
- Cleanup is guaranteed via `try/finally` — both the vector store and the uploaded file are deleted at class-scope teardown.
- No protocol types or router code was modified. No existing tests were touched.

## Test plan

- `cd e2e_test && pytest responses/test_annotations.py --collect-only` — collects exactly 8 tests:
  ```
  test_annotations.py::TestUrlCitationAnnotation::test_url_citation_non_streaming[openai]
  test_annotations.py::TestUrlCitationAnnotation::test_url_citation_streaming[openai]
  test_annotations.py::TestFileCitationAnnotation::test_file_citation_non_streaming[openai]
  test_annotations.py::TestFileCitationAnnotation::test_file_citation_streaming[openai]
  test_annotations.py::TestContainerFileCitationAnnotation::test_container_file_citation_non_streaming[openai]
  test_annotations.py::TestContainerFileCitationAnnotation::test_container_file_citation_streaming[openai]
  test_annotations.py::TestFilePathAnnotation::test_file_path_non_streaming[openai]
  test_annotations.py::TestFilePathAnnotation::test_file_path_streaming[openai]
  ```
- `ruff check e2e_test/responses/test_annotations.py` — passes.
- `ruff format --check e2e_test/responses/test_annotations.py` — passes.
- Full runtime validation requires `OPENAI_API_KEY` and an outbound connection to `api.openai.com`; it runs on the `gpu=0` cloud lane in CI via the existing `@pytest.mark.vendor(\"openai\")` marker, and the file_search flow skips cleanly when `OPENAI_API_KEY` is absent.

## Scope check

- [x] New test file only (`e2e_test/responses/test_annotations.py`).
- [x] No changes to `crates/protocols/` or any router code.
- [x] No existing test files modified.
- [x] Branch `test/audit-e5-annotations` is all-lowercase and matches the convention.
- [x] Commit signed with `-s` (DCO), no AI attribution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests validating typed annotations in API message outputs.
  * Coverage for web search citations, file search results, and code-execution annotations.
  * Tests exercise both streaming and non-streaming response flows.
  * Structural validation of annotation fields and relationships; tests skip gracefully when annotations or tools are unavailable.
  * File-search tests include automated setup and teardown of test data storage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->