### PR TITLE
refactor(smg): move skill resolution into skills crate

### DIFF
--- a/crates/skills/Cargo.toml
+++ b/crates/skills/Cargo.toml
@@ -19,8 +19,10 @@ name = "smg_skills"
 [dependencies]
 async-trait.workspace = true
 chrono = { workspace = true, features = ["serde"] }
+openai-protocol.workspace = true
 parking_lot.workspace = true
 serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
 serde_yml = "0.0.12"
 smg-blob-storage.workspace = true
 thiserror.workspace = true
@@ -29,7 +31,6 @@ zip = "8.1"
 
 [dev-dependencies]
 anyhow.workspace = true
-serde_json.workspace = true
 tempfile = "3.15"
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 

--- a/crates/skills/src/api.rs
+++ b/crates/skills/src/api.rs
@@ -373,10 +373,7 @@ impl SkillService {
         skill_id: &str,
         selector: SkillVersionSelector<'_>,
     ) -> Result<PinnedSkillVersion, SkillServiceError> {
-        let tenant_id =
-            normalize_required_value(tenant_id.to_string(), SkillServiceError::MissingTenantId)?;
-        let skill_id =
-            normalize_required_value(skill_id.to_string(), SkillServiceError::MissingSkillId)?;
+        let (tenant_id, skill_id) = normalize_skill_ids(tenant_id, skill_id)?;
         let metadata_store = self
             .metadata_store()
             .ok_or(SkillServiceError::MissingComponent {
@@ -409,10 +406,7 @@ impl SkillService {
         skill_id: &str,
         selector: SkillVersionSelector<'_>,
     ) -> Result<Option<PinnedSkillVersion>, SkillServiceError> {
-        let tenant_id =
-            normalize_required_value(tenant_id.to_string(), SkillServiceError::MissingTenantId)?;
-        let skill_id =
-            normalize_required_value(skill_id.to_string(), SkillServiceError::MissingSkillId)?;
+        let (tenant_id, skill_id) = normalize_skill_ids(tenant_id, skill_id)?;
         let metadata_store = self
             .metadata_store()
             .ok_or(SkillServiceError::MissingComponent {
@@ -886,6 +880,17 @@ fn normalize_required_value(
         return Err(error);
     }
     Ok(value.to_string())
+}
+
+fn normalize_skill_ids(
+    tenant_id: &str,
+    skill_id: &str,
+) -> Result<(String, String), SkillServiceError> {
+    let tenant_id =
+        normalize_required_value(tenant_id.to_string(), SkillServiceError::MissingTenantId)?;
+    let skill_id =
+        normalize_required_value(skill_id.to_string(), SkillServiceError::MissingSkillId)?;
+    Ok((tenant_id, skill_id))
 }
 
 fn normalize_upload_bundle(

--- a/crates/skills/src/api.rs
+++ b/crates/skills/src/api.rs
@@ -18,8 +18,8 @@ use crate::{
         TenantAliasStore,
     },
     types::{
-        NormalizedSkillBundle, ParsedSkillBundle, SkillFileRecord, SkillParseWarning, SkillRecord,
-        SkillVersionRecord,
+        NormalizedSkillBundle, ParsedSkillBundle, PinnedSkillVersion, SkillFileRecord,
+        SkillParseWarning, SkillRecord, SkillVersionRecord, SkillVersionSelector,
     },
     validation::{
         is_code_file_path, normalize_skill_bundle_zip_with_limits, parse_skill_bundle,
@@ -365,6 +365,74 @@ impl SkillService {
                 component: "metadata_store",
             })?;
         resolve_skill_version_record(&*metadata_store, &tenant_id, &skill_id, &version_ref).await
+    }
+
+    pub async fn pin_skill_version(
+        &self,
+        tenant_id: &str,
+        skill_id: &str,
+        selector: SkillVersionSelector<'_>,
+    ) -> Result<PinnedSkillVersion, SkillServiceError> {
+        let tenant_id =
+            normalize_required_value(tenant_id.to_string(), SkillServiceError::MissingTenantId)?;
+        let skill_id =
+            normalize_required_value(skill_id.to_string(), SkillServiceError::MissingSkillId)?;
+        let metadata_store = self
+            .metadata_store()
+            .ok_or(SkillServiceError::MissingComponent {
+                component: "metadata_store",
+            })?;
+        let skill = metadata_store
+            .get_skill(&tenant_id, &skill_id)
+            .await?
+            .ok_or_else(|| SkillServiceError::SkillNotFound {
+                tenant_id: tenant_id.clone(),
+                skill_id: skill_id.clone(),
+            })?;
+
+        let record = resolve_skill_version_record_for_selector(
+            &*metadata_store,
+            &tenant_id,
+            &skill,
+            selector,
+        )
+        .await?;
+        Ok(PinnedSkillVersion {
+            version: record.version,
+            version_number: record.version_number,
+        })
+    }
+
+    pub async fn try_pin_skill_version(
+        &self,
+        tenant_id: &str,
+        skill_id: &str,
+        selector: SkillVersionSelector<'_>,
+    ) -> Result<Option<PinnedSkillVersion>, SkillServiceError> {
+        let tenant_id =
+            normalize_required_value(tenant_id.to_string(), SkillServiceError::MissingTenantId)?;
+        let skill_id =
+            normalize_required_value(skill_id.to_string(), SkillServiceError::MissingSkillId)?;
+        let metadata_store = self
+            .metadata_store()
+            .ok_or(SkillServiceError::MissingComponent {
+                component: "metadata_store",
+            })?;
+        let Some(skill) = metadata_store.get_skill(&tenant_id, &skill_id).await? else {
+            return Ok(None);
+        };
+
+        let record = resolve_skill_version_record_for_selector(
+            &*metadata_store,
+            &tenant_id,
+            &skill,
+            selector,
+        )
+        .await?;
+        Ok(Some(PinnedSkillVersion {
+            version: record.version,
+            version_number: record.version_number,
+        }))
     }
 
     pub async fn list_skill_versions(
@@ -1066,6 +1134,65 @@ async fn resolve_skill_version_record(
     })
 }
 
+async fn resolve_skill_version_record_for_selector(
+    metadata_store: &dyn SkillMetadataStore,
+    tenant_id: &str,
+    skill: &SkillRecord,
+    selector: SkillVersionSelector<'_>,
+) -> Result<SkillVersionRecord, SkillServiceError> {
+    match selector {
+        SkillVersionSelector::Default => {
+            let version = skill.default_version.as_deref().ok_or_else(|| {
+                SkillServiceError::MissingDefaultVersion {
+                    tenant_id: tenant_id.to_string(),
+                    skill_id: skill.skill_id.clone(),
+                }
+            })?;
+            get_exact_skill_version(metadata_store, tenant_id, &skill.skill_id, version).await
+        }
+        SkillVersionSelector::Latest => {
+            let version = skill.latest_version.as_deref().ok_or_else(|| {
+                SkillServiceError::SkillVersionNotFound {
+                    tenant_id: tenant_id.to_string(),
+                    skill_id: skill.skill_id.clone(),
+                    version: "latest".to_string(),
+                }
+            })?;
+            get_exact_skill_version(metadata_store, tenant_id, &skill.skill_id, version).await
+        }
+        SkillVersionSelector::Exact(version) => {
+            get_exact_skill_version(metadata_store, tenant_id, &skill.skill_id, version).await
+        }
+        SkillVersionSelector::VersionNumber(version_number) => {
+            let versions = metadata_store.list_skill_versions(&skill.skill_id).await?;
+            versions
+                .into_iter()
+                .find(|record| record.version_number == version_number)
+                .ok_or_else(|| SkillServiceError::SkillVersionNotFound {
+                    tenant_id: tenant_id.to_string(),
+                    skill_id: skill.skill_id.clone(),
+                    version: version_number.to_string(),
+                })
+        }
+    }
+}
+
+async fn get_exact_skill_version(
+    metadata_store: &dyn SkillMetadataStore,
+    tenant_id: &str,
+    skill_id: &str,
+    version: &str,
+) -> Result<SkillVersionRecord, SkillServiceError> {
+    metadata_store
+        .get_skill_version(skill_id, version)
+        .await?
+        .ok_or_else(|| SkillServiceError::SkillVersionNotFound {
+            tenant_id: tenant_id.to_string(),
+            skill_id: skill_id.to_string(),
+            version: version.to_string(),
+        })
+}
+
 fn apply_skill_projection_from_version(skill: &mut SkillRecord, version: &SkillVersionRecord) {
     skill.name.clone_from(&version.name);
     skill
@@ -1099,6 +1226,7 @@ mod tests {
         SkillServiceError, SkillServiceMode, SkillUpload, SkillUploadLimits, UpdateSkillRequest,
         UpdateSkillVersionRequest, UploadedSkillFile,
     };
+    use crate::SkillVersionSelector;
 
     #[test]
     fn placeholder_service_reports_placeholder_mode() {
@@ -1270,6 +1398,84 @@ mod tests {
             next.skill.default_version,
             Some(created.version.version.clone())
         );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn pin_skill_version_resolves_domain_selectors() -> Result<()> {
+        let root = TempDir::new()?;
+        let blob_store = Arc::new(FilesystemBlobStore::new(root.path())?);
+        let service = SkillService::in_memory(blob_store);
+
+        let created = service
+            .create_skill(CreateSkillRequest {
+                tenant_id: "tenant-a".to_string(),
+                upload: SkillUpload::Files(vec![UploadedSkillFile {
+                    relative_path: "SKILL.md".to_string(),
+                    contents: b"---\nname: acme:map\ndescription: Map the repo\n---\nUse rg."
+                        .to_vec(),
+                    media_type: Some("text/markdown".to_string()),
+                }]),
+            })
+            .await?;
+        let second = service
+            .create_skill_version(CreateSkillVersionRequest {
+                tenant_id: "tenant-a".to_string(),
+                skill_id: created.skill.skill_id.clone(),
+                upload: SkillUpload::Files(vec![UploadedSkillFile {
+                    relative_path: "SKILL.md".to_string(),
+                    contents: b"---\nname: acme:search\ndescription: Search the repo\n---\nUse fd."
+                        .to_vec(),
+                    media_type: Some("text/markdown".to_string()),
+                }]),
+            })
+            .await?;
+
+        let default_pin = service
+            .pin_skill_version(
+                "tenant-a",
+                &created.skill.skill_id,
+                SkillVersionSelector::Default,
+            )
+            .await?;
+        let latest_pin = service
+            .pin_skill_version(
+                "tenant-a",
+                &created.skill.skill_id,
+                SkillVersionSelector::Latest,
+            )
+            .await?;
+        let exact_pin = service
+            .pin_skill_version(
+                "tenant-a",
+                &created.skill.skill_id,
+                SkillVersionSelector::Exact(&created.version.version),
+            )
+            .await?;
+        let number_pin = service
+            .pin_skill_version(
+                "tenant-a",
+                &created.skill.skill_id,
+                SkillVersionSelector::VersionNumber(2),
+            )
+            .await?;
+
+        assert_eq!(default_pin.version, created.version.version);
+        assert_eq!(default_pin.version_number, 1);
+        assert_eq!(latest_pin.version, second.version.version);
+        assert_eq!(latest_pin.version_number, 2);
+        assert_eq!(exact_pin.version, created.version.version);
+        assert_eq!(number_pin.version, second.version.version);
+
+        let missing = service
+            .try_pin_skill_version(
+                "tenant-a",
+                "openai-provider-skill",
+                SkillVersionSelector::Default,
+            )
+            .await?;
+        assert_eq!(missing, None);
 
         Ok(())
     }

--- a/crates/skills/src/lib.rs
+++ b/crates/skills/src/lib.rs
@@ -7,7 +7,10 @@
 pub mod api;
 pub mod config;
 pub mod memory;
+pub mod resolution;
 pub mod storage;
+pub mod tool_protocol;
+pub mod tool_schemas;
 pub mod types;
 pub mod validation;
 
@@ -25,15 +28,31 @@ pub use config::{
     SkillsTenancyConfig, SkillsToolLoopConfig, SkillsZdrConfig,
 };
 pub use memory::InMemorySkillStore;
+pub use resolution::{
+    resolve_messages_skill_manifest, resolve_responses_skill_manifest, ResolvedSkillManifest,
+    ResolvedSkillRef, SkillResolutionError,
+};
 pub use storage::{
     BundleTokenStore, ContinuationCookieStore, SkillMetadataStore, SkillsStoreError,
     SkillsStoreResult, TenantAliasStore,
 };
+pub use tool_protocol::{
+    messages_skill_tools, response_skill_tools, validate_messages_reserved_skill_tool_names,
+    validate_responses_reserved_skill_tool_names, ReservedSkillToolNameError,
+};
+pub use tool_schemas::{
+    execute_skill_tool, is_reserved_skill_tool_name, is_skill_executor_configured,
+    list_skill_files_tool, read_only_skill_tools, read_skill_file_tool, read_skill_tool,
+    should_register_execute_skill, skill_tools, SkillToolDefinition, EXECUTE_SKILL_TOOL_NAME,
+    LIST_SKILL_FILES_TOOL_NAME, READ_SKILL_FILE_TOOL_NAME, READ_SKILL_TOOL_NAME,
+    RESERVED_SKILL_TOOL_NAMES,
+};
 pub use types::{
     BundleTokenClaim, ContinuationCookieClaim, NormalizedSkillBundle, NormalizedSkillFile,
-    ParsedSkillBundle, SkillDependencyTool, SkillFileRecord, SkillInterfaceMetadata,
-    SkillParseWarning, SkillParseWarningKind, SkillPolicyMetadata, SkillRecord,
-    SkillSidecarDependencies, SkillVersionRecord, TenantAliasRecord,
+    ParsedSkillBundle, PinnedSkillVersion, SkillDependencyTool, SkillFileRecord,
+    SkillInterfaceMetadata, SkillParseWarning, SkillParseWarningKind, SkillPolicyMetadata,
+    SkillRecord, SkillSidecarDependencies, SkillVersionRecord, SkillVersionSelector,
+    TenantAliasRecord,
 };
 pub use validation::{
     is_code_file_path, normalize_skill_bundle_zip, parse_skill_bundle, SkillBundleArchiveError,

--- a/crates/skills/src/resolution.rs
+++ b/crates/skills/src/resolution.rs
@@ -1,4 +1,9 @@
-use axum::response::Response;
+//! Request-local skill reference resolution.
+//!
+//! This module owns the skills feature semantics for Messages and Responses
+//! request shapes. The gateway invokes it after tenant metadata is resolved and
+//! before forwarding to provider-specific routers.
+
 use openai_protocol::{
     messages::CreateMessageRequest,
     responses::{
@@ -12,10 +17,8 @@ use openai_protocol::{
     },
 };
 use serde_json::Value;
-use smg_skills::{SkillRecord, SkillService, SkillVersionRecord, SkillsStoreError};
-use tracing::error;
 
-use crate::{routers::error as route_error, tenant::TenantKey};
+use crate::{PinnedSkillVersion, SkillService, SkillServiceError, SkillVersionSelector};
 
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct ResolvedSkillManifest {
@@ -64,59 +67,18 @@ pub enum ResolvedSkillRef {
     },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct PinnedSkillVersion {
-    pub version: String,
-    pub version_number: u32,
-}
-
 #[derive(Debug, thiserror::Error)]
 pub enum SkillResolutionError {
     #[error("skills are not enabled")]
     SkillsNotEnabled,
 
-    #[error("skills metadata store is not available")]
-    MissingMetadataStore,
-
-    #[error("skill not found")]
-    SkillNotFound,
-
-    #[error("skill version not found")]
-    SkillVersionNotFound,
-
-    #[error("skills metadata lookup failed: {0}")]
-    Store(#[from] SkillsStoreError),
-}
-
-impl SkillResolutionError {
-    #[must_use]
-    pub fn into_response(self) -> Response {
-        match self {
-            Self::SkillsNotEnabled => route_error::bad_request(
-                "skills_not_enabled",
-                "SMG skills are not enabled for this gateway",
-            ),
-            Self::SkillNotFound => {
-                route_error::bad_request("skill_not_found", "Referenced SMG skill was not found")
-            }
-            Self::SkillVersionNotFound => route_error::bad_request(
-                "skill_version_not_found",
-                "Referenced SMG skill version was not found",
-            ),
-            Self::MissingMetadataStore | Self::Store(_) => {
-                error!(error = %self, "failed to resolve request skills");
-                route_error::internal_error(
-                    "skills_resolution_failed",
-                    "Failed to resolve request skills",
-                )
-            }
-        }
-    }
+    #[error(transparent)]
+    Service(#[from] SkillServiceError),
 }
 
 pub async fn resolve_messages_skill_manifest(
     skill_service: Option<&SkillService>,
-    tenant_key: &TenantKey,
+    tenant_id: &str,
     request: &CreateMessageRequest,
 ) -> Result<ResolvedSkillManifest, SkillResolutionError> {
     let Some(skills) = request
@@ -132,27 +94,27 @@ pub async fn resolve_messages_skill_manifest(
 
     let mut refs = Vec::with_capacity(skills.len());
     for skill in skills {
-        refs.push(resolve_messages_skill_ref(skill_service, tenant_key, skill).await?);
+        refs.push(resolve_messages_skill_ref(skill_service, tenant_id, skill).await?);
     }
     Ok(ResolvedSkillManifest::new(refs))
 }
 
 pub async fn resolve_responses_skill_manifest(
     skill_service: Option<&SkillService>,
-    tenant_key: &TenantKey,
+    tenant_id: &str,
     request: &ResponsesRequest,
 ) -> Result<ResolvedSkillManifest, SkillResolutionError> {
     let mut refs = Vec::new();
 
     if let Some(tools) = &request.tools {
         for tool in tools {
-            resolve_response_tool_skills(skill_service, tenant_key, tool, &mut refs).await?;
+            resolve_response_tool_skills(skill_service, tenant_id, tool, &mut refs).await?;
         }
     }
 
     if let ResponseInput::Items(items) = &request.input {
         for item in items {
-            resolve_response_input_item_skills(skill_service, tenant_key, item, &mut refs).await?;
+            resolve_response_input_item_skills(skill_service, tenant_id, item, &mut refs).await?;
         }
     }
 
@@ -161,7 +123,7 @@ pub async fn resolve_responses_skill_manifest(
 
 async fn resolve_messages_skill_ref(
     skill_service: Option<&SkillService>,
-    tenant_key: &TenantKey,
+    tenant_id: &str,
     skill: &MessagesSkillRef,
 ) -> Result<ResolvedSkillRef, SkillResolutionError> {
     match skill {
@@ -172,9 +134,14 @@ async fn resolve_messages_skill_ref(
             })
         }
         MessagesSkillRef::Custom { skill_id, version } => {
-            let pinned =
-                resolve_required_smg_skill(skill_service, tenant_key, skill_id, version.as_ref())
-                    .await?;
+            let service = skill_service.ok_or(SkillResolutionError::SkillsNotEnabled)?;
+            let pinned = service
+                .pin_skill_version(
+                    tenant_id,
+                    skill_id,
+                    skill_version_selector(version.as_ref()),
+                )
+                .await?;
             Ok(ResolvedSkillRef::SmgStorage {
                 skill_id: skill_id.clone(),
                 requested_version: version.clone(),
@@ -186,7 +153,7 @@ async fn resolve_messages_skill_ref(
 
 async fn resolve_response_tool_skills(
     skill_service: Option<&SkillService>,
-    tenant_key: &TenantKey,
+    tenant_id: &str,
     tool: &ResponseTool,
     refs: &mut Vec<ResolvedSkillRef>,
 ) -> Result<(), SkillResolutionError> {
@@ -194,14 +161,14 @@ async fn resolve_response_tool_skills(
         ResponseTool::CodeInterpreter(CodeInterpreterTool { environment, .. }) => {
             resolve_response_tool_environment_skills(
                 skill_service,
-                tenant_key,
+                tenant_id,
                 environment.as_ref(),
                 refs,
             )
             .await
         }
         ResponseTool::Shell(ShellTool { environment }) => {
-            resolve_shell_environment_skills(skill_service, tenant_key, environment.as_ref(), refs)
+            resolve_shell_environment_skills(skill_service, tenant_id, environment.as_ref(), refs)
                 .await
         }
         _ => Ok(()),
@@ -210,49 +177,44 @@ async fn resolve_response_tool_skills(
 
 async fn resolve_response_input_item_skills(
     skill_service: Option<&SkillService>,
-    tenant_key: &TenantKey,
+    tenant_id: &str,
     item: &ResponseInputOutputItem,
     refs: &mut Vec<ResolvedSkillRef>,
 ) -> Result<(), SkillResolutionError> {
     if let ResponseInputOutputItem::ShellCall { environment, .. } = item {
-        resolve_shell_call_environment_skills(
-            skill_service,
-            tenant_key,
-            environment.as_ref(),
-            refs,
-        )
-        .await?;
+        resolve_shell_call_environment_skills(skill_service, tenant_id, environment.as_ref(), refs)
+            .await?;
     }
     Ok(())
 }
 
 async fn resolve_response_tool_environment_skills(
     skill_service: Option<&SkillService>,
-    tenant_key: &TenantKey,
+    tenant_id: &str,
     environment: Option<&ResponseToolEnvironment>,
     refs: &mut Vec<ResolvedSkillRef>,
 ) -> Result<(), SkillResolutionError> {
     if let Some(skills) = environment.and_then(|environment| environment.skills.as_ref()) {
-        resolve_responses_skill_entries(skill_service, tenant_key, skills, refs).await?;
+        resolve_responses_skill_entries(skill_service, tenant_id, skills, refs).await?;
     }
     Ok(())
 }
 
 async fn resolve_shell_environment_skills(
     skill_service: Option<&SkillService>,
-    tenant_key: &TenantKey,
+    tenant_id: &str,
     environment: Option<&ShellEnvironment>,
     refs: &mut Vec<ResolvedSkillRef>,
 ) -> Result<(), SkillResolutionError> {
     match environment {
         Some(ShellEnvironment::ContainerAuto(environment)) => {
             if let Some(skills) = &environment.skills {
-                resolve_responses_skill_entries(skill_service, tenant_key, skills, refs).await?;
+                resolve_responses_skill_entries(skill_service, tenant_id, skills, refs).await?;
             }
         }
         Some(ShellEnvironment::Local(LocalShellEnvironment { skills })) => {
             if let Some(skills) = skills {
-                resolve_responses_skill_entries(skill_service, tenant_key, skills, refs).await?;
+                resolve_responses_skill_entries(skill_service, tenant_id, skills, refs).await?;
             }
         }
         Some(ShellEnvironment::ContainerReference(_)) | None => {}
@@ -262,7 +224,7 @@ async fn resolve_shell_environment_skills(
 
 async fn resolve_shell_call_environment_skills(
     skill_service: Option<&SkillService>,
-    tenant_key: &TenantKey,
+    tenant_id: &str,
     environment: Option<&ShellCallEnvironment>,
     refs: &mut Vec<ResolvedSkillRef>,
 ) -> Result<(), SkillResolutionError> {
@@ -270,32 +232,32 @@ async fn resolve_shell_call_environment_skills(
         skills: Some(skills),
     })) = environment
     {
-        resolve_responses_skill_entries(skill_service, tenant_key, skills, refs).await?;
+        resolve_responses_skill_entries(skill_service, tenant_id, skills, refs).await?;
     }
     Ok(())
 }
 
 async fn resolve_responses_skill_entries(
     skill_service: Option<&SkillService>,
-    tenant_key: &TenantKey,
+    tenant_id: &str,
     skills: &[ResponsesSkillEntry],
     refs: &mut Vec<ResolvedSkillRef>,
 ) -> Result<(), SkillResolutionError> {
     refs.reserve(skills.len());
     for skill in skills {
-        refs.push(resolve_responses_skill_entry(skill_service, tenant_key, skill).await?);
+        refs.push(resolve_responses_skill_entry(skill_service, tenant_id, skill).await?);
     }
     Ok(())
 }
 
 async fn resolve_responses_skill_entry(
     skill_service: Option<&SkillService>,
-    tenant_key: &TenantKey,
+    tenant_id: &str,
     skill: &ResponsesSkillEntry,
 ) -> Result<ResolvedSkillRef, SkillResolutionError> {
     match skill {
         ResponsesSkillEntry::Typed(ResponsesSkillRef::Reference { skill_id, version }) => {
-            resolve_responses_reference(skill_service, tenant_key, skill_id, version.as_ref()).await
+            resolve_responses_reference(skill_service, tenant_id, skill_id, version.as_ref()).await
         }
         ResponsesSkillEntry::Typed(ResponsesSkillRef::Local {
             name,
@@ -316,7 +278,7 @@ async fn resolve_responses_skill_entry(
 
 async fn resolve_responses_reference(
     skill_service: Option<&SkillService>,
-    tenant_key: &TenantKey,
+    tenant_id: &str,
     skill_id: &str,
     version: Option<&SkillVersionRef>,
 ) -> Result<ResolvedSkillRef, SkillResolutionError> {
@@ -326,12 +288,9 @@ async fn resolve_responses_reference(
             raw_version: version.map(skill_version_ref_to_string),
         });
     };
-    let metadata_store = service
-        .metadata_store()
-        .ok_or(SkillResolutionError::MissingMetadataStore)?;
 
-    let Some(skill) = metadata_store
-        .get_skill(tenant_key.as_str(), skill_id)
+    let Some(pinned) = service
+        .try_pin_skill_version(tenant_id, skill_id, skill_version_selector(version))
         .await?
     else {
         return Ok(ResolvedSkillRef::OpenAIProvider {
@@ -340,7 +299,6 @@ async fn resolve_responses_reference(
         });
     };
 
-    let pinned = resolve_smg_skill_version(service, skill, version).await?;
     Ok(ResolvedSkillRef::SmgStorage {
         skill_id: skill_id.to_string(),
         requested_version: version.cloned(),
@@ -348,85 +306,15 @@ async fn resolve_responses_reference(
     })
 }
 
-async fn resolve_required_smg_skill(
-    skill_service: Option<&SkillService>,
-    tenant_key: &TenantKey,
-    skill_id: &str,
-    version: Option<&SkillVersionRef>,
-) -> Result<PinnedSkillVersion, SkillResolutionError> {
-    let service = skill_service.ok_or(SkillResolutionError::SkillsNotEnabled)?;
-    let metadata_store = service
-        .metadata_store()
-        .ok_or(SkillResolutionError::MissingMetadataStore)?;
-    let skill = metadata_store
-        .get_skill(tenant_key.as_str(), skill_id)
-        .await?
-        .ok_or(SkillResolutionError::SkillNotFound)?;
-    resolve_smg_skill_version(service, skill, version).await
-}
-
-async fn resolve_smg_skill_version(
-    service: &SkillService,
-    skill: SkillRecord,
-    version: Option<&SkillVersionRef>,
-) -> Result<PinnedSkillVersion, SkillResolutionError> {
-    let record = match version {
-        None => {
-            let default_version = skill
-                .default_version
-                .as_deref()
-                .ok_or(SkillResolutionError::SkillVersionNotFound)?;
-            get_exact_skill_version(service, &skill, default_version).await?
-        }
-        Some(SkillVersionRef::Latest) => {
-            let latest_version = skill
-                .latest_version
-                .as_deref()
-                .ok_or(SkillResolutionError::SkillVersionNotFound)?;
-            get_exact_skill_version(service, &skill, latest_version).await?
-        }
-        Some(SkillVersionRef::Timestamp(version)) => {
-            get_exact_skill_version(service, &skill, version).await?
-        }
+fn skill_version_selector(version: Option<&SkillVersionRef>) -> SkillVersionSelector<'_> {
+    match version {
+        None => SkillVersionSelector::Default,
+        Some(SkillVersionRef::Latest) => SkillVersionSelector::Latest,
         Some(SkillVersionRef::Integer(version_number)) => {
-            get_skill_version_by_number(service, &skill, *version_number).await?
+            SkillVersionSelector::VersionNumber(*version_number)
         }
-    };
-
-    Ok(PinnedSkillVersion {
-        version: record.version,
-        version_number: record.version_number,
-    })
-}
-
-async fn get_exact_skill_version(
-    service: &SkillService,
-    skill: &SkillRecord,
-    version: &str,
-) -> Result<SkillVersionRecord, SkillResolutionError> {
-    let metadata_store = service
-        .metadata_store()
-        .ok_or(SkillResolutionError::MissingMetadataStore)?;
-    metadata_store
-        .get_skill_version(&skill.skill_id, version)
-        .await?
-        .ok_or(SkillResolutionError::SkillVersionNotFound)
-}
-
-async fn get_skill_version_by_number(
-    service: &SkillService,
-    skill: &SkillRecord,
-    version_number: u32,
-) -> Result<SkillVersionRecord, SkillResolutionError> {
-    let metadata_store = service
-        .metadata_store()
-        .ok_or(SkillResolutionError::MissingMetadataStore)?;
-    metadata_store
-        .list_skill_versions(&skill.skill_id)
-        .await?
-        .into_iter()
-        .find(|record| record.version_number == version_number)
-        .ok_or(SkillResolutionError::SkillVersionNotFound)
+        Some(SkillVersionRef::Timestamp(version)) => SkillVersionSelector::Exact(version),
+    }
 }
 
 fn skill_version_ref_to_string(version: &SkillVersionRef) -> String {
@@ -444,13 +332,13 @@ mod tests {
     use anyhow::{anyhow, Result};
     use openai_protocol::{messages::CreateMessageRequest, responses::ResponsesRequest};
     use smg_blob_storage::FilesystemBlobStore;
-    use smg_skills::{
-        CreateSkillRequest, CreateSkillVersionRequest, SkillService, SkillUpload,
-        UpdateSkillRequest, UploadedSkillFile,
-    };
     use tempfile::TempDir;
 
     use super::*;
+    use crate::{
+        CreateSkillRequest, CreateSkillVersionRequest, SkillService, SkillUpload,
+        UpdateSkillRequest, UploadedSkillFile,
+    };
 
     const TENANT_ID: &str = "auth:test-tenant";
 
@@ -486,10 +374,6 @@ mod tests {
             })
             .await?;
         Ok(result.version.version)
-    }
-
-    fn tenant_key() -> TenantKey {
-        TenantKey::from(TENANT_ID)
     }
 
     fn messages_request(skill_id: &str, version: Option<Value>) -> Result<CreateMessageRequest> {
@@ -535,8 +419,7 @@ mod tests {
     async fn messages_custom_default_version_is_pinned_at_resolution() -> Result<()> {
         let (_root, service, skill_id) = create_test_service().await?;
         let request = messages_request(&skill_id, None)?;
-        let manifest =
-            resolve_messages_skill_manifest(Some(&service), &tenant_key(), &request).await?;
+        let manifest = resolve_messages_skill_manifest(Some(&service), TENANT_ID, &request).await?;
 
         let second_version = create_second_version(&service, &skill_id).await?;
         service
@@ -562,8 +445,7 @@ mod tests {
     async fn messages_custom_latest_version_is_pinned_at_resolution() -> Result<()> {
         let (_root, service, skill_id) = create_test_service().await?;
         let request = messages_request(&skill_id, Some(Value::String("latest".to_string())))?;
-        let manifest =
-            resolve_messages_skill_manifest(Some(&service), &tenant_key(), &request).await?;
+        let manifest = resolve_messages_skill_manifest(Some(&service), TENANT_ID, &request).await?;
 
         let second_version = create_second_version(&service, &skill_id).await?;
 
@@ -594,7 +476,7 @@ mod tests {
         ])?;
 
         let manifest =
-            resolve_responses_skill_manifest(Some(&service), &tenant_key(), &request).await?;
+            resolve_responses_skill_manifest(Some(&service), TENANT_ID, &request).await?;
 
         assert_eq!(manifest.refs().len(), 2);
         match &manifest.refs()[0] {
@@ -633,7 +515,7 @@ mod tests {
             }),
         ])?;
 
-        let manifest = resolve_responses_skill_manifest(None, &tenant_key(), &request).await?;
+        let manifest = resolve_responses_skill_manifest(None, TENANT_ID, &request).await?;
 
         assert_eq!(manifest.refs().len(), 2);
         assert!(matches!(
@@ -652,7 +534,7 @@ mod tests {
     #[tokio::test]
     async fn messages_custom_requires_enabled_smg_skills() -> Result<()> {
         let request = messages_request("skill_missing", None)?;
-        let error = resolve_messages_skill_manifest(None, &tenant_key(), &request)
+        let error = resolve_messages_skill_manifest(None, TENANT_ID, &request)
             .await
             .err()
             .ok_or_else(|| anyhow!("expected skills-not-enabled error"))?;

--- a/crates/skills/src/tool_protocol.rs
+++ b/crates/skills/src/tool_protocol.rs
@@ -1,0 +1,345 @@
+//! Protocol-facing skill tool adapters and request guardrails.
+
+use std::collections::HashMap;
+
+use openai_protocol::{
+    common::Function,
+    messages::{self, CustomTool as MessagesCustomTool, InputSchema},
+    responses::{FunctionTool, NamespaceTool, ResponseTool},
+};
+use serde_json::Value;
+
+use crate::{is_reserved_skill_tool_name, skill_tools, SkillToolDefinition};
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("tool name '{tool_name}' is reserved for SMG skill tools")]
+pub struct ReservedSkillToolNameError {
+    tool_name: String,
+}
+
+impl ReservedSkillToolNameError {
+    #[must_use]
+    pub fn tool_name(&self) -> &str {
+        &self.tool_name
+    }
+}
+
+pub fn validate_messages_reserved_skill_tool_names(
+    tools: Option<&[messages::Tool]>,
+) -> Result<(), ReservedSkillToolNameError> {
+    let Some(tools) = tools else {
+        return Ok(());
+    };
+
+    for tool in tools {
+        if let Some(name) = messages_tool_name(tool) {
+            validate_user_tool_name(name)?;
+        }
+    }
+
+    Ok(())
+}
+
+pub fn validate_responses_reserved_skill_tool_names(
+    tools: Option<&[ResponseTool]>,
+) -> Result<(), ReservedSkillToolNameError> {
+    let Some(tools) = tools else {
+        return Ok(());
+    };
+
+    for tool in tools {
+        match tool {
+            ResponseTool::Function(function_tool) => {
+                validate_user_tool_name(&function_tool.function.name)?;
+            }
+            ResponseTool::Custom(custom_tool) => {
+                validate_user_tool_name(&custom_tool.name)?;
+            }
+            ResponseTool::Namespace(namespace) => {
+                validate_user_tool_name(&namespace.name)?;
+                for nested_tool in &namespace.tools {
+                    validate_namespace_tool_name(nested_tool)?;
+                }
+            }
+            ResponseTool::WebSearchPreview(_)
+            | ResponseTool::WebSearch(_)
+            | ResponseTool::CodeInterpreter(_)
+            | ResponseTool::Mcp(_)
+            | ResponseTool::FileSearch(_)
+            | ResponseTool::ImageGeneration(_)
+            | ResponseTool::Computer
+            | ResponseTool::ComputerUsePreview(_)
+            | ResponseTool::Shell(_)
+            | ResponseTool::ApplyPatch
+            | ResponseTool::LocalShell => {}
+        }
+    }
+
+    Ok(())
+}
+
+pub fn response_skill_tools(include_execution: bool) -> Vec<ResponseTool> {
+    skill_tools(include_execution)
+        .into_iter()
+        .map(response_skill_tool)
+        .collect()
+}
+
+pub fn messages_skill_tools(include_execution: bool) -> Vec<messages::Tool> {
+    skill_tools(include_execution)
+        .into_iter()
+        .map(messages_skill_tool)
+        .collect()
+}
+
+fn response_skill_tool(tool: SkillToolDefinition) -> ResponseTool {
+    ResponseTool::Function(FunctionTool {
+        function: Function {
+            name: tool.name.to_string(),
+            description: Some(tool.description.to_string()),
+            parameters: tool.input_schema.clone(),
+            strict: Some(false),
+        },
+    })
+}
+
+fn messages_skill_tool(tool: SkillToolDefinition) -> messages::Tool {
+    messages::Tool::Custom(MessagesCustomTool {
+        name: tool.name.to_string(),
+        tool_type: None,
+        description: Some(tool.description.to_string()),
+        input_schema: input_schema_from_json_schema(tool.input_schema),
+        defer_loading: None,
+        cache_control: None,
+    })
+}
+
+fn input_schema_from_json_schema(schema: &Value) -> InputSchema {
+    let Some(schema_map) = schema.as_object() else {
+        return object_input_schema(HashMap::new());
+    };
+
+    let schema_type = schema_map
+        .get("type")
+        .and_then(Value::as_str)
+        .unwrap_or("object")
+        .to_string();
+    let properties = schema_map
+        .get("properties")
+        .and_then(Value::as_object)
+        .map(|obj| {
+            obj.iter()
+                .map(|(key, value)| (key.clone(), value.clone()))
+                .collect()
+        });
+    let required = schema_map
+        .get("required")
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(Value::as_str)
+                .map(str::to_string)
+                .collect()
+        });
+    let additional = schema_map
+        .iter()
+        .filter(|(key, _)| *key != "type" && *key != "properties" && *key != "required")
+        .map(|(key, value)| (key.clone(), value.clone()))
+        .collect();
+
+    InputSchema {
+        schema_type,
+        properties,
+        required,
+        additional,
+    }
+}
+
+fn object_input_schema(additional: HashMap<String, Value>) -> InputSchema {
+    InputSchema {
+        schema_type: "object".to_string(),
+        properties: None,
+        required: None,
+        additional,
+    }
+}
+
+fn messages_tool_name(tool: &messages::Tool) -> Option<&str> {
+    match tool {
+        messages::Tool::McpToolset(_) => None,
+        messages::Tool::Custom(tool) => Some(&tool.name),
+        messages::Tool::ToolSearch(tool) => Some(&tool.name),
+        messages::Tool::Bash(tool) => Some(&tool.name),
+        messages::Tool::TextEditor(tool) => Some(&tool.name),
+        messages::Tool::WebSearch(tool) => Some(&tool.name),
+    }
+}
+
+fn validate_namespace_tool_name(tool: &NamespaceTool) -> Result<(), ReservedSkillToolNameError> {
+    match tool {
+        NamespaceTool::Function(function_tool) => {
+            validate_user_tool_name(&function_tool.function.name)
+        }
+        NamespaceTool::Custom(custom_tool) => validate_user_tool_name(&custom_tool.name),
+    }
+}
+
+fn validate_user_tool_name(name: &str) -> Result<(), ReservedSkillToolNameError> {
+    if is_reserved_skill_tool_name(name) {
+        Err(ReservedSkillToolNameError {
+            tool_name: name.to_string(),
+        })
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use openai_protocol::{
+        common::Function,
+        messages::{CustomTool as MessagesCustomTool, InputSchema as MessagesInputSchema},
+        responses::{
+            CustomTool as ResponseCustomTool, FunctionTool, NamespaceToolDef, ResponseInput,
+            ResponsesRequest,
+        },
+    };
+    use serde_json::{json, Value};
+
+    use super::*;
+    use crate::EXECUTE_SKILL_TOOL_NAME;
+
+    fn empty_messages_schema() -> MessagesInputSchema {
+        MessagesInputSchema {
+            schema_type: "object".to_string(),
+            properties: None,
+            required: None,
+            additional: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn response_skill_tools_serialize_as_function_tools() -> Result<(), serde_json::Error> {
+        let tools = response_skill_tools(false);
+        let serialized = serde_json::to_value(&tools)?;
+
+        assert_eq!(
+            serialized,
+            json!([
+                {
+                    "type": "function",
+                    "name": "read_skill",
+                    "description": crate::read_skill_tool().description,
+                    "parameters": crate::read_skill_tool().input_schema,
+                    "strict": false
+                },
+                {
+                    "type": "function",
+                    "name": "list_skill_files",
+                    "description": crate::list_skill_files_tool().description,
+                    "parameters": crate::list_skill_files_tool().input_schema,
+                    "strict": false
+                },
+                {
+                    "type": "function",
+                    "name": "read_skill_file",
+                    "description": crate::read_skill_file_tool().description,
+                    "parameters": crate::read_skill_file_tool().input_schema,
+                    "strict": false
+                }
+            ])
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn messages_skill_tools_serialize_as_custom_tools() -> Result<(), serde_json::Error> {
+        let tools = messages_skill_tools(true);
+        let serialized = serde_json::to_value(&tools)?;
+
+        assert_eq!(tools.len(), 4);
+        assert_eq!(serialized[0]["name"], "read_skill");
+        assert_eq!(serialized[0]["input_schema"]["type"], "object");
+        assert_eq!(serialized[0]["input_schema"]["additionalProperties"], false);
+        assert_eq!(serialized[3]["name"], EXECUTE_SKILL_TOOL_NAME);
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_reserved_messages_tool_name() {
+        let tools = vec![messages::Tool::Custom(MessagesCustomTool {
+            name: crate::READ_SKILL_TOOL_NAME.to_string(),
+            tool_type: None,
+            description: None,
+            input_schema: empty_messages_schema(),
+            defer_loading: None,
+            cache_control: None,
+        })];
+
+        assert_eq!(
+            validate_messages_reserved_skill_tool_names(Some(&tools)),
+            Err(ReservedSkillToolNameError {
+                tool_name: crate::READ_SKILL_TOOL_NAME.to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_reserved_responses_function_tool_name() {
+        let tools = vec![ResponseTool::Function(FunctionTool {
+            function: Function {
+                name: crate::READ_SKILL_FILE_TOOL_NAME.to_string(),
+                description: None,
+                parameters: json!({"type": "object"}),
+                strict: None,
+            },
+        })];
+
+        assert_eq!(
+            validate_responses_reserved_skill_tool_names(Some(&tools)),
+            Err(ReservedSkillToolNameError {
+                tool_name: crate::READ_SKILL_FILE_TOOL_NAME.to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_reserved_responses_namespace_tool_name() {
+        let tools = vec![ResponseTool::Namespace(NamespaceToolDef {
+            name: "safe_namespace".to_string(),
+            description: "safe".to_string(),
+            tools: vec![NamespaceTool::Custom(ResponseCustomTool {
+                name: crate::LIST_SKILL_FILES_TOOL_NAME.to_string(),
+                description: None,
+                defer_loading: None,
+                format: None,
+            })],
+        })];
+
+        assert_eq!(
+            validate_responses_reserved_skill_tool_names(Some(&tools)),
+            Err(ReservedSkillToolNameError {
+                tool_name: crate::LIST_SKILL_FILES_TOOL_NAME.to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn allows_non_reserved_tool_names() {
+        let request = ResponsesRequest {
+            model: "gpt-5.4".to_string(),
+            input: ResponseInput::Text("hello".to_string()),
+            tools: Some(vec![ResponseTool::Function(FunctionTool {
+                function: Function {
+                    name: "lookup_customer".to_string(),
+                    description: None,
+                    parameters: Value::Object(Default::default()),
+                    strict: None,
+                },
+            })]),
+            ..Default::default()
+        };
+
+        assert!(validate_responses_reserved_skill_tool_names(request.tools.as_deref()).is_ok());
+    }
+}

--- a/crates/skills/src/tool_schemas.rs
+++ b/crates/skills/src/tool_schemas.rs
@@ -1,0 +1,406 @@
+//! Canonical SMG skill tool definitions.
+//!
+//! These definitions are provider-neutral. Gateway adapters serialize them into
+//! provider-specific request shapes, for example Responses `function` tools or
+//! Anthropic Messages `custom` tools.
+
+use std::sync::LazyLock;
+
+use serde_json::{json, Value};
+
+use crate::{SkillsConfig, SkillsExecutionConfig};
+
+pub const READ_SKILL_TOOL_NAME: &str = "read_skill";
+pub const LIST_SKILL_FILES_TOOL_NAME: &str = "list_skill_files";
+pub const READ_SKILL_FILE_TOOL_NAME: &str = "read_skill_file";
+pub const EXECUTE_SKILL_TOOL_NAME: &str = "execute_skill";
+
+pub const RESERVED_SKILL_TOOL_NAMES: [&str; 4] = [
+    READ_SKILL_TOOL_NAME,
+    LIST_SKILL_FILES_TOOL_NAME,
+    READ_SKILL_FILE_TOOL_NAME,
+    EXECUTE_SKILL_TOOL_NAME,
+];
+
+#[derive(Debug, Clone, Copy)]
+pub struct SkillToolDefinition {
+    pub name: &'static str,
+    pub description: &'static str,
+    pub input_schema: &'static Value,
+    pub output_schema: &'static Value,
+}
+
+pub fn read_skill_tool() -> SkillToolDefinition {
+    SkillToolDefinition {
+        name: READ_SKILL_TOOL_NAME,
+        description: "Fetch the full SKILL.md body for a skill attached to this request. Call this when the user's task matches a skill's description in the skills_instructions listing, or when the user explicitly names a skill. The returned body contains YAML frontmatter and Markdown instructions; read only what you need.",
+        input_schema: LazyLock::force(&READ_SKILL_INPUT_SCHEMA),
+        output_schema: LazyLock::force(&READ_SKILL_OUTPUT_SCHEMA),
+    }
+}
+
+pub fn list_skill_files_tool() -> SkillToolDefinition {
+    SkillToolDefinition {
+        name: LIST_SKILL_FILES_TOOL_NAME,
+        description: "List the non-SKILL.md files bundled with a skill (scripts, templates, references, assets). Returns a flat list of paths relative to the skill root. Call this when SKILL.md references a file under scripts/ or references/ and you need to know which files exist before reading one.",
+        input_schema: LazyLock::force(&SKILL_ID_ONLY_INPUT_SCHEMA),
+        output_schema: LazyLock::force(&LIST_SKILL_FILES_OUTPUT_SCHEMA),
+    }
+}
+
+pub fn read_skill_file_tool() -> SkillToolDefinition {
+    SkillToolDefinition {
+        name: READ_SKILL_FILE_TOOL_NAME,
+        description: "Read the content of a single file in a skill bundle. Use this to load a specific script, template, or reference file mentioned in SKILL.md. Do not bulk-load files - read only what you need for the current task. The response may return text (utf8 encoding) or base64-encoded bytes (binary encoding) depending on the file's type, as reported by list_skill_files.",
+        input_schema: LazyLock::force(&READ_SKILL_FILE_INPUT_SCHEMA),
+        output_schema: LazyLock::force(&READ_SKILL_FILE_OUTPUT_SCHEMA),
+    }
+}
+
+pub fn execute_skill_tool() -> SkillToolDefinition {
+    SkillToolDefinition {
+        name: EXECUTE_SKILL_TOOL_NAME,
+        description: "Run a skill's code via the configured external executor. Use this for skills whose SKILL.md describes a workflow to be executed rather than transcribing or re-implementing the code yourself. The input is a free-form JSON object whose shape is defined by the specific skill's SKILL.md. Only small model-consumable files are returned inline in files_produced; larger artifacts are out of scope for this transport.",
+        input_schema: LazyLock::force(&EXECUTE_SKILL_INPUT_SCHEMA),
+        output_schema: LazyLock::force(&EXECUTE_SKILL_OUTPUT_SCHEMA),
+    }
+}
+
+pub fn read_only_skill_tools() -> [SkillToolDefinition; 3] {
+    [
+        read_skill_tool(),
+        list_skill_files_tool(),
+        read_skill_file_tool(),
+    ]
+}
+
+pub fn skill_tools(include_execution: bool) -> Vec<SkillToolDefinition> {
+    let mut tools = Vec::with_capacity(if include_execution { 4 } else { 3 });
+    tools.extend(read_only_skill_tools());
+    if include_execution {
+        tools.push(execute_skill_tool());
+    }
+    tools
+}
+
+pub fn is_reserved_skill_tool_name(name: &str) -> bool {
+    RESERVED_SKILL_TOOL_NAMES.contains(&name)
+}
+
+pub fn is_skill_executor_configured(config: &SkillsConfig) -> bool {
+    is_execution_configured(&config.execution)
+}
+
+pub fn should_register_execute_skill(config: Option<&SkillsConfig>, has_code_files: bool) -> bool {
+    has_code_files && config.is_some_and(is_skill_executor_configured)
+}
+
+fn is_execution_configured(config: &SkillsExecutionConfig) -> bool {
+    let has_url = config
+        .executor_url
+        .as_deref()
+        .is_some_and(|url| !url.trim().is_empty());
+    let has_key = config
+        .executor_api_key
+        .as_deref()
+        .is_some_and(|key| !key.trim().is_empty());
+    has_url && has_key
+}
+
+static READ_SKILL_INPUT_SCHEMA: LazyLock<Value> = LazyLock::new(|| {
+    json!({
+        "type": "object",
+        "properties": {
+            "skill_id": {
+                "type": "string",
+                "description": "Skill id exactly as it appears in the skills_instructions listing."
+            }
+        },
+        "required": ["skill_id"],
+        "additionalProperties": false
+    })
+});
+
+static SKILL_ID_ONLY_INPUT_SCHEMA: LazyLock<Value> = LazyLock::new(|| {
+    json!({
+        "type": "object",
+        "properties": {
+            "skill_id": {
+                "type": "string",
+                "description": "Skill id from the skills_instructions listing."
+            }
+        },
+        "required": ["skill_id"],
+        "additionalProperties": false
+    })
+});
+
+static READ_SKILL_FILE_INPUT_SCHEMA: LazyLock<Value> = LazyLock::new(|| {
+    json!({
+        "type": "object",
+        "properties": {
+            "skill_id": {
+                "type": "string",
+                "description": "Skill id from the skills_instructions listing."
+            },
+            "path": {
+                "type": "string",
+                "description": "Path from list_skill_files output. Must match exactly - relative to skill root, forward-slash delimited. Does not accept absolute paths, '..', or symlink traversal."
+            },
+            "offset": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Byte offset into the file. Defaults to 0. Use with length to chunk large files."
+            },
+            "length": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 65536,
+                "description": "Maximum number of bytes to return from offset. Defaults to the largest value that still fits within the tool-result budget."
+            }
+        },
+        "required": ["skill_id", "path"],
+        "additionalProperties": false
+    })
+});
+
+static EXECUTE_SKILL_INPUT_SCHEMA: LazyLock<Value> = LazyLock::new(|| {
+    json!({
+        "type": "object",
+        "properties": {
+            "skill_id": {
+                "type": "string",
+                "description": "Skill id from the skills_instructions listing."
+            },
+            "input": {
+                "description": "Free-form JSON payload passed to the skill's entry point. Shape is defined by the skill's SKILL.md. Read SKILL.md first if the expected shape is not obvious.",
+                "type": ["object", "array", "string", "number", "boolean", "null"]
+            }
+        },
+        "required": ["skill_id", "input"],
+        "additionalProperties": false
+    })
+});
+
+static READ_SKILL_OUTPUT_SCHEMA: LazyLock<Value> = LazyLock::new(|| {
+    json!({
+        "type": "object",
+        "properties": {
+            "name": {
+                "type": "string",
+                "description": "Skill name from SKILL.md frontmatter."
+            },
+            "version": {
+                "type": "string",
+                "description": "Version identifier of the skill."
+            },
+            "body": {
+                "type": "string",
+                "description": "Full SKILL.md contents including frontmatter."
+            }
+        },
+        "required": ["name", "version", "body"],
+        "additionalProperties": false
+    })
+});
+
+static LIST_SKILL_FILES_OUTPUT_SCHEMA: LazyLock<Value> = LazyLock::new(|| {
+    json!({
+        "type": "object",
+        "properties": {
+            "files": {
+                "type": "array",
+                "description": "All non-SKILL.md files in the bundle. Capped at upload time, so pagination is not needed.",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "path": {
+                            "type": "string",
+                            "description": "Path relative to skill root, forward-slash delimited."
+                        },
+                        "size_bytes": {
+                            "type": "integer",
+                            "minimum": 0
+                        },
+                        "mime_type": {
+                            "type": "string",
+                            "description": "Detected at upload; for example text/x-python or application/octet-stream."
+                        },
+                        "encoding": {
+                            "type": "string",
+                            "enum": ["utf8", "binary"],
+                            "description": "Whether read_skill_file returns text or base64."
+                        }
+                    },
+                    "required": ["path", "size_bytes", "mime_type", "encoding"],
+                    "additionalProperties": false
+                }
+            }
+        },
+        "required": ["files"],
+        "additionalProperties": false
+    })
+});
+
+static READ_SKILL_FILE_OUTPUT_SCHEMA: LazyLock<Value> = LazyLock::new(|| {
+    json!({
+        "type": "object",
+        "properties": {
+            "content": {
+                "type": "string",
+                "description": "File contents. UTF-8 text when encoding=utf8, base64-encoded bytes when encoding=binary."
+            },
+            "encoding": {
+                "type": "string",
+                "enum": ["utf8", "base64"]
+            },
+            "mime_type": {
+                "type": "string"
+            },
+            "offset": {
+                "type": "integer",
+                "minimum": 0
+            },
+            "total_size_bytes": {
+                "type": "integer",
+                "minimum": 0
+            },
+            "has_more": {
+                "type": "boolean",
+                "description": "True when unread bytes remain after this chunk."
+            }
+        },
+        "required": ["content", "encoding", "mime_type", "offset", "total_size_bytes", "has_more"],
+        "additionalProperties": false
+    })
+});
+
+static EXECUTE_SKILL_OUTPUT_SCHEMA: LazyLock<Value> = LazyLock::new(|| {
+    json!({
+        "type": "object",
+        "properties": {
+            "status": {
+                "type": "string",
+                "enum": ["completed", "paused"],
+                "description": "paused means the execution is long-running; resume through the API surface's continuation contract."
+            },
+            "cookie": {
+                "type": ["string", "null"],
+                "description": "Continuation cookie, present iff status=paused."
+            },
+            "summary": {
+                "type": ["string", "null"],
+                "description": "Textual summary of what the skill did or produced."
+            },
+            "files_produced": {
+                "type": "array",
+                "description": "Small files the skill created, delivered inline. Reference the filename when describing results to the user; the client extracts the base64 content from the final response.",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "Filename, including extension."
+                        },
+                        "mime_type": {
+                            "type": "string",
+                            "description": "Detected content type."
+                        },
+                        "size_bytes": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "description": "Size of decoded content."
+                        },
+                        "content_base64": {
+                            "type": "string",
+                            "description": "Base64-encoded file content. Subject to the generic tool-result cap and execution output caps."
+                        }
+                    },
+                    "required": ["name", "mime_type", "size_bytes", "content_base64"],
+                    "additionalProperties": false
+                }
+            }
+        },
+        "required": ["status"],
+        "additionalProperties": false
+    })
+});
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exposes_reserved_skill_tool_names() {
+        assert!(is_reserved_skill_tool_name(READ_SKILL_TOOL_NAME));
+        assert!(is_reserved_skill_tool_name(LIST_SKILL_FILES_TOOL_NAME));
+        assert!(is_reserved_skill_tool_name(READ_SKILL_FILE_TOOL_NAME));
+        assert!(is_reserved_skill_tool_name(EXECUTE_SKILL_TOOL_NAME));
+        assert!(!is_reserved_skill_tool_name("user_tool"));
+    }
+
+    #[test]
+    fn read_only_tool_set_omits_execute_skill() {
+        let tools = skill_tools(false);
+        let names: Vec<&str> = tools.iter().map(|tool| tool.name).collect();
+
+        assert_eq!(
+            names,
+            vec![
+                READ_SKILL_TOOL_NAME,
+                LIST_SKILL_FILES_TOOL_NAME,
+                READ_SKILL_FILE_TOOL_NAME
+            ]
+        );
+    }
+
+    #[test]
+    fn execution_tool_set_includes_execute_skill_last() {
+        let tools = skill_tools(true);
+        let names: Vec<&str> = tools.iter().map(|tool| tool.name).collect();
+
+        assert_eq!(
+            names,
+            vec![
+                READ_SKILL_TOOL_NAME,
+                LIST_SKILL_FILES_TOOL_NAME,
+                READ_SKILL_FILE_TOOL_NAME,
+                EXECUTE_SKILL_TOOL_NAME
+            ]
+        );
+    }
+
+    #[test]
+    fn executor_configuration_requires_url_and_key() {
+        let mut config = SkillsConfig::default();
+        assert!(!should_register_execute_skill(Some(&config), true));
+
+        config.execution.executor_url = Some("http://executor.internal".to_string());
+        assert!(!should_register_execute_skill(Some(&config), true));
+
+        config.execution.executor_api_key = Some("secret".to_string());
+        assert!(should_register_execute_skill(Some(&config), true));
+        assert!(!should_register_execute_skill(Some(&config), false));
+        assert!(!should_register_execute_skill(None, true));
+    }
+
+    #[test]
+    fn schemas_are_closed_and_have_expected_required_fields() {
+        let tool = read_skill_file_tool();
+
+        assert_eq!(tool.input_schema["additionalProperties"], false);
+        assert_eq!(tool.input_schema["required"], json!(["skill_id", "path"]));
+        assert_eq!(tool.output_schema["additionalProperties"], false);
+        assert_eq!(
+            tool.output_schema["required"],
+            json!([
+                "content",
+                "encoding",
+                "mime_type",
+                "offset",
+                "total_size_bytes",
+                "has_more"
+            ])
+        );
+    }
+}

--- a/crates/skills/src/tool_schemas.rs
+++ b/crates/skills/src/tool_schemas.rs
@@ -107,33 +107,26 @@ fn is_execution_configured(config: &SkillsExecutionConfig) -> bool {
     has_url && has_key
 }
 
-static READ_SKILL_INPUT_SCHEMA: LazyLock<Value> = LazyLock::new(|| {
+fn skill_id_only_input_schema(description: &'static str) -> Value {
     json!({
         "type": "object",
         "properties": {
             "skill_id": {
                 "type": "string",
-                "description": "Skill id exactly as it appears in the skills_instructions listing."
+                "description": description
             }
         },
         "required": ["skill_id"],
         "additionalProperties": false
     })
+}
+
+static READ_SKILL_INPUT_SCHEMA: LazyLock<Value> = LazyLock::new(|| {
+    skill_id_only_input_schema("Skill id exactly as it appears in the skills_instructions listing.")
 });
 
-static SKILL_ID_ONLY_INPUT_SCHEMA: LazyLock<Value> = LazyLock::new(|| {
-    json!({
-        "type": "object",
-        "properties": {
-            "skill_id": {
-                "type": "string",
-                "description": "Skill id from the skills_instructions listing."
-            }
-        },
-        "required": ["skill_id"],
-        "additionalProperties": false
-    })
-});
+static SKILL_ID_ONLY_INPUT_SCHEMA: LazyLock<Value> =
+    LazyLock::new(|| skill_id_only_input_schema("Skill id from the skills_instructions listing."));
 
 static READ_SKILL_FILE_INPUT_SCHEMA: LazyLock<Value> = LazyLock::new(|| {
     json!({

--- a/crates/skills/src/types.rs
+++ b/crates/skills/src/types.rs
@@ -38,6 +38,27 @@ pub struct SkillVersionRecord {
     pub created_at: DateTime<Utc>,
 }
 
+/// Immutable skill-version pin captured at request attach time.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PinnedSkillVersion {
+    pub version: String,
+    pub version_number: u32,
+}
+
+/// Domain-level selector used when resolving a skill reference to a concrete
+/// immutable version.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SkillVersionSelector<'a> {
+    /// Use the skill projection's current default version.
+    Default,
+    /// Use the skill projection's current latest version.
+    Latest,
+    /// Use an exact immutable version id.
+    Exact(&'a str),
+    /// Use a version-number lookup.
+    VersionNumber(u32),
+}
+
 /// File-level manifest entry stored alongside a normalized skill bundle.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SkillFileRecord {

--- a/model_gateway/src/routers/common/mod.rs
+++ b/model_gateway/src/routers/common/mod.rs
@@ -18,13 +18,10 @@
 //!   coupling to the `Worker` trait — it lived in `worker/` for
 //!   historical reasons before this extraction.
 //! - [`background`] — background-mode response scaffolding.
-//! - [`skill_resolution`] — request-local skill manifest resolution
-//!   before forwarding to provider-specific routers.
 
 pub mod background;
 pub mod header_utils;
 pub mod mcp_utils;
 pub mod persistence_utils;
 pub mod retry;
-pub mod skill_resolution;
 pub mod worker_selection;

--- a/model_gateway/src/routers/error.rs
+++ b/model_gateway/src/routers/error.rs
@@ -7,6 +7,8 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::Serialize;
 use serde_json::Value;
+use smg_skills::{ReservedSkillToolNameError, SkillResolutionError, SkillServiceError};
+use tracing::error;
 
 #[derive(Serialize)]
 struct ErrorResponse<'a> {
@@ -100,6 +102,48 @@ pub fn model_not_found(model: &str) -> Response {
         "model_not_found",
         format!("No worker available for model '{model}'"),
     )
+}
+
+pub fn reserved_skill_tool_name(error: ReservedSkillToolNameError) -> Response {
+    bad_request(
+        "reserved_tool_name",
+        format!(
+            "Tool name '{}' is reserved for SMG skill tools",
+            error.tool_name()
+        ),
+    )
+}
+
+pub fn skill_resolution_error(error: SkillResolutionError) -> Response {
+    match error {
+        SkillResolutionError::SkillsNotEnabled => bad_request(
+            "skills_not_enabled",
+            "SMG skills are not enabled for this gateway",
+        ),
+        SkillResolutionError::Service(SkillServiceError::SkillNotFound { .. }) => {
+            bad_request("skill_not_found", "Referenced SMG skill was not found")
+        }
+        SkillResolutionError::Service(
+            SkillServiceError::SkillVersionNotFound { .. }
+            | SkillServiceError::MissingDefaultVersion { .. },
+        ) => bad_request(
+            "skill_version_not_found",
+            "Referenced SMG skill version was not found",
+        ),
+        SkillResolutionError::Service(
+            SkillServiceError::MissingTenantId | SkillServiceError::MissingSkillId,
+        ) => bad_request(
+            "invalid_skill_reference",
+            "Skill reference is missing a required field",
+        ),
+        SkillResolutionError::Service(_) => {
+            error!(error = %error, "failed to resolve request skills");
+            internal_error(
+                "skills_resolution_failed",
+                "Failed to resolve request skills",
+            )
+        }
+    }
 }
 
 pub fn extract_error_code_from_response<B>(response: &Response<B>) -> &str {

--- a/model_gateway/src/routers/router_manager.rs
+++ b/model_gateway/src/routers/router_manager.rs
@@ -36,7 +36,11 @@ use openai_protocol::{
     transcription::TranscriptionRequest,
 };
 use serde_json::Value;
-use smg_skills::SkillService;
+use smg_skills::{
+    resolve_messages_skill_manifest, resolve_responses_skill_manifest,
+    validate_messages_reserved_skill_tool_names, validate_responses_reserved_skill_tool_names,
+    SkillService,
+};
 use tracing::{debug, info, warn};
 
 use crate::{
@@ -44,10 +48,8 @@ use crate::{
     config::RoutingMode,
     middleware::TenantRequestMeta,
     routers::{
-        common::{
-            header_utils::apply_provider_headers,
-            skill_resolution::{resolve_messages_skill_manifest, resolve_responses_skill_manifest},
-        },
+        common::header_utils::apply_provider_headers,
+        error as route_error,
         factory::{router_ids, RouterId},
         AudioFile, RouterFactory, RouterTrait,
     },
@@ -588,18 +590,21 @@ impl RouterTrait for RouterManager {
         body: &CreateMessageRequest,
         model_id: &str,
     ) -> Response {
-        let router = self.select_router_for_request(headers, Some(model_id));
+        if let Err(error) = validate_messages_reserved_skill_tool_names(body.tools.as_deref()) {
+            return route_error::reserved_skill_tool_name(error);
+        }
 
+        let router = self.select_router_for_request(headers, Some(model_id));
         if let Some(router) = router {
             let skill_manifest = match resolve_messages_skill_manifest(
                 self.skill_service.as_deref(),
-                tenant_meta.tenant_key(),
+                tenant_meta.tenant_key().as_str(),
                 body,
             )
             .await
             {
                 Ok(manifest) => manifest,
-                Err(error) => return error.into_response(),
+                Err(error) => return route_error::skill_resolution_error(error),
             };
             let tenant_meta = if skill_manifest.is_empty() {
                 tenant_meta.clone()
@@ -625,18 +630,21 @@ impl RouterTrait for RouterManager {
         body: &ResponsesRequest,
         model_id: &str,
     ) -> Response {
-        let router = self.select_router_for_request(headers, Some(model_id));
+        if let Err(error) = validate_responses_reserved_skill_tool_names(body.tools.as_deref()) {
+            return route_error::reserved_skill_tool_name(error);
+        }
 
+        let router = self.select_router_for_request(headers, Some(model_id));
         if let Some(router) = router {
             let skill_manifest = match resolve_responses_skill_manifest(
                 self.skill_service.as_deref(),
-                tenant_meta.tenant_key(),
+                tenant_meta.tenant_key().as_str(),
                 body,
             )
             .await
             {
                 Ok(manifest) => manifest,
-                Err(error) => return error.into_response(),
+                Err(error) => return route_error::skill_resolution_error(error),
             };
             let tenant_meta = if skill_manifest.is_empty() {
                 tenant_meta.clone()


### PR DESCRIPTION
Summary:
- Move skill request resolution into smg-skills instead of keeping it under gateway router common code.
- Move reserved skill tool protocol adapters and canonical tool schemas into smg-skills.
- Keep RouterManager responsible for HTTP mapping and attaching the resolved manifest to request metadata.

Tests:
- cargo +nightly fmt --all
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Skill version pinning (Default/Latest/Exact/Numbered) and new public types/APIs for resolving pinned versions.
  * OpenAI-compatible adapters for message/response skill tools.
  * Canonical skill tool definitions and execute gating based on executor config and code presence.
  * Validation helpers to detect reserved skill tool names.

* **Bug Fixes / Behavior**
  * Requests with reserved skill tool names now return clear 400 errors.
  * Improved, more specific skill-resolution error responses.

* **Chores**
  * Updated runtime dependency declarations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->