### PR TITLE
feat(protocols): implement T6 shell (containerized) tool + call/output items

### DIFF
--- a/crates/mcp/src/core/session.rs
+++ b/crates/mcp/src/core/session.rs
@@ -561,6 +561,8 @@ impl<'a> McpToolSession<'a> {
             | ResponseOutputItem::ImageGenerationCall { .. }
             | ResponseOutputItem::ComputerCall { .. }
             | ResponseOutputItem::ComputerCallOutput { .. }
+            | ResponseOutputItem::ShellCall { .. }
+            | ResponseOutputItem::ShellCallOutput { .. }
             | ResponseOutputItem::Message { .. }
             | ResponseOutputItem::Reasoning { .. }
             | ResponseOutputItem::Compaction { .. } => true,

--- a/crates/protocols/src/responses.rs
+++ b/crates/protocols/src/responses.rs
@@ -413,6 +413,16 @@ pub enum ResponseTool {
     /// hosted/built-in tools are explicitly not permitted as elements.
     #[serde(rename = "namespace")]
     Namespace(NamespaceToolDef),
+
+    /// Containerized `shell` tool. Distinct from `local_shell` — the model
+    /// issues `shell_call` items scoped to an optional
+    /// [`ShellEnvironment`] (container-auto, local, or existing container
+    /// reference).
+    ///
+    /// Spec (openai-responses-api-spec.md §tools, L463-470):
+    /// `Shell { type: "shell", environment? }`.
+    #[serde(rename = "shell")]
+    Shell(ShellTool),
 }
 
 /// Payload carried by [`ResponseTool::Namespace`].
@@ -686,6 +696,234 @@ pub enum CustomToolCallOutputContent {
     /// Array of input-typed content parts (`input_text` / `input_image` /
     /// `input_file`) per the spec's `output` array shape.
     Parts(Vec<CustomToolInputContentPart>),
+}
+
+/// Containerized `shell` tool. Spec
+/// (openai-responses-api-spec.md §tools, L463-470):
+/// `Shell { type: "shell", environment? }`.
+///
+/// The discriminator (`type: "shell"`) is enforced by the parent
+/// [`ResponseTool`] enum; this struct carries only the optional environment
+/// payload so the flatten-style wire shape survives a round-trip.
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Clone, Default, Deserialize, Serialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ShellTool {
+    /// Optional environment scope for the shell tool. When omitted, the
+    /// model runs commands inside the platform-default environment.
+    pub environment: Option<ShellEnvironment>,
+}
+
+/// Tool-side environment union carried on [`ShellTool::environment`].
+///
+/// Spec (openai-responses-api-spec.md §tools, L464-470):
+/// `environment: ContainerAuto | LocalEnvironment | ContainerReference`.
+///
+/// Distinct from the response-side [`ShellCallEnvironment`] union: the tool
+/// form permits the `container_auto` variant, which asks the platform to
+/// provision a new container; the call form only carries the resolved
+/// `local` / `container_reference` shape that the model echoes back.
+#[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
+#[serde(tag = "type")]
+pub enum ShellEnvironment {
+    /// `type: "container_auto"` — spec L465-468. Requests a
+    /// platform-provisioned container with optional `file_ids`,
+    /// `memory_limit`, `network_policy`, and `skills`.
+    #[serde(rename = "container_auto")]
+    ContainerAuto(ContainerAutoEnvironment),
+    /// `type: "local"` — spec L469. Runs in the caller-owned environment,
+    /// optionally carrying a `skills` attachment list
+    /// ([`ResponsesSkillEntry`] already accepts both the typed and opaque
+    /// skill object shapes).
+    #[serde(rename = "local")]
+    Local(LocalShellEnvironment),
+    /// `type: "container_reference"` — spec L470. Pins execution to an
+    /// existing container by id.
+    #[serde(rename = "container_reference")]
+    ContainerReference(ContainerReferenceEnvironment),
+}
+
+/// Payload for [`ShellEnvironment::ContainerAuto`]. All fields are optional
+/// per spec.
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Clone, Default, Deserialize, Serialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ContainerAutoEnvironment {
+    /// Files pre-mounted into the container by id.
+    pub file_ids: Option<Vec<String>>,
+    /// Memory budget. Spec (CodeInterpreter §447): `"1g"|"4g"|"16g"|"64g"`
+    /// — kept `String`-typed here for forward compatibility with future tiers.
+    pub memory_limit: Option<String>,
+    /// Network isolation policy.
+    pub network_policy: Option<ContainerNetworkPolicy>,
+    /// Skill attachments. Reuses [`ResponsesSkillEntry`] — the same union
+    /// the `/v1/responses` tool surfaces accept for CodeInterpreter, which
+    /// covers both typed `skill_reference` / `local` shapes and opaque
+    /// provider-owned objects.
+    pub skills: Option<Vec<ResponsesSkillEntry>>,
+}
+
+/// Payload for [`ShellEnvironment::Local`]. Only `skills` is permitted per
+/// spec.
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Clone, Default, Deserialize, Serialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct LocalShellEnvironment {
+    /// Optional skill attachments carried into the local environment.
+    pub skills: Option<Vec<ResponsesSkillEntry>>,
+}
+
+/// Payload for [`ShellEnvironment::ContainerReference`]. Pins the tool to
+/// an existing container id.
+#[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ContainerReferenceEnvironment {
+    /// Existing container id.
+    pub container_id: String,
+}
+
+/// Network isolation policy for [`ContainerAutoEnvironment::network_policy`].
+///
+/// Spec (openai-responses-api-spec.md §tools, L448):
+/// `ContainerNetworkPolicyDisabled { type: "disabled" } |
+/// ContainerNetworkPolicyAllowlist { allowed_domains, type: "allowlist",
+/// domain_secrets? }`.
+#[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
+#[serde(tag = "type")]
+pub enum ContainerNetworkPolicy {
+    /// `type: "disabled"` — no outbound network access.
+    #[serde(rename = "disabled")]
+    Disabled,
+    /// `type: "allowlist"` — only the listed domains are reachable.
+    #[serde(rename = "allowlist")]
+    Allowlist(ContainerNetworkAllowlist),
+}
+
+/// Payload for [`ContainerNetworkPolicy::Allowlist`].
+///
+/// Spec (openai-responses-api-spec.md §tools, L448-449):
+/// `{ allowed_domains, type: "allowlist", domain_secrets? }` where
+/// `domain_secrets: array of { domain, name, value }`.
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ContainerNetworkAllowlist {
+    /// Outbound-reachable hostnames.
+    pub allowed_domains: Vec<String>,
+    /// Optional per-domain secret bindings.
+    pub domain_secrets: Option<Vec<ContainerDomainSecret>>,
+}
+
+/// Per-domain secret binding carried by
+/// [`ContainerNetworkAllowlist::domain_secrets`].
+#[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ContainerDomainSecret {
+    /// Target domain the secret applies to.
+    pub domain: String,
+    /// Secret identifier / lookup name.
+    pub name: String,
+    /// Secret value.
+    pub value: String,
+}
+
+/// Response-side environment union carried on
+/// [`ResponseInputOutputItem::ShellCall`] / [`ResponseOutputItem::ShellCall`].
+///
+/// Spec (openai-responses-api-spec.md §ShellCall, L228-231 and §returns,
+/// L512-513): only the resolved `local` / `container_reference` shapes are
+/// echoed back by the model — `container_auto` is a request-side hint that
+/// the platform resolves into one of these two before the call is surfaced.
+#[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
+#[serde(tag = "type")]
+pub enum ShellCallEnvironment {
+    /// `type: "local"` — resolved local environment, mirrors the tool-form
+    /// [`LocalShellEnvironment`].
+    #[serde(rename = "local")]
+    Local(LocalShellEnvironment),
+    /// `type: "container_reference"` — resolved container binding.
+    #[serde(rename = "container_reference")]
+    ContainerReference(ContainerReferenceEnvironment),
+}
+
+/// Action payload for [`ResponseInputOutputItem::ShellCall`] /
+/// [`ResponseOutputItem::ShellCall`].
+///
+/// Spec (openai-responses-api-spec.md §ShellCall, L229):
+/// `action: { commands, max_output_length?, timeout_ms? }`.
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ShellCallAction {
+    /// Command line to run inside the environment, as a positional-argv
+    /// array (equivalent to `argv` of `execve`).
+    pub commands: Vec<String>,
+    /// Optional cap on captured stdout / stderr bytes.
+    pub max_output_length: Option<u64>,
+    /// Optional per-command timeout in milliseconds.
+    pub timeout_ms: Option<u64>,
+}
+
+/// Status for [`ResponseInputOutputItem::ShellCall`] /
+/// [`ResponseOutputItem::ShellCall`] and their `*_output` siblings.
+///
+/// Spec (openai-responses-api-spec.md §ShellCall, L221+L238):
+/// `status: "in_progress" | "completed" | "incomplete"`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, schemars::JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ShellCallStatus {
+    /// `in_progress` — call is still executing.
+    InProgress,
+    /// `completed` — call finished and `output` chunks are final.
+    Completed,
+    /// `incomplete` — call aborted or never reached completion.
+    Incomplete,
+}
+
+/// One entry of a `shell_call_output.output` array.
+///
+/// Spec (openai-responses-api-spec.md §ShellCallOutput, L234-238):
+/// `{ outcome, stderr, stdout }` plus the optional `created_by` marker
+/// mirroring the same tag on `FunctionCallOutput`/`ComputerCallOutput` for
+/// provenance.
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ShellOutputChunk {
+    /// Call outcome — timeout or numeric exit.
+    pub outcome: ShellOutcome,
+    /// Captured stderr bytes (UTF-8 where possible).
+    pub stderr: String,
+    /// Captured stdout bytes (UTF-8 where possible).
+    pub stdout: String,
+    /// Optional provenance marker — `"system"`, `"user"`, or similar per
+    /// spec. Kept `Option<String>` for forward-compatibility with future
+    /// `created_by` tags.
+    pub created_by: Option<String>,
+}
+
+/// Outcome of a shell call. Spec (openai-responses-api-spec.md
+/// §ShellCallOutput, L235):
+/// `outcome: Timeout { type: "timeout" } | Exit { exit_code, type: "exit" }`.
+#[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
+#[serde(tag = "type")]
+pub enum ShellOutcome {
+    /// `type: "timeout"` — the call exceeded `action.timeout_ms` and was
+    /// killed by the environment.
+    #[serde(rename = "timeout")]
+    Timeout,
+    /// `type: "exit"` — the process exited, carrying the numeric exit code.
+    #[serde(rename = "exit")]
+    Exit(ShellExit),
+}
+
+/// Exit payload for [`ShellOutcome::Exit`]. Spec: `{ exit_code, type: "exit" }`.
+#[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ShellExit {
+    /// Process exit code. Signed to preserve negative error codes on
+    /// platforms that report them.
+    pub exit_code: i32,
 }
 
 #[serde_with::skip_serializing_none]
@@ -1283,6 +1521,46 @@ pub enum ResponseInputOutputItem {
         #[serde(skip_serializing_if = "Option::is_none")]
         id: Option<String>,
     },
+    /// `type: "shell_call"` — assistant's call into the containerized
+    /// [`ResponseTool::Shell`] tool.
+    ///
+    /// Spec (openai-responses-api-spec.md §ShellCall, L228-231):
+    /// `{ action, call_id, type, id, environment, status }`. `id` is
+    /// `Option<String>` so newly-minted client-side calls can omit it;
+    /// the model populates it on items round-tripped from a previous
+    /// response.
+    #[serde(rename = "shell_call")]
+    ShellCall {
+        action: ShellCallAction,
+        call_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        id: Option<String>,
+        /// Resolved execution environment. Spec constrains this to
+        /// `local` or `container_reference` on the call form (see
+        /// [`ShellCallEnvironment`] docs).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        environment: Option<ShellCallEnvironment>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        status: Option<ShellCallStatus>,
+    },
+    /// `type: "shell_call_output"` — client's reply to a `shell_call`.
+    ///
+    /// Spec (openai-responses-api-spec.md §ShellCallOutput, L233-238):
+    /// `{ call_id, output, type, id, max_output_length, status }`.
+    /// `id` and `max_output_length` are modelled as `Option` so
+    /// newly-minted client replies can omit them; the server populates
+    /// both on items round-tripped from a previous response.
+    #[serde(rename = "shell_call_output")]
+    ShellCallOutput {
+        call_id: String,
+        output: Vec<ShellOutputChunk>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        id: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        max_output_length: Option<u64>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        status: Option<ShellCallStatus>,
+    },
     #[serde(untagged)]
     SimpleInputMessage {
         content: StringOrContentParts,
@@ -1592,6 +1870,40 @@ pub enum ResponseOutputItem {
         acknowledged_safety_checks: Vec<ComputerSafetyCheck>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         status: Option<ComputerCallStatus>,
+    },
+    /// `type: "shell_call"` — output-side mirror of the input variant.
+    ///
+    /// Spec (openai-responses-api-spec.md §ShellCall, L228-231 and §returns
+    /// L512-513): emitted when the model issues a containerized shell
+    /// action. The environment echoed back is restricted to `local` /
+    /// `container_reference` (see [`ShellCallEnvironment`]).
+    #[serde(rename = "shell_call")]
+    ShellCall {
+        action: ShellCallAction,
+        call_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        id: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        environment: Option<ShellCallEnvironment>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        status: Option<ShellCallStatus>,
+    },
+    /// `type: "shell_call_output"` — output-side mirror of the input
+    /// variant.
+    ///
+    /// Spec (openai-responses-api-spec.md §ShellCallOutput, L233-238).
+    /// Emitted when the platform surfaces captured stdout/stderr plus an
+    /// [`ShellOutcome`] for a prior shell call.
+    #[serde(rename = "shell_call_output")]
+    ShellCallOutput {
+        call_id: String,
+        output: Vec<ShellOutputChunk>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        id: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        max_output_length: Option<u64>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        status: Option<ShellCallStatus>,
     },
 }
 
@@ -2267,7 +2579,9 @@ impl GenerationRequest for ResponsesRequest {
                         | ResponseInputOutputItem::ComputerCall { .. }
                         | ResponseInputOutputItem::ComputerCallOutput { .. }
                         | ResponseInputOutputItem::CustomToolCall { .. }
-                        | ResponseInputOutputItem::CustomToolCallOutput { .. } => {}
+                        | ResponseInputOutputItem::CustomToolCallOutput { .. }
+                        | ResponseInputOutputItem::ShellCall { .. }
+                        | ResponseInputOutputItem::ShellCallOutput { .. } => {}
                     }
                 }
 
@@ -2561,6 +2875,19 @@ fn validate_input_item(item: &ResponseInputOutputItem) -> Result<(), ValidationE
             }
             _ => {}
         },
+        // ShellCall is model-generated and echoed back on multi-turn replay;
+        // mirrors FunctionToolCall above with no content validation so a
+        // parameterless shell call can round-trip cleanly.
+        ResponseInputOutputItem::ShellCall { .. } => {}
+        ResponseInputOutputItem::ShellCallOutput { .. } => {
+            // Backend execution is out of scope for T6 (schema-only); the
+            // router returns 501 for shell calls, so SMG never synthesises
+            // a ShellCallOutput itself. Skip content validation here so
+            // round-tripping a previously-recorded response (even with an
+            // empty chunk list) stays lossless — the cross-turn replay
+            // contract is the motivating use case for keeping this arm
+            // content-agnostic.
+        }
     }
     Ok(())
 }

--- a/crates/protocols/src/responses.rs
+++ b/crates/protocols/src/responses.rs
@@ -834,17 +834,35 @@ pub struct ContainerDomainSecret {
 /// L512-513): only the resolved `local` / `container_reference` shapes are
 /// echoed back by the model — `container_auto` is a request-side hint that
 /// the platform resolves into one of these two before the call is surfaced.
+/// Spec L513 explicitly types the response-side local arm as
+/// `ResponseLocalEnvironment { type: "local" }` (no `skills` attachment on
+/// the call form) — `skills` is a request-side input on the tool, never
+/// echoed back on the resolved call.
 #[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
 #[serde(tag = "type")]
 pub enum ShellCallEnvironment {
-    /// `type: "local"` — resolved local environment, mirrors the tool-form
-    /// [`LocalShellEnvironment`].
+    /// `type: "local"` — resolved local environment on the response-side
+    /// call form. Per spec L513 this is `ResponseLocalEnvironment { type:
+    /// "local" }`, without the `skills` attachment carried on the
+    /// request-side [`LocalShellEnvironment`].
     #[serde(rename = "local")]
-    Local(LocalShellEnvironment),
+    Local(ResponseLocalShellEnvironment),
     /// `type: "container_reference"` — resolved container binding.
     #[serde(rename = "container_reference")]
     ContainerReference(ContainerReferenceEnvironment),
 }
+
+/// Payload for [`ShellCallEnvironment::Local`].
+///
+/// Spec (openai-responses-api-spec.md §returns L513): response-side local
+/// environment is `ResponseLocalEnvironment { type: "local" }` — the
+/// discriminator is the only field the model echoes back. `skills` is a
+/// request-side attachment on [`LocalShellEnvironment`] (tool form) and is
+/// not part of the response-side envelope; modelling it here would let
+/// unknown request fields leak through the response union unchecked.
+#[derive(Debug, Clone, Default, Deserialize, Serialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ResponseLocalShellEnvironment {}
 
 /// Action payload for [`ResponseInputOutputItem::ShellCall`] /
 /// [`ResponseOutputItem::ShellCall`].

--- a/crates/protocols/src/responses.rs
+++ b/crates/protocols/src/responses.rs
@@ -827,39 +827,69 @@ pub struct ContainerDomainSecret {
     pub value: String,
 }
 
-/// Response-side environment union carried on
-/// [`ResponseInputOutputItem::ShellCall`] / [`ResponseOutputItem::ShellCall`].
+/// Input-side environment union carried on
+/// [`ResponseInputOutputItem::ShellCall`].
 ///
-/// Spec (openai-responses-api-spec.md §ShellCall, L228-231 and §returns,
-/// L512-513): only the resolved `local` / `container_reference` shapes are
-/// echoed back by the model — `container_auto` is a request-side hint that
-/// the platform resolves into one of these two before the call is surfaced.
-/// Spec L513 explicitly types the response-side local arm as
-/// `ResponseLocalEnvironment { type: "local" }` (no `skills` attachment on
-/// the call form) — `skills` is a request-side input on the tool, never
-/// echoed back on the resolved call.
+/// Spec (openai-responses-api-spec.md §ShellCall, L228-230): the input-side
+/// call form carries `environment: optional LocalEnvironment { type: "local",
+/// skills? } | ContainerReference { container_id, type: "container_reference"
+/// }`. `container_auto` is rejected here — it is a request-side *tool*
+/// hint (§tools L465) that the platform resolves into `local` /
+/// `container_reference` before a call is surfaced, not a call-form value.
+///
+/// The tool-side [`LocalShellEnvironment`] is intentionally reused so
+/// spec-compliant replay flows that echo back input call items with their
+/// original `skills` attachment continue to round-trip losslessly.
+/// Response-side emissions use the narrower [`ResponseShellCallEnvironment`]
+/// instead.
 #[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
 #[serde(tag = "type")]
 pub enum ShellCallEnvironment {
-    /// `type: "local"` — resolved local environment on the response-side
-    /// call form. Per spec L513 this is `ResponseLocalEnvironment { type:
-    /// "local" }`, without the `skills` attachment carried on the
-    /// request-side [`LocalShellEnvironment`].
+    /// `type: "local"` — input-side local environment. Spec L230 allows
+    /// `skills?`, so this variant reuses the tool-form
+    /// [`LocalShellEnvironment`] verbatim. Preserves round-trip fidelity
+    /// for clients that replay prior input items carrying skill
+    /// attachments.
     #[serde(rename = "local")]
-    Local(ResponseLocalShellEnvironment),
+    Local(LocalShellEnvironment),
     /// `type: "container_reference"` — resolved container binding.
     #[serde(rename = "container_reference")]
     ContainerReference(ContainerReferenceEnvironment),
 }
 
-/// Payload for [`ShellCallEnvironment::Local`].
+/// Response-side environment union carried on
+/// [`ResponseOutputItem::ShellCall`].
+///
+/// Spec (openai-responses-api-spec.md §returns L512-513): the ShellCall
+/// response form has `environment: ResponseLocalEnvironment { type: "local"
+/// } | ResponseContainerReference { container_id, type: "container_reference"
+/// }`. Unlike the input-side [`ShellCallEnvironment`], the response-side
+/// local arm is `ResponseLocalEnvironment { type: "local" }` with no
+/// `skills` field — skills is a tool/input-side attachment that is not
+/// echoed back on the resolved call.
+#[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
+#[serde(tag = "type")]
+pub enum ResponseShellCallEnvironment {
+    /// `type: "local"` — resolved local environment on the response-side
+    /// call form. Per spec L513 this is `ResponseLocalEnvironment { type:
+    /// "local" }`, without the `skills` attachment carried on the
+    /// input-side [`ShellCallEnvironment::Local`].
+    #[serde(rename = "local")]
+    Local(ResponseLocalShellEnvironment),
+    /// `type: "container_reference"` — resolved container binding.
+    /// Structurally identical to the input-side variant; reused directly.
+    #[serde(rename = "container_reference")]
+    ContainerReference(ContainerReferenceEnvironment),
+}
+
+/// Payload for [`ResponseShellCallEnvironment::Local`].
 ///
 /// Spec (openai-responses-api-spec.md §returns L513): response-side local
 /// environment is `ResponseLocalEnvironment { type: "local" }` — the
 /// discriminator is the only field the model echoes back. `skills` is a
-/// request-side attachment on [`LocalShellEnvironment`] (tool form) and is
-/// not part of the response-side envelope; modelling it here would let
-/// unknown request fields leak through the response union unchecked.
+/// request/input-side attachment on [`LocalShellEnvironment`] and is not
+/// part of the response-side envelope; modelling it here would let
+/// request-only fields leak through the response union unchecked.
 #[derive(Debug, Clone, Default, Deserialize, Serialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct ResponseLocalShellEnvironment {}
@@ -1894,7 +1924,10 @@ pub enum ResponseOutputItem {
     /// Spec (openai-responses-api-spec.md §ShellCall, L228-231 and §returns
     /// L512-513): emitted when the model issues a containerized shell
     /// action. The environment echoed back is restricted to `local` /
-    /// `container_reference` (see [`ShellCallEnvironment`]).
+    /// `container_reference` via [`ResponseShellCallEnvironment`], which
+    /// narrows the input-side [`ShellCallEnvironment`] by dropping the
+    /// `skills` attachment on the `local` arm — per spec L513 the response
+    /// form uses `ResponseLocalEnvironment { type: "local" }` only.
     ///
     /// `id` and `status` are required on the output wire — the server
     /// always populates both when emitting the call, mirroring the
@@ -1908,7 +1941,7 @@ pub enum ResponseOutputItem {
         call_id: String,
         action: ShellCallAction,
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        environment: Option<ShellCallEnvironment>,
+        environment: Option<ResponseShellCallEnvironment>,
         status: ShellCallStatus,
     },
     /// `type: "shell_call_output"` — output-side mirror of the input

--- a/crates/protocols/src/responses.rs
+++ b/crates/protocols/src/responses.rs
@@ -1581,11 +1581,14 @@ pub enum ResponseInputOutputItem {
     /// `type: "shell_call"` — assistant's call into the containerized
     /// [`ResponseTool::Shell`] tool.
     ///
-    /// Spec (openai-responses-api-spec.md §ShellCall, L228-231):
-    /// `{ action, call_id, type, id, environment, status }`. `id` is
-    /// `Option<String>` so newly-minted client-side calls can omit it;
-    /// the model populates it on items round-tripped from a previous
-    /// response.
+    /// Spec (openai-responses-api-spec.md §ShellCall, L228-231) +
+    /// OpenAI SDK v2.8.1 `ResponseFunctionShellToolCall`:
+    /// `{ action, call_id, type, id, environment, status, created_by? }`.
+    /// `id` is `Option<String>` so newly-minted client-side calls can omit
+    /// it; the model populates it on items round-tripped from a previous
+    /// response. `created_by` carries provenance metadata the SDK types
+    /// as `Optional[str]` — present when the item was emitted by the
+    /// platform, absent on client-authored calls.
     #[serde(rename = "shell_call")]
     ShellCall {
         action: ShellCallAction,
@@ -1599,14 +1602,21 @@ pub enum ResponseInputOutputItem {
         environment: Option<ShellCallEnvironment>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         status: Option<ShellCallStatus>,
+        /// Provenance tag mirroring the SDK's `created_by: Optional[str]`
+        /// on `ResponseFunctionShellToolCall`. Dropped at serialize time
+        /// when absent so client-authored calls do not carry a null
+        /// placeholder.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        created_by: Option<String>,
     },
     /// `type: "shell_call_output"` — client's reply to a `shell_call`.
     ///
-    /// Spec (openai-responses-api-spec.md §ShellCallOutput, L233-238):
-    /// `{ call_id, output, type, id, max_output_length, status }`.
-    /// `id` and `max_output_length` are modelled as `Option` so
-    /// newly-minted client replies can omit them; the server populates
-    /// both on items round-tripped from a previous response.
+    /// Spec (openai-responses-api-spec.md §ShellCallOutput, L233-238) +
+    /// OpenAI SDK v2.8.1 `ResponseFunctionShellToolCallOutput`:
+    /// `{ call_id, output, type, id, max_output_length?, status, created_by? }`.
+    /// `id`, `max_output_length`, and `created_by` are modelled as
+    /// `Option` per the SDK's `Optional[...]` typing; the server populates
+    /// them on items round-tripped from a previous response.
     #[serde(rename = "shell_call_output")]
     ShellCallOutput {
         call_id: String,
@@ -1617,6 +1627,10 @@ pub enum ResponseInputOutputItem {
         max_output_length: Option<u64>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         status: Option<ShellCallStatus>,
+        /// Provenance tag mirroring the SDK's `created_by: Optional[str]`
+        /// on `ResponseFunctionShellToolCallOutput`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        created_by: Option<String>,
     },
     #[serde(untagged)]
     SimpleInputMessage {
@@ -1931,19 +1945,19 @@ pub enum ResponseOutputItem {
     /// `type: "shell_call"` — output-side mirror of the input variant.
     ///
     /// Spec (openai-responses-api-spec.md §ShellCall, L228-231 and §returns
-    /// L512-513): emitted when the model issues a containerized shell
-    /// action. The environment echoed back is restricted to `local` /
+    /// L512-513) + OpenAI SDK v2.8.1 `ResponseFunctionShellToolCall`:
+    /// emitted when the model issues a containerized shell action. The
+    /// environment echoed back is restricted to `local` /
     /// `container_reference` via [`ResponseShellCallEnvironment`], which
     /// narrows the input-side [`ShellCallEnvironment`] by dropping the
     /// `skills` attachment on the `local` arm — per spec L513 the response
     /// form uses `ResponseLocalEnvironment { type: "local" }` only.
     ///
-    /// `id` and `status` are required on the output wire — the server
-    /// always populates both when emitting the call, mirroring the
-    /// `ComputerCall` treatment above. Keeping them required at the type
-    /// boundary makes the SDK's non-`Optional` TypedDict contract explicit
-    /// and keeps response-side consumers from having to unwrap fields the
-    /// platform is contractually obligated to emit.
+    /// `id` and `status` are required on the output wire — the SDK types
+    /// them as non-`Optional` on `ResponseFunctionShellToolCall`, mirroring
+    /// the `ComputerCall` treatment above. `created_by` is the SDK's
+    /// `Optional[str]` provenance tag, populated when the platform stamps
+    /// the item.
     #[serde(rename = "shell_call")]
     ShellCall {
         id: String,
@@ -1952,24 +1966,34 @@ pub enum ResponseOutputItem {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         environment: Option<ResponseShellCallEnvironment>,
         status: ShellCallStatus,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        created_by: Option<String>,
     },
     /// `type: "shell_call_output"` — output-side mirror of the input
     /// variant.
     ///
-    /// Spec (openai-responses-api-spec.md §ShellCallOutput, L233-238).
+    /// Spec (openai-responses-api-spec.md §ShellCallOutput, L233-238) +
+    /// OpenAI SDK v2.8.1 `ResponseFunctionShellToolCallOutput`:
+    /// `{ call_id, output, type, id, max_output_length?, status, created_by? }`.
     /// Emitted when the platform surfaces captured stdout/stderr plus an
     /// [`ShellOutcome`] for a prior shell call.
     ///
-    /// `id`, `max_output_length`, and `status` are required on the output
-    /// wire per spec L233 (`{ call_id, output, type, id, max_output_length,
-    /// status }`) — the server always populates all three on emit.
+    /// `id` and `status` are required per the SDK's non-`Optional` typing.
+    /// `max_output_length` is `Optional[int]` in the SDK (the platform may
+    /// emit shell outputs when the originating `shell_call.action` did not
+    /// specify a cap) and `created_by` is `Optional[str]` — both dropped at
+    /// serialize time when absent so downstream consumers do not see null
+    /// placeholders.
     #[serde(rename = "shell_call_output")]
     ShellCallOutput {
         id: String,
         call_id: String,
         output: Vec<ShellOutputChunk>,
-        max_output_length: u64,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        max_output_length: Option<u64>,
         status: ShellCallStatus,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        created_by: Option<String>,
     },
 }
 

--- a/crates/protocols/src/responses.rs
+++ b/crates/protocols/src/responses.rs
@@ -719,9 +719,13 @@ pub struct ShellTool {
 /// Spec (openai-responses-api-spec.md §tools, L464-470):
 /// `environment: ContainerAuto | LocalEnvironment | ContainerReference`.
 ///
-/// Distinct from the response-side [`ShellCallEnvironment`] union: the tool
+/// Distinct from the call-side environment unions
+/// [`ShellCallEnvironment`] (input-side call form, reuses
+/// [`LocalShellEnvironment`] with `skills?`) and
+/// [`ResponseShellCallEnvironment`] (response-side call form, carries the
+/// narrower [`ResponseLocalShellEnvironment`] with no `skills`): the tool
 /// form permits the `container_auto` variant, which asks the platform to
-/// provision a new container; the call form only carries the resolved
+/// provision a new container; both call forms only carry the resolved
 /// `local` / `container_reference` shape that the model echoes back.
 #[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
 #[serde(tag = "type")]

--- a/crates/protocols/src/responses.rs
+++ b/crates/protocols/src/responses.rs
@@ -1877,16 +1877,21 @@ pub enum ResponseOutputItem {
     /// L512-513): emitted when the model issues a containerized shell
     /// action. The environment echoed back is restricted to `local` /
     /// `container_reference` (see [`ShellCallEnvironment`]).
+    ///
+    /// `id` and `status` are required on the output wire — the server
+    /// always populates both when emitting the call, mirroring the
+    /// `ComputerCall` treatment above. Keeping them required at the type
+    /// boundary makes the SDK's non-`Optional` TypedDict contract explicit
+    /// and keeps response-side consumers from having to unwrap fields the
+    /// platform is contractually obligated to emit.
     #[serde(rename = "shell_call")]
     ShellCall {
-        action: ShellCallAction,
+        id: String,
         call_id: String,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        id: Option<String>,
+        action: ShellCallAction,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         environment: Option<ShellCallEnvironment>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        status: Option<ShellCallStatus>,
+        status: ShellCallStatus,
     },
     /// `type: "shell_call_output"` — output-side mirror of the input
     /// variant.
@@ -1894,16 +1899,17 @@ pub enum ResponseOutputItem {
     /// Spec (openai-responses-api-spec.md §ShellCallOutput, L233-238).
     /// Emitted when the platform surfaces captured stdout/stderr plus an
     /// [`ShellOutcome`] for a prior shell call.
+    ///
+    /// `id`, `max_output_length`, and `status` are required on the output
+    /// wire per spec L233 (`{ call_id, output, type, id, max_output_length,
+    /// status }`) — the server always populates all three on emit.
     #[serde(rename = "shell_call_output")]
     ShellCallOutput {
+        id: String,
         call_id: String,
         output: Vec<ShellOutputChunk>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        id: Option<String>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        max_output_length: Option<u64>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        status: Option<ShellCallStatus>,
+        max_output_length: u64,
+        status: ShellCallStatus,
     },
 }
 

--- a/crates/protocols/src/responses.rs
+++ b/crates/protocols/src/responses.rs
@@ -414,10 +414,15 @@ pub enum ResponseTool {
     #[serde(rename = "namespace")]
     Namespace(NamespaceToolDef),
 
-    /// Containerized `shell` tool. Distinct from `local_shell` — the model
-    /// issues `shell_call` items scoped to an optional
-    /// [`ShellEnvironment`] (container-auto, local, or existing container
-    /// reference).
+    /// Containerized `shell` tool. Distinct from `local_shell` — the tool
+    /// definition itself may carry an optional [`ShellEnvironment`]
+    /// (container-auto, local, or existing container reference) that the
+    /// platform resolves into a concrete execution target. Emitted
+    /// `shell_call` items use the narrower call-side unions
+    /// [`ShellCallEnvironment`] (input path) and
+    /// [`ResponseShellCallEnvironment`] (response path), which drop the
+    /// `container_auto` variant and (on the response path) the tool-side
+    /// `skills` attachment.
     ///
     /// Spec (openai-responses-api-spec.md §tools, L463-470):
     /// `Shell { type: "shell", environment? }`.

--- a/crates/protocols/tests/responses.rs
+++ b/crates/protocols/tests/responses.rs
@@ -2383,6 +2383,55 @@ fn shell_call_output_item_round_trips_on_response_side() {
 }
 
 #[test]
+fn shell_call_container_reference_on_response_side_round_trip() {
+    // Spec (openai-responses-api-spec.md §returns L512-513): the
+    // response-side shell_call environment covers both `local` and
+    // `container_reference`. The sibling
+    // `shell_call_output_item_round_trips_on_response_side` test only
+    // exercises the `Local` arm; this fixture closes coverage for
+    // [`ResponseShellCallEnvironment::ContainerReference`] so a broken
+    // container_reference arm can't slip through the suite even though
+    // the input- and response-side enums are intentionally distinct.
+    let payload = json!({
+        "type": "shell_call",
+        "id": "sc_20",
+        "call_id": "call_shell_20",
+        "action": {"commands": ["echo", "ok"]},
+        "environment": {
+            "type": "container_reference",
+            "container_id": "container_xyz"
+        },
+        "status": "completed"
+    });
+
+    let item: ResponseOutputItem = serde_json::from_value(payload.clone())
+        .expect("response-side shell_call w/ container_reference should deserialize");
+    match &item {
+        ResponseOutputItem::ShellCall {
+            id,
+            call_id,
+            environment,
+            status,
+            ..
+        } => {
+            assert_eq!(id, "sc_20");
+            assert_eq!(call_id, "call_shell_20");
+            match environment.as_ref().expect("env present") {
+                ResponseShellCallEnvironment::ContainerReference(r) => {
+                    assert_eq!(r.container_id, "container_xyz");
+                }
+                ResponseShellCallEnvironment::Local(_) => {
+                    panic!("expected ContainerReference env, got Local")
+                }
+            }
+            assert_eq!(*status, ShellCallStatus::Completed);
+        }
+        other => panic!("expected ResponseOutputItem::ShellCall, got {other:?}"),
+    }
+    assert_eq!(serde_json::to_value(&item).expect("serialize"), payload);
+}
+
+#[test]
 fn shell_call_output_response_side_round_trip() {
     // Mirror of shell_call_output_input_item_round_trips_spec_shape but
     // deserialized into [`ResponseOutputItem`] to prove the output union

--- a/crates/protocols/tests/responses.rs
+++ b/crates/protocols/tests/responses.rs
@@ -2361,11 +2361,13 @@ fn shell_call_output_item_round_trips_on_response_side() {
         .expect("response-side shell_call should deserialize");
     match &item {
         ResponseOutputItem::ShellCall {
+            id,
             call_id,
             environment,
             status,
             ..
         } => {
+            assert_eq!(id, "sc_10");
             assert_eq!(call_id, "call_shell_10");
             match environment.as_ref().expect("env present") {
                 ShellCallEnvironment::Local(local) => assert!(local.skills.is_none()),
@@ -2373,7 +2375,7 @@ fn shell_call_output_item_round_trips_on_response_side() {
                     panic!("expected Local env, got ContainerReference")
                 }
             }
-            assert_eq!(*status, Some(ShellCallStatus::Completed));
+            assert_eq!(*status, ShellCallStatus::Completed);
         }
         other => panic!("expected ResponseOutputItem::ShellCall, got {other:?}"),
     }
@@ -2384,7 +2386,8 @@ fn shell_call_output_item_round_trips_on_response_side() {
 fn shell_call_output_response_side_round_trip() {
     // Mirror of shell_call_output_input_item_round_trips_spec_shape but
     // deserialized into [`ResponseOutputItem`] to prove the output union
-    // accepts the same wire shape.
+    // accepts the same wire shape. The response-side variant requires `id`,
+    // `max_output_length`, and `status` per spec L233.
     let payload = json!({
         "type": "shell_call_output",
         "id": "sco_10",
@@ -2396,6 +2399,7 @@ fn shell_call_output_response_side_round_trip() {
                 "stdout": ""
             }
         ],
+        "max_output_length": 65536,
         "status": "incomplete"
     });
 
@@ -2403,15 +2407,16 @@ fn shell_call_output_response_side_round_trip() {
         .expect("response-side shell_call_output should deserialize");
     match &item {
         ResponseOutputItem::ShellCallOutput {
+            id,
             call_id,
             output,
             status,
             max_output_length,
-            ..
         } => {
+            assert_eq!(id, "sco_10");
             assert_eq!(call_id, "call_shell_10");
-            assert_eq!(*status, Some(ShellCallStatus::Incomplete));
-            assert!(max_output_length.is_none());
+            assert_eq!(*status, ShellCallStatus::Incomplete);
+            assert_eq!(*max_output_length, 65536);
             assert_eq!(output.len(), 1);
             match &output[0].outcome {
                 ShellOutcome::Exit(e) => assert_eq!(e.exit_code, 2),

--- a/crates/protocols/tests/responses.rs
+++ b/crates/protocols/tests/responses.rs
@@ -2027,3 +2027,425 @@ fn test_custom_tool_call_output_validation_rejects_empty_text_and_parts() {
         "non-empty CustomToolCallOutput must validate",
     );
 }
+
+// ---------------------------------------------------------------------------
+// T6 — containerized `shell` tool + call/output items
+// ---------------------------------------------------------------------------
+
+#[test]
+fn shell_tool_no_environment_round_trip() {
+    // Spec (openai-responses-api-spec.md §tools, L463-464):
+    // `Shell { type: "shell", environment? }`. Environment is optional.
+    let payload = json!({
+        "type": "shell",
+    });
+    let tool: ResponseTool =
+        serde_json::from_value(payload.clone()).expect("shell tool w/o env should deserialize");
+    match &tool {
+        ResponseTool::Shell(s) => assert!(s.environment.is_none()),
+        other => panic!("expected ResponseTool::Shell, got {other:?}"),
+    }
+    assert_eq!(serde_json::to_value(&tool).expect("serialize"), payload);
+}
+
+#[test]
+fn shell_tool_container_auto_environment_round_trip() {
+    // Spec (openai-responses-api-spec.md §tools, L465-468):
+    // `ContainerAuto { type: "container_auto", file_ids?, memory_limit?,
+    //  network_policy?, skills? }`.
+    let payload = json!({
+        "type": "shell",
+        "environment": {
+            "type": "container_auto",
+            "file_ids": ["file_001", "file_002"],
+            "memory_limit": "4g",
+            "network_policy": {
+                "type": "allowlist",
+                "allowed_domains": ["api.github.com", "pypi.org"],
+                "domain_secrets": [
+                    {"domain": "api.github.com", "name": "GH_TOKEN", "value": "sk-abc"}
+                ]
+            },
+            "skills": [
+                {"type": "skill_reference", "skill_id": "skill_123", "version": "latest"}
+            ]
+        }
+    });
+
+    let tool: ResponseTool = serde_json::from_value(payload.clone())
+        .expect("shell tool w/ container_auto env should deserialize");
+    match &tool {
+        ResponseTool::Shell(s) => match &s.environment {
+            Some(ShellEnvironment::ContainerAuto(auto)) => {
+                assert_eq!(
+                    auto.file_ids.as_deref(),
+                    Some(&["file_001".into(), "file_002".into()][..])
+                );
+                assert_eq!(auto.memory_limit.as_deref(), Some("4g"));
+                match auto
+                    .network_policy
+                    .as_ref()
+                    .expect("network_policy present")
+                {
+                    ContainerNetworkPolicy::Allowlist(a) => {
+                        assert_eq!(a.allowed_domains, vec!["api.github.com", "pypi.org"]);
+                        let secrets = a.domain_secrets.as_ref().expect("domain_secrets present");
+                        assert_eq!(secrets.len(), 1);
+                        assert_eq!(secrets[0].domain, "api.github.com");
+                        assert_eq!(secrets[0].name, "GH_TOKEN");
+                        assert_eq!(secrets[0].value, "sk-abc");
+                    }
+                    ContainerNetworkPolicy::Disabled => {
+                        panic!("expected Allowlist policy, got Disabled")
+                    }
+                }
+                let skills = auto.skills.as_ref().expect("skills present");
+                assert_eq!(skills.len(), 1);
+            }
+            other => panic!("expected ContainerAuto, got {other:?}"),
+        },
+        other => panic!("expected ResponseTool::Shell, got {other:?}"),
+    }
+
+    assert_eq!(serde_json::to_value(&tool).expect("serialize"), payload);
+}
+
+#[test]
+fn shell_tool_container_auto_disabled_network_policy_round_trip() {
+    // Spec (openai-responses-api-spec.md §tools, L448):
+    // `ContainerNetworkPolicyDisabled { type: "disabled" }` carries no fields.
+    let payload = json!({
+        "type": "shell",
+        "environment": {
+            "type": "container_auto",
+            "network_policy": {"type": "disabled"}
+        }
+    });
+    let tool: ResponseTool = serde_json::from_value(payload.clone())
+        .expect("shell tool w/ disabled network policy should deserialize");
+    match &tool {
+        ResponseTool::Shell(s) => match &s.environment {
+            Some(ShellEnvironment::ContainerAuto(auto)) => {
+                assert!(matches!(
+                    auto.network_policy.as_ref().expect("policy present"),
+                    ContainerNetworkPolicy::Disabled
+                ));
+            }
+            other => panic!("expected ContainerAuto env, got {other:?}"),
+        },
+        other => panic!("expected ResponseTool::Shell, got {other:?}"),
+    }
+    assert_eq!(serde_json::to_value(&tool).expect("serialize"), payload);
+}
+
+#[test]
+fn shell_tool_local_environment_round_trip() {
+    // Spec (openai-responses-api-spec.md §tools, L469):
+    // `LocalEnvironment { type: "local", skills? }` with `LocalSkill`
+    // members `{ description, name, path }`.
+    let payload = json!({
+        "type": "shell",
+        "environment": {
+            "type": "local",
+            "skills": [
+                {
+                    "type": "local",
+                    "name": "fmt",
+                    "description": "Run rustfmt",
+                    "path": "/usr/local/bin/rustfmt"
+                }
+            ]
+        }
+    });
+
+    let tool: ResponseTool = serde_json::from_value(payload.clone())
+        .expect("shell tool w/ local env should deserialize");
+    match &tool {
+        ResponseTool::Shell(s) => match &s.environment {
+            Some(ShellEnvironment::Local(local)) => {
+                let skills = local.skills.as_ref().expect("skills present");
+                assert_eq!(skills.len(), 1);
+            }
+            other => panic!("expected Local env, got {other:?}"),
+        },
+        other => panic!("expected ResponseTool::Shell, got {other:?}"),
+    }
+
+    assert_eq!(serde_json::to_value(&tool).expect("serialize"), payload);
+}
+
+#[test]
+fn shell_tool_container_reference_environment_round_trip() {
+    // Spec (openai-responses-api-spec.md §tools, L470):
+    // `ContainerReference { container_id, type: "container_reference" }`.
+    let payload = json!({
+        "type": "shell",
+        "environment": {
+            "type": "container_reference",
+            "container_id": "container_abc123"
+        }
+    });
+
+    let tool: ResponseTool = serde_json::from_value(payload.clone())
+        .expect("shell tool w/ container_reference env should deserialize");
+    match &tool {
+        ResponseTool::Shell(s) => match &s.environment {
+            Some(ShellEnvironment::ContainerReference(r)) => {
+                assert_eq!(r.container_id, "container_abc123");
+            }
+            other => panic!("expected ContainerReference env, got {other:?}"),
+        },
+        other => panic!("expected ResponseTool::Shell, got {other:?}"),
+    }
+
+    assert_eq!(serde_json::to_value(&tool).expect("serialize"), payload);
+}
+
+#[test]
+fn shell_call_input_item_round_trips_spec_shape() {
+    // Spec (openai-responses-api-spec.md §ShellCall, L228-231):
+    // `{ action, call_id, type, id, environment, status }` with
+    // `action: { commands: array of string, max_output_length?, timeout_ms? }`
+    // and `environment: optional LocalEnvironment | ContainerReference`
+    // (no `container_auto` on the call form per L512-513).
+    let payload = json!({
+        "type": "shell_call",
+        "id": "sc_01",
+        "call_id": "call_shell_1",
+        "action": {
+            "commands": ["bash", "-lc", "echo hi"],
+            "max_output_length": 65536,
+            "timeout_ms": 10000
+        },
+        "environment": {
+            "type": "container_reference",
+            "container_id": "container_abc"
+        },
+        "status": "in_progress"
+    });
+
+    let item: ResponseInputOutputItem =
+        serde_json::from_value(payload.clone()).expect("shell_call should deserialize");
+    match &item {
+        ResponseInputOutputItem::ShellCall {
+            action,
+            call_id,
+            id,
+            environment,
+            status,
+        } => {
+            assert_eq!(call_id, "call_shell_1");
+            assert_eq!(id.as_deref(), Some("sc_01"));
+            assert_eq!(action.commands, vec!["bash", "-lc", "echo hi"]);
+            assert_eq!(action.max_output_length, Some(65536));
+            assert_eq!(action.timeout_ms, Some(10000));
+            assert!(matches!(
+                environment.as_ref().expect("env present"),
+                ShellCallEnvironment::ContainerReference(_)
+            ));
+            assert_eq!(*status, Some(ShellCallStatus::InProgress));
+        }
+        other => panic!("expected ShellCall, got {other:?}"),
+    }
+    assert_eq!(serde_json::to_value(&item).expect("serialize"), payload);
+}
+
+#[test]
+fn shell_call_minimal_shape_round_trips() {
+    // Spec: `id`, `environment`, `status` are all acceptable as absent on
+    // the input side; `action` and `call_id` are the only required fields
+    // per the audit's Desired shape (§T6 L528).
+    let payload = json!({
+        "type": "shell_call",
+        "call_id": "call_shell_2",
+        "action": {"commands": ["ls"]}
+    });
+
+    let item: ResponseInputOutputItem =
+        serde_json::from_value(payload.clone()).expect("minimal shell_call should deserialize");
+    match &item {
+        ResponseInputOutputItem::ShellCall {
+            action,
+            call_id,
+            id,
+            environment,
+            status,
+        } => {
+            assert_eq!(call_id, "call_shell_2");
+            assert!(id.is_none());
+            assert!(environment.is_none());
+            assert!(status.is_none());
+            assert_eq!(action.commands, vec!["ls"]);
+            assert!(action.max_output_length.is_none());
+            assert!(action.timeout_ms.is_none());
+        }
+        other => panic!("expected ShellCall, got {other:?}"),
+    }
+    assert_eq!(serde_json::to_value(&item).expect("serialize"), payload);
+}
+
+#[test]
+fn shell_call_output_input_item_round_trips_spec_shape() {
+    // Spec (openai-responses-api-spec.md §ShellCallOutput, L233-238):
+    // `{ call_id, output, type, id, max_output_length, status }` with
+    // `output: array of { outcome, stderr, stdout }` where
+    // `outcome: Timeout { type: "timeout" } | Exit { exit_code, type: "exit" }`.
+    let payload = json!({
+        "type": "shell_call_output",
+        "id": "sco_01",
+        "call_id": "call_shell_1",
+        "output": [
+            {
+                "outcome": {"type": "exit", "exit_code": 0},
+                "stderr": "",
+                "stdout": "hi\n",
+                "created_by": "system"
+            },
+            {
+                "outcome": {"type": "timeout"},
+                "stderr": "killed\n",
+                "stdout": ""
+            }
+        ],
+        "max_output_length": 65536,
+        "status": "completed"
+    });
+
+    let item: ResponseInputOutputItem =
+        serde_json::from_value(payload.clone()).expect("shell_call_output should deserialize");
+    match &item {
+        ResponseInputOutputItem::ShellCallOutput {
+            call_id,
+            output,
+            id,
+            max_output_length,
+            status,
+        } => {
+            assert_eq!(call_id, "call_shell_1");
+            assert_eq!(id.as_deref(), Some("sco_01"));
+            assert_eq!(*max_output_length, Some(65536));
+            assert_eq!(*status, Some(ShellCallStatus::Completed));
+            assert_eq!(output.len(), 2);
+            match &output[0].outcome {
+                ShellOutcome::Exit(e) => assert_eq!(e.exit_code, 0),
+                ShellOutcome::Timeout => panic!("expected Exit outcome, got Timeout"),
+            }
+            assert_eq!(output[0].stdout, "hi\n");
+            assert_eq!(output[0].stderr, "");
+            assert_eq!(output[0].created_by.as_deref(), Some("system"));
+            assert!(matches!(output[1].outcome, ShellOutcome::Timeout));
+            assert_eq!(output[1].stderr, "killed\n");
+            assert!(output[1].created_by.is_none());
+        }
+        other => panic!("expected ShellCallOutput, got {other:?}"),
+    }
+    assert_eq!(serde_json::to_value(&item).expect("serialize"), payload);
+}
+
+#[test]
+fn shell_call_output_item_round_trips_on_response_side() {
+    // Spec (openai-responses-api-spec.md §returns `output: array of
+    // ResponseOutputItem`, L512-514): ShellCall / ShellCallOutput are
+    // listed as legal output items. Mirrors the input-side variant
+    // byte-for-byte.
+    let payload = json!({
+        "type": "shell_call",
+        "id": "sc_10",
+        "call_id": "call_shell_10",
+        "action": {"commands": ["echo", "ok"]},
+        "environment": {"type": "local"},
+        "status": "completed"
+    });
+
+    let item: ResponseOutputItem = serde_json::from_value(payload.clone())
+        .expect("response-side shell_call should deserialize");
+    match &item {
+        ResponseOutputItem::ShellCall {
+            call_id,
+            environment,
+            status,
+            ..
+        } => {
+            assert_eq!(call_id, "call_shell_10");
+            match environment.as_ref().expect("env present") {
+                ShellCallEnvironment::Local(local) => assert!(local.skills.is_none()),
+                ShellCallEnvironment::ContainerReference(_) => {
+                    panic!("expected Local env, got ContainerReference")
+                }
+            }
+            assert_eq!(*status, Some(ShellCallStatus::Completed));
+        }
+        other => panic!("expected ResponseOutputItem::ShellCall, got {other:?}"),
+    }
+    assert_eq!(serde_json::to_value(&item).expect("serialize"), payload);
+}
+
+#[test]
+fn shell_call_output_response_side_round_trip() {
+    // Mirror of shell_call_output_input_item_round_trips_spec_shape but
+    // deserialized into [`ResponseOutputItem`] to prove the output union
+    // accepts the same wire shape.
+    let payload = json!({
+        "type": "shell_call_output",
+        "id": "sco_10",
+        "call_id": "call_shell_10",
+        "output": [
+            {
+                "outcome": {"type": "exit", "exit_code": 2},
+                "stderr": "boom",
+                "stdout": ""
+            }
+        ],
+        "status": "incomplete"
+    });
+
+    let item: ResponseOutputItem = serde_json::from_value(payload.clone())
+        .expect("response-side shell_call_output should deserialize");
+    match &item {
+        ResponseOutputItem::ShellCallOutput {
+            call_id,
+            output,
+            status,
+            max_output_length,
+            ..
+        } => {
+            assert_eq!(call_id, "call_shell_10");
+            assert_eq!(*status, Some(ShellCallStatus::Incomplete));
+            assert!(max_output_length.is_none());
+            assert_eq!(output.len(), 1);
+            match &output[0].outcome {
+                ShellOutcome::Exit(e) => assert_eq!(e.exit_code, 2),
+                ShellOutcome::Timeout => panic!("expected Exit outcome, got Timeout"),
+            }
+        }
+        other => panic!("expected ResponseOutputItem::ShellCallOutput, got {other:?}"),
+    }
+    assert_eq!(serde_json::to_value(&item).expect("serialize"), payload);
+}
+
+#[test]
+fn shell_call_environment_rejects_container_auto() {
+    // Spec (openai-responses-api-spec.md §returns, L512-513): the call-side
+    // environment union only carries `local` / `container_reference` —
+    // `container_auto` is request-only. A payload that tries to sneak it
+    // onto a call form must fail to deserialize rather than silently
+    // succeed, preserving the response-form restriction.
+    let payload = json!({
+        "type": "shell_call",
+        "call_id": "call_shell_3",
+        "action": {"commands": ["ls"]},
+        "environment": {
+            "type": "container_auto",
+            "file_ids": []
+        }
+    });
+    // Rejection must happen — the exact message varies depending on which
+    // internal serde branch fires first (outer `type`-tagged arm vs. the
+    // untagged SimpleInputMessage fallback), but no variant of
+    // [`ResponseInputOutputItem`] accepts `container_auto` on a
+    // `shell_call.environment` payload, so deserialization must fail.
+    assert!(
+        serde_json::from_value::<ResponseInputOutputItem>(payload).is_err(),
+        "container_auto must be rejected on shell_call.environment"
+    );
+}

--- a/crates/protocols/tests/responses.rs
+++ b/crates/protocols/tests/responses.rs
@@ -2370,8 +2370,8 @@ fn shell_call_output_item_round_trips_on_response_side() {
             assert_eq!(id, "sc_10");
             assert_eq!(call_id, "call_shell_10");
             match environment.as_ref().expect("env present") {
-                ShellCallEnvironment::Local(_) => {}
-                ShellCallEnvironment::ContainerReference(_) => {
+                ResponseShellCallEnvironment::Local(_) => {}
+                ResponseShellCallEnvironment::ContainerReference(_) => {
                     panic!("expected Local env, got ContainerReference")
                 }
             }
@@ -2456,25 +2456,98 @@ fn shell_call_environment_rejects_container_auto() {
 }
 
 #[test]
-fn shell_call_environment_local_rejects_skills_on_response_side() {
-    // Spec (openai-responses-api-spec.md §returns L513): the response-side
-    // `local` environment is `ResponseLocalEnvironment { type: "local" }` —
-    // `skills` is a request-side attachment on the tool's
-    // `LocalShellEnvironment` and is not echoed back on the resolved call.
-    // `deny_unknown_fields` on [`ResponseLocalShellEnvironment`] must reject
-    // a payload that tries to carry `skills` across the boundary so the
-    // request-only field cannot silently round-trip on the response union.
+fn shell_call_environment_local_accepts_skills_on_input_side() {
+    // Spec (openai-responses-api-spec.md §ShellCall L228-230): the
+    // input-side `shell_call.environment.local` arm accepts the tool-side
+    // `LocalEnvironment { type: "local", skills? }` shape verbatim.
+    // Clients that replay prior input items with skill attachments must
+    // round-trip losslessly through [`ResponseInputOutputItem`].
     let payload = json!({
         "type": "shell_call",
-        "call_id": "call_shell_4",
+        "call_id": "call_shell_skills",
+        "action": {"commands": ["ls"]},
+        "environment": {
+            "type": "local",
+            "skills": [
+                {
+                    "type": "local",
+                    "name": "fmt",
+                    "description": "Run rustfmt",
+                    "path": "/usr/local/bin/rustfmt"
+                }
+            ]
+        }
+    });
+    let item: ResponseInputOutputItem = serde_json::from_value(payload.clone())
+        .expect("input-side shell_call with local skills should deserialize");
+    match &item {
+        ResponseInputOutputItem::ShellCall { environment, .. } => {
+            match environment.as_ref().expect("env present") {
+                ShellCallEnvironment::Local(local) => {
+                    let skills = local.skills.as_ref().expect("skills present");
+                    assert_eq!(skills.len(), 1);
+                }
+                ShellCallEnvironment::ContainerReference(_) => {
+                    panic!("expected Local env, got ContainerReference")
+                }
+            }
+        }
+        other => panic!("expected ShellCall, got {other:?}"),
+    }
+    assert_eq!(serde_json::to_value(&item).expect("serialize"), payload);
+}
+
+#[test]
+fn shell_call_environment_local_rejects_skills_on_response_side() {
+    // Spec (openai-responses-api-spec.md §returns L512-513): the
+    // response-side `local` environment is `ResponseLocalEnvironment {
+    // type: "local" }` — `skills` is an input/tool-side attachment and is
+    // not echoed back on the resolved call. `deny_unknown_fields` on
+    // [`ResponseLocalShellEnvironment`] (carried by
+    // [`ResponseShellCallEnvironment::Local`]) must reject a payload that
+    // tries to carry `skills` across the boundary so the input-only field
+    // cannot silently round-trip on the response union.
+    let payload = json!({
+        "type": "shell_call",
+        "id": "sc_reject",
+        "call_id": "call_shell_reject",
         "action": {"commands": ["ls"]},
         "environment": {
             "type": "local",
             "skills": []
-        }
+        },
+        "status": "completed"
     });
     assert!(
-        serde_json::from_value::<ResponseInputOutputItem>(payload).is_err(),
+        serde_json::from_value::<ResponseOutputItem>(payload).is_err(),
         "skills must be rejected on response-side shell_call.environment.local"
+    );
+}
+
+#[test]
+fn shell_call_output_validation_accepts_empty_output_for_replay() {
+    // Spec (openai-responses-api-spec.md §ShellCallOutput L233-238):
+    // `output: array of ResponseFunctionShellCallOutputContent`. The array
+    // is legitimately empty on replay-only fixtures where the platform
+    // surfaced an outcome without per-chunk stdout/stderr — request-level
+    // validation (`validate_input_item`) keeps empty arrays valid. This
+    // regression fixture locks that relaxed shape in so it cannot be
+    // accidentally tightened, matching the pattern used for apply_patch
+    // replay acceptance elsewhere in this file.
+    let request: ResponsesRequest = serde_json::from_value(json!({
+        "model": "gpt-5.4",
+        "input": [
+            {"role": "user", "content": "hi"},
+            {
+                "type": "shell_call_output",
+                "call_id": "call_shell_empty",
+                "output": []
+            }
+        ]
+    }))
+    .expect("request with empty shell_call_output.output should deserialize");
+    assert!(
+        validator::Validate::validate(&request).is_ok(),
+        "empty shell_call_output.output must remain valid for lossless replay"
     );
 }

--- a/crates/protocols/tests/responses.rs
+++ b/crates/protocols/tests/responses.rs
@@ -2233,6 +2233,7 @@ fn shell_call_input_item_round_trips_spec_shape() {
             id,
             environment,
             status,
+            created_by,
         } => {
             assert_eq!(call_id, "call_shell_1");
             assert_eq!(id.as_deref(), Some("sc_01"));
@@ -2244,6 +2245,7 @@ fn shell_call_input_item_round_trips_spec_shape() {
                 ShellCallEnvironment::ContainerReference(_)
             ));
             assert_eq!(*status, Some(ShellCallStatus::InProgress));
+            assert!(created_by.is_none());
         }
         other => panic!("expected ShellCall, got {other:?}"),
     }
@@ -2270,6 +2272,7 @@ fn shell_call_minimal_shape_round_trips() {
             id,
             environment,
             status,
+            created_by,
         } => {
             assert_eq!(call_id, "call_shell_2");
             assert!(id.is_none());
@@ -2278,6 +2281,7 @@ fn shell_call_minimal_shape_round_trips() {
             assert_eq!(action.commands, vec!["ls"]);
             assert!(action.max_output_length.is_none());
             assert!(action.timeout_ms.is_none());
+            assert!(created_by.is_none());
         }
         other => panic!("expected ShellCall, got {other:?}"),
     }
@@ -2320,6 +2324,7 @@ fn shell_call_output_input_item_round_trips_spec_shape() {
             id,
             max_output_length,
             status,
+            created_by,
         } => {
             assert_eq!(call_id, "call_shell_1");
             assert_eq!(id.as_deref(), Some("sco_01"));
@@ -2336,6 +2341,7 @@ fn shell_call_output_input_item_round_trips_spec_shape() {
             assert!(matches!(output[1].outcome, ShellOutcome::Timeout));
             assert_eq!(output[1].stderr, "killed\n");
             assert!(output[1].created_by.is_none());
+            assert!(created_by.is_none());
         }
         other => panic!("expected ShellCallOutput, got {other:?}"),
     }
@@ -2461,16 +2467,103 @@ fn shell_call_output_response_side_round_trip() {
             output,
             status,
             max_output_length,
+            created_by,
         } => {
             assert_eq!(id, "sco_10");
             assert_eq!(call_id, "call_shell_10");
             assert_eq!(*status, ShellCallStatus::Incomplete);
-            assert_eq!(*max_output_length, 65536);
+            assert_eq!(*max_output_length, Some(65536));
             assert_eq!(output.len(), 1);
             match &output[0].outcome {
                 ShellOutcome::Exit(e) => assert_eq!(e.exit_code, 2),
                 ShellOutcome::Timeout => panic!("expected Exit outcome, got Timeout"),
             }
+            assert!(created_by.is_none());
+        }
+        other => panic!("expected ResponseOutputItem::ShellCallOutput, got {other:?}"),
+    }
+    assert_eq!(serde_json::to_value(&item).expect("serialize"), payload);
+}
+
+#[test]
+fn shell_call_with_created_by_round_trip() {
+    // OpenAI SDK v2.8.1 `ResponseFunctionShellToolCall` carries an optional
+    // `created_by: Optional[str]` provenance tag (see
+    // `response_function_shell_tool_call.py`). Items returned by the
+    // platform populate it; client-authored calls omit it. This fixture
+    // locks both the deserialize-with-value and serialize-preserves-value
+    // paths on the input side.
+    let payload = json!({
+        "type": "shell_call",
+        "id": "sc_cb",
+        "call_id": "call_shell_cb",
+        "action": {"commands": ["ls"]},
+        "status": "completed",
+        "created_by": "user_abc"
+    });
+    let item: ResponseInputOutputItem = serde_json::from_value(payload.clone())
+        .expect("shell_call w/ created_by should deserialize");
+    match &item {
+        ResponseInputOutputItem::ShellCall { created_by, .. } => {
+            assert_eq!(created_by.as_deref(), Some("user_abc"));
+        }
+        other => panic!("expected ShellCall, got {other:?}"),
+    }
+    assert_eq!(serde_json::to_value(&item).expect("serialize"), payload);
+}
+
+#[test]
+fn shell_call_output_with_created_by_round_trip() {
+    // OpenAI SDK v2.8.1 `ResponseFunctionShellToolCallOutput` carries an
+    // optional `created_by: Optional[str]` (see
+    // `response_function_shell_tool_call_output.py`). Mirror of the
+    // `shell_call_with_created_by_round_trip` fixture for the
+    // `shell_call_output` variant — different SDK type, same
+    // `Optional[str]` contract.
+    let payload = json!({
+        "type": "shell_call_output",
+        "id": "sco_cb",
+        "call_id": "call_shell_cb",
+        "output": [],
+        "status": "completed",
+        "created_by": "platform"
+    });
+    let item: ResponseInputOutputItem = serde_json::from_value(payload.clone())
+        .expect("shell_call_output w/ created_by should deserialize");
+    match &item {
+        ResponseInputOutputItem::ShellCallOutput { created_by, .. } => {
+            assert_eq!(created_by.as_deref(), Some("platform"));
+        }
+        other => panic!("expected ShellCallOutput, got {other:?}"),
+    }
+    assert_eq!(serde_json::to_value(&item).expect("serialize"), payload);
+}
+
+#[test]
+fn shell_call_output_without_max_output_length_round_trips_on_response_side() {
+    // OpenAI SDK v2.8.1 `ResponseFunctionShellToolCallOutput.max_output_length`
+    // is typed `Optional[int]`, so the platform may emit `shell_call_output`
+    // items where the originating `shell_call.action.max_output_length` was
+    // not set. This fixture proves the response-side union deserializes the
+    // SDK-optional shape without requiring `max_output_length` to be
+    // present on the wire.
+    let payload = json!({
+        "type": "shell_call_output",
+        "id": "sco_no_max",
+        "call_id": "call_shell_no_max",
+        "output": [],
+        "status": "completed"
+    });
+    let item: ResponseOutputItem = serde_json::from_value(payload.clone())
+        .expect("response-side shell_call_output w/o max_output_length should deserialize");
+    match &item {
+        ResponseOutputItem::ShellCallOutput {
+            max_output_length,
+            created_by,
+            ..
+        } => {
+            assert!(max_output_length.is_none());
+            assert!(created_by.is_none());
         }
         other => panic!("expected ResponseOutputItem::ShellCallOutput, got {other:?}"),
     }

--- a/crates/protocols/tests/responses.rs
+++ b/crates/protocols/tests/responses.rs
@@ -2505,6 +2505,32 @@ fn shell_call_environment_rejects_container_auto() {
 }
 
 #[test]
+fn shell_call_environment_rejects_container_auto_on_response_side() {
+    // Mirror of `shell_call_environment_rejects_container_auto` targeting
+    // the response-side union. [`ResponseShellCallEnvironment`] is a
+    // separate enum from the input-side [`ShellCallEnvironment`], so the
+    // input-side rejection test doesn't prove the response-side variant
+    // also refuses `container_auto`. Spec §returns L512-513 constrains
+    // the response-side shell_call environment to `local` /
+    // `container_reference` only.
+    let payload = json!({
+        "type": "shell_call",
+        "id": "sc_bad",
+        "call_id": "call_shell_bad",
+        "action": {"commands": ["ls"]},
+        "environment": {
+            "type": "container_auto",
+            "file_ids": []
+        },
+        "status": "completed"
+    });
+    assert!(
+        serde_json::from_value::<ResponseOutputItem>(payload).is_err(),
+        "container_auto must be rejected on response-side shell_call.environment"
+    );
+}
+
+#[test]
 fn shell_call_environment_local_accepts_skills_on_input_side() {
     // Spec (openai-responses-api-spec.md §ShellCall L228-230): the
     // input-side `shell_call.environment.local` arm accepts the tool-side

--- a/crates/protocols/tests/responses.rs
+++ b/crates/protocols/tests/responses.rs
@@ -2370,7 +2370,7 @@ fn shell_call_output_item_round_trips_on_response_side() {
             assert_eq!(id, "sc_10");
             assert_eq!(call_id, "call_shell_10");
             match environment.as_ref().expect("env present") {
-                ShellCallEnvironment::Local(local) => assert!(local.skills.is_none()),
+                ShellCallEnvironment::Local(_) => {}
                 ShellCallEnvironment::ContainerReference(_) => {
                     panic!("expected Local env, got ContainerReference")
                 }
@@ -2452,5 +2452,29 @@ fn shell_call_environment_rejects_container_auto() {
     assert!(
         serde_json::from_value::<ResponseInputOutputItem>(payload).is_err(),
         "container_auto must be rejected on shell_call.environment"
+    );
+}
+
+#[test]
+fn shell_call_environment_local_rejects_skills_on_response_side() {
+    // Spec (openai-responses-api-spec.md §returns L513): the response-side
+    // `local` environment is `ResponseLocalEnvironment { type: "local" }` —
+    // `skills` is a request-side attachment on the tool's
+    // `LocalShellEnvironment` and is not echoed back on the resolved call.
+    // `deny_unknown_fields` on [`ResponseLocalShellEnvironment`] must reject
+    // a payload that tries to carry `skills` across the boundary so the
+    // request-only field cannot silently round-trip on the response union.
+    let payload = json!({
+        "type": "shell_call",
+        "call_id": "call_shell_4",
+        "action": {"commands": ["ls"]},
+        "environment": {
+            "type": "local",
+            "skills": []
+        }
+    });
+    assert!(
+        serde_json::from_value::<ResponseInputOutputItem>(payload).is_err(),
+        "skills must be rejected on response-side shell_call.environment.local"
     );
 }

--- a/model_gateway/benches/routing_allocation_bench.rs
+++ b/model_gateway/benches/routing_allocation_bench.rs
@@ -74,6 +74,8 @@ fn extract_text_for_routing_old(req: &ResponsesRequest) -> String {
                 ResponseInputOutputItem::ComputerCallOutput { .. } => None,
                 ResponseInputOutputItem::CustomToolCall { .. }
                 | ResponseInputOutputItem::CustomToolCallOutput { .. } => None,
+                ResponseInputOutputItem::ShellCall { .. }
+                | ResponseInputOutputItem::ShellCallOutput { .. } => None,
             })
             .collect::<Vec<String>>()
             .join(" "),

--- a/model_gateway/src/routers/grpc/harmony/builder.rs
+++ b/model_gateway/src/routers/grpc/harmony/builder.rs
@@ -442,6 +442,7 @@ impl HarmonyBuilder {
                             ResponseTool::ComputerUsePreview(_) => "computer_use_preview",
                             ResponseTool::Custom(_) => "custom",
                             ResponseTool::Namespace(_) => "namespace",
+                            ResponseTool::Shell(_) => "shell",
                         })
                         .collect()
                 })
@@ -752,6 +753,15 @@ impl HarmonyBuilder {
                 warn!(
                     function = "parse_response_item_to_harmony_message",
                     "Custom tool item reached Harmony conversion"
+                );
+                Err("Unsupported input item type".to_string())
+            }
+
+            ResponseInputOutputItem::ShellCall { .. }
+            | ResponseInputOutputItem::ShellCallOutput { .. } => {
+                warn!(
+                    function = "parse_response_item_to_harmony_message",
+                    "Shell tool item reached Harmony conversion"
                 );
                 Err("Unsupported input item type".to_string())
             }

--- a/model_gateway/src/routers/grpc/harmony/builder.rs
+++ b/model_gateway/src/routers/grpc/harmony/builder.rs
@@ -67,6 +67,7 @@ const BUILTIN_TOOLS: &[&str] = &[
     "container",
     "file_search",
     "image_generation",
+    "shell",
 ];
 
 /// Trait for tool-like objects that can be converted to Harmony ToolDescription

--- a/model_gateway/src/routers/grpc/regular/responses/conversions.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/conversions.rs
@@ -170,6 +170,14 @@ pub(crate) fn responses_to_chat(req: &ResponsesRequest) -> Result<ChatCompletion
                         );
                         return Err("Unsupported input item type".to_string());
                     }
+                    ResponseInputOutputItem::ShellCall { .. }
+                    | ResponseInputOutputItem::ShellCallOutput { .. } => {
+                        warn!(
+                            function = "responses_to_chat",
+                            "Shell tool item reached chat conversion"
+                        );
+                        return Err("Unsupported input item type".to_string());
+                    }
                 }
             }
         }

--- a/model_gateway/src/routers/openai/responses/utils.rs
+++ b/model_gateway/src/routers/openai/responses/utils.rs
@@ -256,6 +256,7 @@ pub(super) fn response_tool_to_value(tool: &ResponseTool) -> Option<Value> {
         // the full {type, name, description, tools} payload round-trips back
         // to the client unchanged (T9).
         ResponseTool::Namespace(_) => serde_json::to_value(tool).ok(),
+        ResponseTool::Shell(_) => serde_json::to_value(tool).ok(),
         ResponseTool::Function(_) => None,
     }
 }


### PR DESCRIPTION
## Summary
Implements audit task T6: adds the containerized `shell` tool to the Responses protocol along with its matching input and output items. Distinct from the existing `local_shell` surface — the `shell` tool carries an `environment` that can be `container_auto`, `local`, or `container_reference`, with skill attachments supported on the first two.

## What changed
- `crates/protocols/src/responses.rs`
  - New `ResponseTool::Shell(ShellTool)` variant with `#[serde(rename = "shell")]`.
  - New tool-side `ShellEnvironment` union (`ContainerAuto` / `Local` / `ContainerReference`).
  - New `ContainerAutoEnvironment { file_ids?, memory_limit?, network_policy?, skills? }`, `LocalShellEnvironment { skills? }`, `ContainerReferenceEnvironment { container_id }`.
  - New `ContainerNetworkPolicy` (`Disabled` / `Allowlist`) with `ContainerNetworkAllowlist { allowed_domains, domain_secrets? }` and `ContainerDomainSecret { domain, name, value }`.
  - New response-side `ShellCallEnvironment` (`Local` / `ContainerReference` only — spec restricts the call form per L512-513).
  - New `ShellCallAction { commands, max_output_length?, timeout_ms? }`, `ShellCallStatus`, `ShellOutputChunk { outcome, stderr, stdout, created_by? }`, `ShellOutcome { Timeout, Exit(ShellExit { exit_code }) }`.
  - New `ResponseInputOutputItem::ShellCall { action, call_id, id?, environment?, status? }` and `ResponseInputOutputItem::ShellCallOutput { call_id, output: Vec<ShellOutputChunk>, id?, max_output_length?, status? }`.
  - Matching `ResponseOutputItem::ShellCall` / `ShellCallOutput` emitted on response output arrays.
  - Two existing exhaustive matches inside `responses.rs` (routing-text extractor + `validate_input_item`) extended with neutral arms.
- Forced-cascade router match arms (1-line neutral returns only; no guardrails):
  - `crates/mcp/src/core/session.rs` — `ResponseOutputItem::ShellCall` / `ShellCallOutput` added to the "kept" arm of `should_hide_item`.
  - `model_gateway/benches/routing_allocation_bench.rs` — `None` for routing-text extraction.
  - `model_gateway/src/routers/grpc/harmony/builder.rs` — `"shell"` tool-type label + `Unsupported input item type` on Harmony input conversion.
  - `model_gateway/src/routers/grpc/regular/responses/conversions.rs` — `Unsupported input item type` on `responses_to_chat`.
  - `model_gateway/src/routers/openai/responses/utils.rs` — `serde_json::to_value` passthrough in `response_tool_to_value`.
- `crates/protocols/tests/responses.rs` — 11 new integration-file serde round-trip tests covering the shell tool (no env / container_auto full / container_auto disabled-network / local / container_reference), the call form (full + minimal), the output form (multi-chunk with Exit + Timeout), both response-side variants, and the spec constraint rejecting `container_auto` on `shell_call.environment`.

## Why
The OpenAI Responses API spec enumerates `Shell { type: "shell", environment? }` as a distinct tool with its own call/output items (openai-responses-api-spec.md L228-238, L463-470, L512-513). smg's `ResponseTool` enum was missing the `Shell` variant and its call/output siblings, so clients sending spec-valid `{ "type": "shell" }` tool declarations — or the matching `shell_call` / `shell_call_output` items on replay — fell through without typed support. This PR lands the schema-only contract; backend execution of shell calls is explicitly out of scope per the audit task (T6: "Backend exec is not in scope — schema only").

## Verification
- `cargo check -p openai-protocol --tests` — green.
- `cargo test -p openai-protocol --test responses` — 70 passed / 0 failed, including the 11 new `shell_*` tests (counts validated with `--list` against a worktree-local target-dir to avoid the shared `CARGO_TARGET_DIR` binary-hash collision that affects parallel audit worktrees).
- `cargo check -p smg --lib` — green.
- `cargo fmt --all` — clean.
- `cargo clippy -p openai-protocol -p smg --lib --tests -- -D warnings` — clean.

## Blast radius
- Protocol: 1 file (`crates/protocols/src/responses.rs`).
- Routers / bench / MCP session: 5 files, match-arm additions only (no behavior change for non-shell items).
- Tests: 1 integration file extended (no new files, no inline `#[cfg(test)] mod tests`).

## Out of scope
- Backend execution of shell calls (T6 audit explicitly defers this — routers return `Unsupported input item type` today).
- `apply_patch` / `local_shell` / `namespace` tools (separate tasks T7 / T5 / T9).
- Status Board / Drift Log edits (the audit file lives outside this worktree — not in §6.1 write-path).

Refs: audit task T6.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full support for a shell tool (containerized or local) with shell-call and shell-call-output items, environment variants, and optional network allowlists/secrets.

* **Behavior Changes**
  * Shell call items are client-visible by default, excluded from routing-text extraction, preserved for lossless multi-turn replay, and explicitly rejected by conversions that cannot represent them. Shell tool entries are round-trippable when restoring tool lists.

* **Tests**
  * Extensive serialization, round-trip, schema, and validation tests for shell tooling and I/O items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->