### PR TITLE
refactor(server): extract /v1/audio/transcriptions multipart parsing into FromRequest

### DIFF
--- a/crates/protocols/Cargo.toml
+++ b/crates/protocols/Cargo.toml
@@ -15,11 +15,12 @@ categories = ["api-bindings", "data-structures"]
 
 [features]
 default = []
-axum = ["dep:axum"]
+axum = ["dep:axum", "axum/multipart"]
 
 [dependencies]
 axum = { workspace = true, optional = true }
 bitflags.workspace = true
+bytes = "1.8.0"
 chrono.workspace = true
 rand.workspace = true
 serde = { workspace = true, features = ["derive"] }

--- a/crates/protocols/src/lib.rs
+++ b/crates/protocols/src/lib.rs
@@ -20,6 +20,7 @@ pub mod messages;
 pub mod model_card;
 pub mod model_type;
 pub mod models;
+pub mod multipart;
 pub mod parser;
 pub mod realtime_conversation;
 pub mod realtime_events;

--- a/crates/protocols/src/multipart.rs
+++ b/crates/protocols/src/multipart.rs
@@ -1,0 +1,162 @@
+//! Axum extractors for multipart/form-data inference endpoints.
+//!
+//! JSON endpoints get [`crate::validated::ValidatedJson`]; the
+//! `/v1/audio/transcriptions` endpoint uses multipart/form-data and gets
+//! [`AudioTranscriptionMultipart`], which parses the form into a typed
+//! `(TranscriptionRequest, AudioFile)` pair before the handler runs.
+
+#[cfg(feature = "axum")]
+use axum::{
+    extract::{multipart::MultipartError, FromRequest, Multipart, Request},
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+
+#[cfg(feature = "axum")]
+use crate::transcription::{AudioFile, TranscriptionRequest};
+
+/// Extractor for `/v1/audio/transcriptions` requests.
+///
+/// Parses `multipart/form-data` into a [`TranscriptionRequest`] (text fields)
+/// plus an [`AudioFile`] (the `file` part). Returns `400 Bad Request` on
+/// malformed parts, missing/empty `file`, missing/blank `model`, or
+/// out-of-range `temperature`.
+#[cfg(feature = "axum")]
+pub struct AudioTranscriptionMultipart {
+    pub request: TranscriptionRequest,
+    pub audio: AudioFile,
+}
+
+#[cfg(feature = "axum")]
+impl<S: Send + Sync> FromRequest<S> for AudioTranscriptionMultipart {
+    type Rejection = Response;
+
+    async fn from_request(req: Request, state: &S) -> Result<Self, Self::Rejection> {
+        let mut multipart = Multipart::from_request(req, state)
+            .await
+            .map_err(IntoResponse::into_response)?;
+
+        let mut file_bytes: Option<bytes::Bytes> = None;
+        let mut file_name: Option<String> = None;
+        let mut file_content_type: Option<String> = None;
+        let mut request = TranscriptionRequest::default();
+        let mut timestamp_granularities: Vec<String> = Vec::new();
+
+        loop {
+            let field = match multipart.next_field().await {
+                Ok(Some(f)) => f,
+                Ok(None) => break,
+                Err(e) => {
+                    return Err(bad_request(format!("Failed to read multipart field: {e}")));
+                }
+            };
+
+            let name = field.name().unwrap_or("").to_string();
+            match name.as_str() {
+                "file" => {
+                    file_name = field.file_name().map(str::to_string);
+                    file_content_type = field.content_type().map(str::to_string);
+                    match field.bytes().await {
+                        Ok(b) => file_bytes = Some(b),
+                        Err(e) => {
+                            return Err(bad_request(format!(
+                                "Failed to read audio file bytes: {e}"
+                            )));
+                        }
+                    }
+                }
+                "model" => match field.text().await {
+                    Ok(t) => request.model = t,
+                    Err(e) => return Err(bad_text_field("model", e)),
+                },
+                "language" => match field.text().await {
+                    Ok(t) => request.language = Some(t),
+                    Err(e) => return Err(bad_text_field("language", e)),
+                },
+                "prompt" => match field.text().await {
+                    Ok(t) => request.prompt = Some(t),
+                    Err(e) => return Err(bad_text_field("prompt", e)),
+                },
+                "response_format" => match field.text().await {
+                    Ok(t) => request.response_format = Some(t),
+                    Err(e) => return Err(bad_text_field("response_format", e)),
+                },
+                "temperature" => match field.text().await {
+                    Ok(t) => match t.trim().parse::<f32>() {
+                        Ok(v) if v.is_finite() && (0.0..=1.0).contains(&v) => {
+                            request.temperature = Some(v);
+                        }
+                        Ok(v) => {
+                            return Err(bad_request(format!(
+                                "Invalid 'temperature' value: {v} (must be a finite number in [0.0, 1.0])"
+                            )));
+                        }
+                        Err(e) => {
+                            return Err(bad_request(format!("Invalid 'temperature' value: {e}")));
+                        }
+                    },
+                    Err(e) => return Err(bad_text_field("temperature", e)),
+                },
+                "timestamp_granularities" | "timestamp_granularities[]" => {
+                    match field.text().await {
+                        Ok(t) => timestamp_granularities.push(t),
+                        Err(e) => return Err(bad_text_field("timestamp_granularities", e)),
+                    }
+                }
+                "stream" => match field.text().await {
+                    Ok(t) => match t.as_str() {
+                        "true" | "True" | "TRUE" | "1" => request.stream = Some(true),
+                        "false" | "False" | "FALSE" | "0" => request.stream = Some(false),
+                        other => {
+                            return Err(bad_request(format!(
+                                "Invalid 'stream' value: '{other}' (expected true/false/1/0)"
+                            )));
+                        }
+                    },
+                    Err(e) => return Err(bad_text_field("stream", e)),
+                },
+                _ => {
+                    // Unknown field; drain to free resources but otherwise ignore.
+                    let _ = field.bytes().await;
+                }
+            }
+        }
+
+        if request.model.trim().is_empty() {
+            return Err(bad_request("Missing required 'model' field".to_string()));
+        }
+        request.model = request.model.trim().to_string();
+
+        let bytes = match file_bytes {
+            Some(b) if !b.is_empty() => b,
+            Some(_) => {
+                return Err(bad_request("Uploaded 'file' part is empty".to_string()));
+            }
+            None => {
+                return Err(bad_request("Missing required 'file' part".to_string()));
+            }
+        };
+
+        if !timestamp_granularities.is_empty() {
+            request.timestamp_granularities = Some(timestamp_granularities);
+        }
+
+        let audio = AudioFile {
+            bytes,
+            file_name: file_name.unwrap_or_else(|| "audio".to_string()),
+            content_type: file_content_type,
+        };
+
+        Ok(AudioTranscriptionMultipart { request, audio })
+    }
+}
+
+#[cfg(feature = "axum")]
+fn bad_request(message: String) -> Response {
+    (StatusCode::BAD_REQUEST, message).into_response()
+}
+
+#[cfg(feature = "axum")]
+fn bad_text_field(field: &str, e: MultipartError) -> Response {
+    bad_request(format!("Failed to read '{field}' field: {e}"))
+}

--- a/crates/protocols/src/transcription.rs
+++ b/crates/protocols/src/transcription.rs
@@ -54,3 +54,17 @@ impl GenerationRequest for TranscriptionRequest {
         self.prompt.clone().unwrap_or_default()
     }
 }
+
+/// Binary audio payload for `/v1/audio/transcriptions`.
+///
+/// The transcription endpoint uses multipart/form-data, so the file bytes
+/// travel alongside the JSON-like `TranscriptionRequest` rather than inside it.
+#[derive(Debug, Clone)]
+pub struct AudioFile {
+    /// Raw audio bytes (wav/mp3/m4a/etc.).
+    pub bytes: bytes::Bytes,
+    /// Original filename from the multipart part. Forwarded verbatim to the worker.
+    pub file_name: String,
+    /// Original content-type of the audio part (e.g. `audio/wav`), if the client supplied one.
+    pub content_type: Option<String>,
+}

--- a/model_gateway/src/routers/http/router.rs
+++ b/model_gateway/src/routers/http/router.rs
@@ -17,7 +17,7 @@ use openai_protocol::{
     generate::GenerateRequest,
     rerank::{RerankRequest, RerankResponse, RerankResult},
     responses::ResponsesRequest,
-    transcription::TranscriptionRequest,
+    transcription::{AudioFile, TranscriptionRequest},
 };
 use reqwest::{
     multipart::{Form, Part},
@@ -44,7 +44,7 @@ use crate::{
         },
         error::{self, extract_error_code_from_response},
         grpc::utils::{error_type_from_status, route_to_endpoint},
-        AudioFile, RouterTrait,
+        RouterTrait,
     },
     worker::{AttachedBody, ConnectionMode, Worker, WorkerLoadGuard, WorkerRegistry, WorkerType},
 };

--- a/model_gateway/src/routers/mod.rs
+++ b/model_gateway/src/routers/mod.rs
@@ -23,7 +23,7 @@ use openai_protocol::{
     },
     rerank::RerankRequest,
     responses::ResponsesRequest,
-    transcription::TranscriptionRequest,
+    transcription::{AudioFile, TranscriptionRequest},
 };
 
 use crate::middleware::TenantRequestMeta;
@@ -47,20 +47,6 @@ pub mod tokenize;
 pub use factory::RouterFactory;
 // Re-export HTTP routers for convenience
 pub use http::{pd_router, pd_types, router};
-
-/// Binary audio payload for `/v1/audio/transcriptions`.
-///
-/// The transcription endpoint uses multipart/form-data, so the file bytes
-/// travel alongside the JSON-like `TranscriptionRequest` rather than inside it.
-#[derive(Debug, Clone)]
-pub struct AudioFile {
-    /// Raw audio bytes (wav/mp3/m4a/etc.).
-    pub bytes: bytes::Bytes,
-    /// Original filename from the multipart part. Forwarded verbatim to the worker.
-    pub file_name: String,
-    /// Original content-type of the audio part (e.g. `audio/wav`), if the client supplied one.
-    pub content_type: Option<String>,
-}
 
 /// Core trait for all router implementations
 ///

--- a/model_gateway/src/routers/router_manager.rs
+++ b/model_gateway/src/routers/router_manager.rs
@@ -33,7 +33,7 @@ use openai_protocol::{
     },
     rerank::RerankRequest,
     responses::ResponsesRequest,
-    transcription::TranscriptionRequest,
+    transcription::{AudioFile, TranscriptionRequest},
     UNKNOWN_MODEL_ID,
 };
 use serde_json::Value;
@@ -52,7 +52,7 @@ use crate::{
         common::header_utils::apply_provider_headers,
         error as route_error,
         factory::{router_ids, RouterId},
-        AudioFile, RouterFactory, RouterTrait,
+        RouterFactory, RouterTrait,
     },
     server::ServerConfig,
     worker::{ConnectionMode, ProviderType, RuntimeType, WorkerRegistry, WorkerType},

--- a/model_gateway/src/server.rs
+++ b/model_gateway/src/server.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use axum::{
-    extract::{multipart::MultipartError, Extension, Multipart, Path, Query, Request, State},
+    extract::{Extension, Multipart, Path, Query, Request, State},
     http::{header::InvalidHeaderName, HeaderMap, StatusCode},
     response::{IntoResponse, Response},
     routing::{delete, get, post},
@@ -22,6 +22,7 @@ use openai_protocol::{
     generate::GenerateRequest,
     interactions::InteractionsRequest,
     messages::CreateMessageRequest,
+    multipart::AudioTranscriptionMultipart,
     parser::{ParseFunctionCallRequest, SeparateReasoningRequest},
     realtime_session::{
         RealtimeClientSecretCreateRequest, RealtimeSessionCreateRequest,
@@ -34,7 +35,6 @@ use openai_protocol::{
         SkillsListQuery,
     },
     tokenize::{AddTokenizerRequest, DetokenizeRequest, TokenizeRequest},
-    transcription::TranscriptionRequest,
     validated::ValidatedJson,
     worker::{WorkerSpec, WorkerUpdateRequest},
 };
@@ -67,7 +67,7 @@ use crate::{
         openai::realtime::ws::RealtimeQueryParams,
         parse, responses as response_handlers,
         router_manager::RouterManager,
-        skills, tokenize, AudioFile, RouterTrait,
+        skills, tokenize, RouterTrait,
     },
     service_discovery::{start_service_discovery, ServiceDiscoveryConfig},
     wasm::route::{add_wasm_module, list_wasm_modules, remove_wasm_module},
@@ -314,145 +314,18 @@ async fn v1_audio_transcriptions(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
     Extension(tenant_meta): Extension<middleware::TenantRequestMeta>,
-    mut multipart: Multipart,
+    AudioTranscriptionMultipart { request, audio }: AudioTranscriptionMultipart,
 ) -> Response {
-    let mut file_bytes: Option<bytes::Bytes> = None;
-    let mut file_name: Option<String> = None;
-    let mut file_content_type: Option<String> = None;
-    let mut req = TranscriptionRequest::default();
-    let mut timestamp_granularities: Vec<String> = Vec::new();
-
-    loop {
-        let field = match multipart.next_field().await {
-            Ok(Some(f)) => f,
-            Ok(None) => break,
-            Err(e) => {
-                return (
-                    StatusCode::BAD_REQUEST,
-                    format!("Failed to read multipart field: {e}"),
-                )
-                    .into_response();
-            }
-        };
-
-        let name = field.name().unwrap_or("").to_string();
-        match name.as_str() {
-            "file" => {
-                file_name = field.file_name().map(str::to_string);
-                file_content_type = field.content_type().map(str::to_string);
-                match field.bytes().await {
-                    Ok(b) => file_bytes = Some(b),
-                    Err(e) => {
-                        return (
-                            StatusCode::BAD_REQUEST,
-                            format!("Failed to read audio file bytes: {e}"),
-                        )
-                            .into_response();
-                    }
-                }
-            }
-            "model" => match field.text().await {
-                Ok(t) => req.model = t,
-                Err(e) => return bad_text_field("model", e),
-            },
-            "language" => match field.text().await {
-                Ok(t) => req.language = Some(t),
-                Err(e) => return bad_text_field("language", e),
-            },
-            "prompt" => match field.text().await {
-                Ok(t) => req.prompt = Some(t),
-                Err(e) => return bad_text_field("prompt", e),
-            },
-            "response_format" => match field.text().await {
-                Ok(t) => req.response_format = Some(t),
-                Err(e) => return bad_text_field("response_format", e),
-            },
-            "temperature" => match field.text().await {
-                Ok(t) => match t.trim().parse::<f32>() {
-                    Ok(v) if v.is_finite() && (0.0..=1.0).contains(&v) => {
-                        req.temperature = Some(v);
-                    }
-                    Ok(v) => {
-                        return (
-                            StatusCode::BAD_REQUEST,
-                            format!(
-                                "Invalid 'temperature' value: {v} (must be a finite number in [0.0, 1.0])"
-                            ),
-                        )
-                            .into_response();
-                    }
-                    Err(e) => {
-                        return (
-                            StatusCode::BAD_REQUEST,
-                            format!("Invalid 'temperature' value: {e}"),
-                        )
-                            .into_response();
-                    }
-                },
-                Err(e) => return bad_text_field("temperature", e),
-            },
-            "timestamp_granularities" | "timestamp_granularities[]" => match field.text().await {
-                Ok(t) => timestamp_granularities.push(t),
-                Err(e) => return bad_text_field("timestamp_granularities", e),
-            },
-            "stream" => match field.text().await {
-                Ok(t) => match t.as_str() {
-                    "true" | "True" | "TRUE" | "1" => req.stream = Some(true),
-                    "false" | "False" | "FALSE" | "0" => req.stream = Some(false),
-                    other => {
-                        return (
-                            StatusCode::BAD_REQUEST,
-                            format!("Invalid 'stream' value: '{other}' (expected true/false/1/0)"),
-                        )
-                            .into_response();
-                    }
-                },
-                Err(e) => return bad_text_field("stream", e),
-            },
-            _ => {
-                // Unknown field; drain to free resources but otherwise ignore.
-                let _ = field.bytes().await;
-            }
-        }
-    }
-
-    // Reject blank/whitespace-only `model` before it reaches worker selection.
-    if req.model.trim().is_empty() {
-        return (StatusCode::BAD_REQUEST, "Missing required 'model' field").into_response();
-    }
-    req.model = req.model.trim().to_string();
-    let bytes = match file_bytes {
-        Some(b) if !b.is_empty() => b,
-        Some(_) => {
-            return (StatusCode::BAD_REQUEST, "Uploaded 'file' part is empty").into_response();
-        }
-        None => {
-            return (StatusCode::BAD_REQUEST, "Missing required 'file' part").into_response();
-        }
-    };
-
-    if !timestamp_granularities.is_empty() {
-        req.timestamp_granularities = Some(timestamp_granularities);
-    }
-
-    let audio = AudioFile {
-        bytes,
-        file_name: file_name.unwrap_or_else(|| "audio".to_string()),
-        content_type: file_content_type,
-    };
-
     state
         .router
-        .route_audio_transcriptions(Some(&headers), &tenant_meta, &req, audio, &req.model)
+        .route_audio_transcriptions(
+            Some(&headers),
+            &tenant_meta,
+            &request,
+            audio,
+            &request.model,
+        )
         .await
-}
-
-fn bad_text_field(field: &str, e: MultipartError) -> Response {
-    (
-        StatusCode::BAD_REQUEST,
-        format!("Failed to read '{field}' field: {e}"),
-    )
-        .into_response()
 }
 
 async fn v1_responses_get(


### PR DESCRIPTION
## Description

### Problem

`v1_audio_transcriptions` in `model_gateway/src/server.rs` was the only inference handler doing inline `multipart/form-data` parsing — about 135 lines of manual field extraction, per-field error responses, temperature range checking, stream coercion, and model/file validation. Every other endpoint (`v1_chat_completions`, `v1_completions`, `v1_classify`, `v1_embeddings`, etc.) is a 5–8 line function that delegates to a custom Axum extractor (`ValidatedJson<T>` from `openai-protocol`) and then forwards to `state.router.route_X(...)`. The transcription handler broke that symmetry and made the routing call hard to find.

### Solution

Move the multipart parsing into a new `FromRequest` extractor (`AudioTranscriptionMultipart`) in `openai-protocol`, modeled directly on `ValidatedJson`. The handler shrinks to match every other endpoint: extract typed request → forward to router. Routing/dispatch (`RouterTrait::route_audio_transcriptions`, `Router::route_multipart_transcription`, `build_transcription_form`) was already correct and is unchanged.

`AudioFile` moves from `model_gateway/src/routers/mod.rs` into `openai_protocol::transcription` (next to `TranscriptionRequest`) so the extractor can construct it without taking a dependency on `model_gateway`.

## Changes

- New `crates/protocols/src/multipart.rs` defines `AudioTranscriptionMultipart` (feature-gated on `axum`). All existing `400 Bad Request` messages preserved verbatim — no behavior change for clients.
- `AudioFile` moved from `model_gateway/src/routers/mod.rs` → `crates/protocols/src/transcription.rs`.
- `crates/protocols/Cargo.toml`: add `bytes = "1.8.0"`; the optional `axum` feature now also enables `axum/multipart`.
- `model_gateway/src/server.rs`: `v1_audio_transcriptions` shrinks from ~135 lines to 9 lines; `bad_text_field` helper deleted; unused `MultipartError` / `TranscriptionRequest` imports dropped.
- Three import sites (`server.rs`, `routers/router_manager.rs`, `routers/http/router.rs`) now pull `AudioFile` from `openai_protocol::transcription` instead of `crate::routers`.
- Net diff: +33 / -158 lines.

## Test Plan

- `cargo build -p smg` — passes
- `cargo clippy -p smg --all-targets -- -D warnings` — passes
- `cargo clippy -p openai-protocol --features axum --all-targets -- -D warnings` — passes
- `cargo +nightly fmt --all` — clean
- `cargo test -p openai-protocol --features axum --lib` — 56 passed
- `cargo test -p smg --lib` — 679 passed
- Behavior preservation: every error path in the new extractor returns the exact same `(StatusCode::BAD_REQUEST, message)` pairs as the original handler (model missing/blank, file missing/empty, temperature out of range, unparseable temperature, invalid stream value, multipart read errors, per-field text-decode errors).

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Reorganized audio transcription endpoint implementation to consolidate request processing and file handling
  * Unified audio file data structures into the shared protocol layer, reducing duplication across services and improving code consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->