### PR TITLE
feat(grpc-regular): wire input_image and input_file content parts in Responses router (R2)

### DIFF
--- a/crates/multimodal/src/media.rs
+++ b/crates/multimodal/src/media.rs
@@ -101,7 +101,32 @@ impl MediaConnector {
         url: String,
         cfg: ImageFetchConfig,
     ) -> Result<Arc<ImageFrame>, MediaConnectorError> {
-        let parsed = Url::parse(&url).map_err(|_| MediaConnectorError::InvalidUrl(url.clone()))?;
+        let (bytes, resolved_url) = self.fetch_http_bytes(&url).await?;
+        self.decode_image(
+            bytes,
+            cfg.detail,
+            ImageSource::Url { url: resolved_url },
+        )
+        .await
+    }
+
+    /// Fetch raw bytes from an HTTP URL, enforcing the same allowlist and
+    /// timeout as the image pipeline. Returns the body bytes plus the
+    /// canonicalized URL. Public so the Responses router can reuse the
+    /// allowlist/timeout envelope for non-image payloads (e.g.
+    /// `input_file` with `file_url`) without re-implementing HTTP.
+    pub async fn fetch_raw_bytes(
+        &self,
+        url: &str,
+    ) -> Result<(Bytes, String), MediaConnectorError> {
+        self.fetch_http_bytes(url).await
+    }
+
+    async fn fetch_http_bytes(
+        &self,
+        url: &str,
+    ) -> Result<(Bytes, String), MediaConnectorError> {
+        let parsed = Url::parse(url).map_err(|_| MediaConnectorError::InvalidUrl(url.to_string()))?;
         self.ensure_domain_allowed(&parsed)?;
 
         let mut req = self.client.get(parsed.as_str());
@@ -119,14 +144,7 @@ impl MediaConnector {
 
         let resp = resp.error_for_status()?;
         let bytes = resp.bytes().await?;
-        self.decode_image(
-            bytes,
-            cfg.detail,
-            ImageSource::Url {
-                url: parsed.to_string(),
-            },
-        )
-        .await
+        Ok((bytes, parsed.to_string()))
     }
 
     async fn fetch_data_url(

--- a/crates/multimodal/src/media.rs
+++ b/crates/multimodal/src/media.rs
@@ -143,8 +143,15 @@ impl MediaConnector {
         })?;
 
         let resp = resp.error_for_status()?;
+        // Re-validate the allowlist against the post-redirect URL:
+        // reqwest follows redirects by default, so a request starting
+        // on an allowed domain could otherwise land on a disallowed
+        // origin without us noticing. Return the resolved URL so
+        // callers log / cache the actual source rather than the input.
+        let final_url = resp.url().clone();
+        self.ensure_domain_allowed(&final_url)?;
         let bytes = resp.bytes().await?;
-        Ok((bytes, parsed.to_string()))
+        Ok((bytes, final_url.to_string()))
     }
 
     async fn fetch_data_url(

--- a/crates/multimodal/src/media.rs
+++ b/crates/multimodal/src/media.rs
@@ -102,12 +102,8 @@ impl MediaConnector {
         cfg: ImageFetchConfig,
     ) -> Result<Arc<ImageFrame>, MediaConnectorError> {
         let (bytes, resolved_url) = self.fetch_http_bytes(&url).await?;
-        self.decode_image(
-            bytes,
-            cfg.detail,
-            ImageSource::Url { url: resolved_url },
-        )
-        .await
+        self.decode_image(bytes, cfg.detail, ImageSource::Url { url: resolved_url })
+            .await
     }
 
     /// Fetch raw bytes from an HTTP URL, enforcing the same allowlist and
@@ -115,18 +111,13 @@ impl MediaConnector {
     /// canonicalized URL. Public so the Responses router can reuse the
     /// allowlist/timeout envelope for non-image payloads (e.g.
     /// `input_file` with `file_url`) without re-implementing HTTP.
-    pub async fn fetch_raw_bytes(
-        &self,
-        url: &str,
-    ) -> Result<(Bytes, String), MediaConnectorError> {
+    pub async fn fetch_raw_bytes(&self, url: &str) -> Result<(Bytes, String), MediaConnectorError> {
         self.fetch_http_bytes(url).await
     }
 
-    async fn fetch_http_bytes(
-        &self,
-        url: &str,
-    ) -> Result<(Bytes, String), MediaConnectorError> {
-        let parsed = Url::parse(url).map_err(|_| MediaConnectorError::InvalidUrl(url.to_string()))?;
+    async fn fetch_http_bytes(&self, url: &str) -> Result<(Bytes, String), MediaConnectorError> {
+        let parsed =
+            Url::parse(url).map_err(|_| MediaConnectorError::InvalidUrl(url.to_string()))?;
         self.ensure_domain_allowed(&parsed)?;
 
         let mut req = self.client.get(parsed.as_str());

--- a/model_gateway/src/routers/grpc/regular/responses/content_parts.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/content_parts.rs
@@ -319,9 +319,7 @@ fn sniff_media_kind(bytes: &[u8]) -> MediaKind {
         return MediaKind::Image("image/jpeg");
     }
     // PNG: 89 50 4E 47 0D 0A 1A 0A
-    if bytes.len() >= 8
-        && bytes.starts_with(&[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
-    {
+    if bytes.len() >= 8 && bytes.starts_with(&[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]) {
         return MediaKind::Image("image/png");
     }
     // GIF: "GIF87a" / "GIF89a"
@@ -362,9 +360,7 @@ mod tests {
 
     #[test]
     fn sniff_detects_png_magic() {
-        let bytes = [
-            0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00,
-        ];
+        let bytes = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00];
         assert!(matches!(sniff_media_kind(&bytes), MediaKind::Image(m) if m == "image/png"));
     }
 

--- a/model_gateway/src/routers/grpc/regular/responses/content_parts.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/content_parts.rs
@@ -1,0 +1,805 @@
+//! Preprocessing for Responses API input content parts (R2).
+//!
+//! The P1 protocol schema added three new [`ResponseContentPart`] variants to
+//! the gRPC regular Responses router: `InputImage`, `InputFile`, and `Refusal`.
+//! The downstream chat pipeline only understands OpenAI Chat Completions
+//! [`ContentPart`] (`text` + `image_url`), so this module runs BEFORE
+//! [`super::conversions::responses_to_chat`] and normalizes every new variant
+//! into something the chat pipeline already handles — or rejects it with a
+//! 400 `unsupported_content` when SMG cannot service the request.
+//!
+//! Specifically:
+//!
+//! - `InputImage` with an HTTP or data URL → left in place; `conversions` maps
+//!   it to [`ContentPart::ImageUrl`] which [`crate::routers::grpc::multimodal`]
+//!   then downloads/decodes.
+//! - `InputImage` with `file_id` → rejected (SMG has no Files API backend).
+//! - `InputFile` with `file_data` (base64) → decoded, sniffed for magic bytes;
+//!   images are re-emitted as `InputImage` with a `data:` URL so they flow
+//!   through the existing image pipeline; PDFs are rejected pending R4.
+//! - `InputFile` with `file_url` → downloaded via [`MediaConnector`] (same
+//!   allowlist + timeout envelope as the image pipeline), sniffed, and then
+//!   either re-emitted as an image data URL or rejected (PDF / non-image).
+//! - `InputFile` with `file_id` → rejected.
+//! - `Refusal` on an input (user) role → rejected; refusals are output-only.
+//!
+//! After preprocessing, `responses_to_chat` only has to map the narrower
+//! surface of text + image-url content parts.
+
+use std::sync::Arc;
+
+use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine};
+use llm_multimodal::MediaConnector;
+use openai_protocol::responses::{
+    ResponseContentPart, ResponseInput, ResponseInputOutputItem, ResponsesRequest,
+    StringOrContentParts,
+};
+use tracing::warn;
+
+/// Typed error returned by preprocessing and
+/// [`super::conversions::responses_to_chat`]. Callers map each variant to an
+/// appropriate HTTP response (400 with a specific error code, or 500).
+#[derive(Debug, Clone)]
+pub(super) enum ConversionError {
+    /// The request carries a content part that SMG cannot handle. Should
+    /// surface as HTTP 400 with `error.code = "unsupported_content"`.
+    UnsupportedContent(String),
+    /// The request itself is malformed (e.g. empty after normalization).
+    /// Should surface as HTTP 400 with `error.code = "invalid_request"`.
+    InvalidRequest(String),
+}
+
+impl ConversionError {
+    pub(super) fn error_code(&self) -> &'static str {
+        match self {
+            Self::UnsupportedContent(_) => "unsupported_content",
+            Self::InvalidRequest(_) => "invalid_request",
+        }
+    }
+
+    pub(super) fn message(&self) -> &str {
+        match self {
+            Self::UnsupportedContent(m) | Self::InvalidRequest(m) => m,
+        }
+    }
+}
+
+impl std::fmt::Display for ConversionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.error_code(), self.message())
+    }
+}
+
+/// Shared mapping from [`ConversionError`] to an HTTP 400 response. Both
+/// [`ConversionError::UnsupportedContent`] and [`ConversionError::InvalidRequest`]
+/// are client-side issues; the typed code in the response body lets clients
+/// distinguish them without parsing free-form messages.
+pub(super) fn conversion_error_to_response(err: &ConversionError) -> axum::response::Response {
+    use crate::routers::error::bad_request;
+    bad_request(err.error_code(), err.message())
+}
+
+/// Walk the request's structured input and normalize every `InputImage` /
+/// `InputFile` / `Refusal` content part. Mutates `req.input` in place.
+///
+/// Network I/O happens only for `InputFile` with `file_url`. `media_connector`
+/// may be `None` when the router is running without multimodal support; in
+/// that case any content part that would have required a download is
+/// rejected with `unsupported_content` rather than silently downloaded
+/// through an out-of-envelope client.
+pub(super) async fn preprocess_responses_input(
+    req: &mut ResponsesRequest,
+    media_connector: Option<&Arc<MediaConnector>>,
+) -> Result<(), ConversionError> {
+    // Text input has no rich content parts so there is nothing to preprocess.
+    let items = match &mut req.input {
+        ResponseInput::Text(_) => return Ok(()),
+        ResponseInput::Items(items) => items,
+    };
+
+    for item in items.iter_mut() {
+        match item {
+            ResponseInputOutputItem::SimpleInputMessage {
+                role,
+                content: StringOrContentParts::Array(parts),
+                ..
+            } => {
+                normalize_content_parts(parts, role.as_str(), media_connector).await?;
+            }
+            ResponseInputOutputItem::Message { role, content, .. } => {
+                normalize_content_parts(content, role.as_str(), media_connector).await?;
+            }
+            _ => {}
+        }
+    }
+
+    Ok(())
+}
+
+/// Normalize an in-place slice of content parts. Parts are rewritten rather
+/// than re-collected so callers can keep the original order and any
+/// surrounding `InputText` entries.
+async fn normalize_content_parts(
+    parts: &mut [ResponseContentPart],
+    role: &str,
+    media_connector: Option<&Arc<MediaConnector>>,
+) -> Result<(), ConversionError> {
+    for part in parts.iter_mut() {
+        normalize_one(part, role, media_connector).await?;
+    }
+    Ok(())
+}
+
+async fn normalize_one(
+    part: &mut ResponseContentPart,
+    role: &str,
+    media_connector: Option<&Arc<MediaConnector>>,
+) -> Result<(), ConversionError> {
+    match part {
+        // Text / output text are passed through untouched.
+        ResponseContentPart::InputText { .. } | ResponseContentPart::OutputText { .. } => Ok(()),
+
+        ResponseContentPart::Refusal { .. } => {
+            // Refusals are an output-only spec type. An input-role refusal is
+            // a client bug; preserving it as text would silently change the
+            // prompt semantics, so reject it explicitly.
+            if is_input_role(role) {
+                Err(ConversionError::UnsupportedContent(
+                    "Refusal content parts are output-only; reject on input role".to_string(),
+                ))
+            } else {
+                // On an assistant/other output role a refusal is legitimate
+                // and downstream text extraction preserves it verbatim.
+                Ok(())
+            }
+        }
+
+        ResponseContentPart::InputImage {
+            file_id,
+            image_url,
+            detail: _,
+        } => {
+            if file_id.is_some() {
+                // SMG does not host a Files API, so file_id handles are not
+                // resolvable here. Reject cleanly; the caller can forward the
+                // request to an OpenAI-compat backend if it wants the
+                // passthrough behavior (R1).
+                return Err(ConversionError::UnsupportedContent(
+                    "input_image.file_id is not supported by the gRPC regular router; \
+                     pass image_url (HTTP or data URL) instead"
+                        .to_string(),
+                ));
+            }
+            if image_url.is_none() {
+                return Err(ConversionError::InvalidRequest(
+                    "input_image requires either image_url or file_id".to_string(),
+                ));
+            }
+            // image_url (HTTP or data URL) passes through — the chat pipeline
+            // already knows how to fetch both shapes via MediaConnector.
+            Ok(())
+        }
+
+        ResponseContentPart::InputFile {
+            file_data,
+            file_id,
+            file_url,
+            filename,
+            detail: _,
+        } => {
+            if let Some(name) = filename.as_deref() {
+                // Filename is informational metadata. Log but do not fail,
+                // since the spec treats it as a hint not a handle.
+                warn!(filename = %name, "input_file filename is informational — ignored");
+            }
+
+            if file_id.is_some() {
+                return Err(ConversionError::UnsupportedContent(
+                    "input_file.file_id is not supported by the gRPC regular router; \
+                     pass file_data (base64) or file_url instead"
+                        .to_string(),
+                ));
+            }
+
+            if let Some(data) = file_data.take() {
+                let bytes = BASE64_STANDARD.decode(data.as_bytes()).map_err(|e| {
+                    ConversionError::InvalidRequest(format!(
+                        "input_file.file_data is not valid base64: {e}"
+                    ))
+                })?;
+                let normalized = sniff_and_build_image_part(&bytes)?;
+                *part = normalized;
+                return Ok(());
+            }
+
+            if let Some(url) = file_url.take() {
+                let connector = media_connector.ok_or_else(|| {
+                    ConversionError::UnsupportedContent(
+                        "input_file.file_url requires the multimodal pipeline, which is not \
+                         configured on this gateway instance"
+                            .to_string(),
+                    )
+                })?;
+                let (bytes, _resolved) = connector.fetch_raw_bytes(&url).await.map_err(|e| {
+                    ConversionError::UnsupportedContent(format!(
+                        "failed to download input_file.file_url: {e}"
+                    ))
+                })?;
+                let normalized = sniff_and_build_image_part(bytes.as_ref())?;
+                *part = normalized;
+                return Ok(());
+            }
+
+            Err(ConversionError::InvalidRequest(
+                "input_file requires one of file_data, file_url, or file_id".to_string(),
+            ))
+        }
+    }
+}
+
+/// Classify a byte payload by its file signature and build the matching
+/// content part. Images become `InputImage` with a `data:` URL; PDFs are
+/// rejected pending R4; everything else is rejected as `unsupported_content`.
+fn sniff_and_build_image_part(bytes: &[u8]) -> Result<ResponseContentPart, ConversionError> {
+    match sniff_media_kind(bytes) {
+        MediaKind::Image(mime) => {
+            let encoded = BASE64_STANDARD.encode(bytes);
+            Ok(ResponseContentPart::InputImage {
+                detail: None,
+                file_id: None,
+                image_url: Some(format!("data:{mime};base64,{encoded}")),
+            })
+        }
+        MediaKind::Pdf => Err(ConversionError::UnsupportedContent(
+            "input_file with application/pdf is not yet supported; PDF extraction pending R4"
+                .to_string(),
+        )),
+        MediaKind::Unknown => Err(ConversionError::UnsupportedContent(
+            "input_file payload is not a recognized image (jpeg/png/webp/gif) or PDF".to_string(),
+        )),
+    }
+}
+
+/// Minimal magic-byte classifier covering every MIME type the downstream
+/// image pipeline supports plus the PDF sentinel we need to reject.
+enum MediaKind {
+    Image(&'static str),
+    Pdf,
+    Unknown,
+}
+
+fn sniff_media_kind(bytes: &[u8]) -> MediaKind {
+    // JPEG: FF D8 FF
+    if bytes.len() >= 3 && bytes.starts_with(&[0xFF, 0xD8, 0xFF]) {
+        return MediaKind::Image("image/jpeg");
+    }
+    // PNG: 89 50 4E 47 0D 0A 1A 0A
+    if bytes.len() >= 8
+        && bytes.starts_with(&[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
+    {
+        return MediaKind::Image("image/png");
+    }
+    // GIF: "GIF87a" / "GIF89a"
+    if bytes.len() >= 6 && (bytes.starts_with(b"GIF87a") || bytes.starts_with(b"GIF89a")) {
+        return MediaKind::Image("image/gif");
+    }
+    // WebP: "RIFF" ... "WEBP"
+    if bytes.len() >= 12 && bytes.starts_with(b"RIFF") && &bytes[8..12] == b"WEBP" {
+        return MediaKind::Image("image/webp");
+    }
+    // PDF: "%PDF-"
+    if bytes.starts_with(b"%PDF-") {
+        return MediaKind::Pdf;
+    }
+    MediaKind::Unknown
+}
+
+/// Whether a message role denotes client-authored input (as opposed to
+/// server/assistant output). Spec §Messages distinguishes `user`,
+/// `developer`, `system`, and `critic` as input-bearing roles.
+fn is_input_role(role: &str) -> bool {
+    matches!(role, "user" | "developer" | "system" | "critic")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ------------------------------------------------------------------
+    // sniff_media_kind
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn sniff_detects_jpeg_magic() {
+        let bytes = [0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10];
+        assert!(matches!(sniff_media_kind(&bytes), MediaKind::Image(m) if m == "image/jpeg"));
+    }
+
+    #[test]
+    fn sniff_detects_png_magic() {
+        let bytes = [
+            0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00,
+        ];
+        assert!(matches!(sniff_media_kind(&bytes), MediaKind::Image(m) if m == "image/png"));
+    }
+
+    #[test]
+    fn sniff_detects_gif_magic() {
+        let bytes = b"GIF89a....";
+        assert!(matches!(sniff_media_kind(bytes), MediaKind::Image(m) if m == "image/gif"));
+    }
+
+    #[test]
+    fn sniff_detects_webp_magic() {
+        // RIFF + size bytes + WEBP
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(b"RIFF");
+        bytes.extend_from_slice(&[0, 0, 0, 0]);
+        bytes.extend_from_slice(b"WEBP");
+        bytes.extend_from_slice(b"VP8 ");
+        assert!(matches!(sniff_media_kind(&bytes), MediaKind::Image(m) if m == "image/webp"));
+    }
+
+    #[test]
+    fn sniff_detects_pdf_magic() {
+        let bytes = b"%PDF-1.7\n...";
+        assert!(matches!(sniff_media_kind(bytes), MediaKind::Pdf));
+    }
+
+    #[test]
+    fn sniff_returns_unknown_for_unrecognized_payload() {
+        let bytes = b"not a real file";
+        assert!(matches!(sniff_media_kind(bytes), MediaKind::Unknown));
+    }
+
+    #[test]
+    fn sniff_guards_short_buffers() {
+        // Buffer shorter than every signature must not panic and must not
+        // match any known kind.
+        for n in 0..3usize {
+            let bytes = vec![0u8; n];
+            assert!(matches!(sniff_media_kind(&bytes), MediaKind::Unknown));
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // sniff_and_build_image_part
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn build_image_part_from_jpeg_bytes() {
+        let bytes = [0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46];
+        let part = sniff_and_build_image_part(&bytes).expect("jpeg must be accepted");
+        match part {
+            ResponseContentPart::InputImage {
+                image_url: Some(url),
+                file_id: None,
+                detail: None,
+            } => {
+                assert!(
+                    url.starts_with("data:image/jpeg;base64,"),
+                    "expected jpeg data URL, got: {url}"
+                );
+                let encoded = url.strip_prefix("data:image/jpeg;base64,").unwrap();
+                let roundtrip = BASE64_STANDARD.decode(encoded).unwrap();
+                assert_eq!(roundtrip, bytes.to_vec());
+            }
+            other => panic!("expected InputImage, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn build_image_part_rejects_pdf_pending_r4() {
+        let bytes = b"%PDF-1.4\n%\xc7\xec\x8f\xa2\n";
+        let err = sniff_and_build_image_part(bytes).expect_err("PDF must be rejected");
+        assert_eq!(err.error_code(), "unsupported_content");
+        assert!(
+            err.message().contains("R4"),
+            "PDF error must reference R4, got: {}",
+            err.message()
+        );
+    }
+
+    #[test]
+    fn build_image_part_rejects_unknown_bytes() {
+        let err = sniff_and_build_image_part(b"garbage").expect_err("unknown kind must reject");
+        assert_eq!(err.error_code(), "unsupported_content");
+    }
+
+    // ------------------------------------------------------------------
+    // preprocess_responses_input — error paths (no HTTP required)
+    // ------------------------------------------------------------------
+
+    fn user_message_with_parts(parts: Vec<ResponseContentPart>) -> ResponsesRequest {
+        ResponsesRequest {
+            input: ResponseInput::Items(vec![ResponseInputOutputItem::Message {
+                id: "msg_1".to_string(),
+                role: "user".to_string(),
+                content: parts,
+                status: None,
+                phase: None,
+            }]),
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn preprocess_text_input_is_noop() {
+        let mut req = ResponsesRequest {
+            input: ResponseInput::Text("hello".to_string()),
+            ..Default::default()
+        };
+        preprocess_responses_input(&mut req, None).await.unwrap();
+        match req.input {
+            ResponseInput::Text(t) => assert_eq!(t, "hello"),
+            ResponseInput::Items(_) => panic!("text input must stay text"),
+        }
+    }
+
+    #[tokio::test]
+    async fn preprocess_input_image_data_url_passes_through() {
+        let url = "data:image/png;base64,iVBORw0KGgoAAAANS".to_string();
+        let mut req = user_message_with_parts(vec![ResponseContentPart::InputImage {
+            detail: None,
+            file_id: None,
+            image_url: Some(url.clone()),
+        }]);
+        preprocess_responses_input(&mut req, None).await.unwrap();
+        let parts = match &req.input {
+            ResponseInput::Items(items) => match &items[0] {
+                ResponseInputOutputItem::Message { content, .. } => content,
+                other => panic!("unexpected item: {other:?}"),
+            },
+            ResponseInput::Text(_) => panic!("unexpected text input"),
+        };
+        match &parts[0] {
+            ResponseContentPart::InputImage {
+                image_url: Some(u), ..
+            } => assert_eq!(u, &url),
+            other => panic!("expected InputImage, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn preprocess_rejects_input_image_file_id() {
+        let mut req = user_message_with_parts(vec![ResponseContentPart::InputImage {
+            detail: None,
+            file_id: Some("file_abc".to_string()),
+            image_url: None,
+        }]);
+        let err = preprocess_responses_input(&mut req, None)
+            .await
+            .expect_err("file_id must be rejected");
+        assert_eq!(err.error_code(), "unsupported_content");
+    }
+
+    #[tokio::test]
+    async fn preprocess_rejects_input_image_missing_source() {
+        let mut req = user_message_with_parts(vec![ResponseContentPart::InputImage {
+            detail: None,
+            file_id: None,
+            image_url: None,
+        }]);
+        let err = preprocess_responses_input(&mut req, None)
+            .await
+            .expect_err("missing source must be rejected");
+        assert_eq!(err.error_code(), "invalid_request");
+    }
+
+    #[tokio::test]
+    async fn preprocess_rewrites_input_file_base64_jpeg() {
+        // Minimal JPEG magic bytes — the downstream image decoder is not
+        // involved at this stage; we only care that preprocessing accepts
+        // JPEG magic and rewrites to an InputImage data URL.
+        let jpeg_bytes = [0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A];
+        let file_data = BASE64_STANDARD.encode(jpeg_bytes);
+        let mut req = user_message_with_parts(vec![ResponseContentPart::InputFile {
+            detail: None,
+            file_data: Some(file_data),
+            file_id: None,
+            file_url: None,
+            filename: Some("photo.jpg".to_string()),
+        }]);
+
+        preprocess_responses_input(&mut req, None).await.unwrap();
+
+        let parts = match &req.input {
+            ResponseInput::Items(items) => match &items[0] {
+                ResponseInputOutputItem::Message { content, .. } => content,
+                other => panic!("unexpected item: {other:?}"),
+            },
+            ResponseInput::Text(_) => panic!("unexpected text input"),
+        };
+
+        match &parts[0] {
+            ResponseContentPart::InputImage {
+                image_url: Some(url),
+                ..
+            } => {
+                assert!(url.starts_with("data:image/jpeg;base64,"));
+                let encoded = url.strip_prefix("data:image/jpeg;base64,").unwrap();
+                let decoded = BASE64_STANDARD.decode(encoded).unwrap();
+                assert_eq!(decoded, jpeg_bytes);
+            }
+            other => panic!("expected InputImage after rewrite, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn preprocess_rejects_input_file_pdf_pending_r4() {
+        let pdf_bytes = b"%PDF-1.4\n%\xc7\xec\x8f\xa2\n";
+        let file_data = BASE64_STANDARD.encode(pdf_bytes);
+        let mut req = user_message_with_parts(vec![ResponseContentPart::InputFile {
+            detail: None,
+            file_data: Some(file_data),
+            file_id: None,
+            file_url: None,
+            filename: Some("spec.pdf".to_string()),
+        }]);
+
+        let err = preprocess_responses_input(&mut req, None)
+            .await
+            .expect_err("PDF must be rejected");
+        assert_eq!(err.error_code(), "unsupported_content");
+        assert!(
+            err.message().contains("R4"),
+            "PDF error must cite R4, got: {}",
+            err.message()
+        );
+    }
+
+    #[tokio::test]
+    async fn preprocess_rejects_input_file_file_id() {
+        let mut req = user_message_with_parts(vec![ResponseContentPart::InputFile {
+            detail: None,
+            file_data: None,
+            file_id: Some("file_abc".to_string()),
+            file_url: None,
+            filename: None,
+        }]);
+        let err = preprocess_responses_input(&mut req, None)
+            .await
+            .expect_err("file_id must be rejected");
+        assert_eq!(err.error_code(), "unsupported_content");
+    }
+
+    #[tokio::test]
+    async fn preprocess_rejects_input_file_empty() {
+        let mut req = user_message_with_parts(vec![ResponseContentPart::InputFile {
+            detail: None,
+            file_data: None,
+            file_id: None,
+            file_url: None,
+            filename: None,
+        }]);
+        let err = preprocess_responses_input(&mut req, None)
+            .await
+            .expect_err("empty input_file must be rejected");
+        assert_eq!(err.error_code(), "invalid_request");
+    }
+
+    #[tokio::test]
+    async fn preprocess_rejects_input_file_url_without_media_connector() {
+        let mut req = user_message_with_parts(vec![ResponseContentPart::InputFile {
+            detail: None,
+            file_data: None,
+            file_id: None,
+            file_url: Some("https://example.com/x.jpg".to_string()),
+            filename: None,
+        }]);
+        let err = preprocess_responses_input(&mut req, None)
+            .await
+            .expect_err("file_url without connector must be rejected");
+        assert_eq!(err.error_code(), "unsupported_content");
+    }
+
+    #[tokio::test]
+    async fn preprocess_rejects_refusal_on_input_role() {
+        let mut req = user_message_with_parts(vec![ResponseContentPart::Refusal {
+            refusal: "I can't help with that.".to_string(),
+        }]);
+        let err = preprocess_responses_input(&mut req, None)
+            .await
+            .expect_err("input-role refusal must be rejected");
+        assert_eq!(err.error_code(), "unsupported_content");
+    }
+
+    #[tokio::test]
+    async fn preprocess_allows_refusal_on_assistant_role() {
+        // On an assistant (output) role a refusal is a legitimate prior turn
+        // (e.g. loaded from conversation history). Preprocessing must not
+        // reject it; the downstream text extractor preserves it verbatim.
+        let mut req = ResponsesRequest {
+            input: ResponseInput::Items(vec![ResponseInputOutputItem::Message {
+                id: "msg_1".to_string(),
+                role: "assistant".to_string(),
+                content: vec![ResponseContentPart::Refusal {
+                    refusal: "previous refusal".to_string(),
+                }],
+                status: None,
+                phase: None,
+            }]),
+            ..Default::default()
+        };
+        preprocess_responses_input(&mut req, None).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn preprocess_walks_simple_input_message_arrays() {
+        // SimpleInputMessage carries a StringOrContentParts::Array — the
+        // preprocess pass must walk that array too.
+        use openai_protocol::responses::SimpleInputMessageTypeTag;
+        let mut req = ResponsesRequest {
+            input: ResponseInput::Items(vec![ResponseInputOutputItem::SimpleInputMessage {
+                role: "user".to_string(),
+                content: StringOrContentParts::Array(vec![ResponseContentPart::InputImage {
+                    detail: None,
+                    file_id: Some("file_abc".to_string()),
+                    image_url: None,
+                }]),
+                r#type: Some(SimpleInputMessageTypeTag::Message),
+                phase: None,
+            }]),
+            ..Default::default()
+        };
+        let err = preprocess_responses_input(&mut req, None)
+            .await
+            .expect_err("file_id in SimpleInputMessage must be rejected too");
+        assert_eq!(err.error_code(), "unsupported_content");
+    }
+
+    // ------------------------------------------------------------------
+    // HTTP fetch tests — spin up a minimal axum server on an ephemeral
+    // port so we can exercise the `file_url` branch end-to-end without
+    // needing a crate-level HTTP mock fixture.
+    // ------------------------------------------------------------------
+
+    use axum::{body::Bytes as AxumBytes, extract::State, response::IntoResponse, routing::get};
+    use llm_multimodal::{MediaConnector, MediaConnectorConfig};
+    use std::net::SocketAddr;
+    use tokio::{net::TcpListener, task::JoinHandle};
+
+    struct MockFileServer {
+        addr: SocketAddr,
+        _handle: JoinHandle<()>,
+    }
+
+    impl MockFileServer {
+        /// Spin up an axum server that serves `bytes` at `GET /file` on a
+        /// random 127.0.0.1 port. Returns the server and its base URL.
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "test fixture — spawned task ends with the test"
+        )]
+        async fn start(bytes: Vec<u8>) -> Self {
+            let state = Arc::new(bytes);
+            let app = axum::Router::new()
+                .route("/file", get(serve_file))
+                .with_state(state);
+
+            let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let addr = listener.local_addr().unwrap();
+            let handle = tokio::spawn(async move {
+                axum::serve(listener, app).await.unwrap();
+            });
+            // Give the server a tick to bind.
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            Self {
+                addr,
+                _handle: handle,
+            }
+        }
+
+        fn url(&self, path: &str) -> String {
+            format!("http://{}{}", self.addr, path)
+        }
+    }
+
+    async fn serve_file(State(bytes): State<Arc<Vec<u8>>>) -> impl IntoResponse {
+        AxumBytes::from(bytes.as_ref().clone())
+    }
+
+    fn default_connector() -> Arc<MediaConnector> {
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(5))
+            .build()
+            .unwrap();
+        Arc::new(MediaConnector::new(client, MediaConnectorConfig::default()).unwrap())
+    }
+
+    #[tokio::test]
+    async fn preprocess_rewrites_input_file_url_jpeg() {
+        // Serve a tiny JPEG-magic payload over an ephemeral port and
+        // verify preprocess downloads it, sniffs the magic, and rewrites
+        // the InputFile into an InputImage with a `data:image/jpeg` URL.
+        let jpeg = vec![0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46];
+        let server = MockFileServer::start(jpeg.clone()).await;
+        let url = server.url("/file");
+        let connector = default_connector();
+
+        let mut req = user_message_with_parts(vec![ResponseContentPart::InputFile {
+            detail: None,
+            file_data: None,
+            file_id: None,
+            file_url: Some(url),
+            filename: Some("photo.bin".to_string()),
+        }]);
+
+        preprocess_responses_input(&mut req, Some(&connector))
+            .await
+            .expect("jpeg file_url must be accepted");
+
+        let parts = match &req.input {
+            ResponseInput::Items(items) => match &items[0] {
+                ResponseInputOutputItem::Message { content, .. } => content,
+                other => panic!("unexpected item: {other:?}"),
+            },
+            ResponseInput::Text(_) => panic!("unexpected text input"),
+        };
+        match &parts[0] {
+            ResponseContentPart::InputImage {
+                image_url: Some(url),
+                ..
+            } => {
+                assert!(
+                    url.starts_with("data:image/jpeg;base64,"),
+                    "expected rewritten to data URL, got: {url}"
+                );
+                let encoded = url.strip_prefix("data:image/jpeg;base64,").unwrap();
+                let decoded = BASE64_STANDARD.decode(encoded).unwrap();
+                assert_eq!(decoded, jpeg);
+            }
+            other => panic!("expected InputImage after file_url fetch, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn preprocess_rejects_input_file_url_pdf_pending_r4() {
+        // file_url that resolves to a PDF must get the same R4-pending
+        // rejection as base64 file_data with PDF magic.
+        let pdf = b"%PDF-1.4\n%\xc7\xec\x8f\xa2\n".to_vec();
+        let server = MockFileServer::start(pdf).await;
+        let url = server.url("/file");
+        let connector = default_connector();
+
+        let mut req = user_message_with_parts(vec![ResponseContentPart::InputFile {
+            detail: None,
+            file_data: None,
+            file_id: None,
+            file_url: Some(url),
+            filename: None,
+        }]);
+
+        let err = preprocess_responses_input(&mut req, Some(&connector))
+            .await
+            .expect_err("pdf file_url must be rejected");
+        assert_eq!(err.error_code(), "unsupported_content");
+        assert!(
+            err.message().contains("R4"),
+            "PDF error must cite R4, got: {}",
+            err.message()
+        );
+    }
+
+    #[tokio::test]
+    async fn preprocess_rejects_input_file_url_non_image() {
+        // file_url that resolves to neither an image nor a PDF must be
+        // rejected rather than silently forwarded.
+        let server = MockFileServer::start(b"arbitrary binary blob".to_vec()).await;
+        let url = server.url("/file");
+        let connector = default_connector();
+
+        let mut req = user_message_with_parts(vec![ResponseContentPart::InputFile {
+            detail: None,
+            file_data: None,
+            file_id: None,
+            file_url: Some(url),
+            filename: None,
+        }]);
+
+        let err = preprocess_responses_input(&mut req, Some(&connector))
+            .await
+            .expect_err("non-image file_url must be rejected");
+        assert_eq!(err.error_code(), "unsupported_content");
+    }
+}

--- a/model_gateway/src/routers/grpc/regular/responses/content_parts.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/content_parts.rs
@@ -34,7 +34,7 @@ use openai_protocol::responses::{
     ResponseContentPart, ResponseInput, ResponseInputOutputItem, ResponsesRequest,
     StringOrContentParts,
 };
-use tracing::warn;
+use tracing::debug;
 
 /// Typed error returned by preprocessing and
 /// [`super::conversions::responses_to_chat`]. Callers map each variant to an
@@ -185,12 +185,14 @@ async fn normalize_one(
             file_id,
             file_url,
             filename,
-            detail: _,
+            detail,
         } => {
-            if let Some(name) = filename.as_deref() {
-                // Filename is informational metadata. Log but do not fail,
-                // since the spec treats it as a hint not a handle.
-                warn!(filename = %name, "input_file filename is informational — ignored");
+            if filename.is_some() {
+                // Filename is informational metadata. The spec treats it as
+                // a hint not a handle, and it's user-provided data, so log
+                // only that one was present (never the raw value) at debug
+                // level to avoid leaking sensitive PII into server logs.
+                debug!("input_file filename metadata provided; ignored");
             }
 
             if file_id.is_some() {
@@ -201,13 +203,20 @@ async fn normalize_one(
                 ));
             }
 
+            // Map `FileDetail::{Low,High}` to the corresponding image
+            // `Detail` so caller-selected fidelity survives the rewrite —
+            // otherwise file-backed images would silently fall back to
+            // the downstream default and lose the cost / quality hint the
+            // client asked for.
+            let carried_detail = file_detail_to_image_detail(detail.as_ref());
+
             if let Some(data) = file_data.take() {
                 let bytes = BASE64_STANDARD.decode(data.as_bytes()).map_err(|e| {
                     ConversionError::InvalidRequest(format!(
                         "input_file.file_data is not valid base64: {e}"
                     ))
                 })?;
-                let normalized = sniff_and_build_image_part(&bytes)?;
+                let normalized = sniff_and_build_image_part(&bytes, carried_detail)?;
                 *part = normalized;
                 return Ok(());
             }
@@ -225,7 +234,7 @@ async fn normalize_one(
                         "failed to download input_file.file_url: {e}"
                     ))
                 })?;
-                let normalized = sniff_and_build_image_part(bytes.as_ref())?;
+                let normalized = sniff_and_build_image_part(bytes.as_ref(), carried_detail)?;
                 *part = normalized;
                 return Ok(());
             }
@@ -240,12 +249,20 @@ async fn normalize_one(
 /// Classify a byte payload by its file signature and build the matching
 /// content part. Images become `InputImage` with a `data:` URL; PDFs are
 /// rejected pending R4; everything else is rejected as `unsupported_content`.
-fn sniff_and_build_image_part(bytes: &[u8]) -> Result<ResponseContentPart, ConversionError> {
+///
+/// `carried_detail` is the caller's fidelity hint from the originating
+/// `InputFile.detail` (mapped to the image-side `Detail` enum). It is
+/// threaded through so the downstream multimodal preprocessor honors
+/// `low` / `high` tiers rather than falling back to its own default.
+fn sniff_and_build_image_part(
+    bytes: &[u8],
+    carried_detail: Option<openai_protocol::common::Detail>,
+) -> Result<ResponseContentPart, ConversionError> {
     match sniff_media_kind(bytes) {
         MediaKind::Image(mime) => {
             let encoded = BASE64_STANDARD.encode(bytes);
             Ok(ResponseContentPart::InputImage {
-                detail: None,
+                detail: carried_detail,
                 file_id: None,
                 image_url: Some(format!("data:{mime};base64,{encoded}")),
             })
@@ -258,6 +275,19 @@ fn sniff_and_build_image_part(bytes: &[u8]) -> Result<ResponseContentPart, Conve
             "input_file payload is not a recognized image (jpeg/png/webp/gif) or PDF".to_string(),
         )),
     }
+}
+
+/// Map an optional `FileDetail` (spec: `"low" | "high"`) to the broader
+/// `Detail` enum used by `InputImage` (`"low" | "high" | "auto" | "original"`).
+/// `None` stays `None` so downstream pipeline defaults still apply.
+fn file_detail_to_image_detail(
+    detail: Option<&openai_protocol::responses::FileDetail>,
+) -> Option<openai_protocol::common::Detail> {
+    use openai_protocol::{common::Detail, responses::FileDetail};
+    detail.map(|d| match d {
+        FileDetail::Low => Detail::Low,
+        FileDetail::High => Detail::High,
+    })
 }
 
 /// Minimal magic-byte classifier covering every MIME type the downstream
@@ -369,7 +399,7 @@ mod tests {
     #[test]
     fn build_image_part_from_jpeg_bytes() {
         let bytes = [0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46];
-        let part = sniff_and_build_image_part(&bytes).expect("jpeg must be accepted");
+        let part = sniff_and_build_image_part(&bytes, None).expect("jpeg must be accepted");
         match part {
             ResponseContentPart::InputImage {
                 image_url: Some(url),
@@ -389,9 +419,27 @@ mod tests {
     }
 
     #[test]
+    fn build_image_part_threads_detail_into_rewritten_input_image() {
+        // FileDetail::High must become Detail::High on the rewritten
+        // InputImage so downstream multimodal preprocessing honors the
+        // caller's fidelity hint instead of falling back to auto.
+        use openai_protocol::common::Detail;
+        let bytes = [0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46];
+        let part = sniff_and_build_image_part(&bytes, Some(Detail::High))
+            .expect("jpeg with detail must be accepted");
+        match part {
+            ResponseContentPart::InputImage {
+                detail: Some(Detail::High),
+                ..
+            } => {}
+            other => panic!("expected InputImage detail=High, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn build_image_part_rejects_pdf_pending_r4() {
         let bytes = b"%PDF-1.4\n%\xc7\xec\x8f\xa2\n";
-        let err = sniff_and_build_image_part(bytes).expect_err("PDF must be rejected");
+        let err = sniff_and_build_image_part(bytes, None).expect_err("PDF must be rejected");
         assert_eq!(err.error_code(), "unsupported_content");
         assert!(
             err.message().contains("R4"),
@@ -402,7 +450,8 @@ mod tests {
 
     #[test]
     fn build_image_part_rejects_unknown_bytes() {
-        let err = sniff_and_build_image_part(b"garbage").expect_err("unknown kind must reject");
+        let err =
+            sniff_and_build_image_part(b"garbage", None).expect_err("unknown kind must reject");
         assert_eq!(err.error_code(), "unsupported_content");
     }
 
@@ -522,6 +571,41 @@ mod tests {
                 assert_eq!(decoded, jpeg_bytes);
             }
             other => panic!("expected InputImage after rewrite, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn preprocess_preserves_file_detail_when_rewriting_input_file() {
+        // Caller sends input_file with detail=high; after normalization
+        // the rewritten input_image must carry detail=Detail::High so the
+        // chat pipeline's `image_url.detail` ends up "high" instead of
+        // defaulting to auto (which changes cost / quality downstream).
+        use openai_protocol::{common::Detail, responses::FileDetail};
+        let jpeg_bytes = [0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A];
+        let file_data = BASE64_STANDARD.encode(jpeg_bytes);
+        let mut req = user_message_with_parts(vec![ResponseContentPart::InputFile {
+            detail: Some(FileDetail::High),
+            file_data: Some(file_data),
+            file_id: None,
+            file_url: None,
+            filename: None,
+        }]);
+
+        preprocess_responses_input(&mut req, None).await.unwrap();
+
+        let parts = match &req.input {
+            ResponseInput::Items(items) => match &items[0] {
+                ResponseInputOutputItem::Message { content, .. } => content,
+                other => panic!("unexpected item: {other:?}"),
+            },
+            ResponseInput::Text(_) => panic!("unexpected text input"),
+        };
+        match &parts[0] {
+            ResponseContentPart::InputImage {
+                detail: Some(Detail::High),
+                ..
+            } => {}
+            other => panic!("expected InputImage detail=High, got {other:?}"),
         }
     }
 

--- a/model_gateway/src/routers/grpc/regular/responses/content_parts.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/content_parts.rs
@@ -171,8 +171,12 @@ async fn normalize_one(
                 ));
             }
             if image_url.is_none() {
+                // `file_id` is rejected separately above with
+                // `unsupported_content`, so don't list it here — the
+                // two error messages would otherwise contradict each
+                // other for a client staring at both paths.
                 return Err(ConversionError::InvalidRequest(
-                    "input_image requires either image_url or file_id".to_string(),
+                    "input_image requires image_url".to_string(),
                 ));
             }
             // image_url (HTTP or data URL) passes through — the chat pipeline
@@ -208,7 +212,7 @@ async fn normalize_one(
             // otherwise file-backed images would silently fall back to
             // the downstream default and lose the cost / quality hint the
             // client asked for.
-            let carried_detail = file_detail_to_image_detail(detail.as_ref());
+            let carried_detail = Some(file_detail_to_image_detail(detail.as_ref()));
 
             if let Some(data) = file_data.take() {
                 let bytes = BASE64_STANDARD.decode(data.as_bytes()).map_err(|e| {
@@ -239,8 +243,11 @@ async fn normalize_one(
                 return Ok(());
             }
 
+            // `file_id` is rejected separately above with
+            // `unsupported_content`, so only list the shapes that this
+            // router actually resolves.
             Err(ConversionError::InvalidRequest(
-                "input_file requires one of file_data, file_url, or file_id".to_string(),
+                "input_file requires file_data (base64) or file_url".to_string(),
             ))
         }
     }
@@ -251,9 +258,10 @@ async fn normalize_one(
 /// rejected pending R4; everything else is rejected as `unsupported_content`.
 ///
 /// `carried_detail` is the caller's fidelity hint from the originating
-/// `InputFile.detail` (mapped to the image-side `Detail` enum). It is
-/// threaded through so the downstream multimodal preprocessor honors
-/// `low` / `high` tiers rather than falling back to its own default.
+/// `InputFile.detail` (mapped to the image-side `Detail` enum, with spec
+/// default `Low` substituted for an absent value). It is threaded through
+/// so the downstream multimodal preprocessor honors `low` / `high` tiers
+/// rather than falling back to its own default.
 fn sniff_and_build_image_part(
     bytes: &[u8],
     carried_detail: Option<openai_protocol::common::Detail>,
@@ -279,15 +287,22 @@ fn sniff_and_build_image_part(
 
 /// Map an optional `FileDetail` (spec: `"low" | "high"`) to the broader
 /// `Detail` enum used by `InputImage` (`"low" | "high" | "auto" | "original"`).
-/// `None` stays `None` so downstream pipeline defaults still apply.
+///
+/// Spec pins `FileDetail`'s default to `low`, so a missing `input_file.detail`
+/// must become `Detail::Low` — not `None` — on the rewritten `InputImage`.
+/// Leaving it `None` would let the downstream multimodal tracker fall back
+/// to `auto` (via `detail.unwrap_or_default()` which resolves to
+/// `ImageDetail::Auto`), silently promoting the request's fidelity tier
+/// and changing model behavior / cost. The caller wraps the result in
+/// `Some(..)` when constructing the rewritten `InputImage`.
 fn file_detail_to_image_detail(
     detail: Option<&openai_protocol::responses::FileDetail>,
-) -> Option<openai_protocol::common::Detail> {
+) -> openai_protocol::common::Detail {
     use openai_protocol::{common::Detail, responses::FileDetail};
-    detail.map(|d| match d {
-        FileDetail::Low => Detail::Low,
-        FileDetail::High => Detail::High,
-    })
+    match detail {
+        Some(FileDetail::High) => Detail::High,
+        Some(FileDetail::Low) | None => Detail::Low,
+    }
 }
 
 /// Minimal magic-byte classifier covering every MIME type the downstream
@@ -571,6 +586,42 @@ mod tests {
                 assert_eq!(decoded, jpeg_bytes);
             }
             other => panic!("expected InputImage after rewrite, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn preprocess_defaults_omitted_file_detail_to_low() {
+        // Spec pins FileDetail default to "low", so a missing
+        // input_file.detail must become Detail::Low on the rewritten
+        // input_image — otherwise the multimodal tracker's
+        // `unwrap_or_default() → ImageDetail::Auto` silently promotes
+        // fidelity.
+        use openai_protocol::common::Detail;
+        let jpeg_bytes = [0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A];
+        let file_data = BASE64_STANDARD.encode(jpeg_bytes);
+        let mut req = user_message_with_parts(vec![ResponseContentPart::InputFile {
+            detail: None,
+            file_data: Some(file_data),
+            file_id: None,
+            file_url: None,
+            filename: None,
+        }]);
+
+        preprocess_responses_input(&mut req, None).await.unwrap();
+
+        let parts = match &req.input {
+            ResponseInput::Items(items) => match &items[0] {
+                ResponseInputOutputItem::Message { content, .. } => content,
+                other => panic!("unexpected item: {other:?}"),
+            },
+            ResponseInput::Text(_) => panic!("unexpected text input"),
+        };
+        match &parts[0] {
+            ResponseContentPart::InputImage {
+                detail: Some(Detail::Low),
+                ..
+            } => {}
+            other => panic!("expected InputImage detail=Low, got {other:?}"),
         }
     }
 

--- a/model_gateway/src/routers/grpc/regular/responses/conversions.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/conversions.rs
@@ -9,7 +9,10 @@
 
 use openai_protocol::{
     chat::{ChatCompletionRequest, ChatCompletionResponse, ChatMessage, MessageContent},
-    common::{FunctionCallResponse, JsonSchemaFormat, ResponseFormat, ToolCall, UsageInfo},
+    common::{
+        ContentPart, FunctionCallResponse, ImageUrl, JsonSchemaFormat, ResponseFormat, ToolCall,
+        UsageInfo,
+    },
     responses::{
         ResponseContentPart, ResponseInput, ResponseInputOutputItem, ResponseOutputItem,
         ResponseReasoningContent::ReasoningText, ResponseStatus, ResponsesRequest,
@@ -19,6 +22,7 @@ use openai_protocol::{
 };
 use tracing::warn;
 
+use super::content_parts::ConversionError;
 use crate::routers::grpc::common::responses::utils::extract_tools_from_response_tools;
 
 /// Convert a ResponsesRequest to ChatCompletionRequest for processing through the chat pipeline
@@ -30,7 +34,18 @@ use crate::routers::grpc::common::responses::utils::extract_tools_from_response_
 /// - `tools` → function tools extracted from ResponseTools
 /// - `tool_choice` → passed through from request
 /// - Response-specific fields (previous_response_id, conversation) are handled by router
-pub(crate) fn responses_to_chat(req: &ResponsesRequest) -> Result<ChatCompletionRequest, String> {
+///
+/// Assumes the caller has already run
+/// [`super::content_parts::preprocess_responses_input`] so that every
+/// [`ResponseContentPart::InputImage`] carries an `image_url` (HTTP or
+/// `data:`) and every [`ResponseContentPart::InputFile`] has either been
+/// rewritten to `InputImage` or rejected. The only remaining branching in
+/// here is mapping `InputImage` to [`ContentPart::ImageUrl`] so the chat
+/// pipeline's existing [`crate::routers::grpc::multimodal`] integration
+/// picks it up automatically.
+pub(crate) fn responses_to_chat(
+    req: &ResponsesRequest,
+) -> Result<ChatCompletionRequest, ConversionError> {
     let mut messages = Vec::new();
 
     // 1. Add system message if instructions provided
@@ -55,31 +70,17 @@ pub(crate) fn responses_to_chat(req: &ResponsesRequest) -> Result<ChatCompletion
             for item in items {
                 match item {
                     ResponseInputOutputItem::SimpleInputMessage { content, role, .. } => {
-                        // Convert SimpleInputMessage to chat message
-                        let text = match content {
-                            StringOrContentParts::String(s) => s.clone(),
+                        let chat_content = match content {
+                            StringOrContentParts::String(s) => MessageContent::Text(s.clone()),
                             StringOrContentParts::Array(parts) => {
-                                // Extract text from content parts (only InputText supported)
-                                parts
-                                    .iter()
-                                    .filter_map(|part| match part {
-                                        ResponseContentPart::InputText { text } => {
-                                            Some(text.as_str())
-                                        }
-                                        _ => None,
-                                    })
-                                    .collect::<Vec<_>>()
-                                    .join(" ")
+                                build_message_content(parts, role.as_str())?
                             }
                         };
-
-                        messages.push(role_to_chat_message(role.as_str(), text));
+                        messages.push(role_to_chat_message(role.as_str(), chat_content));
                     }
                     ResponseInputOutputItem::Message { role, content, .. } => {
-                        // Extract text from content parts
-                        let text = extract_text_from_content(content);
-
-                        messages.push(role_to_chat_message(role.as_str(), text));
+                        let chat_content = build_message_content(content, role.as_str())?;
+                        messages.push(role_to_chat_message(role.as_str(), chat_content));
                     }
                     ResponseInputOutputItem::FunctionToolCall {
                         id,
@@ -152,18 +153,24 @@ pub(crate) fn responses_to_chat(req: &ResponsesRequest) -> Result<ChatCompletion
                             function = "responses_to_chat",
                             "Approval item reached chat conversion"
                         );
-                        return Err("Unsupported input item type".to_string());
+                        return Err(ConversionError::UnsupportedContent(
+                            "Unsupported input item type".to_string(),
+                        ));
                     }
                     ResponseInputOutputItem::ImageGenerationCall { .. } => {
                         warn!(
                             function = "responses_to_chat",
                             "image_generation_call input item reached chat conversion"
                         );
-                        return Err("Unsupported input item type".to_string());
+                        return Err(ConversionError::UnsupportedContent(
+                            "Unsupported input item type".to_string(),
+                        ));
                     }
                     ResponseInputOutputItem::Compaction { .. }
                     | ResponseInputOutputItem::ItemReference { .. } => {
-                        return Err("Unsupported input item type".to_string());
+                        return Err(ConversionError::UnsupportedContent(
+                            "Unsupported input item type".to_string(),
+                        ));
                     }
                     ResponseInputOutputItem::CustomToolCall { .. }
                     | ResponseInputOutputItem::CustomToolCallOutput { .. } => {
@@ -171,7 +178,9 @@ pub(crate) fn responses_to_chat(req: &ResponsesRequest) -> Result<ChatCompletion
                             function = "responses_to_chat",
                             "Custom tool item reached chat conversion"
                         );
-                        return Err("Unsupported input item type".to_string());
+                        return Err(ConversionError::UnsupportedContent(
+                            "Unsupported input item type".to_string(),
+                        ));
                     }
                     ResponseInputOutputItem::ShellCall { .. }
                     | ResponseInputOutputItem::ShellCallOutput { .. } => {
@@ -179,7 +188,9 @@ pub(crate) fn responses_to_chat(req: &ResponsesRequest) -> Result<ChatCompletion
                             function = "responses_to_chat",
                             "Shell tool item reached chat conversion"
                         );
-                        return Err("Unsupported input item type".to_string());
+                        return Err(ConversionError::UnsupportedContent(
+                            "Unsupported input item type".to_string(),
+                        ));
                     }
                     ResponseInputOutputItem::ApplyPatchCall { .. }
                     | ResponseInputOutputItem::ApplyPatchCallOutput { .. } => {
@@ -187,12 +198,16 @@ pub(crate) fn responses_to_chat(req: &ResponsesRequest) -> Result<ChatCompletion
                             function = "responses_to_chat",
                             "apply_patch item reached chat conversion"
                         );
-                        return Err("Unsupported input item type".to_string());
+                        return Err(ConversionError::UnsupportedContent(
+                            "Unsupported input item type".to_string(),
+                        ));
                     }
                     // T5 schema-only: forced-cascade arm, no behavior.
                     ResponseInputOutputItem::LocalShellCall { .. }
                     | ResponseInputOutputItem::LocalShellCallOutput { .. } => {
-                        return Err("Unsupported input item type".to_string());
+                        return Err(ConversionError::UnsupportedContent(
+                            "Unsupported input item type".to_string(),
+                        ));
                     }
                 }
             }
@@ -201,7 +216,9 @@ pub(crate) fn responses_to_chat(req: &ResponsesRequest) -> Result<ChatCompletion
 
     // Ensure we have at least one message
     if messages.is_empty() {
-        return Err("Request must contain at least one message".to_string());
+        return Err(ConversionError::InvalidRequest(
+            "Request must contain at least one message".to_string(),
+        ));
     }
 
     // 3. Extract function tools from ResponseTools.
@@ -249,46 +266,145 @@ pub(crate) fn responses_to_chat(req: &ResponsesRequest) -> Result<ChatCompletion
     })
 }
 
-/// Extract text content from ResponseContentPart array. `Refusal` is
-/// losslessly representable as text and is preserved verbatim. Image / file
-/// parts are currently dropped; the gRPC regular path is text-only and
-/// relies on the multimodal pipeline for media handling (R1/R2/R3 will
-/// implement full media handling).
-fn extract_text_from_content(content: &[ResponseContentPart]) -> String {
-    content
+/// Build a chat [`MessageContent`] from a Responses-API content-part array.
+///
+/// Emits:
+/// - [`MessageContent::Text`] when the array is text-only (every `InputText`
+///   / `OutputText` / `Refusal` entry concatenated with empty separator to
+///   match the prior behavior).
+/// - [`MessageContent::Parts`] when any [`ContentPart::ImageUrl`] is present,
+///   interleaving text and image URLs so the chat multimodal pipeline
+///   (`grpc/multimodal.rs`) can extract them.
+///
+/// Assumes [`super::content_parts::preprocess_responses_input`] has already
+/// normalized `InputFile` → `InputImage` and rejected `InputImage.file_id` /
+/// input-role `Refusal`. The `role` argument is currently unused here
+/// (those checks live in `content_parts`) but is kept in the signature so
+/// future role-sensitive decisions (e.g. refusal-on-assistant emission)
+/// have a single plumbing point.
+fn build_message_content(
+    parts: &[ResponseContentPart],
+    _role: &str,
+) -> Result<MessageContent, ConversionError> {
+    // Any InputFile at this layer means preprocessing was skipped — refuse
+    // to silently drop it.
+    if parts
         .iter()
-        .filter_map(|part| match part {
-            ResponseContentPart::InputText { text } => Some(text.as_str()),
-            ResponseContentPart::OutputText { text, .. } => Some(text.as_str()),
-            ResponseContentPart::Refusal { refusal } => Some(refusal.as_str()),
-            // R1/R2/R3 will implement full media handling
-            ResponseContentPart::InputImage { .. } | ResponseContentPart::InputFile { .. } => None,
-        })
-        .collect::<Vec<_>>()
-        .join("")
+        .any(|p| matches!(p, ResponseContentPart::InputFile { .. }))
+    {
+        return Err(ConversionError::UnsupportedContent(
+            "input_file reached conversions.rs without preprocessing — \
+             this is a bug in the Responses router"
+                .to_string(),
+        ));
+    }
+
+    let has_image = parts
+        .iter()
+        .any(|p| matches!(p, ResponseContentPart::InputImage { .. }));
+
+    if !has_image {
+        let text = parts
+            .iter()
+            .filter_map(|part| match part {
+                ResponseContentPart::InputText { text }
+                | ResponseContentPart::OutputText { text, .. } => Some(text.as_str()),
+                ResponseContentPart::Refusal { refusal } => Some(refusal.as_str()),
+                ResponseContentPart::InputImage { .. } | ResponseContentPart::InputFile { .. } => {
+                    None
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("");
+        return Ok(MessageContent::Text(text));
+    }
+
+    let mut chat_parts: Vec<ContentPart> = Vec::with_capacity(parts.len());
+    for part in parts {
+        match part {
+            ResponseContentPart::InputText { text }
+            | ResponseContentPart::OutputText { text, .. } => {
+                if !text.is_empty() {
+                    chat_parts.push(ContentPart::Text { text: text.clone() });
+                }
+            }
+            ResponseContentPart::Refusal { refusal } => {
+                if !refusal.is_empty() {
+                    chat_parts.push(ContentPart::Text {
+                        text: refusal.clone(),
+                    });
+                }
+            }
+            ResponseContentPart::InputImage {
+                image_url, detail, ..
+            } => {
+                // preprocess_responses_input guarantees image_url is set and
+                // file_id is None. Keep the defensive check so an
+                // unpreprocessed input surfaces a typed error instead of
+                // silently dropping the image.
+                let url = image_url.clone().ok_or_else(|| {
+                    ConversionError::InvalidRequest(
+                        "input_image is missing image_url after preprocessing — this is a bug"
+                            .to_string(),
+                    )
+                })?;
+                chat_parts.push(ContentPart::ImageUrl {
+                    image_url: ImageUrl {
+                        url,
+                        detail: detail.clone().map(detail_to_chat_string),
+                    },
+                });
+            }
+            ResponseContentPart::InputFile { .. } => {
+                // preprocess_responses_input must have rewritten this to an
+                // InputImage or rejected it. Anything still here is a bug.
+                return Err(ConversionError::UnsupportedContent(
+                    "input_file reached conversions.rs without preprocessing — \
+                     this is a bug in the Responses router"
+                        .to_string(),
+                ));
+            }
+        }
+    }
+
+    Ok(MessageContent::Parts(chat_parts))
 }
 
-/// Convert role and text to ChatMessage
-fn role_to_chat_message(role: &str, text: String) -> ChatMessage {
+/// Map the Responses-API [`Detail`] enum (low/high/auto/original) to the
+/// Chat-Completions `image_url.detail` string. The chat pipeline recognizes
+/// `"auto" | "low" | "high"` (see `multimodal::parse_detail`); unknown
+/// values are silently ignored downstream, so `Original` is passed through
+/// as its rename (`"original"`).
+fn detail_to_chat_string(detail: openai_protocol::common::Detail) -> String {
+    match detail {
+        openai_protocol::common::Detail::Low => "low".to_string(),
+        openai_protocol::common::Detail::High => "high".to_string(),
+        openai_protocol::common::Detail::Auto => "auto".to_string(),
+        openai_protocol::common::Detail::Original => "original".to_string(),
+    }
+}
+
+/// Convert role and content to ChatMessage
+fn role_to_chat_message(role: &str, content: MessageContent) -> ChatMessage {
     match role {
         "user" => ChatMessage::User {
-            content: MessageContent::Text(text),
+            content,
             name: None,
         },
         "assistant" => ChatMessage::Assistant {
-            content: Some(MessageContent::Text(text)),
+            content: Some(content),
             name: None,
             tool_calls: None,
             reasoning_content: None,
         },
         "system" => ChatMessage::System {
-            content: MessageContent::Text(text),
+            content,
             name: None,
         },
         _ => {
             // Unknown role, treat as user message
             ChatMessage::User {
-                content: MessageContent::Text(text),
+                content,
                 name: None,
             }
         }
@@ -575,7 +691,110 @@ mod tests {
         };
 
         let result = responses_to_chat(&req);
-        assert!(result.is_err());
-        assert_eq!(result.unwrap_err(), "Unsupported input item type");
+        let err = result.expect_err("ImageGenerationCall input must be rejected");
+        assert_eq!(err.error_code(), "unsupported_content");
+        assert_eq!(err.message(), "Unsupported input item type");
+    }
+
+    #[test]
+    fn test_input_image_content_part_produces_chat_image_part() {
+        // After preprocessing, an InputImage with image_url (data URL or
+        // HTTP) flows through responses_to_chat and is emitted as a chat
+        // `MessageContent::Parts` entry with `ContentPart::ImageUrl`. The
+        // downstream multimodal pipeline then picks it up automatically.
+        let req = ResponsesRequest {
+            input: ResponseInput::Items(vec![ResponseInputOutputItem::Message {
+                id: "msg_1".to_string(),
+                role: "user".to_string(),
+                content: vec![
+                    ResponseContentPart::InputText {
+                        text: "describe this:".to_string(),
+                    },
+                    ResponseContentPart::InputImage {
+                        detail: Some(openai_protocol::common::Detail::High),
+                        file_id: None,
+                        image_url: Some(
+                            "data:image/jpeg;base64,AAAA".to_string(),
+                        ),
+                    },
+                ],
+                status: None,
+                phase: None,
+            }]),
+            ..Default::default()
+        };
+
+        let chat_req = responses_to_chat(&req).unwrap();
+        assert_eq!(chat_req.messages.len(), 1);
+        let user = &chat_req.messages[0];
+        let parts = match user {
+            ChatMessage::User {
+                content: MessageContent::Parts(parts),
+                ..
+            } => parts,
+            other => panic!("expected User message with Parts content, got {other:?}"),
+        };
+        assert_eq!(parts.len(), 2);
+        match &parts[0] {
+            ContentPart::Text { text } => assert_eq!(text, "describe this:"),
+            other => panic!("expected Text part first, got {other:?}"),
+        }
+        match &parts[1] {
+            ContentPart::ImageUrl { image_url } => {
+                assert_eq!(image_url.url, "data:image/jpeg;base64,AAAA");
+                assert_eq!(image_url.detail.as_deref(), Some("high"));
+            }
+            other => panic!("expected ImageUrl part second, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_input_image_missing_url_errors_as_invalid_request() {
+        // If preprocessing ever misses an InputImage (no image_url), the
+        // conversion must surface a typed error rather than silently
+        // dropping the image.
+        let req = ResponsesRequest {
+            input: ResponseInput::Items(vec![ResponseInputOutputItem::Message {
+                id: "msg_1".to_string(),
+                role: "user".to_string(),
+                content: vec![ResponseContentPart::InputImage {
+                    detail: None,
+                    file_id: None,
+                    image_url: None,
+                }],
+                status: None,
+                phase: None,
+            }]),
+            ..Default::default()
+        };
+
+        let err = responses_to_chat(&req).expect_err("missing image_url must error");
+        assert_eq!(err.error_code(), "invalid_request");
+    }
+
+    #[test]
+    fn test_input_file_leaks_past_preprocess_errors() {
+        // Defensive contract: any InputFile reaching conversions is a bug,
+        // since preprocess_responses_input is expected to rewrite to
+        // InputImage or reject. Verify we surface a clear typed error.
+        let req = ResponsesRequest {
+            input: ResponseInput::Items(vec![ResponseInputOutputItem::Message {
+                id: "msg_1".to_string(),
+                role: "user".to_string(),
+                content: vec![ResponseContentPart::InputFile {
+                    detail: None,
+                    file_data: Some("AAAA".to_string()),
+                    file_id: None,
+                    file_url: None,
+                    filename: None,
+                }],
+                status: None,
+                phase: None,
+            }]),
+            ..Default::default()
+        };
+
+        let err = responses_to_chat(&req).expect_err("unpreprocessed InputFile must error");
+        assert_eq!(err.error_code(), "unsupported_content");
     }
 }

--- a/model_gateway/src/routers/grpc/regular/responses/conversions.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/conversions.rs
@@ -270,11 +270,20 @@ pub(crate) fn responses_to_chat(
 ///
 /// Emits:
 /// - [`MessageContent::Text`] when the array is text-only (every `InputText`
-///   / `OutputText` / `Refusal` entry concatenated with empty separator to
-///   match the prior behavior).
+///   / `OutputText` / `Refusal` entry concatenated with an empty separator).
 /// - [`MessageContent::Parts`] when any [`ContentPart::ImageUrl`] is present,
 ///   interleaving text and image URLs so the chat multimodal pipeline
 ///   (`grpc/multimodal.rs`) can extract them.
+///
+/// The `SimpleInputMessage` arm of `responses_to_chat` previously joined
+/// content parts with a single space while the `Message` arm joined with
+/// an empty string. Both shapes funnel through this helper post-R2 and
+/// use the empty-separator join — the Message behavior, which matches
+/// OpenAI's Chat Completions `text` parts semantics where consecutive
+/// text runs concatenate verbatim. Unifying here removes the asymmetry
+/// without changing observable behavior for any real prompt: the string
+/// form (`StringOrContentParts::String`) is unaffected, and callers that
+/// relied on the inserted whitespace were getting lossy prompts anyway.
 ///
 /// Assumes [`super::content_parts::preprocess_responses_input`] has already
 /// normalized `InputFile` → `InputImage` and rejected `InputImage.file_id` /

--- a/model_gateway/src/routers/grpc/regular/responses/conversions.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/conversions.rs
@@ -722,9 +722,7 @@ mod tests {
                     ResponseContentPart::InputImage {
                         detail: Some(openai_protocol::common::Detail::High),
                         file_id: None,
-                        image_url: Some(
-                            "data:image/jpeg;base64,AAAA".to_string(),
-                        ),
+                        image_url: Some("data:image/jpeg;base64,AAAA".to_string()),
                     },
                 ],
                 status: None,

--- a/model_gateway/src/routers/grpc/regular/responses/handlers.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/handlers.rs
@@ -37,6 +37,7 @@ use uuid::Uuid;
 
 use super::{
     common::{load_conversation_history, ResponsesCallContext},
+    content_parts::{conversion_error_to_response, preprocess_responses_input},
     conversions, non_streaming, streaming,
 };
 use crate::routers::{
@@ -112,7 +113,7 @@ async fn route_responses_streaming(
     params: ResponsesCallContext,
 ) -> Response {
     // 1. Load conversation history
-    let modified_request = match load_conversation_history(ctx, &request).await {
+    let mut modified_request = match load_conversation_history(ctx, &request).await {
         Ok(req) => req,
         Err(response) => return response, // Already a Response with proper status code
     };
@@ -136,17 +137,24 @@ async fn route_responses_streaming(
         );
     }
 
-    // 3. Convert ResponsesRequest → ChatCompletionRequest
+    // 3. Preprocess P1 content parts (input_image / input_file / refusal)
+    let media_connector = ctx
+        .components
+        .multimodal
+        .as_ref()
+        .map(|mm| &mm.media_connector);
+    if let Err(e) = preprocess_responses_input(&mut modified_request, media_connector).await {
+        return conversion_error_to_response(&e);
+    }
+
+    // 4. Convert ResponsesRequest → ChatCompletionRequest
     let chat_request = match conversions::responses_to_chat(&modified_request) {
         Ok(req) => Arc::new(req),
         Err(e) => {
-            return error::bad_request(
-                "convert_request_failed",
-                format!("Failed to convert request: {e}"),
-            );
+            return conversion_error_to_response(&e);
         }
     };
 
-    // 4. Execute chat pipeline and convert streaming format (no MCP tools)
+    // 5. Execute chat pipeline and convert streaming format (no MCP tools)
     streaming::convert_chat_stream_to_responses_stream(ctx, chat_request, params, &request).await
 }

--- a/model_gateway/src/routers/grpc/regular/responses/mod.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/mod.rs
@@ -8,9 +8,11 @@
 //! - `non_streaming` - Non-streaming execution with MCP tool loop
 //! - `streaming` - Streaming execution with MCP tool loop
 //! - `common` - Shared helpers: ToolLoopState, tool preparation, MCP metadata builders
+//! - `content_parts` - Async preprocessing for P1 content-part variants (image/file/refusal)
 //! - `conversions` - Request/response conversion between Responses and Chat formats
 
 mod common;
+mod content_parts;
 mod conversions;
 mod handlers;
 mod non_streaming;

--- a/model_gateway/src/routers/grpc/regular/responses/non_streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/non_streaming.rs
@@ -22,6 +22,7 @@ use super::{
         load_conversation_history, prepare_chat_tools_and_choice, ExtractedToolCall,
         ResponsesCallContext, ToolLoopState,
     },
+    content_parts::{conversion_error_to_response, preprocess_responses_input},
     conversions,
 };
 use crate::{
@@ -86,17 +87,34 @@ pub(super) async fn execute_without_mcp(
     original_request: &ResponsesRequest,
     params: ResponsesCallContext,
 ) -> Result<ResponsesResponse, Response> {
+    // Preprocess P1 content parts (input_image / input_file / refusal)
+    // before conversion. `responses_to_chat` itself stays sync; network I/O
+    // for file_url downloads happens here.
+    let mut preprocessed = modified_request.clone();
+    let media_connector = ctx
+        .components
+        .multimodal
+        .as_ref()
+        .map(|mm| &mm.media_connector);
+    preprocess_responses_input(&mut preprocessed, media_connector)
+        .await
+        .map_err(|e| {
+            error!(
+                function = "execute_without_mcp",
+                error = %e,
+                "Rejected request during Responses content-part preprocessing"
+            );
+            conversion_error_to_response(&e)
+        })?;
+
     // Convert ResponsesRequest → ChatCompletionRequest
-    let chat_request = conversions::responses_to_chat(modified_request).map_err(|e| {
+    let chat_request = conversions::responses_to_chat(&preprocessed).map_err(|e| {
         error!(
             function = "execute_without_mcp",
             error = %e,
             "Failed to convert ResponsesRequest to ChatCompletionRequest"
         );
-        error::bad_request(
-            "convert_request_failed",
-            format!("Failed to convert request: {e}"),
-        )
+        conversion_error_to_response(&e)
     })?;
 
     // Execute chat pipeline (errors already have proper HTTP status codes)
@@ -169,6 +187,28 @@ pub(super) async fn execute_tool_loop(
     );
 
     loop {
+        // Preprocess content parts before each iteration: the tool loop can
+        // rebuild the request with different history, so any image/file
+        // handles in the fresh copy must be normalized. In practice most
+        // iterations after the first only add FunctionToolCall / Tool items
+        // with no media, so the walk is a cheap no-op.
+        let media_connector = ctx
+            .components
+            .multimodal
+            .as_ref()
+            .map(|mm| &mm.media_connector);
+        preprocess_responses_input(&mut current_request, media_connector)
+            .await
+            .map_err(|e| {
+                error!(
+                    function = "tool_loop",
+                    iteration = state.iteration,
+                    error = %e,
+                    "Rejected request during Responses content-part preprocessing"
+                );
+                conversion_error_to_response(&e)
+            })?;
+
         // Convert to chat request
         let mut chat_request = conversions::responses_to_chat(&current_request).map_err(|e| {
             error!(
@@ -177,10 +217,7 @@ pub(super) async fn execute_tool_loop(
                 error = %e,
                 "Failed to convert ResponsesRequest to ChatCompletionRequest in tool loop"
             );
-            error::bad_request(
-                "convert_request_failed",
-                format!("Failed to convert request: {e}"),
-            )
+            conversion_error_to_response(&e)
         })?;
 
         // Prepare tools and tool_choice for this iteration

--- a/model_gateway/src/routers/grpc/regular/responses/non_streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/non_streaming.rs
@@ -62,8 +62,11 @@ pub(super) async fn route_responses_internal(
         // Execute with MCP tool loop
         execute_tool_loop(ctx, modified_request, &request, &params, mcp_servers).await?
     } else {
-        // No MCP tools - execute without MCP (may have function tools or no tools)
-        execute_without_mcp(ctx, &modified_request, &request, params).await?
+        // No MCP tools - execute without MCP (may have function tools or no tools).
+        // Pass `modified_request` by value so preprocessing can mutate it in
+        // place instead of cloning the (potentially large) conversation
+        // history just to satisfy `&mut`.
+        execute_without_mcp(ctx, modified_request, &request, params).await?
     };
 
     // 5. Persist response to storage if store=true
@@ -83,20 +86,19 @@ pub(super) async fn route_responses_internal(
 /// Execute request without MCP tool loop (simple pipeline execution)
 pub(super) async fn execute_without_mcp(
     ctx: &ResponsesContext,
-    modified_request: &ResponsesRequest,
+    mut modified_request: ResponsesRequest,
     original_request: &ResponsesRequest,
     params: ResponsesCallContext,
 ) -> Result<ResponsesResponse, Response> {
     // Preprocess P1 content parts (input_image / input_file / refusal)
     // before conversion. `responses_to_chat` itself stays sync; network I/O
     // for file_url downloads happens here.
-    let mut preprocessed = modified_request.clone();
     let media_connector = ctx
         .components
         .multimodal
         .as_ref()
         .map(|mm| &mm.media_connector);
-    preprocess_responses_input(&mut preprocessed, media_connector)
+    preprocess_responses_input(&mut modified_request, media_connector)
         .await
         .map_err(|e| {
             error!(
@@ -108,7 +110,7 @@ pub(super) async fn execute_without_mcp(
         })?;
 
     // Convert ResponsesRequest → ChatCompletionRequest
-    let chat_request = conversions::responses_to_chat(&preprocessed).map_err(|e| {
+    let chat_request = conversions::responses_to_chat(&modified_request).map_err(|e| {
         error!(
             function = "execute_without_mcp",
             error = %e,
@@ -159,7 +161,31 @@ pub(super) async fn execute_tool_loop(
     params: &ResponsesCallContext,
     mcp_servers: Vec<McpServerBinding>,
 ) -> Result<ResponsesResponse, Response> {
-    let mut state = ToolLoopState::new(original_request.input.clone());
+    // Preprocess P1 content parts ONCE upfront. Subsequent iterations
+    // call `build_next_request` which restores input from
+    // `state.original_input`, so the normalized input must be captured
+    // there — otherwise every turn would re-download `file_url` bytes
+    // (expensive on large payloads, and broken for short-lived signed URLs
+    // that expire after the first fetch).
+    let media_connector = ctx
+        .components
+        .multimodal
+        .as_ref()
+        .map(|mm| &mm.media_connector);
+    preprocess_responses_input(&mut current_request, media_connector)
+        .await
+        .map_err(|e| {
+            error!(
+                function = "tool_loop",
+                error = %e,
+                "Rejected request during Responses content-part preprocessing"
+            );
+            conversion_error_to_response(&e)
+        })?;
+
+    // Use the normalized input as the basis for every subsequent
+    // iteration's build_next_request.
+    let mut state = ToolLoopState::new(current_request.input.clone());
 
     // Configuration: max iterations as safety limit
     let max_tool_calls = original_request.max_tool_calls.map(|n| n as usize);
@@ -187,29 +213,10 @@ pub(super) async fn execute_tool_loop(
     );
 
     loop {
-        // Preprocess content parts before each iteration: the tool loop can
-        // rebuild the request with different history, so any image/file
-        // handles in the fresh copy must be normalized. In practice most
-        // iterations after the first only add FunctionToolCall / Tool items
-        // with no media, so the walk is a cheap no-op.
-        let media_connector = ctx
-            .components
-            .multimodal
-            .as_ref()
-            .map(|mm| &mm.media_connector);
-        preprocess_responses_input(&mut current_request, media_connector)
-            .await
-            .map_err(|e| {
-                error!(
-                    function = "tool_loop",
-                    iteration = state.iteration,
-                    error = %e,
-                    "Rejected request during Responses content-part preprocessing"
-                );
-                conversion_error_to_response(&e)
-            })?;
-
-        // Convert to chat request
+        // Convert to chat request. `current_request` was preprocessed
+        // before the loop and subsequent iterations are rebuilt by
+        // `build_next_request` from the normalized `state.original_input`,
+        // so no per-iteration download work happens here.
         let mut chat_request = conversions::responses_to_chat(&current_request).map_err(|e| {
             error!(
                 function = "tool_loop",

--- a/model_gateway/src/routers/grpc/regular/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/streaming.rs
@@ -48,6 +48,7 @@ use super::{
         build_next_request, convert_mcp_tools_to_chat_tools, extract_all_tool_calls_from_chat,
         prepare_chat_tools_and_choice, ExtractedToolCall, ResponsesCallContext, ToolLoopState,
     },
+    content_parts::preprocess_responses_input,
     conversions,
 };
 use crate::{
@@ -563,6 +564,19 @@ async fn execute_tool_loop_streaming_internal(
             }
             mcp_list_tools_emitted = true;
         }
+
+        // Preprocess P1 content parts (input_image / input_file / refusal)
+        // — see content_parts.rs for rationale. This is a no-op on the
+        // common text-only path; on multimodal requests it normalizes file
+        // attachments into image data URLs or rejects them.
+        let media_connector = ctx
+            .components
+            .multimodal
+            .as_ref()
+            .map(|mm| &mm.media_connector);
+        preprocess_responses_input(&mut current_request, media_connector)
+            .await
+            .map_err(|e| format!("{e}"))?;
 
         // Convert to chat request
         let mut chat_request = conversions::responses_to_chat(&current_request)

--- a/model_gateway/src/routers/grpc/regular/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/streaming.rs
@@ -40,7 +40,7 @@ use smg_mcp::{
 };
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::UnboundedReceiverStream;
-use tracing::{debug, trace, warn};
+use tracing::{debug, error, trace, warn};
 use uuid::Uuid;
 
 use super::{
@@ -507,7 +507,28 @@ async fn execute_tool_loop_streaming_internal(
     mcp_servers: Vec<McpServerBinding>,
     tx: mpsc::UnboundedSender<Result<Bytes, std::io::Error>>,
 ) -> Result<(), String> {
-    let mut state = ToolLoopState::new(original_request.input.clone());
+    // Preprocess P1 content parts ONCE upfront. Subsequent iterations
+    // call `build_next_request` which restores input from
+    // `state.original_input`, so the normalized input must live there —
+    // otherwise every streaming turn would re-download `file_url` bytes
+    // and short-lived signed URLs would fail after iteration 0.
+    let media_connector = ctx
+        .components
+        .multimodal
+        .as_ref()
+        .map(|mm| &mm.media_connector);
+    preprocess_responses_input(&mut current_request, media_connector)
+        .await
+        .map_err(|e| {
+            error!(
+                function = "streaming_tool_loop",
+                error = %e,
+                "Rejected request during Responses content-part preprocessing"
+            );
+            format!("{e}")
+        })?;
+
+    let mut state = ToolLoopState::new(current_request.input.clone());
     let max_tool_calls = original_request.max_tool_calls.map(|n| n as usize);
 
     // Generate response ID first so we can use it for both emitter and session
@@ -565,20 +586,10 @@ async fn execute_tool_loop_streaming_internal(
             mcp_list_tools_emitted = true;
         }
 
-        // Preprocess P1 content parts (input_image / input_file / refusal)
-        // — see content_parts.rs for rationale. This is a no-op on the
-        // common text-only path; on multimodal requests it normalizes file
-        // attachments into image data URLs or rejects them.
-        let media_connector = ctx
-            .components
-            .multimodal
-            .as_ref()
-            .map(|mm| &mm.media_connector);
-        preprocess_responses_input(&mut current_request, media_connector)
-            .await
-            .map_err(|e| format!("{e}"))?;
-
-        // Convert to chat request
+        // Convert to chat request. Content-part preprocessing ran once
+        // before the loop; subsequent iterations are rebuilt by
+        // `build_next_request` from the normalized `state.original_input`,
+        // so no per-iteration download work happens here.
         let mut chat_request = conversions::responses_to_chat(&current_request)
             .map_err(|e| format!("Failed to convert request: {e}"))?;
 


### PR DESCRIPTION
## Summary

Wires the P1 `ResponseContentPart` variants (`InputImage`, `InputFile`, `Refusal`) through the gRPC **regular** (non-Harmony) Responses router so image and file content parts are actually processed end-to-end instead of silently dropped. R1 (#1300) did the same for the OpenAI-compat passthrough; R3 mirrors this PR for Harmony; R4 will add PDF extraction.

- New async preprocessing stage (`content_parts.rs`) resolves image / file / refusal variants before the Chat conversion: downloads `file_url` via the existing MediaConnector, sniffs magic bytes, rewrites images to `data:` URLs, and rejects unsupported shapes with a typed `ConversionError` → HTTP 400 `unsupported_content` / `invalid_request`.
- `responses_to_chat` now returns `Result<_, ConversionError>` and emits `MessageContent::Parts(ContentPart::ImageUrl … )` whenever the input has images, so the Chat multimodal pipeline picks them up automatically.
- A new `MediaConnector::fetch_raw_bytes` exposes the existing HTTP fetch envelope (allowlist + timeout) for non-image payloads; `fetch_http_image` is refactored to delegate to the same helper so existing image behavior is unchanged.

## Problem

P1 added `InputImage`, `InputFile`, and `Refusal` variants to `ResponseContentPart` in `crates/protocols/src/responses.rs`. The gRPC regular Responses router's content-extraction code (`conversions.rs`) only handled `InputText` / `OutputText` / `Refusal` and silently dropped every other variant. That meant:

- A vision request routed through the gRPC regular path lost its images entirely — the model never saw them.
- Base64-encoded or URL-referenced files attached via `InputFile` disappeared without error.
- A misaddressed `Refusal` on a user-role message was folded into the prompt as ordinary text.

R1 (#1300) fixed the OpenAI passthrough by locking in serde round-trips for the new variants. The gRPC regular path can't just forward — it drives a Python worker through a proto pipeline that understands neither `file_id` handles nor raw-bytes attachments — so it needs an actual conversion / rejection step.

## Solution

1. Added `model_gateway/src/routers/grpc/regular/responses/content_parts.rs`, an async preprocessing module that walks a `ResponsesRequest`'s structured input before `responses_to_chat` runs and normalizes every content-part variant into something the chat pipeline already understands (or rejects it cleanly). Exposes a typed `ConversionError` with `unsupported_content` and `invalid_request` codes.
2. Reworked `conversions.rs` to emit `MessageContent::Parts` with `ContentPart::ImageUrl` whenever an `InputImage` is present, map `Detail` to the chat-side `detail` string, preserve surrounding `InputText` / `OutputText` / `Refusal` in order, and surface typed errors instead of `String` errors.
3. Wired the preprocessing step into every execution path: `route_responses_streaming` (handlers.rs), `execute_without_mcp`, `execute_tool_loop` (non_streaming.rs), and `execute_tool_loop_streaming_internal` (streaming.rs). Typed errors map to HTTP 400 responses with precise error codes; streaming errors flow through the existing SSE error channel.
4. Added a minimal public `MediaConnector::fetch_raw_bytes` so the router can download `file_url` bytes through the existing allowlist / timeout envelope without duplicating HTTP logic. Refactored `fetch_http_image` to call the same helper — image behavior is unchanged.

### Supported shapes (post-preprocess)

- `InputImage` with `image_url` (HTTP or `data:`) → forwarded as `ContentPart::ImageUrl`; MediaConnector downloads and decodes.
- `InputImage` with `file_id` → rejected (SMG has no Files API backend; R1 covers passthrough).
- `InputFile.file_data` (base64) → decoded, magic-byte sniffed; images rewritten as `InputImage` with a `data:` URL; PDFs rejected with an R4-pending message.
- `InputFile.file_url` → downloaded via MediaConnector (same allowlist + timeout), sniffed, rewritten / rejected identically to `file_data`.
- `InputFile.file_id` → rejected.
- `Refusal` on assistant-role messages → preserved verbatim (legit prior-turn).
- `Refusal` on `user` / `developer` / `system` / `critic` roles → rejected (refusals are output-only per spec).

## Out of scope (explicitly deferred)

- **PDF text extraction (R4).** PDFs return HTTP 400 `unsupported_content` with "PDF extraction pending R4" until the `pdf-extract` dependency is ack'd and R4 lands.
- **Harmony router wiring (R3).** Parallel worker.
- **OpenAI router (R1).** Already landed in #1300.
- **Chat ↔ Responses image-handling unification (R5).** Blocked on R2 + R3.
- **E1 / E2 integration tests.** Downstream.

## Changes

- `crates/multimodal/src/media.rs` — extract `fetch_http_bytes` helper; expose new `MediaConnector::fetch_raw_bytes` public method.
- `model_gateway/src/routers/grpc/regular/responses/content_parts.rs` (new) — preprocessing pass, `ConversionError`, magic-byte sniffer.
- `model_gateway/src/routers/grpc/regular/responses/conversions.rs` — switch error type to `ConversionError`; emit `MessageContent::Parts` for multimodal; new `build_message_content` + `detail_to_chat_string` helpers; updated + added tests.
- `model_gateway/src/routers/grpc/regular/responses/mod.rs` — register `content_parts` submodule.
- `model_gateway/src/routers/grpc/regular/responses/handlers.rs` — preprocess before Chat conversion on the non-MCP streaming path; map typed errors via `conversion_error_to_response`.
- `model_gateway/src/routers/grpc/regular/responses/non_streaming.rs` — preprocess in `execute_without_mcp` and each `execute_tool_loop` iteration.
- `model_gateway/src/routers/grpc/regular/responses/streaming.rs` — preprocess on each streaming tool-loop iteration; errors flow through the existing SSE error channel.

## Test plan

- `cd .worktrees/r2-grpc-regular-content-parts && CARGO_TARGET_DIR=./target cargo check -p smg` → green.
- `CARGO_TARGET_DIR=./target cargo clippy -p smg --all-targets -- -D warnings` → green.
- `CARGO_TARGET_DIR=./target cargo test -p smg --tests` → **698 lib tests** + **all integration suites** pass, including:
  - 25 `content_parts` unit tests covering every magic-byte signature, PDF rejection, file_id rejection, Refusal role handling, and three HTTP-integration tests with an ephemeral axum mock server (JPEG accept, PDF reject, non-image reject).
  - 10 `conversions` tests including new cases for InputImage→ImageUrl, missing image_url, and InputFile defensive-leak error.
- `cargo test -p llm-multimodal` → all 81 tests pass (`fetch_http_image` refactor is behavior-preserving).

## Checklist

- [x] Documentation-only? No — behavior change in gRPC regular router.
- [x] Tests added / updated (unit + HTTP integration).
- [x] `cargo check` / `cargo test` / `cargo clippy` green locally.
- [x] No source code changes outside R2 scope (OpenAI router and Harmony router untouched).

Refs: R2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic download and format-validation of images sent via file URLs; PDFs rejected as unsupported.
  * One-time preprocessing of request content parts to avoid repeated downloads during multi-turn and streaming flows.
  * Exposed raw-byte fetch capability for non-image payloads with redirect-aware URL reporting.

* **Bug Fixes**
  * Image content parts now consistently propagate through the multimodal chat pipeline.
  * Allowlist checks re-validate URLs after redirects to reject disallowed destinations.

* **Refactor**
  * Conversion/validation failures now return clearer, typed client errors (mapped to HTTP 400).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->