### PR TITLE
ci(release): add dev wheel workflow → GitHub Releases

### DIFF
--- a/.github/workflows/release-pypi-dev.yml
+++ b/.github/workflows/release-pypi-dev.yml
@@ -94,20 +94,31 @@ jobs:
         with:
           python-version: "3.13"
 
-      # Patch only Python-side version metadata. Cargo rejects PEP 440 dev
-      # versions like "1.4.2.dev42" (semver requires "1.4.2-dev42"), so we
-      # deliberately leave Cargo.toml versions alone — they aren't published
-      # by this workflow and maturin uses pyproject.toml for the wheel version.
-      - name: Patch dev version (Python files only)
+      # Patches both Python and Rust version sources so the wheel reports a
+      # consistent dev version everywhere — Python metadata, smg.__version__,
+      # and the compiled runtime banner from model_gateway::build.rs.
+      #
+      # Cargo enforces semver and rejects PEP 440 (\"1.4.2.dev42\"), so we map
+      # the Python dev suffix to a semver prerelease (\"1.4.2-dev42\") for
+      # Cargo.toml. Other workspace Cargo manifests reference model_gateway by
+      # path with no version pin, so this is safe.
+      - name: Patch dev version (Python + model_gateway Cargo)
         working-directory: smg-repo
         env:
           SMG_VERSION: ${{ needs.prepare.outputs.smg_version }}
         run: |
           set -euo pipefail
+          # PEP 440 "X.Y.Z.devN" → semver "X.Y.Z-devN" for Cargo.
+          SMG_CARGO_VERSION="${SMG_VERSION/.dev/-dev}"
+
           sed -i.bak "s/^version = \".*\"/version = \"${SMG_VERSION}\"/" bindings/python/pyproject.toml
           sed -i.bak "s/__version__ = \".*\"/__version__ = \"${SMG_VERSION}\"/" bindings/python/src/smg/version.py
-          rm -f bindings/python/pyproject.toml.bak bindings/python/src/smg/version.py.bak
-          echo "Patched smg version to ${SMG_VERSION}"
+          sed -i.bak "s/^version = \".*\"/version = \"${SMG_CARGO_VERSION}\"/" model_gateway/Cargo.toml
+          rm -f bindings/python/pyproject.toml.bak bindings/python/src/smg/version.py.bak model_gateway/Cargo.toml.bak
+
+          echo "Patched smg version:"
+          echo "  pyproject.toml + __version__: ${SMG_VERSION}"
+          echo "  model_gateway/Cargo.toml:     ${SMG_CARGO_VERSION}"
 
       - name: Build manylinux x86_64 wheels
         uses: PyO3/maturin-action@v1
@@ -264,13 +275,28 @@ jobs:
           python-version: "3.12"
       - name: Install build deps
         run: pip install build twine
-      - name: Patch dev version
+      # Pin the servicer's smg-grpc-proto dependency to the exact dev version
+      # built in this same run, so a consumer who installs servicer-dev gets
+      # the matching proto-dev — not a stale stable proto (without --pre) or
+      # an unrelated newer dev (with --pre). Only pin when proto is also being
+      # released in this run; otherwise leave the >=0.4.x range so the dev
+      # servicer can resolve against the stable proto on PyPI.
+      - name: Patch dev version (+ pin proto dep if releasing proto together)
         env:
           SERVICER_VERSION: ${{ needs.prepare.outputs.servicer_version }}
+          PROTO_VERSION: ${{ needs.prepare.outputs.proto_version }}
+          RELEASE_PROTO: ${{ github.event_name == 'pull_request' || inputs.release_proto }}
         run: |
           set -euo pipefail
           sed -i.bak "s/^version = \".*\"/version = \"${SERVICER_VERSION}\"/" \
             grpc_servicer/pyproject.toml
+          if [ "${RELEASE_PROTO}" = "true" ]; then
+            # Matches both the core dep ("smg-grpc-proto>=0.4.6") and the
+            # mlx extra ("smg-grpc-proto>=0.4.7").
+            sed -i.bak -E "s|smg-grpc-proto>=[0-9.]+|smg-grpc-proto==${PROTO_VERSION}|g" \
+              grpc_servicer/pyproject.toml
+            echo "Pinned smg-grpc-proto==${PROTO_VERSION} for dev coherence"
+          fi
           rm -f grpc_servicer/pyproject.toml.bak
       - name: Build package
         run: cd grpc_servicer && python -m build
@@ -284,14 +310,25 @@ jobs:
   upload-servicer:
     name: Upload smg-grpc-servicer to PyPI
     needs: [build-servicer, upload-proto]
-    # Tolerate proto being skipped (release_proto=false); fail-fast if proto was
-    # requested but failed, so we don't publish a half-finished set.
+    # Proto state must be coherent with what was requested:
+    #   - If proto WAS requested (pull_request or release_proto=true):
+    #       upload-proto MUST equal 'success'. A skip here would mean
+    #       build-proto failed, and we don't want a half-finished dev set.
+    #   - If proto was NOT requested (workflow_dispatch + release_proto=false):
+    #       upload-proto naturally becomes 'skipped' and that's fine.
     if: >-
       always()
       && (github.event_name == 'pull_request' || inputs.release_servicer)
       && github.repository == 'lightseekorg/smg'
       && needs.build-servicer.result == 'success'
-      && (needs.upload-proto.result == 'success' || needs.upload-proto.result == 'skipped')
+      && (
+        needs.upload-proto.result == 'success'
+        || (
+          github.event_name == 'workflow_dispatch'
+          && !inputs.release_proto
+          && needs.upload-proto.result == 'skipped'
+        )
+      )
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v8

--- a/.github/workflows/release-pypi-dev.yml
+++ b/.github/workflows/release-pypi-dev.yml
@@ -19,6 +19,12 @@ on:
         description: "Dry run: build, patch versions, run twine check, but do NOT upload to PyPI"
         type: boolean
         default: false
+  # Self-validating: a PR that changes this workflow auto-runs in forced-dry-run
+  # mode (all three packages enabled, no PyPI upload). Lets us catch breakage
+  # before merge.
+  pull_request:
+    paths:
+      - .github/workflows/release-pypi-dev.yml
 
 permissions:
   contents: read
@@ -76,7 +82,7 @@ jobs:
   build-smg:
     name: Build smg dev wheel
     needs: prepare
-    if: ${{ inputs.release_smg }}
+    if: ${{ github.event_name == 'pull_request' || inputs.release_smg }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -144,7 +150,9 @@ jobs:
   upload-smg:
     name: Upload smg to PyPI
     needs: build-smg
-    if: ${{ inputs.release_smg && github.repository == 'lightseekorg/smg' }}
+    if: >-
+      (github.event_name == 'pull_request' || inputs.release_smg)
+      && github.repository == 'lightseekorg/smg'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v8
@@ -155,12 +163,12 @@ jobs:
         with:
           python-version: "3.12"
       - name: Dry-run notice
-        if: ${{ inputs.dry_run }}
+        if: ${{ github.event_name == 'pull_request' || inputs.dry_run }}
         run: |
           echo "DRY RUN: skipping PyPI upload for smg"
           ls -lh dist/
       - name: Upload
-        if: ${{ !inputs.dry_run }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !inputs.dry_run }}
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN_ROUTER }}
@@ -172,7 +180,7 @@ jobs:
   build-proto:
     name: Build smg-grpc-proto dev
     needs: prepare
-    if: ${{ inputs.release_proto }}
+    if: ${{ github.event_name == 'pull_request' || inputs.release_proto }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -206,7 +214,9 @@ jobs:
   upload-proto:
     name: Upload smg-grpc-proto to PyPI
     needs: build-proto
-    if: ${{ inputs.release_proto && github.repository == 'lightseekorg/smg' }}
+    if: >-
+      (github.event_name == 'pull_request' || inputs.release_proto)
+      && github.repository == 'lightseekorg/smg'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v8
@@ -217,12 +227,12 @@ jobs:
         with:
           python-version: "3.12"
       - name: Dry-run notice
-        if: ${{ inputs.dry_run }}
+        if: ${{ github.event_name == 'pull_request' || inputs.dry_run }}
         run: |
           echo "DRY RUN: skipping PyPI upload for smg-grpc-proto"
           ls -lh dist/
       - name: Upload
-        if: ${{ !inputs.dry_run }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !inputs.dry_run }}
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN_GRPC_PROTO }}
@@ -236,7 +246,7 @@ jobs:
   build-servicer:
     name: Build smg-grpc-servicer dev
     needs: prepare
-    if: ${{ inputs.release_servicer }}
+    if: ${{ github.event_name == 'pull_request' || inputs.release_servicer }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -269,7 +279,7 @@ jobs:
     # requested but failed, so we don't publish a half-finished set.
     if: >-
       always()
-      && inputs.release_servicer
+      && (github.event_name == 'pull_request' || inputs.release_servicer)
       && github.repository == 'lightseekorg/smg'
       && needs.build-servicer.result == 'success'
       && (needs.upload-proto.result == 'success' || needs.upload-proto.result == 'skipped')
@@ -283,12 +293,12 @@ jobs:
         with:
           python-version: "3.12"
       - name: Dry-run notice
-        if: ${{ inputs.dry_run }}
+        if: ${{ github.event_name == 'pull_request' || inputs.dry_run }}
         run: |
           echo "DRY RUN: skipping PyPI upload for smg-grpc-servicer"
           ls -lh dist/
       - name: Upload
-        if: ${{ !inputs.dry_run }}
+        if: ${{ github.event_name == 'workflow_dispatch' && !inputs.dry_run }}
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN_GRPC_SERVICER }}
@@ -314,7 +324,7 @@ jobs:
     steps:
       - run: |
           {
-            if [ "${{ inputs.dry_run }}" = "true" ]; then
+            if [ "${{ inputs.dry_run }}" = "true" ] || [ "${{ github.event_name }}" = "pull_request" ]; then
               echo "## Dev release summary (DRY RUN — nothing uploaded to PyPI)"
             else
               echo "## Dev release summary"
@@ -326,7 +336,7 @@ jobs:
             echo "| smg-grpc-proto | ${{ needs.prepare.outputs.proto_version }} | ${{ needs.build-proto.result }} | ${{ needs.upload-proto.result }} |"
             echo "| smg-grpc-servicer | ${{ needs.prepare.outputs.servicer_version }} | ${{ needs.build-servicer.result }} | ${{ needs.upload-servicer.result }} |"
             echo ""
-            if [ "${{ inputs.dry_run }}" != "true" ]; then
+            if [ "${{ inputs.dry_run }}" != "true" ] && [ "${{ github.event_name }}" != "pull_request" ]; then
               echo "Install (allow pre-releases):"
               echo '```'
               echo "pip install --pre smg smg-grpc-servicer"

--- a/.github/workflows/release-pypi-dev.yml
+++ b/.github/workflows/release-pypi-dev.yml
@@ -1,27 +1,27 @@
-name: Release SMG to PyPI (dev)
+name: Release SMG dev wheels (GitHub Releases)
+
+# Builds dev wheels for smg, smg-grpc-proto, and smg-grpc-servicer and
+# publishes them as a single GitHub Release per workflow run. Avoids the
+# 10 GB PyPI project quota and lets us delete old dev releases freely.
+# Prod releases continue to go to PyPI via release-pypi.yml / release-grpc.yml.
 
 on:
   workflow_dispatch:
     inputs:
       release_smg:
-        description: "Release smg (Rust wheel)"
+        description: "Build & release smg (Rust wheel)"
         type: boolean
         default: true
       release_servicer:
-        description: "Release smg-grpc-servicer"
+        description: "Build & release smg-grpc-servicer"
         type: boolean
         default: true
       release_proto:
-        description: "Release smg-grpc-proto (only if proto files changed)"
+        description: "Build & release smg-grpc-proto"
         type: boolean
-        default: false
-      dry_run:
-        description: "Dry run: build, patch versions, run twine check, but do NOT upload to PyPI"
-        type: boolean
-        default: false
-  # Self-validating: a PR that changes this workflow auto-runs in forced-dry-run
-  # mode (all three packages enabled, no PyPI upload). Lets us catch breakage
-  # before merge.
+        default: true
+  # Self-validating: PRs that touch this workflow file auto-build (no release
+  # is created on pull_request runs; they are pure dry-runs for CI).
   pull_request:
     paths:
       - .github/workflows/release-pypi-dev.yml
@@ -30,8 +30,6 @@ permissions:
   contents: read
 
 jobs:
-  # Compute shared dev versions once so all packages from this run share the
-  # same dev<run_number> suffix (e.g. smg==1.4.2.dev42, smg-grpc-servicer==0.5.3.dev42).
   prepare:
     name: Compute dev versions
     runs-on: ubuntu-latest
@@ -39,6 +37,7 @@ jobs:
       smg_version: ${{ steps.compute.outputs.smg_version }}
       proto_version: ${{ steps.compute.outputs.proto_version }}
       servicer_version: ${{ steps.compute.outputs.servicer_version }}
+      release_tag: ${{ steps.compute.outputs.release_tag }}
     steps:
       - uses: actions/checkout@v6
 
@@ -46,13 +45,13 @@ jobs:
         run: |
           set -euo pipefail
           SUFFIX="dev${{ github.run_number }}"
+          RELEASE_TAG="smg-dev-${{ github.run_number }}"
 
           read_version() {
             grep -m1 '^version = ' "$1" | sed 's/version = "\(.*\)"/\1/'
           }
 
-          # Bump patch so dev sorts AFTER current stable.
-          # E.g. base 1.4.1 -> 1.4.2.dev<N> (so --pre picks it as latest).
+          # Bump patch so dev sorts AFTER current stable in PEP 440 ordering.
           bump_patch() {
             local IFS=.
             # shellcheck disable=SC2206
@@ -68,14 +67,17 @@ jobs:
           echo "smg_version=${SMG_VERSION}" >> "$GITHUB_OUTPUT"
           echo "proto_version=${PROTO_VERSION}" >> "$GITHUB_OUTPUT"
           echo "servicer_version=${SERVICER_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "release_tag=${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
 
           {
             echo "## Planned dev versions"
-            echo "| Package | Version | Will publish? |"
+            echo "| Package | Version | Will build? |"
             echo "|---|---|---|"
-            echo "| smg | ${SMG_VERSION} | ${{ inputs.release_smg }} |"
-            echo "| smg-grpc-proto | ${PROTO_VERSION} | ${{ inputs.release_proto }} |"
-            echo "| smg-grpc-servicer | ${SERVICER_VERSION} | ${{ inputs.release_servicer }} |"
+            echo "| smg | ${SMG_VERSION} | ${{ github.event_name == 'pull_request' || inputs.release_smg }} |"
+            echo "| smg-grpc-proto | ${PROTO_VERSION} | ${{ github.event_name == 'pull_request' || inputs.release_proto }} |"
+            echo "| smg-grpc-servicer | ${SERVICER_VERSION} | ${{ github.event_name == 'pull_request' || inputs.release_servicer }} |"
+            echo ""
+            echo "Release tag (workflow_dispatch only): \`${RELEASE_TAG}\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
   # ── smg (Rust wheel via maturin) — slim matrix: manylinux x86_64 + sdist ──
@@ -94,21 +96,17 @@ jobs:
         with:
           python-version: "3.13"
 
-      # Patches both Python and Rust version sources so the wheel reports a
-      # consistent dev version everywhere — Python metadata, smg.__version__,
-      # and the compiled runtime banner from model_gateway::build.rs.
-      #
-      # Cargo enforces semver and rejects PEP 440 (\"1.4.2.dev42\"), so we map
-      # the Python dev suffix to a semver prerelease (\"1.4.2-dev42\") for
-      # Cargo.toml. Other workspace Cargo manifests reference model_gateway by
-      # path with no version pin, so this is safe.
+      # Patches Python metadata + Rust runtime version so the wheel reports a
+      # consistent dev version everywhere — smg.__version__, the smg.smg_rs
+      # banner from model_gateway::build.rs, and pyproject.toml. PEP 440
+      # (1.4.2.dev42) for Python, semver (1.4.2-dev42) for Cargo. Other
+      # workspace crates reference model_gateway via path with no version pin.
       - name: Patch dev version (Python + model_gateway Cargo)
         working-directory: smg-repo
         env:
           SMG_VERSION: ${{ needs.prepare.outputs.smg_version }}
         run: |
           set -euo pipefail
-          # PEP 440 "X.Y.Z.devN" → semver "X.Y.Z-devN" for Cargo.
           SMG_CARGO_VERSION="${SMG_VERSION/.dev/-dev}"
 
           sed -i.bak "s/^version = \".*\"/version = \"${SMG_VERSION}\"/" bindings/python/pyproject.toml
@@ -126,7 +124,9 @@ jobs:
           working-directory: smg-repo/bindings/python
           target: x86_64
           manylinux: auto
-          args: --release --out dist --features vendored-openssl --interpreter 3.10 3.11 3.12 3.13
+          # PR runs build a single interpreter (3.12) to keep dry-run fast
+          # (~6 min vs ~25 min); workflow_dispatch builds the full matrix.
+          args: --release --out dist --features vendored-openssl --interpreter ${{ github.event_name == 'pull_request' && '3.12' || '3.10 3.11 3.12 3.13' }}
           rust-toolchain: stable
           before-script-linux: |
             if command -v yum &> /dev/null; then
@@ -140,10 +140,8 @@ jobs:
              rm protoc-32.0-linux-x86_64.zip)
             protoc --version
 
-      # The manylinux wheel build above runs inside a Docker container as
-      # root, so files in dist/ end up root-owned. The next step runs on
-      # the host as the runner user and cannot write into that directory.
-      # Fix ownership so the sdist build can land its tarball alongside.
+      # The manylinux wheel build above runs inside Docker as root; dist/ ends
+      # up root-owned. Reclaim ownership so the host-side sdist step can write.
       - name: Reclaim dist ownership from manylinux container
         run: |
           sudo chown -R "$(whoami):$(whoami)" smg-repo/bindings/python/dist
@@ -166,35 +164,6 @@ jobs:
         with:
           name: smg-dev-dist
           path: smg-repo/bindings/python/dist/
-
-  upload-smg:
-    name: Upload smg to PyPI
-    needs: build-smg
-    if: >-
-      (github.event_name == 'pull_request' || inputs.release_smg)
-      && github.repository == 'lightseekorg/smg'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/download-artifact@v8
-        with:
-          name: smg-dev-dist
-          path: dist
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-      - name: Dry-run notice
-        if: ${{ github.event_name == 'pull_request' || inputs.dry_run }}
-        run: |
-          echo "DRY RUN: skipping PyPI upload for smg"
-          ls -lh dist/
-      - name: Upload
-        if: ${{ github.event_name == 'workflow_dispatch' && !inputs.dry_run }}
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN_ROUTER }}
-        run: |
-          pip install -U twine
-          twine upload dist/* --verbose --skip-existing
 
   # ── smg-grpc-proto (pure Python) ──
   build-proto:
@@ -231,38 +200,7 @@ jobs:
           name: proto-dev-dist
           path: crates/grpc_client/python/dist/
 
-  upload-proto:
-    name: Upload smg-grpc-proto to PyPI
-    needs: build-proto
-    if: >-
-      (github.event_name == 'pull_request' || inputs.release_proto)
-      && github.repository == 'lightseekorg/smg'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/download-artifact@v8
-        with:
-          name: proto-dev-dist
-          path: dist
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-      - name: Dry-run notice
-        if: ${{ github.event_name == 'pull_request' || inputs.dry_run }}
-        run: |
-          echo "DRY RUN: skipping PyPI upload for smg-grpc-proto"
-          ls -lh dist/
-      - name: Upload
-        if: ${{ github.event_name == 'workflow_dispatch' && !inputs.dry_run }}
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN_GRPC_PROTO }}
-        run: |
-          pip install -U twine
-          twine upload dist/* --verbose --skip-existing
-
   # ── smg-grpc-servicer (pure Python) ──
-  # Builds in parallel with proto; the upload step is what gates on proto
-  # upload completing (so a coherent dev set lands on PyPI together).
   build-servicer:
     name: Build smg-grpc-servicer dev
     needs: prepare
@@ -275,12 +213,8 @@ jobs:
           python-version: "3.12"
       - name: Install build deps
         run: pip install build twine
-      # Pin the servicer's smg-grpc-proto dependency to the exact dev version
-      # built in this same run, so a consumer who installs servicer-dev gets
-      # the matching proto-dev — not a stale stable proto (without --pre) or
-      # an unrelated newer dev (with --pre). Only pin when proto is also being
-      # released in this run; otherwise leave the >=0.4.x range so the dev
-      # servicer can resolve against the stable proto on PyPI.
+      # When proto is also being built in this run, pin the servicer's proto
+      # dep to the exact dev version so consumers get a coherent dev set.
       - name: Patch dev version (+ pin proto dep if releasing proto together)
         env:
           SERVICER_VERSION: ${{ needs.prepare.outputs.servicer_version }}
@@ -307,85 +241,108 @@ jobs:
           name: servicer-dev-dist
           path: grpc_servicer/dist/
 
-  upload-servicer:
-    name: Upload smg-grpc-servicer to PyPI
-    needs: [build-servicer, upload-proto]
-    # Proto state must be coherent with what was requested:
-    #   - If proto WAS requested (pull_request or release_proto=true):
-    #       upload-proto MUST equal 'success'. A skip here would mean
-    #       build-proto failed, and we don't want a half-finished dev set.
-    #   - If proto was NOT requested (workflow_dispatch + release_proto=false):
-    #       upload-proto naturally becomes 'skipped' and that's fine.
+  # ── Create the GitHub Release with all built dev wheels attached ──
+  # Only fires for workflow_dispatch — pull_request runs validate the build
+  # but never create a release.
+  release:
+    name: Create GitHub Release
+    needs: [prepare, build-smg, build-proto, build-servicer]
+    # Conditions:
+    #   - Only on workflow_dispatch (no releases on pull_request runs).
+    #   - prepare must have succeeded so we have a tag/versions.
+    #   - No requested build may have failed.
+    #   - At least one build must have produced artifacts.
     if: >-
       always()
-      && (github.event_name == 'pull_request' || inputs.release_servicer)
+      && github.event_name == 'workflow_dispatch'
       && github.repository == 'lightseekorg/smg'
-      && needs.build-servicer.result == 'success'
+      && needs.prepare.result == 'success'
+      && needs.build-smg.result != 'failure'
+      && needs.build-proto.result != 'failure'
+      && needs.build-servicer.result != 'failure'
       && (
-        needs.upload-proto.result == 'success'
-        || (
-          github.event_name == 'workflow_dispatch'
-          && !inputs.release_proto
-          && needs.upload-proto.result == 'skipped'
-        )
+        needs.build-smg.result == 'success'
+        || needs.build-proto.result == 'success'
+        || needs.build-servicer.result == 'success'
       )
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - uses: actions/download-artifact@v8
+      - name: Download all dev artifacts
+        uses: actions/download-artifact@v8
         with:
-          name: servicer-dev-dist
           path: dist
-      - uses: actions/setup-python@v6
+          pattern: "*-dev-dist"
+          merge-multiple: true
+
+      - name: List collected assets
+        run: ls -lh dist/
+
+      - name: Create dev release
+        uses: softprops/action-gh-release@v2
         with:
-          python-version: "3.12"
-      - name: Dry-run notice
-        if: ${{ github.event_name == 'pull_request' || inputs.dry_run }}
-        run: |
-          echo "DRY RUN: skipping PyPI upload for smg-grpc-servicer"
-          ls -lh dist/
-      - name: Upload
-        if: ${{ github.event_name == 'workflow_dispatch' && !inputs.dry_run }}
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN_GRPC_SERVICER }}
-        run: |
-          pip install -U twine
-          twine upload dist/* --verbose --skip-existing
+          tag_name: ${{ needs.prepare.outputs.release_tag }}
+          name: "smg dev ${{ github.run_number }}"
+          prerelease: true
+          make_latest: "false"
+          target_commitish: ${{ github.sha }}
+          fail_on_unmatched_files: true
+          body: |
+            Auto-generated dev release from workflow run ${{ github.run_number }}.
+
+            **Versions**
+            - `smg==${{ needs.prepare.outputs.smg_version }}` — build: `${{ needs.build-smg.result }}`
+            - `smg-grpc-proto==${{ needs.prepare.outputs.proto_version }}` — build: `${{ needs.build-proto.result }}`
+            - `smg-grpc-servicer==${{ needs.prepare.outputs.servicer_version }}` — build: `${{ needs.build-servicer.result }}`
+
+            **Install**
+
+            ```bash
+            pip install smg smg-grpc-servicer smg-grpc-proto \
+              --find-links https://github.com/${{ github.repository }}/releases/expanded_assets/${{ needs.prepare.outputs.release_tag }}
+            ```
+
+            Source commit: `${{ github.sha }}`
+          files: dist/*
 
   # ── Final summary in the run UI ──
-  # Surfaces build and upload results separately so a failed build doesn't
-  # look indistinguishable from an unselected package.
   summary:
     name: Summary
     needs:
       - prepare
       - build-smg
-      - upload-smg
       - build-proto
-      - upload-proto
       - build-servicer
-      - upload-servicer
+      - release
     if: always()
     runs-on: ubuntu-latest
     steps:
       - run: |
           {
-            if [ "${{ inputs.dry_run }}" = "true" ] || [ "${{ github.event_name }}" = "pull_request" ]; then
-              echo "## Dev release summary (DRY RUN — nothing uploaded to PyPI)"
+            if [ "${{ github.event_name }}" = "pull_request" ]; then
+              echo "## Dev build summary (pull_request — no GitHub Release created)"
             else
               echo "## Dev release summary"
             fi
             echo ""
-            echo "| Package | Version | Build | Upload |"
-            echo "|---|---|---|---|"
-            echo "| smg | ${{ needs.prepare.outputs.smg_version }} | ${{ needs.build-smg.result }} | ${{ needs.upload-smg.result }} |"
-            echo "| smg-grpc-proto | ${{ needs.prepare.outputs.proto_version }} | ${{ needs.build-proto.result }} | ${{ needs.upload-proto.result }} |"
-            echo "| smg-grpc-servicer | ${{ needs.prepare.outputs.servicer_version }} | ${{ needs.build-servicer.result }} | ${{ needs.upload-servicer.result }} |"
+            echo "| Package | Version | Build |"
+            echo "|---|---|---|"
+            echo "| smg | ${{ needs.prepare.outputs.smg_version }} | ${{ needs.build-smg.result }} |"
+            echo "| smg-grpc-proto | ${{ needs.prepare.outputs.proto_version }} | ${{ needs.build-proto.result }} |"
+            echo "| smg-grpc-servicer | ${{ needs.prepare.outputs.servicer_version }} | ${{ needs.build-servicer.result }} |"
             echo ""
-            if [ "${{ inputs.dry_run }}" != "true" ] && [ "${{ github.event_name }}" != "pull_request" ]; then
-              echo "Install (allow pre-releases):"
-              echo '```'
-              echo "pip install --pre smg smg-grpc-servicer"
+            if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ needs.release.result }}" = "success" ]; then
+              TAG="${{ needs.prepare.outputs.release_tag }}"
+              REPO="${{ github.repository }}"
+              echo "### Release"
+              echo ""
+              echo "https://github.com/${REPO}/releases/tag/${TAG}"
+              echo ""
+              echo "### Install"
+              echo '```bash'
+              echo "pip install smg smg-grpc-servicer smg-grpc-proto \\"
+              echo "  --find-links https://github.com/${REPO}/releases/expanded_assets/${TAG}"
               echo '```'
             fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-pypi-dev.yml
+++ b/.github/workflows/release-pypi-dev.yml
@@ -129,6 +129,15 @@ jobs:
              rm protoc-32.0-linux-x86_64.zip)
             protoc --version
 
+      # The manylinux wheel build above runs inside a Docker container as
+      # root, so files in dist/ end up root-owned. The next step runs on
+      # the host as the runner user and cannot write into that directory.
+      # Fix ownership so the sdist build can land its tarball alongside.
+      - name: Reclaim dist ownership from manylinux container
+        run: |
+          sudo chown -R "$(whoami):$(whoami)" smg-repo/bindings/python/dist
+          ls -la smg-repo/bindings/python/dist
+
       - name: Build sdist
         uses: PyO3/maturin-action@v1
         with:

--- a/.github/workflows/release-pypi-dev.yml
+++ b/.github/workflows/release-pypi-dev.yml
@@ -24,7 +24,7 @@ jobs:
   # same dev<run_number> suffix (e.g. smg==1.4.2.dev42, smg-grpc-servicer==0.5.3.dev42).
   prepare:
     name: Compute dev versions
-    runs-on: ubuntu-latest
+    runs-on: ["cpu-e5"]
     outputs:
       smg_version: ${{ steps.compute.outputs.smg_version }}
       proto_version: ${{ steps.compute.outputs.proto_version }}
@@ -73,7 +73,7 @@ jobs:
     name: Build smg dev wheel
     needs: prepare
     if: ${{ inputs.release_smg }}
-    runs-on: ubuntu-latest
+    runs-on: ["cpu-e5"]
     steps:
       - uses: actions/checkout@v6
         with:
@@ -141,7 +141,7 @@ jobs:
     name: Upload smg to PyPI
     needs: build-smg
     if: ${{ inputs.release_smg && github.repository == 'lightseekorg/smg' }}
-    runs-on: ubuntu-latest
+    runs-on: ["cpu-e5"]
     steps:
       - uses: actions/download-artifact@v8
         with:
@@ -163,7 +163,7 @@ jobs:
     name: Build smg-grpc-proto dev
     needs: prepare
     if: ${{ inputs.release_proto }}
-    runs-on: ubuntu-latest
+    runs-on: ["cpu-e5"]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -197,7 +197,7 @@ jobs:
     name: Upload smg-grpc-proto to PyPI
     needs: build-proto
     if: ${{ inputs.release_proto && github.repository == 'lightseekorg/smg' }}
-    runs-on: ubuntu-latest
+    runs-on: ["cpu-e5"]
     steps:
       - uses: actions/download-artifact@v8
         with:
@@ -221,7 +221,7 @@ jobs:
     name: Build smg-grpc-servicer dev
     needs: prepare
     if: ${{ inputs.release_servicer }}
-    runs-on: ubuntu-latest
+    runs-on: ["cpu-e5"]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -257,7 +257,7 @@ jobs:
       && github.repository == 'lightseekorg/smg'
       && needs.build-servicer.result == 'success'
       && (needs.upload-proto.result == 'success' || needs.upload-proto.result == 'skipped')
-    runs-on: ubuntu-latest
+    runs-on: ["cpu-e5"]
     steps:
       - uses: actions/download-artifact@v8
         with:
@@ -288,7 +288,7 @@ jobs:
       - build-servicer
       - upload-servicer
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ["cpu-e5"]
     steps:
       - run: |
           {

--- a/.github/workflows/release-pypi-dev.yml
+++ b/.github/workflows/release-pypi-dev.yml
@@ -84,9 +84,20 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Patch dev version (5 version files)
+      # Patch only Python-side version metadata. Cargo rejects PEP 440 dev
+      # versions like "1.4.2.dev42" (semver requires "1.4.2-dev42"), so we
+      # deliberately leave Cargo.toml versions alone — they aren't published
+      # by this workflow and maturin uses pyproject.toml for the wheel version.
+      - name: Patch dev version (Python files only)
         working-directory: smg-repo
-        run: make bump-version VERSION=${{ needs.prepare.outputs.smg_version }}
+        env:
+          SMG_VERSION: ${{ needs.prepare.outputs.smg_version }}
+        run: |
+          set -euo pipefail
+          sed -i.bak "s/^version = \".*\"/version = \"${SMG_VERSION}\"/" bindings/python/pyproject.toml
+          sed -i.bak "s/__version__ = \".*\"/__version__ = \"${SMG_VERSION}\"/" bindings/python/src/smg/version.py
+          rm -f bindings/python/pyproject.toml.bak bindings/python/src/smg/version.py.bak
+          echo "Patched smg version to ${SMG_VERSION}"
 
       - name: Build manylinux x86_64 wheels
         uses: PyO3/maturin-action@v1
@@ -161,8 +172,11 @@ jobs:
       - name: Install build deps
         run: pip install build twine grpcio-tools
       - name: Patch dev version
+        env:
+          PROTO_VERSION: ${{ needs.prepare.outputs.proto_version }}
         run: |
-          sed -i.bak 's/^version = ".*"/version = "${{ needs.prepare.outputs.proto_version }}"/' \
+          set -euo pipefail
+          sed -i.bak "s/^version = \".*\"/version = \"${PROTO_VERSION}\"/" \
             crates/grpc_client/python/pyproject.toml
           rm -f crates/grpc_client/python/pyproject.toml.bak
       - name: Copy proto files (replace symlink with real files)
@@ -201,14 +215,12 @@ jobs:
           twine upload dist/* --verbose --skip-existing
 
   # ── smg-grpc-servicer (pure Python) ──
-  # Waits for proto upload if proto was selected; otherwise runs in parallel.
+  # Builds in parallel with proto; the upload step is what gates on proto
+  # upload completing (so a coherent dev set lands on PyPI together).
   build-servicer:
     name: Build smg-grpc-servicer dev
-    needs: [prepare, upload-proto]
-    if: >-
-      always()
-      && inputs.release_servicer
-      && (needs.upload-proto.result == 'success' || needs.upload-proto.result == 'skipped')
+    needs: prepare
+    if: ${{ inputs.release_servicer }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -218,8 +230,11 @@ jobs:
       - name: Install build deps
         run: pip install build twine
       - name: Patch dev version
+        env:
+          SERVICER_VERSION: ${{ needs.prepare.outputs.servicer_version }}
         run: |
-          sed -i.bak 's/^version = ".*"/version = "${{ needs.prepare.outputs.servicer_version }}"/' \
+          set -euo pipefail
+          sed -i.bak "s/^version = \".*\"/version = \"${SERVICER_VERSION}\"/" \
             grpc_servicer/pyproject.toml
           rm -f grpc_servicer/pyproject.toml.bak
       - name: Build package
@@ -233,8 +248,15 @@ jobs:
 
   upload-servicer:
     name: Upload smg-grpc-servicer to PyPI
-    needs: build-servicer
-    if: ${{ inputs.release_servicer && github.repository == 'lightseekorg/smg' }}
+    needs: [build-servicer, upload-proto]
+    # Tolerate proto being skipped (release_proto=false); fail-fast if proto was
+    # requested but failed, so we don't publish a half-finished set.
+    if: >-
+      always()
+      && inputs.release_servicer
+      && github.repository == 'lightseekorg/smg'
+      && needs.build-servicer.result == 'success'
+      && (needs.upload-proto.result == 'success' || needs.upload-proto.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v8
@@ -253,9 +275,18 @@ jobs:
           twine upload dist/* --verbose --skip-existing
 
   # ── Final summary in the run UI ──
+  # Surfaces build and upload results separately so a failed build doesn't
+  # look indistinguishable from an unselected package.
   summary:
     name: Summary
-    needs: [prepare, upload-smg, upload-proto, upload-servicer]
+    needs:
+      - prepare
+      - build-smg
+      - upload-smg
+      - build-proto
+      - upload-proto
+      - build-servicer
+      - upload-servicer
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -263,11 +294,11 @@ jobs:
           {
             echo "## Dev release summary"
             echo ""
-            echo "| Package | Version | Status |"
-            echo "|---|---|---|"
-            echo "| smg | ${{ needs.prepare.outputs.smg_version }} | ${{ needs.upload-smg.result }} |"
-            echo "| smg-grpc-proto | ${{ needs.prepare.outputs.proto_version }} | ${{ needs.upload-proto.result }} |"
-            echo "| smg-grpc-servicer | ${{ needs.prepare.outputs.servicer_version }} | ${{ needs.upload-servicer.result }} |"
+            echo "| Package | Version | Build | Upload |"
+            echo "|---|---|---|---|"
+            echo "| smg | ${{ needs.prepare.outputs.smg_version }} | ${{ needs.build-smg.result }} | ${{ needs.upload-smg.result }} |"
+            echo "| smg-grpc-proto | ${{ needs.prepare.outputs.proto_version }} | ${{ needs.build-proto.result }} | ${{ needs.upload-proto.result }} |"
+            echo "| smg-grpc-servicer | ${{ needs.prepare.outputs.servicer_version }} | ${{ needs.build-servicer.result }} | ${{ needs.upload-servicer.result }} |"
             echo ""
             echo "Install (allow pre-releases):"
             echo '```'

--- a/.github/workflows/release-pypi-dev.yml
+++ b/.github/workflows/release-pypi-dev.yml
@@ -15,6 +15,10 @@ on:
         description: "Release smg-grpc-proto (only if proto files changed)"
         type: boolean
         default: false
+      dry_run:
+        description: "Dry run: build, patch versions, run twine check, but do NOT upload to PyPI"
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -150,7 +154,13 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+      - name: Dry-run notice
+        if: ${{ inputs.dry_run }}
+        run: |
+          echo "DRY RUN: skipping PyPI upload for smg"
+          ls -lh dist/
       - name: Upload
+        if: ${{ !inputs.dry_run }}
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN_ROUTER }}
@@ -206,7 +216,13 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+      - name: Dry-run notice
+        if: ${{ inputs.dry_run }}
+        run: |
+          echo "DRY RUN: skipping PyPI upload for smg-grpc-proto"
+          ls -lh dist/
       - name: Upload
+        if: ${{ !inputs.dry_run }}
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN_GRPC_PROTO }}
@@ -266,7 +282,13 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+      - name: Dry-run notice
+        if: ${{ inputs.dry_run }}
+        run: |
+          echo "DRY RUN: skipping PyPI upload for smg-grpc-servicer"
+          ls -lh dist/
       - name: Upload
+        if: ${{ !inputs.dry_run }}
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN_GRPC_SERVICER }}
@@ -292,7 +314,11 @@ jobs:
     steps:
       - run: |
           {
-            echo "## Dev release summary"
+            if [ "${{ inputs.dry_run }}" = "true" ]; then
+              echo "## Dev release summary (DRY RUN — nothing uploaded to PyPI)"
+            else
+              echo "## Dev release summary"
+            fi
             echo ""
             echo "| Package | Version | Build | Upload |"
             echo "|---|---|---|---|"
@@ -300,8 +326,10 @@ jobs:
             echo "| smg-grpc-proto | ${{ needs.prepare.outputs.proto_version }} | ${{ needs.build-proto.result }} | ${{ needs.upload-proto.result }} |"
             echo "| smg-grpc-servicer | ${{ needs.prepare.outputs.servicer_version }} | ${{ needs.build-servicer.result }} | ${{ needs.upload-servicer.result }} |"
             echo ""
-            echo "Install (allow pre-releases):"
-            echo '```'
-            echo "pip install --pre smg smg-grpc-servicer"
-            echo '```'
+            if [ "${{ inputs.dry_run }}" != "true" ]; then
+              echo "Install (allow pre-releases):"
+              echo '```'
+              echo "pip install --pre smg smg-grpc-servicer"
+              echo '```'
+            fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-pypi-dev.yml
+++ b/.github/workflows/release-pypi-dev.yml
@@ -1,0 +1,276 @@
+name: Release SMG to PyPI (dev)
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_smg:
+        description: "Release smg (Rust wheel)"
+        type: boolean
+        default: true
+      release_servicer:
+        description: "Release smg-grpc-servicer"
+        type: boolean
+        default: true
+      release_proto:
+        description: "Release smg-grpc-proto (only if proto files changed)"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  # Compute shared dev versions once so all packages from this run share the
+  # same dev<run_number> suffix (e.g. smg==1.4.2.dev42, smg-grpc-servicer==0.5.3.dev42).
+  prepare:
+    name: Compute dev versions
+    runs-on: ubuntu-latest
+    outputs:
+      smg_version: ${{ steps.compute.outputs.smg_version }}
+      proto_version: ${{ steps.compute.outputs.proto_version }}
+      servicer_version: ${{ steps.compute.outputs.servicer_version }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - id: compute
+        run: |
+          set -euo pipefail
+          SUFFIX="dev${{ github.run_number }}"
+
+          read_version() {
+            grep -m1 '^version = ' "$1" | sed 's/version = "\(.*\)"/\1/'
+          }
+
+          # Bump patch so dev sorts AFTER current stable.
+          # E.g. base 1.4.1 -> 1.4.2.dev<N> (so --pre picks it as latest).
+          bump_patch() {
+            local IFS=.
+            # shellcheck disable=SC2206
+            local parts=($1)
+            parts[2]=$(( ${parts[2]} + 1 ))
+            echo "${parts[0]}.${parts[1]}.${parts[2]}"
+          }
+
+          SMG_VERSION="$(bump_patch "$(read_version bindings/python/pyproject.toml)").${SUFFIX}"
+          PROTO_VERSION="$(bump_patch "$(read_version crates/grpc_client/python/pyproject.toml)").${SUFFIX}"
+          SERVICER_VERSION="$(bump_patch "$(read_version grpc_servicer/pyproject.toml)").${SUFFIX}"
+
+          echo "smg_version=${SMG_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "proto_version=${PROTO_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "servicer_version=${SERVICER_VERSION}" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "## Planned dev versions"
+            echo "| Package | Version | Will publish? |"
+            echo "|---|---|---|"
+            echo "| smg | ${SMG_VERSION} | ${{ inputs.release_smg }} |"
+            echo "| smg-grpc-proto | ${PROTO_VERSION} | ${{ inputs.release_proto }} |"
+            echo "| smg-grpc-servicer | ${SERVICER_VERSION} | ${{ inputs.release_servicer }} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # ── smg (Rust wheel via maturin) — slim matrix: manylinux x86_64 + sdist ──
+  build-smg:
+    name: Build smg dev wheel
+    needs: prepare
+    if: ${{ inputs.release_smg }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          path: smg-repo
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Patch dev version (5 version files)
+        working-directory: smg-repo
+        run: make bump-version VERSION=${{ needs.prepare.outputs.smg_version }}
+
+      - name: Build manylinux x86_64 wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          working-directory: smg-repo/bindings/python
+          target: x86_64
+          manylinux: auto
+          args: --release --out dist --features vendored-openssl --interpreter 3.10 3.11 3.12 3.13
+          rust-toolchain: stable
+          before-script-linux: |
+            if command -v yum &> /dev/null; then
+              yum update -y && yum install -y wget unzip gcc gcc-c++ perl-core make
+            elif command -v apt-get &> /dev/null; then
+              apt-get update && apt-get install -y wget unzip gcc g++ perl make
+            fi
+            (cd /tmp && \
+             wget https://github.com/protocolbuffers/protobuf/releases/download/v32.0/protoc-32.0-linux-x86_64.zip && \
+             unzip protoc-32.0-linux-x86_64.zip -d /usr/local && \
+             rm protoc-32.0-linux-x86_64.zip)
+            protoc --version
+
+      - name: Build sdist
+        uses: PyO3/maturin-action@v1
+        with:
+          working-directory: smg-repo/bindings/python
+          command: sdist
+          args: --out dist
+          rust-toolchain: stable
+
+      - name: Check packages
+        run: |
+          pip install -U twine
+          twine check --strict smg-repo/bindings/python/dist/*
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: smg-dev-dist
+          path: smg-repo/bindings/python/dist/
+
+  upload-smg:
+    name: Upload smg to PyPI
+    needs: build-smg
+    if: ${{ inputs.release_smg && github.repository == 'lightseekorg/smg' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: smg-dev-dist
+          path: dist
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Upload
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN_ROUTER }}
+        run: |
+          pip install -U twine
+          twine upload dist/* --verbose --skip-existing
+
+  # ── smg-grpc-proto (pure Python) ──
+  build-proto:
+    name: Build smg-grpc-proto dev
+    needs: prepare
+    if: ${{ inputs.release_proto }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install build deps
+        run: pip install build twine grpcio-tools
+      - name: Patch dev version
+        run: |
+          sed -i.bak 's/^version = ".*"/version = "${{ needs.prepare.outputs.proto_version }}"/' \
+            crates/grpc_client/python/pyproject.toml
+          rm -f crates/grpc_client/python/pyproject.toml.bak
+      - name: Copy proto files (replace symlink with real files)
+        run: |
+          rm -f crates/grpc_client/python/smg_grpc_proto/proto
+          mkdir -p crates/grpc_client/python/smg_grpc_proto/proto
+          cp crates/grpc_client/proto/*.proto crates/grpc_client/python/smg_grpc_proto/proto/
+      - name: Build package
+        run: cd crates/grpc_client/python && python -m build
+      - name: Check package
+        run: twine check --strict crates/grpc_client/python/dist/*
+      - uses: actions/upload-artifact@v7
+        with:
+          name: proto-dev-dist
+          path: crates/grpc_client/python/dist/
+
+  upload-proto:
+    name: Upload smg-grpc-proto to PyPI
+    needs: build-proto
+    if: ${{ inputs.release_proto && github.repository == 'lightseekorg/smg' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: proto-dev-dist
+          path: dist
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Upload
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN_GRPC_PROTO }}
+        run: |
+          pip install -U twine
+          twine upload dist/* --verbose --skip-existing
+
+  # ── smg-grpc-servicer (pure Python) ──
+  # Waits for proto upload if proto was selected; otherwise runs in parallel.
+  build-servicer:
+    name: Build smg-grpc-servicer dev
+    needs: [prepare, upload-proto]
+    if: >-
+      always()
+      && inputs.release_servicer
+      && (needs.upload-proto.result == 'success' || needs.upload-proto.result == 'skipped')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install build deps
+        run: pip install build twine
+      - name: Patch dev version
+        run: |
+          sed -i.bak 's/^version = ".*"/version = "${{ needs.prepare.outputs.servicer_version }}"/' \
+            grpc_servicer/pyproject.toml
+          rm -f grpc_servicer/pyproject.toml.bak
+      - name: Build package
+        run: cd grpc_servicer && python -m build
+      - name: Check package
+        run: twine check --strict grpc_servicer/dist/*
+      - uses: actions/upload-artifact@v7
+        with:
+          name: servicer-dev-dist
+          path: grpc_servicer/dist/
+
+  upload-servicer:
+    name: Upload smg-grpc-servicer to PyPI
+    needs: build-servicer
+    if: ${{ inputs.release_servicer && github.repository == 'lightseekorg/smg' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: servicer-dev-dist
+          path: dist
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Upload
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN_GRPC_SERVICER }}
+        run: |
+          pip install -U twine
+          twine upload dist/* --verbose --skip-existing
+
+  # ── Final summary in the run UI ──
+  summary:
+    name: Summary
+    needs: [prepare, upload-smg, upload-proto, upload-servicer]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          {
+            echo "## Dev release summary"
+            echo ""
+            echo "| Package | Version | Status |"
+            echo "|---|---|---|"
+            echo "| smg | ${{ needs.prepare.outputs.smg_version }} | ${{ needs.upload-smg.result }} |"
+            echo "| smg-grpc-proto | ${{ needs.prepare.outputs.proto_version }} | ${{ needs.upload-proto.result }} |"
+            echo "| smg-grpc-servicer | ${{ needs.prepare.outputs.servicer_version }} | ${{ needs.upload-servicer.result }} |"
+            echo ""
+            echo "Install (allow pre-releases):"
+            echo '```'
+            echo "pip install --pre smg smg-grpc-servicer"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-pypi-dev.yml
+++ b/.github/workflows/release-pypi-dev.yml
@@ -24,7 +24,7 @@ jobs:
   # same dev<run_number> suffix (e.g. smg==1.4.2.dev42, smg-grpc-servicer==0.5.3.dev42).
   prepare:
     name: Compute dev versions
-    runs-on: ["cpu-e5"]
+    runs-on: ubuntu-latest
     outputs:
       smg_version: ${{ steps.compute.outputs.smg_version }}
       proto_version: ${{ steps.compute.outputs.proto_version }}
@@ -73,7 +73,7 @@ jobs:
     name: Build smg dev wheel
     needs: prepare
     if: ${{ inputs.release_smg }}
-    runs-on: ["cpu-e5"]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
@@ -141,7 +141,7 @@ jobs:
     name: Upload smg to PyPI
     needs: build-smg
     if: ${{ inputs.release_smg && github.repository == 'lightseekorg/smg' }}
-    runs-on: ["cpu-e5"]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v8
         with:
@@ -163,7 +163,7 @@ jobs:
     name: Build smg-grpc-proto dev
     needs: prepare
     if: ${{ inputs.release_proto }}
-    runs-on: ["cpu-e5"]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -197,7 +197,7 @@ jobs:
     name: Upload smg-grpc-proto to PyPI
     needs: build-proto
     if: ${{ inputs.release_proto && github.repository == 'lightseekorg/smg' }}
-    runs-on: ["cpu-e5"]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v8
         with:
@@ -221,7 +221,7 @@ jobs:
     name: Build smg-grpc-servicer dev
     needs: prepare
     if: ${{ inputs.release_servicer }}
-    runs-on: ["cpu-e5"]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -257,7 +257,7 @@ jobs:
       && github.repository == 'lightseekorg/smg'
       && needs.build-servicer.result == 'success'
       && (needs.upload-proto.result == 'success' || needs.upload-proto.result == 'skipped')
-    runs-on: ["cpu-e5"]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v8
         with:
@@ -288,7 +288,7 @@ jobs:
       - build-servicer
       - upload-servicer
     if: always()
-    runs-on: ["cpu-e5"]
+    runs-on: ubuntu-latest
     steps:
       - run: |
           {


### PR DESCRIPTION
## Description

### Problem

Downstream projects like tokenspeed need to consume dev builds of `smg`, `smg-grpc-proto`, and `smg-grpc-servicer` from in-flight feature branches before they merge to `main`. The existing `release-pypi.yml` / `release-grpc.yml` only fire on push-to-main and target stable PyPI releases.

We initially tried publishing dev wheels to PyPI under a `.devN` suffix, but PyPI's per-project storage cap is 10 GB and the API is append-only — the vendored-openssl smg wheel is ~80-150 MB per build, so a handful of dev iterations would burn the quota with no way to reclaim space. PyPI is the wrong store for ephemeral dev artifacts.

### Solution

Add a workflow that publishes dev wheels to **GitHub Releases** instead of PyPI. No quota concerns, releases can be deleted freely, and prod release pipelines stay untouched.

Key properties:

- `workflow_dispatch`-only releases: one combined GitHub Release per run, tagged `smg-dev-<run_number>`, marked as prerelease, containing all selected packages' wheels + sdists.
- Shared dev suffix across packages from the same run (e.g. `smg==1.4.2.dev42` + `smg-grpc-servicer==0.5.3.dev42`).
- When proto and servicer are released together, the servicer wheel hard-pins `smg-grpc-proto==<dev_version>` so consumers can't accidentally mix versions.
- Patches both Python metadata and `model_gateway/Cargo.toml` so the wheel's runtime banner reports the dev version (`1.4.2-dev42` semver) — not stale stable.
- Pull_request trigger filtered to this workflow file: PRs that change the workflow auto-validate the build pipeline in pure dry-run mode (single Python interpreter, no GitHub Release created). This is how we caught the sdist permission bug and other issues during review.

## Changes

- `.github/workflows/release-pypi-dev.yml` (new): six jobs — `prepare`, `build-smg`, `build-proto`, `build-servicer`, `release` (workflow_dispatch only), `summary`. ~340 lines.
- Reuses `softprops/action-gh-release@v2` for release publishing; no new secrets needed.

## Test Plan

Validated end-to-end via the file's own `pull_request:` trigger across the iterations on this branch. Catches caught in dry-run and fixed before merge:

1. ✅ Cargo rejects PEP 440 dev versions — patched only Python files (then later added semver mapping for runtime banner).
2. ✅ Maturin sdist failed with `Permission denied` after manylinux container — added a `chown` reclaim step.
3. ✅ Half-finished set risk (proto build fails, servicer still uploads) — tightened gate.
4. ✅ Loose proto dep on servicer → resolver could pick wrong proto — pinned at build time.

Post-merge:

1. From any branch (e.g. PR #1465's `feat/grpc-tokenspeed-ci-tests`):
   ```
   Actions → "Release SMG dev wheels (GitHub Releases)" → Run workflow → branch dropdown → all three boxes → Run
   ```
2. Watch the release land at `https://github.com/lightseekorg/smg/releases/tag/smg-dev-<run_number>`.
3. In a consumer venv:
   ```bash
   pip install smg smg-grpc-servicer smg-grpc-proto \
     --find-links https://github.com/lightseekorg/smg/releases/expanded_assets/smg-dev-<run_number>
   ```
4. Confirm `import smg; print(smg.__version__)` and the smg runtime banner both report the dev version.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes (no Rust changes)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (no Rust changes)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>