### PR TITLE
test(e2e): add basic string stop and matched stop test coverage for MLX

### DIFF
--- a/e2e_test/mlx/test_mlx_backend.py
+++ b/e2e_test/mlx/test_mlx_backend.py
@@ -21,6 +21,7 @@ pytestmark = pytest.mark.skipif(
     reason="MLX backend requires Apple Silicon (macOS arm64)",
 )
 
+
 def collect_streamed_completion(stream):
     """Collect all text and the final choice from a streaming completion response."""
     chunks = list(stream)
@@ -29,6 +30,7 @@ def collect_streamed_completion(stream):
         c.choices[0] for c in reversed(chunks) if c.choices and c.choices[0].finish_reason
     )
     return text, final_choice
+
 
 def assert_stop_text_trimmed(text, stop_text):
     assert stop_text not in text, f"Stop text {stop_text!r} should not appear in output: {text!r}"
@@ -40,10 +42,14 @@ def assert_matched_stop(choice, expected):
 
 
 def assert_api_error(err, expected_status: int, expected_code: str) -> None:
-    assert err.status_code == expected_status, f"Expected HTTP {expected_status}, got {err.status_code}"
+    assert err.status_code == expected_status, (
+        f"Expected HTTP {expected_status}, got {err.status_code}"
+    )
     body = getattr(err, "body", None) or {}
     error_str = str(body) + str(getattr(err, "message", ""))
-    assert expected_code in error_str, f"Expected {expected_code!r} in error body, got: {error_str!r}"
+    assert expected_code in error_str, (
+        f"Expected {expected_code!r} in error body, got: {error_str!r}"
+    )
 
 
 WEATHER_TOOL = {

--- a/e2e_test/mlx/test_mlx_backend.py
+++ b/e2e_test/mlx/test_mlx_backend.py
@@ -27,8 +27,9 @@ def collect_streamed_completion(stream):
     chunks = list(stream)
     text = "".join(c.choices[0].text for c in chunks if c.choices and c.choices[0].text)
     final_choice = next(
-        c.choices[0] for c in reversed(chunks) if c.choices and c.choices[0].finish_reason
+        (c.choices[0] for c in reversed(chunks) if c.choices and c.choices[0].finish_reason), None
     )
+    assert final_choice is not None, "No chunk with finish_reason found in stream"
     return text, final_choice
 
 

--- a/e2e_test/mlx/test_mlx_backend.py
+++ b/e2e_test/mlx/test_mlx_backend.py
@@ -13,12 +13,37 @@ import json
 import platform
 import sys
 
+import openai
 import pytest
 
 pytestmark = pytest.mark.skipif(
     sys.platform != "darwin" or platform.machine() != "arm64",
     reason="MLX backend requires Apple Silicon (macOS arm64)",
 )
+
+def collect_streamed_completion(stream):
+    """Collect all text and the final choice from a streaming completion response."""
+    chunks = list(stream)
+    text = "".join(c.choices[0].text for c in chunks if c.choices and c.choices[0].text)
+    final_choice = next(
+        c.choices[0] for c in reversed(chunks) if c.choices and c.choices[0].finish_reason
+    )
+    return text, final_choice
+
+def assert_stop_text_trimmed(text, stop_text):
+    assert stop_text not in text, f"Stop text {stop_text!r} should not appear in output: {text!r}"
+
+
+def assert_matched_stop(choice, expected):
+    actual = getattr(choice, "matched_stop", None)
+    assert actual == expected, f"Expected matched_stop={expected!r}, got {actual!r}"
+
+
+def assert_api_error(err, expected_status: int, expected_code: str) -> None:
+    assert err.status_code == expected_status, f"Expected HTTP {expected_status}, got {err.status_code}"
+    body = getattr(err, "body", None) or {}
+    error_str = str(body) + str(getattr(err, "message", ""))
+    assert expected_code in error_str, f"Expected {expected_code!r} in error body, got: {error_str!r}"
 
 
 WEATHER_TOOL = {
@@ -59,6 +84,9 @@ class TestMlxBackend:
     # Disable thinking on basic chat tests so the 0.6B model has budget for
     # actual content within max_tokens.
     NO_THINKING = {"chat_template_kwargs": {"enable_thinking": False}}
+
+    STOP_SEQUENCE_TEST_PROMPT = "Repeat: 1 2 3 hello world 4 5 6 7"
+    SINGLE_STRING_STOP = "6"
 
     def test_basic_chat(self, model, api_client):
         response = api_client.chat.completions.create(
@@ -153,3 +181,66 @@ class TestMlxBackend:
         )
         assert response.choices[0].finish_reason == "length"
         assert response.usage.completion_tokens == 10
+
+    def test_chat_stop_string_non_streaming(self, model, api_client):
+        response = api_client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": self.STOP_SEQUENCE_TEST_PROMPT}],
+            max_tokens=160,
+            temperature=0,
+            stop=[self.SINGLE_STRING_STOP],
+            extra_body=self.NO_THINKING,
+        )
+        choice = response.choices[0]
+        assert choice.finish_reason == "stop"
+        assert_stop_text_trimmed(choice.message.content or "", self.SINGLE_STRING_STOP)
+        assert_matched_stop(choice, self.SINGLE_STRING_STOP)
+
+    def test_completion_stop_string_non_streaming(self, model, api_client):
+        response = api_client.completions.create(
+            model=model,
+            prompt=self.STOP_SEQUENCE_TEST_PROMPT,
+            max_tokens=160,
+            temperature=0,
+            stop=[self.SINGLE_STRING_STOP],
+        )
+        choice = response.choices[0]
+        assert choice.finish_reason == "stop"
+        assert_stop_text_trimmed(choice.text, self.SINGLE_STRING_STOP)
+        assert_matched_stop(choice, self.SINGLE_STRING_STOP)
+
+    def test_chat_rejects_multi_token_stop_string(self, model, api_client):
+        with pytest.raises((openai.BadRequestError, openai.APIStatusError)) as exc_info:
+            api_client.chat.completions.create(
+                model=model,
+                messages=[{"role": "user", "content": self.STOP_SEQUENCE_TEST_PROMPT}],
+                max_tokens=10,
+                stop=["hello world"],
+                extra_body=self.NO_THINKING,
+            )
+        assert_api_error(exc_info.value, 400, "unsupported_stop_string")
+
+    def test_completion_rejects_multi_token_stop_string(self, model, api_client):
+        with pytest.raises((openai.BadRequestError, openai.APIStatusError)) as exc_info:
+            api_client.completions.create(
+                model=model,
+                prompt=self.STOP_SEQUENCE_TEST_PROMPT,
+                max_tokens=10,
+                stop=["hello world"],
+            )
+        assert_api_error(exc_info.value, 400, "unsupported_stop_string")
+
+    def test_completion_stop_string_streaming_final_chunk(self, model, api_client):
+        """Streaming completion: final chunk has finish_reason='stop' and matched_stop set."""
+        stream = api_client.completions.create(
+            model=model,
+            prompt=self.STOP_SEQUENCE_TEST_PROMPT,
+            max_tokens=160,
+            temperature=0,
+            stop=[self.SINGLE_STRING_STOP],
+            stream=True,
+        )
+        text, final_choice = collect_streamed_completion(stream)
+        assert final_choice.finish_reason == "stop"
+        assert_stop_text_trimmed(text, self.SINGLE_STRING_STOP)
+        assert_matched_stop(final_choice, self.SINGLE_STRING_STOP)


### PR DESCRIPTION
## Description

### Problem

The MLX gRPC backend added support for string stop sequences and `matched_stop` reporting, but had no end-to-end test coverage validating this through the full router → gRPC → MLX worker path.

String stop support PR: https://github.com/lightseekorg/smg/pull/1524

### Solution

Add 5 e2e tests to `e2e_test/mlx/test_mlx_backend.py` covering the stop sequence feature for the regular (non-Harmony) pipeline:

- 2 tests for **Chat/completion non-streaming, single-token string stop**: verifies the response returns HTTP 200, `finish_reason == "stop"`, stop text is excluded
from the output, and `matched_stop` echoes back the stop string.
- 2 tests for **Chat/completion non-streaming, multi-token string stop**: verifies the gateway returns HTTP 400 with `unsupported_stop_string` error code.
- 1 test for **Completion streaming, single-token string stop**: verifies the final SSE chunk carries `finish_reason == "stop"` and the correct `matched_stop` value.

Helper functions `assert_stop_text_trimmed`, `assert_matched_stop`, `assert_api_error`, and `collect_streamed_completion` are extracted to keep the
test bodies concise.

## Changes

- `e2e_test/mlx/test_mlx_backend.py`: add 5 stop-sequence/matched-stop tests and supporting helper functions; add `STOP_SEQUENCE_TEST_PROMPT` and
`SINGLE_STRING_STOP` class constants to `TestMlxBackend`

## Test Plan

Run on Apple Silicon (macOS arm64) with `mlx-community/Qwen3-0.6B-4bit`:

```bash
E2E_RUNTIME=mlx pytest e2e_test/mlx/test_mlx_backend.py -v

All 10 tests pass (5 pre-existing + 5 new).
```


- [x] cargo +nightly fmt passes
- [x] cargo clippy --all-targets --all-features -- -D warnings passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack #sig-smg (https://slack.lightseek.org) to discuss, review, and merge PRs


also run python format checks:
```
# Lint (with auto-fix)
ruff check --fix e2e_test/ bindings/python/ scripts/

# Format
ruff format e2e_test/ bindings/python/ scripts/

# Type check
mypy e2e_test/ --config-file mypy.ini
mypy bindings/python/ --config-file mypy.ini
```


</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded MLX backend test coverage for stop-sequence handling in streaming and non-streaming modes
  * Added checks that returned/streamed output is trimmed so stop strings are not present and that reported finish reasons and matched-stop indicators reflect the stop string
  * Added validation for rejection of multi-token stop sequences and for proper HTTP error status and error code fragments

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightseekorg/smg/pull/1538?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->