### PR TITLE
fix(mcp): forward request.user to hosted-tool MCP dispatch args

### DIFF
--- a/e2e_test/infra/mock_mcp_server.py
+++ b/e2e_test/infra/mock_mcp_server.py
@@ -380,6 +380,7 @@ class MockMcpServer:
             quality: str = "standard",
             moderation: str = "auto",
             output_format: str = "png",
+            user: str | None = None,
         ) -> dict[str, str]:
             record_call(
                 {
@@ -390,6 +391,7 @@ class MockMcpServer:
                         "quality": quality,
                         "moderation": moderation,
                         "output_format": output_format,
+                        "user": user,
                     },
                 }
             )

--- a/e2e_test/responses/test_image_generation.py
+++ b/e2e_test/responses/test_image_generation.py
@@ -383,6 +383,49 @@ class _ImageGenerationAssertions:
             f"Compactor did not pin quality override; got {received.get('quality')!r}"
         )
 
+    def test_image_generation_user_forwarded_to_mcp(self, request, image_gen_tool_args) -> None:
+        """Request-level ``user`` reaches the MCP server's dispatch args.
+
+        The OpenAI Responses API takes a top-level ``user`` field for
+        end-user attribution. The gateway forwards that into the
+        hosted-tool dispatch args (``routers/common/mcp_utils.rs::
+        prepare_hosted_dispatch_args``). The mock server records every
+        invocation in ``call_log``, so we can assert the value rode
+        through end-to-end without relying on side-channel logs.
+        """
+        _, client, mock_mcp, model = self._ctx(request)
+
+        user_value = "test-user-forward-abc123"
+        baseline_calls = len(mock_mcp.call_log)
+
+        resp = client.responses.create(
+            model=model,
+            input=_IMAGE_GEN_PROMPT,
+            tools=[image_gen_tool_args],
+            tool_choice=_FORCED_TOOL_CHOICE,
+            user=user_value,
+            stream=False,
+        )
+
+        assert resp.error is None, f"Response error: {resp.error}"
+
+        # Non-vacuity guard: at least one fresh MCP call was recorded.
+        # Without this the next assertion could pass on stale state
+        # from an earlier test in the same session.
+        assert len(mock_mcp.call_log) > baseline_calls, (
+            f"Mock MCP server saw no new calls (baseline={baseline_calls}); "
+            "user-forwarding assertion would be vacuous."
+        )
+
+        last_args = mock_mcp.last_call_args
+        assert last_args is not None, "Mock MCP server saw no calls"
+        received = last_args.get("arguments", {})
+        assert received.get("user") == user_value, (
+            f"Gateway did not forward request-level `user` into MCP dispatch args. "
+            f"Expected {user_value!r}, got {received.get('user')!r}. "
+            f"Full received args: {received!r}"
+        )
+
     def test_image_generation_compactor_strips_base64(self, request, image_gen_tool_args) -> None:
         """Multi-turn replay: base64 payload must not survive into stored context."""
         gateway, client, mock_mcp, model = self._ctx(request)

--- a/model_gateway/src/routers/common/mcp_utils.rs
+++ b/model_gateway/src/routers/common/mcp_utils.rs
@@ -357,12 +357,19 @@ pub(crate) fn inject_user_into_hosted_args(
     let Value::Object(args_map) = arguments else {
         return;
     };
-    if args_map.contains_key("user") {
-        debug!(
-            "Hosted-tool dispatch args already include 'user'; preserving \
-             model-supplied value over request-level identifier"
-        );
-        return;
+    // Preserve a real model-supplied identifier, but treat an explicit
+    // null (or absent key) as "no value" — when the synthesized function
+    // tool exposes `user` as a parameter the model dutifully emits
+    // `{"user": null}` even though the caller provided no value, and that
+    // null should not block the request-level forwarding.
+    if let Some(existing) = args_map.get("user") {
+        if !existing.is_null() {
+            debug!(
+                "Hosted-tool dispatch args already include a non-null 'user'; \
+                 preserving model-supplied value over request-level identifier"
+            );
+            return;
+        }
     }
     args_map.insert("user".to_string(), json!(user_value));
 }
@@ -391,23 +398,12 @@ pub(crate) fn prepare_hosted_dispatch_args(
     request_tools: &[ResponseTool],
     request_user: Option<&str>,
 ) {
-    tracing::warn!(
-        response_format = ?response_format,
-        request_user = ?request_user,
-        request_tools_count = request_tools.len(),
-        is_object = arguments.is_object(),
-        "USER-FWD-DEBUG (helper enter): prepare_hosted_dispatch_args"
-    );
     if let Some(kind) = response_format.to_builtin_tool_type() {
         if let Some(overrides) = extract_hosted_tool_overrides(request_tools, kind) {
             apply_hosted_tool_overrides(arguments, &overrides);
         }
     }
     inject_user_into_hosted_args(arguments, response_format, request_user);
-    tracing::warn!(
-        post_args = ?arguments,
-        "USER-FWD-DEBUG (helper exit): prepare_hosted_dispatch_args"
-    );
 }
 
 #[cfg(test)]
@@ -859,6 +855,21 @@ mod tests {
             tool_names: Some(vec!["mutating_tool".to_string()]),
         });
         assert_eq!(project_allowed_tools(Some(&value)), Some(Vec::new()));
+    }
+
+    /// When the synthesized function tool exposes `user` as a parameter,
+    /// the model emits `{"user": null}` even though no value is supplied.
+    /// That null must not block request-level forwarding — the helper
+    /// treats absent and null as equivalent for injection purposes.
+    #[test]
+    fn inject_user_hosted_format_overwrites_model_supplied_null() {
+        let mut args = json!({"prompt": "a cat", "user": null});
+        inject_user_into_hosted_args(
+            &mut args,
+            &ResponseFormat::ImageGenerationCall,
+            Some("user-123"),
+        );
+        assert_eq!(args.get("user"), Some(&json!("user-123")));
     }
 
     #[test]

--- a/model_gateway/src/routers/common/mcp_utils.rs
+++ b/model_gateway/src/routers/common/mcp_utils.rs
@@ -391,12 +391,23 @@ pub(crate) fn prepare_hosted_dispatch_args(
     request_tools: &[ResponseTool],
     request_user: Option<&str>,
 ) {
+    tracing::warn!(
+        response_format = ?response_format,
+        request_user = ?request_user,
+        request_tools_count = request_tools.len(),
+        is_object = arguments.is_object(),
+        "USER-FWD-DEBUG (helper enter): prepare_hosted_dispatch_args"
+    );
     if let Some(kind) = response_format.to_builtin_tool_type() {
         if let Some(overrides) = extract_hosted_tool_overrides(request_tools, kind) {
             apply_hosted_tool_overrides(arguments, &overrides);
         }
     }
     inject_user_into_hosted_args(arguments, response_format, request_user);
+    tracing::warn!(
+        post_args = ?arguments,
+        "USER-FWD-DEBUG (helper exit): prepare_hosted_dispatch_args"
+    );
 }
 
 #[cfg(test)]

--- a/model_gateway/src/routers/common/mcp_utils.rs
+++ b/model_gateway/src/routers/common/mcp_utils.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 use openai_protocol::responses::{McpAllowedTools, ResponseTool, ResponsesRequest};
+use serde_json::{json, Value};
 use smg_mcp::{
     BuiltinToolType, McpOrchestrator, McpServerBinding, McpServerConfig, McpTransport,
     ResponseFormat,
@@ -320,6 +321,50 @@ pub async fn ensure_request_mcp_client(
     let builtin_types = extract_builtin_types(tools);
 
     ensure_mcp_servers(mcp_orchestrator, &inputs, &builtin_types).await
+}
+
+/// Forward the caller's `user` identifier into hosted-tool dispatch arguments.
+///
+/// OpenAI's Responses API takes a top-level `user` field for end-user
+/// attribution. We mirror that into the MCP dispatch payload for hosted
+/// tools (image_generation, web_search_preview, web_search, code_interpreter,
+/// file_search) so a downstream MCP server can attribute usage and enforce
+/// per-user quotas.
+///
+/// Scope is hosted-tools only — `ResponseFormat::Passthrough` (plain MCP
+/// function tools) is a no-op because plain tool schemas are caller-defined
+/// and may not expect a `user` key. Surprising those servers with an
+/// unsolicited field is worse than missing the feature.
+///
+/// Behavior:
+/// - No-op if `response_format` is `Passthrough` (non-hosted).
+/// - No-op if `user` is `None` or an empty string.
+/// - No-op if `arguments` is not a JSON object.
+/// - No-op if `arguments` already contains a `user` key — model-supplied
+///   values win over the request-level identifier.
+/// - Otherwise inserts `arguments["user"] = json!(user)`.
+pub(crate) fn inject_user_into_hosted_args(
+    arguments: &mut Value,
+    response_format: &ResponseFormat,
+    user: Option<&str>,
+) {
+    if response_format.to_builtin_tool_type().is_none() {
+        return;
+    }
+    let Some(user_value) = user.filter(|u| !u.is_empty()) else {
+        return;
+    };
+    let Value::Object(args_map) = arguments else {
+        return;
+    };
+    if args_map.contains_key("user") {
+        debug!(
+            "Hosted-tool dispatch args already include 'user'; preserving \
+             model-supplied value over request-level identifier"
+        );
+        return;
+    }
+    args_map.insert("user".to_string(), json!(user_value));
 }
 
 #[cfg(test)]
@@ -771,5 +816,79 @@ mod tests {
             tool_names: Some(vec!["mutating_tool".to_string()]),
         });
         assert_eq!(project_allowed_tools(Some(&value)), Some(Vec::new()));
+    }
+
+    #[test]
+    fn inject_user_hosted_format_inserts_user_into_clean_args() {
+        let mut args = json!({"prompt": "a cat"});
+        inject_user_into_hosted_args(
+            &mut args,
+            &ResponseFormat::ImageGenerationCall,
+            Some("user-123"),
+        );
+        assert_eq!(args.get("user"), Some(&json!("user-123")));
+        assert_eq!(args.get("prompt"), Some(&json!("a cat")));
+    }
+
+    #[test]
+    fn inject_user_hosted_format_preserves_existing_user_key() {
+        // Model-supplied `user` wins over the request-level identifier; the
+        // helper must not clobber it.
+        let mut args = json!({"prompt": "a cat", "user": "model-supplied"});
+        inject_user_into_hosted_args(
+            &mut args,
+            &ResponseFormat::ImageGenerationCall,
+            Some("request-level"),
+        );
+        assert_eq!(args.get("user"), Some(&json!("model-supplied")));
+    }
+
+    #[test]
+    fn inject_user_passthrough_format_is_noop() {
+        // Plain MCP function tools have caller-defined schemas; injecting
+        // `user` could surprise tools that don't expect that key.
+        let mut args = json!({"q": "weather"});
+        inject_user_into_hosted_args(&mut args, &ResponseFormat::Passthrough, Some("user-123"));
+        assert!(
+            !args.as_object().unwrap().contains_key("user"),
+            "passthrough format must not receive an injected user key"
+        );
+    }
+
+    #[test]
+    fn inject_user_empty_or_missing_user_is_noop() {
+        let mut args_none = json!({"prompt": "x"});
+        inject_user_into_hosted_args(&mut args_none, &ResponseFormat::WebSearchCall, None);
+        assert!(!args_none.as_object().unwrap().contains_key("user"));
+
+        let mut args_empty = json!({"prompt": "x"});
+        inject_user_into_hosted_args(&mut args_empty, &ResponseFormat::WebSearchCall, Some(""));
+        assert!(!args_empty.as_object().unwrap().contains_key("user"));
+    }
+
+    #[test]
+    fn inject_user_non_object_args_is_noop() {
+        let mut args = json!("not-an-object");
+        inject_user_into_hosted_args(&mut args, &ResponseFormat::FileSearchCall, Some("u1"));
+        assert_eq!(args, json!("not-an-object"));
+    }
+
+    #[test]
+    fn inject_user_covers_every_hosted_format() {
+        // All four hosted formats should accept the injection identically.
+        for format in [
+            ResponseFormat::ImageGenerationCall,
+            ResponseFormat::WebSearchCall,
+            ResponseFormat::CodeInterpreterCall,
+            ResponseFormat::FileSearchCall,
+        ] {
+            let mut args = json!({});
+            inject_user_into_hosted_args(&mut args, &format, Some("user-xyz"));
+            assert_eq!(
+                args.get("user"),
+                Some(&json!("user-xyz")),
+                "expected user injection for format {format:?}"
+            );
+        }
     }
 }

--- a/model_gateway/src/routers/common/mcp_utils.rs
+++ b/model_gateway/src/routers/common/mcp_utils.rs
@@ -8,8 +8,8 @@ use std::{
 use openai_protocol::responses::{McpAllowedTools, ResponseTool, ResponsesRequest};
 use serde_json::{json, Value};
 use smg_mcp::{
-    BuiltinToolType, McpOrchestrator, McpServerBinding, McpServerConfig, McpTransport,
-    ResponseFormat,
+    apply_hosted_tool_overrides, extract_hosted_tool_overrides, BuiltinToolType, McpOrchestrator,
+    McpServerBinding, McpServerConfig, McpTransport, ResponseFormat,
 };
 use tracing::{debug, warn};
 
@@ -365,6 +365,38 @@ pub(crate) fn inject_user_into_hosted_args(
         return;
     }
     args_map.insert("user".to_string(), json!(user_value));
+}
+
+/// Prepare an MCP dispatch payload for a hosted-tool call.
+///
+/// One call collapses the two per-dispatch mutations every router used to
+/// repeat:
+/// 1. Merge caller-declared hosted-tool overrides from `request_tools` into
+///    `arguments` (e.g. an `image_generation` request's `size`/`quality`
+///    pinning the model's tool-call args).
+/// 2. Forward the request-level `user` identifier into `arguments` for
+///    hosted tools so a downstream MCP server can attribute usage.
+///
+/// Both steps are no-ops when `response_format` is `Passthrough` (plain MCP
+/// function tools); they are also no-ops on individual missing inputs
+/// (no overrides, no `user`, non-object args, pre-existing `user`).
+///
+/// Routers should call this in place of the inline override + injection
+/// pair. Keeping it here (in `routers/common/mcp_utils.rs`) avoids leaking
+/// gateway-side concerns into `crates/mcp` while still giving every router
+/// a single chokepoint.
+pub(crate) fn prepare_hosted_dispatch_args(
+    arguments: &mut Value,
+    response_format: &ResponseFormat,
+    request_tools: &[ResponseTool],
+    request_user: Option<&str>,
+) {
+    if let Some(kind) = response_format.to_builtin_tool_type() {
+        if let Some(overrides) = extract_hosted_tool_overrides(request_tools, kind) {
+            apply_hosted_tool_overrides(arguments, &overrides);
+        }
+    }
+    inject_user_into_hosted_args(arguments, response_format, request_user);
 }
 
 #[cfg(test)]

--- a/model_gateway/src/routers/grpc/harmony/responses/execution.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/execution.rs
@@ -6,15 +6,13 @@ use openai_protocol::{
     responses::{ResponseOutputItem, ResponseTool},
 };
 use serde_json::{from_str, json, Value};
-use smg_mcp::{
-    apply_hosted_tool_overrides, extract_hosted_tool_overrides, McpToolSession, ToolExecutionInput,
-};
+use smg_mcp::{McpToolSession, ToolExecutionInput};
 use tracing::{debug, error};
 
 use super::common::McpCallTracking;
 use crate::{
     observability::metrics::{metrics_labels, Metrics},
-    routers::common::mcp_utils::inject_user_into_hosted_args,
+    routers::common::mcp_utils::prepare_hosted_dispatch_args,
 };
 
 /// Tool execution result
@@ -93,16 +91,7 @@ pub(super) async fn execute_mcp_tools(
                 }
             };
             let response_format = session.tool_response_format(&tc.function.name);
-            if let Some(kind) = response_format.to_builtin_tool_type() {
-                if let Some(overrides) = extract_hosted_tool_overrides(request_tools, kind) {
-                    apply_hosted_tool_overrides(&mut args, &overrides);
-                }
-            }
-            // Forward request-level `user` into hosted-tool dispatch args so
-            // the downstream MCP server can attribute per-user usage. Skips
-            // plain MCP function tools (Passthrough format) and never
-            // overwrites a model-supplied `user` value.
-            inject_user_into_hosted_args(&mut args, &response_format, request_user);
+            prepare_hosted_dispatch_args(&mut args, &response_format, request_tools, request_user);
             ToolExecutionInput {
                 call_id: tc.id.clone(),
                 tool_name: tc.function.name.clone(),

--- a/model_gateway/src/routers/grpc/harmony/responses/execution.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/execution.rs
@@ -12,7 +12,10 @@ use smg_mcp::{
 use tracing::{debug, error};
 
 use super::common::McpCallTracking;
-use crate::observability::metrics::{metrics_labels, Metrics};
+use crate::{
+    observability::metrics::{metrics_labels, Metrics},
+    routers::common::mcp_utils::inject_user_into_hosted_args,
+};
 
 /// Tool execution result
 ///
@@ -44,6 +47,11 @@ pub(crate) struct ToolResult {
 /// Tool execution errors are returned as error results to the model
 /// (allows model to handle gracefully).
 ///
+/// `request_user` is the request-level `user` identifier (OpenAI Responses
+/// API `user` field), forwarded into hosted-tool dispatch args so the MCP
+/// server can attribute usage. Plain MCP function tools (Passthrough format)
+/// are not affected.
+///
 /// Vector of tool results (one per tool call)
 pub(super) async fn execute_mcp_tools(
     session: &McpToolSession<'_>,
@@ -51,6 +59,7 @@ pub(super) async fn execute_mcp_tools(
     tracking: &mut McpCallTracking,
     model_id: &str,
     request_tools: &[ResponseTool],
+    request_user: Option<&str>,
 ) -> Result<Vec<ToolResult>, Response> {
     // Convert tool calls to execution inputs, merging caller-declared
     // hosted-tool configuration from `request_tools` into dispatch args.
@@ -83,14 +92,17 @@ pub(super) async fn execute_mcp_tools(
                     json!({})
                 }
             };
-            if let Some(kind) = session
-                .tool_response_format(&tc.function.name)
-                .to_builtin_tool_type()
-            {
+            let response_format = session.tool_response_format(&tc.function.name);
+            if let Some(kind) = response_format.to_builtin_tool_type() {
                 if let Some(overrides) = extract_hosted_tool_overrides(request_tools, kind) {
                     apply_hosted_tool_overrides(&mut args, &overrides);
                 }
             }
+            // Forward request-level `user` into hosted-tool dispatch args so
+            // the downstream MCP server can attribute per-user usage. Skips
+            // plain MCP function tools (Passthrough format) and never
+            // overwrites a model-supplied `user` value.
+            inject_user_into_hosted_args(&mut args, &response_format, request_user);
             ToolExecutionInput {
                 call_id: tc.id.clone(),
                 tool_name: tc.function.name.clone(),

--- a/model_gateway/src/routers/grpc/harmony/responses/non_streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/non_streaming.rs
@@ -259,7 +259,9 @@ async fn execute_with_mcp_loop(
 
                 // Execute MCP tools (if any). Caller-declared hosted-tool overrides
                 // live on `original_tools` (pre-MCP-injection), so we thread those
-                // into dispatch — `execute_mcp_tools` merges per-kind.
+                // into dispatch — `execute_mcp_tools` merges per-kind. The
+                // request-level `user` identifier is also forwarded into
+                // hosted-tool dispatch args.
                 let mcp_results = if mcp_tool_calls.is_empty() {
                     Vec::new()
                 } else {
@@ -269,6 +271,7 @@ async fn execute_with_mcp_loop(
                         &mut mcp_tracking,
                         &current_request.model,
                         original_tools.as_deref().unwrap_or(&[]),
+                        current_request.user.as_deref(),
                     )
                     .await?
                 };

--- a/model_gateway/src/routers/grpc/harmony/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/streaming.rs
@@ -311,7 +311,9 @@ async fn execute_mcp_tool_loop_streaming(
 
                 // Execute MCP tools (if any). `original_request.tools` is the
                 // caller-declared tool list (hosted-tool config lives there);
-                // `execute_mcp_tools` merges the per-kind overrides into dispatch args.
+                // `execute_mcp_tools` merges the per-kind overrides into
+                // dispatch args and forwards the request-level `user`
+                // identifier for hosted tools.
                 let mcp_results = if mcp_tool_calls.is_empty() {
                     Vec::new()
                 } else {
@@ -321,6 +323,7 @@ async fn execute_mcp_tool_loop_streaming(
                         &mut mcp_tracking,
                         &current_request.model,
                         original_request.tools.as_deref().unwrap_or(&[]),
+                        original_request.user.as_deref(),
                     )
                     .await
                     {

--- a/model_gateway/src/routers/grpc/regular/responses/non_streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/non_streaming.rs
@@ -10,10 +10,7 @@ use std::sync::Arc;
 use axum::response::Response;
 use openai_protocol::responses::{ResponseStatus, ResponsesRequest, ResponsesResponse};
 use serde_json::json;
-use smg_mcp::{
-    apply_hosted_tool_overrides, extract_hosted_tool_overrides, McpServerBinding, McpToolSession,
-    ToolExecutionInput,
-};
+use smg_mcp::{McpServerBinding, McpToolSession, ToolExecutionInput};
 use tracing::{debug, error, trace, warn};
 
 use super::{
@@ -27,7 +24,7 @@ use super::{
 use crate::{
     observability::metrics::{metrics_labels, Metrics},
     routers::{
-        common::mcp_utils::{inject_user_into_hosted_args, DEFAULT_MAX_ITERATIONS},
+        common::mcp_utils::{prepare_hosted_dispatch_args, DEFAULT_MAX_ITERATIONS},
         error,
         grpc::common::responses::{
             collect_user_function_names, ensure_mcp_connection, persist_response_if_needed,
@@ -354,13 +351,12 @@ pub(super) async fn execute_tool_loop(
                             _ => json!({}),
                         };
                     let response_format = session.tool_response_format(&tc.name);
-                    if let Some(kind) = response_format.to_builtin_tool_type() {
-                        if let Some(overrides) = extract_hosted_tool_overrides(request_tools, kind)
-                        {
-                            apply_hosted_tool_overrides(&mut arguments, &overrides);
-                        }
-                    }
-                    inject_user_into_hosted_args(&mut arguments, &response_format, request_user);
+                    prepare_hosted_dispatch_args(
+                        &mut arguments,
+                        &response_format,
+                        request_tools,
+                        request_user,
+                    );
                     ToolExecutionInput {
                         call_id: tc.call_id,
                         tool_name: tc.name,

--- a/model_gateway/src/routers/grpc/regular/responses/non_streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/non_streaming.rs
@@ -27,7 +27,7 @@ use super::{
 use crate::{
     observability::metrics::{metrics_labels, Metrics},
     routers::{
-        common::mcp_utils::DEFAULT_MAX_ITERATIONS,
+        common::mcp_utils::{inject_user_into_hosted_args, DEFAULT_MAX_ITERATIONS},
         error,
         grpc::common::responses::{
             collect_user_function_names, ensure_mcp_connection, persist_response_if_needed,
@@ -341,8 +341,10 @@ pub(super) async fn execute_tool_loop(
             // Convert tool calls to execution inputs, merging caller-declared
             // hosted-tool config from `original_request.tools` into dispatch args.
             // Non-object model payloads coerce to `{}` so the merge actually
-            // applies instead of silently dropping the caller's config.
+            // applies instead of silently dropping the caller's config. The
+            // request-level `user` is also forwarded into hosted-tool args.
             let request_tools = original_request.tools.as_deref().unwrap_or(&[]);
+            let request_user = original_request.user.as_deref();
             let inputs: Vec<ToolExecutionInput> = mcp_tool_calls
                 .into_iter()
                 .map(|tc| {
@@ -351,15 +353,14 @@ pub(super) async fn execute_tool_loop(
                             Ok(serde_json::Value::Object(map)) => serde_json::Value::Object(map),
                             _ => json!({}),
                         };
-                    if let Some(kind) = session
-                        .tool_response_format(&tc.name)
-                        .to_builtin_tool_type()
-                    {
+                    let response_format = session.tool_response_format(&tc.name);
+                    if let Some(kind) = response_format.to_builtin_tool_type() {
                         if let Some(overrides) = extract_hosted_tool_overrides(request_tools, kind)
                         {
                             apply_hosted_tool_overrides(&mut arguments, &overrides);
                         }
                     }
+                    inject_user_into_hosted_args(&mut arguments, &response_format, request_user);
                     ToolExecutionInput {
                         call_id: tc.call_id,
                         tool_name: tc.name,

--- a/model_gateway/src/routers/grpc/regular/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/streaming.rs
@@ -53,7 +53,7 @@ use super::{
 use crate::{
     observability::metrics::{metrics_labels, Metrics},
     routers::{
-        common::mcp_utils::DEFAULT_MAX_ITERATIONS,
+        common::mcp_utils::{inject_user_into_hosted_args, DEFAULT_MAX_ITERATIONS},
         grpc::{
             common::responses::{
                 build_sse_response, persist_response_if_needed,
@@ -724,6 +724,15 @@ async fn execute_tool_loop_streaming_internal(
                         apply_hosted_tool_overrides(&mut arguments, &overrides);
                     }
                 }
+                // Forward request-level `user` into hosted-tool dispatch args
+                // so the downstream MCP server can attribute per-user usage.
+                // Skips plain MCP function tools (Passthrough format) and
+                // never overwrites a model-supplied `user` value.
+                inject_user_into_hosted_args(
+                    &mut arguments,
+                    &response_format,
+                    original_request.user.as_deref(),
+                );
 
                 // Execute the single tool via the normalized MCP execution API.
                 // This avoids custom serialization and manual re-transformation in streaming paths.

--- a/model_gateway/src/routers/grpc/regular/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/streaming.rs
@@ -34,10 +34,7 @@ use smg_data_connector::{
     ConversationItemStorage, ConversationStorage, RequestContext as StorageRequestContext,
     ResponseStorage,
 };
-use smg_mcp::{
-    apply_hosted_tool_overrides, extract_hosted_tool_overrides, McpServerBinding, McpToolSession,
-    ResponseFormat, ToolExecutionInput,
-};
+use smg_mcp::{McpServerBinding, McpToolSession, ResponseFormat, ToolExecutionInput};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::{debug, trace, warn};
@@ -53,7 +50,7 @@ use super::{
 use crate::{
     observability::metrics::{metrics_labels, Metrics},
     routers::{
-        common::mcp_utils::{inject_user_into_hosted_args, DEFAULT_MAX_ITERATIONS},
+        common::mcp_utils::{prepare_hosted_dispatch_args, DEFAULT_MAX_ITERATIONS},
         grpc::{
             common::responses::{
                 build_sse_response, persist_response_if_needed,
@@ -716,21 +713,10 @@ async fn execute_tool_loop_streaming_internal(
                     Ok(Value::Object(map)) => Value::Object(map),
                     _ => json!({}),
                 };
-                if let Some(kind) = response_format.to_builtin_tool_type() {
-                    if let Some(overrides) = extract_hosted_tool_overrides(
-                        original_request.tools.as_deref().unwrap_or(&[]),
-                        kind,
-                    ) {
-                        apply_hosted_tool_overrides(&mut arguments, &overrides);
-                    }
-                }
-                // Forward request-level `user` into hosted-tool dispatch args
-                // so the downstream MCP server can attribute per-user usage.
-                // Skips plain MCP function tools (Passthrough format) and
-                // never overwrites a model-supplied `user` value.
-                inject_user_into_hosted_args(
+                prepare_hosted_dispatch_args(
                     &mut arguments,
                     &response_format,
+                    original_request.tools.as_deref().unwrap_or(&[]),
                     original_request.user.as_deref(),
                 );
 

--- a/model_gateway/src/routers/openai/mcp/tool_loop.rs
+++ b/model_gateway/src/routers/openai/mcp/tool_loop.rs
@@ -256,6 +256,12 @@ pub(crate) async fn execute_streaming_tool_calls(
         // on image_generation) into dispatch args, then forward the request-
         // level `user` so a downstream MCP server can attribute per-user usage.
         // Both steps are no-ops for plain MCP function tools.
+        tracing::warn!(
+            tool = %call.name,
+            response_format = ?response_format,
+            request_user = ?request_user,
+            "USER-FWD-DEBUG (streaming): pre-prepare_hosted_dispatch_args"
+        );
         prepare_hosted_dispatch_args(
             &mut arguments,
             &response_format,
@@ -265,7 +271,11 @@ pub(crate) async fn execute_streaming_tool_calls(
 
         // Log the effective (post-merge) args so the log reflects what the
         // MCP server actually receives, not the pre-merge string from the model.
-        debug!("Calling MCP tool '{}' with args: {}", call.name, arguments);
+        tracing::warn!(
+            "USER-FWD-DEBUG (streaming): post-dispatch args for '{}': {}",
+            call.name,
+            arguments
+        );
         let tool_output = session
             .execute_tool(ToolExecutionInput {
                 call_id: call.call_id.clone(),
@@ -940,11 +950,11 @@ pub(crate) async fn execute_tool_loop(
             // can attribute per-user usage. Both steps are no-ops for plain
             // MCP function tools (Passthrough format).
             let response_format = session.tool_response_format(&call.name);
-            info!(
+            tracing::warn!(
                 tool = %call.name,
                 response_format = ?response_format,
                 request_user = ?original_body.user,
-                "non-streaming dispatch: about to call prepare_hosted_dispatch_args"
+                "USER-FWD-DEBUG (non-streaming): pre-prepare_hosted_dispatch_args"
             );
             prepare_hosted_dispatch_args(
                 &mut arguments,
@@ -959,8 +969,8 @@ pub(crate) async fn execute_tool_loop(
             let effective_arguments =
                 serde_json::to_string(&arguments).unwrap_or_else(|_| call.arguments.clone());
 
-            info!(
-                "Calling MCP tool '{}' with args: {}",
+            tracing::warn!(
+                "USER-FWD-DEBUG (non-streaming): post-dispatch args for '{}': {}",
                 call.name, effective_arguments
             );
             let tool_result = session

--- a/model_gateway/src/routers/openai/mcp/tool_loop.rs
+++ b/model_gateway/src/routers/openai/mcp/tool_loop.rs
@@ -21,9 +21,8 @@ use openai_protocol::{
 };
 use serde_json::{json, to_value, Value};
 use smg_mcp::{
-    apply_hosted_tool_overrides, extract_embedded_openai_responses, extract_hosted_tool_overrides,
-    mcp_response_item_id, McpServerBinding, McpToolSession, ResponseFormat, ResponseTransformer,
-    ToolExecutionInput, ToolExecutionResult,
+    extract_embedded_openai_responses, mcp_response_item_id, McpServerBinding, McpToolSession,
+    ResponseFormat, ResponseTransformer, ToolExecutionInput, ToolExecutionResult,
 };
 use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
@@ -34,7 +33,7 @@ use crate::{
     routers::{
         common::{
             header_utils::ApiProvider,
-            mcp_utils::{inject_user_into_hosted_args, DEFAULT_MAX_ITERATIONS},
+            mcp_utils::{prepare_hosted_dispatch_args, DEFAULT_MAX_ITERATIONS},
         },
         error,
     },
@@ -254,17 +253,15 @@ pub(crate) async fn execute_streaming_tool_calls(
             arguments = json!({});
         }
         // Merge caller-declared hosted-tool configuration (e.g. `size`, `quality`
-        // on image_generation) into dispatch args. No-op for non-hosted tools.
-        if let Some(kind) = response_format.to_builtin_tool_type() {
-            if let Some(overrides) = extract_hosted_tool_overrides(request_tools, kind) {
-                apply_hosted_tool_overrides(&mut arguments, &overrides);
-            }
-        }
-        // Forward request-level `user` into hosted-tool dispatch args so the
-        // downstream MCP server can attribute per-user usage. Skips plain MCP
-        // function tools (Passthrough format) and never overwrites a
-        // model-supplied `user` value.
-        inject_user_into_hosted_args(&mut arguments, &response_format, request_user);
+        // on image_generation) into dispatch args, then forward the request-
+        // level `user` so a downstream MCP server can attribute per-user usage.
+        // Both steps are no-ops for plain MCP function tools.
+        prepare_hosted_dispatch_args(
+            &mut arguments,
+            &response_format,
+            request_tools,
+            request_user,
+        );
 
         // Log the effective (post-merge) args so the log reflects what the
         // MCP server actually receives, not the pre-merge string from the model.
@@ -939,24 +936,14 @@ pub(crate) async fn execute_tool_loop(
                 arguments = json!({});
             }
             // Merge caller-declared hosted-tool configuration into dispatch args
-            // for this tool's hosted-tool kind, if any. `original_body.tools` is
-            // the caller's tool declarations; empty / None = no-op.
+            // and forward the request-level `user` so a downstream MCP server
+            // can attribute per-user usage. Both steps are no-ops for plain
+            // MCP function tools (Passthrough format).
             let response_format = session.tool_response_format(&call.name);
-            if let Some(kind) = response_format.to_builtin_tool_type() {
-                if let Some(overrides) = extract_hosted_tool_overrides(
-                    original_body.tools.as_deref().unwrap_or(&[]),
-                    kind,
-                ) {
-                    apply_hosted_tool_overrides(&mut arguments, &overrides);
-                }
-            }
-            // Forward request-level `user` into hosted-tool dispatch args so
-            // the downstream MCP server can attribute per-user usage. Skips
-            // plain MCP function tools (Passthrough format) and never
-            // overwrites a model-supplied `user` value.
-            inject_user_into_hosted_args(
+            prepare_hosted_dispatch_args(
                 &mut arguments,
                 &response_format,
+                original_body.tools.as_deref().unwrap_or(&[]),
                 original_body.user.as_deref(),
             );
 

--- a/model_gateway/src/routers/openai/mcp/tool_loop.rs
+++ b/model_gateway/src/routers/openai/mcp/tool_loop.rs
@@ -256,12 +256,6 @@ pub(crate) async fn execute_streaming_tool_calls(
         // on image_generation) into dispatch args, then forward the request-
         // level `user` so a downstream MCP server can attribute per-user usage.
         // Both steps are no-ops for plain MCP function tools.
-        tracing::warn!(
-            tool = %call.name,
-            response_format = ?response_format,
-            request_user = ?request_user,
-            "USER-FWD-DEBUG (streaming): pre-prepare_hosted_dispatch_args"
-        );
         prepare_hosted_dispatch_args(
             &mut arguments,
             &response_format,
@@ -271,11 +265,7 @@ pub(crate) async fn execute_streaming_tool_calls(
 
         // Log the effective (post-merge) args so the log reflects what the
         // MCP server actually receives, not the pre-merge string from the model.
-        tracing::warn!(
-            "USER-FWD-DEBUG (streaming): post-dispatch args for '{}': {}",
-            call.name,
-            arguments
-        );
+        debug!("Calling MCP tool '{}' with args: {}", call.name, arguments);
         let tool_output = session
             .execute_tool(ToolExecutionInput {
                 call_id: call.call_id.clone(),
@@ -950,12 +940,6 @@ pub(crate) async fn execute_tool_loop(
             // can attribute per-user usage. Both steps are no-ops for plain
             // MCP function tools (Passthrough format).
             let response_format = session.tool_response_format(&call.name);
-            tracing::warn!(
-                tool = %call.name,
-                response_format = ?response_format,
-                request_user = ?original_body.user,
-                "USER-FWD-DEBUG (non-streaming): pre-prepare_hosted_dispatch_args"
-            );
             prepare_hosted_dispatch_args(
                 &mut arguments,
                 &response_format,
@@ -969,8 +953,8 @@ pub(crate) async fn execute_tool_loop(
             let effective_arguments =
                 serde_json::to_string(&arguments).unwrap_or_else(|_| call.arguments.clone());
 
-            tracing::warn!(
-                "USER-FWD-DEBUG (non-streaming): post-dispatch args for '{}': {}",
+            debug!(
+                "Calling MCP tool '{}' with args: {}",
                 call.name, effective_arguments
             );
             let tool_result = session

--- a/model_gateway/src/routers/openai/mcp/tool_loop.rs
+++ b/model_gateway/src/routers/openai/mcp/tool_loop.rs
@@ -940,6 +940,12 @@ pub(crate) async fn execute_tool_loop(
             // can attribute per-user usage. Both steps are no-ops for plain
             // MCP function tools (Passthrough format).
             let response_format = session.tool_response_format(&call.name);
+            info!(
+                tool = %call.name,
+                response_format = ?response_format,
+                request_user = ?original_body.user,
+                "non-streaming dispatch: about to call prepare_hosted_dispatch_args"
+            );
             prepare_hosted_dispatch_args(
                 &mut arguments,
                 &response_format,
@@ -953,7 +959,7 @@ pub(crate) async fn execute_tool_loop(
             let effective_arguments =
                 serde_json::to_string(&arguments).unwrap_or_else(|_| call.arguments.clone());
 
-            debug!(
+            info!(
                 "Calling MCP tool '{}' with args: {}",
                 call.name, effective_arguments
             );

--- a/model_gateway/src/routers/openai/mcp/tool_loop.rs
+++ b/model_gateway/src/routers/openai/mcp/tool_loop.rs
@@ -32,7 +32,10 @@ use super::tool_handler::FunctionCallInProgress;
 use crate::{
     observability::metrics::{metrics_labels, Metrics},
     routers::{
-        common::{header_utils::ApiProvider, mcp_utils::DEFAULT_MAX_ITERATIONS},
+        common::{
+            header_utils::ApiProvider,
+            mcp_utils::{inject_user_into_hosted_args, DEFAULT_MAX_ITERATIONS},
+        },
         error,
     },
 };
@@ -155,7 +158,17 @@ fn build_message_from_openai_response(openai_response: Value) -> Option<Value> {
 /// request so per-kind hosted-tool overrides can be merged into dispatch args
 /// before [`McpToolSession::execute_tool`].
 ///
+/// `request_user` is the request-level `user` identifier (OpenAI Responses API
+/// `user` field), forwarded into hosted-tool dispatch args so the MCP server
+/// can attribute usage. Plain MCP function tools (Passthrough format) are
+/// not affected.
+///
 /// Returns false if client disconnected during execution
+#[expect(
+    clippy::too_many_arguments,
+    reason = "Streaming tool dispatch threads channel + state + per-request inputs \
+              (tools, user) directly to the loop without an intermediate context struct."
+)]
 pub(crate) async fn execute_streaming_tool_calls(
     pending_calls: Vec<FunctionCallInProgress>,
     session: &McpToolSession<'_>,
@@ -164,6 +177,7 @@ pub(crate) async fn execute_streaming_tool_calls(
     sequence_number: &mut u64,
     model_id: &str,
     request_tools: &[ResponseTool],
+    request_user: Option<&str>,
 ) -> bool {
     for call in pending_calls {
         if call.name.is_empty() {
@@ -246,6 +260,11 @@ pub(crate) async fn execute_streaming_tool_calls(
                 apply_hosted_tool_overrides(&mut arguments, &overrides);
             }
         }
+        // Forward request-level `user` into hosted-tool dispatch args so the
+        // downstream MCP server can attribute per-user usage. Skips plain MCP
+        // function tools (Passthrough format) and never overwrites a
+        // model-supplied `user` value.
+        inject_user_into_hosted_args(&mut arguments, &response_format, request_user);
 
         // Log the effective (post-merge) args so the log reflects what the
         // MCP server actually receives, not the pre-merge string from the model.
@@ -931,6 +950,15 @@ pub(crate) async fn execute_tool_loop(
                     apply_hosted_tool_overrides(&mut arguments, &overrides);
                 }
             }
+            // Forward request-level `user` into hosted-tool dispatch args so
+            // the downstream MCP server can attribute per-user usage. Skips
+            // plain MCP function tools (Passthrough format) and never
+            // overwrites a model-supplied `user` value.
+            inject_user_into_hosted_args(
+                &mut arguments,
+                &response_format,
+                original_body.user.as_deref(),
+            );
 
             // Serialize the post-merge args once so downstream logging + the
             // approval payload show the effective (dispatched) payload rather

--- a/model_gateway/src/routers/openai/responses/streaming.rs
+++ b/model_gateway/src/routers/openai/responses/streaming.rs
@@ -1011,7 +1011,8 @@ pub(super) fn handle_streaming_with_tool_interception(
 
             // Execute all pending tool calls. Pass the caller-declared tools so
             // hosted-tool overrides (e.g. image_generation size/quality) are
-            // merged into dispatch args before MCP execution.
+            // merged into dispatch args before MCP execution. The request-level
+            // `user` is also forwarded into hosted-tool dispatch args.
             if !execute_streaming_tool_calls(
                 pending_calls,
                 &session,
@@ -1020,6 +1021,7 @@ pub(super) fn handle_streaming_with_tool_interception(
                 &mut sequence_number,
                 &original_request.model,
                 original_request.tools.as_deref().unwrap_or(&[]),
+                original_request.user.as_deref(),
             )
             .await
             {


### PR DESCRIPTION
## Description

### Problem

OpenAI's Responses API takes a top-level `user` field for end-user
attribution. The gateway already mirrors this into `safety_identifier`
for OpenAI cloud forwarding (`model_gateway/src/routers/openai/responses/utils.rs:91`),
but the MCP dispatch path silently drops the value, so downstream MCP
servers cannot attribute usage or enforce per-user quotas.

External-reviewer ground truth captured in
`/tmp/openai_ground_truth/results/SUMMARY.md` confirmed the gap by
exercising hosted `image_generation` against an MCP proxy at commit
`cb84bbb8`: dispatch args contained `prompt` / `size` / etc. but never
`user`. The same gap affects every hosted tool (image_generation,
web_search_preview, web_search, code_interpreter, file_search) since
they all flow through the same `apply_hosted_tool_overrides` call sites.

### Solution

Introduce a small router-side helper `inject_user_into_hosted_args`
(`pub(crate)` in `model_gateway/src/routers/common/mcp_utils.rs`) and
call it at every existing `apply_hosted_tool_overrides` call site.

The helper:

- is a **no-op for `ResponseFormat::Passthrough`** (plain MCP function
  tools have caller-defined schemas; injecting an unsolicited `user`
  key could break tools that don't expect it);
- is a no-op for empty / `None` user;
- is a no-op for non-object args;
- preserves a model-supplied `user` value if already present (debug log
  only) — model wins over the request-level identifier;
- otherwise inserts `args["user"] = user`.

Scope is hosted tools only: image_generation, web_search_preview,
web_search, code_interpreter, file_search. The gating is via
`ResponseFormat::to_builtin_tool_type()`, which already cleanly
separates hosted formats from `Passthrough`.

### What this PR deliberately does NOT do

This is the smaller, hosted-tool-scoped subset of PR #1386 (CLOSED as
architectural overreach). In particular this PR does **NOT**:

- add new public API to `crates/mcp/` (no `resolve_response_format`,
  no `inject_user_into_hosted_tool_args` exported helper, no new
  public `ToolExecutionInput` field);
- modify `McpToolSession::tool_response_format`'s signature;
- touch the SSE rewrite layer in `openai/responses/streaming.rs`.

The helper lives next to its call sites in the router tree, where the
existing per-site `apply_hosted_tool_overrides` calls already live —
same scope, same call-site shape.

## Changes

### `model_gateway/src/routers/common/mcp_utils.rs`

- Adds `pub(crate) fn inject_user_into_hosted_args(arguments, response_format, user)`
  with full doc comment covering each no-op branch.
- Adds 6 unit tests in `routers::common::mcp_utils::tests`:
  - hosted format + clean args + non-empty user → injects
  - hosted format + args already has `user` → preserves model value
  - Passthrough format → no-op (must NOT inject)
  - None / empty user → no-op
  - Non-object args → no-op
  - Every hosted format kind (ImageGenerationCall, WebSearchCall,
    CodeInterpreterCall, FileSearchCall) injects identically

### Wired at all five existing dispatch sites

| File | Function | Change |
|---|---|---|
| `model_gateway/src/routers/openai/mcp/tool_loop.rs` | `execute_streaming_tool_calls` | New `request_user: Option<&str>` parameter; injects after `apply_hosted_tool_overrides`. `#[expect(clippy::too_many_arguments, reason=...)]` because the parameter count goes from 7 → 8. |
| `model_gateway/src/routers/openai/mcp/tool_loop.rs` | `execute_tool_loop` (non-streaming dispatch) | Sources user from `original_body.user.as_deref()`; injects after `apply_hosted_tool_overrides`. |
| `model_gateway/src/routers/grpc/harmony/responses/execution.rs` | `execute_mcp_tools` | New `request_user: Option<&str>` parameter; injects per-tool inside the `tool_calls.iter().map(...)` builder. |
| `model_gateway/src/routers/grpc/regular/responses/streaming.rs` | `execute_tool_loop_streaming_internal` (single-tool dispatch) | Sources user from `original_request.user.as_deref()`; injects after `apply_hosted_tool_overrides`. |
| `model_gateway/src/routers/grpc/regular/responses/non_streaming.rs` | `execute_tool_loop` (per-tool loop) | Sources user from `original_request.user.as_deref()`; injects per-tool inside the `mcp_tool_calls.into_iter().map(...)` builder. |

Caller sites updated:
- `model_gateway/src/routers/openai/responses/streaming.rs` — passes `original_request.user.as_deref()` into `execute_streaming_tool_calls`.
- `model_gateway/src/routers/grpc/harmony/responses/non_streaming.rs` and `streaming.rs` — pass user into `execute_mcp_tools`.

## Test plan

- `cargo check --workspace --all-targets` — green.
- `cargo clippy --workspace --all-targets -- -D warnings` — green.
- `cargo test --workspace` — green; 6 new unit tests pass; no existing
  tests regressed.
- The Passthrough no-op invariant is the load-bearing safety property
  and is covered by the dedicated `inject_user_passthrough_format_is_noop`
  test (we must never surprise a plain MCP server with an unsolicited
  `user` key).

Worker B is adding parallel e2e coverage that asserts `user` reaches a
mock MCP server end-to-end; that work lives in a separate PR.

<details>
<summary>Checklist</summary>

- [x] Documentation updated (inline doc comments on the new helper)
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized hosted-tool argument preparation and consistent forwarding of the top-level request "user" into hosted tool invocations; preserves model-provided user values and leaves passthrough cases unchanged.
* **Tests**
  * Added unit tests for injection/no-op conditions and an end-to-end test verifying the top-level user is forwarded into hosted tool calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->