### PR TITLE
feat(scheduler): foundation — class, config, policy (PR 2 M1)

### DIFF
--- a/model_gateway/src/middleware/mod.rs
+++ b/model_gateway/src/middleware/mod.rs
@@ -9,6 +9,7 @@ pub mod concurrency;
 pub mod logging;
 pub mod metrics;
 pub mod request_id;
+pub mod scheduler;
 pub mod storage_context;
 pub mod tenant_resolution;
 pub mod token_bucket;

--- a/model_gateway/src/middleware/scheduler/class.rs
+++ b/model_gateway/src/middleware/scheduler/class.rs
@@ -9,8 +9,12 @@ pub const PRIORITY_HEADER: &str = "x-smg-priority";
 ///
 /// Numeric values are load-bearing: `Ord` is derived so the tenant clamp is
 /// `std::cmp::min(header_class, max_class)`, and `repr(u8)` lets the scheduler
-/// pack per-class inflight counts into a single `AtomicU64`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+/// pack per-class inflight counts into a single `AtomicU64`. Serde encoding is
+/// lowercase so YAML files use `system`/`interactive`/`default`/`bulk`.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
+)]
+#[serde(rename_all = "lowercase")]
 #[repr(u8)]
 pub enum Class {
     /// Background / batch jobs. Lowest priority; preemptible by everyone else.

--- a/model_gateway/src/middleware/scheduler/class.rs
+++ b/model_gateway/src/middleware/scheduler/class.rs
@@ -37,12 +37,19 @@ impl Class {
     /// Parse a header value into a class. Case-insensitive, whitespace-tolerant.
     /// Unknown values (including the empty string) map to [`Class::Default`]
     /// — admission shouldn't fail because of a typo in a non-essential header.
+    ///
+    /// Avoids allocating: `eq_ignore_ascii_case` does the comparison in place
+    /// rather than building a lowercased `String` on every request.
     pub fn parse_header(value: &str) -> Class {
-        match value.trim().to_ascii_lowercase().as_str() {
-            "system" => Self::System,
-            "interactive" => Self::Interactive,
-            "bulk" => Self::Bulk,
-            _ => Self::Default,
+        let trimmed = value.trim();
+        if trimmed.eq_ignore_ascii_case("system") {
+            Self::System
+        } else if trimmed.eq_ignore_ascii_case("interactive") {
+            Self::Interactive
+        } else if trimmed.eq_ignore_ascii_case("bulk") {
+            Self::Bulk
+        } else {
+            Self::Default
         }
     }
 

--- a/model_gateway/src/middleware/scheduler/class.rs
+++ b/model_gateway/src/middleware/scheduler/class.rs
@@ -1,0 +1,132 @@
+//! Priority class + `X-SMG-Priority` header parser.
+
+/// HTTP request header that conveys the desired priority class.
+///
+/// Case-insensitive; unknown values degrade to [`Class::Default`].
+pub const PRIORITY_HEADER: &str = "x-smg-priority";
+
+/// Service class assigned to an inbound request.
+///
+/// Numeric values are load-bearing: `Ord` is derived so the tenant clamp is
+/// `std::cmp::min(header_class, max_class)`, and `repr(u8)` lets the scheduler
+/// pack per-class inflight counts into a single `AtomicU64`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(u8)]
+pub enum Class {
+    /// Background / batch jobs. Lowest priority; preemptible by everyone else.
+    Bulk = 0,
+    /// Unlabeled traffic. Middle of the road; what every request gets when no
+    /// header is set.
+    Default = 1,
+    /// Latency-sensitive traffic (chat completions, autocomplete).
+    Interactive = 2,
+    /// Internal control-plane traffic. Highest priority; never preempted by
+    /// external clients (the tenant clamp prevents any external tenant from
+    /// landing here in practice).
+    System = 3,
+}
+
+impl Class {
+    /// All four variants in ascending priority order.
+    pub const ALL: [Class; 4] = [Self::Bulk, Self::Default, Self::Interactive, Self::System];
+
+    /// Parse a header value into a class. Case-insensitive, whitespace-tolerant.
+    /// Unknown values (including the empty string) map to [`Class::Default`]
+    /// — admission shouldn't fail because of a typo in a non-essential header.
+    pub fn parse_header(value: &str) -> Class {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "system" => Self::System,
+            "interactive" => Self::Interactive,
+            "bulk" => Self::Bulk,
+            _ => Self::Default,
+        }
+    }
+
+    /// Lowercase variant name. Used as a metrics label and structured-log field
+    /// only; never serialized back over the wire.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Bulk => "bulk",
+            Self::Default => "default",
+            Self::Interactive => "interactive",
+            Self::System => "system",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_header_known_values() {
+        assert_eq!(Class::parse_header("system"), Class::System);
+        assert_eq!(Class::parse_header("interactive"), Class::Interactive);
+        assert_eq!(Class::parse_header("default"), Class::Default);
+        assert_eq!(Class::parse_header("bulk"), Class::Bulk);
+    }
+
+    #[test]
+    fn test_parse_header_is_case_insensitive() {
+        assert_eq!(Class::parse_header("Bulk"), Class::Bulk);
+        assert_eq!(Class::parse_header("INTERACTIVE"), Class::Interactive);
+        assert_eq!(Class::parse_header("SyStEm"), Class::System);
+    }
+
+    #[test]
+    fn test_parse_header_unknown_defaults_to_default() {
+        assert_eq!(Class::parse_header("urgent"), Class::Default);
+        assert_eq!(Class::parse_header(""), Class::Default);
+        assert_eq!(Class::parse_header("123"), Class::Default);
+    }
+
+    #[test]
+    fn test_parse_header_tolerates_whitespace() {
+        assert_eq!(Class::parse_header("  bulk  "), Class::Bulk);
+        assert_eq!(Class::parse_header("\tinteractive\n"), Class::Interactive);
+    }
+
+    #[test]
+    fn test_ord_min_implements_tenant_clamp() {
+        // Tenant clamp = min(header_class, max_class).
+        assert_eq!(
+            std::cmp::min(Class::Interactive, Class::Default),
+            Class::Default
+        );
+        assert_eq!(
+            std::cmp::min(Class::System, Class::Interactive),
+            Class::Interactive
+        );
+        assert_eq!(std::cmp::min(Class::Bulk, Class::System), Class::Bulk);
+    }
+
+    #[test]
+    fn test_all_is_ascending() {
+        assert_eq!(
+            Class::ALL,
+            [
+                Class::Bulk,
+                Class::Default,
+                Class::Interactive,
+                Class::System
+            ]
+        );
+        // Ord order matches numeric order.
+        assert!(Class::Bulk < Class::Default);
+        assert!(Class::Default < Class::Interactive);
+        assert!(Class::Interactive < Class::System);
+    }
+
+    #[test]
+    fn test_as_str_returns_lowercase_variant_name() {
+        assert_eq!(Class::Bulk.as_str(), "bulk");
+        assert_eq!(Class::Default.as_str(), "default");
+        assert_eq!(Class::Interactive.as_str(), "interactive");
+        assert_eq!(Class::System.as_str(), "system");
+    }
+
+    #[test]
+    fn test_priority_header_constant() {
+        assert_eq!(PRIORITY_HEADER, "x-smg-priority");
+    }
+}

--- a/model_gateway/src/middleware/scheduler/config.rs
+++ b/model_gateway/src/middleware/scheduler/config.rs
@@ -5,6 +5,7 @@ use std::{collections::HashMap, time::Duration};
 use serde::{Deserialize, Serialize};
 
 use super::Class;
+use crate::tenant::TenantKey;
 
 /// Per-class configuration as it appears in the optional YAML file.
 ///
@@ -117,14 +118,121 @@ pub struct TenantPolicyConfig {
 ///
 /// Both maps are absent-as-empty: an empty document parses to
 /// `PrioritySchedulerYaml::default()`, and downstream
-/// [`super::SchedulerSettings::from_cli_and_yaml`] fills in built-in
-/// defaults for any class that wasn't overridden.
+/// [`SchedulerSettings::from_cli_and_yaml`] fills in built-in defaults
+/// for any class that wasn't overridden.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct PrioritySchedulerYaml {
     #[serde(default)]
     pub classes: HashMap<Class, ClassConfig>,
     #[serde(default)]
     pub tenant_policies: HashMap<String, TenantPolicyConfig>,
+}
+
+/// Per-field validation failures discovered while assembling
+/// [`SchedulerSettings`]. Capacity-vs-reserved validation lives later
+/// (the scheduler doesn't know the backend capacity until
+/// [`super::scheduler::PriorityScheduler::new`] receives it).
+#[derive(Debug, thiserror::Error, PartialEq)]
+pub enum SettingsValidationError {
+    #[error("class {class:?}: queue_size_per_slot must be >= 0.0")]
+    NegativeMultiplier { class: Class },
+    #[error("class {class:?}: queue_timeout_secs must be > 0")]
+    ZeroQueueTimeout { class: Class },
+    #[error("class {class:?}: starvation_threshold_secs must be > 0")]
+    ZeroStarvationThreshold { class: Class },
+}
+
+/// Runtime scheduler configuration assembled from CLI flags + the
+/// optional YAML file + built-in defaults. Built once at startup and
+/// then read-only.
+///
+/// Capacity is *not* stored here — it lives on
+/// [`super::scheduler::PriorityScheduler`] as a live `AtomicU16` fed by
+/// [`crate::worker::WorkerCapacity`] (PR 1). The scheduler reacts to
+/// capacity changes via the watch channel; settings stay fixed.
+#[derive(Debug, Clone)]
+pub struct SchedulerSettings {
+    /// Master switch. When `false`, the legacy `concurrency_limit_middleware`
+    /// stays wired in `server.rs` and none of the scheduler types are
+    /// constructed.
+    pub enabled: bool,
+    /// Tenant policy applied when a tenant is not in `tenant_policies`.
+    pub default_max_class: Class,
+    /// Per-class config, indexed by `class as usize`. Always populated
+    /// for all four classes — YAML overrides land on top of
+    /// [`ClassConfig::default_for`].
+    classes: [ClassConfig; 4],
+    /// Per-tenant clamp lookup. Keys come from
+    /// [`crate::tenant::RouteRequestMeta::tenant_key`].
+    pub tenant_policies: HashMap<TenantKey, TenantPolicyConfig>,
+    /// Cap on the number of tenants emitted as labels for
+    /// `scheduler_tenant_*` gauges. Everything past the cap is
+    /// bucketed under `tenant="other"`.
+    pub tenant_metric_top_n: u32,
+}
+
+impl SchedulerSettings {
+    /// Indexed accessor for the per-class config.
+    pub fn class_config(&self, class: Class) -> &ClassConfig {
+        &self.classes[class as usize]
+    }
+
+    /// Assemble settings from CLI flags + optional YAML, validating
+    /// per-field invariants. Capacity-vs-reserved validation is the
+    /// scheduler's job at construction time.
+    ///
+    /// Merge order: built-in defaults → YAML overrides per class. CLI
+    /// flags supply the top-level fields (`enabled`, `default_max_class`,
+    /// `tenant_metric_top_n`) since they aren't representable in the YAML.
+    pub fn from_cli_and_yaml(
+        enabled: bool,
+        default_max_class: Class,
+        tenant_metric_top_n: u32,
+        yaml: Option<&PrioritySchedulerYaml>,
+    ) -> Result<Self, SettingsValidationError> {
+        let mut classes: [ClassConfig; 4] = [
+            ClassConfig::default_for(Class::Bulk),
+            ClassConfig::default_for(Class::Default),
+            ClassConfig::default_for(Class::Interactive),
+            ClassConfig::default_for(Class::System),
+        ];
+
+        if let Some(yaml) = yaml {
+            for (class, override_cfg) in &yaml.classes {
+                classes[*class as usize] = *override_cfg;
+            }
+        }
+
+        for class in Class::ALL {
+            let cfg = &classes[class as usize];
+            if cfg.queue_size_per_slot < 0.0 {
+                return Err(SettingsValidationError::NegativeMultiplier { class });
+            }
+            if cfg.queue_timeout_secs == 0 {
+                return Err(SettingsValidationError::ZeroQueueTimeout { class });
+            }
+            if cfg.starvation_threshold_secs == 0 {
+                return Err(SettingsValidationError::ZeroStarvationThreshold { class });
+            }
+        }
+
+        let tenant_policies = yaml
+            .map(|y| {
+                y.tenant_policies
+                    .iter()
+                    .map(|(k, v)| (TenantKey::new(k), *v))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        Ok(Self {
+            enabled,
+            default_max_class,
+            classes,
+            tenant_policies,
+            tenant_metric_top_n,
+        })
+    }
 }
 
 #[cfg(test)]
@@ -273,5 +381,117 @@ tenant_policies:
             rendered.contains("bulk:"),
             "class key should serialize as lowercase: {rendered}"
         );
+    }
+
+    // ── SchedulerSettings::from_cli_and_yaml ─────────────────────────
+
+    use crate::tenant::TenantKey;
+
+    #[test]
+    fn test_settings_no_yaml_uses_builtin_defaults() {
+        let s = SchedulerSettings::from_cli_and_yaml(false, Class::Default, 32, None).unwrap();
+        assert!(!s.enabled);
+        assert_eq!(s.default_max_class, Class::Default);
+        assert_eq!(s.tenant_metric_top_n, 32);
+        for class in Class::ALL {
+            assert_eq!(s.class_config(class), &ClassConfig::default_for(class));
+        }
+        assert!(s.tenant_policies.is_empty());
+    }
+
+    #[test]
+    fn test_settings_yaml_partial_override_merges_with_defaults() {
+        let mut classes = HashMap::new();
+        let mut interactive = ClassConfig::default_for(Class::Interactive);
+        interactive.reserved = 64;
+        classes.insert(Class::Interactive, interactive);
+        let yaml = PrioritySchedulerYaml {
+            classes,
+            tenant_policies: Default::default(),
+        };
+        let s =
+            SchedulerSettings::from_cli_and_yaml(true, Class::Default, 32, Some(&yaml)).unwrap();
+        assert_eq!(s.class_config(Class::Interactive).reserved, 64);
+        // Bulk untouched — still equal to built-in default.
+        assert_eq!(
+            s.class_config(Class::Bulk),
+            &ClassConfig::default_for(Class::Bulk)
+        );
+    }
+
+    #[test]
+    fn test_settings_yaml_tenant_policy_propagates() {
+        let mut tenant_policies = HashMap::new();
+        tenant_policies.insert(
+            "auth:acme".to_string(),
+            TenantPolicyConfig {
+                max_class: Class::Interactive,
+            },
+        );
+        let yaml = PrioritySchedulerYaml {
+            classes: Default::default(),
+            tenant_policies,
+        };
+        let s =
+            SchedulerSettings::from_cli_and_yaml(true, Class::Default, 32, Some(&yaml)).unwrap();
+        assert_eq!(s.tenant_policies.len(), 1);
+        let key = TenantKey::new("auth:acme");
+        assert_eq!(s.tenant_policies[&key].max_class, Class::Interactive);
+    }
+
+    #[test]
+    fn test_settings_rejects_negative_multiplier() {
+        let mut classes = HashMap::new();
+        let mut interactive = ClassConfig::default_for(Class::Interactive);
+        interactive.queue_size_per_slot = -1.0;
+        classes.insert(Class::Interactive, interactive);
+        let yaml = PrioritySchedulerYaml {
+            classes,
+            tenant_policies: Default::default(),
+        };
+        let err = SchedulerSettings::from_cli_and_yaml(true, Class::Default, 32, Some(&yaml))
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            SettingsValidationError::NegativeMultiplier {
+                class: Class::Interactive
+            }
+        ));
+    }
+
+    #[test]
+    fn test_settings_rejects_zero_queue_timeout() {
+        let mut classes = HashMap::new();
+        let mut bulk = ClassConfig::default_for(Class::Bulk);
+        bulk.queue_timeout_secs = 0;
+        classes.insert(Class::Bulk, bulk);
+        let yaml = PrioritySchedulerYaml {
+            classes,
+            tenant_policies: Default::default(),
+        };
+        let err = SchedulerSettings::from_cli_and_yaml(true, Class::Default, 32, Some(&yaml))
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            SettingsValidationError::ZeroQueueTimeout { class: Class::Bulk }
+        ));
+    }
+
+    #[test]
+    fn test_settings_rejects_zero_starvation_threshold() {
+        let mut classes = HashMap::new();
+        let mut bulk = ClassConfig::default_for(Class::Bulk);
+        bulk.starvation_threshold_secs = 0;
+        classes.insert(Class::Bulk, bulk);
+        let yaml = PrioritySchedulerYaml {
+            classes,
+            tenant_policies: Default::default(),
+        };
+        let err = SchedulerSettings::from_cli_and_yaml(true, Class::Default, 32, Some(&yaml))
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            SettingsValidationError::ZeroStarvationThreshold { class: Class::Bulk }
+        ));
     }
 }

--- a/model_gateway/src/middleware/scheduler/config.rs
+++ b/model_gateway/src/middleware/scheduler/config.rs
@@ -41,9 +41,8 @@ pub struct ClassConfig {
 }
 
 impl ClassConfig {
-    /// Built-in defaults per `02-priority-scheduler-design.md` §3.
-    /// These are what every class gets when no YAML file supplies an
-    /// override.
+    /// Built-in defaults. These are what every class gets when no YAML
+    /// file supplies an override.
     pub fn default_for(class: Class) -> Self {
         match class {
             Class::System => Self {
@@ -129,9 +128,9 @@ pub struct PrioritySchedulerYaml {
 }
 
 /// Per-field validation failures discovered while assembling
-/// [`SchedulerSettings`]. Capacity-vs-reserved validation lives later
-/// (the scheduler doesn't know the backend capacity until
-/// [`super::scheduler::PriorityScheduler::new`] receives it).
+/// [`SchedulerSettings`]. Capacity-vs-reserved validation is not in
+/// scope here — the scheduler performs it at construction time, once
+/// the live backend capacity is known.
 #[derive(Debug, thiserror::Error, PartialEq)]
 pub enum SettingsValidationError {
     #[error("class {class:?}: queue_size_per_slot must be >= 0.0")]
@@ -146,15 +145,14 @@ pub enum SettingsValidationError {
 /// optional YAML file + built-in defaults. Built once at startup and
 /// then read-only.
 ///
-/// Capacity is *not* stored here — it lives on
-/// [`super::scheduler::PriorityScheduler`] as a live `AtomicU16` fed by
-/// [`crate::worker::WorkerCapacity`] (PR 1). The scheduler reacts to
-/// capacity changes via the watch channel; settings stay fixed.
+/// Capacity is not stored here; the scheduler reads it live from
+/// [`crate::worker::WorkerCapacity`] and reacts to changes via its
+/// watch channel. Settings stay fixed.
 #[derive(Debug, Clone)]
 pub struct SchedulerSettings {
-    /// Master switch. When `false`, the legacy `concurrency_limit_middleware`
-    /// stays wired in `server.rs` and none of the scheduler types are
-    /// constructed.
+    /// Master switch. When `false`, the priority scheduler is not
+    /// constructed and the gateway falls back to its legacy
+    /// concurrency-limit admission path.
     pub enabled: bool,
     /// Tenant policy applied when a tenant is not in `tenant_policies`.
     pub default_max_class: Class,

--- a/model_gateway/src/middleware/scheduler/config.rs
+++ b/model_gateway/src/middleware/scheduler/config.rs
@@ -1,6 +1,8 @@
 //! Scheduler config: on-disk YAML shape + runtime form.
 
-use std::time::Duration;
+use std::{collections::HashMap, time::Duration};
+
+use serde::{Deserialize, Serialize};
 
 use super::Class;
 
@@ -10,7 +12,7 @@ use super::Class;
 /// uses primitive types friendly to serde and human editing, while the
 /// runtime form pre-converts seconds into [`Duration`] so hot paths
 /// don't repeat the conversion.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct ClassConfig {
     /// Slots reserved for this class. Higher-class reservations are
     /// honored by lower-class admissions via the packed-CAS slot
@@ -101,6 +103,30 @@ impl ClassRuntimeConfig {
     }
 }
 
+/// Per-tenant policy entry in the YAML file.
+///
+/// Future fields (`weight`, `slot_quota`, `rps_cap`) are additive: adding
+/// them is non-breaking because the trait
+/// [`super::policy::TenantPolicyResolver`] returns the whole struct.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct TenantPolicyConfig {
+    pub max_class: Class,
+}
+
+/// Optional YAML config loaded via `--priority-scheduler-config <path>`.
+///
+/// Both maps are absent-as-empty: an empty document parses to
+/// `PrioritySchedulerYaml::default()`, and downstream
+/// [`super::SchedulerSettings::from_cli_and_yaml`] fills in built-in
+/// defaults for any class that wasn't overridden.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct PrioritySchedulerYaml {
+    #[serde(default)]
+    pub classes: HashMap<Class, ClassConfig>,
+    #[serde(default)]
+    pub tenant_policies: HashMap<String, TenantPolicyConfig>,
+}
+
 #[cfg(test)]
 mod tests {
     use std::time::Duration;
@@ -168,5 +194,84 @@ mod tests {
         assert!(interactive.can_preempt);
         let bulk = ClassRuntimeConfig::from_class_config(&ClassConfig::default_for(Class::Bulk));
         assert!(!bulk.can_preempt);
+    }
+
+    // ── PrioritySchedulerYaml serde ───────────────────────────────────
+
+    #[test]
+    fn test_yaml_empty_document_yields_default() {
+        let parsed: PrioritySchedulerYaml = serde_yaml::from_str("").unwrap();
+        assert!(parsed.classes.is_empty());
+        assert!(parsed.tenant_policies.is_empty());
+    }
+
+    #[test]
+    fn test_yaml_partial_class_override_round_trips() {
+        let yaml = r"
+classes:
+  interactive:
+    reserved: 200
+    queue_size: 256
+    queue_size_per_slot: 0.25
+    queue_timeout_secs: 30
+    starvation_threshold_secs: 5
+    can_preempt: true
+";
+        let parsed: PrioritySchedulerYaml = serde_yaml::from_str(yaml).unwrap();
+        let interactive = parsed
+            .classes
+            .get(&Class::Interactive)
+            .expect("interactive present");
+        assert_eq!(interactive.reserved, 200);
+        // Only one class entry — others are absent (settings layer fills defaults).
+        assert_eq!(parsed.classes.len(), 1);
+        assert!(parsed.tenant_policies.is_empty());
+    }
+
+    #[test]
+    fn test_yaml_tenant_policy_round_trips() {
+        let yaml = r#"
+tenant_policies:
+  "auth:acme":
+    max_class: interactive
+  "auth:internal-cron":
+    max_class: system
+"#;
+        let parsed: PrioritySchedulerYaml = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(parsed.tenant_policies.len(), 2);
+        assert_eq!(
+            parsed.tenant_policies["auth:acme"].max_class,
+            Class::Interactive
+        );
+        assert_eq!(
+            parsed.tenant_policies["auth:internal-cron"].max_class,
+            Class::System
+        );
+    }
+
+    #[test]
+    fn test_yaml_unknown_class_value_is_serde_error() {
+        let yaml = r#"
+tenant_policies:
+  "auth:acme":
+    max_class: garbage
+"#;
+        let result: Result<PrioritySchedulerYaml, _> = serde_yaml::from_str(yaml);
+        assert!(result.is_err(), "expected serde error for unknown class");
+    }
+
+    #[test]
+    fn test_yaml_class_name_serializes_as_lowercase() {
+        let mut classes = HashMap::new();
+        classes.insert(Class::Bulk, ClassConfig::default_for(Class::Bulk));
+        let yaml = PrioritySchedulerYaml {
+            classes,
+            tenant_policies: Default::default(),
+        };
+        let rendered = serde_yaml::to_string(&yaml).unwrap();
+        assert!(
+            rendered.contains("bulk:"),
+            "class key should serialize as lowercase: {rendered}"
+        );
     }
 }

--- a/model_gateway/src/middleware/scheduler/config.rs
+++ b/model_gateway/src/middleware/scheduler/config.rs
@@ -1,0 +1,172 @@
+//! Scheduler config: on-disk YAML shape + runtime form.
+
+use std::time::Duration;
+
+use super::Class;
+
+/// Per-class configuration as it appears in the optional YAML file.
+///
+/// Lives separately from [`ClassRuntimeConfig`] because the YAML form
+/// uses primitive types friendly to serde and human editing, while the
+/// runtime form pre-converts seconds into [`Duration`] so hot paths
+/// don't repeat the conversion.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ClassConfig {
+    /// Slots reserved for this class. Higher-class reservations are
+    /// honored by lower-class admissions via the packed-CAS slot
+    /// accounting in [`super::scheduler`].
+    pub reserved: u16,
+    /// Absolute floor on the per-class queue depth.
+    pub queue_size: u32,
+    /// Optional multiplier: effective limit =
+    /// `max(queue_size, ceil(queue_size_per_slot * capacity))`.
+    /// `0.0` disables the multiplier (use the absolute floor only).
+    pub queue_size_per_slot: f32,
+    /// How long a queued waiter waits before the admission middleware
+    /// returns 408. Seconds at rest; converted to [`Duration`] in
+    /// [`ClassRuntimeConfig`].
+    pub queue_timeout_secs: u64,
+    /// Head-of-queue age past which the dispatcher promotes a waiter
+    /// out of normal priority order to avoid starvation. Seconds at
+    /// rest; converted to [`Duration`] in [`ClassRuntimeConfig`].
+    pub starvation_threshold_secs: u64,
+    /// Whether admissions in this class are allowed to preempt a
+    /// lower-class inflight request that has not yet emitted its first
+    /// byte. Higher classes default to `true`; lower classes default
+    /// to `false`.
+    pub can_preempt: bool,
+}
+
+impl ClassConfig {
+    /// Built-in defaults per `02-priority-scheduler-design.md` §3.
+    /// These are what every class gets when no YAML file supplies an
+    /// override.
+    pub fn default_for(class: Class) -> Self {
+        match class {
+            Class::System => Self {
+                reserved: 32,
+                queue_size: 64,
+                queue_size_per_slot: 0.0,
+                queue_timeout_secs: 30,
+                starvation_threshold_secs: 5,
+                can_preempt: true,
+            },
+            Class::Interactive => Self {
+                reserved: 128,
+                queue_size: 256,
+                queue_size_per_slot: 0.25,
+                queue_timeout_secs: 30,
+                starvation_threshold_secs: 5,
+                can_preempt: true,
+            },
+            Class::Default => Self {
+                reserved: 0,
+                queue_size: 512,
+                queue_size_per_slot: 0.5,
+                queue_timeout_secs: 60,
+                starvation_threshold_secs: 30,
+                can_preempt: false,
+            },
+            Class::Bulk => Self {
+                reserved: 0,
+                queue_size: 1024,
+                queue_size_per_slot: 1.0,
+                queue_timeout_secs: 300,
+                starvation_threshold_secs: 120,
+                can_preempt: false,
+            },
+        }
+    }
+}
+
+/// Runtime view of [`ClassConfig`] — only the fields the dispatcher
+/// reads on its hot path, with seconds pre-converted to [`Duration`].
+/// `reserved`, `queue_size`, and `queue_size_per_slot` live elsewhere
+/// (the packed-CAS array and the per-class queue impl), so they don't
+/// appear here.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ClassRuntimeConfig {
+    pub queue_timeout: Duration,
+    pub starvation_threshold: Duration,
+    pub can_preempt: bool,
+}
+
+impl ClassRuntimeConfig {
+    pub fn from_class_config(cfg: &ClassConfig) -> Self {
+        Self {
+            queue_timeout: Duration::from_secs(cfg.queue_timeout_secs),
+            starvation_threshold: Duration::from_secs(cfg.starvation_threshold_secs),
+            can_preempt: cfg.can_preempt,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+    use crate::middleware::scheduler::Class;
+
+    #[test]
+    fn test_default_for_system() {
+        let cfg = ClassConfig::default_for(Class::System);
+        assert_eq!(cfg.reserved, 32);
+        assert_eq!(cfg.queue_size, 64);
+        assert_eq!(cfg.queue_size_per_slot, 0.0);
+        assert_eq!(cfg.queue_timeout_secs, 30);
+        assert_eq!(cfg.starvation_threshold_secs, 5);
+        assert!(cfg.can_preempt);
+    }
+
+    #[test]
+    fn test_default_for_interactive() {
+        let cfg = ClassConfig::default_for(Class::Interactive);
+        assert_eq!(cfg.reserved, 128);
+        assert_eq!(cfg.queue_size, 256);
+        assert_eq!(cfg.queue_size_per_slot, 0.25);
+        assert_eq!(cfg.queue_timeout_secs, 30);
+        assert_eq!(cfg.starvation_threshold_secs, 5);
+        assert!(cfg.can_preempt);
+    }
+
+    #[test]
+    fn test_default_for_default() {
+        let cfg = ClassConfig::default_for(Class::Default);
+        assert_eq!(cfg.reserved, 0);
+        assert_eq!(cfg.queue_size, 512);
+        assert_eq!(cfg.queue_size_per_slot, 0.5);
+        assert_eq!(cfg.queue_timeout_secs, 60);
+        assert_eq!(cfg.starvation_threshold_secs, 30);
+        assert!(!cfg.can_preempt);
+    }
+
+    #[test]
+    fn test_default_for_bulk() {
+        let cfg = ClassConfig::default_for(Class::Bulk);
+        assert_eq!(cfg.reserved, 0);
+        assert_eq!(cfg.queue_size, 1024);
+        assert_eq!(cfg.queue_size_per_slot, 1.0);
+        assert_eq!(cfg.queue_timeout_secs, 300);
+        assert_eq!(cfg.starvation_threshold_secs, 120);
+        assert!(!cfg.can_preempt);
+    }
+
+    #[test]
+    fn test_runtime_config_converts_seconds_to_duration() {
+        let cfg = ClassConfig::default_for(Class::Default);
+        let runtime = ClassRuntimeConfig::from_class_config(&cfg);
+        assert_eq!(runtime.queue_timeout, Duration::from_secs(60));
+        assert_eq!(runtime.starvation_threshold, Duration::from_secs(30));
+        assert!(!runtime.can_preempt);
+    }
+
+    #[test]
+    fn test_runtime_config_preserves_can_preempt_flag() {
+        let interactive =
+            ClassRuntimeConfig::from_class_config(&ClassConfig::default_for(Class::Interactive));
+        assert!(interactive.can_preempt);
+        let bulk = ClassRuntimeConfig::from_class_config(&ClassConfig::default_for(Class::Bulk));
+        assert!(!bulk.can_preempt);
+    }
+}

--- a/model_gateway/src/middleware/scheduler/config.rs
+++ b/model_gateway/src/middleware/scheduler/config.rs
@@ -133,8 +133,8 @@ pub struct PrioritySchedulerYaml {
 /// the live backend capacity is known.
 #[derive(Debug, thiserror::Error, PartialEq)]
 pub enum SettingsValidationError {
-    #[error("class {class:?}: queue_size_per_slot must be >= 0.0")]
-    NegativeMultiplier { class: Class },
+    #[error("class {class:?}: queue_size_per_slot must be a finite, non-negative number")]
+    InvalidMultiplier { class: Class },
     #[error("class {class:?}: queue_timeout_secs must be > 0")]
     ZeroQueueTimeout { class: Class },
     #[error("class {class:?}: starvation_threshold_secs must be > 0")]
@@ -203,8 +203,8 @@ impl SchedulerSettings {
 
         for class in Class::ALL {
             let cfg = &classes[class as usize];
-            if cfg.queue_size_per_slot < 0.0 {
-                return Err(SettingsValidationError::NegativeMultiplier { class });
+            if !cfg.queue_size_per_slot.is_finite() || cfg.queue_size_per_slot < 0.0 {
+                return Err(SettingsValidationError::InvalidMultiplier { class });
             }
             if cfg.queue_timeout_secs == 0 {
                 return Err(SettingsValidationError::ZeroQueueTimeout { class });
@@ -451,7 +451,7 @@ tenant_policies:
             .unwrap_err();
         assert!(matches!(
             err,
-            SettingsValidationError::NegativeMultiplier {
+            SettingsValidationError::InvalidMultiplier {
                 class: Class::Interactive
             }
         ));
@@ -472,6 +472,67 @@ tenant_policies:
         assert!(matches!(
             err,
             SettingsValidationError::ZeroQueueTimeout { class: Class::Bulk }
+        ));
+    }
+
+    #[test]
+    fn test_settings_rejects_nan_multiplier_from_yaml() {
+        // serde_yaml parses `.nan` into f32::NAN. Without an explicit
+        // is_finite() check, the comparison `< 0.0` is false for NaN and the
+        // bad value slips through to garbage queue-limit math later.
+        let yaml = r"
+classes:
+  interactive:
+    reserved: 128
+    queue_size: 256
+    queue_size_per_slot: .nan
+    queue_timeout_secs: 30
+    starvation_threshold_secs: 5
+    can_preempt: true
+";
+        let parsed: PrioritySchedulerYaml = serde_yaml::from_str(yaml).unwrap();
+        assert!(
+            parsed.classes[&Class::Interactive]
+                .queue_size_per_slot
+                .is_nan(),
+            "serde_yaml deserialized .nan as NaN"
+        );
+        let err = SchedulerSettings::from_cli_and_yaml(true, Class::Default, 32, Some(&parsed))
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            SettingsValidationError::InvalidMultiplier {
+                class: Class::Interactive
+            }
+        ));
+    }
+
+    #[test]
+    fn test_settings_rejects_infinity_multiplier_from_yaml() {
+        let yaml = r"
+classes:
+  interactive:
+    reserved: 128
+    queue_size: 256
+    queue_size_per_slot: .inf
+    queue_timeout_secs: 30
+    starvation_threshold_secs: 5
+    can_preempt: true
+";
+        let parsed: PrioritySchedulerYaml = serde_yaml::from_str(yaml).unwrap();
+        assert!(
+            parsed.classes[&Class::Interactive]
+                .queue_size_per_slot
+                .is_infinite(),
+            "serde_yaml deserialized .inf as +Infinity"
+        );
+        let err = SchedulerSettings::from_cli_and_yaml(true, Class::Default, 32, Some(&parsed))
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            SettingsValidationError::InvalidMultiplier {
+                class: Class::Interactive
+            }
         ));
     }
 

--- a/model_gateway/src/middleware/scheduler/mod.rs
+++ b/model_gateway/src/middleware/scheduler/mod.rs
@@ -1,8 +1,4 @@
 //! Priority-aware admission scheduler.
-//!
-//! See `.claude/docs/scheduler/02-priority-scheduler-design.md` for the
-//! full design rationale and `02-priority-scheduler-plan.md` for the
-//! implementation sequencing.
 
 pub mod class;
 pub mod config;

--- a/model_gateway/src/middleware/scheduler/mod.rs
+++ b/model_gateway/src/middleware/scheduler/mod.rs
@@ -8,4 +8,7 @@ pub mod class;
 pub mod config;
 
 pub use class::{Class, PRIORITY_HEADER};
-pub use config::{ClassConfig, ClassRuntimeConfig, PrioritySchedulerYaml, TenantPolicyConfig};
+pub use config::{
+    ClassConfig, ClassRuntimeConfig, PrioritySchedulerYaml, SchedulerSettings,
+    SettingsValidationError, TenantPolicyConfig,
+};

--- a/model_gateway/src/middleware/scheduler/mod.rs
+++ b/model_gateway/src/middleware/scheduler/mod.rs
@@ -8,4 +8,4 @@ pub mod class;
 pub mod config;
 
 pub use class::{Class, PRIORITY_HEADER};
-pub use config::{ClassConfig, ClassRuntimeConfig};
+pub use config::{ClassConfig, ClassRuntimeConfig, PrioritySchedulerYaml, TenantPolicyConfig};

--- a/model_gateway/src/middleware/scheduler/mod.rs
+++ b/model_gateway/src/middleware/scheduler/mod.rs
@@ -6,9 +6,11 @@
 
 pub mod class;
 pub mod config;
+pub mod policy;
 
 pub use class::{Class, PRIORITY_HEADER};
 pub use config::{
     ClassConfig, ClassRuntimeConfig, PrioritySchedulerYaml, SchedulerSettings,
     SettingsValidationError, TenantPolicyConfig,
 };
+pub use policy::{StaticTenantPolicyResolver, TenantPolicy, TenantPolicyResolver};

--- a/model_gateway/src/middleware/scheduler/mod.rs
+++ b/model_gateway/src/middleware/scheduler/mod.rs
@@ -5,5 +5,7 @@
 //! implementation sequencing.
 
 pub mod class;
+pub mod config;
 
 pub use class::{Class, PRIORITY_HEADER};
+pub use config::{ClassConfig, ClassRuntimeConfig};

--- a/model_gateway/src/middleware/scheduler/mod.rs
+++ b/model_gateway/src/middleware/scheduler/mod.rs
@@ -1,0 +1,9 @@
+//! Priority-aware admission scheduler.
+//!
+//! See `.claude/docs/scheduler/02-priority-scheduler-design.md` for the
+//! full design rationale and `02-priority-scheduler-plan.md` for the
+//! implementation sequencing.
+
+pub mod class;
+
+pub use class::{Class, PRIORITY_HEADER};

--- a/model_gateway/src/middleware/scheduler/policy.rs
+++ b/model_gateway/src/middleware/scheduler/policy.rs
@@ -16,17 +16,17 @@ pub struct TenantPolicy {
     pub max_class: Class,
 }
 
-/// Lookup interface used by the admission middleware. A future async
-/// store-backed impl can land via a sync cache wrapper without changing
-/// the call site.
+/// Tenant policy lookup. Returns the [`TenantPolicy`] for a tenant,
+/// with a default fallback for unknown keys. Trait-shaped so an async
+/// store-backed implementation can swap in behind a sync cache without
+/// changing call sites.
 pub trait TenantPolicyResolver: Send + Sync {
     fn policy(&self, tenant: &TenantKey) -> TenantPolicy;
 }
 
-/// Static in-memory resolver — what gets used at v1.
-///
-/// Built once from [`SchedulerSettings`] at gateway startup; lookups are
-/// pure `HashMap::get` with a default-policy fallback.
+/// Static in-memory resolver: a `HashMap` of explicit per-tenant
+/// overrides plus a single default policy applied to every other tenant.
+/// Built once from [`SchedulerSettings`] at gateway startup.
 pub struct StaticTenantPolicyResolver {
     policies: HashMap<TenantKey, TenantPolicy>,
     default: TenantPolicy,

--- a/model_gateway/src/middleware/scheduler/policy.rs
+++ b/model_gateway/src/middleware/scheduler/policy.rs
@@ -1,0 +1,140 @@
+//! Tenant policy resolver: maps a `TenantKey` to a [`TenantPolicy`].
+//!
+//! Trait-shaped so a future store-backed implementation (with async lookup +
+//! sync cache) can land without touching the admission middleware.
+
+use std::{collections::HashMap, sync::Arc};
+
+use super::{Class, SchedulerSettings};
+use crate::tenant::TenantKey;
+
+/// Per-tenant policy. The single field today is [`max_class`]; future
+/// non-breaking additions: `weight: u32`, `slot_quota: Option<usize>`,
+/// `rps_cap: Option<u32>`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TenantPolicy {
+    pub max_class: Class,
+}
+
+/// Lookup interface used by the admission middleware. A future async
+/// store-backed impl can land via a sync cache wrapper without changing
+/// the call site.
+pub trait TenantPolicyResolver: Send + Sync {
+    fn policy(&self, tenant: &TenantKey) -> TenantPolicy;
+}
+
+/// Static in-memory resolver — what gets used at v1.
+///
+/// Built once from [`SchedulerSettings`] at gateway startup; lookups are
+/// pure `HashMap::get` with a default-policy fallback.
+pub struct StaticTenantPolicyResolver {
+    policies: HashMap<TenantKey, TenantPolicy>,
+    default: TenantPolicy,
+}
+
+impl StaticTenantPolicyResolver {
+    /// Build from the runtime settings. Reads `tenant_policies` and
+    /// `default_max_class`; never returns an error (validation happens
+    /// inside [`SchedulerSettings::from_cli_and_yaml`]).
+    pub fn from_settings(settings: &SchedulerSettings) -> Self {
+        let policies = settings
+            .tenant_policies
+            .iter()
+            .map(|(key, cfg)| {
+                (
+                    key.clone(),
+                    TenantPolicy {
+                        max_class: cfg.max_class,
+                    },
+                )
+            })
+            .collect();
+        Self {
+            policies,
+            default: TenantPolicy {
+                max_class: settings.default_max_class,
+            },
+        }
+    }
+
+    /// Test-only constructor used by call sites that don't want to build
+    /// a full [`SchedulerSettings`] just to exercise the resolver.
+    #[cfg(test)]
+    pub(crate) fn with_default(default_max_class: Class) -> Self {
+        Self {
+            policies: HashMap::new(),
+            default: TenantPolicy {
+                max_class: default_max_class,
+            },
+        }
+    }
+}
+
+impl TenantPolicyResolver for StaticTenantPolicyResolver {
+    fn policy(&self, tenant: &TenantKey) -> TenantPolicy {
+        self.policies.get(tenant).copied().unwrap_or(self.default)
+    }
+}
+
+impl TenantPolicyResolver for Arc<dyn TenantPolicyResolver> {
+    fn policy(&self, tenant: &TenantKey) -> TenantPolicy {
+        (**self).policy(tenant)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::middleware::scheduler::{PrioritySchedulerYaml, TenantPolicyConfig};
+
+    #[test]
+    fn test_empty_resolver_returns_default() {
+        let resolver = StaticTenantPolicyResolver::with_default(Class::Default);
+        let policy = resolver.policy(&TenantKey::new("anonymous"));
+        assert_eq!(policy.max_class, Class::Default);
+    }
+
+    #[test]
+    fn test_known_tenant_overrides_default() {
+        let mut tenant_policies = HashMap::new();
+        tenant_policies.insert(
+            "auth:acme".to_string(),
+            TenantPolicyConfig {
+                max_class: Class::Interactive,
+            },
+        );
+        let yaml = PrioritySchedulerYaml {
+            classes: Default::default(),
+            tenant_policies,
+        };
+        let settings =
+            SchedulerSettings::from_cli_and_yaml(true, Class::Default, 32, Some(&yaml)).unwrap();
+        let resolver = StaticTenantPolicyResolver::from_settings(&settings);
+
+        let known = resolver.policy(&TenantKey::new("auth:acme"));
+        assert_eq!(known.max_class, Class::Interactive);
+
+        // Unknown tenant still gets the default.
+        let unknown = resolver.policy(&TenantKey::new("anonymous"));
+        assert_eq!(unknown.max_class, Class::Default);
+    }
+
+    #[test]
+    fn test_resolver_trait_object_dispatches() {
+        let resolver: Arc<dyn TenantPolicyResolver> =
+            Arc::new(StaticTenantPolicyResolver::with_default(Class::Interactive));
+        // Dispatch through the &dyn TenantPolicyResolver impl on Arc.
+        let policy = resolver.policy(&TenantKey::new("anything"));
+        assert_eq!(policy.max_class, Class::Interactive);
+    }
+
+    #[test]
+    fn test_clamp_via_min_with_resolved_policy() {
+        // Demonstrate the admission-time clamp: effective = min(header, policy.max_class).
+        let resolver = StaticTenantPolicyResolver::with_default(Class::Default);
+        let header_class = Class::Interactive; // client asked for interactive
+        let policy = resolver.policy(&TenantKey::new("anonymous"));
+        let effective = std::cmp::min(header_class, policy.max_class);
+        assert_eq!(effective, Class::Default);
+    }
+}


### PR DESCRIPTION
## Description

### Problem

The model gateway has no notion of priority on inbound traffic. Today's `concurrency_limit_middleware` admits requests in FIFO order against a single global slot pool — interactive chat completions queue behind whatever bulk batch happened to arrive first.

The full design lives in [`.claude/docs/scheduler/02-priority-scheduler-design.md`](https://github.com/lightseekorg/smg/blob/main/.claude/docs/scheduler/02-priority-scheduler-design.md). Splitting the implementation into milestones lets each chunk land reviewably without flipping the master `--priority-scheduler-enabled` flag to `true` until everything is wired up.

### Solution

**This PR is Milestone 1 of 6** for PR 2 (priority scheduler). It introduces the vocabulary used by every later milestone: the `Class` enum, per-class config (YAML + runtime), tenant policy resolver. **No call sites yet** — these types are reachable from `crate::middleware::scheduler::*` but no production code path constructs them. Behavior on `main` is unchanged.

Subsequent milestones (each its own PR):
- M2 — scheduler core (slot accounting, queues, dispatcher, capacity-watch)
- M3 — preemption (TTFT CAS + body wrapper)
- M4 — CLI flags, `AppContext` wiring, `priority_admission_middleware`, cancel-token plumbing across handlers
- M5 — observability (metrics + tracing)
- M6 — integration tests + flip the master flag from "experimental" to "ready"

The implementation plan lives at [`.claude/docs/scheduler/02-priority-scheduler-plan.md`](https://github.com/lightseekorg/smg/blob/main/.claude/docs/scheduler/02-priority-scheduler-plan.md) (also in this PR's diff — it's a new file).

## Changes

Five commits, one per task in M1:

1. **`feat(scheduler): add Class enum + priority header parser`** — `Class { Bulk=0, Default=1, Interactive=2, System=3 }` with `Ord` derived (tenant clamp = `min(header, max)`) and `repr(u8)` (later packed into `AtomicU64`). `parse_header` is case-insensitive, whitespace-tolerant, lenient on unknown values. `PRIORITY_HEADER = "x-smg-priority"`.

2. **`feat(scheduler): add ClassConfig + ClassRuntimeConfig with defaults`** — `ClassConfig` is the YAML-shaped on-disk form (`u64` secs, `f32` multiplier); `ClassRuntimeConfig` is the runtime form (`Duration`). `default_for(Class)` returns the built-in per-class defaults from the design's §3 table.

3. **`feat(scheduler): PrioritySchedulerYaml serde schema`** — `PrioritySchedulerYaml { classes, tenant_policies }`, both `#[serde(default)]`. `Class` derives `Serialize`/`Deserialize` with `#[serde(rename_all = "lowercase")]`. Empty YAML round-trips to default.

4. **`feat(scheduler): SchedulerSettings::from_cli_and_yaml builder`** — Merges built-in defaults + optional YAML + CLI flags into a single read-only `SchedulerSettings`. Per-field validation (non-negative multiplier, positive timeouts). Capacity-vs-reserved check is deferred to `PriorityScheduler::new` (M2).

5. **`feat(scheduler): tenant policy resolver trait + static impl`** — `trait TenantPolicyResolver` (lets a future async store-backed impl swap in without touching the admission path) + `StaticTenantPolicyResolver` (HashMap with default fallback).

Plus: `.claude/docs/scheduler/02-priority-scheduler-plan.md` (the implementation plan for PR 2).

## Test Plan

Each commit follows TDD discipline: failing tests first, verify they fail with the expected error, then implement, verify pass, commit. 29 new unit tests cover:

- `Class::parse_header` over all four valid values, case-insensitivity, whitespace tolerance, unknown→Default, and the `Ord`-derived clamp semantics.
- `ClassConfig::default_for` matches the design §3 defaults table exactly for all four classes.
- `ClassRuntimeConfig::from_class_config` converts seconds to `Duration` and preserves `can_preempt`.
- `PrioritySchedulerYaml` serde round-trips: empty document, partial class override, tenant policy map, unknown-class serde error, lowercase serialization.
- `SchedulerSettings::from_cli_and_yaml`: defaults-only, partial YAML override merges with defaults, tenant policies propagate, validation rejects negative multiplier / zero queue timeout / zero starvation threshold.
- `StaticTenantPolicyResolver`: empty resolver returns default, known tenant overrides default, trait-object dispatch, admission clamp via `min(header, policy.max_class)`.

```bash
$ cargo test --package smg --lib middleware::scheduler
... 29 passed; 0 failed; 0 ignored; 0 measured; 902 filtered out
```

```bash
$ cargo clippy --package smg --all-targets --all-features -- -D warnings
... Finished `dev` profile [unoptimized + debuginfo] target(s)
```

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes (enforced by pre-commit hook)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] (Optional) Documentation updated — design + implementation plan in `.claude/docs/scheduler/`
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a priority-aware admission scheduler to enable request prioritization.
  * Introduced four priority classes — Bulk, Default, Interactive, System — and a standard request priority header (x-smg-priority).
  * Added configurable per-class settings with validation and runtime conversion.
  * Added tenant-level policy support and an in-memory tenant policy resolver for tenant-specific overrides.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightseekorg/smg/pull/1541?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->