### PR TITLE
fix(mcp): response_format runtime override + user forwarding + regression e2e (R7)

### DIFF
--- a/crates/mcp/src/core/mod.rs
+++ b/crates/mcp/src/core/mod.rs
@@ -27,4 +27,7 @@ pub use orchestrator::{
 };
 pub use pool::{McpConnectionPool, PoolKey};
 pub use reconnect::ReconnectionManager;
-pub use session::{McpServerBinding, McpToolSession, DEFAULT_SERVER_LABEL};
+pub use session::{
+    inject_user_into_hosted_tool_args, resolve_response_format, McpServerBinding, McpToolSession,
+    DEFAULT_SERVER_LABEL,
+};

--- a/crates/mcp/src/core/orchestrator.rs
+++ b/crates/mcp/src/core/orchestrator.rs
@@ -204,7 +204,7 @@ impl ToolCallResult {
 ///
 /// This is a simplified input format that allows routers to batch
 /// multiple tool calls without worrying about the underlying execution details.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct ToolExecutionInput {
     /// Unique identifier for this tool call (from LLM response).
     pub call_id: String,
@@ -212,6 +212,16 @@ pub struct ToolExecutionInput {
     pub tool_name: String,
     /// Tool arguments as JSON.
     pub arguments: Value,
+    /// Optional runtime override for the response format applied to the
+    /// output item transformation.
+    ///
+    /// When `Some`, this replaces the session-resolved `ResponseFormat` on the
+    /// resulting [`ToolExecutionOutput`]. The canonical producer is
+    /// [`crate::core::session::resolve_response_format`], which combines the
+    /// session's configured format with hosted-tool declarations from the
+    /// caller's `tools` list. Leaving this as `None` preserves the legacy
+    /// behavior (session state is authoritative).
+    pub response_format_override: Option<ResponseFormat>,
 }
 
 /// Output from batch tool execution.
@@ -1017,6 +1027,7 @@ impl McpOrchestrator {
 
         let qualified = QualifiedToolName::new(server_key, &input.tool_name);
         let entry = self.tool_inventory.get_entry(server_key, &input.tool_name);
+        let format_override = input.response_format_override;
 
         match entry {
             Some(entry) => match self
@@ -1029,6 +1040,9 @@ impl McpOrchestrator {
                     output.server_key = server_key.to_string();
                     output.server_label = server_label.to_string();
                     output.arguments_str = arguments_str;
+                    if let Some(override_format) = format_override {
+                        output.response_format = override_format;
+                    }
                     ToolExecutionResult::Executed(output)
                 }
                 ToolExecutionResult::PendingApproval(mut pending) => {
@@ -1037,6 +1051,9 @@ impl McpOrchestrator {
                     pending.server_key = server_key.to_string();
                     pending.server_label = server_label.to_string();
                     pending.arguments_str = arguments_str;
+                    if let Some(override_format) = format_override {
+                        pending.response_format = override_format;
+                    }
                     ToolExecutionResult::PendingApproval(pending)
                 }
             },
@@ -1054,7 +1071,7 @@ impl McpOrchestrator {
                     output: serde_json::json!({ "error": &err }),
                     is_error: true,
                     error_message: Some(err),
-                    response_format: ResponseFormat::Passthrough,
+                    response_format: format_override.unwrap_or(ResponseFormat::Passthrough),
                     duration: start.elapsed(),
                 })
             }

--- a/crates/mcp/src/core/session.rs
+++ b/crates/mcp/src/core/session.rs
@@ -896,15 +896,10 @@ impl<'a> McpToolSession<'a> {
     }
 }
 
-/// Canonical hosted-tool name that identifies a dispatched `image_generation` call.
-///
-/// R7: callers declare `tools: [{"type": "image_generation", ...}]`, but the
-/// MCP server may expose the tool under an alias or a synonym. This constant
-/// pins the set of aliases we treat as "this call is an image_generation
-/// hosted-tool call" for the purpose of inferring the response format when
-/// the server has no `builtin_type` config. Keep this list narrow — broader
-/// matching belongs in the MCP config's alias/tool_config mechanism, not
-/// here.
+/// Aliases we treat as an `image_generation` hosted-tool call for the
+/// purpose of inferring the response format when the MCP server has no
+/// `builtin_type` config. Keep this list narrow — broader matching belongs
+/// in the MCP config's alias/tool_config mechanism, not here.
 const HOSTED_IMAGE_GENERATION_NAMES: &[&str] = &["image_generation"];
 
 /// Canonical hosted-tool name for `web_search_preview` dispatches.
@@ -1946,7 +1941,7 @@ mod tests {
     }
 
     // ---------------------------------------------------------------
-    // R7: resolve_response_format + inject_user_into_hosted_tool_args
+    // resolve_response_format + inject_user_into_hosted_tool_args
     // ---------------------------------------------------------------
 
     fn default_image_generation_tool() -> ResponseTool {

--- a/crates/mcp/src/core/session.rs
+++ b/crates/mcp/src/core/session.rs
@@ -280,6 +280,7 @@ impl<'a> McpToolSession<'a> {
                         call_id: input.call_id,
                         tool_name: resolved_tool_name.clone(),
                         arguments: input.arguments,
+                        response_format_override: input.response_format_override,
                     },
                     &binding.server_key,
                     &binding.server_label,
@@ -314,7 +315,9 @@ impl<'a> McpToolSession<'a> {
                 output: serde_json::json!({ "error": &err }),
                 is_error: true,
                 error_message: Some(err),
-                response_format: ResponseFormat::Passthrough,
+                response_format: input
+                    .response_format_override
+                    .unwrap_or(ResponseFormat::Passthrough),
                 duration: std::time::Duration::default(),
             })
         }
@@ -893,6 +896,146 @@ impl<'a> McpToolSession<'a> {
     }
 }
 
+/// Canonical hosted-tool name that identifies a dispatched `image_generation` call.
+///
+/// R7: callers declare `tools: [{"type": "image_generation", ...}]`, but the
+/// MCP server may expose the tool under an alias or a synonym. This constant
+/// pins the set of aliases we treat as "this call is an image_generation
+/// hosted-tool call" for the purpose of inferring the response format when
+/// the server has no `builtin_type` config. Keep this list narrow — broader
+/// matching belongs in the MCP config's alias/tool_config mechanism, not
+/// here.
+const HOSTED_IMAGE_GENERATION_NAMES: &[&str] = &["image_generation"];
+
+/// Canonical hosted-tool name for `web_search_preview` dispatches.
+const HOSTED_WEB_SEARCH_PREVIEW_NAMES: &[&str] = &["web_search_preview", "web_search"];
+
+/// Canonical hosted-tool name for `code_interpreter` dispatches.
+const HOSTED_CODE_INTERPRETER_NAMES: &[&str] = &["code_interpreter"];
+
+/// Canonical hosted-tool name for `file_search` dispatches.
+const HOSTED_FILE_SEARCH_NAMES: &[&str] = &["file_search"];
+
+/// Resolve the response format for a dispatched tool call.
+///
+/// # Contract
+///
+/// * If the session already classifies the tool as a hosted format (i.e. the
+///   MCP server was explicitly tagged with `builtin_type` in its config),
+///   the session's format wins — explicit server-side configuration is
+///   authoritative.
+/// * Otherwise, if the caller's `tools` list contains a hosted-tool
+///   declaration AND the dispatched `tool_name` matches that hosted tool's
+///   canonical name (or a known alias), the resolved format is the hosted
+///   format for that declaration.
+/// * Otherwise, the session format is returned unchanged (typically
+///   `Passthrough`, which surfaces the call as a generic `mcp_call` item).
+///
+/// # Why this exists
+///
+/// OpenAI's Responses API says the CLIENT's `tools: [{"type": "..."}]`
+/// declaration determines the shape of the matching output item. The MCP
+/// server's `builtin_type` is an SMG-specific routing hint; it should not be
+/// the sole gate on whether we emit an `image_generation_call` (or similar)
+/// output item.
+///
+/// This function is intentionally pure (no session state other than the
+/// already-resolved `session_format`) so all router dispatch paths can share
+/// one source of truth for the "which output item shape?" decision.
+pub fn resolve_response_format(
+    session_format: ResponseFormat,
+    request_tools: &[ResponseTool],
+    tool_name: &str,
+) -> ResponseFormat {
+    // Explicit server configuration always wins.
+    if !matches!(session_format, ResponseFormat::Passthrough) {
+        return session_format;
+    }
+
+    for tool in request_tools {
+        match tool {
+            ResponseTool::ImageGeneration(_) if is_canonical_name(tool_name, HOSTED_IMAGE_GENERATION_NAMES) => {
+                return ResponseFormat::ImageGenerationCall;
+            }
+            ResponseTool::WebSearchPreview(_)
+                if is_canonical_name(tool_name, HOSTED_WEB_SEARCH_PREVIEW_NAMES) =>
+            {
+                return ResponseFormat::WebSearchCall;
+            }
+            ResponseTool::WebSearch(_)
+                if is_canonical_name(tool_name, HOSTED_WEB_SEARCH_PREVIEW_NAMES) =>
+            {
+                return ResponseFormat::WebSearchCall;
+            }
+            ResponseTool::CodeInterpreter(_)
+                if is_canonical_name(tool_name, HOSTED_CODE_INTERPRETER_NAMES) =>
+            {
+                return ResponseFormat::CodeInterpreterCall;
+            }
+            ResponseTool::FileSearch(_)
+                if is_canonical_name(tool_name, HOSTED_FILE_SEARCH_NAMES) =>
+            {
+                return ResponseFormat::FileSearchCall;
+            }
+            _ => {}
+        }
+    }
+
+    session_format
+}
+
+fn is_canonical_name(tool_name: &str, canonical_names: &[&str]) -> bool {
+    canonical_names.contains(&tool_name)
+}
+
+/// Inject the caller's `user` field into a hosted-tool dispatch args object.
+///
+/// # Contract
+///
+/// * Only hosted tools (those whose resolved format is non-passthrough) get
+///   the injection — plain MCP function tools are left alone to avoid
+///   surprising a tool schema that doesn't expect a `user` key.
+/// * `arguments` must be an object; non-object payloads are no-ops.
+/// * If the caller's `user` is empty or `None`, this is a no-op.
+/// * If the args already contain a `user` key, we preserve the model-supplied
+///   value and emit a `debug!` log rather than overwriting.
+///
+/// # Why this exists
+///
+/// OpenAI's spec for hosted tools (image_generation, etc.) does NOT list
+/// `user` as a declarable field on the tool config — it lives on the top-level
+/// request. But the MCP server often proxies for an upstream API that already
+/// expects `user` at the dispatch level for per-user quotas and moderation
+/// attribution. Mirroring the top-level `user` into the dispatch args keeps
+/// that attribution intact without requiring every MCP tool schema to grow a
+/// `user` field.
+pub fn inject_user_into_hosted_tool_args(
+    arguments: &mut serde_json::Value,
+    resolved_format: &ResponseFormat,
+    user: Option<&str>,
+) {
+    if matches!(resolved_format, ResponseFormat::Passthrough) {
+        return;
+    }
+    let Some(user_value) = user.filter(|s| !s.is_empty()) else {
+        return;
+    };
+    let serde_json::Value::Object(args_map) = arguments else {
+        return;
+    };
+    if args_map.contains_key("user") {
+        tracing::debug!(
+            %user_value,
+            "Hosted-tool dispatch args already contain `user`; preserving model-supplied value",
+        );
+        return;
+    }
+    args_map.insert(
+        "user".to_string(),
+        serde_json::Value::String(user_value.to_string()),
+    );
+}
+
 fn sanitize_tool_token(input: &str) -> String {
     let mut out = String::with_capacity(input.len().max(1));
     for ch in input.chars() {
@@ -1063,6 +1206,7 @@ mod tests {
                 call_id: "call-1".to_string(),
                 tool_name: "test_tool".to_string(),
                 arguments: json!({"hello": "world"}),
+                response_format_override: None,
             })
             .await;
 
@@ -1799,5 +1943,201 @@ mod tests {
             request_ctx.forwarded_headers.get("opc-request-id"),
             Some(&"req-123".to_string())
         );
+    }
+
+    // ---------------------------------------------------------------
+    // R7: resolve_response_format + inject_user_into_hosted_tool_args
+    // ---------------------------------------------------------------
+
+    fn default_image_generation_tool() -> ResponseTool {
+        ResponseTool::ImageGeneration(
+            openai_protocol::responses::ImageGenerationTool::default(),
+        )
+    }
+
+    fn default_web_search_preview_tool() -> ResponseTool {
+        ResponseTool::WebSearchPreview(
+            openai_protocol::responses::WebSearchPreviewTool::default(),
+        )
+    }
+
+    fn default_file_search_tool() -> ResponseTool {
+        ResponseTool::FileSearch(openai_protocol::responses::FileSearchTool {
+            vector_store_ids: vec![],
+            filters: None,
+            max_num_results: None,
+            ranking_options: None,
+        })
+    }
+
+    fn default_code_interpreter_tool() -> ResponseTool {
+        ResponseTool::CodeInterpreter(
+            openai_protocol::responses::CodeInterpreterTool::default(),
+        )
+    }
+
+    #[test]
+    fn test_resolve_response_format_session_passthrough_no_declaration() {
+        // Without any hosted-tool declaration on the request, Passthrough
+        // survives — plain mcp_call shape is correct for generic MCP tools.
+        let format = resolve_response_format(ResponseFormat::Passthrough, &[], "brave_web_search");
+        assert_eq!(format, ResponseFormat::Passthrough);
+    }
+
+    #[test]
+    fn test_resolve_response_format_session_passthrough_with_image_generation_declaration() {
+        // Server is untagged (Passthrough) but the request declares
+        // image_generation and the dispatched tool name matches. This is the
+        // exact reviewer-reported bug scenario; the resolver promotes the
+        // format so the output item is an image_generation_call.
+        let tools = vec![default_image_generation_tool()];
+        let format = resolve_response_format(
+            ResponseFormat::Passthrough,
+            &tools,
+            "image_generation",
+        );
+        assert_eq!(format, ResponseFormat::ImageGenerationCall);
+    }
+
+    #[test]
+    fn test_resolve_response_format_session_format_wins_over_request() {
+        // Server-tagged format must win even if the request also declares a
+        // hosted tool: explicit configuration is authoritative.
+        let tools = vec![default_web_search_preview_tool()];
+        let format = resolve_response_format(
+            ResponseFormat::ImageGenerationCall,
+            &tools,
+            "image_generation",
+        );
+        assert_eq!(format, ResponseFormat::ImageGenerationCall);
+    }
+
+    #[test]
+    fn test_resolve_response_format_tool_name_must_match() {
+        // Request declares image_generation but dispatched tool is some other
+        // name — don't promote the format; that would be incorrect for a
+        // generic MCP tool that happens to run in the same session.
+        let tools = vec![default_image_generation_tool()];
+        let format = resolve_response_format(
+            ResponseFormat::Passthrough,
+            &tools,
+            "some_unrelated_mcp_tool",
+        );
+        assert_eq!(format, ResponseFormat::Passthrough);
+    }
+
+    #[test]
+    fn test_resolve_response_format_file_search_declaration() {
+        let tools = vec![default_file_search_tool()];
+        let format =
+            resolve_response_format(ResponseFormat::Passthrough, &tools, "file_search");
+        assert_eq!(format, ResponseFormat::FileSearchCall);
+    }
+
+    #[test]
+    fn test_resolve_response_format_code_interpreter_declaration() {
+        let tools = vec![default_code_interpreter_tool()];
+        let format =
+            resolve_response_format(ResponseFormat::Passthrough, &tools, "code_interpreter");
+        assert_eq!(format, ResponseFormat::CodeInterpreterCall);
+    }
+
+    #[test]
+    fn test_resolve_response_format_web_search_preview_declaration() {
+        let tools = vec![default_web_search_preview_tool()];
+        let format =
+            resolve_response_format(ResponseFormat::Passthrough, &tools, "web_search_preview");
+        assert_eq!(format, ResponseFormat::WebSearchCall);
+    }
+
+    #[test]
+    fn test_resolve_response_format_multiple_declarations_first_match_wins() {
+        // The resolver matches on (declaration kind, tool_name) pair, so the
+        // dispatched tool name alone picks the correct declaration even when
+        // several kinds are declared.
+        let tools = vec![
+            default_file_search_tool(),
+            default_image_generation_tool(),
+        ];
+        let format = resolve_response_format(
+            ResponseFormat::Passthrough,
+            &tools,
+            "image_generation",
+        );
+        assert_eq!(format, ResponseFormat::ImageGenerationCall);
+    }
+
+    #[test]
+    fn test_inject_user_skipped_for_passthrough() {
+        let mut args = serde_json::json!({"prompt": "hello"});
+        inject_user_into_hosted_tool_args(
+            &mut args,
+            &ResponseFormat::Passthrough,
+            Some("user-abc"),
+        );
+        assert_eq!(args, serde_json::json!({"prompt": "hello"}));
+    }
+
+    #[test]
+    fn test_inject_user_skipped_for_empty_user() {
+        let mut args = serde_json::json!({"prompt": "hello"});
+        inject_user_into_hosted_tool_args(
+            &mut args,
+            &ResponseFormat::ImageGenerationCall,
+            Some(""),
+        );
+        assert_eq!(args, serde_json::json!({"prompt": "hello"}));
+    }
+
+    #[test]
+    fn test_inject_user_skipped_for_none_user() {
+        let mut args = serde_json::json!({"prompt": "hello"});
+        inject_user_into_hosted_tool_args(&mut args, &ResponseFormat::ImageGenerationCall, None);
+        assert_eq!(args, serde_json::json!({"prompt": "hello"}));
+    }
+
+    #[test]
+    fn test_inject_user_injected_for_hosted_tool() {
+        let mut args = serde_json::json!({"prompt": "hello"});
+        inject_user_into_hosted_tool_args(
+            &mut args,
+            &ResponseFormat::ImageGenerationCall,
+            Some("user-abc"),
+        );
+        assert_eq!(
+            args,
+            serde_json::json!({"prompt": "hello", "user": "user-abc"})
+        );
+    }
+
+    #[test]
+    fn test_inject_user_preserves_existing_user_key() {
+        // If the model (or earlier override merge) already populated `user`,
+        // keep it — overwriting the model-supplied value would be a nasty
+        // surprise. Debug log only (verified at the call site manually).
+        let mut args = serde_json::json!({"prompt": "hello", "user": "model-user"});
+        inject_user_into_hosted_tool_args(
+            &mut args,
+            &ResponseFormat::ImageGenerationCall,
+            Some("request-user"),
+        );
+        assert_eq!(
+            args,
+            serde_json::json!({"prompt": "hello", "user": "model-user"})
+        );
+    }
+
+    #[test]
+    fn test_inject_user_noop_on_non_object_args() {
+        // apply_hosted_tool_overrides coerces non-objects to `{}` before this
+        // runs in practice, but defend-in-depth: a non-object payload should
+        // not panic or silently turn into an object.
+        let mut args = serde_json::Value::String("scalar".to_string());
+        inject_user_into_hosted_tool_args(
+            &mut args,
+            &ResponseFormat::ImageGenerationCall,
+            Some("user-abc"),
+        );
+        assert_eq!(args, serde_json::Value::String("scalar".to_string()));
     }
 }

--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -28,12 +28,13 @@ pub mod responses_bridge;
 pub use core::{config, pool as connection_pool};
 // Re-export from core
 pub use core::{
-    ArgMappingConfig, BuiltinToolType, ConfigValidationError, HandlerRequestContext,
-    LatencySnapshot, McpConfig, McpMetrics, McpOrchestrator, McpRequestContext, McpServerBinding,
-    McpServerConfig, McpToolSession, McpTransport, MetricsSnapshot, PendingToolExecution,
-    PolicyConfig, PolicyDecisionConfig, PoolKey, RefreshRequest, ResponseFormatConfig,
-    ServerPolicyConfig, SmgClientHandler, Tool, ToolCallResult, ToolConfig, ToolExecutionInput,
-    ToolExecutionOutput, ToolExecutionResult, TrustLevelConfig, DEFAULT_SERVER_LABEL,
+    inject_user_into_hosted_tool_args, resolve_response_format, ArgMappingConfig, BuiltinToolType,
+    ConfigValidationError, HandlerRequestContext, LatencySnapshot, McpConfig, McpMetrics,
+    McpOrchestrator, McpRequestContext, McpServerBinding, McpServerConfig, McpToolSession,
+    McpTransport, MetricsSnapshot, PendingToolExecution, PolicyConfig, PolicyDecisionConfig,
+    PoolKey, RefreshRequest, ResponseFormatConfig, ServerPolicyConfig, SmgClientHandler, Tool,
+    ToolCallResult, ToolConfig, ToolExecutionInput, ToolExecutionOutput, ToolExecutionResult,
+    TrustLevelConfig, DEFAULT_SERVER_LABEL,
 };
 
 // Re-export shared types

--- a/e2e_test/infra/mock_mcp_server.py
+++ b/e2e_test/infra/mock_mcp_server.py
@@ -383,7 +383,7 @@ class MockMcpServer:
             user: str | None = None,
         ) -> dict[str, str]:
             # ``user`` is forwarded by the gateway when the client sets the
-            # top-level ``user`` field on the Responses request (R7 Fix B).
+            # top-level ``user`` field on the Responses request .
             # The OpenAI spec does not list ``user`` as an
             # ``ImageGenerationTool`` field, but the gateway injects it into
             # hosted-tool dispatch args so MCP proxies can attribute usage

--- a/e2e_test/infra/mock_mcp_server.py
+++ b/e2e_test/infra/mock_mcp_server.py
@@ -380,17 +380,28 @@ class MockMcpServer:
             quality: str = "standard",
             moderation: str = "auto",
             output_format: str = "png",
+            user: str | None = None,
         ) -> dict[str, str]:
+            # ``user`` is forwarded by the gateway when the client sets the
+            # top-level ``user`` field on the Responses request (R7 Fix B).
+            # The OpenAI spec does not list ``user`` as an
+            # ``ImageGenerationTool`` field, but the gateway injects it into
+            # hosted-tool dispatch args so MCP proxies can attribute usage
+            # per-user. The arg is accepted here AND recorded in the call log
+            # so tests can assert on it.
+            arguments: dict[str, Any] = {
+                "prompt": prompt,
+                "size": size,
+                "quality": quality,
+                "moderation": moderation,
+                "output_format": output_format,
+            }
+            if user is not None:
+                arguments["user"] = user
             record_call(
                 {
                     "tool": "image_generation",
-                    "arguments": {
-                        "prompt": prompt,
-                        "size": size,
-                        "quality": quality,
-                        "moderation": moderation,
-                        "output_format": output_format,
-                    },
+                    "arguments": arguments,
                 }
             )
             return {

--- a/e2e_test/responses/conftest.py
+++ b/e2e_test/responses/conftest.py
@@ -91,17 +91,17 @@ def _image_generation_mcp_config(mock_mcp_url: str) -> dict:
 def _plain_mcp_config(mock_mcp_url: str) -> dict:
     """Build an MCP config that registers the mock server WITHOUT builtin_type.
 
-    This mirrors the deployment the external reviewer hit in R7: a plain MCP
+    This mirrors the deployment the external reviewer hit: a plain MCP
     server that happens to expose an ``image_generation`` tool, but whose YAML
     config does NOT tag the server with ``builtin_type: image_generation`` or
     ``response_format: image_generation_call``.
 
     With this shape, the gateway's session-side response format for the tool
-    resolves to ``Passthrough``. The R7 runtime override must then promote
+    resolves to ``Passthrough``. The runtime override must then promote
     the format to ``ImageGenerationCall`` based on the client-declared
     ``tools: [{"type": "image_generation", ...}]`` in the Responses API
     request. This fixture is what proves the bug the reviewer reported is
-    fixed — the original R6.5 fixture pre-matched both sides, which is why
+    fixed — the original fixture pre-matched both sides, which is why
     the bug slipped past the test suite.
     """
     return {
@@ -143,7 +143,7 @@ def mock_mcp_config_file(mock_mcp_server: MockMcpServer) -> Iterator[str]:  # no
 def mock_mcp_config_file_plain(mock_mcp_server: MockMcpServer) -> Iterator[str]:  # noqa: F811
     """Write the plain (no ``builtin_type``) MCP config YAML to a tempfile.
 
-    Counterpart to ``mock_mcp_config_file`` for R7 regression coverage. The
+    Counterpart to ``mock_mcp_config_file`` for regression coverage. The
     mock MCP server is the same (``image_generation`` tool still reachable)
     but the gateway config leaves ``builtin_type`` / ``response_format``
     unset, forcing the runtime override path to decide the output shape
@@ -243,13 +243,13 @@ def gateway_with_mock_mcp_plain_cloud(
 ) -> Iterator[tuple]:
     """Launch an OpenAI cloud gateway wired to a PLAIN MCP server (no ``builtin_type``).
 
-    R7 regression fixture. Same mock MCP server as
+    regression fixture. Same mock MCP server as
     ``gateway_with_mock_mcp_cloud`` (so the underlying ``image_generation``
     tool behaves identically), but the gateway's MCP config deliberately
     does NOT tag the server with ``builtin_type: image_generation`` or a
     per-tool ``response_format``. The client is still expected to declare
     ``tools: [{"type": "image_generation", ...}]`` on the request — that
-    declaration is what the R7 runtime override uses to shape the output
+    declaration is what the runtime override uses to shape the output
     item.
 
     Skips when ``OPENAI_API_KEY`` is absent, same as the matched cloud

--- a/e2e_test/responses/conftest.py
+++ b/e2e_test/responses/conftest.py
@@ -88,6 +88,33 @@ def _image_generation_mcp_config(mock_mcp_url: str) -> dict:
     }
 
 
+def _plain_mcp_config(mock_mcp_url: str) -> dict:
+    """Build an MCP config that registers the mock server WITHOUT builtin_type.
+
+    This mirrors the deployment the external reviewer hit in R7: a plain MCP
+    server that happens to expose an ``image_generation`` tool, but whose YAML
+    config does NOT tag the server with ``builtin_type: image_generation`` or
+    ``response_format: image_generation_call``.
+
+    With this shape, the gateway's session-side response format for the tool
+    resolves to ``Passthrough``. The R7 runtime override must then promote
+    the format to ``ImageGenerationCall`` based on the client-declared
+    ``tools: [{"type": "image_generation", ...}]`` in the Responses API
+    request. This fixture is what proves the bug the reviewer reported is
+    fixed — the original R6.5 fixture pre-matched both sides, which is why
+    the bug slipped past the test suite.
+    """
+    return {
+        "servers": [
+            {
+                "name": "mock-image-gen-plain",
+                "protocol": "streamable",
+                "url": mock_mcp_url,
+            }
+        ]
+    }
+
+
 @pytest.fixture(scope="session")
 def mock_mcp_config_file(mock_mcp_server: MockMcpServer) -> Iterator[str]:  # noqa: F811
     """Write the MCP config YAML to a tempfile and yield its path.
@@ -106,6 +133,28 @@ def mock_mcp_config_file(mock_mcp_server: MockMcpServer) -> Iterator[str]:  # no
         with os.fdopen(fd, "w") as f:
             yaml.dump(config, f)
         logger.info("MCP config for mock image_generation at %s", path)
+        yield path
+    finally:
+        if os.path.exists(path):
+            os.unlink(path)
+
+
+@pytest.fixture(scope="session")
+def mock_mcp_config_file_plain(mock_mcp_server: MockMcpServer) -> Iterator[str]:  # noqa: F811
+    """Write the plain (no ``builtin_type``) MCP config YAML to a tempfile.
+
+    Counterpart to ``mock_mcp_config_file`` for R7 regression coverage. The
+    mock MCP server is the same (``image_generation`` tool still reachable)
+    but the gateway config leaves ``builtin_type`` / ``response_format``
+    unset, forcing the runtime override path to decide the output shape
+    based on the client's request-side tool declaration.
+    """
+    config = _plain_mcp_config(mock_mcp_server.url)
+    fd, path = tempfile.mkstemp(suffix=".yaml", prefix="mock_mcp_image_gen_plain_")
+    try:
+        with os.fdopen(fd, "w") as f:
+            yaml.dump(config, f)
+        logger.info("Plain MCP config (no builtin_type) at %s", path)
         yield path
     finally:
         if os.path.exists(path):
@@ -185,6 +234,55 @@ def gateway_with_mock_mcp_cloud(
 # The rewritten suite prefers the explicit ``_cloud`` / ``_grpc_*`` names
 # but this preserves anyone who imported ``gateway_with_mock_mcp`` before.
 gateway_with_mock_mcp = gateway_with_mock_mcp_cloud
+
+
+@pytest.fixture(scope="class")
+def gateway_with_mock_mcp_plain_cloud(
+    mock_mcp_server: MockMcpServer,  # noqa: F811
+    mock_mcp_config_file_plain: str,
+) -> Iterator[tuple]:
+    """Launch an OpenAI cloud gateway wired to a PLAIN MCP server (no ``builtin_type``).
+
+    R7 regression fixture. Same mock MCP server as
+    ``gateway_with_mock_mcp_cloud`` (so the underlying ``image_generation``
+    tool behaves identically), but the gateway's MCP config deliberately
+    does NOT tag the server with ``builtin_type: image_generation`` or a
+    per-tool ``response_format``. The client is still expected to declare
+    ``tools: [{"type": "image_generation", ...}]`` on the request — that
+    declaration is what the R7 runtime override uses to shape the output
+    item.
+
+    Skips when ``OPENAI_API_KEY`` is absent, same as the matched cloud
+    fixture.
+    """
+    api_key_env = "OPENAI_API_KEY"
+    if not os.environ.get(api_key_env):
+        pytest.skip(f"{api_key_env} not set — plain-MCP image_generation cloud lane needs OpenAI")
+
+    logger.info(
+        "Launching OpenAI cloud gateway with PLAIN mock MCP config (url=%s, config=%s)",
+        mock_mcp_server.url,
+        mock_mcp_config_file_plain,
+    )
+    gateway = launch_cloud_gateway(
+        "openai",
+        history_backend="memory",
+        extra_args=["--mcp-config-path", mock_mcp_config_file_plain],
+    )
+
+    try:
+        client = openai.OpenAI(
+            base_url=f"{gateway.base_url}/v1",
+            api_key=os.environ[api_key_env],
+        )
+    except Exception:
+        gateway.shutdown()
+        raise
+
+    try:
+        yield gateway, client, mock_mcp_server, "gpt-5-nano"
+    finally:
+        gateway.shutdown()
 
 
 # =============================================================================

--- a/e2e_test/responses/test_image_generation.py
+++ b/e2e_test/responses/test_image_generation.py
@@ -6,6 +6,17 @@ tool result is transformed into an ``image_generation_call`` output item, the
 argument compactor applies size/quality overrides correctly, and multi-turn
 replay strips the base64 payload from stored conversation context.
 
+Also covers R7 regression surfaces:
+
+* ``TestImageGenerationClientDeclaredServerPlain`` exercises a plain MCP
+  server (no ``builtin_type`` on the config) so the runtime response-format
+  override is forced to kick in based on the client's request-side
+  ``tools: [{"type": "image_generation", ...}]`` declaration. Every happy-path
+  body from ``_ImageGenerationAssertions`` must pass against this fixture.
+* ``_UserForwardingAssertions`` proves the top-level ``user`` field reaches
+  the MCP server as part of the dispatch arguments, so per-user quotas /
+  usage attribution downstream of the proxy keep working.
+
 The tests point the gateway at the in-process ``MockMcpServer`` so that:
 
 * responses are deterministic (byte-for-byte assertions on the base64 image),
@@ -22,6 +33,9 @@ Engine matrix
 * **openai** cloud (``TestImageGenerationCloud``) — exercised against the
   real ``gpt-5-nano`` upstream; the mock MCP server replaces the image
   backend. Validates the OpenAI-compat router (R6.2).
+* **openai** cloud, plain MCP server (``TestImageGenerationClientDeclaredServerPlain``) —
+  forces the runtime response-format override to make the decision
+  (R7 Fix A).
 * **sglang** + gpt-oss-20b via harmony (``TestImageGenerationGrpc``,
   engine=sglang) — validates the gRPC-harmony path (R6.3).
 * **vllm** + Llama-3.1-8B-Instruct via regular (``TestImageGenerationGrpc``,
@@ -437,16 +451,116 @@ class _ImageGenerationAssertions:
 
 
 # =============================================================================
+# R7: user-forwarding mix-in
+# =============================================================================
+
+
+class _UserForwardingAssertions:
+    """Test body that asserts ``request.user`` reaches the MCP dispatch args.
+
+    Shared by the plain-MCP cloud class AND the original cloud class so we
+    exercise R7 Fix B on both server configurations. The OpenAI spec does
+    NOT list ``user`` as a field on ``ImageGeneration`` tool config, so the
+    gateway injects it into the dispatch args payload directly (mirroring
+    what OpenAI's own hosted image-generation backend does via the
+    top-level request ``user``).
+
+    Subclasses supply ``_fixture_name`` pointing at a fixture that yields
+    ``(gateway, client, mock_mcp, model)``.
+    """
+
+    _fixture_name: str = ""  # overridden by subclasses
+
+    def _ctx(self, request):
+        return request.getfixturevalue(self._fixture_name)
+
+    def test_image_generation_forwards_user_to_mcp(self, request, image_gen_tool_args) -> None:
+        """R7: top-level ``user`` must reach MCP dispatch arguments.
+
+        The reviewer-reported bug was: ``ResponsesRequest.user`` is only
+        mirrored into ``safety_identifier`` for OpenAI cloud, never into the
+        MCP dispatch. Per-user quotas / usage attribution on the MCP proxy
+        side then silently fail. The mock MCP server records every call's
+        arguments in ``call_log``; assert the ``user`` we sent shows up
+        exactly there.
+
+        Non-vacuity guard: snapshot the call-log length before issuing the
+        request so a regression that silently skips the tool invocation
+        (making the test pass vacuously on leftover state) still fails.
+        """
+        _, client, mock_mcp, model = self._ctx(request)
+
+        user_id = "test-user-abc123"
+        baseline_calls = len(mock_mcp.call_log)
+
+        resp = client.responses.create(
+            model=model,
+            input=_IMAGE_GEN_PROMPT,
+            tools=[image_gen_tool_args],
+            tool_choice=_FORCED_TOOL_CHOICE,
+            stream=False,
+            user=user_id,
+        )
+
+        assert resp.error is None, f"Response error: {resp.error}"
+
+        # New invocation must have been recorded.
+        assert len(mock_mcp.call_log) > baseline_calls, (
+            f"Mock MCP server saw no new calls (baseline={baseline_calls}); "
+            "user-forwarding assertion would be vacuous."
+        )
+
+        last_args = mock_mcp.last_call_args
+        assert last_args is not None, "Mock MCP server saw no calls"
+        received = last_args.get("arguments", {})
+        assert received.get("user") == user_id, (
+            f"Gateway did not forward top-level request.user into MCP dispatch args; "
+            f"expected {user_id!r}, got {received.get('user')!r}. "
+            f"Full args received: {received!r}"
+        )
+
+
+# =============================================================================
 # Engine-specific classes
 # =============================================================================
 
 
 @pytest.mark.vendor("openai")
 @pytest.mark.gpu(0)
-class TestImageGenerationCloud(_ImageGenerationAssertions):
-    """``image_generation`` tool against the OpenAI cloud backend (R6.2)."""
+class TestImageGenerationCloud(_ImageGenerationAssertions, _UserForwardingAssertions):
+    """``image_generation`` tool against the OpenAI cloud backend (R6.2).
+
+    Extended for R7 to also exercise ``user`` forwarding on the
+    ``builtin_type``-tagged server config (the most common production
+    deployment).
+    """
 
     _fixture_name = "gateway_with_mock_mcp_cloud"
+
+
+@pytest.mark.vendor("openai")
+@pytest.mark.gpu(0)
+class TestImageGenerationClientDeclaredServerPlain(
+    _ImageGenerationAssertions, _UserForwardingAssertions
+):
+    """R7 regression: the MCP server config has no ``builtin_type``.
+
+    The reviewer's deployment doesn't tag the MCP server with
+    ``builtin_type: image_generation`` and doesn't set a per-tool
+    ``response_format``. Before R7, the session-side format resolved to
+    ``Passthrough`` and ``ResponseTransformer::transform`` emitted an
+    ``mcp_call`` item with ``output`` + ``arguments`` fields — wrong for a
+    hosted image_generation call. The R7 runtime override rescues the
+    output shape using the client-declared ``tools: [{"type":
+    "image_generation"}]`` on the request.
+
+    Every assertion in ``_ImageGenerationAssertions`` must pass against
+    this fixture, same as the original cloud class. If R7 Fix A
+    regresses, the non-streaming test fails first (output item type +
+    field names), followed by the streaming envelope (wrong event types).
+    """
+
+    _fixture_name = "gateway_with_mock_mcp_plain_cloud"
 
 
 # ``gpu(2)`` on the gRPC classes matches the ``e2e-2gpu-responses`` job in

--- a/e2e_test/responses/test_image_generation.py
+++ b/e2e_test/responses/test_image_generation.py
@@ -6,7 +6,7 @@ tool result is transformed into an ``image_generation_call`` output item, the
 argument compactor applies size/quality overrides correctly, and multi-turn
 replay strips the base64 payload from stored conversation context.
 
-Also covers R7 regression surfaces:
+Also covers Regression surfaces:
 
 * ``TestImageGenerationClientDeclaredServerPlain`` exercises a plain MCP
   server (no ``builtin_type`` on the config) so the runtime response-format
@@ -35,7 +35,7 @@ Engine matrix
   backend. Validates the OpenAI-compat router (R6.2).
 * **openai** cloud, plain MCP server (``TestImageGenerationClientDeclaredServerPlain``) —
   forces the runtime response-format override to make the decision
-  (R7 Fix A).
+  .
 * **sglang** + gpt-oss-20b via harmony (``TestImageGenerationGrpc``,
   engine=sglang) — validates the gRPC-harmony path (R6.3).
 * **vllm** + Llama-3.1-8B-Instruct via regular (``TestImageGenerationGrpc``,
@@ -451,7 +451,7 @@ class _ImageGenerationAssertions:
 
 
 # =============================================================================
-# R7: user-forwarding mix-in
+# User-forwarding mix-in
 # =============================================================================
 
 
@@ -459,7 +459,7 @@ class _UserForwardingAssertions:
     """Test body that asserts ``request.user`` reaches the MCP dispatch args.
 
     Shared by the plain-MCP cloud class AND the original cloud class so we
-    exercise R7 Fix B on both server configurations. The OpenAI spec does
+    exercise  on both server configurations. The OpenAI spec does
     NOT list ``user`` as a field on ``ImageGeneration`` tool config, so the
     gateway injects it into the dispatch args payload directly (mirroring
     what OpenAI's own hosted image-generation backend does via the
@@ -475,7 +475,7 @@ class _UserForwardingAssertions:
         return request.getfixturevalue(self._fixture_name)
 
     def test_image_generation_forwards_user_to_mcp(self, request, image_gen_tool_args) -> None:
-        """R7: top-level ``user`` must reach MCP dispatch arguments.
+        """Top-level ``user`` must reach MCP dispatch arguments.
 
         The reviewer-reported bug was: ``ResponsesRequest.user`` is only
         mirrored into ``safety_identifier`` for OpenAI cloud, never into the
@@ -530,7 +530,7 @@ class _UserForwardingAssertions:
 class TestImageGenerationCloud(_ImageGenerationAssertions, _UserForwardingAssertions):
     """``image_generation`` tool against the OpenAI cloud backend (R6.2).
 
-    Extended for R7 to also exercise ``user`` forwarding on the
+    Extended to also exercise ``user`` forwarding on the
     ``builtin_type``-tagged server config (the most common production
     deployment).
     """
@@ -543,19 +543,19 @@ class TestImageGenerationCloud(_ImageGenerationAssertions, _UserForwardingAssert
 class TestImageGenerationClientDeclaredServerPlain(
     _ImageGenerationAssertions, _UserForwardingAssertions
 ):
-    """R7 regression: the MCP server config has no ``builtin_type``.
+    """the MCP server config has no ``builtin_type``.
 
     The reviewer's deployment doesn't tag the MCP server with
     ``builtin_type: image_generation`` and doesn't set a per-tool
-    ``response_format``. Before R7, the session-side format resolved to
+    ``response_format``. Before this fix, the session-side format resolved to
     ``Passthrough`` and ``ResponseTransformer::transform`` emitted an
     ``mcp_call`` item with ``output`` + ``arguments`` fields — wrong for a
-    hosted image_generation call. The R7 runtime override rescues the
+    hosted image_generation call. The runtime override rescues the
     output shape using the client-declared ``tools: [{"type":
     "image_generation"}]`` on the request.
 
     Every assertion in ``_ImageGenerationAssertions`` must pass against
-    this fixture, same as the original cloud class. If R7 Fix A
+    this fixture, same as the original cloud class. If 
     regresses, the non-streaming test fails first (output item type +
     field names), followed by the streaming envelope (wrong event types).
     """

--- a/model_gateway/src/routers/anthropic/mcp.rs
+++ b/model_gateway/src/routers/anthropic/mcp.rs
@@ -222,6 +222,7 @@ async fn execute_mcp_tool_calls(
             call_id: tool_call.id.clone(),
             tool_name: tool_call.name.clone(),
             arguments: tool_call.input.clone(),
+            response_format_override: None,
         };
 
         let output = session.execute_tool(input).await;

--- a/model_gateway/src/routers/grpc/harmony/responses/execution.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/execution.rs
@@ -60,7 +60,7 @@ pub(super) async fn execute_mcp_tools(
     // Non-object model payloads coerce to `{}` so the override merge actually
     // applies rather than silently dropping the caller's declared config.
     //
-    // R7: `resolve_response_format` combines the session's format with a
+    // `resolve_response_format` combines the session's format with the
     // request-side hosted-tool declaration so the MCP server doesn't need
     // `builtin_type` config for the client's `tools: [{"type": "..."}]`
     // to shape the output item correctly. The resolved format flows into

--- a/model_gateway/src/routers/grpc/harmony/responses/execution.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/execution.rs
@@ -7,7 +7,8 @@ use openai_protocol::{
 };
 use serde_json::{from_str, json, Value};
 use smg_mcp::{
-    apply_hosted_tool_overrides, extract_hosted_tool_overrides, McpToolSession, ToolExecutionInput,
+    apply_hosted_tool_overrides, extract_hosted_tool_overrides, inject_user_into_hosted_tool_args,
+    resolve_response_format, McpToolSession, ToolExecutionInput,
 };
 use tracing::{debug, error};
 
@@ -51,12 +52,20 @@ pub(super) async fn execute_mcp_tools(
     tracking: &mut McpCallTracking,
     model_id: &str,
     request_tools: &[ResponseTool],
+    request_user: Option<&str>,
 ) -> Result<Vec<ToolResult>, Response> {
     // Convert tool calls to execution inputs, merging caller-declared
     // hosted-tool configuration from `request_tools` into dispatch args.
     // For non-hosted-tool calls (Passthrough format), no override lookup runs.
     // Non-object model payloads coerce to `{}` so the override merge actually
     // applies rather than silently dropping the caller's declared config.
+    //
+    // R7: `resolve_response_format` combines the session's format with a
+    // request-side hosted-tool declaration so the MCP server doesn't need
+    // `builtin_type` config for the client's `tools: [{"type": "..."}]`
+    // to shape the output item correctly. The resolved format flows into
+    // `ToolExecutionInput.response_format_override` so
+    // `ToolExecutionOutput::to_response_item` emits the correct shape.
     let inputs: Vec<ToolExecutionInput> = tool_calls
         .iter()
         .map(|tc| {
@@ -83,18 +92,22 @@ pub(super) async fn execute_mcp_tools(
                     json!({})
                 }
             };
-            if let Some(kind) = session
-                .tool_response_format(&tc.function.name)
-                .to_builtin_tool_type()
-            {
+            let resolved_format = resolve_response_format(
+                session.tool_response_format(&tc.function.name),
+                request_tools,
+                &tc.function.name,
+            );
+            if let Some(kind) = resolved_format.to_builtin_tool_type() {
                 if let Some(overrides) = extract_hosted_tool_overrides(request_tools, kind) {
                     apply_hosted_tool_overrides(&mut args, &overrides);
                 }
             }
+            inject_user_into_hosted_tool_args(&mut args, &resolved_format, request_user);
             ToolExecutionInput {
                 call_id: tc.id.clone(),
                 tool_name: tc.function.name.clone(),
                 arguments: args,
+                response_format_override: Some(resolved_format),
             }
         })
         .collect();

--- a/model_gateway/src/routers/grpc/harmony/responses/non_streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/non_streaming.rs
@@ -259,7 +259,9 @@ async fn execute_with_mcp_loop(
 
                 // Execute MCP tools (if any). Caller-declared hosted-tool overrides
                 // live on `original_tools` (pre-MCP-injection), so we thread those
-                // into dispatch — `execute_mcp_tools` merges per-kind.
+                // into dispatch — `execute_mcp_tools` merges per-kind. The
+                // caller's top-level `user` is also forwarded so hosted-tool
+                // MCP proxies can attribute usage per-user (R7 Fix B).
                 let mcp_results = if mcp_tool_calls.is_empty() {
                     Vec::new()
                 } else {
@@ -269,6 +271,7 @@ async fn execute_with_mcp_loop(
                         &mut mcp_tracking,
                         &current_request.model,
                         original_tools.as_deref().unwrap_or(&[]),
+                        current_request.user.as_deref(),
                     )
                     .await?
                 };

--- a/model_gateway/src/routers/grpc/harmony/responses/non_streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/non_streaming.rs
@@ -261,7 +261,7 @@ async fn execute_with_mcp_loop(
                 // live on `original_tools` (pre-MCP-injection), so we thread those
                 // into dispatch — `execute_mcp_tools` merges per-kind. The
                 // caller's top-level `user` is also forwarded so hosted-tool
-                // MCP proxies can attribute usage per-user (R7 Fix B).
+                // MCP proxies can attribute usage per-user.
                 let mcp_results = if mcp_tool_calls.is_empty() {
                     Vec::new()
                 } else {

--- a/model_gateway/src/routers/grpc/harmony/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/streaming.rs
@@ -311,7 +311,9 @@ async fn execute_mcp_tool_loop_streaming(
 
                 // Execute MCP tools (if any). `original_request.tools` is the
                 // caller-declared tool list (hosted-tool config lives there);
-                // `execute_mcp_tools` merges the per-kind overrides into dispatch args.
+                // `execute_mcp_tools` merges the per-kind overrides into dispatch
+                // args. The caller's top-level `user` rides through so hosted-tool
+                // MCP proxies can attribute usage per-user (R7 Fix B).
                 let mcp_results = if mcp_tool_calls.is_empty() {
                     Vec::new()
                 } else {
@@ -321,6 +323,7 @@ async fn execute_mcp_tool_loop_streaming(
                         &mut mcp_tracking,
                         &current_request.model,
                         original_request.tools.as_deref().unwrap_or(&[]),
+                        original_request.user.as_deref(),
                     )
                     .await
                     {

--- a/model_gateway/src/routers/grpc/harmony/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/streaming.rs
@@ -313,7 +313,7 @@ async fn execute_mcp_tool_loop_streaming(
                 // caller-declared tool list (hosted-tool config lives there);
                 // `execute_mcp_tools` merges the per-kind overrides into dispatch
                 // args. The caller's top-level `user` rides through so hosted-tool
-                // MCP proxies can attribute usage per-user (R7 Fix B).
+                // MCP proxies can attribute usage per-user.
                 let mcp_results = if mcp_tool_calls.is_empty() {
                     Vec::new()
                 } else {

--- a/model_gateway/src/routers/grpc/regular/responses/non_streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/non_streaming.rs
@@ -11,8 +11,8 @@ use axum::response::Response;
 use openai_protocol::responses::{ResponseStatus, ResponsesRequest, ResponsesResponse};
 use serde_json::json;
 use smg_mcp::{
-    apply_hosted_tool_overrides, extract_hosted_tool_overrides, McpServerBinding, McpToolSession,
-    ToolExecutionInput,
+    apply_hosted_tool_overrides, extract_hosted_tool_overrides, inject_user_into_hosted_tool_args,
+    resolve_response_format, McpServerBinding, McpToolSession, ToolExecutionInput,
 };
 use tracing::{debug, error, trace, warn};
 
@@ -342,7 +342,12 @@ pub(super) async fn execute_tool_loop(
             // hosted-tool config from `original_request.tools` into dispatch args.
             // Non-object model payloads coerce to `{}` so the merge actually
             // applies instead of silently dropping the caller's config.
+            //
+            // R7: resolve the response format by combining session state with
+            // request-side hosted-tool declarations and also forward the caller's
+            // `user` into the dispatch payload for hosted tools.
             let request_tools = original_request.tools.as_deref().unwrap_or(&[]);
+            let request_user = original_request.user.as_deref();
             let inputs: Vec<ToolExecutionInput> = mcp_tool_calls
                 .into_iter()
                 .map(|tc| {
@@ -351,19 +356,27 @@ pub(super) async fn execute_tool_loop(
                             Ok(serde_json::Value::Object(map)) => serde_json::Value::Object(map),
                             _ => json!({}),
                         };
-                    if let Some(kind) = session
-                        .tool_response_format(&tc.name)
-                        .to_builtin_tool_type()
-                    {
+                    let resolved_format = resolve_response_format(
+                        session.tool_response_format(&tc.name),
+                        request_tools,
+                        &tc.name,
+                    );
+                    if let Some(kind) = resolved_format.to_builtin_tool_type() {
                         if let Some(overrides) = extract_hosted_tool_overrides(request_tools, kind)
                         {
                             apply_hosted_tool_overrides(&mut arguments, &overrides);
                         }
                     }
+                    inject_user_into_hosted_tool_args(
+                        &mut arguments,
+                        &resolved_format,
+                        request_user,
+                    );
                     ToolExecutionInput {
                         call_id: tc.call_id,
                         tool_name: tc.name,
                         arguments,
+                        response_format_override: Some(resolved_format),
                     }
                 })
                 .collect();

--- a/model_gateway/src/routers/grpc/regular/responses/non_streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/non_streaming.rs
@@ -343,7 +343,7 @@ pub(super) async fn execute_tool_loop(
             // Non-object model payloads coerce to `{}` so the merge actually
             // applies instead of silently dropping the caller's config.
             //
-            // R7: resolve the response format by combining session state with
+            // Resolve the response format by combining session state with
             // request-side hosted-tool declarations and also forward the caller's
             // `user` into the dispatch payload for hosted tools.
             let request_tools = original_request.tools.as_deref().unwrap_or(&[]);

--- a/model_gateway/src/routers/grpc/regular/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/streaming.rs
@@ -640,7 +640,7 @@ async fn execute_tool_loop_streaming_internal(
                     tool_call.call_id
                 );
 
-                // Resolve response_format for this tool. R7: prefer the session's
+                // Resolve response_format for this tool: prefer the session's
                 // explicit hosted format; otherwise fall back to the caller's
                 // request-side tool declaration. This guarantees streaming
                 // events match the client-declared hosted-tool shape even when
@@ -733,7 +733,7 @@ async fn execute_tool_loop_streaming_internal(
                     }
                 }
 
-                // R7: forward the caller's top-level `user` into hosted-tool
+                // Forward the caller's top-level `user` into hosted-tool
                 // dispatch args so MCP proxies can attribute usage per-user.
                 inject_user_into_hosted_tool_args(
                     &mut arguments,
@@ -744,8 +744,7 @@ async fn execute_tool_loop_streaming_internal(
                 // Execute the single tool via the normalized MCP execution API.
                 // This avoids custom serialization and manual re-transformation in streaming paths.
                 // The resolved format flows through the override so
-                // `ToolExecutionOutput::to_response_item` emits the correct shape
-                // (R7 Fix A).
+                // `ToolExecutionOutput::to_response_item` emits the correct shape.
                 let tool_output = session
                     .execute_tool(ToolExecutionInput {
                         call_id: tool_call.call_id.clone(),

--- a/model_gateway/src/routers/grpc/regular/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/streaming.rs
@@ -35,8 +35,8 @@ use smg_data_connector::{
     ResponseStorage,
 };
 use smg_mcp::{
-    apply_hosted_tool_overrides, extract_hosted_tool_overrides, McpServerBinding, McpToolSession,
-    ResponseFormat, ToolExecutionInput,
+    apply_hosted_tool_overrides, extract_hosted_tool_overrides, inject_user_into_hosted_tool_args,
+    resolve_response_format, McpServerBinding, McpToolSession, ResponseFormat, ToolExecutionInput,
 };
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::UnboundedReceiverStream;
@@ -640,8 +640,16 @@ async fn execute_tool_loop_streaming_internal(
                     tool_call.call_id
                 );
 
-                // Look up response_format for this tool
-                let response_format = session.tool_response_format(&tool_call.name);
+                // Resolve response_format for this tool. R7: prefer the session's
+                // explicit hosted format; otherwise fall back to the caller's
+                // request-side tool declaration. This guarantees streaming
+                // events match the client-declared hosted-tool shape even when
+                // the MCP server itself has no `builtin_type` config.
+                let response_format = resolve_response_format(
+                    session.tool_response_format(&tool_call.name),
+                    original_request.tools.as_deref().unwrap_or(&[]),
+                    &tool_call.name,
+                );
 
                 // Use emitter helpers to determine correct type and allocate index
                 let item_type =
@@ -725,13 +733,25 @@ async fn execute_tool_loop_streaming_internal(
                     }
                 }
 
+                // R7: forward the caller's top-level `user` into hosted-tool
+                // dispatch args so MCP proxies can attribute usage per-user.
+                inject_user_into_hosted_tool_args(
+                    &mut arguments,
+                    &response_format,
+                    original_request.user.as_deref(),
+                );
+
                 // Execute the single tool via the normalized MCP execution API.
                 // This avoids custom serialization and manual re-transformation in streaming paths.
+                // The resolved format flows through the override so
+                // `ToolExecutionOutput::to_response_item` emits the correct shape
+                // (R7 Fix A).
                 let tool_output = session
                     .execute_tool(ToolExecutionInput {
                         call_id: tool_call.call_id.clone(),
                         tool_name: tool_call.name.clone(),
                         arguments,
+                        response_format_override: Some(response_format.clone()),
                     })
                     .await;
 

--- a/model_gateway/src/routers/openai/mcp/tool_loop.rs
+++ b/model_gateway/src/routers/openai/mcp/tool_loop.rs
@@ -22,8 +22,9 @@ use openai_protocol::{
 use serde_json::{json, to_value, Value};
 use smg_mcp::{
     apply_hosted_tool_overrides, extract_embedded_openai_responses, extract_hosted_tool_overrides,
-    mcp_response_item_id, McpServerBinding, McpToolSession, ResponseFormat, ResponseTransformer,
-    ToolExecutionInput, ToolExecutionResult,
+    inject_user_into_hosted_tool_args, mcp_response_item_id, resolve_response_format,
+    McpServerBinding, McpToolSession, ResponseFormat, ResponseTransformer, ToolExecutionInput,
+    ToolExecutionResult,
 };
 use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
@@ -153,9 +154,15 @@ fn build_message_from_openai_response(openai_response: Value) -> Option<Value> {
 ///
 /// `request_tools` carries the caller-declared `tools` list from the original
 /// request so per-kind hosted-tool overrides can be merged into dispatch args
-/// before [`McpToolSession::execute_tool`].
+/// before [`McpToolSession::execute_tool`]. `request_user` carries the
+/// caller's top-level `user` identifier so hosted-tool dispatches can mirror
+/// it into their args (R7 Fix B).
 ///
 /// Returns false if client disconnected during execution
+#[expect(
+    clippy::too_many_arguments,
+    reason = "streaming dispatch intentionally threads request-scoped state (tools, user, session, emitter, metrics model id) without an intermediate struct; the alternative is a one-call-site wrapper struct that obscures the signature for no ergonomic gain"
+)]
 pub(crate) async fn execute_streaming_tool_calls(
     pending_calls: Vec<FunctionCallInProgress>,
     session: &McpToolSession<'_>,
@@ -164,6 +171,7 @@ pub(crate) async fn execute_streaming_tool_calls(
     sequence_number: &mut u64,
     model_id: &str,
     request_tools: &[ResponseTool],
+    request_user: Option<&str>,
 ) -> bool {
     for call in pending_calls {
         if call.name.is_empty() {
@@ -185,7 +193,13 @@ pub(crate) async fn execute_streaming_tool_calls(
             &call.arguments_buffer
         };
 
-        let response_format = session.tool_response_format(&call.name);
+        // R7: resolve the format first so both event emission (below) and
+        // dispatch (override on ToolExecutionInput) use the same shape.
+        let response_format = resolve_response_format(
+            session.tool_response_format(&call.name),
+            request_tools,
+            &call.name,
+        );
         let server_label = session.resolve_tool_server_label(&call.name);
 
         let mut arguments: Value = match serde_json::from_str(args_str) {
@@ -247,6 +261,9 @@ pub(crate) async fn execute_streaming_tool_calls(
             }
         }
 
+        // R7: forward caller's top-level `user` into hosted-tool dispatch args.
+        inject_user_into_hosted_tool_args(&mut arguments, &response_format, request_user);
+
         // Log the effective (post-merge) args so the log reflects what the
         // MCP server actually receives, not the pre-merge string from the model.
         debug!("Calling MCP tool '{}' with args: {}", call.name, arguments);
@@ -255,6 +272,7 @@ pub(crate) async fn execute_streaming_tool_calls(
                 call_id: call.call_id.clone(),
                 tool_name: call.name.clone(),
                 arguments,
+                response_format_override: Some(response_format.clone()),
             })
             .await;
 
@@ -876,12 +894,21 @@ pub(crate) async fn execute_tool_loop(
                     original_body,
                 );
             }
+            // R7: resolve the format up-front so the error-handling branch and
+            // the dispatch branch agree on the output shape. The resolved format
+            // is then threaded through `response_format_override` so
+            // `ToolExecutionOutput::to_response_item` emits the correct item
+            // type even when the MCP server lacks an explicit `builtin_type`.
+            let response_format = resolve_response_format(
+                session.tool_response_format(&call.name),
+                original_body.tools.as_deref().unwrap_or(&[]),
+                &call.name,
+            );
             let mut arguments: Value = match serde_json::from_str(&call.arguments) {
                 Ok(v) => v,
                 Err(e) => {
                     warn!(tool = %call.name, error = %e, "Failed to parse tool arguments as JSON");
                     let error_output = format!("Invalid tool arguments: {e}");
-                    let response_format = session.tool_response_format(&call.name);
                     let server_label = session.resolve_tool_server_label(&call.name);
                     let tool_item_id =
                         non_streaming_tool_item_id_source(&call.item_id, &response_format);
@@ -922,7 +949,6 @@ pub(crate) async fn execute_tool_loop(
             // Merge caller-declared hosted-tool configuration into dispatch args
             // for this tool's hosted-tool kind, if any. `original_body.tools` is
             // the caller's tool declarations; empty / None = no-op.
-            let response_format = session.tool_response_format(&call.name);
             if let Some(kind) = response_format.to_builtin_tool_type() {
                 if let Some(overrides) = extract_hosted_tool_overrides(
                     original_body.tools.as_deref().unwrap_or(&[]),
@@ -931,6 +957,15 @@ pub(crate) async fn execute_tool_loop(
                     apply_hosted_tool_overrides(&mut arguments, &overrides);
                 }
             }
+
+            // R7: forward caller's top-level `user` into hosted-tool dispatch
+            // args so MCP proxies can attribute usage per-user. No-op for
+            // non-hosted function tools.
+            inject_user_into_hosted_tool_args(
+                &mut arguments,
+                &response_format,
+                original_body.user.as_deref(),
+            );
 
             // Serialize the post-merge args once so downstream logging + the
             // approval payload show the effective (dispatched) payload rather
@@ -947,6 +982,7 @@ pub(crate) async fn execute_tool_loop(
                     call_id: call.call_id.clone(),
                     tool_name: call.name.clone(),
                     arguments,
+                    response_format_override: Some(response_format.clone()),
                 })
                 .await;
 

--- a/model_gateway/src/routers/openai/mcp/tool_loop.rs
+++ b/model_gateway/src/routers/openai/mcp/tool_loop.rs
@@ -156,7 +156,7 @@ fn build_message_from_openai_response(openai_response: Value) -> Option<Value> {
 /// request so per-kind hosted-tool overrides can be merged into dispatch args
 /// before [`McpToolSession::execute_tool`]. `request_user` carries the
 /// caller's top-level `user` identifier so hosted-tool dispatches can mirror
-/// it into their args (R7 Fix B).
+/// it into their args.
 ///
 /// Returns false if client disconnected during execution
 #[expect(
@@ -193,7 +193,7 @@ pub(crate) async fn execute_streaming_tool_calls(
             &call.arguments_buffer
         };
 
-        // R7: resolve the format first so both event emission (below) and
+        // Resolve the format first so both event emission (below) and
         // dispatch (override on ToolExecutionInput) use the same shape.
         let response_format = resolve_response_format(
             session.tool_response_format(&call.name),
@@ -261,7 +261,7 @@ pub(crate) async fn execute_streaming_tool_calls(
             }
         }
 
-        // R7: forward caller's top-level `user` into hosted-tool dispatch args.
+        // Forward caller's top-level `user` into hosted-tool dispatch args.
         inject_user_into_hosted_tool_args(&mut arguments, &response_format, request_user);
 
         // Log the effective (post-merge) args so the log reflects what the
@@ -894,7 +894,7 @@ pub(crate) async fn execute_tool_loop(
                     original_body,
                 );
             }
-            // R7: resolve the format up-front so the error-handling branch and
+            // Resolve the format up-front so the error-handling branch and
             // the dispatch branch agree on the output shape. The resolved format
             // is then threaded through `response_format_override` so
             // `ToolExecutionOutput::to_response_item` emits the correct item
@@ -958,7 +958,7 @@ pub(crate) async fn execute_tool_loop(
                 }
             }
 
-            // R7: forward caller's top-level `user` into hosted-tool dispatch
+            // Forward caller's top-level `user` into hosted-tool dispatch
             // args so MCP proxies can attribute usage per-user. No-op for
             // non-hosted function tools.
             inject_user_into_hosted_tool_args(

--- a/model_gateway/src/routers/openai/responses/streaming.rs
+++ b/model_gateway/src/routers/openai/responses/streaming.rs
@@ -26,7 +26,8 @@ use openai_protocol::{
 };
 use serde_json::{json, Value};
 use smg_mcp::{
-    mcp_response_item_id, McpOrchestrator, McpServerBinding, McpToolSession, ResponseFormat,
+    mcp_response_item_id, resolve_response_format, McpOrchestrator, McpServerBinding, McpToolSession,
+    ResponseFormat,
 };
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::UnboundedReceiverStream;
@@ -147,7 +148,14 @@ pub(super) fn apply_event_transformations_inplace(
                         if let Some(session) =
                             ctx.session.filter(|s| s.has_exposed_tool(&tool_name))
                         {
-                            let response_format = session.tool_response_format(&tool_name);
+                            // R7: resolve the format using the client's request-side
+                            // tool declaration so plain (un-tagged) MCP servers still
+                            // produce the correct streaming event shape.
+                            let response_format = resolve_response_format(
+                                session.tool_response_format(&tool_name),
+                                ctx.original_request.tools.as_deref().unwrap_or(&[]),
+                                &tool_name,
+                            );
 
                             // Determine item type and ID prefix based on response_format
                             let (new_type, id_prefix) = match response_format {
@@ -1011,7 +1019,9 @@ pub(super) fn handle_streaming_with_tool_interception(
 
             // Execute all pending tool calls. Pass the caller-declared tools so
             // hosted-tool overrides (e.g. image_generation size/quality) are
-            // merged into dispatch args before MCP execution.
+            // merged into dispatch args before MCP execution. Also forward
+            // `original_request.user` so hosted-tool dispatch args get the
+            // top-level user identifier (R7 Fix B).
             if !execute_streaming_tool_calls(
                 pending_calls,
                 &session,
@@ -1020,6 +1030,7 @@ pub(super) fn handle_streaming_with_tool_interception(
                 &mut sequence_number,
                 &original_request.model,
                 original_request.tools.as_deref().unwrap_or(&[]),
+                original_request.user.as_deref(),
             )
             .await
             {

--- a/model_gateway/src/routers/openai/responses/streaming.rs
+++ b/model_gateway/src/routers/openai/responses/streaming.rs
@@ -148,7 +148,7 @@ pub(super) fn apply_event_transformations_inplace(
                         if let Some(session) =
                             ctx.session.filter(|s| s.has_exposed_tool(&tool_name))
                         {
-                            // R7: resolve the format using the client's request-side
+                            // Resolve the format using the client's request-side
                             // tool declaration so plain (un-tagged) MCP servers still
                             // produce the correct streaming event shape.
                             let response_format = resolve_response_format(
@@ -1021,7 +1021,7 @@ pub(super) fn handle_streaming_with_tool_interception(
             // hosted-tool overrides (e.g. image_generation size/quality) are
             // merged into dispatch args before MCP execution. Also forward
             // `original_request.user` so hosted-tool dispatch args get the
-            // top-level user identifier (R7 Fix B).
+            // top-level user identifier.
             if !execute_streaming_tool_calls(
                 pending_calls,
                 &session,


### PR DESCRIPTION
## Description

### Problem

An external reviewer tested our `image_generation` MCP integration at
commit `cb84bbb8` (R6.5) and reported three real spec violations. All
three are gateway-side bugs, not user-config issues.

#### Bug 1 — `user` not forwarded to MCP dispatch

`ResponsesRequest.user` is mirrored into `safety_identifier` for OpenAI
cloud forwarding (`model_gateway/src/routers/openai/responses/utils.rs:91`)
but never reaches the MCP server. MCP proxies downstream of SMG cannot
attribute usage or enforce per-user quotas.

Repro: send a Responses request with `user: "u1"` and a hosted
`image_generation` tool declaration. Observed: the MCP tool call
arguments contain `prompt`/`size`/etc. but no `user`.

#### Bug 2+3 — Response item shape is wrong when the MCP server lacks `builtin_type`

When an MCP server exposes an `image_generation` tool but its YAML
config does NOT tag it with `builtin_type: image_generation`, the
emitted output item is shaped as a generic `mcp_call`:

```json
{"id": "...", "type": "image_generation_call", "output": "<nested json with base64>", "arguments": "<metadata json>", ...}
```

Correct spec shape (`openai-responses-api-spec.md §ImageGenerationCall`):

```json
{"id": "ig_...", "type": "image_generation_call", "result": "<base64>", "status": "completed",
 "size": "1024x1024", "quality": "...", "background": "...", "output_format": "...", "action": "...",
 "revised_prompt": "..."}
```

Repro: point the gateway at an MCP server without `builtin_type` in its
YAML config, send a Responses request with `tools:
[{"type": "image_generation", ...}]`, inspect the response output —
item type is present but with the `mcp_call` field layout (`output` +
`arguments`) instead of the spec-correct `result` + `status` + metadata
fields.

Root cause: `McpToolSession::tool_response_format(tool_name)` at
`crates/mcp/src/core/session.rs:461` resolves the format purely from
the session binding, which is built from the server-side `builtin_type`
config. If the server wasn't tagged, the format falls back to
`Passthrough` and `ResponseTransformer::transform` emits `mcp_call`
output. Per spec, the CLIENT's `tools` declaration determines the
output item shape; the server's `builtin_type` is an SMG-specific
routing knob and should NOT be the sole gate on the output shape.

The same class of bug affects all four hosted tools (image_generation,
web_search_preview, code_interpreter, file_search). This PR fixes the
general case; e2e coverage is scoped to image_generation because
that's what the reviewer exercised.

### Why the R6.5 test suite didn't catch these

The R6.5 `gateway_with_mock_mcp_cloud` fixture tagged the mock MCP
server with `builtin_type: image_generation` AND the client declared
the same hosted tool on the request. Both paths matched, so:
1. The session-side response format was already `ImageGenerationCall`
   at dispatch time — the runtime override path was never exercised.
2. There was no assertion on `user` reaching the MCP server, just that
   the tool ran.

This PR adds a parallel fixture and test class that breaks the
pre-matched setup, plus a new user-forwarding assertion mixed into
both the old and new fixtures.

### Solution

#### Fix A — Runtime response_format override (one pure function, one source of truth)

* New pure function `resolve_response_format(session_format,
  request_tools, tool_name)` in `crates/mcp/src/core/session.rs`:
  * If the session already classifies the tool as a hosted format
    (server was explicitly tagged), keep it — explicit config wins.
  * Otherwise, if the request `tools` contains a hosted-tool
    declaration AND the dispatched tool name matches that hosted
    tool's canonical name (`image_generation`,
    `web_search_preview`/`web_search`, `code_interpreter`,
    `file_search`), return the matching hosted format.
  * Otherwise, return the session format unchanged.

* New `ToolExecutionInput.response_format_override:
  Option<ResponseFormat>` field (defaults to `None`, so existing
  call sites compile unchanged). When set,
  `execute_tool_resolved_result` replaces the tool entry's
  session-derived format on the resulting `ToolExecutionOutput` /
  `PendingToolExecution`. `ToolExecutionOutput::to_response_item`
  therefore emits the correct shape without per-site transformer
  rewrites.

* Wired at all five router execution sites:
  1. `grpc/harmony/responses/execution.rs::execute_mcp_tools`
  2. `grpc/regular/responses/non_streaming.rs` tool-loop batch
  3. `grpc/regular/responses/streaming.rs` per-call dispatch
  4. `openai/mcp/tool_loop.rs::execute_streaming_tool_calls`
  5. `openai/mcp/tool_loop.rs::execute_tool_loop` (non-streaming)

* Also updated `openai/responses/streaming.rs::apply_event_transformations_inplace`
  (cloud SSE rewrite layer) so the `fc_*` → hosted-item rewrite uses
  the resolved format — otherwise streaming events for a plain-MCP
  server would still emit `mcp_call` types.

#### Fix B — `user` forwarding into MCP dispatch args (one pure function, hosted-tools only)

OpenAI's spec does NOT list `user` as a field on `ImageGenerationTool`,
so we can't ride the existing `tool_overrides` (R6.6) path. Instead:

* New pure function `inject_user_into_hosted_tool_args(arguments,
  resolved_format, user)` in `crates/mcp/src/core/session.rs`:
  * No-op for `ResponseFormat::Passthrough` (plain MCP function
    tools are left alone — safer than potentially breaking an MCP
    tool schema that doesn't expect a `user` key).
  * No-op for empty/None `user`.
  * If `arguments` already has a `user` key, preserve the
    model-supplied value and log at `debug!` — don't overwrite.
  * Otherwise inject `"user": "<value>"` into the args object.

* Called at each of the five router sites after
  `apply_hosted_tool_overrides`.

### Out of scope (noted for follow-up)

* `grpc/harmony/streaming.rs` (the chat-completion-level streaming
  path) still uses the session-only format at its mid-tool event
  emission site. The function doesn't currently have access to
  `ResponsesRequest`; R7's cloud regression test doesn't exercise
  it (cloud routes through `openai/responses/streaming.rs`).
  Threading `request_tools` through the Harmony chat pipeline
  is a follow-up for when the plain-MCP scenario gets e2e coverage on
  the gRPC lanes.

* Parallel plain-MCP + user-forwarding e2e coverage for
  `web_search_preview`, `code_interpreter`, `file_search`. The
  Fix A / Fix B logic already handles all four hosted-tool kinds
  uniformly — only the e2e test coverage is deferred to when each
  tool gets its own R6.x-style mock tool + test suite.

## Changes

### Rust / MCP crate

* `crates/mcp/src/core/session.rs` — adds `resolve_response_format`
  and `inject_user_into_hosted_tool_args` pure functions, plus 14
  unit tests covering every branch (session-wins, passthrough
  promotion, tool-name mismatch, four hosted kinds, user injection
  happy path, skipped-for-passthrough, skipped-for-empty,
  preserve-existing-key, non-object no-op).
* `crates/mcp/src/core/orchestrator.rs` — adds
  `ToolExecutionInput.response_format_override` and the override
  plumbing inside `execute_tool_resolved_result`.
* `crates/mcp/src/core/mod.rs` + `crates/mcp/src/lib.rs` —
  re-exports for both new pure functions.
* `crates/mcp/src/core/session.rs` — propagates `response_format_override`
  through `execute_tool_result` for the resolved-name hop.

### Router execution sites

* `model_gateway/src/routers/grpc/harmony/responses/execution.rs`
  + `non_streaming.rs` + `streaming.rs`: thread `request_tools` +
  `request_user` through; call `resolve_response_format` and
  `inject_user_into_hosted_tool_args`; attach override to
  `ToolExecutionInput`.
* `model_gateway/src/routers/grpc/regular/responses/non_streaming.rs`
  + `streaming.rs`: same.
* `model_gateway/src/routers/openai/mcp/tool_loop.rs`: same at both
  streaming and non-streaming dispatch sites. Adds `request_user`
  param to `execute_streaming_tool_calls`.
* `model_gateway/src/routers/openai/responses/streaming.rs`:
  resolves format for the SSE item-type rewrite.
* `model_gateway/src/routers/anthropic/mcp.rs`: `response_format_override: None`
  for the existing `ToolExecutionInput` construction (no behavior
  change on the Anthropic path).

### E2E tests

* `e2e_test/responses/conftest.py`: new `_plain_mcp_config`,
  `mock_mcp_config_file_plain`, `gateway_with_mock_mcp_plain_cloud`
  fixture — same mock server, no `builtin_type` tagging.
* `e2e_test/responses/test_image_generation.py`:
  * New `TestImageGenerationClientDeclaredServerPlain` class that
    reuses the full `_ImageGenerationAssertions` body (4 tests) +
    the new user-forwarding assertion.
  * New `_UserForwardingAssertions` mix-in with
    `test_image_generation_forwards_user_to_mcp`, mixed into both
    `TestImageGenerationCloud` and the new plain-server class (so
    we exercise `user` on both server configs).
* `e2e_test/infra/mock_mcp_server.py`: `image_generation` tool
  accepts `user: str | None` and records it in `call_log`.

## Test plan

* `cargo check --workspace --all-targets` — green.
* `cargo clippy --workspace --all-targets -- -D warnings` — green.
* `cargo test -p smg-mcp --lib` — 215 tests pass (14 new).
* `cargo test -p smg` — all existing tests pass.
* `python3.11 -m ruff check e2e_test/responses/ e2e_test/infra/` — clean.
* `python3.11 -m ruff format --check e2e_test/responses/ e2e_test/infra/` — clean.
* New e2e test classes collect successfully:
  * `TestImageGenerationCloud` — 5 tests (4 existing + 1 user-forwarding).
  * `TestImageGenerationClientDeclaredServerPlain` — 5 tests (4 happy-path + 1 user-forwarding) against the plain-MCP fixture.
  * `TestImageGenerationGrpcSglang` / `TestImageGenerationGrpcVllm` — 4 tests each (unchanged).
* Full cloud e2e runs require `OPENAI_API_KEY`; CI will exercise both
  `TestImageGenerationCloud` and `TestImageGenerationClientDeclaredServerPlain`
  on the cloud runner.

Refs: R7

<details>
<summary>Checklist</summary>

- [x] Documentation updated (inline doc comments for both pure functions)
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-call response format resolution for tool calls so outputs match session and client-declared tool intent across server types.
  * Forwarding of caller user context into hosted-tool dispatch arguments to enable per-user attribution.

* **Tests**
  * Added end-to-end tests verifying user forwarding and response-format behavior with mock MCP server configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->