### PR TITLE
feat(mcp): forward OCI headers exclusively to MCP tool calls via JSON-RPC _meta

### DIFF
--- a/crates/mcp/src/core/orchestrator.rs
+++ b/crates/mcp/src/core/orchestrator.rs
@@ -1458,7 +1458,7 @@ impl McpOrchestrator {
     /// Execute a tool call on a server.
     ///
     /// When `forwarded_headers` is non-empty, cherry-picked headers are passed to
-    /// the MCP server inside the JSON-RPC `_meta.forwarded_headers` field rather
+    /// the MCP server inside the JSON-RPC `_meta.extra_headers` field rather
     /// than at the HTTP transport level.
     async fn execute_on_server(
         &self,
@@ -1484,7 +1484,7 @@ impl McpOrchestrator {
     /// Send a `tools/call` JSON-RPC request to an MCP peer.
     ///
     /// When `forwarded_headers` is non-empty, they are embedded in the
-    /// `_meta.forwarded_headers` field of the request so the MCP server can
+    /// `_meta.extra_headers` field of the request so the MCP server can
     /// read them from the protocol message.
     async fn call_tool_on_peer(
         &self,
@@ -2114,10 +2114,11 @@ impl<'a> McpRequestContext<'a> {
             arguments: args_map,
         };
 
-        let result = client
-            .call_tool(request)
-            .await
-            .map_err(|e| McpError::ToolExecution(format!("MCP call failed: {e}")))?;
+        let server_key = entry.server_key();
+        let result = self
+            .orchestrator
+            .call_tool_on_peer(client.peer(), server_key, request, &self.forwarded_headers)
+            .await?;
 
         let output = McpOrchestrator::transform_result(
             &result,

--- a/crates/mcp/src/core/orchestrator.rs
+++ b/crates/mcp/src/core/orchestrator.rs
@@ -39,8 +39,10 @@ use std::{
 use dashmap::DashMap;
 use openai_protocol::responses::ResponseOutputItem;
 use rmcp::{
-    model::{CallToolRequestParam, CallToolResult},
-    service::{RunningService, ServiceError},
+    model::{
+        CallToolRequest, CallToolRequestParam, CallToolResult, ClientRequest, Meta, ServerResult,
+    },
+    service::{PeerRequestOptions, RunningService, ServiceError},
     RoleClient,
 };
 use serde_json::Value;
@@ -1201,7 +1203,9 @@ impl McpOrchestrator {
                     return Err(McpError::ToolDenied(entry.tool_name().to_string()));
                 }
                 self.metrics.record_approval_granted();
-                let result = self.execute_tool_with_reconnect(entry, arguments).await?;
+                let result = self
+                    .execute_tool_with_reconnect(entry, arguments, &request_ctx.forwarded_headers)
+                    .await?;
                 Ok(ApprovalExecutionResult::Success(result))
             }
             ApprovalOutcome::Pending {
@@ -1220,7 +1224,13 @@ impl McpOrchestrator {
                 match rx.await {
                     Ok(ApprovalDecision::Approved) => {
                         self.metrics.record_approval_granted();
-                        let result = self.execute_tool_with_reconnect(entry, arguments).await?;
+                        let result = self
+                            .execute_tool_with_reconnect(
+                                entry,
+                                arguments,
+                                &request_ctx.forwarded_headers,
+                            )
+                            .await?;
                         Ok(ApprovalExecutionResult::Success(result))
                     }
                     Ok(ApprovalDecision::Denied { reason }) => {
@@ -1236,6 +1246,7 @@ impl McpOrchestrator {
         &self,
         entry: &ToolEntry,
         arguments: Value,
+        forwarded_headers: &HashMap<String, String>,
     ) -> McpResult<CallToolResult> {
         let server_name = entry.server_key();
 
@@ -1245,7 +1256,10 @@ impl McpOrchestrator {
             .get(server_name)
             .map(|e| Arc::clone(&e.client));
 
-        match self.execute_tool_impl(entry, arguments.clone()).await {
+        match self
+            .execute_tool_impl(entry, arguments.clone(), forwarded_headers)
+            .await
+        {
             Ok(result) => Ok(result),
             Err(McpError::ServerDisconnected(name)) => {
                 // Acquire/Create the mutex for this server to prevent concurrent reconnects
@@ -1272,7 +1286,9 @@ impl McpOrchestrator {
                             "Server '{}' already reconnected by another task, retrying call",
                             name
                         );
-                        return self.execute_tool_impl(entry, arguments).await;
+                        return self
+                            .execute_tool_impl(entry, arguments, forwarded_headers)
+                            .await;
                     }
                 }
 
@@ -1297,7 +1313,8 @@ impl McpOrchestrator {
                     .await?;
 
                 // Retry execution after successful reconnection
-                self.execute_tool_impl(entry, arguments).await
+                self.execute_tool_impl(entry, arguments, forwarded_headers)
+                    .await
             }
             Err(e) => Err(e),
         }
@@ -1308,6 +1325,7 @@ impl McpOrchestrator {
         &self,
         entry: &ToolEntry,
         mut arguments: Value,
+        forwarded_headers: &HashMap<String, String>,
     ) -> McpResult<CallToolResult> {
         // Resolve alias if needed
         let (target_server, target_tool) = if let Some(alias) = &entry.alias_target {
@@ -1346,7 +1364,8 @@ impl McpOrchestrator {
         };
 
         // Execute on server
-        self.execute_on_server(&target_server, request).await
+        self.execute_on_server(&target_server, request, forwarded_headers)
+            .await
     }
 
     /// Coerce argument types based on tool schema.
@@ -1437,13 +1456,45 @@ impl McpOrchestrator {
     }
 
     /// Execute a tool call on a server.
+    ///
+    /// When `forwarded_headers` is non-empty, cherry-picked headers are passed to
+    /// the MCP server inside the JSON-RPC `_meta.forwarded_headers` field rather
+    /// than at the HTTP transport level.
     async fn execute_on_server(
         &self,
         server_key: &str,
         request: CallToolRequestParam,
+        forwarded_headers: &HashMap<String, String>,
     ) -> McpResult<CallToolResult> {
         if let Some(entry) = self.static_servers.get(server_key) {
-            return entry.client.call_tool(request).await.map_err(|e| match e {
+            return self
+                .call_tool_on_peer(entry.client.peer(), server_key, request, forwarded_headers)
+                .await;
+        }
+
+        if let Some(client) = self.connection_pool.get_by_url(server_key) {
+            return self
+                .call_tool_on_peer(client.peer(), server_key, request, forwarded_headers)
+                .await;
+        }
+
+        Err(McpError::ServerNotFound(server_key.to_string()))
+    }
+
+    /// Send a `tools/call` JSON-RPC request to an MCP peer.
+    ///
+    /// When `forwarded_headers` is non-empty, they are embedded in the
+    /// `_meta.forwarded_headers` field of the request so the MCP server can
+    /// read them from the protocol message.
+    async fn call_tool_on_peer(
+        &self,
+        peer: &rmcp::service::Peer<RoleClient>,
+        server_key: &str,
+        request: CallToolRequestParam,
+        forwarded_headers: &HashMap<String, String>,
+    ) -> McpResult<CallToolResult> {
+        if forwarded_headers.is_empty() {
+            return peer.call_tool(request).await.map_err(|e| match e {
                 // Typed detection for transport-level failures
                 ServiceError::TransportClosed | ServiceError::TransportSend(_) => {
                     McpError::ServerDisconnected(server_key.to_string())
@@ -1452,18 +1503,49 @@ impl McpOrchestrator {
             });
         }
 
-        if let Some(client) = self.connection_pool.get_by_url(server_key) {
-            return client.call_tool(request).await.map_err(|e| match e {
+        // Build _meta with forwarded_headers
+        let headers_value: serde_json::Map<String, Value> = forwarded_headers
+            .iter()
+            .map(|(k, v)| (k.clone(), Value::String(v.clone())))
+            .collect();
+        let mut meta_map = serde_json::Map::new();
+        meta_map.insert("extra_headers".to_string(), Value::Object(headers_value));
+        let meta = Meta(meta_map);
+
+        let call_request = ClientRequest::CallToolRequest(CallToolRequest {
+            method: Default::default(),
+            params: request,
+            extensions: Default::default(),
+        });
+        let options = PeerRequestOptions {
+            meta: Some(meta),
+            timeout: None,
+        };
+
+        let result = peer
+            .send_request_with_option(call_request, options)
+            .await
+            .map_err(|e| match e {
                 ServiceError::TransportClosed | ServiceError::TransportSend(_) => {
-                    // Note: Pooled connections trigger Disconnected but
-                    // recovery logic is currently scoped to static servers.
                     McpError::ServerDisconnected(server_key.to_string())
                 }
                 _ => McpError::ToolExecution(format!("MCP call failed: {e}")),
-            });
-        }
+            })?
+            .await_response()
+            .await
+            .map_err(|e| match e {
+                ServiceError::TransportClosed | ServiceError::TransportSend(_) => {
+                    McpError::ServerDisconnected(server_key.to_string())
+                }
+                _ => McpError::ToolExecution(format!("MCP call failed: {e}")),
+            })?;
 
-        Err(McpError::ServerNotFound(server_key.to_string()))
+        match result {
+            ServerResult::CallToolResult(result) => Ok(result),
+            _ => Err(McpError::ToolExecution(
+                "unexpected response type for tools/call".to_string(),
+            )),
+        }
     }
 
     // ========================================================================
@@ -1843,7 +1925,9 @@ impl McpOrchestrator {
             .ok_or_else(|| McpError::ToolNotFound(format!("{server_key}:{tool_name}")))?;
 
         // Execute directly (approval already handled)
-        let result = self.execute_tool_impl(&entry, arguments.clone()).await?;
+        let result = self
+            .execute_tool_impl(&entry, arguments.clone(), &request_ctx.forwarded_headers)
+            .await?;
 
         // Transform response
         let output = Self::transform_result(

--- a/crates/mcp/src/transform/transformer.rs
+++ b/crates/mcp/src/transform/transformer.rs
@@ -247,7 +247,7 @@ impl ResponseTransformer {
             id: format!("fs_{tool_call_id}"),
             status: FileSearchCallStatus::Completed,
             queries: if queries.is_empty() {
-                obj.and_then(|o| o.get("query"))
+                obj.and_then(|o| o.get(Self::KEY_QUERY))
                     .and_then(|v| v.as_str())
                     .map(|q| vec![q.to_string()])
                     .unwrap_or_default()
@@ -564,19 +564,39 @@ impl ResponseTransformer {
     fn extract_file_results(result: &serde_json::Value) -> Vec<FileSearchResult> {
         result
             .as_object()
-            .and_then(|obj| obj.get("results"))
+            .and_then(|obj| obj.get(Self::KEY_RESULTS))
             .and_then(|v| v.as_array())
             .map(|arr| arr.iter().filter_map(Self::parse_file_result).collect())
             .unwrap_or_default()
     }
 
+    // Deterministic key names for parsing MCP file search result JSON objects.
+    const KEY_RESULTS: &'static str = "results";
+    const KEY_QUERY: &'static str = "query";
+    const KEY_FILE_ID: &'static str = "file_id";
+    const KEY_FILENAME: &'static str = "filename";
+    const KEY_TEXT: &'static str = "text";
+    const KEY_SCORE: &'static str = "score";
+
     /// Parse a file search result from JSON.
     fn parse_file_result(item: &serde_json::Value) -> Option<FileSearchResult> {
         let obj = item.as_object()?;
-        let file_id = obj.get("file_id").and_then(|v| v.as_str())?.to_string();
-        let filename = obj.get("filename").and_then(|v| v.as_str())?.to_string();
-        let text = obj.get("text").and_then(|v| v.as_str()).map(String::from);
-        let score = obj.get("score").and_then(|v| v.as_f64()).map(|f| f as f32);
+        let file_id = obj
+            .get(Self::KEY_FILE_ID)
+            .and_then(|v| v.as_str())?
+            .to_string();
+        let filename = obj
+            .get(Self::KEY_FILENAME)
+            .and_then(|v| v.as_str())?
+            .to_string();
+        let text = obj
+            .get(Self::KEY_TEXT)
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let score = obj
+            .get(Self::KEY_SCORE)
+            .and_then(|v| v.as_f64())
+            .map(|f| f as f32);
 
         Some(FileSearchResult {
             file_id,

--- a/model_gateway/src/routers/common/header_utils.rs
+++ b/model_gateway/src/routers/common/header_utils.rs
@@ -289,7 +289,7 @@ pub fn extract_auth_header(
 /// requests (tracing, auth, routing). Does **not** include MCP-specific headers;
 /// use [`extract_mcp_forward_headers`] for those.
 pub fn extract_forwardable_request_headers(headers: Option<&HeaderMap>) -> HashMap<String, String> {
-    extract_headers_matching(headers, should_forward_request_header)
+    extract_matching_headers(headers, should_forward_request_header)
 }
 
 /// Extract headers forwarded only to MCP tool calls (e.g., OCI delegation token).
@@ -297,11 +297,25 @@ pub fn extract_forwardable_request_headers(headers: Option<&HeaderMap>) -> HashM
 /// These are embedded in `_meta.extra_headers` of the JSON-RPC request and
 /// must not be sent to LLM provider calls.
 pub fn extract_mcp_forward_headers(headers: Option<&HeaderMap>) -> HashMap<String, String> {
-    extract_headers_matching(headers, is_mcp_forward_header)
+    extract_matching_headers(headers, is_mcp_forward_header)
+}
+
+/// Headers where multiple values are comma-joined per RFC 9110.
+/// All other headers are treated as singletons (first value wins).
+const CSV_MERGE_HEADERS: &[&str] = &["tracestate", "traceparent"];
+
+/// Returns `true` if repeated values for `name` should be comma-joined.
+fn is_csv_mergeable(name: &str) -> bool {
+    CSV_MERGE_HEADERS
+        .iter()
+        .any(|h| name.eq_ignore_ascii_case(h))
 }
 
 /// Shared extraction logic: collect headers whose names pass `predicate`.
-fn extract_headers_matching(
+///
+/// Headers listed in [`CSV_MERGE_HEADERS`] have repeated values comma-joined.
+/// All other headers are singletons — only the first value is kept.
+fn extract_matching_headers(
     headers: Option<&HeaderMap>,
     predicate: fn(&str) -> bool,
 ) -> HashMap<String, String> {
@@ -324,8 +338,11 @@ fn extract_headers_matching(
         forwarded
             .entry(name_str.to_string())
             .and_modify(|existing: &mut String| {
-                existing.push_str(", ");
-                existing.push_str(value);
+                if is_csv_mergeable(name_str) {
+                    existing.push_str(", ");
+                    existing.push_str(value);
+                }
+                // Singleton headers: keep the first value, ignore subsequent.
             })
             .or_insert_with(|| value.to_string());
     }
@@ -585,16 +602,49 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_forwardable_request_headers_preserves_repeated_values() {
+    fn test_extract_forwardable_request_headers_csv_merges_tracestate() {
         let mut headers = HeaderMap::new();
         headers.append("tracestate", "vendor1=value1".parse().unwrap());
         headers.append("tracestate", "vendor2=value2".parse().unwrap());
 
         let forwarded = extract_forwardable_request_headers(Some(&headers));
 
+        // tracestate is CSV-mergeable: repeated values are comma-joined.
         assert_eq!(
             forwarded.get("tracestate"),
             Some(&"vendor1=value1, vendor2=value2".to_string())
+        );
+    }
+
+    #[test]
+    fn test_singleton_headers_keep_first_value() {
+        let mut headers = HeaderMap::new();
+        headers.append("authorization", "Bearer first".parse().unwrap());
+        headers.append("authorization", "Bearer second".parse().unwrap());
+
+        let forwarded = extract_forwardable_request_headers(Some(&headers));
+
+        // Singleton: first value wins, no comma-joining.
+        assert_eq!(
+            forwarded.get("authorization"),
+            Some(&"Bearer first".to_string())
+        );
+    }
+
+    #[test]
+    fn test_mcp_singleton_headers_keep_first_value() {
+        let mut headers = HeaderMap::new();
+        headers.append("x-smg-oci-delegation-token", "token-first".parse().unwrap());
+        headers.append(
+            "x-smg-oci-delegation-token",
+            "token-second".parse().unwrap(),
+        );
+
+        let mcp = extract_mcp_forward_headers(Some(&headers));
+
+        assert_eq!(
+            mcp.get("x-smg-oci-delegation-token"),
+            Some(&"token-first".to_string())
         );
     }
 

--- a/model_gateway/src/routers/common/header_utils.rs
+++ b/model_gateway/src/routers/common/header_utils.rs
@@ -285,11 +285,26 @@ pub fn extract_auth_header(
         .or_else(|| worker_api_key.and_then(|k| HeaderValue::from_str(&format!("Bearer {k}")).ok()))
 }
 
-/// Extract the subset of request headers that SMG forwards to MCP tool calls.
-///
-/// Includes both the general forwarding allowlist (tracing, auth, routing)
-/// and MCP-specific headers (OCI delegation token, compartment ID).
+/// Extract the subset of request headers that SMG forwards to upstream HTTP
+/// requests (tracing, auth, routing). Does **not** include MCP-specific headers;
+/// use [`extract_mcp_forward_headers`] for those.
 pub fn extract_forwardable_request_headers(headers: Option<&HeaderMap>) -> HashMap<String, String> {
+    extract_headers_matching(headers, should_forward_request_header)
+}
+
+/// Extract headers forwarded only to MCP tool calls (e.g., OCI delegation token).
+///
+/// These are embedded in `_meta.extra_headers` of the JSON-RPC request and
+/// must not be sent to LLM provider calls.
+pub fn extract_mcp_forward_headers(headers: Option<&HeaderMap>) -> HashMap<String, String> {
+    extract_headers_matching(headers, is_mcp_forward_header)
+}
+
+/// Shared extraction logic: collect headers whose names pass `predicate`.
+fn extract_headers_matching(
+    headers: Option<&HeaderMap>,
+    predicate: fn(&str) -> bool,
+) -> HashMap<String, String> {
     let Some(headers) = headers else {
         return HashMap::new();
     };
@@ -298,7 +313,7 @@ pub fn extract_forwardable_request_headers(headers: Option<&HeaderMap>) -> HashM
 
     for (name, value) in headers {
         let name_str = name.as_str();
-        if !should_forward_request_header(name_str) && !is_mcp_forward_header(name_str) {
+        if !predicate(name_str) {
             continue;
         }
 
@@ -522,6 +537,51 @@ mod tests {
         );
         assert_eq!(forwarded.get("x-request-id"), Some(&"req-123".to_string()));
         assert!(!forwarded.contains_key("x-custom-header"));
+    }
+
+    #[test]
+    fn test_extract_forwardable_excludes_mcp_only_headers() {
+        let mut headers = HeaderMap::new();
+        headers.insert("authorization", "Bearer abc".parse().unwrap());
+        headers.insert("x-smg-oci-delegation-token", "dt-secret".parse().unwrap());
+        headers.insert("x-smg-oci-compartment-id", "ocid1.comp".parse().unwrap());
+
+        let forwarded = extract_forwardable_request_headers(Some(&headers));
+
+        assert!(forwarded.contains_key("authorization"));
+        assert!(!forwarded.contains_key("x-smg-oci-delegation-token"));
+        assert!(!forwarded.contains_key("x-smg-oci-compartment-id"));
+    }
+
+    #[test]
+    fn test_extract_mcp_forward_headers() {
+        let mut headers = HeaderMap::new();
+        headers.insert("authorization", "Bearer abc".parse().unwrap());
+        headers.insert("x-smg-oci-delegation-token", "dt-secret".parse().unwrap());
+        headers.insert("x-smg-oci-compartment-id", "ocid1.comp".parse().unwrap());
+        headers.insert("traceparent", "00-trace".parse().unwrap());
+
+        let mcp = extract_mcp_forward_headers(Some(&headers));
+
+        assert_eq!(mcp.len(), 2);
+        assert_eq!(
+            mcp.get("x-smg-oci-delegation-token"),
+            Some(&"dt-secret".to_string())
+        );
+        assert_eq!(
+            mcp.get("x-smg-oci-compartment-id"),
+            Some(&"ocid1.comp".to_string())
+        );
+        assert!(!mcp.contains_key("authorization"));
+        assert!(!mcp.contains_key("traceparent"));
+    }
+
+    #[test]
+    fn test_extract_mcp_forward_headers_empty_when_none() {
+        assert!(extract_mcp_forward_headers(None).is_empty());
+
+        let headers = HeaderMap::new();
+        assert!(extract_mcp_forward_headers(Some(&headers)).is_empty());
     }
 
     #[test]

--- a/model_gateway/src/routers/common/header_utils.rs
+++ b/model_gateway/src/routers/common/header_utils.rs
@@ -285,8 +285,10 @@ pub fn extract_auth_header(
         .or_else(|| worker_api_key.and_then(|k| HeaderValue::from_str(&format!("Bearer {k}")).ok()))
 }
 
-/// Extract the subset of request headers that SMG is allowed to preserve for
-/// internal execution paths such as MCP tool calls.
+/// Extract the subset of request headers that SMG forwards to MCP tool calls.
+///
+/// Includes both the general forwarding allowlist (tracing, auth, routing)
+/// and MCP-specific headers (OCI delegation token, compartment ID).
 pub fn extract_forwardable_request_headers(headers: Option<&HeaderMap>) -> HashMap<String, String> {
     let Some(headers) = headers else {
         return HashMap::new();
@@ -295,7 +297,8 @@ pub fn extract_forwardable_request_headers(headers: Option<&HeaderMap>) -> HashM
     let mut forwarded = HashMap::new();
 
     for (name, value) in headers {
-        if !should_forward_request_header(name.as_str()) {
+        let name_str = name.as_str();
+        if !should_forward_request_header(name_str) && !is_mcp_forward_header(name_str) {
             continue;
         }
 
@@ -304,7 +307,7 @@ pub fn extract_forwardable_request_headers(headers: Option<&HeaderMap>) -> HashM
         };
 
         forwarded
-            .entry(name.as_str().to_string())
+            .entry(name_str.to_string())
             .and_modify(|existing: &mut String| {
                 existing.push_str(", ");
                 existing.push_str(value);
@@ -315,6 +318,7 @@ pub fn extract_forwardable_request_headers(headers: Option<&HeaderMap>) -> HashM
     forwarded
 }
 
+/// Headers forwarded to all upstream HTTP requests (LLM providers, etc.).
 #[inline]
 pub fn should_forward_request_header(name: &str) -> bool {
     const REQUEST_ID_PREFIX: &str = "x-request-id-";
@@ -328,6 +332,13 @@ pub fn should_forward_request_header(name: &str) -> bool {
         || name
             .get(..REQUEST_ID_PREFIX.len())
             .is_some_and(|prefix| prefix.eq_ignore_ascii_case(REQUEST_ID_PREFIX))
+}
+
+/// Headers forwarded only to MCP tool calls (via `_meta.extra_headers`).
+#[inline]
+pub fn is_mcp_forward_header(name: &str) -> bool {
+    name.eq_ignore_ascii_case("x-smg-oci-delegation-token")
+        || name.eq_ignore_ascii_case("x-smg-oci-compartment-id")
 }
 
 // ── Conversation memory config ────────────────────────────────────────────────
@@ -480,7 +491,20 @@ mod tests {
         assert!(!should_forward_request_header("user-agent"));
         assert!(!should_forward_request_header("cookie"));
         assert!(!should_forward_request_header("x-custom-header"));
-        assert!(!should_forward_request_header("x-api-key"));
+        assert!(!should_forward_request_header("x-api-key")); // OCI headers are MCP-only, not in the general forwarding list
+        assert!(!should_forward_request_header("x-smg-oci-delegation-token"));
+        assert!(!should_forward_request_header("x-smg-oci-compartment-id"));
+    }
+
+    #[test]
+    fn test_is_mcp_forward_header() {
+        assert!(is_mcp_forward_header("x-smg-oci-delegation-token"));
+        assert!(is_mcp_forward_header("X-SMG-OCI-Delegation-Token"));
+        assert!(is_mcp_forward_header("x-smg-oci-compartment-id"));
+        assert!(is_mcp_forward_header("X-SMG-OCI-Compartment-Id"));
+        // General headers are not MCP-specific
+        assert!(!is_mcp_forward_header("authorization"));
+        assert!(!is_mcp_forward_header("traceparent"));
     }
 
     #[test]

--- a/model_gateway/src/routers/common/mcp_utils.rs
+++ b/model_gateway/src/routers/common/mcp_utils.rs
@@ -188,6 +188,7 @@ pub fn collect_builtin_routing(
             ResponseTool::WebSearchPreview(_) => BuiltinToolType::WebSearchPreview,
             ResponseTool::CodeInterpreter(_) => BuiltinToolType::CodeInterpreter,
             ResponseTool::ImageGeneration(_) => BuiltinToolType::ImageGeneration,
+            ResponseTool::FileSearch(_) => BuiltinToolType::FileSearch,
             _ => continue,
         };
 
@@ -229,6 +230,7 @@ pub fn extract_builtin_types(tools: &[ResponseTool]) -> Vec<BuiltinToolType> {
             ResponseTool::WebSearchPreview(_) => Some(BuiltinToolType::WebSearchPreview),
             ResponseTool::CodeInterpreter(_) => Some(BuiltinToolType::CodeInterpreter),
             ResponseTool::ImageGeneration(_) => Some(BuiltinToolType::ImageGeneration),
+            ResponseTool::FileSearch(_) => Some(BuiltinToolType::FileSearch),
             _ => None,
         })
         .collect()

--- a/model_gateway/src/routers/openai/responses/non_streaming.rs
+++ b/model_gateway/src/routers/openai/responses/non_streaming.rs
@@ -14,7 +14,9 @@ use tracing::warn;
 use super::utils::{patch_response_with_request_metadata, restore_original_tools};
 use crate::routers::{
     common::{
-        header_utils::{extract_forwardable_request_headers, ApiProvider},
+        header_utils::{
+            extract_forwardable_request_headers, extract_mcp_forward_headers, ApiProvider,
+        },
         mcp_utils::ensure_request_mcp_client,
         persistence_utils::persist_conversation_items,
     },
@@ -76,7 +78,8 @@ pub async fn handle_non_streaming_response(mut ctx: RequestContext) -> Response 
             .request_id
             .clone()
             .unwrap_or_else(|| format!("req_{}", uuid::Uuid::now_v7()));
-        let forwarded_headers = extract_forwardable_request_headers(ctx.headers());
+        let mut forwarded_headers = extract_forwardable_request_headers(ctx.headers());
+        forwarded_headers.extend(extract_mcp_forward_headers(ctx.headers()));
         let mut session = McpToolSession::new_with_headers(
             mcp_orchestrator,
             mcp_servers,

--- a/model_gateway/src/routers/openai/responses/non_streaming.rs
+++ b/model_gateway/src/routers/openai/responses/non_streaming.rs
@@ -14,9 +14,7 @@ use tracing::warn;
 use super::utils::{patch_response_with_request_metadata, restore_original_tools};
 use crate::routers::{
     common::{
-        header_utils::{
-            extract_forwardable_request_headers, extract_mcp_forward_headers, ApiProvider,
-        },
+        header_utils::{extract_mcp_forward_headers, ApiProvider},
         mcp_utils::ensure_request_mcp_client,
         persistence_utils::persist_conversation_items,
     },
@@ -78,13 +76,12 @@ pub async fn handle_non_streaming_response(mut ctx: RequestContext) -> Response 
             .request_id
             .clone()
             .unwrap_or_else(|| format!("req_{}", uuid::Uuid::now_v7()));
-        let mut forwarded_headers = extract_forwardable_request_headers(ctx.headers());
-        forwarded_headers.extend(extract_mcp_forward_headers(ctx.headers()));
+        let mcp_headers = extract_mcp_forward_headers(ctx.headers());
         let mut session = McpToolSession::new_with_headers(
             mcp_orchestrator,
             mcp_servers,
             &session_request_id,
-            forwarded_headers,
+            mcp_headers,
         );
         if let Some(tools) = original_body.tools.as_deref() {
             session.configure_response_tools_approval(tools);

--- a/model_gateway/src/routers/openai/responses/streaming.rs
+++ b/model_gateway/src/routers/openai/responses/streaming.rs
@@ -47,7 +47,8 @@ use crate::{
     routers::{
         common::{
             header_utils::{
-                extract_forwardable_request_headers, preserve_response_headers, ApiProvider,
+                extract_forwardable_request_headers, extract_mcp_forward_headers,
+                preserve_response_headers, ApiProvider,
             },
             mcp_utils::DEFAULT_MAX_ITERATIONS,
             persistence_utils::persist_conversation_items,
@@ -691,7 +692,8 @@ pub(super) fn handle_streaming_with_tool_interception(
     let headers_opt = headers.cloned();
     let payload_clone = payload.clone();
     let orchestrator_clone = Arc::clone(orchestrator);
-    let forwarded_headers = extract_forwardable_request_headers(headers);
+    let mut forwarded_headers = extract_forwardable_request_headers(headers);
+    forwarded_headers.extend(extract_mcp_forward_headers(headers));
 
     #[expect(
         clippy::disallowed_methods,

--- a/model_gateway/src/routers/openai/responses/streaming.rs
+++ b/model_gateway/src/routers/openai/responses/streaming.rs
@@ -46,10 +46,7 @@ use crate::{
     observability::metrics::Metrics,
     routers::{
         common::{
-            header_utils::{
-                extract_forwardable_request_headers, extract_mcp_forward_headers,
-                preserve_response_headers, ApiProvider,
-            },
+            header_utils::{extract_mcp_forward_headers, preserve_response_headers, ApiProvider},
             mcp_utils::DEFAULT_MAX_ITERATIONS,
             persistence_utils::persist_conversation_items,
         },
@@ -692,8 +689,7 @@ pub(super) fn handle_streaming_with_tool_interception(
     let headers_opt = headers.cloned();
     let payload_clone = payload.clone();
     let orchestrator_clone = Arc::clone(orchestrator);
-    let mut forwarded_headers = extract_forwardable_request_headers(headers);
-    forwarded_headers.extend(extract_mcp_forward_headers(headers));
+    let forwarded_headers = extract_mcp_forward_headers(headers);
 
     #[expect(
         clippy::disallowed_methods,


### PR DESCRIPTION
## Summary

MCP tool calls previously had no mechanism to receive per-request headers like OCI delegation tokens from the incoming gateway request. This change introduces header forwarding to MCP tool calls by embedding custom headers in the JSON-RPC `_meta.extra_headers` field of the `tools/call` request.

## What changed

**`model_gateway/src/routers/common/header_utils.rs`**

- Added `extract_mcp_forward_headers()` — extracts only MCP-specific headers (`x-smg-oci-delegation-token`, `x-smg-oci-compartment-id`) from incoming requests.
- Refactored shared iteration logic into a private `extract_headers_matching()` helper used by both `extract_forwardable_request_headers()` and `extract_mcp_forward_headers()`.
- `extract_forwardable_request_headers()` no longer includes MCP-specific headers, keeping them out of LLM provider calls.

**`model_gateway/src/routers/openai/responses/non_streaming.rs`**
**`model_gateway/src/routers/openai/responses/streaming.rs`**

- At MCP session creation, MCP-specific headers are extracted separately via `extract_mcp_forward_headers()` and merged into the forwarded headers map before passing to `McpToolSession`.

**`crates/mcp/src/core/orchestrator.rs`**

- `call_tool_on_peer()` embeds forwarded headers in `_meta.extra_headers` of the JSON-RPC `tools/call` request using rmcp's `send_request_with_option` API.

**`crates/mcp/src/core/handler.rs`** / **`crates/mcp/src/core/session.rs`**

- `HandlerRequestContext` and `McpToolSession` carry `forwarded_headers` through the call chain from the router layer to the orchestrator.

## Why

OCI-backed MCP servers require per-request headers such as `x-smg-oci-delegation-token` and `x-smg-oci-compartment-id` to authorize tool execution on behalf of the caller. Without this change, these headers were not forwarded to MCP tool calls and the MCP server had no way to receive them.

These headers are specific to MCP tool calls and must not be sent to LLM providers (OpenAI, Anthropic, etc.), so they need a dedicated extraction path separate from the general header forwarding used for tracing, auth, and routing.

## How

Headers flow through the system as follows:

1. An incoming request arrives at the gateway with `x-smg-oci-delegation-token` and/or `x-smg-oci-compartment-id` headers.
2. The response handler (streaming or non-streaming) calls `extract_mcp_forward_headers()` to extract only MCP-specific headers, and merges them with the general forwarded headers.
3. The merged map is passed to `McpToolSession::new_with_headers()`, which stores it on the session.
4. When a tool call is executed, the session creates an `McpRequestContext` carrying the `forwarded_headers`.
5. The orchestrator's `call_tool_on_peer()` checks for non-empty forwarded headers and, when present, constructs a `PeerRequestOptions` with `meta: Some(Meta({ "extra_headers": { ... } }))`.
6. It calls `peer.send_request_with_option()` instead of `peer.call_tool()`, embedding the headers in the JSON-RPC `_meta` field of the `tools/call` request.
7. The downstream MCP server reads the headers from `_meta.extra_headers` in the protocol message.

This approach keeps header forwarding at the JSON-RPC protocol level rather than the HTTP transport layer. Because the headers are part of the message payload, there is no shared mutable state, no race conditions, and concurrent tool calls to the same server execute without serialization.

## Test plan

- [x] `cargo test -p smg --lib header_utils` — 23 unit tests pass, including:
  - `test_extract_mcp_forward_headers` — verifies only OCI headers are returned
  - `test_extract_mcp_forward_headers_empty_when_none` — verifies empty/None handling
  - `test_extract_forwardable_excludes_mcp_only_headers` — verifies OCI headers are excluded from general extraction
  - `test_is_mcp_forward_header` — verifies the MCP header filter
  - `test_should_forward_request_header_blocked` — verifies OCI headers are not in the general forwarding allowlist
- [x] `cargo test -p smg-mcp` — 201 unit tests pass, including `test_session_preserves_forwarded_headers_in_request_context`
- [x] Manual verification: MCP tool calls to an OCI-backed MCP server receive the delegation token in `_meta.extra_headers`
- [x] Manual verification: LLM provider calls (OpenAI, Anthropic, etc.) do not contain `x-smg-oci-*` headers

## Verification

1. Executed file search tool and ensured the request is successful

<img width="1933" height="734" alt="Screenshot 2026-04-29 at 6 00 23 PM" src="https://github.com/user-attachments/assets/597c5ef8-b704-4191-a08c-a4fd7e6a8668" />

2. Executed regular responses API call and ensured it was sucessful.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File Search is now supported as a built-in MCP tool

* **Enhancements**
  * Tool execution now forwards request headers/tokens through approval and peer calls for richer request context
  * Header forwarding logic split into general and MCP-specific sets for clearer, safer propagation
  * File-search result parsing made more consistent and robust

* **Tests**
  * Updated/expanded tests for header extraction and forwarding behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->