### PR TITLE
feat(kv-index): iter_entries lazy walker for Tree and TokenTree

### DIFF
--- a/crates/kv_index/src/string_tree.rs
+++ b/crates/kv_index/src/string_tree.rs
@@ -1138,9 +1138,11 @@ pub struct EntriesIter {
 
 struct EntryFrame {
     remaining_children: std::vec::IntoIter<NodeRef>,
-    /// Number of `chars` in this frame's edge text — used to
-    /// truncate the path buffer correctly when popping.
-    edge_char_count: usize,
+    /// Byte length of this frame's edge text — used to truncate
+    /// the path buffer in O(1) when popping. Each descent pushes
+    /// a complete `&str` of this length, so popping the same
+    /// byte count always lands on a UTF-8 char boundary.
+    edge_byte_len: usize,
 }
 
 impl EntriesIter {
@@ -1150,7 +1152,7 @@ impl EntriesIter {
         Self {
             stack: vec![EntryFrame {
                 remaining_children: collect_sorted_children(&tree.root).into_iter(),
-                edge_char_count: 0,
+                edge_byte_len: 0,
             }],
             path: String::new(),
             pending,
@@ -1168,14 +1170,20 @@ impl Iterator for EntriesIter {
         loop {
             let frame = self.stack.last_mut()?;
             if let Some(child) = frame.remaining_children.next() {
-                let edge = child.text.read().as_str().to_string();
-                let edge_char_count = edge.chars().count();
-                self.path.push_str(&edge);
+                // Push the edge directly through the lock guard —
+                // no intermediate clone — and capture its byte
+                // length so we can truncate atomically on pop.
+                let edge_byte_len = {
+                    let guard = child.text.read();
+                    let s = guard.as_str();
+                    self.path.push_str(s);
+                    s.len()
+                };
 
                 let tenants = snapshot_tenants(&child);
                 self.stack.push(EntryFrame {
                     remaining_children: collect_sorted_children(&child).into_iter(),
-                    edge_char_count,
+                    edge_byte_len,
                 });
                 if !tenants.is_empty() {
                     return Some((self.path.clone(), tenants));
@@ -1183,12 +1191,10 @@ impl Iterator for EntriesIter {
                 // Empty tenants → loop continues, descending into
                 // this child's children on the next iteration.
             } else {
-                // No more children at this depth — capture the
-                // edge length before popping so we can truncate
-                // the path back to the parent's level.
-                let edge_char_count = frame.edge_char_count;
+                let edge_byte_len = frame.edge_byte_len;
                 self.stack.pop();
-                truncate_chars_from_end(&mut self.path, edge_char_count);
+                let new_len = self.path.len().saturating_sub(edge_byte_len);
+                self.path.truncate(new_len);
             }
         }
     }
@@ -1212,24 +1218,6 @@ fn collect_sorted_children(node: &NodeRef) -> Vec<NodeRef> {
         .collect();
     children.sort_by_key(|(c, _)| *c);
     children.into_iter().map(|(_, n)| n).collect()
-}
-
-fn truncate_chars_from_end(s: &mut String, n: usize) {
-    if n == 0 {
-        return;
-    }
-    let total = s.chars().count();
-    if n >= total {
-        s.clear();
-        return;
-    }
-    let keep_chars = total - n;
-    let cutoff = s
-        .char_indices()
-        .nth(keep_chars)
-        .map(|(i, _)| i)
-        .unwrap_or(s.len());
-    s.truncate(cutoff);
 }
 
 impl Tree {
@@ -3013,10 +3001,12 @@ mod tests {
     #[test]
     fn test_iter_entries_preserves_utf8_paths() {
         // Multi-byte chars must not produce torn paths when the
-        // walker pops a frame (path is truncated by char count,
-        // not byte count). Also exercises the split-node case
-        // where the shared "你好" prefix node emits with a clean
-        // multi-byte path.
+        // walker pops a frame. Path is truncated by byte length
+        // — safe because each descent pushes a complete `&str`,
+        // so popping the same byte count always lands on a UTF-8
+        // char boundary (`String::truncate` would panic if not).
+        // Also exercises the split-node case where the shared
+        // "你好" prefix node emits with a clean multi-byte path.
         let tree = Tree::new();
         tree.insert_text("你好世界", "w1");
         tree.insert_text("你好朋友", "w2");

--- a/crates/kv_index/src/string_tree.rs
+++ b/crates/kv_index/src/string_tree.rs
@@ -1101,6 +1101,138 @@ impl Tree {
         }
     }
 
+    /// Lazily walk the tree in pre-order, yielding each node's
+    /// `(prefix, [(tenant, epoch)])` pair without materializing
+    /// the full tree as a single buffer. Empty-tenant nodes are
+    /// skipped (they're routing intermediates, not real entries).
+    /// Children are visited in deterministic char-sorted order so
+    /// callers paging the iterator can resume by re-running and
+    /// skipping the first N items if the tree is unchanged.
+    ///
+    /// Like [`Tree::snapshot`], the walk is not atomic — concurrent
+    /// `insert_text` may split or replace nodes mid-walk; the
+    /// iterator may then reflect a mix of pre- and post-split
+    /// state. Acceptable for mesh sync (eventual consistency).
+    pub fn iter_entries(&self) -> EntriesIter {
+        EntriesIter::new(self)
+    }
+}
+
+/// Iterator yielded by [`Tree::iter_entries`]. Owns `Arc<Node>`
+/// clones for the path it's currently inside so it survives
+/// across awaits or any temporary release of `&Tree`.
+pub struct EntriesIter {
+    /// DFS frame stack. The top frame's `remaining_children` is
+    /// the queue of children we still have to visit at the
+    /// current depth. Frames are pushed when descending, popped
+    /// when their children exhaust.
+    stack: Vec<EntryFrame>,
+    /// Mutable accumulated path-from-root. Pushed when descending
+    /// into a child, truncated when popping a frame.
+    path: String,
+    /// Pre-staged emission. Set when a node with tenants is
+    /// entered; consumed by the next `next()` call before
+    /// continuing the walk.
+    pending: Option<(String, Vec<(TenantId, u64)>)>,
+}
+
+struct EntryFrame {
+    remaining_children: std::vec::IntoIter<NodeRef>,
+    /// Number of `chars` in this frame's edge text — used to
+    /// truncate the path buffer correctly when popping.
+    edge_char_count: usize,
+}
+
+impl EntriesIter {
+    fn new(tree: &Tree) -> Self {
+        let root_tenants = snapshot_tenants(&tree.root);
+        let pending = (!root_tenants.is_empty()).then(|| (String::new(), root_tenants));
+        Self {
+            stack: vec![EntryFrame {
+                remaining_children: collect_sorted_children(&tree.root).into_iter(),
+                edge_char_count: 0,
+            }],
+            path: String::new(),
+            pending,
+        }
+    }
+}
+
+impl Iterator for EntriesIter {
+    type Item = (String, Vec<(TenantId, u64)>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(entry) = self.pending.take() {
+            return Some(entry);
+        }
+        loop {
+            let frame = self.stack.last_mut()?;
+            if let Some(child) = frame.remaining_children.next() {
+                let edge = child.text.read().as_str().to_string();
+                let edge_char_count = edge.chars().count();
+                self.path.push_str(&edge);
+
+                let tenants = snapshot_tenants(&child);
+                self.stack.push(EntryFrame {
+                    remaining_children: collect_sorted_children(&child).into_iter(),
+                    edge_char_count,
+                });
+                if !tenants.is_empty() {
+                    return Some((self.path.clone(), tenants));
+                }
+                // Empty tenants → loop continues, descending into
+                // this child's children on the next iteration.
+            } else {
+                // No more children at this depth — capture the
+                // edge length before popping so we can truncate
+                // the path back to the parent's level.
+                let edge_char_count = frame.edge_char_count;
+                self.stack.pop();
+                truncate_chars_from_end(&mut self.path, edge_char_count);
+            }
+        }
+    }
+}
+
+fn snapshot_tenants(node: &NodeRef) -> Vec<(TenantId, u64)> {
+    let mut tenants: Vec<(TenantId, u64)> = node
+        .tenant_last_access_time
+        .iter()
+        .map(|entry| (Arc::clone(entry.key()), *entry.value()))
+        .collect();
+    tenants.sort_by(|a, b| a.0.cmp(&b.0));
+    tenants
+}
+
+fn collect_sorted_children(node: &NodeRef) -> Vec<NodeRef> {
+    let mut children: Vec<(char, NodeRef)> = node
+        .children
+        .iter()
+        .map(|entry| (*entry.key(), entry.value().clone()))
+        .collect();
+    children.sort_by_key(|(c, _)| *c);
+    children.into_iter().map(|(_, n)| n).collect()
+}
+
+fn truncate_chars_from_end(s: &mut String, n: usize) {
+    if n == 0 {
+        return;
+    }
+    let total = s.chars().count();
+    if n >= total {
+        s.clear();
+        return;
+    }
+    let keep_chars = total - n;
+    let cutoff = s
+        .char_indices()
+        .nth(keep_chars)
+        .map(|(i, _)| i)
+        .unwrap_or(s.len());
+    s.truncate(cutoff);
+}
+
+impl Tree {
     /// Reconstruct a tree from a snapshot.
     ///
     /// The snapshot must be in pre-order (parent before children) with
@@ -2808,5 +2940,89 @@ mod tests {
         let r2 = tree1.match_prefix_with_counts("Hello there");
         assert_eq!(r2.matched_char_count, 11);
         assert_eq!(r2.tenant.as_ref(), "worker-2");
+    }
+
+    #[test]
+    fn test_iter_entries_empty_tree() {
+        let tree = Tree::new();
+        let entries: Vec<_> = tree.iter_entries().collect();
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn test_iter_entries_single_insert() {
+        let tree = Tree::new();
+        tree.insert_text("hello", "worker-1");
+        let entries: Vec<_> = tree
+            .iter_entries()
+            .map(|(p, ts)| (p, ts.into_iter().map(|(t, _)| t).collect::<Vec<_>>()))
+            .collect();
+        // Worker registration would also tag root with the tenant,
+        // but we only call insert_text. Root has no tenants here;
+        // the leaf "hello" carries `worker-1`.
+        let leaf = entries
+            .iter()
+            .find(|(p, _)| p == "hello")
+            .expect("leaf with tenants");
+        assert_eq!(leaf.1.len(), 1);
+        assert_eq!(leaf.1[0].as_ref(), "worker-1");
+    }
+
+    #[test]
+    fn test_iter_entries_pre_order_and_split_nodes() {
+        // Two inserts that share a prefix produce a split node.
+        // The radix tree registers tenants at root and copies the
+        // tenant map to intermediate split nodes, so every level
+        // along the shared path emits an entry. Pre-order means
+        // "" before "Hello " before its leaves; deterministic
+        // char order gives "Hello there" before "Hello world"
+        // (t < w).
+        let tree = Tree::new();
+        tree.insert_text("Hello world", "w1");
+        tree.insert_text("Hello there", "w2");
+
+        let paths: Vec<String> = tree.iter_entries().map(|(p, _)| p).collect();
+        assert_eq!(paths, vec!["", "Hello ", "Hello there", "Hello world"],);
+    }
+
+    #[test]
+    fn test_iter_entries_round_trips_via_snapshot() {
+        // The walker yields the same `(path, tenants)` set that
+        // building a tree from a snapshot would round-trip.
+        let tree = Tree::new();
+        tree.insert_text("alpha", "w1");
+        tree.insert_text("alpha-beta", "w2");
+        tree.insert_text("zulu", "w3");
+
+        let mut from_iter: Vec<(String, Vec<String>)> = tree
+            .iter_entries()
+            .map(|(p, ts)| (p, ts.into_iter().map(|(t, _)| t.to_string()).collect()))
+            .collect();
+        from_iter.sort();
+
+        let restored = Tree::from_snapshot(&tree.snapshot());
+        let mut from_restored: Vec<(String, Vec<String>)> = restored
+            .iter_entries()
+            .map(|(p, ts)| (p, ts.into_iter().map(|(t, _)| t.to_string()).collect()))
+            .collect();
+        from_restored.sort();
+
+        assert_eq!(from_iter, from_restored);
+    }
+
+    #[test]
+    fn test_iter_entries_preserves_utf8_paths() {
+        // Multi-byte chars must not produce torn paths when the
+        // walker pops a frame (path is truncated by char count,
+        // not byte count). Also exercises the split-node case
+        // where the shared "你好" prefix node emits with a clean
+        // multi-byte path.
+        let tree = Tree::new();
+        tree.insert_text("你好世界", "w1");
+        tree.insert_text("你好朋友", "w2");
+
+        let mut paths: Vec<String> = tree.iter_entries().map(|(p, _)| p).collect();
+        paths.sort();
+        assert_eq!(paths, vec!["", "你好", "你好世界", "你好朋友"]);
     }
 }

--- a/crates/kv_index/src/token_tree.rs
+++ b/crates/kv_index/src/token_tree.rs
@@ -1093,9 +1093,13 @@ impl Iterator for EntriesIter {
         loop {
             let frame = self.stack.last_mut()?;
             if let Some(child) = frame.remaining_children.next() {
-                let edge_tokens = child.tokens.read().clone();
-                let edge_token_count = edge_tokens.len();
-                self.path.extend_from_slice(&edge_tokens);
+                // Extend the path directly through the lock guard
+                // — no intermediate Vec<TokenId> clone.
+                let edge_token_count = {
+                    let guard = child.tokens.read();
+                    self.path.extend_from_slice(&guard);
+                    guard.len()
+                };
 
                 let tenants = snapshot_tenants(&child);
                 self.stack.push(EntryFrame {

--- a/crates/kv_index/src/token_tree.rs
+++ b/crates/kv_index/src/token_tree.rs
@@ -1022,6 +1022,121 @@ impl TokenTree {
             self.evict_tenant(&tenant_id, max_size);
         }
     }
+
+    /// Lazily walk the tree in pre-order, yielding each node's
+    /// `(prefix_tokens, [(tenant, epoch)])` pair without
+    /// materializing the full tree as a single buffer.
+    /// Empty-tenant nodes are skipped (they're routing
+    /// intermediates, not real entries). Children are visited in
+    /// lexicographic page-key order so callers paging the
+    /// iterator can resume by re-running and skipping the first
+    /// N items if the tree is unchanged.
+    ///
+    /// The walk is not atomic — concurrent `insert_tokens` may
+    /// split or replace nodes mid-walk; the iterator may then
+    /// reflect a mix of pre- and post-split state. Acceptable
+    /// for mesh sync (eventual consistency).
+    pub fn iter_entries(&self) -> EntriesIter {
+        EntriesIter::new(self)
+    }
+}
+
+/// Iterator yielded by [`TokenTree::iter_entries`]. Owns
+/// `Arc<Node>` clones for the path it's currently inside so it
+/// survives across awaits or temporary releases of `&TokenTree`.
+pub struct EntriesIter {
+    /// DFS frame stack. The top frame's `remaining_children` is
+    /// the queue of children we still have to visit at the
+    /// current depth. Frames are pushed when descending, popped
+    /// when their children exhaust.
+    stack: Vec<EntryFrame>,
+    /// Mutable accumulated path-from-root tokens. Pushed when
+    /// descending into a child, truncated when popping a frame.
+    path: Vec<TokenId>,
+    /// Pre-staged emission. Set when a node with tenants is
+    /// entered; consumed by the next `next()` call before
+    /// continuing the walk.
+    pending: Option<EntryItem>,
+}
+
+type EntryItem = (Vec<TokenId>, Vec<(TenantId, u64)>);
+
+struct EntryFrame {
+    remaining_children: std::vec::IntoIter<NodeRef>,
+    /// Number of tokens contributed by this frame's edge — used
+    /// to truncate the path buffer correctly when popping.
+    edge_token_count: usize,
+}
+
+impl EntriesIter {
+    fn new(tree: &TokenTree) -> Self {
+        let root_tenants = snapshot_tenants(&tree.root);
+        let pending = (!root_tenants.is_empty()).then(|| (Vec::<TokenId>::new(), root_tenants));
+        Self {
+            stack: vec![EntryFrame {
+                remaining_children: collect_sorted_children(&tree.root).into_iter(),
+                edge_token_count: 0,
+            }],
+            path: Vec::new(),
+            pending,
+        }
+    }
+}
+
+impl Iterator for EntriesIter {
+    type Item = EntryItem;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(entry) = self.pending.take() {
+            return Some(entry);
+        }
+        loop {
+            let frame = self.stack.last_mut()?;
+            if let Some(child) = frame.remaining_children.next() {
+                let edge_tokens = child.tokens.read().clone();
+                let edge_token_count = edge_tokens.len();
+                self.path.extend_from_slice(&edge_tokens);
+
+                let tenants = snapshot_tenants(&child);
+                self.stack.push(EntryFrame {
+                    remaining_children: collect_sorted_children(&child).into_iter(),
+                    edge_token_count,
+                });
+                if !tenants.is_empty() {
+                    return Some((self.path.clone(), tenants));
+                }
+                // Empty tenants → loop continues, descending into
+                // this child's children on the next iteration.
+            } else {
+                let edge_token_count = frame.edge_token_count;
+                self.stack.pop();
+                let new_len = self.path.len().saturating_sub(edge_token_count);
+                self.path.truncate(new_len);
+            }
+        }
+    }
+}
+
+fn snapshot_tenants(node: &NodeRef) -> Vec<(TenantId, u64)> {
+    let mut tenants: Vec<(TenantId, u64)> = node
+        .tenant_last_access_time
+        .iter()
+        .map(|entry| (Arc::clone(entry.key()), *entry.value()))
+        .collect();
+    tenants.sort_by(|a, b| a.0.cmp(&b.0));
+    tenants
+}
+
+fn collect_sorted_children(node: &NodeRef) -> Vec<NodeRef> {
+    let mut children: Vec<(TokenPageKey, NodeRef)> = node
+        .children
+        .iter()
+        .map(|entry| (*entry.key(), entry.value().clone()))
+        .collect();
+    // Lexicographic order over the page key — deterministic
+    // traversal across hash-shard layouts.
+    children.sort_by_key(|(k, _)| *k);
+    children.into_iter().map(|(_, n)| n).collect()
 }
 
 impl RadixTree for TokenTree {
@@ -2525,5 +2640,54 @@ mod tests {
     fn test_tree_with_config_invalid_page_size() {
         // Test that invalid page_size panics
         let _tree = TokenTree::with_config(32, EvictionPolicy::Lru);
+    }
+
+    #[test]
+    fn test_iter_entries_empty_tree() {
+        let tree = TokenTree::new();
+        let entries: Vec<_> = tree.iter_entries().collect();
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn test_iter_entries_single_insert() {
+        let tree = TokenTree::new();
+        let tokens: Vec<TokenId> = (0..16).collect();
+        tree.insert_tokens(&tokens, "worker-1");
+
+        let entries: Vec<(Vec<TokenId>, Vec<String>)> = tree
+            .iter_entries()
+            .map(|(p, ts)| (p, ts.into_iter().map(|(t, _)| t.to_string()).collect()))
+            .collect();
+        let leaf = entries
+            .iter()
+            .find(|(p, _)| p == &tokens)
+            .expect("leaf with the inserted tokens");
+        assert_eq!(leaf.1, vec!["worker-1".to_string()]);
+    }
+
+    #[test]
+    fn test_iter_entries_pre_order_lex_sorted() {
+        // Two inserts with a shared prefix produce a split node.
+        // Children sort by `TokenPageKey` lexicographically, so
+        // the smaller-page-key child emits first.
+        let tree = TokenTree::new();
+        let prefix: Vec<TokenId> = (0..16).collect();
+        let mut a: Vec<TokenId> = prefix.clone();
+        a.extend(0..16); // child page = [0..16]
+        let mut b: Vec<TokenId> = prefix.clone();
+        b.extend(100..116); // child page = [100..116]
+        tree.insert_tokens(&a, "wa");
+        tree.insert_tokens(&b, "wb");
+
+        let paths: Vec<Vec<TokenId>> = tree.iter_entries().map(|(p, _)| p).collect();
+        // Order: shared "0..16" parent appears first via wa being
+        // present at index 0 of children; the actual leaves come
+        // through in lex order.
+        assert!(paths.contains(&a));
+        assert!(paths.contains(&b));
+        let pos_a = paths.iter().position(|p| p == &a).unwrap();
+        let pos_b = paths.iter().position(|p| p == &b).unwrap();
+        assert!(pos_a < pos_b, "page-key 0..16 < 100..116");
     }
 }


### PR DESCRIPTION
## Description

### Problem

The mesh repair protocol needs to page `(prefix, tenants)` entries out of a tree without buffering the whole tree into memory at once. Spec §7.1 line 1086 explicitly forbids `snapshot()`-style full materialization on the repair-page path.

The existing `Tree::snapshot()` walks the whole tree recursively into a `Vec<SnapshotNode>` — fine for the v1 anti-entropy code that already uses it, but ruled out for v2 repair pages. `TokenTree` has neither a snapshot nor a walker (per spec §7.1:919's "no token-tree snapshot helpers yet" note).

### Solution

Add iterator-based pre-order walkers on both kinds:

```rust
impl Tree {
    pub fn iter_entries(&self) -> EntriesIter; // yields (String, Vec<(TenantId, u64)>)
}
impl TokenTree {
    pub fn iter_entries(&self) -> EntriesIter; // yields (Vec<TokenId>, Vec<(TenantId, u64)>)
}
```

Both walkers use an explicit DFS stack with a single mutable path buffer — pushed when descending into a child, truncated by char/token count when popping a frame. Children are visited in deterministic order (char-sorted for strings, lex-sorted on `TokenPageKey` for tokens), so callers paging the iterator can resume by re-running and skipping the first N items if the tree hasn't changed. Each iterator owns `Arc<Node>` clones for the path it's currently inside, so it survives across awaits and any temporary release of `&Tree` / `&TokenTree`.

## Changes

- `crates/kv_index/src/string_tree.rs`: `Tree::iter_entries`, `EntriesIter`, supporting helpers (`snapshot_tenants`, `collect_sorted_children`, `truncate_chars_from_end` for UTF-8 path truncation).
- `crates/kv_index/src/token_tree.rs`: `TokenTree::iter_entries`, mirror impl with `Vec<TokenId>` path buffer.
- 8 new unit tests across both files.

## Behaviour notes

Empty-tenant intermediate nodes that nevertheless carry tenants (because the radix tree attaches tenants at root and copies tenant maps onto split-parent nodes during inserts) are emitted faithfully. A receiver applying the yielded entries via `insert_text` / `insert_tokens` reconstructs the same tenant placements that the producer holds. Verified by `test_iter_entries_pre_order_and_split_nodes` and `test_iter_entries_round_trips_via_snapshot`.

Like `Tree::snapshot()`, the walk is not atomic. Concurrent inserts may split nodes mid-walk; the iterator may reflect a mix of pre- and post-split state. That matches the eventual-consistency model mesh sync runs under (and matches the existing `snapshot()` behavior, documented at `string_tree.rs:1061`).

### Not in this PR

- The wire `TreePage` format (with byte-cap accumulation, cursor encoding) is mesh-specific and lives in `model_gateway` — slice d-2b builds it on top of these `iter_entries` primitives.
- `iter_repair_pages` on `TreeHandle`, the responder subscription, and `apply_repair_page` are all slice d-2b / d-2c.

## Test Plan

- `cargo test -p kv-index --lib` — 176 tests pass.
- `cargo clippy -p kv-index --all-targets --all-features -- -D warnings` — clean.
- `cargo test -p smg --lib` — 746 tests pass downstream (no regression from the new API surface).
- New tests cover: empty trees, single insert, split-prefix multi-tenant, UTF-8 multi-byte paths, snapshot round-trip equivalence, lex-sorted token-tree traversal.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added lazy, deterministic pre-order traversal APIs for index trees, yielding prefix paths with tenant + epoch/timestamp metadata, visiting children in sorted order and preserving UTF‑8 path integrity without building full snapshots.

* **Tests**
  * Added unit tests covering empty trees, single inserts, split-node ordering, snapshot round‑trip, and UTF‑8 path correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->