### PR TITLE
test(e2e): stabilize Mistral required streaming

### DIFF
--- a/e2e_test/chat_completions/test_function_calling.py
+++ b/e2e_test/chat_completions/test_function_calling.py
@@ -1055,6 +1055,7 @@ class _TestToolChoiceBase:
             model=model,
             messages=messages,
             max_tokens=2048,
+            temperature=0.1,
             tools=tools,
             tool_choice="required",
             stream=True,


### PR DESCRIPTION
## Description

### Problem

After PR #1478 merged, `TestToolChoiceMistral.test_tool_choice_required_streaming` started showing flakiness: required streaming sometimes produced no streamed tool-call chunks. The comparable non-streaming required test already pins `temperature=0.2`, and the stricter required streaming arguments test pins `temperature=0.1`; this smoke test was still using the backend default sampling temperature.

### Solution

Pin the Mistral required streaming smoke test to `temperature=0.1` so the assertion exercises streaming tool-call plumbing instead of sampling variance. I also checked the Mistral e2e setup: it uses the model default chat template and `--tool-call-parser mistral`; no special chat template is injected. The Mistral path still uses the structural-tag constraint from `MistralParser::build_structural_tag`.

## Changes

- Set `temperature=0.1` for `test_tool_choice_required_streaming` in the shared tool-choice e2e base.

## Test Plan

- `python3 -m py_compile e2e_test/chat_completions/test_function_calling.py`
- GPU e2e not run locally; this should be validated by the PR e2e matrix, with the Mistral required streaming job rerun a few times to confirm the flake rate drops.

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This release contains internal test enhancements with no user-visible changes.

* **Tests**
  * Improved streaming function calling test coverage with adjusted test parameters.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightseekorg/smg/pull/1483)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->