### PR TITLE
feat(reasoning_parser): add none reasoning parser

### DIFF
--- a/crates/reasoning_parser/src/factory.rs
+++ b/crates/reasoning_parser/src/factory.rs
@@ -9,7 +9,7 @@ use tokio::sync::Mutex;
 use crate::{
     parsers::{
         BaseReasoningParser, CohereCmdParser, DeepSeekR1Parser, Glm45Parser, KimiParser,
-        MiniMaxParser, NanoV3Parser, Qwen3Parser, QwenThinkingParser, Step3Parser,
+        MiniMaxParser, NanoV3Parser, NoneParser, Qwen3Parser, QwenThinkingParser, Step3Parser,
     },
     traits::{ParserConfig, ReasoningParser, DEFAULT_MAX_BUFFER_SIZE},
 };
@@ -175,6 +175,11 @@ impl ParserFactory {
         registry.register_parser("base", || {
             Box::new(BaseReasoningParser::new(ParserConfig::default()))
         });
+
+        // Register no-op parser: returns all text as normal content,
+        // never produces reasoning_content. Selectable via
+        // `--reasoning-parser none`.
+        registry.register_parser("none", || Box::new(NoneParser::new()));
 
         // Register DeepSeek-R1 parser (starts with in_reasoning=true)
         registry.register_parser("deepseek_r1", || Box::new(DeepSeekR1Parser::new()));

--- a/crates/reasoning_parser/src/lib.rs
+++ b/crates/reasoning_parser/src/lib.rs
@@ -5,7 +5,7 @@ pub mod traits;
 pub use factory::{ParserFactory, ParserRegistry, PooledParser};
 pub use parsers::{
     BaseReasoningParser, CohereCmdParser, DeepSeekR1Parser, Glm45Parser, KimiParser, MiniMaxParser,
-    NanoV3Parser, Qwen3Parser, QwenThinkingParser, Step3Parser,
+    NanoV3Parser, NoneParser, Qwen3Parser, QwenThinkingParser, Step3Parser,
 };
 pub use traits::{
     ParseError, ParserConfig, ParserResult, ReasoningParser, DEFAULT_MAX_BUFFER_SIZE,

--- a/crates/reasoning_parser/src/parsers/mod.rs
+++ b/crates/reasoning_parser/src/parsers/mod.rs
@@ -5,6 +5,7 @@ pub mod glm45;
 pub mod kimi;
 pub mod minimax;
 pub mod nano_v3;
+pub mod none;
 pub mod qwen3;
 pub mod step3;
 
@@ -15,5 +16,6 @@ pub use glm45::Glm45Parser;
 pub use kimi::KimiParser;
 pub use minimax::MiniMaxParser;
 pub use nano_v3::NanoV3Parser;
+pub use none::NoneParser;
 pub use qwen3::{Qwen3Parser, QwenThinkingParser};
 pub use step3::Step3Parser;

--- a/crates/reasoning_parser/src/parsers/none.rs
+++ b/crates/reasoning_parser/src/parsers/none.rs
@@ -1,0 +1,123 @@
+// No-op reasoning parser.
+//
+// Returns all input text as `normal_text` and never produces reasoning text,
+// regardless of whether the input contains `<think>`/`</think>` (or any other)
+// markers. Use this when the model emits a single content stream and the
+// caller does not want any portion of it separated into `reasoning_content`.
+
+use crate::traits::{ParseError, ParserResult, ReasoningParser};
+
+/// Parser that performs no reasoning extraction.
+///
+/// Every byte received is forwarded to `normal_text`; `reasoning_text` is always
+/// empty. State is trivial: no buffering, no tokens, no flags.
+#[derive(Debug, Clone, Default)]
+pub struct NoneParser;
+
+impl NoneParser {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl ReasoningParser for NoneParser {
+    fn detect_and_parse_reasoning(&mut self, text: &str) -> Result<ParserResult, ParseError> {
+        Ok(ParserResult::normal(text.to_string()))
+    }
+
+    fn parse_reasoning_streaming_incremental(
+        &mut self,
+        text: &str,
+    ) -> Result<ParserResult, ParseError> {
+        Ok(ParserResult::normal(text.to_string()))
+    }
+
+    fn reset(&mut self) {}
+
+    fn model_type(&self) -> &str {
+        "none"
+    }
+
+    fn is_in_reasoning(&self) -> bool {
+        false
+    }
+
+    fn mark_reasoning_started(&mut self) {}
+
+    fn mark_think_start_stripped(&mut self) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plain_text_goes_to_normal() {
+        let mut parser = NoneParser::new();
+        let result = parser
+            .detect_and_parse_reasoning("just some content")
+            .unwrap();
+        assert_eq!(result.normal_text, "just some content");
+        assert_eq!(result.reasoning_text, "");
+    }
+
+    #[test]
+    fn think_tags_are_kept_in_normal_text() {
+        let mut parser = NoneParser::new();
+        let result = parser
+            .detect_and_parse_reasoning("<think>cot</think>answer")
+            .unwrap();
+        assert_eq!(result.normal_text, "<think>cot</think>answer");
+        assert_eq!(result.reasoning_text, "");
+    }
+
+    #[test]
+    fn streaming_passes_chunks_through_unchanged() {
+        let mut parser = NoneParser::new();
+
+        let r1 = parser
+            .parse_reasoning_streaming_incremental("<think>")
+            .unwrap();
+        assert_eq!(r1.normal_text, "<think>");
+        assert_eq!(r1.reasoning_text, "");
+
+        let r2 = parser
+            .parse_reasoning_streaming_incremental("hidden cot")
+            .unwrap();
+        assert_eq!(r2.normal_text, "hidden cot");
+        assert_eq!(r2.reasoning_text, "");
+
+        let r3 = parser
+            .parse_reasoning_streaming_incremental("</think>visible")
+            .unwrap();
+        assert_eq!(r3.normal_text, "</think>visible");
+        assert_eq!(r3.reasoning_text, "");
+    }
+
+    #[test]
+    fn empty_input_is_normal_and_empty() {
+        let mut parser = NoneParser::new();
+        let result = parser.detect_and_parse_reasoning("").unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn mark_helpers_do_not_change_behavior() {
+        let mut parser = NoneParser::new();
+        parser.mark_reasoning_started();
+        parser.mark_think_start_stripped();
+        assert!(!parser.is_in_reasoning());
+
+        let result = parser
+            .detect_and_parse_reasoning("<think>x</think>y")
+            .unwrap();
+        assert_eq!(result.normal_text, "<think>x</think>y");
+        assert_eq!(result.reasoning_text, "");
+    }
+
+    #[test]
+    fn model_type_is_none() {
+        let parser = NoneParser::new();
+        assert_eq!(parser.model_type(), "none");
+    }
+}


### PR DESCRIPTION
Cherry-picks `5ab36713b84ef1c49febf3ee84eca705c63bc063` on top of latest main.

Co-authored-by: Jue Wang <zjuwangjue@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new no-operation parser option that processes input without extracting reasoning. All content is returned unchanged, including any structured reasoning tags. This parser variant provides a passthrough option when reasoning separation is not required.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightseekorg/smg/pull/1505?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->