### PR TITLE
fix(worker): honor explicit worker connection schemes

### DIFF
--- a/crates/grpc_client/src/mlx_engine.rs
+++ b/crates/grpc_client/src/mlx_engine.rs
@@ -124,6 +124,8 @@ impl MlxEngineClient {
 
         let http_endpoint = if let Some(addr) = endpoint.strip_prefix("grpc://") {
             format!("http://{addr}")
+        } else if let Some(addr) = endpoint.strip_prefix("grpcs://") {
+            format!("https://{addr}")
         } else {
             endpoint.to_string()
         };

--- a/crates/grpc_client/src/sglang_scheduler.rs
+++ b/crates/grpc_client/src/sglang_scheduler.rs
@@ -142,9 +142,11 @@ impl SglangSchedulerClient {
     ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
         debug!("Connecting to SGLang scheduler at {}", endpoint);
 
-        // Convert grpc:// to http:// for tonic
+        // Convert gRPC schemes to tonic-compatible HTTP(S) endpoints.
         let http_endpoint = if let Some(addr) = endpoint.strip_prefix("grpc://") {
             format!("http://{addr}")
+        } else if let Some(addr) = endpoint.strip_prefix("grpcs://") {
+            format!("https://{addr}")
         } else {
             endpoint.to_string()
         };

--- a/crates/grpc_client/src/trtllm_service.rs
+++ b/crates/grpc_client/src/trtllm_service.rs
@@ -141,9 +141,11 @@ impl TrtllmServiceClient {
     ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
         debug!("Connecting to TensorRT-LLM gRPC server at {}", endpoint);
 
-        // Convert grpc:// to http:// for tonic
+        // Convert gRPC schemes to tonic-compatible HTTP(S) endpoints.
         let http_endpoint = if let Some(addr) = endpoint.strip_prefix("grpc://") {
             format!("http://{addr}")
+        } else if let Some(addr) = endpoint.strip_prefix("grpcs://") {
+            format!("https://{addr}")
         } else {
             endpoint.to_string()
         };

--- a/crates/grpc_client/src/vllm_engine.rs
+++ b/crates/grpc_client/src/vllm_engine.rs
@@ -142,9 +142,11 @@ impl VllmEngineClient {
     ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
         debug!("Connecting to vLLM gRPC server at {}", endpoint);
 
-        // Convert grpc:// to http:// for tonic
+        // Convert gRPC schemes to tonic-compatible HTTP(S) endpoints.
         let http_endpoint = if let Some(addr) = endpoint.strip_prefix("grpc://") {
             format!("http://{addr}")
+        } else if let Some(addr) = endpoint.strip_prefix("grpcs://") {
+            format!("https://{addr}")
         } else {
             endpoint.to_string()
         };

--- a/model_gateway/src/config/validation.rs
+++ b/model_gateway/src/config/validation.rs
@@ -835,10 +835,12 @@ impl ConfigValidator {
                 });
             }
 
-            if !url.starts_with("http://")
-                && !url.starts_with("https://")
-                && !url.starts_with("grpc://")
-                && !url.starts_with("grpcs://")
+            // Perform case-insensitive scheme check
+            let url_lower = url.to_ascii_lowercase();
+            if !url_lower.starts_with("http://")
+                && !url_lower.starts_with("https://")
+                && !url_lower.starts_with("grpc://")
+                && !url_lower.starts_with("grpcs://")
             {
                 return Err(ConfigError::InvalidValue {
                     field: "worker_url".to_string(),

--- a/model_gateway/src/config/validation.rs
+++ b/model_gateway/src/config/validation.rs
@@ -838,11 +838,13 @@ impl ConfigValidator {
             if !url.starts_with("http://")
                 && !url.starts_with("https://")
                 && !url.starts_with("grpc://")
+                && !url.starts_with("grpcs://")
             {
                 return Err(ConfigError::InvalidValue {
                     field: "worker_url".to_string(),
                     value: url.clone(),
-                    reason: "URL must start with http://, https://, or grpc://".to_string(),
+                    reason: "URL must start with http://, https://, grpc://, or grpcs://"
+                        .to_string(),
                 });
             }
 
@@ -1224,6 +1226,22 @@ mod tests {
         let mut config = RouterConfig::new(
             RoutingMode::Regular {
                 worker_urls: vec!["grpc://worker:50051".to_string()],
+            },
+            PolicyConfig::Random,
+        );
+
+        config.connection_mode = ConnectionMode::Grpc;
+        config.model_path = Some("meta-llama/Llama-3-8B".to_string());
+
+        let result = ConfigValidator::validate(&config);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_validate_grpcs_worker_url() {
+        let mut config = RouterConfig::new(
+            RoutingMode::Regular {
+                worker_urls: vec!["grpcs://worker:50051".to_string()],
             },
             PolicyConfig::Random,
         );

--- a/model_gateway/src/workflow/steps/local/create_worker.rs
+++ b/model_gateway/src/workflow/steps/local/create_worker.rs
@@ -298,12 +298,53 @@ fn infer_non_generation_type(labels: &HashMap<String, String>) -> ModelType {
 }
 
 fn normalize_url(url: &str, connection_mode: ConnectionMode) -> String {
-    if url.starts_with("http://") || url.starts_with("https://") || url.starts_with("grpc://") {
+    if url.starts_with("http://")
+        || url.starts_with("https://")
+        || url.starts_with("grpc://")
+        || url.starts_with("grpcs://")
+    {
         url.to_string()
     } else {
         match connection_mode {
             ConnectionMode::Http => format!("http://{url}"),
             ConnectionMode::Grpc => format!("grpc://{url}"),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_url_preserves_existing_schemes() {
+        assert_eq!(
+            normalize_url("http://localhost:30000", ConnectionMode::Http),
+            "http://localhost:30000"
+        );
+        assert_eq!(
+            normalize_url("https://localhost:30000", ConnectionMode::Http),
+            "https://localhost:30000"
+        );
+        assert_eq!(
+            normalize_url("grpc://localhost:30001", ConnectionMode::Grpc),
+            "grpc://localhost:30001"
+        );
+        assert_eq!(
+            normalize_url("grpcs://localhost:30001", ConnectionMode::Grpc),
+            "grpcs://localhost:30001"
+        );
+    }
+
+    #[test]
+    fn normalize_url_adds_scheme_for_bare_urls() {
+        assert_eq!(
+            normalize_url("localhost:30000", ConnectionMode::Http),
+            "http://localhost:30000"
+        );
+        assert_eq!(
+            normalize_url("localhost:30001", ConnectionMode::Grpc),
+            "grpc://localhost:30001"
+        );
     }
 }

--- a/model_gateway/src/workflow/steps/local/detect_connection.rs
+++ b/model_gateway/src/workflow/steps/local/detect_connection.rs
@@ -16,9 +16,20 @@ use crate::{
     },
 };
 
+fn explicit_connection_mode(url: &str) -> Option<ConnectionMode> {
+    if url.starts_with("grpc://") || url.starts_with("grpcs://") {
+        Some(ConnectionMode::Grpc)
+    } else if url.starts_with("http://") || url.starts_with("https://") {
+        Some(ConnectionMode::Http)
+    } else {
+        None
+    }
+}
+
 /// Step 1: Detect connection mode (HTTP vs gRPC).
 ///
-/// Probes both protocols in parallel. HTTP takes priority if both succeed.
+/// Explicit URL schemes are honored. For bare host:port URLs, probes both
+/// protocols in parallel and HTTP takes priority if both succeed.
 /// Does NOT detect backend runtime — that's handled by DetectBackendStep.
 pub struct DetectConnectionModeStep;
 
@@ -51,6 +62,33 @@ impl StepExecutor<WorkerWorkflowData> for DetectConnectionModeStep {
             .unwrap_or(app_context.router_config.health_check.timeout_secs);
         let client = &app_context.client;
 
+        if let Some(connection_mode) = explicit_connection_mode(&url) {
+            let result = match connection_mode {
+                ConnectionMode::Http => try_http_reachable(&url, timeout, client).await,
+                ConnectionMode::Grpc => try_grpc_reachable(&url, timeout).await,
+            };
+
+            match result {
+                Ok(()) => {
+                    debug!(
+                        "{} explicitly configured as {}",
+                        config.url, connection_mode
+                    );
+                    context.data.connection_mode = Some(connection_mode);
+                    return Ok(StepResult::Success);
+                }
+                Err(err) => {
+                    return Err(WorkflowError::StepFailed {
+                        step_id: StepId::new("detect_connection_mode"),
+                        message: format!(
+                            "{connection_mode} health check failed for explicitly configured worker URL {}: {}",
+                            config.url, err
+                        ),
+                    });
+                }
+            }
+        }
+
         let (http_result, grpc_result) = tokio::join!(
             try_http_reachable(&url, timeout, client),
             try_grpc_reachable(&url, timeout)
@@ -82,5 +120,39 @@ impl StepExecutor<WorkerWorkflowData> for DetectConnectionModeStep {
 
     fn is_retryable(&self, _error: &WorkflowError) -> bool {
         true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn explicit_connection_mode_honors_grpc_scheme() {
+        assert_eq!(
+            explicit_connection_mode("grpc://localhost:30001"),
+            Some(ConnectionMode::Grpc)
+        );
+        assert_eq!(
+            explicit_connection_mode("grpcs://localhost:30001"),
+            Some(ConnectionMode::Grpc)
+        );
+    }
+
+    #[test]
+    fn explicit_connection_mode_honors_http_schemes() {
+        assert_eq!(
+            explicit_connection_mode("http://localhost:30000"),
+            Some(ConnectionMode::Http)
+        );
+        assert_eq!(
+            explicit_connection_mode("https://example.com"),
+            Some(ConnectionMode::Http)
+        );
+    }
+
+    #[test]
+    fn explicit_connection_mode_leaves_bare_urls_for_probe_detection() {
+        assert_eq!(explicit_connection_mode("localhost:30000"), None);
     }
 }

--- a/model_gateway/src/workflow/steps/util.rs
+++ b/model_gateway/src/workflow/steps/util.rs
@@ -6,29 +6,68 @@ use reqwest::Client;
 
 use crate::routers::grpc::client::GrpcClient;
 
-/// Strip protocol prefix (http://, https://, grpc://) from URL.
-pub(crate) fn strip_protocol(url: &str) -> String {
-    url.trim_start_matches("http://")
-        .trim_start_matches("https://")
-        .trim_start_matches("grpc://")
-        .to_string()
+fn strip_scheme<'a>(url: &'a str, scheme: &str) -> Option<&'a str> {
+    url.get(..scheme.len())
+        .filter(|prefix| prefix.eq_ignore_ascii_case(scheme))
+        .map(|_| &url[scheme.len()..])
 }
 
-/// Ensure URL has an HTTP(S) scheme — handles bare `host:port` and `grpc://` inputs.
+fn url_scheme(url: &str) -> Option<String> {
+    url.split_once("://")
+        .map(|(scheme, _)| scheme.to_ascii_lowercase())
+}
+
+/// Strip protocol prefix (http://, https://, grpc://, grpcs://) from URL.
+pub(crate) fn strip_protocol(url: &str) -> String {
+    for scheme in ["http://", "https://", "grpc://", "grpcs://"] {
+        if let Some(rest) = strip_scheme(url, scheme) {
+            return rest.to_string();
+        }
+    }
+    url.to_string()
+}
+
+/// Ensure URL has an HTTP(S) scheme — handles bare `host:port` and gRPC inputs.
 pub(crate) fn http_base_url(url: &str) -> String {
-    if url.starts_with("http://") || url.starts_with("https://") {
+    if strip_scheme(url, "http://").is_some() || strip_scheme(url, "https://").is_some() {
         url.trim_end_matches('/').to_string()
     } else {
         format!("http://{}", strip_protocol(url).trim_end_matches('/'))
     }
 }
 
-/// Ensure URL has a gRPC scheme — handles bare `host:port` and `http://` inputs.
+/// Ensure URL has a gRPC scheme — handles bare `host:port` and HTTP(S) inputs.
 pub(crate) fn grpc_base_url(url: &str) -> String {
-    if url.starts_with("grpc://") {
+    if strip_scheme(url, "grpc://").is_some() || strip_scheme(url, "grpcs://").is_some() {
         url.trim_end_matches('/').to_string()
     } else {
         format!("grpc://{}", strip_protocol(url).trim_end_matches('/'))
+    }
+}
+
+fn http_health_url(url: &str) -> Result<String, String> {
+    match url_scheme(url).as_deref() {
+        Some("http") | Some("https") => Ok(format!("{}/health", url.trim_end_matches('/'))),
+        Some("grpc") | Some("grpcs") => Err(format!(
+            "HTTP health check does not accept gRPC URL scheme: {url}"
+        )),
+        Some(scheme) => Err(format!(
+            "HTTP health check does not accept URL scheme '{scheme}': {url}"
+        )),
+        None => Ok(format!("http://{}/health", url.trim_end_matches('/'))),
+    }
+}
+
+fn grpc_reachable_url(url: &str) -> Result<String, String> {
+    match url_scheme(url).as_deref() {
+        Some("grpc") | Some("grpcs") => Ok(url.trim_end_matches('/').to_string()),
+        Some("http") | Some("https") => Err(format!(
+            "gRPC health check does not accept HTTP URL scheme: {url}"
+        )),
+        Some(scheme) => Err(format!(
+            "gRPC health check does not accept URL scheme '{scheme}': {url}"
+        )),
+        None => Ok(format!("grpc://{}", url.trim_end_matches('/'))),
     }
 }
 
@@ -38,10 +77,7 @@ pub(crate) async fn try_http_reachable(
     timeout_secs: u64,
     client: &Client,
 ) -> Result<(), String> {
-    let is_https = url.starts_with("https://");
-    let protocol = if is_https { "https" } else { "http" };
-    let clean_url = strip_protocol(url);
-    let health_url = format!("{protocol}://{clean_url}/health");
+    let health_url = http_health_url(url)?;
 
     client
         .get(&health_url)
@@ -82,11 +118,7 @@ pub(crate) async fn do_grpc_health_check(
 /// We don't care which runtime it is here — that's `DetectBackendStep`'s job.
 /// We just need to know: does this endpoint speak gRPC at all?
 pub(crate) async fn try_grpc_reachable(url: &str, timeout_secs: u64) -> Result<(), String> {
-    let grpc_url = if url.starts_with("grpc://") {
-        url.to_string()
-    } else {
-        format!("grpc://{}", strip_protocol(url))
-    };
+    let grpc_url = grpc_reachable_url(url)?;
 
     let (sglang, vllm, trtllm, mlx) = tokio::join!(
         do_grpc_health_check(&grpc_url, timeout_secs, "sglang"),
@@ -100,5 +132,54 @@ pub(crate) async fn try_grpc_reachable(url: &str, timeout_secs: u64) -> Result<(
         (Err(e1), Err(e2), Err(e3), Err(e4)) => Err(format!(
             "gRPC not reachable (tried sglang, vllm, trtllm, mlx): sglang={e1}, vllm={e2}, trtllm={e3}, mlx={e4}",
         )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn http_health_url_accepts_http_https_and_bare_urls() {
+        assert_eq!(
+            http_health_url("http://localhost:30000").unwrap(),
+            "http://localhost:30000/health"
+        );
+        assert_eq!(
+            http_health_url("https://example.com/").unwrap(),
+            "https://example.com/health"
+        );
+        assert_eq!(
+            http_health_url("localhost:30000").unwrap(),
+            "http://localhost:30000/health"
+        );
+    }
+
+    #[test]
+    fn http_health_url_rejects_grpc_schemes() {
+        assert!(http_health_url("grpc://localhost:30001").is_err());
+        assert!(http_health_url("grpcs://localhost:30001").is_err());
+    }
+
+    #[test]
+    fn grpc_reachable_url_accepts_grpc_grpcs_and_bare_urls() {
+        assert_eq!(
+            grpc_reachable_url("grpc://localhost:30001").unwrap(),
+            "grpc://localhost:30001"
+        );
+        assert_eq!(
+            grpc_reachable_url("grpcs://localhost:30001/").unwrap(),
+            "grpcs://localhost:30001"
+        );
+        assert_eq!(
+            grpc_reachable_url("localhost:30001").unwrap(),
+            "grpc://localhost:30001"
+        );
+    }
+
+    #[test]
+    fn grpc_reachable_url_rejects_http_schemes() {
+        assert!(grpc_reachable_url("http://localhost:30000").is_err());
+        assert!(grpc_reachable_url("https://localhost:30000").is_err());
     }
 }


### PR DESCRIPTION
## Description

### Problem

Explicit worker URL schemes were not fully respected during local connection mode detection. A worker configured with `grpc://host:port` could still be probed over HTTP, and if the HTTP health check succeeded, the worker could be classified as `ConnectionMode::Http` despite the explicit gRPC scheme.

### Solution

Honor explicit URL schemes before falling back to auto-detection:

- `grpc://...` runs only the gRPC reachability check and sets `ConnectionMode::Grpc`
- `http://...` and `https://...` run only the HTTP reachability check and set `ConnectionMode::Http`
- bare `host:port` URLs keep the existing behavior of probing both protocols, with HTTP priority if both pass

## Changes

- Added explicit scheme classification for local worker connection detection.
- Short-circuited detection for explicit HTTP/gRPC worker URLs.
- Preserved existing auto-detection behavior for bare worker URLs.
- Added unit tests for explicit gRPC, explicit HTTP(S), and bare URL handling.

## Test Plan

Reproduced the issue by reviewing `DetectConnectionModeStep`: before this change, all URLs were passed into both HTTP and gRPC probes, so `grpc://...` could still be selected as HTTP when `/health` responded.

After this change, explicit schemes are handled before the auto-detection block, so `grpc://...` no longer falls through to HTTP probing.


<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for secure gRPC endpoints (grpcs://) by normalizing them to HTTPS for client connections.
  * Connection detection now honors explicit URL schemes (http/https vs grpc/grpcs) and runs only the matching protocol probe.

* **Tests**
  * Added unit tests for scheme recognition, URL normalization, and reachability behavior.

* **Documentation/Validation**
  * Configuration validation updated to accept grpcs:// worker URLs and reflect this in messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightseekorg/smg/pull/1485)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->