### PR TITLE
feat(protocols): implement I2 item_reference input item

### DIFF
--- a/crates/protocols/src/responses.rs
+++ b/crates/protocols/src/responses.rs
@@ -1650,6 +1650,43 @@ pub enum ResponseInputOutputItem {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         phase: Option<MessagePhase>,
     },
+    /// `type: "item_reference"` — pointer to a previously-stored item in the
+    /// active conversation. Spec (openai-responses-api-spec.md §InputItemList
+    /// L275-276): `ItemReference { id, type }` where `type` is
+    /// `optional "item_reference"`. The variant is declared as
+    /// `#[serde(untagged)]` because the `type` discriminator is optional on
+    /// the wire; `r#type` is pinned to [`ItemReferenceTypeTag`] so payloads
+    /// whose `type` is not `"item_reference"` (e.g. `"totally_made_up"`) do
+    /// not silently land in this catch-all variant — P5 fail-fast contract.
+    ///
+    /// Declared AFTER [`Self::SimpleInputMessage`] so a `{id, role, content}`
+    /// payload (the id-carrying shape of `SimpleInputMessage`) still lands in
+    /// `SimpleInputMessage` first; only `{id}` / `{id, type: "item_reference"}`
+    /// payloads — which fail `SimpleInputMessage`'s required-field check —
+    /// fall through to this arm.
+    ///
+    /// Backend resolution (router looks up `id` from conversation history and
+    /// substitutes the referenced item inline) is deferred to a future R
+    /// task; this variant only adds the schema surface.
+    #[serde(untagged)]
+    ItemReference {
+        id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        #[serde(rename = "type")]
+        r#type: Option<ItemReferenceTypeTag>,
+    },
+}
+
+/// Single-value tag enum pinning [`ResponseInputOutputItem::ItemReference`]'s
+/// optional `type` discriminator to the spec's only permitted value,
+/// `"item_reference"`. Used because the outer enum is `type`-tagged and the
+/// `ItemReference` variant is declared `#[serde(untagged)]` to accept payloads
+/// that omit `type` entirely — without this pin the catch-all would silently
+/// swallow payloads whose `type` discriminator is an unknown string.
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, schemars::JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ItemReferenceTypeTag {
+    ItemReference,
 }
 
 /// Single-value tag enum pinning `EasyInputMessage.type` to the spec's only
@@ -2671,7 +2708,8 @@ impl GenerationRequest for ResponsesRequest {
                         | ResponseInputOutputItem::CustomToolCall { .. }
                         | ResponseInputOutputItem::CustomToolCallOutput { .. }
                         | ResponseInputOutputItem::ShellCall { .. }
-                        | ResponseInputOutputItem::ShellCallOutput { .. } => {}
+                        | ResponseInputOutputItem::ShellCallOutput { .. }
+                        | ResponseInputOutputItem::ItemReference { .. } => {}
                     }
                 }
 
@@ -2978,6 +3016,9 @@ fn validate_input_item(item: &ResponseInputOutputItem) -> Result<(), ValidationE
             // contract is the motivating use case for keeping this arm
             // content-agnostic.
         }
+        // I2: schema-only; backend resolution (history lookup +
+        // substitution) is deferred to a future R task.
+        ResponseInputOutputItem::ItemReference { .. } => {}
     }
     Ok(())
 }

--- a/crates/protocols/tests/responses.rs
+++ b/crates/protocols/tests/responses.rs
@@ -2253,6 +2253,27 @@ fn shell_call_input_item_round_trips_spec_shape() {
 }
 
 #[test]
+fn item_reference_input_item_round_trips_with_type() {
+    // Spec (openai-responses-api-spec.md L275-276):
+    // `ItemReference { id, type }` where `type` is `optional "item_reference"`.
+    // The tagged form carries the discriminator explicitly.
+    let payload = json!({
+        "type": "item_reference",
+        "id": "msg_abc123",
+    });
+    let item: ResponseInputOutputItem =
+        serde_json::from_value(payload.clone()).expect("tagged item_reference should deserialize");
+    match &item {
+        ResponseInputOutputItem::ItemReference { id, r#type } => {
+            assert_eq!(id, "msg_abc123");
+            assert_eq!(*r#type, Some(ItemReferenceTypeTag::ItemReference));
+        }
+        other => panic!("expected ItemReference, got {other:?}"),
+    }
+    assert_eq!(serde_json::to_value(&item).expect("serialize"), payload);
+}
+
+#[test]
 fn shell_call_minimal_shape_round_trips() {
     // Spec: `id`, `environment`, `status` are all acceptable as absent on
     // the input side; `action` and `call_id` are the only required fields
@@ -2285,6 +2306,28 @@ fn shell_call_minimal_shape_round_trips() {
         }
         other => panic!("expected ShellCall, got {other:?}"),
     }
+    assert_eq!(serde_json::to_value(&item).expect("serialize"), payload);
+}
+
+#[test]
+fn item_reference_input_item_accepts_missing_type() {
+    // Spec L276: `type: optional "item_reference"` — the discriminator can
+    // be omitted on the wire. Bare `{id}` must still land in the
+    // `ItemReference` variant and not in any other catch-all shape.
+    let payload = json!({
+        "id": "msg_abc123",
+    });
+    let item: ResponseInputOutputItem =
+        serde_json::from_value(payload.clone()).expect("id-only item_reference should deserialize");
+    match &item {
+        ResponseInputOutputItem::ItemReference { id, r#type } => {
+            assert_eq!(id, "msg_abc123");
+            assert!(r#type.is_none());
+        }
+        other => panic!("expected ItemReference, got {other:?}"),
+    }
+    // `r#type: None` is `skip_serializing_if = Option::is_none`, so the
+    // serialized shape round-trips exactly to the id-only payload.
     assert_eq!(serde_json::to_value(&item).expect("serialize"), payload);
 }
 
@@ -2718,4 +2761,45 @@ fn shell_call_output_validation_accepts_empty_output_for_replay() {
         validator::Validate::validate(&request).is_ok(),
         "empty shell_call_output.output must remain valid for lossless replay"
     );
+}
+
+#[test]
+fn item_reference_input_item_rejects_unknown_type_tag() {
+    // Spec L276 constrains `type` to exactly `"item_reference"` when
+    // present. A payload carrying a different `type` must not silently land
+    // in the `ItemReference` variant — the untagged catch-all is pinned to
+    // [`ItemReferenceTypeTag::ItemReference`] for this reason (P5 fail-fast).
+    let payload = json!({
+        "type": "totally_made_up",
+        "id": "msg_abc123",
+    });
+    let result: Result<ResponseInputOutputItem, _> = serde_json::from_value(payload);
+    assert!(
+        result.is_err(),
+        "item_reference must reject unknown `type` discriminator, got: {result:?}"
+    );
+}
+
+#[test]
+fn simple_input_message_with_id_does_not_match_item_reference() {
+    // Regression: `ItemReference` is declared after `SimpleInputMessage` in
+    // the untagged fallback chain, so a `{id, role, content}` payload — the
+    // id-carrying shape of [`ResponseInputOutputItem::SimpleInputMessage`] —
+    // lands in `SimpleInputMessage` first and does NOT silently drop
+    // `role` / `content` by matching the bare-`id` `ItemReference` arm
+    // behind it.
+    let payload = json!({
+        "id": "msg_abc123",
+        "role": "user",
+        "content": "hello",
+    });
+    let item: ResponseInputOutputItem =
+        serde_json::from_value(payload).expect("message-shaped payload with id must deserialize");
+    match &item {
+        ResponseInputOutputItem::SimpleInputMessage { role, content, .. } => {
+            assert_eq!(role, "user");
+            assert!(matches!(content, StringOrContentParts::String(s) if s == "hello"));
+        }
+        other => panic!("expected SimpleInputMessage, got {other:?}"),
+    }
 }

--- a/model_gateway/benches/routing_allocation_bench.rs
+++ b/model_gateway/benches/routing_allocation_bench.rs
@@ -76,6 +76,7 @@ fn extract_text_for_routing_old(req: &ResponsesRequest) -> String {
                 | ResponseInputOutputItem::CustomToolCallOutput { .. } => None,
                 ResponseInputOutputItem::ShellCall { .. }
                 | ResponseInputOutputItem::ShellCallOutput { .. } => None,
+                ResponseInputOutputItem::ItemReference { .. } => None,
             })
             .collect::<Vec<String>>()
             .join(" "),

--- a/model_gateway/src/routers/grpc/harmony/builder.rs
+++ b/model_gateway/src/routers/grpc/harmony/builder.rs
@@ -745,7 +745,8 @@ impl HarmonyBuilder {
                 Err("Unsupported input item type".to_string())
             }
 
-            ResponseInputOutputItem::Compaction { .. } => {
+            ResponseInputOutputItem::Compaction { .. }
+            | ResponseInputOutputItem::ItemReference { .. } => {
                 Err("Unsupported input item type".to_string())
             }
 

--- a/model_gateway/src/routers/grpc/regular/responses/conversions.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/conversions.rs
@@ -159,7 +159,8 @@ pub(crate) fn responses_to_chat(req: &ResponsesRequest) -> Result<ChatCompletion
                         );
                         return Err("Unsupported input item type".to_string());
                     }
-                    ResponseInputOutputItem::Compaction { .. } => {
+                    ResponseInputOutputItem::Compaction { .. }
+                    | ResponseInputOutputItem::ItemReference { .. } => {
                         return Err("Unsupported input item type".to_string());
                     }
                     ResponseInputOutputItem::CustomToolCall { .. }


### PR DESCRIPTION
## Description

### Problem

Per the audit plan (`.claude/_audit/responses-api-gap-audit.md` §I2), the
OpenAI Responses API spec defines an `ItemReference` input item shape —
`{ id, type: optional "item_reference" }` — that lets clients refer to a
previously-stored item in the active conversation by id, rather than
resending the full item contents. smg's `ResponseInputOutputItem` did
not model this variant, so such payloads could only be parsed by
accident (falling into the untagged `SimpleInputMessage` catch-all and
silently dropping the `id`), and there was no type-safe way to branch
on `ItemReference` in router code.

### Solution

Adds a new `ResponseInputOutputItem::ItemReference { id, r#type }`
variant (schema only) plus an `ItemReferenceTypeTag` single-value tag
enum that pins `type` to `"item_reference"` when present.

This is a protocol-only change. Backend resolution — the router looking
up `id` from conversation history via `history.rs` and substituting the
referenced item inline before dispatching to the backend — is
explicitly **deferred to a future R task** per the audit plan (§I2
`Backend impact`). This PR only enlarges the schema surface so later
work can branch on the variant cleanly.

Ref: spec §InputItemList L275-276 (`ItemReference { id, type }` where
`type` is `optional "item_reference"`).

## Changes

- `crates/protocols/src/responses.rs`
  - New `ResponseInputOutputItem::ItemReference { id: String, r#type: Option<ItemReferenceTypeTag> }`
    variant, declared `#[serde(untagged)]` after `SimpleInputMessage`.
  - New `ItemReferenceTypeTag` enum pinning the optional discriminator
    to `"item_reference"` (mirrors the `SimpleInputMessageTypeTag`
    pattern).
  - `extract_text_for_routing` cascade arm updated — `ItemReference`
    joins the existing neutral `{}` catch-all (no new branch, no logging).
  - `validate_input_item` gets a single no-op `ItemReference` arm so the
    validator stays exhaustive.

- Router forced-cascade arms (1 line each, no new `warn!` / `Err`
  blocks — `ItemReference` joins the existing `Compaction` arm that
  already returns `Err("Unsupported input item type")`):
  - `model_gateway/src/routers/grpc/regular/responses/conversions.rs`
  - `model_gateway/src/routers/grpc/harmony/builder.rs`
  - `model_gateway/benches/routing_allocation_bench.rs` (`None` arm)

- `crates/protocols/tests/responses.rs` — four new integration tests
  (see Test plan).

## Design notes

- **Why untagged, not tagged-with-rename**: the spec says `type` is
  optional, so `{id}` alone must still land in `ItemReference`. A
  `#[serde(tag = "type")]`-dispatched variant requires `type` to match
  the rename; only an untagged variant can accept both `{id}` and
  `{id, type: "item_reference"}`.
- **Why the tag-enum pin**: without `Option<ItemReferenceTypeTag>` an
  untagged variant would silently swallow payloads whose `type` is an
  unknown string (e.g. `{id, type: "totally_made_up"}`), violating the
  P5 fail-fast contract established for `SimpleInputMessage`.
- **Why declared AFTER `SimpleInputMessage`**: serde tries untagged
  variants in declaration order. A `{id, role, content}` payload (the
  id-carrying shape of `SimpleInputMessage`) must still land in
  `SimpleInputMessage` — not have `role` and `content` silently
  discarded by a bare-`id` match ahead of it. Placing `ItemReference`
  after `SimpleInputMessage` forces serde to try the stricter
  (role + content-required) variant first; only `{id}` / `{id, type}`
  payloads, which fail `SimpleInputMessage`, fall through.

## Test plan

Four integration tests in `crates/protocols/tests/responses.rs`:

- `item_reference_input_item_round_trips_with_type` — `{type: "item_reference", id}`
  deserializes into `ItemReference { id, r#type: Some(ItemReferenceTypeTag::ItemReference) }`
  and serializes back byte-for-byte.
- `item_reference_input_item_accepts_missing_type` — bare `{id}`
  deserializes into `ItemReference { id, r#type: None }` and
  re-serializes to the same id-only payload (`skip_serializing_if =
  Option::is_none` on `r#type`).
- `item_reference_input_item_rejects_unknown_type_tag` —
  `{id, type: "totally_made_up"}` fails to deserialize because the
  `ItemReferenceTypeTag` pin rejects unknown values (P5 fail-fast).
- `simple_input_message_with_id_does_not_match_item_reference` —
  regression test: `{id, role, content}` still lands in
  `SimpleInputMessage`, confirming the declaration-order ordering is
  correct.

Gates run in the worktree (`CARGO_TARGET_DIR=/Users/simolin/.cargo/target`):

- `cargo check -p openai-protocol --tests` — clean
- `cargo check -p smg --tests --benches` — clean
- `cargo test -p openai-protocol` — 63 tests pass in `tests/responses.rs`
  (60 pre-existing + my 3 I2 + 1 regression), plus all other crate
  tests green
- `cargo test -p smg --lib` — 598 tests pass, 4 ignored
- `cargo test -p smg --test spec_test` — 95 pass, 1 ignored
- `cargo fmt -p openai-protocol -p smg -- --check` — clean
- `cargo clippy -p openai-protocol -p smg --tests --benches -- -D warnings` — clean

No source code outside the protocol + forced-cascade arms was
modified. Backend resolution is deferred to a future R task per the
audit scope.

Refs: `.claude/_audit/responses-api-gap-audit.md` §I2 (L643-653);
`.claude/_audit/openai-responses-api-spec.md` L275-276.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for an ItemReference type in response schemas to represent referenced items in structured responses.

* **Behavior Changes**
  * Item references are treated as non-text (excluded from text extraction) and are explicitly rejected by some conversion paths to prevent misrouting/substitution.

* **Tests**
  * Added tests for serialization/deserialization, optional discriminator handling, error cases, and a regression ensuring message-shaped payloads are not misrouted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->