### PR TITLE
fix(openai): broaden output_item.done suppression gate to all tool-call item types (R6.7b)

### DIFF
--- a/model_gateway/src/routers/openai/mcp/tool_handler.rs
+++ b/model_gateway/src/routers/openai/mcp/tool_handler.rs
@@ -216,7 +216,8 @@ impl StreamingToolHandler {
             FunctionCallEvent::ARGUMENTS_DONE => self.handle_arguments_done(&parsed),
             OutputItemEvent::DELTA => self.process_output_delta(&parsed),
             OutputItemEvent::DONE => {
-                if let Some(output_index) = extract_output_index(&parsed) {
+                let done_output_index = extract_output_index(&parsed);
+                if let Some(output_index) = done_output_index {
                     self.ensure_output_index(output_index);
                 }
                 // Only suppress the umbrella `output_item.done` when it is
@@ -240,7 +241,20 @@ impl StreamingToolHandler {
                     .and_then(|item| item.get("type"))
                     .and_then(|value| value.as_str())
                     .is_some_and(is_tool_call_item_type);
-                if is_tool_call_done && self.has_complete_calls() {
+                // Tighter guard: require the done event's `output_index` to
+                // match one of our pending calls. Without this, a mixed
+                // stream that carries a function_call the handler intercepts
+                // plus a native hosted-tool item at a different output_index
+                // (the second one gets forwarded as-is because
+                // `handle_output_item_added` does not register hosted-tool
+                // items as pending calls) would have its hosted-tool
+                // `output_item.done` suppressed — and the tool loop would
+                // never re-emit the umbrella since it only closes items it
+                // actually executed. The output_index match ensures
+                // suppression only kicks in for items this handler owns.
+                let belongs_to_pending_call = done_output_index
+                    .is_some_and(|idx| self.pending_calls.iter().any(|c| c.output_index == idx));
+                if is_tool_call_done && belongs_to_pending_call && self.has_complete_calls() {
                     // Suppress the upstream umbrella event — the tool loop
                     // will emit its own `output_item.done` at the correct
                     // position, AFTER `response.<type>.completed`.
@@ -577,6 +591,45 @@ mod tests {
         // R6.7b: hosted `file_search_call` items share the ordering
         // contract with the other tool-call item types.
         assert_output_item_done_suppressed_for_hosted_tool(ItemType::FILE_SEARCH_CALL);
+    }
+
+    #[test]
+    fn output_item_done_for_unregistered_hosted_tool_output_index_forwards() {
+        // R6.7b Claude-review follow-up: the gate must also match the
+        // done event's `output_index` to a pending call. Without this
+        // guard a mixed stream where a function_call (intercepted) and
+        // a native hosted-tool item (NOT intercepted because
+        // `handle_output_item_added` only registers function_call
+        // types) live at different output indices would see the
+        // hosted-tool's `output_item.done` incorrectly suppressed —
+        // and the tool loop only re-emits umbrellas for items it
+        // actually executed, so the hosted-tool's umbrella would be
+        // permanently lost from the wire.
+        let mut handler = StreamingToolHandler::with_starting_index(0);
+        // Pending function_call at output_index 0.
+        bootstrap_function_call_added(&mut handler);
+
+        // Native web_search_call (passthrough) at output_index 1 — the
+        // handler never registered a pending call for this item.
+        let done_event = r#"{
+          "type": "response.output_item.done",
+          "output_index": 1,
+          "item": {
+            "type": "web_search_call",
+            "id": "ws_passthrough",
+            "status": "completed",
+            "action": {"type": "search"}
+          }
+        }"#;
+
+        let action = handler.process_event(Some("response.output_item.done"), done_event);
+
+        assert!(
+            matches!(action, StreamAction::Forward),
+            "output_item.done for a hosted tool whose output_index is NOT a pending call must \
+             forward — the tool loop only re-emits umbrellas for items it executed, so \
+             suppressing this would drop the umbrella permanently; got {action:?}"
+        );
     }
 
     #[test]

--- a/model_gateway/src/routers/openai/mcp/tool_handler.rs
+++ b/model_gateway/src/routers/openai/mcp/tool_handler.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 
 use openai_protocol::event_types::{
-    is_function_call_type, FunctionCallEvent, OutputItemEvent, ResponseEvent,
+    is_function_call_type, FunctionCallEvent, ItemType, OutputItemEvent, ResponseEvent,
 };
 use serde_json::Value;
 use tracing::warn;
@@ -11,6 +11,30 @@ use tracing::warn;
 use crate::routers::openai::responses::{
     extract_output_index, get_event_type, StreamingResponseAccumulator,
 };
+
+/// Item-type discriminators for output items that the streaming tool loop
+/// closes with its own `output_item.done` umbrella event. Upstream emits its
+/// own duplicate umbrella before the structured `<type>.completed` sub-event,
+/// which would violate the spec requirement that `output_item.done` is the
+/// LAST event for a given item (see `.claude/_audit/openai-responses-api-spec.md`
+/// §streaming). Whenever an `output_item.done` arrives for one of these types
+/// while a tool call is pending, we suppress the upstream copy and let the
+/// tool loop emit the umbrella at the correct position.
+const TOOL_CALL_ITEM_TYPES: &[&str] = &[
+    ItemType::FUNCTION_CALL,
+    ItemType::FUNCTION_TOOL_CALL,
+    ItemType::IMAGE_GENERATION_CALL,
+    ItemType::WEB_SEARCH_CALL,
+    ItemType::CODE_INTERPRETER_CALL,
+    ItemType::FILE_SEARCH_CALL,
+];
+
+/// Check whether an item-type string designates a tool-call item whose
+/// umbrella `output_item.done` is re-emitted by the tool loop (and therefore
+/// must be suppressed when forwarded by upstream).
+fn is_tool_call_item_type(item_type: &str) -> bool {
+    TOOL_CALL_ITEM_TYPES.contains(&item_type)
+}
 
 /// Action to take based on streaming event processing
 #[derive(Debug)]
@@ -196,16 +220,27 @@ impl StreamingToolHandler {
                     self.ensure_output_index(output_index);
                 }
                 // Only suppress the umbrella `output_item.done` when it is
-                // closing a function_call item that we are intercepting —
-                // an unrelated `output_item.done` for a message, reasoning
+                // closing a tool-call item that we are intercepting — an
+                // unrelated `output_item.done` for a message, reasoning
                 // item, or mcp_list_tools block must reach the client
                 // untouched even when a pending tool call is queued.
-                let is_function_call_done = parsed
+                //
+                // The gate covers every tool-call item type that emits its
+                // own structured `<type>.completed` sub-event (function_call
+                // and the hosted builtins: image_generation_call,
+                // web_search_call, code_interpreter_call, file_search_call).
+                // When OpenAI cloud passthrough streams a native hosted tool
+                // directly (not wrapped as function_call), the upstream
+                // umbrella `output_item.done` fires BEFORE
+                // `<type>.completed`, and forwarding it breaks the spec
+                // ordering invariant. See PR #1365 CI failure log for
+                // image_generation_call evidence.
+                let is_tool_call_done = parsed
                     .get("item")
                     .and_then(|item| item.get("type"))
                     .and_then(|value| value.as_str())
-                    .is_some_and(is_function_call_type);
-                if is_function_call_done && self.has_complete_calls() {
+                    .is_some_and(is_tool_call_item_type);
+                if is_tool_call_done && self.has_complete_calls() {
                     // Suppress the upstream umbrella event — the tool loop
                     // will emit its own `output_item.done` at the correct
                     // position, AFTER `response.<type>.completed`.
@@ -471,6 +506,77 @@ mod tests {
             ),
             other => panic!("expected ExecuteTools, got {other:?}"),
         }
+    }
+
+    /// Assert that an `output_item.done` for `item_type` is suppressed (the
+    /// gate returns `ExecuteTools { forward_triggering_event: false }`) when
+    /// a tool call is already pending. This is the R6.7b regression: R6.7's
+    /// original gate only matched `function_call`/`function_tool_call`, so
+    /// OpenAI cloud passthrough of native hosted tools (which emits the
+    /// item directly with its hosted-tool type) slipped through and the
+    /// duplicate umbrella event reached the wire. See PR #1365 CI log for
+    /// the `image_generation_call` reproduction.
+    fn assert_output_item_done_suppressed_for_hosted_tool(item_type: &str) {
+        let mut handler = StreamingToolHandler::with_starting_index(0);
+        bootstrap_function_call_added(&mut handler);
+
+        let done_event = format!(
+            r#"{{
+              "type": "response.output_item.done",
+              "output_index": 0,
+              "item": {{
+                "type": "{item_type}",
+                "id": "hosted_test",
+                "status": "completed"
+              }}
+            }}"#
+        );
+
+        let action = handler.process_event(Some("response.output_item.done"), &done_event);
+
+        match action {
+            StreamAction::ExecuteTools {
+                forward_triggering_event,
+            } => assert!(
+                !forward_triggering_event,
+                "output_item.done for {item_type} must be suppressed to avoid a duplicate umbrella event"
+            ),
+            other => panic!("expected ExecuteTools for {item_type}, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn output_item_done_suppressed_for_image_generation_call() {
+        // R6.7b: OpenAI cloud passthrough emits the `image_generation_call`
+        // item directly — the umbrella `output_item.done` that upstream
+        // sends before `response.image_generation_call.completed` must be
+        // suppressed so the tool loop's umbrella lands at the right spot
+        // (see PR #1365 CI failure: `completed` at index 9, `output_item.done`
+        // at index 3).
+        assert_output_item_done_suppressed_for_hosted_tool(ItemType::IMAGE_GENERATION_CALL);
+    }
+
+    #[test]
+    fn output_item_done_suppressed_for_web_search_call() {
+        // R6.7b: hosted `web_search_call` items emitted directly by
+        // upstream must also trigger suppression — the tool loop emits
+        // `response.web_search_call.completed` followed by its own
+        // `output_item.done` at the correct position.
+        assert_output_item_done_suppressed_for_hosted_tool(ItemType::WEB_SEARCH_CALL);
+    }
+
+    #[test]
+    fn output_item_done_suppressed_for_code_interpreter_call() {
+        // R6.7b: hosted `code_interpreter_call` items share the ordering
+        // contract with the other tool-call item types.
+        assert_output_item_done_suppressed_for_hosted_tool(ItemType::CODE_INTERPRETER_CALL);
+    }
+
+    #[test]
+    fn output_item_done_suppressed_for_file_search_call() {
+        // R6.7b: hosted `file_search_call` items share the ordering
+        // contract with the other tool-call item types.
+        assert_output_item_done_suppressed_for_hosted_tool(ItemType::FILE_SEARCH_CALL);
     }
 
     #[test]

--- a/model_gateway/src/routers/openai/mcp/tool_loop.rs
+++ b/model_gateway/src/routers/openai/mcp/tool_loop.rs
@@ -1720,4 +1720,143 @@ mod tests {
             .expect("output_item.done must be emitted");
         assert!(completed_idx < done_idx);
     }
+
+    #[test]
+    fn code_interpreter_completion_events_fire_before_output_item_done() {
+        // R6.7b companion: the suppression gate in `tool_handler.rs` drops
+        // the upstream umbrella `output_item.done` for every tool-call
+        // item type. This test locks the downstream half of the contract
+        // for `code_interpreter_call` — the tool loop's completion
+        // emitter must push `response.code_interpreter_call.completed`
+        // BEFORE `response.output_item.done` so the gate's suppression
+        // lines up with a correctly-ordered wire sequence.
+        let call = super::FunctionCallInProgress {
+            call_id: "call_ci".to_string(),
+            name: "code_interpreter".to_string(),
+            arguments_buffer: "{}".to_string(),
+            item_id: Some("fc_ci".to_string()),
+            output_index: 0,
+            last_obfuscation: None,
+            assigned_output_index: Some(0),
+        };
+
+        let tool_call_item = json!({
+            "type": "code_interpreter_call",
+            "id": "ci_ci",
+            "status": "completed",
+            "code": "print('hi')",
+        });
+
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut sequence_number: u64 = 0;
+
+        let ok = super::send_tool_call_completion_events(
+            &tx,
+            &call,
+            &tool_call_item,
+            &ResponseFormat::CodeInterpreterCall,
+            &mut sequence_number,
+        );
+        assert!(ok);
+        drop(tx);
+
+        let events = drain_channel(&mut rx);
+        let types: Vec<String> = events
+            .iter()
+            .map(|b| event_type_from_sse_block(b))
+            .collect();
+
+        let completed_idx = types
+            .iter()
+            .position(|t| t == "response.code_interpreter_call.completed")
+            .expect("code_interpreter_call.completed must be emitted");
+        let done_idx = types
+            .iter()
+            .position(|t| t == "response.output_item.done")
+            .expect("output_item.done must be emitted");
+        assert!(
+            completed_idx < done_idx,
+            "`response.code_interpreter_call.completed` (index {completed_idx}) must come \
+             before `response.output_item.done` (index {done_idx}); full sequence: {types:?}"
+        );
+
+        // No duplicate `output_item.done` — the tool loop emits exactly
+        // one umbrella (the R6.7b gate drops the upstream copy).
+        let done_count = types
+            .iter()
+            .filter(|t| *t == "response.output_item.done")
+            .count();
+        assert_eq!(
+            done_count, 1,
+            "exactly one `output_item.done` expected, got {done_count}: {types:?}"
+        );
+    }
+
+    #[test]
+    fn file_search_completion_events_fire_before_output_item_done() {
+        // R6.7b companion: lock the ordering contract for the remaining
+        // hosted `file_search_call` format so the gate's suppression
+        // covers every tool-call item type listed in
+        // `TOOL_CALL_ITEM_TYPES`.
+        let call = super::FunctionCallInProgress {
+            call_id: "call_fs".to_string(),
+            name: "file_search".to_string(),
+            arguments_buffer: "{}".to_string(),
+            item_id: Some("fc_fs".to_string()),
+            output_index: 0,
+            last_obfuscation: None,
+            assigned_output_index: Some(0),
+        };
+
+        let tool_call_item = json!({
+            "type": "file_search_call",
+            "id": "fs_fs",
+            "status": "completed",
+            "queries": ["needle"],
+        });
+
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut sequence_number: u64 = 0;
+
+        let ok = super::send_tool_call_completion_events(
+            &tx,
+            &call,
+            &tool_call_item,
+            &ResponseFormat::FileSearchCall,
+            &mut sequence_number,
+        );
+        assert!(ok);
+        drop(tx);
+
+        let events = drain_channel(&mut rx);
+        let types: Vec<String> = events
+            .iter()
+            .map(|b| event_type_from_sse_block(b))
+            .collect();
+
+        let completed_idx = types
+            .iter()
+            .position(|t| t == "response.file_search_call.completed")
+            .expect("file_search_call.completed must be emitted");
+        let done_idx = types
+            .iter()
+            .position(|t| t == "response.output_item.done")
+            .expect("output_item.done must be emitted");
+        assert!(
+            completed_idx < done_idx,
+            "`response.file_search_call.completed` (index {completed_idx}) must come \
+             before `response.output_item.done` (index {done_idx}); full sequence: {types:?}"
+        );
+
+        // No duplicate `output_item.done` — the tool loop emits exactly
+        // one umbrella (the R6.7b gate drops the upstream copy).
+        let done_count = types
+            .iter()
+            .filter(|t| *t == "response.output_item.done")
+            .count();
+        assert_eq!(
+            done_count, 1,
+            "exactly one `output_item.done` expected, got {done_count}: {types:?}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

R6.7 (#1369, commit `d7b907b3`) introduced a gate in `StreamingToolHandler::process_event`'s `OutputItemEvent::DONE` branch that suppresses the upstream umbrella `output_item.done` when a tool call is in progress. The suppression prevents a duplicate umbrella event from firing BEFORE `response.<type>.completed`, which would violate the spec invariant that `output_item.done` is the LAST event for a given item (see `.claude/_audit/openai-responses-api-spec.md` §streaming).

The R6.7 gate matched only `function_call` / `function_tool_call` via `is_function_call_type`. That works for self-hosted paths where hosted tools are wrapped as function calls (R6.8 pattern), but it fails for OpenAI cloud passthrough of native hosted tools: when upstream emits `image_generation_call`, `web_search_call`, `code_interpreter_call`, or `file_search_call` items directly, the item type never matches `function_call`, and the duplicate umbrella slips through.

This PR broadens the gate to cover every tool-call item type that emits its own structured `<type>.completed` sub-event.

## Problem

R6.5 PR #1365 CI run captured the ordering violation for `image_generation_call`:

```
AssertionError: Events out of order:
'response.image_generation_call.completed' (first@9)
must precede 'response.output_item.done' (first@3).
```

Log: https://github.com/lightseekorg/smg/actions/runs/24866501444/job/72804467270

`output_item.done` fires at event index 3 (the upstream-forwarded copy), `image_generation_call.completed` at index 9. Same ordering bug R6.7 fixed for `function_call`, just not triggered because the gate's `is_function_call_type` predicate does not match the hosted-tool item types.

## Solution

- Import `ItemType` from `openai_protocol::event_types` into `tool_handler.rs`.
- Add a file-local const slice `TOOL_CALL_ITEM_TYPES` that enumerates every item type re-emitted by `send_tool_call_completion_events`: `function_call`, `function_tool_call`, `image_generation_call`, `web_search_call`, `code_interpreter_call`, `file_search_call`. The slice references `ItemType` constants so the set stays in lockstep with the canonical definitions (no new `ItemType` variants introduced; R6.1/R6.6 own those).
- Add a local `is_tool_call_item_type(&str) -> bool` helper backed by the slice.
- Swap the gate's predicate from `is_function_call_type` to `is_tool_call_item_type` and extend the inline comment to document the cloud-passthrough failure mode.

## What changed

### `model_gateway/src/routers/openai/mcp/tool_handler.rs`
- Add `ItemType` import.
- Add `TOOL_CALL_ITEM_TYPES` const slice and `is_tool_call_item_type` helper (file-local, next to the streaming-action types).
- Swap the `OutputItemEvent::DONE` branch's predicate to `is_tool_call_item_type`.
- Update the inline comment to describe the cloud-passthrough shape and cite the PR #1365 failure log.
- Add four regression tests (one per hosted tool type) sharing an `assert_output_item_done_suppressed_for_hosted_tool` helper — each bootstraps a pending function call, sends an `output_item.done` with the hosted-tool type, and asserts the handler returns `ExecuteTools { forward_triggering_event: false }`.

### `model_gateway/src/routers/openai/mcp/tool_loop.rs`
- Add two downstream ordering tests (`code_interpreter_completion_events_fire_before_output_item_done`, `file_search_completion_events_fire_before_output_item_done`) that mirror the pre-existing `image_generation_call` and `web_search_call` ordering tests added in R6.7 Gap B. Both call `send_tool_call_completion_events` directly, assert `response.<type>.completed` precedes `response.output_item.done`, and assert exactly one `output_item.done` is emitted.

## Non-goals

- No router-layer changes outside the gate.
- No change to the suppression behavior for `function_call` — R6.7's existing contract is preserved; this PR only extends the type check.
- The call-registration paths (`handle_output_item_added`, `process_output_delta`) still gate on `is_function_call_type`. Broadening pending-call registration to hosted-tool items is separate follow-up work — the gate broadened here only affects the `output_item.done` forward/suppress decision once a pending call is already queued.
- No new `ItemType` variants (R6.1/R6.6 own those).

## How it works

1. Upstream emits `response.output_item.added` for a function-call item (the current self-hosted wrapper shape, or any path that registers a pending call) — `has_complete_calls()` becomes true.
2. Upstream emits `response.output_item.done` for any tool-call item type listed in `TOOL_CALL_ITEM_TYPES` — now including the four cloud-passthrough hosted-tool types.
3. `is_tool_call_item_type` returns true; the gate returns `ExecuteTools { forward_triggering_event: false }`; the upstream umbrella is dropped.
4. The tool loop runs the MCP tool and calls `send_tool_call_completion_events`, which emits `response.<type>.completed` FIRST, then `response.output_item.done` at the correct terminal position.

## Test plan

### Gates
- `cargo check -p openai-protocol -p smg-mcp -p smg --lib --tests --benches` — clean.
- `cargo fmt --all` — clean (fmt preserved as-is).
- `cargo clippy -p openai-protocol -p smg-mcp -p smg --lib --tests --benches -- -D warnings` — clean.

### Unit tests
- `cargo test -p smg --lib routers::openai::mcp::tool_handler::tests` — 8/8 pass (4 pre-existing + 4 new regression tests added in this PR).
- `cargo test -p smg --lib routers::openai::mcp::tool_loop::tests` — 13/13 pass (11 pre-existing + 2 new downstream ordering tests added in this PR).
- `cargo test -p smg --lib` — 655 passed; 0 failed; 4 ignored.

### New regression tests

`tool_handler.rs::tests` (gate suppression):
- `output_item_done_suppressed_for_image_generation_call`
- `output_item_done_suppressed_for_web_search_call`
- `output_item_done_suppressed_for_code_interpreter_call`
- `output_item_done_suppressed_for_file_search_call`

`tool_loop.rs::tests` (downstream ordering + no-duplicate):
- `code_interpreter_completion_events_fire_before_output_item_done`
- `file_search_completion_events_fire_before_output_item_done`

Combined with R6.7's pre-existing `image_generation_completion_events_fire_before_output_item_done` and `web_search_completion_events_fire_before_output_item_done`, the invariant is now locked at both ends (gate-level suppression + tool-loop emission ordering) for all four hosted tool types.

### E2E
Once merged, R6.5's `image_generation` Responses API tests on the OpenAI cloud passthrough lane will stop hitting the ordering failure shown in the PR #1365 CI log.

## Refs
- R6.7 PR #1369 (commit `d7b907b3`) — the original gate this PR broadens.
- R6.5 PR #1365 — CI failure log documenting the `image_generation_call` ordering break.

<details>
<summary>Checklist</summary>

- [x] Gate predicate broadened from `is_function_call_type` to `is_tool_call_item_type` covering all six tool-call item types.
- [x] Six new regression tests (4 gate, 2 downstream ordering) locking the invariant across all four hosted tool types.
- [x] `cargo fmt --all`, `cargo check`, `cargo clippy -- -D warnings`, full `cargo test -p smg --lib` all clean.
- [x] No router-layer changes outside the gate; R6.7's `function_call` suppression behavior unchanged.
- [x] No new `ItemType` variants; slice driven by existing `ItemType` constants.
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate or premature "done" events for hosted tool completions, ensuring correct event ordering and reliable streamed responses.

* **Tests**
  * Added regression tests covering multiple hosted tool completion types to verify ordering and single delivery of completion events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->