### PR TITLE
ci(tokenspeed): add CI install + GPU e2e coverage (Part 3/3)

### DIFF
--- a/.github/actions/setup-tokenspeed/action.yml
+++ b/.github/actions/setup-tokenspeed/action.yml
@@ -1,0 +1,13 @@
+name: 'Setup TokenSpeed Backend'
+description: 'Create Python venv and install TokenSpeed (engine + kernel + scheduler) from source.'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup Python venv
+      shell: bash
+      run: bash scripts/ci_setup_python_venv.sh
+
+    - name: Install TokenSpeed
+      shell: bash
+      run: bash scripts/ci_install_tokenspeed.sh

--- a/.github/workflows/e2e-gpu-job.yml
+++ b/.github/workflows/e2e-gpu-job.yml
@@ -6,7 +6,7 @@ on:
       engine:
         required: true
         type: string
-        description: "Engine to test: sglang, vllm, or trtllm"
+        description: "Engine to test: sglang, vllm, trtllm, or tokenspeed"
       gpu_tier:
         required: true
         type: string
@@ -67,6 +67,10 @@ jobs:
       - name: Setup TRT-LLM backend
         if: inputs.engine == 'trtllm'
         uses: ./.github/actions/setup-trtllm
+
+      - name: Setup TokenSpeed backend
+        if: inputs.engine == 'tokenspeed'
+        uses: ./.github/actions/setup-tokenspeed
 
       # Artifact downloads
       - name: Download wheel artifact

--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -399,6 +399,7 @@ jobs:
               - 'scripts/ci_setup_python_venv.sh'
               - 'scripts/ci_install_sglang.sh'
               - 'scripts/ci_install_vllm.sh'
+              - 'scripts/ci_install_tokenspeed.sh'
               - 'scripts/ci_install_e2e_deps.sh'
               - 'scripts/ci_killall_sglang.sh'
               - 'scripts/ci_build_wheel.sh'
@@ -413,6 +414,7 @@ jobs:
               - 'e2e_test/router/**'
               - 'scripts/ci_install_vllm.sh'
               - 'scripts/ci_install_trtllm.sh'
+              - 'scripts/ci_install_tokenspeed.sh'
             agentic:
               - 'crates/mcp/**'
               - 'crates/data_connector/**'
@@ -476,6 +478,10 @@ jobs:
             timeout: 20
           - engine: trtllm
             timeout: 90
+          # TokenSpeed builds kernel (CUDA) + scheduler (C++/CMake) from
+          # source, so first run takes ~30 min; cached runs are faster.
+          - engine: tokenspeed
+            timeout: 60
     uses: ./.github/workflows/e2e-gpu-job.yml
     with:
       engine: ${{ matrix.engine }}
@@ -586,6 +592,11 @@ jobs:
             timeout: 20
           - engine: trtllm
             timeout: 30
+          # Picks up TestChatCompletionGptOss (gpt-oss-20b, ``@pytest.mark.gpu(2)``)
+          # on the tokenspeed engine; the 1-GPU job collected the test class but
+          # pytest skipped it at collection because the runner only had 1 GPU.
+          - engine: tokenspeed
+            timeout: 60
     uses: ./.github/workflows/e2e-gpu-job.yml
     with:
       engine: ${{ matrix.engine }}

--- a/e2e_test/chat_completions/test_enable_thinking.py
+++ b/e2e_test/chat_completions/test_enable_thinking.py
@@ -18,13 +18,13 @@ API_KEY = "not-used"
 
 
 # =============================================================================
-# Enable Thinking Tests (Qwen 30B)
+# Enable Thinking Tests (Qwen3)
 # =============================================================================
 
 
-@pytest.mark.engine("sglang", "vllm", "trtllm")
+@pytest.mark.engine("sglang", "vllm", "trtllm", "tokenspeed")
 @pytest.mark.gpu(1)
-@pytest.mark.model("Qwen/Qwen3-30B-A3B")
+@pytest.mark.model("Qwen/Qwen3-4B")
 @pytest.mark.gateway(extra_args=["--reasoning-parser", "qwen3", "--history-backend", "memory"])
 @pytest.mark.parametrize("setup_backend", ["grpc"], indirect=True)
 @pytest.mark.parametrize("api_client", ["openai", "smg"], indirect=True)

--- a/e2e_test/chat_completions/test_function_calling.py
+++ b/e2e_test/chat_completions/test_function_calling.py
@@ -22,7 +22,9 @@ logger = logging.getLogger(__name__)
 # Shared Tool Definitions
 # =============================================================================
 
-# System message for Llama3.2 function calling
+# System message for Llama3.2 function calling — prescribes the
+# {"name": ..., "parameters": ...} JSON shape that the ``llama`` tool
+# parser looks for. Used by ``TestToolChoiceLlama`` below.
 LLAMA_SYSTEM_MESSAGE = (
     "You are a helpful assistant with tool calling capabilities. "
     "Only reply with a tool call if the function exists in the library provided by the user. "
@@ -100,14 +102,14 @@ PYTHONIC_MESSAGES = [
 # =============================================================================
 
 
-@pytest.mark.engine("sglang", "vllm", "trtllm")
+@pytest.mark.engine("sglang", "vllm", "trtllm", "tokenspeed")
 @pytest.mark.gpu(1)
 @pytest.mark.model("meta-llama/Llama-3.2-1B-Instruct")
 @pytest.mark.gateway(extra_args=["--tool-call-parser", "llama", "--history-backend", "memory"])
 @pytest.mark.parametrize("setup_backend", ["grpc"], indirect=True)
 @pytest.mark.parametrize("api_client", ["openai", "smg"], indirect=True)
 class TestOpenAIServerFunctionCalling:
-    """Tests for OpenAI-compatible function calling with Llama tool parser."""
+    """Tests for OpenAI-compatible function calling with the llama tool parser."""
 
     def test_function_calling_format(self, model, api_client):
         """Test: Whether the function call format returned by the AI is correct.
@@ -265,8 +267,8 @@ class TestOpenAIServerFunctionCalling:
                         },
                         "required": ["a", "b"],
                     },
-                    # Llama-3.2-1B is flaky in tool call. It won't always respond with
-                    # parameters unless we set strict.
+                    # Llama-3.2-1B is flaky in tool call format, so we force it
+                    # with strict mode.
                     "strict": True,
                 },
             }
@@ -377,7 +379,6 @@ class TestOpenAIServerFunctionCalling:
 
         - When tool_choice == "required", the model should return one or more tool_calls.
         """
-
         tools = [
             {
                 "type": "function",
@@ -467,7 +468,6 @@ class TestOpenAIServerFunctionCalling:
 
         - When tool_choice is a specific ToolChoice, the model should return one or more tool_calls.
         """
-
         tools = [
             {
                 "type": "function",
@@ -536,7 +536,6 @@ class TestOpenAIServerFunctionCalling:
 
         This tests the fix for the bug where only the last index got a finish_reason chunk.
         """
-
         tools = [
             {
                 "type": "function",
@@ -719,7 +718,7 @@ class TestOpenAIServerFunctionCalling:
 # =============================================================================
 
 
-@pytest.mark.engine("sglang", "vllm", "trtllm")
+@pytest.mark.engine("sglang", "vllm", "trtllm", "tokenspeed")
 @pytest.mark.gpu(1)
 @pytest.mark.model("meta-llama/Llama-3.1-8B-Instruct")
 @pytest.mark.gateway(extra_args=["--tool-call-parser", "pythonic", "--history-backend", "memory"])
@@ -1500,7 +1499,7 @@ class _TestToolChoiceBase:
 # =============================================================================
 
 
-@pytest.mark.engine("sglang", "vllm", "trtllm")
+@pytest.mark.engine("sglang", "vllm", "trtllm", "tokenspeed")
 @pytest.mark.gpu(1)
 @pytest.mark.model("meta-llama/Llama-3.2-1B-Instruct")
 @pytest.mark.gateway(extra_args=["--tool-call-parser", "llama", "--history-backend", "memory"])
@@ -1521,9 +1520,9 @@ class TestToolChoiceLlama(_TestToolChoiceBase):
 # =============================================================================
 
 
-@pytest.mark.engine("sglang", "vllm", "trtllm")
+@pytest.mark.engine("sglang", "vllm", "trtllm", "tokenspeed")
 @pytest.mark.gpu(1)
-@pytest.mark.model("Qwen/Qwen2.5-7B-Instruct")
+@pytest.mark.model("Qwen/Qwen3-4B-Instruct-2507")
 @pytest.mark.gateway(extra_args=["--tool-call-parser", "qwen", "--history-backend", "memory"])
 @pytest.mark.parametrize("setup_backend", ["grpc"], indirect=True)
 @pytest.mark.parametrize("api_client", ["openai", "smg"], indirect=True)
@@ -1590,9 +1589,9 @@ WEATHER_TOOL = {
 }
 
 
-@pytest.mark.engine("sglang", "vllm", "trtllm")
-@pytest.mark.gpu(2)
-@pytest.mark.model("Qwen/Qwen2.5-14B-Instruct")
+@pytest.mark.engine("sglang", "vllm", "trtllm", "tokenspeed")
+@pytest.mark.gpu(1)
+@pytest.mark.model("Qwen/Qwen3-4B-Instruct-2507")
 @pytest.mark.gateway(extra_args=["--tool-call-parser", "qwen", "--history-backend", "memory"])
 @pytest.mark.parametrize("setup_backend", ["grpc"], indirect=True)
 @pytest.mark.parametrize("api_client", ["openai", "smg"], indirect=True)

--- a/e2e_test/chat_completions/test_openai_server.py
+++ b/e2e_test/chat_completions/test_openai_server.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 # =============================================================================
 
 
-@pytest.mark.engine("sglang", "vllm", "trtllm")
+@pytest.mark.engine("sglang", "vllm", "trtllm", "tokenspeed")
 @pytest.mark.gpu(1)
 @pytest.mark.model("meta-llama/Llama-3.1-8B-Instruct")
 @pytest.mark.gateway(extra_args=["--history-backend", "memory"])
@@ -33,7 +33,23 @@ class TestChatCompletion:
     # Harmony (gpt-oss) does not trim because its detokenization is not channel-aware.
     STOP_SEQUENCE_TRIMMED = True
 
-    @pytest.mark.parametrize("logprobs", [None, 5])
+    @pytest.mark.parametrize(
+        "logprobs",
+        [
+            None,
+            pytest.param(
+                5,
+                marks=pytest.mark.skip_for_runtime(
+                    "tokenspeed",
+                    reason=(
+                        "tokenspeed's --enable-top-logprobs is not yet implemented "
+                        "(raises at startup); base output logprobs work via "
+                        "--enable-output-logprobs but the test requires top_logprobs=5"
+                    ),
+                ),
+            ),
+        ],
+    )
     @pytest.mark.parametrize("parallel_sample_num", [1, 2])
     def test_chat_completion(self, model, api_client, logprobs, parallel_sample_num):
         """Test non-streaming chat completion with logprobs and parallel sampling."""
@@ -73,7 +89,23 @@ class TestChatCompletion:
         assert response.usage.completion_tokens > 0
         assert response.usage.total_tokens > 0
 
-    @pytest.mark.parametrize("logprobs", [None, 5])
+    @pytest.mark.parametrize(
+        "logprobs",
+        [
+            None,
+            pytest.param(
+                5,
+                marks=pytest.mark.skip_for_runtime(
+                    "tokenspeed",
+                    reason=(
+                        "tokenspeed's --enable-top-logprobs is not yet implemented "
+                        "(raises at startup); base output logprobs work via "
+                        "--enable-output-logprobs but the test requires top_logprobs=5"
+                    ),
+                ),
+            ),
+        ],
+    )
     @pytest.mark.parametrize("parallel_sample_num", [1, 2])
     def test_chat_completion_stream(self, model, api_client, logprobs, parallel_sample_num):
         """Test streaming chat completion with logprobs and parallel sampling."""
@@ -359,7 +391,7 @@ convenient hands-free control to your smart devices.
         return delta.content or getattr(delta, "reasoning_content", "") or ""
 
 
-@pytest.mark.engine("sglang", "vllm", "trtllm")
+@pytest.mark.engine("sglang", "vllm", "trtllm", "tokenspeed")
 @pytest.mark.gpu(2)
 @pytest.mark.model("openai/gpt-oss-20b")
 @pytest.mark.gateway(extra_args=["--history-backend", "memory"])
@@ -375,13 +407,45 @@ class TestChatCompletionGptOss(TestChatCompletion):
 
     STOP_SEQUENCE_TRIMMED = False
 
-    @pytest.mark.parametrize("logprobs", [None, 5])
+    @pytest.mark.parametrize(
+        "logprobs",
+        [
+            None,
+            pytest.param(
+                5,
+                marks=pytest.mark.skip_for_runtime(
+                    "tokenspeed",
+                    reason=(
+                        "tokenspeed's --enable-top-logprobs is not yet implemented "
+                        "(raises at startup); base output logprobs work via "
+                        "--enable-output-logprobs but the test requires top_logprobs=5"
+                    ),
+                ),
+            ),
+        ],
+    )
     @pytest.mark.parametrize("parallel_sample_num", [1, 2])
     def test_chat_completion(self, model, api_client, logprobs, parallel_sample_num):
         """Test non-streaming chat completion with logprobs and parallel sampling."""
         super().test_chat_completion(model, api_client, logprobs, parallel_sample_num)
 
-    @pytest.mark.parametrize("logprobs", [None, 5])
+    @pytest.mark.parametrize(
+        "logprobs",
+        [
+            None,
+            pytest.param(
+                5,
+                marks=pytest.mark.skip_for_runtime(
+                    "tokenspeed",
+                    reason=(
+                        "tokenspeed's --enable-top-logprobs is not yet implemented "
+                        "(raises at startup); base output logprobs work via "
+                        "--enable-output-logprobs but the test requires top_logprobs=5"
+                    ),
+                ),
+            ),
+        ],
+    )
     @pytest.mark.parametrize("parallel_sample_num", [1, 2])
     @pytest.mark.skip_for_runtime(
         "trtllm", reason="trtllm may return more top_logprobs than requested in streaming"
@@ -402,7 +466,7 @@ class TestChatCompletionGptOss(TestChatCompletion):
         pass
 
 
-@pytest.mark.engine("sglang", "vllm", "trtllm")
+@pytest.mark.engine("sglang", "vllm", "trtllm", "tokenspeed")
 @pytest.mark.gpu(4)
 @pytest.mark.model("openai/gpt-oss-120b")
 @pytest.mark.gateway(extra_args=["--history-backend", "memory"])

--- a/e2e_test/chat_completions/test_structured_output.py
+++ b/e2e_test/chat_completions/test_structured_output.py
@@ -124,7 +124,7 @@ class _TestStructuredOutputBase:
 # =============================================================================
 
 
-@pytest.mark.engine("sglang", "vllm", "trtllm")
+@pytest.mark.engine("sglang", "vllm", "trtllm", "tokenspeed")
 @pytest.mark.gpu(1)
 @pytest.mark.model("meta-llama/Llama-3.1-8B-Instruct")
 @pytest.mark.gateway(extra_args=["--history-backend", "memory"])
@@ -139,7 +139,7 @@ class TestStructuredOutputRegular(_TestStructuredOutputBase):
 # =============================================================================
 
 
-@pytest.mark.engine("sglang", "vllm", "trtllm")
+@pytest.mark.engine("sglang", "vllm", "trtllm", "tokenspeed")
 @pytest.mark.gpu(2)
 @pytest.mark.model("openai/gpt-oss-20b")
 @pytest.mark.gateway(extra_args=["--history-backend", "memory"])
@@ -149,7 +149,7 @@ class TestStructuredOutputGptOss(_TestStructuredOutputBase):
     """Structured output tests for Harmony models (GPT-OSS 20B, 1 GPU)."""
 
 
-@pytest.mark.engine("sglang", "vllm", "trtllm")
+@pytest.mark.engine("sglang", "vllm", "trtllm", "tokenspeed")
 @pytest.mark.gpu(4)
 @pytest.mark.model("openai/gpt-oss-120b")
 @pytest.mark.gateway(extra_args=["--history-backend", "memory"])

--- a/e2e_test/chat_completions/test_validation.py
+++ b/e2e_test/chat_completions/test_validation.py
@@ -37,7 +37,7 @@ def get_tokenizer(model_path: str):
 # =============================================================================
 
 
-@pytest.mark.engine("sglang", "vllm", "trtllm")
+@pytest.mark.engine("sglang", "vllm", "trtllm", "tokenspeed")
 @pytest.mark.gpu(1)
 @pytest.mark.model("meta-llama/Llama-3.1-8B-Instruct")
 @pytest.mark.gateway(extra_args=["--history-backend", "memory"])
@@ -107,7 +107,7 @@ class TestIgnoreEOS:
 # =============================================================================
 
 
-@pytest.mark.engine("sglang", "vllm", "trtllm")
+@pytest.mark.engine("sglang", "vllm", "trtllm", "tokenspeed")
 @pytest.mark.gpu(1)
 @pytest.mark.model("meta-llama/Llama-3.1-8B-Instruct")
 @pytest.mark.gateway(extra_args=["--history-backend", "memory"])
@@ -157,9 +157,10 @@ class TestLargeMaxNewTokens:
         assert len(responses) == num_requests
         for i, response in enumerate(responses):
             assert response.choices[0].message.content, f"Request {i} returned empty content"
-            assert response.choices[0].finish_reason in ("stop", "length"), (
-                f"Request {i} had unexpected finish_reason: {response.choices[0].finish_reason}"
-            )
+            assert response.choices[0].finish_reason in (
+                "stop",
+                "length",
+            ), f"Request {i} had unexpected finish_reason: {response.choices[0].finish_reason}"
 
 
 # =============================================================================
@@ -167,7 +168,7 @@ class TestLargeMaxNewTokens:
 # =============================================================================
 
 
-@pytest.mark.engine("sglang", "vllm", "trtllm")
+@pytest.mark.engine("sglang", "vllm", "trtllm", "tokenspeed")
 @pytest.mark.gpu(2)
 @pytest.mark.model("openai/gpt-oss-20b")
 @pytest.mark.gateway(extra_args=["--history-backend", "memory"])
@@ -243,7 +244,7 @@ class TestGptOssValidation:
 # =============================================================================
 
 
-@pytest.mark.engine("sglang", "vllm")
+@pytest.mark.engine("sglang", "vllm", "tokenspeed")
 @pytest.mark.gpu(1)
 @pytest.mark.model("meta-llama/Llama-3.2-1B-Instruct")
 @pytest.mark.gateway(extra_args=["--tool-call-parser", "llama", "--history-backend", "memory"])

--- a/e2e_test/completions/test_basic.py
+++ b/e2e_test/completions/test_basic.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import pytest
 
 
-@pytest.mark.engine("sglang", "vllm")
+@pytest.mark.engine("sglang", "vllm", "tokenspeed")
 @pytest.mark.gpu(1)
 @pytest.mark.model("meta-llama/Llama-3.1-8B-Instruct")
 @pytest.mark.parametrize("setup_backend", ["grpc"], indirect=True)
@@ -161,7 +161,7 @@ class TestCompletionBasic:
         assert response.usage.completion_tokens == 0
 
 
-@pytest.mark.engine("sglang", "vllm")
+@pytest.mark.engine("sglang", "vllm", "tokenspeed")
 @pytest.mark.gpu(1)
 @pytest.mark.model("meta-llama/Llama-3.1-8B-Instruct")
 @pytest.mark.parametrize("setup_backend", ["grpc"], indirect=True)

--- a/e2e_test/fixtures/hooks.py
+++ b/e2e_test/fixtures/hooks.py
@@ -82,12 +82,18 @@ def pytest_configure(config: pytest.Config) -> None:
 
 
 def pytest_runtest_setup(item: pytest.Item) -> None:
-    """Skip tests marked with ``@pytest.mark.skip_for_runtime``."""
-    marker = item.get_closest_marker("skip_for_runtime")
-    if marker:
-        current_runtime = get_runtime()
-        skip_runtimes = marker.args
-        if current_runtime in skip_runtimes:
+    """Skip tests marked with ``@pytest.mark.skip_for_runtime``.
+
+    A single test item can carry multiple ``skip_for_runtime`` marks — e.g. a
+    method-level ``@pytest.mark.skip_for_runtime("trtllm", ...)`` plus a
+    parametrize-attached ``pytest.param(5, marks=skip_for_runtime("tokenspeed",
+    ...))``. ``get_closest_marker`` only returns one of them, which silently
+    drops the others. Iterate every mark so a runtime that's named in any of
+    them gets skipped, regardless of which is "closest".
+    """
+    current_runtime = get_runtime()
+    for marker in item.iter_markers(name="skip_for_runtime"):
+        if current_runtime in marker.args:
             reason = marker.kwargs.get("reason", f"Not supported on {current_runtime}")
             pytest.skip(f"Skipping for {current_runtime}: {reason}")
 

--- a/e2e_test/infra/constants.py
+++ b/e2e_test/infra/constants.py
@@ -26,6 +26,7 @@ class Runtime(StrEnum):
     VLLM = "vllm"
     TRTLLM = "trtllm"
     MLX = "mlx"
+    TOKENSPEED = "tokenspeed"
     OPENAI = "openai"
     XAI = "xai"
     GEMINI = "gemini"
@@ -34,7 +35,9 @@ class Runtime(StrEnum):
 
 # Convenience sets
 LOCAL_MODES = frozenset({ConnectionMode.HTTP, ConnectionMode.GRPC})
-LOCAL_RUNTIMES = frozenset({Runtime.SGLANG, Runtime.VLLM, Runtime.TRTLLM, Runtime.MLX})
+LOCAL_RUNTIMES = frozenset(
+    {Runtime.SGLANG, Runtime.VLLM, Runtime.TRTLLM, Runtime.MLX, Runtime.TOKENSPEED}
+)
 CLOUD_RUNTIMES = frozenset({Runtime.OPENAI, Runtime.XAI, Runtime.GEMINI, Runtime.ANTHROPIC})
 
 # Fixture parameter names (used in @pytest.mark.parametrize)
@@ -52,7 +55,9 @@ DEFAULT_RUNTIME = "sglang"
 ENV_MODELS = "E2E_MODELS"
 ENV_BACKENDS = "E2E_BACKENDS"
 ENV_MODEL = "E2E_MODEL"
-ENV_RUNTIME = "E2E_RUNTIME"  # Runtime for gRPC tests: "sglang", "vllm", or "trtllm"
+ENV_RUNTIME = (
+    "E2E_RUNTIME"  # Runtime for gRPC tests — one of Runtime.{SGLANG,VLLM,TRTLLM,TOKENSPEED}
+)
 ENV_STARTUP_TIMEOUT = "E2E_STARTUP_TIMEOUT"
 ENV_SKIP_MODEL_POOL = "SKIP_MODEL_POOL"
 ENV_SKIP_BACKEND_SETUP = "SKIP_BACKEND_SETUP"
@@ -110,12 +115,22 @@ def is_mlx() -> bool:
     return get_runtime() == "mlx"
 
 
+def is_tokenspeed() -> bool:
+    """Check if tests are running with TokenSpeed runtime.
+
+    Returns:
+        True if E2E_RUNTIME is "tokenspeed", False otherwise.
+    """
+    return get_runtime() == "tokenspeed"
+
+
 # Runtime display labels
 RUNTIME_LABELS = {
     "sglang": "SGLang",
     "vllm": "vLLM",
     "trtllm": "TensorRT-LLM",
     "mlx": "MLX",
+    "tokenspeed": "TokenSpeed",
 }
 
 ENV_SHOW_ROUTER_LOGS = "SHOW_ROUTER_LOGS"

--- a/e2e_test/infra/model_specs.py
+++ b/e2e_test/infra/model_specs.py
@@ -61,7 +61,26 @@ MODEL_SPECS: dict[str, dict] = {
         "tp": 1,
         "features": ["chat", "streaming", "reasoning"],
     },
-    # Thinking/reasoning model (larger)
+    # Qwen3 instruct (non-thinking variant) — emits the same
+    # `<tool_call>\n{"name": ..., "arguments": ...}\n</tool_call>` format as
+    # Qwen 2.5, so the gateway's ``qwen`` tool-call parser applies. Used by
+    # ``TestToolChoiceQwen`` and ``TestMultiTurnToolCall``: a Qwen3 model is
+    # required because the Qwen2 family is not in TokenSpeed's model registry.
+    "Qwen/Qwen3-4B-Instruct-2507": {
+        "model": _resolve_model_path("Qwen/Qwen3-4B-Instruct-2507"),
+        "tp": 1,
+        "features": ["chat", "streaming", "function_calling", "tool_choice"],
+    },
+    # Hybrid Qwen3 with the ``enable_thinking`` chat-template toggle. Used
+    # by ``TestEnableThinking``. Dense (``Qwen3ForCausalLM``), so it lands
+    # on tokenspeed's current model registry where the larger
+    # ``Qwen3-30B-A3B`` (``Qwen3MoeForCausalLM``) does not. Uses the
+    # existing ``qwen3`` reasoning parser.
+    "Qwen/Qwen3-4B": {
+        "model": _resolve_model_path("Qwen/Qwen3-4B"),
+        "tp": 1,
+        "features": ["chat", "streaming", "thinking", "reasoning"],
+    },
     "Qwen/Qwen3-30B-A3B": {
         "model": _resolve_model_path("Qwen/Qwen3-30B-A3B"),
         "tp": 1,
@@ -95,6 +114,10 @@ MODEL_SPECS: dict[str, dict] = {
             "--structured-outputs-config",
             '{"enable_in_reasoning": true}',
         ],
+        # Tells the engine to wrap ``response_format=json_schema`` as the
+        # Harmony structural tag so the grammar only activates inside the
+        # final channel — otherwise xgrammar fights the analysis preamble.
+        "tokenspeed_args": ["--reasoning-parser", "gpt-oss"],
     },
     "openai/gpt-oss-120b": {
         "model": _resolve_model_path("openai/gpt-oss-120b"),
@@ -105,6 +128,7 @@ MODEL_SPECS: dict[str, dict] = {
             "--structured-outputs-config",
             '{"enable_in_reasoning": true}',
         ],
+        "tokenspeed_args": ["--reasoning-parser", "gpt-oss"],
     },
     # MiniMax M2 - nightly benchmarks
     "minimaxai/minimax-m2": {
@@ -242,7 +266,7 @@ FUNCTION_CALLING_MODELS = get_models_with_feature("function_calling")
 DEFAULT_MODEL_PATH = MODEL_SPECS["meta-llama/Llama-3.1-8B-Instruct"]["model"]
 DEFAULT_SMALL_MODEL_PATH = MODEL_SPECS["meta-llama/Llama-3.2-1B-Instruct"]["model"]
 DEFAULT_REASONING_MODEL_PATH = MODEL_SPECS["deepseek-ai/DeepSeek-R1-Distill-Qwen-7B"]["model"]
-DEFAULT_ENABLE_THINKING_MODEL_PATH = MODEL_SPECS["Qwen/Qwen3-30B-A3B"]["model"]
+DEFAULT_ENABLE_THINKING_MODEL_PATH = MODEL_SPECS["Qwen/Qwen3-4B"]["model"]
 DEFAULT_QWEN_FUNCTION_CALLING_MODEL_PATH = MODEL_SPECS["Qwen/Qwen2.5-7B-Instruct"]["model"]
 DEFAULT_MISTRAL_FUNCTION_CALLING_MODEL_PATH = MODEL_SPECS["mistralai/Mistral-7B-Instruct-v0.3"][
     "model"

--- a/e2e_test/infra/worker.py
+++ b/e2e_test/infra/worker.py
@@ -34,7 +34,7 @@ class Worker:
     """A single inference worker process."""
 
     model_id: str
-    engine: str  # "sglang", "vllm", or "trtllm"
+    engine: str  # "sglang", "vllm", "trtllm", or "tokenspeed"
     port: int
     gpu_ids: list[int]
     mode: ConnectionMode = ConnectionMode.HTTP
@@ -180,6 +180,13 @@ class Worker:
             return self._build_trtllm_cmd(model_path, tp_size, spec)
         elif self.engine == "mlx":
             return self._build_mlx_cmd(model_path, spec)
+        elif self.engine == "tokenspeed":
+            if self.mode != ConnectionMode.GRPC:
+                raise ValueError(
+                    "TokenSpeed e2e workers only support gRPC mode; "
+                    "HTTP mode would go through the existing OpenAI frontend."
+                )
+            return self._build_tokenspeed_grpc_cmd(model_path, tp_size, spec)
         else:
             raise ValueError(f"Unsupported engine: {self.engine}")
 
@@ -279,6 +286,41 @@ class Worker:
             str(self.port),
         ]
         extra = spec.get("mlx_args", [])
+        if extra:
+            cmd.extend(extra)
+        return cmd
+
+    def _build_tokenspeed_grpc_cmd(self, model_path: str, tp_size: int, spec: dict) -> list[str]:
+        """Build TokenSpeed gRPC server command.
+
+        Launches ``smg_grpc_servicer.tokenspeed`` which wraps TokenSpeed's
+        ``AsyncLLM`` behind the dedicated ``tokenspeed.grpc.scheduler``
+        service.
+        """
+        cmd = [
+            "python3",
+            "-m",
+            "smg_grpc_servicer.tokenspeed",
+            "--model",
+            model_path,
+            "--host",
+            DEFAULT_HOST,
+            "--port",
+            str(self.port),
+            "--tensor-parallel-size",
+            str(tp_size),
+            "--log-level",
+            "warning",
+            # ``tool_choice=required`` / ``tool_choice={function}`` becomes a
+            # json_schema constraint on the wire; TokenSpeed only honors that
+            # when a grammar backend is configured (default is ``None``).
+            "--grammar-backend",
+            "xgrammar",
+            # Output logprobs default OFF in tokenspeed; flip them on so
+            # ``logprobs=True`` requests get real per-token data back.
+            "--enable-output-logprobs",
+        ]
+        extra = spec.get("tokenspeed_args", [])
         if extra:
             cmd.extend(extra)
         return cmd

--- a/e2e_test/responses/test_sampling_params.py
+++ b/e2e_test/responses/test_sampling_params.py
@@ -103,7 +103,7 @@ class TestSamplingParamsLocal(_SamplingParamsBase):
     """Regular model (Qwen via SGLang)."""
 
 
-@pytest.mark.engine("sglang", "vllm", "trtllm")
+@pytest.mark.engine("sglang", "vllm", "trtllm", "tokenspeed")
 @pytest.mark.gpu(2)
 @pytest.mark.e2e
 @pytest.mark.model("openai/gpt-oss-20b")

--- a/e2e_test/responses/test_state_management.py
+++ b/e2e_test/responses/test_state_management.py
@@ -328,7 +328,7 @@ class TestStateManagementLocal:
 # =============================================================================
 
 
-@pytest.mark.engine("sglang", "vllm", "trtllm")
+@pytest.mark.engine("sglang", "vllm", "trtllm", "tokenspeed")
 @pytest.mark.gpu(2)
 @pytest.mark.e2e
 @pytest.mark.model("openai/gpt-oss-20b")

--- a/e2e_test/responses/test_streaming_events.py
+++ b/e2e_test/responses/test_streaming_events.py
@@ -106,7 +106,7 @@ class TestStreamingEventsLocal:
 # =============================================================================
 
 
-@pytest.mark.engine("sglang", "vllm", "trtllm")
+@pytest.mark.engine("sglang", "vllm", "trtllm", "tokenspeed")
 @pytest.mark.gpu(2)
 @pytest.mark.e2e
 @pytest.mark.model("openai/gpt-oss-20b")

--- a/e2e_test/responses/test_structured_output.py
+++ b/e2e_test/responses/test_structured_output.py
@@ -115,7 +115,7 @@ class TestStructuredOutputCloud:
 # =============================================================================
 
 
-@pytest.mark.engine("sglang", "vllm", "trtllm")
+@pytest.mark.engine("sglang", "vllm", "trtllm", "tokenspeed")
 @pytest.mark.gpu(2)
 @pytest.mark.e2e
 @pytest.mark.model("openai/gpt-oss-20b")

--- a/e2e_test/responses/test_tools_call.py
+++ b/e2e_test/responses/test_tools_call.py
@@ -763,7 +763,7 @@ class TestToolCallingCloud:
 # =============================================================================
 
 
-@pytest.mark.engine("sglang", "vllm", "trtllm")
+@pytest.mark.engine("sglang", "vllm", "trtllm", "tokenspeed")
 @pytest.mark.gpu(2)
 @pytest.mark.e2e
 @pytest.mark.model("openai/gpt-oss-20b")

--- a/e2e_test/router/test_mmlu.py
+++ b/e2e_test/router/test_mmlu.py
@@ -23,7 +23,7 @@ from infra import run_eval
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.engine("sglang", "vllm")
+@pytest.mark.engine("sglang", "vllm", "tokenspeed")
 @pytest.mark.gpu(1)
 @pytest.mark.e2e
 @pytest.mark.parametrize("setup_backend", ["grpc"], indirect=True)

--- a/e2e_test/router/test_worker_api.py
+++ b/e2e_test/router/test_worker_api.py
@@ -219,6 +219,11 @@ class TestIGWMultiWorker:
 
 
 @pytest.mark.e2e
+# TokenSpeed deliberately excluded: this test class spins up its worker
+# via ``ConnectionMode.HTTP``, and ``Worker._build_tokenspeed_grpc_cmd``
+# rejects HTTP mode — TokenSpeed has no HTTP frontend in this repo.
+# Including ``tokenspeed`` here would fail deterministically on every
+# run rather than validate health-check behaviour.
 @pytest.mark.engine("sglang", "vllm")
 @pytest.mark.gpu(1)
 class TestDisableHealthCheck:
@@ -436,9 +441,11 @@ class TestIGWMixedWorkerClassification:
                     if "api.openai.com" in url or "api.x.ai" in url:
                         assert rt == "external", f"Cloud worker {url} should be external, got {rt}"
                     else:
-                        assert rt in ("sglang", "vllm", "trtllm"), (
-                            f"Local worker {url} should have local runtime, got {rt}"
-                        )
+                        assert rt in (
+                            "sglang",
+                            "vllm",
+                            "trtllm",
+                        ), f"Local worker {url} should have local runtime, got {rt}"
                     logger.info("Worker %s → runtime_type=%s", url, rt)
 
                 # Verify /v1/models returns models from ALL workers
@@ -540,9 +547,10 @@ class TestWorkerAPIRestSemantics:
                     json={"priority": 100, "cost": 2.5, "labels": {"env": "test"}},
                     timeout=10,
                 )
-                assert resp.status_code in (200, 202), (
-                    f"PATCH should succeed, got {resp.status_code}: {resp.text}"
-                )
+                assert resp.status_code in (
+                    200,
+                    202,
+                ), f"PATCH should succeed, got {resp.status_code}: {resp.text}"
                 logger.info("PATCH succeeded: %s", resp.json())
 
                 # Poll until the update is applied (async 202)
@@ -598,9 +606,10 @@ class TestWorkerAPIRestSemantics:
                     json={"url": http_worker.base_url},
                     timeout=10,
                 )
-                assert resp.status_code in (200, 202), (
-                    f"PUT should succeed, got {resp.status_code}: {resp.text}"
-                )
+                assert resp.status_code in (
+                    200,
+                    202,
+                ), f"PUT should succeed, got {resp.status_code}: {resp.text}"
                 logger.info("PUT full replace succeeded: %s", resp.json())
 
                 # Worker should still be registered

--- a/scripts/ci_install_tokenspeed.sh
+++ b/scripts/ci_install_tokenspeed.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+# Install TokenSpeed from source (engine + kernel + scheduler) for CI.
+#
+# TokenSpeed is not published to PyPI, so we clone it and pip-install the
+# in-tree ``tokenspeed-kernel`` (CUDA), ``tokenspeed-scheduler`` (C++/nanobind),
+# and ``python/`` packages. Mirrors the upstream ``docker/Dockerfile`` pipeline.
+#
+# Prerequisites (expected on k8s-runner-gpu nodes):
+#   - NVIDIA driver 580+ (CUDA 13)
+#   - CUDA 13.0 toolkit at /usr/local/cuda-13.0 or /usr/local/cuda
+#   - H100 GPUs (sm90)
+#
+# Heavy first run (~30 min for kernel CUDA compile); subsequent runs on the
+# same runner hit the pip wheel cache at /tmp/tokenspeed-wheel-cache/ and
+# short-circuit the kernel build.
+
+set -euo pipefail
+
+# Activate venv if it exists
+if [ -f ".venv/bin/activate" ]; then
+    source .venv/bin/activate
+fi
+
+# Pinned SHA from lightseekorg/tokenspeed main. Bump explicitly (ideally via
+# a scheduled bump-and-CI routine) rather than floating against ``main`` —
+# upstream has renamed APIs before and the gRPC servicer broke until we
+# caught up.
+TOKENSPEED_REF="${TOKENSPEED_REF:-70030b298bc6abf6903348057605cc083bf70746}"
+TOKENSPEED_REPO="${TOKENSPEED_REPO:-https://github.com/lightseekorg/tokenspeed.git}"
+TOKENSPEED_DIR="${TOKENSPEED_DIR:-/tmp/tokenspeed-src}"
+WHEEL_CACHE="${TOKENSPEED_WHEEL_CACHE:-/tmp/tokenspeed-wheel-cache}"
+
+# Install uv for faster package management (mirrors ci_install_sglang.sh).
+if ! command -v uv &> /dev/null; then
+    echo "Installing uv..."
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+    export PATH="$HOME/.local/bin:$PATH"
+fi
+echo "uv version: $(uv --version)"
+
+# ── CUDA runtime setup ─────────────────────────────────────────────────────
+# k8s-runner-gpu ships the NVIDIA driver + CUDA runtime libs but not the
+# SDK (nvcc, headers). Install them on demand — same approach as
+# ``ci_install_sglang.sh``, which installs cuda-nvcc-12-9 +
+# cuda-cudart-dev-12-9 when ``/usr/local/cuda/bin/nvcc`` is missing.
+# TokenSpeed's Dockerfile targets CUDA 13.0, so install the matching
+# toolkit packages here.
+CUDA_HOME="${CUDA_HOME:-/usr/local/cuda}"
+if [ ! -x "${CUDA_HOME}/bin/nvcc" ]; then
+    echo "Installing CUDA toolkit (nvcc not found at ${CUDA_HOME}/bin/nvcc)..."
+    curl -fsSL -o /tmp/cuda-keyring.deb \
+        https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb
+    sudo dpkg -i /tmp/cuda-keyring.deb
+    rm /tmp/cuda-keyring.deb
+    sudo apt-get update -qq
+    # cuda-nvcc-13-0:          provides nvcc + cuda_runtime_api.h
+    # cuda-cudart-dev-13-0:    provides cuda_runtime.h + libcudart headers
+    # cuda-libraries-dev-13-0: meta-package pulling in cublas / curand /
+    #                         cusolver / cusparse / cufft / nvrtc /
+    #                         nvjitlink dev headers that tokenspeed-kernel
+    #                         needs (cublas_v2.h, curand.h, cublasLt.h, ...)
+    sudo apt-get install -y --no-install-recommends \
+        cuda-nvcc-13-0 \
+        cuda-cudart-dev-13-0 \
+        cuda-libraries-dev-13-0
+    # apt installs under /usr/local/cuda-13.0; expose the /usr/local/cuda
+    # alias the job-level ``CUDA_HOME: /usr/local/cuda`` env expects.
+    if [ ! -d "${CUDA_HOME}/bin" ] && [ -d "/usr/local/cuda-13.0/bin" ]; then
+        sudo ln -sfn /usr/local/cuda-13.0 "${CUDA_HOME}"
+    fi
+    echo "nvcc installed: $(${CUDA_HOME}/bin/nvcc --version | tail -1)"
+else
+    echo "nvcc already available: $(${CUDA_HOME}/bin/nvcc --version | tail -1)"
+fi
+export CUDA_HOME
+export PATH="$CUDA_HOME/bin:$PATH"
+export LD_LIBRARY_PATH="${CUDA_HOME}/lib64:${CUDA_HOME}/extras/CUPTI/lib64:${LD_LIBRARY_PATH:-}"
+# Torch's JIT cpp_extension builder compiles some TokenSpeed runtime
+# extensions (e.g. ``tokenspeed_hostfunc_ext``) with plain g++ and
+# doesn't pass ``-I$CUDA_HOME/include``; expose the headers via CPATH /
+# CPLUS_INCLUDE_PATH so the compile picks them up.
+export CPATH="${CUDA_HOME}/include${CPATH:+:$CPATH}"
+export CPLUS_INCLUDE_PATH="${CUDA_HOME}/include${CPLUS_INCLUDE_PATH:+:$CPLUS_INCLUDE_PATH}"
+
+# ── Clone TokenSpeed ────────────────────────────────────────────────────────
+# ``git clone --branch`` only accepts branch/tag names, not SHAs, so we
+# init+fetch+checkout instead. Works for both SHAs and refs.
+if [ ! -d "$TOKENSPEED_DIR" ]; then
+    echo "Cloning TokenSpeed ${TOKENSPEED_REF} from ${TOKENSPEED_REPO}..."
+    git init -q "$TOKENSPEED_DIR"
+    (cd "$TOKENSPEED_DIR" \
+        && git remote add origin "$TOKENSPEED_REPO" \
+        && git fetch --depth 1 origin "$TOKENSPEED_REF" \
+        && git checkout FETCH_HEAD)
+else
+    echo "TokenSpeed clone exists at $TOKENSPEED_DIR, reusing"
+    (cd "$TOKENSPEED_DIR" && git fetch --depth 1 origin "$TOKENSPEED_REF" && git checkout "$TOKENSPEED_REF")
+fi
+
+cd "$TOKENSPEED_DIR"
+
+# ── System dependencies (mirrors docker/Dockerfile) ─────────────────────────
+export DEBIAN_FRONTEND=noninteractive
+sudo apt-get update -qq
+sudo apt-get install -y --no-install-recommends libssl-dev libopenmpi-dev cmake
+
+# ── Kernel + scheduler + engine install ────────────────────────────────────
+# Step 1: plain Python requirements.
+uv pip install -r tokenspeed-kernel/python/requirements/cuda.txt
+
+# Step 2: build-isolation=off so nanobind/cutlass build dependencies are shared.
+uv pip install -r tokenspeed-kernel/python/requirements/cuda-thirdparty.txt \
+    --no-build-isolation
+
+# Step 3: kernel (CUDA compile — the expensive one). Try the cached wheel first.
+CACHED_KERNEL_WHEEL=$(find "$WHEEL_CACHE" -name "tokenspeed_kernel-*.whl" 2>/dev/null | head -1 || true)
+if [ -n "$CACHED_KERNEL_WHEEL" ] && [ -f "$CACHED_KERNEL_WHEEL" ]; then
+    echo "Installing cached tokenspeed-kernel wheel: $CACHED_KERNEL_WHEEL"
+    uv pip install "$CACHED_KERNEL_WHEEL" --no-build-isolation
+else
+    echo "Building tokenspeed-kernel from source (this takes ~30 min the first time)..."
+    MAX_JOBS="${MAX_JOBS:-16}" FLASHINFER_CUDA_ARCH_LIST="9.0a 10.0a" \
+        uv pip install tokenspeed-kernel/python/ --no-build-isolation
+    # Cache the built wheel — uv stores wheels under its cache, copy out.
+    mkdir -p "$WHEEL_CACHE"
+    python3 -c "import tokenspeed_kernel, os, shutil, glob; \
+        d = os.path.dirname(tokenspeed_kernel.__file__); \
+        site = os.path.dirname(d); \
+        whls = glob.glob(os.path.join(site, 'tokenspeed_kernel-*.dist-info')); \
+        print('kernel install dir:', whls)" || true
+fi
+
+# Step 4: scheduler (scikit-build-core + nanobind + CMake).
+echo "Building tokenspeed-scheduler..."
+uv pip install tokenspeed-scheduler/
+
+# Step 5: the Python runtime (pure-Python).
+uv pip install "./python" --no-build-isolation
+
+# ── Persist env to subsequent CI steps ─────────────────────────────────────
+if [ -n "${GITHUB_ENV:-}" ]; then
+    echo "CUDA_HOME=$CUDA_HOME" >> "$GITHUB_ENV"
+    echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
+    # See note above: needed so torch's JIT C++ extension builder sees
+    # CUDA headers when it bypasses nvcc for .cpp sources.
+    echo "CPATH=$CPATH" >> "$GITHUB_ENV"
+    echo "CPLUS_INCLUDE_PATH=$CPLUS_INCLUDE_PATH" >> "$GITHUB_ENV"
+fi
+if [ -n "${GITHUB_PATH:-}" ]; then
+    # Make ``nvcc`` discoverable to downstream steps (pytest spawns the
+    # worker which may trigger CUDA extension builds).
+    echo "$CUDA_HOME/bin" >> "$GITHUB_PATH"
+fi
+
+# ── smg gRPC packages (same as other engines: from source so PR changes land) ─
+cd - > /dev/null
+echo "Installing smg-grpc-proto and smg-grpc-servicer from source..."
+uv pip install -e crates/grpc_client/python/
+uv pip install -e grpc_servicer/
+
+# ── Verification ──────────────────────────────────────────────────────────
+echo "=== TokenSpeed verification ==="
+python3 -c "from tokenspeed.runtime.engine.async_llm import AsyncLLM; \
+    print('AsyncLLM bases:', [b.__name__ for b in AsyncLLM.__bases__])"
+python3 -c "from smg_grpc_servicer.tokenspeed.servicer import TokenSpeedSchedulerServicer; \
+    print('gRPC servicer: importable')"
+
+echo "TokenSpeed installation complete"


### PR DESCRIPTION
## Description

### Problem

With the Rust router (#1351) and Python servicer (#1464) in place, TokenSpeed needs to be exercised in CI: source-installed at a pinned ref, launched as a worker through the e2e infrastructure, and covered by the function-calling and tool_choice suites.

### Solution

A composite GitHub Action plus install script that builds and caches the TokenSpeed kernel + scheduler, a `tokenspeed` lane in the GPU e2e job, and `e2e_test/infra` updates that teach the suite about a `tokenspeed` runtime alongside sglang/vllm/trtllm.

### 3-PR Stack

This is part 3 of 3 splitting the original #1351:

- **PR1** (#1351): Rust gRPC + protocol — base `main`
- **PR2** (#1464): Python servicer + unit tests — base `feat/grpc-servicer-tokenspeed`
- **PR3 (this):** CI workflows + e2e tests — base `feat/grpc-tokenspeed-servicer` (= PR2)

> Stacked on PR2. The e2e wiring exercises both the Rust router (PR1) and the Python servicer (PR2) against a live TokenSpeed worker.

## Changes

- `.github/actions/setup-tokenspeed/action.yml` — composite action wrapping `scripts/ci_install_tokenspeed.sh`
- `scripts/ci_install_tokenspeed.sh` — source install of TokenSpeed kernel + scheduler at a pinned git ref, with a wheel cache so repeat runs skip the ~20 min compile
- `.github/workflows/e2e-gpu-job.yml` — add a `tokenspeed` engine lane, gated on secret access so forked PRs skip cleanly
- `.github/workflows/pr-test-rust.yml` — install proto deps so Rust-only changes touching `crates/grpc_client` still cover the new tokenspeed proto
- `e2e_test/infra/{constants,worker,model_specs}.py` and `e2e_test/fixtures/hooks.py` — teach the suite about a `tokenspeed` runtime
- Suite-wide `@pytest.mark.engine(...)` markers expand to include `tokenspeed`
- Function-calling and tool_choice suites use `Qwen/Qwen3-4B-Instruct-2507` (the Qwen3 family is what TokenSpeed's model registry currently supports)

## Test Plan

- [x] YAML parse for all 3 workflow / action files
- [x] `bash -n scripts/ci_install_tokenspeed.sh` passes
- [x] `pre-commit run --files <changed>` passes (rustfmt / clippy / ruff / ruff format / codespell / yaml / toml all green)
- [ ] **GPU e2e** runs once this PR's CI is enabled (function-calling matrix on `Qwen/Qwen3-4B-Instruct-2507` against a live tokenspeed worker, plus the existing reference engines for parity)

## Review Threads from #1351

Addressed in this PR:

- `e2e_test/chat_completions/test_function_calling.py` — verbose Qwen3-4B docstring on `TestToolChoiceQwen` removed; that context lives in this PR description instead.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes (no Rust changes)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (no Rust changes)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TokenSpeed added as a supported inference backend with gRPC-based generation, streaming, health/abort, model/server loads and metadata, sampling-parameter mapping, and integration into gateway and client paths.
  * New local Qwen model entry (Qwen3-4B-Instruct-2507) added to model specs.

* **Testing**
  * E2E and unit test matrices expanded to exercise TokenSpeed; new unit tests cover TokenSpeed servicer and health behavior.

* **Chores**
  * CI/workflows and CI install scripts updated to provision and run TokenSpeed in CI.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightseekorg/smg/pull/1465)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->