### PR TITLE
feat(mesh): apply known remote tenant deltas instead of just logging

### DIFF
--- a/model_gateway/src/mesh/adapters/tree_sync.rs
+++ b/model_gateway/src/mesh/adapters/tree_sync.rs
@@ -1,17 +1,16 @@
 //! `td:` stream adapter: gateway ↔ mesh bridge for the distributed
-//! prefix tree. Scope so far: tenant-delta fast path, inbound
-//! hash resolution via [`TreeHandle`], and repair-request issuance
-//! on unknown hashes via [`PeerList`].
+//! prefix tree.
 //!
 //! - Outbound: `on_local_insert` buffers per-model `TreeDelta`s;
 //!   the drain callback batches each model into one
 //!   `td:{model_id}` stream entry per gossip round.
 //! - Inbound: a spawned task subscribes to `td:`, decodes each
-//!   batch, and asks the [`TreeHandle`] whether each delta's hash
-//!   is locally known. Known → trace (apply sink lands next
-//!   slice). Unknown → publish a `tree:req:` repair request
+//!   batch, and hands every delta to [`TreeHandle`] which either
+//!   applies it (the matched prefix is already known locally and
+//!   the worker becomes a tenant of that node) or returns false.
+//!   On false, the adapter publishes a `tree:req:` repair request
 //!   targeted at a random ALIVE peer; the response (`tree:page:`)
-//!   is consumed in the next slice.
+//!   is consumed in a later slice.
 //!
 //! The adapter holds no tree-membership state. The tree owner
 //! (`CacheAwarePolicy` in production) implements [`TreeHandle`];
@@ -290,18 +289,19 @@ impl TreeSyncAdapter {
             "remote tenant-delta batch received"
         );
         for delta in &batch {
-            if self
-                .tree
-                .contains_hash(model_id, delta.tree_kind, delta.node_hash)
-            {
-                // Known locally; actual apply sink lands next slice.
+            if self.tree.apply_known_remote_insert(
+                model_id,
+                delta.tree_kind,
+                delta.node_hash,
+                &delta.worker_url,
+            ) {
                 trace!(
                     model_id,
                     kind = ?delta.tree_kind,
                     hash = delta.node_hash,
                     worker_url = %delta.worker_url,
                     epoch = delta.epoch,
-                    "resolved remote tenant delta against local tree handle",
+                    "applied remote tenant delta against local tree",
                 );
             } else {
                 debug!(
@@ -421,27 +421,48 @@ mod tests {
         }
     }
 
-    /// Test-only [`TreeHandle`]: keyed by `(model_id, TreeKind)`
-    /// with a set of known hashes.
+    /// Test-only [`TreeHandle`]: a set of known `(model, kind,
+    /// hash)` tuples plus a log of every applied call so tests
+    /// can assert on apply-side effects. Apply succeeds (returns
+    /// `true`) iff the hash is in the known set.
     #[derive(Debug, Default)]
     struct MockTreeHandle {
-        known: DashMap<(String, TreeKind), DashMap<u64, ()>>,
+        known: DashMap<(String, TreeKind, u64), ()>,
+        applied: parking_lot::Mutex<Vec<(String, TreeKind, u64, String)>>,
     }
 
     impl MockTreeHandle {
-        fn insert(&self, model_id: &str, tree_kind: TreeKind, node_hash: u64) {
+        fn mark_known(&self, model_id: &str, tree_kind: TreeKind, node_hash: u64) {
             self.known
-                .entry((model_id.to_string(), tree_kind))
-                .or_default()
-                .insert(node_hash, ());
+                .insert((model_id.to_string(), tree_kind, node_hash), ());
+        }
+
+        fn applied_calls(&self) -> Vec<(String, TreeKind, u64, String)> {
+            self.applied.lock().clone()
         }
     }
 
     impl TreeHandle for MockTreeHandle {
-        fn contains_hash(&self, model_id: &str, tree_kind: TreeKind, node_hash: u64) -> bool {
-            self.known
-                .get(&(model_id.to_string(), tree_kind))
-                .is_some_and(|entry| entry.contains_key(&node_hash))
+        fn apply_known_remote_insert(
+            &self,
+            model_id: &str,
+            tree_kind: TreeKind,
+            node_hash: u64,
+            worker_url: &str,
+        ) -> bool {
+            if !self
+                .known
+                .contains_key(&(model_id.to_string(), tree_kind, node_hash))
+            {
+                return false;
+            }
+            self.applied.lock().push((
+                model_id.to_string(),
+                tree_kind,
+                node_hash,
+                worker_url.to_string(),
+            ));
+            true
         }
     }
 
@@ -600,15 +621,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn handle_incoming_batch_consults_tree() {
-        // Deltas must be classified via the injected handle; kinds
-        // must not alias (same hash, different kind ≠ match).
-        // `handle_incoming_batch` is read-only on membership.
+    async fn handle_incoming_batch_applies_known_and_skips_unknown() {
+        // Known deltas hit `apply_known_remote_insert`; unknown
+        // ones don't (and trigger repair, exercised in dedicated
+        // tests below). Kinds must not alias: same hash on a
+        // different `TreeKind` is a different (model, kind, hash)
+        // tuple and stays unknown.
         let mesh = MeshKV::new("node-a".into());
         let td = td_namespace(&mesh);
         let req = req_namespace(&mesh);
         let tree = Arc::new(MockTreeHandle::default());
-        tree.insert("model-1", TreeKind::String, 42);
+        tree.mark_known("model-1", TreeKind::String, 42);
         let adapter_tree: Arc<dyn TreeHandle> = tree.clone();
         let peers: Arc<dyn PeerList> = MockPeerList::with(&["node-b"]);
         let adapter = TreeSyncAdapter::new(td, req, adapter_tree, peers, "node-a".into());
@@ -636,9 +659,17 @@ mod tests {
         let bytes = Bytes::from(bincode::serialize(&batch).unwrap());
         adapter.handle_incoming_batch("model-1", &[bytes]);
 
-        assert!(tree.contains_hash("model-1", TreeKind::String, 42));
-        assert!(!tree.contains_hash("model-1", TreeKind::String, 99));
-        assert!(!tree.contains_hash("model-1", TreeKind::Token, 42));
+        let applied = tree.applied_calls();
+        assert_eq!(
+            applied,
+            vec![(
+                "model-1".to_string(),
+                TreeKind::String,
+                42,
+                "http://w1".to_string(),
+            )],
+            "only the (String, 42) delta applied; unknown String:99 and Token:42 did not",
+        );
     }
 
     #[tokio::test]
@@ -848,7 +879,7 @@ mod tests {
         let td = td_namespace(&mesh);
         let req = req_namespace(&mesh);
         let tree = Arc::new(MockTreeHandle::default());
-        tree.insert("model-1", TreeKind::String, 42);
+        tree.mark_known("model-1", TreeKind::String, 42);
         let adapter_tree: Arc<dyn TreeHandle> = tree.clone();
         let peers: Arc<dyn PeerList> = MockPeerList::with(&["node-b"]);
         let adapter = TreeSyncAdapter::new(td, req, adapter_tree, peers, "node-a".into());

--- a/model_gateway/src/policies/cache_aware.rs
+++ b/model_gateway/src/policies/cache_aware.rs
@@ -749,8 +749,18 @@ impl TreeHandle for CacheAwarePolicy {
                     return false;
                 };
                 let Some(tree) = self.string_trees.get(model_id) else {
-                    // Hash index entry without a tree is a
-                    // populate-site bug; nothing to apply against.
+                    // Hash index entry without a corresponding
+                    // tree means a populate site mutated
+                    // `hash_index` without creating the tree
+                    // (or eviction dropped the tree but left the
+                    // index). Returning false here masks the
+                    // invariant violation as a spurious repair
+                    // request, so log loudly.
+                    warn!(
+                        model_id,
+                        node_hash,
+                        "string hash_index entry without matching string_trees entry; populate-site invariant violated",
+                    );
                     return false;
                 };
                 tree.insert_text(path.value(), worker_url);
@@ -761,6 +771,11 @@ impl TreeHandle for CacheAwarePolicy {
                     return false;
                 };
                 let Some(tree) = self.token_trees.get(model_id) else {
+                    warn!(
+                        model_id,
+                        node_hash,
+                        "token hash_index entry without matching token_trees entry; populate-site invariant violated",
+                    );
                     return false;
                 };
                 tree.insert_tokens(tokens.value(), worker_url);

--- a/model_gateway/src/policies/cache_aware.rs
+++ b/model_gateway/src/policies/cache_aware.rs
@@ -1515,6 +1515,75 @@ mod tests {
     }
 
     #[test]
+    fn test_apply_known_remote_insert_from_request_hot_path() {
+        // Companion to `test_apply_known_remote_insert_round_trip`.
+        // That test seeds via `apply_remote_tree_operation`, which
+        // stores full text/tokens. The local request hot path
+        // (`select_worker_with_text` / `_with_tokens` plus the
+        // imbalanced fallback) stores the *matched prefix* shape
+        // instead. A regression on the matched-prefix apply path
+        // would still pass the full-path test, so seed via
+        // `select_worker` here and assert apply succeeds.
+        let policy = CacheAwarePolicy::with_config(CacheAwareConfig {
+            eviction_interval_secs: 0,
+            ..Default::default()
+        });
+        let workers: Vec<Arc<dyn Worker>> = vec![
+            Arc::new(
+                BasicWorkerBuilder::new("http://w1:8000")
+                    .worker_type(WorkerType::Regular)
+                    .health_config(no_health_check())
+                    .build(),
+            ),
+            Arc::new(
+                BasicWorkerBuilder::new("http://w2:8000")
+                    .worker_type(WorkerType::Regular)
+                    .health_config(no_health_check())
+                    .build(),
+            ),
+        ];
+        policy.init_workers(&workers);
+
+        // Drive a string request through select_worker — populates
+        // the string-side hash_index with a matched-prefix value.
+        let text = "the quick brown fox jumps over the lazy dog";
+        policy
+            .select_worker(
+                &workers,
+                &SelectWorkerInfo {
+                    request_text: Some(text),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        let text_hash = smg_mesh::hash_node_path(text);
+
+        // Drive a token request — populates the token-side
+        // hash_index. select_worker uses the model_id from the
+        // first worker's `model_id()`, which the builder leaves
+        // empty → UNKNOWN_MODEL_ID after normalization.
+        let tokens: Vec<u32> = (0..32).collect();
+        policy
+            .select_worker(
+                &workers,
+                &SelectWorkerInfo {
+                    tokens: Some(&tokens),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        let token_hash = smg_mesh::hash_token_path(&tokens);
+
+        // Both populate sites use UNKNOWN_MODEL_ID for these
+        // workers (no model_id set on the builder), and the
+        // resolver normalizes empty → UNKNOWN_MODEL_ID, so an
+        // empty model_id resolves the same entries the populate
+        // sites wrote.
+        assert!(policy.apply_known_remote_insert("", TreeKind::String, text_hash, "http://remote",));
+        assert!(policy.apply_known_remote_insert("", TreeKind::Token, token_hash, "http://remote",));
+    }
+
+    #[test]
     fn test_cache_aware_multi_node_consistency() {
         use std::sync::Arc;
 

--- a/model_gateway/src/policies/cache_aware.rs
+++ b/model_gateway/src/policies/cache_aware.rs
@@ -367,13 +367,13 @@ impl CacheAwarePolicy {
     /// Apply a tree insert and populate the model-scoped hash
     /// index alongside it. Remote-replay paths
     /// (`apply_remote_tree_operation`, `restore_tree_state_from_mesh`)
-    /// funnel here, so `TreeHandle::contains_hash` reflects nodes
-    /// learned from gossip — not just locally-routed inserts.
-    /// Without this, replayed prefixes would be misclassified as
-    /// unknown and trigger unnecessary repair once the adapter is
-    /// wired up. The string-side value is the full `text` (not a
-    /// matched prefix) because remote apply doesn't compute a
-    /// match; `apply_tenant_delta` re-inserts whatever string is
+    /// funnel here, so `TreeHandle::apply_known_remote_insert`
+    /// can find these nodes when a peer broadcasts a delta that
+    /// references them. Without this, replayed prefixes would be
+    /// misclassified as unknown and trigger unnecessary repair.
+    /// The string-side value is the full `text` (not a matched
+    /// prefix) because remote apply doesn't compute a match;
+    /// `apply_known_remote_insert` re-inserts whatever string is
     /// stored.
     fn apply_insert_to_trees(
         &self,
@@ -704,25 +704,69 @@ pub enum TreeKind {
     Token,
 }
 
-/// Read-only handle the policy exposes so mesh-adjacent consumers
-/// can answer "is this hash known locally?" without reaching into
-/// private fields. Defined here (not in the adapter) to keep the
-/// dependency direction `adapter → policy`.
+/// Handle the policy exposes so mesh-adjacent consumers can apply
+/// remote tenant inserts against the local tree without reaching
+/// into private fields. Defined here (not in the adapter) to keep
+/// the dependency direction `adapter → policy`.
 pub trait TreeHandle: Send + Sync + std::fmt::Debug {
-    fn contains_hash(&self, model_id: &str, tree_kind: TreeKind, node_hash: u64) -> bool;
+    /// If `node_hash` is known locally (resolvable to a stored
+    /// matched-prefix), record `worker_url` as a tenant of the
+    /// matched node and return `true`. Returns `false` if the
+    /// hash isn't known — the caller is expected to request
+    /// repair so the path can be reconstructed from a peer.
+    ///
+    /// This subsumes "is the hash known?" plus "apply the
+    /// insert": the adapter doesn't need separate read+write
+    /// trips, and we never expose the matched value across the
+    /// trait boundary (it stays inside the policy where
+    /// eviction owns its lifecycle).
+    fn apply_known_remote_insert(
+        &self,
+        model_id: &str,
+        tree_kind: TreeKind,
+        node_hash: u64,
+        worker_url: &str,
+    ) -> bool;
 }
 
 impl TreeHandle for CacheAwarePolicy {
-    fn contains_hash(&self, model_id: &str, tree_kind: TreeKind, node_hash: u64) -> bool {
+    fn apply_known_remote_insert(
+        &self,
+        model_id: &str,
+        tree_kind: TreeKind,
+        node_hash: u64,
+        worker_url: &str,
+    ) -> bool {
         // Normalize empty → UNKNOWN_MODEL_ID so lookups match the
         // key shape every populate site already uses.
         let model_id = normalize_model_key(model_id);
-        self.hash_index
-            .get(model_id)
-            .is_some_and(|entry| match tree_kind {
-                TreeKind::String => entry.string_tree.contains_key(&node_hash),
-                TreeKind::Token => entry.token_tree.contains_key(&node_hash),
-            })
+        let Some(model_entry) = self.hash_index.get(model_id) else {
+            return false;
+        };
+        match tree_kind {
+            TreeKind::String => {
+                let Some(path) = model_entry.string_tree.get(&node_hash) else {
+                    return false;
+                };
+                let Some(tree) = self.string_trees.get(model_id) else {
+                    // Hash index entry without a tree is a
+                    // populate-site bug; nothing to apply against.
+                    return false;
+                };
+                tree.insert_text(path.value(), worker_url);
+                true
+            }
+            TreeKind::Token => {
+                let Some(tokens) = model_entry.token_tree.get(&node_hash) else {
+                    return false;
+                };
+                let Some(tree) = self.token_trees.get(model_id) else {
+                    return false;
+                };
+                tree.insert_tokens(tokens.value(), worker_url);
+                true
+            }
+        }
     }
 }
 
@@ -1380,6 +1424,79 @@ mod tests {
 
         let tree = policy.token_trees.get("model1");
         assert!(tree.is_some());
+    }
+
+    #[test]
+    fn test_apply_known_remote_insert_round_trip() {
+        // Populate via apply_remote_tree_operation (which goes
+        // through apply_insert_to_trees and seeds hash_index for
+        // both kinds), then verify apply_known_remote_insert
+        // resolves the hash and returns true. Unknown hashes
+        // return false. Wrong-kind lookups against the same
+        // hash return false (model + kind scope the index).
+        use smg_mesh::{TreeInsertOp, TreeKey, TreeOperation};
+
+        let config = CacheAwareConfig {
+            eviction_interval_secs: 0,
+            ..Default::default()
+        };
+        let policy = CacheAwarePolicy::with_config(config);
+
+        let text = "remote_text";
+        let tokens = vec![1u32, 2, 3, 4];
+        policy.apply_remote_tree_operation(
+            "model1",
+            &TreeOperation::Insert(TreeInsertOp {
+                key: TreeKey::Text(text.to_string()),
+                tenant: "http://w1".to_string(),
+            }),
+        );
+        policy.apply_remote_tree_operation(
+            "model1",
+            &TreeOperation::Insert(TreeInsertOp {
+                key: TreeKey::Tokens(tokens.clone()),
+                tenant: "http://w1".to_string(),
+            }),
+        );
+
+        let text_hash = smg_mesh::hash_node_path(text);
+        let token_hash = smg_mesh::hash_token_path(&tokens);
+
+        // Known hashes apply for the matching kind.
+        assert!(policy.apply_known_remote_insert(
+            "model1",
+            TreeKind::String,
+            text_hash,
+            "http://w2",
+        ));
+        assert!(policy.apply_known_remote_insert(
+            "model1",
+            TreeKind::Token,
+            token_hash,
+            "http://w2",
+        ));
+
+        // Same hash but wrong kind doesn't alias.
+        assert!(!policy.apply_known_remote_insert(
+            "model1",
+            TreeKind::Token,
+            text_hash,
+            "http://w2",
+        ));
+
+        // Unknown hash, unknown model → false.
+        assert!(!policy.apply_known_remote_insert(
+            "model1",
+            TreeKind::String,
+            0xDEAD_BEEF,
+            "http://w2",
+        ));
+        assert!(!policy.apply_known_remote_insert(
+            "unknown_model",
+            TreeKind::String,
+            text_hash,
+            "http://w2",
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Description

### Problem

After #1444 the inbound `td:` subscription routes deltas through `TreeHandle::contains_hash`: known hashes log at `trace!`, unknown hashes trigger a `tree:req:` repair. But the known branch never actually mutates the local tree. With the adapter scheduled to be wired into `server.rs` next, that gap would mean cluster deltas resolve correctly but the receiver's tree never gains the remote tenant — defeating the whole point of mesh sync.

### Solution

Reshape `TreeHandle`: drop `contains_hash` (which only ever answered the routing decision) and replace with one method that does the full thing.

```rust
fn apply_known_remote_insert(
    &self,
    model_id: &str,
    tree_kind: TreeKind,
    node_hash: u64,
    worker_url: &str,
) -> bool;
```

Returns `true` on apply, `false` on unknown. The adapter's existing slice-c repair trigger keys off the `false` return. The matched value (the stored prefix or token sequence) never escapes the trait, which keeps eviction's lifecycle ownership inside `CacheAwarePolicy`.

`CacheAwarePolicy`'s impl walks the model-scoped `hash_index`, fetches the matched prefix (string) or full tokens (token), and calls `string_tree.insert_text` / `token_tree.insert_tokens` under `worker_url`. The string-side matched-prefix comes from the existing `select_worker` populate sites; remote-replay populate (#1364's `apply_insert_to_trees`) stores the full text/tokens — both shapes are re-insertable correctly.

## Changes

- `model_gateway/src/policies/cache_aware.rs`:
  - `TreeHandle::contains_hash` → `TreeHandle::apply_known_remote_insert`.
  - Real impl on `CacheAwarePolicy` doing the model-scoped lookup + tree mutation.
  - Updated the `apply_insert_to_trees` doc to reference the new method name.
- `model_gateway/src/mesh/adapters/tree_sync.rs`:
  - Inbound subscription's known branch now calls `apply_known_remote_insert`.
  - Module doc updated to describe apply (not just classify).
- Tests:
  - `MockTreeHandle` gains an `applied_calls()` log so adapter tests can assert which deltas were applied vs ignored.
  - New `test_apply_known_remote_insert_round_trip` on the policy exercises the real impl end-to-end (known/unknown/wrong-kind/unknown-model).
  - Existing `handle_incoming_batch_consults_tree` rewritten as `handle_incoming_batch_applies_known_and_skips_unknown` with applied-call assertions.

### Not in this PR

Reserved for the rest of the wiring sequence:

**Slice d-2 (next)** — repair roundtrip:
- `tree:req:` subscriber + `iter_repair_pages` walkers (string + token).
- `tree:page:` subscriber + `apply_repair_page`.
- Session lifecycle (re-introduces `RepairProgress` with real readers — page matching, timeout retry).

**Slice d-3** — server wiring:
- `mesh_v2_enabled` flag + adapter construction.
- Cold-start fan-out (`request_repair_for_all_local_models`).
- Connecting `CacheAwarePolicy::sync_insert_*` to `adapter.on_local_insert`.

## Test Plan

- `cargo test -p smg --lib` — 735 tests pass.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean.
- New unit test on `CacheAwarePolicy::apply_known_remote_insert` covers known/unknown/wrong-kind/unknown-model paths, both `String` and `Token` kinds, and confirms model + kind scope the index correctly.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More efficient tree synchronization: verified remote updates are applied directly, reducing redundant checks and improving update throughput.
  * Robustness: unknown or mismatched hashes still trigger repair requests and warnings to preserve data consistency.

* **Tests**
  * Updated test coverage for the new apply-path and edge cases (known vs unknown/mismatched entries).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->