### PR TITLE
fix(observability): use expect for metrics bind failure

### DIFF
--- a/model_gateway/src/observability/metrics_server.rs
+++ b/model_gateway/src/observability/metrics_server.rs
@@ -62,7 +62,7 @@ pub async fn start_metrics_server(
 
     let listener = bind_metrics_listener(addr)
         .await
-        .unwrap_or_else(|msg| panic!("{msg}"));
+        .expect("failed to bind metrics server on configured address");
 
     info!("Metrics server listening on {addr} (/metrics + /ws/metrics)");
 


### PR DESCRIPTION
## Summary
- replace the metrics listener bind failure panic path with Result::expect
- keep the existing #[expect(clippy::expect_used)] lint expectation accurate

## Testing
- git diff --check
- not run: cargo fmt --check / cargo test -p smg bind_metrics_listener_error_includes_addr (cargo is not installed in this environment)

Refs https://github.com/lightseekorg/smg/pull/1525#discussion_r3293978154