### PR TITLE
fix(pd): Fix PD cache-aware policy lifecycle

### DIFF
--- a/model_gateway/src/policies/registry.rs
+++ b/model_gateway/src/policies/registry.rs
@@ -365,6 +365,27 @@ impl PolicyRegistry {
         }
     }
 
+    /// Remove a worker from PD cache-aware policies if applicable
+    /// This should be called when a prefill or decode worker is being removed
+    pub fn remove_worker_from_pd_cache_aware(&self, worker_url: &str) {
+        for (worker_type, policy) in [
+            ("prefill", self.prefill_policy.get()),
+            ("decode", self.decode_policy.get()),
+        ] {
+            if let Some(policy) = policy {
+                if policy.name() == "cache_aware" {
+                    if let Some(cache_aware) = policy.as_any().downcast_ref::<CacheAwarePolicy>() {
+                        cache_aware.remove_worker_by_url(worker_url);
+                        debug!(
+                            "Removed worker {} from {} cache-aware policy",
+                            worker_url, worker_type
+                        );
+                    }
+                }
+            }
+        }
+    }
+
     /// Initialize cache-aware policies for PD mode (prefill and decode) - lock-free
     pub fn init_pd_cache_aware_policies(
         &self,
@@ -436,7 +457,36 @@ impl std::fmt::Debug for PolicyRegistry {
 
 #[cfg(test)]
 mod tests {
+    use openai_protocol::worker::HealthCheckConfig;
+
     use super::*;
+    use crate::{
+        policies::{CacheAwareConfig, SelectWorkerInfo},
+        worker::{BasicWorkerBuilder, Worker, WorkerType},
+    };
+
+    fn no_health_check() -> HealthCheckConfig {
+        HealthCheckConfig {
+            disable_health_check: true,
+            ..Default::default()
+        }
+    }
+
+    fn worker(url: &str, worker_type: WorkerType) -> Arc<dyn Worker> {
+        Arc::new(
+            BasicWorkerBuilder::new(url)
+                .worker_type(worker_type)
+                .health_config(no_health_check())
+                .build(),
+        )
+    }
+
+    fn cache_aware_policy() -> Arc<dyn LoadBalancingPolicy> {
+        Arc::new(CacheAwarePolicy::with_config(CacheAwareConfig {
+            eviction_interval_secs: 0,
+            ..Default::default()
+        }))
+    }
 
     #[test]
     fn test_policy_registry_basic() {
@@ -496,5 +546,43 @@ mod tests {
         // Get default directly
         let default = registry.get_default_policy();
         assert_eq!(default.name(), "round_robin");
+    }
+
+    #[test]
+    fn test_pd_cache_aware_policy_initialization() {
+        let registry = PolicyRegistry::new(PolicyConfig::RoundRobin);
+        registry.set_prefill_policy(cache_aware_policy());
+        registry.set_decode_policy(cache_aware_policy());
+
+        let prefill_workers = vec![
+            worker("http://prefill-1:8000", WorkerType::Prefill),
+            worker("http://prefill-2:8000", WorkerType::Prefill),
+        ];
+        let decode_workers = vec![
+            worker("http://decode-1:8000", WorkerType::Decode),
+            worker("http://decode-2:8000", WorkerType::Decode),
+        ];
+
+        registry.init_pd_cache_aware_policies(&prefill_workers, &decode_workers);
+
+        let prefill_policy = registry.get_prefill_policy();
+        let decode_policy = registry.get_decode_policy();
+        let info = SelectWorkerInfo {
+            request_text: Some("shared prefix request"),
+            ..Default::default()
+        };
+
+        let prefill_first = prefill_policy.select_worker(&prefill_workers, &info);
+        let prefill_second = prefill_policy.select_worker(&prefill_workers, &info);
+        assert!(prefill_first.is_some());
+        assert_eq!(prefill_first, prefill_second);
+
+        let decode_first = decode_policy.select_worker(&decode_workers, &info);
+        let decode_second = decode_policy.select_worker(&decode_workers, &info);
+        assert!(decode_first.is_some());
+        assert_eq!(decode_first, decode_second);
+
+        registry.remove_worker_from_pd_cache_aware("http://prefill-1:8000");
+        registry.remove_worker_from_pd_cache_aware("http://decode-1:8000");
     }
 }

--- a/model_gateway/src/workflow/steps/local/remove_from_policy_registry.rs
+++ b/model_gateway/src/workflow/steps/local/remove_from_policy_registry.rs
@@ -47,6 +47,9 @@ impl StepExecutor<WorkerRemovalWorkflowData> for RemoveFromPolicyRegistryStep {
             app_context
                 .policy_registry
                 .remove_worker_from_cache_aware(&model_id, worker_url);
+            app_context
+                .policy_registry
+                .remove_worker_from_pd_cache_aware(worker_url);
 
             // Notify policy registry
             app_context.policy_registry.on_worker_removed(&model_id);

--- a/model_gateway/src/workflow/steps/local/update_policies_for_worker.rs
+++ b/model_gateway/src/workflow/steps/local/update_policies_for_worker.rs
@@ -63,6 +63,12 @@ impl StepExecutor<WorkerUpdateWorkflowData> for UpdatePoliciesForWorkerStep {
             app_context.policy_registry.on_worker_added(model_id, None);
         }
 
+        let prefill_workers = app_context.worker_registry.get_prefill_workers();
+        let decode_workers = app_context.worker_registry.get_decode_workers();
+        app_context
+            .policy_registry
+            .init_pd_cache_aware_policies(&prefill_workers, &decode_workers);
+
         Ok(StepResult::Success)
     }
 

--- a/model_gateway/src/workflow/steps/local/update_remaining_policies.rs
+++ b/model_gateway/src/workflow/steps/local/update_remaining_policies.rs
@@ -49,6 +49,12 @@ impl StepExecutor<WorkerRemovalWorkflowData> for UpdateRemainingPoliciesStep {
             }
         }
 
+        let prefill_workers = app_context.worker_registry.get_prefill_workers();
+        let decode_workers = app_context.worker_registry.get_decode_workers();
+        app_context
+            .policy_registry
+            .init_pd_cache_aware_policies(&prefill_workers, &decode_workers);
+
         // Log final result at info level
         if worker_urls.len() == 1 {
             info!("Removed worker {}", worker_urls[0]);

--- a/model_gateway/src/workflow/steps/shared/update_policies.rs
+++ b/model_gateway/src/workflow/steps/shared/update_policies.rs
@@ -146,8 +146,12 @@ impl<D: WorkerRegistrationData + WorkflowData> StepExecutor<D> for UpdatePolicie
             }
         }
 
-        // Initialize bucket policies for prefill workers (local workers only)
+        // Initialize PD policies for prefill/decode workers (local workers only)
         let prefill_workers = app_context.worker_registry.get_prefill_workers();
+        let decode_workers = app_context.worker_registry.get_decode_workers();
+        app_context
+            .policy_registry
+            .init_pd_cache_aware_policies(&prefill_workers, &decode_workers);
         if !prefill_workers.is_empty() {
             let policy = app_context.policy_registry.get_prefill_policy();
             if policy.name() == "bucket" {


### PR DESCRIPTION
## Description

### Problem

PD cache-aware routing uses dedicated prefill and decode policy instances, separate from the per-model policy used by the regular routing path. The regular path initializes and refreshes its cache-aware policy during worker registration, update, and removal, but the PD cache-aware policy instances were not refreshed through the same lifecycle hooks.

This shows up for PD configurations that use `cache_aware` routing for prefill and/or decode workers, especially when there is more than one worker in a PD role and requests have overlapping prefixes. The request path can reach a cache-aware policy whose string tree was never initialized, producing logs like:

```text
Warning: No string tree found for model '<model-id>', using random worker selection
```

At that point, prefix-aware routing is bypassed for the affected PD policy and worker selection falls back to random selection. The symptom is that repeated or prefix-overlapping requests do not consistently preserve locality even though `cache_aware` routing is configured.

### Solution

Mirror the existing regular cache-aware lifecycle behavior for PD cache-aware policy instances:

- initialize PD cache-aware policies when workers are registered
- refresh PD cache-aware policies when workers are updated
- remove stale worker URLs from PD cache-aware policies when workers are removed
- refresh PD cache-aware policies after removal using the remaining worker set

This keeps the PD path aligned with the existing non-PD cache-aware path.

## Changes

- Added `remove_worker_from_pd_cache_aware(...)` next to the existing regular cache-aware removal helper.
- Call `init_pd_cache_aware_policies(...)` from worker registration, update, and post-removal policy refresh paths.
- Call the new PD cache-aware removal helper from worker removal.
- Added a focused unit test covering PD cache-aware policy initialization and repeated-prefix selection.

## Test Plan

Repro before this change:

1. Configure PD routing with `cache_aware` selected for prefill and/or decode routing and more than one worker in at least one PD role.
2. Register workers through the normal worker lifecycle.
3. Submit repeated requests with overlapping prefixes.
4. Observe that the affected PD cache-aware policy can log a missing string tree and fall back to random worker selection:

```text
Warning: No string tree found for model '<model-id>', using random worker selection
```

Expected behavior after this change:

1. Worker registration initializes the PD cache-aware prefill/decode policy trees.
2. Worker update/removal refreshes those PD policy trees using the current worker registry state.
3. Repeated requests with overlapping prefixes can use the initialized PD cache-aware policy instead of falling back due to missing prefix trees.

Commands run:

```bash
cargo fmt --all
cargo test -p smg test_pd_cache_aware_policy_initialization
cargo check -p smg
```

`cargo fmt --all` completed successfully, while printing existing rustfmt warnings about unstable import-formatting options in the repo config.

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced worker management for PD-mode cache-aware policies, including deterministic worker selection and safer removal of workers.
  * Ensures policies reinitialize and stay synchronized after worker additions or removals.

* **Tests**
  * Added tests for cache-aware policy initialization and worker lifecycle operations, including deterministic selection and removal scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightseekorg/smg/pull/1520?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->