### PR TITLE
fix(harmony): normalize gpt-oss tool transcripts

### DIFF
--- a/model_gateway/src/routers/grpc/harmony/builder.rs
+++ b/model_gateway/src/routers/grpc/harmony/builder.rs
@@ -233,6 +233,17 @@ fn has_custom_tools(tool_types: &[&str]) -> bool {
     !tool_types.iter().all(|t| BUILTIN_TOOLS.contains(t))
 }
 
+fn parse_chat_reasoning_effort(effort: &str) -> ReasoningEffort {
+    match effort.to_ascii_lowercase().as_str() {
+        "high" => ReasoningEffort::High,
+        "medium" => ReasoningEffort::Medium,
+        "low" => ReasoningEffort::Low,
+        // Harmony does not support minimal reasoning effort.
+        "minimal" => ReasoningEffort::Low,
+        _ => ReasoningEffort::Medium,
+    }
+}
+
 /// Harmony request builder
 ///
 /// Converts OpenAI-format requests into Harmony-encoded format with input_ids,
@@ -402,14 +413,7 @@ impl HarmonyBuilder {
         let reasoning_effort = request
             .reasoning_effort
             .as_deref()
-            .map(|effort| match effort {
-                "high" => ReasoningEffort::High,
-                "medium" => ReasoningEffort::Medium,
-                "low" => ReasoningEffort::Low,
-                // Harmony does not support minimal reasoning effort
-                "minimal" => ReasoningEffort::Low,
-                _ => ReasoningEffort::Medium,
-            });
+            .map(parse_chat_reasoning_effort);
 
         let has_tools = request.tools.is_some();
         self.build_system_message(reasoning_effort, has_tools)
@@ -701,13 +705,13 @@ impl HarmonyBuilder {
                 if let Some(output_str) = output {
                     // Tool result - use Tool role with "functions.{name}" as author name
                     // IMPORTANT: Must include recipient="assistant" for parser to recognize it.
-                    // We keep channel=None to minimize what the model might copy.
+                    // Tool results belong to the commentary channel in Harmony.
                     let author_name = format!("functions.{name}");
                     debug!(
                         tool_name = %name,
                         author_name = %author_name,
                         output_preview = %output_str.chars().take(100).collect::<String>(),
-                        "Building tool result message with Tool role (recipient=assistant, no channel)"
+                        "Building tool result message with Tool role (recipient=assistant, channel=commentary)"
                     );
                     Ok(HarmonyMessage {
                         author: Author {
@@ -718,7 +722,7 @@ impl HarmonyBuilder {
                         content: vec![Content::Text(TextContent {
                             text: output_str.clone(),
                         })],
-                        channel: None,
+                        channel: Some("commentary".to_string()),
                         content_type: None,
                     })
                 } else {
@@ -765,7 +769,7 @@ impl HarmonyBuilder {
 
                 // Create Tool message with "functions.{name}" prefix
                 // IMPORTANT: Must include recipient="assistant" for parser to recognize it.
-                // We keep channel=None to minimize what the model might copy.
+                // Tool results belong to the commentary channel in Harmony.
                 Ok(HarmonyMessage {
                     author: Author {
                         role: Role::Tool,
@@ -775,7 +779,7 @@ impl HarmonyBuilder {
                     content: vec![Content::Text(TextContent {
                         text: output.clone(),
                     })],
-                    channel: None,
+                    channel: Some("commentary".to_string()),
                     content_type: None,
                 })
             }
@@ -1060,7 +1064,7 @@ impl HarmonyBuilder {
                         .unwrap_or_else(|| tool_call_id.clone());
 
                     // Tool result - Must include recipient="assistant" for parser to recognize it.
-                    // We keep channel=None to minimize what the model might copy.
+                    // Tool results belong to the commentary channel in Harmony.
                     let harmony_msg = HarmonyMessage {
                         author: Author {
                             role: Role::Tool,
@@ -1070,7 +1074,7 @@ impl HarmonyBuilder {
                         content: vec![Content::Text(TextContent {
                             text: content.to_simple_string(),
                         })],
-                        channel: None,
+                        channel: Some("commentary".to_string()),
                         content_type: None,
                     };
                     harmony_messages.push(harmony_msg);
@@ -1079,7 +1083,7 @@ impl HarmonyBuilder {
                 ChatMessage::Function { content, name } => {
                     // Function messages also use Role::Tool
                     // Tool result - Must include recipient="assistant" for parser to recognize it.
-                    // We keep channel=None to minimize what the model might copy.
+                    // Tool results belong to the commentary channel in Harmony.
                     let harmony_msg = HarmonyMessage {
                         author: Author {
                             role: Role::Tool,
@@ -1089,7 +1093,7 @@ impl HarmonyBuilder {
                         content: vec![Content::Text(TextContent {
                             text: content.clone(),
                         })],
-                        channel: None,
+                        channel: Some("commentary".to_string()),
                         content_type: None,
                     };
                     harmony_messages.push(harmony_msg);
@@ -1163,8 +1167,13 @@ mod tests {
     //!      signature (`type image_generation = (_: …) => any;`) that
     //!      gpt-oss is trained to emit calls against.
 
-    use openai_protocol::responses::{
-        ImageGenerationTool, ResponseInput, ResponseTool, ResponsesRequest,
+    use openai_protocol::{
+        chat::{ChatMessage, MessageContent},
+        common::{FunctionCallResponse, ToolCall},
+        responses::{
+            ImageGenerationTool, ResponseInput, ResponseInputOutputItem, ResponseTool,
+            ResponsesRequest,
+        },
     };
 
     use super::*;
@@ -1379,5 +1388,101 @@ mod tests {
              function-tools namespace; found {occurrences} occurrences. \
              Decoded prompt:\n{decoded}",
         );
+    }
+
+    fn assert_tool_result_metadata(message: &HarmonyMessage, function_name: &str) {
+        assert_eq!(message.author.role, Role::Tool);
+        assert_eq!(message.author.name.as_deref(), Some(function_name));
+        assert_eq!(message.recipient.as_deref(), Some("assistant"));
+        assert_eq!(message.channel.as_deref(), Some("commentary"));
+    }
+
+    fn assert_reasoning_effort(input: &str, expected: ReasoningEffort) {
+        let actual = parse_chat_reasoning_effort(input);
+        match (actual, expected) {
+            (ReasoningEffort::High, ReasoningEffort::High)
+            | (ReasoningEffort::Medium, ReasoningEffort::Medium)
+            | (ReasoningEffort::Low, ReasoningEffort::Low) => {}
+            _ => panic!("unexpected reasoning effort mapping for {input}"),
+        }
+    }
+
+    #[test]
+    fn chat_reasoning_effort_is_case_insensitive() {
+        assert_reasoning_effort("HIGH", ReasoningEffort::High);
+        assert_reasoning_effort("medium", ReasoningEffort::Medium);
+        assert_reasoning_effort("LOW", ReasoningEffort::Low);
+        assert_reasoning_effort("MiNiMaL", ReasoningEffort::Low);
+        assert_reasoning_effort("unknown", ReasoningEffort::Medium);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn chat_tool_results_use_commentary_channel() {
+        let builder = HarmonyBuilder::new();
+        let messages = vec![
+            ChatMessage::Assistant {
+                content: None,
+                name: None,
+                tool_calls: Some(vec![ToolCall {
+                    id: "call_lookup".to_string(),
+                    tool_type: "function".to_string(),
+                    function: FunctionCallResponse {
+                        name: "lookup".to_string(),
+                        arguments: Some("{}".to_string()),
+                    },
+                }]),
+                reasoning_content: None,
+            },
+            ChatMessage::Tool {
+                content: MessageContent::Text("{\"ok\":true}".to_string()),
+                tool_call_id: "call_lookup".to_string(),
+            },
+            ChatMessage::Function {
+                content: "{\"ok\":true}".to_string(),
+                name: "legacy_lookup".to_string(),
+            },
+        ];
+
+        let harmony_messages = builder.convert_chat_messages(&messages);
+
+        assert_tool_result_metadata(&harmony_messages[1], "functions.lookup");
+        assert_tool_result_metadata(&harmony_messages[2], "functions.legacy_lookup");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn response_tool_results_use_commentary_channel() {
+        let builder = HarmonyBuilder::new();
+        let previous_call = ResponseInputOutputItem::FunctionToolCall {
+            id: "fc_1".to_string(),
+            call_id: "call_lookup".to_string(),
+            name: "lookup".to_string(),
+            arguments: "{}".to_string(),
+            output: None,
+            status: None,
+        };
+        let inline_output = ResponseInputOutputItem::FunctionToolCall {
+            id: "fc_2".to_string(),
+            call_id: "call_inline".to_string(),
+            name: "inline_lookup".to_string(),
+            arguments: "{}".to_string(),
+            output: Some("{\"ok\":true}".to_string()),
+            status: None,
+        };
+        let separate_output = ResponseInputOutputItem::FunctionCallOutput {
+            id: None,
+            call_id: "call_lookup".to_string(),
+            output: "{\"ok\":true}".to_string(),
+            status: None,
+        };
+
+        let inline_message = builder
+            .parse_response_item_to_harmony_message(&inline_output, &[])
+            .expect("inline output should convert");
+        let separate_message = builder
+            .parse_response_item_to_harmony_message(&separate_output, &[&previous_call])
+            .expect("separate output should convert");
+
+        assert_tool_result_metadata(&inline_message, "functions.inline_lookup");
+        assert_tool_result_metadata(&separate_message, "functions.lookup");
     }
 }

--- a/model_gateway/src/routers/grpc/harmony/builder.rs
+++ b/model_gateway/src/routers/grpc/harmony/builder.rs
@@ -233,17 +233,6 @@ fn has_custom_tools(tool_types: &[&str]) -> bool {
     !tool_types.iter().all(|t| BUILTIN_TOOLS.contains(t))
 }
 
-fn parse_chat_reasoning_effort(effort: &str) -> ReasoningEffort {
-    match effort.to_ascii_lowercase().as_str() {
-        "high" => ReasoningEffort::High,
-        "medium" => ReasoningEffort::Medium,
-        "low" => ReasoningEffort::Low,
-        // Harmony does not support minimal reasoning effort.
-        "minimal" => ReasoningEffort::Low,
-        _ => ReasoningEffort::Medium,
-    }
-}
-
 /// Harmony request builder
 ///
 /// Converts OpenAI-format requests into Harmony-encoded format with input_ids,
@@ -413,7 +402,14 @@ impl HarmonyBuilder {
         let reasoning_effort = request
             .reasoning_effort
             .as_deref()
-            .map(parse_chat_reasoning_effort);
+            .map(|effort| match effort {
+                "high" => ReasoningEffort::High,
+                "medium" => ReasoningEffort::Medium,
+                "low" => ReasoningEffort::Low,
+                // Harmony does not support minimal reasoning effort
+                "minimal" => ReasoningEffort::Low,
+                _ => ReasoningEffort::Medium,
+            });
 
         let has_tools = request.tools.is_some();
         self.build_system_message(reasoning_effort, has_tools)
@@ -1395,25 +1391,6 @@ mod tests {
         assert_eq!(message.author.name.as_deref(), Some(function_name));
         assert_eq!(message.recipient.as_deref(), Some("assistant"));
         assert_eq!(message.channel.as_deref(), Some("commentary"));
-    }
-
-    fn assert_reasoning_effort(input: &str, expected: ReasoningEffort) {
-        let actual = parse_chat_reasoning_effort(input);
-        match (actual, expected) {
-            (ReasoningEffort::High, ReasoningEffort::High)
-            | (ReasoningEffort::Medium, ReasoningEffort::Medium)
-            | (ReasoningEffort::Low, ReasoningEffort::Low) => {}
-            _ => panic!("unexpected reasoning effort mapping for {input}"),
-        }
-    }
-
-    #[test]
-    fn chat_reasoning_effort_is_case_insensitive() {
-        assert_reasoning_effort("HIGH", ReasoningEffort::High);
-        assert_reasoning_effort("medium", ReasoningEffort::Medium);
-        assert_reasoning_effort("LOW", ReasoningEffort::Low);
-        assert_reasoning_effort("MiNiMaL", ReasoningEffort::Low);
-        assert_reasoning_effort("unknown", ReasoningEffort::Medium);
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/model_gateway/src/routers/grpc/harmony/parser.rs
+++ b/model_gateway/src/routers/grpc/harmony/parser.rs
@@ -4,6 +4,7 @@
 
 use openai_harmony::{chat::Role, HarmonyEncoding, StreamableParser};
 use openai_protocol::common::{FunctionCallResponse, ToolCall};
+use serde_json::Value;
 use uuid::Uuid;
 
 use super::types::{HarmonyChannelDelta, HarmonyChannelOutput};
@@ -62,6 +63,20 @@ impl HarmonyParserAdapter {
             .join("")
     }
 
+    fn normalize_tool_arguments(arguments: &str, content_type: Option<&str>) -> String {
+        let should_parse_as_json = match content_type {
+            Some(content_type) => content_type.to_ascii_lowercase().contains("json"),
+            None => true,
+        };
+        if !should_parse_as_json {
+            return arguments.to_string();
+        }
+
+        serde_json::from_str::<Value>(arguments)
+            .and_then(|value| serde_json::to_string(&value))
+            .unwrap_or_else(|_| arguments.to_string())
+    }
+
     /// Handle incomplete content from parser state (private helper)
     ///
     /// Checks for any remaining incomplete content in the parser and appends it
@@ -84,10 +99,20 @@ impl HarmonyParserAdapter {
                     Some("analysis") => {
                         *analysis = Some(current_content);
                     }
-                    Some("final") | None => {
+                    Some("final") => {
                         final_text.push_str(&current_content);
                     }
-                    _ => {}
+                    None => {
+                        tracing::warn!(
+                            "Dropping incomplete Harmony content without a channel instead of treating it as final text"
+                        );
+                    }
+                    _ => {
+                        tracing::warn!(
+                            channel = ?current_channel,
+                            "Dropping incomplete Harmony content with unknown channel instead of treating it as final text"
+                        );
+                    }
                 }
             }
         }
@@ -118,7 +143,6 @@ impl HarmonyParserAdapter {
                 continue;
             }
 
-            let channel = msg.channel.as_deref().unwrap_or("");
             let recipient = msg.recipient.as_deref();
 
             // IMPORTANT: Check recipient FIRST before channel
@@ -133,12 +157,16 @@ impl HarmonyParserAdapter {
                     for content in &msg.content {
                         if let openai_harmony::chat::Content::Text(tc) = content {
                             let call_id = format!("call_{}", Uuid::now_v7());
+                            let arguments = Self::normalize_tool_arguments(
+                                &tc.text,
+                                msg.content_type.as_deref(),
+                            );
                             let tool_call = ToolCall {
                                 id: call_id,
                                 tool_type: "function".to_string(),
                                 function: FunctionCallResponse {
                                     name: function_name.to_string(),
-                                    arguments: Some(tc.text.clone()),
+                                    arguments: Some(arguments),
                                 },
                             };
 
@@ -174,8 +202,8 @@ impl HarmonyParserAdapter {
             }
 
             // Now process by channel (only if not already handled by recipient)
-            match channel {
-                "analysis" => {
+            match msg.channel.as_deref() {
+                Some("analysis") => {
                     // Process each content item
                     // For Chat API, we join them into a single reasoning_content
                     let text = Self::extract_text_from_content(&msg.content);
@@ -184,7 +212,7 @@ impl HarmonyParserAdapter {
                         analysis = Some(text);
                     }
                 }
-                "commentary" => {
+                Some("commentary") => {
                     // If we reach here, recipient was not "functions.*" or built-in tools
                     // Commentary channel should always have a recipient
                     // This is likely a model bug - log warning and treat as reasoning
@@ -206,15 +234,21 @@ impl HarmonyParserAdapter {
                         }
                     }
                 }
-                "final" => {
+                Some("final") => {
                     // Process final channel content
                     let text = Self::extract_text_from_content(&msg.content);
                     final_text.push_str(&text);
                 }
-                _ => {
-                    // Unknown channel, append to final text as fallback
-                    let text = Self::extract_text_from_content(&msg.content);
-                    final_text.push_str(&text);
+                None => {
+                    tracing::warn!(
+                        "Dropping Harmony message without a channel instead of treating it as final text"
+                    );
+                }
+                Some(channel) => {
+                    tracing::warn!(
+                        channel = channel,
+                        "Dropping Harmony message with unknown channel instead of treating it as final text"
+                    );
                 }
             }
         }
@@ -307,6 +341,7 @@ impl HarmonyParserAdapter {
         if content.is_empty() {
             return None;
         }
+        let arguments = Self::normalize_tool_arguments(&content, None);
 
         // Extract function name from recipient
         let Some(function_name) = recipient.strip_prefix("functions.") else {
@@ -321,7 +356,7 @@ impl HarmonyParserAdapter {
             tool_type: "function".to_string(),
             function: FunctionCallResponse {
                 name: function_name.to_string(),
-                arguments: Some(content),
+                arguments: Some(arguments),
             },
         };
 
@@ -377,10 +412,15 @@ impl HarmonyParserAdapter {
                             .get_or_insert_with(String::new)
                             .push_str(&delta_text);
                     }
-                    Some("final") | None => {
+                    Some("final") => {
                         final_delta
                             .get_or_insert_with(String::new)
                             .push_str(&delta_text);
+                    }
+                    None => {
+                        tracing::debug!(
+                            "Dropping Harmony streaming delta without a channel instead of treating it as final text"
+                        );
                     }
                     Some("commentary") => {
                         // Accumulate delta for commentary
@@ -521,5 +561,85 @@ impl Default for HarmonyParserAdapter {
     )]
     fn default() -> Self {
         Self::new().expect("Failed to create default parser")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use openai_harmony::chat::{Author, Content, Message, Role, TextContent};
+
+    use super::HarmonyParserAdapter;
+
+    #[test]
+    fn parse_messages_compacts_json_tool_arguments() {
+        let messages = vec![Message {
+            author: Author {
+                role: Role::Assistant,
+                name: None,
+            },
+            recipient: Some("functions.lookup_account_plan".to_string()),
+            content: vec![Content::Text(TextContent {
+                text: "{\n  \"account_id\": \"acct_123\",\n  \"items\": [\n    {\n      \"sku\": \"premium_addon\",\n      \"quantity\": 1\n    }\n  ],\n  \"amount\": \"12.34\"\n}".to_string(),
+            })],
+            channel: Some("commentary".to_string()),
+            content_type: Some("json".to_string()),
+        }];
+
+        let (_analysis, tool_calls, final_text) = HarmonyParserAdapter::parse_messages(&messages);
+        let tool_calls = tool_calls.expect("expected tool call");
+
+        assert!(final_text.is_empty());
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(
+            tool_calls[0].function.arguments.as_deref(),
+            Some(
+                "{\"account_id\":\"acct_123\",\"items\":[{\"sku\":\"premium_addon\",\"quantity\":1}],\"amount\":\"12.34\"}"
+            )
+        );
+    }
+
+    #[test]
+    fn parse_messages_preserves_malformed_json_tool_arguments() {
+        let messages = vec![Message {
+            author: Author {
+                role: Role::Assistant,
+                name: None,
+            },
+            recipient: Some("functions.echo".to_string()),
+            content: vec![Content::Text(TextContent {
+                text: "not json".to_string(),
+            })],
+            channel: Some("commentary".to_string()),
+            content_type: Some("json".to_string()),
+        }];
+
+        let (_analysis, tool_calls, _final_text) = HarmonyParserAdapter::parse_messages(&messages);
+        let tool_calls = tool_calls.expect("expected tool call");
+
+        assert_eq!(
+            tool_calls[0].function.arguments.as_deref(),
+            Some("not json")
+        );
+    }
+
+    #[test]
+    fn parse_messages_does_not_surface_channel_less_content_as_final_text() {
+        let messages = vec![Message {
+            author: Author {
+                role: Role::Assistant,
+                name: None,
+            },
+            recipient: None,
+            content: vec![Content::Text(TextContent {
+                text: "This should not become visible final content".to_string(),
+            })],
+            channel: None,
+            content_type: None,
+        }];
+
+        let (_analysis, tool_calls, final_text) = HarmonyParserAdapter::parse_messages(&messages);
+
+        assert!(tool_calls.is_none());
+        assert!(final_text.is_empty());
     }
 }

--- a/model_gateway/src/routers/grpc/harmony/parser.rs
+++ b/model_gateway/src/routers/grpc/harmony/parser.rs
@@ -599,7 +599,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_messages_preserves_malformed_json_tool_arguments() {
+    fn parse_messages_preserves_non_json_tool_arguments() {
         let messages = vec![Message {
             author: Author {
                 role: Role::Assistant,

--- a/model_gateway/src/routers/grpc/harmony/parser.rs
+++ b/model_gateway/src/routers/grpc/harmony/parser.rs
@@ -103,12 +103,12 @@ impl HarmonyParserAdapter {
                         final_text.push_str(&current_content);
                     }
                     None => {
-                        tracing::warn!(
+                        tracing::debug!(
                             "Dropping incomplete Harmony content without a channel instead of treating it as final text"
                         );
                     }
                     _ => {
-                        tracing::warn!(
+                        tracing::debug!(
                             channel = ?current_channel,
                             "Dropping incomplete Harmony content with unknown channel instead of treating it as final text"
                         );


### PR DESCRIPTION
## Description

### Problem

In GPT-OSS tool-calling flows through the SMG gRPC path, the request can succeed with HTTP 200 and `finish_reason="stop"`, but the final assistant message after a tool result can be malformed. The visible `message.content` may contain repeated fragments, invisible-character loops, or model self-repair / analysis-style text that should not be exposed as the final answer.

The same request shape did not reproduce through the native vLLM OpenAI HTTP path with the same vLLM version. That points to a transcript construction / parsing difference in the SMG gRPC path rather than a backend crash or transport error.

### Solution

This PR keeps the fix as a focused Harmony round-trip update. For the reproduced SMG+vLLM GPT-OSS failure mode, the changes address distinct parts of the broken tool round trip:

- Normalize JSON tool-call arguments so the assistant tool-call message carried into the next turn matches the compact OpenAI/vLLM-style shape.
- Mark Chat and Responses tool-result messages with the Harmony `commentary` channel so SMG does not feed GPT-OSS a channel-less tool result.
- Drop channel-less or unknown-channel parser residuals so malformed post-tool continuations do not escape as successful final text.

In failure-chain terms, non-canonical tool-call args plus a channel-less tool result can produce a malformed post-tool continuation, and the old parser could surface malformed residual text as normal final content. A separate `reasoning_effort` ablation did not affect this failure mode, so that change was removed.

I considered splitting these into smaller PRs. The latest leave-one-out testing shows argument normalization is required for the reproduced symptom, and earlier parser-side-only testing showed that parser fixes alone were not enough without the builder-side tool-result channel fix. Parser hardening is included as the response-boundary guard for the same malformed Harmony residual class; a follow-up leave-one-out run with argument normalization plus tool-result channeling passed 3/3 without that hardening, so I am open to splitting the hardening into a separate PR if maintainers prefer.

## Changes

- Add JSON argument normalization in the Harmony parser for assistant function calls and incomplete commentary tool calls.
- Preserve non-JSON or malformed argument strings unchanged.
- Set `channel="commentary"` on Chat and Responses tool-result messages.
- Drop channel-less or unknown-channel parser residuals instead of appending them to final text.
- Add targeted unit tests for parser normalization, parser hardening, and tool-result metadata.

## Test Plan

```bash
cargo +nightly fmt --all -- --check
cargo test -p smg --lib routers::grpc::harmony::parser::tests -- --nocapture
cargo test -p smg --lib routers::grpc::harmony::builder::tests -- --nocapture
```

Additional validation was run on an H100 node against GPT-OSS 120B served by vLLM gRPC:

- Unpatched SMG in front of vLLM gRPC reproduced the malformed post-tool final response in 7/7 runs.
- Direct vLLM OpenAI HTTP with the same vLLM version did not reproduce the failure in 7/7 runs.
- A replay ablation isolated JSON argument formatting as the strongest trigger: replaying SMG-style pretty JSON tool arguments failed 3/3, while compacting only `tool_calls[].function.arguments` passed 3/3.
- A `reasoning_effort`-only ablation failed 3/3 runs, so case-insensitive Chat reasoning-effort parsing is not included in this PR.
- An args-only patch still produced malformed or empty final output after the tool result.
- A parser-only patch still produced an unstable post-tool response, including one run that hit `finish_reason="length"` with a large leaked `reasoning_content`.
- The final PR patch without `reasoning_effort` normalization passed 3/3 runs using lowercase `reasoning_effort` input.
- A full-minus-argument-normalization patch reproduced malformed post-tool output, including invisible/non-breaking-space artifacts and self-analysis leakage.
- A full-minus-parser-hardening patch passed 3/3 in the same run, so parser hardening is treated as a response-boundary safety fix rather than a demonstrated requirement for this exact sampled repro.

Reproduction artifacts are intentionally not included in this public PR.

## Notes For Reviewers

The main behavior question is parser hardening: this PR drops channel-less or unknown-channel residual Harmony content instead of treating it as normal assistant final content. That is intentional because malformed Harmony residuals should not be exposed as a successful final answer.

The H100 ablations support argument normalization as the strongest trigger fix and tool-result `commentary` as part of transcript fidelity. Parser hardening is intentionally defensive: malformed channel-less or unknown-channel Harmony residuals should not be returned as successful final text, even if the prompt-side fixes prevent the sampled repro.
