### PR TITLE
feat(grpc_servicer): add TokenSpeed servicer (Part 2/3)

### DIFF
--- a/grpc_servicer/pyproject.toml
+++ b/grpc_servicer/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "smg-grpc-servicer"
 version = "0.5.3"
-description = "SMG gRPC servicer implementations for LLM inference engines (vLLM, SGLang, MLX)"
+description = "SMG gRPC servicer implementations for LLM inference engines (vLLM, SGLang, MLX, TokenSpeed)"
 requires-python = ">=3.10"
 dependencies = [
     "smg-grpc-proto>=0.4.7",

--- a/grpc_servicer/smg_grpc_servicer/tokenspeed/__init__.py
+++ b/grpc_servicer/smg_grpc_servicer/tokenspeed/__init__.py
@@ -1,0 +1,5 @@
+"""TokenSpeed gRPC servicer — wraps :class:`AsyncLLM` behind the gRPC wire."""
+
+from smg_grpc_servicer.tokenspeed.servicer import TokenSpeedSchedulerServicer
+
+__all__ = ["TokenSpeedSchedulerServicer"]

--- a/grpc_servicer/smg_grpc_servicer/tokenspeed/__main__.py
+++ b/grpc_servicer/smg_grpc_servicer/tokenspeed/__main__.py
@@ -1,0 +1,43 @@
+"""CLI entrypoint for the TokenSpeed gRPC server.
+
+Usage::
+
+    python -m smg_grpc_servicer.tokenspeed --model <model> --host 127.0.0.1 --port 50051
+
+All :class:`ServerArgs` flags are accepted — argv is parsed by
+``prepare_server_args`` so there is no flag drift vs the HTTP frontend.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+
+from tokenspeed.runtime.utils.server_args import prepare_server_args
+
+from smg_grpc_servicer.tokenspeed.server import serve_grpc
+
+try:
+    import uvloop
+except ImportError:  # uvloop is optional — fall back to the default loop.
+    uvloop = None
+
+
+def main(argv: list[str] | None = None) -> None:
+    if argv is None:
+        argv = sys.argv[1:]
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(name)s] %(levelname)s %(message)s",
+    )
+
+    server_args = prepare_server_args(argv)
+    if uvloop is not None:
+        asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+    asyncio.run(serve_grpc(server_args))
+
+
+if __name__ == "__main__":
+    main()

--- a/grpc_servicer/smg_grpc_servicer/tokenspeed/health_servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/tokenspeed/health_servicer.py
@@ -1,0 +1,119 @@
+"""Standard ``grpc.health.v1.Health`` servicer for the TokenSpeed backend.
+
+Advertises ``tokenspeed.grpc.scheduler.TokenSpeedScheduler`` so the router
+can auto-detect the backend via the health probe.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import AsyncIterator
+from typing import TYPE_CHECKING
+
+import grpc
+from grpc_health.v1 import health_pb2, health_pb2_grpc
+from smg_grpc_proto.generated import tokenspeed_scheduler_pb2
+
+if TYPE_CHECKING:
+    from tokenspeed.runtime.engine.async_llm import AsyncLLM
+
+logger = logging.getLogger(__name__)
+
+# Seconds of scheduler silence (with pending requests) before reporting NOT_SERVING.
+STUCK_SCHEDULER_THRESHOLD_SEC = 30.0
+
+# Sourced from the proto descriptor so a package/service rename stays in sync.
+TOKENSPEED_SCHEDULER_SERVICE_NAME = tokenspeed_scheduler_pb2.DESCRIPTOR.services_by_name[
+    "TokenSpeedScheduler"
+].full_name
+
+
+class TokenSpeedHealthServicer(health_pb2_grpc.HealthServicer):
+    """Health servicer that tracks TokenSpeed's AsyncLLM liveness.
+
+    Advertises two service levels:
+
+    * ``""`` (empty) — overall server health, flipped to SERVING once the
+      warmup request succeeds and back to NOT_SERVING on shutdown.
+    * ``tokenspeed.grpc.scheduler.TokenSpeedScheduler`` — readiness: the
+      base status, plus a scheduler-responsiveness check (if there are
+      pending requests but the scheduler hasn't pushed output for >30s,
+      report NOT_SERVING).
+    """
+
+    OVERALL_SERVER = ""
+    TOKENSPEED_SERVICE = TOKENSPEED_SCHEDULER_SERVICE_NAME
+
+    def __init__(self, async_llm: AsyncLLM, scheduler_info: dict):
+        self.async_llm = async_llm
+        self.scheduler_info = scheduler_info
+        self._serving_status: dict[str, int] = {
+            self.OVERALL_SERVER: health_pb2.HealthCheckResponse.NOT_SERVING,
+            self.TOKENSPEED_SERVICE: health_pb2.HealthCheckResponse.NOT_SERVING,
+        }
+        logger.info("TokenSpeed gRPC health service initialized")
+
+    def set_serving(self) -> None:
+        """Flip both services to SERVING (call after successful warmup)."""
+        self._serving_status[self.OVERALL_SERVER] = health_pb2.HealthCheckResponse.SERVING
+        self._serving_status[self.TOKENSPEED_SERVICE] = health_pb2.HealthCheckResponse.SERVING
+        logger.info("TokenSpeed gRPC health status -> SERVING")
+
+    def set_not_serving(self) -> None:
+        """Flip both services to NOT_SERVING (call on shutdown)."""
+        self._serving_status[self.OVERALL_SERVER] = health_pb2.HealthCheckResponse.NOT_SERVING
+        self._serving_status[self.TOKENSPEED_SERVICE] = health_pb2.HealthCheckResponse.NOT_SERVING
+        logger.info("TokenSpeed gRPC health status -> NOT_SERVING")
+
+    async def Check(
+        self,
+        request: health_pb2.HealthCheckRequest,
+        context: grpc.aio.ServicerContext,
+    ) -> health_pb2.HealthCheckResponse:
+        service_name = request.service
+        logger.debug("Health check request for service=%r", service_name)
+
+        if self.async_llm.gracefully_exit:
+            return health_pb2.HealthCheckResponse(status=health_pb2.HealthCheckResponse.NOT_SERVING)
+
+        if service_name == self.OVERALL_SERVER:
+            return health_pb2.HealthCheckResponse(
+                status=self._serving_status.get(
+                    self.OVERALL_SERVER, health_pb2.HealthCheckResponse.NOT_SERVING
+                )
+            )
+
+        if service_name == self.TOKENSPEED_SERVICE:
+            base = self._serving_status.get(
+                self.TOKENSPEED_SERVICE, health_pb2.HealthCheckResponse.NOT_SERVING
+            )
+            if base != health_pb2.HealthCheckResponse.SERVING:
+                return health_pb2.HealthCheckResponse(status=base)
+
+            # Scheduler-stuck check: pending work but no recent output.
+            time_since_last_receive = time.time() - self.async_llm.last_receive_tstamp
+            pending = len(self.async_llm.rid_to_state)
+            if time_since_last_receive > STUCK_SCHEDULER_THRESHOLD_SEC and pending > 0:
+                logger.warning(
+                    "Scheduler appears stuck: %.1fs since last receive, %d pending requests",
+                    time_since_last_receive,
+                    pending,
+                )
+                return health_pb2.HealthCheckResponse(
+                    status=health_pb2.HealthCheckResponse.NOT_SERVING
+                )
+
+            return health_pb2.HealthCheckResponse(status=health_pb2.HealthCheckResponse.SERVING)
+
+        context.set_code(grpc.StatusCode.NOT_FOUND)
+        context.set_details(f"Unknown service: {service_name}")
+        return health_pb2.HealthCheckResponse(status=health_pb2.HealthCheckResponse.SERVICE_UNKNOWN)
+
+    async def Watch(
+        self,
+        request: health_pb2.HealthCheckRequest,
+        context: grpc.aio.ServicerContext,
+    ) -> AsyncIterator[health_pb2.HealthCheckResponse]:
+        # K8s probes use Check, not Watch — we emit the current status once.
+        yield await self.Check(request, context)

--- a/grpc_servicer/smg_grpc_servicer/tokenspeed/scheduler_launcher.py
+++ b/grpc_servicer/smg_grpc_servicer/tokenspeed/scheduler_launcher.py
@@ -1,0 +1,43 @@
+"""Scheduler subprocess launcher for the TokenSpeed gRPC server.
+
+Delegates to TokenSpeed's ``_launch_subprocesses`` and returns the
+``AsyncLLM`` + scheduler-info dict the gRPC server cares about.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from tokenspeed.runtime.engine.async_llm import AsyncLLM
+from tokenspeed.runtime.entrypoints.engine import _launch_subprocesses
+from tokenspeed.runtime.utils.server_args import PortArgs, ServerArgs
+
+logger = logging.getLogger(__name__)
+
+
+def launch_engine(
+    server_args: ServerArgs,
+    port_args: PortArgs | None = None,
+) -> tuple[AsyncLLM, dict[str, Any]]:
+    """Launch the scheduler subprocess(es) and return the live ``AsyncLLM``.
+
+    Raises ``RuntimeError`` on non-rank-0 nodes (which return ``None`` and
+    block forever on the dummy health server — they never serve gRPC).
+    """
+    async_llm, _template_manager, scheduler_info = _launch_subprocesses(
+        server_args=server_args,
+        port_args=port_args,
+    )
+
+    if async_llm is None:
+        raise RuntimeError(
+            "launch_engine() returned no AsyncLLM — only rank 0 may serve gRPC traffic."
+        )
+
+    logger.info(
+        "TokenSpeed engine ready: max_total_num_tokens=%s max_req_input_len=%s",
+        scheduler_info.get("max_total_num_tokens"),
+        scheduler_info.get("max_req_input_len"),
+    )
+    return async_llm, scheduler_info

--- a/grpc_servicer/smg_grpc_servicer/tokenspeed/server.py
+++ b/grpc_servicer/smg_grpc_servicer/tokenspeed/server.py
@@ -1,0 +1,189 @@
+"""Standalone TokenSpeed gRPC server."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import signal
+import threading
+import time
+from concurrent import futures
+
+import grpc
+from grpc_health.v1 import health_pb2_grpc
+from grpc_reflection.v1alpha import reflection
+from smg_grpc_proto import tokenspeed_scheduler_pb2_grpc
+from smg_grpc_proto.generated import tokenspeed_scheduler_pb2
+from tokenspeed.runtime.utils.server_args import ServerArgs
+
+from smg_grpc_servicer.tokenspeed.health_servicer import TokenSpeedHealthServicer
+from smg_grpc_servicer.tokenspeed.scheduler_launcher import launch_engine
+from smg_grpc_servicer.tokenspeed.servicer import TokenSpeedSchedulerServicer
+
+logger = logging.getLogger(__name__)
+
+
+async def serve_grpc(server_args: ServerArgs) -> None:
+    """Run the TokenSpeed gRPC server until a shutdown signal is received."""
+
+    logger.info("Launching TokenSpeed scheduler + AsyncLLM...")
+    async_llm, scheduler_info = launch_engine(server_args)
+
+    server = grpc.aio.server(
+        futures.ThreadPoolExecutor(max_workers=10),
+        options=[
+            ("grpc.max_send_message_length", 1024 * 1024 * 256),
+            ("grpc.max_receive_message_length", 1024 * 1024 * 256),
+            # Permissive keepalive so long prefill stalls don't trip GOAWAY.
+            ("grpc.http2.min_recv_ping_interval_without_data_ms", 10000),
+            ("grpc.keepalive_permit_without_calls", True),
+        ],
+    )
+
+    health_servicer = TokenSpeedHealthServicer(
+        async_llm=async_llm,
+        scheduler_info=scheduler_info,
+    )
+    health_pb2_grpc.add_HealthServicer_to_server(health_servicer, server)
+
+    servicer = TokenSpeedSchedulerServicer(
+        async_llm=async_llm,
+        server_args=server_args,
+        scheduler_info=scheduler_info,
+        health_servicer=health_servicer,
+    )
+    tokenspeed_scheduler_pb2_grpc.add_TokenSpeedSchedulerServicer_to_server(servicer, server)
+
+    service_names = (
+        tokenspeed_scheduler_pb2.DESCRIPTOR.services_by_name["TokenSpeedScheduler"].full_name,
+        "grpc.health.v1.Health",
+        reflection.SERVICE_NAME,
+    )
+    reflection.enable_server_reflection(service_names, server)
+
+    listen_addr = f"{server_args.host}:{server_args.port}"
+    server.add_insecure_port(listen_addr)
+    logger.info("TokenSpeed gRPC server listening on %s", listen_addr)
+
+    await server.start()
+
+    # Warmup on a background thread so the async server can handle the probe.
+    warmup_thread = threading.Thread(
+        target=_wait_and_warmup,
+        args=(server_args, health_servicer),
+        daemon=True,
+    )
+    warmup_thread.start()
+
+    loop = asyncio.get_running_loop()
+    stop_event = asyncio.Event()
+
+    def _signal_handler() -> None:
+        logger.info("Received shutdown signal")
+        stop_event.set()
+
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        try:
+            loop.add_signal_handler(sig, _signal_handler)
+        except NotImplementedError:
+            # Windows and some exotic envs don't support loop.add_signal_handler.
+            pass
+
+    try:
+        await stop_event.wait()
+    finally:
+        logger.info("Shutting down TokenSpeed gRPC server")
+        try:
+            await servicer.shutdown()
+        except Exception:  # noqa: BLE001
+            logger.exception("servicer.shutdown() raised")
+        await server.stop(5.0)
+        if warmup_thread.is_alive():
+            warmup_thread.join(timeout=5.0)
+
+
+def _wait_and_warmup(
+    server_args: ServerArgs,
+    health_servicer: TokenSpeedHealthServicer,
+) -> None:
+    """Probe the gRPC server until it can generate one token, then set SERVING.
+
+    Hits the external port so the warmup exercises transport, proto codec,
+    and scheduler IPC end-to-end.
+    """
+    if os.getenv("TOKENSPEED_SKIP_GRPC_WARMUP", "0").lower() in ("1", "true", "yes"):
+        logger.info("TOKENSPEED_SKIP_GRPC_WARMUP=1 — skipping warmup")
+        health_servicer.set_serving()
+        return
+
+    # Wildcard bind hosts aren't routable as destinations; dial loopback instead.
+    warmup_host = {"0.0.0.0": "127.0.0.1", "::": "::1"}.get(server_args.host, server_args.host)
+    grpc_url = f"{warmup_host}:{server_args.port}"
+    channel = grpc.insecure_channel(
+        grpc_url,
+        options=[
+            ("grpc.max_send_message_length", 1024 * 1024 * 256),
+            ("grpc.max_receive_message_length", 1024 * 1024 * 256),
+        ],
+    )
+    stub = tokenspeed_scheduler_pb2_grpc.TokenSpeedSchedulerStub(channel)
+
+    # GetModelInfo is the quickest confirmation the server is bound + the
+    # engine is alive.
+    deadline = time.time() + 180
+    connected = False
+    while time.time() < deadline:
+        try:
+            stub.GetModelInfo(
+                tokenspeed_scheduler_pb2.GetModelInfoRequest(),
+                timeout=5,
+            )
+            connected = True
+            break
+        except Exception as e:  # noqa: BLE001
+            logger.debug("Warmup: GetModelInfo not ready yet: %s", e)
+            time.sleep(1)
+
+    if not connected:
+        logger.error("TokenSpeed gRPC warmup failed: GetModelInfo never succeeded")
+        channel.close()
+        return
+
+    # Generative only — warmup is a 1-token generate.
+    warmup_ok = False
+    try:
+        warmup = tokenspeed_scheduler_pb2.GenerateRequest(
+            request_id=f"WARMUP_{time.time()}",
+            tokenized=tokenspeed_scheduler_pb2.TokenizedInput(
+                input_ids=[0],
+                original_text="warmup",
+            ),
+            sampling_params=tokenspeed_scheduler_pb2.SamplingParams(
+                temperature=0.0,
+                max_new_tokens=1,
+            ),
+            stream=False,
+        )
+        final = None
+        for resp in stub.Generate(warmup, timeout=600):
+            final = resp
+        if final is None or not final.HasField("complete"):
+            logger.warning(
+                "Warmup Generate returned no Complete frame (last=%r)",
+                final,
+            )
+        else:
+            logger.info("Warmup generation succeeded")
+            warmup_ok = True
+    except Exception as e:  # noqa: BLE001
+        logger.warning("TokenSpeed warmup failed: %s", e)
+    finally:
+        channel.close()
+
+    if warmup_ok:
+        health_servicer.set_serving()
+        logger.info("TokenSpeed gRPC server is ready to serve")
+    else:
+        # Stays NOT_SERVING so K8s readiness keeps this worker out of rotation.
+        logger.error("TokenSpeed gRPC warmup did not produce a complete frame")

--- a/grpc_servicer/smg_grpc_servicer/tokenspeed/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/tokenspeed/servicer.py
@@ -1,0 +1,871 @@
+"""TokenSpeed gRPC servicer.
+
+Implements ``tokenspeed.grpc.scheduler.TokenSpeedScheduler`` on top of
+:class:`tokenspeed.runtime.engine.async_llm.AsyncLLM`. The proto field set
+is intentionally minimal — generative LLM serving only, no Embed /
+GetTokenizer / SubscribeKvEvents / multimodal / PD-disaggregated / LoRA /
+hidden states / classifier outputs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import json
+import logging
+import os
+import re
+import time
+from collections.abc import AsyncIterator
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+import grpc
+from google.protobuf.struct_pb2 import Struct
+from google.protobuf.timestamp_pb2 import Timestamp
+from smg_grpc_proto import tokenspeed_scheduler_pb2_grpc
+from smg_grpc_proto.generated import tokenspeed_scheduler_pb2
+
+from smg_grpc_servicer.tokenspeed.health_servicer import TokenSpeedHealthServicer
+
+if TYPE_CHECKING:
+    # Type-only imports — not resolved at module load so the servicer is
+    # importable in test environments that stub AsyncLLM / ServerArgs.
+    from tokenspeed.runtime.engine.async_llm import AsyncLLM
+    from tokenspeed.runtime.utils.server_args import ServerArgs
+
+logger = logging.getLogger(__name__)
+
+HEALTH_CHECK_TIMEOUT = int(os.getenv("TOKENSPEED_HEALTH_CHECK_TIMEOUT", "20"))
+
+
+def _lazy_generate_req_input():
+    """Late import for ``tokenspeed.runtime.engine.io_struct.GenerateReqInput``.
+
+    Kept lazy so the top of this module loads in test environments that stub
+    the TokenSpeed engine surface (unit tests don't need a fully-working
+    TokenSpeed install to exercise proto ↔ request-input conversion).
+    """
+    from tokenspeed.runtime.engine.io_struct import GenerateReqInput
+
+    return GenerateReqInput
+
+
+def _finish_reason_to_dict(reason: Any) -> dict | None:
+    """Normalise a TokenSpeed finish reason into a dict.
+
+    TokenSpeed emits ``BaseFinishReason``-style objects (or an already-
+    normalised dict) in ``meta_info["finish_reason"]``; downstream code
+    expects a dict with at minimum ``{"type": ...}`` and optionally
+    ``{"matched": int|str}``. ``None`` means "still running".
+
+    We duck-type on ``to_json()`` so the servicer module loads without
+    pulling in TokenSpeed's full request-processing graph. Unknown shapes
+    raise ``TypeError`` rather than silently flipping ``length`` / ``abort``
+    to ``stop`` — the caller maps that to ``StatusCode.INTERNAL``.
+    """
+    if reason is None or isinstance(reason, dict):
+        return reason
+    to_json = getattr(reason, "to_json", None)
+    if callable(to_json):
+        result = to_json()
+        if isinstance(result, dict):
+            return result
+        raise TypeError(
+            f"finish_reason {type(reason).__name__!r}.to_json() returned "
+            f"{type(result).__name__!r}; expected dict with at least 'type'."
+        )
+    raise TypeError(
+        f"Unknown finish_reason shape {type(reason).__name__!r}; expected "
+        f"a dict or an object with a to_json() method."
+    )
+
+
+class TokenSpeedSchedulerServicer(tokenspeed_scheduler_pb2_grpc.TokenSpeedSchedulerServicer):
+    """gRPC servicer exposing TokenSpeed's AsyncLLM over the dedicated TokenSpeed proto."""
+
+    def __init__(
+        self,
+        async_llm: AsyncLLM,
+        server_args: ServerArgs,
+        scheduler_info: dict,
+        health_servicer: TokenSpeedHealthServicer | None = None,
+    ):
+        self.async_llm = async_llm
+        self.server_args = server_args
+        self.scheduler_info = scheduler_info
+        self.health_servicer = health_servicer
+        self.start_time = time.time()
+
+        # Drive AsyncLLM's output-dispatch loop. This is idempotent — the
+        # first caller creates the handle loop; subsequent callers (including
+        # the HealthCheck RPC) are no-ops thanks to ``no_create_loop``.
+        self.async_llm.auto_create_handle_loop()
+
+        logger.info("TokenSpeedSchedulerServicer initialized")
+
+    # ------------------------------------------------------------------
+    # Generate (server-streaming)
+    # ------------------------------------------------------------------
+
+    async def Generate(
+        self,
+        request: tokenspeed_scheduler_pb2.GenerateRequest,
+        context: grpc.aio.ServicerContext,
+    ) -> AsyncIterator[tokenspeed_scheduler_pb2.GenerateResponse]:
+        rid = request.request_id
+        logger.info("Generate request %s (stream=%s)", rid, request.stream)
+
+        try:
+            req_obj = self._build_generate_req(request)
+        except ValueError as e:
+            await context.abort(grpc.StatusCode.INVALID_ARGUMENT, str(e))
+            return
+        except Exception as e:  # noqa: BLE001
+            logger.exception("Failed to build generate request for %s", rid)
+            await context.abort(grpc.StatusCode.INTERNAL, str(e))
+            return
+
+        # n>1 emits a *list* of final dicts (non-streaming) or per-choice
+        # streamed dicts tagged with ``index`` — both handled below.
+        expanded_rid = getattr(req_obj, "rid", None)
+
+        # Threaded through the response builders so the matched stop token
+        # stays in ``output_ids`` when the client asked to keep it.
+        no_stop_trim = bool(request.sampling_params.no_stop_trim)
+
+        aborted = False
+        try:
+            async for output in self.async_llm.generate_request(req_obj):
+                # Non-streaming n>1 emits a list of final dicts in one yield.
+                # Pre-scan for aborts so we don't yield partial successes
+                # before raising on a later aborted choice.
+                if isinstance(output, list):
+                    item_reasons = [
+                        _finish_reason_to_dict(item.get("meta_info", {}).get("finish_reason"))
+                        for item in output
+                    ]
+                    for r in item_reasons:
+                        if r and r.get("type") == "abort":
+                            code = _abort_status_code(r)
+                            await context.abort(code, r.get("message") or "aborted")
+                            return
+                    for idx, (item, item_reason) in enumerate(zip(output, item_reasons)):
+                        ci = int(item.get("index", idx))
+                        yield self._complete_response(
+                            rid, item, item_reason, ci, no_stop_trim=no_stop_trim
+                        )
+                    continue
+
+                meta = output.get("meta_info", {})
+                reason_dict = _finish_reason_to_dict(meta.get("finish_reason"))
+                is_finished = reason_dict is not None
+
+                if reason_dict is not None and reason_dict.get("type") == "abort":
+                    code = _abort_status_code(reason_dict)
+                    await context.abort(code, reason_dict.get("message") or "aborted")
+                    return
+
+                choice_index = int(output.get("index", 0))
+
+                if request.stream:
+                    yield self._chunk_response(
+                        rid, output, reason_dict, choice_index, no_stop_trim=no_stop_trim
+                    )
+                    if is_finished:
+                        yield self._complete_response(
+                            rid, output, reason_dict, choice_index, no_stop_trim=no_stop_trim
+                        )
+                elif is_finished:
+                    yield self._complete_response(
+                        rid, output, reason_dict, choice_index, no_stop_trim=no_stop_trim
+                    )
+
+        except ValueError as e:
+            logger.warning("Generate invalid request %s: %s", rid, e)
+            await context.abort(grpc.StatusCode.INVALID_ARGUMENT, str(e))
+        except asyncio.CancelledError:
+            # Client disconnected — sweep every scheduler-side rid we minted
+            # (including the per-choice ``{rid}-n{i}`` children n>1 creates)
+            # so abandoned requests don't keep consuming GPU work.
+            aborted = True
+            if isinstance(expanded_rid, list):
+                for r in expanded_rid:
+                    self.async_llm.abort_request(r)
+            else:
+                self.async_llm.abort_request(rid)
+            raise
+        except grpc.aio.AbortError:
+            raise
+        except Exception as e:
+            logger.exception("Generate failed for request %s", rid)
+            await context.abort(grpc.StatusCode.INTERNAL, str(e))
+        finally:
+            # Defensive cleanup — the scheduler owns rid_to_state, but if the
+            # stream was torn down before finish we need to notify it. When
+            # n>1 we expanded rid to a list of per-choice ids, so walk them.
+            if not aborted:
+                rids_to_check = (
+                    list(expanded_rid)
+                    if isinstance(expanded_rid, list)
+                    else ([expanded_rid] if isinstance(expanded_rid, str) else [])
+                )
+                for r in rids_to_check:
+                    state = self.async_llm.rid_to_state.get(r)
+                    if state is not None and not getattr(state, "finished", False):
+                        self.async_llm.abort_request(r)
+
+    # ------------------------------------------------------------------
+    # HealthCheck (unary)
+    # ------------------------------------------------------------------
+
+    async def HealthCheck(
+        self,
+        request: tokenspeed_scheduler_pb2.HealthCheckRequest,
+        context: grpc.aio.ServicerContext,
+    ) -> tokenspeed_scheduler_pb2.HealthCheckResponse:
+        """Deep health probe — sends a 1-token generation to the scheduler.
+
+        Any scheduler push within ``HEALTH_CHECK_TIMEOUT`` counts as alive.
+        ``log_metrics=False`` so health checks don't skew Prometheus counters.
+        """
+        rid = f"HEALTH_CHECK_{time.time()}"
+
+        if self.async_llm.gracefully_exit:
+            return tokenspeed_scheduler_pb2.HealthCheckResponse(
+                healthy=False, message="Server is shutting down"
+            )
+
+        GenerateReqInput = _lazy_generate_req_input()
+        probe = GenerateReqInput(
+            input_ids=[0],
+            sampling_params={"max_new_tokens": 1, "temperature": 0.0},
+            log_metrics=False,
+        )
+        probe.rid = rid
+
+        tic = time.time()
+
+        async def _drive_probe() -> bool:
+            try:
+                async for _ in self.async_llm.generate_request(probe):
+                    return True
+            except Exception as e:  # noqa: BLE001 — the probe is best-effort.
+                logger.warning("Health probe failed: %s", e)
+                return False
+            return False
+
+        task = asyncio.create_task(_drive_probe())
+        try:
+            while time.time() - tic < HEALTH_CHECK_TIMEOUT:
+                await asyncio.sleep(0.5)
+                # Any scheduler push after we started counts as healthy.
+                if self.async_llm.last_receive_tstamp > tic:
+                    return tokenspeed_scheduler_pb2.HealthCheckResponse(
+                        healthy=True,
+                        message="Health check passed",
+                    )
+                if task.done():
+                    return tokenspeed_scheduler_pb2.HealthCheckResponse(
+                        healthy=bool(task.result()),
+                        message=(
+                            "Health check passed"
+                            if task.result()
+                            else "Scheduler returned no output"
+                        ),
+                    )
+        finally:
+            if not task.done():
+                task.cancel()
+            # Best-effort cleanup: the probe rid shouldn't linger.
+            self.async_llm.abort_request(rid)
+
+        return tokenspeed_scheduler_pb2.HealthCheckResponse(
+            healthy=False,
+            message=f"Health check timeout after {HEALTH_CHECK_TIMEOUT}s",
+        )
+
+    # ------------------------------------------------------------------
+    # Abort (unary)
+    # ------------------------------------------------------------------
+
+    async def Abort(
+        self,
+        request: tokenspeed_scheduler_pb2.AbortRequest,
+        _context: grpc.aio.ServicerContext,
+    ) -> tokenspeed_scheduler_pb2.AbortResponse:
+        """Abort the request + any per-choice expansions from n>1.
+
+        Generate rewrites ``n>1`` requests into a list of rids
+        ``[{request_id}-n0, {request_id}-n1, ...]`` so TokenSpeed's batch
+        path sees unique rids. Aborting only the original ``request_id``
+        would leave those children running — we sweep them all.
+        """
+        rid = request.request_id
+        logger.info("Abort request %s", rid)
+        state_map = self.async_llm.rid_to_state
+
+        # Anchored regex avoids matching unrelated rids like "{rid}-name".
+        child_pattern = re.compile(rf"^{re.escape(rid)}-n\d+$")
+        targets = [r for r in state_map if r == rid or child_pattern.match(r)]
+
+        try:
+            for r in targets:
+                self.async_llm.abort_request(r)
+            known = bool(targets)
+            return tokenspeed_scheduler_pb2.AbortResponse(
+                success=known,
+                message=(
+                    f"Aborted {len(targets)} request(s) for {rid}"
+                    if known
+                    else f"Request {rid} not found"
+                ),
+            )
+        except Exception as e:
+            logger.exception("Abort failed for %s", rid)
+            return tokenspeed_scheduler_pb2.AbortResponse(success=False, message=str(e))
+
+    # ------------------------------------------------------------------
+    # GetModelInfo (unary)
+    # ------------------------------------------------------------------
+
+    async def GetModelInfo(
+        self,
+        _request: tokenspeed_scheduler_pb2.GetModelInfoRequest,
+        _context: grpc.aio.ServicerContext,
+    ) -> tokenspeed_scheduler_pb2.GetModelInfoResponse:
+        model_config = self.async_llm.model_config
+        hf_config = getattr(model_config, "hf_config", None)
+
+        eos = getattr(hf_config, "eos_token_id", None) if hf_config else None
+        if isinstance(eos, int):
+            eos_token_ids = [eos]
+        elif isinstance(eos, list):
+            eos_token_ids = list(eos)
+        else:
+            eos_token_ids = []
+
+        max_req_input_len = self.scheduler_info.get("max_req_input_len") or (
+            self.async_llm.max_req_input_len or 0
+        )
+
+        # Upstream renamed ``model_path`` → ``model`` and
+        # ``tokenizer_path`` → ``tokenizer``; accept either so the servicer
+        # works against both old and new builds.
+        model_path = getattr(self.server_args, "model", None) or getattr(
+            self.server_args, "model_path", ""
+        )
+        tokenizer_path = getattr(self.server_args, "tokenizer", None) or getattr(
+            self.server_args, "tokenizer_path", ""
+        )
+        return tokenspeed_scheduler_pb2.GetModelInfoResponse(
+            model_path=model_path,
+            tokenizer_path=tokenizer_path or "",
+            default_sampling_params_json=self.server_args.preferred_sampling_params or "",
+            weight_version="",
+            served_model_name=(self.server_args.served_model_name or model_path),
+            max_context_length=int(self.async_llm.context_len),
+            vocab_size=int(model_config.vocab_size),
+            model_type=(getattr(hf_config, "model_type", "") or "") if hf_config else "",
+            architectures=(getattr(hf_config, "architectures", []) or []) if hf_config else [],
+            eos_token_ids=eos_token_ids,
+            pad_token_id=(getattr(hf_config, "pad_token_id", 0) or 0) if hf_config else 0,
+            bos_token_id=(getattr(hf_config, "bos_token_id", 0) or 0) if hf_config else 0,
+            max_req_input_len=int(max_req_input_len),
+        )
+
+    # ------------------------------------------------------------------
+    # GetServerInfo (unary)
+    # ------------------------------------------------------------------
+
+    async def GetServerInfo(
+        self,
+        _request: tokenspeed_scheduler_pb2.GetServerInfoRequest,
+        _context: grpc.aio.ServicerContext,
+    ) -> tokenspeed_scheduler_pb2.GetServerInfoResponse:
+        # TokenSpeed's ``ServerArgs`` is a dataclass, but tests sometimes pass
+        # a plain namespace. Fall back to ``__dict__`` so both shapes work.
+        if dataclasses.is_dataclass(self.server_args) and not isinstance(self.server_args, type):
+            server_args_dict = dataclasses.asdict(self.server_args)
+        else:
+            server_args_dict = dict(getattr(self.server_args, "__dict__", {}))
+        server_args_struct = Struct()
+        server_args_struct.update(_make_json_serializable(server_args_dict))
+
+        scheduler_info_struct = Struct()
+        scheduler_info_struct.update(_make_json_serializable(dict(self.scheduler_info)))
+
+        uptime = time.time() - self.start_time
+        start_timestamp = Timestamp()
+        start_timestamp.FromSeconds(int(self.start_time))
+
+        try:
+            import tokenspeed  # local import: avoid module-load-time dependency
+
+            version = getattr(tokenspeed, "__version__", "unknown")
+        except Exception:  # noqa: BLE001 — fall back gracefully.
+            version = "unknown"
+
+        return tokenspeed_scheduler_pb2.GetServerInfoResponse(
+            server_args=server_args_struct,
+            scheduler_info=scheduler_info_struct,
+            active_requests=len(self.async_llm.rid_to_state),
+            is_paused=False,
+            uptime_seconds=float(uptime),
+            tokenspeed_version=version,
+            start_time=start_timestamp,
+            max_total_num_tokens=int(self.scheduler_info.get("max_total_num_tokens", 0)),
+        )
+
+    # ------------------------------------------------------------------
+    # GetLoads (unary) — bridges to TokenSpeed's scheduler-side load metrics
+    # ------------------------------------------------------------------
+
+    async def GetLoads(
+        self,
+        request: tokenspeed_scheduler_pb2.GetLoadsRequest,
+        context: grpc.aio.ServicerContext,
+    ) -> tokenspeed_scheduler_pb2.GetLoadsResponse:
+        """Return per-DP-rank scheduler load (optionally filtered to one rank).
+
+        ``AsyncLLM.get_load()`` round-trips a ``GetLoadReqInput`` over the
+        scheduler zmq channel; each reply carries ``num_reqs`` (running +
+        waiting), ``num_waiting_reqs``, and ``num_pages`` (KV pages in use).
+        """
+        try:
+            load_outputs = await asyncio.wait_for(
+                self.async_llm.get_load(), timeout=HEALTH_CHECK_TIMEOUT
+            )
+        except TimeoutError:
+            await context.abort(
+                grpc.StatusCode.DEADLINE_EXCEEDED,
+                f"tokenspeed scheduler did not respond to GetLoad within {HEALTH_CHECK_TIMEOUT}s",
+            )
+            return
+        except Exception as e:  # noqa: BLE001
+            logger.exception("GetLoads failed")
+            await context.abort(grpc.StatusCode.INTERNAL, str(e))
+            return
+
+        # Honor the optional ``dp_rank`` filter before any aggregation.
+        if request.HasField("dp_rank"):
+            wanted = int(request.dp_rank)
+            load_outputs = [lo for lo in load_outputs if int(lo.dp_rank) == wanted]
+
+        page_size = int(getattr(self.async_llm.server_args, "page_size", 1) or 1)
+        # Fall back to ``server_args.max_total_num_tokens`` for SimpleNamespace test stubs.
+        max_total_num_tokens = int(
+            (self.scheduler_info.get("max_total_num_tokens") if self.scheduler_info else None)
+            or getattr(self.async_llm.server_args, "max_total_num_tokens", 0)
+            or 0
+        )
+
+        scheduler_loads: list[tokenspeed_scheduler_pb2.SchedulerLoad] = []
+        total_running = 0
+        total_waiting = 0
+        token_usages: list[float] = []
+        for lo in load_outputs:
+            num_running = max(0, int(lo.num_reqs) - int(lo.num_waiting_reqs))
+            num_used_tokens = int(lo.num_pages) * page_size
+            token_usage = (
+                num_used_tokens / max_total_num_tokens if max_total_num_tokens > 0 else 0.0
+            )
+            scheduler_loads.append(
+                tokenspeed_scheduler_pb2.SchedulerLoad(
+                    dp_rank=int(lo.dp_rank),
+                    num_running_reqs=num_running,
+                    num_waiting_reqs=int(lo.num_waiting_reqs),
+                    num_total_reqs=int(lo.num_reqs),
+                    num_used_tokens=num_used_tokens,
+                    max_total_num_tokens=max_total_num_tokens,
+                    token_usage=token_usage,
+                )
+            )
+            total_running += num_running
+            total_waiting += int(lo.num_waiting_reqs)
+            token_usages.append(token_usage)
+
+        aggregate = tokenspeed_scheduler_pb2.AggregateMetrics(
+            total_running_reqs=total_running,
+            total_waiting_reqs=total_waiting,
+            total_reqs=total_running + total_waiting,
+            avg_token_usage=(sum(token_usages) / len(token_usages)) if token_usages else 0.0,
+        )
+
+        return tokenspeed_scheduler_pb2.GetLoadsResponse(
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            version="tokenspeed",
+            dp_rank_count=len(scheduler_loads),
+            loads=scheduler_loads,
+            aggregate=aggregate,
+        )
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    async def shutdown(self, drain_timeout_secs: float = 30.0) -> None:
+        """Graceful shutdown — drain in-flight requests, then kill scheduler children.
+
+        AsyncLLM's ``sigterm_watchdog`` polls ``gracefully_exit`` every 5s,
+        drains ``rid_to_state`` and finally calls
+        ``kill_process_tree(getpid, include_parent=True)``. That works in
+        steady-state but the gRPC server's main coroutine may unwind before
+        the watchdog ticks again, in which case the scheduler subprocesses
+        outlive the parent and end up orphaned. To avoid that, we:
+
+        1. Flag ``gracefully_exit`` so AsyncLLM stops accepting work and
+           the watchdog will eventually run its own cleanup.
+        2. Wait up to ``drain_timeout_secs`` for ``rid_to_state`` to empty.
+        3. Forcibly kill the subprocess tree (``include_parent=False``) so
+           the scheduler children are reaped regardless of whether the
+           watchdog tick fires before this coroutine returns. Idempotent
+           with the watchdog's own ``kill_process_tree`` call.
+        """
+        self.async_llm.gracefully_exit = True
+        if self.health_servicer:
+            self.health_servicer.set_not_serving()
+
+        deadline = time.monotonic() + drain_timeout_secs
+        while time.monotonic() < deadline:
+            if not getattr(self.async_llm, "rid_to_state", None):
+                break
+            await asyncio.sleep(0.5)
+        else:
+            logger.warning(
+                "shutdown drain timed out after %.1fs with %d in-flight requests; "
+                "killing scheduler children anyway",
+                drain_timeout_secs,
+                len(getattr(self.async_llm, "rid_to_state", {}) or {}),
+            )
+
+        # Reap the scheduler subprocesses without taking down our own PID;
+        # server.py's stop sequence still needs us alive to finish gRPC drain.
+        try:
+            from tokenspeed.runtime.utils.process import kill_process_tree
+        except ImportError:
+            logger.exception(
+                "Could not import tokenspeed.runtime.utils.process.kill_process_tree; "
+                "scheduler subprocesses may be orphaned"
+            )
+            return
+        kill_process_tree(os.getpid(), include_parent=False)
+
+    def _build_generate_req(self, request: tokenspeed_scheduler_pb2.GenerateRequest):
+        """Translate proto GenerateRequest → TokenSpeed GenerateReqInput.
+
+        Keeps the router's pre-tokenized inputs intact (``input_ids`` set,
+        ``text`` left blank) so the TokenSpeed InputProcessor skips its own
+        tokenizer pass.
+        """
+        if not request.HasField("tokenized"):
+            raise ValueError("GenerateRequest.tokenized is required")
+
+        input_ids = list(request.tokenized.input_ids)
+        if not input_ids:
+            raise ValueError("GenerateRequest.tokenized.input_ids is empty")
+
+        sampling = self._sampling_params_from_proto(
+            request.sampling_params,
+            reasoning_parser=getattr(self.server_args, "reasoning_parser", None),
+        )
+
+        GenerateReqInput = _lazy_generate_req_input()
+        obj = GenerateReqInput(
+            input_ids=input_ids,
+            sampling_params=sampling,
+            stream=bool(request.stream),
+            return_logprob=bool(request.return_logprob),
+            # presence-tracking distinguishes "client omitted" (→ ``-1`` =
+            # no input logprobs) from explicit ``0`` (start at position 0).
+            logprob_start_len=(
+                request.logprob_start_len if request.HasField("logprob_start_len") else -1
+            ),
+            top_logprobs_num=int(request.top_logprobs_num or 0),
+            token_ids_logprob=(
+                list(request.token_ids_logprob) if request.token_ids_logprob else None
+            ),
+        )
+        # ``normalize_batch_and_arguments`` asserts ``rid`` is a list when
+        # n>1; expand to deterministic per-choice rids so the assert holds.
+        n = sampling.get("n", 1) or 1
+        if n > 1:
+            obj.rid = [f"{request.request_id}-n{i}" for i in range(n)]
+        else:
+            obj.rid = request.request_id
+
+        # Don't set ``obj.text`` even when the proto carries
+        # ``original_text``: the HTTP path passes ``input_ids=[...], text=None``
+        # and setting both perturbs the engine's input-processor.
+
+        return obj
+
+    @staticmethod
+    def _sampling_params_from_proto(
+        params: tokenspeed_scheduler_pb2.SamplingParams,
+        *,
+        reasoning_parser: str | None = None,
+    ) -> dict[str, Any]:
+        """Build the dict that ``GenerateReqInput.sampling_params`` expects.
+
+        Field names must match :class:`SamplingParams.__init__`
+        (``max_new_tokens``, ``stop``, ``stop_token_ids``, ...).
+        """
+        out: dict[str, Any] = {}
+
+        # Sampling scalars are ``optional``; ``HasField()`` forwards only
+        # what the client explicitly set so absent fields fall through to
+        # engine defaults. Avoids the truthy-check pitfall that would drop
+        # an explicit ``temperature=0`` (greedy decoding).
+        for _field in (
+            "max_new_tokens",
+            "temperature",
+            "top_p",
+            "top_k",
+            "min_p",
+            "frequency_penalty",
+            "presence_penalty",
+            "repetition_penalty",
+        ):
+            if params.HasField(_field):
+                out[_field] = getattr(params, _field)
+
+        if params.min_new_tokens:
+            # ``min_new_tokens`` is non-optional; 0 is the "no minimum" sentinel.
+            out["min_new_tokens"] = params.min_new_tokens
+
+        # Lists
+        if params.stop:
+            out["stop"] = list(params.stop)
+        if params.stop_token_ids:
+            out["stop_token_ids"] = list(params.stop_token_ids)
+
+        # Bools (always forwarded)
+        out["skip_special_tokens"] = bool(params.skip_special_tokens)
+        out["spaces_between_special_tokens"] = bool(params.spaces_between_special_tokens)
+        out["ignore_eos"] = bool(params.ignore_eos)
+        # Keeps the matched stop token in ``output_ids`` so it reaches the
+        # gateway's detokenizer when ``skip_special_tokens=False``.
+        out["no_stop_trim"] = bool(params.no_stop_trim)
+
+        # n (OpenAI-compat, passthrough)
+        if params.n:
+            out["n"] = params.n
+        if params.logit_bias:
+            out["logit_bias"] = dict(params.logit_bias)
+
+        # Constraint types — exactly one may be set.
+        if params.HasField("regex"):
+            out["regex"] = params.regex
+        elif params.HasField("json_schema"):
+            # For reasoning parsers with an xgrammar template (e.g.
+            # ``gpt-oss`` → ``harmony``), wrap the JSON schema as a
+            # structural tag so the grammar only activates inside the
+            # response channel — otherwise xgrammar fights the channel
+            # preamble (``<|channel|>analysis<|message|>…``) and the model
+            # stalls until ``max_tokens``.
+            wrapped: str | None = None
+            if reasoning_parser:
+                try:
+                    from tokenspeed.runtime.grammar.reasoning_structural_tag import (
+                        structural_tag_for_reasoning_json_schema,
+                    )
+
+                    wrapped = structural_tag_for_reasoning_json_schema(
+                        reasoning_parser, json.loads(params.json_schema)
+                    )
+                except (ImportError, json.JSONDecodeError):
+                    wrapped = None
+            if wrapped is not None:
+                out["structural_tag"] = wrapped
+            else:
+                out["json_schema"] = params.json_schema
+        elif params.HasField("ebnf_grammar"):
+            out["ebnf"] = params.ebnf_grammar
+        elif params.HasField("structural_tag"):
+            out["structural_tag"] = params.structural_tag
+
+        return out
+
+    def _generated_output_ids(
+        self,
+        output: dict,
+        reason_dict: dict | None,
+        *,
+        no_stop_trim: bool = False,
+    ) -> list[int]:
+        """Return just the newly-generated tokens from an AsyncLLM output dict.
+
+        ``output_ids`` is prefixed with the Llama-3 assistant chat-template
+        header (``<|eot_id|><|start_header_id|>assistant<|end_header_id|>\\n\\n``)
+        and suffixed with the trailing matched stop token. Slicing the last
+        ``meta_info.completion_tokens`` strips the prefix; we then drop any
+        trailing matched stop. The per-choice ``matched_stop`` rides in a
+        dedicated proto field, so nothing is lost.
+        """
+        raw = list(output.get("output_ids") or [])
+        if not raw:
+            return raw
+        completion = output.get("meta_info", {}).get("completion_tokens")
+        if isinstance(completion, int) and 0 <= completion <= len(raw):
+            # ``raw[-0:]`` is the whole list, not empty — guard explicitly.
+            token_ids = raw[-completion:] if completion > 0 else []
+        else:
+            token_ids = raw
+        if not no_stop_trim and reason_dict and reason_dict.get("type") == "stop":
+            matched = reason_dict.get("matched")
+            if isinstance(matched, int) and token_ids and token_ids[-1] == matched:
+                token_ids = token_ids[:-1]
+        return token_ids
+
+    def _chunk_response(
+        self,
+        rid: str,
+        output: dict,
+        reason_dict: dict | None,
+        choice_index: int = 0,
+        *,
+        no_stop_trim: bool = False,
+    ) -> tokenspeed_scheduler_pb2.GenerateResponse:
+        meta = output.get("meta_info", {})
+        token_ids = self._generated_output_ids(output, reason_dict, no_stop_trim=no_stop_trim)
+        return tokenspeed_scheduler_pb2.GenerateResponse(
+            request_id=rid,
+            chunk=tokenspeed_scheduler_pb2.GenerateStreamChunk(
+                token_ids=token_ids,
+                prompt_tokens=int(meta.get("prompt_tokens", 0)),
+                completion_tokens=int(meta.get("completion_tokens", len(token_ids))),
+                cached_tokens=int(meta.get("cached_tokens", 0)),
+                output_logprobs=self._convert_output_logprobs_to_proto(output, len(token_ids)),
+                index=choice_index,
+            ),
+        )
+
+    def _complete_response(
+        self,
+        rid: str,
+        output: dict,
+        reason_dict: dict | None,
+        choice_index: int = 0,
+        *,
+        no_stop_trim: bool = False,
+    ) -> tokenspeed_scheduler_pb2.GenerateResponse:
+        meta = output.get("meta_info", {})
+        token_ids = self._generated_output_ids(output, reason_dict, no_stop_trim=no_stop_trim)
+
+        finish_reason = "stop"
+        matched_kwargs: dict[str, Any] = {}
+        if reason_dict:
+            kind = reason_dict.get("type")
+            if kind == "length":
+                finish_reason = "length"
+            elif kind == "abort":
+                finish_reason = "abort"
+            matched = reason_dict.get("matched")
+            if isinstance(matched, int):
+                matched_kwargs["matched_token_id"] = matched
+            elif isinstance(matched, str):
+                matched_kwargs["matched_stop_str"] = matched
+
+        return tokenspeed_scheduler_pb2.GenerateResponse(
+            request_id=rid,
+            complete=tokenspeed_scheduler_pb2.GenerateComplete(
+                output_ids=token_ids,
+                finish_reason=finish_reason,
+                prompt_tokens=int(meta.get("prompt_tokens", 0)),
+                completion_tokens=int(meta.get("completion_tokens", len(token_ids))),
+                cached_tokens=int(meta.get("cached_tokens", 0)),
+                output_logprobs=self._convert_output_logprobs_to_proto(output, len(token_ids)),
+                index=choice_index,
+                **matched_kwargs,
+            ),
+        )
+
+    @staticmethod
+    def _convert_output_logprobs_to_proto(
+        output: dict, n_keep: int
+    ) -> tokenspeed_scheduler_pb2.OutputLogProbs | None:
+        """Build an ``OutputLogProbs`` proto from a tokenspeed output dict.
+
+        TokenSpeed accumulates the request's logprobs in per-request state
+        across chunks; ``meta_info["output_token_logprobs"]`` is therefore the
+        running cumulative list of detokenized
+        ``(logprob: float, token_id: int, text: Optional[str])`` tuples, and
+        ``meta_info["output_top_logprobs"]`` is the parallel list of top-K
+        alternatives per position (each entry is ``None`` or a list of the
+        same tuple shape).
+
+        We slice the cumulative list down to just **this frame's tokens** by
+        taking the last ``len(output["output_ids"])`` entries — that's how
+        many new tokens this frame emitted — and then keep only the first
+        ``n_keep`` of those, so the alignment matches whatever
+        ``_generated_output_ids`` returned (it strips a trailing stop token
+        when the finish reason is ``stop``, leaving the last logprob entry
+        with no corresponding output id).
+
+        Returns ``None`` when there are no logprobs to emit — either the
+        client did not request them, or the server was started without
+        ``--enable-output-logprobs`` (in which case TokenSpeed silently
+        leaves these meta_info lists empty rather than raising).
+        """
+        if n_keep <= 0:
+            return None
+        meta = output.get("meta_info", {}) or {}
+        raw_token = meta.get("output_token_logprobs") or []
+        if not raw_token:
+            return None
+        n_chunk = len(output.get("output_ids", []) or [])
+        if n_chunk <= 0:
+            return None
+
+        raw_top = meta.get("output_top_logprobs") or []
+        chunk_token = raw_token[-n_chunk:] if len(raw_token) >= n_chunk else raw_token
+        chunk_top = raw_top[-n_chunk:] if len(raw_top) >= n_chunk else raw_top
+        delta_token = chunk_token[:n_keep]
+        # Pad ``delta_top`` to align with ``delta_token`` — TokenSpeed leaves
+        # ``output_top_logprobs`` empty when ``--enable-top-logprobs`` is off,
+        # but the gateway expects one ``TopLogProbs`` per emitted token.
+        delta_top = chunk_top[:n_keep] + [None] * max(0, len(delta_token) - len(chunk_top))
+
+        top_proto = []
+        for entry in delta_top:
+            if entry:
+                top_proto.append(
+                    tokenspeed_scheduler_pb2.TopLogProbs(
+                        values=[t[0] for t in entry],
+                        token_ids=[t[1] for t in entry],
+                    )
+                )
+            else:
+                # Position with no top-K data (e.g. ``--enable-top-logprobs``
+                # is not yet implemented in TokenSpeed; we still emit a
+                # placeholder per position so the gateway can align indices).
+                top_proto.append(tokenspeed_scheduler_pb2.TopLogProbs())
+
+        return tokenspeed_scheduler_pb2.OutputLogProbs(
+            token_logprobs=[t[0] for t in delta_token],
+            token_ids=[t[1] for t in delta_token],
+            top_logprobs=top_proto,
+        )
+
+
+def _abort_status_code(reason: dict) -> grpc.StatusCode:
+    status_code = reason.get("status_code")
+    if status_code == 400:
+        return grpc.StatusCode.INVALID_ARGUMENT
+    if status_code in (408, 504):
+        return grpc.StatusCode.DEADLINE_EXCEEDED
+    if status_code == 429:
+        return grpc.StatusCode.RESOURCE_EXHAUSTED
+    return grpc.StatusCode.INTERNAL
+
+
+def _make_json_serializable(obj: Any) -> Any:
+    """Flatten an arbitrary dataclass/config graph into JSON-safe primitives."""
+    if obj is None or isinstance(obj, str | int | float | bool):
+        return obj
+    if isinstance(obj, list | tuple | set):
+        return [_make_json_serializable(x) for x in obj]
+    if isinstance(obj, dict):
+        return {str(k): _make_json_serializable(v) for k, v in obj.items()}
+    return str(obj)


### PR DESCRIPTION
## Description

### Problem

PR #1351's Rust router can dial a TokenSpeed worker over the gRPC protocol it defines, but no worker speaks that protocol. We need a Python servicer that runs alongside a TokenSpeed scheduler process and serves those wire types.

### Solution

A self-contained TokenSpeed servicer module under `grpc_servicer/smg_grpc_servicer/tokenspeed/`, with cancellation handling for streaming/non-streaming, channel-close, and `n>1` paths.

### 3-PR Stack

This is part 2 of 3 splitting the original #1351:

- **PR1** (#1351, merged): Rust gRPC + protocol
- **PR2 (this):** Python servicer — base `main`
- **PR3** (#1465): CI workflows + e2e tests — base `feat/grpc-tokenspeed-servicer`

## Changes

- `grpc_servicer/smg_grpc_servicer/tokenspeed/servicer.py` — async scheduler servicer (Generate / HealthCheck / Abort / GetModelInfo / GetServerInfo / GetLoads), with cancellation that sweeps every `{rid}-n{i}` child rid expanded by `n>1`
- `grpc_servicer/smg_grpc_servicer/tokenspeed/health_servicer.py` — health-service bridge that flips SERVING / NOT_SERVING based on bounded-staleness scheduler liveness probes
- `grpc_servicer/smg_grpc_servicer/tokenspeed/scheduler_launcher.py` — boots TokenSpeed `AsyncLLM` in-process
- `grpc_servicer/smg_grpc_servicer/tokenspeed/server.py` and `__main__.py` — `python -m smg_grpc_servicer.tokenspeed` entrypoint
- `GetLoads` returns real `AsyncLLM.get_load()` metrics

## Test Plan

- [x] `ruff check grpc_servicer/smg_grpc_servicer/tokenspeed/` clean
- [x] `ruff format --check grpc_servicer/` clean
- [x] Manual smoke against a live TokenSpeed worker via PR3's e2e suite

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes (no Rust changes)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (no Rust changes)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TokenSpeed as a supported LLM backend with end-to-end gRPC support.
  * New CLI entrypoint to run the TokenSpeed gRPC server.
  * Health probing and readiness checks for scheduler and server, with warmup on startup.
  * Full scheduler API: streaming generation, abort, model info, server info, and real-time load metrics.
  * Graceful shutdown and background warmup behavior to improve startup reliability.

* **Chore**
  * Project metadata updated to include TokenSpeed in supported backends.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightseekorg/smg/pull/1464?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->