### PR TITLE
fix(ci): pin nixl<1.1.0 to avoid cu13 libcudart on CUDA 12 runners

### DIFF
--- a/scripts/ci_install_vllm.sh
+++ b/scripts/ci_install_vllm.sh
@@ -35,9 +35,12 @@ echo "Using uv version: $(uv --version)"
 echo "Installing vLLM..."
 uv pip install "vllm<0.19.1"
 
-# Install nixl for vLLM PD disaggregation (NIXL KV transfer)
+# Install nixl for vLLM PD disaggregation (NIXL KV transfer).
+# Pin <1.1.0: 1.1.0 lands a cu13 nixl_ep_cpp.so that vLLM 0.19.0 imports
+# unconditionally, breaking CUDA-12 ARC pods. Drop once vLLM or the
+# runner pool catches up.
 echo "Installing nixl..."
-uv pip install nixl
+uv pip install "nixl<1.1.0"
 
 # Install gRPC packages from source (not PyPI) so PR changes are always tested
 echo "Installing smg-grpc-proto and smg-grpc-servicer from source..."


### PR DESCRIPTION
## Description

### Problem

vLLM CI jobs are failing non-deterministically with:

```
ImportError: libcudart.so.13: cannot open shared object file: No such file or directory
```

Example: https://github.com/lightseekorg/smg/actions/runs/25752898749/job/75633763852

The same job passes on retry without any code change — the flakiness depends on which self-hosted ARC pod the job lands on.

### Root cause

Two independent shifts collided today (2026-05-12):

1. **`nixl 1.1.0` was published.** It is now a **meta-package** that installs *both* `nixl-cu12==1.1.0` and `nixl-cu13==1.1.0` into the same `site-packages/nixl_ep/` directory. Whichever wheel `uv` installs last wins the `nixl_ep_cpp.so` file conflict — in practice `uv` lands the cu13 variant on top, so loading `nixl_ep_cpp` ends up trying to `dlopen` `libcudart.so.13`.

   Install log proof:
   ```
   Installing nixl...
   Downloading nixl-cu12 (36.7MiB)
   Downloading nixl-cu13 (34.4MiB)
    + nixl==1.1.0
    + nixl-cu12==1.1.0
    + nixl-cu13==1.1.0
   ```

2. **vLLM 0.19.0** (`vllm/model_executor/layers/fused_moe/nixl_ep_prepare_finalize.py:5`) does a plain `import nixl_ep` at module load, **bypassing** the `nixl` meta-package's runtime CUDA-version selector. So whichever `.so` is on disk is what gets loaded — there is no fallback.

3. **The ARC runner pool is mid-rollover.** Same label, different base images:

   | Job | Runner | Version | Result |
   |---|---|---|---|
   | first attempt | `arc-runner-1-gpu-h100-gwjtg-d6ngw` | `2.331.0` (CUDA 12) | ❌ |
   | rerun | `arc-runner-1-gpu-h100-gwjtg-7dkpc` | `2.334.0` (CUDA 13) | ✅ |

   Jobs landing on `2.331.0` pods (CUDA 12 only) fail; jobs landing on `2.334.0` pods (CUDA 13) pass. Every vLLM GPU job is exposed, because the failing import is in vLLM's `gpu_worker.py → kernel_warmup → ... → nixl_ep_prepare_finalize` chain hit during *any* engine init.

### Solution

Cap `nixl` to `<1.1.0` so we go back to a single CUDA-specific wheel that doesn't ship a stray cu13 `.so`. This keeps behavior deterministic across the heterogeneous pool regardless of which pod a job lands on. The pin is intentionally narrow and mirrors the existing `vllm<0.19.1` pattern in the same script.

Drop the pin once **either**:
- vLLM ships a release that goes through nixl's runtime selector instead of `import nixl_ep` directly, or
- the ARC runner pool is fully on the CUDA-13 image.

## Changes

- `scripts/ci_install_vllm.sh`: change `uv pip install nixl` → `uv pip install "nixl<1.1.0"` with a short inline note pointing at this PR.

## Test Plan

- Re-running any vLLM e2e job from `runs/25752898749` after this lands should pass deterministically on both `2.331.0` and `2.334.0` ARC pods.
- Quick local sanity:
  ```
  uv pip install --dry-run "nixl<1.1.0"   # should resolve to 1.0.x, no nixl-cu13 in the plan
  ```

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes (no Rust changes)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (no Rust changes)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI installation configuration to enforce version constraints on a core dependency. This modification prevents potential binary import compatibility issues that could occur when running CI in CUDA-12 environments, improving installation reliability and ensuring more stable, consistent builds across varied system configurations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightseekorg/smg/pull/1477)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->