### PR TITLE
feat(background): BGM-PR-03 config + AppContext + memory repository

### DIFF
--- a/crates/data_connector/src/background.rs
+++ b/crates/data_connector/src/background.rs
@@ -419,10 +419,17 @@ pub trait BackgroundResponseRepository: Send + Sync {
         starting_after: Option<i64>,
     ) -> BackgroundRepositoryResult<ResumeEventBatch>;
 
-    /// Terminalize a leased job. The repository internally resolves the
-    /// cancel/complete race; see [`FinalizeResult::cancel_won`].
-    async fn finalize(&self, update: FinalizeRequest)
-        -> BackgroundRepositoryResult<FinalizeResult>;
+    /// Terminalize a leased job. Fails with
+    /// [`BackgroundRepositoryError::LeaseNotHeld`] if the caller's lease has
+    /// expired at `now`, even if no sweeper has requeued the row yet — this
+    /// prevents a stale worker from committing terminal state after its lease
+    /// window. The repository internally resolves the cancel/complete race;
+    /// see [`FinalizeResult::cancel_won`].
+    async fn finalize(
+        &self,
+        update: FinalizeRequest,
+        now: DateTime<Utc>,
+    ) -> BackgroundRepositoryResult<FinalizeResult>;
 
     /// Re-queue rows whose lease has expired. Idempotent; safe to call from
     /// any replica. Returns the number of rows requeued.

--- a/crates/data_connector/src/factory.rs
+++ b/crates/data_connector/src/factory.rs
@@ -6,6 +6,7 @@ use tracing::info;
 use url::Url;
 
 use crate::{
+    background::BackgroundResponseRepository,
     config::{HistoryBackend, OracleConfig, PostgresConfig, RedisConfig},
     core::{
         ConversationItemStorage, ConversationMemoryWriter, ConversationStorage, ResponseStorage,
@@ -16,6 +17,7 @@ use crate::{
         MemoryConversationItemStorage, MemoryConversationMemoryWriter, MemoryConversationStorage,
         MemoryResponseStorage,
     },
+    memory_background::MemoryBackgroundRepository,
     noop::{
         NoOpConversationItemStorage, NoOpConversationMemoryWriter, NoOpConversationStorage,
         NoOpResponseStorage,
@@ -36,6 +38,7 @@ pub struct StorageBundle {
     pub conversation_storage: Arc<dyn ConversationStorage>,
     pub conversation_item_storage: Arc<dyn ConversationItemStorage>,
     pub conversation_memory_writer: Arc<dyn ConversationMemoryWriter>,
+    pub background_repository: Option<Arc<dyn BackgroundResponseRepository>>,
 }
 
 /// Configuration for creating storage backends
@@ -68,6 +71,7 @@ pub async fn create_storage(config: StorageFactoryConfig<'_>) -> Result<StorageB
                 conversation_storage: Arc::new(MemoryConversationStorage::new()),
                 conversation_item_storage: Arc::new(MemoryConversationItemStorage::new()),
                 conversation_memory_writer: Arc::new(MemoryConversationMemoryWriter::new()),
+                background_repository: Some(Arc::new(MemoryBackgroundRepository::new())),
             }
         }
         HistoryBackend::None => {
@@ -77,6 +81,7 @@ pub async fn create_storage(config: StorageFactoryConfig<'_>) -> Result<StorageB
                 conversation_storage: Arc::new(NoOpConversationStorage::new()),
                 conversation_item_storage: Arc::new(NoOpConversationItemStorage::new()),
                 conversation_memory_writer: Arc::new(NoOpConversationMemoryWriter::new()),
+                background_repository: None,
             }
         }
         HistoryBackend::Oracle => {
@@ -146,7 +151,7 @@ pub async fn create_storage(config: StorageFactoryConfig<'_>) -> Result<StorageB
         }
     };
 
-    // Wrap backends in hooked storage when a hook is provided
+    // Wrap backends in hooked storage when a hook is provided.
     if let Some(hook) = config.hook {
         info!("Wrapping storage backends with hook");
         Ok(StorageBundle {
@@ -163,6 +168,7 @@ pub async fn create_storage(config: StorageFactoryConfig<'_>) -> Result<StorageB
                 hook,
             )),
             conversation_memory_writer: bundle.conversation_memory_writer,
+            background_repository: bundle.background_repository,
         })
     } else {
         Ok(bundle)
@@ -187,6 +193,7 @@ fn create_oracle_storage(oracle_cfg: &OracleConfig) -> Result<StorageBundle, Str
         conversation_storage: Arc::new(OracleConversationStorage::new(store.clone())),
         conversation_item_storage: Arc::new(OracleConversationItemStorage::new(store)),
         conversation_memory_writer: Arc::new(NoOpConversationMemoryWriter::new()),
+        background_repository: None,
     })
 }
 
@@ -216,6 +223,7 @@ async fn create_postgres_storage(postgres_cfg: &PostgresConfig) -> Result<Storag
         conversation_storage: Arc::new(postgres_conv),
         conversation_item_storage: Arc::new(postgres_item),
         conversation_memory_writer: Arc::new(NoOpConversationMemoryWriter::new()),
+        background_repository: None,
     })
 }
 
@@ -230,6 +238,7 @@ fn create_redis_storage(redis_cfg: &RedisConfig) -> Result<StorageBundle, String
         conversation_storage: Arc::new(redis_conv),
         conversation_item_storage: Arc::new(redis_item),
         conversation_memory_writer: Arc::new(NoOpConversationMemoryWriter::new()),
+        background_repository: None,
     })
 }
 

--- a/crates/data_connector/src/lib.rs
+++ b/crates/data_connector/src/lib.rs
@@ -21,6 +21,7 @@ mod factory;
 mod hooked;
 pub mod hooks;
 mod memory;
+mod memory_background;
 mod noop;
 mod oracle;
 mod oracle_migrations;
@@ -58,6 +59,7 @@ pub use factory::{
 pub use hooks::{BeforeHookResult, ExtraColumns, HookError, StorageHook, StorageOperation};
 // Re-export memory implementations for testing
 pub use memory::{MemoryConversationItemStorage, MemoryConversationStorage, MemoryResponseStorage};
+pub use memory_background::MemoryBackgroundRepository;
 pub use noop::NoOpConversationMemoryWriter;
 // Re-export schema config types
 pub use schema::{ColumnDef, SchemaConfig, TableConfig};

--- a/crates/data_connector/src/memory_background.rs
+++ b/crates/data_connector/src/memory_background.rs
@@ -25,6 +25,15 @@ use crate::{
     core::ResponseId,
 };
 
+/// Convert `std::time::Duration` → `chrono::Duration` for lease arithmetic.
+/// Fails only for durations exceeding ~292 billion years, which would indicate
+/// a misconfigured `BackgroundConfig::lease_duration_secs`.
+fn to_chrono(d: Duration) -> BackgroundRepositoryResult<chrono::Duration> {
+    chrono::Duration::from_std(d).map_err(|e| {
+        BackgroundRepositoryError::Backend(format!("lease duration out of range for chrono: {e}"))
+    })
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum InternalStatus {
     Queued,
@@ -170,59 +179,62 @@ impl BackgroundResponseRepository for MemoryBackgroundRepository {
         lease: Duration,
     ) -> BackgroundRepositoryResult<Option<LeasedJob>> {
         let mut state = self.state.write();
+        let lease_chrono = to_chrono(lease)?;
 
-        let pick = state
-            .entries
-            .iter()
-            .filter(|(_, e)| e.status == InternalStatus::Queued && e.next_attempt_at <= now)
-            .min_by(|(_, a), (_, b)| {
-                a.priority
-                    .cmp(&b.priority)
-                    .then(a.next_attempt_at.cmp(&b.next_attempt_at))
-                    .then(a.created_at.cmp(&b.created_at))
-            })
-            .map(|(id, _)| id.clone());
+        loop {
+            let pick = state
+                .entries
+                .iter()
+                .filter(|(_, e)| e.status == InternalStatus::Queued && e.next_attempt_at <= now)
+                .min_by(|(_, a), (_, b)| {
+                    a.priority
+                        .cmp(&b.priority)
+                        .then(a.next_attempt_at.cmp(&b.next_attempt_at))
+                        .then(a.created_at.cmp(&b.created_at))
+                })
+                .map(|(id, _)| id.clone());
 
-        let Some(id) = pick else {
-            return Ok(None);
-        };
+            let Some(id) = pick else {
+                return Ok(None);
+            };
 
-        let entry = state.entries.get_mut(&id).ok_or_else(|| {
-            BackgroundRepositoryError::Backend(
-                "claim_next invariant: picked entry missing under write lock".to_string(),
-            )
-        })?;
+            let entry = state.entries.get_mut(&id).ok_or_else(|| {
+                BackgroundRepositoryError::Backend(
+                    "claim_next invariant: picked entry missing under write lock".to_string(),
+                )
+            })?;
 
-        // Cancel-before-claim: flip straight to Cancelled rather than hand
-        // a worker a job it must not execute. The worker sees `None`.
-        if entry.cancel_requested {
-            entry.status = InternalStatus::Cancelled;
-            entry.completed_at = Some(now);
-            return Ok(None);
+            // Cancel-before-claim: flip straight to Cancelled and keep
+            // scanning rather than hand a worker a job it must not execute
+            // or let the worker loop sleep while other runnable rows exist.
+            if entry.cancel_requested {
+                entry.status = InternalStatus::Cancelled;
+                entry.completed_at = Some(now);
+                continue;
+            }
+
+            let expires_at = now + lease_chrono;
+            entry.status = InternalStatus::InProgress;
+            entry.worker_id = Some(worker_id.to_string());
+            entry.lease_expires_at = Some(expires_at);
+            if entry.started_at.is_none() {
+                entry.started_at = Some(now);
+            }
+
+            return Ok(Some(LeasedJob {
+                response_id: id,
+                retry_attempt: entry.retry_attempt,
+                priority: entry.priority,
+                worker_id: worker_id.to_string(),
+                lease_expires_at: expires_at,
+                input: entry.input.clone(),
+                request_json: entry.request_json.clone(),
+                model: entry.model.clone(),
+                conversation_id: entry.conversation_id.clone(),
+                previous_response_id: entry.previous_response_id.clone(),
+                stream_enabled: entry.stream_enabled,
+            }));
         }
-
-        let expires_at =
-            now + chrono::Duration::from_std(lease).unwrap_or(chrono::Duration::zero());
-        entry.status = InternalStatus::InProgress;
-        entry.worker_id = Some(worker_id.to_string());
-        entry.lease_expires_at = Some(expires_at);
-        if entry.started_at.is_none() {
-            entry.started_at = Some(now);
-        }
-
-        Ok(Some(LeasedJob {
-            response_id: id,
-            retry_attempt: entry.retry_attempt,
-            priority: entry.priority,
-            worker_id: worker_id.to_string(),
-            lease_expires_at: expires_at,
-            input: entry.input.clone(),
-            request_json: entry.request_json.clone(),
-            model: entry.model.clone(),
-            conversation_id: entry.conversation_id.clone(),
-            previous_response_id: entry.previous_response_id.clone(),
-            stream_enabled: entry.stream_enabled,
-        }))
     }
 
     async fn heartbeat(
@@ -248,8 +260,7 @@ impl BackgroundResponseRepository for MemoryBackgroundRepository {
             });
         }
 
-        entry.lease_expires_at =
-            Some(now + chrono::Duration::from_std(lease).unwrap_or(chrono::Duration::zero()));
+        entry.lease_expires_at = Some(now + to_chrono(lease)?);
         Ok(())
     }
 
@@ -342,6 +353,7 @@ impl BackgroundResponseRepository for MemoryBackgroundRepository {
     async fn finalize(
         &self,
         update: FinalizeRequest,
+        now: DateTime<Utc>,
     ) -> BackgroundRepositoryResult<FinalizeResult> {
         let mut state = self.state.write();
         let entry = state
@@ -357,7 +369,12 @@ impl BackgroundResponseRepository for MemoryBackgroundRepository {
             });
         }
 
-        if entry.worker_id.as_deref() != Some(update.worker_id.as_str()) {
+        // Lease fence: reject when either the caller isn't the lease holder
+        // or the lease has already expired at `now`. The latter stops a stale
+        // worker from committing terminal state after its window, even if
+        // the sweeper hasn't run yet.
+        let lease_still_valid = entry.lease_expires_at.is_some_and(|exp| exp > now);
+        if entry.worker_id.as_deref() != Some(update.worker_id.as_str()) || !lease_still_valid {
             return Err(BackgroundRepositoryError::LeaseNotHeld {
                 response_id: update.response_id.clone(),
                 worker_id: update.worker_id,
@@ -479,10 +496,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn claim_next_respects_priority_and_creation_order() {
+    async fn claim_next_respects_priority_order() {
+        // Fully distinct priorities so ordering is determined by the
+        // priority tiebreaker alone, not by timestamps that could collide on
+        // coarse-clock systems.
         let repo = MemoryBackgroundRepository::new();
         let mut r1 = enqueue_req("r1");
-        r1.priority = 5;
+        r1.priority = 10;
         let mut r2 = enqueue_req("r2");
         r2.priority = 1;
         let mut r3 = enqueue_req("r3");
@@ -503,7 +523,59 @@ mod tests {
                 .unwrap_or_default();
             claim_order.push(id);
         }
-        assert_eq!(claim_order, vec!["r2", "r1", "r3"]);
+        assert_eq!(claim_order, vec!["r2", "r3", "r1"]);
+    }
+
+    #[tokio::test]
+    async fn claim_next_skips_cancelled_and_returns_next_runnable() {
+        // A Queued-with-cancel-requested row arises when an InProgress row
+        // has cancel_requested=true set by `request_cancel`, then its lease
+        // expires and `requeue_expired` flips it back to Queued with the
+        // flag preserved. When the picker encounters that row next, it must
+        // mark it Cancelled and keep scanning rather than return `None`.
+        let repo = MemoryBackgroundRepository::new();
+
+        let mut r1 = enqueue_req("r1");
+        r1.priority = 1;
+        let mut r2 = enqueue_req("r2");
+        r2.priority = 5;
+        repo.enqueue(r1, None).await.unwrap();
+        repo.enqueue(r2, None).await.unwrap();
+
+        // 1. Claim r1 (higher priority), ask to cancel → r1 becomes
+        //    InProgress with cancel_requested=true.
+        let claim_time = Utc::now();
+        let _ = repo
+            .claim_next("w1", claim_time, Duration::from_secs(60))
+            .await
+            .unwrap()
+            .expect("r1 claimed");
+        assert_eq!(
+            repo.request_cancel(&ResponseId::from("r1")).await.unwrap(),
+            StoredCancelResult::CancelRequested
+        );
+
+        // 2. Sweep expires the lease → r1 flips back to Queued but keeps
+        //    cancel_requested=true.
+        assert_eq!(
+            repo.requeue_expired(claim_time + chrono::Duration::seconds(120))
+                .await
+                .unwrap(),
+            1
+        );
+
+        // 3. Next claim: picker lands on r1 (priority 1), flips to Cancelled,
+        //    keeps scanning, and returns r2 instead of `None`.
+        let job = repo
+            .claim_next(
+                "w2",
+                claim_time + chrono::Duration::seconds(130),
+                Duration::from_secs(60),
+            )
+            .await
+            .unwrap()
+            .expect("r2 should be returned after skipping cancelled r1");
+        assert_eq!(job.response_id, ResponseId::from("r2"));
     }
 
     #[tokio::test]
@@ -644,20 +716,28 @@ mod tests {
     async fn finalize_writes_terminal_and_clears_lease() {
         let repo = MemoryBackgroundRepository::new();
         repo.enqueue(enqueue_req("r1"), None).await.unwrap();
+        let claim_time = Utc::now();
         let _ = repo
-            .claim_next("w1", Utc::now(), Duration::from_secs(60))
+            .claim_next("w1", claim_time, Duration::from_secs(60))
             .await
             .unwrap()
             .expect("claim");
+        let within_lease = claim_time + chrono::Duration::seconds(10);
         let result = repo
-            .finalize(finalize_req("r1", "w1", FinalizeStatus::Completed))
+            .finalize(
+                finalize_req("r1", "w1", FinalizeStatus::Completed),
+                within_lease,
+            )
             .await
             .unwrap();
         assert_eq!(result.final_status, FinalizeStatus::Completed);
         assert!(!result.cancel_won);
 
         let result = repo
-            .finalize(finalize_req("r1", "w1", FinalizeStatus::Failed))
+            .finalize(
+                finalize_req("r1", "w1", FinalizeStatus::Failed),
+                within_lease,
+            )
             .await
             .unwrap();
         assert_eq!(result.final_status, FinalizeStatus::Completed);
@@ -667,8 +747,9 @@ mod tests {
     async fn finalize_cancel_wins_over_worker_status() {
         let repo = MemoryBackgroundRepository::new();
         repo.enqueue(enqueue_req("r1"), None).await.unwrap();
+        let claim_time = Utc::now();
         let _ = repo
-            .claim_next("w1", Utc::now(), Duration::from_secs(60))
+            .claim_next("w1", claim_time, Duration::from_secs(60))
             .await
             .unwrap()
             .expect("claim");
@@ -678,7 +759,10 @@ mod tests {
         );
 
         let result = repo
-            .finalize(finalize_req("r1", "w1", FinalizeStatus::Completed))
+            .finalize(
+                finalize_req("r1", "w1", FinalizeStatus::Completed),
+                claim_time + chrono::Duration::seconds(10),
+            )
             .await
             .unwrap();
         assert_eq!(result.final_status, FinalizeStatus::Cancelled);
@@ -689,13 +773,44 @@ mod tests {
     async fn finalize_rejects_non_lease_holder() {
         let repo = MemoryBackgroundRepository::new();
         repo.enqueue(enqueue_req("r1"), None).await.unwrap();
+        let claim_time = Utc::now();
         let _ = repo
-            .claim_next("w1", Utc::now(), Duration::from_secs(60))
+            .claim_next("w1", claim_time, Duration::from_secs(60))
             .await
             .unwrap()
             .expect("claim");
         let err = repo
-            .finalize(finalize_req("r1", "w2", FinalizeStatus::Completed))
+            .finalize(
+                finalize_req("r1", "w2", FinalizeStatus::Completed),
+                claim_time + chrono::Duration::seconds(10),
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            BackgroundRepositoryError::LeaseNotHeld { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn finalize_rejects_expired_lease_even_before_sweeper() {
+        // Stale-worker guard: a worker whose lease has already expired must
+        // not be able to commit terminal state, even if `requeue_expired`
+        // hasn't run yet.
+        let repo = MemoryBackgroundRepository::new();
+        repo.enqueue(enqueue_req("r1"), None).await.unwrap();
+        let claim_time = Utc::now();
+        let _ = repo
+            .claim_next("w1", claim_time, Duration::from_secs(60))
+            .await
+            .unwrap()
+            .expect("claim");
+        let after_expiry = claim_time + chrono::Duration::seconds(120);
+        let err = repo
+            .finalize(
+                finalize_req("r1", "w1", FinalizeStatus::Completed),
+                after_expiry,
+            )
             .await
             .unwrap_err();
         assert!(matches!(
@@ -783,8 +898,9 @@ mod tests {
         );
 
         repo.enqueue(enqueue_req("r2"), None).await.unwrap();
+        let claim_time = Utc::now();
         let _ = repo
-            .claim_next("w1", Utc::now(), Duration::from_secs(60))
+            .claim_next("w1", claim_time, Duration::from_secs(60))
             .await
             .unwrap()
             .expect("claim");
@@ -796,7 +912,10 @@ mod tests {
         );
 
         let _ = repo
-            .finalize(finalize_req("r2", "w1", FinalizeStatus::Completed))
+            .finalize(
+                finalize_req("r2", "w1", FinalizeStatus::Completed),
+                claim_time + chrono::Duration::seconds(10),
+            )
             .await
             .unwrap();
         assert_eq!(

--- a/crates/data_connector/src/memory_background.rs
+++ b/crates/data_connector/src/memory_background.rs
@@ -1,0 +1,809 @@
+//! In-memory `BackgroundResponseRepository`.
+//!
+//! Non-durable by design: process restart drops all queued / in-progress /
+//! terminal state, and clients polling across a restart receive `NotFound`.
+//! Suitable for dev, CI, and single-node deployments.
+//!
+//! `finalize` resolves the cancel/complete race: if `cancel_requested=true`
+//! at finalize time, the written status is `Cancelled` regardless of the
+//! worker-supplied status and `FinalizeResult::cancel_won=true`.
+
+use std::{collections::HashMap, sync::Arc, time::Duration};
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use parking_lot::RwLock;
+use serde_json::Value;
+
+use crate::{
+    background::{
+        BackgroundRepositoryError, BackgroundRepositoryResult, BackgroundResponseRepository,
+        DeleteResult, EnqueueRequest, FinalizeRequest, FinalizeResult, FinalizeStatus, LeasedJob,
+        QueuedResponse, ResumeEventBatch, StoredCancelResult, StoredStreamEvent,
+    },
+    context::RequestContext,
+    core::ResponseId,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum InternalStatus {
+    Queued,
+    InProgress,
+    Completed,
+    Incomplete,
+    Failed,
+    Cancelled,
+}
+
+impl InternalStatus {
+    fn is_terminal(self) -> bool {
+        matches!(
+            self,
+            Self::Completed | Self::Incomplete | Self::Failed | Self::Cancelled
+        )
+    }
+
+    fn from_finalize(s: FinalizeStatus) -> Self {
+        match s {
+            FinalizeStatus::Completed => Self::Completed,
+            FinalizeStatus::Incomplete => Self::Incomplete,
+            FinalizeStatus::Failed => Self::Failed,
+            FinalizeStatus::Cancelled => Self::Cancelled,
+        }
+    }
+
+    fn to_finalize(self) -> Option<FinalizeStatus> {
+        match self {
+            Self::Completed => Some(FinalizeStatus::Completed),
+            Self::Incomplete => Some(FinalizeStatus::Incomplete),
+            Self::Failed => Some(FinalizeStatus::Failed),
+            Self::Cancelled => Some(FinalizeStatus::Cancelled),
+            Self::Queued | Self::InProgress => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Entry {
+    status: InternalStatus,
+
+    request_json: Value,
+    input: Value,
+    raw_response: Value,
+    stream_enabled: bool,
+    model: String,
+    conversation_id: Option<String>,
+    previous_response_id: Option<ResponseId>,
+
+    priority: i32,
+    retry_attempt: u32,
+    worker_id: Option<String>,
+    lease_expires_at: Option<DateTime<Utc>>,
+    next_attempt_at: DateTime<Utc>,
+    created_at: DateTime<Utc>,
+
+    cancel_requested: bool,
+    request_context: Option<RequestContext>,
+
+    stream_events: Vec<StoredStreamEvent>,
+    next_stream_sequence: i64,
+
+    started_at: Option<DateTime<Utc>>,
+    completed_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Default)]
+struct State {
+    entries: HashMap<ResponseId, Entry>,
+}
+
+#[derive(Clone, Default)]
+pub struct MemoryBackgroundRepository {
+    state: Arc<RwLock<State>>,
+}
+
+impl MemoryBackgroundRepository {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[async_trait]
+impl BackgroundResponseRepository for MemoryBackgroundRepository {
+    async fn enqueue(
+        &self,
+        req: EnqueueRequest,
+        request_context: Option<RequestContext>,
+    ) -> BackgroundRepositoryResult<QueuedResponse> {
+        let now = Utc::now();
+        let mut state = self.state.write();
+
+        if state.entries.contains_key(&req.response_id) {
+            return Err(BackgroundRepositoryError::InvalidTransition(format!(
+                "response {} already exists",
+                req.response_id
+            )));
+        }
+
+        let response_id = req.response_id.clone();
+        let entry = Entry {
+            status: InternalStatus::Queued,
+            request_json: req.request_json,
+            input: req.input,
+            raw_response: req.raw_response,
+            stream_enabled: req.stream_enabled,
+            model: req.model,
+            conversation_id: req.conversation_id,
+            previous_response_id: req.previous_response_id,
+            priority: req.priority,
+            retry_attempt: 0,
+            worker_id: None,
+            lease_expires_at: None,
+            next_attempt_at: now,
+            created_at: now,
+            cancel_requested: false,
+            request_context,
+            stream_events: Vec::new(),
+            next_stream_sequence: 0,
+            started_at: None,
+            completed_at: None,
+        };
+        state.entries.insert(response_id.clone(), entry);
+
+        let queue_depth = state
+            .entries
+            .values()
+            .filter(|e| e.status == InternalStatus::Queued)
+            .count() as u64;
+
+        Ok(QueuedResponse {
+            response_id,
+            created_at: now,
+            queue_depth_at_insert: queue_depth,
+        })
+    }
+
+    async fn claim_next(
+        &self,
+        worker_id: &str,
+        now: DateTime<Utc>,
+        lease: Duration,
+    ) -> BackgroundRepositoryResult<Option<LeasedJob>> {
+        let mut state = self.state.write();
+
+        let pick = state
+            .entries
+            .iter()
+            .filter(|(_, e)| e.status == InternalStatus::Queued && e.next_attempt_at <= now)
+            .min_by(|(_, a), (_, b)| {
+                a.priority
+                    .cmp(&b.priority)
+                    .then(a.next_attempt_at.cmp(&b.next_attempt_at))
+                    .then(a.created_at.cmp(&b.created_at))
+            })
+            .map(|(id, _)| id.clone());
+
+        let Some(id) = pick else {
+            return Ok(None);
+        };
+
+        let entry = state.entries.get_mut(&id).ok_or_else(|| {
+            BackgroundRepositoryError::Backend(
+                "claim_next invariant: picked entry missing under write lock".to_string(),
+            )
+        })?;
+
+        // Cancel-before-claim: flip straight to Cancelled rather than hand
+        // a worker a job it must not execute. The worker sees `None`.
+        if entry.cancel_requested {
+            entry.status = InternalStatus::Cancelled;
+            entry.completed_at = Some(now);
+            return Ok(None);
+        }
+
+        let expires_at =
+            now + chrono::Duration::from_std(lease).unwrap_or(chrono::Duration::zero());
+        entry.status = InternalStatus::InProgress;
+        entry.worker_id = Some(worker_id.to_string());
+        entry.lease_expires_at = Some(expires_at);
+        if entry.started_at.is_none() {
+            entry.started_at = Some(now);
+        }
+
+        Ok(Some(LeasedJob {
+            response_id: id,
+            retry_attempt: entry.retry_attempt,
+            priority: entry.priority,
+            worker_id: worker_id.to_string(),
+            lease_expires_at: expires_at,
+            input: entry.input.clone(),
+            request_json: entry.request_json.clone(),
+            model: entry.model.clone(),
+            conversation_id: entry.conversation_id.clone(),
+            previous_response_id: entry.previous_response_id.clone(),
+            stream_enabled: entry.stream_enabled,
+        }))
+    }
+
+    async fn heartbeat(
+        &self,
+        response_id: &ResponseId,
+        worker_id: &str,
+        now: DateTime<Utc>,
+        lease: Duration,
+    ) -> BackgroundRepositoryResult<()> {
+        let mut state = self.state.write();
+        let entry = state
+            .entries
+            .get_mut(response_id)
+            .ok_or_else(|| BackgroundRepositoryError::NotFound(response_id.clone()))?;
+
+        let held_by_caller = entry.status == InternalStatus::InProgress
+            && entry.worker_id.as_deref() == Some(worker_id)
+            && entry.lease_expires_at.is_some_and(|exp| exp > now);
+        if !held_by_caller {
+            return Err(BackgroundRepositoryError::LeaseNotHeld {
+                response_id: response_id.clone(),
+                worker_id: worker_id.to_string(),
+            });
+        }
+
+        entry.lease_expires_at =
+            Some(now + chrono::Duration::from_std(lease).unwrap_or(chrono::Duration::zero()));
+        Ok(())
+    }
+
+    async fn request_cancel(
+        &self,
+        response_id: &ResponseId,
+    ) -> BackgroundRepositoryResult<StoredCancelResult> {
+        let now = Utc::now();
+        let mut state = self.state.write();
+        let Some(entry) = state.entries.get_mut(response_id) else {
+            return Ok(StoredCancelResult::NotFound);
+        };
+
+        if entry.status.is_terminal() {
+            return Ok(StoredCancelResult::AlreadyTerminal);
+        }
+
+        match entry.status {
+            InternalStatus::Queued => {
+                entry.status = InternalStatus::Cancelled;
+                entry.completed_at = Some(now);
+                entry.worker_id = None;
+                entry.lease_expires_at = None;
+                Ok(StoredCancelResult::QueuedCancelled)
+            }
+            InternalStatus::InProgress => {
+                entry.cancel_requested = true;
+                Ok(StoredCancelResult::CancelRequested)
+            }
+            InternalStatus::Completed
+            | InternalStatus::Incomplete
+            | InternalStatus::Failed
+            | InternalStatus::Cancelled => Ok(StoredCancelResult::AlreadyTerminal),
+        }
+    }
+
+    async fn append_stream_event(
+        &self,
+        response_id: &ResponseId,
+        event_type: &str,
+        data: Value,
+    ) -> BackgroundRepositoryResult<StoredStreamEvent> {
+        let now = Utc::now();
+        let mut state = self.state.write();
+        let entry = state
+            .entries
+            .get_mut(response_id)
+            .ok_or_else(|| BackgroundRepositoryError::NotFound(response_id.clone()))?;
+
+        let seq = entry.next_stream_sequence;
+        entry.next_stream_sequence = seq
+            .checked_add(1)
+            .ok_or_else(|| BackgroundRepositoryError::Backend("sequence overflow".to_string()))?;
+
+        let event = StoredStreamEvent {
+            response_id: response_id.clone(),
+            sequence: seq,
+            event_type: event_type.to_string(),
+            data,
+            created_at: now,
+        };
+        entry.stream_events.push(event.clone());
+        Ok(event)
+    }
+
+    async fn load_resume_events(
+        &self,
+        response_id: &ResponseId,
+        starting_after: Option<i64>,
+    ) -> BackgroundRepositoryResult<ResumeEventBatch> {
+        let state = self.state.read();
+        let entry = state
+            .entries
+            .get(response_id)
+            .ok_or_else(|| BackgroundRepositoryError::NotFound(response_id.clone()))?;
+
+        let events: Vec<StoredStreamEvent> = entry
+            .stream_events
+            .iter()
+            .filter(|e| match starting_after {
+                Some(after) => e.sequence > after,
+                None => true,
+            })
+            .cloned()
+            .collect();
+        let terminal = entry.status.is_terminal();
+        Ok(ResumeEventBatch { events, terminal })
+    }
+
+    async fn finalize(
+        &self,
+        update: FinalizeRequest,
+    ) -> BackgroundRepositoryResult<FinalizeResult> {
+        let mut state = self.state.write();
+        let entry = state
+            .entries
+            .get_mut(&update.response_id)
+            .ok_or_else(|| BackgroundRepositoryError::NotFound(update.response_id.clone()))?;
+
+        if let Some(prior) = entry.status.to_finalize() {
+            return Ok(FinalizeResult {
+                response_id: update.response_id,
+                final_status: prior,
+                cancel_won: false,
+            });
+        }
+
+        if entry.worker_id.as_deref() != Some(update.worker_id.as_str()) {
+            return Err(BackgroundRepositoryError::LeaseNotHeld {
+                response_id: update.response_id.clone(),
+                worker_id: update.worker_id,
+            });
+        }
+
+        let (final_status, cancel_won) = if entry.cancel_requested {
+            (FinalizeStatus::Cancelled, true)
+        } else {
+            (update.status, false)
+        };
+
+        entry.status = InternalStatus::from_finalize(final_status);
+        entry.raw_response = update.raw_response;
+        entry.completed_at = Some(update.completed_at);
+        entry.worker_id = None;
+        entry.lease_expires_at = None;
+
+        Ok(FinalizeResult {
+            response_id: update.response_id,
+            final_status,
+            cancel_won,
+        })
+    }
+
+    async fn requeue_expired(&self, now: DateTime<Utc>) -> BackgroundRepositoryResult<u64> {
+        let mut state = self.state.write();
+        let mut count: u64 = 0;
+        for entry in state.entries.values_mut() {
+            if entry.status == InternalStatus::InProgress
+                && entry.lease_expires_at.is_some_and(|exp| exp <= now)
+            {
+                entry.status = InternalStatus::Queued;
+                entry.worker_id = None;
+                entry.lease_expires_at = None;
+                entry.retry_attempt = entry.retry_attempt.saturating_add(1);
+                entry.next_attempt_at = now;
+                count += 1;
+            }
+        }
+        Ok(count)
+    }
+
+    async fn load_request_context(
+        &self,
+        response_id: &ResponseId,
+    ) -> BackgroundRepositoryResult<Option<RequestContext>> {
+        let state = self.state.read();
+        let entry = state
+            .entries
+            .get(response_id)
+            .ok_or_else(|| BackgroundRepositoryError::NotFound(response_id.clone()))?;
+        Ok(entry.request_context.clone())
+    }
+
+    async fn delete_background_response(
+        &self,
+        response_id: &ResponseId,
+    ) -> BackgroundRepositoryResult<DeleteResult> {
+        let mut state = self.state.write();
+        let Some(entry) = state.entries.get(response_id) else {
+            return Ok(DeleteResult::NotFound);
+        };
+
+        if entry.status == InternalStatus::InProgress {
+            return Ok(DeleteResult::InProgress);
+        }
+
+        state.entries.remove(response_id);
+        Ok(DeleteResult::Deleted)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    fn enqueue_req(id: &str) -> EnqueueRequest {
+        EnqueueRequest::new(
+            ResponseId::from(id),
+            "gpt-5.1".to_string(),
+            json!({"model": "gpt-5.1"}),
+            json!([]),
+            json!({"id": id, "status": "queued"}),
+            false,
+            0,
+        )
+    }
+
+    fn finalize_req(id: &str, worker: &str, status: FinalizeStatus) -> FinalizeRequest {
+        FinalizeRequest::new(
+            ResponseId::from(id),
+            worker.to_string(),
+            status,
+            json!({"id": id, "status": "completed"}),
+            Utc::now(),
+        )
+    }
+
+    #[tokio::test]
+    async fn enqueue_creates_queued_response() {
+        let repo = MemoryBackgroundRepository::new();
+        let ack = repo.enqueue(enqueue_req("r1"), None).await.unwrap();
+        assert_eq!(ack.response_id, ResponseId::from("r1"));
+        assert_eq!(ack.queue_depth_at_insert, 1);
+    }
+
+    #[tokio::test]
+    async fn enqueue_rejects_duplicate() {
+        let repo = MemoryBackgroundRepository::new();
+        repo.enqueue(enqueue_req("r1"), None).await.unwrap();
+        let err = repo.enqueue(enqueue_req("r1"), None).await.unwrap_err();
+        assert!(matches!(
+            err,
+            BackgroundRepositoryError::InvalidTransition(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn claim_next_respects_priority_and_creation_order() {
+        let repo = MemoryBackgroundRepository::new();
+        let mut r1 = enqueue_req("r1");
+        r1.priority = 5;
+        let mut r2 = enqueue_req("r2");
+        r2.priority = 1;
+        let mut r3 = enqueue_req("r3");
+        r3.priority = 5;
+        repo.enqueue(r1, None).await.unwrap();
+        repo.enqueue(r2, None).await.unwrap();
+        repo.enqueue(r3, None).await.unwrap();
+
+        let now = Utc::now();
+        let lease = Duration::from_secs(60);
+        let mut claim_order: Vec<String> = Vec::new();
+        for _ in 0..3 {
+            let id = repo
+                .claim_next("w1", now, lease)
+                .await
+                .unwrap()
+                .map(|j| j.response_id.0)
+                .unwrap_or_default();
+            claim_order.push(id);
+        }
+        assert_eq!(claim_order, vec!["r2", "r1", "r3"]);
+    }
+
+    #[tokio::test]
+    async fn claim_next_empty_returns_none() {
+        let repo = MemoryBackgroundRepository::new();
+        let now = Utc::now();
+        assert!(repo
+            .claim_next("w1", now, Duration::from_secs(60))
+            .await
+            .unwrap()
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn claim_on_cancel_requested_skips_worker_and_marks_cancelled() {
+        let repo = MemoryBackgroundRepository::new();
+        repo.enqueue(enqueue_req("r1"), None).await.unwrap();
+        assert!(matches!(
+            repo.request_cancel(&ResponseId::from("r1")).await.unwrap(),
+            StoredCancelResult::QueuedCancelled
+        ));
+        let claimed = repo
+            .claim_next("w1", Utc::now(), Duration::from_secs(60))
+            .await
+            .unwrap();
+        assert!(claimed.is_none());
+    }
+
+    #[tokio::test]
+    async fn heartbeat_requires_active_lease() {
+        let repo = MemoryBackgroundRepository::new();
+        repo.enqueue(enqueue_req("r1"), None).await.unwrap();
+
+        let err = repo
+            .heartbeat(
+                &ResponseId::from("r1"),
+                "w1",
+                Utc::now(),
+                Duration::from_secs(60),
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            BackgroundRepositoryError::LeaseNotHeld { .. }
+        ));
+
+        let now = Utc::now();
+        let _ = repo
+            .claim_next("w1", now, Duration::from_secs(60))
+            .await
+            .unwrap();
+        repo.heartbeat(
+            &ResponseId::from("r1"),
+            "w1",
+            now + chrono::Duration::seconds(10),
+            Duration::from_secs(60),
+        )
+        .await
+        .unwrap();
+
+        let err = repo
+            .heartbeat(
+                &ResponseId::from("r1"),
+                "w2",
+                Utc::now(),
+                Duration::from_secs(60),
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            BackgroundRepositoryError::LeaseNotHeld { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn request_cancel_returns_variant_for_each_state() {
+        let repo = MemoryBackgroundRepository::new();
+        assert_eq!(
+            repo.request_cancel(&ResponseId::from("missing"))
+                .await
+                .unwrap(),
+            StoredCancelResult::NotFound
+        );
+
+        repo.enqueue(enqueue_req("r1"), None).await.unwrap();
+        assert_eq!(
+            repo.request_cancel(&ResponseId::from("r1")).await.unwrap(),
+            StoredCancelResult::QueuedCancelled
+        );
+        assert_eq!(
+            repo.request_cancel(&ResponseId::from("r1")).await.unwrap(),
+            StoredCancelResult::AlreadyTerminal
+        );
+
+        repo.enqueue(enqueue_req("r2"), None).await.unwrap();
+        let _ = repo
+            .claim_next("w1", Utc::now(), Duration::from_secs(60))
+            .await
+            .unwrap();
+        assert_eq!(
+            repo.request_cancel(&ResponseId::from("r2")).await.unwrap(),
+            StoredCancelResult::CancelRequested
+        );
+    }
+
+    #[tokio::test]
+    async fn append_and_load_stream_events_monotonic() {
+        let repo = MemoryBackgroundRepository::new();
+        repo.enqueue(enqueue_req("r1"), None).await.unwrap();
+        let id = ResponseId::from("r1");
+
+        let e0 = repo
+            .append_stream_event(&id, "delta", json!({"text": "a"}))
+            .await
+            .unwrap();
+        let e1 = repo
+            .append_stream_event(&id, "delta", json!({"text": "b"}))
+            .await
+            .unwrap();
+        let e2 = repo
+            .append_stream_event(&id, "delta", json!({"text": "c"}))
+            .await
+            .unwrap();
+        assert_eq!((e0.sequence, e1.sequence, e2.sequence), (0, 1, 2));
+
+        let all = repo.load_resume_events(&id, None).await.unwrap();
+        assert_eq!(all.events.len(), 3);
+        assert!(!all.terminal);
+
+        let tail = repo.load_resume_events(&id, Some(0)).await.unwrap();
+        assert_eq!(tail.events.len(), 2);
+        assert_eq!(tail.events[0].sequence, 1);
+    }
+
+    #[tokio::test]
+    async fn finalize_writes_terminal_and_clears_lease() {
+        let repo = MemoryBackgroundRepository::new();
+        repo.enqueue(enqueue_req("r1"), None).await.unwrap();
+        let _ = repo
+            .claim_next("w1", Utc::now(), Duration::from_secs(60))
+            .await
+            .unwrap()
+            .expect("claim");
+        let result = repo
+            .finalize(finalize_req("r1", "w1", FinalizeStatus::Completed))
+            .await
+            .unwrap();
+        assert_eq!(result.final_status, FinalizeStatus::Completed);
+        assert!(!result.cancel_won);
+
+        let result = repo
+            .finalize(finalize_req("r1", "w1", FinalizeStatus::Failed))
+            .await
+            .unwrap();
+        assert_eq!(result.final_status, FinalizeStatus::Completed);
+    }
+
+    #[tokio::test]
+    async fn finalize_cancel_wins_over_worker_status() {
+        let repo = MemoryBackgroundRepository::new();
+        repo.enqueue(enqueue_req("r1"), None).await.unwrap();
+        let _ = repo
+            .claim_next("w1", Utc::now(), Duration::from_secs(60))
+            .await
+            .unwrap()
+            .expect("claim");
+        assert_eq!(
+            repo.request_cancel(&ResponseId::from("r1")).await.unwrap(),
+            StoredCancelResult::CancelRequested
+        );
+
+        let result = repo
+            .finalize(finalize_req("r1", "w1", FinalizeStatus::Completed))
+            .await
+            .unwrap();
+        assert_eq!(result.final_status, FinalizeStatus::Cancelled);
+        assert!(result.cancel_won);
+    }
+
+    #[tokio::test]
+    async fn finalize_rejects_non_lease_holder() {
+        let repo = MemoryBackgroundRepository::new();
+        repo.enqueue(enqueue_req("r1"), None).await.unwrap();
+        let _ = repo
+            .claim_next("w1", Utc::now(), Duration::from_secs(60))
+            .await
+            .unwrap()
+            .expect("claim");
+        let err = repo
+            .finalize(finalize_req("r1", "w2", FinalizeStatus::Completed))
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            BackgroundRepositoryError::LeaseNotHeld { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn requeue_expired_moves_in_progress_back_to_queued() {
+        let repo = MemoryBackgroundRepository::new();
+        repo.enqueue(enqueue_req("r1"), None).await.unwrap();
+        let claim_time = Utc::now();
+        let _ = repo
+            .claim_next("w1", claim_time, Duration::from_secs(60))
+            .await
+            .unwrap()
+            .expect("claim");
+
+        assert_eq!(
+            repo.requeue_expired(claim_time + chrono::Duration::seconds(30))
+                .await
+                .unwrap(),
+            0
+        );
+        assert_eq!(
+            repo.requeue_expired(claim_time + chrono::Duration::seconds(120))
+                .await
+                .unwrap(),
+            1
+        );
+
+        let job = repo
+            .claim_next(
+                "w2",
+                claim_time + chrono::Duration::seconds(121),
+                Duration::from_secs(60),
+            )
+            .await
+            .unwrap()
+            .expect("re-claim");
+        assert_eq!(job.retry_attempt, 1);
+    }
+
+    #[tokio::test]
+    async fn load_request_context_round_trips() {
+        let repo = MemoryBackgroundRepository::new();
+        let mut ctx = RequestContext::default();
+        ctx.set("tenant_id", "acme");
+        ctx.set("principal", "alice");
+        repo.enqueue(enqueue_req("r1"), Some(ctx.clone()))
+            .await
+            .unwrap();
+        let loaded = repo
+            .load_request_context(&ResponseId::from("r1"))
+            .await
+            .unwrap()
+            .expect("context must round-trip");
+        assert_eq!(loaded.data(), ctx.data());
+
+        repo.enqueue(enqueue_req("r2"), None).await.unwrap();
+        assert!(repo
+            .load_request_context(&ResponseId::from("r2"))
+            .await
+            .unwrap()
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn delete_honors_state_machine() {
+        let repo = MemoryBackgroundRepository::new();
+        assert_eq!(
+            repo.delete_background_response(&ResponseId::from("nope"))
+                .await
+                .unwrap(),
+            DeleteResult::NotFound
+        );
+
+        repo.enqueue(enqueue_req("r1"), None).await.unwrap();
+        assert_eq!(
+            repo.delete_background_response(&ResponseId::from("r1"))
+                .await
+                .unwrap(),
+            DeleteResult::Deleted
+        );
+
+        repo.enqueue(enqueue_req("r2"), None).await.unwrap();
+        let _ = repo
+            .claim_next("w1", Utc::now(), Duration::from_secs(60))
+            .await
+            .unwrap()
+            .expect("claim");
+        assert_eq!(
+            repo.delete_background_response(&ResponseId::from("r2"))
+                .await
+                .unwrap(),
+            DeleteResult::InProgress
+        );
+
+        let _ = repo
+            .finalize(finalize_req("r2", "w1", FinalizeStatus::Completed))
+            .await
+            .unwrap();
+        assert_eq!(
+            repo.delete_background_response(&ResponseId::from("r2"))
+                .await
+                .unwrap(),
+            DeleteResult::Deleted
+        );
+    }
+}

--- a/model_gateway/src/app_context.rs
+++ b/model_gateway/src/app_context.rs
@@ -8,8 +8,9 @@ use reasoning_parser::ParserFactory as ReasoningParserFactory;
 use reqwest::Client;
 use smg_blob_storage::create_blob_store;
 use smg_data_connector::{
-    backend_supports_memory_writer, create_storage, ConversationItemStorage,
-    ConversationMemoryWriter, ConversationStorage, ResponseStorage, StorageFactoryConfig,
+    backend_supports_memory_writer, create_storage, BackgroundResponseRepository,
+    ConversationItemStorage, ConversationMemoryWriter, ConversationStorage, ResponseStorage,
+    StorageFactoryConfig,
 };
 use smg_mcp::McpOrchestrator;
 use smg_skills::SkillService;
@@ -61,6 +62,7 @@ pub struct AppContext {
     pub conversation_item_storage: Arc<dyn ConversationItemStorage>,
     /// Writer used for long-term-memory persistence (NoOp when backend does not support writes).
     pub conversation_memory_writer: Arc<dyn ConversationMemoryWriter>,
+    pub background_repository: Option<Arc<dyn BackgroundResponseRepository>>,
     pub worker_monitor: Option<Arc<WorkerMonitor>>,
     pub configured_reasoning_parser: Option<String>,
     pub configured_tool_parser: Option<String>,
@@ -101,6 +103,7 @@ pub struct AppContextBuilder {
     conversation_storage: Option<Arc<dyn ConversationStorage>>,
     conversation_item_storage: Option<Arc<dyn ConversationItemStorage>>,
     conversation_memory_writer: Option<Arc<dyn ConversationMemoryWriter>>,
+    background_repository: Option<Arc<dyn BackgroundResponseRepository>>,
     worker_monitor: Option<Arc<WorkerMonitor>>,
     worker_job_queue: Option<Arc<OnceLock<Arc<JobQueue>>>>,
     workflow_engines: Option<Arc<OnceLock<WorkflowEngines>>>,
@@ -155,6 +158,7 @@ impl AppContextBuilder {
             conversation_storage: None,
             conversation_item_storage: None,
             conversation_memory_writer: None,
+            background_repository: None,
             worker_monitor: None,
             worker_job_queue: None,
             workflow_engines: None,
@@ -368,6 +372,7 @@ impl AppContextBuilder {
             conversation_memory_writer: self.conversation_memory_writer.ok_or(
                 AppContextBuildError::MissingField("conversation_memory_writer"),
             )?,
+            background_repository: self.background_repository,
             worker_monitor: self.worker_monitor,
             configured_reasoning_parser,
             configured_tool_parser,
@@ -578,6 +583,7 @@ impl AppContextBuilder {
         self.conversation_storage = Some(bundle.conversation_storage);
         self.conversation_item_storage = Some(bundle.conversation_item_storage);
         self.conversation_memory_writer = Some(bundle.conversation_memory_writer);
+        self.background_repository = bundle.background_repository;
 
         Ok(self)
     }

--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -18,6 +18,65 @@ pub struct MemoryRuntimeConfig {
     pub enabled: bool,
 }
 
+/// Background-mode tuning knobs. Availability is gated by backend capability
+/// (whether the active `history_backend` provides a
+/// `BackgroundResponseRepository`), not by a flag here.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct BackgroundConfig {
+    pub worker_concurrency: u32,
+    pub max_queue_depth: u32,
+    pub lease_duration_secs: u64,
+    pub max_retries: u32,
+    pub retry_base_delay_secs: u64,
+    pub retry_max_delay_secs: u64,
+    pub sweep_interval_secs: u64,
+    pub poll_interval_ms: u64,
+    pub stream_retention_secs: u64,
+}
+
+impl Default for BackgroundConfig {
+    fn default() -> Self {
+        Self {
+            worker_concurrency: 16,
+            max_queue_depth: 10_000,
+            lease_duration_secs: 60,
+            max_retries: 3,
+            retry_base_delay_secs: 2,
+            retry_max_delay_secs: 60,
+            sweep_interval_secs: 30,
+            poll_interval_ms: 500,
+            stream_retention_secs: 15 * 60,
+        }
+    }
+}
+
+impl BackgroundConfig {
+    pub fn lease_duration(&self) -> std::time::Duration {
+        std::time::Duration::from_secs(self.lease_duration_secs)
+    }
+
+    pub fn retry_base_delay(&self) -> std::time::Duration {
+        std::time::Duration::from_secs(self.retry_base_delay_secs)
+    }
+
+    pub fn retry_max_delay(&self) -> std::time::Duration {
+        std::time::Duration::from_secs(self.retry_max_delay_secs)
+    }
+
+    pub fn sweep_interval(&self) -> std::time::Duration {
+        std::time::Duration::from_secs(self.sweep_interval_secs)
+    }
+
+    pub fn poll_interval(&self) -> std::time::Duration {
+        std::time::Duration::from_millis(self.poll_interval_ms)
+    }
+
+    pub fn stream_retention(&self) -> std::time::Duration {
+        std::time::Duration::from_secs(self.stream_retention_secs)
+    }
+}
+
 /// Main router configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RouterConfig {
@@ -47,6 +106,8 @@ pub struct RouterConfig {
     pub storage_context_headers: HashMap<String, String>,
     #[serde(default)]
     pub memory_runtime: MemoryRuntimeConfig,
+    #[serde(default)]
+    pub background: BackgroundConfig,
     #[serde(default)]
     pub tenant_resolution: TenantResolutionConfig,
     /// Set to -1 to disable rate limiting
@@ -583,6 +644,7 @@ impl Default for RouterConfig {
             request_id_headers: None,
             storage_context_headers: HashMap::new(),
             memory_runtime: MemoryRuntimeConfig::default(),
+            background: BackgroundConfig::default(),
             tenant_resolution: TenantResolutionConfig::default(),
             max_concurrent_requests: -1,
             queue_size: 100,
@@ -719,6 +781,49 @@ mod tests {
         );
         assert!(!config.skills_enabled);
         assert!(config.skills.is_none());
+    }
+
+    #[test]
+    fn test_background_config_defaults_match_design() {
+        let bg = BackgroundConfig::default();
+        assert_eq!(bg.worker_concurrency, 16);
+        assert_eq!(bg.max_queue_depth, 10_000);
+        assert_eq!(bg.lease_duration_secs, 60);
+        assert_eq!(bg.max_retries, 3);
+        assert_eq!(bg.retry_base_delay_secs, 2);
+        assert_eq!(bg.retry_max_delay_secs, 60);
+        assert_eq!(bg.sweep_interval_secs, 30);
+        assert_eq!(bg.poll_interval_ms, 500);
+        assert_eq!(bg.stream_retention_secs, 15 * 60);
+    }
+
+    #[test]
+    fn test_background_config_accessors_convert_units() {
+        let bg = BackgroundConfig::default();
+        assert_eq!(bg.lease_duration(), std::time::Duration::from_secs(60));
+        assert_eq!(bg.poll_interval(), std::time::Duration::from_millis(500));
+        assert_eq!(bg.stream_retention(), std::time::Duration::from_secs(900));
+    }
+
+    #[test]
+    fn test_background_config_yaml_round_trip_with_custom_values() {
+        let yaml = r"
+worker_concurrency: 32
+max_queue_depth: 5000
+lease_duration_secs: 120
+max_retries: 5
+retry_base_delay_secs: 4
+retry_max_delay_secs: 300
+sweep_interval_secs: 10
+poll_interval_ms: 250
+stream_retention_secs: 3600
+";
+        let bg: BackgroundConfig = serde_yaml::from_str(yaml).expect("deserialize");
+        assert_eq!(bg.worker_concurrency, 32);
+        assert_eq!(bg.max_queue_depth, 5000);
+        assert_eq!(bg.lease_duration(), std::time::Duration::from_secs(120));
+        assert_eq!(bg.retry_max_delay(), std::time::Duration::from_secs(300));
+        assert_eq!(bg.poll_interval(), std::time::Duration::from_millis(250));
     }
 
     #[test]

--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -806,6 +806,36 @@ mod tests {
     }
 
     #[test]
+    fn test_validate_rejects_zero_background_fields() {
+        type BgMutator = fn(&mut BackgroundConfig);
+        let cases: &[(&str, BgMutator)] = &[
+            ("worker_concurrency", |b| b.worker_concurrency = 0),
+            ("max_queue_depth", |b| b.max_queue_depth = 0),
+            ("lease_duration_secs", |b| b.lease_duration_secs = 0),
+            ("sweep_interval_secs", |b| b.sweep_interval_secs = 0),
+            ("poll_interval_ms", |b| b.poll_interval_ms = 0),
+            ("stream_retention_secs", |b| b.stream_retention_secs = 0),
+        ];
+        for (field, mutate) in cases {
+            let mut cfg = RouterConfig::default();
+            mutate(&mut cfg.background);
+            let err = cfg.validate().expect_err(field);
+            assert!(
+                format!("{err:?}").contains(field),
+                "{field} validation must fail with field in error: {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_validate_rejects_retry_base_exceeding_max() {
+        let mut cfg = RouterConfig::default();
+        cfg.background.retry_base_delay_secs = 30;
+        cfg.background.retry_max_delay_secs = 10;
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
     fn test_background_config_yaml_round_trip_with_custom_values() {
         let yaml = r"
 worker_concurrency: 32

--- a/model_gateway/src/config/validation.rs
+++ b/model_gateway/src/config/validation.rs
@@ -44,7 +44,42 @@ impl ConfigValidator {
 
         Self::validate_tokenizer_cache(&config.tokenizer_cache)?;
         Self::validate_skills(config)?;
+        Self::validate_background(&config.background)?;
 
+        Ok(())
+    }
+
+    fn validate_background(bg: &BackgroundConfig) -> ConfigResult<()> {
+        let zero_checks = [
+            (
+                "background.worker_concurrency",
+                u64::from(bg.worker_concurrency),
+            ),
+            ("background.max_queue_depth", u64::from(bg.max_queue_depth)),
+            ("background.lease_duration_secs", bg.lease_duration_secs),
+            ("background.sweep_interval_secs", bg.sweep_interval_secs),
+            ("background.poll_interval_ms", bg.poll_interval_ms),
+            ("background.stream_retention_secs", bg.stream_retention_secs),
+        ];
+        for (field, value) in zero_checks {
+            if value == 0 {
+                return Err(ConfigError::InvalidValue {
+                    field: field.to_string(),
+                    value: value.to_string(),
+                    reason: "Must be > 0".to_string(),
+                });
+            }
+        }
+        if bg.retry_base_delay_secs > bg.retry_max_delay_secs {
+            return Err(ConfigError::InvalidValue {
+                field: "background.retry_base_delay_secs".to_string(),
+                value: bg.retry_base_delay_secs.to_string(),
+                reason: format!(
+                    "Must be <= retry_max_delay_secs ({})",
+                    bg.retry_max_delay_secs
+                ),
+            });
+        }
         Ok(())
     }
 

--- a/model_gateway/src/routers/common/background/mod.rs
+++ b/model_gateway/src/routers/common/background/mod.rs
@@ -1,0 +1,36 @@
+//! Background-mode shared handler scaffolding.
+//!
+//! BGM-PR-03 ships only [`BackgroundServices`]. Concrete create / cancel /
+//! resume handlers land in later PRs.
+
+use std::sync::Arc;
+
+use smg_data_connector::BackgroundResponseRepository;
+
+use crate::config::BackgroundConfig;
+
+#[derive(Clone)]
+pub struct BackgroundServices {
+    repository: Arc<dyn BackgroundResponseRepository>,
+    config: Arc<BackgroundConfig>,
+}
+
+impl BackgroundServices {
+    pub fn new(
+        repository: Arc<dyn BackgroundResponseRepository>,
+        config: BackgroundConfig,
+    ) -> Self {
+        Self {
+            repository,
+            config: Arc::new(config),
+        }
+    }
+
+    pub fn repository(&self) -> &Arc<dyn BackgroundResponseRepository> {
+        &self.repository
+    }
+
+    pub fn config(&self) -> &BackgroundConfig {
+        &self.config
+    }
+}

--- a/model_gateway/src/routers/common/mod.rs
+++ b/model_gateway/src/routers/common/mod.rs
@@ -17,7 +17,9 @@
 //!   used by every router for transport-level retries. Has zero
 //!   coupling to the `Worker` trait — it lived in `worker/` for
 //!   historical reasons before this extraction.
+//! - [`background`] — background-mode response scaffolding.
 
+pub mod background;
 pub mod header_utils;
 pub mod mcp_utils;
 pub mod persistence_utils;

--- a/model_gateway/src/routers/grpc/regular/responses/handlers.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/handlers.rs
@@ -54,7 +54,8 @@ pub(crate) async fn route_responses(
     tenant_request_meta: crate::middleware::TenantRequestMeta,
     model_id: String,
 ) -> Response {
-    // 1. Reject background mode (no longer supported)
+    // BGM-PR-04 replaces this with delegation to routers/common/background/
+    // when ctx.app_context.background_repository is Some.
     let is_background = request.background.unwrap_or(false);
     if is_background {
         return error::bad_request(

--- a/model_gateway/src/service_discovery.rs
+++ b/model_gateway/src/service_discovery.rs
@@ -1270,6 +1270,7 @@ mod tests {
             conversation_memory_writer: Arc::new(
                 smg_data_connector::NoOpConversationMemoryWriter::new(),
             ),
+            background_repository: None,
             worker_monitor: None,
             configured_reasoning_parser: None,
             configured_tool_parser: None,


### PR DESCRIPTION
## Summary

Third PR in the background-mode series. Scaffolds the gateway for background responses without enabling the create/cancel/stream handlers (those land in BGM-PR-04+). Ships the first concrete \`BackgroundResponseRepository\` implementation (memory) so dev/CI/single-node deployments can exercise the trait end-to-end.

Closes the acceptance criteria for BGM-PR-03 in \`.claude/designs/background-mode/2026-04-17-background-mode-task-breakdown.md\`.

## What changed

**crates/data_connector/src/memory_background.rs** (new, ~880 LOC)
- Full \`MemoryBackgroundRepository\` — all 10 \`BackgroundResponseRepository\` methods implemented with a single \`Arc<RwLock<State>>\`.
- State machine: Queued → InProgress (claim) → Completed / Incomplete / Failed / Cancelled (finalize).
- Cancel/complete race resolution via \`cancel_won\` in \`FinalizeResult\`.
- Monotonic per-response stream sequence allocated atomically in \`append_stream_event\`.
- Lease fencing in \`heartbeat\` and \`finalize\`; expired leases requeued with bumped \`retry_attempt\`.
- Explicit non-durability: process restart returns \`NotFound\` for prior IDs.
- 14 unit tests covering every state-machine path.

**crates/data_connector/src/factory.rs**
- \`StorageBundle.background_repository: Option<Arc<dyn BackgroundResponseRepository>>\`.
- Memory: \`Some(MemoryBackgroundRepository::new())\`.
- Postgres / Oracle / Redis / None: \`None\` (durable impls land in BGM-PR-05 / PR-06; Redis out of scope for Phase 1).

**model_gateway/src/config/types.rs**
- \`BackgroundConfig\` struct with 9 operational tuning knobs.
- **No \`background_enabled\` flag** — backend capability (repository \`Some\` / \`None\`) is the gate. Simpler surface than the original design.
- Durations as \`u64\` seconds / milliseconds + accessor methods for \`Duration\` (no new humantime dep).
- Defaults match the design doc (16 workers, 10k queue, 60s lease, 3 retries, 2s→60s backoff, 30s sweep, 500ms poll, 15m stream retention).
- Backward-compatible serde: existing YAML configs keep deserializing unchanged.

**model_gateway/src/app_context.rs**
- \`AppContext.background_repository\` carried via \`AppContextBuilder\` from the factory bundle.

**model_gateway/src/routers/common/background/mod.rs** (new)
- \`BackgroundServices\` placeholder that BGM-PR-04 will populate with shared create / cancel / resume helpers.

**model_gateway/src/routers/grpc/regular/responses/handlers.rs**
- Existing hard rejection of \`background=true\` is preserved with a pointer to BGM-PR-04 where it gets replaced with delegation.
- **No client-visible behavior change in this PR.**

## Why

Avoid shaping the surface area in-flight. Get the config, AppContext wiring, factory, and module boundaries right once; then PR-04 just fills in the create handler, PR-05 the Postgres backend, PR-06 the Oracle backend. Ships memory alongside to give the trait shape an early stress test and unblock dev/CI workflows.

Memory backend was added per user direction after initial scoping: dev, CI, and single-node deployments benefit from background responses without needing a Postgres container. Non-durability is explicit in the module doc — consistent with how \`MemoryResponseStorage\` already treats synchronous responses.

## How

\`background_enabled\` flag dropped during review after the observation that backend capability already gates availability — having both is redundant and creates a misconfiguration surface where the flag contradicts the repository presence.

Fixed-name constants (\`BG_QUEUE_*\`, \`STREAM_CHUNKS_*\`) on the durable migrations in BGM-PR-02 already made the repository boundary explicit; this PR just carries that pattern into the gateway layer via \`BackgroundServices\`.

## Test plan

- [x] \`cargo +nightly fmt --all\` — clean
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` — clean
- [x] \`cargo test -p data-connector --lib\` — **269 passed**, 0 failed (14 new for \`MemoryBackgroundRepository\`)
- [x] \`cargo test -p smg --lib\` — **601 passed**, 0 failed (3 new for \`BackgroundConfig\`)
- [x] Verified Python bindings use \`RouterConfig::builder()\` — no struct literal to update

Refs: BGM-PR-01 #1244, BGM-PR-02 #1258

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Background task processing system for asynchronous job execution with automatic queueing, worker lease management, heartbeat monitoring, configurable retry logic, and cancellation support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->