### PR TITLE
fix(mlx-grpc): per-step admission + own-thread BatchGenerator (eliminates chat-c4 TTFT regression and Stream(gpu,1) crash)

### DIFF
--- a/grpc_servicer/smg_grpc_servicer/mlx/server.py
+++ b/grpc_servicer/smg_grpc_servicer/mlx/server.py
@@ -19,7 +19,6 @@ from grpc_health.v1 import health_pb2_grpc
 from grpc_reflection.v1alpha import reflection
 from huggingface_hub import snapshot_download
 from mlx_lm import load
-from mlx_lm.generate import BatchGenerator
 from smg_grpc_proto import mlx_engine_pb2, mlx_engine_pb2_grpc
 
 from smg_grpc_servicer.mlx.health_servicer import MlxHealthServicer
@@ -85,38 +84,11 @@ def load_model(args):
     return model, tokenizer, model_dir, model_config, eos_token_ids
 
 
-def _warmup(batch_generator):
-    """Run one end-to-end token through the batch generator so the first
-    real request doesn't pay JIT/kernel compilation cost."""
-    logger.info("Running warmup generation...")
-    try:
-        uids = batch_generator.insert(prompts=[[1]], max_tokens=[1])
-        for _ in range(10):
-            _, gen_responses = batch_generator.next()
-            if any(r.finish_reason is not None for r in gen_responses if r.uid == uids[0]):
-                break
-        batch_generator.remove(uids)
-        logger.info("Warmup complete")
-    except Exception:
-        logger.warning("Warmup failed (non-fatal)", exc_info=True)
-
-
 async def serve_grpc(args):
     """Start the MLX gRPC server."""
     start_time = time.time()
 
     model, tokenizer, model_dir, model_config, eos_token_ids = load_model(args)
-
-    batch_generator = BatchGenerator(
-        model,
-        completion_batch_size=args.completion_batch_size,
-        prefill_batch_size=args.prefill_batch_size,
-    )
-    logger.info(
-        "BatchGenerator created (prefill=%d, completion=%d)",
-        args.prefill_batch_size,
-        args.completion_batch_size,
-    )
 
     server = grpc.aio.server(
         futures.ThreadPoolExecutor(max_workers=10),
@@ -131,8 +103,17 @@ async def serve_grpc(args):
     health_servicer = MlxHealthServicer()
     health_pb2_grpc.add_HealthServicer_to_server(health_servicer, server)
 
+    # Construct the servicer WITHOUT a BatchGenerator. The BatchGenerator
+    # (and its thread-local mlx stream) is built on the generation thread
+    # below, so all mlx state lives on one thread — same model as
+    # mlx-lm.server. This avoids the cross-thread "no Stream(gpu, 1) in
+    # current thread" RuntimeError we saw when an mx.async_eval
+    # continuation tried to look up the stream context on a thread that
+    # never bound it.
     servicer = MlxEngineServicer(
-        batch_generator=batch_generator,
+        model=model,
+        completion_batch_size=args.completion_batch_size,
+        prefill_batch_size=args.prefill_batch_size,
         model_path=args.model,
         model_dir=model_dir,
         model_config=model_config,
@@ -153,16 +134,15 @@ async def serve_grpc(args):
     if bound_port == 0:
         raise RuntimeError(f"Failed to bind gRPC server to {listen_addr}")
 
-    # Warmup BEFORE starting the generation loop (batch_generator.next() is
-    # not thread-safe — only one caller at a time).
-    _warmup(batch_generator)
+    # The gen thread does construction → warmup → enters main loop. Wait
+    # for it to signal ready before flipping the health check to SERVING,
+    # otherwise a Generate RPC could slip into the window where the gen
+    # thread hasn't constructed BatchGenerator yet and block forever on
+    # _pending.
     servicer.start_generation_loop()
+    loop = asyncio.get_running_loop()
+    await loop.run_in_executor(None, servicer.wait_ready)
 
-    # Only accept RPCs after the generation loop is running. Otherwise a
-    # Generate RPC could slip into the window between server.start() and
-    # start_generation_loop() and block forever on queue.get() because no
-    # gen thread is dispatching tokens. HealthCheck always returns OK, so
-    # the router can't use it to detect this window.
     await server.start()
     health_servicer.set_serving()
     logger.info("gRPC server listening on %s — model: %s", listen_addr, args.model)
@@ -187,7 +167,6 @@ async def serve_grpc(args):
         # loop first would leave new/in-flight RPCs stranded.
         await server.stop(5.0)
         servicer.stop_generation_loop()
-        batch_generator.close()
         logger.info("Server stopped")
 
 

--- a/grpc_servicer/smg_grpc_servicer/mlx/server.py
+++ b/grpc_servicer/smg_grpc_servicer/mlx/server.py
@@ -138,10 +138,16 @@ async def serve_grpc(args):
     # for it to signal ready before flipping the health check to SERVING,
     # otherwise a Generate RPC could slip into the window where the gen
     # thread hasn't constructed BatchGenerator yet and block forever on
-    # _pending.
+    # _pending. wait_ready() returns False if BatchGenerator construction
+    # raised on the gen thread — fail startup loudly in that case rather
+    # than advertising a healthy server with a dead gen thread that hangs
+    # every Generate RPC on _pending.
     servicer.start_generation_loop()
     loop = asyncio.get_running_loop()
-    await loop.run_in_executor(None, servicer.wait_ready)
+    ready = await loop.run_in_executor(None, servicer.wait_ready)
+    if not ready:
+        servicer.stop_generation_loop()
+        raise RuntimeError("MLX generation thread failed to become ready — see preceding logs")
 
     await server.start()
     health_servicer.set_serving()

--- a/grpc_servicer/smg_grpc_servicer/mlx/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/mlx/servicer.py
@@ -145,22 +145,41 @@ class MlxEngineServicer(mlx_engine_pb2_grpc.MlxEngineServicer):
 
     Thread-safety
     -------------
-    ``self._gen_lock`` protects all mutations of the BatchGenerator and
-    of ``_active_uids`` / ``_uid_queues``. It is acquired by:
+    Every mlx-state mutation runs on the gen thread:
 
-      * the gen thread for each loop iteration (drain-pending + insert
-        + next + dispatch + finished-remove);
-      * the event loop in ``Generate``'s ``finally`` for the
-        client-disconnect cleanup ``remove()``;
-      * the event loop in ``Abort`` for the in-flight ``remove()``.
+      * ``insert(...)`` — drained from ``_pending`` at the start of
+        each loop iteration.
+      * ``next()`` — once per iteration.
+      * ``remove(...)`` — split into two paths:
 
-    ``self._pending_lock`` protects the pending list/index and is held
-    only briefly: append in ``Generate``, drain in the gen thread, pop
-    in ``Abort``. The gen thread nests it inside ``_gen_lock`` each
-    iteration; all other sites acquire just one of the two locks at a
-    time, so this is the only nesting direction in the codebase —
-    acquiring ``_gen_lock`` while already holding ``_pending_lock``
-    would deadlock.
+        - The natural-completion path (``finish_reason`` returned by
+          ``next()``) is handled inline inside the same iteration,
+          since we're already on the gen thread.
+        - The cleanup paths from event-loop callers (``Generate``'s
+          ``finally`` and ``CancelledError`` handler, ``Abort``)
+          enqueue the uid into ``_pending_remove`` instead of calling
+          ``BatchGenerator.remove(...)`` directly. The gen thread
+          drains that queue between phase 1 (insert) and phase 2
+          (next), keeping all mlx array operations on a single thread.
+
+    ``self._gen_lock`` protects ``_active_uids`` / ``_uid_queues`` /
+    ``_request_uid_map`` against the cross-thread visibility of
+    completed inserts. It is acquired by:
+
+      * the gen thread for each loop iteration (drain-pending +
+        insert + drain-removes + next + dispatch + finished-remove);
+      * the event loop in ``Generate``'s ``CancelledError`` handler
+        when checking whether the gen thread already inserted us
+        before the cancel landed.
+
+    ``self._pending_lock`` protects the pending lists/index and is
+    held only briefly: append/drain ``_pending``, append/drain
+    ``_pending_remove``, lookup/pop in ``_pending_by_request_id``.
+    The gen thread nests it inside ``_gen_lock`` each iteration; all
+    other sites acquire just one of the two locks at a time, so this
+    is the only nesting direction in the codebase — acquiring
+    ``_gen_lock`` while already holding ``_pending_lock`` would
+    deadlock.
 
     Cost model: the event loop can block up to one ``next()`` step
     (~10–50 ms on M-series) while the gen thread holds ``_gen_lock``.
@@ -222,6 +241,16 @@ class MlxEngineServicer(mlx_engine_pb2_grpc.MlxEngineServicer):
         # cancel a request that hasn't entered the batch yet.
         self._pending: list[_PendingRequest] = []
         self._pending_by_request_id: dict[str, _PendingRequest] = {}
+        # Removal commands queued by event-loop callers (Generate's
+        # finally / CancelledError handler, Abort). Drained on the gen
+        # thread between phase 1 (insert) and phase 2 (next), so
+        # ``BatchGenerator.remove()`` — which does mlx array indexing
+        # against the calling thread's stream context — runs only on
+        # the gen thread. Direct calls from the asyncio main thread
+        # produced cross-thread mlx-state corruption surfacing as
+        # ``RuntimeError: There is no Stream(gpu, 1) in current thread``
+        # or rope-shape mismatches under burst-with-cancel traffic.
+        self._pending_remove: list[int] = []
         self._pending_lock = threading.Lock()
         # Resolve context length once — config doesn't change at runtime,
         # and Generate was previously scanning these keys on every request.
@@ -614,6 +643,29 @@ class MlxEngineServicer(mlx_engine_pb2_grpc.MlxEngineServicer):
                                 _set_future_result_safe, p.uid_future, uid
                             )
 
+                    # Phase 1.5: drain queued removals from event-loop
+                    # callers (Generate.finally / CancelledError /
+                    # Abort). They append to _pending_remove instead
+                    # of calling batch_generator.remove() directly so
+                    # mlx array indexing runs only on this thread.
+                    with self._pending_lock:
+                        to_remove = self._pending_remove[:]
+                        self._pending_remove.clear()
+                    # Filter to uids still active — the gen thread also
+                    # removes on finish_reason inline below, so a uid
+                    # may already be gone by the time the queued remove
+                    # is drained. Skipping inactive uids avoids
+                    # spurious "uid not found" exceptions in
+                    # batch_generator.remove().
+                    to_remove = [uid for uid in to_remove if uid in self._active_uids]
+                    if to_remove:
+                        try:
+                            self.batch_generator.remove(to_remove)
+                            for uid in to_remove:
+                                self._active_uids.discard(uid)
+                        except Exception:
+                            logger.exception("Failed to drain queued removes: %s", to_remove)
+
                     # Phase 2: advance one step. Skip when nothing is
                     # in flight — next() on an empty BatchGenerator is
                     # wasted work. (Successful insert above adds uids
@@ -753,17 +805,15 @@ class MlxEngineServicer(mlx_engine_pb2_grpc.MlxEngineServicer):
                         self._request_uid_map.pop(request_id, None)
                     if inserted_uid is not None:
                         self._uid_queues.pop(inserted_uid, None)
-                        try:
-                            self.batch_generator.remove([inserted_uid])
-                            self._active_uids.discard(inserted_uid)
-                        except Exception:
-                            # Don't drop _active_uids on a failed remove
-                            # — keep the gate honest so drain-and-fill
-                            # doesn't insert into a partial batch.
-                            logger.exception(
-                                "Failed to remove uid %s during cancel cleanup",
-                                inserted_uid,
-                            )
+                # Queue the backend remove for the gen thread instead
+                # of calling batch_generator.remove() here. mlx array
+                # indexing inside remove() runs against the calling
+                # thread's stream context; doing it on the asyncio
+                # main thread violates the same single-thread mlx
+                # invariant this servicer enforces for insert/next.
+                if inserted_uid is not None:
+                    with self._pending_lock:
+                        self._pending_remove.append(inserted_uid)
                 raise
             # Note: _request_uid_map[request_id] = uid is published by
             # the gen thread BEFORE waking us, so Abort can find this
@@ -843,28 +893,19 @@ class MlxEngineServicer(mlx_engine_pb2_grpc.MlxEngineServicer):
                 self._active_requests -= 1
                 self._request_uid_map.pop(request_id, None)
                 self._uid_queues.pop(uid, None)
-                # Ensure the backend request is removed on any Generate exit
-                # (client disconnect, deadline, CancelledError, unexpected
-                # exception). Without this, a cancelled request keeps decoding
-                # until its own stop/max-tokens condition, wasting batch slots
-                # — and, crucially, holds drain-and-batch up so new requests
-                # in _pending can't enter until this one finishes naturally.
-                # Safe to double-call: the gen thread's finish-path remove
-                # and Abort's remove both land here if racing, and remove()
-                # raises on unknown uid (which we swallow).
-                with self._gen_lock:
-                    try:
-                        self.batch_generator.remove([uid])
-                        self._active_uids.discard(uid)
-                    except Exception:
-                        # Already removed by the gen thread or Abort —
-                        # in those paths, _active_uids was already
-                        # discarded after the successful remove. If the
-                        # remove failed for a real backend reason on
-                        # *every* path, the uid stays in _active_uids
-                        # so drain-and-fill won't insert into a still-
-                        # live batch.
-                        pass
+                # Queue the backend remove for the gen thread instead
+                # of calling batch_generator.remove() here. mlx array
+                # indexing inside remove() runs against the calling
+                # thread's stream context; doing it on the asyncio
+                # main thread violates the single-thread mlx invariant
+                # this servicer enforces for insert/next.
+                #
+                # Safe to double-queue: the gen thread also removes on
+                # finish_reason inline; the queued-remove drain filters
+                # by `uid in _active_uids` so a uid already gone
+                # produces no spurious error.
+                with self._pending_lock:
+                    self._pending_remove.append(uid)
 
         except ValueError as e:
             logger.warning("Generate invalid request %s: %s", request_id, e)
@@ -889,7 +930,8 @@ class MlxEngineServicer(mlx_engine_pb2_grpc.MlxEngineServicer):
                     pending.uid_future.cancel()
                 continue
 
-            # Case B: already inserted — existing in-flight remove path.
+            # Case B: already inserted — queue the remove for the gen
+            # thread.
             uid = self._request_uid_map.pop(request_id, None)
             if uid is not None:
                 queue = self._uid_queues.pop(uid, None)
@@ -905,19 +947,13 @@ class MlxEngineServicer(mlx_engine_pb2_grpc.MlxEngineServicer):
                     # Wake the Generate waiter blocked on queue.get() so it
                     # exits cleanly instead of hanging until transport cancel.
                     queue.put_nowait(None)
-                # remove() races with the gen thread's next() without the
-                # lock — see class docstring.
-                with self._gen_lock:
-                    try:
-                        self.batch_generator.remove([uid])
-                        self._active_uids.discard(uid)
-                    except Exception:
-                        # Same invariant as Generate's finally: only
-                        # discard from _active_uids on a successful
-                        # remove. If this fails because the gen thread
-                        # already removed, _active_uids was already
-                        # cleared on that success path.
-                        logger.warning("Failed to remove uid %d for request %s", uid, request_id)
+                # Queue the backend remove for the gen thread (see
+                # class docstring for why all batch_generator.remove
+                # calls run there). Generate.finally on the same uid
+                # also queues a remove; the drain filters by
+                # `uid in _active_uids` so the duplicate is a no-op.
+                with self._pending_lock:
+                    self._pending_remove.append(uid)
         return mlx_engine_pb2.AbortResponse()
 
     async def HealthCheck(self, request, context):

--- a/grpc_servicer/smg_grpc_servicer/mlx/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/mlx/servicer.py
@@ -303,16 +303,26 @@ class MlxEngineServicer(mlx_engine_pb2_grpc.MlxEngineServicer):
         the same thread-local stream binding the bench traffic will use.
         """
         logger.info("Running warmup generation...")
+        uids = None
         try:
             uids = self.batch_generator.insert(prompts=[[1]], max_tokens=[1])
             for _ in range(10):
                 _, gen_responses = self.batch_generator.next()
                 if any(r.finish_reason is not None for r in gen_responses if r.uid == uids[0]):
                     break
-            self.batch_generator.remove(uids)
             logger.info("Warmup complete")
         except Exception:
             logger.warning("Warmup failed (non-fatal)", exc_info=True)
+        finally:
+            # Always clean up the warmup probe even if next() raised
+            # mid-iteration. Otherwise the warmup uid leaks inside
+            # BatchGenerator and the first real request runs against
+            # corrupted batch state.
+            if uids is not None:
+                try:
+                    self.batch_generator.remove(uids)
+                except Exception:
+                    logger.warning("Warmup cleanup failed", exc_info=True)
 
     @staticmethod
     def _build_sampler(sampling_params):
@@ -727,6 +737,34 @@ class MlxEngineServicer(mlx_engine_pb2_grpc.MlxEngineServicer):
         # We also clear self.batch_generator under the lock so any such
         # late call sees None and short-circuits.
         with self._gen_lock:
+            # Wake any RPCs still waiting on the gen loop. Without
+            # this, Generate calls blocked on `await uid_future` (not
+            # yet inserted) or `await queue.get()` (mid-stream) hang
+            # until the client deadline or transport cancellation.
+            with self._pending_lock:
+                pending = self._pending[:]
+                self._pending.clear()
+                self._pending_remove.clear()
+                for p in pending:
+                    self._pending_by_request_id.pop(p.request_id, None)
+
+            shutdown_exc = RuntimeError("MlxEngineServicer is shutting down")
+            for p in pending:
+                if self._loop is not None:
+                    self._loop.call_soon_threadsafe(
+                        _set_future_exception_safe, p.uid_future, shutdown_exc
+                    )
+
+            queues = list(self._uid_queues.values())
+            self._uid_queues.clear()
+            self._request_uid_map.clear()
+            self._active_uids.clear()
+            for queue in queues:
+                # Sentinel — Generate's stream/non-stream loops both
+                # treat None as "Abort received, stop emitting".
+                if self._loop is not None:
+                    self._loop.call_soon_threadsafe(queue.put_nowait, None)
+
             if self.batch_generator is not None:
                 try:
                     self.batch_generator.close()

--- a/grpc_servicer/smg_grpc_servicer/mlx/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/mlx/servicer.py
@@ -205,8 +205,11 @@ class MlxEngineServicer(mlx_engine_pb2_grpc.MlxEngineServicer):
         # warmup has completed; ``server.serve_grpc`` waits on this
         # before flipping the health check to SERVING so that no
         # Generate RPC arrives before there's a BatchGenerator to
-        # insert into.
+        # insert into. ``_construction_failed`` lets ``wait_ready``
+        # report failure to the startup path even though the event
+        # itself was set (so waiters unblock instead of hanging).
         self._ready_event = threading.Event()
+        self._construction_failed = False
         self._loop = None
         self._gen_thread = None
         # Protects mlx-lm BatchGenerator state + ``_uid_queues`` +
@@ -236,7 +239,10 @@ class MlxEngineServicer(mlx_engine_pb2_grpc.MlxEngineServicer):
         Called from ``server.serve_grpc`` (in an executor thread so the
         asyncio loop isn't blocked) before flipping the health probe
         to SERVING. Returns ``True`` when ready; ``False`` if the
-        servicer was shut down before becoming ready.
+        servicer was shut down before becoming ready, or if
+        BatchGenerator construction raised on the gen thread (in which
+        case the gen thread sets ``_construction_failed`` then sets the
+        event to unblock this waiter).
         """
         # Poll so a shutdown signal during warmup unblocks the waiter.
         deadline = None if timeout is None else (time.monotonic() + timeout)
@@ -250,7 +256,7 @@ class MlxEngineServicer(mlx_engine_pb2_grpc.MlxEngineServicer):
                     return False
                 wait = min(wait, remaining)
             self._ready_event.wait(wait)
-        return True
+        return not self._construction_failed
 
     def _warmup(self) -> None:
         """Run one end-to-end token through the batch generator so the
@@ -520,7 +526,11 @@ class MlxEngineServicer(mlx_engine_pb2_grpc.MlxEngineServicer):
             )
         except Exception:
             logger.exception("BatchGenerator construction failed")
-            self._ready_event.set()  # Unblock waiters; they'll see no batch_generator.
+            # Flag the failure BEFORE setting the event so wait_ready
+            # observes the flag (the event is set last, after the
+            # write — readers re-check the flag once unblocked).
+            self._construction_failed = True
+            self._ready_event.set()
             return
         logger.info(
             "BatchGenerator created on gen thread (prefill=%d, completion=%d)",
@@ -546,7 +556,6 @@ class MlxEngineServicer(mlx_engine_pb2_grpc.MlxEngineServicer):
         while not self._shutdown_event.is_set():
             prompt_responses: list = []
             gen_responses: list = []
-            inserted_this_iter = False
             try:
                 with self._gen_lock:
                     # Phase 1: admit pending. NOT gated on _active_uids
@@ -604,12 +613,13 @@ class MlxEngineServicer(mlx_engine_pb2_grpc.MlxEngineServicer):
                             self._loop.call_soon_threadsafe(
                                 _set_future_result_safe, p.uid_future, uid
                             )
-                        inserted_this_iter = True
 
-                    # Phase 2: advance one step. Skip when there's
-                    # nothing in flight AND nothing was just inserted —
-                    # next() on an empty BatchGenerator is wasted work.
-                    if self._active_uids or inserted_this_iter:
+                    # Phase 2: advance one step. Skip when nothing is
+                    # in flight — next() on an empty BatchGenerator is
+                    # wasted work. (Successful insert above adds uids
+                    # to _active_uids, so a separate "just inserted"
+                    # flag would be redundant.)
+                    if self._active_uids:
                         # BatchGenerator.next() wraps itself in
                         # `with mx.stream(self._stream):` internally
                         # (mlx_lm/generate.py:1847), so no outer wrap
@@ -647,12 +657,19 @@ class MlxEngineServicer(mlx_engine_pb2_grpc.MlxEngineServicer):
                 if pending_size == 0:
                     time.sleep(0.001)
 
-        # Shutdown — release wired-limit etc.
-        if self.batch_generator is not None:
-            try:
-                self.batch_generator.close()
-            except Exception:
-                logger.warning("BatchGenerator.close raised", exc_info=True)
+        # Shutdown — release wired-limit etc. Hold _gen_lock so an
+        # RPC's finally / Abort cleanup that races past server.stop()'s
+        # grace period can't call remove() on a half-closed generator.
+        # We also clear self.batch_generator under the lock so any such
+        # late call sees None and short-circuits.
+        with self._gen_lock:
+            if self.batch_generator is not None:
+                try:
+                    self.batch_generator.close()
+                except Exception:
+                    logger.warning("BatchGenerator.close raised", exc_info=True)
+                finally:
+                    self.batch_generator = None
 
     async def Generate(self, request, context):
         request_id = request.request_id

--- a/grpc_servicer/smg_grpc_servicer/mlx/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/mlx/servicer.py
@@ -170,7 +170,14 @@ class MlxEngineServicer(mlx_engine_pb2_grpc.MlxEngineServicer):
         insert + drain-removes + next + dispatch + finished-remove);
       * the event loop in ``Generate``'s ``CancelledError`` handler
         when checking whether the gen thread already inserted us
-        before the cancel landed.
+        before the cancel landed;
+      * the event loop in ``Abort`` to observe the gen thread's
+        pending->inserted transition atomically. Without this lock,
+        the gen thread releases ``_pending_lock`` between popping
+        ``_pending_by_request_id`` and setting ``_request_uid_map``,
+        leaving a window where Abort could find the request in
+        neither map and silently no-op while the request keeps
+        decoding.
 
     ``self._pending_lock`` protects the pending lists/index and is
     held only briefly: append/drain ``_pending``, append/drain
@@ -648,23 +655,28 @@ class MlxEngineServicer(mlx_engine_pb2_grpc.MlxEngineServicer):
                     # Abort). They append to _pending_remove instead
                     # of calling batch_generator.remove() directly so
                     # mlx array indexing runs only on this thread.
+                    #
+                    # Remove per-uid (matching the finish_reason path
+                    # below) so a single bad uid doesn't poison the
+                    # rest of the batch's cleanup, and dedup since
+                    # Abort + Generate.finally both enqueue the same
+                    # uid on cancel paths.
                     with self._pending_lock:
-                        to_remove = self._pending_remove[:]
+                        queued_removes = self._pending_remove[:]
                         self._pending_remove.clear()
-                    # Filter to uids still active — the gen thread also
-                    # removes on finish_reason inline below, so a uid
-                    # may already be gone by the time the queued remove
-                    # is drained. Skipping inactive uids avoids
-                    # spurious "uid not found" exceptions in
-                    # batch_generator.remove().
-                    to_remove = [uid for uid in to_remove if uid in self._active_uids]
-                    if to_remove:
+                    seen_remove: set[int] = set()
+                    for uid in queued_removes:
+                        if uid in seen_remove or uid not in self._active_uids:
+                            # uid already drained this iter, or removed
+                            # inline by the finish_reason path on a
+                            # previous iter. Either way nothing to do.
+                            continue
+                        seen_remove.add(uid)
                         try:
-                            self.batch_generator.remove(to_remove)
-                            for uid in to_remove:
-                                self._active_uids.discard(uid)
+                            self.batch_generator.remove([uid])
+                            self._active_uids.discard(uid)
                         except Exception:
-                            logger.exception("Failed to drain queued removes: %s", to_remove)
+                            logger.exception("Failed to remove uid %d during queued drain", uid)
 
                     # Phase 2: advance one step. Skip when nothing is
                     # in flight — next() on an empty BatchGenerator is
@@ -916,25 +928,49 @@ class MlxEngineServicer(mlx_engine_pb2_grpc.MlxEngineServicer):
 
     async def Abort(self, request, context):
         for request_id in request.request_ids:
-            # Case A: request hasn't entered the batch yet — pop from
-            # pending and cancel its uid_future so Generate exits cleanly.
-            with self._pending_lock:
-                pending = self._pending_by_request_id.pop(request_id, None)
+            # Lookup the request under _gen_lock so we observe the
+            # gen thread's pending->inserted transition atomically.
+            # The gen thread releases _pending_lock between popping
+            # `_pending_by_request_id` and setting `_request_uid_map`,
+            # so an Abort that took only `_pending_lock` could find
+            # the request in NEITHER map and silently no-op while the
+            # request keeps decoding. Holding `_gen_lock` here forces
+            # Abort to wait for the gen thread's iteration to
+            # complete — the transition is atomic from outside.
+            #
+            # Cost: Abort blocks for up to one gen-loop iteration
+            # (~50 ms on M-series, less for small batches). Abort
+            # itself is rare (router-initiated cancel), so the
+            # latency hit is acceptable in exchange for the
+            # correctness guarantee.
+            with self._gen_lock:
+                with self._pending_lock:
+                    pending = self._pending_by_request_id.pop(request_id, None)
+                    if pending is not None:
+                        try:
+                            self._pending.remove(pending)
+                        except ValueError:
+                            pass
+
+                # Case A: request hasn't entered the batch yet.
                 if pending is not None:
-                    try:
-                        self._pending.remove(pending)
-                    except ValueError:
-                        pass
+                    uid = None
+                    queue = None
+                # Case B: already inserted — pull the uid + queue
+                # while still under _gen_lock so they don't get
+                # mutated by another path between read and use.
+                else:
+                    uid = self._request_uid_map.pop(request_id, None)
+                    queue = self._uid_queues.pop(uid, None) if uid is not None else None
+
             if pending is not None:
+                # Cancel the pending request's future so Generate
+                # exits cleanly via its CancelledError handler.
                 if not pending.uid_future.done():
                     pending.uid_future.cancel()
                 continue
 
-            # Case B: already inserted — queue the remove for the gen
-            # thread.
-            uid = self._request_uid_map.pop(request_id, None)
             if uid is not None:
-                queue = self._uid_queues.pop(uid, None)
                 if queue is not None:
                     # Drain already-buffered tokens so Generate stops emitting
                     # output immediately rather than flushing a backlog of
@@ -951,7 +987,8 @@ class MlxEngineServicer(mlx_engine_pb2_grpc.MlxEngineServicer):
                 # class docstring for why all batch_generator.remove
                 # calls run there). Generate.finally on the same uid
                 # also queues a remove; the drain filters by
-                # `uid in _active_uids` so the duplicate is a no-op.
+                # `uid in _active_uids` and dedups so the duplicate is
+                # a no-op.
                 with self._pending_lock:
                     self._pending_remove.append(uid)
         return mlx_engine_pb2.AbortResponse()

--- a/grpc_servicer/smg_grpc_servicer/mlx/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/mlx/servicer.py
@@ -143,56 +143,48 @@ class MlxEngineServicer(mlx_engine_pb2_grpc.MlxEngineServicer):
         known so ``Generate`` can register its uid for ``Abort`` and
         start consuming tokens from its per-uid queue.
 
-    Thread-safety
-    -------------
-    Every mlx-state mutation runs on the gen thread:
+    Thread-safety: mlx-lm.server's signal pattern
+    ---------------------------------------------
+    Every mlx-state mutation — ``insert``, ``next``, ``remove`` on
+    ``BatchGenerator``, plus all mutations of ``_active_uids`` /
+    ``_uid_queues`` / ``_request_uid_map`` — runs on the gen thread.
+    Event-loop callers (``Generate``'s ``finally`` / ``CancelledError``
+    handler, ``Abort``) communicate with the gen thread by appending
+    request_ids to ``self._aborted_request_ids`` (a set guarded by
+    ``_pending_lock``). The gen thread drains that set at the start
+    of each iteration and does all the cleanup work itself.
 
-      * ``insert(...)`` — drained from ``_pending`` at the start of
-        each loop iteration.
-      * ``next()`` — once per iteration.
-      * ``remove(...)`` — split into two paths:
+    This mirrors ``mlx_lm/server.py`` (``ctx.stop()`` flips
+    ``_should_stop``; the gen thread observes it on the next
+    iteration). Their pattern works because everything runs on one
+    thread; ours works because the asyncio→gen-thread channel is a
+    single shared set, and the gen thread reads it at a known point
+    in each iteration.
 
-        - The natural-completion path (``finish_reason`` returned by
-          ``next()``) is handled inline inside the same iteration,
-          since we're already on the gen thread.
-        - The cleanup paths from event-loop callers (``Generate``'s
-          ``finally`` and ``CancelledError`` handler, ``Abort``)
-          enqueue the uid into ``_pending_remove`` instead of calling
-          ``BatchGenerator.remove(...)`` directly. The gen thread
-          drains that queue between phase 1 (insert) and phase 2
-          (next), keeping all mlx array operations on a single thread.
+    Concrete consequences:
 
-    ``self._gen_lock`` protects ``_active_uids`` / ``_uid_queues`` /
-    ``_request_uid_map`` against the cross-thread visibility of
-    completed inserts. It is acquired by:
+      * ``Abort`` is non-blocking. It just adds to a set and returns;
+        cleanup happens within one decode-step (~50 ms) on the gen
+        thread.
+      * No ``_gen_lock``. There is no shared mutable state between
+        the gen thread and event-loop callers other than the
+        ``_pending_lock``-guarded fields.
+      * The race the prior lock-based fix closed (``Abort`` arriving
+        between gen's ``_pending_by_request_id.pop`` and
+        ``_request_uid_map[rid] = uid``) goes away naturally:
+        ``Abort`` records the rid, the gen thread observes it
+        ≥1 iteration later, by which time the prior iteration's
+        transition is fully committed and ``_request_uid_map[rid]``
+        is reliably populated.
 
-      * the gen thread for each loop iteration (drain-pending +
-        insert + drain-removes + next + dispatch + finished-remove);
-      * the event loop in ``Generate``'s ``CancelledError`` handler
-        when checking whether the gen thread already inserted us
-        before the cancel landed;
-      * the event loop in ``Abort`` to observe the gen thread's
-        pending->inserted transition atomically. Without this lock,
-        the gen thread releases ``_pending_lock`` between popping
-        ``_pending_by_request_id`` and setting ``_request_uid_map``,
-        leaving a window where Abort could find the request in
-        neither map and silently no-op while the request keeps
-        decoding.
+    ``self._pending_lock`` is the only lock. It guards
+    ``_pending`` / ``_pending_by_request_id`` (request submission)
+    and ``_aborted_request_ids`` (cleanup signal). Held only briefly
+    each time, never nested with anything else.
 
-    ``self._pending_lock`` protects the pending lists/index and is
-    held only briefly: append/drain ``_pending``, append/drain
-    ``_pending_remove``, lookup/pop in ``_pending_by_request_id``.
-    The gen thread nests it inside ``_gen_lock`` each iteration; all
-    other sites acquire just one of the two locks at a time, so this
-    is the only nesting direction in the codebase — acquiring
-    ``_gen_lock`` while already holding ``_pending_lock`` would
-    deadlock.
-
-    Cost model: the event loop can block up to one ``next()`` step
-    (~10–50 ms on M-series) while the gen thread holds ``_gen_lock``.
-    Acceptable for single-worker Mac inference; if you need
-    1000+ concurrent req/s, refactor to a command-queue / actor model
-    (see vLLM's AsyncLLMEngine).
+    Cost model: ``Abort`` returns within microseconds (one
+    set-add). Cleanup of an aborted request lags by at most one
+    decode step (~10–50 ms on M-series).
     """
 
     def __init__(
@@ -219,12 +211,12 @@ class MlxEngineServicer(mlx_engine_pb2_grpc.MlxEngineServicer):
         self._eos_token_ids = eos_token_ids
         self.start_time = start_time
         self._active_requests = 0
-        self._request_uid_map = {}
-        self._uid_queues = {}
-        # Set of uids currently live in the BatchGenerator. Mutated only
-        # under ``_gen_lock``. Used as the gate for "is the batch
-        # drained?" cleanup decisions; new admissions are *not* gated on
-        # this anymore (per-step model — see class docstring).
+        # Gen-thread-only state — every mutation happens on the gen
+        # thread. Event-loop callers never touch these dicts/set
+        # directly; they signal the gen thread via
+        # ``_aborted_request_ids`` and it does the cleanup.
+        self._request_uid_map: dict[str, int] = {}
+        self._uid_queues: dict[int, asyncio.Queue] = {}
         self._active_uids: set[int] = set()
         self._shutdown_event = threading.Event()
         # Set by the gen thread once BatchGenerator is constructed and
@@ -238,26 +230,21 @@ class MlxEngineServicer(mlx_engine_pb2_grpc.MlxEngineServicer):
         self._construction_failed = False
         self._loop = None
         self._gen_thread = None
-        # Protects mlx-lm BatchGenerator state + ``_uid_queues`` +
-        # ``_active_uids`` against the background gen thread. See class
-        # docstring.
-        self._gen_lock = threading.Lock()
         # Per-step admission state. New ``Generate`` calls land here
-        # and the gen thread drains them on EVERY iteration (not gated
-        # on ``_active_uids``). Indexed by request_id so ``Abort`` can
-        # cancel a request that hasn't entered the batch yet.
+        # and the gen thread drains them at the top of every iteration
+        # (regardless of ``_active_uids``). Indexed by request_id so
+        # ``Abort`` can cancel a request that hasn't entered the
+        # batch yet.
         self._pending: list[_PendingRequest] = []
         self._pending_by_request_id: dict[str, _PendingRequest] = {}
-        # Removal commands queued by event-loop callers (Generate's
-        # finally / CancelledError handler, Abort). Drained on the gen
-        # thread between phase 1 (insert) and phase 2 (next), so
-        # ``BatchGenerator.remove()`` — which does mlx array indexing
-        # against the calling thread's stream context — runs only on
-        # the gen thread. Direct calls from the asyncio main thread
-        # produced cross-thread mlx-state corruption surfacing as
-        # ``RuntimeError: There is no Stream(gpu, 1) in current thread``
-        # or rope-shape mismatches under burst-with-cancel traffic.
-        self._pending_remove: list[int] = []
+        # mlx-lm.server-style abort signal. Event-loop callers
+        # (``Generate``'s ``finally`` / ``CancelledError`` handler,
+        # ``Abort``) add request_ids here; the gen thread drains the
+        # set between phase 1 (insert) and phase 2 (next) and does
+        # all cleanup work itself, keeping every mlx-state mutation
+        # on one thread. See class docstring for the analogy to
+        # mlx_lm/server.py's ``ctx.stop()`` pattern.
+        self._aborted_request_ids: set[str] = set()
         self._pending_lock = threading.Lock()
         # Resolve context length once — config doesn't change at runtime,
         # and Generate was previously scanning these keys on every request.
@@ -603,175 +590,194 @@ class MlxEngineServicer(mlx_engine_pb2_grpc.MlxEngineServicer):
             prompt_responses: list = []
             gen_responses: list = []
             try:
-                with self._gen_lock:
-                    # Phase 1: admit pending. NOT gated on _active_uids
-                    # — pending requests can join while a batch is
-                    # mid-decode, which is the whole point of the
-                    # mlx-lm.server-style scheduler.
-                    with self._pending_lock:
-                        batch = self._pending[:]
-                        self._pending.clear()
-                        # Don't pop from _pending_by_request_id yet:
-                        # keeping pending entries indexed until insert()
-                        # succeeds lets Abort() cancel a request that
-                        # lost the insert race.
+                # Phase 1: admit pending. NOT gated on _active_uids —
+                # pending requests can join while a batch is mid-decode,
+                # the whole point of mlx-lm.server-style scheduling.
+                with self._pending_lock:
+                    batch = self._pending[:]
+                    self._pending.clear()
+                    # Don't pop from _pending_by_request_id yet:
+                    # keeping pending entries indexed until insert()
+                    # succeeds lets Abort() cancel a request that
+                    # lost the insert race.
 
-                    batch = [p for p in batch if not p.uid_future.cancelled()]
+                batch = [p for p in batch if not p.uid_future.cancelled()]
 
-                    if batch:
-                        try:
-                            uids = self.batch_generator.insert(
-                                prompts=[p.token_ids for p in batch],
-                                max_tokens=[p.max_tokens for p in batch],
-                                samplers=[p.sampler for p in batch],
-                                logits_processors=[p.logits_processors for p in batch],
-                                state_machines=[p.state_machine for p in batch],
-                            )
-                        except Exception as e:
-                            # Wake every waiter with a real error so
-                            # Generate exits with INTERNAL instead of
-                            # hanging on uid_future forever.
-                            logger.exception(
-                                "BatchGenerator.insert failed for batch of %d", len(batch)
-                            )
-                            with self._pending_lock:
-                                for p in batch:
-                                    self._pending_by_request_id.pop(p.request_id, None)
-                            for p in batch:
-                                self._loop.call_soon_threadsafe(
-                                    _set_future_exception_safe, p.uid_future, e
-                                )
-                            continue
-
-                        # insert() succeeded — finalize each request.
+                if batch:
+                    try:
+                        uids = self.batch_generator.insert(
+                            prompts=[p.token_ids for p in batch],
+                            max_tokens=[p.max_tokens for p in batch],
+                            samplers=[p.sampler for p in batch],
+                            logits_processors=[p.logits_processors for p in batch],
+                            state_machines=[p.state_machine for p in batch],
+                        )
+                    except Exception as e:
+                        # Wake every waiter with a real error so
+                        # Generate exits with INTERNAL instead of
+                        # hanging on uid_future forever.
+                        logger.exception("BatchGenerator.insert failed for batch of %d", len(batch))
                         with self._pending_lock:
                             for p in batch:
                                 self._pending_by_request_id.pop(p.request_id, None)
-                        for uid, p in zip(uids, batch):
-                            self._uid_queues[uid] = p.queue
-                            self._active_uids.add(uid)
-                            # Publish the request_id -> uid mapping
-                            # BEFORE waking Generate. Otherwise Abort
-                            # can land in the gap between set_result
-                            # and Generate's own assignment and miss
-                            # the mapping entirely (silent no-op).
-                            self._request_uid_map[p.request_id] = uid
+                        for p in batch:
                             self._loop.call_soon_threadsafe(
-                                _set_future_result_safe, p.uid_future, uid
+                                _set_future_exception_safe, p.uid_future, e
                             )
+                        continue
 
-                    # Phase 1.5: drain queued removals from event-loop
-                    # callers (Generate.finally / CancelledError /
-                    # Abort). They append to _pending_remove instead
-                    # of calling batch_generator.remove() directly so
-                    # mlx array indexing runs only on this thread.
-                    #
-                    # Remove per-uid (matching the finish_reason path
-                    # below) so a single bad uid doesn't poison the
-                    # rest of the batch's cleanup, and dedup since
-                    # Abort + Generate.finally both enqueue the same
-                    # uid on cancel paths.
+                    # insert() succeeded — finalize each request.
                     with self._pending_lock:
-                        queued_removes = self._pending_remove[:]
-                        self._pending_remove.clear()
-                    seen_remove: set[int] = set()
-                    for uid in queued_removes:
-                        if uid in seen_remove or uid not in self._active_uids:
-                            # uid already drained this iter, or removed
-                            # inline by the finish_reason path on a
-                            # previous iter. Either way nothing to do.
-                            continue
-                        seen_remove.add(uid)
+                        for p in batch:
+                            self._pending_by_request_id.pop(p.request_id, None)
+                    for uid, p in zip(uids, batch):
+                        self._uid_queues[uid] = p.queue
+                        self._active_uids.add(uid)
+                        self._request_uid_map[p.request_id] = uid
+                        self._loop.call_soon_threadsafe(_set_future_result_safe, p.uid_future, uid)
+
+                # Phase 1.5: drain abort signals (mlx-lm.server-style
+                # ctx.stop() equivalent). Generate.finally,
+                # Generate.CancelledError, and Abort all add request_ids
+                # to _aborted_request_ids. We do all the cleanup here
+                # so every mlx-state mutation stays on the gen thread.
+                with self._pending_lock:
+                    aborted = self._aborted_request_ids
+                    self._aborted_request_ids = set()
+
+                for rid in aborted:
+                    # Case A: request still pending — never inserted.
+                    with self._pending_lock:
+                        pending = self._pending_by_request_id.pop(rid, None)
+                        if pending is not None:
+                            try:
+                                self._pending.remove(pending)
+                            except ValueError:
+                                pass
+                    if pending is not None:
+                        # Cancel the future so Generate's await raises
+                        # CancelledError. Already-done futures (e.g.,
+                        # natural completion of a request that never
+                        # got past the insert race) are no-ops.
+                        if not pending.uid_future.done():
+                            self._loop.call_soon_threadsafe(pending.uid_future.cancel)
+                        continue
+
+                    # Case B: already inserted (or never registered —
+                    # e.g., Generate.finally called for a request that
+                    # was never accepted). Look up uid + clean up.
+                    uid = self._request_uid_map.pop(rid, None)
+                    if uid is None:
+                        # Either never inserted, or already cleaned up
+                        # by a prior abort drain. Nothing to do.
+                        continue
+
+                    queue = self._uid_queues.pop(uid, None)
+                    if queue is not None:
+                        # Drain buffered tokens so a still-streaming
+                        # consumer stops emitting immediately rather
+                        # than flushing stale chunks before seeing the
+                        # sentinel.
+                        while not queue.empty():
+                            try:
+                                queue.get_nowait()
+                            except asyncio.QueueEmpty:
+                                break
+                        self._loop.call_soon_threadsafe(queue.put_nowait, None)
+
+                    if uid in self._active_uids:
                         try:
                             self.batch_generator.remove([uid])
                             self._active_uids.discard(uid)
                         except Exception:
-                            logger.exception("Failed to remove uid %d during queued drain", uid)
+                            logger.exception(
+                                "BatchGenerator.remove failed for uid %d during abort drain",
+                                uid,
+                            )
+                    # else: gen thread already removed the uid inline
+                    # via the finish_reason path on a prior iteration.
+                    # Generate.finally fired afterward; nothing to do
+                    # at the backend level.
 
-                    # Phase 2: advance one step. Skip when nothing is
-                    # in flight — next() on an empty BatchGenerator is
-                    # wasted work. (Successful insert above adds uids
-                    # to _active_uids, so a separate "just inserted"
-                    # flag would be redundant.)
-                    if self._active_uids:
-                        # BatchGenerator.next() wraps itself in
-                        # `with mx.stream(self._stream):` internally
-                        # (mlx_lm/generate.py:1847), so no outer wrap
-                        # is needed here — and adding one would just
-                        # nest into the same thread-local stream.
-                        prompt_responses, gen_responses = self.batch_generator.next()
+                # Phase 2: advance one step. Skip when nothing is in
+                # flight — next() on an empty BatchGenerator is wasted
+                # work.
+                if self._active_uids:
+                    # BatchGenerator.next() wraps itself in
+                    # `with mx.stream(self._stream):` internally
+                    # (mlx_lm/generate.py:1847), so no outer wrap
+                    # needed.
+                    prompt_responses, gen_responses = self.batch_generator.next()
 
-                        for r in gen_responses:
-                            queue = self._uid_queues.get(r.uid)
-                            if queue is not None:
-                                self._loop.call_soon_threadsafe(queue.put_nowait, r)
-                            if r.finish_reason is not None:
-                                # Only discard from _active_uids on a
-                                # successful remove. If remove fails
-                                # for a real backend reason, the uid
-                                # stays tracked so we don't lose
-                                # accounting on cleanup paths.
-                                try:
-                                    self.batch_generator.remove([r.uid])
-                                    self._active_uids.discard(r.uid)
-                                except Exception:
-                                    logger.exception(
-                                        "BatchGenerator.remove failed for uid %d", r.uid
-                                    )
+                    for r in gen_responses:
+                        queue = self._uid_queues.get(r.uid)
+                        if queue is not None:
+                            self._loop.call_soon_threadsafe(queue.put_nowait, r)
+                        if r.finish_reason is not None:
+                            # Only discard from _active_uids on a
+                            # successful remove; if remove fails for a
+                            # real backend reason the uid stays
+                            # tracked so accounting isn't lost.
+                            try:
+                                self.batch_generator.remove([r.uid])
+                                self._active_uids.discard(r.uid)
+                            except Exception:
+                                logger.exception("BatchGenerator.remove failed for uid %d", r.uid)
             except Exception:
                 logger.exception("Error in generation loop")
                 continue
 
-            # Idle sleep only when there's truly nothing to do — gives
-            # the event loop a chance to append to _pending without
-            # contending on _gen_lock.
+            # Idle sleep only when there's truly nothing to do.
             if not prompt_responses and not gen_responses and not self._active_uids:
                 with self._pending_lock:
-                    pending_size = len(self._pending)
-                if pending_size == 0:
+                    nothing_to_do = len(self._pending) == 0 and len(self._aborted_request_ids) == 0
+                if nothing_to_do:
                     time.sleep(0.001)
 
-        # Shutdown — release wired-limit etc. Hold _gen_lock so an
-        # RPC's finally / Abort cleanup that races past server.stop()'s
-        # grace period can't call remove() on a half-closed generator.
-        # We also clear self.batch_generator under the lock so any such
-        # late call sees None and short-circuits.
-        with self._gen_lock:
-            # Wake any RPCs still waiting on the gen loop. Without
-            # this, Generate calls blocked on `await uid_future` (not
-            # yet inserted) or `await queue.get()` (mid-stream) hang
-            # until the client deadline or transport cancellation.
-            with self._pending_lock:
-                pending = self._pending[:]
-                self._pending.clear()
-                self._pending_remove.clear()
-                for p in pending:
-                    self._pending_by_request_id.pop(p.request_id, None)
-
-            shutdown_exc = RuntimeError("MlxEngineServicer is shutting down")
+        # Shutdown — runs on the gen thread, after the main loop
+        # exits. No lock needed: every mlx-state field below is
+        # gen-thread-only mutated, and event-loop callers can only
+        # add to _pending / _aborted_request_ids under _pending_lock,
+        # which we acquire briefly when clearing those fields.
+        # Clearing self.batch_generator unconditionally — any
+        # event-loop caller that races past server.stop()'s grace
+        # period only adds to _aborted_request_ids; it never touches
+        # batch_generator directly.
+        with self._pending_lock:
+            pending = self._pending[:]
+            self._pending.clear()
+            self._aborted_request_ids.clear()
             for p in pending:
-                if self._loop is not None:
-                    self._loop.call_soon_threadsafe(
-                        _set_future_exception_safe, p.uid_future, shutdown_exc
-                    )
+                self._pending_by_request_id.pop(p.request_id, None)
 
-            queues = list(self._uid_queues.values())
-            self._uid_queues.clear()
-            self._request_uid_map.clear()
-            self._active_uids.clear()
-            for queue in queues:
-                # Sentinel — Generate's stream/non-stream loops both
-                # treat None as "Abort received, stop emitting".
-                if self._loop is not None:
-                    self._loop.call_soon_threadsafe(queue.put_nowait, None)
+        # Wake any RPCs still waiting. Without this, Generate calls
+        # blocked on `await uid_future` (not yet inserted) or
+        # `await queue.get()` (mid-stream) would hang until the
+        # client deadline or transport cancellation.
+        shutdown_exc = RuntimeError("MlxEngineServicer is shutting down")
+        for p in pending:
+            if self._loop is not None:
+                self._loop.call_soon_threadsafe(
+                    _set_future_exception_safe, p.uid_future, shutdown_exc
+                )
 
-            if self.batch_generator is not None:
-                try:
-                    self.batch_generator.close()
-                except Exception:
-                    logger.warning("BatchGenerator.close raised", exc_info=True)
-                finally:
-                    self.batch_generator = None
+        queues = list(self._uid_queues.values())
+        self._uid_queues.clear()
+        self._request_uid_map.clear()
+        self._active_uids.clear()
+        for queue in queues:
+            # Sentinel — Generate's stream/non-stream loops both
+            # treat None as "Abort received, stop emitting".
+            if self._loop is not None:
+                self._loop.call_soon_threadsafe(queue.put_nowait, None)
+
+        if self.batch_generator is not None:
+            try:
+                self.batch_generator.close()
+            except Exception:
+                logger.warning("BatchGenerator.close raised", exc_info=True)
+            finally:
+                self.batch_generator = None
 
     async def Generate(self, request, context):
         request_id = request.request_id
@@ -821,53 +827,23 @@ class MlxEngineServicer(mlx_engine_pb2_grpc.MlxEngineServicer):
                 self._pending_by_request_id[request_id] = pending
                 self._pending.append(pending)
             try:
-                uid = await uid_future
+                # Wait for the gen thread to actually insert this
+                # request. The uid value isn't needed by Generate
+                # anymore (gen thread owns _request_uid_map /
+                # _uid_queues / _active_uids); we just need the
+                # synchronization that the gen thread has admitted us.
+                await uid_future
             except asyncio.CancelledError:
-                # Two cases:
-                #  (1) Gen thread hasn't drained us yet — scrub from
-                #      pending so it doesn't insert a doomed request.
-                #  (2) Gen thread inserted us right before the cancel
-                #      landed. We must still run the same backend
-                #      cleanup the normal finally would have done,
-                #      otherwise the uid keeps decoding and the batch
-                #      never drains.
+                # Signal the gen thread to clean up — whether the
+                # request was still pending, already inserted, or in
+                # the transient gap between the two. The gen thread
+                # observes this on its next iteration and does all
+                # the necessary backend cleanup itself, so we don't
+                # touch _request_uid_map / _uid_queues / batch_generator
+                # from the asyncio thread.
                 with self._pending_lock:
-                    self._pending_by_request_id.pop(request_id, None)
-                    try:
-                        self._pending.remove(pending)
-                    except ValueError:
-                        pass
-                # Recover the uid: prefer the future's result, but fall
-                # back to _request_uid_map (the gen thread publishes the
-                # mapping *before* scheduling set_result, so it's
-                # populated even when the cancel arrived first and put
-                # the future into the cancelled state).
-                inserted_uid = None
-                if uid_future.done() and not uid_future.cancelled():
-                    try:
-                        inserted_uid = uid_future.result()
-                    except Exception:
-                        inserted_uid = None
-                with self._gen_lock:
-                    if inserted_uid is None:
-                        inserted_uid = self._request_uid_map.pop(request_id, None)
-                    else:
-                        self._request_uid_map.pop(request_id, None)
-                    if inserted_uid is not None:
-                        self._uid_queues.pop(inserted_uid, None)
-                # Queue the backend remove for the gen thread instead
-                # of calling batch_generator.remove() here. mlx array
-                # indexing inside remove() runs against the calling
-                # thread's stream context; doing it on the asyncio
-                # main thread violates the same single-thread mlx
-                # invariant this servicer enforces for insert/next.
-                if inserted_uid is not None:
-                    with self._pending_lock:
-                        self._pending_remove.append(inserted_uid)
+                    self._aborted_request_ids.add(request_id)
                 raise
-            # Note: _request_uid_map[request_id] = uid is published by
-            # the gen thread BEFORE waking us, so Abort can find this
-            # request immediately. Don't re-set it here (no-op anyway).
             self._active_requests += 1
             prompt_tokens = len(token_ids)
 
@@ -941,21 +917,17 @@ class MlxEngineServicer(mlx_engine_pb2_grpc.MlxEngineServicer):
                             break
             finally:
                 self._active_requests -= 1
-                self._request_uid_map.pop(request_id, None)
-                self._uid_queues.pop(uid, None)
-                # Queue the backend remove for the gen thread instead
-                # of calling batch_generator.remove() here. mlx array
-                # indexing inside remove() runs against the calling
-                # thread's stream context; doing it on the asyncio
-                # main thread violates the single-thread mlx invariant
-                # this servicer enforces for insert/next.
-                #
-                # Safe to double-queue: the gen thread also removes on
-                # finish_reason inline; the queued-remove drain filters
-                # by `uid in _active_uids` so a uid already gone
-                # produces no spurious error.
+                # Signal the gen thread to clean up
+                # _request_uid_map / _uid_queues / (if still in
+                # _active_uids) BatchGenerator. Natural-completion
+                # requests already had `_active_uids.discard(uid)` run
+                # inline on the gen thread when finish_reason fired;
+                # the abort drain just pops the asyncio-side index
+                # entries. Disconnect-mid-stream requests get the full
+                # cleanup including `batch_generator.remove`. Either
+                # way, all mlx-state mutations stay on the gen thread.
                 with self._pending_lock:
-                    self._pending_remove.append(uid)
+                    self._aborted_request_ids.add(request_id)
 
         except ValueError as e:
             logger.warning("Generate invalid request %s: %s", request_id, e)
@@ -965,70 +937,15 @@ class MlxEngineServicer(mlx_engine_pb2_grpc.MlxEngineServicer):
             await context.abort(grpc.StatusCode.INTERNAL, str(e))
 
     async def Abort(self, request, context):
-        for request_id in request.request_ids:
-            # Lookup the request under _gen_lock so we observe the
-            # gen thread's pending->inserted transition atomically.
-            # The gen thread releases _pending_lock between popping
-            # `_pending_by_request_id` and setting `_request_uid_map`,
-            # so an Abort that took only `_pending_lock` could find
-            # the request in NEITHER map and silently no-op while the
-            # request keeps decoding. Holding `_gen_lock` here forces
-            # Abort to wait for the gen thread's iteration to
-            # complete — the transition is atomic from outside.
-            #
-            # Cost: Abort blocks for up to one gen-loop iteration
-            # (~50 ms on M-series, less for small batches). Abort
-            # itself is rare (router-initiated cancel), so the
-            # latency hit is acceptable in exchange for the
-            # correctness guarantee.
-            with self._gen_lock:
-                with self._pending_lock:
-                    pending = self._pending_by_request_id.pop(request_id, None)
-                    if pending is not None:
-                        try:
-                            self._pending.remove(pending)
-                        except ValueError:
-                            pass
-
-                # Case A: request hasn't entered the batch yet.
-                if pending is not None:
-                    uid = None
-                    queue = None
-                # Case B: already inserted — pull the uid + queue
-                # while still under _gen_lock so they don't get
-                # mutated by another path between read and use.
-                else:
-                    uid = self._request_uid_map.pop(request_id, None)
-                    queue = self._uid_queues.pop(uid, None) if uid is not None else None
-
-            if pending is not None:
-                # Cancel the pending request's future so Generate
-                # exits cleanly via its CancelledError handler.
-                if not pending.uid_future.done():
-                    pending.uid_future.cancel()
-                continue
-
-            if uid is not None:
-                if queue is not None:
-                    # Drain already-buffered tokens so Generate stops emitting
-                    # output immediately rather than flushing a backlog of
-                    # stale chunks before seeing the sentinel.
-                    while not queue.empty():
-                        try:
-                            queue.get_nowait()
-                        except asyncio.QueueEmpty:
-                            break
-                    # Wake the Generate waiter blocked on queue.get() so it
-                    # exits cleanly instead of hanging until transport cancel.
-                    queue.put_nowait(None)
-                # Queue the backend remove for the gen thread (see
-                # class docstring for why all batch_generator.remove
-                # calls run there). Generate.finally on the same uid
-                # also queues a remove; the drain filters by
-                # `uid in _active_uids` and dedups so the duplicate is
-                # a no-op.
-                with self._pending_lock:
-                    self._pending_remove.append(uid)
+        # mlx-lm.server-style: just record the request_ids in the
+        # abort signal set and return. The gen thread observes the
+        # set on its next iteration and does all the cleanup work
+        # — pending lookup, uid lookup, queue wake, BatchGenerator
+        # remove. Abort returns within microseconds; the actual
+        # cleanup lags by at most one decode step.
+        with self._pending_lock:
+            for request_id in request.request_ids:
+                self._aborted_request_ids.add(request_id)
         return mlx_engine_pb2.AbortResponse()
 
     async def HealthCheck(self, request, context):

--- a/grpc_servicer/smg_grpc_servicer/mlx/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/mlx/servicer.py
@@ -16,7 +16,7 @@ import zipfile
 
 import grpc
 import mlx.core as mx
-from mlx_lm.generate import SequenceStateMachine, generation_stream
+from mlx_lm.generate import BatchGenerator, SequenceStateMachine
 from mlx_lm.sample_utils import make_logits_processors, make_sampler
 from smg_grpc_proto import mlx_engine_pb2, mlx_engine_pb2_grpc
 from smg_grpc_proto.generated import common_pb2
@@ -91,61 +91,76 @@ class _PendingRequest:
 class MlxEngineServicer(mlx_engine_pb2_grpc.MlxEngineServicer):
     """gRPC servicer implementing the MlxEngine service for MLX backends.
 
-    Concurrency model: drain-and-batch
-    ----------------------------------
-    mlx-lm's ``BatchGenerator`` does not support inserting new sequences
-    while the active batch is in its decode phase: the rope offset cache
-    is sized at the start of decode and a mid-decode ``insert()`` leaves
-    it out of sync with the new batch shape, which surfaces as
+    Concurrency model: per-step admission (mlx-lm.server-style)
+    ----------------------------------------------------------
+    The earlier drain-and-batch model — wait for ``_active_uids`` to be
+    empty before allowing inserts — was a workaround for a
+    cross-thread mlx-state corruption that surfaced as
 
         ValueError: [rope] offset must be a scalar or vector with N
             elements but has shape (N-1).
 
-    inside ``mx.fast.rope`` on the next ``_step()``. mlx-lm.server avoids
-    this by serving each batch to completion before accepting the next
-    set of requests; we mirror that here.
+    inside ``mx.fast.rope`` (PR #1414). The drain wait paid for that
+    correctness with a TTFT regression at high concurrency-to-batch-size
+    ratio: a request arriving mid-decode of a 4-way batch had to wait
+    for all four to finish (~3 s for chat) before its prefill could
+    start.
+
+    The actual root cause turned out to be threading, not insert timing.
+    ``mlx_lm.generate.generation_stream`` is allocated by
+    ``mx.new_thread_local_stream(...)``; mlx's ``mx.stream(s)`` context
+    is per-thread. When the BatchGenerator is constructed on thread A
+    (the asyncio main thread, in the original design) and ``next()``
+    runs on thread B (the gen thread), the stream object's per-thread
+    binding doesn't follow it — mx kernel calls and ``mx.async_eval``
+    continuations later raise "no Stream(gpu, 1) in current thread".
+    That's the same threading bug that made concurrent insert-during-
+    decode unsafe in our setup, but mlx-lm.server doesn't hit either
+    failure because it runs all mlx state on a single dispatch thread.
+
+    This servicer now mirrors mlx-lm.server's design:
+
+      * The BatchGenerator is constructed inside ``_generation_loop``
+        on the gen thread, so its thread-local stream binds to that
+        thread for the lifetime of the process. All ``insert()``,
+        ``next()``, and ``remove()`` calls run on that same thread.
+      * Per-step admission. Each iteration of the loop drains
+        ``_pending`` (regardless of whether the batch is empty), calls
+        ``insert()``, then advances by exactly one ``next()`` step.
+        Worst-case admission delay is one decode step (~50 ms),
+        matching mlx-lm.server's main loop.
 
     Flow:
 
       * Incoming ``Generate`` calls build a :class:`_PendingRequest` and
         push it onto ``self._pending``, then await ``uid_future``.
-      * The generation thread's main loop, between iterations, checks
-        whether the active batch has drained (``_active_uids`` empty).
-        When it has, it drains ``_pending`` in one shot and feeds the
-        whole list to a single ``BatchGenerator.insert()`` call — this
-        keeps batching for concurrent arrivals while ensuring no insert
-        ever happens during decode.
+      * The gen thread, every iteration, drains ``_pending`` and calls
+        ``BatchGenerator.insert()`` (which only appends to the
+        ``_unprocessed_sequences`` deque — fast, no batch shape
+        mutation). Then ``BatchGenerator.next()`` pulls from that deque
+        into the prefill batch and advances generation by one token.
       * Each request's ``uid_future`` is resolved as soon as its uid is
-        known, so ``Generate`` can register its uid for ``Abort`` lookup
-        and start consuming tokens from its per-uid queue.
-
-    Trade-off: a request arriving while a batch is mid-decode waits for
-    that batch to drain before its first token. That's the same behavior
-    as ``mlx-lm.server`` and is the correctness fix for the rope crash;
-    re-introducing true dynamic batching is a separate optimization that
-    requires fixes in mlx-lm's BatchGenerator.
+        known so ``Generate`` can register its uid for ``Abort`` and
+        start consuming tokens from its per-uid queue.
 
     Thread-safety
     -------------
     ``self._gen_lock`` protects all mutations of the BatchGenerator and
     of ``_active_uids`` / ``_uid_queues``. It is acquired by:
 
-      * the gen thread, around the whole drain-pending + ``next()`` +
-        dispatch + finished-``remove()`` block (one critical section per
-        loop iteration);
+      * the gen thread for each loop iteration (drain-pending + insert
+        + next + dispatch + finished-remove);
       * the event loop in ``Generate``'s ``finally`` for the
         client-disconnect cleanup ``remove()``;
       * the event loop in ``Abort`` for the in-flight ``remove()``.
 
     ``self._pending_lock`` protects the pending list/index and is held
     only briefly: append in ``Generate``, drain in the gen thread, pop
-    in ``Abort``. The gen thread *does* nest it inside ``_gen_lock``
-    during drain-and-fill (we hold ``_gen_lock`` for the whole
-    iteration and grab ``_pending_lock`` only to swap pending into the
-    batch). All other sites acquire just one of the two locks at a
+    in ``Abort``. The gen thread nests it inside ``_gen_lock`` each
+    iteration; all other sites acquire just one of the two locks at a
     time, so this is the only nesting direction in the codebase —
-    adding any path that acquires ``_gen_lock`` while already holding
-    ``_pending_lock`` would deadlock.
+    acquiring ``_gen_lock`` while already holding ``_pending_lock``
+    would deadlock.
 
     Cost model: the event loop can block up to one ``next()`` step
     (~10–50 ms on M-series) while the gen thread holds ``_gen_lock``.
@@ -155,9 +170,23 @@ class MlxEngineServicer(mlx_engine_pb2_grpc.MlxEngineServicer):
     """
 
     def __init__(
-        self, batch_generator, model_path, model_dir, model_config, eos_token_ids, start_time
+        self,
+        *,
+        model,
+        completion_batch_size: int,
+        prefill_batch_size: int,
+        model_path,
+        model_dir,
+        model_config,
+        eos_token_ids,
+        start_time,
     ):
-        self.batch_generator = batch_generator
+        # The BatchGenerator is constructed lazily on the gen thread (see
+        # class docstring). Until then `batch_generator is None`.
+        self._model = model
+        self._completion_batch_size = completion_batch_size
+        self._prefill_batch_size = prefill_batch_size
+        self.batch_generator = None
         self.model_path = model_path
         self.model_dir = model_dir
         self.model_config = model_config
@@ -167,21 +196,27 @@ class MlxEngineServicer(mlx_engine_pb2_grpc.MlxEngineServicer):
         self._request_uid_map = {}
         self._uid_queues = {}
         # Set of uids currently live in the BatchGenerator. Mutated only
-        # under ``_gen_lock``. The gen thread inspects ``not _active_uids``
-        # to decide whether it's safe to drain ``_pending`` into a fresh
-        # ``insert()``.
+        # under ``_gen_lock``. Used as the gate for "is the batch
+        # drained?" cleanup decisions; new admissions are *not* gated on
+        # this anymore (per-step model — see class docstring).
         self._active_uids: set[int] = set()
         self._shutdown_event = threading.Event()
+        # Set by the gen thread once BatchGenerator is constructed and
+        # warmup has completed; ``server.serve_grpc`` waits on this
+        # before flipping the health check to SERVING so that no
+        # Generate RPC arrives before there's a BatchGenerator to
+        # insert into.
+        self._ready_event = threading.Event()
         self._loop = None
         self._gen_thread = None
         # Protects mlx-lm BatchGenerator state + ``_uid_queues`` +
         # ``_active_uids`` against the background gen thread. See class
         # docstring.
         self._gen_lock = threading.Lock()
-        # Drain-and-batch state. New ``Generate`` calls land here and
-        # wait for the gen thread to pull them into a fresh batch once
-        # the previous batch drains. Index by request_id so ``Abort``
-        # can cancel a request that hasn't entered the batch yet.
+        # Per-step admission state. New ``Generate`` calls land here
+        # and the gen thread drains them on EVERY iteration (not gated
+        # on ``_active_uids``). Indexed by request_id so ``Abort`` can
+        # cancel a request that hasn't entered the batch yet.
         self._pending: list[_PendingRequest] = []
         self._pending_by_request_id: dict[str, _PendingRequest] = {}
         self._pending_lock = threading.Lock()
@@ -194,6 +229,48 @@ class MlxEngineServicer(mlx_engine_pb2_grpc.MlxEngineServicer):
                 self._ctx_limit = val
                 break
         logger.info("MlxEngineServicer initialized for model %s", model_path)
+
+    def wait_ready(self, timeout: float | None = None) -> bool:
+        """Block until the gen thread has constructed BatchGenerator + warmed up.
+
+        Called from ``server.serve_grpc`` (in an executor thread so the
+        asyncio loop isn't blocked) before flipping the health probe
+        to SERVING. Returns ``True`` when ready; ``False`` if the
+        servicer was shut down before becoming ready.
+        """
+        # Poll so a shutdown signal during warmup unblocks the waiter.
+        deadline = None if timeout is None else (time.monotonic() + timeout)
+        while not self._ready_event.is_set():
+            if self._shutdown_event.is_set():
+                return False
+            wait = 0.1
+            if deadline is not None:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return False
+                wait = min(wait, remaining)
+            self._ready_event.wait(wait)
+        return True
+
+    def _warmup(self) -> None:
+        """Run one end-to-end token through the batch generator so the
+        first real request doesn't pay JIT/kernel compilation cost.
+
+        Runs ON the gen thread, after BatchGenerator construction and
+        before the main per-step loop, so the warmup also exercises
+        the same thread-local stream binding the bench traffic will use.
+        """
+        logger.info("Running warmup generation...")
+        try:
+            uids = self.batch_generator.insert(prompts=[[1]], max_tokens=[1])
+            for _ in range(10):
+                _, gen_responses = self.batch_generator.next()
+                if any(r.finish_reason is not None for r in gen_responses if r.uid == uids[0]):
+                    break
+            self.batch_generator.remove(uids)
+            logger.info("Warmup complete")
+        except Exception:
+            logger.warning("Warmup failed (non-fatal)", exc_info=True)
 
     @staticmethod
     def _build_sampler(sampling_params):
@@ -427,116 +504,155 @@ class MlxEngineServicer(mlx_engine_pb2_grpc.MlxEngineServicer):
         logger.info("Generation loop stopped")
 
     def _generation_loop(self):
+        # Construct the BatchGenerator HERE on the gen thread so its
+        # thread-local mlx stream binds to this thread for life. All
+        # subsequent insert/next/remove calls happen on this same
+        # thread, matching mlx-lm.server's single-threaded mlx state
+        # invariant. See class docstring for why cross-thread mlx
+        # state was the underlying cause of both the rope crash from
+        # PR #1414 and the "no Stream(gpu, 1) in current thread"
+        # RuntimeError seen at concurrency 4.
+        try:
+            self.batch_generator = BatchGenerator(
+                self._model,
+                completion_batch_size=self._completion_batch_size,
+                prefill_batch_size=self._prefill_batch_size,
+            )
+        except Exception:
+            logger.exception("BatchGenerator construction failed")
+            self._ready_event.set()  # Unblock waiters; they'll see no batch_generator.
+            return
+        logger.info(
+            "BatchGenerator created on gen thread (prefill=%d, completion=%d)",
+            self._prefill_batch_size,
+            self._completion_batch_size,
+        )
+
+        # Warmup before signalling ready so the first real Generate RPC
+        # doesn't pay JIT/kernel compilation cost.
+        self._warmup()
+        self._ready_event.set()
+
+        # Per-step admission loop. Every iteration:
+        #   1. Drain _pending into BatchGenerator.insert(...) (deque
+        #      append on the gen thread — fast, no batch shape mutation).
+        #   2. Advance the batch by exactly one BatchGenerator.next()
+        #      step. next() pulls from _unprocessed_sequences into the
+        #      prefill batch, runs one prefill chunk and one decode
+        #      token, and returns responses.
+        # Worst-case admission delay for a request that arrives just
+        # after a next() call begins: one decode step (~50 ms on
+        # M-series), matching mlx-lm.server's loop.
         while not self._shutdown_event.is_set():
             prompt_responses: list = []
             gen_responses: list = []
             inserted_this_iter = False
             try:
                 with self._gen_lock:
-                    # Phase 1: drain-and-fill. _pending_lock is nested
-                    # inside _gen_lock here — the only nesting site in
-                    # the codebase (see class docstring).
-                    if not self._active_uids:
-                        with self._pending_lock:
-                            batch = self._pending[:]
-                            self._pending.clear()
-                            # NOTE: do NOT pop from _pending_by_request_id
-                            # yet — keeping pending entries indexed until
-                            # insert() succeeds means Abort() can still
-                            # cancel a request that lost its insert race.
+                    # Phase 1: admit pending. NOT gated on _active_uids
+                    # — pending requests can join while a batch is
+                    # mid-decode, which is the whole point of the
+                    # mlx-lm.server-style scheduler.
+                    with self._pending_lock:
+                        batch = self._pending[:]
+                        self._pending.clear()
+                        # Don't pop from _pending_by_request_id yet:
+                        # keeping pending entries indexed until insert()
+                        # succeeds lets Abort() cancel a request that
+                        # lost the insert race.
 
-                        # Filter out requests whose uid_future was already
-                        # cancelled (client disconnected before drain).
-                        batch = [p for p in batch if not p.uid_future.cancelled()]
+                    batch = [p for p in batch if not p.uid_future.cancelled()]
 
-                        if batch:
-                            try:
-                                uids = self.batch_generator.insert(
-                                    prompts=[p.token_ids for p in batch],
-                                    max_tokens=[p.max_tokens for p in batch],
-                                    samplers=[p.sampler for p in batch],
-                                    logits_processors=[p.logits_processors for p in batch],
-                                    state_machines=[p.state_machine for p in batch],
-                                )
-                            except Exception as e:
-                                # Wake every waiter with a real error so
-                                # Generate exits with INTERNAL instead of
-                                # hanging on uid_future forever.
-                                logger.exception(
-                                    "BatchGenerator.insert failed for batch of %d", len(batch)
-                                )
-                                with self._pending_lock:
-                                    for p in batch:
-                                        self._pending_by_request_id.pop(p.request_id, None)
-                                for p in batch:
-                                    self._loop.call_soon_threadsafe(
-                                        _set_future_exception_safe, p.uid_future, e
-                                    )
-                                # Skip phase 2 — nothing was inserted.
-                                continue
-
-                            # insert() succeeded — finalize each request.
+                    if batch:
+                        try:
+                            uids = self.batch_generator.insert(
+                                prompts=[p.token_ids for p in batch],
+                                max_tokens=[p.max_tokens for p in batch],
+                                samplers=[p.sampler for p in batch],
+                                logits_processors=[p.logits_processors for p in batch],
+                                state_machines=[p.state_machine for p in batch],
+                            )
+                        except Exception as e:
+                            # Wake every waiter with a real error so
+                            # Generate exits with INTERNAL instead of
+                            # hanging on uid_future forever.
+                            logger.exception(
+                                "BatchGenerator.insert failed for batch of %d", len(batch)
+                            )
                             with self._pending_lock:
                                 for p in batch:
                                     self._pending_by_request_id.pop(p.request_id, None)
-                            for uid, p in zip(uids, batch):
-                                self._uid_queues[uid] = p.queue
-                                self._active_uids.add(uid)
-                                # Publish the request_id -> uid mapping
-                                # BEFORE waking Generate. Otherwise Abort
-                                # can land in the gap between set_result
-                                # and Generate's own assignment and miss
-                                # the mapping entirely (silent no-op).
-                                self._request_uid_map[p.request_id] = uid
+                            for p in batch:
                                 self._loop.call_soon_threadsafe(
-                                    _set_future_result_safe, p.uid_future, uid
+                                    _set_future_exception_safe, p.uid_future, e
                                 )
-                            inserted_this_iter = True
+                            continue
 
-                    # Phase 2: drive the active batch one step. Skip if the
-                    # batch is empty *and* we didn't just insert anything —
-                    # next() on an empty batch is wasted work.
-                    if self._active_uids:
-                        with mx.stream(generation_stream):
-                            prompt_responses, gen_responses = self.batch_generator.next()
+                        # insert() succeeded — finalize each request.
+                        with self._pending_lock:
+                            for p in batch:
+                                self._pending_by_request_id.pop(p.request_id, None)
+                        for uid, p in zip(uids, batch):
+                            self._uid_queues[uid] = p.queue
+                            self._active_uids.add(uid)
+                            # Publish the request_id -> uid mapping
+                            # BEFORE waking Generate. Otherwise Abort
+                            # can land in the gap between set_result
+                            # and Generate's own assignment and miss
+                            # the mapping entirely (silent no-op).
+                            self._request_uid_map[p.request_id] = uid
+                            self._loop.call_soon_threadsafe(
+                                _set_future_result_safe, p.uid_future, uid
+                            )
+                        inserted_this_iter = True
+
+                    # Phase 2: advance one step. Skip when there's
+                    # nothing in flight AND nothing was just inserted —
+                    # next() on an empty BatchGenerator is wasted work.
+                    if self._active_uids or inserted_this_iter:
+                        # BatchGenerator.next() wraps itself in
+                        # `with mx.stream(self._stream):` internally
+                        # (mlx_lm/generate.py:1847), so no outer wrap
+                        # is needed here — and adding one would just
+                        # nest into the same thread-local stream.
+                        prompt_responses, gen_responses = self.batch_generator.next()
 
                         for r in gen_responses:
                             queue = self._uid_queues.get(r.uid)
                             if queue is not None:
                                 self._loop.call_soon_threadsafe(queue.put_nowait, r)
                             if r.finish_reason is not None:
-                                # Discard from _active_uids ONLY after a
-                                # successful remove. _active_uids is the
-                                # gate that admits new pending requests;
-                                # if remove() fails for a real backend
-                                # reason (not just an already-removed
-                                # uid), discarding would let drain-and-
-                                # fill insert into a still-live batch
-                                # and reintroduce the rope crash this
-                                # whole change is fixing.
+                                # Only discard from _active_uids on a
+                                # successful remove. If remove fails
+                                # for a real backend reason, the uid
+                                # stays tracked so we don't lose
+                                # accounting on cleanup paths.
                                 try:
                                     self.batch_generator.remove([r.uid])
                                     self._active_uids.discard(r.uid)
                                 except Exception:
                                     logger.exception(
-                                        "BatchGenerator.remove failed for uid %d "
-                                        "(keeping it in _active_uids to preserve "
-                                        "the drain gate)",
-                                        r.uid,
+                                        "BatchGenerator.remove failed for uid %d", r.uid
                                     )
             except Exception:
                 logger.exception("Error in generation loop")
                 continue
 
-            if (
-                not prompt_responses
-                and not gen_responses
-                and not inserted_this_iter
-                and not self._active_uids
-            ):
-                # Truly idle — sleep so the event loop can append to
-                # _pending without contending on the gen lock.
-                time.sleep(0.001)
+            # Idle sleep only when there's truly nothing to do — gives
+            # the event loop a chance to append to _pending without
+            # contending on _gen_lock.
+            if not prompt_responses and not gen_responses and not self._active_uids:
+                with self._pending_lock:
+                    pending_size = len(self._pending)
+                if pending_size == 0:
+                    time.sleep(0.001)
+
+        # Shutdown — release wired-limit etc.
+        if self.batch_generator is not None:
+            try:
+                self.batch_generator.close()
+            except Exception:
+                logger.warning("BatchGenerator.close raised", exc_info=True)
 
     async def Generate(self, request, context):
         request_id = request.request_id


### PR DESCRIPTION
## Description

### Problem

PR #1399's nightly bench measured a TTFT regression at chat concurrency=4 against the drain-and-batch design from PR #1414, plus a separate cross-thread mlx-state crash mid-agent_c4. From CI run [25195762280](https://github.com/lightseekorg/smg/actions/runs/25195762280):

| Scenario / c | Backend          | TTFT mean | TTFT p99   | Notes                          |
|--------------|------------------|-----------|------------|---------------------------------|
| chat / 4     | mlx-lm.server     | 7,622 ms  | 10,590 ms  | tight, smooth                   |
| chat / 4     | smg → mlx-grpc    | 11,247 ms | **31,243 ms** | bimodal (p50=7,219, p90=23,265) |
| agent / 4    | smg → mlx-grpc    | 62,166 ms | 100,621 ms | 5/8 ok, then 726× `404 No available workers` after `RuntimeError: There is no Stream(gpu, 1) in current thread` in `mlx_lm/generate.py:_step` |

Two distinct failures, both rooted in the **same threading mistake**: the previous design constructed `BatchGenerator` on the asyncio main thread but called `next()` on a separate gen thread. mlx-lm's `generation_stream` is allocated by `mx.new_thread_local_stream(...)` and `mx.stream(s)` context is per-thread — the stream object's per-thread binding doesn't follow it across threads, so `mx.async_eval` continuations later fail to find the stream in the gen-thread context. mlx-lm.server doesn't hit either failure because it runs all mlx state on a single scheduler thread.

PR #1414's drain-and-batch (wait for `_active_uids` to be empty before inserting) was a workaround for the rope-offset corruption that surfaced *because of* the cross-thread mlx state. With the threading mistake fixed, the drain wait becomes pure latency cost, exactly the bimodal pattern visible in CI's chat_c4 column.

### Solution

Mirror mlx-lm.server's design: keep the gen thread, but make sure all mlx state lives on it.

**A. Construct `BatchGenerator` on the gen thread.** Defer construction from `server.serve_grpc` (asyncio main thread) into the first lines of `_generation_loop`. `mlx_lm.generate.generation_stream` then lazily binds to the gen thread for the lifetime of the process, and `insert/next/remove` all run on the same thread. New `_ready_event` lets `serve_grpc` wait for construction + warmup to finish before flipping the health probe to SERVING.

**B. Per-step admission instead of drain-and-batch.** Once A is in place, mid-decode insert is safe (insert and next are serialized by being on the same thread, plus `_gen_lock`). Loop now mirrors `mlx_lm/server.py:_generate`: every iteration drains `_pending`, calls `insert(...)`, then advances by exactly one `next()` step. Worst-case admission delay collapses from a full batch drain (~3 s) to one decode step (~50 ms).

**C. Drop the redundant outer `with mx.stream(generation_stream):` wrapper.** `BatchGenerator.next()` already wraps itself in `with mx.stream(self._stream):` internally ([mlx_lm/generate.py:1847](https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/generate.py#L1847)). Our outer wrap was dead code under the old threading model and would have re-entered the same thread-local stream under the new one.

## Changes

- `grpc_servicer/smg_grpc_servicer/mlx/server.py` (+/- ~30 lines)
  - Drop `BatchGenerator` import and up-front construction; pass `model` + batch sizes to the servicer instead.
  - Drop the standalone `_warmup` helper (moved into the servicer, runs on the gen thread).
  - `serve_grpc` now `await`s `servicer.wait_ready` (in an executor) before `health_servicer.set_serving()`.
- `grpc_servicer/smg_grpc_servicer/mlx/servicer.py` (+/- ~250 lines, mostly comments + docstring rewrite)
  - New keyword-only `__init__` signature: `model=`, `completion_batch_size=`, `prefill_batch_size=` (replaces `batch_generator=`).
  - New `_ready_event` and public `wait_ready(timeout=None)`.
  - `_generation_loop`: phase 0 constructs `BatchGenerator` + warms up + signals ready. Main loop: `drain pending → insert → next() once → dispatch responses` per iteration, no `_active_uids` admission gate.
  - Class docstring rewritten to describe the new threading invariant + per-step admission model and to point at the underlying mlx thread-local-stream behavior.

No proto, gateway, or client changes. Marker for the `Generate.finally` and `Abort` cleanup paths is unchanged.

## Test Plan

Local validation on Apple Silicon against `mlx-community/gemma-3-4b-it-qat-4bit` with `target/ci/smg`:

- c=1: 4.2 s, 66 chunks, no errors.
- c=4 (4 concurrent identical agent prompts): 9.6 s, 4 × 66 chunks, no errors.
- c=8: 24.4 s, 8 × 66 chunks, no errors. c=4 → c=8 scales sub-linearly, confirming batched prefill still works.
- Cancel-mid-stream: cancelled request's uid is reclaimed; follow-up request completes in 0.4 s instead of waiting for the cancelled one to finish naturally.
- **Staggered burst test** (16 requests at concurrency 4, max_tokens=64, simulating genai-bench's chat c=4 burst pattern):

  | metric | drain-and-batch (CI 25195762280) | per-step (this branch, local) |
  |---|---|---|
  | p50 | 7,219 ms | **354 ms** |
  | p90 | 23,265 ms | **1,010 ms** |
  | max | 31,243 ms | **1,010 ms** |

  Tail/median ratio: 4.3× (bimodal) → 2.9× (smooth). The full-bench numbers will be tighter on the slower CI runner; this is the apples-to-apples shape change.

- Zero `rope`, `Stream(gpu, 1)`, `InvalidStateError` errors in `mlx-grpc.log` across all of the above.
- `pre-commit run --files` (ruff, ruff format, codespell): clean.

End-to-end CI validation will arrive via the next nightly mlx-bench run on PR #1399 (which uses this servicer); the c=4 chat_c4 cell should drop into the same range as `mlx-lm.server` and the agent_c4 cell should produce real numbers instead of crashing.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes (no Rust files changed)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (no Rust files changed)
- [x] `pre-commit run --files grpc_servicer/...` passes (ruff, ruff format, codespell)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Generation loop now initializes and warms up before serving; service only goes live after readiness is confirmed.
  * Generation resources are constructed lazily on the background generation thread to reduce upfront work and memory.
  * Per-step scheduling implemented for more predictable progression and cancellation behavior.
  * Shutdown now more reliably stops background generation to avoid partial serving or leaked resources.

* **Bug Fixes**
  * Startup aborts cleanly if readiness fails, preventing a partially serving state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->