### PR TITLE
ci: cancel stale PR test runs

### DIFF
--- a/.github/workflows/cancel-merged-pr-tests.yml
+++ b/.github/workflows/cancel-merged-pr-tests.yml
@@ -1,0 +1,30 @@
+name: Cancel Merged PR Tests
+
+on:
+  pull_request:
+    branches: [main]
+    types: [closed]
+
+permissions:
+  contents: read
+
+jobs:
+  gateway-tests:
+    name: Cancel PR Test (SMG)
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    concurrency:
+      group: gateway-tests-pr-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    steps:
+      - run: echo "Cancelling in-progress PR Test (SMG) runs for merged PR #${{ github.event.pull_request.number }}."
+
+  mlx-tests:
+    name: Cancel PR Test (MLX)
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    concurrency:
+      group: mlx-tests-pr-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    steps:
+      - run: echo "Cancelling in-progress PR Test (MLX) runs for merged PR #${{ github.event.pull_request.number }}."

--- a/.github/workflows/pr-test-mlx.yml
+++ b/.github/workflows/pr-test-mlx.yml
@@ -36,8 +36,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: mlx-tests-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: mlx-tests-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.ref_name }}
+  cancel-in-progress: true
 
 jobs:
   e2e-mlx:

--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -20,8 +20,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: gateway-tests-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: gateway-tests-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.ref_name }}
+  cancel-in-progress: true
 
 env:
   RUSTC_WRAPPER: sccache


### PR DESCRIPTION
## Summary
- use stable PR-number concurrency groups for SMG and MLX PR test workflows
- cancel in-progress PR test runs when a PR is merged via a lightweight closed-PR workflow
- enable cancellation for superseded push-to-main PR test runs

## Testing
- pre-commit run --all-files
- git diff --cached --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Automated cancellation of test runs for merged pull requests to reduce unnecessary CI processing
  * Enhanced pull request test concurrency management for more efficient feedback

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightseekorg/smg/pull/1530?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->