### PR TITLE
fix(helm): add clusterWide flag for opt-in cluster-scoped service discovery

### DIFF
--- a/deploy/helm/smg/templates/_helpers.tpl
+++ b/deploy/helm/smg/templates/_helpers.tpl
@@ -141,8 +141,10 @@ Called from the router Deployment template.
 {{- end }}
 - "--service-discovery-port"
 - {{ .Values.router.serviceDiscovery.port | quote }}
+{{- if not .Values.router.serviceDiscovery.clusterWide }}
 - "--service-discovery-namespace"
 - {{ .Values.router.serviceDiscovery.namespace | default .Release.Namespace | quote }}
+{{- end }}
 {{- if .Values.router.serviceDiscovery.modelIdFrom }}
 - "--model-id-from"
 - {{ .Values.router.serviceDiscovery.modelIdFrom | quote }}

--- a/deploy/helm/smg/templates/role.yaml
+++ b/deploy/helm/smg/templates/role.yaml
@@ -1,6 +1,10 @@
 {{- if or .Values.rbac.create .Values.router.serviceDiscovery.enabled .Values.router.mesh.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
+{{- if .Values.router.serviceDiscovery.clusterWide }}
+kind: ClusterRole
+{{- else }}
 kind: Role
+{{- end }}
 metadata:
   name: {{ include "smg.fullname" . }}
   labels:
@@ -8,5 +12,5 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["pods"]
-    verbs: ["list", "watch"]
+    verbs: ["get", "list", "watch"]
 {{- end }}

--- a/deploy/helm/smg/templates/rolebinding.yaml
+++ b/deploy/helm/smg/templates/rolebinding.yaml
@@ -1,13 +1,21 @@
 {{- if or .Values.rbac.create .Values.router.serviceDiscovery.enabled .Values.router.mesh.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
+{{- if .Values.router.serviceDiscovery.clusterWide }}
+kind: ClusterRoleBinding
+{{- else }}
 kind: RoleBinding
+{{- end }}
 metadata:
   name: {{ include "smg.fullname" . }}
   labels:
     {{- include "smg.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
+  {{- if .Values.router.serviceDiscovery.clusterWide }}
+  kind: ClusterRole
+  {{- else }}
   kind: Role
+  {{- end }}
   name: {{ include "smg.fullname" . }}
 subjects:
   - kind: ServiceAccount

--- a/deploy/helm/smg/values.yaml
+++ b/deploy/helm/smg/values.yaml
@@ -39,6 +39,7 @@ router:
   # -- Kubernetes service discovery (auto-discover worker pods by label)
   serviceDiscovery:
     enabled: false
+    clusterWide: false     # set true to watch all namespaces (requires ClusterRole/ClusterRoleBinding)
     namespace: ""          # defaults to release namespace
     selector: ""           # e.g. "app=sglang-worker"
     port: 80


### PR DESCRIPTION
## Description

### Problem
When `router.serviceDiscovery.enabled=true`, the chart always passed `--service-discovery-namespace`, defaulting to the Helm release namespace. This prevented SMG from discovering predictor pods running in other namespaces.

Additionally, the chart only rendered a namespaced `Role`/`RoleBinding`, which does not grant permissions outside the release namespace, and the router service account permissions were also missing the `get` verb.

### Solution

Added an explicit `router.serviceDiscovery.clusterWide` opt-in flag (default: `false`).

- When `false`, SMG watches only the Helm release namespace using a namespaced `Role`/`RoleBinding`, which is safer for standard multi-tenant deployments.
- When `true`, the chart omits `--service-discovery-namespace`, allowing SMG to internally use `Api::all()` for cluster-wide discovery. In this mode, the chart also renders a `ClusterRole`/`ClusterRoleBinding` to grant the router service account the required cluster-wide pod watch permissions.


## Changes

- **`values.yaml`**: Added `router.serviceDiscovery.clusterWide: false`
- **`_helpers.tpl`**: Omit `--service-discovery-namespace` when `clusterWide=true`; otherwise pass the configured namespace, defaulting to the Helm release namespace
- **`role.yaml`**: Render a `ClusterRole` when `clusterWide=true`, otherwise render a namespaced `Role`; also add the missing `get` verb to pod permissions
- **`rolebinding.yaml`**: Render either a `ClusterRoleBinding` or `RoleBinding`, with the corresponding `roleRef.kind`, based on the value of `clusterWide`


## Test Plan

<!-- Provide a thorough reproducible test showing before and after behavior. -->

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [x] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
