### PR TITLE
chore: add .mailmap to canonicalize CatherineSue's commits

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,11 @@
+# Canonicalize commit author display for tools that honour `.mailmap`
+# (`git log --use-mailmap`, `git shortlog`, GitHub commit detail UI).
+#
+# Note: this file does NOT change GitHub's contributor list / contribution
+# graph. Those use the raw author email on each commit and match it against
+# verified emails on a GitHub account; `.mailmap` is bypassed there.
+#
+# Format: <canonical name> <canonical email> <old email>
+# See: https://git-scm.com/docs/gitmailmap
+
+Chang Su <8605658+CatherineSue@users.noreply.github.com> <chang.s.su@oracle.com>


### PR DESCRIPTION
## Summary

@CatherineSue (display name **Chang Su**) authored **656 commits** under \`chang.s.su@oracle.com\`. Now that she has left Oracle, that mailbox is deactivated. This adds a \`.mailmap\` so local tooling consistently shows her under her GitHub-internal noreply address.

## What changed

- New top-level \`.mailmap\`:

  \`\`\`
  Chang Su <8605658+CatherineSue@users.noreply.github.com> <chang.s.su@oracle.com>
  \`\`\`

## Why noreply.github.com instead of her personal email?

- It's auto-verified on her GitHub account, no support ticket / no personal-mailbox dependency.
- Doesn't expose a personal email publicly.
- If she'd prefer a personal email instead, swap the canonical line in a follow-up.

## Verified locally

\`\`\`
$ git shortlog -sne --all | grep -i chang   # without .mailmap
   656  Chang Su <chang.s.su@oracle.com>

$ git shortlog -sne --all | grep -i chang   # with .mailmap
   656  Chang Su <8605658+CatherineSue@users.noreply.github.com>
\`\`\`

## Scope and limitations

| Surface | Effect of this PR |
|---|---|
| \`git shortlog\` | ✅ shows canonical email |
| \`git log --use-mailmap\` | ✅ shows canonical email |
| GitHub commit-detail UI | ✅ honours \`.mailmap\` for author display |
| **GitHub contributor list / contribution graph** | ❌ **NOT affected** — those bypass \`.mailmap\` and use the raw commit author email matched against the user's verified emails |

### To restore her on the contributor list

Two paths, neither in scope here:

1. **Easiest**: have @CatherineSue confirm \`chang.s.su@oracle.com\` is still on her [GitHub verified-emails list](https://github.com/settings/emails). GitHub doesn't auto-remove emails when the upstream mailbox dies — most likely it's still there and contributor attribution is intact (the "missing from contributor list" appearance is then just GitHub's contributor-graph one-year activity window).
2. If she removed the Oracle email when leaving: contact [GitHub Support](https://support.github.com/contact) — they can re-attach a previously-verified email to a user's account when the upstream mailbox is no longer reachable.

A history rewrite (\`git filter-repo --mailmap\`) would also fix the contributor list but breaks every existing fork / clone / open PR — explicitly out of scope.

## Test plan

- [x] \`git shortlog -sne --all | grep -i chang\` shows the canonical noreply email
- [x] No other authors affected (mailmap only contains Chang Su's mapping)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a `.mailmap` configuration file to standardize author attribution display in Git history and tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->