### PR TITLE
feat(workflow): surface max_running_requests on SGLang HTTP /server_info

### DIFF
--- a/model_gateway/src/workflow/steps/local/discover_metadata.rs
+++ b/model_gateway/src/workflow/steps/local/discover_metadata.rs
@@ -50,6 +50,11 @@ pub struct ServerInfo {
     pub is_embedding: Option<bool>,
     pub context_length: Option<usize>,
     pub max_total_tokens: Option<usize>,
+    /// Per-instance concurrency cap. CLI flag `--max-running-requests` on SGLang.
+    /// Already extracted by the SGLang gRPC label pipeline; surfacing it here
+    /// closes the HTTP-only path so capacity-aware consumers (e.g. WorkerCapacity)
+    /// see the same label regardless of transport.
+    pub max_running_requests: Option<usize>,
     pub weight_version: Option<String>,
 }
 
@@ -430,5 +435,41 @@ mod tests {
             .expect("grpc metadata");
         dump_labels("vLLM gRPC", &labels);
         assert!(!labels.is_empty());
+    }
+
+    #[test]
+    fn test_sglang_server_info_surfaces_max_running_requests_label() {
+        // Subset of an actual SGLang /server_info response. The full payload has
+        // many more fields; `serde(deny_unknown_fields)` is off by default so
+        // they're silently ignored.
+        let body = serde_json::json!({
+            "model_path": "Qwen/Qwen3-8B",
+            "tp_size": 1,
+            "dp_size": 1,
+            "max_running_requests": 256,
+            "context_length": 32768,
+        });
+        let info: ServerInfo = serde_json::from_value(body).expect("deserialize ServerInfo");
+        assert_eq!(info.max_running_requests, Some(256));
+
+        let labels = flat_labels(&info);
+        assert_eq!(
+            labels.get("max_running_requests").map(String::as_str),
+            Some("256")
+        );
+    }
+
+    #[test]
+    fn test_sglang_server_info_max_running_requests_optional() {
+        // Older SGLang versions or special configurations may omit the field.
+        let body = serde_json::json!({
+            "model_path": "Qwen/Qwen3-8B",
+            "tp_size": 1,
+        });
+        let info: ServerInfo = serde_json::from_value(body).expect("deserialize ServerInfo");
+        assert_eq!(info.max_running_requests, None);
+
+        let labels = flat_labels(&info);
+        assert!(!labels.contains_key("max_running_requests"));
     }
 }


### PR DESCRIPTION
## Summary
- SMG's curated `ServerInfo` struct in `discover_metadata.rs` deserializes a subset of SGLang's `/server_info` response (which has ~800 fields). `max_running_requests` — the per-instance batch-capacity cap from `--max-running-requests` — was being silently dropped.
- Adds `pub max_running_requests: Option<usize>` to the struct. `flat_labels` is serde-based and picks it up automatically — no other changes needed.
- The SGLang gRPC label pipeline (`SGLANG_GRPC_KEYS` in `routers/grpc/client.rs`) already extracts this field; this closes the HTTP-only path so capacity-aware consumers see the same label regardless of transport.

## Test plan
- [x] `cargo test --package smg --lib workflow::steps::local::discover_metadata::tests::test_sglang_server_info` — 2 new unit tests pass (present-and-absent cases).
- [ ] Existing `#[ignore]` integration tests against a live SGLang server still pass.
- [ ] No regression in the rest of the `workflow` test suite.

## Notes
- Independent of #1526. Can merge in any order.
- vLLM's HTTP server doesn't expose an equivalent endpoint and vLLM's `vllm_engine.proto` `GetServerInfoResponse` has no batch-capacity field, so this fix is SGLang-HTTP-specific. TRT-LLM uses `max_batch_size` (different name); that's a separate, larger change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * System now surfaces per-instance concurrency limits so users can see how many requests an instance will run concurrently.

* **Tests**
  * Added unit tests to verify correct detection and handling when the concurrency-limit information is present or omitted.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightseekorg/smg/pull/1529?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->