### PR TITLE
feat(smg): resolve tenant aliases in request metadata

### DIFF
--- a/model_gateway/src/middleware/tenant_resolution.rs
+++ b/model_gateway/src/middleware/tenant_resolution.rs
@@ -10,6 +10,7 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use smg_skills::TenantAliasStore;
+use tracing::error;
 
 use crate::{
     config::{RouterConfig, TenantResolutionConfig},
@@ -125,9 +126,10 @@ pub async fn route_request_meta_middleware(
     let request_meta = match resolve_route_request_meta(&state, &request).await {
         Ok(request_meta) => request_meta,
         Err(error) => {
+            error!(error = %error, "failed to resolve tenant metadata");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                format!("failed to resolve tenant metadata: {error}"),
+                "failed to resolve tenant metadata",
             )
                 .into_response();
         }
@@ -150,6 +152,7 @@ pub async fn ordinary_tenant_resolution_middleware(
 mod tests {
     use std::sync::Arc;
 
+    use async_trait::async_trait;
     use axum::{
         body::Body,
         extract::connect_info::ConnectInfo,
@@ -159,7 +162,10 @@ mod tests {
         routing::get,
         Router,
     };
-    use smg_skills::{InMemorySkillStore, TenantAliasRecord, TenantAliasStore};
+    use smg_skills::{
+        InMemorySkillStore, SkillsStoreError, SkillsStoreResult, TenantAliasRecord,
+        TenantAliasStore,
+    };
     use tower::ServiceExt;
 
     use super::*;
@@ -168,6 +174,31 @@ mod tests {
         middleware::TenantRequestMeta,
         tenant::DEFAULT_TENANT_HEADER_NAME,
     };
+
+    #[derive(Debug)]
+    struct FailingTenantAliasStore;
+
+    #[async_trait]
+    impl TenantAliasStore for FailingTenantAliasStore {
+        async fn put_tenant_alias(&self, _record: TenantAliasRecord) -> SkillsStoreResult<()> {
+            Err(SkillsStoreError::Storage("put not supported".to_string()))
+        }
+
+        async fn get_tenant_alias(
+            &self,
+            _alias_tenant_id: &str,
+        ) -> SkillsStoreResult<Option<TenantAliasRecord>> {
+            Err(SkillsStoreError::Storage(
+                "oracle backend connection details".to_string(),
+            ))
+        }
+
+        async fn delete_tenant_alias(&self, _alias_tenant_id: &str) -> SkillsStoreResult<bool> {
+            Err(SkillsStoreError::Storage(
+                "delete not supported".to_string(),
+            ))
+        }
+    }
 
     fn resolution_state() -> TenantResolutionState {
         TenantResolutionState::new(&RouterConfig::new(
@@ -323,5 +354,39 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(std::str::from_utf8(&body).unwrap(), "auth:tenant-a");
+    }
+
+    #[tokio::test]
+    async fn middleware_hides_tenant_alias_lookup_errors_from_clients() {
+        async fn handler() -> impl IntoResponse {
+            StatusCode::OK
+        }
+
+        let app = Router::new()
+            .route("/", get(handler))
+            .route_layer(from_fn_with_state(
+                resolution_state().with_tenant_alias_store(Some(Arc::new(FailingTenantAliasStore))),
+                route_request_meta_middleware,
+            ));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/")
+                    .extension(DataPlaneCaller::new(TenantKey::from("auth:tenant-a")))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert_eq!(
+            std::str::from_utf8(&body).unwrap(),
+            "failed to resolve tenant metadata"
+        );
     }
 }

--- a/model_gateway/src/middleware/tenant_resolution.rs
+++ b/model_gateway/src/middleware/tenant_resolution.rs
@@ -5,10 +5,11 @@ use std::{net::SocketAddr, sync::Arc};
 use axum::{
     body::Body,
     extract::{connect_info::ConnectInfo, Request, State},
-    http::{header::InvalidHeaderName, HeaderMap, HeaderName},
+    http::{header::InvalidHeaderName, HeaderMap, HeaderName, StatusCode},
     middleware::Next,
-    response::Response,
+    response::{IntoResponse, Response},
 };
+use smg_skills::TenantAliasStore;
 
 use crate::{
     config::{RouterConfig, TenantResolutionConfig},
@@ -19,6 +20,7 @@ use crate::{
 pub struct TenantResolutionState {
     trust_tenant_header: bool,
     trusted_tenant_header_name: HeaderName,
+    tenant_alias_store: Option<Arc<dyn TenantAliasStore>>,
 }
 
 impl TenantResolutionState {
@@ -32,15 +34,30 @@ impl TenantResolutionState {
         Ok(Self {
             trust_tenant_header: config.trust_tenant_header,
             trusted_tenant_header_name,
+            tenant_alias_store: None,
         })
+    }
+
+    #[must_use]
+    pub fn with_tenant_alias_store(
+        mut self,
+        tenant_alias_store: Option<Arc<dyn TenantAliasStore>>,
+    ) -> Self {
+        self.tenant_alias_store = tenant_alias_store;
+        self
     }
 }
 
-fn resolve_tenant_key(state: &TenantResolutionState, request: &Request<Body>) -> TenantKey {
+#[derive(Debug, thiserror::Error)]
+pub enum RouteRequestMetaError {
+    #[error("tenant alias lookup failed: {0}")]
+    TenantAliasLookup(#[from] smg_skills::SkillsStoreError),
+}
+
+fn resolve_raw_tenant_key(state: &TenantResolutionState, request: &Request<Body>) -> TenantKey {
     if let Some(caller) = request.extensions().get::<DataPlaneCaller>() {
         return caller.tenant_key().clone();
     }
-
     if state.trust_tenant_header {
         if let Some(tenant_id) = extract_trusted_tenant_id(state, request.headers()) {
             return canonical_tenant_key(TenantIdentity::Header(Arc::from(tenant_id)));
@@ -54,6 +71,28 @@ fn resolve_tenant_key(state: &TenantResolutionState, request: &Request<Body>) ->
     canonical_tenant_key(TenantIdentity::Anonymous)
 }
 
+async fn resolve_tenant_key(
+    state: &TenantResolutionState,
+    raw_tenant_key: TenantKey,
+) -> Result<TenantKey, RouteRequestMetaError> {
+    let Some(alias_store) = &state.tenant_alias_store else {
+        return Ok(raw_tenant_key);
+    };
+    let Some(record) = alias_store
+        .get_tenant_alias(raw_tenant_key.as_str())
+        .await?
+    else {
+        return Ok(raw_tenant_key);
+    };
+    if record
+        .expires_at
+        .is_some_and(|expires_at| expires_at <= chrono::Utc::now())
+    {
+        return Ok(raw_tenant_key);
+    }
+    Ok(TenantKey::from(record.canonical_tenant_id))
+}
+
 fn extract_trusted_tenant_id<'a>(
     state: &TenantResolutionState,
     headers: &'a HeaderMap,
@@ -65,12 +104,17 @@ fn extract_trusted_tenant_id<'a>(
         .filter(|value| !value.is_empty())
 }
 
-#[must_use]
-pub fn resolve_route_request_meta(
-    state: &TenantResolutionState,
+pub fn resolve_route_request_meta<'a>(
+    state: &'a TenantResolutionState,
     request: &Request<Body>,
-) -> RouteRequestMeta {
-    RouteRequestMeta::new(resolve_tenant_key(state, request))
+) -> impl std::future::Future<Output = Result<RouteRequestMeta, RouteRequestMetaError>> + Send + 'a
+{
+    let raw_tenant_key = resolve_raw_tenant_key(state, request);
+    async move {
+        Ok(RouteRequestMeta::new(
+            resolve_tenant_key(state, raw_tenant_key).await?,
+        ))
+    }
 }
 
 pub async fn route_request_meta_middleware(
@@ -78,7 +122,16 @@ pub async fn route_request_meta_middleware(
     mut request: Request<Body>,
     next: Next,
 ) -> Response {
-    let request_meta = resolve_route_request_meta(&state, &request);
+    let request_meta = match resolve_route_request_meta(&state, &request).await {
+        Ok(request_meta) => request_meta,
+        Err(error) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("failed to resolve tenant metadata: {error}"),
+            )
+                .into_response();
+        }
+    };
     request.extensions_mut().insert(request_meta);
     next.run(request).await
 }
@@ -95,6 +148,8 @@ pub async fn ordinary_tenant_resolution_middleware(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use axum::{
         body::Body,
         extract::connect_info::ConnectInfo,
@@ -104,6 +159,7 @@ mod tests {
         routing::get,
         Router,
     };
+    use smg_skills::{InMemorySkillStore, TenantAliasRecord, TenantAliasStore};
     use tower::ServiceExt;
 
     use super::*;
@@ -123,8 +179,8 @@ mod tests {
         .unwrap()
     }
 
-    #[test]
-    fn request_meta_prefers_authenticated_data_plane_identity() {
+    #[tokio::test]
+    async fn request_meta_prefers_authenticated_data_plane_identity() {
         let state = resolution_state();
         let mut request = Request::builder().uri("/").body(Body::empty()).unwrap();
         request
@@ -134,12 +190,12 @@ mod tests {
             .extensions_mut()
             .insert(ConnectInfo("127.0.0.1:8080".parse::<SocketAddr>().unwrap()));
 
-        let request_meta = resolve_route_request_meta(&state, &request);
+        let request_meta = resolve_route_request_meta(&state, &request).await.unwrap();
         assert_eq!(request_meta.tenant_key().as_str(), "auth:b3c2");
     }
 
-    #[test]
-    fn request_meta_uses_trusted_header_when_enabled() {
+    #[tokio::test]
+    async fn request_meta_uses_trusted_header_when_enabled() {
         let mut config = RouterConfig::new(
             RoutingMode::Regular {
                 worker_urls: vec!["http://worker1:8000".to_string()],
@@ -155,29 +211,79 @@ mod tests {
             .body(Body::empty())
             .unwrap();
 
-        let request_meta = resolve_route_request_meta(&state, &request);
+        let request_meta = resolve_route_request_meta(&state, &request).await.unwrap();
         assert_eq!(request_meta.tenant_key().as_str(), "header:team-red");
     }
 
-    #[test]
-    fn request_meta_falls_back_to_client_ip() {
+    #[tokio::test]
+    async fn request_meta_falls_back_to_client_ip() {
         let state = resolution_state();
         let mut request = Request::builder().uri("/").body(Body::empty()).unwrap();
         request.extensions_mut().insert(ConnectInfo(
             "203.0.113.42:443".parse::<SocketAddr>().unwrap(),
         ));
 
-        let request_meta = resolve_route_request_meta(&state, &request);
+        let request_meta = resolve_route_request_meta(&state, &request).await.unwrap();
         assert_eq!(request_meta.tenant_key().as_str(), "ip:203.0.113.42");
     }
 
-    #[test]
-    fn request_meta_falls_back_to_anonymous_without_identity_sources() {
+    #[tokio::test]
+    async fn request_meta_falls_back_to_anonymous_without_identity_sources() {
         let state = resolution_state();
         let request = Request::builder().uri("/").body(Body::empty()).unwrap();
 
-        let request_meta = resolve_route_request_meta(&state, &request);
+        let request_meta = resolve_route_request_meta(&state, &request).await.unwrap();
         assert_eq!(request_meta.tenant_key().as_str(), "anonymous");
+    }
+
+    #[tokio::test]
+    async fn request_meta_uses_active_tenant_alias() {
+        let store = Arc::new(InMemorySkillStore::default());
+        store
+            .put_tenant_alias(TenantAliasRecord {
+                alias_tenant_id: "auth:new-key".to_string(),
+                canonical_tenant_id: "auth:old-key".to_string(),
+                created_at: chrono::Utc::now(),
+                expires_at: None,
+            })
+            .await
+            .unwrap();
+        let state = resolution_state().with_tenant_alias_store(Some(store));
+        let mut request = Request::builder().uri("/").body(Body::empty()).unwrap();
+        request
+            .extensions_mut()
+            .insert(DataPlaneCaller::new(TenantKey::from("auth:new-key")));
+
+        let request_meta = resolve_route_request_meta(&state, &request).await.unwrap();
+        assert_eq!(request_meta.tenant_key().as_str(), "auth:old-key");
+    }
+
+    #[tokio::test]
+    async fn request_meta_ignores_missing_and_expired_tenant_aliases() {
+        let store = Arc::new(InMemorySkillStore::default());
+        store
+            .put_tenant_alias(TenantAliasRecord {
+                alias_tenant_id: "auth:expired-key".to_string(),
+                canonical_tenant_id: "auth:old-key".to_string(),
+                created_at: chrono::Utc::now(),
+                expires_at: Some(chrono::Utc::now() - chrono::Duration::seconds(1)),
+            })
+            .await
+            .unwrap();
+        let state = resolution_state().with_tenant_alias_store(Some(store));
+        let mut expired = Request::builder().uri("/").body(Body::empty()).unwrap();
+        expired
+            .extensions_mut()
+            .insert(DataPlaneCaller::new(TenantKey::from("auth:expired-key")));
+        let mut missing = Request::builder().uri("/").body(Body::empty()).unwrap();
+        missing
+            .extensions_mut()
+            .insert(DataPlaneCaller::new(TenantKey::from("auth:missing-key")));
+
+        let expired_meta = resolve_route_request_meta(&state, &expired).await.unwrap();
+        let missing_meta = resolve_route_request_meta(&state, &missing).await.unwrap();
+        assert_eq!(expired_meta.tenant_key().as_str(), "auth:expired-key");
+        assert_eq!(missing_meta.tenant_key().as_str(), "auth:missing-key");
     }
 
     #[tokio::test]

--- a/model_gateway/src/server.rs
+++ b/model_gateway/src/server.rs
@@ -29,6 +29,10 @@ use openai_protocol::{
     },
     rerank::{RerankRequest, V1RerankReqInput},
     responses::ResponsesRequest,
+    skills::{
+        SkillGetQuery, SkillPatchRequest, SkillVersionPatchRequest, SkillVersionsListQuery,
+        SkillsListQuery,
+    },
     tokenize::{AddTokenizerRequest, DetokenizeRequest, TokenizeRequest},
     transcription::TranscriptionRequest,
     validated::ValidatedJson,
@@ -795,7 +799,7 @@ async fn v1_skills_create(State(state): State<Arc<AppState>>, multipart: Multipa
 
 async fn v1_skills_list(
     State(state): State<Arc<AppState>>,
-    query: Query<openai_protocol::skills::SkillsListQuery>,
+    query: Query<SkillsListQuery>,
     headers: HeaderMap,
 ) -> Response {
     skills::list_skills(State(state), query, headers).await
@@ -804,7 +808,7 @@ async fn v1_skills_list(
 async fn v1_skills_get(
     State(state): State<Arc<AppState>>,
     Path(skill_id): Path<String>,
-    query: Query<openai_protocol::skills::SkillGetQuery>,
+    query: Query<SkillGetQuery>,
     headers: HeaderMap,
 ) -> Response {
     skills::get_skill(State(state), Path(skill_id), query, headers).await
@@ -813,8 +817,8 @@ async fn v1_skills_get(
 async fn v1_skills_patch(
     State(state): State<Arc<AppState>>,
     Path(skill_id): Path<String>,
-    query: Query<openai_protocol::skills::SkillGetQuery>,
-    ValidatedJson(body): ValidatedJson<openai_protocol::skills::SkillPatchRequest>,
+    query: Query<SkillGetQuery>,
+    ValidatedJson(body): ValidatedJson<SkillPatchRequest>,
 ) -> Response {
     skills::patch_skill(State(state), Path(skill_id), query, Json(body)).await
 }
@@ -830,7 +834,7 @@ async fn v1_skills_create_version(
 async fn v1_skills_list_versions(
     State(state): State<Arc<AppState>>,
     Path(skill_id): Path<String>,
-    query: Query<openai_protocol::skills::SkillVersionsListQuery>,
+    query: Query<SkillVersionsListQuery>,
     headers: HeaderMap,
 ) -> Response {
     skills::list_skill_versions(State(state), Path(skill_id), query, headers).await
@@ -839,7 +843,7 @@ async fn v1_skills_list_versions(
 async fn v1_skills_get_version(
     State(state): State<Arc<AppState>>,
     Path((skill_id, version)): Path<(String, String)>,
-    query: Query<openai_protocol::skills::SkillGetQuery>,
+    query: Query<SkillGetQuery>,
     headers: HeaderMap,
 ) -> Response {
     skills::get_skill_version(State(state), Path((skill_id, version)), query, headers).await
@@ -848,8 +852,8 @@ async fn v1_skills_get_version(
 async fn v1_skills_patch_version(
     State(state): State<Arc<AppState>>,
     Path((skill_id, version)): Path<(String, String)>,
-    query: Query<openai_protocol::skills::SkillGetQuery>,
-    ValidatedJson(body): ValidatedJson<openai_protocol::skills::SkillVersionPatchRequest>,
+    query: Query<SkillGetQuery>,
+    ValidatedJson(body): ValidatedJson<SkillVersionPatchRequest>,
 ) -> Response {
     skills::patch_skill_version(State(state), Path((skill_id, version)), query, Json(body)).await
 }
@@ -857,7 +861,7 @@ async fn v1_skills_patch_version(
 async fn v1_skills_delete(
     State(state): State<Arc<AppState>>,
     Path(skill_id): Path<String>,
-    query: Query<openai_protocol::skills::SkillGetQuery>,
+    query: Query<SkillGetQuery>,
 ) -> Response {
     skills::delete_skill(State(state), Path(skill_id), query).await
 }
@@ -865,7 +869,7 @@ async fn v1_skills_delete(
 async fn v1_skills_delete_version(
     State(state): State<Arc<AppState>>,
     Path((skill_id, version)): Path<(String, String)>,
-    query: Query<openai_protocol::skills::SkillGetQuery>,
+    query: Query<SkillGetQuery>,
 ) -> Response {
     skills::delete_skill_version(State(state), Path((skill_id, version)), query).await
 }
@@ -911,7 +915,14 @@ pub fn build_app(
     );
 
     let tenant_resolution_state =
-        middleware::TenantResolutionState::new(&app_state.context.router_config)?;
+        middleware::TenantResolutionState::new(&app_state.context.router_config)?
+            .with_tenant_alias_store(
+                app_state
+                    .context
+                    .skill_service
+                    .as_ref()
+                    .and_then(|skill_service| skill_service.tenant_alias_store()),
+            );
 
     let protected_routes = Router::new()
         .route("/v1/responses", post(v1_responses))


### PR DESCRIPTION
## Summary
- resolve tenant aliases inside request metadata middleware before inference routing
- wire the optional tenant alias store into server startup without adding any management API
- keep the scope to runtime canonicalization only and defer alias CRUD/admin endpoints to a later phase

## Verification
- cargo +nightly fmt --all
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tenant alias remapping added to tenant resolution so tenant identifiers can be looked up and remapped.

* **Improvements**
  * Middleware now hides alias lookup failures from clients and returns a generic 500 response to avoid leaking backend details.
  * Application wiring supplies the alias store to tenant resolution logic.

* **Tests**
  * Added async tests covering alias remapping, expired/missing aliases, and middleware error behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->