### PR TITLE
ci(claude-review): flag PRs missing required template sections

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -105,6 +105,66 @@ jobs:
             "won't fix", "disagree"), respect their response. Do not re-flag
             issues that the author has acknowledged or intentionally declined.
 
+            IMPORTANT — PR description template check (run this FIRST,
+            before the code review steps below, on every event):
+
+            The PR body must follow .github/PULL_REQUEST_TEMPLATE.md.
+            Required headers (literal lines, anywhere in body, any order):
+              ## Description
+              ### Problem
+              ### Solution
+              ## Changes
+              ## Test Plan
+            The trailing <details>Checklist</details> block is optional; ignore.
+
+            "Section content" = text between a header and the NEXT ## or ###
+            header line (or end of body). After stripping all HTML comments
+            (<!-- ... -->, including multi-line) and trimming whitespace,
+            content must be non-empty. For "## Description", the Problem and
+            Solution subsections count as content — Description is filled if
+            both subsections are filled, even if no prose sits directly under it.
+
+            To check:
+            a. Fetch the body:
+                 BODY=$(gh pr view ${{ github.event.pull_request.number }} \
+                   --repo ${{ github.repository }} --json body --jq .body)
+            b. Verify each required header appears in BODY.
+            c. For each of Problem, Solution, Changes, Test Plan, verify the
+               section is filled per the definition above.
+            d. Build a bulleted gap list, e.g.
+                 - Missing header: `## Test Plan`
+                 - Empty section: `### Problem` (only contains HTML comments)
+
+            Dedup by a hidden marker on a claude[bot] top-level (issue) comment:
+                 EXISTING=$(gh api \
+                   repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments \
+                   --paginate \
+                   --jq '.[] | select(.user.login == "claude[bot]" and (.body | startswith("<!-- claude-pr-template-check -->"))) | .id' \
+                   | head -1)
+
+            Cases:
+              gaps + no EXISTING → post a new comment:
+                gh pr comment ${{ github.event.pull_request.number }} \
+                  --repo ${{ github.repository }} --body "$MSG"
+              gaps + EXISTING → update in place (never post a second one):
+                gh api repos/${{ github.repository }}/issues/comments/$EXISTING \
+                  -X PATCH -f body="$MSG"
+              no gaps + EXISTING → delete on green:
+                gh api repos/${{ github.repository }}/issues/comments/$EXISTING -X DELETE
+              no gaps + no EXISTING → do nothing.
+
+            $MSG body (verbatim, with the gap list from step d substituted in):
+              <!-- claude-pr-template-check -->
+              👋 The PR description doesn't fully follow
+              [PULL_REQUEST_TEMPLATE.md](https://github.com/${{ github.repository }}/blob/main/.github/PULL_REQUEST_TEMPLATE.md):
+
+              <bulleted gap list from step d>
+
+              Please update the PR description so reviewers have the context they need.
+
+            Finish this check (post/update/delete) before moving on, so a
+            turn-limit cutoff during code review doesn't lose the template check.
+
             Steps (do steps 1-3 in parallel):
             1. Run the appropriate git diff (see incremental review rules above).
             2. Read REVIEW.md for severity format, focus areas, and domain knowledge.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -115,14 +115,25 @@ jobs:
               ### Solution
               ## Changes
               ## Test Plan
-            The trailing <details>Checklist</details> block is optional; ignore.
+            The trailing <details>Checklist</details> block is template
+            boilerplate, not content — strip it before computing section
+            content (see pre-processing below).
+
+            Pre-processing: before computing section content, strip from
+            BODY any <details>...</details> block whose <summary> line,
+            after trimming, is exactly "Checklist". This is the trailing
+            block from PULL_REQUEST_TEMPLATE.md and must not count as
+            content for any section — otherwise an empty Test Plan would
+            be falsely treated as filled, because there is no later ##
+            header so the checklist sits inside the Test Plan section.
 
             "Section content" = text between a header and the NEXT ## or ###
-            header line (or end of body). After stripping all HTML comments
-            (<!-- ... -->, including multi-line) and trimming whitespace,
-            content must be non-empty. For "## Description", the Problem and
-            Solution subsections count as content — Description is filled if
-            both subsections are filled, even if no prose sits directly under it.
+            header line (or end of body) in the pre-processed BODY. After
+            stripping all HTML comments (<!-- ... -->, including multi-line)
+            and trimming whitespace, content must be non-empty. For
+            "## Description", the Problem and Solution subsections count
+            as content — Description is filled if both subsections are
+            filled, even if no prose sits directly under it.
 
             To check:
             a. Fetch the body:


### PR DESCRIPTION
## Description

### Problem

Nothing currently checks whether a PR description actually follows [PULL_REQUEST_TEMPLATE.md](.github/PULL_REQUEST_TEMPLATE.md). Contributors sometimes delete the template wholesale, leave the headers in place but never fill them in (only `<!-- ... -->` comment placeholders remain), or skip the `## Test Plan` section — which makes review harder.

The repo has a deterministic check for PR title and branch name ([pr-naming-check.yml](.github/workflows/pr-naming-check.yml)) but no equivalent for the body.

### Solution

Extend the existing Claude PR review prompt at [claude-code-review.yml](.github/workflows/claude-code-review.yml) to verify the PR description structure on every review run. Picked the Claude workflow over a new deterministic shell job because:

- Pattern-matching "section is filled vs only contains HTML comments" in bash is brittle, and false positives on a required check are very annoying.
- The Claude review job already fetches PR context, so the marginal turn cost is small.

Trade-off accepted: the workflow trigger is `[opened, synchronize, reopened]`, **not** `edited`. A body-only fix won't re-fire Claude until the next push. Most contributors fix the body before pushing again, and the dedup mechanism (below) makes this fail-soft.

How the check behaves:

- Claude fetches the PR body, verifies the five required headers (`## Description`, `### Problem`, `### Solution`, `## Changes`, `## Test Plan`) are present, and that each section has non-comment, non-empty content.
- It posts / updates / deletes **one** top-level comment carrying the hidden marker `<!-- claude-pr-template-check -->`:

| State | Prior marker comment? | Action |
|---|---|---|
| Gaps | No | Post new comment |
| Gaps | Yes | `PATCH` the existing one (no re-post spam) |
| No gaps | Yes | `DELETE` (no stale "missing X" left in the timeline) |
| No gaps | No | No-op |

- The check runs **before** the code review block in the prompt, so a turn-limit cutoff during code review doesn't lose it.

## Changes

- [.github/workflows/claude-code-review.yml](.github/workflows/claude-code-review.yml) — insert a new `IMPORTANT — PR description template check` block into the review prompt, right before the existing `Steps (do steps 1-3 in parallel):` block. The new block defines:
  - the required headers,
  - what "section content" means (HTML comments stripped, whitespace trimmed),
  - exact `gh` commands for fetching the body and the marker comment,
  - the four-case dedup matrix above,
  - the verbatim comment body template.

No new jobs, no trigger change, no new permissions — the existing review job already holds `pull-requests: write` and `issues: write`.

## Test Plan

Local checks:

```bash
pre-commit run --files .github/workflows/claude-code-review.yml
```

All hooks pass (`check yaml`, `codespell`, `trim trailing whitespace`, DCO sign-off, no-AI-co-author).

No Rust or Python sources changed, so `cargo fmt` / `cargo clippy` aren't applicable.

Behavioral verification once merged (won't apply to this PR itself — the workflow change only takes effect on PRs opened after merge):

- **Negative case** — open a follow-up PR with `## Test Plan` header removed → Claude posts one top-level marker comment listing `Missing header: ## Test Plan`.
- **Update case** — while the gap comment exists, push another commit with the gap still present → existing comment is `PATCH`ed in place, no second comment.
- **Delete on green** — fix the body to add `## Test Plan`, push another commit → the marker comment is deleted.
- **No-op case** — open a PR whose body already follows the template → no top-level comment from `claude[bot]`.

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated PR description validator that runs before other review steps: it normalizes PR bodies, checks required headers and section content (with special handling for description subsections), and reports missing or empty sections.
  * Posts, updates, or removes a single deduplicated bot comment to surface template gaps, ensuring timely, non-redundant feedback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightseekorg/smg/pull/1537?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->