### PR TITLE
docs: fix image reference paths

### DIFF
--- a/docs/concepts/architecture/grpc-pipeline.md
+++ b/docs/concepts/architecture/grpc-pipeline.md
@@ -51,7 +51,7 @@ Parse function calls and execute MCP tools with automatic result injection.
 ## Pipeline Architecture
 
 <div class="architecture-diagram">
-  <img src="../../../assets/images/grpc-pipeline.svg" alt="gRPC Pipeline Architecture">
+  <img src="../../assets/images/grpc-pipeline.svg" alt="gRPC Pipeline Architecture">
 </div>
 
 <div class="grid" markdown>

--- a/docs/concepts/architecture/high-availability.md
+++ b/docs/concepts/architecture/high-availability.md
@@ -51,7 +51,7 @@ Perform rolling updates without service interruption. Graceful shutdown with req
 ## Mesh Architecture
 
 <div class="architecture-diagram">
-  <img src="../../../assets/images/mesh-architecture.svg" alt="SMG Mesh Architecture">
+  <img src="../../assets/images/mesh-architecture.svg" alt="SMG Mesh Architecture">
 </div>
 
 <div class="grid" markdown>

--- a/docs/concepts/architecture/overview.md
+++ b/docs/concepts/architecture/overview.md
@@ -11,7 +11,7 @@ SMG is a high-performance inference gateway that sits between your applications 
 ## System Architecture
 
 <div class="architecture-diagram">
-  <img src="../../../assets/images/architecture-detailed.svg" alt="SMG Architecture">
+  <img src="../../assets/images/architecture-detailed.svg" alt="SMG Architecture">
 </div>
 
 ---

--- a/docs/concepts/architecture/service-discovery.md
+++ b/docs/concepts/architecture/service-discovery.md
@@ -51,7 +51,7 @@ Separate discovery for prefill and decode workers in disaggregated deployments.
 ## How It Works
 
 <div class="architecture-diagram">
-  <img src="../../../assets/images/service-discovery.svg" alt="Service Discovery Architecture">
+  <img src="../../assets/images/service-discovery.svg" alt="Service Discovery Architecture">
 </div>
 
 ### Discovery Flow

--- a/docs/concepts/extensibility/mcp.md
+++ b/docs/concepts/extensibility/mcp.md
@@ -53,7 +53,7 @@ Automatic tool discovery with caching, TTL-based refresh, and qualified names to
 SMG's MCP Orchestrator manages all interactions between LLM workers and external MCP servers.
 
 <div class="architecture-diagram">
-  <img src="../../../assets/images/mcp-architecture.svg" alt="MCP Integration Architecture">
+  <img src="../../assets/images/mcp-architecture.svg" alt="MCP Integration Architecture">
 </div>
 
 ### Request Flow

--- a/docs/concepts/extensibility/wasm-plugins.md
+++ b/docs/concepts/extensibility/wasm-plugins.md
@@ -53,7 +53,7 @@ Pre-compiled components with LRU caching. Typical overhead: <1ms per invocation.
 WASM plugins execute in SMG's **middleware layer**, intercepting requests before they reach workers and responses before they return to clients.
 
 <div class="architecture-diagram">
-  <img src="../../../assets/images/wasm-plugins.svg" alt="WASM Plugin Pipeline Architecture">
+  <img src="../../assets/images/wasm-plugins.svg" alt="WASM Plugin Pipeline Architecture">
 </div>
 
 ### Plugin Chain Execution

--- a/docs/concepts/performance/tokenizer-caching.md
+++ b/docs/concepts/performance/tokenizer-caching.md
@@ -93,7 +93,7 @@ Similar prompt templates with variable parts. High L0 hit rates.
 ## Cache Architecture
 
 <div class="architecture-diagram">
-  <img src="../../../assets/images/tokenization-cache.svg" alt="Tokenization Cache Architecture">
+  <img src="../../assets/images/tokenization-cache.svg" alt="Tokenization Cache Architecture">
 </div>
 
 <div class="grid" markdown>

--- a/docs/concepts/reliability/circuit-breakers.md
+++ b/docs/concepts/reliability/circuit-breakers.md
@@ -64,7 +64,7 @@ Circuit breakers **fail fast**—they detect failing workers and stop sending tr
 ## How It Works
 
 <div class="architecture-diagram">
-  <img src="../../../assets/images/circuit-breaker.svg" alt="Circuit Breaker State Machine">
+  <img src="../../assets/images/circuit-breaker.svg" alt="Circuit Breaker State Machine">
 </div>
 
 Each worker has its own circuit breaker with three states:
@@ -213,19 +213,19 @@ smg \
 ### Normal Operation
 
 <div class="architecture-diagram">
-  <img src="../../../assets/images/circuit-breaker-normal.svg" alt="Circuit Breaker Normal Operation">
+  <img src="../../assets/images/circuit-breaker-normal.svg" alt="Circuit Breaker Normal Operation">
 </div>
 
 ### Worker Fails
 
 <div class="architecture-diagram">
-  <img src="../../../assets/images/circuit-breaker-failure.svg" alt="Circuit Breaker Worker Failure">
+  <img src="../../assets/images/circuit-breaker-failure.svg" alt="Circuit Breaker Worker Failure">
 </div>
 
 ### Recovery
 
 <div class="architecture-diagram">
-  <img src="../../../assets/images/circuit-breaker-recovery.svg" alt="Circuit Breaker Recovery">
+  <img src="../../assets/images/circuit-breaker-recovery.svg" alt="Circuit Breaker Recovery">
 </div>
 
 ---

--- a/docs/concepts/reliability/graceful-shutdown.md
+++ b/docs/concepts/reliability/graceful-shutdown.md
@@ -69,7 +69,7 @@ With graceful shutdown:
 ## How It Works
 
 <div class="architecture-diagram">
-  <img src="../../../assets/images/graceful-shutdown.svg" alt="Graceful Shutdown Sequence">
+  <img src="../../assets/images/graceful-shutdown.svg" alt="Graceful Shutdown Sequence">
 </div>
 
 ### Shutdown Sequence

--- a/docs/concepts/reliability/health-checks.md
+++ b/docs/concepts/reliability/health-checks.md
@@ -69,7 +69,7 @@ With health checks:
 SMG sends periodic HTTP requests to each worker's health endpoint:
 
 <div class="architecture-diagram">
-  <img src="../../../assets/images/health-checks-flow.svg" alt="Health Check Sequence Diagram">
+  <img src="../../assets/images/health-checks-flow.svg" alt="Health Check Sequence Diagram">
 </div>
 
 ### Worker States

--- a/docs/concepts/reliability/rate-limiting.md
+++ b/docs/concepts/reliability/rate-limiting.md
@@ -66,7 +66,7 @@ Rate limiting ensures **fair access** and **predictable performance**.
 SMG uses a **token bucket** algorithm:
 
 <div class="architecture-diagram">
-  <img src="../../../assets/images/rate-limiting.svg" alt="Token Bucket Rate Limiting">
+  <img src="../../assets/images/rate-limiting.svg" alt="Token Bucket Rate Limiting">
 </div>
 
 ### Token Bucket

--- a/docs/concepts/routing/cache-aware.md
+++ b/docs/concepts/routing/cache-aware.md
@@ -97,7 +97,7 @@ Multiple users with same instructions. Amortized prefill cost across sessions.
 ## Multi-Tenant Radix Tree Architecture
 
 <div class="architecture-diagram">
-  <img src="../../../assets/images/radix-tree.svg" alt="Multi-Tenant Radix Tree Architecture">
+  <img src="../../assets/images/radix-tree.svg" alt="Multi-Tenant Radix Tree Architecture">
 </div>
 
 SMG maintains a **multi-tenant radix tree** that mirrors the KV cache state on each backend worker. This enables true cache-aware routing with 100% prefix match accuracy.
@@ -193,7 +193,7 @@ max_load > balance_rel_threshold × min_load
 ### Selection Flow
 
 <div class="architecture-diagram">
-  <img src="../../../assets/images/cache-routing-flow.svg" alt="Cache-Aware Routing Selection Flow">
+  <img src="../../assets/images/cache-routing-flow.svg" alt="Cache-Aware Routing Selection Flow">
 </div>
 
 ---

--- a/docs/concepts/routing/pd-disaggregation.md
+++ b/docs/concepts/routing/pd-disaggregation.md
@@ -92,7 +92,7 @@ vLLM supports two backends for KV cache transfer:
 ### SGLang PD (Parallel Dispatch)
 
 <div class="architecture-diagram">
-  <img src="../../../assets/images/pd-sglang.svg" alt="SGLang PD Parallel Dispatch Sequence">
+  <img src="../../assets/images/pd-sglang.svg" alt="SGLang PD Parallel Dispatch Sequence">
 </div>
 
 SGLang uses **parallel dispatch** with bootstrap-based coordination:
@@ -105,7 +105,7 @@ SGLang uses **parallel dispatch** with bootstrap-based coordination:
 ### vLLM PD (Sequential Dispatch)
 
 <div class="architecture-diagram">
-  <img src="../../../assets/images/pd-vllm.svg" alt="vLLM PD Sequential Dispatch Sequence">
+  <img src="../../assets/images/pd-vllm.svg" alt="vLLM PD Sequential Dispatch Sequence">
 </div>
 
 vLLM uses **sequential dispatch** with NIXL or Mooncake KV transfer:


### PR DESCRIPTION
## Description

### Problem

Several nested concept docs pages referenced images with `../../../assets/images/...`, which resolves outside the `docs/` directory to `assets/images/...`. Those files do not exist there, so the diagrams fail to load.

### Solution

Update the affected nested concept docs pages to use `../../assets/images/...`, which correctly resolves to `docs/assets/images/...`.

## Changes

- Fixed broken image references in nested `docs/concepts/*/*.md` pages.
- Updated 18 image references across 13 documentation files.
- Left already-valid image references unchanged.

## Test Plan

Verified the docs build:

```text
mkdocs build --strict --site-dir /tmp/smg-docs-site
```

completed successfully.

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Fixed diagram asset references across architecture, extensibility, performance, reliability, and routing documentation so diagrams render correctly and consistently throughout the docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->