### PR TITLE
feat(skills): add patch and delete admin endpoints

### DIFF
--- a/crates/protocols/src/skills.rs
+++ b/crates/protocols/src/skills.rs
@@ -181,6 +181,7 @@ pub struct SkillMutationResponse {
 
 /// JSON body accepted by `PATCH /v1/skills/{skill_id}`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Validate, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct SkillPatchRequest {
     pub default_version: SkillVersionRef,
 }
@@ -189,6 +190,7 @@ impl Normalizable for SkillPatchRequest {}
 
 /// JSON body accepted by `PATCH /v1/skills/{skill_id}/versions/{version}`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Validate, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct SkillVersionPatchRequest {
     pub deprecated: bool,
 }

--- a/crates/protocols/src/skills.rs
+++ b/crates/protocols/src/skills.rs
@@ -8,6 +8,9 @@ use serde::{
     Deserialize, Deserializer, Serialize, Serializer,
 };
 use serde_json::{Map, Value};
+use validator::Validate;
+
+use crate::validated::Normalizable;
 
 /// Multipart field carrying the explicit admin target tenant id.
 pub const SKILLS_MULTIPART_TENANT_ID_FIELD: &str = "tenant_id";
@@ -175,6 +178,22 @@ pub struct SkillMutationResponse {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub warnings: Vec<SkillWarningResponse>,
 }
+
+/// JSON body accepted by `PATCH /v1/skills/{skill_id}`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Validate, schemars::JsonSchema)]
+pub struct SkillPatchRequest {
+    pub default_version: SkillVersionRef,
+}
+
+impl Normalizable for SkillPatchRequest {}
+
+/// JSON body accepted by `PATCH /v1/skills/{skill_id}/versions/{version}`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Validate, schemars::JsonSchema)]
+pub struct SkillVersionPatchRequest {
+    pub deprecated: bool,
+}
+
+impl Normalizable for SkillVersionPatchRequest {}
 
 /// Query parameters accepted by `GET /v1/skills`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default, schemars::JsonSchema)]

--- a/crates/protocols/tests/skills_protocol.rs
+++ b/crates/protocols/tests/skills_protocol.rs
@@ -274,6 +274,18 @@ fn skill_version_patch_request_round_trips() {
 }
 
 #[test]
+fn skill_patch_request_rejects_unknown_fields() {
+    let raw = r#"{"default_version":2,"extra":true}"#;
+    assert!(serde_json::from_str::<SkillPatchRequest>(raw).is_err());
+}
+
+#[test]
+fn skill_version_patch_request_rejects_unknown_fields() {
+    let raw = r#"{"deprecated":true,"extra":"nope"}"#;
+    assert!(serde_json::from_str::<SkillVersionPatchRequest>(raw).is_err());
+}
+
+#[test]
 fn skills_error_envelope_round_trips() {
     let raw = json!({
         "error": {

--- a/crates/protocols/tests/skills_protocol.rs
+++ b/crates/protocols/tests/skills_protocol.rs
@@ -3,7 +3,8 @@ use openai_protocol::{
     responses::{CodeInterpreterTool, ResponseTool},
     skills::{
         MessagesSkillRef, OpaqueOpenAIObject, ResponsesSkillEntry, ResponsesSkillRef,
-        SkillMutationResponse, SkillVersionRef, SkillsErrorEnvelope,
+        SkillMutationResponse, SkillPatchRequest, SkillVersionPatchRequest, SkillVersionRef,
+        SkillsErrorEnvelope,
     },
 };
 use schemars::schema_for;
@@ -247,6 +248,28 @@ fn skill_mutation_response_round_trips() {
     });
 
     let parsed: SkillMutationResponse = serde_json::from_value(raw.clone()).unwrap();
+    assert_eq!(serde_json::to_value(&parsed).unwrap(), raw);
+}
+
+#[test]
+fn skill_patch_request_round_trips() {
+    let raw = json!({
+        "default_version": 2
+    });
+
+    let parsed: SkillPatchRequest = serde_json::from_value(raw.clone()).unwrap();
+    assert_eq!(parsed.default_version, SkillVersionRef::Integer(2));
+    assert_eq!(serde_json::to_value(&parsed).unwrap(), raw);
+}
+
+#[test]
+fn skill_version_patch_request_round_trips() {
+    let raw = json!({
+        "deprecated": true
+    });
+
+    let parsed: SkillVersionPatchRequest = serde_json::from_value(raw.clone()).unwrap();
+    assert!(parsed.deprecated);
     assert_eq!(serde_json::to_value(&parsed).unwrap(), raw);
 }
 

--- a/crates/skills/src/api.rs
+++ b/crates/skills/src/api.rs
@@ -466,6 +466,21 @@ impl SkillService {
                 skill_id: skill_id.clone(),
             })?;
         let existing_versions = metadata_store.list_skill_versions(&skill_id).await?;
+        let existing_default_projection = existing_skill
+            .default_version
+            .as_ref()
+            .map(|default_version| {
+                existing_versions
+                    .iter()
+                    .find(|record| record.version == *default_version)
+                    .cloned()
+                    .ok_or_else(|| SkillServiceError::SkillVersionNotFound {
+                        tenant_id: tenant_id.clone(),
+                        skill_id: skill_id.clone(),
+                        version: default_version.clone(),
+                    })
+            })
+            .transpose()?;
 
         let (bundle, media_types) = normalize_upload_bundle(request.upload)?;
         let parsed_bundle = parse_bundle_contents(&bundle)?;
@@ -511,24 +526,8 @@ impl SkillService {
         if updated_skill.default_version.is_none() {
             updated_skill.default_version = Some(version.clone());
         }
-        let default_version = updated_skill.default_version.clone().ok_or_else(|| {
-            SkillServiceError::MissingDefaultVersion {
-                tenant_id: tenant_id.clone(),
-                skill_id: skill_id.clone(),
-            }
-        })?;
-        let default_projection = if default_version == version {
-            version_record.clone()
-        } else {
-            metadata_store
-                .get_skill_version(&skill_id, &default_version)
-                .await?
-                .ok_or_else(|| SkillServiceError::SkillVersionNotFound {
-                    tenant_id: tenant_id.clone(),
-                    skill_id: skill_id.clone(),
-                    version: default_version.clone(),
-                })?
-        };
+        let default_projection =
+            existing_default_projection.unwrap_or_else(|| version_record.clone());
         apply_skill_projection_from_version(&mut updated_skill, &default_projection);
         updated_skill.updated_at = now;
 
@@ -623,12 +622,16 @@ impl SkillService {
         let mut version =
             resolve_skill_version_record(&*metadata_store, &tenant_id, &skill_id, &version_ref)
                 .await?;
+        let original_version = version.clone();
 
         version.deprecated = request.deprecated;
         metadata_store.put_skill_version(version.clone()).await?;
 
         skill.updated_at = Utc::now();
-        metadata_store.put_skill(skill).await?;
+        if let Err(error) = metadata_store.put_skill(skill).await {
+            let _ = metadata_store.put_skill_version(original_version).await;
+            return Err(error.into());
+        }
 
         Ok(version)
     }
@@ -698,20 +701,21 @@ impl SkillService {
                 component: "blob_store",
             })?;
 
-        let mut skill = metadata_store
+        let original_skill = metadata_store
             .get_skill(&tenant_id, &skill_id)
             .await?
             .ok_or_else(|| SkillServiceError::SkillNotFound {
                 tenant_id: tenant_id.clone(),
                 skill_id: skill_id.clone(),
             })?;
+        let mut updated_skill = original_skill.clone();
         let version =
             resolve_skill_version_record(&*metadata_store, &tenant_id, &skill_id, &version_ref)
                 .await?;
         let versions = metadata_store.list_skill_versions(&skill_id).await?;
 
         if versions.len() > 1
-            && skill
+            && original_skill
                 .default_version
                 .as_deref()
                 .is_some_and(|default_version| default_version == version.version)
@@ -723,33 +727,32 @@ impl SkillService {
             });
         }
 
-        metadata_store
-            .delete_skill_version(&skill.skill_id, &version.version)
-            .await?;
-        cleanup_blobs(&*blob_store, &version.file_manifest).await;
-
         if versions.len() == 1 {
             metadata_store
-                .delete_skill(&skill.tenant_id, &skill.skill_id)
+                .delete_skill(&original_skill.tenant_id, &original_skill.skill_id)
                 .await?;
+            cleanup_blobs(&*blob_store, &version.file_manifest).await;
             return Ok(DeletedSkillVersionResult {
                 deleted_skill: true,
             });
         }
 
-        let remaining_versions = metadata_store.list_skill_versions(&skill.skill_id).await?;
+        let remaining_versions = versions
+            .into_iter()
+            .filter(|record| record.version != version.version)
+            .collect::<Vec<_>>();
         let latest_version = latest_skill_version(&remaining_versions).ok_or_else(|| {
             SkillServiceError::SkillVersionNotFound {
-                tenant_id: skill.tenant_id.clone(),
-                skill_id: skill.skill_id.clone(),
+                tenant_id: original_skill.tenant_id.clone(),
+                skill_id: original_skill.skill_id.clone(),
                 version: "latest".to_string(),
             }
         })?;
-        skill.latest_version = Some(latest_version.version.clone());
-        let default_version = skill.default_version.clone().ok_or_else(|| {
+        updated_skill.latest_version = Some(latest_version.version.clone());
+        let default_version = updated_skill.default_version.clone().ok_or_else(|| {
             SkillServiceError::MissingDefaultVersion {
-                tenant_id: skill.tenant_id.clone(),
-                skill_id: skill.skill_id.clone(),
+                tenant_id: original_skill.tenant_id.clone(),
+                skill_id: original_skill.skill_id.clone(),
             }
         })?;
         let default_projection = remaining_versions
@@ -757,13 +760,21 @@ impl SkillService {
             .find(|record| record.version == default_version)
             .cloned()
             .ok_or_else(|| SkillServiceError::SkillVersionNotFound {
-                tenant_id: skill.tenant_id.clone(),
-                skill_id: skill.skill_id.clone(),
+                tenant_id: original_skill.tenant_id.clone(),
+                skill_id: original_skill.skill_id.clone(),
                 version: default_version,
             })?;
-        apply_skill_projection_from_version(&mut skill, &default_projection);
-        skill.updated_at = Utc::now();
-        metadata_store.put_skill(skill).await?;
+        apply_skill_projection_from_version(&mut updated_skill, &default_projection);
+        updated_skill.updated_at = Utc::now();
+        metadata_store.put_skill(updated_skill).await?;
+        if let Err(error) = metadata_store
+            .delete_skill_version(&original_skill.skill_id, &version.version)
+            .await
+        {
+            let _ = metadata_store.put_skill(original_skill).await;
+            return Err(error.into());
+        }
+        cleanup_blobs(&*blob_store, &version.file_manifest).await;
 
         Ok(DeletedSkillVersionResult {
             deleted_skill: false,

--- a/crates/skills/src/api.rs
+++ b/crates/skills/src/api.rs
@@ -21,7 +21,8 @@ use crate::{
         SkillVersionRecord,
     },
     validation::{
-        normalize_skill_bundle_zip, parse_skill_bundle, SkillBundleArchiveError, SkillParseError,
+        is_code_file_path, normalize_skill_bundle_zip, parse_skill_bundle, SkillBundleArchiveError,
+        SkillParseError,
     },
 };
 
@@ -84,10 +85,30 @@ pub struct CreateSkillVersionRequest {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UpdateSkillRequest {
+    pub tenant_id: String,
+    pub skill_id: String,
+    pub default_version_ref: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UpdateSkillVersionRequest {
+    pub tenant_id: String,
+    pub skill_id: String,
+    pub version_ref: String,
+    pub deprecated: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SkillCreateResult {
     pub skill: SkillRecord,
     pub version: SkillVersionRecord,
     pub warnings: Vec<SkillParseWarning>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeletedSkillVersionResult {
+    pub deleted_skill: bool,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -142,6 +163,18 @@ pub enum SkillServiceError {
 
     #[error("failed to build skill bundle: {0}")]
     BundleBuild(String),
+
+    #[error("skill '{skill_id}' in tenant '{tenant_id}' has no default version")]
+    MissingDefaultVersion { tenant_id: String, skill_id: String },
+
+    #[error(
+        "cannot delete default version '{version}' for skill '{skill_id}' in tenant '{tenant_id}' while other versions remain"
+    )]
+    CannotDeleteDefaultVersion {
+        tenant_id: String,
+        skill_id: String,
+        version: String,
+    },
 }
 
 impl Default for SkillService {
@@ -290,50 +323,7 @@ impl SkillService {
             .ok_or(SkillServiceError::MissingComponent {
                 component: "metadata_store",
             })?;
-
-        let skill = metadata_store
-            .get_skill(&tenant_id, &skill_id)
-            .await?
-            .ok_or_else(|| SkillServiceError::SkillNotFound {
-                tenant_id: tenant_id.clone(),
-                skill_id: skill_id.clone(),
-            })?;
-
-        if version_ref == "latest" {
-            if let Some(latest_version) = skill.latest_version {
-                return metadata_store
-                    .get_skill_version(&skill_id, &latest_version)
-                    .await?
-                    .ok_or(SkillServiceError::SkillVersionNotFound {
-                        tenant_id,
-                        skill_id,
-                        version: latest_version,
-                    });
-            }
-        }
-
-        if let Some(record) = metadata_store
-            .get_skill_version(&skill_id, &version_ref)
-            .await?
-        {
-            return Ok(record);
-        }
-
-        if let Ok(version_number) = version_ref.parse::<u32>() {
-            let versions = metadata_store.list_skill_versions(&skill_id).await?;
-            if let Some(record) = versions
-                .into_iter()
-                .find(|record| record.version_number == version_number)
-            {
-                return Ok(record);
-            }
-        }
-
-        Err(SkillServiceError::SkillVersionNotFound {
-            tenant_id,
-            skill_id,
-            version: version_ref,
-        })
+        resolve_skill_version_record(&*metadata_store, &tenant_id, &skill_id, &version_ref).await
     }
 
     pub async fn list_skill_versions(
@@ -517,14 +507,29 @@ impl SkillService {
         }
 
         let mut updated_skill = existing_skill.clone();
-        updated_skill.name = parsed_bundle.name.clone();
-        updated_skill.short_description = parsed_bundle.short_description.clone();
-        updated_skill.description = Some(parsed_bundle.description.clone());
-        updated_skill.has_code_files = bundle.has_code_files;
         updated_skill.latest_version = Some(version.clone());
         if updated_skill.default_version.is_none() {
             updated_skill.default_version = Some(version.clone());
         }
+        let default_version = updated_skill.default_version.clone().ok_or_else(|| {
+            SkillServiceError::MissingDefaultVersion {
+                tenant_id: tenant_id.clone(),
+                skill_id: skill_id.clone(),
+            }
+        })?;
+        let default_projection = if default_version == version {
+            version_record.clone()
+        } else {
+            metadata_store
+                .get_skill_version(&skill_id, &default_version)
+                .await?
+                .ok_or_else(|| SkillServiceError::SkillVersionNotFound {
+                    tenant_id: tenant_id.clone(),
+                    skill_id: skill_id.clone(),
+                    version: default_version.clone(),
+                })?
+        };
+        apply_skill_projection_from_version(&mut updated_skill, &default_projection);
         updated_skill.updated_at = now;
 
         if let Err(error) = metadata_store.put_skill(updated_skill.clone()).await {
@@ -539,6 +544,229 @@ impl SkillService {
             skill: updated_skill,
             version: version_record,
             warnings: parsed_bundle.warnings,
+        })
+    }
+
+    pub async fn update_skill(
+        &self,
+        request: UpdateSkillRequest,
+    ) -> Result<SkillRecord, SkillServiceError> {
+        let tenant_id =
+            normalize_required_value(request.tenant_id, SkillServiceError::MissingTenantId)?;
+        let skill_id =
+            normalize_required_value(request.skill_id, SkillServiceError::MissingSkillId)?;
+        let default_version_ref = normalize_required_value(
+            request.default_version_ref,
+            SkillServiceError::SkillVersionNotFound {
+                tenant_id: tenant_id.clone(),
+                skill_id: skill_id.clone(),
+                version: String::new(),
+            },
+        )?;
+        let metadata_store = self
+            .metadata_store()
+            .ok_or(SkillServiceError::MissingComponent {
+                component: "metadata_store",
+            })?;
+
+        let mut skill = metadata_store
+            .get_skill(&tenant_id, &skill_id)
+            .await?
+            .ok_or_else(|| SkillServiceError::SkillNotFound {
+                tenant_id: tenant_id.clone(),
+                skill_id: skill_id.clone(),
+            })?;
+        let target_version = resolve_skill_version_record(
+            &*metadata_store,
+            &tenant_id,
+            &skill_id,
+            &default_version_ref,
+        )
+        .await?;
+
+        skill.default_version = Some(target_version.version.clone());
+        apply_skill_projection_from_version(&mut skill, &target_version);
+        skill.updated_at = Utc::now();
+        metadata_store.put_skill(skill.clone()).await?;
+        Ok(skill)
+    }
+
+    pub async fn update_skill_version(
+        &self,
+        request: UpdateSkillVersionRequest,
+    ) -> Result<SkillVersionRecord, SkillServiceError> {
+        let tenant_id =
+            normalize_required_value(request.tenant_id, SkillServiceError::MissingTenantId)?;
+        let skill_id =
+            normalize_required_value(request.skill_id, SkillServiceError::MissingSkillId)?;
+        let version_ref = normalize_required_value(
+            request.version_ref,
+            SkillServiceError::SkillVersionNotFound {
+                tenant_id: tenant_id.clone(),
+                skill_id: skill_id.clone(),
+                version: String::new(),
+            },
+        )?;
+        let metadata_store = self
+            .metadata_store()
+            .ok_or(SkillServiceError::MissingComponent {
+                component: "metadata_store",
+            })?;
+
+        let mut skill = metadata_store
+            .get_skill(&tenant_id, &skill_id)
+            .await?
+            .ok_or_else(|| SkillServiceError::SkillNotFound {
+                tenant_id: tenant_id.clone(),
+                skill_id: skill_id.clone(),
+            })?;
+        let mut version =
+            resolve_skill_version_record(&*metadata_store, &tenant_id, &skill_id, &version_ref)
+                .await?;
+
+        version.deprecated = request.deprecated;
+        metadata_store.put_skill_version(version.clone()).await?;
+
+        skill.updated_at = Utc::now();
+        metadata_store.put_skill(skill).await?;
+
+        Ok(version)
+    }
+
+    pub async fn delete_skill(
+        &self,
+        tenant_id: &str,
+        skill_id: &str,
+    ) -> Result<(), SkillServiceError> {
+        let tenant_id =
+            normalize_required_value(tenant_id.to_string(), SkillServiceError::MissingTenantId)?;
+        let skill_id =
+            normalize_required_value(skill_id.to_string(), SkillServiceError::MissingSkillId)?;
+        let metadata_store = self
+            .metadata_store()
+            .ok_or(SkillServiceError::MissingComponent {
+                component: "metadata_store",
+            })?;
+        let blob_store = self
+            .blob_store()
+            .ok_or(SkillServiceError::MissingComponent {
+                component: "blob_store",
+            })?;
+
+        metadata_store
+            .get_skill(&tenant_id, &skill_id)
+            .await?
+            .ok_or_else(|| SkillServiceError::SkillNotFound {
+                tenant_id: tenant_id.clone(),
+                skill_id: skill_id.clone(),
+            })?;
+
+        let versions = metadata_store.list_skill_versions(&skill_id).await?;
+        metadata_store.delete_skill(&tenant_id, &skill_id).await?;
+        for version in &versions {
+            cleanup_blobs(&*blob_store, &version.file_manifest).await;
+        }
+        Ok(())
+    }
+
+    pub async fn delete_skill_version(
+        &self,
+        tenant_id: &str,
+        skill_id: &str,
+        version_ref: &str,
+    ) -> Result<DeletedSkillVersionResult, SkillServiceError> {
+        let tenant_id =
+            normalize_required_value(tenant_id.to_string(), SkillServiceError::MissingTenantId)?;
+        let skill_id =
+            normalize_required_value(skill_id.to_string(), SkillServiceError::MissingSkillId)?;
+        let version_ref = normalize_required_value(
+            version_ref.to_string(),
+            SkillServiceError::SkillVersionNotFound {
+                tenant_id: tenant_id.clone(),
+                skill_id: skill_id.clone(),
+                version: version_ref.trim().to_string(),
+            },
+        )?;
+        let metadata_store = self
+            .metadata_store()
+            .ok_or(SkillServiceError::MissingComponent {
+                component: "metadata_store",
+            })?;
+        let blob_store = self
+            .blob_store()
+            .ok_or(SkillServiceError::MissingComponent {
+                component: "blob_store",
+            })?;
+
+        let mut skill = metadata_store
+            .get_skill(&tenant_id, &skill_id)
+            .await?
+            .ok_or_else(|| SkillServiceError::SkillNotFound {
+                tenant_id: tenant_id.clone(),
+                skill_id: skill_id.clone(),
+            })?;
+        let version =
+            resolve_skill_version_record(&*metadata_store, &tenant_id, &skill_id, &version_ref)
+                .await?;
+        let versions = metadata_store.list_skill_versions(&skill_id).await?;
+
+        if versions.len() > 1
+            && skill
+                .default_version
+                .as_deref()
+                .is_some_and(|default_version| default_version == version.version)
+        {
+            return Err(SkillServiceError::CannotDeleteDefaultVersion {
+                tenant_id,
+                skill_id,
+                version: version.version,
+            });
+        }
+
+        metadata_store
+            .delete_skill_version(&skill.skill_id, &version.version)
+            .await?;
+        cleanup_blobs(&*blob_store, &version.file_manifest).await;
+
+        if versions.len() == 1 {
+            metadata_store
+                .delete_skill(&skill.tenant_id, &skill.skill_id)
+                .await?;
+            return Ok(DeletedSkillVersionResult {
+                deleted_skill: true,
+            });
+        }
+
+        let remaining_versions = metadata_store.list_skill_versions(&skill.skill_id).await?;
+        let latest_version = latest_skill_version(&remaining_versions).ok_or_else(|| {
+            SkillServiceError::SkillVersionNotFound {
+                tenant_id: skill.tenant_id.clone(),
+                skill_id: skill.skill_id.clone(),
+                version: "latest".to_string(),
+            }
+        })?;
+        skill.latest_version = Some(latest_version.version.clone());
+        let default_version = skill.default_version.clone().ok_or_else(|| {
+            SkillServiceError::MissingDefaultVersion {
+                tenant_id: skill.tenant_id.clone(),
+                skill_id: skill.skill_id.clone(),
+            }
+        })?;
+        let default_projection = remaining_versions
+            .iter()
+            .find(|record| record.version == default_version)
+            .cloned()
+            .ok_or_else(|| SkillServiceError::SkillVersionNotFound {
+                tenant_id: skill.tenant_id.clone(),
+                skill_id: skill.skill_id.clone(),
+                version: default_version,
+            })?;
+        apply_skill_projection_from_version(&mut skill, &default_projection);
+        skill.updated_at = Utc::now();
+        metadata_store.put_skill(skill).await?;
+
+        Ok(DeletedSkillVersionResult {
+            deleted_skill: false,
         })
     }
 }
@@ -698,6 +926,83 @@ fn next_version_number(existing_versions: &[SkillVersionRecord]) -> u32 {
         .saturating_add(1)
 }
 
+async fn resolve_skill_version_record(
+    metadata_store: &dyn SkillMetadataStore,
+    tenant_id: &str,
+    skill_id: &str,
+    version_ref: &str,
+) -> Result<SkillVersionRecord, SkillServiceError> {
+    let skill = metadata_store
+        .get_skill(tenant_id, skill_id)
+        .await?
+        .ok_or_else(|| SkillServiceError::SkillNotFound {
+            tenant_id: tenant_id.to_string(),
+            skill_id: skill_id.to_string(),
+        })?;
+
+    if version_ref == "latest" {
+        let latest_version =
+            skill
+                .latest_version
+                .ok_or_else(|| SkillServiceError::SkillVersionNotFound {
+                    tenant_id: tenant_id.to_string(),
+                    skill_id: skill_id.to_string(),
+                    version: "latest".to_string(),
+                })?;
+        return metadata_store
+            .get_skill_version(skill_id, &latest_version)
+            .await?
+            .ok_or_else(|| SkillServiceError::SkillVersionNotFound {
+                tenant_id: tenant_id.to_string(),
+                skill_id: skill_id.to_string(),
+                version: latest_version,
+            });
+    }
+
+    if let Some(record) = metadata_store
+        .get_skill_version(skill_id, version_ref)
+        .await?
+    {
+        return Ok(record);
+    }
+
+    if let Ok(version_number) = version_ref.parse::<u32>() {
+        let versions = metadata_store.list_skill_versions(skill_id).await?;
+        if let Some(record) = versions
+            .into_iter()
+            .find(|record| record.version_number == version_number)
+        {
+            return Ok(record);
+        }
+    }
+
+    Err(SkillServiceError::SkillVersionNotFound {
+        tenant_id: tenant_id.to_string(),
+        skill_id: skill_id.to_string(),
+        version: version_ref.to_string(),
+    })
+}
+
+fn apply_skill_projection_from_version(skill: &mut SkillRecord, version: &SkillVersionRecord) {
+    skill.name.clone_from(&version.name);
+    skill
+        .short_description
+        .clone_from(&version.short_description);
+    skill.description = Some(version.description.clone());
+    skill.has_code_files = version
+        .file_manifest
+        .iter()
+        .any(|file| is_code_file_path(&file.relative_path));
+}
+
+fn latest_skill_version(versions: &[SkillVersionRecord]) -> Option<SkillVersionRecord> {
+    versions.iter().cloned().max_by(|left, right| {
+        left.version_number
+            .cmp(&right.version_number)
+            .then_with(|| left.version.cmp(&right.version))
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -708,7 +1013,7 @@ mod tests {
 
     use super::{
         CreateSkillRequest, CreateSkillVersionRequest, SkillService, SkillServiceMode, SkillUpload,
-        UploadedSkillFile,
+        UpdateSkillRequest, UpdateSkillVersionRequest, UploadedSkillFile,
     };
 
     #[test]
@@ -839,6 +1144,211 @@ mod tests {
             next.skill.default_version,
             Some(created.version.version.clone())
         );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn update_skill_switches_default_projection() -> Result<()> {
+        let root = TempDir::new()?;
+        let blob_store = Arc::new(FilesystemBlobStore::new(root.path())?);
+        let service = SkillService::in_memory(blob_store);
+
+        let created = service
+            .create_skill(CreateSkillRequest {
+                tenant_id: "tenant-a".to_string(),
+                upload: SkillUpload::Files(vec![UploadedSkillFile {
+                    relative_path: "SKILL.md".to_string(),
+                    contents: b"---\nname: acme:map\ndescription: Map the repo\n---\nUse rg."
+                        .to_vec(),
+                    media_type: Some("text/markdown".to_string()),
+                }]),
+            })
+            .await?;
+
+        let second = service
+            .create_skill_version(CreateSkillVersionRequest {
+                tenant_id: "tenant-a".to_string(),
+                skill_id: created.skill.skill_id.clone(),
+                upload: SkillUpload::Files(vec![
+                    UploadedSkillFile {
+                        relative_path: "SKILL.md".to_string(),
+                        contents:
+                            b"---\nname: acme:search\ndescription: Search the repo\n---\nUse fd."
+                                .to_vec(),
+                        media_type: Some("text/markdown".to_string()),
+                    },
+                    UploadedSkillFile {
+                        relative_path: "scripts/run.py".to_string(),
+                        contents: b"print('v2')".to_vec(),
+                        media_type: Some("text/x-python".to_string()),
+                    },
+                ]),
+            })
+            .await?;
+
+        assert_eq!(second.skill.name, "acme:map");
+        assert!(!second.skill.has_code_files);
+
+        let updated = service
+            .update_skill(UpdateSkillRequest {
+                tenant_id: "tenant-a".to_string(),
+                skill_id: created.skill.skill_id.clone(),
+                default_version_ref: "2".to_string(),
+            })
+            .await?;
+
+        assert_eq!(
+            updated.default_version,
+            Some(second.version.version.clone())
+        );
+        assert_eq!(updated.name, "acme:search");
+        assert!(updated.has_code_files);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn delete_default_version_requires_switch_when_multiple_versions_remain() -> Result<()> {
+        let root = TempDir::new()?;
+        let blob_store = Arc::new(FilesystemBlobStore::new(root.path())?);
+        let service = SkillService::in_memory(blob_store);
+
+        let created = service
+            .create_skill(CreateSkillRequest {
+                tenant_id: "tenant-a".to_string(),
+                upload: SkillUpload::Files(vec![UploadedSkillFile {
+                    relative_path: "SKILL.md".to_string(),
+                    contents: b"---\nname: acme:map\ndescription: Map the repo\n---\nUse rg."
+                        .to_vec(),
+                    media_type: Some("text/markdown".to_string()),
+                }]),
+            })
+            .await?;
+        let second = service
+            .create_skill_version(CreateSkillVersionRequest {
+                tenant_id: "tenant-a".to_string(),
+                skill_id: created.skill.skill_id.clone(),
+                upload: SkillUpload::Files(vec![UploadedSkillFile {
+                    relative_path: "SKILL.md".to_string(),
+                    contents: b"---\nname: acme:search\ndescription: Search the repo\n---\nUse fd."
+                        .to_vec(),
+                    media_type: Some("text/markdown".to_string()),
+                }]),
+            })
+            .await?;
+
+        let error = service
+            .delete_skill_version(
+                "tenant-a",
+                &created.skill.skill_id,
+                &created.version.version,
+            )
+            .await
+            .expect_err("default version delete should fail");
+        assert!(matches!(
+            error,
+            super::SkillServiceError::CannotDeleteDefaultVersion { .. }
+        ));
+
+        let switched = service
+            .update_skill(UpdateSkillRequest {
+                tenant_id: "tenant-a".to_string(),
+                skill_id: created.skill.skill_id.clone(),
+                default_version_ref: second.version.version.clone(),
+            })
+            .await?;
+        assert_eq!(
+            switched.default_version,
+            Some(second.version.version.clone())
+        );
+
+        service
+            .delete_skill_version(
+                "tenant-a",
+                &created.skill.skill_id,
+                &created.version.version,
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn delete_last_version_removes_skill() -> Result<()> {
+        let root = TempDir::new()?;
+        let blob_store = Arc::new(FilesystemBlobStore::new(root.path())?);
+        let service = SkillService::in_memory(blob_store);
+
+        let created = service
+            .create_skill(CreateSkillRequest {
+                tenant_id: "tenant-a".to_string(),
+                upload: SkillUpload::Files(vec![UploadedSkillFile {
+                    relative_path: "SKILL.md".to_string(),
+                    contents: b"---\nname: acme:map\ndescription: Map the repo\n---\nUse rg."
+                        .to_vec(),
+                    media_type: Some("text/markdown".to_string()),
+                }]),
+            })
+            .await?;
+
+        let deleted = service
+            .delete_skill_version(
+                "tenant-a",
+                &created.skill.skill_id,
+                &created.version.version,
+            )
+            .await?;
+        assert!(deleted.deleted_skill);
+
+        let metadata_store = service
+            .metadata_store()
+            .ok_or_else(|| anyhow!("metadata store missing"))?;
+        assert!(metadata_store
+            .get_skill("tenant-a", &created.skill.skill_id)
+            .await?
+            .is_none());
+        assert!(metadata_store
+            .list_skill_versions(&created.skill.skill_id)
+            .await?
+            .is_empty());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn update_skill_version_marks_deprecated_and_updates_skill_timestamp() -> Result<()> {
+        let root = TempDir::new()?;
+        let blob_store = Arc::new(FilesystemBlobStore::new(root.path())?);
+        let service = SkillService::in_memory(blob_store);
+
+        let created = service
+            .create_skill(CreateSkillRequest {
+                tenant_id: "tenant-a".to_string(),
+                upload: SkillUpload::Files(vec![UploadedSkillFile {
+                    relative_path: "SKILL.md".to_string(),
+                    contents: b"---\nname: acme:map\ndescription: Map the repo\n---\nUse rg."
+                        .to_vec(),
+                    media_type: Some("text/markdown".to_string()),
+                }]),
+            })
+            .await?;
+        let before_updated_at = created.skill.updated_at;
+
+        let updated = service
+            .update_skill_version(UpdateSkillVersionRequest {
+                tenant_id: "tenant-a".to_string(),
+                skill_id: created.skill.skill_id.clone(),
+                version_ref: created.version.version.clone(),
+                deprecated: true,
+            })
+            .await?;
+        assert!(updated.deprecated);
+
+        let skill = service
+            .get_skill("tenant-a", &created.skill.skill_id)
+            .await?;
+        assert!(skill.updated_at >= before_updated_at);
 
         Ok(())
     }

--- a/crates/skills/src/lib.rs
+++ b/crates/skills/src/lib.rs
@@ -12,8 +12,9 @@ pub mod types;
 pub mod validation;
 
 pub use api::{
-    CreateSkillRequest, CreateSkillVersionRequest, SkillCreateResult, SkillService,
-    SkillServiceError, SkillServiceMode, SkillUpload, UploadedSkillFile,
+    CreateSkillRequest, CreateSkillVersionRequest, DeletedSkillVersionResult, SkillCreateResult,
+    SkillService, SkillServiceError, SkillServiceMode, SkillUpload, UpdateSkillRequest,
+    UpdateSkillVersionRequest, UploadedSkillFile,
 };
 pub use config::{
     SkillsAdminConfig, SkillsAdminOperation, SkillsBlobStoreBackend, SkillsBlobStoreConfig,

--- a/model_gateway/src/routers/skills/handlers.rs
+++ b/model_gateway/src/routers/skills/handlers.rs
@@ -9,18 +9,18 @@ use axum::{
 };
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use openai_protocol::skills::{
-    SkillGetQuery, SkillMutationResponse, SkillResponse, SkillVersionFileResponse,
-    SkillVersionResponse, SkillVersionsListQuery, SkillVersionsListResponse, SkillWarningResponse,
-    SkillsErrorBody, SkillsErrorEnvelope, SkillsListQuery, SkillsListResponse,
-    SKILLS_MULTIPART_BUNDLE_FIELD, SKILLS_MULTIPART_FILES_FIELD, SKILLS_MULTIPART_FILE_FIELD,
-    SKILLS_MULTIPART_TENANT_ID_FIELD,
+    SkillGetQuery, SkillMutationResponse, SkillPatchRequest, SkillResponse,
+    SkillVersionFileResponse, SkillVersionPatchRequest, SkillVersionRef, SkillVersionResponse,
+    SkillVersionsListQuery, SkillVersionsListResponse, SkillWarningResponse, SkillsErrorBody,
+    SkillsErrorEnvelope, SkillsListQuery, SkillsListResponse, SKILLS_MULTIPART_BUNDLE_FIELD,
+    SKILLS_MULTIPART_FILES_FIELD, SKILLS_MULTIPART_FILE_FIELD, SKILLS_MULTIPART_TENANT_ID_FIELD,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 use smg_skills::{
     CreateSkillRequest, CreateSkillVersionRequest, SkillCreateResult, SkillServiceError,
-    SkillUpload, UploadedSkillFile,
+    SkillUpload, UpdateSkillRequest, UpdateSkillVersionRequest, UploadedSkillFile,
 };
 
 use crate::{middleware::resolve_admin_target_tenant_key, server::AppState};
@@ -115,11 +115,19 @@ impl From<SkillServiceError> for SkillsApiError {
                     message: error.to_string(),
                 }
             }
+            SkillServiceError::CannotDeleteDefaultVersion { .. } => Self::Conflict {
+                code: "default_version_conflict",
+                message: error.to_string(),
+            },
             SkillServiceError::BundleBuild(_)
             | SkillServiceError::BlobStore(_)
             | SkillServiceError::Store(_)
             | SkillServiceError::MissingComponent { .. } => Self::Internal {
                 code: "skills_internal_error",
+                message: error.to_string(),
+            },
+            SkillServiceError::MissingDefaultVersion { .. } => Self::Conflict {
+                code: "default_version_missing",
                 message: error.to_string(),
             },
         }
@@ -164,10 +172,9 @@ pub async fn get_skill(
     Query(query): Query<SkillGetQuery>,
     headers: HeaderMap,
 ) -> Response {
-    match get_skill_impl(state, skill_id, query, &headers).await {
-        Ok(response) => response,
-        Err(error) => error.into_response(),
-    }
+    get_skill_impl(state, skill_id, query, &headers)
+        .await
+        .unwrap_or_else(|error| error.into_response())
 }
 
 pub async fn list_skill_versions(
@@ -176,10 +183,9 @@ pub async fn list_skill_versions(
     Query(query): Query<SkillVersionsListQuery>,
     headers: HeaderMap,
 ) -> Response {
-    match list_skill_versions_impl(state, skill_id, query, &headers).await {
-        Ok(response) => response,
-        Err(error) => error.into_response(),
-    }
+    list_skill_versions_impl(state, skill_id, query, &headers)
+        .await
+        .unwrap_or_else(|error| error.into_response())
 }
 
 pub async fn get_skill_version(
@@ -188,8 +194,53 @@ pub async fn get_skill_version(
     Query(query): Query<SkillGetQuery>,
     headers: HeaderMap,
 ) -> Response {
-    match get_skill_version_impl(state, skill_id, version, query, &headers).await {
-        Ok(response) => response,
+    get_skill_version_impl(state, skill_id, version, query, &headers)
+        .await
+        .unwrap_or_else(|error| error.into_response())
+}
+
+pub async fn patch_skill(
+    State(state): State<std::sync::Arc<AppState>>,
+    Path(skill_id): Path<String>,
+    Query(query): Query<SkillGetQuery>,
+    Json(body): Json<SkillPatchRequest>,
+) -> Response {
+    match patch_skill_impl(state, skill_id, query, body).await {
+        Ok(response) => Json(response).into_response(),
+        Err(error) => error.into_response(),
+    }
+}
+
+pub async fn patch_skill_version(
+    State(state): State<std::sync::Arc<AppState>>,
+    Path((skill_id, version)): Path<(String, String)>,
+    Query(query): Query<SkillGetQuery>,
+    Json(body): Json<SkillVersionPatchRequest>,
+) -> Response {
+    match patch_skill_version_impl(state, skill_id, version, query, body).await {
+        Ok(response) => Json(response).into_response(),
+        Err(error) => error.into_response(),
+    }
+}
+
+pub async fn delete_skill(
+    State(state): State<std::sync::Arc<AppState>>,
+    Path(skill_id): Path<String>,
+    Query(query): Query<SkillGetQuery>,
+) -> Response {
+    match delete_skill_impl(state, skill_id, query).await {
+        Ok(()) => StatusCode::NO_CONTENT.into_response(),
+        Err(error) => error.into_response(),
+    }
+}
+
+pub async fn delete_skill_version(
+    State(state): State<std::sync::Arc<AppState>>,
+    Path((skill_id, version)): Path<(String, String)>,
+    Query(query): Query<SkillGetQuery>,
+) -> Response {
+    match delete_skill_version_impl(state, skill_id, version, query).await {
+        Ok(()) => StatusCode::NO_CONTENT.into_response(),
         Err(error) => error.into_response(),
     }
 }
@@ -242,6 +293,106 @@ async fn create_skill_version_impl(
         .await
         .map_err(SkillsApiError::from)?;
     build_mutation_response(result)
+}
+
+async fn patch_skill_impl(
+    state: std::sync::Arc<AppState>,
+    skill_id: String,
+    query: SkillGetQuery,
+    body: SkillPatchRequest,
+) -> Result<SkillResponse, SkillsApiError> {
+    let skill_service =
+        state
+            .context
+            .skill_service
+            .clone()
+            .ok_or_else(|| SkillsApiError::Internal {
+                code: "skills_not_configured",
+                message: "skills service is not configured".to_string(),
+            })?;
+    let tenant_id = resolve_target_tenant_id(query.tenant_id.as_deref())?;
+    let updated = skill_service
+        .update_skill(UpdateSkillRequest {
+            tenant_id,
+            skill_id,
+            default_version_ref: skill_version_ref_to_string(&body.default_version),
+        })
+        .await
+        .map_err(SkillsApiError::from)?;
+    Ok(skill_response_from_record(&updated))
+}
+
+async fn patch_skill_version_impl(
+    state: std::sync::Arc<AppState>,
+    skill_id: String,
+    version: String,
+    query: SkillGetQuery,
+    body: SkillVersionPatchRequest,
+) -> Result<SkillVersionResponse, SkillsApiError> {
+    let skill_service =
+        state
+            .context
+            .skill_service
+            .clone()
+            .ok_or_else(|| SkillsApiError::Internal {
+                code: "skills_not_configured",
+                message: "skills service is not configured".to_string(),
+            })?;
+    let tenant_id = resolve_target_tenant_id(query.tenant_id.as_deref())?;
+    let updated = skill_service
+        .update_skill_version(UpdateSkillVersionRequest {
+            tenant_id,
+            skill_id,
+            version_ref: version,
+            deprecated: body.deprecated,
+        })
+        .await
+        .map_err(SkillsApiError::from)?;
+    skill_version_response_from_record(&updated)
+}
+
+async fn delete_skill_impl(
+    state: std::sync::Arc<AppState>,
+    skill_id: String,
+    query: SkillGetQuery,
+) -> Result<(), SkillsApiError> {
+    let skill_service =
+        state
+            .context
+            .skill_service
+            .clone()
+            .ok_or_else(|| SkillsApiError::Internal {
+                code: "skills_not_configured",
+                message: "skills service is not configured".to_string(),
+            })?;
+    let tenant_id = resolve_target_tenant_id(query.tenant_id.as_deref())?;
+    skill_service
+        .delete_skill(&tenant_id, &skill_id)
+        .await
+        .map_err(SkillsApiError::from)
+}
+
+async fn delete_skill_version_impl(
+    state: std::sync::Arc<AppState>,
+    skill_id: String,
+    version: String,
+    query: SkillGetQuery,
+) -> Result<(), SkillsApiError> {
+    let skill_service =
+        state
+            .context
+            .skill_service
+            .clone()
+            .ok_or_else(|| SkillsApiError::Internal {
+                code: "skills_not_configured",
+                message: "skills service is not configured".to_string(),
+            })?;
+    let tenant_id = resolve_target_tenant_id(query.tenant_id.as_deref())?;
+    skill_service
+        .delete_skill_version(&tenant_id, &skill_id, &version)
+        .await
+        .map(|_| ())
+        .map_err(SkillsApiError::from)
 }
 
 async fn list_skills_impl(
@@ -350,6 +501,10 @@ async fn list_skill_versions_impl(
             })?;
     let tenant_id = resolve_target_tenant_id(query.tenant_id.as_deref())?;
     let limit = validate_list_limit(query.limit)?;
+    let skill = skill_service
+        .get_skill(&tenant_id, &skill_id)
+        .await
+        .map_err(SkillsApiError::from)?;
     let mut versions = skill_service
         .list_skill_versions(&tenant_id, &skill_id, query.include_deprecated)
         .await
@@ -366,11 +521,14 @@ async fn list_skill_versions_impl(
 
     let etag = build_list_etag(
         &query,
-        versions
-            .iter()
-            .map(|record| (record.version.clone(), record.created_at.to_rfc3339())),
+        versions.iter().map(|record| {
+            (
+                record.version.clone(),
+                format!("{}:{}", record.created_at.to_rfc3339(), record.deprecated),
+            )
+        }),
     )?;
-    let last_modified = list_last_modified(versions.iter().map(|record| record.created_at));
+    let last_modified = skill.updated_at;
     if is_not_modified(request_headers, &etag, last_modified) {
         return not_modified_response(&etag, last_modified);
     }
@@ -408,13 +566,17 @@ async fn get_skill_version_impl(
                 message: "skills service is not configured".to_string(),
             })?;
     let tenant_id = resolve_target_tenant_id(query.tenant_id.as_deref())?;
+    let skill = skill_service
+        .get_skill(&tenant_id, &skill_id)
+        .await
+        .map_err(SkillsApiError::from)?;
     let record = skill_service
         .get_skill_version(&tenant_id, &skill_id, &version)
         .await
         .map_err(SkillsApiError::from)?;
     let response_body = skill_version_response_from_record(&record)?;
     let etag = build_resource_etag(&response_body, false)?;
-    let last_modified = record.created_at;
+    let last_modified = skill.updated_at;
     if is_not_modified(request_headers, &etag, last_modified) {
         return not_modified_response(&etag, last_modified);
     }
@@ -869,6 +1031,14 @@ fn skill_response_from_record(record: &smg_skills::SkillRecord) -> SkillResponse
         has_code_files: record.has_code_files,
         created_at: record.created_at.to_rfc3339(),
         updated_at: record.updated_at.to_rfc3339(),
+    }
+}
+
+fn skill_version_ref_to_string(version: &SkillVersionRef) -> String {
+    match version {
+        SkillVersionRef::Latest => "latest".to_string(),
+        SkillVersionRef::Integer(value) => value.to_string(),
+        SkillVersionRef::Timestamp(value) => value.clone(),
     }
 }
 

--- a/model_gateway/src/routers/skills/handlers.rs
+++ b/model_gateway/src/routers/skills/handlers.rs
@@ -126,7 +126,7 @@ impl From<SkillServiceError> for SkillsApiError {
                 code: "skills_internal_error",
                 message: error.to_string(),
             },
-            SkillServiceError::MissingDefaultVersion { .. } => Self::Conflict {
+            SkillServiceError::MissingDefaultVersion { .. } => Self::Internal {
                 code: "default_version_missing",
                 message: error.to_string(),
             },

--- a/model_gateway/src/routers/skills/mod.rs
+++ b/model_gateway/src/routers/skills/mod.rs
@@ -1,6 +1,6 @@
 mod handlers;
 
 pub use handlers::{
-    create_skill, create_skill_version, get_skill, get_skill_version, list_skill_versions,
-    list_skills,
+    create_skill, create_skill_version, delete_skill, delete_skill_version, get_skill,
+    get_skill_version, list_skill_versions, list_skills, patch_skill, patch_skill_version,
 };

--- a/model_gateway/src/server.rs
+++ b/model_gateway/src/server.rs
@@ -810,6 +810,15 @@ async fn v1_skills_get(
     skills::get_skill(State(state), Path(skill_id), query, headers).await
 }
 
+async fn v1_skills_patch(
+    State(state): State<Arc<AppState>>,
+    Path(skill_id): Path<String>,
+    query: Query<openai_protocol::skills::SkillGetQuery>,
+    ValidatedJson(body): ValidatedJson<openai_protocol::skills::SkillPatchRequest>,
+) -> Response {
+    skills::patch_skill(State(state), Path(skill_id), query, Json(body)).await
+}
+
 async fn v1_skills_create_version(
     State(state): State<Arc<AppState>>,
     Path(skill_id): Path<String>,
@@ -834,6 +843,31 @@ async fn v1_skills_get_version(
     headers: HeaderMap,
 ) -> Response {
     skills::get_skill_version(State(state), Path((skill_id, version)), query, headers).await
+}
+
+async fn v1_skills_patch_version(
+    State(state): State<Arc<AppState>>,
+    Path((skill_id, version)): Path<(String, String)>,
+    query: Query<openai_protocol::skills::SkillGetQuery>,
+    ValidatedJson(body): ValidatedJson<openai_protocol::skills::SkillVersionPatchRequest>,
+) -> Response {
+    skills::patch_skill_version(State(state), Path((skill_id, version)), query, Json(body)).await
+}
+
+async fn v1_skills_delete(
+    State(state): State<Arc<AppState>>,
+    Path(skill_id): Path<String>,
+    query: Query<openai_protocol::skills::SkillGetQuery>,
+) -> Response {
+    skills::delete_skill(State(state), Path(skill_id), query).await
+}
+
+async fn v1_skills_delete_version(
+    State(state): State<Arc<AppState>>,
+    Path((skill_id, version)): Path<(String, String)>,
+    query: Query<openai_protocol::skills::SkillGetQuery>,
+) -> Response {
+    skills::delete_skill_version(State(state), Path((skill_id, version)), query).await
 }
 
 pub struct ServerConfig {
@@ -1032,15 +1066,22 @@ pub fn build_app(
     {
         admin_routes = admin_routes
             .route("/v1/skills", post(v1_skills_create).get(v1_skills_list))
-            .route("/v1/skills/{skill_id}", get(v1_skills_get))
+            .route(
+                "/v1/skills/{skill_id}",
+                get(v1_skills_get)
+                    .patch(v1_skills_patch)
+                    .delete(v1_skills_delete),
+            )
             .route(
                 "/v1/skills/{skill_id}/versions",
                 post(v1_skills_create_version).get(v1_skills_list_versions),
+            )
+            .route(
+                "/v1/skills/{skill_id}/versions/{version}",
+                get(v1_skills_get_version)
+                    .patch(v1_skills_patch_version)
+                    .delete(v1_skills_delete_version),
             );
-        admin_routes = admin_routes.route(
-            "/v1/skills/{skill_id}/versions/{version}",
-            get(v1_skills_get_version),
-        );
     }
 
     // Build worker routes

--- a/model_gateway/src/server.rs
+++ b/model_gateway/src/server.rs
@@ -1684,7 +1684,13 @@ fn create_cors_layer(allowed_origins: Vec<String>) -> tower_http::cors::CorsLaye
 
         tower_http::cors::CorsLayer::new()
             .allow_origin(origins)
-            .allow_methods([http::Method::GET, http::Method::POST, http::Method::OPTIONS])
+            .allow_methods([
+                http::Method::GET,
+                http::Method::POST,
+                http::Method::PATCH,
+                http::Method::DELETE,
+                http::Method::OPTIONS,
+            ])
             .allow_headers([http::header::CONTENT_TYPE, http::header::AUTHORIZATION])
             .expose_headers([http::header::HeaderName::from_static("x-request-id")])
     };

--- a/model_gateway/tests/api/skills_api_test.rs
+++ b/model_gateway/tests/api/skills_api_test.rs
@@ -157,6 +157,31 @@ async fn create_skill_version_via_api(
     response.json().await.expect("json response")
 }
 
+fn extract_etag(response: &reqwest::Response) -> String {
+    response
+        .headers()
+        .get(reqwest::header::ETAG)
+        .expect("etag header")
+        .to_str()
+        .expect("etag text")
+        .to_string()
+}
+
+async fn assert_if_none_match_status(
+    request: reqwest::RequestBuilder,
+    etag: &str,
+    expected_status: reqwest::StatusCode,
+) {
+    let if_none_match = request
+        .try_clone()
+        .expect("clone request builder for etag")
+        .header(reqwest::header::IF_NONE_MATCH, etag)
+        .send()
+        .await
+        .expect("send If-None-Match request");
+    assert_eq!(if_none_match.status(), expected_status);
+}
+
 #[tokio::test]
 async fn create_skill_returns_created_skill_and_version() {
     let blob_dir = tempfile::tempdir().expect("blob tempdir");
@@ -696,6 +721,25 @@ async fn patch_skill_and_version_endpoints_update_default_and_deprecated_state()
         b"---\nname: acme:search\ndescription: Search the repo\n---\nUse fd.",
     )
     .await;
+    let skill_get = client
+        .get(format!("{base_url}/v1/skills/{skill_id}"))
+        .bearer_auth("test-admin-key")
+        .query(&[("tenant_id", "tenant-a")])
+        .send()
+        .await
+        .expect("send initial get skill request");
+    assert_eq!(skill_get.status(), reqwest::StatusCode::OK);
+    let skill_etag = extract_etag(&skill_get);
+    let _: Value = skill_get.json().await.expect("json response");
+    assert_if_none_match_status(
+        client
+            .get(format!("{base_url}/v1/skills/{skill_id}"))
+            .bearer_auth("test-admin-key")
+            .query(&[("tenant_id", "tenant-a")]),
+        &skill_etag,
+        reqwest::StatusCode::NOT_MODIFIED,
+    )
+    .await;
 
     let patch_skill = client
         .patch(format!("{base_url}/v1/skills/{skill_id}"))
@@ -714,6 +758,35 @@ async fn patch_skill_and_version_endpoints_update_default_and_deprecated_state()
         second["version"]["version"]
     );
     assert_eq!(patched_skill["name"], "acme:search");
+    assert_if_none_match_status(
+        client
+            .get(format!("{base_url}/v1/skills/{skill_id}"))
+            .bearer_auth("test-admin-key")
+            .query(&[("tenant_id", "tenant-a")]),
+        &skill_etag,
+        reqwest::StatusCode::OK,
+    )
+    .await;
+
+    let versions_before_patch = client
+        .get(format!("{base_url}/v1/skills/{skill_id}/versions"))
+        .bearer_auth("test-admin-key")
+        .query(&[("tenant_id", "tenant-a")])
+        .send()
+        .await
+        .expect("send pre-patch list versions request");
+    assert_eq!(versions_before_patch.status(), reqwest::StatusCode::OK);
+    let versions_etag = extract_etag(&versions_before_patch);
+    let _: Value = versions_before_patch.json().await.expect("json response");
+    assert_if_none_match_status(
+        client
+            .get(format!("{base_url}/v1/skills/{skill_id}/versions"))
+            .bearer_auth("test-admin-key")
+            .query(&[("tenant_id", "tenant-a")]),
+        &versions_etag,
+        reqwest::StatusCode::NOT_MODIFIED,
+    )
+    .await;
 
     let patch_version = client
         .patch(format!(
@@ -731,6 +804,15 @@ async fn patch_skill_and_version_endpoints_update_default_and_deprecated_state()
     assert_eq!(patch_version.status(), reqwest::StatusCode::OK);
     let patched_version: Value = patch_version.json().await.expect("json response");
     assert_eq!(patched_version["deprecated"], true);
+    assert_if_none_match_status(
+        client
+            .get(format!("{base_url}/v1/skills/{skill_id}/versions"))
+            .bearer_auth("test-admin-key")
+            .query(&[("tenant_id", "tenant-a")]),
+        &versions_etag,
+        reqwest::StatusCode::OK,
+    )
+    .await;
 
     let list_versions = client
         .get(format!("{base_url}/v1/skills/{skill_id}/versions"))
@@ -817,6 +899,26 @@ async fn delete_skill_version_and_skill_endpoints_enforce_default_and_cascade_ru
         .expect("send patch skill request");
     assert_eq!(patch_skill.status(), reqwest::StatusCode::OK);
 
+    let skill_before_delete = client
+        .get(format!("{base_url}/v1/skills/{skill_id}"))
+        .bearer_auth("test-admin-key")
+        .query(&[("tenant_id", "tenant-a")])
+        .send()
+        .await
+        .expect("send get skill before delete request");
+    assert_eq!(skill_before_delete.status(), reqwest::StatusCode::OK);
+    let skill_etag = extract_etag(&skill_before_delete);
+    let _: Value = skill_before_delete.json().await.expect("json response");
+    assert_if_none_match_status(
+        client
+            .get(format!("{base_url}/v1/skills/{skill_id}"))
+            .bearer_auth("test-admin-key")
+            .query(&[("tenant_id", "tenant-a")]),
+        &skill_etag,
+        reqwest::StatusCode::NOT_MODIFIED,
+    )
+    .await;
+
     let delete_first = client
         .delete(format!(
             "{base_url}/v1/skills/{skill_id}/versions/{}",
@@ -830,6 +932,15 @@ async fn delete_skill_version_and_skill_endpoints_enforce_default_and_cascade_ru
         .await
         .expect("send delete first version request");
     assert_eq!(delete_first.status(), reqwest::StatusCode::NO_CONTENT);
+    assert_if_none_match_status(
+        client
+            .get(format!("{base_url}/v1/skills/{skill_id}"))
+            .bearer_auth("test-admin-key")
+            .query(&[("tenant_id", "tenant-a")]),
+        &skill_etag,
+        reqwest::StatusCode::OK,
+    )
+    .await;
 
     let get_skill = client
         .get(format!("{base_url}/v1/skills/{skill_id}"))
@@ -839,6 +950,17 @@ async fn delete_skill_version_and_skill_endpoints_enforce_default_and_cascade_ru
         .await
         .expect("send get skill request");
     assert_eq!(get_skill.status(), reqwest::StatusCode::OK);
+    let post_delete_skill_etag = extract_etag(&get_skill);
+    let _: Value = get_skill.json().await.expect("json response");
+    assert_if_none_match_status(
+        client
+            .get(format!("{base_url}/v1/skills/{skill_id}"))
+            .bearer_auth("test-admin-key")
+            .query(&[("tenant_id", "tenant-a")]),
+        &post_delete_skill_etag,
+        reqwest::StatusCode::NOT_MODIFIED,
+    )
+    .await;
 
     let delete_last = client
         .delete(format!(
@@ -853,6 +975,15 @@ async fn delete_skill_version_and_skill_endpoints_enforce_default_and_cascade_ru
         .await
         .expect("send delete last version request");
     assert_eq!(delete_last.status(), reqwest::StatusCode::NO_CONTENT);
+    assert_if_none_match_status(
+        client
+            .get(format!("{base_url}/v1/skills/{skill_id}"))
+            .bearer_auth("test-admin-key")
+            .query(&[("tenant_id", "tenant-a")]),
+        &post_delete_skill_etag,
+        reqwest::StatusCode::NOT_FOUND,
+    )
+    .await;
 
     let missing_skill = client
         .get(format!("{base_url}/v1/skills/{skill_id}"))
@@ -870,6 +1001,26 @@ async fn delete_skill_version_and_skill_endpoints_enforce_default_and_cascade_ru
         b"---\nname: acme:delete\ndescription: Delete the repo map\n---\nUse rm carefully.",
     )
     .await;
+    let list_before_delete = client
+        .get(format!("{base_url}/v1/skills"))
+        .bearer_auth("test-admin-key")
+        .query(&[("tenant_id", "tenant-a")])
+        .send()
+        .await
+        .expect("send list skills before delete request");
+    assert_eq!(list_before_delete.status(), reqwest::StatusCode::OK);
+    let list_etag = extract_etag(&list_before_delete);
+    let _: Value = list_before_delete.json().await.expect("json response");
+    assert_if_none_match_status(
+        client
+            .get(format!("{base_url}/v1/skills"))
+            .bearer_auth("test-admin-key")
+            .query(&[("tenant_id", "tenant-a")]),
+        &list_etag,
+        reqwest::StatusCode::NOT_MODIFIED,
+    )
+    .await;
+
     let delete_skill = client
         .delete(format!(
             "{base_url}/v1/skills/{}",
@@ -881,6 +1032,15 @@ async fn delete_skill_version_and_skill_endpoints_enforce_default_and_cascade_ru
         .await
         .expect("send delete skill request");
     assert_eq!(delete_skill.status(), reqwest::StatusCode::NO_CONTENT);
+    assert_if_none_match_status(
+        client
+            .get(format!("{base_url}/v1/skills"))
+            .bearer_auth("test-admin-key")
+            .query(&[("tenant_id", "tenant-a")]),
+        &list_etag,
+        reqwest::StatusCode::OK,
+    )
+    .await;
 
     server.abort();
 }

--- a/model_gateway/tests/api/skills_api_test.rs
+++ b/model_gateway/tests/api/skills_api_test.rs
@@ -670,6 +670,222 @@ async fn invalid_after_cursor_returns_bad_request_before_conditional_cache_check
 }
 
 #[tokio::test]
+async fn patch_skill_and_version_endpoints_update_default_and_deprecated_state() {
+    let blob_dir = tempfile::tempdir().expect("blob tempdir");
+    let cache_dir = tempfile::tempdir().expect("cache tempdir");
+    let app = create_skills_test_app(skills_test_config(&blob_dir, &cache_dir, true)).await;
+    let (base_url, server) = spawn_app(app).await;
+    let client = reqwest::Client::new();
+
+    let created = create_skill_via_api(
+        &client,
+        &base_url,
+        "tenant-a",
+        b"---\nname: acme:map\ndescription: Map the repo\n---\nUse rg.",
+    )
+    .await;
+    let skill_id = created["skill"]["id"]
+        .as_str()
+        .expect("skill id")
+        .to_string();
+    let second = create_skill_version_via_api(
+        &client,
+        &base_url,
+        "tenant-a",
+        &skill_id,
+        b"---\nname: acme:search\ndescription: Search the repo\n---\nUse fd.",
+    )
+    .await;
+
+    let patch_skill = client
+        .patch(format!("{base_url}/v1/skills/{skill_id}"))
+        .bearer_auth("test-admin-key")
+        .query(&[("tenant_id", "tenant-a")])
+        .json(&serde_json::json!({
+            "default_version": 2
+        }))
+        .send()
+        .await
+        .expect("send patch skill request");
+    assert_eq!(patch_skill.status(), reqwest::StatusCode::OK);
+    let patched_skill: Value = patch_skill.json().await.expect("json response");
+    assert_eq!(
+        patched_skill["default_version"],
+        second["version"]["version"]
+    );
+    assert_eq!(patched_skill["name"], "acme:search");
+
+    let patch_version = client
+        .patch(format!(
+            "{base_url}/v1/skills/{skill_id}/versions/{}",
+            second["version"]["version"].as_str().expect("version id")
+        ))
+        .bearer_auth("test-admin-key")
+        .query(&[("tenant_id", "tenant-a")])
+        .json(&serde_json::json!({
+            "deprecated": true
+        }))
+        .send()
+        .await
+        .expect("send patch skill version request");
+    assert_eq!(patch_version.status(), reqwest::StatusCode::OK);
+    let patched_version: Value = patch_version.json().await.expect("json response");
+    assert_eq!(patched_version["deprecated"], true);
+
+    let list_versions = client
+        .get(format!("{base_url}/v1/skills/{skill_id}/versions"))
+        .bearer_auth("test-admin-key")
+        .query(&[("tenant_id", "tenant-a")])
+        .send()
+        .await
+        .expect("send list versions request");
+    assert_eq!(list_versions.status(), reqwest::StatusCode::OK);
+    let versions_body: Value = list_versions.json().await.expect("json response");
+    assert_eq!(versions_body["data"].as_array().map(Vec::len), Some(1));
+    assert_eq!(versions_body["data"][0]["version_number"], 1);
+
+    let include_deprecated = client
+        .get(format!("{base_url}/v1/skills/{skill_id}/versions"))
+        .bearer_auth("test-admin-key")
+        .query(&[("tenant_id", "tenant-a"), ("include_deprecated", "true")])
+        .send()
+        .await
+        .expect("send list versions include deprecated request");
+    assert_eq!(include_deprecated.status(), reqwest::StatusCode::OK);
+    let include_body: Value = include_deprecated.json().await.expect("json response");
+    assert_eq!(include_body["data"].as_array().map(Vec::len), Some(2));
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn delete_skill_version_and_skill_endpoints_enforce_default_and_cascade_rules() {
+    let blob_dir = tempfile::tempdir().expect("blob tempdir");
+    let cache_dir = tempfile::tempdir().expect("cache tempdir");
+    let app = create_skills_test_app(skills_test_config(&blob_dir, &cache_dir, true)).await;
+    let (base_url, server) = spawn_app(app).await;
+    let client = reqwest::Client::new();
+
+    let created = create_skill_via_api(
+        &client,
+        &base_url,
+        "tenant-a",
+        b"---\nname: acme:map\ndescription: Map the repo\n---\nUse rg.",
+    )
+    .await;
+    let skill_id = created["skill"]["id"]
+        .as_str()
+        .expect("skill id")
+        .to_string();
+    let second = create_skill_version_via_api(
+        &client,
+        &base_url,
+        "tenant-a",
+        &skill_id,
+        b"---\nname: acme:search\ndescription: Search the repo\n---\nUse fd.",
+    )
+    .await;
+
+    let delete_default = client
+        .delete(format!(
+            "{base_url}/v1/skills/{skill_id}/versions/{}",
+            created["version"]["version"]
+                .as_str()
+                .expect("default version id")
+        ))
+        .bearer_auth("test-admin-key")
+        .query(&[("tenant_id", "tenant-a")])
+        .send()
+        .await
+        .expect("send delete default version request");
+    assert_eq!(delete_default.status(), reqwest::StatusCode::CONFLICT);
+    let delete_default_body: Value = delete_default.json().await.expect("json response");
+    assert_eq!(
+        delete_default_body["error"]["code"],
+        "default_version_conflict"
+    );
+
+    let patch_skill = client
+        .patch(format!("{base_url}/v1/skills/{skill_id}"))
+        .bearer_auth("test-admin-key")
+        .query(&[("tenant_id", "tenant-a")])
+        .json(&serde_json::json!({
+            "default_version": second["version"]["version"]
+        }))
+        .send()
+        .await
+        .expect("send patch skill request");
+    assert_eq!(patch_skill.status(), reqwest::StatusCode::OK);
+
+    let delete_first = client
+        .delete(format!(
+            "{base_url}/v1/skills/{skill_id}/versions/{}",
+            created["version"]["version"]
+                .as_str()
+                .expect("first version id")
+        ))
+        .bearer_auth("test-admin-key")
+        .query(&[("tenant_id", "tenant-a")])
+        .send()
+        .await
+        .expect("send delete first version request");
+    assert_eq!(delete_first.status(), reqwest::StatusCode::NO_CONTENT);
+
+    let get_skill = client
+        .get(format!("{base_url}/v1/skills/{skill_id}"))
+        .bearer_auth("test-admin-key")
+        .query(&[("tenant_id", "tenant-a")])
+        .send()
+        .await
+        .expect("send get skill request");
+    assert_eq!(get_skill.status(), reqwest::StatusCode::OK);
+
+    let delete_last = client
+        .delete(format!(
+            "{base_url}/v1/skills/{skill_id}/versions/{}",
+            second["version"]["version"]
+                .as_str()
+                .expect("second version id")
+        ))
+        .bearer_auth("test-admin-key")
+        .query(&[("tenant_id", "tenant-a")])
+        .send()
+        .await
+        .expect("send delete last version request");
+    assert_eq!(delete_last.status(), reqwest::StatusCode::NO_CONTENT);
+
+    let missing_skill = client
+        .get(format!("{base_url}/v1/skills/{skill_id}"))
+        .bearer_auth("test-admin-key")
+        .query(&[("tenant_id", "tenant-a")])
+        .send()
+        .await
+        .expect("send get missing skill request");
+    assert_eq!(missing_skill.status(), reqwest::StatusCode::NOT_FOUND);
+
+    let created_again = create_skill_via_api(
+        &client,
+        &base_url,
+        "tenant-a",
+        b"---\nname: acme:delete\ndescription: Delete the repo map\n---\nUse rm carefully.",
+    )
+    .await;
+    let delete_skill = client
+        .delete(format!(
+            "{base_url}/v1/skills/{}",
+            created_again["skill"]["id"].as_str().expect("skill id")
+        ))
+        .bearer_auth("test-admin-key")
+        .query(&[("tenant_id", "tenant-a")])
+        .send()
+        .await
+        .expect("send delete skill request");
+    assert_eq!(delete_skill.status(), reqwest::StatusCode::NO_CONTENT);
+
+    server.abort();
+}
+
+#[tokio::test]
 async fn create_skill_route_is_not_mounted_when_skills_admin_is_disabled() {
     let blob_dir = tempfile::tempdir().expect("blob tempdir");
     let cache_dir = tempfile::tempdir().expect("cache tempdir");


### PR DESCRIPTION
## Summary
- add admin PATCH endpoints for switching a skill default version and toggling version deprecation
- add admin DELETE endpoints for deleting skills and skill versions with the default-version safety rule
- update read-side cache validators and API coverage so patch/delete state changes are reflected correctly

## Verification
- cargo +nightly fmt --all --check
- cargo test -p openai-protocol --test skills_protocol
- cargo test -p smg-skills --lib
- cargo test -p smg --test api_tests skills_api
- cargo clippy --all-targets --all-features -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PATCH endpoints to update a skill's default version and to mark skill versions as deprecated
  * DELETE endpoints to remove skills and skill versions
  * New request bodies for patch operations enforce strict JSON validation (unknown fields rejected)

* **Behavior Changes**
  * Service reprojections: skill metadata now derives from the effective default version when versions change
  * Version listings exclude deprecated versions by default; opt-in to include them
  * Caching/ETag and last-modified semantics now reflect skill-level updates; new conflict/missing error responses for default-version operations

* **Tests**
  * Added unit and integration tests covering patch/delete flows, strict deserialization, and listing/conditional-request behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->