### PR TITLE
feat(grpc-harmony): wire image_generation streaming events (R6.3)

### DIFF
--- a/model_gateway/src/routers/grpc/harmony/streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/streaming.rs
@@ -44,6 +44,30 @@ use crate::{
     },
 };
 
+/// Whether a tool call of this `ResponseFormat` streams its arguments via
+/// `mcp_call.arguments.delta` / `function_call.arguments.delta` events.
+///
+/// Hosted built-in tools (`web_search_call`, `code_interpreter_call`,
+/// `file_search_call`, `image_generation_call`) instead surface their
+/// progress through structured events emitted by the shared
+/// [`ResponseStreamEventEmitter`] helpers (`emit_tool_call_in_progress`,
+/// `emit_tool_call_searching`, `emit_tool_call_completed` — plus
+/// `emit_image_generation_partial_image` for the image_generation
+/// partial-image frame). Those builtins therefore skip argument
+/// streaming here.
+///
+/// `None` (plain function tools) and `Some(Passthrough)` (MCP `mcp_call`)
+/// are the only formats that stream arguments through this router.
+fn streams_arguments(response_format: Option<&ResponseFormat>) -> bool {
+    match response_format {
+        None | Some(ResponseFormat::Passthrough) => true,
+        Some(ResponseFormat::WebSearchCall)
+        | Some(ResponseFormat::CodeInterpreterCall)
+        | Some(ResponseFormat::FileSearchCall)
+        | Some(ResponseFormat::ImageGenerationCall) => false,
+    }
+}
+
 /// Processor for streaming Harmony responses
 ///
 /// Returns an SSE stream that parses Harmony tokens incrementally and
@@ -720,11 +744,14 @@ impl HarmonyStreamingProcessor {
                                     }
                                 }
 
-                                // Emit initial arguments delta for mcp_call only (skip for builtin tools)
-                                if matches!(
-                                    response_format,
-                                    Some(ResponseFormat::Passthrough) | None
-                                ) {
+                                // Emit initial arguments delta for mcp_call / function_call
+                                // only. Hosted built-in tools (web_search_call,
+                                // code_interpreter_call, file_search_call,
+                                // image_generation_call) surface progress via
+                                // the structured `*.in_progress` /
+                                // `*.searching` / `*.generating` events emitted
+                                // above instead of streaming their arguments.
+                                if streams_arguments(response_format.as_ref()) {
                                     let event = match &response_format {
                                         Some(_) => emitter.emit_mcp_call_arguments_delta(
                                             output_index,
@@ -744,11 +771,14 @@ impl HarmonyStreamingProcessor {
                                 if let Some((output_index, item_id, response_format)) =
                                     tool_call_tracking.get(&call_index)
                                 {
-                                    // Skip arguments streaming for builtin tools (only mcp_call streams arguments)
-                                    if !matches!(
-                                        response_format,
-                                        Some(ResponseFormat::Passthrough) | None
-                                    ) {
+                                    // Only mcp_call / function_call stream
+                                    // arguments; hosted built-in tools
+                                    // (web_search_call, code_interpreter_call,
+                                    // file_search_call, image_generation_call)
+                                    // skip argument deltas — their progress
+                                    // rides on the structured events emitted
+                                    // around MCP dispatch.
+                                    if !streams_arguments(response_format.as_ref()) {
                                         continue;
                                     }
 
@@ -808,11 +838,13 @@ impl HarmonyStreamingProcessor {
                                 let args_str =
                                     tool_call.function.arguments.as_deref().unwrap_or("");
 
-                                // Emit arguments done (skip for builtin tools)
-                                if matches!(
-                                    response_format,
-                                    Some(ResponseFormat::Passthrough) | None
-                                ) {
+                                // Emit arguments.done for mcp_call /
+                                // function_call only. Hosted built-in tools
+                                // (web_search_call, code_interpreter_call,
+                                // file_search_call, image_generation_call)
+                                // close out through the `*.completed`
+                                // structured event emitted below.
+                                if streams_arguments(response_format.as_ref()) {
                                     let event = match response_format {
                                         Some(_) => emitter.emit_mcp_call_arguments_done(
                                             *output_index,
@@ -944,8 +976,12 @@ impl HarmonyStreamingProcessor {
                         let tool_name = &tool_call.function.name;
                         let args_str = tool_call.function.arguments.as_deref().unwrap_or("");
 
-                        // Emit arguments done (skip for builtin tools)
-                        if matches!(response_format, Some(ResponseFormat::Passthrough) | None) {
+                        // Emit arguments.done for mcp_call / function_call
+                        // only. Hosted built-in tools (web_search_call,
+                        // code_interpreter_call, file_search_call,
+                        // image_generation_call) close out through the
+                        // `*.completed` structured event emitted below.
+                        if streams_arguments(response_format.as_ref()) {
                             let event = match response_format {
                                 Some(_) => emitter.emit_mcp_call_arguments_done(
                                     *output_index,
@@ -1058,5 +1094,44 @@ impl HarmonyStreamingProcessor {
 impl Default for HarmonyStreamingProcessor {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Locks the `streams_arguments` classification so the Harmony router
+    // keeps treating hosted built-in tools — including `image_generation` —
+    // as structured-event emitters rather than argument streamers.
+    // `match` is used instead of a table-driven form so a newly added
+    // `ResponseFormat` variant produces a compile error until it is
+    // explicitly classified here.
+    #[test]
+    fn streams_arguments_matches_passthrough_and_function_only() {
+        // None → plain function call: streams arguments.
+        assert!(streams_arguments(None));
+
+        // Every ResponseFormat variant is classified explicitly.
+        for format in [
+            ResponseFormat::Passthrough,
+            ResponseFormat::WebSearchCall,
+            ResponseFormat::CodeInterpreterCall,
+            ResponseFormat::FileSearchCall,
+            ResponseFormat::ImageGenerationCall,
+        ] {
+            let expected = match format {
+                ResponseFormat::Passthrough => true,
+                ResponseFormat::WebSearchCall
+                | ResponseFormat::CodeInterpreterCall
+                | ResponseFormat::FileSearchCall
+                | ResponseFormat::ImageGenerationCall => false,
+            };
+            assert_eq!(
+                streams_arguments(Some(&format)),
+                expected,
+                "streams_arguments classification changed for {format:?}",
+            );
+        }
     }
 }

--- a/model_gateway/src/routers/grpc/harmony/streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/streaming.rs
@@ -1101,37 +1101,71 @@ impl Default for HarmonyStreamingProcessor {
 mod tests {
     use super::*;
 
-    // Locks the `streams_arguments` classification so the Harmony router
-    // keeps treating hosted built-in tools — including `image_generation` —
-    // as structured-event emitters rather than argument streamers.
-    // `match` is used instead of a table-driven form so a newly added
-    // `ResponseFormat` variant produces a compile error until it is
-    // explicitly classified here.
-    #[test]
-    fn streams_arguments_matches_passthrough_and_function_only() {
-        // None → plain function call: streams arguments.
-        assert!(streams_arguments(None));
-
-        // Every ResponseFormat variant is classified explicitly.
-        for format in [
-            ResponseFormat::Passthrough,
-            ResponseFormat::WebSearchCall,
-            ResponseFormat::CodeInterpreterCall,
-            ResponseFormat::FileSearchCall,
-            ResponseFormat::ImageGenerationCall,
-        ] {
-            let expected = match format {
-                ResponseFormat::Passthrough => true,
-                ResponseFormat::WebSearchCall
-                | ResponseFormat::CodeInterpreterCall
-                | ResponseFormat::FileSearchCall
-                | ResponseFormat::ImageGenerationCall => false,
-            };
-            assert_eq!(
-                streams_arguments(Some(&format)),
-                expected,
-                "streams_arguments classification changed for {format:?}",
-            );
+    /// Compile-time exhaustiveness anchor.
+    ///
+    /// This helper exists solely to force every [`ResponseFormat`] variant
+    /// to flow through a non-wildcard `match`. If a new variant is added to
+    /// [`ResponseFormat`] without being classified, this function fails to
+    /// compile — which in turn breaks `streams_arguments_explicit_variants`
+    /// below, since both helpers iterate the same variant set.
+    ///
+    /// Intentionally *does not* call [`streams_arguments`] — this mirrors
+    /// the production classifier so a drift between the two is a separate
+    /// failure (runtime assertion miss) from a missing variant (compile
+    /// error here).
+    fn expected_streams_arguments(format: &ResponseFormat) -> bool {
+        match format {
+            ResponseFormat::Passthrough => true,
+            ResponseFormat::WebSearchCall
+            | ResponseFormat::CodeInterpreterCall
+            | ResponseFormat::FileSearchCall
+            | ResponseFormat::ImageGenerationCall => false,
         }
+    }
+
+    // Locks the `streams_arguments` classification so the Harmony router
+    // keeps treating hosted built-in tools — including `image_generation`
+    // — as structured-event emitters rather than argument streamers.
+    //
+    // Every `ResponseFormat` variant is named explicitly (no `_` arm, no
+    // iteration over a hand-maintained array), so adding a new variant
+    // fails to compile in `expected_streams_arguments` above AND in every
+    // explicit `let ... = ResponseFormat::X;` binding here — which in
+    // turn ensures the production `streams_arguments` classifier must
+    // also be updated to compile.
+    #[test]
+    fn streams_arguments_explicit_variants() {
+        // `None` (plain function tool) streams arguments.
+        assert!(streams_arguments(None), "function_call should stream args");
+
+        // `Some(Passthrough)` (mcp_call) streams arguments.
+        let passthrough = ResponseFormat::Passthrough;
+        assert!(
+            streams_arguments(Some(&passthrough)),
+            "mcp_call (Passthrough) should stream args",
+        );
+        assert!(expected_streams_arguments(&passthrough));
+
+        // Hosted built-ins do *not* stream arguments — they surface
+        // progress via structured `*.in_progress` / `*.searching` /
+        // `*.generating` / `*.completed` events from the shared emitter.
+        let web_search = ResponseFormat::WebSearchCall;
+        assert!(!streams_arguments(Some(&web_search)));
+        assert!(!expected_streams_arguments(&web_search));
+
+        let code_interpreter = ResponseFormat::CodeInterpreterCall;
+        assert!(!streams_arguments(Some(&code_interpreter)));
+        assert!(!expected_streams_arguments(&code_interpreter));
+
+        let file_search = ResponseFormat::FileSearchCall;
+        assert!(!streams_arguments(Some(&file_search)));
+        assert!(!expected_streams_arguments(&file_search));
+
+        let image_generation = ResponseFormat::ImageGenerationCall;
+        assert!(
+            !streams_arguments(Some(&image_generation)),
+            "image_generation_call must ride the structured-event path",
+        );
+        assert!(!expected_streams_arguments(&image_generation));
     }
 }


### PR DESCRIPTION
## Summary

R6.3 of the 4-PR split for the `image_generation` hosted-tool audit (R6). Wires the gRPC Harmony router's per-site handling of `ImageGenerationCall` so it explicitly follows the structured-event path that `WebSearchCall`, `CodeInterpreterCall`, and `FileSearchCall` already use. No behavior change for existing hosted tools — this is an explicit-intent + exhaustiveness refactor that removes the implicit stub R6.1 deliberately left in Harmony for per-router PRs.

Refs: R6 image_generation integration. Builds on R6.1 (#1355). Sibling PRs: R6.2 (openai HTTP router) and R6.4 (gRPC regular router).

## Problem

R6.1 (#1355) landed the shared streaming infrastructure for `image_generation_call` in `model_gateway/src/routers/grpc/common/responses/streaming.rs`:
- Added `ResponseFormat::ImageGenerationCall` arms to `emit_tool_call_in_progress` / `emit_tool_call_searching` / `emit_tool_call_completed`.
- Added `emit_image_generation_partial_image` (marked `#[expect(dead_code)]` until per-router PRs wire it up).
- Added `image_generation_call` entries in `type_str_for_format` / `output_item_type_for_format` / `allocate_output_index`.

The gRPC Harmony router's `process_decode_stream` in `model_gateway/src/routers/grpc/harmony/streaming.rs` gates argument streaming on a negative pattern:

```rust
if matches!(response_format, Some(ResponseFormat::Passthrough) | None) { ... }
```

That pattern quietly excluded every hosted built-in — including the newly added `ImageGenerationCall` — by pattern exhaustion rather than by deliberate naming. When a new `ResponseFormat` variant lands (as R6.1 just did), the compiler gives no signal that the variant is unclassified. The behavior was correct by coincidence; the intent was implicit.

## Solution

Make the classification explicit, named, and compiler-checked — same structured-event path that `WebSearchCall` / `CodeInterpreterCall` / `FileSearchCall` already take in the shared emitter.

### What changed

**`model_gateway/src/routers/grpc/harmony/streaming.rs`**

- Added a private `streams_arguments(Option<&ResponseFormat>) -> bool` classifier:
  ```rust
  fn streams_arguments(response_format: Option<&ResponseFormat>) -> bool {
      match response_format {
          None | Some(ResponseFormat::Passthrough) => true,
          Some(ResponseFormat::WebSearchCall)
          | Some(ResponseFormat::CodeInterpreterCall)
          | Some(ResponseFormat::FileSearchCall)
          | Some(ResponseFormat::ImageGenerationCall) => false,
      }
  }
  ```
  `match` (not `matches!`) so adding a new `ResponseFormat` variant is a compile error until explicitly classified. Doc comment names all four hosted builtins and points at the shared emitter helpers (including `emit_image_generation_partial_image`).

- Replaced the four `matches!(response_format, Some(ResponseFormat::Passthrough) | None)` call sites with `streams_arguments(response_format.as_ref())`:
  1. Around L726 — initial `arguments.delta` on new tool call (mcp_call / function_call only).
  2. Around L750 — continuing `arguments.delta` during streaming (skip for builtins).
  3. Around L814 — `arguments.done` in the `Complete` branch after parser finalize.
  4. Around L948 — `arguments.done` in the fallback branch that extracts commentary from the parser when Complete hadn't emitted tool calls.

- Rewrote the surrounding comments to name the four hosted builtins (web_search_call, code_interpreter_call, file_search_call, image_generation_call) and point at the structured `*.in_progress` / `*.searching` / `*.generating` / `*.completed` events the shared `ResponseStreamEventEmitter` emits. Replaces the old opaque "builtin tools" phrasing.

- Added unit test `streams_arguments_matches_passthrough_and_function_only` under `#[cfg(test)] mod tests` that iterates every `ResponseFormat` variant plus `None` and locks the classification. The inner `match format { ... }` inside the test is also exhaustive, so a new variant fails to compile in the test too.

### Why this shape (not just keep `matches!`)

The point of R6 is that `image_generation` is a first-class hosted built-in. R6.1 added it to every dispatch surface in the shared emitter. Harmony's negative `Some(Passthrough) | None` gate was the only remaining site where `ImageGenerationCall` landed on the correct path by pattern accident. After this PR, the decision is named, compiler-enforced, and explained inline, and the classification is test-locked. The runtime behavior is bit-identical.

### Harmony-specific nuance (why image_generation rides MCP dispatch on Harmony)

Harmony is designed for gpt-oss, which was not trained on `image_generation` as a native builtin (see PR #1353 and the separate `fix(harmony): shrink BUILTIN_TOOLS to the gpt-oss-native tool set` work). On the Harmony path, `image_generation` tool calls come through the gateway-level MCP dispatch (`execute_mcp_tools` in `harmony/responses/execution.rs`), not from model tokens. The streaming events (`response.image_generation_call.in_progress` / `.generating` / `.completed`) fire from the shared emitter when the Harmony parser surfaces a commentary-channel tool call, while the actual image generation runs in the MCP orchestrator. Argument streaming must stay skipped so the structured events are the single source of progress signal — which is exactly what `streams_arguments(...) == false` enforces for `ImageGenerationCall`.

### Scope boundary

Hard-limited to `model_gateway/src/routers/grpc/harmony/streaming.rs` per the R6.3 task contract.
- `model_gateway/src/routers/grpc/common/responses/streaming.rs` is R6.1's territory (landed in #1355) and is shared by the regular router — untouched here.
- `model_gateway/src/routers/grpc/regular/` is R6.4's territory — untouched here.
- `model_gateway/src/routers/openai/mcp/tool_loop.rs` is R6.2's territory — untouched here.

`grep -rnE "ResponseFormat::ImageGenerationCall" model_gateway/src/routers/grpc/harmony/` confirmed no other stub sites in the Harmony tree.

## Test plan

Run from `model_gateway/src/routers/grpc/harmony/` with `CARGO_TARGET_DIR=/Users/simolin/.cargo/target`:

- `cargo check -p smg --lib` — clean
- `cargo test -p smg --lib` — 617 passed, 4 ignored, 0 failed, including the new `routers::grpc::harmony::streaming::tests::streams_arguments_matches_passthrough_and_function_only`
- `cargo fmt --all` — no diffs (re-ran `--check`)
- `cargo clippy -p smg --lib --tests -- -D warnings` — clean

The unit test double-locks the classification:
- asserts `streams_arguments` returns `true` for `None` and `Some(Passthrough)`, `false` for the four hosted builtins.
- the `match format` inside the test is itself exhaustive, so any new `ResponseFormat` variant fails to compile in both the production path and the test.

No source behavior change for existing hosted tools; `ImageGenerationCall` now rides the same structured-event path it was already (accidentally) on, but explicitly and compiler-enforced.

Refs: #1355 (R6.1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated streaming argument logic for improved consistency across tool-call operations.

* **Tests**
  * Added tests to verify streaming behavior across all response format variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->