### PR TITLE
fix(service-discovery): drop http:// prefix so dual-probe detects gRPC

### DIFF
--- a/model_gateway/src/service_discovery.rs
+++ b/model_gateway/src/service_discovery.rs
@@ -349,8 +349,8 @@ impl PodInfo {
     }
 
     pub fn worker_url(&self, port: u16) -> String {
-        // Default to http:// prefix; workflow will detect actual protocol (HTTP vs gRPC)
-        format!("http://{}:{}", self.ip, port)
+        // Bare host:port lets DetectConnectionModeStep dual-probe HTTP and gRPC.
+        format!("{}:{}", self.ip, port)
     }
 }
 

--- a/model_gateway/src/worker/registry.rs
+++ b/model_gateway/src/worker/registry.rs
@@ -182,7 +182,7 @@ impl WorkerRegistry {
         self.resolve_url_to_id(url)
     }
 
-    /// Resolve a URL string to the `WorkerId` it is registered under.
+    /// Resolve a URL string to the `WorkerId` of a live worker.
     ///
     /// Tries exact match first. If the input has no recognized scheme
     /// (`http://`, `https://`, `grpc://`, `grpcs://`), retries with
@@ -190,9 +190,20 @@ impl WorkerRegistry {
     /// bare `host:port` URLs and the workflow normalizes them to either
     /// scheme based on probe results, so removal-by-url needs to match
     /// either canonical form.
+    ///
+    /// Skips ids that are present in `url_to_id` but missing from `workers`.
+    /// [`Self::reserve_id_for_url`] writes the URL→ID mapping before the
+    /// worker is built, so a bare URL submitted to `WorkerService::create_worker`
+    /// can shadow the canonical `http://`/`grpc://` entry that the
+    /// AddWorker workflow later registers under.
     fn resolve_url_to_id(&self, url: &str) -> Option<WorkerId> {
+        let is_live = |id: &WorkerId| self.workers.contains_key(id);
+
         if let Some(id) = self.url_to_id.get(url) {
-            return Some(id.clone());
+            let id = id.clone();
+            if is_live(&id) {
+                return Some(id);
+            }
         }
         let has_scheme = url.starts_with("http://")
             || url.starts_with("https://")
@@ -204,7 +215,10 @@ impl WorkerRegistry {
         for scheme in ["http://", "grpc://"] {
             let candidate = format!("{scheme}{url}");
             if let Some(id) = self.url_to_id.get(&candidate) {
-                return Some(id.clone());
+                let id = id.clone();
+                if is_live(&id) {
+                    return Some(id);
+                }
             }
         }
         None
@@ -1664,6 +1678,45 @@ mod tests {
         assert!(registry.get_by_url("nothing:8080").is_none());
         assert!(registry.get_id_by_url("nothing:8080").is_none());
         assert!(registry.remove_by_url("nothing:8080").is_none());
+    }
+
+    /// Regression for the bare-URL reservation shadowing the canonical
+    /// scheme-prefixed entry. `WorkerService::create_worker` reserves an
+    /// ID against `config.url` *before* `normalize_url` runs in the
+    /// AddWorker workflow, so when service discovery submits bare
+    /// `host:port` the registry briefly holds two `url_to_id` entries:
+    /// the bare reservation (no live worker) and the canonical
+    /// scheme-prefixed entry (live worker). Lookups for the bare URL
+    /// must skip the reservation and resolve to the live worker.
+    #[test]
+    fn test_url_lookup_skips_orphan_reservation_for_bare_host_port() {
+        let registry = WorkerRegistry::new();
+        let _reserved = registry.reserve_id_for_url("orphan:8080");
+
+        let worker: Arc<dyn Worker> = Arc::new(
+            BasicWorkerBuilder::new("grpc://orphan:8080")
+                .worker_type(WorkerType::Regular)
+                .connection_mode(ConnectionMode::Grpc)
+                .health_config(no_health_check())
+                .build(),
+        );
+        let live_id = registry.register(worker).unwrap();
+
+        assert_eq!(registry.get_id_by_url("orphan:8080"), Some(live_id.clone()));
+        assert!(registry
+            .get_by_url("orphan:8080")
+            .is_some_and(|w| w.url() == "grpc://orphan:8080"));
+        assert!(registry.remove_by_url("orphan:8080").is_some());
+        assert!(registry.get(&live_id).is_none());
+    }
+
+    #[test]
+    fn test_url_lookup_returns_none_when_only_reservation_exists() {
+        let registry = WorkerRegistry::new();
+        registry.reserve_id_for_url("pending:8080");
+        assert!(registry.get_by_url("pending:8080").is_none());
+        assert!(registry.get_id_by_url("pending:8080").is_none());
+        assert!(registry.remove_by_url("pending:8080").is_none());
     }
 
     /// `transition_status_inner` (the shared backend used by both

--- a/model_gateway/src/worker/registry.rs
+++ b/model_gateway/src/worker/registry.rs
@@ -162,8 +162,11 @@ impl WorkerRegistry {
     ///
     /// Returns `Some(worker)` when a worker with this URL is registered,
     /// `None` otherwise. Read-only, lock-free. Emits no events.
+    ///
+    /// A scheme-less `host:port` input is canonicalized against the registered
+    /// `http://`/`grpc://` form — see [`Self::resolve_url_to_id`].
     pub fn get_by_url(&self, url: &str) -> Option<Arc<dyn Worker>> {
-        self.url_to_id.get(url).and_then(|id| self.get(&id))
+        self.resolve_url_to_id(url).and_then(|id| self.get(&id))
     }
 
     /// Look up a worker's ID by its URL.
@@ -172,8 +175,39 @@ impl WorkerRegistry {
     /// `None` otherwise. Read-only, lock-free. Emits no events. Useful for
     /// callers that need to invoke `transition_status_if_revision` with
     /// the current worker revision.
+    ///
+    /// A scheme-less `host:port` input is canonicalized against the registered
+    /// `http://`/`grpc://` form — see [`Self::resolve_url_to_id`].
     pub fn get_id_by_url(&self, url: &str) -> Option<WorkerId> {
-        self.url_to_id.get(url).map(|id| id.clone())
+        self.resolve_url_to_id(url)
+    }
+
+    /// Resolve a URL string to the `WorkerId` it is registered under.
+    ///
+    /// Tries exact match first. If the input has no recognized scheme
+    /// (`http://`, `https://`, `grpc://`, `grpcs://`), retries with
+    /// `http://` and `grpc://` prefixes — service discovery synthesizes
+    /// bare `host:port` URLs and the workflow normalizes them to either
+    /// scheme based on probe results, so removal-by-url needs to match
+    /// either canonical form.
+    fn resolve_url_to_id(&self, url: &str) -> Option<WorkerId> {
+        if let Some(id) = self.url_to_id.get(url) {
+            return Some(id.clone());
+        }
+        let has_scheme = url.starts_with("http://")
+            || url.starts_with("https://")
+            || url.starts_with("grpc://")
+            || url.starts_with("grpcs://");
+        if has_scheme {
+            return None;
+        }
+        for scheme in ["http://", "grpc://"] {
+            let candidate = format!("{scheme}{url}");
+            if let Some(id) = self.url_to_id.get(&candidate) {
+                return Some(id.clone());
+            }
+        }
+        None
     }
 
     /// Reverse-lookup the URL for a given worker ID.
@@ -932,7 +966,7 @@ impl WorkerRegistry {
     /// `WorkerId` before `remove()` takes the lock, and the subsequent
     /// teardown would then delete the new mapping.
     pub fn remove_by_url(&self, url: &str) -> Option<Arc<dyn Worker>> {
-        let worker_id = self.url_to_id.get(url).map(|entry| entry.clone())?;
+        let worker_id = self.resolve_url_to_id(url)?;
         self.remove(&worker_id)
     }
 
@@ -1560,6 +1594,76 @@ mod tests {
     fn test_get_id_by_url_returns_none_for_unknown_url() {
         let registry = WorkerRegistry::new();
         assert!(registry.get_id_by_url("http://missing:8080").is_none());
+    }
+
+    #[test]
+    fn test_url_lookup_canonicalizes_bare_host_port_to_http_form() {
+        let registry = WorkerRegistry::new();
+        let worker: Arc<dyn Worker> = Arc::new(
+            BasicWorkerBuilder::new("http://canon:8080")
+                .worker_type(WorkerType::Regular)
+                .health_config(no_health_check())
+                .build(),
+        );
+        let worker_id = registry.register(worker).unwrap();
+
+        assert_eq!(registry.get_id_by_url("canon:8080"), Some(worker_id));
+        assert!(registry.get_by_url("canon:8080").is_some());
+    }
+
+    #[test]
+    fn test_url_lookup_canonicalizes_bare_host_port_to_grpc_form() {
+        let registry = WorkerRegistry::new();
+        let worker: Arc<dyn Worker> = Arc::new(
+            BasicWorkerBuilder::new("grpc://canon-grpc:8080")
+                .worker_type(WorkerType::Regular)
+                .connection_mode(ConnectionMode::Grpc)
+                .health_config(no_health_check())
+                .build(),
+        );
+        let worker_id = registry.register(worker).unwrap();
+
+        assert_eq!(registry.get_id_by_url("canon-grpc:8080"), Some(worker_id));
+        assert!(registry.get_by_url("canon-grpc:8080").is_some());
+    }
+
+    #[test]
+    fn test_remove_by_url_canonicalizes_bare_host_port() {
+        let registry = WorkerRegistry::new();
+        let worker: Arc<dyn Worker> = Arc::new(
+            BasicWorkerBuilder::new("http://to-remove:8080")
+                .worker_type(WorkerType::Regular)
+                .health_config(no_health_check())
+                .build(),
+        );
+        let worker_id = registry.register(worker).unwrap();
+
+        assert!(registry.remove_by_url("to-remove:8080").is_some());
+        assert!(registry.get(&worker_id).is_none());
+        assert!(registry.get_by_url("http://to-remove:8080").is_none());
+    }
+
+    #[test]
+    fn test_url_lookup_does_not_cross_match_explicit_schemes() {
+        let registry = WorkerRegistry::new();
+        let worker: Arc<dyn Worker> = Arc::new(
+            BasicWorkerBuilder::new("http://strict:8080")
+                .worker_type(WorkerType::Regular)
+                .health_config(no_health_check())
+                .build(),
+        );
+        registry.register(worker).unwrap();
+
+        assert!(registry.get_by_url("grpc://strict:8080").is_none());
+        assert!(registry.get_id_by_url("grpcs://strict:8080").is_none());
+    }
+
+    #[test]
+    fn test_url_lookup_returns_none_for_bare_host_port_with_no_match() {
+        let registry = WorkerRegistry::new();
+        assert!(registry.get_by_url("nothing:8080").is_none());
+        assert!(registry.get_id_by_url("nothing:8080").is_none());
+        assert!(registry.remove_by_url("nothing:8080").is_none());
     }
 
     /// `transition_status_inner` (the shared backend used by both


### PR DESCRIPTION
## Description

### Problem

`PodInfo::worker_url` in `service_discovery.rs` unconditionally synthesizes `http://host:port` for every Kubernetes-discovered pod. After PR #1485 (`fix(worker): honor explicit worker connection schemes`) introduced `explicit_connection_mode` in `DetectConnectionModeStep`, the synthetic `http://` prefix makes that step short-circuit to an HTTP-only probe. gRPC-only workers (vLLM gRPC, sglang scheduler, TRT-LLM, MLX, TokenSpeed) discovered via K8s can no longer be detected — their startup workflow fails with:

> `Http health check failed for explicitly configured worker URL http://<pod-ip>:<port>`

The intent expressed by the original comment on `worker_url` — *"workflow will detect actual protocol (HTTP vs gRPC)"* — has been silently broken since #1485 landed for any pod that is not an HTTP backend.

### Solution

Return bare `host:port` from `PodInfo::worker_url`. `explicit_connection_mode` returns `None` for scheme-less inputs, so `DetectConnectionModeStep` falls through to the dual-probe branch. `normalize_url` in `CreateWorkerStep` then prepends the correct scheme (`http://` or `grpc://`) based on the detected `ConnectionMode` before the worker is registered.

That introduces a second issue on its own: `service_discovery`'s eviction, pod-deletion, and reconciliation paths still recompute the URL via `PodInfo::worker_url(port)` when submitting `RemoveWorker` jobs. The registry, however, stores the worker under the *normalized* URL (`http://X:Y` or `grpc://X:Y`). `WorkerRegistry::remove_by_url` does an exact-string lookup against `url_to_id`, so a bare-`host:port` removal would silently no-op and leak workers on pod churn. To close that gap in the same PR, `get_by_url` / `get_id_by_url` / `remove_by_url` now canonicalize: exact match first, and for scheme-less inputs only, fall back to `http://` and `grpc://` prefixes. Explicit-scheme inputs (`http://`, `https://`, `grpc://`, `grpcs://`) still require exact match — preserving #1485's "no silent fallback for operator-configured URLs" guarantee.

## Changes

- `model_gateway/src/service_discovery.rs`: `PodInfo::worker_url(port)` returns `format!("{ip}:{port}")` instead of `format!("http://{ip}:{port}")`.
- `model_gateway/src/worker/registry.rs`: introduce private `resolve_url_to_id(url)`; `get_by_url`, `get_id_by_url`, and `remove_by_url` route through it. Canonicalization only triggers for scheme-less inputs; explicit-scheme inputs keep exact-match semantics.
- Tests: six new unit tests in `worker::registry::tests` covering canonicalization to either scheme, removal-by-bare-host-port, the strict no-cross-match behavior for explicit schemes, and the "no match" path.

## Test Plan

- `cargo test -p smg --lib worker::registry::tests::` — **27/27 passing**, including the 6 new tests.
- `cargo test -p smg --lib workflow::steps::local::drain_workers` — **6/6 passing** (downstream removal-flow step that calls `get_id_by_url`).
- `cargo test -p smg --lib mesh::adapters::worker_sync` — **6/6 passing** (mesh cross-region path that calls `get_by_url`).
- `cargo +nightly fmt --check` clean.
- `cargo clippy -p smg --all-targets --all-features -- -D warnings` clean.

Repro of the original failure on `main`: deploy any gRPC-only inference workload (e.g. `vllm-gpt-oss-120b-mxfp4`) and let K8s service discovery register the pod — the router fails with `Http health check failed for explicitly configured worker URL ...` and exits after the probe retry budget is exhausted. After this PR, the same workload is detected as gRPC and registered as `grpc://<ip>:<port>`.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL handling to accept bare host:port inputs and reliably detect/resolve HTTP and gRPC endpoints without breaking explicit scheme matches
  * Registry operations (lookup/removal) now canonicalize scheme-less addresses while avoiding cross-scheme conflicts and ignoring non-live entries

* **Tests**
  * Added tests for canonicalization, scheme-less resolution, removal behavior, and cross-scheme matching scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightseekorg/smg/pull/1523?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->