### PR TITLE
fix(helm): add curl retry flags to test-connection pod

### DIFF
--- a/deploy/helm/smg/templates/tests/test-connection.yaml
+++ b/deploy/helm/smg/templates/tests/test-connection.yaml
@@ -13,5 +13,12 @@ spec:
       command:
         - curl
         - -sf
+        - --retry
+        - "10"
+        - --retry-connrefused
+        - --retry-delay
+        - "3"
+        - --retry-max-time
+        - "60"
         - http://{{ include "smg.fullname" . }}-router:{{ .Values.router.service.port }}/health
   restartPolicy: Never


### PR DESCRIPTION
## Description

### Problem
The `smg-test-connection` Helm test pod fails intermittently with curl exit code 7 ("Failed to connect to host") because it runs immediately after deployment and the router may not have finished binding to its port yet. 

### Solution
Add `--retry 10 --retry-connrefused --retry-delay 3 --retry-max-time 60` to the curl command so the test retries on connection refused for up to 60 seconds before failing, tolerating normal router startup latency. 

## Changes
- `deploy/helm/smg/templates/tests/test-connection.yaml`: add curl retry flags to the test-connection pod command

## Test Plan
 1. Deploy the chart: `helm upgrade --install smg ./deploy/helm/smg`                                                        
 2. Run the Helm test immediately: `helm test smg`
 3. Observe `smg-test-connection` pod reaches `Succeeded` 

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [x] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved deployment health verification resilience with enhanced retry mechanisms during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->