### PR TITLE
feat(skills): add read and list admin endpoints

### DIFF
--- a/crates/protocols/src/skills.rs
+++ b/crates/protocols/src/skills.rs
@@ -11,8 +11,6 @@ use serde_json::{Map, Value};
 
 /// Multipart field carrying the explicit admin target tenant id.
 pub const SKILLS_MULTIPART_TENANT_ID_FIELD: &str = "tenant_id";
-/// Query parameter carrying the explicit admin target tenant id.
-pub const SKILLS_QUERY_TENANT_ID_PARAM: &str = "tenant_id";
 /// Multipart field for zip archive uploads.
 pub const SKILLS_MULTIPART_BUNDLE_FIELD: &str = "bundle";
 /// Alternate multipart field name accepted for zip archive uploads.
@@ -219,8 +217,10 @@ pub struct SkillsListResponse {
     pub object: String,
     pub data: Vec<SkillResponse>,
     pub has_more: bool,
+    /// Opaque pagination cursor for the first item on this page.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub first_id: Option<String>,
+    /// Opaque pagination cursor for the last item on this page.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_id: Option<String>,
 }

--- a/crates/protocols/src/skills.rs
+++ b/crates/protocols/src/skills.rs
@@ -11,6 +11,8 @@ use serde_json::{Map, Value};
 
 /// Multipart field carrying the explicit admin target tenant id.
 pub const SKILLS_MULTIPART_TENANT_ID_FIELD: &str = "tenant_id";
+/// Query parameter carrying the explicit admin target tenant id.
+pub const SKILLS_QUERY_TENANT_ID_PARAM: &str = "tenant_id";
 /// Multipart field for zip archive uploads.
 pub const SKILLS_MULTIPART_BUNDLE_FIELD: &str = "bundle";
 /// Alternate multipart field name accepted for zip archive uploads.
@@ -174,6 +176,65 @@ pub struct SkillMutationResponse {
     pub version: SkillVersionResponse,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub warnings: Vec<SkillWarningResponse>,
+}
+
+/// Query parameters accepted by `GET /v1/skills`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default, schemars::JsonSchema)]
+pub struct SkillsListQuery {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tenant_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub after: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+}
+
+/// Query parameters accepted by `GET /v1/skills/{skill_id}`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default, schemars::JsonSchema)]
+pub struct SkillGetQuery {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tenant_id: Option<String>,
+}
+
+/// Query parameters accepted by `GET /v1/skills/{skill_id}/versions`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default, schemars::JsonSchema)]
+pub struct SkillVersionsListQuery {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tenant_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub after: Option<String>,
+    #[serde(default)]
+    pub include_deprecated: bool,
+}
+
+/// One page of skill records from `GET /v1/skills`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct SkillsListResponse {
+    pub object: String,
+    pub data: Vec<SkillResponse>,
+    pub has_more: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub first_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_id: Option<String>,
+}
+
+/// One page of version records from `GET /v1/skills/{skill_id}/versions`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct SkillVersionsListResponse {
+    pub object: String,
+    pub data: Vec<SkillVersionResponse>,
+    pub has_more: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub first_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_id: Option<String>,
 }
 
 /// Standard error envelope for skills CRUD endpoints.

--- a/crates/skills/src/api.rs
+++ b/crates/skills/src/api.rs
@@ -104,6 +104,15 @@ pub enum SkillServiceError {
     #[error("skill '{skill_id}' was not found for tenant '{tenant_id}'")]
     SkillNotFound { tenant_id: String, skill_id: String },
 
+    #[error(
+        "skill version '{version}' was not found for skill '{skill_id}' in tenant '{tenant_id}'"
+    )]
+    SkillVersionNotFound {
+        tenant_id: String,
+        skill_id: String,
+        version: String,
+    },
+
     #[error("multipart upload must contain either one zip archive or one or more files[] parts")]
     MissingUploadParts,
 
@@ -207,6 +216,155 @@ impl SkillService {
 
     pub fn blob_store(&self) -> Option<Arc<dyn BlobStore>> {
         self.inner.blob_store.clone()
+    }
+
+    pub async fn get_skill(
+        &self,
+        tenant_id: &str,
+        skill_id: &str,
+    ) -> Result<SkillRecord, SkillServiceError> {
+        let tenant_id =
+            normalize_required_value(tenant_id.to_string(), SkillServiceError::MissingTenantId)?;
+        let skill_id =
+            normalize_required_value(skill_id.to_string(), SkillServiceError::MissingSkillId)?;
+        let metadata_store = self
+            .metadata_store()
+            .ok_or(SkillServiceError::MissingComponent {
+                component: "metadata_store",
+            })?;
+
+        metadata_store
+            .get_skill(&tenant_id, &skill_id)
+            .await?
+            .ok_or(SkillServiceError::SkillNotFound {
+                tenant_id,
+                skill_id,
+            })
+    }
+
+    pub async fn list_skills(
+        &self,
+        tenant_id: &str,
+        source: Option<&str>,
+        name: Option<&str>,
+    ) -> Result<Vec<SkillRecord>, SkillServiceError> {
+        let tenant_id =
+            normalize_required_value(tenant_id.to_string(), SkillServiceError::MissingTenantId)?;
+        let metadata_store = self
+            .metadata_store()
+            .ok_or(SkillServiceError::MissingComponent {
+                component: "metadata_store",
+            })?;
+
+        let source = source.map(str::trim).filter(|value| !value.is_empty());
+        let name = name.map(str::trim).filter(|value| !value.is_empty());
+
+        let mut records = metadata_store.list_skills(&tenant_id).await?;
+        records.retain(|record| {
+            source.is_none_or(|value| record.source == value)
+                && name.is_none_or(|value| record.name == value)
+        });
+        Ok(records)
+    }
+
+    pub async fn get_skill_version(
+        &self,
+        tenant_id: &str,
+        skill_id: &str,
+        version_ref: &str,
+    ) -> Result<SkillVersionRecord, SkillServiceError> {
+        let tenant_id =
+            normalize_required_value(tenant_id.to_string(), SkillServiceError::MissingTenantId)?;
+        let skill_id =
+            normalize_required_value(skill_id.to_string(), SkillServiceError::MissingSkillId)?;
+        let version_ref = normalize_required_value(
+            version_ref.to_string(),
+            SkillServiceError::SkillVersionNotFound {
+                tenant_id: tenant_id.clone(),
+                skill_id: skill_id.clone(),
+                version: version_ref.trim().to_string(),
+            },
+        )?;
+        let metadata_store = self
+            .metadata_store()
+            .ok_or(SkillServiceError::MissingComponent {
+                component: "metadata_store",
+            })?;
+
+        let skill = metadata_store
+            .get_skill(&tenant_id, &skill_id)
+            .await?
+            .ok_or_else(|| SkillServiceError::SkillNotFound {
+                tenant_id: tenant_id.clone(),
+                skill_id: skill_id.clone(),
+            })?;
+
+        if version_ref == "latest" {
+            if let Some(latest_version) = skill.latest_version {
+                return metadata_store
+                    .get_skill_version(&skill_id, &latest_version)
+                    .await?
+                    .ok_or(SkillServiceError::SkillVersionNotFound {
+                        tenant_id,
+                        skill_id,
+                        version: latest_version,
+                    });
+            }
+        }
+
+        if let Some(record) = metadata_store
+            .get_skill_version(&skill_id, &version_ref)
+            .await?
+        {
+            return Ok(record);
+        }
+
+        if let Ok(version_number) = version_ref.parse::<u32>() {
+            let versions = metadata_store.list_skill_versions(&skill_id).await?;
+            if let Some(record) = versions
+                .into_iter()
+                .find(|record| record.version_number == version_number)
+            {
+                return Ok(record);
+            }
+        }
+
+        Err(SkillServiceError::SkillVersionNotFound {
+            tenant_id,
+            skill_id,
+            version: version_ref,
+        })
+    }
+
+    pub async fn list_skill_versions(
+        &self,
+        tenant_id: &str,
+        skill_id: &str,
+        include_deprecated: bool,
+    ) -> Result<Vec<SkillVersionRecord>, SkillServiceError> {
+        let tenant_id =
+            normalize_required_value(tenant_id.to_string(), SkillServiceError::MissingTenantId)?;
+        let skill_id =
+            normalize_required_value(skill_id.to_string(), SkillServiceError::MissingSkillId)?;
+        let metadata_store = self
+            .metadata_store()
+            .ok_or(SkillServiceError::MissingComponent {
+                component: "metadata_store",
+            })?;
+
+        metadata_store
+            .get_skill(&tenant_id, &skill_id)
+            .await?
+            .ok_or_else(|| SkillServiceError::SkillNotFound {
+                tenant_id: tenant_id.clone(),
+                skill_id: skill_id.clone(),
+            })?;
+
+        let mut versions = metadata_store.list_skill_versions(&skill_id).await?;
+        if !include_deprecated {
+            versions.retain(|record| !record.deprecated);
+        }
+        Ok(versions)
     }
 
     pub async fn create_skill(
@@ -681,6 +839,105 @@ mod tests {
             next.skill.default_version,
             Some(created.version.version.clone())
         );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn list_skills_filters_by_source_and_name() -> Result<()> {
+        let root = TempDir::new()?;
+        let blob_store = Arc::new(FilesystemBlobStore::new(root.path())?);
+        let service = SkillService::in_memory(blob_store);
+
+        service
+            .create_skill(CreateSkillRequest {
+                tenant_id: "tenant-a".to_string(),
+                upload: SkillUpload::Files(vec![UploadedSkillFile {
+                    relative_path: "SKILL.md".to_string(),
+                    contents: b"---\nname: acme:map\ndescription: Map the repo\n---\nUse rg."
+                        .to_vec(),
+                    media_type: Some("text/markdown".to_string()),
+                }]),
+            })
+            .await?;
+        service
+            .create_skill(CreateSkillRequest {
+                tenant_id: "tenant-a".to_string(),
+                upload: SkillUpload::Files(vec![UploadedSkillFile {
+                    relative_path: "SKILL.md".to_string(),
+                    contents: b"---\nname: acme:search\ndescription: Search the repo\n---\nUse fd."
+                        .to_vec(),
+                    media_type: Some("text/markdown".to_string()),
+                }]),
+            })
+            .await?;
+        service
+            .create_skill(CreateSkillRequest {
+                tenant_id: "tenant-b".to_string(),
+                upload: SkillUpload::Files(vec![UploadedSkillFile {
+                    relative_path: "SKILL.md".to_string(),
+                    contents: b"---\nname: acme:map\ndescription: Tenant B skill\n---\nUse rg."
+                        .to_vec(),
+                    media_type: Some("text/markdown".to_string()),
+                }]),
+            })
+            .await?;
+
+        let tenant_a = service
+            .list_skills("tenant-a", Some("custom"), None)
+            .await?;
+        assert_eq!(tenant_a.len(), 2);
+        assert!(tenant_a.iter().all(|record| record.tenant_id == "tenant-a"));
+
+        let filtered = service
+            .list_skills("tenant-a", Some("custom"), Some("acme:map"))
+            .await?;
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].name, "acme:map");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn get_skill_version_resolves_latest_and_integer_version_number() -> Result<()> {
+        let root = TempDir::new()?;
+        let blob_store = Arc::new(FilesystemBlobStore::new(root.path())?);
+        let service = SkillService::in_memory(blob_store);
+
+        let created = service
+            .create_skill(CreateSkillRequest {
+                tenant_id: "tenant-a".to_string(),
+                upload: SkillUpload::Files(vec![UploadedSkillFile {
+                    relative_path: "SKILL.md".to_string(),
+                    contents: b"---\nname: acme:map\ndescription: Map the repo\n---\nUse rg."
+                        .to_vec(),
+                    media_type: Some("text/markdown".to_string()),
+                }]),
+            })
+            .await?;
+
+        let second = service
+            .create_skill_version(CreateSkillVersionRequest {
+                tenant_id: "tenant-a".to_string(),
+                skill_id: created.skill.skill_id.clone(),
+                upload: SkillUpload::Files(vec![UploadedSkillFile {
+                    relative_path: "SKILL.md".to_string(),
+                    contents: b"---\nname: acme:map\ndescription: Updated mapping skill\n---\nUse rg --files."
+                        .to_vec(),
+                    media_type: Some("text/markdown".to_string()),
+                }]),
+            })
+            .await?;
+
+        let latest = service
+            .get_skill_version("tenant-a", &created.skill.skill_id, "latest")
+            .await?;
+        assert_eq!(latest.version, second.version.version);
+
+        let by_number = service
+            .get_skill_version("tenant-a", &created.skill.skill_id, "2")
+            .await?;
+        assert_eq!(by_number.version, second.version.version);
 
         Ok(())
     }

--- a/model_gateway/src/routers/skills/handlers.rs
+++ b/model_gateway/src/routers/skills/handlers.rs
@@ -1,21 +1,31 @@
 use axum::{
-    extract::{multipart::MultipartError, Multipart, Path, State},
-    http::StatusCode,
+    extract::{multipart::MultipartError, Multipart, Path, Query, State},
+    http::{
+        header::{self, HeaderMap, HeaderValue},
+        StatusCode,
+    },
     response::{IntoResponse, Response},
     Json,
 };
 use openai_protocol::skills::{
-    SkillMutationResponse, SkillResponse, SkillVersionFileResponse, SkillVersionResponse,
-    SkillWarningResponse, SkillsErrorBody, SkillsErrorEnvelope, SKILLS_MULTIPART_BUNDLE_FIELD,
-    SKILLS_MULTIPART_FILES_FIELD, SKILLS_MULTIPART_FILE_FIELD, SKILLS_MULTIPART_TENANT_ID_FIELD,
+    SkillGetQuery, SkillMutationResponse, SkillResponse, SkillVersionFileResponse,
+    SkillVersionResponse, SkillVersionsListQuery, SkillVersionsListResponse, SkillWarningResponse,
+    SkillsErrorBody, SkillsErrorEnvelope, SkillsListQuery, SkillsListResponse,
+    SKILLS_MULTIPART_BUNDLE_FIELD, SKILLS_MULTIPART_FILES_FIELD, SKILLS_MULTIPART_FILE_FIELD,
+    SKILLS_MULTIPART_TENANT_ID_FIELD,
 };
+use serde::Serialize;
 use serde_json::Value;
+use sha2::{Digest, Sha256};
 use smg_skills::{
     CreateSkillRequest, CreateSkillVersionRequest, SkillCreateResult, SkillServiceError,
     SkillUpload, UploadedSkillFile,
 };
 
 use crate::{middleware::resolve_admin_target_tenant_key, server::AppState};
+
+const DEFAULT_SKILLS_LIST_LIMIT: usize = 100;
+const MAX_SKILLS_LIST_LIMIT: usize = 100;
 
 #[derive(Debug)]
 struct ParsedSkillUpload {
@@ -66,6 +76,10 @@ impl From<SkillServiceError> for SkillsApiError {
             },
             SkillServiceError::SkillNotFound { .. } => Self::NotFound {
                 code: "skill_not_found",
+                message: error.to_string(),
+            },
+            SkillServiceError::SkillVersionNotFound { .. } => Self::NotFound {
+                code: "skill_version_not_found",
                 message: error.to_string(),
             },
             SkillServiceError::MissingUploadParts => Self::BadRequest {
@@ -132,6 +146,53 @@ pub async fn create_skill_version(
     }
 }
 
+pub async fn list_skills(
+    State(state): State<std::sync::Arc<AppState>>,
+    Query(query): Query<SkillsListQuery>,
+    headers: HeaderMap,
+) -> Response {
+    match list_skills_impl(state, query, &headers).await {
+        Ok(response) => response,
+        Err(error) => error.into_response(),
+    }
+}
+
+pub async fn get_skill(
+    State(state): State<std::sync::Arc<AppState>>,
+    Path(skill_id): Path<String>,
+    Query(query): Query<SkillGetQuery>,
+    headers: HeaderMap,
+) -> Response {
+    match get_skill_impl(state, skill_id, query, &headers).await {
+        Ok(response) => response,
+        Err(error) => error.into_response(),
+    }
+}
+
+pub async fn list_skill_versions(
+    State(state): State<std::sync::Arc<AppState>>,
+    Path(skill_id): Path<String>,
+    Query(query): Query<SkillVersionsListQuery>,
+    headers: HeaderMap,
+) -> Response {
+    match list_skill_versions_impl(state, skill_id, query, &headers).await {
+        Ok(response) => response,
+        Err(error) => error.into_response(),
+    }
+}
+
+pub async fn get_skill_version(
+    State(state): State<std::sync::Arc<AppState>>,
+    Path((skill_id, version)): Path<(String, String)>,
+    Query(query): Query<SkillGetQuery>,
+    headers: HeaderMap,
+) -> Response {
+    match get_skill_version_impl(state, skill_id, version, query, &headers).await {
+        Ok(response) => response,
+        Err(error) => error.into_response(),
+    }
+}
+
 async fn create_skill_impl(
     state: std::sync::Arc<AppState>,
     multipart: Multipart,
@@ -180,6 +241,367 @@ async fn create_skill_version_impl(
         .await
         .map_err(SkillsApiError::from)?;
     build_mutation_response(result)
+}
+
+async fn list_skills_impl(
+    state: std::sync::Arc<AppState>,
+    query: SkillsListQuery,
+    request_headers: &HeaderMap,
+) -> Result<Response, SkillsApiError> {
+    let skill_service =
+        state
+            .context
+            .skill_service
+            .clone()
+            .ok_or_else(|| SkillsApiError::Internal {
+                code: "skills_not_configured",
+                message: "skills service is not configured".to_string(),
+            })?;
+    let tenant_id = resolve_target_tenant_id(query.tenant_id.as_deref())?;
+    let limit = validate_list_limit(query.limit)?;
+    let mut records = skill_service
+        .list_skills(&tenant_id, query.source.as_deref(), query.name.as_deref())
+        .await
+        .map_err(SkillsApiError::from)?;
+    records.sort_by(|left, right| {
+        right
+            .updated_at
+            .cmp(&left.updated_at)
+            .then_with(|| left.skill_id.cmp(&right.skill_id))
+    });
+
+    let etag = build_list_etag(
+        &query,
+        records
+            .iter()
+            .map(|record| (record.skill_id.clone(), record.updated_at.to_rfc3339())),
+    )?;
+    let last_modified = list_last_modified(records.iter().map(|record| record.updated_at));
+    if is_not_modified(request_headers, &etag, last_modified) {
+        return not_modified_response(&etag, last_modified);
+    }
+
+    let page = paginate_records(records, query.after.as_deref(), limit, |record| {
+        record.skill_id.as_str()
+    })?;
+    let body = SkillsListResponse {
+        object: "list".to_string(),
+        first_id: page.items.first().map(|record| record.skill_id.clone()),
+        last_id: page.items.last().map(|record| record.skill_id.clone()),
+        has_more: page.has_more,
+        data: page.items.iter().map(skill_response_from_record).collect(),
+    };
+
+    with_cache_headers(etag, last_modified, Json(body))
+}
+
+async fn get_skill_impl(
+    state: std::sync::Arc<AppState>,
+    skill_id: String,
+    query: SkillGetQuery,
+    request_headers: &HeaderMap,
+) -> Result<Response, SkillsApiError> {
+    let skill_service =
+        state
+            .context
+            .skill_service
+            .clone()
+            .ok_or_else(|| SkillsApiError::Internal {
+                code: "skills_not_configured",
+                message: "skills service is not configured".to_string(),
+            })?;
+    let tenant_id = resolve_target_tenant_id(query.tenant_id.as_deref())?;
+    let record = skill_service
+        .get_skill(&tenant_id, &skill_id)
+        .await
+        .map_err(SkillsApiError::from)?;
+    let response_body = skill_response_from_record(&record);
+    let etag = build_resource_etag(&response_body, false)?;
+    let last_modified = record.updated_at;
+    if is_not_modified(request_headers, &etag, last_modified) {
+        return not_modified_response(&etag, last_modified);
+    }
+
+    with_cache_headers(etag, last_modified, Json(response_body))
+}
+
+async fn list_skill_versions_impl(
+    state: std::sync::Arc<AppState>,
+    skill_id: String,
+    query: SkillVersionsListQuery,
+    request_headers: &HeaderMap,
+) -> Result<Response, SkillsApiError> {
+    let skill_service =
+        state
+            .context
+            .skill_service
+            .clone()
+            .ok_or_else(|| SkillsApiError::Internal {
+                code: "skills_not_configured",
+                message: "skills service is not configured".to_string(),
+            })?;
+    let tenant_id = resolve_target_tenant_id(query.tenant_id.as_deref())?;
+    let limit = validate_list_limit(query.limit)?;
+    let mut versions = skill_service
+        .list_skill_versions(&tenant_id, &skill_id, query.include_deprecated)
+        .await
+        .map_err(SkillsApiError::from)?;
+    versions.sort_by(|left, right| {
+        right
+            .version_number
+            .cmp(&left.version_number)
+            .then_with(|| left.version.cmp(&right.version))
+    });
+
+    let etag = build_list_etag(
+        &query,
+        versions
+            .iter()
+            .map(|record| (record.version.clone(), record.created_at.to_rfc3339())),
+    )?;
+    let last_modified = list_last_modified(versions.iter().map(|record| record.created_at));
+    if is_not_modified(request_headers, &etag, last_modified) {
+        return not_modified_response(&etag, last_modified);
+    }
+
+    let page = paginate_records(versions, query.after.as_deref(), limit, |record| {
+        record.version.as_str()
+    })?;
+    let body = SkillVersionsListResponse {
+        object: "list".to_string(),
+        first_id: page.items.first().map(|record| record.version.clone()),
+        last_id: page.items.last().map(|record| record.version.clone()),
+        has_more: page.has_more,
+        data: page
+            .items
+            .iter()
+            .map(skill_version_response_from_record)
+            .collect::<Result<Vec<_>, _>>()?,
+    };
+
+    with_cache_headers(etag, last_modified, Json(body))
+}
+
+async fn get_skill_version_impl(
+    state: std::sync::Arc<AppState>,
+    skill_id: String,
+    version: String,
+    query: SkillGetQuery,
+    request_headers: &HeaderMap,
+) -> Result<Response, SkillsApiError> {
+    let skill_service =
+        state
+            .context
+            .skill_service
+            .clone()
+            .ok_or_else(|| SkillsApiError::Internal {
+                code: "skills_not_configured",
+                message: "skills service is not configured".to_string(),
+            })?;
+    let tenant_id = resolve_target_tenant_id(query.tenant_id.as_deref())?;
+    let record = skill_service
+        .get_skill_version(&tenant_id, &skill_id, &version)
+        .await
+        .map_err(SkillsApiError::from)?;
+    let response_body = skill_version_response_from_record(&record)?;
+    let etag = build_resource_etag(&response_body, false)?;
+    let last_modified = record.created_at;
+    if is_not_modified(request_headers, &etag, last_modified) {
+        return not_modified_response(&etag, last_modified);
+    }
+
+    with_cache_headers(etag, last_modified, Json(response_body))
+}
+
+struct Page<T> {
+    items: Vec<T>,
+    has_more: bool,
+}
+
+fn resolve_target_tenant_id(raw_tenant_id: Option<&str>) -> Result<String, SkillsApiError> {
+    let tenant_id = raw_tenant_id.ok_or_else(|| SkillsApiError::BadRequest {
+        code: "missing_target_tenant",
+        message: "target tenant id is required".to_string(),
+    })?;
+    resolve_admin_target_tenant_key(tenant_id)
+        .map(|tenant_key| tenant_key.to_string())
+        .map_err(|error| SkillsApiError::BadRequest {
+            code: "missing_target_tenant",
+            message: error.to_string(),
+        })
+}
+
+fn validate_list_limit(limit: Option<u32>) -> Result<usize, SkillsApiError> {
+    let limit = limit.unwrap_or(DEFAULT_SKILLS_LIST_LIMIT as u32);
+    if limit == 0 || limit as usize > MAX_SKILLS_LIST_LIMIT {
+        return Err(SkillsApiError::BadRequest {
+            code: "invalid_limit",
+            message: format!("limit must be between 1 and {MAX_SKILLS_LIST_LIMIT}"),
+        });
+    }
+    Ok(limit as usize)
+}
+
+fn paginate_records<T, F>(
+    items: Vec<T>,
+    after: Option<&str>,
+    limit: usize,
+    id_of: F,
+) -> Result<Page<T>, SkillsApiError>
+where
+    F: Fn(&T) -> &str,
+{
+    let start = if let Some(after) = after.map(str::trim).filter(|value| !value.is_empty()) {
+        items
+            .iter()
+            .position(|item| id_of(item) == after)
+            .map(|index| index + 1)
+            .ok_or_else(|| SkillsApiError::BadRequest {
+                code: "invalid_after_cursor",
+                message: format!("after cursor '{after}' was not found"),
+            })?
+    } else {
+        0
+    };
+
+    let total = items.len();
+    let items = items
+        .into_iter()
+        .skip(start)
+        .take(limit)
+        .collect::<Vec<_>>();
+    Ok(Page {
+        has_more: total > start.saturating_add(limit),
+        items,
+    })
+}
+
+fn list_last_modified<I>(timestamps: I) -> chrono::DateTime<chrono::Utc>
+where
+    I: Iterator<Item = chrono::DateTime<chrono::Utc>>,
+{
+    timestamps
+        .max()
+        .unwrap_or_else(|| chrono::DateTime::<chrono::Utc>::from(std::time::SystemTime::UNIX_EPOCH))
+}
+
+fn build_list_etag<Q, I>(query: &Q, records: I) -> Result<String, SkillsApiError>
+where
+    Q: Serialize,
+    I: IntoIterator<Item = (String, String)>,
+{
+    let mut hasher = Sha256::new();
+    hasher.update(
+        serde_json::to_vec(query).map_err(|error| SkillsApiError::Internal {
+            code: "skills_internal_error",
+            message: format!("failed to serialize skills query for ETag: {error}"),
+        })?,
+    );
+    for (id, updated_at) in records {
+        hasher.update(id.as_bytes());
+        hasher.update([0]);
+        hasher.update(updated_at.as_bytes());
+        hasher.update([0xff]);
+    }
+    Ok(format!("W/\"{:x}\"", hasher.finalize()))
+}
+
+fn build_resource_etag<T: Serialize>(value: &T, weak: bool) -> Result<String, SkillsApiError> {
+    let digest =
+        Sha256::digest(
+            serde_json::to_vec(value).map_err(|error| SkillsApiError::Internal {
+                code: "skills_internal_error",
+                message: format!("failed to serialize skills response payload: {error}"),
+            })?,
+        );
+    Ok(if weak {
+        format!("W/\"{digest:x}\"")
+    } else {
+        format!("\"{digest:x}\"")
+    })
+}
+
+fn is_not_modified(
+    request_headers: &HeaderMap,
+    etag: &str,
+    last_modified: chrono::DateTime<chrono::Utc>,
+) -> bool {
+    if let Some(if_none_match) = request_headers.get(header::IF_NONE_MATCH) {
+        return if_none_match_matches(if_none_match, etag);
+    }
+
+    request_headers
+        .get(header::IF_MODIFIED_SINCE)
+        .and_then(|value| value.to_str().ok())
+        .and_then(parse_http_date)
+        .is_some_and(|value| {
+            let last_modified = last_modified.timestamp();
+            last_modified <= value.timestamp()
+        })
+}
+
+fn if_none_match_matches(value: &HeaderValue, etag: &str) -> bool {
+    value.to_str().ok().is_some_and(|value| {
+        value.split(',').map(str::trim).any(|candidate| {
+            candidate == "*" || strip_weak_prefix(candidate) == strip_weak_prefix(etag)
+        })
+    })
+}
+
+fn strip_weak_prefix(etag: &str) -> &str {
+    etag.strip_prefix("W/").unwrap_or(etag)
+}
+
+fn parse_http_date(value: &str) -> Option<chrono::DateTime<chrono::Utc>> {
+    chrono::DateTime::parse_from_rfc2822(value)
+        .ok()
+        .map(|value| value.with_timezone(&chrono::Utc))
+}
+
+fn not_modified_response(
+    etag: &str,
+    last_modified: chrono::DateTime<chrono::Utc>,
+) -> Result<Response, SkillsApiError> {
+    Ok((
+        StatusCode::NOT_MODIFIED,
+        cache_headers(etag, last_modified)?,
+    )
+        .into_response())
+}
+
+fn with_cache_headers<T: IntoResponse>(
+    etag: String,
+    last_modified: chrono::DateTime<chrono::Utc>,
+    body: T,
+) -> Result<Response, SkillsApiError> {
+    Ok((cache_headers(&etag, last_modified)?, body).into_response())
+}
+
+fn cache_headers(
+    etag: &str,
+    last_modified: chrono::DateTime<chrono::Utc>,
+) -> Result<HeaderMap, SkillsApiError> {
+    let mut headers = HeaderMap::with_capacity(2);
+    headers.insert(
+        header::ETAG,
+        HeaderValue::from_str(etag).map_err(|error| SkillsApiError::Internal {
+            code: "skills_internal_error",
+            message: format!("failed to build ETag header: {error}"),
+        })?,
+    );
+    headers.insert(
+        header::LAST_MODIFIED,
+        HeaderValue::from_str(
+            &last_modified
+                .format("%a, %d %b %Y %H:%M:%S GMT")
+                .to_string(),
+        )
+        .map_err(|error| SkillsApiError::Internal {
+            code: "skills_internal_error",
+            message: format!("failed to build Last-Modified header: {error}"),
+        })?,
+    );
+    Ok(headers)
 }
 
 async fn parse_skill_upload(mut multipart: Multipart) -> Result<ParsedSkillUpload, SkillsApiError> {
@@ -326,40 +748,8 @@ fn build_mutation_response(
     value: SkillCreateResult,
 ) -> Result<SkillMutationResponse, SkillsApiError> {
     Ok(SkillMutationResponse {
-        skill: SkillResponse {
-            id: value.skill.skill_id.clone(),
-            name: value.skill.name.clone(),
-            short_description: value.skill.short_description.clone(),
-            description: value.skill.description.clone().unwrap_or_default(),
-            source: value.skill.source.clone(),
-            latest_version: value.skill.latest_version.clone(),
-            default_version: value.skill.default_version.clone(),
-            has_code_files: value.skill.has_code_files,
-            created_at: value.skill.created_at.to_rfc3339(),
-            updated_at: value.skill.updated_at.to_rfc3339(),
-        },
-        version: SkillVersionResponse {
-            skill_id: value.version.skill_id.clone(),
-            version: value.version.version.clone(),
-            version_number: value.version.version_number,
-            name: value.version.name.clone(),
-            short_description: value.version.short_description.clone(),
-            description: value.version.description.clone(),
-            interface: serialize_optional_json(value.version.interface.as_ref())?,
-            dependencies: serialize_optional_json(value.version.dependencies.as_ref())?,
-            policy: serialize_optional_json(value.version.policy.as_ref())?,
-            deprecated: value.version.deprecated,
-            files: value
-                .version
-                .file_manifest
-                .iter()
-                .map(|entry| SkillVersionFileResponse {
-                    path: entry.relative_path.clone(),
-                    size_bytes: entry.size_bytes,
-                })
-                .collect(),
-            created_at: value.version.created_at.to_rfc3339(),
-        },
+        skill: skill_response_from_record(&value.skill),
+        version: skill_version_response_from_record(&value.version)?,
         warnings: value
             .warnings
             .into_iter()
@@ -372,7 +762,48 @@ fn build_mutation_response(
     })
 }
 
-fn serialize_optional_json<T: serde::Serialize>(
+fn skill_response_from_record(record: &smg_skills::SkillRecord) -> SkillResponse {
+    SkillResponse {
+        id: record.skill_id.clone(),
+        name: record.name.clone(),
+        short_description: record.short_description.clone(),
+        description: record.description.clone().unwrap_or_default(),
+        source: record.source.clone(),
+        latest_version: record.latest_version.clone(),
+        default_version: record.default_version.clone(),
+        has_code_files: record.has_code_files,
+        created_at: record.created_at.to_rfc3339(),
+        updated_at: record.updated_at.to_rfc3339(),
+    }
+}
+
+fn skill_version_response_from_record(
+    record: &smg_skills::SkillVersionRecord,
+) -> Result<SkillVersionResponse, SkillsApiError> {
+    Ok(SkillVersionResponse {
+        skill_id: record.skill_id.clone(),
+        version: record.version.clone(),
+        version_number: record.version_number,
+        name: record.name.clone(),
+        short_description: record.short_description.clone(),
+        description: record.description.clone(),
+        interface: serialize_optional_json(record.interface.as_ref())?,
+        dependencies: serialize_optional_json(record.dependencies.as_ref())?,
+        policy: serialize_optional_json(record.policy.as_ref())?,
+        deprecated: record.deprecated,
+        files: record
+            .file_manifest
+            .iter()
+            .map(|entry| SkillVersionFileResponse {
+                path: entry.relative_path.clone(),
+                size_bytes: entry.size_bytes,
+            })
+            .collect(),
+        created_at: record.created_at.to_rfc3339(),
+    })
+}
+
+fn serialize_optional_json<T: Serialize>(
     value: Option<&T>,
 ) -> Result<Option<Value>, SkillsApiError> {
     value

--- a/model_gateway/src/routers/skills/handlers.rs
+++ b/model_gateway/src/routers/skills/handlers.rs
@@ -7,6 +7,7 @@ use axum::{
     response::{IntoResponse, Response},
     Json,
 };
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use openai_protocol::skills::{
     SkillGetQuery, SkillMutationResponse, SkillResponse, SkillVersionFileResponse,
     SkillVersionResponse, SkillVersionsListQuery, SkillVersionsListResponse, SkillWarningResponse,
@@ -14,7 +15,7 @@ use openai_protocol::skills::{
     SKILLS_MULTIPART_BUNDLE_FIELD, SKILLS_MULTIPART_FILES_FIELD, SKILLS_MULTIPART_FILE_FIELD,
     SKILLS_MULTIPART_TENANT_ID_FIELD,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 use smg_skills::{
@@ -269,6 +270,7 @@ async fn list_skills_impl(
             .cmp(&left.updated_at)
             .then_with(|| left.skill_id.cmp(&right.skill_id))
     });
+    let start = skills_list_start_index(&records, query.after.as_deref())?;
 
     let etag = build_list_etag(
         &query,
@@ -281,13 +283,19 @@ async fn list_skills_impl(
         return not_modified_response(&etag, last_modified);
     }
 
-    let page = paginate_records(records, query.after.as_deref(), limit, |record| {
-        record.skill_id.as_str()
-    })?;
+    let page = paginate_from_start(records, start, limit);
     let body = SkillsListResponse {
         object: "list".to_string(),
-        first_id: page.items.first().map(|record| record.skill_id.clone()),
-        last_id: page.items.last().map(|record| record.skill_id.clone()),
+        first_id: page
+            .items
+            .first()
+            .map(|record| SkillsListCursor::from_record(record).encode())
+            .transpose()?,
+        last_id: page
+            .items
+            .last()
+            .map(|record| SkillsListCursor::from_record(record).encode())
+            .transpose()?,
         has_more: page.has_more,
         data: page.items.iter().map(skill_response_from_record).collect(),
     };
@@ -352,6 +360,9 @@ async fn list_skill_versions_impl(
             .cmp(&left.version_number)
             .then_with(|| left.version.cmp(&right.version))
     });
+    let start = start_index_from_id_cursor(&versions, query.after.as_deref(), |record| {
+        record.version.as_str()
+    })?;
 
     let etag = build_list_etag(
         &query,
@@ -364,9 +375,7 @@ async fn list_skill_versions_impl(
         return not_modified_response(&etag, last_modified);
     }
 
-    let page = paginate_records(versions, query.after.as_deref(), limit, |record| {
-        record.version.as_str()
-    })?;
+    let page = paginate_from_start(versions, start, limit);
     let body = SkillVersionsListResponse {
         object: "list".to_string(),
         first_id: page.items.first().map(|record| record.version.clone()),
@@ -418,6 +427,64 @@ struct Page<T> {
     has_more: bool,
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+struct SkillsListCursorPayload {
+    updated_at: String,
+    skill_id: String,
+}
+
+#[derive(Debug)]
+struct SkillsListCursor {
+    updated_at: chrono::DateTime<chrono::Utc>,
+    skill_id: String,
+}
+
+impl SkillsListCursor {
+    fn from_record(record: &smg_skills::SkillRecord) -> Self {
+        Self {
+            updated_at: record.updated_at,
+            skill_id: record.skill_id.clone(),
+        }
+    }
+
+    fn encode(&self) -> Result<String, SkillsApiError> {
+        let payload = SkillsListCursorPayload {
+            updated_at: self.updated_at.to_rfc3339(),
+            skill_id: self.skill_id.clone(),
+        };
+        let bytes = serde_json::to_vec(&payload).map_err(|error| SkillsApiError::Internal {
+            code: "skills_internal_error",
+            message: format!("failed to serialize skills list cursor: {error}"),
+        })?;
+        Ok(URL_SAFE_NO_PAD.encode(bytes))
+    }
+
+    fn decode(raw: &str) -> Result<Self, SkillsApiError> {
+        let bytes = URL_SAFE_NO_PAD
+            .decode(raw)
+            .map_err(|_| invalid_after_cursor("after cursor is not valid base64url".to_string()))?;
+        let payload: SkillsListCursorPayload = serde_json::from_slice(&bytes).map_err(|_| {
+            invalid_after_cursor("after cursor is not valid skills cursor JSON".to_string())
+        })?;
+        let updated_at = chrono::DateTime::parse_from_rfc3339(&payload.updated_at)
+            .map_err(|_| {
+                invalid_after_cursor(
+                    "after cursor does not contain a valid RFC3339 timestamp".to_string(),
+                )
+            })?
+            .with_timezone(&chrono::Utc);
+        if payload.skill_id.trim().is_empty() {
+            return Err(invalid_after_cursor(
+                "after cursor does not contain a skill id".to_string(),
+            ));
+        }
+        Ok(Self {
+            updated_at,
+            skill_id: payload.skill_id,
+        })
+    }
+}
+
 fn resolve_target_tenant_id(raw_tenant_id: Option<&str>) -> Result<String, SkillsApiError> {
     let tenant_id = raw_tenant_id.ok_or_else(|| SkillsApiError::BadRequest {
         code: "missing_target_tenant",
@@ -442,38 +509,62 @@ fn validate_list_limit(limit: Option<u32>) -> Result<usize, SkillsApiError> {
     Ok(limit as usize)
 }
 
-fn paginate_records<T, F>(
-    items: Vec<T>,
+fn normalized_after_cursor(after: Option<&str>) -> Option<&str> {
+    after.map(str::trim).filter(|value| !value.is_empty())
+}
+
+fn skills_list_start_index(
+    items: &[smg_skills::SkillRecord],
     after: Option<&str>,
-    limit: usize,
+) -> Result<usize, SkillsApiError> {
+    let Some(after) = normalized_after_cursor(after) else {
+        return Ok(0);
+    };
+    let cursor = SkillsListCursor::decode(after)?;
+    Ok(items
+        .iter()
+        .position(|record| skill_record_is_after_cursor(record, &cursor))
+        .unwrap_or(items.len()))
+}
+
+fn skill_record_is_after_cursor(
+    record: &smg_skills::SkillRecord,
+    cursor: &SkillsListCursor,
+) -> bool {
+    record.updated_at < cursor.updated_at
+        || (record.updated_at == cursor.updated_at && record.skill_id > cursor.skill_id)
+}
+
+fn start_index_from_id_cursor<T, F>(
+    items: &[T],
+    after: Option<&str>,
     id_of: F,
-) -> Result<Page<T>, SkillsApiError>
+) -> Result<usize, SkillsApiError>
 where
     F: Fn(&T) -> &str,
 {
-    let start = if let Some(after) = after.map(str::trim).filter(|value| !value.is_empty()) {
+    if let Some(after) = normalized_after_cursor(after) {
         items
             .iter()
             .position(|item| id_of(item) == after)
             .map(|index| index + 1)
-            .ok_or_else(|| SkillsApiError::BadRequest {
-                code: "invalid_after_cursor",
-                message: format!("after cursor '{after}' was not found"),
-            })?
+            .ok_or_else(|| invalid_after_cursor(format!("after cursor '{after}' was not found")))
     } else {
-        0
-    };
+        Ok(0)
+    }
+}
 
+fn paginate_from_start<T>(items: Vec<T>, start: usize, limit: usize) -> Page<T> {
     let total = items.len();
     let items = items
         .into_iter()
         .skip(start)
         .take(limit)
         .collect::<Vec<_>>();
-    Ok(Page {
+    Page {
         has_more: total > start.saturating_add(limit),
         items,
-    })
+    }
 }
 
 fn list_last_modified<I>(timestamps: I) -> chrono::DateTime<chrono::Utc>
@@ -534,10 +625,7 @@ fn is_not_modified(
         .get(header::IF_MODIFIED_SINCE)
         .and_then(|value| value.to_str().ok())
         .and_then(parse_http_date)
-        .is_some_and(|value| {
-            let last_modified = last_modified.timestamp();
-            last_modified <= value.timestamp()
-        })
+        .is_some_and(|value| last_modified <= value)
 }
 
 fn if_none_match_matches(value: &HeaderValue, etag: &str) -> bool {
@@ -726,6 +814,13 @@ fn looks_like_zip_upload(file_name: Option<&str>, content_type: Option<&str>) ->
 fn invalid_multipart(message: String) -> SkillsApiError {
     SkillsApiError::BadRequest {
         code: "invalid_multipart",
+        message,
+    }
+}
+
+fn invalid_after_cursor(message: String) -> SkillsApiError {
+    SkillsApiError::BadRequest {
+        code: "invalid_after_cursor",
         message,
     }
 }

--- a/model_gateway/src/routers/skills/mod.rs
+++ b/model_gateway/src/routers/skills/mod.rs
@@ -1,3 +1,6 @@
 mod handlers;
 
-pub use handlers::{create_skill, create_skill_version};
+pub use handlers::{
+    create_skill, create_skill_version, get_skill, get_skill_version, list_skill_versions,
+    list_skills,
+};

--- a/model_gateway/src/server.rs
+++ b/model_gateway/src/server.rs
@@ -8,7 +8,7 @@ use std::{
 
 use axum::{
     extract::{multipart::MultipartError, Extension, Multipart, Path, Query, Request, State},
-    http::{header::InvalidHeaderName, StatusCode},
+    http::{header::InvalidHeaderName, HeaderMap, StatusCode},
     response::{IntoResponse, Response},
     routing::{delete, get, post},
     Json, Router,
@@ -181,7 +181,7 @@ async fn get_model_info(State(state): State<Arc<AppState>>, req: Request) -> Res
 
 async fn generate(
     State(state): State<Arc<AppState>>,
-    headers: http::HeaderMap,
+    headers: HeaderMap,
     Extension(tenant_meta): Extension<middleware::TenantRequestMeta>,
     Json(body): Json<GenerateRequest>,
 ) -> Response {
@@ -193,7 +193,7 @@ async fn generate(
 
 async fn v1_chat_completions(
     State(state): State<Arc<AppState>>,
-    headers: http::HeaderMap,
+    headers: HeaderMap,
     Extension(tenant_meta): Extension<middleware::TenantRequestMeta>,
     ValidatedJson(body): ValidatedJson<ChatCompletionRequest>,
 ) -> Response {
@@ -205,7 +205,7 @@ async fn v1_chat_completions(
 
 async fn v1_completions(
     State(state): State<Arc<AppState>>,
-    headers: http::HeaderMap,
+    headers: HeaderMap,
     Extension(tenant_meta): Extension<middleware::TenantRequestMeta>,
     ValidatedJson(body): ValidatedJson<CompletionRequest>,
 ) -> Response {
@@ -217,7 +217,7 @@ async fn v1_completions(
 
 async fn rerank(
     State(state): State<Arc<AppState>>,
-    headers: http::HeaderMap,
+    headers: HeaderMap,
     Extension(tenant_meta): Extension<middleware::TenantRequestMeta>,
     ValidatedJson(body): ValidatedJson<RerankRequest>,
 ) -> Response {
@@ -229,7 +229,7 @@ async fn rerank(
 
 async fn v1_rerank(
     State(state): State<Arc<AppState>>,
-    headers: http::HeaderMap,
+    headers: HeaderMap,
     Extension(tenant_meta): Extension<middleware::TenantRequestMeta>,
     Json(body): Json<V1RerankReqInput>,
 ) -> Response {
@@ -247,7 +247,7 @@ async fn v1_rerank(
 
 async fn v1_responses(
     State(state): State<Arc<AppState>>,
-    headers: http::HeaderMap,
+    headers: HeaderMap,
     Extension(tenant_meta): Extension<middleware::TenantRequestMeta>,
     ValidatedJson(body): ValidatedJson<ResponsesRequest>,
 ) -> Response {
@@ -259,7 +259,7 @@ async fn v1_responses(
 
 async fn v1_interactions(
     State(state): State<Arc<AppState>>,
-    headers: http::HeaderMap,
+    headers: HeaderMap,
     Extension(tenant_meta): Extension<middleware::TenantRequestMeta>,
     ValidatedJson(body): ValidatedJson<InteractionsRequest>,
 ) -> Response {
@@ -272,7 +272,7 @@ async fn v1_interactions(
 
 async fn v1_embeddings(
     State(state): State<Arc<AppState>>,
-    headers: http::HeaderMap,
+    headers: HeaderMap,
     Extension(tenant_meta): Extension<middleware::TenantRequestMeta>,
     Json(body): Json<EmbeddingRequest>,
 ) -> Response {
@@ -284,7 +284,7 @@ async fn v1_embeddings(
 
 async fn v1_messages(
     State(state): State<Arc<AppState>>,
-    headers: http::HeaderMap,
+    headers: HeaderMap,
     Extension(tenant_meta): Extension<middleware::TenantRequestMeta>,
     ValidatedJson(body): ValidatedJson<CreateMessageRequest>,
 ) -> Response {
@@ -296,7 +296,7 @@ async fn v1_messages(
 
 async fn v1_classify(
     State(state): State<Arc<AppState>>,
-    headers: http::HeaderMap,
+    headers: HeaderMap,
     Extension(tenant_meta): Extension<middleware::TenantRequestMeta>,
     Json(body): Json<ClassifyRequest>,
 ) -> Response {
@@ -308,7 +308,7 @@ async fn v1_classify(
 
 async fn v1_audio_transcriptions(
     State(state): State<Arc<AppState>>,
-    headers: http::HeaderMap,
+    headers: HeaderMap,
     Extension(tenant_meta): Extension<middleware::TenantRequestMeta>,
     mut multipart: Multipart,
 ) -> Response {
@@ -461,7 +461,7 @@ async fn v1_responses_get(
 async fn v1_responses_cancel(
     State(state): State<Arc<AppState>>,
     Path(response_id): Path<String>,
-    headers: http::HeaderMap,
+    headers: HeaderMap,
 ) -> Response {
     state
         .router
@@ -550,7 +550,7 @@ struct GetItemQuery {
 async fn v1_conversations_create_items(
     State(state): State<Arc<AppState>>,
     Path(conversation_id): Path<String>,
-    headers: http::HeaderMap,
+    headers: HeaderMap,
     Json(body): Json<Value>,
 ) -> Response {
     let memory_execution_context =
@@ -625,7 +625,7 @@ async fn v1_realtime_ws(
 
 async fn v1_realtime_session(
     State(state): State<Arc<AppState>>,
-    headers: http::HeaderMap,
+    headers: HeaderMap,
     ValidatedJson(body): ValidatedJson<RealtimeSessionCreateRequest>,
 ) -> Response {
     state
@@ -636,7 +636,7 @@ async fn v1_realtime_session(
 
 async fn v1_realtime_client_secret(
     State(state): State<Arc<AppState>>,
-    headers: http::HeaderMap,
+    headers: HeaderMap,
     ValidatedJson(body): ValidatedJson<RealtimeClientSecretCreateRequest>,
 ) -> Response {
     state
@@ -647,7 +647,7 @@ async fn v1_realtime_client_secret(
 
 async fn v1_realtime_transcription_session(
     State(state): State<Arc<AppState>>,
-    headers: http::HeaderMap,
+    headers: HeaderMap,
     ValidatedJson(body): ValidatedJson<RealtimeTranscriptionSessionCreateRequest>,
 ) -> Response {
     state
@@ -793,12 +793,47 @@ async fn v1_skills_create(State(state): State<Arc<AppState>>, multipart: Multipa
     skills::create_skill(State(state), multipart).await
 }
 
+async fn v1_skills_list(
+    State(state): State<Arc<AppState>>,
+    query: Query<openai_protocol::skills::SkillsListQuery>,
+    headers: HeaderMap,
+) -> Response {
+    skills::list_skills(State(state), query, headers).await
+}
+
+async fn v1_skills_get(
+    State(state): State<Arc<AppState>>,
+    Path(skill_id): Path<String>,
+    query: Query<openai_protocol::skills::SkillGetQuery>,
+    headers: HeaderMap,
+) -> Response {
+    skills::get_skill(State(state), Path(skill_id), query, headers).await
+}
+
 async fn v1_skills_create_version(
     State(state): State<Arc<AppState>>,
     Path(skill_id): Path<String>,
     multipart: Multipart,
 ) -> Response {
     skills::create_skill_version(State(state), Path(skill_id), multipart).await
+}
+
+async fn v1_skills_list_versions(
+    State(state): State<Arc<AppState>>,
+    Path(skill_id): Path<String>,
+    query: Query<openai_protocol::skills::SkillVersionsListQuery>,
+    headers: HeaderMap,
+) -> Response {
+    skills::list_skill_versions(State(state), Path(skill_id), query, headers).await
+}
+
+async fn v1_skills_get_version(
+    State(state): State<Arc<AppState>>,
+    Path((skill_id, version)): Path<(String, String)>,
+    query: Query<openai_protocol::skills::SkillGetQuery>,
+    headers: HeaderMap,
+) -> Response {
+    skills::get_skill_version(State(state), Path((skill_id, version)), query, headers).await
 }
 
 pub struct ServerConfig {
@@ -996,11 +1031,16 @@ pub fn build_app(
         && app_state.context.skill_service.is_some()
     {
         admin_routes = admin_routes
-            .route("/v1/skills", post(v1_skills_create))
+            .route("/v1/skills", post(v1_skills_create).get(v1_skills_list))
+            .route("/v1/skills/{skill_id}", get(v1_skills_get))
             .route(
                 "/v1/skills/{skill_id}/versions",
-                post(v1_skills_create_version),
+                post(v1_skills_create_version).get(v1_skills_list_versions),
             );
+        admin_routes = admin_routes.route(
+            "/v1/skills/{skill_id}/versions/{version}",
+            get(v1_skills_get_version),
+        );
     }
 
     // Build worker routes

--- a/model_gateway/tests/api/skills_api_test.rs
+++ b/model_gateway/tests/api/skills_api_test.rs
@@ -396,10 +396,34 @@ async fn list_skills_returns_paginated_results_and_supports_if_none_match() {
     assert_eq!(list_body["data"].as_array().map(Vec::len), Some(1));
     assert_eq!(list_body["has_more"], true);
 
+    let listed_skill_id = list_body["data"][0]["id"]
+        .as_str()
+        .expect("listed skill id")
+        .to_string();
     let after = list_body["last_id"]
         .as_str()
         .expect("last id on first page")
         .to_string();
+
+    let not_modified = client
+        .get(format!("{base_url}/v1/skills"))
+        .bearer_auth("test-admin-key")
+        .query(&[("tenant_id", "tenant-a"), ("limit", "1")])
+        .header(reqwest::header::IF_NONE_MATCH, etag)
+        .send()
+        .await
+        .expect("send conditional list skills request");
+    assert_eq!(not_modified.status(), reqwest::StatusCode::NOT_MODIFIED);
+
+    create_skill_version_via_api(
+        &client,
+        &base_url,
+        "tenant-a",
+        &listed_skill_id,
+        b"---\nname: acme:map\ndescription: Updated list ordering skill\n---\nUse rg --files.",
+    )
+    .await;
+
     let next_page = client
         .get(format!("{base_url}/v1/skills"))
         .bearer_auth("test-admin-key")
@@ -415,7 +439,7 @@ async fn list_skills_returns_paginated_results_and_supports_if_none_match() {
     let next_body: Value = next_page.json().await.expect("json response");
     assert_eq!(next_body["data"].as_array().map(Vec::len), Some(1));
     let returned_id = next_body["data"][0]["id"].as_str().expect("skill id");
-    assert_ne!(returned_id, after);
+    assert_ne!(returned_id, listed_skill_id);
     assert!(
         returned_id == first_skill["skill"]["id"].as_str().expect("first skill id")
             || returned_id
@@ -423,16 +447,6 @@ async fn list_skills_returns_paginated_results_and_supports_if_none_match() {
                     .as_str()
                     .expect("second skill id")
     );
-
-    let not_modified = client
-        .get(format!("{base_url}/v1/skills"))
-        .bearer_auth("test-admin-key")
-        .query(&[("tenant_id", "tenant-a"), ("limit", "1")])
-        .header(reqwest::header::IF_NONE_MATCH, etag)
-        .send()
-        .await
-        .expect("send conditional list skills request");
-    assert_eq!(not_modified.status(), reqwest::StatusCode::NOT_MODIFIED);
 
     server.abort();
 }
@@ -542,13 +556,114 @@ async fn get_skill_and_version_read_endpoints_require_target_tenant_and_return_c
         .get(format!("{base_url}/v1/skills/{skill_id}"))
         .bearer_auth("test-admin-key")
         .query(&[("tenant_id", "tenant-a")])
-        .header(reqwest::header::IF_MODIFIED_SINCE, skill_last_modified)
+        .header(
+            reqwest::header::IF_MODIFIED_SINCE,
+            (chrono::DateTime::parse_from_rfc2822(&skill_last_modified)
+                .expect("parse last-modified header")
+                + chrono::Duration::seconds(1))
+            .format("%a, %d %b %Y %H:%M:%S GMT")
+            .to_string(),
+        )
         .send()
         .await
         .expect("send if-modified-since get skill request");
     assert_eq!(
         not_modified_since.status(),
         reqwest::StatusCode::NOT_MODIFIED
+    );
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn invalid_after_cursor_returns_bad_request_before_conditional_cache_checks() {
+    let blob_dir = tempfile::tempdir().expect("blob tempdir");
+    let cache_dir = tempfile::tempdir().expect("cache tempdir");
+    let app = create_skills_test_app(skills_test_config(&blob_dir, &cache_dir, true)).await;
+    let (base_url, server) = spawn_app(app).await;
+    let client = reqwest::Client::new();
+
+    let created = create_skill_via_api(
+        &client,
+        &base_url,
+        "tenant-a",
+        b"---\nname: acme:map\ndescription: Map the repo\n---\nUse rg.",
+    )
+    .await;
+    let skill_id = created["skill"]["id"]
+        .as_str()
+        .expect("skill id")
+        .to_string();
+    create_skill_version_via_api(
+        &client,
+        &base_url,
+        "tenant-a",
+        &skill_id,
+        b"---\nname: acme:map\ndescription: Updated mapping skill\n---\nUse rg --files.",
+    )
+    .await;
+
+    let list_response = client
+        .get(format!("{base_url}/v1/skills"))
+        .bearer_auth("test-admin-key")
+        .query(&[("tenant_id", "tenant-a")])
+        .send()
+        .await
+        .expect("send list skills request");
+    let list_etag = list_response
+        .headers()
+        .get(reqwest::header::ETAG)
+        .expect("skills list etag")
+        .to_str()
+        .expect("etag text")
+        .to_string();
+
+    let invalid_skills_after = client
+        .get(format!("{base_url}/v1/skills"))
+        .bearer_auth("test-admin-key")
+        .query(&[("tenant_id", "tenant-a"), ("after", "not-a-valid-cursor")])
+        .header(reqwest::header::IF_NONE_MATCH, list_etag)
+        .send()
+        .await
+        .expect("send invalid after list request");
+    assert_eq!(
+        invalid_skills_after.status(),
+        reqwest::StatusCode::BAD_REQUEST
+    );
+    let invalid_skills_body: Value = invalid_skills_after.json().await.expect("json response");
+    assert_eq!(invalid_skills_body["error"]["code"], "invalid_after_cursor");
+
+    let versions_response = client
+        .get(format!("{base_url}/v1/skills/{skill_id}/versions"))
+        .bearer_auth("test-admin-key")
+        .query(&[("tenant_id", "tenant-a")])
+        .send()
+        .await
+        .expect("send list skill versions request");
+    let versions_etag = versions_response
+        .headers()
+        .get(reqwest::header::ETAG)
+        .expect("skill versions etag")
+        .to_str()
+        .expect("etag text")
+        .to_string();
+
+    let invalid_versions_after = client
+        .get(format!("{base_url}/v1/skills/{skill_id}/versions"))
+        .bearer_auth("test-admin-key")
+        .query(&[("tenant_id", "tenant-a"), ("after", "bogus-version")])
+        .header(reqwest::header::IF_NONE_MATCH, versions_etag)
+        .send()
+        .await
+        .expect("send invalid versions after request");
+    assert_eq!(
+        invalid_versions_after.status(),
+        reqwest::StatusCode::BAD_REQUEST
+    );
+    let invalid_versions_body: Value = invalid_versions_after.json().await.expect("json response");
+    assert_eq!(
+        invalid_versions_body["error"]["code"],
+        "invalid_after_cursor"
     );
 
     server.abort();

--- a/model_gateway/tests/api/skills_api_test.rs
+++ b/model_gateway/tests/api/skills_api_test.rs
@@ -106,6 +106,57 @@ fn build_skill_zip(skill_md: &[u8], extra_files: &[(&str, &[u8])]) -> Vec<u8> {
     writer.finish().expect("finish zip writer").into_inner()
 }
 
+async fn create_skill_via_api(
+    client: &reqwest::Client,
+    base_url: &str,
+    tenant_id: &str,
+    skill_md: &[u8],
+) -> Value {
+    let response = client
+        .post(format!("{base_url}/v1/skills"))
+        .bearer_auth("test-admin-key")
+        .multipart(
+            Form::new().text("tenant_id", tenant_id.to_string()).part(
+                "files[]",
+                Part::bytes(skill_md.to_vec())
+                    .file_name("SKILL.md")
+                    .mime_str("text/markdown")
+                    .expect("valid markdown mime"),
+            ),
+        )
+        .send()
+        .await
+        .expect("send create skill request");
+    assert_eq!(response.status(), reqwest::StatusCode::CREATED);
+    response.json().await.expect("json response")
+}
+
+async fn create_skill_version_via_api(
+    client: &reqwest::Client,
+    base_url: &str,
+    tenant_id: &str,
+    skill_id: &str,
+    skill_md: &[u8],
+) -> Value {
+    let response = client
+        .post(format!("{base_url}/v1/skills/{skill_id}/versions"))
+        .bearer_auth("test-admin-key")
+        .multipart(
+            Form::new().text("tenant_id", tenant_id.to_string()).part(
+                "files[]",
+                Part::bytes(skill_md.to_vec())
+                    .file_name("SKILL.md")
+                    .mime_str("text/markdown")
+                    .expect("valid markdown mime"),
+            ),
+        )
+        .send()
+        .await
+        .expect("send create skill version request");
+    assert_eq!(response.status(), reqwest::StatusCode::CREATED);
+    response.json().await.expect("json response")
+}
+
 #[tokio::test]
 async fn create_skill_returns_created_skill_and_version() {
     let blob_dir = tempfile::tempdir().expect("blob tempdir");
@@ -294,6 +345,210 @@ async fn create_skill_version_returns_incremented_version() {
     assert_eq!(
         version_body["version"]["files"].as_array().map(Vec::len),
         Some(2)
+    );
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn list_skills_returns_paginated_results_and_supports_if_none_match() {
+    let blob_dir = tempfile::tempdir().expect("blob tempdir");
+    let cache_dir = tempfile::tempdir().expect("cache tempdir");
+    let app = create_skills_test_app(skills_test_config(&blob_dir, &cache_dir, true)).await;
+    let (base_url, server) = spawn_app(app).await;
+    let client = reqwest::Client::new();
+
+    let first_skill = create_skill_via_api(
+        &client,
+        &base_url,
+        "tenant-a",
+        b"---\nname: acme:map\ndescription: Map the repo\n---\nUse rg.",
+    )
+    .await;
+    let second_skill = create_skill_via_api(
+        &client,
+        &base_url,
+        "tenant-a",
+        b"---\nname: acme:search\ndescription: Search the repo\n---\nUse fd.",
+    )
+    .await;
+
+    let list_response = client
+        .get(format!("{base_url}/v1/skills"))
+        .bearer_auth("test-admin-key")
+        .query(&[("tenant_id", "tenant-a"), ("limit", "1")])
+        .send()
+        .await
+        .expect("send list skills request");
+    assert_eq!(list_response.status(), reqwest::StatusCode::OK);
+    let etag = list_response
+        .headers()
+        .get(reqwest::header::ETAG)
+        .expect("etag header")
+        .to_str()
+        .expect("etag text")
+        .to_string();
+    assert!(list_response
+        .headers()
+        .contains_key(reqwest::header::LAST_MODIFIED));
+    let list_body: Value = list_response.json().await.expect("json response");
+    assert_eq!(list_body["object"], "list");
+    assert_eq!(list_body["data"].as_array().map(Vec::len), Some(1));
+    assert_eq!(list_body["has_more"], true);
+
+    let after = list_body["last_id"]
+        .as_str()
+        .expect("last id on first page")
+        .to_string();
+    let next_page = client
+        .get(format!("{base_url}/v1/skills"))
+        .bearer_auth("test-admin-key")
+        .query(&[
+            ("tenant_id", "tenant-a"),
+            ("limit", "1"),
+            ("after", after.as_str()),
+        ])
+        .send()
+        .await
+        .expect("send second list skills request");
+    assert_eq!(next_page.status(), reqwest::StatusCode::OK);
+    let next_body: Value = next_page.json().await.expect("json response");
+    assert_eq!(next_body["data"].as_array().map(Vec::len), Some(1));
+    let returned_id = next_body["data"][0]["id"].as_str().expect("skill id");
+    assert_ne!(returned_id, after);
+    assert!(
+        returned_id == first_skill["skill"]["id"].as_str().expect("first skill id")
+            || returned_id
+                == second_skill["skill"]["id"]
+                    .as_str()
+                    .expect("second skill id")
+    );
+
+    let not_modified = client
+        .get(format!("{base_url}/v1/skills"))
+        .bearer_auth("test-admin-key")
+        .query(&[("tenant_id", "tenant-a"), ("limit", "1")])
+        .header(reqwest::header::IF_NONE_MATCH, etag)
+        .send()
+        .await
+        .expect("send conditional list skills request");
+    assert_eq!(not_modified.status(), reqwest::StatusCode::NOT_MODIFIED);
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn get_skill_and_version_read_endpoints_require_target_tenant_and_return_cache_headers() {
+    let blob_dir = tempfile::tempdir().expect("blob tempdir");
+    let cache_dir = tempfile::tempdir().expect("cache tempdir");
+    let app = create_skills_test_app(skills_test_config(&blob_dir, &cache_dir, true)).await;
+    let (base_url, server) = spawn_app(app).await;
+    let client = reqwest::Client::new();
+
+    let created = create_skill_via_api(
+        &client,
+        &base_url,
+        "tenant-a",
+        b"---\nname: acme:map\ndescription: Map the repo\nmetadata:\n  short-description: Map it\n---\nUse rg.",
+    )
+    .await;
+    let skill_id = created["skill"]["id"]
+        .as_str()
+        .expect("skill id")
+        .to_string();
+
+    create_skill_version_via_api(
+        &client,
+        &base_url,
+        "tenant-a",
+        &skill_id,
+        b"---\nname: acme:map\ndescription: Updated mapping skill\nmetadata:\n  short-description: Map it better\n---\nUse rg --files.",
+    )
+    .await;
+
+    let missing_tenant = client
+        .get(format!("{base_url}/v1/skills/{skill_id}"))
+        .bearer_auth("test-admin-key")
+        .send()
+        .await
+        .expect("send missing tenant get request");
+    assert_eq!(missing_tenant.status(), reqwest::StatusCode::BAD_REQUEST);
+    let missing_body: Value = missing_tenant.json().await.expect("json response");
+    assert_eq!(missing_body["error"]["code"], "missing_target_tenant");
+
+    let get_skill = client
+        .get(format!("{base_url}/v1/skills/{skill_id}"))
+        .bearer_auth("test-admin-key")
+        .query(&[("tenant_id", "tenant-a")])
+        .send()
+        .await
+        .expect("send get skill request");
+    assert_eq!(get_skill.status(), reqwest::StatusCode::OK);
+    let skill_etag = get_skill
+        .headers()
+        .get(reqwest::header::ETAG)
+        .expect("etag header")
+        .to_str()
+        .expect("etag text")
+        .to_string();
+    let skill_last_modified = get_skill
+        .headers()
+        .get(reqwest::header::LAST_MODIFIED)
+        .expect("last-modified header")
+        .to_str()
+        .expect("last-modified text")
+        .to_string();
+    assert!(get_skill
+        .headers()
+        .contains_key(reqwest::header::LAST_MODIFIED));
+    let skill_body: Value = get_skill.json().await.expect("json response");
+    assert_eq!(skill_body["id"], skill_id);
+
+    let list_versions = client
+        .get(format!("{base_url}/v1/skills/{skill_id}/versions"))
+        .bearer_auth("test-admin-key")
+        .query(&[("tenant_id", "tenant-a")])
+        .send()
+        .await
+        .expect("send list versions request");
+    assert_eq!(list_versions.status(), reqwest::StatusCode::OK);
+    let versions_body: Value = list_versions.json().await.expect("json response");
+    assert_eq!(versions_body["object"], "list");
+    assert_eq!(versions_body["data"].as_array().map(Vec::len), Some(2));
+
+    let get_version = client
+        .get(format!("{base_url}/v1/skills/{skill_id}/versions/2"))
+        .bearer_auth("test-admin-key")
+        .query(&[("tenant_id", "tenant-a")])
+        .send()
+        .await
+        .expect("send get version request");
+    assert_eq!(get_version.status(), reqwest::StatusCode::OK);
+    assert!(get_version.headers().contains_key(reqwest::header::ETAG));
+    let version_body: Value = get_version.json().await.expect("json response");
+    assert_eq!(version_body["version_number"], 2);
+
+    let not_modified = client
+        .get(format!("{base_url}/v1/skills/{skill_id}"))
+        .bearer_auth("test-admin-key")
+        .query(&[("tenant_id", "tenant-a")])
+        .header(reqwest::header::IF_NONE_MATCH, skill_etag)
+        .send()
+        .await
+        .expect("send conditional get skill request");
+    assert_eq!(not_modified.status(), reqwest::StatusCode::NOT_MODIFIED);
+
+    let not_modified_since = client
+        .get(format!("{base_url}/v1/skills/{skill_id}"))
+        .bearer_auth("test-admin-key")
+        .query(&[("tenant_id", "tenant-a")])
+        .header(reqwest::header::IF_MODIFIED_SINCE, skill_last_modified)
+        .send()
+        .await
+        .expect("send if-modified-since get skill request");
+    assert_eq!(
+        not_modified_since.status(),
+        reqwest::StatusCode::NOT_MODIFIED
     );
 
     server.abort();


### PR DESCRIPTION
## Summary
- add admin-gated skills read/list endpoints for skills and versions
- add protocol and service-layer query/list support with pagination and filtering
- add ETag and Last-Modified handling for skills GET/list routes and cover the new API behavior with tests

## Verification
- cargo +nightly fmt --all
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo test -p smg --test api_tests skills_api

## Notes
- make python-dev was started as the bindings gate because this branch touches crates/protocols, but that run was interrupted from the terminal and was not completed in this session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GET endpoints to list and retrieve individual skills with cursor-based pagination
  * Added GET endpoints to list and retrieve skill versions with optional filtering by deprecation status
  * Enabled HTTP caching with ETag and conditional request support for improved performance
  * Added query parameter support to filter skills by source and name

* **Tests**
  * Added integration tests for skills read and list endpoints, including pagination and caching behavior validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->