### PR TITLE
fix(grpc-harmony): dispatch image_generation as function tool for gpt-oss (R6.8)

### DIFF
--- a/model_gateway/src/routers/grpc/common/responses/utils.rs
+++ b/model_gateway/src/routers/grpc/common/responses/utils.rs
@@ -25,11 +25,11 @@ use crate::{
     worker::WorkerRegistry,
 };
 
-/// Ensure MCP connection succeeds if MCP tools or builtin tools are declared
+/// Ensure MCP connection succeeds if MCP tools or builtin tools are declared.
 ///
-/// Checks if request declares MCP tools or builtin tool types (web_search_preview,
-/// code_interpreter), and if so, validates that the MCP clients can be created
-/// and connected.
+/// Checks if the request declares MCP tools or builtin tool types
+/// (`web_search_preview`, `code_interpreter`, `image_generation`) and,
+/// if so, validates that the MCP clients can be created and connected.
 ///
 /// Returns Ok((has_mcp_tools, mcp_servers)) on success.
 pub(crate) async fn ensure_mcp_connection(
@@ -41,13 +41,23 @@ pub(crate) async fn ensure_mcp_connection(
         .map(|t| t.iter().any(|tool| matches!(tool, ResponseTool::Mcp(_))))
         .unwrap_or(false);
 
-    // Check for builtin tools that MAY have MCP routing configured
+    // Check for builtin tools that MAY have MCP routing configured.
+    //
+    // `ImageGeneration` is included here (R6.8) because gpt-oss via the
+    // harmony pipeline, and Qwen/Llama via the regular pipeline, both
+    // dispatch hosted `image_generation` calls through the same MCP
+    // routing path — the only difference is how the tool is advertised in
+    // the prompt. Without this arm, the short-circuit below returned
+    // `(false, Vec::new())`, the MCP loop was never entered, and the
+    // registered `image_generation` MCP server received zero dispatches.
     let has_builtin_tools = tools
         .map(|t| {
             t.iter().any(|tool| {
                 matches!(
                     tool,
-                    ResponseTool::WebSearchPreview(_) | ResponseTool::CodeInterpreter(_)
+                    ResponseTool::WebSearchPreview(_)
+                        | ResponseTool::CodeInterpreter(_)
+                        | ResponseTool::ImageGeneration(_)
                 )
             })
         })

--- a/model_gateway/src/routers/grpc/harmony/builder.rs
+++ b/model_gateway/src/routers/grpc/harmony/builder.rs
@@ -2,7 +2,7 @@
 //!
 //! Handles encoding of Chat/Responses requests into Harmony format using openai-harmony library.
 
-use std::sync::OnceLock;
+use std::{collections::HashSet, sync::OnceLock};
 
 use chrono::Local;
 use openai_harmony::{
@@ -21,6 +21,7 @@ use openai_protocol::{
         StringOrContentParts,
     },
 };
+use serde_json::json;
 use tracing::{debug, trace, warn};
 
 use super::types::HarmonyBuildOutput;
@@ -59,21 +60,44 @@ pub(crate) fn convert_harmony_logprobs(proto_logprobs: &ProtoOutputLogProbs) -> 
     })
 }
 
-/// Built-in tools that are added to the system message
+/// Built-in tools that are advertised in the gpt-oss system message.
+///
+/// Scoped to the hosted tools gpt-oss was trained to emit directly as
+/// channel-tagged tool calls (per the openai-harmony spec):
+/// `web_search_preview`, `web_search`, `code_interpreter` / `container`,
+/// `file_search`.
+///
+/// Hosted tools outside this set — notably `image_generation` — were
+/// *not* part of gpt-oss training. Advertising them here would render
+/// them into the builtin-tools preamble, but the model has never been
+/// trained to emit the corresponding `image_generation_call` channel
+/// tag, so the result is undefined behavior (hallucinated malformed
+/// call, ignored advertisement, or garbled output). Instead, the
+/// [`ToolLike`] impl for [`ResponseTool::ImageGeneration`] renders the
+/// hosted tool as a *function tool* in the developer-message
+/// custom-tool section (R6.8): gpt-oss sees `image_generation` as a
+/// callable function, emits a plain function call with a `prompt`
+/// argument, and the downstream MCP dispatch path — keyed on the
+/// exposed function-tool name — routes the call to the registered
+/// `image_generation` MCP server and materializes the response as an
+/// `image_generation_call` output item.
 const BUILTIN_TOOLS: &[&str] = &[
     "web_search_preview",
     "web_search",
     "code_interpreter",
     "container",
     "file_search",
-    "image_generation",
     "shell",
 ];
 
 /// Trait for tool-like objects that can be converted to Harmony ToolDescription
 trait ToolLike {
-    /// Check if this is a built-in tool (should be skipped in developer message)
-    #[expect(dead_code)]
+    /// Check if this is a built-in tool (should be skipped in developer message).
+    ///
+    /// Only exercised by tests today; once per-worker hosted-tool
+    /// capability flags land (R0 follow-up), production code will dispatch
+    /// on this to gate advertisement per model.
+    #[cfg_attr(not(test), expect(dead_code, reason = "reserved for R0 follow-up"))]
     fn is_builtin(&self) -> bool;
 
     /// Check if this is a custom tool (function or MCP)
@@ -117,7 +141,15 @@ impl ToolLike for ResponseTool {
     }
 
     fn is_custom(&self) -> bool {
-        matches!(self, ResponseTool::Function(_))
+        // `ImageGeneration` is rendered as a *function tool* because gpt-oss
+        // was not trained to emit `image_generation_call` as a builtin
+        // channel tag; instead, the gateway advertises it in the custom-tool
+        // section and routes the resulting function call through MCP
+        // dispatch. See [`BUILTIN_TOOLS`] above and the R6.8 commit body.
+        matches!(
+            self,
+            ResponseTool::Function(_) | ResponseTool::ImageGeneration(_)
+        )
     }
 
     fn to_tool_description(&self) -> Option<ToolDescription> {
@@ -127,9 +159,74 @@ impl ToolLike for ResponseTool {
                 ft.function.description.clone().unwrap_or_default(),
                 Some(ft.function.parameters.clone()),
             )),
+            ResponseTool::ImageGeneration(_) => Some(image_generation_tool_description()),
             _ => None,
         }
     }
+}
+
+/// Synthesize a function-tool description for the hosted `image_generation`
+/// tool when targeting gpt-oss via the harmony pipeline.
+///
+/// gpt-oss was not trained to emit `image_generation_call` as a native
+/// hosted-tool channel tag (see [`BUILTIN_TOOLS`]). This helper produces a
+/// JSON-schema that exposes the same tool surface the OpenAI spec documents
+/// (`prompt`, plus pass-through configuration fields mirrored from
+/// [`openai_protocol::responses::ImageGenerationTool`]) as a plain function
+/// tool. gpt-oss then emits `{"name": "image_generation", "arguments": {…}}`
+/// on the commentary channel, and the shared MCP dispatch path — keyed on
+/// the function name against the registered `image_generation` MCP server —
+/// materializes the response into a proper `image_generation_call` output
+/// item.
+///
+/// The schema deliberately stays a superset of what the spec documents on
+/// the tool-level configuration so the model can choose to override
+/// caller-supplied defaults when the prompt demands it (e.g. switching
+/// `size` for portrait vs. landscape output). The caller's original
+/// tool-level configuration continues to round-trip in
+/// `ResponseTool::ImageGeneration(cfg)` for downstream routing / tests.
+fn image_generation_tool_description() -> ToolDescription {
+    let parameters = json!({
+        "type": "object",
+        "properties": {
+            "prompt": {
+                "type": "string",
+                "description": "Natural-language description of the image to generate. Required."
+            },
+            "background": {
+                "type": "string",
+                "enum": ["transparent", "opaque", "auto"],
+                "description": "Background handling for the generated image."
+            },
+            "model": {
+                "type": "string",
+                "description": "Image-generation model identifier (e.g. gpt-image-1, gpt-image-1-mini, gpt-image-1.5)."
+            },
+            "output_format": {
+                "type": "string",
+                "enum": ["png", "webp", "jpeg"],
+                "description": "Encoding for the returned image."
+            },
+            "quality": {
+                "type": "string",
+                "enum": ["low", "medium", "high", "auto"],
+                "description": "Quality tier requested from the image model."
+            },
+            "size": {
+                "type": "string",
+                "enum": ["1024x1024", "1024x1536", "1536x1024", "auto"],
+                "description": "Output resolution. Use 'auto' to let the model pick."
+            }
+        },
+        "required": ["prompt"],
+        "additionalProperties": false
+    });
+
+    ToolDescription::new(
+        "image_generation",
+        "Generate an image from a natural-language prompt. Use this when the user asks for a picture, illustration, or other visual content. The call is routed through the gateway's image_generation MCP server and the result is returned as a base64-encoded image in an image_generation_call output item.",
+        Some(parameters),
+    )
 }
 
 fn has_custom_tools(tool_types: &[&str]) -> bool {
@@ -370,11 +467,29 @@ impl HarmonyBuilder {
             return HarmonyMessage::from_role_and_content(Role::Developer, dev_content);
         };
 
-        // Filter to custom tools and convert to ToolDescription
+        // Filter to custom tools, convert to ToolDescription, and
+        // deduplicate by name.
+        //
+        // Deduplication matters in the Responses-API path because the
+        // upstream MCP loop extends `request.tools` with a
+        // `ResponseTool::Function` entry for every tool exposed by a
+        // registered MCP server (see `execute_with_mcp_loop` in
+        // `harmony/responses/non_streaming.rs`). When the caller's
+        // original request also declared a hosted tool that the MCP
+        // server resolves by the same name — most notably
+        // `image_generation` via the R6.8 synthesized schema — we would
+        // otherwise emit two identically-named entries inside
+        // `namespace functions { … }` and confuse gpt-oss about which
+        // signature to follow. Keeping the first occurrence (the
+        // caller's original / synthesized tool) yields a stable
+        // developer-message shape even when the MCP loop injects a
+        // same-name function tool on a later iteration.
+        let mut seen_names = HashSet::<String>::new();
         let tool_descriptions: Vec<ToolDescription> = tools
             .iter()
             .filter(|t| t.is_custom())
             .filter_map(|t| t.to_tool_description())
+            .filter(|td| seen_names.insert(td.name.clone()))
             .collect();
 
         // Add function tools to developer content
@@ -1042,5 +1157,247 @@ impl HarmonyBuilder {
 impl Default for HarmonyBuilder {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! R6.8 regression coverage for the `image_generation` → function-tool
+    //! translation gpt-oss needs via the harmony pipeline.
+    //!
+    //! Before R6.8 the harmony builder silently dropped
+    //! `ResponseTool::ImageGeneration` — it classified as a builtin (via
+    //! the historical `BUILTIN_TOOLS` membership) but gpt-oss was never
+    //! trained to emit `image_generation_call` as a builtin channel tag.
+    //! Net effect: the model saw no tool at all, emitted a
+    //! reasoning + message pair, and the registered `image_generation`
+    //! MCP server received zero dispatches.
+    //!
+    //! These tests lock in the new contract:
+    //!   1. `image_generation` is NOT in `BUILTIN_TOOLS`.
+    //!   2. `ResponseTool::ImageGeneration` is treated as a *custom* tool
+    //!      by the harmony `ToolLike` impl.
+    //!   3. `to_tool_description()` synthesizes a JSON-schema whose
+    //!      `required` set includes `prompt`.
+    //!   4. The encoded harmony conversation contains the function-tool
+    //!      signature (`type image_generation = (_: …) => any;`) that
+    //!      gpt-oss is trained to emit calls against.
+
+    use openai_protocol::responses::{
+        ImageGenerationTool, ResponseInput, ResponseTool, ResponsesRequest,
+    };
+
+    use super::*;
+
+    /// PR #1353's invariant: `image_generation` must never be advertised
+    /// as a gpt-oss native builtin tool. If a future change re-adds it,
+    /// gpt-oss's behavior becomes undefined (hallucinated tool call
+    /// shape, ignored advertisement, or garbled output) because the
+    /// model was not trained on that channel tag. Keep this guard until
+    /// per-worker hosted-tool capability flags exist.
+    #[test]
+    fn image_generation_is_not_a_builtin_tool() {
+        assert!(
+            !BUILTIN_TOOLS.contains(&"image_generation"),
+            "image_generation must not be advertised as a gpt-oss builtin; \
+             it is rendered as a function tool instead (R6.8)",
+        );
+    }
+
+    /// The [`ToolLike`] custom-tool classifier drives two pieces of the
+    /// harmony prompt assembly: whether to include the `commentary`
+    /// channel in the system message and whether the developer message
+    /// is emitted with a tools section. Both are required for gpt-oss
+    /// to emit a function call, so `ImageGeneration` must report as
+    /// custom.
+    #[test]
+    fn response_tool_image_generation_is_custom() {
+        let tool = ResponseTool::ImageGeneration(ImageGenerationTool::default());
+        assert!(
+            tool.is_custom(),
+            "ImageGeneration must be is_custom() == true so the harmony \
+             pipeline renders it in the developer-message tools section",
+        );
+        assert!(
+            !tool.is_builtin(),
+            "ImageGeneration must not be classified as a gpt-oss native builtin",
+        );
+    }
+
+    /// Exercise the synthesized JSON-schema the harmony builder hands to
+    /// gpt-oss. `prompt` is the only required field (the rest mirror
+    /// [`ImageGenerationTool`] caller-side configuration knobs). If the
+    /// schema shape drifts, the model either stops emitting valid
+    /// `image_generation` calls or regresses on caller-driven overrides.
+    #[test]
+    fn image_generation_tool_description_exposes_required_prompt() {
+        let tool = ResponseTool::ImageGeneration(ImageGenerationTool::default());
+        let description = tool
+            .to_tool_description()
+            .expect("ImageGeneration must produce a synthesized ToolDescription");
+
+        assert_eq!(
+            description.name, "image_generation",
+            "function-tool name must match what the MCP session exposes so \
+             dispatch routes correctly",
+        );
+        assert!(
+            !description.description.is_empty(),
+            "description should be non-empty so gpt-oss understands when to call",
+        );
+
+        let parameters = description
+            .parameters
+            .as_ref()
+            .expect("parameters JSON-schema must be present");
+        assert_eq!(parameters["type"], "object", "schema must be an object");
+
+        let required = parameters["required"]
+            .as_array()
+            .expect("`required` array must be present");
+        assert!(
+            required.iter().any(|v| v.as_str() == Some("prompt")),
+            "`prompt` must be a required parameter, got: {required:?}",
+        );
+
+        let properties = parameters["properties"]
+            .as_object()
+            .expect("`properties` object must be present");
+        for expected in ["prompt", "size", "quality", "background", "output_format"] {
+            assert!(
+                properties.contains_key(expected),
+                "parameters.properties must include `{expected}`; got: {:?}",
+                properties.keys().collect::<Vec<_>>(),
+            );
+        }
+
+        // `prompt` must be typed as a string so gpt-oss renders a
+        // free-form text slot rather than a structured object.
+        assert_eq!(
+            properties["prompt"]["type"], "string",
+            "`prompt` must be a string parameter",
+        );
+    }
+
+    /// End-to-end assertion on the encoded harmony prompt: for a request
+    /// that declares only an `image_generation` tool, the rendered
+    /// conversation MUST contain the function-tool signature gpt-oss
+    /// looks for on the commentary channel. This catches regressions
+    /// where the tool is silently dropped from the developer message.
+    ///
+    /// Uses `#[tokio::test(flavor = "multi_thread")]` because
+    /// [`HarmonyBuilder::new`] → [`get_harmony_encoding`] wraps its
+    /// one-shot initialization in [`tokio::task::block_in_place`], which
+    /// requires a multi-threaded runtime context.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn build_from_responses_renders_image_generation_as_function_tool() {
+        let builder = HarmonyBuilder::new();
+        let request = ResponsesRequest {
+            model: "gpt-oss-120b".to_string(),
+            input: ResponseInput::Text("draw a cat".to_string()),
+            tools: Some(vec![ResponseTool::ImageGeneration(
+                ImageGenerationTool::default(),
+            )]),
+            ..Default::default()
+        };
+
+        let output = builder
+            .build_from_responses(&request)
+            .expect("harmony build must succeed");
+
+        let decoded = builder
+            .encoding
+            .tokenizer()
+            .decode_utf8(&output.input_ids)
+            .expect("decode harmony tokens back to UTF-8");
+
+        assert!(
+            decoded.contains("type image_generation = ("),
+            "harmony prompt must advertise image_generation as a function \
+             tool to gpt-oss; decoded prompt: {decoded}",
+        );
+        assert!(
+            decoded.contains("namespace functions"),
+            "function-tool section (namespace functions) must be present; \
+             decoded prompt: {decoded}",
+        );
+        assert!(
+            decoded.contains("prompt"),
+            "synthesized schema must expose `prompt`; decoded prompt: {decoded}",
+        );
+    }
+
+    /// Guard against future regressions where callers attach an
+    /// `image_generation` configuration but `has_custom_tools()` still
+    /// returns false (which would skip the developer-message tools
+    /// section entirely and leave gpt-oss unable to emit the call).
+    #[test]
+    fn has_custom_tools_true_for_image_generation_only_request() {
+        let tool_types = ["image_generation"];
+        assert!(
+            has_custom_tools(&tool_types),
+            "a request whose only tool is image_generation must still \
+             trigger the custom-tool path in the harmony prompt",
+        );
+    }
+
+    /// Simulate the MCP-loop side effect where the router appends a
+    /// `ResponseTool::Function` copy of each MCP-exposed tool onto the
+    /// request (see `execute_with_mcp_loop`). For
+    /// `image_generation` the MCP server's tool name collides with the
+    /// synthesized function-tool name, so the harmony developer
+    /// message would otherwise carry two identically-named entries
+    /// inside `namespace functions { … }` and confuse gpt-oss. The
+    /// builder deduplicates by name, keeping the caller's
+    /// original/synthesized entry.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn dedupes_duplicate_function_tool_names_from_mcp_loop() {
+        use openai_protocol::{common::Function, responses::FunctionTool};
+
+        let builder = HarmonyBuilder::new();
+        let request = ResponsesRequest {
+            model: "gpt-oss-120b".to_string(),
+            input: ResponseInput::Text("draw a cat".to_string()),
+            tools: Some(vec![
+                ResponseTool::ImageGeneration(ImageGenerationTool::default()),
+                // What `convert_mcp_tools_to_response_tools` would
+                // append after the MCP session exposes
+                // `image_generation` — a function tool with the same
+                // name but a schema reflecting the MCP server's side.
+                ResponseTool::Function(FunctionTool {
+                    function: Function {
+                        name: "image_generation".to_string(),
+                        description: Some("mcp-exposed duplicate".to_string()),
+                        parameters: json!({
+                            "type": "object",
+                            "properties": {
+                                "prompt": {"type": "string"}
+                            },
+                            "required": ["prompt"]
+                        }),
+                        strict: None,
+                    },
+                }),
+            ]),
+            ..Default::default()
+        };
+
+        let output = builder
+            .build_from_responses(&request)
+            .expect("harmony build must succeed");
+
+        let decoded = builder
+            .encoding
+            .tokenizer()
+            .decode_utf8(&output.input_ids)
+            .expect("decode harmony tokens back to UTF-8");
+
+        let occurrences = decoded.matches("type image_generation = (").count();
+        assert_eq!(
+            occurrences, 1,
+            "image_generation must appear exactly once in the rendered \
+             function-tools namespace; found {occurrences} occurrences. \
+             Decoded prompt:\n{decoded}",
+        );
     }
 }

--- a/model_gateway/src/routers/grpc/harmony/responses/common.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/common.rs
@@ -7,13 +7,13 @@ use openai_protocol::{
     common::ToolCall,
     responses::{
         ResponseContentPart, ResponseInput, ResponseInputOutputItem, ResponseOutputItem,
-        ResponseReasoningContent, ResponsesRequest, ResponsesResponse, ResponsesToolChoice,
-        StringOrContentParts, ToolChoiceOptions,
+        ResponseReasoningContent, ResponseTool, ResponsesRequest, ResponsesResponse,
+        ResponsesToolChoice, StringOrContentParts, ToolChoiceOptions,
     },
 };
 use serde_json::{from_value, to_string, Value};
 use smg_data_connector::{ResponseId, ResponseStorageError};
-use smg_mcp::McpToolSession;
+use smg_mcp::{McpToolSession, ResponseFormat};
 use tracing::{debug, error, warn};
 use uuid::Uuid;
 
@@ -299,4 +299,56 @@ pub(super) async fn load_previous_messages(
     modified_request.previous_response_id = None;
 
     Ok(modified_request)
+}
+
+/// Strip `ResponseTool::ImageGeneration` from a request's tools list once
+/// the MCP session has exposed an MCP-routed replacement.
+///
+/// Motivation (R6.8): the harmony builder synthesizes a function-tool
+/// description named `image_generation` from
+/// [`openai_protocol::responses::ResponseTool::ImageGeneration`]. That is
+/// the right advertisement when no MCP server is configured, but once the
+/// MCP loop injects a `ResponseTool::Function` for the MCP-exposed
+/// image-generation tool (via `convert_mcp_tools_to_response_tools`), two
+/// function-tool entries can end up in the developer-message `namespace
+/// functions { … }`. Worse, if the MCP server is configured with a
+/// non-canonical `builtin_tool_name` (e.g. `generate_image`), the
+/// advertised `image_generation` synthesis will not be recognized as
+/// MCP-exposed by `McpToolSession::has_exposed_tool`, so any call the
+/// model makes against the synthesized name falls through to the
+/// unresolved function-call path instead of dispatching.
+///
+/// Removing the `ResponseTool::ImageGeneration` tag once the MCP loop has
+/// taken ownership keeps the advertisement single-source (the MCP-exposed
+/// Function tool) and guarantees the model only sees a name the session
+/// can dispatch against.
+pub(super) fn strip_image_generation_from_request_tools(
+    request: &mut ResponsesRequest,
+    session: &McpToolSession<'_>,
+) {
+    // Check whether any MCP tool in the session carries the
+    // `ImageGenerationCall` response format — this is the authoritative
+    // signal that an MCP server is routed for the hosted
+    // `image_generation` tool in this request.
+    let mcp_has_image_generation = session
+        .mcp_tools()
+        .iter()
+        .any(|entry| matches!(entry.response_format, ResponseFormat::ImageGenerationCall));
+
+    if !mcp_has_image_generation {
+        return;
+    }
+
+    if let Some(tools) = request.tools.as_mut() {
+        let before = tools.len();
+        tools.retain(|t| !matches!(t, ResponseTool::ImageGeneration(_)));
+        let after = tools.len();
+        if before != after {
+            debug!(
+                removed = before - after,
+                "Stripped ResponseTool::ImageGeneration from request.tools because the \
+                 MCP session exposes an image_generation-routed dispatcher",
+            );
+        }
+    }
 }

--- a/model_gateway/src/routers/grpc/harmony/responses/non_streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/non_streaming.rs
@@ -20,7 +20,8 @@ use tracing::{debug, error, warn};
 
 use super::{
     common::{
-        build_next_request_with_tools, inject_mcp_metadata, load_previous_messages, McpCallTracking,
+        build_next_request_with_tools, inject_mcp_metadata, load_previous_messages,
+        strip_image_generation_from_request_tools, McpCallTracking,
     },
     execution::{convert_mcp_tools_to_response_tools, execute_mcp_tools, ToolResult},
 };
@@ -133,6 +134,13 @@ async fn execute_with_mcp_loop(
             "MCP client available - added static MCP tools to Harmony Responses request"
         );
     }
+
+    // R6.8: once the MCP loop has taken ownership of image_generation
+    // dispatch, drop the hosted-tool descriptor so the harmony builder
+    // advertises only the MCP-exposed function-tool name (which
+    // `has_exposed_tool` actually recognizes for dispatch). See the
+    // helper doc comment in `common.rs` for the full rationale.
+    strip_image_generation_from_request_tools(&mut current_request, &session);
 
     loop {
         iteration_count += 1;

--- a/model_gateway/src/routers/grpc/harmony/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/streaming.rs
@@ -12,7 +12,10 @@ use tracing::{debug, warn};
 use uuid::Uuid;
 
 use super::{
-    common::{build_next_request_with_tools, load_previous_messages, McpCallTracking},
+    common::{
+        build_next_request_with_tools, load_previous_messages,
+        strip_image_generation_from_request_tools, McpCallTracking,
+    },
     execution::{convert_mcp_tools_to_response_tools, execute_mcp_tools},
 };
 use crate::{
@@ -161,6 +164,13 @@ async fn execute_mcp_tool_loop_streaming(
             "MCP client available - added static MCP tools to Harmony Responses streaming request"
         );
     }
+
+    // R6.8: once the MCP loop has taken ownership of image_generation
+    // dispatch, drop the hosted-tool descriptor so the harmony builder
+    // advertises only the MCP-exposed function-tool name (which
+    // `has_exposed_tool` actually recognizes for dispatch). See the
+    // helper doc comment in `common.rs` for the full rationale.
+    strip_image_generation_from_request_tools(&mut current_request, &session);
 
     let mut mcp_tracking = McpCallTracking::new();
 


### PR DESCRIPTION
## Description

### Problem

[R6.3 #1359] wired the `image_generation_call` streaming-event plumbing for gpt-oss via the harmony pipeline, but left gpt-oss with no way to emit the underlying tool call.

gpt-oss was not trained to emit `image_generation_call` as a native hosted-tool channel tag — per the openai-harmony spec, gpt-oss only knows `web_search_preview`, `web_search`, `code_interpreter` / `container`, `file_search` as builtin tools. Advertising `image_generation` in the harmony prompt's builtin-tools preamble produces undefined behavior: the model hallucinates a malformed call, ignores the advertisement, or emits `reasoning + message` instead of an `image_generation_call`.

Net effect on the harmony lane of R6.5 (#1365):
- Mock MCP server receives **zero** dispatches.
- Model emits `reasoning + message` instead of `image_generation_call`.

Refs:
- [R6.3 #1359] — harmony streaming-event wiring (the foundation R6.8 extends).
- [R6.5 #1365] — paused e2e coverage that documented the integration gap.
- [PR #1353] — shrink `BUILTIN_TOOLS` to the gpt-oss-native tool set (honored as an invariant here).

### Solution

Translate the hosted `image_generation` tool into a **function tool** that gpt-oss CAN emit, rendered into the developer-message custom-tool section. gpt-oss then emits `{"name": "image_generation", "arguments": {"prompt": "..."}}` on the commentary channel, and the shared MCP dispatch path — keyed on the exposed function-tool name against the registered `image_generation` MCP server — materializes the result as an `image_generation_call` output item (R6.1 plumbing).

**Scope discipline:** R6.8 only touches the `image_generation` path. Generalizing to a hosted-tool → function-tool framework for the other non-native hosted tools (`shell`, `computer`, `local_shell`, `apply_patch`) is follow-up work — flagged below as R6.9.

## Changes

### `model_gateway/src/routers/grpc/harmony/builder.rs`

- **Drop `"image_generation"` from `BUILTIN_TOOLS`** (honoring the invariant PR #1353 proposed). `"shell"` stays for now — out of R6.8 scope. The new doc comment explains the gpt-oss-native set and why hosted tools outside it must route through the custom-tool path instead.
- **`ToolLike for ResponseTool::is_custom()`** now returns `true` for `ImageGeneration`, so `has_custom_tools()` keeps the `commentary` channel in the system message and emits the developer-message tools section for image-generation-only requests.
- **`ToolLike for ResponseTool::to_tool_description()`** synthesizes a JSON-schema function-tool descriptor via a new `image_generation_tool_description()` helper — `prompt` required, plus mirrored pass-through configuration fields from `ImageGenerationTool` (`background`, `model`, `output_format`, `quality`, `size`).
- **`build_developer_message()` deduplicates function tools by name.** The MCP loop extends `request.tools` with an MCP-derived `ResponseTool::Function { name: "image_generation" }` once the MCP session resolves the hosted tool (see `execute_with_mcp_loop` in `harmony/responses/non_streaming.rs`). Without deduplication the rendered `namespace functions { … }` would carry two identically-named entries and confuse gpt-oss about which signature to follow.
- **Added `#[cfg(test)] mod tests`** with six regression tests locking the contract (see Test plan below).

### `model_gateway/src/routers/grpc/common/responses/utils.rs`

- **`ensure_mcp_connection()` now recognizes `ResponseTool::ImageGeneration`** alongside `WebSearchPreview` and `CodeInterpreter`. Without this arm the gating short-circuit returned `(false, Vec::new())`, the MCP loop was never entered, and the registered `image_generation` MCP server received zero dispatches on both the harmony and regular lanes — the concrete failure R6.5 (#1365) documented. The helper is shared by harmony and regular, so this single change benefits both.

## How it works end-to-end

1. Caller sends `tools: [{type: "image_generation", size: "512x512"}]`.
2. `ensure_mcp_connection` sees `ImageGeneration`, triggers the MCP loop, and `ensure_request_mcp_client` resolves the registered `image_generation` MCP server binding.
3. `execute_with_mcp_loop` appends the MCP-exposed `ResponseTool::Function { name: "image_generation" }` to the request's tools.
4. `HarmonyBuilder::build_from_responses` renders the developer message with a single `image_generation` function-tool entry (dedup keeps the synthesized schema from the original `ImageGeneration` declaration).
5. gpt-oss emits `{"name": "image_generation", "arguments": {"prompt": "a cat"}}` on the commentary channel.
6. The harmony responses loop partitions calls via `session.has_exposed_tool("image_generation")` → routed to `execute_mcp_tools`.
7. MCP session dispatches to the registered server, which returns the base64 image.
8. `to_response_item()` produces a `ResponseOutputItem::ImageGenerationCall` (R6.1 plumbing), and streaming events fire from `ResponseFormat::ImageGenerationCall` (R6.3 wiring).

## Test plan

### New unit tests (`model_gateway/src/routers/grpc/harmony/builder.rs::tests`)

1. `image_generation_is_not_a_builtin_tool` — PR #1353's `BUILTIN_TOOLS` invariant holds.
2. `response_tool_image_generation_is_custom` — `is_custom()` / `is_builtin()` flag change.
3. `image_generation_tool_description_exposes_required_prompt` — synthesized JSON-schema shape (`prompt` required, `size`/`quality`/`background`/`output_format` pass-through).
4. `build_from_responses_renders_image_generation_as_function_tool` — end-to-end harmony-prompt decode asserts `type image_generation = (…)` and `namespace functions` appear.
5. `has_custom_tools_true_for_image_generation_only_request` — `has_custom_tools()` returns true for image-generation-only requests.
6. `dedupes_duplicate_function_tool_names_from_mcp_loop` — after the MCP loop appends a same-named `ResponseTool::Function`, the rendered prompt carries exactly one `image_generation` entry.

### Gates (all clean)

- `cargo fmt --all`
- `cargo check -p openai-protocol -p smg-mcp -p smg --lib --tests --benches`
- `cargo test -p smg --lib routers::grpc::harmony::builder::tests` — 6/6 pass
- `cargo test -p smg --lib` — 639/643 pass (4 pre-existing ignored, 0 failed)
- `cargo clippy -p openai-protocol -p smg-mcp -p smg --lib --tests --benches -- -D warnings`

### E2E coverage

R6.5 (#1365) added the harmony/regular lane tests (behind `@pytest.mark.skip_for_runtime`). Un-skipping those after R6.8 merges will exercise the full gpt-oss → MCP → `image_generation_call` flow end-to-end.

## Follow-up (R6.9)

The hosted-tool → function-tool translation pattern generalizes to the other non-native hosted tools (`shell`, `computer`, `computer_use_preview`, `local_shell`, `apply_patch`). R6.9 should factor the R6.8 synthesis into a reusable per-tool-kind helper, introduce per-worker hosted-tool capability flags, and apply the pattern to the remaining hosted tools so every tool gpt-oss wasn't trained on still has a dispatch path.

<details>
<summary>Checklist</summary>

- [x] Documentation updated (module-level doc comments + `BUILTIN_TOOLS` doc comment explain the invariant)
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Image-generation requests are now routed correctly when external MCP routing is configured; hosted image-generation descriptors are removed so only MCP-exposed function tools are discoverable.
  * Image-generation is treated as a custom function tool and tool descriptions are deduplicated to prevent duplicate entries during dispatch.

* **Tests**
  * Added regression tests for image-generation classification, schema/encoding, routing behavior, and deduplication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->