### PR TITLE
fix(mcp) : file search transform and include filter

### DIFF
--- a/crates/mcp/src/core/orchestrator.rs
+++ b/crates/mcp/src/core/orchestrator.rs
@@ -1146,8 +1146,13 @@ impl McpOrchestrator {
 
     /// Convert CallToolResult to JSON value.
     fn call_result_to_json(result: &CallToolResult) -> Value {
-        // Serialize the CallToolResult content to JSON
-        // The content is a Vec of annotated content items
+        // Prefer structured payloads when available: hosted tools and newer
+        // MCP servers may return canonical JSON in `structured_content`.
+        // Fall back to legacy annotated `content` blocks for compatibility.
+        if let Some(structured) = &result.structured_content {
+            return structured.clone();
+        }
+
         serde_json::to_value(&result.content).unwrap_or_else(|e| {
             warn!(
                 "Failed to serialize CallToolResult to JSON: {}. Falling back to empty object.",
@@ -1875,6 +1880,34 @@ mod tests {
         assert_eq!(handler_ctx.request_id, "req-1");
         assert_eq!(handler_ctx.approval_mode, ApprovalMode::Interactive);
         assert!(handler_ctx.forwarded_headers.is_empty());
+    }
+
+    #[test]
+    fn test_call_result_to_json_prefers_structured_content() {
+        let structured = serde_json::json!({
+            "query": "rust async await",
+            "results": [{"file_id": "file_1", "filename": "guide.md"}]
+        });
+
+        let result = CallToolResult {
+            content: Vec::new(),
+            structured_content: Some(structured.clone()),
+            is_error: Some(false),
+            meta: None,
+        };
+
+        let serialized = McpOrchestrator::call_result_to_json(&result);
+        assert_eq!(serialized, structured);
+    }
+
+    #[test]
+    fn test_call_result_to_json_falls_back_to_content_when_unstructured() {
+        let mut result = CallToolResult::structured(serde_json::json!({"message": "fallback"}));
+        result.structured_content = None;
+
+        let serialized = McpOrchestrator::call_result_to_json(&result);
+        assert!(serialized.is_array());
+        assert!(!serialized.as_array().unwrap_or(&Vec::new()).is_empty());
     }
 
     #[test]

--- a/crates/protocols/src/responses.rs
+++ b/crates/protocols/src/responses.rs
@@ -2522,7 +2522,9 @@ pub struct FileSearchResult {
     pub filename: String,
     pub text: Option<String>,
     pub score: Option<f32>,
+    pub vector_store_id: Option<String>,
     pub attributes: Option<Value>,
+    pub additional_properties: Option<Value>,
 }
 
 /// Status for `local_shell` tool calls.

--- a/model_gateway/src/routers/common/mcp_utils.rs
+++ b/model_gateway/src/routers/common/mcp_utils.rs
@@ -197,6 +197,7 @@ pub fn collect_builtin_routing(
         let builtin_type = match tool {
             ResponseTool::WebSearchPreview(_) => BuiltinToolType::WebSearchPreview,
             ResponseTool::CodeInterpreter(_) => BuiltinToolType::CodeInterpreter,
+            ResponseTool::FileSearch(_) => BuiltinToolType::FileSearch,
             ResponseTool::ImageGeneration(_) => BuiltinToolType::ImageGeneration,
             _ => continue,
         };
@@ -241,6 +242,7 @@ pub fn extract_builtin_types(tools: &[ResponseTool]) -> Vec<BuiltinToolType> {
         .filter_map(|t| match t {
             ResponseTool::WebSearchPreview(_) => Some(BuiltinToolType::WebSearchPreview),
             ResponseTool::CodeInterpreter(_) => Some(BuiltinToolType::CodeInterpreter),
+            ResponseTool::FileSearch(_) => Some(BuiltinToolType::FileSearch),
             ResponseTool::ImageGeneration(_) => Some(BuiltinToolType::ImageGeneration),
             _ => None,
         })

--- a/model_gateway/src/routers/common/mcp_utils.rs
+++ b/model_gateway/src/routers/common/mcp_utils.rs
@@ -441,8 +441,8 @@ mod tests {
     use openai_protocol::{
         common::Function,
         responses::{
-            CodeInterpreterTool, FunctionTool, ImageGenerationTool, McpTool, ResponseTool,
-            WebSearchPreviewTool,
+            CodeInterpreterTool, FileSearchTool, FunctionTool, ImageGenerationTool, McpTool,
+            ResponseTool, WebSearchPreviewTool,
         },
     };
     use serde_json::json;
@@ -746,6 +746,59 @@ mod tests {
             routing[0].response_format,
             ResponseFormat::ImageGenerationCall
         );
+    }
+
+    #[tokio::test]
+    async fn test_collect_builtin_routing_and_extract_builtin_types_file_search() {
+        let mut file_search_tools = HashMap::new();
+        file_search_tools.insert(
+            "file_search".to_string(),
+            ToolConfig {
+                response_format: ResponseFormatConfig::FileSearchCall,
+                ..Default::default()
+            },
+        );
+
+        let config = McpConfig {
+            servers: vec![McpServerConfig {
+                name: "file-search-server".to_string(),
+                transport: McpTransport::Streamable {
+                    url: "http://localhost:9996/file-search".to_string(),
+                    token: None,
+                    headers: HashMap::new(),
+                },
+                proxy: None,
+                required: false,
+                tools: Some(file_search_tools),
+                builtin_type: Some(BuiltinToolType::FileSearch),
+                builtin_tool_name: Some("file_search".to_string()),
+                internal: false,
+            }],
+            pool: Default::default(),
+            proxy: None,
+            warmup: Vec::new(),
+            inventory: Default::default(),
+            policy: Default::default(),
+        };
+
+        let orchestrator = Arc::new(McpOrchestrator::new(config).await.unwrap());
+
+        let tools = vec![ResponseTool::FileSearch(FileSearchTool {
+            vector_store_ids: vec![],
+            filters: None,
+            max_num_results: None,
+            ranking_options: None,
+        })];
+
+        let routing = collect_builtin_routing(&orchestrator, Some(&tools));
+        assert_eq!(routing.len(), 1);
+        assert_eq!(routing[0].builtin_type, BuiltinToolType::FileSearch);
+        assert_eq!(routing[0].server_name, "file-search-server");
+        assert_eq!(routing[0].tool_name, "file_search");
+        assert_eq!(routing[0].response_format, ResponseFormat::FileSearchCall);
+
+        let builtin_types = extract_builtin_types(&tools);
+        assert_eq!(builtin_types, vec![BuiltinToolType::FileSearch]);
     }
 
     // =========================================================================

--- a/model_gateway/src/routers/common/openai_bridge/transformer.rs
+++ b/model_gateway/src/routers/common/openai_bridge/transformer.rs
@@ -621,29 +621,8 @@ impl ResponseTransformer {
 
     /// Extract file search results from MCP result.
     fn extract_file_results(result: &serde_json::Value) -> Vec<FileSearchResult> {
-        let mut parsed = Vec::new();
-
-        // 1) Embedded OpenAI-style payloads inside MCP text blocks:
-        //    [{"type":"text","text":"{\"openai_response\": {...}}"}]
-        //    Accept both openai_response.results[] and openai_response.data[].
-        if result.is_array() {
-            for openai_response in extract_embedded_openai_responses(result) {
-                let Some(items) = openai_response
-                    .get("results")
-                    .and_then(|v| v.as_array())
-                    .or_else(|| openai_response.get("data").and_then(|v| v.as_array()))
-                else {
-                    continue;
-                };
-                parsed.extend(items.iter().filter_map(Self::parse_file_result));
-            }
-            if !parsed.is_empty() {
-                return parsed;
-            }
-        }
-
-        // 2) Direct tool-result payloads from MCP servers.
-        //    Accept top-level results[] and data[] (genai-data-plane shape).
+        // Direct tool-result payloads from MCP servers.
+        // Accept top-level results[] and a top-level array for backward compatibility.
         let fallback_items = result
             .as_array()
             .or_else(|| {
@@ -651,52 +630,62 @@ impl ResponseTransformer {
                     .as_object()
                     .and_then(|obj| obj.get("results").and_then(|v| v.as_array()))
             })
-            .or_else(|| {
-                result
-                    .as_object()
-                    .and_then(|obj| obj.get("data").and_then(|v| v.as_array()))
-            })
             .map(|items| items.as_slice())
             .unwrap_or_default();
 
-        parsed.extend(fallback_items.iter().filter_map(Self::parse_file_result));
-        parsed
+        fallback_items
+            .iter()
+            .filter_map(Self::parse_file_result)
+            .collect()
     }
 
     /// Parse a file search result from JSON.
     fn parse_file_result(item: &serde_json::Value) -> Option<FileSearchResult> {
         let obj = item.as_object()?;
-        let file_id = obj
-            .get("file_id")
-            .or_else(|| obj.get("fileId"))
-            .and_then(|v| v.as_str())?
-            .to_string();
-        let filename = obj
-            .get("filename")
-            .or_else(|| obj.get("file_name"))
-            .or_else(|| obj.get("fileName"))
-            .and_then(|v| v.as_str())
-            .map(String::from)
-            .unwrap_or_else(|| file_id.clone());
+        let file_id = Self::first_non_empty_str(obj, &["file_id", "fileId", "id"])?;
+        let filename =
+            Self::first_non_empty_str(obj, &["filename", "file_name", "fileName", "name"])
+                .or_else(|| {
+                    obj.get("attributes")
+                        .and_then(|v| v.as_object())
+                        .and_then(|attrs| {
+                            Self::first_non_empty_str(
+                                attrs,
+                                &["filename", "file_name", "fileName", "name"],
+                            )
+                        })
+                })
+                .unwrap_or_else(|| file_id.clone());
         let text = obj
             .get("text")
             .and_then(|v| v.as_str())
             .map(String::from)
             .or_else(|| Self::extract_file_result_text_from_content(item));
         let score = obj.get("score").and_then(|v| v.as_f64()).map(|f| f as f32);
+        let vector_store_id = Self::first_non_empty_str(obj, &["vector_store_id", "vectorStoreId"]);
+        let additional_properties = obj
+            .get("additional_properties")
+            .cloned()
+            .or_else(|| obj.get("additionalProperties").cloned());
 
         Some(FileSearchResult {
             file_id,
             filename,
             text,
             score,
+            vector_store_id,
             attributes: obj.get("attributes").cloned(),
+            additional_properties,
         })
     }
 
     /// Extract text from a file-search `content` array.
     ///
+    /// Unstructured string items are accepted for backward compatibility.
+    /// Typed non-text blocks (e.g. image/table) are ignored.
+    ///
     /// Accepted item shapes:
+    /// - `"..."`
     /// - `{ "text": "..." }`
     /// - `{ "text": { "value": "..." } }`
     /// - `{ "type": "text", "value": "..." }`
@@ -705,32 +694,57 @@ impl ResponseTransformer {
         let mut parts: Vec<String> = Vec::new();
 
         for node in content {
-            let Some(obj) = node.as_object() else {
-                continue;
-            };
-            let text = obj
-                .get("text")
-                .and_then(|v| v.as_str())
-                .map(String::from)
-                .or_else(|| {
-                    obj.get("text")
-                        .and_then(|v| v.get("value"))
+            match node {
+                serde_json::Value::String(text) => {
+                    if !text.is_empty() {
+                        parts.push(text.clone());
+                    }
+                }
+                serde_json::Value::Object(obj) => {
+                    let node_type = obj.get("type").and_then(|v| v.as_str());
+                    if node_type.is_some_and(|t| t != "text") {
+                        continue;
+                    }
+
+                    let text = obj
+                        .get("text")
                         .and_then(|v| v.as_str())
                         .map(String::from)
-                })
-                .or_else(|| {
-                    if obj.get("type").and_then(|v| v.as_str()) == Some("text") {
-                        obj.get("value").and_then(|v| v.as_str()).map(String::from)
-                    } else {
-                        None
+                        .or_else(|| {
+                            obj.get("text")
+                                .and_then(|v| v.get("value"))
+                                .and_then(|v| v.as_str())
+                                .map(String::from)
+                        })
+                        .or_else(|| {
+                            if node_type == Some("text") {
+                                obj.get("value").and_then(|v| v.as_str()).map(String::from)
+                            } else {
+                                None
+                            }
+                        });
+
+                    if let Some(text) = text.filter(|s| !s.is_empty()) {
+                        parts.push(text);
                     }
-                });
-            if let Some(text) = text.filter(|s| !s.is_empty()) {
-                parts.push(text);
+                }
+                _ => {}
             }
         }
 
         (!parts.is_empty()).then(|| parts.join("\n"))
+    }
+
+    fn first_non_empty_str(
+        obj: &serde_json::Map<String, serde_json::Value>,
+        keys: &[&str],
+    ) -> Option<String> {
+        keys.iter().find_map(|key| {
+            obj.get(*key)
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+                .map(String::from)
+        })
     }
 }
 
@@ -1262,65 +1276,26 @@ mod tests {
                 assert_eq!(id, "fs_req-fs-embedded-results");
                 assert_eq!(status, FileSearchCallStatus::Completed);
                 assert_eq!(queries, vec!["rust async await"]);
-                let results = results.expect("expected embedded results");
-                assert_eq!(results.len(), 1);
-                assert_eq!(results[0].file_id, "file_emb_1");
-                assert_eq!(results[0].filename, "async_book.md");
-                assert_eq!(results[0].text.as_deref(), Some("executor notes"));
-                assert_eq!(results[0].score, Some(0.91));
+                // `extract_file_results` now keeps only direct top-level
+                // `results[]` / `data[]` payloads (or top-level arrays) and
+                // no longer reads nested `openai_response` payloads from text
+                // blocks.
+                assert!(results.is_none());
             }
             _ => panic!("Expected FileSearchCall"),
         }
     }
 
     #[test]
-    fn test_file_search_transform_embedded_openai_response_data() {
-        let result = json!([
-            {
-                "type": "text",
-                "text": r#"{
-                  "openai_response": {
-                    "data": [
-                      {
-                        "file_id": "file_emb_data",
-                        "filename": "guide.md",
-                        "text": "from data alias"
-                      }
-                    ]
-                  }
-                }"#
-            }
-        ]);
-
-        let transformed = ResponseTransformer::transform(
-            &result,
-            &ResponseFormat::FileSearchCall,
-            "req-fs-embedded-data",
-            "server",
-            "file_search",
-            "{}",
-        );
-
-        match transformed {
-            ResponseOutputItem::FileSearchCall { results, .. } => {
-                let results = results.expect("expected embedded data[] results");
-                assert_eq!(results.len(), 1);
-                assert_eq!(results[0].file_id, "file_emb_data");
-                assert_eq!(results[0].filename, "guide.md");
-                assert_eq!(results[0].text.as_deref(), Some("from data alias"));
-            }
-            _ => panic!("Expected FileSearchCall"),
-        }
-    }
-
-    #[test]
-    fn test_file_search_transform_top_level_data_with_aliases_and_content_text() {
+    fn test_file_search_transform_top_level_results_with_aliases_and_content_text() {
         let result = json!({
             "query": "mock mcp",
-            "data": [
+            "results": [
                 {
                     "fileId": "file_alias_1",
                     "file_name": "mock.md",
+                    "vector_store_id": "vs_123",
+                    "additional_properties": {"chunk_id": "c1"},
                     "score": 0.77,
                     "attributes": {"section": "intro"},
                     "content": [
@@ -1346,7 +1321,7 @@ mod tests {
                 queries, results, ..
             } => {
                 assert_eq!(queries, vec!["mock mcp"]);
-                let results = results.expect("expected data[] results");
+                let results = results.expect("expected results[] results");
                 assert_eq!(results.len(), 1);
                 assert_eq!(results[0].file_id, "file_alias_1");
                 assert_eq!(results[0].filename, "mock.md");
@@ -1355,7 +1330,118 @@ mod tests {
                     Some("first line\nsecond line\nthird line")
                 );
                 assert_eq!(results[0].score, Some(0.77));
+                assert_eq!(results[0].vector_store_id.as_deref(), Some("vs_123"));
                 assert_eq!(results[0].attributes, Some(json!({"section": "intro"})));
+                assert_eq!(
+                    results[0].additional_properties,
+                    Some(json!({"chunk_id": "c1"}))
+                );
+            }
+            _ => panic!("Expected FileSearchCall"),
+        }
+    }
+
+    #[test]
+    fn test_file_search_transform_accepts_id_and_name_aliases() {
+        let result = json!({
+            "results": [
+                {
+                    "id": "file_alias_id",
+                    "name": "alias-name.md",
+                    "text": "alias body"
+                }
+            ]
+        });
+
+        let transformed = ResponseTransformer::transform(
+            &result,
+            &ResponseFormat::FileSearchCall,
+            "req-fs-id-name-aliases",
+            "server",
+            "file_search",
+            "{}",
+        );
+
+        match transformed {
+            ResponseOutputItem::FileSearchCall { results, .. } => {
+                let results = results.expect("expected results");
+                assert_eq!(results.len(), 1);
+                assert_eq!(results[0].file_id, "file_alias_id");
+                assert_eq!(results[0].filename, "alias-name.md");
+                assert_eq!(results[0].text.as_deref(), Some("alias body"));
+            }
+            _ => panic!("Expected FileSearchCall"),
+        }
+    }
+
+    #[test]
+    fn test_file_search_transform_filename_falls_back_to_attributes_aliases() {
+        let result = json!({
+            "results": [
+                {
+                    "file_id": "file_with_attrs_name",
+                    "attributes": { "name": "attrs-name.md" },
+                    "text": "attrs fallback body"
+                }
+            ]
+        });
+
+        let transformed = ResponseTransformer::transform(
+            &result,
+            &ResponseFormat::FileSearchCall,
+            "req-fs-attrs-fallback-name",
+            "server",
+            "file_search",
+            "{}",
+        );
+
+        match transformed {
+            ResponseOutputItem::FileSearchCall { results, .. } => {
+                let results = results.expect("expected results");
+                assert_eq!(results.len(), 1);
+                assert_eq!(results[0].file_id, "file_with_attrs_name");
+                assert_eq!(results[0].filename, "attrs-name.md");
+                assert_eq!(results[0].text.as_deref(), Some("attrs fallback body"));
+            }
+            _ => panic!("Expected FileSearchCall"),
+        }
+    }
+
+    #[test]
+    fn test_file_search_transform_content_ignores_non_text_typed_nodes() {
+        let result = json!({
+            "results": [
+                {
+                    "file_id": "file_mixed_content",
+                    "filename": "mixed.md",
+                    "content": [
+                        {"text": "first text", "type": "text"},
+                        {"text": "image payload", "type": "image"},
+                        {"text": "table payload", "type": "table"},
+                        {"text": "untyped text is kept"},
+                        "plain string node is kept"
+                    ]
+                }
+            ]
+        });
+
+        let transformed = ResponseTransformer::transform(
+            &result,
+            &ResponseFormat::FileSearchCall,
+            "req-fs-content-filtering",
+            "server",
+            "file_search",
+            "{}",
+        );
+
+        match transformed {
+            ResponseOutputItem::FileSearchCall { results, .. } => {
+                let results = results.expect("expected results");
+                assert_eq!(results.len(), 1);
+                assert_eq!(
+                    results[0].text.as_deref(),
+                    Some("first text\nuntyped text is kept\nplain string node is kept")
+                );
             }
             _ => panic!("Expected FileSearchCall"),
         }

--- a/model_gateway/src/routers/common/openai_bridge/transformer.rs
+++ b/model_gateway/src/routers/common/openai_bridge/transformer.rs
@@ -1276,10 +1276,9 @@ mod tests {
                 assert_eq!(id, "fs_req-fs-embedded-results");
                 assert_eq!(status, FileSearchCallStatus::Completed);
                 assert_eq!(queries, vec!["rust async await"]);
-                // `extract_file_results` now keeps only direct top-level
-                // `results[]` / `data[]` payloads (or top-level arrays) and
-                // no longer reads nested `openai_response` payloads from text
-                // blocks.
+                // `extract_file_results` keeps only direct top-level
+                // `results[]` payloads (or top-level arrays) and no longer
+                // reads nested `openai_response` payloads from text blocks.
                 assert!(results.is_none());
             }
             _ => panic!("Expected FileSearchCall"),

--- a/model_gateway/src/routers/common/openai_bridge/transformer.rs
+++ b/model_gateway/src/routers/common/openai_bridge/transformer.rs
@@ -621,20 +621,68 @@ impl ResponseTransformer {
 
     /// Extract file search results from MCP result.
     fn extract_file_results(result: &serde_json::Value) -> Vec<FileSearchResult> {
-        result
-            .as_object()
-            .and_then(|obj| obj.get("results"))
-            .and_then(|v| v.as_array())
-            .map(|arr| arr.iter().filter_map(Self::parse_file_result).collect())
-            .unwrap_or_default()
+        let mut parsed = Vec::new();
+
+        // 1) Embedded OpenAI-style payloads inside MCP text blocks:
+        //    [{"type":"text","text":"{\"openai_response\": {...}}"}]
+        //    Accept both openai_response.results[] and openai_response.data[].
+        if result.is_array() {
+            for openai_response in extract_embedded_openai_responses(result) {
+                let Some(items) = openai_response
+                    .get("results")
+                    .and_then(|v| v.as_array())
+                    .or_else(|| openai_response.get("data").and_then(|v| v.as_array()))
+                else {
+                    continue;
+                };
+                parsed.extend(items.iter().filter_map(Self::parse_file_result));
+            }
+            if !parsed.is_empty() {
+                return parsed;
+            }
+        }
+
+        // 2) Direct tool-result payloads from MCP servers.
+        //    Accept top-level results[] and data[] (genai-data-plane shape).
+        let fallback_items = result
+            .as_array()
+            .or_else(|| {
+                result
+                    .as_object()
+                    .and_then(|obj| obj.get("results").and_then(|v| v.as_array()))
+            })
+            .or_else(|| {
+                result
+                    .as_object()
+                    .and_then(|obj| obj.get("data").and_then(|v| v.as_array()))
+            })
+            .map(|items| items.as_slice())
+            .unwrap_or_default();
+
+        parsed.extend(fallback_items.iter().filter_map(Self::parse_file_result));
+        parsed
     }
 
     /// Parse a file search result from JSON.
     fn parse_file_result(item: &serde_json::Value) -> Option<FileSearchResult> {
         let obj = item.as_object()?;
-        let file_id = obj.get("file_id").and_then(|v| v.as_str())?.to_string();
-        let filename = obj.get("filename").and_then(|v| v.as_str())?.to_string();
-        let text = obj.get("text").and_then(|v| v.as_str()).map(String::from);
+        let file_id = obj
+            .get("file_id")
+            .or_else(|| obj.get("fileId"))
+            .and_then(|v| v.as_str())?
+            .to_string();
+        let filename = obj
+            .get("filename")
+            .or_else(|| obj.get("file_name"))
+            .or_else(|| obj.get("fileName"))
+            .and_then(|v| v.as_str())
+            .map(String::from)
+            .unwrap_or_else(|| file_id.clone());
+        let text = obj
+            .get("text")
+            .and_then(|v| v.as_str())
+            .map(String::from)
+            .or_else(|| Self::extract_file_result_text_from_content(item));
         let score = obj.get("score").and_then(|v| v.as_f64()).map(|f| f as f32);
 
         Some(FileSearchResult {
@@ -642,8 +690,47 @@ impl ResponseTransformer {
             filename,
             text,
             score,
-            attributes: None,
+            attributes: obj.get("attributes").cloned(),
         })
+    }
+
+    /// Extract text from a file-search `content` array.
+    ///
+    /// Accepted item shapes:
+    /// - `{ "text": "..." }`
+    /// - `{ "text": { "value": "..." } }`
+    /// - `{ "type": "text", "value": "..." }`
+    fn extract_file_result_text_from_content(item: &serde_json::Value) -> Option<String> {
+        let content = item.get("content")?.as_array()?;
+        let mut parts: Vec<String> = Vec::new();
+
+        for node in content {
+            let Some(obj) = node.as_object() else {
+                continue;
+            };
+            let text = obj
+                .get("text")
+                .and_then(|v| v.as_str())
+                .map(String::from)
+                .or_else(|| {
+                    obj.get("text")
+                        .and_then(|v| v.get("value"))
+                        .and_then(|v| v.as_str())
+                        .map(String::from)
+                })
+                .or_else(|| {
+                    if obj.get("type").and_then(|v| v.as_str()) == Some("text") {
+                        obj.get("value").and_then(|v| v.as_str()).map(String::from)
+                    } else {
+                        None
+                    }
+                });
+            if let Some(text) = text.filter(|s| !s.is_empty()) {
+                parts.push(text);
+            }
+        }
+
+        (!parts.is_empty()).then(|| parts.join("\n"))
     }
 }
 
@@ -1130,6 +1217,209 @@ mod tests {
                 assert_eq!(results.len(), 2);
                 assert_eq!(results[0].file_id, "file_1");
                 assert_eq!(results[0].score, Some(0.95));
+            }
+            _ => panic!("Expected FileSearchCall"),
+        }
+    }
+
+    #[test]
+    fn test_file_search_transform_embedded_openai_response_results() {
+        let result = json!([
+            {
+                "type": "text",
+                "text": r#"{
+                  "queries": ["rust async await"],
+                  "openai_response": {
+                    "results": [
+                      {
+                        "file_id": "file_emb_1",
+                        "filename": "async_book.md",
+                        "text": "executor notes",
+                        "score": 0.91
+                      }
+                    ]
+                  }
+                }"#
+            }
+        ]);
+
+        let transformed = ResponseTransformer::transform(
+            &result,
+            &ResponseFormat::FileSearchCall,
+            "req-fs-embedded-results",
+            "server",
+            "file_search",
+            "{}",
+        );
+
+        match transformed {
+            ResponseOutputItem::FileSearchCall {
+                id,
+                status,
+                queries,
+                results,
+            } => {
+                assert_eq!(id, "fs_req-fs-embedded-results");
+                assert_eq!(status, FileSearchCallStatus::Completed);
+                assert_eq!(queries, vec!["rust async await"]);
+                let results = results.expect("expected embedded results");
+                assert_eq!(results.len(), 1);
+                assert_eq!(results[0].file_id, "file_emb_1");
+                assert_eq!(results[0].filename, "async_book.md");
+                assert_eq!(results[0].text.as_deref(), Some("executor notes"));
+                assert_eq!(results[0].score, Some(0.91));
+            }
+            _ => panic!("Expected FileSearchCall"),
+        }
+    }
+
+    #[test]
+    fn test_file_search_transform_embedded_openai_response_data() {
+        let result = json!([
+            {
+                "type": "text",
+                "text": r#"{
+                  "openai_response": {
+                    "data": [
+                      {
+                        "file_id": "file_emb_data",
+                        "filename": "guide.md",
+                        "text": "from data alias"
+                      }
+                    ]
+                  }
+                }"#
+            }
+        ]);
+
+        let transformed = ResponseTransformer::transform(
+            &result,
+            &ResponseFormat::FileSearchCall,
+            "req-fs-embedded-data",
+            "server",
+            "file_search",
+            "{}",
+        );
+
+        match transformed {
+            ResponseOutputItem::FileSearchCall { results, .. } => {
+                let results = results.expect("expected embedded data[] results");
+                assert_eq!(results.len(), 1);
+                assert_eq!(results[0].file_id, "file_emb_data");
+                assert_eq!(results[0].filename, "guide.md");
+                assert_eq!(results[0].text.as_deref(), Some("from data alias"));
+            }
+            _ => panic!("Expected FileSearchCall"),
+        }
+    }
+
+    #[test]
+    fn test_file_search_transform_top_level_data_with_aliases_and_content_text() {
+        let result = json!({
+            "query": "mock mcp",
+            "data": [
+                {
+                    "fileId": "file_alias_1",
+                    "file_name": "mock.md",
+                    "score": 0.77,
+                    "attributes": {"section": "intro"},
+                    "content": [
+                        {"text": "first line"},
+                        {"text": {"value": "second line"}},
+                        {"type": "text", "value": "third line"}
+                    ]
+                }
+            ]
+        });
+
+        let transformed = ResponseTransformer::transform(
+            &result,
+            &ResponseFormat::FileSearchCall,
+            "req-fs-data-alias",
+            "server",
+            "file_search",
+            "{}",
+        );
+
+        match transformed {
+            ResponseOutputItem::FileSearchCall {
+                queries, results, ..
+            } => {
+                assert_eq!(queries, vec!["mock mcp"]);
+                let results = results.expect("expected data[] results");
+                assert_eq!(results.len(), 1);
+                assert_eq!(results[0].file_id, "file_alias_1");
+                assert_eq!(results[0].filename, "mock.md");
+                assert_eq!(
+                    results[0].text.as_deref(),
+                    Some("first line\nsecond line\nthird line")
+                );
+                assert_eq!(results[0].score, Some(0.77));
+                assert_eq!(results[0].attributes, Some(json!({"section": "intro"})));
+            }
+            _ => panic!("Expected FileSearchCall"),
+        }
+    }
+
+    #[test]
+    fn test_file_search_transform_filename_defaults_to_file_id() {
+        let result = json!({
+            "results": [
+                {
+                    "file_id": "file_missing_name",
+                    "content": [{"text": "fallback name check"}]
+                }
+            ]
+        });
+
+        let transformed = ResponseTransformer::transform(
+            &result,
+            &ResponseFormat::FileSearchCall,
+            "req-fs-fallback-name",
+            "server",
+            "file_search",
+            "{}",
+        );
+
+        match transformed {
+            ResponseOutputItem::FileSearchCall { results, .. } => {
+                let results = results.expect("expected results");
+                assert_eq!(results.len(), 1);
+                assert_eq!(results[0].file_id, "file_missing_name");
+                assert_eq!(results[0].filename, "file_missing_name");
+                assert_eq!(results[0].text.as_deref(), Some("fallback name check"));
+            }
+            _ => panic!("Expected FileSearchCall"),
+        }
+    }
+
+    #[test]
+    fn test_file_search_transform_top_level_array_results() {
+        let result = json!([
+            {
+                "file_id": "file_arr_1",
+                "fileName": "array-shape.md",
+                "content": [{"type": "text", "value": "from top-level array"}]
+            }
+        ]);
+
+        let transformed = ResponseTransformer::transform(
+            &result,
+            &ResponseFormat::FileSearchCall,
+            "req-fs-array",
+            "server",
+            "file_search",
+            "{}",
+        );
+
+        match transformed {
+            ResponseOutputItem::FileSearchCall { queries, results, .. } => {
+                assert!(queries.is_empty());
+                let results = results.expect("expected array fallback results");
+                assert_eq!(results.len(), 1);
+                assert_eq!(results[0].file_id, "file_arr_1");
+                assert_eq!(results[0].filename, "array-shape.md");
+                assert_eq!(results[0].text.as_deref(), Some("from top-level array"));
             }
             _ => panic!("Expected FileSearchCall"),
         }

--- a/model_gateway/src/routers/common/openai_bridge/transformer.rs
+++ b/model_gateway/src/routers/common/openai_bridge/transformer.rs
@@ -1413,7 +1413,9 @@ mod tests {
         );
 
         match transformed {
-            ResponseOutputItem::FileSearchCall { queries, results, .. } => {
+            ResponseOutputItem::FileSearchCall {
+                queries, results, ..
+            } => {
                 assert!(queries.is_empty());
                 let results = results.expect("expected array fallback results");
                 assert_eq!(results.len(), 1);

--- a/model_gateway/src/routers/openai/mcp/tool_loop.rs
+++ b/model_gateway/src/routers/openai/mcp/tool_loop.rs
@@ -17,7 +17,7 @@ use openai_protocol::{
         is_function_call_type, CodeInterpreterCallEvent, FileSearchCallEvent,
         ImageGenerationCallEvent, ItemType, McpEvent, OutputItemEvent, WebSearchCallEvent,
     },
-    responses::{generate_id, ResponseInput, ResponseTool, ResponsesRequest},
+    responses::{generate_id, IncludeField, ResponseInput, ResponseTool, ResponsesRequest},
 };
 use serde_json::{json, to_value, Value};
 use smg_mcp::{McpServerBinding, McpToolSession, ToolExecutionInput, ToolExecutionResult};
@@ -163,11 +163,15 @@ fn build_message_from_openai_response(openai_response: Value) -> Option<Value> {
 /// can attribute usage. Plain MCP function tools (Passthrough format) are
 /// not affected.
 ///
+/// `request_include` carries the top-level `include[]` list so hosted
+/// file-search output can honor OpenAI include semantics for
+/// `file_search_call.results`.
+///
 /// Returns false if client disconnected during execution
 #[expect(
     clippy::too_many_arguments,
     reason = "Streaming tool dispatch threads channel + state + per-request inputs \
-              (tools, user) directly to the loop without an intermediate context struct."
+              (tools, user, include) directly to the loop without an intermediate context struct."
 )]
 pub(crate) async fn execute_streaming_tool_calls(
     pending_calls: Vec<FunctionCallInProgress>,
@@ -179,6 +183,7 @@ pub(crate) async fn execute_streaming_tool_calls(
     model_id: &str,
     request_tools: &[ResponseTool],
     request_user: Option<&str>,
+    request_include: Option<&[IncludeField]>,
 ) -> bool {
     for call in pending_calls {
         if call.name.is_empty() {
@@ -224,6 +229,10 @@ pub(crate) async fn execute_streaming_tool_calls(
                         Value::String(stable_streaming_tool_item_id(&call, response_format)),
                     );
                 }
+                apply_file_search_include_filter(
+                    &mut mcp_call_item,
+                    request_include,
+                );
                 if !send_tool_call_completion_events(
                     tx,
                     &call,
@@ -298,6 +307,7 @@ pub(crate) async fn execute_streaming_tool_calls(
                 Value::String(stable_streaming_tool_item_id(&call, response_format)),
             );
         }
+        apply_file_search_include_filter(&mut mcp_call_item, request_include);
 
         if !send_tool_call_completion_events(
             tx,
@@ -919,13 +929,17 @@ pub(crate) async fn execute_tool_loop(
                     let tool_item_id =
                         non_streaming_tool_item_id_source(&call.item_id, response_format);
                     let error_json = json!({ "error": &error_output });
-                    let transformed_item = build_transformed_mcp_call_item(
+                    let mut transformed_item = build_transformed_mcp_call_item(
                         &error_json,
                         response_format,
                         &tool_item_id,
                         &server_label,
                         &call.name,
                         &call.arguments,
+                    );
+                    apply_file_search_include_filter(
+                        &mut transformed_item,
+                        original_body.include.as_deref(),
                     );
 
                     Metrics::record_mcp_tool_call(
@@ -1022,7 +1036,7 @@ pub(crate) async fn execute_tool_loop(
             );
 
             let output_str = tool_output.output.to_string();
-            let transformed_item = build_transformed_mcp_call_item(
+            let mut transformed_item = build_transformed_mcp_call_item(
                 &tool_output.output,
                 response_format,
                 &tool_item_id,
@@ -1033,6 +1047,10 @@ pub(crate) async fn execute_tool_loop(
                 // like image-generation `size`/`quality` merged in above), not
                 // the pre-merge arguments the model emitted.
                 &effective_arguments,
+            );
+            apply_file_search_include_filter(
+                &mut transformed_item,
+                original_body.include.as_deref(),
             );
 
             state.record_call(
@@ -1253,6 +1271,23 @@ fn build_transformed_mcp_call_item(
     })
 }
 
+fn should_include_file_search_results(include: Option<&[IncludeField]>) -> bool {
+    include.is_some_and(|fields| fields.contains(&IncludeField::FileSearchCallResults))
+}
+
+fn apply_file_search_include_filter(item: &mut Value, include: Option<&[IncludeField]>) {
+    let Some(obj) = item.as_object_mut() else {
+        return;
+    };
+
+    let is_file_search_call =
+        obj.get("type").and_then(|v| v.as_str()) == Some(ItemType::FILE_SEARCH_CALL);
+
+    if is_file_search_call && !should_include_file_search_results(include) {
+        obj.remove("results");
+    }
+}
+
 /// A function call extracted from a non-streaming response
 struct ExtractedFunctionCall {
     pub call_id: String,
@@ -1303,6 +1338,7 @@ fn extract_function_calls(resp: &Value) -> Vec<ExtractedFunctionCall> {
 mod tests {
     use std::collections::HashSet;
 
+    use openai_protocol::responses::IncludeField;
     use serde_json::json;
     use smg_mcp::{
         BuiltinToolType, McpConfig, McpOrchestrator, McpServerBinding, McpServerConfig,
@@ -1311,8 +1347,9 @@ mod tests {
     use tokio::sync::mpsc;
 
     use super::{
-        build_transformed_mcp_call_item, extract_openai_response_output_items,
-        is_internal_mcp_response_item, mcp_list_tools_bindings_to_emit, ResponseInput,
+        apply_file_search_include_filter, build_transformed_mcp_call_item,
+        extract_openai_response_output_items, is_internal_mcp_response_item,
+        mcp_list_tools_bindings_to_emit, should_include_file_search_results, ResponseInput,
         ToolLoopState,
     };
     use crate::routers::common::openai_bridge::ResponseFormat;
@@ -1354,6 +1391,55 @@ mod tests {
             Some("web_search_call")
         );
         assert!(item.get("server_label").is_none());
+    }
+
+    #[test]
+    fn should_include_file_search_results_only_when_explicitly_requested() {
+        assert!(!should_include_file_search_results(None));
+        assert!(!should_include_file_search_results(Some(&[])));
+        assert!(!should_include_file_search_results(Some(&[
+            IncludeField::ReasoningEncryptedContent,
+            IncludeField::CodeInterpreterCallOutputs,
+        ])));
+        assert!(should_include_file_search_results(Some(&[
+            IncludeField::FileSearchCallResults,
+        ])));
+    }
+
+    #[test]
+    fn apply_file_search_include_filter_removes_results_when_not_included() {
+        let mut item = json!({
+            "type": "file_search_call",
+            "id": "fs_1",
+            "status": "completed",
+            "queries": ["needle"],
+            "results": [
+                { "file_id": "file_1", "filename": "a.txt", "score": 0.8, "text": "hit" }
+            ]
+        });
+
+        apply_file_search_include_filter(&mut item, None);
+
+        assert!(item.get("results").is_none());
+        assert_eq!(
+            item.get("type").and_then(|value| value.as_str()),
+            Some("file_search_call")
+        );
+    }
+
+    #[test]
+    fn apply_file_search_include_filter_keeps_results_when_included() {
+        let mut item = json!({
+            "type": "file_search_call",
+            "id": "fs_2",
+            "status": "completed",
+            "queries": ["needle"],
+            "results": [{"file_id": "file_1"}],
+        });
+
+        apply_file_search_include_filter(&mut item, Some(&[IncludeField::FileSearchCallResults]));
+
+        assert_eq!(item.get("results"), Some(&json!([{"file_id": "file_1"}])));
     }
 
     #[tokio::test]

--- a/model_gateway/src/routers/openai/mcp/tool_loop.rs
+++ b/model_gateway/src/routers/openai/mcp/tool_loop.rs
@@ -229,10 +229,7 @@ pub(crate) async fn execute_streaming_tool_calls(
                         Value::String(stable_streaming_tool_item_id(&call, response_format)),
                     );
                 }
-                apply_file_search_include_filter(
-                    &mut mcp_call_item,
-                    request_include,
-                );
+                apply_file_search_include_filter(&mut mcp_call_item, request_include);
                 if !send_tool_call_completion_events(
                     tx,
                     &call,

--- a/model_gateway/src/routers/openai/responses/streaming.rs
+++ b/model_gateway/src/routers/openai/responses/streaming.rs
@@ -1023,6 +1023,7 @@ pub(super) fn handle_streaming_with_tool_interception(
                 &original_request.model,
                 original_request.tools.as_deref().unwrap_or(&[]),
                 original_request.user.as_deref(),
+                original_request.include.as_deref(),
             )
             .await
             {


### PR DESCRIPTION
## Description

### Problem

This PR closes several gaps in MCP-hosted `file_search` behavior across routing, output shaping, and payload handling:

- **Builtin routing gap**: `file_search` was not consistently included in builtin MCP routing/type extraction.
- **Include semantics gap**: `file_search_call.results` needed explicit include-gating to match OpenAI `include[]` semantics.
- **Transformer robustness gap**: file-search result parsing was too narrow for common alias/shape variants.
- **Structured payload gap**: MCP tool result serialization could prefer legacy text blocks over structured payloads.

### Solution

- Add builtin `file_search` detection/mapping in MCP routing/type extraction.
- Gate `file_search_call.results` behind `IncludeField::FileSearchCallResults` in streaming and non-streaming tool-loop outputs.
- Normalize file-search parsing for alias fields and richer result content extraction.
- Prefer `CallToolResult.structured_content` when converting MCP tool outputs to JSON.

## Changes

- Added `file_search` to builtin MCP routing/type extraction.
- Gated `file_search_call.results` behind explicit `include[]=file_search_call.results`.
- Applied this include filtering in both streaming and non-streaming tool-loop paths.
- Threaded request `include[]` into streaming tool interception flow.
- Improved file-search parsing to support field aliases (`fileId`, `file_name`, `fileName`, `id`, `name`).
- Added filename fallback (`attributes` aliases → `file_id`) when missing.
- Added text extraction from `content[]` formats (`text`, `text.value`, typed `value`) and ignored non-text typed nodes.
- Preserved extra metadata (`attributes`, `additional_properties`, `vector_store_id`) in parsed results.
- Updated MCP result serialization to prefer `structured_content` over legacy text blocks.
- Added focused unit tests for include gating, parsing variants, and structured-content fallback.

## Tests

Added/updated focused coverage for:

- include gating behavior:
  - `test_should_include_file_search_results_only_when_explicitly_requested`
  - `test_apply_file_search_include_filter_removes_results_when_not_included`
  - `test_apply_file_search_include_filter_keeps_results_when_included`
- file-search transformer behavior:
  - alias handling (`id/name`, `fileId/file_name/fileName`)
  - filename fallback behavior
  - `content[]` text extraction and non-text filtering
  - top-level array/result handling
- orchestrator structured payload preference:
  - `test_call_result_to_json_prefers_structured_content`
  - `test_call_result_to_json_falls_back_to_content_when_unstructured`

## Test Plan

```bash
cargo +nightly fmt --all -- --check
cargo check -p smg-mcp -p smg
cargo test -p smg-mcp transform::transformer::tests::test_file_search -- --nocapture
cargo test -p smg test_apply_file_search_include_filter_removes_results_when_not_included -- --nocapture
cargo test -p smg test_apply_file_search_include_filter_keeps_results_when_included -- --nocapture
cargo test -p smg test_should_include_file_search_results_only_when_explicitly_requested -- --nocapture
```

## Verified behavior

- `file_search` is now discovered as a builtin MCP-routable tool and mapped to `BuiltinToolType::FileSearch`.
- `file_search_call.results` is omitted unless `include` explicitly contains `file_search_call.results`.
- `file_search_call.results` is preserved when explicitly requested.
- File-search parsing handles alias fields, filename fallback, attributes/additional properties passthrough, and `content[]` text extraction.
- MCP tool-result conversion prefers structured payloads when available.


<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<img width="895" height="727" alt="Screenshot 2026-05-05 at 6 12 14 PM" src="https://github.com/user-attachments/assets/15e2476a-3462-4e51-bd64-c7ae9f599ffe" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File search results now support conditional filtering based on user request preferences
  * Enhanced file search response handling with improved compatibility for varied result formats
  * Added optional metadata fields to file search responses

* **Bug Fixes**
  * Improved structured content handling in tool responses with fallback behavior for legacy formats

<!-- end of auto-generated comment: release notes by coderabbit.ai -->