### PR TITLE
fix(router): require model for IGW generate requests

### DIFF
--- a/model_gateway/src/routers/router_manager.rs
+++ b/model_gateway/src/routers/router_manager.rs
@@ -34,6 +34,7 @@ use openai_protocol::{
     rerank::RerankRequest,
     responses::ResponsesRequest,
     transcription::TranscriptionRequest,
+    UNKNOWN_MODEL_ID,
 };
 use serde_json::Value;
 use smg_skills::{
@@ -245,6 +246,10 @@ impl RouterManager {
         } else {
             None
         }
+    }
+
+    fn requires_explicit_generate_model(&self, model_id: &str) -> bool {
+        self.enable_igw && (model_id.trim().is_empty() || model_id == UNKNOWN_MODEL_ID)
     }
 
     pub fn select_router_for_request(
@@ -524,6 +529,13 @@ impl RouterTrait for RouterManager {
         body: &GenerateRequest,
         model_id: &str,
     ) -> Response {
+        if self.requires_explicit_generate_model(model_id) {
+            return route_error::bad_request(
+                "missing_model",
+                "/generate requests must include a model when IGW routing is enabled",
+            );
+        }
+
         let router = self.select_router_for_request(headers, Some(model_id));
 
         if let Some(router) = router {
@@ -886,5 +898,90 @@ impl std::fmt::Debug for RouterManager {
             .field("workers_count", &self.worker_registry.get_all().len())
             .field("default_router", &*default_router)
             .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use async_trait::async_trait;
+
+    use super::*;
+    use crate::{
+        middleware::{RouteRequestMeta, TenantKey},
+        routers::factory::router_ids,
+        worker::WorkerRegistry,
+    };
+
+    #[derive(Debug)]
+    struct StubRouter;
+
+    #[async_trait]
+    impl RouterTrait for StubRouter {
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+
+        async fn route_generate(
+            &self,
+            _headers: Option<&HeaderMap>,
+            _tenant_meta: &TenantRequestMeta,
+            _body: &GenerateRequest,
+            _model_id: &str,
+        ) -> Response {
+            (StatusCode::OK, "routed").into_response()
+        }
+
+        fn router_type(&self) -> &'static str {
+            "stub"
+        }
+    }
+
+    fn test_manager(enable_igw: bool) -> Arc<RouterManager> {
+        let mut manager =
+            RouterManager::new(Arc::new(WorkerRegistry::new()), reqwest::Client::new());
+        manager.enable_igw = enable_igw;
+        let manager = Arc::new(manager);
+        manager.register_router(router_ids::HTTP_REGULAR, Arc::new(StubRouter));
+        manager
+    }
+
+    fn test_tenant_meta() -> TenantRequestMeta {
+        RouteRequestMeta::new(TenantKey::from("test-tenant"))
+    }
+
+    fn generate_request_without_model() -> GenerateRequest {
+        serde_json::from_value(serde_json::json!({ "text": "hello" })).unwrap()
+    }
+
+    #[tokio::test]
+    async fn igw_generate_rejects_default_unknown_model() {
+        let manager = test_manager(true);
+        let request = generate_request_without_model();
+
+        assert_eq!(request.model, UNKNOWN_MODEL_ID);
+
+        let response = manager
+            .route_generate(None, &test_tenant_meta(), &request, &request.model)
+            .await;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(
+            route_error::extract_error_code_from_response(&response),
+            "missing_model"
+        );
+    }
+
+    #[tokio::test]
+    async fn single_router_generate_keeps_default_unknown_model_behavior() {
+        let manager = test_manager(false);
+        let request = generate_request_without_model();
+
+        assert_eq!(request.model, UNKNOWN_MODEL_ID);
+
+        let response = manager
+            .route_generate(None, &test_tenant_meta(), &request, &request.model)
+            .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
     }
 }


### PR DESCRIPTION
## Description

### Problem

`/generate` treats an omitted `model` as the protocol sentinel `"unknown"`. In IGW mode that sentinel can flow into router selection and worker selection, where it behaves like a wildcard. In a multi-model gateway this can send a request without an explicit model to an arbitrary compatible router/worker.

### Solution

Reject missing, blank, or default `"unknown"` `/generate` model IDs in `RouterManager` when IGW routing is enabled. This returns a structured `400 missing_model` before router selection. Single-router mode keeps the existing omitted-model behavior.

## Changes

- add an IGW-only `/generate` explicit-model guard in `RouterManager`
- return `missing_model` before wildcard router/worker selection can run
- add regression coverage for IGW rejection and single-router compatibility

## Test Plan

- `cargo +nightly fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p smg routers::router_manager::tests`
- `cargo test -p smg --test routing_tests -- --test-threads=1`
- `cargo test -p smg --test routing_tests routing::test_pd_routing::pd_routing_unit_tests::test_large_batch_bootstrap_injection -- --nocapture`
- `SKIP=rustfmt,clippy,no-commit-to-branch,branch-name-check,dco-check,no-ai-co-author pre-commit run --all-files --show-diff-on-failure`

Note: `cargo test` under local default parallelism hit an unrelated timing assertion in `routing::test_pd_routing::pd_routing_unit_tests::test_large_batch_bootstrap_injection` twice (`batch_size 1024` took about 12.4s). The same test passed isolated in 41-48ms and the full `routing_tests` binary passed serially. The changed router-manager tests passed in both full runs before that unrelated routing test failure.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for generate requests when IGW is enabled. Requests with missing or invalid model identifiers now return a proper error response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->