### PR TITLE
feat(grpc): apply backend sampling defaults

### DIFF
--- a/crates/grpc_client/proto/sglang_scheduler.proto
+++ b/crates/grpc_client/proto/sglang_scheduler.proto
@@ -438,6 +438,10 @@ message GetModelInfoResponse {
   string id2label_json = 16;
   // Number of classification labels (0 if not a classifier)
   int32 num_labels = 17;
+
+  // Resolved sampling defaults from --sampling-defaults + --preferred-sampling-params.
+  // JSON dict, e.g. '{"temperature": 0.6, "top_p": 0.9}'. Empty = no overrides.
+  string default_sampling_params_json = 20;
 }
 
 // Get server information

--- a/crates/grpc_client/proto/vllm_engine.proto
+++ b/crates/grpc_client/proto/vllm_engine.proto
@@ -303,6 +303,7 @@ message GetModelInfoResponse {
   int32 pad_token_id = 11;
   int32 bos_token_id = 12;
   int32 max_req_input_len = 13;
+  string default_sampling_params_json = 14;
 }
 
 message GetServerInfoRequest {}

--- a/grpc_servicer/smg_grpc_servicer/sglang/server.py
+++ b/grpc_servicer/smg_grpc_servicer/sglang/server.py
@@ -130,6 +130,7 @@ async def serve_grpc(
     servicer = SGLangSchedulerServicer(
         request_manager=request_manager,
         server_args=server_args,
+        model_config=model_config,
         model_info=model_info,
         scheduler_info=scheduler_info,
         health_servicer=health_servicer,

--- a/grpc_servicer/smg_grpc_servicer/sglang/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/sglang/servicer.py
@@ -8,6 +8,7 @@ for orchestration without tokenization.
 import asyncio
 import dataclasses
 import hashlib
+import json
 import logging
 import os
 import time
@@ -25,6 +26,7 @@ import zmq.asyncio
 from google.protobuf.json_format import MessageToDict
 from google.protobuf.struct_pb2 import Struct
 from google.protobuf.timestamp_pb2 import Timestamp
+from sglang.srt.configs.model_config import ModelConfig
 from sglang.srt.disaggregation.kv_events import (
     AllBlocksCleared,
     BlockRemoved,
@@ -53,6 +55,23 @@ from smg_grpc_servicer.tokenizer_bundle import CHUNK_SIZE, build_tokenizer_zip
 
 logger = logging.getLogger(__name__)
 HEALTH_CHECK_TIMEOUT = int(os.getenv("SGLANG_HEALTH_CHECK_TIMEOUT", 20))
+SAMPLING_DEFAULT_KEYS = (
+    "temperature",
+    "top_p",
+    "top_k",
+    "min_p",
+    "repetition_penalty",
+)
+
+
+def _filtered_sampling_defaults(params: dict | None) -> dict:
+    if not params:
+        return {}
+    return {
+        key: params[key]
+        for key in SAMPLING_DEFAULT_KEYS
+        if key in params and params[key] is not None
+    }
 
 
 def _convert_loads_to_protobuf(
@@ -159,6 +178,7 @@ class SGLangSchedulerServicer(sglang_scheduler_pb2_grpc.SglangSchedulerServicer)
         self,
         request_manager: GrpcRequestManager,
         server_args: ServerArgs,
+        model_config: ModelConfig,
         model_info: dict,
         scheduler_info: dict,
         health_servicer: SGLangHealthServicer | None = None,
@@ -166,6 +186,7 @@ class SGLangSchedulerServicer(sglang_scheduler_pb2_grpc.SglangSchedulerServicer)
         """Initialize the standalone gRPC service."""
         self.request_manager = request_manager
         self.server_args = server_args
+        self.model_config = model_config
         self.model_info = model_info
         self.scheduler_info = scheduler_info
         self.start_time = time.time()
@@ -420,6 +441,35 @@ class SGLangSchedulerServicer(sglang_scheduler_pb2_grpc.SglangSchedulerServicer)
                 message=str(e),
             )
 
+    def _default_sampling_params_json(self) -> str:
+        defaults = dict(self.model_config.get_default_sampling_params() or {})
+        preferred = self.server_args.preferred_sampling_params
+        if preferred:
+            if isinstance(preferred, str):
+                try:
+                    preferred = json.loads(preferred)
+                except json.JSONDecodeError:
+                    logger.warning("Failed to parse preferred_sampling_params JSON")
+                    preferred = None
+            if isinstance(preferred, dict):
+                defaults.update(preferred)
+            else:
+                logger.warning(
+                    "Ignoring preferred_sampling_params with unsupported type: %s",
+                    type(preferred).__name__,
+                )
+
+        defaults = _filtered_sampling_defaults(defaults)
+        return json.dumps(defaults, separators=(",", ":")) if defaults else ""
+
+    def _preferred_sampling_params_json(self) -> str:
+        preferred = self.server_args.preferred_sampling_params
+        if isinstance(preferred, dict):
+            return json.dumps(preferred, separators=(",", ":"))
+        if isinstance(preferred, str):
+            return preferred
+        return json.dumps(preferred, separators=(",", ":")) if preferred else ""
+
     async def GetModelInfo(
         self,
         _request: sglang_scheduler_pb2.GetModelInfoRequest,
@@ -436,7 +486,8 @@ class SGLangSchedulerServicer(sglang_scheduler_pb2_grpc.SglangSchedulerServicer)
             model_path=self.server_args.model_path,
             tokenizer_path=self.server_args.tokenizer_path or "",
             is_generation=is_generation,
-            preferred_sampling_params=(self.server_args.preferred_sampling_params or ""),
+            preferred_sampling_params=self._preferred_sampling_params_json(),
+            default_sampling_params_json=self._default_sampling_params_json(),
             weight_version=self.server_args.weight_version or "",
             served_model_name=self.server_args.served_model_name,
             max_context_length=self.model_info["max_context_length"],

--- a/grpc_servicer/smg_grpc_servicer/vllm/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/vllm/servicer.py
@@ -7,6 +7,7 @@ Implements the VllmEngine gRPC service on top of vLLM's EngineClient.
 
 import hashlib
 import itertools
+import json
 import time
 from collections.abc import AsyncGenerator, AsyncIterator
 from pathlib import Path
@@ -33,6 +34,24 @@ from vllm.sampling_params import RequestOutputKind, StructuredOutputsParams
 from smg_grpc_servicer.tokenizer_bundle import CHUNK_SIZE, build_tokenizer_zip
 
 logger = init_logger(__name__)
+SAMPLING_DEFAULT_KEYS = (
+    "temperature",
+    "top_p",
+    "top_k",
+    "min_p",
+    "repetition_penalty",
+)
+
+
+def _filtered_sampling_defaults(params: dict | None) -> dict:
+    if not params:
+        return {}
+    return {
+        key: params[key]
+        for key in SAMPLING_DEFAULT_KEYS
+        if key in params and params[key] is not None
+    }
+
 
 # Proto dtype string → torch dtype
 _PROTO_DTYPE_MAP: dict[str, torch.dtype] = {
@@ -321,6 +340,10 @@ class VllmEngineServicer(vllm_engine_pb2_grpc.VllmEngineServicer):
         else:
             eos_token_ids = []
 
+        sampling_defaults = _filtered_sampling_defaults(
+            model_config.get_diff_sampling_param() or {}
+        )
+
         return vllm_engine_pb2.GetModelInfoResponse(
             model_path=model_config.model,
             is_generation=model_config.runner_type == "generate",
@@ -335,6 +358,9 @@ class VllmEngineServicer(vllm_engine_pb2_grpc.VllmEngineServicer):
             pad_token_id=getattr(hf_config, "pad_token_id", None) or 0,
             bos_token_id=getattr(hf_config, "bos_token_id", None) or 0,
             max_req_input_len=model_config.max_model_len,
+            default_sampling_params_json=(
+                json.dumps(sampling_defaults, separators=(",", ":")) if sampling_defaults else ""
+            ),
         )
 
     async def GetServerInfo(

--- a/model_gateway/src/routers/grpc/common/stages/helpers.rs
+++ b/model_gateway/src/routers/grpc/common/stages/helpers.rs
@@ -3,7 +3,6 @@
 use std::sync::Arc;
 
 use rand::Rng;
-use serde::Deserialize;
 use smg_grpc_client::{
     mlx_proto,
     sglang_proto::{self, DisaggregatedParams},
@@ -16,39 +15,11 @@ use crate::{
         context::{RequestType, WorkerSelection},
         proto_wrapper::ProtoGenerateRequest,
     },
-    worker::{RuntimeType, Worker, DEFAULT_BOOTSTRAP_PORT},
+    worker::{
+        sampling_defaults::SamplingDefaults, RuntimeType, Worker, DEFAULT_BOOTSTRAP_PORT,
+        DEFAULT_SAMPLING_PARAMS_LABEL,
+    },
 };
-
-const DEFAULT_SAMPLING_PARAMS_LABEL: &str = "default_sampling_params_json";
-
-/// Model-author sampling defaults reported by a backend.
-///
-/// This intentionally covers only knobs that are true sampling defaults. Length
-/// limits such as `max_new_tokens` are ignored even when present in a model's
-/// `generation_config.json`.
-#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq)]
-pub(crate) struct SamplingDefaults {
-    temperature: Option<f32>,
-    top_p: Option<f32>,
-    top_k: Option<i32>,
-    min_p: Option<f32>,
-    repetition_penalty: Option<f32>,
-}
-
-impl SamplingDefaults {
-    fn is_empty(&self) -> bool {
-        self.temperature.is_none()
-            && self.top_p.is_none()
-            && self.top_k.is_none()
-            && self.min_p.is_none()
-            && self.repetition_penalty.is_none()
-    }
-
-    fn from_json_str(json: &str) -> Result<Option<Self>, serde_json::Error> {
-        let defaults: Self = serde_json::from_str(json)?;
-        Ok((!defaults.is_empty()).then_some(defaults))
-    }
-}
 
 #[derive(Clone, Copy, Debug, Default)]
 struct SamplingDefaultsMask {

--- a/model_gateway/src/routers/grpc/common/stages/helpers.rs
+++ b/model_gateway/src/routers/grpc/common/stages/helpers.rs
@@ -3,13 +3,249 @@
 use std::sync::Arc;
 
 use rand::Rng;
-use smg_grpc_client::sglang_proto::DisaggregatedParams;
-use tracing::debug;
+use serde::Deserialize;
+use smg_grpc_client::{
+    mlx_proto,
+    sglang_proto::{self, DisaggregatedParams},
+    vllm_proto,
+};
+use tracing::{debug, warn};
 
 use crate::{
-    routers::grpc::{context::WorkerSelection, proto_wrapper::ProtoGenerateRequest},
+    routers::grpc::{
+        context::{RequestType, WorkerSelection},
+        proto_wrapper::ProtoGenerateRequest,
+    },
     worker::{RuntimeType, Worker, DEFAULT_BOOTSTRAP_PORT},
 };
+
+const DEFAULT_SAMPLING_PARAMS_LABEL: &str = "default_sampling_params_json";
+
+/// Model-author sampling defaults reported by a backend.
+///
+/// This intentionally covers only knobs that are true sampling defaults. Length
+/// limits such as `max_new_tokens` are ignored even when present in a model's
+/// `generation_config.json`.
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq)]
+pub(crate) struct SamplingDefaults {
+    temperature: Option<f32>,
+    top_p: Option<f32>,
+    top_k: Option<i32>,
+    min_p: Option<f32>,
+    repetition_penalty: Option<f32>,
+}
+
+impl SamplingDefaults {
+    fn is_empty(&self) -> bool {
+        self.temperature.is_none()
+            && self.top_p.is_none()
+            && self.top_k.is_none()
+            && self.min_p.is_none()
+            && self.repetition_penalty.is_none()
+    }
+
+    fn from_json_str(json: &str) -> Result<Option<Self>, serde_json::Error> {
+        let defaults: Self = serde_json::from_str(json)?;
+        Ok((!defaults.is_empty()).then_some(defaults))
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct SamplingDefaultsMask {
+    temperature: bool,
+    top_p: bool,
+    top_k: bool,
+    min_p: bool,
+    repetition_penalty: bool,
+}
+
+impl SamplingDefaultsMask {
+    fn from_request_type(request_type: &RequestType) -> Option<Self> {
+        match request_type {
+            RequestType::Chat(request) => Some(Self {
+                temperature: request.temperature.is_none(),
+                top_p: request.top_p.is_none(),
+                top_k: request.top_k.is_none(),
+                min_p: request.min_p.is_none(),
+                repetition_penalty: request.repetition_penalty.is_none(),
+            }),
+            RequestType::Completion(request) => Some(Self {
+                temperature: request.temperature.is_none(),
+                top_p: request.top_p.is_none(),
+                top_k: request.top_k.is_none(),
+                min_p: request.min_p.is_none(),
+                repetition_penalty: request.repetition_penalty.is_none(),
+            }),
+            RequestType::Generate(request) => {
+                let params = request.sampling_params.as_ref();
+                Some(Self {
+                    temperature: params.and_then(|params| params.temperature).is_none(),
+                    top_p: params.and_then(|params| params.top_p).is_none(),
+                    top_k: params.and_then(|params| params.top_k).is_none(),
+                    min_p: params.and_then(|params| params.min_p).is_none(),
+                    repetition_penalty: params
+                        .and_then(|params| params.repetition_penalty)
+                        .is_none(),
+                })
+            }
+            RequestType::Messages(request) => Some(Self {
+                temperature: request.temperature.is_none(),
+                top_p: request.top_p.is_none(),
+                top_k: request.top_k.is_none(),
+                // Messages does not expose these knobs, so model defaults are
+                // the only source of request-level values for them.
+                min_p: true,
+                repetition_penalty: true,
+            }),
+            RequestType::Responses(_) | RequestType::Embedding(_) | RequestType::Classify(_) => {
+                None
+            }
+        }
+    }
+
+    fn any(self) -> bool {
+        self.temperature || self.top_p || self.top_k || self.min_p || self.repetition_penalty
+    }
+}
+
+/// Decode selected-worker sampling defaults from labels.
+///
+/// In PD mode the decode worker is authoritative because it produces visible
+/// output tokens. The resolved request is then sent through the existing PD
+/// flow unchanged.
+pub(crate) fn sampling_defaults_for_request(
+    workers: Option<&WorkerSelection>,
+) -> Option<SamplingDefaults> {
+    let worker = match workers? {
+        WorkerSelection::Single { worker } => worker,
+        WorkerSelection::Dual { decode, .. } => decode,
+    };
+    let json = worker
+        .metadata()
+        .spec
+        .labels
+        .get(DEFAULT_SAMPLING_PARAMS_LABEL)?;
+
+    match SamplingDefaults::from_json_str(json) {
+        Ok(defaults) => defaults,
+        Err(e) => {
+            warn!(
+                worker_url = %worker.url(),
+                error = %e,
+                "Ignoring invalid default sampling params label"
+            );
+            None
+        }
+    }
+}
+
+/// Apply model sampling defaults to a built proto request.
+///
+/// The proto already contains backend fallback values, so `request_type` is
+/// used only as an omission mask: defaults fill fields the user did not set.
+pub(crate) fn apply_sampling_defaults_to_generate_request(
+    request: &mut ProtoGenerateRequest,
+    request_type: &RequestType,
+    workers: Option<&WorkerSelection>,
+) {
+    if matches!(request, ProtoGenerateRequest::Trtllm(_)) {
+        return;
+    }
+
+    let Some(mask) = SamplingDefaultsMask::from_request_type(request_type) else {
+        return;
+    };
+    if !mask.any() {
+        return;
+    }
+
+    let Some(defaults) = sampling_defaults_for_request(workers) else {
+        return;
+    };
+
+    match request {
+        ProtoGenerateRequest::Sglang(req) => {
+            let Some(params) = req.sampling_params.as_mut() else {
+                warn!("Cannot apply sampling defaults to SGLang request without sampling_params");
+                return;
+            };
+            apply_sglang_sampling_defaults(params, defaults, mask);
+        }
+        ProtoGenerateRequest::Vllm(req) => {
+            let Some(params) = req.sampling_params.as_mut() else {
+                warn!("Cannot apply sampling defaults to vLLM request without sampling_params");
+                return;
+            };
+            apply_vllm_sampling_defaults(params, defaults, mask);
+        }
+        ProtoGenerateRequest::Mlx(req) => {
+            let Some(params) = req.sampling_params.as_mut() else {
+                warn!("Cannot apply sampling defaults to MLX request without sampling_params");
+                return;
+            };
+            apply_mlx_sampling_defaults(params, defaults, mask);
+        }
+        ProtoGenerateRequest::Trtllm(_) => {}
+    }
+}
+
+macro_rules! apply_numeric_default {
+    ($params:expr, $defaults:expr, $mask:expr, $field:ident) => {
+        if $mask.$field {
+            if let Some(value) = $defaults.$field {
+                $params.$field = value;
+            }
+        }
+    };
+}
+
+macro_rules! apply_unsigned_top_k_default {
+    ($params:expr, $defaults:expr, $mask:expr) => {
+        if $mask.top_k {
+            if let Some(value) = $defaults.top_k {
+                $params.top_k = value.max(0) as u32;
+            }
+        }
+    };
+}
+
+macro_rules! optional_temperature_sampling_defaults_fn {
+    ($fn_name:ident, $params_ty:path) => {
+        fn $fn_name(
+            params: &mut $params_ty,
+            defaults: SamplingDefaults,
+            mask: SamplingDefaultsMask,
+        ) {
+            if mask.temperature {
+                if let Some(value) = defaults.temperature {
+                    params.temperature = Some(value);
+                }
+            }
+            apply_numeric_default!(params, defaults, mask, top_p);
+            apply_unsigned_top_k_default!(params, defaults, mask);
+            apply_numeric_default!(params, defaults, mask, min_p);
+            apply_numeric_default!(params, defaults, mask, repetition_penalty);
+        }
+    };
+}
+
+fn apply_sglang_sampling_defaults(
+    params: &mut sglang_proto::SamplingParams,
+    defaults: SamplingDefaults,
+    mask: SamplingDefaultsMask,
+) {
+    apply_numeric_default!(params, defaults, mask, temperature);
+    apply_numeric_default!(params, defaults, mask, top_p);
+    apply_numeric_default!(params, defaults, mask, top_k);
+    apply_numeric_default!(params, defaults, mask, min_p);
+    apply_numeric_default!(params, defaults, mask, repetition_penalty);
+}
+
+optional_temperature_sampling_defaults_fn!(
+    apply_vllm_sampling_defaults,
+    vllm_proto::SamplingParams
+);
+optional_temperature_sampling_defaults_fn!(apply_mlx_sampling_defaults, mlx_proto::SamplingParams);
 
 /// Inject PD bootstrap metadata for SGLang if needed.
 ///

--- a/model_gateway/src/routers/grpc/regular/stages/chat/request_building.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/chat/request_building.rs
@@ -102,6 +102,12 @@ impl PipelineStage for ChatRequestBuildingStage {
                 error::bad_request("invalid_request_parameters", format!("Invalid request parameters: {e}"))
             })?;
 
+        helpers::apply_sampling_defaults_to_generate_request(
+            &mut proto_request,
+            &ctx.input.request_type,
+            ctx.state.workers.as_ref(),
+        );
+
         if self.inject_pd_metadata {
             if let Some(workers) = ctx.state.workers.as_ref() {
                 helpers::maybe_inject_pd_metadata(&mut proto_request, workers);

--- a/model_gateway/src/routers/grpc/regular/stages/completion/request_building.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/completion/request_building.rs
@@ -82,6 +82,12 @@ impl PipelineStage for CompletionRequestBuildingStage {
                 )
             })?;
 
+        helpers::apply_sampling_defaults_to_generate_request(
+            &mut proto_request,
+            &ctx.input.request_type,
+            ctx.state.workers.as_ref(),
+        );
+
         if self.inject_pd_metadata {
             if let Some(workers) = ctx.state.workers.as_ref() {
                 helpers::maybe_inject_pd_metadata(&mut proto_request, workers);

--- a/model_gateway/src/routers/grpc/regular/stages/generate/request_building.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/generate/request_building.rs
@@ -76,6 +76,12 @@ impl PipelineStage for GenerateRequestBuildingStage {
                 error::bad_request("build_request_failed", e)
             })?;
 
+        helpers::apply_sampling_defaults_to_generate_request(
+            &mut proto_request,
+            &ctx.input.request_type,
+            ctx.state.workers.as_ref(),
+        );
+
         if self.inject_pd_metadata {
             if let Some(workers) = ctx.state.workers.as_ref() {
                 helpers::maybe_inject_pd_metadata(&mut proto_request, workers);

--- a/model_gateway/src/routers/grpc/regular/stages/messages/request_building.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/messages/request_building.rs
@@ -103,6 +103,12 @@ impl PipelineStage for MessageRequestBuildingStage {
                 error::bad_request("invalid_request_parameters", format!("Invalid request parameters: {e}"))
             })?;
 
+        helpers::apply_sampling_defaults_to_generate_request(
+            &mut proto_request,
+            &ctx.input.request_type,
+            ctx.state.workers.as_ref(),
+        );
+
         if self.inject_pd_metadata {
             if let Some(workers) = ctx.state.workers.as_ref() {
                 helpers::maybe_inject_pd_metadata(&mut proto_request, workers);

--- a/model_gateway/src/worker/mod.rs
+++ b/model_gateway/src/worker/mod.rs
@@ -12,6 +12,7 @@ pub mod metrics_aggregator;
 pub mod monitor;
 pub mod registry;
 pub mod resilience;
+pub mod sampling_defaults;
 pub mod service;
 // FIXME: worker.rs is a 1800-line monolith containing the Worker trait,
 // BasicWorker impl, HealthChecker, WorkerType, ConnectionMode, and more.
@@ -40,6 +41,7 @@ pub use openai_protocol::{
 };
 pub use registry::WorkerRegistry;
 pub use resilience::{resolve_resilience, ResolvedResilience, DEFAULT_RETRYABLE_STATUS_CODES};
+pub use sampling_defaults::DEFAULT_SAMPLING_PARAMS_LABEL;
 pub use service::WorkerService;
 pub use worker::{
     AttachedBody, BasicWorker, ConnectionMode, RuntimeType, Worker, WorkerLoadGuard, WorkerType,

--- a/model_gateway/src/worker/registry.rs
+++ b/model_gateway/src/worker/registry.rs
@@ -12,7 +12,10 @@
 //! removed, not per request. See [`crate::worker::hash_ring`] for the ring
 //! itself — this file only wires registry events to ring rebuilds.
 
-use std::{collections::HashSet, sync::Arc};
+use std::{
+    collections::{BTreeSet, HashSet},
+    sync::Arc,
+};
 
 use dashmap::{mapref::entry::Entry, DashMap};
 use openai_protocol::worker::WorkerStatus;
@@ -29,7 +32,7 @@ use crate::{
         event::WorkerEvent,
         hash_ring::HashRing,
         worker::{RuntimeType, WorkerType},
-        ConnectionMode, Worker,
+        ConnectionMode, Worker, DEFAULT_SAMPLING_PARAMS_LABEL,
     },
 };
 
@@ -670,6 +673,8 @@ impl WorkerRegistry {
             self.rebuild_hash_ring(kept_model);
         }
 
+        self.warn_on_sampling_defaults_divergence_for_worker(&new_worker);
+
         if old_worker.worker_type() != new_worker.worker_type() {
             if let Some(mut type_workers) = self.type_workers.get_mut(old_worker.worker_type()) {
                 type_workers.retain(|id| id != worker_id);
@@ -895,7 +900,6 @@ impl WorkerRegistry {
                     self.model_retry_configs.remove(&model_id);
                 }
             }
-
             if let Some(mut type_workers) = self.type_workers.get_mut(worker.worker_type()) {
                 type_workers.retain(|id| id != worker_id);
             }
@@ -982,6 +986,67 @@ impl WorkerRegistry {
         model_ids
     }
 
+    fn sampling_defaults_label(worker: &Arc<dyn Worker>) -> Option<&str> {
+        worker
+            .metadata()
+            .spec
+            .labels
+            .get(DEFAULT_SAMPLING_PARAMS_LABEL)
+            .map(String::as_str)
+            .filter(|value| !value.is_empty())
+    }
+
+    fn sampling_defaults_values_for_group(
+        &self,
+        model_id: &str,
+        worker_type: WorkerType,
+    ) -> Vec<String> {
+        self.get_workers_filtered(
+            Some(model_id),
+            Some(worker_type),
+            Some(ConnectionMode::Grpc),
+            None,
+            false,
+        )
+        .into_iter()
+        .filter_map(|worker| Self::sampling_defaults_label(&worker).map(str::to_owned))
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+    }
+
+    fn warn_on_sampling_defaults_divergence_for_worker(&self, worker: &Arc<dyn Worker>) {
+        if *worker.connection_mode() != ConnectionMode::Grpc {
+            return;
+        }
+
+        if !matches!(
+            *worker.worker_type(),
+            WorkerType::Regular | WorkerType::Decode
+        ) {
+            return;
+        }
+
+        if Self::sampling_defaults_label(worker).is_none() {
+            return;
+        }
+
+        let worker_type = *worker.worker_type();
+        for model_id in Self::worker_model_ids(worker) {
+            let values = self.sampling_defaults_values_for_group(&model_id, worker_type);
+            if values.len() > 1 {
+                tracing::warn!(
+                    model_id = %model_id,
+                    worker_type = %worker_type,
+                    connection_mode = %ConnectionMode::Grpc,
+                    worker_url = %worker.url(),
+                    observed_values = ?values,
+                    "Divergent default sampling params reported by workers in the same routing group"
+                );
+            }
+        }
+    }
+
     /// Core registration logic shared by local and mesh paths.
     ///
     /// Acquires the per-worker mutation lock before making the worker
@@ -1031,6 +1096,7 @@ impl WorkerRegistry {
             self.add_worker_to_model_index(&model_id, worker.clone());
             self.rebuild_hash_ring(&model_id);
         }
+        self.warn_on_sampling_defaults_divergence_for_worker(&worker);
 
         // Update type index (clone needed for DashMap key ownership)
         self.type_workers
@@ -1290,6 +1356,43 @@ mod tests {
             disable_health_check: true,
             ..Default::default()
         }
+    }
+
+    fn worker_with_sampling_defaults(
+        url: &str,
+        model_id: &str,
+        worker_type: WorkerType,
+        connection_mode: ConnectionMode,
+        defaults: Option<&str>,
+    ) -> Arc<dyn Worker> {
+        let mut builder = BasicWorkerBuilder::new(url)
+            .model(ModelCard::new(model_id))
+            .worker_type(worker_type)
+            .connection_mode(connection_mode);
+
+        if let Some(defaults) = defaults {
+            let mut labels = HashMap::new();
+            labels.insert(
+                DEFAULT_SAMPLING_PARAMS_LABEL.to_string(),
+                defaults.to_string(),
+            );
+            builder = builder.labels(labels);
+        }
+
+        Arc::new(builder.build())
+    }
+
+    fn assert_sampling_defaults_group_values(
+        registry: &WorkerRegistry,
+        model_id: &str,
+        worker_type: WorkerType,
+        expected: &[&str],
+    ) {
+        let expected: Vec<String> = expected.iter().map(|value| value.to_string()).collect();
+        assert_eq!(
+            registry.sampling_defaults_values_for_group(model_id, worker_type),
+            expected
+        );
     }
 
     #[test]
@@ -1816,6 +1919,133 @@ mod tests {
         // Remove last worker — config should be cleaned up
         registry.remove(&id2);
         assert!(registry.get_retry_config("llama-3").is_none());
+    }
+
+    #[test]
+    fn test_sampling_defaults_group_warning_scan_tracks_distinct_values() {
+        let registry = WorkerRegistry::new();
+        let defaults_a = r#"{"temperature":0.6}"#;
+        let defaults_b = r#"{"temperature":0.7}"#;
+
+        let id1 = registry
+            .register(worker_with_sampling_defaults(
+                "http://worker1:8080",
+                "llama-3",
+                WorkerType::Regular,
+                ConnectionMode::Grpc,
+                Some(defaults_a),
+            ))
+            .unwrap();
+        let id2 = registry
+            .register(worker_with_sampling_defaults(
+                "http://worker2:8080",
+                "llama-3",
+                WorkerType::Regular,
+                ConnectionMode::Grpc,
+                Some(defaults_a),
+            ))
+            .unwrap();
+
+        assert_sampling_defaults_group_values(
+            &registry,
+            "llama-3",
+            WorkerType::Regular,
+            &[defaults_a],
+        );
+
+        let id3 = registry
+            .register(worker_with_sampling_defaults(
+                "http://worker3:8080",
+                "llama-3",
+                WorkerType::Regular,
+                ConnectionMode::Grpc,
+                Some(defaults_b),
+            ))
+            .unwrap();
+
+        assert_sampling_defaults_group_values(
+            &registry,
+            "llama-3",
+            WorkerType::Regular,
+            &[defaults_a, defaults_b],
+        );
+
+        registry.remove(&id3);
+        assert_sampling_defaults_group_values(
+            &registry,
+            "llama-3",
+            WorkerType::Regular,
+            &[defaults_a],
+        );
+
+        registry.remove(&id1);
+        registry.remove(&id2);
+        assert_sampling_defaults_group_values(&registry, "llama-3", WorkerType::Regular, &[]);
+    }
+
+    #[test]
+    fn test_sampling_defaults_group_warning_scan_updates_on_replace() {
+        let registry = WorkerRegistry::new();
+        let defaults_a = r#"{"temperature":0.6}"#;
+        let defaults_b = r#"{"temperature":0.7}"#;
+
+        let id = registry
+            .register(worker_with_sampling_defaults(
+                "http://worker:8080",
+                "llama-3",
+                WorkerType::Decode,
+                ConnectionMode::Grpc,
+                Some(defaults_a),
+            ))
+            .unwrap();
+
+        assert!(registry.replace(
+            &id,
+            worker_with_sampling_defaults(
+                "http://worker:8080",
+                "llama-3",
+                WorkerType::Decode,
+                ConnectionMode::Grpc,
+                Some(defaults_b),
+            ),
+        ));
+
+        assert_sampling_defaults_group_values(
+            &registry,
+            "llama-3",
+            WorkerType::Decode,
+            &[defaults_b],
+        );
+    }
+
+    #[test]
+    fn test_sampling_defaults_group_warning_scan_ignores_non_applicable_workers() {
+        let registry = WorkerRegistry::new();
+        let defaults = r#"{"temperature":0.6}"#;
+
+        registry.register(worker_with_sampling_defaults(
+            "http://prefill:8080",
+            "llama-3",
+            WorkerType::Prefill,
+            ConnectionMode::Grpc,
+            Some(defaults),
+        ));
+        registry.register(worker_with_sampling_defaults(
+            "http://http-worker:8080",
+            "llama-3",
+            WorkerType::Regular,
+            ConnectionMode::Http,
+            Some(defaults),
+        ));
+        registry.register(worker_with_sampling_defaults(
+            "http://missing-label:8080",
+            "llama-3",
+            WorkerType::Regular,
+            ConnectionMode::Grpc,
+            None,
+        ));
+
+        assert_sampling_defaults_group_values(&registry, "llama-3", WorkerType::Regular, &[]);
     }
 
     #[test]

--- a/model_gateway/src/worker/sampling_defaults.rs
+++ b/model_gateway/src/worker/sampling_defaults.rs
@@ -1,0 +1,84 @@
+//! Backend-reported sampling defaults carried on worker labels.
+
+use serde::{Deserialize, Serialize};
+
+/// Worker label carrying backend-reported model sampling defaults as JSON.
+pub const DEFAULT_SAMPLING_PARAMS_LABEL: &str = "default_sampling_params_json";
+
+/// Model-author sampling defaults reported by a backend.
+///
+/// This intentionally covers only knobs that are true sampling defaults. Length
+/// limits such as `max_new_tokens` are ignored even when present in a model's
+/// `generation_config.json`.
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Serialize)]
+pub(crate) struct SamplingDefaults {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) temperature: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) top_p: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) top_k: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) min_p: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) repetition_penalty: Option<f32>,
+}
+
+impl SamplingDefaults {
+    fn is_empty(&self) -> bool {
+        self.temperature.is_none()
+            && self.top_p.is_none()
+            && self.top_k.is_none()
+            && self.min_p.is_none()
+            && self.repetition_penalty.is_none()
+    }
+
+    pub(crate) fn from_json_str(json: &str) -> Result<Option<Self>, serde_json::Error> {
+        let defaults: Self = serde_json::from_str(json)?;
+        Ok((!defaults.is_empty()).then_some(defaults))
+    }
+
+    pub(crate) fn canonical_json_from_str(json: &str) -> Result<Option<String>, String> {
+        let Some(defaults) = Self::from_json_str(json)
+            .map_err(|e| format!("failed to parse sampling defaults JSON: {e}"))?
+        else {
+            return Ok(None);
+        };
+
+        serde_json::to_string(&defaults)
+            .map(Some)
+            .map_err(|e| format!("failed to serialize sampling defaults JSON: {e}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SamplingDefaults;
+
+    #[test]
+    fn canonical_json_filters_unknown_and_null_fields() {
+        let canonical = SamplingDefaults::canonical_json_from_str(
+            r#"{"temperature":0.6,"top_k":0,"min_p":null,"max_new_tokens":32}"#,
+        )
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(canonical, r#"{"temperature":0.6,"top_k":0}"#);
+    }
+
+    #[test]
+    fn canonical_json_removes_empty_defaults() {
+        let canonical =
+            SamplingDefaults::canonical_json_from_str(r#"{"min_p":null,"max_new_tokens":32}"#)
+                .unwrap();
+
+        assert_eq!(canonical, None);
+    }
+
+    #[test]
+    fn canonical_json_rejects_invalid_default_types() {
+        let err = SamplingDefaults::canonical_json_from_str(r#"{"top_k":1.5}"#).unwrap_err();
+
+        assert!(err.contains("failed to parse sampling defaults JSON"));
+    }
+}

--- a/model_gateway/src/workflow/steps/local/discover_metadata.rs
+++ b/model_gateway/src/workflow/steps/local/discover_metadata.rs
@@ -29,6 +29,15 @@ static HTTP_CLIENT: Lazy<Client> = Lazy::new(|| {
         .expect("Failed to create HTTP client")
 });
 
+const DEFAULT_SAMPLING_PARAMS_LABEL: &str = "default_sampling_params_json";
+const DEFAULT_SAMPLING_PARAM_KEYS: &[&str] = &[
+    "temperature",
+    "top_p",
+    "top_k",
+    "min_p",
+    "repetition_penalty",
+];
+
 // ---------------------------------------------------------------------------
 // HTTP response structs (sglang /server_info, /model_info; vllm /v1/models)
 // ---------------------------------------------------------------------------
@@ -271,6 +280,59 @@ fn normalize_grpc_keys(labels: &mut HashMap<String, String>) {
         "server_type",
     ] {
         labels.remove(key);
+    }
+    normalize_default_sampling_params_label(labels);
+}
+
+fn normalize_default_sampling_params_label(labels: &mut HashMap<String, String>) {
+    let Some(raw) = labels.get(DEFAULT_SAMPLING_PARAMS_LABEL).cloned() else {
+        return;
+    };
+
+    match canonical_default_sampling_params_json(&raw) {
+        Ok(Some(canonical)) => {
+            labels.insert(DEFAULT_SAMPLING_PARAMS_LABEL.to_string(), canonical);
+        }
+        Ok(None) => {
+            labels.remove(DEFAULT_SAMPLING_PARAMS_LABEL);
+        }
+        Err(e) => {
+            warn!(
+                error = %e,
+                "Ignoring invalid default sampling params label"
+            );
+            labels.remove(DEFAULT_SAMPLING_PARAMS_LABEL);
+        }
+    }
+}
+
+fn canonical_default_sampling_params_json(raw: &str) -> Result<Option<String>, String> {
+    let value: serde_json::Value = serde_json::from_str(raw)
+        .map_err(|e| format!("failed to parse sampling defaults JSON: {e}"))?;
+    let object = value
+        .as_object()
+        .ok_or_else(|| "sampling defaults JSON must be an object".to_string())?;
+
+    let mut filtered = serde_json::Map::new();
+    for key in DEFAULT_SAMPLING_PARAM_KEYS {
+        let Some(value) = object.get(*key) else {
+            continue;
+        };
+        if value.is_null() {
+            continue;
+        }
+        if !value.is_number() {
+            return Err(format!("sampling default `{key}` must be numeric"));
+        }
+        filtered.insert((*key).to_string(), value.clone());
+    }
+
+    if filtered.is_empty() {
+        Ok(None)
+    } else {
+        serde_json::to_string(&serde_json::Value::Object(filtered))
+            .map(Some)
+            .map_err(|e| format!("failed to serialize sampling defaults JSON: {e}"))
     }
 }
 

--- a/model_gateway/src/workflow/steps/local/discover_metadata.rs
+++ b/model_gateway/src/workflow/steps/local/discover_metadata.rs
@@ -11,7 +11,7 @@ use wfaas::{StepExecutor, StepResult, WorkflowContext, WorkflowError, WorkflowRe
 
 use crate::{
     routers::grpc::client::{flat_labels, GrpcClient},
-    worker::ConnectionMode,
+    worker::{sampling_defaults::SamplingDefaults, ConnectionMode, DEFAULT_SAMPLING_PARAMS_LABEL},
     workflow::{
         data::{WorkerKind, WorkerWorkflowData},
         steps::util::{grpc_base_url, http_base_url},
@@ -28,15 +28,6 @@ static HTTP_CLIENT: Lazy<Client> = Lazy::new(|| {
         .build()
         .expect("Failed to create HTTP client")
 });
-
-const DEFAULT_SAMPLING_PARAMS_LABEL: &str = "default_sampling_params_json";
-const DEFAULT_SAMPLING_PARAM_KEYS: &[&str] = &[
-    "temperature",
-    "top_p",
-    "top_k",
-    "min_p",
-    "repetition_penalty",
-];
 
 // ---------------------------------------------------------------------------
 // HTTP response structs (sglang /server_info, /model_info; vllm /v1/models)
@@ -289,7 +280,7 @@ fn normalize_default_sampling_params_label(labels: &mut HashMap<String, String>)
         return;
     };
 
-    match canonical_default_sampling_params_json(&raw) {
+    match SamplingDefaults::canonical_json_from_str(&raw) {
         Ok(Some(canonical)) => {
             labels.insert(DEFAULT_SAMPLING_PARAMS_LABEL.to_string(), canonical);
         }
@@ -303,36 +294,6 @@ fn normalize_default_sampling_params_label(labels: &mut HashMap<String, String>)
             );
             labels.remove(DEFAULT_SAMPLING_PARAMS_LABEL);
         }
-    }
-}
-
-fn canonical_default_sampling_params_json(raw: &str) -> Result<Option<String>, String> {
-    let value: serde_json::Value = serde_json::from_str(raw)
-        .map_err(|e| format!("failed to parse sampling defaults JSON: {e}"))?;
-    let object = value
-        .as_object()
-        .ok_or_else(|| "sampling defaults JSON must be an object".to_string())?;
-
-    let mut filtered = serde_json::Map::new();
-    for key in DEFAULT_SAMPLING_PARAM_KEYS {
-        let Some(value) = object.get(*key) else {
-            continue;
-        };
-        if value.is_null() {
-            continue;
-        }
-        if !value.is_number() {
-            return Err(format!("sampling default `{key}` must be numeric"));
-        }
-        filtered.insert((*key).to_string(), value.clone());
-    }
-
-    if filtered.is_empty() {
-        Ok(None)
-    } else {
-        serde_json::to_string(&serde_json::Value::Object(filtered))
-            .map(Some)
-            .map_err(|e| format!("failed to serialize sampling defaults JSON: {e}"))
     }
 }
 


### PR DESCRIPTION
## Description

### Problem

Backends can carry model-author sampling defaults in `generation_config.json`, but the gateway previously built gRPC sampling params from API/proto fallback values only. That meant omitted request fields like `temperature`, `top_p`, `top_k`, `min_p`, or `repetition_penalty` could lose the model defaults before the request reached SGLang/vLLM.

This also needs to work in service discovery / IGW flows, where the gateway only sees worker metadata after discovery, and in PD mode where decode is the side that produces visible tokens.

Related: #1237, #1107

### Solution

Publish a filtered `default_sampling_params_json` field from SGLang/vLLM gRPC model info, normalize that metadata into worker labels during discovery, and apply those defaults in the gRPC request-building helper only when the original user request omitted the field.

Key design choices:

- Keep the merge in SMG, not only in backend servicers, because the gateway owns API omission semantics and can distinguish omitted fields from proto fallback values.
- Apply defaults from the selected worker label; in PD mode the decode worker is authoritative.
- Support chat, completions, messages, and plain generate. Leave TRT-LLM out for now because it does not support this functionality yet.
- Filter to true sampling knobs only: `temperature`, `top_p`, `top_k`, `min_p`, and `repetition_penalty`. Length limits such as `max_new_tokens` are intentionally ignored.
- Put label/canonicalization logic in `worker::sampling_defaults` so discovery normalization and request application share one typed definition instead of drifting string/key lists.
- Warn on divergent sampling defaults for gRPC regular/decode workers in the same implicit routing group during registry register/replace, not per request. This covers service discovery and IGW because both use the same worker registry path.

## Changes

- Added gRPC proto fields for backend-reported sampling defaults.
- Added SGLang and vLLM servicer support to publish filtered model sampling defaults.
- Normalized `default_sampling_params_json` during gRPC metadata discovery.
- Added a typed `SamplingDefaults` helper shared by discovery and request building.
- Applied selected-worker defaults to SGLang/vLLM/MLX gRPC generate requests only for omitted API fields.
- Added registry warning coverage for divergent default sampling labels across gRPC regular/decode workers.
- Added focused tests for canonicalization and divergence warning scans.

## Test Plan

- Rebased cleanly on `origin/main`.
- Ran `env -u RUSTC_WRAPPER pre-commit run --all-files`.
  - This exercises `cargo +nightly fmt --all --`.
  - This exercises `cargo clippy --workspace --all-targets --all-features -- -D warnings`.
  - Also passed codespell, ruff, yaml/toml, whitespace, merge-conflict, private-key, and related pre-commit hooks.
- Ran `pre-commit run branch-name-check --hook-stage pre-push --all-files`.
- Ran `cargo test -p smg sampling_defaults`.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Models can now define default sampling parameters as JSON that are automatically applied to requests not specifying sampling parameters
  * System detects and warns when default sampling parameters are inconsistent across multiple workers serving the same model

<!-- end of auto-generated comment: release notes by coderabbit.ai -->