### PR TITLE
fix(mcp): reconcile mixed streaming final response and harden visibility logic

### DIFF
--- a/crates/mcp/src/core/config.rs
+++ b/crates/mcp/src/core/config.rs
@@ -215,9 +215,10 @@ pub struct McpServerConfig {
 
     /// Whether tools from this server should be hidden from standard client-visible output.
     ///
-    /// Limitation: `internal: true` does not currently redact or block live streaming
-    /// Server-Sent Events (SSE) tool events. Internal tool activity may still appear in
-    /// real-time streams until streaming redaction is implemented.
+    /// Behavior:
+    /// - Internal non-builtin server metadata/tool-trace items are redacted from assembled
+    ///   responses and streaming SSE output.
+    /// - Builtin-routed tool result items (for example `web_search_call`) remain visible.
     #[serde(default)]
     pub internal: bool,
 }

--- a/crates/mcp/src/core/session.rs
+++ b/crates/mcp/src/core/session.rs
@@ -78,7 +78,7 @@ pub struct McpToolSession<'a> {
     tenant_ctx: TenantContext,
     /// All MCP servers in this session (including builtin).
     all_mcp_servers: Vec<McpServerBinding>,
-    /// Non-builtin MCP servers only — used for `mcp_list_tools` output.
+    /// Non-builtin MCP servers only — default source for `mcp_list_tools` output.
     mcp_servers: Vec<McpServerBinding>,
     mcp_tools: Vec<ToolEntry>,
     exposed_name_map: HashMap<String, ExposedToolBinding>,
@@ -211,6 +211,17 @@ impl<'a> McpToolSession<'a> {
     /// Returns true if the name is exposed to the model for this session.
     pub fn has_exposed_tool(&self, tool_name: &str) -> bool {
         self.exposed_name_map.contains_key(tool_name)
+    }
+
+    /// Returns true when a function call should be intercepted and executed as MCP.
+    ///
+    /// User-defined function tools take precedence on name collisions.
+    pub fn should_intercept_function_call(
+        &self,
+        tool_name: &str,
+        user_function_names: &HashSet<String>,
+    ) -> bool {
+        self.has_exposed_tool(tool_name) && !user_function_names.contains(tool_name)
     }
 
     /// Returns the session's qualified-name -> exposed-name mapping.
@@ -460,6 +471,12 @@ impl<'a> McpToolSession<'a> {
     ) -> openai_protocol::responses::ResponseOutputItem {
         let tools = self.list_tools_for_server(server_key);
         build_mcp_list_tools_item(server_label, &tools)
+    }
+
+    /// Returns true when a per-server streaming `mcp_list_tools` item should be emitted.
+    pub fn should_emit_streaming_mcp_list_tools(&self, server_label: &str) -> bool {
+        !self.is_builtin_server_label(server_label)
+            && !self.is_internal_non_builtin_server_label(server_label)
     }
 
     /// Inject MCP metadata into a response output array.

--- a/docs/reference/mcp-internal-servers.md
+++ b/docs/reference/mcp-internal-servers.md
@@ -17,14 +17,13 @@ servers:
 ```
 
 In the current implementation, `internal: true` applies only to self-provided
-MCP servers declared under `servers:`. It affects final assembled,
-non-streaming MCP responses by allowing higher layers to strip internal server
-tool lists and tool-call trace items before the response is returned to the
-client.
+MCP servers declared under `servers:`. It affects both final assembled
+responses and streaming output by allowing higher layers to strip
+client-visible internal server tool lists and internal non-builtin tool-call
+trace items.
 
-This flag does not currently hide streaming output, and it does not apply to
-builtin-routed MCP results such as `web_search_call`, `code_interpreter_call`,
-or `file_search_call`.
+Builtin-routed MCP results such as `web_search_call`, `code_interpreter_call`,
+or `file_search_call` remain client-visible.
 
 This flag is generic. It does not imply any vendor-specific behavior and does
 not change transport setup or tool execution on its own.

--- a/model_gateway/src/routers/grpc/common/responses/mod.rs
+++ b/model_gateway/src/routers/grpc/common/responses/mod.rs
@@ -8,6 +8,10 @@ pub(crate) mod utils;
 // Re-export commonly used items
 pub(crate) use context::ResponsesContext;
 pub(crate) use streaming::build_sse_response;
-pub(crate) use utils::{ensure_mcp_connection, persist_response_if_needed};
+pub(crate) use utils::{
+    emit_visible_mcp_list_tools_sequence, ensure_mcp_connection, persist_response_if_needed,
+    retain_client_visible_output_items, retain_client_visible_request_tools,
+    retain_client_visible_response_tools,
+};
 
 pub(crate) use crate::routers::common::mcp_utils::collect_user_function_names;

--- a/model_gateway/src/routers/grpc/common/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/common/responses/streaming.rs
@@ -1,5 +1,7 @@
 //! Streaming infrastructure for /v1/responses endpoint
 
+use std::collections::HashSet;
+
 use axum::{body::Body, http::StatusCode, response::Response};
 use bytes::Bytes;
 use http::header::{HeaderValue, CONTENT_TYPE};
@@ -15,7 +17,7 @@ use openai_protocol::{
     },
 };
 use serde_json::json;
-use smg_mcp::{self as mcp, ResponseFormat};
+use smg_mcp::{self as mcp, McpToolSession, ResponseFormat};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::warn;
@@ -1009,4 +1011,12 @@ pub(crate) fn attach_mcp_server_label(
     if let (Some(label), Some(ResponseFormat::Passthrough)) = (server_label, response_format) {
         item["server_label"] = json!(label);
     }
+}
+
+pub(crate) fn is_client_visible_streaming_output_item(
+    session: Option<&McpToolSession<'_>>,
+    item: &serde_json::Value,
+    user_function_names: &HashSet<String>,
+) -> bool {
+    session.is_none_or(|s| !s.should_hide_output_item_json(item, user_function_names))
 }

--- a/model_gateway/src/routers/grpc/common/responses/utils.rs
+++ b/model_gateway/src/routers/grpc/common/responses/utils.rs
@@ -1,20 +1,26 @@
 //! Utility functions for /v1/responses endpoint
 
-use std::sync::Arc;
+use std::{collections::HashSet, sync::Arc};
 
 use axum::response::Response;
+use bytes::Bytes;
 use openai_protocol::{
     common::Tool,
-    responses::{ResponseTool, ResponsesRequest, ResponsesResponse},
+    responses::{
+        ResponseOutputItem, ResponseTool, ResponsesRequest, ResponsesResponse, ResponsesToolChoice,
+        ToolChoiceOptions,
+    },
 };
 use serde_json::to_value;
 use smg_data_connector::{
     ConversationItemStorage, ConversationStorage, RequestContext as StorageRequestContext,
     ResponseStorage,
 };
-use smg_mcp::{McpOrchestrator, McpServerBinding};
+use smg_mcp::{McpOrchestrator, McpServerBinding, McpToolSession};
+use tokio::sync::mpsc;
 use tracing::{debug, error, warn};
 
+use super::streaming::ResponseStreamEventEmitter;
 use crate::{
     routers::{
         common::{
@@ -165,4 +171,130 @@ pub(crate) async fn persist_response_if_needed(
             debug!("Persisted response: {}", response.id);
         }
     }
+}
+
+/// Retain only client-visible output items based on session hide policy.
+///
+/// This keeps non-streaming redaction behavior consistent across regular and
+/// harmony response paths.
+pub(crate) fn retain_client_visible_output_items(
+    output: &mut Vec<ResponseOutputItem>,
+    session: &McpToolSession<'_>,
+    user_function_names: &HashSet<String>,
+) {
+    output.retain(|item| {
+        let Ok(json) = to_value(item) else {
+            return true;
+        };
+        !session.should_hide_output_item_json(&json, user_function_names)
+    });
+}
+
+fn retain_client_visible_tools_in_place(
+    tools: &mut Vec<ResponseTool>,
+    session: &McpToolSession<'_>,
+    user_function_names: &HashSet<String>,
+) {
+    tools.retain(|tool| {
+        let Ok(json) = to_value(tool) else {
+            return true;
+        };
+        !session.should_hide_tool_json(&json, user_function_names)
+    });
+}
+
+fn has_function_tool(tools: &[ResponseTool], tool_name: &str) -> bool {
+    tools.iter().any(|tool| {
+        matches!(
+            tool,
+            ResponseTool::Function(function_tool) if function_tool.function.name == tool_name
+        )
+    })
+}
+
+fn normalize_request_tool_choice(
+    tool_choice: &mut Option<ResponsesToolChoice>,
+    tools: &[ResponseTool],
+) {
+    if tools.is_empty() {
+        *tool_choice = None;
+        return;
+    }
+
+    if let Some(selected_name) = tool_choice
+        .as_ref()
+        .and_then(ResponsesToolChoice::function_name)
+    {
+        if !has_function_tool(tools, selected_name) {
+            *tool_choice = Some(ResponsesToolChoice::Options(ToolChoiceOptions::Auto));
+        }
+    }
+}
+
+fn normalize_response_tool_choice(tool_choice: &mut String, tools: &[ResponseTool]) {
+    if tools.is_empty() {
+        *tool_choice = "auto".to_string();
+        return;
+    }
+
+    let selected_name = serde_json::from_str::<ResponsesToolChoice>(tool_choice)
+        .ok()
+        .and_then(|choice| choice.function_name().map(str::to_string));
+    if let Some(selected_name) = selected_name {
+        if !has_function_tool(tools, &selected_name) {
+            *tool_choice = "auto".to_string();
+        }
+    }
+}
+
+/// Retain only client-visible tools and normalize request `tool_choice`.
+///
+/// Used on streaming paths before copying original request fields into
+/// `response.completed` payloads.
+pub(crate) fn retain_client_visible_request_tools(
+    request: &mut ResponsesRequest,
+    session: &McpToolSession<'_>,
+    user_function_names: &HashSet<String>,
+) {
+    if let Some(tools) = request.tools.as_mut() {
+        retain_client_visible_tools_in_place(tools, session, user_function_names);
+        normalize_request_tool_choice(&mut request.tool_choice, tools);
+        if tools.is_empty() {
+            request.tools = None;
+        }
+    } else {
+        request.tool_choice = None;
+    }
+}
+
+/// Retain only client-visible tools and normalize response `tool_choice`.
+///
+/// Keeps gRPC non-streaming responses aligned with session hide policy.
+pub(crate) fn retain_client_visible_response_tools(
+    response: &mut ResponsesResponse,
+    session: &McpToolSession<'_>,
+    user_function_names: &HashSet<String>,
+) {
+    retain_client_visible_tools_in_place(&mut response.tools, session, user_function_names);
+    normalize_response_tool_choice(&mut response.tool_choice, &response.tools);
+}
+
+/// Emit the visible `mcp_list_tools` streaming sequence for all server bindings
+/// in the session.
+///
+/// Visibility is gated by `session.should_emit_streaming_mcp_list_tools` so
+/// hidden bindings do not appear in client-facing streams.
+pub(crate) fn emit_visible_mcp_list_tools_sequence(
+    session: &McpToolSession<'_>,
+    emitter: &mut ResponseStreamEventEmitter,
+    tx: &mpsc::UnboundedSender<Result<Bytes, std::io::Error>>,
+) -> Result<(), String> {
+    for binding in session.mcp_servers() {
+        if !session.should_emit_streaming_mcp_list_tools(&binding.label) {
+            continue;
+        }
+        let tools_for_server = session.list_tools_for_server(&binding.server_key);
+        emitter.emit_mcp_list_tools_sequence(&binding.label, &tools_for_server, tx)?;
+    }
+    Ok(())
 }

--- a/model_gateway/src/routers/grpc/harmony/responses/non_streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/non_streaming.rs
@@ -33,6 +33,7 @@ use crate::{
         grpc::{
             common::responses::{
                 collect_user_function_names, ensure_mcp_connection, persist_response_if_needed,
+                retain_client_visible_output_items, retain_client_visible_response_tools,
                 ResponsesContext,
             },
             harmony::processor::ResponsesIterationResult,
@@ -180,12 +181,14 @@ async fn execute_with_mcp_loop(
                     "Tool calls found - separating MCP and function tools"
                 );
 
-                // Separate MCP and function tool calls based on session exposure.
-                // MCP tools are exposed to the model as function tools, so the only reliable
-                // discriminator is whether the name belongs to the MCP session.
-                let (mcp_tool_calls, function_tool_calls): (Vec<_>, Vec<_>) = tool_calls
-                    .into_iter()
-                    .partition(|tc| session.has_exposed_tool(tc.function.name.as_str()));
+                // Separate MCP and function tool calls based on session policy.
+                let (mcp_tool_calls, function_tool_calls): (Vec<_>, Vec<_>) =
+                    tool_calls.into_iter().partition(|tc| {
+                        session.should_intercept_function_call(
+                            tc.function.name.as_str(),
+                            &user_function_names,
+                        )
+                    });
 
                 debug!(
                     mcp_calls = mcp_tool_calls.len(),
@@ -245,6 +248,16 @@ async fn execute_with_mcp_loop(
                             &user_function_names,
                         );
                     }
+                    retain_client_visible_output_items(
+                        &mut response.output,
+                        &session,
+                        &user_function_names,
+                    );
+                    retain_client_visible_response_tools(
+                        &mut response,
+                        &session,
+                        &user_function_names,
+                    );
 
                     return Ok(response);
                 }
@@ -295,6 +308,11 @@ async fn execute_with_mcp_loop(
                             &user_function_names,
                         );
                     }
+                    retain_client_visible_response_tools(
+                        &mut response,
+                        &session,
+                        &user_function_names,
+                    );
 
                     return Ok(response);
                 }
@@ -329,6 +347,7 @@ async fn execute_with_mcp_loop(
 
                 // Restore original tools (hide internal MCP tools from response)
                 response.tools = original_tools.take().unwrap_or_default();
+                retain_client_visible_response_tools(&mut response, &session, &user_function_names);
 
                 debug!(
                     mcp_calls = mcp_tracking.total_calls(),

--- a/model_gateway/src/routers/grpc/harmony/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/streaming.rs
@@ -22,7 +22,9 @@ use crate::{
         common::mcp_utils::DEFAULT_MAX_ITERATIONS,
         grpc::{
             common::responses::{
-                build_sse_response, ensure_mcp_connection, persist_response_if_needed,
+                build_sse_response, collect_user_function_names,
+                emit_visible_mcp_list_tools_sequence, ensure_mcp_connection,
+                persist_response_if_needed, retain_client_visible_request_tools,
                 streaming::ResponseStreamEventEmitter, ResponsesContext,
             },
             harmony::{processor::ResponsesIterationResult, streaming::HarmonyStreamingProcessor},
@@ -146,6 +148,14 @@ async fn execute_mcp_tool_loop_streaming(
     let session_request_id = format!("resp_{}", Uuid::now_v7());
 
     let session = McpToolSession::new(&ctx.mcp_orchestrator, mcp_servers, &session_request_id);
+    let user_function_names = collect_user_function_names(original_request);
+    let mut client_visible_request = original_request.clone();
+    retain_client_visible_request_tools(
+        &mut client_visible_request,
+        &session,
+        &user_function_names,
+    );
+    emitter.set_original_request(client_visible_request);
 
     // Add filtered MCP tools (static + requested dynamic) to the request
     let mcp_tools = session.mcp_tools();
@@ -165,15 +175,8 @@ async fn execute_mcp_tool_loop_streaming(
     let mut mcp_tracking = McpCallTracking::new();
 
     // Emit mcp_list_tools on first iteration
-    for binding in session.mcp_servers() {
-        let tools_for_server = session.list_tools_for_server(&binding.server_key);
-
-        if emitter
-            .emit_mcp_list_tools_sequence(&binding.label, &tools_for_server, tx)
-            .is_err()
-        {
-            return;
-        }
+    if emit_visible_mcp_list_tools_sequence(&session, emitter, tx).is_err() {
+        return;
     }
 
     debug!(
@@ -231,6 +234,7 @@ async fn execute_mcp_tool_loop_streaming(
             emitter,
             tx,
             Some(&session),
+            Some(&user_function_names),
         )
         .await
         {
@@ -257,10 +261,12 @@ async fn execute_mcp_tool_loop_streaming(
                     "Tool calls found - separating MCP and function tools"
                 );
 
-                // Separate MCP and function tool calls based on session exposure.
-                let (mcp_tool_calls, function_tool_calls): (Vec<_>, Vec<_>) = tool_calls
-                    .into_iter()
-                    .partition(|tc| session.has_exposed_tool(&tc.function.name));
+                // Separate MCP and function tool calls based on session policy.
+                let (mcp_tool_calls, function_tool_calls): (Vec<_>, Vec<_>) =
+                    tool_calls.into_iter().partition(|tc| {
+                        session
+                            .should_intercept_function_call(&tc.function.name, &user_function_names)
+                    });
 
                 debug!(
                     mcp_calls = mcp_tool_calls.len(),
@@ -438,6 +444,7 @@ async fn execute_without_mcp_streaming(
         execution_result,
         emitter,
         tx,
+        None,
         None,
     )
     .await

--- a/model_gateway/src/routers/grpc/harmony/streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/streaming.rs
@@ -1,7 +1,7 @@
 //! Harmony streaming response processor
 
 use std::{
-    collections::{hash_map::Entry::Vacant, HashMap},
+    collections::{hash_map::Entry::Vacant, HashMap, HashSet},
     io,
     sync::Arc,
     time::Instant,
@@ -35,7 +35,10 @@ use crate::{
             response_formatting::CompletionTokenTracker,
             responses::{
                 build_sse_response,
-                streaming::{attach_mcp_server_label, OutputItemType, ResponseStreamEventEmitter},
+                streaming::{
+                    attach_mcp_server_label, is_client_visible_streaming_output_item,
+                    OutputItemType, ResponseStreamEventEmitter,
+                },
             },
         },
         context,
@@ -49,6 +52,14 @@ use crate::{
 /// Returns an SSE stream that parses Harmony tokens incrementally and
 /// emits ChatCompletionChunk events for streaming responses.
 pub(crate) struct HarmonyStreamingProcessor;
+
+#[derive(Debug, Clone)]
+struct ToolCallStreamState {
+    output_index: Option<usize>,
+    item_id: Option<String>,
+    response_format: Option<ResponseFormat>,
+    is_visible: bool,
+}
 
 impl HarmonyStreamingProcessor {
     /// Create a new Harmony streaming processor
@@ -475,15 +486,25 @@ impl HarmonyStreamingProcessor {
         emitter: &mut ResponseStreamEventEmitter,
         tx: &mpsc::UnboundedSender<Result<Bytes, io::Error>>,
         session: Option<&McpToolSession<'_>>,
+        user_function_names: Option<&HashSet<String>>,
     ) -> Result<ResponsesIterationResult, String> {
         match execution_result {
             context::ExecutionResult::Single { stream } => {
                 debug!("Processing Responses API single stream mode");
-                Self::process_decode_stream(stream, emitter, tx, session, 0).await
+                Self::process_decode_stream(stream, emitter, tx, session, user_function_names, 0)
+                    .await
             }
             context::ExecutionResult::Dual { prefill, decode } => {
                 debug!("Processing Responses API dual stream mode");
-                Self::process_responses_dual_stream(prefill, *decode, emitter, tx, session).await
+                Self::process_responses_dual_stream(
+                    prefill,
+                    *decode,
+                    emitter,
+                    tx,
+                    session,
+                    user_function_names,
+                )
+                .await
             }
             context::ExecutionResult::Embedding { .. } => {
                 Err("Embeddings not supported in Responses API streaming".to_string())
@@ -497,6 +518,7 @@ impl HarmonyStreamingProcessor {
         emitter: &mut ResponseStreamEventEmitter,
         tx: &mpsc::UnboundedSender<Result<Bytes, io::Error>>,
         session: Option<&McpToolSession<'_>>,
+        user_function_names: Option<&HashSet<String>>,
     ) -> Result<ResponsesIterationResult, String> {
         // Phase 1: Drain prefill stream, collecting cached_tokens from Complete messages
         let mut prefill_cached_tokens_by_index: HashMap<u32, u32> = HashMap::new();
@@ -510,9 +532,15 @@ impl HarmonyStreamingProcessor {
         let prefill_cached_tokens: u32 = prefill_cached_tokens_by_index.values().sum();
 
         // Phase 2: Process decode stream
-        let result =
-            Self::process_decode_stream(decode_stream, emitter, tx, session, prefill_cached_tokens)
-                .await;
+        let result = Self::process_decode_stream(
+            decode_stream,
+            emitter,
+            tx,
+            session,
+            user_function_names,
+            prefill_cached_tokens,
+        )
+        .await;
 
         prefill_stream.mark_completed();
         result
@@ -524,6 +552,7 @@ impl HarmonyStreamingProcessor {
         emitter: &mut ResponseStreamEventEmitter,
         tx: &mpsc::UnboundedSender<Result<Bytes, io::Error>>,
         session: Option<&McpToolSession<'_>>,
+        user_function_names: Option<&HashSet<String>>,
         prefill_cached_tokens: u32,
     ) -> Result<ResponsesIterationResult, String> {
         let mut parser =
@@ -539,8 +568,9 @@ impl HarmonyStreamingProcessor {
         let mut has_emitted_content_part_added = false;
 
         // Tool call tracking: call_index -> (output_index, item_id, response_format)
-        let mut tool_call_tracking: HashMap<usize, (usize, String, Option<ResponseFormat>)> =
-            HashMap::new();
+        let empty_user_function_names = HashSet::new();
+        let user_function_names = user_function_names.unwrap_or(&empty_user_function_names);
+        let mut tool_call_tracking: HashMap<usize, ToolCallStreamState> = HashMap::new();
 
         // Metadata from Complete message; seed cached_tokens from prefill phase (dual-stream)
         let mut finish_reason: String;
@@ -655,7 +685,10 @@ impl HarmonyStreamingProcessor {
 
                                 // Determine response_format based on MCP context.
                                 let response_format = session.and_then(|s| {
-                                    if s.has_exposed_tool(tool_name) {
+                                    if s.should_intercept_function_call(
+                                        tool_name,
+                                        user_function_names,
+                                    ) {
                                         Some(s.tool_response_format(tool_name))
                                     } else {
                                         None
@@ -671,17 +704,7 @@ impl HarmonyStreamingProcessor {
                                     response_format.as_ref(),
                                 );
 
-                                let (output_index, item_id) =
-                                    emitter.allocate_output_index(output_item_type);
-
-                                tool_call_tracking.insert(
-                                    call_index,
-                                    (output_index, item_id.clone(), response_format.clone()),
-                                );
-
-                                // Build output_item.added event
-                                let mut item = json!({
-                                    "id": item_id,
+                                let mut visibility_probe_item = json!({
                                     "type": type_str,
                                     "name": tool_name,
                                     "call_id": call_id,
@@ -693,57 +716,87 @@ impl HarmonyStreamingProcessor {
                                     .map(|s| s.resolve_tool_server_label(tool_name))
                                     .unwrap_or_else(|| DEFAULT_SERVER_LABEL.to_string());
                                 attach_mcp_server_label(
-                                    &mut item,
+                                    &mut visibility_probe_item,
                                     Some(label.as_str()),
                                     response_format.as_ref(),
                                 );
+                                let is_visible = is_client_visible_streaming_output_item(
+                                    session,
+                                    &visibility_probe_item,
+                                    user_function_names,
+                                );
 
-                                let event = emitter.emit_output_item_added(output_index, &item);
-                                emitter.send_event_best_effort(&event, tx);
+                                let mut stream_state = ToolCallStreamState {
+                                    output_index: None,
+                                    item_id: None,
+                                    response_format: response_format.clone(),
+                                    is_visible,
+                                };
 
-                                // Emit in_progress event for MCP tools
-                                if let Some(ref fmt) = response_format {
-                                    let event = emitter.emit_tool_call_in_progress(
-                                        output_index,
-                                        &item_id,
-                                        fmt,
-                                    );
+                                if is_visible {
+                                    let (output_index, item_id) =
+                                        emitter.allocate_output_index(output_item_type);
+                                    let mut item = visibility_probe_item;
+                                    item["id"] = json!(item_id.clone());
+
+                                    let event = emitter.emit_output_item_added(output_index, &item);
                                     emitter.send_event_best_effort(&event, tx);
 
-                                    // Emit searching/interpreting event for builtin tools
-                                    if let Some(event) = emitter.emit_tool_call_searching(
-                                        output_index,
-                                        &item_id,
-                                        fmt,
+                                    if let Some(ref fmt) = response_format {
+                                        let event = emitter.emit_tool_call_in_progress(
+                                            output_index,
+                                            &item_id,
+                                            fmt,
+                                        );
+                                        emitter.send_event_best_effort(&event, tx);
+
+                                        if let Some(event) = emitter.emit_tool_call_searching(
+                                            output_index,
+                                            &item_id,
+                                            fmt,
+                                        ) {
+                                            emitter.send_event_best_effort(&event, tx);
+                                        }
+                                    }
+
+                                    if matches!(
+                                        response_format,
+                                        Some(ResponseFormat::Passthrough) | None
                                     ) {
+                                        let event = match &response_format {
+                                            Some(_) => emitter.emit_mcp_call_arguments_delta(
+                                                output_index,
+                                                &item_id,
+                                                "",
+                                            ),
+                                            None => emitter.emit_function_call_arguments_delta(
+                                                output_index,
+                                                &item_id,
+                                                "",
+                                            ),
+                                        };
                                         emitter.send_event_best_effort(&event, tx);
                                     }
+
+                                    stream_state.output_index = Some(output_index);
+                                    stream_state.item_id = Some(item_id);
                                 }
 
-                                // Emit initial arguments delta for mcp_call only (skip for builtin tools)
-                                if matches!(
-                                    response_format,
-                                    Some(ResponseFormat::Passthrough) | None
-                                ) {
-                                    let event = match &response_format {
-                                        Some(_) => emitter.emit_mcp_call_arguments_delta(
-                                            output_index,
-                                            &item_id,
-                                            "",
-                                        ),
-                                        None => emitter.emit_function_call_arguments_delta(
-                                            output_index,
-                                            &item_id,
-                                            "",
-                                        ),
-                                    };
-                                    emitter.send_event_best_effort(&event, tx);
-                                }
+                                tool_call_tracking.insert(call_index, stream_state);
                             } else {
                                 // Continuing tool call: emit arguments delta
-                                if let Some((output_index, item_id, response_format)) =
-                                    tool_call_tracking.get(&call_index)
-                                {
+                                if let Some(stream_state) = tool_call_tracking.get(&call_index) {
+                                    if !stream_state.is_visible {
+                                        continue;
+                                    }
+                                    let (Some(output_index), Some(item_id)) = (
+                                        stream_state.output_index,
+                                        stream_state.item_id.as_deref(),
+                                    ) else {
+                                        continue;
+                                    };
+                                    let response_format = &stream_state.response_format;
+
                                     // Skip arguments streaming for builtin tools (only mcp_call streams arguments)
                                     if !matches!(
                                         response_format,
@@ -760,12 +813,12 @@ impl HarmonyStreamingProcessor {
                                     {
                                         let event = match response_format {
                                             Some(_) => emitter.emit_mcp_call_arguments_delta(
-                                                *output_index,
+                                                output_index,
                                                 item_id,
                                                 args,
                                             ),
                                             None => emitter.emit_function_call_arguments_delta(
-                                                *output_index,
+                                                output_index,
                                                 item_id,
                                                 args,
                                             ),
@@ -801,9 +854,16 @@ impl HarmonyStreamingProcessor {
                     // Complete all tool calls if we have commentary
                     if let Some(ref tool_calls) = accumulated_tool_calls {
                         for (call_idx, tool_call) in tool_calls.iter().enumerate() {
-                            if let Some((output_index, item_id, response_format)) =
-                                tool_call_tracking.get(&call_idx)
-                            {
+                            if let Some(stream_state) = tool_call_tracking.get(&call_idx) {
+                                if !stream_state.is_visible {
+                                    continue;
+                                }
+                                let (Some(output_index), Some(item_id)) =
+                                    (stream_state.output_index, stream_state.item_id.as_deref())
+                                else {
+                                    continue;
+                                };
+                                let response_format = &stream_state.response_format;
                                 let tool_name = &tool_call.function.name;
                                 let args_str =
                                     tool_call.function.arguments.as_deref().unwrap_or("");
@@ -815,12 +875,12 @@ impl HarmonyStreamingProcessor {
                                 ) {
                                     let event = match response_format {
                                         Some(_) => emitter.emit_mcp_call_arguments_done(
-                                            *output_index,
+                                            output_index,
                                             item_id,
                                             args_str,
                                         ),
                                         None => emitter.emit_function_call_arguments_done(
-                                            *output_index,
+                                            output_index,
                                             item_id,
                                             args_str,
                                         ),
@@ -831,7 +891,7 @@ impl HarmonyStreamingProcessor {
                                 // Emit completed event for MCP tools
                                 if let Some(ref fmt) = response_format {
                                     let event = emitter.emit_tool_call_completed(
-                                        *output_index,
+                                        output_index,
                                         item_id,
                                         fmt,
                                     );
@@ -861,8 +921,8 @@ impl HarmonyStreamingProcessor {
                                     response_format.as_ref(),
                                 );
 
-                                let event = emitter.emit_output_item_done(*output_index, &item);
-                                emitter.complete_output_item(*output_index);
+                                let event = emitter.emit_output_item_done(output_index, &item);
+                                emitter.complete_output_item(output_index);
                                 emitter.send_event_best_effort(&event, tx);
                             }
                         }
@@ -938,9 +998,16 @@ impl HarmonyStreamingProcessor {
             // Complete any pending tool calls with data from completed messages
             if let Some(ref tool_calls) = accumulated_tool_calls {
                 for (call_idx, tool_call) in tool_calls.iter().enumerate() {
-                    if let Some((output_index, item_id, response_format)) =
-                        tool_call_tracking.get(&call_idx)
-                    {
+                    if let Some(stream_state) = tool_call_tracking.get(&call_idx) {
+                        if !stream_state.is_visible {
+                            continue;
+                        }
+                        let (Some(output_index), Some(item_id)) =
+                            (stream_state.output_index, stream_state.item_id.as_deref())
+                        else {
+                            continue;
+                        };
+                        let response_format = &stream_state.response_format;
                         let tool_name = &tool_call.function.name;
                         let args_str = tool_call.function.arguments.as_deref().unwrap_or("");
 
@@ -948,12 +1015,12 @@ impl HarmonyStreamingProcessor {
                         if matches!(response_format, Some(ResponseFormat::Passthrough) | None) {
                             let event = match response_format {
                                 Some(_) => emitter.emit_mcp_call_arguments_done(
-                                    *output_index,
+                                    output_index,
                                     item_id,
                                     args_str,
                                 ),
                                 None => emitter.emit_function_call_arguments_done(
-                                    *output_index,
+                                    output_index,
                                     item_id,
                                     args_str,
                                 ),
@@ -964,7 +1031,7 @@ impl HarmonyStreamingProcessor {
                         // Emit completed event for MCP tools
                         if let Some(ref fmt) = response_format {
                             let event =
-                                emitter.emit_tool_call_completed(*output_index, item_id, fmt);
+                                emitter.emit_tool_call_completed(output_index, item_id, fmt);
                             emitter.send_event_best_effort(&event, tx);
                         }
 
@@ -990,8 +1057,8 @@ impl HarmonyStreamingProcessor {
                             response_format.as_ref(),
                         );
 
-                        let event = emitter.emit_output_item_done(*output_index, &item);
-                        emitter.complete_output_item(*output_index);
+                        let event = emitter.emit_output_item_done(output_index, &item);
+                        emitter.complete_output_item(output_index);
                         emitter.send_event_best_effort(&event, tx);
                     }
                 }

--- a/model_gateway/src/routers/grpc/harmony/streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/streaming.rs
@@ -704,6 +704,8 @@ impl HarmonyStreamingProcessor {
                                     response_format.as_ref(),
                                 );
 
+                                // Keep this probe shape aligned with fields currently inspected
+                                // by `McpToolSession::should_hide_output_item_json`.
                                 let mut visibility_probe_item = json!({
                                     "type": type_str,
                                     "name": tool_name,

--- a/model_gateway/src/routers/grpc/regular/responses/non_streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/non_streaming.rs
@@ -28,6 +28,7 @@ use crate::{
         error,
         grpc::common::responses::{
             collect_user_function_names, ensure_mcp_connection, persist_response_if_needed,
+            retain_client_visible_output_items, retain_client_visible_response_tools,
             ResponsesContext,
         },
     },
@@ -240,6 +241,11 @@ pub(super) async fn execute_tool_loop(
                     state.total_calls
                 );
             }
+            retain_client_visible_response_tools(
+                &mut responses_response,
+                &session,
+                &user_function_names,
+            );
 
             return Ok(responses_response);
         } else {
@@ -254,11 +260,11 @@ pub(super) async fn execute_tool_loop(
                 tool_calls.len()
             );
 
-            // Separate MCP and function tool calls using session-exposed names.
+            // Separate MCP and function tool calls using session policy.
             let (mcp_tool_calls, function_tool_calls): (Vec<ExtractedToolCall>, Vec<_>) =
-                tool_calls
-                    .into_iter()
-                    .partition(|tc| session.has_exposed_tool(tc.name.as_str()));
+                tool_calls.into_iter().partition(|tc| {
+                    session.should_intercept_function_call(tc.name.as_str(), &user_function_names)
+                });
 
             trace!(
                 "Separated tool calls: {} MCP, {} function",
@@ -266,10 +272,10 @@ pub(super) async fn execute_tool_loop(
                 function_tool_calls.len()
             );
 
-            // If ANY tool call is a function tool, return to caller immediately
-            if !function_tool_calls.is_empty() {
-                // Convert chat response to responses format (includes all tool calls)
-                let responses_response = conversions::chat_to_responses(
+            let has_user_function_calls = !function_tool_calls.is_empty();
+            if mcp_tool_calls.is_empty() {
+                // Convert chat response to responses format (includes only user function calls)
+                let mut responses_response = conversions::chat_to_responses(
                     &chat_response,
                     original_request,
                     params.response_id.clone(),
@@ -287,8 +293,12 @@ pub(super) async fn execute_tool_loop(
                         format!("Failed to convert to responses format: {e}"),
                     )
                 })?;
+                retain_client_visible_response_tools(
+                    &mut responses_response,
+                    &session,
+                    &user_function_names,
+                );
 
-                // Return response with function tool calls to caller
                 return Ok(responses_response);
             }
 
@@ -331,6 +341,16 @@ pub(super) async fn execute_tool_loop(
                 // Mark as completed but with incomplete details
                 responses_response.status = ResponseStatus::Completed;
                 responses_response.incomplete_details = Some(json!({ "reason": "max_tool_calls" }));
+                retain_client_visible_output_items(
+                    &mut responses_response.output,
+                    &session,
+                    &user_function_names,
+                );
+                retain_client_visible_response_tools(
+                    &mut responses_response,
+                    &session,
+                    &user_function_names,
+                );
 
                 return Ok(responses_response);
             }
@@ -388,6 +408,53 @@ pub(super) async fn execute_tool_loop(
 
                 // Increment total calls counter
                 state.total_calls += 1;
+            }
+
+            if has_user_function_calls {
+                // Return mixed response: MCP calls executed by gateway; user function calls
+                // remain for client execution.
+                let mut responses_response = conversions::chat_to_responses(
+                    &chat_response,
+                    original_request,
+                    params.response_id.clone(),
+                )
+                .map_err(|e| {
+                    error!(
+                        function = "tool_loop",
+                        iteration = state.iteration,
+                        error = %e,
+                        context = "mixed_tool_calls",
+                        "Failed to convert ChatCompletionResponse to ResponsesResponse"
+                    );
+                    error::internal_error(
+                        "convert_to_responses_format_failed",
+                        format!("Failed to convert to responses format: {e}"),
+                    )
+                })?;
+
+                // Remove MCP function_call placeholders; executed MCP results are injected
+                // below as MCP/builtin output items.
+                responses_response.output.retain(|item| match item {
+                    openai_protocol::responses::ResponseOutputItem::FunctionToolCall {
+                        name,
+                        ..
+                    } => !session.should_intercept_function_call(name, &user_function_names),
+                    _ => true,
+                });
+
+                let tool_items = std::mem::take(&mut state.mcp_call_items);
+                session.inject_client_visible_mcp_output_items(
+                    &mut responses_response.output,
+                    tool_items,
+                    &user_function_names,
+                );
+                retain_client_visible_response_tools(
+                    &mut responses_response,
+                    &session,
+                    &user_function_names,
+                );
+
+                return Ok(responses_response);
             }
 
             // Build resume request with conversation history

--- a/model_gateway/src/routers/grpc/regular/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/streaming.rs
@@ -53,8 +53,13 @@ use crate::{
         common::mcp_utils::DEFAULT_MAX_ITERATIONS,
         grpc::{
             common::responses::{
-                build_sse_response, persist_response_if_needed,
-                streaming::{attach_mcp_server_label, OutputItemType, ResponseStreamEventEmitter},
+                build_sse_response, collect_user_function_names,
+                emit_visible_mcp_list_tools_sequence, persist_response_if_needed,
+                retain_client_visible_request_tools,
+                streaming::{
+                    attach_mcp_server_label, is_client_visible_streaming_output_item,
+                    OutputItemType, ResponseStreamEventEmitter,
+                },
                 ResponsesContext,
             },
             utils,
@@ -511,6 +516,7 @@ async fn execute_tool_loop_streaming_internal(
 
     // Create session once — bundles orchestrator, request_ctx, server_keys, mcp_tools
     let session = McpToolSession::new(&ctx.mcp_orchestrator, mcp_servers, &response_id);
+    let user_function_names = collect_user_function_names(original_request);
 
     // Create response event emitter
     let created_at = SystemTime::now()
@@ -519,7 +525,13 @@ async fn execute_tool_loop_streaming_internal(
         .as_secs();
     let mut emitter =
         ResponseStreamEventEmitter::new(response_id, current_request.model.clone(), created_at);
-    emitter.set_original_request(original_request.clone());
+    let mut client_visible_request = original_request.clone();
+    retain_client_visible_request_tools(
+        &mut client_visible_request,
+        &session,
+        &user_function_names,
+    );
+    emitter.set_original_request(client_visible_request);
 
     // Emit initial response.created and response.in_progress events
     let event = emitter.emit_created();
@@ -553,11 +565,7 @@ async fn execute_tool_loop_streaming_internal(
 
         // Emit mcp_list_tools as first output item (only once, on first iteration)
         if !mcp_list_tools_emitted {
-            for binding in session.mcp_servers() {
-                let tools_for_server = session.list_tools_for_server(&binding.server_key);
-
-                emitter.emit_mcp_list_tools_sequence(&binding.label, &tools_for_server, &tx)?;
-            }
+            emit_visible_mcp_list_tools_sequence(&session, &mut emitter, &tx)?;
             mcp_list_tools_emitted = true;
         }
 
@@ -595,11 +603,11 @@ async fn execute_tool_loop_streaming_internal(
                 tool_calls.len()
             );
 
-            // Separate MCP and function tool calls using session-exposed names.
+            // Separate MCP and function tool calls using session policy.
             let (mcp_tool_calls, function_tool_calls): (Vec<ExtractedToolCall>, Vec<_>) =
-                tool_calls
-                    .into_iter()
-                    .partition(|tc| session.has_exposed_tool(tc.name.as_str()));
+                tool_calls.into_iter().partition(|tc| {
+                    session.should_intercept_function_call(tc.name.as_str(), &user_function_names)
+                });
 
             trace!(
                 "Separated tool calls: {} MCP, {} function",
@@ -646,57 +654,67 @@ async fn execute_tool_loop_streaming_internal(
                 let output_item_type =
                     ResponseStreamEventEmitter::output_item_type_for_format(Some(&response_format));
                 let resolved_label = session.resolve_tool_server_label(&tool_call.name);
-
-                // Allocate output_index with correct type (generates appropriate item_id prefix)
-                let (output_index, item_id) = emitter.allocate_output_index(output_item_type);
-
-                // Build initial tool call item
-                let mut item = json!({
-                    "id": item_id,
+                let mut visibility_probe_item = json!({
                     "type": item_type,
                     "name": tool_call.name,
                     "status": "in_progress",
                     "arguments": ""
                 });
                 attach_mcp_server_label(
-                    &mut item,
+                    &mut visibility_probe_item,
                     Some(resolved_label.as_str()),
                     Some(&response_format),
                 );
+                let should_emit_tool_item = is_client_visible_streaming_output_item(
+                    Some(&session),
+                    &visibility_probe_item,
+                    &user_function_names,
+                );
 
-                // Emit output_item.added
-                let event = emitter.emit_output_item_added(output_index, &item);
-                emitter.send_event(&event, &tx)?;
+                let mut output_index: Option<usize> = None;
+                let mut item_id: Option<String> = None;
+                if should_emit_tool_item {
+                    let (allocated_output_index, allocated_item_id) =
+                        emitter.allocate_output_index(output_item_type);
+                    let mut item = visibility_probe_item;
+                    item["id"] = json!(allocated_item_id.clone());
 
-                // Emit tool_call.in_progress
-                let event =
-                    emitter.emit_tool_call_in_progress(output_index, &item_id, &response_format);
-                emitter.send_event(&event, &tx)?;
+                    let event = emitter.emit_output_item_added(allocated_output_index, &item);
+                    emitter.send_event(&event, &tx)?;
 
-                // Emit arguments events for mcp_call only (skip for builtin tools)
-                if matches!(response_format, ResponseFormat::Passthrough) {
-                    // Emit mcp_call_arguments.delta (simulate streaming by sending full arguments)
-                    let event = emitter.emit_mcp_call_arguments_delta(
-                        output_index,
-                        &item_id,
-                        &tool_call.arguments,
+                    let event = emitter.emit_tool_call_in_progress(
+                        allocated_output_index,
+                        &allocated_item_id,
+                        &response_format,
                     );
                     emitter.send_event(&event, &tx)?;
 
-                    // Emit mcp_call_arguments.done
-                    let event = emitter.emit_mcp_call_arguments_done(
-                        output_index,
-                        &item_id,
-                        &tool_call.arguments,
-                    );
-                    emitter.send_event(&event, &tx)?;
-                }
+                    if matches!(response_format, ResponseFormat::Passthrough) {
+                        let event = emitter.emit_mcp_call_arguments_delta(
+                            allocated_output_index,
+                            &allocated_item_id,
+                            &tool_call.arguments,
+                        );
+                        emitter.send_event(&event, &tx)?;
 
-                // Emit searching/interpreting event for builtin tools
-                if let Some(event) =
-                    emitter.emit_tool_call_searching(output_index, &item_id, &response_format)
-                {
-                    emitter.send_event(&event, &tx)?;
+                        let event = emitter.emit_mcp_call_arguments_done(
+                            allocated_output_index,
+                            &allocated_item_id,
+                            &tool_call.arguments,
+                        );
+                        emitter.send_event(&event, &tx)?;
+                    }
+
+                    if let Some(event) = emitter.emit_tool_call_searching(
+                        allocated_output_index,
+                        &allocated_item_id,
+                        &response_format,
+                    ) {
+                        emitter.send_event(&event, &tx)?;
+                    }
+
+                    output_index = Some(allocated_output_index);
+                    item_id = Some(allocated_item_id);
                 }
 
                 // Execute the MCP tool
@@ -724,29 +742,33 @@ async fn execute_tool_loop_streaming_internal(
 
                 if success {
                     // Emit tool_call.completed
-                    let event =
-                        emitter.emit_tool_call_completed(output_index, &item_id, &response_format);
-                    emitter.send_event(&event, &tx)?;
+                    if let (Some(output_index), Some(item_id)) = (output_index, item_id.as_deref())
+                    {
+                        let event = emitter.emit_tool_call_completed(
+                            output_index,
+                            item_id,
+                            &response_format,
+                        );
+                        emitter.send_event(&event, &tx)?;
 
-                    // Build complete item with output
-                    let mut item_done = json!({
-                        "id": item_id,
-                        "type": item_type,
-                        "name": tool_output.tool_name,
-                        "status": "completed",
-                        "arguments": tool_output.arguments_str,
-                        "output": output_str
-                    });
-                    attach_mcp_server_label(
-                        &mut item_done,
-                        Some(tool_output.server_label.as_str()),
-                        Some(&response_format),
-                    );
+                        let mut item_done = json!({
+                            "id": item_id,
+                            "type": item_type,
+                            "name": tool_output.tool_name,
+                            "status": "completed",
+                            "arguments": tool_output.arguments_str,
+                            "output": output_str
+                        });
+                        attach_mcp_server_label(
+                            &mut item_done,
+                            Some(tool_output.server_label.as_str()),
+                            Some(&response_format),
+                        );
 
-                    // Emit output_item.done
-                    let event = emitter.emit_output_item_done(output_index, &item_done);
-                    emitter.send_event(&event, &tx)?;
-                    emitter.complete_output_item(output_index);
+                        let event = emitter.emit_output_item_done(output_index, &item_done);
+                        emitter.send_event(&event, &tx)?;
+                        emitter.complete_output_item(output_index);
+                    }
                 } else {
                     let err_text = tool_output
                         .error_message
@@ -754,29 +776,29 @@ async fn execute_tool_loop_streaming_internal(
                         .unwrap_or_else(|| output_str.clone());
                     warn!("Tool execution returned error: {}", err_text);
 
-                    // Emit mcp_call.failed (no web_search_call.failed event exists)
-                    let event = emitter.emit_mcp_call_failed(output_index, &item_id, &err_text);
-                    emitter.send_event(&event, &tx)?;
+                    if let (Some(output_index), Some(item_id)) = (output_index, item_id.as_deref())
+                    {
+                        let event = emitter.emit_mcp_call_failed(output_index, item_id, &err_text);
+                        emitter.send_event(&event, &tx)?;
 
-                    // Build failed item
-                    let mut item_done = json!({
-                        "id": item_id,
-                        "type": item_type,
-                        "name": tool_output.tool_name,
-                        "status": "failed",
-                        "arguments": tool_output.arguments_str,
-                        "error": err_text
-                    });
-                    attach_mcp_server_label(
-                        &mut item_done,
-                        Some(tool_output.server_label.as_str()),
-                        Some(&response_format),
-                    );
+                        let mut item_done = json!({
+                            "id": item_id,
+                            "type": item_type,
+                            "name": tool_output.tool_name,
+                            "status": "failed",
+                            "arguments": tool_output.arguments_str,
+                            "error": err_text
+                        });
+                        attach_mcp_server_label(
+                            &mut item_done,
+                            Some(tool_output.server_label.as_str()),
+                            Some(&response_format),
+                        );
 
-                    // Emit output_item.done
-                    let event = emitter.emit_output_item_done(output_index, &item_done);
-                    emitter.send_event(&event, &tx)?;
-                    emitter.complete_output_item(output_index);
+                        let event = emitter.emit_output_item_done(output_index, &item_done);
+                        emitter.send_event(&event, &tx)?;
+                        emitter.complete_output_item(output_index);
+                    }
                 }
 
                 // Record MCP tool metrics

--- a/model_gateway/src/routers/grpc/regular/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/streaming.rs
@@ -654,6 +654,8 @@ async fn execute_tool_loop_streaming_internal(
                 let output_item_type =
                     ResponseStreamEventEmitter::output_item_type_for_format(Some(&response_format));
                 let resolved_label = session.resolve_tool_server_label(&tool_call.name);
+                // Keep this probe shape aligned with fields currently inspected by
+                // `McpToolSession::should_hide_output_item_json`.
                 let mut visibility_probe_item = json!({
                     "type": item_type,
                     "name": tool_call.name,

--- a/model_gateway/src/routers/openai/context.rs
+++ b/model_gateway/src/routers/openai/context.rs
@@ -1,6 +1,6 @@
 //! Request context types for OpenAI router pipeline.
 
-use std::sync::Arc;
+use std::{collections::HashSet, sync::Arc};
 
 use axum::http::HeaderMap;
 use openai_protocol::{chat::ChatCompletionRequest, responses::ResponsesRequest};
@@ -322,6 +322,7 @@ pub struct StreamingEventContext<'a> {
     pub original_request: &'a ResponsesRequest,
     pub previous_response_id: Option<&'a str>,
     pub session: Option<&'a McpToolSession<'a>>,
+    pub user_function_names: &'a HashSet<String>,
 }
 
 pub type StreamingRequest = OwnedStreamingContext;

--- a/model_gateway/src/routers/openai/mcp/mod.rs
+++ b/model_gateway/src/routers/openai/mcp/mod.rs
@@ -11,6 +11,7 @@ pub(crate) use tool_handler::{StreamAction, StreamingToolHandler};
 // Re-export functions used by responses/streaming.rs and responses/non_streaming.rs
 pub(crate) use tool_loop::{
     build_resume_payload, execute_streaming_tool_calls, execute_tool_loop,
-    inject_mcp_metadata_streaming, mcp_list_tools_bindings_to_emit, prepare_mcp_tools_as_functions,
+    inject_mcp_metadata_streaming, mcp_list_tools_bindings_to_emit,
+    mcp_list_tools_dedupe_key_from_item, prepare_mcp_tools_as_functions,
     send_mcp_list_tools_events, ToolLoopExecutionContext, ToolLoopState,
 };

--- a/model_gateway/src/routers/openai/mcp/mod.rs
+++ b/model_gateway/src/routers/openai/mcp/mod.rs
@@ -13,5 +13,6 @@ pub(crate) use tool_loop::{
     build_resume_payload, execute_streaming_tool_calls, execute_tool_loop,
     inject_mcp_metadata_streaming, mcp_list_tools_bindings_to_emit,
     mcp_list_tools_dedupe_key_from_item, prepare_mcp_tools_as_functions,
-    send_mcp_list_tools_events, ToolLoopExecutionContext, ToolLoopState,
+    remove_intercepted_mcp_function_calls_from_output, send_mcp_list_tools_events,
+    ToolLoopExecutionContext, ToolLoopState,
 };

--- a/model_gateway/src/routers/openai/mcp/tool_handler.rs
+++ b/model_gateway/src/routers/openai/mcp/tool_handler.rs
@@ -141,9 +141,20 @@ impl StreamingToolHandler {
     }
 
     pub fn mark_output_hidden(&mut self, upstream_index: usize) {
-        if self.visibility_state(upstream_index) == OutputVisibilityState::Unknown {
-            self.output_visibility
-                .insert(upstream_index, OutputVisibilityState::Hidden);
+        match self.visibility_state(upstream_index) {
+            OutputVisibilityState::Unknown => {
+                self.output_visibility
+                    .insert(upstream_index, OutputVisibilityState::Hidden);
+            }
+            OutputVisibilityState::Hidden => {}
+            OutputVisibilityState::Visible => {
+                // First-writer-wins by design: once an index has been mapped and emitted
+                // client-visible, we must not silently remap/remove it.
+                warn!(
+                    upstream_index,
+                    "Ignoring hide attempt for already-visible output index"
+                );
+            }
         }
     }
 
@@ -399,5 +410,42 @@ impl StreamingToolHandler {
 
     pub fn take_pending_calls(&mut self) -> Vec<FunctionCallInProgress> {
         std::mem::take(&mut self.pending_calls)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{OutputVisibilityState, StreamingToolHandler};
+
+    #[test]
+    fn hidden_before_resolution_stays_hidden_and_unmapped() {
+        let mut handler = StreamingToolHandler::with_starting_index(0);
+
+        assert_eq!(handler.visibility_state(3), OutputVisibilityState::Unknown);
+        handler.mark_output_hidden(3);
+
+        assert!(handler.is_output_hidden(3));
+        assert_eq!(handler.resolve_output_index_for_forwarding(3), None);
+        assert_eq!(handler.mapped_output_index(3), None);
+    }
+
+    #[test]
+    fn resolving_unknown_commits_visible_mapping() {
+        let mut handler = StreamingToolHandler::with_starting_index(0);
+
+        assert_eq!(handler.resolve_output_index_for_forwarding(7), Some(0));
+        assert_eq!(handler.visibility_state(7), OutputVisibilityState::Visible);
+        assert_eq!(handler.mapped_output_index(7), Some(0));
+    }
+
+    #[test]
+    fn hide_after_visible_is_ignored() {
+        let mut handler = StreamingToolHandler::with_starting_index(0);
+        assert_eq!(handler.resolve_output_index_for_forwarding(11), Some(0));
+
+        handler.mark_output_hidden(11);
+
+        assert_eq!(handler.visibility_state(11), OutputVisibilityState::Visible);
+        assert_eq!(handler.resolve_output_index_for_forwarding(11), Some(0));
     }
 }

--- a/model_gateway/src/routers/openai/mcp/tool_handler.rs
+++ b/model_gateway/src/routers/openai/mcp/tool_handler.rs
@@ -59,6 +59,14 @@ impl OutputIndexMapper {
     }
 }
 
+/// Per-upstream-index visibility and mapping state for client-facing streaming output.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum OutputVisibilityState {
+    Unknown,
+    Hidden,
+    Visible,
+}
+
 /// Represents a function call being accumulated across delta events
 #[derive(Debug, Clone)]
 pub(crate) struct FunctionCallInProgress {
@@ -101,6 +109,8 @@ pub(crate) struct StreamingToolHandler {
     pub pending_calls: Vec<FunctionCallInProgress>,
     /// Manage output_index remapping so they increment per item
     output_index_mapper: OutputIndexMapper,
+    /// Visibility/mapping state keyed by upstream output_index.
+    output_visibility: HashMap<usize, OutputVisibilityState>,
     /// Original response id captured from the first response.created event
     pub original_response_id: Option<String>,
 }
@@ -111,16 +121,54 @@ impl StreamingToolHandler {
             accumulator: StreamingResponseAccumulator::new(),
             pending_calls: Vec::new(),
             output_index_mapper: OutputIndexMapper::with_start(start),
+            output_visibility: HashMap::new(),
             original_response_id: None,
         }
     }
 
-    pub fn ensure_output_index(&mut self, upstream_index: usize) -> usize {
-        self.output_index_mapper.ensure_mapping(upstream_index)
+    pub fn mapped_output_index(&self, upstream_index: usize) -> Option<usize> {
+        match self.visibility_state(upstream_index) {
+            OutputVisibilityState::Visible => self.output_index_mapper.lookup(upstream_index),
+            OutputVisibilityState::Unknown | OutputVisibilityState::Hidden => None,
+        }
     }
 
-    pub fn mapped_output_index(&self, upstream_index: usize) -> Option<usize> {
-        self.output_index_mapper.lookup(upstream_index)
+    pub fn visibility_state(&self, upstream_index: usize) -> OutputVisibilityState {
+        self.output_visibility
+            .get(&upstream_index)
+            .copied()
+            .unwrap_or(OutputVisibilityState::Unknown)
+    }
+
+    pub fn mark_output_hidden(&mut self, upstream_index: usize) {
+        if self.visibility_state(upstream_index) == OutputVisibilityState::Unknown {
+            self.output_visibility
+                .insert(upstream_index, OutputVisibilityState::Hidden);
+        }
+    }
+
+    pub fn is_output_hidden(&self, upstream_index: usize) -> bool {
+        self.visibility_state(upstream_index) == OutputVisibilityState::Hidden
+    }
+
+    pub fn resolve_output_index_for_forwarding(&mut self, upstream_index: usize) -> Option<usize> {
+        match self.visibility_state(upstream_index) {
+            OutputVisibilityState::Hidden => None,
+            OutputVisibilityState::Visible => {
+                Some(self.output_index_mapper.ensure_mapping(upstream_index))
+            }
+            OutputVisibilityState::Unknown => {
+                let mapped_index = self.output_index_mapper.ensure_mapping(upstream_index);
+                self.output_visibility
+                    .insert(upstream_index, OutputVisibilityState::Visible);
+                if let Some(call) = self.find_call_mut(upstream_index) {
+                    if call.assigned_output_index.is_none() {
+                        call.assigned_output_index = Some(mapped_index);
+                    }
+                }
+                Some(mapped_index)
+            }
+        }
     }
 
     pub fn allocate_synthetic_output_index(&mut self) -> usize {
@@ -174,9 +222,6 @@ impl StreamingToolHandler {
             FunctionCallEvent::ARGUMENTS_DONE => self.handle_arguments_done(&parsed),
             OutputItemEvent::DELTA => self.process_output_delta(&parsed),
             OutputItemEvent::DONE => {
-                if let Some(output_index) = extract_output_index(&parsed) {
-                    self.ensure_output_index(output_index);
-                }
                 if self.has_complete_calls() {
                     StreamAction::ExecuteTools
                 } else {
@@ -189,9 +234,6 @@ impl StreamingToolHandler {
 
     fn handle_output_item_added(&mut self, parsed: &Value) -> StreamAction {
         let cached_output_index = extract_output_index(parsed);
-        if let Some(output_index) = cached_output_index {
-            self.ensure_output_index(output_index);
-        }
 
         let Some(item) = parsed.get("item") else {
             return StreamAction::Forward;
@@ -212,18 +254,19 @@ impl StreamingToolHandler {
             return StreamAction::Forward;
         };
 
-        let assigned_index = self.ensure_output_index(output_index);
         let call_id = item.get("call_id").and_then(|v| v.as_str()).unwrap_or("");
         let name = item.get("name").and_then(|v| v.as_str()).unwrap_or("");
 
-        let call = self.get_or_create_call(output_index, item);
-        call.call_id = call_id.to_string();
-        call.name = name.to_string();
-        call.item_id = item
-            .get("id")
-            .and_then(|v| v.as_str())
-            .map(|id| id.to_string());
-        call.assigned_output_index = Some(assigned_index);
+        {
+            let call = self.get_or_create_call(output_index, item);
+            call.call_id = call_id.to_string();
+            call.name = name.to_string();
+            call.item_id = item
+                .get("id")
+                .and_then(|v| v.as_str())
+                .map(|id| id.to_string());
+        }
+        self.maybe_assign_existing_mapping(output_index);
 
         StreamAction::Forward
     }
@@ -233,30 +276,21 @@ impl StreamingToolHandler {
             return StreamAction::Forward;
         };
 
-        let assigned_index = self.ensure_output_index(output_index);
-
         if let Some(delta) = parsed.get("delta").and_then(|v| v.as_str()) {
             if let Some(call) = self.find_call_mut(output_index) {
                 call.arguments_buffer.push_str(delta);
                 if let Some(obfuscation) = parsed.get("obfuscation").and_then(|v| v.as_str()) {
                     call.last_obfuscation = Some(obfuscation.to_string());
                 }
-                if call.assigned_output_index.is_none() {
-                    call.assigned_output_index = Some(assigned_index);
-                }
             }
+            self.maybe_assign_existing_mapping(output_index);
         }
         StreamAction::Forward
     }
 
     fn handle_arguments_done(&mut self, parsed: &Value) -> StreamAction {
         if let Some(output_index) = extract_output_index(parsed) {
-            let assigned_index = self.ensure_output_index(output_index);
-            if let Some(call) = self.find_call_mut(output_index) {
-                if call.assigned_output_index.is_none() {
-                    call.assigned_output_index = Some(assigned_index);
-                }
-            }
+            self.maybe_assign_existing_mapping(output_index);
         }
 
         if self.has_complete_calls() {
@@ -275,7 +309,6 @@ impl StreamingToolHandler {
     /// Process output delta events to detect and accumulate function calls
     fn process_output_delta(&mut self, event: &Value) -> StreamAction {
         let output_index = extract_output_index(event).unwrap_or(0);
-        let assigned_index = self.ensure_output_index(output_index);
 
         let delta = match event.get("delta") {
             Some(d) => d,
@@ -286,25 +319,28 @@ impl StreamingToolHandler {
 
         if item_type.is_some_and(is_function_call_type) {
             // Get or create function call for this output index
-            let call = self.get_or_create_call(output_index, delta);
-            call.assigned_output_index = Some(assigned_index);
+            {
+                let call = self.get_or_create_call(output_index, delta);
+                if let Some(call_id) = delta.get("call_id").and_then(|v| v.as_str()) {
+                    call.call_id = call_id.to_string();
+                }
+                if let Some(item_id) = delta.get("id").and_then(|v| v.as_str()) {
+                    call.item_id = Some(item_id.to_string());
+                }
+                if let Some(name) = delta.get("name").and_then(|v| v.as_str()) {
+                    call.name.push_str(name);
+                }
+                if let Some(args) = delta.get("arguments").and_then(|v| v.as_str()) {
+                    call.arguments_buffer.push_str(args);
+                }
 
-            if let Some(call_id) = delta.get("call_id").and_then(|v| v.as_str()) {
-                call.call_id = call_id.to_string();
+                if let Some(obfuscation) = delta.get("obfuscation").and_then(|v| v.as_str()) {
+                    call.last_obfuscation = Some(obfuscation.to_string());
+                }
             }
-            if let Some(item_id) = delta.get("id").and_then(|v| v.as_str()) {
-                call.item_id = Some(item_id.to_string());
-            }
-            if let Some(name) = delta.get("name").and_then(|v| v.as_str()) {
-                call.name.push_str(name);
-            }
-            if let Some(args) = delta.get("arguments").and_then(|v| v.as_str()) {
-                call.arguments_buffer.push_str(args);
-            }
-
-            if let Some(obfuscation) = delta.get("obfuscation").and_then(|v| v.as_str()) {
-                call.last_obfuscation = Some(obfuscation.to_string());
-            }
+            // Keep deferred allocation behavior: only assign when a mapping already
+            // exists for this upstream index (typically after a visible event).
+            self.maybe_assign_existing_mapping(output_index);
 
             return StreamAction::Buffer;
         }
@@ -344,6 +380,17 @@ impl StreamingToolHandler {
         self.pending_calls
             .last_mut()
             .expect("Just pushed to pending_calls, must have at least one element")
+    }
+
+    fn maybe_assign_existing_mapping(&mut self, output_index: usize) {
+        let Some(mapped_index) = self.mapped_output_index(output_index) else {
+            return;
+        };
+        if let Some(call) = self.find_call_mut(output_index) {
+            if call.assigned_output_index.is_none() {
+                call.assigned_output_index = Some(mapped_index);
+            }
+        }
     }
 
     fn has_complete_calls(&self) -> bool {

--- a/model_gateway/src/routers/openai/mcp/tool_loop.rs
+++ b/model_gateway/src/routers/openai/mcp/tool_loop.rs
@@ -673,7 +673,7 @@ fn visible_mcp_list_tools_items(
         .collect()
 }
 
-fn remove_intercepted_mcp_function_calls_from_output(
+pub(crate) fn remove_intercepted_mcp_function_calls_from_output(
     response: &mut Value,
     session: &McpToolSession<'_>,
     user_function_names: &HashSet<String>,

--- a/model_gateway/src/routers/openai/mcp/tool_loop.rs
+++ b/model_gateway/src/routers/openai/mcp/tool_loop.rs
@@ -17,7 +17,7 @@ use openai_protocol::{
         is_function_call_type, CodeInterpreterCallEvent, FileSearchCallEvent, ItemType, McpEvent,
         OutputItemEvent, WebSearchCallEvent,
     },
-    responses::{generate_id, ResponseInput, ResponseTool, ResponsesRequest},
+    responses::{generate_id, ResponseInput, ResponsesRequest},
 };
 use serde_json::{json, to_value, Value};
 use smg_mcp::{
@@ -31,7 +31,10 @@ use super::tool_handler::FunctionCallInProgress;
 use crate::{
     observability::metrics::{metrics_labels, Metrics},
     routers::{
-        common::{header_utils::ApiProvider, mcp_utils::DEFAULT_MAX_ITERATIONS},
+        common::{
+            header_utils::ApiProvider,
+            mcp_utils::{collect_user_function_names, DEFAULT_MAX_ITERATIONS},
+        },
         error,
     },
 };
@@ -46,7 +49,7 @@ pub(crate) struct ToolLoopState {
     pub conversation_history: Vec<Value>,
     /// Original user input (preserved for building resume payloads)
     pub original_input: ResponseInput,
-    /// MCP bindings already represented by historical `mcp_list_tools` items.
+    /// MCP list-tools dedupe keys already represented by historical `mcp_list_tools` items.
     pub existing_mcp_list_tools_labels: HashSet<String>,
     /// Transformed output items (mcp_call, web_search_call, etc.) - stored to avoid reconstruction
     pub mcp_call_items: Vec<Value>,
@@ -153,6 +156,7 @@ fn build_message_from_openai_response(openai_response: Value) -> Option<Value> {
 pub(crate) async fn execute_streaming_tool_calls(
     pending_calls: Vec<FunctionCallInProgress>,
     session: &McpToolSession<'_>,
+    user_function_names: &HashSet<String>,
     tx: &mpsc::UnboundedSender<Result<Bytes, io::Error>>,
     state: &mut ToolLoopState,
     sequence_number: &mut u64,
@@ -163,6 +167,15 @@ pub(crate) async fn execute_streaming_tool_calls(
             warn!(
                 "Skipping incomplete tool call: name is empty, args_len={}",
                 call.arguments_buffer.len()
+            );
+            continue;
+        }
+
+        if !session.should_intercept_function_call(&call.name, user_function_names) {
+            debug!(
+                tool_name = %call.name,
+                call_id = %call.call_id,
+                "Skipping non-MCP function call in streaming tool execution"
             );
             continue;
         }
@@ -180,6 +193,17 @@ pub(crate) async fn execute_streaming_tool_calls(
 
         let response_format = session.tool_response_format(&call.name);
         let server_label = session.resolve_tool_server_label(&call.name);
+        let mut visibility_probe_item = json!({
+            "type": streaming_output_item_type(&response_format),
+            "name": &call.name,
+            "status": "in_progress",
+            "arguments": args_str,
+        });
+        if matches!(response_format, ResponseFormat::Passthrough) {
+            visibility_probe_item["server_label"] = json!(&server_label);
+        }
+        let should_emit_live_item =
+            !session.should_hide_output_item_json(&visibility_probe_item, user_function_names);
 
         let arguments: Value = match serde_json::from_str(args_str) {
             Ok(v) => v,
@@ -201,13 +225,15 @@ pub(crate) async fn execute_streaming_tool_calls(
                         Value::String(stable_streaming_tool_item_id(&call, &response_format)),
                     );
                 }
-                if !send_tool_call_completion_events(
-                    tx,
-                    &call,
-                    &mcp_call_item,
-                    &response_format,
-                    sequence_number,
-                ) {
+                if should_emit_live_item
+                    && !send_tool_call_completion_events(
+                        tx,
+                        &call,
+                        &mcp_call_item,
+                        &response_format,
+                        sequence_number,
+                    )
+                {
                     return false;
                 }
                 state.record_call(
@@ -222,7 +248,9 @@ pub(crate) async fn execute_streaming_tool_calls(
             }
         };
 
-        if !send_tool_call_intermediate_event(tx, &call, &response_format, sequence_number) {
+        if should_emit_live_item
+            && !send_tool_call_intermediate_event(tx, &call, &response_format, sequence_number)
+        {
             return false;
         }
 
@@ -258,13 +286,15 @@ pub(crate) async fn execute_streaming_tool_calls(
             );
         }
 
-        if !send_tool_call_completion_events(
-            tx,
-            &call,
-            &mcp_call_item,
-            &response_format,
-            sequence_number,
-        ) {
+        if should_emit_live_item
+            && !send_tool_call_completion_events(
+                tx,
+                &call,
+                &mcp_call_item,
+                &response_format,
+                sequence_number,
+            )
+        {
             return false;
         }
 
@@ -374,6 +404,12 @@ pub(crate) fn send_mcp_list_tools_events(
     sequence_number: &mut u64,
     server_key: &str,
 ) -> bool {
+    // Defense in depth: callers should pre-filter with
+    // `should_emit_streaming_mcp_list_tools` before allocating output indexes.
+    if !session.should_emit_streaming_mcp_list_tools(server_label) {
+        return true;
+    }
+
     let tools_item_full = session.build_mcp_list_tools_json(server_label, server_key);
     let item_id = tools_item_full
         .get("id")
@@ -587,13 +623,80 @@ fn approval_request_item_id_source(item_id: &str) -> String {
 
 pub(crate) fn mcp_list_tools_bindings_to_emit(
     existing_labels: &HashSet<String>,
-    bindings: &[McpServerBinding],
+    session: &McpToolSession<'_>,
 ) -> Vec<(String, String)> {
-    bindings
+    session
+        .mcp_servers()
         .iter()
-        .filter(|binding| !existing_labels.contains(&binding.label))
+        .filter(|binding| {
+            let dedupe_key = mcp_list_tools_dedupe_key_for_binding(session, binding);
+            !existing_labels.contains(&dedupe_key)
+        })
         .map(|binding| (binding.label.clone(), binding.server_key.clone()))
         .collect()
+}
+
+pub(crate) fn mcp_list_tools_dedupe_key(server_label: &str, tools: &Value) -> String {
+    let serialized_tools = serde_json::to_string(tools).unwrap_or_else(|_| "[]".to_string());
+    format!("{server_label}\u{1f}{serialized_tools}")
+}
+
+pub(crate) fn mcp_list_tools_dedupe_key_from_item(item: &Value) -> Option<String> {
+    if item.get("type").and_then(|value| value.as_str()) != Some(ItemType::MCP_LIST_TOOLS) {
+        return None;
+    }
+
+    let server_label = item.get("server_label").and_then(|value| value.as_str())?;
+    let tools = item.get("tools").cloned().unwrap_or_else(|| json!([]));
+    Some(mcp_list_tools_dedupe_key(server_label, &tools))
+}
+
+fn mcp_list_tools_dedupe_key_for_binding(
+    session: &McpToolSession<'_>,
+    binding: &McpServerBinding,
+) -> String {
+    let item = session.build_mcp_list_tools_json(&binding.label, &binding.server_key);
+    mcp_list_tools_dedupe_key_from_item(&item)
+        .unwrap_or_else(|| mcp_list_tools_dedupe_key(&binding.label, &json!([])))
+}
+
+fn visible_mcp_list_tools_items(
+    session: &McpToolSession<'_>,
+    list_tools_bindings: &[(String, String)],
+) -> Vec<Value> {
+    list_tools_bindings
+        .iter()
+        .filter(|(server_label, _)| session.should_emit_streaming_mcp_list_tools(server_label))
+        .map(|(server_label, server_key)| {
+            session.build_mcp_list_tools_json(server_label, server_key)
+        })
+        .collect()
+}
+
+fn remove_intercepted_mcp_function_calls_from_output(
+    response: &mut Value,
+    session: &McpToolSession<'_>,
+    user_function_names: &HashSet<String>,
+) {
+    let Some(output_array) = response
+        .get_mut("output")
+        .and_then(|value| value.as_array_mut())
+    else {
+        return;
+    };
+
+    output_array.retain(|item| {
+        let item_type = item.get("type").and_then(|value| value.as_str());
+        if !item_type.is_some_and(is_function_call_type) {
+            return true;
+        }
+
+        let Some(name) = item.get("name").and_then(|value| value.as_str()) else {
+            return true;
+        };
+
+        !session.should_intercept_function_call(name, user_function_names)
+    });
 }
 
 /// Inject MCP metadata into a streaming response
@@ -601,44 +704,33 @@ pub(crate) fn inject_mcp_metadata_streaming(
     response: &mut Value,
     state: &ToolLoopState,
     session: &McpToolSession<'_>,
+    user_function_names: &HashSet<String>,
 ) {
-    let list_tools_bindings = mcp_list_tools_bindings_to_emit(
-        &state.existing_mcp_list_tools_labels,
-        session.mcp_servers(),
-    );
+    let list_tools_bindings =
+        mcp_list_tools_bindings_to_emit(&state.existing_mcp_list_tools_labels, session);
 
     if let Some(output_array) = response.get_mut("output").and_then(|v| v.as_array_mut()) {
         output_array.retain(|item| {
             item.get("type").and_then(|t| t.as_str()) != Some(ItemType::MCP_LIST_TOOLS)
         });
 
-        let mut prefix = Vec::with_capacity(list_tools_bindings.len() + state.mcp_call_items.len());
-        for (server_label, server_key) in &list_tools_bindings {
-            if !session.is_internal_server_label(server_label) {
-                prefix.push(session.build_mcp_list_tools_json(server_label, server_key));
-            }
-        }
+        let mut prefix = visible_mcp_list_tools_items(session, &list_tools_bindings);
         prefix.extend(
             state
                 .mcp_call_items
                 .iter()
-                .filter(|item| !is_internal_mcp_response_item(item, session))
+                .filter(|item| !session.should_hide_output_item_json(item, user_function_names))
                 .cloned(),
         );
         output_array.splice(0..0, prefix);
     } else if let Some(obj) = response.as_object_mut() {
-        let mut output_items = Vec::new();
-        for (server_label, server_key) in &list_tools_bindings {
-            if !session.is_internal_server_label(server_label) {
-                output_items.push(session.build_mcp_list_tools_json(server_label, server_key));
-            }
-        }
+        let mut output_items = visible_mcp_list_tools_items(session, &list_tools_bindings);
         // Use stored transformed items (no reconstruction needed)
         output_items.extend(
             state
                 .mcp_call_items
                 .iter()
-                .filter(|item| !is_internal_mcp_response_item(item, session))
+                .filter(|item| !session.should_hide_output_item_json(item, user_function_names))
                 .cloned(),
         );
         obj.insert("output".to_string(), Value::Array(output_items));
@@ -657,24 +749,33 @@ fn build_approval_response(
         .ok_or_else(|| "response not an object".to_string())?;
     obj.insert("status".to_string(), Value::String("completed".to_string()));
 
-    let list_tools_bindings = mcp_list_tools_bindings_to_emit(
-        &state.existing_mcp_list_tools_labels,
-        session.mcp_servers(),
-    );
+    let list_tools_bindings =
+        mcp_list_tools_bindings_to_emit(&state.existing_mcp_list_tools_labels, session);
+    let user_function_names = collect_user_function_names(original_body);
 
     match obj.get_mut("output").and_then(|v| v.as_array_mut()) {
         Some(output_array) => {
-            let retained_items = retained_output_items(output_array, original_body);
-            let prefix =
-                approval_prefix_items(&state, session, &list_tools_bindings, approval_item);
+            let retained_items = retained_output_items(output_array, session, &user_function_names);
+            let prefix = approval_prefix_items(
+                &state,
+                session,
+                &list_tools_bindings,
+                &user_function_names,
+                approval_item,
+            );
 
             output_array.clear();
             output_array.extend(prefix);
             output_array.extend(retained_items);
         }
         None => {
-            let output_items =
-                approval_prefix_items(&state, session, &list_tools_bindings, approval_item);
+            let output_items = approval_prefix_items(
+                &state,
+                session,
+                &list_tools_bindings,
+                &user_function_names,
+                approval_item,
+            );
             obj.insert("output".to_string(), Value::Array(output_items));
         }
     }
@@ -682,35 +783,14 @@ fn build_approval_response(
     Ok(response)
 }
 
-fn retained_output_items(output_array: &[Value], original_body: &ResponsesRequest) -> Vec<Value> {
-    let user_function_names: HashSet<&str> = original_body
-        .tools
-        .as_deref()
-        .map(|tools| {
-            tools
-                .iter()
-                .filter_map(|tool| match tool {
-                    ResponseTool::Function(function_tool) => {
-                        Some(function_tool.function.name.as_str())
-                    }
-                    _ => None,
-                })
-                .collect()
-        })
-        .unwrap_or_default();
-
+fn retained_output_items(
+    output_array: &[Value],
+    session: &McpToolSession<'_>,
+    user_function_names: &HashSet<String>,
+) -> Vec<Value> {
     output_array
         .iter()
-        .filter(|item| {
-            let item_type = item.get("type").and_then(|value| value.as_str());
-            if !item_type.is_some_and(is_function_call_type) {
-                return true;
-            }
-
-            item.get("name")
-                .and_then(|value| value.as_str())
-                .is_some_and(|name| user_function_names.contains(name))
-        })
+        .filter(|item| !session.should_hide_output_item_json(item, user_function_names))
         .cloned()
         .collect()
 }
@@ -719,22 +799,18 @@ fn approval_prefix_items(
     state: &ToolLoopState,
     session: &McpToolSession<'_>,
     list_tools_bindings: &[(String, String)],
+    user_function_names: &HashSet<String>,
     approval_item: Value,
 ) -> Vec<Value> {
-    let mut prefix = Vec::with_capacity(list_tools_bindings.len() + state.mcp_call_items.len() + 1);
-    for (list_server_label, server_key) in list_tools_bindings {
-        if !session.is_internal_server_label(list_server_label) {
-            prefix.push(session.build_mcp_list_tools_json(list_server_label, server_key));
-        }
-    }
+    let mut prefix = visible_mcp_list_tools_items(session, list_tools_bindings);
     prefix.extend(
         state
             .mcp_call_items
             .iter()
-            .filter(|item| !is_internal_mcp_response_item(item, session))
+            .filter(|item| !session.should_hide_output_item_json(item, user_function_names))
             .cloned(),
     );
-    if !is_internal_mcp_response_item(&approval_item, session) {
+    if !session.should_hide_output_item_json(&approval_item, user_function_names) {
         prefix.push(approval_item);
     }
     prefix
@@ -765,6 +841,7 @@ pub(crate) async fn execute_tool_loop(
         original_body.input.clone(),
         existing_mcp_list_tools_labels.to_vec(),
     );
+    let user_function_names = collect_user_function_names(original_body);
     let max_tool_calls = original_body.max_tool_calls.map(|n| n as usize);
     let base_payload = initial_payload.clone();
     let tools_json = base_payload.get("tools").cloned().unwrap_or(json!([]));
@@ -805,8 +882,27 @@ pub(crate) async fn execute_tool_loop(
                 state.iteration, state.total_calls
             );
             if state.total_calls > 0 {
-                inject_mcp_metadata_streaming(&mut response_json, &state, session);
+                inject_mcp_metadata_streaming(
+                    &mut response_json,
+                    &state,
+                    session,
+                    &user_function_names,
+                );
             }
+            return Ok(response_json);
+        }
+
+        let (mcp_function_calls, user_function_calls): (Vec<_>, Vec<_>) =
+            function_calls.into_iter().partition(|call| {
+                session.should_intercept_function_call(&call.name, &user_function_names)
+            });
+
+        let has_user_function_calls = !user_function_calls.is_empty();
+        if mcp_function_calls.is_empty() {
+            info!(
+                "Returning response with {} user function call(s) without MCP interception",
+                user_function_calls.len()
+            );
             return Ok(response_json);
         }
 
@@ -814,9 +910,10 @@ pub(crate) async fn execute_tool_loop(
         Metrics::record_mcp_tool_iteration(&original_body.model);
 
         info!(
-            "Tool loop iteration {}: {} function call(s) detected",
+            "Tool loop iteration {}: {} MCP function call(s) detected (user calls in batch: {})",
             state.iteration,
-            function_calls.len()
+            mcp_function_calls.len(),
+            has_user_function_calls
         );
 
         let effective_limit = match max_tool_calls {
@@ -824,7 +921,7 @@ pub(crate) async fn execute_tool_loop(
             None => DEFAULT_MAX_ITERATIONS,
         };
 
-        for call in function_calls {
+        for call in mcp_function_calls {
             state.total_calls += 1;
 
             if state.total_calls > effective_limit {
@@ -948,6 +1045,27 @@ pub(crate) async fn execute_tool_loop(
             );
         }
 
+        if has_user_function_calls {
+            remove_intercepted_mcp_function_calls_from_output(
+                &mut response_json,
+                session,
+                &user_function_names,
+            );
+            if state.total_calls > 0 {
+                inject_mcp_metadata_streaming(
+                    &mut response_json,
+                    &state,
+                    session,
+                    &user_function_names,
+                );
+            }
+            info!(
+                "Returning mixed response after executing {} MCP call(s); user function call(s) remain for client execution",
+                state.total_calls
+            );
+            return Ok(response_json);
+        }
+
         current_payload = build_resume_payload(
             &base_payload,
             &state.conversation_history,
@@ -978,28 +1096,12 @@ fn build_incomplete_response(
         json!({ "reason": reason }),
     );
 
-    let list_tools_bindings = mcp_list_tools_bindings_to_emit(
-        &state.existing_mcp_list_tools_labels,
-        session.mcp_servers(),
-    );
+    let list_tools_bindings =
+        mcp_list_tools_bindings_to_emit(&state.existing_mcp_list_tools_labels, session);
 
-    let user_function_names: HashSet<&str> = original_body
-        .tools
-        .as_deref()
-        .map(|tools| {
-            tools
-                .iter()
-                .filter_map(|tool| match tool {
-                    ResponseTool::Function(function_tool) => {
-                        Some(function_tool.function.name.as_str())
-                    }
-                    _ => None,
-                })
-                .collect()
-        })
-        .unwrap_or_default();
+    let user_function_names = collect_user_function_names(original_body);
 
-    // Convert MCP function_call items in output to mcp_call format.
+    // Convert only MCP-intercepted function_call items in output to mcp_call format.
     if let Some(output_array) = obj.get_mut("output").and_then(|v| v.as_array_mut()) {
         // Find any function_call items and convert them to mcp_call (incomplete)
         let mut incomplete_items = Vec::new();
@@ -1007,8 +1109,9 @@ fn build_incomplete_response(
             let item_type = item.get("type").and_then(|t| t.as_str());
             if item_type.is_some_and(is_function_call_type) {
                 let tool_name = item.get("name").and_then(|v| v.as_str()).unwrap_or("");
-                if user_function_names.contains(tool_name) {
-                    // User function calls must remain as function_call output items.
+                if !session.should_intercept_function_call(tool_name, &user_function_names) {
+                    // Non-intercepted calls (user tools, unknown names, collisions) must remain
+                    // function_call output items.
                     continue;
                 }
                 let args = item
@@ -1032,25 +1135,20 @@ fn build_incomplete_response(
 
         // Add mcp_list_tools and executed mcp_call items at the beginning
         if state.total_calls > 0 || !incomplete_items.is_empty() {
-            let mut prefix = Vec::with_capacity(
-                list_tools_bindings.len() + state.mcp_call_items.len() + incomplete_items.len(),
-            );
-            for (server_label, server_key) in &list_tools_bindings {
-                if !session.is_internal_server_label(server_label) {
-                    prefix.push(session.build_mcp_list_tools_json(server_label, server_key));
-                }
-            }
+            let mut prefix = visible_mcp_list_tools_items(session, &list_tools_bindings);
             prefix.extend(
                 state
                     .mcp_call_items
                     .iter()
-                    .filter(|item| !is_internal_mcp_response_item(item, session))
+                    .filter(|item| {
+                        !session.should_hide_output_item_json(item, &user_function_names)
+                    })
                     .cloned(),
             );
             prefix.extend(
-                incomplete_items
-                    .into_iter()
-                    .filter(|item| !is_internal_mcp_response_item(item, session)),
+                incomplete_items.into_iter().filter(|item| {
+                    !session.should_hide_output_item_json(item, &user_function_names)
+                }),
             );
             output_array.splice(0..0, prefix);
         }
@@ -1075,15 +1173,15 @@ fn build_incomplete_response(
     Ok(response)
 }
 
-fn is_internal_mcp_response_item(item: &Value, session: &McpToolSession<'_>) -> bool {
-    let matches_internal_server = item
-        .get("server_label")
-        .and_then(|value| value.as_str())
-        .is_some_and(|server_label| session.is_internal_non_builtin_server_label(server_label));
-
-    match item.get("name").and_then(|value| value.as_str()) {
-        Some(name) if session.has_exposed_tool(name) => session.is_internal_non_builtin_tool(name),
-        _ => matches_internal_server,
+// Keep this mapping in sync with
+// `ResponseStreamEventEmitter::output_item_type_for_format` in
+// `grpc/common/responses/streaming.rs`.
+fn streaming_output_item_type(response_format: &ResponseFormat) -> &'static str {
+    match response_format {
+        ResponseFormat::Passthrough => ItemType::MCP_CALL,
+        ResponseFormat::WebSearchCall => ItemType::WEB_SEARCH_CALL,
+        ResponseFormat::CodeInterpreterCall => ItemType::CODE_INTERPRETER_CALL,
+        ResponseFormat::FileSearchCall => ItemType::FILE_SEARCH_CALL,
     }
 }
 
@@ -1209,8 +1307,7 @@ mod tests {
 
     use super::{
         build_transformed_mcp_call_item, extract_openai_response_output_items,
-        is_internal_mcp_response_item, mcp_list_tools_bindings_to_emit, ResponseInput,
-        ToolLoopState,
+        mcp_list_tools_bindings_to_emit, mcp_list_tools_dedupe_key, ResponseInput, ToolLoopState,
     };
 
     fn test_tool(name: &str) -> Tool {
@@ -1297,7 +1394,7 @@ mod tests {
             "server_label": "internal-label"
         });
 
-        assert!(!is_internal_mcp_response_item(&item, &session));
+        assert!(!session.should_hide_output_item_json(&item, &HashSet::new()));
     }
 
     #[tokio::test]
@@ -1356,16 +1453,12 @@ mod tests {
             "server_label": "internal-label"
         });
 
-        assert!(!is_internal_mcp_response_item(&builtin_item, &session));
-        assert!(is_internal_mcp_response_item(
-            &internal_non_builtin_item,
-            &session
-        ));
+        assert!(!session.should_hide_output_item_json(&builtin_item, &HashSet::new()));
+        assert!(session.should_hide_output_item_json(&internal_non_builtin_item, &HashSet::new()));
     }
 
-    #[test]
-    fn emits_only_new_binding_when_resume_adds_second_tool_block() {
-        let existing_labels = HashSet::from(["deepwiki_ask".to_string()]);
+    #[tokio::test]
+    async fn emits_only_new_binding_when_resume_adds_second_tool_block() {
         let bindings = vec![
             McpServerBinding {
                 label: "deepwiki_ask".to_string(),
@@ -1378,8 +1471,46 @@ mod tests {
                 allowed_tools: Some(vec!["read_wiki_structure".to_string()]),
             },
         ];
+        let orchestrator = McpOrchestrator::new(McpConfig {
+            servers: vec![
+                McpServerConfig {
+                    name: "server-ask".to_string(),
+                    transport: McpTransport::Sse {
+                        url: "http://localhost:3000/sse".to_string(),
+                        token: None,
+                        headers: Default::default(),
+                    },
+                    proxy: None,
+                    required: false,
+                    tools: None,
+                    builtin_type: None,
+                    builtin_tool_name: None,
+                    internal: false,
+                },
+                McpServerConfig {
+                    name: "server-read".to_string(),
+                    transport: McpTransport::Sse {
+                        url: "http://localhost:3001/sse".to_string(),
+                        token: None,
+                        headers: Default::default(),
+                    },
+                    proxy: None,
+                    required: false,
+                    tools: None,
+                    builtin_type: None,
+                    builtin_tool_name: None,
+                    internal: false,
+                },
+            ],
+            ..Default::default()
+        })
+        .await
+        .expect("orchestrator");
+        let session = McpToolSession::new(&orchestrator, bindings, "test-request");
+        let existing_labels =
+            HashSet::from([mcp_list_tools_dedupe_key("deepwiki_ask", &json!([]))]);
 
-        let bindings_to_emit = mcp_list_tools_bindings_to_emit(&existing_labels, &bindings);
+        let bindings_to_emit = mcp_list_tools_bindings_to_emit(&existing_labels, &session);
 
         assert_eq!(
             bindings_to_emit,
@@ -1387,16 +1518,39 @@ mod tests {
         );
     }
 
-    #[test]
-    fn emits_all_bindings_when_no_prior_mcp_list_tools_exist() {
+    #[tokio::test]
+    async fn emits_all_bindings_when_no_prior_mcp_list_tools_exist() {
         let existing_labels = HashSet::new();
-        let bindings = vec![McpServerBinding {
-            label: "deepwiki_ask".to_string(),
-            server_key: "server-ask".to_string(),
-            allowed_tools: Some(vec!["ask_question".to_string()]),
-        }];
+        let orchestrator = McpOrchestrator::new(McpConfig {
+            servers: vec![McpServerConfig {
+                name: "server-ask".to_string(),
+                transport: McpTransport::Sse {
+                    url: "http://localhost:3000/sse".to_string(),
+                    token: None,
+                    headers: Default::default(),
+                },
+                proxy: None,
+                required: false,
+                tools: None,
+                builtin_type: None,
+                builtin_tool_name: None,
+                internal: false,
+            }],
+            ..Default::default()
+        })
+        .await
+        .expect("orchestrator");
+        let session = McpToolSession::new(
+            &orchestrator,
+            vec![McpServerBinding {
+                label: "deepwiki_ask".to_string(),
+                server_key: "server-ask".to_string(),
+                allowed_tools: Some(vec!["ask_question".to_string()]),
+            }],
+            "test-request",
+        );
 
-        let bindings_to_emit = mcp_list_tools_bindings_to_emit(&existing_labels, &bindings);
+        let bindings_to_emit = mcp_list_tools_bindings_to_emit(&existing_labels, &session);
 
         assert_eq!(
             bindings_to_emit,

--- a/model_gateway/src/routers/openai/responses/history.rs
+++ b/model_gateway/src/routers/openai/responses/history.rs
@@ -22,6 +22,7 @@ use crate::{
             header_utils::ConversationMemoryConfig, persistence_utils::split_stored_message_content,
         },
         error,
+        openai::mcp::mcp_list_tools_dedupe_key_from_item,
     },
 };
 
@@ -59,7 +60,7 @@ pub(crate) async fn load_input_history(
         {
             Ok(chain) if !chain.responses.is_empty() => {
                 existing_mcp_list_tools_labels.extend(chain.responses.iter().flat_map(|stored| {
-                    extract_mcp_list_tools_labels(
+                    extract_mcp_list_tools_dedupe_keys(
                         stored.raw_response.get("output").unwrap_or(&Value::Null),
                     )
                 }));
@@ -254,17 +255,12 @@ fn deserialize_items_from_array(array: &Value) -> Vec<ResponseInputOutputItem> {
         .unwrap_or_default()
 }
 
-fn extract_mcp_list_tools_labels(array: &Value) -> Vec<String> {
+fn extract_mcp_list_tools_dedupe_keys(array: &Value) -> Vec<String> {
     array
         .as_array()
         .map(|arr| {
             arr.iter()
-                .filter_map(|item| {
-                    (item.get("type").and_then(|t| t.as_str()) == Some(ItemType::MCP_LIST_TOOLS))
-                        .then(|| item.get("server_label").and_then(|v| v.as_str()))
-                        .flatten()
-                        .map(ToOwned::to_owned)
-                })
+                .filter_map(mcp_list_tools_dedupe_key_from_item)
                 .collect()
         })
         .unwrap_or_default()

--- a/model_gateway/src/routers/openai/responses/streaming.rs
+++ b/model_gateway/src/routers/openai/responses/streaming.rs
@@ -46,7 +46,7 @@ use crate::{
     routers::{
         common::{
             header_utils::{preserve_response_headers, ApiProvider},
-            mcp_utils::DEFAULT_MAX_ITERATIONS,
+            mcp_utils::{collect_user_function_names, DEFAULT_MAX_ITERATIONS},
             persistence_utils::persist_conversation_items,
         },
         error,
@@ -141,9 +141,9 @@ pub(super) fn apply_event_transformations_inplace(
                             .to_string();
 
                         // Only transform if this is an MCP tool; keep function_call unchanged
-                        if let Some(session) =
-                            ctx.session.filter(|s| s.has_exposed_tool(&tool_name))
-                        {
+                        if let Some(session) = ctx.session.filter(|s| {
+                            s.should_intercept_function_call(&tool_name, ctx.user_function_names)
+                        }) {
                             let response_format = session.tool_response_format(&tool_name);
 
                             // Determine item type and ID prefix based on response_format
@@ -173,16 +173,6 @@ pub(super) fn apply_event_transformations_inplace(
                     }
                 }
             }
-        }
-        FunctionCallEvent::ARGUMENTS_DONE => {
-            parsed_data["type"] = json!(McpEvent::CALL_ARGUMENTS_DONE);
-
-            // Transform item_id from fc_* to mcp_*
-            if let Some(item_id) = parsed_data.get("item_id").and_then(|v| v.as_str()) {
-                parsed_data["item_id"] = json!(mcp_response_item_id(item_id));
-            }
-
-            changed = true;
         }
         _ => {}
     }
@@ -218,21 +208,46 @@ fn send_sse_event(
     tx.send(Ok(Bytes::from(block))).is_ok()
 }
 
-/// Map function_call event names to mcp_call event names
+/// Map function_call event names to mcp_call event names when MCP interception is active.
 #[inline]
-fn map_event_name(event_name: &str) -> &str {
-    match event_name {
-        FunctionCallEvent::ARGUMENTS_DELTA => McpEvent::CALL_ARGUMENTS_DELTA,
-        FunctionCallEvent::ARGUMENTS_DONE => McpEvent::CALL_ARGUMENTS_DONE,
-        other => other,
+fn map_event_name(event_name: &str, map_function_call_args: bool) -> &str {
+    if map_function_call_args {
+        match event_name {
+            FunctionCallEvent::ARGUMENTS_DELTA => McpEvent::CALL_ARGUMENTS_DELTA,
+            FunctionCallEvent::ARGUMENTS_DONE => McpEvent::CALL_ARGUMENTS_DONE,
+            other => other,
+        }
+    } else {
+        event_name
     }
+}
+
+fn is_mcp_arguments_event(
+    parsed_data: &Value,
+    handler: &StreamingToolHandler,
+    ctx: &StreamingEventContext<'_>,
+) -> bool {
+    let Some(session) = ctx.session else {
+        return false;
+    };
+
+    extract_output_index(parsed_data)
+        .and_then(|idx| {
+            handler
+                .pending_calls
+                .iter()
+                .find(|call| call.output_index == idx)
+                .map(|call| call.name.as_str())
+        })
+        .filter(|name| !name.is_empty())
+        .is_some_and(|name| session.should_intercept_function_call(name, ctx.user_function_names))
 }
 
 /// Send buffered function call arguments as a synthetic delta event.
 /// Returns false if client disconnected.
 fn send_buffered_arguments(
     parsed_data: &mut Value,
-    handler: &StreamingToolHandler,
+    handler: &mut StreamingToolHandler,
     tx: &mpsc::UnboundedSender<Result<Bytes, io::Error>>,
     sequence_number: &mut u64,
     mapped_output_index: &mut Option<usize>,
@@ -241,9 +256,9 @@ fn send_buffered_arguments(
         return true;
     };
 
-    let assigned_index = handler
-        .mapped_output_index(output_index)
-        .unwrap_or(output_index);
+    let Some(assigned_index) = handler.resolve_output_index_for_forwarding(output_index) else {
+        return true;
+    };
     *mapped_output_index = Some(assigned_index);
 
     let Some(call) = handler
@@ -300,6 +315,60 @@ fn send_buffered_arguments(
     true
 }
 
+fn should_drop_hidden_internal_tool_event(
+    event_name: Option<&str>,
+    parsed_data: &Value,
+    handler: &mut StreamingToolHandler,
+    visibility_session: Option<&McpToolSession<'_>>,
+    user_function_names: &std::collections::HashSet<String>,
+) -> bool {
+    let Some(session) = visibility_session else {
+        return false;
+    };
+
+    let output_index = extract_output_index(parsed_data);
+    // Fast path: if already marked hidden (from when ADDED was dropped), hide all follow-up events.
+    if output_index.is_some_and(|idx| handler.is_output_hidden(idx)) {
+        return true;
+    }
+
+    let resolved_event_name =
+        event_name.or_else(|| parsed_data.get("type").and_then(Value::as_str));
+
+    let should_hide = match resolved_event_name {
+        Some(OutputItemEvent::ADDED) | Some(OutputItemEvent::DONE) => parsed_data
+            .get("item")
+            .filter(|item| {
+                item.get("type")
+                    .and_then(|v| v.as_str())
+                    .is_some_and(is_function_call_type)
+            })
+            .is_some_and(|item| session.should_hide_output_item_json(item, user_function_names)),
+        // MCP ARGUMENTS_DELTA events are handled before this function is reached
+        // (buffered and re-emitted synthetically), so only ARGUMENTS_DONE needs handling here.
+        Some(FunctionCallEvent::ARGUMENTS_DONE) => output_index
+            .and_then(|idx| {
+                handler
+                    .pending_calls
+                    .iter()
+                    .find(|c| c.output_index == idx)
+                    .filter(|c| !c.name.is_empty())
+            })
+            .is_some_and(|c| {
+                let probe = json!({ "type": ItemType::FUNCTION_CALL, "name": c.name.as_str() });
+                session.should_hide_output_item_json(&probe, user_function_names)
+            }),
+        _ => false,
+    };
+
+    if should_hide {
+        if let Some(idx) = output_index {
+            handler.mark_output_hidden(idx);
+        }
+    }
+    should_hide
+}
+
 /// An SSE event to be forwarded to the client, with optional pre-parsed JSON.
 pub(super) struct SseEventData<'a> {
     pub raw_block: &'a str,
@@ -316,6 +385,7 @@ pub(super) fn forward_streaming_event(
     handler: &mut StreamingToolHandler,
     tx: &mpsc::UnboundedSender<Result<Bytes, io::Error>>,
     ctx: &StreamingEventContext<'_>,
+    redaction_session: Option<&McpToolSession<'_>>,
     sequence_number: &mut u64,
 ) -> bool {
     let SseEventData {
@@ -324,10 +394,6 @@ pub(super) fn forward_streaming_event(
         data,
         pre_parsed,
     } = event;
-
-    if event_name == Some(FunctionCallEvent::ARGUMENTS_DELTA) {
-        return true;
-    }
 
     // Use pre-parsed value or parse JSON data
     let mut parsed_data: Value = match pre_parsed {
@@ -341,14 +407,37 @@ pub(super) fn forward_streaming_event(
         },
     };
 
+    let is_mcp_call_arguments_event = matches!(
+        event_name,
+        Some(FunctionCallEvent::ARGUMENTS_DELTA | FunctionCallEvent::ARGUMENTS_DONE)
+    ) && is_mcp_arguments_event(&parsed_data, handler, ctx);
+
+    // Only MCP-intercepted argument deltas are dropped. User-function argument
+    // deltas must pass through unchanged.
+    if event_name == Some(FunctionCallEvent::ARGUMENTS_DELTA) && is_mcp_call_arguments_event {
+        return true;
+    }
+
     let event_type = get_event_type(event_name, &parsed_data);
     if event_type == ResponseEvent::COMPLETED {
+        return true;
+    }
+
+    let visibility_session = ctx.session.or(redaction_session);
+    if should_drop_hidden_internal_tool_event(
+        event_name,
+        &parsed_data,
+        handler,
+        visibility_session,
+        ctx.user_function_names,
+    ) {
         return true;
     }
 
     // Handle function_call_arguments.done - send buffered args first
     let mut mapped_output_index: Option<usize> = None;
     if event_name == Some(FunctionCallEvent::ARGUMENTS_DONE)
+        && is_mcp_call_arguments_event
         && !send_buffered_arguments(
             &mut parsed_data,
             handler,
@@ -362,11 +451,21 @@ pub(super) fn forward_streaming_event(
 
     if mapped_output_index.is_none() {
         if let Some(idx) = extract_output_index(&parsed_data) {
-            mapped_output_index = handler.mapped_output_index(idx);
+            let Some(mapped) = handler.resolve_output_index_for_forwarding(idx) else {
+                return true;
+            };
+            mapped_output_index = Some(mapped);
         }
     }
     if let Some(mapped) = mapped_output_index {
         parsed_data["output_index"] = json!(mapped);
+    }
+
+    if event_name == Some(FunctionCallEvent::ARGUMENTS_DONE) && is_mcp_call_arguments_event {
+        parsed_data["type"] = json!(McpEvent::CALL_ARGUMENTS_DONE);
+        if let Some(item_id) = parsed_data.get("item_id").and_then(|v| v.as_str()) {
+            parsed_data["item_id"] = json!(mcp_response_item_id(item_id));
+        }
     }
 
     apply_event_transformations_inplace(&mut parsed_data, ctx);
@@ -394,7 +493,11 @@ pub(super) fn forward_streaming_event(
     };
 
     let final_block = match event_name {
-        Some(evt) => format!("event: {}\ndata: {}\n\n", map_event_name(evt), final_data),
+        Some(evt) => format!(
+            "event: {}\ndata: {}\n\n",
+            map_event_name(evt, is_mcp_call_arguments_event),
+            final_data
+        ),
         None => format!("data: {final_data}\n\n"),
     };
 
@@ -460,6 +563,7 @@ pub(super) fn send_final_response_event(
     sequence_number: &mut u64,
     state: &ToolLoopState,
     ctx: &StreamingEventContext<'_>,
+    redaction_session: Option<&McpToolSession<'_>>,
 ) -> bool {
     let mut final_response = match handler.snapshot_final_response() {
         Some(resp) => resp,
@@ -476,10 +580,15 @@ pub(super) fn send_final_response_event(
     }
 
     if let Some(session) = ctx.session {
-        inject_mcp_metadata_streaming(&mut final_response, state, session);
+        inject_mcp_metadata_streaming(&mut final_response, state, session, ctx.user_function_names);
     }
 
-    restore_original_tools(&mut final_response, ctx.original_request, None);
+    let session_for_redaction = redaction_session.or(ctx.session);
+    restore_original_tools(
+        &mut final_response,
+        ctx.original_request,
+        session_for_redaction,
+    );
     patch_response_with_request_metadata(
         &mut final_response,
         ctx.original_request,
@@ -711,16 +820,23 @@ pub(super) fn handle_streaming_with_tool_interception(
         let mut sequence_number: u64 = 0;
         let mut next_output_index: usize = 0;
         let mut preserved_response_id: Option<String> = None;
-        let list_tools_bindings = mcp_list_tools_bindings_to_emit(
-            &state.existing_mcp_list_tools_labels,
-            session.mcp_servers(),
-        );
+        let list_tools_bindings =
+            mcp_list_tools_bindings_to_emit(&state.existing_mcp_list_tools_labels, &session);
+        let user_function_names = collect_user_function_names(&original_request);
 
         let streaming_ctx = StreamingEventContext {
             original_request: &original_request,
             previous_response_id: previous_response_id.as_deref(),
             session: Some(&session),
+            user_function_names: &user_function_names,
         };
+        let passthrough_streaming_ctx = StreamingEventContext {
+            original_request: &original_request,
+            previous_response_id: previous_response_id.as_deref(),
+            session: None,
+            user_function_names: &user_function_names,
+        };
+        let mut disable_mcp_interception = false;
         let provider = ApiProvider::from_url(&url_clone);
         let auth_header =
             provider.extract_auth_header(headers_opt.as_ref(), worker_api_key.as_ref());
@@ -774,14 +890,13 @@ pub(super) fn handle_streaming_with_tool_interception(
                                 continue;
                             }
 
+                            let parsed = serde_json::from_str::<Value>(data.as_ref()).ok();
+
                             // Process through handler
                             let action = handler.process_event(event_name, data.as_ref());
 
                             match action {
                                 StreamAction::Forward => {
-                                    // Parse data once and reuse for skip check, forwarding, and in_progress check
-                                    let parsed = serde_json::from_str::<Value>(data.as_ref()).ok();
-
                                     // Skip response.created and response.in_progress on subsequent iterations
                                     let should_skip = if is_first_iteration {
                                         false
@@ -803,6 +918,11 @@ pub(super) fn handle_streaming_with_tool_interception(
                                         });
 
                                     if !should_skip {
+                                        let active_ctx = if disable_mcp_interception {
+                                            &passthrough_streaming_ctx
+                                        } else {
+                                            &streaming_ctx
+                                        };
                                         // Forward the event with pre-parsed value (moved, not cloned)
                                         if !forward_streaming_event(
                                             SseEventData {
@@ -813,7 +933,8 @@ pub(super) fn handle_streaming_with_tool_interception(
                                             },
                                             &mut handler,
                                             &tx,
-                                            &streaming_ctx,
+                                            active_ctx,
+                                            Some(&session),
                                             &mut sequence_number,
                                         ) {
                                             return;
@@ -822,8 +943,16 @@ pub(super) fn handle_streaming_with_tool_interception(
 
                                     if is_in_progress {
                                         seen_in_progress = true;
-                                        if !mcp_list_tools_sent {
+                                        if !disable_mcp_interception && !mcp_list_tools_sent {
                                             for (server_label, server_key) in &list_tools_bindings {
+                                                // Guard before synthetic index allocation so hidden
+                                                // bindings do not consume client-visible output
+                                                // indexes.
+                                                if !session.should_emit_streaming_mcp_list_tools(
+                                                    server_label,
+                                                ) {
+                                                    continue;
+                                                }
                                                 let list_tools_index =
                                                     handler.allocate_synthetic_output_index();
                                                 if !send_mcp_list_tools_events(
@@ -843,23 +972,120 @@ pub(super) fn handle_streaming_with_tool_interception(
                                     }
                                 }
                                 StreamAction::Buffer => {
-                                    // Don't forward, just buffer
+                                    if disable_mcp_interception
+                                        && !forward_streaming_event(
+                                            SseEventData {
+                                                raw_block: &raw_block,
+                                                event_name,
+                                                data: data.as_ref(),
+                                                pre_parsed: parsed,
+                                            },
+                                            &mut handler,
+                                            &tx,
+                                            &passthrough_streaming_ctx,
+                                            Some(&session),
+                                            &mut sequence_number,
+                                        )
+                                    {
+                                        return;
+                                    }
                                 }
                                 StreamAction::ExecuteTools => {
+                                    let has_non_mcp_calls =
+                                        handler.pending_calls.iter().any(|call| {
+                                            !call.name.is_empty()
+                                                && !session.should_intercept_function_call(
+                                                    &call.name,
+                                                    &user_function_names,
+                                                )
+                                        });
+
+                                    let active_ctx = if disable_mcp_interception {
+                                        &passthrough_streaming_ctx
+                                    } else {
+                                        &streaming_ctx
+                                    };
+
                                     if !forward_streaming_event(
                                         SseEventData {
                                             raw_block: &raw_block,
                                             event_name,
                                             data: data.as_ref(),
-                                            pre_parsed: None,
+                                            pre_parsed: parsed,
                                         },
                                         &mut handler,
                                         &tx,
-                                        &streaming_ctx,
+                                        active_ctx,
+                                        Some(&session),
                                         &mut sequence_number,
                                     ) {
                                         return;
                                     }
+
+                                    if has_non_mcp_calls {
+                                        let pending_calls = handler.take_pending_calls();
+                                        let (mcp_pending_calls, _passthrough_calls): (
+                                            Vec<_>,
+                                            Vec<_>,
+                                        ) = pending_calls.into_iter().partition(|call| {
+                                            !call.name.is_empty()
+                                                && session.should_intercept_function_call(
+                                                    &call.name,
+                                                    &user_function_names,
+                                                )
+                                        });
+
+                                        if !mcp_pending_calls.is_empty() {
+                                            state.iteration += 1;
+                                            state.total_calls += mcp_pending_calls.len();
+                                            Metrics::record_mcp_tool_iteration(
+                                                &original_request.model,
+                                            );
+
+                                            let effective_limit = match max_tool_calls {
+                                                Some(user_max) => {
+                                                    user_max.min(DEFAULT_MAX_ITERATIONS)
+                                                }
+                                                None => DEFAULT_MAX_ITERATIONS,
+                                            };
+
+                                            if state.total_calls > effective_limit {
+                                                warn!(
+                                                    "Reached tool call limit during streaming: {}",
+                                                    effective_limit
+                                                );
+                                                send_sse_event(
+                                                    &tx,
+                                                    "error",
+                                                    &json!({"error": {"message": "Exceeded max_tool_calls limit"}}),
+                                                );
+                                                let _ = tx.send(Ok(Bytes::from_static(
+                                                    SSE_DONE.as_bytes(),
+                                                )));
+                                                return;
+                                            }
+
+                                            if !execute_streaming_tool_calls(
+                                                mcp_pending_calls,
+                                                &session,
+                                                &user_function_names,
+                                                &tx,
+                                                &mut state,
+                                                &mut sequence_number,
+                                                &original_request.model,
+                                            )
+                                            .await
+                                            {
+                                                return;
+                                            }
+                                        }
+
+                                        // Any user-function call in the batch means this turn must
+                                        // remain client-driven; continue passthrough streaming.
+                                        disable_mcp_interception = true;
+                                        continue;
+                                    }
+
                                     tool_calls_detected = true;
                                     break; // Exit stream processing to execute tools
                                 }
@@ -888,12 +1114,18 @@ pub(super) fn handle_streaming_with_tool_interception(
 
             // If no tool calls, we're done - stream is complete
             if !tool_calls_detected {
+                let final_streaming_ctx = if disable_mcp_interception {
+                    &passthrough_streaming_ctx
+                } else {
+                    &streaming_ctx
+                };
                 if !send_final_response_event(
                     &handler,
                     &tx,
                     &mut sequence_number,
                     &state,
-                    &streaming_ctx,
+                    final_streaming_ctx,
+                    Some(&session),
                 ) {
                     return;
                 }
@@ -910,7 +1142,14 @@ pub(super) fn handle_streaming_with_tool_interception(
                             obj.insert("id".to_string(), Value::String(id.clone()));
                         }
                     }
-                    inject_mcp_metadata_streaming(&mut response_json, &state, &session);
+                    if !disable_mcp_interception {
+                        inject_mcp_metadata_streaming(
+                            &mut response_json,
+                            &state,
+                            &session,
+                            &user_function_names,
+                        );
+                    }
 
                     restore_original_tools(&mut response_json, &original_request, Some(&session));
                     patch_response_with_request_metadata(
@@ -974,6 +1213,7 @@ pub(super) fn handle_streaming_with_tool_interception(
             if !execute_streaming_tool_calls(
                 pending_calls,
                 &session,
+                &user_function_names,
                 &tx,
                 &mut state,
                 &mut sequence_number,

--- a/model_gateway/src/routers/openai/responses/streaming.rs
+++ b/model_gateway/src/routers/openai/responses/streaming.rs
@@ -7,7 +7,7 @@
 //! - MCP tool execution loops within streaming responses
 //! - Event transformation and output index remapping
 
-use std::{borrow::Cow, io, sync::Arc};
+use std::{borrow::Cow, collections::HashSet, io, sync::Arc};
 
 use axum::{
     body::Body,
@@ -55,7 +55,8 @@ use crate::{
             mcp::{
                 build_resume_payload, execute_streaming_tool_calls, inject_mcp_metadata_streaming,
                 mcp_list_tools_bindings_to_emit, prepare_mcp_tools_as_functions,
-                send_mcp_list_tools_events, StreamAction, StreamingToolHandler, ToolLoopState,
+                remove_intercepted_mcp_function_calls_from_output, send_mcp_list_tools_events,
+                StreamAction, StreamingToolHandler, ToolLoopState,
             },
         },
     },
@@ -320,7 +321,7 @@ fn should_drop_hidden_internal_tool_event(
     parsed_data: &Value,
     handler: &mut StreamingToolHandler,
     visibility_session: Option<&McpToolSession<'_>>,
-    user_function_names: &std::collections::HashSet<String>,
+    user_function_names: &HashSet<String>,
 ) -> bool {
     let Some(session) = visibility_session else {
         return false;
@@ -346,6 +347,8 @@ fn should_drop_hidden_internal_tool_event(
             .is_some_and(|item| session.should_hide_output_item_json(item, user_function_names)),
         // MCP ARGUMENTS_DELTA events are handled before this function is reached
         // (buffered and re-emitted synthetically), so only ARGUMENTS_DONE needs handling here.
+        // This branch assumes pending_calls has already been populated from prior
+        // function_call/output_item events for this output_index.
         Some(FunctionCallEvent::ARGUMENTS_DONE) => output_index
             .and_then(|idx| {
                 handler
@@ -385,6 +388,8 @@ pub(super) fn forward_streaming_event(
     handler: &mut StreamingToolHandler,
     tx: &mpsc::UnboundedSender<Result<Bytes, io::Error>>,
     ctx: &StreamingEventContext<'_>,
+    // Optional policy-only session used when interception is disabled but
+    // visibility/redaction must still apply.
     redaction_session: Option<&McpToolSession<'_>>,
     sequence_number: &mut u64,
 ) -> bool {
@@ -451,6 +456,9 @@ pub(super) fn forward_streaming_event(
 
     if mapped_output_index.is_none() {
         if let Some(idx) = extract_output_index(&parsed_data) {
+            // IMPORTANT: resolve_output_index_for_forwarding has committing side-effects
+            // for Unknown indices (allocates + marks Visible). Keep hidden-drop checks above
+            // this call so hidden items cannot become visible by accident.
             let Some(mapped) = handler.resolve_output_index_for_forwarding(idx) else {
                 return true;
             };
@@ -555,6 +563,19 @@ fn maybe_inject_tool_in_progress(
     send_sse_event(tx, event_type, &event)
 }
 
+fn reconcile_mixed_mode_final_response(
+    final_response: &mut Value,
+    state: &ToolLoopState,
+    session: &McpToolSession<'_>,
+    user_function_names: &HashSet<String>,
+) {
+    // In mixed MCP + user-function batches, upstream final responses still contain
+    // function_call placeholders for MCP calls we already executed server-side.
+    // Remove those placeholders before injecting executed MCP output metadata.
+    remove_intercepted_mcp_function_calls_from_output(final_response, session, user_function_names);
+    inject_mcp_metadata_streaming(final_response, state, session, user_function_names);
+}
+
 /// Send final response.completed event to client
 /// Returns false if client disconnected
 pub(super) fn send_final_response_event(
@@ -581,6 +602,13 @@ pub(super) fn send_final_response_event(
 
     if let Some(session) = ctx.session {
         inject_mcp_metadata_streaming(&mut final_response, state, session, ctx.user_function_names);
+    } else if let Some(session) = redaction_session.filter(|_| state.total_calls > 0) {
+        reconcile_mixed_mode_final_response(
+            &mut final_response,
+            state,
+            session,
+            ctx.user_function_names,
+        );
     }
 
     let session_for_redaction = redaction_session.or(ctx.session);
@@ -1034,6 +1062,9 @@ pub(super) fn handle_streaming_with_tool_interception(
                                                     &user_function_names,
                                                 )
                                         });
+                                        // `_passthrough_calls` are intentionally not executed
+                                        // here; they are surfaced to the client in upstream
+                                        // response output so the client can drive them.
 
                                         if !mcp_pending_calls.is_empty() {
                                             state.iteration += 1;
@@ -1144,6 +1175,13 @@ pub(super) fn handle_streaming_with_tool_interception(
                     }
                     if !disable_mcp_interception {
                         inject_mcp_metadata_streaming(
+                            &mut response_json,
+                            &state,
+                            &session,
+                            &user_function_names,
+                        );
+                    } else if state.total_calls > 0 {
+                        reconcile_mixed_mode_final_response(
                             &mut response_json,
                             &state,
                             &session,
@@ -1309,4 +1347,217 @@ pub async fn handle_streaming_response(ctx: RequestContext) -> Response {
         &mcp_orchestrator,
         mcp_servers,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use openai_protocol::responses::ResponseInput;
+    use serde_json::json;
+    use smg_mcp::{
+        McpConfig, McpOrchestrator, McpServerBinding, McpServerConfig, McpToolSession,
+        McpTransport, Tool, ToolEntry,
+    };
+
+    use super::{
+        reconcile_mixed_mode_final_response, should_drop_hidden_internal_tool_event,
+        StreamingToolHandler,
+    };
+
+    fn test_tool(name: &str) -> Tool {
+        let mut schema = serde_json::Map::new();
+        schema.insert("type".to_string(), json!("object"));
+        schema.insert("properties".to_string(), json!({}));
+
+        Tool {
+            name: name.to_string().into(),
+            title: None,
+            description: Some("test".into()),
+            input_schema: schema.into(),
+            output_schema: None,
+            icons: None,
+            annotations: None,
+        }
+    }
+
+    fn internal_server_config() -> McpServerConfig {
+        McpServerConfig {
+            name: "internal-server".to_string(),
+            transport: McpTransport::Sse {
+                url: "http://localhost:3000/sse".to_string(),
+                token: None,
+                headers: Default::default(),
+            },
+            proxy: None,
+            required: false,
+            tools: None,
+            builtin_type: None,
+            builtin_tool_name: None,
+            internal: true,
+        }
+    }
+
+    fn internal_server_binding() -> McpServerBinding {
+        McpServerBinding {
+            label: "internal_label".to_string(),
+            server_key: "internal-server".to_string(),
+            allowed_tools: Some(vec!["internal_non_builtin_tool".to_string()]),
+        }
+    }
+
+    fn visible_server_config() -> McpServerConfig {
+        McpServerConfig {
+            name: "visible-server".to_string(),
+            transport: McpTransport::Sse {
+                url: "http://localhost:3001/sse".to_string(),
+                token: None,
+                headers: Default::default(),
+            },
+            proxy: None,
+            required: false,
+            tools: None,
+            builtin_type: None,
+            builtin_tool_name: None,
+            internal: false,
+        }
+    }
+
+    fn visible_server_binding() -> McpServerBinding {
+        McpServerBinding {
+            label: "visible_label".to_string(),
+            server_key: "visible-server".to_string(),
+            allowed_tools: Some(vec!["visible_mcp_tool".to_string()]),
+        }
+    }
+
+    #[tokio::test]
+    async fn drops_hidden_done_event_even_without_added_event() {
+        let orchestrator = McpOrchestrator::new(McpConfig {
+            servers: vec![internal_server_config()],
+            ..Default::default()
+        })
+        .await
+        .expect("orchestrator");
+        orchestrator
+            .tool_inventory()
+            .insert_entry(ToolEntry::from_server_tool(
+                "internal-server",
+                test_tool("internal_non_builtin_tool"),
+            ));
+        let session = McpToolSession::new(
+            &orchestrator,
+            vec![internal_server_binding()],
+            "test-request",
+        );
+        let mut handler = StreamingToolHandler::with_starting_index(0);
+
+        let done_event = json!({
+            "type": "response.output_item.done",
+            "output_index": 4,
+            "item": {
+                "type": "function_call",
+                "name": "internal_non_builtin_tool",
+                "status": "completed",
+                "arguments": "{}"
+            }
+        });
+
+        let dropped = should_drop_hidden_internal_tool_event(
+            Some("response.output_item.done"),
+            &done_event,
+            &mut handler,
+            Some(&session),
+            &HashSet::new(),
+        );
+
+        assert!(dropped);
+        assert!(handler.is_output_hidden(4));
+    }
+
+    #[tokio::test]
+    async fn mixed_mode_reconciliation_removes_mcp_placeholders() {
+        let orchestrator = McpOrchestrator::new(McpConfig {
+            servers: vec![visible_server_config()],
+            ..Default::default()
+        })
+        .await
+        .expect("orchestrator");
+        orchestrator
+            .tool_inventory()
+            .insert_entry(ToolEntry::from_server_tool(
+                "visible-server",
+                test_tool("visible_mcp_tool"),
+            ));
+        let session = McpToolSession::new(
+            &orchestrator,
+            vec![visible_server_binding()],
+            "test-request",
+        );
+        let mut state = super::ToolLoopState::new(ResponseInput::Text("hello".to_string()), vec![]);
+        state.total_calls = 1;
+        state.mcp_call_items.push(json!({
+            "type": "mcp_call",
+            "id": "mcp_visible_tool",
+            "name": "visible_mcp_tool",
+            "server_label": "visible_label",
+            "status": "completed",
+            "arguments": "{}",
+            "output": "ok"
+        }));
+
+        let mut final_response = json!({
+            "output": [
+                {
+                    "type": "function_call",
+                    "id": "fc_internal",
+                    "name": "visible_mcp_tool",
+                    "status": "completed",
+                    "arguments": "{}"
+                },
+                {
+                    "type": "function_call",
+                    "id": "fc_user",
+                    "name": "user_tool",
+                    "status": "completed",
+                    "arguments": "{}"
+                }
+            ]
+        });
+        let user_function_names = HashSet::from(["user_tool".to_string()]);
+
+        reconcile_mixed_mode_final_response(
+            &mut final_response,
+            &state,
+            &session,
+            &user_function_names,
+        );
+
+        let output = final_response
+            .get("output")
+            .and_then(|value| value.as_array())
+            .expect("output array");
+
+        assert!(
+            output.iter().any(|item| {
+                item.get("type").and_then(|v| v.as_str()) == Some("mcp_call")
+                    && item.get("name").and_then(|v| v.as_str()) == Some("visible_mcp_tool")
+            }),
+            "expected executed MCP output item to be present"
+        );
+        assert!(
+            output.iter().any(|item| {
+                item.get("type").and_then(|v| v.as_str()) == Some("function_call")
+                    && item.get("name").and_then(|v| v.as_str()) == Some("user_tool")
+            }),
+            "expected user function call to remain in final output"
+        );
+        assert!(
+            !output.iter().any(|item| {
+                item.get("type").and_then(|v| v.as_str()) == Some("function_call")
+                    && item.get("name").and_then(|v| v.as_str()) == Some("visible_mcp_tool")
+            }),
+            "expected intercepted MCP function_call placeholder to be removed"
+        );
+    }
 }


### PR DESCRIPTION
## Description

### Problem

Streaming MCP interception had a mixed-batch gap: when a streamed turn contained both user function calls and MCP-intercepted calls, final `response.completed`/persisted output could omit already-executed MCP output items. That creates client state mismatch and replay risk.

In addition, output visibility/index behavior relied on subtle ordering assumptions with limited local guardrails/tests.

### Solution

- Reconcile mixed-mode final response snapshots by removing intercepted MCP `function_call` placeholders and injecting executed MCP output items before `response.completed` emission and persistence.
- Reuse the same reconciliation in stored final response handling for mixed-mode streaming.
- Add explicit guardrail comments around `resolve_output_index_for_forwarding` side effects and interception vs redaction context usage.
- Add warning path when `mark_output_hidden` is called after an index is already visible.
- Add targeted tests for:
  - output visibility state transitions,
  - hidden `output_item.done` handling,
  - mixed-mode final-response reconciliation.
- Add probe-shape invariant comments in gRPC regular/harmony streaming visibility checks.

## Changes

- `model_gateway/src/routers/openai/responses/streaming.rs`
  - Added mixed-mode final-response reconciliation helper.
  - Applied reconciliation in `send_final_response_event` and persisted final response path when interception is disabled but MCP calls executed.
  - Added comments clarifying side-effect ordering and mixed-call passthrough behavior.
  - Added new streaming tests for hidden DONE event and mixed-mode reconciliation.
- `model_gateway/src/routers/openai/mcp/tool_handler.rs`
  - Added warning behavior for hide-after-visible attempts.
  - Added visibility transition tests.
- `model_gateway/src/routers/openai/mcp/tool_loop.rs`
  - Exported helper used by streaming reconciliation.
- `model_gateway/src/routers/openai/mcp/mod.rs`
  - Re-exported helper for streaming module usage.
- `model_gateway/src/routers/grpc/regular/responses/streaming.rs`
  - Added probe-shape invariant comment.
- `model_gateway/src/routers/grpc/harmony/streaming.rs`
  - Added probe-shape invariant comment.

## Test Plan

Reproducible verification run:

1. `cargo test -p smg --lib routers::openai::mcp::tool_handler::tests::`
2. `cargo test -p smg --lib routers::openai::responses::streaming::tests::`
3. `cargo test -p smg --lib routers::openai::mcp::tool_loop::tests::`
4. `cargo test -p smg --test api_tests responses`
5. `cargo test -p smg --test api_tests mcp`
6. `pre-commit run --all-files`

Expected/observed: all commands pass.

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
