### PR TITLE
test(e2e): lock mcp_call shape for plain-MCP image_generation tool

### DIFF
--- a/e2e_test/responses/conftest.py
+++ b/e2e_test/responses/conftest.py
@@ -112,6 +112,47 @@ def mock_mcp_config_file(mock_mcp_server: MockMcpServer) -> Iterator[str]:  # no
             os.unlink(path)
 
 
+def _regular_mcp_config(mock_mcp_url: str) -> dict:
+    """Build an MCP config that registers the mock server as a plain MCP
+    server — no ``builtin_type``, no ``builtin_tool_name``, no
+    ``response_format`` hint per tool. The tool literally named
+    ``image_generation`` is therefore exposed as a generic MCP function
+    tool, not as a hosted-tool surface.
+
+    This is the configuration that produced the wire shape an external
+    reviewer reported (``output`` field carrying a stringified MCP
+    payload + ``arguments`` field carrying the dispatched args).
+    Locking the behavior here so future "auto-detect from request
+    tools" attempts have to break a real test on purpose.
+    """
+    return {
+        "servers": [
+            {
+                "name": "mock-regular",
+                "protocol": "streamable",
+                "url": mock_mcp_url,
+            }
+        ]
+    }
+
+
+@pytest.fixture(scope="session")
+def mock_mcp_config_file_regular(mock_mcp_server: MockMcpServer) -> Iterator[str]:  # noqa: F811
+    """Counterpart to ``mock_mcp_config_file`` registering the same mock
+    server as a plain MCP server (no ``builtin_type`` tag).
+    """
+    config = _regular_mcp_config(mock_mcp_server.url)
+    fd, path = tempfile.mkstemp(suffix=".yaml", prefix="mock_mcp_regular_")
+    try:
+        with os.fdopen(fd, "w") as f:
+            yaml.dump(config, f)
+        logger.info("MCP config for plain (no-builtin) mock at %s", path)
+        yield path
+    finally:
+        if os.path.exists(path):
+            os.unlink(path)
+
+
 # =============================================================================
 # Tool argument helpers
 # =============================================================================
@@ -185,6 +226,47 @@ def gateway_with_mock_mcp_cloud(
 # The rewritten suite prefers the explicit ``_cloud`` / ``_grpc_*`` names
 # but this preserves anyone who imported ``gateway_with_mock_mcp`` before.
 gateway_with_mock_mcp = gateway_with_mock_mcp_cloud
+
+
+@pytest.fixture(scope="class")
+def gateway_with_mock_mcp_regular_cloud(
+    mock_mcp_server: MockMcpServer,  # noqa: F811
+    mock_mcp_config_file_regular: str,
+) -> Iterator[tuple]:
+    """Cloud gateway wired to the mock MCP server registered as a plain
+    MCP server (no ``builtin_type`` tag). Yields the same
+    ``(gateway, client, mock_mcp_server, model)`` tuple shape as
+    ``gateway_with_mock_mcp_cloud`` so existing helpers compose.
+    Skips when ``OPENAI_API_KEY`` is absent.
+    """
+    api_key_env = "OPENAI_API_KEY"
+    if not os.environ.get(api_key_env):
+        pytest.skip(f"{api_key_env} not set — regular-MCP cloud lane needs OpenAI")
+
+    logger.info(
+        "Launching OpenAI cloud gateway with regular (no-builtin) MCP config (url=%s, config=%s)",
+        mock_mcp_server.url,
+        mock_mcp_config_file_regular,
+    )
+    gateway = launch_cloud_gateway(
+        "openai",
+        history_backend="memory",
+        extra_args=["--mcp-config-path", mock_mcp_config_file_regular],
+    )
+
+    try:
+        client = openai.OpenAI(
+            base_url=f"{gateway.base_url}/v1",
+            api_key=os.environ[api_key_env],
+        )
+    except Exception:
+        gateway.shutdown()
+        raise
+
+    try:
+        yield gateway, client, mock_mcp_server, "gpt-5-nano"
+    finally:
+        gateway.shutdown()
 
 
 # =============================================================================

--- a/e2e_test/responses/test_image_generation.py
+++ b/e2e_test/responses/test_image_generation.py
@@ -488,3 +488,85 @@ class TestImageGenerationGrpcVllm(_ImageGenerationAssertions):
     """
 
     _fixture_name = "gateway_with_mock_mcp_grpc_vllm"
+
+
+# =============================================================================
+# Negative coverage: server NOT tagged with builtin_type
+# =============================================================================
+
+
+@pytest.mark.vendor("openai")
+@pytest.mark.gpu(0)
+@pytest.mark.e2e
+class TestImageGenerationRegularMcpServer:
+    """Locks the design: when the MCP server is registered as a plain MCP
+    server (no ``builtin_type`` tag) and the model invokes a tool that
+    happens to be named ``image_generation``, the gateway emits an
+    ``mcp_call``-shaped output item — NOT an ``image_generation_call``.
+
+    This is the wire shape an external reviewer reported (the ``output``
+    field carrying a stringified MCP payload + ``arguments`` field
+    carrying the dispatched args) and the configuration that produces
+    it. Server-side ``builtin_type`` is the authoritative knob for
+    surfacing a hosted-tool shape; absent that tag, the request's
+    ``tools: [{"type": "image_generation"}]`` declaration cannot
+    auto-promote a plain MCP tool into a hosted-tool output. Any future
+    change that auto-resolves response_format from the request tools
+    array would break this test on purpose.
+    """
+
+    def test_response_is_mcp_call_shape(self, request) -> None:
+        gateway, client, _mock, model = request.getfixturevalue(
+            "gateway_with_mock_mcp_regular_cloud"
+        )
+        del gateway
+
+        resp = client.responses.create(
+            model=model,
+            input=(
+                "Use the image_generation tool to produce a 1x1 pixel test image. "
+                "Reply with whatever the tool returns."
+            ),
+            tools=[
+                {
+                    "type": "mcp",
+                    "server_label": "mock-regular",
+                    "allowed_tools": ["image_generation"],
+                    "require_approval": "never",
+                }
+            ],
+            tool_choice={
+                "type": "mcp",
+                "server_label": "mock-regular",
+                "name": "image_generation",
+            },
+            stream=False,
+        )
+
+        assert resp.error is None, f"Response error: {resp.error}"
+        assert resp.output is not None
+
+        mcp_calls = [item for item in resp.output if getattr(item, "type", None) == "mcp_call"]
+        assert mcp_calls, (
+            f"Expected at least one mcp_call in response.output; got types "
+            f"{[getattr(i, 'type', None) for i in resp.output]}"
+        )
+
+        # Every dispatched plain-MCP call carries the mcp_call wire shape:
+        # `output` holds the stringified MCP payload and `arguments` holds
+        # the dispatched args — neither should be the hosted
+        # image_generation_call shape.
+        for call in mcp_calls:
+            assert call.name == "image_generation", f"unexpected mcp_call.name={call.name!r}"
+            assert hasattr(call, "output") and call.output is not None, (
+                f"mcp_call must carry an `output` field; got dump={call.model_dump()}"
+            )
+            assert hasattr(call, "arguments") and call.arguments is not None, (
+                f"mcp_call must carry an `arguments` field; got dump={call.model_dump()}"
+            )
+
+        assert _find_image_generation_call(resp.output) is None, (
+            "Plain MCP server (no builtin_type) MUST NOT auto-promote a tool "
+            "named `image_generation` into the hosted image_generation_call "
+            "output shape. Server-side builtin_type is the authoritative knob."
+        )


### PR DESCRIPTION
## Why

External reviewer reported the gateway emitting an ``mcp_call``-shaped output item (``output`` field carrying a stringified MCP payload, ``arguments`` field carrying the dispatched args) when their MCP server exposed a tool literally named ``image_generation`` but wasn't tagged with ``builtin_type: ImageGeneration``. That's the correct behavior per design — server-side ``builtin_type`` is the authoritative knob — but the existing R6.5 fixture only covers the happy path where both sides agree, so the mismatch path was never exercised. This PR pins the design decision into a regression test.

## What changes

- ``e2e_test/responses/conftest.py``: adds ``_regular_mcp_config`` / ``mock_mcp_config_file_regular`` / ``gateway_with_mock_mcp_regular_cloud`` — same mock MCP server, no ``builtin_type`` tag, no ``builtin_tool_name``, no ``response_format`` hint.
- ``e2e_test/responses/test_image_generation.py``: adds ``TestImageGenerationRegularMcpServer``. Invokes the ``image_generation`` MCP tool via ``tools: [{"type": "mcp", "server_label, "allowed_tools": ["image_generation"]}]`` with ``tool_choice`` forcing the call. Asserts ``response.output`` carries an ``mcp_call`` with ``output`` + ``arguments`` fields, and that no ``image_generation_call`` item is present.

## Source of truth

OpenAI's image_generation hosted-tool wire shape is captured at ``/tmp/openai_ground_truth/results/`` (per the recent ground-truth sweep). Spec-compliant ``image_generation_call`` carries top-level ``result`` / ``action`` / ``background`` / ``output_format`` / ``quality`` / ``size``, never ``output`` / ``arguments``. ``mcp_call`` is a different output-item type with its own (stringified) ``output`` and (echoed) ``arguments`` — that's the wire shape the reviewer saw and the shape this test now locks.

## Why this matters

A future change that tries to "auto-resolve hosted-tool format from the request's ``tools`` array" (the R7 architecture we rejected) would silently turn the reviewer's reported scenario from a documented config issue into a silent shape change. With this test, that change has to break a real assertion on purpose, which forces a design conversation rather than a stealth refactor.

## Test plan

- ``OPENAI_API_KEY`` available: ``TestImageGenerationRegularMcpServer::test_response_is_mcp_call_shape`` runs against ``gpt-5-nano`` cloud, mock MCP server registered as plain MCP. Forces ``tool_choice`` to the named MCP tool. Asserts response shape.
- ``OPENAI_API_KEY`` absent: skips cleanly via fixture.
- Runs in the existing ``openai-responses`` matrix entry in ``.github/workflows/pr-test-rust.yml`` (already scoped to ``e2e_test/responses/``).

No production code changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test infrastructure with new fixtures for alternative MCP server configurations without built-in routing hints.
  * Added end-to-end validation tests for MCP tool response handling, ensuring the system correctly emits proper output formats and prevents unintended automatic response format promotion based on server configuration type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->