### PR TITLE
feat(router): support provider endpoint url override

### DIFF
--- a/docs/reference/api/responses.md
+++ b/docs/reference/api/responses.md
@@ -74,6 +74,28 @@ POST /v1/responses
 | `user` | string | No | End-user identifier |
 | `background` | boolean | No | Run request in background (not with streaming) |
 
+### Direct Endpoint Override
+
+For OpenAI-compatible Responses endpoints, a request can target a provider endpoint
+directly without registering a worker first:
+
+```bash
+curl http://localhost:30000/v1/responses \
+  -H "Content-Type: application/json" \
+  -H "x-model-provider: gpt-oss" \
+  -H "x-provider-endpoint: https://provider.example.com/v1/responses" \
+  -d '{
+    "model": "gpt-oss-20b",
+    "input": "Hello"
+  }'
+```
+
+`x-provider-endpoint` must be a full `http` or `https` URL, including the
+upstream path. SMG sends the request to that URL for this request only.
+`x-model-provider` is a provider hint; `gpt-oss` is treated as an
+OpenAI-compatible provider. Provider-native endpoint shapes require matching
+provider adaptation and may not work through this override.
+
 ### Input Formats
 
 **Simple text input:**

--- a/model_gateway/src/routers/common/header_utils.rs
+++ b/model_gateway/src/routers/common/header_utils.rs
@@ -12,6 +12,8 @@ use tracing::debug;
 static HEADER_TARGET_WORKER: HeaderName = HeaderName::from_static("x-smg-target-worker");
 static HEADER_ROUTING_KEY: HeaderName = HeaderName::from_static("x-smg-routing-key");
 static HEADER_MCP: HeaderName = HeaderName::from_static("x-smg-mcp");
+static HEADER_PROVIDER_ENDPOINT: HeaderName = HeaderName::from_static("x-provider-endpoint");
+static HEADER_MODEL_PROVIDER: HeaderName = HeaderName::from_static("x-model-provider");
 
 /// Parsed and normalized memory-related request headers.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -71,6 +73,14 @@ pub fn extract_target_worker(headers: Option<&HeaderMap>) -> Option<&str> {
 
 pub fn extract_routing_key(headers: Option<&HeaderMap>) -> Option<&str> {
     extract_header_value(headers, &HEADER_ROUTING_KEY)
+}
+
+pub fn extract_provider_endpoint(headers: Option<&HeaderMap>) -> Option<&str> {
+    extract_header_value(headers, &HEADER_PROVIDER_ENDPOINT)
+}
+
+pub fn extract_model_provider(headers: Option<&HeaderMap>) -> Option<&str> {
+    extract_header_value(headers, &HEADER_MODEL_PROVIDER)
 }
 
 /// Check if SMG MCP orchestration is enabled via `X-SMG-MCP: enabled` header.

--- a/model_gateway/src/routers/openai/provider/provider_trait.rs
+++ b/model_gateway/src/routers/openai/provider/provider_trait.rs
@@ -1,3 +1,4 @@
+use http::HeaderValue;
 use reqwest::RequestBuilder;
 use serde_json::Value;
 
@@ -25,7 +26,21 @@ pub trait Provider: Send + Sync {
         Ok(())
     }
 
-    fn apply_headers(&self, builder: RequestBuilder) -> RequestBuilder {
+    fn upstream_url(
+        &self,
+        worker_url: &str,
+        provided_upstream_url: Option<&str>,
+    ) -> Result<String, ProviderError> {
+        Ok(provided_upstream_url
+            .map(ToString::to_string)
+            .unwrap_or_else(|| format!("{worker_url}/v1/responses")))
+    }
+
+    fn apply_headers(
+        &self,
+        builder: RequestBuilder,
+        _auth_header: Option<&HeaderValue>,
+    ) -> RequestBuilder {
         builder
     }
 }

--- a/model_gateway/src/routers/openai/responses/route.rs
+++ b/model_gateway/src/routers/openai/responses/route.rs
@@ -4,7 +4,7 @@
 //! `router.rs` packs borrowed references into [`ResponsesRouterContext`] and
 //! delegates to [`route_responses`].
 
-use std::{sync::Arc, time::Instant};
+use std::{net::IpAddr, sync::Arc, time::Instant};
 
 use axum::{http::HeaderMap, response::Response};
 use openai_protocol::{
@@ -92,6 +92,28 @@ fn normalize_provider_endpoint(raw: &str) -> Option<(String, String)> {
     if !matches!(parsed.scheme(), "http" | "https") {
         return None;
     }
+    if !parsed.username().is_empty() || parsed.password().is_some() {
+        return None;
+    }
+    let host = parsed.host_str()?;
+    if host.eq_ignore_ascii_case("localhost") {
+        return None;
+    }
+    let ip_host = host
+        .strip_prefix('[')
+        .and_then(|host| host.strip_suffix(']'))
+        .unwrap_or(host);
+    if let Ok(ip) = ip_host.parse::<IpAddr>() {
+        let blocked = match ip {
+            IpAddr::V4(ip) => ip.is_loopback() || ip.is_private() || ip.is_link_local(),
+            IpAddr::V6(ip) => {
+                ip.is_loopback() || ip.is_unique_local() || ip.is_unicast_link_local()
+            }
+        };
+        if blocked {
+            return None;
+        }
+    }
     if parsed.path() == "/" {
         return None;
     }
@@ -120,7 +142,7 @@ fn endpoint_override_error_response(error: EndpointOverrideError) -> Response {
         ),
         EndpointOverrideError::InvalidEndpoint => error::bad_request(
             "invalid_request",
-            "x-provider-endpoint must be an absolute http(s) URL with a non-empty path".to_string(),
+            "x-provider-endpoint must be an absolute public http(s) URL with a non-empty path and no credentials".to_string(),
         ),
     }
 }
@@ -417,6 +439,49 @@ mod tests {
         },
     };
     use serde_json::{json, to_value};
+
+    use super::normalize_provider_endpoint;
+
+    #[test]
+    fn endpoint_override_normalization_accepts_public_url_and_strips_fragment() {
+        let Some((worker_base_url, target_url)) =
+            normalize_provider_endpoint("https://api.example.com/v1/responses?alt=sse#secret")
+        else {
+            panic!("public endpoint should be accepted");
+        };
+
+        assert_eq!(worker_base_url, "https://api.example.com");
+        assert_eq!(target_url, "https://api.example.com/v1/responses?alt=sse");
+    }
+
+    #[test]
+    fn endpoint_override_normalization_rejects_userinfo() {
+        assert!(
+            normalize_provider_endpoint("https://user:pass@api.example.com/v1/responses").is_none()
+        );
+        assert!(normalize_provider_endpoint("https://user@api.example.com/v1/responses").is_none());
+    }
+
+    #[test]
+    fn endpoint_override_normalization_rejects_local_and_private_hosts() {
+        for endpoint in [
+            "https://localhost/v1/responses",
+            "https://LOCALHOST/v1/responses",
+            "http://127.0.0.1/v1/responses",
+            "http://[::1]/v1/responses",
+            "http://10.0.0.1/v1/responses",
+            "http://172.16.0.1/v1/responses",
+            "http://192.168.1.1/v1/responses",
+            "http://169.254.169.254/latest/meta-data",
+            "http://[fc00::1]/v1/responses",
+            "http://[fe80::1]/v1/responses",
+        ] {
+            assert!(
+                normalize_provider_endpoint(endpoint).is_none(),
+                "{endpoint} should be rejected"
+            );
+        }
+    }
 
     fn build_request_with_mixed_content() -> ResponsesRequest {
         ResponsesRequest {

--- a/model_gateway/src/routers/openai/responses/route.rs
+++ b/model_gateway/src/routers/openai/responses/route.rs
@@ -7,8 +7,14 @@
 use std::{sync::Arc, time::Instant};
 
 use axum::{http::HeaderMap, response::Response};
-use openai_protocol::responses::{ResponseInput, ResponseInputOutputItem, ResponsesRequest};
+use openai_protocol::{
+    model_card::ModelCard,
+    responses::{ResponseInput, ResponseInputOutputItem, ResponsesRequest},
+    worker::{HealthCheckConfig, RuntimeType, WorkerModels, WorkerSpec},
+};
 use serde_json::to_value;
+use tracing::debug;
+use url::Url;
 
 use super::{
     super::{
@@ -26,13 +32,119 @@ use crate::{
     observability::metrics::{bool_to_static_str, metrics_labels, Metrics},
     routers::{
         common::{
-            header_utils::extract_conversation_memory_config,
+            header_utils::{
+                extract_conversation_memory_config, extract_model_provider,
+                extract_provider_endpoint,
+            },
             worker_selection::{SelectWorkerRequest, WorkerSelector},
         },
         error,
     },
-    worker::{Endpoint, ProviderType, WorkerRegistry},
+    worker::{BasicWorkerBuilder, Endpoint, ProviderType, Worker, WorkerRegistry},
 };
+
+struct EndpointOverride {
+    worker_base_url: String,
+    target_url: String,
+    provider: ProviderType,
+}
+
+fn normalize_provider_endpoint(raw: &str) -> Option<(String, String)> {
+    let mut parsed = Url::parse(raw.trim()).ok()?;
+    if !matches!(parsed.scheme(), "http" | "https") {
+        return None;
+    }
+    if parsed.path().is_empty() || parsed.path() == "/" {
+        return None;
+    }
+
+    parsed.set_fragment(None);
+    let target_url = parsed.to_string();
+    let worker_base_url = parsed.origin().ascii_serialization();
+
+    Some((worker_base_url, target_url))
+}
+
+#[derive(Debug)]
+enum EndpointOverrideError {
+    InvalidProvider,
+    InvalidEndpoint,
+}
+
+fn endpoint_override_error_response(error: EndpointOverrideError) -> Response {
+    match error {
+        EndpointOverrideError::InvalidProvider => error::bad_request(
+            "invalid_request",
+            "x-model-provider must be one of openai, gpt-oss, xai, google, or anthropic"
+                .to_string(),
+        ),
+        EndpointOverrideError::InvalidEndpoint => error::bad_request(
+            "invalid_request",
+            "x-provider-endpoint must be an absolute http(s) URL with a non-empty path".to_string(),
+        ),
+    }
+}
+
+fn provider_from_header(
+    headers: Option<&HeaderMap>,
+) -> Result<ProviderType, EndpointOverrideError> {
+    let Some(raw_provider) = extract_model_provider(headers) else {
+        return Ok(ProviderType::OpenAI);
+    };
+
+    let provider = raw_provider.trim();
+    if provider.is_empty() {
+        return Err(EndpointOverrideError::InvalidProvider);
+    }
+
+    match provider.to_ascii_lowercase().as_str() {
+        "openai" | "gpt-oss" => Ok(ProviderType::OpenAI),
+        "xai" => Ok(ProviderType::XAI),
+        "google" => Ok(ProviderType::Gemini),
+        "anthropic" => Ok(ProviderType::Anthropic),
+        _ => Err(EndpointOverrideError::InvalidProvider),
+    }
+}
+
+fn endpoint_override_from_headers(
+    headers: Option<&HeaderMap>,
+) -> Result<Option<EndpointOverride>, EndpointOverrideError> {
+    let Some(raw_endpoint) = extract_provider_endpoint(headers) else {
+        return Ok(None);
+    };
+
+    let provider = provider_from_header(headers)?;
+    let (worker_base_url, target_url) =
+        normalize_provider_endpoint(raw_endpoint).ok_or(EndpointOverrideError::InvalidEndpoint)?;
+
+    Ok(Some(EndpointOverride {
+        worker_base_url,
+        target_url,
+        provider,
+    }))
+}
+
+fn build_request_scoped_worker(
+    base_url: &str,
+    model: &str,
+    provider: ProviderType,
+    http_client: reqwest::Client,
+) -> Arc<dyn Worker> {
+    let mut spec = WorkerSpec::new(base_url.to_string());
+    spec.runtime_type = RuntimeType::External;
+    spec.provider = Some(provider);
+    spec.models = WorkerModels::from(vec![ModelCard::new(model)]);
+
+    Arc::new(
+        BasicWorkerBuilder::from_spec(spec)
+            .health_config(HealthCheckConfig {
+                disable_health_check: true,
+                ..Default::default()
+            })
+            .http_client(http_client)
+            .build(),
+    )
+}
 
 /// Shared context passed to responses routing functions.
 pub(in crate::routers::openai) struct ResponsesRouterContext<'a> {
@@ -62,29 +174,65 @@ pub(in crate::routers::openai) async fn route_responses(
         bool_to_static_str(streaming),
     );
 
-    let worker = match WorkerSelector::new(
-        deps.worker_registry,
-        &deps.responses_components.shared.client,
-    )
-    .select_worker(&SelectWorkerRequest {
-        model_id: model,
-        headers,
-        provider: Some(ProviderType::OpenAI),
-        ..Default::default()
-    })
-    .await
-    {
-        Ok(w) => w,
-        Err(response) => {
+    let endpoint_override = match endpoint_override_from_headers(headers) {
+        Ok(override_url) => override_url,
+        Err(err) => {
+            debug!(
+                model,
+                error = ?err,
+                "Rejecting Responses endpoint override"
+            );
             Metrics::record_router_error(
                 metrics_labels::ROUTER_OPENAI,
                 metrics_labels::BACKEND_EXTERNAL,
                 metrics_labels::CONNECTION_HTTP,
                 model,
                 metrics_labels::ENDPOINT_RESPONSES,
-                metrics_labels::ERROR_NO_WORKERS,
+                metrics_labels::ERROR_VALIDATION,
             );
-            return response;
+            return endpoint_override_error_response(err);
+        }
+    };
+
+    let worker = if let Some(endpoint_override) = endpoint_override.as_ref() {
+        debug!(
+            model,
+            provider = ?endpoint_override.provider,
+            upstream_base_url = %endpoint_override.worker_base_url,
+            streaming,
+            "Using request-scoped Responses endpoint override"
+        );
+        build_request_scoped_worker(
+            &endpoint_override.worker_base_url,
+            model,
+            endpoint_override.provider.clone(),
+            deps.responses_components.shared.client.clone(),
+        )
+    } else {
+        match WorkerSelector::new(
+            deps.worker_registry,
+            &deps.responses_components.shared.client,
+        )
+        .select_worker(&SelectWorkerRequest {
+            model_id: model,
+            headers,
+            provider: Some(ProviderType::OpenAI),
+            ..Default::default()
+        })
+        .await
+        {
+            Ok(w) => w,
+            Err(response) => {
+                Metrics::record_router_error(
+                    metrics_labels::ROUTER_OPENAI,
+                    metrics_labels::BACKEND_EXTERNAL,
+                    metrics_labels::CONNECTION_HTTP,
+                    model,
+                    metrics_labels::ENDPOINT_RESPONSES,
+                    metrics_labels::ERROR_NO_WORKERS,
+                );
+                return response;
+            }
         }
     };
 
@@ -184,7 +332,10 @@ pub(in crate::routers::openai) async fn route_responses(
 
     ctx.state.payload = Some(PayloadState {
         json: payload,
-        url: format!("{}/v1/responses", worker.url()),
+        url: endpoint_override
+            .as_ref()
+            .map(|endpoint_override| endpoint_override.target_url.clone())
+            .unwrap_or_else(|| format!("{}/v1/responses", worker.url())),
     });
     ctx.state.responses_payload = Some(ResponsesPayloadState {
         previous_response_id: loaded_history.previous_response_id,

--- a/model_gateway/src/routers/openai/responses/route.rs
+++ b/model_gateway/src/routers/openai/responses/route.rs
@@ -472,7 +472,7 @@ mod tests {
 
     #[test]
     fn endpoint_override_without_endpoint_rejects_invalid_provider_hint() {
-        let headers = headers_with_model_provider("gemiin");
+        let headers = headers_with_model_provider("gemini");
         let result = endpoint_override_from_headers(Some(&headers));
 
         assert!(matches!(

--- a/model_gateway/src/routers/openai/responses/route.rs
+++ b/model_gateway/src/routers/openai/responses/route.rs
@@ -239,27 +239,28 @@ pub(in crate::routers::openai) async fn route_responses(
         bool_to_static_str(streaming),
     );
 
-    let requested_provider = match provider_from_headers(headers) {
-        Ok(provider) => provider,
-        Err(err) => {
-            debug!(
-                model,
-                error = ?err,
-                "Rejecting Responses provider hint"
-            );
-            Metrics::record_router_error(
-                metrics_labels::ROUTER_OPENAI,
-                metrics_labels::BACKEND_EXTERNAL,
-                metrics_labels::CONNECTION_HTTP,
-                model,
-                metrics_labels::ENDPOINT_RESPONSES,
-                metrics_labels::ERROR_VALIDATION,
-            );
-            return endpoint_override_error_response(err);
-        }
-    };
-    let endpoint_override =
-        match endpoint_override_from_headers(headers, requested_provider.clone()) {
+    let endpoint_override = if extract_provider_endpoint(headers).is_some() {
+        let requested_provider = match provider_from_headers(headers) {
+            Ok(provider) => provider,
+            Err(err) => {
+                debug!(
+                    model,
+                    error = ?err,
+                    "Rejecting Responses endpoint override provider"
+                );
+                Metrics::record_router_error(
+                    metrics_labels::ROUTER_OPENAI,
+                    metrics_labels::BACKEND_EXTERNAL,
+                    metrics_labels::CONNECTION_HTTP,
+                    model,
+                    metrics_labels::ENDPOINT_RESPONSES,
+                    metrics_labels::ERROR_VALIDATION,
+                );
+                return endpoint_override_error_response(err);
+            }
+        };
+
+        match endpoint_override_from_headers(headers, requested_provider) {
             Ok(override_url) => override_url,
             Err(err) => {
                 debug!(
@@ -277,7 +278,10 @@ pub(in crate::routers::openai) async fn route_responses(
                 );
                 return endpoint_override_error_response(err);
             }
-        };
+        }
+    } else {
+        None
+    };
 
     let worker = if let Some(endpoint_override) = endpoint_override.as_ref() {
         debug!(
@@ -301,7 +305,7 @@ pub(in crate::routers::openai) async fn route_responses(
         .select_worker(&SelectWorkerRequest {
             model_id: model,
             headers,
-            provider: Some(requested_provider.clone()),
+            provider: Some(ProviderType::OpenAI),
             ..Default::default()
         })
         .await
@@ -524,7 +528,7 @@ mod tests {
     }
 
     #[test]
-    fn endpoint_override_without_endpoint_rejects_invalid_provider_header() {
+    fn provider_from_headers_rejects_invalid_provider_header() {
         let headers = headers_with_model_provider("unknown");
         let result = provider_from_headers(Some(&headers));
 

--- a/model_gateway/src/routers/openai/responses/route.rs
+++ b/model_gateway/src/routers/openai/responses/route.rs
@@ -166,20 +166,21 @@ fn build_request_scoped_worker(
     base_url: &str,
     model: &str,
     provider: ProviderType,
-    http_client: reqwest::Client,
+    http_client: &reqwest::Client,
 ) -> Arc<dyn Worker> {
     let mut spec = WorkerSpec::new(base_url.to_string());
     spec.runtime_type = RuntimeType::External;
     spec.provider = Some(provider);
     spec.models = WorkerModels::from(vec![ModelCard::new(model)]);
 
+    // Reuse the router's shared client handle for both streaming and non-streaming overrides.
     Arc::new(
         BasicWorkerBuilder::from_spec(spec)
             .health_config(HealthCheckConfig {
                 disable_health_check: true,
                 ..Default::default()
             })
-            .http_client(http_client)
+            .http_client(http_client.clone())
             .build(),
     )
 }
@@ -244,7 +245,7 @@ pub(in crate::routers::openai) async fn route_responses(
             &endpoint_override.worker_base_url,
             model,
             endpoint_override.provider.clone(),
-            deps.responses_components.shared.client.clone(),
+            &deps.responses_components.shared.client,
         )
     } else {
         match WorkerSelector::new(

--- a/model_gateway/src/routers/openai/responses/route.rs
+++ b/model_gateway/src/routers/openai/responses/route.rs
@@ -49,6 +49,44 @@ struct EndpointOverride {
     provider: ProviderType,
 }
 
+struct ProviderHeaderMapping {
+    header_value: &'static str,
+    provider: ProviderType,
+}
+
+fn provider_header_mappings() -> [ProviderHeaderMapping; 5] {
+    [
+        ProviderHeaderMapping {
+            header_value: ProviderType::OpenAI.as_str(),
+            provider: ProviderType::OpenAI,
+        },
+        ProviderHeaderMapping {
+            header_value: "gpt-oss",
+            provider: ProviderType::OpenAI,
+        },
+        ProviderHeaderMapping {
+            header_value: ProviderType::XAI.as_str(),
+            provider: ProviderType::XAI,
+        },
+        ProviderHeaderMapping {
+            header_value: "google",
+            provider: ProviderType::Gemini,
+        },
+        ProviderHeaderMapping {
+            header_value: ProviderType::Anthropic.as_str(),
+            provider: ProviderType::Anthropic,
+        },
+    ]
+}
+
+fn supported_provider_header_values() -> String {
+    provider_header_mappings()
+        .into_iter()
+        .map(|mapping| mapping.header_value)
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
 fn normalize_provider_endpoint(raw: &str) -> Option<(String, String)> {
     let mut parsed = Url::parse(raw.trim()).ok()?;
     if !matches!(parsed.scheme(), "http" | "https") {
@@ -75,8 +113,10 @@ fn endpoint_override_error_response(error: EndpointOverrideError) -> Response {
     match error {
         EndpointOverrideError::InvalidProvider => error::bad_request(
             "invalid_request",
-            "x-model-provider must be one of openai, gpt-oss, xai, google, or anthropic"
-                .to_string(),
+            format!(
+                "x-model-provider must be one of {}",
+                supported_provider_header_values()
+            ),
         ),
         EndpointOverrideError::InvalidEndpoint => error::bad_request(
             "invalid_request",
@@ -97,13 +137,11 @@ fn provider_from_header(
         return Err(EndpointOverrideError::InvalidProvider);
     }
 
-    match provider.to_ascii_lowercase().as_str() {
-        "openai" | "gpt-oss" => Ok(ProviderType::OpenAI),
-        "xai" => Ok(ProviderType::XAI),
-        "google" => Ok(ProviderType::Gemini),
-        "anthropic" => Ok(ProviderType::Anthropic),
-        _ => Err(EndpointOverrideError::InvalidProvider),
-    }
+    provider_header_mappings()
+        .into_iter()
+        .find(|mapping| provider.eq_ignore_ascii_case(mapping.header_value))
+        .map(|mapping| mapping.provider)
+        .ok_or(EndpointOverrideError::InvalidProvider)
 }
 
 fn endpoint_override_from_headers(

--- a/model_gateway/src/routers/openai/responses/route.rs
+++ b/model_gateway/src/routers/openai/responses/route.rs
@@ -377,9 +377,17 @@ pub(in crate::routers::openai) async fn route_responses(
         return error::bad_request("invalid_request", format!("Provider transform error: {e}"));
     }
 
+    let request_headers = headers.cloned().map(|mut headers| {
+        if endpoint_override.is_some() {
+            headers.remove("x-provider-endpoint");
+            headers.remove("x-model-provider");
+        }
+        headers
+    });
+
     let mut ctx = RequestContext::for_responses(
         Arc::new(body.clone()),
-        headers.cloned(),
+        request_headers,
         Some(model_id.to_string()),
         ComponentRefs::Responses(Arc::clone(deps.responses_components)),
     );

--- a/model_gateway/src/routers/openai/responses/route.rs
+++ b/model_gateway/src/routers/openai/responses/route.rs
@@ -54,7 +54,7 @@ struct ProviderHeaderMapping {
     provider: ProviderType,
 }
 
-fn provider_header_mappings() -> [ProviderHeaderMapping; 5] {
+fn provider_header_mappings() -> [ProviderHeaderMapping; 6] {
     [
         ProviderHeaderMapping {
             header_value: ProviderType::OpenAI.as_str(),
@@ -70,6 +70,10 @@ fn provider_header_mappings() -> [ProviderHeaderMapping; 5] {
         },
         ProviderHeaderMapping {
             header_value: "google",
+            provider: ProviderType::Gemini,
+        },
+        ProviderHeaderMapping {
+            header_value: "gemini",
             provider: ProviderType::Gemini,
         },
         ProviderHeaderMapping {
@@ -147,7 +151,7 @@ fn endpoint_override_error_response(error: EndpointOverrideError) -> Response {
     }
 }
 
-fn provider_from_header(
+fn provider_from_headers(
     headers: Option<&HeaderMap>,
 ) -> Result<ProviderType, EndpointOverrideError> {
     let Some(raw_provider) = extract_model_provider(headers) else {
@@ -168,15 +172,12 @@ fn provider_from_header(
 
 fn endpoint_override_from_headers(
     headers: Option<&HeaderMap>,
+    provider: ProviderType,
 ) -> Result<Option<EndpointOverride>, EndpointOverrideError> {
     let Some(raw_endpoint) = extract_provider_endpoint(headers) else {
-        if extract_model_provider(headers).is_some() {
-            provider_from_header(headers)?;
-        }
         return Ok(None);
     };
 
-    let provider = provider_from_header(headers)?;
     let (worker_base_url, target_url) =
         normalize_provider_endpoint(raw_endpoint).ok_or(EndpointOverrideError::InvalidEndpoint)?;
 
@@ -238,13 +239,13 @@ pub(in crate::routers::openai) async fn route_responses(
         bool_to_static_str(streaming),
     );
 
-    let endpoint_override = match endpoint_override_from_headers(headers) {
-        Ok(override_url) => override_url,
+    let requested_provider = match provider_from_headers(headers) {
+        Ok(provider) => provider,
         Err(err) => {
             debug!(
                 model,
                 error = ?err,
-                "Rejecting Responses endpoint override"
+                "Rejecting Responses provider hint"
             );
             Metrics::record_router_error(
                 metrics_labels::ROUTER_OPENAI,
@@ -257,6 +258,26 @@ pub(in crate::routers::openai) async fn route_responses(
             return endpoint_override_error_response(err);
         }
     };
+    let endpoint_override =
+        match endpoint_override_from_headers(headers, requested_provider.clone()) {
+            Ok(override_url) => override_url,
+            Err(err) => {
+                debug!(
+                    model,
+                    error = ?err,
+                    "Rejecting Responses endpoint override"
+                );
+                Metrics::record_router_error(
+                    metrics_labels::ROUTER_OPENAI,
+                    metrics_labels::BACKEND_EXTERNAL,
+                    metrics_labels::CONNECTION_HTTP,
+                    model,
+                    metrics_labels::ENDPOINT_RESPONSES,
+                    metrics_labels::ERROR_VALIDATION,
+                );
+                return endpoint_override_error_response(err);
+            }
+        };
 
     let worker = if let Some(endpoint_override) = endpoint_override.as_ref() {
         debug!(
@@ -280,7 +301,7 @@ pub(in crate::routers::openai) async fn route_responses(
         .select_worker(&SelectWorkerRequest {
             model_id: model,
             headers,
-            provider: Some(ProviderType::OpenAI),
+            provider: Some(requested_provider.clone()),
             ..Default::default()
         })
         .await
@@ -380,6 +401,29 @@ pub(in crate::routers::openai) async fn route_responses(
         return error::bad_request("invalid_request", format!("Provider transform error: {e}"));
     }
 
+    let upstream_url = match provider.upstream_url(
+        worker.url(),
+        endpoint_override
+            .as_ref()
+            .map(|endpoint_override| endpoint_override.target_url.as_str()),
+    ) {
+        Ok(url) => url,
+        Err(e) => {
+            Metrics::record_router_error(
+                metrics_labels::ROUTER_OPENAI,
+                metrics_labels::BACKEND_EXTERNAL,
+                metrics_labels::CONNECTION_HTTP,
+                model,
+                metrics_labels::ENDPOINT_RESPONSES,
+                metrics_labels::ERROR_VALIDATION,
+            );
+            return error::bad_request(
+                "invalid_request",
+                format!("Provider upstream URL error: {e}"),
+            );
+        }
+    };
+
     let request_headers = headers.cloned().map(|mut headers| {
         if endpoint_override.is_some() {
             headers.remove("x-provider-endpoint");
@@ -404,10 +448,7 @@ pub(in crate::routers::openai) async fn route_responses(
 
     ctx.state.payload = Some(PayloadState {
         json: payload,
-        url: endpoint_override
-            .as_ref()
-            .map(|endpoint_override| endpoint_override.target_url.clone())
-            .unwrap_or_else(|| format!("{}/v1/responses", worker.url())),
+        url: upstream_url,
     });
     ctx.state.responses_payload = Some(ResponsesPayloadState {
         previous_response_id: loaded_history.previous_response_id,
@@ -453,8 +494,10 @@ mod tests {
     use serde_json::{json, to_value};
 
     use super::{
-        endpoint_override_from_headers, normalize_provider_endpoint, EndpointOverrideError,
+        endpoint_override_from_headers, normalize_provider_endpoint, provider_from_headers,
+        EndpointOverrideError,
     };
+    use crate::worker::ProviderType;
 
     fn headers_with_model_provider(provider: &'static str) -> HeaderMap {
         let mut headers = HeaderMap::new();
@@ -463,17 +506,27 @@ mod tests {
     }
 
     #[test]
-    fn endpoint_override_without_endpoint_accepts_valid_provider_hint() {
+    fn endpoint_override_without_endpoint_accepts_valid_provider_header() {
         let headers = headers_with_model_provider("openai");
-        let result = endpoint_override_from_headers(Some(&headers));
+        let result = endpoint_override_from_headers(Some(&headers), ProviderType::OpenAI);
 
         assert!(matches!(result, Ok(None)));
     }
 
     #[test]
-    fn endpoint_override_without_endpoint_rejects_invalid_provider_hint() {
+    fn endpoint_override_without_endpoint_accepts_gemini_provider_header() {
         let headers = headers_with_model_provider("gemini");
-        let result = endpoint_override_from_headers(Some(&headers));
+        let provider = provider_from_headers(Some(&headers));
+        let result = endpoint_override_from_headers(Some(&headers), ProviderType::Gemini);
+
+        assert!(matches!(provider, Ok(ProviderType::Gemini)));
+        assert!(matches!(result, Ok(None)));
+    }
+
+    #[test]
+    fn endpoint_override_without_endpoint_rejects_invalid_provider_header() {
+        let headers = headers_with_model_provider("unknown");
+        let result = provider_from_headers(Some(&headers));
 
         assert!(matches!(
             result,
@@ -484,9 +537,17 @@ mod tests {
     #[test]
     fn endpoint_override_without_endpoint_or_provider_is_absent() {
         let headers = HeaderMap::new();
-        let result = endpoint_override_from_headers(Some(&headers));
+        let result = endpoint_override_from_headers(Some(&headers), ProviderType::OpenAI);
 
         assert!(matches!(result, Ok(None)));
+    }
+
+    #[test]
+    fn provider_defaults_to_openai_without_header_even_for_gemini_model_name() {
+        let headers = HeaderMap::new();
+        let provider = provider_from_headers(Some(&headers));
+
+        assert!(matches!(provider, Ok(ProviderType::OpenAI)));
     }
 
     #[test]

--- a/model_gateway/src/routers/openai/responses/route.rs
+++ b/model_gateway/src/routers/openai/responses/route.rs
@@ -92,7 +92,7 @@ fn normalize_provider_endpoint(raw: &str) -> Option<(String, String)> {
     if !matches!(parsed.scheme(), "http" | "https") {
         return None;
     }
-    if parsed.path().is_empty() || parsed.path() == "/" {
+    if parsed.path() == "/" {
         return None;
     }
 

--- a/model_gateway/src/routers/openai/responses/route.rs
+++ b/model_gateway/src/routers/openai/responses/route.rs
@@ -170,6 +170,9 @@ fn endpoint_override_from_headers(
     headers: Option<&HeaderMap>,
 ) -> Result<Option<EndpointOverride>, EndpointOverrideError> {
     let Some(raw_endpoint) = extract_provider_endpoint(headers) else {
+        if extract_model_provider(headers).is_some() {
+            provider_from_header(headers)?;
+        }
         return Ok(None);
     };
 
@@ -439,6 +442,7 @@ mod tests {
     //! `to_value(&request_body)` site). These tests lock the shape that the
     //! post-P1 content-part variants produce, so any future change to the
     //! serde layer surfaces here before it reaches an upstream.
+    use axum::http::{HeaderMap, HeaderValue};
     use openai_protocol::{
         common::Detail,
         responses::{
@@ -448,7 +452,42 @@ mod tests {
     };
     use serde_json::{json, to_value};
 
-    use super::normalize_provider_endpoint;
+    use super::{
+        endpoint_override_from_headers, normalize_provider_endpoint, EndpointOverrideError,
+    };
+
+    fn headers_with_model_provider(provider: &'static str) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-model-provider", HeaderValue::from_static(provider));
+        headers
+    }
+
+    #[test]
+    fn endpoint_override_without_endpoint_accepts_valid_provider_hint() {
+        let headers = headers_with_model_provider("openai");
+        let result = endpoint_override_from_headers(Some(&headers));
+
+        assert!(matches!(result, Ok(None)));
+    }
+
+    #[test]
+    fn endpoint_override_without_endpoint_rejects_invalid_provider_hint() {
+        let headers = headers_with_model_provider("gemiin");
+        let result = endpoint_override_from_headers(Some(&headers));
+
+        assert!(matches!(
+            result,
+            Err(EndpointOverrideError::InvalidProvider)
+        ));
+    }
+
+    #[test]
+    fn endpoint_override_without_endpoint_or_provider_is_absent() {
+        let headers = HeaderMap::new();
+        let result = endpoint_override_from_headers(Some(&headers));
+
+        assert!(matches!(result, Ok(None)));
+    }
 
     #[test]
     fn endpoint_override_normalization_accepts_public_url_and_strips_fragment() {

--- a/model_gateway/src/routers/router_manager.rs
+++ b/model_gateway/src/routers/router_manager.rs
@@ -45,7 +45,7 @@ use crate::{
     middleware::TenantRequestMeta,
     routers::{
         common::{
-            header_utils::apply_provider_headers,
+            header_utils::{apply_provider_headers, extract_provider_endpoint},
             skill_resolution::{resolve_messages_skill_manifest, resolve_responses_skill_manifest},
         },
         factory::{router_ids, RouterId},
@@ -315,6 +315,28 @@ impl RouterManager {
         }
 
         best_router
+    }
+
+    fn select_router_for_responses(
+        &self,
+        headers: Option<&HeaderMap>,
+        model_id: &str,
+    ) -> Option<Arc<dyn RouterTrait>> {
+        if extract_provider_endpoint(headers).is_some() {
+            // Direct endpoint overrides are implemented by the OpenAI-compatible
+            // Responses pipeline. Provider-specific payload adaptation happens
+            // inside that router via x-model-provider.
+            debug!(
+                model_id,
+                "Routing Responses endpoint override through OpenAI-compatible router"
+            );
+            return self
+                .routers
+                .get(&router_ids::HTTP_OPENAI)
+                .map(|r| r.clone());
+        }
+
+        self.select_router_for_request(headers, Some(model_id))
     }
 
     /// Build a response from self-hosted registry models (excludes external workers).
@@ -625,7 +647,7 @@ impl RouterTrait for RouterManager {
         body: &ResponsesRequest,
         model_id: &str,
     ) -> Response {
-        let router = self.select_router_for_request(headers, Some(model_id));
+        let router = self.select_router_for_responses(headers, model_id);
 
         if let Some(router) = router {
             let skill_manifest = match resolve_responses_skill_manifest(

--- a/model_gateway/src/routers/router_manager.rs
+++ b/model_gateway/src/routers/router_manager.rs
@@ -330,10 +330,19 @@ impl RouterManager {
                 model_id,
                 "Routing Responses endpoint override through OpenAI-compatible router"
             );
-            return self
+            let router = self
                 .routers
                 .get(&router_ids::HTTP_OPENAI)
                 .map(|r| r.clone());
+            if router.is_none() {
+                warn!(
+                    model_id,
+                    endpoint_override_present = true,
+                    router_id = router_ids::HTTP_OPENAI.as_str(),
+                    "Endpoint override requested but OpenAI-compatible router (HTTP_OPENAI) is not registered; endpoint overrides are unsupported in single-router mode"
+                );
+            }
+            return router;
         }
 
         self.select_router_for_request(headers, Some(model_id))

--- a/model_gateway/tests/routing/test_openai_routing.rs
+++ b/model_gateway/tests/routing/test_openai_routing.rs
@@ -457,6 +457,16 @@ async fn test_responses_endpoint_override_rejects_unknown_provider_without_fallb
         )
         .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let (_, body) = response.into_parts();
+    let body_bytes = axum::body::to_bytes(body, usize::MAX)
+        .await
+        .expect("error response body");
+    let body_json: serde_json::Value =
+        serde_json::from_slice(&body_bytes).expect("error response json");
+    assert_eq!(
+        body_json["error"]["message"],
+        json!("x-model-provider must be one of openai, gpt-oss, xai, google, anthropic")
+    );
     assert_eq!(dedicated_state.requests.load(Ordering::SeqCst), 0);
     assert_eq!(shared_state.requests.load(Ordering::SeqCst), 0);
 }

--- a/model_gateway/tests/routing/test_openai_routing.rs
+++ b/model_gateway/tests/routing/test_openai_routing.rs
@@ -10,9 +10,9 @@ use std::{
 
 use axum::{
     body::Body,
-    extract::Request,
-    http::{Method, StatusCode},
-    response::Response,
+    extract::{Request, State},
+    http::{header::CONTENT_TYPE, HeaderMap, Method, StatusCode},
+    response::{IntoResponse, Response},
     routing::post,
     Json, Router,
 };
@@ -36,6 +36,7 @@ use smg::{
 use smg_data_connector::{ResponseId, StoredResponse};
 use tokio::{
     net::TcpListener,
+    sync::Mutex as AsyncMutex,
     time::{sleep, Duration},
 };
 use tower::ServiceExt;
@@ -100,6 +101,148 @@ fn create_minimal_completion_request() -> CompletionRequest {
 
 fn test_tenant_meta() -> smg::middleware::TenantRequestMeta {
     RouteRequestMeta::new(TenantKey::from("test-tenant"))
+}
+
+#[derive(Clone)]
+struct CaptureResponsesState {
+    requests: Arc<AtomicUsize>,
+    last_body: Arc<AsyncMutex<Option<serde_json::Value>>>,
+    last_headers: Arc<AsyncMutex<Option<HeaderMap>>>,
+    last_uri: Arc<AsyncMutex<Option<String>>>,
+    status: StatusCode,
+}
+
+#[expect(
+    clippy::unwrap_used,
+    reason = "test helper with known-valid header value"
+)]
+async fn capture_responses_handler(
+    State(state): State<CaptureResponsesState>,
+    req: Request<Body>,
+) -> Response {
+    state.requests.fetch_add(1, Ordering::SeqCst);
+
+    *state.last_uri.lock().await = Some(req.uri().to_string());
+
+    let headers = req.headers().clone();
+    *state.last_headers.lock().await = Some(headers);
+
+    let (_, body) = req.into_parts();
+    let body_bytes = match axum::body::to_bytes(body, usize::MAX).await {
+        Ok(bytes) => bytes,
+        Err(_) => return StatusCode::BAD_REQUEST.into_response(),
+    };
+    let payload: serde_json::Value = match serde_json::from_slice(&body_bytes) {
+        Ok(payload) => payload,
+        Err(_) => return StatusCode::BAD_REQUEST.into_response(),
+    };
+    *state.last_body.lock().await = Some(payload.clone());
+
+    if !state.status.is_success() {
+        return (
+            state.status,
+            Json(json!({
+                "error": {
+                    "message": "capture failure",
+                    "type": "internal_error",
+                    "code": "internal_error"
+                }
+            })),
+        )
+            .into_response();
+    }
+
+    let model = payload
+        .get("model")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown");
+    let is_streaming = payload
+        .get("stream")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    if is_streaming {
+        let data = json!({
+            "type": "response.completed",
+            "response": {
+                "id": "resp_capture",
+                "object": "response",
+                "created_at": 1,
+                "model": model,
+                "output": [],
+                "status": "completed"
+            }
+        });
+        let mut response = Response::new(Body::from(format!(
+            "event: response.completed\ndata: {data}\n\ndata: [DONE]\n\n"
+        )));
+        response
+            .headers_mut()
+            .insert(CONTENT_TYPE, "text/event-stream".parse().unwrap());
+        response
+    } else {
+        Json(json!({
+            "id": "resp_capture",
+            "object": "response",
+            "created_at": 1,
+            "model": model,
+            "output": [],
+            "status": "completed",
+            "usage": null
+        }))
+        .into_response()
+    }
+}
+
+#[expect(
+    clippy::disallowed_methods,
+    clippy::expect_used,
+    reason = "test infrastructure"
+)]
+async fn start_capture_responses_server(status: StatusCode) -> (String, CaptureResponsesState) {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind capture server");
+    let addr = listener.local_addr().expect("capture server local addr");
+    let state = CaptureResponsesState {
+        requests: Arc::new(AtomicUsize::new(0)),
+        last_body: Arc::new(AsyncMutex::new(None)),
+        last_headers: Arc::new(AsyncMutex::new(None)),
+        last_uri: Arc::new(AsyncMutex::new(None)),
+        status,
+    };
+
+    let app = Router::new()
+        .route("/v1/responses", post(capture_responses_handler))
+        .fallback(post(capture_responses_handler))
+        .with_state(state.clone());
+
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("capture server");
+    });
+
+    sleep(Duration::from_millis(10)).await;
+    (format!("http://{addr}"), state)
+}
+
+#[expect(
+    clippy::unwrap_used,
+    reason = "test helper with known-valid header values"
+)]
+fn endpoint_override_headers(provider: &str, endpoint: &str) -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    headers.insert("x-model-provider", provider.parse().unwrap());
+    headers.insert("x-provider-endpoint", endpoint.parse().unwrap());
+    headers
+}
+
+fn endpoint_override_request(stream: bool) -> ResponsesRequest {
+    ResponsesRequest {
+        model: "gpt-oss-20b".to_string(),
+        input: ResponseInput::Text("hello dedicated".to_string()),
+        stream: stream.then_some(true),
+        ..Default::default()
+    }
 }
 
 /// Test basic OpenAI router creation and configuration
@@ -171,6 +314,186 @@ async fn test_openai_router_models() {
 
     assert_eq!(models["object"], "list");
     assert!(models["data"].is_array());
+}
+
+#[tokio::test]
+async fn test_responses_endpoint_override_uses_exact_endpoint_and_strips_override_headers() {
+    let (shared_url, shared_state) = start_capture_responses_server(StatusCode::OK).await;
+    let (dedicated_url, dedicated_state) = start_capture_responses_server(StatusCode::OK).await;
+
+    let ctx = create_test_app_context().await;
+    register_external_worker(&ctx, &shared_url, Some(vec!["gpt-oss-20b"]));
+    let router = OpenAIRouter::new(&ctx).await.unwrap();
+
+    let headers = endpoint_override_headers(
+        "openai",
+        &format!("{dedicated_url}/v1beta/models/gemini-2.5-flash:generateContent?alt=sse"),
+    );
+    let request = endpoint_override_request(false);
+
+    let response = router
+        .route_responses(
+            Some(&headers),
+            &test_tenant_meta(),
+            &request,
+            &request.model,
+        )
+        .await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    assert_eq!(dedicated_state.requests.load(Ordering::SeqCst), 1);
+    assert_eq!(shared_state.requests.load(Ordering::SeqCst), 0);
+
+    let body = dedicated_state
+        .last_body
+        .lock()
+        .await
+        .clone()
+        .expect("dedicated request body captured");
+    assert_eq!(body["model"], json!("gpt-oss-20b"));
+    let uri = dedicated_state
+        .last_uri
+        .lock()
+        .await
+        .clone()
+        .expect("dedicated request URI captured");
+    assert_eq!(
+        uri,
+        "/v1beta/models/gemini-2.5-flash:generateContent?alt=sse"
+    );
+
+    let forwarded_headers = dedicated_state
+        .last_headers
+        .lock()
+        .await
+        .clone()
+        .expect("dedicated request headers captured");
+    assert!(forwarded_headers.get("x-provider-endpoint").is_none());
+    assert!(forwarded_headers.get("x-model-provider").is_none());
+}
+
+#[tokio::test]
+async fn test_responses_endpoint_override_rejects_invalid_endpoint_urls_without_fallback() {
+    let (shared_url, shared_state) = start_capture_responses_server(StatusCode::OK).await;
+    let (dedicated_url, dedicated_state) = start_capture_responses_server(StatusCode::OK).await;
+
+    let ctx = create_test_app_context().await;
+    register_external_worker(&ctx, &shared_url, Some(vec!["gpt-oss-20b"]));
+    let router = OpenAIRouter::new(&ctx).await.unwrap();
+    let request = endpoint_override_request(false);
+
+    for endpoint in ["notaurl", dedicated_url.as_str()] {
+        let headers = endpoint_override_headers("openai", endpoint);
+        let response = router
+            .route_responses(
+                Some(&headers),
+                &test_tenant_meta(),
+                &request,
+                &request.model,
+            )
+            .await;
+        assert_eq!(
+            response.status(),
+            StatusCode::BAD_REQUEST,
+            "invalid endpoint should be rejected: {endpoint}"
+        );
+    }
+
+    assert_eq!(
+        dedicated_state.requests.load(Ordering::SeqCst),
+        0,
+        "invalid endpoint URLs must fail before calling the override endpoint"
+    );
+    assert_eq!(
+        shared_state.requests.load(Ordering::SeqCst),
+        0,
+        "invalid endpoint URLs must not fall back to registered workers"
+    );
+}
+
+#[tokio::test]
+async fn test_responses_endpoint_override_accepts_gpt_oss_as_openai_provider() {
+    let (shared_url, shared_state) = start_capture_responses_server(StatusCode::OK).await;
+    let (dedicated_url, dedicated_state) = start_capture_responses_server(StatusCode::OK).await;
+
+    let ctx = create_test_app_context().await;
+    register_external_worker(&ctx, &shared_url, Some(vec!["gpt-oss-20b"]));
+    let router = OpenAIRouter::new(&ctx).await.unwrap();
+
+    let headers = endpoint_override_headers("gpt-oss", &format!("{dedicated_url}/v1/responses"));
+    let request = endpoint_override_request(false);
+
+    let response = router
+        .route_responses(
+            Some(&headers),
+            &test_tenant_meta(),
+            &request,
+            &request.model,
+        )
+        .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(dedicated_state.requests.load(Ordering::SeqCst), 1);
+    assert_eq!(shared_state.requests.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn test_responses_endpoint_override_rejects_unknown_provider_without_fallback() {
+    let (shared_url, shared_state) = start_capture_responses_server(StatusCode::OK).await;
+    let (dedicated_url, dedicated_state) = start_capture_responses_server(StatusCode::OK).await;
+
+    let ctx = create_test_app_context().await;
+    register_external_worker(&ctx, &shared_url, Some(vec!["gpt-oss-20b"]));
+    let router = OpenAIRouter::new(&ctx).await.unwrap();
+
+    let headers = endpoint_override_headers("gemiin", &format!("{dedicated_url}/v1/responses"));
+    let request = endpoint_override_request(false);
+
+    let response = router
+        .route_responses(
+            Some(&headers),
+            &test_tenant_meta(),
+            &request,
+            &request.model,
+        )
+        .await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(dedicated_state.requests.load(Ordering::SeqCst), 0);
+    assert_eq!(shared_state.requests.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn test_streaming_responses_endpoint_override_uses_dedicated_endpoint() {
+    let (shared_url, shared_state) = start_capture_responses_server(StatusCode::OK).await;
+    let (dedicated_url, dedicated_state) = start_capture_responses_server(StatusCode::OK).await;
+
+    let ctx = create_test_app_context().await;
+    register_external_worker(&ctx, &shared_url, Some(vec!["gpt-oss-20b"]));
+    let router = OpenAIRouter::new(&ctx).await.unwrap();
+
+    let headers = endpoint_override_headers("openai", &format!("{dedicated_url}/v1/responses"));
+    let request = endpoint_override_request(true);
+
+    let response = router
+        .route_responses(
+            Some(&headers),
+            &test_tenant_meta(),
+            &request,
+            &request.model,
+        )
+        .await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    assert_eq!(dedicated_state.requests.load(Ordering::SeqCst), 1);
+    assert_eq!(shared_state.requests.load(Ordering::SeqCst), 0);
+
+    let body = dedicated_state
+        .last_body
+        .lock()
+        .await
+        .clone()
+        .expect("dedicated streaming body captured");
+    assert_eq!(body["model"], json!("gpt-oss-20b"));
+    assert_eq!(body["stream"], json!(true));
 }
 
 #[expect(clippy::disallowed_methods, reason = "test infrastructure")]

--- a/model_gateway/tests/routing/test_openai_routing.rs
+++ b/model_gateway/tests/routing/test_openai_routing.rs
@@ -221,7 +221,6 @@ async fn start_capture_responses_server(status: StatusCode) -> (String, CaptureR
         axum::serve(listener, app).await.expect("capture server");
     });
 
-    sleep(Duration::from_millis(10)).await;
     (format!("http://{addr}"), state)
 }
 
@@ -417,7 +416,7 @@ async fn test_responses_endpoint_override_rejects_unknown_provider_without_fallb
     register_external_worker(&ctx, &shared_url, Some(vec!["gpt-oss-20b"]));
     let router = OpenAIRouter::new(&ctx).await.unwrap();
 
-    let headers = endpoint_override_headers("gemiin", &format!("{dedicated_url}/v1/responses"));
+    let headers = endpoint_override_headers("gemini", &format!("{dedicated_url}/v1/responses"));
     let request = endpoint_override_request(false);
 
     let response = router

--- a/model_gateway/tests/routing/test_openai_routing.rs
+++ b/model_gateway/tests/routing/test_openai_routing.rs
@@ -317,7 +317,7 @@ async fn test_openai_router_models() {
 }
 
 #[tokio::test]
-async fn test_responses_endpoint_override_uses_exact_endpoint_and_strips_override_headers() {
+async fn test_responses_endpoint_override_rejects_loopback_endpoint_without_fallback() {
     let (shared_url, shared_state) = start_capture_responses_server(StatusCode::OK).await;
     let (dedicated_url, dedicated_state) = start_capture_responses_server(StatusCode::OK).await;
 
@@ -339,37 +339,9 @@ async fn test_responses_endpoint_override_uses_exact_endpoint_and_strips_overrid
             &request.model,
         )
         .await;
-    assert_eq!(response.status(), StatusCode::OK);
-
-    assert_eq!(dedicated_state.requests.load(Ordering::SeqCst), 1);
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(dedicated_state.requests.load(Ordering::SeqCst), 0);
     assert_eq!(shared_state.requests.load(Ordering::SeqCst), 0);
-
-    let body = dedicated_state
-        .last_body
-        .lock()
-        .await
-        .clone()
-        .expect("dedicated request body captured");
-    assert_eq!(body["model"], json!("gpt-oss-20b"));
-    let uri = dedicated_state
-        .last_uri
-        .lock()
-        .await
-        .clone()
-        .expect("dedicated request URI captured");
-    assert_eq!(
-        uri,
-        "/v1beta/models/gemini-2.5-flash:generateContent?alt=sse"
-    );
-
-    let forwarded_headers = dedicated_state
-        .last_headers
-        .lock()
-        .await
-        .clone()
-        .expect("dedicated request headers captured");
-    assert!(forwarded_headers.get("x-provider-endpoint").is_none());
-    assert!(forwarded_headers.get("x-model-provider").is_none());
 }
 
 #[tokio::test]
@@ -412,7 +384,7 @@ async fn test_responses_endpoint_override_rejects_invalid_endpoint_urls_without_
 }
 
 #[tokio::test]
-async fn test_responses_endpoint_override_accepts_gpt_oss_as_openai_provider() {
+async fn test_responses_endpoint_override_rejects_loopback_for_gpt_oss_without_fallback() {
     let (shared_url, shared_state) = start_capture_responses_server(StatusCode::OK).await;
     let (dedicated_url, dedicated_state) = start_capture_responses_server(StatusCode::OK).await;
 
@@ -431,8 +403,8 @@ async fn test_responses_endpoint_override_accepts_gpt_oss_as_openai_provider() {
             &request.model,
         )
         .await;
-    assert_eq!(response.status(), StatusCode::OK);
-    assert_eq!(dedicated_state.requests.load(Ordering::SeqCst), 1);
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(dedicated_state.requests.load(Ordering::SeqCst), 0);
     assert_eq!(shared_state.requests.load(Ordering::SeqCst), 0);
 }
 
@@ -472,7 +444,7 @@ async fn test_responses_endpoint_override_rejects_unknown_provider_without_fallb
 }
 
 #[tokio::test]
-async fn test_streaming_responses_endpoint_override_uses_dedicated_endpoint() {
+async fn test_streaming_responses_endpoint_override_rejects_loopback_without_fallback() {
     let (shared_url, shared_state) = start_capture_responses_server(StatusCode::OK).await;
     let (dedicated_url, dedicated_state) = start_capture_responses_server(StatusCode::OK).await;
 
@@ -491,19 +463,9 @@ async fn test_streaming_responses_endpoint_override_uses_dedicated_endpoint() {
             &request.model,
         )
         .await;
-    assert_eq!(response.status(), StatusCode::OK);
-
-    assert_eq!(dedicated_state.requests.load(Ordering::SeqCst), 1);
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(dedicated_state.requests.load(Ordering::SeqCst), 0);
     assert_eq!(shared_state.requests.load(Ordering::SeqCst), 0);
-
-    let body = dedicated_state
-        .last_body
-        .lock()
-        .await
-        .clone()
-        .expect("dedicated streaming body captured");
-    assert_eq!(body["model"], json!("gpt-oss-20b"));
-    assert_eq!(body["stream"], json!(true));
 }
 
 #[expect(clippy::disallowed_methods, reason = "test infrastructure")]

--- a/model_gateway/tests/routing/test_openai_routing.rs
+++ b/model_gateway/tests/routing/test_openai_routing.rs
@@ -416,7 +416,7 @@ async fn test_responses_endpoint_override_rejects_unknown_provider_without_fallb
     register_external_worker(&ctx, &shared_url, Some(vec!["gpt-oss-20b"]));
     let router = OpenAIRouter::new(&ctx).await.unwrap();
 
-    let headers = endpoint_override_headers("gemini", &format!("{dedicated_url}/v1/responses"));
+    let headers = endpoint_override_headers("unknown", &format!("{dedicated_url}/v1/responses"));
     let request = endpoint_override_request(false);
 
     let response = router
@@ -436,7 +436,7 @@ async fn test_responses_endpoint_override_rejects_unknown_provider_without_fallb
         serde_json::from_slice(&body_bytes).expect("error response json");
     assert_eq!(
         body_json["error"]["message"],
-        json!("x-model-provider must be one of openai, gpt-oss, xai, google, anthropic")
+        json!("x-model-provider must be one of openai, gpt-oss, xai, google, gemini, anthropic")
     );
     assert_eq!(dedicated_state.requests.load(Ordering::SeqCst), 0);
     assert_eq!(shared_state.requests.load(Ordering::SeqCst), 0);


### PR DESCRIPTION
## Description

Resolves https://github.com/lightseekorg/smg/issues/1404

### Problem

Responses API requests could only route through registered workers. Dedicated endpoint requests need to target a provider endpoint directly for a single request without registering that endpoint as a worker first.

### Solution

Add a Responses endpoint override path using `x-provider-endpoint` and `x-model-provider`. When present, SMG routes the request through the OpenAI-compatible Responses router, builds a request-scoped external worker, sends the request to the exact upstream URL, and strips override headers before forwarding.

## Changes

- Added `x-provider-endpoint` and `x-model-provider` header extraction.
- Added request-scoped Responses endpoint override handling.
- Routed Responses endpoint overrides through the OpenAI-compatible router.
- Added validation for endpoint URL and provider hint.
- Added routing tests for exact endpoint usage, invalid inputs, `gpt-oss`, and streaming.
- Documented the direct endpoint override behavior.

## Test Plan

- `cargo +nightly fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p smg --test routing_tests test_responses_endpoint_override -- --nocapture`
- `cargo test -p smg --test routing_tests`

Known: full `cargo test` currently fails in unrelated `otel_tracing_test::test_router_with_tracing`, where the collector receives 0 spans instead of 2.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-request upstream endpoint override for OpenAI-compatible Responses via HTTP headers, with optional provider hint (supports common provider identifiers).

* **Behavior**
  * Overrides route the single request to the specified endpoint and use the hinted provider; absent hint defaults to OpenAI.

* **Bug Fixes / Validation**
  * Invalid or disallowed overrides (e.g., loopback/non-public or unknown providers) are rejected with validation errors.

* **Tests**
  * Integration tests for override acceptance, rejection (including streaming), and telemetry.

* **Documentation**
  * API reference updated with override usage and constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->