### PR TITLE
fix(tokenizer): plumb tools, thinking introspection, and V3.2 iteration for DeepSeek encoders

### DIFF
--- a/crates/tokenizer/src/encoders/deepseek_v32.rs
+++ b/crates/tokenizer/src/encoders/deepseek_v32.rs
@@ -499,7 +499,7 @@ pub fn encode_messages(
         full_messages = drop_thinking_messages(&full_messages);
     }
 
-    for idx in 0..messages.len() {
+    for idx in 0..full_messages.len() {
         prompt.push_str(&render_message(idx, &full_messages, thinking_mode)?);
     }
 
@@ -634,5 +634,23 @@ mod tests {
         let out = encode_messages(&msgs, ThinkingMode::Chat, &params).unwrap();
         assert!(!out.starts_with(BOS_TOKEN));
         assert!(out.starts_with(USER_PREFIX));
+    }
+
+    #[test]
+    fn drop_thinking_does_not_overrun_when_filtering_shrinks_messages() {
+        // `drop_thinking_messages` removes developer-role messages before the
+        // last user turn, so `full_messages.len() < messages.len()`. The
+        // outer loop must iterate the filtered length, not the original, or
+        // it walks off the end and returns IndexOutOfRange.
+        let msgs = [
+            json!({ "role": "developer", "content": "earlier developer note" }),
+            json!({ "role": "user", "content": "now" }),
+        ];
+        let out = encode_messages(&msgs, ThinkingMode::Thinking, &EncodeParams::default())
+            .expect("filtered message length must not blow up the loop");
+        assert!(
+            out.contains("now"),
+            "user message missing from prompt: {out}"
+        );
     }
 }

--- a/crates/tokenizer/src/huggingface.rs
+++ b/crates/tokenizer/src/huggingface.rs
@@ -486,24 +486,16 @@ fn detect_renderer_from_config(dir: &std::path::Path) -> Renderer {
 // ---------------------------------------------------------------------------
 // DeepSeek V3.2 / V4 dispatch shims
 // ---------------------------------------------------------------------------
-/// Derive the V3.2 / V4 thinking mode from `template_kwargs`.
-///
-/// Mirrors vllm's `vllm/tokenizers/deepseek_v32.py`: thinking is ON if
-/// either `thinking` or `enable_thinking` is truthy in the kwargs map.
+/// Derive the V3.2 / V4 thinking mode from `template_kwargs`. Only the
+/// `thinking` key is honored, matching sglang's DeepSeek serving path and
+/// the `ThinkingKeyName::Thinking` contract reported by this tokenizer.
 fn derive_thinking_mode(params: &ChatTemplateParams) -> deepseek_v32::ThinkingMode {
-    let kwargs = match params.template_kwargs {
-        Some(k) => k,
-        None => return deepseek_v32::ThinkingMode::Chat,
-    };
-    let thinking = kwargs
-        .get("thinking")
+    let enabled = params
+        .template_kwargs
+        .and_then(|k| k.get("thinking"))
         .and_then(serde_json::Value::as_bool)
         .unwrap_or(false);
-    let enable_thinking = kwargs
-        .get("enable_thinking")
-        .and_then(serde_json::Value::as_bool)
-        .unwrap_or(false);
-    if thinking || enable_thinking {
+    if enabled {
         deepseek_v32::ThinkingMode::Thinking
     } else {
         deepseek_v32::ThinkingMode::Chat

--- a/crates/tokenizer/src/huggingface.rs
+++ b/crates/tokenizer/src/huggingface.rs
@@ -412,14 +412,29 @@ impl TokenizerTrait for HuggingFaceTokenizer {
     }
 
     fn thinking_toggle(&self) -> ThinkingToggle {
-        self.chat_template.thinking_toggle()
+        match self.renderer {
+            // DeepSeek V3.2 and V4 encoders gate thinking on the `thinking`
+            // kwarg, default off. The Jinja processor has no knowledge of
+            // the native encoder so we must report it directly.
+            Renderer::DeepseekV32 | Renderer::DeepseekV4 => ThinkingToggle::DefaultOff,
+            Renderer::Jinja => self.chat_template.thinking_toggle(),
+        }
     }
 
     fn thinking_key_name(&self) -> Option<ThinkingKeyName> {
-        self.chat_template.thinking_key_name()
+        match self.renderer {
+            Renderer::DeepseekV32 | Renderer::DeepseekV4 => Some(ThinkingKeyName::Thinking),
+            Renderer::Jinja => self.chat_template.thinking_key_name(),
+        }
     }
     fn think_in_prefill(&self) -> bool {
-        self.chat_template.think_in_prefill()
+        match self.renderer {
+            // Both encoders emit `<｜Assistant｜><think>` at the end of the
+            // prompt when thinking mode is on; the completion therefore starts
+            // mid-reasoning and the parser must be told so.
+            Renderer::DeepseekV32 | Renderer::DeepseekV4 => true,
+            Renderer::Jinja => self.chat_template.think_in_prefill(),
+        }
     }
 
     fn set_chat_template(&mut self, template: String) -> Result<()> {
@@ -506,22 +521,53 @@ fn resolve_drop_thinking(messages: &[serde_json::Value]) -> bool {
                 .is_some_and(|arr| !arr.is_empty())
     })
 }
+/// Attach `tools` to a leading system/developer message so the V3.2/V4
+/// encoder can render the tools block. Mirrors the wrapper step in
+/// vllm's `vllm/tokenizers/deepseek_v32.py` and sglang's V4 serving path.
+/// Returns `None` when no rewrite is needed so callers can pass the input
+/// slice directly in the common path.
+fn inject_tools_into_messages(
+    messages: &[serde_json::Value],
+    tools: Option<&[serde_json::Value]>,
+) -> Option<Vec<serde_json::Value>> {
+    let tools = tools?;
+    if tools.is_empty() {
+        return None;
+    }
+    let mut owned: Vec<serde_json::Value> = messages.to_vec();
+    let first_role = owned
+        .first()
+        .and_then(|m| m.get("role"))
+        .and_then(|r| r.as_str());
+    if !matches!(first_role, Some("system" | "developer")) {
+        owned.insert(0, serde_json::json!({ "role": "system", "content": "" }));
+    }
+    if let Some(obj) = owned[0].as_object_mut() {
+        obj.insert("tools".into(), serde_json::Value::Array(tools.to_vec()));
+    }
+    Some(owned)
+}
+
 fn apply_deepseek_v32(
     messages: &[serde_json::Value],
     params: &ChatTemplateParams,
 ) -> Result<String> {
+    let owned = inject_tools_into_messages(messages, params.tools);
+    let msgs: &[serde_json::Value] = owned.as_deref().unwrap_or(messages);
     let thinking_mode = derive_thinking_mode(params);
     let encode_params = deepseek_v32::EncodeParams {
         add_default_bos_token: true,
-        drop_thinking: resolve_drop_thinking(messages),
+        drop_thinking: resolve_drop_thinking(msgs),
     };
-    deepseek_v32::encode_messages(messages, thinking_mode, &encode_params)
+    deepseek_v32::encode_messages(msgs, thinking_mode, &encode_params)
         .map_err(|e| Error::msg(format!("DeepSeek V3.2 encode failed: {e}")))
 }
 fn apply_deepseek_v4(
     messages: &[serde_json::Value],
     params: &ChatTemplateParams,
 ) -> Result<String> {
+    let owned = inject_tools_into_messages(messages, params.tools);
+    let msgs: &[serde_json::Value] = owned.as_deref().unwrap_or(messages);
     let thinking_mode = derive_thinking_mode(params);
     let reasoning_effort = params
         .template_kwargs
@@ -534,9 +580,9 @@ fn apply_deepseek_v4(
         });
     let encode_params = deepseek_v4::EncodeParams {
         add_default_bos_token: true,
-        drop_thinking: resolve_drop_thinking(messages),
+        drop_thinking: resolve_drop_thinking(msgs),
         reasoning_effort,
     };
-    deepseek_v4::encode_messages(messages, thinking_mode, &encode_params)
+    deepseek_v4::encode_messages(msgs, thinking_mode, &encode_params)
         .map_err(|e| Error::msg(format!("DeepSeek V4 encode failed: {e}")))
 }

--- a/crates/tokenizer/tests/deepseek_renderer_detection.rs
+++ b/crates/tokenizer/tests/deepseek_renderer_detection.rs
@@ -5,7 +5,9 @@ mod tests {
     use std::{collections::HashMap, fs};
 
     use llm_tokenizer::{
-        chat_template::ChatTemplateParams, huggingface::HuggingFaceTokenizer, TokenizerTrait,
+        chat_template::{ChatTemplateParams, ThinkingKeyName, ThinkingToggle},
+        huggingface::HuggingFaceTokenizer,
+        TokenizerTrait,
     };
     use serde_json::json;
     use tempfile::TempDir;
@@ -108,6 +110,117 @@ mod tests {
         let result = tokenizer.apply_chat_template(&messages, ChatTemplateParams::default());
         assert!(result.is_err());
     }
+    #[test]
+    fn deepseek_v4_injects_tools_into_system_message() {
+        // Client passes tools at the request level (params.tools), not embedded
+        // in messages. The shim must attach them to a system message so the
+        // encoder renders the tools block.
+        let (_tmp, tok) = write_dir(Some(&["DeepseekV4ForCausalLM"]));
+        let tokenizer = HuggingFaceTokenizer::from_file(&tok).unwrap();
+        let messages = vec![json!({ "role": "user", "content": "Hello" })];
+        let tools = vec![json!({
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get weather",
+                "parameters": {
+                    "type": "object",
+                    "properties": { "city": { "type": "string" } },
+                    "required": ["city"]
+                }
+            }
+        })];
+        let params = ChatTemplateParams {
+            tools: Some(&tools),
+            ..Default::default()
+        };
+        let out = tokenizer.apply_chat_template(&messages, params).unwrap();
+        assert!(out.contains("## Tools"), "tools block missing: {out}");
+        assert!(
+            out.contains("get_weather"),
+            "tool name missing from prompt: {out}"
+        );
+        assert!(
+            out.contains("<\u{FF5C}DSML\u{FF5C}tool_calls>"),
+            "V4 DSML invocation grammar missing: {out}"
+        );
+    }
+
+    #[test]
+    fn deepseek_v32_injects_tools_into_system_message() {
+        let (_tmp, tok) = write_dir(Some(&["DeepseekV32ForCausalLM"]));
+        let tokenizer = HuggingFaceTokenizer::from_file(&tok).unwrap();
+        let messages = vec![json!({ "role": "user", "content": "Hi" })];
+        let tools = vec![json!({
+            "type": "function",
+            "function": { "name": "ping", "description": "ping", "parameters": {} }
+        })];
+        let params = ChatTemplateParams {
+            tools: Some(&tools),
+            ..Default::default()
+        };
+        let out = tokenizer.apply_chat_template(&messages, params).unwrap();
+        assert!(out.contains("## Tools"), "tools block missing: {out}");
+        assert!(out.contains("ping"), "tool name missing: {out}");
+        // V3.2 uses function_calls (vs V4's tool_calls).
+        assert!(
+            out.contains("<\u{FF5C}DSML\u{FF5C}function_calls>"),
+            "V3.2 DSML invocation grammar missing: {out}"
+        );
+    }
+
+    #[test]
+    fn deepseek_v4_attaches_tools_to_existing_system_message() {
+        // When a system message is already present, tools should attach to it
+        // rather than inserting a second system block.
+        let (_tmp, tok) = write_dir(Some(&["DeepseekV4ForCausalLM"]));
+        let tokenizer = HuggingFaceTokenizer::from_file(&tok).unwrap();
+        let messages = vec![
+            json!({ "role": "system", "content": "Be concise." }),
+            json!({ "role": "user", "content": "Hi" }),
+        ];
+        let tools = vec![json!({
+            "type": "function",
+            "function": { "name": "ping", "description": "ping", "parameters": {} }
+        })];
+        let params = ChatTemplateParams {
+            tools: Some(&tools),
+            ..Default::default()
+        };
+        let out = tokenizer.apply_chat_template(&messages, params).unwrap();
+        assert!(
+            out.contains("Be concise."),
+            "existing system content lost: {out}"
+        );
+        assert!(out.contains("ping"), "tool not attached: {out}");
+    }
+
+    #[test]
+    fn deepseek_renderers_report_thinking_introspection() {
+        // V3.2 / V4 inject `<think>` in the prefill when thinking is on, and
+        // gate thinking on the `thinking` kwarg. The trait methods must
+        // surface this so the gateway can call `mark_reasoning_started` on
+        // the conditional reasoning parser (deepseek_v31 etc).
+        for arch in &["DeepseekV32ForCausalLM", "DeepseekV4ForCausalLM"] {
+            let (_tmp, tok) = write_dir(Some(&[*arch]));
+            let tokenizer = HuggingFaceTokenizer::from_file(&tok).unwrap();
+            assert_eq!(
+                tokenizer.thinking_toggle(),
+                ThinkingToggle::DefaultOff,
+                "{arch}: expected DefaultOff toggle"
+            );
+            assert_eq!(
+                tokenizer.thinking_key_name(),
+                Some(ThinkingKeyName::Thinking),
+                "{arch}: expected Thinking key name"
+            );
+            assert!(
+                tokenizer.think_in_prefill(),
+                "{arch}: expected think_in_prefill=true"
+            );
+        }
+    }
+
     #[test]
     fn deepseek_v4_renderer_passes_reasoning_effort() {
         let (_tmp, tok) = write_dir(Some(&["DeepseekV4ForCausalLM"]));

--- a/crates/tokenizer/tests/deepseek_renderer_detection.rs
+++ b/crates/tokenizer/tests/deepseek_renderer_detection.rs
@@ -222,6 +222,51 @@ mod tests {
     }
 
     #[test]
+    fn deepseek_renderers_honor_thinking_kwarg_only() {
+        // `thinking: true` → prompt ends with <think> (thinking mode).
+        // `enable_thinking: true` alone → ignored (chat mode), matching
+        // `thinking_key_name() == Some(Thinking)` and sglang's DeepSeek path.
+        for arch in &["DeepseekV32ForCausalLM", "DeepseekV4ForCausalLM"] {
+            let (_tmp, tok) = write_dir(Some(&[*arch]));
+            let tokenizer = HuggingFaceTokenizer::from_file(&tok).unwrap();
+            let messages = vec![json!({ "role": "user", "content": "Hi" })];
+
+            let mut thinking_kwargs: HashMap<String, serde_json::Value> = HashMap::new();
+            thinking_kwargs.insert("thinking".to_string(), serde_json::Value::Bool(true));
+            let out_thinking = tokenizer
+                .apply_chat_template(
+                    &messages,
+                    ChatTemplateParams {
+                        template_kwargs: Some(&thinking_kwargs),
+                        ..Default::default()
+                    },
+                )
+                .unwrap();
+            assert!(
+                out_thinking.ends_with("<think>"),
+                "{arch}: thinking=true should enter thinking mode: {out_thinking}"
+            );
+
+            let mut enable_thinking_kwargs: HashMap<String, serde_json::Value> = HashMap::new();
+            enable_thinking_kwargs
+                .insert("enable_thinking".to_string(), serde_json::Value::Bool(true));
+            let out_enable = tokenizer
+                .apply_chat_template(
+                    &messages,
+                    ChatTemplateParams {
+                        template_kwargs: Some(&enable_thinking_kwargs),
+                        ..Default::default()
+                    },
+                )
+                .unwrap();
+            assert!(
+                out_enable.ends_with("</think>"),
+                "{arch}: enable_thinking alone must NOT enter thinking mode: {out_enable}"
+            );
+        }
+    }
+
+    #[test]
     fn deepseek_v4_renderer_passes_reasoning_effort() {
         let (_tmp, tok) = write_dir(Some(&["DeepseekV4ForCausalLM"]));
         let tokenizer = HuggingFaceTokenizer::from_file(&tok).unwrap();


### PR DESCRIPTION
## Description

### Problem

Three independent defects in the DeepSeek V3.2 / V4 chat-template renderers that landed in #1373. All three are observable against a real DeepSeek-V4-Flash backend by the gateway invocation:

```
cargo run --bin smg -- --host 0.0.0.0 --port 3002 --worker-urls grpc://127.0.0.1:8080 \
  --tool-call-parser deepseek_v4 --reasoning-parser deepseek_v31 --log-level info
```

with a client request that sends `tools=[…]` and `chat_template_kwargs={"thinking": true}`.

1. **Tools never reach the encoder.** `apply_deepseek_v32` / `apply_deepseek_v4` in `crates/tokenizer/src/huggingface.rs` discard `params.tools` and forward `messages` unchanged to `encode_messages`. The encoder reads `tools` from `msg.get("tools")` on a leading system/developer message (`crates/tokenizer/src/encoders/deepseek_v4.rs:242`), so it sees nothing. The model replies "I don't see any tools listed."

2. **Reasoning parser never receives the prefill signal.** `HuggingFaceTokenizer::{thinking_toggle, thinking_key_name, think_in_prefill}` delegate unconditionally to the Jinja chat-template processor, which has no knowledge of the DeepSeek encoders. The gateway's `should_mark_reasoning_started` therefore stays `false`, and the conditional `deepseek_v31` parser never enters reasoning mode. The entire `<think>…</think>` block leaks into `message.content` (with a literal `</think>` embedded) while `reasoning_content` stays `None`.

3. **V3.2 iteration can overrun.** `encoders/deepseek_v32.rs::encode_messages` iterates `0..messages.len()` (original count) but indexes into `full_messages` (post-`drop_thinking_messages`). When developer messages before the last user turn get filtered out the indexing walks off the end and returns `IndexOutOfRange`. Same bug exists in the upstream Python. Flagged in #1373 review by coderabbit ([comment](https://github.com/lightseekorg/smg/pull/1373#discussion_r3135534112)).

### Solution

1. Add `inject_tools_into_messages` helper. When `params.tools` is non-empty, ensure a leading system/developer message (insert an empty one if none) and attach the tools array to it. Mirrors vllm's `vllm/tokenizers/deepseek_v32.py:41-43` wrapper and sglang's V4 serving path (sgl/deepseek_v4 branch, `serving_chat.py:486`). The helper returns `None` when no rewrite is needed so the common non-tool path skips all cloning.

2. Override `thinking_toggle` / `thinking_key_name` / `think_in_prefill` on the `TokenizerTrait` impl to branch on `self.renderer`. For `Renderer::DeepseekV32 | DeepseekV4` report `DefaultOff` / `Some(Thinking)` / `true`. The Jinja branch keeps delegating unchanged, preserving behavior for every other model.

3. Change the V3.2 encoder loop to iterate `0..full_messages.len()`, matching the V4 encoder's existing loop at `encoders/deepseek_v4.rs:659`.

## Changes

- `crates/tokenizer/src/huggingface.rs`: `inject_tools_into_messages` helper; three overridden trait methods; both `apply_deepseek_*` shims consume the helper before calling into the encoder.
- `crates/tokenizer/src/encoders/deepseek_v32.rs`: loop iterates the filtered length, not the original input length.
- `crates/tokenizer/tests/deepseek_renderer_detection.rs`: four new integration tests covering V32 tool injection, V4 tool injection, existing-system-message reuse, and the trait-method introspection contract for DeepSeek renderers.
- `crates/tokenizer/src/encoders/deepseek_v32.rs` (tests): regression test for the iteration bug — a conversation with a pre-last-user developer message no longer panics.

## Test Plan

- `cargo test -p llm-tokenizer` — 14 encoder unit tests + 10 integration tests pass.
- `cargo +nightly fmt` — clean.
- `cargo clippy -p llm-tokenizer --all-targets --all-features -- -D warnings` — clean.
- Manual: re-run the reproduction in `Problem` against a live DeepSeek-V4-Flash worker and confirm:
  - Prompt contains the `## Tools` block and each tool name.
  - Response populates `reasoning_content` and strips `</think>` from `content`.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed out-of-range indexing when filtering messages during prompt rendering.

* **New Features**
  * Added preprocessing to inject tool definitions into messages for DeepSeek V3.2/V4 so tools render correctly.
  * Standardized thinking-related metadata reporting and ensured only the explicit thinking flag triggers think behavior.

* **Tests**
  * Added regression test for message-filtering shrink scenario.
  * Added tests for tool rendering and thinking metadata across DeepSeek variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Live verification

Running SMG with the fix applied against a live DeepSeek-V4-Flash sglang backend:

```
cargo run --bin smg -- --host 0.0.0.0 --port 3002 --prometheus-port 9322 \
  --worker-urls grpc://127.0.0.1:8080 --log-level info \
  --tool-call-parser deepseek_v4 --reasoning-parser deepseek_v31
```

<details>
<summary>Repro script and response</summary>

```python
from openai import OpenAI

client = OpenAI(base_url="http://localhost:3002/v1", api_key="test_api_key")

tools = [
    {"type": "function", "function": {
        "name": "sub",
        "description": "Compute the difference of two integers",
        "parameters": {
            "type": "object",
            "properties": {
                "int_a": {"type": "integer"}, "int_b": {"type": "integer"},
            },
            "required": ["int_a", "int_b"],
        },
    }},
    {"type": "function", "function": {
        "name": "get_weather",
        "description": "Get latest weather for a city given its name",
        "parameters": {
            "type": "object",
            "properties": {"city": {"type": "string"}},
            "required": ["city"],
        },
    }},
]

response = client.chat.completions.create(
    model="deepseek-ai/DeepSeek-V4-Flash",
    messages=[{"role": "user", "content": "What is the weather in New York? Also, what is 15 minus 7?"}],
    tools=tools,
    temperature=0,
    max_tokens=1000,
    reasoning_effort="high",
    extra_body={"chat_template_kwargs": {"thinking": True}},
)
print(response)
```

Response (post-fix):

```text
ChatCompletion(
  id='chatcmpl-…',
  choices=[Choice(
    finish_reason='tool_calls',
    message=ChatCompletionMessage(
      content=None,
      role='assistant',
      tool_calls=[
        ToolCall(function=Function(name='get_weather', arguments='{"city":"New York"}'), …),
        ToolCall(function=Function(name='sub',         arguments='{"int_a":15,"int_b":7}'), …),
      ],
      reasoning_content="The user is asking two things:\n1. The weather in New York - I can use the get_weather tool\n2. What is 15 minus 7 - I can use the sub tool\n\nLet me make both calls simultaneously since they're independent.",
    ),
  )],
  usage=CompletionUsage(completion_tokens=146, prompt_tokens=371, total_tokens=517),
)
```

Three things to observe:

1. `tool_calls` is populated with both tools (fix — tools now reach the encoder).
2. `reasoning_content` is a clean string; `content` is `None` with no stray `</think>` (fix — parser received the prefill-started signal).
3. `finish_reason='tool_calls'` and the parser emits well-formed function-call objects.

Pre-fix behavior on the same request: `tool_calls=None`, `content` contained the entire reasoning block plus the literal text "I don't see any tools listed", and `reasoning_content=None`.

</details>
