### PR TITLE
ci(docker): move image builds to cpu-e5 runner and parallelize make

### DIFF
--- a/.github/workflows/_build-engine-image.yml
+++ b/.github/workflows/_build-engine-image.yml
@@ -57,7 +57,7 @@ on:
 jobs:
   build-and-push:
     if: github.repository == 'lightseekorg/smg'
-    runs-on: ["8-gpu-h200"]
+    runs-on: ["cpu-e5"]
     steps:
       - name: Print inputs to summary
         env:

--- a/.github/workflows/nightly-docker.yml
+++ b/.github/workflows/nightly-docker.yml
@@ -18,7 +18,7 @@ jobs:
   build-and-push:
     name: Build nightly Docker image
     if: github.repository == 'lightseekorg/smg'
-    runs-on: ["8-gpu-h200"]
+    runs-on: ["cpu-e5"]
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -23,7 +23,7 @@ jobs:
   build-and-push:
     name: Build and push Docker image
     if: github.repository == 'lightseekorg/smg'
-    runs-on: ["8-gpu-h200"]
+    runs-on: ["cpu-e5"]
     permissions:
       contents: read
     steps:

--- a/scripts/installation/install-smg.sh
+++ b/scripts/installation/install-smg.sh
@@ -5,6 +5,8 @@ set -e
 # Usage: install-smg.sh [path-to-smg-src]
 # Default path: /tmp/smg-src
 
+export MAKEFLAGS="-j$(nproc)"
+
 SMG_SRC="${1:-/tmp/smg-src}"
 
 apt update -y \


### PR DESCRIPTION
## Description

### Problem

The three Docker-image-build workflows (`_build-engine-image.yml`, `release-docker.yml`, `nightly-docker.yml`) all run on `runs-on: ["8-gpu-h200"]`. Nothing in the build path actually uses the GPU:

- `docker/engine.Dockerfile` only clones sources and runs shell install scripts inside the base image (no `nvcc`, no CUDA-arch compile).
- `scripts/installation/install-smg.sh` does apt → protoc → rustup → `maturin build --release --features vendored-openssl` → pip install — all CPU/IO-bound.
- Other `install-*.sh` scripts are 10–18 lines each and contain no GPU work.

Meanwhile the `vendored-openssl` feature compiles OpenSSL from C source inside a `build.rs`, but the inner `make` runs single-threaded by default — it doesn't inherit cargo's parallelism. On a 64-vCPU host this step wastes ~90 s of wall-clock on one core.

### Solution

1. Switch the three image-build workflows from `["8-gpu-h200"]` to `["cpu-e5"]` (a new OCI `VM.Standard.E5.Flex` self-hosted runner). `nightly-benchmark.yml` is intentionally left alone — those jobs do need GPU.
2. Export `MAKEFLAGS="-j$(nproc)"` at the top of `install-smg.sh` so every downstream `make` invocation (notably `openssl-src`'s build.rs) fans out across all cores.

## Changes

- `.github/workflows/_build-engine-image.yml` — `runs-on` label → `cpu-e5`
- `.github/workflows/release-docker.yml` — `runs-on` label → `cpu-e5`
- `.github/workflows/nightly-docker.yml` — `runs-on` label → `cpu-e5`
- `scripts/installation/install-smg.sh` — export `MAKEFLAGS="-j$(nproc)"` before any build step

## Test Plan

- [ ] Trigger `_build-engine-image` via `workflow_dispatch` with `dry_run: true` for `engine: sglang` and confirm it lands on the new `cpu-e5` runner and completes successfully.
- [ ] Confirm total build wall-clock is comparable to or better than the prior H200 build (expect the vendored-openssl step to drop from ~90 s to <10 s).
- [ ] Trigger `release-docker` (workflow_dispatch, no version bump → push=false path) and confirm the build step succeeds on the new runner.
- [ ] Verify the `cpu-e5` self-hosted runner is registered on the repo and shows `Idle` before kicking off any workflow.

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes (N/A — no Rust changes)
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes (N/A — no Rust changes)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI Docker build workflows switched to a CPU-based runner to use optimized build infrastructure.
  * Installation script now enables parallel compilation by exporting build flags that use available CPU cores, speeding local builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->