### PR TITLE
fix(grpc-harmony): drop tool-call structural tag on chat/completions path

### DIFF
--- a/model_gateway/src/routers/grpc/harmony/stages/preparation.rs
+++ b/model_gateway/src/routers/grpc/harmony/stages/preparation.rs
@@ -101,27 +101,25 @@ impl HarmonyPreparationStage {
         // Step 1: Filter tools if needed
         let mut body_ref = utils::filter_chat_request_by_tool_choice(request);
 
-        // Step 2: Build structural tag constraint
-        let tool_constraint = if let Some(tools) = body_ref.tools.as_ref() {
-            Self::generate_tool_call_constraint(tools, body_ref.tool_choice.as_ref())
-                .map_err(|e| *e)?
-        } else {
-            None
-        };
+        // Step 2: Build constraint. Skip the tool-call structural tag on the
+        // ChatCompletion Harmony path. Direct gRPC probes confirmed that under
+        // `tool_choice=required` or `tool_choice={type:"function",...}` with a
+        // prompt that conflicts with calling the named tool, vLLM guided
+        // decoding satisfies the structural tag at the byte level by emitting
+        // ASCII text matching the Harmony commentary header into the final
+        // channel — leaking raw control markup like
+        // `<|channel|>commentary to=functions.X<|message|>{...}` into
+        // `message.content` with empty `tool_calls`. Harmony tool descriptions
+        // already advertise the available tools, so leaving the constraint off
+        // matches the HTTP path's behavior. Keep `response_format_constraint`
+        // for the JSON-schema enforcement path; the Responses path is handled
+        // by `prepare_responses` and is not affected by this change.
         let response_format_constraint =
             Self::generate_response_format_constraint(body_ref.response_format.as_ref())
                 .map_err(|e| *e)?;
 
-        // Reject requests that specify both tool call and response_format constraints
-        if tool_constraint.is_some() && response_format_constraint.is_some() {
-            return Err(error::bad_request(
-                "invalid_request_parameters",
-                "Constrained decoding (response_format) is not compatible with tool calls",
-            ));
-        }
-
         let has_response_format_constraint = response_format_constraint.is_some();
-        let constraint = tool_constraint.or(response_format_constraint);
+        let constraint = response_format_constraint;
 
         // If response_format was converted to a structural tag, clear it from the request
         // so the backend builder doesn't also try to add a json_schema constraint from it.


### PR DESCRIPTION
## Description

### Problem

`POST /v1/chat/completions` on the gRPC harmony path with gpt-oss-120b returns HTTP 200 with raw Harmony markup leaked into `message.content` instead of structured `tool_calls`, when:
- `tool_choice: {type: "function", function: {name: "X"}}` (forced specific), OR
- `tool_choice: "required"`

…and the prompt does not naturally lead to a tool call (safety-refusal or off-topic).

Example leaked response:
```
{"choices":[{"message":{"content":"<|channel|>commentary to=functions.calculator<|constrain|>json<|message|>{\"expression\":\"1+1\"}","tool_calls":[]}}]}
```

The customer sees a 200 with garbage content; their `tool_calls` parser finds nothing.

### Root cause

`generate_tool_call_constraint` builds a `structural_tag` with `at_least_one: true` and tags whose `begin` patterns are the literal Harmony commentary headers. Under prompt-tool conflict, vLLM's xgrammar guided decoding satisfies the tag at the byte level by emitting **plain ASCII text** that spells out the markup into the `final` channel — instead of emitting the real `<|channel|>` (200005) / `<|message|>` (200008) special tokens. The Harmony parser correctly captures that text into `final_text`, and `processor.rs:106` puts it in `message.content` with empty `tool_calls`.

`tool_choice: "auto"` is not affected because `preparation.rs:339` returns `None` for the catch-all `ToolChoice::Value(_)` — auto never sends a structural_tag.

### Solution

Skip the tool-call structural tag on the Chat Harmony path entirely. Harmony tool descriptions in the system prompt already advertise tools, so models that want to call a tool emit a real commentary frame and the parser captures it correctly. `response_format_constraint` is preserved for JSON-schema enforcement; the Responses API path (`prepare_responses`) is untouched.

### Tradeoff (documented softening)

`tool_choice: "required"` and `tool_choice: {type: "function", function: {name: "X"}}` lose hard enforcement on the Chat gRPC path — the model may answer in the final channel instead of calling the named tool. **This matches the HTTP path's behavior**, where SMG also does not emit a structural_tag for Chat tool_choice (verified `routers/openai/` and `routers/http/` have zero `structural_tag` references).

## Changes

- `model_gateway/src/routers/grpc/harmony/stages/preparation.rs` — `prepare_chat`: drop `tool_constraint` generation; preserve `response_format_constraint` flow; remove the (now dead) "both at once" check.

## Test Plan — End-to-end on patched image

Built the patched image as `fra.ocir.io/idqj093njucb/smg:v1.4.1.post3` (digest `sha256:2cb5286b3db46fde0e13ff0ef48cd19fab3c4820ea7bb1048ff70a4bf8f80c74`) and deployed against `vllm.entrypoints.grpc_server` on A100-80G TP=2 (`gpt-oss-120b`, `max-model-len=131072`, `--async-scheduling`).

Re-ran the 6-way matrix that originally reproduced the leak (calculator tool × auto/required/forced × benign/chitchat prompts):

| # | tool_choice | prompt | Before fix | After fix |
|---|---|---|---|---|
| 1 | `auto` | benign-math | clean `tool_calls` | clean `tool_calls` |
| 2 | `auto` | chitchat | clean text | clean joke text |
| 3 | `required` | benign-math | clean `tool_calls` | clean `tool_calls` |
| 4 | `required` | chitchat | 🚨 LEAK | ✅ clean joke text |
| 5 | `function:calculator` | benign-math | clean `tool_calls` | clean `tool_calls` |
| 6 | `function:calculator` | chitchat | 🚨 LEAK | ✅ clean joke text |

Cases 4 and 6 — the previously-broken ones — now return clean text (model softens to refusal, as documented). No `<|channel|>`, `<|message|>`, or `<|constrain|>` markers in any `message.content`.

Cases 1/3/5 still emit valid `tool_calls` envelopes, confirming the happy path is preserved.

`cargo +nightly fmt` passes; `cargo clippy --bin smg --all-features -- -D warnings` passes.

## Known follow-up (out of scope)

`response_format: {type: "json_schema"}` exhibits a similar pre-existing leak via the same byte-level grammar-vs-policy mechanism on the `final` channel. This PR does not touch that path (`response_format_constraint` is preserved). Will file a separate issue/PR for the json_schema variant.