### PR TITLE
feat(mcp): add hosted-tool overrides helpers and wire image_generation dispatch (R6.6)

### DIFF
--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -57,6 +57,7 @@ pub use responses_bridge::{
 pub use tenant::{SessionId, TenantContext, TenantId};
 // Re-export from transform
 pub use transform::{
-    compact_image_generation_output, extract_embedded_openai_responses, mcp_response_item_id,
+    apply_hosted_tool_overrides, compact_image_generation_output,
+    extract_embedded_openai_responses, extract_hosted_tool_overrides, mcp_response_item_id,
     ResponseFormat, ResponseTransformer,
 };

--- a/crates/mcp/src/transform/mod.rs
+++ b/crates/mcp/src/transform/mod.rs
@@ -19,9 +19,11 @@
 //! );
 //! ```
 
+mod overrides;
 mod transformer;
 mod types;
 
+pub use overrides::{apply_hosted_tool_overrides, extract_hosted_tool_overrides};
 pub use transformer::{
     compact_image_generation_output, extract_embedded_openai_responses, mcp_response_item_id,
     ResponseTransformer,

--- a/crates/mcp/src/transform/overrides.rs
+++ b/crates/mcp/src/transform/overrides.rs
@@ -1,0 +1,283 @@
+//! Pure-function helpers that merge caller-declared hosted-tool configuration
+//! into model-emitted tool-call arguments before MCP dispatch.
+//!
+//! # Motivation
+//!
+//! OpenAI's Responses API lets callers declare hosted-tool configuration on the
+//! request, e.g.:
+//!
+//! ```json
+//! { "tools": [{ "type": "image_generation", "size": "512x512", "quality": "high" }] }
+//! ```
+//!
+//! When the model emits the hosted-tool call, the arguments field often
+//! contains only the dynamic subset (e.g. `{"prompt": "a cat"}`). The remaining
+//! caller-declared knobs (`size`, `quality`, `model`, ...) live on the
+//! `tools` declaration and must be merged into the dispatch payload so the
+//! MCP server receives the effective configuration.
+//!
+//! These helpers are intentionally:
+//! - **pure**: no session state, no I/O; testable in isolation.
+//! - **symmetric** with [`crate::transform::transformer`], which handles the
+//!   inverse direction (MCP result → `ResponseOutputItem`).
+//!
+//! # Contract
+//!
+//! [`extract_hosted_tool_overrides`] walks `tools` for the first declaration of
+//! the requested kind, serializes it to `Value::Object`, drops null entries
+//! (so absent fields don't overwrite model-supplied values), strips the `type`
+//! discriminator (the kind is already known to the caller), and returns the
+//! remaining object — or `None` if no configurable fields remain.
+//!
+//! [`apply_hosted_tool_overrides`] mutates the dispatch args in-place, with
+//! overrides winning over model args for overlapping keys. Non-object or empty
+//! inputs are no-ops.
+
+use openai_protocol::responses::ResponseTool;
+use serde_json::Value;
+
+use crate::core::config::BuiltinToolType;
+
+/// Extract caller-declared configuration for the given hosted-tool kind from
+/// the request's `tools` declarations.
+///
+/// Returns `Some(Value::Object(...))` containing only non-null, non-default
+/// fields; returns `None` if there is no matching declaration or the matching
+/// declaration has no overridable fields.
+///
+/// # Contract
+///
+/// - Walks `tools` in order and matches the first declaration whose variant
+///   corresponds to `kind` (e.g. `BuiltinToolType::ImageGeneration` →
+///   `ResponseTool::ImageGeneration(..)`).
+/// - Serializes the inner struct to `Value::Object`, then:
+///   - drops entries whose value is `Value::Null`;
+///   - drops the `type` discriminator (the kind is already known to the
+///     caller and merging it into dispatch args would be spurious).
+/// - Returns `None` if the resulting object is empty.
+///
+/// This preserves forward compatibility: unknown / newly-added fields on a
+/// hosted-tool struct are forwarded verbatim without requiring changes here.
+pub fn extract_hosted_tool_overrides(
+    tools: &[ResponseTool],
+    kind: BuiltinToolType,
+) -> Option<Value> {
+    let declaration = tools.iter().find(|tool| matches_kind(tool, kind))?;
+    let serialized = serde_json::to_value(declaration).ok()?;
+    let Value::Object(mut map) = serialized else {
+        return None;
+    };
+
+    map.remove("type");
+    map.retain(|_, value| !value.is_null());
+
+    if map.is_empty() {
+        None
+    } else {
+        Some(Value::Object(map))
+    }
+}
+
+/// Merge caller-declared overrides into model-emitted tool-call arguments.
+///
+/// Overrides win over model args for overlapping keys; non-overlapping model
+/// args are preserved. This is a no-op if `arguments` is not an object or if
+/// `overrides` does not contain an object payload.
+pub fn apply_hosted_tool_overrides(arguments: &mut Value, overrides: &Value) {
+    let Value::Object(args_map) = arguments else {
+        return;
+    };
+    let Some(overrides_map) = overrides.as_object() else {
+        return;
+    };
+
+    for (key, value) in overrides_map {
+        args_map.insert(key.clone(), value.clone());
+    }
+}
+
+/// Check whether a `ResponseTool` variant matches the given `BuiltinToolType`.
+///
+/// Only hosted-tool kinds that are routable via MCP are handled; the arms for
+/// tool kinds without currently configurable fields still match so the helper
+/// stays consistent as `ResponseTool::*` inner structs grow overridable
+/// fields over time.
+fn matches_kind(tool: &ResponseTool, kind: BuiltinToolType) -> bool {
+    matches!(
+        (tool, kind),
+        (
+            ResponseTool::ImageGeneration(_),
+            BuiltinToolType::ImageGeneration,
+        ) | (
+            ResponseTool::WebSearchPreview(_),
+            BuiltinToolType::WebSearchPreview,
+        ) | (
+            ResponseTool::CodeInterpreter(_),
+            BuiltinToolType::CodeInterpreter,
+        ) | (ResponseTool::FileSearch(_), BuiltinToolType::FileSearch,)
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use openai_protocol::responses::{
+        CodeInterpreterTool, FileSearchTool, ImageGenerationTool, ResponseTool,
+        WebSearchPreviewTool,
+    };
+    use serde_json::json;
+
+    use super::*;
+
+    fn image_gen_tool(
+        size: Option<&str>,
+        quality: Option<&str>,
+        model: Option<&str>,
+    ) -> ResponseTool {
+        ResponseTool::ImageGeneration(ImageGenerationTool {
+            action: None,
+            background: None,
+            input_fidelity: None,
+            input_image_mask: None,
+            model: model.map(ToString::to_string),
+            moderation: None,
+            output_compression: None,
+            output_format: None,
+            partial_images: None,
+            quality: quality.map(ToString::to_string),
+            size: size.map(ToString::to_string),
+        })
+    }
+
+    #[test]
+    fn extract_image_generation_overrides_drops_nulls() {
+        let tools = vec![image_gen_tool(Some("512x512"), None, Some("gpt-image-1.5"))];
+
+        let overrides = extract_hosted_tool_overrides(&tools, BuiltinToolType::ImageGeneration)
+            .expect("overrides present when any field is set");
+
+        let obj = overrides.as_object().expect("object overrides");
+        assert_eq!(obj.get("size"), Some(&json!("512x512")));
+        assert_eq!(obj.get("model"), Some(&json!("gpt-image-1.5")));
+        assert!(
+            !obj.contains_key("quality"),
+            "null fields must not be forwarded as overrides",
+        );
+        assert!(
+            !obj.contains_key("type"),
+            "the type discriminator is redundant at dispatch time",
+        );
+    }
+
+    #[test]
+    fn extract_image_generation_overrides_empty_returns_none() {
+        let tools = vec![image_gen_tool(None, None, None)];
+        assert!(extract_hosted_tool_overrides(&tools, BuiltinToolType::ImageGeneration).is_none());
+    }
+
+    #[test]
+    fn extract_image_generation_overrides_missing_declaration_returns_none() {
+        let tools: Vec<ResponseTool> = vec![];
+        assert!(extract_hosted_tool_overrides(&tools, BuiltinToolType::ImageGeneration).is_none());
+    }
+
+    #[test]
+    fn extract_image_generation_ignores_non_matching_declarations_first() {
+        // A non-matching declaration precedes the image_generation one; matching logic
+        // should skip past it rather than short-circuiting on the first tool.
+        let tools = vec![
+            ResponseTool::Computer,
+            image_gen_tool(Some("1024x1024"), None, None),
+        ];
+
+        let overrides = extract_hosted_tool_overrides(&tools, BuiltinToolType::ImageGeneration)
+            .expect("matches the image_generation declaration, not the computer tool");
+        assert_eq!(
+            overrides.as_object().and_then(|o| o.get("size")),
+            Some(&json!("1024x1024")),
+        );
+    }
+
+    #[test]
+    fn extract_other_hosted_kinds_are_empty_by_default_today() {
+        // These structs currently have no fields that are caller-configurable-at-dispatch
+        // (all are Option<None> when default-constructed). The arms exist for consistency
+        // and will yield real overrides automatically once the tool structs grow fields.
+        let web_tools = vec![ResponseTool::WebSearchPreview(
+            WebSearchPreviewTool::default(),
+        )];
+        assert!(
+            extract_hosted_tool_overrides(&web_tools, BuiltinToolType::WebSearchPreview).is_none(),
+        );
+
+        let ci_tools = vec![ResponseTool::CodeInterpreter(CodeInterpreterTool::default())];
+        assert!(
+            extract_hosted_tool_overrides(&ci_tools, BuiltinToolType::CodeInterpreter).is_none(),
+        );
+
+        let fs_tools = vec![ResponseTool::FileSearch(FileSearchTool {
+            vector_store_ids: vec![],
+            filters: None,
+            max_num_results: None,
+            ranking_options: None,
+        })];
+        // file_search has a required `vector_store_ids` field which serializes even when empty.
+        let overrides = extract_hosted_tool_overrides(&fs_tools, BuiltinToolType::FileSearch);
+        if let Some(value) = overrides {
+            assert!(value
+                .as_object()
+                .is_some_and(|o| o.contains_key("vector_store_ids")));
+        }
+    }
+
+    #[test]
+    fn apply_overrides_caller_wins_over_model() {
+        let mut args = json!({"prompt": "cat", "size": "auto"});
+        let overrides = json!({"size": "512x512"});
+
+        apply_hosted_tool_overrides(&mut args, &overrides);
+
+        assert_eq!(args.get("size"), Some(&json!("512x512")));
+        assert_eq!(args.get("prompt"), Some(&json!("cat")));
+    }
+
+    #[test]
+    fn apply_overrides_extends_args_with_new_keys() {
+        let mut args = json!({"prompt": "cat"});
+        let overrides = json!({"size": "512x512"});
+
+        apply_hosted_tool_overrides(&mut args, &overrides);
+
+        assert_eq!(args.get("prompt"), Some(&json!("cat")));
+        assert_eq!(args.get("size"), Some(&json!("512x512")));
+    }
+
+    #[test]
+    fn apply_overrides_non_object_noop() {
+        let mut args = Value::String("bad".to_string());
+        let overrides = json!({"size": "512x512"});
+
+        apply_hosted_tool_overrides(&mut args, &overrides);
+
+        assert_eq!(args, Value::String("bad".to_string()));
+    }
+
+    #[test]
+    fn apply_overrides_empty_overrides_noop() {
+        let mut args = json!({"prompt": "cat"});
+        let overrides = json!({});
+
+        apply_hosted_tool_overrides(&mut args, &overrides);
+
+        assert_eq!(args, json!({"prompt": "cat"}));
+    }
+
+    #[test]
+    fn apply_overrides_non_object_overrides_noop() {
+        let mut args = json!({"prompt": "cat"});
+        let overrides = Value::String("not-an-object".to_string());
+
+        apply_hosted_tool_overrides(&mut args, &overrides);
+
+        assert_eq!(args, json!({"prompt": "cat"}));
+    }
+}

--- a/crates/mcp/src/transform/types.rs
+++ b/crates/mcp/src/transform/types.rs
@@ -2,7 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::core::config::ResponseFormatConfig;
+use crate::core::config::{BuiltinToolType, ResponseFormatConfig};
 
 /// Format for transforming MCP responses to API-specific formats.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -19,6 +19,25 @@ pub enum ResponseFormat {
     FileSearchCall,
     /// Transform to OpenAI image_generation_call format
     ImageGenerationCall,
+}
+
+impl ResponseFormat {
+    /// Inverse of [`BuiltinToolType::response_format`]: returns the hosted-tool
+    /// kind this response format corresponds to, or `None` for the non-hosted
+    /// `Passthrough` format.
+    ///
+    /// Router dispatch paths use this to look up caller-declared overrides
+    /// for the current tool's hosted-tool kind without threading
+    /// [`BuiltinToolType`] separately through session bindings.
+    pub fn to_builtin_tool_type(&self) -> Option<BuiltinToolType> {
+        match self {
+            ResponseFormat::Passthrough => None,
+            ResponseFormat::WebSearchCall => Some(BuiltinToolType::WebSearchPreview),
+            ResponseFormat::CodeInterpreterCall => Some(BuiltinToolType::CodeInterpreter),
+            ResponseFormat::FileSearchCall => Some(BuiltinToolType::FileSearch),
+            ResponseFormat::ImageGenerationCall => Some(BuiltinToolType::ImageGeneration),
+        }
+    }
 }
 
 impl From<ResponseFormatConfig> for ResponseFormat {
@@ -65,5 +84,24 @@ mod tests {
     #[test]
     fn test_response_format_default() {
         assert_eq!(ResponseFormat::default(), ResponseFormat::Passthrough);
+    }
+
+    #[test]
+    fn test_to_builtin_tool_type_round_trip() {
+        // Non-passthrough formats should round-trip cleanly through
+        // BuiltinToolType::response_format.
+        let kinds = [
+            BuiltinToolType::WebSearchPreview,
+            BuiltinToolType::CodeInterpreter,
+            BuiltinToolType::FileSearch,
+            BuiltinToolType::ImageGeneration,
+        ];
+        for kind in kinds {
+            let fmt: ResponseFormat = kind.response_format().into();
+            assert_eq!(fmt.to_builtin_tool_type(), Some(kind));
+        }
+
+        // Passthrough is not a hosted-tool kind.
+        assert_eq!(ResponseFormat::Passthrough.to_builtin_tool_type(), None);
     }
 }

--- a/model_gateway/src/routers/grpc/harmony/responses/execution.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/execution.rs
@@ -43,20 +43,34 @@ pub(super) async fn execute_mcp_tools(
     // Convert tool calls to execution inputs, merging caller-declared
     // hosted-tool configuration from `request_tools` into dispatch args.
     // For non-hosted-tool calls (Passthrough format), no override lookup runs.
+    // Non-object model payloads coerce to `{}` so the override merge actually
+    // applies rather than silently dropping the caller's declared config.
     let inputs: Vec<ToolExecutionInput> = tool_calls
         .iter()
         .map(|tc| {
             let args_str = tc.function.arguments.as_deref().unwrap_or("{}");
-            let mut args: Value = from_str(args_str).unwrap_or_else(|e| {
-                error!(
-                    function = "execute_mcp_tools",
-                    tool_name = %tc.function.name,
-                    call_id = %tc.id,
-                    error = %e,
-                    "Failed to parse tool arguments JSON, using empty object"
-                );
-                json!({})
-            });
+            let mut args: Value = match from_str::<Value>(args_str) {
+                Ok(Value::Object(map)) => Value::Object(map),
+                Ok(_) => {
+                    debug!(
+                        function = "execute_mcp_tools",
+                        tool_name = %tc.function.name,
+                        call_id = %tc.id,
+                        "Tool arguments parsed to non-object JSON; coercing to empty object"
+                    );
+                    json!({})
+                }
+                Err(e) => {
+                    error!(
+                        function = "execute_mcp_tools",
+                        tool_name = %tc.function.name,
+                        call_id = %tc.id,
+                        error = %e,
+                        "Failed to parse tool arguments JSON, using empty object"
+                    );
+                    json!({})
+                }
+            };
             if let Some(kind) = session
                 .tool_response_format(&tc.function.name)
                 .to_builtin_tool_type()

--- a/model_gateway/src/routers/grpc/harmony/responses/execution.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/execution.rs
@@ -3,7 +3,9 @@
 use axum::response::Response;
 use openai_protocol::{common::ToolCall, responses::ResponseTool};
 use serde_json::{from_str, json, Value};
-use smg_mcp::{McpToolSession, ToolExecutionInput};
+use smg_mcp::{
+    apply_hosted_tool_overrides, extract_hosted_tool_overrides, McpToolSession, ToolExecutionInput,
+};
 use tracing::{debug, error};
 
 use super::common::McpCallTracking;
@@ -36,13 +38,16 @@ pub(super) async fn execute_mcp_tools(
     tool_calls: &[ToolCall],
     tracking: &mut McpCallTracking,
     model_id: &str,
+    request_tools: &[ResponseTool],
 ) -> Result<Vec<ToolResult>, Response> {
-    // Convert tool calls to execution inputs
+    // Convert tool calls to execution inputs, merging caller-declared
+    // hosted-tool configuration from `request_tools` into dispatch args.
+    // For non-hosted-tool calls (Passthrough format), no override lookup runs.
     let inputs: Vec<ToolExecutionInput> = tool_calls
         .iter()
         .map(|tc| {
             let args_str = tc.function.arguments.as_deref().unwrap_or("{}");
-            let args: Value = from_str(args_str).unwrap_or_else(|e| {
+            let mut args: Value = from_str(args_str).unwrap_or_else(|e| {
                 error!(
                     function = "execute_mcp_tools",
                     tool_name = %tc.function.name,
@@ -52,6 +57,14 @@ pub(super) async fn execute_mcp_tools(
                 );
                 json!({})
             });
+            if let Some(kind) = session
+                .tool_response_format(&tc.function.name)
+                .to_builtin_tool_type()
+            {
+                if let Some(overrides) = extract_hosted_tool_overrides(request_tools, kind) {
+                    apply_hosted_tool_overrides(&mut args, &overrides);
+                }
+            }
             ToolExecutionInput {
                 call_id: tc.id.clone(),
                 tool_name: tc.function.name.clone(),

--- a/model_gateway/src/routers/grpc/harmony/responses/non_streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/non_streaming.rs
@@ -249,7 +249,9 @@ async fn execute_with_mcp_loop(
                     return Ok(response);
                 }
 
-                // Execute MCP tools (if any)
+                // Execute MCP tools (if any). Caller-declared hosted-tool overrides
+                // live on `original_tools` (pre-MCP-injection), so we thread those
+                // into dispatch — `execute_mcp_tools` merges per-kind.
                 let mcp_results = if mcp_tool_calls.is_empty() {
                     Vec::new()
                 } else {
@@ -258,6 +260,7 @@ async fn execute_with_mcp_loop(
                         &mcp_tool_calls,
                         &mut mcp_tracking,
                         &current_request.model,
+                        original_tools.as_deref().unwrap_or(&[]),
                     )
                     .await?
                 };

--- a/model_gateway/src/routers/grpc/harmony/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/streaming.rs
@@ -299,7 +299,9 @@ async fn execute_mcp_tool_loop_streaming(
                     return;
                 }
 
-                // Execute MCP tools (if any)
+                // Execute MCP tools (if any). `original_request.tools` is the
+                // caller-declared tool list (hosted-tool config lives there);
+                // `execute_mcp_tools` merges the per-kind overrides into dispatch args.
                 let mcp_results = if mcp_tool_calls.is_empty() {
                     Vec::new()
                 } else {
@@ -308,6 +310,7 @@ async fn execute_mcp_tool_loop_streaming(
                         &mcp_tool_calls,
                         &mut mcp_tracking,
                         &current_request.model,
+                        original_request.tools.as_deref().unwrap_or(&[]),
                     )
                     .await
                     {

--- a/model_gateway/src/routers/grpc/regular/responses/non_streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/non_streaming.rs
@@ -340,12 +340,17 @@ pub(super) async fn execute_tool_loop(
 
             // Convert tool calls to execution inputs, merging caller-declared
             // hosted-tool config from `original_request.tools` into dispatch args.
+            // Non-object model payloads coerce to `{}` so the merge actually
+            // applies instead of silently dropping the caller's config.
             let request_tools = original_request.tools.as_deref().unwrap_or(&[]);
             let inputs: Vec<ToolExecutionInput> = mcp_tool_calls
                 .into_iter()
                 .map(|tc| {
-                    let mut arguments: serde_json::Value =
-                        serde_json::from_str(&tc.arguments).unwrap_or_else(|_| json!({}));
+                    let mut arguments =
+                        match serde_json::from_str::<serde_json::Value>(&tc.arguments) {
+                            Ok(serde_json::Value::Object(map)) => serde_json::Value::Object(map),
+                            _ => json!({}),
+                        };
                     if let Some(kind) = session
                         .tool_response_format(&tc.name)
                         .to_builtin_tool_type()

--- a/model_gateway/src/routers/grpc/regular/responses/non_streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/non_streaming.rs
@@ -10,7 +10,10 @@ use std::sync::Arc;
 use axum::response::Response;
 use openai_protocol::responses::{ResponseStatus, ResponsesRequest, ResponsesResponse};
 use serde_json::json;
-use smg_mcp::{McpServerBinding, McpToolSession, ToolExecutionInput};
+use smg_mcp::{
+    apply_hosted_tool_overrides, extract_hosted_tool_overrides, McpServerBinding, McpToolSession,
+    ToolExecutionInput,
+};
 use tracing::{debug, error, trace, warn};
 
 use super::{
@@ -335,13 +338,28 @@ pub(super) async fn execute_tool_loop(
                 return Ok(responses_response);
             }
 
-            // Convert tool calls to execution inputs
+            // Convert tool calls to execution inputs, merging caller-declared
+            // hosted-tool config from `original_request.tools` into dispatch args.
+            let request_tools = original_request.tools.as_deref().unwrap_or(&[]);
             let inputs: Vec<ToolExecutionInput> = mcp_tool_calls
                 .into_iter()
-                .map(|tc| ToolExecutionInput {
-                    call_id: tc.call_id,
-                    tool_name: tc.name,
-                    arguments: serde_json::from_str(&tc.arguments).unwrap_or_else(|_| json!({})),
+                .map(|tc| {
+                    let mut arguments: serde_json::Value =
+                        serde_json::from_str(&tc.arguments).unwrap_or_else(|_| json!({}));
+                    if let Some(kind) = session
+                        .tool_response_format(&tc.name)
+                        .to_builtin_tool_type()
+                    {
+                        if let Some(overrides) = extract_hosted_tool_overrides(request_tools, kind)
+                        {
+                            apply_hosted_tool_overrides(&mut arguments, &overrides);
+                        }
+                    }
+                    ToolExecutionInput {
+                        call_id: tc.call_id,
+                        tool_name: tc.name,
+                        arguments,
+                    }
                 })
                 .collect();
 

--- a/model_gateway/src/routers/grpc/regular/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/streaming.rs
@@ -34,7 +34,10 @@ use smg_data_connector::{
     ConversationItemStorage, ConversationStorage, RequestContext as StorageRequestContext,
     ResponseStorage,
 };
-use smg_mcp::{McpServerBinding, McpToolSession, ResponseFormat, ToolExecutionInput};
+use smg_mcp::{
+    apply_hosted_tool_overrides, extract_hosted_tool_overrides, McpServerBinding, McpToolSession,
+    ResponseFormat, ToolExecutionInput,
+};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::{debug, trace, warn};
@@ -705,9 +708,18 @@ async fn execute_tool_loop_streaming_internal(
                     tool_call.name,
                     tool_call.arguments
                 );
-                // Parse arguments to Value
-                let arguments: Value =
+                // Parse arguments to Value, merging caller-declared hosted-tool
+                // config from `original_request.tools` for the matching kind.
+                let mut arguments: Value =
                     serde_json::from_str(&tool_call.arguments).unwrap_or_else(|_| json!({}));
+                if let Some(kind) = response_format.to_builtin_tool_type() {
+                    if let Some(overrides) = extract_hosted_tool_overrides(
+                        original_request.tools.as_deref().unwrap_or(&[]),
+                        kind,
+                    ) {
+                        apply_hosted_tool_overrides(&mut arguments, &overrides);
+                    }
+                }
 
                 // Execute the single tool via the normalized MCP execution API.
                 // This avoids custom serialization and manual re-transformation in streaming paths.

--- a/model_gateway/src/routers/grpc/regular/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/streaming.rs
@@ -708,10 +708,14 @@ async fn execute_tool_loop_streaming_internal(
                     tool_call.name,
                     tool_call.arguments
                 );
-                // Parse arguments to Value, merging caller-declared hosted-tool
-                // config from `original_request.tools` for the matching kind.
-                let mut arguments: Value =
-                    serde_json::from_str(&tool_call.arguments).unwrap_or_else(|_| json!({}));
+                // Parse arguments to Value, coercing scalar/array/null payloads
+                // to an empty object so hosted-tool override merge can actually
+                // apply. `apply_hosted_tool_overrides` is a no-op on non-objects;
+                // silently dropping caller-declared config would be surprising.
+                let mut arguments = match serde_json::from_str::<Value>(&tool_call.arguments) {
+                    Ok(Value::Object(map)) => Value::Object(map),
+                    _ => json!({}),
+                };
                 if let Some(kind) = response_format.to_builtin_tool_type() {
                     if let Some(overrides) = extract_hosted_tool_overrides(
                         original_request.tools.as_deref().unwrap_or(&[]),

--- a/model_gateway/src/routers/openai/mcp/tool_loop.rs
+++ b/model_gateway/src/routers/openai/mcp/tool_loop.rs
@@ -233,6 +233,12 @@ pub(crate) async fn execute_streaming_tool_calls(
             return false;
         }
 
+        // Coerce non-object payloads to `{}` before merging overrides — the
+        // merge is a no-op on scalars/arrays and we don't want to silently
+        // drop caller-declared hosted-tool config.
+        if !matches!(arguments, Value::Object(_)) {
+            arguments = json!({});
+        }
         // Merge caller-declared hosted-tool configuration (e.g. `size`, `quality`
         // on image_generation) into dispatch args. No-op for non-hosted tools.
         if let Some(kind) = response_format.to_builtin_tool_type() {
@@ -241,7 +247,9 @@ pub(crate) async fn execute_streaming_tool_calls(
             }
         }
 
-        debug!("Calling MCP tool '{}' with args: {}", call.name, args_str);
+        // Log the effective (post-merge) args so the log reflects what the
+        // MCP server actually receives, not the pre-merge string from the model.
+        debug!("Calling MCP tool '{}' with args: {}", call.name, arguments);
         let tool_output = session
             .execute_tool(ToolExecutionInput {
                 call_id: call.call_id.clone(),
@@ -905,6 +913,12 @@ pub(crate) async fn execute_tool_loop(
                 }
             };
 
+            // Coerce non-object payloads to `{}` before merging overrides —
+            // the merge is a no-op on scalars/arrays and we don't want to
+            // silently drop caller-declared hosted-tool config.
+            if !matches!(arguments, Value::Object(_)) {
+                arguments = json!({});
+            }
             // Merge caller-declared hosted-tool configuration into dispatch args
             // for this tool's hosted-tool kind, if any. `original_body.tools` is
             // the caller's tool declarations; empty / None = no-op.
@@ -918,9 +932,15 @@ pub(crate) async fn execute_tool_loop(
                 }
             }
 
+            // Serialize the post-merge args once so downstream logging + the
+            // approval payload show the effective (dispatched) payload rather
+            // than the pre-merge string the model emitted.
+            let effective_arguments =
+                serde_json::to_string(&arguments).unwrap_or_else(|_| call.arguments.clone());
+
             debug!(
                 "Calling MCP tool '{}' with args: {}",
-                call.name, call.arguments
+                call.name, effective_arguments
             );
             let tool_result = session
                 .execute_tool_result(ToolExecutionInput {
@@ -940,7 +960,7 @@ pub(crate) async fn execute_tool_loop(
                     let approval_item = build_mcp_approval_request_item(
                         &approval_request_id,
                         &pending.tool_name,
-                        &call.arguments,
+                        &effective_arguments,
                         &server_label,
                     );
                     return build_approval_response(

--- a/model_gateway/src/routers/openai/mcp/tool_loop.rs
+++ b/model_gateway/src/routers/openai/mcp/tool_loop.rs
@@ -21,8 +21,9 @@ use openai_protocol::{
 };
 use serde_json::{json, to_value, Value};
 use smg_mcp::{
-    extract_embedded_openai_responses, mcp_response_item_id, McpServerBinding, McpToolSession,
-    ResponseFormat, ResponseTransformer, ToolExecutionInput, ToolExecutionResult,
+    apply_hosted_tool_overrides, extract_embedded_openai_responses, extract_hosted_tool_overrides,
+    mcp_response_item_id, McpServerBinding, McpToolSession, ResponseFormat, ResponseTransformer,
+    ToolExecutionInput, ToolExecutionResult,
 };
 use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
@@ -148,7 +149,12 @@ fn build_message_from_openai_response(openai_response: Value) -> Option<Value> {
     }))
 }
 
-/// Execute detected tool calls and send completion events to client
+/// Execute detected tool calls and send completion events to client.
+///
+/// `request_tools` carries the caller-declared `tools` list from the original
+/// request so per-kind hosted-tool overrides can be merged into dispatch args
+/// before [`McpToolSession::execute_tool`].
+///
 /// Returns false if client disconnected during execution
 pub(crate) async fn execute_streaming_tool_calls(
     pending_calls: Vec<FunctionCallInProgress>,
@@ -157,6 +163,7 @@ pub(crate) async fn execute_streaming_tool_calls(
     state: &mut ToolLoopState,
     sequence_number: &mut u64,
     model_id: &str,
+    request_tools: &[ResponseTool],
 ) -> bool {
     for call in pending_calls {
         if call.name.is_empty() {
@@ -181,7 +188,7 @@ pub(crate) async fn execute_streaming_tool_calls(
         let response_format = session.tool_response_format(&call.name);
         let server_label = session.resolve_tool_server_label(&call.name);
 
-        let arguments: Value = match serde_json::from_str(args_str) {
+        let mut arguments: Value = match serde_json::from_str(args_str) {
             Ok(v) => v,
             Err(e) => {
                 let err_str = format!("Failed to parse tool arguments: {e}");
@@ -224,6 +231,14 @@ pub(crate) async fn execute_streaming_tool_calls(
 
         if !send_tool_call_intermediate_event(tx, &call, &response_format, sequence_number) {
             return false;
+        }
+
+        // Merge caller-declared hosted-tool configuration (e.g. `size`, `quality`
+        // on image_generation) into dispatch args. No-op for non-hosted tools.
+        if let Some(kind) = response_format.to_builtin_tool_type() {
+            if let Some(overrides) = extract_hosted_tool_overrides(request_tools, kind) {
+                apply_hosted_tool_overrides(&mut arguments, &overrides);
+            }
         }
 
         debug!("Calling MCP tool '{}' with args: {}", call.name, args_str);
@@ -853,7 +868,7 @@ pub(crate) async fn execute_tool_loop(
                     original_body,
                 );
             }
-            let arguments: Value = match serde_json::from_str(&call.arguments) {
+            let mut arguments: Value = match serde_json::from_str(&call.arguments) {
                 Ok(v) => v,
                 Err(e) => {
                     warn!(tool = %call.name, error = %e, "Failed to parse tool arguments as JSON");
@@ -890,6 +905,19 @@ pub(crate) async fn execute_tool_loop(
                 }
             };
 
+            // Merge caller-declared hosted-tool configuration into dispatch args
+            // for this tool's hosted-tool kind, if any. `original_body.tools` is
+            // the caller's tool declarations; empty / None = no-op.
+            let response_format = session.tool_response_format(&call.name);
+            if let Some(kind) = response_format.to_builtin_tool_type() {
+                if let Some(overrides) = extract_hosted_tool_overrides(
+                    original_body.tools.as_deref().unwrap_or(&[]),
+                    kind,
+                ) {
+                    apply_hosted_tool_overrides(&mut arguments, &overrides);
+                }
+            }
+
             debug!(
                 "Calling MCP tool '{}' with args: {}",
                 call.name, call.arguments
@@ -902,7 +930,6 @@ pub(crate) async fn execute_tool_loop(
                 })
                 .await;
 
-            let response_format = session.tool_response_format(&call.name);
             let server_label = session.resolve_tool_server_label(&call.name);
             let tool_item_id = non_streaming_tool_item_id_source(&call.item_id, &response_format);
             let approval_request_id = approval_request_item_id_source(&call.item_id);

--- a/model_gateway/src/routers/openai/responses/streaming.rs
+++ b/model_gateway/src/routers/openai/responses/streaming.rs
@@ -980,7 +980,9 @@ pub(super) fn handle_streaming_with_tool_interception(
                 return;
             }
 
-            // Execute all pending tool calls
+            // Execute all pending tool calls. Pass the caller-declared tools so
+            // hosted-tool overrides (e.g. image_generation size/quality) are
+            // merged into dispatch args before MCP execution.
             if !execute_streaming_tool_calls(
                 pending_calls,
                 &session,
@@ -988,6 +990,7 @@ pub(super) fn handle_streaming_with_tool_interception(
                 &mut state,
                 &mut sequence_number,
                 &original_request.model,
+                original_request.tools.as_deref().unwrap_or(&[]),
             )
             .await
             {


### PR DESCRIPTION
## Description

### Problem
R6.1–R6.4 (#1355, #1356, #1358, #1359) added image_generation plumbing end-to-end: `ResponseFormat::ImageGenerationCall`, `BuiltinToolType::ImageGeneration`, streaming event emitters per router, and the MCP transformer. The MCP dispatch path still **drops caller-declared hosted-tool configuration**. A request declaring

\`\`\`json
{ "tools": [{ "type": "image_generation", "size": "512x512", "quality": "high" }] }
\`\`\`

paired with a model that emits `{prompt}` reaches the MCP server as just `{prompt}` — `size` and `quality` are silently lost. R6.5's e2e probe on #1365 (`test_image_generation_tool_overrides_size`) confirmed the gap: the mock MCP server never saw `size=512x512`.

### Solution
Two pure helpers in `smg-mcp` + per-router wiring at every MCP dispatch site.

- Helpers live in `smg-mcp` because the crate already depends on `openai-protocol` and already contains the inverse direction (`ResponseTransformer::to_image_generation_call`: MCP result → `ResponseOutputItem`). The extract-and-merge path is the symmetric complement.
- Pure functions (not `McpToolSession` methods) because the merge needs no session state: `&[ResponseTool] + BuiltinToolType → Option<Value>`, then in-place merge into dispatch args. This keeps `call_tool`'s contract clean and makes the helpers unit-testable in isolation.
- Router wiring is narrow: each call site maps its per-tool `ResponseFormat` back to `BuiltinToolType` via a new `ResponseFormat::to_builtin_tool_type()` and calls the two helpers before `session.execute_tool[s]`.

## Changes

### `smg-mcp` helpers (commit 1)

- **`crates/mcp/src/transform/overrides.rs`** (new):
  - `pub fn extract_hosted_tool_overrides(tools: &[ResponseTool], kind: BuiltinToolType) -> Option<Value>` — finds the first matching declaration, serializes the inner struct, drops null fields, drops the `type` discriminator, returns `None` if empty. Image_generation is the only kind with caller-configurable fields today; the other arms stay in place so they pick up new overridable fields automatically as those tool structs grow.
  - `pub fn apply_hosted_tool_overrides(arguments: &mut Value, overrides: &Value)` — in-place merge; caller-declared keys win over model-emitted keys; no-op for non-object inputs.
  - 11 unit tests: null-drop, empty→None, missing-declaration→None, first-match-after-non-matching, caller-wins, args extension, non-object args/overrides no-ops, empty-overrides no-op, and coverage of the other three hosted kinds.
- **`crates/mcp/src/transform/types.rs`**: `ResponseFormat::to_builtin_tool_type() -> Option<BuiltinToolType>` as the inverse of `BuiltinToolType::response_format()`, plus a round-trip test.
- **`crates/mcp/src/transform/mod.rs`** and **`crates/mcp/src/lib.rs`**: top-level re-exports following the existing transform re-export convention.

### Router wiring (commit 2)

All dispatch loci now merge caller-declared overrides before `session.execute_tool[s]`:

- **`openai/mcp/tool_loop.rs`** — streaming (`execute_streaming_tool_calls` gains a `request_tools: &[ResponseTool]` parameter) and non-streaming (`execute_tool_loop` reads `original_body.tools`).
- **`openai/responses/streaming.rs`** — threads `original_request.tools` into `execute_streaming_tool_calls`.
- **`grpc/harmony/responses/execution.rs`** — `execute_mcp_tools` gains `request_tools: &[ResponseTool]` and merges inside the `ToolExecutionInput` build loop.
- **`grpc/harmony/responses/{streaming,non_streaming}.rs`** — call sites pass `original_request.tools` / `original_tools` respectively (both preserved before MCP tool injection).
- **`grpc/regular/responses/non_streaming.rs`** — tool-loop `ToolExecutionInput` build loop merges from `original_request.tools`.
- **`grpc/regular/responses/streaming.rs`** — single-tool `execute_tool` path merges from `original_request.tools`.

Non-hosted dispatch is unaffected: `ResponseFormat::Passthrough` maps to `None` and the merge short-circuits. User-registered (non-builtin) MCP tool dispatch paths are guarded by the same check — no forced cascade.

## Non-goals

- No compactor changes (R6.1 already covers).
- No new event types (R6.1 covers).
- No fix for the gRPC harmony gpt-oss dispatch gap R6.5 found (separate — belongs in R6.7).
- No fix for R6.2's event-ordering / empty-\`result\` bugs R6.5 found (separate R6.x follow-up).

## Test Plan

- [x] \`cargo check -p openai-protocol -p smg-mcp -p smg --lib --tests --benches\`
- [x] \`cargo test -p smg-mcp --lib\` — 195 tests pass (12 new in transform::overrides + transform::types).
- [x] \`cargo test -p smg --lib\` — 633 tests pass.
- [x] \`cargo fmt --all\`
- [x] \`cargo clippy -p openai-protocol -p smg-mcp -p smg --lib --tests --benches -- -D warnings\` — clean.
- [ ] R6.5 e2e (#1365) — once this lands and #1365 rebases, \`test_image_generation_tool_overrides_size\` should pass (the mock MCP server will see \`size=512x512\` as an effective arg).

Refs: R6 §tool-overrides (\`.claude/_audit/responses-api-gap-audit.md\`); R6.5 #1365

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tool execution now merges caller-declared hosted-tool configuration overrides into dispatch arguments across streaming and non-streaming flows and protocols, ensuring caller-specified tool settings are applied when tools run.
  * Tool argument payloads are normalized so overrides consistently take effect, and logged/approved payloads reflect the effective (post-merge) arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->