### PR TITLE
fix(openai-bridge): address PR #1429 review follow-ups (alias miss, error state, wire shape)

### DIFF
--- a/crates/mcp/src/core/orchestrator.rs
+++ b/crates/mcp/src/core/orchestrator.rs
@@ -158,7 +158,8 @@ pub struct ToolExecutionInput {
 /// Output from batch tool execution.
 ///
 /// `#[non_exhaustive]` so additive fields don't break consumers; only
-/// `smg-mcp` constructs this.
+/// `smg-mcp` constructs this in production. External crates that need to
+/// fabricate one for tests should use [`ToolExecutionOutput::new_for_test`].
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct ToolExecutionOutput {
@@ -182,6 +183,45 @@ pub struct ToolExecutionOutput {
     pub error_message: Option<String>,
     /// Execution duration.
     pub duration: Duration,
+}
+
+impl ToolExecutionOutput {
+    /// Construct an instance from explicit field values.
+    ///
+    /// `#[non_exhaustive]` blocks struct-literal syntax in downstream crates,
+    /// but those crates still need a way to fabricate fixtures (e.g. router
+    /// transformer tests that need a `is_error: true` output without spinning
+    /// up an MCP server). Adding a field to the struct doesn't break this
+    /// constructor — only adding a *required* field would, which is a
+    /// deliberate signal that all callers need to think about the new field.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "Test fixture constructor; one positional arg per public field is intentional \
+                  so adding a field forces every test to consider it."
+    )]
+    pub fn new_for_test(
+        call_id: impl Into<String>,
+        tool_name: impl Into<String>,
+        server_key: impl Into<String>,
+        server_label: impl Into<String>,
+        arguments_str: impl Into<String>,
+        output: Value,
+        is_error: bool,
+        error_message: Option<String>,
+        duration: Duration,
+    ) -> Self {
+        Self {
+            call_id: call_id.into(),
+            tool_name: tool_name.into(),
+            server_key: server_key.into(),
+            server_label: server_label.into(),
+            arguments_str: arguments_str.into(),
+            output,
+            is_error,
+            error_message,
+            duration,
+        }
+    }
 }
 
 /// Result from resolved tool execution that preserves interactive approval state.

--- a/crates/mcp/src/core/orchestrator.rs
+++ b/crates/mcp/src/core/orchestrator.rs
@@ -158,8 +158,8 @@ pub struct ToolExecutionInput {
 /// Output from batch tool execution.
 ///
 /// `#[non_exhaustive]` so additive fields don't break consumers; only
-/// `smg-mcp` constructs this in production. External crates that need to
-/// fabricate one for tests should use [`ToolExecutionOutput::new_for_test`].
+/// `smg-mcp` constructs this in production. External tests use
+/// [`ToolExecutionOutput::new_for_test`].
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct ToolExecutionOutput {
@@ -186,18 +186,12 @@ pub struct ToolExecutionOutput {
 }
 
 impl ToolExecutionOutput {
-    /// Construct an instance from explicit field values.
-    ///
-    /// `#[non_exhaustive]` blocks struct-literal syntax in downstream crates,
-    /// but those crates still need a way to fabricate fixtures (e.g. router
-    /// transformer tests that need a `is_error: true` output without spinning
-    /// up an MCP server). Adding a field to the struct doesn't break this
-    /// constructor — only adding a *required* field would, which is a
-    /// deliberate signal that all callers need to think about the new field.
+    /// Test-only constructor for downstream crates blocked by
+    /// `#[non_exhaustive]`. One positional arg per public field is
+    /// intentional so adding a field forces every test to consider it.
     #[expect(
         clippy::too_many_arguments,
-        reason = "Test fixture constructor; one positional arg per public field is intentional \
-                  so adding a field forces every test to consider it."
+        reason = "Test fixture constructor; one arg per field is intentional."
     )]
     pub fn new_for_test(
         call_id: impl Into<String>,

--- a/crates/mcp/src/inventory/types.rs
+++ b/crates/mcp/src/inventory/types.rs
@@ -161,7 +161,13 @@ impl ToolEntry {
 
     pub fn from_server_tool(server_key: impl AsRef<str>, tool: Tool) -> Self {
         let name = tool.name.to_string();
-        Self::new(QualifiedToolName::new(server_key, name), tool)
+        // Lift the rmcp annotations the server advertised into our richer
+        // wrapper so `entry.annotations.read_only` (and the other hints the
+        // approval pipeline reads) reflect what the tool actually declared.
+        // Without this, every server-loaded tool reports `read_only: false`
+        // because `Self::new` initialises annotations to default.
+        let annotations = ToolAnnotations::from_rmcp_option(tool.annotations.as_ref());
+        Self::new(QualifiedToolName::new(server_key, name), tool).with_annotations(annotations)
     }
 
     #[must_use]
@@ -270,6 +276,28 @@ mod tests {
         assert_eq!(entry.tool_name(), "my_tool");
         assert_eq!(entry.category, ToolCategory::Static);
         assert!(!entry.is_expired());
+    }
+
+    #[test]
+    fn from_server_tool_lifts_rmcp_annotations() {
+        // Without this lift the read_only hint is lost on every server-loaded
+        // tool, and `mcp_list_tools[].tools[].annotations.read_only` reports
+        // false even for tools the MCP server explicitly marked read-only.
+        use rmcp::model::ToolAnnotations as RmcpToolAnnotations;
+
+        let mut tool = create_test_tool("read_only_tool");
+        tool.annotations = Some(RmcpToolAnnotations {
+            title: None,
+            read_only_hint: Some(true),
+            destructive_hint: Some(false),
+            idempotent_hint: Some(true),
+            open_world_hint: Some(false),
+        });
+        let entry = ToolEntry::from_server_tool("server", tool);
+        assert!(entry.annotations.read_only);
+        assert!(!entry.annotations.destructive);
+        assert!(entry.annotations.idempotent);
+        assert!(!entry.annotations.open_world);
     }
 
     #[test]

--- a/crates/mcp/src/inventory/types.rs
+++ b/crates/mcp/src/inventory/types.rs
@@ -161,13 +161,7 @@ impl ToolEntry {
 
     pub fn from_server_tool(server_key: impl AsRef<str>, tool: Tool) -> Self {
         let name = tool.name.to_string();
-        // Lift the rmcp annotations the server advertised into our richer
-        // wrapper so `entry.annotations.read_only` (and the other hints the
-        // approval pipeline reads) reflect what the tool actually declared.
-        // Without this, every server-loaded tool reports `read_only: false`
-        // because `Self::new` initialises annotations to default.
-        let annotations = ToolAnnotations::from_rmcp_option(tool.annotations.as_ref());
-        Self::new(QualifiedToolName::new(server_key, name), tool).with_annotations(annotations)
+        Self::new(QualifiedToolName::new(server_key, name), tool)
     }
 
     #[must_use]
@@ -276,28 +270,6 @@ mod tests {
         assert_eq!(entry.tool_name(), "my_tool");
         assert_eq!(entry.category, ToolCategory::Static);
         assert!(!entry.is_expired());
-    }
-
-    #[test]
-    fn from_server_tool_lifts_rmcp_annotations() {
-        // Without this lift the read_only hint is lost on every server-loaded
-        // tool, and `mcp_list_tools[].tools[].annotations.read_only` reports
-        // false even for tools the MCP server explicitly marked read-only.
-        use rmcp::model::ToolAnnotations as RmcpToolAnnotations;
-
-        let mut tool = create_test_tool("read_only_tool");
-        tool.annotations = Some(RmcpToolAnnotations {
-            title: None,
-            read_only_hint: Some(true),
-            destructive_hint: Some(false),
-            idempotent_hint: Some(true),
-            open_world_hint: Some(false),
-        });
-        let entry = ToolEntry::from_server_tool("server", tool);
-        assert!(entry.annotations.read_only);
-        assert!(!entry.annotations.destructive);
-        assert!(entry.annotations.idempotent);
-        assert!(!entry.annotations.open_world);
     }
 
     #[test]

--- a/model_gateway/src/routers/common/mcp_utils.rs
+++ b/model_gateway/src/routers/common/mcp_utils.rs
@@ -248,9 +248,7 @@ pub fn extract_builtin_types(tools: &[ResponseTool]) -> Vec<BuiltinToolType> {
 }
 
 /// True if `tools` carries any MCP-routed entry (declared MCP server or a
-/// builtin family that the gateway intercepts via MCP). Used by the OpenAI
-/// router to decide whether the format-registry component is required for
-/// the request — plain-tool requests don't need it and must not 500.
+/// builtin family that the gateway intercepts via MCP).
 pub fn request_uses_mcp_routing(tools: &[ResponseTool]) -> bool {
     tools.iter().any(|t| {
         matches!(

--- a/model_gateway/src/routers/common/mcp_utils.rs
+++ b/model_gateway/src/routers/common/mcp_utils.rs
@@ -247,6 +247,22 @@ pub fn extract_builtin_types(tools: &[ResponseTool]) -> Vec<BuiltinToolType> {
         .collect()
 }
 
+/// True if `tools` carries any MCP-routed entry (declared MCP server or a
+/// builtin family that the gateway intercepts via MCP). Used by the OpenAI
+/// router to decide whether the format-registry component is required for
+/// the request — plain-tool requests don't need it and must not 500.
+pub fn request_uses_mcp_routing(tools: &[ResponseTool]) -> bool {
+    tools.iter().any(|t| {
+        matches!(
+            t,
+            ResponseTool::Mcp(_)
+                | ResponseTool::WebSearchPreview(_)
+                | ResponseTool::CodeInterpreter(_)
+                | ResponseTool::ImageGeneration(_)
+        )
+    })
+}
+
 /// Collect user-declared function tool names from a Responses request.
 pub(crate) fn collect_user_function_names(request: &ResponsesRequest) -> HashSet<String> {
     request

--- a/model_gateway/src/routers/common/mcp_utils.rs
+++ b/model_gateway/src/routers/common/mcp_utils.rs
@@ -249,16 +249,13 @@ pub fn extract_builtin_types(tools: &[ResponseTool]) -> Vec<BuiltinToolType> {
 
 /// True if `tools` carries any MCP-routed entry (declared MCP server or a
 /// builtin family that the gateway intercepts via MCP).
+///
+/// Derived from [`extract_builtin_types`] so the predicate and the actual
+/// routing path can't drift — adding a new builtin to the routing path
+/// (e.g. `file_search`) makes this predicate cover it too.
 pub fn request_uses_mcp_routing(tools: &[ResponseTool]) -> bool {
-    tools.iter().any(|t| {
-        matches!(
-            t,
-            ResponseTool::Mcp(_)
-                | ResponseTool::WebSearchPreview(_)
-                | ResponseTool::CodeInterpreter(_)
-                | ResponseTool::ImageGeneration(_)
-        )
-    })
+    tools.iter().any(|t| matches!(t, ResponseTool::Mcp(_)))
+        || !extract_builtin_types(tools).is_empty()
 }
 
 /// Collect user-declared function tool names from a Responses request.

--- a/model_gateway/src/routers/common/openai_bridge/format_registry.rs
+++ b/model_gateway/src/routers/common/openai_bridge/format_registry.rs
@@ -52,39 +52,65 @@ impl FormatRegistry {
         self.formats.insert(qualified, format);
     }
 
+    fn remove(&self, qualified: &QualifiedToolName) {
+        self.formats.remove(qualified);
+    }
+
     /// Populate from a server config: per-tool overrides + builtin defaults.
-    /// Safe to call repeatedly — entries for non-Passthrough formats are
-    /// overwritten. Downgrading a format back to `Passthrough` requires a
-    /// separate registry rebuild (no production caller mutates configs in
-    /// place today).
     ///
-    /// Mirrors `McpOrchestrator::apply_tool_configs`:
-    /// - When a tool has an `alias`, the format is attached **only** to the
-    ///   alias entry (under `("alias", alias_name)`), matching the orchestrator's
-    ///   `register_alias` qualified-name shape. The underlying `(server, tool)`
-    ///   stays at the `Passthrough` default so direct calls aren't transformed.
-    /// - When a tool has no alias but a non-default format, attach to
-    ///   `(server, tool)` directly.
-    /// - When the per-tool stanza omits `response_format` entirely
-    ///   (`None`), the builtin default still applies. This lets users add an
-    ///   `alias` or `arg_mapping` to a builtin tool without disabling its
-    ///   hosted-format wire shape. An explicit `Some(Passthrough)` *does*
-    ///   block the builtin default — that is the documented escape hatch
-    ///   for opting out of the hosted shape.
+    /// Safe to call repeatedly. Each affected key is unconditionally rewritten
+    /// (or removed for an explicit `Some(Passthrough)` downgrade) so a later
+    /// config that demotes a tool from a hosted format back to `Passthrough`
+    /// does not leave the previous entry behind in the map.
+    ///
+    /// Mirrors `McpOrchestrator::apply_tool_configs` *and* the dispatch shape
+    /// of `McpToolSession`. Two production lookup paths must resolve to the
+    /// same format:
+    /// - via the alias key `("alias", alias_name)` — what the session exposes
+    ///   when `collect_visible_mcp_tools` replaces the direct entry with its
+    ///   alias entry (see `crates/mcp/src/core/session.rs:565-571`).
+    /// - via the underlying `(server_key, tool_name)` — what direct dispatch
+    ///   uses when no alias hides the tool.
+    ///
+    /// So when a tool has an alias the format is mirrored on **both** keys.
+    /// Aliased builtin tools get the same treatment, and only when the
+    /// per-tool stanza omits `response_format` entirely (`None`) is the
+    /// builtin default applied; an explicit `Some(Passthrough)` is the
+    /// documented escape hatch for opting out of the hosted shape.
     pub fn populate_from_server_config(&self, config: &McpServerConfig) {
         if let Some(tools) = &config.tools {
             for (tool_name, tool_config) in tools {
+                let direct_key = QualifiedToolName::new(&config.name, tool_name);
+                let alias_key = tool_config
+                    .alias
+                    .as_deref()
+                    .map(|alias| QualifiedToolName::new(ALIAS_SERVER_KEY, alias));
+
                 let Some(format_config) = tool_config.response_format else {
+                    // `response_format` omitted: defer to the builtin-default
+                    // pass below. Don't touch existing entries here so a
+                    // direct-dispatch override placed by an earlier loop
+                    // iteration survives.
                     continue;
                 };
                 let format: ResponseFormat = format_config.into();
                 if format == ResponseFormat::Passthrough {
+                    // Explicit downgrade — clear any prior hosted-format entry
+                    // on every key the production lookup might consult.
+                    self.remove(&direct_key);
+                    if let Some(alias_key) = &alias_key {
+                        self.remove(alias_key);
+                    }
                     continue;
                 }
-                if let Some(alias) = &tool_config.alias {
-                    self.insert(QualifiedToolName::new(ALIAS_SERVER_KEY, alias), format);
-                } else {
-                    self.insert(QualifiedToolName::new(&config.name, tool_name), format);
+
+                // Mirror the format on every key production might query.
+                // Also write the direct key so that direct dispatch (which
+                // does not go through the alias rewrite) still gets the
+                // hosted shape.
+                self.insert(direct_key, format);
+                if let Some(alias_key) = alias_key {
+                    self.insert(alias_key, format);
                 }
             }
         }
@@ -92,14 +118,18 @@ impl FormatRegistry {
         if let (Some(builtin_type), Some(tool_name)) =
             (&config.builtin_type, &config.builtin_tool_name)
         {
-            let has_explicit_format = config
-                .tools
-                .as_ref()
-                .and_then(|tools| tools.get(tool_name))
-                .is_some_and(|cfg| cfg.response_format.is_some());
+            let stanza = config.tools.as_ref().and_then(|tools| tools.get(tool_name));
+            let has_explicit_format = stanza.is_some_and(|cfg| cfg.response_format.is_some());
             if !has_explicit_format {
                 let format: ResponseFormat = builtin_type.response_format().into();
                 self.insert(QualifiedToolName::new(&config.name, tool_name), format);
+                // `collect_visible_mcp_tools` exposes the alias entry instead
+                // of the direct entry, so the production lookup queries
+                // `("alias", alias)`. Without this mirror an alias-only stanza
+                // on a builtin tool silently degrades to `Passthrough`.
+                if let Some(alias) = stanza.and_then(|cfg| cfg.alias.as_deref()) {
+                    self.insert(QualifiedToolName::new(ALIAS_SERVER_KEY, alias), format);
+                }
             }
         }
     }
@@ -142,9 +172,11 @@ mod tests {
     }
 
     #[test]
-    fn alias_format_stored_under_alias_server_key() {
-        // Mirrors orchestrator::register_alias which uses
-        // QualifiedToolName::new("alias", alias_name).
+    fn alias_format_mirrored_on_both_keys() {
+        // The session lookup path goes through `("alias", alias_name)` because
+        // `collect_visible_mcp_tools` replaces the direct entry with its alias
+        // entry. Direct dispatch (no alias rewrite) still queries
+        // `(server_key, tool_name)`, so both keys must carry the format.
         let mut tools = HashMap::new();
         tools.insert(
             "brave_web_search".to_string(),
@@ -167,8 +199,9 @@ mod tests {
         );
         assert_eq!(
             r.lookup_by_names("brave", "brave_web_search"),
-            ResponseFormat::Passthrough,
-            "underlying tool entry must NOT receive the format when an alias exists"
+            ResponseFormat::WebSearchCall,
+            "direct (server_key, tool_name) entry must also carry the format \
+             so direct dispatch resolves the same shape as alias dispatch"
         );
     }
 
@@ -239,12 +272,15 @@ mod tests {
     }
 
     #[test]
-    fn alias_only_stanza_preserves_builtin_default() {
+    fn alias_only_stanza_preserves_builtin_default_on_both_keys() {
         // Regression: a per-tool stanza that only aliases a builtin tool
         // (or only sets arg_mapping) used to suppress the builtin default,
-        // collapsing the hosted format to plain mcp_call. With
-        // `response_format: None` meaning "inherit context", the builtin
-        // default must still apply.
+        // collapsing the hosted format to plain mcp_call. The crucial
+        // production path is the alias key — `collect_visible_mcp_tools`
+        // exposes the alias entry, so `lookup_tool_format(session, …,
+        // "web_search")` resolves to `("alias", "web_search")`. If the
+        // builtin default only landed at the direct key, dispatch silently
+        // degrades to `Passthrough`.
         let mut tools = HashMap::new();
         tools.insert(
             "do_search".to_string(),
@@ -262,10 +298,74 @@ mod tests {
         let r = FormatRegistry::new();
         r.populate_from_server_config(&cfg);
 
+        // Alias key — what production session lookup actually hits.
+        assert_eq!(
+            r.lookup_by_names("alias", "web_search"),
+            ResponseFormat::WebSearchCall,
+            "alias-only stanza on a builtin must mirror the hosted format on \
+             the alias key — that is the key production resolves through"
+        );
+        // Direct key — what direct dispatch hits.
         assert_eq!(
             r.lookup_by_names("search", "do_search"),
             ResponseFormat::WebSearchCall,
-            "alias-only stanza must not disable the builtin's hosted format"
+            "direct (server, tool) lookup must still resolve the hosted format"
+        );
+    }
+
+    #[test]
+    fn explicit_passthrough_downgrade_clears_prior_hosted_entry() {
+        // `populate_from_server_config` is called every time a server
+        // (re)registers, so a config that flips a tool from a hosted format
+        // back to `Passthrough` must clear the stale entry — otherwise the
+        // registry keeps transforming outputs as the old hosted type.
+        let r = FormatRegistry::new();
+
+        let mut hosted = HashMap::new();
+        hosted.insert(
+            "brave_web_search".to_string(),
+            ToolConfig {
+                alias: Some("web_search".to_string()),
+                response_format: Some(ResponseFormatConfig::WebSearchCall),
+                arg_mapping: None,
+            },
+        );
+        let mut hosted_cfg = server("brave");
+        hosted_cfg.tools = Some(hosted);
+        r.populate_from_server_config(&hosted_cfg);
+        assert_eq!(
+            r.lookup_by_names("alias", "web_search"),
+            ResponseFormat::WebSearchCall,
+            "precondition: alias key carries the hosted format"
+        );
+        assert_eq!(
+            r.lookup_by_names("brave", "brave_web_search"),
+            ResponseFormat::WebSearchCall,
+            "precondition: direct key carries the hosted format"
+        );
+
+        let mut downgraded = HashMap::new();
+        downgraded.insert(
+            "brave_web_search".to_string(),
+            ToolConfig {
+                alias: Some("web_search".to_string()),
+                response_format: Some(ResponseFormatConfig::Passthrough),
+                arg_mapping: None,
+            },
+        );
+        let mut downgraded_cfg = server("brave");
+        downgraded_cfg.tools = Some(downgraded);
+        r.populate_from_server_config(&downgraded_cfg);
+
+        assert_eq!(
+            r.lookup_by_names("alias", "web_search"),
+            ResponseFormat::Passthrough,
+            "explicit Passthrough must clear the previous alias entry"
+        );
+        assert_eq!(
+            r.lookup_by_names("brave", "brave_web_search"),
+            ResponseFormat::Passthrough,
+            "explicit Passthrough must clear the previous direct entry"
         );
     }
 }

--- a/model_gateway/src/routers/common/openai_bridge/format_registry.rs
+++ b/model_gateway/src/routers/common/openai_bridge/format_registry.rs
@@ -56,27 +56,13 @@ impl FormatRegistry {
         self.formats.remove(qualified);
     }
 
-    /// Populate from a server config: per-tool overrides + builtin defaults.
+    /// Populate from a server config. Safe to call repeatedly.
     ///
-    /// Safe to call repeatedly. Each affected key is unconditionally rewritten
-    /// (or removed for an explicit `Some(Passthrough)` downgrade) so a later
-    /// config that demotes a tool from a hosted format back to `Passthrough`
-    /// does not leave the previous entry behind in the map.
-    ///
-    /// Mirrors `McpOrchestrator::apply_tool_configs` *and* the dispatch shape
-    /// of `McpToolSession`. Two production lookup paths must resolve to the
-    /// same format:
-    /// - via the alias key `("alias", alias_name)` — what the session exposes
-    ///   when `collect_visible_mcp_tools` replaces the direct entry with its
-    ///   alias entry (see `crates/mcp/src/core/session.rs:565-571`).
-    /// - via the underlying `(server_key, tool_name)` — what direct dispatch
-    ///   uses when no alias hides the tool.
-    ///
-    /// So when a tool has an alias the format is mirrored on **both** keys.
-    /// Aliased builtin tools get the same treatment, and only when the
-    /// per-tool stanza omits `response_format` entirely (`None`) is the
-    /// builtin default applied; an explicit `Some(Passthrough)` is the
-    /// documented escape hatch for opting out of the hosted shape.
+    /// `McpToolSession::collect_visible_mcp_tools` replaces a direct tool
+    /// entry with its alias entry, so production session lookup of an
+    /// aliased tool resolves through `("alias", alias_name)`. Direct
+    /// dispatch still uses `(server_key, tool_name)`. Both keys must carry
+    /// the same format, so non-Passthrough formats are mirrored on both.
     pub fn populate_from_server_config(&self, config: &McpServerConfig) {
         if let Some(tools) = &config.tools {
             for (tool_name, tool_config) in tools {
@@ -87,16 +73,10 @@ impl FormatRegistry {
                     .map(|alias| QualifiedToolName::new(ALIAS_SERVER_KEY, alias));
 
                 let Some(format_config) = tool_config.response_format else {
-                    // `response_format` omitted: defer to the builtin-default
-                    // pass below. Don't touch existing entries here so a
-                    // direct-dispatch override placed by an earlier loop
-                    // iteration survives.
                     continue;
                 };
                 let format: ResponseFormat = format_config.into();
                 if format == ResponseFormat::Passthrough {
-                    // Explicit downgrade — clear any prior hosted-format entry
-                    // on every key the production lookup might consult.
                     self.remove(&direct_key);
                     if let Some(alias_key) = &alias_key {
                         self.remove(alias_key);
@@ -104,10 +84,6 @@ impl FormatRegistry {
                     continue;
                 }
 
-                // Mirror the format on every key production might query.
-                // Also write the direct key so that direct dispatch (which
-                // does not go through the alias rewrite) still gets the
-                // hosted shape.
                 self.insert(direct_key, format);
                 if let Some(alias_key) = alias_key {
                     self.insert(alias_key, format);
@@ -123,10 +99,6 @@ impl FormatRegistry {
             if !has_explicit_format {
                 let format: ResponseFormat = builtin_type.response_format().into();
                 self.insert(QualifiedToolName::new(&config.name, tool_name), format);
-                // `collect_visible_mcp_tools` exposes the alias entry instead
-                // of the direct entry, so the production lookup queries
-                // `("alias", alias)`. Without this mirror an alias-only stanza
-                // on a builtin tool silently degrades to `Passthrough`.
                 if let Some(alias) = stanza.and_then(|cfg| cfg.alias.as_deref()) {
                     self.insert(QualifiedToolName::new(ALIAS_SERVER_KEY, alias), format);
                 }
@@ -173,10 +145,6 @@ mod tests {
 
     #[test]
     fn alias_format_mirrored_on_both_keys() {
-        // The session lookup path goes through `("alias", alias_name)` because
-        // `collect_visible_mcp_tools` replaces the direct entry with its alias
-        // entry. Direct dispatch (no alias rewrite) still queries
-        // `(server_key, tool_name)`, so both keys must carry the format.
         let mut tools = HashMap::new();
         tools.insert(
             "brave_web_search".to_string(),
@@ -195,13 +163,10 @@ mod tests {
         assert_eq!(
             r.lookup_by_names("alias", "web_search"),
             ResponseFormat::WebSearchCall,
-            "alias entry must use the literal `alias` server_key prefix"
         );
         assert_eq!(
             r.lookup_by_names("brave", "brave_web_search"),
             ResponseFormat::WebSearchCall,
-            "direct (server_key, tool_name) entry must also carry the format \
-             so direct dispatch resolves the same shape as alias dispatch"
         );
     }
 
@@ -250,7 +215,6 @@ mod tests {
             "do_search".to_string(),
             ToolConfig {
                 alias: None,
-                // Explicit override differs from the builtin default.
                 response_format: Some(ResponseFormatConfig::Passthrough),
                 arg_mapping: None,
             },
@@ -263,8 +227,6 @@ mod tests {
         let r = FormatRegistry::new();
         r.populate_from_server_config(&cfg);
 
-        // Explicit Some(Passthrough) override means "no entry inserted" AND
-        // the builtin default is NOT applied on top.
         assert_eq!(
             r.lookup_by_names("search", "do_search"),
             ResponseFormat::Passthrough
@@ -273,14 +235,6 @@ mod tests {
 
     #[test]
     fn alias_only_stanza_preserves_builtin_default_on_both_keys() {
-        // Regression: a per-tool stanza that only aliases a builtin tool
-        // (or only sets arg_mapping) used to suppress the builtin default,
-        // collapsing the hosted format to plain mcp_call. The crucial
-        // production path is the alias key — `collect_visible_mcp_tools`
-        // exposes the alias entry, so `lookup_tool_format(session, …,
-        // "web_search")` resolves to `("alias", "web_search")`. If the
-        // builtin default only landed at the direct key, dispatch silently
-        // degrades to `Passthrough`.
         let mut tools = HashMap::new();
         tools.insert(
             "do_search".to_string(),
@@ -298,27 +252,20 @@ mod tests {
         let r = FormatRegistry::new();
         r.populate_from_server_config(&cfg);
 
-        // Alias key — what production session lookup actually hits.
+        // Alias key — what production session lookup hits.
         assert_eq!(
             r.lookup_by_names("alias", "web_search"),
             ResponseFormat::WebSearchCall,
-            "alias-only stanza on a builtin must mirror the hosted format on \
-             the alias key — that is the key production resolves through"
         );
         // Direct key — what direct dispatch hits.
         assert_eq!(
             r.lookup_by_names("search", "do_search"),
             ResponseFormat::WebSearchCall,
-            "direct (server, tool) lookup must still resolve the hosted format"
         );
     }
 
     #[test]
     fn explicit_passthrough_downgrade_clears_prior_hosted_entry() {
-        // `populate_from_server_config` is called every time a server
-        // (re)registers, so a config that flips a tool from a hosted format
-        // back to `Passthrough` must clear the stale entry — otherwise the
-        // registry keeps transforming outputs as the old hosted type.
         let r = FormatRegistry::new();
 
         let mut hosted = HashMap::new();
@@ -336,12 +283,10 @@ mod tests {
         assert_eq!(
             r.lookup_by_names("alias", "web_search"),
             ResponseFormat::WebSearchCall,
-            "precondition: alias key carries the hosted format"
         );
         assert_eq!(
             r.lookup_by_names("brave", "brave_web_search"),
             ResponseFormat::WebSearchCall,
-            "precondition: direct key carries the hosted format"
         );
 
         let mut downgraded = HashMap::new();
@@ -360,12 +305,10 @@ mod tests {
         assert_eq!(
             r.lookup_by_names("alias", "web_search"),
             ResponseFormat::Passthrough,
-            "explicit Passthrough must clear the previous alias entry"
         );
         assert_eq!(
             r.lookup_by_names("brave", "brave_web_search"),
             ResponseFormat::Passthrough,
-            "explicit Passthrough must clear the previous direct entry"
         );
     }
 }

--- a/model_gateway/src/routers/common/openai_bridge/tool_descriptors.rs
+++ b/model_gateway/src/routers/common/openai_bridge/tool_descriptors.rs
@@ -86,13 +86,10 @@ pub fn response_tools(session: &McpToolSession<'_>) -> Vec<ResponseTool> {
 
 /// `McpToolInfo` records used inside `mcp_list_tools` output items.
 ///
-/// Wire-shape note: OpenAI's Responses API exposes only `{"read_only": …}`
-/// inside `mcp_list_tools[].tools[].annotations`. The richer SMG
-/// `ToolAnnotations` (which also carries `destructive`/`idempotent`/
-/// `open_world`) is intentionally narrowed here to match that shape — those
-/// extra hints are read directly off `ToolEntry::annotations` by the approval
-/// pipeline and would only confuse downstream OpenAI-compatible clients if
-/// emitted on the wire.
+/// `annotations` is narrowed to `{"read_only": …}` to match OpenAI's
+/// Responses API shape. The richer `ToolAnnotations` (with
+/// `destructive`/`idempotent`/`open_world`) is read internally off
+/// `ToolEntry::annotations` by the approval pipeline.
 pub fn build_mcp_tool_infos(entries: &[smg_mcp::ToolEntry]) -> Vec<McpToolInfo> {
     entries
         .iter()
@@ -342,11 +339,6 @@ mod tests {
 
     #[test]
     fn build_mcp_tool_infos_emits_only_read_only_annotation() {
-        // Wire-spec parity: OpenAI's `mcp_list_tools[].tools[].annotations`
-        // exposes `{"read_only": …}` only. The richer SMG `ToolAnnotations`
-        // carries `destructive`/`idempotent`/`open_world` that the approval
-        // pipeline reads internally; surfacing them on the wire would change
-        // the documented shape.
         let annotations = ToolAnnotations::default()
             .with_read_only(true)
             .with_destructive(true);

--- a/model_gateway/src/routers/common/openai_bridge/tool_descriptors.rs
+++ b/model_gateway/src/routers/common/openai_bridge/tool_descriptors.rs
@@ -87,19 +87,28 @@ pub fn response_tools(session: &McpToolSession<'_>) -> Vec<ResponseTool> {
 /// `McpToolInfo` records used inside `mcp_list_tools` output items.
 ///
 /// `annotations` is narrowed to `{"read_only": …}` to match OpenAI's
-/// Responses API shape. The richer `ToolAnnotations` (with
-/// `destructive`/`idempotent`/`open_world`) is read internally off
-/// `ToolEntry::annotations` by the approval pipeline.
+/// Responses API shape. The hint is read straight off the rmcp tool
+/// (`tool.annotations.read_only_hint`) rather than the SMG
+/// `ToolAnnotations` wrapper — the wrapper applies conservative policy
+/// defaults (destructive=true on absent hint) that are intended for the
+/// approval pipeline, not the wire surface, and reading them here would
+/// surface the wrong `read_only` for tools the server didn't annotate.
 pub fn build_mcp_tool_infos(entries: &[smg_mcp::ToolEntry]) -> Vec<McpToolInfo> {
     entries
         .iter()
-        .map(|entry| McpToolInfo {
-            name: entry.tool_name().to_string(),
-            description: entry.tool.description.as_ref().map(|d| d.to_string()),
-            input_schema: schema_to_value(&entry.tool.input_schema),
-            annotations: Some(json!({
-                "read_only": entry.annotations.read_only,
-            })),
+        .map(|entry| {
+            let read_only = entry
+                .tool
+                .annotations
+                .as_ref()
+                .and_then(|a| a.read_only_hint)
+                .unwrap_or(false);
+            McpToolInfo {
+                name: entry.tool_name().to_string(),
+                description: entry.tool.description.as_ref().map(|d| d.to_string()),
+                input_schema: schema_to_value(&entry.tool.input_schema),
+                annotations: Some(json!({ "read_only": read_only })),
+            }
         })
         .collect()
 }
@@ -319,38 +328,55 @@ fn is_client_visible_output_item(
 mod tests {
     use std::{borrow::Cow, sync::Arc};
 
-    use rmcp::model::Tool;
-    use smg_mcp::{ToolAnnotations, ToolEntry};
+    use rmcp::model::{Tool, ToolAnnotations as RmcpToolAnnotations};
+    use smg_mcp::ToolEntry;
 
     use super::*;
 
-    fn entry_with_annotations(annotations: ToolAnnotations) -> ToolEntry {
+    fn entry_with_rmcp_annotations(annotations: Option<RmcpToolAnnotations>) -> ToolEntry {
         let tool = Tool {
             name: Cow::Owned("widget".to_string()),
             title: None,
             description: Some(Cow::Owned("widget description".to_string())),
             input_schema: Arc::new(serde_json::Map::new()),
             output_schema: None,
-            annotations: None,
+            annotations,
             icons: None,
         };
-        ToolEntry::from_server_tool("srv", tool).with_annotations(annotations)
+        ToolEntry::from_server_tool("srv", tool)
+    }
+
+    fn read_only_hint(value: bool) -> RmcpToolAnnotations {
+        RmcpToolAnnotations {
+            title: None,
+            read_only_hint: Some(value),
+            destructive_hint: None,
+            idempotent_hint: None,
+            open_world_hint: None,
+        }
     }
 
     #[test]
-    fn build_mcp_tool_infos_emits_only_read_only_annotation() {
-        let annotations = ToolAnnotations::default()
-            .with_read_only(true)
-            .with_destructive(true);
-        let entries = vec![entry_with_annotations(annotations)];
-
+    fn build_mcp_tool_infos_surfaces_rmcp_read_only_hint() {
+        let entries = vec![entry_with_rmcp_annotations(Some(read_only_hint(true)))];
         let infos = build_mcp_tool_infos(&entries);
-        assert_eq!(infos.len(), 1);
         let serialized = serde_json::to_value(&infos[0])
             .expect("McpToolInfo must serialize")
             .get("annotations")
             .cloned()
             .expect("annotations must serialize");
         assert_eq!(serialized, json!({ "read_only": true }));
+    }
+
+    #[test]
+    fn build_mcp_tool_infos_defaults_to_false_when_hint_absent() {
+        let entries = vec![entry_with_rmcp_annotations(None)];
+        let infos = build_mcp_tool_infos(&entries);
+        let serialized = serde_json::to_value(&infos[0])
+            .expect("McpToolInfo must serialize")
+            .get("annotations")
+            .cloned()
+            .expect("annotations must serialize");
+        assert_eq!(serialized, json!({ "read_only": false }));
     }
 }

--- a/model_gateway/src/routers/common/openai_bridge/tool_descriptors.rs
+++ b/model_gateway/src/routers/common/openai_bridge/tool_descriptors.rs
@@ -85,6 +85,14 @@ pub fn response_tools(session: &McpToolSession<'_>) -> Vec<ResponseTool> {
 }
 
 /// `McpToolInfo` records used inside `mcp_list_tools` output items.
+///
+/// Wire-shape note: OpenAI's Responses API exposes only `{"read_only": …}`
+/// inside `mcp_list_tools[].tools[].annotations`. The richer SMG
+/// `ToolAnnotations` (which also carries `destructive`/`idempotent`/
+/// `open_world`) is intentionally narrowed here to match that shape — those
+/// extra hints are read directly off `ToolEntry::annotations` by the approval
+/// pipeline and would only confuse downstream OpenAI-compatible clients if
+/// emitted on the wire.
 pub fn build_mcp_tool_infos(entries: &[smg_mcp::ToolEntry]) -> Vec<McpToolInfo> {
     entries
         .iter()
@@ -92,11 +100,9 @@ pub fn build_mcp_tool_infos(entries: &[smg_mcp::ToolEntry]) -> Vec<McpToolInfo> 
             name: entry.tool_name().to_string(),
             description: entry.tool.description.as_ref().map(|d| d.to_string()),
             input_schema: schema_to_value(&entry.tool.input_schema),
-            annotations: entry
-                .tool
-                .annotations
-                .as_ref()
-                .and_then(|a| serde_json::to_value(a).ok()),
+            annotations: Some(json!({
+                "read_only": entry.annotations.read_only,
+            })),
         })
         .collect()
 }
@@ -309,5 +315,50 @@ fn is_client_visible_output_item(
         | ResponseOutputItem::Compaction { .. }
         | ResponseOutputItem::LocalShellCall { .. }
         | ResponseOutputItem::LocalShellCallOutput { .. } => true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{borrow::Cow, sync::Arc};
+
+    use rmcp::model::Tool;
+    use smg_mcp::{ToolAnnotations, ToolEntry};
+
+    use super::*;
+
+    fn entry_with_annotations(annotations: ToolAnnotations) -> ToolEntry {
+        let tool = Tool {
+            name: Cow::Owned("widget".to_string()),
+            title: None,
+            description: Some(Cow::Owned("widget description".to_string())),
+            input_schema: Arc::new(serde_json::Map::new()),
+            output_schema: None,
+            annotations: None,
+            icons: None,
+        };
+        ToolEntry::from_server_tool("srv", tool).with_annotations(annotations)
+    }
+
+    #[test]
+    fn build_mcp_tool_infos_emits_only_read_only_annotation() {
+        // Wire-spec parity: OpenAI's `mcp_list_tools[].tools[].annotations`
+        // exposes `{"read_only": …}` only. The richer SMG `ToolAnnotations`
+        // carries `destructive`/`idempotent`/`open_world` that the approval
+        // pipeline reads internally; surfacing them on the wire would change
+        // the documented shape.
+        let annotations = ToolAnnotations::default()
+            .with_read_only(true)
+            .with_destructive(true);
+        let entries = vec![entry_with_annotations(annotations)];
+
+        let infos = build_mcp_tool_infos(&entries);
+        assert_eq!(infos.len(), 1);
+        let serialized = serde_json::to_value(&infos[0])
+            .expect("McpToolInfo must serialize")
+            .get("annotations")
+            .cloned()
+            .expect("annotations must serialize");
+        assert_eq!(serialized, json!({ "read_only": true }));
     }
 }

--- a/model_gateway/src/routers/common/openai_bridge/transformer.rs
+++ b/model_gateway/src/routers/common/openai_bridge/transformer.rs
@@ -18,15 +18,19 @@ use super::ResponseFormat;
 /// registry lookup against `(output.server_key, output.tool_name)` would
 /// miss for disambiguated names like `mcp_<server>_<tool>`.
 ///
-/// On `is_error`, the four hosted-builtin variants emit `status: "failed"`
-/// only (those wire shapes have no `error` field); `mcp_call` carries the
-/// `error_message` in its `error` field.
+/// On `is_error`: only `mcp_call` surfaces the failure (`status: "failed"`,
+/// `error: Some(msg)`). The four hosted-builtin variants always emit
+/// `status: "completed"` — that matches OpenAI cloud's de-facto behavior
+/// (the cloud's native `web_search_call`/`code_interpreter_call`/etc.
+/// don't emit `Failed` for soft failures like empty results or rate
+/// limits, and many MCP servers set `isError: true` for those very cases).
+/// The error context lives in the item's content, not in `status`.
 pub fn transform_tool_output(
     output: &smg_mcp::ToolExecutionOutput,
     response_format: ResponseFormat,
 ) -> ResponseOutputItem {
-    if output.is_error {
-        return failed_output_item(output, response_format);
+    if output.is_error && response_format == ResponseFormat::Passthrough {
+        return failed_mcp_call(output);
     }
     ResponseTransformer::transform(
         &output.output,
@@ -38,10 +42,7 @@ pub fn transform_tool_output(
     )
 }
 
-fn failed_output_item(
-    output: &smg_mcp::ToolExecutionOutput,
-    response_format: ResponseFormat,
-) -> ResponseOutputItem {
+fn failed_mcp_call(output: &smg_mcp::ToolExecutionOutput) -> ResponseOutputItem {
     // The MCP `CallToolResult { is_error: true, .. }` path can leave
     // `error_message` unset while carrying the real failure text inside
     // `output.output` (typed text blocks). Fall back to that before the
@@ -55,51 +56,15 @@ fn failed_output_item(
             (!text.is_empty()).then_some(text)
         })
         .unwrap_or_else(|| "Tool execution failed".to_string());
-    match response_format {
-        ResponseFormat::Passthrough => ResponseOutputItem::McpCall {
-            id: mcp_response_item_id(&output.call_id),
-            status: "failed".to_string(),
-            approval_request_id: None,
-            arguments: output.arguments_str.clone(),
-            error: Some(err_msg),
-            name: output.tool_name.clone(),
-            output: String::new(),
-            server_label: output.server_label.clone(),
-        },
-        ResponseFormat::WebSearchCall => ResponseOutputItem::WebSearchCall {
-            id: format!("ws_{}", output.call_id),
-            status: WebSearchCallStatus::Failed,
-            action: WebSearchAction::Search {
-                query: None,
-                queries: Vec::new(),
-                sources: Vec::new(),
-            },
-            results: None,
-        },
-        ResponseFormat::CodeInterpreterCall => ResponseOutputItem::CodeInterpreterCall {
-            id: format!("ci_{}", output.call_id),
-            status: CodeInterpreterCallStatus::Failed,
-            container_id: String::new(),
-            code: None,
-            outputs: None,
-        },
-        ResponseFormat::FileSearchCall => ResponseOutputItem::FileSearchCall {
-            id: format!("fs_{}", output.call_id),
-            status: FileSearchCallStatus::Failed,
-            queries: Vec::new(),
-            results: None,
-        },
-        ResponseFormat::ImageGenerationCall => ResponseOutputItem::ImageGenerationCall {
-            id: format!("ig_{}", output.call_id),
-            action: None,
-            background: None,
-            output_format: None,
-            quality: None,
-            result: String::new(),
-            revised_prompt: None,
-            size: None,
-            status: ImageGenerationCallStatus::Failed,
-        },
+    ResponseOutputItem::McpCall {
+        id: mcp_response_item_id(&output.call_id),
+        status: "failed".to_string(),
+        approval_request_id: None,
+        arguments: output.arguments_str.clone(),
+        error: Some(err_msg),
+        name: output.tool_name.clone(),
+        output: String::new(),
+        server_label: output.server_label.clone(),
     }
 }
 
@@ -1677,7 +1642,13 @@ mod tests {
     }
 
     #[test]
-    fn transform_tool_output_emits_hosted_failed_status_only() {
+    fn transform_tool_output_emits_hosted_completed_even_on_is_error() {
+        // Hosted-builtin variants always emit status=completed regardless of
+        // upstream is_error. Real OpenAI cloud doesn't emit Failed for soft
+        // failures (rate-limited search, no results, etc.) and many MCP
+        // servers set isError=true for those exact cases — propagating it
+        // would break clients that expect cloud-parity wire shape. The
+        // failure context lives in the item content, not in `status`.
         for fmt in [
             ResponseFormat::WebSearchCall,
             ResponseFormat::CodeInterpreterCall,
@@ -1686,8 +1657,11 @@ mod tests {
         ] {
             let item = transform_tool_output(&failed_tool_output("search"), fmt);
             let serialized = serde_json::to_value(&item).expect("serialize failed item");
-            assert_eq!(serialized["status"], serde_json::json!("failed"), "{fmt:?}");
-            assert!(serialized.get("error").is_none(), "{fmt:?} {serialized}");
+            assert_eq!(
+                serialized["status"],
+                serde_json::json!("completed"),
+                "{fmt:?}"
+            );
         }
     }
 

--- a/model_gateway/src/routers/common/openai_bridge/transformer.rs
+++ b/model_gateway/src/routers/common/openai_bridge/transformer.rs
@@ -9,23 +9,18 @@ use tracing::warn;
 
 use super::ResponseFormat;
 
-/// Transform a `ToolExecutionOutput` to a `ResponseOutputItem` using a
+/// Transform a `ToolExecutionOutput` into a `ResponseOutputItem` using a
 /// pre-resolved `ResponseFormat`.
 ///
-/// The format MUST be resolved via the session's exposed-name map (e.g.
-/// [`super::lookup_tool_format`]). `output.tool_name` is the *invoked/exposed*
-/// name after `McpToolSession::execute_tool_result` rewrites it, so a registry
-/// lookup against `(output.server_key, output.tool_name)` would miss for
-/// disambiguated names like `mcp_<server>_<tool>` and silently degrade to
-/// `Passthrough`.
+/// `response_format` must be resolved via the session's exposed-name map
+/// (e.g. [`super::lookup_tool_format`]) — `output.tool_name` carries the
+/// *invoked/exposed* name after session-side rewriting, so a fresh
+/// registry lookup against `(output.server_key, output.tool_name)` would
+/// miss for disambiguated names like `mcp_<server>_<tool>`.
 ///
-/// Failure handling: when `output.is_error` is set, the success-path builders
-/// (which always stamp `status = "completed"` and `error = None`) would
-/// persist a failed call as a success and replay it as such on the next turn.
-/// We bypass them and emit a typed failure item — `status = "failed"` on every
-/// hosted-builtin variant; only the `mcp_call` variant carries an additional
-/// `error` field, matching the OpenAI Responses spec where the four
-/// hosted-builtin families convey failure via `status` alone.
+/// On `is_error`, the four hosted-builtin variants emit `status: "failed"`
+/// only (those wire shapes have no `error` field); `mcp_call` carries the
+/// `error_message` in its `error` field.
 pub fn transform_tool_output(
     output: &smg_mcp::ToolExecutionOutput,
     response_format: ResponseFormat,
@@ -43,9 +38,6 @@ pub fn transform_tool_output(
     )
 }
 
-/// Build a typed failure-state output item for a `ToolExecutionOutput` whose
-/// `is_error` is set. Centralizes the per-format failure shape so callers
-/// don't need to reach into the typed `ResponseOutputItem` enum.
 fn failed_output_item(
     output: &smg_mcp::ToolExecutionOutput,
     response_format: ResponseFormat,
@@ -68,8 +60,6 @@ fn failed_output_item(
         ResponseFormat::WebSearchCall => ResponseOutputItem::WebSearchCall {
             id: format!("ws_{}", output.call_id),
             status: WebSearchCallStatus::Failed,
-            // No query is recoverable from a failed dispatch; emit the
-            // empty `Search` action variant so the wire shape stays valid.
             action: WebSearchAction::Search {
                 query: None,
                 queries: Vec::new(),
@@ -1660,10 +1650,6 @@ mod tests {
 
     #[test]
     fn transform_tool_output_emits_hosted_failed_status_only() {
-        // Hosted-builtin variants must convey failure via `status: "failed"`
-        // alone; they have no `error` field on the wire. Using
-        // `transform_tool_output` against the success-path builders would
-        // stamp `status: "completed"` on a failed call — that is the bug.
         for fmt in [
             ResponseFormat::WebSearchCall,
             ResponseFormat::CodeInterpreterCall,
@@ -1672,15 +1658,8 @@ mod tests {
         ] {
             let item = transform_tool_output(&failed_tool_output("search"), fmt);
             let serialized = serde_json::to_value(&item).expect("serialize failed item");
-            assert_eq!(
-                serialized["status"],
-                serde_json::json!("failed"),
-                "{fmt:?} must serialize status=failed on error"
-            );
-            assert!(
-                serialized.get("error").is_none(),
-                "{fmt:?} must not carry an `error` field (hosted variants don't have one): {serialized}"
-            );
+            assert_eq!(serialized["status"], serde_json::json!("failed"), "{fmt:?}");
+            assert!(serialized.get("error").is_none(), "{fmt:?} {serialized}");
         }
     }
 

--- a/model_gateway/src/routers/common/openai_bridge/transformer.rs
+++ b/model_gateway/src/routers/common/openai_bridge/transformer.rs
@@ -18,10 +18,21 @@ use super::ResponseFormat;
 /// lookup against `(output.server_key, output.tool_name)` would miss for
 /// disambiguated names like `mcp_<server>_<tool>` and silently degrade to
 /// `Passthrough`.
+///
+/// Failure handling: when `output.is_error` is set, the success-path builders
+/// (which always stamp `status = "completed"` and `error = None`) would
+/// persist a failed call as a success and replay it as such on the next turn.
+/// We bypass them and emit a typed failure item — `status = "failed"` on every
+/// hosted-builtin variant; only the `mcp_call` variant carries an additional
+/// `error` field, matching the OpenAI Responses spec where the four
+/// hosted-builtin families convey failure via `status` alone.
 pub fn transform_tool_output(
     output: &smg_mcp::ToolExecutionOutput,
     response_format: ResponseFormat,
 ) -> ResponseOutputItem {
+    if output.is_error {
+        return failed_output_item(output, response_format);
+    }
     ResponseTransformer::transform(
         &output.output,
         response_format,
@@ -30,6 +41,67 @@ pub fn transform_tool_output(
         &output.tool_name,
         &output.arguments_str,
     )
+}
+
+/// Build a typed failure-state output item for a `ToolExecutionOutput` whose
+/// `is_error` is set. Centralizes the per-format failure shape so callers
+/// don't need to reach into the typed `ResponseOutputItem` enum.
+fn failed_output_item(
+    output: &smg_mcp::ToolExecutionOutput,
+    response_format: ResponseFormat,
+) -> ResponseOutputItem {
+    let err_msg = output
+        .error_message
+        .clone()
+        .unwrap_or_else(|| "Tool execution failed".to_string());
+    match response_format {
+        ResponseFormat::Passthrough => ResponseOutputItem::McpCall {
+            id: mcp_response_item_id(&output.call_id),
+            status: "failed".to_string(),
+            approval_request_id: None,
+            arguments: output.arguments_str.clone(),
+            error: Some(err_msg),
+            name: output.tool_name.clone(),
+            output: String::new(),
+            server_label: output.server_label.clone(),
+        },
+        ResponseFormat::WebSearchCall => ResponseOutputItem::WebSearchCall {
+            id: format!("ws_{}", output.call_id),
+            status: WebSearchCallStatus::Failed,
+            // No query is recoverable from a failed dispatch; emit the
+            // empty `Search` action variant so the wire shape stays valid.
+            action: WebSearchAction::Search {
+                query: None,
+                queries: Vec::new(),
+                sources: Vec::new(),
+            },
+            results: None,
+        },
+        ResponseFormat::CodeInterpreterCall => ResponseOutputItem::CodeInterpreterCall {
+            id: format!("ci_{}", output.call_id),
+            status: CodeInterpreterCallStatus::Failed,
+            container_id: String::new(),
+            code: None,
+            outputs: None,
+        },
+        ResponseFormat::FileSearchCall => ResponseOutputItem::FileSearchCall {
+            id: format!("fs_{}", output.call_id),
+            status: FileSearchCallStatus::Failed,
+            queries: Vec::new(),
+            results: None,
+        },
+        ResponseFormat::ImageGenerationCall => ResponseOutputItem::ImageGenerationCall {
+            id: format!("ig_{}", output.call_id),
+            action: None,
+            background: None,
+            output_format: None,
+            quality: None,
+            result: String::new(),
+            revised_prompt: None,
+            size: None,
+            status: ImageGenerationCallStatus::Failed,
+        },
+    }
 }
 
 /// Normalize an MCP response item id source into an external `mcp_call.id`.
@@ -1544,6 +1616,71 @@ mod tests {
         match item {
             ResponseOutputItem::WebSearchCall { id, .. } => assert_eq!(id, "ws_xyz"),
             _ => panic!("Expected WebSearchCall"),
+        }
+    }
+
+    fn failed_tool_output(tool_name: &str) -> smg_mcp::ToolExecutionOutput {
+        smg_mcp::ToolExecutionOutput::new_for_test(
+            "call_xyz",
+            tool_name,
+            "srv",
+            "srv-label",
+            "{\"q\":\"v\"}",
+            serde_json::json!({}),
+            /* is_error */ true,
+            Some("upstream broke".to_string()),
+            std::time::Duration::default(),
+        )
+    }
+
+    #[test]
+    fn transform_tool_output_emits_mcp_call_failed_with_error_message() {
+        let item = transform_tool_output(
+            &failed_tool_output("brave_web_search"),
+            ResponseFormat::Passthrough,
+        );
+        match item {
+            ResponseOutputItem::McpCall {
+                status,
+                error,
+                output,
+                arguments,
+                name,
+                ..
+            } => {
+                assert_eq!(status, "failed");
+                assert_eq!(error.as_deref(), Some("upstream broke"));
+                assert_eq!(output, "");
+                assert_eq!(arguments, "{\"q\":\"v\"}");
+                assert_eq!(name, "brave_web_search");
+            }
+            _ => panic!("Expected McpCall"),
+        }
+    }
+
+    #[test]
+    fn transform_tool_output_emits_hosted_failed_status_only() {
+        // Hosted-builtin variants must convey failure via `status: "failed"`
+        // alone; they have no `error` field on the wire. Using
+        // `transform_tool_output` against the success-path builders would
+        // stamp `status: "completed"` on a failed call — that is the bug.
+        for fmt in [
+            ResponseFormat::WebSearchCall,
+            ResponseFormat::CodeInterpreterCall,
+            ResponseFormat::FileSearchCall,
+            ResponseFormat::ImageGenerationCall,
+        ] {
+            let item = transform_tool_output(&failed_tool_output("search"), fmt);
+            let serialized = serde_json::to_value(&item).expect("serialize failed item");
+            assert_eq!(
+                serialized["status"],
+                serde_json::json!("failed"),
+                "{fmt:?} must serialize status=failed on error"
+            );
+            assert!(
+                serialized.get("error").is_none(),
+                "{fmt:?} must not carry an `error` field (hosted variants don't have one): {serialized}"
+            );
         }
     }
 

--- a/model_gateway/src/routers/common/openai_bridge/transformer.rs
+++ b/model_gateway/src/routers/common/openai_bridge/transformer.rs
@@ -42,9 +42,18 @@ fn failed_output_item(
     output: &smg_mcp::ToolExecutionOutput,
     response_format: ResponseFormat,
 ) -> ResponseOutputItem {
+    // The MCP `CallToolResult { is_error: true, .. }` path can leave
+    // `error_message` unset while carrying the real failure text inside
+    // `output.output` (typed text blocks). Fall back to that before the
+    // generic placeholder so client-visible mcp_call.error stays useful.
     let err_msg = output
         .error_message
         .clone()
+        .filter(|msg| !msg.is_empty())
+        .or_else(|| {
+            let text = ResponseTransformer::flatten_mcp_output(&output.output);
+            (!text.is_empty()).then_some(text)
+        })
         .unwrap_or_else(|| "Tool execution failed".to_string());
     match response_format {
         ResponseFormat::Passthrough => ResponseOutputItem::McpCall {
@@ -1643,6 +1652,25 @@ mod tests {
                 assert_eq!(output, "");
                 assert_eq!(arguments, "{\"q\":\"v\"}");
                 assert_eq!(name, "brave_web_search");
+            }
+            _ => panic!("Expected McpCall"),
+        }
+    }
+
+    #[test]
+    fn transform_tool_output_falls_back_to_output_text_when_error_message_missing() {
+        // MCP `CallToolResult { is_error: true }` can leave error_message
+        // unset and put the failure text inside the result blocks.
+        let mut output = failed_tool_output("brave_web_search");
+        output.error_message = None;
+        output.output = serde_json::json!([
+            {"type": "text", "text": "rate limited"}
+        ]);
+
+        let item = transform_tool_output(&output, ResponseFormat::Passthrough);
+        match item {
+            ResponseOutputItem::McpCall { error, .. } => {
+                assert_eq!(error.as_deref(), Some("rate limited"));
             }
             _ => panic!("Expected McpCall"),
         }

--- a/model_gateway/src/routers/common/persistence_utils.rs
+++ b/model_gateway/src/routers/common/persistence_utils.rs
@@ -320,19 +320,23 @@ fn extract_input_items(input: &ResponseInput) -> Result<Vec<Value>, String> {
 fn item_to_new_conversation_item(
     item_value: &Value,
     response_id: Option<String>,
-    is_input: bool,
+    _is_input: bool,
 ) -> NewConversationItem {
     let item_type = item_value
         .get("type")
         .and_then(|v| v.as_str())
         .unwrap_or("message");
 
-    // Determine if we should store the whole item or just the content field
-    let store_whole_item = if is_input {
-        item_type == "function_call" || item_type == "function_call_output"
-    } else {
-        item_type != "message"
-    };
+    // Store the whole item for every non-message type, regardless of input vs
+    // output side. The previous input-side branch only treated
+    // `function_call` / `function_call_output` as whole-item, so a replayed
+    // structural item (e.g. `image_generation_call`, `web_search_call`,
+    // `mcp_call` carried back into a turn's input) fell through to the
+    // `content` extractor — but those items have no `content` field, so
+    // persistence would store an empty array and the next history load would
+    // lose the original item. Non-message items have no `content` field on
+    // the wire either way, so unifying the rule is safe.
+    let store_whole_item = item_type != "message";
 
     let content = if store_whole_item {
         item_value.clone()
@@ -514,4 +518,64 @@ async fn persist_conversation_items_inner(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn replayed_image_generation_input_item_is_stored_whole() {
+        // Regression: structural input items (replayed `image_generation_call`
+        // and friends) carry their fields at the top level — not under
+        // `content`. The previous input-side branch only treated
+        // `function_call`/`function_call_output` as whole-item, so any other
+        // structural type fell through to `item_value.get("content")` which
+        // collapsed to `[]`, dropping the whole item from the next history
+        // load.
+        let input_item = json!({
+            "id": "ig_replay_1",
+            "type": "image_generation_call",
+            "status": "completed",
+            "revised_prompt": "cat",
+        });
+
+        let new_item = item_to_new_conversation_item(&input_item, None, /* is_input */ true);
+        assert_eq!(new_item.item_type, "image_generation_call");
+        // Whole-item content preserves all top-level fields, not just `content`.
+        assert_eq!(
+            new_item
+                .content
+                .get("revised_prompt")
+                .and_then(|v| v.as_str()),
+            Some("cat"),
+            "structural input items must round-trip their top-level fields, \
+             not collapse to `content` (was bug for replayed hosted-tool items)"
+        );
+        assert_eq!(
+            new_item.content.get("type").and_then(|v| v.as_str()),
+            Some("image_generation_call"),
+        );
+    }
+
+    #[test]
+    fn replayed_message_input_item_still_extracts_content() {
+        // The unification only changes non-message handling; message items
+        // continue to extract their `content` array (and may wrap with `phase`
+        // when present, exercised separately).
+        let input_item = json!({
+            "id": "msg_1",
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": "hi"}],
+            "status": "completed",
+        });
+
+        let new_item = item_to_new_conversation_item(&input_item, None, /* is_input */ true);
+        assert_eq!(new_item.item_type, "message");
+        assert_eq!(
+            new_item.content,
+            json!([{"type": "input_text", "text": "hi"}])
+        );
+    }
 }

--- a/model_gateway/src/routers/common/persistence_utils.rs
+++ b/model_gateway/src/routers/common/persistence_utils.rs
@@ -85,8 +85,23 @@ pub fn item_to_json(item: &ConversationItem) -> Value {
                 obj.insert("phase".to_string(), phase_value);
             }
         }
+    } else if let Some(content_obj) = item.content.as_object() {
+        // Whole-item store path (`store_whole_item` in
+        // `item_to_new_conversation_item`): `content` is the original item
+        // value with its fields at the top level. Hoist them back rather
+        // than wrapping them under `content`, otherwise replayed structural
+        // items come back as `{"type":"…","content":{"type":"…",…}}` and
+        // lose `revised_prompt`/`status`/etc. on the wire.
+        for (k, v) in content_obj {
+            if matches!(k.as_str(), "id" | "type" | "role" | "status") {
+                continue;
+            }
+            obj.insert(k.clone(), v.clone());
+        }
     } else {
-        // Default: include content as-is
+        // Pre-fix rows for non-listed types stored `[]` instead of the
+        // whole item; preserve the legacy `{"content": …}` wrapping so we
+        // don't drop data that came in under the old write path.
         obj.insert("content".to_string(), item.content.clone());
     }
 
@@ -517,7 +532,52 @@ async fn persist_conversation_items_inner(
 
 #[cfg(test)]
 mod tests {
+    use chrono::Utc;
+
     use super::*;
+
+    fn stored_item(item_type: &str, content: Value) -> ConversationItem {
+        ConversationItem {
+            id: ConversationItemId::from("ig_replay_1"),
+            response_id: None,
+            item_type: item_type.to_string(),
+            role: None,
+            content,
+            status: Some("completed".to_string()),
+            created_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn item_to_json_restores_top_level_fields_for_whole_item_store() {
+        let stored = stored_item(
+            "image_generation_call",
+            json!({
+                "id": "ig_replay_1",
+                "type": "image_generation_call",
+                "status": "completed",
+                "revised_prompt": "cat",
+            }),
+        );
+
+        let serialized = item_to_json(&stored);
+        assert_eq!(serialized["type"], json!("image_generation_call"));
+        assert_eq!(serialized["revised_prompt"], json!("cat"));
+        assert!(
+            serialized.get("content").is_none(),
+            "non-message whole-item store must hoist top-level fields, not \
+             nest the original item under `content`: {serialized}"
+        );
+    }
+
+    #[test]
+    fn item_to_json_falls_back_to_legacy_content_wrap_for_array_content() {
+        // Pre-fix rows for non-listed types may have stored `[]`. Preserve
+        // the legacy wrapping so old data still round-trips.
+        let stored = stored_item("image_generation_call", json!([]));
+        let serialized = item_to_json(&stored);
+        assert_eq!(serialized["content"], json!([]));
+    }
 
     #[test]
     fn replayed_image_generation_input_item_is_stored_whole() {

--- a/model_gateway/src/routers/common/persistence_utils.rs
+++ b/model_gateway/src/routers/common/persistence_utils.rs
@@ -327,15 +327,10 @@ fn item_to_new_conversation_item(
         .and_then(|v| v.as_str())
         .unwrap_or("message");
 
-    // Store the whole item for every non-message type, regardless of input vs
-    // output side. The previous input-side branch only treated
-    // `function_call` / `function_call_output` as whole-item, so a replayed
-    // structural item (e.g. `image_generation_call`, `web_search_call`,
-    // `mcp_call` carried back into a turn's input) fell through to the
-    // `content` extractor — but those items have no `content` field, so
-    // persistence would store an empty array and the next history load would
-    // lose the original item. Non-message items have no `content` field on
-    // the wire either way, so unifying the rule is safe.
+    // Non-message items carry their fields at the top level (no `content`
+    // field on the wire), so reading `content` on the input side would
+    // collapse replayed structural items (`image_generation_call`,
+    // `web_search_call`, …) to `[]`.
     let store_whole_item = item_type != "message";
 
     let content = if store_whole_item {
@@ -526,13 +521,6 @@ mod tests {
 
     #[test]
     fn replayed_image_generation_input_item_is_stored_whole() {
-        // Regression: structural input items (replayed `image_generation_call`
-        // and friends) carry their fields at the top level — not under
-        // `content`. The previous input-side branch only treated
-        // `function_call`/`function_call_output` as whole-item, so any other
-        // structural type fell through to `item_value.get("content")` which
-        // collapsed to `[]`, dropping the whole item from the next history
-        // load.
         let input_item = json!({
             "id": "ig_replay_1",
             "type": "image_generation_call",
@@ -542,15 +530,12 @@ mod tests {
 
         let new_item = item_to_new_conversation_item(&input_item, None, /* is_input */ true);
         assert_eq!(new_item.item_type, "image_generation_call");
-        // Whole-item content preserves all top-level fields, not just `content`.
         assert_eq!(
             new_item
                 .content
                 .get("revised_prompt")
                 .and_then(|v| v.as_str()),
             Some("cat"),
-            "structural input items must round-trip their top-level fields, \
-             not collapse to `content` (was bug for replayed hosted-tool items)"
         );
         assert_eq!(
             new_item.content.get("type").and_then(|v| v.as_str()),
@@ -560,9 +545,6 @@ mod tests {
 
     #[test]
     fn replayed_message_input_item_still_extracts_content() {
-        // The unification only changes non-message handling; message items
-        // continue to extract their `content` array (and may wrap with `phase`
-        // when present, exercised separately).
         let input_item = json!({
             "id": "msg_1",
             "type": "message",

--- a/model_gateway/src/routers/grpc/regular/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/streaming.rs
@@ -776,8 +776,10 @@ async fn execute_tool_loop_streaming_internal(
                     warn!("Tool execution returned error: {}", err_text);
 
                     // `response.mcp_call.failed` is the only `*.failed` event
-                    // in the Responses API; hosted-builtin families close via
-                    // `*.completed` + `output_item.done` with status=failed.
+                    // in the Responses API. Hosted-builtin families close via
+                    // `*.completed` to mirror OpenAI cloud's wire shape;
+                    // the failure context (when present) lives in the item
+                    // content.
                     if matches!(response_format, ResponseFormat::Passthrough) {
                         let event = emitter.emit_mcp_call_failed(output_index, &item_id, &err_text);
                         emitter.send_event(&event, &tx)?;

--- a/model_gateway/src/routers/grpc/regular/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/streaming.rs
@@ -739,16 +739,6 @@ async fn execute_tool_loop_streaming_internal(
                 let success = !tool_output.is_error;
                 let output_str = tool_output.output.to_string();
 
-                // Build the typed output item once and reuse it for both the
-                // streamed `output_item.done` payload and the persisted state
-                // record. The previous code hand-rolled an ad-hoc envelope
-                // (`{name, status, arguments, output|error}`) for the wire
-                // payload — a shape that does not match the hosted-builtin
-                // variants (`web_search_call`/`code_interpreter_call`/
-                // `file_search_call`/`image_generation_call` have no `name`/
-                // `arguments`/`output` fields, and only `mcp_call` carries an
-                // `error` field) — so the streamed final item could diverge
-                // from the persisted one and leak invalid fields on failure.
                 let output_item =
                     openai_bridge::transform_tool_output(&tool_output, response_format);
                 let mut item_done = serde_json::to_value(&output_item).unwrap_or_else(|e| {
@@ -763,8 +753,8 @@ async fn execute_tool_loop_streaming_internal(
                         "status": if success { "completed" } else { "failed" },
                     })
                 });
-                // Preserve the streaming-allocated id so `output_item.done`
-                // matches the earlier `output_item.added`.
+                // Override the typed item's id so output_item.done matches the
+                // streaming-allocated id used by the earlier output_item.added.
                 if let Some(obj) = item_done.as_object_mut() {
                     obj.insert("id".to_string(), json!(&item_id));
                 }
@@ -775,7 +765,6 @@ async fn execute_tool_loop_streaming_internal(
                 );
 
                 if success {
-                    // Emit format-specific tool_call.completed event.
                     let event =
                         emitter.emit_tool_call_completed(output_index, &item_id, response_format);
                     emitter.send_event(&event, &tx)?;
@@ -786,11 +775,9 @@ async fn execute_tool_loop_streaming_internal(
                         .unwrap_or_else(|| output_str.clone());
                     warn!("Tool execution returned error: {}", err_text);
 
-                    // `mcp_call.failed` is the only `*.failed` event in the
-                    // Responses API event taxonomy — hosted-builtin families
-                    // close out via `*.completed` followed by `output_item.done`
-                    // carrying `status: "failed"` (no `error` field on those
-                    // variants).
+                    // `response.mcp_call.failed` is the only `*.failed` event
+                    // in the Responses API; hosted-builtin families close via
+                    // `*.completed` + `output_item.done` with status=failed.
                     if matches!(response_format, ResponseFormat::Passthrough) {
                         let event = emitter.emit_mcp_call_failed(output_index, &item_id, &err_text);
                         emitter.send_event(&event, &tx)?;
@@ -804,13 +791,10 @@ async fn execute_tool_loop_streaming_internal(
                     }
                 }
 
-                // Emit output_item.done with the transformed item (correct
-                // shape for both mcp_call and hosted-builtin variants).
                 let event = emitter.emit_output_item_done(output_index, &item_done);
                 emitter.send_event(&event, &tx)?;
                 emitter.complete_output_item(output_index);
 
-                // Record MCP tool metrics
                 Metrics::record_mcp_tool_duration(
                     &current_request.model,
                     &tool_output.tool_name,
@@ -826,8 +810,6 @@ async fn execute_tool_loop_streaming_internal(
                     },
                 );
 
-                // Record the call in state with the same transformed item we
-                // just emitted on the wire.
                 state.record_call(
                     tool_output.call_id,
                     tool_output.tool_name,

--- a/model_gateway/src/routers/grpc/regular/responses/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/streaming.rs
@@ -739,31 +739,46 @@ async fn execute_tool_loop_streaming_internal(
                 let success = !tool_output.is_error;
                 let output_str = tool_output.output.to_string();
 
+                // Build the typed output item once and reuse it for both the
+                // streamed `output_item.done` payload and the persisted state
+                // record. The previous code hand-rolled an ad-hoc envelope
+                // (`{name, status, arguments, output|error}`) for the wire
+                // payload — a shape that does not match the hosted-builtin
+                // variants (`web_search_call`/`code_interpreter_call`/
+                // `file_search_call`/`image_generation_call` have no `name`/
+                // `arguments`/`output` fields, and only `mcp_call` carries an
+                // `error` field) — so the streamed final item could diverge
+                // from the persisted one and leak invalid fields on failure.
+                let output_item =
+                    openai_bridge::transform_tool_output(&tool_output, response_format);
+                let mut item_done = serde_json::to_value(&output_item).unwrap_or_else(|e| {
+                    warn!(
+                        tool = %tool_output.tool_name,
+                        error = %e,
+                        "Failed to serialize transformed output item; falling back to a minimal stub",
+                    );
+                    json!({
+                        "id": item_id,
+                        "type": item_type,
+                        "status": if success { "completed" } else { "failed" },
+                    })
+                });
+                // Preserve the streaming-allocated id so `output_item.done`
+                // matches the earlier `output_item.added`.
+                if let Some(obj) = item_done.as_object_mut() {
+                    obj.insert("id".to_string(), json!(&item_id));
+                }
+                attach_mcp_server_label(
+                    &mut item_done,
+                    Some(tool_output.server_label.as_str()),
+                    Some(&response_format),
+                );
+
                 if success {
-                    // Emit tool_call.completed
+                    // Emit format-specific tool_call.completed event.
                     let event =
                         emitter.emit_tool_call_completed(output_index, &item_id, response_format);
                     emitter.send_event(&event, &tx)?;
-
-                    // Build complete item with output
-                    let mut item_done = json!({
-                        "id": item_id,
-                        "type": item_type,
-                        "name": tool_output.tool_name,
-                        "status": "completed",
-                        "arguments": tool_output.arguments_str,
-                        "output": output_str
-                    });
-                    attach_mcp_server_label(
-                        &mut item_done,
-                        Some(tool_output.server_label.as_str()),
-                        Some(&response_format),
-                    );
-
-                    // Emit output_item.done
-                    let event = emitter.emit_output_item_done(output_index, &item_done);
-                    emitter.send_event(&event, &tx)?;
-                    emitter.complete_output_item(output_index);
                 } else {
                     let err_text = tool_output
                         .error_message
@@ -771,30 +786,29 @@ async fn execute_tool_loop_streaming_internal(
                         .unwrap_or_else(|| output_str.clone());
                     warn!("Tool execution returned error: {}", err_text);
 
-                    // Emit mcp_call.failed (no web_search_call.failed event exists)
-                    let event = emitter.emit_mcp_call_failed(output_index, &item_id, &err_text);
-                    emitter.send_event(&event, &tx)?;
-
-                    // Build failed item
-                    let mut item_done = json!({
-                        "id": item_id,
-                        "type": item_type,
-                        "name": tool_output.tool_name,
-                        "status": "failed",
-                        "arguments": tool_output.arguments_str,
-                        "error": err_text
-                    });
-                    attach_mcp_server_label(
-                        &mut item_done,
-                        Some(tool_output.server_label.as_str()),
-                        Some(&response_format),
-                    );
-
-                    // Emit output_item.done
-                    let event = emitter.emit_output_item_done(output_index, &item_done);
-                    emitter.send_event(&event, &tx)?;
-                    emitter.complete_output_item(output_index);
+                    // `mcp_call.failed` is the only `*.failed` event in the
+                    // Responses API event taxonomy — hosted-builtin families
+                    // close out via `*.completed` followed by `output_item.done`
+                    // carrying `status: "failed"` (no `error` field on those
+                    // variants).
+                    if matches!(response_format, ResponseFormat::Passthrough) {
+                        let event = emitter.emit_mcp_call_failed(output_index, &item_id, &err_text);
+                        emitter.send_event(&event, &tx)?;
+                    } else {
+                        let event = emitter.emit_tool_call_completed(
+                            output_index,
+                            &item_id,
+                            response_format,
+                        );
+                        emitter.send_event(&event, &tx)?;
+                    }
                 }
+
+                // Emit output_item.done with the transformed item (correct
+                // shape for both mcp_call and hosted-builtin variants).
+                let event = emitter.emit_output_item_done(output_index, &item_done);
+                emitter.send_event(&event, &tx)?;
+                emitter.complete_output_item(output_index);
 
                 // Record MCP tool metrics
                 Metrics::record_mcp_tool_duration(
@@ -812,10 +826,8 @@ async fn execute_tool_loop_streaming_internal(
                     },
                 );
 
-                let output_item =
-                    openai_bridge::transform_tool_output(&tool_output, response_format);
-
-                // Record the call in state with transformed output item
+                // Record the call in state with the same transformed item we
+                // just emitted on the wire.
                 state.record_call(
                     tool_output.call_id,
                     tool_output.tool_name,

--- a/model_gateway/src/routers/openai/responses/non_streaming.rs
+++ b/model_gateway/src/routers/openai/responses/non_streaming.rs
@@ -15,7 +15,7 @@ use super::utils::{patch_response_with_request_metadata, restore_original_tools}
 use crate::routers::{
     common::{
         header_utils::{extract_forwardable_request_headers, ApiProvider},
-        mcp_utils::ensure_request_mcp_client,
+        mcp_utils::{ensure_request_mcp_client, request_uses_mcp_routing},
         openai_bridge,
         persistence_utils::persist_conversation_items,
     },
@@ -65,24 +65,33 @@ pub async fn handle_non_streaming_response(mut ctx: RequestContext) -> Response 
 
     // The format registry is the router-side source of truth for MCP
     // builtin/alias format resolution; falling back to a default would
-    // silently mis-route hosted tools instead of failing fast.
-    let mcp_format_registry = match ctx.components.mcp_format_registry() {
-        Some(r) => r.clone(),
-        None => {
-            return error::internal_error("internal_error", "MCP format registry required");
+    // silently mis-route hosted tools instead of failing fast. The check is
+    // scoped to MCP-laden requests — plain non-MCP requests must still
+    // succeed in deployments where the gateway runs without MCP wiring.
+    //
+    // A request with MCP tools but no registry component is a configuration
+    // error: route resolution would silently degrade to `Passthrough`, so we
+    // fail fast instead. Resolve `(mcp_servers, registry)` together so the
+    // typed result carries the registry into the MCP arm without a second
+    // option lookup.
+    let mcp_routing = match original_body.tools.as_deref() {
+        Some(tools) if request_uses_mcp_routing(tools) => {
+            let Some(registry) = ctx.components.mcp_format_registry() else {
+                return error::internal_error(
+                    "internal_error",
+                    "MCP format registry required for requests carrying MCP/builtin tools",
+                );
+            };
+            ensure_request_mcp_client(mcp_orchestrator, registry, tools)
+                .await
+                .map(|servers| (servers, registry.clone()))
         }
-    };
-
-    // Check for MCP tools and create session if needed
-    let mcp_servers = if let Some(tools) = original_body.tools.as_deref() {
-        ensure_request_mcp_client(mcp_orchestrator, &mcp_format_registry, tools).await
-    } else {
-        None
+        _ => None,
     };
 
     let mut response_json: Value;
 
-    if let Some(mcp_servers) = mcp_servers {
+    if let Some((mcp_servers, mcp_format_registry)) = mcp_routing {
         let session_request_id = original_body
             .request_id
             .clone()

--- a/model_gateway/src/routers/openai/responses/non_streaming.rs
+++ b/model_gateway/src/routers/openai/responses/non_streaming.rs
@@ -56,19 +56,19 @@ pub async fn handle_non_streaming_response(mut ctx: RequestContext) -> Response 
             return error::internal_error("internal_error", "Worker not selected");
         }
     };
-    let mcp_orchestrator = match ctx.components.mcp_orchestrator() {
-        Some(m) => m,
-        None => {
-            return error::internal_error("internal_error", "MCP orchestrator required");
-        }
-    };
-
-    // Only MCP-laden requests need the format registry; without this
-    // narrowing, plain non-MCP requests would 500 in deployments that run
-    // the gateway without MCP wiring. A registry-less MCP request still
-    // hard-fails — silent fallback would mis-route hosted tools.
+    // Only MCP-laden requests need the orchestrator and format registry;
+    // without this narrowing, plain non-MCP requests would 500 in
+    // deployments that run the gateway without MCP wiring. A registry-less
+    // MCP request still hard-fails — silent fallback would mis-route
+    // hosted tools.
     let mcp_routing = match original_body.tools.as_deref() {
         Some(tools) if request_uses_mcp_routing(tools) => {
+            let Some(mcp_orchestrator) = ctx.components.mcp_orchestrator() else {
+                return error::internal_error(
+                    "internal_error",
+                    "MCP orchestrator required for requests carrying MCP/builtin tools",
+                );
+            };
             let Some(registry) = ctx.components.mcp_format_registry() else {
                 return error::internal_error(
                     "internal_error",
@@ -77,21 +77,21 @@ pub async fn handle_non_streaming_response(mut ctx: RequestContext) -> Response 
             };
             ensure_request_mcp_client(mcp_orchestrator, registry, tools)
                 .await
-                .map(|servers| (servers, registry.clone()))
+                .map(|servers| (servers, mcp_orchestrator.clone(), registry.clone()))
         }
         _ => None,
     };
 
     let mut response_json: Value;
 
-    if let Some((mcp_servers, mcp_format_registry)) = mcp_routing {
+    if let Some((mcp_servers, mcp_orchestrator, mcp_format_registry)) = mcp_routing {
         let session_request_id = original_body
             .request_id
             .clone()
             .unwrap_or_else(|| format!("req_{}", uuid::Uuid::now_v7()));
         let forwarded_headers = extract_forwardable_request_headers(ctx.headers());
         let mut session = McpToolSession::new_with_headers(
-            mcp_orchestrator,
+            &mcp_orchestrator,
             mcp_servers,
             &session_request_id,
             forwarded_headers,

--- a/model_gateway/src/routers/openai/responses/non_streaming.rs
+++ b/model_gateway/src/routers/openai/responses/non_streaming.rs
@@ -63,17 +63,10 @@ pub async fn handle_non_streaming_response(mut ctx: RequestContext) -> Response 
         }
     };
 
-    // The format registry is the router-side source of truth for MCP
-    // builtin/alias format resolution; falling back to a default would
-    // silently mis-route hosted tools instead of failing fast. The check is
-    // scoped to MCP-laden requests — plain non-MCP requests must still
-    // succeed in deployments where the gateway runs without MCP wiring.
-    //
-    // A request with MCP tools but no registry component is a configuration
-    // error: route resolution would silently degrade to `Passthrough`, so we
-    // fail fast instead. Resolve `(mcp_servers, registry)` together so the
-    // typed result carries the registry into the MCP arm without a second
-    // option lookup.
+    // Only MCP-laden requests need the format registry; without this
+    // narrowing, plain non-MCP requests would 500 in deployments that run
+    // the gateway without MCP wiring. A registry-less MCP request still
+    // hard-fails — silent fallback would mis-route hosted tools.
     let mcp_routing = match original_body.tools.as_deref() {
         Some(tools) if request_uses_mcp_routing(tools) => {
             let Some(registry) = ctx.components.mcp_format_registry() else {

--- a/model_gateway/src/routers/openai/responses/streaming.rs
+++ b/model_gateway/src/routers/openai/responses/streaming.rs
@@ -1065,7 +1065,7 @@ pub(super) fn handle_streaming_with_tool_interception(
 
 /// Main entry point for streaming responses
 pub async fn handle_streaming_response(ctx: RequestContext) -> Response {
-    use crate::routers::common::mcp_utils::ensure_request_mcp_client;
+    use crate::routers::common::mcp_utils::{ensure_request_mcp_client, request_uses_mcp_routing};
 
     let worker = match ctx.worker() {
         Some(w) => w.clone(),
@@ -1086,20 +1086,28 @@ pub async fn handle_streaming_response(ctx: RequestContext) -> Response {
             return error::internal_error("internal_error", "MCP orchestrator required");
         }
     };
-    // Same fail-fast contract as the non-streaming path: a missing format
-    // registry means MCP routing decisions would be silently wrong.
-    let mcp_format_registry = match ctx.components.mcp_format_registry() {
-        Some(r) => r.clone(),
-        None => {
-            return error::internal_error("internal_error", "MCP format registry required");
+    // Scope the format-registry fail-fast to MCP-laden requests. Plain
+    // streaming requests must still pass through deployments that run
+    // without MCP wiring; only requests that actually need MCP routing
+    // require the registry.
+    //
+    // Resolve `(mcp_servers, registry)` as a single tuple so the cloned
+    // registry follows mcp_servers into the interception path without a
+    // second option lookup downstream.
+    let mcp_routing = match original_body.tools.as_deref() {
+        Some(tools) if request_uses_mcp_routing(tools) => {
+            let Some(registry) = ctx.components.mcp_format_registry() else {
+                return error::internal_error(
+                    "internal_error",
+                    "MCP format registry required for requests carrying MCP/builtin tools",
+                );
+            };
+            let registry = registry.clone();
+            ensure_request_mcp_client(&mcp_orchestrator, &registry, tools)
+                .await
+                .map(|servers| (servers, registry))
         }
-    };
-
-    // Check for MCP tools and create request context if needed
-    let mcp_servers = if let Some(tools) = original_body.tools.as_deref() {
-        ensure_request_mcp_client(&mcp_orchestrator, &mcp_format_registry, tools).await
-    } else {
-        None
+        _ => None,
     };
 
     let client = ctx.components.client().clone();
@@ -1110,7 +1118,7 @@ pub async fn handle_streaming_response(ctx: RequestContext) -> Response {
         }
     };
 
-    let Some(mcp_servers) = mcp_servers else {
+    let Some((mcp_servers, mcp_format_registry)) = mcp_routing else {
         return handle_simple_streaming_passthrough(&client, &worker, headers.as_ref(), req).await;
     };
 

--- a/model_gateway/src/routers/openai/responses/streaming.rs
+++ b/model_gateway/src/routers/openai/responses/streaming.rs
@@ -1086,14 +1086,8 @@ pub async fn handle_streaming_response(ctx: RequestContext) -> Response {
             return error::internal_error("internal_error", "MCP orchestrator required");
         }
     };
-    // Scope the format-registry fail-fast to MCP-laden requests. Plain
-    // streaming requests must still pass through deployments that run
-    // without MCP wiring; only requests that actually need MCP routing
-    // require the registry.
-    //
-    // Resolve `(mcp_servers, registry)` as a single tuple so the cloned
-    // registry follows mcp_servers into the interception path without a
-    // second option lookup downstream.
+    // Only MCP-laden requests need the format registry; plain streaming
+    // requests must still pass through deployments without MCP wiring.
     let mcp_routing = match original_body.tools.as_deref() {
         Some(tools) if request_uses_mcp_routing(tools) => {
             let Some(registry) = ctx.components.mcp_format_registry() else {

--- a/model_gateway/src/routers/openai/responses/streaming.rs
+++ b/model_gateway/src/routers/openai/responses/streaming.rs
@@ -1080,16 +1080,17 @@ pub async fn handle_streaming_response(ctx: RequestContext) -> Response {
             return error::internal_error("internal_error", "Expected responses request");
         }
     };
-    let mcp_orchestrator = match ctx.components.mcp_orchestrator() {
-        Some(m) => m.clone(),
-        None => {
-            return error::internal_error("internal_error", "MCP orchestrator required");
-        }
-    };
-    // Only MCP-laden requests need the format registry; plain streaming
-    // requests must still pass through deployments without MCP wiring.
+    // Only MCP-laden requests need the orchestrator and format registry;
+    // plain streaming requests must still pass through deployments without
+    // MCP wiring.
     let mcp_routing = match original_body.tools.as_deref() {
         Some(tools) if request_uses_mcp_routing(tools) => {
+            let Some(mcp_orchestrator) = ctx.components.mcp_orchestrator().cloned() else {
+                return error::internal_error(
+                    "internal_error",
+                    "MCP orchestrator required for requests carrying MCP/builtin tools",
+                );
+            };
             let Some(registry) = ctx.components.mcp_format_registry() else {
                 return error::internal_error(
                     "internal_error",
@@ -1099,7 +1100,7 @@ pub async fn handle_streaming_response(ctx: RequestContext) -> Response {
             let registry = registry.clone();
             ensure_request_mcp_client(&mcp_orchestrator, &registry, tools)
                 .await
-                .map(|servers| (servers, registry))
+                .map(|servers| (servers, mcp_orchestrator, registry))
         }
         _ => None,
     };
@@ -1112,7 +1113,7 @@ pub async fn handle_streaming_response(ctx: RequestContext) -> Response {
         }
     };
 
-    let Some((mcp_servers, mcp_format_registry)) = mcp_routing else {
+    let Some((mcp_servers, mcp_orchestrator, mcp_format_registry)) = mcp_routing else {
         return handle_simple_streaming_passthrough(&client, &worker, headers.as_ref(), req).await;
     };
 

--- a/model_gateway/tests/mcp_test.rs
+++ b/model_gateway/tests/mcp_test.rs
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 use common::mock_mcp_server::{MockMCPServer, MockSearchResponseMCPServer, MockSearchResponseMode};
 use openai_protocol::responses::{ResponseOutputItem, WebSearchAction};
 use serde_json::json;
-use smg::routers::common::openai_bridge::{ResponseFormat, ResponseTransformer};
+use smg::routers::common::openai_bridge::{transform_tool_output, ResponseFormat};
 use smg_mcp::{
     core::config::{ResponseFormatConfig, ToolConfig},
     McpConfig, McpOrchestrator, McpServerBinding, McpServerConfig, McpToolSession, McpTransport,
@@ -334,17 +334,13 @@ async fn test_web_search_transform_handles_openai_search_response_with_mock() {
 
     assert!(!output.is_error, "Tool execution should succeed");
 
-    // The session returns the raw `output` Value from the MCP call. Re-transform
-    // with WebSearchCall format to verify serialization (end-to-end source
-    // extraction is covered by the gateway bridge's own tests).
-    let transformed = ResponseTransformer::transform(
-        &output.output,
-        ResponseFormat::WebSearchCall,
-        "test-request-openai-search",
-        "openai_search_server",
-        "brave_web_search",
-        "{\"query\":\"rust openai search\"}",
-    );
+    // Route the actual `ToolExecutionOutput` through the production bridge
+    // helper so a regression in session-side rewrites (`call_id`,
+    // `server_label`, `tool_name`, `arguments_str` all live on `output`)
+    // would surface here too. Hardcoding those fields against
+    // `ResponseTransformer::transform` would let such a regression slip
+    // through with the test still green.
+    let transformed = transform_tool_output(&output, ResponseFormat::WebSearchCall);
     match transformed {
         ResponseOutputItem::WebSearchCall { action, .. } => match action {
             WebSearchAction::Search {
@@ -419,14 +415,10 @@ async fn test_web_search_transform_sets_action_query_for_brave_search_with_mock(
 
     assert!(!output.is_error, "Tool execution should succeed");
 
-    let transformed = ResponseTransformer::transform(
-        &output.output,
-        ResponseFormat::WebSearchCall,
-        "test-request-brave",
-        "brave_response_server",
-        "brave_web_search",
-        "{\"query\":\"rust brave query\"}",
-    );
+    // Same reasoning as the OpenAI variant above — feed the actual
+    // `ToolExecutionOutput` through the production bridge helper so any
+    // future regression in session-side field rewrites surfaces here.
+    let transformed = transform_tool_output(&output, ResponseFormat::WebSearchCall);
     match transformed {
         ResponseOutputItem::WebSearchCall { action, .. } => match action {
             WebSearchAction::Search {

--- a/model_gateway/tests/mcp_test.rs
+++ b/model_gateway/tests/mcp_test.rs
@@ -334,12 +334,6 @@ async fn test_web_search_transform_handles_openai_search_response_with_mock() {
 
     assert!(!output.is_error, "Tool execution should succeed");
 
-    // Route the actual `ToolExecutionOutput` through the production bridge
-    // helper so a regression in session-side rewrites (`call_id`,
-    // `server_label`, `tool_name`, `arguments_str` all live on `output`)
-    // would surface here too. Hardcoding those fields against
-    // `ResponseTransformer::transform` would let such a regression slip
-    // through with the test still green.
     let transformed = transform_tool_output(&output, ResponseFormat::WebSearchCall);
     match transformed {
         ResponseOutputItem::WebSearchCall { action, .. } => match action {
@@ -415,9 +409,6 @@ async fn test_web_search_transform_sets_action_query_for_brave_search_with_mock(
 
     assert!(!output.is_error, "Tool execution should succeed");
 
-    // Same reasoning as the OpenAI variant above — feed the actual
-    // `ToolExecutionOutput` through the production bridge helper so any
-    // future regression in session-side field rewrites surfaces here.
     let transformed = transform_tool_output(&output, ResponseFormat::WebSearchCall);
     match transformed {
         ResponseOutputItem::WebSearchCall { action, .. } => match action {


### PR DESCRIPTION
## Summary

PR #1429 left a number of CodeRabbit / Codex / Claude review comments unaddressed (or only partially addressed). This PR closes them, grouped by the bug each fix touches. Every fix has a regression test; the existing wire shape stays unchanged for the non-MCP and explicit-Passthrough cases.

| # | Bug | Severity | Comments addressed |
|---|---|---|---|
| 1 | Aliased builtin lookup miss + Passthrough downgrade leaves stale entry | 🔴 + 🟠 | claude `3174955420`, claude `3174955773`, codex `3174963504`, coderabbit `3174799419`, coderabbit `3174799424`, coderabbit `3174987646`, claude `3174778983`, codex `3176332060` |
| 2 | `transform_tool_output` discards `is_error`/`error_message` | 🟠 | coderabbit `3175392558` |
| 3 | `mcp_list_tools.tools[].annotations` widened to full struct | 🟠 | coderabbit `3174799428`, coderabbit `3174799434` |
| 4 | Replayed structural input items lose `content` | 🟠 | coderabbit `3175392562` |
| 5 | OpenAI streaming/non-streaming format-registry eager 500 | 🟠 | coderabbit `3175392563` |
| 6 | gRPC regular streaming `output_item.done` ad-hoc envelope | 🟠 | coderabbit `3174987653` |
| 7 | mcp_test bypasses bridge helper | 🟡 | coderabbit `3175392565` |

False positive (no change): gemini `3174766561` — `server()` helper already lives inside `#[cfg(test)] mod tests {}`.
Skipped (perf micro-nit, not a hot path): gemini `3174766567`.

## Why these matter

- **(1)** is the worst regression. `McpToolSession::collect_visible_mcp_tools` (`crates/mcp/src/core/session.rs:565-571`) replaces a direct entry with its alias entries when an alias is registered, so production session lookup of an aliased builtin queries `("alias", alias_name)`. The previous code only landed the format on `(server, tool)`, so any aliased builtin silently degraded to `mcp_call` instead of the hosted shape (e.g. `web_search_call` / `image_generation_call`). The fix mirrors non-Passthrough formats on both keys and adds explicit downgrade-clears so a config that demotes a tool to Passthrough no longer leaves the stale hosted entry behind.
- **(2)** is a correctness bug in failure replay: a failed hosted-tool execution was persisted and re-shipped to the model as `status = "completed"`. The fix bypasses the success-path builders when `is_error` is set and emits a typed failure item. `mcp_call` carries `error`; the four hosted-builtin families convey failure via `status: "failed"` only (matches the OpenAI Responses spec).
- **(3)** restores the wire-spec narrowing introduced by `1c82bca1` and reverted by the bridge move.
- **(4)** the previous code only treated `function_call`/`function_call_output` as whole-item on the input side, so any other replayed structural item (`image_generation_call`, `web_search_call`, `mcp_call`, `mcp_list_tools`) collapsed to `content: []` on persist, dropping the item from the next history load.
- **(5)** the previous fail-fast check ran before the router knew whether the request would even use MCP routing, so plain non-MCP requests 500'd in deployments without MCP wiring. The check is now scoped to MCP-laden requests via a new `request_uses_mcp_routing(tools)` predicate; the safety contract is preserved exactly when it matters.
- **(6)** the gRPC streaming `output_item.done` payload was hand-rolled with `{name, status, arguments, output|error}` — wrong shape for hosted-builtin variants (no `name`/`arguments`/`output` fields) and leaked an `error` field on hosted failures (only `mcp_call` carries `error`). Now serializes the typed item from `transform_tool_output` and reuses it for both the wire payload and `state.record_call`.

## Test plan

- [x] `cargo build -p smg` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test -p smg --lib openai_bridge::` — 50 pass (5 new regression tests added)
- [x] `cargo test -p smg --test mcp_test` — 23 pass (2 tests rerouted through `transform_tool_output`)
- [x] `cargo test -p smg-mcp` — 158 pass
- [x] `cargo test -p smg --lib` — 731 pass
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More consistent failure reporting for tool executions (failed status, clearer error message, empty output where appropriate).
  * Streaming now emits the correct completion/failure events and persists a single, consistent output item.

* **Improvements**
  * Response-format rules now correctly mirror/clear hosted formats and respect aliases.
  * Better detection/routing for MCP/built-in tools and simpler tool metadata (read-only) serialization.
  * Non-message items are now stored with full top-level fields when replayed.

* **Tests**
  * Updated/added tests covering transformations, formats, annotations, and persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->