### PR TITLE
chore(gprc): bump up grpc-servicer version to 0.5.3

### DIFF
--- a/grpc_servicer/pyproject.toml
+++ b/grpc_servicer/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "smg-grpc-servicer"
-version = "0.5.2"
+version = "0.5.3"
 description = "SMG gRPC servicer implementations for LLM inference engines (vLLM, SGLang, MLX)"
 requires-python = ">=3.10"
 dependencies = [

--- a/grpc_servicer/pyproject.toml
+++ b/grpc_servicer/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.5.3"
 description = "SMG gRPC servicer implementations for LLM inference engines (vLLM, SGLang, MLX)"
 requires-python = ">=3.10"
 dependencies = [
-    "smg-grpc-proto>=0.4.6",
+    "smg-grpc-proto>=0.4.7",
     "grpcio>=1.78.0",
     "grpcio-reflection>=1.78.0",
     "grpcio-health-checking>=1.78.0",


### PR DESCRIPTION
## Description

### Problem

The current `grpc-servicer` release lacks the recently added `GetTokenizer` support for vLLM and SGLang, as well as the new servicer implementation for MLX.

### Solution

Bump the `smg-grpc-servicer` version to 0.5.3 to cut a new release on PyPI, making these features available for downstream integrations.

## Changes

- Bump `smg-grpc-servicer` version from 0.5.2 to 0.5.3 in `grpc_servicer/pyproject.toml`.

## Test Plan

- [ ] CI passes
- [ ] PyPI publish workflow succeeds

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.5.3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Released version 0.5.3.
  * Raised minimum required version of a gRPC protocol dependency to ensure compatibility and receive upstream fixes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightseekorg/smg/pull/1443)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->