### PR TITLE
perf(discovery): push label selectors to K8s API server

### DIFF
--- a/model_gateway/Cargo.toml
+++ b/model_gateway/Cargo.toml
@@ -143,6 +143,7 @@ serial_test = "3.0"
 rsa = { version = "0.9", features = ["sha2"] }
 jsonwebtoken = "9.3"
 validator = "0.20.0"
+tracing-test = "0.2"
 kv-index.workspace = true
 wasmtime-wasi = { workspace = true }
 lru = { workspace = true }

--- a/model_gateway/src/service_discovery.rs
+++ b/model_gateway/src/service_discovery.rs
@@ -128,6 +128,34 @@ impl ServiceDiscoveryConfig {
                 .join(",")
         }
     }
+
+    /// Build a label selector string for router pod K8s list/watch calls.
+    /// Returns an empty string when the router selector is unset, in which
+    /// case the watcher should fall back to listing without server-side
+    /// label filtering.
+    fn router_label_selector(&self) -> String {
+        self.router_selector
+            .iter()
+            .map(|(k, v)| format!("{k}={v}"))
+            .collect::<Vec<_>>()
+            .join(",")
+    }
+}
+
+/// Build a kube watcher Config that pushes the given label selector down to
+/// the API server, logging the start of a new watcher iteration at INFO.
+/// An empty selector falls back to `Config::default()` (no server-side
+/// label filtering) so the watcher still functions when no selector is set.
+fn build_watcher_config(watcher_kind: &str, label_selector: &str) -> Config {
+    info!(
+        "Starting K8s {} watcher | selector: '{}'",
+        watcher_kind, label_selector
+    );
+    if label_selector.is_empty() {
+        Config::default()
+    } else {
+        Config::default().labels(label_selector)
+    }
 }
 
 impl Default for ServiceDiscoveryConfig {
@@ -505,7 +533,7 @@ pub async fn start_service_discovery(
         const MAX_RETRY_DELAY: Duration = Duration::from_secs(300);
 
         loop {
-            let watcher_config = Config::default();
+            let watcher_config = build_watcher_config("worker", &config_arc.list_label_selector());
             let watcher_stream = watcher(pods.clone(), watcher_config).applied_objects();
 
             let config_clone = Arc::clone(&config_arc);
@@ -1027,7 +1055,7 @@ async fn start_router_discovery(
     const MAX_RETRY_DELAY: Duration = Duration::from_secs(300);
 
     loop {
-        let watcher_config = Config::default();
+        let watcher_config = build_watcher_config("router", &config.router_label_selector());
         let watcher_stream = watcher(pods.clone(), watcher_config).applied_objects();
 
         let config_clone = Arc::clone(&config);
@@ -1153,6 +1181,7 @@ mod tests {
         api::core::v1::{Pod, PodCondition, PodSpec, PodStatus},
         apimachinery::pkg::apis::meta::v1::{ObjectMeta, Time},
     };
+    use tracing_test::traced_test;
 
     use super::*;
     use crate::routers::{common::openai_bridge, grpc::multimodal::MultimodalConfigRegistry};
@@ -2516,5 +2545,109 @@ mod tests {
     fn test_deregistration_reconciled_metric_label() {
         // Verify the metric label constant exists and has expected value
         assert_eq!(metrics_labels::DEREGISTRATION_RECONCILED, "reconciled");
+    }
+
+    #[test]
+    fn test_build_watcher_config_with_selector_pushes_label_selector() {
+        let cfg = build_watcher_config("worker", "app=sglang");
+        assert_eq!(cfg.label_selector.as_deref(), Some("app=sglang"));
+    }
+
+    #[test]
+    fn test_build_watcher_config_empty_selector_falls_back_to_default() {
+        let cfg = build_watcher_config("worker", "");
+        assert!(cfg.label_selector.is_none());
+    }
+
+    #[test]
+    fn test_build_watcher_config_for_regular_mode_pushes_worker_selector() {
+        let mut selector = HashMap::new();
+        selector.insert("app".to_string(), "sglang".to_string());
+        let config = ServiceDiscoveryConfig {
+            selector,
+            pd_mode: false,
+            ..Default::default()
+        };
+        let watcher_config = build_watcher_config("worker", &config.list_label_selector());
+        assert_eq!(watcher_config.label_selector.as_deref(), Some("app=sglang"));
+    }
+
+    #[test]
+    fn test_build_watcher_config_for_pd_mode_pushes_intersection() {
+        let mut prefill = HashMap::new();
+        prefill.insert("app".to_string(), "sglang".to_string());
+        prefill.insert("component".to_string(), "prefill".to_string());
+        let mut decode = HashMap::new();
+        decode.insert("app".to_string(), "sglang".to_string());
+        decode.insert("component".to_string(), "decode".to_string());
+        let config = ServiceDiscoveryConfig {
+            pd_mode: true,
+            prefill_selector: prefill,
+            decode_selector: decode,
+            ..Default::default()
+        };
+        let watcher_config = build_watcher_config("worker", &config.list_label_selector());
+        assert_eq!(watcher_config.label_selector.as_deref(), Some("app=sglang"));
+    }
+
+    #[test]
+    fn test_build_watcher_config_for_pd_mode_no_common_labels_omits_filter() {
+        let mut prefill = HashMap::new();
+        prefill.insert("role".to_string(), "prefill".to_string());
+        let mut decode = HashMap::new();
+        decode.insert("role".to_string(), "decode".to_string());
+        let config = ServiceDiscoveryConfig {
+            pd_mode: true,
+            prefill_selector: prefill,
+            decode_selector: decode,
+            ..Default::default()
+        };
+        let watcher_config = build_watcher_config("worker", &config.list_label_selector());
+        assert!(watcher_config.label_selector.is_none());
+    }
+
+    #[test]
+    fn test_router_label_selector_serializes_router_selector() {
+        let mut router = HashMap::new();
+        router.insert("app".to_string(), "smg".to_string());
+        let config = ServiceDiscoveryConfig {
+            router_selector: router,
+            ..Default::default()
+        };
+        assert_eq!(config.router_label_selector(), "app=smg");
+    }
+
+    #[test]
+    fn test_router_label_selector_empty_when_unset() {
+        let config = ServiceDiscoveryConfig::default();
+        assert!(config.router_label_selector().is_empty());
+    }
+
+    #[test]
+    fn test_build_watcher_config_for_router_pushes_router_selector() {
+        let mut router = HashMap::new();
+        router.insert("app".to_string(), "smg".to_string());
+        let config = ServiceDiscoveryConfig {
+            router_selector: router,
+            ..Default::default()
+        };
+        let watcher_config = build_watcher_config("router", &config.router_label_selector());
+        assert_eq!(watcher_config.label_selector.as_deref(), Some("app=smg"));
+    }
+
+    #[traced_test]
+    #[test]
+    fn test_build_watcher_config_logs_selector_at_info_level() {
+        let _ = build_watcher_config("worker", "app=sglang");
+        assert!(logs_contain("Starting K8s worker watcher"));
+        assert!(logs_contain("app=sglang"));
+    }
+
+    #[traced_test]
+    #[test]
+    fn test_build_watcher_config_logs_router_kind_with_empty_selector() {
+        let _ = build_watcher_config("router", "");
+        assert!(logs_contain("Starting K8s router watcher"));
+        assert!(logs_contain("selector: ''"));
     }
 }


### PR DESCRIPTION
## Summary

- The pod watcher used `Config::default()` and filtered pods client-side via `PodInfo::should_include` / `PodInfo::matches_selector`, so every pod in the watched namespace flowed through the watcher even when only a few matched.
- The reconciler at `service_discovery.rs:884` already pushes the selector down via `ListParams::default().labels(...)`. This change brings the worker watcher (was line 508) and router watcher in `start_router_discovery` (was line 1031) in line.
- New helper `build_watcher_config(kind, label_selector)` returns `Config::default().labels(sel)` for non-empty selectors and falls back to `Config::default()` when empty (preserving current "no server-side filter" behavior). It also emits an `INFO` log on each watcher (re)start naming the watcher kind and selector — useful for log-capture assertions and runtime debugging across restarts.
- Worker watcher uses `ServiceDiscoveryConfig::list_label_selector()` (PD-mode intersection of prefill+decode); `should_include` continues to discriminate per-pod prefill vs decode. Router watcher uses a new `ServiceDiscoveryConfig::router_label_selector()`.

## Test plan

- [x] `cargo +nightly fmt --all` (silent)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (clean)
- [x] `cargo test` — full suite passes; `service_discovery::tests`: 75 passed (10 new + 65 existing).
- [x] New unit tests: `build_watcher_config` for single-selector pushdown, PD-mode intersection pushdown, PD-mode no-common-labels fallback, router-selector pushdown, and empty-selector fallback to `Config::default()`; `router_label_selector` serialization and empty-when-unset; `INFO` log emission via `#[traced_test]` (added `tracing-test` as a dev-dep).
- [ ] Manual smoke against a live K8s cluster — left to reviewer; reconciler already exercises the same selector path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Kubernetes watchers now support server-side label filtering based on configured selectors for improved performance and resource efficiency
  * Enhanced logging for service and router discovery initialization to provide better operational visibility

* **Tests**
  * Extended test coverage for watcher configuration behavior and logging validation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightseekorg/smg/pull/1488)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->