### PR TITLE
feat(protocols): implement T10 tool_search hosted/client-executed tool

### DIFF
--- a/crates/protocols/src/responses.rs
+++ b/crates/protocols/src/responses.rs
@@ -450,6 +450,78 @@ pub enum ResponseTool {
     /// matching `local_shell_call_output` item.
     #[serde(rename = "local_shell")]
     LocalShell,
+
+    /// Hosted / client-executed `tool_search` tool — `{ type: "tool_search",
+    /// description?, execution?, parameters? }`.
+    ///
+    /// Spec (openai-responses-api-spec.md §tools L476): `ToolSearch { type:
+    /// "tool_search", description?, execution?: "server"|"client",
+    /// parameters? }`. The tool lets the model discover additional tool
+    /// definitions at inference time; `execution` controls whether the
+    /// platform (`server`) or the calling client (`client`) runs the
+    /// lookup. The model emits a matching [`ResponseInputOutputItem::ToolSearchCall`]
+    /// carrying the query payload, and the resolver replies with
+    /// [`ResponseInputOutputItem::ToolSearchOutput`] carrying the discovered
+    /// tool set (a recursive use of the full [`ResponseTool`] union).
+    #[serde(rename = "tool_search")]
+    ToolSearch(ToolSearchTool),
+}
+
+/// Payload carried by [`ResponseTool::ToolSearch`].
+///
+/// All three fields are optional per spec (openai-responses-api-spec.md
+/// §tools L476). `execution` is pinned to [`ToolSearchExecution`] so
+/// unknown values fail closed rather than silently degrading to default
+/// behaviour; `parameters` is kept as an opaque [`serde_json::Value`] so
+/// arbitrary search-parameter schemas (string queries, filters, etc.) pass
+/// through unchanged — mirroring the spec wording of `parameters?: any`.
+#[serde_with::skip_serializing_none]
+#[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ToolSearchTool {
+    /// Optional human-readable description surfaced alongside the tool.
+    pub description: Option<String>,
+    /// Optional execution mode — controls whether the platform (`server`)
+    /// or the caller (`client`) resolves the search. Absent ⇒ provider
+    /// default.
+    pub execution: Option<ToolSearchExecution>,
+    /// Opaque parameter payload forwarded to the resolver. Typed as
+    /// [`serde_json::Value`] to match the spec's `parameters?: any`.
+    pub parameters: Option<Value>,
+}
+
+/// Execution surface for [`ToolSearchTool::execution`] /
+/// [`ResponseInputOutputItem::ToolSearchCall::execution`] /
+/// [`ResponseInputOutputItem::ToolSearchOutput::execution`].
+///
+/// Spec (openai-responses-api-spec.md §tools L476 +
+/// §ToolSearchCall L191): `execution: optional "server" | "client"`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, schemars::JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ToolSearchExecution {
+    /// Platform resolves the search upstream of the client.
+    Server,
+    /// Caller resolves the search and replies with discovered tools.
+    Client,
+}
+
+/// Status for [`ResponseInputOutputItem::ToolSearchCall`] /
+/// [`ResponseInputOutputItem::ToolSearchOutput`].
+///
+/// Spec (openai-responses-api-spec.md §ToolSearchCall L188 +
+/// §ToolSearchOutput L193): `status: optional "in_progress" | "completed"
+/// | "incomplete"`. Defined as a dedicated enum (instead of reusing a
+/// sibling like [`ShellCallStatus`]) so doc links and future evolution
+/// stay tied to the tool_search surface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, schemars::JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ToolSearchStatus {
+    /// `in_progress` — the search is still running.
+    InProgress,
+    /// `completed` — the resolver returned a final tool list.
+    Completed,
+    /// `incomplete` — the resolver aborted or failed to complete.
+    Incomplete,
 }
 
 /// Payload carried by [`ResponseTool::Namespace`].
@@ -1931,6 +2003,48 @@ pub enum ResponseInputOutputItem {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         error: Option<String>,
     },
+    /// `type: "tool_search_call"` — emitted when the model invokes the
+    /// hosted / client-executed `tool_search` tool. Spec
+    /// (openai-responses-api-spec.md §ToolSearchCall L188-191):
+    /// `{ arguments, type, id?, call_id?, execution?, status? }`. `arguments`
+    /// is typed as [`serde_json::Value`] to match the spec's
+    /// `arguments: unknown`. `id` / `call_id` / `execution` / `status` are
+    /// modelled as `Option<_>` so newly-minted client-side calls can omit
+    /// them; they are populated on items round-tripped from a previous
+    /// response.
+    #[serde(rename = "tool_search_call")]
+    ToolSearchCall {
+        arguments: Value,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        id: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        call_id: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        execution: Option<ToolSearchExecution>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        status: Option<ToolSearchStatus>,
+    },
+    /// `type: "tool_search_output"` — carries the tool definitions
+    /// discovered by a prior [`Self::ToolSearchCall`]. Spec
+    /// (openai-responses-api-spec.md §ToolSearchOutput L193-195):
+    /// `{ tools, type, id?, call_id?, execution?, status? }`. `tools` is the
+    /// full recursive [`ResponseTool`] union — including `tool_search`
+    /// itself — so discovered tools can themselves surface a `tool_search`
+    /// capability. Optionality of `id` / `call_id` / `execution` / `status`
+    /// mirrors [`Self::ToolSearchCall`] so client-authored replays can omit
+    /// them.
+    #[serde(rename = "tool_search_output")]
+    ToolSearchOutput {
+        tools: Vec<ResponseTool>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        id: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        call_id: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        execution: Option<ToolSearchExecution>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        status: Option<ToolSearchStatus>,
+    },
     #[serde(untagged)]
     SimpleInputMessage {
         content: StringOrContentParts,
@@ -3149,7 +3263,10 @@ impl GenerationRequest for ResponsesRequest {
                         | ResponseInputOutputItem::LocalShellCall { .. }
                         | ResponseInputOutputItem::LocalShellCallOutput { .. }
                         | ResponseInputOutputItem::McpCall { .. }
-                        | ResponseInputOutputItem::McpListTools { .. } => {}
+                        | ResponseInputOutputItem::McpListTools { .. }
+                        // T10 schema-only: forced-cascade arm, no behavior.
+                        | ResponseInputOutputItem::ToolSearchCall { .. }
+                        | ResponseInputOutputItem::ToolSearchOutput { .. } => {}
                     }
                 }
 
@@ -3483,6 +3600,14 @@ fn validate_input_item(item: &ResponseInputOutputItem) -> Result<(), ValidationE
         // error absent) can round-trip cleanly.
         ResponseInputOutputItem::McpCall { .. } => {}
         ResponseInputOutputItem::McpListTools { .. } => {}
+        // T10 schema-only: `tool_search_call` / `tool_search_output` input
+        // items replayed for stateless multi-turn. `arguments` is
+        // `serde_json::Value` (spec: `unknown`) and `tools` is the recursive
+        // `ResponseTool` union, so content-level validation is deferred to
+        // a future R task — mirrors the treatment of `CustomToolCall`
+        // above.
+        ResponseInputOutputItem::ToolSearchCall { .. } => {}
+        ResponseInputOutputItem::ToolSearchOutput { .. } => {}
     }
     Ok(())
 }

--- a/crates/protocols/src/responses.rs
+++ b/crates/protocols/src/responses.rs
@@ -3264,7 +3264,6 @@ impl GenerationRequest for ResponsesRequest {
                         | ResponseInputOutputItem::LocalShellCallOutput { .. }
                         | ResponseInputOutputItem::McpCall { .. }
                         | ResponseInputOutputItem::McpListTools { .. }
-                        // T10 schema-only: forced-cascade arm, no behavior.
                         | ResponseInputOutputItem::ToolSearchCall { .. }
                         | ResponseInputOutputItem::ToolSearchOutput { .. } => {}
                     }
@@ -3600,11 +3599,10 @@ fn validate_input_item(item: &ResponseInputOutputItem) -> Result<(), ValidationE
         // error absent) can round-trip cleanly.
         ResponseInputOutputItem::McpCall { .. } => {}
         ResponseInputOutputItem::McpListTools { .. } => {}
-        // T10 schema-only: `tool_search_call` / `tool_search_output` input
-        // items replayed for stateless multi-turn. `arguments` is
-        // `serde_json::Value` (spec: `unknown`) and `tools` is the recursive
-        // `ResponseTool` union, so content-level validation is deferred to
-        // a future R task — mirrors the treatment of `CustomToolCall`
+        // `tool_search_call.arguments` is `serde_json::Value` (spec:
+        // `unknown`) and `tool_search_output.tools` is the recursive
+        // `ResponseTool` union — content-level validation is deferred to
+        // the router transformer, matching how `CustomToolCall` is handled
         // above.
         ResponseInputOutputItem::ToolSearchCall { .. } => {}
         ResponseInputOutputItem::ToolSearchOutput { .. } => {}

--- a/crates/protocols/tests/responses.rs
+++ b/crates/protocols/tests/responses.rs
@@ -4125,16 +4125,10 @@ fn test_mcp_list_tools_input_item_with_error_round_trip() {
     assert_eq!(serde_json::to_value(&item).expect("serialize"), payload);
 }
 
-// ---------------------------------------------------------------------------
-// T10: `tool_search` hosted / client-executed tool + call / output items
-//
-// Spec refs:
-//   .claude/_audit/openai-responses-api-spec.md L476 (ToolSearch tool),
-//   L188-191 (ToolSearchCall), L193-195 (ToolSearchOutput). `tools` inside
-//   ToolSearchOutput is a recursive use of the full Tool union, so the
-//   output-item test exercises `function`, `mcp`, and a nested
-//   `tool_search` element to pin the recursive surface.
-// ---------------------------------------------------------------------------
+// `tool_search` — hosted and client-executed tool + call / output items.
+// `tools` inside a `tool_search_output` is a recursive use of the full
+// Tool union, so the output-item test exercises `function`, `mcp`, and a
+// nested `tool_search` element to pin the recursive surface.
 
 /// `ResponseTool::ToolSearch` with `execution: "server"` and a non-trivial
 /// `parameters` payload round-trips. Spec

--- a/crates/protocols/tests/responses.rs
+++ b/crates/protocols/tests/responses.rs
@@ -4161,7 +4161,10 @@ fn test_tool_search_tool_server_execution_round_trip() {
                 Some("Discover additional tools at inference time")
             );
             assert_eq!(ts.execution, Some(ToolSearchExecution::Server));
-            let params = ts.parameters.as_ref().expect("parameters should be present");
+            let params = ts
+                .parameters
+                .as_ref()
+                .expect("parameters should be present");
             assert_eq!(params["required"], json!(["query"]));
         }
         other => panic!("expected ResponseTool::ToolSearch, got {other:?}"),
@@ -4194,8 +4197,8 @@ fn test_tool_search_tool_client_execution_round_trip() {
 #[test]
 fn test_tool_search_tool_minimal_round_trip() {
     let payload = json!({"type": "tool_search"});
-    let tool: ResponseTool = serde_json::from_value(payload.clone())
-        .expect("bare tool_search tool should deserialize");
+    let tool: ResponseTool =
+        serde_json::from_value(payload.clone()).expect("bare tool_search tool should deserialize");
     match &tool {
         ResponseTool::ToolSearch(ts) => {
             assert_eq!(ts.description, None);
@@ -4351,10 +4354,7 @@ fn test_tool_search_output_input_item_recursive_tools_round_trip() {
             match &tools[1] {
                 ResponseTool::Mcp(m) => {
                     assert_eq!(m.server_label, "deepwiki");
-                    assert_eq!(
-                        m.server_url.as_deref(),
-                        Some("https://example.invalid/mcp")
-                    );
+                    assert_eq!(m.server_url.as_deref(), Some("https://example.invalid/mcp"));
                 }
                 other => panic!("expected tools[1] = Mcp, got {other:?}"),
             }

--- a/crates/protocols/tests/responses.rs
+++ b/crates/protocols/tests/responses.rs
@@ -4124,3 +4124,294 @@ fn test_mcp_list_tools_input_item_with_error_round_trip() {
 
     assert_eq!(serde_json::to_value(&item).expect("serialize"), payload);
 }
+
+// ---------------------------------------------------------------------------
+// T10: `tool_search` hosted / client-executed tool + call / output items
+//
+// Spec refs:
+//   .claude/_audit/openai-responses-api-spec.md L476 (ToolSearch tool),
+//   L188-191 (ToolSearchCall), L193-195 (ToolSearchOutput). `tools` inside
+//   ToolSearchOutput is a recursive use of the full Tool union, so the
+//   output-item test exercises `function`, `mcp`, and a nested
+//   `tool_search` element to pin the recursive surface.
+// ---------------------------------------------------------------------------
+
+/// `ResponseTool::ToolSearch` with `execution: "server"` and a non-trivial
+/// `parameters` payload round-trips. Spec
+/// (openai-responses-api-spec.md §tools L476): `{ type: "tool_search",
+/// description?, execution?: "server"|"client", parameters? }`.
+#[test]
+fn test_tool_search_tool_server_execution_round_trip() {
+    let payload = json!({
+        "type": "tool_search",
+        "description": "Discover additional tools at inference time",
+        "execution": "server",
+        "parameters": {
+            "type": "object",
+            "properties": {"query": {"type": "string"}},
+            "required": ["query"],
+        },
+    });
+    let tool: ResponseTool = serde_json::from_value(payload.clone())
+        .expect("tool_search tool with server execution should deserialize");
+    match &tool {
+        ResponseTool::ToolSearch(ts) => {
+            assert_eq!(
+                ts.description.as_deref(),
+                Some("Discover additional tools at inference time")
+            );
+            assert_eq!(ts.execution, Some(ToolSearchExecution::Server));
+            let params = ts.parameters.as_ref().expect("parameters should be present");
+            assert_eq!(params["required"], json!(["query"]));
+        }
+        other => panic!("expected ResponseTool::ToolSearch, got {other:?}"),
+    }
+    assert_eq!(serde_json::to_value(&tool).expect("serialize"), payload);
+}
+
+/// `ResponseTool::ToolSearch` with `execution: "client"` round-trips.
+#[test]
+fn test_tool_search_tool_client_execution_round_trip() {
+    let payload = json!({
+        "type": "tool_search",
+        "execution": "client",
+    });
+    let tool: ResponseTool = serde_json::from_value(payload.clone())
+        .expect("tool_search tool with client execution should deserialize");
+    match &tool {
+        ResponseTool::ToolSearch(ts) => {
+            assert_eq!(ts.description, None);
+            assert_eq!(ts.execution, Some(ToolSearchExecution::Client));
+            assert_eq!(ts.parameters, None);
+        }
+        other => panic!("expected ResponseTool::ToolSearch, got {other:?}"),
+    }
+    assert_eq!(serde_json::to_value(&tool).expect("serialize"), payload);
+}
+
+/// `ResponseTool::ToolSearch` with all optional fields absent ( `execution`
+/// omitted entirely) round-trips — the minimum spec shape.
+#[test]
+fn test_tool_search_tool_minimal_round_trip() {
+    let payload = json!({"type": "tool_search"});
+    let tool: ResponseTool = serde_json::from_value(payload.clone())
+        .expect("bare tool_search tool should deserialize");
+    match &tool {
+        ResponseTool::ToolSearch(ts) => {
+            assert_eq!(ts.description, None);
+            assert_eq!(ts.execution, None);
+            assert_eq!(ts.parameters, None);
+        }
+        other => panic!("expected ResponseTool::ToolSearch, got {other:?}"),
+    }
+    assert_eq!(serde_json::to_value(&tool).expect("serialize"), payload);
+}
+
+/// Unknown `execution` values must fail closed rather than silently
+/// degrading — `ToolSearchExecution` is a closed enum so an unknown variant
+/// surfaces as a serde error.
+#[test]
+fn test_tool_search_tool_rejects_unknown_execution() {
+    let err = serde_json::from_value::<ResponseTool>(json!({
+        "type": "tool_search",
+        "execution": "local", // not in {server, client}
+    }))
+    .expect_err("unknown execution value must not deserialize");
+    assert!(!err.to_string().is_empty());
+}
+
+/// `ResponseInputOutputItem::ToolSearchCall` with all optional fields
+/// populated round-trips. Spec
+/// (openai-responses-api-spec.md §ToolSearchCall L188-191):
+/// `{ arguments, type, id?, call_id?, execution?, status? }`.
+#[test]
+fn test_tool_search_call_input_item_full_round_trip() {
+    let payload = json!({
+        "type": "tool_search_call",
+        "id": "ts_call_1",
+        "call_id": "call_ts_1",
+        "arguments": {"q": "image editing"},
+        "execution": "server",
+        "status": "in_progress",
+    });
+    let item: ResponseInputOutputItem = serde_json::from_value(payload.clone())
+        .expect("tool_search_call with all fields should deserialize");
+    match &item {
+        ResponseInputOutputItem::ToolSearchCall {
+            arguments,
+            id,
+            call_id,
+            execution,
+            status,
+        } => {
+            assert_eq!(id.as_deref(), Some("ts_call_1"));
+            assert_eq!(call_id.as_deref(), Some("call_ts_1"));
+            assert_eq!(arguments["q"], json!("image editing"));
+            assert_eq!(*execution, Some(ToolSearchExecution::Server));
+            assert_eq!(*status, Some(ToolSearchStatus::InProgress));
+        }
+        other => panic!("expected ToolSearchCall, got {other:?}"),
+    }
+    assert_eq!(serde_json::to_value(&item).expect("serialize"), payload);
+}
+
+/// `ResponseInputOutputItem::ToolSearchCall` with only the required
+/// `arguments` field — `id`/`call_id`/`execution`/`status` absent so the
+/// client-authored minimum replay form stays lossless.
+#[test]
+fn test_tool_search_call_input_item_minimal_round_trip() {
+    let payload = json!({
+        "type": "tool_search_call",
+        "arguments": "raw-string-is-fine-too",
+    });
+    let item: ResponseInputOutputItem = serde_json::from_value(payload.clone())
+        .expect("minimal tool_search_call should deserialize");
+    match &item {
+        ResponseInputOutputItem::ToolSearchCall {
+            arguments,
+            id,
+            call_id,
+            execution,
+            status,
+        } => {
+            assert_eq!(arguments, &json!("raw-string-is-fine-too"));
+            assert_eq!(id, &None);
+            assert_eq!(call_id, &None);
+            assert_eq!(*execution, None);
+            assert_eq!(*status, None);
+        }
+        other => panic!("expected ToolSearchCall, got {other:?}"),
+    }
+    assert_eq!(serde_json::to_value(&item).expect("serialize"), payload);
+}
+
+/// `ResponseInputOutputItem::ToolSearchOutput` carries the full recursive
+/// [`ResponseTool`] union — verified here with `function`, `mcp`, and a
+/// nested `tool_search` element. Spec
+/// (openai-responses-api-spec.md §ToolSearchOutput L193-195):
+/// `{ tools, type, id?, call_id?, execution?, status? }` where `tools` is
+/// the recursive tool union.
+#[test]
+fn test_tool_search_output_input_item_recursive_tools_round_trip() {
+    let payload = json!({
+        "type": "tool_search_output",
+        "id": "ts_out_1",
+        "call_id": "call_ts_1",
+        "execution": "client",
+        "status": "completed",
+        "tools": [
+            {
+                "type": "function",
+                "name": "lookup_doc",
+                "description": "Fetch a doc by id",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"id": {"type": "string"}},
+                    "required": ["id"],
+                },
+                "strict": true
+            },
+            {
+                "type": "mcp",
+                "server_label": "deepwiki",
+                "server_url": "https://example.invalid/mcp",
+            },
+            // Recursive case: tool_search discovered by a prior tool_search.
+            {
+                "type": "tool_search",
+                "description": "nested",
+                "execution": "server",
+            },
+        ],
+    });
+
+    let item: ResponseInputOutputItem = serde_json::from_value(payload.clone())
+        .expect("tool_search_output with recursive tools should deserialize");
+
+    match &item {
+        ResponseInputOutputItem::ToolSearchOutput {
+            tools,
+            id,
+            call_id,
+            execution,
+            status,
+        } => {
+            assert_eq!(id.as_deref(), Some("ts_out_1"));
+            assert_eq!(call_id.as_deref(), Some("call_ts_1"));
+            assert_eq!(*execution, Some(ToolSearchExecution::Client));
+            assert_eq!(*status, Some(ToolSearchStatus::Completed));
+            assert_eq!(tools.len(), 3);
+            match &tools[0] {
+                ResponseTool::Function(ft) => {
+                    assert_eq!(ft.function.name, "lookup_doc");
+                    assert_eq!(ft.function.strict, Some(true));
+                }
+                other => panic!("expected tools[0] = Function, got {other:?}"),
+            }
+            match &tools[1] {
+                ResponseTool::Mcp(m) => {
+                    assert_eq!(m.server_label, "deepwiki");
+                    assert_eq!(
+                        m.server_url.as_deref(),
+                        Some("https://example.invalid/mcp")
+                    );
+                }
+                other => panic!("expected tools[1] = Mcp, got {other:?}"),
+            }
+            match &tools[2] {
+                ResponseTool::ToolSearch(ts) => {
+                    assert_eq!(ts.description.as_deref(), Some("nested"));
+                    assert_eq!(ts.execution, Some(ToolSearchExecution::Server));
+                }
+                other => panic!("expected tools[2] = ToolSearch, got {other:?}"),
+            }
+        }
+        other => panic!("expected ToolSearchOutput, got {other:?}"),
+    }
+
+    // Byte-for-byte round-trip: recursive shape preserves structure exactly.
+    assert_eq!(serde_json::to_value(&item).expect("serialize"), payload);
+}
+
+/// `ResponseInputOutputItem::ToolSearchOutput` with an empty `tools: []`
+/// and no optional metadata — the minimum replayable shape for a resolver
+/// that found nothing.
+#[test]
+fn test_tool_search_output_input_item_minimal_round_trip() {
+    let payload = json!({
+        "type": "tool_search_output",
+        "tools": [],
+    });
+    let item: ResponseInputOutputItem = serde_json::from_value(payload.clone())
+        .expect("minimal tool_search_output should deserialize");
+    match &item {
+        ResponseInputOutputItem::ToolSearchOutput {
+            tools,
+            id,
+            call_id,
+            execution,
+            status,
+        } => {
+            assert!(tools.is_empty());
+            assert_eq!(id, &None);
+            assert_eq!(call_id, &None);
+            assert_eq!(*execution, None);
+            assert_eq!(*status, None);
+        }
+        other => panic!("expected ToolSearchOutput, got {other:?}"),
+    }
+    assert_eq!(serde_json::to_value(&item).expect("serialize"), payload);
+}
+
+/// Unknown `status` values on `tool_search_call` fail closed rather than
+/// silently degrading — `ToolSearchStatus` is a closed enum.
+#[test]
+fn test_tool_search_call_rejects_unknown_status() {
+    let err = serde_json::from_value::<ResponseInputOutputItem>(json!({
+        "type": "tool_search_call",
+        "arguments": {},
+        "status": "pending", // not in {in_progress, completed, incomplete}
+    }))
+    .expect_err("unknown status value must not deserialize");
+    assert!(!err.to_string().is_empty());
+}

--- a/crates/protocols/tests/responses.rs
+++ b/crates/protocols/tests/responses.rs
@@ -4415,3 +4415,19 @@ fn test_tool_search_call_rejects_unknown_status() {
     .expect_err("unknown status value must not deserialize");
     assert!(!err.to_string().is_empty());
 }
+
+/// Parity with [`test_tool_search_call_rejects_unknown_status`] — unknown
+/// `status` values on `tool_search_output` must also fail closed. The
+/// `status` field is shared (`ToolSearchStatus`), so rejection behaviour
+/// is identical, but we pin it with a dedicated test so a regression on
+/// either variant is caught independently.
+#[test]
+fn test_tool_search_output_rejects_unknown_status() {
+    let err = serde_json::from_value::<ResponseInputOutputItem>(json!({
+        "type": "tool_search_output",
+        "tools": [],
+        "status": "pending", // not in {in_progress, completed, incomplete}
+    }))
+    .expect_err("unknown status value must not deserialize");
+    assert!(!err.to_string().is_empty());
+}

--- a/model_gateway/benches/routing_allocation_bench.rs
+++ b/model_gateway/benches/routing_allocation_bench.rs
@@ -82,10 +82,8 @@ fn extract_text_for_routing_old(req: &ResponsesRequest) -> String {
                 // T5 schema-only: forced-cascade arm, no behavior.
                 ResponseInputOutputItem::LocalShellCall { .. }
                 | ResponseInputOutputItem::LocalShellCallOutput { .. } => None,
-                // T11 schema-only: forced-cascade arm, no behavior.
                 ResponseInputOutputItem::McpCall { .. }
                 | ResponseInputOutputItem::McpListTools { .. } => None,
-                // T10 schema-only: forced-cascade arm, no behavior.
                 ResponseInputOutputItem::ToolSearchCall { .. }
                 | ResponseInputOutputItem::ToolSearchOutput { .. } => None,
             })

--- a/model_gateway/benches/routing_allocation_bench.rs
+++ b/model_gateway/benches/routing_allocation_bench.rs
@@ -85,6 +85,9 @@ fn extract_text_for_routing_old(req: &ResponsesRequest) -> String {
                 // T11 schema-only: forced-cascade arm, no behavior.
                 ResponseInputOutputItem::McpCall { .. }
                 | ResponseInputOutputItem::McpListTools { .. } => None,
+                // T10 schema-only: forced-cascade arm, no behavior.
+                ResponseInputOutputItem::ToolSearchCall { .. }
+                | ResponseInputOutputItem::ToolSearchOutput { .. } => None,
             })
             .collect::<Vec<String>>()
             .join(" "),

--- a/model_gateway/src/routers/grpc/harmony/builder.rs
+++ b/model_gateway/src/routers/grpc/harmony/builder.rs
@@ -562,6 +562,8 @@ impl HarmonyBuilder {
                             ResponseTool::ApplyPatch => "apply_patch",
                             // T5 schema-only: forced-cascade arm, no behavior.
                             ResponseTool::LocalShell => "local_shell",
+                            // T10 schema-only: forced-cascade arm, no behavior.
+                            ResponseTool::ToolSearch(_) => "tool_search",
                         })
                         .collect()
                 })
@@ -899,6 +901,11 @@ impl HarmonyBuilder {
             // T5 schema-only: forced-cascade arm, no behavior.
             ResponseInputOutputItem::LocalShellCall { .. }
             | ResponseInputOutputItem::LocalShellCallOutput { .. } => {
+                Err("Unsupported input item type".to_string())
+            }
+            // T10 schema-only: forced-cascade arm, no behavior.
+            ResponseInputOutputItem::ToolSearchCall { .. }
+            | ResponseInputOutputItem::ToolSearchOutput { .. } => {
                 Err("Unsupported input item type".to_string())
             }
         }

--- a/model_gateway/src/routers/grpc/harmony/builder.rs
+++ b/model_gateway/src/routers/grpc/harmony/builder.rs
@@ -560,9 +560,7 @@ impl HarmonyBuilder {
                             ResponseTool::Namespace(_) => "namespace",
                             ResponseTool::Shell(_) => "shell",
                             ResponseTool::ApplyPatch => "apply_patch",
-                            // T5 schema-only: forced-cascade arm, no behavior.
                             ResponseTool::LocalShell => "local_shell",
-                            // T10 schema-only: forced-cascade arm, no behavior.
                             ResponseTool::ToolSearch(_) => "tool_search",
                         })
                         .collect()
@@ -898,12 +896,10 @@ impl HarmonyBuilder {
                 );
                 Err("Unsupported input item type".to_string())
             }
-            // T5 schema-only: forced-cascade arm, no behavior.
             ResponseInputOutputItem::LocalShellCall { .. }
             | ResponseInputOutputItem::LocalShellCallOutput { .. } => {
                 Err("Unsupported input item type".to_string())
             }
-            // T10 schema-only: forced-cascade arm, no behavior.
             ResponseInputOutputItem::ToolSearchCall { .. }
             | ResponseInputOutputItem::ToolSearchOutput { .. } => {
                 Err("Unsupported input item type".to_string())

--- a/model_gateway/src/routers/grpc/regular/responses/conversions.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/conversions.rs
@@ -194,6 +194,11 @@ pub(crate) fn responses_to_chat(req: &ResponsesRequest) -> Result<ChatCompletion
                     | ResponseInputOutputItem::LocalShellCallOutput { .. } => {
                         return Err("Unsupported input item type".to_string());
                     }
+                    // T10 schema-only: forced-cascade arm, no behavior.
+                    ResponseInputOutputItem::ToolSearchCall { .. }
+                    | ResponseInputOutputItem::ToolSearchOutput { .. } => {
+                        return Err("Unsupported input item type".to_string());
+                    }
                 }
             }
         }

--- a/model_gateway/src/routers/grpc/regular/responses/conversions.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/conversions.rs
@@ -194,7 +194,6 @@ pub(crate) fn responses_to_chat(req: &ResponsesRequest) -> Result<ChatCompletion
                     | ResponseInputOutputItem::LocalShellCallOutput { .. } => {
                         return Err("Unsupported input item type".to_string());
                     }
-                    // T10 schema-only: forced-cascade arm, no behavior.
                     ResponseInputOutputItem::ToolSearchCall { .. }
                     | ResponseInputOutputItem::ToolSearchOutput { .. } => {
                         return Err("Unsupported input item type".to_string());

--- a/model_gateway/src/routers/openai/responses/utils.rs
+++ b/model_gateway/src/routers/openai/responses/utils.rs
@@ -263,9 +263,7 @@ pub(super) fn response_tool_to_value(tool: &ResponseTool) -> Option<Value> {
         ResponseTool::Shell(_) => serde_json::to_value(tool).ok(),
         ResponseTool::ApplyPatch => serde_json::to_value(tool).ok(),
         ResponseTool::Function(_) => None,
-        // T5 schema-only: forced-cascade arm, no behavior.
         ResponseTool::LocalShell => serde_json::to_value(tool).ok(),
-        // T10 schema-only: forced-cascade arm, no behavior.
         ResponseTool::ToolSearch(_) => serde_json::to_value(tool).ok(),
     }
 }

--- a/model_gateway/src/routers/openai/responses/utils.rs
+++ b/model_gateway/src/routers/openai/responses/utils.rs
@@ -265,6 +265,8 @@ pub(super) fn response_tool_to_value(tool: &ResponseTool) -> Option<Value> {
         ResponseTool::Function(_) => None,
         // T5 schema-only: forced-cascade arm, no behavior.
         ResponseTool::LocalShell => serde_json::to_value(tool).ok(),
+        // T10 schema-only: forced-cascade arm, no behavior.
+        ResponseTool::ToolSearch(_) => serde_json::to_value(tool).ok(),
     }
 }
 


### PR DESCRIPTION
## Description

### Problem
The Responses API audit (`.claude/_audit/responses-api-gap-audit.md` §T10)
identifies `tool_search` as the final outstanding tool variant. T1–T9 and
T11 have all landed; T10 is blocked-free now (T1–T9 established the full
tool union that T10 reuses recursively). Without it, the `ResponseTool`
surface cannot represent the hosted / client-executed `tool_search`
capability and the corresponding `tool_search_call` / `tool_search_output`
items cannot round-trip — which in turn blocks the E3 tool-coverage tests.

### Solution
Adds the three spec variants (one `ResponseTool`, two
`ResponseInputOutputItem`) plus supporting `ToolSearchTool`,
`ToolSearchExecution`, and `ToolSearchStatus` types. Schema-only; no
router behavior. Forced-cascade match-arm updates follow the pattern from
T5/T6/T7/I2 — exhaustive arms that fall through to the existing
no-op / error-return path with `T10 schema-only: forced-cascade arm, no
behavior.` markers.

## Changes

### `crates/protocols/src/responses.rs`
- `ResponseTool::ToolSearch(ToolSearchTool)` — `{ type: "tool_search",
  description?, execution?: "server"|"client", parameters? }`. Spec:
  `openai-responses-api-spec.md` §tools L476.
- `ToolSearchTool` struct (`deny_unknown_fields`); `parameters` is
  `serde_json::Value` to match the spec's `parameters?: any`.
- `ToolSearchExecution` closed enum (`server | client`, snake_case).
- `ToolSearchStatus` closed enum (`in_progress | completed |
  incomplete`, snake_case).
- `ResponseInputOutputItem::ToolSearchCall` — `{ arguments: Value, id?,
  call_id?, execution?, status? }`. Spec: §ToolSearchCall L188-191.
- `ResponseInputOutputItem::ToolSearchOutput` — `{ tools:
  Vec<ResponseTool>, id?, call_id?, execution?, status? }` — recursive
  use of the full tool union (including `tool_search` itself). Spec:
  §ToolSearchOutput L193-195.
- Forced-cascade arms in `extract_text_for_routing` and
  `validate_input_item`.

### Forced-cascade match-arm updates (no behavior change)
- `model_gateway/src/routers/grpc/harmony/builder.rs` — ResponseTool
  label map and input-item → Harmony conversion (error arm).
- `model_gateway/src/routers/grpc/regular/responses/conversions.rs` —
  `responses_to_chat` (error arm).
- `model_gateway/src/routers/openai/responses/utils.rs` —
  `response_tool_to_value` (pass-through via serde).
- `model_gateway/benches/routing_allocation_bench.rs` —
  `extract_text_for_routing_old` (None arm).

### Tests (`crates/protocols/tests/responses.rs`)
Nine new integration tests (per C1/C2 convention, `tests/` not `src/`):
- `test_tool_search_tool_server_execution_round_trip` — full payload.
- `test_tool_search_tool_client_execution_round_trip` — execution=client.
- `test_tool_search_tool_minimal_round_trip` — bare `{type}`.
- `test_tool_search_tool_rejects_unknown_execution` — fail-closed guard.
- `test_tool_search_call_input_item_full_round_trip` — all fields.
- `test_tool_search_call_input_item_minimal_round_trip` — only
  `arguments`.
- `test_tool_search_output_input_item_recursive_tools_round_trip` —
  carries `function`, `mcp`, **and a nested `tool_search`** to pin the
  recursive tool-union surface, byte-for-byte round-trip verified.
- `test_tool_search_output_input_item_minimal_round_trip` — empty tools
  list.
- `test_tool_search_call_rejects_unknown_status` — fail-closed guard.

## Why
T1–T9 and T11 established every other tool variant; T10 is the last
outstanding tool in the audit track. Adding `tool_search` unblocks
`E3` tool-coverage tests (see audit doc §T10, §E3).

## How
Schema-only — no router behavior. `parameters` stays opaque
(`serde_json::Value`) so arbitrary search-parameter schemas pass through
unchanged, mirroring the spec's `parameters?: any`. `execution` and
`status` are closed enums (not free-form strings) so unknown wire values
fail closed, matching the treatment of `ShellCallStatus`,
`CustomToolGrammarSyntax`, etc.

The `tools` field on `ToolSearchOutput` is a recursive use of
`ResponseTool` — the output-item test exercises this by carrying
`function`, `mcp`, and a nested `tool_search` element and asserts a
byte-for-byte round-trip.

## Test plan
- [x] `cargo check -p openai-protocol` — clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo test -p openai-protocol --tests` — 218 tests pass (9 new).
- [x] `cargo check -p smg` — forced-cascade arm coverage verified across
      model_gateway routers + benches.

Refs: `.claude/_audit/responses-api-gap-audit.md` §T10, §E3.

<details>
<summary>Checklist</summary>

- [x] Protocol types added
- [x] Serde round-trip tests added (in `tests/`, not `src/`)
- [x] Forced-cascade match arms updated (no behavior change)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a tool_search capability with server/client execution modes, optional parameters, and explicit status states.

* **Bug Fixes / Compatibility**
  * Treats tool_search as schema-only (no prompt text extraction) and filters it from routing text; integrations now explicitly handle or reject unsupported tool_search items.
  * Restores client-side representation for tool_search tools during response reconstruction.

* **Tests**
  * Added comprehensive serialization, parsing, recursive-content, and fail-closed validation tests for tool_search variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->