### PR TITLE
fix(ci): restore per-commit CI runs on main

### DIFF
--- a/.github/workflows/pr-test-mlx.yml
+++ b/.github/workflows/pr-test-mlx.yml
@@ -37,7 +37,7 @@ permissions:
 
 concurrency:
   group: mlx-tests-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.ref_name }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   e2e-mlx:

--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -21,7 +21,7 @@ permissions:
 
 concurrency:
   group: gateway-tests-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.ref_name }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   RUSTC_WRAPPER: sccache


### PR DESCRIPTION
## Description

### Problem

[#1530](https://github.com/lightseekorg/smg/pull/1530) rewrote the `concurrency` block in `pr-test-rust.yml` and `pr-test-mlx.yml` and, alongside the new PR-number-based group key, dropped the `event_name == 'pull_request'` guard on `cancel-in-progress`, making it unconditionally `true`.

For push-to-`main`, the group key resolves to `gateway-tests-main` / `mlx-tests-main` — every commit on `main` shares one group. With `cancel-in-progress: true`, when commit B lands while commit A's CI is still running, B joins A's group and **kills A's run mid-flight**.

This breaks smg's invariant that every commit on `main` runs CI to completion. Without per-commit CI, a `git bisect` against a regression on `main` can land on a commit whose CI was cancelled and therefore has no signal.

The PR-number-based group key for PR events and the new `cancel-merged-pr-tests.yml` workflow added by #1530 are unaffected by this fix — they only target PR runs.

### Solution

Restore the `event_name == 'pull_request'` guard on `cancel-in-progress`, keeping the PR-number-based group key from #1530:

```yaml
concurrency:
  group: gateway-tests-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.ref_name }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

Net behavior after this PR:
- **PR runs** — still cancelled on new pushes within the same PR (preserves the intent of #1530).
- **Main push runs** — each commit's CI run completes independently (preserves the per-commit bisection invariant).
- **`workflow_dispatch` on `main`** — shares the main push group; neither cancels the other.

## Changes

- `.github/workflows/pr-test-rust.yml` — change `cancel-in-progress: true` back to `cancel-in-progress: ${{ github.event_name == 'pull_request' }}`.
- `.github/workflows/pr-test-mlx.yml` — same change.

## Test Plan

Local checks:

```bash
pre-commit run --files .github/workflows/pr-test-rust.yml .github/workflows/pr-test-mlx.yml
git diff --cached --check
```

Both pass; YAML parses, no whitespace issues.

No Rust or Python sources are touched in this PR, so `cargo fmt` / `cargo clippy` are not applicable.

Behavioral verification once merged (observable on `main`):
- Land a no-op commit on `main` while the prior commit's `PR Test (SMG)` is in progress; the prior run should continue to completion (after this PR) instead of being cancelled (before this PR).
- On an open PR, push two consecutive commits — the older run should still be cancelled when the newer one starts (intent of #1530 preserved).

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized GitHub Actions workflow concurrency settings to improve CI/CD efficiency for pull requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightseekorg/smg/pull/1536?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->