### PR TITLE
feat(grpc-regular): wire image_generation streaming events in Responses router (R6.4)

### DIFF
--- a/model_gateway/src/routers/grpc/regular/responses/conversions.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/conversions.rs
@@ -548,4 +548,27 @@ mod tests {
         assert!(!chat_req.stream);
         assert!(chat_req.stream_options.is_none());
     }
+
+    #[test]
+    fn test_image_generation_call_input_rejected() {
+        // Regression (R6.4): `image_generation_call` items are server-produced
+        // output (populated via the shared MCP transformer in R6.1) and must
+        // not be round-tripped back into the chat conversion as input.
+        // The regular gRPC path — used by non-Harmony text LLMs that only do
+        // function calling — rejects this variant with the same contract as
+        // sibling hosted-tool items (Computer/Shell/Custom/ApplyPatch).
+        let req = ResponsesRequest {
+            input: ResponseInput::Items(vec![ResponseInputOutputItem::ImageGenerationCall {
+                id: "ig_test".to_string(),
+                result: Some("base64data".to_string()),
+                revised_prompt: Some("a cat".to_string()),
+                status: None,
+            }]),
+            ..Default::default()
+        };
+
+        let result = responses_to_chat(&req);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), "Unsupported input item type");
+    }
 }


### PR DESCRIPTION
## Description

### Problem
R6.1 (#1355) landed the shared hosted-tool MCP plumbing for
`image_generation_call` (events, transformer, shared emitter
helpers, `OutputItemType::ImageGenerationCall`, `ig_*` item-id
prefix). It also left three downstream tickets open to wire the
per-router streaming-event emission and item-type-tagging sites:

- R6.2 — `openai/mcp/tool_loop.rs` (stubbed in R6.1)
- R6.3 — `grpc/harmony/` (per-router work)
- **R6.4 — `grpc/regular/` (this PR)**

The regular gRPC Responses router serves non-Harmony text LLMs
(Llama, Qwen, Mistral, DeepSeek, etc.) — models that only do
function calling. For hosted `image_generation`, the gateway
translates the tool into a function-call schema the model emits,
intercepts the function call at MCP dispatch time, emits
`ImageGenerationCallEvent::*` streaming events, and transforms the
MCP result back into `ResponseOutputItem::ImageGenerationCall`.

### Solution
Investigate the regular-gRPC Responses router for
`ResponseFormat::ImageGenerationCall` stubs and replace them with
real per-site wiring. Findings:

- `grep -nE 'ResponseFormat::ImageGenerationCall' model_gateway/src/routers/grpc/regular/`
  → **0 matches**. The regular router was written format-generically
  from day one. Every ResponseFormat-specific decision in the
  regular streaming path routes through R6.1's shared helpers:
    - `ResponseStreamEventEmitter::type_str_for_format(Some(&fmt))`
      → `"image_generation_call"` (common/responses/streaming.rs:569)
    - `ResponseStreamEventEmitter::output_item_type_for_format(Some(&fmt))`
      → `OutputItemType::ImageGenerationCall` (common/responses/streaming.rs:581)
    - `allocate_output_index(OutputItemType::ImageGenerationCall)`
      → `ig_*` item id (common/responses/streaming.rs:675)
    - `emit_tool_call_in_progress(&fmt)` /
      `emit_tool_call_searching(&fmt)` /
      `emit_tool_call_completed(&fmt)` all fan out
      `ImageGenerationCallEvent::{IN_PROGRESS, GENERATING, COMPLETED}`
      internally (common/responses/streaming.rs:480, 502, 553).
  - The non-streaming path calls `result.to_response_item()` which
    invokes `ResponseTransformer::to_image_generation_call` (R6.1)
    to produce the final `ResponseOutputItem::ImageGenerationCall`.

- The only regular-specific site that references image_generation is
  the multi-turn replay rejection in
  `responses_to_chat` (`conversions.rs:155-161`), which rejects
  `ResponseInputOutputItem::ImageGenerationCall` as input with the
  same warn-log + `Err(\"Unsupported input item type\")` contract
  used for sibling hosted-tool items (Computer, Shell, Custom,
  ApplyPatch). This rejection is intentional: `image_generation_call`
  items are server-produced output and non-Harmony Chat Completions
  has no representation for them; the task spec explicitly says to
  leave this alone.

Given there are no stubs to replace, this PR lands a single
regression test locking in the input-rejection contract so the
\"image_generation is output-only on non-Harmony chat conversion\"
boundary cannot silently regress.

## Changes
- **`model_gateway/src/routers/grpc/regular/responses/conversions.rs`**
  — added `test_image_generation_call_input_rejected` to the existing
  `mod tests` block. Constructs a `ResponseInput::Items` vec
  containing a single `ResponseInputOutputItem::ImageGenerationCall`
  (with the id-only + optional `result`/`revised_prompt`/`status`
  shape from `crates/protocols/src/responses.rs:1569-1582`), calls
  `responses_to_chat`, asserts `Err(\"Unsupported input item type\")`.

## Test Plan
- [x] `cargo check -p smg --lib` — clean
- [x] `cargo test -p smg --lib` — 617 pass, 0 fail, 4 ignored
- [x] `cargo test -p smg --lib routers::grpc::regular::responses::conversions::tests` — 7 pass including new test
- [x] `cargo fmt --all` — clean
- [x] `cargo clippy -p smg --lib --tests -- -D warnings` — clean
- [x] `grep -nE 'ResponseFormat::ImageGenerationCall' model_gateway/src/routers/grpc/regular/` — 0 results (confirms no stubs were missed)

## Scope
- Touches only `model_gateway/src/routers/grpc/regular/`.
- **No changes** under `model_gateway/src/routers/grpc/common/` (R6.1),
  `model_gateway/src/routers/openai/` (R6.2), or
  `model_gateway/src/routers/grpc/harmony/` (R6.3).
- **No source-code behavior change**; test-only delta.

Refs: R6.4

<details>
<summary>Checklist</summary>

- [x] Tests added
- [x] Documentation in commit/PR body explains wiring audit findings
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation testing to ensure unsupported input types are properly rejected in gRPC response conversion handling, improving system reliability and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->