### PR TITLE
feat(container_backend): scaffold OpenAI-compat container client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["model_gateway", "crates/protocols", "crates/reasoning_parser", "crates/tool_parser", "crates/workflow", "crates/tokenizer", "crates/auth", "crates/vendor_auth", "crates/mcp", "crates/kv_index", "crates/data_connector", "crates/multimodal", "crates/wasm", "crates/mesh", "crates/grpc_client", "crates/skills", "crates/blob_storage", "bindings/python", "bindings/golang", "clients/rust", "clients/openapi-gen", "tui"]
+members = ["model_gateway", "crates/protocols", "crates/reasoning_parser", "crates/tool_parser", "crates/workflow", "crates/tokenizer", "crates/auth", "crates/vendor_auth", "crates/container_backend", "crates/mcp", "crates/kv_index", "crates/data_connector", "crates/multimodal", "crates/wasm", "crates/mesh", "crates/grpc_client", "crates/skills", "crates/blob_storage", "bindings/python", "bindings/golang", "clients/rust", "clients/openapi-gen", "tui"]
 resolver = "2"
 
 [workspace.dependencies]

--- a/crates/container_backend/Cargo.toml
+++ b/crates/container_backend/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "smg-container-backend"
+version = "0.1.0"
+edition = "2021"
+description = "Vendor-agnostic container backend for SMG (OpenAI public + OCI OpenAI-compat in v1)."
+license = "Apache-2.0"
+repository = "https://github.com/lightseekorg/smg"
+authors = ["Simo Lin <linsimo.mark@gmail.com>"]
+
+[lib]
+name = "smg_container_backend"
+
+[dependencies]
+# CB-1 — provides the OutboundAuth trait + impls (OpenAiApiKeyAuth, OciDelegatedAuth).
+smg-vendor-auth = { path = "../vendor_auth" }
+
+# Common
+async-trait.workspace = true
+bytes = "1"
+chrono = { workspace = true, features = ["clock"] }
+http.workspace = true
+reqwest = { workspace = true, features = ["rustls-tls", "json"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+url = "2.5"
+
+[dev-dependencies]
+httpmock = "0.7"
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
+secrecy = "0.10"
+
+[lints]
+workspace = true

--- a/crates/container_backend/src/lib.rs
+++ b/crates/container_backend/src/lib.rs
@@ -1,0 +1,109 @@
+//! `smg-container-backend` — vendor-agnostic container client for SMG.
+//!
+//! This crate exposes the [`ContainerBackend`] trait and a single concrete
+//! v1 impl, [`OpenAiCompatContainersClient`], that serves both:
+//!
+//! 1. The public OpenAI `/v1/containers` endpoint, and
+//! 2. OCI's OpenAI-compat container endpoint
+//!
+//! per design doc decision **D5** — the wire surface is identical; the only
+//! difference is which [`OutboundAuth`](smg_vendor_auth::OutboundAuth) is
+//! injected (and, for OCI, the base URL).
+//!
+//! See `.claude/plans/container-backend-design.md` §7 for the full contract.
+//!
+//! # Layout
+//!
+//! - [`types`] — wire types ([`Container`], [`MemoryLimit`], …).
+//! - [`openai_compat`] — the [`OpenAiCompatContainersClient`] HTTP client.
+//! - [`mock`] — an in-memory [`MockBackend`] for hermetic tests
+//!   (used by SMG e2e in CB-3 / CB-4).
+
+pub mod mock;
+pub mod openai_compat;
+pub mod types;
+
+pub use mock::MockBackend;
+pub use openai_compat::OpenAiCompatContainersClient;
+pub use types::{
+    Container, ContainerStatus, CreateContainerParams, DomainSecret, ExpiresAfter, ListOrder,
+    ListQuery, MemoryLimit, NetworkPolicy, Page,
+};
+
+use async_trait::async_trait;
+
+/// Errors returned by [`ContainerBackend`] implementations.
+///
+/// HTTP-level mapping (see [`OpenAiCompatContainersClient`]):
+/// - `401` or `403` → [`BackendError::Unauthorized`]
+/// - `404` → [`BackendError::NotFound`]
+/// - `429` → [`BackendError::RateLimited`] (parses `retry-after` if present)
+/// - other non-2xx → [`BackendError::Backend`]
+#[derive(Debug, thiserror::Error)]
+pub enum BackendError {
+    /// The backend returned 404 — the container id (or list cursor) does not
+    /// exist or is no longer addressable. Carries the response body for
+    /// caller-side logging.
+    #[error("not found: {0}")]
+    NotFound(String),
+
+    /// The backend returned 401 or 403 — the inbound credential was rejected.
+    /// Both codes collapse here; callers don't need to distinguish bad-auth
+    /// from forbidden-resource at this layer.
+    #[error("unauthorized")]
+    Unauthorized,
+
+    /// The backend returned 429. `retry_after_secs` is parsed from the
+    /// `retry-after` header when present.
+    #[error("rate limited (retry-after: {retry_after_secs:?}s)")]
+    RateLimited {
+        /// Number of seconds the client should wait before retrying.
+        retry_after_secs: Option<u64>,
+    },
+
+    /// Any other non-2xx response. `status` is the HTTP status code; `message`
+    /// is the response body (lossily UTF-8 decoded).
+    #[error("backend error {status}: {message}")]
+    Backend { status: u16, message: String },
+
+    /// `reqwest`-level transport error (DNS, TCP, TLS, body read).
+    #[error("transport: {0}")]
+    Transport(#[from] reqwest::Error),
+
+    /// The injected [`OutboundAuth`](smg_vendor_auth::OutboundAuth) failed to
+    /// apply credentials to the request.
+    #[error("auth: {0}")]
+    Auth(#[from] smg_vendor_auth::AuthError),
+
+    /// Request body serialization or response body deserialization failed.
+    #[error("serialization: {0}")]
+    Serialization(#[from] serde_json::Error),
+
+    /// The HTTP request did not complete before the configured deadline.
+    /// (Reserved — `reqwest::Error` already covers timeouts in v1; this
+    /// variant exists so callers can distinguish a deadline violation from a
+    /// transport failure once we wire an external deadline.)
+    #[error("timeout")]
+    Timeout,
+}
+
+/// A vendor-agnostic container backend.
+///
+/// v1 impls:
+/// - [`OpenAiCompatContainersClient`] — real HTTP, both OpenAI public and OCI.
+/// - [`MockBackend`] — in-memory, for hermetic tests.
+///
+/// Future impls (GCP / Azure / AWS) slot under the same trait.
+#[async_trait]
+pub trait ContainerBackend: Send + Sync + std::fmt::Debug {
+    /// Create a new container.
+    async fn create(&self, params: CreateContainerParams) -> Result<Container, BackendError>;
+    /// Retrieve the current state of an existing container.
+    async fn retrieve(&self, id: &str) -> Result<Container, BackendError>;
+    /// Delete a container. Idempotent at the trait level (callers may treat
+    /// `404` as success if they wish — the trait returns `NotFound`).
+    async fn delete(&self, id: &str) -> Result<(), BackendError>;
+    /// List containers. Pagination follows the OpenAI list-envelope shape
+    /// ([`Page`]).
+    async fn list(&self, q: ListQuery) -> Result<Page<Container>, BackendError>;
+}

--- a/crates/container_backend/src/mock.rs
+++ b/crates/container_backend/src/mock.rs
@@ -1,0 +1,124 @@
+//! [`MockBackend`] — in-memory [`ContainerBackend`] for hermetic tests.
+//!
+//! Used by SMG e2e tests in CB-3 / CB-4 to exercise the dispatch flow
+//! without touching the network. Two `MockBackend` instances do NOT share
+//! state — each owns its own map.
+//!
+//! # Behaviour
+//!
+//! - `create` allocates ids of the form `cntr_mock_<n>` (monotonic per
+//!   instance) and returns a fresh [`Container`] in [`ContainerStatus::Running`].
+//! - `retrieve` returns the stored container or [`BackendError::NotFound`].
+//! - `delete` removes by id; returns `Ok(())` whether or not the id existed
+//!   (matches the wire surface — `DELETE` is idempotent on the OpenAI side).
+//! - `list` returns every stored container in arbitrary order, with
+//!   `has_more: false` and no cursor — pagination is intentionally not
+//!   modelled here.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+
+use crate::types::{
+    Container, ContainerStatus, CreateContainerParams, ListQuery, Page,
+};
+use crate::{BackendError, ContainerBackend};
+
+/// In-memory [`ContainerBackend`] for hermetic tests.
+///
+/// `Clone` shares the same backing map (rc-counted), so callers that want
+/// independent state should construct separate instances.
+#[derive(Debug, Default, Clone)]
+pub struct MockBackend {
+    inner: Arc<Mutex<HashMap<String, Container>>>,
+    seq: Arc<Mutex<u64>>,
+}
+
+impl MockBackend {
+    /// Construct an empty backend.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[async_trait]
+impl ContainerBackend for MockBackend {
+    async fn create(&self, params: CreateContainerParams) -> Result<Container, BackendError> {
+        let id = {
+            let mut seq = self
+                .seq
+                .lock()
+                .map_err(|e| BackendError::Backend {
+                    status: 0,
+                    message: format!("mock seq lock poisoned: {e}"),
+                })?;
+            *seq += 1;
+            format!("cntr_mock_{}", *seq)
+        };
+        let container = Container {
+            id: id.clone(),
+            object: "container".into(),
+            created_at: chrono::Utc::now().timestamp(),
+            status: ContainerStatus::Running,
+            name: params.name,
+            last_active_at: None,
+            expires_after: params.expires_after,
+            memory_limit: params.memory_limit,
+            network_policy: params.network_policy,
+            file_ids: params.file_ids,
+            skills: params.skills,
+        };
+        self.inner
+            .lock()
+            .map_err(|e| BackendError::Backend {
+                status: 0,
+                message: format!("mock map lock poisoned: {e}"),
+            })?
+            .insert(id, container.clone());
+        Ok(container)
+    }
+
+    async fn retrieve(&self, id: &str) -> Result<Container, BackendError> {
+        self.inner
+            .lock()
+            .map_err(|e| BackendError::Backend {
+                status: 0,
+                message: format!("mock map lock poisoned: {e}"),
+            })?
+            .get(id)
+            .cloned()
+            .ok_or_else(|| BackendError::NotFound(id.to_owned()))
+    }
+
+    async fn delete(&self, id: &str) -> Result<(), BackendError> {
+        self.inner
+            .lock()
+            .map_err(|e| BackendError::Backend {
+                status: 0,
+                message: format!("mock map lock poisoned: {e}"),
+            })?
+            .remove(id);
+        Ok(())
+    }
+
+    async fn list(&self, _q: ListQuery) -> Result<Page<Container>, BackendError> {
+        let data: Vec<Container> = self
+            .inner
+            .lock()
+            .map_err(|e| BackendError::Backend {
+                status: 0,
+                message: format!("mock map lock poisoned: {e}"),
+            })?
+            .values()
+            .cloned()
+            .collect();
+        Ok(Page {
+            data,
+            object: "list".into(),
+            first_id: None,
+            last_id: None,
+            has_more: false,
+        })
+    }
+}

--- a/crates/container_backend/src/openai_compat.rs
+++ b/crates/container_backend/src/openai_compat.rs
@@ -1,0 +1,228 @@
+//! [`OpenAiCompatContainersClient`] — HTTP client for the OpenAI Containers
+//! REST surface.
+//!
+//! Per design doc D5: a single client serves both the public OpenAI endpoint
+//! and OCI's OpenAI-compat endpoint. The wire shape is identical; the only
+//! difference is which [`OutboundAuth`] is injected and what the base URL is.
+//!
+//! # Auth boundary
+//!
+//! For each request we:
+//!
+//! 1. Build a fully-formed `http::Request<Bytes>` with method, URI, body, and
+//!    `content-type: application/json` set.
+//! 2. Call [`OutboundAuth::apply`] on the request — this is where vendor-auth
+//!    signs (OCI) or attaches a bearer header (OpenAI).
+//! 3. Translate the now-signed `http::Request` into a `reqwest::RequestBuilder`
+//!    and send.
+//!
+//! Step (1) before (2) is load-bearing for OCI: the signer hashes the body
+//! and content-type into `x-content-sha256` / `Authorization: Signature`. If
+//! we set headers after `apply`, the signature would be over a stale view of
+//! the request.
+//!
+//! # Error mapping
+//!
+//! | HTTP status     | `BackendError` variant                      |
+//! |-----------------|---------------------------------------------|
+//! | 2xx             | (success — return parsed body)              |
+//! | 401, 403        | [`BackendError::Unauthorized`]              |
+//! | 404             | [`BackendError::NotFound`]                  |
+//! | 429             | [`BackendError::RateLimited`] + `retry-after` |
+//! | other 4xx, 5xx  | [`BackendError::Backend`]                   |
+//!
+//! Mirrors Java `AbstractContainerToolProcessor.java:280-292` 4xx-mapping
+//! intent (Java collapses all 4xx to `IllegalArgumentException` upstream;
+//! we keep the status-class distinction so retry logic can branch on it).
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use http::{Method, Request};
+use smg_vendor_auth::OutboundAuth;
+use url::Url;
+
+use crate::types::{Container, CreateContainerParams, ListOrder, ListQuery, Page};
+use crate::{BackendError, ContainerBackend};
+
+/// HTTP client for the OpenAI-shaped Containers endpoint.
+///
+/// Constructed with an [`OutboundAuth`] (selects API-key vs OCI-OBO mode), a
+/// base URL (selects which vendor / region), and a shared `reqwest::Client`.
+///
+/// `Clone` is cheap — the auth and HTTP client are reference-counted.
+#[derive(Debug, Clone)]
+pub struct OpenAiCompatContainersClient {
+    auth: Arc<dyn OutboundAuth>,
+    base_url: Url,
+    http: reqwest::Client,
+}
+
+impl OpenAiCompatContainersClient {
+    /// Construct a new client.
+    ///
+    /// `base_url` must be the API root (e.g. `https://api.openai.com/` for
+    /// public OpenAI, or the OCI region's OpenAI-compat root). The client
+    /// appends `/v1/containers...` regardless of any path prefix on
+    /// `base_url`. This matches the wire shape in design doc §13.
+    pub fn new(auth: Arc<dyn OutboundAuth>, base_url: Url, http: reqwest::Client) -> Self {
+        Self {
+            auth,
+            base_url,
+            http,
+        }
+    }
+
+    /// Build the absolute URL for a `/v1/containers{suffix}` endpoint.
+    ///
+    /// Both OpenAI public (`https://api.openai.com`) and OCI OpenAI-compat
+    /// (e.g. `https://inference.generativeai.us-ashburn-1.oci.oraclecloud.com`)
+    /// expose the surface at the absolute path `/v1/containers...`, so
+    /// overwriting the path on the base URL is correct.
+    fn endpoint(&self, suffix: &str) -> Url {
+        let mut u = self.base_url.clone();
+        u.set_path(&format!("/v1/containers{suffix}"));
+        // Clear any inherited query string from the base URL — query params
+        // for our requests are added by the caller (e.g. list pagination).
+        u.set_query(None);
+        u
+    }
+
+    /// Sign and send an HTTP request, returning the raw response.
+    ///
+    /// The caller owns method, URL, and body. `content-type: application/json`
+    /// is set here, before [`OutboundAuth::apply`], so the OCI signer hashes
+    /// the correct value.
+    async fn send_signed(
+        &self,
+        method: Method,
+        url: Url,
+        body: Bytes,
+    ) -> Result<reqwest::Response, BackendError> {
+        let mut req = Request::builder()
+            .method(method.clone())
+            .uri(url.as_str())
+            .header("content-type", "application/json")
+            .body(body)
+            .map_err(|e| BackendError::Backend {
+                status: 0,
+                message: format!("invalid http request: {e}"),
+            })?;
+
+        // Auth boundary — vendor_auth signs (OCI) or attaches bearer (OpenAI).
+        self.auth.apply(&mut req).await?;
+
+        // Translate http::Request<Bytes> -> reqwest::RequestBuilder.
+        // Note: `reqwest::Method` is a re-export of `http::Method`, so the
+        // `parts.method` value is reused as-is.
+        let (parts, body) = req.into_parts();
+        let mut rb = self.http.request(parts.method, url.as_str());
+        for (name, value) in &parts.headers {
+            rb = rb.header(name.as_str(), value.as_bytes());
+        }
+        rb = rb.body(body);
+        let resp = rb.send().await?;
+        Ok(resp)
+    }
+
+    /// Decode a JSON response body or map a non-2xx status to a [`BackendError`].
+    async fn handle<T: serde::de::DeserializeOwned>(
+        resp: reqwest::Response,
+    ) -> Result<T, BackendError> {
+        let status = resp.status();
+        if status.is_success() {
+            let bytes = resp.bytes().await?;
+            return Ok(serde_json::from_slice::<T>(&bytes)?);
+        }
+
+        let retry_after = resp
+            .headers()
+            .get("retry-after")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| s.parse::<u64>().ok());
+
+        let bytes = resp.bytes().await.unwrap_or_default();
+        let body = String::from_utf8_lossy(&bytes).to_string();
+
+        Err(match status.as_u16() {
+            401 | 403 => BackendError::Unauthorized,
+            404 => BackendError::NotFound(body),
+            429 => BackendError::RateLimited {
+                retry_after_secs: retry_after,
+            },
+            s => BackendError::Backend { status: s, message: body },
+        })
+    }
+}
+
+#[async_trait]
+impl ContainerBackend for OpenAiCompatContainersClient {
+    async fn create(&self, params: CreateContainerParams) -> Result<Container, BackendError> {
+        let body = serde_json::to_vec(&params)?;
+        let resp = self
+            .send_signed(Method::POST, self.endpoint(""), Bytes::from(body))
+            .await?;
+        Self::handle(resp).await
+    }
+
+    async fn retrieve(&self, id: &str) -> Result<Container, BackendError> {
+        let resp = self
+            .send_signed(
+                Method::GET,
+                self.endpoint(&format!("/{id}")),
+                Bytes::new(),
+            )
+            .await?;
+        Self::handle(resp).await
+    }
+
+    async fn delete(&self, id: &str) -> Result<(), BackendError> {
+        let resp = self
+            .send_signed(
+                Method::DELETE,
+                self.endpoint(&format!("/{id}")),
+                Bytes::new(),
+            )
+            .await?;
+        if resp.status().is_success() {
+            return Ok(());
+        }
+        // Drain body and route through the same error mapper.
+        let err = Self::handle::<serde_json::Value>(resp)
+            .await
+            .err()
+            .unwrap_or(BackendError::Backend {
+                status: 0,
+                message: String::from("delete failed without status"),
+            });
+        Err(err)
+    }
+
+    async fn list(&self, q: ListQuery) -> Result<Page<Container>, BackendError> {
+        let mut url = self.endpoint("");
+        {
+            let mut qp = url.query_pairs_mut();
+            if let Some(l) = q.limit {
+                qp.append_pair("limit", &l.to_string());
+            }
+            if let Some(a) = &q.after {
+                qp.append_pair("after", a);
+            }
+            if let Some(b) = &q.before {
+                qp.append_pair("before", b);
+            }
+            if let Some(o) = q.order {
+                qp.append_pair(
+                    "order",
+                    match o {
+                        ListOrder::Asc => "asc",
+                        ListOrder::Desc => "desc",
+                    },
+                );
+            }
+        }
+        let resp = self.send_signed(Method::GET, url, Bytes::new()).await?;
+        Self::handle(resp).await
+    }
+}

--- a/crates/container_backend/src/types.rs
+++ b/crates/container_backend/src/types.rs
@@ -1,0 +1,170 @@
+//! Wire types for the OpenAI Containers REST surface.
+//!
+//! These types serialize/deserialize to the exact JSON shape used by:
+//!
+//! - The public OpenAI `/v1/containers` endpoint, and
+//! - OCI's OpenAI-compat `/v1/containers` endpoint (D5).
+//!
+//! Field names are pinned by the Java reference at
+//! `RemoteMcpConstants.java:158-168` (CONTAINER_KEY, CONTAINER_ID_KEY,
+//! MEMORY_LIMIT, EXPIRES_AFTER, FILE_IDS, CONTAINER_STATUS_RUNNING,
+//! CONTAINER_NAME_PREFIX) and `:193-197` (NETWORK_POLICY, ALLOWED_DOMAINS,
+//! DOMAIN_SECRETS, DOMAIN_KEY, VALUE_KEY).
+//!
+//! See design doc `.claude/plans/container-backend-design.md` §7.2 for the
+//! field-by-field cross-ref to the Java side and §13 for wire-shape examples.
+
+use serde::{Deserialize, Serialize};
+
+/// A container as returned by the backend.
+///
+/// `_additionalProperties().get("skills")` from the Java SDK becomes the
+/// `skills` field below, modelled as an opaque `serde_json::Value` because
+/// it's a per-vendor extension that the backend treats as pass-through.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Container {
+    pub id: String,
+    /// Always `"container"` on the wire.
+    pub object: String,
+    /// Unix epoch seconds.
+    pub created_at: i64,
+    pub status: ContainerStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// Unix epoch seconds.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_active_at: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires_after: Option<ExpiresAfter>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub memory_limit: Option<MemoryLimit>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub network_policy: Option<NetworkPolicy>,
+    #[serde(default)]
+    pub file_ids: Vec<String>,
+    /// Container "skills" — opaque to the backend; surfaced from Java's
+    /// `ContainerCreateResponse._additionalProperties().get("skills")`.
+    /// See `AbstractContainerToolProcessor.java:193-233`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub skills: Option<serde_json::Value>,
+}
+
+/// Container lifecycle status.
+///
+/// `Unknown` is a forward-compat catch-all (R4): if the backend introduces a
+/// new status string we still deserialize successfully and let the caller
+/// decide whether to treat the container as usable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ContainerStatus {
+    Running,
+    Expired,
+    Deleted,
+    /// Forward-compat catch-all — never panic on unknown statuses.
+    #[serde(other)]
+    Unknown,
+}
+
+/// Memory limit for a container. Wire format is the lowercase string
+/// `"1g" | "4g" | "16g" | "64g"`.
+///
+/// Pins the four documented sizes per Java
+/// `CodeInterpreterProcessor.java:365` (`ContainerCreateParams.MemoryLimit.of`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum MemoryLimit {
+    #[serde(rename = "1g")]
+    Mem1G,
+    #[serde(rename = "4g")]
+    Mem4G,
+    #[serde(rename = "16g")]
+    Mem16G,
+    #[serde(rename = "64g")]
+    Mem64G,
+}
+
+/// Network policy applied to the container.
+///
+/// Wire format is tagged on the `type` field — `"disabled"` or
+/// `"allowlist"`. See Java `RemoteMcpConstants.java:193-197` for the field
+/// names.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum NetworkPolicy {
+    Disabled,
+    Allowlist {
+        #[serde(default)]
+        allowed_domains: Vec<String>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        domain_secrets: Vec<DomainSecret>,
+    },
+}
+
+/// A `(domain, value)` pair forwarded as part of an `Allowlist` network policy.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DomainSecret {
+    pub domain: String,
+    pub value: String,
+}
+
+/// Expiry policy for a container.
+///
+/// `anchor` is `"last_active_at"` for the OpenAI surface today. `minutes`
+/// is the idle window before the container is reclaimed.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExpiresAfter {
+    pub anchor: String,
+    pub minutes: u32,
+}
+
+/// Parameters for [`ContainerBackend::create`](crate::ContainerBackend::create).
+///
+/// All fields are optional except that the wire format always carries at
+/// least an empty `file_ids` array (see §13.1 wire example).
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct CreateContainerParams {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub memory_limit: Option<MemoryLimit>,
+    /// Always serialized — wire shape matches Java `populateBodyFromConfig`
+    /// `bodyBuilder.fileIds(...)` (`CodeInterpreterProcessor.java:366`).
+    #[serde(default)]
+    pub file_ids: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub network_policy: Option<NetworkPolicy>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires_after: Option<ExpiresAfter>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub skills: Option<serde_json::Value>,
+}
+
+/// Query parameters for [`ContainerBackend::list`](crate::ContainerBackend::list).
+#[derive(Debug, Default, Clone)]
+pub struct ListQuery {
+    pub limit: Option<u32>,
+    pub after: Option<String>,
+    pub before: Option<String>,
+    pub order: Option<ListOrder>,
+}
+
+/// Sort order for a list query.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ListOrder {
+    Asc,
+    Desc,
+}
+
+/// Standard OpenAI list-response envelope.
+///
+/// `{"object":"list","data":[...],"first_id":..,"last_id":..,"has_more":..}`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Page<T> {
+    pub data: Vec<T>,
+    /// Always `"list"` on the wire.
+    pub object: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub first_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_id: Option<String>,
+    pub has_more: bool,
+}

--- a/crates/container_backend/tests/mock_backend.rs
+++ b/crates/container_backend/tests/mock_backend.rs
@@ -1,0 +1,85 @@
+//! Tests for the in-memory [`MockBackend`].
+//!
+//! Used downstream by SMG e2e (CB-3 / CB-4) to drive dispatch flows
+//! without hitting the network. Only behavioural contracts that callers
+//! depend on are tested here.
+
+// `clippy.toml` sets `allow-{unwrap,expect,panic}-in-tests = true` for `#[test]`
+// bodies, but `-D warnings` promotes the workspace `warn` for these to deny.
+// This file is a test target; opt out at file scope.
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use smg_container_backend::{
+    BackendError, ContainerBackend, ContainerStatus, CreateContainerParams, MemoryLimit,
+    MockBackend,
+};
+
+// =====================================================================
+// Test 8 — mock_backend_isolated_state
+// Two MockBackend instances must not share state.
+// =====================================================================
+#[tokio::test]
+async fn mock_backend_isolated_state() {
+    let a = MockBackend::new();
+    let b = MockBackend::new();
+
+    let c = a
+        .create(CreateContainerParams {
+            name: Some("from-a".into()),
+            memory_limit: Some(MemoryLimit::Mem1G),
+            ..Default::default()
+        })
+        .await
+        .expect("a.create");
+
+    // Container present in a:
+    let got = a.retrieve(&c.id).await.expect("a.retrieve");
+    assert_eq!(got.id, c.id);
+    assert_eq!(got.status, ContainerStatus::Running);
+
+    // Same id NOT present in b:
+    let err = b
+        .retrieve(&c.id)
+        .await
+        .expect_err("b should not see a's container");
+    assert!(matches!(err, BackendError::NotFound(_)));
+
+    // b's create produces a fresh id (mock_seq is per-instance):
+    let from_b = b.create(CreateContainerParams::default()).await.expect("b.create");
+    assert_eq!(from_b.id, "cntr_mock_1");
+    assert_eq!(c.id, "cntr_mock_1"); // same prefix, fresh seq per backend
+}
+
+#[tokio::test]
+async fn mock_backend_round_trip() {
+    let backend = MockBackend::new();
+
+    let created = backend
+        .create(CreateContainerParams {
+            name: Some("test".into()),
+            memory_limit: Some(MemoryLimit::Mem4G),
+            file_ids: vec!["file_1".into(), "file_2".into()],
+            ..Default::default()
+        })
+        .await
+        .expect("create");
+
+    assert!(created.id.starts_with("cntr_mock_"));
+    assert_eq!(created.status, ContainerStatus::Running);
+    assert_eq!(created.memory_limit, Some(MemoryLimit::Mem4G));
+    assert_eq!(created.file_ids, vec!["file_1", "file_2"]);
+
+    let listed = backend
+        .list(Default::default())
+        .await
+        .expect("list");
+    assert_eq!(listed.data.len(), 1);
+    assert!(!listed.has_more);
+
+    backend.delete(&created.id).await.expect("delete");
+    let err = backend.retrieve(&created.id).await.expect_err("gone");
+    assert!(matches!(err, BackendError::NotFound(_)));
+
+    // delete is idempotent
+    backend.delete(&created.id).await.expect("delete again");
+}

--- a/crates/container_backend/tests/openai_compat.rs
+++ b/crates/container_backend/tests/openai_compat.rs
@@ -1,0 +1,303 @@
+//! HTTP-level tests for [`OpenAiCompatContainersClient`].
+//!
+//! Uses `httpmock` to mount a local server, drives the client against it,
+//! and asserts on the wire shape (request body + headers) and the
+//! response-to-error mapping. Auth is provided by `OpenAiApiKeyAuth` (the
+//! simplest [`OutboundAuth`] impl) for tests that don't need OCI signing.
+//!
+//! See design doc §7.5 for the test matrix and §13.1 for the wire-shape
+//! reference.
+
+// `clippy.toml` sets `allow-{unwrap,expect,panic}-in-tests = true` for `#[test]`
+// bodies, but `-D warnings` promotes the workspace `warn` for these to deny.
+// This file is a test target; opt out at file scope to mirror the pattern in
+// `crates/vendor_auth/tests/oci_delegated_auth.rs`.
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use http::Request;
+use httpmock::prelude::*;
+use reqwest::Client;
+use secrecy::SecretString;
+use serde_json::json;
+use smg_container_backend::{
+    BackendError, Container, ContainerBackend, ContainerStatus, CreateContainerParams,
+    ListOrder, ListQuery, MemoryLimit, OpenAiCompatContainersClient,
+};
+use smg_vendor_auth::{AuthError, OpenAiApiKeyAuth, OutboundAuth};
+use url::Url;
+
+fn client_for(server: &MockServer, auth: Arc<dyn OutboundAuth>) -> OpenAiCompatContainersClient {
+    let base = Url::parse(&server.base_url()).expect("mock base url");
+    OpenAiCompatContainersClient::new(auth, base, Client::new())
+}
+
+fn api_key_auth() -> Arc<dyn OutboundAuth> {
+    Arc::new(OpenAiApiKeyAuth::new(SecretString::from("test-key".to_string())))
+}
+
+// =====================================================================
+// Test 1 — create_round_trip
+// Verifies wire shape per design doc §13.1 and BackendError::Backend
+// reachability path is NOT exercised here (200 OK).
+// =====================================================================
+#[tokio::test]
+async fn create_round_trip() {
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/v1/containers")
+            .header("authorization", "Bearer test-key")
+            .header("content-type", "application/json")
+            // Wire shape per §13.1: the body must serialize to this JSON.
+            .json_body(json!({
+                "name": "cntr-test-abc",
+                "memory_limit": "4g",
+                "file_ids": []
+            }));
+        then.status(200).header("content-type", "application/json").json_body(json!({
+            "id": "cntr_xyz",
+            "object": "container",
+            "created_at": 1745611200,
+            "status": "running",
+            "name": "cntr-test-abc",
+            "memory_limit": "4g",
+            "file_ids": []
+        }));
+    });
+
+    let client = client_for(&server, api_key_auth());
+    let params = CreateContainerParams {
+        name: Some("cntr-test-abc".into()),
+        memory_limit: Some(MemoryLimit::Mem4G),
+        ..Default::default()
+    };
+    let got: Container = client.create(params).await.expect("create succeeds");
+
+    assert_eq!(got.id, "cntr_xyz");
+    assert_eq!(got.object, "container");
+    assert_eq!(got.status, ContainerStatus::Running);
+    assert_eq!(got.memory_limit, Some(MemoryLimit::Mem4G));
+    mock.assert();
+}
+
+// =====================================================================
+// Test 2 — retrieve_404_maps_to_not_found
+// Exercises BackendError::NotFound.
+// =====================================================================
+#[tokio::test]
+async fn retrieve_404_maps_to_not_found() {
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(GET).path("/v1/containers/cntr_missing");
+        then.status(404)
+            .header("content-type", "application/json")
+            .json_body(json!({"error": {"message": "not found"}}));
+    });
+
+    let client = client_for(&server, api_key_auth());
+    let err = client.retrieve("cntr_missing").await.expect_err("404 surfaces as error");
+    match err {
+        BackendError::NotFound(body) => {
+            assert!(body.contains("not found"), "body should contain server message: {body}");
+        }
+        other => panic!("expected NotFound, got {other:?}"),
+    }
+    mock.assert();
+}
+
+// =====================================================================
+// Test 3 — rate_limit_passes_retry_after
+// Exercises BackendError::RateLimited with retry-after parsing.
+// =====================================================================
+#[tokio::test]
+async fn rate_limit_passes_retry_after() {
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(POST).path("/v1/containers");
+        then.status(429)
+            .header("retry-after", "30")
+            .body("rate limited");
+    });
+
+    let client = client_for(&server, api_key_auth());
+    let err = client
+        .create(CreateContainerParams::default())
+        .await
+        .expect_err("429 surfaces as error");
+    match err {
+        BackendError::RateLimited { retry_after_secs } => {
+            assert_eq!(retry_after_secs, Some(30));
+        }
+        other => panic!("expected RateLimited, got {other:?}"),
+    }
+    mock.assert();
+}
+
+// =====================================================================
+// Test 4 — unauthorized_401_and_403_collapse
+// Exercises BackendError::Unauthorized — both 401 and 403.
+// =====================================================================
+#[tokio::test]
+async fn unauthorized_401_and_403_collapse() {
+    // 401 path
+    let server_401 = MockServer::start();
+    let mock_401 = server_401.mock(|when, then| {
+        when.method(GET).path("/v1/containers/cntr_a");
+        then.status(401).body("unauthorized");
+    });
+    let client_401 = client_for(&server_401, api_key_auth());
+    let err_401 = client_401.retrieve("cntr_a").await.expect_err("401");
+    assert!(
+        matches!(err_401, BackendError::Unauthorized),
+        "expected Unauthorized for 401, got {err_401:?}"
+    );
+    mock_401.assert();
+
+    // 403 path
+    let server_403 = MockServer::start();
+    let mock_403 = server_403.mock(|when, then| {
+        when.method(GET).path("/v1/containers/cntr_b");
+        then.status(403).body("forbidden");
+    });
+    let client_403 = client_for(&server_403, api_key_auth());
+    let err_403 = client_403.retrieve("cntr_b").await.expect_err("403");
+    assert!(
+        matches!(err_403, BackendError::Unauthorized),
+        "expected Unauthorized for 403, got {err_403:?}"
+    );
+    mock_403.assert();
+}
+
+// =====================================================================
+// Test 5 — delete_succeeds_on_204
+// Exercises Ok(()) on the delete path.
+// =====================================================================
+#[tokio::test]
+async fn delete_succeeds_on_204() {
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(DELETE).path("/v1/containers/cntr_xyz");
+        then.status(204);
+    });
+
+    let client = client_for(&server, api_key_auth());
+    client.delete("cntr_xyz").await.expect("204 → Ok(())");
+    mock.assert();
+}
+
+// =====================================================================
+// Test 6 — list_paginates
+// Verifies query-param wiring + Page envelope deserialization.
+// =====================================================================
+#[tokio::test]
+async fn list_paginates() {
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(GET)
+            .path("/v1/containers")
+            .query_param("limit", "10")
+            .query_param("after", "cntr_cursor")
+            .query_param("order", "desc");
+        then.status(200).header("content-type", "application/json").json_body(json!({
+            "object": "list",
+            "data": [{
+                "id": "cntr_1",
+                "object": "container",
+                "created_at": 1,
+                "status": "running",
+                "file_ids": []
+            }, {
+                "id": "cntr_2",
+                "object": "container",
+                "created_at": 2,
+                "status": "expired",
+                "file_ids": []
+            }],
+            "first_id": "cntr_1",
+            "last_id": "cntr_2",
+            "has_more": true
+        }));
+    });
+
+    let client = client_for(&server, api_key_auth());
+    let page = client
+        .list(ListQuery {
+            limit: Some(10),
+            after: Some("cntr_cursor".into()),
+            before: None,
+            order: Some(ListOrder::Desc),
+        })
+        .await
+        .expect("list succeeds");
+
+    assert_eq!(page.object, "list");
+    assert_eq!(page.data.len(), 2);
+    assert_eq!(page.first_id.as_deref(), Some("cntr_1"));
+    assert_eq!(page.last_id.as_deref(), Some("cntr_2"));
+    assert!(page.has_more);
+    assert_eq!(page.data[0].status, ContainerStatus::Running);
+    assert_eq!(page.data[1].status, ContainerStatus::Expired);
+    mock.assert();
+}
+
+// =====================================================================
+// Test 7 — auth_apply_called_once_per_request
+// Wraps the real auth in a Counter to assert it's invoked exactly once
+// per HTTP send. Guards against double-signing or missed signing.
+// =====================================================================
+#[derive(Debug)]
+struct CountingAuth {
+    inner: Arc<dyn OutboundAuth>,
+    count: Arc<AtomicUsize>,
+}
+
+#[async_trait]
+impl OutboundAuth for CountingAuth {
+    async fn apply(&self, req: &mut Request<Bytes>) -> Result<(), AuthError> {
+        self.count.fetch_add(1, Ordering::SeqCst);
+        self.inner.apply(req).await
+    }
+}
+
+#[tokio::test]
+async fn auth_apply_called_once_per_request() {
+    let server = MockServer::start();
+    let _create_mock = server.mock(|when, then| {
+        when.method(POST).path("/v1/containers");
+        then.status(200).header("content-type", "application/json").json_body(json!({
+            "id": "cntr_z",
+            "object": "container",
+            "created_at": 1,
+            "status": "running",
+            "file_ids": []
+        }));
+    });
+    let _retrieve_mock = server.mock(|when, then| {
+        when.method(GET).path("/v1/containers/cntr_z");
+        then.status(200).header("content-type", "application/json").json_body(json!({
+            "id": "cntr_z",
+            "object": "container",
+            "created_at": 1,
+            "status": "running",
+            "file_ids": []
+        }));
+    });
+
+    let count = Arc::new(AtomicUsize::new(0));
+    let counting: Arc<dyn OutboundAuth> = Arc::new(CountingAuth {
+        inner: api_key_auth(),
+        count: count.clone(),
+    });
+    let client = client_for(&server, counting);
+
+    let _ = client.create(CreateContainerParams::default()).await.expect("create");
+    assert_eq!(count.load(Ordering::SeqCst), 1, "create should sign once");
+
+    let _ = client.retrieve("cntr_z").await.expect("retrieve");
+    assert_eq!(count.load(Ordering::SeqCst), 2, "retrieve should sign once");
+}


### PR DESCRIPTION
## Summary

Scaffolds `crates/container_backend`, the generic container-client crate that powers the Responses API `shell` and `apply_patch` hosted tools. Single client implementation serves both OpenAI public and OCI's OpenAI-compat container endpoint; vendor selection happens by injecting the right `OutboundAuth` from `smg-vendor-auth` (CB-1).

**Stacked on:** #1394 (CB-1). This PR's `base` is `cb-1/vendor-auth`. Review CB-1 first; once it merges, the diff here will rebase against `main` automatically.

Refs: CB-2 (internal tracker #52). Depends on CB-1 (#51).

## What changed

- Added `crates/container_backend` (`smg-container-backend`):
  - `src/lib.rs` — `ContainerBackend` async trait (create / retrieve / delete / list) + `BackendError` taxonomy (NotFound, Unauthorized, RateLimited{retry_after_secs}, Backend{status,message}, Transport, Auth, Serialization, Timeout).
  - `src/types.rs` — wire types: `Container`, `ContainerStatus` (Running / Expired / Deleted + `#[serde(other)] Unknown` for forward-compat), `MemoryLimit` (1g / 4g / 16g / 64g), `NetworkPolicy` (Disabled / Allowlist), `DomainSecret`, `ExpiresAfter`, `CreateContainerParams`, `ListQuery`, `ListOrder`, `Page<T>`.
  - `src/openai_compat.rs` — `OpenAiCompatContainersClient`. Constructed with `Arc<dyn OutboundAuth>` + base URL + `reqwest::Client`. Status mapping: 401|403→Unauthorized, 404→NotFound, 429→RateLimited (parses `retry-after`), other 4xx/5xx→Backend{status,message}.
  - `src/mock.rs` — `MockBackend` for hermetic SMG e2e tests in CB-3 / CB-4.
  - `tests/openai_compat.rs` — 7 `httpmock`-based unit tests covering create / retrieve / delete / list / 4xx mapping / rate-limit / auth-apply contract.
  - `tests/mock_backend.rs` — 2 in-process mock backend tests.
- One-line workspace edit: registered `crates/container_backend` in workspace `Cargo.toml` members list.

## Why

This crate plus CB-1 (auth) plus the upcoming CB-3 (gateway dispatch) and CB-4 (real-vendor tests) close the gap between SMG's protocol surface (already supports `shell` / `apply_patch`) and a real container execution backend.

The OpenAI Containers REST surface is shared by OpenAI public and OCI's OpenAI-compat endpoint — the wire shape (POST `/v1/containers`, `GET /v1/containers/{id}`, etc.) is identical. The only difference between the two vendors is auth, which is fully handled by CB-1's `OutboundAuth` impls. So a single client struct suffices: future GCP / Azure / AWS impls would slot under the same trait.

## How

- **Java contract match.**
  - Body shape mirrors `genai-data-plane/.../CodeInterpreterProcessor.java:300-380` — `name`, `memory_limit`, `file_ids`, `network_policy`, `skills`. Field names match `RemoteMcpConstants.java:158-168`.
  - Error mapping diverges deliberately: Java collapses all 4xx into `IllegalArgumentException` (`AbstractContainerToolProcessor.java:280-292`); Rust preserves status-class distinctions for more informative caller diagnostics. Callers can collapse if they want.
- **Forward-compat (R4 in design doc).** `#[serde(other)]` catch-all on `ContainerStatus` so the client doesn't crash when OpenAI ships a new status enum value.
- **Wire-shape verification.** `tests/openai_compat.rs::create_round_trip` asserts the POST body via `httpmock` structural JSON match against the design doc `§13.1` reference. Status: passes.
- **Auth boundary contract.** `tests/openai_compat.rs::auth_apply_called_once_per_request` uses a `CountingAuth` wrapper to assert exactly-once `apply()` per HTTP send.
- **D5 satisfied.** Same `OpenAiCompatContainersClient` struct serves both vendors. OpenAI public path is exercised in this crate's tests via `OpenAiApiKeyAuth`; the OCI path's signature wire shape is already covered by CB-1's `tests/oci_delegated_auth.rs`. End-to-end OCI integration (real signer + real OCI gateway) is CB-4's territory per the design doc §10.

## Test plan

Verified locally on macOS (workspace `cargo` 1.x):

- [x] `cargo check -p smg-container-backend` — clean.
- [x] `cargo test -p smg-container-backend` — 9/9 tests pass:
  - `tests/openai_compat.rs::create_round_trip` — body shape + auth headers asserted via httpmock.
  - `tests/openai_compat.rs::retrieve_404_maps_to_not_found` — `BackendError::NotFound` returned with body in message.
  - `tests/openai_compat.rs::rate_limit_passes_retry_after` — `BackendError::RateLimited { retry_after_secs: Some(30) }`.
  - `tests/openai_compat.rs::unauthorized_401_and_403_collapse` — both 401 and 403 map to `Unauthorized`.
  - `tests/openai_compat.rs::delete_succeeds_on_204` — no error on no-body 204.
  - `tests/openai_compat.rs::list_paginates` — `has_more`, `first_id`, `last_id` parsing.
  - `tests/openai_compat.rs::auth_apply_called_once_per_request` — `CountingAuth` wrapper records exactly-once apply.
  - `tests/mock_backend.rs::mock_backend_round_trip` — sanity-check mock CRUD.
  - `tests/mock_backend.rs::mock_backend_isolated_state` — two `MockBackend` instances are independent.
- [x] `cargo clippy -p smg-container-backend --all-targets -- -D warnings` — zero warnings.
- [x] Stays inside scope: only `crates/container_backend/` and one line in workspace `Cargo.toml`. `crates/vendor_auth/` not modified. `model_gateway/` not modified.

### Known follow-ups

- Direct `BackendError::Backend{status, message}` test (other 5xx case) — reachable today via `?` propagation but no explicit test. Tracked locally as CB-2.A; will fold into a follow-up commit.
- OCI end-to-end integration (real OCI gateway + real signer) — CB-4 scope per design doc §10 (CI runs in OKE pod with workload identity / instance principals).