### PR TITLE
fix(skills): harden skills API review findings

### DIFF
--- a/crates/skills/src/api.rs
+++ b/crates/skills/src/api.rs
@@ -11,6 +11,7 @@ use ulid::Ulid;
 use zip::{write::SimpleFileOptions, CompressionMethod, ZipWriter};
 
 use crate::{
+    config::SkillUploadLimits,
     memory::InMemorySkillStore,
     storage::{
         BundleTokenStore, ContinuationCookieStore, SkillMetadataStore, SkillsStoreError,
@@ -21,8 +22,8 @@ use crate::{
         SkillVersionRecord,
     },
     validation::{
-        is_code_file_path, normalize_skill_bundle_zip, parse_skill_bundle, SkillBundleArchiveError,
-        SkillParseError,
+        is_code_file_path, normalize_skill_bundle_zip_with_limits, parse_skill_bundle,
+        SkillBundleArchiveError, SkillParseError,
     },
 };
 
@@ -40,6 +41,7 @@ struct SkillServiceInner {
     bundle_token_store: Option<Arc<dyn BundleTokenStore>>,
     continuation_cookie_store: Option<Arc<dyn ContinuationCookieStore>>,
     blob_store: Option<Arc<dyn BlobStore>>,
+    upload_limits: SkillUploadLimits,
 }
 
 impl fmt::Debug for SkillServiceInner {
@@ -193,6 +195,7 @@ impl SkillService {
                 bundle_token_store: None,
                 continuation_cookie_store: None,
                 blob_store: None,
+                upload_limits: SkillUploadLimits::default(),
             }),
         }
     }
@@ -204,6 +207,24 @@ impl SkillService {
         continuation_cookie_store: Arc<dyn ContinuationCookieStore>,
         blob_store: Arc<dyn BlobStore>,
     ) -> Self {
+        Self::single_process_with_limits(
+            metadata_store,
+            tenant_alias_store,
+            bundle_token_store,
+            continuation_cookie_store,
+            blob_store,
+            SkillUploadLimits::default(),
+        )
+    }
+
+    pub fn single_process_with_limits(
+        metadata_store: Arc<dyn SkillMetadataStore>,
+        tenant_alias_store: Arc<dyn TenantAliasStore>,
+        bundle_token_store: Arc<dyn BundleTokenStore>,
+        continuation_cookie_store: Arc<dyn ContinuationCookieStore>,
+        blob_store: Arc<dyn BlobStore>,
+        upload_limits: SkillUploadLimits,
+    ) -> Self {
         Self {
             inner: Arc::new(SkillServiceInner {
                 mode: SkillServiceMode::SingleProcess,
@@ -212,6 +233,7 @@ impl SkillService {
                 bundle_token_store: Some(bundle_token_store),
                 continuation_cookie_store: Some(continuation_cookie_store),
                 blob_store: Some(blob_store),
+                upload_limits,
             }),
         }
     }
@@ -224,6 +246,21 @@ impl SkillService {
             store.clone(),
             store,
             blob_store,
+        )
+    }
+
+    pub fn in_memory_with_limits(
+        blob_store: Arc<dyn BlobStore>,
+        upload_limits: SkillUploadLimits,
+    ) -> Self {
+        let store = Arc::new(InMemorySkillStore::default());
+        Self::single_process_with_limits(
+            store.clone(),
+            store.clone(),
+            store.clone(),
+            store,
+            blob_store,
+            upload_limits,
         )
     }
 
@@ -249,6 +286,10 @@ impl SkillService {
 
     pub fn blob_store(&self) -> Option<Arc<dyn BlobStore>> {
         self.inner.blob_store.clone()
+    }
+
+    pub fn upload_limits(&self) -> SkillUploadLimits {
+        self.inner.upload_limits
     }
 
     pub async fn get_skill(
@@ -374,7 +415,7 @@ impl SkillService {
                 component: "blob_store",
             })?;
 
-        let (bundle, media_types) = normalize_upload_bundle(request.upload)?;
+        let (bundle, media_types) = normalize_upload_bundle(request.upload, self.upload_limits())?;
         let parsed_bundle = parse_bundle_contents(&bundle)?;
         let skill_id = generate_skill_id();
         let version = generate_version_id(&[]);
@@ -418,16 +459,10 @@ impl SkillService {
             created_at: now,
         };
 
-        if let Err(error) = metadata_store.put_skill(skill_record.clone()).await {
-            cleanup_blobs(&*blob_store, &version_record.file_manifest).await;
-            return Err(error.into());
-        }
-
         if let Err(error) = metadata_store
-            .put_skill_version(version_record.clone())
+            .put_skill_with_initial_version(skill_record.clone(), version_record.clone())
             .await
         {
-            let _ = metadata_store.delete_skill(&tenant_id, &skill_id).await;
             cleanup_blobs(&*blob_store, &version_record.file_manifest).await;
             return Err(error.into());
         }
@@ -482,7 +517,7 @@ impl SkillService {
             })
             .transpose()?;
 
-        let (bundle, media_types) = normalize_upload_bundle(request.upload)?;
+        let (bundle, media_types) = normalize_upload_bundle(request.upload, self.upload_limits())?;
         let parsed_bundle = parse_bundle_contents(&bundle)?;
         let version = generate_version_id(&existing_versions);
         let version_number = next_version_number(&existing_versions);
@@ -513,14 +548,6 @@ impl SkillService {
             created_at: now,
         };
 
-        if let Err(error) = metadata_store
-            .put_skill_version(version_record.clone())
-            .await
-        {
-            cleanup_blobs(&*blob_store, &version_record.file_manifest).await;
-            return Err(error.into());
-        }
-
         let mut updated_skill = existing_skill.clone();
         updated_skill.latest_version = Some(version.clone());
         if updated_skill.default_version.is_none() {
@@ -531,10 +558,10 @@ impl SkillService {
         apply_skill_projection_from_version(&mut updated_skill, &default_projection);
         updated_skill.updated_at = now;
 
-        if let Err(error) = metadata_store.put_skill(updated_skill.clone()).await {
-            let _ = metadata_store
-                .delete_skill_version(&skill_id, &version)
-                .await;
+        if let Err(error) = metadata_store
+            .put_skill_version_and_update_skill(version_record.clone(), updated_skill.clone())
+            .await
+        {
             cleanup_blobs(&*blob_store, &version_record.file_manifest).await;
             return Err(error.into());
         }
@@ -795,21 +822,29 @@ fn normalize_required_value(
 
 fn normalize_upload_bundle(
     upload: SkillUpload,
+    limits: SkillUploadLimits,
 ) -> Result<(NormalizedSkillBundle, HashMap<String, Option<String>>), SkillServiceError> {
     match upload {
         SkillUpload::Zip(bytes) => {
-            let bundle = normalize_skill_bundle_zip(&bytes)?;
+            if bytes.len() > limits.max_upload_size_bytes {
+                return Err(SkillBundleArchiveError::BundleTooLarge {
+                    max_bytes: limits.max_upload_size_bytes as u64,
+                }
+                .into());
+            }
+            let bundle = normalize_skill_bundle_zip_with_limits(&bytes, limits)?;
             Ok((bundle, HashMap::new()))
         }
         SkillUpload::Files(files) => {
             if files.is_empty() {
                 return Err(SkillServiceError::MissingUploadParts);
             }
+            validate_files_upload_limits(&files, limits)?;
             let media_types = files
                 .iter()
                 .map(|file| (file.relative_path.clone(), file.media_type.clone()))
                 .collect::<HashMap<_, _>>();
-            let bundle = normalize_files_upload(&files)?;
+            let bundle = normalize_files_upload(&files, limits)?;
             Ok((bundle, media_types))
         }
     }
@@ -817,6 +852,7 @@ fn normalize_upload_bundle(
 
 fn normalize_files_upload(
     files: &[UploadedSkillFile],
+    limits: SkillUploadLimits,
 ) -> Result<NormalizedSkillBundle, SkillServiceError> {
     let mut buffer = Cursor::new(Vec::new());
     {
@@ -835,7 +871,43 @@ fn normalize_files_upload(
             .map_err(|error| SkillServiceError::BundleBuild(error.to_string()))?;
     }
 
-    normalize_skill_bundle_zip(buffer.get_ref()).map_err(Into::into)
+    normalize_skill_bundle_zip_with_limits(buffer.get_ref(), limits).map_err(Into::into)
+}
+
+fn validate_files_upload_limits(
+    files: &[UploadedSkillFile],
+    limits: SkillUploadLimits,
+) -> Result<(), SkillServiceError> {
+    if files.len() > limits.max_files_per_version {
+        return Err(SkillBundleArchiveError::TooManyFiles {
+            max_files: limits.max_files_per_version,
+        }
+        .into());
+    }
+
+    let mut total_size_bytes = 0usize;
+    for file in files {
+        if file.contents.len() > limits.max_file_size_bytes {
+            return Err(SkillBundleArchiveError::EntryTooLarge {
+                path: file.relative_path.clone(),
+                max_bytes: limits.max_file_size_bytes as u64,
+            }
+            .into());
+        }
+        total_size_bytes = total_size_bytes.checked_add(file.contents.len()).ok_or(
+            SkillBundleArchiveError::BundleTooLarge {
+                max_bytes: limits.max_upload_size_bytes as u64,
+            },
+        )?;
+        if total_size_bytes > limits.max_upload_size_bytes {
+            return Err(SkillBundleArchiveError::BundleTooLarge {
+                max_bytes: limits.max_upload_size_bytes as u64,
+            }
+            .into());
+        }
+    }
+
+    Ok(())
 }
 
 fn parse_bundle_contents(
@@ -1023,8 +1095,9 @@ mod tests {
     use tempfile::TempDir;
 
     use super::{
-        CreateSkillRequest, CreateSkillVersionRequest, SkillService, SkillServiceMode, SkillUpload,
-        UpdateSkillRequest, UpdateSkillVersionRequest, UploadedSkillFile,
+        CreateSkillRequest, CreateSkillVersionRequest, SkillBundleArchiveError, SkillService,
+        SkillServiceError, SkillServiceMode, SkillUpload, SkillUploadLimits, UpdateSkillRequest,
+        UpdateSkillVersionRequest, UploadedSkillFile,
     };
 
     #[test]
@@ -1105,6 +1178,48 @@ mod tests {
             .await?
             .is_some());
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn create_skill_enforces_configured_file_count_limit() -> Result<()> {
+        let root = TempDir::new()?;
+        let blob_store = Arc::new(FilesystemBlobStore::new(root.path())?);
+        let service = SkillService::in_memory_with_limits(
+            blob_store,
+            SkillUploadLimits {
+                max_upload_size_bytes: 1024,
+                max_files_per_version: 1,
+                max_file_size_bytes: 1024,
+            },
+        );
+
+        let error = service
+            .create_skill(CreateSkillRequest {
+                tenant_id: "tenant-a".to_string(),
+                upload: SkillUpload::Files(vec![
+                    UploadedSkillFile {
+                        relative_path: "SKILL.md".to_string(),
+                        contents: b"---\nname: acme:map\ndescription: Map the repo\n---\nUse rg."
+                            .to_vec(),
+                        media_type: Some("text/markdown".to_string()),
+                    },
+                    UploadedSkillFile {
+                        relative_path: "notes.txt".to_string(),
+                        contents: b"notes".to_vec(),
+                        media_type: Some("text/plain".to_string()),
+                    },
+                ]),
+            })
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            SkillServiceError::BundleArchive(SkillBundleArchiveError::TooManyFiles {
+                max_files: 1
+            })
+        ));
         Ok(())
     }
 
@@ -1259,7 +1374,7 @@ mod tests {
             .expect_err("default version delete should fail");
         assert!(matches!(
             error,
-            super::SkillServiceError::CannotDeleteDefaultVersion { .. }
+            SkillServiceError::CannotDeleteDefaultVersion { .. }
         ));
 
         let switched = service

--- a/crates/skills/src/config.rs
+++ b/crates/skills/src/config.rs
@@ -9,6 +9,8 @@ pub use smg_blob_storage::{
     BlobStoreConfig as SkillsBlobStoreConfig,
 };
 
+const MEBIBYTE: usize = 1024 * 1024;
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum SkillsMissingMcpPolicy {
@@ -37,7 +39,9 @@ pub enum SkillsExecutionAsyncMode {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum SkillsAdminOperation {
+    CreateAnyTenant,
     ReadAnyTenant,
+    UpdateAnyTenant,
     DeleteAnyTenant,
     CreateAlias,
     ExecuteMigration,
@@ -166,6 +170,52 @@ pub struct SkillsConfig {
     pub retention: SkillsRetentionConfig,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SkillUploadLimits {
+    pub max_upload_size_bytes: usize,
+    pub max_files_per_version: usize,
+    pub max_file_size_bytes: usize,
+}
+
+impl SkillUploadLimits {
+    pub fn from_config(config: &SkillsConfig) -> Result<Self, String> {
+        if config.max_upload_size_mb == 0 {
+            return Err("skills.max_upload_size_mb must be greater than 0".to_string());
+        }
+        if config.max_file_size_mb == 0 {
+            return Err("skills.max_file_size_mb must be greater than 0".to_string());
+        }
+        if config.max_file_size_mb > config.max_upload_size_mb {
+            return Err(
+                "skills.max_file_size_mb must be less than or equal to skills.max_upload_size_mb"
+                    .to_string(),
+            );
+        }
+        if config.max_files_per_version == 0 {
+            return Err("skills.max_files_per_version must be greater than 0".to_string());
+        }
+
+        Ok(Self {
+            max_upload_size_bytes: mb_to_bytes(
+                config.max_upload_size_mb,
+                "skills.max_upload_size_mb",
+            )?,
+            max_files_per_version: config.max_files_per_version,
+            max_file_size_bytes: mb_to_bytes(config.max_file_size_mb, "skills.max_file_size_mb")?,
+        })
+    }
+}
+
+impl Default for SkillUploadLimits {
+    fn default() -> Self {
+        Self {
+            max_upload_size_bytes: 30 * MEBIBYTE,
+            max_files_per_version: 500,
+            max_file_size_bytes: 25 * MEBIBYTE,
+        }
+    }
+}
+
 impl Default for SkillsConfig {
     fn default() -> Self {
         Self {
@@ -188,6 +238,12 @@ impl Default for SkillsConfig {
             retention: SkillsRetentionConfig::default(),
         }
     }
+}
+
+fn mb_to_bytes(value_mb: usize, field: &'static str) -> Result<usize, String> {
+    value_mb
+        .checked_mul(MEBIBYTE)
+        .ok_or_else(|| format!("{field} is too large to convert to bytes"))
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -218,7 +274,9 @@ impl Default for SkillsAdminConfig {
         Self {
             enabled: false,
             allowed_operations: vec![
+                SkillsAdminOperation::CreateAnyTenant,
                 SkillsAdminOperation::ReadAnyTenant,
+                SkillsAdminOperation::UpdateAnyTenant,
                 SkillsAdminOperation::DeleteAnyTenant,
                 SkillsAdminOperation::CreateAlias,
                 SkillsAdminOperation::ExecuteMigration,

--- a/crates/skills/src/lib.rs
+++ b/crates/skills/src/lib.rs
@@ -17,12 +17,12 @@ pub use api::{
     UpdateSkillVersionRequest, UploadedSkillFile,
 };
 pub use config::{
-    SkillsAdminConfig, SkillsAdminOperation, SkillsBlobStoreBackend, SkillsBlobStoreConfig,
-    SkillsBudgetLimit, SkillsCacheConfig, SkillsConfig, SkillsDependenciesConfig,
-    SkillsExecutionAsyncMode, SkillsExecutionConfig, SkillsExecutionModeOverrides,
-    SkillsInstructionBudgetConfig, SkillsMissingMcpPolicy, SkillsRateLimitsConfig,
-    SkillsResolutionMode, SkillsRetentionConfig, SkillsRetentionMode, SkillsTenancyConfig,
-    SkillsToolLoopConfig, SkillsZdrConfig,
+    SkillUploadLimits, SkillsAdminConfig, SkillsAdminOperation, SkillsBlobStoreBackend,
+    SkillsBlobStoreConfig, SkillsBudgetLimit, SkillsCacheConfig, SkillsConfig,
+    SkillsDependenciesConfig, SkillsExecutionAsyncMode, SkillsExecutionConfig,
+    SkillsExecutionModeOverrides, SkillsInstructionBudgetConfig, SkillsMissingMcpPolicy,
+    SkillsRateLimitsConfig, SkillsResolutionMode, SkillsRetentionConfig, SkillsRetentionMode,
+    SkillsTenancyConfig, SkillsToolLoopConfig, SkillsZdrConfig,
 };
 pub use memory::InMemorySkillStore;
 pub use storage::{

--- a/crates/skills/src/memory.rs
+++ b/crates/skills/src/memory.rs
@@ -8,8 +8,8 @@ use parking_lot::RwLock;
 
 use crate::{
     storage::{
-        BundleTokenStore, ContinuationCookieStore, SkillMetadataStore, SkillsStoreResult,
-        TenantAliasStore,
+        BundleTokenStore, ContinuationCookieStore, SkillMetadataStore, SkillsStoreError,
+        SkillsStoreResult, TenantAliasStore,
     },
     types::{
         BundleTokenClaim, ContinuationCookieClaim, SkillRecord, SkillVersionRecord,
@@ -41,21 +41,31 @@ pub struct InMemorySkillStore {
 impl SkillMetadataStore for InMemorySkillStore {
     async fn put_skill(&self, record: SkillRecord) -> SkillsStoreResult<()> {
         let mut state = self.state.write();
-        if let Some(existing) = state.skills.get(&record.skill_id) {
-            if existing.tenant_id != record.tenant_id {
-                return Err(crate::storage::SkillsStoreError::InvalidData(format!(
-                    "skill_id '{}' already belongs to tenant '{}'",
-                    record.skill_id, existing.tenant_id
-                )));
-            }
+        put_skill_locked(&mut state, record)?;
+        Ok(())
+    }
+
+    async fn put_skill_with_initial_version(
+        &self,
+        skill: SkillRecord,
+        version: SkillVersionRecord,
+    ) -> SkillsStoreResult<()> {
+        if skill.skill_id != version.skill_id {
+            return Err(SkillsStoreError::InvalidData(format!(
+                "version skill_id '{}' does not match skill_id '{}'",
+                version.skill_id, skill.skill_id
+            )));
         }
 
+        let mut state = self.state.write();
+        validate_skill_tenant_locked(&state, &skill)?;
         state
             .skill_ids_by_tenant
-            .entry(record.tenant_id.clone())
+            .entry(skill.tenant_id.clone())
             .or_default()
-            .insert(record.skill_id.clone());
-        state.skills.insert(record.skill_id.clone(), record);
+            .insert(skill.skill_id.clone());
+        state.skills.insert(skill.skill_id.clone(), skill);
+        put_skill_version_locked(&mut state, version)?;
         Ok(())
     }
 
@@ -122,20 +132,27 @@ impl SkillMetadataStore for InMemorySkillStore {
     }
 
     async fn put_skill_version(&self, record: SkillVersionRecord) -> SkillsStoreResult<()> {
-        let key = (record.skill_id.clone(), record.version.clone());
         let mut state = self.state.write();
-        if !state.skills.contains_key(&record.skill_id) {
-            return Err(crate::storage::SkillsStoreError::InvalidData(format!(
-                "skill_id '{}' must exist before inserting a version",
-                record.skill_id
+        put_skill_version_locked(&mut state, record)?;
+        Ok(())
+    }
+
+    async fn put_skill_version_and_update_skill(
+        &self,
+        version: SkillVersionRecord,
+        skill: SkillRecord,
+    ) -> SkillsStoreResult<()> {
+        if skill.skill_id != version.skill_id {
+            return Err(SkillsStoreError::InvalidData(format!(
+                "version skill_id '{}' does not match skill_id '{}'",
+                version.skill_id, skill.skill_id
             )));
         }
-        state
-            .skill_versions_by_skill
-            .entry(record.skill_id.clone())
-            .or_default()
-            .insert(record.version.clone());
-        state.skill_versions.insert(key, record);
+
+        let mut state = self.state.write();
+        validate_skill_tenant_locked(&state, &skill)?;
+        put_skill_version_locked(&mut state, version)?;
+        put_skill_locked(&mut state, skill)?;
         Ok(())
     }
 
@@ -192,6 +209,53 @@ impl SkillMetadataStore for InMemorySkillStore {
 
         Ok(true)
     }
+}
+
+fn validate_skill_tenant_locked(
+    state: &InMemorySkillState,
+    record: &SkillRecord,
+) -> SkillsStoreResult<()> {
+    if let Some(existing) = state.skills.get(&record.skill_id) {
+        if existing.tenant_id != record.tenant_id {
+            return Err(SkillsStoreError::InvalidData(format!(
+                "skill_id '{}' already belongs to tenant '{}'",
+                record.skill_id, existing.tenant_id
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+fn put_skill_locked(state: &mut InMemorySkillState, record: SkillRecord) -> SkillsStoreResult<()> {
+    validate_skill_tenant_locked(state, &record)?;
+    state
+        .skill_ids_by_tenant
+        .entry(record.tenant_id.clone())
+        .or_default()
+        .insert(record.skill_id.clone());
+    state.skills.insert(record.skill_id.clone(), record);
+    Ok(())
+}
+
+fn put_skill_version_locked(
+    state: &mut InMemorySkillState,
+    record: SkillVersionRecord,
+) -> SkillsStoreResult<()> {
+    let key = (record.skill_id.clone(), record.version.clone());
+    if !state.skills.contains_key(&record.skill_id) {
+        return Err(SkillsStoreError::InvalidData(format!(
+            "skill_id '{}' must exist before inserting a version",
+            record.skill_id
+        )));
+    }
+    state
+        .skill_versions_by_skill
+        .entry(record.skill_id.clone())
+        .or_default()
+        .insert(record.version.clone());
+    state.skill_versions.insert(key, record);
+    Ok(())
 }
 
 fn max_sort_key() -> String {

--- a/crates/skills/src/storage.rs
+++ b/crates/skills/src/storage.rs
@@ -18,9 +18,19 @@ pub enum SkillsStoreError {
 pub type SkillsStoreResult<T> = Result<T, SkillsStoreError>;
 
 /// Persistence contract for skill metadata rows and immutable version rows.
+///
+/// The combined write methods are part of the contract intentionally: CRUD
+/// callers must not publish a skill projection separately from the version row
+/// that makes the projection resolvable.
 #[async_trait]
 pub trait SkillMetadataStore: Send + Sync + 'static {
     async fn put_skill(&self, record: SkillRecord) -> SkillsStoreResult<()>;
+
+    async fn put_skill_with_initial_version(
+        &self,
+        skill: SkillRecord,
+        version: SkillVersionRecord,
+    ) -> SkillsStoreResult<()>;
 
     async fn get_skill(
         &self,
@@ -33,6 +43,12 @@ pub trait SkillMetadataStore: Send + Sync + 'static {
     async fn delete_skill(&self, tenant_id: &str, skill_id: &str) -> SkillsStoreResult<bool>;
 
     async fn put_skill_version(&self, record: SkillVersionRecord) -> SkillsStoreResult<()>;
+
+    async fn put_skill_version_and_update_skill(
+        &self,
+        version: SkillVersionRecord,
+        skill: SkillRecord,
+    ) -> SkillsStoreResult<()>;
 
     async fn get_skill_version(
         &self,

--- a/crates/skills/src/validation.rs
+++ b/crates/skills/src/validation.rs
@@ -9,10 +9,13 @@ use serde_yml::{Mapping, Value};
 use thiserror::Error;
 use zip::ZipArchive;
 
-use crate::types::{
-    NormalizedSkillBundle, NormalizedSkillFile, ParsedSkillBundle, SkillDependencyTool,
-    SkillInterfaceMetadata, SkillParseWarning, SkillParseWarningKind, SkillPolicyMetadata,
-    SkillSidecarDependencies,
+use crate::{
+    config::SkillUploadLimits,
+    types::{
+        NormalizedSkillBundle, NormalizedSkillFile, ParsedSkillBundle, SkillDependencyTool,
+        SkillInterfaceMetadata, SkillParseWarning, SkillParseWarningKind, SkillPolicyMetadata,
+        SkillSidecarDependencies,
+    },
 };
 
 const MAX_NAME_LEN: usize = 64;
@@ -20,9 +23,6 @@ const MAX_DISPLAY_NAME_LEN: usize = 64;
 const MAX_DESCRIPTION_LEN: usize = 1024;
 const MAX_SIDECAR_STRING_LEN: usize = 1024;
 const MAX_BUNDLE_ARCHIVE_ENTRY_COUNT: usize = 1024;
-const MAX_BUNDLE_FILE_COUNT: usize = 500;
-const MAX_BUNDLE_FILE_SIZE_BYTES: u64 = 25 * 1024 * 1024;
-const MAX_BUNDLE_TOTAL_SIZE_BYTES: u64 = 30 * 1024 * 1024;
 const RESERVED_SKILL_NAMES: [&str; 3] = ["anthropic", "claude", "openai"];
 const SKILL_MD_PATH: &str = "SKILL.md";
 const OPENAI_SIDECAR_PATH: &str = "agents/openai.yaml";
@@ -154,6 +154,14 @@ pub fn parse_skill_bundle(
 pub fn normalize_skill_bundle_zip(
     zip_bytes: &[u8],
 ) -> Result<NormalizedSkillBundle, SkillBundleArchiveError> {
+    normalize_skill_bundle_zip_with_limits(zip_bytes, SkillUploadLimits::default())
+}
+
+/// Normalize an uploaded skill-bundle zip archive using explicit upload limits.
+pub fn normalize_skill_bundle_zip_with_limits(
+    zip_bytes: &[u8],
+    limits: SkillUploadLimits,
+) -> Result<NormalizedSkillBundle, SkillBundleArchiveError> {
     let mut archive = ZipArchive::new(Cursor::new(zip_bytes)).map_err(|error| {
         SkillBundleArchiveError::InvalidZip {
             message: error.to_string(),
@@ -237,32 +245,32 @@ pub fn normalize_skill_bundle_zip(
         match entry_type {
             ZipEntryType::Directory => continue,
             ZipEntryType::RegularFile => {
-                if files.len() >= MAX_BUNDLE_FILE_COUNT {
+                if files.len() >= limits.max_files_per_version {
                     return Err(SkillBundleArchiveError::TooManyFiles {
-                        max_files: MAX_BUNDLE_FILE_COUNT,
+                        max_files: limits.max_files_per_version,
                     });
                 }
 
                 let advertised_size_bytes = entry.size();
-                if advertised_size_bytes > MAX_BUNDLE_FILE_SIZE_BYTES {
+                if advertised_size_bytes > limits.max_file_size_bytes as u64 {
                     return Err(SkillBundleArchiveError::EntryTooLarge {
                         path: relative_path,
-                        max_bytes: MAX_BUNDLE_FILE_SIZE_BYTES,
+                        max_bytes: limits.max_file_size_bytes as u64,
                     });
                 }
 
-                let remaining_bundle_bytes = MAX_BUNDLE_TOTAL_SIZE_BYTES
+                let remaining_bundle_bytes = (limits.max_upload_size_bytes as u64)
                     .checked_sub(total_uncompressed_size_bytes)
                     .ok_or(SkillBundleArchiveError::BundleTooLarge {
-                        max_bytes: MAX_BUNDLE_TOTAL_SIZE_BYTES,
+                        max_bytes: limits.max_upload_size_bytes as u64,
                     })?;
                 if advertised_size_bytes > remaining_bundle_bytes {
                     return Err(SkillBundleArchiveError::BundleTooLarge {
-                        max_bytes: MAX_BUNDLE_TOTAL_SIZE_BYTES,
+                        max_bytes: limits.max_upload_size_bytes as u64,
                     });
                 }
 
-                let max_read_bytes = remaining_bundle_bytes.min(MAX_BUNDLE_FILE_SIZE_BYTES);
+                let max_read_bytes = remaining_bundle_bytes.min(limits.max_file_size_bytes as u64);
                 let mut contents = Vec::new();
                 let mut limited_entry = entry.take(max_read_bytes + 1);
                 limited_entry.read_to_end(&mut contents).map_err(|error| {
@@ -277,20 +285,20 @@ pub fn normalize_skill_bundle_zip(
                         message: "decompressed entry size overflowed u64".to_owned(),
                     }
                 })?;
-                if actual_size_bytes > MAX_BUNDLE_FILE_SIZE_BYTES {
+                if actual_size_bytes > limits.max_file_size_bytes as u64 {
                     return Err(SkillBundleArchiveError::EntryTooLarge {
                         path: relative_path,
-                        max_bytes: MAX_BUNDLE_FILE_SIZE_BYTES,
+                        max_bytes: limits.max_file_size_bytes as u64,
                     });
                 }
                 total_uncompressed_size_bytes = total_uncompressed_size_bytes
                     .checked_add(actual_size_bytes)
                     .ok_or(SkillBundleArchiveError::BundleTooLarge {
-                        max_bytes: MAX_BUNDLE_TOTAL_SIZE_BYTES,
+                        max_bytes: limits.max_upload_size_bytes as u64,
                     })?;
-                if total_uncompressed_size_bytes > MAX_BUNDLE_TOTAL_SIZE_BYTES {
+                if total_uncompressed_size_bytes > limits.max_upload_size_bytes as u64 {
                     return Err(SkillBundleArchiveError::BundleTooLarge {
-                        max_bytes: MAX_BUNDLE_TOTAL_SIZE_BYTES,
+                        max_bytes: limits.max_upload_size_bytes as u64,
                     });
                 }
 

--- a/model_gateway/src/app_context.rs
+++ b/model_gateway/src/app_context.rs
@@ -13,7 +13,7 @@ use smg_data_connector::{
     StorageFactoryConfig,
 };
 use smg_mcp::McpOrchestrator;
-use smg_skills::SkillService;
+use smg_skills::{SkillService, SkillUploadLimits};
 use tool_parser::ParserFactory as ToolParserFactory;
 use tracing::debug;
 
@@ -673,7 +673,12 @@ impl AppContextBuilder {
         let blob_store =
             create_blob_store(&skills_config.blob_store, Some(&skills_config.cache))
                 .map_err(|error| format!("Failed to initialize skills blob store: {error}"))?;
-        self.skill_service = Some(Arc::new(SkillService::in_memory(blob_store)));
+        let upload_limits = SkillUploadLimits::from_config(skills_config)
+            .map_err(|error| format!("Invalid skills upload limits: {error}"))?;
+        self.skill_service = Some(Arc::new(SkillService::in_memory_with_limits(
+            blob_store,
+            upload_limits,
+        )));
         Ok(self)
     }
 

--- a/model_gateway/src/config/validation.rs
+++ b/model_gateway/src/config/validation.rs
@@ -120,6 +120,7 @@ impl ConfigValidator {
                 reason: "Must be > 0".to_string(),
             });
         }
+        validate_mebibyte_limit("skills.max_upload_size_mb", skills.max_upload_size_mb)?;
 
         if skills.max_file_size_mb == 0 {
             return Err(ConfigError::InvalidValue {
@@ -128,6 +129,7 @@ impl ConfigValidator {
                 reason: "Must be > 0".to_string(),
             });
         }
+        validate_mebibyte_limit("skills.max_file_size_mb", skills.max_file_size_mb)?;
 
         if skills.max_file_size_mb > skills.max_upload_size_mb {
             return Err(ConfigError::InvalidValue {
@@ -862,6 +864,20 @@ impl ConfigValidator {
         }
         Ok(())
     }
+}
+
+fn validate_mebibyte_limit(field: &str, value_mb: usize) -> ConfigResult<()> {
+    const MEBIBYTE: usize = 1024 * 1024;
+
+    if value_mb.checked_mul(MEBIBYTE).is_none() {
+        return Err(ConfigError::InvalidValue {
+            field: field.to_string(),
+            value: value_mb.to_string(),
+            reason: "Must fit into usize bytes".to_string(),
+        });
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/model_gateway/src/routers/skills/handlers.rs
+++ b/model_gateway/src/routers/skills/handlers.rs
@@ -1,5 +1,5 @@
 use axum::{
-    extract::{multipart::MultipartError, Multipart, Path, Query, State},
+    extract::{multipart::Field, Multipart, Path, Query, State},
     http::{
         header::{self, HeaderMap, HeaderValue},
         StatusCode,
@@ -20,13 +20,16 @@ use serde_json::Value;
 use sha2::{Digest, Sha256};
 use smg_skills::{
     CreateSkillRequest, CreateSkillVersionRequest, SkillCreateResult, SkillServiceError,
-    SkillUpload, UpdateSkillRequest, UpdateSkillVersionRequest, UploadedSkillFile,
+    SkillUpload, SkillUploadLimits, SkillsAdminOperation, UpdateSkillRequest,
+    UpdateSkillVersionRequest, UploadedSkillFile,
 };
+use tracing::error;
 
 use crate::{middleware::resolve_admin_target_tenant_key, server::AppState};
 
 const DEFAULT_SKILLS_LIST_LIMIT: usize = 100;
 const MAX_SKILLS_LIST_LIMIT: usize = 100;
+const MAX_TENANT_ID_FIELD_BYTES: usize = 4096;
 
 #[derive(Debug)]
 struct ParsedSkillUpload {
@@ -37,6 +40,7 @@ struct ParsedSkillUpload {
 #[derive(Debug)]
 enum SkillsApiError {
     BadRequest { code: &'static str, message: String },
+    Forbidden { code: &'static str, message: String },
     NotFound { code: &'static str, message: String },
     Conflict { code: &'static str, message: String },
     Internal { code: &'static str, message: String },
@@ -46,6 +50,7 @@ impl IntoResponse for SkillsApiError {
     fn into_response(self) -> Response {
         let (status, code, message) = match self {
             Self::BadRequest { code, message } => (StatusCode::BAD_REQUEST, code, message),
+            Self::Forbidden { code, message } => (StatusCode::FORBIDDEN, code, message),
             Self::NotFound { code, message } => (StatusCode::NOT_FOUND, code, message),
             Self::Conflict { code, message } => (StatusCode::CONFLICT, code, message),
             Self::Internal { code, message } => (StatusCode::INTERNAL_SERVER_ERROR, code, message),
@@ -122,15 +127,29 @@ impl From<SkillServiceError> for SkillsApiError {
             SkillServiceError::BundleBuild(_)
             | SkillServiceError::BlobStore(_)
             | SkillServiceError::Store(_)
-            | SkillServiceError::MissingComponent { .. } => Self::Internal {
-                code: "skills_internal_error",
-                message: error.to_string(),
-            },
-            SkillServiceError::MissingDefaultVersion { .. } => Self::Internal {
-                code: "default_version_missing",
-                message: error.to_string(),
-            },
+            | SkillServiceError::MissingComponent { .. } => internal_skill_service_error(
+                error,
+                "skills_internal_error",
+                "skills request failed due to an internal error",
+            ),
+            SkillServiceError::MissingDefaultVersion { .. } => internal_skill_service_error(
+                error,
+                "default_version_missing",
+                "skills metadata is internally inconsistent",
+            ),
         }
+    }
+}
+
+fn internal_skill_service_error(
+    error: SkillServiceError,
+    code: &'static str,
+    public_message: &'static str,
+) -> SkillsApiError {
+    error!(error = %error, "skills API internal error");
+    SkillsApiError::Internal {
+        code,
+        message: public_message.to_string(),
     }
 }
 
@@ -258,7 +277,8 @@ async fn create_skill_impl(
                 code: "skills_not_configured",
                 message: "skills service is not configured".to_string(),
             })?;
-    let parsed = parse_skill_upload(multipart).await?;
+    ensure_admin_operation_allowed(&state, SkillsAdminOperation::CreateAnyTenant)?;
+    let parsed = parse_skill_upload(multipart, skill_service.upload_limits()).await?;
     let result = skill_service
         .create_skill(CreateSkillRequest {
             tenant_id: parsed.tenant_id,
@@ -283,7 +303,8 @@ async fn create_skill_version_impl(
                 code: "skills_not_configured",
                 message: "skills service is not configured".to_string(),
             })?;
-    let parsed = parse_skill_upload(multipart).await?;
+    ensure_admin_operation_allowed(&state, SkillsAdminOperation::CreateAnyTenant)?;
+    let parsed = parse_skill_upload(multipart, skill_service.upload_limits()).await?;
     let result = skill_service
         .create_skill_version(CreateSkillVersionRequest {
             tenant_id: parsed.tenant_id,
@@ -310,6 +331,7 @@ async fn patch_skill_impl(
                 code: "skills_not_configured",
                 message: "skills service is not configured".to_string(),
             })?;
+    ensure_admin_operation_allowed(&state, SkillsAdminOperation::UpdateAnyTenant)?;
     let tenant_id = resolve_target_tenant_id(query.tenant_id.as_deref())?;
     let updated = skill_service
         .update_skill(UpdateSkillRequest {
@@ -338,6 +360,7 @@ async fn patch_skill_version_impl(
                 code: "skills_not_configured",
                 message: "skills service is not configured".to_string(),
             })?;
+    ensure_admin_operation_allowed(&state, SkillsAdminOperation::UpdateAnyTenant)?;
     let tenant_id = resolve_target_tenant_id(query.tenant_id.as_deref())?;
     let updated = skill_service
         .update_skill_version(UpdateSkillVersionRequest {
@@ -365,6 +388,7 @@ async fn delete_skill_impl(
                 code: "skills_not_configured",
                 message: "skills service is not configured".to_string(),
             })?;
+    ensure_admin_operation_allowed(&state, SkillsAdminOperation::DeleteAnyTenant)?;
     let tenant_id = resolve_target_tenant_id(query.tenant_id.as_deref())?;
     skill_service
         .delete_skill(&tenant_id, &skill_id)
@@ -387,6 +411,7 @@ async fn delete_skill_version_impl(
                 code: "skills_not_configured",
                 message: "skills service is not configured".to_string(),
             })?;
+    ensure_admin_operation_allowed(&state, SkillsAdminOperation::DeleteAnyTenant)?;
     let tenant_id = resolve_target_tenant_id(query.tenant_id.as_deref())?;
     skill_service
         .delete_skill_version(&tenant_id, &skill_id, &version)
@@ -409,6 +434,7 @@ async fn list_skills_impl(
                 code: "skills_not_configured",
                 message: "skills service is not configured".to_string(),
             })?;
+    ensure_admin_operation_allowed(&state, SkillsAdminOperation::ReadAnyTenant)?;
     let tenant_id = resolve_target_tenant_id(query.tenant_id.as_deref())?;
     let limit = validate_list_limit(query.limit)?;
     let mut records = skill_service
@@ -469,6 +495,7 @@ async fn get_skill_impl(
                 code: "skills_not_configured",
                 message: "skills service is not configured".to_string(),
             })?;
+    ensure_admin_operation_allowed(&state, SkillsAdminOperation::ReadAnyTenant)?;
     let tenant_id = resolve_target_tenant_id(query.tenant_id.as_deref())?;
     let record = skill_service
         .get_skill(&tenant_id, &skill_id)
@@ -499,6 +526,7 @@ async fn list_skill_versions_impl(
                 code: "skills_not_configured",
                 message: "skills service is not configured".to_string(),
             })?;
+    ensure_admin_operation_allowed(&state, SkillsAdminOperation::ReadAnyTenant)?;
     let tenant_id = resolve_target_tenant_id(query.tenant_id.as_deref())?;
     let limit = validate_list_limit(query.limit)?;
     let skill = skill_service
@@ -565,6 +593,7 @@ async fn get_skill_version_impl(
                 code: "skills_not_configured",
                 message: "skills service is not configured".to_string(),
             })?;
+    ensure_admin_operation_allowed(&state, SkillsAdminOperation::ReadAnyTenant)?;
     let tenant_id = resolve_target_tenant_id(query.tenant_id.as_deref())?;
     let skill = skill_service
         .get_skill(&tenant_id, &skill_id)
@@ -658,6 +687,26 @@ fn resolve_target_tenant_id(raw_tenant_id: Option<&str>) -> Result<String, Skill
             code: "missing_target_tenant",
             message: error.to_string(),
         })
+}
+
+fn ensure_admin_operation_allowed(
+    state: &AppState,
+    operation: SkillsAdminOperation,
+) -> Result<(), SkillsApiError> {
+    let allowed = state
+        .context
+        .router_config
+        .skills
+        .as_ref()
+        .is_some_and(|skills| skills.admin.allowed_operations.contains(&operation));
+    if allowed {
+        return Ok(());
+    }
+
+    Err(SkillsApiError::Forbidden {
+        code: "skills_operation_not_allowed",
+        message: format!("skills admin operation '{operation:?}' is not allowed"),
+    })
 }
 
 fn validate_list_limit(limit: Option<u32>) -> Result<usize, SkillsApiError> {
@@ -854,10 +903,14 @@ fn cache_headers(
     Ok(headers)
 }
 
-async fn parse_skill_upload(mut multipart: Multipart) -> Result<ParsedSkillUpload, SkillsApiError> {
+async fn parse_skill_upload(
+    mut multipart: Multipart,
+    limits: SkillUploadLimits,
+) -> Result<ParsedSkillUpload, SkillsApiError> {
     let mut tenant_id = None;
     let mut zip_upload = None;
     let mut files = Vec::new();
+    let mut total_file_bytes = 0usize;
 
     while let Some(field) = multipart
         .next_field()
@@ -870,10 +923,12 @@ async fn parse_skill_upload(mut multipart: Multipart) -> Result<ParsedSkillUploa
                 if tenant_id.is_some() {
                     return Err(unexpected_field("tenant_id may only be provided once"));
                 }
-                let value = field
-                    .text()
-                    .await
-                    .map_err(|error| bad_text_field(SKILLS_MULTIPART_TENANT_ID_FIELD, error))?;
+                let value = read_text_field_limited(
+                    field,
+                    SKILLS_MULTIPART_TENANT_ID_FIELD,
+                    MAX_TENANT_ID_FIELD_BYTES,
+                )
+                .await?;
                 tenant_id = Some(
                     resolve_admin_target_tenant_key(&value)
                         .map_err(|error| SkillsApiError::BadRequest {
@@ -901,10 +956,10 @@ async fn parse_skill_upload(mut multipart: Multipart) -> Result<ParsedSkillUploa
                                 .to_string(),
                     });
                 }
-                let bytes = field.bytes().await.map_err(|error| {
-                    invalid_multipart(format!("failed to read zip upload: {error}"))
-                })?;
-                zip_upload = Some(bytes.to_vec());
+                let bytes =
+                    read_field_bytes_limited(field, limits.max_upload_size_bytes, "zip upload")
+                        .await?;
+                zip_upload = Some(bytes);
             }
             "files" | SKILLS_MULTIPART_FILES_FIELD => {
                 if zip_upload.is_some() {
@@ -921,17 +976,38 @@ async fn parse_skill_upload(mut multipart: Multipart) -> Result<ParsedSkillUploa
                     }
                 })?;
                 let media_type = field.content_type().map(str::to_string);
-                let contents = field.bytes().await.map_err(|error| {
-                    invalid_multipart(format!("failed to read uploaded file bytes: {error}"))
-                })?;
+                if files.len() >= limits.max_files_per_version {
+                    return Err(SkillsApiError::BadRequest {
+                        code: "invalid_skill_bundle",
+                        message: format!(
+                            "skill bundle contains more than {} regular files",
+                            limits.max_files_per_version
+                        ),
+                    });
+                }
+                let remaining_upload_bytes = limits
+                    .max_upload_size_bytes
+                    .saturating_sub(total_file_bytes);
+                let max_field_bytes = remaining_upload_bytes.min(limits.max_file_size_bytes);
+                let contents =
+                    read_field_bytes_limited(field, max_field_bytes, "uploaded skill file").await?;
+                total_file_bytes =
+                    total_file_bytes
+                        .checked_add(contents.len())
+                        .ok_or_else(|| SkillsApiError::BadRequest {
+                            code: "skill_upload_too_large",
+                            message: format!(
+                                "skill upload exceeds maximum total size of {} bytes",
+                                limits.max_upload_size_bytes
+                            ),
+                        })?;
                 files.push(UploadedSkillFile {
                     relative_path,
-                    contents: contents.to_vec(),
+                    contents,
                     media_type,
                 });
             }
             _ => {
-                let _ = field.bytes().await;
                 return Err(unexpected_field(&format!(
                     "unexpected multipart field '{field_name}'"
                 )));
@@ -994,10 +1070,43 @@ fn unexpected_field(message: &str) -> SkillsApiError {
     }
 }
 
-fn bad_text_field(field: &str, error: MultipartError) -> SkillsApiError {
-    SkillsApiError::BadRequest {
+async fn read_text_field_limited(
+    field: Field<'_>,
+    field_name: &'static str,
+    max_bytes: usize,
+) -> Result<String, SkillsApiError> {
+    let bytes = read_field_bytes_limited(field, max_bytes, field_name).await?;
+    String::from_utf8(bytes).map_err(|error| SkillsApiError::BadRequest {
         code: "invalid_multipart",
-        message: format!("failed to read '{field}' field: {error}"),
+        message: format!("failed to read '{field_name}' field as UTF-8: {error}"),
+    })
+}
+
+async fn read_field_bytes_limited(
+    mut field: Field<'_>,
+    max_bytes: usize,
+    field_description: &str,
+) -> Result<Vec<u8>, SkillsApiError> {
+    let mut bytes = Vec::new();
+    while let Some(chunk) = field.chunk().await.map_err(|error| {
+        invalid_multipart(format!("failed to read {field_description}: {error}"))
+    })? {
+        let next_len = bytes
+            .len()
+            .checked_add(chunk.len())
+            .ok_or_else(|| upload_too_large(field_description, max_bytes))?;
+        if next_len > max_bytes {
+            return Err(upload_too_large(field_description, max_bytes));
+        }
+        bytes.extend_from_slice(&chunk);
+    }
+    Ok(bytes)
+}
+
+fn upload_too_large(field_description: &str, max_bytes: usize) -> SkillsApiError {
+    SkillsApiError::BadRequest {
+        code: "skill_upload_too_large",
+        message: format!("{field_description} exceeds maximum size of {max_bytes} bytes"),
     }
 }
 
@@ -1079,4 +1188,35 @@ fn serialize_optional_json<T: Serialize>(
             })
         })
         .transpose()
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::body::to_bytes;
+    use smg_blob_storage::BlobStoreError;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn internal_skill_service_errors_hide_backend_details(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let response =
+            SkillsApiError::from(SkillServiceError::BlobStore(BlobStoreError::Operation {
+                operation: "put",
+                message: "oracle dsn and filesystem path".to_string(),
+            }))
+            .into_response();
+
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let bytes = to_bytes(response.into_body(), usize::MAX).await?;
+        let body: Value = serde_json::from_slice(&bytes)?;
+        assert_eq!(body["error"]["code"], "skills_internal_error");
+        assert_eq!(
+            body["error"]["message"],
+            "skills request failed due to an internal error"
+        );
+        assert!(!body.to_string().contains("oracle dsn"));
+
+        Ok(())
+    }
 }

--- a/model_gateway/tests/api/skills_api_test.rs
+++ b/model_gateway/tests/api/skills_api_test.rs
@@ -19,7 +19,7 @@ use smg::{
     config::{PolicyConfig, RouterConfig, RoutingMode},
     routers::RouterTrait,
 };
-use smg_skills::SkillsConfig;
+use smg_skills::{SkillsAdminOperation, SkillsConfig};
 use tempfile::TempDir;
 use zip::{write::SimpleFileOptions, CompressionMethod, ZipWriter};
 
@@ -1071,6 +1071,90 @@ async fn create_skill_route_is_not_mounted_when_skills_admin_is_disabled() {
         .expect("send create skill request");
 
     assert_eq!(response.status(), reqwest::StatusCode::NOT_FOUND);
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn create_skill_enforces_configured_upload_limits_before_service() {
+    let blob_dir = tempfile::tempdir().expect("blob tempdir");
+    let cache_dir = tempfile::tempdir().expect("cache tempdir");
+    let mut config = skills_test_config(&blob_dir, &cache_dir, true);
+    let skills = config.skills.as_mut().expect("skills config");
+    skills.max_upload_size_mb = 2;
+    skills.max_file_size_mb = 1;
+    let app = create_skills_test_app(config).await;
+    let (base_url, server) = spawn_app(app).await;
+
+    let response = reqwest::Client::new()
+        .post(format!("{base_url}/v1/skills"))
+        .bearer_auth("test-admin-key")
+        .multipart(
+            Form::new()
+                .text("tenant_id", "tenant-a")
+                .part(
+                    "files[]",
+                    Part::bytes(
+                        b"---\nname: acme:map\ndescription: Map the repo\n---\nUse rg.".to_vec(),
+                    )
+                    .file_name("SKILL.md")
+                    .mime_str("text/markdown")
+                    .expect("valid markdown mime"),
+                )
+                .part(
+                    "files[]",
+                    Part::bytes(vec![b'x'; 1024 * 1024 + 1])
+                        .file_name("too-large.txt")
+                        .mime_str("text/plain")
+                        .expect("valid text mime"),
+                ),
+        )
+        .send()
+        .await
+        .expect("send create skill request");
+
+    assert_eq!(response.status(), reqwest::StatusCode::BAD_REQUEST);
+    let body: Value = response.json().await.expect("json response");
+    assert_eq!(body["error"]["code"], "skill_upload_too_large");
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn skills_admin_allowed_operations_gate_create_requests() {
+    let blob_dir = tempfile::tempdir().expect("blob tempdir");
+    let cache_dir = tempfile::tempdir().expect("cache tempdir");
+    let mut config = skills_test_config(&blob_dir, &cache_dir, true);
+    config
+        .skills
+        .as_mut()
+        .expect("skills config")
+        .admin
+        .allowed_operations = vec![SkillsAdminOperation::ReadAnyTenant];
+    let app = create_skills_test_app(config).await;
+    let (base_url, server) = spawn_app(app).await;
+
+    let response = reqwest::Client::new()
+        .post(format!("{base_url}/v1/skills"))
+        .bearer_auth("test-admin-key")
+        .multipart(
+            Form::new().text("tenant_id", "tenant-a").part(
+                "files[]",
+                Part::bytes(
+                    b"---\nname: acme:map\ndescription: Map the repo\n---\nUse rg.".to_vec(),
+                )
+                .file_name("SKILL.md")
+                .mime_str("text/markdown")
+                .expect("valid markdown mime"),
+            ),
+        )
+        .send()
+        .await
+        .expect("send create skill request");
+
+    assert_eq!(response.status(), reqwest::StatusCode::FORBIDDEN);
+    let body: Value = response.json().await.expect("json response");
+    assert_eq!(body["error"]["code"], "skills_operation_not_allowed");
 
     server.abort();
 }


### PR DESCRIPTION
## Summary

- Enforce configured skills upload, file-size, total-size, and file-count limits before buffering uploads and inside direct service calls.
- Sanitize internal skills service, store, and blob errors in API responses while logging backend details server-side.
- Gate skills CRUD routes with `allowed_operations` and make create/version metadata writes atomic at the store boundary.

## Validation

- `cargo check -p smg-skills -p smg --tests`
- `cargo test -p smg-skills`
- `cargo test -p smg --test api_tests skills_api`
- `cargo test -p smg internal_skill_service_errors_hide_backend_details`
- `cargo +nightly fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Configurable upload limits for skills now enforced: maximum file size, file count per version, and total upload size.
  * Admin operation authorization checks added to skill management endpoints; requests without proper permissions return 403 Forbidden.

* **Bug Fixes**
  * Enhanced error handling with clearer, safer error messages for skill service operations.
  * Added validation to prevent configuration overflow when converting size limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->