### PR TITLE
feat(worker): add max_running_requests accessor on Worker trait

### DIFF
--- a/model_gateway/src/worker/worker.rs
+++ b/model_gateway/src/worker/worker.rs
@@ -210,6 +210,25 @@ pub trait Worker: Send + Sync + fmt::Debug + 'static {
     /// Get worker-specific metadata
     fn metadata(&self) -> &WorkerMetadata;
 
+    /// Worker-reported in-flight capacity, if available.
+    ///
+    /// Reads the `max_running_requests` label populated by the metadata
+    /// discovery pipeline (Step 4 of the worker lifecycle). Returns
+    /// `None` when the worker hasn't reported a value or reports zero
+    /// (zero is meaningless for capacity accounting).
+    ///
+    /// `WorkerCapacity` uses this to derive total fleet capacity when
+    /// every worker reports; falls back to a configured per-worker
+    /// estimate otherwise.
+    fn max_running_requests(&self) -> Option<u16> {
+        self.metadata()
+            .spec
+            .labels
+            .get("max_running_requests")
+            .and_then(|s| s.parse::<u16>().ok())
+            .filter(|n| *n > 0)
+    }
+
     /// Get the current circuit breaker state for observability/debugging.
     fn circuit_breaker_state(&self) -> super::circuit_breaker::CircuitState;
 
@@ -1260,6 +1279,50 @@ mod tests {
             .build();
 
         assert_eq!(worker.metadata().spec.labels, labels);
+    }
+
+    #[test]
+    fn test_max_running_requests_parses_from_label() {
+        use crate::worker::BasicWorkerBuilder;
+        let mut labels = std::collections::HashMap::new();
+        labels.insert("max_running_requests".to_string(), "256".to_string());
+        let worker = BasicWorkerBuilder::new("http://w:9000")
+            .labels(labels)
+            .build();
+        assert_eq!(worker.max_running_requests(), Some(256));
+    }
+
+    #[test]
+    fn test_max_running_requests_returns_none_when_label_missing() {
+        use crate::worker::BasicWorkerBuilder;
+        let worker = BasicWorkerBuilder::new("http://w:9000").build();
+        assert_eq!(worker.max_running_requests(), None);
+    }
+
+    #[test]
+    fn test_max_running_requests_returns_none_on_bad_value() {
+        use crate::worker::BasicWorkerBuilder;
+        let mut labels = std::collections::HashMap::new();
+        labels.insert(
+            "max_running_requests".to_string(),
+            "not-a-number".to_string(),
+        );
+        let worker = BasicWorkerBuilder::new("http://w:9000")
+            .labels(labels)
+            .build();
+        assert_eq!(worker.max_running_requests(), None);
+    }
+
+    #[test]
+    fn test_max_running_requests_zero_treated_as_none() {
+        use crate::worker::BasicWorkerBuilder;
+        let mut labels = std::collections::HashMap::new();
+        labels.insert("max_running_requests".to_string(), "0".to_string());
+        let worker = BasicWorkerBuilder::new("http://w:9000")
+            .labels(labels)
+            .build();
+        // Zero is meaningless for capacity; treat as "not reported".
+        assert_eq!(worker.max_running_requests(), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds a `max_running_requests(&self) -> Option<u16>` default method on the `Worker` trait that reads the `max_running_requests` label populated by metadata discovery (vLLM `--max-num-seqs`, SGLang `--max-running-requests`).
- Returns `None` when the label is missing, unparseable, or zero (zero is meaningless for capacity accounting).
- Pure addition — no callers yet. Sets up the input that an upcoming `WorkerCapacity` component will consume to derive fleet-wide in-flight capacity from `WorkerRegistry`.

## Test plan
- [x] `cargo test --package smg --lib worker::worker::tests::test_max_running_requests` — 4 new tests pass (label present / missing / unparseable / zero).
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- [ ] No regression in existing `worker::*` tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workers can now surface a configured maximum concurrent-request limit via metadata labels; the limit is returned as an optional numeric value when specified and treated as unspecified for missing, invalid, or "0" labels.

* **Tests**
  * Added unit tests validating a valid numeric limit, missing label, non-numeric label, and "0" treated as unspecified to ensure predictable behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightseekorg/smg/pull/1526?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->