### PR TITLE
fix(grpc): tighten sampling defaults metadata

### DIFF
--- a/e2e_test/chat_completions/test_sampling_defaults.py
+++ b/e2e_test/chat_completions/test_sampling_defaults.py
@@ -1,0 +1,71 @@
+"""Sampling default E2E tests for gRPC workers.
+
+These tests run a real SGLang worker and a real gateway. Qwen's published
+generation_config.json includes sampling defaults, which should be surfaced
+through worker metadata and usable for regular omitted-sampling requests.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+DEFAULT_SAMPLING_PARAMS_LABEL = "default_sampling_params_json"
+
+
+def _worker_sampling_defaults(gateway) -> dict:
+    response = httpx.get(f"{gateway.base_url}/workers", timeout=10)
+    response.raise_for_status()
+    workers = response.json()["workers"]
+    for worker in workers:
+        labels = worker.get("labels") or {}
+        raw_defaults = labels.get(DEFAULT_SAMPLING_PARAMS_LABEL)
+        if raw_defaults:
+            return json.loads(raw_defaults)
+    raise AssertionError(f"missing {DEFAULT_SAMPLING_PARAMS_LABEL} label")
+
+
+@pytest.mark.engine("sglang")
+@pytest.mark.gpu(1)
+@pytest.mark.e2e
+@pytest.mark.model("Qwen/Qwen2.5-7B-Instruct")
+@pytest.mark.gateway(extra_args=["--tool-call-parser", "qwen", "--history-backend", "memory"])
+@pytest.mark.parametrize("setup_backend", ["grpc"], indirect=True)
+class TestSamplingDefaultsGrpc:
+    """Verify real generation-config sampling defaults flow through the gateway."""
+
+    def test_generation_config_sampling_defaults_are_discovered(self, setup_backend):
+        _, _, _, gateway = setup_backend
+
+        defaults = _worker_sampling_defaults(gateway)
+
+        assert defaults["temperature"] == pytest.approx(0.7)
+        assert defaults["top_p"] == pytest.approx(0.8)
+        assert defaults["top_k"] == 20
+        assert defaults["repetition_penalty"] == pytest.approx(1.05)
+
+    def test_omitted_chat_sampling_params_complete_with_discovered_defaults(
+        self, setup_backend, api_client
+    ):
+        _, model, _, gateway = setup_backend
+        defaults = _worker_sampling_defaults(gateway)
+        assert defaults["top_k"] == 20
+
+        response = api_client.chat.completions.create(
+            model=model,
+            messages=[
+                {
+                    "role": "user",
+                    "content": (
+                        "Invent a short surreal product name for a futuristic cafe. "
+                        "Only output the name."
+                    ),
+                }
+            ],
+            max_tokens=16,
+        )
+
+        assert response.choices
+        assert (response.choices[0].message.content or "").strip()

--- a/grpc_servicer/smg_grpc_servicer/sglang/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/sglang/servicer.py
@@ -450,7 +450,7 @@ class SGLangSchedulerServicer(sglang_scheduler_pb2_grpc.SglangSchedulerServicer)
                     preferred = json.loads(preferred)
                 except json.JSONDecodeError:
                     logger.warning("Failed to parse preferred_sampling_params JSON")
-                    preferred = None
+                    preferred = {}
             if isinstance(preferred, dict):
                 defaults.update(preferred)
             else:
@@ -468,7 +468,7 @@ class SGLangSchedulerServicer(sglang_scheduler_pb2_grpc.SglangSchedulerServicer)
             return json.dumps(preferred, separators=(",", ":"))
         if isinstance(preferred, str):
             return preferred
-        return json.dumps(preferred, separators=(",", ":")) if preferred else ""
+        return ""
 
     async def GetModelInfo(
         self,


### PR DESCRIPTION
## Description

### Problem

The merged backend sampling defaults work needed a small follow-up from review:
- SGLang metadata should not serialize unsupported `preferred_sampling_params` shapes into the proto response.
- Invalid preferred sampling JSON should produce one clear warning path without also triggering the unsupported-type warning.
- We wanted real e2e coverage for backend-provided generation-config defaults through a real SGLang gRPC worker and gateway.

### Solution

- Treat invalid SGLang `preferred_sampling_params` JSON as absent when merging defaults.
- Return an empty preferred sampling params string for unsupported non-dict/non-string values.
- Add a real SGLang gRPC e2e using `Qwen/Qwen2.5-7B-Instruct`, whose `generation_config.json` reports temperature/top_p/top_k/repetition_penalty defaults. The e2e verifies those defaults are discovered on worker metadata and that an omitted-sampling chat request completes through the real gateway/backend path.

## Changes

- Added `e2e_test/chat_completions/test_sampling_defaults.py` for real SGLang gRPC/gateway coverage using Qwen generation-config defaults.
- Tightened SGLang servicer preferred sampling params serialization.

## Test Plan

- [x] `cargo fmt --check`
- [x] `python3 -m compileall -q e2e_test/chat_completions/test_sampling_defaults.py grpc_servicer/smg_grpc_servicer/sglang/servicer.py`
- [x] `git diff --check`
- [x] `env -u RUSTC_WRAPPER pre-commit run --all-files`

Not run locally:
- `E2E_RUNTIME=sglang python -m pytest e2e_test/chat_completions/test_sampling_defaults.py -q`

This requires launching the real SGLang gRPC worker and gateway in the GPU e2e environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end test suite validating sampling defaults discovery and application in chat completions requests with omitted sampling parameters.

* **Improvements**
  * Enhanced robustness of sampling parameter handling with improved error recovery and fallback mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->