### PR TITLE
feat(smg): TreeHandle on CacheAwarePolicy — adapter consumes policy-owned hash membership

### DIFF
--- a/model_gateway/src/mesh/adapters/mod.rs
+++ b/model_gateway/src/mesh/adapters/mod.rs
@@ -8,5 +8,5 @@ pub mod tree_sync;
 pub mod worker_sync;
 
 pub use rate_limit_sync::RateLimitSyncAdapter;
-pub use tree_sync::{TreeDelta, TreeKind, TreeSyncAdapter};
+pub use tree_sync::{LocalHashResolver, TreeDelta, TreeKind, TreeSyncAdapter};
 pub use worker_sync::WorkerSyncAdapter;

--- a/model_gateway/src/mesh/adapters/mod.rs
+++ b/model_gateway/src/mesh/adapters/mod.rs
@@ -8,5 +8,5 @@ pub mod tree_sync;
 pub mod worker_sync;
 
 pub use rate_limit_sync::RateLimitSyncAdapter;
-pub use tree_sync::{LocalHashResolver, TreeDelta, TreeKind, TreeSyncAdapter};
+pub use tree_sync::{TreeDelta, TreeSyncAdapter};
 pub use worker_sync::WorkerSyncAdapter;

--- a/model_gateway/src/mesh/adapters/tree_sync.rs
+++ b/model_gateway/src/mesh/adapters/tree_sync.rs
@@ -1,27 +1,18 @@
-//! `td:` / `tree:*` stream adapter: gateway ↔ mesh bridge for the
-//! distributed prefix tree.
+//! `td:` stream adapter: gateway ↔ mesh bridge for the distributed
+//! prefix tree. Scope so far: tenant-delta fast path + inbound
+//! hash resolution via [`TreeHandle`].
 //!
-//! Current scope: tenant-delta fast path + inbound hash resolution
-//! via [`crate::policies::cache_aware::TreeHandle`]. The adapter
-//! holds no tree-membership state of its own — the tree-owning
-//! component (`CacheAwarePolicy` in production) exposes the handle
-//! and the adapter queries through it. This keeps the dependency
-//! direction adapter → policy; the policy never imports from this
-//! module.
+//! - Outbound: `on_local_insert` buffers per-model `TreeDelta`s;
+//!   the drain callback batches each model into one
+//!   `td:{model_id}` stream entry per gossip round.
+//! - Inbound: a spawned task subscribes to `td:`, decodes each
+//!   batch, and asks the [`TreeHandle`] whether each delta's hash
+//!   is locally known. Known → trace, unknown → debug (repair in
+//!   a later slice).
 //!
-//! - Outbound: `on_local_insert` buffers per-model `TreeDelta`
-//!   entries. The mesh drain callback, called once per gossip round,
-//!   batches each model's buffer into a single `td:{model_id}`
-//!   stream entry (bincode-serialised `Vec<TreeDelta>`).
-//! - Inbound: a spawned task subscribes to `td:` and decodes
-//!   incoming batches. For each delta, the adapter asks the tree
-//!   handle "do you have this node locally?" — known hashes log
-//!   at trace (the apply sink lands in the next slice), unknown
-//!   hashes log at debug (the repair request lands in the slice
-//!   after).
-//!
-//! Repair sessions and the apply sink are deliberately not in this
-//! file yet so the handle contract can soak on its own.
+//! The adapter holds no tree-membership state. The tree owner
+//! (`CacheAwarePolicy` in production) implements [`TreeHandle`];
+//! dependency direction is adapter → policy.
 
 use std::sync::{Arc, OnceLock};
 
@@ -35,44 +26,32 @@ use crate::policies::{TreeHandle, TreeKind};
 
 const PREFIX: &str = "td:";
 
-/// One prefix-tree change observed on a producing node.
-///
-/// `node_hash` is the blake3-derived 8-byte identifier for the tree
-/// node scoped by `(model_id, tree_kind, path)`. The scope is carried
-/// implicitly: `model_id` is encoded in the stream key (`td:{model_id}`)
-/// and `tree_kind` sits inside this struct. The receiver resolves the
-/// hash through its own `(model_id, tree_kind)` index; unknown hashes
-/// trigger a repair request in a later slice.
+/// One prefix-tree change observed on a producing node. `node_hash`
+/// is the blake3 8-byte id scoped by `(model_id, tree_kind, path)`;
+/// `model_id` lives in the stream key, `tree_kind` is inside this
+/// struct. Receivers resolve the hash via `TreeHandle`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TreeDelta {
     pub tree_kind: TreeKind,
     pub node_hash: u64,
     /// Worker URL that cached the prefix.
     pub worker_url: String,
-    /// Cache-event epoch. The merge rule is max-epoch-wins on the
-    /// same node; this field is irrelevant to the stream transport
-    /// but kept on the payload so the receiver can order within a
-    /// batch.
+    /// Cache-event epoch for intra-batch ordering on the receiver;
+    /// the stream transport itself doesn't inspect it.
     pub epoch: u64,
 }
 
-/// Bridge between the `td:` broadcast stream namespace and the
-/// gateway's per-model tenant buffers.
-///
-/// The adapter holds no tree-membership state of its own. The
-/// tree-owning component (`CacheAwarePolicy` in production) exposes
-/// a [`TreeHandle`] and the adapter queries through it. Layering
-/// flows: `adapter → policies::cache_aware::TreeHandle ←
-/// CacheAwarePolicy`, so the policy never imports from this module.
+/// Bridges the `td:` broadcast stream namespace to per-model
+/// tenant buffers, querying a [`TreeHandle`] for inbound hash
+/// resolution.
 pub struct TreeSyncAdapter {
     tenant_deltas: Arc<StreamNamespace>,
     pending_deltas: DashMap<String, Vec<TreeDelta>>,
     /// Hash-membership oracle provided by the tree owner.
     tree: Arc<dyn TreeHandle>,
     node_name: String,
-    /// Keeps the drain registration alive for the adapter's lifetime.
-    /// Dropping the handle unregisters from the mesh drain registry;
-    /// `OnceLock` guards against a second `start` call.
+    /// Keeps the drain registration alive; dropping it unregisters
+    /// from the mesh. `OnceLock` guards against a second `start`.
     drain_handle: OnceLock<DrainHandle>,
 }
 
@@ -114,20 +93,15 @@ impl TreeSyncAdapter {
         })
     }
 
-    /// Register the drain callback and start the inbound task. Must
-    /// be called exactly once per adapter — a second call panics via
-    /// the mesh's one-drain-per-prefix invariant. The spawned recv
-    /// loop runs until the namespace's subscriber channel closes
-    /// (only on `MeshKV` drop).
+    /// Register the drain callback and start the inbound task. Call
+    /// once per adapter — a second call panics via the mesh's
+    /// one-drain-per-prefix invariant.
     pub fn start(self: &Arc<Self>) {
-        // Capture a `Weak` ref so the drain closure doesn't keep the
-        // adapter alive. A strong `Arc` here would cycle:
-        // `TreeSyncAdapter → DrainHandle → DrainRegistry → drain
-        // closure → TreeSyncAdapter`, and `DrainHandle::drop` would
-        // never fire, leaking the drain registration. The upgrade
-        // check returns an empty batch if the adapter has already
-        // been dropped — the drain is a no-op until the mesh tears
-        // the `DrainHandle` down on its own `Drop`.
+        // `Weak` avoids the `TreeSyncAdapter → DrainHandle →
+        // DrainRegistry → drain closure → TreeSyncAdapter` strong
+        // cycle that would leak the drain registration past adapter
+        // drop. If upgrade fails, return an empty batch; the mesh
+        // tears down the `DrainHandle` on its own `Drop`.
         let drain_owner = Arc::downgrade(self);
         let handle = self.tenant_deltas.register_drain(Box::new(move || {
             drain_owner
@@ -140,12 +114,9 @@ impl TreeSyncAdapter {
             "TreeSyncAdapter::start called more than once",
         );
 
-        // Same `Weak` pattern for the subscription task: a strong
-        // `Arc<Self>` captured in the spawned future would keep the
-        // adapter alive until MeshKV drops the subscription channel,
-        // even if the caller has explicitly dropped its last
-        // reference. Upgrade per iteration and exit the loop on
-        // first-None so the task releases cleanly.
+        // Same `Weak` pattern for the subscription task so a late
+        // channel close can't strand the adapter alive. Exit on
+        // first upgrade-None.
         let sub_owner = Arc::downgrade(self);
         let mut sub = self.tenant_deltas.subscribe("");
         #[expect(
@@ -165,10 +136,8 @@ impl TreeSyncAdapter {
                 match value {
                     Some(fragments) => this.handle_incoming_batch(model_id, &fragments),
                     None => {
-                        // Stream namespaces don't emit tombstones in
-                        // the current mesh, but the subscription API
-                        // type is shared with CRDT. Log once and
-                        // keep going — nothing to apply.
+                        // Shared CRDT/stream subscription API — td:
+                        // never emits tombstones today.
                         debug!(model_id, "unexpected td: tombstone event");
                     }
                 }
@@ -177,17 +146,11 @@ impl TreeSyncAdapter {
         });
     }
 
-    /// Buffer a local tree insert for the next gossip round. Called
-    /// by `CacheAwarePolicy` on every local cache event; the batch
-    /// is flushed by the drain callback and must not do anything
-    /// heavy here.
-    ///
-    /// `delta.node_hash` must not be zero: `GLOBAL_EVICTION_HASH` in
-    /// `smg_mesh::tree_ops` reserves 0 as the "evict everywhere"
-    /// sentinel, and the `hash_node_path` / `hash_token_path`
-    /// producers both remap 0→1 to keep the space disjoint. A zero
-    /// hash here would collide with the sentinel in the apply path
-    /// landing next slice.
+    /// Buffer a local tree insert for the next gossip round. Hot
+    /// path — keep it cheap; the drain does the serialisation.
+    /// `delta.node_hash` must be non-zero: 0 is
+    /// `smg_mesh::tree_ops::GLOBAL_EVICTION_HASH` (producers remap
+    /// 0→1 to keep the space disjoint).
     pub fn on_local_insert(&self, model_id: &str, delta: TreeDelta) {
         debug_assert!(
             !model_id.is_empty(),
@@ -203,10 +166,9 @@ impl TreeSyncAdapter {
             .push(delta);
     }
 
-    /// Collect each model's buffer into a single `td:{model_id}`
-    /// stream entry. Called exactly once per gossip round by the
-    /// mesh. The iterate→remove pattern avoids iterating while
-    /// mutating, which would deadlock the `DashMap` shards.
+    /// Collect each model's buffer into one `td:{model_id}` stream
+    /// entry. Called once per gossip round. Iterate→collect→remove
+    /// avoids the deadlock DashMap hits on iterate-and-mutate.
     fn drain_pending_deltas(&self) -> Vec<(String, Bytes)> {
         let model_ids: Vec<String> = self
             .pending_deltas
@@ -228,9 +190,8 @@ impl TreeSyncAdapter {
                     entries.push((format!("{PREFIX}{model_id}"), Bytes::from(bytes)));
                 }
                 Err(err) => {
-                    // Serialisation should never fail for this
-                    // schema; if it does, drop the batch so we don't
-                    // re-enter and log on every round.
+                    // Should be unreachable for this schema; drop
+                    // the batch rather than re-enter next round.
                     warn!(model_id, %err, "failed to serialize tenant deltas");
                 }
             }
@@ -261,9 +222,7 @@ impl TreeSyncAdapter {
                 .tree
                 .contains_hash(model_id, delta.tree_kind, delta.node_hash)
             {
-                // Hash is locally known. Applying the tenant to the
-                // matched tree node lands in the next slice via an
-                // apply sink; for now, just log.
+                // Known locally; actual apply sink lands next slice.
                 trace!(
                     model_id,
                     kind = ?delta.tree_kind,
@@ -273,10 +232,8 @@ impl TreeSyncAdapter {
                     "resolved remote tenant delta against local tree handle",
                 );
             } else {
-                // Unknown hash — the repair-request slice will turn
-                // this into a `tree:req:` message. For now, debug-log
-                // so soak runs can see unresolved deltas without
-                // inflating the trace stream.
+                // Unknown — repair-request slice will turn this
+                // into a `tree:req:` message later.
                 debug!(
                     model_id,
                     kind = ?delta.tree_kind,
@@ -315,11 +272,8 @@ mod tests {
         }
     }
 
-    /// Test-only implementation of [`TreeHandle`]. Keyed by
-    /// `(model_id, TreeKind)` with a set of known hashes. The real
-    /// handle lives on `CacheAwarePolicy` and is backed by the
-    /// policy's `path_hash_index` / `token_path_hash_index` — this
-    /// mock only answers the contract, not the full policy.
+    /// Test-only [`TreeHandle`]: keyed by `(model_id, TreeKind)`
+    /// with a set of known hashes.
     #[derive(Debug, Default)]
     struct MockTreeHandle {
         known: DashMap<(String, TreeKind), DashMap<u64, ()>>,
@@ -414,9 +368,7 @@ mod tests {
 
     #[tokio::test]
     async fn drain_skips_empty_model_buffers() {
-        // `on_local_insert` creates an entry; if a test ever fills
-        // and then clears a model, the next drain must not emit an
-        // empty batch (empty batches would burn gossip bandwidth).
+        // Cleared model buckets must not emit empty batches.
         let mesh = MeshKV::new("node-a".into());
         let adapter = adapter_with_empty_handle(&mesh, "node-a");
 
@@ -430,8 +382,8 @@ mod tests {
 
     #[tokio::test]
     async fn start_registers_drain_with_mesh_round_collector() {
-        // Exercise the end-to-end outbound path: start() → drain
-        // registration → mesh.collect_round_batch() pulls our entries.
+        // End-to-end outbound: start → drain registration →
+        // collect_round_batch pulls our entries.
         let mesh = MeshKV::new("node-a".into());
         let adapter = adapter_with_empty_handle(&mesh, "node-a");
         adapter.start();
@@ -448,10 +400,9 @@ mod tests {
 
     #[tokio::test]
     async fn drain_closure_uses_weak_reference() {
-        // Dropping the only strong `Arc` to the adapter must actually
-        // drop it. If the drain closure held `Arc<Self>`, the cycle
-        // through the DrainRegistry would keep the adapter alive
-        // until MeshKV drop. Verify via a `Weak::upgrade` check.
+        // Dropping the last strong Arc must actually drop the
+        // adapter; a strong Arc in the drain closure would cycle
+        // through DrainRegistry and leak it.
         let mesh = MeshKV::new("node-a".into());
         let adapter = adapter_with_empty_handle(&mesh, "node-a");
         adapter.start();
@@ -463,8 +414,7 @@ mod tests {
             "drain closure must not strongly hold the adapter",
         );
 
-        // The drain is now a no-op. Collecting a round should not
-        // panic and should not yield any entries from this prefix.
+        // Drain is now a no-op; round produces no td: entries.
         let round = mesh.collect_round_batch();
         let td_entries: Vec<_> = round
             .drain_entries
@@ -476,10 +426,9 @@ mod tests {
 
     #[tokio::test]
     async fn handle_incoming_batch_consults_tree() {
-        // Inbound deltas must be classified via the injected
-        // tree. Hashes the tree handle knows are "resolved"; those
-        // it doesn't are "unknown". The tree handle itself is untouched
-        // — `handle_incoming_batch` is read-only on membership.
+        // Deltas must be classified via the injected handle; kinds
+        // must not alias (same hash, different kind ≠ match).
+        // `handle_incoming_batch` is read-only on membership.
         let mesh = MeshKV::new("node-a".into());
         let ns = td_namespace(&mesh);
         let tree = Arc::new(MockTreeHandle::default());
@@ -490,19 +439,19 @@ mod tests {
         let batch = vec![
             TreeDelta {
                 tree_kind: TreeKind::String,
-                node_hash: 42, // known per tree handle
+                node_hash: 42, // known
                 worker_url: "http://w1".into(),
                 epoch: 1,
             },
             TreeDelta {
                 tree_kind: TreeKind::String,
-                node_hash: 99, // unknown per tree handle
+                node_hash: 99, // unknown
                 worker_url: "http://w2".into(),
                 epoch: 1,
             },
             TreeDelta {
                 tree_kind: TreeKind::Token,
-                node_hash: 42, // same hash but different kind — must not alias
+                node_hash: 42, // same hash, different kind — must not alias
                 worker_url: "http://w3".into(),
                 epoch: 1,
             },
@@ -510,7 +459,6 @@ mod tests {
         let bytes = Bytes::from(bincode::serialize(&batch).unwrap());
         adapter.handle_incoming_batch("model-1", &[bytes]);
 
-        // Adapter neither mutates the tree handle nor caches membership.
         assert!(tree.contains_hash("model-1", TreeKind::String, 42));
         assert!(!tree.contains_hash("model-1", TreeKind::String, 99));
         assert!(!tree.contains_hash("model-1", TreeKind::Token, 42));
@@ -518,9 +466,7 @@ mod tests {
 
     #[tokio::test]
     async fn handle_incoming_batch_ignores_malformed_payload() {
-        // A corrupt batch must not propagate any state and must not
-        // panic. The tree handle should never be queried since decode
-        // fails before the per-delta loop.
+        // Corrupt batch → no propagation, no panic.
         let mesh = MeshKV::new("node-a".into());
         let ns = td_namespace(&mesh);
         let tree: Arc<dyn TreeHandle> = Arc::new(MockTreeHandle::default());
@@ -556,10 +502,8 @@ mod tests {
     #[tokio::test]
     #[should_panic(expected = "drain already registered for prefix 'td:'")]
     async fn start_is_fused() {
-        // The mesh drain registry allows only one callback per
-        // prefix, so a second start() on the same adapter must fail
-        // loudly rather than register a phantom drain that the
-        // OnceLock silently drops.
+        // Second start must panic at the mesh's
+        // one-drain-per-prefix invariant.
         let mesh = MeshKV::new("node-a".into());
         let adapter = adapter_with_empty_handle(&mesh, "node-a");
         adapter.start();

--- a/model_gateway/src/mesh/adapters/tree_sync.rs
+++ b/model_gateway/src/mesh/adapters/tree_sync.rs
@@ -2,25 +2,26 @@
 //! distributed prefix tree.
 //!
 //! Current scope: tenant-delta fast path + inbound hash resolution
-//! via an injected [`LocalHashResolver`]. The adapter holds no
-//! tree-membership state of its own — the tree-owning component
-//! (`CacheAwarePolicy` in production) is the single source of truth,
-//! implemented behind the trait so this adapter can test and evolve
-//! without a circular dependency on the policy.
+//! via [`crate::policies::cache_aware::TreeHandle`]. The adapter
+//! holds no tree-membership state of its own — the tree-owning
+//! component (`CacheAwarePolicy` in production) exposes the handle
+//! and the adapter queries through it. This keeps the dependency
+//! direction adapter → policy; the policy never imports from this
+//! module.
 //!
 //! - Outbound: `on_local_insert` buffers per-model `TreeDelta`
 //!   entries. The mesh drain callback, called once per gossip round,
 //!   batches each model's buffer into a single `td:{model_id}`
 //!   stream entry (bincode-serialised `Vec<TreeDelta>`).
 //! - Inbound: a spawned task subscribes to `td:` and decodes
-//!   incoming batches. For each delta, the adapter asks the
-//!   resolver "do you have this node locally?" — known hashes log
+//!   incoming batches. For each delta, the adapter asks the tree
+//!   handle "do you have this node locally?" — known hashes log
 //!   at trace (the apply sink lands in the next slice), unknown
 //!   hashes log at debug (the repair request lands in the slice
 //!   after).
 //!
 //! Repair sessions and the apply sink are deliberately not in this
-//! file yet so the resolver contract can soak on its own.
+//! file yet so the handle contract can soak on its own.
 
 use std::sync::{Arc, OnceLock};
 
@@ -30,16 +31,9 @@ use serde::{Deserialize, Serialize};
 use smg_mesh::{DrainHandle, StreamNamespace};
 use tracing::{debug, trace, warn};
 
-const PREFIX: &str = "td:";
+use crate::policies::{TreeHandle, TreeKind};
 
-/// Which local tree a delta originated from. String and token trees
-/// have disjoint hash spaces, so the adapter keeps them separate
-/// across every data path (hash index, repair sessions, apply logic).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub enum TreeKind {
-    String,
-    Token,
-}
+const PREFIX: &str = "td:";
 
 /// One prefix-tree change observed on a producing node.
 ///
@@ -62,48 +56,19 @@ pub struct TreeDelta {
     pub epoch: u64,
 }
 
-/// Answers "do we have this node in our local tree?" for incoming
-/// tenant deltas. Implemented by the tree-owning component
-/// (`CacheAwarePolicy` in production); injected into the adapter at
-/// construction so the adapter holds no tree-membership state of
-/// its own.
-///
-/// Why a trait here instead of a concrete handle:
-///
-/// - **Single source of truth.** `CacheAwarePolicy` already
-///   maintains `path_hash_index` for the string tree and will grow
-///   an equivalent for the token tree. Duplicating that state
-///   inside the adapter forces two parallel membership maps with
-///   lockstep sync discipline — and the wrong answer on a missed
-///   sync (false "unknown") routes to unnecessary repair.
-/// - **Multi-tenant correctness.** Tree nodes are shared across
-///   tenants; the policy's tree already knows whether any tenant
-///   still holds a node. The adapter can't reconstruct that from
-///   per-tenant event notifications without refcounting, which just
-///   shifts the same bookkeeping into the wrong module.
-/// - **Testability.** Tests use a trivial mock implementation of
-///   this trait without pulling in the full policy.
-///
-/// Implementors must be cheap on the read path — the adapter calls
-/// `contains_hash` once per incoming delta. A DashMap / HashSet
-/// lookup is appropriate; network or disk I/O is not.
-pub trait LocalHashResolver: Send + Sync + std::fmt::Debug {
-    /// Returns `true` if the local tree for `model_id` has a node
-    /// matching `node_hash` under the given `tree_kind`. String and
-    /// token trees have disjoint hash spaces — the implementer must
-    /// not conflate them.
-    fn contains_hash(&self, model_id: &str, tree_kind: TreeKind, node_hash: u64) -> bool;
-}
-
 /// Bridge between the `td:` broadcast stream namespace and the
 /// gateway's per-model tenant buffers.
+///
+/// The adapter holds no tree-membership state of its own. The
+/// tree-owning component (`CacheAwarePolicy` in production) exposes
+/// a [`TreeHandle`] and the adapter queries through it. Layering
+/// flows: `adapter → policies::cache_aware::TreeHandle ←
+/// CacheAwarePolicy`, so the policy never imports from this module.
 pub struct TreeSyncAdapter {
     tenant_deltas: Arc<StreamNamespace>,
     pending_deltas: DashMap<String, Vec<TreeDelta>>,
-    /// Hash-membership oracle provided by the tree owner. See the
-    /// [`LocalHashResolver`] docs for why this lives outside the
-    /// adapter.
-    resolver: Arc<dyn LocalHashResolver>,
+    /// Hash-membership oracle provided by the tree owner.
+    tree: Arc<dyn TreeHandle>,
     node_name: String,
     /// Keeps the drain registration alive for the adapter's lifetime.
     /// Dropping the handle unregisters from the mesh drain registry;
@@ -128,7 +93,7 @@ impl TreeSyncAdapter {
     /// of fanning deltas into the wrong stream.
     pub fn new(
         tenant_deltas: Arc<StreamNamespace>,
-        resolver: Arc<dyn LocalHashResolver>,
+        tree: Arc<dyn TreeHandle>,
         node_name: String,
     ) -> Arc<Self> {
         assert_eq!(
@@ -143,7 +108,7 @@ impl TreeSyncAdapter {
         Arc::new(Self {
             tenant_deltas,
             pending_deltas: DashMap::new(),
-            resolver,
+            tree,
             node_name,
             drain_handle: OnceLock::new(),
         })
@@ -293,7 +258,7 @@ impl TreeSyncAdapter {
         );
         for delta in &batch {
             if self
-                .resolver
+                .tree
                 .contains_hash(model_id, delta.tree_kind, delta.node_hash)
             {
                 // Hash is locally known. Applying the tenant to the
@@ -305,7 +270,7 @@ impl TreeSyncAdapter {
                     hash = delta.node_hash,
                     worker_url = %delta.worker_url,
                     epoch = delta.epoch,
-                    "resolved remote tenant delta against local resolver",
+                    "resolved remote tenant delta against local tree handle",
                 );
             } else {
                 // Unknown hash — the repair-request slice will turn
@@ -350,17 +315,17 @@ mod tests {
         }
     }
 
-    /// Test-only implementation of [`LocalHashResolver`]. Keyed by
+    /// Test-only implementation of [`TreeHandle`]. Keyed by
     /// `(model_id, TreeKind)` with a set of known hashes. The real
-    /// resolver will live on `CacheAwarePolicy` and be backed by the
-    /// policy's `path_hash_index` / token-tree index — this mock
-    /// only needs to answer the contract, not mirror the policy.
+    /// handle lives on `CacheAwarePolicy` and is backed by the
+    /// policy's `path_hash_index` / `token_path_hash_index` — this
+    /// mock only answers the contract, not the full policy.
     #[derive(Debug, Default)]
-    struct MockResolver {
+    struct MockTreeHandle {
         known: DashMap<(String, TreeKind), DashMap<u64, ()>>,
     }
 
-    impl MockResolver {
+    impl MockTreeHandle {
         fn insert(&self, model_id: &str, tree_kind: TreeKind, node_hash: u64) {
             self.known
                 .entry((model_id.to_string(), tree_kind))
@@ -369,7 +334,7 @@ mod tests {
         }
     }
 
-    impl LocalHashResolver for MockResolver {
+    impl TreeHandle for MockTreeHandle {
         fn contains_hash(&self, model_id: &str, tree_kind: TreeKind, node_hash: u64) -> bool {
             self.known
                 .get(&(model_id.to_string(), tree_kind))
@@ -377,14 +342,14 @@ mod tests {
         }
     }
 
-    fn empty_resolver() -> Arc<MockResolver> {
-        Arc::new(MockResolver::default())
+    fn empty_handle() -> Arc<MockTreeHandle> {
+        Arc::new(MockTreeHandle::default())
     }
 
-    fn adapter_with_empty_resolver(mesh: &MeshKV, node_name: &str) -> Arc<TreeSyncAdapter> {
+    fn adapter_with_empty_handle(mesh: &MeshKV, node_name: &str) -> Arc<TreeSyncAdapter> {
         let ns = td_namespace(mesh);
-        let resolver: Arc<dyn LocalHashResolver> = empty_resolver();
-        TreeSyncAdapter::new(ns, resolver, node_name.into())
+        let tree: Arc<dyn TreeHandle> = empty_handle();
+        TreeSyncAdapter::new(ns, tree, node_name.into())
     }
 
     #[tokio::test]
@@ -411,7 +376,7 @@ mod tests {
     #[tokio::test]
     async fn on_local_insert_buffers_per_model() {
         let mesh = MeshKV::new("node-a".into());
-        let adapter = adapter_with_empty_resolver(&mesh, "node-a");
+        let adapter = adapter_with_empty_handle(&mesh, "node-a");
 
         adapter.on_local_insert("model-1", delta(1, "http://w1"));
         adapter.on_local_insert("model-1", delta(2, "http://w1"));
@@ -424,7 +389,7 @@ mod tests {
     #[tokio::test]
     async fn drain_batches_per_model_and_clears_buffer() {
         let mesh = MeshKV::new("node-a".into());
-        let adapter = adapter_with_empty_resolver(&mesh, "node-a");
+        let adapter = adapter_with_empty_handle(&mesh, "node-a");
 
         adapter.on_local_insert("model-1", delta(1, "http://w1"));
         adapter.on_local_insert("model-1", delta(2, "http://w1"));
@@ -453,7 +418,7 @@ mod tests {
         // and then clears a model, the next drain must not emit an
         // empty batch (empty batches would burn gossip bandwidth).
         let mesh = MeshKV::new("node-a".into());
-        let adapter = adapter_with_empty_resolver(&mesh, "node-a");
+        let adapter = adapter_with_empty_handle(&mesh, "node-a");
 
         adapter
             .pending_deltas
@@ -468,7 +433,7 @@ mod tests {
         // Exercise the end-to-end outbound path: start() → drain
         // registration → mesh.collect_round_batch() pulls our entries.
         let mesh = MeshKV::new("node-a".into());
-        let adapter = adapter_with_empty_resolver(&mesh, "node-a");
+        let adapter = adapter_with_empty_handle(&mesh, "node-a");
         adapter.start();
 
         adapter.on_local_insert("model-1", delta(10, "http://w1"));
@@ -488,7 +453,7 @@ mod tests {
         // through the DrainRegistry would keep the adapter alive
         // until MeshKV drop. Verify via a `Weak::upgrade` check.
         let mesh = MeshKV::new("node-a".into());
-        let adapter = adapter_with_empty_resolver(&mesh, "node-a");
+        let adapter = adapter_with_empty_handle(&mesh, "node-a");
         adapter.start();
 
         let weak = Arc::downgrade(&adapter);
@@ -510,28 +475,28 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn handle_incoming_batch_consults_resolver() {
+    async fn handle_incoming_batch_consults_tree() {
         // Inbound deltas must be classified via the injected
-        // resolver. Hashes the resolver knows are "resolved"; those
-        // it doesn't are "unknown". The resolver itself is untouched
+        // tree. Hashes the tree handle knows are "resolved"; those
+        // it doesn't are "unknown". The tree handle itself is untouched
         // — `handle_incoming_batch` is read-only on membership.
         let mesh = MeshKV::new("node-a".into());
         let ns = td_namespace(&mesh);
-        let resolver = Arc::new(MockResolver::default());
-        resolver.insert("model-1", TreeKind::String, 42);
-        let adapter_resolver: Arc<dyn LocalHashResolver> = resolver.clone();
-        let adapter = TreeSyncAdapter::new(ns, adapter_resolver, "node-a".into());
+        let tree = Arc::new(MockTreeHandle::default());
+        tree.insert("model-1", TreeKind::String, 42);
+        let adapter_tree: Arc<dyn TreeHandle> = tree.clone();
+        let adapter = TreeSyncAdapter::new(ns, adapter_tree, "node-a".into());
 
         let batch = vec![
             TreeDelta {
                 tree_kind: TreeKind::String,
-                node_hash: 42, // known per resolver
+                node_hash: 42, // known per tree handle
                 worker_url: "http://w1".into(),
                 epoch: 1,
             },
             TreeDelta {
                 tree_kind: TreeKind::String,
-                node_hash: 99, // unknown per resolver
+                node_hash: 99, // unknown per tree handle
                 worker_url: "http://w2".into(),
                 epoch: 1,
             },
@@ -545,21 +510,21 @@ mod tests {
         let bytes = Bytes::from(bincode::serialize(&batch).unwrap());
         adapter.handle_incoming_batch("model-1", &[bytes]);
 
-        // Adapter neither mutates the resolver nor caches membership.
-        assert!(resolver.contains_hash("model-1", TreeKind::String, 42));
-        assert!(!resolver.contains_hash("model-1", TreeKind::String, 99));
-        assert!(!resolver.contains_hash("model-1", TreeKind::Token, 42));
+        // Adapter neither mutates the tree handle nor caches membership.
+        assert!(tree.contains_hash("model-1", TreeKind::String, 42));
+        assert!(!tree.contains_hash("model-1", TreeKind::String, 99));
+        assert!(!tree.contains_hash("model-1", TreeKind::Token, 42));
     }
 
     #[tokio::test]
     async fn handle_incoming_batch_ignores_malformed_payload() {
         // A corrupt batch must not propagate any state and must not
-        // panic. The resolver should never be queried since decode
+        // panic. The tree handle should never be queried since decode
         // fails before the per-delta loop.
         let mesh = MeshKV::new("node-a".into());
         let ns = td_namespace(&mesh);
-        let resolver: Arc<dyn LocalHashResolver> = Arc::new(MockResolver::default());
-        let adapter = TreeSyncAdapter::new(ns, resolver, "node-a".into());
+        let tree: Arc<dyn TreeHandle> = Arc::new(MockTreeHandle::default());
+        let adapter = TreeSyncAdapter::new(ns, tree, "node-a".into());
 
         adapter.handle_incoming_batch("model-1", &[Bytes::from_static(b"not-bincode")]);
     }
@@ -575,8 +540,8 @@ mod tests {
                 routing: StreamRouting::Targeted,
             },
         );
-        let resolver: Arc<dyn LocalHashResolver> = empty_resolver();
-        let _ = TreeSyncAdapter::new(ns, resolver, "node-a".into());
+        let tree: Arc<dyn TreeHandle> = empty_handle();
+        let _ = TreeSyncAdapter::new(ns, tree, "node-a".into());
     }
 
     #[tokio::test]
@@ -584,8 +549,8 @@ mod tests {
     async fn new_rejects_empty_node_name() {
         let mesh = MeshKV::new("node-a".into());
         let ns = td_namespace(&mesh);
-        let resolver: Arc<dyn LocalHashResolver> = empty_resolver();
-        let _ = TreeSyncAdapter::new(ns, resolver, String::new());
+        let tree: Arc<dyn TreeHandle> = empty_handle();
+        let _ = TreeSyncAdapter::new(ns, tree, String::new());
     }
 
     #[tokio::test]
@@ -596,7 +561,7 @@ mod tests {
         // loudly rather than register a phantom drain that the
         // OnceLock silently drops.
         let mesh = MeshKV::new("node-a".into());
-        let adapter = adapter_with_empty_resolver(&mesh, "node-a");
+        let adapter = adapter_with_empty_handle(&mesh, "node-a");
         adapter.start();
         adapter.start();
     }

--- a/model_gateway/src/mesh/adapters/tree_sync.rs
+++ b/model_gateway/src/mesh/adapters/tree_sync.rs
@@ -1,21 +1,26 @@
 //! `td:` / `tree:*` stream adapter: gateway ↔ mesh bridge for the
 //! distributed prefix tree.
 //!
-//! First slice (this PR): tenant-delta fast path only.
+//! Current scope: tenant-delta fast path + inbound hash resolution
+//! via an injected [`LocalHashResolver`]. The adapter holds no
+//! tree-membership state of its own — the tree-owning component
+//! (`CacheAwarePolicy` in production) is the single source of truth,
+//! implemented behind the trait so this adapter can test and evolve
+//! without a circular dependency on the policy.
+//!
 //! - Outbound: `on_local_insert` buffers per-model `TreeDelta`
 //!   entries. The mesh drain callback, called once per gossip round,
 //!   batches each model's buffer into a single `td:{model_id}`
 //!   stream entry (bincode-serialised `Vec<TreeDelta>`).
 //! - Inbound: a spawned task subscribes to `td:` and decodes
-//!   incoming batches. Apply-to-local-tree is deferred to the next
-//!   slice (hash index + resolution); for now, remote deltas are
-//!   logged for observability.
+//!   incoming batches. For each delta, the adapter asks the
+//!   resolver "do you have this node locally?" — known hashes log
+//!   at trace (the apply sink lands in the next slice), unknown
+//!   hashes log at debug (the repair request lands in the slice
+//!   after).
 //!
-//! Repair sessions (unknown-hash recovery, cold-start export/apply)
-//! are tracked by later PRs in the outer sequence. The adapter is
-//! intentionally scoped to the drain-and-subscribe shape here so the
-//! wire format and the outbound path can soak without pulling in the
-//! full session state machine.
+//! Repair sessions and the apply sink are deliberately not in this
+//! file yet so the resolver contract can soak on its own.
 
 use std::sync::{Arc, OnceLock};
 
@@ -57,11 +62,48 @@ pub struct TreeDelta {
     pub epoch: u64,
 }
 
+/// Answers "do we have this node in our local tree?" for incoming
+/// tenant deltas. Implemented by the tree-owning component
+/// (`CacheAwarePolicy` in production); injected into the adapter at
+/// construction so the adapter holds no tree-membership state of
+/// its own.
+///
+/// Why a trait here instead of a concrete handle:
+///
+/// - **Single source of truth.** `CacheAwarePolicy` already
+///   maintains `path_hash_index` for the string tree and will grow
+///   an equivalent for the token tree. Duplicating that state
+///   inside the adapter forces two parallel membership maps with
+///   lockstep sync discipline — and the wrong answer on a missed
+///   sync (false "unknown") routes to unnecessary repair.
+/// - **Multi-tenant correctness.** Tree nodes are shared across
+///   tenants; the policy's tree already knows whether any tenant
+///   still holds a node. The adapter can't reconstruct that from
+///   per-tenant event notifications without refcounting, which just
+///   shifts the same bookkeeping into the wrong module.
+/// - **Testability.** Tests use a trivial mock implementation of
+///   this trait without pulling in the full policy.
+///
+/// Implementors must be cheap on the read path — the adapter calls
+/// `contains_hash` once per incoming delta. A DashMap / HashSet
+/// lookup is appropriate; network or disk I/O is not.
+pub trait LocalHashResolver: Send + Sync + std::fmt::Debug {
+    /// Returns `true` if the local tree for `model_id` has a node
+    /// matching `node_hash` under the given `tree_kind`. String and
+    /// token trees have disjoint hash spaces — the implementer must
+    /// not conflate them.
+    fn contains_hash(&self, model_id: &str, tree_kind: TreeKind, node_hash: u64) -> bool;
+}
+
 /// Bridge between the `td:` broadcast stream namespace and the
 /// gateway's per-model tenant buffers.
 pub struct TreeSyncAdapter {
     tenant_deltas: Arc<StreamNamespace>,
     pending_deltas: DashMap<String, Vec<TreeDelta>>,
+    /// Hash-membership oracle provided by the tree owner. See the
+    /// [`LocalHashResolver`] docs for why this lives outside the
+    /// adapter.
+    resolver: Arc<dyn LocalHashResolver>,
     node_name: String,
     /// Keeps the drain registration alive for the adapter's lifetime.
     /// Dropping the handle unregisters from the mesh drain registry;
@@ -84,7 +126,11 @@ impl TreeSyncAdapter {
     /// and the local node name. Panics if the namespace prefix is
     /// wrong so a mis-wired caller fails loudly at startup instead
     /// of fanning deltas into the wrong stream.
-    pub fn new(tenant_deltas: Arc<StreamNamespace>, node_name: String) -> Arc<Self> {
+    pub fn new(
+        tenant_deltas: Arc<StreamNamespace>,
+        resolver: Arc<dyn LocalHashResolver>,
+        node_name: String,
+    ) -> Arc<Self> {
         assert_eq!(
             tenant_deltas.prefix(),
             PREFIX,
@@ -97,6 +143,7 @@ impl TreeSyncAdapter {
         Arc::new(Self {
             tenant_deltas,
             pending_deltas: DashMap::new(),
+            resolver,
             node_name,
             drain_handle: OnceLock::new(),
         })
@@ -128,6 +175,13 @@ impl TreeSyncAdapter {
             "TreeSyncAdapter::start called more than once",
         );
 
+        // Same `Weak` pattern for the subscription task: a strong
+        // `Arc<Self>` captured in the spawned future would keep the
+        // adapter alive until MeshKV drops the subscription channel,
+        // even if the caller has explicitly dropped its last
+        // reference. Upgrade per iteration and exit the loop on
+        // first-None so the task releases cleanly.
+        let sub_owner = Arc::downgrade(self);
         let mut sub = self.tenant_deltas.subscribe("");
         #[expect(
             clippy::disallowed_methods,
@@ -135,12 +189,16 @@ impl TreeSyncAdapter {
         )]
         tokio::spawn(async move {
             while let Some((key, value)) = sub.receiver.recv().await {
+                let Some(this) = sub_owner.upgrade() else {
+                    debug!("TreeSyncAdapter dropped, exiting tenant-delta subscription");
+                    break;
+                };
                 let Some(model_id) = key.strip_prefix(PREFIX).filter(|s| !s.is_empty()) else {
                     warn!(key, "td: subscription yielded unexpected key shape");
                     continue;
                 };
                 match value {
-                    Some(fragments) => Self::handle_incoming_batch(model_id, &fragments),
+                    Some(fragments) => this.handle_incoming_batch(model_id, &fragments),
                     None => {
                         // Stream namespaces don't emit tombstones in
                         // the current mesh, but the subscription API
@@ -215,34 +273,54 @@ impl TreeSyncAdapter {
         entries
     }
 
-    fn handle_incoming_batch(model_id: &str, fragments: &[Bytes]) {
+    fn handle_incoming_batch(&self, model_id: &str, fragments: &[Bytes]) {
         let total = fragments.iter().map(Bytes::len).sum();
         let mut bytes = Vec::with_capacity(total);
         for frag in fragments {
             bytes.extend_from_slice(frag);
         }
-        match bincode::deserialize::<Vec<TreeDelta>>(&bytes) {
-            Ok(batch) => {
+        let batch: Vec<TreeDelta> = match bincode::deserialize(&bytes) {
+            Ok(batch) => batch,
+            Err(err) => {
+                warn!(model_id, %err, "failed to decode tenant-delta batch");
+                return;
+            }
+        };
+        debug!(
+            model_id,
+            count = batch.len(),
+            "remote tenant-delta batch received"
+        );
+        for delta in &batch {
+            if self
+                .resolver
+                .contains_hash(model_id, delta.tree_kind, delta.node_hash)
+            {
+                // Hash is locally known. Applying the tenant to the
+                // matched tree node lands in the next slice via an
+                // apply sink; for now, just log.
+                trace!(
+                    model_id,
+                    kind = ?delta.tree_kind,
+                    hash = delta.node_hash,
+                    worker_url = %delta.worker_url,
+                    epoch = delta.epoch,
+                    "resolved remote tenant delta against local resolver",
+                );
+            } else {
+                // Unknown hash — the repair-request slice will turn
+                // this into a `tree:req:` message. For now, debug-log
+                // so soak runs can see unresolved deltas without
+                // inflating the trace stream.
                 debug!(
                     model_id,
-                    count = batch.len(),
-                    "remote tenant-delta batch received"
+                    kind = ?delta.tree_kind,
+                    hash = delta.node_hash,
+                    worker_url = %delta.worker_url,
+                    epoch = delta.epoch,
+                    "unknown remote tenant delta hash (repair deferred to next slice)",
                 );
-                // Apply + unknown-hash repair are in the next slice.
-                // For now, trace-log each delta so observability is
-                // available during manual soak.
-                for delta in &batch {
-                    trace!(
-                        model_id,
-                        kind = ?delta.tree_kind,
-                        hash = delta.node_hash,
-                        worker_url = %delta.worker_url,
-                        epoch = delta.epoch,
-                        "remote tenant delta",
-                    );
-                }
             }
-            Err(err) => warn!(model_id, %err, "failed to decode tenant-delta batch"),
         }
     }
 }
@@ -272,6 +350,43 @@ mod tests {
         }
     }
 
+    /// Test-only implementation of [`LocalHashResolver`]. Keyed by
+    /// `(model_id, TreeKind)` with a set of known hashes. The real
+    /// resolver will live on `CacheAwarePolicy` and be backed by the
+    /// policy's `path_hash_index` / token-tree index — this mock
+    /// only needs to answer the contract, not mirror the policy.
+    #[derive(Debug, Default)]
+    struct MockResolver {
+        known: DashMap<(String, TreeKind), DashMap<u64, ()>>,
+    }
+
+    impl MockResolver {
+        fn insert(&self, model_id: &str, tree_kind: TreeKind, node_hash: u64) {
+            self.known
+                .entry((model_id.to_string(), tree_kind))
+                .or_default()
+                .insert(node_hash, ());
+        }
+    }
+
+    impl LocalHashResolver for MockResolver {
+        fn contains_hash(&self, model_id: &str, tree_kind: TreeKind, node_hash: u64) -> bool {
+            self.known
+                .get(&(model_id.to_string(), tree_kind))
+                .is_some_and(|entry| entry.contains_key(&node_hash))
+        }
+    }
+
+    fn empty_resolver() -> Arc<MockResolver> {
+        Arc::new(MockResolver::default())
+    }
+
+    fn adapter_with_empty_resolver(mesh: &MeshKV, node_name: &str) -> Arc<TreeSyncAdapter> {
+        let ns = td_namespace(mesh);
+        let resolver: Arc<dyn LocalHashResolver> = empty_resolver();
+        TreeSyncAdapter::new(ns, resolver, node_name.into())
+    }
+
     #[tokio::test]
     async fn tree_delta_bincode_round_trip() {
         let batch = vec![
@@ -296,8 +411,7 @@ mod tests {
     #[tokio::test]
     async fn on_local_insert_buffers_per_model() {
         let mesh = MeshKV::new("node-a".into());
-        let ns = td_namespace(&mesh);
-        let adapter = TreeSyncAdapter::new(ns, "node-a".into());
+        let adapter = adapter_with_empty_resolver(&mesh, "node-a");
 
         adapter.on_local_insert("model-1", delta(1, "http://w1"));
         adapter.on_local_insert("model-1", delta(2, "http://w1"));
@@ -310,8 +424,7 @@ mod tests {
     #[tokio::test]
     async fn drain_batches_per_model_and_clears_buffer() {
         let mesh = MeshKV::new("node-a".into());
-        let ns = td_namespace(&mesh);
-        let adapter = TreeSyncAdapter::new(ns, "node-a".into());
+        let adapter = adapter_with_empty_resolver(&mesh, "node-a");
 
         adapter.on_local_insert("model-1", delta(1, "http://w1"));
         adapter.on_local_insert("model-1", delta(2, "http://w1"));
@@ -340,8 +453,7 @@ mod tests {
         // and then clears a model, the next drain must not emit an
         // empty batch (empty batches would burn gossip bandwidth).
         let mesh = MeshKV::new("node-a".into());
-        let ns = td_namespace(&mesh);
-        let adapter = TreeSyncAdapter::new(ns, "node-a".into());
+        let adapter = adapter_with_empty_resolver(&mesh, "node-a");
 
         adapter
             .pending_deltas
@@ -356,8 +468,7 @@ mod tests {
         // Exercise the end-to-end outbound path: start() → drain
         // registration → mesh.collect_round_batch() pulls our entries.
         let mesh = MeshKV::new("node-a".into());
-        let ns = td_namespace(&mesh);
-        let adapter = TreeSyncAdapter::new(ns, "node-a".into());
+        let adapter = adapter_with_empty_resolver(&mesh, "node-a");
         adapter.start();
 
         adapter.on_local_insert("model-1", delta(10, "http://w1"));
@@ -377,8 +488,7 @@ mod tests {
         // through the DrainRegistry would keep the adapter alive
         // until MeshKV drop. Verify via a `Weak::upgrade` check.
         let mesh = MeshKV::new("node-a".into());
-        let ns = td_namespace(&mesh);
-        let adapter = TreeSyncAdapter::new(ns, "node-a".into());
+        let adapter = adapter_with_empty_resolver(&mesh, "node-a");
         adapter.start();
 
         let weak = Arc::downgrade(&adapter);
@@ -400,6 +510,61 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn handle_incoming_batch_consults_resolver() {
+        // Inbound deltas must be classified via the injected
+        // resolver. Hashes the resolver knows are "resolved"; those
+        // it doesn't are "unknown". The resolver itself is untouched
+        // — `handle_incoming_batch` is read-only on membership.
+        let mesh = MeshKV::new("node-a".into());
+        let ns = td_namespace(&mesh);
+        let resolver = Arc::new(MockResolver::default());
+        resolver.insert("model-1", TreeKind::String, 42);
+        let adapter_resolver: Arc<dyn LocalHashResolver> = resolver.clone();
+        let adapter = TreeSyncAdapter::new(ns, adapter_resolver, "node-a".into());
+
+        let batch = vec![
+            TreeDelta {
+                tree_kind: TreeKind::String,
+                node_hash: 42, // known per resolver
+                worker_url: "http://w1".into(),
+                epoch: 1,
+            },
+            TreeDelta {
+                tree_kind: TreeKind::String,
+                node_hash: 99, // unknown per resolver
+                worker_url: "http://w2".into(),
+                epoch: 1,
+            },
+            TreeDelta {
+                tree_kind: TreeKind::Token,
+                node_hash: 42, // same hash but different kind — must not alias
+                worker_url: "http://w3".into(),
+                epoch: 1,
+            },
+        ];
+        let bytes = Bytes::from(bincode::serialize(&batch).unwrap());
+        adapter.handle_incoming_batch("model-1", &[bytes]);
+
+        // Adapter neither mutates the resolver nor caches membership.
+        assert!(resolver.contains_hash("model-1", TreeKind::String, 42));
+        assert!(!resolver.contains_hash("model-1", TreeKind::String, 99));
+        assert!(!resolver.contains_hash("model-1", TreeKind::Token, 42));
+    }
+
+    #[tokio::test]
+    async fn handle_incoming_batch_ignores_malformed_payload() {
+        // A corrupt batch must not propagate any state and must not
+        // panic. The resolver should never be queried since decode
+        // fails before the per-delta loop.
+        let mesh = MeshKV::new("node-a".into());
+        let ns = td_namespace(&mesh);
+        let resolver: Arc<dyn LocalHashResolver> = Arc::new(MockResolver::default());
+        let adapter = TreeSyncAdapter::new(ns, resolver, "node-a".into());
+
+        adapter.handle_incoming_batch("model-1", &[Bytes::from_static(b"not-bincode")]);
+    }
+
+    #[tokio::test]
     #[should_panic(expected = "TreeSyncAdapter requires a tenant-delta namespace scoped to `td:`")]
     async fn new_rejects_wrong_prefix() {
         let mesh = MeshKV::new("node-a".into());
@@ -410,7 +575,8 @@ mod tests {
                 routing: StreamRouting::Targeted,
             },
         );
-        let _ = TreeSyncAdapter::new(ns, "node-a".into());
+        let resolver: Arc<dyn LocalHashResolver> = empty_resolver();
+        let _ = TreeSyncAdapter::new(ns, resolver, "node-a".into());
     }
 
     #[tokio::test]
@@ -418,7 +584,8 @@ mod tests {
     async fn new_rejects_empty_node_name() {
         let mesh = MeshKV::new("node-a".into());
         let ns = td_namespace(&mesh);
-        let _ = TreeSyncAdapter::new(ns, String::new());
+        let resolver: Arc<dyn LocalHashResolver> = empty_resolver();
+        let _ = TreeSyncAdapter::new(ns, resolver, String::new());
     }
 
     #[tokio::test]
@@ -429,8 +596,7 @@ mod tests {
         // loudly rather than register a phantom drain that the
         // OnceLock silently drops.
         let mesh = MeshKV::new("node-a".into());
-        let ns = td_namespace(&mesh);
-        let adapter = TreeSyncAdapter::new(ns, "node-a".into());
+        let adapter = adapter_with_empty_resolver(&mesh, "node-a");
         adapter.start();
         adapter.start();
     }

--- a/model_gateway/src/mesh/mod.rs
+++ b/model_gateway/src/mesh/mod.rs
@@ -4,7 +4,4 @@
 
 pub mod adapters;
 
-pub use adapters::{
-    LocalHashResolver, RateLimitSyncAdapter, TreeDelta, TreeKind, TreeSyncAdapter,
-    WorkerSyncAdapter,
-};
+pub use adapters::{RateLimitSyncAdapter, TreeDelta, TreeSyncAdapter, WorkerSyncAdapter};

--- a/model_gateway/src/mesh/mod.rs
+++ b/model_gateway/src/mesh/mod.rs
@@ -4,4 +4,7 @@
 
 pub mod adapters;
 
-pub use adapters::{RateLimitSyncAdapter, TreeDelta, TreeKind, TreeSyncAdapter, WorkerSyncAdapter};
+pub use adapters::{
+    LocalHashResolver, RateLimitSyncAdapter, TreeDelta, TreeKind, TreeSyncAdapter,
+    WorkerSyncAdapter,
+};

--- a/model_gateway/src/policies/cache_aware.rs
+++ b/model_gateway/src/policies/cache_aware.rs
@@ -85,11 +85,18 @@ pub struct CacheAwarePolicy {
     /// Spec §7.1 mandates model scoping: the same hash can refer
     /// to different prefixes in different models, so a global
     /// index mis-routes multi-model deployments. Bounded by
-    /// eviction at `max_tree_size` total entries and by per-entry
-    /// payload size: every populate site stores the prior shared
-    /// prefix from a pre-insert match, never the full input. A
-    /// 32K-token request therefore costs O(matched-prefix), not
-    /// O(input), keeping the worst-case bytes/entry small.
+    /// eviction at `max_tree_size` total entries.
+    ///
+    /// Per-entry value semantics differ by populate site:
+    /// - `select_worker_*` (request hot paths) store the prior
+    ///   shared prefix from a pre-insert match. Bytes/entry is
+    ///   bounded by tree depth, not input size — a 32K-token
+    ///   request costs O(matched-prefix), not O(input).
+    /// - `apply_insert_to_trees` (snapshot/restore replay) stores
+    ///   the full inserted path because `apply_tenant_delta`
+    ///   re-inserts whatever value is stored, and the canonical
+    ///   path is required to attach tenants at the right node.
+    ///   This path runs at replay frequency, not request rate.
     hash_index: Arc<DashMap<String, PerModelHashIndex>>,
 }
 
@@ -375,31 +382,33 @@ impl CacheAwarePolicy {
         token_tree: &Arc<TokenTree>,
         insert_op: &TreeInsertOp,
     ) {
+        // Replay/restore path: store the FULL inserted path, not a
+        // matched prefix. `apply_tenant_delta` re-inserts whatever
+        // value is stored (line 460), so the canonical path is
+        // required to attach remote tenants at the correct node.
+        // On cold start the local tree is empty → a pre-insert
+        // `match_prefix_with_counts` would return 0 → storing ""
+        // would later cause `insert_text("", remote_worker)`,
+        // attaching the worker at root and tainting routing for
+        // every request to this model. This path runs at replay
+        // frequency (cold start, snapshot reconciliation), not per
+        // request, so the unbounded value cost is acceptable.
         match &insert_op.key {
             TreeKey::Text(text) => {
-                // Match BEFORE insert: post-insert the tree contains
-                // a full path for `text`, so the match would return
-                // the entire input length and we'd store the full
-                // prompt — exactly the memory bloat we avoid on the
-                // local cache-aware paths.
-                let result = string_tree.match_prefix_with_counts(text);
-                let matched_prefix: String = text.chars().take(result.matched_char_count).collect();
                 string_tree.insert_text(text, &insert_op.tenant);
                 self.hash_index
                     .entry(model_id.to_string())
                     .or_default()
                     .string_tree
-                    .insert(smg_mesh::hash_node_path(text), matched_prefix);
+                    .insert(smg_mesh::hash_node_path(text), text.clone());
             }
             TreeKey::Tokens(tokens) => {
-                let result = token_tree.match_prefix_with_counts(tokens);
-                let matched_prefix: Vec<u32> = tokens[..result.matched_token_count].to_vec();
                 token_tree.insert_tokens(tokens, &insert_op.tenant);
                 self.hash_index
                     .entry(model_id.to_string())
                     .or_default()
                     .token_tree
-                    .insert(smg_mesh::hash_token_path(tokens), matched_prefix);
+                    .insert(smg_mesh::hash_token_path(tokens), tokens.clone());
             }
         }
     }

--- a/model_gateway/src/policies/cache_aware.rs
+++ b/model_gateway/src/policies/cache_aware.rs
@@ -55,8 +55,6 @@ use super::{
     get_healthy_worker_indices, normalize_model_key, utils::PeriodicTask, CacheAwareConfig,
     LoadBalancingPolicy, SelectWorkerInfo,
 };
-#[cfg(test)]
-use crate::worker::UNKNOWN_MODEL_ID;
 use crate::worker::{KvEventMonitor, Worker};
 
 /// Cache-aware routing policy
@@ -1031,7 +1029,7 @@ mod tests {
     use openai_protocol::worker::{HealthCheckConfig, WorkerStatus};
 
     use super::*;
-    use crate::worker::{BasicWorkerBuilder, WorkerType};
+    use crate::worker::{BasicWorkerBuilder, WorkerType, UNKNOWN_MODEL_ID};
 
     fn no_health_check() -> HealthCheckConfig {
         HealthCheckConfig {

--- a/model_gateway/src/policies/cache_aware.rs
+++ b/model_gateway/src/policies/cache_aware.rs
@@ -85,12 +85,11 @@ pub struct CacheAwarePolicy {
     /// Spec §7.1 mandates model scoping: the same hash can refer
     /// to different prefixes in different models, so a global
     /// index mis-routes multi-model deployments. Bounded by
-    /// eviction at `max_tree_size` total entries.
-    ///
-    /// String side stores the matched prefix (short) rather than
-    /// the full prompt text; remote apply re-inserts by that
-    /// prefix. Token side stores the full token sequence — v1
-    /// had no token hash index, so this is new v2 plumbing.
+    /// eviction at `max_tree_size` total entries and by per-entry
+    /// payload size: every populate site stores the prior shared
+    /// prefix from a pre-insert match, never the full input. A
+    /// 32K-token request therefore costs O(matched-prefix), not
+    /// O(input), keeping the worst-case bytes/entry small.
     hash_index: Arc<DashMap<String, PerModelHashIndex>>,
 }
 
@@ -378,20 +377,29 @@ impl CacheAwarePolicy {
     ) {
         match &insert_op.key {
             TreeKey::Text(text) => {
+                // Match BEFORE insert: post-insert the tree contains
+                // a full path for `text`, so the match would return
+                // the entire input length and we'd store the full
+                // prompt — exactly the memory bloat we avoid on the
+                // local cache-aware paths.
+                let result = string_tree.match_prefix_with_counts(text);
+                let matched_prefix: String = text.chars().take(result.matched_char_count).collect();
                 string_tree.insert_text(text, &insert_op.tenant);
                 self.hash_index
                     .entry(model_id.to_string())
                     .or_default()
                     .string_tree
-                    .insert(smg_mesh::hash_node_path(text), text.clone());
+                    .insert(smg_mesh::hash_node_path(text), matched_prefix);
             }
             TreeKey::Tokens(tokens) => {
+                let result = token_tree.match_prefix_with_counts(tokens);
+                let matched_prefix: Vec<u32> = tokens[..result.matched_token_count].to_vec();
                 token_tree.insert_tokens(tokens, &insert_op.tenant);
                 self.hash_index
                     .entry(model_id.to_string())
                     .or_default()
                     .token_tree
-                    .insert(smg_mesh::hash_token_path(tokens), tokens.clone());
+                    .insert(smg_mesh::hash_token_path(tokens), matched_prefix);
             }
         }
     }
@@ -622,12 +630,21 @@ impl CacheAwarePolicy {
                 .get(model_id)
                 .map(|entry| entry.value().clone());
             if let Some(tree) = tree {
+                // Match BEFORE insert (mirrors the string-side
+                // imbalanced path below). After `insert_tokens`,
+                // the tree contains a full path for `tokens` so a
+                // match returns the entire input length and we'd
+                // store the full sequence — at 32K tokens × 4 bytes
+                // × max_tree_size that's multi-GB per model.
+                let result = tree.match_prefix_with_counts(tokens);
+                let matched_prefix: Vec<u32> = tokens[..result.matched_token_count].to_vec();
+
                 tree.insert_tokens(tokens, worker_url);
                 self.hash_index
                     .entry(model_id.to_string())
                     .or_default()
                     .token_tree
-                    .insert(smg_mesh::hash_token_path(tokens), tokens.to_vec());
+                    .insert(smg_mesh::hash_token_path(tokens), matched_prefix);
                 self.sync_insert_tokens(model_id, tokens, worker_url);
             }
         } else if let Some(text) = info.request_text {
@@ -923,14 +940,23 @@ impl CacheAwarePolicy {
             if let Some(idx) = selected_idx {
                 tree.insert_tokens(tokens, workers[idx].url());
 
-                // v1 never populated a token hash index; v2's
-                // `TreeHandle` impl consults this map per incoming
-                // token delta, so maintain it alongside the tree.
+                // Record hash(full_tokens)→matched_prefix tokens.
+                // The hash key matches what sync_tree_operation
+                // sends on the wire (hash of full sequence). The
+                // VALUE is only the matched prefix — not the full
+                // sequence (32K tokens × 4 bytes = 128 KB worst
+                // case). v1 never populated a token hash index;
+                // v2's `TreeHandle` impl consults this map per
+                // incoming token delta, so maintain it alongside
+                // the tree. Mirrors the string side at the
+                // analogous block; reuses the match `result`
+                // already computed at the top of this branch.
+                let matched_prefix: Vec<u32> = tokens[..result.matched_token_count].to_vec();
                 self.hash_index
                     .entry(model_id.to_string())
                     .or_default()
                     .token_tree
-                    .insert(smg_mesh::hash_token_path(tokens), tokens.to_vec());
+                    .insert(smg_mesh::hash_token_path(tokens), matched_prefix);
 
                 self.sync_insert_tokens(model_id, tokens, workers[idx].url());
                 workers[idx].increment_processed();

--- a/model_gateway/src/policies/cache_aware.rs
+++ b/model_gateway/src/policies/cache_aware.rs
@@ -638,17 +638,17 @@ impl CacheAwarePolicy {
                 .map(|entry| entry.value().clone());
 
             if let Some(tree) = tree {
-                tree.insert_text(text, worker_url);
-
-                // Populate hash_index with the matched prefix, not
-                // the full prompt text. Running the match here adds
-                // a small CPU cost on the imbalanced fallback
-                // (microseconds per request), but storing the short
-                // matched_prefix (~50-200 chars) instead of the full
-                // text (80k+) avoids the memory leak v1 called out.
-                // Matches the happy-path populate pattern.
+                // Match BEFORE insert: after `insert_text`, the
+                // tree contains a full path for `text` so a match
+                // would return the entire input length and we'd
+                // store the full prompt — exactly the memory leak
+                // we're trying to avoid. The pre-insert match
+                // returns the prior shared prefix (~50-200 chars).
                 let result = tree.match_prefix_with_counts(text);
                 let matched_prefix: String = text.chars().take(result.matched_char_count).collect();
+
+                tree.insert_text(text, worker_url);
+
                 let path_hash = smg_mesh::hash_node_path(text);
                 self.hash_index
                     .entry(model_id.to_string())

--- a/model_gateway/src/policies/cache_aware.rs
+++ b/model_gateway/src/policies/cache_aware.rs
@@ -47,6 +47,7 @@ use dashmap::DashMap;
 use kv_index::{compute_request_content_hashes, PositionalIndexer, TokenTree, Tree};
 use parking_lot::RwLock;
 use rand::Rng;
+use serde::{Deserialize, Serialize};
 use smg_mesh::{OptionalMeshSyncManager, TreeInsertOp, TreeKey, TreeOperation};
 use tracing::{debug, warn};
 
@@ -89,6 +90,22 @@ pub struct CacheAwarePolicy {
     /// compound key `(model_id, hash)` or hashing `model_id\0text` would be
     /// correct.  Deferring to a follow-up to avoid changing the wire format.
     path_hash_index: Arc<DashMap<u64, String>>,
+
+    /// Mirror of `path_hash_index` for the token tree. Populated on
+    /// local token-based inserts and consulted by the v2
+    /// [`LocalHashResolver`] implementation so incoming token deltas
+    /// can be classified known/unknown without a repair round trip.
+    /// Value is the full `Vec<u32>` tokens for the hashed prefix —
+    /// mirrors the string side, which stores the matched prefix so
+    /// repair/apply paths can reconstruct the node from hash alone.
+    /// Bounded by the same periodic eviction as `path_hash_index`.
+    ///
+    /// v1's `apply_tenant_delta` only touches the string tree
+    /// (line 408 comment: "token-based inserts do NOT populate
+    /// path_hash_index"); the token side is entirely new v2
+    /// plumbing, so any pre-v2 gap here is preserved unchanged —
+    /// no remote token deltas existed to apply.
+    token_path_hash_index: Arc<DashMap<u64, Vec<u32>>>,
 }
 
 impl CacheAwarePolicy {
@@ -100,12 +117,14 @@ impl CacheAwarePolicy {
         let string_trees = Arc::new(DashMap::<String, Arc<Tree>>::new());
         let token_trees = Arc::new(DashMap::<String, Arc<TokenTree>>::new());
         let path_hash_index = Arc::new(DashMap::<u64, String>::new());
+        let token_path_hash_index = Arc::new(DashMap::<u64, Vec<u32>>::new());
 
         // Start background eviction thread if configured
         let eviction_task = if config.eviction_interval_secs > 0 {
             let string_trees_clone = Arc::clone(&string_trees);
             let token_trees_clone = Arc::clone(&token_trees);
             let path_hash_index_clone = Arc::clone(&path_hash_index);
+            let token_path_hash_index_clone = Arc::clone(&token_path_hash_index);
             let max_tree_size = config.max_tree_size;
 
             Some(PeriodicTask::spawn(
@@ -143,16 +162,24 @@ impl CacheAwarePolicy {
                             max_tree_size
                         );
                     }
+                    if token_path_hash_index_clone.len() > max_tree_size {
+                        token_path_hash_index_clone.clear();
+                        debug!(
+                            "Token path hash index cleared (exceeded max_tree_size: {})",
+                            max_tree_size
+                        );
+                    }
 
                     // Log tree sizes — use model count + path_hash_index only.
                     // DO NOT call tree.snapshot() here — it clones all edge text
                     // (~170 MB) every eviction cycle, causing allocator fragmentation.
                     tracing::info!(
                         "Tree memory: string_trees={} models, token_trees={} models, \
-                         path_hash_index={} entries",
+                         path_hash_index={} entries, token_path_hash_index={} entries",
                         string_trees_clone.len(),
                         token_trees_clone.len(),
                         path_hash_index_clone.len(),
+                        token_path_hash_index_clone.len(),
                     );
                 },
             ))
@@ -168,6 +195,7 @@ impl CacheAwarePolicy {
             _eviction_task: eviction_task,
             kv_monitor: RwLock::new(None),
             path_hash_index,
+            token_path_hash_index,
         }
     }
 
@@ -557,6 +585,8 @@ impl CacheAwarePolicy {
                 .map(|entry| entry.value().clone());
             if let Some(tree) = tree {
                 tree.insert_tokens(tokens, worker_url);
+                self.token_path_hash_index
+                    .insert(smg_mesh::hash_token_path(tokens), tokens.to_vec());
                 self.sync_insert_tokens(model_id, tokens, worker_url);
             }
         } else if let Some(text) = info.request_text {
@@ -589,6 +619,30 @@ impl CacheAwarePolicy {
         workers[min_load_idx].increment_processed();
 
         Some(min_load_idx)
+    }
+}
+
+/// Which of the two local trees a hash query targets.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum TreeKind {
+    String,
+    Token,
+}
+
+/// Read-only handle the policy exposes so mesh-adjacent consumers
+/// can answer "is this hash known locally?" without reaching into
+/// private fields. Defined here (not in the adapter) to keep the
+/// dependency direction `adapter → policy`.
+pub trait TreeHandle: Send + Sync + std::fmt::Debug {
+    fn contains_hash(&self, model_id: &str, tree_kind: TreeKind, node_hash: u64) -> bool;
+}
+
+impl TreeHandle for CacheAwarePolicy {
+    fn contains_hash(&self, _model_id: &str, tree_kind: TreeKind, node_hash: u64) -> bool {
+        match tree_kind {
+            TreeKind::String => self.path_hash_index.contains_key(&node_hash),
+            TreeKind::Token => self.token_path_hash_index.contains_key(&node_hash),
+        }
     }
 }
 
@@ -815,11 +869,19 @@ impl CacheAwarePolicy {
             if let Some(idx) = selected_idx {
                 tree.insert_tokens(tokens, workers[idx].url());
 
-                // Note: token-based inserts do NOT populate path_hash_index.
-                // Token hashes can't be resolved back to the original token
-                // sequence on the receiving side. Token trees rely on Layer 2
-                // (periodic structure snapshots) for cross-node convergence,
-                // not tenant deltas.
+                // v1 did not populate a token hash index — v1's
+                // `apply_tenant_delta` only touches the string tree,
+                // so there was nothing on the receiving side to
+                // resolve. v2's `TreeSyncAdapter` consults the
+                // `LocalHashResolver` impl below on every incoming
+                // token delta, so the token hash → tokens mapping
+                // has to be maintained alongside the string side.
+                // The `Vec<u32>` value mirrors the string side's
+                // matched-prefix value: future repair/apply paths can
+                // reconstruct the tree node from hash alone.
+                self.token_path_hash_index
+                    .insert(smg_mesh::hash_token_path(tokens), tokens.to_vec());
+
                 self.sync_insert_tokens(model_id, tokens, workers[idx].url());
                 workers[idx].increment_processed();
                 return Some(idx);

--- a/model_gateway/src/policies/cache_aware.rs
+++ b/model_gateway/src/policies/cache_aware.rs
@@ -640,13 +640,21 @@ impl CacheAwarePolicy {
             if let Some(tree) = tree {
                 tree.insert_text(text, worker_url);
 
-                // Don't populate path_hash_index here — we don't have a
-                // match result and storing the full prompt text (80k+ chars)
-                // would recreate the memory leak. Layer 2 snapshots handle
-                // convergence for entries from the imbalanced-load path.
-
-                // Use hash-based sync to avoid 80k+ String clone.
+                // Populate hash_index with the matched prefix, not
+                // the full prompt text. Running the match here adds
+                // a small CPU cost on the imbalanced fallback
+                // (microseconds per request), but storing the short
+                // matched_prefix (~50-200 chars) instead of the full
+                // text (80k+) avoids the memory leak v1 called out.
+                // Matches the happy-path populate pattern.
+                let result = tree.match_prefix_with_counts(text);
+                let matched_prefix: String = text.chars().take(result.matched_char_count).collect();
                 let path_hash = smg_mesh::hash_node_path(text);
+                self.hash_index
+                    .entry(model_id.to_string())
+                    .or_default()
+                    .string_tree
+                    .insert(path_hash, matched_prefix);
                 self.sync_insert_hash(model_id, path_hash, worker_url);
             } else {
                 debug!(

--- a/model_gateway/src/policies/cache_aware.rs
+++ b/model_gateway/src/policies/cache_aware.rs
@@ -91,20 +91,14 @@ pub struct CacheAwarePolicy {
     /// correct.  Deferring to a follow-up to avoid changing the wire format.
     path_hash_index: Arc<DashMap<u64, String>>,
 
-    /// Mirror of `path_hash_index` for the token tree. Populated on
-    /// local token-based inserts and consulted by the v2
-    /// [`LocalHashResolver`] implementation so incoming token deltas
-    /// can be classified known/unknown without a repair round trip.
-    /// Value is the full `Vec<u32>` tokens for the hashed prefix —
-    /// mirrors the string side, which stores the matched prefix so
-    /// repair/apply paths can reconstruct the node from hash alone.
-    /// Bounded by the same periodic eviction as `path_hash_index`.
-    ///
-    /// v1's `apply_tenant_delta` only touches the string tree
-    /// (line 408 comment: "token-based inserts do NOT populate
-    /// path_hash_index"); the token side is entirely new v2
-    /// plumbing, so any pre-v2 gap here is preserved unchanged —
-    /// no remote token deltas existed to apply.
+    /// Token-tree counterpart to `path_hash_index`. Populated on
+    /// local token inserts and consulted by the [`TreeHandle`] impl
+    /// so incoming token deltas can be classified known/unknown.
+    /// Stores the full token sequence so future repair/apply paths
+    /// can reconstruct the node from hash alone. Bounded by the
+    /// same periodic eviction as `path_hash_index`. v1 had no token
+    /// hash index (v1's `apply_tenant_delta` only touched the
+    /// string tree), so the token side is entirely new v2 plumbing.
     token_path_hash_index: Arc<DashMap<u64, Vec<u32>>>,
 }
 
@@ -869,16 +863,11 @@ impl CacheAwarePolicy {
             if let Some(idx) = selected_idx {
                 tree.insert_tokens(tokens, workers[idx].url());
 
-                // v1 did not populate a token hash index — v1's
-                // `apply_tenant_delta` only touches the string tree,
-                // so there was nothing on the receiving side to
-                // resolve. v2's `TreeSyncAdapter` consults the
-                // `LocalHashResolver` impl below on every incoming
-                // token delta, so the token hash → tokens mapping
-                // has to be maintained alongside the string side.
-                // The `Vec<u32>` value mirrors the string side's
-                // matched-prefix value: future repair/apply paths can
-                // reconstruct the tree node from hash alone.
+                // v1 never populated a token hash index (its
+                // `apply_tenant_delta` only touched the string
+                // tree). v2's `TreeHandle` impl consults this map
+                // on every incoming token delta, so we maintain it
+                // alongside the string side.
                 self.token_path_hash_index
                     .insert(smg_mesh::hash_token_path(tokens), tokens.to_vec());
 

--- a/model_gateway/src/policies/cache_aware.rs
+++ b/model_gateway/src/policies/cache_aware.rs
@@ -384,8 +384,8 @@ impl CacheAwarePolicy {
     ) {
         // Replay/restore path: store the FULL inserted path, not a
         // matched prefix. `apply_tenant_delta` re-inserts whatever
-        // value is stored (line 460), so the canonical path is
-        // required to attach remote tenants at the correct node.
+        // value is stored, so the canonical path is required to
+        // attach remote tenants at the correct node.
         // On cold start the local tree is empty → a pre-insert
         // `match_prefix_with_counts` would return 0 → storing ""
         // would later cause `insert_text("", remote_worker)`,

--- a/model_gateway/src/policies/cache_aware.rs
+++ b/model_gateway/src/policies/cache_aware.rs
@@ -354,17 +354,44 @@ impl CacheAwarePolicy {
             .or_insert_with(|| Arc::new(TokenTree::new()))
             .clone();
 
-        Self::apply_insert_to_trees(&string_tree, &token_tree, insert_op);
+        self.apply_insert_to_trees(model_id, &string_tree, &token_tree, insert_op);
     }
 
+    /// Apply a tree insert and populate the model-scoped hash
+    /// index alongside it. Remote-replay paths
+    /// (`apply_remote_tree_operation`, `restore_tree_state_from_mesh`)
+    /// funnel here, so `TreeHandle::contains_hash` reflects nodes
+    /// learned from gossip — not just locally-routed inserts.
+    /// Without this, replayed prefixes would be misclassified as
+    /// unknown and trigger unnecessary repair once the adapter is
+    /// wired up. The string-side value is the full `text` (not a
+    /// matched prefix) because remote apply doesn't compute a
+    /// match; `apply_tenant_delta` re-inserts whatever string is
+    /// stored.
     fn apply_insert_to_trees(
+        &self,
+        model_id: &str,
         string_tree: &Arc<Tree>,
         token_tree: &Arc<TokenTree>,
         insert_op: &TreeInsertOp,
     ) {
         match &insert_op.key {
-            TreeKey::Text(text) => string_tree.insert_text(text, &insert_op.tenant),
-            TreeKey::Tokens(tokens) => token_tree.insert_tokens(tokens, &insert_op.tenant),
+            TreeKey::Text(text) => {
+                string_tree.insert_text(text, &insert_op.tenant);
+                self.hash_index
+                    .entry(model_id.to_string())
+                    .or_default()
+                    .string_tree
+                    .insert(smg_mesh::hash_node_path(text), text.clone());
+            }
+            TreeKey::Tokens(tokens) => {
+                token_tree.insert_tokens(tokens, &insert_op.tenant);
+                self.hash_index
+                    .entry(model_id.to_string())
+                    .or_default()
+                    .token_tree
+                    .insert(smg_mesh::hash_token_path(tokens), tokens.clone());
+            }
         }
     }
 

--- a/model_gateway/src/policies/cache_aware.rs
+++ b/model_gateway/src/policies/cache_aware.rs
@@ -149,19 +149,30 @@ impl CacheAwarePolicy {
                             model_id, max_tree_size
                         );
                     }
-                    // Evict hash index if total entries exceed the
-                    // tree size limit. Entries are repopulated on
-                    // the next local insert.
-                    let hash_total: usize = hash_index_clone
-                        .iter()
-                        .map(|e| e.value().string_tree.len() + e.value().token_tree.len())
-                        .sum();
-                    if hash_total > max_tree_size {
-                        hash_index_clone.clear();
-                        debug!(
-                            "Hash index cleared (exceeded max_tree_size: {})",
-                            max_tree_size
-                        );
+                    // Evict hash index per model: `max_tree_size` is a
+                    // per-tree bound, so clearing one model's overflow
+                    // must not wipe other models' still-valid metadata.
+                    // Each tree kind is checked independently.
+                    let mut hash_total: usize = 0;
+                    for entry in hash_index_clone.iter() {
+                        let per_model = entry.value();
+                        if per_model.string_tree.len() > max_tree_size {
+                            per_model.string_tree.clear();
+                            debug!(
+                                model_id = entry.key(),
+                                "String hash index cleared (exceeded max_tree_size: {})",
+                                max_tree_size
+                            );
+                        }
+                        if per_model.token_tree.len() > max_tree_size {
+                            per_model.token_tree.clear();
+                            debug!(
+                                model_id = entry.key(),
+                                "Token hash index cleared (exceeded max_tree_size: {})",
+                                max_tree_size
+                            );
+                        }
+                        hash_total += per_model.string_tree.len() + per_model.token_tree.len();
                     }
 
                     // Log tree sizes — model counts + hash-index total.
@@ -566,15 +577,25 @@ impl CacheAwarePolicy {
                 model_id, max_size
             );
         }
-        // Evict hash index if total entries exceed tree size limit.
-        let hash_total: usize = self
-            .hash_index
-            .iter()
-            .map(|e| e.value().string_tree.len() + e.value().token_tree.len())
-            .sum();
-        if hash_total > max_size {
-            self.hash_index.clear();
-            debug!("Hash index cleared (exceeded max_size: {})", max_size);
+        // Evict hash index per model per tree kind. `max_size` is a
+        // per-tree bound; clearing one model's overflow must not wipe
+        // other models' still-valid metadata.
+        for entry in self.hash_index.iter() {
+            let per_model = entry.value();
+            if per_model.string_tree.len() > max_size {
+                per_model.string_tree.clear();
+                debug!(
+                    model_id = entry.key(),
+                    "String hash index cleared (exceeded max_size: {})", max_size
+                );
+            }
+            if per_model.token_tree.len() > max_size {
+                per_model.token_tree.clear();
+                debug!(
+                    model_id = entry.key(),
+                    "Token hash index cleared (exceeded max_size: {})", max_size
+                );
+            }
         }
     }
 

--- a/model_gateway/src/policies/cache_aware.rs
+++ b/model_gateway/src/policies/cache_aware.rs
@@ -55,7 +55,9 @@ use super::{
     get_healthy_worker_indices, normalize_model_key, utils::PeriodicTask, CacheAwareConfig,
     LoadBalancingPolicy, SelectWorkerInfo,
 };
-use crate::worker::{KvEventMonitor, Worker, UNKNOWN_MODEL_ID};
+#[cfg(test)]
+use crate::worker::UNKNOWN_MODEL_ID;
+use crate::worker::{KvEventMonitor, Worker};
 
 /// Cache-aware routing policy
 ///
@@ -327,18 +329,8 @@ impl CacheAwarePolicy {
         }
     }
 
-    /// Normalize model_id for mesh synchronization
-    /// Converts empty model_id to UNKNOWN_MODEL_ID for consistency
-    fn normalize_mesh_model_id(model_id: &str) -> &str {
-        if model_id.is_empty() {
-            UNKNOWN_MODEL_ID
-        } else {
-            model_id
-        }
-    }
-
     pub fn apply_remote_tree_operation(&self, model_id: &str, operation: &TreeOperation) {
-        let tree_key = Self::normalize_mesh_model_id(model_id);
+        let tree_key = normalize_model_key(model_id);
 
         match operation {
             TreeOperation::Insert(insert_op) => {
@@ -412,7 +404,7 @@ impl CacheAwarePolicy {
     fn sync_insert_hash(&self, model_id: &str, path_hash: u64, tenant: &str) {
         let mesh_sync = self.mesh_sync.read().clone();
         if let Some(mesh_sync) = mesh_sync {
-            let mesh_model_id = Self::normalize_mesh_model_id(model_id);
+            let mesh_model_id = normalize_model_key(model_id);
             mesh_sync.sync_tree_insert_hash(mesh_model_id, path_hash, tenant);
         }
     }
@@ -425,7 +417,7 @@ impl CacheAwarePolicy {
                 key: TreeKey::Tokens(tokens.to_vec()),
                 tenant: tenant.to_string(),
             });
-            let mesh_model_id = Self::normalize_mesh_model_id(model_id);
+            let mesh_model_id = normalize_model_key(model_id);
             if let Err(error) = mesh_sync.sync_tree_operation(mesh_model_id.to_string(), op) {
                 warn!("Failed to sync tree insert operation to mesh: {}", error);
             }
@@ -435,7 +427,7 @@ impl CacheAwarePolicy {
     /// Merge remote tree state into local trees incrementally.
     /// Uses entry-based insertion to preserve existing local routing state.
     pub fn apply_remote_tree_state(&self, model_id: &str, tree_state: &smg_mesh::TreeState) {
-        let model_id = Self::normalize_mesh_model_id(model_id);
+        let model_id = normalize_model_key(model_id);
         for operation in &tree_state.operations {
             if let TreeOperation::Insert(insert_op) = operation {
                 self.apply_insert_operation(model_id, insert_op);
@@ -452,7 +444,7 @@ impl CacheAwarePolicy {
         inserts: &[smg_mesh::TenantInsert],
         evictions: &[smg_mesh::TenantEvict],
     ) {
-        let model_id = Self::normalize_mesh_model_id(model_id);
+        let model_id = normalize_model_key(model_id);
 
         let string_tree = self
             .string_trees
@@ -494,7 +486,7 @@ impl CacheAwarePolicy {
         reason = "pop() after last_mut().is_some() is infallible"
     )]
     pub fn export_tree_state(&self, model_id: &str) -> Option<smg_mesh::TreeState> {
-        let model_id = Self::normalize_mesh_model_id(model_id);
+        let model_id = normalize_model_key(model_id);
         let tree = self.string_trees.get(model_id)?;
         let snapshot = tree.snapshot();
         if snapshot.nodes.is_empty() {
@@ -546,7 +538,7 @@ impl CacheAwarePolicy {
     /// which preserves shared prefixes and is much smaller than the flat
     /// `TreeState` returned by [`export_tree_state`].
     pub fn export_tree_snapshot(&self, model_id: &str) -> Option<kv_index::snapshot::TreeSnapshot> {
-        let model_id = Self::normalize_mesh_model_id(model_id);
+        let model_id = normalize_model_key(model_id);
         let tree = self.string_trees.get(model_id)?;
         let snapshot = tree.snapshot();
         if snapshot.nodes.is_empty() {
@@ -690,6 +682,9 @@ pub trait TreeHandle: Send + Sync + std::fmt::Debug {
 
 impl TreeHandle for CacheAwarePolicy {
     fn contains_hash(&self, model_id: &str, tree_kind: TreeKind, node_hash: u64) -> bool {
+        // Normalize empty → UNKNOWN_MODEL_ID so lookups match the
+        // key shape every populate site already uses.
+        let model_id = normalize_model_key(model_id);
         self.hash_index
             .get(model_id)
             .is_some_and(|entry| match tree_kind {

--- a/model_gateway/src/policies/cache_aware.rs
+++ b/model_gateway/src/policies/cache_aware.rs
@@ -79,27 +79,31 @@ pub struct CacheAwarePolicy {
     _eviction_task: Option<PeriodicTask>,
     /// Event-driven KV cache monitor for overlap scoring (gRPC workers only).
     kv_monitor: RwLock<Option<Arc<KvEventMonitor>>>,
-    /// Hash → matched prefix index for resolving tenant delta hashes.
-    /// Populated on local inserts with the MATCHED PREFIX from the radix
-    /// tree (not the full prompt text). Consumed on remote tenant delta
-    /// application. Bounded by eviction at `max_tree_size` entries.
+    /// Model-scoped hash indexes for resolving tenant delta hashes.
+    /// Outer key is the normalized model_id; inner maps hold
+    /// `hash → reconstructable prefix/tokens` per tree kind.
+    /// Spec §7.1 mandates model scoping: the same hash can refer
+    /// to different prefixes in different models, so a global
+    /// index mis-routes multi-model deployments. Bounded by
+    /// eviction at `max_tree_size` total entries.
     ///
-    /// TODO: this index is NOT scoped by model_id — if two models produce the
-    /// same text hash but match different prefixes, the last writer wins.
-    /// Low risk in practice (most deployments serve a single model) but a
-    /// compound key `(model_id, hash)` or hashing `model_id\0text` would be
-    /// correct.  Deferring to a follow-up to avoid changing the wire format.
-    path_hash_index: Arc<DashMap<u64, String>>,
+    /// String side stores the matched prefix (short) rather than
+    /// the full prompt text; remote apply re-inserts by that
+    /// prefix. Token side stores the full token sequence — v1
+    /// had no token hash index, so this is new v2 plumbing.
+    hash_index: Arc<DashMap<String, PerModelHashIndex>>,
+}
 
-    /// Token-tree counterpart to `path_hash_index`. Populated on
-    /// local token inserts and consulted by the [`TreeHandle`] impl
-    /// so incoming token deltas can be classified known/unknown.
-    /// Stores the full token sequence so future repair/apply paths
-    /// can reconstruct the node from hash alone. Bounded by the
-    /// same periodic eviction as `path_hash_index`. v1 had no token
-    /// hash index (v1's `apply_tenant_delta` only touched the
-    /// string tree), so the token side is entirely new v2 plumbing.
-    token_path_hash_index: Arc<DashMap<u64, Vec<u32>>>,
+/// Per-model inner container for [`CacheAwarePolicy::hash_index`].
+/// Keeping both kinds in one struct per model makes the
+/// "separate model-scoped hash indexes for string and token
+/// trees" invariant from spec §7.1 explicit in the type.
+#[derive(Debug, Default)]
+struct PerModelHashIndex {
+    /// path hash → matched prefix (reconstructs the string-tree node).
+    string_tree: DashMap<u64, String>,
+    /// token-path hash → tokens (reconstructs the token-tree node).
+    token_tree: DashMap<u64, Vec<u32>>,
 }
 
 impl CacheAwarePolicy {
@@ -110,15 +114,13 @@ impl CacheAwarePolicy {
     pub fn with_config(config: CacheAwareConfig) -> Self {
         let string_trees = Arc::new(DashMap::<String, Arc<Tree>>::new());
         let token_trees = Arc::new(DashMap::<String, Arc<TokenTree>>::new());
-        let path_hash_index = Arc::new(DashMap::<u64, String>::new());
-        let token_path_hash_index = Arc::new(DashMap::<u64, Vec<u32>>::new());
+        let hash_index = Arc::new(DashMap::<String, PerModelHashIndex>::new());
 
         // Start background eviction thread if configured
         let eviction_task = if config.eviction_interval_secs > 0 {
             let string_trees_clone = Arc::clone(&string_trees);
             let token_trees_clone = Arc::clone(&token_trees);
-            let path_hash_index_clone = Arc::clone(&path_hash_index);
-            let token_path_hash_index_clone = Arc::clone(&token_path_hash_index);
+            let hash_index_clone = Arc::clone(&hash_index);
             let max_tree_size = config.max_tree_size;
 
             Some(PeriodicTask::spawn(
@@ -147,33 +149,31 @@ impl CacheAwarePolicy {
                             model_id, max_tree_size
                         );
                     }
-                    // Evict path hash index if it exceeds tree size limit.
-                    // Entries are repopulated on the next local insert.
-                    if path_hash_index_clone.len() > max_tree_size {
-                        path_hash_index_clone.clear();
+                    // Evict hash index if total entries exceed the
+                    // tree size limit. Entries are repopulated on
+                    // the next local insert.
+                    let hash_total: usize = hash_index_clone
+                        .iter()
+                        .map(|e| e.value().string_tree.len() + e.value().token_tree.len())
+                        .sum();
+                    if hash_total > max_tree_size {
+                        hash_index_clone.clear();
                         debug!(
-                            "Path hash index cleared (exceeded max_tree_size: {})",
-                            max_tree_size
-                        );
-                    }
-                    if token_path_hash_index_clone.len() > max_tree_size {
-                        token_path_hash_index_clone.clear();
-                        debug!(
-                            "Token path hash index cleared (exceeded max_tree_size: {})",
+                            "Hash index cleared (exceeded max_tree_size: {})",
                             max_tree_size
                         );
                     }
 
-                    // Log tree sizes — use model count + path_hash_index only.
-                    // DO NOT call tree.snapshot() here — it clones all edge text
-                    // (~170 MB) every eviction cycle, causing allocator fragmentation.
+                    // Log tree sizes — model counts + hash-index total.
+                    // DO NOT call tree.snapshot() here — it clones all
+                    // edge text (~170 MB) every cycle.
                     tracing::info!(
                         "Tree memory: string_trees={} models, token_trees={} models, \
-                         path_hash_index={} entries, token_path_hash_index={} entries",
+                         hash_index={} models / {} entries",
                         string_trees_clone.len(),
                         token_trees_clone.len(),
-                        path_hash_index_clone.len(),
-                        token_path_hash_index_clone.len(),
+                        hash_index_clone.len(),
+                        hash_total,
                     );
                 },
             ))
@@ -188,8 +188,7 @@ impl CacheAwarePolicy {
             mesh_sync: RwLock::new(None),
             _eviction_task: eviction_task,
             kv_monitor: RwLock::new(None),
-            path_hash_index,
-            token_path_hash_index,
+            hash_index,
         }
     }
 
@@ -423,13 +422,15 @@ impl CacheAwarePolicy {
             .or_insert_with(|| Arc::new(Tree::new()))
             .clone();
 
-        // Apply inserts — look up the prefix path by hash in our local index.
-        // If the hash is unknown (prefix doesn't exist locally), the insert is
-        // silently dropped. The next structure snapshot (every ~30s) will deliver
-        // the full tree including this prefix + its tenants.
+        // Apply inserts — look up the prefix path by hash in this
+        // model's index. Unknown hashes are silently dropped; the
+        // next structure snapshot (every ~30s) delivers the full
+        // tree including this prefix + its tenants.
         for insert in inserts {
-            if let Some(path_entry) = self.path_hash_index.get(&insert.node_path_hash) {
-                string_tree.insert_text(path_entry.value(), &insert.worker_url);
+            if let Some(model_entry) = self.hash_index.get(model_id) {
+                if let Some(path) = model_entry.string_tree.get(&insert.node_path_hash) {
+                    string_tree.insert_text(path.value(), &insert.worker_url);
+                }
             }
             // Unknown hash — dropped, next snapshot corrects
         }
@@ -538,10 +539,15 @@ impl CacheAwarePolicy {
                 model_id, max_size
             );
         }
-        // Evict path hash index if it exceeds tree size limit
-        if self.path_hash_index.len() > max_size {
-            self.path_hash_index.clear();
-            debug!("Path hash index cleared (exceeded max_size: {})", max_size);
+        // Evict hash index if total entries exceed tree size limit.
+        let hash_total: usize = self
+            .hash_index
+            .iter()
+            .map(|e| e.value().string_tree.len() + e.value().token_tree.len())
+            .sum();
+        if hash_total > max_size {
+            self.hash_index.clear();
+            debug!("Hash index cleared (exceeded max_size: {})", max_size);
         }
     }
 
@@ -579,7 +585,10 @@ impl CacheAwarePolicy {
                 .map(|entry| entry.value().clone());
             if let Some(tree) = tree {
                 tree.insert_tokens(tokens, worker_url);
-                self.token_path_hash_index
+                self.hash_index
+                    .entry(model_id.to_string())
+                    .or_default()
+                    .token_tree
                     .insert(smg_mesh::hash_token_path(tokens), tokens.to_vec());
                 self.sync_insert_tokens(model_id, tokens, worker_url);
             }
@@ -632,11 +641,13 @@ pub trait TreeHandle: Send + Sync + std::fmt::Debug {
 }
 
 impl TreeHandle for CacheAwarePolicy {
-    fn contains_hash(&self, _model_id: &str, tree_kind: TreeKind, node_hash: u64) -> bool {
-        match tree_kind {
-            TreeKind::String => self.path_hash_index.contains_key(&node_hash),
-            TreeKind::Token => self.token_path_hash_index.contains_key(&node_hash),
-        }
+    fn contains_hash(&self, model_id: &str, tree_kind: TreeKind, node_hash: u64) -> bool {
+        self.hash_index
+            .get(model_id)
+            .is_some_and(|entry| match tree_kind {
+                TreeKind::String => entry.string_tree.contains_key(&node_hash),
+                TreeKind::Token => entry.token_tree.contains_key(&node_hash),
+            })
     }
 }
 
@@ -863,12 +874,13 @@ impl CacheAwarePolicy {
             if let Some(idx) = selected_idx {
                 tree.insert_tokens(tokens, workers[idx].url());
 
-                // v1 never populated a token hash index (its
-                // `apply_tenant_delta` only touched the string
-                // tree). v2's `TreeHandle` impl consults this map
-                // on every incoming token delta, so we maintain it
-                // alongside the string side.
-                self.token_path_hash_index
+                // v1 never populated a token hash index; v2's
+                // `TreeHandle` impl consults this map per incoming
+                // token delta, so maintain it alongside the tree.
+                self.hash_index
+                    .entry(model_id.to_string())
+                    .or_default()
+                    .token_tree
                     .insert(smg_mesh::hash_token_path(tokens), tokens.to_vec());
 
                 self.sync_insert_tokens(model_id, tokens, workers[idx].url());
@@ -936,7 +948,11 @@ impl CacheAwarePolicy {
                 // tree node. This keeps the index memory-bounded.
                 let matched_prefix: String = text.chars().take(result.matched_char_count).collect();
                 let path_hash = smg_mesh::hash_node_path(text);
-                self.path_hash_index.insert(path_hash, matched_prefix);
+                self.hash_index
+                    .entry(model_id.to_string())
+                    .or_default()
+                    .string_tree
+                    .insert(path_hash, matched_prefix);
 
                 // Use hash-based sync to avoid cloning 80k+ prompt text.
                 self.sync_insert_hash(model_id, path_hash, workers[idx].url());

--- a/model_gateway/src/policies/mod.rs
+++ b/model_gateway/src/policies/mod.rs
@@ -24,7 +24,7 @@ mod round_robin;
 pub(crate) mod utils;
 
 pub use bucket::BucketPolicy;
-pub use cache_aware::CacheAwarePolicy;
+pub use cache_aware::{CacheAwarePolicy, TreeHandle, TreeKind};
 pub use consistent_hashing::ConsistentHashingPolicy;
 pub use dp_min_token::MinimumTokensPolicy;
 pub use factory::PolicyFactory;


### PR DESCRIPTION
## Description

### Problem

Earlier drafts of this PR put a `PerModelHashIndex` inside the `TreeSyncAdapter`, mirroring the policy's tree membership via `record_local_hash` / `forget_local_hash` calls. Review surfaced two issues:

1. **Duplicated state** with `CacheAwarePolicy::path_hash_index`, which already tracks string-tree hashes for v1's `apply_tenant_delta`.
2. **Multi-tenant correctness**: tree nodes are shared across tenants; per-tenant record/forget can't reconstruct "is this node still alive?" without refcounting that mirrors the tree's tenant-set bookkeeping.

A follow-up moved the trait into the adapter module but had the policy implement it — which inverted the layering (policy depending on adapter types).

Final shape: the policy owns the contract. The adapter consumes it.

### Solution

Policy side (`cache_aware.rs`):

- `pub enum TreeKind { String, Token }` — the string/token split is a property of the tree owner, so it lives here.
- `pub trait TreeHandle { fn contains_hash(...) -> bool }` — read-only resolver the adapter queries. Its contract is "can I resolve this hash locally?" (resolver cache), not "is this node currently live in the tree" — stale-but-resolvable is intentional, it lets the apply path skip unnecessary repair.
- **Single unified index**: `hash_index: Arc<DashMap<String, PerModelHashIndex>>`, where `PerModelHashIndex` holds a `string_tree: DashMap<u64, String>` (hash → matched prefix) and a `token_tree: DashMap<u64, Vec<u32>>` (hash → tokens). Model-scoped per spec §7.1. Replaces the old flat `path_hash_index` and the temporary `token_path_hash_index` I added at first.
- `impl TreeHandle for CacheAwarePolicy` backed by `hash_index`, with `model_id` normalized through `normalize_model_key` to match every populate site.
- Re-exported from `policies::mod` so consumers import `use crate::policies::{TreeHandle, TreeKind}`.

Adapter side (`mesh/adapters/tree_sync.rs`):

- No local trait, no local hash index, no `TreeKind` definition — all deleted.
- `TreeSyncAdapter::new` takes `Arc<dyn TreeHandle>`.
- The inbound subscription asks the handle per delta; known → trace, unknown → debug.
- Tests use a `MockTreeHandle` implementing the trait.

Dependency direction: `adapter → policies::TreeHandle ← CacheAwarePolicy`. Policy never imports from the adapter module.

### What else changed along the way

- **Remote-replay populate**: `apply_insert_to_trees` promoted from a static fn to `&self` and now populates `hash_index` alongside every tree insert. Without this, prefixes learned via `apply_remote_tree_operation` or `restore_tree_state_from_mesh` would have been invisible to `TreeHandle::contains_hash`.
- **Per-model eviction**: both the periodic eviction task and the manual `evict_cache` now iterate per model per tree kind and clear only the inner maps that exceed `max_tree_size`. The earlier aggregate-size clear would have wiped innocent models' metadata under a single overflowing model.
- **Normalizer cleanup**: deleted the private `normalize_mesh_model_id` in `cache_aware.rs` (byte-for-byte identical to the shared `policies::normalize_model_key`) and routed every call site through the shared helper.

### Not in this PR

- **No `server.rs` wiring.** `TreeSyncAdapter::new(..., tree_handle, ...)` isn't called from anywhere yet; that happens in the final slice of the TreeSync sequence behind `mesh_v2_enabled`.
- **Existing `smg_mesh::*` imports in `cache_aware.rs`** (`TenantInsert`, `OptionalMeshSyncManager`, `hash_node_path`, etc.) are not touched. They serve v1's `apply_tenant_delta` path and get ripped out in Step 6 of the v2 migration plan. This PR adds no new mesh-adapter imports to the policy.

## Changes

- `model_gateway/src/policies/cache_aware.rs`:
  - New `TreeKind` enum and `TreeHandle` trait.
  - New `PerModelHashIndex` struct and `hash_index: Arc<DashMap<String, PerModelHashIndex>>` field replacing the prior flat `path_hash_index` (also removes the short-lived separate `token_path_hash_index`).
  - Populated at every local-insert site + remote-replay path.
  - `impl TreeHandle for CacheAwarePolicy`.
  - Per-model eviction in both the periodic task and `evict_cache`.
  - Consolidated to `normalize_model_key`; `normalize_mesh_model_id` deleted.
- `model_gateway/src/policies/mod.rs`: re-export `TreeHandle`, `TreeKind`.
- `model_gateway/src/mesh/adapters/tree_sync.rs`:
  - Dropped local `TreeKind` / `LocalHashResolver` definitions.
  - `TreeSyncAdapter::new` takes `Arc<dyn TreeHandle>`.
  - Subscription consults the handle; `Weak<Self>` + per-iteration upgrade on the recv task.
  - Tests use `MockTreeHandle`.
- `model_gateway/src/mesh/{mod,adapters/mod}.rs`: updated re-exports.

## Test Plan

- [x] \`cargo test -p smg --lib policies::cache_aware\` — 23 tests passing.
- [x] \`cargo test -p smg --lib mesh::adapters::tree_sync\` — 11 tests passing.
- [x] \`cargo clippy -p smg --lib --tests -- -D warnings\`
- [x] \`cargo +nightly fmt --all\`

<details>
<summary>Checklist</summary>

- [x] \`cargo +nightly fmt\` passes
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved per-model hash resolution and caching for safer, model-scoped routing.
  * Exposed tree membership utilities so callers can check whether a hash is known.
  * Reduced noisy tracing and added clearer, membership-based logging levels.

* **Bug Fixes**
  * Added explicit warnings and early returns for malformed or undecodable payloads to avoid silent failures.

* **Tests**
  * Expanded coverage for membership checks, tree-kind distinctions, and malformed payload scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->