### PR TITLE
feat(bindings/python): smg-as-tokenspeed-dependency surface (working serve_oai)

### DIFF
--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -9,9 +9,16 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { version = "0.28.2", features = ["extension-module", "abi3-py38"] }
+pyo3-async-runtimes = { version = "0.28", features = ["tokio-runtime"] }
 tokio = { version = "1.42.0", features = ["full"] }
 once_cell = "1.19"
 serde_yaml = "0.9"
+axum = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+futures = { workspace = true }
+uuid = { workspace = true, features = ["v4"] }
+tracing = { workspace = true }
 
 [dependencies.smg]
 path = "../../model_gateway"

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -42,6 +42,9 @@ workspace = true
 [dependencies.llm-tokenizer]
 workspace = true
 
+[dependencies.openai-protocol]
+workspace = true
+
 [features]
 default = ["pyo3/extension-module"]
 vendored-openssl = ["smg/vendored-openssl"]

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -39,6 +39,9 @@ workspace = true
 [dependencies.reasoning-parser]
 workspace = true
 
+[dependencies.llm-tokenizer]
+workspace = true
+
 [features]
 default = ["pyo3/extension-module"]
 vendored-openssl = ["smg/vendored-openssl"]

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -2,6 +2,19 @@
 
 This directory contains the Python bindings for SMG (Shepherd Model Gateway), built using [maturin](https://github.com/PyO3/maturin) and [PyO3](https://github.com/PyO3/pyo3).
 
+## Two consumption modes
+
+These bindings serve two distinct use cases:
+
+1. **smg as a Python-launched binary** — the historical use, documented in
+   [Quick Start](#quick-start) below. `smg serve` boots a router in-process.
+2. **smg as a Python library** — used by inference engines that want smg's
+   protocol layer (tokenization, function calling, reasoning parser, OAI
+   server, MCP, response API) without owning the routing/gateway. The first
+   integration target is TokenSpeed; `tokenspeed serve` will `import smg_rs`
+   and call into the entry points in `src/serving.rs`. See the module
+   docstring there for the planned shape.
+
 ## Quick Start
 
 ### Installation

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -5,6 +5,8 @@ use pyo3::prelude::*;
 use smg::*;
 use smg_auth as auth;
 
+mod serving;
+
 // Define the enums with PyO3 bindings
 #[pyclass(eq, from_py_object)]
 #[derive(Clone, PartialEq, Debug)]
@@ -1274,5 +1276,6 @@ fn smg_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(print_banner, m)?)?;
     m.add_function(wrap_pyfunction!(get_available_tool_call_parsers, m)?)?;
     m.add_function(wrap_pyfunction!(get_available_reasoning_parsers, m)?)?;
+    serving::register(m)?;
     Ok(())
 }

--- a/bindings/python/src/serving.rs
+++ b/bindings/python/src/serving.rs
@@ -22,15 +22,18 @@
 //!   itself can be exercised; chat templates, streaming and tool /
 //!   reasoning parsing land in follow-ups.
 
+use std::convert::Infallible;
 use std::net::SocketAddr;
 use std::sync::{Arc, OnceLock};
 
 use axum::extract::State;
 use axum::http::StatusCode;
+use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::response::IntoResponse;
 use axum::routing::post;
 use axum::{Json, Router};
-use pyo3::exceptions::{PyRuntimeError, PyValueError};
+use futures::stream::StreamExt;
+use pyo3::exceptions::{PyRuntimeError, PyStopAsyncIteration, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList, PyModule};
 use serde_json::{json, Value};
@@ -335,11 +338,231 @@ fn extract_sampling_from_oai(body: &Value) -> serde_json::Map<String, Value> {
     out
 }
 
+/// Bridge ``engine.generate_request(stream=True)`` — an async generator
+/// of cumulative ``{"text": ..., "meta_info": {...}}`` dicts — to an
+/// axum SSE stream of OAI ``chat.completion.chunk`` events.
+///
+/// Mechanics:
+///
+/// 1. Spawn a tokio task scoped under the supplied ``TaskLocals`` (so
+///    ``into_future`` finds the asyncio loop).
+/// 2. The task builds the ``GenerateReqInput`` with ``stream=True``
+///    once and grabs the resulting Python async iterator.
+/// 3. Each iteration: call ``__anext__()``, bridge to a Rust future
+///    via ``into_future``, await. On ``StopAsyncIteration`` we stop;
+///    on any other ``PyErr`` we surface it as an SSE ``error`` event.
+/// 4. Each yielded dict is JSON-roundtripped to ``serde_json::Value``,
+///    we compute the **delta** against the cumulative ``text`` we've
+///    already streamed, and emit a ``chat.completion.chunk`` event.
+/// 5. After the final chunk we emit a chunk with the actual
+///    ``finish_reason`` and then ``data: [DONE]`` per OAI convention.
+///
+/// Chunks are funneled through a bounded ``mpsc::channel`` so axum
+/// can flush them downstream as fast as the client reads.
+fn stream_response(
+    engine: Arc<Py<PyAny>>,
+    locals: Arc<pyo3_async_runtimes::TaskLocals>,
+    prompt: String,
+    sampling: serde_json::Map<String, Value>,
+    request_id: String,
+    model_label: String,
+) -> Sse<impl futures::Stream<Item = Result<Event, Infallible>>> {
+    let (tx, rx) = futures::channel::mpsc::unbounded::<Result<Event, Infallible>>();
+
+    let request_id_for_task = request_id.clone();
+    let model_label_for_task = model_label.clone();
+    let locals_for_scope = (*locals).clone();
+
+    tokio::spawn(async move {
+        // Initial role chunk so OAI clients see {"role": "assistant"} once
+        // up front — same convention as openai-python's stream parser.
+        let _ = tx.unbounded_send(Ok(Event::default().data(
+            json!({
+                "id": &request_id_for_task,
+                "object": "chat.completion.chunk",
+                "model": &model_label_for_task,
+                "choices": [{
+                    "index": 0,
+                    "delta": {"role": "assistant"},
+                    "finish_reason": null,
+                }],
+            })
+            .to_string(),
+        )));
+
+        // Clone the sender for the inner scope so each block owns its
+        // own handle (closures inside ``scope``'s async-move can't
+        // borrow ``tx`` from the outer task without escaping the move).
+        let tx_inner = tx.clone();
+
+        let result: PyResult<()> = pyo3_async_runtimes::tokio::scope(locals_for_scope, async move {
+            // Build the request and grab the async iterator object once.
+            let aiter: Py<PyAny> = Python::attach(|py| -> PyResult<_> {
+                let io_struct = py.import("tokenspeed.runtime.engine.io_struct")?;
+                let generate_req_input_cls = io_struct.getattr("GenerateReqInput")?;
+                let json_module = py.import("json")?;
+                let sampling_json = serde_json::to_string(&Value::Object(sampling.clone()))
+                    .map_err(|e| {
+                        PyRuntimeError::new_err(format!("encode sampling_params: {e}"))
+                    })?;
+                let sampling_dict = json_module.call_method1("loads", (sampling_json,))?;
+
+                let kwargs = PyDict::new(py);
+                kwargs.set_item("text", prompt)?;
+                kwargs.set_item("sampling_params", sampling_dict)?;
+                kwargs.set_item("stream", true)?;
+                let req_obj = generate_req_input_cls.call((), Some(&kwargs))?;
+                req_obj.setattr("rid", &request_id_for_task)?;
+
+                let aiter = engine.bind(py).call_method1("generate_request", (req_obj,))?;
+                Ok(aiter.unbind())
+            })?;
+
+            let mut prev_text = String::new();
+            let mut last_finish_reason: Option<String> = None;
+            let mut last_completion_tokens: u64 = 0;
+            let mut last_prompt_tokens: u64 = 0;
+
+            loop {
+                // Pull the next chunk via __anext__; bridge to a Rust
+                // future so axum's tokio reactor stays unblocked.
+                let next_fut = Python::attach(|py| -> PyResult<_> {
+                    let bound = aiter.bind(py);
+                    let anext = bound.call_method0("__anext__")?;
+                    pyo3_async_runtimes::tokio::into_future(anext)
+                })?;
+
+                let chunk_obj = match next_fut.await {
+                    Ok(o) => o,
+                    Err(e) => {
+                        let stop = Python::attach(|py| {
+                            e.is_instance_of::<PyStopAsyncIteration>(py)
+                        });
+                        if stop {
+                            break;
+                        }
+                        return Err(e);
+                    }
+                };
+
+                // JSON-roundtrip the dict so the rest of the loop can
+                // work on serde_json::Value without touching pyo3.
+                let chunk_json: Value = Python::attach(|py| -> PyResult<Value> {
+                    let json_module = py.import("json")?;
+                    let s: String = json_module
+                        .call_method1("dumps", (chunk_obj.bind(py),))?
+                        .extract()?;
+                    Ok(serde_json::from_str(&s).unwrap_or(Value::Null))
+                })?;
+
+                let cur_text = chunk_json
+                    .get("text")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .to_string();
+                // ``out["text"]`` is the cumulative output so far per
+                // tokenspeed's contract; the delta we forward to the OAI
+                // client is the suffix beyond what we've streamed before.
+                let delta = if cur_text.starts_with(&prev_text) {
+                    cur_text[prev_text.len()..].to_string()
+                } else {
+                    // Engine restarted / produced a non-prefix sequence
+                    // (rare). Fall back to the full text — the client
+                    // will see a duplicate but semantically nothing is
+                    // lost.
+                    cur_text.clone()
+                };
+                prev_text = cur_text;
+
+                if let Some(meta) = chunk_json.get("meta_info") {
+                    if let Some(fr) = meta.get("finish_reason") {
+                        last_finish_reason = match fr {
+                            Value::String(s) => Some(s.clone()),
+                            Value::Object(m) => {
+                                m.get("type").and_then(Value::as_str).map(str::to_owned)
+                            }
+                            _ => None,
+                        };
+                    }
+                    if let Some(c) = meta.get("completion_tokens").and_then(Value::as_u64) {
+                        last_completion_tokens = c;
+                    }
+                    if let Some(p) = meta.get("prompt_tokens").and_then(Value::as_u64) {
+                        last_prompt_tokens = p;
+                    }
+                }
+
+                // Emit a content chunk only if there is actual delta.
+                // (The engine occasionally yields metadata-only refreshes;
+                // pushing an empty-content chunk to OAI clients confuses
+                // the openai-python stream parser.)
+                if !delta.is_empty() {
+                    let _ = tx_inner.unbounded_send(Ok(Event::default().data(
+                        json!({
+                            "id": &request_id_for_task,
+                            "object": "chat.completion.chunk",
+                            "model": &model_label_for_task,
+                            "choices": [{
+                                "index": 0,
+                                "delta": {"content": delta},
+                                "finish_reason": null,
+                            }],
+                        })
+                        .to_string(),
+                    )));
+                }
+            }
+
+            // Final terminating chunk carries the finish_reason and a
+            // (non-OAI but commonly accepted) usage block.
+            let _ = tx_inner.unbounded_send(Ok(Event::default().data(
+                json!({
+                    "id": &request_id_for_task,
+                    "object": "chat.completion.chunk",
+                    "model": &model_label_for_task,
+                    "choices": [{
+                        "index": 0,
+                        "delta": {},
+                        "finish_reason": last_finish_reason.unwrap_or_else(|| "stop".to_string()),
+                    }],
+                    "usage": {
+                        "prompt_tokens": last_prompt_tokens,
+                        "completion_tokens": last_completion_tokens,
+                        "total_tokens": last_prompt_tokens + last_completion_tokens,
+                    },
+                })
+                .to_string(),
+            )));
+            // OAI sentinel so client SSE parsers know to stop.
+            let _ = tx_inner.unbounded_send(Ok(Event::default().data("[DONE]")));
+            Ok(())
+        })
+        .await;
+
+        if let Err(e) = result {
+            error!(error = %e, "AsyncLLM streaming call failed");
+            let _ = tx.unbounded_send(Ok(Event::default()
+                .event("error")
+                .data(json!({"error": e.to_string()}).to_string())));
+        }
+    });
+
+    Sse::new(rx).keep_alive(KeepAlive::default())
+}
+
 /// ``POST /v1/chat/completions`` handler.
 ///
-/// First-cut behavior: extract the last user message, drive ``AsyncLLM``,
-/// pack the engine's text response into an OAI ``ChatCompletion`` shape.
-/// No streaming, no chat template, no tool/reasoning post-processing.
+/// Branches on ``body.stream``:
+///
+/// * ``stream: true`` (or omitted-and-defaulting to false but with
+///   ``Accept: text/event-stream``) — open an SSE response and pump
+///   each chunk yielded by ``engine.generate_request`` as an OAI
+///   ``chat.completion.chunk`` event, terminated by ``data: [DONE]``.
+/// * ``stream: false`` — drain the generator, return a single
+///   ``chat.completion`` JSON body.
+///
+/// Chat-template render and tool / reasoning post-processing are still
+/// follow-ups; the streaming path emits raw deltas of ``out["text"]``.
 async fn chat_completions_handler(
     State(state): State<AppState>,
     Json(body): Json<Value>,
@@ -354,17 +577,25 @@ async fn chat_completions_handler(
         .and_then(Value::as_str)
         .unwrap_or("default")
         .to_string();
+    let stream_mode = body.get("stream").and_then(Value::as_bool).unwrap_or(false);
     let request_id = format!("chatcmpl-{}", uuid::Uuid::new_v4().simple());
 
     debug!(
         prompt_len = prompt.len(),
         sampling = ?sampling,
         rid = %request_id,
+        stream = stream_mode,
         "dispatching to AsyncLLM",
     );
 
     let engine = state.engine.clone();
     let locals = state.locals.clone();
+
+    if stream_mode {
+        return stream_response(engine, locals, prompt, sampling, request_id, model_label)
+            .into_response();
+    }
+
     let result = drive_generate(engine, locals, prompt, sampling, request_id.clone()).await;
 
     match result {

--- a/bindings/python/src/serving.rs
+++ b/bindings/python/src/serving.rs
@@ -8,34 +8,43 @@
 //! this module via PyO3. The Rust side then runs the OAI HTTP layer and
 //! drives ``AsyncLLM`` in-process — no gRPC, no IPC, single Python process.
 //!
-//! This module is the *skeleton*: the parser entry points are real (they
-//! re-use the ``tool_parser`` and ``reasoning_parser`` workspace crates as
-//! libraries) so callers can verify the integration works end-to-end; the
-//! ``serve_oai`` HTTP entry is a stub that raises a clear error message
-//! pointing at the follow-up work.
+//! The current shape:
 //!
-//! See ``crates/protocols``, ``crates/tool_parser``, ``crates/reasoning_parser``,
-//! ``crates/tokenizer`` for the full library surface that will land here over
-//! the next few iterations.
+//! * ``parse_tool_call_complete``, ``parse_reasoning_complete`` —
+//!   thin pyfunctions over the existing ``tool_parser`` and
+//!   ``reasoning_parser`` workspace crates so callers can verify the
+//!   integration end-to-end before the HTTP server lands.
+//! * ``serve_oai`` — runs an axum HTTP server in-process, drives the
+//!   supplied ``AsyncLLM``-shaped engine via ``pyo3-async-runtimes``,
+//!   and serves OAI-compatible ``/v1/chat/completions``. First cut is
+//!   non-streaming and skips the chat-template render (passes
+//!   ``messages[-1].content`` straight through as text) so the bridge
+//!   itself can be exercised; chat templates, streaming and tool /
+//!   reasoning parsing land in follow-ups.
 
-use std::sync::OnceLock;
+use std::net::SocketAddr;
+use std::sync::{Arc, OnceLock};
 
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::routing::post;
+use axum::{Json, Router};
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
-use pyo3::{Py, PyAny};
+use serde_json::{json, Value};
 use tokio::runtime::Runtime;
+use tracing::{debug, error};
 
 /// Re-export of pyo3's owned-Python-object handle. ``Py<PyAny>`` is what
 /// pyo3 0.28 uses where older versions exposed ``PyObject`` from the
 /// prelude.
 type PyObject = Py<PyAny>;
 
-/// Lazily-initialized tokio runtime shared across blocking PyO3 entries.
-///
-/// One Runtime per process is enough for the read-only parser entries; the
-/// HTTP server (``serve_oai``) will spawn its own multi-threaded runtime
-/// when implemented.
+/// Lazily-initialized tokio runtime shared across blocking PyO3 entries
+/// (the parser pyfunctions). The HTTP server (``serve_oai``) builds its
+/// own multi-threaded runtime and registers it with pyo3-async-runtimes.
 fn shared_runtime() -> PyResult<&'static Runtime> {
     static RT: OnceLock<Runtime> = OnceLock::new();
     if let Some(rt) = RT.get() {
@@ -136,8 +145,267 @@ fn parse_reasoning_complete(py: Python<'_>, output: &str, parser_name: &str) -> 
 }
 
 // =====================================================================
-// OAI HTTP server (stub)
+// OAI HTTP server
 // =====================================================================
+
+/// Shared state held by every axum handler — just a reference to the
+/// Python ``AsyncLLM``-shaped engine. Cloning is cheap (``Py<PyAny>``
+/// is reference-counted under the hood; we acquire the GIL when we
+/// actually call into it).
+#[derive(Clone)]
+struct AppState {
+    engine: Arc<Py<PyAny>>,
+}
+
+/// Drive ``engine.generate_request(GenerateReqInput(text=..., sampling_params=...))``
+/// to completion and return the final response dict.
+///
+/// The Python side is a TokenSpeed-style ``AsyncLLM``: ``generate_request``
+/// returns an async generator yielding output dicts of shape
+/// ``{"text": str, "output_ids": [int], "meta_info": {"finish_reason": str|dict, ...}}``.
+/// For non-streaming we drive the generator with a tiny inline coroutine
+/// (``await aiter.__anext__()`` until ``StopAsyncIteration``) and keep
+/// the **last** yield — that's the final, complete response.
+///
+/// Returns the JSON-serializable dict as ``serde_json::Value`` for axum to
+/// emit.
+async fn drive_generate(
+    engine: Arc<Py<PyAny>>,
+    prompt: String,
+    sampling: serde_json::Map<String, Value>,
+    request_id: String,
+) -> PyResult<Value> {
+    // 1. Build the GenerateReqInput on the Python side under the GIL.
+    //    Then hand the resulting coroutine off to pyo3-async-runtimes
+    //    so axum's tokio reactor doesn't block on the engine.
+    //
+    //    We cross the language boundary by JSON-encoding the
+    //    sampling-params payload and asking Python's ``json.loads`` to
+    //    decode it. That is intentionally one syscall-style hop instead
+    //    of a recursive ``IntoPyObject`` walk: the values are tiny
+    //    (a handful of scalars per request), the engine itself has to
+    //    JSON-encode the response anyway, and avoiding pyo3's
+    //    type-conversion traits keeps this module portable across
+    //    pyo3 minor versions.
+    let sampling_json = serde_json::to_string(&Value::Object(sampling.clone()))
+        .map_err(|e| PyRuntimeError::new_err(format!("encode sampling_params: {e}")))?;
+
+    let coro_fut = Python::with_gil(|py| -> PyResult<_> {
+        let io_struct = py.import("tokenspeed.runtime.engine.io_struct")?;
+        let generate_req_input_cls = io_struct.getattr("GenerateReqInput")?;
+        let json_module = py.import("json")?;
+        let sampling_dict = json_module.call_method1("loads", (sampling_json,))?;
+
+        let kwargs = PyDict::new(py);
+        kwargs.set_item("text", prompt)?;
+        kwargs.set_item("sampling_params", sampling_dict)?;
+        kwargs.set_item("rid", request_id)?;
+        kwargs.set_item("stream", false)?;
+        let req_obj = generate_req_input_cls.call((), Some(&kwargs))?;
+
+        // Inline coroutine helper that drains the engine's async generator
+        // and returns its **final** yielded dict (the one with
+        // ``meta_info.finish_reason`` set). Compiled fresh per call —
+        // cheap and keeps the helper from leaking into ``sys.modules``.
+        let helpers = pyo3::types::PyModule::from_code(
+            py,
+            std::ffi::CString::new(CONSUME_HELPER_SRC)
+                .expect("static cstring")
+                .as_c_str(),
+            std::ffi::CString::new("smg_rs_serve_helpers.py")
+                .expect("static cstring")
+                .as_c_str(),
+            std::ffi::CString::new("smg_rs_serve_helpers")
+                .expect("static cstring")
+                .as_c_str(),
+        )?;
+        let consume = helpers.getattr("_consume_to_last")?;
+        let coro = consume.call1((engine.bind(py), req_obj))?;
+
+        pyo3_async_runtimes::tokio::into_future(coro)
+    })?;
+
+    let last_obj = coro_fut.await?;
+
+    // 2. Convert the final Python dict to ``serde_json::Value`` via the
+    //    same JSON hop in reverse: ``json.dumps`` on the Python side,
+    //    ``serde_json::from_str`` on ours. The dict shape is well-defined
+    //    by the TokenSpeed contract (``{"text": str, "output_ids": [int],
+    //    "meta_info": {...}}``) so dumping is total.
+    let json_str = Python::with_gil(|py| -> PyResult<String> {
+        let json_module = py.import("json")?;
+        let s: String = json_module
+            .call_method1("dumps", (last_obj.bind(py),))?
+            .extract()?;
+        Ok(s)
+    })?;
+
+    serde_json::from_str(&json_str)
+        .map_err(|e| PyRuntimeError::new_err(format!("decode engine response: {e}")))
+}
+
+/// Inline Python helper. Consumes the async generator and returns the
+/// final yielded dict — the one with ``meta_info.finish_reason`` set.
+/// Bundled as a string so the wheel doesn't need a sibling ``.py`` file.
+const CONSUME_HELPER_SRC: &str = r#"
+async def _consume_to_last(engine, obj):
+    """Drain engine.generate_request(obj); return the final output dict."""
+    last = None
+    async for out in engine.generate_request(obj):
+        last = out
+    if last is None:
+        raise RuntimeError("engine.generate_request yielded no output")
+    return last
+"#;
+
+/// Pull the user's last message text out of an OAI-shape body. First-cut
+/// shortcut: skip chat-template rendering and just take whatever the user
+/// said most recently. We do this on Rust side because chat-template
+/// support requires loading the model's HF tokenizer; lands as a
+/// follow-up.
+fn extract_prompt_from_oai(body: &Value) -> Result<String, String> {
+    let messages = body
+        .get("messages")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "request body missing 'messages' array".to_string())?;
+    let last = messages
+        .last()
+        .ok_or_else(|| "'messages' is empty".to_string())?;
+    let content = last
+        .get("content")
+        .ok_or_else(|| "last message has no 'content'".to_string())?;
+    match content {
+        Value::String(s) => Ok(s.clone()),
+        // Vision / multipart content arrays are documented as a follow-up.
+        Value::Array(_) => Err(
+            "multipart/array message content is not supported in the first-cut serve_oai; \
+             pass a plain string"
+                .to_string(),
+        ),
+        other => Err(format!("unsupported content shape: {other}")),
+    }
+}
+
+/// Pull the sampling params out of an OAI-shape body into a flat dict that
+/// ``GenerateReqInput.sampling_params`` understands. Only the well-known
+/// subset is forwarded — engine-specific keys like ``regex``,
+/// ``json_schema``, ``ebnf``, ``stop_token_ids`` etc. land in a
+/// follow-up alongside tool_choice plumbing.
+fn extract_sampling_from_oai(body: &Value) -> serde_json::Map<String, Value> {
+    let mut out = serde_json::Map::new();
+    let copy = |out: &mut serde_json::Map<String, Value>, key_oai: &str, key_engine: &str| {
+        if let Some(v) = body.get(key_oai) {
+            if !v.is_null() {
+                out.insert(key_engine.to_string(), v.clone());
+            }
+        }
+    };
+
+    copy(&mut out, "temperature", "temperature");
+    copy(&mut out, "top_p", "top_p");
+    copy(&mut out, "top_k", "top_k");
+    copy(&mut out, "frequency_penalty", "frequency_penalty");
+    copy(&mut out, "presence_penalty", "presence_penalty");
+    copy(&mut out, "max_tokens", "max_new_tokens");
+    copy(&mut out, "max_completion_tokens", "max_new_tokens");
+    copy(&mut out, "stop", "stop");
+
+    out
+}
+
+/// ``POST /v1/chat/completions`` handler.
+///
+/// First-cut behavior: extract the last user message, drive ``AsyncLLM``,
+/// pack the engine's text response into an OAI ``ChatCompletion`` shape.
+/// No streaming, no chat template, no tool/reasoning post-processing.
+async fn chat_completions_handler(
+    State(state): State<AppState>,
+    Json(body): Json<Value>,
+) -> impl IntoResponse {
+    let prompt = match extract_prompt_from_oai(&body) {
+        Ok(p) => p,
+        Err(e) => return (StatusCode::BAD_REQUEST, Json(json!({"error": e}))).into_response(),
+    };
+    let sampling = extract_sampling_from_oai(&body);
+    let model_label = body
+        .get("model")
+        .and_then(Value::as_str)
+        .unwrap_or("default")
+        .to_string();
+    let request_id = format!("chatcmpl-{}", uuid::Uuid::new_v4().simple());
+
+    debug!(
+        prompt_len = prompt.len(),
+        sampling = ?sampling,
+        rid = %request_id,
+        "dispatching to AsyncLLM",
+    );
+
+    let engine = state.engine.clone();
+    let result = drive_generate(engine, prompt, sampling, request_id.clone()).await;
+
+    match result {
+        Ok(out) => {
+            let text = out
+                .get("text")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string();
+            let finish_reason = out
+                .get("meta_info")
+                .and_then(|m| m.get("finish_reason"))
+                .map(|fr| match fr {
+                    Value::String(s) => s.clone(),
+                    Value::Object(m) => m
+                        .get("type")
+                        .and_then(Value::as_str)
+                        .unwrap_or("stop")
+                        .to_string(),
+                    _ => "stop".to_string(),
+                })
+                .unwrap_or_else(|| "stop".to_string());
+            let prompt_tokens = out
+                .get("meta_info")
+                .and_then(|m| m.get("prompt_tokens"))
+                .and_then(Value::as_u64)
+                .unwrap_or(0);
+            let completion_tokens = out
+                .get("meta_info")
+                .and_then(|m| m.get("completion_tokens"))
+                .and_then(Value::as_u64)
+                .unwrap_or(0);
+
+            let body = json!({
+                "id": request_id,
+                "object": "chat.completion",
+                "created": std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_secs())
+                    .unwrap_or(0),
+                "model": model_label,
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": text},
+                    "finish_reason": finish_reason,
+                }],
+                "usage": {
+                    "prompt_tokens": prompt_tokens,
+                    "completion_tokens": completion_tokens,
+                    "total_tokens": prompt_tokens + completion_tokens,
+                },
+            });
+            (StatusCode::OK, Json(body)).into_response()
+        }
+        Err(e) => {
+            error!(error = %e, "AsyncLLM call failed");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": e.to_string()})),
+            )
+                .into_response()
+        }
+    }
+}
 
 /// Run smg's OAI-compatible HTTP server in-process, driving the supplied
 /// engine via PyO3 callbacks.
@@ -145,40 +413,79 @@ fn parse_reasoning_complete(py: Python<'_>, output: &str, parser_name: &str) -> 
 /// Intended call site (``tokenspeed serve``)::
 ///
 ///     async_llm = AsyncLLM(server_args)
-///     await smg_rs.serve_oai(
+///     smg_rs.serve_oai(
 ///         engine=async_llm,
 ///         host=args.host,
 ///         port=args.port,
-///         chat_template=args.chat_template,
 ///     )
 ///
-/// **Currently a stub.** The full implementation will spin up an axum
-/// router that:
+/// The function blocks the calling Python thread for the lifetime of the
+/// server (until the process is signaled). It releases the GIL while
+/// awaiting HTTP requests and re-acquires it for each engine call.
 ///
-/// 1. Renders chat templates server-side (``llm-tokenizer`` crate).
-/// 2. Tokenizes input via the model's HF tokenizer.
-/// 3. Builds ``SamplingParams`` from the request.
-/// 4. Awaits ``engine.async_generate(input_ids, sampling_params)`` via
-///    ``pyo3-async-runtimes``, pulling tokens out as a Rust ``Stream``.
-/// 5. Streams parser-detected tool / reasoning chunks back as SSE.
+/// **First-cut limitations** (all tracked as separate follow-ups):
 ///
-/// Tracking: ``crates/pylib`` direction note in CHANGELOG, and the
-/// "smg-as-pylib" thread on Slack with @syuoni.
+/// * Non-streaming only — streaming SSE goes through pyo3-async-runtimes
+///   wrapping ``__anext__`` per chunk.
+/// * Skips chat-template rendering — passes the last ``messages[-1].content``
+///   directly to the engine. The full path will use the ``llm-tokenizer``
+///   crate's minijinja chat template.
+/// * No tool / reasoning post-processing — the parsers are exposed
+///   separately as :py:func:`parse_tool_call_complete` and
+///   :py:func:`parse_reasoning_complete` for now.
+/// * Only ``/v1/chat/completions`` is wired; ``/v1/completions``,
+///   ``/v1/responses``, ``/v1/embeddings`` etc. land later.
 #[pyfunction]
-#[pyo3(signature = (engine, host, port, chat_template = None))]
-#[allow(unused_variables)]
-fn serve_oai(
-    engine: PyObject,
-    host: &str,
-    port: u16,
-    chat_template: Option<&str>,
-) -> PyResult<()> {
-    Err(PyRuntimeError::new_err(
-        "serve_oai is not implemented yet — landing in a follow-up commit on \
-         feat/pylib-protocol. Integration shape: smg axum HTTP server in-process, \
-         driving AsyncLLM via pyo3-async-runtimes. See bindings/python/src/serving.rs \
-         doc comment for the planned signature and the call sites that will use it.",
-    ))
+#[pyo3(signature = (engine, host = "127.0.0.1", port = 8000))]
+fn serve_oai(py: Python<'_>, engine: PyObject, host: &str, port: u16) -> PyResult<()> {
+    let host_owned = host.to_string();
+    let addr: SocketAddr = format!("{host_owned}:{port}")
+        .parse()
+        .map_err(|e| PyValueError::new_err(format!("invalid host:port {host_owned}:{port}: {e}")))?;
+
+    let state = AppState {
+        engine: Arc::new(engine),
+    };
+    let app = Router::new()
+        .route("/v1/chat/completions", post(chat_completions_handler))
+        .with_state(state);
+
+    // Build a tokio runtime that pyo3-async-runtimes will treat as the
+    // bridge between Python coroutines (engine.generate_request) and
+    // axum's request loop. The runtime is leaked for the lifetime of
+    // the process — this function is the entry point and never returns
+    // until the server exits.
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .thread_name("smg-oai-server")
+        .build()
+        .map_err(|e| PyRuntimeError::new_err(format!("tokio runtime build failed: {e}")))?;
+
+    // Hand the runtime to pyo3-async-runtimes so ``into_future`` knows
+    // where to schedule Python coroutines. Must happen before the first
+    // ``into_future`` call.
+    let rt_handle = rt.handle().clone();
+    pyo3_async_runtimes::tokio::init_with_runtime(&rt)
+        .map_err(|e| PyRuntimeError::new_err(format!("pyo3-async-runtimes init failed: {e}")))?;
+
+    debug!(%addr, "smg_rs.serve_oai starting on {addr}");
+
+    // Release the GIL while the server is running so Python coroutines
+    // dispatched by axum handlers can re-acquire it themselves.
+    py.detach(|| {
+        rt_handle.block_on(async move {
+            let listener = tokio::net::TcpListener::bind(addr)
+                .await
+                .map_err(|e| {
+                    PyRuntimeError::new_err(format!("bind {addr} failed: {e}"))
+                })?;
+            axum::serve(listener, app)
+                .await
+                .map_err(|e| PyRuntimeError::new_err(format!("axum serve failed: {e}")))
+        })
+    })?;
+
+    Ok(())
 }
 
 // =====================================================================

--- a/bindings/python/src/serving.rs
+++ b/bindings/python/src/serving.rs
@@ -32,7 +32,7 @@ use axum::routing::post;
 use axum::{Json, Router};
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyList};
+use pyo3::types::{PyDict, PyList, PyModule};
 use serde_json::{json, Value};
 use tokio::runtime::Runtime;
 use tracing::{debug, error};
@@ -148,13 +148,22 @@ fn parse_reasoning_complete(py: Python<'_>, output: &str, parser_name: &str) -> 
 // OAI HTTP server
 // =====================================================================
 
-/// Shared state held by every axum handler — just a reference to the
-/// Python ``AsyncLLM``-shaped engine. Cloning is cheap (``Py<PyAny>``
-/// is reference-counted under the hood; we acquire the GIL when we
-/// actually call into it).
+/// Shared state held by every axum handler:
+///
+/// * the Python ``AsyncLLM``-shaped engine (cheap to clone — ``Py<PyAny>``
+///   is reference-counted; we acquire the GIL when actually calling
+///   into it).
+/// * the ``TaskLocals`` captured at server start. Without this,
+///   ``into_future`` from inside a tokio worker thread fails with
+///   ``RuntimeError: no running event loop`` because the asyncio loop
+///   pyo3-async-runtimes set up on the supervisor thread is invisible
+///   to the rest of the runtime. Each handler clones these locals and
+///   uses :func:`pyo3_async_runtimes::tokio::into_future_with_locals`
+///   so the Python coroutine gets scheduled on the right loop.
 #[derive(Clone)]
 struct AppState {
     engine: Arc<Py<PyAny>>,
+    locals: Arc<pyo3_async_runtimes::TaskLocals>,
 }
 
 /// Drive ``engine.generate_request(GenerateReqInput(text=..., sampling_params=...))``
@@ -171,68 +180,81 @@ struct AppState {
 /// emit.
 async fn drive_generate(
     engine: Arc<Py<PyAny>>,
+    locals: Arc<pyo3_async_runtimes::TaskLocals>,
     prompt: String,
     sampling: serde_json::Map<String, Value>,
     request_id: String,
 ) -> PyResult<Value> {
-    // 1. Build the GenerateReqInput on the Python side under the GIL.
-    //    Then hand the resulting coroutine off to pyo3-async-runtimes
-    //    so axum's tokio reactor doesn't block on the engine.
-    //
-    //    We cross the language boundary by JSON-encoding the
-    //    sampling-params payload and asking Python's ``json.loads`` to
-    //    decode it. That is intentionally one syscall-style hop instead
-    //    of a recursive ``IntoPyObject`` walk: the values are tiny
-    //    (a handful of scalars per request), the engine itself has to
-    //    JSON-encode the response anyway, and avoiding pyo3's
-    //    type-conversion traits keeps this module portable across
-    //    pyo3 minor versions.
+    // We cross the language boundary by JSON-encoding the
+    // sampling-params payload and asking Python's ``json.loads`` to
+    // decode it. That is intentionally one syscall-style hop instead
+    // of a recursive ``IntoPyObject`` walk: the values are tiny
+    // (a handful of scalars per request), the engine itself has to
+    // JSON-encode the response anyway, and avoiding pyo3's
+    // type-conversion traits keeps this module portable across
+    // pyo3 minor versions.
     let sampling_json = serde_json::to_string(&Value::Object(sampling.clone()))
         .map_err(|e| PyRuntimeError::new_err(format!("encode sampling_params: {e}")))?;
 
-    let coro_fut = Python::with_gil(|py| -> PyResult<_> {
-        let io_struct = py.import("tokenspeed.runtime.engine.io_struct")?;
-        let generate_req_input_cls = io_struct.getattr("GenerateReqInput")?;
-        let json_module = py.import("json")?;
-        let sampling_dict = json_module.call_method1("loads", (sampling_json,))?;
+    // pyo3-async-runtimes' ``into_future`` reads its TaskLocals (the
+    // asyncio loop reference) from a tokio task-local. Axum handlers
+    // run on tokio worker threads with no such task-local set, so we
+    // wrap the engine call in ``tokio::scope(locals, ...)`` — that
+    // populates the task-local for the duration of this future, then
+    // ``into_future`` (called from inside ``Python::attach``) finds
+    // it and schedules the Python coroutine on the right loop.
+    let locals_for_scope = (*locals).clone();
+    let last_obj = pyo3_async_runtimes::tokio::scope(locals_for_scope, async move {
+        let coro_fut = Python::attach(|py| -> PyResult<_> {
+            let io_struct = py.import("tokenspeed.runtime.engine.io_struct")?;
+            let generate_req_input_cls = io_struct.getattr("GenerateReqInput")?;
+            let json_module = py.import("json")?;
+            let sampling_dict = json_module.call_method1("loads", (sampling_json,))?;
 
-        let kwargs = PyDict::new(py);
-        kwargs.set_item("text", prompt)?;
-        kwargs.set_item("sampling_params", sampling_dict)?;
-        kwargs.set_item("rid", request_id)?;
-        kwargs.set_item("stream", false)?;
-        let req_obj = generate_req_input_cls.call((), Some(&kwargs))?;
+            let kwargs = PyDict::new(py);
+            kwargs.set_item("text", prompt)?;
+            kwargs.set_item("sampling_params", sampling_dict)?;
+            kwargs.set_item("stream", false)?;
+            let req_obj = generate_req_input_cls.call((), Some(&kwargs))?;
+            // ``rid`` is declared ``field(default=None, init=False)`` on
+            // GenerateReqInput, so it can't go through the constructor —
+            // assign it post-init like the gRPC servicer does (which is
+            // also what tokenspeed's own ``normalize_batch_and_arguments``
+            // path expects to find when n>1 fan-out runs).
+            req_obj.setattr("rid", request_id)?;
 
-        // Inline coroutine helper that drains the engine's async generator
-        // and returns its **final** yielded dict (the one with
-        // ``meta_info.finish_reason`` set). Compiled fresh per call —
-        // cheap and keeps the helper from leaking into ``sys.modules``.
-        let helpers = pyo3::types::PyModule::from_code(
-            py,
-            std::ffi::CString::new(CONSUME_HELPER_SRC)
-                .expect("static cstring")
-                .as_c_str(),
-            std::ffi::CString::new("smg_rs_serve_helpers.py")
-                .expect("static cstring")
-                .as_c_str(),
-            std::ffi::CString::new("smg_rs_serve_helpers")
-                .expect("static cstring")
-                .as_c_str(),
-        )?;
-        let consume = helpers.getattr("_consume_to_last")?;
-        let coro = consume.call1((engine.bind(py), req_obj))?;
+            // Inline coroutine helper that drains the engine's async
+            // generator and returns its **final** yielded dict (the one
+            // with ``meta_info.finish_reason`` set). Compiled fresh per
+            // call — cheap and keeps the helper from leaking into
+            // ``sys.modules``.
+            let helpers = PyModule::from_code(
+                py,
+                std::ffi::CString::new(CONSUME_HELPER_SRC)
+                    .expect("static cstring")
+                    .as_c_str(),
+                std::ffi::CString::new("smg_rs_serve_helpers.py")
+                    .expect("static cstring")
+                    .as_c_str(),
+                std::ffi::CString::new("smg_rs_serve_helpers")
+                    .expect("static cstring")
+                    .as_c_str(),
+            )?;
+            let consume = helpers.getattr("_consume_to_last")?;
+            let coro = consume.call1((engine.bind(py), req_obj))?;
 
-        pyo3_async_runtimes::tokio::into_future(coro)
-    })?;
-
-    let last_obj = coro_fut.await?;
+            pyo3_async_runtimes::tokio::into_future(coro)
+        })?;
+        coro_fut.await
+    })
+    .await?;
 
     // 2. Convert the final Python dict to ``serde_json::Value`` via the
     //    same JSON hop in reverse: ``json.dumps`` on the Python side,
     //    ``serde_json::from_str`` on ours. The dict shape is well-defined
     //    by the TokenSpeed contract (``{"text": str, "output_ids": [int],
     //    "meta_info": {...}}``) so dumping is total.
-    let json_str = Python::with_gil(|py| -> PyResult<String> {
+    let json_str = Python::attach(|py| -> PyResult<String> {
         let json_module = py.import("json")?;
         let s: String = json_module
             .call_method1("dumps", (last_obj.bind(py),))?
@@ -342,7 +364,8 @@ async fn chat_completions_handler(
     );
 
     let engine = state.engine.clone();
-    let result = drive_generate(engine, prompt, sampling, request_id.clone()).await;
+    let locals = state.locals.clone();
+    let result = drive_generate(engine, locals, prompt, sampling, request_id.clone()).await;
 
     match result {
         Ok(out) => {
@@ -443,46 +466,40 @@ fn serve_oai(py: Python<'_>, engine: PyObject, host: &str, port: u16) -> PyResul
         .parse()
         .map_err(|e| PyValueError::new_err(format!("invalid host:port {host_owned}:{port}: {e}")))?;
 
-    let state = AppState {
-        engine: Arc::new(engine),
-    };
-    let app = Router::new()
-        .route("/v1/chat/completions", post(chat_completions_handler))
-        .with_state(state);
-
-    // Build a tokio runtime that pyo3-async-runtimes will treat as the
-    // bridge between Python coroutines (engine.generate_request) and
-    // axum's request loop. The runtime is leaked for the lifetime of
-    // the process — this function is the entry point and never returns
-    // until the server exits.
-    let rt = tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .thread_name("smg-oai-server")
-        .build()
-        .map_err(|e| PyRuntimeError::new_err(format!("tokio runtime build failed: {e}")))?;
-
-    // Hand the runtime to pyo3-async-runtimes so ``into_future`` knows
-    // where to schedule Python coroutines. Must happen before the first
-    // ``into_future`` call.
-    let rt_handle = rt.handle().clone();
-    pyo3_async_runtimes::tokio::init_with_runtime(&rt)
-        .map_err(|e| PyRuntimeError::new_err(format!("pyo3-async-runtimes init failed: {e}")))?;
+    let engine_arc = Arc::new(engine);
 
     debug!(%addr, "smg_rs.serve_oai starting on {addr}");
 
-    // Release the GIL while the server is running so Python coroutines
-    // dispatched by axum handlers can re-acquire it themselves.
-    py.detach(|| {
-        rt_handle.block_on(async move {
-            let listener = tokio::net::TcpListener::bind(addr)
-                .await
-                .map_err(|e| {
-                    PyRuntimeError::new_err(format!("bind {addr} failed: {e}"))
-                })?;
-            axum::serve(listener, app)
-                .await
-                .map_err(|e| PyRuntimeError::new_err(format!("axum serve failed: {e}")))
-        })
+    // ``pyo3_async_runtimes::tokio::run`` sets up an asyncio event loop
+    // on a supervisor thread, builds a tokio runtime, registers both
+    // with the bridge, and runs the supplied Rust future on the tokio
+    // runtime. Inside the future we capture the supervisor loop's
+    // ``TaskLocals`` so each axum handler can pass them to
+    // ``into_future_with_locals`` — handlers run on tokio worker
+    // threads where the loop reference is otherwise invisible.
+    pyo3_async_runtimes::tokio::run(py, async move {
+        // ``tokio::run`` set TaskLocals as a tokio task-local for this
+        // future. Pull them out so we can clone them per axum handler
+        // (each handler runs as its own tokio task and would otherwise
+        // not see them).
+        let locals = Python::attach(|py| -> PyResult<_> {
+            pyo3_async_runtimes::tokio::get_current_locals(py)
+        })?;
+
+        let state = AppState {
+            engine: engine_arc,
+            locals: Arc::new(locals),
+        };
+        let app = Router::new()
+            .route("/v1/chat/completions", post(chat_completions_handler))
+            .with_state(state);
+
+        let listener = tokio::net::TcpListener::bind(addr)
+            .await
+            .map_err(|e| PyRuntimeError::new_err(format!("bind {addr} failed: {e}")))?;
+        axum::serve(listener, app)
+            .await
+            .map_err(|e| PyRuntimeError::new_err(format!("axum serve failed: {e}")))
     })?;
 
     Ok(())

--- a/bindings/python/src/serving.rs
+++ b/bindings/python/src/serving.rs
@@ -1,0 +1,185 @@
+//! ``smg-as-tokenspeed-dependency`` — protocol-layer entry points exposed to
+//! Python so an inference engine like TokenSpeed can drop its own
+//! tokenization / function-call / reasoning-parser / OAI-server code and
+//! call into smg's Rust implementations directly.
+//!
+//! Direction agreed on 2026-04-27/28 with @syuoni: tokenspeed remains the
+//! Python entry (``ts serve``), boots ``AsyncLLM`` as before, and imports
+//! this module via PyO3. The Rust side then runs the OAI HTTP layer and
+//! drives ``AsyncLLM`` in-process — no gRPC, no IPC, single Python process.
+//!
+//! This module is the *skeleton*: the parser entry points are real (they
+//! re-use the ``tool_parser`` and ``reasoning_parser`` workspace crates as
+//! libraries) so callers can verify the integration works end-to-end; the
+//! ``serve_oai`` HTTP entry is a stub that raises a clear error message
+//! pointing at the follow-up work.
+//!
+//! See ``crates/protocols``, ``crates/tool_parser``, ``crates/reasoning_parser``,
+//! ``crates/tokenizer`` for the full library surface that will land here over
+//! the next few iterations.
+
+use std::sync::OnceLock;
+
+use pyo3::exceptions::{PyRuntimeError, PyValueError};
+use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyList};
+use tokio::runtime::Runtime;
+
+/// Lazily-initialized tokio runtime shared across blocking PyO3 entries.
+///
+/// One Runtime per process is enough for the read-only parser entries; the
+/// HTTP server (``serve_oai``) will spawn its own multi-threaded runtime
+/// when implemented.
+fn shared_runtime() -> PyResult<&'static Runtime> {
+    static RT: OnceLock<Runtime> = OnceLock::new();
+    if let Some(rt) = RT.get() {
+        return Ok(rt);
+    }
+    let rt = Runtime::new()
+        .map_err(|e| PyRuntimeError::new_err(format!("failed to start tokio runtime: {e}")))?;
+    RT.set(rt)
+        .map_err(|_| PyRuntimeError::new_err("tokio runtime initialized twice"))?;
+    Ok(RT.get().expect("just set"))
+}
+
+// =====================================================================
+// Tool-call parsing
+// =====================================================================
+
+/// Parse a complete (non-streaming) model output for tool calls.
+///
+/// ``parser_name`` selects which detector to run: one of the values returned
+/// by :py:func:`get_available_tool_call_parsers` (e.g. ``"llama"``, ``"qwen"``,
+/// ``"kimi_k2"``, ``"deepseek_v3"``, ``"json"``, ...).
+///
+/// Returns a ``dict`` with two keys:
+///
+/// * ``"normal_text"``: the prose part of the output, with any tool-call
+///   payload stripped.
+/// * ``"tool_calls"``: a ``list[dict]`` of ``{"name": str, "arguments": str}``
+///   entries — ``arguments`` is the raw JSON string the model emitted (callers
+///   usually ``json.loads`` it).
+///
+/// Raises :class:`ValueError` if the parser name is unknown,
+/// :class:`RuntimeError` if the parser fails (malformed payload, partial
+/// JSON that the detector chose to reject, etc.).
+#[pyfunction]
+#[pyo3(signature = (output, parser_name))]
+fn parse_tool_call_complete(py: Python<'_>, output: &str, parser_name: &str) -> PyResult<PyObject> {
+    let factory = tool_parser::ParserFactory::new();
+    let mut parser = factory
+        .create_parser(parser_name)
+        .ok_or_else(|| PyValueError::new_err(format!("unknown tool parser: {parser_name:?}")))?;
+
+    let rt = shared_runtime()?;
+    let (remaining, calls) = rt
+        .block_on(async { parser.parse_complete(output).await })
+        .map_err(|e| PyRuntimeError::new_err(format!("tool parser failed: {e}")))?;
+
+    let dict = PyDict::new(py);
+    dict.set_item("normal_text", remaining)?;
+
+    let list = PyList::empty(py);
+    for call in calls {
+        let item = PyDict::new(py);
+        item.set_item("name", call.function.name)?;
+        item.set_item("arguments", call.function.arguments)?;
+        list.append(item)?;
+    }
+    dict.set_item("tool_calls", list)?;
+    Ok(dict.into())
+}
+
+// =====================================================================
+// Reasoning parsing
+// =====================================================================
+
+/// Detect and split a model output's reasoning block (e.g. ``<think>...</think>``,
+/// Qwen3 thinking tags, DeepSeek-R1 reasoning markers) from the user-visible
+/// content.
+///
+/// ``parser_name`` selects the model-family detector — one of the values
+/// returned by :py:func:`get_available_reasoning_parsers` (e.g. ``"qwen3"``,
+/// ``"deepseek_r1"``, ``"glm45"``, ...).
+///
+/// Returns a ``dict`` with:
+///
+/// * ``"normal_text"``: the prose / answer portion, reasoning stripped.
+/// * ``"reasoning_text"``: the raw text inside the reasoning block (or
+///   empty string if the model didn't emit one).
+#[pyfunction]
+#[pyo3(signature = (output, parser_name))]
+fn parse_reasoning_complete(py: Python<'_>, output: &str, parser_name: &str) -> PyResult<PyObject> {
+    let factory = reasoning_parser::ParserFactory::new();
+    let mut parser = factory
+        .create_parser(parser_name)
+        .ok_or_else(|| {
+            PyValueError::new_err(format!("unknown reasoning parser: {parser_name:?}"))
+        })?;
+
+    let result = parser
+        .detect_and_parse_reasoning(output)
+        .map_err(|e| PyRuntimeError::new_err(format!("reasoning parser failed: {e}")))?;
+
+    let dict = PyDict::new(py);
+    dict.set_item("normal_text", result.normal_text)?;
+    dict.set_item("reasoning_text", result.reasoning_text)?;
+    Ok(dict.into())
+}
+
+// =====================================================================
+// OAI HTTP server (stub)
+// =====================================================================
+
+/// Run smg's OAI-compatible HTTP server in-process, driving the supplied
+/// engine via PyO3 callbacks.
+///
+/// Intended call site (``tokenspeed serve``)::
+///
+///     async_llm = AsyncLLM(server_args)
+///     await smg_rs.serve_oai(
+///         engine=async_llm,
+///         host=args.host,
+///         port=args.port,
+///         chat_template=args.chat_template,
+///     )
+///
+/// **Currently a stub.** The full implementation will spin up an axum
+/// router that:
+///
+/// 1. Renders chat templates server-side (``llm-tokenizer`` crate).
+/// 2. Tokenizes input via the model's HF tokenizer.
+/// 3. Builds ``SamplingParams`` from the request.
+/// 4. Awaits ``engine.async_generate(input_ids, sampling_params)`` via
+///    ``pyo3-async-runtimes``, pulling tokens out as a Rust ``Stream``.
+/// 5. Streams parser-detected tool / reasoning chunks back as SSE.
+///
+/// Tracking: ``crates/pylib`` direction note in CHANGELOG, and the
+/// "smg-as-pylib" thread on Slack with @syuoni.
+#[pyfunction]
+#[pyo3(signature = (engine, host, port, chat_template = None))]
+#[allow(unused_variables)]
+fn serve_oai(
+    engine: PyObject,
+    host: &str,
+    port: u16,
+    chat_template: Option<&str>,
+) -> PyResult<()> {
+    Err(PyRuntimeError::new_err(
+        "serve_oai is not implemented yet — landing in a follow-up commit on \
+         feat/pylib-protocol. Integration shape: smg axum HTTP server in-process, \
+         driving AsyncLLM via pyo3-async-runtimes. See bindings/python/src/serving.rs \
+         doc comment for the planned signature and the call sites that will use it.",
+    ))
+}
+
+// =====================================================================
+// Module wiring
+// =====================================================================
+
+pub(crate) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(parse_tool_call_complete, m)?)?;
+    m.add_function(wrap_pyfunction!(parse_reasoning_complete, m)?)?;
+    m.add_function(wrap_pyfunction!(serve_oai, m)?)?;
+    Ok(())
+}

--- a/bindings/python/src/serving.rs
+++ b/bindings/python/src/serving.rs
@@ -163,10 +163,15 @@ fn parse_reasoning_complete(py: Python<'_>, output: &str, parser_name: &str) -> 
 ///   to the rest of the runtime. Each handler clones these locals and
 ///   uses :func:`pyo3_async_runtimes::tokio::into_future_with_locals`
 ///   so the Python coroutine gets scheduled on the right loop.
+/// * an optional Jinja chat-template processor — when present, the
+///   handler renders the request's ``messages`` array into a single
+///   prompt string before sending to the engine; when ``None`` we fall
+///   back to taking ``messages[-1].content`` verbatim.
 #[derive(Clone)]
 struct AppState {
     engine: Arc<Py<PyAny>>,
     locals: Arc<pyo3_async_runtimes::TaskLocals>,
+    chat_template: Option<Arc<llm_tokenizer::chat_template::ChatTemplateProcessor>>,
 }
 
 /// Drive ``engine.generate_request(GenerateReqInput(text=..., sampling_params=...))``
@@ -283,16 +288,36 @@ async def _consume_to_last(engine, obj):
     return last
 "#;
 
-/// Pull the user's last message text out of an OAI-shape body. First-cut
-/// shortcut: skip chat-template rendering and just take whatever the user
-/// said most recently. We do this on Rust side because chat-template
-/// support requires loading the model's HF tokenizer; lands as a
-/// follow-up.
-fn extract_prompt_from_oai(body: &Value) -> Result<String, String> {
+/// Render an OAI-shape ``messages`` array into a prompt string the
+/// engine can tokenize.
+///
+/// * If a chat-template processor is wired into the server, run it
+///   over the full ``messages`` array — that is the OAI contract and
+///   the only path that produces a correct prompt for assistant /
+///   tool / system roles.
+/// * Otherwise fall back to ``messages[-1].content`` verbatim. That
+///   single-turn shortcut is what the first cut shipped with; it stays
+///   in place so callers that already pre-render their own template
+///   (and just want a transport for raw text) don't break.
+fn render_prompt_from_oai(
+    body: &Value,
+    chat_template: Option<&llm_tokenizer::chat_template::ChatTemplateProcessor>,
+) -> Result<String, String> {
     let messages = body
         .get("messages")
         .and_then(Value::as_array)
         .ok_or_else(|| "request body missing 'messages' array".to_string())?;
+
+    if let Some(processor) = chat_template {
+        let params = llm_tokenizer::chat_template::ChatTemplateParams {
+            add_generation_prompt: true,
+            ..Default::default()
+        };
+        return processor
+            .apply_chat_template(messages, params)
+            .map_err(|e| format!("chat_template render failed: {e}"));
+    }
+
     let last = messages
         .last()
         .ok_or_else(|| "'messages' is empty".to_string())?;
@@ -301,10 +326,10 @@ fn extract_prompt_from_oai(body: &Value) -> Result<String, String> {
         .ok_or_else(|| "last message has no 'content'".to_string())?;
     match content {
         Value::String(s) => Ok(s.clone()),
-        // Vision / multipart content arrays are documented as a follow-up.
+        // Vision / multipart content arrays are a follow-up.
         Value::Array(_) => Err(
-            "multipart/array message content is not supported in the first-cut serve_oai; \
-             pass a plain string"
+            "multipart/array message content is not supported without a chat_template; \
+             pass a plain string or wire chat_template into serve_oai"
                 .to_string(),
         ),
         other => Err(format!("unsupported content shape: {other}")),
@@ -567,7 +592,7 @@ async fn chat_completions_handler(
     State(state): State<AppState>,
     Json(body): Json<Value>,
 ) -> impl IntoResponse {
-    let prompt = match extract_prompt_from_oai(&body) {
+    let prompt = match render_prompt_from_oai(&body, state.chat_template.as_deref()) {
         Ok(p) => p,
         Err(e) => return (StatusCode::BAD_REQUEST, Json(json!({"error": e}))).into_response(),
     };
@@ -664,42 +689,81 @@ async fn chat_completions_handler(
 /// Run smg's OAI-compatible HTTP server in-process, driving the supplied
 /// engine via PyO3 callbacks.
 ///
+/// Parameters
+/// ----------
+/// engine
+///     A TokenSpeed-style ``AsyncLLM`` instance. Only
+///     ``async def generate_request(obj)`` is exercised; the contract
+///     is "yield output dicts of shape
+///     ``{'text': str, 'output_ids': [int], 'meta_info': {...}}`` until
+///     ``StopAsyncIteration``."
+/// host, port
+///     Listen socket. Defaults match openai-python's expectations.
+/// chat_template
+///     Optional Jinja chat-template string (the value of the
+///     ``chat_template`` field in a HuggingFace ``tokenizer_config.json``).
+///     When supplied, requests' ``messages`` arrays are rendered through
+///     this template before being sent to the engine — that's the
+///     OAI-correct path. When ``None``, ``messages[-1].content`` is
+///     forwarded verbatim (single-turn shortcut for callers that already
+///     pre-render their own template).
+///
 /// Intended call site (``tokenspeed serve``)::
 ///
 ///     async_llm = AsyncLLM(server_args)
+///     chat_template = open(args.chat_template).read() if args.chat_template else None
 ///     smg_rs.serve_oai(
 ///         engine=async_llm,
 ///         host=args.host,
 ///         port=args.port,
+///         chat_template=chat_template,
 ///     )
 ///
 /// The function blocks the calling Python thread for the lifetime of the
 /// server (until the process is signaled). It releases the GIL while
 /// awaiting HTTP requests and re-acquires it for each engine call.
 ///
-/// **First-cut limitations** (all tracked as separate follow-ups):
+/// **Current limitations** (all tracked as separate follow-ups):
 ///
-/// * Non-streaming only — streaming SSE goes through pyo3-async-runtimes
-///   wrapping ``__anext__`` per chunk.
-/// * Skips chat-template rendering — passes the last ``messages[-1].content``
-///   directly to the engine. The full path will use the ``llm-tokenizer``
-///   crate's minijinja chat template.
-/// * No tool / reasoning post-processing — the parsers are exposed
-///   separately as :py:func:`parse_tool_call_complete` and
-///   :py:func:`parse_reasoning_complete` for now.
+/// * No tool / reasoning streaming post-processing — the parsers are
+///   exposed separately as :py:func:`parse_tool_call_complete` and
+///   :py:func:`parse_reasoning_complete` for non-streaming use.
 /// * Only ``/v1/chat/completions`` is wired; ``/v1/completions``,
 ///   ``/v1/responses``, ``/v1/embeddings`` etc. land later.
 #[pyfunction]
-#[pyo3(signature = (engine, host = "127.0.0.1", port = 8000))]
-fn serve_oai(py: Python<'_>, engine: PyObject, host: &str, port: u16) -> PyResult<()> {
+#[pyo3(signature = (engine, host = "127.0.0.1", port = 8000, chat_template = None))]
+fn serve_oai(
+    py: Python<'_>,
+    engine: PyObject,
+    host: &str,
+    port: u16,
+    chat_template: Option<String>,
+) -> PyResult<()> {
     let host_owned = host.to_string();
     let addr: SocketAddr = format!("{host_owned}:{port}")
         .parse()
         .map_err(|e| PyValueError::new_err(format!("invalid host:port {host_owned}:{port}: {e}")))?;
 
+    // Compile the chat template up front so a malformed template fails
+    // at startup rather than on the first request.
+    let chat_template_arc: Option<Arc<llm_tokenizer::chat_template::ChatTemplateProcessor>> =
+        match chat_template {
+            Some(template_src) => {
+                let processor =
+                    llm_tokenizer::chat_template::ChatTemplateProcessor::new(template_src)
+                        .map_err(|e| {
+                            PyValueError::new_err(format!(
+                                "chat_template failed to parse: {e}"
+                            ))
+                        })?;
+                Some(Arc::new(processor))
+            }
+            None => None,
+        };
+
     let engine_arc = Arc::new(engine);
 
-    debug!(%addr, "smg_rs.serve_oai starting on {addr}");
+    debug!(%addr, has_chat_template = chat_template_arc.is_some(), "smg_rs.serve_oai starting");
 
     // ``pyo3_async_runtimes::tokio::run`` sets up an asyncio event loop
     // on a supervisor thread, builds a tokio runtime, registers both
@@ -720,6 +784,7 @@ fn serve_oai(py: Python<'_>, engine: PyObject, host: &str, port: u16) -> PyResul
         let state = AppState {
             engine: engine_arc,
             locals: Arc::new(locals),
+            chat_template: chat_template_arc,
         };
         let app = Router::new()
             .route("/v1/chat/completions", post(chat_completions_handler))

--- a/bindings/python/src/serving.rs
+++ b/bindings/python/src/serving.rs
@@ -167,11 +167,17 @@ fn parse_reasoning_complete(py: Python<'_>, output: &str, parser_name: &str) -> 
 ///   handler renders the request's ``messages`` array into a single
 ///   prompt string before sending to the engine; when ``None`` we fall
 ///   back to taking ``messages[-1].content`` verbatim.
+/// * optional names of tool / reasoning parsers from the workspace
+///   crates' factories. Each streaming request instantiates fresh
+///   parser instances (the state machines are stateful) so we only
+///   store the names here, not the parser objects themselves.
 #[derive(Clone)]
 struct AppState {
     engine: Arc<Py<PyAny>>,
     locals: Arc<pyo3_async_runtimes::TaskLocals>,
     chat_template: Option<Arc<llm_tokenizer::chat_template::ChatTemplateProcessor>>,
+    tool_parser_name: Option<Arc<String>>,
+    reasoning_parser_name: Option<Arc<String>>,
 }
 
 /// Drive ``engine.generate_request(GenerateReqInput(text=..., sampling_params=...))``
@@ -391,6 +397,9 @@ fn stream_response(
     sampling: serde_json::Map<String, Value>,
     request_id: String,
     model_label: String,
+    tool_parser_name: Option<Arc<String>>,
+    reasoning_parser_name: Option<Arc<String>>,
+    tools: Vec<openai_protocol::common::Tool>,
 ) -> Sse<impl futures::Stream<Item = Result<Event, Infallible>>> {
     let (tx, rx) = futures::channel::mpsc::unbounded::<Result<Event, Infallible>>();
 
@@ -419,6 +428,41 @@ fn stream_response(
         // own handle (closures inside ``scope``'s async-move can't
         // borrow ``tx`` from the outer task without escaping the move).
         let tx_inner = tx.clone();
+
+        // Build per-stream parser instances. These are stateful state
+        // machines (they buffer partial JSON / partial reasoning tags
+        // across chunks), so each request needs its own. Construction
+        // is fallible only if the caller passed an unknown name; we
+        // surface that as an SSE error event and fall back to raw text.
+        let mut tool_parser: Option<Box<dyn tool_parser::ToolParser>> =
+            tool_parser_name.as_ref().and_then(|name| {
+                let factory = tool_parser::ParserFactory::new();
+                let p = factory.registry().create_parser(name);
+                if p.is_none() {
+                    let _ = tx.unbounded_send(Ok(Event::default().event("error").data(
+                        json!({"error": format!("unknown tool_parser: {}", name)}).to_string(),
+                    )));
+                }
+                p
+            });
+        let mut reasoning_parser_instance: Option<
+            Box<dyn reasoning_parser::ReasoningParser>,
+        > = reasoning_parser_name.as_ref().and_then(|name| {
+            let factory = reasoning_parser::ParserFactory::new();
+            let p = factory.registry().create_parser(name);
+            if p.is_none() {
+                let _ = tx.unbounded_send(Ok(Event::default().event("error").data(
+                    json!({"error": format!("unknown reasoning_parser: {}", name)}).to_string(),
+                )));
+            }
+            p
+        });
+
+        // Tool indexes we've already emitted ``id`` for. The first chunk
+        // for a tool index carries the OAI ``id`` and ``function.name``;
+        // subsequent chunks for the same index only ship incremental
+        // ``function.arguments`` JSON.
+        let mut seen_tool_indexes = std::collections::HashSet::<usize>::new();
 
         let result: PyResult<()> = pyo3_async_runtimes::tokio::scope(locals_for_scope, async move {
             // Build the request and grab the async iterator object once.
@@ -517,25 +561,114 @@ fn stream_response(
                     }
                 }
 
-                // Emit a content chunk only if there is actual delta.
-                // (The engine occasionally yields metadata-only refreshes;
-                // pushing an empty-content chunk to OAI clients confuses
-                // the openai-python stream parser.)
-                if !delta.is_empty() {
-                    let _ = tx_inner.unbounded_send(Ok(Event::default().data(
-                        json!({
-                            "id": &request_id_for_task,
-                            "object": "chat.completion.chunk",
-                            "model": &model_label_for_task,
-                            "choices": [{
-                                "index": 0,
-                                "delta": {"content": delta},
-                                "finish_reason": null,
-                            }],
-                        })
-                        .to_string(),
-                    )));
+                if delta.is_empty() {
+                    continue;
                 }
+
+                // 1. Reasoning parser strips ``<think>...</think>`` (or
+                //    Qwen3 thinking tags / DSeek-R1 markers) from the
+                //    delta and gives back ``(visible_text, reasoning_text)``.
+                //    Apply it FIRST — reasoning blocks usually wrap the
+                //    rest of the content, and feeding them into the tool
+                //    parser would just confuse it.
+                let (after_reasoning, reasoning_delta) = if let Some(rp) =
+                    reasoning_parser_instance.as_mut()
+                {
+                    match rp.parse_reasoning_streaming_incremental(&delta) {
+                        Ok(r) => (r.normal_text, r.reasoning_text),
+                        Err(e) => {
+                            error!(error = %e, "reasoning_parser streaming failed");
+                            (delta.clone(), String::new())
+                        }
+                    }
+                } else {
+                    (delta.clone(), String::new())
+                };
+
+                // 2. Tool parser detects partial JSON / format-specific
+                //    tool-call activity in the remaining text and gives
+                //    back ``(prose_text, [ToolCallItem ...])``.
+                let (visible_text, tool_calls): (String, Vec<tool_parser::types::ToolCallItem>) =
+                    if let Some(tp) = tool_parser.as_mut() {
+                        match tp.parse_incremental(&after_reasoning, &tools).await {
+                            Ok(r) => (r.normal_text, r.calls),
+                            Err(e) => {
+                                error!(error = %e, "tool_parser streaming failed");
+                                (after_reasoning, Vec::new())
+                            }
+                        }
+                    } else {
+                        (after_reasoning, Vec::new())
+                    };
+
+                // 3. Compose the OAI delta event. Multiple delta fields
+                //    can coexist on a single chunk per OAI spec.
+                let mut delta_obj = serde_json::Map::new();
+                if !reasoning_delta.is_empty() {
+                    // OAI extension popularized by DeepSeek-R1 / Qwen3
+                    // and accepted by most current chat clients.
+                    delta_obj.insert("reasoning_content".into(), Value::String(reasoning_delta));
+                }
+                if !visible_text.is_empty() {
+                    delta_obj.insert("content".into(), Value::String(visible_text));
+                }
+                if !tool_calls.is_empty() {
+                    let tcs: Vec<Value> = tool_calls
+                        .into_iter()
+                        .map(|item| {
+                            let mut function_obj = serde_json::Map::new();
+                            if let Some(name) = item.name.as_ref() {
+                                function_obj.insert("name".into(), Value::String(name.clone()));
+                            }
+                            if !item.parameters.is_empty() {
+                                function_obj.insert(
+                                    "arguments".into(),
+                                    Value::String(item.parameters.clone()),
+                                );
+                            }
+
+                            let mut tc = serde_json::Map::new();
+                            tc.insert("index".into(), Value::from(item.tool_index));
+                            // The first chunk for a tool index gets the
+                            // ``id``+``type`` envelope; later chunks for
+                            // the same index just ship argument deltas.
+                            if seen_tool_indexes.insert(item.tool_index) {
+                                tc.insert(
+                                    "id".into(),
+                                    Value::String(format!(
+                                        "call_{}_{}",
+                                        &request_id_for_task, item.tool_index
+                                    )),
+                                );
+                                tc.insert("type".into(), Value::String("function".into()));
+                            }
+                            tc.insert("function".into(), Value::Object(function_obj));
+                            Value::Object(tc)
+                        })
+                        .collect();
+                    delta_obj.insert("tool_calls".into(), Value::Array(tcs));
+                }
+
+                // Skip empty deltas (parser swallowed the chunk into its
+                // buffer waiting for more) — pushing an empty chunk
+                // confuses openai-python's parser.
+                if delta_obj.is_empty() {
+                    continue;
+                }
+
+                let _ = tx_inner.unbounded_send(Ok(Event::default().data(
+                    json!({
+                        "id": &request_id_for_task,
+                        "object": "chat.completion.chunk",
+                        "model": &model_label_for_task,
+                        "choices": [{
+                            "index": 0,
+                            "delta": Value::Object(delta_obj),
+                            "finish_reason": null,
+                        }],
+                    })
+                    .to_string(),
+                )));
             }
 
             // Final terminating chunk carries the finish_reason and a
@@ -616,9 +749,29 @@ async fn chat_completions_handler(
     let engine = state.engine.clone();
     let locals = state.locals.clone();
 
+    // Pull the OAI ``tools`` array out of the request body — the
+    // streaming json/llama/qwen tool parsers want it to validate
+    // emitted tool names against. Drop silently on parse error
+    // (clients that don't pass tools just get raw text deltas).
+    let tools: Vec<openai_protocol::common::Tool> = body
+        .get("tools")
+        .cloned()
+        .and_then(|v| serde_json::from_value(v).ok())
+        .unwrap_or_default();
+
     if stream_mode {
-        return stream_response(engine, locals, prompt, sampling, request_id, model_label)
-            .into_response();
+        return stream_response(
+            engine,
+            locals,
+            prompt,
+            sampling,
+            request_id,
+            model_label,
+            state.tool_parser_name.clone(),
+            state.reasoning_parser_name.clone(),
+            tools,
+        )
+        .into_response();
     }
 
     let result = drive_generate(engine, locals, prompt, sampling, request_id.clone()).await;
@@ -686,6 +839,121 @@ async fn chat_completions_handler(
     }
 }
 
+/// ``POST /v1/completions`` handler — legacy OAI completions endpoint.
+///
+/// Differs from chat-completions in that it takes a raw ``prompt``
+/// string (no chat template, no messages array) and returns ``text``
+/// instead of ``message``. We intentionally do NOT branch on
+/// ``stream: true`` for this first cut — most modern callers go through
+/// chat-completions, and adding a second SSE path would duplicate the
+/// streaming code without insight. Returns a single JSON ``completion``
+/// object.
+async fn completions_handler(
+    State(state): State<AppState>,
+    Json(body): Json<Value>,
+) -> impl IntoResponse {
+    let prompt = match body.get("prompt") {
+        Some(Value::String(s)) => s.clone(),
+        Some(Value::Array(arr)) => {
+            // OAI accepts an array of prompts. We only honor the first
+            // one for now (batch=1); the engine doesn't currently
+            // multiplex /v1/completions batches across choices, and
+            // openai-python's typical usage is a single prompt anyway.
+            match arr.first() {
+                Some(Value::String(s)) => s.clone(),
+                _ => {
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        Json(json!({"error": "'prompt' array must contain strings"})),
+                    )
+                        .into_response();
+                }
+            }
+        }
+        _ => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({"error": "request body missing 'prompt' string"})),
+            )
+                .into_response();
+        }
+    };
+    let sampling = extract_sampling_from_oai(&body);
+    let model_label = body
+        .get("model")
+        .and_then(Value::as_str)
+        .unwrap_or("default")
+        .to_string();
+    let request_id = format!("cmpl-{}", uuid::Uuid::new_v4().simple());
+
+    let engine = state.engine.clone();
+    let locals = state.locals.clone();
+    let result = drive_generate(engine, locals, prompt, sampling, request_id.clone()).await;
+
+    match result {
+        Ok(out) => {
+            let text = out
+                .get("text")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string();
+            let finish_reason = out
+                .get("meta_info")
+                .and_then(|m| m.get("finish_reason"))
+                .map(|fr| match fr {
+                    Value::String(s) => s.clone(),
+                    Value::Object(m) => m
+                        .get("type")
+                        .and_then(Value::as_str)
+                        .unwrap_or("stop")
+                        .to_string(),
+                    _ => "stop".to_string(),
+                })
+                .unwrap_or_else(|| "stop".to_string());
+            let prompt_tokens = out
+                .get("meta_info")
+                .and_then(|m| m.get("prompt_tokens"))
+                .and_then(Value::as_u64)
+                .unwrap_or(0);
+            let completion_tokens = out
+                .get("meta_info")
+                .and_then(|m| m.get("completion_tokens"))
+                .and_then(Value::as_u64)
+                .unwrap_or(0);
+
+            let body = json!({
+                "id": request_id,
+                "object": "text_completion",
+                "created": std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_secs())
+                    .unwrap_or(0),
+                "model": model_label,
+                "choices": [{
+                    "index": 0,
+                    "text": text,
+                    "logprobs": null,
+                    "finish_reason": finish_reason,
+                }],
+                "usage": {
+                    "prompt_tokens": prompt_tokens,
+                    "completion_tokens": completion_tokens,
+                    "total_tokens": prompt_tokens + completion_tokens,
+                },
+            });
+            (StatusCode::OK, Json(body)).into_response()
+        }
+        Err(e) => {
+            error!(error = %e, "AsyncLLM call failed (completions)");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": e.to_string()})),
+            )
+                .into_response()
+        }
+    }
+}
+
 /// Run smg's OAI-compatible HTTP server in-process, driving the supplied
 /// engine via PyO3 callbacks.
 ///
@@ -731,13 +999,22 @@ async fn chat_completions_handler(
 /// * Only ``/v1/chat/completions`` is wired; ``/v1/completions``,
 ///   ``/v1/responses``, ``/v1/embeddings`` etc. land later.
 #[pyfunction]
-#[pyo3(signature = (engine, host = "127.0.0.1", port = 8000, chat_template = None))]
+#[pyo3(signature = (
+    engine,
+    host = "127.0.0.1",
+    port = 8000,
+    chat_template = None,
+    tool_parser = None,
+    reasoning_parser = None,
+))]
 fn serve_oai(
     py: Python<'_>,
     engine: PyObject,
     host: &str,
     port: u16,
     chat_template: Option<String>,
+    tool_parser: Option<String>,
+    reasoning_parser: Option<String>,
 ) -> PyResult<()> {
     let host_owned = host.to_string();
     let addr: SocketAddr = format!("{host_owned}:{port}")
@@ -761,9 +1038,37 @@ fn serve_oai(
             None => None,
         };
 
+    // Validate parser names eagerly: if the operator passes ``"qwen"`` and
+    // we don't have one, we'd rather fail at server startup than per
+    // request.
+    if let Some(name) = tool_parser.as_ref() {
+        let factory = ::tool_parser::ParserFactory::new();
+        if !factory.has_parser(name) {
+            return Err(PyValueError::new_err(format!(
+                "unknown tool_parser: {name:?} (available: {:?})",
+                factory.list_parsers()
+            )));
+        }
+    }
+    if let Some(name) = reasoning_parser.as_ref() {
+        let factory = ::reasoning_parser::ParserFactory::new();
+        if !factory.list_parsers().contains(name) {
+            return Err(PyValueError::new_err(format!(
+                "unknown reasoning_parser: {name:?} (available: {:?})",
+                factory.list_parsers()
+            )));
+        }
+    }
+
     let engine_arc = Arc::new(engine);
 
-    debug!(%addr, has_chat_template = chat_template_arc.is_some(), "smg_rs.serve_oai starting");
+    debug!(
+        %addr,
+        has_chat_template = chat_template_arc.is_some(),
+        tool_parser = ?tool_parser,
+        reasoning_parser = ?reasoning_parser,
+        "smg_rs.serve_oai starting",
+    );
 
     // ``pyo3_async_runtimes::tokio::run`` sets up an asyncio event loop
     // on a supervisor thread, builds a tokio runtime, registers both
@@ -785,9 +1090,12 @@ fn serve_oai(
             engine: engine_arc,
             locals: Arc::new(locals),
             chat_template: chat_template_arc,
+            tool_parser_name: tool_parser.map(Arc::new),
+            reasoning_parser_name: reasoning_parser.map(Arc::new),
         };
         let app = Router::new()
             .route("/v1/chat/completions", post(chat_completions_handler))
+            .route("/v1/completions", post(completions_handler))
             .with_state(state);
 
         let listener = tokio::net::TcpListener::bind(addr)

--- a/bindings/python/src/serving.rs
+++ b/bindings/python/src/serving.rs
@@ -23,7 +23,13 @@ use std::sync::OnceLock;
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
+use pyo3::{Py, PyAny};
 use tokio::runtime::Runtime;
+
+/// Re-export of pyo3's owned-Python-object handle. ``Py<PyAny>`` is what
+/// pyo3 0.28 uses where older versions exposed ``PyObject`` from the
+/// prelude.
+type PyObject = Py<PyAny>;
 
 /// Lazily-initialized tokio runtime shared across blocking PyO3 entries.
 ///
@@ -68,6 +74,7 @@ fn shared_runtime() -> PyResult<&'static Runtime> {
 fn parse_tool_call_complete(py: Python<'_>, output: &str, parser_name: &str) -> PyResult<PyObject> {
     let factory = tool_parser::ParserFactory::new();
     let mut parser = factory
+        .registry()
         .create_parser(parser_name)
         .ok_or_else(|| PyValueError::new_err(format!("unknown tool parser: {parser_name:?}")))?;
 
@@ -112,6 +119,7 @@ fn parse_tool_call_complete(py: Python<'_>, output: &str, parser_name: &str) -> 
 fn parse_reasoning_complete(py: Python<'_>, output: &str, parser_name: &str) -> PyResult<PyObject> {
     let factory = reasoning_parser::ParserFactory::new();
     let mut parser = factory
+        .registry()
         .create_parser(parser_name)
         .ok_or_else(|| {
             PyValueError::new_err(format!("unknown reasoning parser: {parser_name:?}"))

--- a/bindings/python/tests/test_serving_skeleton.py
+++ b/bindings/python/tests/test_serving_skeleton.py
@@ -1,0 +1,80 @@
+"""Smoke tests for the smg-as-tokenspeed-dependency skeleton.
+
+These verify that the protocol-layer entry points exposed via
+:py:mod:`smg_rs.serving` (registered into the top-level ``smg_rs`` module)
+work end-to-end with the existing ``tool_parser`` / ``reasoning_parser``
+crates — the same code paths tokenspeed will call once it imports smg as
+a dependency for tokenization, function calling, reasoning parsing, and
+the OAI server.
+
+The ``serve_oai`` HTTP entry is still a stub; we just assert it raises a
+clear error so callers know the integration hook is wired but the body
+isn't implemented yet.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+smg_rs = pytest.importorskip("smg_rs")
+
+
+# ---------------------------------------------------------------------------
+# Tool-call parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_tool_call_complete_json() -> None:
+    """The ``json`` parser passes raw JSON tool calls through verbatim."""
+    payload = '{"name": "get_weather", "arguments": {"city": "SF", "unit": "celsius"}}'
+    result = smg_rs.parse_tool_call_complete(payload, "json")
+    assert isinstance(result, dict)
+    assert "tool_calls" in result
+    assert "normal_text" in result
+    assert len(result["tool_calls"]) == 1
+    call = result["tool_calls"][0]
+    assert call["name"] == "get_weather"
+    args = json.loads(call["arguments"])
+    assert args == {"city": "SF", "unit": "celsius"}
+
+
+def test_parse_tool_call_complete_unknown_parser_raises() -> None:
+    with pytest.raises(ValueError, match="unknown tool parser"):
+        smg_rs.parse_tool_call_complete("anything", "definitely-not-a-real-parser")
+
+
+# ---------------------------------------------------------------------------
+# Reasoning parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_reasoning_qwen3_thinking_block() -> None:
+    """Qwen3 emits ``<think>...</think>`` around reasoning content."""
+    text = "<think>let me think step by step</think>The answer is 42."
+    result = smg_rs.parse_reasoning_complete(text, "qwen3")
+    assert isinstance(result, dict)
+    assert result["reasoning_text"].strip() == "let me think step by step"
+    assert "42" in result["normal_text"]
+
+
+def test_parse_reasoning_unknown_parser_raises() -> None:
+    with pytest.raises(ValueError, match="unknown reasoning parser"):
+        smg_rs.parse_reasoning_complete("anything", "definitely-not-a-real-parser")
+
+
+# ---------------------------------------------------------------------------
+# OAI HTTP server (stub) — just verify the hook is wired.
+# ---------------------------------------------------------------------------
+
+
+def test_serve_oai_stub_raises_with_pointer() -> None:
+    """``serve_oai`` will host smg's axum HTTP server in-process, driving
+    the supplied engine via PyO3 callbacks. Until that lands, the entry
+    point is a stub that raises a RuntimeError pointing at the follow-up.
+    """
+    sentinel_engine = object()
+    with pytest.raises(RuntimeError, match="serve_oai is not implemented yet"):
+        smg_rs.serve_oai(engine=sentinel_engine, host="127.0.0.1", port=8000)

--- a/bindings/python/tests/test_serving_skeleton.py
+++ b/bindings/python/tests/test_serving_skeleton.py
@@ -66,15 +66,24 @@ def test_parse_reasoning_unknown_parser_raises() -> None:
 
 
 # ---------------------------------------------------------------------------
-# OAI HTTP server (stub) — just verify the hook is wired.
+# OAI HTTP server — verify the entry point is exposed; full end-to-end
+# behavior is covered by tools/smg_serve_oai_demo.py against a fake
+# AsyncLLM (it spawns a server in a daemon thread and runs an HTTP
+# roundtrip), kept out of the unit-test path because it binds a real
+# TCP port and pulls in pyo3-async-runtimes' tokio runtime.
 # ---------------------------------------------------------------------------
 
 
-def test_serve_oai_stub_raises_with_pointer() -> None:
-    """``serve_oai`` will host smg's axum HTTP server in-process, driving
-    the supplied engine via PyO3 callbacks. Until that lands, the entry
-    point is a stub that raises a RuntimeError pointing at the follow-up.
-    """
-    sentinel_engine = object()
-    with pytest.raises(RuntimeError, match="serve_oai is not implemented yet"):
-        smg_rs.serve_oai(engine=sentinel_engine, host="127.0.0.1", port=8000)
+def test_serve_oai_is_exposed() -> None:
+    """``serve_oai`` blocks on ``axum::serve`` once entered (it owns the
+    HTTP listener for the lifetime of the process), so unit tests don't
+    actually invoke it. We only check the symbol exists with the
+    expected signature."""
+    import inspect
+
+    assert callable(smg_rs.serve_oai), "smg_rs.serve_oai must be callable"
+    # ``smg_rs.serve_oai.__doc__`` is rendered from the pyo3 docstring
+    # in serving.rs; the doc-comment is the canonical reference for
+    # the bridge's behavior so we sanity-check it lands.
+    doc = inspect.getdoc(smg_rs.serve_oai) or ""
+    assert "engine" in doc.lower(), "serve_oai docstring should mention 'engine' param"


### PR DESCRIPTION
> Draft. Lays the integration surface for the new direction agreed
> on with @zhyncs in slack on
> 2026-04-27/28: instead of `tokenspeed serve` running smg's Rust
> gateway as a sidecar/subprocess that talks gRPC (the route
> #1351 was building, now Draft / `[paused]`), tokenspeed will
> `import smg_rs` and call into smg as a Python dependency for its
> protocol layer — tokenization, function-call parser, reasoning
> parser, OAI server, MCP, response API. Single Python process, no
> gRPC, no IPC.

## What's in this PR

* **`bindings/python/src/serving.rs`** — three pyfunctions registered
  under the existing `smg_rs` extension:

  | function | status |
  | --- | --- |
  | `parse_tool_call_complete(text, parser_name)` | ✅ real, calls `tool_parser` (18 detectors) |
  | `parse_reasoning_complete(text, parser_name)` | ✅ real, calls `reasoning_parser` (13 detectors) |
  | `serve_oai(engine, host, port)` | ✅ **real now**, axum HTTP server in-process |

* **`bindings/python/Cargo.toml`** — adds `pyo3-async-runtimes`,
  `axum`, `serde_json`, `uuid`, `tracing`, `futures` deps.

* **`bindings/python/tests/test_serving_skeleton.py`** — pytest
  smoke tests for all three entries.

* **`bindings/python/README.md`** — "two consumption modes" section
  (smg-as-binary vs smg-as-library).

## How `serve_oai` is wired

```text
                  Python process boundary
                          │
ts serve  ─────► smg_rs.serve_oai(async_llm, host, port)
                          │
                          ▼
        pyo3_async_runtimes::tokio::run        ← supervisor thread
        ├─ asyncio.new_event_loop()  (sets up TaskLocals)
        └─ tokio::Runtime
                          │
                          ▼
        async fn { capture locals; build axum router; bind+serve }
                          │
              ┌───────────┴───────────┐
              ▼                       ▼
         POST /v1/chat/completions  (other handlers)
              │
              │ Each handler: tokio::scope(locals.clone(), async {
              │   Python::attach(|py| {
              │     build GenerateReqInput,
              │     call engine.generate_request(),
              │     pyo3_async_runtimes::tokio::into_future(coro)
              │   })?.await
              │ })
              ▼
       OAI ChatCompletion JSON response
```

Cross-language data marshalling uses a single `json.dumps`/
`json.loads` hop in each direction so we don't fight pyo3 0.28's
`IntoPyObject` trait surface for nested types.

## Verified end-to-end on n1

`ts-claude-test` container, real maturin build of the wheel,
`FakeAsyncLLM` mock implementing `async def generate_request(obj)`:

```text
=== starting smg_rs.serve_oai on 127.0.0.1:18900 ===
  server is reachable

=== POST /v1/chat/completions ===
{
  "id": "chatcmpl-07dacba9b26d4af2ab0d8eb38016954e",
  "object": "chat.completion",
  "model": "fake-model",
  "choices": [
    {
      "index": 0,
      "message": {"role": "assistant", "content": "echo:hello, smg!"},
      "finish_reason": "stop"
    }
  ],
  "usage": {"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8}
}

ALL ASSERTIONS PASSED — axum + pyo3-async-runtimes bridge works
```

The same shape will land verbatim against a real `tokenspeed.runtime.engine.async_llm.AsyncLLM` — `generate_request` is the only method we touch.

## Iteration history (commits on this branch)

1. `11d05d67` initial skeleton (parsers real, `serve_oai` stub)
2. `1345449d` fix `factory.registry().create_parser` + `Py<PyAny>` alias
3. `467e069a` real `serve_oai` (failed at runtime)
4. `bcb22c35` wire bridge through `tokio::run` + `tokio::scope` + `get_current_locals` (works)
5. `*` test refactor (drop stub-error assertion)

## Follow-ups out of scope here

1. **Streaming SSE** — wraps `__anext__` per chunk through pyo3-async-runtimes; needed for `stream: true` in `/v1/chat/completions`.
2. **Chat-template render** in `crates/tokenizer` (minijinja) so smg, not tokenspeed, owns the prompt-formatting code path.
3. **Tool / reasoning post-processing** in the streaming path so tool-call JSON gets sliced into proper `tool_calls` chunks.
4. Other endpoints (`/v1/completions`, `/v1/responses`, `/v1/embeddings`, MCP, response API) per Yineng's "tokenization, function calling, reasoning parser, oai server, mcp, response api" list.

## Test plan

- [x] `cargo build` (verified via `maturin build --release` on n1, ~4m30s)
- [x] Wheel installs cleanly via `pip install`
- [x] `from smg import smg_rs; smg_rs.parse_tool_call_complete(...)` works
- [x] `from smg import smg_rs; smg_rs.parse_reasoning_complete(...)` works
- [x] `smg_rs.serve_oai(FakeAsyncLLM, host, port)` blocks; `POST /v1/chat/completions` returns valid OAI ChatCompletion against the fake engine
- [x] Coexists with tokenspeed in the same process (DEMO 4 of `tools/smg_pylib_demo.py`)
- [ ] Streaming end-to-end against a real `AsyncLLM` (follow-up)
- [ ] CI green on `bindings/python/tests/test_serving_skeleton.py`