### PR TITLE
fix(mesh): off-by-one in RetryManager backoff slot lookup

### DIFF
--- a/crates/mesh/src/gossip_controller.rs
+++ b/crates/mesh/src/gossip_controller.rs
@@ -787,11 +787,11 @@ struct RetryManager {
 
 impl RetryManager {
     /// Whether enough time has elapsed since the last attempt to retry.
+    /// `attempt_count` counts *completed* attempts; the next retry's
+    /// delay slot is therefore the zero-indexed `attempt_count - 1`.
     fn should_retry(&self) -> bool {
         match self.last_attempt {
-            Some(last_attempt) => {
-                last_attempt.elapsed() >= self.backoff.delay_for_attempt(self.attempt_count)
-            }
+            Some(last_attempt) => last_attempt.elapsed() >= self.next_delay(),
             None => true,
         }
     }
@@ -812,6 +812,57 @@ impl RetryManager {
     }
 
     fn next_delay(&self) -> Duration {
-        self.backoff.delay_for_attempt(self.attempt_count)
+        // `attempt_count` counts completed attempts; the upcoming retry
+        // is in the zero-indexed slot one below it.
+        self.backoff
+            .delay_for_attempt(self.attempt_count.saturating_sub(1))
+    }
+}
+
+#[cfg(test)]
+mod retry_manager_tests {
+    use super::*;
+
+    #[test]
+    fn first_retry_uses_initial_delay() {
+        let mut mgr = RetryManager::default();
+        mgr.record_attempt();
+        // ExponentialBackoff::default() = (1s, 60s, 2.0)
+        assert_eq!(mgr.next_delay(), Duration::from_secs(1));
+    }
+
+    #[test]
+    fn subsequent_retries_double_until_capped() {
+        let mut mgr = RetryManager::default();
+        mgr.record_attempt();
+        assert_eq!(mgr.next_delay(), Duration::from_secs(1));
+        mgr.record_attempt();
+        assert_eq!(mgr.next_delay(), Duration::from_secs(2));
+        mgr.record_attempt();
+        assert_eq!(mgr.next_delay(), Duration::from_secs(4));
+        // Cap is 60s with the default config: 1 * 2^6 = 64 -> clamped.
+        for _ in 0..10 {
+            mgr.record_attempt();
+        }
+        assert_eq!(mgr.next_delay(), Duration::from_secs(60));
+    }
+
+    #[test]
+    fn reset_returns_to_first_retry_state() {
+        let mut mgr = RetryManager::default();
+        for _ in 0..5 {
+            mgr.record_attempt();
+        }
+        assert_ne!(mgr.next_delay(), Duration::from_secs(1));
+        mgr.reset();
+        assert!(mgr.should_retry(), "post-reset should always allow retry");
+        mgr.record_attempt();
+        assert_eq!(mgr.next_delay(), Duration::from_secs(1));
+    }
+
+    #[test]
+    fn should_retry_before_any_attempt() {
+        let mgr = RetryManager::default();
+        assert!(mgr.should_retry());
     }
 }


### PR DESCRIPTION
## Description

### Problem

`RetryManager::record_attempt` increments `attempt_count` *after* each attempt, so by the time `should_retry` / `next_delay` are consulted for the *next* retry the count already reflects the just-finished attempt. The code then passes that post-increment value straight into `ExponentialBackoff::delay_for_attempt`, which is documented as 0-indexed. Net effect with the default `(1s, 60s, 2.0)` config:

| Retry | Expected wait | Actual wait |
| --- | --- | --- |
| 1 | 1s | 2s |
| 2 | 2s | 4s |
| 3 | 4s | 8s |
| … | doubles to 60s cap | doubles to 60s cap (one slot earlier) |

Every wait is one exponent ahead.

History: this behaviour predates the recent rename (#1495). The increment-then-read pattern has been in `flow_control.rs` since the v1 mesh contribution at `4e108ef0` (Tony Lu / Alibaba, 2026-01-14). Raised by CodeRabbit on the #1495 thread (https://github.com/lightseekorg/smg/pull/1495#discussion_r3243654678); I deferred the fix to keep #1495 scoped as a pure refactor.

### Solution

Read `self.attempt_count.saturating_sub(1)` at the two lookup sites (`should_retry` and `next_delay`) instead of the raw count. `record_attempt` keeps its current "increment on completion" semantics; the consumers translate completed-attempts → zero-indexed retry slot themselves.

`saturating_sub` keeps the `should_retry` branch correct even when `attempt_count == 0` — unreachable today because the `None` arm of `last_attempt` is taken first, but cheap to keep correct in case the invariant ever shifts.

## Changes

- `crates/mesh/src/gossip_controller.rs`
  - `RetryManager::should_retry` now compares `elapsed()` against `self.next_delay()` (avoids duplicating the slot-translation logic).
  - `RetryManager::next_delay` looks up `delay_for_attempt(self.attempt_count.saturating_sub(1))`.
  - Doc comments on both methods explain the completed-attempts → zero-indexed-retry-slot translation.
  - New `retry_manager_tests` module exercising the public `RetryManager` API end-to-end (per codex's recommendation: pin the regression where the bug lived, not at the lower-level `ExponentialBackoff` primitive).

## Test Plan

Before this PR, with the default `(1s, 60s, 2.0)` config:

```text
record_attempt() x1 -> next_delay() = 2s   // expected 1s
record_attempt() x2 -> next_delay() = 4s   // expected 2s
record_attempt() x3 -> next_delay() = 8s   // expected 4s
```

After this PR:

```text
record_attempt() x1 -> next_delay() = 1s   ✓
record_attempt() x2 -> next_delay() = 2s   ✓
record_attempt() x3 -> next_delay() = 4s   ✓
record_attempt() x14 -> next_delay() = 60s ✓ (capped at max_delay)
reset(); record_attempt() -> next_delay() = 1s ✓
```

New `cargo test -p smg-mesh --lib retry_manager` output:

```text
test gossip_controller::retry_manager_tests::should_retry_before_any_attempt ... ok
test gossip_controller::retry_manager_tests::first_retry_uses_initial_delay ... ok
test gossip_controller::retry_manager_tests::reset_returns_to_first_retry_state ... ok
test gossip_controller::retry_manager_tests::subsequent_retries_double_until_capped ... ok
```

Full lib suite: `116 passed; 0 failed; 1 ignored` (4 new from this PR).

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes (pre-commit hook ran `cargo fmt`)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (`cargo clippy -p smg-mesh --all-targets` clean locally)
- [ ] (Optional) Documentation updated — not needed; the doc comment is on the type itself
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)