### PR TITLE
fix(protocols): accept flat Responses tool_choice shape

### DIFF
--- a/crates/data_connector/src/memory.rs
+++ b/crates/data_connector/src/memory.rs
@@ -435,7 +435,7 @@ impl ResponseStorage for MemoryResponseStorage {
                 .collect();
 
             // Sort by creation time (newest first)
-            responses_with_time.sort_by(|a, b| b.0.cmp(&a.0));
+            responses_with_time.sort_by_key(|(created_at, _)| std::cmp::Reverse(*created_at));
 
             // Apply limit and collect the actual responses
             let limit = limit.unwrap_or(responses_with_time.len());

--- a/crates/mcp/src/core/metrics.rs
+++ b/crates/mcp/src/core/metrics.rs
@@ -206,7 +206,7 @@ impl LatencyStats {
 
         LatencySnapshot {
             count,
-            avg_ms: if count > 0 { total / count } else { 0 },
+            avg_ms: total.checked_div(count).unwrap_or(0),
             min_ms: if min == u64::MAX { 0 } else { min },
             max_ms: max,
         }

--- a/crates/protocols/src/builders/responses/response.rs
+++ b/crates/protocols/src/builders/responses/response.rs
@@ -30,7 +30,7 @@ pub struct ResponsesResponseBuilder {
     store: bool,
     temperature: Option<f32>,
     text: Option<TextConfig>,
-    tool_choice: String,
+    tool_choice: Value,
     tools: Vec<ResponseTool>,
     top_p: Option<f32>,
     truncation: Option<String>,
@@ -64,7 +64,7 @@ impl ResponsesResponseBuilder {
             store: true,
             temperature: None,
             text: None,
-            tool_choice: "auto".to_string(),
+            tool_choice: serde_json::json!("auto"),
             tools: Vec::new(),
             top_p: None,
             truncation: None,
@@ -91,11 +91,11 @@ impl ResponsesResponseBuilder {
             .clone_from(&request.previous_response_id);
         self.store = request.store.unwrap_or(true);
         self.temperature = request.temperature;
-        self.tool_choice = if let Some(ref tc) = request.tool_choice {
-            serde_json::to_string(tc).unwrap_or_else(|_| "auto".to_string())
-        } else {
-            "auto".to_string()
-        };
+        self.tool_choice = request
+            .tool_choice
+            .as_ref()
+            .map(responses_tool_choice_value)
+            .unwrap_or_else(|| serde_json::json!("auto"));
         self.tools = request.tools.clone().unwrap_or_default();
         self.top_p = request.top_p;
         self.user.clone_from(&request.user);
@@ -196,7 +196,7 @@ impl ResponsesResponseBuilder {
     }
 
     /// Set tool choice setting
-    pub fn tool_choice(mut self, tool_choice: impl Into<String>) -> Self {
+    pub fn tool_choice(mut self, tool_choice: impl Into<Value>) -> Self {
         self.tool_choice = tool_choice.into();
         self
     }

--- a/crates/protocols/src/responses.rs
+++ b/crates/protocols/src/responses.rs
@@ -9,8 +9,9 @@ use validator::{Validate, ValidationError};
 
 use super::{
     common::{
-        default_model, default_true, validate_stop, ChatLogProbs, Function, GenerationRequest,
-        PromptTokenUsageInfo, StringOrArray, ToolChoice, ToolChoiceValue, ToolReference, UsageInfo,
+        default_model, default_true, validate_stop, ChatLogProbs, Function, FunctionChoice,
+        GenerationRequest, PromptTokenUsageInfo, StringOrArray, ToolChoice, ToolChoiceValue,
+        ToolReference, UsageInfo,
     },
     sampling_params::{validate_top_k_value, validate_top_p_value},
 };
@@ -708,7 +709,12 @@ pub struct ResponsesRequest {
     pub temperature: Option<f32>,
 
     /// Tool choice behavior
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_responses_tool_choice",
+        serialize_with = "serialize_responses_tool_choice",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub tool_choice: Option<ToolChoice>,
 
     /// Available tools
@@ -932,6 +938,65 @@ impl GenerationRequest for ResponsesRequest {
                 .join(" "),
         }
     }
+}
+
+pub fn responses_tool_choice_value(tool_choice: &ToolChoice) -> Value {
+    match tool_choice {
+        ToolChoice::Function { function, .. } => serde_json::json!({
+            "type": "function",
+            "name": function.name,
+        }),
+        _ => serde_json::to_value(tool_choice).unwrap_or_else(|_| serde_json::json!("auto")),
+    }
+}
+
+#[expect(
+    clippy::ref_option,
+    reason = "serde serialize_with passes the field as &Option<T>"
+)]
+fn serialize_responses_tool_choice<S>(
+    tool_choice: &Option<ToolChoice>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    match tool_choice {
+        Some(tool_choice) => responses_tool_choice_value(tool_choice).serialize(serializer),
+        None => serializer.serialize_none(),
+    }
+}
+
+fn deserialize_responses_tool_choice<'de, D>(
+    deserializer: D,
+) -> Result<Option<ToolChoice>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let Some(value) = Option::<Value>::deserialize(deserializer)? else {
+        return Ok(None);
+    };
+
+    if value.is_null() {
+        return Ok(None);
+    }
+
+    if let Some(name) = value
+        .as_object()
+        .filter(|obj| obj.get("type").and_then(Value::as_str) == Some("function"))
+        .and_then(|obj| obj.get("name").and_then(Value::as_str))
+    {
+        return Ok(Some(ToolChoice::Function {
+            tool_type: "function".to_string(),
+            function: FunctionChoice {
+                name: name.to_string(),
+            },
+        }));
+    }
+
+    serde_json::from_value(value)
+        .map(Some)
+        .map_err(serde::de::Error::custom)
 }
 
 /// Validate conversation ID format
@@ -1338,7 +1403,7 @@ pub struct ResponsesResponse {
 
     /// Tool choice setting
     #[serde(default = "default_tool_choice")]
-    pub tool_choice: String,
+    pub tool_choice: Value,
 
     /// Available tools
     #[serde(default)]
@@ -1368,8 +1433,8 @@ fn default_object_type() -> String {
     "response".to_string()
 }
 
-fn default_tool_choice() -> String {
-    "auto".to_string()
+fn default_tool_choice() -> Value {
+    serde_json::json!("auto")
 }
 
 impl ResponsesResponse {

--- a/crates/tokenizer/src/cache/fingerprint.rs
+++ b/crates/tokenizer/src/cache/fingerprint.rs
@@ -42,11 +42,7 @@ impl TokenizerFingerprint {
 
         // Sample up to 1000 tokens for speed
         let sample_size = vocab_size.min(1000);
-        let step = if sample_size > 0 {
-            vocab_size / sample_size
-        } else {
-            1
-        };
+        let step = vocab_size.checked_div(sample_size).unwrap_or(1);
 
         for i in (0..vocab_size).step_by(step.max(1)) {
             if let Some(token) = tokenizer.id_to_token(i as u32) {

--- a/crates/tokenizer/src/chat_template.rs
+++ b/crates/tokenizer/src/chat_template.rs
@@ -209,12 +209,11 @@ impl<'a> Detector<'a> {
                 self.inspect_expr_for_structure(&e.expr);
             }
             // {% set content = message.content %}
-            Stmt::Set(s) => {
+            Stmt::Set(s)
                 if Self::is_var_access(&s.target, "content")
-                    && self.is_any_scope_var_content(&s.expr)
-                {
-                    self.flags.saw_assignment = true;
-                }
+                    && self.is_any_scope_var_content(&s.expr) =>
+            {
+                self.flags.saw_assignment = true;
             }
             Stmt::Macro(m) => {
                 // Heuristic: macro that checks type (via `is` test) and also has any loop
@@ -236,13 +235,12 @@ impl<'a> Detector<'a> {
 
         match expr {
             // content[0] or message.content[0]
-            Expr::GetItem(gi) => {
+            Expr::GetItem(gi)
                 if (matches!(&gi.expr, Expr::Var(v) if v.id == "content")
                     || self.is_any_scope_var_content(&gi.expr))
-                    && Self::is_numeric_const(&gi.subscript_expr)
-                {
-                    self.flags.saw_structure = true;
-                }
+                    && Self::is_numeric_const(&gi.subscript_expr) =>
+            {
+                self.flags.saw_structure = true;
             }
             // content|length or message.content|length
             Expr::Filter(f) => {

--- a/model_gateway/src/core/metrics_aggregator.rs
+++ b/model_gateway/src/core/metrics_aggregator.rs
@@ -33,7 +33,7 @@ pub fn aggregate_metrics(metric_packs: Vec<MetricPack>) -> anyhow::Result<String
         expositions.push(exposition);
     }
 
-    let text = try_reduce(expositions.into_iter(), merge_exposition)?
+    let text = try_reduce(expositions, merge_exposition)?
         .map(|x| format!("{x}"))
         .unwrap_or_default();
     Ok(text)

--- a/model_gateway/src/policies/bucket.rs
+++ b/model_gateway/src/policies/bucket.rs
@@ -363,10 +363,7 @@ impl Bucket {
         }
 
         let worker_cnt = bucket_cnt;
-        let boundary = if worker_cnt == 0 {
-            Vec::new()
-        } else {
-            let gap = self.l_max / worker_cnt;
+        let boundary = if let Some(gap) = self.l_max.checked_div(worker_cnt) {
             self.l_max = usize::MAX;
             prefill_worker_urls
                 .iter()
@@ -381,6 +378,8 @@ impl Bucket {
                     Boundary::new(url.clone(), [min, max])
                 })
                 .collect()
+        } else {
+            Vec::new()
         };
 
         self.boundary = boundary;

--- a/model_gateway/src/routers/grpc/common/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/common/responses/streaming.rs
@@ -11,7 +11,8 @@ use openai_protocol::{
         McpEvent, OutputItemEvent, OutputTextEvent, ResponseEvent, WebSearchCallEvent,
     },
     responses::{
-        ResponseOutputItem, ResponseStatus, ResponsesRequest, ResponsesResponse, ResponsesUsage,
+        responses_tool_choice_value, ResponseOutputItem, ResponseStatus, ResponsesRequest,
+        ResponsesResponse, ResponsesUsage,
     },
 };
 use serde_json::json;
@@ -340,7 +341,7 @@ impl ResponseStreamEventEmitter {
 
             // tool_choice: serialize if present, otherwise use "auto"
             if let Some(ref tc) = req.tool_choice {
-                response_obj["tool_choice"] = json!(tc);
+                response_obj["tool_choice"] = responses_tool_choice_value(tc);
             } else {
                 response_obj["tool_choice"] = json!("auto");
             }
@@ -1008,5 +1009,49 @@ pub(crate) fn attach_mcp_server_label(
 ) {
     if let (Some(label), Some(ResponseFormat::Passthrough)) = (server_label, response_format) {
         item["server_label"] = json!(label);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use openai_protocol::{
+        common::{Function, FunctionChoice, ToolChoice},
+        responses::{FunctionTool, ResponseInput, ResponseTool},
+    };
+
+    use super::*;
+
+    #[test]
+    fn completed_event_serializes_flat_responses_function_tool_choice() {
+        let mut emitter =
+            ResponseStreamEventEmitter::new("resp_test".to_string(), "mock-model".to_string(), 1);
+        emitter.set_original_request(ResponsesRequest {
+            input: ResponseInput::Text("test".to_string()),
+            tools: Some(vec![ResponseTool::Function(FunctionTool {
+                function: Function {
+                    name: "lookup_city".to_string(),
+                    description: None,
+                    parameters: json!({}),
+                    strict: None,
+                },
+            })]),
+            tool_choice: Some(ToolChoice::Function {
+                tool_type: "function".to_string(),
+                function: FunctionChoice {
+                    name: "lookup_city".to_string(),
+                },
+            }),
+            ..Default::default()
+        });
+
+        let event = emitter.emit_completed(None);
+
+        assert_eq!(
+            event["response"]["tool_choice"],
+            json!({
+                "type": "function",
+                "name": "lookup_city"
+            })
+        );
     }
 }

--- a/model_gateway/src/routers/openai/responses/accumulator.rs
+++ b/model_gateway/src/routers/openai/responses/accumulator.rs
@@ -104,11 +104,9 @@ impl StreamingResponseAccumulator {
         };
 
         match get_event_type(event_name, &parsed) {
-            ResponseEvent::CREATED => {
-                if self.initial_response.is_none() {
-                    if let Some(response) = parsed.get("response") {
-                        self.initial_response = Some(response.clone());
-                    }
+            ResponseEvent::CREATED if self.initial_response.is_none() => {
+                if let Some(response) = parsed.get("response") {
+                    self.initial_response = Some(response.clone());
                 }
             }
             ResponseEvent::COMPLETED => {

--- a/model_gateway/tests/api/api_endpoints_test.rs
+++ b/model_gateway/tests/api/api_endpoints_test.rs
@@ -689,6 +689,61 @@ mod responses_endpoint_tests {
     }
 
     #[tokio::test]
+    async fn test_v1_responses_accepts_flat_forced_function_tool_choice() {
+        let ctx = AppTestContext::new(vec![MockWorkerConfig {
+            port: 0,
+            worker_type: WorkerType::Regular,
+            health_status: HealthStatus::Healthy,
+            response_delay_ms: 0,
+            fail_rate: 0.0,
+        }])
+        .await;
+
+        let app = ctx.create_app();
+
+        let payload = json!({
+            "input": "Run lookup_city.",
+            "model": "mock-model",
+            "stream": false,
+            "tools": [
+                {
+                    "type": "function",
+                    "name": "lookup_city",
+                    "description": "Look up a city",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "city": { "type": "string" }
+                        },
+                        "required": ["city"]
+                    }
+                }
+            ],
+            "tool_choice": {
+                "type": "function",
+                "name": "lookup_city"
+            }
+        });
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/responses")
+            .header(CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_string(&payload).unwrap()))
+            .unwrap();
+
+        let resp = app.clone().oneshot(req).await.unwrap();
+        assert_ne!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "Responses flat function tool_choice should not be rejected by request validation"
+        );
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        ctx.shutdown().await;
+    }
+
+    #[tokio::test]
     async fn test_v1_responses_streaming() {
         let ctx = AppTestContext::new(vec![MockWorkerConfig {
             port: 18951,

--- a/model_gateway/tests/api/parser_endpoints_test.rs
+++ b/model_gateway/tests/api/parser_endpoints_test.rs
@@ -71,17 +71,13 @@ impl ParserTestContext {
         match &mut config.mode {
             RoutingMode::Regular {
                 worker_urls: ref mut urls,
-            } => {
-                if urls.is_empty() {
-                    urls.clone_from(&worker_urls);
-                }
+            } if urls.is_empty() => {
+                urls.clone_from(&worker_urls);
             }
             RoutingMode::OpenAI {
                 worker_urls: ref mut urls,
-            } => {
-                if urls.is_empty() {
-                    urls.clone_from(&worker_urls);
-                }
+            } if urls.is_empty() => {
+                urls.clone_from(&worker_urls);
             }
             _ => {} // PrefillDecode mode has its own setup
         }

--- a/model_gateway/tests/common/mod.rs
+++ b/model_gateway/tests/common/mod.rs
@@ -221,17 +221,13 @@ impl AppTestContext {
             match &mut config.mode {
                 RoutingMode::Regular {
                     worker_urls: ref mut urls,
-                } => {
-                    if urls.is_empty() {
-                        urls.clone_from(&worker_urls);
-                    }
+                } if urls.is_empty() => {
+                    urls.clone_from(&worker_urls);
                 }
                 RoutingMode::OpenAI {
                     worker_urls: ref mut urls,
-                } => {
-                    if urls.is_empty() {
-                        urls.clone_from(&worker_urls);
-                    }
+                } if urls.is_empty() => {
+                    urls.clone_from(&worker_urls);
                 }
                 _ => {}
             }

--- a/model_gateway/tests/otel_tracing_test.rs
+++ b/model_gateway/tests/otel_tracing_test.rs
@@ -168,6 +168,10 @@ async fn test_router_with_tracing() {
     );
     println!("Logging initialized with OTEL layer");
 
+    let otel_layer = otel_trace::get_otel_layer().expect("Failed to get OTEL layer");
+    let subscriber = tracing_subscriber::registry().with(otel_layer);
+    let _subscriber_guard = tracing::subscriber::set_default(subscriber);
+
     // 5. Create a span and sleep for a while
     let _span = info_span!(target: "smg::otel-trace", "test_router_with_tracing");
     tokio::time::sleep(Duration::from_secs(1)).await;

--- a/model_gateway/tests/spec/responses.rs
+++ b/model_gateway/tests/spec/responses.rs
@@ -2,7 +2,7 @@ use openai_protocol::{
     common::{Function, StringOrArray, ToolChoice, ToolChoiceValue},
     responses::{
         FunctionTool, IncludeField, McpTool, ResponseInput, ResponseInputOutputItem, ResponseTool,
-        ResponsesRequest, StringOrContentParts, TextConfig, TextFormat,
+        ResponsesRequest, ResponsesResponse, StringOrContentParts, TextConfig, TextFormat,
     },
 };
 use serde_json::json;
@@ -816,6 +816,166 @@ fn test_validate_tool_choice_requires_tools() {
         assert!(
             error_msg.contains("tool_choice") && error_msg.contains("tools"),
             "Error should mention tool_choice requires tools"
+        );
+    }
+}
+
+#[test]
+fn test_deserialize_responses_flat_function_tool_choice() {
+    let request: ResponsesRequest = serde_json::from_value(json!({
+        "input": "test",
+        "tools": [
+            {
+                "type": "function",
+                "name": "lookup_city",
+                "parameters": {}
+            }
+        ],
+        "tool_choice": {
+            "type": "function",
+            "name": "lookup_city"
+        }
+    }))
+    .expect("Responses flat function tool_choice should deserialize");
+
+    assert!(
+        matches!(
+            request.tool_choice,
+            Some(ToolChoice::Function { ref function, .. }) if function.name == "lookup_city"
+        ),
+        "flat Responses tool_choice should normalize to internal function choice"
+    );
+    assert!(
+        request.validate().is_ok(),
+        "flat Responses tool_choice should validate when the function exists"
+    );
+
+    let serialized = serde_json::to_value(&request).expect("ResponsesRequest should serialize");
+    assert_eq!(
+        serialized["tool_choice"],
+        json!({
+            "type": "function",
+            "name": "lookup_city"
+        }),
+        "Responses function tool_choice should serialize in flat Responses shape"
+    );
+}
+
+#[test]
+fn test_responses_response_builder_serializes_flat_function_tool_choice() {
+    let request: ResponsesRequest = serde_json::from_value(json!({
+        "input": "test",
+        "tools": [
+            {
+                "type": "function",
+                "name": "lookup_city",
+                "parameters": {}
+            }
+        ],
+        "tool_choice": {
+            "type": "function",
+            "name": "lookup_city"
+        }
+    }))
+    .expect("Responses flat function tool_choice should deserialize");
+
+    let response = ResponsesResponse::builder("resp_test", "mock-model")
+        .copy_from_request(&request)
+        .build();
+    let serialized = serde_json::to_value(response).expect("ResponsesResponse should serialize");
+
+    assert_eq!(
+        serialized["tool_choice"],
+        json!({
+            "type": "function",
+            "name": "lookup_city"
+        }),
+        "Responses response should echo function tool_choice in flat Responses shape"
+    );
+}
+
+#[test]
+fn test_deserialize_responses_flat_function_tool_choice_validates_tool_name() {
+    let request: ResponsesRequest = serde_json::from_value(json!({
+        "input": "test",
+        "tools": [
+            {
+                "type": "function",
+                "name": "lookup_city",
+                "parameters": {}
+            }
+        ],
+        "tool_choice": {
+            "type": "function",
+            "name": "missing_tool"
+        }
+    }))
+    .expect("Responses flat function tool_choice should deserialize before validation");
+
+    let result = request.validate();
+    assert!(
+        result.is_err(),
+        "flat Responses tool_choice should still reject unknown functions"
+    );
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("function 'missing_tool' not found"),
+        "Error should mention the missing function: {err}"
+    );
+}
+
+#[test]
+fn test_deserialize_responses_chat_style_function_tool_choice_backcompat() {
+    let request: ResponsesRequest = serde_json::from_value(json!({
+        "input": "test",
+        "tools": [
+            {
+                "type": "function",
+                "name": "lookup_city",
+                "parameters": {}
+            }
+        ],
+        "tool_choice": {
+            "type": "function",
+            "function": {
+                "name": "lookup_city"
+            }
+        }
+    }))
+    .expect("Chat-style function tool_choice should remain accepted");
+
+    assert!(
+        matches!(
+            request.tool_choice,
+            Some(ToolChoice::Function { ref function, .. }) if function.name == "lookup_city"
+        ),
+        "Chat-style tool_choice should keep using the internal function choice"
+    );
+    assert!(
+        request.validate().is_ok(),
+        "Chat-style function tool_choice should still validate"
+    );
+}
+
+#[test]
+fn test_deserialize_responses_string_tool_choice_backcompat() {
+    for value in ["auto", "required", "none"] {
+        let request: ResponsesRequest = serde_json::from_value(json!({
+            "input": "test",
+            "tools": [
+                {
+                    "type": "function",
+                    "name": "lookup_city",
+                    "parameters": {}
+                }
+            ],
+            "tool_choice": value
+        }))
+        .expect("string tool_choice should remain accepted");
+
+        assert!(
+            request.tool_choice.is_some(),
+            "string tool_choice should deserialize"
         );
     }
 }


### PR DESCRIPTION
## Description

### Problem

`POST /v1/responses` rejects requests that use the OpenAI-spec-correct flat function `tool_choice` shape with HTTP 400 `tool_choice: data did not match any variant of untagged enum ToolChoice`.

The OpenAI Responses API uses a flat shape:

```json
{ "tool_choice": { "type": "function", "name": "lookup_city" } }
```

while Chat Completions uses a nested shape:

```json
{ "tool_choice": { "type": "function", "function": { "name": "lookup_city" } } }
```

`ResponsesRequest.tool_choice` reuses the shared `ToolChoice` enum which models only the nested Chat shape, so serde rejects the spec-correct flat input at the SMG entrypoint, before any router dispatch — affecting both gRPC- and HTTP-backend routing modes equally.

### Solution

Add a Responses-specific input variant that accepts the flat shape and normalize it into the existing internal `ToolChoice::Function` after deserialization. Downstream Harmony preparation, validation, and dispatch continue to operate on the existing internal shape unchanged. The Chat Completions nested shape remains accepted via the same input variant, preserving backcompat.

## Changes

- `crates/protocols/src/responses.rs` — Responses-specific tool_choice input variant accepting flat shape; normalization to internal `ToolChoice`.
- `crates/protocols/src/builders/responses/response.rs` — flat-shape serialization for Responses output.
- `model_gateway/src/routers/grpc/common/responses/streaming.rs` — flat-shape serialization for streaming `response.completed`.
- `model_gateway/tests/spec/responses.rs` — spec coverage for flat-input deserialize, nested-input backcompat, and roundtrip.
- `model_gateway/tests/api/api_endpoints_test.rs` — endpoint guard exercising the flat-input path end-to-end.

## Test Plan

```
cargo +nightly fmt -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all-features
```

All three pass locally. The new spec and endpoint tests cover:
- flat function tool_choice deserializes and normalizes to internal Function variant
- nested Chat-style tool_choice continues to deserialize correctly (backcompat)
- Responses request echo, response-builder output, and streaming `response.completed` all serialize the flat shape
- spec-invalid shapes still produce the expected validation errors

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced tool choice handling with support for flat function-style format and improved backward compatibility for alternative input shapes.

* **Bug Fixes**
  * Improved API endpoint validation for forced function tool choices.

* **Tests**
  * Added comprehensive test coverage for tool choice serialization and validation scenarios, including legacy string format support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->