### PR TITLE
feat(scheduler): admission data layer — inflight, queue, slots (PR 2 M2a)

### DIFF
--- a/model_gateway/src/middleware/scheduler/inflight.rs
+++ b/model_gateway/src/middleware/scheduler/inflight.rs
@@ -57,10 +57,13 @@ impl InflightHandle {
     /// admit. Returns `true` on the first successful CAS; subsequent calls
     /// (or any call after preemption was marked) return `false`.
     ///
-    /// `now_ms` is clamped to `u64::MAX - 1` so a TTFT measurement can
-    /// never collide with the preempt sentinel.
+    /// `now_ms` is clamped to `[1, PREEMPTED_SENTINEL - 1]`. The upper
+    /// bound avoids colliding with the preempt sentinel; the lower bound
+    /// avoids colliding with the "unset" state (`0`), which would let a
+    /// subsequent `try_mark_preempted` succeed even though TTFT has
+    /// already happened.
     pub fn try_mark_first_byte(&self, now_ms: u64) -> bool {
-        let value = now_ms.min(Self::PREEMPTED_SENTINEL - 1);
+        let value = now_ms.clamp(1, Self::PREEMPTED_SENTINEL - 1);
         self.first_byte_at
             .compare_exchange(0, value, Ordering::AcqRel, Ordering::Acquire)
             .is_ok()
@@ -158,5 +161,23 @@ mod tests {
     fn test_initial_state_is_zero() {
         let handle = InflightHandle::new();
         assert_eq!(handle.first_byte_at_raw(Ordering::Acquire), 0);
+    }
+
+    #[test]
+    fn test_ttft_at_zero_ms_does_not_collide_with_unset_sentinel() {
+        // Regression: now_ms == 0 (TTFT in the same millisecond as
+        // admission) must not write 0 into first_byte_at. If it did, a
+        // subsequent try_mark_preempted would see the "unset" sentinel
+        // and succeed, breaking mutual exclusion.
+        let handle = InflightHandle::new();
+        assert!(handle.try_mark_first_byte(0), "first call must succeed");
+        assert!(
+            handle.first_byte_at_raw(Ordering::Acquire) != 0,
+            "stored value must not collide with the unset sentinel"
+        );
+        assert!(
+            !handle.try_mark_preempted(),
+            "preempt must lose because TTFT already won"
+        );
     }
 }

--- a/model_gateway/src/middleware/scheduler/inflight.rs
+++ b/model_gateway/src/middleware/scheduler/inflight.rs
@@ -1,0 +1,162 @@
+//! In-flight request bookkeeping for the priority scheduler.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Tracks a single admitted request from admission until its response body
+/// finishes draining (or the scheduler preempts it).
+///
+/// The central race resolver is [`first_byte_at`]: it encodes three states
+/// in one `AtomicU64`, using a sentinel for "preempted" so that the
+/// admission side and the body-wrapping side can resolve their race with a
+/// single compare-and-swap each.
+///
+/// State encoding for `first_byte_at`:
+///
+/// | Value         | Meaning                                                   |
+/// |---------------|-----------------------------------------------------------|
+/// | `0`           | No first-byte emitted yet and not preempted (initial)     |
+/// | `u64::MAX`    | Scheduler preempted this request before TTFT (sentinel)   |
+/// | anything else | Millis-since-admit of the first response byte (TTFT)      |
+///
+/// `try_mark_first_byte` clamps `now_ms` to `u64::MAX - 1` so a TTFT
+/// measurement can never collide with the preempt sentinel.
+pub struct InflightHandle {
+    first_byte_at: AtomicU64,
+}
+
+impl InflightHandle {
+    /// Sentinel stored in `first_byte_at` once the scheduler has selected
+    /// this request for preemption.
+    const PREEMPTED_SENTINEL: u64 = u64::MAX;
+
+    pub fn new() -> Self {
+        Self {
+            first_byte_at: AtomicU64::new(0),
+        }
+    }
+
+    /// Attempt to mark this request as preempted. Returns `true` on the
+    /// first successful CAS; subsequent calls (or any call after TTFT was
+    /// marked) return `false`.
+    ///
+    /// The caller fires the cancellation token only after a `true` return,
+    /// so preemption never races with a response that already started
+    /// streaming bytes to the client.
+    pub fn try_mark_preempted(&self) -> bool {
+        self.first_byte_at
+            .compare_exchange(
+                0,
+                Self::PREEMPTED_SENTINEL,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_ok()
+    }
+
+    /// Attempt to mark the first response byte at `now_ms` millis-since-
+    /// admit. Returns `true` on the first successful CAS; subsequent calls
+    /// (or any call after preemption was marked) return `false`.
+    ///
+    /// `now_ms` is clamped to `u64::MAX - 1` so a TTFT measurement can
+    /// never collide with the preempt sentinel.
+    pub fn try_mark_first_byte(&self, now_ms: u64) -> bool {
+        let value = now_ms.min(Self::PREEMPTED_SENTINEL - 1);
+        self.first_byte_at
+            .compare_exchange(0, value, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+    }
+
+    /// Test-only raw read of the underlying atomic. Production callers
+    /// should compare against the sentinel via the type's API rather than
+    /// reading the raw value.
+    #[cfg(test)]
+    fn first_byte_at_raw(&self, ord: Ordering) -> u64 {
+        self.first_byte_at.load(ord)
+    }
+}
+
+impl Default for InflightHandle {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::Ordering;
+
+    use super::*;
+
+    #[test]
+    fn test_try_mark_preempted_succeeds_then_fails() {
+        let handle = InflightHandle::new();
+        assert!(
+            handle.try_mark_preempted(),
+            "first preempt CAS should succeed"
+        );
+        assert!(
+            !handle.try_mark_preempted(),
+            "second preempt CAS should fail (slot already taken)"
+        );
+    }
+
+    #[test]
+    fn test_try_mark_preempted_stores_sentinel() {
+        let handle = InflightHandle::new();
+        handle.try_mark_preempted();
+        assert_eq!(
+            handle.first_byte_at_raw(Ordering::Acquire),
+            u64::MAX,
+            "preempt sentinel is u64::MAX"
+        );
+    }
+
+    #[test]
+    fn test_try_mark_first_byte_succeeds_then_fails() {
+        let handle = InflightHandle::new();
+        assert!(
+            handle.try_mark_first_byte(42),
+            "first TTFT CAS should succeed"
+        );
+        assert!(
+            !handle.try_mark_first_byte(99),
+            "second TTFT CAS should fail (slot already taken)"
+        );
+    }
+
+    #[test]
+    fn test_ttft_loses_race_against_preempt() {
+        let handle = InflightHandle::new();
+        assert!(handle.try_mark_preempted());
+        assert!(
+            !handle.try_mark_first_byte(5),
+            "TTFT must lose if preempt already won"
+        );
+    }
+
+    #[test]
+    fn test_preempt_loses_race_against_ttft() {
+        let handle = InflightHandle::new();
+        assert!(handle.try_mark_first_byte(5));
+        assert!(
+            !handle.try_mark_preempted(),
+            "preempt must lose if TTFT already won"
+        );
+    }
+
+    #[test]
+    fn test_try_mark_first_byte_clamps_to_avoid_sentinel_collision() {
+        // u64::MAX is the preempt sentinel; a TTFT measurement that happens
+        // to equal that value would falsely appear as "preempted" to any
+        // reader. Clamp to u64::MAX - 1.
+        let handle = InflightHandle::new();
+        assert!(handle.try_mark_first_byte(u64::MAX));
+        assert_eq!(handle.first_byte_at_raw(Ordering::Acquire), u64::MAX - 1);
+    }
+
+    #[test]
+    fn test_initial_state_is_zero() {
+        let handle = InflightHandle::new();
+        assert_eq!(handle.first_byte_at_raw(Ordering::Acquire), 0);
+    }
+}

--- a/model_gateway/src/middleware/scheduler/inflight.rs
+++ b/model_gateway/src/middleware/scheduler/inflight.rs
@@ -18,8 +18,9 @@ use std::sync::atomic::{AtomicU64, Ordering};
 /// | `u64::MAX`    | Scheduler preempted this request before TTFT (sentinel)   |
 /// | anything else | Millis-since-admit of the first response byte (TTFT)      |
 ///
-/// `try_mark_first_byte` clamps `now_ms` to `u64::MAX - 1` so a TTFT
-/// measurement can never collide with the preempt sentinel.
+/// `try_mark_first_byte` clamps `now_ms` to `[1, u64::MAX - 1]` so a
+/// TTFT measurement can never collide with either the unset state or
+/// the preempt sentinel.
 pub struct InflightHandle {
     first_byte_at: AtomicU64,
 }

--- a/model_gateway/src/middleware/scheduler/mod.rs
+++ b/model_gateway/src/middleware/scheduler/mod.rs
@@ -4,6 +4,7 @@ pub mod class;
 pub mod config;
 pub mod inflight;
 pub mod policy;
+pub mod queue;
 
 pub use class::{Class, PRIORITY_HEADER};
 pub use config::{

--- a/model_gateway/src/middleware/scheduler/mod.rs
+++ b/model_gateway/src/middleware/scheduler/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod class;
 pub mod config;
+pub mod inflight;
 pub mod policy;
 
 pub use class::{Class, PRIORITY_HEADER};

--- a/model_gateway/src/middleware/scheduler/mod.rs
+++ b/model_gateway/src/middleware/scheduler/mod.rs
@@ -5,6 +5,7 @@ pub mod config;
 pub mod inflight;
 pub mod policy;
 pub mod queue;
+pub mod slots;
 
 pub use class::{Class, PRIORITY_HEADER};
 pub use config::{

--- a/model_gateway/src/middleware/scheduler/queue.rs
+++ b/model_gateway/src/middleware/scheduler/queue.rs
@@ -1,0 +1,210 @@
+//! Per-class waiter queue used by [`super::scheduler`] to hold admission
+//! candidates while their class is at capacity.
+
+use std::{
+    collections::VecDeque,
+    time::{Duration, Instant},
+};
+
+use parking_lot::Mutex;
+use tokio_util::sync::CancellationToken;
+
+use super::Class;
+
+/// A request waiting for admission in a class queue.
+///
+/// Carries only what the queue and dispatcher need: which class to admit
+/// under, when the wait started (for starvation tracking), and the
+/// cancellation token the client owns (so we can GC walkaway clients
+/// without admitting them). Additional fields (tenant key, request id,
+/// permit channel) are attached at higher layers as they're needed.
+#[derive(Debug)]
+pub struct Waiter {
+    pub class: Class,
+    pub queued_at: Instant,
+    pub cancel: CancellationToken,
+}
+
+impl Waiter {
+    pub fn new(class: Class, cancel: CancellationToken) -> Self {
+        Self {
+            class,
+            queued_at: Instant::now(),
+            cancel,
+        }
+    }
+}
+
+/// Per-class waiter queue.
+///
+/// Implemented as a trait so the v1 FIFO impl can be swapped for a
+/// per-tenant fair-queue implementation without touching the scheduler.
+/// All methods are sync; the queue is a contention point on slot release
+/// and admission, so it uses `parking_lot::Mutex` rather than an async
+/// mutex.
+pub trait ClassQueue: Send + Sync {
+    /// Append a waiter. Returns `Err(waiter)` when the queue is at its
+    /// configured limit so the caller can convert the rejection into a
+    /// 429 response.
+    fn try_enqueue(&self, waiter: Waiter) -> Result<(), Waiter>;
+
+    /// Pop the next waiter, or `None` when empty.
+    fn pop_eligible(&self) -> Option<Waiter>;
+
+    /// Wall-clock age of the head waiter (used by the dispatcher's
+    /// starvation override). `None` when empty.
+    fn head_age(&self) -> Option<Duration>;
+
+    /// Current depth, including waiters whose cancel token has fired.
+    fn depth(&self) -> usize;
+
+    /// Remove the head waiter if its cancel token has fired (client
+    /// walked away while queued). Single-step; the caller may invoke
+    /// repeatedly to GC a run of cancelled heads.
+    fn drop_cancelled_head(&self);
+}
+
+/// First-in, first-out per-class queue with a fixed maximum depth.
+pub struct FifoClassQueue {
+    waiters: Mutex<VecDeque<Waiter>>,
+    max: usize,
+}
+
+impl FifoClassQueue {
+    pub fn new(max: usize) -> Self {
+        Self {
+            waiters: Mutex::new(VecDeque::with_capacity(max.min(64))),
+            max,
+        }
+    }
+}
+
+impl ClassQueue for FifoClassQueue {
+    fn try_enqueue(&self, waiter: Waiter) -> Result<(), Waiter> {
+        let mut guard = self.waiters.lock();
+        if guard.len() >= self.max {
+            return Err(waiter);
+        }
+        guard.push_back(waiter);
+        Ok(())
+    }
+
+    fn pop_eligible(&self) -> Option<Waiter> {
+        self.waiters.lock().pop_front()
+    }
+
+    fn head_age(&self) -> Option<Duration> {
+        self.waiters.lock().front().map(|w| w.queued_at.elapsed())
+    }
+
+    fn depth(&self) -> usize {
+        self.waiters.lock().len()
+    }
+
+    fn drop_cancelled_head(&self) {
+        let mut guard = self.waiters.lock();
+        if guard.front().is_some_and(|w| w.cancel.is_cancelled()) {
+            guard.pop_front();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use tokio_util::sync::CancellationToken;
+
+    use super::*;
+    use crate::middleware::scheduler::Class;
+
+    fn waiter(class: Class) -> Waiter {
+        Waiter::new(class, CancellationToken::new())
+    }
+
+    #[test]
+    fn test_try_enqueue_fills_to_capacity_then_rejects() {
+        let q = FifoClassQueue::new(4);
+        for _ in 0..4 {
+            assert!(q.try_enqueue(waiter(Class::Default)).is_ok());
+        }
+        let rejected = q
+            .try_enqueue(waiter(Class::Default))
+            .expect_err("queue full");
+        assert_eq!(rejected.class, Class::Default);
+    }
+
+    #[test]
+    fn test_pop_eligible_is_fifo() {
+        // Distinguish waiters by class to verify insertion order is preserved.
+        let q = FifoClassQueue::new(4);
+        q.try_enqueue(waiter(Class::Bulk)).unwrap();
+        q.try_enqueue(waiter(Class::Default)).unwrap();
+        q.try_enqueue(waiter(Class::Interactive)).unwrap();
+        assert_eq!(q.pop_eligible().unwrap().class, Class::Bulk);
+        assert_eq!(q.pop_eligible().unwrap().class, Class::Default);
+        assert_eq!(q.pop_eligible().unwrap().class, Class::Interactive);
+        assert!(q.pop_eligible().is_none());
+    }
+
+    #[test]
+    fn test_pop_eligible_returns_none_when_empty() {
+        let q = FifoClassQueue::new(4);
+        assert!(q.pop_eligible().is_none());
+    }
+
+    #[test]
+    fn test_head_age_is_some_after_enqueue() {
+        let q = FifoClassQueue::new(4);
+        assert!(q.head_age().is_none());
+        q.try_enqueue(waiter(Class::Default)).unwrap();
+        std::thread::sleep(Duration::from_millis(5));
+        let age = q.head_age().expect("head present");
+        assert!(age >= Duration::from_millis(5));
+    }
+
+    #[test]
+    fn test_depth_reflects_enqueue_and_pop() {
+        let q = FifoClassQueue::new(4);
+        assert_eq!(q.depth(), 0);
+        q.try_enqueue(waiter(Class::Default)).unwrap();
+        q.try_enqueue(waiter(Class::Default)).unwrap();
+        assert_eq!(q.depth(), 2);
+        q.pop_eligible();
+        assert_eq!(q.depth(), 1);
+    }
+
+    #[test]
+    fn test_drop_cancelled_head_removes_cancelled_head_only() {
+        let q = FifoClassQueue::new(4);
+        let cancelled = CancellationToken::new();
+        cancelled.cancel();
+        q.try_enqueue(Waiter::new(Class::Default, cancelled))
+            .unwrap();
+        q.try_enqueue(waiter(Class::Interactive)).unwrap();
+        assert_eq!(q.depth(), 2);
+
+        q.drop_cancelled_head();
+        assert_eq!(q.depth(), 1, "cancelled head dropped");
+        assert_eq!(
+            q.pop_eligible().unwrap().class,
+            Class::Interactive,
+            "live waiter exposed as new head"
+        );
+    }
+
+    #[test]
+    fn test_drop_cancelled_head_leaves_live_head_alone() {
+        let q = FifoClassQueue::new(4);
+        q.try_enqueue(waiter(Class::Default)).unwrap();
+        q.drop_cancelled_head();
+        assert_eq!(q.depth(), 1, "non-cancelled head retained");
+    }
+
+    #[test]
+    fn test_drop_cancelled_head_noop_on_empty_queue() {
+        let q = FifoClassQueue::new(4);
+        q.drop_cancelled_head();
+        assert_eq!(q.depth(), 0);
+    }
+}

--- a/model_gateway/src/middleware/scheduler/queue.rs
+++ b/model_gateway/src/middleware/scheduler/queue.rs
@@ -58,9 +58,10 @@ pub trait ClassQueue: Send + Sync {
     /// Current depth, including waiters whose cancel token has fired.
     fn depth(&self) -> usize;
 
-    /// Remove the head waiter if its cancel token has fired (client
-    /// walked away while queued). Single-step; the caller may invoke
-    /// repeatedly to GC a run of cancelled heads.
+    /// Drain any leading run of waiters whose cancel token has fired
+    /// (clients that walked away while queued). One call removes every
+    /// consecutive cancelled head in a single lock acquisition; the
+    /// first non-cancelled or empty position stops the scan.
     fn drop_cancelled_head(&self);
 }
 
@@ -103,7 +104,7 @@ impl ClassQueue for FifoClassQueue {
 
     fn drop_cancelled_head(&self) {
         let mut guard = self.waiters.lock();
-        if guard.front().is_some_and(|w| w.cancel.is_cancelled()) {
+        while guard.front().is_some_and(|w| w.cancel.is_cancelled()) {
             guard.pop_front();
         }
     }
@@ -206,5 +207,34 @@ mod tests {
         let q = FifoClassQueue::new(4);
         q.drop_cancelled_head();
         assert_eq!(q.depth(), 0);
+    }
+
+    #[test]
+    fn test_drop_cancelled_head_drains_run_in_single_call() {
+        // When several clients in a row have walked away, a single call
+        // should clear the whole run rather than requiring the caller to
+        // loop. This keeps the dispatcher's GC pass to one lock cycle
+        // instead of N.
+        let q = FifoClassQueue::new(8);
+        for _ in 0..3 {
+            let cancelled = CancellationToken::new();
+            cancelled.cancel();
+            q.try_enqueue(Waiter::new(Class::Default, cancelled))
+                .unwrap();
+        }
+        q.try_enqueue(waiter(Class::Interactive)).unwrap();
+        assert_eq!(q.depth(), 4);
+
+        q.drop_cancelled_head();
+        assert_eq!(
+            q.depth(),
+            1,
+            "all three cancelled heads dropped in one call"
+        );
+        assert_eq!(
+            q.pop_eligible().unwrap().class,
+            Class::Interactive,
+            "first live waiter is now the head"
+        );
     }
 }

--- a/model_gateway/src/middleware/scheduler/slots.rs
+++ b/model_gateway/src/middleware/scheduler/slots.rs
@@ -1,0 +1,320 @@
+//! Packed slot accounting for the priority scheduler.
+//!
+//! Per-class in-flight counts are packed into a single `AtomicU64` (four
+//! `u16` lanes) so an admission check can both verify availability and
+//! claim a slot in a single compare-and-swap. This keeps the reservation
+//! guard race-free under concurrent admissions to different classes — a
+//! property that a per-class counter array cannot give us cheaply.
+//!
+//! Lane layout (low to high u16): `[Bulk, Default, Interactive, System]`,
+//! indexed by [`Class`] cast to `usize`.
+
+use std::sync::atomic::{AtomicU16, AtomicU64, Ordering};
+
+use super::Class;
+
+/// Decode a packed `u64` into per-class in-flight counts, lane order
+/// `[Bulk, Default, Interactive, System]`.
+pub(super) fn unpack(packed: u64) -> [u16; 4] {
+    [
+        (packed & 0xFFFF) as u16,
+        ((packed >> 16) & 0xFFFF) as u16,
+        ((packed >> 32) & 0xFFFF) as u16,
+        ((packed >> 48) & 0xFFFF) as u16,
+    ]
+}
+
+/// Encode per-class in-flight counts into a single `u64`.
+pub(super) fn pack(counts: [u16; 4]) -> u64 {
+    u64::from(counts[0])
+        | (u64::from(counts[1]) << 16)
+        | (u64::from(counts[2]) << 32)
+        | (u64::from(counts[3]) << 48)
+}
+
+/// How many slots a `class` admission may consume right now, given the
+/// current per-class counts, reservations, and total capacity.
+///
+/// Higher-priority classes hold their reservations: a `Bulk` admission
+/// cannot consume a slot that `System` has reserved but not yet used.
+/// Once a higher class has actually consumed its reservation, the hold
+/// collapses 1:1 and the slot returns to the shared pool.
+///
+/// A class's own reservation never shrinks its own headroom.
+pub(super) fn slots_available_to(
+    counts: [u16; 4],
+    reserved: [u16; 4],
+    capacity: u16,
+    class: Class,
+) -> u16 {
+    let used_total: u16 = counts.iter().copied().fold(0, u16::saturating_add);
+    let unavailable_to_us: u16 = Class::ALL
+        .iter()
+        .filter(|&&c| c > class)
+        .map(|&c| reserved[c as usize].saturating_sub(counts[c as usize]))
+        .fold(0, u16::saturating_add);
+    capacity
+        .saturating_sub(used_total)
+        .saturating_sub(unavailable_to_us)
+}
+
+/// Slot pool: capacity, per-class reservations, and packed per-class
+/// in-flight counts. The admission middleware acquires a slot here at
+/// admission and releases it from the response-body wrapper.
+pub struct SlotPool {
+    capacity: AtomicU16,
+    inflight_packed: AtomicU64,
+    reserved: [AtomicU16; 4],
+}
+
+impl SlotPool {
+    /// Build a pool with the given capacity and per-class reservations
+    /// (lane order `[Bulk, Default, Interactive, System]`).
+    pub fn new(capacity: u16, reserved: [u16; 4]) -> Self {
+        Self {
+            capacity: AtomicU16::new(capacity),
+            inflight_packed: AtomicU64::new(0),
+            reserved: reserved.map(AtomicU16::new),
+        }
+    }
+
+    /// Current in-flight count for a class. Single atomic load + a few
+    /// shifts; safe to call from any thread.
+    pub fn inflight(&self, class: Class) -> u16 {
+        unpack(self.inflight_packed.load(Ordering::Acquire))[class as usize]
+    }
+
+    fn snapshot_reserved(&self) -> [u16; 4] {
+        [
+            self.reserved[0].load(Ordering::Relaxed),
+            self.reserved[1].load(Ordering::Relaxed),
+            self.reserved[2].load(Ordering::Relaxed),
+            self.reserved[3].load(Ordering::Relaxed),
+        ]
+    }
+
+    /// Reservation-aware acquire. Returns `true` after a successful CAS;
+    /// `false` if `class` has no headroom under the reservation guard.
+    /// Bounded loop — re-reads on each failed CAS and exits as soon as
+    /// the slot is genuinely full.
+    pub fn try_acquire(&self, class: Class) -> bool {
+        let lane = class as usize;
+        let capacity = self.capacity.load(Ordering::Acquire);
+        let reserved = self.snapshot_reserved();
+        let mut cur = self.inflight_packed.load(Ordering::Acquire);
+        loop {
+            let mut counts = unpack(cur);
+            if slots_available_to(counts, reserved, capacity, class) == 0 {
+                return false;
+            }
+            counts[lane] = counts[lane].saturating_add(1);
+            let new = pack(counts);
+            match self.inflight_packed.compare_exchange_weak(
+                cur,
+                new,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => return true,
+                Err(observed) => cur = observed,
+            }
+        }
+    }
+
+    /// Acquire ignoring the reservation guard — only the total-capacity
+    /// ceiling applies. Used by the dispatcher's starvation override so
+    /// a starved low-class waiter can consume a reserved-but-unused slot
+    /// rather than wait indefinitely.
+    pub fn try_acquire_ignoring_reservations(&self, class: Class) -> bool {
+        let lane = class as usize;
+        let capacity = self.capacity.load(Ordering::Acquire);
+        let mut cur = self.inflight_packed.load(Ordering::Acquire);
+        loop {
+            let mut counts = unpack(cur);
+            let used_total: u16 = counts.iter().copied().fold(0, u16::saturating_add);
+            if used_total >= capacity {
+                return false;
+            }
+            counts[lane] = counts[lane].saturating_add(1);
+            match self.inflight_packed.compare_exchange_weak(
+                cur,
+                pack(counts),
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => return true,
+                Err(observed) => cur = observed,
+            }
+        }
+    }
+
+    /// Release a previously acquired slot. Saturates at zero so a stray
+    /// extra release cannot underflow the lane (defensive — production
+    /// callers acquire and release in `SchedulerPermit::Drop`).
+    pub fn release(&self, class: Class) {
+        let lane = class as usize;
+        let mut cur = self.inflight_packed.load(Ordering::Acquire);
+        loop {
+            let mut counts = unpack(cur);
+            counts[lane] = counts[lane].saturating_sub(1);
+            match self.inflight_packed.compare_exchange_weak(
+                cur,
+                pack(counts),
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => return,
+                Err(observed) => cur = observed,
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::middleware::scheduler::Class;
+
+    // ── pack/unpack pure-function round trip ─────────────────────────
+
+    #[test]
+    fn test_pack_unpack_round_trip() {
+        let samples: [[u16; 4]; 6] = [
+            [0, 0, 0, 0],
+            [1, 2, 3, 4],
+            [u16::MAX, 0, u16::MAX, 0],
+            [0, u16::MAX, 0, u16::MAX],
+            [10_000, 20_000, 30_000, 40_000],
+            [u16::MAX; 4],
+        ];
+        for s in samples {
+            assert_eq!(unpack(pack(s)), s);
+        }
+    }
+
+    // ── slots_available_to: reservation honored across classes ───────
+
+    #[test]
+    fn test_slots_available_to_subtracts_higher_class_reservation() {
+        // Capacity 128, System holds a 32-slot reservation (lane 3), no
+        // inflight. A Bulk admission may use at most 128 - 32 = 96.
+        let counts = [0, 0, 0, 0];
+        let reserved = [0, 0, 0, 32];
+        assert_eq!(slots_available_to(counts, reserved, 128, Class::Bulk), 96);
+        // The reserving class itself gets the full capacity — its own
+        // reservation is "available to" it.
+        assert_eq!(
+            slots_available_to(counts, reserved, 128, Class::System),
+            128
+        );
+    }
+
+    #[test]
+    fn test_slots_available_to_ignores_same_class_reservation() {
+        // A class's own reservation doesn't shrink its own headroom.
+        let counts = [0, 0, 0, 0];
+        let reserved = [32, 0, 0, 0];
+        assert_eq!(slots_available_to(counts, reserved, 128, Class::Bulk), 128);
+    }
+
+    #[test]
+    fn test_slots_available_to_consumed_reservation_releases_headroom() {
+        // Once a higher class is already consuming its reservation, the
+        // reservation hold collapses 1:1 — Bulk regains those slots.
+        let counts = [0, 0, 0, 32];
+        let reserved = [0, 0, 0, 32];
+        // used_total = 32, unavailable_to_bulk = max(0, 32-32) = 0
+        // → 128 - 32 - 0 = 96
+        assert_eq!(slots_available_to(counts, reserved, 128, Class::Bulk), 96);
+    }
+
+    #[test]
+    fn test_slots_available_to_returns_zero_when_used_meets_capacity() {
+        let counts = [10, 10, 10, 10];
+        let reserved = [0, 0, 0, 0];
+        assert_eq!(slots_available_to(counts, reserved, 40, Class::Default), 0);
+    }
+
+    // ── try_acquire_slot / release_slot ──────────────────────────────
+
+    #[test]
+    fn test_try_acquire_increments_lane_then_release_decrements() {
+        let pool = SlotPool::new(8, [0, 0, 0, 0]);
+        assert!(pool.try_acquire(Class::Default));
+        assert_eq!(pool.inflight(Class::Default), 1);
+        pool.release(Class::Default);
+        assert_eq!(pool.inflight(Class::Default), 0);
+    }
+
+    #[test]
+    fn test_try_acquire_respects_higher_class_reservation() {
+        // Capacity 4, System reserves 2. Bulk can take at most 2.
+        let pool = SlotPool::new(4, [0, 0, 0, 2]);
+        assert!(pool.try_acquire(Class::Bulk));
+        assert!(pool.try_acquire(Class::Bulk));
+        assert!(
+            !pool.try_acquire(Class::Bulk),
+            "Bulk must not consume System's reservation"
+        );
+        // System itself still has room.
+        assert!(pool.try_acquire(Class::System));
+        assert!(pool.try_acquire(Class::System));
+        assert!(!pool.try_acquire(Class::System), "now truly full");
+    }
+
+    #[test]
+    fn test_try_acquire_returns_false_when_full_without_spinning() {
+        let pool = SlotPool::new(1, [0, 0, 0, 0]);
+        assert!(pool.try_acquire(Class::Default));
+        // Second call must return promptly, not spin forever.
+        assert!(!pool.try_acquire(Class::Default));
+    }
+
+    #[test]
+    fn test_try_acquire_ignoring_reservations_bypasses_guard() {
+        // Capacity 4, System reserves 4 (locks Bulk out under the guard).
+        let pool = SlotPool::new(4, [0, 0, 0, 4]);
+        assert!(!pool.try_acquire(Class::Bulk), "guarded acquire is blocked");
+        assert!(
+            pool.try_acquire_ignoring_reservations(Class::Bulk),
+            "starvation-override path bypasses the reservation guard"
+        );
+    }
+
+    #[test]
+    fn test_release_saturates_at_zero() {
+        // Defensive: an extra release shouldn't underflow the lane.
+        let pool = SlotPool::new(1, [0, 0, 0, 0]);
+        pool.release(Class::Default);
+        assert_eq!(pool.inflight(Class::Default), 0);
+    }
+
+    // ── concurrent contention: no over- or under-admission ───────────
+
+    #[test]
+    fn test_concurrent_admission_admits_exactly_capacity() {
+        // 200 threads racing to acquire one Default slot against a pool
+        // sized for 64. The CAS loop must guarantee exactly 64 successes
+        // — no over-admission (race) or under-admission (giving up too
+        // early). Uses std::thread rather than tokio so the test
+        // exercises real OS-level concurrency without a runtime.
+        use std::thread;
+
+        let pool = Arc::new(SlotPool::new(64, [0, 0, 0, 0]));
+        let handles: Vec<_> = (0..200)
+            .map(|_| {
+                let pool = pool.clone();
+                thread::spawn(move || pool.try_acquire(Class::Default))
+            })
+            .collect();
+        let successes = handles
+            .into_iter()
+            .filter_map(|h| h.join().ok())
+            .filter(|admitted| *admitted)
+            .count();
+        assert_eq!(successes, 64);
+        assert_eq!(pool.inflight(Class::Default), 64);
+    }
+}

--- a/model_gateway/src/middleware/scheduler/slots.rs
+++ b/model_gateway/src/middleware/scheduler/slots.rs
@@ -151,15 +151,24 @@ impl SlotPool {
     /// Release a previously acquired slot. Saturates at zero so a stray
     /// extra release cannot underflow the lane (defensive — production
     /// callers acquire and release in `SchedulerPermit::Drop`).
+    ///
+    /// Returns early without issuing a CAS when the lane is already
+    /// zero. An unchanged-value atomic write would still trigger cache-
+    /// line invalidation across cores via the coherence protocol, so
+    /// the short-circuit matters on hot release paths.
     pub fn release(&self, class: Class) {
         let lane = class as usize;
         let mut cur = self.inflight_packed.load(Ordering::Acquire);
         loop {
-            let mut counts = unpack(cur);
-            counts[lane] = counts[lane].saturating_sub(1);
+            let counts = unpack(cur);
+            if counts[lane] == 0 {
+                return;
+            }
+            let mut new_counts = counts;
+            new_counts[lane] -= 1;
             match self.inflight_packed.compare_exchange_weak(
                 cur,
-                pack(counts),
+                pack(new_counts),
                 Ordering::AcqRel,
                 Ordering::Acquire,
             ) {


### PR DESCRIPTION
## Description

### Problem

PR 2 (priority scheduler) is split into milestones. M1 (#1541) landed the vocabulary types (`Class`, configs, `TenantPolicyResolver`). This PR is **M2a**, the first half of M2 (scheduler core): the data-layer types the engine will own — in-flight bookkeeping, per-class waiter queue, and packed-CAS slot accounting.

M2b will follow with the engine itself (`PriorityScheduler::new`, `admit`, dispatcher, capacity-watch integration).

### Solution

Three small, self-contained modules with full unit-test coverage. **No production wiring** — these types are reachable from `crate::middleware::scheduler::*` but no call site constructs them yet. Behavior on `main` is unchanged.

## Changes

Three commits, one per task:

1. **`feat(scheduler): InflightHandle with TTFT/preempt CAS sentinels`** — `InflightHandle` tracks a single admitted request via one `AtomicU64` (`first_byte_at`). Three states encoded in one word: `0` = no TTFT yet, `u64::MAX` = preempted (sentinel), anything else = millis-since-admit at TTFT. Two symmetric CAS methods (`try_mark_preempted`, `try_mark_first_byte`) resolve the race between the scheduler firing a preempt and the response body emitting its first frame — whichever wins the CAS dictates the outcome, the loser respects the winner. `try_mark_first_byte` clamps to `u64::MAX - 1` so a TTFT measurement can never collide with the sentinel.

2. **`feat(scheduler): FIFO per-class queue + ClassQueue trait`** — `Waiter` (class + queued-at instant + cancel token) and `ClassQueue` trait (`try_enqueue` / `pop_eligible` / `head_age` / `depth` / `drop_cancelled_head`). v1 impl is `FifoClassQueue { Mutex<VecDeque<Waiter>>, max }`. Trait shape lets a future per-tenant fair-queue swap in without touching the dispatcher. `drop_cancelled_head` GCs walkaway clients so they don't consume a slot when their turn comes.

3. **`feat(scheduler): packed-CAS slot accounting with reservation guard`** — `SlotPool` packs four `u16` per-class in-flight counts into one `AtomicU64`. A single compare-and-swap both verifies availability under the reservation guard and claims the slot, so concurrent admissions to different classes can't race and double-spend a higher-class reservation. `try_acquire` honors reservations; `try_acquire_ignoring_reservations` is the starvation-override path. Released slots saturate at zero (defensive against stray double-releases).

## Test Plan

Each task: failing test → verify FAIL → implement → verify PASS → commit. 26 new unit tests:

- **inflight (7)**: preempt CAS succeeds-then-fails, TTFT CAS succeeds-then-fails, mutual exclusion in both directions (TTFT loses if preempt already won, and vice versa), sentinel-collision clamp at `u64::MAX - 1`, initial state is zero.
- **queue (8)**: enqueue fills to capacity then rejects with `Err(waiter)`, pop FIFO order, head_age tracks wall-clock wait, depth reflects mutations, `drop_cancelled_head` removes cancelled head only and is a no-op on live head / empty queue.
- **slots (11)**: pack/unpack round-trip across 6 sample vectors including `[u16::MAX; 4]`, `slots_available_to` honors higher-class reservations / ignores same-class / collapses 1:1 on consumed reservation, `try_acquire` respects guard / returns false when full without spinning, `try_acquire_ignoring_reservations` bypasses guard, release saturates at zero, and a **concurrent contention test**: 200 threads racing against capacity=64 admit exactly 64 (no over- or under-admission).

```bash
$ cargo test --package smg --lib middleware::scheduler
... 55 passed; 0 failed
```

```bash
$ cargo clippy --package smg --all-targets --all-features -- -D warnings
... Finished `dev` profile, no warnings
```

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes (enforced by pre-commit hook)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] (Optional) Documentation updated — see `.claude/docs/scheduler/02-priority-scheduler-plan.md` (in #1541)
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced scheduler: precise in-flight tracking for admitted requests and a preemption marker.
  * Per-class FIFO admission queues with cancellation handling, wait-age reporting, and bounded capacity.
  * Slot-based capacity manager with per-class reservations, reservation-aware admissions, and robust release behavior.
* **Tests**
  * Comprehensive unit tests covering booking, queue behavior, slot semantics, edge cases, and contention.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightseekorg/smg/pull/1546?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->