### PR TITLE
smg now needs either launch, server or serve - those examples are all…

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,13 @@ cargo install smg
 
 ```bash
 # Single worker
-smg --worker-urls http://localhost:8000
+smg launch --worker-urls http://localhost:8000
 
 # Multiple workers with cache-aware routing
-smg --worker-urls http://gpu1:8000 http://gpu2:8000 --policy cache_aware
+smg launch --worker-urls http://gpu1:8000 http://gpu2:8000 --policy cache_aware
 
 # With high availability mesh
-smg --worker-urls http://gpu1:8000 --enable-mesh \
+smg launch --worker-urls http://gpu1:8000 --enable-mesh \
   --mesh-advertise-host 10.0.0.1 --mesh-peer-urls 10.0.0.2:39527
 ```
 


### PR DESCRIPTION
It's just a fix on the readme, so it works with the latest main release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated quick-start examples to reflect correct command usage for running the application across single-worker, multi-worker, and high-availability configurations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightseekorg/smg/pull/1474)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->