### PR TITLE
refactor(mesh): extract shared SyncStream message helpers

### DIFF
--- a/crates/mesh/src/gossip_controller.rs
+++ b/crates/mesh/src/gossip_controller.rs
@@ -1,3 +1,29 @@
+//! Node-wide gossip event loop and outbound stream management.
+//!
+//! Despite the name, this file does more than outbound gossip. It owns the
+//! single per-node tick (1 Hz) that drives several responsibilities:
+//!
+//! 1. **SWIM-style peer probing.** Picks a peer from cluster state, sends a
+//!    `Ping` (with `ping_req` indirect-probe fallback), updates membership.
+//! 2. **Outbound `sync_stream` lifecycle.** Dials peers that need a stream,
+//!    spawns the per-peer outbound sender task, retries with exponential
+//!    backoff on failure, garbage-collects finished connections.
+//! 3. **Round collection (node-wide housekeeping).** Drains the local
+//!    [`MeshKV`](crate::kv::MeshKV) into a fresh [`RoundBatch`](crate::kv::RoundBatch)
+//!    and publishes it into a shared `Arc<RwLock<Arc<RoundBatch>>>` slot
+//!    that is read by BOTH the outbound senders here AND the inbound
+//!    senders in [`gossip_service`](crate::gossip_service). This step is
+//!    not outbound-specific — it produces the shared per-round data that
+//!    every outgoing stream (in either direction) consumes.
+//! 4. **Periodic housekeeping**: chunk-assembler GC, retry-manager pruning.
+//!
+//! Per-peer outbound sender tasks also live here. They are spawned by
+//! [`GossipController::event_loop`] when this node initiates a stream to a
+//! peer. The peer's name is captured as a `String` at task-spawn time, so
+//! these senders never need to learn peer identity at runtime — contrast
+//! with the inbound senders in `gossip_service.rs`, which must learn the
+//! counterparty from the first inbound frame.
+
 use std::{
     collections::{BTreeMap, HashMap},
     net::SocketAddr,
@@ -37,6 +63,12 @@ use crate::{
     },
 };
 
+/// The per-node event loop driver. Holds the cluster-state reference,
+/// self-identity, init-peer address, mTLS config, the live set of
+/// outbound sync_stream task handles, and the shared `RoundBatch` slot.
+///
+/// One instance per mesh node. See module docs for the full set of
+/// responsibilities driven by [`event_loop`](Self::event_loop).
 pub struct GossipController {
     state: ClusterState,
     self_name: String,

--- a/crates/mesh/src/gossip_controller.rs
+++ b/crates/mesh/src/gossip_controller.rs
@@ -30,11 +30,9 @@ use super::{
 use crate::{
     metrics,
     transport::{
-        chunking::{build_stream_batches, chunk_value, dispatch_stream_batch, next_generation},
-        limits::{
-            DEFAULT_MAX_CHUNKS_PER_BATCH, MAX_MESSAGE_SIZE, MAX_STREAM_CHUNK_BYTES,
-            STREAM_IDLE_TIMEOUT,
-        },
+        chunking::dispatch_stream_batch,
+        limits::{MAX_MESSAGE_SIZE, STREAM_IDLE_TIMEOUT},
+        sync_stream_messages::{build_heartbeat, build_peer_stream_batches, wrap_stream_batch},
     },
 };
 
@@ -417,12 +415,8 @@ impl GossipController {
                 let sequence = Arc::new(AtomicU64::new(0));
 
                 // Send initial heartbeat
-                let heartbeat = StreamMessage {
-                    message_type: StreamMessageType::Heartbeat as i32,
-                    payload: None,
-                    sequence: sequence.fetch_add(1, Ordering::Relaxed),
-                    peer_id: self_name.clone(),
-                };
+                let heartbeat =
+                    build_heartbeat(sequence.fetch_add(1, Ordering::Relaxed), self_name.clone());
                 if tx.send(heartbeat).await.is_err() {
                     log::warn!("Failed to send initial heartbeat to {}", peer_name);
                     return;
@@ -449,10 +443,9 @@ impl GossipController {
                             let round_start = Instant::now();
 
                             // Stream batches: drain-portion (broadcast) +
-                            // targeted entries addressed to this peer. Each
-                            // entry is chunked if oversized. On channel
-                            // full, the round's stream traffic for this
-                            // peer is dropped — no retry (at-most-once).
+                            // targeted entries addressed to this peer. On
+                            // channel full, the round's stream traffic for
+                            // this peer is dropped — no retry (at-most-once).
                             // Application regenerates on its own retry cycle.
                             let stream_batch = stream_batch_handle.read().clone();
                             let fresh_batch = last_stream_batch
@@ -460,60 +453,32 @@ impl GossipController {
                                 .is_none_or(|last| !Arc::ptr_eq(last, &stream_batch));
                             if fresh_batch {
                                 last_stream_batch = Some(stream_batch.clone());
-                                let mut entries = Vec::new();
-                                // Drain entries are broadcast: every peer emits.
-                                // Generation is per-value so concurrent publishes
-                                // to the same key get distinct tags.
-                                for (key, value) in &stream_batch.drain_entries {
-                                    entries.extend(chunk_value(
-                                        key.clone(),
-                                        next_generation(),
-                                        value.clone(),
-                                        MAX_STREAM_CHUNK_BYTES,
-                                    ));
-                                }
-                                // Targeted entries: only those addressed to this peer.
-                                for (target, key, value) in &stream_batch.targeted_entries {
-                                    if target == &peer_name_incremental {
-                                        entries.extend(chunk_value(
-                                            key.clone(),
-                                            next_generation(),
-                                            value.clone(),
-                                            MAX_STREAM_CHUNK_BYTES,
-                                        ));
-                                    }
-                                }
-                                if !entries.is_empty() {
-                                    for batch in build_stream_batches(
-                                        entries,
-                                        DEFAULT_MAX_CHUNKS_PER_BATCH,
-                                        MAX_STREAM_CHUNK_BYTES,
-                                    ) {
-                                        let msg = StreamMessage {
-                                            message_type: StreamMessageType::StreamBatch as i32,
-                                            payload: Some(StreamPayload::StreamBatch(batch)),
-                                            sequence: shared_sequence
-                                                .fetch_add(1, Ordering::Relaxed),
-                                            peer_id: self_name_incremental.clone(),
-                                        };
-                                        match tx_incremental.try_send(msg) {
-                                            Ok(()) => {}
-                                            Err(mpsc::error::TrySendError::Full(_)) => {
-                                                log::debug!(
-                                                    peer = %peer_name_incremental,
-                                                    "stream batch dropped on backpressure"
-                                                );
-                                                // TODO(metrics): bump
-                                                // stream_dropped_on_backpressure
-                                                break;
-                                            }
-                                            Err(mpsc::error::TrySendError::Closed(_)) => {
-                                                log::warn!(
-                                                    peer = %peer_name_incremental,
-                                                    "stream sender: channel closed, stopping"
-                                                );
-                                                return;
-                                            }
+                                for batch in build_peer_stream_batches(
+                                    &stream_batch,
+                                    &peer_name_incremental,
+                                ) {
+                                    let msg = wrap_stream_batch(
+                                        batch,
+                                        shared_sequence.fetch_add(1, Ordering::Relaxed),
+                                        self_name_incremental.clone(),
+                                    );
+                                    match tx_incremental.try_send(msg) {
+                                        Ok(()) => {}
+                                        Err(mpsc::error::TrySendError::Full(_)) => {
+                                            log::debug!(
+                                                peer = %peer_name_incremental,
+                                                "stream batch dropped on backpressure"
+                                            );
+                                            // TODO(metrics): bump
+                                            // stream_dropped_on_backpressure
+                                            break;
+                                        }
+                                        Err(mpsc::error::TrySendError::Closed(_)) => {
+                                            log::warn!(
+                                                peer = %peer_name_incremental,
+                                                "stream sender: channel closed, stopping"
+                                            );
+                                            return;
                                         }
                                     }
                                 }
@@ -544,13 +509,10 @@ impl GossipController {
                             match msg.message_type() {
                                 StreamMessageType::Heartbeat => {
                                     log::trace!("Received heartbeat from {}", peer_name);
-                                    // Send heartbeat back
-                                    let heartbeat = StreamMessage {
-                                        message_type: StreamMessageType::Heartbeat as i32,
-                                        payload: None,
-                                        sequence: sequence.fetch_add(1, Ordering::Relaxed),
-                                        peer_id: self_name.clone(),
-                                    };
+                                    let heartbeat = build_heartbeat(
+                                        sequence.fetch_add(1, Ordering::Relaxed),
+                                        self_name.clone(),
+                                    );
                                     if tx.send(heartbeat).await.is_err() {
                                         log::warn!("Failed to send heartbeat to {}", peer_name);
                                         break;

--- a/crates/mesh/src/gossip_controller.rs
+++ b/crates/mesh/src/gossip_controller.rs
@@ -30,9 +30,10 @@ use super::{
 use crate::{
     metrics,
     transport::{
-        chunking::dispatch_stream_batch,
         limits::{MAX_MESSAGE_SIZE, STREAM_IDLE_TIMEOUT},
-        sync_stream_messages::{build_heartbeat, build_peer_stream_batches, wrap_stream_batch},
+        sync_stream::{
+            build_heartbeat, build_peer_stream_batches, dispatch_stream_batch, wrap_stream_batch,
+        },
     },
 };
 

--- a/crates/mesh/src/gossip_controller.rs
+++ b/crates/mesh/src/gossip_controller.rs
@@ -416,7 +416,7 @@ impl GossipController {
 
                 // Send initial heartbeat
                 let heartbeat =
-                    build_heartbeat(sequence.fetch_add(1, Ordering::Relaxed), self_name.clone());
+                    build_heartbeat(sequence.fetch_add(1, Ordering::Relaxed), &self_name);
                 if tx.send(heartbeat).await.is_err() {
                     log::warn!("Failed to send initial heartbeat to {}", peer_name);
                     return;
@@ -460,7 +460,7 @@ impl GossipController {
                                     let msg = wrap_stream_batch(
                                         batch,
                                         shared_sequence.fetch_add(1, Ordering::Relaxed),
-                                        self_name_incremental.clone(),
+                                        &self_name_incremental,
                                     );
                                     match tx_incremental.try_send(msg) {
                                         Ok(()) => {}
@@ -511,7 +511,7 @@ impl GossipController {
                                     log::trace!("Received heartbeat from {}", peer_name);
                                     let heartbeat = build_heartbeat(
                                         sequence.fetch_add(1, Ordering::Relaxed),
-                                        self_name.clone(),
+                                        &self_name,
                                     );
                                     if tx.send(heartbeat).await.is_err() {
                                         log::warn!("Failed to send heartbeat to {}", peer_name);

--- a/crates/mesh/src/gossip_service.rs
+++ b/crates/mesh/src/gossip_service.rs
@@ -250,12 +250,18 @@ impl Gossip for GossipService {
 
                     // Empty string disables targeted-entry inclusion when
                     // the inbound peer identity hasn't been learned yet —
-                    // drain entries still go out (broadcast).
-                    let peer_for_targeted = learned_peer_sender.read().clone().unwrap_or_default();
-                    for batch in build_peer_stream_batches(&stream_batch, &peer_for_targeted) {
+                    // drain entries still go out (broadcast). Build the
+                    // batches while holding the read guard (sync, no
+                    // awaits) so we don't allocate an owned String per
+                    // tick just to drop it again.
+                    let batches = {
+                        let guard = learned_peer_sender.read();
+                        let peer_for_targeted = guard.as_deref().unwrap_or("");
+                        build_peer_stream_batches(&stream_batch, peer_for_targeted)
+                    };
+                    for batch in batches {
                         sequence_counter += 1;
-                        let msg =
-                            wrap_stream_batch(batch, sequence_counter, self_name_sender.clone());
+                        let msg = wrap_stream_batch(batch, sequence_counter, &self_name_sender);
                         match tx_sender.try_send(Ok(msg)) {
                             Ok(()) => {}
                             Err(mpsc::error::TrySendError::Full(_)) => {
@@ -324,7 +330,7 @@ impl Gossip for GossipService {
 
                 match msg.message_type() {
                     StreamMessageType::Heartbeat => {
-                        let heartbeat = build_heartbeat(sequence, self_name.clone());
+                        let heartbeat = build_heartbeat(sequence, &self_name);
                         if tx.send(Ok(heartbeat)).await.is_err() {
                             break;
                         }

--- a/crates/mesh/src/gossip_service.rs
+++ b/crates/mesh/src/gossip_service.rs
@@ -25,11 +25,9 @@ use super::{
         try_ping, ClusterState,
     },
     transport::{
-        chunking::{build_stream_batches, chunk_value, dispatch_stream_batch, next_generation},
-        limits::{
-            DEFAULT_MAX_CHUNKS_PER_BATCH, MAX_MESSAGE_SIZE, MAX_STREAM_CHUNK_BYTES,
-            STREAM_IDLE_TIMEOUT,
-        },
+        chunking::dispatch_stream_batch,
+        limits::{MAX_MESSAGE_SIZE, STREAM_IDLE_TIMEOUT},
+        sync_stream_messages::{build_heartbeat, build_peer_stream_batches, wrap_stream_batch},
     },
 };
 
@@ -250,51 +248,14 @@ impl Gossip for GossipService {
                     }
                     last_stream_batch = Some(stream_batch.clone());
 
-                    let peer_for_targeted = learned_peer_sender.read().clone();
-                    let has_targeted = peer_for_targeted.as_ref().is_some_and(|p| {
-                        stream_batch.targeted_entries.iter().any(|(t, _, _)| t == p)
-                    });
-                    if stream_batch.drain_entries.is_empty() && !has_targeted {
-                        continue;
-                    }
-
-                    let mut entries = Vec::new();
-                    for (key, value) in &stream_batch.drain_entries {
-                        entries.extend(chunk_value(
-                            key.clone(),
-                            next_generation(),
-                            value.clone(),
-                            MAX_STREAM_CHUNK_BYTES,
-                        ));
-                    }
-                    if let Some(ref peer) = peer_for_targeted {
-                        for (target, key, value) in &stream_batch.targeted_entries {
-                            if target == peer {
-                                entries.extend(chunk_value(
-                                    key.clone(),
-                                    next_generation(),
-                                    value.clone(),
-                                    MAX_STREAM_CHUNK_BYTES,
-                                ));
-                            }
-                        }
-                    }
-                    if entries.is_empty() {
-                        continue;
-                    }
-
-                    for batch in build_stream_batches(
-                        entries,
-                        DEFAULT_MAX_CHUNKS_PER_BATCH,
-                        MAX_STREAM_CHUNK_BYTES,
-                    ) {
+                    // Empty string disables targeted-entry inclusion when
+                    // the inbound peer identity hasn't been learned yet —
+                    // drain entries still go out (broadcast).
+                    let peer_for_targeted = learned_peer_sender.read().clone().unwrap_or_default();
+                    for batch in build_peer_stream_batches(&stream_batch, &peer_for_targeted) {
                         sequence_counter += 1;
-                        let msg = StreamMessage {
-                            message_type: StreamMessageType::StreamBatch as i32,
-                            payload: Some(gossip::stream_message::Payload::StreamBatch(batch)),
-                            sequence: sequence_counter,
-                            peer_id: self_name_sender.clone(),
-                        };
+                        let msg =
+                            wrap_stream_batch(batch, sequence_counter, self_name_sender.clone());
                         match tx_sender.try_send(Ok(msg)) {
                             Ok(()) => {}
                             Err(mpsc::error::TrySendError::Full(_)) => {
@@ -363,12 +324,7 @@ impl Gossip for GossipService {
 
                 match msg.message_type() {
                     StreamMessageType::Heartbeat => {
-                        let heartbeat = StreamMessage {
-                            message_type: StreamMessageType::Heartbeat as i32,
-                            payload: None,
-                            sequence,
-                            peer_id: self_name.clone(),
-                        };
+                        let heartbeat = build_heartbeat(sequence, self_name.clone());
                         if tx.send(Ok(heartbeat)).await.is_err() {
                             break;
                         }

--- a/crates/mesh/src/gossip_service.rs
+++ b/crates/mesh/src/gossip_service.rs
@@ -248,16 +248,12 @@ impl Gossip for GossipService {
                     }
                     last_stream_batch = Some(stream_batch.clone());
 
-                    // Empty string disables targeted-entry inclusion when
-                    // the inbound peer identity hasn't been learned yet —
-                    // drain entries still go out (broadcast). Build the
-                    // batches while holding the read guard (sync, no
-                    // awaits) so we don't allocate an owned String per
-                    // tick just to drop it again.
+                    // `peer_id = ""` => peer not yet learned; drain still
+                    // emits, targeted skipped. Hold the guard across the
+                    // sync helper call to avoid a per-tick String alloc.
                     let batches = {
                         let guard = learned_peer_sender.read();
-                        let peer_for_targeted = guard.as_deref().unwrap_or("");
-                        build_peer_stream_batches(&stream_batch, peer_for_targeted)
+                        build_peer_stream_batches(&stream_batch, guard.as_deref().unwrap_or(""))
                     };
                     for batch in batches {
                         sequence_counter += 1;

--- a/crates/mesh/src/gossip_service.rs
+++ b/crates/mesh/src/gossip_service.rs
@@ -1,3 +1,34 @@
+//! Inbound `Gossip` gRPC service.
+//!
+//! Implements the proto-defined `Gossip` service (see
+//! `proto/gossip.proto`). For each accepted connection this file
+//! handles both RPCs:
+//!
+//! - **`PingServer` (unary)**: SWIM-style ping with optional embedded
+//!   `state_sync` and `ping_req` indirect-probe forwarding. Used by
+//!   the membership channel; no streaming, no per-call task state.
+//! - **`SyncStream` (bidirectional streaming)**: spawns **two tasks**
+//!   per accepted stream that share a few small pieces of state:
+//!   - **Inbound-handler task** — reads frames the dialer sends.
+//!     The first non-empty `msg.peer_id` is written into
+//!     `learned_peer: Arc<RwLock<Option<String>>>`. Dispatches
+//!     received `StreamBatch` payloads into local `MeshKV` via
+//!     [`dispatch_stream_batch`](crate::transport::sync_stream::dispatch_stream_batch).
+//!     Idle-timeout wraps `incoming.next()` so unhealthy peers don't
+//!     pin the task indefinitely.
+//!   - **Inbound-sender task** — every 1 Hz, reads the shared
+//!     [`RoundBatch`](crate::kv::RoundBatch) slot produced by
+//!     [`gossip_controller`](crate::gossip_controller)'s event loop,
+//!     filters targeted entries for the learned peer, and emits
+//!     `StreamBatch` envelopes on this stream.
+//!
+//! Asymmetry with the outbound side: the dialer (gossip_controller)
+//! knows its counterparty by name at task-spawn time. The acceptor
+//! here does not — the only way to associate the in-flight TCP/gRPC
+//! connection with a logical mesh identity (today, pre-mTLS-derived
+//! identity) is to read the first inbound frame's `peer_id`. That
+//! learning step is what `learned_peer` exists for.
+
 use std::{net::SocketAddr, pin::Pin, sync::Arc, time::Duration};
 
 use anyhow::Result;
@@ -32,6 +63,14 @@ use super::{
     },
 };
 
+/// Server-side handler for the proto-defined `Gossip` service.
+///
+/// One instance per mesh node. Configured at startup by
+/// `service.rs::MeshServerBuilder` and registered with tonic. Holds
+/// shared references to the cluster state, mTLS config, partition
+/// detector, the per-node `RoundBatch` slot owned by the controller,
+/// and the node's `MeshKV`. See module docs for the per-accepted-
+/// stream task topology spawned by `sync_stream`.
 #[derive(Debug)]
 pub struct GossipService {
     state: ClusterState,

--- a/crates/mesh/src/gossip_service.rs
+++ b/crates/mesh/src/gossip_service.rs
@@ -25,9 +25,10 @@ use super::{
         try_ping, ClusterState,
     },
     transport::{
-        chunking::dispatch_stream_batch,
         limits::{MAX_MESSAGE_SIZE, STREAM_IDLE_TIMEOUT},
-        sync_stream_messages::{build_heartbeat, build_peer_stream_batches, wrap_stream_batch},
+        sync_stream::{
+            build_heartbeat, build_peer_stream_batches, dispatch_stream_batch, wrap_stream_batch,
+        },
     },
 };
 

--- a/crates/mesh/src/tests/chunking_integration.rs
+++ b/crates/mesh/src/tests/chunking_integration.rs
@@ -37,8 +37,9 @@ use crate::{
     kv::{MeshKV, StreamConfig, StreamRouting},
     service::gossip::StreamEntry,
     transport::{
-        chunking::{build_stream_batches, chunk_value, dispatch_stream_batch, next_generation},
+        chunking::{build_stream_batches, chunk_value, next_generation},
         limits::{DEFAULT_MAX_CHUNKS_PER_BATCH, MAX_STREAM_CHUNK_BYTES},
+        sync_stream::dispatch_stream_batch,
     },
 };
 

--- a/crates/mesh/src/transport/chunking.rs
+++ b/crates/mesh/src/transport/chunking.rs
@@ -1,13 +1,15 @@
-//! Sender-side stream chunking helpers and receiver-side dispatch.
+//! Stream chunking and batching primitives.
 //!
-//! Sender: [`chunk_value`] splits an oversized value into a sequence
-//! of `StreamEntry`s; [`build_stream_batches`] packs them into
-//! `StreamBatch` messages respecting a per-batch cap.
+//! [`chunk_value`] splits an oversized value into a sequence of
+//! `StreamEntry`s; [`build_stream_batches`] packs them into
+//! `StreamBatch` messages respecting per-batch count and byte caps.
+//! [`next_generation`] hands out monotonic tags so the receiver's
+//! [`ChunkAssembler`](crate::transport::chunk_assembler::ChunkAssembler)
+//! can group chunks of the same value.
 //!
-//! Receiver: [`dispatch_stream_batch`] routes inbound entries —
-//! single-chunk entries fire subscribers directly, multi-chunk entries
-//! go through the [`ChunkAssembler`](crate::transport::chunk_assembler::ChunkAssembler)
-//! and fire subscribers only on full reassembly.
+//! These are pure data-shape functions: no `MeshKV` state, no peer
+//! routing, no envelope construction. Higher-level composition lives
+//! in [`crate::transport::sync_stream`].
 
 use std::sync::{
     atomic::{AtomicU64, Ordering},
@@ -16,10 +18,7 @@ use std::sync::{
 
 use bytes::Bytes;
 
-use crate::{
-    kv::MeshKV,
-    service::gossip::{StreamBatch, StreamEntry},
-};
+use crate::service::gossip::{StreamBatch, StreamEntry};
 
 /// Monotonic generation counter for stream-batch values. Seeded from
 /// wall-clock nanos on first use so a process restart starts at a
@@ -89,52 +88,6 @@ pub fn chunk_value(
         });
     }
     entries
-}
-
-/// Receiver-side dispatch for `StreamBatch` entries. Single-chunk
-/// entries (`total_chunks == 1`) fire subscribers directly — no state
-/// in the chunk assembler. Multi-chunk entries route through the
-/// assembler and fire subscribers only on full reassembly.
-///
-/// Each chunk payload is detached from the decoded `StreamBatch`
-/// buffer via `Bytes::copy_from_slice` before it's stored or
-/// forwarded. Without this, the prost-generated `StreamEntry.data`
-/// is a `Bytes` view into the message frame, so a single pinned
-/// chunk (in the assembler or in a subscriber queue) would retain
-/// the entire batch allocation. That would let a peer packing many
-/// tiny entries into near-`MAX_MESSAGE_SIZE` batches defeat both
-/// `DEFAULT_MAX_ASSEMBLER_BYTES` and subscriber backpressure.
-///
-/// The chunk assembler scopes in-flight state by `peer_id` so
-/// concurrent chunked values from different senders under the same
-/// key don't collide.
-pub fn dispatch_stream_batch(
-    mesh_kv: &MeshKV,
-    peer_id: &str,
-    entries: impl IntoIterator<Item = StreamEntry>,
-) {
-    for entry in entries {
-        let data = Bytes::copy_from_slice(&entry.data);
-        if entry.total_chunks == 1 {
-            // A fresh single-chunk value supersedes any in-flight
-            // multi-chunk assembly for the same (peer, key); drop the
-            // stale fragments so they don't wait for GC.
-            mesh_kv.chunk_assembler().drop_pending(peer_id, &entry.key);
-            mesh_kv.notify_subscribers(&entry.key, Some(vec![data]));
-        } else {
-            let key = entry.key.clone();
-            if let Some(fragments) = mesh_kv.chunk_assembler().receive_chunk(
-                peer_id,
-                &key,
-                entry.generation,
-                entry.chunk_index,
-                entry.total_chunks,
-                data,
-            ) {
-                mesh_kv.notify_subscribers(&key, Some(fragments));
-            }
-        }
-    }
 }
 
 /// Pack `StreamEntry`s into one or more `StreamBatch`es, flushing

--- a/crates/mesh/src/transport/mod.rs
+++ b/crates/mesh/src/transport/mod.rs
@@ -5,3 +5,4 @@
 pub mod chunk_assembler;
 pub mod chunking;
 pub mod limits;
+pub mod sync_stream_messages;

--- a/crates/mesh/src/transport/mod.rs
+++ b/crates/mesh/src/transport/mod.rs
@@ -5,4 +5,4 @@
 pub mod chunk_assembler;
 pub mod chunking;
 pub mod limits;
-pub mod sync_stream_messages;
+pub mod sync_stream;

--- a/crates/mesh/src/transport/sync_stream.rs
+++ b/crates/mesh/src/transport/sync_stream.rs
@@ -1,17 +1,30 @@
-//! Shared SyncStream payload construction helpers.
+//! SyncStream wire-message helpers — both directions of the
+//! bidirectional `Gossip::sync_stream` RPC live here.
 //!
-//! Both the outbound [`gossip_controller`](crate::gossip_controller)
-//! and the inbound [`gossip_service`](crate::gossip_service) need
-//! to build per-peer stream batches from a drained
-//! [`RoundBatch`](crate::kv::RoundBatch) and wrap them in
-//! `StreamMessage` envelopes. Putting that logic in one place keeps
-//! the chunking + batching + envelope shape consistent across both
-//! directions of the stream.
+//! Outbound (sender side):
+//! - [`build_peer_stream_batches`] composes [`chunk_value`] +
+//!   [`build_stream_batches`] for a single peer.
+//! - [`wrap_stream_batch`] / [`build_heartbeat`] construct
+//!   `StreamMessage` envelopes.
+//!
+//! Inbound (receiver side):
+//! - [`dispatch_stream_batch`] routes the entries of a received
+//!   `StreamBatch` to local subscribers — single-chunk entries fire
+//!   directly; multi-chunk entries go through the
+//!   [`ChunkAssembler`](crate::transport::chunk_assembler::ChunkAssembler)
+//!   and fire only on full reassembly.
+//!
+//! The pure chunk/batch arithmetic lives in
+//! [`crate::transport::chunking`]; this module composes it into
+//! the message layer.
+
+use bytes::Bytes;
 
 use crate::{
-    kv::RoundBatch,
+    kv::{MeshKV, RoundBatch},
     service::gossip::{
-        stream_message::Payload as StreamPayload, StreamBatch, StreamMessage, StreamMessageType,
+        stream_message::Payload as StreamPayload, StreamBatch, StreamEntry, StreamMessage,
+        StreamMessageType,
     },
     transport::{
         chunking::{build_stream_batches, chunk_value, next_generation},
@@ -82,6 +95,52 @@ pub fn build_heartbeat(sequence: u64, self_name: &str) -> StreamMessage {
         payload: None,
         sequence,
         peer_id: self_name.to_owned(),
+    }
+}
+
+/// Receiver-side dispatch for `StreamBatch` entries. Single-chunk
+/// entries (`total_chunks == 1`) fire subscribers directly — no state
+/// in the chunk assembler. Multi-chunk entries route through the
+/// assembler and fire subscribers only on full reassembly.
+///
+/// Each chunk payload is detached from the decoded `StreamBatch`
+/// buffer via `Bytes::copy_from_slice` before it's stored or
+/// forwarded. Without this, the prost-generated `StreamEntry.data`
+/// is a `Bytes` view into the message frame, so a single pinned
+/// chunk (in the assembler or in a subscriber queue) would retain
+/// the entire batch allocation. That would let a peer packing many
+/// tiny entries into near-`MAX_MESSAGE_SIZE` batches defeat both
+/// `DEFAULT_MAX_ASSEMBLER_BYTES` and subscriber backpressure.
+///
+/// The chunk assembler scopes in-flight state by `peer_id` so
+/// concurrent chunked values from different senders under the same
+/// key don't collide.
+pub fn dispatch_stream_batch(
+    mesh_kv: &MeshKV,
+    peer_id: &str,
+    entries: impl IntoIterator<Item = StreamEntry>,
+) {
+    for entry in entries {
+        let data = Bytes::copy_from_slice(&entry.data);
+        if entry.total_chunks == 1 {
+            // A fresh single-chunk value supersedes any in-flight
+            // multi-chunk assembly for the same (peer, key); drop the
+            // stale fragments so they don't wait for GC.
+            mesh_kv.chunk_assembler().drop_pending(peer_id, &entry.key);
+            mesh_kv.notify_subscribers(&entry.key, Some(vec![data]));
+        } else {
+            let key = entry.key.clone();
+            if let Some(fragments) = mesh_kv.chunk_assembler().receive_chunk(
+                peer_id,
+                &key,
+                entry.generation,
+                entry.chunk_index,
+                entry.total_chunks,
+                data,
+            ) {
+                mesh_kv.notify_subscribers(&key, Some(fragments));
+            }
+        }
     }
 }
 

--- a/crates/mesh/src/transport/sync_stream_messages.rs
+++ b/crates/mesh/src/transport/sync_stream_messages.rs
@@ -25,13 +25,16 @@ use crate::{
 ///
 /// `drain_entries` are broadcast: every peer's emitter includes
 /// them. `targeted_entries` are only included when their target
-/// matches `peer_id` — pass `""` to skip all targeted entries
-/// (e.g. when the inbound peer identity is not yet learned).
+/// matches `peer_id` AND `peer_id` is non-empty — pass `""` to
+/// disable targeted entries entirely (e.g. when the inbound peer
+/// identity is not yet learned). The explicit empty-check guards
+/// against the degenerate `target == "" == peer_id` match.
 /// Oversized values are split via [`chunk_value`]; the returned
 /// batches respect the `DEFAULT_MAX_CHUNKS_PER_BATCH` /
 /// `MAX_STREAM_CHUNK_BYTES` caps.
 pub fn build_peer_stream_batches(round_batch: &RoundBatch, peer_id: &str) -> Vec<StreamBatch> {
-    let mut entries = Vec::new();
+    let mut entries =
+        Vec::with_capacity(round_batch.drain_entries.len() + round_batch.targeted_entries.len());
     for (key, value) in &round_batch.drain_entries {
         entries.extend(chunk_value(
             key.clone(),
@@ -40,14 +43,16 @@ pub fn build_peer_stream_batches(round_batch: &RoundBatch, peer_id: &str) -> Vec
             MAX_STREAM_CHUNK_BYTES,
         ));
     }
-    for (target, key, value) in &round_batch.targeted_entries {
-        if target == peer_id {
-            entries.extend(chunk_value(
-                key.clone(),
-                next_generation(),
-                value.clone(),
-                MAX_STREAM_CHUNK_BYTES,
-            ));
+    if !peer_id.is_empty() {
+        for (target, key, value) in &round_batch.targeted_entries {
+            if target == peer_id {
+                entries.extend(chunk_value(
+                    key.clone(),
+                    next_generation(),
+                    value.clone(),
+                    MAX_STREAM_CHUNK_BYTES,
+                ));
+            }
         }
     }
     if entries.is_empty() {
@@ -61,22 +66,22 @@ pub fn build_peer_stream_batches(round_batch: &RoundBatch, peer_id: &str) -> Vec
 }
 
 /// Wrap a `StreamBatch` in a `StreamMessage` envelope.
-pub fn wrap_stream_batch(batch: StreamBatch, sequence: u64, self_name: String) -> StreamMessage {
+pub fn wrap_stream_batch(batch: StreamBatch, sequence: u64, self_name: &str) -> StreamMessage {
     StreamMessage {
         message_type: StreamMessageType::StreamBatch as i32,
         payload: Some(StreamPayload::StreamBatch(batch)),
         sequence,
-        peer_id: self_name,
+        peer_id: self_name.to_owned(),
     }
 }
 
 /// Build a heartbeat `StreamMessage` (no payload, message_type = Heartbeat).
-pub fn build_heartbeat(sequence: u64, self_name: String) -> StreamMessage {
+pub fn build_heartbeat(sequence: u64, self_name: &str) -> StreamMessage {
     StreamMessage {
         message_type: StreamMessageType::Heartbeat as i32,
         payload: None,
         sequence,
-        peer_id: self_name,
+        peer_id: self_name.to_owned(),
     }
 }
 
@@ -151,9 +156,20 @@ mod tests {
     }
 
     #[test]
+    fn empty_peer_id_skips_target_with_empty_string() {
+        // Defensive: a targeted entry whose `target` is the empty
+        // string MUST NOT match the "peer unknown" sentinel
+        // (`peer_id = ""`). Without the explicit `is_empty` guard the
+        // `target == peer_id` comparison would let it through.
+        let rb = round_batch_with(vec![], vec![("", "tree:req:bad", b"oops".as_slice())]);
+        let batches = build_peer_stream_batches(&rb, "");
+        assert!(batches.is_empty(), "empty peer_id must skip all targeted");
+    }
+
+    #[test]
     fn wrap_stream_batch_envelope_shape() {
         let batch = StreamBatch::default();
-        let msg = wrap_stream_batch(batch, 42, "node-1".to_string());
+        let msg = wrap_stream_batch(batch, 42, "node-1");
         assert_eq!(msg.message_type, StreamMessageType::StreamBatch as i32);
         assert_eq!(msg.sequence, 42);
         assert_eq!(msg.peer_id, "node-1");
@@ -162,7 +178,7 @@ mod tests {
 
     #[test]
     fn build_heartbeat_envelope_shape() {
-        let msg = build_heartbeat(7, "node-2".to_string());
+        let msg = build_heartbeat(7, "node-2");
         assert_eq!(msg.message_type, StreamMessageType::Heartbeat as i32);
         assert_eq!(msg.sequence, 7);
         assert_eq!(msg.peer_id, "node-2");

--- a/crates/mesh/src/transport/sync_stream_messages.rs
+++ b/crates/mesh/src/transport/sync_stream_messages.rs
@@ -1,0 +1,171 @@
+//! Shared SyncStream payload construction helpers.
+//!
+//! Both the outbound [`gossip_controller`](crate::gossip_controller)
+//! and the inbound [`gossip_service`](crate::gossip_service) need
+//! to build per-peer stream batches from a drained
+//! [`RoundBatch`](crate::kv::RoundBatch) and wrap them in
+//! `StreamMessage` envelopes. Putting that logic in one place keeps
+//! the chunking + batching + envelope shape consistent across both
+//! directions of the stream.
+
+use crate::{
+    kv::RoundBatch,
+    service::gossip::{
+        stream_message::Payload as StreamPayload, StreamBatch, StreamMessage, StreamMessageType,
+    },
+    transport::{
+        chunking::{build_stream_batches, chunk_value, next_generation},
+        limits::{DEFAULT_MAX_CHUNKS_PER_BATCH, MAX_STREAM_CHUNK_BYTES},
+    },
+};
+
+/// Build the `StreamBatch`es that should be sent to `peer_id` for
+/// the current round. Returns an empty `Vec` when neither the
+/// broadcast drain nor any targeted entry is addressed to this peer.
+///
+/// `drain_entries` are broadcast: every peer's emitter includes
+/// them. `targeted_entries` are only included when their target
+/// matches `peer_id` — pass `""` to skip all targeted entries
+/// (e.g. when the inbound peer identity is not yet learned).
+/// Oversized values are split via [`chunk_value`]; the returned
+/// batches respect the `DEFAULT_MAX_CHUNKS_PER_BATCH` /
+/// `MAX_STREAM_CHUNK_BYTES` caps.
+pub fn build_peer_stream_batches(round_batch: &RoundBatch, peer_id: &str) -> Vec<StreamBatch> {
+    let mut entries = Vec::new();
+    for (key, value) in &round_batch.drain_entries {
+        entries.extend(chunk_value(
+            key.clone(),
+            next_generation(),
+            value.clone(),
+            MAX_STREAM_CHUNK_BYTES,
+        ));
+    }
+    for (target, key, value) in &round_batch.targeted_entries {
+        if target == peer_id {
+            entries.extend(chunk_value(
+                key.clone(),
+                next_generation(),
+                value.clone(),
+                MAX_STREAM_CHUNK_BYTES,
+            ));
+        }
+    }
+    if entries.is_empty() {
+        return Vec::new();
+    }
+    build_stream_batches(
+        entries,
+        DEFAULT_MAX_CHUNKS_PER_BATCH,
+        MAX_STREAM_CHUNK_BYTES,
+    )
+}
+
+/// Wrap a `StreamBatch` in a `StreamMessage` envelope.
+pub fn wrap_stream_batch(batch: StreamBatch, sequence: u64, self_name: String) -> StreamMessage {
+    StreamMessage {
+        message_type: StreamMessageType::StreamBatch as i32,
+        payload: Some(StreamPayload::StreamBatch(batch)),
+        sequence,
+        peer_id: self_name,
+    }
+}
+
+/// Build a heartbeat `StreamMessage` (no payload, message_type = Heartbeat).
+pub fn build_heartbeat(sequence: u64, self_name: String) -> StreamMessage {
+    StreamMessage {
+        message_type: StreamMessageType::Heartbeat as i32,
+        payload: None,
+        sequence,
+        peer_id: self_name,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+
+    use super::*;
+
+    fn round_batch_with(
+        drain: Vec<(&str, &[u8])>,
+        targeted: Vec<(&str, &str, &[u8])>,
+    ) -> RoundBatch {
+        RoundBatch {
+            drain_entries: drain
+                .into_iter()
+                .map(|(k, v)| (k.to_string(), Bytes::copy_from_slice(v)))
+                .collect(),
+            targeted_entries: targeted
+                .into_iter()
+                .map(|(t, k, v)| (t.to_string(), k.to_string(), Bytes::copy_from_slice(v)))
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn empty_round_batch_emits_nothing() {
+        let rb = round_batch_with(vec![], vec![]);
+        assert!(build_peer_stream_batches(&rb, "peer1").is_empty());
+    }
+
+    #[test]
+    fn drain_only_is_emitted_to_every_peer() {
+        let rb = round_batch_with(vec![("td:abc", b"hello")], vec![]);
+        let a = build_peer_stream_batches(&rb, "peer1");
+        let b = build_peer_stream_batches(&rb, "peer2");
+        assert_eq!(a.len(), 1);
+        assert_eq!(b.len(), 1);
+        assert_eq!(a[0].entries.len(), 1);
+        assert_eq!(a[0].entries[0].key, "td:abc");
+    }
+
+    #[test]
+    fn targeted_entries_filter_by_peer() {
+        let rb = round_batch_with(
+            vec![],
+            vec![
+                ("peer1", "tree:req:a", b"req-a".as_slice()),
+                ("peer2", "tree:req:b", b"req-b".as_slice()),
+            ],
+        );
+        let a = build_peer_stream_batches(&rb, "peer1");
+        assert_eq!(a.len(), 1);
+        assert_eq!(a[0].entries.len(), 1);
+        assert_eq!(a[0].entries[0].key, "tree:req:a");
+
+        let none = build_peer_stream_batches(&rb, "");
+        assert!(none.is_empty());
+    }
+
+    #[test]
+    fn drain_emitted_even_when_peer_unknown() {
+        let rb = round_batch_with(
+            vec![("td:abc", b"hello".as_slice())],
+            vec![("peer1", "tree:req:a", b"req-a".as_slice())],
+        );
+        // Empty peer_id -> targeted entries excluded, drain still emitted.
+        let batches = build_peer_stream_batches(&rb, "");
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].entries.len(), 1);
+        assert_eq!(batches[0].entries[0].key, "td:abc");
+    }
+
+    #[test]
+    fn wrap_stream_batch_envelope_shape() {
+        let batch = StreamBatch::default();
+        let msg = wrap_stream_batch(batch, 42, "node-1".to_string());
+        assert_eq!(msg.message_type, StreamMessageType::StreamBatch as i32);
+        assert_eq!(msg.sequence, 42);
+        assert_eq!(msg.peer_id, "node-1");
+        assert!(matches!(msg.payload, Some(StreamPayload::StreamBatch(_))));
+    }
+
+    #[test]
+    fn build_heartbeat_envelope_shape() {
+        let msg = build_heartbeat(7, "node-2".to_string());
+        assert_eq!(msg.message_type, StreamMessageType::Heartbeat as i32);
+        assert_eq!(msg.sequence, 7);
+        assert_eq!(msg.peer_id, "node-2");
+        assert!(msg.payload.is_none());
+    }
+}


### PR DESCRIPTION
## Description

### Problem

The per-peer batch-emit pipeline was duplicated between the outbound controller (`gossip_controller.rs`) and the inbound service (`gossip_service.rs`):

- Drain a `RoundBatch` into `drain_entries` (broadcast) + `targeted_entries` (filter by this peer)
- Chunk oversized values via `chunk_value`
- Pack chunks through `build_stream_batches`
- Wrap each `StreamBatch` in a `StreamMessage` envelope with `message_type = StreamBatch`, payload, sequence, self_name

Plus a smaller heartbeat constructor (`StreamMessage { message_type = Heartbeat, payload: None, sequence, peer_id: self_name }`) duplicated across three sites: the controller's initial heartbeat, the controller's inbound heartbeat reply, and the service's inbound heartbeat reply.

Any future change to the envelope shape — adding the planned `CRDT_BATCH` outbound path, tweaking sequence semantics, etc. — would have to land in two files in lockstep.

### Solution

Extract the shared logic into a new `transport::sync_stream_messages` module:

- `build_peer_stream_batches(round_batch, peer_id) -> Vec<StreamBatch>` — drain (broadcast) + targeted-to-this-peer filtering + chunking + batching. Pass `peer_id = ""` to skip targeted entries entirely (used by the inbound service before it learns the remote peer identity; drain still goes out). The explicit `!peer_id.is_empty()` guard prevents a degenerate match against a targeted entry whose target is also the empty string.
- `wrap_stream_batch(batch, sequence, self_name: &str) -> StreamMessage` — single point for the envelope shape. Caller controls the sequence source, so the controller's shared `Arc<AtomicU64>` and the service's task-local `u64` both fit without ceremony.
- `build_heartbeat(sequence, self_name: &str) -> StreamMessage` — three call sites collapse to one constructor.

Behaviour is preserved. One micro-change: the service used to short-circuit the per-tick body with `continue` when `drain_entries` was empty AND no `targeted_entries` matched the learned peer. Now the helper returns an empty `Vec<StreamBatch>` and the per-batch loop simply doesn't execute. Same effect, fewer branches at the call site. The `fresh` check (`Arc::ptr_eq` against last batch) still fires first, so the empty-Vec path is rare.

## Changes

- `crates/mesh/src/transport/sync_stream_messages.rs` — new module with the three helpers plus 7 unit tests.
- `crates/mesh/src/transport/mod.rs` — declare the new module.
- `crates/mesh/src/gossip_controller.rs` — replace inline batch-emit pipeline + two inline heartbeat constructions with the helpers. Removes ~60 lines of duplicated logic.
- `crates/mesh/src/gossip_service.rs` — same on the inbound side, plus the inbound heartbeat-reply site. Removes ~45 lines. Holds the `learned_peer` read guard across the synchronous helper call and uses `as_deref()` instead of cloning the `Option<String>` every tick.

## Test Plan

New `transport::sync_stream_messages::tests`:

```text
test transport::sync_stream_messages::tests::build_heartbeat_envelope_shape ... ok
test transport::sync_stream_messages::tests::drain_emitted_even_when_peer_unknown ... ok
test transport::sync_stream_messages::tests::drain_only_is_emitted_to_every_peer ... ok
test transport::sync_stream_messages::tests::empty_peer_id_skips_target_with_empty_string ... ok
test transport::sync_stream_messages::tests::empty_round_batch_emits_nothing ... ok
test transport::sync_stream_messages::tests::targeted_entries_filter_by_peer ... ok
test transport::sync_stream_messages::tests::wrap_stream_batch_envelope_shape ... ok
```

Cases covered: empty RoundBatch returns empty Vec, drain entries go to every peer, targeted entries filter by `peer_id`, drain is still emitted when `peer_id = ""` (peer unknown), the defensive guard that `peer_id = ""` skips a targeted entry whose target is also empty, and the `wrap_stream_batch` / `build_heartbeat` envelope shapes.

Full lib suite: `cargo test -p smg-mesh --lib` — **123 passed, 0 failed, 1 ignored** (116 prior + 7 new).

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes (pre-commit ran `cargo fmt`)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (`cargo clippy -p smg-mesh --all-targets` clean locally)
- [ ] (Optional) Documentation updated — module doc comments + doc on each helper
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactoring**
  * Reorganized sync-stream message construction into shared helpers for cleaner, more consistent outbound and inbound handling.
* **Reliability / Performance**
  * Reduced redundant per-peer sends by skipping unchanged rounds and improving heartbeat consistency, preserving backpressure behavior.
* **Tests**
  * Added unit tests covering outbound batch selection, envelope shapes, and edge cases for peer-targeted routing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightseekorg/smg/pull/1513?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->