### PR TITLE
fix(worker): honor explicit worker connection schemes

### DIFF
--- a/model_gateway/src/workflow/steps/local/detect_connection.rs
+++ b/model_gateway/src/workflow/steps/local/detect_connection.rs
@@ -16,9 +16,21 @@ use crate::{
     },
 };
 
+fn explicit_connection_mode(url: &str) -> Option<ConnectionMode> {
+    let normalized_url = url.to_ascii_lowercase();
+    if normalized_url.starts_with("grpc://") {
+        Some(ConnectionMode::Grpc)
+    } else if normalized_url.starts_with("http://") || normalized_url.starts_with("https://") {
+        Some(ConnectionMode::Http)
+    } else {
+        None
+    }
+}
+
 /// Step 1: Detect connection mode (HTTP vs gRPC).
 ///
-/// Probes both protocols in parallel. HTTP takes priority if both succeed.
+/// Explicit URL schemes are honored. For bare host:port URLs, probes both
+/// protocols in parallel and HTTP takes priority if both succeed.
 /// Does NOT detect backend runtime — that's handled by DetectBackendStep.
 pub struct DetectConnectionModeStep;
 
@@ -51,6 +63,37 @@ impl StepExecutor<WorkerWorkflowData> for DetectConnectionModeStep {
             .unwrap_or(app_context.router_config.health_check.timeout_secs);
         let client = &app_context.client;
 
+        if let Some(connection_mode) = explicit_connection_mode(&url) {
+            let result = match connection_mode {
+                ConnectionMode::Http => try_http_reachable(&url, timeout, client).await,
+                ConnectionMode::Grpc => try_grpc_reachable(&url, timeout).await,
+            };
+
+            match result {
+                Ok(()) => {
+                    debug!(
+                        "{} explicitly configured as {}",
+                        config.url, connection_mode
+                    );
+                    context.data.connection_mode = Some(connection_mode);
+                    return Ok(StepResult::Success);
+                }
+                Err(err) => {
+                    let protocol = match connection_mode {
+                        ConnectionMode::Http => "HTTP",
+                        ConnectionMode::Grpc => "gRPC",
+                    };
+                    return Err(WorkflowError::StepFailed {
+                        step_id: StepId::new("detect_connection_mode"),
+                        message: format!(
+                            "{protocol} health check failed for explicit {} worker URL {}: {}",
+                            connection_mode, config.url, err
+                        ),
+                    });
+                }
+            }
+        }
+
         let (http_result, grpc_result) = tokio::join!(
             try_http_reachable(&url, timeout, client),
             try_grpc_reachable(&url, timeout)
@@ -82,5 +125,35 @@ impl StepExecutor<WorkerWorkflowData> for DetectConnectionModeStep {
 
     fn is_retryable(&self, _error: &WorkflowError) -> bool {
         true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn explicit_connection_mode_honors_grpc_scheme() {
+        assert_eq!(
+            explicit_connection_mode("grpc://localhost:30001"),
+            Some(ConnectionMode::Grpc)
+        );
+    }
+
+    #[test]
+    fn explicit_connection_mode_honors_http_schemes() {
+        assert_eq!(
+            explicit_connection_mode("http://localhost:30000"),
+            Some(ConnectionMode::Http)
+        );
+        assert_eq!(
+            explicit_connection_mode("https://example.com"),
+            Some(ConnectionMode::Http)
+        );
+    }
+
+    #[test]
+    fn explicit_connection_mode_leaves_bare_urls_for_probe_detection() {
+        assert_eq!(explicit_connection_mode("localhost:30000"), None);
     }
 }


### PR DESCRIPTION
```markdown
## Description

### Problem

Explicit worker URL schemes were not fully respected during local connection mode detection. A worker configured with `grpc://host:port` could still be probed over HTTP, and if the HTTP health check succeeded, the worker could be classified as `ConnectionMode::Http` despite the explicit gRPC scheme.

### Solution

Honor explicit URL schemes before falling back to auto-detection:

- `grpc://...` runs only the gRPC reachability check and sets `ConnectionMode::Grpc`
- `http://...` and `https://...` run only the HTTP reachability check and set `ConnectionMode::Http`
- bare `host:port` URLs keep the existing behavior of probing both protocols, with HTTP priority if both pass

## Changes

- Added explicit scheme classification for local worker connection detection.
- Short-circuited detection for explicit HTTP/gRPC worker URLs.
- Preserved existing auto-detection behavior for bare worker URLs.
- Added unit tests for explicit gRPC, explicit HTTP(S), and bare URL handling.

## Test Plan

Reproduced the issue by reviewing `DetectConnectionModeStep`: before this change, all URLs were passed into both HTTP and gRPC probes, so `grpc://...` could still be selected as HTTP when `/health` responded.

After this change, explicit schemes are handled before the auto-detection block, so `grpc://...` no longer falls through to HTTP probing.


<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Connection detection now respects explicit URL schemes (grpc://, http://, https://), performing targeted health checks for the specified protocol with clear error messages if the connection fails. Bare host:port URLs retain existing probing behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightseekorg/smg/pull/1484)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->