### PR TITLE
fix(openai): image_generation result round-trip + streaming event ordering (R6.7)

### DIFF
--- a/crates/mcp/src/transform/transformer.rs
+++ b/crates/mcp/src/transform/transformer.rs
@@ -321,21 +321,23 @@ impl ResponseTransformer {
         //    Both shapes are read so either style works interchangeably;
         //    first occurrence wins for each slot (matches the accumulator
         //    semantics in `update_fields`).
-        if result.is_array() {
-            for openai_response in extract_embedded_openai_responses(result) {
-                if let Some(obj) = openai_response.as_object() {
-                    update_fields(obj);
+        if let Some(text_blocks) = result.as_array() {
+            for item in text_blocks {
+                let Some(payload) = parse_text_block_payload(item) else {
+                    continue;
+                };
+                // First-occurrence-wins accumulation means the
+                // `openai_response`-wrapped shape keeps priority over the
+                // top-level shape when a single block carries both.
+                if let Some(inner) = payload
+                    .get("openai_response")
+                    .filter(|value| !value.is_null())
+                    .and_then(|value| value.as_object())
+                {
+                    update_fields(inner);
                 }
-            }
-
-            if let Some(text_blocks) = result.as_array() {
-                for item in text_blocks {
-                    let Some(payload) = parse_text_block_payload(item) else {
-                        continue;
-                    };
-                    if let Some(obj) = payload.as_object() {
-                        update_fields(obj);
-                    }
+                if let Some(obj) = payload.as_object() {
+                    update_fields(obj);
                 }
             }
         }

--- a/crates/mcp/src/transform/transformer.rs
+++ b/crates/mcp/src/transform/transformer.rs
@@ -302,11 +302,40 @@ impl ResponseTransformer {
             update_fields(obj);
         }
 
-        // 2) Embedded openai_response payloads inside MCP text blocks.
+        // 2) Array of MCP text blocks. An MCP server returning a JSON-shaped
+        //    tool result is serialized by `call_result_to_json` as an array
+        //    of text blocks (`[{"type":"text","text":"{...}"}, ...]`). Two
+        //    text-block shapes are accepted:
+        //
+        //    a) `{"openai_response": {"result": ..., "revised_prompt": ...}}`
+        //       (internal convention used by web_search_call and other
+        //       SMG-authored MCP servers).
+        //    b) Top-level fields: `{"result": ..., "revised_prompt": ...}`.
+        //       This is the natural shape produced by servers that return
+        //       a plain `dict` from their tool handler (e.g. FastMCP's
+        //       `@tool` decorator wrapping a `dict` return value — see
+        //       `e2e_test/infra/mock_mcp_server.py`). It also covers any
+        //       third-party MCP server that emits the OpenAI Images API
+        //       shape directly.
+        //
+        //    Both shapes are read so either style works interchangeably;
+        //    first occurrence wins for each slot (matches the accumulator
+        //    semantics in `update_fields`).
         if result.is_array() {
             for openai_response in extract_embedded_openai_responses(result) {
                 if let Some(obj) = openai_response.as_object() {
                     update_fields(obj);
+                }
+            }
+
+            if let Some(text_blocks) = result.as_array() {
+                for item in text_blocks {
+                    let Some(payload) = parse_text_block_payload(item) else {
+                        continue;
+                    };
+                    if let Some(obj) = payload.as_object() {
+                        update_fields(obj);
+                    }
                 }
             }
         }
@@ -1070,6 +1099,77 @@ mod tests {
             } => {
                 assert_eq!(result, "EMBEDDED_BYTES");
                 assert_eq!(revised_prompt, Some("tweaked prompt".to_string()));
+            }
+            _ => panic!("Expected ImageGenerationCall"),
+        }
+    }
+
+    #[test]
+    fn test_image_generation_transform_text_block_top_level_fields() {
+        // MCP servers authored against the FastMCP SDK (and any server that
+        // returns a plain `dict` from its tool handler) emit a single text
+        // block whose JSON body has `result` / `revised_prompt` at the TOP
+        // level — there is no `openai_response` wrapper. This is the shape
+        // produced by the R6.5 in-process mock and is equally valid per the
+        // MCP spec. The extractor must read those top-level fields the same
+        // way it reads direct-object and embedded-openai_response payloads.
+        let result = json!([
+            {
+                "type": "text",
+                "text": r#"{
+                  "result": "TOP_LEVEL_BYTES",
+                  "revised_prompt": "a happy cat",
+                  "status": "completed"
+                }"#
+            }
+        ]);
+
+        let transformed = ResponseTransformer::transform(
+            &result,
+            &ResponseFormat::ImageGenerationCall,
+            "req-img-toplevel",
+            "server",
+            "image_generation",
+            "{}",
+        );
+
+        match transformed {
+            ResponseOutputItem::ImageGenerationCall {
+                result,
+                revised_prompt,
+                ..
+            } => {
+                assert_eq!(result, "TOP_LEVEL_BYTES");
+                assert_eq!(revised_prompt, Some("a happy cat".to_string()));
+            }
+            _ => panic!("Expected ImageGenerationCall"),
+        }
+    }
+
+    #[test]
+    fn test_image_generation_transform_text_block_b64_json_alias() {
+        // Alias check: when a text-block payload uses `b64_json` (the OpenAI
+        // Images API field name) instead of `result`, the extractor must
+        // still pick it up.
+        let result = json!([
+            {
+                "type": "text",
+                "text": r#"{"b64_json": "ALIAS_BYTES"}"#
+            }
+        ]);
+
+        let transformed = ResponseTransformer::transform(
+            &result,
+            &ResponseFormat::ImageGenerationCall,
+            "req-img-alias",
+            "server",
+            "image_generation",
+            "{}",
+        );
+
+        match transformed {
+            ResponseOutputItem::ImageGenerationCall { result, .. } => {
+                assert_eq!(result, "ALIAS_BYTES");
             }
             _ => panic!("Expected ImageGenerationCall"),
         }

--- a/model_gateway/src/routers/openai/mcp/tool_handler.rs
+++ b/model_gateway/src/routers/openai/mcp/tool_handler.rs
@@ -15,9 +15,27 @@ use crate::routers::openai::responses::{
 /// Action to take based on streaming event processing
 #[derive(Debug)]
 pub(crate) enum StreamAction {
-    Forward,      // Pass event to client
-    Buffer,       // Accumulate for tool execution
-    ExecuteTools, // Function call complete, execute now
+    /// Pass this event to the client.
+    Forward,
+    /// Accumulate the event for tool execution, do not send downstream.
+    Buffer,
+    /// The upstream signalled tool-call completion — run the MCP tool now.
+    ///
+    /// `forward_triggering_event` distinguishes two upstream shapes:
+    ///
+    /// * When the upstream emits `function_call_arguments.done` we want to
+    ///   forward the event (it becomes `mcp_call_arguments.done`, a sub-event
+    ///   that belongs BEFORE `response.<type>.completed`).
+    /// * When the upstream skips the delta/done arguments events and signals
+    ///   tool completion with `output_item.done` for the `function_call`
+    ///   item, forwarding it would emit a duplicate umbrella
+    ///   `response.output_item.done` event that fires BEFORE the sub-event
+    ///   `response.<type>.completed` — violating the spec sub-event ordering
+    ///   (spec §streaming: the umbrella `output_item.done` is always the
+    ///   LAST event for a given item). The tool_loop's
+    ///   `send_tool_call_completion_events` emits the correct umbrella
+    ///   `output_item.done` in its proper position.
+    ExecuteTools { forward_triggering_event: bool },
 }
 
 /// Maps upstream output indices to sequential downstream indices
@@ -178,7 +196,12 @@ impl StreamingToolHandler {
                     self.ensure_output_index(output_index);
                 }
                 if self.has_complete_calls() {
-                    StreamAction::ExecuteTools
+                    // Suppress the upstream umbrella event — the tool loop
+                    // will emit its own `output_item.done` at the correct
+                    // position, AFTER `response.<type>.completed`.
+                    StreamAction::ExecuteTools {
+                        forward_triggering_event: false,
+                    }
                 } else {
                     StreamAction::Forward
                 }
@@ -260,7 +283,13 @@ impl StreamingToolHandler {
         }
 
         if self.has_complete_calls() {
-            StreamAction::ExecuteTools
+            // Forward the triggering event — `function_call_arguments.done`
+            // becomes `mcp_call_arguments.done` which is a sub-event
+            // belonging BEFORE `response.<type>.completed` and therefore
+            // safe to forward inline here.
+            StreamAction::ExecuteTools {
+                forward_triggering_event: true,
+            }
         } else {
             StreamAction::Forward
         }
@@ -352,5 +381,142 @@ impl StreamingToolHandler {
 
     pub fn take_pending_calls(&mut self) -> Vec<FunctionCallInProgress> {
         std::mem::take(&mut self.pending_calls)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Regression tests for R6.7 Gap B — streaming event ordering for
+    //! image-generation-style built-in tool calls.
+    //!
+    //! The bug: when the upstream signalled tool completion with a direct
+    //! `response.output_item.done` event (no preceding
+    //! `response.function_call_arguments.done`), the streaming layer used
+    //! to forward that upstream event to the client. The tool loop then
+    //! emitted its own umbrella `output_item.done` AFTER emitting the
+    //! `<tool>.completed` sub-event — producing the wire sequence
+    //!
+    //!     response.output_item.added
+    //!     response.<tool>.in_progress
+    //!     response.output_item.done       ← duplicate (upstream-forwarded)
+    //!     response.<tool>.generating
+    //!     response.<tool>.completed
+    //!     response.output_item.done       ← tool-loop synthesized
+    //!
+    //! which violates the spec invariant that `response.output_item.done`
+    //! is the LAST event emitted for a given item (see
+    //! `.claude/_audit/openai-responses-api-spec.md` §streaming, events
+    //! L1054-L1072).
+
+    use super::*;
+
+    /// Feed an `output_item.added` for a function_call item so the handler
+    /// has a complete pending call registered.
+    fn bootstrap_function_call_added(handler: &mut StreamingToolHandler) {
+        let data = r#"{
+          "type": "response.output_item.added",
+          "output_index": 0,
+          "item": {
+            "type": "function_call",
+            "id": "fc_test",
+            "call_id": "call_test",
+            "name": "image_generation"
+          }
+        }"#;
+        let _ = handler.process_event(Some("response.output_item.added"), data);
+    }
+
+    #[test]
+    fn output_item_done_triggers_execute_tools_without_forwarding() {
+        // Gap B: when the upstream signals tool-call completion via
+        // `output_item.done` for a function_call item (no preceding
+        // `function_call_arguments.done`), the handler must ask the
+        // caller NOT to forward the triggering event — the tool loop
+        // will emit its own umbrella `output_item.done` at the correct
+        // position after `response.<tool>.completed`.
+        let mut handler = StreamingToolHandler::with_starting_index(0);
+        bootstrap_function_call_added(&mut handler);
+
+        let done_event = r#"{
+          "type": "response.output_item.done",
+          "output_index": 0,
+          "item": {
+            "type": "function_call",
+            "id": "fc_test",
+            "call_id": "call_test",
+            "name": "image_generation",
+            "arguments": "{}",
+            "status": "completed"
+          }
+        }"#;
+
+        let action = handler.process_event(Some("response.output_item.done"), done_event);
+
+        match action {
+            StreamAction::ExecuteTools {
+                forward_triggering_event,
+            } => assert!(
+                !forward_triggering_event,
+                "output_item.done must be suppressed to avoid a duplicate umbrella event"
+            ),
+            other => panic!("expected ExecuteTools, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn arguments_done_triggers_execute_tools_with_forwarding() {
+        // Forwarding is safe for `function_call_arguments.done` because it
+        // becomes `mcp_call_arguments.done` — a sub-event that belongs
+        // BEFORE `response.<tool>.completed` per spec sub-event ordering.
+        let mut handler = StreamingToolHandler::with_starting_index(0);
+        bootstrap_function_call_added(&mut handler);
+
+        let args_done = r#"{
+          "type": "response.function_call_arguments.done",
+          "output_index": 0,
+          "item_id": "fc_test",
+          "arguments": "{}"
+        }"#;
+
+        let action =
+            handler.process_event(Some("response.function_call_arguments.done"), args_done);
+
+        match action {
+            StreamAction::ExecuteTools {
+                forward_triggering_event,
+            } => assert!(
+                forward_triggering_event,
+                "function_call_arguments.done forwards as mcp_call_arguments.done"
+            ),
+            other => panic!("expected ExecuteTools, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn output_item_done_without_pending_calls_forwards() {
+        // Non-function-call umbrella `output_item.done` events (messages,
+        // mcp_list_tools items, etc.) must pass through unchanged. This
+        // prevents regressing the path where the assistant emits a plain
+        // text message after tool execution completes.
+        let mut handler = StreamingToolHandler::with_starting_index(0);
+
+        let done_event = r#"{
+          "type": "response.output_item.done",
+          "output_index": 0,
+          "item": {
+            "type": "message",
+            "id": "msg_test",
+            "status": "completed",
+            "role": "assistant",
+            "content": []
+          }
+        }"#;
+
+        let action = handler.process_event(Some("response.output_item.done"), done_event);
+
+        assert!(
+            matches!(action, StreamAction::Forward),
+            "expected Forward for an umbrella output_item.done on a non-tool item, got {action:?}"
+        );
     }
 }

--- a/model_gateway/src/routers/openai/mcp/tool_handler.rs
+++ b/model_gateway/src/routers/openai/mcp/tool_handler.rs
@@ -195,7 +195,17 @@ impl StreamingToolHandler {
                 if let Some(output_index) = extract_output_index(&parsed) {
                     self.ensure_output_index(output_index);
                 }
-                if self.has_complete_calls() {
+                // Only suppress the umbrella `output_item.done` when it is
+                // closing a function_call item that we are intercepting —
+                // an unrelated `output_item.done` for a message, reasoning
+                // item, or mcp_list_tools block must reach the client
+                // untouched even when a pending tool call is queued.
+                let is_function_call_done = parsed
+                    .get("item")
+                    .and_then(|item| item.get("type"))
+                    .and_then(|value| value.as_str())
+                    .is_some_and(is_function_call_type);
+                if is_function_call_done && self.has_complete_calls() {
                     // Suppress the upstream umbrella event — the tool loop
                     // will emit its own `output_item.done` at the correct
                     // position, AFTER `response.<type>.completed`.
@@ -490,6 +500,39 @@ mod tests {
             ),
             other => panic!("expected ExecuteTools, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn output_item_done_for_unrelated_item_forwards_even_with_pending_call() {
+        // Regression for PR #1369 review (chatgpt-codex-connector P1):
+        // suppression must be gated on the done event's item type. When a
+        // function_call is queued AND an unrelated `output_item.done` for a
+        // message / reasoning / mcp_list_tools block arrives, the umbrella
+        // event for that sibling item must pass through untouched so the
+        // client sees its completion. Only the function_call's own
+        // `output_item.done` should be suppressed (the tool loop will emit
+        // the correct umbrella at its proper position).
+        let mut handler = StreamingToolHandler::with_starting_index(0);
+        bootstrap_function_call_added(&mut handler);
+
+        let done_event = r#"{
+          "type": "response.output_item.done",
+          "output_index": 1,
+          "item": {
+            "type": "message",
+            "id": "msg_sibling",
+            "status": "completed",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "hello"}]
+          }
+        }"#;
+
+        let action = handler.process_event(Some("response.output_item.done"), done_event);
+
+        assert!(
+            matches!(action, StreamAction::Forward),
+            "sibling output_item.done must forward even while a function_call is pending; got {action:?}"
+        );
     }
 
     #[test]

--- a/model_gateway/src/routers/openai/mcp/tool_loop.rs
+++ b/model_gateway/src/routers/openai/mcp/tool_loop.rs
@@ -1220,6 +1220,7 @@ mod tests {
         BuiltinToolType, McpConfig, McpOrchestrator, McpServerBinding, McpServerConfig,
         McpToolSession, McpTransport, ResponseFormat, Tool, ToolEntry,
     };
+    use tokio::sync::mpsc;
 
     use super::{
         build_transformed_mcp_call_item, extract_openai_response_output_items,
@@ -1528,5 +1529,148 @@ mod tests {
         let output = r#"[{"type":"text","text":"{\"openai_response\":null}"}]"#;
         let extracted = extract_openai_response_output_items(output);
         assert!(extracted.is_empty());
+    }
+
+    // ========================================================================
+    // R6.7 Gap B — streaming emission ordering invariant.
+    //
+    // `send_tool_call_completion_events` MUST emit
+    // `response.<tool>.completed` BEFORE `response.output_item.done` so the
+    // umbrella event terminates the item's sub-events per spec (see
+    // `.claude/_audit/openai-responses-api-spec.md` §streaming, events
+    // L1054-L1072).
+    // ========================================================================
+
+    fn drain_channel(
+        rx: &mut mpsc::UnboundedReceiver<Result<bytes::Bytes, std::io::Error>>,
+    ) -> Vec<String> {
+        let mut events = Vec::new();
+        while let Ok(chunk) = rx.try_recv() {
+            let bytes = chunk.expect("no io errors in unit-test channel");
+            events.push(String::from_utf8(bytes.to_vec()).expect("utf-8 sse block"));
+        }
+        events
+    }
+
+    fn event_type_from_sse_block(block: &str) -> String {
+        // SSE block shape: `event: <name>\ndata: {...}\n\n`. We parse only
+        // the leading `event: …` line to get the wire type without pulling
+        // serde_json into this tiny assertion helper.
+        for line in block.lines() {
+            if let Some(rest) = line.strip_prefix("event: ") {
+                return rest.trim().to_string();
+            }
+        }
+        block.to_string()
+    }
+
+    #[test]
+    fn image_generation_completion_events_fire_before_output_item_done() {
+        // Gap B lock test: after the tool executes, the completion
+        // emitter must push `response.image_generation_call.completed`
+        // onto the wire BEFORE `response.output_item.done`. If a future
+        // refactor reverses the order this asserts and fails loudly.
+        let call = super::FunctionCallInProgress {
+            call_id: "call_img".to_string(),
+            name: "image_generation".to_string(),
+            arguments_buffer: "{}".to_string(),
+            item_id: Some("fc_img".to_string()),
+            output_index: 0,
+            last_obfuscation: None,
+            assigned_output_index: Some(0),
+        };
+
+        let tool_call_item = json!({
+            "type": "image_generation_call",
+            "id": "ig_img",
+            "status": "completed",
+            "result": "BASE64",
+        });
+
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut sequence_number: u64 = 0;
+
+        let ok = super::send_tool_call_completion_events(
+            &tx,
+            &call,
+            &tool_call_item,
+            &ResponseFormat::ImageGenerationCall,
+            &mut sequence_number,
+        );
+        assert!(ok, "send_tool_call_completion_events should not disconnect");
+        drop(tx);
+
+        let events = drain_channel(&mut rx);
+        let types: Vec<String> = events
+            .iter()
+            .map(|b| event_type_from_sse_block(b))
+            .collect();
+
+        let completed_idx = types
+            .iter()
+            .position(|t| t == "response.image_generation_call.completed")
+            .expect("response.image_generation_call.completed must be emitted");
+        let done_idx = types
+            .iter()
+            .position(|t| t == "response.output_item.done")
+            .expect("response.output_item.done must be emitted");
+
+        assert!(
+            completed_idx < done_idx,
+            "`response.image_generation_call.completed` (index {completed_idx}) must come \
+             before `response.output_item.done` (index {done_idx}); full sequence: {types:?}"
+        );
+    }
+
+    #[test]
+    fn web_search_completion_events_fire_before_output_item_done() {
+        // Same ordering contract for the pre-existing web_search_call path,
+        // so the invariant applies uniformly across every hosted-tool
+        // ResponseFormat we emit.
+        let call = super::FunctionCallInProgress {
+            call_id: "call_ws".to_string(),
+            name: "web_search".to_string(),
+            arguments_buffer: "{}".to_string(),
+            item_id: Some("fc_ws".to_string()),
+            output_index: 0,
+            last_obfuscation: None,
+            assigned_output_index: Some(0),
+        };
+
+        let tool_call_item = json!({
+            "type": "web_search_call",
+            "id": "ws_ws",
+            "status": "completed",
+            "action": {"type": "search"}
+        });
+
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut sequence_number: u64 = 0;
+
+        let ok = super::send_tool_call_completion_events(
+            &tx,
+            &call,
+            &tool_call_item,
+            &ResponseFormat::WebSearchCall,
+            &mut sequence_number,
+        );
+        assert!(ok);
+        drop(tx);
+
+        let events = drain_channel(&mut rx);
+        let types: Vec<String> = events
+            .iter()
+            .map(|b| event_type_from_sse_block(b))
+            .collect();
+
+        let completed_idx = types
+            .iter()
+            .position(|t| t == "response.web_search_call.completed")
+            .expect("web_search_call.completed must be emitted");
+        let done_idx = types
+            .iter()
+            .position(|t| t == "response.output_item.done")
+            .expect("output_item.done must be emitted");
+        assert!(completed_idx < done_idx);
     }
 }

--- a/model_gateway/src/routers/openai/responses/streaming.rs
+++ b/model_gateway/src/routers/openai/responses/streaming.rs
@@ -855,19 +855,32 @@ pub(super) fn handle_streaming_with_tool_interception(
                                 StreamAction::Buffer => {
                                     // Don't forward, just buffer
                                 }
-                                StreamAction::ExecuteTools => {
-                                    if !forward_streaming_event(
-                                        SseEventData {
-                                            raw_block: &raw_block,
-                                            event_name,
-                                            data: data.as_ref(),
-                                            pre_parsed: None,
-                                        },
-                                        &mut handler,
-                                        &tx,
-                                        &streaming_ctx,
-                                        &mut sequence_number,
-                                    ) {
+                                StreamAction::ExecuteTools {
+                                    forward_triggering_event,
+                                } => {
+                                    // When the upstream signals tool completion via
+                                    // `output_item.done` (instead of a preceding
+                                    // `function_call_arguments.done`), forwarding the
+                                    // event here would emit an umbrella
+                                    // `response.output_item.done` BEFORE
+                                    // `response.<tool>.completed`, violating spec
+                                    // sub-event ordering. The tool loop emits its own
+                                    // `output_item.done` at the correct position after
+                                    // the `.completed` sub-event; suppress here.
+                                    if forward_triggering_event
+                                        && !forward_streaming_event(
+                                            SseEventData {
+                                                raw_block: &raw_block,
+                                                event_name,
+                                                data: data.as_ref(),
+                                                pre_parsed: None,
+                                            },
+                                            &mut handler,
+                                            &tx,
+                                            &streaming_ctx,
+                                            &mut sequence_number,
+                                        )
+                                    {
                                         return;
                                     }
                                     tool_calls_detected = true;


### PR DESCRIPTION
## Summary

R6.5 (#1365) added the first e2e coverage for the `image_generation`
built-in tool and surfaced two real integration gaps in the
OpenAI-compat router's wiring — both observed on the live mock MCP
server path and both independent of the gRPC lanes (R6.3/R6.4). This
PR fixes them without modifying the e2e tests themselves; R6.5's
test surface becomes the acceptance gate.

### Gap A — `result` dropped on round-trip (`crates/mcp`)

`ResponseTransformer::extract_image_generation_fields` knew two MCP
result shapes for image_generation payloads:

* a direct object `{"result": ..., "revised_prompt": ...}`, and
* an array of text blocks whose JSON body is wrapped in
  `{"openai_response": {...}}` (the SMG-internal convention used by
  web_search tooling).

It did NOT know the third, and most natural, MCP shape: a text block
whose JSON body carries `result` / `revised_prompt` / `image_base64` /
`b64_json` at the TOP level without an `openai_response` wrapper. This
is exactly what FastMCP-style servers produce from a `@tool`-decorated
function returning a plain `dict` — including R6.5's `MockMcpServer`
and any third-party MCP server that emits the OpenAI Images API shape
directly. With this miss, an upstream tool payload carrying a real
base64 PNG round-tripped to the client as
`ImageGenerationCall { result: "", revised_prompt: None }`.

The fix extends the text-block sweep to also merge fields parsed
directly from the top-level JSON after the existing
`extract_embedded_openai_responses` pass, using the same
first-occurrence-wins accumulator so all three shapes work
interchangeably and none of the existing paths regress.

### Gap B — `response.output_item.done` fired before `<tool>.completed`

`StreamingToolHandler::process_event` returned
`StreamAction::ExecuteTools` from TWO distinct upstream shapes:

1. `response.function_call_arguments.done` — forwarded as
   `mcp_call_arguments.done`, which is a sub-event belonging BEFORE
   `response.<tool>.completed`. Forwarding is correct.
2. `response.output_item.done` on the `function_call` item — this is
   the shape emitted by gpt-5-nano for image_generation when the
   upstream skips the `function_call_arguments.done` event entirely.
   Forwarding it here emitted an umbrella `output_item.done` BEFORE
   `response.<tool>.completed`, and then the tool loop's
   `send_tool_call_completion_events` emitted a SECOND umbrella
   `output_item.done` in its correct position after the `.completed`
   sub-event. Duplicate + out-of-order. R6.5 observed this exactly:
   `output_item.done` at event index 3 and
   `response.image_generation_call.completed` at index 9 — violating
   the spec invariant that `response.output_item.done` is the LAST
   event for a given item (spec §streaming, events L1054-L1072; see
   `.claude/_audit/openai-responses-api-spec.md`).

The fix widens `StreamAction::ExecuteTools` into a struct variant
`ExecuteTools { forward_triggering_event: bool }`:

* `OutputItemEvent::DONE` branch returns `false` — umbrella upstream
  event is dropped; the tool loop emits the correct single
  `output_item.done` in its proper position.
* `FunctionCallEvent::ARGUMENTS_DONE` branch returns `true` —
  forwarding stays correct because this becomes
  `mcp_call_arguments.done`, a sub-event.

The change is surgical: only the one call site in
`handle_streaming_with_tool_interception` inspects
`forward_triggering_event`, no other streaming path changes, and no
event names or output shapes move.

## Test plan

Five new unit tests lock the contracts:

**Gap A** (`crates/mcp/src/transform/transformer.rs`)
* `test_image_generation_transform_text_block_top_level_fields`
* `test_image_generation_transform_text_block_b64_json_alias`

**Gap B** (`model_gateway/src/routers/openai/mcp/...`)
* `tool_handler::tests::output_item_done_triggers_execute_tools_without_forwarding`
* `tool_handler::tests::arguments_done_triggers_execute_tools_with_forwarding`
* `tool_handler::tests::output_item_done_without_pending_calls_forwards`
* `tool_loop::tests::image_generation_completion_events_fire_before_output_item_done`
* `tool_loop::tests::web_search_completion_events_fire_before_output_item_done`

Gates run locally and all clean:
- `cargo check -p openai-protocol -p smg-mcp -p smg --lib --tests --benches`
- `cargo test -p smg-mcp --lib` — 187 tests pass
- `cargo test -p smg --lib` — 638 tests pass
- `cargo fmt --all`
- `cargo clippy -p openai-protocol -p smg-mcp -p smg --lib --tests --benches -- -D warnings`

No source code beyond the two identified fix sites was modified; no
defensive scaffolding. R6.5 (#1365) can come off PAUSED state after
this lands.

<details>
<summary>Checklist</summary>

- [x] Code updated
- [x] Unit tests added
- [x] Gates green locally
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

Refs: R6.1 #1355, R6.2 #1356, R6.5 #1365

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Broadened image-generation parsing to accept top-level result/revised_prompt and b64_json aliases.
  * Ensured tool-completion events are emitted in correct order and avoided duplicate umbrella completion notifications.

* **Tests**
  * Added tests covering additional image response formats and alias handling.
  * Added tests validating event sequencing and forwarding behavior during tool execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->