### PR TITLE
perf(e2e): pool local workers across classes and cluster tests by config

### DIFF
--- a/e2e_test/conftest.py
+++ b/e2e_test/conftest.py
@@ -19,8 +19,12 @@ Markers
 
 Fixtures
 --------
-setup_backend: Class-scoped fixture that launches workers + gateway per test class.
-    Returns (backend_name, model_path, client, gateway).
+setup_backend: Class-scoped fixture that launches (or reuses) workers and a
+    fresh gateway per test class. Workers for non-PD local backends are
+    pooled across classes that share ``(model_id, engine, mode, count)`` so
+    cold-start cost is paid once per distinct config per session. Set
+    ``E2E_DISABLE_WORKER_POOL=1`` to fall back to per-class worker
+    start/stop. Returns ``(backend_name, model_path, client, gateway)``.
 model: Convenience fixture that returns just the model_path from setup_backend.
 """
 
@@ -108,6 +112,7 @@ from fixtures import (
     pytest_collection_modifyitems,
     pytest_configure,
     pytest_runtest_setup,
+    pytest_sessionfinish,
     setup_backend,
 )
 from smg_client import SmgClient
@@ -151,6 +156,7 @@ __all__ = [
     "pytest_runtest_setup",
     "pytest_collection_modifyitems",
     "pytest_configure",
+    "pytest_sessionfinish",
     # Fixtures
     "setup_backend",
     "backend_router",

--- a/e2e_test/fixtures/__init__.py
+++ b/e2e_test/fixtures/__init__.py
@@ -12,6 +12,7 @@ from .hooks import (
     pytest_collection_modifyitems,
     pytest_configure,
     pytest_runtest_setup,
+    pytest_sessionfinish,
 )
 
 # Marker helpers
@@ -25,6 +26,7 @@ __all__ = [
     "pytest_collection_modifyitems",
     "pytest_configure",
     "pytest_runtest_setup",
+    "pytest_sessionfinish",
     # Backend fixtures
     "setup_backend",
     "backend_router",

--- a/e2e_test/fixtures/hooks.py
+++ b/e2e_test/fixtures/hooks.py
@@ -3,16 +3,23 @@
 This module handles:
 - Marker registration: Defining custom pytest markers
 - Test filtering: Env-var-based filtering by engine, vendor, and GPU tier
+- Test ordering: Cluster items by backend config so the session-scoped
+  worker pool in ``setup_backend`` can amortize cold starts across classes.
+- Session cleanup: Stop any pooled workers at session end.
 """
 
 from __future__ import annotations
 
+import logging
 import os
 
 import pytest
 from infra import get_runtime
 
 from .markers import resolve_class_marker
+from .setup_backend import shutdown_worker_pool
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Marker registration
@@ -106,36 +113,127 @@ def _get_marker(item: pytest.Item, name: str):
     return resolve_class_marker(item, name)
 
 
+def _parametrize_argnames_to_set(argnames: object) -> set[str]:
+    if isinstance(argnames, str):
+        return {n.strip() for n in argnames.split(",") if n.strip()}
+    if isinstance(argnames, (tuple, list)):
+        return {str(n) for n in argnames}
+    return set()
+
+
+def _class_level_backend_sort_token(item: pytest.Item) -> str | None:
+    """Stable token from class ``pytestmark`` ``parametrize`` for backend fixtures.
+
+    When ``setup_backend`` / ``backend_router`` are parametrized on the class,
+    using only ``callspec.params`` splits items by concrete value and scatters
+    them in the global sort. Aggregating class-level ``parametrize`` keeps all
+    variants of that class adjacent (stable sort preserves intra-class order).
+    """
+    cls = getattr(item, "cls", None)
+    if cls is None:
+        return None
+    tokens: list[str] = []
+    for base in cls.__mro__:
+        if base is object:
+            continue
+        marks = getattr(base, "pytestmark", None)
+        if marks is None:
+            continue
+        if not isinstance(marks, list):
+            marks = [marks]
+        for mark in marks:
+            if getattr(mark, "name", None) != "parametrize":
+                continue
+            mark_args = tuple(getattr(mark, "args", ()) or ())
+            if len(mark_args) < 2:
+                continue
+            argnames_obj = mark_args[0]
+            argvalues_obj = mark_args[1]
+            names = _parametrize_argnames_to_set(argnames_obj)
+            if not (names & {"setup_backend", "backend_router"}):
+                continue
+            tokens.append(repr((argnames_obj, argvalues_obj)))
+    if not tokens:
+        return None
+    return "|".join(sorted(set(tokens)))
+
+
+def _backend_sort_key(item: pytest.Item) -> tuple:
+    """Stable ordering key used to cluster test classes by backend config.
+
+    Items that share ``(model_id, workers_config, backend_bucket)`` end up
+    adjacent so the session-scoped worker pool in ``setup_backend`` can
+    reuse warm workers between consecutive same-config classes. The backend
+    bucket prefers an aggregate token from class-level ``parametrize`` marks
+    for ``setup_backend`` / ``backend_router`` so mixed parametrizations do
+    not scatter tests; otherwise falls back to ``callspec.params``. Items
+    without these markers/params fall into a single neutral bucket and
+    keep their original collection order via Python's stable sort.
+    """
+    model = resolve_class_marker(item, "model")
+    workers = resolve_class_marker(item, "workers")
+
+    model_id = model.args[0] if model and model.args else ""
+    if workers is not None:
+        wcount = workers.kwargs.get("count") or 0
+        wprefill = workers.kwargs.get("prefill") or 0
+        wdecode = workers.kwargs.get("decode") or 0
+    else:
+        wcount = wprefill = wdecode = 0
+
+    backend = _class_level_backend_sort_token(item)
+    if backend is None:
+        callspec = getattr(item, "callspec", None)
+        if callspec is not None:
+            params = getattr(callspec, "params", {})
+            backend = str(params.get("setup_backend") or params.get("backend_router") or "")
+        else:
+            backend = ""
+
+    return (model_id, wcount, wprefill, wdecode, backend)
+
+
 def pytest_collection_modifyitems(
     config: pytest.Config,
     items: list[pytest.Item],
 ) -> None:
-    """Filter collected tests based on E2E_ENGINE, E2E_VENDOR, and E2E_GPU_TIER env vars."""
+    """Filter collected tests based on env vars, then cluster by backend config."""
     engine = os.environ.get("E2E_ENGINE") or None
     vendor = os.environ.get("E2E_VENDOR") or None
     gpu_tier = os.environ.get("E2E_GPU_TIER") or None
 
-    if not any([engine, vendor, gpu_tier]):
-        return
+    if any([engine, vendor, gpu_tier]):
+        selected: list[pytest.Item] = []
+        for item in items:
+            if engine:
+                engine_marker = _get_marker(item, "engine")
+                if not engine_marker or engine not in engine_marker.args:
+                    continue
+            if vendor:
+                vendor_marker = _get_marker(item, "vendor")
+                if not vendor_marker or vendor not in vendor_marker.args:
+                    continue
+            if gpu_tier is not None:
+                gpu_marker = _get_marker(item, "gpu")
+                gpu_count = gpu_marker.args[0] if gpu_marker else 1
+                if str(gpu_count) != gpu_tier:
+                    continue
+            selected.append(item)
 
-    selected: list[pytest.Item] = []
-    for item in items:
-        # Filter by engine
-        if engine:
-            engine_marker = _get_marker(item, "engine")
-            if not engine_marker or engine not in engine_marker.args:
-                continue
-        # Filter by vendor
-        if vendor:
-            vendor_marker = _get_marker(item, "vendor")
-            if not vendor_marker or vendor not in vendor_marker.args:
-                continue
-        # Filter by GPU tier
-        if gpu_tier is not None:
-            gpu_marker = _get_marker(item, "gpu")
-            gpu_count = gpu_marker.args[0] if gpu_marker else 1
-            if str(gpu_count) != gpu_tier:
-                continue
-        selected.append(item)
+        items[:] = selected
 
-    items[:] = selected
+    # Stable sort: equal keys preserve the original (post-filter) order, so
+    # tests within a single class stay together and only the class-level
+    # grouping changes.
+    if os.environ.get("E2E_DISABLE_TEST_SORT", "").lower() not in ("1", "true", "yes"):
+        items.sort(key=_backend_sort_key)
+
+
+# ---------------------------------------------------------------------------
+# Session lifecycle
+# ---------------------------------------------------------------------------
+
+
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+    """Stop any workers held by the ``setup_backend`` pool at session end."""
+    shutdown_worker_pool()

--- a/e2e_test/fixtures/setup_backend.py
+++ b/e2e_test/fixtures/setup_backend.py
@@ -1,14 +1,29 @@
 """Backend setup fixtures for E2E tests.
 
-Simplified backend lifecycle -- one set of workers and gateway per test class.
-No model pool, no thread-local caching. Direct worker management via
-start_workers/stop_workers.
+Backend lifecycle: one gateway per test class, but the underlying workers
+are pooled across classes that share ``(model_id, engine, mode, count)``.
+
+Workers are the expensive part (cold start is 1-3 minutes); gateways start
+in seconds. Decoupling worker lifetime from class scope lets consecutive
+same-config classes reuse warm workers and just spin a fresh gateway.
+
+Pool behaviour:
+- Keyed on ``(model_id, engine, mode, count)``; PD and cloud backends are
+  never pooled.
+- LRU with a single-entry default (``E2E_WORKER_POOL_SIZE``) so GPU memory
+  stays bounded.
+- Flushed at session end via ``shutdown_worker_pool``; on eviction the
+  evicted workers are stopped immediately.
+- Opt out with ``E2E_DISABLE_WORKER_POOL=1`` (falls back to per-class
+  start/stop semantics).
 """
 
 from __future__ import annotations
 
 import logging
 import os
+from collections import OrderedDict
+from typing import NamedTuple
 
 import anthropic
 import openai
@@ -56,6 +71,103 @@ def _start_workers_tracked(**kwargs) -> list:
     except (TimeoutError, RuntimeError):
         _worker_start_failures[engine] = _worker_start_failures.get(engine, 0) + 1
         raise
+
+
+def _require_exact_worker_count(*, role: str, requested: int, workers: list) -> None:
+    """Fail the run if we did not acquire exactly the requested worker count."""
+    got = len(workers) if workers is not None else 0
+    if got != requested:
+        pytest.fail(
+            f"E2E worker acquisition failed: expected exactly {requested} {role} "
+            f"worker(s), obtained {got}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Session-scoped worker pool
+# ---------------------------------------------------------------------------
+
+
+class _WorkerKey(NamedTuple):
+    model_id: str
+    engine: str
+    mode: str  # "http" | "grpc"
+    worker_count: int
+
+
+_worker_pool: OrderedDict[_WorkerKey, list] = OrderedDict()
+
+_raw_pool_size = os.environ.get("E2E_WORKER_POOL_SIZE", "1") or "1"
+try:
+    _parsed_pool_size = int(_raw_pool_size)
+except (TypeError, ValueError):
+    logger.warning("Invalid E2E_WORKER_POOL_SIZE=%r, using 1", _raw_pool_size)
+    _parsed_pool_size = 1
+_POOL_MAX = max(1, _parsed_pool_size)
+
+_POOL_DISABLED = os.environ.get("E2E_DISABLE_WORKER_POOL", "").lower() in ("1", "true", "yes")
+
+
+def _pool_enabled() -> bool:
+    return not _POOL_DISABLED
+
+
+def _pool_get(key: _WorkerKey) -> list | None:
+    """Return cached workers for ``key`` and mark them most-recently-used."""
+    workers = _worker_pool.get(key)
+    if workers is not None:
+        _worker_pool.move_to_end(key)
+    return workers
+
+
+def _pool_put(key: _WorkerKey, workers: list) -> None:
+    """Insert ``workers`` into the pool, evicting LRU entries past the cap.
+
+    Eviction stops the evicted workers eagerly so GPU memory is reclaimed
+    before the next cold start.
+    """
+    _worker_pool[key] = workers
+    _worker_pool.move_to_end(key)
+    while len(_worker_pool) > _POOL_MAX:
+        evict_key = next(iter(_worker_pool))
+        if evict_key == key:
+            # Should not happen with _POOL_MAX >= 1, but guard anyway.
+            break
+        evict_workers = _worker_pool.pop(evict_key)
+        logger.info("Evicting cached workers for %s", evict_key)
+        stop_workers(evict_workers)
+
+
+def _pool_make_room_for(key: _WorkerKey) -> None:
+    """Evict LRU pool entries to free GPUs before launching ``key`` fresh.
+
+    Pooled workers occupy GPUs 0..tp*count-1; a brand-new worker set for a
+    different config would collide with them. Drop everything that does not
+    match ``key`` until the pool has strictly less than ``_POOL_MAX`` entries,
+    leaving room for the new entry. Called only on cache-miss so a true cache
+    hit never evicts anyone.
+    """
+    while len(_worker_pool) >= _POOL_MAX:
+        evict_key = next(iter(_worker_pool))
+        if evict_key == key:
+            # Pool already has our key (shouldn't happen on a miss); bail out.
+            break
+        evict_workers = _worker_pool.pop(evict_key)
+        logger.info("Evicting cached workers for %s to free GPUs", evict_key)
+        stop_workers(evict_workers)
+
+
+def _pool_drop(key: _WorkerKey) -> list | None:
+    """Remove a key from the pool without stopping its workers."""
+    return _worker_pool.pop(key, None)
+
+
+def shutdown_worker_pool() -> None:
+    """Stop and forget every pooled worker. Called at session end."""
+    while _worker_pool:
+        key, workers = _worker_pool.popitem(last=False)
+        logger.info("Stopping pooled workers for %s at session end", key)
+        stop_workers(workers)
 
 
 def _start_gateway(gateway: Gateway, gateway_config: dict, **mode_kwargs) -> None:
@@ -175,17 +287,50 @@ def _setup_local(
     backend_name,
     log_dir,
 ):
-    """Launch regular workers + gateway, yield result tuple, tear down."""
-    num_workers = workers_config.get("count") or 1
-    logger.info("Starting %s backend: model=%s, workers=%d", backend_name, model_id, num_workers)
+    """Launch (or reuse) regular workers + a fresh gateway, yield, tear down.
 
-    workers = _start_workers_tracked(
-        model_id=model_id,
-        engine=engine,
-        mode=connection_mode,
-        count=num_workers,
-        log_dir=log_dir,
+    Workers are pooled across test classes that share
+    ``(model_id, engine, connection_mode, count)`` so the 1-3 min cold start
+    is paid once per distinct config per session instead of per class. The
+    gateway is always fresh — its startup is cheap and isolates router state.
+    """
+    num_workers = workers_config.get("count") or 1
+    key = _WorkerKey(model_id, engine, connection_mode.value, num_workers)
+    use_pool = _pool_enabled()
+
+    cached = _pool_get(key) if use_pool else None
+    if cached is not None:
+        logger.info(
+            "Reusing pooled workers for %s backend: model=%s, workers=%d",
+            backend_name,
+            model_id,
+            num_workers,
+        )
+        workers = cached
+        is_fresh = False
+    else:
+        if use_pool:
+            # Free up GPUs occupied by stale pool entries before launching.
+            _pool_make_room_for(key)
+        logger.info(
+            "Starting %s backend: model=%s, workers=%d", backend_name, model_id, num_workers
+        )
+        workers = _start_workers_tracked(
+            model_id=model_id,
+            engine=engine,
+            mode=connection_mode,
+            count=num_workers,
+            log_dir=log_dir,
+        )
+        is_fresh = True
+
+    _require_exact_worker_count(
+        role=f"{backend_name} ({model_id})",
+        requested=num_workers,
+        workers=workers,
     )
+
+    gateway_started = False
     try:
         _start_gateway(
             gateway,
@@ -193,12 +338,30 @@ def _setup_local(
             worker_urls=[w.base_url for w in workers],
             model_path=model_path,
         )
+        gateway_started = True
         logger.info("%s backend ready at %s", backend_name, gateway.base_url)
         yield backend_name, model_path, _make_openai_client(gateway), gateway
     finally:
         logger.info("Tearing down %s backend", backend_name)
         gateway.shutdown()
-        stop_workers(workers)
+        if not use_pool:
+            if is_fresh:
+                stop_workers(workers)
+        elif gateway_started:
+            # Gateway came up healthy → workers are good to keep warm.
+            if is_fresh:
+                _pool_put(key, workers)
+            # else: cached workers stayed in pool throughout (never popped).
+        else:
+            # Gateway never came up: treat these workers as suspect.
+            if is_fresh:
+                logger.info("Discarding workers after gateway start failure")
+                stop_workers(workers)
+            else:
+                evicted = _pool_drop(key)
+                if evicted is not None:
+                    logger.info("Evicting cached workers after gateway start failure")
+                    stop_workers(evicted)
 
 
 # ---------------------------------------------------------------------------
@@ -231,6 +394,13 @@ def _setup_pd(
         num_decode,
     )
 
+    # PD workers assign GPUs starting at 0, which would collide with any
+    # regular (non-PD) workers kept warm in the pool. Drain the pool first
+    # so the GPUs are free.
+    if _worker_pool:
+        logger.info("Draining %d pooled worker set(s) before PD setup", len(_worker_pool))
+        shutdown_worker_pool()
+
     all_workers: list = []
     try:
         prefill_workers = _start_workers_tracked(
@@ -240,6 +410,11 @@ def _setup_pd(
             count=num_prefill,
             worker_type=WorkerType.PREFILL,
             log_dir=log_dir,
+        )
+        _require_exact_worker_count(
+            role=f"PD prefill ({model_id})",
+            requested=num_prefill,
+            workers=prefill_workers,
         )
         all_workers.extend(prefill_workers)
 
@@ -253,6 +428,11 @@ def _setup_pd(
             worker_type=WorkerType.DECODE,
             log_dir=log_dir,
             gpu_offset=decode_gpu_offset,
+        )
+        _require_exact_worker_count(
+            role=f"PD decode ({model_id})",
+            requested=num_decode,
+            workers=decode_workers,
         )
         all_workers.extend(decode_workers)
 
@@ -332,6 +512,11 @@ def backend_router(request: pytest.FixtureRequest):
     model_path = get_model_spec(model_id)["model"]
 
     workers = start_workers(model_id, engine=get_runtime(), mode=connection_mode, count=1)
+    _require_exact_worker_count(
+        role=f"backend_router {backend_name} ({model_id})",
+        requested=1,
+        workers=workers,
+    )
     gateway = Gateway()
     try:
         gateway.start(worker_urls=[w.base_url for w in workers], model_path=model_path)


### PR DESCRIPTION
## Description

### Problem

GPU E2E jobs (especially e2e_test/responses on 2×H100) were hitting the 25-minute pytest step timeout even though tests passed. Most wall time went to repeated cold starts of SGLang/vLLM/TRT-LLM workers (~1–3 minutes each) because setup_backend was class-scoped and tore down workers after every test class. Alternating models (e.g. Qwen vs gpt-oss) made reuse impossible without reordering and pooling.

### Solution

Session-scoped worker pooling for non-PD local backends: workers are keyed by (model_id, engine, connection_mode, count) and reused across classes; each class still gets a fresh gateway for isolated router state. LRU eviction (default pool size 1) frees GPUs before starting a new worker set; the pool is drained before PD setups to avoid GPU overlap with prefill/decode. Stable collection sort clusters tests by the same key so consecutive classes are more likely to hit the pool. pytest_sessionfinish stops any remaining pooled workers at session end.

## Changes
- `e2e_test/fixtures/setup_backend.py`: worker pool (`_WorkerKey`, `_pool_get` / `_pool_put` / `_pool_make_room_for` / `_pool_drop`), `shutdown_worker_pool()`, `_setup_local` reuses workers and always tears down the gateway; gateway failure paths discard or evict suspect workers; PD path drains the pool before worker launch.
- `e2e_test/fixtures/hooks.py`: `_backend_sort_key`, extend `pytest_collection_modifyitems` with stable sort after env filtering; `pytest_sessionfinish` calls `shutdown_worker_pool()`.
- `e2e_test/fixtures/__init__.py`, `e2e_test/conftest.py`: export/import `pytest_sessionfinish`; docstring updates for `setup_backend`.
- **Env toggles**: `E2E_DISABLE_WORKER_POOL=1` (legacy per-class behavior), `E2E_WORKER_POOL_SIZE` (default `1`), `E2E_DISABLE_TEST_SORT=1` (skip clustering sort).

## Test Plan
- Compare log lines `Starting … grpc worker` vs `Reusing pooled workers for`. After the change there should be **far fewer cold starts** when multiple classes share the same model/mode/worker count.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [x] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved test infrastructure with enhanced resource pooling mechanisms and better session cleanup to optimize test efficiency.

* **Tests**
  * Refined test collection and ordering logic to better organize backend test scenarios and manage resource utilization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightseekorg/smg/pull/1487)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->