### PR TITLE
refactor(openai-bridge): close last new-builtin coupling leaks (descriptor + connect wrapper)

### DIFF
--- a/model_gateway/src/routers/common/mcp_utils.rs
+++ b/model_gateway/src/routers/common/mcp_utils.rs
@@ -120,9 +120,6 @@ pub async fn connect_mcp_servers(
 
             let server_key = McpOrchestrator::server_key(&server_config);
 
-            // Use the bridge wrapper so the orchestrator + FormatRegistry
-            // can never be left out of sync. See
-            // openai_bridge/connect.rs.
             match openai_bridge::connect_dynamic_server(
                 mcp_orchestrator,
                 format_registry,

--- a/model_gateway/src/routers/common/mcp_utils.rs
+++ b/model_gateway/src/routers/common/mcp_utils.rs
@@ -120,15 +120,17 @@ pub async fn connect_mcp_servers(
 
             let server_key = McpOrchestrator::server_key(&server_config);
 
-            match mcp_orchestrator
-                .connect_dynamic_server(server_config.clone())
-                .await
+            // Use the bridge wrapper so the orchestrator + FormatRegistry
+            // can never be left out of sync. See
+            // openai_bridge/connect.rs.
+            match openai_bridge::connect_dynamic_server(
+                mcp_orchestrator,
+                format_registry,
+                server_config,
+            )
+            .await
             {
                 Ok(_) => {
-                    // Mirror the orchestrator's tool-config + builtin-format passes
-                    // into the gateway-side FormatRegistry. See
-                    // routers/common/openai_bridge/format_registry.rs.
-                    format_registry.populate_from_server_config(&server_config);
                     if !mcp_servers.iter().any(|b| b.server_key == server_key) {
                         mcp_servers.push(McpServerBinding {
                             label: input.label.clone(),

--- a/model_gateway/src/routers/common/openai_bridge/connect.rs
+++ b/model_gateway/src/routers/common/openai_bridge/connect.rs
@@ -1,0 +1,39 @@
+//! Atomic `orchestrator.connect_*` + `registry.populate_*` helpers.
+//!
+//! Use these in place of calling [`McpOrchestrator::connect_static_server`]
+//! / [`McpOrchestrator::connect_dynamic_server`] directly so the
+//! gateway-side [`FormatRegistry`] can never drift out of sync with the
+//! orchestrator's tool inventory.
+//!
+//! Forgetting `populate_from_server_config` after a connect leaves
+//! hosted-tool dispatch silently downgraded to `mcp_call`. The
+//! `lookup_tool_format` debug log added in 283f27f1 fingerprints the bug
+//! at runtime, but a wrapper makes the mistake structurally impossible.
+
+use smg_mcp::{McpOrchestrator, McpResult, McpServerConfig};
+
+use super::FormatRegistry;
+
+/// Connect a static MCP server and mirror its tool-format config into
+/// `registry`.
+pub async fn connect_static_server(
+    orchestrator: &McpOrchestrator,
+    registry: &FormatRegistry,
+    config: &McpServerConfig,
+) -> McpResult<()> {
+    orchestrator.connect_static_server(config).await?;
+    registry.populate_from_server_config(config);
+    Ok(())
+}
+
+/// Connect a dynamic MCP server and mirror its tool-format config into
+/// `registry`. Returns the assigned server key.
+pub async fn connect_dynamic_server(
+    orchestrator: &McpOrchestrator,
+    registry: &FormatRegistry,
+    config: McpServerConfig,
+) -> McpResult<String> {
+    let server_key = orchestrator.connect_dynamic_server(config.clone()).await?;
+    registry.populate_from_server_config(&config);
+    Ok(server_key)
+}

--- a/model_gateway/src/routers/common/openai_bridge/connect.rs
+++ b/model_gateway/src/routers/common/openai_bridge/connect.rs
@@ -14,8 +14,6 @@ use smg_mcp::{McpOrchestrator, McpResult, McpServerConfig};
 
 use super::FormatRegistry;
 
-/// Connect a static MCP server and mirror its tool-format config into
-/// `registry`.
 pub async fn connect_static_server(
     orchestrator: &McpOrchestrator,
     registry: &FormatRegistry,
@@ -26,8 +24,7 @@ pub async fn connect_static_server(
     Ok(())
 }
 
-/// Connect a dynamic MCP server and mirror its tool-format config into
-/// `registry`. Returns the assigned server key.
+/// Returns the assigned server key.
 pub async fn connect_dynamic_server(
     orchestrator: &McpOrchestrator,
     registry: &FormatRegistry,

--- a/model_gateway/src/routers/common/openai_bridge/format_descriptor.rs
+++ b/model_gateway/src/routers/common/openai_bridge/format_descriptor.rs
@@ -44,6 +44,23 @@ pub fn format_from_type_str(type_str: &str) -> Option<ResponseFormat> {
     }
 }
 
+/// True iff `item_type` names a *hosted* tool-call item (web_search_call,
+/// code_interpreter_call, file_search_call, image_generation_call) — i.e.
+/// any item the bridge maps to a non-Passthrough `ResponseFormat`.
+///
+/// `mcp_call` and non-format types (`function_call`, `message`, …) return
+/// false. The streaming router uses this to decide whether the upstream
+/// `output_item.done` for a hosted tool item must be suppressed (the tool
+/// loop emits its own correctly-ordered umbrella).
+///
+/// Sourced from [`format_from_type_str`] + [`ResponseFormat::to_builtin_tool_type`]
+/// so the descriptor table remains the single source of truth — adding a
+/// new hosted format flips this predicate automatically with no router
+/// edit required.
+pub fn is_hosted_tool_call_item_type(item_type: &str) -> bool {
+    format_from_type_str(item_type).is_some_and(|f| f.to_builtin_tool_type().is_some())
+}
+
 pub const fn descriptor(format: ResponseFormat) -> FormatDescriptor {
     match format {
         ResponseFormat::WebSearchCall => FormatDescriptor {

--- a/model_gateway/src/routers/common/openai_bridge/format_descriptor.rs
+++ b/model_gateway/src/routers/common/openai_bridge/format_descriptor.rs
@@ -44,19 +44,7 @@ pub fn format_from_type_str(type_str: &str) -> Option<ResponseFormat> {
     }
 }
 
-/// True iff `item_type` names a *hosted* tool-call item (web_search_call,
-/// code_interpreter_call, file_search_call, image_generation_call) — i.e.
-/// any item the bridge maps to a non-Passthrough `ResponseFormat`.
-///
-/// `mcp_call` and non-format types (`function_call`, `message`, …) return
-/// false. The streaming router uses this to decide whether the upstream
-/// `output_item.done` for a hosted tool item must be suppressed (the tool
-/// loop emits its own correctly-ordered umbrella).
-///
-/// Sourced from [`format_from_type_str`] + [`ResponseFormat::to_builtin_tool_type`]
-/// so the descriptor table remains the single source of truth — adding a
-/// new hosted format flips this predicate automatically with no router
-/// edit required.
+/// True iff `item_type` maps to a non-Passthrough `ResponseFormat`.
 pub fn is_hosted_tool_call_item_type(item_type: &str) -> bool {
     format_from_type_str(item_type).is_some_and(|f| f.to_builtin_tool_type().is_some())
 }

--- a/model_gateway/src/routers/common/openai_bridge/mod.rs
+++ b/model_gateway/src/routers/common/openai_bridge/mod.rs
@@ -3,6 +3,7 @@
 //! Conversion logic between MCP protocol types and OpenAI Responses API
 //! shapes. Gateway-internal — `smg-mcp` does not depend on OpenAI vocabulary.
 
+pub mod connect;
 pub mod format_descriptor;
 pub mod format_registry;
 pub mod overrides;
@@ -10,6 +11,7 @@ pub mod response_format;
 pub mod tool_descriptors;
 pub mod transformer;
 
+pub use connect::{connect_dynamic_server, connect_static_server};
 pub use format_descriptor::{
     descriptor, format_from_type_str, is_hosted_tool_call_item_type, FormatDescriptor,
 };

--- a/model_gateway/src/routers/common/openai_bridge/mod.rs
+++ b/model_gateway/src/routers/common/openai_bridge/mod.rs
@@ -10,7 +10,9 @@ pub mod response_format;
 pub mod tool_descriptors;
 pub mod transformer;
 
-pub use format_descriptor::{descriptor, format_from_type_str, FormatDescriptor};
+pub use format_descriptor::{
+    descriptor, format_from_type_str, is_hosted_tool_call_item_type, FormatDescriptor,
+};
 pub use format_registry::{lookup_tool_format, FormatRegistry};
 pub use overrides::{apply_hosted_tool_overrides, extract_hosted_tool_overrides};
 pub use response_format::ResponseFormat;

--- a/model_gateway/src/routers/openai/mcp/tool_handler.rs
+++ b/model_gateway/src/routers/openai/mcp/tool_handler.rs
@@ -13,18 +13,12 @@ use crate::routers::{
     openai::responses::{extract_output_index, get_event_type, StreamingResponseAccumulator},
 };
 
-/// True for item types whose umbrella `output_item.done` is re-emitted by
-/// the streaming tool loop and therefore must be suppressed when the
-/// upstream forwards its own duplicate (which would land BEFORE the
-/// structured `<type>.completed` sub-event and break the spec invariant
-/// that `output_item.done` is the LAST event for a given item — see
-/// `.claude/_audit/openai-responses-api-spec.md` §streaming).
-///
-/// Covers function-call variants (`function_call`, `function_tool_call`)
-/// and the four hosted tool-call families. `mcp_call` is excluded — those
-/// umbrellas are emitted by the tool loop directly, not forwarded from
-/// upstream. Sourcing the hosted set from `openai_bridge` means a new
-/// hosted format flips this check automatically with no edit here.
+/// True for item types whose upstream `output_item.done` must be suppressed
+/// — the tool loop emits its own umbrella AFTER `<type>.completed` to
+/// satisfy the spec invariant that the umbrella is the LAST event for a
+/// given item (see `.claude/_audit/openai-responses-api-spec.md`
+/// §streaming). `mcp_call` is excluded; that umbrella is synthesized
+/// here, not forwarded.
 fn is_tool_call_item_type(item_type: &str) -> bool {
     is_function_call_type(item_type) || openai_bridge::is_hosted_tool_call_item_type(item_type)
 }

--- a/model_gateway/src/routers/openai/mcp/tool_handler.rs
+++ b/model_gateway/src/routers/openai/mcp/tool_handler.rs
@@ -3,37 +3,30 @@
 use std::collections::{HashMap, HashSet};
 
 use openai_protocol::event_types::{
-    is_function_call_type, FunctionCallEvent, ItemType, OutputItemEvent, ResponseEvent,
+    is_function_call_type, FunctionCallEvent, OutputItemEvent, ResponseEvent,
 };
 use serde_json::Value;
 use tracing::warn;
 
-use crate::routers::openai::responses::{
-    extract_output_index, get_event_type, StreamingResponseAccumulator,
+use crate::routers::{
+    common::openai_bridge,
+    openai::responses::{extract_output_index, get_event_type, StreamingResponseAccumulator},
 };
 
-/// Item-type discriminators for output items that the streaming tool loop
-/// closes with its own `output_item.done` umbrella event. Upstream emits its
-/// own duplicate umbrella before the structured `<type>.completed` sub-event,
-/// which would violate the spec requirement that `output_item.done` is the
-/// LAST event for a given item (see `.claude/_audit/openai-responses-api-spec.md`
-/// §streaming). Whenever an `output_item.done` arrives for one of these types
-/// while a tool call is pending, we suppress the upstream copy and let the
-/// tool loop emit the umbrella at the correct position.
-const TOOL_CALL_ITEM_TYPES: &[&str] = &[
-    ItemType::FUNCTION_CALL,
-    ItemType::FUNCTION_TOOL_CALL,
-    ItemType::IMAGE_GENERATION_CALL,
-    ItemType::WEB_SEARCH_CALL,
-    ItemType::CODE_INTERPRETER_CALL,
-    ItemType::FILE_SEARCH_CALL,
-];
-
-/// Check whether an item-type string designates a tool-call item whose
-/// umbrella `output_item.done` is re-emitted by the tool loop (and therefore
-/// must be suppressed when forwarded by upstream).
+/// True for item types whose umbrella `output_item.done` is re-emitted by
+/// the streaming tool loop and therefore must be suppressed when the
+/// upstream forwards its own duplicate (which would land BEFORE the
+/// structured `<type>.completed` sub-event and break the spec invariant
+/// that `output_item.done` is the LAST event for a given item — see
+/// `.claude/_audit/openai-responses-api-spec.md` §streaming).
+///
+/// Covers function-call variants (`function_call`, `function_tool_call`)
+/// and the four hosted tool-call families. `mcp_call` is excluded — those
+/// umbrellas are emitted by the tool loop directly, not forwarded from
+/// upstream. Sourcing the hosted set from `openai_bridge` means a new
+/// hosted format flips this check automatically with no edit here.
 fn is_tool_call_item_type(item_type: &str) -> bool {
-    TOOL_CALL_ITEM_TYPES.contains(&item_type)
+    is_function_call_type(item_type) || openai_bridge::is_hosted_tool_call_item_type(item_type)
 }
 
 /// Action to take based on streaming event processing
@@ -543,6 +536,8 @@ mod tests {
     //! is the LAST event emitted for a given item (see
     //! `.claude/_audit/openai-responses-api-spec.md` §streaming, events
     //! L1054-L1072).
+
+    use openai_protocol::event_types::ItemType;
 
     use super::*;
 
@@ -1069,5 +1064,39 @@ mod tests {
             "second output_item.done for native passthrough must Forward after the first \
              dropped envelope consumed the passthrough-index entry; got {second_action:?}"
         );
+    }
+
+    #[test]
+    fn is_tool_call_item_type_covers_function_call_and_hosted_builtins() {
+        // Pin the suppression-gate set: function_call variants + hosted
+        // builtins. `mcp_call` is NOT included — those umbrellas are
+        // emitted by the tool loop, not forwarded from upstream.
+        // Adding a new hosted format must flip this set automatically via
+        // openai_bridge::is_hosted_tool_call_item_type — no edit here.
+        for ty in [
+            ItemType::FUNCTION_CALL,
+            ItemType::FUNCTION_TOOL_CALL,
+            ItemType::WEB_SEARCH_CALL,
+            ItemType::CODE_INTERPRETER_CALL,
+            ItemType::FILE_SEARCH_CALL,
+            ItemType::IMAGE_GENERATION_CALL,
+        ] {
+            assert!(
+                is_tool_call_item_type(ty),
+                "{ty} must be classified as a tool-call item type"
+            );
+        }
+        for ty in [
+            ItemType::MCP_CALL,
+            ItemType::MCP_LIST_TOOLS,
+            ItemType::FUNCTION_CALL_OUTPUT,
+            "message",
+            "reasoning",
+        ] {
+            assert!(
+                !is_tool_call_item_type(ty),
+                "{ty} must NOT be classified as a tool-call item type"
+            );
+        }
     }
 }

--- a/model_gateway/src/workflow/mcp_registration.rs
+++ b/model_gateway/src/workflow/mcp_registration.rs
@@ -9,7 +9,9 @@ use wfaas::{
 };
 
 use super::data::McpWorkflowData;
-use crate::{app_context::AppContext, observability::metrics::Metrics};
+use crate::{
+    app_context::AppContext, observability::metrics::Metrics, routers::common::openai_bridge,
+};
 
 /// MCP server connection configuration
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -65,21 +67,24 @@ impl StepExecutor<McpWorkflowData> for ConnectMcpServerStep {
                     message: "MCP orchestrator not initialized".to_string(),
                 })?;
 
-        // Connect to MCP server (orchestrator handles everything)
-        mcp_orchestrator
-            .connect_static_server(&config_request.config)
-            .await
-            .map_err(|e| WorkflowError::StepFailed {
-                step_id: StepId::new("connect_mcp_server"),
-                message: format!(
-                    "Failed to connect to MCP server {}: {}",
-                    config_request.name, e
-                ),
-            })?;
-
-        app_context
-            .mcp_format_registry
-            .populate_from_server_config(&config_request.config);
+        // Connect via the bridge wrapper so the orchestrator's tool inventory
+        // and the gateway-side FormatRegistry move atomically — the bare
+        // `connect_static_server` + `populate_from_server_config` sequence
+        // would silently downgrade hosted-tool dispatch if a future caller
+        // forgot the second call.
+        openai_bridge::connect_static_server(
+            mcp_orchestrator,
+            &app_context.mcp_format_registry,
+            &config_request.config,
+        )
+        .await
+        .map_err(|e| WorkflowError::StepFailed {
+            step_id: StepId::new("connect_mcp_server"),
+            message: format!(
+                "Failed to connect to MCP server {}: {}",
+                config_request.name, e
+            ),
+        })?;
 
         // Update active MCP servers metric
         Metrics::set_mcp_servers_active(mcp_orchestrator.list_servers().len());

--- a/model_gateway/src/workflow/mcp_registration.rs
+++ b/model_gateway/src/workflow/mcp_registration.rs
@@ -67,11 +67,6 @@ impl StepExecutor<McpWorkflowData> for ConnectMcpServerStep {
                     message: "MCP orchestrator not initialized".to_string(),
                 })?;
 
-        // Connect via the bridge wrapper so the orchestrator's tool inventory
-        // and the gateway-side FormatRegistry move atomically — the bare
-        // `connect_static_server` + `populate_from_server_config` sequence
-        // would silently downgrade hosted-tool dispatch if a future caller
-        // forgot the second call.
         openai_bridge::connect_static_server(
             mcp_orchestrator,
             &app_context.mcp_format_registry,


### PR DESCRIPTION
## Summary
- Closes the last two ways adding a built-in tool can drift outside `openai_bridge/`:
  - `tool_handler.rs` no longer hand-maintains `TOOL_CALL_ITEM_TYPES`. The suppression gate now sources its hosted set from `openai_bridge::is_hosted_tool_call_item_type`, which derives from the descriptor table.
  - The `McpOrchestrator::connect_*` + `FormatRegistry::populate_from_server_config` pair is collapsed into one wrapper (`openai_bridge::connect_static_server` / `connect_dynamic_server`) so a future connect path can't silently leave the registry behind.

## Motivation
After PR #1450 merged, two residual leaks were left from the `mcp-refactor` design:

1. **`tool_handler.rs:23` `TOOL_CALL_ITEM_TYPES`** — a hand-maintained list of every item type whose upstream `output_item.done` umbrella the streaming tool loop suppresses. Adding a new hosted family without remembering to update this const lets the upstream's duplicate umbrella slip through ahead of `<type>.completed`, breaking the spec's "umbrella is the LAST event" invariant.
2. **`populate_from_server_config` parity** — connect paths in `mcp_utils.rs` and `workflow/mcp_registration.rs` each had to remember to call `format_registry.populate_from_server_config` after `orchestrator.connect_*`. Forgetting the second call silently downgrades hosted-tool dispatch to `mcp_call`. The 283f27f1 debug log catches it at runtime, but a wrapper makes the bug structurally impossible.

Both were the kind of thing reviewers would not catch — neither is a compile error.

## Changes
- `openai_bridge/format_descriptor.rs` — add `is_hosted_tool_call_item_type` derived from `format_from_type_str`.
- `openai_bridge/connect.rs` — new module with `connect_static_server` + `connect_dynamic_server` wrappers.
- `openai_bridge/mod.rs` — re-exports.
- `openai/mcp/tool_handler.rs` — replace const + helper with the descriptor-derived check; add a regression test pinning the 6 hits + 5 misses.
- `routers/common/mcp_utils.rs` — migrate dynamic-connect site to the wrapper.
- `workflow/mcp_registration.rs` — migrate static-connect site to the wrapper.

## Test plan
- [x] `cargo test -p smg --lib` — 751 passed
- [x] `cargo clippy -p smg --lib --tests -- -D warnings` — clean
- [x] `cargo fmt -p smg` — clean
- [x] New regression test `is_tool_call_item_type_covers_function_call_and_hosted_builtins` locks the 6-item suppression set against silent drift

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Bridge-based MCP server connections now centralize registration updates for more consistent connectivity behavior.
  * Tool-call detection broadened to recognize hosted built-in types alongside function-call types for more accurate request handling.
  * Internal module organization and re-exports clarified to improve maintainability and surface the new bridge helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->