### PR TITLE
feat(protocols): implement T7 apply_patch tool + call/output items

### DIFF
--- a/crates/mcp/src/core/session.rs
+++ b/crates/mcp/src/core/session.rs
@@ -563,6 +563,8 @@ impl<'a> McpToolSession<'a> {
             | ResponseOutputItem::ComputerCallOutput { .. }
             | ResponseOutputItem::ShellCall { .. }
             | ResponseOutputItem::ShellCallOutput { .. }
+            | ResponseOutputItem::ApplyPatchCall { .. }
+            | ResponseOutputItem::ApplyPatchCallOutput { .. }
             | ResponseOutputItem::Message { .. }
             | ResponseOutputItem::Reasoning { .. }
             | ResponseOutputItem::Compaction { .. } => true,

--- a/crates/protocols/src/responses.rs
+++ b/crates/protocols/src/responses.rs
@@ -428,6 +428,17 @@ pub enum ResponseTool {
     /// `Shell { type: "shell", environment? }`.
     #[serde(rename = "shell")]
     Shell(ShellTool),
+
+    /// Built-in `apply_patch` tool — `{ type: "apply_patch" }`.
+    ///
+    /// Spec (openai-responses-api-spec.md §tools, L478): `ApplyPatch
+    /// { type: "apply_patch" }`. Unit variant with no payload — the model is
+    /// simply told the apply_patch surface is available and subsequently emits
+    /// `apply_patch_call` items carrying file-edit operations (see
+    /// [`ResponseInputOutputItem::ApplyPatchCall`]). Pairs with
+    /// [`ResponsesToolChoice::ApplyPatch`] when callers want to force usage.
+    #[serde(rename = "apply_patch")]
+    ApplyPatch,
 }
 
 /// Payload carried by [`ResponseTool::Namespace`].
@@ -981,6 +992,66 @@ pub struct ShellExit {
     /// Process exit code. Signed to preserve negative error codes on
     /// platforms that report them.
     pub exit_code: i32,
+}
+
+/// File-edit operation payload carried by
+/// [`ResponseInputOutputItem::ApplyPatchCall`] /
+/// [`ResponseOutputItem::ApplyPatchCall`].
+///
+/// Spec (openai-responses-api-spec.md §ApplyPatchCall L240-L246): the
+/// `operation` field is a `type`-tagged union of three shapes —
+/// `CreateFile { diff, path, type: "create_file" }`,
+/// `DeleteFile { path, type: "delete_file" }`, and
+/// `UpdateFile { diff, path, type: "update_file" }`. `DeleteFile` carries no
+/// diff because the whole file is removed; the other two carry a unified
+/// diff payload describing the edit.
+#[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
+#[serde(tag = "type")]
+#[serde(rename_all = "snake_case")]
+// Variant names intentionally mirror the spec's `*_file` tag set; the shared
+// `File` postfix tracks the spec verbatim and keeps the type discriminator
+// symmetric with the JSON wire shape.
+#[expect(
+    clippy::enum_variant_names,
+    reason = "variant names mirror spec `create_file` / `delete_file` / `update_file` tags by design"
+)]
+pub enum ApplyPatchOperation {
+    /// `{ type: "create_file", diff, path }` — create a new file whose
+    /// contents are described by `diff`.
+    CreateFile { diff: String, path: String },
+    /// `{ type: "delete_file", path }` — remove an existing file.
+    DeleteFile { path: String },
+    /// `{ type: "update_file", diff, path }` — apply a unified diff to an
+    /// existing file at `path`.
+    UpdateFile { diff: String, path: String },
+}
+
+/// Status for a [`ResponseInputOutputItem::ApplyPatchCall`] /
+/// [`ResponseOutputItem::ApplyPatchCall`] item.
+///
+/// Spec (openai-responses-api-spec.md §ApplyPatchCall L245):
+/// `status: "in_progress" | "completed"`. Distinct from
+/// [`ApplyPatchCallOutputStatus`] which adds `"failed"` for the output item.
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, schemars::JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ApplyPatchCallStatus {
+    InProgress,
+    Completed,
+}
+
+/// Status for a [`ResponseInputOutputItem::ApplyPatchCallOutput`] /
+/// [`ResponseOutputItem::ApplyPatchCallOutput`] item.
+///
+/// Spec (openai-responses-api-spec.md §ApplyPatchCallOutput L249):
+/// `status: "completed" | "failed"`. The output-side status intentionally
+/// drops `"in_progress"` because the output only materialises once the
+/// apply_patch attempt has terminated — either the edit applied cleanly or
+/// it failed — so an in-progress output would be spec-invalid.
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, schemars::JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ApplyPatchCallOutputStatus {
+    Completed,
+    Failed,
 }
 
 #[serde_with::skip_serializing_none]
@@ -1632,6 +1703,38 @@ pub enum ResponseInputOutputItem {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         created_by: Option<String>,
     },
+    /// `type: "apply_patch_call"` — model-issued file-edit request. Spec
+    /// (openai-responses-api-spec.md §ApplyPatchCall L240-L246):
+    /// `{ call_id, operation, status, type, id }`. `id` is `Option<String>`
+    /// so newly-minted client-side calls can omit it; it is always present on
+    /// items round-tripped from a previous response. The `operation` union is
+    /// `CreateFile | DeleteFile | UpdateFile` per
+    /// [`ApplyPatchOperation`]; the client owns execution (apply the diff on
+    /// disk) and replies with a matching [`Self::ApplyPatchCallOutput`].
+    #[serde(rename = "apply_patch_call")]
+    ApplyPatchCall {
+        call_id: String,
+        operation: ApplyPatchOperation,
+        status: ApplyPatchCallStatus,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        id: Option<String>,
+    },
+    /// `type: "apply_patch_call_output"` — client's response to an
+    /// `apply_patch_call`. Spec (openai-responses-api-spec.md
+    /// §ApplyPatchCallOutput L248-L251): `{ call_id, status, type, id,
+    /// output }` where `output` is optional log text. `id` is
+    /// `Option<String>` for the same reason as `ApplyPatchCall.id` above;
+    /// `output` uses `skip_serializing_if` so a no-log success round-trips
+    /// without emitting an explicit `null`.
+    #[serde(rename = "apply_patch_call_output")]
+    ApplyPatchCallOutput {
+        call_id: String,
+        status: ApplyPatchCallOutputStatus,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        id: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        output: Option<String>,
+    },
     #[serde(untagged)]
     SimpleInputMessage {
         content: StringOrContentParts,
@@ -2031,6 +2134,31 @@ pub enum ResponseOutputItem {
         status: ShellCallStatus,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         created_by: Option<String>,
+    },
+    /// `type: "apply_patch_call"` — server-emitted mirror of the input
+    /// variant. Spec (openai-responses-api-spec.md §ApplyPatchCall L240-L246):
+    /// `{ call_id, operation, status, type, id }`. `id` is required on the
+    /// output wire because the server always assigns one when emitting the
+    /// apply_patch call item.
+    #[serde(rename = "apply_patch_call")]
+    ApplyPatchCall {
+        id: String,
+        call_id: String,
+        operation: ApplyPatchOperation,
+        status: ApplyPatchCallStatus,
+    },
+    /// `type: "apply_patch_call_output"` — server-emitted mirror of the
+    /// input variant. Spec (openai-responses-api-spec.md
+    /// §ApplyPatchCallOutput L248-L251): `{ call_id, status, type, id,
+    /// output }`. `id` is required on the output wire; `output` is optional
+    /// log text surfaced by the upstream apply_patch executor.
+    #[serde(rename = "apply_patch_call_output")]
+    ApplyPatchCallOutput {
+        id: String,
+        call_id: String,
+        status: ApplyPatchCallOutputStatus,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        output: Option<String>,
     },
 }
 
@@ -2709,7 +2837,9 @@ impl GenerationRequest for ResponsesRequest {
                         | ResponseInputOutputItem::CustomToolCallOutput { .. }
                         | ResponseInputOutputItem::ShellCall { .. }
                         | ResponseInputOutputItem::ShellCallOutput { .. }
-                        | ResponseInputOutputItem::ItemReference { .. } => {}
+                        | ResponseInputOutputItem::ItemReference { .. }
+                        | ResponseInputOutputItem::ApplyPatchCall { .. }
+                        | ResponseInputOutputItem::ApplyPatchCallOutput { .. } => {}
                     }
                 }
 
@@ -3019,6 +3149,19 @@ fn validate_input_item(item: &ResponseInputOutputItem) -> Result<(), ValidationE
         // I2: schema-only; backend resolution (history lookup +
         // substitution) is deferred to a future R task.
         ResponseInputOutputItem::ItemReference { .. } => {}
+        // ApplyPatchCall is model-generated and echoed back on multi-turn
+        // replay; matches the FunctionToolCall / CustomToolCall arms with no
+        // diff/path validation — the operation payload is structurally
+        // enforced by the `ApplyPatchOperation` enum, and accepting empty
+        // diffs for `create_file` / `update_file` preserves round-trip
+        // fidelity with items emitted by upstream providers.
+        ResponseInputOutputItem::ApplyPatchCall { .. } => {}
+        // ApplyPatchCallOutput.output is optional log text per spec
+        // (openai-responses-api-spec.md §ApplyPatchCallOutput L251); an
+        // absent or empty log is spec-legal (a clean `completed` with no
+        // output, or a `failed` where the executor had nothing to log) so
+        // no emptiness check applies here.
+        ResponseInputOutputItem::ApplyPatchCallOutput { .. } => {}
     }
     Ok(())
 }

--- a/crates/protocols/src/responses.rs
+++ b/crates/protocols/src/responses.rs
@@ -1005,8 +1005,13 @@ pub struct ShellExit {
 /// `UpdateFile { diff, path, type: "update_file" }`. `DeleteFile` carries no
 /// diff because the whole file is removed; the other two carry a unified
 /// diff payload describing the edit.
+///
+/// `deny_unknown_fields` is applied so variants fail fast on foreign keys —
+/// e.g. `{"type":"delete_file","path":"x","diff":"..."}` is rejected rather
+/// than silently dropping the stray `diff`, matching the P5 fail-fast
+/// contract applied elsewhere on protocol-surface structs.
 #[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
-#[serde(tag = "type")]
+#[serde(tag = "type", deny_unknown_fields)]
 #[serde(rename_all = "snake_case")]
 // Variant names intentionally mirror the spec's `*_file` tag set; the shared
 // `File` postfix tracks the spec verbatim and keeps the type discriminator

--- a/crates/protocols/tests/responses.rs
+++ b/crates/protocols/tests/responses.rs
@@ -2780,6 +2780,77 @@ fn item_reference_input_item_rejects_unknown_type_tag() {
     );
 }
 
+// ============================================================================
+// T7 — apply_patch tool + call/output items
+// ============================================================================
+
+#[test]
+fn test_apply_patch_tool_round_trip() {
+    // Spec (openai-responses-api-spec.md §tools L478):
+    // `ApplyPatch { type: "apply_patch" }`. Unit variant with no payload.
+    let payload = json!({"type": "apply_patch"});
+
+    let tool: ResponseTool =
+        serde_json::from_value(payload.clone()).expect("apply_patch tool should deserialize");
+    assert!(matches!(tool, ResponseTool::ApplyPatch));
+
+    let serialized = serde_json::to_value(&tool).expect("apply_patch tool should serialize");
+    assert_eq!(serialized, payload);
+}
+
+#[test]
+fn test_apply_patch_operation_create_file_round_trip() {
+    // Spec (openai-responses-api-spec.md §ApplyPatchCall L242):
+    // `CreateFile { diff, path, type: "create_file" }`.
+    let payload = json!({
+        "type": "create_file",
+        "diff": "+ hello world\n",
+        "path": "src/greeting.rs",
+    });
+
+    let op: ApplyPatchOperation =
+        serde_json::from_value(payload.clone()).expect("create_file should deserialize");
+    match &op {
+        ApplyPatchOperation::CreateFile { diff, path } => {
+            assert_eq!(diff, "+ hello world\n");
+            assert_eq!(path, "src/greeting.rs");
+        }
+        other => panic!("expected CreateFile, got {other:?}"),
+    }
+
+    let serialized = serde_json::to_value(&op).expect("serialize");
+    assert_eq!(serialized, payload);
+}
+
+#[test]
+fn test_apply_patch_operation_delete_file_round_trip() {
+    // Spec (openai-responses-api-spec.md §ApplyPatchCall L243):
+    // `DeleteFile { path, type: "delete_file" }`. No `diff` — whole file is
+    // removed, so the payload must deserialize cleanly without one and
+    // serialize back without a spurious diff field.
+    let payload = json!({
+        "type": "delete_file",
+        "path": "src/obsolete.rs",
+    });
+
+    let op: ApplyPatchOperation =
+        serde_json::from_value(payload.clone()).expect("delete_file should deserialize");
+    match &op {
+        ApplyPatchOperation::DeleteFile { path } => {
+            assert_eq!(path, "src/obsolete.rs");
+        }
+        other => panic!("expected DeleteFile, got {other:?}"),
+    }
+
+    let serialized = serde_json::to_value(&op).expect("serialize");
+    assert_eq!(serialized, payload);
+    // Ensure no stray `diff` key is emitted for delete_file operations.
+    assert!(
+        serialized.get("diff").is_none(),
+        "delete_file must not emit a diff field"
+    );
+}
+
 #[test]
 fn simple_input_message_with_id_does_not_match_item_reference() {
     // Regression: `ItemReference` is declared after `SimpleInputMessage` in
@@ -2802,4 +2873,265 @@ fn simple_input_message_with_id_does_not_match_item_reference() {
         }
         other => panic!("expected SimpleInputMessage, got {other:?}"),
     }
+}
+
+#[test]
+fn test_apply_patch_operation_update_file_round_trip() {
+    // Spec (openai-responses-api-spec.md §ApplyPatchCall L244):
+    // `UpdateFile { diff, path, type: "update_file" }`.
+    let payload = json!({
+        "type": "update_file",
+        "diff": "@@ -1,1 +1,1 @@\n-old\n+new\n",
+        "path": "src/main.rs",
+    });
+
+    let op: ApplyPatchOperation =
+        serde_json::from_value(payload.clone()).expect("update_file should deserialize");
+    match &op {
+        ApplyPatchOperation::UpdateFile { diff, path } => {
+            assert_eq!(diff, "@@ -1,1 +1,1 @@\n-old\n+new\n");
+            assert_eq!(path, "src/main.rs");
+        }
+        other => panic!("expected UpdateFile, got {other:?}"),
+    }
+
+    let serialized = serde_json::to_value(&op).expect("serialize");
+    assert_eq!(serialized, payload);
+}
+
+#[test]
+fn test_apply_patch_call_input_item_round_trip() {
+    // Spec (openai-responses-api-spec.md §ApplyPatchCall L240-L246):
+    // `{ call_id, operation, status, type, id }` with
+    // `status: "in_progress" | "completed"` and `type: "apply_patch_call"`.
+    let payload = json!({
+        "type": "apply_patch_call",
+        "call_id": "call_patch_001",
+        "operation": {
+            "type": "update_file",
+            "diff": "@@ -1 +1 @@\n-a\n+b\n",
+            "path": "src/lib.rs",
+        },
+        "status": "completed",
+        "id": "apc_01",
+    });
+
+    let item: ResponseInputOutputItem =
+        serde_json::from_value(payload.clone()).expect("apply_patch_call should deserialize");
+    match &item {
+        ResponseInputOutputItem::ApplyPatchCall {
+            call_id,
+            operation,
+            status,
+            id,
+        } => {
+            assert_eq!(call_id, "call_patch_001");
+            assert_eq!(*status, ApplyPatchCallStatus::Completed);
+            assert_eq!(id.as_deref(), Some("apc_01"));
+            match operation {
+                ApplyPatchOperation::UpdateFile { diff, path } => {
+                    assert_eq!(diff, "@@ -1 +1 @@\n-a\n+b\n");
+                    assert_eq!(path, "src/lib.rs");
+                }
+                other => panic!("expected UpdateFile operation, got {other:?}"),
+            }
+        }
+        other => panic!("expected ApplyPatchCall, got {other:?}"),
+    }
+
+    let serialized = serde_json::to_value(&item).expect("serialize");
+    assert_eq!(serialized, payload);
+}
+
+#[test]
+fn test_apply_patch_call_input_item_in_progress_status_and_omitted_id() {
+    // Spec (L245): status `"in_progress"` is also legal. `id` is
+    // `Option<String>` on the input side, so a newly-minted client-side call
+    // may omit it; `skip_serializing_if` keeps it off the wire.
+    let payload = json!({
+        "type": "apply_patch_call",
+        "call_id": "call_patch_002",
+        "operation": {"type": "delete_file", "path": "old.rs"},
+        "status": "in_progress",
+    });
+
+    let item: ResponseInputOutputItem =
+        serde_json::from_value(payload.clone()).expect("apply_patch_call should deserialize");
+    match &item {
+        ResponseInputOutputItem::ApplyPatchCall {
+            call_id,
+            operation,
+            status,
+            id,
+        } => {
+            assert_eq!(call_id, "call_patch_002");
+            assert_eq!(*status, ApplyPatchCallStatus::InProgress);
+            assert!(id.is_none(), "id should be absent when omitted on the wire");
+            assert!(matches!(operation, ApplyPatchOperation::DeleteFile { .. }));
+        }
+        other => panic!("expected ApplyPatchCall, got {other:?}"),
+    }
+
+    let serialized = serde_json::to_value(&item).expect("serialize");
+    assert_eq!(serialized, payload);
+    assert!(
+        serialized.get("id").is_none(),
+        "omitted id must not be serialized back as null",
+    );
+}
+
+#[test]
+fn test_apply_patch_call_output_input_item_completed_round_trip() {
+    // Spec (openai-responses-api-spec.md §ApplyPatchCallOutput L248-L251):
+    // `{ call_id, status, type, id, output }` with
+    // `status: "completed" | "failed"` and `output: optional string`.
+    let payload = json!({
+        "type": "apply_patch_call_output",
+        "call_id": "call_patch_001",
+        "status": "completed",
+        "id": "apco_01",
+        "output": "1 file updated",
+    });
+
+    let item: ResponseInputOutputItem = serde_json::from_value(payload.clone())
+        .expect("apply_patch_call_output should deserialize");
+    match &item {
+        ResponseInputOutputItem::ApplyPatchCallOutput {
+            call_id,
+            status,
+            id,
+            output,
+        } => {
+            assert_eq!(call_id, "call_patch_001");
+            assert_eq!(*status, ApplyPatchCallOutputStatus::Completed);
+            assert_eq!(id.as_deref(), Some("apco_01"));
+            assert_eq!(output.as_deref(), Some("1 file updated"));
+        }
+        other => panic!("expected ApplyPatchCallOutput, got {other:?}"),
+    }
+
+    let serialized = serde_json::to_value(&item).expect("serialize");
+    assert_eq!(serialized, payload);
+}
+
+#[test]
+fn test_apply_patch_call_output_input_item_failed_without_output() {
+    // Spec (L251): `output` is optional — a `failed` output with no log text
+    // must round-trip without emitting an explicit `null`.
+    let payload = json!({
+        "type": "apply_patch_call_output",
+        "call_id": "call_patch_003",
+        "status": "failed",
+    });
+
+    let item: ResponseInputOutputItem = serde_json::from_value(payload.clone())
+        .expect("apply_patch_call_output without output should deserialize");
+    match &item {
+        ResponseInputOutputItem::ApplyPatchCallOutput {
+            call_id,
+            status,
+            id,
+            output,
+        } => {
+            assert_eq!(call_id, "call_patch_003");
+            assert_eq!(*status, ApplyPatchCallOutputStatus::Failed);
+            assert!(id.is_none());
+            assert!(output.is_none());
+        }
+        other => panic!("expected ApplyPatchCallOutput, got {other:?}"),
+    }
+
+    let serialized = serde_json::to_value(&item).expect("serialize");
+    assert_eq!(serialized, payload);
+    assert!(serialized.get("id").is_none());
+    assert!(serialized.get("output").is_none());
+}
+
+#[test]
+fn test_apply_patch_call_output_item_round_trip() {
+    // Spec: output-side mirror of the input variant. `id` is always populated
+    // by the server on emit, so it appears unconditionally on the wire.
+    let payload = json!({
+        "type": "apply_patch_call",
+        "id": "apc_out_01",
+        "call_id": "call_patch_004",
+        "operation": {
+            "type": "create_file",
+            "diff": "+new line\n",
+            "path": "src/new.rs",
+        },
+        "status": "completed",
+    });
+
+    let item: ResponseOutputItem = serde_json::from_value(payload.clone())
+        .expect("apply_patch_call output item should deserialize");
+    match &item {
+        ResponseOutputItem::ApplyPatchCall {
+            id,
+            call_id,
+            operation,
+            status,
+        } => {
+            assert_eq!(id, "apc_out_01");
+            assert_eq!(call_id, "call_patch_004");
+            assert_eq!(*status, ApplyPatchCallStatus::Completed);
+            assert!(matches!(operation, ApplyPatchOperation::CreateFile { .. }));
+        }
+        other => panic!("expected ResponseOutputItem::ApplyPatchCall, got {other:?}"),
+    }
+
+    let serialized = serde_json::to_value(&item).expect("serialize");
+    assert_eq!(serialized, payload);
+}
+
+#[test]
+fn test_apply_patch_call_output_response_item_round_trip() {
+    // Spec: output-side mirror of `ApplyPatchCallOutput`. `id` is required on
+    // the output wire.
+    let payload = json!({
+        "type": "apply_patch_call_output",
+        "id": "apco_out_01",
+        "call_id": "call_patch_005",
+        "status": "failed",
+        "output": "merge conflict at src/lib.rs:42",
+    });
+
+    let item: ResponseOutputItem = serde_json::from_value(payload.clone())
+        .expect("apply_patch_call_output output item should deserialize");
+    match &item {
+        ResponseOutputItem::ApplyPatchCallOutput {
+            id,
+            call_id,
+            status,
+            output,
+        } => {
+            assert_eq!(id, "apco_out_01");
+            assert_eq!(call_id, "call_patch_005");
+            assert_eq!(*status, ApplyPatchCallOutputStatus::Failed);
+            assert_eq!(output.as_deref(), Some("merge conflict at src/lib.rs:42"));
+        }
+        other => panic!("expected ResponseOutputItem::ApplyPatchCallOutput, got {other:?}"),
+    }
+
+    let serialized = serde_json::to_value(&item).expect("serialize");
+    assert_eq!(serialized, payload);
+}
+
+#[test]
+fn test_apply_patch_tool_choice_round_trip() {
+    // Spec (openai-responses-api-spec.md §tool_choice L424):
+    // `ToolChoiceApplyPatch { type: "apply_patch" }`. Pairs with the
+    // `ResponseTool::ApplyPatch` declaration so callers can force usage.
+    let payload = json!({"type": "apply_patch"});
+    let choice: ResponsesToolChoice = serde_json::from_value(payload.clone())
+        .expect("apply_patch tool_choice should deserialize");
+    match &choice {
+        ResponsesToolChoice::ApplyPatch { tool_type } => {
+            assert_eq!(*tool_type, ApplyPatchToolChoiceTag::ApplyPatch);
+        }
+        other => panic!("expected ResponsesToolChoice::ApplyPatch, got {other:?}"),
+    }
+
+    let serialized = serde_json::to_value(&choice).expect("serialize");
+    assert_eq!(serialized, payload);
 }

--- a/crates/protocols/tests/responses.rs
+++ b/crates/protocols/tests/responses.rs
@@ -3118,6 +3118,65 @@ fn test_apply_patch_call_output_response_item_round_trip() {
 }
 
 #[test]
+fn test_apply_patch_operation_rejects_unknown_fields() {
+    // P5 fail-fast contract: extra fields on an operation variant must be
+    // rejected rather than silently dropped. `deny_unknown_fields` on the
+    // `ApplyPatchOperation` enum enforces this per-variant.
+    //
+    // Regression for CodeRabbit feedback on PR #1339: a `delete_file`
+    // operation carrying a stray `diff` key would otherwise deserialize
+    // successfully and lose the foreign field, masking client bugs that
+    // send the wrong operation shape.
+    let stray_diff_on_delete = json!({
+        "type": "delete_file",
+        "path": "src/obsolete.rs",
+        "diff": "should not be accepted",
+    });
+    assert!(
+        serde_json::from_value::<ApplyPatchOperation>(stray_diff_on_delete).is_err(),
+        "delete_file must reject a stray `diff` field per deny_unknown_fields"
+    );
+
+    // A stray foreign key on a variant that does carry `diff` / `path` must
+    // also be rejected — deny_unknown_fields is not relaxed for the
+    // create_file / update_file shapes.
+    let foreign_key_on_create = json!({
+        "type": "create_file",
+        "diff": "+ hi\n",
+        "path": "src/new.rs",
+        "not_a_field": "nope",
+    });
+    assert!(
+        serde_json::from_value::<ApplyPatchOperation>(foreign_key_on_create).is_err(),
+        "create_file must reject foreign keys per deny_unknown_fields"
+    );
+
+    let foreign_key_on_update = json!({
+        "type": "update_file",
+        "diff": "@@ -1 +1 @@\n-a\n+b\n",
+        "path": "src/main.rs",
+        "mode": "force",
+    });
+    assert!(
+        serde_json::from_value::<ApplyPatchOperation>(foreign_key_on_update).is_err(),
+        "update_file must reject foreign keys per deny_unknown_fields"
+    );
+
+    // Sanity: the spec-canonical shapes still deserialize cleanly after
+    // the tightening.
+    for payload in [
+        json!({"type": "create_file", "diff": "+ hi\n", "path": "src/new.rs"}),
+        json!({"type": "delete_file", "path": "src/old.rs"}),
+        json!({"type": "update_file", "diff": "@@ -1 +1 @@\n-a\n+b\n", "path": "src/main.rs"}),
+    ] {
+        assert!(
+            serde_json::from_value::<ApplyPatchOperation>(payload.clone()).is_ok(),
+            "spec-canonical shape must still deserialize: {payload}"
+        );
+    }
+}
+
+#[test]
 fn test_apply_patch_tool_choice_round_trip() {
     // Spec (openai-responses-api-spec.md §tool_choice L424):
     // `ToolChoiceApplyPatch { type: "apply_patch" }`. Pairs with the

--- a/crates/protocols/tests/responses.rs
+++ b/crates/protocols/tests/responses.rs
@@ -3194,3 +3194,91 @@ fn test_apply_patch_tool_choice_round_trip() {
     let serialized = serde_json::to_value(&choice).expect("serialize");
     assert_eq!(serialized, payload);
 }
+
+#[test]
+fn test_apply_patch_request_validate_accepts_relaxed_shapes() {
+    // Regression for CodeRabbit feedback on PR #1339: the `validate_input_item`
+    // arms for `ApplyPatchCall` and `ApplyPatchCallOutput` intentionally do
+    // no content checking — the spec permits empty/absent `output` on the
+    // call-output side (L251), and the `ApplyPatchOperation` enum
+    // structurally enforces the `diff` / `path` shape so an empty `diff`
+    // string on `create_file` / `update_file` is spec-legal. This test
+    // locks those relaxed branches in so they cannot regress back to a
+    // stricter non-empty check.
+    //
+    // The cross-parameter validator (see `validate_response_request`)
+    // requires at least one Message/SimpleInputMessage alongside any tool
+    // item, so every fixture below pairs the apply_patch item with a plain
+    // user message to isolate the apply_patch branch under test.
+    use validator::Validate;
+
+    let user_msg = json!({"role": "user", "content": "hi"});
+
+    // (a) apply_patch_call_output with `output: ""` — empty-string log
+    // must validate cleanly because the output-empty path was intentionally
+    // omitted (cf. the `custom_tool_call_output_empty` check we did NOT
+    // mirror here).
+    let empty_output: ResponsesRequest = serde_json::from_value(json!({
+        "model": "gpt-5.4",
+        "input": [
+            user_msg.clone(),
+            {
+                "type": "apply_patch_call_output",
+                "call_id": "call_patch_1",
+                "status": "completed",
+                "output": "",
+            }
+        ]
+    }))
+    .expect("request should deserialize");
+    assert!(
+        empty_output.validate().is_ok(),
+        "empty ApplyPatchCallOutput.output string must pass validation"
+    );
+
+    // (b) apply_patch_call_output with `output` omitted entirely — spec
+    // L251 marks `output` as optional, so a no-log `failed` output must
+    // validate without raising.
+    let omitted_output: ResponsesRequest = serde_json::from_value(json!({
+        "model": "gpt-5.4",
+        "input": [
+            user_msg.clone(),
+            {
+                "type": "apply_patch_call_output",
+                "call_id": "call_patch_2",
+                "status": "failed",
+            }
+        ]
+    }))
+    .expect("request should deserialize");
+    assert!(
+        omitted_output.validate().is_ok(),
+        "omitted ApplyPatchCallOutput.output must pass validation"
+    );
+
+    // (c) apply_patch_call UpdateFile with `diff: ""` — an empty-diff
+    // update is structurally legal (the `ApplyPatchOperation` enum only
+    // enforces presence of the fields, not their contents) and the
+    // validator intentionally does not content-check the operation.
+    let empty_update_diff: ResponsesRequest = serde_json::from_value(json!({
+        "model": "gpt-5.4",
+        "input": [
+            user_msg,
+            {
+                "type": "apply_patch_call",
+                "call_id": "call_patch_3",
+                "operation": {
+                    "type": "update_file",
+                    "diff": "",
+                    "path": "src/main.rs"
+                },
+                "status": "completed"
+            }
+        ]
+    }))
+    .expect("request should deserialize");
+    assert!(
+        empty_update_diff.validate().is_ok(),
+        "empty ApplyPatchCall.operation.diff on update_file must pass validation"
+    );
+}

--- a/model_gateway/benches/routing_allocation_bench.rs
+++ b/model_gateway/benches/routing_allocation_bench.rs
@@ -77,6 +77,8 @@ fn extract_text_for_routing_old(req: &ResponsesRequest) -> String {
                 ResponseInputOutputItem::ShellCall { .. }
                 | ResponseInputOutputItem::ShellCallOutput { .. } => None,
                 ResponseInputOutputItem::ItemReference { .. } => None,
+                ResponseInputOutputItem::ApplyPatchCall { .. }
+                | ResponseInputOutputItem::ApplyPatchCallOutput { .. } => None,
             })
             .collect::<Vec<String>>()
             .join(" "),

--- a/model_gateway/src/routers/grpc/harmony/builder.rs
+++ b/model_gateway/src/routers/grpc/harmony/builder.rs
@@ -444,6 +444,7 @@ impl HarmonyBuilder {
                             ResponseTool::Custom(_) => "custom",
                             ResponseTool::Namespace(_) => "namespace",
                             ResponseTool::Shell(_) => "shell",
+                            ResponseTool::ApplyPatch => "apply_patch",
                         })
                         .collect()
                 })
@@ -764,6 +765,15 @@ impl HarmonyBuilder {
                 warn!(
                     function = "parse_response_item_to_harmony_message",
                     "Shell tool item reached Harmony conversion"
+                );
+                Err("Unsupported input item type".to_string())
+            }
+
+            ResponseInputOutputItem::ApplyPatchCall { .. }
+            | ResponseInputOutputItem::ApplyPatchCallOutput { .. } => {
+                warn!(
+                    function = "parse_response_item_to_harmony_message",
+                    "apply_patch item reached Harmony conversion"
                 );
                 Err("Unsupported input item type".to_string())
             }

--- a/model_gateway/src/routers/grpc/regular/responses/conversions.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/conversions.rs
@@ -179,6 +179,14 @@ pub(crate) fn responses_to_chat(req: &ResponsesRequest) -> Result<ChatCompletion
                         );
                         return Err("Unsupported input item type".to_string());
                     }
+                    ResponseInputOutputItem::ApplyPatchCall { .. }
+                    | ResponseInputOutputItem::ApplyPatchCallOutput { .. } => {
+                        warn!(
+                            function = "responses_to_chat",
+                            "apply_patch item reached chat conversion"
+                        );
+                        return Err("Unsupported input item type".to_string());
+                    }
                 }
             }
         }

--- a/model_gateway/src/routers/openai/responses/utils.rs
+++ b/model_gateway/src/routers/openai/responses/utils.rs
@@ -257,6 +257,7 @@ pub(super) fn response_tool_to_value(tool: &ResponseTool) -> Option<Value> {
         // to the client unchanged (T9).
         ResponseTool::Namespace(_) => serde_json::to_value(tool).ok(),
         ResponseTool::Shell(_) => serde_json::to_value(tool).ok(),
+        ResponseTool::ApplyPatch => serde_json::to_value(tool).ok(),
         ResponseTool::Function(_) => None,
     }
 }


### PR DESCRIPTION
## Description

### Problem

The Responses API protocol in `crates/protocols/src/responses.rs` had no typed support for the `apply_patch` surface documented in `.claude/_audit/openai-responses-api-spec.md` §tools L478, §ApplyPatchCall L240-L246, §ApplyPatchCallOutput L248-L251:

- `type: "apply_patch"` tools on `ResponseTool` had no variant, so payloads failed `#[serde(tag = "type")]` deserialization outright.
- `apply_patch_call` / `apply_patch_call_output` input+output items had no corresponding `ResponseInputOutputItem` / `ResponseOutputItem` variants, so routers could not inspect the `operation` union (`create_file` / `delete_file` / `update_file`) or the `status` field on either call or output items.
- Without typed variants, the `ResponsesToolChoice::ApplyPatch` variant landed by P7 (#1276) had no tool declaration to force.

This block T7 and gates E3 (per-tool coverage tests) in the audit plan.

### Solution

Add the apply_patch surface as a protocol-only change, spec-sourced from the frozen snapshot at `.claude/_audit/openai-responses-api-spec.md`. No execution backend is wired — forced-cascade match arms in routers only, mirroring the T2 / T4 / T8 precedents (Computer, ImageGeneration, Custom). Reviewed by a tech-lead pass before commit.

## Changes

`crates/protocols/src/responses.rs`:

- `ResponseTool::ApplyPatch` unit variant (`{ type: "apply_patch" }`) on the `#[serde(tag = "type")]` tool enum.
- `ApplyPatchOperation` enum (tagged by `type`): `CreateFile { diff, path }`, `DeleteFile { path }`, `UpdateFile { diff, path }`. `DeleteFile` intentionally carries no diff since the whole file is removed. `#[expect(clippy::enum_variant_names)]` with a `reason` annotation matches the T8 precedent for spec-verbatim tag sets.
- `ApplyPatchCallStatus` (`InProgress | Completed`) and `ApplyPatchCallOutputStatus` (`Completed | Failed`) enums. Output-side status drops `in_progress` because the output only materialises once the apply_patch attempt has terminated, per spec L249.
- `ResponseInputOutputItem::ApplyPatchCall { call_id, operation, status, id? }` and `::ApplyPatchCallOutput { call_id, status, id?, output? }` variants. `id` is `Option<String>` on the input side (clients may omit on new calls; populated on round-tripped items) and required on the output side (server always populates). `output` is optional log text with `skip_serializing_if` for clean round-trips.
- `ResponseOutputItem::ApplyPatchCall { id, call_id, operation, status }` and `::ApplyPatchCallOutput { id, call_id, status, output? }` — server-emitted mirrors with required `id`.
- Match arms added to `GenerationRequest::prompt_text` and `validate_input_item`. Validation accepts empty `output` (spec allows a no-log `completed` / `failed`) and does not content-check the diff — structural enforcement comes from the `ApplyPatchOperation` enum.

`crates/protocols/tests/responses.rs` (11 new integration tests):

- `test_apply_patch_tool_round_trip` — unit-variant tool declaration.
- `test_apply_patch_operation_create_file_round_trip` / `_delete_file_` / `_update_file_` — each operation variant, with an explicit assertion that `delete_file` emits no stray `diff` field.
- `test_apply_patch_call_input_item_round_trip` — full-populated input item with `completed` + `id`.
- `test_apply_patch_call_input_item_in_progress_status_and_omitted_id` — exercises the `Option<String>` id path and the `in_progress` status, asserting `skip_serializing_if` keeps the omitted id off the wire.
- `test_apply_patch_call_output_input_item_completed_round_trip` — input-side output item with log text.
- `test_apply_patch_call_output_input_item_failed_without_output` — input-side output item with `failed` status, no log, asserting both `id` and `output` stay off the wire when absent.
- `test_apply_patch_call_output_item_round_trip` — output-item side of `ApplyPatchCall` with required `id`.
- `test_apply_patch_call_output_response_item_round_trip` — output-item side of `ApplyPatchCallOutput`.
- `test_apply_patch_tool_choice_round_trip` — spec-fixture round-trip for the pre-existing `ResponsesToolChoice::ApplyPatch` variant (from P7) to assert the tool-choice surface stays paired with this task's tool declaration.

Router forced-cascade arms (schema-only, no execution wiring):

- `model_gateway/src/routers/grpc/harmony/builder.rs`: `"apply_patch"` tool_type mapping + unsupported-input arm for `ApplyPatchCall` / `ApplyPatchCallOutput`, matching the `CustomToolCall` arm pattern from T8.
- `model_gateway/src/routers/grpc/regular/responses/conversions.rs`: unsupported-input arm for both variants.
- `model_gateway/src/routers/openai/responses/utils.rs`: `ResponseTool::ApplyPatch` passthrough in `response_tool_to_value` so the tool survives the MCP restore pipeline.
- `model_gateway/benches/routing_allocation_bench.rs`: `None` arm keeping the allocation bench exhaustive match in sync.
- `crates/mcp/src/core/session.rs`: `ResponseOutputItem` arm so apply_patch output items stay visible to clients alongside the other built-in tool call types.

## Test Plan

- `cargo check --workspace --all-targets` — clean.
- `cargo test -p openai-protocol` — 70 tests pass (was 59 + 11 new).
- `cargo test --workspace` — 92 test-binary reports, 0 failures, 0 errors.
- `cargo fmt --check` — clean.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- Each new test cites a spec line-range from `.claude/_audit/openai-responses-api-spec.md`.

Refs: T7 in `.claude/_audit/responses-api-gap-audit.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * First-class support for an apply_patch tool in responses; create/update/delete operations and apply_patch call/output items are preserved and treated as visible in outputs.

* **Behavior Changes**
  * apply_patch items are excluded from routing/prompt text and retain optional output/log fields for faithful round-trips.
  * Conversions now log a warning and consistently surface unsupported apply_patch input items.

* **Tests**
  * Comprehensive serialization and validation tests added for apply_patch wire shape and decoding rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->