### PR TITLE
fix(tokenizer): support Kimi K2/K2.5/K2.6 tiktoken models

### DIFF
--- a/crates/tokenizer/src/kimi_k2_tokenizer.rs
+++ b/crates/tokenizer/src/kimi_k2_tokenizer.rs
@@ -1,0 +1,240 @@
+//! Kimi-K2 / K2.5 / K2.6 detection and special-token helpers.
+//!
+//! Kimi models use the standard tiktoken BPE engine but with a Han-aware regex
+//! and a 256-slot reserved-special-token range starting at `len(mergeable_ranks)`.
+//! These helpers let the generic `TiktokenTokenizer` loader specialize itself
+//! when it sees a Kimi directory, without exposing a separate public type.
+//!
+//! Upstream reference (identical across all three Kimi variants):
+//!   - moonshotai/Kimi-K2-Thinking/tokenization_kimi.py
+//!   - moonshotai/Kimi-K2.5/tokenization_kimi.py
+//!   - moonshotai/Kimi-K2.6/tokenization_kimi.py
+
+use std::{
+    collections::{HashMap, HashSet},
+    path::Path,
+};
+
+use serde_json::Value;
+
+use crate::traits::TokenIdType;
+
+const NUM_RESERVED_SPECIAL_TOKENS: usize = 256;
+
+/// Han-aware tokenization regex used by Kimi K2/K2.5/K2.6. Byte-identical to
+/// the `pat_str` in upstream `tokenization_kimi.py`.
+pub(crate) const KIMI_K2_PATTERN: &str = r"[\p{Han}]+|[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}&&[^\p{Han}]]*[\p{Ll}\p{Lm}\p{Lo}\p{M}&&[^\p{Han}]]+(?i:'s|'t|'re|'ve|'m|'ll|'d)?|[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}&&[^\p{Han}]]+[\p{Ll}\p{Lm}\p{Lo}\p{M}&&[^\p{Han}]]*(?i:'s|'t|'re|'ve|'m|'ll|'d)?|\p{N}{1,3}| ?[^\s\p{L}\p{N}]+[\r\n]*|\s*[\r\n]+|\s+(?!\S)|\s+";
+
+/// Returns true if `dir` looks like a Kimi K2/K2.5/K2.6 model directory.
+///
+/// Primary signal: `tokenizer_config.json` references `tokenization_kimi`
+/// (via `auto_map`, `tokenizer_class`, etc.). Fallback: `config.json::model_type`
+/// is one of the known Kimi values.
+pub(crate) fn matches_dir(dir: &Path) -> bool {
+    if let Some(config) = read_json(&dir.join("tokenizer_config.json")) {
+        if value_mentions_kimi_tokenizer(&config) {
+            return true;
+        }
+    }
+
+    read_json(&dir.join("config.json")).is_some_and(|config| model_config_is_kimi(&config))
+}
+
+/// Fill the 256-slot reserved special-token range starting at `base_vocab_size`
+/// with synthetic `<|reserved_token_{id}|>` entries, preserving any explicit
+/// `added_tokens_decoder` entries that already occupy slots in that range.
+///
+/// Mirrors upstream `tokenization_kimi.py`:
+/// ```python
+/// {special_tokens_mapping.get(i, f"<|reserved_token_{i}|>"): i
+///  for i in range(num_base_tokens, num_base_tokens + 256)}
+/// ```
+/// where `num_base_tokens = len(mergeable_ranks)` — i.e., `encoder.len()`.
+pub(crate) fn apply_reserved_special_tokens(
+    added_tokens: &mut HashMap<String, TokenIdType>,
+    base_vocab_size: usize,
+) {
+    let Ok(start) = TokenIdType::try_from(base_vocab_size) else {
+        return;
+    };
+
+    let occupied_ids: HashSet<TokenIdType> = added_tokens.values().copied().collect();
+    for offset in 0..NUM_RESERVED_SPECIAL_TOKENS {
+        let id = start + offset as TokenIdType;
+        if occupied_ids.contains(&id) {
+            continue;
+        }
+
+        added_tokens
+            .entry(format!("<|reserved_token_{id}|>"))
+            .or_insert(id);
+    }
+}
+
+fn read_json(path: &Path) -> Option<Value> {
+    let content = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+fn model_config_is_kimi(config: &Value) -> bool {
+    let model_type = config.get("model_type").and_then(Value::as_str);
+    matches!(model_type, Some("kimi_k2") | Some("kimi_k25"))
+}
+
+fn value_mentions_kimi_tokenizer(value: &Value) -> bool {
+    match value {
+        Value::String(s) => s.contains("tokenization_kimi"),
+        Value::Array(values) => values.iter().any(value_mentions_kimi_tokenizer),
+        Value::Object(map) => map.values().any(value_mentions_kimi_tokenizer),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use base64::{engine::general_purpose::STANDARD, Engine as _};
+
+    use super::*;
+    use crate::{
+        tiktoken::TiktokenTokenizer,
+        traits::{Decoder, Encoder, Tokenizer},
+    };
+
+    // Minimal BPE: bytes 'a' (rank 0), 'b' (rank 1). Used for tests that only
+    // exercise decode of synthetic special tokens (no BPE encode).
+    const MINIMAL_TIKTOKEN_MODEL: &str = "YQ== 0\nYg== 1\n";
+    // Minimal BPE: "hello's" (rank 0), "hello" (rank 1), "'s" (rank 2).
+    const CONTRACTION_TIKTOKEN_MODEL: &str = "aGVsbG8ncw== 0\naGVsbG8= 1\nJ3M= 2\n";
+
+    /// Build a tiktoken model file with all 256 single-byte tokens (ranks 0..256)
+    /// plus the given multi-byte tokens at successive ranks starting at 256.
+    /// tiktoken's BPE requires every input byte to have a rank, so a real-world
+    /// encode test needs the full byte layer.
+    fn full_byte_bpe(extra: &[&[u8]]) -> String {
+        let mut out = String::new();
+        for b in 0u32..256 {
+            out.push_str(&format!("{} {}\n", STANDARD.encode([b as u8]), b));
+        }
+        for (offset, bytes) in extra.iter().enumerate() {
+            out.push_str(&format!("{} {}\n", STANDARD.encode(bytes), 256 + offset));
+        }
+        out
+    }
+
+    fn write_kimi_dir(model: &str, tokenizer_config: &str) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("tiktoken.model"), model).unwrap();
+        std::fs::write(dir.path().join("tokenizer_config.json"), tokenizer_config).unwrap();
+        dir
+    }
+
+    const KIMI_AUTO_MAP_CONFIG: &str = r#"{
+        "tokenizer_class": "TikTokenTokenizer",
+        "auto_map": {
+            "AutoTokenizer": ["tokenization_kimi.TikTokenTokenizer", null]
+        }
+    }"#;
+
+    #[test]
+    fn reserved_special_tokens_are_synthesized() {
+        let dir = write_kimi_dir(
+            MINIMAL_TIKTOKEN_MODEL,
+            r#"{
+                "tokenizer_class": "TikTokenTokenizer",
+                "auto_map": {
+                    "AutoTokenizer": ["tokenization_kimi.TikTokenTokenizer", null]
+                },
+                "added_tokens_decoder": {
+                    "2": { "content": "[BOS]", "special": true },
+                    "5": { "content": "<|im_assistant|>", "special": true }
+                }
+            }"#,
+        );
+        let tokenizer = TiktokenTokenizer::from_dir(dir.path()).unwrap();
+
+        assert_eq!(tokenizer.vocab_size(), 258);
+        assert_eq!(
+            tokenizer.decode(&[4], false).unwrap(),
+            "<|reserved_token_4|>"
+        );
+        assert_eq!(tokenizer.decode(&[5], false).unwrap(), "<|im_assistant|>");
+        assert_eq!(tokenizer.token_to_id("<|reserved_token_4|>"), Some(4));
+        assert_eq!(
+            tokenizer.id_to_token(4).as_deref(),
+            Some("<|reserved_token_4|>")
+        );
+    }
+
+    #[test]
+    fn matches_via_model_type_kimi_k2() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("tiktoken.model"), MINIMAL_TIKTOKEN_MODEL).unwrap();
+        std::fs::write(
+            dir.path().join("tokenizer_config.json"),
+            r#"{ "added_tokens_decoder": {} }"#,
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("config.json"),
+            r#"{ "model_type": "kimi_k2" }"#,
+        )
+        .unwrap();
+
+        assert!(matches_dir(dir.path()));
+        // Round-trip a synthetic reserved token to confirm Kimi load path was taken.
+        let tokenizer = TiktokenTokenizer::from_dir(dir.path()).unwrap();
+        assert_eq!(
+            tokenizer.decode(&[42], false).unwrap(),
+            "<|reserved_token_42|>"
+        );
+    }
+
+    #[test]
+    fn matches_via_model_type_kimi_k25() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("tiktoken.model"), MINIMAL_TIKTOKEN_MODEL).unwrap();
+        std::fs::write(
+            dir.path().join("tokenizer_config.json"),
+            r#"{ "added_tokens_decoder": {} }"#,
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("config.json"),
+            r#"{ "model_type": "kimi_k25" }"#,
+        )
+        .unwrap();
+
+        assert!(matches_dir(dir.path()));
+    }
+
+    #[test]
+    fn uses_kimi_pattern_for_contractions() {
+        let dir = write_kimi_dir(CONTRACTION_TIKTOKEN_MODEL, KIMI_AUTO_MAP_CONFIG);
+        let tokenizer = TiktokenTokenizer::from_dir(dir.path()).unwrap();
+        // The Kimi regex keeps "hello's" as a single match (contraction handling
+        // in the third alternation), so the BPE returns rank 0.
+        assert_eq!(
+            tokenizer.encode("hello's", false).unwrap().token_ids(),
+            &[0]
+        );
+    }
+
+    #[test]
+    fn han_input_round_trips_through_kimi_pattern() {
+        // The Kimi regex's leading alternation is `[\p{Han}]+`. The main
+        // regressions this guards against are (a) the character-class
+        // intersection `[X&&[^\p{Han}]]` failing to compile under tiktoken-rs's
+        // fancy-regex backend, and (b) Han input being rejected at the
+        // pre-tokenizer. A minimal synthetic BPE can't reproduce a real Kimi
+        // vocab, so we assert byte-level round-trip rather than exact token
+        // IDs: encode must not panic, and decode must reconstruct the input.
+        let model = full_byte_bpe(&[]);
+        let dir = write_kimi_dir(&model, KIMI_AUTO_MAP_CONFIG);
+        let tokenizer = TiktokenTokenizer::from_dir(dir.path()).unwrap();
+
+        let text = "你好世界 hello!";
+        let encoding = tokenizer.encode(text, false).unwrap();
+        let decoded = tokenizer.decode(encoding.token_ids(), false).unwrap();
+        assert_eq!(decoded, text);
+    }
+}

--- a/crates/tokenizer/src/kimi_k2_tokenizer.rs
+++ b/crates/tokenizer/src/kimi_k2_tokenizer.rs
@@ -27,16 +27,15 @@ pub(crate) const KIMI_K2_PATTERN: &str = r"[\p{Han}]+|[^\r\n\p{L}\p{N}]?[\p{Lu}\
 
 /// Returns true if `dir` looks like a Kimi K2/K2.5/K2.6 model directory.
 ///
-/// Primary signal: `tokenizer_config.json` references `tokenization_kimi`
-/// (via `auto_map`, `tokenizer_class`, etc.). Fallback: `config.json::model_type`
-/// is one of the known Kimi values.
-pub(crate) fn matches_dir(dir: &Path) -> bool {
-    if let Some(config) = read_json(&dir.join("tokenizer_config.json")) {
-        if value_mentions_kimi_tokenizer(&config) {
-            return true;
-        }
+/// Primary signal: the already-parsed `tokenizer_config.json` references
+/// `tokenization_kimi` (via `auto_map`, `tokenizer_class`, etc.). Callers pass
+/// the parsed JSON so we don't re-read the file the tiktoken loader already
+/// parsed. Fallback: read sibling `config.json` and check `model_type` ∈
+/// `{kimi_k2, kimi_k25}`.
+pub(crate) fn matches(tokenizer_config: Option<&Value>, dir: &Path) -> bool {
+    if tokenizer_config.is_some_and(value_mentions_kimi_tokenizer) {
+        return true;
     }
-
     read_json(&dir.join("config.json")).is_some_and(|config| model_config_is_kimi(&config))
 }
 
@@ -83,11 +82,18 @@ fn model_config_is_kimi(config: &Value) -> bool {
 
 fn value_mentions_kimi_tokenizer(value: &Value) -> bool {
     match value {
-        Value::String(s) => s.contains("tokenization_kimi"),
+        Value::String(s) => mentions_kimi_tokenizer_module(s),
         Value::Array(values) => values.iter().any(value_mentions_kimi_tokenizer),
         Value::Object(map) => map.values().any(value_mentions_kimi_tokenizer),
         _ => false,
     }
+}
+
+/// Match the dotted-path identifier `tokenization_kimi` as a whole segment,
+/// not a substring — so `tokenization_kimi.TikTokenTokenizer` matches but
+/// `tokenization_kimi_v2` or `my_tokenization_kimi_helper` do not.
+fn mentions_kimi_tokenizer_module(s: &str) -> bool {
+    s.split('.').any(|seg| seg == "tokenization_kimi")
 }
 
 #[cfg(test)]
@@ -135,6 +141,12 @@ mod tests {
         }
     }"#;
 
+    /// Read tokenizer_config.json from `dir`, mirroring what the real loader
+    /// hands to `matches`. Used so each test exercises the same call shape.
+    fn tokenizer_config(dir: &Path) -> Option<Value> {
+        read_json(&dir.join("tokenizer_config.json"))
+    }
+
     #[test]
     fn reserved_special_tokens_are_synthesized() {
         let dir = write_kimi_dir(
@@ -180,7 +192,7 @@ mod tests {
         )
         .unwrap();
 
-        assert!(matches_dir(dir.path()));
+        assert!(matches(tokenizer_config(dir.path()).as_ref(), dir.path()));
         // Round-trip a synthetic reserved token to confirm Kimi load path was taken.
         let tokenizer = TiktokenTokenizer::from_dir(dir.path()).unwrap();
         assert_eq!(
@@ -204,7 +216,25 @@ mod tests {
         )
         .unwrap();
 
-        assert!(matches_dir(dir.path()));
+        assert!(matches(tokenizer_config(dir.path()).as_ref(), dir.path()));
+    }
+
+    #[test]
+    fn substring_does_not_falsely_match_kimi() {
+        // Names that *contain* "tokenization_kimi" as a substring but aren't
+        // the module identifier itself must not trigger Kimi detection.
+        assert!(!mentions_kimi_tokenizer_module("tokenization_kimi_v2"));
+        assert!(!mentions_kimi_tokenizer_module(
+            "my_tokenization_kimi_helper"
+        ));
+        // Real upstream forms should still match.
+        assert!(mentions_kimi_tokenizer_module("tokenization_kimi"));
+        assert!(mentions_kimi_tokenizer_module(
+            "tokenization_kimi.TikTokenTokenizer"
+        ));
+        assert!(mentions_kimi_tokenizer_module(
+            "pkg.tokenization_kimi.TikTokenTokenizer"
+        ));
     }
 
     #[test]

--- a/crates/tokenizer/src/lib.rs
+++ b/crates/tokenizer/src/lib.rs
@@ -16,6 +16,7 @@ pub mod traits;
 
 pub mod chat_template;
 pub mod huggingface;
+mod kimi_k2_tokenizer;
 pub mod tiktoken;
 
 #[cfg(test)]

--- a/crates/tokenizer/src/tiktoken.rs
+++ b/crates/tokenizer/src/tiktoken.rs
@@ -14,20 +14,17 @@ use crate::{
         ChatTemplateState, ThinkingKeyName, ThinkingToggle,
     },
     factory::discover_chat_template_in_dir,
+    kimi_k2_tokenizer,
     traits::{Decoder, Encoder, Encoding, SpecialTokens, TokenIdType, Tokenizer as TokenizerTrait},
 };
 
 /// Regex pattern for cl100k_base tokenization.
 ///
-/// This pattern is correct for OpenAI models and most open-source tiktoken models (e.g.
-/// DeepSeek, Kimi K2). Some models use a different regex — for example, Kimi K2's native
-/// regex includes `\p{Han}` for Chinese character splitting — but encode/decode roundtrips
-/// still work correctly because BPE vocab handles tokenization; the regex only affects exact
-/// token boundary placement. A future enhancement could parse the regex from HuggingFace's
-/// `generation_config.json` or similar metadata.
-const CL100K_BASE_PATTERN: &str = r"(?i:'s|'t|'re|'ve|'m|'ll|'d)|[^\r\n\p{L}\p{N}]?\p{L}+|\p{N}{1,3}| ?[^\s\p{L}\p{N}]+[\r\n]*|\s*[\r\n]+|\s+(?!\S)|\s+";
+/// This pattern is correct for OpenAI models and most open-source tiktoken models. Models
+/// with a tokenizer-specific regex should build through a specialized tokenizer wrapper.
+pub(crate) const CL100K_BASE_PATTERN: &str = r"(?i:'s|'t|'re|'ve|'m|'ll|'d)|[^\r\n\p{L}\p{N}]?\p{L}+|\p{N}{1,3}| ?[^\s\p{L}\p{N}]+[\r\n]*|\s*[\r\n]+|\s+(?!\S)|\s+";
 
-type Rank = u32;
+pub(crate) type Rank = u32;
 
 // ---------------------------------------------------------------------------
 // Tiktoken-specific config parsing (from tokenizer_config.json)
@@ -35,15 +32,15 @@ type Rank = u32;
 
 /// Parsed `tokenizer_config.json` for tiktoken-based models.
 #[derive(Default)]
-struct TiktokenConfig {
-    special_tokens: SpecialTokens,
+pub(crate) struct TiktokenConfig {
+    pub(crate) special_tokens: SpecialTokens,
     /// Token string -> ID mapping from `added_tokens_decoder`
-    added_tokens: HashMap<String, TokenIdType>,
-    chat_template: Option<String>,
+    pub(crate) added_tokens: HashMap<String, TokenIdType>,
+    pub(crate) chat_template: Option<String>,
 }
 
 /// Parse `tokenizer_config.json` for tiktoken-based models.
-fn load_tiktoken_config(config_path: &Path) -> Result<TiktokenConfig> {
+pub(crate) fn load_tiktoken_config(config_path: &Path) -> Result<TiktokenConfig> {
     let content = std::fs::read_to_string(config_path)?;
     let config: serde_json::Value = serde_json::from_str(&content)?;
 
@@ -60,6 +57,15 @@ fn load_tiktoken_config(config_path: &Path) -> Result<TiktokenConfig> {
         added_tokens,
         chat_template,
     })
+}
+
+pub(crate) fn load_tiktoken_config_from_dir(dir: &Path) -> Result<TiktokenConfig> {
+    let config_path = dir.join("tokenizer_config.json");
+    if config_path.exists() {
+        load_tiktoken_config(&config_path)
+    } else {
+        Ok(TiktokenConfig::default())
+    }
 }
 
 /// Parse `added_tokens_decoder` from config JSON.
@@ -213,33 +219,51 @@ impl TiktokenTokenizer {
     }
 
     /// Core loading logic shared by `from_dir` and `from_file` constructors.
+    ///
+    /// Detects Kimi-K2/K2.5/K2.6 directories and specializes the regex and
+    /// reserved-special-token range without exposing a separate public type.
     fn load_from_path(tiktoken_path: &Path, chat_template_path: Option<&str>) -> Result<Self> {
-        // 1. Load BPE encoder from the exact file
         let tiktoken_path_str = tiktoken_path
             .to_str()
             .ok_or_else(|| Error::msg("Tiktoken file path is not valid UTF-8"))?;
         let encoder = load_tiktoken_bpe(tiktoken_path_str)?;
 
-        // 2. Parse tokenizer_config.json from the same directory
         let dir = tiktoken_path
             .parent()
             .ok_or_else(|| Error::msg("Cannot determine parent directory of tiktoken file"))?;
-        let config_path = dir.join("tokenizer_config.json");
-        let config = if config_path.exists() {
-            load_tiktoken_config(&config_path)?
+        let mut config = load_tiktoken_config_from_dir(dir)?;
+
+        let pattern = if kimi_k2_tokenizer::matches_dir(dir) {
+            kimi_k2_tokenizer::apply_reserved_special_tokens(
+                &mut config.added_tokens,
+                encoder.len(),
+            );
+            kimi_k2_tokenizer::KIMI_K2_PATTERN
         } else {
-            TiktokenConfig::default()
+            CL100K_BASE_PATTERN
         };
 
-        // 3. Build special tokens encoder for CoreBPE (needs FxHashMap)
+        Self::from_encoder_and_config(encoder, dir, chat_template_path, pattern, config)
+    }
+
+    /// Build a `TiktokenTokenizer` from already-prepared pieces. Crate-private
+    /// seam used by `load_from_path` after pattern/config specialization.
+    fn from_encoder_and_config(
+        encoder: FxHashMap<Vec<u8>, Rank>,
+        dir: &Path,
+        chat_template_path: Option<&str>,
+        pattern: &str,
+        config: TiktokenConfig,
+    ) -> Result<Self> {
+        // CoreBPE wants its special-tokens map as FxHashMap.
         let special_tokens_encoder: FxHashMap<String, Rank> = config
             .added_tokens
             .iter()
             .map(|(k, &v)| (k.clone(), v))
             .collect();
 
-        // 4. Calculate true vocab size from max token ID (handles sparse/reserved IDs),
-        //    build string-based vocab maps (borrows encoder), then pass encoder by value to CoreBPE
+        // True vocab size = max(token_id) + 1, which correctly handles sparse
+        // reserved-special-token IDs that sit above the dense BPE range.
         let vocab_size = encoder
             .values()
             .copied()
@@ -248,10 +272,11 @@ impl TiktokenTokenizer {
             .map(|id| id as usize + 1)
             .unwrap_or(0);
         let (vocab, reverse_vocab) = build_vocab_maps(&encoder, &config.added_tokens);
-        let tokenizer = CoreBPE::new(encoder, special_tokens_encoder, CL100K_BASE_PATTERN)?;
+        let tokenizer = CoreBPE::new(encoder, special_tokens_encoder, pattern)?;
 
-        // 5. Load chat template — propagate errors for explicit paths,
-        //    silently fall back for auto-discovery
+        // Chat template: explicit path is authoritative; otherwise prefer the
+        // template embedded in tokenizer_config.json, then fall back to
+        // sibling discovery.
         let chat_template = if let Some(p) = chat_template_path {
             load_chat_template_from_file(p)?
         } else {
@@ -261,7 +286,6 @@ impl TiktokenTokenizer {
             })
         };
 
-        // Load merged EOS token IDs from config.json + generation_config.json
         let eos_token_ids = crate::eos::load_eos_token_ids(dir);
 
         Ok(TiktokenTokenizer {
@@ -343,7 +367,7 @@ impl TiktokenTokenizer {
 /// Parse a .tiktoken / tiktoken.model file into a BPE encoder.
 ///
 /// Format: each line is `<base64-encoded-token-bytes> <rank>`
-fn load_tiktoken_bpe(path: &str) -> Result<FxHashMap<Vec<u8>, Rank>> {
+pub(crate) fn load_tiktoken_bpe(path: &str) -> Result<FxHashMap<Vec<u8>, Rank>> {
     let content = std::fs::read_to_string(path)?;
     let mut encoder =
         FxHashMap::with_capacity_and_hasher(content.lines().count(), Default::default());
@@ -394,7 +418,7 @@ fn build_vocab_maps(
 /// Find a tiktoken model file in the given directory.
 ///
 /// Looks for `tiktoken.model` first, then any `*.tiktoken` file.
-fn find_tiktoken_file(dir: &Path) -> Result<PathBuf> {
+pub(crate) fn find_tiktoken_file(dir: &Path) -> Result<PathBuf> {
     let tiktoken_model = dir.join("tiktoken.model");
     if tiktoken_model.exists() {
         return Ok(tiktoken_model);
@@ -473,6 +497,9 @@ impl Decoder for TiktokenTokenizer {
     fn decode(&self, token_ids: &[TokenIdType], _skip_special_tokens: bool) -> Result<String> {
         match self.tokenizer.decode(token_ids.to_vec()) {
             Ok(text) => Ok(text),
+            Err(err) if is_unknown_tiktoken_decode_error(&err) => Err(Error::msg(format!(
+                "tiktoken decode failed for unknown token id: {err}"
+            ))),
             Err(err) => {
                 // Fallback to lossy decoding for incomplete UTF-8 sequences
                 let bytes: Vec<u8> = self
@@ -489,6 +516,17 @@ impl Decoder for TiktokenTokenizer {
             }
         }
     }
+}
+
+/// Detect tiktoken's "unknown token id" error so we can surface a clean error
+/// instead of letting the lossy-decode fallback panic on a missing key.
+///
+/// We match on the `Display` string because tiktoken-rs's `DecodeKeyError` lives
+/// in a private `vendor_tiktoken` module and isn't re-exported (as of 0.9.1),
+/// so a typed `downcast_ref` is not available. The message format is stable —
+/// see `vendor_tiktoken::DecodeKeyError::fmt` upstream.
+fn is_unknown_tiktoken_decode_error(err: &Error) -> bool {
+    err.to_string().starts_with("Invalid token for decoding:")
 }
 
 impl TokenizerTrait for TiktokenTokenizer {
@@ -556,6 +594,21 @@ impl TokenizerTrait for TiktokenTokenizer {
 mod tests {
     use super::*;
     use crate::traits::{Decoder, Encoder, Tokenizer};
+
+    const MINIMAL_TIKTOKEN_MODEL: &str = "YQ== 0\nYg== 1\n";
+
+    fn write_minimal_tiktoken_dir(
+        tokenizer_config: &str,
+        model_config: Option<&str>,
+    ) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("tiktoken.model"), MINIMAL_TIKTOKEN_MODEL).unwrap();
+        std::fs::write(dir.path().join("tokenizer_config.json"), tokenizer_config).unwrap();
+        if let Some(model_config) = model_config {
+            std::fs::write(dir.path().join("config.json"), model_config).unwrap();
+        }
+        dir
+    }
 
     #[test]
     fn test_tiktoken_creation() {
@@ -752,6 +805,26 @@ mod tests {
         assert_eq!(tokens.get("[BOS]"), Some(&163584));
         assert_eq!(tokens.get("[EOS]"), Some(&163585));
         assert_eq!(tokens.get("<|im_end|>"), Some(&163586));
+    }
+
+    #[test]
+    fn test_tiktoken_unknown_token_decode_returns_error() {
+        let dir = write_minimal_tiktoken_dir(
+            r#"{
+                "added_tokens_decoder": {
+                    "2": { "content": "[BOS]", "special": true }
+                }
+            }"#,
+            None,
+        );
+        let tokenizer = TiktokenTokenizer::from_dir(dir.path()).unwrap();
+
+        let err = tokenizer.decode(&[4], false).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("tiktoken decode failed for unknown token id"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/crates/tokenizer/src/tiktoken.rs
+++ b/crates/tokenizer/src/tiktoken.rs
@@ -21,10 +21,10 @@ use crate::{
 /// Regex pattern for cl100k_base tokenization.
 ///
 /// This pattern is correct for OpenAI models and most open-source tiktoken models. Models
-/// with a tokenizer-specific regex should build through a specialized tokenizer wrapper.
-pub(crate) const CL100K_BASE_PATTERN: &str = r"(?i:'s|'t|'re|'ve|'m|'ll|'d)|[^\r\n\p{L}\p{N}]?\p{L}+|\p{N}{1,3}| ?[^\s\p{L}\p{N}]+[\r\n]*|\s*[\r\n]+|\s+(?!\S)|\s+";
+/// with a tokenizer-specific regex specialize the pattern inside `load_from_path`.
+const CL100K_BASE_PATTERN: &str = r"(?i:'s|'t|'re|'ve|'m|'ll|'d)|[^\r\n\p{L}\p{N}]?\p{L}+|\p{N}{1,3}| ?[^\s\p{L}\p{N}]+[\r\n]*|\s*[\r\n]+|\s+(?!\S)|\s+";
 
-pub(crate) type Rank = u32;
+type Rank = u32;
 
 // ---------------------------------------------------------------------------
 // Tiktoken-specific config parsing (from tokenizer_config.json)
@@ -32,15 +32,15 @@ pub(crate) type Rank = u32;
 
 /// Parsed `tokenizer_config.json` for tiktoken-based models.
 #[derive(Default)]
-pub(crate) struct TiktokenConfig {
-    pub(crate) special_tokens: SpecialTokens,
+struct TiktokenConfig {
+    special_tokens: SpecialTokens,
     /// Token string -> ID mapping from `added_tokens_decoder`
-    pub(crate) added_tokens: HashMap<String, TokenIdType>,
-    pub(crate) chat_template: Option<String>,
+    added_tokens: HashMap<String, TokenIdType>,
+    chat_template: Option<String>,
 }
 
 /// Parse `tokenizer_config.json` for tiktoken-based models.
-pub(crate) fn load_tiktoken_config(config_path: &Path) -> Result<TiktokenConfig> {
+fn load_tiktoken_config(config_path: &Path) -> Result<TiktokenConfig> {
     let content = std::fs::read_to_string(config_path)?;
     let config: serde_json::Value = serde_json::from_str(&content)?;
 
@@ -59,7 +59,7 @@ pub(crate) fn load_tiktoken_config(config_path: &Path) -> Result<TiktokenConfig>
     })
 }
 
-pub(crate) fn load_tiktoken_config_from_dir(dir: &Path) -> Result<TiktokenConfig> {
+fn load_tiktoken_config_from_dir(dir: &Path) -> Result<TiktokenConfig> {
     let config_path = dir.join("tokenizer_config.json");
     if config_path.exists() {
         load_tiktoken_config(&config_path)
@@ -219,20 +219,22 @@ impl TiktokenTokenizer {
     }
 
     /// Core loading logic shared by `from_dir` and `from_file` constructors.
-    ///
-    /// Detects Kimi-K2/K2.5/K2.6 directories and specializes the regex and
-    /// reserved-special-token range without exposing a separate public type.
     fn load_from_path(tiktoken_path: &Path, chat_template_path: Option<&str>) -> Result<Self> {
+        // 1. Load BPE encoder from the exact file
         let tiktoken_path_str = tiktoken_path
             .to_str()
             .ok_or_else(|| Error::msg("Tiktoken file path is not valid UTF-8"))?;
         let encoder = load_tiktoken_bpe(tiktoken_path_str)?;
 
+        // 2. Parse tokenizer_config.json from the same directory
         let dir = tiktoken_path
             .parent()
             .ok_or_else(|| Error::msg("Cannot determine parent directory of tiktoken file"))?;
         let mut config = load_tiktoken_config_from_dir(dir)?;
 
+        // Kimi-K2/K2.5/K2.6 specialize the regex and pre-fill 256 reserved
+        // special-token slots starting at `len(mergeable_ranks)`; all other
+        // tiktoken models use the cl100k pattern unchanged.
         let pattern = if kimi_k2_tokenizer::matches_dir(dir) {
             kimi_k2_tokenizer::apply_reserved_special_tokens(
                 &mut config.added_tokens,
@@ -243,27 +245,15 @@ impl TiktokenTokenizer {
             CL100K_BASE_PATTERN
         };
 
-        Self::from_encoder_and_config(encoder, dir, chat_template_path, pattern, config)
-    }
-
-    /// Build a `TiktokenTokenizer` from already-prepared pieces. Crate-private
-    /// seam used by `load_from_path` after pattern/config specialization.
-    fn from_encoder_and_config(
-        encoder: FxHashMap<Vec<u8>, Rank>,
-        dir: &Path,
-        chat_template_path: Option<&str>,
-        pattern: &str,
-        config: TiktokenConfig,
-    ) -> Result<Self> {
-        // CoreBPE wants its special-tokens map as FxHashMap.
+        // 3. Build special tokens encoder for CoreBPE (needs FxHashMap)
         let special_tokens_encoder: FxHashMap<String, Rank> = config
             .added_tokens
             .iter()
             .map(|(k, &v)| (k.clone(), v))
             .collect();
 
-        // True vocab size = max(token_id) + 1, which correctly handles sparse
-        // reserved-special-token IDs that sit above the dense BPE range.
+        // 4. Calculate true vocab size from max token ID (handles sparse/reserved IDs),
+        //    build string-based vocab maps (borrows encoder), then pass encoder by value to CoreBPE
         let vocab_size = encoder
             .values()
             .copied()
@@ -274,9 +264,8 @@ impl TiktokenTokenizer {
         let (vocab, reverse_vocab) = build_vocab_maps(&encoder, &config.added_tokens);
         let tokenizer = CoreBPE::new(encoder, special_tokens_encoder, pattern)?;
 
-        // Chat template: explicit path is authoritative; otherwise prefer the
-        // template embedded in tokenizer_config.json, then fall back to
-        // sibling discovery.
+        // 5. Load chat template — propagate errors for explicit paths,
+        //    silently fall back for auto-discovery
         let chat_template = if let Some(p) = chat_template_path {
             load_chat_template_from_file(p)?
         } else {
@@ -286,6 +275,7 @@ impl TiktokenTokenizer {
             })
         };
 
+        // Load merged EOS token IDs from config.json + generation_config.json
         let eos_token_ids = crate::eos::load_eos_token_ids(dir);
 
         Ok(TiktokenTokenizer {
@@ -367,7 +357,7 @@ impl TiktokenTokenizer {
 /// Parse a .tiktoken / tiktoken.model file into a BPE encoder.
 ///
 /// Format: each line is `<base64-encoded-token-bytes> <rank>`
-pub(crate) fn load_tiktoken_bpe(path: &str) -> Result<FxHashMap<Vec<u8>, Rank>> {
+fn load_tiktoken_bpe(path: &str) -> Result<FxHashMap<Vec<u8>, Rank>> {
     let content = std::fs::read_to_string(path)?;
     let mut encoder =
         FxHashMap::with_capacity_and_hasher(content.lines().count(), Default::default());
@@ -418,7 +408,7 @@ fn build_vocab_maps(
 /// Find a tiktoken model file in the given directory.
 ///
 /// Looks for `tiktoken.model` first, then any `*.tiktoken` file.
-pub(crate) fn find_tiktoken_file(dir: &Path) -> Result<PathBuf> {
+fn find_tiktoken_file(dir: &Path) -> Result<PathBuf> {
     let tiktoken_model = dir.join("tiktoken.model");
     if tiktoken_model.exists() {
         return Ok(tiktoken_model);

--- a/crates/tokenizer/src/tiktoken.rs
+++ b/crates/tokenizer/src/tiktoken.rs
@@ -39,33 +39,32 @@ struct TiktokenConfig {
     chat_template: Option<String>,
 }
 
-/// Parse `tokenizer_config.json` for tiktoken-based models.
-fn load_tiktoken_config(config_path: &Path) -> Result<TiktokenConfig> {
-    let content = std::fs::read_to_string(config_path)?;
-    let config: serde_json::Value = serde_json::from_str(&content)?;
-
-    let added_tokens = parse_added_tokens_decoder(&config);
-    let special_tokens = parse_special_tokens(&config);
-
-    let chat_template = config
-        .get("chat_template")
-        .and_then(|v| v.as_str())
-        .map(String::from);
-
-    Ok(TiktokenConfig {
-        special_tokens,
-        added_tokens,
-        chat_template,
-    })
+/// Parse an already-loaded `tokenizer_config.json` value into a `TiktokenConfig`.
+fn parse_tiktoken_config(value: &serde_json::Value) -> TiktokenConfig {
+    TiktokenConfig {
+        special_tokens: parse_special_tokens(value),
+        added_tokens: parse_added_tokens_decoder(value),
+        chat_template: value
+            .get("chat_template")
+            .and_then(|v| v.as_str())
+            .map(String::from),
+    }
 }
 
-fn load_tiktoken_config_from_dir(dir: &Path) -> Result<TiktokenConfig> {
+/// Load `tokenizer_config.json` from `dir`, returning both the parsed
+/// `TiktokenConfig` and the raw JSON value (so callers like Kimi detection
+/// can inspect the same parse without re-reading the file).
+fn load_tiktoken_config_from_dir(
+    dir: &Path,
+) -> Result<(TiktokenConfig, Option<serde_json::Value>)> {
     let config_path = dir.join("tokenizer_config.json");
-    if config_path.exists() {
-        load_tiktoken_config(&config_path)
-    } else {
-        Ok(TiktokenConfig::default())
+    if !config_path.exists() {
+        return Ok((TiktokenConfig::default(), None));
     }
+    let content = std::fs::read_to_string(&config_path)?;
+    let value: serde_json::Value = serde_json::from_str(&content)?;
+    let config = parse_tiktoken_config(&value);
+    Ok((config, Some(value)))
 }
 
 /// Parse `added_tokens_decoder` from config JSON.
@@ -230,12 +229,13 @@ impl TiktokenTokenizer {
         let dir = tiktoken_path
             .parent()
             .ok_or_else(|| Error::msg("Cannot determine parent directory of tiktoken file"))?;
-        let mut config = load_tiktoken_config_from_dir(dir)?;
+        let (mut config, tokenizer_config_value) = load_tiktoken_config_from_dir(dir)?;
 
         // Kimi-K2/K2.5/K2.6 specialize the regex and pre-fill 256 reserved
         // special-token slots starting at `len(mergeable_ranks)`; all other
-        // tiktoken models use the cl100k pattern unchanged.
-        let pattern = if kimi_k2_tokenizer::matches_dir(dir) {
+        // tiktoken models use the cl100k pattern unchanged. Reuse the
+        // already-parsed tokenizer_config.json so we don't re-read it.
+        let pattern = if kimi_k2_tokenizer::matches(tokenizer_config_value.as_ref(), dir) {
             kimi_k2_tokenizer::apply_reserved_special_tokens(
                 &mut config.added_tokens,
                 encoder.len(),

--- a/crates/tokenizer/src/tiktoken.rs
+++ b/crates/tokenizer/src/tiktoken.rs
@@ -856,6 +856,14 @@ mod tests {
     }
 
     #[test]
+    fn test_load_tiktoken_config_from_dir_missing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let (config, value) = load_tiktoken_config_from_dir(dir.path()).unwrap();
+        assert!(value.is_none());
+        assert!(config.added_tokens.is_empty());
+    }
+
+    #[test]
     fn test_decode_lossy_fallback_for_invalid_utf8() {
         // cl100k_base maps individual bytes to token IDs via its byte-level BPE.
         // Encode a multi-byte UTF-8 character, then decode only a prefix of its


### PR DESCRIPTION
## Description

### Problem

Kimi K2 / K2.5 / K2.6 ship tiktoken-style vocabs alongside their HF repos. Their `tokenizer_config.json` enumerates a handful of named special tokens (e.g. `<|im_assistant|>` at ID 163588), but does **not** enumerate every slot in the 256-slot reserved-special-token range that upstream `tokenization_kimi.py` synthesizes via:

```python
{special_tokens_mapping.get(i, f"<|reserved_token_{i}|>"): i
 for i in range(num_base_tokens, num_base_tokens + 256)}
```

The generic `TiktokenTokenizer` only registered IDs present in `tiktoken.model` or `added_tokens_decoder`, so unnamed reserved IDs were unknown to `CoreBPE`. Decoding a sequence that contained one fell through into `_decode_native_and_split`, which indexes `special_tokens_decoder[&token]` directly — **panic** on the missing key.

There is also a pre-tokenizer mismatch: Kimi's regex begins with `[\p{Han}]+` and uses character-class intersection (`[X&&[^\p{Han}]]`) so Han chars are split from the letter/contraction branches. The generic path used the cl100k regex, mangling Han-heavy inputs.

Fixes #1475.

### Solution

Detect Kimi inside `TiktokenTokenizer::load_from_path` and specialize two things:
1. **Pattern** — use the Han-aware regex (byte-identical to upstream `pat_str`, verified against K2-Thinking, K2.5, and K2.6 — all three `tokenization_kimi.py` files are identical on the BPE-relevant fields).
2. **Reserved slots** — fill 256 entries at `[len(mergeable_ranks), len(mergeable_ranks)+256)` with `<|reserved_token_{id}|>`, skipping any IDs already occupied by explicit `added_tokens_decoder` entries.

Detection lives in a crate-private `kimi_k2_tokenizer` helper module and exposes only three items to `tiktoken.rs`: the regex constant, `matches_dir`, and `apply_reserved_special_tokens`. There is no separate public `KimiK2Tokenizer` type and no change to `factory.rs` — Kimi support is transparent at the call surface, so future tiktoken variants (LLaMA-3-tiktoken, etc.) can follow the same pattern without growing a dispatch table.

Detection matches all three Kimi variants:
- Primary: `tokenizer_config.json` mentions `tokenization_kimi` (via `auto_map`, `tokenizer_class`, etc.).
- Fallback: `config.json::model_type` ∈ `{kimi_k2, kimi_k25}`. K2-Thinking reports `kimi_k2`; K2.5 and K2.6 both report `kimi_k25`. The architecture string is intentionally **not** checked — K2-Thinking shares `DeepseekV3ForCausalLM` with vanilla DeepSeek and would false-positive.

Separately, the generic tiktoken decode path now returns a clean `Err` on truly unknown token IDs instead of falling into the lossy-byte path that panics. The guard matches tiktoken-rs's `DecodeKeyError` Display message; the typed error lives in a private module (`vendor_tiktoken`) and isn't re-exported as of tiktoken-rs 0.9.1, so a typed downcast isn't available.

## Changes

- `crates/tokenizer/src/kimi_k2_tokenizer.rs` (new, crate-private): `KIMI_K2_PATTERN`, `matches_dir`, `apply_reserved_special_tokens`, and helpers for the two-tier detection.
- `crates/tokenizer/src/tiktoken.rs`: `load_from_path` now consults the Kimi module, picks the pattern, pre-fills reserved slots before constructing `CoreBPE`; `from_encoder_and_config` is now private. `decode` returns a structured error on unknown IDs instead of letting `_decode_native_and_split` panic.
- `crates/tokenizer/src/lib.rs`: `mod kimi_k2_tokenizer` (was `pub mod`); the helper module has no public surface.

## Test Plan

`cargo test -p llm-tokenizer --lib` — 132/132 pass, including five new Kimi tests:

- `reserved_special_tokens_are_synthesized` — 256 slots filled, explicit names preserved, vocab_size correct, decode/encode of synthetic reserved IDs round-trips.
- `matches_via_model_type_kimi_k2` — `model_type: "kimi_k2"` (K2-Thinking) triggers Kimi load path.
- `matches_via_model_type_kimi_k25` — `model_type: "kimi_k25"` (K2.5 + K2.6) triggers Kimi load path.
- `uses_kimi_pattern_for_contractions` — the Kimi regex matches `hello's` as one chunk (cl100k would split before `'s`).
- `han_input_round_trips_through_kimi_pattern` — Han + ASCII mixed input encodes without panic and decodes byte-equal. Guards the fancy-regex character-class-intersection compatibility risk.

`cargo clippy -p llm-tokenizer --lib --tests --no-deps` clean.
`cargo +nightly fmt -p llm-tokenizer -- --check` clean.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic detection and support for Kimi K2/K2.5/K2.6 tokenizers, including Han-aware tokenization and improved contraction handling.
  * Synthesized reserved special-token ranges to avoid ID conflicts.

* **Bug Fixes**
  * Clearer user-facing error when decoding unknown token IDs.
  * More robust loading when tokenizer config file is absent.

* **Tests**
  * Added tests for tokenizer detection, reserved-token synthesis, missing-config handling, and decode error behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightseekorg/smg/pull/1482)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->