### PR TITLE
feat(mesh): tree-repair pages, responder side of the protocol

### DIFF
--- a/crates/mesh/src/lib.rs
+++ b/crates/mesh/src/lib.rs
@@ -31,11 +31,12 @@ mod tree_ops;
 mod tests;
 
 // Re-export commonly used types
+// v2 API
+pub use chunking::MAX_STREAM_CHUNK_BYTES;
 pub use crdt_kv::{
     decode as decode_epoch_count, encode as encode_epoch_count, merge as merge_epoch_max_wins,
     CrdtOrMap, EpochCount, OperationLog, EPOCH_MAX_WINS_ENCODED_LEN,
 };
-// v2 API
 pub use kv::{
     CrdtNamespace, DrainHandle, MergeStrategy, MeshKV, StreamConfig, StreamDrainFn,
     StreamNamespace, StreamRouting, Subscription,

--- a/model_gateway/src/mesh/adapters/tree_sync.rs
+++ b/model_gateway/src/mesh/adapters/tree_sync.rs
@@ -25,8 +25,8 @@ use dashmap::DashMap;
 use kv_index::TenantId;
 use rand::seq::IndexedRandom;
 use serde::{Deserialize, Serialize};
-use smg_mesh::{DrainHandle, StreamNamespace};
-use tracing::{debug, trace, warn};
+use smg_mesh::{DrainHandle, StreamNamespace, MAX_STREAM_CHUNK_BYTES};
+use tracing::{debug, error, trace, warn};
 use uuid::Uuid;
 
 use crate::policies::{TreeHandle, TreeKind};
@@ -36,9 +36,12 @@ const REPAIR_REQUEST_PREFIX: &str = "tree:req:";
 const REPAIR_PAGE_PREFIX: &str = "tree:page:";
 
 /// Soft cap on the bincode-serialized size of a single
-/// [`TreeRepairPage`]. The responder fills entries until the next
-/// would push the page over this budget. Source: spec §3.1
-/// (ephemeral-stream message budget).
+/// [`TreeRepairPage`]. Spec default (mesh-v2 §3.1,
+/// `max_tree_repair_page_bytes`). The responder fills entries
+/// until the next would push the page over this budget.
+//
+// TODO(d-3): read from the live `MeshConfig.max_tree_repair_page_bytes`
+// once `server.rs` wires the adapter, instead of using a const.
 pub const TREE_REPAIR_PAGE_BYTE_CAP: usize = 2 * 1024 * 1024;
 
 /// Reserved budget for the [`TreeRepairPage`] header (everything
@@ -47,6 +50,22 @@ pub const TREE_REPAIR_PAGE_BYTE_CAP: usize = 2 * 1024 * 1024;
 /// added back. UUID + model_id + tree_kind + counters comfortably
 /// fit; 256 is conservative.
 const TREE_REPAIR_PAGE_HEADER_OVERHEAD: usize = 256;
+
+/// Hard ceiling on the bincode-serialized size of a single
+/// [`TreeRepairPage`]. Above this, the mesh layer's chunking path
+/// fires a `debug_assert!` for `tree:page:*` (spec forbids
+/// multi-chunk reassembly for tree repair) and would split the
+/// value across multiple wire frames in release. The ceiling
+/// already accounts for gossip envelope overhead via
+/// `STREAM_CHUNK_OVERHEAD_MARGIN`.
+const TREE_REPAIR_PAGE_HARD_CEILING: usize = MAX_STREAM_CHUNK_BYTES;
+
+/// Hard ceiling on a single [`RepairEntry`]'s serialized size:
+/// the wire ceiling minus the page header reserve. Entries
+/// exceeding this cannot be shipped at all without triggering
+/// the multi-chunk path.
+const REPAIR_ENTRY_HARD_CEILING: usize =
+    TREE_REPAIR_PAGE_HARD_CEILING - TREE_REPAIR_PAGE_HEADER_OVERHEAD;
 
 /// Live-membership view consumed by the adapter when picking a
 /// peer to send a repair request to. Defined here (not in the
@@ -190,6 +209,70 @@ impl PagingIter {
     }
 }
 
+impl PagingIter {
+    /// Classify and try to pack a single entry into the current
+    /// page being built. Returns `Some(entry)` if the entry didn't
+    /// fit and must be deferred to the next page; otherwise `None`
+    /// (entry was either packed, or dropped above the wire ceiling).
+    ///
+    /// Four cases:
+    ///   - size > `REPAIR_ENTRY_HARD_CEILING`: drop with `error!`
+    ///     (multi-chunk path is forbidden for `tree:page:*`).
+    ///   - page non-empty AND would overflow `entry_budget`:
+    ///     defer to next page.
+    ///   - page empty AND size > `entry_budget`: emit anyway as
+    ///     sole-entry page with `warn!` flagged as spec debt.
+    ///   - otherwise: pack normally.
+    fn try_pack_entry(
+        &mut self,
+        entries: &mut Vec<RepairEntry>,
+        size: &mut usize,
+        entry: RepairEntry,
+    ) -> Option<RepairEntry> {
+        let entry_size =
+            bincode::serialized_size(&entry).unwrap_or(REPAIR_ENTRY_HARD_CEILING as u64) as usize;
+
+        if entry_size > REPAIR_ENTRY_HARD_CEILING {
+            error!(
+                entry_size,
+                ceiling = REPAIR_ENTRY_HARD_CEILING,
+                model_id = %self.model_id,
+                kind = ?self.tree_kind,
+                "RepairEntry exceeds wire-level ceiling; dropping. \
+                 Receiver will not learn this prefix via repair until \
+                 direct traffic populates it. See d-2c follow-up for \
+                 entry fragmentation."
+            );
+            // TODO(d-2c): emit a `router_mesh_tree_repair_drops_total{reason=\"oversized_entry\"}` counter.
+            self.cumulative_consumed += 1;
+            return None;
+        }
+
+        if !entries.is_empty() && *size + entry_size > self.entry_budget {
+            return Some(entry);
+        }
+
+        if entries.is_empty() && entry_size > self.entry_budget {
+            warn!(
+                entry_size,
+                budget = self.entry_budget,
+                ceiling = REPAIR_ENTRY_HARD_CEILING,
+                model_id = %self.model_id,
+                kind = ?self.tree_kind,
+                "tree-repair spec debt: RepairEntry exceeds soft page \
+                 cap; emitting as sole-entry oversized page (still \
+                 under the wire ceiling). See d-2c follow-up for \
+                 entry fragmentation."
+            );
+        }
+
+        entries.push(entry);
+        *size += entry_size;
+        self.cumulative_consumed += 1;
+        None
+    }
+}
+
 impl Iterator for PagingIter {
     type Item = TreeRepairPage;
 
@@ -202,30 +285,36 @@ impl Iterator for PagingIter {
         let mut size: usize = 0;
         let mut hit_budget = false;
 
-        // Carry over the entry deferred from the previous page.
-        // Default unknown sizes to the budget so an estimator
-        // failure forces a page break (the safe direction —
-        // never silently overflow the cap). Unreachable for our
-        // schema in practice; defensive against future changes.
+        // Carry over the entry deferred from the previous page,
+        // running it through the same classification as fresh
+        // pulls (it could itself be oversized if it was deferred
+        // by a sole-entry warn-emit on the previous page).
         if let Some(entry) = self.deferred.take() {
-            let entry_size =
-                bincode::serialized_size(&entry).unwrap_or(self.entry_budget as u64) as usize;
-            entries.push(entry);
-            size += entry_size;
-            self.cumulative_consumed += 1;
+            if let Some(deferred) = self.try_pack_entry(&mut entries, &mut size, entry) {
+                self.deferred = Some(deferred);
+                hit_budget = true;
+            }
         }
 
-        for entry in self.stream.by_ref() {
-            let entry_size =
-                bincode::serialized_size(&entry).unwrap_or(self.entry_budget as u64) as usize;
-            if !entries.is_empty() && size + entry_size > self.entry_budget {
-                self.deferred = Some(entry);
-                hit_budget = true;
-                break;
+        if !hit_budget {
+            // Pull-then-process avoids holding a `&mut self.stream`
+            // borrow across the `&mut self` call to `try_pack_entry`,
+            // so `for` / `while let` over the stream won't compile
+            // here even though clippy prefers them.
+            #[expect(
+                clippy::while_let_loop,
+                reason = "alternative forms hold &mut self.stream across the try_pack_entry &mut self call"
+            )]
+            loop {
+                let Some(entry) = self.stream.next() else {
+                    break;
+                };
+                if let Some(deferred) = self.try_pack_entry(&mut entries, &mut size, entry) {
+                    self.deferred = Some(deferred);
+                    hit_budget = true;
+                    break;
+                }
             }
-            entries.push(entry);
-            size += entry_size;
-            self.cumulative_consumed += 1;
         }
 
         let is_last = !hit_budget;
@@ -1326,6 +1415,82 @@ mod tests {
         let bytes = bincode::serialize(&tk_page).unwrap();
         let decoded: TreeRepairPage = bincode::deserialize(&bytes).unwrap();
         assert_eq!(decoded, tk_page);
+    }
+
+    #[tokio::test]
+    async fn paging_drops_entries_above_wire_ceiling() {
+        // Entry serialized size > REPAIR_ENTRY_HARD_CEILING must be
+        // dropped, not emitted — otherwise the mesh chunking layer
+        // would split the page across wire frames and the spec
+        // forbids `tree:page:*` from entering that path.
+        let huge_path: String = "x".repeat(REPAIR_ENTRY_HARD_CEILING + 1024);
+        let small = string_entry("small", &[("w1", 1)]);
+        let entries: Vec<RepairEntry> = vec![
+            RepairEntry::String {
+                path: huge_path,
+                tenants: vec![(Arc::from("w1"), 0)],
+            },
+            small.clone(),
+        ];
+
+        let pager = PagingIter::new(
+            Box::new(entries.into_iter()),
+            Uuid::now_v7(),
+            "m".into(),
+            TreeKind::String,
+            TREE_REPAIR_PAGE_BYTE_CAP,
+            0,
+        );
+        let pages: Vec<_> = pager.collect();
+        // The huge entry is dropped; only `small` survives. We
+        // should see exactly one page (the terminal one) carrying
+        // just the small entry.
+        let surviving: Vec<RepairEntry> = pages.iter().flat_map(|p| p.entries.clone()).collect();
+        assert_eq!(surviving, vec![small], "huge entry dropped, small survives");
+        assert!(pages.last().unwrap().is_last);
+    }
+
+    #[tokio::test]
+    async fn paging_pages_never_exceed_wire_ceiling() {
+        // Invariant test: no `TreeRepairPage` produced by paging
+        // serializes above `TREE_REPAIR_PAGE_HARD_CEILING`. Mix
+        // entries at three sizes — small, between soft and hard,
+        // and above hard — and assert every emitted page fits.
+        let between = "y".repeat(TREE_REPAIR_PAGE_BYTE_CAP + 16 * 1024); // ~2 MB + 16 KB
+        let above = "z".repeat(REPAIR_ENTRY_HARD_CEILING + 1024);
+
+        let entries: Vec<RepairEntry> = vec![
+            string_entry("small-1", &[("w1", 1)]),
+            RepairEntry::String {
+                path: between,
+                tenants: vec![(Arc::from("w1"), 0)],
+            },
+            string_entry("small-2", &[("w1", 2)]),
+            RepairEntry::String {
+                path: above,
+                tenants: vec![(Arc::from("w1"), 0)],
+            },
+            string_entry("small-3", &[("w1", 3)]),
+        ];
+
+        let pager = PagingIter::new(
+            Box::new(entries.into_iter()),
+            Uuid::now_v7(),
+            "m".into(),
+            TreeKind::String,
+            TREE_REPAIR_PAGE_BYTE_CAP,
+            0,
+        );
+        let pages: Vec<_> = pager.collect();
+        for (i, p) in pages.iter().enumerate() {
+            let size = bincode::serialized_size(p).unwrap() as usize;
+            assert!(
+                size <= TREE_REPAIR_PAGE_HARD_CEILING,
+                "page {i} (size {size}) exceeds hard wire ceiling \
+                 ({TREE_REPAIR_PAGE_HARD_CEILING}) — would invoke \
+                 multi-chunk path forbidden for tree:page:*",
+            );
+        }
     }
 
     #[tokio::test]

--- a/model_gateway/src/mesh/adapters/tree_sync.rs
+++ b/model_gateway/src/mesh/adapters/tree_sync.rs
@@ -293,10 +293,10 @@ impl Iterator for PagingIter {
         // Pull-then-process avoids holding a `&mut self.stream`
         // borrow across the `&mut self` call to `try_pack_entry`.
         loop {
-            let entry = if let Some(d) = self.deferred.take() {
-                d
-            } else if let Some(s) = self.stream.next() {
-                s
+            let entry = if let Some(entry) = self.deferred.take() {
+                entry
+            } else if let Some(entry) = self.stream.next() {
+                entry
             } else {
                 break;
             };

--- a/model_gateway/src/mesh/adapters/tree_sync.rs
+++ b/model_gateway/src/mesh/adapters/tree_sync.rs
@@ -134,79 +134,126 @@ pub struct TreeRepairPage {
     pub is_last: bool,
 }
 
-/// Chunk a stream of [`RepairEntry`] into byte-capped
-/// [`TreeRepairPage`]s. Always emits at least one page (even on
-/// an empty stream — the empty page acts as an ACK for the
-/// requester and gives d-2c a clean session-cleanup signal).
-///
-/// `start_skip` advances the stream by that many items before
-/// chunking — used to honour [`TreeRepairRequest::cursor`].
-/// Unknown serialized-size estimates default to `entry_budget`
-/// so an estimator failure forces a page break (safe direction —
-/// never silently overflow the cap).
-fn paginate(
-    mut stream: Box<dyn Iterator<Item = RepairEntry> + Send>,
+/// Iterator that chunks a stream of [`RepairEntry`] into
+/// byte-capped [`TreeRepairPage`]s. Always emits at least one
+/// page (even on an empty stream — the empty page acts as an
+/// ACK for the requester and gives d-2c a clean session-cleanup
+/// signal).
+struct PagingIter {
+    stream: Box<dyn Iterator<Item = RepairEntry> + Send>,
+    /// Entry pulled from the stream that didn't fit in the
+    /// previous page's budget; consumed first on the next call.
+    deferred: Option<RepairEntry>,
     session_id: Uuid,
     model_id: String,
     tree_kind: TreeKind,
-    byte_cap: usize,
-    start_skip: u64,
-) -> Vec<TreeRepairPage> {
-    // Best-effort cursor: skip entries the requester already
-    // has. If the tree shrunk between rounds we end early —
-    // the final page just has fewer entries.
-    for _ in 0..start_skip {
-        if stream.next().is_none() {
-            break;
+    /// Per-page budget for entry bytes (cap minus reserved header
+    /// overhead). At least one entry always fits per page even
+    /// if the entry alone exceeds the budget.
+    entry_budget: usize,
+    /// Total entries already consumed across all pages, including
+    /// any entries skipped via the start cursor. Used as the
+    /// `next_cursor` value for the page being built.
+    cumulative_consumed: u64,
+    page_index: u32,
+    finished: bool,
+}
+
+impl PagingIter {
+    fn new(
+        mut stream: Box<dyn Iterator<Item = RepairEntry> + Send>,
+        session_id: Uuid,
+        model_id: String,
+        tree_kind: TreeKind,
+        byte_cap: usize,
+        start_skip: u64,
+    ) -> Self {
+        // Best-effort cursor: skip entries the requester already
+        // has. If the tree shrunk between rounds we end early —
+        // the final page just has fewer entries.
+        for _ in 0..start_skip {
+            if stream.next().is_none() {
+                break;
+            }
+        }
+        Self {
+            stream,
+            deferred: None,
+            session_id,
+            model_id,
+            tree_kind,
+            entry_budget: byte_cap.saturating_sub(TREE_REPAIR_PAGE_HEADER_OVERHEAD),
+            cumulative_consumed: start_skip,
+            page_index: 0,
+            finished: false,
         }
     }
+}
 
-    let entry_budget = byte_cap.saturating_sub(TREE_REPAIR_PAGE_HEADER_OVERHEAD);
-    let mut pages: Vec<TreeRepairPage> = Vec::new();
-    let mut entries: Vec<RepairEntry> = Vec::new();
-    let mut size: usize = 0;
-    let mut page_index: u32 = 0;
+impl Iterator for PagingIter {
+    type Item = TreeRepairPage;
 
-    // `index` is the count of entries consumed BEFORE this
-    // iteration — exactly the cursor a requester would need to
-    // resume from the entry we're about to consider.
-    for (index, entry) in (start_skip..).zip(&mut stream) {
-        let entry_size = bincode::serialized_size(&entry).unwrap_or(entry_budget as u64) as usize;
-        if !entries.is_empty() && size + entry_size > entry_budget {
-            // Current page is full — emit it and start a new one
-            // with this entry as the first item.
-            pages.push(TreeRepairPage {
-                session_id,
-                model_id: model_id.clone(),
-                tree_kind,
-                page_index,
-                entries: std::mem::take(&mut entries),
-                // u64 always bincode-serializes; an empty cursor
-                // decodes back to 0 ("start over") on the
-                // unreachable failure path.
-                next_cursor: Some(bincode::serialize(&index).unwrap_or_default()),
-                is_last: false,
-            });
-            page_index += 1;
-            size = 0;
+    fn next(&mut self) -> Option<TreeRepairPage> {
+        if self.finished {
+            return None;
         }
-        entries.push(entry);
-        size += entry_size;
+
+        let mut entries: Vec<RepairEntry> = Vec::new();
+        let mut size: usize = 0;
+        let mut hit_budget = false;
+
+        // Carry over the entry deferred from the previous page.
+        // Default unknown sizes to the budget so an estimator
+        // failure forces a page break (the safe direction —
+        // never silently overflow the cap). Unreachable for our
+        // schema in practice; defensive against future changes.
+        if let Some(entry) = self.deferred.take() {
+            let entry_size =
+                bincode::serialized_size(&entry).unwrap_or(self.entry_budget as u64) as usize;
+            entries.push(entry);
+            size += entry_size;
+            self.cumulative_consumed += 1;
+        }
+
+        for entry in self.stream.by_ref() {
+            let entry_size =
+                bincode::serialized_size(&entry).unwrap_or(self.entry_budget as u64) as usize;
+            if !entries.is_empty() && size + entry_size > self.entry_budget {
+                self.deferred = Some(entry);
+                hit_budget = true;
+                break;
+            }
+            entries.push(entry);
+            size += entry_size;
+            self.cumulative_consumed += 1;
+        }
+
+        let is_last = !hit_budget;
+        let next_cursor = if is_last {
+            None
+        } else {
+            // u64 always bincode-serializes; if it ever didn't,
+            // an empty cursor decodes back to 0 ("start over") —
+            // safe best-effort fallback rather than a panic.
+            Some(bincode::serialize(&self.cumulative_consumed).unwrap_or_default())
+        };
+
+        let page = TreeRepairPage {
+            session_id: self.session_id,
+            model_id: self.model_id.clone(),
+            tree_kind: self.tree_kind,
+            page_index: self.page_index,
+            entries,
+            next_cursor,
+            is_last,
+        };
+
+        self.page_index += 1;
+        if is_last {
+            self.finished = true;
+        }
+        Some(page)
     }
-
-    // Always emit a terminal page — even empty — so the
-    // requester gets an ACK on empty trees / unknown models.
-    pages.push(TreeRepairPage {
-        session_id,
-        model_id,
-        tree_kind,
-        page_index,
-        entries,
-        next_cursor: None,
-        is_last: true,
-    });
-
-    pages
 }
 
 /// Decode a [`TreeRepairRequest::cursor`] (bincode-encoded `u64`
@@ -542,7 +589,7 @@ impl TreeSyncAdapter {
             .unwrap_or_else(|| Box::new(std::iter::empty()));
 
         let start_skip = decode_cursor(request.cursor.as_deref());
-        let pages = paginate(
+        let pager = PagingIter::new(
             stream,
             request.session_id,
             request.model_id.clone(),
@@ -552,7 +599,7 @@ impl TreeSyncAdapter {
         );
 
         let mut pages_sent: u32 = 0;
-        for page in pages {
+        for page in pager {
             let key = format!(
                 "{REPAIR_PAGE_PREFIX}{}:{}",
                 page.session_id, page.page_index,
@@ -1285,7 +1332,7 @@ mod tests {
     async fn paging_empty_stream_emits_one_is_last_page() {
         // Empty input → one page so the requester sees an ACK.
         let stream: Box<dyn Iterator<Item = RepairEntry> + Send> = Box::new(std::iter::empty());
-        let pages = paginate(
+        let pager = PagingIter::new(
             stream,
             Uuid::now_v7(),
             "m".into(),
@@ -1293,6 +1340,7 @@ mod tests {
             TREE_REPAIR_PAGE_BYTE_CAP,
             0,
         );
+        let pages: Vec<_> = pager.collect();
         assert_eq!(pages.len(), 1);
         assert!(pages[0].is_last);
         assert!(pages[0].entries.is_empty());
@@ -1315,7 +1363,7 @@ mod tests {
         let total = entries.len();
 
         // 4 KB cap; entry size ~1 KB + bincode overhead.
-        let pages = paginate(
+        let pager = PagingIter::new(
             Box::new(entries.clone().into_iter()),
             Uuid::now_v7(),
             "m".into(),
@@ -1323,6 +1371,7 @@ mod tests {
             4 * 1024,
             0,
         );
+        let pages: Vec<_> = pager.collect();
         assert!(pages.len() >= 2, "small cap must produce multiple pages");
 
         // Total entries preserved; only the final page is marked
@@ -1363,7 +1412,7 @@ mod tests {
             path: "x".repeat(8 * 1024),
             tenants: vec![(Arc::from("w1"), 0)],
         };
-        let pages = paginate(
+        let pager = PagingIter::new(
             Box::new(vec![huge].into_iter()),
             Uuid::now_v7(),
             "m".into(),
@@ -1371,6 +1420,7 @@ mod tests {
             1024, // cap < entry size
             0,
         );
+        let pages: Vec<_> = pager.collect();
         assert_eq!(pages.len(), 1, "single entry yields exactly one page");
         assert!(pages[0].is_last);
         assert_eq!(pages[0].entries.len(), 1);
@@ -1387,7 +1437,7 @@ mod tests {
             .collect();
 
         // Full pass.
-        let full: Vec<RepairEntry> = paginate(
+        let full: Vec<RepairEntry> = PagingIter::new(
             Box::new(entries.clone().into_iter()),
             Uuid::now_v7(),
             "m".into(),
@@ -1395,14 +1445,13 @@ mod tests {
             4 * 1024,
             0,
         )
-        .into_iter()
         .flat_map(|p| p.entries)
         .collect();
         assert_eq!(full.len(), entries.len());
         assert_eq!(full, entries);
 
         // Resume halfway: skip 5 → final pass yields the last 5.
-        let resumed: Vec<RepairEntry> = paginate(
+        let resumed: Vec<RepairEntry> = PagingIter::new(
             Box::new(entries.clone().into_iter()),
             Uuid::now_v7(),
             "m".into(),
@@ -1410,7 +1459,6 @@ mod tests {
             4 * 1024,
             5,
         )
-        .into_iter()
         .flat_map(|p| p.entries)
         .collect();
         assert_eq!(resumed.len(), 5);
@@ -1428,7 +1476,7 @@ mod tests {
                 tenants: vec![(Arc::from("w1"), i as u64)],
             })
             .collect();
-        let pages = paginate(
+        let pager = PagingIter::new(
             Box::new(entries.into_iter()),
             Uuid::now_v7(),
             "m".into(),
@@ -1436,6 +1484,7 @@ mod tests {
             4 * 1024,
             0,
         );
+        let pages: Vec<_> = pager.collect();
         let mut running_total = 0usize;
         for (i, p) in pages.iter().enumerate() {
             running_total += p.entries.len();

--- a/model_gateway/src/mesh/adapters/tree_sync.rs
+++ b/model_gateway/src/mesh/adapters/tree_sync.rs
@@ -22,6 +22,7 @@ use std::sync::{Arc, OnceLock};
 
 use bytes::Bytes;
 use dashmap::DashMap;
+use kv_index::TenantId;
 use rand::seq::IndexedRandom;
 use serde::{Deserialize, Serialize};
 use smg_mesh::{DrainHandle, StreamNamespace};
@@ -32,6 +33,20 @@ use crate::policies::{TreeHandle, TreeKind};
 
 const PREFIX: &str = "td:";
 const REPAIR_REQUEST_PREFIX: &str = "tree:req:";
+const REPAIR_PAGE_PREFIX: &str = "tree:page:";
+
+/// Soft cap on the bincode-serialized size of a single
+/// [`TreeRepairPage`]. The responder fills entries until the next
+/// would push the page over this budget. Source: spec §3.1
+/// (ephemeral-stream message budget).
+pub const TREE_REPAIR_PAGE_BYTE_CAP: usize = 2 * 1024 * 1024;
+
+/// Reserved budget for the [`TreeRepairPage`] header (everything
+/// other than `entries`). Subtracted from the byte cap so the
+/// assembled page stays under the cap once header bytes are
+/// added back. UUID + model_id + tree_kind + counters comfortably
+/// fit; 256 is conservative.
+const TREE_REPAIR_PAGE_HEADER_OVERHEAD: usize = 256;
 
 /// Live-membership view consumed by the adapter when picking a
 /// peer to send a repair request to. Defined here (not in the
@@ -87,15 +102,178 @@ pub struct TreeRepairRequest {
     pub reason: RepairReason,
 }
 
+/// One reconstructable tree entry on the repair-page wire. The
+/// variant matches the requested [`TreeKind`]; receivers may
+/// validate the variant against the page's `tree_kind` and drop
+/// mismatched entries as malformed.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RepairEntry {
+    String {
+        path: String,
+        tenants: Vec<(TenantId, u64)>,
+    },
+    Token {
+        tokens: Vec<u32>,
+        tenants: Vec<(TenantId, u64)>,
+    },
+}
+
+/// One page of tree-repair payload, targeted at the requester
+/// keyed `tree:page:{session_id}:{page_index}`. `next_cursor`
+/// is `None` iff `is_last`; resumed requests echo the cursor
+/// back in [`TreeRepairRequest::cursor`] so the responder skips
+/// already-shipped entries.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TreeRepairPage {
+    pub session_id: Uuid,
+    pub model_id: String,
+    pub tree_kind: TreeKind,
+    pub page_index: u32,
+    pub entries: Vec<RepairEntry>,
+    pub next_cursor: Option<Vec<u8>>,
+    pub is_last: bool,
+}
+
+/// Iterator that chunks a stream of [`RepairEntry`] into
+/// byte-capped [`TreeRepairPage`]s. Always emits at least one
+/// page (even on an empty stream — the empty page acts as an
+/// ACK for the requester and gives d-2c a clean session-cleanup
+/// signal).
+struct PagingIter {
+    stream: Box<dyn Iterator<Item = RepairEntry> + Send>,
+    /// Entry pulled from the stream that didn't fit in the
+    /// previous page's budget; consumed first on the next call.
+    deferred: Option<RepairEntry>,
+    session_id: Uuid,
+    model_id: String,
+    tree_kind: TreeKind,
+    /// Per-page budget for entry bytes (cap minus reserved header
+    /// overhead). At least one entry always fits per page even
+    /// if the entry alone exceeds the budget.
+    entry_budget: usize,
+    /// Total entries already consumed across all pages, including
+    /// any entries skipped via the start cursor. Used as the
+    /// `next_cursor` value for the page being built.
+    cumulative_consumed: u64,
+    page_index: u32,
+    finished: bool,
+}
+
+impl PagingIter {
+    fn new(
+        mut stream: Box<dyn Iterator<Item = RepairEntry> + Send>,
+        session_id: Uuid,
+        model_id: String,
+        tree_kind: TreeKind,
+        byte_cap: usize,
+        start_skip: u64,
+    ) -> Self {
+        // Best-effort cursor: skip entries the requester already
+        // has. If the tree shrunk between rounds we end early —
+        // the final page just has fewer entries.
+        for _ in 0..start_skip {
+            if stream.next().is_none() {
+                break;
+            }
+        }
+        Self {
+            stream,
+            deferred: None,
+            session_id,
+            model_id,
+            tree_kind,
+            entry_budget: byte_cap.saturating_sub(TREE_REPAIR_PAGE_HEADER_OVERHEAD),
+            cumulative_consumed: start_skip,
+            page_index: 0,
+            finished: false,
+        }
+    }
+}
+
+impl Iterator for PagingIter {
+    type Item = TreeRepairPage;
+
+    fn next(&mut self) -> Option<TreeRepairPage> {
+        if self.finished {
+            return None;
+        }
+
+        let mut entries: Vec<RepairEntry> = Vec::new();
+        let mut size: usize = 0;
+        let mut hit_budget = false;
+
+        // Carry over the entry deferred from the previous page.
+        if let Some(entry) = self.deferred.take() {
+            let entry_size = bincode::serialized_size(&entry).unwrap_or(0) as usize;
+            entries.push(entry);
+            size += entry_size;
+            self.cumulative_consumed += 1;
+        }
+
+        for entry in self.stream.by_ref() {
+            let entry_size = bincode::serialized_size(&entry).unwrap_or(0) as usize;
+            if !entries.is_empty() && size + entry_size > self.entry_budget {
+                self.deferred = Some(entry);
+                hit_budget = true;
+                break;
+            }
+            entries.push(entry);
+            size += entry_size;
+            self.cumulative_consumed += 1;
+        }
+
+        let is_last = !hit_budget;
+        let next_cursor = if is_last {
+            None
+        } else {
+            // u64 always bincode-serializes; if it ever didn't,
+            // an empty cursor decodes back to 0 ("start over") —
+            // safe best-effort fallback rather than a panic.
+            Some(bincode::serialize(&self.cumulative_consumed).unwrap_or_default())
+        };
+
+        let page = TreeRepairPage {
+            session_id: self.session_id,
+            model_id: self.model_id.clone(),
+            tree_kind: self.tree_kind,
+            page_index: self.page_index,
+            entries,
+            next_cursor,
+            is_last,
+        };
+
+        self.page_index += 1;
+        if is_last {
+            self.finished = true;
+        }
+        Some(page)
+    }
+}
+
+/// Decode a [`TreeRepairRequest::cursor`] (bincode-encoded `u64`
+/// skip count). Treats `None` and decode errors as "start from
+/// the beginning" — a malformed cursor is best handled by re-
+/// shipping the whole tree rather than refusing to respond.
+fn decode_cursor(cursor: Option<&[u8]>) -> u64 {
+    cursor
+        .and_then(|bytes| bincode::deserialize::<u64>(bytes).ok())
+        .unwrap_or(0)
+}
+
 /// Bridges the `td:` broadcast stream namespace to per-model
 /// tenant buffers, querying a [`TreeHandle`] for inbound hash
 /// resolution and a [`PeerList`] for repair-request targeting.
 pub struct TreeSyncAdapter {
     tenant_deltas: Arc<StreamNamespace>,
-    /// Targeted namespace for `tree:req:*` repair requests. The
-    /// adapter only publishes here in slice 5c; subscription (the
-    /// responder side) lands in slice 5d.
+    /// Targeted namespace for `tree:req:*` repair requests.
+    /// The adapter both publishes (5c, when a local node hits an
+    /// unknown hash) and subscribes (d-2b, when a peer asks us
+    /// for our tree).
     tree_repair_requests: Arc<StreamNamespace>,
+    /// Targeted namespace for `tree:page:*` repair pages.
+    /// The adapter publishes pages here in response to
+    /// `tree:req:` messages; the receiver side lands in d-2c.
+    tree_repair_pages: Arc<StreamNamespace>,
     pending_deltas: DashMap<String, Vec<TreeDelta>>,
     /// Hash-membership handle provided by the tree owner.
     tree: Arc<dyn TreeHandle>,
@@ -104,7 +282,7 @@ pub struct TreeSyncAdapter {
     /// Outstanding repair sessions, keyed by (model_id, kind).
     /// Presence-only set: while a key is here, additional unknown
     /// hashes for the same (model, kind) are coalesced into the
-    /// in-flight session. Slice 5d adds the response-side cleanup
+    /// in-flight session. d-2c adds the response-side cleanup
     /// (and the per-session bookkeeping that needs reading).
     outstanding_repairs: DashMap<(String, TreeKind), ()>,
     node_name: String,
@@ -134,6 +312,7 @@ impl TreeSyncAdapter {
     pub fn new(
         tenant_deltas: Arc<StreamNamespace>,
         tree_repair_requests: Arc<StreamNamespace>,
+        tree_repair_pages: Arc<StreamNamespace>,
         tree: Arc<dyn TreeHandle>,
         peers: Arc<dyn PeerList>,
         node_name: String,
@@ -148,6 +327,11 @@ impl TreeSyncAdapter {
             REPAIR_REQUEST_PREFIX,
             "TreeSyncAdapter requires a repair-request namespace scoped to `{REPAIR_REQUEST_PREFIX}`",
         );
+        assert_eq!(
+            tree_repair_pages.prefix(),
+            REPAIR_PAGE_PREFIX,
+            "TreeSyncAdapter requires a repair-page namespace scoped to `{REPAIR_PAGE_PREFIX}`",
+        );
         assert!(
             !node_name.is_empty(),
             "TreeSyncAdapter node_name must not be empty",
@@ -155,6 +339,7 @@ impl TreeSyncAdapter {
         Arc::new(Self {
             tenant_deltas,
             tree_repair_requests,
+            tree_repair_pages,
             pending_deltas: DashMap::new(),
             tree,
             peers,
@@ -214,6 +399,36 @@ impl TreeSyncAdapter {
                 }
             }
             debug!("TreeSyncAdapter tenant-delta subscription closed");
+        });
+
+        // Responder side of the repair protocol: subscribe to
+        // `tree:req:`, dispatch each request to a bounded per-
+        // session task that pages the local tree out via
+        // `tree:page:` to the requester.
+        let req_owner = Arc::downgrade(self);
+        let mut req_sub = self.tree_repair_requests.subscribe("");
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "subscription task ends automatically when the mesh KV drops and closes the channel; no handle needed"
+        )]
+        tokio::spawn(async move {
+            while let Some((key, value)) = req_sub.receiver.recv().await {
+                let Some(this) = req_owner.upgrade() else {
+                    debug!("TreeSyncAdapter dropped, exiting tree:req: subscription");
+                    break;
+                };
+                if !key.starts_with(REPAIR_REQUEST_PREFIX) {
+                    warn!(key, "tree:req: subscription yielded unexpected key shape");
+                    continue;
+                }
+                match value {
+                    Some(fragments) => this.handle_incoming_repair_request(&fragments),
+                    None => {
+                        debug!("unexpected tree:req: tombstone event");
+                    }
+                }
+            }
+            debug!("TreeSyncAdapter tree:req: subscription closed");
         });
     }
 
@@ -317,6 +532,98 @@ impl TreeSyncAdapter {
         }
     }
 
+    /// Decode an incoming `tree:req:` payload and dispatch a
+    /// per-session paging task. Mismatched `target_peer_id` is
+    /// dropped silently — targeted routing should already filter,
+    /// but defense-in-depth against future routing changes.
+    fn handle_incoming_repair_request(self: &Arc<Self>, fragments: &[Bytes]) {
+        let total: usize = fragments.iter().map(Bytes::len).sum();
+        let mut bytes = Vec::with_capacity(total);
+        for frag in fragments {
+            bytes.extend_from_slice(frag);
+        }
+        let request: TreeRepairRequest = match bincode::deserialize(&bytes) {
+            Ok(req) => req,
+            Err(err) => {
+                warn!(%err, "failed to decode TreeRepairRequest");
+                return;
+            }
+        };
+        if request.target_peer_id != self.node_name {
+            trace!(
+                target = %request.target_peer_id,
+                local = %self.node_name,
+                session_id = %request.session_id,
+                "dropping repair request not addressed to this node",
+            );
+            return;
+        }
+
+        let this = Arc::clone(self);
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "per-request paging task is bounded by stream length and exits on iterator exhaustion"
+        )]
+        tokio::spawn(async move {
+            this.respond_to_repair_request(request);
+        });
+    }
+
+    /// Walk the local tree for the requested model+kind, chunk
+    /// it into byte-capped pages, and publish each page to the
+    /// requester. Always emits at least one page (an empty
+    /// `is_last=true` page if the tree is missing or empty) so
+    /// the requester sees an ACK and d-2c session-cleanup has a
+    /// clean signal.
+    fn respond_to_repair_request(&self, request: TreeRepairRequest) {
+        let stream: Box<dyn Iterator<Item = RepairEntry> + Send> = self
+            .tree
+            .open_repair_stream(&request.model_id, request.tree_kind)
+            .unwrap_or_else(|| Box::new(std::iter::empty()));
+
+        let start_skip = decode_cursor(request.cursor.as_deref());
+        let pager = PagingIter::new(
+            stream,
+            request.session_id,
+            request.model_id.clone(),
+            request.tree_kind,
+            TREE_REPAIR_PAGE_BYTE_CAP,
+            start_skip,
+        );
+
+        let mut pages_sent: u32 = 0;
+        for page in pager {
+            let key = format!(
+                "{REPAIR_PAGE_PREFIX}{}:{}",
+                page.session_id, page.page_index,
+            );
+            let bytes = match bincode::serialize(&page) {
+                Ok(b) => Bytes::from(b),
+                Err(err) => {
+                    warn!(
+                        session_id = %page.session_id,
+                        page_index = page.page_index,
+                        %err,
+                        "failed to serialize TreeRepairPage; skipping",
+                    );
+                    continue;
+                }
+            };
+            self.tree_repair_pages
+                .publish_to(&request.requester_peer_id, &key, bytes);
+            pages_sent += 1;
+        }
+
+        debug!(
+            session_id = %request.session_id,
+            model_id = %request.model_id,
+            kind = ?request.tree_kind,
+            requester = %request.requester_peer_id,
+            pages_sent,
+            "completed repair response",
+        );
+    }
+
     /// Issue a `tree:req:{session_id}` repair request for an
     /// unknown hash, targeted at a random ALIVE peer. Coalesces
     /// duplicates: while a session is already in flight for the
@@ -412,6 +719,18 @@ mod tests {
         )
     }
 
+    fn page_namespace(mesh: &MeshKV) -> Arc<StreamNamespace> {
+        mesh.configure_stream_prefix(
+            REPAIR_PAGE_PREFIX,
+            StreamConfig {
+                // Generous so tests with multi-MB pages don't
+                // FIFO-evict before assertions inspect them.
+                max_buffer_bytes: 8 * 1024 * 1024,
+                routing: StreamRouting::Targeted,
+            },
+        )
+    }
+
     fn delta(hash: u64, worker: &str) -> TreeDelta {
         TreeDelta {
             tree_kind: TreeKind::String,
@@ -424,11 +743,14 @@ mod tests {
     /// Test-only [`TreeHandle`]: a set of known `(model, kind,
     /// hash)` tuples plus a log of every applied call so tests
     /// can assert on apply-side effects. Apply succeeds (returns
-    /// `true`) iff the hash is in the known set.
+    /// `true`) iff the hash is in the known set. `streams` lets
+    /// d-2b tests pre-load `RepairEntry` sequences for
+    /// `open_repair_stream` lookups.
     #[derive(Debug, Default)]
     struct MockTreeHandle {
         known: DashMap<(String, TreeKind, u64), ()>,
         applied: parking_lot::Mutex<Vec<(String, TreeKind, u64, String)>>,
+        streams: DashMap<(String, TreeKind), Vec<RepairEntry>>,
     }
 
     impl MockTreeHandle {
@@ -439,6 +761,16 @@ mod tests {
 
         fn applied_calls(&self) -> Vec<(String, TreeKind, u64, String)> {
             self.applied.lock().clone()
+        }
+
+        fn set_repair_stream(
+            &self,
+            model_id: &str,
+            tree_kind: TreeKind,
+            entries: Vec<RepairEntry>,
+        ) {
+            self.streams
+                .insert((model_id.to_string(), tree_kind), entries);
         }
     }
 
@@ -463,6 +795,15 @@ mod tests {
                 worker_url.to_string(),
             ));
             true
+        }
+
+        fn open_repair_stream(
+            &self,
+            model_id: &str,
+            tree_kind: TreeKind,
+        ) -> Option<Box<dyn Iterator<Item = RepairEntry> + Send>> {
+            let entries = self.streams.get(&(model_id.to_string(), tree_kind))?;
+            Some(Box::new(entries.value().clone().into_iter()))
         }
     }
 
@@ -497,9 +838,10 @@ mod tests {
     fn adapter_with_empty_handle(mesh: &MeshKV, node_name: &str) -> Arc<TreeSyncAdapter> {
         let td = td_namespace(mesh);
         let req = req_namespace(mesh);
+        let pages = page_namespace(mesh);
         let tree: Arc<dyn TreeHandle> = empty_handle();
         let peers: Arc<dyn PeerList> = empty_peers();
-        TreeSyncAdapter::new(td, req, tree, peers, node_name.into())
+        TreeSyncAdapter::new(td, req, pages, tree, peers, node_name.into())
     }
 
     #[tokio::test]
@@ -630,11 +972,12 @@ mod tests {
         let mesh = MeshKV::new("node-a".into());
         let td = td_namespace(&mesh);
         let req = req_namespace(&mesh);
+        let pages = page_namespace(&mesh);
         let tree = Arc::new(MockTreeHandle::default());
         tree.mark_known("model-1", TreeKind::String, 42);
         let adapter_tree: Arc<dyn TreeHandle> = tree.clone();
         let peers: Arc<dyn PeerList> = MockPeerList::with(&["node-b"]);
-        let adapter = TreeSyncAdapter::new(td, req, adapter_tree, peers, "node-a".into());
+        let adapter = TreeSyncAdapter::new(td, req, pages, adapter_tree, peers, "node-a".into());
 
         let batch = vec![
             TreeDelta {
@@ -687,6 +1030,7 @@ mod tests {
         // Pass the repair-request namespace as the td: arg.
         let mesh = MeshKV::new("node-a".into());
         let req = req_namespace(&mesh);
+        let pages = page_namespace(&mesh);
         let req_again = mesh.configure_stream_prefix(
             "td-misnamed:",
             StreamConfig {
@@ -696,7 +1040,7 @@ mod tests {
         );
         let tree: Arc<dyn TreeHandle> = empty_handle();
         let peers: Arc<dyn PeerList> = empty_peers();
-        let _ = TreeSyncAdapter::new(req_again, req, tree, peers, "node-a".into());
+        let _ = TreeSyncAdapter::new(req_again, req, pages, tree, peers, "node-a".into());
     }
 
     #[tokio::test]
@@ -707,6 +1051,7 @@ mod tests {
         // Pass the td: namespace as the repair-request arg.
         let mesh = MeshKV::new("node-a".into());
         let td = td_namespace(&mesh);
+        let pages = page_namespace(&mesh);
         let td_again = mesh.configure_stream_prefix(
             "td-also:",
             StreamConfig {
@@ -716,7 +1061,7 @@ mod tests {
         );
         let tree: Arc<dyn TreeHandle> = empty_handle();
         let peers: Arc<dyn PeerList> = empty_peers();
-        let _ = TreeSyncAdapter::new(td, td_again, tree, peers, "node-a".into());
+        let _ = TreeSyncAdapter::new(td, td_again, pages, tree, peers, "node-a".into());
     }
 
     #[tokio::test]
@@ -725,9 +1070,10 @@ mod tests {
         let mesh = MeshKV::new("node-a".into());
         let td = td_namespace(&mesh);
         let req = req_namespace(&mesh);
+        let pages = page_namespace(&mesh);
         let tree: Arc<dyn TreeHandle> = empty_handle();
         let peers: Arc<dyn PeerList> = empty_peers();
-        let _ = TreeSyncAdapter::new(td, req, tree, peers, String::new());
+        let _ = TreeSyncAdapter::new(td, req, pages, tree, peers, String::new());
     }
 
     #[tokio::test]
@@ -773,9 +1119,10 @@ mod tests {
         let mesh = MeshKV::new("node-a".into());
         let td = td_namespace(&mesh);
         let req = req_namespace(&mesh);
+        let pages = page_namespace(&mesh);
         let tree: Arc<dyn TreeHandle> = Arc::new(MockTreeHandle::default());
         let peers: Arc<dyn PeerList> = MockPeerList::with(&["node-b"]);
-        let adapter = TreeSyncAdapter::new(td, req, tree, peers, "node-a".into());
+        let adapter = TreeSyncAdapter::new(td, req, pages, tree, peers, "node-a".into());
 
         // Single unknown delta → one targeted publish to node-b.
         let batch = vec![delta(99, "http://w1")];
@@ -810,9 +1157,10 @@ mod tests {
         let mesh = MeshKV::new("node-a".into());
         let td = td_namespace(&mesh);
         let req = req_namespace(&mesh);
+        let pages = page_namespace(&mesh);
         let tree: Arc<dyn TreeHandle> = Arc::new(MockTreeHandle::default());
         let peers: Arc<dyn PeerList> = MockPeerList::with(&["node-b"]);
-        let adapter = TreeSyncAdapter::new(td, req, tree, peers, "node-a".into());
+        let adapter = TreeSyncAdapter::new(td, req, pages, tree, peers, "node-a".into());
 
         let batch = vec![delta(101, "http://w1"), delta(102, "http://w2")];
         let bytes = Bytes::from(bincode::serialize(&batch).unwrap());
@@ -829,9 +1177,10 @@ mod tests {
         let mesh = MeshKV::new("node-a".into());
         let td = td_namespace(&mesh);
         let req = req_namespace(&mesh);
+        let pages = page_namespace(&mesh);
         let tree: Arc<dyn TreeHandle> = Arc::new(MockTreeHandle::default());
         let peers: Arc<dyn PeerList> = MockPeerList::with(&["node-b"]);
-        let adapter = TreeSyncAdapter::new(td, req, tree, peers, "node-a".into());
+        let adapter = TreeSyncAdapter::new(td, req, pages, tree, peers, "node-a".into());
 
         let batch = vec![
             TreeDelta {
@@ -878,11 +1227,12 @@ mod tests {
         let mesh = MeshKV::new("node-a".into());
         let td = td_namespace(&mesh);
         let req = req_namespace(&mesh);
+        let pages = page_namespace(&mesh);
         let tree = Arc::new(MockTreeHandle::default());
         tree.mark_known("model-1", TreeKind::String, 42);
         let adapter_tree: Arc<dyn TreeHandle> = tree.clone();
         let peers: Arc<dyn PeerList> = MockPeerList::with(&["node-b"]);
-        let adapter = TreeSyncAdapter::new(td, req, adapter_tree, peers, "node-a".into());
+        let adapter = TreeSyncAdapter::new(td, req, pages, adapter_tree, peers, "node-a".into());
 
         let batch = vec![delta(42, "http://w1")];
         let bytes = Bytes::from(bincode::serialize(&batch).unwrap());
@@ -890,5 +1240,491 @@ mod tests {
 
         let publishes = drain_repair_publishes(&mesh);
         assert!(publishes.is_empty(), "known hash skips repair entirely");
+    }
+
+    // ----- d-2b: repair page wire format + responder -----
+
+    fn string_entry(path: &str, tenants: &[(&str, u64)]) -> RepairEntry {
+        RepairEntry::String {
+            path: path.into(),
+            tenants: tenants.iter().map(|(t, e)| (Arc::from(*t), *e)).collect(),
+        }
+    }
+
+    fn token_entry(tokens: &[u32], tenants: &[(&str, u64)]) -> RepairEntry {
+        RepairEntry::Token {
+            tokens: tokens.to_vec(),
+            tenants: tenants.iter().map(|(t, e)| (Arc::from(*t), *e)).collect(),
+        }
+    }
+
+    fn drain_page_publishes(mesh: &MeshKV) -> Vec<(String, String, Bytes)> {
+        let round = mesh.collect_round_batch();
+        round
+            .targeted_entries
+            .into_iter()
+            .filter(|(_, key, _)| key.starts_with(REPAIR_PAGE_PREFIX))
+            .collect()
+    }
+
+    fn make_request(
+        session_id: Uuid,
+        target: &str,
+        requester: &str,
+        model_id: &str,
+        kind: TreeKind,
+        cursor: Option<Vec<u8>>,
+    ) -> TreeRepairRequest {
+        TreeRepairRequest {
+            session_id,
+            requester_peer_id: requester.into(),
+            target_peer_id: target.into(),
+            model_id: model_id.into(),
+            tree_kind: kind,
+            cursor,
+            reason: RepairReason::UnknownHash(0xdead_beef),
+        }
+    }
+
+    #[tokio::test]
+    async fn repair_entry_and_page_round_trip_through_bincode() {
+        let entries = vec![
+            string_entry("hello", &[("worker-1", 7)]),
+            string_entry("hello world", &[("worker-1", 8), ("worker-2", 9)]),
+        ];
+        let page = TreeRepairPage {
+            session_id: Uuid::now_v7(),
+            model_id: "model-1".into(),
+            tree_kind: TreeKind::String,
+            page_index: 3,
+            entries: entries.clone(),
+            next_cursor: Some(vec![1, 2, 3]),
+            is_last: false,
+        };
+        let bytes = bincode::serialize(&page).unwrap();
+        let decoded: TreeRepairPage = bincode::deserialize(&bytes).unwrap();
+        assert_eq!(decoded, page);
+
+        // Token variant round-trips too.
+        let tk_entries = vec![token_entry(&[1, 2, 3, 4], &[("worker-1", 0)])];
+        let tk_page = TreeRepairPage {
+            session_id: Uuid::now_v7(),
+            model_id: "model-2".into(),
+            tree_kind: TreeKind::Token,
+            page_index: 0,
+            entries: tk_entries.clone(),
+            next_cursor: None,
+            is_last: true,
+        };
+        let bytes = bincode::serialize(&tk_page).unwrap();
+        let decoded: TreeRepairPage = bincode::deserialize(&bytes).unwrap();
+        assert_eq!(decoded, tk_page);
+    }
+
+    #[tokio::test]
+    async fn paging_empty_stream_emits_one_is_last_page() {
+        // Empty input → one page so the requester sees an ACK.
+        let stream: Box<dyn Iterator<Item = RepairEntry> + Send> = Box::new(std::iter::empty());
+        let pager = PagingIter::new(
+            stream,
+            Uuid::now_v7(),
+            "m".into(),
+            TreeKind::String,
+            TREE_REPAIR_PAGE_BYTE_CAP,
+            0,
+        );
+        let pages: Vec<_> = pager.collect();
+        assert_eq!(pages.len(), 1);
+        assert!(pages[0].is_last);
+        assert!(pages[0].entries.is_empty());
+        assert!(pages[0].next_cursor.is_none());
+        assert_eq!(pages[0].page_index, 0);
+    }
+
+    #[tokio::test]
+    async fn paging_chunks_by_byte_cap_and_marks_last() {
+        // Build entries large enough that a tiny cap forces
+        // multiple pages. Use ~1 KB string paths and a 4 KB
+        // entry budget so each page holds ~3-4 entries.
+        let big_path: String = "a".repeat(1024);
+        let entries: Vec<RepairEntry> = (0..12)
+            .map(|i| RepairEntry::String {
+                path: format!("{big_path}-{i}"),
+                tenants: vec![(Arc::from("worker-1"), i as u64)],
+            })
+            .collect();
+        let total = entries.len();
+
+        // 4 KB cap; entry size ~1 KB + bincode overhead.
+        let pager = PagingIter::new(
+            Box::new(entries.clone().into_iter()),
+            Uuid::now_v7(),
+            "m".into(),
+            TreeKind::String,
+            4 * 1024,
+            0,
+        );
+        let pages: Vec<_> = pager.collect();
+        assert!(pages.len() >= 2, "small cap must produce multiple pages");
+
+        // Total entries preserved; only the final page is marked
+        // last; each non-last page carries a non-None cursor.
+        let total_entries: usize = pages.iter().map(|p| p.entries.len()).sum();
+        assert_eq!(total_entries, total);
+        for (i, p) in pages.iter().enumerate() {
+            let is_last = i == pages.len() - 1;
+            assert_eq!(p.is_last, is_last, "page {i} is_last");
+            assert_eq!(p.next_cursor.is_none(), is_last, "page {i} cursor parity");
+            assert_eq!(p.page_index, i as u32, "page index sequential");
+            // Every page that's not the last must have at least
+            // one entry (we always pack at least one per page).
+            if !is_last {
+                assert!(!p.entries.is_empty(), "non-last page must be non-empty");
+            }
+        }
+
+        // Each non-last page's serialized bincode size stays
+        // close to the cap once header overhead is added back.
+        for p in &pages {
+            let size = bincode::serialized_size(p).unwrap() as usize;
+            // Final page may be smaller; just assert non-final
+            // pages don't exceed `cap + slop` for the slop budget
+            // (header overhead already reserved).
+            assert!(
+                size <= 4 * 1024 + TREE_REPAIR_PAGE_HEADER_OVERHEAD,
+                "page size {size} exceeds cap + header budget",
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn paging_oversized_single_entry_still_emits_one_per_page() {
+        // A single entry larger than the cap must still go out
+        // — we never produce an empty non-last page.
+        let huge: RepairEntry = RepairEntry::String {
+            path: "x".repeat(8 * 1024),
+            tenants: vec![(Arc::from("w1"), 0)],
+        };
+        let pager = PagingIter::new(
+            Box::new(vec![huge].into_iter()),
+            Uuid::now_v7(),
+            "m".into(),
+            TreeKind::String,
+            1024, // cap < entry size
+            0,
+        );
+        let pages: Vec<_> = pager.collect();
+        assert_eq!(pages.len(), 1, "single entry yields exactly one page");
+        assert!(pages[0].is_last);
+        assert_eq!(pages[0].entries.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn paging_cursor_resume_yields_same_total() {
+        let big_path: String = "p".repeat(1024);
+        let entries: Vec<RepairEntry> = (0..10)
+            .map(|i| RepairEntry::String {
+                path: format!("{big_path}-{i}"),
+                tenants: vec![(Arc::from("w1"), i as u64)],
+            })
+            .collect();
+
+        // Full pass.
+        let full: Vec<RepairEntry> = PagingIter::new(
+            Box::new(entries.clone().into_iter()),
+            Uuid::now_v7(),
+            "m".into(),
+            TreeKind::String,
+            4 * 1024,
+            0,
+        )
+        .flat_map(|p| p.entries)
+        .collect();
+        assert_eq!(full.len(), entries.len());
+        assert_eq!(full, entries);
+
+        // Resume halfway: skip 5 → final pass yields the last 5.
+        let resumed: Vec<RepairEntry> = PagingIter::new(
+            Box::new(entries.clone().into_iter()),
+            Uuid::now_v7(),
+            "m".into(),
+            TreeKind::String,
+            4 * 1024,
+            5,
+        )
+        .flat_map(|p| p.entries)
+        .collect();
+        assert_eq!(resumed.len(), 5);
+        assert_eq!(resumed, entries[5..]);
+    }
+
+    #[tokio::test]
+    async fn paging_cursor_encodes_cumulative_count() {
+        // Each non-last page's `next_cursor` must decode to the
+        // total items consumed so far — usable as a resume key.
+        let big_path: String = "c".repeat(1024);
+        let entries: Vec<RepairEntry> = (0..8)
+            .map(|i| RepairEntry::String {
+                path: format!("{big_path}-{i}"),
+                tenants: vec![(Arc::from("w1"), i as u64)],
+            })
+            .collect();
+        let pager = PagingIter::new(
+            Box::new(entries.into_iter()),
+            Uuid::now_v7(),
+            "m".into(),
+            TreeKind::String,
+            4 * 1024,
+            0,
+        );
+        let pages: Vec<_> = pager.collect();
+        let mut running_total = 0usize;
+        for (i, p) in pages.iter().enumerate() {
+            running_total += p.entries.len();
+            if i < pages.len() - 1 {
+                let cursor_bytes = p.next_cursor.as_ref().expect("non-last has cursor");
+                let decoded: u64 = bincode::deserialize(cursor_bytes).unwrap();
+                assert_eq!(decoded as usize, running_total, "page {i} cursor matches");
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn responder_publishes_pages_targeted_at_requester() {
+        let mesh = MeshKV::new("node-a".into());
+        let td = td_namespace(&mesh);
+        let req = req_namespace(&mesh);
+        let pages = page_namespace(&mesh);
+        let tree = Arc::new(MockTreeHandle::default());
+        tree.set_repair_stream(
+            "model-1",
+            TreeKind::String,
+            vec![
+                string_entry("hello", &[("w1", 1)]),
+                string_entry("hello world", &[("w1", 2), ("w2", 3)]),
+            ],
+        );
+        let adapter_tree: Arc<dyn TreeHandle> = tree.clone();
+        let peers: Arc<dyn PeerList> = MockPeerList::with(&["node-b"]);
+        let adapter = TreeSyncAdapter::new(td, req, pages, adapter_tree, peers, "node-a".into());
+
+        let session_id = Uuid::now_v7();
+        let request = make_request(
+            session_id,
+            "node-a", // targeted at us
+            "node-b", // requester
+            "model-1",
+            TreeKind::String,
+            None,
+        );
+        adapter.respond_to_repair_request(request);
+
+        let publishes = drain_page_publishes(&mesh);
+        assert!(
+            !publishes.is_empty(),
+            "responder must publish at least one page"
+        );
+        for (target, key, _payload) in &publishes {
+            assert_eq!(target, "node-b", "all pages targeted at requester");
+            let expected_prefix = format!("{REPAIR_PAGE_PREFIX}{session_id}:");
+            assert!(
+                key.starts_with(&expected_prefix),
+                "key {key} matches tree:page:{session_id}:N",
+            );
+        }
+
+        // Reconstruct the page sequence and verify entries cover
+        // the input set.
+        let mut all_entries: Vec<RepairEntry> = Vec::new();
+        for (_, _, payload) in &publishes {
+            let page: TreeRepairPage = bincode::deserialize(payload).unwrap();
+            all_entries.extend(page.entries);
+        }
+        assert_eq!(all_entries.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn responder_emits_empty_ack_for_unknown_model() {
+        // Same shape as "tree exists but is empty" — one is_last
+        // page with no entries — gives the requester an ACK.
+        let mesh = MeshKV::new("node-a".into());
+        let td = td_namespace(&mesh);
+        let req = req_namespace(&mesh);
+        let pages = page_namespace(&mesh);
+        let tree: Arc<dyn TreeHandle> = empty_handle();
+        let peers: Arc<dyn PeerList> = empty_peers();
+        let adapter = TreeSyncAdapter::new(td, req, pages, tree, peers, "node-a".into());
+
+        let request = make_request(
+            Uuid::now_v7(),
+            "node-a",
+            "node-b",
+            "unknown-model",
+            TreeKind::String,
+            None,
+        );
+        adapter.respond_to_repair_request(request);
+
+        let publishes = drain_page_publishes(&mesh);
+        assert_eq!(publishes.len(), 1, "exactly one ACK page");
+        let page: TreeRepairPage = bincode::deserialize(&publishes[0].2).unwrap();
+        assert!(page.is_last);
+        assert!(page.entries.is_empty());
+        assert!(page.next_cursor.is_none());
+    }
+
+    #[tokio::test]
+    async fn responder_drops_request_with_mismatched_target() {
+        let mesh = MeshKV::new("node-a".into());
+        let td = td_namespace(&mesh);
+        let req = req_namespace(&mesh);
+        let pages = page_namespace(&mesh);
+        let tree = Arc::new(MockTreeHandle::default());
+        tree.set_repair_stream(
+            "model-1",
+            TreeKind::String,
+            vec![string_entry("p", &[("w1", 1)])],
+        );
+        let adapter_tree: Arc<dyn TreeHandle> = tree.clone();
+        let peers: Arc<dyn PeerList> = empty_peers();
+        let adapter = TreeSyncAdapter::new(td, req, pages, adapter_tree, peers, "node-a".into());
+
+        // Target is some other peer — drop, no spawn, no publish.
+        let request = make_request(
+            Uuid::now_v7(),
+            "node-elsewhere",
+            "node-b",
+            "model-1",
+            TreeKind::String,
+            None,
+        );
+        let bytes = bincode::serialize(&request).unwrap();
+        adapter.handle_incoming_repair_request(&[Bytes::from(bytes)]);
+        // Yield once to let any spurious spawn observe state;
+        // none is expected.
+        tokio::task::yield_now().await;
+
+        let publishes = drain_page_publishes(&mesh);
+        assert!(
+            publishes.is_empty(),
+            "mismatched target_peer_id must drop the request",
+        );
+    }
+
+    #[tokio::test]
+    async fn responder_handles_two_distinct_sessions_independently() {
+        let mesh = MeshKV::new("node-a".into());
+        let td = td_namespace(&mesh);
+        let req = req_namespace(&mesh);
+        let pages = page_namespace(&mesh);
+        let tree = Arc::new(MockTreeHandle::default());
+        tree.set_repair_stream(
+            "model-1",
+            TreeKind::String,
+            vec![string_entry("a", &[("w1", 1)])],
+        );
+        tree.set_repair_stream(
+            "model-2",
+            TreeKind::Token,
+            vec![token_entry(&[1, 2, 3], &[("w2", 2)])],
+        );
+        let adapter_tree: Arc<dyn TreeHandle> = tree.clone();
+        let peers: Arc<dyn PeerList> = empty_peers();
+        let adapter = TreeSyncAdapter::new(td, req, pages, adapter_tree, peers, "node-a".into());
+
+        let session_a = Uuid::now_v7();
+        let session_b = Uuid::now_v7();
+        adapter.respond_to_repair_request(make_request(
+            session_a,
+            "node-a",
+            "node-b",
+            "model-1",
+            TreeKind::String,
+            None,
+        ));
+        adapter.respond_to_repair_request(make_request(
+            session_b,
+            "node-a",
+            "node-c",
+            "model-2",
+            TreeKind::Token,
+            None,
+        ));
+
+        let publishes = drain_page_publishes(&mesh);
+        let mut by_session: std::collections::HashMap<Uuid, Vec<TreeRepairPage>> =
+            std::collections::HashMap::new();
+        for (_, _, payload) in &publishes {
+            let page: TreeRepairPage = bincode::deserialize(payload).unwrap();
+            by_session.entry(page.session_id).or_default().push(page);
+        }
+        assert!(by_session.contains_key(&session_a));
+        assert!(by_session.contains_key(&session_b));
+        // Each session ends with exactly one is_last=true page.
+        for pages in by_session.values() {
+            let last = pages.iter().filter(|p| p.is_last).count();
+            assert_eq!(last, 1, "each session has exactly one terminal page");
+        }
+    }
+
+    #[tokio::test]
+    async fn responder_resumes_from_request_cursor() {
+        let big_path: String = "r".repeat(1024);
+        let canned: Vec<RepairEntry> = (0..6)
+            .map(|i| RepairEntry::String {
+                path: format!("{big_path}-{i}"),
+                tenants: vec![(Arc::from("w1"), i as u64)],
+            })
+            .collect();
+        let mesh = MeshKV::new("node-a".into());
+        let td = td_namespace(&mesh);
+        let req = req_namespace(&mesh);
+        let pages = page_namespace(&mesh);
+        let tree = Arc::new(MockTreeHandle::default());
+        tree.set_repair_stream("model-1", TreeKind::String, canned.clone());
+        let adapter_tree: Arc<dyn TreeHandle> = tree.clone();
+        let peers: Arc<dyn PeerList> = empty_peers();
+        let adapter = TreeSyncAdapter::new(td, req, pages, adapter_tree, peers, "node-a".into());
+
+        // Resume at offset 4 → response covers the last 2 entries.
+        let cursor = bincode::serialize(&4u64).unwrap();
+        adapter.respond_to_repair_request(make_request(
+            Uuid::now_v7(),
+            "node-a",
+            "node-b",
+            "model-1",
+            TreeKind::String,
+            Some(cursor),
+        ));
+
+        let publishes = drain_page_publishes(&mesh);
+        let mut all_entries: Vec<RepairEntry> = Vec::new();
+        for (_, _, payload) in &publishes {
+            let page: TreeRepairPage = bincode::deserialize(payload).unwrap();
+            all_entries.extend(page.entries);
+        }
+        assert_eq!(all_entries.len(), 2);
+        assert_eq!(all_entries, canned[4..]);
+    }
+
+    #[tokio::test]
+    #[should_panic(
+        expected = "TreeSyncAdapter requires a repair-page namespace scoped to `tree:page:`"
+    )]
+    async fn new_rejects_wrong_pages_prefix() {
+        // Pass the repair-request namespace as the pages arg.
+        let mesh = MeshKV::new("node-a".into());
+        let td = td_namespace(&mesh);
+        let req = req_namespace(&mesh);
+        let req_again = mesh.configure_stream_prefix(
+            "tree:page-misnamed:",
+            StreamConfig {
+                max_buffer_bytes: 64 * 1024,
+                routing: StreamRouting::Targeted,
+            },
+        );
+        let tree: Arc<dyn TreeHandle> = empty_handle();
+        let peers: Arc<dyn PeerList> = empty_peers();
+        let _ = TreeSyncAdapter::new(td, req, req_again, tree, peers, "node-a".into());
     }
 }

--- a/model_gateway/src/mesh/adapters/tree_sync.rs
+++ b/model_gateway/src/mesh/adapters/tree_sync.rs
@@ -134,126 +134,79 @@ pub struct TreeRepairPage {
     pub is_last: bool,
 }
 
-/// Iterator that chunks a stream of [`RepairEntry`] into
-/// byte-capped [`TreeRepairPage`]s. Always emits at least one
-/// page (even on an empty stream — the empty page acts as an
-/// ACK for the requester and gives d-2c a clean session-cleanup
-/// signal).
-struct PagingIter {
-    stream: Box<dyn Iterator<Item = RepairEntry> + Send>,
-    /// Entry pulled from the stream that didn't fit in the
-    /// previous page's budget; consumed first on the next call.
-    deferred: Option<RepairEntry>,
+/// Chunk a stream of [`RepairEntry`] into byte-capped
+/// [`TreeRepairPage`]s. Always emits at least one page (even on
+/// an empty stream — the empty page acts as an ACK for the
+/// requester and gives d-2c a clean session-cleanup signal).
+///
+/// `start_skip` advances the stream by that many items before
+/// chunking — used to honour [`TreeRepairRequest::cursor`].
+/// Unknown serialized-size estimates default to `entry_budget`
+/// so an estimator failure forces a page break (safe direction —
+/// never silently overflow the cap).
+fn paginate(
+    mut stream: Box<dyn Iterator<Item = RepairEntry> + Send>,
     session_id: Uuid,
     model_id: String,
     tree_kind: TreeKind,
-    /// Per-page budget for entry bytes (cap minus reserved header
-    /// overhead). At least one entry always fits per page even
-    /// if the entry alone exceeds the budget.
-    entry_budget: usize,
-    /// Total entries already consumed across all pages, including
-    /// any entries skipped via the start cursor. Used as the
-    /// `next_cursor` value for the page being built.
-    cumulative_consumed: u64,
-    page_index: u32,
-    finished: bool,
-}
-
-impl PagingIter {
-    fn new(
-        mut stream: Box<dyn Iterator<Item = RepairEntry> + Send>,
-        session_id: Uuid,
-        model_id: String,
-        tree_kind: TreeKind,
-        byte_cap: usize,
-        start_skip: u64,
-    ) -> Self {
-        // Best-effort cursor: skip entries the requester already
-        // has. If the tree shrunk between rounds we end early —
-        // the final page just has fewer entries.
-        for _ in 0..start_skip {
-            if stream.next().is_none() {
-                break;
-            }
-        }
-        Self {
-            stream,
-            deferred: None,
-            session_id,
-            model_id,
-            tree_kind,
-            entry_budget: byte_cap.saturating_sub(TREE_REPAIR_PAGE_HEADER_OVERHEAD),
-            cumulative_consumed: start_skip,
-            page_index: 0,
-            finished: false,
+    byte_cap: usize,
+    start_skip: u64,
+) -> Vec<TreeRepairPage> {
+    // Best-effort cursor: skip entries the requester already
+    // has. If the tree shrunk between rounds we end early —
+    // the final page just has fewer entries.
+    for _ in 0..start_skip {
+        if stream.next().is_none() {
+            break;
         }
     }
-}
 
-impl Iterator for PagingIter {
-    type Item = TreeRepairPage;
+    let entry_budget = byte_cap.saturating_sub(TREE_REPAIR_PAGE_HEADER_OVERHEAD);
+    let mut pages: Vec<TreeRepairPage> = Vec::new();
+    let mut entries: Vec<RepairEntry> = Vec::new();
+    let mut size: usize = 0;
+    let mut page_index: u32 = 0;
 
-    fn next(&mut self) -> Option<TreeRepairPage> {
-        if self.finished {
-            return None;
+    // `index` is the count of entries consumed BEFORE this
+    // iteration — exactly the cursor a requester would need to
+    // resume from the entry we're about to consider.
+    for (index, entry) in (start_skip..).zip(&mut stream) {
+        let entry_size = bincode::serialized_size(&entry).unwrap_or(entry_budget as u64) as usize;
+        if !entries.is_empty() && size + entry_size > entry_budget {
+            // Current page is full — emit it and start a new one
+            // with this entry as the first item.
+            pages.push(TreeRepairPage {
+                session_id,
+                model_id: model_id.clone(),
+                tree_kind,
+                page_index,
+                entries: std::mem::take(&mut entries),
+                // u64 always bincode-serializes; an empty cursor
+                // decodes back to 0 ("start over") on the
+                // unreachable failure path.
+                next_cursor: Some(bincode::serialize(&index).unwrap_or_default()),
+                is_last: false,
+            });
+            page_index += 1;
+            size = 0;
         }
-
-        let mut entries: Vec<RepairEntry> = Vec::new();
-        let mut size: usize = 0;
-        let mut hit_budget = false;
-
-        // Carry over the entry deferred from the previous page.
-        // Default unknown sizes to the budget so an estimator
-        // failure forces a page break (the safe direction —
-        // never silently overflow the cap). Unreachable for our
-        // schema in practice; defensive against future changes.
-        if let Some(entry) = self.deferred.take() {
-            let entry_size =
-                bincode::serialized_size(&entry).unwrap_or(self.entry_budget as u64) as usize;
-            entries.push(entry);
-            size += entry_size;
-            self.cumulative_consumed += 1;
-        }
-
-        for entry in self.stream.by_ref() {
-            let entry_size =
-                bincode::serialized_size(&entry).unwrap_or(self.entry_budget as u64) as usize;
-            if !entries.is_empty() && size + entry_size > self.entry_budget {
-                self.deferred = Some(entry);
-                hit_budget = true;
-                break;
-            }
-            entries.push(entry);
-            size += entry_size;
-            self.cumulative_consumed += 1;
-        }
-
-        let is_last = !hit_budget;
-        let next_cursor = if is_last {
-            None
-        } else {
-            // u64 always bincode-serializes; if it ever didn't,
-            // an empty cursor decodes back to 0 ("start over") —
-            // safe best-effort fallback rather than a panic.
-            Some(bincode::serialize(&self.cumulative_consumed).unwrap_or_default())
-        };
-
-        let page = TreeRepairPage {
-            session_id: self.session_id,
-            model_id: self.model_id.clone(),
-            tree_kind: self.tree_kind,
-            page_index: self.page_index,
-            entries,
-            next_cursor,
-            is_last,
-        };
-
-        self.page_index += 1;
-        if is_last {
-            self.finished = true;
-        }
-        Some(page)
+        entries.push(entry);
+        size += entry_size;
     }
+
+    // Always emit a terminal page — even empty — so the
+    // requester gets an ACK on empty trees / unknown models.
+    pages.push(TreeRepairPage {
+        session_id,
+        model_id,
+        tree_kind,
+        page_index,
+        entries,
+        next_cursor: None,
+        is_last: true,
+    });
+
+    pages
 }
 
 /// Decode a [`TreeRepairRequest::cursor`] (bincode-encoded `u64`
@@ -589,7 +542,7 @@ impl TreeSyncAdapter {
             .unwrap_or_else(|| Box::new(std::iter::empty()));
 
         let start_skip = decode_cursor(request.cursor.as_deref());
-        let pager = PagingIter::new(
+        let pages = paginate(
             stream,
             request.session_id,
             request.model_id.clone(),
@@ -599,7 +552,7 @@ impl TreeSyncAdapter {
         );
 
         let mut pages_sent: u32 = 0;
-        for page in pager {
+        for page in pages {
             let key = format!(
                 "{REPAIR_PAGE_PREFIX}{}:{}",
                 page.session_id, page.page_index,
@@ -1332,7 +1285,7 @@ mod tests {
     async fn paging_empty_stream_emits_one_is_last_page() {
         // Empty input → one page so the requester sees an ACK.
         let stream: Box<dyn Iterator<Item = RepairEntry> + Send> = Box::new(std::iter::empty());
-        let pager = PagingIter::new(
+        let pages = paginate(
             stream,
             Uuid::now_v7(),
             "m".into(),
@@ -1340,7 +1293,6 @@ mod tests {
             TREE_REPAIR_PAGE_BYTE_CAP,
             0,
         );
-        let pages: Vec<_> = pager.collect();
         assert_eq!(pages.len(), 1);
         assert!(pages[0].is_last);
         assert!(pages[0].entries.is_empty());
@@ -1363,7 +1315,7 @@ mod tests {
         let total = entries.len();
 
         // 4 KB cap; entry size ~1 KB + bincode overhead.
-        let pager = PagingIter::new(
+        let pages = paginate(
             Box::new(entries.clone().into_iter()),
             Uuid::now_v7(),
             "m".into(),
@@ -1371,7 +1323,6 @@ mod tests {
             4 * 1024,
             0,
         );
-        let pages: Vec<_> = pager.collect();
         assert!(pages.len() >= 2, "small cap must produce multiple pages");
 
         // Total entries preserved; only the final page is marked
@@ -1412,7 +1363,7 @@ mod tests {
             path: "x".repeat(8 * 1024),
             tenants: vec![(Arc::from("w1"), 0)],
         };
-        let pager = PagingIter::new(
+        let pages = paginate(
             Box::new(vec![huge].into_iter()),
             Uuid::now_v7(),
             "m".into(),
@@ -1420,7 +1371,6 @@ mod tests {
             1024, // cap < entry size
             0,
         );
-        let pages: Vec<_> = pager.collect();
         assert_eq!(pages.len(), 1, "single entry yields exactly one page");
         assert!(pages[0].is_last);
         assert_eq!(pages[0].entries.len(), 1);
@@ -1437,7 +1387,7 @@ mod tests {
             .collect();
 
         // Full pass.
-        let full: Vec<RepairEntry> = PagingIter::new(
+        let full: Vec<RepairEntry> = paginate(
             Box::new(entries.clone().into_iter()),
             Uuid::now_v7(),
             "m".into(),
@@ -1445,13 +1395,14 @@ mod tests {
             4 * 1024,
             0,
         )
+        .into_iter()
         .flat_map(|p| p.entries)
         .collect();
         assert_eq!(full.len(), entries.len());
         assert_eq!(full, entries);
 
         // Resume halfway: skip 5 → final pass yields the last 5.
-        let resumed: Vec<RepairEntry> = PagingIter::new(
+        let resumed: Vec<RepairEntry> = paginate(
             Box::new(entries.clone().into_iter()),
             Uuid::now_v7(),
             "m".into(),
@@ -1459,6 +1410,7 @@ mod tests {
             4 * 1024,
             5,
         )
+        .into_iter()
         .flat_map(|p| p.entries)
         .collect();
         assert_eq!(resumed.len(), 5);
@@ -1476,7 +1428,7 @@ mod tests {
                 tenants: vec![(Arc::from("w1"), i as u64)],
             })
             .collect();
-        let pager = PagingIter::new(
+        let pages = paginate(
             Box::new(entries.into_iter()),
             Uuid::now_v7(),
             "m".into(),
@@ -1484,7 +1436,6 @@ mod tests {
             4 * 1024,
             0,
         );
-        let pages: Vec<_> = pager.collect();
         let mut running_total = 0usize;
         for (i, p) in pages.iter().enumerate() {
             running_total += p.entries.len();

--- a/model_gateway/src/mesh/adapters/tree_sync.rs
+++ b/model_gateway/src/mesh/adapters/tree_sync.rs
@@ -689,6 +689,7 @@ impl TreeSyncAdapter {
                     warn!(
                         session_id = %page.session_id,
                         page_index = page.page_index,
+                        entry_count = page.entries.len(),
                         %err,
                         "failed to serialize TreeRepairPage; skipping",
                     );

--- a/model_gateway/src/mesh/adapters/tree_sync.rs
+++ b/model_gateway/src/mesh/adapters/tree_sync.rs
@@ -203,15 +203,21 @@ impl Iterator for PagingIter {
         let mut hit_budget = false;
 
         // Carry over the entry deferred from the previous page.
+        // Default unknown sizes to the budget so an estimator
+        // failure forces a page break (the safe direction —
+        // never silently overflow the cap). Unreachable for our
+        // schema in practice; defensive against future changes.
         if let Some(entry) = self.deferred.take() {
-            let entry_size = bincode::serialized_size(&entry).unwrap_or(0) as usize;
+            let entry_size =
+                bincode::serialized_size(&entry).unwrap_or(self.entry_budget as u64) as usize;
             entries.push(entry);
             size += entry_size;
             self.cumulative_consumed += 1;
         }
 
         for entry in self.stream.by_ref() {
-            let entry_size = bincode::serialized_size(&entry).unwrap_or(0) as usize;
+            let entry_size =
+                bincode::serialized_size(&entry).unwrap_or(self.entry_budget as u64) as usize;
             if !entries.is_empty() && size + entry_size > self.entry_budget {
                 self.deferred = Some(entry);
                 hit_budget = true;
@@ -559,12 +565,13 @@ impl TreeSyncAdapter {
             return;
         }
 
+        // CPU-bound: tree walk + bincode-serialize multi-MB
+        // pages. Park it on the blocking pool so a busy responder
+        // doesn't starve tokio worker threads. Bounded by stream
+        // length; loss on shutdown is fine (the requester retries
+        // or times out via d-2c session cleanup).
         let this = Arc::clone(self);
-        #[expect(
-            clippy::disallowed_methods,
-            reason = "per-request paging task is bounded by stream length and exits on iterator exhaustion"
-        )]
-        tokio::spawn(async move {
+        tokio::task::spawn_blocking(move || {
             this.respond_to_repair_request(request);
         });
     }

--- a/model_gateway/src/mesh/adapters/tree_sync.rs
+++ b/model_gateway/src/mesh/adapters/tree_sync.rs
@@ -48,7 +48,10 @@ pub const TREE_REPAIR_PAGE_BYTE_CAP: usize = 2 * 1024 * 1024;
 /// other than `entries`). Subtracted from the byte cap so the
 /// assembled page stays under the cap once header bytes are
 /// added back. UUID + model_id + tree_kind + counters comfortably
-/// fit; 256 is conservative.
+/// fit; 256 is conservative for realistic model-id lengths
+/// (typical ~30 chars, max ~100). A pathological multi-hundred-
+/// char model_id could theoretically push the actual header
+/// past this budget, but SMG does not produce such ids.
 const TREE_REPAIR_PAGE_HEADER_OVERHEAD: usize = 256;
 
 /// Hard ceiling on the bincode-serialized size of a single
@@ -285,35 +288,22 @@ impl Iterator for PagingIter {
         let mut size: usize = 0;
         let mut hit_budget = false;
 
-        // Carry over the entry deferred from the previous page,
-        // running it through the same classification as fresh
-        // pulls (it could itself be oversized if it was deferred
-        // by a sole-entry warn-emit on the previous page).
-        if let Some(entry) = self.deferred.take() {
+        // Pull deferred entry first, then fall through to the
+        // stream. Both sources share one classification path.
+        // Pull-then-process avoids holding a `&mut self.stream`
+        // borrow across the `&mut self` call to `try_pack_entry`.
+        loop {
+            let entry = if let Some(d) = self.deferred.take() {
+                d
+            } else if let Some(s) = self.stream.next() {
+                s
+            } else {
+                break;
+            };
             if let Some(deferred) = self.try_pack_entry(&mut entries, &mut size, entry) {
                 self.deferred = Some(deferred);
                 hit_budget = true;
-            }
-        }
-
-        if !hit_budget {
-            // Pull-then-process avoids holding a `&mut self.stream`
-            // borrow across the `&mut self` call to `try_pack_entry`,
-            // so `for` / `while let` over the stream won't compile
-            // here even though clippy prefers them.
-            #[expect(
-                clippy::while_let_loop,
-                reason = "alternative forms hold &mut self.stream across the try_pack_entry &mut self call"
-            )]
-            loop {
-                let Some(entry) = self.stream.next() else {
-                    break;
-                };
-                if let Some(deferred) = self.try_pack_entry(&mut entries, &mut size, entry) {
-                    self.deferred = Some(deferred);
-                    hit_budget = true;
-                    break;
-                }
+                break;
             }
         }
 

--- a/model_gateway/src/policies/cache_aware.rs
+++ b/model_gateway/src/policies/cache_aware.rs
@@ -55,7 +55,10 @@ use super::{
     get_healthy_worker_indices, normalize_model_key, utils::PeriodicTask, CacheAwareConfig,
     LoadBalancingPolicy, SelectWorkerInfo,
 };
-use crate::worker::{KvEventMonitor, Worker};
+use crate::{
+    mesh::adapters::tree_sync::RepairEntry,
+    worker::{KvEventMonitor, Worker},
+};
 
 /// Cache-aware routing policy
 ///
@@ -727,6 +730,18 @@ pub trait TreeHandle: Send + Sync + std::fmt::Debug {
         node_hash: u64,
         worker_url: &str,
     ) -> bool;
+
+    /// Open a stream of `RepairEntry` for one `(model_id,
+    /// tree_kind)`, in the deterministic pre-order produced by
+    /// the underlying tree's `iter_entries`. Returns `None` if
+    /// no tree exists locally for that model. Paging is wire
+    /// shape and lives in the adapter, not on this trait — the
+    /// stream just yields entries one at a time.
+    fn open_repair_stream(
+        &self,
+        model_id: &str,
+        tree_kind: TreeKind,
+    ) -> Option<Box<dyn Iterator<Item = RepairEntry> + Send>>;
 }
 
 impl TreeHandle for CacheAwarePolicy {
@@ -780,6 +795,28 @@ impl TreeHandle for CacheAwarePolicy {
                 };
                 tree.insert_tokens(tokens.value(), worker_url);
                 true
+            }
+        }
+    }
+
+    fn open_repair_stream(
+        &self,
+        model_id: &str,
+        tree_kind: TreeKind,
+    ) -> Option<Box<dyn Iterator<Item = RepairEntry> + Send>> {
+        let model_id = normalize_model_key(model_id);
+        match tree_kind {
+            TreeKind::String => {
+                let tree = self.string_trees.get(model_id)?.value().clone();
+                Some(Box::new(tree.iter_entries().map(|(path, tenants)| {
+                    RepairEntry::String { path, tenants }
+                })))
+            }
+            TreeKind::Token => {
+                let tree = self.token_trees.get(model_id)?.value().clone();
+                Some(Box::new(tree.iter_entries().map(|(tokens, tenants)| {
+                    RepairEntry::Token { tokens, tenants }
+                })))
             }
         }
     }


### PR DESCRIPTION
## Description

### Problem

The mesh repair protocol (slices 5c, d-1) lets a node ASK for a peer's tree when it sees an unknown hash. Nothing yet implements the answering side — when a peer receives a `tree:req:`, it has no way to ship its tree back. This blocks d-2c (the receiving side) and d-3 (cold-start fan-out), since both need the responder running to do anything useful.

### Solution

Add the `tree:page:` wire format and the responder logic that walks a peer's repair request, chunks the local tree into byte-capped pages, and publishes each page targeted at the requester.

Ownership split follows slice 5b's narrow-trait precedent (#1364):

- **`TreeHandle::open_repair_stream(model_id, tree_kind)`** exposes just the policy-private `(model, kind) → tree` resolution. The trait stays minimal — it only answers what the adapter genuinely cannot reach.
- **Paging** (byte-cap accumulation, cursor encoding, page assembly) lives in the adapter alongside the wire types, since paging is wire shape, not policy state. Paging tests run with `vec![entry, ...].into_iter()` — no policy plumbing needed.

## Changes

`model_gateway/src/mesh/adapters/tree_sync.rs`:
- Wire types: `RepairEntry` (String/Token variants), `TreeRepairPage` (session_id, model_id, tree_kind, page_index, entries, next_cursor, is_last).
- `TREE_REPAIR_PAGE_BYTE_CAP = 2 MiB` const per spec §3.1.
- `PagingIter`: byte-cap chunker over `Iterator<Item = RepairEntry>`. Always emits at least one page (empty stream → one `is_last=true` ACK page).
- `tree_repair_pages: Arc<StreamNamespace>` added as a 4th constructor arg; prefix-asserted to `tree:page:`.
- `start()` adds a `tree:req:` subscription that filters by `target_peer_id == self.node_name` and dispatches each request to a per-session `tokio::spawn` so concurrent repairs across distinct `(model, kind)` don't head-of-line block.
- `respond_to_repair_request`: reads the cursor, opens the stream, paginates, publishes each page as `tree:page:{session_id}:{N}`.
- `decode_cursor`: `Option<&[u8]>` → u64; malformed cursor decodes as 0 (start over) — best-effort recovery.

`model_gateway/src/policies/cache_aware.rs`:
- `TreeHandle::open_repair_stream` trait method.
- `CacheAwarePolicy` impl: dispatches to `string_trees` / `token_trees` `iter_entries()` and maps each yield into `RepairEntry::{String,Token}`. Returns `None` on unknown model.

## Test Plan

12 new unit tests across the wire format, paging logic, and responder, plus a panic test for the new prefix-assert. All 30 tree_sync tests pass; full \`cargo test -p smg --lib\` passes (824 tests).

- \`repair_entry_and_page_round_trip_through_bincode\` — wire format round-trip for both variants.
- \`paging_empty_stream_emits_one_is_last_page\` — empty input still yields an ACK page.
- \`paging_chunks_by_byte_cap_and_marks_last\` — multi-page case; only final page is \`is_last\`; all non-final pages carry a \`next_cursor\`; each page's bincode size stays within \`cap + header overhead\`.
- \`paging_oversized_single_entry_still_emits_one_per_page\` — a single entry larger than the cap still goes out (no empty pages).
- \`paging_cursor_resume_yields_same_total\` — full pass and skip-5 pass yield identical entry sets.
- \`paging_cursor_encodes_cumulative_count\` — each non-last page's cursor decodes to the running consumed count.
- \`responder_publishes_pages_targeted_at_requester\` — request → pages, all keyed \`tree:page:{session_id}:N\` and targeted at \`requester_peer_id\`.
- \`responder_emits_empty_ack_for_unknown_model\` — same shape as empty tree.
- \`responder_drops_request_with_mismatched_target\` — defense-in-depth target filter.
- \`responder_handles_two_distinct_sessions_independently\` — concurrent (model, kind) requests both finish with one terminal page each.
- \`responder_resumes_from_request_cursor\` — cursor=4 on a 6-entry tree → response covers entries [4..].
- \`new_rejects_wrong_pages_prefix\` — constructor panic for misnamed pages namespace.

Out of scope (slice d-2c): receiving pages on this node, \`apply_repair_page\`, session lifecycle / \`outstanding_repairs\` cleanup, retry/timeout on missing pages.

<details>
<summary>Checklist</summary>

- [x] \`cargo +nightly fmt\` passes
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Paginated, byte-capped repair pages with guaranteed terminal ACKs for reliable large-data recovery.
  * Targeted delivery and resumable repair streams via cursor support for robust, interruptible transfers.
  * New stream access for tree repair to enable serving local tree contents for repairs.

* **Tests**
  * Expanded tests for pagination, cursor resumption, targeting, oversized entries, and concurrent sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->