### PR TITLE
test(realtime): pin to gpt-realtime GA alias instead of retired preview snapshot

### DIFF
--- a/e2e_test/realtime/test_realtime_ws.py
+++ b/e2e_test/realtime/test_realtime_ws.py
@@ -29,7 +29,7 @@ import websockets
 logger = logging.getLogger(__name__)
 
 OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY", "")
-REALTIME_MODEL = "gpt-4o-realtime-preview-2024-12-17"
+REALTIME_MODEL = "gpt-realtime"
 RECV_TIMEOUT = 30  # seconds — cloud latency can be high
 
 


### PR DESCRIPTION
## Description

### Problem

The `openai-realtime` E2E job started failing on `main` ([run 26075252721](https://github.com/lightseekorg/smg/actions/runs/26075252721/job/76665833164)). 10 of 12 tests in `e2e_test/realtime/test_realtime_ws.py::TestRealtimeWebSocket` fail with `websockets.exceptions.ConnectionClosedOK: received 1005 (no status received)` / `ConnectionResetError: [Errno 104] Connection reset by peer`. The 2 tests that pass are exactly the ones that intentionally fail at SMG's REST middleware (no model, no auth) and never need the upstream WebSocket.

Architecture recap: the realtime E2E job runs SMG in cloud-proxy mode against `https://api.openai.com`. The test connects to local SMG at `ws://127.0.0.1/v1/realtime?model=…`, and SMG's `model_gateway/src/routers/openai/realtime/proxy.rs` opens a separate `wss://api.openai.com/v1/realtime?model=…` and bridges frames. When the upstream handshake fails (non-101 response), `run_ws_proxy` returns `Err`, the upgrade closure ends, and axum drops the already-upgraded client socket without sending a WS close frame — client observes `1005` / TCP RST.

Root cause: the test hard-pinned `REALTIME_MODEL = "gpt-4o-realtime-preview-2024-12-17"`, a December 2024 preview snapshot that is no longer accepted by OpenAI's Realtime API. There is no recent merge to `realtime/` or to the WS proxy on `main` that could have caused this — the only commit between the last green and this red run was `be6f3038` (TokenSpeed gRPC client), which touches nothing in this path.

### Solution

Switch the test to the unversioned GA alias `gpt-realtime` so the suite tracks OpenAI's current GA realtime model and is not subject to future snapshot retirements.

## Changes

- `e2e_test/realtime/test_realtime_ws.py:32` — bump `REALTIME_MODEL` from `gpt-4o-realtime-preview-2024-12-17` to `gpt-realtime`.

## Test Plan

- [ ] CI `openai-realtime` job goes green on this branch.
- [ ] Before/after: the 10 previously-failing tests (`test_session_created_on_connect`, `test_session_update`, `test_text_response`, `test_multi_turn_conversation`, `test_conversation_item_created_event`, `test_response_cancel`, `test_session_created_format`, `test_response_done_format`, `test_response_text_delta_format`, `test_invalid_event_returns_error`) all pass; the 2 always-passing tests (`test_missing_model_returns_error`, `test_missing_auth_returns_error`) remain passing.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes (no Rust changes)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (no Rust changes)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the Realtime WebSocket end-to-end test suite to target the `gpt-realtime` model.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightseekorg/smg/pull/1504?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->