### PR TITLE
feat(memory): add STM condensation scheduling (STMO)

### DIFF
--- a/model_gateway/src/config/builder.rs
+++ b/model_gateway/src/config/builder.rs
@@ -183,6 +183,11 @@ impl RouterConfigBuilder {
         self
     }
 
+    pub fn max_conversation_history_items(mut self, max_items: usize) -> Self {
+        self.config.max_conversation_history_items = max_items;
+        self
+    }
+
     pub fn worker_startup_timeout_secs(mut self, timeout: u64) -> Self {
         self.config.worker_startup_timeout_secs = timeout;
         self

--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -106,6 +106,9 @@ pub struct RouterConfig {
     pub storage_context_headers: HashMap<String, String>,
     #[serde(default)]
     pub memory_runtime: MemoryRuntimeConfig,
+    /// Maximum conversation items to load into request context.
+    #[serde(default = "default_max_conversation_history_items")]
+    pub max_conversation_history_items: usize,
     #[serde(default)]
     pub background: BackgroundConfig,
     #[serde(default)]
@@ -217,6 +220,10 @@ pub struct TokenizerCacheConfig {
 
 fn default_load_monitor_interval_secs() -> u64 {
     10
+}
+
+fn default_max_conversation_history_items() -> usize {
+    100
 }
 
 fn default_enable_l0() -> bool {
@@ -628,8 +635,9 @@ impl Default for RouterConfig {
             policy: PolicyConfig::Random,
             host: "0.0.0.0".to_string(),
             port: 3001,
-            max_payload_size: 536_870_912,     // 512MB
-            request_timeout_secs: 1800,        // 30 minutes
+            max_payload_size: 536_870_912, // 512MB
+            request_timeout_secs: 1800,    // 30 minutes
+            max_conversation_history_items: default_max_conversation_history_items(),
             worker_startup_timeout_secs: 1800, // 30 minutes for large model loading
             worker_startup_check_interval_secs: 30,
             load_monitor_interval_secs: 10,
@@ -766,6 +774,7 @@ mod tests {
         assert_eq!(config.port, 3001);
         assert_eq!(config.max_payload_size, 536_870_912);
         assert_eq!(config.request_timeout_secs, 1800);
+        assert_eq!(config.max_conversation_history_items, 100);
         assert_eq!(config.worker_startup_timeout_secs, 1800);
         assert_eq!(config.worker_startup_check_interval_secs, 30);
         assert_eq!(config.load_monitor_interval_secs, 10);
@@ -955,6 +964,7 @@ stream_retention_secs: 3600
 
         assert!(deserialized.skills_enabled);
         assert!(deserialized.skills.is_none());
+        assert_eq!(deserialized.max_conversation_history_items, 100);
         assert!(!deserialized.tenant_resolution.trust_tenant_header);
         assert_eq!(
             deserialized.tenant_resolution.tenant_header_name,

--- a/model_gateway/src/config/validation.rs
+++ b/model_gateway/src/config/validation.rs
@@ -495,6 +495,14 @@ impl ConfigValidator {
             });
         }
 
+        if config.max_conversation_history_items == 0 {
+            return Err(ConfigError::InvalidValue {
+                field: "max_conversation_history_items".to_string(),
+                value: config.max_conversation_history_items.to_string(),
+                reason: "Must be > 0".to_string(),
+            });
+        }
+
         if config.queue_size > 0 && config.queue_timeout_secs == 0 {
             return Err(ConfigError::InvalidValue {
                 field: "queue_timeout_secs".to_string(),

--- a/model_gateway/src/memory/context.rs
+++ b/model_gateway/src/memory/context.rs
@@ -48,6 +48,8 @@ pub struct MemoryExecutionContext {
     pub subject_id: Option<String>,
     pub embedding_model: Option<String>,
     pub extraction_model: Option<String>,
+    pub stm_enabled: bool,
+    pub stm_condenser_model_id: Option<String>,
 }
 
 impl MemoryExecutionContext {
@@ -68,6 +70,7 @@ impl MemoryExecutionContext {
         }
         let store_ltm_requested = policy.allows_ltm_store();
         let recall_requested = policy.allows_recall();
+        let stm_enabled = headers.stm_enabled && runtime.enabled;
 
         Self {
             store_ltm: MemoryExecutionState::from_requested_and_runtime(
@@ -82,6 +85,10 @@ impl MemoryExecutionContext {
             subject_id: headers.subject_id.clone(),
             embedding_model: headers.embedding_model.clone(),
             extraction_model: headers.extraction_model.clone(),
+            stm_enabled,
+            stm_condenser_model_id: stm_enabled
+                .then_some(headers.stm_condenser_model_id.clone())
+                .flatten(),
         }
     }
 }
@@ -151,6 +158,8 @@ mod tests {
     fn store_and_recall_requested_but_not_active_when_runtime_disabled() {
         let headers = MemoryHeaderView {
             policy: Some("store_and_recall".to_string()),
+            stm_enabled: true,
+            stm_condenser_model_id: Some("condense-1".to_string()),
             ..MemoryHeaderView::default()
         };
 
@@ -159,6 +168,8 @@ mod tests {
         assert_eq!(ctx.store_ltm, MemoryExecutionState::GatedOff);
         assert_eq!(ctx.recall, MemoryExecutionState::GatedOff);
         assert_eq!(ctx.policy_mode, MemoryPolicyMode::StoreAndRecall);
+        assert!(!ctx.stm_enabled);
+        assert_eq!(ctx.stm_condenser_model_id, None);
     }
 
     #[test]
@@ -167,7 +178,7 @@ mod tests {
         headers.insert(
             "x-conversation-memory-config",
             HeaderValue::from_static(
-                r#"{"long_term_memory":{"enabled":true,"policy":"store_and_recall","subject_id":"  subject_abc  ","embedding_model_id":"  text-embedding-3-small  ","extraction_model_id":"  gpt-4.1-mini  "}}"#,
+                r#"{"long_term_memory":{"enabled":true,"policy":"store_and_recall","subject_id":"  subject_abc  ","embedding_model_id":"  text-embedding-3-small  ","extraction_model_id":"  gpt-4.1-mini  "},"short_term_memory":{"enabled":true,"condenser_model_id":"  condense-1  "}}"#,
             ),
         );
 
@@ -182,5 +193,7 @@ mod tests {
             Some("text-embedding-3-small")
         );
         assert_eq!(ctx.extraction_model.as_deref(), Some("gpt-4.1-mini"));
+        assert!(ctx.stm_enabled);
+        assert_eq!(ctx.stm_condenser_model_id.as_deref(), Some("condense-1"));
     }
 }

--- a/model_gateway/src/memory/context.rs
+++ b/model_gateway/src/memory/context.rs
@@ -48,7 +48,7 @@ pub struct MemoryExecutionContext {
     pub subject_id: Option<String>,
     pub embedding_model: Option<String>,
     pub extraction_model: Option<String>,
-    pub stm_enabled: bool,
+    pub stm_enabled: MemoryExecutionState,
     pub stm_condenser_model_id: Option<String>,
 }
 
@@ -70,7 +70,8 @@ impl MemoryExecutionContext {
         }
         let store_ltm_requested = policy.allows_ltm_store();
         let recall_requested = policy.allows_recall();
-        let stm_enabled = headers.stm_enabled && runtime.enabled;
+        let stm_enabled =
+            MemoryExecutionState::from_requested_and_runtime(headers.stm_enabled, runtime.enabled);
 
         Self {
             store_ltm: MemoryExecutionState::from_requested_and_runtime(
@@ -87,6 +88,7 @@ impl MemoryExecutionContext {
             extraction_model: headers.extraction_model.clone(),
             stm_enabled,
             stm_condenser_model_id: stm_enabled
+                .active()
                 .then_some(headers.stm_condenser_model_id.clone())
                 .flatten(),
         }
@@ -168,7 +170,7 @@ mod tests {
         assert_eq!(ctx.store_ltm, MemoryExecutionState::GatedOff);
         assert_eq!(ctx.recall, MemoryExecutionState::GatedOff);
         assert_eq!(ctx.policy_mode, MemoryPolicyMode::StoreAndRecall);
-        assert!(!ctx.stm_enabled);
+        assert_eq!(ctx.stm_enabled, MemoryExecutionState::GatedOff);
         assert_eq!(ctx.stm_condenser_model_id, None);
     }
 
@@ -193,7 +195,7 @@ mod tests {
             Some("text-embedding-3-small")
         );
         assert_eq!(ctx.extraction_model.as_deref(), Some("gpt-4.1-mini"));
-        assert!(ctx.stm_enabled);
+        assert_eq!(ctx.stm_enabled, MemoryExecutionState::Active);
         assert_eq!(ctx.stm_condenser_model_id.as_deref(), Some("condense-1"));
     }
 }

--- a/model_gateway/src/routers/common/header_utils.rs
+++ b/model_gateway/src/routers/common/header_utils.rs
@@ -21,6 +21,8 @@ pub struct MemoryHeaderView {
     pub subject_id: Option<String>,
     pub embedding_model: Option<String>,
     pub extraction_model: Option<String>,
+    pub stm_enabled: bool,
+    pub stm_condenser_model_id: Option<String>,
 }
 
 impl MemoryHeaderView {
@@ -35,6 +37,7 @@ impl MemoryHeaderView {
             return Self::default();
         };
         let ltm_enabled = config.long_term_memory.enabled;
+        let stm_enabled = config.short_term_memory.enabled;
         let policy = if ltm_enabled {
             config
                 .long_term_memory
@@ -53,6 +56,10 @@ impl MemoryHeaderView {
                 .flatten(),
             extraction_model: ltm_enabled
                 .then_some(config.long_term_memory.extraction_model_id)
+                .flatten(),
+            stm_enabled,
+            stm_condenser_model_id: stm_enabled
+                .then_some(config.short_term_memory.condenser_model_id)
                 .flatten(),
         }
     }
@@ -543,6 +550,8 @@ mod tests {
         assert_eq!(view.subject_id, None);
         assert_eq!(view.embedding_model, None);
         assert_eq!(view.extraction_model, None);
+        assert!(!view.stm_enabled);
+        assert_eq!(view.stm_condenser_model_id, None);
     }
 
     #[test]
@@ -561,6 +570,8 @@ mod tests {
         assert_eq!(view.subject_id, None);
         assert_eq!(view.embedding_model, None);
         assert_eq!(view.extraction_model, None);
+        assert!(view.stm_enabled);
+        assert_eq!(view.stm_condenser_model_id.as_deref(), Some("cond-1"));
     }
 
     #[test]
@@ -582,6 +593,8 @@ mod tests {
             Some("text-embedding-3-small")
         );
         assert_eq!(view.extraction_model.as_deref(), Some("gpt-4.1-mini"));
+        assert!(!view.stm_enabled);
+        assert_eq!(view.stm_condenser_model_id, None);
     }
 
     #[test]

--- a/model_gateway/src/routers/common/persistence_utils.rs
+++ b/model_gateway/src/routers/common/persistence_utils.rs
@@ -427,7 +427,7 @@ async fn maybe_schedule_stmo_after_persist(
     user_turns: usize,
     total_items: usize,
 ) -> Result<bool, String> {
-    if !memory_execution_context.stm_enabled {
+    if !memory_execution_context.stm_enabled.active() {
         return Ok(false);
     }
 
@@ -479,7 +479,7 @@ async fn handle_stmo_after_persist(
     conversation_turn_info: Option<ConversationTurnInfo>,
     output_item_count: usize,
 ) {
-    if !memory_execution_context.stm_enabled {
+    if !memory_execution_context.stm_enabled.active() {
         return;
     }
 

--- a/model_gateway/src/routers/common/persistence_utils.rs
+++ b/model_gateway/src/routers/common/persistence_utils.rs
@@ -653,3 +653,56 @@ async fn persist_conversation_items_inner(
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stmo_fires_at_boundary_turns() {
+        // Fires at 4, 7, 10 — not before or between
+        assert!(!should_enqueue_stmo(3));
+        assert!(should_enqueue_stmo(4));
+        assert!(!should_enqueue_stmo(5));
+        assert!(!should_enqueue_stmo(6));
+        assert!(should_enqueue_stmo(7));
+        assert!(should_enqueue_stmo(10));
+    }
+
+    #[test]
+    fn count_user_turns_case_insensitive() {
+        let items = vec![
+            json!({"role": "user", "type": "message"}),
+            json!({"role": "assistant", "type": "message"}),
+            json!({"role": "User", "type": "message"}), // uppercase variant
+            json!({"type": "function_call"}),            // no role — not counted
+        ];
+        assert_eq!(count_user_turns(&items), 2);
+    }
+
+    #[test]
+    fn total_items_exceeds_user_turns() {
+        // Verifies that total_items accounts for non-user items (assistant turns,
+        // tool calls, etc.) so target_item_end in the STMO payload is correct.
+        let input_items = vec![
+            json!({"role": "user"}),
+            json!({"role": "assistant"}),
+            json!({"role": "user"}),
+            json!({"role": "assistant"}),
+            json!({"role": "user"}),
+            json!({"role": "assistant"}),
+            json!({"role": "user"}), // 4th user turn — triggers STMO
+        ];
+        let output_items = [
+            json!({"type": "message"}),
+            json!({"type": "function_call"}),
+        ];
+
+        let user_turns = count_user_turns(&input_items);
+        let total_items = input_items.len() + output_items.len();
+
+        assert_eq!(user_turns, 4);
+        assert_eq!(total_items, 9); // total > user_turns
+        assert!(should_enqueue_stmo(user_turns));
+    }
+}

--- a/model_gateway/src/routers/common/persistence_utils.rs
+++ b/model_gateway/src/routers/common/persistence_utils.rs
@@ -14,7 +14,7 @@ use smg_data_connector::{
     ConversationMemoryWriter, ConversationStorage, NewConversationItem, NewConversationMemory,
     RequestContext as StorageRequestContext, ResponseId, ResponseStorage, StoredResponse,
 };
-use tracing::{debug, info, warn, Instrument};
+use tracing::{debug, info, warn};
 
 use crate::memory::MemoryExecutionContext;
 
@@ -606,34 +606,15 @@ async fn persist_conversation_items_inner(
         )
         .await?;
 
-        if memory_execution_context.stm_enabled {
-            let span = tracing::Span::current();
-            let writer = conversation_memory_writer.clone();
-            let mem_ctx = memory_execution_context.clone();
-            let conv_id = conv_id.clone();
-            let resp_id = response_id.clone();
-            let input_items = input_items.clone();
-            let output_items = output_items.clone();
-
-            #[expect(
-                clippy::disallowed_methods,
-                reason = "STMO enqueue should run best-effort in the background without blocking response success"
-            )]
-            tokio::spawn(
-                async move {
-                    handle_stmo_after_persist(
-                        &writer,
-                        &mem_ctx,
-                        &conv_id,
-                        &resp_id,
-                        &input_items,
-                        &output_items,
-                    )
-                    .await;
-                }
-                .instrument(span),
-            );
-        }
+        handle_stmo_after_persist(
+            &conversation_memory_writer,
+            &memory_execution_context,
+            &conv_id,
+            &response_id,
+            &input_items,
+            &output_items,
+        )
+        .await;
 
         info!(
             conversation_id = %conv_id.0,

--- a/model_gateway/src/routers/common/persistence_utils.rs
+++ b/model_gateway/src/routers/common/persistence_utils.rs
@@ -386,15 +386,37 @@ fn should_enqueue_stmo(user_turns: usize) -> bool {
     user_turns >= 4 && (user_turns - 1) % 3 == 0
 }
 
-fn count_user_turns(input_items: &[Value]) -> usize {
-    input_items
-        .iter()
-        .filter(|item| {
-            item.get("role")
-                .and_then(|v| v.as_str())
-                .is_some_and(|role| role.eq_ignore_ascii_case("user"))
-        })
-        .count()
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ConversationTurnInfo {
+    pub user_turns: usize,
+    pub total_items: usize,
+}
+
+pub fn count_conversation_turn_info(input: &ResponseInput) -> ConversationTurnInfo {
+    match input {
+        ResponseInput::Text(_) => ConversationTurnInfo {
+            user_turns: 1,
+            total_items: 1,
+        },
+        ResponseInput::Items(items) => {
+            let user_turns = items
+                .iter()
+                .filter(|item| match item {
+                    ResponseInputOutputItem::SimpleInputMessage { role, .. } => {
+                        role.eq_ignore_ascii_case("user")
+                    }
+                    ResponseInputOutputItem::Message { role, .. } => {
+                        role.eq_ignore_ascii_case("user")
+                    }
+                    _ => false,
+                })
+                .count();
+            ConversationTurnInfo {
+                user_turns,
+                total_items: items.len(),
+            }
+        }
+    }
 }
 
 async fn maybe_schedule_stmo_after_persist(
@@ -454,15 +476,24 @@ async fn handle_stmo_after_persist(
     memory_execution_context: &MemoryExecutionContext,
     conversation_id: &ConversationId,
     response_id: &ResponseId,
-    input_items: &[Value],
-    output_items: &[Value],
+    conversation_turn_info: Option<ConversationTurnInfo>,
+    output_item_count: usize,
 ) {
     if !memory_execution_context.stm_enabled {
         return;
     }
 
-    let user_turns = count_user_turns(input_items);
-    let total_items = input_items.len() + output_items.len();
+    let Some(turn_info) = conversation_turn_info else {
+        debug!(
+            conversation_id = %conversation_id.0,
+            response_id = %response_id.0,
+            "STMO skipped: missing conversation turn info"
+        );
+        return;
+    };
+
+    let user_turns = turn_info.user_turns;
+    let total_items = turn_info.total_items + output_item_count;
 
     match maybe_schedule_stmo_after_persist(
         conversation_memory_writer,
@@ -523,6 +554,7 @@ pub async fn persist_conversation_items(
     original_body: &ResponsesRequest,
     request_context: Option<StorageRequestContext>,
     memory_execution_context: MemoryExecutionContext,
+    conversation_turn_info: Option<ConversationTurnInfo>,
 ) -> Result<(), String> {
     let inner = persist_conversation_items_inner(
         conversation_storage,
@@ -532,6 +564,7 @@ pub async fn persist_conversation_items(
         response_json,
         original_body,
         memory_execution_context,
+        conversation_turn_info,
     );
     match request_context {
         Some(ctx) => with_request_context(ctx, inner).await,
@@ -547,6 +580,7 @@ async fn persist_conversation_items_inner(
     response_json: &Value,
     original_body: &ResponsesRequest,
     memory_execution_context: MemoryExecutionContext,
+    conversation_turn_info: Option<ConversationTurnInfo>,
 ) -> Result<(), String> {
     // Respect store=false: skip persistence entirely (matches official API behavior)
     if !original_body.store.unwrap_or(true) {
@@ -611,8 +645,8 @@ async fn persist_conversation_items_inner(
             &memory_execution_context,
             &conv_id,
             &response_id,
-            &input_items,
-            &output_items,
+            conversation_turn_info,
+            output_items.len(),
         )
         .await;
 
@@ -652,35 +686,92 @@ mod tests {
 
     #[test]
     fn count_user_turns_case_insensitive() {
-        let items = vec![
-            json!({"role": "user", "type": "message"}),
-            json!({"role": "assistant", "type": "message"}),
-            json!({"role": "User", "type": "message"}), // uppercase variant
-            json!({"type": "function_call"}),           // no role — not counted
-        ];
-        assert_eq!(count_user_turns(&items), 2);
+        let input = ResponseInput::Items(vec![
+            ResponseInputOutputItem::SimpleInputMessage {
+                content: StringOrContentParts::String("u1".to_string()),
+                role: "user".to_string(),
+                r#type: None,
+                phase: None,
+            },
+            ResponseInputOutputItem::SimpleInputMessage {
+                content: StringOrContentParts::String("a1".to_string()),
+                role: "assistant".to_string(),
+                r#type: None,
+                phase: None,
+            },
+            ResponseInputOutputItem::SimpleInputMessage {
+                content: StringOrContentParts::String("u2".to_string()),
+                role: "User".to_string(),
+                r#type: None,
+                phase: None,
+            },
+            ResponseInputOutputItem::FunctionToolCall {
+                id: "fc_1".to_string(),
+                call_id: "call_1".to_string(),
+                name: "tool".to_string(),
+                arguments: "{}".to_string(),
+                output: None,
+                status: None,
+            },
+        ]);
+        let info = count_conversation_turn_info(&input);
+        assert_eq!(info.user_turns, 2);
+        assert_eq!(info.total_items, 4);
     }
 
     #[test]
     fn total_items_exceeds_user_turns() {
-        // Verifies that total_items accounts for non-user items (assistant turns,
-        // tool calls, etc.) so target_item_end in the STMO payload is correct.
-        let input_items = vec![
-            json!({"role": "user"}),
-            json!({"role": "assistant"}),
-            json!({"role": "user"}),
-            json!({"role": "assistant"}),
-            json!({"role": "user"}),
-            json!({"role": "assistant"}),
-            json!({"role": "user"}), // 4th user turn — triggers STMO
-        ];
-        let output_items = [json!({"type": "message"}), json!({"type": "function_call"})];
+        let input = ResponseInput::Items(vec![
+            ResponseInputOutputItem::SimpleInputMessage {
+                content: StringOrContentParts::String("u1".to_string()),
+                role: "user".to_string(),
+                r#type: None,
+                phase: None,
+            },
+            ResponseInputOutputItem::SimpleInputMessage {
+                content: StringOrContentParts::String("a1".to_string()),
+                role: "assistant".to_string(),
+                r#type: None,
+                phase: None,
+            },
+            ResponseInputOutputItem::SimpleInputMessage {
+                content: StringOrContentParts::String("u2".to_string()),
+                role: "user".to_string(),
+                r#type: None,
+                phase: None,
+            },
+            ResponseInputOutputItem::SimpleInputMessage {
+                content: StringOrContentParts::String("a2".to_string()),
+                role: "assistant".to_string(),
+                r#type: None,
+                phase: None,
+            },
+            ResponseInputOutputItem::SimpleInputMessage {
+                content: StringOrContentParts::String("u3".to_string()),
+                role: "user".to_string(),
+                r#type: None,
+                phase: None,
+            },
+            ResponseInputOutputItem::SimpleInputMessage {
+                content: StringOrContentParts::String("a3".to_string()),
+                role: "assistant".to_string(),
+                r#type: None,
+                phase: None,
+            },
+            ResponseInputOutputItem::SimpleInputMessage {
+                content: StringOrContentParts::String("u4".to_string()),
+                role: "user".to_string(),
+                r#type: None,
+                phase: None,
+            },
+        ]);
 
-        let user_turns = count_user_turns(&input_items);
-        let total_items = input_items.len() + output_items.len();
+        let info = count_conversation_turn_info(&input);
+        let target_item_end = info.total_items + 2; // response output contributes after load
 
-        assert_eq!(user_turns, 4);
-        assert_eq!(total_items, 9); // total > user_turns
-        assert!(should_enqueue_stmo(user_turns));
+        assert_eq!(info.user_turns, 4);
+        assert_eq!(info.total_items, 7);
+        assert_eq!(target_item_end, 9); // total > user turns
+        assert!(should_enqueue_stmo(info.user_turns));
     }
 }

--- a/model_gateway/src/routers/common/persistence_utils.rs
+++ b/model_gateway/src/routers/common/persistence_utils.rs
@@ -10,10 +10,13 @@ use openai_protocol::responses::{
 use serde_json::{json, Value};
 use smg_data_connector::{
     with_request_context, ConversationId, ConversationItem, ConversationItemId,
-    ConversationItemStorage, ConversationStorage, NewConversationItem,
+    ConversationItemStorage, ConversationMemoryStatus, ConversationMemoryType,
+    ConversationMemoryWriter, ConversationStorage, NewConversationItem, NewConversationMemory,
     RequestContext as StorageRequestContext, ResponseId, ResponseStorage, StoredResponse,
 };
-use tracing::{debug, info, warn};
+use tracing::{debug, info, warn, Instrument};
+
+use crate::memory::MemoryExecutionContext;
 
 // ============================================================================
 // Constants
@@ -375,6 +378,131 @@ async fn link_items_to_conversation(
     Ok(())
 }
 
+#[expect(
+    clippy::manual_is_multiple_of,
+    reason = "usize::is_multiple_of is not stable; % remainder check is the portable equivalent"
+)]
+fn should_enqueue_stmo(user_turns: usize) -> bool {
+    user_turns >= 4 && (user_turns - 1) % 3 == 0
+}
+
+fn count_user_turns(input_items: &[Value]) -> usize {
+    input_items
+        .iter()
+        .filter(|item| {
+            item.get("role")
+                .and_then(|v| v.as_str())
+                .is_some_and(|role| role.eq_ignore_ascii_case("user"))
+        })
+        .count()
+}
+
+async fn maybe_schedule_stmo_after_persist(
+    conversation_memory_writer: &Arc<dyn ConversationMemoryWriter>,
+    memory_execution_context: &MemoryExecutionContext,
+    conversation_id: &ConversationId,
+    response_id: &ResponseId,
+    user_turns: usize,
+    total_items: usize,
+) -> Result<bool, String> {
+    if !memory_execution_context.stm_enabled {
+        return Ok(false);
+    }
+
+    if !should_enqueue_stmo(user_turns) {
+        return Ok(false);
+    }
+
+    let mut memory_config = json!({
+        "last_index": user_turns,
+        "target_item_end": total_items,
+    });
+
+    if let Some(model_id) = &memory_execution_context.stm_condenser_model_id {
+        memory_config["condenser_model"] = json!(model_id);
+    }
+
+    let memory_config = serde_json::to_string(&memory_config)
+        .map_err(|e| format!("Failed to serialize STMO memory config: {e}"))?;
+
+    let input = NewConversationMemory {
+        conversation_id: conversation_id.clone(),
+        conversation_version: None,
+        response_id: Some(response_id.clone()),
+        memory_type: ConversationMemoryType::Stmo,
+        status: ConversationMemoryStatus::Ready,
+        attempt: 0,
+        owner_id: None,
+        next_run_at: Utc::now(),
+        lease_until: None,
+        content: None,
+        memory_config: Some(memory_config),
+        scope_id: None,
+        error_msg: None,
+    };
+
+    conversation_memory_writer
+        .create_memory(input)
+        .await
+        .map_err(|e| format!("Failed to enqueue STMO memory: {e}"))?;
+
+    Ok(true)
+}
+
+async fn handle_stmo_after_persist(
+    conversation_memory_writer: &Arc<dyn ConversationMemoryWriter>,
+    memory_execution_context: &MemoryExecutionContext,
+    conversation_id: &ConversationId,
+    response_id: &ResponseId,
+    input_items: &[Value],
+    output_items: &[Value],
+) {
+    if !memory_execution_context.stm_enabled {
+        return;
+    }
+
+    let user_turns = count_user_turns(input_items);
+    let total_items = input_items.len() + output_items.len();
+
+    match maybe_schedule_stmo_after_persist(
+        conversation_memory_writer,
+        memory_execution_context,
+        conversation_id,
+        response_id,
+        user_turns,
+        total_items,
+    )
+    .await
+    {
+        Ok(true) => {
+            info!(
+                conversation_id = %conversation_id.0,
+                response_id = %response_id.0,
+                user_turns,
+                total_items,
+                "Enqueued STMO memory condensation job"
+            );
+        }
+        Ok(false) => {
+            debug!(
+                conversation_id = %conversation_id.0,
+                response_id = %response_id.0,
+                user_turns,
+                total_items,
+                "STMO not enqueued for this response boundary"
+            );
+        }
+        Err(e) => {
+            warn!(
+                conversation_id = %conversation_id.0,
+                response_id = %response_id.0,
+                error = %e,
+                "Failed to enqueue STMO memory job; continuing without failing response"
+            );
+        }
+    }
+}
+
 /// Persist conversation items to storage
 ///
 /// This function:
@@ -382,20 +510,28 @@ async fn link_items_to_conversation(
 /// 2. Extracts output items from the response
 /// 3. Stores ALL items in response storage (always)
 /// 4. If conversation provided, also links items to conversation
+#[expect(
+    clippy::too_many_arguments,
+    reason = "persistence entrypoint assembles all storage handles and request context in one call"
+)]
 pub async fn persist_conversation_items(
     conversation_storage: Arc<dyn ConversationStorage>,
     item_storage: Arc<dyn ConversationItemStorage>,
+    conversation_memory_writer: Arc<dyn ConversationMemoryWriter>,
     response_storage: Arc<dyn ResponseStorage>,
     response_json: &Value,
     original_body: &ResponsesRequest,
     request_context: Option<StorageRequestContext>,
+    memory_execution_context: MemoryExecutionContext,
 ) -> Result<(), String> {
     let inner = persist_conversation_items_inner(
         conversation_storage,
         item_storage,
+        conversation_memory_writer,
         response_storage,
         response_json,
         original_body,
+        memory_execution_context,
     );
     match request_context {
         Some(ctx) => with_request_context(ctx, inner).await,
@@ -406,9 +542,11 @@ pub async fn persist_conversation_items(
 async fn persist_conversation_items_inner(
     conversation_storage: Arc<dyn ConversationStorage>,
     item_storage: Arc<dyn ConversationItemStorage>,
+    conversation_memory_writer: Arc<dyn ConversationMemoryWriter>,
     response_storage: Arc<dyn ResponseStorage>,
     response_json: &Value,
     original_body: &ResponsesRequest,
+    memory_execution_context: MemoryExecutionContext,
 ) -> Result<(), String> {
     // Respect store=false: skip persistence entirely (matches official API behavior)
     if !original_body.store.unwrap_or(true) {
@@ -467,6 +605,36 @@ async fn persist_conversation_items_inner(
             response_id_str,
         )
         .await?;
+
+        if memory_execution_context.stm_enabled {
+            let span = tracing::Span::current();
+            let writer = conversation_memory_writer.clone();
+            let mem_ctx = memory_execution_context.clone();
+            let conv_id = conv_id.clone();
+            let resp_id = response_id.clone();
+            let input_items = input_items.clone();
+            let output_items = output_items.clone();
+
+            #[expect(
+                clippy::disallowed_methods,
+                reason = "STMO enqueue should run best-effort in the background without blocking response success"
+            )]
+            tokio::spawn(
+                async move {
+                    handle_stmo_after_persist(
+                        &writer,
+                        &mem_ctx,
+                        &conv_id,
+                        &resp_id,
+                        &input_items,
+                        &output_items,
+                    )
+                    .await;
+                }
+                .instrument(span),
+            );
+        }
+
         info!(
             conversation_id = %conv_id.0,
             response_id = %response_id.0,

--- a/model_gateway/src/routers/common/persistence_utils.rs
+++ b/model_gateway/src/routers/common/persistence_utils.rs
@@ -675,7 +675,7 @@ mod tests {
             json!({"role": "user", "type": "message"}),
             json!({"role": "assistant", "type": "message"}),
             json!({"role": "User", "type": "message"}), // uppercase variant
-            json!({"type": "function_call"}),            // no role — not counted
+            json!({"type": "function_call"}),           // no role — not counted
         ];
         assert_eq!(count_user_turns(&items), 2);
     }
@@ -693,10 +693,7 @@ mod tests {
             json!({"role": "assistant"}),
             json!({"role": "user"}), // 4th user turn — triggers STMO
         ];
-        let output_items = [
-            json!({"type": "message"}),
-            json!({"type": "function_call"}),
-        ];
+        let output_items = [json!({"type": "message"}), json!({"type": "function_call"})];
 
         let user_turns = count_user_turns(&input_items);
         let total_items = input_items.len() + output_items.len();

--- a/model_gateway/src/routers/common/persistence_utils.rs
+++ b/model_gateway/src/routers/common/persistence_utils.rs
@@ -572,6 +572,10 @@ pub async fn persist_conversation_items(
     }
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "inner persistence fn assembles all storage handles, memory context, and turn info in one flow"
+)]
 async fn persist_conversation_items_inner(
     conversation_storage: Arc<dyn ConversationStorage>,
     item_storage: Arc<dyn ConversationItemStorage>,

--- a/model_gateway/src/routers/grpc/common/responses/context.rs
+++ b/model_gateway/src/routers/grpc/common/responses/context.rs
@@ -83,15 +83,4 @@ impl ResponsesContext {
             memory_execution_context,
         }
     }
-
-    /// Clone this context while swapping in a request-scoped storage context.
-    ///
-    /// Mirrors the pattern from PR #1357 to avoid duplicated constructor wiring
-    /// at call sites that need to attach a per-request storage hook context.
-    pub fn with_request_context(&self, request_context: Option<StorageRequestContext>) -> Self {
-        Self {
-            request_context,
-            ..self.clone()
-        }
-    }
 }

--- a/model_gateway/src/routers/grpc/common/responses/context.rs
+++ b/model_gateway/src/routers/grpc/common/responses/context.rs
@@ -15,6 +15,20 @@ use crate::{
     routers::grpc::{context::SharedComponents, pipeline::RequestPipeline},
 };
 
+/// Bundled storage handles for persistence operations.
+///
+/// Groups the four storage backends that every persistence call needs so they
+/// can be passed as a single unit rather than four individual arguments.
+/// Mirrors the pattern introduced in the LTM pipeline (PR #1357) so the two
+/// code paths stay consistent and future merges remain clean.
+#[derive(Clone)]
+pub(crate) struct PersistenceHandles {
+    pub response_storage: Arc<dyn ResponseStorage>,
+    pub conversation_storage: Arc<dyn ConversationStorage>,
+    pub conversation_item_storage: Arc<dyn ConversationItemStorage>,
+    pub conversation_memory_writer: Arc<dyn ConversationMemoryWriter>,
+}
+
 /// Context for /v1/responses endpoint
 ///
 /// Used by both regular and harmony implementations.
@@ -27,17 +41,8 @@ pub(crate) struct ResponsesContext {
     /// Shared components (tokenizer, parsers)
     pub components: Arc<SharedComponents>,
 
-    /// Response storage backend
-    pub response_storage: Arc<dyn ResponseStorage>,
-
-    /// Conversation storage backend
-    pub conversation_storage: Arc<dyn ConversationStorage>,
-
-    /// Conversation item storage backend
-    pub conversation_item_storage: Arc<dyn ConversationItemStorage>,
-
-    /// Conversation memory writer (can be NoOp depending on backend)
-    pub conversation_memory_writer: Arc<dyn ConversationMemoryWriter>,
+    /// Bundled storage handles for persistence operations.
+    pub persistence: PersistenceHandles,
 
     /// MCP orchestrator for tool support
     pub mcp_orchestrator: Arc<McpOrchestrator>,
@@ -59,17 +64,10 @@ pub(crate) struct ResponsesContext {
 
 impl ResponsesContext {
     /// Create a new responses context.
-    #[expect(
-        clippy::too_many_arguments,
-        reason = "responses context assembles shared pipeline + storage handles in one place"
-    )]
     pub fn new(
         pipeline: Arc<RequestPipeline>,
         components: Arc<SharedComponents>,
-        response_storage: Arc<dyn ResponseStorage>,
-        conversation_storage: Arc<dyn ConversationStorage>,
-        conversation_item_storage: Arc<dyn ConversationItemStorage>,
-        conversation_memory_writer: Arc<dyn ConversationMemoryWriter>,
+        persistence: PersistenceHandles,
         mcp_orchestrator: Arc<McpOrchestrator>,
         request_context: Option<StorageRequestContext>,
         max_conversation_history_items: usize,
@@ -78,10 +76,7 @@ impl ResponsesContext {
         Self {
             pipeline,
             components,
-            response_storage,
-            conversation_storage,
-            conversation_item_storage,
-            conversation_memory_writer,
+            persistence,
             mcp_orchestrator,
             request_context,
             max_conversation_history_items,

--- a/model_gateway/src/routers/grpc/common/responses/context.rs
+++ b/model_gateway/src/routers/grpc/common/responses/context.rs
@@ -41,6 +41,9 @@ pub(crate) struct ResponsesContext {
 
     /// Storage hook request context extracted from HTTP headers by middleware.
     pub request_context: Option<StorageRequestContext>,
+
+    /// Maximum conversation history items to load into request context.
+    pub max_conversation_history_items: usize,
 }
 
 impl ResponsesContext {
@@ -58,6 +61,7 @@ impl ResponsesContext {
         conversation_memory_writer: Arc<dyn ConversationMemoryWriter>,
         mcp_orchestrator: Arc<McpOrchestrator>,
         request_context: Option<StorageRequestContext>,
+        max_conversation_history_items: usize,
     ) -> Self {
         Self {
             pipeline,
@@ -68,6 +72,7 @@ impl ResponsesContext {
             conversation_memory_writer,
             mcp_orchestrator,
             request_context,
+            max_conversation_history_items,
         }
     }
 }

--- a/model_gateway/src/routers/grpc/common/responses/context.rs
+++ b/model_gateway/src/routers/grpc/common/responses/context.rs
@@ -10,7 +10,10 @@ use smg_data_connector::{
 };
 use smg_mcp::McpOrchestrator;
 
-use crate::routers::grpc::{context::SharedComponents, pipeline::RequestPipeline};
+use crate::{
+    memory::MemoryExecutionContext,
+    routers::grpc::{context::SharedComponents, pipeline::RequestPipeline},
+};
 
 /// Context for /v1/responses endpoint
 ///
@@ -44,6 +47,14 @@ pub(crate) struct ResponsesContext {
 
     /// Maximum conversation history items to load into request context.
     pub max_conversation_history_items: usize,
+
+    /// Memory execution context derived from per-request headers.
+    ///
+    /// Controls whether LTM store/recall and STM condensation are active for
+    /// this request.  Built from `x-conversation-memory-config` + the runtime
+    /// feature flag at the gRPC entry point and threaded down to the persistence
+    /// layer so it can gate memory side-effects without re-parsing headers.
+    pub memory_execution_context: MemoryExecutionContext,
 }
 
 impl ResponsesContext {
@@ -62,6 +73,7 @@ impl ResponsesContext {
         mcp_orchestrator: Arc<McpOrchestrator>,
         request_context: Option<StorageRequestContext>,
         max_conversation_history_items: usize,
+        memory_execution_context: MemoryExecutionContext,
     ) -> Self {
         Self {
             pipeline,
@@ -73,6 +85,7 @@ impl ResponsesContext {
             mcp_orchestrator,
             request_context,
             max_conversation_history_items,
+            memory_execution_context,
         }
     }
 }

--- a/model_gateway/src/routers/grpc/common/responses/context.rs
+++ b/model_gateway/src/routers/grpc/common/responses/context.rs
@@ -83,4 +83,15 @@ impl ResponsesContext {
             memory_execution_context,
         }
     }
+
+    /// Clone this context while swapping in a request-scoped storage context.
+    ///
+    /// Mirrors the pattern from PR #1357 to avoid duplicated constructor wiring
+    /// at call sites that need to attach a per-request storage hook context.
+    pub fn with_request_context(&self, request_context: Option<StorageRequestContext>) -> Self {
+        Self {
+            request_context,
+            ..self.clone()
+        }
+    }
 }

--- a/model_gateway/src/routers/grpc/common/responses/handlers.rs
+++ b/model_gateway/src/routers/grpc/common/responses/handlers.rs
@@ -16,7 +16,12 @@ pub(crate) async fn cancel_response_impl(ctx: &ResponsesContext, response_id: &s
     let resp_id = ResponseId::from(response_id);
 
     // Check if response exists
-    match ctx.response_storage.get_response(&resp_id).await {
+    match ctx
+        .persistence
+        .response_storage
+        .get_response(&resp_id)
+        .await
+    {
         Ok(Some(stored_response)) => {
             let current_status = stored_response
                 .raw_response

--- a/model_gateway/src/routers/grpc/common/responses/mod.rs
+++ b/model_gateway/src/routers/grpc/common/responses/mod.rs
@@ -6,7 +6,7 @@ pub(crate) mod streaming;
 pub(crate) mod utils;
 
 // Re-export commonly used items
-pub(crate) use context::ResponsesContext;
+pub(crate) use context::{PersistenceHandles, ResponsesContext};
 pub(crate) use streaming::build_sse_response;
 pub(crate) use utils::{ensure_mcp_connection, persist_response_if_needed};
 

--- a/model_gateway/src/routers/grpc/common/responses/utils.rs
+++ b/model_gateway/src/routers/grpc/common/responses/utils.rs
@@ -9,13 +9,14 @@ use openai_protocol::{
 };
 use serde_json::to_value;
 use smg_data_connector::{
-    ConversationItemStorage, ConversationStorage, RequestContext as StorageRequestContext,
-    ResponseStorage,
+    ConversationItemStorage, ConversationMemoryWriter, ConversationStorage,
+    RequestContext as StorageRequestContext, ResponseStorage,
 };
 use smg_mcp::{McpOrchestrator, McpServerBinding};
 use tracing::{debug, error, warn};
 
 use crate::{
+    memory::MemoryExecutionContext,
     routers::{
         common::{
             mcp_utils::ensure_request_mcp_client, persistence_utils::persist_conversation_items,
@@ -150,13 +151,19 @@ pub(crate) fn extract_tools_from_response_tools(
 ///
 /// Common helper function to avoid duplication across sync and streaming paths
 /// in both harmony and regular responses implementations.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "persister takes explicit storage handles and request metadata for shared gRPC paths"
+)]
 pub(crate) async fn persist_response_if_needed(
     conversation_storage: Arc<dyn ConversationStorage>,
     conversation_item_storage: Arc<dyn ConversationItemStorage>,
+    conversation_memory_writer: Arc<dyn ConversationMemoryWriter>,
     response_storage: Arc<dyn ResponseStorage>,
     response: &ResponsesResponse,
     original_request: &ResponsesRequest,
     request_context: Option<StorageRequestContext>,
+    memory_execution_context: MemoryExecutionContext,
 ) {
     if !original_request.store.unwrap_or(true) {
         return;
@@ -166,10 +173,12 @@ pub(crate) async fn persist_response_if_needed(
         if let Err(e) = persist_conversation_items(
             conversation_storage,
             conversation_item_storage,
+            conversation_memory_writer,
             response_storage,
             &response_json,
             original_request,
             request_context,
+            memory_execution_context,
         )
         .await
         {

--- a/model_gateway/src/routers/grpc/common/responses/utils.rs
+++ b/model_gateway/src/routers/grpc/common/responses/utils.rs
@@ -16,7 +16,8 @@ use crate::{
     memory::MemoryExecutionContext,
     routers::{
         common::{
-            mcp_utils::ensure_request_mcp_client, persistence_utils::persist_conversation_items,
+            mcp_utils::ensure_request_mcp_client,
+            persistence_utils::{persist_conversation_items, ConversationTurnInfo},
         },
         error,
         grpc::common::responses::context::PersistenceHandles,
@@ -152,6 +153,7 @@ pub(crate) fn extract_tools_from_response_tools(
 pub(crate) async fn persist_response_if_needed(
     persistence: &PersistenceHandles,
     memory_execution_context: MemoryExecutionContext,
+    conversation_turn_info: Option<ConversationTurnInfo>,
     response: &ResponsesResponse,
     original_request: &ResponsesRequest,
     request_context: Option<StorageRequestContext>,
@@ -170,6 +172,7 @@ pub(crate) async fn persist_response_if_needed(
             original_request,
             request_context,
             memory_execution_context,
+            conversation_turn_info,
         )
         .await
         {

--- a/model_gateway/src/routers/grpc/common/responses/utils.rs
+++ b/model_gateway/src/routers/grpc/common/responses/utils.rs
@@ -8,10 +8,7 @@ use openai_protocol::{
     responses::{ResponseTool, ResponsesRequest, ResponsesResponse},
 };
 use serde_json::to_value;
-use smg_data_connector::{
-    ConversationItemStorage, ConversationMemoryWriter, ConversationStorage,
-    RequestContext as StorageRequestContext, ResponseStorage,
-};
+use smg_data_connector::RequestContext as StorageRequestContext;
 use smg_mcp::{McpOrchestrator, McpServerBinding};
 use tracing::{debug, error, warn};
 
@@ -22,6 +19,7 @@ use crate::{
             mcp_utils::ensure_request_mcp_client, persistence_utils::persist_conversation_items,
         },
         error,
+        grpc::common::responses::context::PersistenceHandles,
     },
     worker::WorkerRegistry,
 };
@@ -151,19 +149,12 @@ pub(crate) fn extract_tools_from_response_tools(
 ///
 /// Common helper function to avoid duplication across sync and streaming paths
 /// in both harmony and regular responses implementations.
-#[expect(
-    clippy::too_many_arguments,
-    reason = "persister takes explicit storage handles and request metadata for shared gRPC paths"
-)]
 pub(crate) async fn persist_response_if_needed(
-    conversation_storage: Arc<dyn ConversationStorage>,
-    conversation_item_storage: Arc<dyn ConversationItemStorage>,
-    conversation_memory_writer: Arc<dyn ConversationMemoryWriter>,
-    response_storage: Arc<dyn ResponseStorage>,
+    persistence: &PersistenceHandles,
+    memory_execution_context: MemoryExecutionContext,
     response: &ResponsesResponse,
     original_request: &ResponsesRequest,
     request_context: Option<StorageRequestContext>,
-    memory_execution_context: MemoryExecutionContext,
 ) {
     if !original_request.store.unwrap_or(true) {
         return;
@@ -171,10 +162,10 @@ pub(crate) async fn persist_response_if_needed(
 
     if let Ok(response_json) = to_value(response) {
         if let Err(e) = persist_conversation_items(
-            conversation_storage,
-            conversation_item_storage,
-            conversation_memory_writer,
-            response_storage,
+            persistence.conversation_storage.clone(),
+            persistence.conversation_item_storage.clone(),
+            persistence.conversation_memory_writer.clone(),
+            persistence.response_storage.clone(),
             &response_json,
             original_request,
             request_context,

--- a/model_gateway/src/routers/grpc/harmony/responses/common.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/common.rs
@@ -18,7 +18,11 @@ use tracing::{debug, error, warn};
 use uuid::Uuid;
 
 use super::execution::ToolResult;
-use crate::routers::{error, grpc::common::responses::ResponsesContext};
+use crate::routers::{
+    common::persistence_utils::{count_conversation_turn_info, ConversationTurnInfo},
+    error,
+    grpc::common::responses::ResponsesContext,
+};
 
 /// Record of a single MCP tool call execution
 ///
@@ -38,6 +42,12 @@ pub(super) struct McpCallRecord {
 pub(super) struct McpCallTracking {
     /// All tool call records across all iterations
     pub tool_calls: Vec<McpCallRecord>,
+}
+
+/// Loaded request bundle for Harmony Responses path.
+pub(super) struct LoadedRequest {
+    pub request: ResponsesRequest,
+    pub turn_info: Option<ConversationTurnInfo>,
 }
 
 impl McpCallTracking {
@@ -191,10 +201,16 @@ pub(super) fn inject_mcp_metadata(
 pub(super) async fn load_previous_messages(
     ctx: &ResponsesContext,
     request: ResponsesRequest,
-) -> Result<ResponsesRequest, Response> {
+    stm_enabled: bool,
+) -> Result<LoadedRequest, Response> {
     let Some(ref prev_id_str) = request.previous_response_id else {
         // No previous_response_id, return request as-is
-        return Ok(request);
+        let turn_info = if stm_enabled {
+            Some(count_conversation_turn_info(&request.input))
+        } else {
+            None
+        };
+        return Ok(LoadedRequest { request, turn_info });
     };
 
     let prev_id = ResponseId::from(prev_id_str.as_str());
@@ -299,7 +315,16 @@ pub(super) async fn load_previous_messages(
     modified_request.input = ResponseInput::Items(all_items);
     modified_request.previous_response_id = None;
 
-    Ok(modified_request)
+    let turn_info = if stm_enabled {
+        Some(count_conversation_turn_info(&modified_request.input))
+    } else {
+        None
+    };
+
+    Ok(LoadedRequest {
+        request: modified_request,
+        turn_info,
+    })
 }
 
 /// Strip `ResponseTool::ImageGeneration` from a request's tools list once

--- a/model_gateway/src/routers/grpc/harmony/responses/common.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/common.rs
@@ -204,8 +204,10 @@ pub(super) async fn load_previous_messages(
     stm_enabled: bool,
 ) -> Result<LoadedRequest, Response> {
     let Some(ref prev_id_str) = request.previous_response_id else {
-        // No previous_response_id, return request as-is
-        let turn_info = if stm_enabled {
+        // No previous_response_id: return request as-is.
+        // If a conversation ID is present we have not loaded its history here,
+        // so turn counts from request.input alone would be wrong — skip STMO.
+        let turn_info = if stm_enabled && request.conversation.is_none() {
             Some(count_conversation_turn_info(&request.input))
         } else {
             None

--- a/model_gateway/src/routers/grpc/harmony/responses/common.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/common.rs
@@ -201,6 +201,7 @@ pub(super) async fn load_previous_messages(
 
     // Load response chain from storage
     let chain = match ctx
+        .persistence
         .response_storage
         .get_response_chain(&prev_id, None)
         .await

--- a/model_gateway/src/routers/grpc/harmony/responses/non_streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/non_streaming.rs
@@ -81,14 +81,11 @@ pub(crate) async fn serve_harmony_responses(
 
     // Persist response to storage if store=true
     persist_response_if_needed(
-        ctx.conversation_storage.clone(),
-        ctx.conversation_item_storage.clone(),
-        ctx.conversation_memory_writer.clone(),
-        ctx.response_storage.clone(),
+        &ctx.persistence,
+        ctx.memory_execution_context.clone(),
         &response,
         &original_request,
         ctx.request_context.clone(),
-        ctx.memory_execution_context.clone(),
     )
     .await;
 

--- a/model_gateway/src/routers/grpc/harmony/responses/non_streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/non_streaming.rs
@@ -60,8 +60,12 @@ pub(crate) async fn serve_harmony_responses(
     let original_request = request.clone();
 
     // Load previous conversation history if previous_response_id is set
-    let loaded_request =
-        load_previous_messages(ctx, request, ctx.memory_execution_context.stm_enabled).await?;
+    let loaded_request = load_previous_messages(
+        ctx,
+        request,
+        ctx.memory_execution_context.stm_enabled.active(),
+    )
+    .await?;
     let current_request = loaded_request.request;
     let conversation_turn_info = loaded_request.turn_info;
 

--- a/model_gateway/src/routers/grpc/harmony/responses/non_streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/non_streaming.rs
@@ -83,10 +83,12 @@ pub(crate) async fn serve_harmony_responses(
     persist_response_if_needed(
         ctx.conversation_storage.clone(),
         ctx.conversation_item_storage.clone(),
+        ctx.conversation_memory_writer.clone(),
         ctx.response_storage.clone(),
         &response,
         &original_request,
         ctx.request_context.clone(),
+        ctx.memory_execution_context.clone(),
     )
     .await;
 

--- a/model_gateway/src/routers/grpc/harmony/responses/non_streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/non_streaming.rs
@@ -60,7 +60,10 @@ pub(crate) async fn serve_harmony_responses(
     let original_request = request.clone();
 
     // Load previous conversation history if previous_response_id is set
-    let current_request = load_previous_messages(ctx, request).await?;
+    let loaded_request =
+        load_previous_messages(ctx, request, ctx.memory_execution_context.stm_enabled).await?;
+    let current_request = loaded_request.request;
+    let conversation_turn_info = loaded_request.turn_info;
 
     // Check MCP connection and get whether MCP tools are present
     let (has_mcp_tools, mcp_servers) =
@@ -83,6 +86,7 @@ pub(crate) async fn serve_harmony_responses(
     persist_response_if_needed(
         &ctx.persistence,
         ctx.memory_execution_context.clone(),
+        conversation_turn_info,
         &response,
         &original_request,
         ctx.request_context.clone(),

--- a/model_gateway/src/routers/grpc/harmony/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/streaming.rs
@@ -22,7 +22,7 @@ use crate::{
     middleware::TenantRequestMeta,
     observability::metrics::Metrics,
     routers::{
-        common::mcp_utils::DEFAULT_MAX_ITERATIONS,
+        common::{mcp_utils::DEFAULT_MAX_ITERATIONS, persistence_utils::ConversationTurnInfo},
         grpc::{
             common::responses::{
                 build_sse_response, ensure_mcp_connection, persist_response_if_needed,
@@ -47,10 +47,18 @@ pub(crate) async fn serve_harmony_responses_stream(
     tenant_request_meta: TenantRequestMeta,
 ) -> Response {
     // Load previous conversation history if previous_response_id is set
-    let current_request = match load_previous_messages(ctx, request.clone()).await {
+    let loaded_request = match load_previous_messages(
+        ctx,
+        request.clone(),
+        ctx.memory_execution_context.stm_enabled,
+    )
+    .await
+    {
         Ok(req) => req,
         Err(err_response) => return err_response,
     };
+    let current_request = loaded_request.request;
+    let conversation_turn_info = loaded_request.turn_info;
 
     // Check MCP connection BEFORE starting stream and get whether MCP tools are present
     let (has_mcp_tools, mcp_servers) = match ensure_mcp_connection(
@@ -102,6 +110,7 @@ pub(crate) async fn serve_harmony_responses_stream(
                 &request,
                 tenant_request_meta.clone(),
                 mcp_servers,
+                conversation_turn_info,
                 &mut emitter,
                 &tx,
             )
@@ -112,6 +121,7 @@ pub(crate) async fn serve_harmony_responses_stream(
                 &current_request,
                 &request,
                 tenant_request_meta,
+                conversation_turn_info,
                 &mut emitter,
                 &tx,
             )
@@ -137,6 +147,7 @@ async fn execute_mcp_tool_loop_streaming(
     original_request: &ResponsesRequest,
     tenant_request_meta: TenantRequestMeta,
     mcp_servers: Vec<McpServerBinding>,
+    conversation_turn_info: Option<ConversationTurnInfo>,
     emitter: &mut ResponseStreamEventEmitter,
     tx: &mpsc::UnboundedSender<Result<Bytes, std::io::Error>>,
 ) {
@@ -391,6 +402,7 @@ async fn execute_mcp_tool_loop_streaming(
                 persist_response_if_needed(
                     &ctx.persistence,
                     ctx.memory_execution_context.clone(),
+                    conversation_turn_info,
                     &final_response,
                     original_request,
                     ctx.request_context.clone(),
@@ -426,6 +438,7 @@ async fn execute_without_mcp_streaming(
     current_request: &ResponsesRequest,
     original_request: &ResponsesRequest,
     tenant_request_meta: TenantRequestMeta,
+    conversation_turn_info: Option<ConversationTurnInfo>,
     emitter: &mut ResponseStreamEventEmitter,
     tx: &mpsc::UnboundedSender<Result<Bytes, std::io::Error>>,
 ) {
@@ -478,6 +491,7 @@ async fn execute_without_mcp_streaming(
     persist_response_if_needed(
         &ctx.persistence,
         ctx.memory_execution_context.clone(),
+        conversation_turn_info,
         &final_response,
         original_request,
         ctx.request_context.clone(),

--- a/model_gateway/src/routers/grpc/harmony/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/streaming.rs
@@ -141,6 +141,10 @@ pub(crate) async fn serve_harmony_responses_stream(
 /// - Loops through tool execution iterations
 /// - Emits final response.completed event
 /// - Persists response internally
+#[expect(
+    clippy::too_many_arguments,
+    reason = "streaming MCP loop threads ctx, requests, MCP state, turn info, emitter, and tx together"
+)]
 async fn execute_mcp_tool_loop_streaming(
     ctx: &ResponsesContext,
     mut current_request: ResponsesRequest,

--- a/model_gateway/src/routers/grpc/harmony/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/streaming.rs
@@ -50,7 +50,7 @@ pub(crate) async fn serve_harmony_responses_stream(
     let loaded_request = match load_previous_messages(
         ctx,
         request.clone(),
-        ctx.memory_execution_context.stm_enabled,
+        ctx.memory_execution_context.stm_enabled.active(),
     )
     .await
     {

--- a/model_gateway/src/routers/grpc/harmony/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/streaming.rs
@@ -391,10 +391,12 @@ async fn execute_mcp_tool_loop_streaming(
                 persist_response_if_needed(
                     ctx.conversation_storage.clone(),
                     ctx.conversation_item_storage.clone(),
+                    ctx.conversation_memory_writer.clone(),
                     ctx.response_storage.clone(),
                     &final_response,
                     original_request,
                     ctx.request_context.clone(),
+                    ctx.memory_execution_context.clone(),
                 )
                 .await;
 
@@ -479,10 +481,12 @@ async fn execute_without_mcp_streaming(
     persist_response_if_needed(
         ctx.conversation_storage.clone(),
         ctx.conversation_item_storage.clone(),
+        ctx.conversation_memory_writer.clone(),
         ctx.response_storage.clone(),
         &final_response,
         original_request,
         ctx.request_context.clone(),
+        ctx.memory_execution_context.clone(),
     )
     .await;
 

--- a/model_gateway/src/routers/grpc/harmony/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/streaming.rs
@@ -389,14 +389,11 @@ async fn execute_mcp_tool_loop_streaming(
 
                 // Persist response to storage if store=true
                 persist_response_if_needed(
-                    ctx.conversation_storage.clone(),
-                    ctx.conversation_item_storage.clone(),
-                    ctx.conversation_memory_writer.clone(),
-                    ctx.response_storage.clone(),
+                    &ctx.persistence,
+                    ctx.memory_execution_context.clone(),
                     &final_response,
                     original_request,
                     ctx.request_context.clone(),
-                    ctx.memory_execution_context.clone(),
                 )
                 .await;
 
@@ -479,14 +476,11 @@ async fn execute_without_mcp_streaming(
 
     // Persist response to storage if store=true
     persist_response_if_needed(
-        ctx.conversation_storage.clone(),
-        ctx.conversation_item_storage.clone(),
-        ctx.conversation_memory_writer.clone(),
-        ctx.response_storage.clone(),
+        &ctx.persistence,
+        ctx.memory_execution_context.clone(),
         &final_response,
         original_request,
         ctx.request_context.clone(),
-        ctx.memory_execution_context.clone(),
     )
     .await;
 

--- a/model_gateway/src/routers/grpc/regular/responses/common.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/common.rs
@@ -278,17 +278,13 @@ pub(super) async fn load_conversation_history(
         }
 
         // Load conversation history.
-        // When STMO is active we request one extra item so we can detect
-        // whether the conversation has grown past max_conversation_history_items.
-        // If it has, turn-count math would be wrong, so we reject early.
+        // Always fetch cap+1 items so we can detect whether the conversation
+        // has grown past max_conversation_history_items. Fetching one extra row
+        // is harmless (it is just a SQL LIMIT). The rejection below only fires
+        // when STMO is active and the response will be persisted.
         let cap = ctx.max_conversation_history_items;
-        let fetch_limit = if stm_enabled && request.store.unwrap_or(true) {
-            cap.saturating_add(1)
-        } else {
-            cap
-        };
         let params = data_connector::ListParams {
-            limit: fetch_limit,
+            limit: cap.saturating_add(1),
             order: data_connector::SortOrder::Asc,
             after: None,
         };

--- a/model_gateway/src/routers/grpc/regular/responses/common.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/common.rs
@@ -24,7 +24,10 @@ use tracing::{debug, warn};
 use crate::{
     middleware::TenantRequestMeta,
     routers::{
-        common::persistence_utils::split_stored_message_content, error,
+        common::persistence_utils::{
+            count_conversation_turn_info, split_stored_message_content, ConversationTurnInfo,
+        },
+        error,
         grpc::common::responses::ResponsesContext,
     },
 };
@@ -49,6 +52,12 @@ pub(super) struct ResponsesCallContext {
     pub model_id: String,
     pub response_id: Option<String>,
     pub tenant_request_meta: TenantRequestMeta,
+}
+
+/// Loaded request bundle for Regular Responses path.
+pub(super) struct LoadedRequest {
+    pub request: ResponsesRequest,
+    pub turn_info: Option<ConversationTurnInfo>,
 }
 
 impl ToolLoopState {
@@ -165,7 +174,8 @@ pub(super) fn convert_mcp_tools_to_chat_tools(session: &McpToolSession<'_>) -> V
 pub(super) async fn load_conversation_history(
     ctx: &ResponsesContext,
     request: &ResponsesRequest,
-) -> Result<ResponsesRequest, Response> {
+    stm_enabled: bool,
+) -> Result<LoadedRequest, Response> {
     let mut modified_request = request.clone();
     let mut conversation_items: Option<Vec<ResponseInputOutputItem>> = None;
 
@@ -359,7 +369,16 @@ pub(super) async fn load_conversation_history(
         "Loaded conversation history"
     );
 
-    Ok(modified_request)
+    let turn_info = if stm_enabled {
+        Some(count_conversation_turn_info(&modified_request.input))
+    } else {
+        None
+    };
+
+    Ok(LoadedRequest {
+        request: modified_request,
+        turn_info,
+    })
 }
 
 /// Build next request with updated conversation history

--- a/model_gateway/src/routers/grpc/regular/responses/common.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/common.rs
@@ -278,13 +278,13 @@ pub(super) async fn load_conversation_history(
         }
 
         // Load conversation history.
-        // Always fetch cap+1 items so we can detect whether the conversation
-        // has grown past max_conversation_history_items. Fetching one extra row
-        // is harmless (it is just a SQL LIMIT). The rejection below only fires
-        // when STMO is active and the response will be persisted.
+        // Fetch up to cap items. If we get cap rows back the conversation is at
+        // or beyond the configured limit; reject when STMO is active and the
+        // response will be persisted. The SQL LIMIT also bounds the inference
+        // window, so no post-fetch truncation is needed.
         let cap = ctx.max_conversation_history_items;
         let params = data_connector::ListParams {
-            limit: cap.saturating_add(1),
+            limit: cap,
             order: data_connector::SortOrder::Asc,
             after: None,
         };
@@ -298,11 +298,11 @@ pub(super) async fn load_conversation_history(
                 // Only reject oversized conversations when the response will
                 // actually be persisted. store=false requests skip persistence
                 // entirely, so STMO is never enqueued and the cap does not apply.
-                if stm_enabled && request.store.unwrap_or(true) && stored_items.len() > cap {
+                if stm_enabled && request.store.unwrap_or(true) && stored_items.len() >= cap {
                     return Err(error::bad_request(
                         "conversation_too_large",
                         format!(
-                            "Conversation exceeds the configured limit of {cap} history items. \
+                            "Conversation has reached the configured limit of {cap} history items. \
                              Increase max_conversation_history_items in the router config \
                              or reduce conversation length before using short-term memory \
                              optimization.",

--- a/model_gateway/src/routers/grpc/regular/responses/common.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/common.rs
@@ -277,9 +277,18 @@ pub(super) async fn load_conversation_history(
             ));
         }
 
-        // Load conversation history
+        // Load conversation history.
+        // When STMO is active we request one extra item so we can detect
+        // whether the conversation has grown past max_conversation_history_items.
+        // If it has, turn-count math would be wrong, so we reject early.
+        let cap = ctx.max_conversation_history_items;
+        let fetch_limit = if stm_enabled {
+            cap.saturating_add(1)
+        } else {
+            cap
+        };
         let params = data_connector::ListParams {
-            limit: ctx.max_conversation_history_items,
+            limit: fetch_limit,
             order: data_connector::SortOrder::Asc,
             after: None,
         };
@@ -290,6 +299,17 @@ pub(super) async fn load_conversation_history(
             .await
         {
             Ok(stored_items) => {
+                if stm_enabled && stored_items.len() > cap {
+                    return Err(error::bad_request(
+                        "conversation_too_large",
+                        format!(
+                            "Conversation exceeds the configured limit of {cap} history items. \
+                             Increase max_conversation_history_items in the router config \
+                             or reduce conversation length before using short-term memory \
+                             optimization.",
+                        ),
+                    ));
+                }
                 raw_stored_item_count = Some(stored_items.len());
                 let mut items: Vec<ResponseInputOutputItem> = Vec::new();
                 for item in stored_items {

--- a/model_gateway/src/routers/grpc/regular/responses/common.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/common.rs
@@ -173,6 +173,7 @@ pub(super) async fn load_conversation_history(
     if let Some(ref prev_id_str) = modified_request.previous_response_id {
         let prev_id = ResponseId::from(prev_id_str.as_str());
         match ctx
+            .persistence
             .response_storage
             .get_response_chain(&prev_id, None)
             .await
@@ -241,6 +242,7 @@ pub(super) async fn load_conversation_history(
 
         // Check if conversation exists - return error if not found
         let conversation = ctx
+            .persistence
             .conversation_storage
             .get_conversation(&conv_id)
             .await
@@ -267,6 +269,7 @@ pub(super) async fn load_conversation_history(
             after: None,
         };
         match ctx
+            .persistence
             .conversation_item_storage
             .list_items(&conv_id, params)
             .await

--- a/model_gateway/src/routers/grpc/regular/responses/common.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/common.rs
@@ -261,13 +261,11 @@ pub(super) async fn load_conversation_history(
         }
 
         // Load conversation history
-        const MAX_CONVERSATION_HISTORY_ITEMS: usize = 100;
         let params = data_connector::ListParams {
-            limit: MAX_CONVERSATION_HISTORY_ITEMS,
+            limit: ctx.max_conversation_history_items,
             order: data_connector::SortOrder::Asc,
             after: None,
         };
-
         match ctx
             .conversation_item_storage
             .list_items(&conv_id, params)

--- a/model_gateway/src/routers/grpc/regular/responses/common.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/common.rs
@@ -396,20 +396,28 @@ pub(super) async fn load_conversation_history(
     );
 
     let turn_info = if stm_enabled {
-        let mut info = count_conversation_turn_info(&modified_request.input);
-        // If we loaded from conversation storage, total_items from the
-        // assembled (message-only) input undercounts — function_call,
-        // function_call_output, and MCP items are in the DB but filtered
-        // out of the inference window. Use the raw DB count instead so
-        // target_item_end points at the correct absolute position.
-        if let Some(raw_count) = raw_stored_item_count {
-            let current_input_count = match &request.input {
-                ResponseInput::Text(_) => 1,
-                ResponseInput::Items(items) => items.len(),
-            };
-            info.total_items = raw_count + current_input_count;
+        // If a conversation was requested but list_items failed, the assembled
+        // input only contains the current request — STMO turn counts would be
+        // wrong. Skip STMO for this request so persistence does not enqueue a
+        // job with an undercounted last_index/target_item_end.
+        if request.conversation.is_some() && raw_stored_item_count.is_none() {
+            None
+        } else {
+            let mut info = count_conversation_turn_info(&modified_request.input);
+            // If we loaded from conversation storage, total_items from the
+            // assembled (message-only) input undercounts — function_call,
+            // function_call_output, and MCP items are in the DB but filtered
+            // out of the inference window. Use the raw DB count instead so
+            // target_item_end points at the correct absolute position.
+            if let Some(raw_count) = raw_stored_item_count {
+                let current_input_count = match &request.input {
+                    ResponseInput::Text(_) => 1,
+                    ResponseInput::Items(items) => items.len(),
+                };
+                info.total_items = raw_count + current_input_count;
+            }
+            Some(info)
         }
-        Some(info)
     } else {
         None
     };

--- a/model_gateway/src/routers/grpc/regular/responses/common.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/common.rs
@@ -410,11 +410,20 @@ pub(super) async fn load_conversation_history(
             // out of the inference window. Use the raw DB count instead so
             // target_item_end points at the correct absolute position.
             if let Some(raw_count) = raw_stored_item_count {
-                let current_input_count = match &request.input {
-                    ResponseInput::Text(_) => 1,
-                    ResponseInput::Items(items) => items.len(),
-                };
-                info.total_items = raw_count + current_input_count;
+                // Only apply the raw-count correction when no response chain
+                // was also loaded. If previous_response_id was set, the chain
+                // merge ran last and overwrote modified_request.input with the
+                // full replayed history — count_conversation_turn_info already
+                // saw every item, so no correction is needed. (conversation and
+                // previous_response_id are mutually exclusive in the API, but
+                // we guard here for safety.)
+                if request.previous_response_id.is_none() {
+                    let current_input_count = match &request.input {
+                        ResponseInput::Text(_) => 1,
+                        ResponseInput::Items(items) => items.len(),
+                    };
+                    info.total_items = raw_count + current_input_count;
+                }
             }
             Some(info)
         }

--- a/model_gateway/src/routers/grpc/regular/responses/common.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/common.rs
@@ -282,7 +282,7 @@ pub(super) async fn load_conversation_history(
         // whether the conversation has grown past max_conversation_history_items.
         // If it has, turn-count math would be wrong, so we reject early.
         let cap = ctx.max_conversation_history_items;
-        let fetch_limit = if stm_enabled {
+        let fetch_limit = if stm_enabled && request.store.unwrap_or(true) {
             cap.saturating_add(1)
         } else {
             cap
@@ -299,7 +299,10 @@ pub(super) async fn load_conversation_history(
             .await
         {
             Ok(stored_items) => {
-                if stm_enabled && stored_items.len() > cap {
+                // Only reject oversized conversations when the response will
+                // actually be persisted. store=false requests skip persistence
+                // entirely, so STMO is never enqueued and the cap does not apply.
+                if stm_enabled && request.store.unwrap_or(true) && stored_items.len() > cap {
                     return Err(error::bad_request(
                         "conversation_too_large",
                         format!(

--- a/model_gateway/src/routers/grpc/regular/responses/common.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/common.rs
@@ -178,6 +178,11 @@ pub(super) async fn load_conversation_history(
 ) -> Result<LoadedRequest, Response> {
     let mut modified_request = request.clone();
     let mut conversation_items: Option<Vec<ResponseInputOutputItem>> = None;
+    // Tracks the raw DB item count (all types) for the conversation path so
+    // that total_items in ConversationTurnInfo is not undercounted when
+    // function_call/function_call_output/MCP items are present in storage
+    // but filtered out of the inference window.
+    let mut raw_stored_item_count: Option<usize> = None;
 
     // Handle previous_response_id by loading response chain
     if let Some(ref prev_id_str) = modified_request.previous_response_id {
@@ -285,6 +290,7 @@ pub(super) async fn load_conversation_history(
             .await
         {
             Ok(stored_items) => {
+                raw_stored_item_count = Some(stored_items.len());
                 let mut items: Vec<ResponseInputOutputItem> = Vec::new();
                 for item in stored_items {
                     if item.item_type == "message" {
@@ -370,7 +376,20 @@ pub(super) async fn load_conversation_history(
     );
 
     let turn_info = if stm_enabled {
-        Some(count_conversation_turn_info(&modified_request.input))
+        let mut info = count_conversation_turn_info(&modified_request.input);
+        // If we loaded from conversation storage, total_items from the
+        // assembled (message-only) input undercounts — function_call,
+        // function_call_output, and MCP items are in the DB but filtered
+        // out of the inference window. Use the raw DB count instead so
+        // target_item_end points at the correct absolute position.
+        if let Some(raw_count) = raw_stored_item_count {
+            let current_input_count = match &request.input {
+                ResponseInput::Text(_) => 1,
+                ResponseInput::Items(items) => items.len(),
+            };
+            info.total_items = raw_count + current_input_count;
+        }
+        Some(info)
     } else {
         None
     };

--- a/model_gateway/src/routers/grpc/regular/responses/handlers.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/handlers.rs
@@ -112,13 +112,16 @@ async fn route_responses_streaming(
     params: ResponsesCallContext,
 ) -> Response {
     // 1. Load conversation history
-    let loaded_request =
-        match load_conversation_history(ctx, &request, ctx.memory_execution_context.stm_enabled)
-            .await
-        {
-            Ok(req) => req,
-            Err(response) => return response, // Already a Response with proper status code
-        };
+    let loaded_request = match load_conversation_history(
+        ctx,
+        &request,
+        ctx.memory_execution_context.stm_enabled.active(),
+    )
+    .await
+    {
+        Ok(req) => req,
+        Err(response) => return response, // Already a Response with proper status code
+    };
     let modified_request = loaded_request.request;
     let conversation_turn_info = loaded_request.turn_info;
 

--- a/model_gateway/src/routers/grpc/regular/responses/handlers.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/handlers.rs
@@ -112,10 +112,15 @@ async fn route_responses_streaming(
     params: ResponsesCallContext,
 ) -> Response {
     // 1. Load conversation history
-    let modified_request = match load_conversation_history(ctx, &request).await {
-        Ok(req) => req,
-        Err(response) => return response, // Already a Response with proper status code
-    };
+    let loaded_request =
+        match load_conversation_history(ctx, &request, ctx.memory_execution_context.stm_enabled)
+            .await
+        {
+            Ok(req) => req,
+            Err(response) => return response, // Already a Response with proper status code
+        };
+    let modified_request = loaded_request.request;
+    let conversation_turn_info = loaded_request.turn_info;
 
     // 2. Check MCP connection and get whether MCP tools are present
     let (has_mcp_tools, mcp_servers) =
@@ -133,6 +138,7 @@ async fn route_responses_streaming(
             &request,
             params,
             mcp_servers,
+            conversation_turn_info,
         );
     }
 
@@ -148,5 +154,12 @@ async fn route_responses_streaming(
     };
 
     // 4. Execute chat pipeline and convert streaming format (no MCP tools)
-    streaming::convert_chat_stream_to_responses_stream(ctx, chat_request, params, &request).await
+    streaming::convert_chat_stream_to_responses_stream(
+        ctx,
+        chat_request,
+        params,
+        &request,
+        conversation_turn_info,
+    )
+    .await
 }

--- a/model_gateway/src/routers/grpc/regular/responses/handlers.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/handlers.rs
@@ -142,7 +142,6 @@ async fn route_responses_streaming(
             &request,
             params,
             mcp_servers,
-            conversation_turn_info,
         );
     }
 

--- a/model_gateway/src/routers/grpc/regular/responses/handlers.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/handlers.rs
@@ -111,26 +111,27 @@ async fn route_responses_streaming(
     request: Arc<ResponsesRequest>,
     params: ResponsesCallContext,
 ) -> Response {
-    // 1. Load conversation history
-    let loaded_request = match load_conversation_history(
-        ctx,
-        &request,
-        ctx.memory_execution_context.stm_enabled.active(),
-    )
-    .await
-    {
-        Ok(req) => req,
-        Err(response) => return response, // Already a Response with proper status code
-    };
-    let modified_request = loaded_request.request;
-    let conversation_turn_info = loaded_request.turn_info;
-
-    // 2. Check MCP connection and get whether MCP tools are present
+    // 1. Check MCP connection first so we can gate STMO logic correctly.
+    // ensure_mcp_connection only inspects request.tools, not request.input,
+    // so it is safe to call before history loading.
     let (has_mcp_tools, mcp_servers) =
         match ensure_mcp_connection(&ctx.mcp_orchestrator, request.tools.as_deref()).await {
             Ok(result) => result,
             Err(response) => return response,
         };
+
+    // 2. Load conversation history.
+    // The MCP streaming path (execute_tool_loop_streaming) never calls
+    // persist_response_if_needed, so STMO is never enqueued there. Disable
+    // stm_enabled for that path so the cap overflow check does not reject
+    // requests that will never trigger STMO anyway.
+    let stm_enabled = ctx.memory_execution_context.stm_enabled.active() && !has_mcp_tools;
+    let loaded_request = match load_conversation_history(ctx, &request, stm_enabled).await {
+        Ok(req) => req,
+        Err(response) => return response,
+    };
+    let modified_request = loaded_request.request;
+    let conversation_turn_info = loaded_request.turn_info;
 
     if has_mcp_tools {
         debug!("MCP tools detected in streaming mode, using streaming tool loop");

--- a/model_gateway/src/routers/grpc/regular/responses/non_streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/non_streaming.rs
@@ -64,14 +64,11 @@ pub(super) async fn route_responses_internal(
 
     // 5. Persist response to storage if store=true
     persist_response_if_needed(
-        ctx.conversation_storage.clone(),
-        ctx.conversation_item_storage.clone(),
-        ctx.conversation_memory_writer.clone(),
-        ctx.response_storage.clone(),
+        &ctx.persistence,
+        ctx.memory_execution_context.clone(),
         &responses_response,
         &request,
         ctx.request_context.clone(),
-        ctx.memory_execution_context.clone(),
     )
     .await;
 

--- a/model_gateway/src/routers/grpc/regular/responses/non_streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/non_streaming.rs
@@ -46,7 +46,10 @@ pub(super) async fn route_responses_internal(
     params: ResponsesCallContext,
 ) -> Result<ResponsesResponse, Response> {
     // 1. Load conversation history and build modified request
-    let modified_request = load_conversation_history(ctx, &request).await?;
+    let loaded_request =
+        load_conversation_history(ctx, &request, ctx.memory_execution_context.stm_enabled).await?;
+    let modified_request = loaded_request.request;
+    let conversation_turn_info = loaded_request.turn_info;
 
     // 2. Check MCP connection and get whether MCP tools are present
     let (has_mcp_tools, mcp_servers) =
@@ -66,6 +69,7 @@ pub(super) async fn route_responses_internal(
     persist_response_if_needed(
         &ctx.persistence,
         ctx.memory_execution_context.clone(),
+        conversation_turn_info,
         &responses_response,
         &request,
         ctx.request_context.clone(),

--- a/model_gateway/src/routers/grpc/regular/responses/non_streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/non_streaming.rs
@@ -66,10 +66,12 @@ pub(super) async fn route_responses_internal(
     persist_response_if_needed(
         ctx.conversation_storage.clone(),
         ctx.conversation_item_storage.clone(),
+        ctx.conversation_memory_writer.clone(),
         ctx.response_storage.clone(),
         &responses_response,
         &request,
         ctx.request_context.clone(),
+        ctx.memory_execution_context.clone(),
     )
     .await;
 

--- a/model_gateway/src/routers/grpc/regular/responses/non_streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/non_streaming.rs
@@ -46,8 +46,12 @@ pub(super) async fn route_responses_internal(
     params: ResponsesCallContext,
 ) -> Result<ResponsesResponse, Response> {
     // 1. Load conversation history and build modified request
-    let loaded_request =
-        load_conversation_history(ctx, &request, ctx.memory_execution_context.stm_enabled).await?;
+    let loaded_request = load_conversation_history(
+        ctx,
+        &request,
+        ctx.memory_execution_context.stm_enabled.active(),
+    )
+    .await?;
     let modified_request = loaded_request.request;
     let conversation_turn_info = loaded_request.turn_info;
 

--- a/model_gateway/src/routers/grpc/regular/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/streaming.rs
@@ -433,7 +433,6 @@ pub(super) fn execute_tool_loop_streaming(
     original_request: &ResponsesRequest,
     params: ResponsesCallContext,
     mcp_servers: Vec<McpServerBinding>,
-    _conversation_turn_info: Option<ConversationTurnInfo>,
 ) -> Response {
     // Create SSE channel for client
     let (tx, rx) = mpsc::unbounded_channel::<Result<Bytes, std::io::Error>>();

--- a/model_gateway/src/routers/grpc/regular/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/streaming.rs
@@ -31,8 +31,8 @@ use openai_protocol::{
 };
 use serde_json::{json, Value};
 use smg_data_connector::{
-    ConversationItemStorage, ConversationStorage, RequestContext as StorageRequestContext,
-    ResponseStorage,
+    ConversationItemStorage, ConversationMemoryWriter, ConversationStorage,
+    RequestContext as StorageRequestContext, ResponseStorage,
 };
 use smg_mcp::{McpServerBinding, McpToolSession, ResponseFormat, ToolExecutionInput};
 use tokio::sync::mpsc;
@@ -48,6 +48,7 @@ use super::{
     conversions,
 };
 use crate::{
+    memory::MemoryExecutionContext,
     observability::metrics::{metrics_labels, Metrics},
     routers::{
         common::mcp_utils::{prepare_hosted_dispatch_args, DEFAULT_MAX_ITERATIONS},
@@ -105,7 +106,9 @@ pub(super) async fn convert_chat_stream_to_responses_stream(
     let response_storage = ctx.response_storage.clone();
     let conversation_storage = ctx.conversation_storage.clone();
     let conversation_item_storage = ctx.conversation_item_storage.clone();
+    let conversation_memory_writer = ctx.conversation_memory_writer.clone();
     let request_context = ctx.request_context.clone();
+    let memory_execution_context = ctx.memory_execution_context.clone();
 
     #[expect(
         clippy::disallowed_methods,
@@ -118,7 +121,9 @@ pub(super) async fn convert_chat_stream_to_responses_stream(
             response_storage,
             conversation_storage,
             conversation_item_storage,
+            conversation_memory_writer,
             request_context,
+            memory_execution_context,
             tx.clone(),
         )
         .await
@@ -136,13 +141,19 @@ pub(super) async fn convert_chat_stream_to_responses_stream(
 }
 
 /// Process chat SSE stream and transform to responses format
+#[expect(
+    clippy::too_many_arguments,
+    reason = "streaming path threads independent handles; grouping them would obscure ownership"
+)]
 async fn process_and_transform_sse_stream(
     body: Body,
     original_request: ResponsesRequest,
     response_storage: Arc<dyn ResponseStorage>,
     conversation_storage: Arc<dyn ConversationStorage>,
     conversation_item_storage: Arc<dyn ConversationItemStorage>,
+    conversation_memory_writer: Arc<dyn ConversationMemoryWriter>,
     request_context: Option<StorageRequestContext>,
+    memory_execution_context: MemoryExecutionContext,
     tx: mpsc::UnboundedSender<Result<Bytes, std::io::Error>>,
 ) -> Result<(), String> {
     // Create accumulator for final response
@@ -233,10 +244,12 @@ async fn process_and_transform_sse_stream(
     persist_response_if_needed(
         conversation_storage,
         conversation_item_storage,
+        conversation_memory_writer,
         response_storage,
         &final_response,
         &original_request,
         request_context,
+        memory_execution_context,
     )
     .await;
 

--- a/model_gateway/src/routers/grpc/regular/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/streaming.rs
@@ -30,11 +30,11 @@ use openai_protocol::{
     },
 };
 use serde_json::{json, Value};
-use smg_data_connector::{
-    ConversationItemStorage, ConversationMemoryWriter, ConversationStorage,
-    RequestContext as StorageRequestContext, ResponseStorage,
+use smg_data_connector::RequestContext as StorageRequestContext;
+use smg_mcp::{
+    apply_hosted_tool_overrides, extract_hosted_tool_overrides, McpServerBinding, McpToolSession,
+    ResponseFormat, ToolExecutionInput,
 };
-use smg_mcp::{McpServerBinding, McpToolSession, ResponseFormat, ToolExecutionInput};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::{debug, trace, warn};
@@ -56,7 +56,7 @@ use crate::{
             common::responses::{
                 build_sse_response, persist_response_if_needed,
                 streaming::{attach_mcp_server_label, OutputItemType, ResponseStreamEventEmitter},
-                ResponsesContext,
+                PersistenceHandles, ResponsesContext,
             },
             utils,
         },
@@ -103,10 +103,7 @@ pub(super) async fn convert_chat_stream_to_responses_stream(
 
     // Spawn background task to transform stream
     let original_request_clone = original_request.clone();
-    let response_storage = ctx.response_storage.clone();
-    let conversation_storage = ctx.conversation_storage.clone();
-    let conversation_item_storage = ctx.conversation_item_storage.clone();
-    let conversation_memory_writer = ctx.conversation_memory_writer.clone();
+    let persistence = ctx.persistence.clone();
     let request_context = ctx.request_context.clone();
     let memory_execution_context = ctx.memory_execution_context.clone();
 
@@ -118,10 +115,7 @@ pub(super) async fn convert_chat_stream_to_responses_stream(
         if let Err(e) = process_and_transform_sse_stream(
             body,
             original_request_clone,
-            response_storage,
-            conversation_storage,
-            conversation_item_storage,
-            conversation_memory_writer,
+            persistence,
             request_context,
             memory_execution_context,
             tx.clone(),
@@ -141,17 +135,10 @@ pub(super) async fn convert_chat_stream_to_responses_stream(
 }
 
 /// Process chat SSE stream and transform to responses format
-#[expect(
-    clippy::too_many_arguments,
-    reason = "streaming path threads independent handles; grouping them would obscure ownership"
-)]
 async fn process_and_transform_sse_stream(
     body: Body,
     original_request: ResponsesRequest,
-    response_storage: Arc<dyn ResponseStorage>,
-    conversation_storage: Arc<dyn ConversationStorage>,
-    conversation_item_storage: Arc<dyn ConversationItemStorage>,
-    conversation_memory_writer: Arc<dyn ConversationMemoryWriter>,
+    persistence: PersistenceHandles,
     request_context: Option<StorageRequestContext>,
     memory_execution_context: MemoryExecutionContext,
     tx: mpsc::UnboundedSender<Result<Bytes, std::io::Error>>,
@@ -242,14 +229,11 @@ async fn process_and_transform_sse_stream(
     // Finalize and persist accumulated response
     let final_response = accumulator.finalize();
     persist_response_if_needed(
-        conversation_storage,
-        conversation_item_storage,
-        conversation_memory_writer,
-        response_storage,
+        &persistence,
+        memory_execution_context,
         &final_response,
         &original_request,
         request_context,
-        memory_execution_context,
     )
     .await;
 

--- a/model_gateway/src/routers/grpc/regular/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/streaming.rs
@@ -31,10 +31,7 @@ use openai_protocol::{
 };
 use serde_json::{json, Value};
 use smg_data_connector::RequestContext as StorageRequestContext;
-use smg_mcp::{
-    apply_hosted_tool_overrides, extract_hosted_tool_overrides, McpServerBinding, McpToolSession,
-    ResponseFormat, ToolExecutionInput,
-};
+use smg_mcp::{McpServerBinding, McpToolSession, ResponseFormat, ToolExecutionInput};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::{debug, trace, warn};

--- a/model_gateway/src/routers/grpc/regular/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/streaming.rs
@@ -48,7 +48,10 @@ use crate::{
     memory::MemoryExecutionContext,
     observability::metrics::{metrics_labels, Metrics},
     routers::{
-        common::mcp_utils::{prepare_hosted_dispatch_args, DEFAULT_MAX_ITERATIONS},
+        common::{
+            mcp_utils::{prepare_hosted_dispatch_args, DEFAULT_MAX_ITERATIONS},
+            persistence_utils::ConversationTurnInfo,
+        },
         grpc::{
             common::responses::{
                 build_sse_response, persist_response_if_needed,
@@ -77,6 +80,7 @@ pub(super) async fn convert_chat_stream_to_responses_stream(
     chat_request: Arc<ChatCompletionRequest>,
     params: ResponsesCallContext,
     original_request: &ResponsesRequest,
+    conversation_turn_info: Option<ConversationTurnInfo>,
 ) -> Response {
     debug!("Converting chat SSE stream to responses SSE format");
 
@@ -115,6 +119,7 @@ pub(super) async fn convert_chat_stream_to_responses_stream(
             persistence,
             request_context,
             memory_execution_context,
+            conversation_turn_info,
             tx.clone(),
         )
         .await
@@ -138,6 +143,7 @@ async fn process_and_transform_sse_stream(
     persistence: PersistenceHandles,
     request_context: Option<StorageRequestContext>,
     memory_execution_context: MemoryExecutionContext,
+    conversation_turn_info: Option<ConversationTurnInfo>,
     tx: mpsc::UnboundedSender<Result<Bytes, std::io::Error>>,
 ) -> Result<(), String> {
     // Create accumulator for final response
@@ -228,6 +234,7 @@ async fn process_and_transform_sse_stream(
     persist_response_if_needed(
         &persistence,
         memory_execution_context,
+        conversation_turn_info,
         &final_response,
         &original_request,
         request_context,
@@ -426,6 +433,7 @@ pub(super) fn execute_tool_loop_streaming(
     original_request: &ResponsesRequest,
     params: ResponsesCallContext,
     mcp_servers: Vec<McpServerBinding>,
+    _conversation_turn_info: Option<ConversationTurnInfo>,
 ) -> Response {
     // Create SSE channel for client
     let (tx, rx) = mpsc::unbounded_channel::<Result<Bytes, std::io::Error>>();

--- a/model_gateway/src/routers/grpc/router.rs
+++ b/model_gateway/src/routers/grpc/router.rs
@@ -14,7 +14,8 @@ use tracing::debug;
 
 use super::{
     common::responses::{
-        handlers::cancel_response_impl, utils::validate_worker_availability, ResponsesContext,
+        handlers::cancel_response_impl, utils::validate_worker_availability, PersistenceHandles,
+        ResponsesContext,
     },
     context::SharedComponents,
     harmony::{serve_harmony_responses, serve_harmony_responses_stream, HarmonyDetector},
@@ -153,10 +154,12 @@ impl GrpcRouter {
             ResponsesContext::new(
                 Arc::new(pipeline.clone()),
                 shared_components.clone(),
-                ctx.response_storage.clone(),
-                ctx.conversation_storage.clone(),
-                ctx.conversation_item_storage.clone(),
-                ctx.conversation_memory_writer.clone(),
+                PersistenceHandles {
+                    response_storage: ctx.response_storage.clone(),
+                    conversation_storage: ctx.conversation_storage.clone(),
+                    conversation_item_storage: ctx.conversation_item_storage.clone(),
+                    conversation_memory_writer: ctx.conversation_memory_writer.clone(),
+                },
                 mcp_orchestrator.clone(),
                 storage_request_context.clone(),
                 max_conversation_history_items,
@@ -355,14 +358,7 @@ impl GrpcRouter {
             let harmony_ctx = ResponsesContext::new(
                 Arc::new(self.harmony_pipeline.clone()),
                 self.shared_components.clone(),
-                self.harmony_responses_context.response_storage.clone(),
-                self.harmony_responses_context.conversation_storage.clone(),
-                self.harmony_responses_context
-                    .conversation_item_storage
-                    .clone(),
-                self.harmony_responses_context
-                    .conversation_memory_writer
-                    .clone(),
+                self.harmony_responses_context.persistence.clone(),
                 self.harmony_responses_context.mcp_orchestrator.clone(),
                 smg_data_connector::current_request_context(),
                 self.max_conversation_history_items,
@@ -386,10 +382,7 @@ impl GrpcRouter {
             let regular_ctx = ResponsesContext::new(
                 Arc::new(self.pipeline.clone()),
                 self.shared_components.clone(),
-                self.responses_context.response_storage.clone(),
-                self.responses_context.conversation_storage.clone(),
-                self.responses_context.conversation_item_storage.clone(),
-                self.responses_context.conversation_memory_writer.clone(),
+                self.responses_context.persistence.clone(),
                 self.responses_context.mcp_orchestrator.clone(),
                 smg_data_connector::current_request_context(),
                 self.max_conversation_history_items,

--- a/model_gateway/src/routers/grpc/router.rs
+++ b/model_gateway/src/routers/grpc/router.rs
@@ -47,6 +47,7 @@ pub struct GrpcRouter {
     shared_components: Arc<SharedComponents>,
     responses_context: ResponsesContext,
     harmony_responses_context: ResponsesContext,
+    max_conversation_history_items: usize,
     retry_config: RetryConfig,
 }
 
@@ -139,6 +140,7 @@ impl GrpcRouter {
 
         // Capture storage request context from middleware task-local (before any spawn)
         let storage_request_context = smg_data_connector::current_request_context();
+        let max_conversation_history_items = ctx.router_config.max_conversation_history_items;
 
         // Helper closure to create responses context with a given pipeline
         let create_responses_context = |pipeline: &RequestPipeline| {
@@ -151,6 +153,7 @@ impl GrpcRouter {
                 ctx.conversation_memory_writer.clone(),
                 mcp_orchestrator.clone(),
                 storage_request_context.clone(),
+                max_conversation_history_items,
             )
         };
 
@@ -169,6 +172,7 @@ impl GrpcRouter {
             shared_components,
             responses_context,
             harmony_responses_context,
+            max_conversation_history_items,
             retry_config: ctx.router_config.effective_retry_config(),
         })
     }
@@ -344,6 +348,7 @@ impl GrpcRouter {
                     .clone(),
                 self.harmony_responses_context.mcp_orchestrator.clone(),
                 smg_data_connector::current_request_context(),
+                self.max_conversation_history_items,
             );
 
             if body.stream.unwrap_or(false) {

--- a/model_gateway/src/routers/grpc/router.rs
+++ b/model_gateway/src/routers/grpc/router.rs
@@ -24,7 +24,8 @@ use super::{
 };
 use crate::{
     app_context::AppContext,
-    config::types::RetryConfig,
+    config::types::{MemoryRuntimeConfig, RetryConfig},
+    memory::MemoryExecutionContext,
     middleware::TenantRequestMeta,
     observability::metrics::{metrics_labels, Metrics},
     routers::{
@@ -48,6 +49,7 @@ pub struct GrpcRouter {
     responses_context: ResponsesContext,
     harmony_responses_context: ResponsesContext,
     max_conversation_history_items: usize,
+    memory_runtime_config: MemoryRuntimeConfig,
     retry_config: RetryConfig,
 }
 
@@ -141,8 +143,12 @@ impl GrpcRouter {
         // Capture storage request context from middleware task-local (before any spawn)
         let storage_request_context = smg_data_connector::current_request_context();
         let max_conversation_history_items = ctx.router_config.max_conversation_history_items;
+        let memory_runtime_config = ctx.router_config.memory_runtime.clone();
 
-        // Helper closure to create responses context with a given pipeline
+        // Helper closure to create responses context with a given pipeline.
+        // Uses MemoryExecutionContext::default() because these contexts are built at
+        // startup before any request headers are available. Per-request contexts are
+        // rebuilt inside route_responses_impl with the actual request headers.
         let create_responses_context = |pipeline: &RequestPipeline| {
             ResponsesContext::new(
                 Arc::new(pipeline.clone()),
@@ -154,6 +160,7 @@ impl GrpcRouter {
                 mcp_orchestrator.clone(),
                 storage_request_context.clone(),
                 max_conversation_history_items,
+                MemoryExecutionContext::default(),
             )
         };
 
@@ -173,6 +180,7 @@ impl GrpcRouter {
             responses_context,
             harmony_responses_context,
             max_conversation_history_items,
+            memory_runtime_config,
             retry_config: ctx.router_config.effective_retry_config(),
         })
     }
@@ -329,6 +337,15 @@ impl GrpcRouter {
         let is_harmony =
             HarmonyDetector::is_harmony_model_in_registry(&self.worker_registry, &body.model);
 
+        // Build memory execution context from per-request headers. gRPC clients map
+        // metadata to HTTP/2 headers, so headers may carry memory config just like
+        // the HTTP path. An absent or empty header produces the default (no-op) context.
+        let empty_headers = HeaderMap::new();
+        let memory_execution_context = MemoryExecutionContext::from_http_headers(
+            headers.unwrap_or(&empty_headers),
+            &self.memory_runtime_config,
+        );
+
         if is_harmony {
             debug!(
                 "Processing Harmony responses request for model: {}, streaming: {}",
@@ -349,6 +366,7 @@ impl GrpcRouter {
                 self.harmony_responses_context.mcp_orchestrator.clone(),
                 smg_data_connector::current_request_context(),
                 self.max_conversation_history_items,
+                memory_execution_context,
             );
 
             if body.stream.unwrap_or(false) {
@@ -362,8 +380,23 @@ impl GrpcRouter {
                 }
             }
         } else {
+            // Build a fresh per-request context so that storage_request_context and
+            // memory_execution_context reflect the current request's headers rather
+            // than the stale values captured at startup.
+            let regular_ctx = ResponsesContext::new(
+                Arc::new(self.pipeline.clone()),
+                self.shared_components.clone(),
+                self.responses_context.response_storage.clone(),
+                self.responses_context.conversation_storage.clone(),
+                self.responses_context.conversation_item_storage.clone(),
+                self.responses_context.conversation_memory_writer.clone(),
+                self.responses_context.mcp_orchestrator.clone(),
+                smg_data_connector::current_request_context(),
+                self.max_conversation_history_items,
+                memory_execution_context,
+            );
             responses::route_responses(
-                &self.responses_context,
+                &regular_ctx,
                 Arc::new(body.clone()),
                 headers.cloned(),
                 tenant_meta.clone(),

--- a/model_gateway/src/routers/openai/context.rs
+++ b/model_gateway/src/routers/openai/context.rs
@@ -14,7 +14,8 @@ use smg_mcp::{McpOrchestrator, McpToolSession};
 use super::provider::Provider;
 use crate::{
     config::RouterConfig, memory::MemoryExecutionContext, middleware,
-    middleware::TenantRequestMeta, worker::Worker,
+    middleware::TenantRequestMeta, routers::common::persistence_utils::ConversationTurnInfo,
+    worker::Worker,
 };
 
 pub struct RequestContext {
@@ -132,6 +133,7 @@ pub struct PayloadState {
 pub struct ResponsesPayloadState {
     pub previous_response_id: Option<String>,
     pub existing_mcp_list_tools_labels: Vec<String>,
+    pub conversation_turn_info: Option<ConversationTurnInfo>,
 }
 
 impl RequestContext {
@@ -268,6 +270,7 @@ pub struct OwnedStreamingContext {
     pub original_body: ResponsesRequest,
     pub previous_response_id: Option<String>,
     pub existing_mcp_list_tools_labels: Vec<String>,
+    pub conversation_turn_info: Option<ConversationTurnInfo>,
     pub storage: StorageHandles,
 }
 
@@ -306,6 +309,7 @@ impl RequestContext {
             original_body,
             previous_response_id: responses_payload_state.previous_response_id,
             existing_mcp_list_tools_labels: responses_payload_state.existing_mcp_list_tools_labels,
+            conversation_turn_info: responses_payload_state.conversation_turn_info,
             storage: StorageHandles {
                 response,
                 conversation,

--- a/model_gateway/src/routers/openai/responses/history.rs
+++ b/model_gateway/src/routers/openai/responses/history.rs
@@ -154,7 +154,7 @@ pub(crate) async fn load_input_history(
             .shared
             .router_config
             .max_conversation_history_items;
-        let fetch_limit = if stm_enabled {
+        let fetch_limit = if stm_enabled && request_body.store.unwrap_or(true) {
             cap.saturating_add(1)
         } else {
             cap
@@ -170,7 +170,10 @@ pub(crate) async fn load_input_history(
             .await
         {
             Ok(stored_items) => {
-                if stm_enabled && stored_items.len() > cap {
+                // Only reject oversized conversations when the response will
+                // actually be persisted. store=false requests skip persistence
+                // entirely, so STMO is never enqueued and the cap does not apply.
+                if stm_enabled && request_body.store.unwrap_or(true) && stored_items.len() > cap {
                     Metrics::record_router_error(
                         metrics_labels::ROUTER_OPENAI,
                         metrics_labels::BACKEND_EXTERNAL,

--- a/model_gateway/src/routers/openai/responses/history.rs
+++ b/model_gateway/src/routers/openai/responses/history.rs
@@ -19,7 +19,10 @@ use crate::{
     observability::metrics::{metrics_labels, Metrics},
     routers::{
         common::{
-            header_utils::ConversationMemoryConfig, persistence_utils::split_stored_message_content,
+            header_utils::ConversationMemoryConfig,
+            persistence_utils::{
+                count_conversation_turn_info, split_stored_message_content, ConversationTurnInfo,
+            },
         },
         error,
     },
@@ -28,6 +31,7 @@ use crate::{
 pub(crate) struct LoadedInputHistory {
     pub previous_response_id: Option<String>,
     pub existing_mcp_list_tools_labels: Vec<String>,
+    pub conversation_turn_info: Option<ConversationTurnInfo>,
 }
 
 /// Load conversation history and/or previous response chain into request input.
@@ -39,6 +43,7 @@ pub(crate) async fn load_input_history(
     conversation: Option<&str>,
     request_body: &mut ResponsesRequest,
     model: &str,
+    stm_enabled: bool,
 ) -> Result<LoadedInputHistory, Response> {
     let previous_response_id = request_body
         .previous_response_id
@@ -232,9 +237,16 @@ pub(crate) async fn load_input_history(
         request_body.input = ResponseInput::Items(items);
     }
 
+    let conversation_turn_info = if stm_enabled {
+        Some(count_conversation_turn_info(&request_body.input))
+    } else {
+        None
+    };
+
     Ok(LoadedInputHistory {
         previous_response_id,
         existing_mcp_list_tools_labels: existing_mcp_list_tools_labels.into_iter().collect(),
+        conversation_turn_info,
     })
 }
 

--- a/model_gateway/src/routers/openai/responses/history.rs
+++ b/model_gateway/src/routers/openai/responses/history.rs
@@ -53,6 +53,12 @@ pub(crate) async fn load_input_history(
 
     // Load items from previous response chain if specified
     let mut chain_items: Option<Vec<ResponseInputOutputItem>> = None;
+    let mut raw_stored_item_count: Option<usize> = None;
+    // Capture current request input count before history loading mutates request_body.input
+    let current_input_count = match &request_body.input {
+        ResponseInput::Text(_) => 1,
+        ResponseInput::Items(items) => items.len(),
+    };
     if let Some(prev_id_str) = &previous_response_id {
         let prev_id = ResponseId::from(prev_id_str.as_str());
         match components
@@ -155,6 +161,7 @@ pub(crate) async fn load_input_history(
             .await
         {
             Ok(stored_items) => {
+                raw_stored_item_count = Some(stored_items.len());
                 let mut items: Vec<ResponseInputOutputItem> = Vec::new();
                 for item in stored_items {
                     match item.item_type.as_str() {
@@ -238,7 +245,15 @@ pub(crate) async fn load_input_history(
     }
 
     let conversation_turn_info = if stm_enabled {
-        Some(count_conversation_turn_info(&request_body.input))
+        let mut info = count_conversation_turn_info(&request_body.input);
+        // Correct total_items when loaded from conversation storage: reasoning
+        // items are skipped during load but are stored in the DB, so the
+        // assembled input underestimates the true conversation size. Use the
+        // raw DB count + current input item count for an accurate target_item_end.
+        if let Some(raw_count) = raw_stored_item_count {
+            info.total_items = raw_count + current_input_count;
+        }
+        Some(info)
     } else {
         None
     };

--- a/model_gateway/src/routers/openai/responses/history.rs
+++ b/model_gateway/src/routers/openai/responses/history.rs
@@ -147,16 +147,16 @@ pub(crate) async fn load_input_history(
             ));
         }
 
-        // Always fetch cap+1 items so we can detect whether the conversation
-        // has grown past max_conversation_history_items. Fetching one extra row
-        // is harmless (it is just a SQL LIMIT). The rejection below only fires
-        // when STMO is active and the response will be persisted.
+        // Fetch up to cap items. If we get cap rows back the conversation is at
+        // or beyond the configured limit; reject when STMO is active and the
+        // response will be persisted. The SQL LIMIT also bounds the inference
+        // window, so no post-fetch truncation is needed.
         let cap = components
             .shared
             .router_config
             .max_conversation_history_items;
         let params = ListParams {
-            limit: cap.saturating_add(1),
+            limit: cap,
             order: SortOrder::Asc,
             after: None,
         };
@@ -169,7 +169,7 @@ pub(crate) async fn load_input_history(
                 // Only reject oversized conversations when the response will
                 // actually be persisted. store=false requests skip persistence
                 // entirely, so STMO is never enqueued and the cap does not apply.
-                if stm_enabled && request_body.store.unwrap_or(true) && stored_items.len() > cap {
+                if stm_enabled && request_body.store.unwrap_or(true) && stored_items.len() >= cap {
                     Metrics::record_router_error(
                         metrics_labels::ROUTER_OPENAI,
                         metrics_labels::BACKEND_EXTERNAL,
@@ -181,7 +181,7 @@ pub(crate) async fn load_input_history(
                     return Err(error::bad_request(
                         "conversation_too_large",
                         format!(
-                            "Conversation exceeds the configured limit of {cap} history items. \
+                            "Conversation has reached the configured limit of {cap} history items. \
                              Increase max_conversation_history_items in the router config \
                              or reduce conversation length before using short-term memory \
                              optimization.",

--- a/model_gateway/src/routers/openai/responses/history.rs
+++ b/model_gateway/src/routers/openai/responses/history.rs
@@ -25,8 +25,6 @@ use crate::{
     },
 };
 
-const MAX_CONVERSATION_HISTORY_ITEMS: usize = 100;
-
 pub(crate) struct LoadedInputHistory {
     pub previous_response_id: Option<String>,
     pub existing_mcp_list_tools_labels: Vec<String>,
@@ -139,11 +137,13 @@ pub(crate) async fn load_input_history(
         }
 
         let params = ListParams {
-            limit: MAX_CONVERSATION_HISTORY_ITEMS,
+            limit: components
+                .shared
+                .router_config
+                .max_conversation_history_items,
             order: SortOrder::Asc,
             after: None,
         };
-
         match components
             .conversation_item_storage
             .list_items(&conv_id, params)

--- a/model_gateway/src/routers/openai/responses/history.rs
+++ b/model_gateway/src/routers/openai/responses/history.rs
@@ -286,7 +286,16 @@ pub(crate) async fn load_input_history(
             // assembled input underestimates the true conversation size. Use the
             // raw DB count + current input item count for an accurate target_item_end.
             if let Some(raw_count) = raw_stored_item_count {
-                info.total_items = raw_count + current_input_count;
+                // Only apply the raw-count correction when no response chain
+                // was also loaded. If previous_response_id was set, the chain
+                // merge ran last and overwrote request_body.input with the full
+                // replayed history — count_conversation_turn_info already saw
+                // every item, so no correction is needed. (conversation and
+                // previous_response_id are mutually exclusive per the API spec,
+                // but we guard here for safety.)
+                if previous_response_id.is_none() {
+                    info.total_items = raw_count + current_input_count;
+                }
             }
             Some(info)
         }

--- a/model_gateway/src/routers/openai/responses/history.rs
+++ b/model_gateway/src/routers/openai/responses/history.rs
@@ -147,20 +147,16 @@ pub(crate) async fn load_input_history(
             ));
         }
 
-        // When STMO is active we request one extra item so we can detect
-        // whether the conversation has grown past max_conversation_history_items.
-        // If it has, turn-count math would be wrong, so we reject early.
+        // Always fetch cap+1 items so we can detect whether the conversation
+        // has grown past max_conversation_history_items. Fetching one extra row
+        // is harmless (it is just a SQL LIMIT). The rejection below only fires
+        // when STMO is active and the response will be persisted.
         let cap = components
             .shared
             .router_config
             .max_conversation_history_items;
-        let fetch_limit = if stm_enabled && request_body.store.unwrap_or(true) {
-            cap.saturating_add(1)
-        } else {
-            cap
-        };
         let params = ListParams {
-            limit: fetch_limit,
+            limit: cap.saturating_add(1),
             order: SortOrder::Asc,
             after: None,
         };

--- a/model_gateway/src/routers/openai/responses/history.rs
+++ b/model_gateway/src/routers/openai/responses/history.rs
@@ -147,11 +147,20 @@ pub(crate) async fn load_input_history(
             ));
         }
 
+        // When STMO is active we request one extra item so we can detect
+        // whether the conversation has grown past max_conversation_history_items.
+        // If it has, turn-count math would be wrong, so we reject early.
+        let cap = components
+            .shared
+            .router_config
+            .max_conversation_history_items;
+        let fetch_limit = if stm_enabled {
+            cap.saturating_add(1)
+        } else {
+            cap
+        };
         let params = ListParams {
-            limit: components
-                .shared
-                .router_config
-                .max_conversation_history_items,
+            limit: fetch_limit,
             order: SortOrder::Asc,
             after: None,
         };
@@ -161,6 +170,25 @@ pub(crate) async fn load_input_history(
             .await
         {
             Ok(stored_items) => {
+                if stm_enabled && stored_items.len() > cap {
+                    Metrics::record_router_error(
+                        metrics_labels::ROUTER_OPENAI,
+                        metrics_labels::BACKEND_EXTERNAL,
+                        metrics_labels::CONNECTION_HTTP,
+                        model,
+                        metrics_labels::ENDPOINT_RESPONSES,
+                        metrics_labels::ERROR_VALIDATION,
+                    );
+                    return Err(error::bad_request(
+                        "conversation_too_large",
+                        format!(
+                            "Conversation exceeds the configured limit of {cap} history items. \
+                             Increase max_conversation_history_items in the router config \
+                             or reduce conversation length before using short-term memory \
+                             optimization.",
+                        ),
+                    ));
+                }
                 raw_stored_item_count = Some(stored_items.len());
                 let mut items: Vec<ResponseInputOutputItem> = Vec::new();
                 for item in stored_items {

--- a/model_gateway/src/routers/openai/responses/history.rs
+++ b/model_gateway/src/routers/openai/responses/history.rs
@@ -273,15 +273,23 @@ pub(crate) async fn load_input_history(
     }
 
     let conversation_turn_info = if stm_enabled {
-        let mut info = count_conversation_turn_info(&request_body.input);
-        // Correct total_items when loaded from conversation storage: reasoning
-        // items are skipped during load but are stored in the DB, so the
-        // assembled input underestimates the true conversation size. Use the
-        // raw DB count + current input item count for an accurate target_item_end.
-        if let Some(raw_count) = raw_stored_item_count {
-            info.total_items = raw_count + current_input_count;
+        // If a conversation was requested but list_items failed, the assembled
+        // input only contains the current request — STMO turn counts would be
+        // wrong. Skip STMO for this request so persistence does not enqueue a
+        // job with an undercounted last_index/target_item_end.
+        if conversation.is_some() && raw_stored_item_count.is_none() {
+            None
+        } else {
+            let mut info = count_conversation_turn_info(&request_body.input);
+            // Correct total_items when loaded from conversation storage: reasoning
+            // items are skipped during load but are stored in the DB, so the
+            // assembled input underestimates the true conversation size. Use the
+            // raw DB count + current input item count for an accurate target_item_end.
+            if let Some(raw_count) = raw_stored_item_count {
+                info.total_items = raw_count + current_input_count;
+            }
+            Some(info)
         }
-        Some(info)
     } else {
         None
     };

--- a/model_gateway/src/routers/openai/responses/non_streaming.rs
+++ b/model_gateway/src/routers/openai/responses/non_streaming.rs
@@ -164,18 +164,21 @@ pub async fn handle_non_streaming_response(mut ctx: RequestContext) -> Response 
         previous_response_id.as_deref(),
     );
 
-    if let (Some(conv_storage), Some(item_storage), Some(resp_storage)) = (
+    if let (Some(conv_storage), Some(item_storage), Some(memory_writer), Some(resp_storage)) = (
         ctx.components.conversation_storage(),
         ctx.components.conversation_item_storage(),
+        ctx.components.conversation_memory_writer(),
         ctx.components.response_storage(),
     ) {
         if let Err(err) = persist_conversation_items(
             conv_storage.clone(),
             item_storage.clone(),
+            memory_writer.clone(),
             resp_storage.clone(),
             &response_json,
             original_body,
             ctx.storage_request_context.clone(),
+            ctx.memory_execution_context.clone(),
         )
         .await
         {

--- a/model_gateway/src/routers/openai/responses/non_streaming.rs
+++ b/model_gateway/src/routers/openai/responses/non_streaming.rs
@@ -41,6 +41,7 @@ pub async fn handle_non_streaming_response(mut ctx: RequestContext) -> Response 
     let ResponsesPayloadState {
         previous_response_id,
         existing_mcp_list_tools_labels,
+        conversation_turn_info,
     } = ctx.take_responses_payload().unwrap_or_default();
 
     let original_body = match ctx.responses_request() {
@@ -179,6 +180,7 @@ pub async fn handle_non_streaming_response(mut ctx: RequestContext) -> Response 
             original_body,
             ctx.storage_request_context.clone(),
             ctx.memory_execution_context.clone(),
+            conversation_turn_info,
         )
         .await
         {

--- a/model_gateway/src/routers/openai/responses/route.rs
+++ b/model_gateway/src/routers/openai/responses/route.rs
@@ -115,12 +115,23 @@ pub(in crate::routers::openai) async fn route_responses(
     let mut request_body = body.clone();
     request_body.model = model_id.to_string();
     request_body.conversation = None;
+    let memory_config = extract_conversation_memory_config(headers);
+    let stm_enabled = memory_config
+        .as_ref()
+        .is_some_and(|cfg| cfg.short_term_memory.enabled)
+        && deps
+            .responses_components
+            .shared
+            .router_config
+            .memory_runtime
+            .enabled;
 
     let loaded_history = match super::history::load_input_history(
         deps.responses_components,
         conversation.map(|c| c.as_id()),
         &mut request_body,
         model,
+        stm_enabled,
     )
     .await
     {
@@ -128,7 +139,7 @@ pub(in crate::routers::openai) async fn route_responses(
         Err(response) => return response,
     };
 
-    if let Some(memory_config) = extract_conversation_memory_config(headers) {
+    if let Some(memory_config) = memory_config {
         super::history::inject_memory_context(&memory_config, &mut request_body);
     }
 
@@ -189,6 +200,7 @@ pub(in crate::routers::openai) async fn route_responses(
     ctx.state.responses_payload = Some(ResponsesPayloadState {
         previous_response_id: loaded_history.previous_response_id,
         existing_mcp_list_tools_labels: loaded_history.existing_mcp_list_tools_labels,
+        conversation_turn_info: loaded_history.conversation_turn_info,
     });
 
     let response = if ctx.is_streaming() {

--- a/model_gateway/src/routers/openai/responses/streaming.rs
+++ b/model_gateway/src/routers/openai/responses/streaming.rs
@@ -634,10 +634,12 @@ pub(super) async fn handle_simple_streaming_passthrough(
                 if let Err(err) = persist_conversation_items(
                     storage.conversation.clone(),
                     storage.conversation_item.clone(),
+                    storage.conversation_memory_writer.clone(),
                     storage.response.clone(),
                     &response_json,
                     &original_request,
                     storage.request_context.clone(),
+                    storage.memory_execution_context.clone(),
                 )
                 .await
                 {
@@ -962,10 +964,12 @@ pub(super) fn handle_streaming_with_tool_interception(
                     if let Err(err) = persist_conversation_items(
                         storage.conversation.clone(),
                         storage.conversation_item.clone(),
+                        storage.conversation_memory_writer.clone(),
                         storage.response.clone(),
                         &response_json,
                         &original_request,
                         storage.request_context.clone(),
+                        storage.memory_execution_context.clone(),
                     )
                     .await
                     {

--- a/model_gateway/src/routers/openai/responses/streaming.rs
+++ b/model_gateway/src/routers/openai/responses/streaming.rs
@@ -562,6 +562,7 @@ pub(super) async fn handle_simple_streaming_passthrough(
     let should_store = req.original_body.store.unwrap_or(true);
     let original_request = req.original_body;
     let previous_response_id = req.previous_response_id;
+    let conversation_turn_info = req.conversation_turn_info;
     let storage = req.storage;
 
     #[expect(
@@ -640,6 +641,7 @@ pub(super) async fn handle_simple_streaming_passthrough(
                     &original_request,
                     storage.request_context.clone(),
                     storage.memory_execution_context.clone(),
+                    conversation_turn_info,
                 )
                 .await
                 {
@@ -685,6 +687,7 @@ pub(super) fn handle_streaming_with_tool_interception(
     let original_request = req.original_body;
     let previous_response_id = req.previous_response_id;
     let existing_mcp_list_tools_labels = req.existing_mcp_list_tools_labels;
+    let conversation_turn_info = req.conversation_turn_info;
     let url = req.url;
     let storage = req.storage;
 
@@ -970,6 +973,7 @@ pub(super) fn handle_streaming_with_tool_interception(
                         &original_request,
                         storage.request_context.clone(),
                         storage.memory_execution_context.clone(),
+                        conversation_turn_info,
                     )
                     .await
                     {


### PR DESCRIPTION
## Description

### Problem

When STM condensation (STMO) is enabled, the Responses API does not write a job entry to the queue after persisting a conversation turn. As a result, STM condensation never gets triggered regardless of the configuration.

A second class of problems was identified during review: even with the scheduling wired up, ConversationTurnInfo — the struct carrying user_turns and total_items used to decide when and where to schedule the job — was being computed from the wrong input in several paths. This caused jobs to be enqueued at the wrong turn boundary or with an incorrect target_item_end, making STMO fire too early, too late, or point at the wrong position in the conversation.

**Note**: The actual DB write for the ConversationMemory job row is a no-op in this PR — the ConversationMemoryWriter implementation is currently a stub and will be replaced with a real Postgres/Oracle write in a follow-up PR.



### Solution

**Core feature**

- Read `stm_enabled` and `stm_condenser_model_id` from the `x-conversation-memory-config` request header, gated by `memory.runtime.enabled` in server config
- After each Responses API turn is persisted, evaluate the STMO boundary: `user_turns >= 4 && (user_turns - 1) % 3 == 0` — fires at turns 4, 7, 10, 13, …
- If triggered and `stm_enabled` is active, write a `ConversationMemory` row with `memory_type = stmo` and `status = ready`

---

**`ConversationTurnInfo` correctness**

`ConversationTurnInfo` carries `user_turns` and `total_items`. Both values must be accurate — wrong values cause STMO to fire on the wrong turn or write a job pointing at the wrong position in the conversation. The following decisions were made to guarantee correctness across all paths:

**1. Compute from assembled input, not raw request**
`user_turns` and `total_items` are counted after history has been fully loaded and prepended to `request.input`. Counting from the raw request alone gives `user_turns = 1` regardless of how long the real conversation is.

**2. Use raw DB item count for `total_items`**
The conversation loaders filter stored items before building the inference window — gRPC regular keeps only messages, OpenAI drops reasoning items. Counting from the filtered window undercounts `total_items`. We capture `stored_items.len()` before any filtering and use `raw_count + current_input_count` for `total_items` so `target_item_end` points at the real end of the conversation.

**3. Skip STMO when history load fails**
If `list_items` returns an error, the loaders warn and continue with only the current message in `request.input`. Rather than compute a wrong `ConversationTurnInfo`, we return `None` so persistence skips STMO entirely for that request. The signal is `conversation.is_some() && raw_stored_item_count.is_none()`.

**4. Cap overflow detection**
`list_items` is bounded by `max_conversation_history_items`. If the conversation has grown past the cap, even the raw count is wrong. We always fetch `cap + 1` items — harmless since it is just a SQL `LIMIT`. If we get `cap + 1` rows back, we reject with `400 conversation_too_large`. This rejection only fires when `stm_enabled && store.unwrap_or(true)` — read-only calls (`store=false`) are never affected since `persist_response_if_needed` already short-circuits before any STMO enqueue.

**5. Harmony path — `request.conversation` without history load**
`load_previous_messages` only loads from `previous_response_id`. If `request.conversation` is set but no history is loaded for it, we return `None` for `turn_info` rather than count from partial input.

**6. Skip raw-count correction when response chain is also loaded**
`conversation` and `previous_response_id` are mutually exclusive by API contract but not enforced inside the loaders. If both paths ran, the chain merge overwrites `modified_request.input` last — `count_conversation_turn_info` already saw every item so applying the raw-count override would drop the chain items from `total_items`. Guard: only apply the correction when `request.previous_response_id.is_none()`.

**7. MCP streaming path never persists**
`execute_tool_loop_streaming` does not call `persist_response_if_needed`, so STMO is never enqueued there. To prevent the cap check from rejecting those requests, `ensure_mcp_connection` is moved before `load_conversation_history` in the streaming handler and `stm_enabled = false` is passed to the loader for the MCP streaming path.

### Changes

**Section 1 — Config**
- `config/types.rs` — added `max_conversation_history_items: usize` to router config (default 100)
- `config/builder.rs` — wires the value from YAML config into the struct
- `config/validation.rs` — rejects 0 at startup

**Section 2 — Header parsing → `MemoryExecutionContext`**
- `routers/common/header_utils.rs` — parses `stm_enabled` and `stm_condenser_model_id` from `x-conversation-memory-config`
- `memory/context.rs` — `stm_enabled` promoted to `MemoryExecutionState` (3-state enum: `NotRequested` / `GatedOff` / `Active`) matching the LTM pattern; `stm_condenser_model_id` added
- `routers/grpc/router.rs` — builds a fresh `MemoryExecutionContext` per request from headers
- `routers/grpc/common/responses/context.rs` — adds `PersistenceHandles` struct grouping the four storage backends; adds `memory_execution_context` to `ResponsesContext`
- `routers/openai/context.rs` — same wiring for the OpenAI Responses path

**Section 3 — History loading with correctness guards**
- `routers/openai/responses/history.rs` — `load_input_history`: cap overflow detection, skip-on-failure guard, raw-count correction, chain-overlap guard, `store=false` gate
- `routers/grpc/regular/responses/common.rs` — `load_conversation_history`: same guards as above
- `routers/grpc/regular/responses/handlers.rs` — streaming handler: `ensure_mcp_connection` moved before history loading; passes `stm_enabled && !has_mcp_tools` to loader
- `routers/grpc/regular/responses/streaming.rs` — removed unused `_conversation_turn_info` parameter from `execute_tool_loop_streaming`
- `routers/grpc/harmony/responses/common.rs` — `load_previous_messages`: early-return guard on `request.conversation.is_none()`

**Section 4 — `ConversationTurnInfo` computation**
- `routers/common/persistence_utils.rs` — `count_conversation_turn_info` counts `user_turns` (role = `"user"`) and `total_items` from the fully assembled input

**Section 5 — Execute and persist (plumbing)**
- `routers/grpc/common/responses/handlers.rs` — gRPC persist call site
- `routers/grpc/common/responses/mod.rs` — export update
- `routers/grpc/common/responses/utils.rs` — persist helper utilities
- `routers/grpc/harmony/responses/non_streaming.rs` — passes `conversation_turn_info` to persist
- `routers/grpc/harmony/responses/streaming.rs` — same for streaming path
- `routers/grpc/regular/responses/non_streaming.rs` — same for regular non-streaming path
- `routers/openai/responses/non_streaming.rs` — OpenAI persist call site
- `routers/openai/responses/streaming.rs` — same for streaming path
- `routers/openai/responses/route.rs` — OpenAI entry point

**Section 6 — STMO boundary check and job write**
- `routers/common/persistence_utils.rs` — `handle_stmo_after_persist`: evaluates boundary, writes `ConversationMemory` row with `memory_type = stmo`, `status = ready`, and `target_item_end` from `total_items`

## Test Plan

Unit tests (persistence_utils.rs):
- stmo_fires_at_boundary_turns — verifies trigger fires at turns 4, 7, 10 and not between
- count_user_turns_case_insensitive — verifies role matching is case-insensitive
- total_items_exceeds_user_turns — verifies target_item_end in the STMO payload accounts for non-user items

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable per-request conversation history limit with a sensible default.
  * Short-term memory (STM) controls per request, including optional condenser selection and gated runtime behavior.
  * Automatic STM condensation scheduling that enqueues condensation jobs at conversation boundaries.
  * Conversation turn tracking propagated through request handling to improve memory indexing and persistence.

* **Bug Fixes / Validation**
  * Configuration validation now rejects non-positive conversation history limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->