### PR TITLE
fix(data-connector): scope startup migrations to core history

### DIFF
--- a/crates/data_connector/README.md
+++ b/crates/data_connector/README.md
@@ -408,6 +408,12 @@ migrations are detected, startup **fails with the exact SQL statements**
 needed so you can review and apply them manually. Set `auto_migrate: true`
 to opt in to automatic migration.
 
+Normal SQL history backend startup currently enforces only the **core history**
+migrations for conversations, conversation items, and responses. Optional
+subsystem schema (for example skills metadata or background-mode queue tables)
+must be managed by the subsystem that actually uses those tables rather than
+being forced on every history-backed deployment.
+
 On startup:
 1. Tables are created if they don't exist (`CREATE TABLE` / `CREATE TABLE IF NOT EXISTS`)
 2. The `_schema_versions` tracking table is created
@@ -415,12 +421,13 @@ On startup:
    - If `auto_migrate: true` → migrations are applied automatically
    - If `auto_migrate: false` (default) → startup fails with actionable SQL if migrations are pending
 
-Current migrations:
+Current core history migrations:
 
 | Version | Description |
 |---------|-------------|
 | 1 | Add `safety_identifier` column to responses |
 | 2 | Remove legacy `user_id` column from responses |
+| 3 | Drop redundant `output`, `metadata`, `instructions`, `tool_calls` columns from responses |
 
 #### Controlling migrations
 

--- a/crates/data_connector/src/oracle.rs
+++ b/crates/data_connector/src/oracle.rs
@@ -31,7 +31,7 @@ use crate::{
     },
     config::OracleConfig,
     context::current_extra_columns,
-    oracle_migrations::ORACLE_MIGRATIONS,
+    oracle_migrations::ORACLE_HISTORY_MIGRATIONS,
     schema::SchemaConfig,
 };
 
@@ -86,7 +86,7 @@ impl OracleStore {
         let applied = crate::versioning::run_oracle_migrations(
             &conn,
             &schema,
-            &ORACLE_MIGRATIONS,
+            &ORACLE_HISTORY_MIGRATIONS,
             schema.version,
             schema.auto_migrate,
         )?;

--- a/crates/data_connector/src/oracle_migrations.rs
+++ b/crates/data_connector/src/oracle_migrations.rs
@@ -7,85 +7,70 @@
 
 use crate::{schema::SchemaConfig, versioning::Migration};
 
+const ORACLE_V1: Migration = Migration {
+    version: 1,
+    description: "Add safety_identifier column to responses",
+    up: oracle_v1_up,
+};
+const ORACLE_V2: Migration = Migration {
+    version: 2,
+    description: "Remove legacy user_id column from responses",
+    up: oracle_v2_up,
+};
+const ORACLE_V3: Migration = Migration {
+    version: 3,
+    description: "Drop redundant output, metadata, instructions, tool_calls columns from responses",
+    up: oracle_v3_up,
+};
+const ORACLE_V4: Migration = Migration {
+    version: 4,
+    description: "Create skills table",
+    up: oracle_v4_up,
+};
+const ORACLE_V5: Migration = Migration {
+    version: 5,
+    description: "Create skill_versions table",
+    up: oracle_v5_up,
+};
+const ORACLE_V6: Migration = Migration {
+    version: 6,
+    description: "Create tenant_aliases table",
+    up: oracle_v6_up,
+};
+const ORACLE_V7: Migration = Migration {
+    version: 7,
+    description: "Create bundle_tokens table",
+    up: oracle_v7_up,
+};
+const ORACLE_V8: Migration = Migration {
+    version: 8,
+    description: "Create continuation_cookies table",
+    up: oracle_v8_up,
+};
+const ORACLE_V9: Migration = Migration {
+    version: 9,
+    description: "Extend responses with background-mode columns",
+    up: oracle_v9_up,
+};
+const ORACLE_V10: Migration = Migration {
+    version: 10,
+    description: "Create background_queue table",
+    up: oracle_v10_up,
+};
+const ORACLE_V11: Migration = Migration {
+    version: 11,
+    description: "Create response_stream_chunks table",
+    up: oracle_v11_up,
+};
+
 /// Core history-backend migrations required by the SQL response/conversation
 /// storage path during normal gateway startup.
-pub(crate) static ORACLE_HISTORY_MIGRATIONS: [Migration; 3] = [
-    Migration {
-        version: 1,
-        description: "Add safety_identifier column to responses",
-        up: oracle_v1_up,
-    },
-    Migration {
-        version: 2,
-        description: "Remove legacy user_id column from responses",
-        up: oracle_v2_up,
-    },
-    Migration {
-        version: 3,
-        description:
-            "Drop redundant output, metadata, instructions, tool_calls columns from responses",
-        up: oracle_v3_up,
-    },
-];
+pub(crate) static ORACLE_HISTORY_MIGRATIONS: [Migration; 3] = [ORACLE_V1, ORACLE_V2, ORACLE_V3];
 
 /// Oracle migration list. Append new migrations here.
 pub(crate) static ORACLE_MIGRATIONS: [Migration; 11] = [
-    Migration {
-        version: 1,
-        description: "Add safety_identifier column to responses",
-        up: oracle_v1_up,
-    },
-    Migration {
-        version: 2,
-        description: "Remove legacy user_id column from responses",
-        up: oracle_v2_up,
-    },
-    Migration {
-        version: 3,
-        description:
-            "Drop redundant output, metadata, instructions, tool_calls columns from responses",
-        up: oracle_v3_up,
-    },
-    Migration {
-        version: 4,
-        description: "Create skills table",
-        up: oracle_v4_up,
-    },
-    Migration {
-        version: 5,
-        description: "Create skill_versions table",
-        up: oracle_v5_up,
-    },
-    Migration {
-        version: 6,
-        description: "Create tenant_aliases table",
-        up: oracle_v6_up,
-    },
-    Migration {
-        version: 7,
-        description: "Create bundle_tokens table",
-        up: oracle_v7_up,
-    },
-    Migration {
-        version: 8,
-        description: "Create continuation_cookies table",
-        up: oracle_v8_up,
-    },
-    Migration {
-        version: 9,
-        description: "Extend responses with background-mode columns",
-        up: oracle_v9_up,
-    },
-    Migration {
-        version: 10,
-        description: "Create background_queue table",
-        up: oracle_v10_up,
-    },
-    Migration {
-        version: 11,
-        description: "Create response_stream_chunks table",
-        up: oracle_v11_up,
-    },
+    ORACLE_V1, ORACLE_V2, ORACLE_V3, ORACLE_V4, ORACLE_V5, ORACLE_V6, ORACLE_V7, ORACLE_V8,
+    ORACLE_V9, ORACLE_V10, ORACLE_V11,
 ];
 
 fn oracle_v1_up(schema: &SchemaConfig) -> Vec<String> {

--- a/crates/data_connector/src/oracle_migrations.rs
+++ b/crates/data_connector/src/oracle_migrations.rs
@@ -3,8 +3,30 @@
 //! Each migration is a function that generates Oracle DDL from [`SchemaConfig`],
 //! so it respects custom table/column names. PL/SQL exception handling ensures
 //! idempotency (safe to re-run if a previous attempt partially completed).
+#![cfg_attr(not(test), allow(dead_code))]
 
 use crate::{schema::SchemaConfig, versioning::Migration};
+
+/// Core history-backend migrations required by the SQL response/conversation
+/// storage path during normal gateway startup.
+pub(crate) static ORACLE_HISTORY_MIGRATIONS: [Migration; 3] = [
+    Migration {
+        version: 1,
+        description: "Add safety_identifier column to responses",
+        up: oracle_v1_up,
+    },
+    Migration {
+        version: 2,
+        description: "Remove legacy user_id column from responses",
+        up: oracle_v2_up,
+    },
+    Migration {
+        version: 3,
+        description:
+            "Drop redundant output, metadata, instructions, tool_calls columns from responses",
+        up: oracle_v3_up,
+    },
+];
 
 /// Oracle migration list. Append new migrations here.
 pub(crate) static ORACLE_MIGRATIONS: [Migration; 11] = [
@@ -448,6 +470,15 @@ fn oracle_v11_up(schema: &SchemaConfig) -> Vec<String> {
 mod tests {
     use super::*;
     use crate::schema::TableConfig;
+
+    #[test]
+    fn oracle_history_migrations_cover_only_core_history_schema() {
+        let versions: Vec<u32> = ORACLE_HISTORY_MIGRATIONS
+            .iter()
+            .map(|migration| migration.version)
+            .collect();
+        assert_eq!(versions, vec![1, 2, 3]);
+    }
 
     #[test]
     fn oracle_migrations_are_sequential() {

--- a/crates/data_connector/src/postgres.rs
+++ b/crates/data_connector/src/postgres.rs
@@ -28,7 +28,7 @@ use crate::{
         ListParams, NewConversation, NewConversationItem, ResponseId, ResponseResult,
         ResponseStorage, ResponseStorageError, SortOrder, StoredResponse,
     },
-    postgres_migrations::POSTGRES_MIGRATIONS,
+    postgres_migrations::POSTGRES_HISTORY_MIGRATIONS,
     schema::SchemaConfig,
 };
 
@@ -69,7 +69,7 @@ impl PostgresStore {
         crate::versioning::run_postgres_migrations(
             &mut client,
             &self.schema,
-            &POSTGRES_MIGRATIONS,
+            &POSTGRES_HISTORY_MIGRATIONS,
             self.schema.version,
             self.schema.auto_migrate,
         )

--- a/crates/data_connector/src/postgres_migrations.rs
+++ b/crates/data_connector/src/postgres_migrations.rs
@@ -3,8 +3,30 @@
 //! Each migration is a function that generates Postgres DDL from [`SchemaConfig`],
 //! so it respects custom table/column names. `IF NOT EXISTS` / `IF EXISTS`
 //! clauses ensure idempotency.
+#![cfg_attr(not(test), allow(dead_code))]
 
 use crate::{schema::SchemaConfig, versioning::Migration};
+
+/// Core history-backend migrations required by the SQL response/conversation
+/// storage path during normal gateway startup.
+pub(crate) static POSTGRES_HISTORY_MIGRATIONS: [Migration; 3] = [
+    Migration {
+        version: 1,
+        description: "Add safety_identifier column to responses",
+        up: pg_v1_up,
+    },
+    Migration {
+        version: 2,
+        description: "Remove legacy user_id column from responses",
+        up: pg_v2_up,
+    },
+    Migration {
+        version: 3,
+        description:
+            "Drop redundant output, metadata, instructions, tool_calls columns from responses",
+        up: pg_v3_up,
+    },
+];
 
 /// Postgres migration list. Append new migrations here.
 pub(crate) static POSTGRES_MIGRATIONS: [Migration; 11] = [
@@ -393,6 +415,15 @@ fn pg_v11_up(schema: &SchemaConfig) -> Vec<String> {
 mod tests {
     use super::*;
     use crate::schema::TableConfig;
+
+    #[test]
+    fn postgres_history_migrations_cover_only_core_history_schema() {
+        let versions: Vec<u32> = POSTGRES_HISTORY_MIGRATIONS
+            .iter()
+            .map(|migration| migration.version)
+            .collect();
+        assert_eq!(versions, vec![1, 2, 3]);
+    }
 
     #[test]
     fn postgres_migrations_are_sequential() {

--- a/crates/data_connector/src/postgres_migrations.rs
+++ b/crates/data_connector/src/postgres_migrations.rs
@@ -7,85 +7,80 @@
 
 use crate::{schema::SchemaConfig, versioning::Migration};
 
+const POSTGRES_V1: Migration = Migration {
+    version: 1,
+    description: "Add safety_identifier column to responses",
+    up: pg_v1_up,
+};
+const POSTGRES_V2: Migration = Migration {
+    version: 2,
+    description: "Remove legacy user_id column from responses",
+    up: pg_v2_up,
+};
+const POSTGRES_V3: Migration = Migration {
+    version: 3,
+    description: "Drop redundant output, metadata, instructions, tool_calls columns from responses",
+    up: pg_v3_up,
+};
+const POSTGRES_V4: Migration = Migration {
+    version: 4,
+    description: "Create skills table",
+    up: pg_v4_up,
+};
+const POSTGRES_V5: Migration = Migration {
+    version: 5,
+    description: "Create skill_versions table",
+    up: pg_v5_up,
+};
+const POSTGRES_V6: Migration = Migration {
+    version: 6,
+    description: "Create tenant_aliases table",
+    up: pg_v6_up,
+};
+const POSTGRES_V7: Migration = Migration {
+    version: 7,
+    description: "Create bundle_tokens table",
+    up: pg_v7_up,
+};
+const POSTGRES_V8: Migration = Migration {
+    version: 8,
+    description: "Create continuation_cookies table",
+    up: pg_v8_up,
+};
+const POSTGRES_V9: Migration = Migration {
+    version: 9,
+    description: "Extend responses with background-mode columns",
+    up: pg_v9_up,
+};
+const POSTGRES_V10: Migration = Migration {
+    version: 10,
+    description: "Create background_queue table",
+    up: pg_v10_up,
+};
+const POSTGRES_V11: Migration = Migration {
+    version: 11,
+    description: "Create response_stream_chunks table",
+    up: pg_v11_up,
+};
+
 /// Core history-backend migrations required by the SQL response/conversation
 /// storage path during normal gateway startup.
-pub(crate) static POSTGRES_HISTORY_MIGRATIONS: [Migration; 3] = [
-    Migration {
-        version: 1,
-        description: "Add safety_identifier column to responses",
-        up: pg_v1_up,
-    },
-    Migration {
-        version: 2,
-        description: "Remove legacy user_id column from responses",
-        up: pg_v2_up,
-    },
-    Migration {
-        version: 3,
-        description:
-            "Drop redundant output, metadata, instructions, tool_calls columns from responses",
-        up: pg_v3_up,
-    },
-];
+pub(crate) static POSTGRES_HISTORY_MIGRATIONS: [Migration; 3] =
+    [POSTGRES_V1, POSTGRES_V2, POSTGRES_V3];
 
 /// Postgres migration list. Append new migrations here.
 pub(crate) static POSTGRES_MIGRATIONS: [Migration; 11] = [
-    Migration {
-        version: 1,
-        description: "Add safety_identifier column to responses",
-        up: pg_v1_up,
-    },
-    Migration {
-        version: 2,
-        description: "Remove legacy user_id column from responses",
-        up: pg_v2_up,
-    },
-    Migration {
-        version: 3,
-        description:
-            "Drop redundant output, metadata, instructions, tool_calls columns from responses",
-        up: pg_v3_up,
-    },
-    Migration {
-        version: 4,
-        description: "Create skills table",
-        up: pg_v4_up,
-    },
-    Migration {
-        version: 5,
-        description: "Create skill_versions table",
-        up: pg_v5_up,
-    },
-    Migration {
-        version: 6,
-        description: "Create tenant_aliases table",
-        up: pg_v6_up,
-    },
-    Migration {
-        version: 7,
-        description: "Create bundle_tokens table",
-        up: pg_v7_up,
-    },
-    Migration {
-        version: 8,
-        description: "Create continuation_cookies table",
-        up: pg_v8_up,
-    },
-    Migration {
-        version: 9,
-        description: "Extend responses with background-mode columns",
-        up: pg_v9_up,
-    },
-    Migration {
-        version: 10,
-        description: "Create background_queue table",
-        up: pg_v10_up,
-    },
-    Migration {
-        version: 11,
-        description: "Create response_stream_chunks table",
-        up: pg_v11_up,
-    },
+    POSTGRES_V1,
+    POSTGRES_V2,
+    POSTGRES_V3,
+    POSTGRES_V4,
+    POSTGRES_V5,
+    POSTGRES_V6,
+    POSTGRES_V7,
+    POSTGRES_V8,
+    POSTGRES_V9,
+    POSTGRES_V10,
+    POSTGRES_V11,
 ];
 
 fn pg_v1_up(schema: &SchemaConfig) -> Vec<String> {

--- a/scripts/oracle_flyway/schema-config.yaml
+++ b/scripts/oracle_flyway/schema-config.yaml
@@ -1,10 +1,10 @@
 # SMG SchemaConfig for genai-data-plane Oracle tables (Flyway-managed)
 #
 # This schema is owned by Flyway, so the gateway must not try to apply its own
-# forward migrations during e2e startup. Keep this pinned to the latest router
-# migration version unless the Flyway-managed schema begins exercising those
-# new tables directly.
-version: 11
+# forward migrations during e2e startup. Pin this to the latest core history
+# migration version that the Flyway-managed schema actually provides. Optional
+# skills/background tables are owned by their feature-specific schema lifecycle.
+version: 3
 auto_migrate: false
 
 conversations:


### PR DESCRIPTION
## Summary
- scope normal Oracle/Postgres history-backend startup migrations to the core history schema only
- stop requiring optional skills and background tables for customer-managed history schemas
- align the Flyway Oracle schema pin with the core history migration version and document the distinction

## Testing
- cargo +nightly fmt --all --check
- cargo test -p data-connector
- cargo clippy -p data-connector --all-targets --all-features -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Migration version 3 applied to remove redundant response schema columns and align history migrations.

* **Documentation**
  * Clarified README guidance on core history migration scope and renamed section to “Current core history migrations”.

* **Refactor**
  * Oracle and Postgres now run a focused set of history migrations.

* **Tests**
  * Added checks ensuring history migration sets contain only versions 1–3.

* **Chores**
  * Updated schema pinning to version 3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->