### PR TITLE
fix(background): keep raw_response.status in sync with terminal transitions

### DIFF
--- a/crates/data_connector/src/memory_background.rs
+++ b/crates/data_connector/src/memory_background.rs
@@ -34,6 +34,16 @@ fn to_chrono(d: Duration) -> BackgroundRepositoryResult<chrono::Duration> {
     })
 }
 
+/// Patch `raw_response.status` so the persisted response payload agrees with
+/// the structured `responses.status` column after a terminal transition.
+/// Without this, `GET /v1/responses/{id}` returns the pre-cancel payload
+/// (e.g. `status: "queued"`) even though the row is terminal.
+fn overwrite_raw_response_status(raw: &mut Value, terminal: &str) {
+    if let Some(obj) = raw.as_object_mut() {
+        obj.insert("status".to_string(), Value::String(terminal.to_string()));
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum InternalStatus {
     Queued,
@@ -284,6 +294,7 @@ impl BackgroundResponseRepository for MemoryBackgroundRepository {
                 entry.completed_at = Some(now);
                 entry.worker_id = None;
                 entry.lease_expires_at = None;
+                overwrite_raw_response_status(&mut entry.raw_response, "cancelled");
                 Ok(StoredCancelResult::QueuedCancelled)
             }
             InternalStatus::InProgress => {
@@ -389,6 +400,12 @@ impl BackgroundResponseRepository for MemoryBackgroundRepository {
 
         entry.status = InternalStatus::from_finalize(final_status);
         entry.raw_response = update.raw_response;
+        // When cancel wins, overwrite the status field in the worker-supplied
+        // payload so `GET /v1/responses/{id}` doesn't return a payload that
+        // claims "completed" while the row is terminal-cancelled.
+        if cancel_won {
+            overwrite_raw_response_status(&mut entry.raw_response, "cancelled");
+        }
         entry.completed_at = Some(update.completed_at);
         entry.worker_id = None;
         entry.lease_expires_at = None;
@@ -744,6 +761,21 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn queued_cancel_rewrites_raw_response_status() {
+        // `GET /v1/responses/{id}` must see status=cancelled in the persisted
+        // payload, not the original queued snapshot.
+        let repo = MemoryBackgroundRepository::new();
+        repo.enqueue(enqueue_req("r1"), None).await.unwrap();
+        assert_eq!(
+            repo.request_cancel(&ResponseId::from("r1")).await.unwrap(),
+            StoredCancelResult::QueuedCancelled
+        );
+        let state = repo.state.read();
+        let entry = state.entries.get(&ResponseId::from("r1")).unwrap();
+        assert_eq!(entry.raw_response["status"], "cancelled");
+    }
+
+    #[tokio::test]
     async fn finalize_cancel_wins_over_worker_status() {
         let repo = MemoryBackgroundRepository::new();
         repo.enqueue(enqueue_req("r1"), None).await.unwrap();
@@ -767,6 +799,13 @@ mod tests {
             .unwrap();
         assert_eq!(result.final_status, FinalizeStatus::Cancelled);
         assert!(result.cancel_won);
+
+        // Worker's raw_response carried `status: "completed"` (see
+        // `finalize_req` helper). The repo must overwrite it so the persisted
+        // payload agrees with the row's terminal status.
+        let state = repo.state.read();
+        let entry = state.entries.get(&ResponseId::from("r1")).unwrap();
+        assert_eq!(entry.raw_response["status"], "cancelled");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Follow-up to BGM-PR-03 (#1340, merged). Addresses two P1 findings from chatgpt-codex that landed on the merged PR after the merge commit.

The persisted \`raw_response\` payload must agree with the structured \`responses.status\` column — otherwise \`GET /v1/responses/{id}\` returns a snapshot where \`status\` says one thing and the payload says another.

## What changed

**crates/data_connector/src/memory_background.rs**
- New helper \`overwrite_raw_response_status(&mut Value, &str)\` patches the top-level \`status\` field on a JSON \`Value\`, leaving everything else intact.
- \`request_cancel\` on a queued row calls \`overwrite_raw_response_status(..., \"cancelled\")\` after flipping the status. Previously, the payload stayed as the original queued object and clients polling immediately after cancel would see \`status: \"queued\"\` on the body even though the row was terminal.
- \`finalize\` with \`cancel_won=true\` also calls \`overwrite_raw_response_status(..., \"cancelled\")\` — the worker-supplied \`update.raw_response\` typically carries \`status: \"completed\"\` or \`\"failed\"\`, and the repo must overwrite to match the Cancelled status it wrote.

## Why

Two separate P1 comments from chatgpt-codex on #1340:
- [Queued-cancel raw_response drift](https://github.com/lightseekorg/smg/pull/1340#discussion_r...)
- [Finalize+cancel raw_response drift](https://github.com/lightseekorg/smg/pull/1340#discussion_r...)

Both are real \`GET\` consistency bugs. Fixed centrally via a single helper so the Postgres and Oracle backends (BGM-PR-05 / PR-06) can reuse the same convention.

## Test plan

- [x] \`cargo +nightly fmt --all\` — clean
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` — clean
- [x] \`cargo test -p data-connector --lib memory_background\` — **17 passed** (2 new): \`queued_cancel_rewrites_raw_response_status\`, and \`finalize_cancel_wins_over_worker_status\` extended to assert the patched \`raw_response\`

Refs: #1340

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed response status handling for cancelled requests to ensure "cancelled" status is correctly persisted in response payloads rather than retaining pre-cancellation values
  * Enhanced cancellation flow to prevent status values from being overwritten with incorrect data

* **Tests**
  * Added and updated tests to verify cancelled responses properly reflect their cancelled status

<!-- end of auto-generated comment: release notes by coderabbit.ai -->