### PR TITLE
test(e2e): drop tokenspeed marker from structurally-unsupported tests

### DIFF
--- a/e2e_test/chat_completions/test_enable_thinking.py
+++ b/e2e_test/chat_completions/test_enable_thinking.py
@@ -22,9 +22,9 @@ API_KEY = "not-used"
 # =============================================================================
 
 
-@pytest.mark.engine("sglang", "vllm", "trtllm", "tokenspeed")
+@pytest.mark.engine("sglang", "vllm", "trtllm")
 @pytest.mark.gpu(1)
-@pytest.mark.model("Qwen/Qwen3-4B")
+@pytest.mark.model("Qwen/Qwen3-30B-A3B")
 @pytest.mark.gateway(extra_args=["--reasoning-parser", "qwen3", "--history-backend", "memory"])
 @pytest.mark.parametrize("setup_backend", ["grpc"], indirect=True)
 @pytest.mark.parametrize("api_client", ["openai", "smg"], indirect=True)

--- a/e2e_test/chat_completions/test_function_calling.py
+++ b/e2e_test/chat_completions/test_function_calling.py
@@ -267,8 +267,8 @@ class TestOpenAIServerFunctionCalling:
                         },
                         "required": ["a", "b"],
                     },
-                    # Llama-3.2-1B is flaky in tool call format, so we force it
-                    # with strict mode.
+                    # Llama-3.2-1B is flaky in tool call. It won't always respond with
+                    # parameters unless we set strict.
                     "strict": True,
                 },
             }

--- a/e2e_test/chat_completions/test_structured_output.py
+++ b/e2e_test/chat_completions/test_structured_output.py
@@ -139,7 +139,7 @@ class TestStructuredOutputRegular(_TestStructuredOutputBase):
 # =============================================================================
 
 
-@pytest.mark.engine("sglang", "vllm", "trtllm", "tokenspeed")
+@pytest.mark.engine("sglang", "vllm", "trtllm")
 @pytest.mark.gpu(2)
 @pytest.mark.model("openai/gpt-oss-20b")
 @pytest.mark.gateway(extra_args=["--history-backend", "memory"])
@@ -149,7 +149,7 @@ class TestStructuredOutputGptOss(_TestStructuredOutputBase):
     """Structured output tests for Harmony models (GPT-OSS 20B, 1 GPU)."""
 
 
-@pytest.mark.engine("sglang", "vllm", "trtllm", "tokenspeed")
+@pytest.mark.engine("sglang", "vllm", "trtllm")
 @pytest.mark.gpu(4)
 @pytest.mark.model("openai/gpt-oss-120b")
 @pytest.mark.gateway(extra_args=["--history-backend", "memory"])

--- a/e2e_test/infra/model_specs.py
+++ b/e2e_test/infra/model_specs.py
@@ -71,16 +71,6 @@ MODEL_SPECS: dict[str, dict] = {
         "tp": 1,
         "features": ["chat", "streaming", "function_calling", "tool_choice"],
     },
-    # Hybrid Qwen3 with the ``enable_thinking`` chat-template toggle. Used
-    # by ``TestEnableThinking``. Dense (``Qwen3ForCausalLM``), so it lands
-    # on tokenspeed's current model registry where the larger
-    # ``Qwen3-30B-A3B`` (``Qwen3MoeForCausalLM``) does not. Uses the
-    # existing ``qwen3`` reasoning parser.
-    "Qwen/Qwen3-4B": {
-        "model": _resolve_model_path("Qwen/Qwen3-4B"),
-        "tp": 1,
-        "features": ["chat", "streaming", "thinking", "reasoning"],
-    },
     "Qwen/Qwen3-30B-A3B": {
         "model": _resolve_model_path("Qwen/Qwen3-30B-A3B"),
         "tp": 1,
@@ -114,10 +104,6 @@ MODEL_SPECS: dict[str, dict] = {
             "--structured-outputs-config",
             '{"enable_in_reasoning": true}',
         ],
-        # Tells the engine to wrap ``response_format=json_schema`` as the
-        # Harmony structural tag so the grammar only activates inside the
-        # final channel — otherwise xgrammar fights the analysis preamble.
-        "tokenspeed_args": ["--reasoning-parser", "gpt-oss"],
     },
     "openai/gpt-oss-120b": {
         "model": _resolve_model_path("openai/gpt-oss-120b"),
@@ -128,7 +114,6 @@ MODEL_SPECS: dict[str, dict] = {
             "--structured-outputs-config",
             '{"enable_in_reasoning": true}',
         ],
-        "tokenspeed_args": ["--reasoning-parser", "gpt-oss"],
     },
     # MiniMax M2 - nightly benchmarks
     "minimaxai/minimax-m2": {
@@ -266,7 +251,7 @@ FUNCTION_CALLING_MODELS = get_models_with_feature("function_calling")
 DEFAULT_MODEL_PATH = MODEL_SPECS["meta-llama/Llama-3.1-8B-Instruct"]["model"]
 DEFAULT_SMALL_MODEL_PATH = MODEL_SPECS["meta-llama/Llama-3.2-1B-Instruct"]["model"]
 DEFAULT_REASONING_MODEL_PATH = MODEL_SPECS["deepseek-ai/DeepSeek-R1-Distill-Qwen-7B"]["model"]
-DEFAULT_ENABLE_THINKING_MODEL_PATH = MODEL_SPECS["Qwen/Qwen3-4B"]["model"]
+DEFAULT_ENABLE_THINKING_MODEL_PATH = MODEL_SPECS["Qwen/Qwen3-30B-A3B"]["model"]
 DEFAULT_QWEN_FUNCTION_CALLING_MODEL_PATH = MODEL_SPECS["Qwen/Qwen2.5-7B-Instruct"]["model"]
 DEFAULT_MISTRAL_FUNCTION_CALLING_MODEL_PATH = MODEL_SPECS["mistralai/Mistral-7B-Instruct-v0.3"][
     "model"


### PR DESCRIPTION
## Description

### Problem

Follow-up to #1465. Two test classes fail on the tokenspeed engine for reasons that aren't fixable at the CI-config level:

1. **\`TestStructuredOutputGptOss[120B]\`** — Harmony + \`response_format=json_schema\`.
   tokenspeed deliberately omits \`gpt-oss\` from its xgrammar reasoning-structural-tag map (\`tokenspeed/runtime/grammar/reasoning_structural_tag.py:53\` says so explicitly) on the assumption that smg's Harmony **Responses** pipeline wraps the schema for it. The **Chat Completions** pipeline doesn't have that wrapping, so the schema lands at the engine unwrapped and xgrammar fights the channel preamble → empty content. The \`--reasoning-parser gpt-oss\` flag that #1465 added doesn't help because gpt-oss is missing from the map by design.
2. **\`TestEnableThinking\`** — model swap. #1465 changed the model from \`Qwen3-30B-A3B\` to \`Qwen3-4B\` because \`Qwen3MoeForCausalLM\` isn't in tokenspeed's model registry. The substitution shrank coverage for the other engines.

### Solution

- Drop \`tokenspeed\` from both engine markers.
- Restore \`TestEnableThinking\` to the original \`Qwen3-30B-A3B\` and remove the unused \`Qwen3-4B\` spec.
- Remove the now-unused \`tokenspeed_args: [\"--reasoning-parser\", \"gpt-oss\"]\` entries on the gpt-oss-20b/120b specs.
- Revert the comment rewording in \`test_function_calling.py\` (per @CatherineSue's review on #1465).

The structured-output gap is fixable in a follow-up by mirroring the Responses-API structural-tag wrapping in the Chat Completions pipeline. That's bigger than this PR's scope.

## Changes

\`\`\`
e2e_test/chat_completions/test_enable_thinking.py   |  7 +++++--
e2e_test/chat_completions/test_function_calling.py  |  4 ++--
e2e_test/chat_completions/test_structured_output.py |  9 +++++++--
e2e_test/infra/model_specs.py                       | 17 +----------------
\`\`\`

## Test Plan

- [x] \`ruff check\` clean (v0.15.0, CI-pinned)
- [x] \`ruff format --check\` clean

<details>
<summary>Checklist</summary>

- [x] \`cargo +nightly fmt\` passes (no Rust changes)
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` passes (no Rust changes)
- [ ] (Optional) Documentation updated

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * E2E test configurations updated to run on a reduced set of supported engines and to use a consistent model variant; clarifying comments added about model behavior in specific frameworks.

* **Chores**
  * Model specifications aligned across test suites and unsupported engine references removed to ensure consistent test coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightseekorg/smg/pull/1517?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->