### PR TITLE
fix(deps): drop default features on hf-hub; opt into rustls-tls

### DIFF
--- a/crates/multimodal/Cargo.toml
+++ b/crates/multimodal/Cargo.toml
@@ -17,7 +17,7 @@ name = "llm_multimodal"
 
 [dependencies]
 base64 = "0.22"
-hf-hub = "0.5.0"
+hf-hub = { version = "0.5.0", default-features = false, features = ["tokio", "rustls-tls"] }
 bytes = { version = "1.8.0", features = ["serde"] }
 fast_image_resize = { version = "6.0.0", features = ["image"] }
 image = { version = "0.25.4", default-features = false, features = ["png", "jpeg", "gif", "bmp", "ico", "tiff", "webp"] }

--- a/crates/tokenizer/Cargo.toml
+++ b/crates/tokenizer/Cargo.toml
@@ -31,7 +31,7 @@ futures.workspace = true
 aho-corasick = "1.1"
 base64 = "0.22"
 rustc-hash = "1.1"
-hf-hub = { version = "0.5.0", features = ["tokio"] }
+hf-hub = { version = "0.5.0", default-features = false, features = ["tokio", "rustls-tls"] }
 minijinja = { version = "2.0", features = ["unstable_machinery", "json", "builtins", "loader", "loop_controls"] }
 minijinja-contrib = { version = "2.0", features = ["pycompat"] }
 rayon = "1.10"


### PR DESCRIPTION
## Description

Both `multimodal` and `tokenizer` only use the async (tokio) hf-hub client (`hf_hub::api::tokio::ApiBuilder`); they don't need the default-on `native-tls` + blocking `ureq` features. Pin `hf-hub = { default-features = false, features = ["tokio", "rustls-tls"] }` so downstream crates don't have to pull in the openssl/native-tls toolchain just to use lightseek.

### Problem

`crates/multimodal` and `crates/tokenizer` depend on `hf-hub = "0.5.0"` with default features (`["default-tls", "tokio", "ureq"]`). That transitively pulls in:

- `native-tls`, `tokio-native-tls`, `hyper-tls`
- `openssl`, `openssl-sys`, `openssl-macros`
- `openssl-src` (vendored OpenSSL C source — requires `perl` at build time)
- the blocking `ureq` client (with native-tls)

Neither crate ever calls the blocking client — the only hf-hub usage in both crates is `hf_hub::api::tokio::ApiBuilder`. Consumers that depend on `llm-multimodal` (e.g. `ai-dynamo/dynamo`, which explicitly bans `native-tls` and `openssl-sys` in their `cargo-deny` config) currently have to fork or `[patch.crates-io]` to use the crate.

### Solution

Pin `hf-hub` with `default-features = false` and the minimal feature set actually used (`tokio` + `rustls-tls`). The async `ApiBuilder` API stays available; the openssl/native-tls subtree disappears from the dep graph; the build no longer needs `perl` to compile vendored OpenSSL.

## Changes

- `crates/multimodal/Cargo.toml`: `hf-hub = "0.5.0"` → `hf-hub = { version = "0.5.0", default-features = false, features = ["tokio", "rustls-tls"] }`
- `crates/tokenizer/Cargo.toml`: `hf-hub = { version = "0.5.0", features = ["tokio"] }` → `hf-hub = { version = "0.5.0", default-features = false, features = ["tokio", "rustls-tls"] }`

No code changes — both crates already only call `hf_hub::api::tokio::ApiBuilder`, which is in the `tokio` feature.

## Test Plan

**Before:**
```text
$ cargo tree -p llm-multimodal --target x86_64-unknown-linux-gnu | grep -E 'native-tls|openssl|rustls'
│   ├── native-tls v0.2.18
│   │   ├── openssl v0.10.79
│   │   │   ├── openssl-macros v0.1.1 (proc-macro)
│   │   │   └── openssl-sys v0.9.115
│   │   ├── openssl-probe v0.2.1
│   │   └── openssl-sys v0.9.115 (*)
│   ├── reqwest v0.12.28
│       └── native-tls v0.2.18 (*)
└── openssl-sys v0.9.115 (*)
```

**After:**
```text
$ cargo tree -p llm-multimodal --target x86_64-unknown-linux-gnu | grep -E 'native-tls|openssl|rustls'
│   │   ├── hyper-rustls v0.27.9
│   │   │   ├── rustls v0.23.40
│   │   │   │   ├── rustls-pki-types v1.14.1
│   │   │   │   └── rustls-webpki v0.103.13
│   │   │   ├── tokio-rustls v0.26.4
```

`cargo tree -i native-tls` returns *"did not match any packages"*.

`cargo check -p llm-multimodal -p llm-tokenizer` passes:
```text
    Checking llm-tokenizer v1.3.2 (/workspace/crates/tokenizer)
    Checking llm-multimodal v1.5.0 (/workspace/crates/multimodal)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 39.86s
```

Existing tests in both crates pass; no behavior change in the async `ApiBuilder` path that the crates actually use.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency configurations to improve network security, TLS handling, and asynchronous runtime compatibility for more reliable and secure operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->