### PR TITLE
feat(py-bindings): add Python Tokenizer binding

### DIFF
--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -32,6 +32,9 @@ workspace = true
 [dependencies.reasoning-parser]
 workspace = true
 
+[dependencies.llm-tokenizer]
+workspace = true
+
 [features]
 default = ["pyo3/extension-module"]
 vendored-openssl = ["smg/vendored-openssl"]

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -35,6 +35,9 @@ workspace = true
 [dependencies.llm-tokenizer]
 workspace = true
 
+[dependencies.serde_json]
+workspace = true
+
 [features]
 default = ["pyo3/extension-module"]
 vendored-openssl = ["smg/vendored-openssl"]

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -123,3 +123,13 @@ prompt = tok.apply_chat_template(
 ```
 
 `Tokenizer` mirrors the Go SDK's `sgl_tokenizer_*` FFI surface (`bindings/golang/src/tokenizer.rs`). Errors are raised as `ValueError` (invalid arguments) or `RuntimeError` (tokenizer failures).
+
+### Parity tests vs tokenspeed
+
+Diff tests in `tests/diff_tokenspeed/` validate that `smg.Tokenizer` produces equivalent output to tokenspeed's `get_tokenizer()`. They are skipped by default. To run them:
+
+````bash
+pip install -e /path/to/tokenspeed
+cd bindings/python
+python -m pytest tests/diff_tokenspeed/ -v
+````

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -92,3 +92,34 @@ pip install dist/smg-*.whl
 cd smg/bindings/python
 pytest tests/
 ```
+
+## Tokenizer
+
+```python
+from smg import Tokenizer
+
+# Local file path or HuggingFace model id
+tok = Tokenizer.from_file("Qwen/Qwen2.5-0.5B-Instruct")
+
+ids = tok.encode("hello world")
+text = tok.decode(ids)
+
+prompt = tok.apply_chat_template(
+    [
+        {"role": "user", "content": "What is 2 + 2?"},
+    ],
+    tools=[
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get weather",
+                "parameters": {"type": "object", "properties": {"city": {"type": "string"}}},
+            },
+        }
+    ],
+    add_generation_prompt=True,
+)
+```
+
+`Tokenizer` mirrors the Go SDK's `sgl_tokenizer_*` FFI surface (`bindings/golang/src/tokenizer.rs`). Errors are raised as `ValueError` (invalid arguments) or `RuntimeError` (tokenizer failures).

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -130,6 +130,6 @@ Diff tests in `tests/diff_tokenspeed/` validate that `smg.Tokenizer` produces eq
 
 ````bash
 pip install -e /path/to/tokenspeed
-cd bindings/python
+cd smg/bindings/python
 python -m pytest tests/diff_tokenspeed/ -v
 ````

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -39,6 +39,7 @@ dev = [
     "requests>=2.25.0",
     "ruff",
     "pytest>=7.0.0",
+    "huggingface_hub",
 ]
 
 [project.scripts]

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -5,6 +5,9 @@ use pyo3::prelude::*;
 use smg::*;
 use smg_auth as auth;
 
+mod tokenizer;
+use tokenizer::PyTokenizer;
+
 // Define the enums with PyO3 bindings
 #[pyclass(eq, from_py_object)]
 #[derive(Clone, PartialEq, Debug)]
@@ -1269,6 +1272,7 @@ fn smg_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyPostgresConfig>()?;
     m.add_class::<PyRedisConfig>()?;
     m.add_class::<Router>()?;
+    m.add_class::<PyTokenizer>()?;
     m.add_function(wrap_pyfunction!(get_version_string, m)?)?;
     m.add_function(wrap_pyfunction!(get_verbose_version_string, m)?)?;
     m.add_function(wrap_pyfunction!(print_banner, m)?)?;

--- a/bindings/python/src/smg/__init__.py
+++ b/bindings/python/src/smg/__init__.py
@@ -1,3 +1,4 @@
+from smg.smg_rs import Tokenizer
 from smg.version import __version__
 
-__all__ = ["__version__"]
+__all__ = ["Tokenizer", "__version__"]

--- a/bindings/python/src/tokenizer.rs
+++ b/bindings/python/src/tokenizer.rs
@@ -6,9 +6,11 @@
 
 use std::sync::Arc;
 
+use llm_tokenizer::chat_template::ChatTemplateParams;
 use llm_tokenizer::traits::Tokenizer as TokenizerTrait;
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
+use serde_json::Value;
 
 /// Python-facing tokenizer handle.
 ///
@@ -69,7 +71,68 @@ impl PyTokenizer {
             .map_err(|e| PyRuntimeError::new_err(format!("decode failed: {e}")))
     }
 
+    /// Apply the tokenizer's chat template to a list of messages.
+    ///
+    /// `messages` is a list of dicts (e.g. `[{"role": "user", "content": "..."}]`).
+    /// `tools`, when provided, is a list of OpenAI-style tool dicts that the
+    /// chat template can render into the prompt.
+    ///
+    /// `add_generation_prompt` defaults to true (matches HuggingFace and
+    /// SGLang/vLLM convention for serving).
+    #[pyo3(signature = (messages, tools = None, add_generation_prompt = true))]
+    fn apply_chat_template(
+        &self,
+        messages: &Bound<'_, PyAny>,
+        tools: Option<&Bound<'_, PyAny>>,
+        add_generation_prompt: bool,
+    ) -> PyResult<String> {
+        let messages_value = py_to_json(messages)?;
+        let messages_vec: Vec<Value> = match messages_value {
+            Value::Array(arr) => arr,
+            _ => {
+                return Err(PyValueError::new_err(
+                    "messages must be a list of message dicts",
+                ));
+            }
+        };
+
+        let tools_vec: Vec<Value> = match tools {
+            None => Vec::new(),
+            Some(t) => match py_to_json(t)? {
+                Value::Array(arr) => arr,
+                _ => {
+                    return Err(PyValueError::new_err("tools must be a list of tool dicts"));
+                }
+            },
+        };
+        let empty_docs: [Value; 0] = [];
+
+        let params = ChatTemplateParams {
+            add_generation_prompt,
+            tools: Some(&tools_vec),
+            documents: Some(&empty_docs),
+            template_kwargs: None,
+            ..Default::default()
+        };
+
+        self.inner
+            .apply_chat_template(&messages_vec, params)
+            .map_err(|e| PyRuntimeError::new_err(format!("apply_chat_template failed: {e}")))
+    }
+
     fn __repr__(&self) -> String {
         format!("Tokenizer(vocab_size={})", self.inner.vocab_size())
     }
+}
+
+/// Convert a Python object (dict, list, etc.) to `serde_json::Value` by going
+/// through Python's JSON serializer. This is the simplest correct way to
+/// bridge arbitrary nested Python data to serde without writing a custom
+/// `FromPyObject` for every shape.
+fn py_to_json(obj: &Bound<'_, PyAny>) -> PyResult<Value> {
+    let py = obj.py();
+    let json = py.import("json")?;
+    let s: String = json.call_method1("dumps", (obj,))?.extract()?;
+    serde_json::from_str(&s)
+        .map_err(|e| PyValueError::new_err(format!("failed to convert Python object to JSON: {e}")))
 }

--- a/bindings/python/src/tokenizer.rs
+++ b/bindings/python/src/tokenizer.rs
@@ -7,7 +7,7 @@
 use std::sync::Arc;
 
 use llm_tokenizer::traits::Tokenizer as TokenizerTrait;
-use pyo3::exceptions::PyValueError;
+use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 
 /// Python-facing tokenizer handle.
@@ -40,6 +40,19 @@ impl PyTokenizer {
             PyValueError::new_err(format!("failed to load tokenizer from {path}: {e}"))
         })?;
         Ok(PyTokenizer { inner })
+    }
+
+    /// Encode `text` to a list of token IDs.
+    ///
+    /// `add_special_tokens` controls whether the tokenizer's BOS/EOS tokens are
+    /// included; defaults to true to match the HuggingFace `__call__` default.
+    #[pyo3(signature = (text, add_special_tokens = true))]
+    fn encode(&self, text: &str, add_special_tokens: bool) -> PyResult<Vec<u32>> {
+        let encoding = self
+            .inner
+            .encode(text, add_special_tokens)
+            .map_err(|e| PyRuntimeError::new_err(format!("encode failed: {e}")))?;
+        Ok(encoding.token_ids().to_vec())
     }
 
     fn __repr__(&self) -> String {

--- a/bindings/python/src/tokenizer.rs
+++ b/bindings/python/src/tokenizer.rs
@@ -38,10 +38,12 @@ impl PyTokenizer {
     /// `RuntimeError` on tokenizer operation failures.
     #[staticmethod]
     #[pyo3(signature = (path))]
-    fn from_file(path: &str) -> PyResult<Self> {
-        let inner = llm_tokenizer::create_tokenizer(path).map_err(|e| {
-            PyValueError::new_err(format!("failed to load tokenizer from {path}: {e}"))
-        })?;
+    fn from_file(py: Python<'_>, path: &str) -> PyResult<Self> {
+        let inner = py
+            .detach(|| llm_tokenizer::create_tokenizer(path))
+            .map_err(|e| {
+                PyValueError::new_err(format!("failed to load tokenizer from {path}: {e}"))
+            })?;
         Ok(PyTokenizer { inner })
     }
 
@@ -50,10 +52,9 @@ impl PyTokenizer {
     /// `add_special_tokens` controls whether the tokenizer's BOS/EOS tokens are
     /// included; defaults to true to match the HuggingFace `__call__` default.
     #[pyo3(signature = (text, add_special_tokens = true))]
-    fn encode(&self, text: &str, add_special_tokens: bool) -> PyResult<Vec<u32>> {
-        let encoding = self
-            .inner
-            .encode(text, add_special_tokens)
+    fn encode(&self, py: Python<'_>, text: &str, add_special_tokens: bool) -> PyResult<Vec<u32>> {
+        let encoding = py
+            .detach(|| self.inner.encode(text, add_special_tokens))
             .map_err(|e| PyRuntimeError::new_err(format!("encode failed: {e}")))?;
         Ok(encoding.token_ids().to_vec())
     }
@@ -63,12 +64,16 @@ impl PyTokenizer {
     /// `skip_special_tokens` controls whether BOS/EOS tokens are stripped from
     /// the output; defaults to true.
     #[pyo3(signature = (token_ids, skip_special_tokens = true))]
-    fn decode(&self, token_ids: Vec<u32>, skip_special_tokens: bool) -> PyResult<String> {
+    fn decode(
+        &self,
+        py: Python<'_>,
+        token_ids: Vec<u32>,
+        skip_special_tokens: bool,
+    ) -> PyResult<String> {
         if token_ids.is_empty() {
             return Ok(String::new());
         }
-        self.inner
-            .decode(&token_ids, skip_special_tokens)
+        py.detach(|| self.inner.decode(&token_ids, skip_special_tokens))
             .map_err(|e| PyRuntimeError::new_err(format!("decode failed: {e}")))
     }
 
@@ -76,17 +81,24 @@ impl PyTokenizer {
     ///
     /// `messages` is a list of dicts (e.g. `[{"role": "user", "content": "..."}]`).
     /// `tools`, when provided, is a list of OpenAI-style tool dicts that the
-    /// chat template can render into the prompt.
+    /// chat template can render into the prompt. When `None` (the default),
+    /// `tools` is left **undefined** in the template context so guards like
+    /// `{% if tools is defined %}` work correctly.
     ///
     /// `add_generation_prompt` defaults to true (matches HuggingFace and
     /// SGLang/vLLM convention for serving).
+    ///
+    /// The tokenizer's special tokens (`bos_token`, `eos_token`, etc.) are
+    /// always injected so templates that reference them render correctly.
     #[pyo3(signature = (messages, tools = None, add_generation_prompt = true))]
     fn apply_chat_template(
         &self,
+        py: Python<'_>,
         messages: &Bound<'_, PyAny>,
         tools: Option<&Bound<'_, PyAny>>,
         add_generation_prompt: bool,
     ) -> PyResult<String> {
+        // py_to_json must run with the GIL held.
         let messages_value = py_to_json(messages)?;
         let messages_vec: Vec<Value> = match messages_value {
             Value::Array(arr) => arr,
@@ -97,28 +109,28 @@ impl PyTokenizer {
             }
         };
 
-        let tools_vec: Vec<Value> = match tools {
-            None => Vec::new(),
+        let tools_vec: Option<Vec<Value>> = match tools {
+            None => None,
             Some(t) => match py_to_json(t)? {
-                Value::Array(arr) => arr,
+                Value::Array(arr) => Some(arr),
                 _ => {
                     return Err(PyValueError::new_err("tools must be a list of tool dicts"));
                 }
             },
         };
-        let empty_docs: [Value; 0] = [];
 
-        let params = ChatTemplateParams {
-            add_generation_prompt,
-            tools: Some(&tools_vec),
-            documents: Some(&empty_docs),
-            template_kwargs: None,
-            ..Default::default()
-        };
-
-        self.inner
-            .apply_chat_template(&messages_vec, params)
-            .map_err(|e| PyRuntimeError::new_err(format!("apply_chat_template failed: {e}")))
+        let inner = Arc::clone(&self.inner);
+        py.detach(move || {
+            let params = ChatTemplateParams {
+                add_generation_prompt,
+                tools: tools_vec.as_deref(),
+                documents: None,
+                template_kwargs: None,
+                special_tokens: Some(inner.get_special_tokens()),
+            };
+            inner.apply_chat_template(&messages_vec, params)
+        })
+        .map_err(|e| PyRuntimeError::new_err(format!("apply_chat_template failed: {e}")))
     }
 
     fn __repr__(&self) -> String {

--- a/bindings/python/src/tokenizer.rs
+++ b/bindings/python/src/tokenizer.rs
@@ -55,6 +55,20 @@ impl PyTokenizer {
         Ok(encoding.token_ids().to_vec())
     }
 
+    /// Decode a list of token IDs to text.
+    ///
+    /// `skip_special_tokens` controls whether BOS/EOS tokens are stripped from
+    /// the output; defaults to true.
+    #[pyo3(signature = (token_ids, skip_special_tokens = true))]
+    fn decode(&self, token_ids: Vec<u32>, skip_special_tokens: bool) -> PyResult<String> {
+        if token_ids.is_empty() {
+            return Ok(String::new());
+        }
+        self.inner
+            .decode(&token_ids, skip_special_tokens)
+            .map_err(|e| PyRuntimeError::new_err(format!("decode failed: {e}")))
+    }
+
     fn __repr__(&self) -> String {
         format!("Tokenizer(vocab_size={})", self.inner.vocab_size())
     }

--- a/bindings/python/src/tokenizer.rs
+++ b/bindings/python/src/tokenizer.rs
@@ -33,9 +33,9 @@ impl PyTokenizer {
     /// Otherwise it is fetched from the HuggingFace Hub (set `HF_TOKEN` env var
     /// for gated models).
     ///
-    /// All errors are currently raised as `ValueError`; future versions may
-    /// distinguish input errors (`ValueError`) from runtime/network errors
-    /// (`RuntimeError`).
+    /// `from_file` raises `ValueError` on invalid inputs (bad path, malformed
+    /// arguments). `encode`, `decode`, and `apply_chat_template` raise
+    /// `RuntimeError` on tokenizer operation failures.
     #[staticmethod]
     #[pyo3(signature = (path))]
     fn from_file(path: &str) -> PyResult<Self> {

--- a/bindings/python/src/tokenizer.rs
+++ b/bindings/python/src/tokenizer.rs
@@ -6,10 +6,11 @@
 
 use std::sync::Arc;
 
-use llm_tokenizer::chat_template::ChatTemplateParams;
-use llm_tokenizer::traits::Tokenizer as TokenizerTrait;
-use pyo3::exceptions::{PyRuntimeError, PyValueError};
-use pyo3::prelude::*;
+use llm_tokenizer::{chat_template::ChatTemplateParams, traits::Tokenizer as TokenizerTrait};
+use pyo3::{
+    exceptions::{PyRuntimeError, PyValueError},
+    prelude::*,
+};
 use serde_json::Value;
 
 /// Python-facing tokenizer handle.

--- a/bindings/python/src/tokenizer.rs
+++ b/bindings/python/src/tokenizer.rs
@@ -1,0 +1,48 @@
+//! PyO3 bindings for the `llm-tokenizer` crate.
+//!
+//! Mirrors the semantics of `bindings/golang/src/tokenizer.rs`, exposed as a
+//! Python class with PyO3 idioms (exceptions instead of error codes,
+//! lifetime via `Drop` instead of explicit `_free` calls).
+
+use std::sync::Arc;
+
+use llm_tokenizer::traits::Tokenizer as TokenizerTrait;
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+
+/// Python-facing tokenizer handle.
+///
+/// Wraps `Arc<dyn llm_tokenizer::traits::Tokenizer>`. Constructed via
+/// `Tokenizer.from_file(path)`. Supports `encode`, `decode`, `apply_chat_template`.
+// The Python-facing name strips the `Py` prefix (`Tokenizer`, not
+// `PyTokenizer`). This is the convention for new bindings modules; older
+// classes in `lib.rs` (e.g. `PyRole`, `PyOracleConfig`) predate it.
+#[pyclass(name = "Tokenizer", module = "smg_rs")]
+pub struct PyTokenizer {
+    inner: Arc<dyn TokenizerTrait>,
+}
+
+#[pymethods]
+impl PyTokenizer {
+    /// Create a tokenizer from a local file path or HuggingFace model ID.
+    ///
+    /// If `path` is a local path, the tokenizer is loaded from disk.
+    /// Otherwise it is fetched from the HuggingFace Hub (set `HF_TOKEN` env var
+    /// for gated models).
+    ///
+    /// All errors are currently raised as `ValueError`; future versions may
+    /// distinguish input errors (`ValueError`) from runtime/network errors
+    /// (`RuntimeError`).
+    #[staticmethod]
+    #[pyo3(signature = (path))]
+    fn from_file(path: &str) -> PyResult<Self> {
+        let inner = llm_tokenizer::create_tokenizer(path).map_err(|e| {
+            PyValueError::new_err(format!("failed to load tokenizer from {path}: {e}"))
+        })?;
+        Ok(PyTokenizer { inner })
+    }
+
+    fn __repr__(&self) -> String {
+        format!("Tokenizer(vocab_size={})", self.inner.vocab_size())
+    }
+}

--- a/bindings/python/tests/conftest.py
+++ b/bindings/python/tests/conftest.py
@@ -4,7 +4,29 @@ Pytest configuration for smg Python binding tests.
 These are unit tests that run without GPU resources or external dependencies.
 """
 
+import pytest
+
 
 def pytest_configure(config):
     """Configure pytest markers."""
     config.addinivalue_line("markers", "unit: mark test as a unit test (no GPU required)")
+
+
+@pytest.fixture(scope="session")
+def hf_tokenizer_path(tmp_path_factory) -> str:
+    """Download a small public HF tokenizer for tests; cache for the whole session.
+
+    Uses Qwen/Qwen2.5-0.5B-Instruct (~1MB tokenizer files; supports chat template + tools).
+    Returns a path that `smg.Tokenizer.from_file` can accept.
+    """
+    try:
+        from huggingface_hub import snapshot_download
+    except ImportError:
+        pytest.skip("huggingface_hub not installed; required for tokenizer tests")
+
+    target = tmp_path_factory.mktemp("hf_tokenizer")
+    return snapshot_download(
+        repo_id="Qwen/Qwen2.5-0.5B-Instruct",
+        local_dir=str(target),
+        allow_patterns=["tokenizer*", "special_tokens_map.json", "vocab.json", "merges.txt"],
+    )

--- a/bindings/python/tests/conftest.py
+++ b/bindings/python/tests/conftest.py
@@ -10,6 +10,7 @@ import pytest
 def pytest_configure(config):
     """Configure pytest markers."""
     config.addinivalue_line("markers", "unit: mark test as a unit test (no GPU required)")
+    config.addinivalue_line("markers", "diff_tokenspeed: mark test as a tokenspeed parity test")
 
 
 @pytest.fixture(scope="session")

--- a/bindings/python/tests/conftest.py
+++ b/bindings/python/tests/conftest.py
@@ -19,6 +19,9 @@ def hf_tokenizer_path(tmp_path_factory) -> str:
 
     Uses Qwen/Qwen2.5-0.5B-Instruct (~1MB tokenizer files; supports chat template + tools).
     Returns a path that `smg.Tokenizer.from_file` can accept.
+
+    Skips the test gracefully if huggingface_hub is unavailable or the network
+    is unreachable so the unit-test suite stays hermetic in offline CI.
     """
     try:
         from huggingface_hub import snapshot_download
@@ -26,8 +29,11 @@ def hf_tokenizer_path(tmp_path_factory) -> str:
         pytest.skip("huggingface_hub not installed; required for tokenizer tests")
 
     target = tmp_path_factory.mktemp("hf_tokenizer")
-    return snapshot_download(
-        repo_id="Qwen/Qwen2.5-0.5B-Instruct",
-        local_dir=str(target),
-        allow_patterns=["tokenizer*", "special_tokens_map.json", "vocab.json", "merges.txt"],
-    )
+    try:
+        return snapshot_download(
+            repo_id="Qwen/Qwen2.5-0.5B-Instruct",
+            local_dir=str(target),
+            allow_patterns=["tokenizer*", "special_tokens_map.json", "vocab.json", "merges.txt"],
+        )
+    except Exception as e:
+        pytest.skip(f"could not download tokenizer fixture (offline CI?): {e}")

--- a/bindings/python/tests/diff_tokenspeed/conftest.py
+++ b/bindings/python/tests/diff_tokenspeed/conftest.py
@@ -3,8 +3,6 @@
 Skipped automatically if tokenspeed is not importable.
 """
 
-from pathlib import Path
-
 import pytest
 
 try:
@@ -14,22 +12,10 @@ except ImportError:
     HAS_TOKENSPEED = False
 
 
-_DIFF_DIR = Path(__file__).parent.resolve()
-
-
 def pytest_collection_modifyitems(config, items):
     if HAS_TOKENSPEED:
         return
     skip_marker = pytest.mark.skip(reason="tokenspeed not installed; install for parity tests")
     for item in items:
-        # Only skip tests that live under this diff_tokenspeed directory; the hook is
-        # invoked globally even though it's defined in a sub-conftest.
-        try:
-            item_path = Path(str(item.fspath)).resolve()
-        except Exception:
-            continue
-        try:
-            item_path.relative_to(_DIFF_DIR)
-        except ValueError:
-            continue
-        item.add_marker(skip_marker)
+        if "diff_tokenspeed" in item.keywords:
+            item.add_marker(skip_marker)

--- a/bindings/python/tests/diff_tokenspeed/conftest.py
+++ b/bindings/python/tests/diff_tokenspeed/conftest.py
@@ -1,0 +1,35 @@
+"""Diff-test infrastructure: validates smg parsers/tokenizer match tokenspeed.
+
+Skipped automatically if tokenspeed is not importable.
+"""
+
+from pathlib import Path
+
+import pytest
+
+try:
+    import tokenspeed  # noqa: F401
+    HAS_TOKENSPEED = True
+except ImportError:
+    HAS_TOKENSPEED = False
+
+
+_DIFF_DIR = Path(__file__).parent.resolve()
+
+
+def pytest_collection_modifyitems(config, items):
+    if HAS_TOKENSPEED:
+        return
+    skip_marker = pytest.mark.skip(reason="tokenspeed not installed; install for parity tests")
+    for item in items:
+        # Only skip tests that live under this diff_tokenspeed directory; the hook is
+        # invoked globally even though it's defined in a sub-conftest.
+        try:
+            item_path = Path(str(item.fspath)).resolve()
+        except Exception:
+            continue
+        try:
+            item_path.relative_to(_DIFF_DIR)
+        except ValueError:
+            continue
+        item.add_marker(skip_marker)

--- a/bindings/python/tests/diff_tokenspeed/conftest.py
+++ b/bindings/python/tests/diff_tokenspeed/conftest.py
@@ -7,6 +7,7 @@ import pytest
 
 try:
     import tokenspeed  # noqa: F401
+
     HAS_TOKENSPEED = True
 except ImportError:
     HAS_TOKENSPEED = False

--- a/bindings/python/tests/diff_tokenspeed/test_tokenizer_parity.py
+++ b/bindings/python/tests/diff_tokenspeed/test_tokenizer_parity.py
@@ -1,0 +1,52 @@
+"""smg.Tokenizer vs tokenspeed.get_tokenizer parity tests."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+import smg
+
+FIXTURES = Path(__file__).parent.parent / "fixtures" / "tokenizer"
+
+
+@pytest.mark.diff_tokenspeed
+def test_apply_chat_template_matches_tokenspeed(hf_tokenizer_path):
+    """smg.Tokenizer.apply_chat_template should produce the same prompt as tokenspeed's
+    AutoTokenizer wrapper for the same input."""
+    from tokenspeed.runtime.utils.hf_transformers_utils import get_tokenizer
+
+    smg_tok = smg.Tokenizer.from_file(hf_tokenizer_path)
+    ts_tok = get_tokenizer(hf_tokenizer_path)
+
+    messages = json.loads((FIXTURES / "messages_basic.json").read_text())
+
+    smg_prompt = smg_tok.apply_chat_template(messages, add_generation_prompt=True)
+    ts_prompt = ts_tok.apply_chat_template(
+        messages, add_generation_prompt=True, tokenize=False
+    )
+
+    assert smg_prompt == ts_prompt, (
+        f"Chat-template output diverges between smg and tokenspeed:\n"
+        f"  smg: {smg_prompt!r}\n"
+        f"  tokenspeed: {ts_prompt!r}\n"
+    )
+
+
+@pytest.mark.diff_tokenspeed
+def test_encode_matches_tokenspeed(hf_tokenizer_path):
+    from tokenspeed.runtime.utils.hf_transformers_utils import get_tokenizer
+
+    smg_tok = smg.Tokenizer.from_file(hf_tokenizer_path)
+    ts_tok = get_tokenizer(hf_tokenizer_path)
+
+    text = "Hello, world! Testing parity."
+
+    smg_ids = smg_tok.encode(text, add_special_tokens=True)
+    ts_ids = ts_tok.encode(text, add_special_tokens=True)
+
+    assert smg_ids == ts_ids, (
+        f"encode diverges between smg and tokenspeed:\n"
+        f"  smg: {smg_ids[:20]}... (len={len(smg_ids)})\n"
+        f"  tokenspeed: {ts_ids[:20]}... (len={len(ts_ids)})\n"
+    )

--- a/bindings/python/tests/diff_tokenspeed/test_tokenizer_parity.py
+++ b/bindings/python/tests/diff_tokenspeed/test_tokenizer_parity.py
@@ -4,7 +4,6 @@ import json
 from pathlib import Path
 
 import pytest
-
 import smg
 
 FIXTURES = Path(__file__).parent.parent / "fixtures" / "tokenizer"
@@ -22,9 +21,7 @@ def test_apply_chat_template_matches_tokenspeed(hf_tokenizer_path):
     messages = json.loads((FIXTURES / "messages_basic.json").read_text())
 
     smg_prompt = smg_tok.apply_chat_template(messages, add_generation_prompt=True)
-    ts_prompt = ts_tok.apply_chat_template(
-        messages, add_generation_prompt=True, tokenize=False
-    )
+    ts_prompt = ts_tok.apply_chat_template(messages, add_generation_prompt=True, tokenize=False)
 
     assert smg_prompt == ts_prompt, (
         f"Chat-template output diverges between smg and tokenspeed:\n"

--- a/bindings/python/tests/fixtures/tokenizer/messages_basic.json
+++ b/bindings/python/tests/fixtures/tokenizer/messages_basic.json
@@ -1,0 +1,4 @@
+[
+  {"role": "system", "content": "You are a helpful assistant."},
+  {"role": "user", "content": "What is 2 + 2?"}
+]

--- a/bindings/python/tests/fixtures/tokenizer/messages_with_tools.json
+++ b/bindings/python/tests/fixtures/tokenizer/messages_with_tools.json
@@ -1,0 +1,22 @@
+{
+  "messages": [
+    {"role": "system", "content": "You can call tools when helpful."},
+    {"role": "user", "content": "What is the weather in Paris?"}
+  ],
+  "tools": [
+    {
+      "type": "function",
+      "function": {
+        "name": "get_weather",
+        "description": "Get current weather for a city",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "city": {"type": "string", "description": "City name"}
+          },
+          "required": ["city"]
+        }
+      }
+    }
+  ]
+}

--- a/bindings/python/tests/test_tokenizer.py
+++ b/bindings/python/tests/test_tokenizer.py
@@ -117,3 +117,18 @@ def test_apply_chat_template_with_tools(hf_tokenizer_path):
     # this assertion would need adjustment - Qwen2.5-Instruct does honor tools.
     assert prompt_with_tools != prompt_no_tools
     assert "get_weather" in prompt_with_tools
+
+
+@pytest.mark.unit
+def test_apply_chat_template_without_generation_prompt(hf_tokenizer_path):
+    """add_generation_prompt=False should NOT append the assistant turn header."""
+    tok = smg.Tokenizer.from_file(hf_tokenizer_path)
+    messages = json.loads((FIXTURES / "messages_basic.json").read_text())
+
+    with_prompt = tok.apply_chat_template(messages, add_generation_prompt=True)
+    without_prompt = tok.apply_chat_template(messages, add_generation_prompt=False)
+
+    # The "with generation prompt" version should be at least as long as without.
+    assert len(with_prompt) >= len(without_prompt)
+    # And the additional content should not be present in the without version.
+    assert with_prompt != without_prompt

--- a/bindings/python/tests/test_tokenizer.py
+++ b/bindings/python/tests/test_tokenizer.py
@@ -1,8 +1,13 @@
 """Tests for smg.Tokenizer PyO3 binding."""
 
+import json
+from pathlib import Path
+
 import pytest
 
 from smg import smg_rs as smg
+
+FIXTURES = Path(__file__).parent / "fixtures" / "tokenizer"
 
 
 @pytest.mark.unit
@@ -81,3 +86,19 @@ def test_decode_skip_special_tokens_flag(hf_tokenizer_path):
     kept = tok.decode(ids, skip_special_tokens=False)
     skipped = tok.decode(ids, skip_special_tokens=True)
     assert len(kept) >= len(skipped)
+
+
+@pytest.mark.unit
+def test_apply_chat_template_basic(hf_tokenizer_path):
+    tok = smg.Tokenizer.from_file(hf_tokenizer_path)
+    messages = json.loads((FIXTURES / "messages_basic.json").read_text())
+
+    prompt = tok.apply_chat_template(messages)
+
+    assert isinstance(prompt, str)
+    assert len(prompt) > 0
+    assert "helpful assistant" in prompt
+    assert "2 + 2" in prompt
+    # The template must have added a generation prompt suffix (e.g. "<|im_start|>assistant\n" for Qwen).
+    # Check it ends with something non-empty after the user message.
+    assert "user" not in prompt.split("assistant")[-1].lower() or "assistant" in prompt

--- a/bindings/python/tests/test_tokenizer.py
+++ b/bindings/python/tests/test_tokenizer.py
@@ -26,8 +26,8 @@ def test_from_file_constructs_tokenizer(hf_tokenizer_path):
 
 @pytest.mark.unit
 def test_from_file_rejects_invalid_path():
-    """from_file should raise on input that's neither a valid path nor a real HF repo."""
-    with pytest.raises((ValueError, RuntimeError)) as exc:
+    """from_file should raise ValueError on input that's neither a valid path nor a real HF repo."""
+    with pytest.raises(ValueError) as exc:
         smg.Tokenizer.from_file("/this/path/does/not/exist/tokenizer.json")
     msg = str(exc.value).lower()
     # Either path-not-found OR HF Hub repo-not-found / 404 messages should match.

--- a/bindings/python/tests/test_tokenizer.py
+++ b/bindings/python/tests/test_tokenizer.py
@@ -98,9 +98,6 @@ def test_apply_chat_template_basic(hf_tokenizer_path):
     assert len(prompt) > 0
     assert "helpful assistant" in prompt
     assert "2 + 2" in prompt
-    # The template must have added a generation prompt suffix (e.g. "<|im_start|>assistant\n" for Qwen).
-    # Check it ends with something non-empty after the user message.
-    assert "user" not in prompt.split("assistant")[-1].lower() or "assistant" in prompt
 
 
 @pytest.mark.unit

--- a/bindings/python/tests/test_tokenizer.py
+++ b/bindings/python/tests/test_tokenizer.py
@@ -4,7 +4,6 @@ import json
 from pathlib import Path
 
 import pytest
-
 from smg import smg_rs as smg
 
 FIXTURES = Path(__file__).parent / "fixtures" / "tokenizer"

--- a/bindings/python/tests/test_tokenizer.py
+++ b/bindings/python/tests/test_tokenizer.py
@@ -55,3 +55,29 @@ def test_encode_empty_string_succeeds(hf_tokenizer_path):
     tok = smg.Tokenizer.from_file(hf_tokenizer_path)
     ids = tok.encode("", add_special_tokens=False)
     assert isinstance(ids, list)
+
+
+@pytest.mark.unit
+def test_decode_round_trips(hf_tokenizer_path):
+    """encode followed by decode should recover the original text (modulo whitespace/specials)."""
+    tok = smg.Tokenizer.from_file(hf_tokenizer_path)
+    text = "hello world, this is a test."
+    ids = tok.encode(text, add_special_tokens=False)
+    out = tok.decode(ids, skip_special_tokens=True)
+    assert out.strip() == text.strip()
+
+
+@pytest.mark.unit
+def test_decode_empty_list_returns_empty_string(hf_tokenizer_path):
+    tok = smg.Tokenizer.from_file(hf_tokenizer_path)
+    assert tok.decode([], skip_special_tokens=True) == ""
+
+
+@pytest.mark.unit
+def test_decode_skip_special_tokens_flag(hf_tokenizer_path):
+    """skip_special_tokens=False should produce output at least as long as True."""
+    tok = smg.Tokenizer.from_file(hf_tokenizer_path)
+    ids = tok.encode("hi", add_special_tokens=True)
+    kept = tok.decode(ids, skip_special_tokens=False)
+    skipped = tok.decode(ids, skip_special_tokens=True)
+    assert len(kept) >= len(skipped)

--- a/bindings/python/tests/test_tokenizer.py
+++ b/bindings/python/tests/test_tokenizer.py
@@ -131,3 +131,13 @@ def test_apply_chat_template_without_generation_prompt(hf_tokenizer_path):
     assert len(with_prompt) >= len(without_prompt)
     # And the additional content should not be present in the without version.
     assert with_prompt != without_prompt
+
+
+@pytest.mark.unit
+def test_public_smg_export(hf_tokenizer_path):
+    """smg.Tokenizer should be the same class as smg.smg_rs.Tokenizer."""
+    import smg as smg_pkg
+
+    assert smg_pkg.Tokenizer is smg.Tokenizer
+    tok = smg_pkg.Tokenizer.from_file(hf_tokenizer_path)
+    assert "Tokenizer" in repr(tok)

--- a/bindings/python/tests/test_tokenizer.py
+++ b/bindings/python/tests/test_tokenizer.py
@@ -29,3 +29,29 @@ def test_from_file_rejects_invalid_path():
     # Either path-not-found OR HF Hub repo-not-found / 404 messages should match.
     expected = ("tokenizer", "not found", "exist", "no such file", "404", "repo", "repository")
     assert any(token in msg for token in expected), f"unexpected error message: {msg!r}"
+
+
+@pytest.mark.unit
+def test_encode_returns_list_of_ints(hf_tokenizer_path):
+    tok = smg.Tokenizer.from_file(hf_tokenizer_path)
+    ids = tok.encode("hello world")
+    assert isinstance(ids, list)
+    assert len(ids) > 0
+    assert all(isinstance(x, int) for x in ids)
+
+
+@pytest.mark.unit
+def test_encode_with_special_tokens_differs(hf_tokenizer_path):
+    tok = smg.Tokenizer.from_file(hf_tokenizer_path)
+    with_special = tok.encode("hello", add_special_tokens=True)
+    without_special = tok.encode("hello", add_special_tokens=False)
+    # With special tokens enabled, the result must be at least as long as without.
+    # On most tokenizers it differs; on some (rare) it may match, so we use >=.
+    assert len(with_special) >= len(without_special)
+
+
+@pytest.mark.unit
+def test_encode_empty_string_succeeds(hf_tokenizer_path):
+    tok = smg.Tokenizer.from_file(hf_tokenizer_path)
+    ids = tok.encode("", add_special_tokens=False)
+    assert isinstance(ids, list)

--- a/bindings/python/tests/test_tokenizer.py
+++ b/bindings/python/tests/test_tokenizer.py
@@ -102,3 +102,18 @@ def test_apply_chat_template_basic(hf_tokenizer_path):
     # The template must have added a generation prompt suffix (e.g. "<|im_start|>assistant\n" for Qwen).
     # Check it ends with something non-empty after the user message.
     assert "user" not in prompt.split("assistant")[-1].lower() or "assistant" in prompt
+
+
+@pytest.mark.unit
+def test_apply_chat_template_with_tools(hf_tokenizer_path):
+    tok = smg.Tokenizer.from_file(hf_tokenizer_path)
+    fixture = json.loads((FIXTURES / "messages_with_tools.json").read_text())
+
+    prompt_no_tools = tok.apply_chat_template(fixture["messages"])
+    prompt_with_tools = tok.apply_chat_template(fixture["messages"], tools=fixture["tools"])
+
+    # When tools are passed, the rendered prompt should differ from the no-tools version
+    # (the chat template injects tool descriptions). For tokenizers that ignore tools,
+    # this assertion would need adjustment - Qwen2.5-Instruct does honor tools.
+    assert prompt_with_tools != prompt_no_tools
+    assert "get_weather" in prompt_with_tools

--- a/bindings/python/tests/test_tokenizer.py
+++ b/bindings/python/tests/test_tokenizer.py
@@ -1,0 +1,31 @@
+"""Tests for smg.Tokenizer PyO3 binding."""
+
+import pytest
+
+from smg import smg_rs as smg
+
+
+@pytest.mark.unit
+def test_tokenizer_class_exists():
+    """The Tokenizer class must be exported from the smg_rs module."""
+    assert hasattr(smg, "Tokenizer")
+    assert callable(smg.Tokenizer.from_file)
+
+
+@pytest.mark.unit
+def test_from_file_constructs_tokenizer(hf_tokenizer_path):
+    """from_file should return a Tokenizer instance for a valid local path."""
+    tok = smg.Tokenizer.from_file(hf_tokenizer_path)
+    assert tok is not None
+    assert "Tokenizer" in repr(tok)
+
+
+@pytest.mark.unit
+def test_from_file_rejects_invalid_path():
+    """from_file should raise on input that's neither a valid path nor a real HF repo."""
+    with pytest.raises((ValueError, RuntimeError)) as exc:
+        smg.Tokenizer.from_file("/this/path/does/not/exist/tokenizer.json")
+    msg = str(exc.value).lower()
+    # Either path-not-found OR HF Hub repo-not-found / 404 messages should match.
+    expected = ("tokenizer", "not found", "exist", "no such file", "404", "repo", "repository")
+    assert any(token in msg for token in expected), f"unexpected error message: {msg!r}"


### PR DESCRIPTION
## Description

### Problem

SMG's `llm-tokenizer` crate cannot be consumed from Python as a library today. The existing Python binding only exposes the in-process `Router` class (which boots the full gateway via `tokio::block_on`) — there is no way for a Python application to use SMG's tokenizer directly as an SDK. The Go binding (`bindings/golang/`) already supports this SDK pattern; Python is missing the equivalent.

### Solution

Add `smg.Tokenizer` — a PyO3 class that wraps `llm_tokenizer::traits::Tokenizer` and mirrors the Go SDK's `sgl_tokenizer_*` FFI surface using PyO3 idioms (exceptions instead of error codes, `Drop` instead of explicit `_free` calls).

This is the first of five planned binding modules under the same pattern. The file layout (`bindings/python/src/<module>.rs`), `lib.rs` registration approach, test fixture conventions, and parity-diff-test infrastructure established here will be reused by tool parser, reasoning parser, preprocessor, and postprocessor binding modules.

## Changes

- New `bindings/python/src/tokenizer.rs` defines `PyTokenizer` with methods:
  - `Tokenizer.from_file(path)` — accepts local paths or HuggingFace model IDs
  - `tok.encode(text, add_special_tokens=True) -> list[int]`
  - `tok.decode(token_ids, skip_special_tokens=True) -> str`
  - `tok.apply_chat_template(messages, tools=None, add_generation_prompt=True) -> str`
  - `__repr__` returning `Tokenizer(vocab_size=N)`
- Register the class in `bindings/python/src/lib.rs` (one `mod` import + one `add_class`).
- Re-export from the top-level `smg` package (`bindings/python/src/smg/__init__.py`).
- Wire workspace dependencies: `llm-tokenizer` and `serde_json` in `bindings/python/Cargo.toml`.
- Add `huggingface_hub` to the `dev` extras in `bindings/python/pyproject.toml` for fixture downloads.
- New tests in `bindings/python/tests/test_tokenizer.py` (13 unit tests covering construction, encoding, decoding, chat templating with and without tools, the `add_generation_prompt` flag, and the public re-export).
- New parity-diff test scaffolding in `bindings/python/tests/diff_tokenspeed/` behind the `diff_tokenspeed` pytest marker; auto-skips when the external Python dependency that provides the parity reference is not installed.
- Document the API in `bindings/python/README.md`.

## Test Plan

### Build

```bash
cargo build -p smg-python
cargo clippy -p smg-python --all-targets --all-features -- -D warnings
cd bindings/python && maturin develop
```

### Unit tests

```bash
cd bindings/python && python -m pytest tests/test_tokenizer.py -v
```

Expected: 13 tests pass.

### Full suite (no regressions)

```bash
cd bindings/python && python -m pytest tests/ -v
```

Expected: 246 passed, 6 skipped (4 pre-existing + 2 parity tests skip when the optional external dep is absent).

### Smoke (manual)

```bash
cd bindings/python && python -c "
import smg
tok = smg.Tokenizer.from_file('Qwen/Qwen2.5-0.5B-Instruct')
ids = tok.encode('hello world')
print('encoded:', ids[:5], '...')
print('decoded:', tok.decode(ids))
prompt = tok.apply_chat_template([{'role': 'user', 'content': 'hi'}])
print('chat:', prompt)
print('repr:', repr(tok))
"
```

Expected: encode/decode round-trip, chat template renders, repr shows `Tokenizer(vocab_size=...)`.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Tokenizer API for encoding, decoding, and rendering chat templates (including tool/schema support).

* **Documentation**
  * Added usage examples, error-handling guidance, and instructions for optional parity testing.

* **Tests**
  * Added unit tests for tokenizer behavior and optional parity tests comparing against an external tokenizer implementation.

* **Chores**
  * Extended dev dependencies to include tooling for fetching tokenizer models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->