### PR TITLE
fix(harmony): shrink BUILTIN_TOOLS to the gpt-oss-native tool set

### DIFF
--- a/model_gateway/src/routers/grpc/harmony/builder.rs
+++ b/model_gateway/src/routers/grpc/harmony/builder.rs
@@ -59,15 +59,22 @@ pub(crate) fn convert_harmony_logprobs(proto_logprobs: &ProtoOutputLogProbs) -> 
     })
 }
 
-/// Built-in tools that are added to the system message
+/// Built-in tools that are added to the system message.
+///
+/// Scoped to the hosted tools gpt-oss was trained to emit (per the
+/// openai-harmony spec). Advertising a tool here that the model was not
+/// trained for — for example `image_generation`, `shell`, `computer`,
+/// `apply_patch`, `local_shell` — leads to undefined behavior: the model
+/// may hallucinate a malformed tool call, ignore the advertisement, or
+/// garble output. Hosted tools outside this set fall through to the
+/// custom/function-tool path and, in the future, will be gated
+/// per-worker via explicit hosted-tool capability flags + MCP dispatch.
 const BUILTIN_TOOLS: &[&str] = &[
     "web_search_preview",
     "web_search",
     "code_interpreter",
     "container",
     "file_search",
-    "image_generation",
-    "shell",
 ];
 
 /// Trait for tool-like objects that can be converted to Harmony ToolDescription


### PR DESCRIPTION
## Summary

Remove `image_generation` and `shell` from `harmony/builder.rs` `BUILTIN_TOOLS`. Per the openai-harmony spec, gpt-oss is trained to emit only `web_search_preview`, `web_search`, `code_interpreter`/`container`, `file_search`, plus `mcp` / `function` / `custom` tools. The two extras (landed via T4 #1303 and T6 #1342 respectively) advertise hosted tools that gpt-oss was not trained for, producing undefined model behavior.

## Why this matters

Today's path for a request like ``\{model: gpt-oss-120b, tools: [\{type: image_generation\}]}``:

1. `harmony/builder.rs` projects `ResponseTool::ImageGeneration` → string `"image_generation"`.
2. `BUILTIN_TOOLS.contains("image_generation")` → `true` → `has_custom_tools()` returns `false` → model is advertised the tool as a builtin in the system message.
3. gpt-oss has never seen this builtin during training. Behavior: hallucinated tool call in the wrong shape, ignored advertisement, or garbled output. No gateway handler exists downstream either — if the model does emit an `image_generation_call`, it's not dispatched anywhere.
4. If it reaches multi-turn replay: `responses_to_chat` and `parse_response_item_to_harmony_message` both `return Err("Unsupported input item type")`, but that only fires on replay, not first-turn emission.

Same story for `shell` on gpt-oss.

## What this changes

- `BUILTIN_TOOLS` shrinks to `[web_search_preview, web_search, code_interpreter, container, file_search]` — the gpt-oss-native hosted-tool set.
- `image_generation` and `shell` tools fall through to the existing custom/function-tool path instead of being advertised as builtins.
- Multi-turn replay rejection at the conversion layer is unchanged (still returns `Err` for `ImageGenerationCall` / `ShellCall` items).
- Added doc comment explaining the invariant so future T-task merges don't silently re-expand the array.

## Followup (tracked as R0 in the audit plan)

The proper fix is per-worker hosted-tool capability flags (`HostedToolCapabilities` bitflags or extension of `ModelType`), populated per model (gpt-oss = WEB_SEARCH_PREVIEW + WEB_SEARCH + CODE_INTERPRETER + FILE_SEARCH + MCP + CUSTOM; OpenAI gpt-5 = all; SGLang Llama = none). `BUILTIN_TOOLS` becomes per-request `worker.hosted_tools() ∩ request.tools`. Separate PR.

## Test plan

- `cargo test -p smg --lib` — **621 passed, 0 failed**.
- `cargo clippy -p smg --lib --tests -- -D warnings` — clean.
- `cargo fmt --all` — clean.
- No protocol types changed, no router behavior changed beyond the advertisement set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the default set of available tools to better align with hosted capabilities and prevent failures from untrained or misconfigured tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->