### PR TITLE
feat(gateway): implement R6 image_generation tool integration

### DIFF
--- a/crates/mcp/src/core/config.rs
+++ b/crates/mcp/src/core/config.rs
@@ -300,6 +300,8 @@ pub enum BuiltinToolType {
     WebSearchPreview,
     /// Code interpreter tool (OpenAI: code_interpreter)
     CodeInterpreter,
+    /// Image generation tool (OpenAI: image_generation)
+    ImageGeneration,
     /// File search tool (OpenAI: file_search)
     FileSearch,
 }
@@ -310,6 +312,7 @@ impl BuiltinToolType {
         match self {
             BuiltinToolType::WebSearchPreview => ResponseFormatConfig::WebSearchCall,
             BuiltinToolType::CodeInterpreter => ResponseFormatConfig::CodeInterpreterCall,
+            BuiltinToolType::ImageGeneration => ResponseFormatConfig::ImageGenerationCall,
             BuiltinToolType::FileSearch => ResponseFormatConfig::FileSearchCall,
         }
     }
@@ -320,6 +323,7 @@ impl fmt::Display for BuiltinToolType {
         match self {
             BuiltinToolType::WebSearchPreview => write!(f, "web_search_preview"),
             BuiltinToolType::CodeInterpreter => write!(f, "code_interpreter"),
+            BuiltinToolType::ImageGeneration => write!(f, "image_generation"),
             BuiltinToolType::FileSearch => write!(f, "file_search"),
         }
     }
@@ -350,6 +354,7 @@ pub enum ResponseFormatConfig {
     WebSearchCall,
     CodeInterpreterCall,
     FileSearchCall,
+    ImageGenerationCall,
 }
 
 /// Argument mapping configuration for tool aliases.
@@ -1025,6 +1030,10 @@ tools:
                 "\"code_interpreter_call\"",
             ),
             (ResponseFormatConfig::FileSearchCall, "\"file_search_call\""),
+            (
+                ResponseFormatConfig::ImageGenerationCall,
+                "\"image_generation_call\"",
+            ),
         ];
 
         for (format, expected) in formats {
@@ -1190,6 +1199,7 @@ policy:
         let types = vec![
             (BuiltinToolType::WebSearchPreview, "\"web_search_preview\""),
             (BuiltinToolType::CodeInterpreter, "\"code_interpreter\""),
+            (BuiltinToolType::ImageGeneration, "\"image_generation\""),
             (BuiltinToolType::FileSearch, "\"file_search\""),
         ];
 
@@ -1211,6 +1221,10 @@ policy:
         assert_eq!(
             BuiltinToolType::CodeInterpreter.response_format(),
             ResponseFormatConfig::CodeInterpreterCall
+        );
+        assert_eq!(
+            BuiltinToolType::ImageGeneration.response_format(),
+            ResponseFormatConfig::ImageGenerationCall
         );
         assert_eq!(
             BuiltinToolType::FileSearch.response_format(),
@@ -1506,6 +1520,10 @@ servers:
         assert_eq!(
             BuiltinToolType::CodeInterpreter.to_string(),
             "code_interpreter"
+        );
+        assert_eq!(
+            BuiltinToolType::ImageGeneration.to_string(),
+            "image_generation"
         );
         assert_eq!(BuiltinToolType::FileSearch.to_string(), "file_search");
     }

--- a/crates/mcp/src/transform/transformer.rs
+++ b/crates/mcp/src/transform/transformer.rs
@@ -493,8 +493,10 @@ struct ImageGenerationPayload {
 /// 3. `{"result": "...", "revised_prompt": "..."}` — top-level object
 ///    (non-MCP adapters that return raw image payloads).
 ///
-/// Anything else returns an empty payload; the caller then emits a `Failed`
-/// status rather than inventing data.
+/// Anything else returns an empty payload. The caller
+/// (`to_image_generation_call`) still emits a `Completed` status in that case
+/// — matching the existing builtin-transformer contract — with an empty
+/// `result` string plus a `warn!` log as the failure signal.
 fn extract_image_generation_payload(result: &Value) -> ImageGenerationPayload {
     // Shape 3: bare object.
     if let Some(obj) = result.as_object() {

--- a/crates/mcp/src/transform/transformer.rs
+++ b/crates/mcp/src/transform/transformer.rs
@@ -2,8 +2,10 @@
 
 use openai_protocol::responses::{
     CodeInterpreterCallStatus, CodeInterpreterOutput, FileSearchCallStatus, FileSearchResult,
-    ResponseOutputItem, WebSearchAction, WebSearchCallStatus, WebSearchSource,
+    ImageGenerationCallStatus, ResponseOutputItem, WebSearchAction, WebSearchCallStatus,
+    WebSearchSource,
 };
+use serde_json::Value;
 use tracing::warn;
 
 use super::ResponseFormat;
@@ -28,7 +30,7 @@ pub fn mcp_response_item_id(source_id: &str) -> String {
 }
 
 /// Extract non-null `openai_response` objects from embedded MCP text-block payloads.
-pub fn extract_embedded_openai_responses(result: &serde_json::Value) -> Vec<serde_json::Value> {
+pub fn extract_embedded_openai_responses(result: &Value) -> Vec<Value> {
     let text_blocks = result
         .as_array()
         .map(|items| items.as_slice())
@@ -61,7 +63,7 @@ impl ResponseTransformer {
     ///
     /// Returns a `ResponseOutputItem` from the protocols crate.
     pub fn transform(
-        result: &serde_json::Value,
+        result: &Value,
         format: &ResponseFormat,
         tool_call_id: &str,
         server_label: &str,
@@ -79,12 +81,15 @@ impl ResponseTransformer {
                 Self::to_code_interpreter_call(result, tool_call_id)
             }
             ResponseFormat::FileSearchCall => Self::to_file_search_call(result, tool_call_id),
+            ResponseFormat::ImageGenerationCall => {
+                Self::to_image_generation_call(result, tool_call_id)
+            }
         }
     }
 
     /// Transform to mcp_call output (passthrough).
     fn to_mcp_call(
-        result: &serde_json::Value,
+        result: &Value,
         tool_call_id: &str,
         server_label: &str,
         tool_name: &str,
@@ -103,9 +108,9 @@ impl ResponseTransformer {
     }
 
     /// Flatten passthrough MCP results into the plain-string output shape used by OpenAI.
-    fn flatten_mcp_output(result: &serde_json::Value) -> String {
+    fn flatten_mcp_output(result: &Value) -> String {
         match result {
-            serde_json::Value::String(text) => text.clone(),
+            Value::String(text) => text.clone(),
             _ => {
                 let mut text_parts = Vec::new();
                 Self::collect_text_parts(result, &mut text_parts);
@@ -118,14 +123,14 @@ impl ResponseTransformer {
         }
     }
 
-    fn collect_text_parts(value: &serde_json::Value, text_parts: &mut Vec<String>) {
+    fn collect_text_parts(value: &Value, text_parts: &mut Vec<String>) {
         match value {
-            serde_json::Value::Array(items) => {
+            Value::Array(items) => {
                 for item in items {
                     Self::collect_text_parts(item, text_parts);
                 }
             }
-            serde_json::Value::Object(obj) => {
+            Value::Object(obj) => {
                 if obj.get("type").and_then(|v| v.as_str()) == Some("text") {
                     if let Some(text) = obj.get("text").and_then(|v| v.as_str()) {
                         text_parts.push(text.to_string());
@@ -163,7 +168,7 @@ impl ResponseTransformer {
 
     /// Transform MCP web search results to OpenAI web_search_call format.
     fn to_web_search_call(
-        result: &serde_json::Value,
+        result: &Value,
         tool_call_id: &str,
         arguments: &str,
     ) -> ResponseOutputItem {
@@ -186,10 +191,7 @@ impl ResponseTransformer {
     }
 
     /// Transform MCP code interpreter results to OpenAI code_interpreter_call format.
-    fn to_code_interpreter_call(
-        result: &serde_json::Value,
-        tool_call_id: &str,
-    ) -> ResponseOutputItem {
+    fn to_code_interpreter_call(result: &Value, tool_call_id: &str) -> ResponseOutputItem {
         let obj = result.as_object();
 
         let container_id = obj
@@ -214,8 +216,50 @@ impl ResponseTransformer {
         }
     }
 
+    /// Transform MCP image generation results to OpenAI image_generation_call format.
+    ///
+    /// Expected success payload shape (OpenAI Python SDK 2.8.1,
+    /// `openai/types/responses/response_image_generation_call.py`):
+    ///
+    /// ```text
+    /// {"result": "<base64 image bytes>", "revised_prompt": "...", "status": "completed"}
+    /// ```
+    ///
+    /// MCP wraps this as
+    /// `[{"type":"text","text":"<stringified-json-above>"}]`. We also tolerate
+    /// flat shapes where `result` sits directly on the content item.
+    ///
+    /// On failure (error text in the content block, or missing `result`),
+    /// `result` is left as an empty string and status is set to `Failed`;
+    /// `revised_prompt` is preserved when available. The spec requires
+    /// `result: String` on the server-side output item, so we always emit a
+    /// valid field — the fallback-text path (error messages) is intentionally
+    /// discarded into the gateway's logs via `warn!` to avoid leaking
+    /// server-side error text as if it were an image.
+    fn to_image_generation_call(result: &Value, tool_call_id: &str) -> ResponseOutputItem {
+        let payload = extract_image_generation_payload(result);
+
+        let (status, result_b64) = match payload.result {
+            Some(b64) if !b64.is_empty() => (ImageGenerationCallStatus::Completed, b64),
+            _ => {
+                warn!(
+                    tool_call_id,
+                    "image_generation MCP result is missing `result` (base64); emitting failed status"
+                );
+                (ImageGenerationCallStatus::Failed, String::new())
+            }
+        };
+
+        ResponseOutputItem::ImageGenerationCall {
+            id: format!("ig_{tool_call_id}"),
+            result: result_b64,
+            revised_prompt: payload.revised_prompt,
+            status,
+        }
+    }
+
     /// Transform MCP file search results to OpenAI file_search_call format.
-    fn to_file_search_call(result: &serde_json::Value, tool_call_id: &str) -> ResponseOutputItem {
+    fn to_file_search_call(result: &Value, tool_call_id: &str) -> ResponseOutputItem {
         let obj = result.as_object();
 
         let queries = Self::extract_queries(result);
@@ -237,7 +281,7 @@ impl ResponseTransformer {
     }
 
     /// Extract web sources from MCP result.
-    fn extract_web_sources(result: &serde_json::Value) -> Vec<WebSearchSource> {
+    fn extract_web_sources(result: &Value) -> Vec<WebSearchSource> {
         let mut sources = Vec::new();
 
         if result.is_array() {
@@ -284,7 +328,7 @@ impl ResponseTransformer {
     }
 
     /// Parse a single web source from JSON.
-    fn parse_web_source(item: &serde_json::Value) -> Option<WebSearchSource> {
+    fn parse_web_source(item: &Value) -> Option<WebSearchSource> {
         let obj = item.as_object()?;
         let url = obj.get("url").and_then(|v| v.as_str())?;
         let source_type = obj.get("type").and_then(|v| v.as_str()).unwrap_or("url");
@@ -295,7 +339,7 @@ impl ResponseTransformer {
     }
 
     /// Extract queries from MCP result.
-    fn extract_queries(result: &serde_json::Value) -> Vec<String> {
+    fn extract_queries(result: &Value) -> Vec<String> {
         let mut queries = Vec::new();
 
         if let Some(text_blocks) = result.as_array() {
@@ -342,7 +386,7 @@ impl ResponseTransformer {
     }
 
     fn extract_query_from_arguments(arguments: &str) -> Option<String> {
-        let args_json = serde_json::from_str::<serde_json::Value>(arguments).ok()?;
+        let args_json = serde_json::from_str::<Value>(arguments).ok()?;
         args_json
             .as_object()
             .and_then(|obj| obj.get("query"))
@@ -351,7 +395,7 @@ impl ResponseTransformer {
     }
 
     /// Extract code interpreter outputs from MCP result.
-    fn extract_code_outputs(result: &serde_json::Value) -> Vec<CodeInterpreterOutput> {
+    fn extract_code_outputs(result: &Value) -> Vec<CodeInterpreterOutput> {
         let mut outputs = Vec::new();
 
         if let Some(obj) = result.as_object() {
@@ -399,7 +443,7 @@ impl ResponseTransformer {
     }
 
     /// Extract file search results from MCP result.
-    fn extract_file_results(result: &serde_json::Value) -> Vec<FileSearchResult> {
+    fn extract_file_results(result: &Value) -> Vec<FileSearchResult> {
         result
             .as_object()
             .and_then(|obj| obj.get("results"))
@@ -409,7 +453,7 @@ impl ResponseTransformer {
     }
 
     /// Parse a file search result from JSON.
-    fn parse_file_result(item: &serde_json::Value) -> Option<FileSearchResult> {
+    fn parse_file_result(item: &Value) -> Option<FileSearchResult> {
         let obj = item.as_object()?;
         let file_id = obj.get("file_id").and_then(|v| v.as_str())?.to_string();
         let filename = obj.get("filename").and_then(|v| v.as_str())?.to_string();
@@ -426,7 +470,102 @@ impl ResponseTransformer {
     }
 }
 
-fn parse_text_block_payload(item: &serde_json::Value) -> Option<serde_json::Value> {
+/// Payload extracted from an MCP image_generation tool result.
+///
+/// Only fields present in T4's `ResponseOutputItem::ImageGenerationCall`
+/// variant (`result`, `revised_prompt`) are captured — the spec also allows
+/// other image-tool request knobs (`background`, `quality`, etc.) but those
+/// are not part of the server-side *output* item, so we intentionally do not
+/// parse them here.
+#[derive(Debug, Default)]
+struct ImageGenerationPayload {
+    result: Option<String>,
+    revised_prompt: Option<String>,
+}
+
+/// Extract the image-generation success payload from an MCP tool result.
+///
+/// Accepted shapes (first match wins):
+/// 1. `[{"type":"text","text":"{\"result\":\"<base64>\",\"revised_prompt\":\"...\"}"}]`
+///    — canonical: stringified JSON embedded in a text content block.
+/// 2. `[{"type":"text","result":"<base64>","revised_prompt":"..."}]`
+///    — flat: keys on the content item itself.
+/// 3. `{"result": "...", "revised_prompt": "..."}` — top-level object
+///    (non-MCP adapters that return raw image payloads).
+///
+/// Anything else returns an empty payload; the caller then emits a `Failed`
+/// status rather than inventing data.
+fn extract_image_generation_payload(result: &Value) -> ImageGenerationPayload {
+    // Shape 3: bare object.
+    if let Some(obj) = result.as_object() {
+        return ImageGenerationPayload {
+            result: obj
+                .get("result")
+                .and_then(Value::as_str)
+                .map(str::to_string),
+            revised_prompt: obj
+                .get("revised_prompt")
+                .and_then(Value::as_str)
+                .map(str::to_string),
+        };
+    }
+
+    let Some(items) = result.as_array() else {
+        return ImageGenerationPayload::default();
+    };
+
+    for item in items {
+        let Some(obj) = item.as_object() else {
+            continue;
+        };
+        if obj.get("type").and_then(Value::as_str) != Some("text") {
+            continue;
+        }
+
+        // Shape 2: flat.
+        let flat_result = obj
+            .get("result")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        if flat_result.is_some() {
+            return ImageGenerationPayload {
+                result: flat_result,
+                revised_prompt: obj
+                    .get("revised_prompt")
+                    .and_then(Value::as_str)
+                    .map(str::to_string),
+            };
+        }
+
+        // Shape 1: text-wrapped JSON.
+        let Some(text) = obj.get("text").and_then(Value::as_str) else {
+            continue;
+        };
+        let Ok(parsed) = serde_json::from_str::<Value>(text) else {
+            continue;
+        };
+        let Some(parsed_obj) = parsed.as_object() else {
+            continue;
+        };
+        let result = parsed_obj
+            .get("result")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        if result.is_some() {
+            return ImageGenerationPayload {
+                result,
+                revised_prompt: parsed_obj
+                    .get("revised_prompt")
+                    .and_then(Value::as_str)
+                    .map(str::to_string),
+            };
+        }
+    }
+
+    ImageGenerationPayload::default()
+}
+
+fn parse_text_block_payload(item: &Value) -> Option<Value> {
     let Some(obj) = item.as_object() else {
         warn!("Expected MCP result item to be an object");
         return None;
@@ -441,7 +580,7 @@ fn parse_text_block_payload(item: &serde_json::Value) -> Option<serde_json::Valu
         return None;
     };
 
-    match serde_json::from_str::<serde_json::Value>(text) {
+    match serde_json::from_str::<Value>(text) {
         Ok(payload) => Some(payload),
         Err(error) => {
             warn!("Failed to parse embedded MCP text block payload: {error}");
@@ -836,6 +975,117 @@ mod tests {
                 assert_eq!(outputs.unwrap().len(), 1);
             }
             _ => panic!("Expected CodeInterpreterCall"),
+        }
+    }
+
+    #[test]
+    fn test_image_generation_transform_embedded_json_success() {
+        let result = json!([
+            {
+                "type": "text",
+                "text": "{\"result\":\"AAAAAAAAAAAAAAAA\",\"revised_prompt\":\"a fluffy cat\",\"status\":\"completed\"}"
+            }
+        ]);
+
+        let transformed = ResponseTransformer::transform(
+            &result,
+            &ResponseFormat::ImageGenerationCall,
+            "req-img-1",
+            "server",
+            "generate_image",
+            r#"{"prompt":"a cat"}"#,
+        );
+
+        match transformed {
+            ResponseOutputItem::ImageGenerationCall {
+                id,
+                result,
+                revised_prompt,
+                status,
+            } => {
+                assert_eq!(id, "ig_req-img-1");
+                assert_eq!(result, "AAAAAAAAAAAAAAAA");
+                assert_eq!(revised_prompt, Some("a fluffy cat".to_string()));
+                assert_eq!(status, ImageGenerationCallStatus::Completed);
+            }
+            other => panic!("Expected ImageGenerationCall, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_image_generation_transform_flat_content_item() {
+        let result = json!([
+            {"type": "text", "result": "BBBBBBBBBBBB", "revised_prompt": "flat cat"}
+        ]);
+
+        let transformed = ResponseTransformer::transform(
+            &result,
+            &ResponseFormat::ImageGenerationCall,
+            "req-img-2",
+            "server",
+            "generate_image",
+            "{}",
+        );
+
+        match transformed {
+            ResponseOutputItem::ImageGenerationCall {
+                result,
+                revised_prompt,
+                status,
+                ..
+            } => {
+                assert_eq!(result, "BBBBBBBBBBBB");
+                assert_eq!(revised_prompt, Some("flat cat".to_string()));
+                assert_eq!(status, ImageGenerationCallStatus::Completed);
+            }
+            other => panic!("Expected ImageGenerationCall, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_image_generation_transform_top_level_object() {
+        let result = json!({"result": "CCCCCCC", "revised_prompt": "plain"});
+
+        let transformed = ResponseTransformer::transform(
+            &result,
+            &ResponseFormat::ImageGenerationCall,
+            "req-img-3",
+            "server",
+            "generate_image",
+            "{}",
+        );
+
+        match transformed {
+            ResponseOutputItem::ImageGenerationCall { result, status, .. } => {
+                assert_eq!(result, "CCCCCCC");
+                assert_eq!(status, ImageGenerationCallStatus::Completed);
+            }
+            other => panic!("Expected ImageGenerationCall, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_image_generation_transform_error_payload_yields_failed_status() {
+        // MCP surfaces tool errors as plain text in the content block.
+        let result = json!([
+            {"type": "text", "text": "Error executing tool generate_image: quota exceeded"}
+        ]);
+
+        let transformed = ResponseTransformer::transform(
+            &result,
+            &ResponseFormat::ImageGenerationCall,
+            "req-img-err",
+            "server",
+            "generate_image",
+            "{}",
+        );
+
+        match transformed {
+            ResponseOutputItem::ImageGenerationCall { result, status, .. } => {
+                assert!(result.is_empty());
+                assert_eq!(status, ImageGenerationCallStatus::Failed);
+            }
+            other => panic!("Expected ImageGenerationCall, got {other:?}"),
         }
     }
 

--- a/crates/mcp/src/transform/transformer.rs
+++ b/crates/mcp/src/transform/transformer.rs
@@ -518,11 +518,11 @@ fn extract_image_generation_payload(result: &Value) -> ImageGenerationPayload {
         let Some(obj) = item.as_object() else {
             continue;
         };
-        if obj.get("type").and_then(Value::as_str) != Some("text") {
-            continue;
-        }
 
-        // Shape 2: flat.
+        // Shape 2: flat variant. Some adapters emit `{"type":"image", "result":
+        // "..."}` rather than `{"type":"text", ...}`, so we accept any item
+        // type that carries a `result` string directly. This mirrors the
+        // compactor's flat-strip branch in `types.rs`.
         let flat_result = obj
             .get("result")
             .and_then(Value::as_str)
@@ -537,7 +537,12 @@ fn extract_image_generation_payload(result: &Value) -> ImageGenerationPayload {
             };
         }
 
-        // Shape 1: text-wrapped JSON.
+        // Shape 1: text-wrapped JSON. This path is specific to text content
+        // blocks — the `text` field only carries meaningful JSON for
+        // `type == "text"` items.
+        if obj.get("type").and_then(Value::as_str) != Some("text") {
+            continue;
+        }
         let Some(text) = obj.get("text").and_then(Value::as_str) else {
             continue;
         };
@@ -1036,6 +1041,38 @@ mod tests {
             } => {
                 assert_eq!(result, "BBBBBBBBBBBB");
                 assert_eq!(revised_prompt, Some("flat cat".to_string()));
+                assert_eq!(status, ImageGenerationCallStatus::Completed);
+            }
+            other => panic!("Expected ImageGenerationCall, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_image_generation_transform_flat_image_typed_content_item() {
+        // Adapters that emit `type: "image"` (not `"text"`) with a flat
+        // `result` must still round-trip to `Completed` status.
+        let result = json!([
+            {"type": "image", "result": "FFFFFFFFFFFF", "revised_prompt": "image-typed"}
+        ]);
+
+        let transformed = ResponseTransformer::transform(
+            &result,
+            &ResponseFormat::ImageGenerationCall,
+            "req-img-2b",
+            "server",
+            "generate_image",
+            "{}",
+        );
+
+        match transformed {
+            ResponseOutputItem::ImageGenerationCall {
+                result,
+                revised_prompt,
+                status,
+                ..
+            } => {
+                assert_eq!(result, "FFFFFFFFFFFF");
+                assert_eq!(revised_prompt, Some("image-typed".to_string()));
                 assert_eq!(status, ImageGenerationCallStatus::Completed);
             }
             other => panic!("Expected ImageGenerationCall, got {other:?}"),

--- a/crates/mcp/src/transform/transformer.rs
+++ b/crates/mcp/src/transform/transformer.rs
@@ -227,26 +227,26 @@ impl ResponseTransformer {
     ///
     /// MCP wraps this as
     /// `[{"type":"text","text":"<stringified-json-above>"}]`. We also tolerate
-    /// flat shapes where `result` sits directly on the content item.
+    /// flat content-item shapes and bare objects.
     ///
-    /// On failure (error text in the content block, or missing `result`),
-    /// `result` is left as an empty string and status is set to `Failed`;
-    /// `revised_prompt` is preserved when available. The spec requires
-    /// `result: String` on the server-side output item, so we always emit a
-    /// valid field — the fallback-text path (error messages) is intentionally
-    /// discarded into the gateway's logs via `warn!` to avoid leaking
-    /// server-side error text as if it were an image.
+    /// Status is always emitted as `Completed`, matching the existing
+    /// builtin-transformer contract (web_search_call, code_interpreter_call,
+    /// and file_search_call all return `Completed` regardless of payload
+    /// validity — their failure signal is structural, not status-coded). On a
+    /// malformed or error payload `result` is empty and the gateway logs a
+    /// warning; downstream clients can detect this via `result.is_empty()` but
+    /// the item itself remains a well-formed `image_generation_call`.
     fn to_image_generation_call(result: &Value, tool_call_id: &str) -> ResponseOutputItem {
         let payload = extract_image_generation_payload(result);
 
-        let (status, result_b64) = match payload.result {
-            Some(b64) if !b64.is_empty() => (ImageGenerationCallStatus::Completed, b64),
+        let result_b64 = match payload.result {
+            Some(b64) if !b64.is_empty() => b64,
             _ => {
                 warn!(
                     tool_call_id,
-                    "image_generation MCP result is missing `result` (base64); emitting failed status"
+                    "image_generation MCP result is missing `result` (base64); emitting empty result"
                 );
-                (ImageGenerationCallStatus::Failed, String::new())
+                String::new()
             }
         };
 
@@ -254,7 +254,7 @@ impl ResponseTransformer {
             id: format!("ig_{tool_call_id}"),
             result: result_b64,
             revised_prompt: payload.revised_prompt,
-            status,
+            status: ImageGenerationCallStatus::Completed,
         }
     }
 
@@ -523,17 +523,20 @@ fn extract_image_generation_payload(result: &Value) -> ImageGenerationPayload {
         // "..."}` rather than `{"type":"text", ...}`, so we accept any item
         // type that carries a `result` string directly. This mirrors the
         // compactor's flat-strip branch in `types.rs`.
+        // Return whenever *either* `result` or `revised_prompt` is present so
+        // the caller can preserve a revised prompt on partial/failed payloads.
         let flat_result = obj
             .get("result")
             .and_then(Value::as_str)
             .map(str::to_string);
-        if flat_result.is_some() {
+        let flat_revised_prompt = obj
+            .get("revised_prompt")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        if flat_result.is_some() || flat_revised_prompt.is_some() {
             return ImageGenerationPayload {
                 result: flat_result,
-                revised_prompt: obj
-                    .get("revised_prompt")
-                    .and_then(Value::as_str)
-                    .map(str::to_string),
+                revised_prompt: flat_revised_prompt,
             };
         }
 
@@ -556,13 +559,14 @@ fn extract_image_generation_payload(result: &Value) -> ImageGenerationPayload {
             .get("result")
             .and_then(Value::as_str)
             .map(str::to_string);
-        if result.is_some() {
+        let revised_prompt = parsed_obj
+            .get("revised_prompt")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        if result.is_some() || revised_prompt.is_some() {
             return ImageGenerationPayload {
                 result,
-                revised_prompt: parsed_obj
-                    .get("revised_prompt")
-                    .and_then(Value::as_str)
-                    .map(str::to_string),
+                revised_prompt,
             };
         }
     }
@@ -1102,8 +1106,42 @@ mod tests {
     }
 
     #[test]
-    fn test_image_generation_transform_error_payload_yields_failed_status() {
+    fn test_image_generation_transform_preserves_revised_prompt_when_result_missing() {
+        // A text-wrapped payload with only `revised_prompt` must still flow
+        // through to the output item (not fall back to default/empty).
+        let result = json!([
+            {"type": "text", "text": "{\"revised_prompt\":\"only prompt, no image\"}"}
+        ]);
+
+        let transformed = ResponseTransformer::transform(
+            &result,
+            &ResponseFormat::ImageGenerationCall,
+            "req-img-rp",
+            "server",
+            "generate_image",
+            "{}",
+        );
+
+        match transformed {
+            ResponseOutputItem::ImageGenerationCall {
+                result,
+                revised_prompt,
+                status,
+                ..
+            } => {
+                assert!(result.is_empty());
+                assert_eq!(revised_prompt, Some("only prompt, no image".to_string()));
+                assert_eq!(status, ImageGenerationCallStatus::Completed);
+            }
+            other => panic!("Expected ImageGenerationCall, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_image_generation_transform_error_payload_yields_empty_result_completed_status() {
         // MCP surfaces tool errors as plain text in the content block.
+        // The transformer matches existing builtin-transformer contract: always
+        // emit `Completed`, and signal failure via empty `result`.
         let result = json!([
             {"type": "text", "text": "Error executing tool generate_image: quota exceeded"}
         ]);
@@ -1120,7 +1158,7 @@ mod tests {
         match transformed {
             ResponseOutputItem::ImageGenerationCall { result, status, .. } => {
                 assert!(result.is_empty());
-                assert_eq!(status, ImageGenerationCallStatus::Failed);
+                assert_eq!(status, ImageGenerationCallStatus::Completed);
             }
             other => panic!("Expected ImageGenerationCall, got {other:?}"),
         }

--- a/crates/mcp/src/transform/types.rs
+++ b/crates/mcp/src/transform/types.rs
@@ -48,7 +48,6 @@ impl ResponseFormat {
 
         debug!(
             response_format = ?self,
-            input_len = output.to_string().len(),
             compacted_len = compacted.len(),
             "compact_tool_output_for_model_context"
         );
@@ -61,7 +60,10 @@ impl ResponseFormat {
 /// model only sees metadata (status, revised_prompt) when the transcript
 /// replays on subsequent turns.
 ///
-/// Input shapes we tolerate:
+/// Input shapes we tolerate (matching `extract_image_generation_payload` in
+/// the transformer):
+/// - `{"result": "<base64>", "revised_prompt": "..."}` — bare object, used by
+///   non-MCP adapters.
 /// - `[{"type":"text","text":"{\"result\":\"<base64>\",\"revised_prompt\":\"...\"}"}]`
 ///   — typical success: stringified JSON embedded in a text content block.
 /// - `[{"type":"text","result":"<base64>", ...}]` — flat variant where
@@ -70,6 +72,14 @@ impl ResponseFormat {
 /// Any shape we do not recognize falls through unchanged via
 /// `output.to_string()` so we never silently drop information.
 fn compact_image_generation(output: &Value) -> String {
+    // Shape 3: bare object. Strip base64 keys directly.
+    if let Some(obj) = output.as_object() {
+        let mut sanitized = obj.clone();
+        sanitized.remove("result");
+        sanitized.remove("data");
+        return Value::Object(sanitized).to_string();
+    }
+
     let Some(items) = output.as_array() else {
         return output.to_string();
     };
@@ -177,6 +187,24 @@ mod tests {
         assert!(!compacted.contains("BBBBBBBB"));
         assert!(!compacted.contains("CCCCCCCC"));
         assert!(compacted.contains("1024x1024"));
+    }
+
+    #[test]
+    fn compact_image_generation_strips_bare_object_result_and_data() {
+        // Shape 3: non-MCP adapter returning a bare object. Matches what the
+        // transformer's `extract_image_generation_payload` accepts.
+        let output = json!({
+            "result": "DDDDDDDD",
+            "data": "EEEEEEEE",
+            "revised_prompt": "keep-me",
+            "status": "completed"
+        });
+        let compacted =
+            ResponseFormat::ImageGenerationCall.compact_tool_output_for_model_context(&output);
+        assert!(!compacted.contains("DDDDDDDD"));
+        assert!(!compacted.contains("EEEEEEEE"));
+        assert!(compacted.contains("keep-me"));
+        assert!(compacted.contains("completed"));
     }
 
     #[test]

--- a/crates/mcp/src/transform/types.rs
+++ b/crates/mcp/src/transform/types.rs
@@ -1,6 +1,8 @@
 //! Response transformation types.
 
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tracing::debug;
 
 use crate::core::config::ResponseFormatConfig;
 
@@ -17,6 +19,89 @@ pub enum ResponseFormat {
     CodeInterpreterCall,
     /// Transform to OpenAI file_search_call format
     FileSearchCall,
+    /// Transform to OpenAI image_generation_call format
+    ImageGenerationCall,
+}
+
+impl ResponseFormat {
+    /// Compact the raw MCP tool output before feeding it back into model
+    /// context on subsequent turns.
+    ///
+    /// For most formats this is a no-op — the full raw output is fed back
+    /// verbatim (it's a short JSON blob, not a multi-megabyte base64).
+    ///
+    /// For `ImageGenerationCall`, the MCP tool response is of the shape
+    /// `[{"type":"text","text":"{\"result\":\"<base64>\",\"revised_prompt\":\"...\"}"}]`.
+    /// Echoing the full base64 into subsequent model context would waste
+    /// many thousands of tokens per turn; the model only needs to know that
+    /// an image was generated (plus any `revised_prompt` it rewrote).
+    /// This strips `result` / `data` (the base64 payloads) from the text
+    /// blocks, keeping status and revised prompt.
+    pub fn compact_tool_output_for_model_context(&self, output: &Value) -> String {
+        let compacted = match self {
+            ResponseFormat::Passthrough
+            | ResponseFormat::WebSearchCall
+            | ResponseFormat::CodeInterpreterCall
+            | ResponseFormat::FileSearchCall => output.to_string(),
+            ResponseFormat::ImageGenerationCall => compact_image_generation(output),
+        };
+
+        debug!(
+            response_format = ?self,
+            input_len = output.to_string().len(),
+            compacted_len = compacted.len(),
+            "compact_tool_output_for_model_context"
+        );
+
+        compacted
+    }
+}
+
+/// Strip base64 image payloads from MCP image-generation tool output so the
+/// model only sees metadata (status, revised_prompt) when the transcript
+/// replays on subsequent turns.
+///
+/// Input shapes we tolerate:
+/// - `[{"type":"text","text":"{\"result\":\"<base64>\",\"revised_prompt\":\"...\"}"}]`
+///   — typical success: stringified JSON embedded in a text content block.
+/// - `[{"type":"text","result":"<base64>", ...}]` — flat variant where
+///   `result`/`data` sit directly on the content item.
+///
+/// Any shape we do not recognize falls through unchanged via
+/// `output.to_string()` so we never silently drop information.
+fn compact_image_generation(output: &Value) -> String {
+    let Some(items) = output.as_array() else {
+        return output.to_string();
+    };
+
+    let mut sanitized = items.clone();
+    for item in &mut sanitized {
+        let Some(item_obj) = item.as_object_mut() else {
+            continue;
+        };
+
+        // Flat variant: strip base64 keys directly off the item.
+        let stripped_flat = item_obj.remove("result").is_some() | item_obj.remove("data").is_some();
+        if stripped_flat {
+            continue;
+        }
+
+        // Embedded variant: parse the `text` field as JSON, drop base64 keys,
+        // re-stringify.
+        let Some(text) = item_obj.get("text").and_then(Value::as_str) else {
+            continue;
+        };
+        let Ok(Value::Object(mut obj)) = serde_json::from_str::<Value>(text) else {
+            continue;
+        };
+        obj.remove("result");
+        obj.remove("data");
+        item_obj.insert(
+            "text".to_string(),
+            Value::String(Value::Object(obj).to_string()),
+        );
+    }
+    Value::Array(sanitized).to_string()
 }
 
 impl From<ResponseFormatConfig> for ResponseFormat {
@@ -26,12 +111,15 @@ impl From<ResponseFormatConfig> for ResponseFormat {
             ResponseFormatConfig::WebSearchCall => ResponseFormat::WebSearchCall,
             ResponseFormatConfig::CodeInterpreterCall => ResponseFormat::CodeInterpreterCall,
             ResponseFormatConfig::FileSearchCall => ResponseFormat::FileSearchCall,
+            ResponseFormatConfig::ImageGenerationCall => ResponseFormat::ImageGenerationCall,
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use serde_json::json;
+
     use super::*;
 
     #[test]
@@ -44,6 +132,10 @@ mod tests {
                 "\"code_interpreter_call\"",
             ),
             (ResponseFormat::FileSearchCall, "\"file_search_call\""),
+            (
+                ResponseFormat::ImageGenerationCall,
+                "\"image_generation_call\"",
+            ),
         ];
 
         for (format, expected) in formats {
@@ -58,5 +150,46 @@ mod tests {
     #[test]
     fn test_response_format_default() {
         assert_eq!(ResponseFormat::default(), ResponseFormat::Passthrough);
+    }
+
+    #[test]
+    fn compact_image_generation_strips_base64_from_embedded_text() {
+        let output = json!([
+            {
+                "type": "text",
+                "text": "{\"result\":\"AAAAAAAA\",\"revised_prompt\":\"a cat\",\"status\":\"completed\"}"
+            }
+        ]);
+        let compacted =
+            ResponseFormat::ImageGenerationCall.compact_tool_output_for_model_context(&output);
+        assert!(!compacted.contains("AAAAAAAA"));
+        assert!(compacted.contains("revised_prompt"));
+        assert!(compacted.contains("a cat"));
+    }
+
+    #[test]
+    fn compact_image_generation_strips_flat_result_and_data() {
+        let output = json!([
+            {"type": "image", "result": "BBBBBBBB", "data": "CCCCCCCC", "size": "1024x1024"}
+        ]);
+        let compacted =
+            ResponseFormat::ImageGenerationCall.compact_tool_output_for_model_context(&output);
+        assert!(!compacted.contains("BBBBBBBB"));
+        assert!(!compacted.contains("CCCCCCCC"));
+        assert!(compacted.contains("1024x1024"));
+    }
+
+    #[test]
+    fn compact_noop_formats_preserve_output_verbatim() {
+        let output = json!({"result": "keep-me", "status": "completed"});
+        for format in [
+            ResponseFormat::Passthrough,
+            ResponseFormat::WebSearchCall,
+            ResponseFormat::CodeInterpreterCall,
+            ResponseFormat::FileSearchCall,
+        ] {
+            let compacted = format.compact_tool_output_for_model_context(&output);
+            assert_eq!(compacted, output.to_string());
+        }
     }
 }

--- a/crates/protocols/src/event_types.rs
+++ b/crates/protocols/src/event_types.rs
@@ -263,6 +263,37 @@ impl fmt::Display for FileSearchCallEvent {
     }
 }
 
+/// Image generation call events for streaming
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ImageGenerationCallEvent {
+    InProgress,
+    Generating,
+    PartialImage,
+    Completed,
+}
+
+impl ImageGenerationCallEvent {
+    pub const IN_PROGRESS: &'static str = "response.image_generation_call.in_progress";
+    pub const GENERATING: &'static str = "response.image_generation_call.generating";
+    pub const PARTIAL_IMAGE: &'static str = "response.image_generation_call.partial_image";
+    pub const COMPLETED: &'static str = "response.image_generation_call.completed";
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::InProgress => Self::IN_PROGRESS,
+            Self::Generating => Self::GENERATING,
+            Self::PartialImage => Self::PARTIAL_IMAGE,
+            Self::Completed => Self::COMPLETED,
+        }
+    }
+}
+
+impl fmt::Display for ImageGenerationCallEvent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 /// Item type discriminators used in output items
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ItemType {
@@ -274,6 +305,7 @@ pub enum ItemType {
     WebSearchCall,
     CodeInterpreterCall,
     FileSearchCall,
+    ImageGenerationCall,
 }
 
 impl ItemType {
@@ -286,6 +318,7 @@ impl ItemType {
     pub const WEB_SEARCH_CALL: &'static str = "web_search_call";
     pub const CODE_INTERPRETER_CALL: &'static str = "code_interpreter_call";
     pub const FILE_SEARCH_CALL: &'static str = "file_search_call";
+    pub const IMAGE_GENERATION_CALL: &'static str = "image_generation_call";
 
     pub const fn as_str(self) -> &'static str {
         match self {
@@ -297,6 +330,7 @@ impl ItemType {
             Self::WebSearchCall => Self::WEB_SEARCH_CALL,
             Self::CodeInterpreterCall => Self::CODE_INTERPRETER_CALL,
             Self::FileSearchCall => Self::FILE_SEARCH_CALL,
+            Self::ImageGenerationCall => Self::IMAGE_GENERATION_CALL,
         }
     }
 
@@ -309,7 +343,10 @@ impl ItemType {
     pub const fn is_builtin_tool_call(self) -> bool {
         matches!(
             self,
-            Self::WebSearchCall | Self::CodeInterpreterCall | Self::FileSearchCall
+            Self::WebSearchCall
+                | Self::CodeInterpreterCall
+                | Self::FileSearchCall
+                | Self::ImageGenerationCall
         )
     }
 }

--- a/model_gateway/src/routers/common/mcp_utils.rs
+++ b/model_gateway/src/routers/common/mcp_utils.rs
@@ -118,9 +118,9 @@ pub async fn connect_mcp_servers(
 
 /// Routing information for a built-in tool type.
 ///
-/// When a built-in tool type (web_search_preview, code_interpreter, image_generation,
-/// file_search) is configured to route to an MCP server, this struct holds the
-/// routing details.
+/// When a built-in tool type (`web_search_preview`, `code_interpreter`,
+/// `image_generation`, `file_search`) is configured to route to an MCP
+/// server, this struct holds the routing details.
 #[derive(Debug, Clone)]
 pub struct BuiltinToolRouting {
     /// The built-in tool type being routed.
@@ -160,6 +160,7 @@ pub fn collect_builtin_routing(
             ResponseTool::WebSearchPreview(_) => BuiltinToolType::WebSearchPreview,
             ResponseTool::CodeInterpreter(_) => BuiltinToolType::CodeInterpreter,
             ResponseTool::ImageGeneration(_) => BuiltinToolType::ImageGeneration,
+            ResponseTool::FileSearch(_) => BuiltinToolType::FileSearch,
             _ => continue,
         };
 
@@ -201,6 +202,7 @@ pub fn extract_builtin_types(tools: &[ResponseTool]) -> Vec<BuiltinToolType> {
             ResponseTool::WebSearchPreview(_) => Some(BuiltinToolType::WebSearchPreview),
             ResponseTool::CodeInterpreter(_) => Some(BuiltinToolType::CodeInterpreter),
             ResponseTool::ImageGeneration(_) => Some(BuiltinToolType::ImageGeneration),
+            ResponseTool::FileSearch(_) => Some(BuiltinToolType::FileSearch),
             _ => None,
         })
         .collect()

--- a/model_gateway/src/routers/common/mcp_utils.rs
+++ b/model_gateway/src/routers/common/mcp_utils.rs
@@ -300,7 +300,8 @@ mod tests {
     use openai_protocol::{
         common::Function,
         responses::{
-            CodeInterpreterTool, FunctionTool, McpTool, ResponseTool, WebSearchPreviewTool,
+            CodeInterpreterTool, FileSearchTool, FunctionTool, ImageGenerationTool, McpTool,
+            ResponseTool, WebSearchPreviewTool,
         },
     };
     use serde_json::json;
@@ -528,6 +529,128 @@ mod tests {
             code_routing.response_format,
             ResponseFormat::CodeInterpreterCall
         );
+    }
+
+    #[tokio::test]
+    async fn test_collect_builtin_routing_with_image_generation_server() {
+        let mut image_tools = HashMap::new();
+        image_tools.insert(
+            "generate_image".to_string(),
+            ToolConfig {
+                response_format: ResponseFormatConfig::ImageGenerationCall,
+                ..Default::default()
+            },
+        );
+
+        let config = McpConfig {
+            servers: vec![McpServerConfig {
+                name: "image-server".to_string(),
+                transport: McpTransport::Streamable {
+                    url: "http://localhost:9997/image".to_string(),
+                    token: None,
+                    headers: HashMap::new(),
+                },
+                proxy: None,
+                required: false,
+                tools: Some(image_tools),
+                builtin_type: Some(BuiltinToolType::ImageGeneration),
+                builtin_tool_name: Some("generate_image".to_string()),
+                internal: false,
+            }],
+            pool: Default::default(),
+            proxy: None,
+            warmup: Vec::new(),
+            inventory: Default::default(),
+            policy: Default::default(),
+        };
+
+        let orchestrator = Arc::new(McpOrchestrator::new(config).await.unwrap());
+
+        let tools = vec![ResponseTool::ImageGeneration(ImageGenerationTool::default())];
+
+        let routing = collect_builtin_routing(&orchestrator, Some(&tools));
+
+        assert_eq!(routing.len(), 1);
+        assert_eq!(routing[0].builtin_type, BuiltinToolType::ImageGeneration);
+        assert_eq!(routing[0].server_name, "image-server");
+        assert_eq!(routing[0].tool_name, "generate_image");
+        assert_eq!(
+            routing[0].response_format,
+            ResponseFormat::ImageGenerationCall
+        );
+    }
+
+    #[tokio::test]
+    async fn test_collect_builtin_routing_with_file_search_server() {
+        let mut file_tools = HashMap::new();
+        file_tools.insert(
+            "file_search".to_string(),
+            ToolConfig {
+                response_format: ResponseFormatConfig::FileSearchCall,
+                ..Default::default()
+            },
+        );
+
+        let config = McpConfig {
+            servers: vec![McpServerConfig {
+                name: "file-server".to_string(),
+                transport: McpTransport::Streamable {
+                    url: "http://localhost:9996/files".to_string(),
+                    token: None,
+                    headers: HashMap::new(),
+                },
+                proxy: None,
+                required: false,
+                tools: Some(file_tools),
+                builtin_type: Some(BuiltinToolType::FileSearch),
+                builtin_tool_name: Some("file_search".to_string()),
+                internal: false,
+            }],
+            pool: Default::default(),
+            proxy: None,
+            warmup: Vec::new(),
+            inventory: Default::default(),
+            policy: Default::default(),
+        };
+
+        let orchestrator = Arc::new(McpOrchestrator::new(config).await.unwrap());
+
+        // `FileSearchTool` requires `vector_store_ids`, so no Default impl.
+        let tools = vec![ResponseTool::FileSearch(FileSearchTool {
+            vector_store_ids: vec!["vs_abc".to_string()],
+            filters: None,
+            max_num_results: None,
+            ranking_options: None,
+        })];
+
+        let routing = collect_builtin_routing(&orchestrator, Some(&tools));
+
+        assert_eq!(routing.len(), 1);
+        assert_eq!(routing[0].builtin_type, BuiltinToolType::FileSearch);
+        assert_eq!(routing[0].server_name, "file-server");
+        assert_eq!(routing[0].tool_name, "file_search");
+        assert_eq!(routing[0].response_format, ResponseFormat::FileSearchCall);
+    }
+
+    #[test]
+    fn test_extract_builtin_types_includes_image_generation_and_file_search() {
+        let tools = vec![
+            ResponseTool::WebSearchPreview(WebSearchPreviewTool::default()),
+            ResponseTool::CodeInterpreter(CodeInterpreterTool::default()),
+            ResponseTool::ImageGeneration(ImageGenerationTool::default()),
+            ResponseTool::FileSearch(FileSearchTool {
+                vector_store_ids: vec!["vs_abc".to_string()],
+                filters: None,
+                max_num_results: None,
+                ranking_options: None,
+            }),
+        ];
+
+        let types = extract_builtin_types(&tools);
+        assert!(types.contains(&BuiltinToolType::WebSearchPreview));
+        assert!(types.contains(&BuiltinToolType::CodeInterpreter));
+        assert!(types.contains(&BuiltinToolType::ImageGeneration));
+        assert!(types.contains(&BuiltinToolType::FileSearch));
     }
 
     // =========================================================================

--- a/model_gateway/src/routers/common/mcp_utils.rs
+++ b/model_gateway/src/routers/common/mcp_utils.rs
@@ -118,8 +118,9 @@ pub async fn connect_mcp_servers(
 
 /// Routing information for a built-in tool type.
 ///
-/// When a built-in tool type (web_search_preview, code_interpreter, file_search)
-/// is configured to route to an MCP server, this struct holds the routing details.
+/// When a built-in tool type (web_search_preview, code_interpreter, image_generation,
+/// file_search) is configured to route to an MCP server, this struct holds the
+/// routing details.
 #[derive(Debug, Clone)]
 pub struct BuiltinToolRouting {
     /// The built-in tool type being routed.
@@ -134,8 +135,8 @@ pub struct BuiltinToolRouting {
 
 /// Collect routing information for built-in tools in a request.
 ///
-/// Scans request tools for built-in types (web_search_preview, code_interpreter, file_search)
-/// and looks up configured MCP servers to handle them.
+/// Scans request tools for built-in types (web_search_preview, code_interpreter,
+/// image_generation, file_search) and looks up configured MCP servers to handle them.
 ///
 /// # Arguments
 /// * `mcp_orchestrator` - The MCP orchestrator with server configuration
@@ -158,6 +159,7 @@ pub fn collect_builtin_routing(
         let builtin_type = match tool {
             ResponseTool::WebSearchPreview(_) => BuiltinToolType::WebSearchPreview,
             ResponseTool::CodeInterpreter(_) => BuiltinToolType::CodeInterpreter,
+            ResponseTool::ImageGeneration(_) => BuiltinToolType::ImageGeneration,
             _ => continue,
         };
 
@@ -198,6 +200,7 @@ pub fn extract_builtin_types(tools: &[ResponseTool]) -> Vec<BuiltinToolType> {
         .filter_map(|t| match t {
             ResponseTool::WebSearchPreview(_) => Some(BuiltinToolType::WebSearchPreview),
             ResponseTool::CodeInterpreter(_) => Some(BuiltinToolType::CodeInterpreter),
+            ResponseTool::ImageGeneration(_) => Some(BuiltinToolType::ImageGeneration),
             _ => None,
         })
         .collect()

--- a/model_gateway/src/routers/common/mod.rs
+++ b/model_gateway/src/routers/common/mod.rs
@@ -24,4 +24,5 @@ pub mod header_utils;
 pub mod mcp_utils;
 pub mod persistence_utils;
 pub mod retry;
+pub mod tool_overrides;
 pub mod worker_selection;

--- a/model_gateway/src/routers/common/tool_overrides.rs
+++ b/model_gateway/src/routers/common/tool_overrides.rs
@@ -1,0 +1,225 @@
+//! Request-time built-in tool argument overrides.
+//!
+//! Built-in tools (like `image_generation`) let callers pin configuration on
+//! the request itself — for example, forcing `size: "1024x1024"` or
+//! `quality: "low"`. When the model later emits a tool call, its arguments may
+//! or may not echo that configuration. To respect the caller's intent, we
+//! merge request-level tool config on top of the model-emitted arguments
+//! right before dispatching the call to MCP. Request-level values win for
+//! overlapping keys.
+//!
+//! This mechanism is opt-in per `ResponseFormat`. Today it only applies to
+//! `ResponseFormat::ImageGenerationCall`; other formats pass through
+//! unchanged. Adding a new builtin tool that needs request-pinned arguments
+//! means extending `request_tool_overrides`.
+
+use openai_protocol::responses::{ResponseTool, ResponsesRequest};
+use serde_json::{to_value, Value};
+use smg_mcp::ResponseFormat;
+
+/// Returns request-level builtin-tool argument overrides for the given
+/// response format, or `None` if this format does not support pinning.
+///
+/// For `ResponseFormat::ImageGenerationCall`, this locates the first
+/// `ResponseTool::ImageGeneration` entry in the request's `tools` list,
+/// serializes the `ImageGenerationTool` struct to a JSON object, drops fields
+/// that serialized to `null` (so unset caller fields do not clobber valid
+/// model-emitted values), and returns the remaining key-value pairs.
+///
+/// Because `ImageGenerationTool` uses `#[serde_with::skip_serializing_none]`,
+/// unset `Option` fields already serialize as absent, not `null`. The
+/// explicit null filter is a defensive second line of defense in case the
+/// attribute is ever removed or a wrapped type serializes `null` explicitly.
+///
+/// The match on `ResponseFormat` is exhaustive; adding a new format requires
+/// touching this function to decide whether it supports overrides.
+pub(crate) fn request_tool_overrides(
+    response_format: &ResponseFormat,
+    original_body: &ResponsesRequest,
+) -> Option<Value> {
+    match response_format {
+        ResponseFormat::ImageGenerationCall => {}
+        ResponseFormat::Passthrough
+        | ResponseFormat::WebSearchCall
+        | ResponseFormat::CodeInterpreterCall
+        | ResponseFormat::FileSearchCall => return None,
+    }
+
+    let tools = original_body.tools.as_ref()?;
+
+    tools.iter().find_map(|tool| {
+        let mut serialized = match tool {
+            ResponseTool::ImageGeneration(image_tool) => match to_value(image_tool).ok()? {
+                Value::Object(obj) => obj,
+                _ => return None,
+            },
+            _ => return None,
+        };
+        serialized.retain(|_, v| !v.is_null());
+        if serialized.is_empty() {
+            None
+        } else {
+            Some(Value::Object(serialized))
+        }
+    })
+}
+
+/// Merge request-level tool-argument overrides into model-emitted tool call
+/// arguments, with request-level values winning on key conflicts.
+///
+/// `arguments` is mutated in place. If the format has no overrides, or the
+/// request does not carry a matching tool config, or `arguments` is not a
+/// JSON object, this is a no-op.
+pub(crate) fn apply_request_tool_overrides(
+    response_format: &ResponseFormat,
+    original_body: &ResponsesRequest,
+    arguments: &mut Value,
+) {
+    let Some(overrides) = request_tool_overrides(response_format, original_body) else {
+        return;
+    };
+    let Some(args_obj) = arguments.as_object_mut() else {
+        return;
+    };
+    let Some(override_obj) = overrides.as_object() else {
+        return;
+    };
+    for (k, v) in override_obj {
+        args_obj.insert(k.clone(), v.clone());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use openai_protocol::responses::{ImageGenerationTool, ResponseTool, ResponsesRequest};
+    use serde_json::json;
+    use smg_mcp::ResponseFormat;
+
+    use super::{apply_request_tool_overrides, request_tool_overrides};
+
+    fn request_with_image_tool(tool: ImageGenerationTool) -> ResponsesRequest {
+        ResponsesRequest {
+            tools: Some(vec![ResponseTool::ImageGeneration(tool)]),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn overrides_are_none_for_non_image_formats() {
+        let request = request_with_image_tool(ImageGenerationTool {
+            size: Some("512x512".to_string()),
+            ..Default::default()
+        });
+        for format in [
+            ResponseFormat::Passthrough,
+            ResponseFormat::WebSearchCall,
+            ResponseFormat::CodeInterpreterCall,
+            ResponseFormat::FileSearchCall,
+        ] {
+            assert!(request_tool_overrides(&format, &request).is_none());
+        }
+    }
+
+    #[test]
+    fn overrides_are_none_when_no_image_tool_present() {
+        let request = ResponsesRequest::default();
+        assert!(request_tool_overrides(&ResponseFormat::ImageGenerationCall, &request).is_none());
+    }
+
+    #[test]
+    fn overrides_drop_null_fields() {
+        // ImageGenerationTool uses skip_serializing_none, so fields that are
+        // `None` serialize as absent. Empty tool struct produces no overrides.
+        let request = request_with_image_tool(ImageGenerationTool::default());
+        assert!(request_tool_overrides(&ResponseFormat::ImageGenerationCall, &request).is_none());
+    }
+
+    #[test]
+    fn request_values_override_model_arguments() {
+        let request = request_with_image_tool(ImageGenerationTool {
+            size: Some("512x512".to_string()),
+            quality: Some("low".to_string()),
+            ..Default::default()
+        });
+        let mut arguments = json!({
+            "size": "1024x1024",
+            "quality": "high",
+            "prompt": "keep-me"
+        });
+
+        apply_request_tool_overrides(
+            &ResponseFormat::ImageGenerationCall,
+            &request,
+            &mut arguments,
+        );
+
+        assert_eq!(
+            arguments.get("size").and_then(|v| v.as_str()),
+            Some("512x512")
+        );
+        assert_eq!(
+            arguments.get("quality").and_then(|v| v.as_str()),
+            Some("low")
+        );
+        assert_eq!(
+            arguments.get("prompt").and_then(|v| v.as_str()),
+            Some("keep-me")
+        );
+    }
+
+    #[test]
+    fn apply_is_noop_when_arguments_not_object() {
+        let request = request_with_image_tool(ImageGenerationTool {
+            size: Some("512x512".to_string()),
+            ..Default::default()
+        });
+        let mut arguments = json!("not-an-object");
+        apply_request_tool_overrides(
+            &ResponseFormat::ImageGenerationCall,
+            &request,
+            &mut arguments,
+        );
+        assert_eq!(arguments, json!("not-an-object"));
+    }
+
+    #[test]
+    fn apply_is_noop_for_non_image_format() {
+        let request = request_with_image_tool(ImageGenerationTool {
+            size: Some("512x512".to_string()),
+            ..Default::default()
+        });
+        let mut arguments = json!({"size": "1024x1024"});
+        apply_request_tool_overrides(&ResponseFormat::WebSearchCall, &request, &mut arguments);
+        assert_eq!(
+            arguments.get("size").and_then(|v| v.as_str()),
+            Some("1024x1024")
+        );
+    }
+
+    #[test]
+    fn first_image_tool_wins_when_multiple_present() {
+        let request = ResponsesRequest {
+            tools: Some(vec![
+                ResponseTool::ImageGeneration(ImageGenerationTool {
+                    size: Some("512x512".to_string()),
+                    ..Default::default()
+                }),
+                ResponseTool::ImageGeneration(ImageGenerationTool {
+                    size: Some("1024x1024".to_string()),
+                    ..Default::default()
+                }),
+            ]),
+            ..Default::default()
+        };
+        let mut arguments = json!({});
+        apply_request_tool_overrides(
+            &ResponseFormat::ImageGenerationCall,
+            &request,
+            &mut arguments,
+        );
+        assert_eq!(
+            arguments.get("size").and_then(|v| v.as_str()),
+            Some("512x512")
+        );
+    }
+}

--- a/model_gateway/src/routers/grpc/common/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/common/responses/streaming.rs
@@ -8,7 +8,8 @@ use openai_protocol::{
     common::{Usage, UsageInfo},
     event_types::{
         CodeInterpreterCallEvent, ContentPartEvent, FileSearchCallEvent, FunctionCallEvent,
-        McpEvent, OutputItemEvent, OutputTextEvent, ResponseEvent, WebSearchCallEvent,
+        ImageGenerationCallEvent, McpEvent, OutputItemEvent, OutputTextEvent, ResponseEvent,
+        WebSearchCallEvent,
     },
     responses::{
         ResponseOutputItem, ResponseStatus, ResponsesRequest, ResponsesResponse, ResponsesUsage,
@@ -32,6 +33,7 @@ pub(crate) enum OutputItemType {
     WebSearchCall,
     CodeInterpreterCall,
     FileSearchCall,
+    ImageGenerationCall,
 }
 
 /// Status of an output item
@@ -475,6 +477,7 @@ impl ResponseStreamEventEmitter {
             ResponseFormat::WebSearchCall => WebSearchCallEvent::IN_PROGRESS,
             ResponseFormat::CodeInterpreterCall => CodeInterpreterCallEvent::IN_PROGRESS,
             ResponseFormat::FileSearchCall => FileSearchCallEvent::IN_PROGRESS,
+            ResponseFormat::ImageGenerationCall => ImageGenerationCallEvent::IN_PROGRESS,
             ResponseFormat::Passthrough => McpEvent::CALL_IN_PROGRESS,
         };
         self.emit_tool_event(event_type, output_index, item_id)
@@ -491,6 +494,7 @@ impl ResponseStreamEventEmitter {
             ResponseFormat::WebSearchCall => WebSearchCallEvent::SEARCHING,
             ResponseFormat::CodeInterpreterCall => CodeInterpreterCallEvent::INTERPRETING,
             ResponseFormat::FileSearchCall => FileSearchCallEvent::SEARCHING,
+            ResponseFormat::ImageGenerationCall => ImageGenerationCallEvent::GENERATING,
             ResponseFormat::Passthrough => return None,
         };
         Some(self.emit_tool_event(event_type, output_index, item_id))
@@ -507,6 +511,7 @@ impl ResponseStreamEventEmitter {
             ResponseFormat::WebSearchCall => WebSearchCallEvent::COMPLETED,
             ResponseFormat::CodeInterpreterCall => CodeInterpreterCallEvent::COMPLETED,
             ResponseFormat::FileSearchCall => FileSearchCallEvent::COMPLETED,
+            ResponseFormat::ImageGenerationCall => ImageGenerationCallEvent::COMPLETED,
             ResponseFormat::Passthrough => McpEvent::CALL_COMPLETED,
         };
         self.emit_tool_event(event_type, output_index, item_id)
@@ -522,6 +527,7 @@ impl ResponseStreamEventEmitter {
             Some(ResponseFormat::WebSearchCall) => "web_search_call",
             Some(ResponseFormat::CodeInterpreterCall) => "code_interpreter_call",
             Some(ResponseFormat::FileSearchCall) => "file_search_call",
+            Some(ResponseFormat::ImageGenerationCall) => "image_generation_call",
             Some(ResponseFormat::Passthrough) => "mcp_call",
             None => "function_call",
         }
@@ -533,6 +539,7 @@ impl ResponseStreamEventEmitter {
             Some(ResponseFormat::WebSearchCall) => OutputItemType::WebSearchCall,
             Some(ResponseFormat::CodeInterpreterCall) => OutputItemType::CodeInterpreterCall,
             Some(ResponseFormat::FileSearchCall) => OutputItemType::FileSearchCall,
+            Some(ResponseFormat::ImageGenerationCall) => OutputItemType::ImageGenerationCall,
             Some(ResponseFormat::Passthrough) => OutputItemType::McpCall,
             None => OutputItemType::FunctionCall,
         }
@@ -626,6 +633,7 @@ impl ResponseStreamEventEmitter {
             OutputItemType::WebSearchCall => "ws",
             OutputItemType::CodeInterpreterCall => "ci",
             OutputItemType::FileSearchCall => "fs",
+            OutputItemType::ImageGenerationCall => "ig",
         };
 
         let id = Self::generate_item_id(id_prefix);

--- a/model_gateway/src/routers/openai/mcp/tool_loop.rs
+++ b/model_gateway/src/routers/openai/mcp/tool_loop.rs
@@ -14,8 +14,8 @@ use axum::http::HeaderMap;
 use bytes::Bytes;
 use openai_protocol::{
     event_types::{
-        is_function_call_type, CodeInterpreterCallEvent, FileSearchCallEvent, ItemType, McpEvent,
-        OutputItemEvent, WebSearchCallEvent,
+        is_function_call_type, CodeInterpreterCallEvent, FileSearchCallEvent,
+        ImageGenerationCallEvent, ItemType, McpEvent, OutputItemEvent, WebSearchCallEvent,
     },
     responses::{generate_id, ResponseInput, ResponseTool, ResponsesRequest},
 };
@@ -31,7 +31,10 @@ use super::tool_handler::FunctionCallInProgress;
 use crate::{
     observability::metrics::{metrics_labels, Metrics},
     routers::{
-        common::{header_utils::ApiProvider, mcp_utils::DEFAULT_MAX_ITERATIONS},
+        common::{
+            header_utils::ApiProvider, mcp_utils::DEFAULT_MAX_ITERATIONS,
+            tool_overrides::apply_request_tool_overrides,
+        },
         error,
     },
 };
@@ -156,7 +159,7 @@ pub(crate) async fn execute_streaming_tool_calls(
     tx: &mpsc::UnboundedSender<Result<Bytes, io::Error>>,
     state: &mut ToolLoopState,
     sequence_number: &mut u64,
-    model_id: &str,
+    original_body: &ResponsesRequest,
 ) -> bool {
     for call in pending_calls {
         if call.name.is_empty() {
@@ -181,7 +184,7 @@ pub(crate) async fn execute_streaming_tool_calls(
         let response_format = session.tool_response_format(&call.name);
         let server_label = session.resolve_tool_server_label(&call.name);
 
-        let arguments: Value = match serde_json::from_str(args_str) {
+        let mut arguments: Value = match serde_json::from_str(args_str) {
             Ok(v) => v,
             Err(e) => {
                 let err_str = format!("Failed to parse tool arguments: {e}");
@@ -222,11 +225,15 @@ pub(crate) async fn execute_streaming_tool_calls(
             }
         };
 
+        // Merge caller-pinned tool config (e.g. image_generation `size`,
+        // `quality`) over model-emitted arguments before dispatch.
+        apply_request_tool_overrides(&response_format, original_body, &mut arguments);
+
         if !send_tool_call_intermediate_event(tx, &call, &response_format, sequence_number) {
             return false;
         }
 
-        debug!("Calling MCP tool '{}' with args: {}", call.name, args_str);
+        debug!("Calling MCP tool '{}' with args: {}", call.name, arguments);
         let tool_output = session
             .execute_tool(ToolExecutionInput {
                 call_id: call.call_id.clone(),
@@ -235,9 +242,13 @@ pub(crate) async fn execute_streaming_tool_calls(
             })
             .await;
 
-        Metrics::record_mcp_tool_duration(model_id, &tool_output.tool_name, tool_output.duration);
+        Metrics::record_mcp_tool_duration(
+            &original_body.model,
+            &tool_output.tool_name,
+            tool_output.duration,
+        );
         Metrics::record_mcp_tool_call(
-            model_id,
+            &original_body.model,
             &tool_output.tool_name,
             if tool_output.is_error {
                 metrics_labels::RESULT_ERROR
@@ -246,7 +257,11 @@ pub(crate) async fn execute_streaming_tool_calls(
             },
         );
 
-        let output_str = tool_output.output.to_string();
+        // Feed a compacted view of the tool output back into the model's
+        // conversation history — for image_generation this drops the
+        // multi-MB base64 while keeping revised_prompt/status.
+        let model_context_output =
+            response_format.compact_tool_output_for_model_context(&tool_output.output);
         let mut mcp_call_item = to_value(tool_output.to_response_item()).unwrap_or_else(|e| {
             warn!(tool = %call.name, error = %e, "Failed to convert item to Value");
             json!({})
@@ -273,7 +288,7 @@ pub(crate) async fn execute_streaming_tool_calls(
             call.call_id,
             call.name,
             call.arguments_buffer,
-            output_str,
+            model_context_output,
             mcp_call_item,
         );
     }
@@ -466,6 +481,7 @@ fn send_tool_call_intermediate_event(
         ResponseFormat::WebSearchCall => WebSearchCallEvent::SEARCHING,
         ResponseFormat::CodeInterpreterCall => CodeInterpreterCallEvent::INTERPRETING,
         ResponseFormat::FileSearchCall => FileSearchCallEvent::SEARCHING,
+        ResponseFormat::ImageGenerationCall => ImageGenerationCallEvent::GENERATING,
         ResponseFormat::Passthrough => return true, // mcp_call has no intermediate event
     };
 
@@ -508,6 +524,7 @@ fn send_tool_call_completion_events(
         ItemType::WEB_SEARCH_CALL => WebSearchCallEvent::COMPLETED,
         ItemType::CODE_INTERPRETER_CALL => CodeInterpreterCallEvent::COMPLETED,
         ItemType::FILE_SEARCH_CALL => FileSearchCallEvent::COMPLETED,
+        ItemType::IMAGE_GENERATION_CALL => ImageGenerationCallEvent::COMPLETED,
         _ => McpEvent::CALL_COMPLETED, // Default to mcp_call for mcp_call and unknown types
     };
 
@@ -553,6 +570,7 @@ fn stable_streaming_tool_item_id(
         ResponseFormat::WebSearchCall => normalize_tool_item_id_with_prefix(source_id, "ws_"),
         ResponseFormat::CodeInterpreterCall => normalize_tool_item_id_with_prefix(source_id, "ci_"),
         ResponseFormat::FileSearchCall => normalize_tool_item_id_with_prefix(source_id, "fs_"),
+        ResponseFormat::ImageGenerationCall => normalize_tool_item_id_with_prefix(source_id, "ig_"),
     }
 }
 
@@ -573,7 +591,8 @@ fn non_streaming_tool_item_id_source(item_id: &str, response_format: &ResponseFo
         ResponseFormat::Passthrough => item_id.to_string(),
         ResponseFormat::WebSearchCall
         | ResponseFormat::CodeInterpreterCall
-        | ResponseFormat::FileSearchCall => item_id
+        | ResponseFormat::FileSearchCall
+        | ResponseFormat::ImageGenerationCall => item_id
             .strip_prefix("fc_")
             .or_else(|| item_id.strip_prefix("call_"))
             .unwrap_or(item_id)
@@ -840,15 +859,16 @@ pub(crate) async fn execute_tool_loop(
                     original_body,
                 );
             }
-            let arguments: Value = match serde_json::from_str(&call.arguments) {
+            let response_format = session.tool_response_format(&call.name);
+            let server_label = session.resolve_tool_server_label(&call.name);
+            let tool_item_id = non_streaming_tool_item_id_source(&call.item_id, &response_format);
+            let approval_request_id = approval_request_item_id_source(&call.item_id);
+
+            let mut arguments: Value = match serde_json::from_str(&call.arguments) {
                 Ok(v) => v,
                 Err(e) => {
                     warn!(tool = %call.name, error = %e, "Failed to parse tool arguments as JSON");
                     let error_output = format!("Invalid tool arguments: {e}");
-                    let response_format = session.tool_response_format(&call.name);
-                    let server_label = session.resolve_tool_server_label(&call.name);
-                    let tool_item_id =
-                        non_streaming_tool_item_id_source(&call.item_id, &response_format);
                     let error_json = json!({ "error": &error_output });
                     let transformed_item = build_transformed_mcp_call_item(
                         &error_json,
@@ -877,9 +897,14 @@ pub(crate) async fn execute_tool_loop(
                 }
             };
 
+            // Merge caller-pinned tool config (e.g. image_generation `size`,
+            // `quality`) over model-emitted arguments before dispatch.
+            apply_request_tool_overrides(&response_format, original_body, &mut arguments);
+            let effective_arguments_str = arguments.to_string();
+
             debug!(
                 "Calling MCP tool '{}' with args: {}",
-                call.name, call.arguments
+                call.name, effective_arguments_str
             );
             let tool_result = session
                 .execute_tool_result(ToolExecutionInput {
@@ -889,18 +914,13 @@ pub(crate) async fn execute_tool_loop(
                 })
                 .await;
 
-            let response_format = session.tool_response_format(&call.name);
-            let server_label = session.resolve_tool_server_label(&call.name);
-            let tool_item_id = non_streaming_tool_item_id_source(&call.item_id, &response_format);
-            let approval_request_id = approval_request_item_id_source(&call.item_id);
-
             let tool_output = match tool_result {
                 ToolExecutionResult::Executed(tool_output) => tool_output,
                 ToolExecutionResult::PendingApproval(pending) => {
                     let approval_item = build_mcp_approval_request_item(
                         &approval_request_id,
                         &pending.tool_name,
-                        &call.arguments,
+                        &effective_arguments_str,
                         &server_label,
                     );
                     return build_approval_response(
@@ -928,7 +948,11 @@ pub(crate) async fn execute_tool_loop(
                 },
             );
 
-            let output_str = tool_output.output.to_string();
+            // Feed a compacted view of the tool output back into the model's
+            // conversation history — for image_generation this drops the
+            // multi-MB base64 while keeping revised_prompt/status.
+            let model_context_output =
+                response_format.compact_tool_output_for_model_context(&tool_output.output);
             let transformed_item = build_transformed_mcp_call_item(
                 &tool_output.output,
                 &response_format,
@@ -943,7 +967,7 @@ pub(crate) async fn execute_tool_loop(
                 call.call_id,
                 call.name,
                 call.arguments,
-                output_str,
+                model_context_output,
                 transformed_item,
             );
         }

--- a/model_gateway/src/routers/openai/mcp/tool_loop.rs
+++ b/model_gateway/src/routers/openai/mcp/tool_loop.rs
@@ -228,12 +228,18 @@ pub(crate) async fn execute_streaming_tool_calls(
         // Merge caller-pinned tool config (e.g. image_generation `size`,
         // `quality`) over model-emitted arguments before dispatch.
         apply_request_tool_overrides(&response_format, original_body, &mut arguments);
+        // Snapshot the post-merge arguments so the history item records what
+        // actually ran (not just the raw model-emitted buffer).
+        let effective_arguments_str = arguments.to_string();
 
         if !send_tool_call_intermediate_event(tx, &call, &response_format, sequence_number) {
             return false;
         }
 
-        debug!("Calling MCP tool '{}' with args: {}", call.name, arguments);
+        debug!(
+            "Calling MCP tool '{}' with args: {}",
+            call.name, effective_arguments_str
+        );
         let tool_output = session
             .execute_tool(ToolExecutionInput {
                 call_id: call.call_id.clone(),
@@ -287,7 +293,7 @@ pub(crate) async fn execute_streaming_tool_calls(
             session.is_builtin_tool(&call.name),
             call.call_id,
             call.name,
-            call.arguments_buffer,
+            effective_arguments_str,
             model_context_output,
             mcp_call_item,
         );
@@ -953,20 +959,23 @@ pub(crate) async fn execute_tool_loop(
             // multi-MB base64 while keeping revised_prompt/status.
             let model_context_output =
                 response_format.compact_tool_output_for_model_context(&tool_output.output);
+            // Record the *effective* arguments (post-override merge) in both
+            // the transformed output item and the conversation history, so the
+            // next loop iteration sees inputs that match what actually ran.
             let transformed_item = build_transformed_mcp_call_item(
                 &tool_output.output,
                 &response_format,
                 &tool_item_id,
                 &server_label,
                 &call.name,
-                &call.arguments,
+                &effective_arguments_str,
             );
 
             state.record_call(
                 session.is_builtin_tool(&call.name),
                 call.call_id,
                 call.name,
-                call.arguments,
+                effective_arguments_str,
                 model_context_output,
                 transformed_item,
             );

--- a/model_gateway/src/routers/openai/responses/streaming.rs
+++ b/model_gateway/src/routers/openai/responses/streaming.rs
@@ -19,7 +19,8 @@ use futures_util::StreamExt;
 use openai_protocol::{
     event_types::{
         is_function_call_type, is_response_event, CodeInterpreterCallEvent, FileSearchCallEvent,
-        FunctionCallEvent, ItemType, McpEvent, OutputItemEvent, ResponseEvent, WebSearchCallEvent,
+        FunctionCallEvent, ImageGenerationCallEvent, ItemType, McpEvent, OutputItemEvent,
+        ResponseEvent, WebSearchCallEvent,
     },
     responses::{ResponseTool, ResponsesRequest},
 };
@@ -149,6 +150,9 @@ pub(super) fn apply_event_transformations_inplace(
                             // Determine item type and ID prefix based on response_format
                             let (new_type, id_prefix) = match response_format {
                                 ResponseFormat::WebSearchCall => (ItemType::WEB_SEARCH_CALL, "ws_"),
+                                ResponseFormat::ImageGenerationCall => {
+                                    (ItemType::IMAGE_GENERATION_CALL, "ig_")
+                                }
                                 _ => (ItemType::MCP_CALL, "mcp_"),
                             };
 
@@ -431,6 +435,7 @@ fn maybe_inject_tool_in_progress(
         ItemType::WEB_SEARCH_CALL => WebSearchCallEvent::IN_PROGRESS,
         ItemType::CODE_INTERPRETER_CALL => CodeInterpreterCallEvent::IN_PROGRESS,
         ItemType::FILE_SEARCH_CALL => FileSearchCallEvent::IN_PROGRESS,
+        ItemType::IMAGE_GENERATION_CALL => ImageGenerationCallEvent::IN_PROGRESS,
         _ => return true, // Not a tool call item, nothing to inject
     };
 
@@ -977,7 +982,7 @@ pub(super) fn handle_streaming_with_tool_interception(
                 &tx,
                 &mut state,
                 &mut sequence_number,
-                &original_request.model,
+                &original_request,
             )
             .await
             {


### PR DESCRIPTION
## Summary

Implements **audit §R6** — end-to-end runtime support for the `image_generation`
built-in tool built on top of T4's merged protocol types. Covers MCP routing,
streaming events, and request-time tool-argument override merging.

PR #1091 (still open) attempted the same thing with some scope creep. This PR
keeps the load-bearing behavior (compactor, overrides, transformer, streaming
events, MCP wiring) and intentionally drops #1091's defensive gRPC rejection
scaffolding and speculative field additions.

Refs: audit §R6; provenance: referenced PR #1091

## What changed

### Protocols (`crates/protocols/src/event_types.rs`, +39 lines)
- `ImageGenerationCallEvent { InProgress, Generating, PartialImage, Completed }`
  with constant strings `response.image_generation_call.{in_progress|generating
  |partial_image|completed}`, `as_str()`, `Display`.
- `ItemType::ImageGenerationCall` + `IMAGE_GENERATION_CALL`. Included in
  `is_builtin_tool_call()`.

### MCP transform (`crates/mcp/src/transform/{types,transformer}.rs`, +431 lines)
- `ResponseFormat::ImageGenerationCall` variant.
- `ResponseFormat::compact_tool_output_for_model_context(&self, &Value) -> String`
  — for image_generation strips `result`/`data` (base64 payloads) from both flat
  and text-embedded content blocks, so subsequent model turns see
  `status`/`revised_prompt` instead of multi-MB base64. Other formats pass
  through unchanged.
- `ResponseTransformer::to_image_generation_call` emits
  `ResponseOutputItem::ImageGenerationCall { id, result, revised_prompt, status }`
  — uses **only** T4's four fields, no speculative additions. Tolerates three
  MCP payload shapes (text-wrapped JSON, flat, bare object) and marks result as
  `Failed` rather than smuggling error text into the base64 slot.
- 4 new transformer tests + 3 new compactor tests.

### MCP core config (`crates/mcp/src/core/config.rs`, +18 lines)
- `BuiltinToolType::ImageGeneration` + `ResponseFormatConfig::ImageGenerationCall`
  wired through `response_format()`, `Display`, and serde-roundtrip tests.
- `session.rs` already handled `ResponseOutputItem::ImageGenerationCall` (landed
  with T4), no change needed.

### Router common — `tool_overrides.rs` (NEW, 225 lines)
- `request_tool_overrides(response_format, request) -> Option<Value>` — for
  `ImageGenerationCall`, serializes first `ResponseTool::ImageGeneration` entry
  to a JSON object and drops null fields.
- `apply_request_tool_overrides(response_format, request, &mut Value)` —
  merges caller-pinned config over model-emitted tool-call arguments.
  Request-level values win on key conflicts so API callers can pin
  `size`/`quality` regardless of what the model picks.
- 7 unit tests: non-image formats return `None`, empty tool → `None`, null
  fields dropped, override precedence, non-object arguments no-op, non-image
  format no-op, first-tool-wins on duplicates.

### Router common — `mcp_utils.rs` (+3 lines + docs)
- `collect_builtin_routing` and `extract_builtin_types` now recognize
  `ResponseTool::ImageGeneration`.

### OpenAI tool_loop (`model_gateway/src/routers/openai/mcp/tool_loop.rs`, +74/-57)
- Import `ImageGenerationCallEvent` + `apply_request_tool_overrides`.
- `execute_streaming_tool_calls` signature: `model_id: &str` →
  `original_body: &ResponsesRequest`. Still records metrics via
  `original_body.model`; now also applies tool overrides.
- Apply `apply_request_tool_overrides` to parsed arguments **before**
  dispatching to MCP on both streaming and non-streaming code paths.
- Replace raw `tool_output.output.to_string()` with
  `response_format.compact_tool_output_for_model_context(&tool_output.output)`
  when recording into conversation history. The client-facing output item
  still carries the full base64; only the model's next-turn context is
  compacted.
- Add `ImageGenerationCall` / `IMAGE_GENERATION_CALL` / `"ig_"` arms to the
  intermediate-event, completed-event, streaming-id, and
  non-streaming-id-source match expressions.

### OpenAI responses streaming (`model_gateway/src/routers/openai/responses/streaming.rs`, +9/-2)
- Import `ImageGenerationCallEvent`.
- `apply_event_transformations_inplace` maps
  `ResponseFormat::ImageGenerationCall` → `(ItemType::IMAGE_GENERATION_CALL, "ig_")`.
- `maybe_inject_tool_in_progress` emits `ImageGenerationCallEvent::IN_PROGRESS`
  for `image_generation_call` items.
- Update `execute_streaming_tool_calls` call site to pass `&original_request`.

### gRPC streaming (`model_gateway/src/routers/grpc/common/responses/streaming.rs`, +10/-3)
- **Forced-cascade arms only**. Extend `OutputItemType` with
  `ImageGenerationCall` (id prefix `"ig"`), and add `ImageGenerationCall` arms
  to `emit_tool_call_in_progress`/`_searching`/`_completed`,
  `type_str_for_format`, and `output_item_type_for_format` so the exhaustive
  `match`es keep compiling. gRPC's existing conversion-layer `Err` for
  `ImageGenerationCall` input items remains the sole rejection point — no new
  guardrails, no `unreachable!()`, no router-entry gate.

## Departures from PR #1091

- **No `unreachable!()` in gRPC streaming.** Forced-cascade arms emit the
  real `ImageGenerationCallEvent` strings; gRPC already rejects
  image_generation *input items* at conversion, so defensive scaffolding is
  duplicate.
- **No `reject_unsupported_tool_for_grpc_route_entry`.** Scope creep over
  existing conversion-layer behavior.
- **No removal of `is_builtin()` trait method** on `ToolLike` — unrelated
  refactor.
- **`ResponseOutputItem::ImageGenerationCall` uses only T4 fields**
  (`id`, `result`, `revised_prompt`, `status`). #1091's speculative
  `background`/`output_format`/`quality`/`size`/`action` additions to the
  output item were not landed in T4 and are not added here. Cross-checked
  against SDK v2.8.1 (`openai/types/responses/response_image_generation_call.py`).

## Test plan

- `cargo check -p openai-protocol -p smg-mcp -p smg --lib --tests --benches`
  → clean.
- `cargo test -p openai-protocol -p smg-mcp -p smg --lib` → **862 passing**
  (56 protocols + 184 mcp + 622 smg, including 4 + 3 + 7 new tests added by
  this PR).
- `cargo clippy -p openai-protocol -p smg-mcp -p smg --lib --tests --benches
  -- -D warnings` → clean.
- `cargo fmt --all --check` → clean.

<details>
<summary>Checklist</summary>

- [x] Implementation
- [x] Tests added for new behavior (transformer, compactor, tool_overrides)
- [x] `cargo test` + `cargo clippy -D warnings` green locally

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Image generation added as a built-in tool-call type platform-wide (streaming + non-streaming), with dedicated lifecycle events and specialized item ID prefixes.
  * Request-time overrides for image-generation tool call arguments (request values take precedence).
  * Tool outputs for image generation are compacted before being fed back to the model; compaction strips embedded/base64 image payloads and supports multiple adapter payload shapes.
  * Robust parsing: missing or invalid image payloads produce an empty result while preserving revised prompts when present.

* **Tests**
  * Unit tests for serialization, payload-shape parsing, compaction behavior, streaming lifecycle, ID mapping, and override semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->