### PR TITLE
fix(api): reject schemeless worker URLs in POST /workers

### DIFF
--- a/model_gateway/src/config/validation.rs
+++ b/model_gateway/src/config/validation.rs
@@ -827,51 +827,44 @@ impl ConfigValidator {
 
     fn validate_urls(urls: &[String]) -> ConfigResult<()> {
         for url in urls {
-            if url.is_empty() {
+            if let Err(reason) = validate_worker_url(url) {
                 return Err(ConfigError::InvalidValue {
                     field: "worker_url".to_string(),
                     value: url.clone(),
-                    reason: "URL cannot be empty".to_string(),
+                    reason,
                 });
-            }
-
-            // Case-insensitive scheme allow-list. Compare just the scheme
-            // segment so we don't allocate a lowercased copy of the full URL.
-            const ALLOWED_SCHEMES: &[&str] = &["http", "https", "grpc", "grpcs"];
-            let scheme = url.split_once("://").map_or("", |(s, _)| s);
-            if !ALLOWED_SCHEMES
-                .iter()
-                .any(|allowed| scheme.eq_ignore_ascii_case(allowed))
-            {
-                return Err(ConfigError::InvalidValue {
-                    field: "worker_url".to_string(),
-                    value: url.clone(),
-                    reason: "URL must start with http://, https://, grpc://, or grpcs://"
-                        .to_string(),
-                });
-            }
-
-            match ::url::Url::parse(url) {
-                Ok(parsed) => {
-                    if parsed.host_str().is_none() {
-                        return Err(ConfigError::InvalidValue {
-                            field: "worker_url".to_string(),
-                            value: url.clone(),
-                            reason: "URL must have a valid host".to_string(),
-                        });
-                    }
-                }
-                Err(e) => {
-                    return Err(ConfigError::InvalidValue {
-                        field: "worker_url".to_string(),
-                        value: url.clone(),
-                        reason: format!("Invalid URL format: {e}"),
-                    });
-                }
             }
         }
         Ok(())
     }
+}
+
+/// Reject empty / schemeless / unparsable worker URLs so callers can wrap the
+/// failure reason in whatever error type fits their layer.
+pub(crate) fn validate_worker_url(url: &str) -> Result<(), String> {
+    if url.is_empty() {
+        return Err("URL cannot be empty".to_string());
+    }
+
+    const ALLOWED_SCHEMES: &[&str] = &["http", "https", "grpc", "grpcs"];
+    let scheme = url.split_once("://").map_or("", |(s, _)| s);
+    if !ALLOWED_SCHEMES
+        .iter()
+        .any(|allowed| scheme.eq_ignore_ascii_case(allowed))
+    {
+        return Err("URL must start with http://, https://, grpc://, or grpcs://".to_string());
+    }
+
+    match ::url::Url::parse(url) {
+        Ok(parsed) => {
+            if parsed.host_str().is_none() {
+                return Err("URL must have a valid host".to_string());
+            }
+        }
+        Err(e) => return Err(format!("Invalid URL format: {e}")),
+    }
+
+    Ok(())
 }
 
 fn validate_mebibyte_limit(field: &str, value_mb: usize) -> ConfigResult<()> {

--- a/model_gateway/src/worker/service.rs
+++ b/model_gateway/src/worker/service.rs
@@ -16,7 +16,7 @@ use serde_json::json;
 use tracing::warn;
 
 use crate::{
-    config::RouterConfig,
+    config::{validation::validate_worker_url, RouterConfig},
     worker::{registry::WorkerId, worker::worker_to_info, WorkerRegistry},
     workflow::{Job, JobQueue},
 };
@@ -241,6 +241,8 @@ impl WorkerService {
         &self,
         config: WorkerSpec,
     ) -> Result<CreateWorkerResult, WorkerServiceError> {
+        validate_worker_url_request(&config.url)?;
+
         if self.router_config.api_key.is_some() && config.api_key.is_none() {
             warn!(
                 "Adding worker {} without API key while router has API key configured. \
@@ -429,5 +431,67 @@ impl WorkerService {
             .map_err(|e| WorkerServiceError::QueueSubmitFailed { message: e })?;
 
         Ok(UpdateWorkerResult { worker_id, url })
+    }
+}
+
+/// Wrap [`validate_worker_url`] so the API layer surfaces a 400 instead of a
+/// config-layer error.
+fn validate_worker_url_request(url: &str) -> Result<(), WorkerServiceError> {
+    validate_worker_url(url).map_err(|reason| WorkerServiceError::BadRequest {
+        message: format!("Worker URL '{url}' is invalid: {reason}"),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_worker_url_request_accepts_all_four_schemes() {
+        assert!(validate_worker_url_request("http://10.0.0.5:8000").is_ok());
+        assert!(validate_worker_url_request("https://10.0.0.5:8000").is_ok());
+        assert!(validate_worker_url_request("grpc://10.0.0.5:8000").is_ok());
+        assert!(validate_worker_url_request("grpcs://10.0.0.5:8000").is_ok());
+    }
+
+    #[test]
+    fn validate_worker_url_request_accepts_case_insensitive_schemes() {
+        assert!(validate_worker_url_request("HTTP://10.0.0.5:8000").is_ok());
+        assert!(validate_worker_url_request("GrPc://10.0.0.5:8000").is_ok());
+    }
+
+    #[test]
+    fn validate_worker_url_request_rejects_bare_host_port_as_400() {
+        let err = validate_worker_url_request("10.0.0.5:8000").unwrap_err();
+        assert!(matches!(err, WorkerServiceError::BadRequest { .. }));
+        assert_eq!(err.status_code(), StatusCode::BAD_REQUEST);
+        assert!(err
+            .to_string()
+            .contains("http://, https://, grpc://, or grpcs://"));
+    }
+
+    #[test]
+    fn validate_worker_url_request_rejects_empty_as_400() {
+        let err = validate_worker_url_request("").unwrap_err();
+        assert!(matches!(err, WorkerServiceError::BadRequest { .. }));
+        assert!(err.to_string().contains("empty"));
+    }
+
+    #[test]
+    fn validate_worker_url_request_rejects_unknown_scheme() {
+        let err = validate_worker_url_request("ftp://10.0.0.5:8000").unwrap_err();
+        assert!(matches!(err, WorkerServiceError::BadRequest { .. }));
+    }
+
+    #[test]
+    fn validate_worker_url_request_rejects_missing_host() {
+        let err = validate_worker_url_request("http://").unwrap_err();
+        assert!(matches!(err, WorkerServiceError::BadRequest { .. }));
+    }
+
+    #[test]
+    fn validate_worker_url_request_rejects_unparsable_url() {
+        let err = validate_worker_url_request("http://[invalid").unwrap_err();
+        assert!(matches!(err, WorkerServiceError::BadRequest { .. }));
     }
 }


### PR DESCRIPTION
## Description

### Problem

`WorkerService::create_worker` (`model_gateway/src/worker/service.rs:240`) calls `reserve_id_for_url(config.url)` (`registry.rs:889`) *before* the AddWorker workflow runs, so that the HTTP handler can return `202 Accepted` synchronously with `Location: /workers/{worker_id}`. The contract requires the reservation key (`config.url` at submission time) and the registration key (`worker.url()` after workflow normalization) to be the **same string** — only then does `register_inner`'s `url_to_id.entry(...)` find the pre-reserved entry and reuse the reserved `WorkerId`.

`CreateWorkerStep` rewrites the URL via `normalize_url` (`model_gateway/src/workflow/steps/local/create_worker.rs:300-313`):

```rust
fn normalize_url(url: &str, connection_mode: ConnectionMode) -> String {
    if url.starts_with("http://") || url.starts_with("https://")
        || url.starts_with("grpc://") || url.starts_with("grpcs://") {
        url.to_string()
    } else {
        match connection_mode {
            ConnectionMode::Http => format!("http://{url}"),
            ConnectionMode::Grpc => format!("grpc://{url}"),
        }
    }
}
```

When the submitted URL has no recognized scheme (e.g. bare `host:port`), `normalize_url` prepends one — the reservation key and registration key diverge — and the `worker_id` returned in the 202 response is permanently orphaned. The client polls `/workers/{worker_id}` and gets `404 Not Found`. The live worker is registered under a different `WorkerId` that the client was never told about.

Adjacent #1523 (`fix(service-discovery): drop http:// prefix so dual-probe detects gRPC`) added a `resolve_url_to_id` canonicalization helper that makes *registry lookups* tolerate the orphan, but does not address the API contract violation. This PR closes the orphan-creation path on the HTTP API side.

### Solution

Validate `config.url` at the API boundary, before `reserve_id_for_url` runs. Reject any URL that:

- is empty,
- does not start with one of `http://`, `https://`, `grpc://`, `grpcs://` (case-insensitive scheme allow-list), or
- does not parse via `::url::Url::parse` or has no host.

The exact rule already lives in `config::validation::ConfigValidator::validate_urls` (used for static `router_config` URLs). Extracted it into a free `pub(crate) fn validate_worker_url(url: &str) -> Result<(), String>` so both the static-config validator and the new service-layer wrapper share one implementation. The service-layer wrapper (`validate_worker_url_request`) translates the plain error string into `WorkerServiceError::BadRequest`, yielding `400 Bad Request` with a message like `Worker URL '10.0.0.5:8000' is invalid: URL must start with http://, https://, grpc://, or grpcs://`.

## Changes

- `model_gateway/src/config/validation.rs`: extract `pub(crate) fn validate_worker_url(url: &str) -> Result<(), String>`. `ConfigValidator::validate_urls` now delegates to it and wraps the error string in `ConfigError::InvalidValue`.
- `model_gateway/src/worker/service.rs`: add `validate_worker_url_request` (wraps the shared helper into `WorkerServiceError::BadRequest`), call it as the first statement of `create_worker` so no state is mutated for invalid input. Seven unit tests covering accept (four schemes + case-insensitive) and reject (bare `host:port`, empty, unknown scheme, missing host, unparsable URL) paths.

## Test Plan

Behavior matrix after this PR, walking every scenario the team discussed for #1523. Each timeline begins at `t=0` when the API handler is invoked.

### Case A — K8s pod is discovered, registered, deleted (the primary scenario #1523 fixed)

This PR does not change this path. `service_discovery` submits `Job::AddWorker` directly to the job queue and never calls `WorkerService::create_worker`; no validation runs.

```
t=0.000s  service_discovery::worker_url("10.0.0.5", 8000) -> "10.0.0.5:8000"
t=0.001s  Job::AddWorker { config { url: "10.0.0.5:8000" } } submitted
t=0.05s   Workflow starts: DetectConnectionMode probes pod
t=2.30s   detection completes -> ConnectionMode::Grpc
t=2.31s   CreateWorkerStep: normalize_url("10.0.0.5:8000", Grpc) = "grpc://10.0.0.5:8000"
t=3.50s   RegisterWorkersStep -> url_to_id["grpc://10.0.0.5:8000"] = liveId; workers[liveId] = w
t=...s    Pod deleted -> Job::RemoveWorker { url: "10.0.0.5:8000" }
          resolve_url_to_id("10.0.0.5:8000"):
            exact "10.0.0.5:8000" -> miss
            fallback "http://10.0.0.5:8000" -> miss
            fallback "grpc://10.0.0.5:8000" -> liveId (is_live True) -> returned
          Worker removed cleanly.
```

✅ Unchanged. Result: correct end-to-end registration and removal.

### Case B — User POSTs `{"url":"http://10.0.0.5:8000"}` (already-schemed)

```
t=0.000s  HTTP handler -> WorkerService::create_worker
t=0.001s  validate_worker_url_request("http://10.0.0.5:8000") -> Ok
t=0.001s  reserve_id_for_url("http://10.0.0.5:8000") -> url_to_id["http://10.0.0.5:8000"] = reservedId
t=0.002s  Job::AddWorker { url: "http://10.0.0.5:8000" } submitted
t=0.003s  202 Accepted, Location: /workers/{reservedId}
t=0.05s   Workflow: detect HTTP, normalize_url no-op (scheme preserved)
t=3.50s   RegisterWorkersStep -> register_or_replace(worker)
          register_inner: url_to_id.entry("http://10.0.0.5:8000") is OCCUPIED with reservedId
          -> reuses reservedId, workers[reservedId] = worker
t=...s    Client polls /workers/{reservedId} -> 200 with worker info ✓
```

✅ Unchanged. Validation passes, no orphan.

### Case C — User POSTs `{"url":"10.0.0.5:8000"}` (bare) — THIS IS THE CASE THIS PR FIXES

Before this PR:

```
t=0.000s  HTTP handler -> WorkerService::create_worker
t=0.001s  reserve_id_for_url("10.0.0.5:8000") -> url_to_id["10.0.0.5:8000"] = reservedId
t=0.002s  Job::AddWorker submitted
t=0.003s  202 Accepted, Location: /workers/{reservedId}, body worker_id = reservedId
t=0.05s   Workflow: detect Grpc, normalize_url("10.0.0.5:8000", Grpc) = "grpc://10.0.0.5:8000"
t=3.50s   RegisterWorkersStep -> register_or_replace(worker, url="grpc://10.0.0.5:8000")
          register_inner: url_to_id.entry("grpc://10.0.0.5:8000") is VACANT
          -> mints NEW liveId, workers[liveId] = worker, url_to_id["grpc://10.0.0.5:8000"] = liveId
t=3.51s   Final registry state:
            url_to_id["10.0.0.5:8000"]      = reservedId  <- ORPHAN, no worker behind it
            url_to_id["grpc://10.0.0.5:8000"] = liveId    <- live worker
            workers[liveId]                 = w
            workers[reservedId]             = (absent)
t=...s    Client polls /workers/{reservedId} -> 404 Not Found
          Client has no way to discover that the actual worker_id is liveId.
```

After this PR:

```
t=0.000s  HTTP handler -> WorkerService::create_worker
t=0.001s  validate_worker_url_request("10.0.0.5:8000")
          -> Err(BadRequest { message: "Worker URL '10.0.0.5:8000' is invalid:
             URL must start with http://, https://, grpc://, or grpcs://" })
t=0.002s  400 Bad Request returned to client
          No reservation written. No job submitted. Registry unchanged.
```

✅ Fixed. Client gets an immediate, actionable 400 instead of 202 -> 404. No orphan can be created via this path.

### Case D — Mixed source: a human POSTs the same pod K8s is already managing

Two sub-cases.

**D1: POST schemed URL while K8s also discovers the same pod.**

```
t=0.000s  service_discovery registers pod first:
          url_to_id["grpc://10.0.0.5:8000"] = liveId; workers[liveId] = w
t=1.000s  User POSTs {"url":"http://10.0.0.5:8000"}
t=1.001s  validate_worker_url_request -> Ok
t=1.001s  reserve_id_for_url("http://10.0.0.5:8000")
          -> url_to_id["http://10.0.0.5:8000"] = newReservedId (different from K8s's liveId because key differs)
t=1.002s  conflict check: get(newReservedId).is_some() -> false (no worker at this id) -> no 409
t=1.003s  Job::AddWorker { url: "http://10.0.0.5:8000" } submitted
t=1.004s  202 Accepted with worker_id = newReservedId
t=1.05s   Workflow: detect HTTP, normalize_url no-op
t=4.50s   RegisterWorkersStep:
          register_inner: url_to_id.entry("http://10.0.0.5:8000") is OCCUPIED with newReservedId
          -> reuses it; workers[newReservedId] = w'
          (Two distinct workers now exist for the same pod, one under each scheme.)
```

Two valid workers exist for the same host:port under different schemes — a pre-existing data model permissiveness, unchanged by this PR. The 202's `worker_id` is honest; polling it returns the worker the user created. No orphan, no 404.

**D2: POST bare URL while K8s also discovers the same pod.**

Before this PR: produces the same orphan + 404 wart as Case C, plus the pod is also tracked separately by service_discovery under the canonical scheme.

After this PR: 400 at the API boundary as in Case C. The K8s-side registration is unaffected.

✅ The only behavior change is in the bare-URL sub-case, where we now reject upfront instead of silently producing an orphan.

### Case E — Workflow or job-submit fails after a successful reservation

```
t=0.000s  HTTP handler -> WorkerService::create_worker
t=0.001s  validate_worker_url_request("http://10.0.0.5:8000") -> Ok
t=0.001s  reserve_id_for_url(...) -> url_to_id["http://10.0.0.5:8000"] = reservedId
t=0.002s  Submit Job::AddWorker

Path E1: queue submit fails
t=0.003s  submit().await -> Err(...)
t=0.003s  create_worker returns Err(QueueSubmitFailed). HTTP 500.
          The reservation written at t=0.001 IS NOT REMOVED.

Path E2: queue submit succeeds, workflow fails downstream
t=0.003s  202 returned with worker_id = reservedId
t=0.05s   Workflow runs: DetectConnectionMode times out, or build fails
t=...s    Workflow errors out. register_or_replace never runs.
          The reservation written at t=0.001 IS NOT REMOVED.
          Client polls /workers/{reservedId} -> 404.
```

⚠️ **Not addressed by this PR.** These leak paths exist on `main` today regardless of whether the submitted URL was schemed or bare. Validation at the API boundary cannot fix them — the URL is well-formed; it's the downstream failure that orphans the reservation.

Properly fixing this requires a `release_reservation(url) -> bool` registry primitive that drops a `url_to_id` entry only when its `WorkerId` is not in `workers`, wired into:
- `WorkerService::create_worker`'s error-return paths (so E1 is reaped synchronously)
- The AddWorker workflow's terminal-failure hook (so E2 is reaped asynchronously)

Tracked separately; out of scope for this PR.

### Test summary

- `cargo test -p smg --lib worker::service::tests::` — 7/7 new tests passing (covering each accept and reject path of `validate_worker_url_request`, including verification that rejections surface as `WorkerServiceError::BadRequest` with `StatusCode::BAD_REQUEST` and the expected error message text).
- `cargo test -p smg --lib config::validation::tests::` — 23/23 pre-existing config-side tests passing after the helper extraction; `test_validate_invalid_urls` still exercises the same accept/reject rules via the new shared path.
- `cargo +nightly fmt --check` clean.
- `cargo clippy -p smg --all-targets --all-features -- -D warnings` clean.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Worker URL validation now enforces stricter requirements during creation, returning HTTP 400 errors for invalid URLs.
  * Validation rejects empty URLs, unsupported schemes, unparsable URLs, and missing hosts.
  * Added support for http, https, grpc, and grpcs schemes.

* **Tests**
  * Added unit tests covering URL validation scenarios and error cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightseekorg/smg/pull/1532?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->