### PR TITLE
fix(mesh): inbound sender drops targeted entries before peer is learned

### DIFF
--- a/crates/mesh/src/gossip_service.rs
+++ b/crates/mesh/src/gossip_service.rs
@@ -50,7 +50,7 @@ use super::{
         gossip::{
             self,
             gossip_server::{Gossip, GossipServer},
-            GossipMessage, NodeState, NodeStatus, NodeUpdate, PingReq, StreamMessage,
+            GossipMessage, NodeState, NodeStatus, NodeUpdate, PingReq, StreamBatch, StreamMessage,
             StreamMessageType,
         },
         try_ping, ClusterState,
@@ -279,22 +279,36 @@ impl Gossip for GossipService {
                 loop {
                     interval.tick().await;
 
-                    let stream_batch = stream_batch_handle.read().clone();
-                    let fresh = last_stream_batch
-                        .as_ref()
-                        .is_none_or(|last| !Arc::ptr_eq(last, &stream_batch));
-                    if !fresh {
-                        continue;
+                    // If the paired inbound handler has dropped its end of
+                    // the mpsc, we have nobody to send to. Exit cleanly
+                    // instead of looping forever — important when peer never
+                    // identifies (so we never reach try_send to learn the
+                    // channel is closed).
+                    if tx_sender.is_closed() {
+                        return;
                     }
-                    last_stream_batch = Some(stream_batch.clone());
 
-                    // `peer_id = ""` => peer not yet learned; drain still
-                    // emits, targeted skipped. Hold the guard across the
-                    // sync helper call to avoid a per-tick String alloc.
+                    let stream_batch = stream_batch_handle.read().clone();
                     let batches = {
                         let guard = learned_peer_sender.read();
-                        build_peer_stream_batches(&stream_batch, guard.as_deref().unwrap_or(""))
+                        match plan_sender_tick(
+                            last_stream_batch.as_ref(),
+                            &stream_batch,
+                            guard.as_deref(),
+                        ) {
+                            SenderTick::SkipPeerUnknown | SenderTick::SkipBatchUnchanged => {
+                                continue
+                            }
+                            SenderTick::Emit(b) => b,
+                        }
                     };
+                    // Only mark this batch consumed after building with a
+                    // real peer_id. If `plan_sender_tick` short-circuited
+                    // (peer unknown or batch unchanged), `last_stream_batch`
+                    // is untouched and the same RoundBatch will be
+                    // re-evaluated on a later tick.
+                    last_stream_batch = Some(stream_batch.clone());
+
                     for batch in batches {
                         sequence_counter += 1;
                         let msg = wrap_stream_batch(batch, sequence_counter, &self_name_sender);
@@ -410,5 +424,179 @@ impl Gossip for GossipService {
         Ok(Response::new(
             Box::pin(output_stream) as Self::SyncStreamStream
         ))
+    }
+}
+
+/// Outcome of one tick of the inbound sender task.
+///
+/// The task only marks a `RoundBatch` consumed (advances
+/// `last_stream_batch`) when [`SenderTick::Emit`] is returned. The two
+/// skip variants preserve `last_stream_batch` so the same `Arc` is
+/// retried on the next tick — important because before peer identity
+/// is learned, we cannot build the correct per-peer batch, and consuming
+/// the batch anyway would silently drop its targeted entries.
+#[derive(Debug)]
+enum SenderTick {
+    /// Peer identity not yet known. Wait until the inbound handler
+    /// records the dialer's `peer_id` from the first frame.
+    SkipPeerUnknown,
+    /// Round batch unchanged since the last successful emit.
+    SkipBatchUnchanged,
+    /// Build successful — emit these batches and advance the watermark.
+    Emit(Vec<StreamBatch>),
+}
+
+/// Decide what one tick of the inbound sender should do.
+///
+/// Splitting this from the async task body makes the per-tick decision
+/// pinnable in unit tests without standing up an interval timer, a
+/// real mpsc, or a tokio runtime. The async loop is responsible for
+/// freshness-watermark advancement and channel I/O; this function is
+/// responsible only for the "what should we do this tick" decision.
+fn plan_sender_tick(
+    last_stream_batch: Option<&Arc<crate::kv::RoundBatch>>,
+    current_stream_batch: &Arc<crate::kv::RoundBatch>,
+    learned_peer: Option<&str>,
+) -> SenderTick {
+    let peer_id = match learned_peer {
+        Some(peer) if !peer.is_empty() => peer,
+        _ => return SenderTick::SkipPeerUnknown,
+    };
+    let fresh = last_stream_batch.is_none_or(|last| !Arc::ptr_eq(last, current_stream_batch));
+    if !fresh {
+        return SenderTick::SkipBatchUnchanged;
+    }
+    SenderTick::Emit(build_peer_stream_batches(current_stream_batch, peer_id))
+}
+
+#[cfg(test)]
+mod sender_tick_tests {
+    use bytes::Bytes;
+
+    use super::*;
+    use crate::kv::RoundBatch;
+
+    fn round_batch_with(
+        drain: Vec<(&str, &[u8])>,
+        targeted: Vec<(&str, &str, &[u8])>,
+    ) -> Arc<RoundBatch> {
+        Arc::new(RoundBatch {
+            drain_entries: drain
+                .into_iter()
+                .map(|(k, v)| (k.to_string(), Bytes::copy_from_slice(v)))
+                .collect(),
+            targeted_entries: targeted
+                .into_iter()
+                .map(|(t, k, v)| (t.to_string(), k.to_string(), Bytes::copy_from_slice(v)))
+                .collect(),
+        })
+    }
+
+    fn batch_keys(batches: &[StreamBatch]) -> Vec<String> {
+        batches
+            .iter()
+            .flat_map(|b| b.entries.iter().map(|e| e.key.clone()))
+            .collect()
+    }
+
+    #[test]
+    fn skips_when_peer_unknown_and_keeps_watermark_unchanged() {
+        // Original race: with learned_peer = None the previous code
+        // would consume the batch with peer_id = "", drop targeted
+        // entries, and advance last_stream_batch — so the next tick
+        // (after peer identity arrived) would see an unchanged Arc and
+        // never re-send the lost targeted entries.
+        let rb = round_batch_with(
+            vec![("td:foo", b"d")],
+            vec![("peer_X", "tree:req:abc", b"r")],
+        );
+        let decision = plan_sender_tick(None, &rb, None);
+        assert!(matches!(decision, SenderTick::SkipPeerUnknown));
+    }
+
+    #[test]
+    fn skips_when_peer_is_empty_string() {
+        // Defensive: an empty learned_peer string must not be treated
+        // as a valid identity, even though the underlying string-equality
+        // would otherwise let a targeted entry with target == "" leak
+        // through.
+        let rb = round_batch_with(vec![], vec![("", "tree:req:weird", b"r")]);
+        let decision = plan_sender_tick(None, &rb, Some(""));
+        assert!(matches!(decision, SenderTick::SkipPeerUnknown));
+    }
+
+    #[test]
+    fn emits_drain_and_targeted_once_peer_is_known() {
+        // First tick (peer unknown) returns SkipPeerUnknown. After the
+        // inbound handler learns the peer, a second tick on the same
+        // Arc must emit both drain and the matching targeted entry.
+        let rb = round_batch_with(
+            vec![("td:foo", b"d")],
+            vec![("peer_X", "tree:req:abc", b"r")],
+        );
+        let pre = plan_sender_tick(None, &rb, None);
+        assert!(matches!(pre, SenderTick::SkipPeerUnknown));
+
+        // last_stream_batch was left unchanged by the skip, so we still
+        // pass None here — modeling the watermark not having advanced.
+        let post = plan_sender_tick(None, &rb, Some("peer_X"));
+        let SenderTick::Emit(batches) = post else {
+            panic!("expected Emit after peer learned, got {post:?}");
+        };
+        let keys = batch_keys(&batches);
+        assert!(keys.contains(&"td:foo".to_string()), "drain entry emitted");
+        assert!(
+            keys.contains(&"tree:req:abc".to_string()),
+            "targeted entry for peer_X emitted"
+        );
+    }
+
+    #[test]
+    fn does_not_resend_same_arc_after_consume() {
+        // After a successful Emit, the loop advances last_stream_batch
+        // to the same Arc. The next tick must report SkipBatchUnchanged
+        // and emit nothing.
+        let rb = round_batch_with(vec![("td:foo", b"d")], vec![]);
+        let decision = plan_sender_tick(Some(&rb), &rb, Some("peer_X"));
+        assert!(matches!(decision, SenderTick::SkipBatchUnchanged));
+    }
+
+    #[test]
+    fn emits_only_targeted_entries_for_learned_peer() {
+        // Targeted-entry filtering still works correctly: a batch with
+        // entries for multiple peers must only emit entries addressed to
+        // this stream's learned peer (plus drain entries which broadcast).
+        let rb = round_batch_with(
+            vec![("td:bcast", b"b")],
+            vec![
+                ("peer_X", "tree:req:x", b"x"),
+                ("peer_Y", "tree:req:y", b"y"),
+            ],
+        );
+        let SenderTick::Emit(batches) = plan_sender_tick(None, &rb, Some("peer_X")) else {
+            panic!("expected Emit");
+        };
+        let keys = batch_keys(&batches);
+        assert!(keys.contains(&"td:bcast".to_string()));
+        assert!(keys.contains(&"tree:req:x".to_string()));
+        assert!(
+            !keys.contains(&"tree:req:y".to_string()),
+            "must not include entries addressed to other peers"
+        );
+    }
+
+    #[test]
+    fn drain_only_batch_still_emits_when_peer_learned() {
+        // Regression guard: a batch with only drain entries and no
+        // targeted entries should still emit after peer is learned —
+        // we do not want a future "skip when no targeted for this peer"
+        // optimization to reintroduce the original race for drain entries.
+        let rb = round_batch_with(vec![("td:foo", b"d"), ("td:bar", b"d")], vec![]);
+        let SenderTick::Emit(batches) = plan_sender_tick(None, &rb, Some("peer_X")) else {
+            panic!("expected Emit for drain-only batch");
+        };
+        let keys = batch_keys(&batches);
+        assert!(keys.contains(&"td:foo".to_string()));
+        assert!(keys.contains(&"td:bar".to_string()));
     }
 }


### PR DESCRIPTION
## Description

### Problem

The per-stream inbound sender task in `gossip_service.rs` drops targeted entries on the very first tick of a newly accepted `sync_stream`. The drop is silent and the same `RoundBatch` is never retried, so the entries are lost permanently.

Sequence on a freshly accepted stream from `peer_X`:

| t | event |
|---|---|
| 0.0 | Stream accepted. Inbound sender task spawned. `learned_peer = None`. |
| 0.0+ | Tokio `interval` returns immediately on its first `tick().await`. Sender wakes. |
| 0.001 | Sender reads `learned_peer` → still `None`. Calls `build_peer_stream_batches(&batch, "")` → returns drain only (empty `peer_id` excludes targeted). Sends drain. **Advances `last_stream_batch`.** |
| 0.002+ | Inbound handler reads peer_X's initial heartbeat. Writes `learned_peer = Some("peer_X")`. |
| 1.0 | Sender's second tick. `stream_batch_handle` still points at the same `Arc`. `Arc::ptr_eq(last, current) = true` → not fresh → `continue`. Targeted entries lost. |
| 1.5 | `GossipController` collects the next round. `Arc<RoundBatch>` swaps. Old round's targeted entries are now unreachable. |

The race is structural, not flaky: tokio's `interval` returns immediately on its first call, so the sender's first tick essentially always fires before the inbound handler has read the first frame. Application-level retry on `tree:req:` / `tree:page:` re-issues from the requester side, which masks the visible symptom, but the silent drop on the first round after stream accept is a real correctness gap.

Affects only the inbound (acceptor) side. The outbound controller captures `peer_name: String` at task-spawn time and has no learn phase, so it never hits this window.

Surfaced by CodeRabbit on the [PR #1513 review thread](https://github.com/lightseekorg/smg/pull/1513#discussion_r3278690432); deferred from #1513 per the cleanup-PR scope rule and validated by the local Codex CLI before fixing.

### Solution

Codex-recommended shape: gate consumption on identity. The per-tick decision becomes _"only mark a `RoundBatch` consumed after building with a stable non-empty counterparty id."_

Two control-flow changes inside the sender task:

1. **Identity check before freshness check.** If `learned_peer` is `None` or `""`, the tick returns without touching `last_stream_batch`. The same `Arc` is re-evaluated on the next tick, after the inbound handler has had time to set `learned_peer`. Drains are briefly delayed (~1 tick) during the pre-identification window; in practice the dialer's initial heartbeat arrives in single-digit milliseconds, so the delay is < 1 round.
2. **`tx_sender.is_closed()` guard at the top of every tick.** Without this, a sender task whose inbound handler exits before identity is ever learned (e.g. idle-timed-out connection where the dialer never sent any frame) would loop forever hitting the new `SkipPeerUnknown` branch — the existing channel-closed detection only fires on `try_send`.

The per-tick decision is split out into a `plan_sender_tick` helper returning a `SenderTick` enum (`SkipPeerUnknown` / `SkipBatchUnchanged` / `Emit`). This makes the regression pinnable in unit tests without driving a tokio interval or building a real mpsc/gRPC stream — the async loop only handles I/O and watermark advancement; the helper handles the decision.

Rejected alternatives:

- **Include `learned_peer` in the freshness key** (re-process same `Arc` on `None → Some` transition): would re-emit drains with fresh `next_generation()` tags. Receivers don't dedupe by `Arc` identity — they group chunks by generation — so duplicated drains would arrive as if they were new values. Requires a "drain already sent" sub-watermark to fix, more bookkeeping than the inbound side justifies.
- **Explicit handshake / start sender only after first valid frame**: architecturally cleaner but requires signal path from inbound→sender, ownership/lifetime decisions, duplicate-spawn protection, and shutdown semantics. Larger blast radius than the race justifies. Worth revisiting when mTLS-derived identity lands (identity known at TLS handshake, no learn phase at all).

## Changes

- `crates/mesh/src/gossip_service.rs`:
  - Refactor the per-stream sender task loop: identity check first, `tx_sender.is_closed()` guard at top, `last_stream_batch` advanced only after successful build.
  - Add private helper `plan_sender_tick(last, current, learned_peer) -> SenderTick` to make the decision testable.
  - Add `SenderTick` enum with three variants describing the per-tick outcome.
  - Add `StreamBatch` to the proto imports (used by the helper signature).
  - Add `sender_tick_tests` module with 6 unit tests covering the regression and adjacent behaviour.

## Test Plan

New `sender_tick_tests` (all pass):

```text
test gossip_service::sender_tick_tests::skips_when_peer_unknown_and_keeps_watermark_unchanged ... ok
test gossip_service::sender_tick_tests::skips_when_peer_is_empty_string ... ok
test gossip_service::sender_tick_tests::emits_drain_and_targeted_once_peer_is_known ... ok
test gossip_service::sender_tick_tests::does_not_resend_same_arc_after_consume ... ok
test gossip_service::sender_tick_tests::emits_only_targeted_entries_for_learned_peer ... ok
test gossip_service::sender_tick_tests::drain_only_batch_still_emits_when_peer_learned ... ok
```

Coverage:

- `skips_when_peer_unknown_and_keeps_watermark_unchanged` — the original race. Asserts that with `learned_peer = None`, the watermark does not advance and no batches are emitted.
- `skips_when_peer_is_empty_string` — defensive guard against `Some("")`. The inbound writer filter normally prevents this (`gossip_service.rs` only writes `Some(non-empty)`), but the sender-side check makes the invariant explicit.
- `emits_drain_and_targeted_once_peer_is_known` — the post-fix happy path: same `Arc` that was skipped before identity is fully emitted after.
- `does_not_resend_same_arc_after_consume` — `Arc::ptr_eq` freshness short-circuit still works.
- `emits_only_targeted_entries_for_learned_peer` — targeted-entry filtering still works correctly with multiple peers in the round batch.
- `drain_only_batch_still_emits_when_peer_learned` — regression guard against future "skip when nothing for this peer" optimization that would reintroduce the race for drain entries.

Full lib suite: `cargo test -p smg-mesh --lib` — **129 passed, 0 failed, 1 ignored** (123 prior + 6 new).

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes (pre-commit ran `cargo fmt`)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (`cargo clippy -p smg-mesh --all-targets` clean locally)
- [ ] (Optional) Documentation updated — relevant module doc already added in #1513
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where targeted gossip entries were incorrectly dropped when peer identification was incomplete.

* **Improvements**
  * Enhanced gossip service reliability with improved sender logic and cleaner connection handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightseekorg/smg/pull/1519?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->