### PR TITLE
ci: skip unit-tests on PRs without Rust changes

### DIFF
--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -233,6 +233,15 @@ jobs:
           pytest -q tests --cov=smg --cov-config=.coveragerc --cov-report=term-missing --cov-fail-under=80
 
   unit-tests:
+    needs: [detect-changes]
+    if: >-
+      always()
+      && !cancelled()
+      && needs.detect-changes.result == 'success'
+      && (
+        github.event_name != 'pull_request'
+        || needs.detect-changes.outputs.rust-ci == 'true'
+      )
     runs-on: k8s-runner-cpu
     permissions:
       contents: read
@@ -359,7 +368,6 @@ jobs:
 
   detect-changes:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
     permissions:
       contents: read
       pull-requests: read
@@ -370,6 +378,7 @@ jobs:
       agentic: ${{ steps.filter.outputs.agentic }}
       embeddings: ${{ steps.filter.outputs.embeddings }}
       go-bindings: ${{ steps.filter.outputs.go-bindings }}
+      rust-ci: ${{ steps.filter.outputs.rust-ci }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v4
@@ -419,6 +428,28 @@ jobs:
               - 'e2e_test/embeddings/**'
             go-bindings:
               - 'e2e_test/bindings_go/**'
+            rust-ci:
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'rustfmt.toml'
+              - 'clippy.toml'
+              - 'crates/**'
+              - 'test_support/**'
+              - 'model_gateway/**'
+              - 'bindings/python/Cargo.toml'
+              - 'bindings/python/build.rs'
+              - 'bindings/python/src/**'
+              - 'bindings/golang/Cargo.toml'
+              - 'bindings/golang/src/**'
+              - 'clients/rust/**'
+              - 'clients/openapi-gen/**'
+              - 'tui/**'
+              - '.cargo/**'
+              - '.github/actions/setup-rust/**'
+              - 'scripts/ci_install_rust.sh'
+              - '.github/workflows/pr-test-rust.yml'
+              - 'examples/wasm/wasm-guest-storage-hook/**'
+              - 'examples/wasm/wasm-guest-storage-hook-passthrough/**'
 
   # --- GPU E2E: organized by GPU tier + API, engine as matrix axis ---
 


### PR DESCRIPTION
## Description

### Problem

  The `unit-tests` job (Rust lint, fmt, and `cargo test`) runs on every PR regardless of whether any Rust-related files changed, wasting CI time on PRs that only touch Python, docs, or other non-Rust code.

### Solution

Add a `rust-ci` path filter to `detect-changes` and gate `unit-tests` behind it on PRs.

## Changes

- Add `rust-ci` output to `detect-changes`, covering all Cargo workspace members, Rust toolchain config, and the two WASM fixture crates built by `build_fixtures.sh`
- Remove the `pull_request`-only guard from `detect-changes` so it runs on push events too (needed since `unit-tests` now depends on it)
- Gate `unit-tests` to skip on PRs when no Rust files changed, while always running on non-PR events

## Test Plan

- Open a PR that only changes Python/docs — confirm `unit-tests` is skipped. 

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [x] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>
