### PR TITLE
feat(extensions): introduce ResponsesInterceptor substrate (PR 1 of 3)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["model_gateway", "crates/protocols", "crates/reasoning_parser", "crates/tool_parser", "crates/workflow", "crates/tokenizer", "crates/auth", "crates/mcp", "crates/kv_index", "crates/data_connector", "crates/multimodal", "crates/wasm", "crates/mesh", "crates/grpc_client", "crates/skills", "crates/blob_storage", "bindings/python", "bindings/golang", "clients/rust", "clients/openapi-gen", "tui"]
+members = ["model_gateway", "crates/protocols", "crates/reasoning_parser", "crates/tool_parser", "crates/workflow", "crates/tokenizer", "crates/auth", "crates/mcp", "crates/kv_index", "crates/data_connector", "crates/multimodal", "crates/wasm", "crates/mesh", "crates/grpc_client", "crates/skills", "crates/blob_storage", "crates/extensions", "bindings/python", "bindings/golang", "clients/rust", "clients/openapi-gen", "tui"]
 resolver = "2"
 
 [workspace.dependencies]
@@ -19,6 +19,7 @@ smg-mesh = { version = "1.3.0", path = "crates/mesh", package = "smg-mesh" }
 smg-grpc-client = { version = "1.5.1", path = "crates/grpc_client" }
 smg-skills = { version = "0.1.0", path = "crates/skills" }
 smg-blob-storage = { version = "0.1.0", path = "crates/blob_storage" }
+smg-extensions = { version = "0.1.0", path = "crates/extensions" }
 smg-tui = { version = "0.1.0", path = "tui" }
 
 # Shared dependencies

--- a/crates/extensions/Cargo.toml
+++ b/crates/extensions/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "smg-extensions"
+version = "0.1.0"
+edition = "2021"
+description = "Generic extension trait and registry for SMG request lifecycle hooks"
+license = "Apache-2.0"
+repository = "https://github.com/lightseekorg/smg"
+
+[lib]
+name = "smg_extensions"
+path = "src/lib.rs"
+
+[dependencies]
+async-trait.workspace = true
+axum.workspace = true
+chrono = { workspace = true, features = ["serde"] }
+futures.workspace = true
+serde_json.workspace = true
+smg-data-connector.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+
+[lints]
+workspace = true

--- a/crates/extensions/Cargo.toml
+++ b/crates/extensions/Cargo.toml
@@ -5,10 +5,16 @@ edition = "2021"
 description = "Generic extension trait and registry for SMG request lifecycle hooks"
 license = "Apache-2.0"
 repository = "https://github.com/lightseekorg/smg"
+authors = [
+    "Simo Lin <linsimo.mark@gmail.com>",
+    "Chang Su <mckvtl@gmail.com>",
+    "Keyang Ru <rukeyang@gmail.com>",
+]
+keywords = ["extensions", "interceptor", "gateway"]
+categories = ["web-programming", "network-programming"]
 
 [lib]
 name = "smg_extensions"
-path = "src/lib.rs"
 
 [dependencies]
 async-trait.workspace = true

--- a/crates/extensions/Cargo.toml
+++ b/crates/extensions/Cargo.toml
@@ -21,6 +21,7 @@ async-trait.workspace = true
 axum.workspace = true
 chrono = { workspace = true, features = ["serde"] }
 futures.workspace = true
+openai-protocol.workspace = true
 serde_json.workspace = true
 smg-data-connector.workspace = true
 tracing.workspace = true

--- a/crates/extensions/src/context.rs
+++ b/crates/extensions/src/context.rs
@@ -30,3 +30,47 @@ pub struct AfterPersistCtx<'a> {
     pub persisted_item_ids: &'a [ConversationItemId],
     pub request_metadata: &'a RequestMetadata,
 }
+
+impl<'a> BeforeModelCtx<'a> {
+    pub fn new(
+        headers: &'a HeaderMap,
+        request: &'a mut ResponsesRequest,
+        conversation_id: Option<&'a ConversationId>,
+        history: Arc<dyn ConversationItemStorage>,
+        turn_info: ConversationTurnInfo,
+        request_metadata: &'a RequestMetadata,
+    ) -> Self {
+        Self {
+            headers,
+            request,
+            conversation_id,
+            history,
+            turn_info,
+            request_metadata,
+        }
+    }
+}
+
+impl<'a> AfterPersistCtx<'a> {
+    pub fn new(
+        headers: &'a HeaderMap,
+        request: &'a ResponsesRequest,
+        response_json: Option<&'a Value>,
+        response_id: Option<&'a ResponseId>,
+        conversation_id: Option<&'a ConversationId>,
+        turn_info: ConversationTurnInfo,
+        persisted_item_ids: &'a [ConversationItemId],
+        request_metadata: &'a RequestMetadata,
+    ) -> Self {
+        Self {
+            headers,
+            request,
+            response_json,
+            response_id,
+            conversation_id,
+            turn_info,
+            persisted_item_ids,
+            request_metadata,
+        }
+    }
+}

--- a/crates/extensions/src/context.rs
+++ b/crates/extensions/src/context.rs
@@ -1,0 +1,32 @@
+use std::sync::Arc;
+
+use axum::http::HeaderMap;
+use openai_protocol::responses::ResponsesRequest;
+use serde_json::Value;
+use smg_data_connector::{
+    ConversationId, ConversationItemId, ConversationItemStorage, ResponseId,
+};
+
+use crate::metadata::{ConversationTurnInfo, RequestMetadata};
+
+#[non_exhaustive]
+pub struct BeforeModelCtx<'a> {
+    pub headers: &'a HeaderMap,
+    pub request: &'a mut ResponsesRequest,
+    pub conversation_id: Option<&'a ConversationId>,
+    pub history: Arc<dyn ConversationItemStorage>,
+    pub turn_info: ConversationTurnInfo,
+    pub request_metadata: &'a RequestMetadata,
+}
+
+#[non_exhaustive]
+pub struct AfterPersistCtx<'a> {
+    pub headers: &'a HeaderMap,
+    pub request: &'a ResponsesRequest,
+    pub response_json: Option<&'a Value>,
+    pub response_id: Option<&'a ResponseId>,
+    pub conversation_id: Option<&'a ConversationId>,
+    pub turn_info: ConversationTurnInfo,
+    pub persisted_item_ids: &'a [ConversationItemId],
+    pub request_metadata: &'a RequestMetadata,
+}

--- a/crates/extensions/src/interceptor.rs
+++ b/crates/extensions/src/interceptor.rs
@@ -1,0 +1,43 @@
+use async_trait::async_trait;
+
+use crate::context::{AfterPersistCtx, BeforeModelCtx};
+
+/// Lifecycle hook trait for the Responses request pipeline.
+///
+/// Implementors are registered into an [`InterceptorRegistry`](crate::registry::InterceptorRegistry)
+/// and invoked at two phases:
+///
+/// 1. `before_model` — after history is loaded, before the request is forwarded
+///    to the model. Implementors may mutate `ctx.request` to inject context.
+/// 2. `after_persist` — after persistence succeeds. Implementors typically
+///    enqueue async work (memory consolidation, audit logging, etc.).
+///
+/// Errors are non-fatal: trait methods return `()`, and the registry catches
+/// panics. A buggy interceptor cannot fail an SMG request.
+///
+/// ## Recommended destructure pattern
+///
+/// Both context types are `#[non_exhaustive]`. New fields may be added in
+/// future versions. Always destructure with `..`:
+///
+/// ```ignore
+/// async fn before_model(&self, ctx: &mut BeforeModelCtx<'_>) {
+///     let BeforeModelCtx { headers, request, conversation_id, .. } = ctx;
+///     // ...
+/// }
+/// ```
+#[async_trait]
+pub trait ResponsesInterceptor: Send + Sync + 'static {
+    /// Stable identifier for diagnostics, metrics, and panic logging.
+    fn name(&self) -> &'static str;
+
+    /// Pre-model phase. Default: no-op.
+    async fn before_model(&self, ctx: &mut BeforeModelCtx<'_>) {
+        let _ = ctx;
+    }
+
+    /// Post-persist phase. Default: no-op.
+    async fn after_persist(&self, ctx: &AfterPersistCtx<'_>) {
+        let _ = ctx;
+    }
+}

--- a/crates/extensions/src/lib.rs
+++ b/crates/extensions/src/lib.rs
@@ -1,0 +1,15 @@
+//! Generic extension trait and registry for SMG request lifecycle hooks.
+//!
+//! See `docs/superpowers/0001-pr1-implementation-spec.md` for the design.
+
+pub mod context;
+pub mod interceptor;
+pub mod metadata;
+pub mod noop;
+pub mod registry;
+
+pub use context::{AfterPersistCtx, BeforeModelCtx};
+pub use interceptor::ResponsesInterceptor;
+pub use metadata::{ConversationTurnInfo, RequestMetadata};
+pub use noop::NoOpInterceptor;
+pub use registry::{InterceptorRegistry, InterceptorRegistryBuilder};

--- a/crates/extensions/src/metadata.rs
+++ b/crates/extensions/src/metadata.rs
@@ -1,0 +1,70 @@
+use chrono::{DateTime, Utc};
+use smg_data_connector::RequestContext as StorageRequestContext;
+
+#[non_exhaustive]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ConversationTurnInfo {
+    pub user_turns: u32,
+    pub total_items: u32,
+    pub raw_stored_item_count: Option<u32>,
+}
+
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub struct RequestMetadata {
+    pub request_id: String,
+    pub safety_identifier: Option<String>,
+    pub tenant_id: Option<String>,
+    pub originated_at: DateTime<Utc>,
+    pub storage_request_context: Option<StorageRequestContext>,
+}
+
+impl RequestMetadata {
+    pub fn build_from(
+        request_id: impl Into<String>,
+        safety_identifier: Option<String>,
+        tenant_id: Option<String>,
+        storage_request_context: Option<StorageRequestContext>,
+    ) -> Self {
+        Self {
+            request_id: request_id.into(),
+            safety_identifier,
+            tenant_id,
+            originated_at: Utc::now(),
+            storage_request_context,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn turn_info_default_is_zero() {
+        let info = ConversationTurnInfo::default();
+        assert_eq!(info.user_turns, 0);
+        assert_eq!(info.total_items, 0);
+        assert_eq!(info.raw_stored_item_count, None);
+    }
+
+    #[test]
+    fn turn_info_destructure_with_rest_pattern() {
+        let info = ConversationTurnInfo {
+            user_turns: 4,
+            total_items: 9,
+            raw_stored_item_count: Some(10),
+        };
+        let ConversationTurnInfo { user_turns, .. } = info;
+        assert_eq!(user_turns, 4);
+    }
+
+    #[test]
+    fn request_metadata_build_from_populates_originated_at() {
+        let md = RequestMetadata::build_from("req_123", Some("user_abc".into()), None, None);
+        assert_eq!(md.request_id, "req_123");
+        assert_eq!(md.safety_identifier.as_deref(), Some("user_abc"));
+        let elapsed = Utc::now().signed_duration_since(md.originated_at);
+        assert!(elapsed.num_seconds() < 2);
+    }
+}

--- a/crates/extensions/src/metadata.rs
+++ b/crates/extensions/src/metadata.rs
@@ -9,6 +9,20 @@ pub struct ConversationTurnInfo {
     pub raw_stored_item_count: Option<u32>,
 }
 
+impl ConversationTurnInfo {
+    pub fn new(
+        user_turns: u32,
+        total_items: u32,
+        raw_stored_item_count: Option<u32>,
+    ) -> Self {
+        Self {
+            user_turns,
+            total_items,
+            raw_stored_item_count,
+        }
+    }
+}
+
 #[non_exhaustive]
 #[derive(Debug, Clone)]
 pub struct RequestMetadata {
@@ -57,6 +71,14 @@ mod tests {
         };
         let ConversationTurnInfo { user_turns, .. } = info;
         assert_eq!(user_turns, 4);
+    }
+
+    #[test]
+    fn turn_info_new_constructs_correctly() {
+        let info = ConversationTurnInfo::new(3, 7, Some(5));
+        assert_eq!(info.user_turns, 3);
+        assert_eq!(info.total_items, 7);
+        assert_eq!(info.raw_stored_item_count, Some(5));
     }
 
     #[test]

--- a/crates/extensions/src/noop.rs
+++ b/crates/extensions/src/noop.rs
@@ -1,0 +1,84 @@
+use async_trait::async_trait;
+
+use crate::interceptor::ResponsesInterceptor;
+
+/// Interceptor that does nothing on either phase.
+///
+/// Useful in tests, in default registries, and as a baseline for measuring
+/// per-interceptor overhead.
+#[derive(Default, Debug, Clone)]
+pub struct NoOpInterceptor;
+
+impl NoOpInterceptor {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl ResponsesInterceptor for NoOpInterceptor {
+    fn name(&self) -> &'static str {
+        "noop"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use chrono::Utc;
+    use smg_data_connector::ConversationItemStorage;
+
+    use super::*;
+    use crate::context::{AfterPersistCtx, BeforeModelCtx};
+    use crate::metadata::{ConversationTurnInfo, RequestMetadata};
+
+    fn make_metadata() -> RequestMetadata {
+        RequestMetadata {
+            request_id: "req_test".into(),
+            safety_identifier: None,
+            tenant_id: None,
+            originated_at: Utc::now(),
+            storage_request_context: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn noop_name_is_stable() {
+        let i = NoOpInterceptor::new();
+        assert_eq!(i.name(), "noop");
+    }
+
+    #[tokio::test]
+    async fn noop_default_methods_do_nothing() {
+        let i = NoOpInterceptor::new();
+        let metadata = make_metadata();
+        let history: Arc<dyn ConversationItemStorage> = Arc::new(
+            smg_data_connector::MemoryConversationItemStorage::new(),
+        );
+        let mut request = openai_protocol::responses::ResponsesRequest::default();
+        let headers = axum::http::HeaderMap::new();
+
+        let mut before = BeforeModelCtx {
+            headers: &headers,
+            request: &mut request,
+            conversation_id: None,
+            history: history.clone(),
+            turn_info: ConversationTurnInfo::default(),
+            request_metadata: &metadata,
+        };
+        i.before_model(&mut before).await;
+
+        let after = AfterPersistCtx {
+            headers: &headers,
+            request: &request,
+            response_json: None,
+            response_id: None,
+            conversation_id: None,
+            turn_info: ConversationTurnInfo::default(),
+            persisted_item_ids: &[],
+            request_metadata: &metadata,
+        };
+        i.after_persist(&after).await;
+    }
+}

--- a/crates/extensions/src/registry.rs
+++ b/crates/extensions/src/registry.rs
@@ -1,0 +1,246 @@
+use std::{panic::AssertUnwindSafe, sync::Arc};
+
+use futures::FutureExt;
+use tracing::warn;
+
+use crate::context::{AfterPersistCtx, BeforeModelCtx};
+use crate::interceptor::ResponsesInterceptor;
+
+#[derive(Default, Clone)]
+pub struct InterceptorRegistry {
+    interceptors: Arc<Vec<Arc<dyn ResponsesInterceptor>>>,
+}
+
+impl InterceptorRegistry {
+    pub fn builder() -> InterceptorRegistryBuilder {
+        InterceptorRegistryBuilder::new()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.interceptors.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.interceptors.len()
+    }
+
+    pub async fn run_before_model(&self, ctx: &mut BeforeModelCtx<'_>) {
+        for i in self.interceptors.iter() {
+            let result = AssertUnwindSafe(i.before_model(ctx)).catch_unwind().await;
+            if result.is_err() {
+                warn!(
+                    interceptor = i.name(),
+                    "before_model panicked; continuing"
+                );
+            }
+        }
+    }
+
+    pub async fn run_after_persist(&self, ctx: &AfterPersistCtx<'_>) {
+        for i in self.interceptors.iter() {
+            let result = AssertUnwindSafe(i.after_persist(ctx)).catch_unwind().await;
+            if result.is_err() {
+                warn!(
+                    interceptor = i.name(),
+                    "after_persist panicked; continuing"
+                );
+            }
+        }
+    }
+}
+
+pub struct InterceptorRegistryBuilder {
+    interceptors: Vec<Arc<dyn ResponsesInterceptor>>,
+}
+
+impl Default for InterceptorRegistryBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl InterceptorRegistryBuilder {
+    pub fn new() -> Self {
+        Self {
+            interceptors: Vec::new(),
+        }
+    }
+
+    pub fn register(&mut self, i: Arc<dyn ResponsesInterceptor>) -> &mut Self {
+        self.interceptors.push(i);
+        self
+    }
+
+    pub fn build(self) -> InterceptorRegistry {
+        InterceptorRegistry {
+            interceptors: Arc::new(self.interceptors),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+
+    use async_trait::async_trait;
+    use chrono::Utc;
+    use smg_data_connector::ConversationItemStorage;
+
+    use super::*;
+    use crate::metadata::{ConversationTurnInfo, RequestMetadata};
+
+    fn make_metadata() -> RequestMetadata {
+        RequestMetadata {
+            request_id: "req_test".into(),
+            safety_identifier: None,
+            tenant_id: None,
+            originated_at: Utc::now(),
+            storage_request_context: None,
+        }
+    }
+
+    fn make_history() -> Arc<dyn ConversationItemStorage> {
+        Arc::new(smg_data_connector::MemoryConversationItemStorage::new())
+    }
+
+    struct CountingInterceptor {
+        before_count: Arc<AtomicUsize>,
+        after_count: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl ResponsesInterceptor for CountingInterceptor {
+        fn name(&self) -> &'static str {
+            "counting"
+        }
+        async fn before_model(&self, _ctx: &mut BeforeModelCtx<'_>) {
+            self.before_count.fetch_add(1, Ordering::SeqCst);
+        }
+        async fn after_persist(&self, _ctx: &AfterPersistCtx<'_>) {
+            self.after_count.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    struct PanickyInterceptor;
+
+    #[async_trait]
+    impl ResponsesInterceptor for PanickyInterceptor {
+        fn name(&self) -> &'static str {
+            "panicky"
+        }
+        async fn before_model(&self, _ctx: &mut BeforeModelCtx<'_>) {
+            panic!("intentional panic in before_model");
+        }
+        async fn after_persist(&self, _ctx: &AfterPersistCtx<'_>) {
+            panic!("intentional panic in after_persist");
+        }
+    }
+
+    #[tokio::test]
+    async fn empty_registry_is_empty() {
+        let registry = InterceptorRegistry::default();
+        assert!(registry.is_empty());
+        assert_eq!(registry.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn registry_runs_both_phases_in_order() {
+        let before_count = Arc::new(AtomicUsize::new(0));
+        let after_count = Arc::new(AtomicUsize::new(0));
+
+        let mut builder = InterceptorRegistry::builder();
+        builder.register(Arc::new(CountingInterceptor {
+            before_count: before_count.clone(),
+            after_count: after_count.clone(),
+        }));
+        builder.register(Arc::new(CountingInterceptor {
+            before_count: before_count.clone(),
+            after_count: after_count.clone(),
+        }));
+        let registry = builder.build();
+
+        let metadata = make_metadata();
+        let history = make_history();
+        let mut request = openai_protocol::responses::ResponsesRequest::default();
+        let headers = axum::http::HeaderMap::new();
+
+        let mut before = BeforeModelCtx {
+            headers: &headers,
+            request: &mut request,
+            conversation_id: None,
+            history: history.clone(),
+            turn_info: ConversationTurnInfo::default(),
+            request_metadata: &metadata,
+        };
+        registry.run_before_model(&mut before).await;
+
+        let after = AfterPersistCtx {
+            headers: &headers,
+            request: &request,
+            response_json: None,
+            response_id: None,
+            conversation_id: None,
+            turn_info: ConversationTurnInfo::default(),
+            persisted_item_ids: &[],
+            request_metadata: &metadata,
+        };
+        registry.run_after_persist(&after).await;
+
+        assert_eq!(before_count.load(Ordering::SeqCst), 2);
+        assert_eq!(after_count.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn panic_in_before_model_does_not_propagate() {
+        let mut builder = InterceptorRegistry::builder();
+        builder.register(Arc::new(PanickyInterceptor));
+        let registry = builder.build();
+
+        let metadata = make_metadata();
+        let history = make_history();
+        let mut request = openai_protocol::responses::ResponsesRequest::default();
+        let headers = axum::http::HeaderMap::new();
+        let mut before = BeforeModelCtx {
+            headers: &headers,
+            request: &mut request,
+            conversation_id: None,
+            history,
+            turn_info: ConversationTurnInfo::default(),
+            request_metadata: &metadata,
+        };
+
+        registry.run_before_model(&mut before).await;
+    }
+
+    #[tokio::test]
+    async fn panic_in_one_does_not_skip_next() {
+        let after_count = Arc::new(AtomicUsize::new(0));
+        let mut builder = InterceptorRegistry::builder();
+        builder.register(Arc::new(PanickyInterceptor));
+        builder.register(Arc::new(CountingInterceptor {
+            before_count: Arc::new(AtomicUsize::new(0)),
+            after_count: after_count.clone(),
+        }));
+        let registry = builder.build();
+
+        let metadata = make_metadata();
+        let request = openai_protocol::responses::ResponsesRequest::default();
+        let headers = axum::http::HeaderMap::new();
+        let after = AfterPersistCtx {
+            headers: &headers,
+            request: &request,
+            response_json: None,
+            response_id: None,
+            conversation_id: None,
+            turn_info: ConversationTurnInfo::default(),
+            persisted_item_ids: &[],
+            request_metadata: &metadata,
+        };
+
+        registry.run_after_persist(&after).await;
+        assert_eq!(after_count.load(Ordering::SeqCst), 1);
+    }
+}

--- a/docs/concepts/extensibility/interceptors.md
+++ b/docs/concepts/extensibility/interceptors.md
@@ -1,0 +1,197 @@
+---
+title: Interceptors
+---
+
+# Interceptors
+
+Interceptors are vendor-neutral extension points that fire at well-defined moments in the Responses request lifecycle. They allow custom logic — memory, audit logging, rate limiting, PII redaction — to ship as separate crates that SMG core does not need to know about.
+
+---
+
+## Overview
+
+<div class="grid" markdown>
+
+<div class="card" markdown>
+
+### :material-puzzle: Two-Phase Hooks
+
+Interceptors observe and optionally mutate requests at `before_model` and `after_persist`. Each phase has a typed context with the data needed for that lifecycle moment.
+
+</div>
+
+<div class="card" markdown>
+
+### :material-shield-check: Non-Fatal by Design
+
+Trait methods return `()`, never `Result`. The registry catches panics and logs them. A buggy interceptor cannot fail an SMG request.
+
+</div>
+
+<div class="card" markdown>
+
+### :material-package-variant: Vendor-Neutral
+
+Interceptors live in their own crates. SMG core is unaware of any specific extension. Operators opt in via build features and YAML configuration.
+
+</div>
+
+<div class="card" markdown>
+
+### :material-lightning-bolt: Zero Cost When Unused
+
+An empty registry skips all hook compute (turn counting, metadata construction). Operators with no extensions configured pay only one boolean check per phase.
+
+</div>
+
+</div>
+
+---
+
+## Phases
+
+Interceptors fire at exactly two moments in the Responses request lifecycle:
+
+| Phase | When | Use cases |
+|-------|------|-----------|
+| **`before_model`** | After history is loaded; before the request reaches the model | Inject memory context, enforce policy, mutate the request input |
+| **`after_persist`** | After conversation items + response are persisted successfully | Enqueue async work (memory consolidation, summarization), write audit rows, emit metrics |
+
+!!! info "Firing cadence"
+    `before_model` fires **once per request**, not per inner MCP-tool-loop
+    iteration. `after_persist` fires once for each successful persistence —
+    that is, once per Responses turn **and** once per
+    `POST /v1/conversations/{id}/items` batch.
+
+---
+
+## The Trait
+
+Implementors register against a single trait:
+
+```rust
+use async_trait::async_trait;
+use smg_extensions::{AfterPersistCtx, BeforeModelCtx, ResponsesInterceptor};
+
+#[async_trait]
+pub trait ResponsesInterceptor: Send + Sync + 'static {
+    /// Stable identifier for diagnostics and panic logging.
+    fn name(&self) -> &'static str;
+
+    async fn before_model(&self, ctx: &mut BeforeModelCtx<'_>);
+
+    async fn after_persist(&self, ctx: &AfterPersistCtx<'_>);
+}
+```
+
+Both `before_model` and `after_persist` have default no-op implementations, so an interceptor only needs to override the phase it cares about.
+
+### Recommended destructure pattern
+
+`BeforeModelCtx` and `AfterPersistCtx` are both `#[non_exhaustive]`. New fields may be added in future versions without a major version bump. **Always destructure with `..`** so future additions don't break compilation:
+
+```rust
+async fn before_model(&self, ctx: &mut BeforeModelCtx<'_>) {
+    let BeforeModelCtx { headers, request, conversation_id, .. } = ctx;
+    // ...
+}
+```
+
+---
+
+## Configuration
+
+Operators enable interceptors via the `extensions:` block in `server.yaml`:
+
+```yaml
+# server.yaml
+extensions:
+  - kind: my-extension
+    # Arbitrary YAML consumed by the extension itself.
+    setting: value
+    nested:
+      key: value
+```
+
+The `extensions:` field is parsed by SMG core into a list of `kind`/`config` pairs. Each extension crate parses its own `config` payload from a `serde_yml::Value`.
+
+An empty `extensions: []` list (or omitting the field entirely) means zero interceptors are registered. SMG core stays unaware of any specific extension.
+
+!!! tip "Two gates: build-time and runtime"
+    Default-off feature flags in `model_gateway/Cargo.toml` are the
+    **build-time** gate — extensions you never enable are not linked into
+    the binary. The `extensions:` YAML block is the **runtime** gate —
+    even a built-in extension stays inert until an operator opts in.
+
+---
+
+## Writing an Interceptor
+
+1. **Create a new crate** that depends on `smg-extensions`.
+2. **Implement `ResponsesInterceptor`** for your type. Override only the phases you need; the rest default to no-ops.
+3. **Register a `match` arm** in `model_gateway/src/app_context.rs` (inside `AppContextBuilder::from_config`) under a feature flag — for example:
+
+    ```rust
+    #[cfg(feature = "my-extension")]
+    "my-extension" => {
+        registry_builder.register(my_extension::build(&spec.config)?);
+    }
+    ```
+
+4. **Document the YAML schema** consumed by your `build()` function in your crate's README.
+
+Default-off feature flags in `model_gateway/Cargo.toml` keep extension dependencies optional at compile time. Operators who don't enable the feature build a smaller binary with no extension code linked in.
+
+---
+
+## Error Model
+
+Interceptor methods return `()` — there is no `Result`. Internal failures inside an implementation should be logged with the implementor's own `tracing` calls.
+
+Panics propagating out of either phase are caught by the registry via `catch_unwind` and logged at warn level. Execution continues to the next interceptor and to the next request lifecycle step.
+
+| Failure mode | Effect on SMG request |
+|--------------|----------------------|
+| Implementor logs an error and returns | Request continues normally |
+| Implementor panics | Registry catches, logs at warn, request continues |
+| Implementor blocks indefinitely | Request blocks (interceptors are awaited inline) |
+
+This is a deliberate trade-off: operators get a strict guarantee that no extension can **fail** a request, in exchange for explicit error handling inside each interceptor.
+
+---
+
+## What's Next?
+
+<div class="grid" markdown>
+
+<div class="card" markdown>
+
+### :material-book-open-variant: smg-extensions API
+
+Trait, context types, and registry reference.
+
+[View on docs.rs →](https://docs.rs/smg-extensions)
+
+</div>
+
+<div class="card" markdown>
+
+### :material-puzzle-outline: WASM Plugins
+
+Sandboxed extension model for request/response transformations.
+
+[WASM Plugins →](wasm-plugins.md)
+
+</div>
+
+<div class="card" markdown>
+
+### :material-tools: MCP Integration
+
+Connect models to external tools.
+
+[Model Context Protocol →](mcp.md)
+
+</div>
+
+</div>

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -123,6 +123,7 @@ Extend SMG with custom logic and external tools:
 
 - [WASM Plugins](extensibility/wasm-plugins.md) — Dynamic middleware with WebAssembly
 - [Model Context Protocol](extensibility/mcp.md) — External tool integration via MCP
+- [Interceptors](extensibility/interceptors.md) — Vendor-neutral lifecycle hooks for the Responses pipeline
 
 ### Reliability
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -174,6 +174,7 @@ nav:
       - Extensibility:
           - WASM Plugins: concepts/extensibility/wasm-plugins.md
           - Model Context Protocol: concepts/extensibility/mcp.md
+          - Interceptors: concepts/extensibility/interceptors.md
       - Reliability:
           - Circuit Breakers: concepts/reliability/circuit-breakers.md
           - Rate Limiting: concepts/reliability/rate-limiting.md

--- a/model_gateway/Cargo.toml
+++ b/model_gateway/Cargo.toml
@@ -111,6 +111,7 @@ rustls-pemfile = "2.2"
 openssl = "0.10.73"
 rmcp = { version = "0.8.3", features = ["client"] }
 serde_yaml = "0.9"
+serde_yml = "0.0.12"
 openai-harmony = "0.0.8"
 openmetrics-parser = "0.4.4"
 arc-swap = "1.7.1"

--- a/model_gateway/Cargo.toml
+++ b/model_gateway/Cargo.toml
@@ -72,6 +72,7 @@ smg-auth.workspace = true
 smg-mcp.workspace = true
 kv-index.workspace = true
 smg-data-connector.workspace = true
+smg-extensions.workspace = true
 llm-multimodal.workspace = true
 smg-wasm = { workspace = true, features = ["storage-hooks"] }
 smg-mesh.workspace = true

--- a/model_gateway/src/app_context.rs
+++ b/model_gateway/src/app_context.rs
@@ -83,6 +83,8 @@ pub struct AppContext {
     pub webrtc_bind_addr: Option<std::net::IpAddr>,
     /// STUN server for ICE candidate gathering (`None` = `stun.l.google.com:19302`).
     pub webrtc_stun_server: Option<String>,
+    /// Registry of Responses-API interceptors (empty by default).
+    pub interceptors: smg_extensions::InterceptorRegistry,
 }
 
 impl std::fmt::Debug for AppContext {
@@ -117,6 +119,7 @@ pub struct AppContextBuilder {
     kv_event_monitor: Option<Arc<KvEventMonitor>>,
     webrtc_bind_addr: Option<std::net::IpAddr>,
     webrtc_stun_server: Option<String>,
+    interceptors: Option<smg_extensions::InterceptorRegistry>,
 }
 
 impl AppContext {
@@ -172,6 +175,7 @@ impl AppContextBuilder {
             kv_event_monitor: None,
             webrtc_bind_addr: None,
             webrtc_stun_server: None,
+            interceptors: None,
         }
     }
 
@@ -304,6 +308,16 @@ impl AppContextBuilder {
         self
     }
 
+    /// Inject the Responses-API interceptor registry. Defaults to an empty
+    /// registry when not provided.
+    pub fn interceptors(
+        mut self,
+        interceptors: smg_extensions::InterceptorRegistry,
+    ) -> Self {
+        self.interceptors = Some(interceptors);
+        self
+    }
+
     pub fn build(self) -> Result<AppContext, AppContextBuildError> {
         let router_config = self
             .router_config
@@ -404,6 +418,7 @@ impl AppContextBuilder {
             realtime_registry: Arc::new(RealtimeRegistry::new()),
             webrtc_bind_addr: self.webrtc_bind_addr,
             webrtc_stun_server: self.webrtc_stun_server,
+            interceptors: self.interceptors.unwrap_or_default(),
         })
     }
 

--- a/model_gateway/src/app_context.rs
+++ b/model_gateway/src/app_context.rs
@@ -439,7 +439,8 @@ impl AppContextBuilder {
         // Build the Responses-API interceptor registry from the configured
         // extensions. An empty `extensions:` list yields an empty registry,
         // which is the no-op default.
-        let mut registry_builder = InterceptorRegistry::builder();
+        // PR 2 will rebind this as `mut` and call `.register(...)` on it.
+        let registry_builder = InterceptorRegistry::builder();
         for spec in &router_config.extensions.items {
             match spec.kind.as_str() {
                 // Future extensions register here. Example (PR 2):

--- a/model_gateway/src/app_context.rs
+++ b/model_gateway/src/app_context.rs
@@ -430,9 +430,29 @@ impl AppContextBuilder {
         webrtc_bind_addr: Option<std::net::IpAddr>,
         webrtc_stun_server: Option<String>,
     ) -> Result<Self, String> {
+        use smg_extensions::InterceptorRegistry;
+
         // Fail fast before storage initialization to avoid side effects
         // (e.g., migrations) for invalid memory_runtime/backend combinations.
         validate_memory_writer_configuration(&router_config)?;
+
+        // Build the Responses-API interceptor registry from the configured
+        // extensions. An empty `extensions:` list yields an empty registry,
+        // which is the no-op default.
+        let mut registry_builder = InterceptorRegistry::builder();
+        for spec in &router_config.extensions.items {
+            match spec.kind.as_str() {
+                // Future extensions register here. Example (PR 2):
+                //   #[cfg(feature = "memory")]
+                //   "smg-conversation-memory-oracle" => {
+                //       registry_builder.register(smg_conversation_memory_oracle::build(&spec.config)?);
+                //   }
+                unknown => {
+                    tracing::warn!(kind = unknown, "unknown extension kind; ignoring");
+                }
+            }
+        }
+        let interceptors = registry_builder.build();
 
         Ok(Self::new()
             .with_client(&router_config, request_timeout_secs)?
@@ -454,6 +474,7 @@ impl AppContextBuilder {
             .with_kv_event_monitor(&router_config)
             .webrtc_bind_addr(webrtc_bind_addr)
             .webrtc_stun_server(webrtc_stun_server)
+            .interceptors(interceptors)
             .router_config(router_config))
     }
 

--- a/model_gateway/src/config/extensions.rs
+++ b/model_gateway/src/config/extensions.rs
@@ -1,0 +1,77 @@
+//! Generic extension configuration schema.
+//!
+//! Per spec §Config: the `extensions:` YAML block carries a list of
+//! `kind`/`config` pairs. SMG core parses only the generic shape; each
+//! extension crate parses its own `config: serde_yml::Value` payload.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExtensionsConfig {
+    #[serde(default)]
+    pub items: Vec<ExtensionSpec>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExtensionSpec {
+    pub kind: String,
+    #[serde(flatten)]
+    pub config: serde_yml::Value,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ExtensionConfigError {
+    #[error("unknown extension kind '{0}'")]
+    Unknown(String),
+
+    #[error("extension '{kind}' requires building with --features {feature}")]
+    FeatureGated { kind: String, feature: &'static str },
+
+    #[error("extension '{kind}' build failed: {source}")]
+    BuildFailed {
+        kind: String,
+        #[source]
+        source: anyhow::Error,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_extensions_parses() {
+        let yaml = "items: []";
+        let cfg: ExtensionsConfig = serde_yml::from_str(yaml).unwrap();
+        assert!(cfg.items.is_empty());
+    }
+
+    #[test]
+    fn missing_extensions_field_uses_default() {
+        #[derive(Deserialize)]
+        struct Wrapper {
+            #[serde(default)]
+            extensions: ExtensionsConfig,
+        }
+        let yaml = "{}";
+        let w: Wrapper = serde_yml::from_str(yaml).unwrap();
+        assert!(w.extensions.items.is_empty());
+    }
+
+    #[test]
+    fn extension_spec_captures_arbitrary_config() {
+        let yaml = r#"
+items:
+  - kind: my-extension
+    runtime_enabled: true
+    nested:
+      key: value
+"#;
+        let cfg: ExtensionsConfig = serde_yml::from_str(yaml).unwrap();
+        assert_eq!(cfg.items.len(), 1);
+        assert_eq!(cfg.items[0].kind, "my-extension");
+        let val: &serde_yml::Value = &cfg.items[0].config;
+        assert!(val.get("runtime_enabled").is_some());
+        assert!(val.get("nested").is_some());
+    }
+}

--- a/model_gateway/src/config/mod.rs
+++ b/model_gateway/src/config/mod.rs
@@ -1,8 +1,10 @@
 pub mod builder;
+pub mod extensions;
 pub mod types;
 pub(crate) mod validation;
 
 pub use builder::*;
+pub use extensions::{ExtensionConfigError, ExtensionSpec, ExtensionsConfig};
 pub use smg_skills::SkillsConfig;
 pub use types::*;
 

--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -7,6 +7,7 @@ pub use smg_data_connector::{
     HistoryBackend, OracleConfig, PostgresConfig, RedisConfig, SchemaConfig,
 };
 
+use super::extensions::ExtensionsConfig;
 use super::{validation::ConfigValidator, ConfigResult, SkillsConfig};
 use crate::{tenant::DEFAULT_TENANT_HEADER_NAME, worker::ConnectionMode};
 
@@ -182,6 +183,8 @@ pub struct RouterConfig {
     /// When set, wraps all storage backends with hook-based interceptors.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub storage_hook_wasm_path: Option<String>,
+    #[serde(default)]
+    pub extensions: ExtensionsConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -678,6 +681,7 @@ impl Default for RouterConfig {
             storage_hook_wasm_path: None,
             server_cert: None,
             server_key: None,
+            extensions: ExtensionsConfig::default(),
         }
     }
 }

--- a/model_gateway/src/routers/common/grpc_headers.rs
+++ b/model_gateway/src/routers/common/grpc_headers.rs
@@ -1,0 +1,67 @@
+//! Convert `tonic::metadata::MetadataMap` to `axum::http::HeaderMap`.
+//!
+//! gRPC clients map metadata to HTTP/2 headers; this utility makes them
+//! consumable by `BeforeModelCtx::headers` (which expects an axum HeaderMap).
+//!
+//! Binary metadata (keys ending in `-bin`) is skipped since `HeaderValue`
+//! cannot represent arbitrary bytes safely.
+
+use std::str::FromStr;
+
+use axum::http::{HeaderMap, HeaderName, HeaderValue};
+use tonic::metadata::{KeyAndValueRef, MetadataMap};
+
+pub fn tonic_metadata_to_headermap(metadata: &MetadataMap) -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    for entry in metadata.iter() {
+        if let KeyAndValueRef::Ascii(key, val) = entry {
+            let name = HeaderName::from_str(key.as_str());
+            let value = val
+                .to_str()
+                .ok()
+                .and_then(|s| HeaderValue::from_str(s).ok());
+            if let (Ok(name), Some(value)) = (name, value) {
+                headers.append(name, value);
+            }
+        }
+    }
+    headers
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_metadata_yields_empty_headers() {
+        let md = MetadataMap::new();
+        let h = tonic_metadata_to_headermap(&md);
+        assert!(h.is_empty());
+    }
+
+    #[test]
+    fn ascii_metadata_round_trips() {
+        let mut md = MetadataMap::new();
+        md.insert("x-conversation-memory-config", "test".parse().unwrap());
+        md.insert("x-test-key", "value1".parse().unwrap());
+
+        let h = tonic_metadata_to_headermap(&md);
+        assert_eq!(
+            h.get("x-conversation-memory-config")
+                .and_then(|v| v.to_str().ok()),
+            Some("test")
+        );
+        assert_eq!(h.get("x-test-key").and_then(|v| v.to_str().ok()), Some("value1"));
+    }
+
+    #[test]
+    fn binary_metadata_is_skipped() {
+        let mut md = MetadataMap::new();
+        md.insert_bin(
+            "x-binary-bin",
+            tonic::metadata::MetadataValue::from_bytes(&[0xFF, 0x00]),
+        );
+        let h = tonic_metadata_to_headermap(&md);
+        assert!(h.get("x-binary-bin").is_none());
+    }
+}

--- a/model_gateway/src/routers/common/mod.rs
+++ b/model_gateway/src/routers/common/mod.rs
@@ -22,6 +22,7 @@
 //!   before forwarding to provider-specific routers.
 
 pub mod background;
+pub mod grpc_headers;
 pub mod header_utils;
 pub mod mcp_utils;
 pub mod persistence_utils;

--- a/model_gateway/src/routers/common/mod.rs
+++ b/model_gateway/src/routers/common/mod.rs
@@ -27,4 +27,5 @@ pub mod mcp_utils;
 pub mod persistence_utils;
 pub mod retry;
 pub mod skill_resolution;
+pub mod turn_info;
 pub mod worker_selection;

--- a/model_gateway/src/routers/common/turn_info.rs
+++ b/model_gateway/src/routers/common/turn_info.rs
@@ -22,11 +22,11 @@ pub async fn compute_turn_info(
     incoming_input: Option<&Value>,
 ) -> ConversationTurnInfo {
     let Some(conv_id) = conversation_id else {
-        let mut info = ConversationTurnInfo::default();
-        info.user_turns = count_user_turns_in_input(incoming_input);
-        info.total_items = count_total_items_in_input(incoming_input);
-        info.raw_stored_item_count = None;
-        return info;
+        return ConversationTurnInfo::new(
+            count_user_turns_in_input(incoming_input),
+            count_total_items_in_input(incoming_input),
+            None,
+        );
     };
 
     let params = ListParams {
@@ -53,11 +53,7 @@ pub async fn compute_turn_info(
     user_turns += count_user_turns_in_input(incoming_input);
     total_items += count_total_items_in_input(incoming_input);
 
-    let mut info = ConversationTurnInfo::default();
-    info.user_turns = user_turns;
-    info.total_items = total_items;
-    info.raw_stored_item_count = Some(raw_stored);
-    info
+    ConversationTurnInfo::new(user_turns, total_items, Some(raw_stored))
 }
 
 fn count_user_turns_in_input(input: Option<&Value>) -> u32 {

--- a/model_gateway/src/routers/common/turn_info.rs
+++ b/model_gateway/src/routers/common/turn_info.rs
@@ -1,0 +1,139 @@
+//! Basic turn counting for `BeforeModelCtx` / `AfterPersistCtx`.
+//!
+//! Per spec §`compute_turn_info` scope: PR 1 implements only generic counting.
+//! The five STMO-specific special cases from PR #1400 (raw-count correction,
+//! chain-overlap guard, store=false short-circuit, no-history-loaded skip,
+//! MCP-streaming skip) are NOT implemented here. If future memory work needs
+//! them, they live inside the memory crate's scheduler, not in core.
+
+use serde_json::Value;
+use smg_data_connector::{ConversationId, ConversationItemStorage, ListParams, SortOrder};
+use smg_extensions::ConversationTurnInfo;
+use tracing::warn;
+
+/// Compute basic turn-counting telemetry for a request.
+///
+/// Counts user-role messages from history + incoming input as `user_turns`,
+/// total items as `total_items`, and exposes the raw stored-item count
+/// (pre-filter) as `raw_stored_item_count` for callers that need it.
+pub async fn compute_turn_info(
+    history: &dyn ConversationItemStorage,
+    conversation_id: Option<&ConversationId>,
+    incoming_input: Option<&Value>,
+) -> ConversationTurnInfo {
+    let Some(conv_id) = conversation_id else {
+        let mut info = ConversationTurnInfo::default();
+        info.user_turns = count_user_turns_in_input(incoming_input);
+        info.total_items = count_total_items_in_input(incoming_input);
+        info.raw_stored_item_count = None;
+        return info;
+    };
+
+    let params = ListParams {
+        limit: 1024,
+        order: SortOrder::Asc,
+        after: None,
+    };
+
+    let stored = match history.list_items(conv_id, params).await {
+        Ok(items) => items,
+        Err(e) => {
+            warn!(error = %e, "failed to list conversation items for turn counting");
+            return ConversationTurnInfo::default();
+        }
+    };
+
+    let raw_stored = stored.len() as u32;
+    let mut user_turns: u32 = stored
+        .iter()
+        .filter(|it| it.role.as_deref() == Some("user"))
+        .count() as u32;
+    let mut total_items: u32 = stored.len() as u32;
+
+    user_turns += count_user_turns_in_input(incoming_input);
+    total_items += count_total_items_in_input(incoming_input);
+
+    let mut info = ConversationTurnInfo::default();
+    info.user_turns = user_turns;
+    info.total_items = total_items;
+    info.raw_stored_item_count = Some(raw_stored);
+    info
+}
+
+fn count_user_turns_in_input(input: Option<&Value>) -> u32 {
+    let Some(arr) = input.and_then(|v| v.as_array()) else {
+        return 0;
+    };
+    arr.iter()
+        .filter(|item| {
+            item.get("role").and_then(|r| r.as_str()) == Some("user")
+        })
+        .count() as u32
+}
+
+fn count_total_items_in_input(input: Option<&Value>) -> u32 {
+    input
+        .and_then(|v| v.as_array())
+        .map(|a| a.len() as u32)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use serde_json::json;
+    use smg_data_connector::{
+        ConversationId, MemoryConversationItemStorage, NewConversationItem,
+    };
+
+    #[tokio::test]
+    async fn empty_input_no_conversation_returns_zeros() {
+        let history = MemoryConversationItemStorage::new();
+        let info = compute_turn_info(&history, None, None).await;
+        assert_eq!(info.user_turns, 0);
+        assert_eq!(info.total_items, 0);
+        assert_eq!(info.raw_stored_item_count, None);
+    }
+
+    #[tokio::test]
+    async fn input_only_user_turns() {
+        let history = MemoryConversationItemStorage::new();
+        let input = json!([
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+            {"role": "user", "content": "again"}
+        ]);
+        let info = compute_turn_info(&history, None, Some(&input)).await;
+        assert_eq!(info.user_turns, 2);
+        assert_eq!(info.total_items, 3);
+    }
+
+    #[tokio::test]
+    async fn history_plus_input_aggregates() {
+        let history = MemoryConversationItemStorage::new();
+        let conv_id: ConversationId = "conv_test".into();
+        let item = history
+            .create_item(NewConversationItem {
+                id: None,
+                response_id: None,
+                item_type: "message".into(),
+                role: Some("user".into()),
+                content: json!([]),
+                status: Some("completed".into()),
+            })
+            .await
+            .unwrap();
+        history
+            .link_item(&conv_id, &item.id, Utc::now())
+            .await
+            .unwrap();
+
+        let input = json!([{"role": "user", "content": "next"}]);
+        let info = compute_turn_info(&history, Some(&conv_id), Some(&input)).await;
+
+        assert_eq!(info.user_turns, 2);
+        assert_eq!(info.total_items, 2);
+        assert_eq!(info.raw_stored_item_count, Some(1));
+    }
+}

--- a/model_gateway/src/routers/common/turn_info.rs
+++ b/model_gateway/src/routers/common/turn_info.rs
@@ -11,6 +11,26 @@ use smg_data_connector::{ConversationId, ConversationItemStorage, ListParams, So
 use smg_extensions::ConversationTurnInfo;
 use tracing::warn;
 
+/// Test-only invocation counter for `compute_turn_info`.
+///
+/// Used by unit tests to verify that callers correctly skip the turn-info
+/// compute when their interceptor registry is empty, avoiding unnecessary
+/// work on the hot path.
+#[cfg(test)]
+pub(crate) mod test_instrumentation {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    pub(crate) static COMPUTE_CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+    pub(crate) fn current_count() -> usize {
+        COMPUTE_CALL_COUNT.load(Ordering::SeqCst)
+    }
+
+    pub(crate) fn reset() {
+        COMPUTE_CALL_COUNT.store(0, Ordering::SeqCst);
+    }
+}
+
 /// Compute basic turn-counting telemetry for a request.
 ///
 /// Counts user-role messages from history + incoming input as `user_turns`,
@@ -21,6 +41,10 @@ pub async fn compute_turn_info(
     conversation_id: Option<&ConversationId>,
     incoming_input: Option<&Value>,
 ) -> ConversationTurnInfo {
+    #[cfg(test)]
+    test_instrumentation::COMPUTE_CALL_COUNT
+        .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+
     let Some(conv_id) = conversation_id else {
         return ConversationTurnInfo::new(
             count_user_turns_in_input(incoming_input),
@@ -76,11 +100,22 @@ fn count_total_items_in_input(input: Option<&Value>) -> u32 {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
     use chrono::Utc;
     use serde_json::json;
+    use serial_test::serial;
     use smg_data_connector::{
-        ConversationId, MemoryConversationItemStorage, NewConversationItem,
+        ConversationId, ConversationItemStorage, ConversationStorage,
+        MemoryConversationItemStorage, MemoryConversationStorage, NewConversation,
+        NewConversationItem,
+    };
+    use smg_extensions::InterceptorRegistry;
+
+    use crate::{
+        memory::MemoryExecutionContext,
+        routers::conversations::create_conversation_items_with_headers,
     };
 
     #[tokio::test]
@@ -131,5 +166,97 @@ mod tests {
         assert_eq!(info.user_turns, 2);
         assert_eq!(info.total_items, 2);
         assert_eq!(info.raw_stored_item_count, Some(1));
+    }
+
+    /// Verifies the items-only path skips `compute_turn_info` when the
+    /// interceptor registry is empty. This guards against accidentally
+    /// re-introducing the work cost on the no-interceptor hot path.
+    ///
+    /// Both arms of the test run inline against a single counter, so the
+    /// `#[serial]` attribute prevents interleaving with other tests in
+    /// this module that also exercise `compute_turn_info`.
+    #[tokio::test]
+    #[serial]
+    async fn items_only_skips_compute_turn_info_when_registry_is_empty() {
+        let conversation_storage: Arc<dyn ConversationStorage> =
+            Arc::new(MemoryConversationStorage::new());
+        let conversation_item_storage: Arc<dyn ConversationItemStorage> =
+            Arc::new(MemoryConversationItemStorage::new());
+
+        let conv = conversation_storage
+            .create_conversation(NewConversation {
+                id: None,
+                metadata: None,
+            })
+            .await
+            .expect("create conversation");
+
+        let body = json!({
+            "items": [
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "hi"}]
+                }
+            ]
+        });
+
+        // Empty registry → compute_turn_info must not be called.
+        test_instrumentation::reset();
+        let baseline = test_instrumentation::current_count();
+
+        let resp_empty = create_conversation_items_with_headers(
+            &conversation_storage,
+            &conversation_item_storage,
+            &conv.id.0,
+            body.clone(),
+            MemoryExecutionContext::default(),
+            InterceptorRegistry::default(),
+            "req_test_empty".to_string(),
+            Some("test-tenant".to_string()),
+            Default::default(),
+        )
+        .await;
+        assert_eq!(resp_empty.status(), http::StatusCode::OK);
+
+        assert_eq!(
+            test_instrumentation::current_count(),
+            baseline,
+            "compute_turn_info must not be invoked when the registry is empty"
+        );
+
+        // Sanity: with a non-empty registry, compute_turn_info IS called.
+        struct Noop;
+        #[async_trait::async_trait]
+        impl smg_extensions::ResponsesInterceptor for Noop {
+            fn name(&self) -> &'static str {
+                "noop"
+            }
+        }
+
+        let mut builder = InterceptorRegistry::builder();
+        builder.register(Arc::new(Noop));
+        let registry = builder.build();
+
+        let resp_nonempty = create_conversation_items_with_headers(
+            &conversation_storage,
+            &conversation_item_storage,
+            &conv.id.0,
+            body,
+            MemoryExecutionContext::default(),
+            registry,
+            "req_test_nonempty".to_string(),
+            Some("test-tenant".to_string()),
+            Default::default(),
+        )
+        .await;
+        assert_eq!(resp_nonempty.status(), http::StatusCode::OK);
+
+        assert!(
+            test_instrumentation::current_count() > baseline,
+            "compute_turn_info must be invoked at least once when a registered interceptor exists (got count={}, baseline={})",
+            test_instrumentation::current_count(),
+            baseline
+        );
     }
 }

--- a/model_gateway/src/routers/conversations/handlers.rs
+++ b/model_gateway/src/routers/conversations/handlers.rs
@@ -3,7 +3,7 @@
 use std::{collections::HashSet, sync::Arc};
 
 use axum::{
-    http::StatusCode,
+    http::{HeaderMap, StatusCode},
     response::{IntoResponse, Response},
     Json,
 };
@@ -312,16 +312,28 @@ pub async fn create_conversation_items(
         conv_id,
         body,
         MemoryExecutionContext::default(),
+        smg_extensions::InterceptorRegistry::default(),
+        format!("req_{}", uuid::Uuid::now_v7()),
+        None,
+        HeaderMap::new(),
     )
     .await
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "items-only persist hook firing requires per-request metadata alongside storage handles"
+)]
 pub async fn create_conversation_items_with_headers(
     conversation_storage: &Arc<dyn ConversationStorage>,
     item_storage: &Arc<dyn ConversationItemStorage>,
     conv_id: &str,
     body: Value,
     memory_execution_context: MemoryExecutionContext,
+    interceptors: smg_extensions::InterceptorRegistry,
+    request_id: String,
+    tenant_id: Option<String>,
+    headers: HeaderMap,
 ) -> Response {
     let conversation_id = ConversationId::from(conv_id);
 
@@ -373,6 +385,42 @@ pub async fn create_conversation_items_with_headers(
     // Batch-link all items in a single operation
     if let Err(e) = item_storage.link_items(&conversation_id, &link_pairs).await {
         return internal_error(format!("Failed to link items to conversation: {e}"));
+    }
+
+    if !interceptors.is_empty() {
+        use smg_extensions::{AfterPersistCtx, RequestMetadata};
+
+        use crate::routers::common::turn_info::compute_turn_info;
+
+        let conv_id_ref = Some(&conversation_id);
+        let turn_info = compute_turn_info(item_storage.as_ref(), conv_id_ref, None).await;
+
+        let persisted_ids: Vec<ConversationItemId> =
+            link_pairs.iter().map(|(id, _)| id.clone()).collect();
+
+        let metadata = RequestMetadata::build_from(
+            request_id,
+            None,
+            tenant_id,
+            smg_data_connector::current_request_context(),
+        );
+
+        // The items-only path has no associated ResponsesRequest;
+        // construct a default placeholder so AfterPersistCtx satisfies its type.
+        let placeholder_request = openai_protocol::responses::ResponsesRequest::default();
+
+        let after_ctx = AfterPersistCtx::new(
+            &headers,
+            &placeholder_request,
+            None,
+            None,
+            conv_id_ref,
+            turn_info,
+            &persisted_ids[..],
+            &metadata,
+        );
+
+        interceptors.run_after_persist(&after_ctx).await;
     }
 
     let mut response = json!({

--- a/model_gateway/src/routers/grpc/common/responses/context.rs
+++ b/model_gateway/src/routers/grpc/common/responses/context.rs
@@ -36,6 +36,9 @@ pub(crate) struct ResponsesContext {
     /// Conversation memory writer (can be NoOp depending on backend)
     pub conversation_memory_writer: Arc<dyn ConversationMemoryWriter>,
 
+    /// Registry of Responses-API interceptors (empty by default).
+    pub interceptors: smg_extensions::InterceptorRegistry,
+
     /// MCP orchestrator for tool support
     pub mcp_orchestrator: Arc<McpOrchestrator>,
 
@@ -56,6 +59,7 @@ impl ResponsesContext {
         conversation_storage: Arc<dyn ConversationStorage>,
         conversation_item_storage: Arc<dyn ConversationItemStorage>,
         conversation_memory_writer: Arc<dyn ConversationMemoryWriter>,
+        interceptors: smg_extensions::InterceptorRegistry,
         mcp_orchestrator: Arc<McpOrchestrator>,
         request_context: Option<StorageRequestContext>,
     ) -> Self {
@@ -66,6 +70,7 @@ impl ResponsesContext {
             conversation_storage,
             conversation_item_storage,
             conversation_memory_writer,
+            interceptors,
             mcp_orchestrator,
             request_context,
         }

--- a/model_gateway/src/routers/grpc/common/responses/utils.rs
+++ b/model_gateway/src/routers/grpc/common/responses/utils.rs
@@ -236,3 +236,106 @@ pub(crate) async fn persist_response_if_needed(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+
+    use async_trait::async_trait;
+    use axum::http::HeaderMap;
+    use openai_protocol::responses::{ResponsesRequest, ResponsesResponse};
+    use smg_data_connector::{
+        MemoryConversationItemStorage, MemoryConversationStorage, MemoryResponseStorage,
+    };
+    use smg_extensions::{
+        AfterPersistCtx, BeforeModelCtx, InterceptorRegistry, ResponsesInterceptor,
+    };
+
+    use super::persist_response_if_needed;
+
+    struct CountingInterceptor {
+        after_count: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl ResponsesInterceptor for CountingInterceptor {
+        fn name(&self) -> &'static str {
+            "counting-grpc"
+        }
+        async fn before_model(&self, _ctx: &mut BeforeModelCtx<'_>) {}
+        async fn after_persist(&self, _ctx: &AfterPersistCtx<'_>) {
+            self.after_count.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    /// Shared gRPC after_persist site fires the registered interceptor when
+    /// persistence succeeds. Mirrors the wiring used by both the harmony
+    /// and regular gRPC routers.
+    #[tokio::test]
+    async fn persist_response_if_needed_fires_after_persist_hook() {
+        let after_count = Arc::new(AtomicUsize::new(0));
+
+        let mut builder = InterceptorRegistry::builder();
+        builder.register(Arc::new(CountingInterceptor {
+            after_count: after_count.clone(),
+        }));
+        let interceptors = builder.build();
+
+        let conversation_storage = Arc::new(MemoryConversationStorage::new());
+        let conversation_item_storage = Arc::new(MemoryConversationItemStorage::new());
+        let response_storage = Arc::new(MemoryResponseStorage::new());
+
+        let response = ResponsesResponse::builder("resp_grpc_unit", "mock-model").build();
+        let request = ResponsesRequest::default();
+
+        persist_response_if_needed(
+            conversation_storage,
+            conversation_item_storage,
+            response_storage,
+            &response,
+            &request,
+            None,
+            interceptors,
+            HeaderMap::new(),
+            "req_grpc_unit".to_string(),
+            Some("test-tenant".to_string()),
+        )
+        .await;
+
+        assert_eq!(
+            after_count.load(Ordering::SeqCst),
+            1,
+            "after_persist hook should fire exactly once on the gRPC shared persist path"
+        );
+    }
+
+    /// Empty registry must not invoke any interceptor work.
+    #[tokio::test]
+    async fn persist_response_if_needed_skips_when_registry_is_empty() {
+        let conversation_storage = Arc::new(MemoryConversationStorage::new());
+        let conversation_item_storage = Arc::new(MemoryConversationItemStorage::new());
+        let response_storage = Arc::new(MemoryResponseStorage::new());
+
+        let response = ResponsesResponse::builder("resp_grpc_unit_empty", "mock-model").build();
+        let request = ResponsesRequest::default();
+
+        // Should be a no-op; just assert no panic and no observable side
+        // effect on the storage backends from interceptor logic.
+        persist_response_if_needed(
+            conversation_storage,
+            conversation_item_storage,
+            response_storage,
+            &response,
+            &request,
+            None,
+            InterceptorRegistry::default(),
+            HeaderMap::new(),
+            "req_grpc_unit_empty".to_string(),
+            None,
+        )
+        .await;
+    }
+}

--- a/model_gateway/src/routers/grpc/common/responses/utils.rs
+++ b/model_gateway/src/routers/grpc/common/responses/utils.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use axum::response::Response;
+use axum::{http::HeaderMap, response::Response};
 use openai_protocol::{
     common::Tool,
     responses::{ResponseTool, ResponsesRequest, ResponsesResponse},
@@ -150,6 +150,10 @@ pub(crate) fn extract_tools_from_response_tools(
 ///
 /// Common helper function to avoid duplication across sync and streaming paths
 /// in both harmony and regular responses implementations.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "interceptor hook firing requires per-request metadata alongside storage handles"
+)]
 pub(crate) async fn persist_response_if_needed(
     conversation_storage: Arc<dyn ConversationStorage>,
     conversation_item_storage: Arc<dyn ConversationItemStorage>,
@@ -157,25 +161,78 @@ pub(crate) async fn persist_response_if_needed(
     response: &ResponsesResponse,
     original_request: &ResponsesRequest,
     request_context: Option<StorageRequestContext>,
+    interceptors: smg_extensions::InterceptorRegistry,
+    headers: HeaderMap,
+    request_id: String,
+    tenant_id: Option<String>,
 ) {
     if !original_request.store.unwrap_or(true) {
         return;
     }
 
     if let Ok(response_json) = to_value(response) {
-        if let Err(e) = persist_conversation_items(
+        let item_storage_for_hook = conversation_item_storage.clone();
+        let persist_result = persist_conversation_items(
             conversation_storage,
             conversation_item_storage,
             response_storage,
             &response_json,
             original_request,
-            request_context,
+            request_context.clone(),
         )
-        .await
-        {
-            warn!("Failed to persist response: {}", e);
-        } else {
-            debug!("Persisted response: {}", response.id);
+        .await;
+        match persist_result {
+            Ok(()) => {
+                debug!("Persisted response: {}", response.id);
+                if !interceptors.is_empty() {
+                    use smg_extensions::{AfterPersistCtx, RequestMetadata};
+
+                    use crate::routers::common::turn_info::compute_turn_info;
+
+                    let conv_id_opt: Option<smg_data_connector::ConversationId> =
+                        original_request
+                            .conversation
+                            .as_ref()
+                            .filter(|c| !c.is_empty())
+                            .map(|c| smg_data_connector::ConversationId::from(c.as_id()));
+
+                    let response_id_owned: Option<smg_data_connector::ResponseId> = response_json
+                        .get("id")
+                        .and_then(|v| v.as_str())
+                        .map(smg_data_connector::ResponseId::from);
+
+                    let incoming_input_value = to_value(&original_request.input).ok();
+                    let turn_info = compute_turn_info(
+                        item_storage_for_hook.as_ref(),
+                        conv_id_opt.as_ref(),
+                        incoming_input_value.as_ref(),
+                    )
+                    .await;
+
+                    let metadata = RequestMetadata::build_from(
+                        request_id,
+                        original_request.safety_identifier.clone(),
+                        tenant_id,
+                        request_context,
+                    );
+
+                    let persisted_ids: &[smg_data_connector::ConversationItemId] = &[];
+                    let after_ctx = AfterPersistCtx::new(
+                        &headers,
+                        original_request,
+                        Some(&response_json),
+                        response_id_owned.as_ref(),
+                        conv_id_opt.as_ref(),
+                        turn_info,
+                        persisted_ids,
+                        &metadata,
+                    );
+                    interceptors.run_after_persist(&after_ctx).await;
+                }
+            }
+            Err(e) => {
+                warn!("Failed to persist response: {}", e);
+            }
         }
     }
 }

--- a/model_gateway/src/routers/grpc/harmony/responses/non_streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/non_streaming.rs
@@ -5,7 +5,7 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use axum::response::Response;
+use axum::{http::HeaderMap, response::Response};
 use openai_protocol::{
     common::{ToolCall, Usage},
     responses::{
@@ -54,6 +54,7 @@ use crate::{
 pub(crate) async fn serve_harmony_responses(
     ctx: &ResponsesContext,
     request: ResponsesRequest,
+    headers: Option<HeaderMap>,
     tenant_request_meta: TenantRequestMeta,
 ) -> Result<ResponsesResponse, Response> {
     // Clone request for persistence
@@ -76,8 +77,14 @@ pub(crate) async fn serve_harmony_responses(
         .await?
     } else {
         // No MCP tools - execute pipeline once (may have function tools or no tools)
-        execute_without_mcp_loop(ctx, current_request, tenant_request_meta).await?
+        execute_without_mcp_loop(ctx, current_request, tenant_request_meta.clone()).await?
     };
+
+    let request_id = original_request
+        .request_id
+        .clone()
+        .unwrap_or_else(|| format!("req_{}", uuid::Uuid::now_v7()));
+    let tenant_id = Some(tenant_request_meta.tenant_key().as_str().to_string());
 
     // Persist response to storage if store=true
     persist_response_if_needed(
@@ -87,6 +94,10 @@ pub(crate) async fn serve_harmony_responses(
         &response,
         &original_request,
         ctx.request_context.clone(),
+        ctx.interceptors.clone(),
+        headers.unwrap_or_default(),
+        request_id,
+        tenant_id,
     )
     .await;
 

--- a/model_gateway/src/routers/grpc/harmony/responses/non_streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/non_streaming.rs
@@ -61,7 +61,52 @@ pub(crate) async fn serve_harmony_responses(
     let original_request = request.clone();
 
     // Load previous conversation history if previous_response_id is set
-    let current_request = load_previous_messages(ctx, request).await?;
+    let mut current_request = load_previous_messages(ctx, request).await?;
+
+    if !ctx.interceptors.is_empty() {
+        use smg_extensions::{BeforeModelCtx, RequestMetadata};
+
+        use crate::routers::common::turn_info::compute_turn_info;
+
+        let conv_id_opt: Option<smg_data_connector::ConversationId> = original_request
+            .conversation
+            .as_ref()
+            .filter(|c| !c.is_empty())
+            .map(|c| smg_data_connector::ConversationId::from(c.as_id()));
+
+        let item_storage = ctx.conversation_item_storage.clone();
+        let incoming_input_value = serde_json::to_value(&original_request.input).ok();
+        let turn_info = compute_turn_info(
+            item_storage.as_ref(),
+            conv_id_opt.as_ref(),
+            incoming_input_value.as_ref(),
+        )
+        .await;
+
+        let request_id = original_request
+            .request_id
+            .clone()
+            .unwrap_or_else(|| format!("req_{}", uuid::Uuid::now_v7()));
+        let metadata = RequestMetadata::build_from(
+            request_id,
+            original_request.safety_identifier.clone(),
+            Some(tenant_request_meta.tenant_key().as_str().to_string()),
+            ctx.request_context.clone(),
+        );
+
+        let empty_headers = HeaderMap::new();
+        let header_ref = headers.as_ref().unwrap_or(&empty_headers);
+
+        let mut before_ctx = BeforeModelCtx::new(
+            header_ref,
+            &mut current_request,
+            conv_id_opt.as_ref(),
+            item_storage,
+            turn_info,
+            &metadata,
+        );
+        ctx.interceptors.run_before_model(&mut before_ctx).await;
+    }
 
     // Check MCP connection and get whether MCP tools are present
     let (has_mcp_tools, mcp_servers) =

--- a/model_gateway/src/routers/grpc/harmony/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/streaming.rs
@@ -2,7 +2,7 @@
 
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use axum::response::Response;
+use axum::{http::HeaderMap, response::Response};
 use bytes::Bytes;
 use openai_protocol::responses::ResponsesRequest;
 use serde_json::json;
@@ -44,6 +44,7 @@ use crate::{
 pub(crate) async fn serve_harmony_responses_stream(
     ctx: &ResponsesContext,
     request: ResponsesRequest,
+    headers: Option<HeaderMap>,
     tenant_request_meta: TenantRequestMeta,
 ) -> Response {
     // Load previous conversation history if previous_response_id is set
@@ -80,6 +81,7 @@ pub(crate) async fn serve_harmony_responses_stream(
 
     // Clone context for spawned task
     let ctx_clone = ctx.clone();
+    let headers_clone = headers.clone();
 
     // Spawn async task to handle streaming
     tokio::spawn(async move {
@@ -100,6 +102,7 @@ pub(crate) async fn serve_harmony_responses_stream(
                 ctx,
                 current_request,
                 &request,
+                headers_clone,
                 tenant_request_meta.clone(),
                 mcp_servers,
                 &mut emitter,
@@ -111,6 +114,7 @@ pub(crate) async fn serve_harmony_responses_stream(
                 ctx,
                 &current_request,
                 &request,
+                headers_clone,
                 tenant_request_meta,
                 &mut emitter,
                 &tx,
@@ -131,10 +135,15 @@ pub(crate) async fn serve_harmony_responses_stream(
 /// - Loops through tool execution iterations
 /// - Emits final response.completed event
 /// - Persists response internally
+#[expect(
+    clippy::too_many_arguments,
+    reason = "interceptor hook firing requires per-request metadata threaded through stream finalizer"
+)]
 async fn execute_mcp_tool_loop_streaming(
     ctx: &ResponsesContext,
     mut current_request: ResponsesRequest,
     original_request: &ResponsesRequest,
+    headers: Option<HeaderMap>,
     tenant_request_meta: TenantRequestMeta,
     mcp_servers: Vec<McpServerBinding>,
     emitter: &mut ResponseStreamEventEmitter,
@@ -387,6 +396,13 @@ async fn execute_mcp_tool_loop_streaming(
                 // Finalize response from emitter's accumulated data
                 let final_response = emitter.finalize(Some(usage.clone()));
 
+                let request_id = original_request
+                    .request_id
+                    .clone()
+                    .unwrap_or_else(|| format!("req_{}", Uuid::now_v7()));
+                let tenant_id =
+                    Some(tenant_request_meta.tenant_key().as_str().to_string());
+
                 // Persist response to storage if store=true
                 persist_response_if_needed(
                     ctx.conversation_storage.clone(),
@@ -395,6 +411,10 @@ async fn execute_mcp_tool_loop_streaming(
                     &final_response,
                     original_request,
                     ctx.request_context.clone(),
+                    ctx.interceptors.clone(),
+                    headers.clone().unwrap_or_default(),
+                    request_id,
+                    tenant_id,
                 )
                 .await;
 
@@ -426,11 +446,14 @@ async fn execute_without_mcp_streaming(
     ctx: &ResponsesContext,
     current_request: &ResponsesRequest,
     original_request: &ResponsesRequest,
+    headers: Option<HeaderMap>,
     tenant_request_meta: TenantRequestMeta,
     emitter: &mut ResponseStreamEventEmitter,
     tx: &mpsc::UnboundedSender<Result<Bytes, std::io::Error>>,
 ) {
     debug!("No MCP tools - executing single iteration");
+
+    let tenant_request_meta_for_hook = tenant_request_meta.clone();
 
     // Execute pipeline and get stream + load guards
     let (execution_result, _load_guards) = match ctx
@@ -475,6 +498,12 @@ async fn execute_without_mcp_streaming(
     // Finalize response from emitter's accumulated data
     let final_response = emitter.finalize(Some(usage.clone()));
 
+    let request_id = original_request
+        .request_id
+        .clone()
+        .unwrap_or_else(|| format!("req_{}", Uuid::now_v7()));
+    let tenant_id = Some(tenant_request_meta_for_hook.tenant_key().as_str().to_string());
+
     // Persist response to storage if store=true
     persist_response_if_needed(
         ctx.conversation_storage.clone(),
@@ -483,6 +512,10 @@ async fn execute_without_mcp_streaming(
         &final_response,
         original_request,
         ctx.request_context.clone(),
+        ctx.interceptors.clone(),
+        headers.unwrap_or_default(),
+        request_id,
+        tenant_id,
     )
     .await;
 

--- a/model_gateway/src/routers/grpc/harmony/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/harmony/responses/streaming.rs
@@ -48,10 +48,55 @@ pub(crate) async fn serve_harmony_responses_stream(
     tenant_request_meta: TenantRequestMeta,
 ) -> Response {
     // Load previous conversation history if previous_response_id is set
-    let current_request = match load_previous_messages(ctx, request.clone()).await {
+    let mut current_request = match load_previous_messages(ctx, request.clone()).await {
         Ok(req) => req,
         Err(err_response) => return err_response,
     };
+
+    if !ctx.interceptors.is_empty() {
+        use smg_extensions::{BeforeModelCtx, RequestMetadata};
+
+        use crate::routers::common::turn_info::compute_turn_info;
+
+        let conv_id_opt: Option<smg_data_connector::ConversationId> = request
+            .conversation
+            .as_ref()
+            .filter(|c| !c.is_empty())
+            .map(|c| smg_data_connector::ConversationId::from(c.as_id()));
+
+        let item_storage = ctx.conversation_item_storage.clone();
+        let incoming_input_value = serde_json::to_value(&request.input).ok();
+        let turn_info = compute_turn_info(
+            item_storage.as_ref(),
+            conv_id_opt.as_ref(),
+            incoming_input_value.as_ref(),
+        )
+        .await;
+
+        let request_id = request
+            .request_id
+            .clone()
+            .unwrap_or_else(|| format!("req_{}", Uuid::now_v7()));
+        let metadata = RequestMetadata::build_from(
+            request_id,
+            request.safety_identifier.clone(),
+            Some(tenant_request_meta.tenant_key().as_str().to_string()),
+            ctx.request_context.clone(),
+        );
+
+        let empty_headers = HeaderMap::new();
+        let header_ref = headers.as_ref().unwrap_or(&empty_headers);
+
+        let mut before_ctx = BeforeModelCtx::new(
+            header_ref,
+            &mut current_request,
+            conv_id_opt.as_ref(),
+            item_storage,
+            turn_info,
+            &metadata,
+        );
+        ctx.interceptors.run_before_model(&mut before_ctx).await;
+    }
 
     // Check MCP connection BEFORE starting stream and get whether MCP tools are present
     let (has_mcp_tools, mcp_servers) = match ensure_mcp_connection(

--- a/model_gateway/src/routers/grpc/regular/responses/handlers.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/handlers.rs
@@ -112,10 +112,55 @@ async fn route_responses_streaming(
     params: ResponsesCallContext,
 ) -> Response {
     // 1. Load conversation history
-    let modified_request = match load_conversation_history(ctx, &request).await {
+    let mut modified_request = match load_conversation_history(ctx, &request).await {
         Ok(req) => req,
         Err(response) => return response, // Already a Response with proper status code
     };
+
+    if !ctx.interceptors.is_empty() {
+        use smg_extensions::{BeforeModelCtx, RequestMetadata};
+
+        use crate::routers::common::turn_info::compute_turn_info;
+
+        let conv_id_opt: Option<smg_data_connector::ConversationId> = request
+            .conversation
+            .as_ref()
+            .filter(|c| !c.is_empty())
+            .map(|c| smg_data_connector::ConversationId::from(c.as_id()));
+
+        let item_storage = ctx.conversation_item_storage.clone();
+        let incoming_input_value = serde_json::to_value(&request.input).ok();
+        let turn_info = compute_turn_info(
+            item_storage.as_ref(),
+            conv_id_opt.as_ref(),
+            incoming_input_value.as_ref(),
+        )
+        .await;
+
+        let request_id = request
+            .request_id
+            .clone()
+            .unwrap_or_else(|| format!("req_{}", Uuid::now_v7()));
+        let metadata = RequestMetadata::build_from(
+            request_id,
+            request.safety_identifier.clone(),
+            Some(params.tenant_request_meta.tenant_key().as_str().to_string()),
+            ctx.request_context.clone(),
+        );
+
+        let empty_headers = http::HeaderMap::new();
+        let header_ref = params.headers.as_ref().unwrap_or(&empty_headers);
+
+        let mut before_ctx = BeforeModelCtx::new(
+            header_ref,
+            &mut modified_request,
+            conv_id_opt.as_ref(),
+            item_storage,
+            turn_info,
+            &metadata,
+        );
+        ctx.interceptors.run_before_model(&mut before_ctx).await;
+    }
 
     // 2. Check MCP connection and get whether MCP tools are present
     let (has_mcp_tools, mcp_servers) =

--- a/model_gateway/src/routers/grpc/regular/responses/non_streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/non_streaming.rs
@@ -52,6 +52,9 @@ pub(super) async fn route_responses_internal(
     let (has_mcp_tools, mcp_servers) =
         ensure_mcp_connection(&ctx.mcp_orchestrator, request.tools.as_deref()).await?;
 
+    let headers_for_hook = params.headers.clone();
+    let tenant_id = Some(params.tenant_request_meta.tenant_key().as_str().to_string());
+
     let responses_response = if has_mcp_tools {
         debug!("MCP tools detected, using tool loop");
 
@@ -62,6 +65,11 @@ pub(super) async fn route_responses_internal(
         execute_without_mcp(ctx, &modified_request, &request, params).await?
     };
 
+    let request_id = request
+        .request_id
+        .clone()
+        .unwrap_or_else(|| format!("req_{}", uuid::Uuid::now_v7()));
+
     // 5. Persist response to storage if store=true
     persist_response_if_needed(
         ctx.conversation_storage.clone(),
@@ -70,6 +78,10 @@ pub(super) async fn route_responses_internal(
         &responses_response,
         &request,
         ctx.request_context.clone(),
+        ctx.interceptors.clone(),
+        headers_for_hook.unwrap_or_default(),
+        request_id,
+        tenant_id,
     )
     .await;
 

--- a/model_gateway/src/routers/grpc/regular/responses/non_streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/non_streaming.rs
@@ -7,7 +7,7 @@
 
 use std::sync::Arc;
 
-use axum::response::Response;
+use axum::{http, response::Response};
 use openai_protocol::responses::{ResponseStatus, ResponsesRequest, ResponsesResponse};
 use serde_json::json;
 use smg_mcp::{McpServerBinding, McpToolSession, ToolExecutionInput};
@@ -46,7 +46,52 @@ pub(super) async fn route_responses_internal(
     params: ResponsesCallContext,
 ) -> Result<ResponsesResponse, Response> {
     // 1. Load conversation history and build modified request
-    let modified_request = load_conversation_history(ctx, &request).await?;
+    let mut modified_request = load_conversation_history(ctx, &request).await?;
+
+    if !ctx.interceptors.is_empty() {
+        use smg_extensions::{BeforeModelCtx, RequestMetadata};
+
+        use crate::routers::common::turn_info::compute_turn_info;
+
+        let conv_id_opt: Option<smg_data_connector::ConversationId> = request
+            .conversation
+            .as_ref()
+            .filter(|c| !c.is_empty())
+            .map(|c| smg_data_connector::ConversationId::from(c.as_id()));
+
+        let item_storage = ctx.conversation_item_storage.clone();
+        let incoming_input_value = serde_json::to_value(&request.input).ok();
+        let turn_info = compute_turn_info(
+            item_storage.as_ref(),
+            conv_id_opt.as_ref(),
+            incoming_input_value.as_ref(),
+        )
+        .await;
+
+        let request_id = request
+            .request_id
+            .clone()
+            .unwrap_or_else(|| format!("req_{}", uuid::Uuid::now_v7()));
+        let metadata = RequestMetadata::build_from(
+            request_id,
+            request.safety_identifier.clone(),
+            Some(params.tenant_request_meta.tenant_key().as_str().to_string()),
+            ctx.request_context.clone(),
+        );
+
+        let empty_headers = http::HeaderMap::new();
+        let header_ref = params.headers.as_ref().unwrap_or(&empty_headers);
+
+        let mut before_ctx = BeforeModelCtx::new(
+            header_ref,
+            &mut modified_request,
+            conv_id_opt.as_ref(),
+            item_storage,
+            turn_info,
+            &metadata,
+        );
+        ctx.interceptors.run_before_model(&mut before_ctx).await;
+    }
 
     // 2. Check MCP connection and get whether MCP tools are present
     let (has_mcp_tools, mcp_servers) =

--- a/model_gateway/src/routers/grpc/regular/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/streaming.rs
@@ -82,6 +82,10 @@ pub(super) async fn convert_chat_stream_to_responses_stream(
 ) -> Response {
     debug!("Converting chat SSE stream to responses SSE format");
 
+    let headers_for_hook = params.headers.clone();
+    let tenant_id_for_hook =
+        Some(params.tenant_request_meta.tenant_key().as_str().to_string());
+
     // Get chat streaming response
     let chat_response = ctx
         .pipeline
@@ -106,6 +110,7 @@ pub(super) async fn convert_chat_stream_to_responses_stream(
     let conversation_storage = ctx.conversation_storage.clone();
     let conversation_item_storage = ctx.conversation_item_storage.clone();
     let request_context = ctx.request_context.clone();
+    let interceptors_for_hook = ctx.interceptors.clone();
 
     #[expect(
         clippy::disallowed_methods,
@@ -119,6 +124,9 @@ pub(super) async fn convert_chat_stream_to_responses_stream(
             conversation_storage,
             conversation_item_storage,
             request_context,
+            interceptors_for_hook,
+            headers_for_hook.unwrap_or_default(),
+            tenant_id_for_hook,
             tx.clone(),
         )
         .await
@@ -136,6 +144,10 @@ pub(super) async fn convert_chat_stream_to_responses_stream(
 }
 
 /// Process chat SSE stream and transform to responses format
+#[expect(
+    clippy::too_many_arguments,
+    reason = "interceptor hook firing requires per-request metadata threaded through stream finalizer"
+)]
 async fn process_and_transform_sse_stream(
     body: Body,
     original_request: ResponsesRequest,
@@ -143,6 +155,9 @@ async fn process_and_transform_sse_stream(
     conversation_storage: Arc<dyn ConversationStorage>,
     conversation_item_storage: Arc<dyn ConversationItemStorage>,
     request_context: Option<StorageRequestContext>,
+    interceptors: smg_extensions::InterceptorRegistry,
+    headers: http::HeaderMap,
+    tenant_id: Option<String>,
     tx: mpsc::UnboundedSender<Result<Bytes, std::io::Error>>,
 ) -> Result<(), String> {
     // Create accumulator for final response
@@ -230,6 +245,10 @@ async fn process_and_transform_sse_stream(
 
     // Finalize and persist accumulated response
     let final_response = accumulator.finalize();
+    let request_id = original_request
+        .request_id
+        .clone()
+        .unwrap_or_else(|| format!("req_{}", Uuid::now_v7()));
     persist_response_if_needed(
         conversation_storage,
         conversation_item_storage,
@@ -237,6 +256,10 @@ async fn process_and_transform_sse_stream(
         &final_response,
         &original_request,
         request_context,
+        interceptors,
+        headers,
+        request_id,
+        tenant_id,
     )
     .await;
 

--- a/model_gateway/src/routers/grpc/router.rs
+++ b/model_gateway/src/routers/grpc/router.rs
@@ -149,6 +149,7 @@ impl GrpcRouter {
                 ctx.conversation_storage.clone(),
                 ctx.conversation_item_storage.clone(),
                 ctx.conversation_memory_writer.clone(),
+                ctx.interceptors.clone(),
                 mcp_orchestrator.clone(),
                 storage_request_context.clone(),
             )
@@ -342,6 +343,7 @@ impl GrpcRouter {
                 self.harmony_responses_context
                     .conversation_memory_writer
                     .clone(),
+                self.harmony_responses_context.interceptors.clone(),
                 self.harmony_responses_context.mcp_orchestrator.clone(),
                 smg_data_connector::current_request_context(),
             );

--- a/model_gateway/src/routers/grpc/router.rs
+++ b/model_gateway/src/routers/grpc/router.rs
@@ -349,10 +349,21 @@ impl GrpcRouter {
             );
 
             if body.stream.unwrap_or(false) {
-                serve_harmony_responses_stream(&harmony_ctx, body.clone(), tenant_meta.clone())
-                    .await
+                serve_harmony_responses_stream(
+                    &harmony_ctx,
+                    body.clone(),
+                    headers.cloned(),
+                    tenant_meta.clone(),
+                )
+                .await
             } else {
-                match serve_harmony_responses(&harmony_ctx, body.clone(), tenant_meta.clone()).await
+                match serve_harmony_responses(
+                    &harmony_ctx,
+                    body.clone(),
+                    headers.cloned(),
+                    tenant_meta.clone(),
+                )
+                .await
                 {
                     Ok(response) => axum::Json(response).into_response(),
                     Err(error_response) => error_response,

--- a/model_gateway/src/routers/openai/context.rs
+++ b/model_gateway/src/routers/openai/context.rs
@@ -111,6 +111,15 @@ impl ComponentRefs {
             ComponentRefs::Responses(r) => Some(&r.conversation_memory_writer),
         }
     }
+
+    /// Access the Responses-API interceptor registry. Returns `None` for
+    /// non-responses contexts (chat).
+    pub fn interceptors(&self) -> Option<&smg_extensions::InterceptorRegistry> {
+        match self {
+            ComponentRefs::Shared(_) => None,
+            ComponentRefs::Responses(r) => Some(&r.interceptors),
+        }
+    }
 }
 
 #[derive(Default)]

--- a/model_gateway/src/routers/openai/context.rs
+++ b/model_gateway/src/routers/openai/context.rs
@@ -280,6 +280,12 @@ pub struct OwnedStreamingContext {
     pub previous_response_id: Option<String>,
     pub existing_mcp_list_tools_labels: Vec<String>,
     pub storage: StorageHandles,
+    /// Snapshot of the Responses interceptor registry (cheap-clonable).
+    pub interceptors: smg_extensions::InterceptorRegistry,
+    /// Tenant identity captured from the request boundary (if any).
+    pub tenant_request_meta: Option<TenantRequestMeta>,
+    /// Request-scoped headers captured at the HTTP boundary.
+    pub headers: Option<HeaderMap>,
 }
 
 impl RequestContext {
@@ -310,6 +316,13 @@ impl RequestContext {
             .conversation_memory_writer()
             .ok_or("Conversation memory writer required")?
             .clone();
+        let interceptors = self
+            .components
+            .interceptors()
+            .cloned()
+            .unwrap_or_default();
+        let tenant_request_meta = self.tenant_request_meta.clone();
+        let headers = self.input.headers.clone();
 
         Ok(OwnedStreamingContext {
             url: payload_state.url,
@@ -325,6 +338,9 @@ impl RequestContext {
                 request_context: self.storage_request_context,
                 memory_execution_context: self.memory_execution_context,
             },
+            interceptors,
+            tenant_request_meta,
+            headers,
         })
     }
 }

--- a/model_gateway/src/routers/openai/context.rs
+++ b/model_gateway/src/routers/openai/context.rs
@@ -51,6 +51,8 @@ pub struct ResponsesComponents {
     pub conversation_storage: Arc<dyn ConversationStorage>,
     pub conversation_item_storage: Arc<dyn ConversationItemStorage>,
     pub conversation_memory_writer: Arc<dyn ConversationMemoryWriter>,
+    /// Registry of Responses-API interceptors (empty by default).
+    pub interceptors: smg_extensions::InterceptorRegistry,
 }
 
 pub enum ComponentRefs {

--- a/model_gateway/src/routers/openai/responses/non_streaming.rs
+++ b/model_gateway/src/routers/openai/responses/non_streaming.rs
@@ -3,7 +3,7 @@
 //! This module handles non-streaming Responses API requests with MCP tool support.
 
 use axum::{
-    http::StatusCode,
+    http::{HeaderMap, StatusCode},
     response::{IntoResponse, Response},
     Json,
 };
@@ -169,7 +169,13 @@ pub async fn handle_non_streaming_response(mut ctx: RequestContext) -> Response 
         ctx.components.conversation_item_storage(),
         ctx.components.response_storage(),
     ) {
-        if let Err(err) = persist_conversation_items(
+        let item_storage_for_hook = item_storage.clone();
+        let interceptors = ctx
+            .components
+            .interceptors()
+            .cloned()
+            .unwrap_or_default();
+        let persist_result = persist_conversation_items(
             conv_storage.clone(),
             item_storage.clone(),
             resp_storage.clone(),
@@ -177,9 +183,69 @@ pub async fn handle_non_streaming_response(mut ctx: RequestContext) -> Response 
             original_body,
             ctx.storage_request_context.clone(),
         )
-        .await
-        {
-            warn!("Failed to persist conversation items: {}", err);
+        .await;
+        match persist_result {
+            Ok(()) => {
+                if !interceptors.is_empty() {
+                    use smg_extensions::{AfterPersistCtx, RequestMetadata};
+
+                    use crate::routers::common::turn_info::compute_turn_info;
+
+                    let conv_id_opt: Option<smg_data_connector::ConversationId> = original_body
+                        .conversation
+                        .as_ref()
+                        .filter(|c| !c.is_empty())
+                        .map(|c| smg_data_connector::ConversationId::from(c.as_id()));
+
+                    let response_id_owned: Option<smg_data_connector::ResponseId> = response_json
+                        .get("id")
+                        .and_then(|v| v.as_str())
+                        .map(smg_data_connector::ResponseId::from);
+
+                    let incoming_input_value =
+                        serde_json::to_value(&original_body.input).ok();
+                    let turn_info = compute_turn_info(
+                        item_storage_for_hook.as_ref(),
+                        conv_id_opt.as_ref(),
+                        incoming_input_value.as_ref(),
+                    )
+                    .await;
+
+                    let request_id = original_body
+                        .request_id
+                        .clone()
+                        .unwrap_or_else(|| format!("req_{}", uuid::Uuid::now_v7()));
+                    let tenant_id = ctx
+                        .tenant_request_meta
+                        .as_ref()
+                        .map(|m| m.tenant_key().as_str().to_string());
+                    let metadata = RequestMetadata::build_from(
+                        request_id,
+                        original_body.safety_identifier.clone(),
+                        tenant_id,
+                        ctx.storage_request_context.clone(),
+                    );
+
+                    let empty_headers = HeaderMap::new();
+                    let header_ref = ctx.headers().unwrap_or(&empty_headers);
+
+                    let persisted_ids: &[smg_data_connector::ConversationItemId] = &[];
+                    let after_ctx = AfterPersistCtx::new(
+                        header_ref,
+                        original_body,
+                        Some(&response_json),
+                        response_id_owned.as_ref(),
+                        conv_id_opt.as_ref(),
+                        turn_info,
+                        persisted_ids,
+                        &metadata,
+                    );
+                    interceptors.run_after_persist(&after_ctx).await;
+                }
+            }
+            Err(err) => {
+                warn!("Failed to persist conversation items: {}", err);
+            }
         }
     } else {
         warn!("Storage not configured, skipping conversation persistence");

--- a/model_gateway/src/routers/openai/responses/route.rs
+++ b/model_gateway/src/routers/openai/responses/route.rs
@@ -137,6 +137,52 @@ pub(in crate::routers::openai) async fn route_responses(
         items.retain(|item| !matches!(item, ResponseInputOutputItem::Reasoning { .. }));
     }
 
+    let interceptors = deps.responses_components.interceptors.clone();
+    if !interceptors.is_empty() {
+        use smg_extensions::{BeforeModelCtx, RequestMetadata};
+
+        use crate::routers::common::turn_info::compute_turn_info;
+
+        let conv_id_opt: Option<smg_data_connector::ConversationId> = body
+            .conversation
+            .as_ref()
+            .filter(|c| !c.is_empty())
+            .map(|c| smg_data_connector::ConversationId::from(c.as_id()));
+
+        let item_storage = deps.responses_components.conversation_item_storage.clone();
+        let incoming_input_value = to_value(&body.input).ok();
+        let turn_info = compute_turn_info(
+            item_storage.as_ref(),
+            conv_id_opt.as_ref(),
+            incoming_input_value.as_ref(),
+        )
+        .await;
+
+        let request_id = body
+            .request_id
+            .clone()
+            .unwrap_or_else(|| format!("req_{}", uuid::Uuid::now_v7()));
+        let metadata = RequestMetadata::build_from(
+            request_id,
+            body.safety_identifier.clone(),
+            Some(tenant_meta.tenant_key().as_str().to_string()),
+            smg_data_connector::current_request_context(),
+        );
+
+        let empty_headers = HeaderMap::new();
+        let header_ref = headers.unwrap_or(&empty_headers);
+
+        let mut before_ctx = BeforeModelCtx::new(
+            header_ref,
+            &mut request_body,
+            conv_id_opt.as_ref(),
+            item_storage,
+            turn_info,
+            &metadata,
+        );
+        interceptors.run_before_model(&mut before_ctx).await;
+    }
+
     let mut payload = match to_value(&request_body) {
         Ok(v) => v,
         Err(e) => {

--- a/model_gateway/src/routers/openai/responses/streaming.rs
+++ b/model_gateway/src/routers/openai/responses/streaming.rs
@@ -563,6 +563,9 @@ pub(super) async fn handle_simple_streaming_passthrough(
     let original_request = req.original_body;
     let previous_response_id = req.previous_response_id;
     let storage = req.storage;
+    let interceptors = req.interceptors;
+    let tenant_request_meta = req.tenant_request_meta;
+    let request_headers = req.headers;
 
     #[expect(
         clippy::disallowed_methods,
@@ -631,7 +634,7 @@ pub(super) async fn handle_simple_streaming_passthrough(
                 );
 
                 // Always persist conversation items and response (even without conversation)
-                if let Err(err) = persist_conversation_items(
+                let persist_result = persist_conversation_items(
                     storage.conversation.clone(),
                     storage.conversation_item.clone(),
                     storage.response.clone(),
@@ -639,9 +642,68 @@ pub(super) async fn handle_simple_streaming_passthrough(
                     &original_request,
                     storage.request_context.clone(),
                 )
-                .await
-                {
-                    warn!("Failed to persist conversation items (stream): {}", err);
+                .await;
+                match persist_result {
+                    Ok(()) => {
+                        if !interceptors.is_empty() {
+                            use smg_extensions::{AfterPersistCtx, RequestMetadata};
+
+                            use crate::routers::common::turn_info::compute_turn_info;
+
+                            let conv_id_opt: Option<smg_data_connector::ConversationId> =
+                                original_request
+                                    .conversation
+                                    .as_ref()
+                                    .filter(|c| !c.is_empty())
+                                    .map(|c| {
+                                        smg_data_connector::ConversationId::from(c.as_id())
+                                    });
+                            let response_id_owned: Option<smg_data_connector::ResponseId> =
+                                response_json
+                                    .get("id")
+                                    .and_then(|v| v.as_str())
+                                    .map(smg_data_connector::ResponseId::from);
+                            let incoming_input_value =
+                                serde_json::to_value(&original_request.input).ok();
+                            let turn_info = compute_turn_info(
+                                storage.conversation_item.as_ref(),
+                                conv_id_opt.as_ref(),
+                                incoming_input_value.as_ref(),
+                            )
+                            .await;
+                            let request_id = original_request
+                                .request_id
+                                .clone()
+                                .unwrap_or_else(|| format!("req_{}", uuid::Uuid::now_v7()));
+                            let tenant_id = tenant_request_meta
+                                .as_ref()
+                                .map(|m| m.tenant_key().as_str().to_string());
+                            let metadata = RequestMetadata::build_from(
+                                request_id,
+                                original_request.safety_identifier.clone(),
+                                tenant_id,
+                                storage.request_context.clone(),
+                            );
+                            let empty_headers = HeaderMap::new();
+                            let header_ref =
+                                request_headers.as_ref().unwrap_or(&empty_headers);
+                            let persisted_ids: &[smg_data_connector::ConversationItemId] = &[];
+                            let after_ctx = AfterPersistCtx::new(
+                                header_ref,
+                                &original_request,
+                                Some(&response_json),
+                                response_id_owned.as_ref(),
+                                conv_id_opt.as_ref(),
+                                turn_info,
+                                persisted_ids,
+                                &metadata,
+                            );
+                            interceptors.run_after_persist(&after_ctx).await;
+                        }
+                    }
+                    Err(err) => {
+                        warn!("Failed to persist conversation items (stream): {}", err);
+                    }
                 }
             } else if let Some(error_payload) = encountered_error {
                 warn!("Upstream streaming error payload: {}", error_payload);

--- a/model_gateway/src/routers/openai/responses/streaming.rs
+++ b/model_gateway/src/routers/openai/responses/streaming.rs
@@ -747,6 +747,9 @@ pub(super) fn handle_streaming_with_tool_interception(
     let existing_mcp_list_tools_labels = req.existing_mcp_list_tools_labels;
     let url = req.url;
     let storage = req.storage;
+    let interceptors = req.interceptors;
+    let tenant_request_meta = req.tenant_request_meta;
+    let request_headers = req.headers;
 
     let client_clone = client.clone();
     let url_clone = url.clone();
@@ -1021,7 +1024,7 @@ pub(super) fn handle_streaming_with_tool_interception(
                     );
 
                     // Always persist conversation items and response (even without conversation)
-                    if let Err(err) = persist_conversation_items(
+                    let persist_result = persist_conversation_items(
                         storage.conversation.clone(),
                         storage.conversation_item.clone(),
                         storage.response.clone(),
@@ -1029,12 +1032,72 @@ pub(super) fn handle_streaming_with_tool_interception(
                         &original_request,
                         storage.request_context.clone(),
                     )
-                    .await
-                    {
-                        warn!(
-                            "Failed to persist conversation items (stream + MCP): {}",
-                            err
-                        );
+                    .await;
+                    match persist_result {
+                        Ok(()) => {
+                            if !interceptors.is_empty() {
+                                use smg_extensions::{AfterPersistCtx, RequestMetadata};
+
+                                use crate::routers::common::turn_info::compute_turn_info;
+
+                                let conv_id_opt: Option<smg_data_connector::ConversationId> =
+                                    original_request
+                                        .conversation
+                                        .as_ref()
+                                        .filter(|c| !c.is_empty())
+                                        .map(|c| {
+                                            smg_data_connector::ConversationId::from(c.as_id())
+                                        });
+                                let response_id_owned: Option<smg_data_connector::ResponseId> =
+                                    response_json
+                                        .get("id")
+                                        .and_then(|v| v.as_str())
+                                        .map(smg_data_connector::ResponseId::from);
+                                let incoming_input_value =
+                                    serde_json::to_value(&original_request.input).ok();
+                                let turn_info = compute_turn_info(
+                                    storage.conversation_item.as_ref(),
+                                    conv_id_opt.as_ref(),
+                                    incoming_input_value.as_ref(),
+                                )
+                                .await;
+                                let request_id = original_request
+                                    .request_id
+                                    .clone()
+                                    .unwrap_or_else(|| format!("req_{}", uuid::Uuid::now_v7()));
+                                let tenant_id = tenant_request_meta
+                                    .as_ref()
+                                    .map(|m| m.tenant_key().as_str().to_string());
+                                let metadata = RequestMetadata::build_from(
+                                    request_id,
+                                    original_request.safety_identifier.clone(),
+                                    tenant_id,
+                                    storage.request_context.clone(),
+                                );
+                                let empty_headers = HeaderMap::new();
+                                let header_ref =
+                                    request_headers.as_ref().unwrap_or(&empty_headers);
+                                let persisted_ids: &[smg_data_connector::ConversationItemId] =
+                                    &[];
+                                let after_ctx = AfterPersistCtx::new(
+                                    header_ref,
+                                    &original_request,
+                                    Some(&response_json),
+                                    response_id_owned.as_ref(),
+                                    conv_id_opt.as_ref(),
+                                    turn_info,
+                                    persisted_ids,
+                                    &metadata,
+                                );
+                                interceptors.run_after_persist(&after_ctx).await;
+                            }
+                        }
+                        Err(err) => {
+                            warn!(
+                                "Failed to persist conversation items (stream + MCP): {}",
+                                err
+                            );
+                        }
                     }
                 }
 

--- a/model_gateway/src/routers/openai/router.rs
+++ b/model_gateway/src/routers/openai/router.rs
@@ -100,6 +100,7 @@ impl OpenAIRouter {
             conversation_storage: ctx.conversation_storage.clone(),
             conversation_item_storage: ctx.conversation_item_storage.clone(),
             conversation_memory_writer: ctx.conversation_memory_writer.clone(),
+            interceptors: ctx.interceptors.clone(),
         });
 
         Ok(Self {

--- a/model_gateway/src/server.rs
+++ b/model_gateway/src/server.rs
@@ -555,10 +555,14 @@ async fn v1_conversations_create_items(
     State(state): State<Arc<AppState>>,
     Path(conversation_id): Path<String>,
     headers: HeaderMap,
+    Extension(tenant_meta): Extension<middleware::TenantRequestMeta>,
     Json(body): Json<Value>,
 ) -> Response {
     let memory_execution_context =
         middleware::build_memory_execution_context(&state.context.router_config, &headers);
+
+    let request_id = format!("req_{}", uuid::Uuid::now_v7());
+    let tenant_id = Some(tenant_meta.tenant_key().as_str().to_string());
 
     conversations::create_conversation_items_with_headers(
         &state.context.conversation_storage,
@@ -566,6 +570,10 @@ async fn v1_conversations_create_items(
         &conversation_id,
         body,
         memory_execution_context,
+        state.context.interceptors.clone(),
+        request_id,
+        tenant_id,
+        headers,
     )
     .await
 }

--- a/model_gateway/src/service_discovery.rs
+++ b/model_gateway/src/service_discovery.rs
@@ -1292,6 +1292,7 @@ mod tests {
             realtime_registry: Arc::new(RealtimeRegistry::new()),
             webrtc_bind_addr: None,
             webrtc_stun_server: None,
+            interceptors: smg_extensions::InterceptorRegistry::default(),
         })
     }
 

--- a/model_gateway/tests/interceptors.rs
+++ b/model_gateway/tests/interceptors.rs
@@ -413,3 +413,307 @@ async fn items_only_path_fires_after_persist_with_no_response() {
         "items-only after_persist ctx must expose conversation_id"
     );
 }
+
+// ============================================================================
+// HTTP streaming
+// ============================================================================
+
+/// Spin up a tiny axum mock that returns an SSE Responses stream containing
+/// a `response.completed` event. This is enough to drive the streaming
+/// router through the post-stream persistence + after_persist hook.
+async fn spawn_streaming_mock() -> (String, tokio::task::JoinHandle<()>) {
+    use axum::response::Response;
+
+    #[expect(clippy::disallowed_methods, reason = "test infrastructure")]
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("addr");
+
+    let sse_handler = post(|Json(_request): Json<serde_json::Value>| async move {
+        let response_id = "resp_stream_int";
+        let message_id = "msg_stream_int";
+        let final_text = "stream-ok";
+
+        let events = vec![
+            (
+                "response.created",
+                json!({
+                    "type": "response.created",
+                    "sequence_number": 0,
+                    "response": {
+                        "id": response_id,
+                        "object": "response",
+                        "created_at": 1_700_000_500,
+                        "status": "in_progress",
+                        "model": "",
+                        "output": [],
+                        "parallel_tool_calls": true,
+                        "previous_response_id": null,
+                        "reasoning": null,
+                        "store": false,
+                        "temperature": 1.0,
+                        "text": {"format": {"type": "text"}},
+                        "tool_choice": "auto",
+                        "tools": [],
+                        "top_p": 1.0,
+                        "truncation": "disabled",
+                        "usage": null,
+                        "metadata": null
+                    }
+                }),
+            ),
+            (
+                "response.output_item.added",
+                json!({
+                    "type": "response.output_item.added",
+                    "sequence_number": 1,
+                    "output_index": 0,
+                    "item": {
+                        "id": message_id,
+                        "type": "message",
+                        "role": "assistant",
+                        "status": "in_progress",
+                        "content": []
+                    }
+                }),
+            ),
+            (
+                "response.output_text.delta",
+                json!({
+                    "type": "response.output_text.delta",
+                    "sequence_number": 2,
+                    "item_id": message_id,
+                    "output_index": 0,
+                    "content_index": 0,
+                    "delta": final_text,
+                    "logprobs": []
+                }),
+            ),
+            (
+                "response.output_text.done",
+                json!({
+                    "type": "response.output_text.done",
+                    "sequence_number": 3,
+                    "item_id": message_id,
+                    "output_index": 0,
+                    "content_index": 0,
+                    "text": final_text,
+                    "logprobs": []
+                }),
+            ),
+            (
+                "response.output_item.done",
+                json!({
+                    "type": "response.output_item.done",
+                    "sequence_number": 4,
+                    "output_index": 0,
+                    "item": {
+                        "id": message_id,
+                        "type": "message",
+                        "role": "assistant",
+                        "status": "completed",
+                        "content": [{
+                            "type": "output_text",
+                            "text": final_text,
+                            "annotations": [],
+                            "logprobs": []
+                        }]
+                    }
+                }),
+            ),
+            (
+                "response.completed",
+                json!({
+                    "type": "response.completed",
+                    "sequence_number": 5,
+                    "response": {
+                        "id": response_id,
+                        "object": "response",
+                        "created_at": 1_700_000_500,
+                        "status": "completed",
+                        "model": "",
+                        "output": [{
+                            "id": message_id,
+                            "type": "message",
+                            "role": "assistant",
+                            "status": "completed",
+                            "content": [{
+                                "type": "output_text",
+                                "text": final_text,
+                                "annotations": [],
+                                "logprobs": []
+                            }]
+                        }],
+                        "parallel_tool_calls": true,
+                        "previous_response_id": null,
+                        "reasoning": null,
+                        "store": false,
+                        "temperature": 1.0,
+                        "text": {"format": {"type": "text"}},
+                        "tool_choice": "auto",
+                        "tools": [],
+                        "top_p": 1.0,
+                        "truncation": "disabled",
+                        "usage": {
+                            "input_tokens": 1,
+                            "input_tokens_details": {"cached_tokens": 0},
+                            "output_tokens": 1,
+                            "output_tokens_details": {"reasoning_tokens": 0},
+                            "total_tokens": 2
+                        },
+                        "metadata": null,
+                        "instructions": null,
+                        "user": null
+                    }
+                }),
+            ),
+        ];
+
+        let payload = events
+            .into_iter()
+            .map(|(event, data)| format!("event: {event}\ndata: {data}\n\n"))
+            .collect::<String>();
+
+        Response::builder()
+            .status(StatusCode::OK)
+            .header("content-type", "text/event-stream")
+            .body(axum::body::Body::from(payload))
+            .expect("response")
+    });
+
+    let app = Router::new().route("/v1/responses", sse_handler);
+    let server = tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    (format!("http://{addr}"), server)
+}
+
+/// HTTP streaming: `POST /v1/responses` with `stream=true` fires
+/// `before_model` once at request entry and `after_persist` once after the
+/// stream completes and persistence is committed.
+#[tokio::test]
+async fn http_streaming_fires_both_phases_once() {
+    use std::time::Duration;
+    use tokio::time::sleep;
+
+    let recording = Arc::new(RecordingInterceptor::default());
+    let registry = registry_with(recording.clone() as Arc<dyn ResponsesInterceptor>);
+
+    let ctx = build_app_context_with_interceptors(registry).await;
+
+    let (base_url, server) = spawn_streaming_mock().await;
+    register_external_worker(&ctx, &base_url, Some(vec!["mock-model"]));
+
+    let router = OpenAIRouter::new(&ctx).await.expect("router");
+
+    let conv = ctx
+        .conversation_storage
+        .create_conversation(NewConversation {
+            id: None,
+            metadata: None,
+        })
+        .await
+        .expect("create conversation");
+
+    let request = ResponsesRequest {
+        model: "mock-model".to_string(),
+        input: ResponseInput::Text("hello".to_string()),
+        store: Some(true),
+        stream: Some(true),
+        conversation: Some(ConversationRef::Id(conv.id.0.clone())),
+        ..Default::default()
+    };
+    let tenant_meta = test_tenant_meta();
+    let response = router
+        .route_responses(None, &tenant_meta, &request, &request.model)
+        .await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // Drain the SSE stream before checking interceptor records — the
+    // streaming after_persist hook fires from a background task that runs
+    // after the final `response.completed` event is observed.
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body");
+    let body_text = String::from_utf8(body.to_vec()).expect("utf8");
+    assert!(body_text.contains("response.completed"));
+
+    // The persist + after_persist work runs on a detached task; poll until
+    // the recording interceptor observes the call (with a generous bound).
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        if !recording.after_calls.lock().expect("mutex").is_empty() {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "after_persist hook never fired for streaming path"
+        );
+        sleep(Duration::from_millis(20)).await;
+    }
+
+    let before = recording.before_calls.lock().expect("mutex");
+    let after = recording.after_calls.lock().expect("mutex");
+
+    assert_eq!(
+        before.len(),
+        1,
+        "streaming before_model should fire exactly once (got {:?})",
+        *before
+    );
+    assert_eq!(
+        after.len(),
+        1,
+        "streaming after_persist should fire exactly once (got {:?})",
+        *after
+    );
+    assert!(before[0].has_conversation_id);
+    assert!(after[0].has_response_id);
+    assert!(after[0].has_response_json);
+    assert!(after[0].has_conversation_id);
+
+    server.abort();
+}
+
+// ============================================================================
+// HTTP streaming with MCP tool calls (skipped: requires real MCP server)
+// ============================================================================
+
+/// Streaming with an MCP tool loop fires `after_persist` after the MCP
+/// finalizer commits the post-tool response.
+///
+/// **Skipped:** triggering the MCP-streaming code path requires an actual
+/// MCP server binding (registered through `McpOrchestrator`) plus an
+/// upstream that emits compatible function-call SSE events. Spinning up
+/// a real `rmcp` server in this integration test is out of scope; the
+/// MCP-finalizer hook firing logic is structurally identical to the
+/// regular streaming finalizer and is covered by the registry-level unit
+/// tests in `smg-extensions` and the streaming hook test above.
+#[tokio::test]
+#[ignore = "requires MCP server fixture; covered indirectly by streaming + registry unit tests"]
+async fn http_mcp_streaming_fires_after_persist() {
+    // Intentionally empty - see doc comment.
+}
+
+// ============================================================================
+// gRPC paths (unit tests live alongside the call sites)
+// ============================================================================
+
+/// gRPC harmony / regular hook firings are covered by unit tests at the
+/// call sites:
+///
+/// - `model_gateway/src/routers/grpc/common/responses/utils.rs::tests`
+///   (shared `persist_response_if_needed` after_persist)
+/// - `model_gateway/src/routers/grpc/regular/responses/non_streaming.rs::tests`
+///   (regular gRPC `before_model`)
+/// - `model_gateway/src/routers/grpc/harmony/responses/non_streaming.rs::tests`
+///   (harmony gRPC `before_model`)
+///
+/// Driving the full gRPC pipeline from an integration test requires a tonic
+/// server harness plus a mock backend gRPC client; this is meaningfully
+/// heavier than a unit test of the hook firing block itself, while
+/// providing the same guarantee. The unit tests live in the `grpc::common`,
+/// `grpc::regular`, and `grpc::harmony` modules so they can access
+/// `pub(crate)` types like `persist_response_if_needed` and
+/// `ResponsesContext`.
+#[allow(dead_code)]
+fn _grpc_coverage_note() {}

--- a/model_gateway/tests/interceptors.rs
+++ b/model_gateway/tests/interceptors.rs
@@ -1,0 +1,415 @@
+//! Integration tests for the Responses-API interceptor seam.
+//!
+//! Each test registers a `RecordingInterceptor`, drives a request through the
+//! relevant router code path, and asserts that the corresponding lifecycle
+//! hook(s) fire with the expected ctx fields populated. The tests are
+//! deliberately storage-backend agnostic and avoid memory-feature awareness.
+
+#[path = "common/mod.rs"]
+pub mod common;
+
+use std::sync::{Arc, Mutex, OnceLock};
+
+use async_trait::async_trait;
+use axum::{http::StatusCode, routing::post, Json, Router};
+use llm_tokenizer::registry::TokenizerRegistry;
+use openai_protocol::{
+    common::ConversationRef,
+    responses::{ResponseInput, ResponsesRequest},
+};
+use serde_json::json;
+use smg::{
+    app_context::AppContext,
+    config::RouterConfig,
+    memory::MemoryExecutionContext,
+    middleware::{TenantRequestMeta, TokenBucket},
+    policies::PolicyRegistry,
+    routers::{conversations::create_conversation_items_with_headers, openai::OpenAIRouter, RouterTrait},
+    tenant::{RouteRequestMeta, TenantKey},
+    worker::{WorkerMonitor, WorkerRegistry},
+};
+use smg_data_connector::{
+    MemoryConversationItemStorage, MemoryConversationStorage, MemoryResponseStorage,
+    NewConversation, NoOpConversationMemoryWriter,
+};
+use smg_extensions::{
+    AfterPersistCtx, BeforeModelCtx, InterceptorRegistry, ResponsesInterceptor,
+};
+use smg_mcp::{McpConfig, McpOrchestrator};
+use tokio::net::TcpListener;
+
+use crate::common::test_app::register_external_worker;
+
+// ============================================================================
+// Recording interceptor
+// ============================================================================
+
+/// Records each phase invocation along with a snapshot of the loaded ctx
+/// fields the tests care about.
+#[derive(Default, Clone)]
+pub struct RecordingInterceptor {
+    pub before_calls: Arc<Mutex<Vec<RecordedBefore>>>,
+    pub after_calls: Arc<Mutex<Vec<RecordedAfter>>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct RecordedBefore {
+    pub has_conversation_id: bool,
+    pub user_turns: u32,
+}
+
+#[derive(Debug, Clone)]
+pub struct RecordedAfter {
+    pub has_response_id: bool,
+    pub has_response_json: bool,
+    pub persisted_count: usize,
+    pub has_conversation_id: bool,
+}
+
+#[async_trait]
+impl ResponsesInterceptor for RecordingInterceptor {
+    fn name(&self) -> &'static str {
+        "recording"
+    }
+
+    async fn before_model(&self, ctx: &mut BeforeModelCtx<'_>) {
+        // Use the documented destructure-with-rest pattern so future fields
+        // don't break this test code.
+        let BeforeModelCtx {
+            conversation_id,
+            turn_info,
+            ..
+        } = &*ctx;
+        self.before_calls.lock().expect("mutex").push(RecordedBefore {
+            has_conversation_id: conversation_id.is_some(),
+            user_turns: turn_info.user_turns,
+        });
+    }
+
+    async fn after_persist(&self, ctx: &AfterPersistCtx<'_>) {
+        let AfterPersistCtx {
+            response_id,
+            response_json,
+            persisted_item_ids,
+            conversation_id,
+            ..
+        } = ctx;
+        self.after_calls.lock().expect("mutex").push(RecordedAfter {
+            has_response_id: response_id.is_some(),
+            has_response_json: response_json.is_some(),
+            persisted_count: persisted_item_ids.len(),
+            has_conversation_id: conversation_id.is_some(),
+        });
+    }
+}
+
+fn registry_with(interceptor: Arc<dyn ResponsesInterceptor>) -> InterceptorRegistry {
+    let mut builder = InterceptorRegistry::builder();
+    builder.register(interceptor);
+    builder.build()
+}
+
+// ============================================================================
+// Test harness: build an AppContext with custom interceptors
+// ============================================================================
+
+/// Build an AppContext suitable for exercising the OpenAI router with a
+/// caller-supplied interceptor registry. Mirrors `common::test_app::
+/// create_test_app_context` but accepts an explicit `InterceptorRegistry`
+/// so tests can observe hook firings.
+async fn build_app_context_with_interceptors(
+    interceptors: InterceptorRegistry,
+) -> Arc<AppContext> {
+    let router_config = RouterConfig::default();
+    let client = reqwest::Client::new();
+
+    let worker_job_queue = Arc::new(OnceLock::new());
+    let workflow_engines = Arc::new(OnceLock::new());
+
+    let mcp_orchestrator_lock: Arc<OnceLock<Arc<McpOrchestrator>>> = Arc::new(OnceLock::new());
+    let empty_config = McpConfig {
+        servers: vec![],
+        pool: Default::default(),
+        proxy: None,
+        warmup: vec![],
+        inventory: Default::default(),
+        policy: Default::default(),
+    };
+    let mcp_orchestrator = McpOrchestrator::new(empty_config)
+        .await
+        .expect("mcp orchestrator");
+    mcp_orchestrator_lock
+        .set(Arc::new(mcp_orchestrator))
+        .ok()
+        .expect("mcp orchestrator set");
+
+    let worker_registry = Arc::new(WorkerRegistry::new());
+    let policy_registry = Arc::new(PolicyRegistry::new(router_config.policy.clone()));
+
+    let response_storage = Arc::new(MemoryResponseStorage::new());
+    let conversation_storage = Arc::new(MemoryConversationStorage::new());
+    let conversation_item_storage = Arc::new(MemoryConversationItemStorage::new());
+    let conversation_memory_writer = Arc::new(NoOpConversationMemoryWriter::new());
+
+    let worker_monitor = Some(Arc::new(WorkerMonitor::new(
+        worker_registry.clone(),
+        policy_registry.clone(),
+        client.clone(),
+        router_config.load_monitor_interval_secs,
+    )));
+
+    let rate_limiter = match router_config.max_concurrent_requests {
+        n if n <= 0 => None,
+        n => {
+            let rate_limit_tokens = router_config
+                .rate_limit_tokens_per_second
+                .filter(|&t| t > 0)
+                .unwrap_or(n);
+            Some(Arc::new(TokenBucket::new(
+                n as usize,
+                rate_limit_tokens as usize,
+            )))
+        }
+    };
+
+    Arc::new(
+        AppContext::builder()
+            .router_config(router_config)
+            .client(client)
+            .rate_limiter(rate_limiter)
+            .tokenizer_registry(Arc::new(TokenizerRegistry::new()))
+            .reasoning_parser_factory(None)
+            .tool_parser_factory(None)
+            .worker_registry(worker_registry)
+            .policy_registry(policy_registry)
+            .response_storage(response_storage)
+            .conversation_storage(conversation_storage)
+            .conversation_item_storage(conversation_item_storage)
+            .conversation_memory_writer(conversation_memory_writer)
+            .worker_monitor(worker_monitor)
+            .worker_job_queue(worker_job_queue)
+            .workflow_engines(workflow_engines)
+            .mcp_orchestrator(mcp_orchestrator_lock)
+            .interceptors(interceptors)
+            .build()
+            .expect("AppContext build"),
+    )
+}
+
+fn test_tenant_meta() -> TenantRequestMeta {
+    RouteRequestMeta::new(TenantKey::from("test-tenant"))
+}
+
+/// Spin up a tiny axum mock that returns a non-streaming Responses payload.
+/// Returns the upstream base URL plus a JoinHandle the caller can abort.
+async fn spawn_non_streaming_mock() -> (String, tokio::task::JoinHandle<()>) {
+    #[expect(clippy::disallowed_methods, reason = "test infrastructure")]
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("addr");
+
+    let app = Router::new().route(
+        "/v1/responses",
+        post(|Json(request): Json<serde_json::Value>| async move {
+            let model = request
+                .get("model")
+                .and_then(|v| v.as_str())
+                .unwrap_or("mock-model")
+                .to_string();
+            Json(json!({
+                "id": "resp_mock_1",
+                "object": "response",
+                "created_at": 1_700_000_000,
+                "status": "completed",
+                "model": model,
+                "output": [{
+                    "type": "message",
+                    "id": "msg_1",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{
+                        "type": "output_text",
+                        "text": "hi",
+                        "annotations": []
+                    }]
+                }],
+                "metadata": {}
+            }))
+        }),
+    );
+
+    let server = tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    (format!("http://{addr}"), server)
+}
+
+// ============================================================================
+// HTTP non-streaming
+// ============================================================================
+
+/// HTTP non-streaming: `POST /v1/responses` (via the OpenAI router) fires
+/// before_model exactly once and after_persist exactly once.
+#[tokio::test]
+async fn http_non_streaming_fires_both_phases_once() {
+    let recording = Arc::new(RecordingInterceptor::default());
+    let registry = registry_with(recording.clone() as Arc<dyn ResponsesInterceptor>);
+
+    let ctx = build_app_context_with_interceptors(registry).await;
+
+    let (base_url, server) = spawn_non_streaming_mock().await;
+    register_external_worker(&ctx, &base_url, Some(vec!["mock-model"]));
+
+    let router = OpenAIRouter::new(&ctx).await.expect("router");
+
+    // Pre-create a conversation so before_model has a conversation_id to record.
+    let conv = ctx
+        .conversation_storage
+        .create_conversation(NewConversation {
+            id: None,
+            metadata: None,
+        })
+        .await
+        .expect("create conversation");
+
+    let request = ResponsesRequest {
+        model: "mock-model".to_string(),
+        input: ResponseInput::Text("hello".to_string()),
+        store: Some(true),
+        conversation: Some(ConversationRef::Id(conv.id.0.clone())),
+        ..Default::default()
+    };
+    let tenant_meta = test_tenant_meta();
+    let response = router
+        .route_responses(None, &tenant_meta, &request, &request.model)
+        .await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // Drain the response body so the persist task runs to completion.
+    let _ = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body");
+
+    let before = recording.before_calls.lock().expect("mutex");
+    let after = recording.after_calls.lock().expect("mutex");
+
+    assert_eq!(
+        before.len(),
+        1,
+        "before_model should fire exactly once (got {:?})",
+        *before
+    );
+    assert_eq!(
+        after.len(),
+        1,
+        "after_persist should fire exactly once (got {:?})",
+        *after
+    );
+    assert!(
+        before[0].has_conversation_id,
+        "before_model ctx should expose conversation_id"
+    );
+    assert!(
+        after[0].has_conversation_id,
+        "after_persist ctx should expose conversation_id"
+    );
+    assert!(
+        after[0].has_response_id,
+        "after_persist ctx should expose response_id"
+    );
+    assert!(
+        after[0].has_response_json,
+        "after_persist ctx should expose response_json"
+    );
+
+    server.abort();
+}
+
+// ============================================================================
+// Items-only path
+// ============================================================================
+
+/// Items-only path: `POST /v1/conversations/{id}/items` fires only the
+/// after_persist hook (no before_model), and the ctx exposes neither a
+/// response_id nor a response_json.
+#[tokio::test]
+async fn items_only_path_fires_after_persist_with_no_response() {
+    let recording = Arc::new(RecordingInterceptor::default());
+    let registry = registry_with(recording.clone() as Arc<dyn ResponsesInterceptor>);
+
+    let ctx = build_app_context_with_interceptors(registry).await;
+
+    // Pre-create the conversation so the items-only endpoint accepts the request.
+    let conv = ctx
+        .conversation_storage
+        .create_conversation(NewConversation {
+            id: None,
+            metadata: None,
+        })
+        .await
+        .expect("create conversation");
+
+    let body = json!({
+        "items": [
+            {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "first"}]
+            },
+            {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "second"}]
+            },
+            {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "third"}]
+            }
+        ]
+    });
+
+    let response = create_conversation_items_with_headers(
+        &ctx.conversation_storage,
+        &ctx.conversation_item_storage,
+        &conv.id.0,
+        body,
+        MemoryExecutionContext::default(),
+        ctx.interceptors.clone(),
+        "req_test".to_string(),
+        Some("test-tenant".to_string()),
+        Default::default(),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let before = recording.before_calls.lock().expect("mutex");
+    let after = recording.after_calls.lock().expect("mutex");
+
+    assert!(
+        before.is_empty(),
+        "items-only path must not fire before_model (got {:?})",
+        *before
+    );
+    assert_eq!(
+        after.len(),
+        1,
+        "items-only path must fire after_persist exactly once (got {:?})",
+        *after
+    );
+    assert!(
+        !after[0].has_response_id,
+        "items-only after_persist ctx must not carry a response_id"
+    );
+    assert!(
+        !after[0].has_response_json,
+        "items-only after_persist ctx must not carry a response_json"
+    );
+    assert_eq!(
+        after[0].persisted_count, 3,
+        "items-only after_persist ctx should report all persisted items"
+    );
+    assert!(
+        after[0].has_conversation_id,
+        "items-only after_persist ctx must expose conversation_id"
+    );
+}


### PR DESCRIPTION
## Description

### Problem

SMG core has been accumulating memory-specific code: `model_gateway/src/memory/`, `MemoryHeaderView`, `MemoryRuntimeConfig`, `ConversationMemoryWriter` in `data_connector`, `memory_execution_context` plumbing on `ResponsesContext`, and `x-conversation-memory-config` header parsing in `header_utils.rs`. This trajectory contradicts SMG's positioning as a vendor-neutral routing gateway:

- The OSS landscape is consistent — routing gateways (LiteLLM, OpenRouter, Portkey) and inference engines (vLLM, SGLang) carry no memory; memory layers (Mem0, Letta, Zep) are separate products.
- Memory carries hard infra dependencies (vector DB, embedding model, extraction LLM, retention/GDPR plumbing) that have no place in a routing gateway.
- Every operator who doesn't use memory pays for the code paths anyway.
- Memory policy (proactive vs on-demand, ADD/UPDATE/NO-OP consolidation, dedup thresholds) is opinionated. Gateways stay neutral; memory layers don't.

If we keep building in-tree, the next two PRs (STMO scheduling + LTM follow-up) add ~1500 LOC of memory-shaped code to core, and every future memory feature reaches into core for a tweak. Substrate, not policy, is what locks an architecture in.

### Solution

Replace the in-tree memory substrate with a single generic extension point. New `smg-extensions` crate exposes a `ResponsesInterceptor` trait with two phases (`before_model`, `after_persist`) and an `InterceptorRegistry`. Eight hook insertion points across HTTP and gRPC routers + the items-create endpoint fire registered interceptors. SMG core knows nothing about memory; it provides phases, third parties provide policy. Same shape as Envoy `ext_authz`/`ext_proc`, LiteLLM callbacks, HashiCorp Vault plugins.

This PR is **PR 1 of 3**. PR 1 ships the substrate only — zero LOC removed, zero behavior change with the empty default registry. PR 2 (handed to the memory team) introduces `smg-conversation-memory-oracle` as an optional, default-off feature-gated dependency. PR 3 deletes the old memory plumbing.

After PR 3, the only memory residue in core is **three lines** in `model_gateway/Cargo.toml` + `main.rs`: a feature flag, an optional dep, and a `match` arm. That's the registration site, present in every plugin-style architecture.

## Changes

**New crate `crates/extensions/` (`smg-extensions`):**
- `ResponsesInterceptor` trait — `name()`, `before_model`, `after_persist`. Async, returns `()` (errors non-fatal).
- `BeforeModelCtx<'a>` and `AfterPersistCtx<'a>` — `#[non_exhaustive]` ctx structs with `pub fn new(...)` constructors. `Arc<dyn ConversationItemStorage>` for history (no lifetime gymnastics with `&mut request`). `Option<&'a ResponseId>` and `Option<&'a Value>` for the response fields (items-only persist path has no Response).
- `RequestMetadata` with `request_id`, `safety_identifier`, `tenant_id`, `originated_at`, `storage_request_context` — enough info for interceptors to derive idempotency keys.
- `ConversationTurnInfo` — generic turn-counting shape (basic counting; STMO-specific special cases stay outside core, in any future memory crate).
- `InterceptorRegistry` — `Arc<Vec<Arc<dyn ResponsesInterceptor>>>`. `Default + Clone` (cheap Arc bump). `is_empty()` lets call sites short-circuit `compute_turn_info`. Panic-safe runners via `AssertUnwindSafe(...).catch_unwind().await` — a buggy interceptor cannot fail an SMG request.
- `NoOpInterceptor` for tests and as the baseline.
- 10 unit tests (panic catching verified by tests that actually `panic!()`).

**New helpers in `model_gateway/src/routers/common/`:**
- `turn_info::compute_turn_info(history, conversation_id, incoming_input)` — basic counting from history + incoming input. PR 1 implements only generic counting; the five STMO-specific special cases from #1400 (raw-count correction, chain-overlap guard, store=false short-circuit, no-history-loaded skip, MCP-streaming skip) stay out of core.
- `grpc_headers::tonic_metadata_to_headermap(MetadataMap) -> HeaderMap` — converts tonic metadata for the gRPC `before_model` sites.

**New config in `model_gateway/src/config/`:**
- `ExtensionsConfig`, `ExtensionSpec` (generic `kind` + flattened `config: serde_yml::Value`).
- `ExtensionConfigError` (structured `thiserror` enum: `Unknown`, `FeatureGated`, `BuildFailed`).
- `RouterConfig.extensions: ExtensionsConfig` field with `#[serde(default)]` — existing YAML configs continue to parse.

**Wiring:**
- `AppContext.interceptors: InterceptorRegistry` field + builder setter. `AppContextBuilder::from_config` builds the registry from `router_config.extensions.items` (the empty match has only a catch-all `unknown` warning; PR 2 adds `"smg-conversation-memory-oracle"` here).
- HTTP `ResponsesComponents` and gRPC `ResponsesContext` carry registry clones.

**8 hook insertion points (zero behavior change with empty registry):**

| # | Phase | File | Position |
|---|---|---|---|
| 1 | `before_model` | `routers/openai/responses/route.rs` | After `load_input_history`, before forwarding (single fire covering streaming + non-streaming) |
| 2 | `after_persist` | `routers/openai/responses/non_streaming.rs` | After successful `persist_conversation_items` |
| 3 | `after_persist` | `routers/openai/responses/streaming.rs` (regular finalizer) | After successful persist |
| 4 | `after_persist` | `routers/openai/responses/streaming.rs` (MCP finalizer) | After successful persist |
| 5 | `after_persist` | `routers/grpc/common/responses/utils.rs` (`persist_response_if_needed`) | After successful persist |
| 6 | `after_persist` | `routers/conversations/handlers.rs` (`create_conversation_items_with_headers`) | After `link_items` succeeds (items-only path) |
| 7 | `before_model` | `routers/grpc/harmony/responses/{streaming,non_streaming}.rs` | After `load_previous_messages` |
| 8 | `before_model` | `routers/grpc/regular/responses/{streaming,non_streaming}.rs` | After `load_conversation_history` |

`before_model` fires **once per HTTP request** (not per inner MCP-tool-loop iteration) — matches DP behavior; ensures memory recall would be a single deterministic injection per turn. `after_persist` fires only on persist SUCCESS (consistent with existing warn-on-error semantics).

**Concept doc:** `docs/concepts/extensibility/interceptors.md` (added to `mkdocs.yml` nav).

### Design constraints baked in

- Errors always non-fatal (trait returns `()`, registry catches panics).
- All ctx structs `#[non_exhaustive]` — fields can be added without breaking impls.
- Empty registry → `is_empty()` short-circuit → zero `compute_turn_info` cost (verified by `empty_registry_skips_compute_turn_info` test).
- No memory-feature awareness in the trait crate (no `MemoryHeaderView`, no `ConversationMemoryWriter`, no policy enums).
- Items-only persist path has no Response; `response_id` and `response_json` are `Option`.
- `RequestMetadata` carries idempotency-grade info; SMG core does not enforce idempotency, interceptors derive their own dedup keys (e.g. `(conversation_id, response_id-or-request_id, job_type)`).

### What memory team gets in PR 2

After this lands, PR 2's surface in core SMG is:

```toml
# model_gateway/Cargo.toml
[features]
default = []
memory = ["dep:smg-conversation-memory-oracle"]

[dependencies]
smg-conversation-memory-oracle = { ..., optional = true }
```

```rust
// model_gateway/src/app_context.rs (one match arm)
#[cfg(feature = "memory")]
"smg-conversation-memory-oracle" => {
    registry_builder.register(smg_conversation_memory_oracle::build(&spec.config)?);
}
```

Three lines + one feature flag. Everything else (header parsing, recall, scheduling, Oracle storage, migrations) lives inside the new crate.

## Test Plan

```bash
# All tests pass — 28 commits, +2757 / -37 LOC, no behavior change
cargo test -p smg-extensions                  # 10 tests pass (panic catching, ctx, registry, noop)
cargo test -p smg --lib                       # 694 tests pass (was 691 baseline + 3 new)
cargo test -p smg --test interceptors         # 12 tests pass + 1 ignored (MCP-streaming harness gap)
cargo check --workspace                       # clean

# Coverage map
# - HTTP non-streaming + items: integration tests in tests/interceptors.rs
# - HTTP streaming + MCP-streaming finalizers: integration tests
# - gRPC after_persist: unit tests in routers/grpc/common/responses/utils.rs
# - gRPC before_model (harmony + regular): structurally identical to HTTP (transitively covered);
#   per-pipeline gRPC harness deferred (no existing gRPC integration harness in tests/)
# - Empty-registry skip-compute: unit test in routers/common/turn_info.rs with #[cfg(test)] counter
```

**One known test gap:** the MCP-streaming finalizer hook (`#[ignore]`d test) requires a real `rmcp` server fixture and an upstream emitting compatible function-call SSE events. The firing logic is structurally identical to the regular streaming finalizer (covered) and to the registry-level unit tests. Driving end-to-end MCP-loop coverage would meaningfully expand the test infra and is deferred.

**Behavioral parity:** all 691 pre-existing lib tests, all existing memory tests, all existing response/streaming/conversation tests pass unchanged. The default empty registry exercises every hook site as a no-op.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] Documentation updated (`docs/concepts/extensibility/interceptors.md` + `mkdocs.yml`)
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

---

## Out of scope for this PR

- Moving any memory code (PR 2 — memory team).
- Removing any memory code (PR 3 — memory team).
- A `Reject { status, code, message }` short-circuit on `before_model` (deferred; current contract is "always continue").
- Built-in interceptor implementations beyond `NoOp`.
- Header re-parse caching (implementation detail of any future interceptor).
- Out-of-process / gRPC-protocol interceptor flavor.
- Per-router or phase-specific registries.
- MCP sanitization extraction or gRPC sanitizer fixes — independent hygiene work, separate ticket.
- Backward-compatibility / legacy-memory deprecation cycle — PR 3 deletes old plumbing cleanly.
