### PR TITLE
feat(openai): wire image_generation streaming events in Responses router (R6.2)

### DIFF
--- a/model_gateway/src/routers/openai/mcp/tool_loop.rs
+++ b/model_gateway/src/routers/openai/mcp/tool_loop.rs
@@ -492,7 +492,8 @@ fn send_tool_call_intermediate_event(
 }
 
 /// Send tool call completion events after tool execution.
-/// Handles mcp_call, web_search_call, code_interpreter_call, and file_search_call items.
+/// Handles mcp_call, web_search_call, code_interpreter_call, file_search_call,
+/// and image_generation_call items.
 /// Returns false if client disconnected.
 fn send_tool_call_completion_events(
     tx: &mpsc::UnboundedSender<Result<Bytes, io::Error>>,
@@ -1139,7 +1140,8 @@ fn build_mcp_approval_request_item(
 /// Build a transformed output item using ResponseTransformer
 ///
 /// Converts the output using the tool's response_format to the correctly-typed
-/// output item (mcp_call, web_search_call, code_interpreter_call, file_search_call).
+/// output item (mcp_call, web_search_call, code_interpreter_call, file_search_call,
+/// image_generation_call).
 /// Returns the result as a JSON Value for SSE event streaming.
 fn build_transformed_mcp_call_item(
     output: &Value,

--- a/model_gateway/src/routers/openai/mcp/tool_loop.rs
+++ b/model_gateway/src/routers/openai/mcp/tool_loop.rs
@@ -466,10 +466,11 @@ fn send_tool_call_intermediate_event(
         ResponseFormat::WebSearchCall => WebSearchCallEvent::SEARCHING,
         ResponseFormat::CodeInterpreterCall => CodeInterpreterCallEvent::INTERPRETING,
         ResponseFormat::FileSearchCall => FileSearchCallEvent::SEARCHING,
-        // stubbed: full event wiring (incl. partial_image payload events) is
-        // implemented in R6.2 for this router. Emitting `generating` as the
-        // generic intermediate keeps the shape consistent with the shared
-        // emitter in `grpc/common/responses/streaming.rs`.
+        // `generating` is the intermediate event for image_generation_call, on
+        // par with `searching` for web/file search and `interpreting` for code.
+        // `partial_image` events are emitted inline by the underlying tool when
+        // it streams preview chunks; the tool_loop path only emits the coarse
+        // in_progress → generating → completed sequence.
         ResponseFormat::ImageGenerationCall => ImageGenerationCallEvent::GENERATING,
         ResponseFormat::Passthrough => return true, // mcp_call has no intermediate event
     };
@@ -559,8 +560,9 @@ fn stable_streaming_tool_item_id(
         ResponseFormat::WebSearchCall => normalize_tool_item_id_with_prefix(source_id, "ws_"),
         ResponseFormat::CodeInterpreterCall => normalize_tool_item_id_with_prefix(source_id, "ci_"),
         ResponseFormat::FileSearchCall => normalize_tool_item_id_with_prefix(source_id, "fs_"),
-        // stubbed: `ig_` prefix matches the shared transformer's output item id
-        // (`to_image_generation_call`). R6.2 wires the full per-router path.
+        // `ig_` prefix mirrors the shared transformer's output item id
+        // (`to_image_generation_call`) and the 2-letter convention used by
+        // the other hosted tool formats.
         ResponseFormat::ImageGenerationCall => normalize_tool_item_id_with_prefix(source_id, "ig_"),
     }
 }
@@ -583,8 +585,6 @@ fn non_streaming_tool_item_id_source(item_id: &str, response_format: &ResponseFo
         ResponseFormat::WebSearchCall
         | ResponseFormat::CodeInterpreterCall
         | ResponseFormat::FileSearchCall
-        // stubbed: image_generation_call shares the fc_/call_ strip behavior
-        // with the other built-ins. R6.2 wires per-router specifics.
         | ResponseFormat::ImageGenerationCall => item_id
             .strip_prefix("fc_")
             .or_else(|| item_id.strip_prefix("call_"))

--- a/model_gateway/src/routers/openai/responses/streaming.rs
+++ b/model_gateway/src/routers/openai/responses/streaming.rs
@@ -19,7 +19,8 @@ use futures_util::StreamExt;
 use openai_protocol::{
     event_types::{
         is_function_call_type, is_response_event, CodeInterpreterCallEvent, FileSearchCallEvent,
-        FunctionCallEvent, ItemType, McpEvent, OutputItemEvent, ResponseEvent, WebSearchCallEvent,
+        FunctionCallEvent, ImageGenerationCallEvent, ItemType, McpEvent, OutputItemEvent,
+        ResponseEvent, WebSearchCallEvent,
     },
     responses::{ResponseTool, ResponsesRequest},
 };
@@ -149,6 +150,9 @@ pub(super) fn apply_event_transformations_inplace(
                             // Determine item type and ID prefix based on response_format
                             let (new_type, id_prefix) = match response_format {
                                 ResponseFormat::WebSearchCall => (ItemType::WEB_SEARCH_CALL, "ws_"),
+                                ResponseFormat::ImageGenerationCall => {
+                                    (ItemType::IMAGE_GENERATION_CALL, "ig_")
+                                }
                                 _ => (ItemType::MCP_CALL, "mcp_"),
                             };
 
@@ -431,6 +435,7 @@ fn maybe_inject_tool_in_progress(
         ItemType::WEB_SEARCH_CALL => WebSearchCallEvent::IN_PROGRESS,
         ItemType::CODE_INTERPRETER_CALL => CodeInterpreterCallEvent::IN_PROGRESS,
         ItemType::FILE_SEARCH_CALL => FileSearchCallEvent::IN_PROGRESS,
+        ItemType::IMAGE_GENERATION_CALL => ImageGenerationCallEvent::IN_PROGRESS,
         _ => return true, // Not a tool call item, nothing to inject
     };
 

--- a/model_gateway/src/routers/openai/responses/streaming.rs
+++ b/model_gateway/src/routers/openai/responses/streaming.rs
@@ -416,7 +416,8 @@ pub(super) fn forward_streaming_event(
 }
 
 /// Inject in_progress event after a tool call item is added.
-/// Handles mcp_call, web_search_call, code_interpreter_call, and file_search_call items.
+/// Handles mcp_call, web_search_call, code_interpreter_call, file_search_call,
+/// and image_generation_call items.
 /// Returns false if client disconnected.
 fn maybe_inject_tool_in_progress(
     parsed_data: &Value,


### PR DESCRIPTION
## Description

### Problem

R6.1 (#1355) landed the shared `ResponseFormat::ImageGenerationCall` plumbing — the variant, the `BuiltinToolType::ImageGeneration` config, the `ImageGenerationCallEvent` protocol constants, the `to_image_generation_call` MCP transformer, and the base64-stripping compactor — but left the OpenAI Responses router itself without real per-site wiring. `image_generation` MCP tool calls therefore fell through to the generic `mcp_call` path in `model_gateway/src/routers/openai/responses/streaming.rs` and emitted the wrong event type to clients.

The three sites in `model_gateway/src/routers/openai/mcp/tool_loop.rs` that R6.1 introduced were marked with `// stubbed:` comments deferring final wiring to R6.2, even though the underlying values (`ImageGenerationCallEvent::GENERATING`, the `ig_` id prefix, and the shared `fc_`/`call_` strip behavior) already matched the pattern used by the other three hosted-tool formats.

### Solution

Finish the per-router wiring so `image_generation` MCP tool calls emit the full `response.image_generation_call.*` event sequence through the OpenAI Responses streaming pipeline, matching the shape already in place for `web_search` / `code_interpreter` / `file_search`.

## Changes

Protocol-only router wiring under `model_gateway/src/routers/openai/`:

### `model_gateway/src/routers/openai/responses/streaming.rs`
- Import `ImageGenerationCallEvent` from `openai_protocol::event_types`.
- `apply_event_transformations_inplace`: extend the `ResponseFormat` match so upstream `function_call` items whose session `response_format` is `ImageGenerationCall` are rewritten to `ItemType::IMAGE_GENERATION_CALL` with the `ig_` id prefix, instead of falling through to the generic `mcp_call` arm. Mirrors the existing `WebSearchCall` arm.
- `maybe_inject_tool_in_progress`: add an `ItemType::IMAGE_GENERATION_CALL` arm that emits `ImageGenerationCallEvent::IN_PROGRESS` so the in_progress event is injected right after the rewritten `output_item.added` event. Parallel to the existing `WEB_SEARCH_CALL` / `CODE_INTERPRETER_CALL` / `FILE_SEARCH_CALL` arms.

### `model_gateway/src/routers/openai/mcp/tool_loop.rs`
- Drop the three `// stubbed:` marker comments left by R6.1 on the `ImageGenerationCall` arms in `send_tool_call_intermediate_event`, `stable_streaming_tool_item_id`, and `non_streaming_tool_item_id_source`. The underlying values already matched the other three hosted-tool formats and now stand as the real wiring.
- Replace the R6.2-TODO comment on the intermediate event with a short design note: `generating` is the coarse intermediate event emitted by `tool_loop`, on par with `searching` for web/file search and `interpreting` for code; `partial_image` preview events are the responsibility of the underlying tool when it streams chunks, not the `tool_loop` path.

## End-to-end event sequence for `image_generation`

1. Upstream emits `response.output_item.added` with a `function_call` item → rewritten to `image_generation_call` with an `ig_*` id.
2. `response.image_generation_call.in_progress` is injected right after.
3. `send_tool_call_intermediate_event` emits `response.image_generation_call.generating` while the tool runs.
4. `send_tool_call_completion_events` emits `response.image_generation_call.completed` plus `response.output_item.done` with the fully-transformed item from the shared `to_image_generation_call` transformer.

Matches the 4-event sequence documented in `.claude/_audit/openai-responses-api-spec.md` §tools (image_generation) and mirrored by OpenAI Python SDK v2.8.1.

## Scope

- In scope: OpenAI Responses streaming router wiring only.
- Out of scope: non-OpenAI transports — the gRPC and HTTP worker paths are owned by R6.3 / R6.4 and are deliberately not touched here.
- Out of scope: `partial_image` preview events. The tool_loop path emits the coarse `in_progress → generating → completed` sequence; inline preview chunks are produced by the underlying tool when it streams them.

## Test plan

- `cargo check -p smg --lib` — clean.
- `cargo test -p smg --lib` — 616 passed, 0 failed, 4 ignored.
- `cargo fmt --all` — no changes.
- `cargo clippy -p smg --lib --tests -- -D warnings` — clean.
- Verified every `ResponseFormat::ImageGenerationCall` site under `model_gateway/src/routers/openai/` is now real wiring (no remaining `// stubbed:` markers or R6.2 TODOs).

Refs: R6.1 #1355 (prerequisite)

<details>
<summary>Checklist</summary>

- [x] Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved streaming event support for image-generation tool calls, including in-progress events, consistent event sequencing, and standardized ID prefix handling.

* **Documentation**
  * Clarified tool-call event definitions to treat image generation as a first-class streamed format and removed outdated references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->