### PR TITLE
fix(mlx-grpc): runtime error in mlx multi streams when loading gpt-oss model series

### DIFF
--- a/grpc_servicer/smg_grpc_servicer/mlx/server.py
+++ b/grpc_servicer/smg_grpc_servicer/mlx/server.py
@@ -63,7 +63,7 @@ def _eval_all_module_arrays(module: nn.Module) -> None:
         elif isinstance(v, dict):
             for child in v.values():
                 _collect_value(child)
-        elif isinstance(v, list):
+        elif isinstance(v, (list, tuple)):
             for child in v:
                 _collect_value(child)
 

--- a/grpc_servicer/smg_grpc_servicer/mlx/server.py
+++ b/grpc_servicer/smg_grpc_servicer/mlx/server.py
@@ -15,6 +15,8 @@ import time
 from concurrent import futures
 
 import grpc
+import mlx.core as mx
+import mlx.nn as nn
 from grpc_health.v1 import health_pb2_grpc
 from grpc_reflection.v1alpha import reflection
 from huggingface_hub import snapshot_download
@@ -25,6 +27,49 @@ from smg_grpc_servicer.mlx.health_servicer import MlxHealthServicer
 from smg_grpc_servicer.mlx.servicer import MlxEngineServicer
 
 logger = logging.getLogger(__name__)
+
+
+def _eval_all_module_arrays(module: nn.Module) -> None:
+    """Force-eval every mx.array in the module tree, including private attrs.
+
+    mlx-lm's load_model() calls mx.eval(model.parameters()), but
+    nn.Module.parameters() silently skips underscore-prefixed attributes
+    (e.g. YarnRoPE._freqs, which is computed lazily from mx.arange() and
+    arithmetic operations at module-construction time).  Those unevaluated
+    arrays are scheduled on the main thread's default stream (Stream gpu, 1).
+
+    The generation loop runs inside ``with mx.stream(generation_stream):``
+    (Stream gpu, 0) on a background thread.  When its forward pass tries to
+    materialize KV-cache arrays that transitively depend on an unevaluated
+    _freqs, MLX cannot find Stream(gpu, 1) on that thread and raises::
+
+        RuntimeError: There is no Stream(gpu, 1) in current thread.
+
+    Calling this function right after load() materialises every lazy array
+    on the main thread before the generation thread starts.
+    """
+    arrays: list[mx.array] = []
+
+    def _collect_value(v: object) -> None:
+        if isinstance(v, mx.array):
+            arrays.append(v)
+        elif isinstance(v, nn.Module):
+            # m.items() (MLX's dict-like API) returns ALL module attributes,
+            # including underscore-prefixed ones like _freqs. vars()/.__dict__
+            # is NOT the right API — MLX stores module state internally, so
+            # vars(m) only returns ['_no_grad', '_training'].
+            for _, child in v.items():
+                _collect_value(child)
+        elif isinstance(v, dict):
+            for child in v.values():
+                _collect_value(child)
+        elif isinstance(v, list):
+            for child in v:
+                _collect_value(child)
+
+    _collect_value(module)
+    if arrays:
+        mx.eval(arrays)
 
 
 def parse_args():
@@ -46,6 +91,10 @@ def load_model(args):
     """Load model and tokenizer via mlx-lm."""
     logger.info("Loading model: %s", args.model)
     model, tokenizer = load(args.model, adapter_path=args.adapter_path)
+    # Force-eval non-parameter arrays missed by mlx-lm's mx.eval(model.parameters()).
+    # Needed for models with YaRN/other RoPE variants whose _freqs arrays are
+    # excluded from parameters() due to underscore prefix. See _eval_all_module_arrays.
+    _eval_all_module_arrays(model)
     logger.info("Model loaded successfully")
 
     model_dir = args.model


### PR DESCRIPTION
## Description

### Problem

MLX gRPC service throws `RuntimeError: There is no Stream(gpu, 1) in current thread.` when loading GPT-OSS series models (like mlx-community/gpt-oss-20b-MXFP4-Q4).


**Root cause:** 

MLX uses lazy evaluation — array computations are scheduled but not actually executed until something forces them. Each GPU thread has its own "stream" (execution channel), and a lazy array is tied to the stream of the thread that created it.

GPT-OSS uses a `YarnRoPE` position embedding that computes a frequency table (`_freqs`) lazily at model construction time. This lazy array is created on the main thread (Stream gpu, 1). The problem is that `mlx-lm`'s `load()` only calls `mx.eval(model.parameters())` to force-evaluate model weights, and `model.parameters()` silently skips attributes with underscore prefixes — so `_freqs` is never evaluated.

When the generation loop later runs on a background thread (Stream gpu, 0) and tries to use any array that depends on `_freqs`, MLX looks for Stream gpu, 1 on that thread, doesn't find it, and raises the RuntimeError. Regular models like Qwen3 are not affected because they use plain `RoPE` with no `_freqs`.

### Solution

After `load()` returns, walk the entire model tree and call `mx.eval()` on every `mx.array` found — including underscore-prefixed attributes that `model.parameters()` skips. This forces all lazy arrays to materialize on the main thread before the generation thread ever starts.

## Changes

`grpc_servicer/smg_grpc_servicer/mlx/server.py`: Added `_eval_all_module_arrays()` helper that uses `module.items()` (MLX's own dict-like API, which returns all attributes including `_`-prefixed ones) to collect and evaluate every array in the model tree. Called once in `load_model()` right after `mlx_lm.load()`.

## Test Plan
Deployed MLX gRPC + SMG and tested with the following scenarios:

The regular model tests confirm the fix doesn't regress existing behavior; the GPT-OSS tests confirm the `Stream(gpu, 1)` RuntimeError is resolved.

> GPT-OSS is a Harmony model: only `/v1/chat/completions` and `/v1/responses` are supported.
> `/v1/completions` returns HTTP 400 on the Harmony path.

| # | Model | Path | Endpoint | stream | Expected | Result |
|---|-------|------|----------|--------|----------|--------|
| R-1 | Qwen3-4B (Regular) | Regular | `/v1/chat/completions` | false | HTTP 200, `content` present | ✅ |
| R-2 | Qwen3-4B (Regular) | Regular | `/v1/chat/completions` | true  | HTTP 200, SSE content chunks | ✅ |
| R-3 | Qwen3-4B (Regular) | Regular | `/v1/completions` | false | HTTP 200, `text` present | ✅ |
| R-4 | Qwen3-4B (Regular) | Regular | `/v1/completions` | true  | HTTP 200, SSE text chunks | ✅ |
| G-1 | GPT-OSS-20B (Harmony) | Harmony | `/v1/chat/completions` | false | HTTP 200, `reasoning_content` + `content` | ✅ |
| G-2 | GPT-OSS-20B (Harmony) | Harmony | `/v1/chat/completions` | true  | HTTP 200, SSE reasoning then content chunks | ✅ |
| G-3 | GPT-OSS-20B (Harmony) | Harmony | `/v1/responses` | false | HTTP 200, reasoning + message output items | ✅ |
| G-4 | GPT-OSS-20B (Harmony) | Harmony | `/v1/completions` | any   | HTTP 400 (Harmony path rejects completions) | N/A |

Full test commands and real responses will be posted in a separate comment later.


<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures all model-internal arrays are fully realized on the main thread during model load so non-parameter data is initialized before generation begins, improving stability and preventing runtime stalls and race conditions during inference startup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightseekorg/smg/pull/1489?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->