### PR TITLE
feat(tokenizer): add DeepSeek V3.2 and V4 chat-template encoders

### DIFF
--- a/crates/tokenizer/src/encoders/deepseek_v32.rs
+++ b/crates/tokenizer/src/encoders/deepseek_v32.rs
@@ -1,0 +1,643 @@
+// Ported from https://huggingface.co/deepseek-ai/DeepSeek-V3.2/blob/main/encoding/encoding_dsv32.py
+//
+// Function and variable names are kept close to the Python source so that
+// future re-syncs against the HuggingFace upstream remain mechanical. The
+// DeepSeek special-token sentinel "｜" is U+FF5C (FULLWIDTH VERTICAL LINE),
+// NOT the ASCII pipe — copy directly from the Python file.
+
+use std::fmt::Write as _;
+
+use serde_json::{json, Value};
+use thiserror::Error;
+
+/// Mode for thinking/reasoning rendering.
+///
+/// Mirrors the Python `thinking_mode` parameter, which only accepts `"chat"`
+/// and `"thinking"`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ThinkingMode {
+    Chat,
+    Thinking,
+}
+
+impl ThinkingMode {
+    fn is_thinking(self) -> bool {
+        matches!(self, ThinkingMode::Thinking)
+    }
+}
+
+/// Parameters for [`encode_messages`].
+///
+/// `context` is intentionally omitted: SMG always renders from scratch, so
+/// the Python default of `context=None` always applies.
+#[derive(Debug, Clone, Copy)]
+pub struct EncodeParams {
+    pub add_default_bos_token: bool,
+    pub drop_thinking: bool,
+}
+
+impl Default for EncodeParams {
+    fn default() -> Self {
+        Self {
+            add_default_bos_token: true,
+            drop_thinking: true,
+        }
+    }
+}
+
+/// Errors raised when a message list is malformed.
+///
+/// Mirrors the Python `DS32EncodingError`.
+#[derive(Debug, Error)]
+pub enum DsEncodingError {
+    #[error("Index {index} out of range for messages list of length {len}")]
+    IndexOutOfRange { index: usize, len: usize },
+
+    #[error("Invalid message for role `{role}`: {msg}")]
+    InvalidMessage { role: String, msg: String },
+
+    #[error("Invalid messages at {index}: {context}")]
+    InvalidToolMessages { index: usize, context: String },
+
+    #[error("No tool calls but found tool output")]
+    NoToolCalls,
+
+    #[error("Unknown role: {0}")]
+    UnknownRole(String),
+
+    #[error("thinking mode: invalid message without reasoning_content/tool_calls after last user message: {0}")]
+    MissingReasoningOrToolCalls(String),
+
+    #[error("Failed to parse tool-call arguments as JSON: {0}")]
+    InvalidToolArgumentsJson(#[source] serde_json::Error),
+}
+
+// ---------------------------------------------------------------------------
+// Special-token constants — copied verbatim from the Python source.
+// ---------------------------------------------------------------------------
+
+pub const BOS_TOKEN: &str = "<｜begin▁of▁sentence｜>";
+pub const EOS_TOKEN: &str = "<｜end▁of▁sentence｜>";
+pub const THINKING_START_TOKEN: &str = "<think>";
+pub const THINKING_END_TOKEN: &str = "</think>";
+pub const DSML_TOKEN: &str = "｜DSML｜";
+
+const USER_PREFIX: &str = "<｜User｜>";
+const ASSISTANT_SUFFIX: &str = "<｜Assistant｜>";
+
+// ---------------------------------------------------------------------------
+// Templates
+// ---------------------------------------------------------------------------
+
+/// Mirrors `TOOLS_SYSTEM_TEMPLATE` from the Python source, including the
+/// blank lines between paragraphs that the upstream template preserves.
+fn render_tools_template(tool_schemas: &str) -> String {
+    let dsml = DSML_TOKEN;
+    let tstart = THINKING_START_TOKEN;
+    let tend = THINKING_END_TOKEN;
+    format!(
+"## Tools
+
+You have access to a set of tools you can use to answer the user's question.
+You can invoke functions by writing a \"<{dsml}function_calls>\" block like the following as part of your reply to the user:
+<{dsml}function_calls>
+<{dsml}invoke name=\"$FUNCTION_NAME\">
+<{dsml}parameter name=\"$PARAMETER_NAME\" string=\"true|false\">$PARAMETER_VALUE</{dsml}parameter>
+...
+</{dsml}invoke>
+<{dsml}invoke name=\"$FUNCTION_NAME2\">
+...
+</{dsml}invoke>
+</{dsml}function_calls>
+
+String and scalar parameters should be specified as is without any escaping or quotes, while lists and objects should use JSON format. The \"string\" attribute should be set to \"true\" for string type parameters and \"false\" for other types (numbers, booleans, arrays, objects).
+
+If the thinking_mode is enabled, then after function results you should strongly consider outputting a thinking block. Here is an example:
+
+<{dsml}function_calls>
+...
+</{dsml}function_calls>
+
+<function_results>
+...
+</function_results>
+
+{tstart}...thinking about results{tend}
+
+Here are the functions available in JSONSchema format:
+<functions>
+{tool_schemas}
+</functions>
+"
+    )
+}
+
+fn response_format_block(schema: &str) -> String {
+    format!(
+        "## Response Format:\n\nYou MUST strictly adhere to the following schema to reply:\n{schema}",
+    )
+}
+
+fn user_msg(content: &str) -> String {
+    format!("{USER_PREFIX}{content}{ASSISTANT_SUFFIX}")
+}
+
+// ---------------------------------------------------------------------------
+// JSON helpers
+// ---------------------------------------------------------------------------
+
+/// Mirrors the Python `to_json` helper. serde_json always emits valid UTF-8
+/// without escaping, so the `ensure_ascii` fallback in the Python version is
+/// effectively a no-op here.
+fn to_json(value: &Value) -> String {
+    serde_json::to_string(value).unwrap_or_else(|_| "null".to_string())
+}
+
+/// `[tool["function"] for tool in tools]`
+fn tools_from_openai_format(tools: &[Value]) -> Vec<Value> {
+    tools
+        .iter()
+        .filter_map(|t| t.get("function").cloned())
+        .collect()
+}
+
+/// `[{ "name": tc["function"]["name"], "arguments": tc["function"]["arguments"] } for tc in tool_calls]`
+fn tool_calls_from_openai_format(tool_calls: &[Value]) -> Vec<Value> {
+    tool_calls
+        .iter()
+        .filter_map(|tc| {
+            let f = tc.get("function")?;
+            Some(json!({
+                "name": f.get("name").cloned().unwrap_or(Value::Null),
+                "arguments": f.get("arguments").cloned().unwrap_or(Value::Null),
+            }))
+        })
+        .collect()
+}
+
+/// Mirrors `encode_arguments_to_dsml`. `tool_call["arguments"]` is a JSON
+/// *string* in OpenAI schema; the Python code does `json.loads(...)` and
+/// iterates over the resulting dict.
+fn encode_arguments_to_dsml(tool_call: &Value) -> Result<String, DsEncodingError> {
+    let arguments_str = tool_call
+        .get("arguments")
+        .and_then(|v| v.as_str())
+        .unwrap_or("{}");
+
+    let arguments: Value =
+        serde_json::from_str(arguments_str).map_err(DsEncodingError::InvalidToolArgumentsJson)?;
+
+    let obj = match arguments.as_object() {
+        Some(obj) => obj,
+        // Non-object payload — render nothing, matching Python behaviour
+        // (`for k, v in arguments.items()` would raise; we tolerate it).
+        None => return Ok(String::new()),
+    };
+
+    let mut parts = Vec::with_capacity(obj.len());
+    for (k, v) in obj {
+        let (is_str, value_str) = match v {
+            Value::String(s) => ("true", s.clone()),
+            other => ("false", to_json(other)),
+        };
+        parts.push(format!(
+            "<{DSML_TOKEN}parameter name=\"{k}\" string=\"{is_str}\">{value_str}</{DSML_TOKEN}parameter>",
+        ));
+    }
+    Ok(parts.join("\n"))
+}
+
+fn render_tools(tools: &[Value]) -> String {
+    let schemas: Vec<String> = tools.iter().map(to_json).collect();
+    render_tools_template(&schemas.join("\n"))
+}
+
+/// Mirrors `find_last_user_index`: returns `None` if no user/developer
+/// message exists (Python returns -1).
+fn find_last_user_index(messages: &[Value]) -> Option<usize> {
+    for idx in (0..messages.len()).rev() {
+        let role = messages[idx].get("role").and_then(|v| v.as_str());
+        if matches!(role, Some("user") | Some("developer")) {
+            return Some(idx);
+        }
+    }
+    None
+}
+
+/// Returns `true` when `index >= last_user_idx` in the Python sense, treating
+/// the "no user message" case (-1) as: every non-negative index satisfies it.
+fn at_or_after_last_user(index: usize, last_user_idx: Option<usize>) -> bool {
+    match last_user_idx {
+        Some(idx) => index >= idx,
+        None => true,
+    }
+}
+
+/// Returns `true` when `index > last_user_idx` in the Python sense.
+fn after_last_user(index: usize, last_user_idx: Option<usize>) -> bool {
+    match last_user_idx {
+        Some(idx) => index > idx,
+        None => true,
+    }
+}
+
+/// Returns `true` when `index == last_user_idx`.
+fn equals_last_user(index: usize, last_user_idx: Option<usize>) -> bool {
+    last_user_idx == Some(index)
+}
+
+// ---------------------------------------------------------------------------
+// render_message — direct port of the Python function with the same name.
+// ---------------------------------------------------------------------------
+
+#[expect(
+    clippy::too_many_lines,
+    reason = "mirrors the Python render_message function 1:1 for sync-ability"
+)]
+fn render_message(
+    index: usize,
+    messages: &[Value],
+    thinking_mode: ThinkingMode,
+) -> Result<String, DsEncodingError> {
+    if index >= messages.len() {
+        return Err(DsEncodingError::IndexOutOfRange {
+            index,
+            len: messages.len(),
+        });
+    }
+
+    let mut prompt = String::new();
+    let msg = &messages[index];
+    let last_user_idx = find_last_user_index(messages);
+
+    let role = msg.get("role").and_then(|v| v.as_str()).unwrap_or("");
+    let content = msg.get("content").and_then(|v| v.as_str()).unwrap_or("");
+    let tools_raw = msg.get("tools").and_then(|v| v.as_array());
+    let response_format = msg.get("response_format");
+    let tool_calls_raw = msg.get("tool_calls").and_then(|v| v.as_array());
+    let reasoning_content = msg
+        .get("reasoning_content")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
+    let tools_owned = tools_raw.map(|t| tools_from_openai_format(t));
+    let tools = tools_owned.as_deref();
+
+    let tool_calls_owned = tool_calls_raw.map(|tc| tool_calls_from_openai_format(tc));
+    let tool_calls = tool_calls_owned.as_deref();
+
+    match role {
+        "system" => {
+            // system_msg_template is "{content}"
+            prompt.push_str(content);
+            if let Some(tools) = tools.filter(|t| !t.is_empty()) {
+                prompt.push_str("\n\n");
+                prompt.push_str(&render_tools(tools));
+            }
+            if let Some(rf) = response_format {
+                prompt.push_str("\n\n");
+                prompt.push_str(&response_format_block(&to_json(rf)));
+            }
+        }
+        "developer" => {
+            if content.is_empty() {
+                return Err(DsEncodingError::InvalidMessage {
+                    role: role.to_string(),
+                    msg: msg.to_string(),
+                });
+            }
+            let mut content_developer = String::new();
+            if let Some(tools) = tools.filter(|t| !t.is_empty()) {
+                content_developer.push_str("\n\n");
+                content_developer.push_str(&render_tools(tools));
+            }
+            if let Some(rf) = response_format {
+                content_developer.push_str("\n\n");
+                content_developer.push_str(&response_format_block(&to_json(rf)));
+            }
+            let _ = write!(content_developer, "\n\n# The user's message is: {content}");
+
+            prompt.push_str(&user_msg(&content_developer));
+
+            if equals_last_user(index, last_user_idx) && thinking_mode.is_thinking() {
+                prompt.push_str(THINKING_START_TOKEN);
+            } else {
+                prompt.push_str(THINKING_END_TOKEN);
+            }
+        }
+        "user" => {
+            prompt.push_str(&user_msg(content));
+            if equals_last_user(index, last_user_idx) && thinking_mode.is_thinking() {
+                prompt.push_str(THINKING_START_TOKEN);
+            } else {
+                prompt.push_str(THINKING_END_TOKEN);
+            }
+        }
+        "tool" => {
+            // Walk back over consecutive tool messages to find the originating
+            // assistant turn — same logic as Python.
+            let mut prev_assistant_idx: isize = index as isize - 1;
+            while prev_assistant_idx >= 0
+                && messages[prev_assistant_idx as usize]
+                    .get("role")
+                    .and_then(|v| v.as_str())
+                    == Some("tool")
+            {
+                prev_assistant_idx -= 1;
+            }
+
+            let assistant_role = if prev_assistant_idx >= 0 {
+                messages[prev_assistant_idx as usize]
+                    .get("role")
+                    .and_then(|v| v.as_str())
+            } else {
+                None
+            };
+
+            let valid_anchor =
+                index == 0 || (prev_assistant_idx >= 0 && assistant_role == Some("assistant"));
+            if !valid_anchor {
+                let anchor_idx = prev_assistant_idx.max(0) as usize;
+                return Err(DsEncodingError::InvalidToolMessages {
+                    index,
+                    context: messages[anchor_idx].to_string(),
+                });
+            }
+
+            let assistant_tool_calls = if prev_assistant_idx >= 0 {
+                messages[prev_assistant_idx as usize]
+                    .get("tool_calls")
+                    .and_then(|v| v.as_array())
+                    .map(|a| a.len())
+                    .unwrap_or(0)
+            } else {
+                0
+            };
+
+            let tool_call_order = (index as isize - prev_assistant_idx) as usize;
+            if assistant_tool_calls == 0 || assistant_tool_calls < tool_call_order {
+                return Err(DsEncodingError::NoToolCalls);
+            }
+
+            if tool_call_order == 1 {
+                prompt.push_str("\n\n<function_results>");
+            }
+
+            // tool_output_template = "\n<result>{content}</result>"
+            let _ = write!(prompt, "\n<result>{content}</result>");
+
+            if tool_call_order == assistant_tool_calls {
+                prompt.push_str("\n</function_results>");
+
+                if at_or_after_last_user(index, last_user_idx) && thinking_mode.is_thinking() {
+                    prompt.push_str("\n\n");
+                    prompt.push_str(THINKING_START_TOKEN);
+                } else {
+                    prompt.push_str("\n\n");
+                    prompt.push_str(THINKING_END_TOKEN);
+                }
+            }
+        }
+        "assistant" => {
+            let mut thinking_part = String::new();
+
+            let mut tool_calls_content = String::new();
+            if let Some(tcs) = tool_calls.filter(|t| !t.is_empty()) {
+                let mut rendered = Vec::with_capacity(tcs.len());
+                for tc in tcs {
+                    let name = tc.get("name").and_then(|v| v.as_str()).unwrap_or("");
+                    let args = encode_arguments_to_dsml(tc)?;
+                    rendered.push(format!(
+                        "<{DSML_TOKEN}invoke name=\"{name}\">\n{args}\n</{DSML_TOKEN}invoke>",
+                    ));
+                }
+                let joined = rendered.join("\n");
+                let _ = write!(
+                    tool_calls_content,
+                    "\n\n<{DSML_TOKEN}function_calls>\n{joined}\n</{DSML_TOKEN}function_calls>"
+                );
+            }
+
+            let summary_content = content;
+
+            if thinking_mode.is_thinking() && after_last_user(index, last_user_idx) {
+                let has_reasoning = !reasoning_content.is_empty();
+                let has_tool_calls = tool_calls.is_some_and(|t| !t.is_empty());
+                if !has_reasoning && !has_tool_calls {
+                    return Err(DsEncodingError::MissingReasoningOrToolCalls(
+                        msg.to_string(),
+                    ));
+                }
+                thinking_part.push_str(reasoning_content);
+                thinking_part.push_str(THINKING_END_TOKEN);
+            }
+
+            // assistant_msg_template = "{reasoning}{content}{tool_calls}<｜end▁of▁sentence｜>"
+            prompt.push_str(&thinking_part);
+            prompt.push_str(summary_content);
+            prompt.push_str(&tool_calls_content);
+            prompt.push_str(EOS_TOKEN);
+        }
+        other => return Err(DsEncodingError::UnknownRole(other.to_string())),
+    }
+
+    Ok(prompt)
+}
+
+// ---------------------------------------------------------------------------
+// drop_thinking_messages
+// ---------------------------------------------------------------------------
+
+fn drop_thinking_messages(messages: &[Value]) -> Vec<Value> {
+    let last_user_idx = find_last_user_index(messages);
+    let mut out: Vec<Value> = Vec::with_capacity(messages.len());
+
+    for (idx, msg) in messages.iter().enumerate() {
+        let role = msg.get("role").and_then(|v| v.as_str()).unwrap_or("");
+        let always_keep =
+            matches!(role, "user" | "system" | "tool") || at_or_after_last_user(idx, last_user_idx);
+
+        if always_keep {
+            out.push(msg.clone());
+            continue;
+        }
+
+        if role == "assistant" {
+            let mut cloned = msg.clone();
+            if let Some(obj) = cloned.as_object_mut() {
+                obj.remove("reasoning_content");
+            }
+            out.push(cloned);
+        }
+        // Other roles before last_user_idx are dropped, matching Python.
+    }
+
+    out
+}
+
+// ---------------------------------------------------------------------------
+// encode_messages — public entry point
+// ---------------------------------------------------------------------------
+
+/// Encode a list of OpenAI-style messages into a DeepSeek V3.2 prompt string.
+///
+/// The signature mirrors the Python `encode_messages` function;
+/// `context` is omitted because SMG always renders from scratch.
+#[expect(
+    clippy::trivially_copy_pass_by_ref,
+    reason = "public API mirrors the documented Rust signature with a borrow"
+)]
+pub fn encode_messages(
+    messages: &[Value],
+    thinking_mode: ThinkingMode,
+    params: &EncodeParams,
+) -> Result<String, DsEncodingError> {
+    let mut full_messages: Vec<Value> = messages.to_vec();
+
+    let mut prompt = if params.add_default_bos_token {
+        BOS_TOKEN.to_string()
+    } else {
+        String::new()
+    };
+
+    if thinking_mode.is_thinking() && params.drop_thinking {
+        full_messages = drop_thinking_messages(&full_messages);
+    }
+
+    for idx in 0..messages.len() {
+        prompt.push_str(&render_message(idx, &full_messages, thinking_mode)?);
+    }
+
+    Ok(prompt)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    fn user(text: &str) -> Value {
+        json!({ "role": "user", "content": text })
+    }
+
+    fn assistant_with_reasoning(reasoning: &str, content: &str) -> Value {
+        json!({
+            "role": "assistant",
+            "reasoning_content": reasoning,
+            "content": content,
+        })
+    }
+
+    #[test]
+    fn one_turn_user_chat_mode_closes_think() {
+        let msgs = [user("Hello")];
+        let out = encode_messages(&msgs, ThinkingMode::Chat, &EncodeParams::default()).unwrap();
+
+        let expected =
+            format!("{BOS_TOKEN}{USER_PREFIX}Hello{ASSISTANT_SUFFIX}{THINKING_END_TOKEN}",);
+        assert_eq!(out, expected);
+    }
+
+    #[test]
+    fn one_turn_user_thinking_mode_opens_think() {
+        let msgs = [user("Hello")];
+        let out = encode_messages(&msgs, ThinkingMode::Thinking, &EncodeParams::default()).unwrap();
+
+        let expected =
+            format!("{BOS_TOKEN}{USER_PREFIX}Hello{ASSISTANT_SUFFIX}{THINKING_START_TOKEN}",);
+        assert_eq!(out, expected);
+    }
+
+    #[test]
+    fn drop_thinking_strips_earlier_reasoning() {
+        // Three-turn conversation: the assistant turn at index 1 carries
+        // reasoning_content. The Python encoder only emits reasoning on
+        // assistant messages strictly *after* the last user turn, so an
+        // earlier assistant turn never leaks reasoning regardless of the
+        // drop_thinking flag. The flag controls whether the field is
+        // *retained on the message dict* — verify the rendered prompt is
+        // unchanged in either direction.
+        let msgs = [
+            user("Q1"),
+            assistant_with_reasoning("private thought", "A1"),
+            user("Q2"),
+        ];
+
+        let out_drop =
+            encode_messages(&msgs, ThinkingMode::Thinking, &EncodeParams::default()).unwrap();
+        assert!(!out_drop.contains("private thought"));
+
+        let params = EncodeParams {
+            drop_thinking: false,
+            ..EncodeParams::default()
+        };
+        let out_keep = encode_messages(&msgs, ThinkingMode::Thinking, &params).unwrap();
+        assert!(!out_keep.contains("private thought"));
+
+        // Sanity: the most-recent assistant turn (after the last user) DOES
+        // emit reasoning_content, proving the dropper acted only on the
+        // earlier turn.
+        let msgs2 = [user("Q1"), assistant_with_reasoning("recent thought", "A1")];
+        let out_recent =
+            encode_messages(&msgs2, ThinkingMode::Thinking, &EncodeParams::default()).unwrap();
+        assert!(out_recent.contains("recent thought"));
+    }
+
+    #[test]
+    fn assistant_tool_call_renders_dsml() {
+        let msgs = [
+            user("call my tool"),
+            json!({
+                "role": "assistant",
+                "reasoning_content": "thinking about tool",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "search",
+                            "arguments": "{\"query\": \"deepseek\", \"limit\": 5}"
+                        }
+                    }
+                ]
+            }),
+        ];
+
+        let out = encode_messages(&msgs, ThinkingMode::Thinking, &EncodeParams::default()).unwrap();
+
+        assert!(out.contains(&format!("<{DSML_TOKEN}function_calls>")));
+        assert!(out.contains(&format!("<{DSML_TOKEN}invoke name=\"search\">")));
+        assert!(out.contains(&format!(
+            "<{DSML_TOKEN}parameter name=\"query\" string=\"true\">deepseek</{DSML_TOKEN}parameter>"
+        )));
+        assert!(out.contains(&format!(
+            "<{DSML_TOKEN}parameter name=\"limit\" string=\"false\">5</{DSML_TOKEN}parameter>"
+        )));
+        assert!(out.contains(&format!("</{DSML_TOKEN}function_calls>")));
+        assert!(out.ends_with(EOS_TOKEN));
+    }
+
+    #[test]
+    fn unknown_role_errors() {
+        let msgs = [json!({ "role": "moderator", "content": "hi" })];
+        let err = encode_messages(&msgs, ThinkingMode::Chat, &EncodeParams::default()).unwrap_err();
+        assert!(matches!(err, DsEncodingError::UnknownRole(ref r) if r == "moderator"));
+    }
+
+    #[test]
+    fn skip_bos_when_disabled() {
+        let msgs = [user("Hi")];
+        let params = EncodeParams {
+            add_default_bos_token: false,
+            ..EncodeParams::default()
+        };
+        let out = encode_messages(&msgs, ThinkingMode::Chat, &params).unwrap();
+        assert!(!out.starts_with(BOS_TOKEN));
+        assert!(out.starts_with(USER_PREFIX));
+    }
+}

--- a/crates/tokenizer/src/encoders/deepseek_v32.rs
+++ b/crates/tokenizer/src/encoders/deepseek_v32.rs
@@ -1,9 +1,4 @@
 // Ported from https://huggingface.co/deepseek-ai/DeepSeek-V3.2/blob/main/encoding/encoding_dsv32.py
-//
-// Function and variable names are kept close to the Python source so that
-// future re-syncs against the HuggingFace upstream remain mechanical. The
-// DeepSeek special-token sentinel "｜" is U+FF5C (FULLWIDTH VERTICAL LINE),
-// NOT the ASCII pipe — copy directly from the Python file.
 
 use std::fmt::Write as _;
 

--- a/crates/tokenizer/src/encoders/deepseek_v4.rs
+++ b/crates/tokenizer/src/encoders/deepseek_v4.rs
@@ -1,0 +1,796 @@
+// Ported from https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash/blob/main/encoding/encoding_dsv4.py
+//
+// Function and variable names are kept close to the Python source so future
+// re-syncs against the HuggingFace upstream remain mechanical. The DeepSeek
+// special-token sentinel "｜" is U+FF5C (FULLWIDTH VERTICAL LINE), NOT the
+// ASCII pipe — copy directly from the Python file.
+
+use std::fmt::Write as _;
+
+use serde_json::{json, Value};
+use thiserror::Error;
+
+// Reuse the public ThinkingMode enum from the V3.2 module to keep the
+// "thinking" / "chat" mode invariant identical across DeepSeek versions.
+pub use super::deepseek_v32::ThinkingMode;
+
+/// Reasoning effort for the V4 prompt prefix.
+///
+/// Mirrors the Python `reasoning_effort` parameter, which only accepts
+/// `None`, `"high"`, or `"max"`. Only `Max` actually emits a prefix today;
+/// `High` is accepted for parity with the Python signature.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReasoningEffort {
+    High,
+    Max,
+}
+
+/// Parameters for [`encode_messages`].
+///
+/// `context` is intentionally omitted: SMG always renders from scratch, so
+/// the Python default of `context=None` always applies.
+#[derive(Debug, Clone, Copy)]
+pub struct EncodeParams {
+    pub add_default_bos_token: bool,
+    pub drop_thinking: bool,
+    pub reasoning_effort: Option<ReasoningEffort>,
+}
+impl Default for EncodeParams {
+    fn default() -> Self {
+        Self {
+            add_default_bos_token: true,
+            drop_thinking: true,
+            reasoning_effort: None,
+        }
+    }
+}
+
+/// Errors raised when a message list is malformed.
+///
+/// V4-local error type. The variants overlap with V3.2 but are kept
+/// independent so each encoder file is a standalone translation of its
+/// Python source.
+#[derive(Debug, Error)]
+pub enum DsEncodingError {
+    #[error("Index {index} out of range for messages list of length {len}")]
+    IndexOutOfRange { index: usize, len: usize },
+    #[error("Invalid message for role `{role}`: {msg}")]
+    InvalidMessage { role: String, msg: String },
+    #[error("Unknown role: {0}")]
+    UnknownRole(String),
+    #[error("DeepSeek V4 merges tool messages into user; preprocess via merge_tool_messages first (got tool message at index {0})")]
+    UnmergedToolRole(usize),
+    #[error(
+        "Invalid task `{0}`. Valid tasks are: action, query, authority, domain, title, read_url"
+    )]
+    InvalidTask(String),
+}
+
+// ---------------------------------------------------------------------------
+// Special-token constants — copied verbatim from the Python source.
+// ---------------------------------------------------------------------------
+pub const BOS_TOKEN: &str = "<｜begin▁of▁sentence｜>";
+pub const EOS_TOKEN: &str = "<｜end▁of▁sentence｜>";
+pub const THINKING_START_TOKEN: &str = "<think>";
+pub const THINKING_END_TOKEN: &str = "</think>";
+pub const DSML_TOKEN: &str = "｜DSML｜";
+const USER_SP_TOKEN: &str = "<｜User｜>";
+const ASSISTANT_SP_TOKEN: &str = "<｜Assistant｜>";
+const LATEST_REMINDER_SP_TOKEN: &str = "<｜latest_reminder｜>";
+const TOOL_CALLS_BLOCK_NAME: &str = "tool_calls";
+// Quick-instruction "task" tokens (`<｜action｜>`, `<｜query｜>`, etc.)
+const TASK_ACTION: &str = "<｜action｜>";
+const TASK_QUERY: &str = "<｜query｜>";
+const TASK_AUTHORITY: &str = "<｜authority｜>";
+const TASK_DOMAIN: &str = "<｜domain｜>";
+const TASK_TITLE: &str = "<｜title｜>";
+const TASK_READ_URL: &str = "<｜read_url｜>";
+fn task_sp_token(task: &str) -> Option<&'static str> {
+    match task {
+        "action" => Some(TASK_ACTION),
+        "query" => Some(TASK_QUERY),
+        "authority" => Some(TASK_AUTHORITY),
+        "domain" => Some(TASK_DOMAIN),
+        "title" => Some(TASK_TITLE),
+        "read_url" => Some(TASK_READ_URL),
+        _ => None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Templates
+// ---------------------------------------------------------------------------
+const REASONING_EFFORT_MAX: &str = "Reasoning Effort: Absolute maximum with no shortcuts permitted.\nYou MUST be very thorough in your thinking and comprehensively decompose the problem to resolve the root cause, rigorously stress-testing your logic against all potential paths, edge cases, and adversarial scenarios.\nExplicitly write out your entire deliberation process, documenting every intermediate step, considered alternative, and rejected hypothesis to ensure absolutely no assumption is left unchecked.\n\n";
+
+/// Mirrors V4's `TOOLS_TEMPLATE`. The block name is `tool_calls` (not
+/// `function_calls` like V3.2) and the wording is updated.
+fn render_tools_template(tool_schemas: &str) -> String {
+    let dsml = DSML_TOKEN;
+    let tcb = TOOL_CALLS_BLOCK_NAME;
+    let tstart = THINKING_START_TOKEN;
+    let tend = THINKING_END_TOKEN;
+    format!(
+"## Tools
+
+You have access to a set of tools to help answer the user's question. You can invoke tools by writing a \"<{dsml}{tcb}>\" block like the following:
+
+<{dsml}{tcb}>
+<{dsml}invoke name=\"$TOOL_NAME\">
+<{dsml}parameter name=\"$PARAMETER_NAME\" string=\"true|false\">$PARAMETER_VALUE</{dsml}parameter>
+...
+</{dsml}invoke>
+<{dsml}invoke name=\"$TOOL_NAME2\">
+...
+</{dsml}invoke>
+</{dsml}{tcb}>
+
+String parameters should be specified as is and set `string=\"true\"`. For all other types (numbers, booleans, arrays, objects), pass the value in JSON format and set `string=\"false\"`.
+
+If thinking_mode is enabled (triggered by {tstart}), you MUST output your complete reasoning inside {tstart}...{tend} BEFORE any tool calls or final response.
+
+Otherwise, output directly after {tend} with tool calls or final response.
+
+### Available Tool Schemas
+
+{tool_schemas}
+
+You MUST strictly follow the above defined tool name and parameter schemas to invoke tool calls.
+"
+    )
+}
+
+// ---------------------------------------------------------------------------
+// JSON helpers (mirror V3.2)
+// ---------------------------------------------------------------------------
+fn to_json(value: &Value) -> String {
+    serde_json::to_string(value).unwrap_or_else(|_| "null".to_string())
+}
+fn tools_from_openai_format(tools: &[Value]) -> Vec<Value> {
+    tools
+        .iter()
+        .filter_map(|t| t.get("function").cloned())
+        .collect()
+}
+fn tool_calls_from_openai_format(tool_calls: &[Value]) -> Vec<Value> {
+    tool_calls
+        .iter()
+        .filter_map(|tc| {
+            let f = tc.get("function")?;
+            Some(json!({
+                "name": f.get("name").cloned().unwrap_or(Value::Null),
+                "arguments": f.get("arguments").cloned().unwrap_or(Value::Null),
+            }))
+        })
+        .collect()
+}
+
+/// V4 differs from V3.2: when `arguments` fails to JSON-parse, the upstream
+/// wraps the raw string in `{"arguments": <raw>}` instead of erroring.
+fn encode_arguments_to_dsml(tool_call: &Value) -> String {
+    let arguments_str = tool_call
+        .get("arguments")
+        .and_then(|v| v.as_str())
+        .unwrap_or("{}");
+    let arguments: Value = match serde_json::from_str(arguments_str) {
+        Ok(v) => v,
+        Err(_) => json!({ "arguments": arguments_str }),
+    };
+    let obj = match arguments.as_object() {
+        Some(obj) => obj,
+        None => return String::new(),
+    };
+    let mut parts = Vec::with_capacity(obj.len());
+    for (k, v) in obj {
+        let (is_str, value_str) = match v {
+            Value::String(s) => ("true", s.clone()),
+            other => ("false", to_json(other)),
+        };
+        parts.push(format!(
+            "<{DSML_TOKEN}parameter name=\"{k}\" string=\"{is_str}\">{value_str}</{DSML_TOKEN}parameter>",
+        ));
+    }
+    parts.join("\n")
+}
+
+fn render_tools(tools: &[Value]) -> String {
+    let schemas: Vec<String> = tools.iter().map(to_json).collect();
+    render_tools_template(&schemas.join("\n"))
+}
+fn find_last_user_index(messages: &[Value]) -> Option<usize> {
+    for idx in (0..messages.len()).rev() {
+        let role = messages[idx].get("role").and_then(|v| v.as_str());
+        if matches!(role, Some("user") | Some("developer")) {
+            return Some(idx);
+        }
+    }
+    None
+}
+fn at_or_after_last_user(index: usize, last_user_idx: Option<usize>) -> bool {
+    match last_user_idx {
+        Some(idx) => index >= idx,
+        None => true,
+    }
+}
+fn after_last_user(index: usize, last_user_idx: Option<usize>) -> bool {
+    match last_user_idx {
+        Some(idx) => index > idx,
+        None => true,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// render_message — direct port of the V4 Python function with the same name.
+// ---------------------------------------------------------------------------
+#[expect(
+    clippy::too_many_lines,
+    reason = "mirrors the Python render_message function 1:1 for sync-ability"
+)]
+fn render_message(
+    index: usize,
+    messages: &[Value],
+    thinking_mode: ThinkingMode,
+    drop_thinking: bool,
+    reasoning_effort: Option<ReasoningEffort>,
+) -> Result<String, DsEncodingError> {
+    if index >= messages.len() {
+        return Err(DsEncodingError::IndexOutOfRange {
+            index,
+            len: messages.len(),
+        });
+    }
+    let mut prompt = String::new();
+    let msg = &messages[index];
+    let last_user_idx = find_last_user_index(messages);
+
+    let role = msg.get("role").and_then(|v| v.as_str()).unwrap_or("");
+    let content = msg.get("content").and_then(|v| v.as_str()).unwrap_or("");
+    let tools_raw = msg.get("tools").and_then(|v| v.as_array());
+    let response_format = msg.get("response_format");
+    let tool_calls_raw = msg.get("tool_calls").and_then(|v| v.as_array());
+    let reasoning_content = msg
+        .get("reasoning_content")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let wo_eos = msg.get("wo_eos").and_then(|v| v.as_bool()).unwrap_or(false);
+    let tools_owned = tools_raw.map(|t| tools_from_openai_format(t));
+    let tools = tools_owned.as_deref();
+    let tool_calls_owned = tool_calls_raw.map(|tc| tool_calls_from_openai_format(tc));
+    let tool_calls = tool_calls_owned.as_deref();
+
+    // Reasoning effort prefix (only at index 0 in thinking mode with max effort)
+    if index == 0
+        && thinking_mode == ThinkingMode::Thinking
+        && reasoning_effort == Some(ReasoningEffort::Max)
+    {
+        prompt.push_str(REASONING_EFFORT_MAX);
+    }
+
+    match role {
+        "system" => {
+            prompt.push_str(content);
+            if let Some(tools) = tools.filter(|t| !t.is_empty()) {
+                prompt.push_str("\n\n");
+                prompt.push_str(&render_tools(tools));
+            }
+            if let Some(rf) = response_format {
+                prompt.push_str("\n\n");
+                prompt.push_str(&format!(
+                    "## Response Format:\n\nYou MUST strictly adhere to the following schema to reply:\n{}",
+                    to_json(rf)
+                ));
+            }
+        }
+
+        "developer" => {
+            if content.is_empty() {
+                return Err(DsEncodingError::InvalidMessage {
+                    role: role.to_string(),
+                    msg: msg.to_string(),
+                });
+            }
+            let mut content_developer = String::new();
+            content_developer.push_str(USER_SP_TOKEN);
+            content_developer.push_str(content);
+            if let Some(tools) = tools.filter(|t| !t.is_empty()) {
+                content_developer.push_str("\n\n");
+                content_developer.push_str(&render_tools(tools));
+            }
+            if let Some(rf) = response_format {
+                content_developer.push_str("\n\n");
+                let _ = write!(
+                    content_developer,
+                    "## Response Format:\n\nYou MUST strictly adhere to the following schema to reply:\n{}",
+                    to_json(rf)
+                );
+            }
+            prompt.push_str(&content_developer);
+        }
+
+        "user" => {
+            prompt.push_str(USER_SP_TOKEN);
+            // Handle content blocks (tool results mixed with text)
+            if let Some(content_blocks) = msg.get("content_blocks").and_then(|v| v.as_array()) {
+                let mut parts: Vec<String> = Vec::with_capacity(content_blocks.len());
+                for block in content_blocks {
+                    let block_type = block.get("type").and_then(|v| v.as_str()).unwrap_or("");
+                    match block_type {
+                        "text" => {
+                            let text = block.get("text").and_then(|v| v.as_str()).unwrap_or("");
+                            parts.push(text.to_string());
+                        }
+                        "tool_result" => {
+                            let tc = block.get("content");
+                            let tool_content = match tc {
+                                Some(Value::Array(items)) => {
+                                    let mut text_parts: Vec<String> =
+                                        Vec::with_capacity(items.len());
+                                    for b in items {
+                                        let bt =
+                                            b.get("type").and_then(|v| v.as_str()).unwrap_or("");
+                                        if bt == "text" {
+                                            text_parts.push(
+                                                b.get("text")
+                                                    .and_then(|v| v.as_str())
+                                                    .unwrap_or("")
+                                                    .to_string(),
+                                            );
+                                        } else {
+                                            text_parts.push(format!("[Unsupported {bt}]"));
+                                        }
+                                    }
+                                    text_parts.join("\n\n")
+                                }
+                                Some(Value::String(s)) => s.clone(),
+                                Some(other) => to_json(other),
+                                None => String::new(),
+                            };
+                            parts.push(format!("<tool_result>{tool_content}</tool_result>"));
+                        }
+                        other => parts.push(format!("[Unsupported {other}]")),
+                    }
+                }
+                prompt.push_str(&parts.join("\n\n"));
+            } else {
+                prompt.push_str(content);
+            }
+        }
+
+        "latest_reminder" => {
+            prompt.push_str(LATEST_REMINDER_SP_TOKEN);
+            prompt.push_str(content);
+        }
+        "tool" => {
+            return Err(DsEncodingError::UnmergedToolRole(index));
+        }
+
+        "assistant" => {
+            let mut thinking_part = String::new();
+            let mut tc_content = String::new();
+            if let Some(tcs) = tool_calls.filter(|t| !t.is_empty()) {
+                let mut tc_list = Vec::with_capacity(tcs.len());
+                for tc in tcs {
+                    let name = tc.get("name").and_then(|v| v.as_str()).unwrap_or("");
+                    let args = encode_arguments_to_dsml(tc);
+                    tc_list.push(format!(
+                        "<{DSML_TOKEN}invoke name=\"{name}\">\n{args}\n</{DSML_TOKEN}invoke>"
+                    ));
+                }
+                let joined = tc_list.join("\n");
+                let _ = write!(
+                    tc_content,
+                    "\n\n<{DSML_TOKEN}{TOOL_CALLS_BLOCK_NAME}>\n{joined}\n</{DSML_TOKEN}{TOOL_CALLS_BLOCK_NAME}>"
+                );
+            }
+            // prev_has_task: if previous message had a task, this is a task
+            // output (no thinking).
+            let prev_has_task = if index >= 1 {
+                messages[index - 1].get("task").is_some()
+                    && !messages[index - 1]
+                        .get("task")
+                        .map(Value::is_null)
+                        .unwrap_or(true)
+            } else {
+                false
+            };
+            if thinking_mode == ThinkingMode::Thinking && !prev_has_task {
+                let emit = !drop_thinking || after_last_user(index, last_user_idx);
+                if emit {
+                    thinking_part.push_str(reasoning_content);
+                    thinking_part.push_str(THINKING_END_TOKEN);
+                }
+            }
+            prompt.push_str(&thinking_part);
+            prompt.push_str(content);
+            prompt.push_str(&tc_content);
+            if !wo_eos {
+                prompt.push_str(EOS_TOKEN);
+            }
+        }
+        other => return Err(DsEncodingError::UnknownRole(other.to_string())),
+    }
+
+    // Append transition tokens based on what follows.
+    if let Some(next) = messages.get(index + 1) {
+        let next_role = next.get("role").and_then(|v| v.as_str()).unwrap_or("");
+        if !matches!(next_role, "assistant" | "latest_reminder") {
+            return Ok(prompt);
+        }
+    }
+
+    let task = messages[index]
+        .get("task")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty());
+    if let Some(task) = task {
+        let sp_token =
+            task_sp_token(task).ok_or_else(|| DsEncodingError::InvalidTask(task.to_string()))?;
+        if task == "action" {
+            // Action task: append Assistant + thinking token + action sp token.
+            prompt.push_str(ASSISTANT_SP_TOKEN);
+            prompt.push_str(if thinking_mode == ThinkingMode::Thinking {
+                THINKING_START_TOKEN
+            } else {
+                THINKING_END_TOKEN
+            });
+            prompt.push_str(sp_token);
+        } else {
+            // Non-action tasks: append task sp token directly after the message.
+            prompt.push_str(sp_token);
+        }
+    } else if matches!(role, "user" | "developer") {
+        // Normal generation: append Assistant + thinking token.
+        prompt.push_str(ASSISTANT_SP_TOKEN);
+        let opens_thinking = thinking_mode == ThinkingMode::Thinking
+            && (!drop_thinking || at_or_after_last_user(index, last_user_idx));
+        if opens_thinking {
+            prompt.push_str(THINKING_START_TOKEN);
+        } else {
+            prompt.push_str(THINKING_END_TOKEN);
+        }
+    }
+    Ok(prompt)
+}
+
+// ---------------------------------------------------------------------------
+// Preprocessing: merge tool messages and sort tool results.
+// ---------------------------------------------------------------------------
+fn merge_tool_messages(messages: &[Value]) -> Vec<Value> {
+    let mut merged: Vec<Value> = Vec::with_capacity(messages.len());
+    for msg in messages {
+        let msg = msg.clone();
+        let role = msg.get("role").and_then(|v| v.as_str()).unwrap_or("");
+        if role == "tool" {
+            let tool_block = json!({
+                "type": "tool_result",
+                "tool_use_id": msg.get("tool_call_id").cloned().unwrap_or(Value::String(String::new())),
+                "content": msg.get("content").cloned().unwrap_or(Value::String(String::new())),
+            });
+            // Append to a previous user message that already has content_blocks.
+            let appended = if let Some(prev) = merged.last_mut() {
+                let prev_role = prev.get("role").and_then(|v| v.as_str()).unwrap_or("");
+                if prev_role == "user" && prev.get("content_blocks").is_some() {
+                    if let Some(blocks) = prev
+                        .get_mut("content_blocks")
+                        .and_then(|v| v.as_array_mut())
+                    {
+                        blocks.push(tool_block.clone());
+                        true
+                    } else {
+                        false
+                    }
+                } else {
+                    false
+                }
+            } else {
+                false
+            };
+            if !appended {
+                merged.push(json!({
+                    "role": "user",
+                    "content_blocks": [tool_block],
+                }));
+            }
+        } else if role == "user" {
+            let text_block = json!({
+                "type": "text",
+                "text": msg.get("content").cloned().unwrap_or(Value::String(String::new())),
+            });
+            let merged_into_prev = if let Some(prev) = merged.last_mut() {
+                let prev_role = prev.get("role").and_then(|v| v.as_str()).unwrap_or("");
+                let prev_has_blocks = prev.get("content_blocks").is_some();
+                let prev_task_none = prev.get("task").map(Value::is_null).unwrap_or(true);
+                if prev_role == "user" && prev_has_blocks && prev_task_none {
+                    if let Some(blocks) = prev
+                        .get_mut("content_blocks")
+                        .and_then(|v| v.as_array_mut())
+                    {
+                        blocks.push(text_block.clone());
+                        true
+                    } else {
+                        false
+                    }
+                } else {
+                    false
+                }
+            } else {
+                false
+            };
+            if !merged_into_prev {
+                let mut new_msg = json!({
+                    "role": "user",
+                    "content": msg.get("content").cloned().unwrap_or(Value::String(String::new())),
+                    "content_blocks": [text_block],
+                });
+                // Preserve extra fields (task, wo_eos, mask, etc.).
+                if let Some(obj) = new_msg.as_object_mut() {
+                    for key in ["task", "wo_eos", "mask"] {
+                        if let Some(v) = msg.get(key) {
+                            obj.insert(key.to_string(), v.clone());
+                        }
+                    }
+                }
+                merged.push(new_msg);
+            }
+        } else {
+            merged.push(msg);
+        }
+    }
+    merged
+}
+
+/// Sort `tool_result` blocks within user messages by the tool-call order
+/// of the *preceding* assistant turn.
+fn sort_tool_results_by_call_order(messages: Vec<Value>) -> Vec<Value> {
+    let mut out = messages;
+    let mut last_tool_call_order: std::collections::HashMap<String, usize> =
+        std::collections::HashMap::new();
+    for msg in &mut out {
+        let role = msg.get("role").and_then(|v| v.as_str()).unwrap_or("");
+        if role == "assistant" {
+            if let Some(tcs) = msg.get("tool_calls").and_then(|v| v.as_array()) {
+                last_tool_call_order.clear();
+                for (idx, tc) in tcs.iter().enumerate() {
+                    let tc_id = tc
+                        .get("id")
+                        .and_then(|v| v.as_str())
+                        .map(str::to_string)
+                        .or_else(|| {
+                            tc.get("function")
+                                .and_then(|f| f.get("id"))
+                                .and_then(|v| v.as_str())
+                                .map(str::to_string)
+                        });
+                    if let Some(id) = tc_id {
+                        last_tool_call_order.insert(id, idx);
+                    }
+                }
+            }
+        } else if role == "user" {
+            if let Some(blocks) = msg.get("content_blocks").and_then(|v| v.as_array()) {
+                let tool_blocks: Vec<&Value> = blocks
+                    .iter()
+                    .filter(|b| b.get("type").and_then(|v| v.as_str()) == Some("tool_result"))
+                    .collect();
+                if tool_blocks.len() > 1 && !last_tool_call_order.is_empty() {
+                    let mut sorted: Vec<Value> = tool_blocks.iter().map(|b| (*b).clone()).collect();
+                    sorted.sort_by_key(|b| {
+                        b.get("tool_use_id")
+                            .and_then(|v| v.as_str())
+                            .and_then(|id| last_tool_call_order.get(id).copied())
+                            .unwrap_or(0)
+                    });
+                    let mut sorted_idx = 0;
+                    let mut new_blocks: Vec<Value> = Vec::with_capacity(blocks.len());
+                    for block in blocks {
+                        if block.get("type").and_then(|v| v.as_str()) == Some("tool_result") {
+                            new_blocks.push(sorted[sorted_idx].clone());
+                            sorted_idx += 1;
+                        } else {
+                            new_blocks.push(block.clone());
+                        }
+                    }
+                    if let Some(obj) = msg.as_object_mut() {
+                        obj.insert("content_blocks".to_string(), Value::Array(new_blocks));
+                    }
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Drop reasoning_content from earlier assistant turns and remove non-essential
+/// developer messages before the last user.
+fn drop_thinking_messages(messages: &[Value]) -> Vec<Value> {
+    let last_user_idx = find_last_user_index(messages);
+    let mut out: Vec<Value> = Vec::with_capacity(messages.len());
+    for (idx, msg) in messages.iter().enumerate() {
+        let role = msg.get("role").and_then(|v| v.as_str()).unwrap_or("");
+        let always_keep = matches!(
+            role,
+            "user" | "system" | "tool" | "latest_reminder" | "direct_search_results"
+        ) || at_or_after_last_user(idx, last_user_idx);
+        if always_keep {
+            out.push(msg.clone());
+            continue;
+        }
+        if role == "assistant" {
+            let mut cloned = msg.clone();
+            if let Some(obj) = cloned.as_object_mut() {
+                obj.remove("reasoning_content");
+            }
+            out.push(cloned);
+        }
+        // developer + other roles before last_user_idx are dropped.
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// encode_messages — public entry point
+// ---------------------------------------------------------------------------
+/// Encode a list of OpenAI-style messages into a DeepSeek V4 prompt string.
+///
+/// The signature mirrors the Python `encode_messages` function;
+/// `context` is omitted because SMG always renders from scratch.
+#[expect(
+    clippy::trivially_copy_pass_by_ref,
+    reason = "public API mirrors the documented Rust signature with a borrow"
+)]
+pub fn encode_messages(
+    messages: &[Value],
+    thinking_mode: ThinkingMode,
+    params: &EncodeParams,
+) -> Result<String, DsEncodingError> {
+    // Preprocess: merge tool messages and sort tool results.
+    let merged = merge_tool_messages(messages);
+    let mut full_messages = sort_tool_results_by_call_order(merged);
+    let mut prompt = if params.add_default_bos_token {
+        BOS_TOKEN.to_string()
+    } else {
+        String::new()
+    };
+    // Resolve drop_thinking: if any message has tools defined, never drop.
+    let mut effective_drop_thinking = params.drop_thinking;
+    if full_messages
+        .iter()
+        .any(|m| m.get("tools").is_some_and(|v| !v.is_null()))
+    {
+        effective_drop_thinking = false;
+    }
+    if thinking_mode == ThinkingMode::Thinking && effective_drop_thinking {
+        full_messages = drop_thinking_messages(&full_messages);
+    }
+    for idx in 0..full_messages.len() {
+        prompt.push_str(&render_message(
+            idx,
+            &full_messages,
+            thinking_mode,
+            effective_drop_thinking,
+            params.reasoning_effort,
+        )?);
+    }
+    Ok(prompt)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+    fn user(text: &str) -> Value {
+        json!({ "role": "user", "content": text })
+    }
+    #[test]
+    fn one_turn_user_chat_mode() {
+        let msgs = [user("Hello")];
+        let out = encode_messages(&msgs, ThinkingMode::Chat, &EncodeParams::default()).unwrap();
+        let expected =
+            format!("{BOS_TOKEN}{USER_SP_TOKEN}Hello{ASSISTANT_SP_TOKEN}{THINKING_END_TOKEN}");
+        assert_eq!(out, expected);
+    }
+    #[test]
+    fn one_turn_user_thinking_mode() {
+        let msgs = [user("Hello")];
+        let out = encode_messages(&msgs, ThinkingMode::Thinking, &EncodeParams::default()).unwrap();
+        let expected =
+            format!("{BOS_TOKEN}{USER_SP_TOKEN}Hello{ASSISTANT_SP_TOKEN}{THINKING_START_TOKEN}");
+        assert_eq!(out, expected);
+    }
+
+    #[test]
+    fn reasoning_effort_max_prepends_prefix() {
+        let msgs = [user("Hello")];
+        let params = EncodeParams {
+            reasoning_effort: Some(ReasoningEffort::Max),
+            ..EncodeParams::default()
+        };
+        let out = encode_messages(&msgs, ThinkingMode::Thinking, &params).unwrap();
+        // The prefix appears immediately after BOS, before the user message.
+        let expected_start = format!("{BOS_TOKEN}{REASONING_EFFORT_MAX}");
+        assert!(
+            out.starts_with(&expected_start),
+            "expected prompt to start with BOS+REASONING_EFFORT_MAX, got: {:?}",
+            &out[..120.min(out.len())]
+        );
+        // Without max effort, the prefix is absent.
+        let out_chat = encode_messages(&msgs, ThinkingMode::Chat, &params).unwrap();
+        assert!(!out_chat.contains("Reasoning Effort"));
+    }
+
+    #[test]
+    fn quick_instruction_action_token() {
+        // A user message tagged with `task: "action"` triggers the action
+        // quick-instruction sequence: ASSISTANT_SP + thinking-end + ACTION token.
+        let msgs = [json!({
+            "role": "user",
+            "content": "Take some action",
+            "task": "action",
+        })];
+        let out = encode_messages(&msgs, ThinkingMode::Chat, &EncodeParams::default()).unwrap();
+        let expected = format!(
+            "{BOS_TOKEN}{USER_SP_TOKEN}Take some action{ASSISTANT_SP_TOKEN}{THINKING_END_TOKEN}{TASK_ACTION}"
+        );
+        assert_eq!(out, expected);
+        // Same in thinking mode but uses thinking-start.
+        let out_t =
+            encode_messages(&msgs, ThinkingMode::Thinking, &EncodeParams::default()).unwrap();
+        assert!(out_t.contains(&format!(
+            "{ASSISTANT_SP_TOKEN}{THINKING_START_TOKEN}{TASK_ACTION}"
+        )));
+    }
+    #[test]
+    fn quick_instruction_query_token() {
+        // Non-action quick-instruction tasks just append the task token.
+        let msgs = [json!({
+            "role": "user",
+            "content": "What is X?",
+            "task": "query",
+        })];
+        let out = encode_messages(&msgs, ThinkingMode::Chat, &EncodeParams::default()).unwrap();
+        let expected = format!("{BOS_TOKEN}{USER_SP_TOKEN}What is X?{TASK_QUERY}");
+        assert_eq!(out, expected);
+    }
+
+    #[test]
+    fn assistant_tool_call_renders_dsml() {
+        let msgs = [
+            user("call my tool"),
+            json!({
+                "role": "assistant",
+                "reasoning_content": "thinking about tool",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "search",
+                            "arguments": "{\"query\": \"deepseek\", \"limit\": 5}"
+                        }
+                    }
+                ]
+            }),
+        ];
+        let out = encode_messages(&msgs, ThinkingMode::Thinking, &EncodeParams::default()).unwrap();
+        // V4 wraps in `<｜DSML｜tool_calls>` (not `function_calls` like V3.2).
+        assert!(out.contains(&format!("<{DSML_TOKEN}{TOOL_CALLS_BLOCK_NAME}>")));
+        assert!(out.contains(&format!("<{DSML_TOKEN}invoke name=\"search\">")));
+        assert!(out.contains(&format!(
+            "<{DSML_TOKEN}parameter name=\"query\" string=\"true\">deepseek</{DSML_TOKEN}parameter>"
+        )));
+        assert!(out.contains(&format!(
+            "<{DSML_TOKEN}parameter name=\"limit\" string=\"false\">5</{DSML_TOKEN}parameter>"
+        )));
+        assert!(out.contains(&format!("</{DSML_TOKEN}{TOOL_CALLS_BLOCK_NAME}>")));
+        assert!(out.ends_with(EOS_TOKEN));
+    }
+    #[test]
+    fn unknown_role_errors() {
+        let msgs = [json!({ "role": "moderator", "content": "hi" })];
+        let err = encode_messages(&msgs, ThinkingMode::Chat, &EncodeParams::default()).unwrap_err();
+        assert!(matches!(err, DsEncodingError::UnknownRole(ref r) if r == "moderator"));
+    }
+}

--- a/crates/tokenizer/src/encoders/deepseek_v4.rs
+++ b/crates/tokenizer/src/encoders/deepseek_v4.rs
@@ -1,9 +1,4 @@
 // Ported from https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash/blob/main/encoding/encoding_dsv4.py
-//
-// Function and variable names are kept close to the Python source so future
-// re-syncs against the HuggingFace upstream remain mechanical. The DeepSeek
-// special-token sentinel "｜" is U+FF5C (FULLWIDTH VERTICAL LINE), NOT the
-// ASCII pipe — copy directly from the Python file.
 
 use std::fmt::Write as _;
 

--- a/crates/tokenizer/src/encoders/mod.rs
+++ b/crates/tokenizer/src/encoders/mod.rs
@@ -1,15 +1,2 @@
-//! Custom chat-template encoders for models that bypass Jinja templates.
-//!
-//! Some model families (notably DeepSeek V3.2 and V4) use a custom Python
-//! encoding step that the bundled Jinja chat template in
-//! `tokenizer_config.json` does not fully reproduce — DSML tool-call format,
-//! conditional thinking-block drops, V4 quick-instruction tokens, and the
-//! reasoning-effort prefix all live outside the template.
-//!
-//! Both vllm and sglang upstream bypass the Jinja template for these models
-//! and call the Python encoder directly. The encoders in this module are
-//! straight Rust ports of the canonical HuggingFace references; see each
-//! file's header comment for the upstream source.
-
 pub mod deepseek_v32;
 pub mod deepseek_v4;

--- a/crates/tokenizer/src/encoders/mod.rs
+++ b/crates/tokenizer/src/encoders/mod.rs
@@ -1,0 +1,15 @@
+//! Custom chat-template encoders for models that bypass Jinja templates.
+//!
+//! Some model families (notably DeepSeek V3.2 and V4) use a custom Python
+//! encoding step that the bundled Jinja chat template in
+//! `tokenizer_config.json` does not fully reproduce — DSML tool-call format,
+//! conditional thinking-block drops, V4 quick-instruction tokens, and the
+//! reasoning-effort prefix all live outside the template.
+//!
+//! Both vllm and sglang upstream bypass the Jinja template for these models
+//! and call the Python encoder directly. The encoders in this module are
+//! straight Rust ports of the canonical HuggingFace references; see each
+//! file's header comment for the upstream source.
+
+pub mod deepseek_v32;
+pub mod deepseek_v4;

--- a/crates/tokenizer/src/huggingface.rs
+++ b/crates/tokenizer/src/huggingface.rs
@@ -501,13 +501,15 @@ fn derive_thinking_mode(params: &ChatTemplateParams) -> deepseek_v32::ThinkingMo
     }
 }
 
-/// Drop earlier reasoning unless any message declares tools — matches the
-/// canonical V4 encoding spec (V4 also enforces this internally; V3.2 does not).
+/// Per DeepSeek's encoding README, preserve all reasoning when a system or
+/// developer message declares `tools`; otherwise drop earlier reasoning.
 fn resolve_drop_thinking(messages: &[serde_json::Value]) -> bool {
     !messages.iter().any(|m| {
-        m.get("tools")
-            .and_then(|t| t.as_array())
-            .is_some_and(|arr| !arr.is_empty())
+        let role = m.get("role").and_then(|r| r.as_str());
+        matches!(role, Some("system" | "developer"))
+            && m.get("tools")
+                .and_then(|t| t.as_array())
+                .is_some_and(|arr| !arr.is_empty())
     })
 }
 fn apply_deepseek_v32(

--- a/crates/tokenizer/src/huggingface.rs
+++ b/crates/tokenizer/src/huggingface.rs
@@ -501,14 +501,14 @@ fn derive_thinking_mode(params: &ChatTemplateParams) -> deepseek_v32::ThinkingMo
     }
 }
 
-/// Resolve `drop_thinking` the way vllm does: drop earlier reasoning when the
-/// final message is a fresh user turn.
+/// Drop earlier reasoning unless any message declares tools — matches the
+/// canonical V4 encoding spec (V4 also enforces this internally; V3.2 does not).
 fn resolve_drop_thinking(messages: &[serde_json::Value]) -> bool {
-    messages
-        .last()
-        .and_then(|m| m.get("role"))
-        .and_then(|r| r.as_str())
-        == Some("user")
+    !messages.iter().any(|m| {
+        m.get("tools")
+            .and_then(|t| t.as_array())
+            .is_some_and(|arr| !arr.is_empty())
+    })
 }
 fn apply_deepseek_v32(
     messages: &[serde_json::Value],

--- a/crates/tokenizer/src/huggingface.rs
+++ b/crates/tokenizer/src/huggingface.rs
@@ -16,12 +16,6 @@ use crate::{
     traits::{Decoder, Encoder, Encoding, SpecialTokens, TokenIdType, Tokenizer as TokenizerTrait},
 };
 
-/// Which renderer to use when applying the chat template.
-///
-/// Most models use the Jinja template stored in tokenizer_config.json. A
-/// small set of model families (DeepSeek V3.2 and V4 today) ship a Python
-/// chat-template encoder that the bundled Jinja template does not fully
-/// reproduce; for those we dispatch to a dedicated Rust port.
 #[derive(Debug, Clone, Copy)]
 enum Renderer {
     Jinja,

--- a/crates/tokenizer/src/huggingface.rs
+++ b/crates/tokenizer/src/huggingface.rs
@@ -12,8 +12,22 @@ use crate::{
         load_chat_template_from_file, ChatTemplateContentFormat, ChatTemplateParams,
         ChatTemplateState, ThinkingKeyName, ThinkingToggle,
     },
+    encoders::{deepseek_v32, deepseek_v4},
     traits::{Decoder, Encoder, Encoding, SpecialTokens, TokenIdType, Tokenizer as TokenizerTrait},
 };
+
+/// Which renderer to use when applying the chat template.
+///
+/// Most models use the Jinja template stored in tokenizer_config.json. A
+/// small set of model families (DeepSeek V3.2 and V4 today) ship a Python
+/// chat-template encoder that the bundled Jinja template does not fully
+/// reproduce; for those we dispatch to a dedicated Rust port.
+#[derive(Debug, Clone, Copy)]
+enum Renderer {
+    Jinja,
+    DeepseekV32,
+    DeepseekV4,
+}
 
 /// HuggingFace tokenizer wrapper
 pub struct HuggingFaceTokenizer {
@@ -24,6 +38,8 @@ pub struct HuggingFaceTokenizer {
     chat_template: ChatTemplateState,
     /// EOS token IDs from config.json + generation_config.json
     eos_token_ids: Vec<TokenIdType>,
+    /// Which renderer applies chat templates for this model.
+    renderer: Renderer,
 }
 
 impl HuggingFaceTokenizer {
@@ -90,6 +106,12 @@ impl HuggingFaceTokenizer {
             .map(crate::eos::load_eos_token_ids)
             .unwrap_or_default();
 
+        // Detect a custom Python-encoder model from config.json::architectures.
+        let renderer = std::path::Path::new(file_path)
+            .parent()
+            .map(detect_renderer_from_config)
+            .unwrap_or(Renderer::Jinja);
+
         Ok(HuggingFaceTokenizer {
             tokenizer,
             special_tokens,
@@ -97,6 +119,7 @@ impl HuggingFaceTokenizer {
             reverse_vocab,
             chat_template: ChatTemplateState::new(chat_template_str)?,
             eos_token_ids,
+            renderer,
         })
     }
 
@@ -164,6 +187,7 @@ impl HuggingFaceTokenizer {
             reverse_vocab,
             chat_template: ChatTemplateState::empty(),
             eos_token_ids: Vec::new(), // No directory path in from_tokenizer
+            renderer: Renderer::Jinja,
         }
     }
 
@@ -372,15 +396,21 @@ impl TokenizerTrait for HuggingFaceTokenizer {
         messages: &[serde_json::Value],
         params: ChatTemplateParams,
     ) -> Result<String> {
-        // Inject special tokens if the caller didn't provide them
-        if params.special_tokens.is_some() {
-            return self.chat_template.apply(messages, params);
+        match self.renderer {
+            Renderer::Jinja => {
+                // Inject special tokens if the caller didn't provide them.
+                if params.special_tokens.is_some() {
+                    return self.chat_template.apply(messages, params);
+                }
+                let params = ChatTemplateParams {
+                    special_tokens: Some(&self.special_tokens),
+                    ..params
+                };
+                self.chat_template.apply(messages, params)
+            }
+            Renderer::DeepseekV32 => apply_deepseek_v32(messages, &params),
+            Renderer::DeepseekV4 => apply_deepseek_v4(messages, &params),
         }
-        let params = ChatTemplateParams {
-            special_tokens: Some(&self.special_tokens),
-            ..params
-        };
-        self.chat_template.apply(messages, params)
     }
 
     fn chat_template_content_format(&self) -> ChatTemplateContentFormat {
@@ -401,4 +431,116 @@ impl TokenizerTrait for HuggingFaceTokenizer {
     fn set_chat_template(&mut self, template: String) -> Result<()> {
         self.chat_template.set(template)
     }
+}
+
+// ---------------------------------------------------------------------------
+// Renderer detection (config.json::architectures)
+// ---------------------------------------------------------------------------
+/// Inspect the sibling `config.json` to decide which chat-template renderer to
+/// use. A missing or malformed file falls back to [`Renderer::Jinja`] without
+/// erroring (debug-logged), preserving backward compatibility for every model
+/// not in the architecture list.
+fn detect_renderer_from_config(dir: &std::path::Path) -> Renderer {
+    let path = dir.join("config.json");
+    if !path.exists() {
+        return Renderer::Jinja;
+    }
+    let content = match std::fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(err) => {
+            debug!(?err, ?path, "config.json unreadable; using Jinja renderer");
+            return Renderer::Jinja;
+        }
+    };
+    let value: serde_json::Value = match serde_json::from_str(&content) {
+        Ok(v) => v,
+        Err(err) => {
+            debug!(?err, ?path, "config.json malformed; using Jinja renderer");
+            return Renderer::Jinja;
+        }
+    };
+    let architectures = value.get("architectures").and_then(|v| v.as_array());
+    let arch_strs: Vec<&str> = architectures
+        .map(|a| a.iter().filter_map(|v| v.as_str()).collect())
+        .unwrap_or_default();
+    if arch_strs.contains(&"DeepseekV32ForCausalLM") {
+        debug!(?path, "selected DeepseekV32 chat-template renderer");
+        return Renderer::DeepseekV32;
+    }
+    if arch_strs.contains(&"DeepseekV4ForCausalLM") {
+        debug!(?path, "selected DeepseekV4 chat-template renderer");
+        return Renderer::DeepseekV4;
+    }
+    Renderer::Jinja
+}
+
+// ---------------------------------------------------------------------------
+// DeepSeek V3.2 / V4 dispatch shims
+// ---------------------------------------------------------------------------
+/// Derive the V3.2 / V4 thinking mode from `template_kwargs`.
+///
+/// Mirrors vllm's `vllm/tokenizers/deepseek_v32.py`: thinking is ON if
+/// either `thinking` or `enable_thinking` is truthy in the kwargs map.
+fn derive_thinking_mode(params: &ChatTemplateParams) -> deepseek_v32::ThinkingMode {
+    let kwargs = match params.template_kwargs {
+        Some(k) => k,
+        None => return deepseek_v32::ThinkingMode::Chat,
+    };
+    let thinking = kwargs
+        .get("thinking")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+    let enable_thinking = kwargs
+        .get("enable_thinking")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+    if thinking || enable_thinking {
+        deepseek_v32::ThinkingMode::Thinking
+    } else {
+        deepseek_v32::ThinkingMode::Chat
+    }
+}
+
+/// Resolve `drop_thinking` the way vllm does: drop earlier reasoning when the
+/// final message is a fresh user turn.
+fn resolve_drop_thinking(messages: &[serde_json::Value]) -> bool {
+    messages
+        .last()
+        .and_then(|m| m.get("role"))
+        .and_then(|r| r.as_str())
+        == Some("user")
+}
+fn apply_deepseek_v32(
+    messages: &[serde_json::Value],
+    params: &ChatTemplateParams,
+) -> Result<String> {
+    let thinking_mode = derive_thinking_mode(params);
+    let encode_params = deepseek_v32::EncodeParams {
+        add_default_bos_token: true,
+        drop_thinking: resolve_drop_thinking(messages),
+    };
+    deepseek_v32::encode_messages(messages, thinking_mode, &encode_params)
+        .map_err(|e| Error::msg(format!("DeepSeek V3.2 encode failed: {e}")))
+}
+fn apply_deepseek_v4(
+    messages: &[serde_json::Value],
+    params: &ChatTemplateParams,
+) -> Result<String> {
+    let thinking_mode = derive_thinking_mode(params);
+    let reasoning_effort = params
+        .template_kwargs
+        .and_then(|k| k.get("reasoning_effort"))
+        .and_then(|v| v.as_str())
+        .and_then(|s| match s {
+            "max" => Some(deepseek_v4::ReasoningEffort::Max),
+            "high" => Some(deepseek_v4::ReasoningEffort::High),
+            _ => None,
+        });
+    let encode_params = deepseek_v4::EncodeParams {
+        add_default_bos_token: true,
+        drop_thinking: resolve_drop_thinking(messages),
+        reasoning_effort,
+    };
+    deepseek_v4::encode_messages(messages, thinking_mode, &encode_params)
+        .map_err(|e| Error::msg(format!("DeepSeek V4 encode failed: {e}")))
 }

--- a/crates/tokenizer/src/lib.rs
+++ b/crates/tokenizer/src/lib.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use anyhow::Result;
 
 pub mod cache;
+pub mod encoders;
 pub mod eos;
 pub mod factory;
 pub mod hub;

--- a/crates/tokenizer/tests/deepseek_renderer_detection.rs
+++ b/crates/tokenizer/tests/deepseek_renderer_detection.rs
@@ -1,0 +1,136 @@
+//! Verify that `HuggingFaceTokenizer` selects the right chat-template renderer
+//! based on `config.json::architectures`.
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashMap, fs};
+
+    use llm_tokenizer::{
+        chat_template::ChatTemplateParams, huggingface::HuggingFaceTokenizer, TokenizerTrait,
+    };
+    use serde_json::json;
+    use tempfile::TempDir;
+    /// A minimal tokenizer.json that loads cleanly. The only requirement is that
+    /// it parses; the encoder logic does not call back into the tokenizer here.
+    const MIN_TOKENIZER_JSON: &str = r#"{
+        "version": "1.0",
+        "truncation": null,
+        "padding": null,
+        "added_tokens": [],
+        "normalizer": null,
+        "pre_tokenizer": { "type": "Whitespace" },
+        "post_processor": null,
+        "decoder": null,
+        "model": {
+            "type": "BPE",
+            "vocab": { "hello": 0, "<s>": 1, "</s>": 2 },
+            "merges": []
+        }
+    }"#;
+    fn write_dir(architectures: Option<&[&str]>) -> (TempDir, String) {
+        let temp = TempDir::new().unwrap();
+        let tok_path = temp.path().join("tokenizer.json");
+        fs::write(&tok_path, MIN_TOKENIZER_JSON).unwrap();
+        if let Some(archs) = architectures {
+            let cfg_path = temp.path().join("config.json");
+            let body = json!({ "architectures": archs }).to_string();
+            fs::write(&cfg_path, body).unwrap();
+        }
+        let p = tok_path.to_str().unwrap().to_string();
+        (temp, p)
+    }
+
+    #[test]
+    fn config_with_deepseek_v32_arch_uses_v32_renderer() {
+        let (_tmp, tok) = write_dir(Some(&["DeepseekV32ForCausalLM"]));
+        let tokenizer = HuggingFaceTokenizer::from_file(&tok).unwrap();
+        let messages = vec![json!({ "role": "user", "content": "Hello" })];
+        let kwargs: HashMap<String, serde_json::Value> = HashMap::new();
+        let params = ChatTemplateParams {
+            template_kwargs: Some(&kwargs),
+            ..Default::default()
+        };
+        let out = tokenizer.apply_chat_template(&messages, params).unwrap();
+        // V3.2 emits BOS + <｜User｜>Hello<｜Assistant｜></think> in chat mode.
+        assert!(out.contains("<\u{FF5C}begin\u{2581}of\u{2581}sentence\u{FF5C}>"));
+        assert!(out.contains("<\u{FF5C}User\u{FF5C}>Hello<\u{FF5C}Assistant\u{FF5C}>"));
+        assert!(out.ends_with("</think>"));
+    }
+    #[test]
+    fn config_with_deepseek_v4_arch_uses_v4_renderer() {
+        let (_tmp, tok) = write_dir(Some(&["DeepseekV4ForCausalLM"]));
+        let tokenizer = HuggingFaceTokenizer::from_file(&tok).unwrap();
+        let messages = vec![json!({ "role": "user", "content": "Hello" })];
+        let kwargs: HashMap<String, serde_json::Value> = HashMap::new();
+        let params = ChatTemplateParams {
+            template_kwargs: Some(&kwargs),
+            ..Default::default()
+        };
+        let out = tokenizer.apply_chat_template(&messages, params).unwrap();
+        // V4 emits BOS + <｜User｜>Hello<｜Assistant｜></think> in chat mode.
+        assert!(out.contains("<\u{FF5C}begin\u{2581}of\u{2581}sentence\u{FF5C}>"));
+        assert!(out.contains("<\u{FF5C}User\u{FF5C}>Hello<\u{FF5C}Assistant\u{FF5C}>"));
+        assert!(out.ends_with("</think>"));
+    }
+
+    #[test]
+    fn config_with_unrelated_arch_falls_back_to_jinja() {
+        // A non-DeepSeek architecture should keep using the Jinja renderer; with
+        // no chat_template set, applying the template should error rather than
+        // silently picking a DeepSeek encoder.
+        let (_tmp, tok) = write_dir(Some(&["LlamaForCausalLM"]));
+        let tokenizer = HuggingFaceTokenizer::from_file(&tok).unwrap();
+        let messages = vec![json!({ "role": "user", "content": "Hello" })];
+        let result = tokenizer.apply_chat_template(&messages, ChatTemplateParams::default());
+        assert!(
+            result.is_err(),
+            "expected error from missing Jinja template"
+        );
+    }
+    #[test]
+    fn no_config_json_falls_back_to_jinja() {
+        // No sibling config.json — must still default to Jinja and not blow up.
+        let (_tmp, tok) = write_dir(None);
+        let tokenizer = HuggingFaceTokenizer::from_file(&tok).unwrap();
+        let messages = vec![json!({ "role": "user", "content": "Hello" })];
+        let result = tokenizer.apply_chat_template(&messages, ChatTemplateParams::default());
+        // Without a chat template registered, the Jinja renderer surfaces an error.
+        // The important thing is that we did NOT auto-select a DeepSeek encoder.
+        assert!(result.is_err());
+    }
+    #[test]
+    fn malformed_config_json_falls_back_to_jinja() {
+        let temp = TempDir::new().unwrap();
+        let tok_path = temp.path().join("tokenizer.json");
+        fs::write(&tok_path, MIN_TOKENIZER_JSON).unwrap();
+        fs::write(temp.path().join("config.json"), "{ this is not json").unwrap();
+        let tokenizer = HuggingFaceTokenizer::from_file(tok_path.to_str().unwrap()).unwrap();
+        let messages = vec![json!({ "role": "user", "content": "Hello" })];
+        let result = tokenizer.apply_chat_template(&messages, ChatTemplateParams::default());
+        assert!(result.is_err());
+    }
+    #[test]
+    fn deepseek_v4_renderer_passes_reasoning_effort() {
+        let (_tmp, tok) = write_dir(Some(&["DeepseekV4ForCausalLM"]));
+        let tokenizer = HuggingFaceTokenizer::from_file(&tok).unwrap();
+        let messages = vec![json!({ "role": "user", "content": "Hello" })];
+        let mut kwargs: HashMap<String, serde_json::Value> = HashMap::new();
+        kwargs.insert(
+            "reasoning_effort".to_string(),
+            serde_json::Value::String("max".to_string()),
+        );
+        kwargs.insert("thinking".to_string(), serde_json::Value::Bool(true));
+        let params = ChatTemplateParams {
+            template_kwargs: Some(&kwargs),
+            ..Default::default()
+        };
+        let out = tokenizer.apply_chat_template(&messages, params).unwrap();
+        assert!(
+            out.contains("Reasoning Effort: Absolute maximum"),
+            "expected reasoning-effort prefix in V4 output"
+        );
+        assert!(
+            out.ends_with("<think>"),
+            "thinking mode should leave a <think> token open"
+        );
+    }
+}


### PR DESCRIPTION
## Description

### Problem

DeepSeek V3.2 and V4 use a custom Python chat-template encoding that the bundled Jinja template in `tokenizer_config.json` does not fully cover: DSML tool-call format (`<｜DSML｜function_calls>` / `<｜DSML｜tool_calls>` blocks), thinking blocks with conditional drop, V4 quick-instruction tokens (`<｜action｜>`, `<｜query｜>`, …), the `reasoning_effort=max` prefix, and the developer/user/tool transition rules.

Both vllm and sglang upstream **bypass** the Jinja template entirely for these models and call the Python encoder directly:

- vllm `vllm/tokenizers/deepseek_v32.py` wraps the HF tokenizer to override `apply_chat_template` with `encode_messages` from `vllm/tokenizers/deepseek_v32_encoding.py`. Selected by `tokenizer_mode="deepseek_v32"`, auto-set when `architectures = ["DeepseekV32ForCausalLM"]` (`vllm/config/model.py:565`).
- sglang `python/sglang/srt/entrypoints/openai/encoding_dsv32.py` is called from `serving_chat.py:528` when `use_dpsk_v32_encoding` is set; the `sgl/deepseek_v4` branch adds an analogous `encoding_dsv4.py`.

SMG's `crates/tokenizer/src/huggingface.rs::apply_chat_template` always renders via `minijinja`, producing wrong prompts for these models.

### Solution

- Rust ports of the canonical HuggingFace encoders:
  - `crates/tokenizer/src/encoders/deepseek_v32.rs` (port of [`encoding_dsv32.py`](https://huggingface.co/deepseek-ai/DeepSeek-V3.2/blob/main/encoding/encoding_dsv32.py)).
  - `crates/tokenizer/src/encoders/deepseek_v4.rs` (port of [`encoding_dsv4.py`](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash/blob/main/encoding/encoding_dsv4.py)).
- Function and variable names are kept close to the Python so future re-syncs are mechanical; the U+FF5C `｜` sentinel character is preserved verbatim.
- `HuggingFaceTokenizer` gains a private `Renderer { Jinja, DeepseekV32, DeepseekV4 }` enum and dispatches inside `apply_chat_template`. The renderer is selected from the sibling `config.json::architectures`; missing/malformed `config.json` falls back to `Renderer::Jinja` (debug-logged) so all non-DeepSeek models behave exactly as before.
- `template_kwargs.thinking` / `enable_thinking` are derived into `ThinkingMode` mirroring vllm; `template_kwargs.reasoning_effort` flows into the V4 encoder; `drop_thinking` is `true` when the last message is a fresh user turn (also matches vllm).
- The Jinja code path is untouched — same special-token injection, same content-format detection, same Llama / Qwen / etc. behaviour.

Tool-call parsing and reasoning parsing for the DSML output format are deliberately out of scope; those belong in `crates/tool_parser` and `crates/reasoning_parser` and are slated for follow-up PRs.

## Changes

- **Added**
  - `crates/tokenizer/src/encoders/mod.rs` — module declarations.
  - `crates/tokenizer/src/encoders/deepseek_v32.rs` — V3.2 port + 6 unit tests.
  - `crates/tokenizer/src/encoders/deepseek_v4.rs` — V4 port + 7 unit tests.
  - `crates/tokenizer/tests/deepseek_renderer_detection.rs` — 6 integration tests covering renderer selection and Jinja fallback.
- **Modified**
  - `crates/tokenizer/src/lib.rs` — `pub mod encoders;`.
  - `crates/tokenizer/src/huggingface.rs` — `Renderer` enum, `renderer` field, arch-driven detection in `from_file_with_chat_template`, dispatch in `apply_chat_template`, and `derive_thinking_mode` / `apply_deepseek_v32` / `apply_deepseek_v4` shims.

No files outside `crates/tokenizer/` were touched. No new dependencies; no public API changes; no Go/Python FFI changes.

## Test Plan

- `cargo +nightly fmt -p llm-tokenizer` — clean.
- `cargo clippy -p llm-tokenizer --all-targets --all-features -- -D warnings` — clean.
- `cargo test -p llm-tokenizer` — 180 tests pass (13 new encoder unit tests + 6 new integration tests + 161 pre-existing).
- Per-encoder coverage:
  - V3.2: 1-turn user in chat vs thinking mode (verifies `</think>` close vs `<think>` open), 2-turn conversation with `drop_thinking=true` strips earlier reasoning, assistant turn with one tool_call renders correct DSML, unknown-role error, BOS suppression.
  - V4: 1-turn user in chat vs thinking mode, `reasoning_effort=max` prepends the max-effort prefix, `task="action"` and `task="query"` quick-instruction tokens render, tool-call rendering uses `<｜DSML｜tool_calls>` (not `function_calls`), unknown-role error.
- Wiring tests: `architectures: ["DeepseekV32ForCausalLM"]` selects the V32 renderer; `["DeepseekV4ForCausalLM"]` selects V4; `["LlamaForCausalLM"]`, missing `config.json`, and malformed `config.json` all keep Jinja.
- Tool-call parsing and reasoning parsing for DSML are **out of scope** here; they will land in `crates/tool_parser` and `crates/reasoning_parser` follow-ups.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DeepSeek V3.2 and V4 prompt encoders with configurable thinking modes, reasoning-effort options, and encoding params (BOS/EOS, drop-thinking).

* **Integration**
  * Tokenizer now auto-detects and dispatches DeepSeek renderers when appropriate and exposes encoders at the crate root for reuse.

* **Bug Fixes & Error Handling**
  * Improved validation and detailed errors for malformed messages, tool-call sequences, and tool arguments.

* **Tests**
  * Added tests covering renderer detection, encoding formats, reasoning behavior, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->