### PR TITLE
feat(mesh): publish tree:req: repair on unknown tenant deltas

### DIFF
--- a/model_gateway/src/mesh/adapters/mod.rs
+++ b/model_gateway/src/mesh/adapters/mod.rs
@@ -8,5 +8,5 @@ pub mod tree_sync;
 pub mod worker_sync;
 
 pub use rate_limit_sync::RateLimitSyncAdapter;
-pub use tree_sync::{TreeDelta, TreeSyncAdapter};
+pub use tree_sync::{PeerList, RepairReason, TreeDelta, TreeRepairRequest, TreeSyncAdapter};
 pub use worker_sync::WorkerSyncAdapter;

--- a/model_gateway/src/mesh/adapters/tree_sync.rs
+++ b/model_gateway/src/mesh/adapters/tree_sync.rs
@@ -1,30 +1,51 @@
 //! `td:` stream adapter: gateway ↔ mesh bridge for the distributed
-//! prefix tree. Scope so far: tenant-delta fast path + inbound
-//! hash resolution via [`TreeHandle`].
+//! prefix tree. Scope so far: tenant-delta fast path, inbound
+//! hash resolution via [`TreeHandle`], and repair-request issuance
+//! on unknown hashes via [`PeerList`].
 //!
 //! - Outbound: `on_local_insert` buffers per-model `TreeDelta`s;
 //!   the drain callback batches each model into one
 //!   `td:{model_id}` stream entry per gossip round.
 //! - Inbound: a spawned task subscribes to `td:`, decodes each
 //!   batch, and asks the [`TreeHandle`] whether each delta's hash
-//!   is locally known. Known → trace, unknown → debug (repair in
-//!   a later slice).
+//!   is locally known. Known → trace (apply sink lands next
+//!   slice). Unknown → publish a `tree:req:` repair request
+//!   targeted at a random ALIVE peer; the response (`tree:page:`)
+//!   is consumed in the next slice.
 //!
 //! The adapter holds no tree-membership state. The tree owner
 //! (`CacheAwarePolicy` in production) implements [`TreeHandle`];
-//! dependency direction is adapter → policy.
+//! dependency direction is adapter → policy. Membership lookups
+//! likewise go through a [`PeerList`] trait so the adapter doesn't
+//! reach into the gossip controller directly.
 
 use std::sync::{Arc, OnceLock};
 
 use bytes::Bytes;
 use dashmap::DashMap;
+use rand::seq::IndexedRandom;
 use serde::{Deserialize, Serialize};
 use smg_mesh::{DrainHandle, StreamNamespace};
 use tracing::{debug, trace, warn};
+use uuid::Uuid;
 
 use crate::policies::{TreeHandle, TreeKind};
 
 const PREFIX: &str = "td:";
+const REPAIR_REQUEST_PREFIX: &str = "tree:req:";
+
+/// Live-membership view consumed by the adapter when picking a
+/// peer to send a repair request to. Defined here (not in the
+/// mesh crate) so adapter tests can supply a mock without spinning
+/// up gossip; the production impl wraps the gossip controller's
+/// alive-peer list and lands with the slice that wires the
+/// adapter into `server.rs`.
+pub trait PeerList: Send + Sync + std::fmt::Debug {
+    /// Currently-ALIVE peer names, excluding the local node.
+    /// Order is implementation-defined; the adapter picks one at
+    /// random.
+    fn alive_peers(&self) -> Vec<String>;
+}
 
 /// One prefix-tree change observed on a producing node. `node_hash`
 /// is the blake3 8-byte id scoped by `(model_id, tree_kind, path)`;
@@ -41,14 +62,52 @@ pub struct TreeDelta {
     pub epoch: u64,
 }
 
+/// Why a node is asking for repair. Carried on the wire so the
+/// responder can log/diagnose; doesn't change the response shape.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RepairReason {
+    /// Inbound `TreeDelta` referenced a hash this node didn't know.
+    UnknownHash(u64),
+}
+
+/// Wire format for a `tree:req:{session_id}` message. Targeted at
+/// one peer; the responder generates `tree:page:{session_id}:N`
+/// fragments back to `requester_peer_id`. Slice 5d implements the
+/// responder + page handler; slice 5c only emits these.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TreeRepairRequest {
+    pub session_id: Uuid,
+    pub requester_peer_id: String,
+    pub target_peer_id: String,
+    pub model_id: String,
+    pub tree_kind: TreeKind,
+    /// Resumable pagination cursor. `None` means "from the
+    /// beginning"; slice 5d will set this on retry after a
+    /// timeout to skip already-applied pages.
+    pub cursor: Option<Vec<u8>>,
+    pub reason: RepairReason,
+}
+
 /// Bridges the `td:` broadcast stream namespace to per-model
 /// tenant buffers, querying a [`TreeHandle`] for inbound hash
-/// resolution.
+/// resolution and a [`PeerList`] for repair-request targeting.
 pub struct TreeSyncAdapter {
     tenant_deltas: Arc<StreamNamespace>,
+    /// Targeted namespace for `tree:req:*` repair requests. The
+    /// adapter only publishes here in slice 5c; subscription (the
+    /// responder side) lands in slice 5d.
+    tree_repair_requests: Arc<StreamNamespace>,
     pending_deltas: DashMap<String, Vec<TreeDelta>>,
-    /// Hash-membership oracle provided by the tree owner.
+    /// Hash-membership handle provided by the tree owner.
     tree: Arc<dyn TreeHandle>,
+    /// Live-peer source for repair-request targeting.
+    peers: Arc<dyn PeerList>,
+    /// Outstanding repair sessions, keyed by (model_id, kind).
+    /// Presence-only set: while a key is here, additional unknown
+    /// hashes for the same (model, kind) are coalesced into the
+    /// in-flight session. Slice 5d adds the response-side cleanup
+    /// (and the per-session bookkeeping that needs reading).
+    outstanding_repairs: DashMap<(String, TreeKind), ()>,
     node_name: String,
     /// Keeps the drain registration alive; dropping it unregisters
     /// from the mesh. `OnceLock` guards against a second `start`.
@@ -61,18 +120,23 @@ impl std::fmt::Debug for TreeSyncAdapter {
             .field("prefix", &self.tenant_deltas.prefix())
             .field("node_name", &self.node_name)
             .field("pending_models", &self.pending_deltas.len())
+            .field("outstanding_repairs", &self.outstanding_repairs.len())
             .finish()
     }
 }
 
 impl TreeSyncAdapter {
-    /// Build an adapter wrapping a `td:`-scoped broadcast namespace
-    /// and the local node name. Panics if the namespace prefix is
+    /// Build an adapter wrapping the `td:` broadcast namespace
+    /// (tenant deltas), the `tree:req:` targeted namespace
+    /// (repair requests), the local tree handle, peer list, and
+    /// the local node name. Panics if either namespace prefix is
     /// wrong so a mis-wired caller fails loudly at startup instead
-    /// of fanning deltas into the wrong stream.
+    /// of fanning entries into the wrong stream.
     pub fn new(
         tenant_deltas: Arc<StreamNamespace>,
+        tree_repair_requests: Arc<StreamNamespace>,
         tree: Arc<dyn TreeHandle>,
+        peers: Arc<dyn PeerList>,
         node_name: String,
     ) -> Arc<Self> {
         assert_eq!(
@@ -80,14 +144,22 @@ impl TreeSyncAdapter {
             PREFIX,
             "TreeSyncAdapter requires a tenant-delta namespace scoped to `{PREFIX}`",
         );
+        assert_eq!(
+            tree_repair_requests.prefix(),
+            REPAIR_REQUEST_PREFIX,
+            "TreeSyncAdapter requires a repair-request namespace scoped to `{REPAIR_REQUEST_PREFIX}`",
+        );
         assert!(
             !node_name.is_empty(),
             "TreeSyncAdapter node_name must not be empty",
         );
         Arc::new(Self {
             tenant_deltas,
+            tree_repair_requests,
             pending_deltas: DashMap::new(),
             tree,
+            peers,
+            outstanding_repairs: DashMap::new(),
             node_name,
             drain_handle: OnceLock::new(),
         })
@@ -232,18 +304,85 @@ impl TreeSyncAdapter {
                     "resolved remote tenant delta against local tree handle",
                 );
             } else {
-                // Unknown — repair-request slice will turn this
-                // into a `tree:req:` message later.
                 debug!(
                     model_id,
                     kind = ?delta.tree_kind,
                     hash = delta.node_hash,
                     worker_url = %delta.worker_url,
                     epoch = delta.epoch,
-                    "unknown remote tenant delta hash (repair deferred to next slice)",
+                    "unknown remote tenant delta hash, requesting repair",
                 );
+                self.request_repair_for_unknown_hash(model_id, delta.tree_kind, delta.node_hash);
             }
         }
+    }
+
+    /// Issue a `tree:req:{session_id}` repair request for an
+    /// unknown hash, targeted at a random ALIVE peer. Coalesces
+    /// duplicates: while a session is already in flight for the
+    /// same `(model_id, tree_kind)`, subsequent unknown-hash
+    /// callbacks are dropped — the in-flight request asks for the
+    /// whole tree (`cursor=None`), so it'll cover the new hash
+    /// when the response lands (slice 5d).
+    fn request_repair_for_unknown_hash(&self, model_id: &str, tree_kind: TreeKind, node_hash: u64) {
+        let key = (model_id.to_string(), tree_kind);
+        if self.outstanding_repairs.contains_key(&key) {
+            trace!(
+                model_id,
+                kind = ?tree_kind,
+                hash = node_hash,
+                "repair already in flight, coalescing unknown-hash trigger",
+            );
+            return;
+        }
+
+        let alive = self.peers.alive_peers();
+        let Some(target) = alive.choose(&mut rand::rng()) else {
+            warn!(
+                model_id,
+                kind = ?tree_kind,
+                hash = node_hash,
+                "no alive peers to request repair from; will retry on next unknown delta",
+            );
+            return;
+        };
+
+        let request = TreeRepairRequest {
+            session_id: Uuid::now_v7(),
+            requester_peer_id: self.node_name.clone(),
+            target_peer_id: target.clone(),
+            model_id: model_id.to_string(),
+            tree_kind,
+            cursor: None,
+            reason: RepairReason::UnknownHash(node_hash),
+        };
+
+        let bytes = match bincode::serialize(&request) {
+            Ok(bytes) => Bytes::from(bytes),
+            Err(err) => {
+                // Schema is fixed-shape — should be unreachable.
+                warn!(model_id, %err, "failed to serialize tree repair request");
+                return;
+            }
+        };
+
+        let stream_key = format!("{REPAIR_REQUEST_PREFIX}{}", request.session_id);
+        self.tree_repair_requests
+            .publish_to(target, &stream_key, bytes);
+
+        // Record the in-flight session AFTER publish so a publish
+        // that panics on a programming error doesn't leave a
+        // ghost entry blocking future requests.
+        self.outstanding_repairs.insert(key, ());
+
+        debug!(
+            model_id,
+            kind = ?tree_kind,
+            hash = node_hash,
+            target = %target,
+            session_id = %request.session_id,
+            "sent tree repair request",
+        );
     }
 }
 
@@ -259,6 +398,16 @@ mod tests {
             StreamConfig {
                 max_buffer_bytes: 64 * 1024,
                 routing: StreamRouting::Broadcast,
+            },
+        )
+    }
+
+    fn req_namespace(mesh: &MeshKV) -> Arc<StreamNamespace> {
+        mesh.configure_stream_prefix(
+            REPAIR_REQUEST_PREFIX,
+            StreamConfig {
+                max_buffer_bytes: 64 * 1024,
+                routing: StreamRouting::Targeted,
             },
         )
     }
@@ -300,10 +449,36 @@ mod tests {
         Arc::new(MockTreeHandle::default())
     }
 
+    /// Test-only [`PeerList`] returning a fixed list of peers.
+    #[derive(Debug, Default)]
+    struct MockPeerList {
+        peers: parking_lot::Mutex<Vec<String>>,
+    }
+
+    impl MockPeerList {
+        fn with(peers: &[&str]) -> Arc<Self> {
+            Arc::new(Self {
+                peers: parking_lot::Mutex::new(peers.iter().map(|s| (*s).into()).collect()),
+            })
+        }
+    }
+
+    impl PeerList for MockPeerList {
+        fn alive_peers(&self) -> Vec<String> {
+            self.peers.lock().clone()
+        }
+    }
+
+    fn empty_peers() -> Arc<MockPeerList> {
+        Arc::new(MockPeerList::default())
+    }
+
     fn adapter_with_empty_handle(mesh: &MeshKV, node_name: &str) -> Arc<TreeSyncAdapter> {
-        let ns = td_namespace(mesh);
+        let td = td_namespace(mesh);
+        let req = req_namespace(mesh);
         let tree: Arc<dyn TreeHandle> = empty_handle();
-        TreeSyncAdapter::new(ns, tree, node_name.into())
+        let peers: Arc<dyn PeerList> = empty_peers();
+        TreeSyncAdapter::new(td, req, tree, peers, node_name.into())
     }
 
     #[tokio::test]
@@ -430,11 +605,13 @@ mod tests {
         // must not alias (same hash, different kind ≠ match).
         // `handle_incoming_batch` is read-only on membership.
         let mesh = MeshKV::new("node-a".into());
-        let ns = td_namespace(&mesh);
+        let td = td_namespace(&mesh);
+        let req = req_namespace(&mesh);
         let tree = Arc::new(MockTreeHandle::default());
         tree.insert("model-1", TreeKind::String, 42);
         let adapter_tree: Arc<dyn TreeHandle> = tree.clone();
-        let adapter = TreeSyncAdapter::new(ns, adapter_tree, "node-a".into());
+        let peers: Arc<dyn PeerList> = MockPeerList::with(&["node-b"]);
+        let adapter = TreeSyncAdapter::new(td, req, adapter_tree, peers, "node-a".into());
 
         let batch = vec![
             TreeDelta {
@@ -468,35 +645,58 @@ mod tests {
     async fn handle_incoming_batch_ignores_malformed_payload() {
         // Corrupt batch → no propagation, no panic.
         let mesh = MeshKV::new("node-a".into());
-        let ns = td_namespace(&mesh);
-        let tree: Arc<dyn TreeHandle> = Arc::new(MockTreeHandle::default());
-        let adapter = TreeSyncAdapter::new(ns, tree, "node-a".into());
+        let adapter = adapter_with_empty_handle(&mesh, "node-a");
 
         adapter.handle_incoming_batch("model-1", &[Bytes::from_static(b"not-bincode")]);
     }
 
     #[tokio::test]
     #[should_panic(expected = "TreeSyncAdapter requires a tenant-delta namespace scoped to `td:`")]
-    async fn new_rejects_wrong_prefix() {
+    async fn new_rejects_wrong_td_prefix() {
+        // Pass the repair-request namespace as the td: arg.
         let mesh = MeshKV::new("node-a".into());
-        let ns = mesh.configure_stream_prefix(
-            "tree:req:",
+        let req = req_namespace(&mesh);
+        let req_again = mesh.configure_stream_prefix(
+            "td-misnamed:",
             StreamConfig {
                 max_buffer_bytes: 64 * 1024,
-                routing: StreamRouting::Targeted,
+                routing: StreamRouting::Broadcast,
             },
         );
         let tree: Arc<dyn TreeHandle> = empty_handle();
-        let _ = TreeSyncAdapter::new(ns, tree, "node-a".into());
+        let peers: Arc<dyn PeerList> = empty_peers();
+        let _ = TreeSyncAdapter::new(req_again, req, tree, peers, "node-a".into());
+    }
+
+    #[tokio::test]
+    #[should_panic(
+        expected = "TreeSyncAdapter requires a repair-request namespace scoped to `tree:req:`"
+    )]
+    async fn new_rejects_wrong_repair_prefix() {
+        // Pass the td: namespace as the repair-request arg.
+        let mesh = MeshKV::new("node-a".into());
+        let td = td_namespace(&mesh);
+        let td_again = mesh.configure_stream_prefix(
+            "td-also:",
+            StreamConfig {
+                max_buffer_bytes: 64 * 1024,
+                routing: StreamRouting::Broadcast,
+            },
+        );
+        let tree: Arc<dyn TreeHandle> = empty_handle();
+        let peers: Arc<dyn PeerList> = empty_peers();
+        let _ = TreeSyncAdapter::new(td, td_again, tree, peers, "node-a".into());
     }
 
     #[tokio::test]
     #[should_panic(expected = "node_name must not be empty")]
     async fn new_rejects_empty_node_name() {
         let mesh = MeshKV::new("node-a".into());
-        let ns = td_namespace(&mesh);
+        let td = td_namespace(&mesh);
+        let req = req_namespace(&mesh);
         let tree: Arc<dyn TreeHandle> = empty_handle();
-        let _ = TreeSyncAdapter::new(ns, tree, String::new());
+        let peers: Arc<dyn PeerList> = empty_peers();
+        let _ = TreeSyncAdapter::new(td, req, tree, peers, String::new());
     }
 
     #[tokio::test]
@@ -508,5 +708,156 @@ mod tests {
         let adapter = adapter_with_empty_handle(&mesh, "node-a");
         adapter.start();
         adapter.start();
+    }
+
+    #[tokio::test]
+    async fn tree_repair_request_bincode_round_trip() {
+        let req = TreeRepairRequest {
+            session_id: Uuid::now_v7(),
+            requester_peer_id: "node-a".into(),
+            target_peer_id: "node-b".into(),
+            model_id: "model-1".into(),
+            tree_kind: TreeKind::Token,
+            cursor: Some(vec![1, 2, 3]),
+            reason: RepairReason::UnknownHash(42),
+        };
+        let bytes = bincode::serialize(&req).unwrap();
+        let decoded: TreeRepairRequest = bincode::deserialize(&bytes).unwrap();
+        assert_eq!(decoded, req);
+    }
+
+    /// Drain the targeted-stream side buffer for repair requests
+    /// so we can inspect what the adapter published.
+    fn drain_repair_publishes(mesh: &MeshKV) -> Vec<(String, String, Bytes)> {
+        let round = mesh.collect_round_batch();
+        round
+            .targeted_entries
+            .into_iter()
+            .filter(|(_, key, _)| key.starts_with(REPAIR_REQUEST_PREFIX))
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn unknown_hash_publishes_repair_request_to_alive_peer() {
+        let mesh = MeshKV::new("node-a".into());
+        let td = td_namespace(&mesh);
+        let req = req_namespace(&mesh);
+        let tree: Arc<dyn TreeHandle> = Arc::new(MockTreeHandle::default());
+        let peers: Arc<dyn PeerList> = MockPeerList::with(&["node-b"]);
+        let adapter = TreeSyncAdapter::new(td, req, tree, peers, "node-a".into());
+
+        // Single unknown delta → one targeted publish to node-b.
+        let batch = vec![delta(99, "http://w1")];
+        let bytes = Bytes::from(bincode::serialize(&batch).unwrap());
+        adapter.handle_incoming_batch("model-1", &[bytes]);
+
+        let publishes = drain_repair_publishes(&mesh);
+        assert_eq!(publishes.len(), 1, "exactly one repair request");
+        let (target, key, payload) = &publishes[0];
+        assert_eq!(target, "node-b");
+        assert!(key.starts_with(REPAIR_REQUEST_PREFIX));
+
+        let request: TreeRepairRequest = bincode::deserialize(payload).unwrap();
+        assert_eq!(request.requester_peer_id, "node-a");
+        assert_eq!(request.target_peer_id, "node-b");
+        assert_eq!(request.model_id, "model-1");
+        assert_eq!(request.tree_kind, TreeKind::String);
+        assert_eq!(request.reason, RepairReason::UnknownHash(99));
+        assert!(request.cursor.is_none());
+
+        // Outstanding-session bookkeeping records the in-flight key.
+        assert!(adapter
+            .outstanding_repairs
+            .contains_key(&("model-1".to_string(), TreeKind::String)),);
+    }
+
+    #[tokio::test]
+    async fn coalesces_duplicate_repair_for_same_model_kind() {
+        // Two unknown hashes for the same (model, kind) within one
+        // batch must produce only one repair request — the
+        // in-flight session covers both.
+        let mesh = MeshKV::new("node-a".into());
+        let td = td_namespace(&mesh);
+        let req = req_namespace(&mesh);
+        let tree: Arc<dyn TreeHandle> = Arc::new(MockTreeHandle::default());
+        let peers: Arc<dyn PeerList> = MockPeerList::with(&["node-b"]);
+        let adapter = TreeSyncAdapter::new(td, req, tree, peers, "node-a".into());
+
+        let batch = vec![delta(101, "http://w1"), delta(102, "http://w2")];
+        let bytes = Bytes::from(bincode::serialize(&batch).unwrap());
+        adapter.handle_incoming_batch("model-1", &[bytes]);
+
+        let publishes = drain_repair_publishes(&mesh);
+        assert_eq!(publishes.len(), 1, "duplicate request should coalesce");
+    }
+
+    #[tokio::test]
+    async fn separate_kinds_get_separate_repair_sessions() {
+        // String and Token unknown hashes for the same model are
+        // distinct sessions — coalescing keys on (model, kind).
+        let mesh = MeshKV::new("node-a".into());
+        let td = td_namespace(&mesh);
+        let req = req_namespace(&mesh);
+        let tree: Arc<dyn TreeHandle> = Arc::new(MockTreeHandle::default());
+        let peers: Arc<dyn PeerList> = MockPeerList::with(&["node-b"]);
+        let adapter = TreeSyncAdapter::new(td, req, tree, peers, "node-a".into());
+
+        let batch = vec![
+            TreeDelta {
+                tree_kind: TreeKind::String,
+                node_hash: 1,
+                worker_url: "http://w1".into(),
+                epoch: 1,
+            },
+            TreeDelta {
+                tree_kind: TreeKind::Token,
+                node_hash: 1,
+                worker_url: "http://w2".into(),
+                epoch: 1,
+            },
+        ];
+        let bytes = Bytes::from(bincode::serialize(&batch).unwrap());
+        adapter.handle_incoming_batch("model-1", &[bytes]);
+
+        let publishes = drain_repair_publishes(&mesh);
+        assert_eq!(publishes.len(), 2, "one per (model, kind) pair");
+    }
+
+    #[tokio::test]
+    async fn no_alive_peers_skips_repair_silently() {
+        // Empty peer list → no publish, no panic, and no entry
+        // recorded so a future delta retries once peers come up.
+        let mesh = MeshKV::new("node-a".into());
+        let adapter = adapter_with_empty_handle(&mesh, "node-a");
+
+        let batch = vec![delta(99, "http://w1")];
+        let bytes = Bytes::from(bincode::serialize(&batch).unwrap());
+        adapter.handle_incoming_batch("model-1", &[bytes]);
+
+        let publishes = drain_repair_publishes(&mesh);
+        assert!(publishes.is_empty(), "no peers means nothing published");
+        assert!(
+            adapter.outstanding_repairs.is_empty(),
+            "no session recorded so the next delta can retry",
+        );
+    }
+
+    #[tokio::test]
+    async fn known_hashes_do_not_trigger_repair() {
+        let mesh = MeshKV::new("node-a".into());
+        let td = td_namespace(&mesh);
+        let req = req_namespace(&mesh);
+        let tree = Arc::new(MockTreeHandle::default());
+        tree.insert("model-1", TreeKind::String, 42);
+        let adapter_tree: Arc<dyn TreeHandle> = tree.clone();
+        let peers: Arc<dyn PeerList> = MockPeerList::with(&["node-b"]);
+        let adapter = TreeSyncAdapter::new(td, req, adapter_tree, peers, "node-a".into());
+
+        let batch = vec![delta(42, "http://w1")];
+        let bytes = Bytes::from(bincode::serialize(&batch).unwrap());
+        adapter.handle_incoming_batch("model-1", &[bytes]);
+
+        let publishes = drain_repair_publishes(&mesh);
+        assert!(publishes.is_empty(), "known hash skips repair entirely");
     }
 }


### PR DESCRIPTION
## Description

### Problem

After #1364 the inbound `td:` subscription classifies each `TreeDelta` as known/unknown via `TreeHandle::contains_hash`, but the unknown branch only logs at `debug!` and stops. Without a follow-up, the cluster has no convergence path: a node that misses an upstream delta stays out of sync indefinitely.

Spec §3 (mesh-v2-implementation-spec.md) explicitly designates tenant-deltas as best-effort and delegates convergence to the repair path (`tree:req:*` request → `tree:page:*` response). This PR lands the request side.

### Solution

The unknown-hash branch now picks a random ALIVE peer and publishes a `tree:req:{session_id}` targeted at it. The responder side (subscribe + page generation) lives in slice 4 — slice 5c's contribution is purely the requester:

- A new `PeerList` trait gives the adapter live-membership without coupling it to the gossip controller. Tests use a `MockPeerList`; the production impl wraps `topology.get_peers()` and lands with the wiring slice.
- `TreeRepairRequest` and `RepairReason` wire types. Each request carries a v7 `session_id` so slice 4 can match `tree:page:{session_id}:N` fragments back; `cursor: Option<Vec<u8>>` is plumbed for slice 4's resumable retry.
- Coalescing via `outstanding_repairs: DashMap<(model, kind), ()>`. While a session is in flight, additional unknown hashes for the same `(model, kind)` are dropped — the in-flight request asks for the whole tree (`cursor=None`), so later hashes are covered by the eventual response.

`TreeSyncAdapter::new` grows two parameters: the `tree:req:` namespace and the `Arc<dyn PeerList>`.

## Changes

- `model_gateway/src/mesh/adapters/tree_sync.rs`:
  - `PeerList` trait + `TreeRepairRequest` / `RepairReason` wire types.
  - Adapter holds `tree_repair_requests` namespace, `peers` handle, `outstanding_repairs` set.
  - `request_repair_for_unknown_hash` method; wired into the unknown branch of `handle_incoming_batch`.
  - Constructor signature change (5 args; assertion on the new namespace prefix).
  - Tests grow from 11 → 18.
- `model_gateway/src/mesh/adapters/mod.rs`: re-export the new public types.

### Not in this PR (deferred to slice 4)

- Responder side of `tree:req:*` (subscribe + page generation via `iter_repair_pages`).
- `apply_repair_page` for incoming pages.
- Apply sink for known hashes (currently still log-only).
- Cold-start fan-out (`request_repair_for_all_local_models`) — deferred because the adapter has no model list at `start()` time; the wiring slice is what knows the configured models.
- Session cleanup on response / timeout retry. Today an entry stays in `outstanding_repairs` once written, which means each `(model, kind)` gets at most one repair per adapter lifetime. That's fine while there's no responder; slice 4 adds the full lifecycle.

## Test Plan

- `cargo test -p smg --lib` — full lib suite passes (734 tests, 0 failed).
- `cargo test -p smg --lib -- mesh::adapters::tree_sync::` — 18 tests pass.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean.
- New tests covering this slice:
  - `tree_repair_request_bincode_round_trip` — wire-format stability.
  - `unknown_hash_publishes_repair_request_to_alive_peer` — end-to-end publish, asserts target peer + payload fields.
  - `coalesces_duplicate_repair_for_same_model_kind` — second unknown hash for the same `(model, kind)` is suppressed.
  - `separate_kinds_get_separate_repair_sessions` — String and Token requests are independent.
  - `no_alive_peers_skips_repair_silently` — empty peer list yields no publish, no panic, and no entry recorded so the next delta retries.
  - `known_hashes_do_not_trigger_repair` — known-branch is unchanged.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced mesh synchronization infrastructure with targeted repair requests for improved recovery from synchronization mismatches
  * Improved request coalescing and peer selection for more efficient synchronization operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->