### PR TITLE
refactor: strip R6.x audit-process residue from MCP + router comments (C3)

### DIFF
--- a/crates/mcp/src/transform/transformer.rs
+++ b/crates/mcp/src/transform/transformer.rs
@@ -260,8 +260,8 @@ impl ResponseTransformer {
             // `result` is non-optional in the spec; fall back to an empty
             // string when the MCP server returns no image data so the shape
             // still matches `ResponseOutputItem::ImageGenerationCall`. Router
-            // wiring in R6.2/R6.3/R6.4 is responsible for surfacing an error
-            // status when `image_b64` is missing.
+            // wiring is responsible for surfacing an error status when
+            // `image_b64` is missing.
             result: image_b64.unwrap_or_default(),
             revised_prompt,
             status: ImageGenerationCallStatus::Completed,
@@ -1111,10 +1111,10 @@ mod tests {
         // MCP servers authored against the FastMCP SDK (and any server that
         // returns a plain `dict` from its tool handler) emit a single text
         // block whose JSON body has `result` / `revised_prompt` at the TOP
-        // level — there is no `openai_response` wrapper. This is the shape
-        // produced by the R6.5 in-process mock and is equally valid per the
-        // MCP spec. The extractor must read those top-level fields the same
-        // way it reads direct-object and embedded-openai_response payloads.
+        // level — there is no `openai_response` wrapper. This shape is
+        // equally valid per the MCP spec. The extractor must read those
+        // top-level fields the same way it reads direct-object and
+        // embedded-openai_response payloads.
         let result = json!([
             {
                 "type": "text",
@@ -1227,7 +1227,7 @@ mod tests {
     fn test_image_generation_transform_missing_image_data() {
         // When the MCP server returns neither image nor prompt, the transformer
         // still produces a well-formed ImageGenerationCall with an empty result.
-        // Per-router wiring in R6.2/R6.3/R6.4 owns surfacing an error status.
+        // Per-router wiring owns surfacing an error status.
         let result = json!({});
 
         let transformed = ResponseTransformer::transform(

--- a/model_gateway/src/routers/common/mcp_utils.rs
+++ b/model_gateway/src/routers/common/mcp_utils.rs
@@ -533,7 +533,7 @@ mod tests {
         // Image generation is wired through the same hosted-tool MCP plumbing
         // as web_search / code_interpreter / file_search. This test proves
         // BuiltinToolType::ImageGeneration → ResponseFormat::ImageGenerationCall
-        // so PRs R6.2/R6.3/R6.4 can rely on the infrastructure.
+        // so per-router wiring can rely on the infrastructure.
         let mut image_gen_tools = HashMap::new();
         image_gen_tools.insert(
             "generate_image".to_string(),

--- a/model_gateway/src/routers/grpc/common/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/common/responses/streaming.rs
@@ -512,11 +512,11 @@ impl ResponseStreamEventEmitter {
     /// `emit_tool_call_searching` gates on format. The payload carries the
     /// base64-encoded partial image bytes plus a 0-based partial image index.
     ///
-    /// Per-router wiring in R6.2/R6.3/R6.4 is responsible for deciding when
-    /// to call this and how to source the partial-image bytes.
+    /// Per-router wiring is responsible for deciding when to call this and
+    /// how to source the partial-image bytes.
     #[expect(
         dead_code,
-        reason = "partial_image emission is wired by per-router PRs R6.2/R6.3/R6.4"
+        reason = "partial_image emission is wired by per-router integrations"
     )]
     pub fn emit_image_generation_partial_image(
         &mut self,

--- a/model_gateway/src/routers/grpc/common/responses/utils.rs
+++ b/model_gateway/src/routers/grpc/common/responses/utils.rs
@@ -43,13 +43,14 @@ pub(crate) async fn ensure_mcp_connection(
 
     // Check for builtin tools that MAY have MCP routing configured.
     //
-    // `ImageGeneration` is included here (R6.8) because gpt-oss via the
+    // `ImageGeneration` is included here because gpt-oss via the
     // harmony pipeline, and Qwen/Llama via the regular pipeline, both
     // dispatch hosted `image_generation` calls through the same MCP
     // routing path — the only difference is how the tool is advertised in
-    // the prompt. Without this arm, the short-circuit below returned
-    // `(false, Vec::new())`, the MCP loop was never entered, and the
-    // registered `image_generation` MCP server received zero dispatches.
+    // the prompt. Without this arm, the short-circuit below would return
+    // `(false, Vec::new())`, the MCP loop would never be entered, and the
+    // registered `image_generation` MCP server would receive zero
+    // dispatches.
     let has_builtin_tools = tools
         .map(|t| {
             t.iter().any(|tool| {

--- a/model_gateway/src/routers/grpc/harmony/builder.rs
+++ b/model_gateway/src/routers/grpc/harmony/builder.rs
@@ -75,12 +75,12 @@ pub(crate) fn convert_harmony_logprobs(proto_logprobs: &ProtoOutputLogProbs) -> 
 /// call, ignored advertisement, or garbled output). Instead, the
 /// [`ToolLike`] impl for [`ResponseTool::ImageGeneration`] renders the
 /// hosted tool as a *function tool* in the developer-message
-/// custom-tool section (R6.8): gpt-oss sees `image_generation` as a
-/// callable function, emits a plain function call with a `prompt`
-/// argument, and the downstream MCP dispatch path — keyed on the
-/// exposed function-tool name — routes the call to the registered
-/// `image_generation` MCP server and materializes the response as an
-/// `image_generation_call` output item.
+/// custom-tool section: gpt-oss sees `image_generation` as a callable
+/// function, emits a plain function call with a `prompt` argument, and
+/// the downstream MCP dispatch path — keyed on the exposed function-tool
+/// name — routes the call to the registered `image_generation` MCP
+/// server and materializes the response as an `image_generation_call`
+/// output item.
 const BUILTIN_TOOLS: &[&str] = &[
     "web_search_preview",
     "web_search",
@@ -145,7 +145,7 @@ impl ToolLike for ResponseTool {
         // was not trained to emit `image_generation_call` as a builtin
         // channel tag; instead, the gateway advertises it in the custom-tool
         // section and routes the resulting function call through MCP
-        // dispatch. See [`BUILTIN_TOOLS`] above and the R6.8 commit body.
+        // dispatch. See [`BUILTIN_TOOLS`] above.
         matches!(
             self,
             ResponseTool::Function(_) | ResponseTool::ImageGeneration(_)
@@ -477,7 +477,7 @@ impl HarmonyBuilder {
         // `harmony/responses/non_streaming.rs`). When the caller's
         // original request also declared a hosted tool that the MCP
         // server resolves by the same name — most notably
-        // `image_generation` via the R6.8 synthesized schema — we would
+        // `image_generation` via the synthesized schema — we would
         // otherwise emit two identically-named entries inside
         // `namespace functions { … }` and confuse gpt-oss about which
         // signature to follow. Keeping the first occurrence (the
@@ -1162,18 +1162,17 @@ impl Default for HarmonyBuilder {
 
 #[cfg(test)]
 mod tests {
-    //! R6.8 regression coverage for the `image_generation` → function-tool
+    //! Regression coverage for the `image_generation` → function-tool
     //! translation gpt-oss needs via the harmony pipeline.
     //!
-    //! Before R6.8 the harmony builder silently dropped
-    //! `ResponseTool::ImageGeneration` — it classified as a builtin (via
-    //! the historical `BUILTIN_TOOLS` membership) but gpt-oss was never
-    //! trained to emit `image_generation_call` as a builtin channel tag.
-    //! Net effect: the model saw no tool at all, emitted a
-    //! reasoning + message pair, and the registered `image_generation`
-    //! MCP server received zero dispatches.
+    //! Classifying `ResponseTool::ImageGeneration` as a builtin made the
+    //! harmony builder silently drop it — gpt-oss was never trained to
+    //! emit `image_generation_call` as a builtin channel tag, so the
+    //! model saw no tool at all, emitted a reasoning + message pair, and
+    //! the registered `image_generation` MCP server received zero
+    //! dispatches.
     //!
-    //! These tests lock in the new contract:
+    //! These tests lock in the contract:
     //!   1. `image_generation` is NOT in `BUILTIN_TOOLS`.
     //!   2. `ResponseTool::ImageGeneration` is treated as a *custom* tool
     //!      by the harmony `ToolLike` impl.
@@ -1189,8 +1188,8 @@ mod tests {
 
     use super::*;
 
-    /// PR #1353's invariant: `image_generation` must never be advertised
-    /// as a gpt-oss native builtin tool. If a future change re-adds it,
+    /// Invariant: `image_generation` must never be advertised as a
+    /// gpt-oss native builtin tool. If a future change re-adds it,
     /// gpt-oss's behavior becomes undefined (hallucinated tool call
     /// shape, ignored advertisement, or garbled output) because the
     /// model was not trained on that channel tag. Keep this guard until
@@ -1200,7 +1199,7 @@ mod tests {
         assert!(
             !BUILTIN_TOOLS.contains(&"image_generation"),
             "image_generation must not be advertised as a gpt-oss builtin; \
-             it is rendered as a function tool instead (R6.8)",
+             it is rendered as a function tool instead",
         );
     }
 

--- a/model_gateway/src/routers/grpc/harmony/responses/common.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/common.rs
@@ -304,8 +304,8 @@ pub(super) async fn load_previous_messages(
 /// Strip `ResponseTool::ImageGeneration` from a request's tools list once
 /// the MCP session has exposed an MCP-routed replacement.
 ///
-/// Motivation (R6.8): the harmony builder synthesizes a function-tool
-/// description named `image_generation` from
+/// The harmony builder synthesizes a function-tool description named
+/// `image_generation` from
 /// [`openai_protocol::responses::ResponseTool::ImageGeneration`]. That is
 /// the right advertisement when no MCP server is configured, but once the
 /// MCP loop injects a `ResponseTool::Function` for the MCP-exposed

--- a/model_gateway/src/routers/grpc/harmony/responses/non_streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/non_streaming.rs
@@ -135,7 +135,7 @@ async fn execute_with_mcp_loop(
         );
     }
 
-    // R6.8: once the MCP loop has taken ownership of image_generation
+    // Once the MCP loop has taken ownership of image_generation
     // dispatch, drop the hosted-tool descriptor so the harmony builder
     // advertises only the MCP-exposed function-tool name (which
     // `has_exposed_tool` actually recognizes for dispatch). See the

--- a/model_gateway/src/routers/grpc/harmony/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/streaming.rs
@@ -165,7 +165,7 @@ async fn execute_mcp_tool_loop_streaming(
         );
     }
 
-    // R6.8: once the MCP loop has taken ownership of image_generation
+    // Once the MCP loop has taken ownership of image_generation
     // dispatch, drop the hosted-tool descriptor so the harmony builder
     // advertises only the MCP-exposed function-tool name (which
     // `has_exposed_tool` actually recognizes for dispatch). See the

--- a/model_gateway/src/routers/grpc/regular/responses/conversions.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/conversions.rs
@@ -551,9 +551,9 @@ mod tests {
 
     #[test]
     fn test_image_generation_call_input_rejected() {
-        // Regression (R6.4): `image_generation_call` items are server-produced
-        // output (populated via the shared MCP transformer in R6.1) and must
-        // not be round-tripped back into the chat conversion as input.
+        // Regression: `image_generation_call` items are server-produced
+        // output (populated via the shared MCP transformer) and must not
+        // be round-tripped back into the chat conversion as input.
         // The regular gRPC path — used by non-Harmony text LLMs that only do
         // function calling — rejects this variant with the same contract as
         // sibling hosted-tool items (Computer/Shell/Custom/ApplyPatch).

--- a/model_gateway/src/routers/openai/mcp/tool_handler.rs
+++ b/model_gateway/src/routers/openai/mcp/tool_handler.rs
@@ -234,8 +234,7 @@ impl StreamingToolHandler {
                 // directly (not wrapped as function_call), the upstream
                 // umbrella `output_item.done` fires BEFORE
                 // `<type>.completed`, and forwarding it breaks the spec
-                // ordering invariant. See PR #1365 CI failure log for
-                // image_generation_call evidence.
+                // ordering invariant.
                 let is_tool_call_done = parsed
                     .get("item")
                     .and_then(|item| item.get("type"))
@@ -445,8 +444,8 @@ impl StreamingToolHandler {
 
 #[cfg(test)]
 mod tests {
-    //! Regression tests for R6.7 Gap B — streaming event ordering for
-    //! image-generation-style built-in tool calls.
+    //! Regression tests for streaming event ordering on image-generation-
+    //! style built-in tool calls.
     //!
     //! The bug: when the upstream signalled tool completion with a direct
     //! `response.output_item.done` event (no preceding
@@ -487,7 +486,7 @@ mod tests {
 
     #[test]
     fn output_item_done_triggers_execute_tools_without_forwarding() {
-        // Gap B: when the upstream signals tool-call completion via
+        // When the upstream signals tool-call completion via
         // `output_item.done` for a function_call item (no preceding
         // `function_call_arguments.done`), the handler must ask the
         // caller NOT to forward the triggering event — the tool loop
@@ -524,12 +523,11 @@ mod tests {
 
     /// Assert that an `output_item.done` for `item_type` is suppressed (the
     /// gate returns `ExecuteTools { forward_triggering_event: false }`) when
-    /// a tool call is already pending. This is the R6.7b regression: R6.7's
-    /// original gate only matched `function_call`/`function_tool_call`, so
-    /// OpenAI cloud passthrough of native hosted tools (which emits the
-    /// item directly with its hosted-tool type) slipped through and the
-    /// duplicate umbrella event reached the wire. See PR #1365 CI log for
-    /// the `image_generation_call` reproduction.
+    /// a tool call is already pending. The gate must match every hosted
+    /// tool-call item type — OpenAI cloud passthrough of native hosted
+    /// tools (which emits the item directly with its hosted-tool type) would
+    /// otherwise slip through and send a duplicate umbrella event to the
+    /// wire.
     fn assert_output_item_done_suppressed_for_hosted_tool(item_type: &str) {
         let mut handler = StreamingToolHandler::with_starting_index(0);
         bootstrap_function_call_added(&mut handler);
@@ -561,19 +559,17 @@ mod tests {
 
     #[test]
     fn output_item_done_suppressed_for_image_generation_call() {
-        // R6.7b: OpenAI cloud passthrough emits the `image_generation_call`
-        // item directly — the umbrella `output_item.done` that upstream
-        // sends before `response.image_generation_call.completed` must be
-        // suppressed so the tool loop's umbrella lands at the right spot
-        // (see PR #1365 CI failure: `completed` at index 9, `output_item.done`
-        // at index 3).
+        // OpenAI cloud passthrough emits the `image_generation_call` item
+        // directly — the umbrella `output_item.done` that upstream sends
+        // before `response.image_generation_call.completed` must be
+        // suppressed so the tool loop's umbrella lands at the right spot.
         assert_output_item_done_suppressed_for_hosted_tool(ItemType::IMAGE_GENERATION_CALL);
     }
 
     #[test]
     fn output_item_done_suppressed_for_web_search_call() {
-        // R6.7b: hosted `web_search_call` items emitted directly by
-        // upstream must also trigger suppression — the tool loop emits
+        // Hosted `web_search_call` items emitted directly by upstream
+        // must also trigger suppression — the tool loop emits
         // `response.web_search_call.completed` followed by its own
         // `output_item.done` at the correct position.
         assert_output_item_done_suppressed_for_hosted_tool(ItemType::WEB_SEARCH_CALL);
@@ -581,30 +577,29 @@ mod tests {
 
     #[test]
     fn output_item_done_suppressed_for_code_interpreter_call() {
-        // R6.7b: hosted `code_interpreter_call` items share the ordering
+        // Hosted `code_interpreter_call` items share the ordering
         // contract with the other tool-call item types.
         assert_output_item_done_suppressed_for_hosted_tool(ItemType::CODE_INTERPRETER_CALL);
     }
 
     #[test]
     fn output_item_done_suppressed_for_file_search_call() {
-        // R6.7b: hosted `file_search_call` items share the ordering
-        // contract with the other tool-call item types.
+        // Hosted `file_search_call` items share the ordering contract
+        // with the other tool-call item types.
         assert_output_item_done_suppressed_for_hosted_tool(ItemType::FILE_SEARCH_CALL);
     }
 
     #[test]
     fn output_item_done_for_unregistered_hosted_tool_output_index_forwards() {
-        // R6.7b Claude-review follow-up: the gate must also match the
-        // done event's `output_index` to a pending call. Without this
-        // guard a mixed stream where a function_call (intercepted) and
-        // a native hosted-tool item (NOT intercepted because
-        // `handle_output_item_added` only registers function_call
-        // types) live at different output indices would see the
-        // hosted-tool's `output_item.done` incorrectly suppressed —
-        // and the tool loop only re-emits umbrellas for items it
-        // actually executed, so the hosted-tool's umbrella would be
-        // permanently lost from the wire.
+        // The gate must also match the done event's `output_index` to a
+        // pending call. Without this guard a mixed stream where a
+        // function_call (intercepted) and a native hosted-tool item
+        // (NOT intercepted because `handle_output_item_added` only
+        // registers function_call types) live at different output
+        // indices would see the hosted-tool's `output_item.done`
+        // incorrectly suppressed — and the tool loop only re-emits
+        // umbrellas for items it actually executed, so the hosted-tool's
+        // umbrella would be permanently lost from the wire.
         let mut handler = StreamingToolHandler::with_starting_index(0);
         // Pending function_call at output_index 0.
         bootstrap_function_call_added(&mut handler);

--- a/model_gateway/src/routers/openai/mcp/tool_loop.rs
+++ b/model_gateway/src/routers/openai/mcp/tool_loop.rs
@@ -1579,7 +1579,7 @@ mod tests {
     }
 
     // ========================================================================
-    // R6.7 Gap B — streaming emission ordering invariant.
+    // Streaming emission ordering invariant.
     //
     // `send_tool_call_completion_events` MUST emit
     // `response.<tool>.completed` BEFORE `response.output_item.done` so the
@@ -1723,13 +1723,13 @@ mod tests {
 
     #[test]
     fn code_interpreter_completion_events_fire_before_output_item_done() {
-        // R6.7b companion: the suppression gate in `tool_handler.rs` drops
-        // the upstream umbrella `output_item.done` for every tool-call
-        // item type. This test locks the downstream half of the contract
-        // for `code_interpreter_call` — the tool loop's completion
-        // emitter must push `response.code_interpreter_call.completed`
-        // BEFORE `response.output_item.done` so the gate's suppression
-        // lines up with a correctly-ordered wire sequence.
+        // The suppression gate in `tool_handler.rs` drops the upstream
+        // umbrella `output_item.done` for every tool-call item type. This
+        // test locks the downstream half of the contract for
+        // `code_interpreter_call` — the tool loop's completion emitter
+        // must push `response.code_interpreter_call.completed` BEFORE
+        // `response.output_item.done` so the gate's suppression lines up
+        // with a correctly-ordered wire sequence.
         let call = super::FunctionCallInProgress {
             call_id: "call_ci".to_string(),
             name: "code_interpreter".to_string(),
@@ -1781,7 +1781,8 @@ mod tests {
         );
 
         // No duplicate `output_item.done` — the tool loop emits exactly
-        // one umbrella (the R6.7b gate drops the upstream copy).
+        // one umbrella (the upstream copy is dropped by the suppression
+        // gate in `tool_handler.rs`).
         let done_count = types
             .iter()
             .filter(|t| *t == "response.output_item.done")
@@ -1794,10 +1795,9 @@ mod tests {
 
     #[test]
     fn file_search_completion_events_fire_before_output_item_done() {
-        // R6.7b companion: lock the ordering contract for the remaining
-        // hosted `file_search_call` format so the gate's suppression
-        // covers every tool-call item type listed in
-        // `TOOL_CALL_ITEM_TYPES`.
+        // Lock the ordering contract for the hosted `file_search_call`
+        // format so the gate's suppression covers every tool-call item
+        // type listed in `TOOL_CALL_ITEM_TYPES`.
         let call = super::FunctionCallInProgress {
             call_id: "call_fs".to_string(),
             name: "file_search".to_string(),
@@ -1849,7 +1849,8 @@ mod tests {
         );
 
         // No duplicate `output_item.done` — the tool loop emits exactly
-        // one umbrella (the R6.7b gate drops the upstream copy).
+        // one umbrella (the upstream copy is dropped by the suppression
+        // gate in `tool_handler.rs`).
         let done_count = types
             .iter()
             .filter(|t| *t == "response.output_item.done")


### PR DESCRIPTION
## Summary

Pure comment hygiene across 11 R6.x-touched files in \`crates/mcp/\` and \`model_gateway/src/routers/\`. Mirrors C2 (#1310) which did the same for \`crates/protocols/src/\` after the Wave-1/2 protocol surface additions.

## Rules applied

**KEEP**: spec references citing file/line or SDK path; per-field \`///\` docs; \`SAFETY:\` / \`NOTE:\` invariants; design-intent prose.

**DROP**: \`R6.x:\` task markers; per-cycle review narrative; "per coordinator" / "flagged for follow-up" / "per audit" references; "Before R6.8 this did X" historical comparisons now that the PR landed.

**PRUNE**: multi-paragraph doc blocks where one paragraph is signal and the rest is audit narrative.

## Acceptance

\`\`\`
$ grep -rnE 'R6\.[0-9]' crates/mcp/src/ model_gateway/src/
(no output)

$ grep -rnE 'per coordinator|per audit|per follow-up|cycle-?[12]|Addresses.*bot-review' \\
    crates/mcp/src/ model_gateway/src/
(no output)
\`\`\`

- No changes to any declared \`pub\` item, field, enum variant, \`#[serde(…)]\` attribute, function signature/body, test, or macro. Pure comment edits.
- \`cargo check -p openai-protocol -p smg-mcp -p smg --lib --tests --benches\` green.
- \`cargo clippy -p openai-protocol -p smg-mcp -p smg --lib --tests --benches -- -D warnings\` green.
- \`cargo fmt --all\` clean.

## Files edited (11)

- \`crates/mcp/src/transform/transformer.rs\`
- \`model_gateway/src/routers/common/mcp_utils.rs\`
- \`model_gateway/src/routers/grpc/common/responses/{streaming,utils}.rs\`
- \`model_gateway/src/routers/grpc/harmony/builder.rs\`
- \`model_gateway/src/routers/grpc/harmony/responses/{common,non_streaming,streaming}.rs\`
- \`model_gateway/src/routers/grpc/regular/responses/conversions.rs\`
- \`model_gateway/src/routers/openai/mcp/{tool_handler,tool_loop}.rs\`

Net line delta: −4 lines (pruning rewrites some prose around cut lines).

## Test plan

Comment-only change. Full cargo build / test / clippy / fmt verified locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated inline documentation and test comments across routing and response handling modules to remove outdated version references and reworded explanatory notes for improved clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->