### PR TITLE
feat(protocols): implement T5 local_shell tool + call/output items

### DIFF
--- a/crates/mcp/src/core/session.rs
+++ b/crates/mcp/src/core/session.rs
@@ -567,7 +567,9 @@ impl<'a> McpToolSession<'a> {
             | ResponseOutputItem::ApplyPatchCallOutput { .. }
             | ResponseOutputItem::Message { .. }
             | ResponseOutputItem::Reasoning { .. }
-            | ResponseOutputItem::Compaction { .. } => true,
+            | ResponseOutputItem::Compaction { .. }
+            | ResponseOutputItem::LocalShellCall { .. }
+            | ResponseOutputItem::LocalShellCallOutput { .. } => true,
         }
     }
 

--- a/crates/protocols/src/responses.rs
+++ b/crates/protocols/src/responses.rs
@@ -439,6 +439,17 @@ pub enum ResponseTool {
     /// [`ResponsesToolChoice::ApplyPatch`] when callers want to force usage.
     #[serde(rename = "apply_patch")]
     ApplyPatch,
+
+    /// Built-in host-execute shell tool — `{ type: "local_shell" }`.
+    ///
+    /// Spec (openai-responses-api-spec.md §tools L462): `LocalShell { type:
+    /// "local_shell" }` — carries no payload. Distinct from `shell` (T6),
+    /// which carries a containerized `environment`. The model emits
+    /// `local_shell_call` output items carrying a `LocalShellExec` action;
+    /// the client executes the command on the host and replies with a
+    /// matching `local_shell_call_output` item.
+    #[serde(rename = "local_shell")]
+    LocalShell,
 }
 
 /// Payload carried by [`ResponseTool::Namespace`].
@@ -1740,6 +1751,35 @@ pub enum ResponseInputOutputItem {
         #[serde(skip_serializing_if = "Option::is_none")]
         output: Option<String>,
     },
+    /// `type: "local_shell_call"` — assistant's call into the
+    /// `local_shell` built-in tool. Spec
+    /// (openai-responses-api-spec.md §LocalShellCall L219-222):
+    /// `{ id, action, call_id, status, type }` where `action` is a
+    /// [`LocalShellExec`] payload describing the command to run on the
+    /// host. The client executes the command and replies with a
+    /// matching [`Self::LocalShellCallOutput`].
+    #[serde(rename = "local_shell_call")]
+    LocalShellCall {
+        id: String,
+        call_id: String,
+        action: LocalShellExec,
+        status: LocalShellCallStatus,
+    },
+    /// `type: "local_shell_call_output"` — client's response to a
+    /// `local_shell_call`. Spec
+    /// (openai-responses-api-spec.md §LocalShellCallOutput L224-226):
+    /// `{ id, output, type, status }`. `output` is a single string
+    /// carrying the command's serialized JSON output; `status` is
+    /// optional per SDK v2.8.1 (`openai==2.8.1`,
+    /// `types/responses/response_input_item_param.py`
+    /// `LocalShellCallOutput` — `Optional` on `status`).
+    #[serde(rename = "local_shell_call_output")]
+    LocalShellCallOutput {
+        id: String,
+        output: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        status: Option<LocalShellCallStatus>,
+    },
     #[serde(untagged)]
     SimpleInputMessage {
         content: StringOrContentParts,
@@ -2165,6 +2205,30 @@ pub enum ResponseOutputItem {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         output: Option<String>,
     },
+    /// `type: "local_shell_call"` — output-side mirror of the input
+    /// variant — emitted when the model issues a `local_shell` tool call.
+    /// Spec (openai-responses-api-spec.md §LocalShellCall L219-222):
+    /// `{ id, action, call_id, status, type }` with `action` as a
+    /// [`LocalShellExec`] payload. See [`ResponseInputOutputItem::LocalShellCall`].
+    #[serde(rename = "local_shell_call")]
+    LocalShellCall {
+        id: String,
+        call_id: String,
+        action: LocalShellExec,
+        status: LocalShellCallStatus,
+    },
+    /// `type: "local_shell_call_output"` — output-side mirror of the
+    /// input variant. Spec
+    /// (openai-responses-api-spec.md §LocalShellCallOutput L224-226):
+    /// `{ id, output, type, status }` with `status` optional per SDK
+    /// v2.8.1. See [`ResponseInputOutputItem::LocalShellCallOutput`].
+    #[serde(rename = "local_shell_call_output")]
+    LocalShellCallOutput {
+        id: String,
+        output: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        status: Option<LocalShellCallStatus>,
+    },
 }
 
 // ============================================================================
@@ -2268,6 +2332,52 @@ pub struct FileSearchResult {
     pub text: Option<String>,
     pub score: Option<f32>,
     pub attributes: Option<Value>,
+}
+
+/// Status for `local_shell` tool calls.
+///
+/// Spec (openai-responses-api-spec.md §LocalShellCall L221): `"in_progress"
+/// | "completed" | "incomplete"`.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, schemars::JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum LocalShellCallStatus {
+    InProgress,
+    Completed,
+    Incomplete,
+}
+
+/// `action` payload carried by a [`ResponseInputOutputItem::LocalShellCall`] /
+/// [`ResponseOutputItem::LocalShellCall`] item.
+///
+/// Spec (openai-responses-api-spec.md §LocalShellCall L220):
+/// `{ command: array of string, env: map[string], type: "exec",
+///   timeout_ms?, user?, working_directory? }`. `env` is always present
+/// (an empty object is semantically distinct from omitting the field),
+/// matching the OpenAI Python SDK (`openai==2.8.1`,
+/// `types/responses/response_input_item_param.py` `LocalShellCallAction`
+/// — non-`Optional` `Dict[str, str]`).
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, schemars::JsonSchema)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum LocalShellExec {
+    /// `type: "exec"` — the only action kind defined by the spec today.
+    #[serde(rename = "exec")]
+    Exec {
+        /// Argv of the command to run on the host.
+        command: Vec<String>,
+        /// Environment variables overlaid on the host process env.
+        /// Always serialized (possibly empty) to match SDK shape.
+        env: std::collections::BTreeMap<String, String>,
+        /// Hard timeout in milliseconds.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        timeout_ms: Option<u64>,
+        /// User to run the command as.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        user: Option<String>,
+        /// Working directory for the command.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        working_directory: Option<String>,
+    },
 }
 
 // ============================================================================
@@ -2844,7 +2954,9 @@ impl GenerationRequest for ResponsesRequest {
                         | ResponseInputOutputItem::ShellCallOutput { .. }
                         | ResponseInputOutputItem::ItemReference { .. }
                         | ResponseInputOutputItem::ApplyPatchCall { .. }
-                        | ResponseInputOutputItem::ApplyPatchCallOutput { .. } => {}
+                        | ResponseInputOutputItem::ApplyPatchCallOutput { .. }
+                        | ResponseInputOutputItem::LocalShellCall { .. }
+                        | ResponseInputOutputItem::LocalShellCallOutput { .. } => {}
                     }
                 }
 
@@ -3167,6 +3279,11 @@ fn validate_input_item(item: &ResponseInputOutputItem) -> Result<(), ValidationE
         // output, or a `failed` where the executor had nothing to log) so
         // no emptiness check applies here.
         ResponseInputOutputItem::ApplyPatchCallOutput { .. } => {}
+        // Schema-only pass-through: T5 adds the protocol variants for the
+        // `local_shell` built-in tool. Validation mirrors `ComputerCall` /
+        // `ImageGenerationCall` above (no payload-level content checks).
+        ResponseInputOutputItem::LocalShellCall { .. } => {}
+        ResponseInputOutputItem::LocalShellCallOutput { .. } => {}
     }
     Ok(())
 }

--- a/crates/protocols/tests/responses.rs
+++ b/crates/protocols/tests/responses.rs
@@ -2431,6 +2431,71 @@ fn shell_call_output_item_round_trips_on_response_side() {
     assert_eq!(serde_json::to_value(&item).expect("serialize"), payload);
 }
 
+// ============================================================================
+// T5: local_shell tool + local_shell_call / local_shell_call_output round-trips
+// ============================================================================
+
+/// `ResponseTool::LocalShell` is a unit tool whose on-wire shape is just
+/// `{ "type": "local_shell" }`. Spec (openai-responses-api-spec.md §tools
+/// L462): `LocalShell { type: "local_shell" }`.
+#[test]
+fn local_shell_tool_round_trips_spec_shape() {
+    let payload = json!({ "type": "local_shell" });
+    let tool: ResponseTool =
+        serde_json::from_value(payload.clone()).expect("local_shell tool should deserialize");
+    assert!(matches!(tool, ResponseTool::LocalShell));
+    assert_eq!(serde_json::to_value(&tool).expect("serialize"), payload);
+}
+
+/// `ResponseInputOutputItem::LocalShellCall` carries the minimum spec shape:
+/// `{ id, action: { command, env, type: "exec" }, call_id, status, type }`.
+/// Spec (openai-responses-api-spec.md §LocalShellCall L219-222).
+#[test]
+fn local_shell_call_input_item_round_trips_spec_shape() {
+    let payload = json!({
+        "type": "local_shell_call",
+        "id": "ls_1",
+        "call_id": "call_ls_1",
+        "action": {
+            "type": "exec",
+            "command": ["/bin/echo", "hello"],
+            "env": {}
+        },
+        "status": "in_progress"
+    });
+    let item: ResponseInputOutputItem = serde_json::from_value(payload.clone())
+        .expect("local_shell_call input item should deserialize");
+    match &item {
+        ResponseInputOutputItem::LocalShellCall {
+            id,
+            call_id,
+            action,
+            status,
+        } => {
+            assert_eq!(id, "ls_1");
+            assert_eq!(call_id, "call_ls_1");
+            assert_eq!(*status, LocalShellCallStatus::InProgress);
+            match action {
+                LocalShellExec::Exec {
+                    command,
+                    env,
+                    timeout_ms,
+                    user,
+                    working_directory,
+                } => {
+                    assert_eq!(command, &vec!["/bin/echo".to_string(), "hello".to_string()]);
+                    assert!(env.is_empty());
+                    assert!(timeout_ms.is_none());
+                    assert!(user.is_none());
+                    assert!(working_directory.is_none());
+                }
+            }
+        }
+        other => panic!("expected LocalShellCall, got {other:?}"),
+    }
+    assert_eq!(serde_json::to_value(&item).expect("serialize"), payload);
+}
+
 #[test]
 fn shell_call_container_reference_on_response_side_round_trip() {
     // Spec (openai-responses-api-spec.md §returns L512-513): the
@@ -2476,6 +2541,52 @@ fn shell_call_container_reference_on_response_side_round_trip() {
             assert_eq!(*status, ShellCallStatus::Completed);
         }
         other => panic!("expected ResponseOutputItem::ShellCall, got {other:?}"),
+    }
+    assert_eq!(serde_json::to_value(&item).expect("serialize"), payload);
+}
+
+/// All optional `LocalShellExec::Exec` fields (`timeout_ms`, `user`,
+/// `working_directory`) plus populated `env` round-trip through a full
+/// (de)serialize cycle.
+#[test]
+fn local_shell_call_input_item_round_trips_with_all_optionals() {
+    let payload = json!({
+        "type": "local_shell_call",
+        "id": "ls_2",
+        "call_id": "call_ls_2",
+        "action": {
+            "type": "exec",
+            "command": ["python", "-c", "print('hi')"],
+            "env": { "PYTHONUNBUFFERED": "1", "LANG": "C.UTF-8" },
+            "timeout_ms": 5000,
+            "user": "root",
+            "working_directory": "/tmp"
+        },
+        "status": "completed"
+    });
+    let item: ResponseInputOutputItem = serde_json::from_value(payload.clone())
+        .expect("local_shell_call with optionals should deserialize");
+    match &item {
+        ResponseInputOutputItem::LocalShellCall { action, status, .. } => {
+            assert_eq!(*status, LocalShellCallStatus::Completed);
+            match action {
+                LocalShellExec::Exec {
+                    command,
+                    env,
+                    timeout_ms,
+                    user,
+                    working_directory,
+                } => {
+                    assert_eq!(command.len(), 3);
+                    assert_eq!(env.get("LANG").map(String::as_str), Some("C.UTF-8"));
+                    assert_eq!(env.get("PYTHONUNBUFFERED").map(String::as_str), Some("1"));
+                    assert_eq!(*timeout_ms, Some(5000));
+                    assert_eq!(user.as_deref(), Some("root"));
+                    assert_eq!(working_directory.as_deref(), Some("/tmp"));
+                }
+            }
+        }
+        other => panic!("expected LocalShellCall, got {other:?}"),
     }
     assert_eq!(serde_json::to_value(&item).expect("serialize"), payload);
 }
@@ -3280,5 +3391,120 @@ fn test_apply_patch_request_validate_accepts_relaxed_shapes() {
     assert!(
         empty_update_diff.validate().is_ok(),
         "empty ApplyPatchCall.operation.diff on update_file must pass validation"
+    );
+}
+
+/// `ResponseInputOutputItem::LocalShellCallOutput` carries a string
+/// `output` + optional `status`. Spec
+/// (openai-responses-api-spec.md §LocalShellCallOutput L224-226):
+/// `{ id, output, type, status }`.
+#[test]
+fn local_shell_call_output_input_item_round_trips_spec_shape() {
+    // With status present.
+    let payload_with_status = json!({
+        "type": "local_shell_call_output",
+        "id": "lso_1",
+        "output": "{\"exit_code\":0,\"stdout\":\"hello\\n\",\"stderr\":\"\"}",
+        "status": "completed"
+    });
+    let item: ResponseInputOutputItem = serde_json::from_value(payload_with_status.clone())
+        .expect("local_shell_call_output should deserialize");
+    match &item {
+        ResponseInputOutputItem::LocalShellCallOutput { id, output, status } => {
+            assert_eq!(id, "lso_1");
+            assert!(output.contains("exit_code"));
+            assert_eq!(*status, Some(LocalShellCallStatus::Completed));
+        }
+        other => panic!("expected LocalShellCallOutput, got {other:?}"),
+    }
+    assert_eq!(
+        serde_json::to_value(&item).expect("serialize"),
+        payload_with_status,
+    );
+
+    // Without status — SDK v2.8.1 types the field as Optional.
+    let payload_no_status = json!({
+        "type": "local_shell_call_output",
+        "id": "lso_2",
+        "output": "raw log"
+    });
+    let item: ResponseInputOutputItem = serde_json::from_value(payload_no_status.clone())
+        .expect("local_shell_call_output without status should deserialize");
+    match &item {
+        ResponseInputOutputItem::LocalShellCallOutput { id, output, status } => {
+            assert_eq!(id, "lso_2");
+            assert_eq!(output, "raw log");
+            assert!(status.is_none());
+        }
+        other => panic!("expected LocalShellCallOutput, got {other:?}"),
+    }
+    // No `"status": null` should leak via skip_serializing_if.
+    assert_eq!(
+        serde_json::to_value(&item).expect("serialize"),
+        payload_no_status,
+    );
+}
+
+/// Output-side mirror: `ResponseOutputItem::LocalShellCall` +
+/// `LocalShellCallOutput` round-trip the same on-wire shape the input-side
+/// variants carry. Spec (openai-responses-api-spec.md L507-516) lists both
+/// under `output: array of ResponseOutputItem`.
+#[test]
+fn local_shell_output_item_variants_round_trip_spec_shape() {
+    let call_payload = json!({
+        "type": "local_shell_call",
+        "id": "ls_out_1",
+        "call_id": "call_ls_out_1",
+        "action": {
+            "type": "exec",
+            "command": ["ls", "-la"],
+            "env": {}
+        },
+        "status": "incomplete"
+    });
+    let call_item: ResponseOutputItem = serde_json::from_value(call_payload.clone())
+        .expect("local_shell_call output item should deserialize");
+    match &call_item {
+        ResponseOutputItem::LocalShellCall {
+            id,
+            call_id,
+            action,
+            status,
+        } => {
+            assert_eq!(id, "ls_out_1");
+            assert_eq!(call_id, "call_ls_out_1");
+            assert_eq!(*status, LocalShellCallStatus::Incomplete);
+            match action {
+                LocalShellExec::Exec { command, .. } => {
+                    assert_eq!(command, &vec!["ls".to_string(), "-la".to_string()]);
+                }
+            }
+        }
+        other => panic!("expected ResponseOutputItem::LocalShellCall, got {other:?}"),
+    }
+    assert_eq!(
+        serde_json::to_value(&call_item).expect("serialize"),
+        call_payload,
+    );
+
+    let output_payload = json!({
+        "type": "local_shell_call_output",
+        "id": "lso_out_1",
+        "output": "{\"exit_code\":0}",
+        "status": "completed"
+    });
+    let output_item: ResponseOutputItem = serde_json::from_value(output_payload.clone())
+        .expect("local_shell_call_output output item should deserialize");
+    match &output_item {
+        ResponseOutputItem::LocalShellCallOutput { id, output, status } => {
+            assert_eq!(id, "lso_out_1");
+            assert!(output.contains("exit_code"));
+            assert_eq!(*status, Some(LocalShellCallStatus::Completed));
+        }
+        other => panic!("expected ResponseOutputItem::LocalShellCallOutput, got {other:?}"),
+    }
+    assert_eq!(
+        serde_json::to_value(&output_item).expect("serialize"),
+        output_payload,
     );
 }

--- a/model_gateway/benches/routing_allocation_bench.rs
+++ b/model_gateway/benches/routing_allocation_bench.rs
@@ -79,6 +79,9 @@ fn extract_text_for_routing_old(req: &ResponsesRequest) -> String {
                 ResponseInputOutputItem::ItemReference { .. } => None,
                 ResponseInputOutputItem::ApplyPatchCall { .. }
                 | ResponseInputOutputItem::ApplyPatchCallOutput { .. } => None,
+                // T5 schema-only: forced-cascade arm, no behavior.
+                ResponseInputOutputItem::LocalShellCall { .. }
+                | ResponseInputOutputItem::LocalShellCallOutput { .. } => None,
             })
             .collect::<Vec<String>>()
             .join(" "),

--- a/model_gateway/src/routers/grpc/harmony/builder.rs
+++ b/model_gateway/src/routers/grpc/harmony/builder.rs
@@ -445,6 +445,8 @@ impl HarmonyBuilder {
                             ResponseTool::Namespace(_) => "namespace",
                             ResponseTool::Shell(_) => "shell",
                             ResponseTool::ApplyPatch => "apply_patch",
+                            // T5 schema-only: forced-cascade arm, no behavior.
+                            ResponseTool::LocalShell => "local_shell",
                         })
                         .collect()
                 })
@@ -775,6 +777,11 @@ impl HarmonyBuilder {
                     function = "parse_response_item_to_harmony_message",
                     "apply_patch item reached Harmony conversion"
                 );
+                Err("Unsupported input item type".to_string())
+            }
+            // T5 schema-only: forced-cascade arm, no behavior.
+            ResponseInputOutputItem::LocalShellCall { .. }
+            | ResponseInputOutputItem::LocalShellCallOutput { .. } => {
                 Err("Unsupported input item type".to_string())
             }
         }

--- a/model_gateway/src/routers/grpc/regular/responses/conversions.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/conversions.rs
@@ -187,6 +187,11 @@ pub(crate) fn responses_to_chat(req: &ResponsesRequest) -> Result<ChatCompletion
                         );
                         return Err("Unsupported input item type".to_string());
                     }
+                    // T5 schema-only: forced-cascade arm, no behavior.
+                    ResponseInputOutputItem::LocalShellCall { .. }
+                    | ResponseInputOutputItem::LocalShellCallOutput { .. } => {
+                        return Err("Unsupported input item type".to_string());
+                    }
                 }
             }
         }

--- a/model_gateway/src/routers/openai/responses/utils.rs
+++ b/model_gateway/src/routers/openai/responses/utils.rs
@@ -259,6 +259,8 @@ pub(super) fn response_tool_to_value(tool: &ResponseTool) -> Option<Value> {
         ResponseTool::Shell(_) => serde_json::to_value(tool).ok(),
         ResponseTool::ApplyPatch => serde_json::to_value(tool).ok(),
         ResponseTool::Function(_) => None,
+        // T5 schema-only: forced-cascade arm, no behavior.
+        ResponseTool::LocalShell => serde_json::to_value(tool).ok(),
     }
 }
 


### PR DESCRIPTION
## Summary
Implements audit task **T5**: adds the `local_shell` built-in tool on `ResponseTool` plus the matching `local_shell_call` / `local_shell_call_output` items on both `ResponseInputOutputItem` and `ResponseOutputItem`.

## What changed
- `crates/protocols/src/responses.rs`:
  - `ResponseTool::LocalShell` — unit variant (`{ type: "local_shell" }`).
  - `ResponseInputOutputItem::LocalShellCall { id, call_id, action, status }` + mirror on `ResponseOutputItem`.
  - `ResponseInputOutputItem::LocalShellCallOutput { id, output, status? }` + mirror on `ResponseOutputItem`.
  - New supporting types: `LocalShellExec::Exec { command, env, timeout_ms?, user?, working_directory? }` and `LocalShellCallStatus` (`in_progress | completed | incomplete`).
  - 2 local cascade arms (`validate_input_item`, request text collector).
- `crates/protocols/tests/responses.rs`: 5 integration round-trip tests (tool, input call, input call with all optionals, input output both status-present/absent, output-item mirror).
- `crates/mcp/src/core/session.rs`, `model_gateway/src/routers/grpc/harmony/builder.rs`, `model_gateway/src/routers/grpc/regular/responses/conversions.rs`, `model_gateway/src/routers/openai/responses/utils.rs`: 4 forced-cascade match arms for the newly added variants, each one line / schema-only (no behavior).

## Why
Per the Responses API spec (`.claude/_audit/openai-responses-api-spec.md`):
- L219-226 — `LocalShellCall` / `LocalShellCallOutput` item shapes.
- L462 — `LocalShell { type: "local_shell" }` tool.
- L507-516 — lists both variants under `output: array of ResponseOutputItem`.

Status-optional on `LocalShellCallOutput` mirrors the OpenAI Python SDK v2.8.1 (`openai==2.8.1`, `types/responses/response_input_item_param.py::LocalShellCallOutput`).

## Verification
- [x] `cargo check -p openai-protocol --tests` passes
- [x] `cargo test -p openai-protocol --test responses` passes (70 tests, incl. 5 new)
- [x] `cargo check -p smg --lib` passes
- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy -p openai-protocol -p smg --lib --tests -- -D warnings` clean
- [x] Spec cross-checked: `.claude/_audit/openai-responses-api-spec.md` §LocalShellCall L219-226, §tools L462

## Blast radius
- Touched: `crates/protocols/src/responses.rs`, `crates/protocols/tests/responses.rs`, plus minimal forced-cascade arms in `crates/mcp/src/core/session.rs`, `model_gateway/src/routers/grpc/harmony/builder.rs`, `model_gateway/src/routers/grpc/regular/responses/conversions.rs`, `model_gateway/src/routers/openai/responses/utils.rs`.
- Matches audit blast radius: schema only; no new router/gateway behavior.

## Out of scope
- No runtime handler for executing local shell commands (schema-only task).
- No MCP/Harmony routing of `local_shell_call` beyond the forced-cascade placeholders.
- No gRPC proto / conversions for the new variants.

Refs: T5 (`.claude/_audit/responses-api-gap-audit.md` L503-515).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added protocol support for a new local_shell built-in tool so shell-call requests and outputs appear in responses.
  * Session visibility updated so local shell calls and their outputs are shown to clients.

* **Behavior**
  * Routing/text-assembly now ignores local shell call items so they don't contribute to routing text.
  * Some gateway paths explicitly treat local shell items as unsupported and return a standard unsupported-item error.

* **Tests**
  * Added serialization/deserialization tests for minimal and full local shell call/output shapes, including conditional status emission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->