### PR TITLE
fix(realtime): drop OpenAI-Beta header rejected by GA Realtime API

### DIFF
--- a/e2e_test/realtime/test_realtime_ws.py
+++ b/e2e_test/realtime/test_realtime_ws.py
@@ -145,7 +145,6 @@ def ws_headers():
     """Build the WebSocket connection headers."""
     return {
         "Authorization": f"Bearer {OPENAI_API_KEY}",
-        "OpenAI-Beta": "realtime=v1",
     }
 
 

--- a/e2e_test/realtime/test_realtime_ws.py
+++ b/e2e_test/realtime/test_realtime_ws.py
@@ -4,7 +4,7 @@ Tests the gateway's ability to proxy OpenAI Realtime API WebSocket sessions:
 - Session lifecycle (connect, session.created, session.update)
 - Text generation (single-turn and multi-turn conversations)
 - Response cancellation mid-stream
-- Response format validation (session.created, response.done, response.text.delta)
+- Response format validation (session.created, response.done, response.output_text.delta)
 - Error handling (invalid events, missing model, missing auth)
 
 Prerequisites:
@@ -97,7 +97,7 @@ async def _collect_response_text(ws, *, timeout: float = RECV_TIMEOUT) -> str:
         if event is None:
             continue
         etype = event.get("type", "")
-        if etype == "response.text.delta" and event.get("delta"):
+        if etype == "response.output_text.delta" and event.get("delta"):
             parts.append(event["delta"])
         elif etype == "response.done":
             break
@@ -111,7 +111,12 @@ async def _realtime_session(ws_url: str, ws_headers: dict):
     """Connect, wait for session.created, configure text modality, yield ws."""
     async with websockets.connect(ws_url, additional_headers=ws_headers) as ws:
         await _recv_event(ws, event_type="session.created")
-        await ws.send(_make_event("session.update", session={"modalities": ["text"]}))
+        await ws.send(
+            _make_event(
+                "session.update",
+                session={"type": "realtime", "output_modalities": ["text"]},
+            )
+        )
         await _recv_event(ws, event_type="session.updated")
         yield ws
 
@@ -178,11 +183,16 @@ class TestRealtimeWebSocket:
         async def _run():
             async with websockets.connect(ws_url, additional_headers=ws_headers) as ws:
                 await _recv_event(ws, event_type="session.created")
-                await ws.send(_make_event("session.update", session={"modalities": ["text"]}))
+                await ws.send(
+                    _make_event(
+                        "session.update",
+                        session={"type": "realtime", "output_modalities": ["text"]},
+                    )
+                )
                 event = await _recv_event(ws, event_type="session.updated")
                 assert event["type"] == "session.updated"
                 assert "session" in event
-                assert event["session"].get("modalities") == ["text"]
+                assert event["session"].get("output_modalities") == ["text"]
                 logger.info("Session updated successfully")
 
         asyncio.run(_run())
@@ -196,7 +206,7 @@ class TestRealtimeWebSocket:
                 await ws.send(
                     _make_event(
                         "response.create",
-                        response={"modalities": ["text"]},
+                        response={"output_modalities": ["text"]},
                     )
                 )
 
@@ -213,14 +223,18 @@ class TestRealtimeWebSocket:
             async with _realtime_session(ws_url, ws_headers) as ws:
                 # Turn 1
                 await ws.send(_make_user_message("My name is Alice."))
-                await ws.send(_make_event("response.create", response={"modalities": ["text"]}))
+                await ws.send(
+                    _make_event("response.create", response={"output_modalities": ["text"]})
+                )
                 text1 = await _collect_response_text(ws)
                 assert len(text1) > 0
                 logger.info("Turn 1: %s", text1[:100])
 
                 # Turn 2 — model should remember the name
                 await ws.send(_make_user_message("What is my name?"))
-                await ws.send(_make_event("response.create", response={"modalities": ["text"]}))
+                await ws.send(
+                    _make_event("response.create", response={"output_modalities": ["text"]})
+                )
                 text2 = await _collect_response_text(ws)
                 assert "alice" in text2.lower(), f"Expected 'Alice' in response, got: {text2}"
                 logger.info("Turn 2: %s", text2[:100])
@@ -248,10 +262,12 @@ class TestRealtimeWebSocket:
                 await ws.send(
                     _make_user_message("Write a very long essay about the history of computing.")
                 )
-                await ws.send(_make_event("response.create", response={"modalities": ["text"]}))
+                await ws.send(
+                    _make_event("response.create", response={"output_modalities": ["text"]})
+                )
 
                 # Wait for first delta to confirm streaming started
-                await _recv_event(ws, event_type="response.text.delta")
+                await _recv_event(ws, event_type="response.output_text.delta")
 
                 # Cancel mid-stream
                 await ws.send(_make_event("response.cancel"))
@@ -272,15 +288,20 @@ class TestRealtimeWebSocket:
                 # Top-level fields
                 assert "event_id" in event, "Missing event_id"
                 assert event["type"] == "session.created"
-                # Session object
+                # Session object (GA shape)
                 session = event["session"]
                 assert isinstance(session, dict)
                 assert isinstance(session.get("id"), str)
                 assert len(session["id"]) > 0
                 assert isinstance(session.get("model"), str)
-                assert isinstance(session.get("modalities"), list)
-                assert isinstance(session.get("voice"), str)
-                assert isinstance(session.get("turn_detection"), (dict, type(None)))
+                assert isinstance(session.get("output_modalities"), list)
+                # In GA, voice/turn_detection moved under audio.{output,input}.
+                audio = session.get("audio")
+                assert isinstance(audio, dict), f"Expected session.audio dict, got: {audio!r}"
+                output = audio.get("output") or {}
+                assert isinstance(output.get("voice"), str)
+                input_cfg = audio.get("input") or {}
+                assert isinstance(input_cfg.get("turn_detection"), (dict, type(None)))
                 logger.info(
                     "session.created schema OK: id=%s model=%s",
                     session["id"],
@@ -295,7 +316,9 @@ class TestRealtimeWebSocket:
         async def _run():
             async with _realtime_session(ws_url, ws_headers) as ws:
                 await ws.send(_make_user_message("Say hi."))
-                await ws.send(_make_event("response.create", response={"modalities": ["text"]}))
+                await ws.send(
+                    _make_event("response.create", response={"output_modalities": ["text"]})
+                )
 
                 event = await _recv_event(ws, event_type="response.done")
                 # Top-level
@@ -308,14 +331,14 @@ class TestRealtimeWebSocket:
                 assert resp.get("status") == "completed"
                 assert isinstance(resp.get("output"), list)
                 assert len(resp["output"]) > 0
-                # Output item
+                # Output item — GA shape uses content type "output_text".
                 item = resp["output"][0]
                 assert item.get("type") == "message"
                 assert item.get("role") == "assistant"
                 assert isinstance(item.get("content"), list)
                 assert len(item["content"]) > 0
                 content = item["content"][0]
-                assert content.get("type") == "text"
+                assert content.get("type") == "output_text"
                 assert isinstance(content.get("text"), str)
                 assert len(content["text"]) > 0
                 # Usage
@@ -332,12 +355,14 @@ class TestRealtimeWebSocket:
         asyncio.run(_run())
 
     def test_response_text_delta_format(self, ws_url, ws_headers):
-        """Validate response.text.delta events have the expected schema."""
+        """Validate response.output_text.delta events have the expected schema."""
 
         async def _run():
             async with _realtime_session(ws_url, ws_headers) as ws:
                 await ws.send(_make_user_message("Say hello."))
-                await ws.send(_make_event("response.create", response={"modalities": ["text"]}))
+                await ws.send(
+                    _make_event("response.create", response={"output_modalities": ["text"]})
+                )
 
                 # Collect a few deltas and validate schema
                 delta_count = 0
@@ -350,7 +375,7 @@ class TestRealtimeWebSocket:
                     event = _parse_event(raw)
                     if event is None:
                         continue
-                    if event.get("type") == "response.text.delta":
+                    if event.get("type") == "response.output_text.delta":
                         assert "event_id" in event
                         assert isinstance(event.get("delta"), str)
                         assert len(event["delta"]) > 0
@@ -362,8 +387,8 @@ class TestRealtimeWebSocket:
                     elif event.get("type") == "response.done":
                         break
 
-                assert delta_count > 0, "Expected at least one response.text.delta"
-                logger.info("response.text.delta schema OK: %d deltas received", delta_count)
+                assert delta_count > 0, "Expected at least one response.output_text.delta"
+                logger.info("response.output_text.delta schema OK: %d deltas received", delta_count)
 
         asyncio.run(_run())
 

--- a/e2e_test/realtime/test_realtime_ws.py
+++ b/e2e_test/realtime/test_realtime_ws.py
@@ -241,16 +241,21 @@ class TestRealtimeWebSocket:
 
         asyncio.run(_run())
 
-    def test_conversation_item_created_event(self, ws_url, ws_headers):
-        """Sending conversation.item.create should echo conversation.item.created."""
+    def test_conversation_item_added_event(self, ws_url, ws_headers):
+        """Sending conversation.item.create should echo conversation.item.added.
+
+        GA renamed the legacy `conversation.item.created` event to
+        `conversation.item.added` (emitted when an item is added to the default
+        conversation).
+        """
 
         async def _run():
             async with _realtime_session(ws_url, ws_headers) as ws:
                 await ws.send(_make_user_message("Hi"))
-                event = await _recv_event(ws, event_type="conversation.item.created")
-                assert event["type"] == "conversation.item.created"
+                event = await _recv_event(ws, event_type="conversation.item.added")
+                assert event["type"] == "conversation.item.added"
                 assert event["item"]["role"] == "user"
-                logger.info("conversation.item.created received: id=%s", event["item"].get("id"))
+                logger.info("conversation.item.added received: id=%s", event["item"].get("id"))
 
         asyncio.run(_run())
 

--- a/model_gateway/src/routers/openai/realtime/proxy.rs
+++ b/model_gateway/src/routers/openai/realtime/proxy.rs
@@ -44,14 +44,15 @@ pub async fn run_ws_proxy(
     // Connect to upstream WebSocket with auth.
     // Let tungstenite auto-add WebSocket handshake headers (Connection, Upgrade,
     // Sec-WebSocket-Version, Sec-WebSocket-Key); we only add app-specific headers.
+    //
+    // Do not send `OpenAI-Beta: realtime=v1` — OpenAI's GA Realtime API rejects
+    // it with `beta_api_shape_disabled` ("The Realtime Beta API is no longer
+    // supported. Please use /v1/realtime for the GA API.").
     use tokio_tungstenite::tungstenite::client::IntoClientRequest;
     let mut request = upstream_url.into_client_request()?;
     request
         .headers_mut()
         .insert("Authorization", auth_header.parse()?);
-    request
-        .headers_mut()
-        .insert("OpenAI-Beta", "realtime=v1".parse()?);
 
     // Build an explicit rustls TLS connector so we don't depend on the
     // process-level CryptoProvider being installed.


### PR DESCRIPTION
## Description

### Problem

After #1504 bumped the realtime test to the GA model alias `gpt-realtime`, the `openai-realtime` job is **still** failing on main with the same `1005 (no status received)` / `ConnectionResetError` pattern ([run 26212745181](https://github.com/lightseekorg/smg/actions/runs/26212745181/job/77128895459)).

Direct upstream reproduction (forcing HTTP/1.1 so the WS upgrade isn't masked by HTTP/2 framing) shows what's actually happening:

```
HTTP/1.1 101 Switching Protocols
…
{"type":"error","error":{
  "type":"invalid_request_error",
  "code":"beta_api_shape_disabled",
  "message":"The Realtime Beta API is no longer supported. Please use /v1/realtime for the GA API."
}}
```

OpenAI accepts the WebSocket upgrade (HTTP 101), then immediately sends an error event and closes the connection because the request carries `OpenAI-Beta: realtime=v1`. SMG forwards that error frame, the upstream tears down, the upgrade closure ends, and the already-upgraded client socket gets dropped → client sees `1005` / TCP RST.

Repeating the same handshake **without** the beta header succeeds and returns a proper GA `session.created`:

```json
{"type":"session.created","session":{"id":"sess_…","model":"gpt-realtime","object":"realtime.session", …}}
```

So bumping the model in #1504 was necessary (the old preview snapshot 404s) but not sufficient (SMG's hardcoded beta header still triggers GA-shape rejection).

### Solution

Drop the hardcoded `OpenAI-Beta: realtime=v1` header from SMG's upstream WebSocket request. The GA Realtime API doesn't want it; the beta API that did want it has been retired.

## Changes

- `model_gateway/src/routers/openai/realtime/proxy.rs` — remove the `.insert("OpenAI-Beta", "realtime=v1")` on the upstream `tokio_tungstenite` request. Leave a short comment documenting why, so nobody re-adds it.
- `e2e_test/realtime/test_realtime_ws.py` — drop `OpenAI-Beta` from the test's `ws_headers` fixture for cleanliness (the test sends it client→SMG, but SMG never proxies client headers upstream, so it was already inert).

## Test Plan

- [ ] CI `openai-realtime` job goes green.
- [ ] Before/after: the 10 previously-failing tests pass; the 2 always-passing tests (`test_missing_model_returns_error`, `test_missing_auth_returns_error`) remain passing.

Direct verification with the upstream (already done locally):
- With `OpenAI-Beta: realtime=v1` → `code: beta_api_shape_disabled`, then close.
- Without it → `session.created` frame with the full GA session object (model `gpt-realtime`, output_modalities `["audio"]`, server_vad turn detection, etc.).

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt --all -- --check` passes
- [x] `cargo check -p smg` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` (relying on CI)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the incompatible realtime header from WebSocket requests and fixtures to ensure compatibility with GA Realtime endpoints.

* **Tests**
  * Updated end-to-end realtime WebSocket tests to match revised event and payload schemas: streaming now uses response.output_text.delta, session and response use output_modalities/text typing, response.done requires output_text content.type, conversation.item.added replaces conversation.item.created, and related assertions/logging adjusted.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightseekorg/smg/pull/1516?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->