### PR TITLE
fix(protocols): accept return_token_budget for web_search tool

### DIFF
--- a/crates/protocols/src/responses.rs
+++ b/crates/protocols/src/responses.rs
@@ -1200,16 +1200,19 @@ pub struct WebSearchPreviewTool {
 /// Non-preview hosted web search tool configuration.
 ///
 /// Spec: `{ type: "web_search" | "web_search_2025_08_26", filters? { allowed_domains? },
-/// search_context_size?: "low"|"medium"|"high", user_location? }`.
+/// return_token_budget?: "default"|"unlimited", search_context_size?: "low"|"medium"|"high",
+/// user_location? }`.
 ///
 /// Distinct from `WebSearchPreviewTool`: adds `filters.allowed_domains` (domain
-/// allowlist) and pins `search_context_size` to the spec-listed enum.
+/// allowlist), `return_token_budget`, and pins `search_context_size` to the spec-listed enum.
 #[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Deserialize, Serialize, Default, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct WebSearchTool {
     /// Optional domain allowlist applied to candidate sources.
     pub filters: Option<WebSearchFilters>,
+    /// Search-result context token budget. Spec enum: `"default" | "unlimited"`.
+    pub return_token_budget: Option<WebSearchReturnTokenBudget>,
     /// Search context budget. Spec enum: `"low" | "medium" | "high"`.
     pub search_context_size: Option<WebSearchContextSize>,
     /// Approximate user location used to bias results.
@@ -1236,6 +1239,16 @@ pub enum WebSearchContextSize {
     Low,
     Medium,
     High,
+}
+
+/// Search-result token budget for the non-preview `web_search` tool.
+///
+/// Spec: `return_token_budget?: "default" | "unlimited"`.
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, schemars::JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum WebSearchReturnTokenBudget {
+    Default,
+    Unlimited,
 }
 
 /// Approximate user location for the non-preview `web_search` tool.

--- a/crates/protocols/tests/responses.rs
+++ b/crates/protocols/tests/responses.rs
@@ -243,13 +243,14 @@ fn test_file_search_tool_round_trip_hybrid_weights_omitted() {
 
 /// Spec fixture (openai-responses-api-spec.md §tools line 439):
 /// `{ type: "web_search" | "web_search_2025_08_26", filters? { allowed_domains? },
-/// search_context_size?: "low"|"medium"|"high", user_location? }`. Covers the
-/// canonical tag, the versioned alias, and full-field nested shape.
+/// return_token_budget?: "default"|"unlimited", search_context_size?: "low"|"medium"|"high",
+/// user_location? }`. Covers the canonical tag, the versioned alias, and full-field nested shape.
 #[test]
 fn test_web_search_tool_round_trip() {
     let payload = json!({
         "type": "web_search",
         "filters": {"allowed_domains": ["example.com", "rust-lang.org"]},
+        "return_token_budget": "default",
         "search_context_size": "high",
         "user_location": {
             "type": "approximate",
@@ -271,6 +272,54 @@ fn test_web_search_tool_round_trip() {
     let alias: ResponseTool = serde_json::from_value(json!({"type": "web_search_2025_08_26"}))
         .expect("web_search_2025_08_26 alias should deserialize");
     assert!(matches!(alias, ResponseTool::WebSearch(_)));
+}
+
+#[test]
+fn test_web_search_response_tool_echo_accepts_return_token_budget() {
+    let payload = json!({
+        "id": "resp_web_echo",
+        "object": "response",
+        "created_at": 1,
+        "status": "completed",
+        "error": null,
+        "incomplete_details": null,
+        "instructions": null,
+        "max_output_tokens": null,
+        "model": "gpt-5.4",
+        "output": [],
+        "parallel_tool_calls": true,
+        "previous_response_id": null,
+        "reasoning": null,
+        "store": true,
+        "temperature": 1.0,
+        "text": {"format": {"type": "text"}},
+        "tool_choice": "auto",
+        "tools": [{
+            "type": "web_search",
+            "return_token_budget": "default",
+            "search_context_size": "low",
+            "user_location": {
+                "type": "approximate",
+                "city": null,
+                "country": null,
+                "region": null,
+                "timezone": null
+            }
+        }],
+        "top_p": 1.0,
+        "truncation": "disabled",
+        "usage": null,
+        "user": null,
+        "metadata": {}
+    });
+
+    let response: ResponsesResponse = serde_json::from_value(payload.clone())
+        .expect("upstream web_search echo with return_token_budget should deserialize");
+    let serialized = serde_json::to_value(&response).expect("serialize response");
+    assert_eq!(
+        serialized["tools"][0]["return_token_budget"],
+        json!("default")
+    );
 }
 
 /// Acceptance: `web_search_call` output item carries an optional typed


### PR DESCRIPTION

## Description


### Problem

web_search responses from upstream OpenAI include return_token_budget field, but SMG’s WebSearchTool schema rejects that unknown field, causing a 500 during ResponsesResponse deserialization. web_search_preview works fine because it does not include that field.

### Solution

Added typed return_token_budget support to SMG’s non-preview web_search protocol model and regression tests for the upstream echo shape.

## Changes

- Add `return_token_budget` support to the non-preview `web_search` Responses tool schema.
- Cover upstream `ResponsesResponse.tools[]` echo deserialization with a regression test.

## Test Plan

After running SMG locally, register openai worker and perform a web_search request. 
Previous experience (internal error):
```
 curl http://localhost:9999/v1/responses   -H "Content-Type: application/json"   -H "Authorization: Bearer sk-key"   -H "OpenAI-Project: 03262026_01"   -d '{
    "model": "gpt-5.1",
    "tools": [
      {
        "type": "web_search"
      }
    ],
    "input": "what is a positive news story from today?"
  }'
Response:
{"error":{"message":"Failed to deserialize upstream ResponsesResponse: unknown field `return_token_budget`, expected one of `filters`, `search_context_size`, `user_location`","type":"server_error","param":null,"code":"internal_error"}}
```
After Fix is added, successful response:
<img width="1846" height="319" alt="Screenshot 2026-05-13 at 6 32 07 PM" src="https://github.com/user-attachments/assets/99c6aff2-c162-46ae-8841-2c2545cdb28f" />


<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended web search tool configuration with a new `return_token_budget` field to control token allocation behavior (supports `default` and `unlimited` settings).

* **Tests**
  * Added comprehensive test coverage for the new `return_token_budget` field to ensure proper serialization and deserialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightseekorg/smg/pull/1490)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->