### PR TITLE
fix(mlx-grpc): drain-and-batch to avoid BatchGenerator rope crash at concurrency≥4

### DIFF
--- a/grpc_servicer/smg_grpc_servicer/mlx/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/mlx/servicer.py
@@ -24,6 +24,29 @@ from smg_grpc_proto.generated import common_pb2
 logger = logging.getLogger(__name__)
 
 
+def _set_future_result_safe(future: asyncio.Future, result) -> None:
+    """``future.set_result`` that no-ops on already-completed futures.
+
+    Used by the gen thread to wake a Generate awaiter via
+    ``call_soon_threadsafe``. Generate's task may be cancelled (which
+    cancels the future) between the time the gen thread schedules this
+    callback and the time the loop runs it; ``set_result`` would then
+    raise ``InvalidStateError``. Cleanup of the inserted batch slot is
+    handled by Generate's CancelledError path.
+    """
+    if not future.done():
+        future.set_result(result)
+
+
+def _set_future_exception_safe(future: asyncio.Future, exc: BaseException) -> None:
+    """``future.set_exception`` that no-ops on already-completed futures.
+
+    Same race as :func:`_set_future_result_safe`.
+    """
+    if not future.done():
+        future.set_exception(exc)
+
+
 class _PendingRequest:
     """A Generate() call queued to enter the next fresh batch.
 
@@ -115,9 +138,14 @@ class MlxEngineServicer(mlx_engine_pb2_grpc.MlxEngineServicer):
       * the event loop in ``Abort`` for the in-flight ``remove()``.
 
     ``self._pending_lock`` protects the pending list/index and is held
-    only briefly: append in ``Generate``, drain in the gen thread, pop in
-    ``Abort``. It is always acquired *outside* ``_gen_lock`` to avoid
-    nesting.
+    only briefly: append in ``Generate``, drain in the gen thread, pop
+    in ``Abort``. The gen thread *does* nest it inside ``_gen_lock``
+    during drain-and-fill (we hold ``_gen_lock`` for the whole
+    iteration and grab ``_pending_lock`` only to swap pending into the
+    batch). All other sites acquire just one of the two locks at a
+    time, so this is the only nesting direction in the codebase —
+    adding any path that acquires ``_gen_lock`` while already holding
+    ``_pending_lock`` would deadlock.
 
     Cost model: the event loop can block up to one ``next()`` step
     (~10–50 ms on M-series) while the gen thread holds ``_gen_lock``.
@@ -404,37 +432,65 @@ class MlxEngineServicer(mlx_engine_pb2_grpc.MlxEngineServicer):
             gen_responses: list = []
             inserted_this_iter = False
             try:
-                # Phase 1: drain-and-fill. Pulled outside _gen_lock to
-                # avoid nesting locks; we re-check active_uids inside the
-                # gen lock before actually inserting, since only the gen
-                # thread mutates _active_uids it can't change between
-                # the read and the insert.
                 with self._gen_lock:
+                    # Phase 1: drain-and-fill. _pending_lock is nested
+                    # inside _gen_lock here — the only nesting site in
+                    # the codebase (see class docstring).
                     if not self._active_uids:
                         with self._pending_lock:
                             batch = self._pending[:]
                             self._pending.clear()
-                            for p in batch:
-                                self._pending_by_request_id.pop(p.request_id, None)
+                            # NOTE: do NOT pop from _pending_by_request_id
+                            # yet — keeping pending entries indexed until
+                            # insert() succeeds means Abort() can still
+                            # cancel a request that lost its insert race.
 
                         # Filter out requests whose uid_future was already
                         # cancelled (client disconnected before drain).
                         batch = [p for p in batch if not p.uid_future.cancelled()]
 
                         if batch:
-                            uids = self.batch_generator.insert(
-                                prompts=[p.token_ids for p in batch],
-                                max_tokens=[p.max_tokens for p in batch],
-                                samplers=[p.sampler for p in batch],
-                                logits_processors=[p.logits_processors for p in batch],
-                                state_machines=[p.state_machine for p in batch],
-                            )
+                            try:
+                                uids = self.batch_generator.insert(
+                                    prompts=[p.token_ids for p in batch],
+                                    max_tokens=[p.max_tokens for p in batch],
+                                    samplers=[p.sampler for p in batch],
+                                    logits_processors=[p.logits_processors for p in batch],
+                                    state_machines=[p.state_machine for p in batch],
+                                )
+                            except Exception as e:
+                                # Wake every waiter with a real error so
+                                # Generate exits with INTERNAL instead of
+                                # hanging on uid_future forever.
+                                logger.exception(
+                                    "BatchGenerator.insert failed for batch of %d", len(batch)
+                                )
+                                with self._pending_lock:
+                                    for p in batch:
+                                        self._pending_by_request_id.pop(p.request_id, None)
+                                for p in batch:
+                                    self._loop.call_soon_threadsafe(
+                                        _set_future_exception_safe, p.uid_future, e
+                                    )
+                                # Skip phase 2 — nothing was inserted.
+                                continue
+
+                            # insert() succeeded — finalize each request.
+                            with self._pending_lock:
+                                for p in batch:
+                                    self._pending_by_request_id.pop(p.request_id, None)
                             for uid, p in zip(uids, batch):
                                 self._uid_queues[uid] = p.queue
                                 self._active_uids.add(uid)
-                                # Hand the uid back to Generate so it can
-                                # register for Abort and start consuming.
-                                self._loop.call_soon_threadsafe(p.uid_future.set_result, uid)
+                                # Publish the request_id -> uid mapping
+                                # BEFORE waking Generate. Otherwise Abort
+                                # can land in the gap between set_result
+                                # and Generate's own assignment and miss
+                                # the mapping entirely (silent no-op).
+                                self._request_uid_map[p.request_id] = uid
+                                self._loop.call_soon_threadsafe(
+                                    _set_future_result_safe, p.uid_future, uid
+                                )
                             inserted_this_iter = True
 
                     # Phase 2: drive the active batch one step. Skip if the
@@ -518,17 +574,43 @@ class MlxEngineServicer(mlx_engine_pb2_grpc.MlxEngineServicer):
             try:
                 uid = await uid_future
             except asyncio.CancelledError:
-                # Client disconnect before we entered the batch — make
-                # sure we're scrubbed from pending so the gen thread
-                # doesn't insert us anyway.
+                # Two cases:
+                #  (1) Gen thread hasn't drained us yet — scrub from
+                #      pending so it doesn't insert a doomed request.
+                #  (2) Gen thread inserted us right before the cancel
+                #      landed (set_result raced our task cancellation).
+                #      The future has a usable result; we still need to
+                #      run the same backend cleanup the normal finally
+                #      would have done, otherwise the uid keeps decoding
+                #      and the batch never drains.
                 with self._pending_lock:
                     self._pending_by_request_id.pop(request_id, None)
                     try:
                         self._pending.remove(pending)
                     except ValueError:
                         pass
+                inserted_uid = None
+                if uid_future.done() and not uid_future.cancelled():
+                    try:
+                        inserted_uid = uid_future.result()
+                    except Exception:
+                        inserted_uid = None
+                if inserted_uid is not None:
+                    # Mirror the normal finally cleanup (the gen thread
+                    # populated _request_uid_map / _uid_queues /
+                    # _active_uids before resolving the future).
+                    self._request_uid_map.pop(request_id, None)
+                    self._uid_queues.pop(inserted_uid, None)
+                    with self._gen_lock:
+                        self._active_uids.discard(inserted_uid)
+                        try:
+                            self.batch_generator.remove([inserted_uid])
+                        except Exception:
+                            pass
                 raise
-            self._request_uid_map[request_id] = uid
+            # Note: _request_uid_map[request_id] = uid is published by
+            # the gen thread BEFORE waking us, so Abort can find this
+            # request immediately. Don't re-set it here (no-op anyway).
             self._active_requests += 1
             prompt_tokens = len(token_ids)
 

--- a/grpc_servicer/smg_grpc_servicer/mlx/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/mlx/servicer.py
@@ -24,35 +24,106 @@ from smg_grpc_proto.generated import common_pb2
 logger = logging.getLogger(__name__)
 
 
+class _PendingRequest:
+    """A Generate() call queued to enter the next fresh batch.
+
+    Holds the inputs we need to feed BatchGenerator.insert() plus an
+    asyncio.Future that the generation thread resolves with the assigned
+    uid once the request actually enters the batch. Generate() awaits
+    that future before it starts pulling tokens off ``queue``.
+    """
+
+    __slots__ = (
+        "token_ids",
+        "max_tokens",
+        "sampler",
+        "logits_processors",
+        "state_machine",
+        "queue",
+        "uid_future",
+        "request_id",
+    )
+
+    def __init__(
+        self,
+        token_ids,
+        max_tokens,
+        sampler,
+        logits_processors,
+        state_machine,
+        queue,
+        uid_future,
+        request_id,
+    ):
+        self.token_ids = token_ids
+        self.max_tokens = max_tokens
+        self.sampler = sampler
+        self.logits_processors = logits_processors
+        self.state_machine = state_machine
+        self.queue = queue
+        self.uid_future = uid_future
+        self.request_id = request_id
+
+
 class MlxEngineServicer(mlx_engine_pb2_grpc.MlxEngineServicer):
     """gRPC servicer implementing the MlxEngine service for MLX backends.
 
-    Thread-safety model
-    -------------------
-    mlx-lm's ``BatchGenerator`` is not thread-safe: ``next()`` mutates
-    ``_prompt_batch`` / ``_generation_batch`` / ``_unprocessed_sequences``
-    while running mlx kernels (which release the GIL), and ``remove()``
-    rebuilds those same structures. This servicer runs ``next()`` on a
-    background thread and services ``insert()`` / ``remove()`` from the
-    asyncio event loop, so we need synchronization.
+    Concurrency model: drain-and-batch
+    ----------------------------------
+    mlx-lm's ``BatchGenerator`` does not support inserting new sequences
+    while the active batch is in its decode phase: the rope offset cache
+    is sized at the start of decode and a mid-decode ``insert()`` leaves
+    it out of sync with the new batch shape, which surfaces as
 
-    ``self._gen_lock`` is acquired by:
-      * the gen thread for the whole ``next() + dispatch + finished-remove``
-        block (one critical section per loop iteration — keeps the batch
-        snapshot consistent);
-      * the event loop around ``insert() + _uid_queues[uid] = queue`` in
-        ``Generate`` (fast path, also closes the register-queue-before-first-
-        response race);
-      * the event loop around ``remove()`` in ``Abort`` (rare).
+        ValueError: [rope] offset must be a scalar or vector with N
+            elements but has shape (N-1).
 
-    ``insert()`` itself only appends to a ``deque`` and increments a counter
-    (both atomic under the GIL), but the lock still wraps it so the uid
-    can't become visible to the gen thread before its queue is registered.
+    inside ``mx.fast.rope`` on the next ``_step()``. mlx-lm.server avoids
+    this by serving each batch to completion before accepting the next
+    set of requests; we mirror that here.
+
+    Flow:
+
+      * Incoming ``Generate`` calls build a :class:`_PendingRequest` and
+        push it onto ``self._pending``, then await ``uid_future``.
+      * The generation thread's main loop, between iterations, checks
+        whether the active batch has drained (``_active_uids`` empty).
+        When it has, it drains ``_pending`` in one shot and feeds the
+        whole list to a single ``BatchGenerator.insert()`` call — this
+        keeps batching for concurrent arrivals while ensuring no insert
+        ever happens during decode.
+      * Each request's ``uid_future`` is resolved as soon as its uid is
+        known, so ``Generate`` can register its uid for ``Abort`` lookup
+        and start consuming tokens from its per-uid queue.
+
+    Trade-off: a request arriving while a batch is mid-decode waits for
+    that batch to drain before its first token. That's the same behavior
+    as ``mlx-lm.server`` and is the correctness fix for the rope crash;
+    re-introducing true dynamic batching is a separate optimization that
+    requires fixes in mlx-lm's BatchGenerator.
+
+    Thread-safety
+    -------------
+    ``self._gen_lock`` protects all mutations of the BatchGenerator and
+    of ``_active_uids`` / ``_uid_queues``. It is acquired by:
+
+      * the gen thread, around the whole drain-pending + ``next()`` +
+        dispatch + finished-``remove()`` block (one critical section per
+        loop iteration);
+      * the event loop in ``Generate``'s ``finally`` for the
+        client-disconnect cleanup ``remove()``;
+      * the event loop in ``Abort`` for the in-flight ``remove()``.
+
+    ``self._pending_lock`` protects the pending list/index and is held
+    only briefly: append in ``Generate``, drain in the gen thread, pop in
+    ``Abort``. It is always acquired *outside* ``_gen_lock`` to avoid
+    nesting.
 
     Cost model: the event loop can block up to one ``next()`` step
-    (~10-50 ms on M-series) while the gen thread holds the lock. Acceptable
-    for single-worker Mac inference; if you need 1000+ concurrent reqs/s,
-    refactor to a command-queue / actor model (see vLLM's AsyncLLMEngine).
+    (~10–50 ms on M-series) while the gen thread holds ``_gen_lock``.
+    Acceptable for single-worker Mac inference; if you need
+    1000+ concurrent req/s, refactor to a command-queue / actor model
+    (see vLLM's AsyncLLMEngine).
     """
 
     def __init__(
@@ -67,12 +138,25 @@ class MlxEngineServicer(mlx_engine_pb2_grpc.MlxEngineServicer):
         self._active_requests = 0
         self._request_uid_map = {}
         self._uid_queues = {}
+        # Set of uids currently live in the BatchGenerator. Mutated only
+        # under ``_gen_lock``. The gen thread inspects ``not _active_uids``
+        # to decide whether it's safe to drain ``_pending`` into a fresh
+        # ``insert()``.
+        self._active_uids: set[int] = set()
         self._shutdown_event = threading.Event()
         self._loop = None
         self._gen_thread = None
-        # Protects mlx-lm BatchGenerator state + self._uid_queues against
-        # the background gen thread. See class docstring.
+        # Protects mlx-lm BatchGenerator state + ``_uid_queues`` +
+        # ``_active_uids`` against the background gen thread. See class
+        # docstring.
         self._gen_lock = threading.Lock()
+        # Drain-and-batch state. New ``Generate`` calls land here and
+        # wait for the gen thread to pull them into a fresh batch once
+        # the previous batch drains. Index by request_id so ``Abort``
+        # can cancel a request that hasn't entered the batch yet.
+        self._pending: list[_PendingRequest] = []
+        self._pending_by_request_id: dict[str, _PendingRequest] = {}
+        self._pending_lock = threading.Lock()
         # Resolve context length once — config doesn't change at runtime,
         # and Generate was previously scanning these keys on every request.
         self._ctx_limit = 0
@@ -318,31 +402,70 @@ class MlxEngineServicer(mlx_engine_pb2_grpc.MlxEngineServicer):
         while not self._shutdown_event.is_set():
             prompt_responses: list = []
             gen_responses: list = []
+            inserted_this_iter = False
             try:
-                # Single critical section: next() + dispatch + finished-remove.
-                # Holding the lock across dispatch keeps the batch snapshot
-                # consistent with the responses we just produced; event-loop
-                # insert/remove serializes naturally against this block.
+                # Phase 1: drain-and-fill. Pulled outside _gen_lock to
+                # avoid nesting locks; we re-check active_uids inside the
+                # gen lock before actually inserting, since only the gen
+                # thread mutates _active_uids it can't change between
+                # the read and the insert.
                 with self._gen_lock:
-                    with mx.stream(generation_stream):
-                        prompt_responses, gen_responses = self.batch_generator.next()
+                    if not self._active_uids:
+                        with self._pending_lock:
+                            batch = self._pending[:]
+                            self._pending.clear()
+                            for p in batch:
+                                self._pending_by_request_id.pop(p.request_id, None)
 
-                    for r in gen_responses:
-                        queue = self._uid_queues.get(r.uid)
-                        if queue is not None:
-                            self._loop.call_soon_threadsafe(queue.put_nowait, r)
-                        if r.finish_reason is not None:
-                            try:
-                                self.batch_generator.remove([r.uid])
-                            except Exception:
-                                logger.exception("Error removing uid %d", r.uid)
+                        # Filter out requests whose uid_future was already
+                        # cancelled (client disconnected before drain).
+                        batch = [p for p in batch if not p.uid_future.cancelled()]
+
+                        if batch:
+                            uids = self.batch_generator.insert(
+                                prompts=[p.token_ids for p in batch],
+                                max_tokens=[p.max_tokens for p in batch],
+                                samplers=[p.sampler for p in batch],
+                                logits_processors=[p.logits_processors for p in batch],
+                                state_machines=[p.state_machine for p in batch],
+                            )
+                            for uid, p in zip(uids, batch):
+                                self._uid_queues[uid] = p.queue
+                                self._active_uids.add(uid)
+                                # Hand the uid back to Generate so it can
+                                # register for Abort and start consuming.
+                                self._loop.call_soon_threadsafe(p.uid_future.set_result, uid)
+                            inserted_this_iter = True
+
+                    # Phase 2: drive the active batch one step. Skip if the
+                    # batch is empty *and* we didn't just insert anything —
+                    # next() on an empty batch is wasted work.
+                    if self._active_uids:
+                        with mx.stream(generation_stream):
+                            prompt_responses, gen_responses = self.batch_generator.next()
+
+                        for r in gen_responses:
+                            queue = self._uid_queues.get(r.uid)
+                            if queue is not None:
+                                self._loop.call_soon_threadsafe(queue.put_nowait, r)
+                            if r.finish_reason is not None:
+                                try:
+                                    self.batch_generator.remove([r.uid])
+                                except Exception:
+                                    logger.exception("Error removing uid %d", r.uid)
+                                self._active_uids.discard(r.uid)
             except Exception:
                 logger.exception("Error in generation loop")
                 continue
 
-            if not prompt_responses and not gen_responses:
-                # Idle — release the lock and briefly sleep so the event
-                # loop can slot in insert/remove work without contention.
+            if (
+                not prompt_responses
+                and not gen_responses
+                and not inserted_this_iter
+                and not self._active_uids
+            ):
+                # Truly idle — sleep so the event loop can append to
+                # _pending without contending on the gen lock.
                 time.sleep(0.001)
 
     async def Generate(self, request, context):
@@ -374,19 +497,37 @@ class MlxEngineServicer(mlx_engine_pb2_grpc.MlxEngineServicer):
                 mx.random.seed(sp.seed)
 
             queue: asyncio.Queue = asyncio.Queue()
-            # Insert + queue registration must be atomic against the gen
-            # thread's next()+remove block so a one-step completion can't
-            # be dispatched and removed before its queue is visible.
-            with self._gen_lock:
-                uids = self.batch_generator.insert(
-                    prompts=[token_ids],
-                    max_tokens=[max_tokens],
-                    samplers=[sampler],
-                    logits_processors=[logits_processors],
-                    state_machines=[state_machine],
-                )
-                uid = uids[0]
-                self._uid_queues[uid] = queue
+            uid_future: asyncio.Future = asyncio.get_running_loop().create_future()
+            pending = _PendingRequest(
+                token_ids=token_ids,
+                max_tokens=max_tokens,
+                sampler=sampler,
+                logits_processors=logits_processors,
+                state_machine=state_machine,
+                queue=queue,
+                uid_future=uid_future,
+                request_id=request_id,
+            )
+            # Hand off to the gen thread. It'll insert this request into
+            # the next fresh batch and resolve uid_future once the uid
+            # is assigned. We register on _pending_by_request_id first so
+            # an Abort that races with this append can still find us.
+            with self._pending_lock:
+                self._pending_by_request_id[request_id] = pending
+                self._pending.append(pending)
+            try:
+                uid = await uid_future
+            except asyncio.CancelledError:
+                # Client disconnect before we entered the batch — make
+                # sure we're scrubbed from pending so the gen thread
+                # doesn't insert us anyway.
+                with self._pending_lock:
+                    self._pending_by_request_id.pop(request_id, None)
+                    try:
+                        self._pending.remove(pending)
+                    except ValueError:
+                        pass
+                raise
             self._request_uid_map[request_id] = uid
             self._active_requests += 1
             prompt_tokens = len(token_ids)
@@ -466,11 +607,14 @@ class MlxEngineServicer(mlx_engine_pb2_grpc.MlxEngineServicer):
                 # Ensure the backend request is removed on any Generate exit
                 # (client disconnect, deadline, CancelledError, unexpected
                 # exception). Without this, a cancelled request keeps decoding
-                # until its own stop/max-tokens condition, wasting batch slots.
-                # Safe to double-call: gen thread's finish-path remove and
-                # Abort's remove both land here if racing, and remove() is
-                # idempotent-ish (raises on unknown uid, which we swallow).
+                # until its own stop/max-tokens condition, wasting batch slots
+                # — and, crucially, holds drain-and-batch up so new requests
+                # in _pending can't enter until this one finishes naturally.
+                # Safe to double-call: the gen thread's finish-path remove
+                # and Abort's remove both land here if racing, and remove()
+                # raises on unknown uid (which we swallow).
                 with self._gen_lock:
+                    self._active_uids.discard(uid)
                     try:
                         self.batch_generator.remove([uid])
                     except Exception:
@@ -486,6 +630,21 @@ class MlxEngineServicer(mlx_engine_pb2_grpc.MlxEngineServicer):
 
     async def Abort(self, request, context):
         for request_id in request.request_ids:
+            # Case A: request hasn't entered the batch yet — pop from
+            # pending and cancel its uid_future so Generate exits cleanly.
+            with self._pending_lock:
+                pending = self._pending_by_request_id.pop(request_id, None)
+                if pending is not None:
+                    try:
+                        self._pending.remove(pending)
+                    except ValueError:
+                        pass
+            if pending is not None:
+                if not pending.uid_future.done():
+                    pending.uid_future.cancel()
+                continue
+
+            # Case B: already inserted — existing in-flight remove path.
             uid = self._request_uid_map.pop(request_id, None)
             if uid is not None:
                 queue = self._uid_queues.pop(uid, None)
@@ -504,6 +663,7 @@ class MlxEngineServicer(mlx_engine_pb2_grpc.MlxEngineServicer):
                 # remove() races with the gen thread's next() without the
                 # lock — see class docstring.
                 with self._gen_lock:
+                    self._active_uids.discard(uid)
                     try:
                         self.batch_generator.remove([uid])
                     except Exception:

--- a/grpc_servicer/smg_grpc_servicer/mlx/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/mlx/servicer.py
@@ -505,11 +505,25 @@ class MlxEngineServicer(mlx_engine_pb2_grpc.MlxEngineServicer):
                             if queue is not None:
                                 self._loop.call_soon_threadsafe(queue.put_nowait, r)
                             if r.finish_reason is not None:
+                                # Discard from _active_uids ONLY after a
+                                # successful remove. _active_uids is the
+                                # gate that admits new pending requests;
+                                # if remove() fails for a real backend
+                                # reason (not just an already-removed
+                                # uid), discarding would let drain-and-
+                                # fill insert into a still-live batch
+                                # and reintroduce the rope crash this
+                                # whole change is fixing.
                                 try:
                                     self.batch_generator.remove([r.uid])
+                                    self._active_uids.discard(r.uid)
                                 except Exception:
-                                    logger.exception("Error removing uid %d", r.uid)
-                                self._active_uids.discard(r.uid)
+                                    logger.exception(
+                                        "BatchGenerator.remove failed for uid %d "
+                                        "(keeping it in _active_uids to preserve "
+                                        "the drain gate)",
+                                        r.uid,
+                                    )
             except Exception:
                 logger.exception("Error in generation loop")
                 continue
@@ -578,35 +592,45 @@ class MlxEngineServicer(mlx_engine_pb2_grpc.MlxEngineServicer):
                 #  (1) Gen thread hasn't drained us yet — scrub from
                 #      pending so it doesn't insert a doomed request.
                 #  (2) Gen thread inserted us right before the cancel
-                #      landed (set_result raced our task cancellation).
-                #      The future has a usable result; we still need to
-                #      run the same backend cleanup the normal finally
-                #      would have done, otherwise the uid keeps decoding
-                #      and the batch never drains.
+                #      landed. We must still run the same backend
+                #      cleanup the normal finally would have done,
+                #      otherwise the uid keeps decoding and the batch
+                #      never drains.
                 with self._pending_lock:
                     self._pending_by_request_id.pop(request_id, None)
                     try:
                         self._pending.remove(pending)
                     except ValueError:
                         pass
+                # Recover the uid: prefer the future's result, but fall
+                # back to _request_uid_map (the gen thread publishes the
+                # mapping *before* scheduling set_result, so it's
+                # populated even when the cancel arrived first and put
+                # the future into the cancelled state).
                 inserted_uid = None
                 if uid_future.done() and not uid_future.cancelled():
                     try:
                         inserted_uid = uid_future.result()
                     except Exception:
                         inserted_uid = None
-                if inserted_uid is not None:
-                    # Mirror the normal finally cleanup (the gen thread
-                    # populated _request_uid_map / _uid_queues /
-                    # _active_uids before resolving the future).
-                    self._request_uid_map.pop(request_id, None)
-                    self._uid_queues.pop(inserted_uid, None)
-                    with self._gen_lock:
-                        self._active_uids.discard(inserted_uid)
+                with self._gen_lock:
+                    if inserted_uid is None:
+                        inserted_uid = self._request_uid_map.pop(request_id, None)
+                    else:
+                        self._request_uid_map.pop(request_id, None)
+                    if inserted_uid is not None:
+                        self._uid_queues.pop(inserted_uid, None)
                         try:
                             self.batch_generator.remove([inserted_uid])
+                            self._active_uids.discard(inserted_uid)
                         except Exception:
-                            pass
+                            # Don't drop _active_uids on a failed remove
+                            # — keep the gate honest so drain-and-fill
+                            # doesn't insert into a partial batch.
+                            logger.exception(
+                                "Failed to remove uid %s during cancel cleanup",
+                                inserted_uid,
+                            )
                 raise
             # Note: _request_uid_map[request_id] = uid is published by
             # the gen thread BEFORE waking us, so Abort can find this
@@ -696,11 +720,17 @@ class MlxEngineServicer(mlx_engine_pb2_grpc.MlxEngineServicer):
                 # and Abort's remove both land here if racing, and remove()
                 # raises on unknown uid (which we swallow).
                 with self._gen_lock:
-                    self._active_uids.discard(uid)
                     try:
                         self.batch_generator.remove([uid])
+                        self._active_uids.discard(uid)
                     except Exception:
-                        # Already removed by the gen thread or Abort — fine.
+                        # Already removed by the gen thread or Abort —
+                        # in those paths, _active_uids was already
+                        # discarded after the successful remove. If the
+                        # remove failed for a real backend reason on
+                        # *every* path, the uid stays in _active_uids
+                        # so drain-and-fill won't insert into a still-
+                        # live batch.
                         pass
 
         except ValueError as e:
@@ -745,10 +775,15 @@ class MlxEngineServicer(mlx_engine_pb2_grpc.MlxEngineServicer):
                 # remove() races with the gen thread's next() without the
                 # lock — see class docstring.
                 with self._gen_lock:
-                    self._active_uids.discard(uid)
                     try:
                         self.batch_generator.remove([uid])
+                        self._active_uids.discard(uid)
                     except Exception:
+                        # Same invariant as Generate's finally: only
+                        # discard from _active_uids on a successful
+                        # remove. If this fails because the gen thread
+                        # already removed, _active_uids was already
+                        # cleared on that success path.
                         logger.warning("Failed to remove uid %d for request %s", uid, request_id)
         return mlx_engine_pb2.AbortResponse()
 


### PR DESCRIPTION
## Description

### Problem

mlx-lm's `BatchGenerator` does not support inserting new sequences during the decode phase of an active batch. The rope offset cache is sized at the start of decode and a mid-decode `insert()` leaves the cache out of sync with the new batch shape, surfacing on the next `_step()` as:

```
ValueError: [rope] offset must be a scalar or vector with 4 elements but has shape (3).
  File ".../mlx_lm/generate.py", line 1332, in _step
    logits = self.model(inputs[:, None], cache=self.prompt_cache)
  File ".../mlx_lm/models/gemma3_text.py", line 89, in __call__
    queries = self.rope(queries, offset=cache.offset)
  File ".../mlx/nn/layers/positional_encoding.py", line 47, in __call__
    return mx.fast.rope(...)
```

Reproduced in the nightly mlx-bench (#1399) at concurrency=4 with 2.5 k-token agent prompts on `macos-latest`:

| Backend | Concurrency | TTFT mean | Completed |
|---|---|---|---|
| `mlx-lm.server` | 4 | 74 195 ms | 8/8 ✅ |
| `smg → mlx-grpc` (this servicer) | 4 | **154 477 ms** | **4/8 ❌** |

The corresponding `mlx-grpc.log` shows the rope `ValueError`; `mlx-lm.log` does not — because `mlx-lm.server` already serializes each batch to completion before accepting the next set of requests, sidestepping the mid-decode insert. Our servicer was doing dynamic insert under `_gen_lock`, which serialized inserts vs `next()` correctly but did not prevent the *mid-decode* insert that triggers the rope-offset corruption.

### Solution

Mirror `mlx-lm.server`'s drain-and-batch model in our gRPC servicer.

- Incoming `Generate()` calls build a `_PendingRequest` (token_ids, max_tokens, sampler, …, queue, `asyncio.Future` for uid delivery, request_id), append it to a `_pending` list, and await the future. No mid-decode `insert()` from `Generate()`.
- The generation thread, between iterations, checks whether the active batch has drained (`_active_uids` empty). When it has, it pulls the entire `_pending` list into **one** `BatchGenerator.insert()` call, registers each uid + queue, and resolves each `uid_future`. Phase 2 (`next()` + dispatch + finished `remove()`) is unchanged.
- Concurrent arrivals still batch together: drain-and-fill grabs everything pending in one shot, so a burst of N concurrent `Generate()`s feeds one batched `insert()`, preserving prefill and decode batching.
- A request arriving mid-decode of an active batch waits for that batch to drain before its first token. Same behavior as `mlx-lm.server`; trade-off is the correctness fix.
- `Abort()` handles a not-yet-inserted request by popping from `_pending_by_request_id` and cancelling its `uid_future`, so `Generate()` exits cleanly without ever consuming a batch slot.

Re-introducing true dynamic mid-decode batching is future work that needs an upstream fix or documented invariant in mlx-lm's `BatchGenerator`.

## Changes

- `grpc_servicer/smg_grpc_servicer/mlx/servicer.py` (+222 / −62)
  - New `_PendingRequest` value class.
  - New state on `MlxEngineServicer`: `_pending`, `_pending_by_request_id`, `_pending_lock`, `_active_uids: set[int]`.
  - `_generation_loop`: Phase 1 drain-and-fill at the top of each iteration; Phase 2 unchanged.
  - `Generate()`: append to `_pending`, await `uid_future`, then existing streaming/non-streaming consumer logic. `CancelledError` while awaiting scrubs the pending entry.
  - `Abort()`: pending check first, in-flight remove second.
  - Class docstring rewritten to describe the drain-and-batch contract and lock ordering (`_pending_lock` always acquired outside `_gen_lock`).

No proto, gateway, or client changes. No public API change.

## Test Plan

Local repro on Apple Silicon against `mlx-community/gemma-3-4b-it-qat-4bit`, 4 concurrent SMG-router → MLX-gRPC requests with `~2.5 k`-token agent prompts:

| Concurrency | Total time | Per-request chunks | Rope errors |
|---|---|---|---|
| c=1 | 3.2 s | 66 | 0 |
| c=4 | 9.4 s | 66 | 0 |
| c=8 | 18.5 s | 66 | 0 |

c=4 → c=8 doubling shows batched prefill still works at 8 concurrent requests (one batched `insert()`, one batched prefill, then batched decode).

Pre-fix repro on the same hardware happened to *not* hit the rope crash — the race window is wider on the slower `macos-latest` runner, narrower on a real M-series. The fix is structural (no mid-decode insert is possible) so it applies regardless of timing.

End-to-end CI validation will arrive via the next nightly mlx-bench run (#1399) once this lands; the c=4 agent SMG cell should drop from 154 s to ≈ matching the c=4 mlx-lm.server cell, and `mlx-grpc.log` should show zero rope errors.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes (no Rust files changed)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (no Rust files changed)
- [x] `pre-commit run --files grpc_servicer/smg_grpc_servicer/mlx/servicer.py` passes (ruff, ruff format, codespell)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal request batching for higher throughput and more consistent processing.
* **Bug Fixes**
  * Fixed cases where queued requests could remain stuck; waiters now receive timely errors on failures.
  * Improved cancellation and abort handling around batching boundaries so aborted or canceled requests are promptly cleaned up and won't hang.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->