### PR TITLE
feat(scheduler): engine — PriorityScheduler, admit, dispatcher (PR 2 M2b)

### DIFF
--- a/crates/auth/src/lib.rs
+++ b/crates/auth/src/lib.rs
@@ -24,5 +24,5 @@ pub use middleware::{
 /// This type can be added to request extensions to provide request IDs
 /// for audit logging. The middleware will extract this from request
 /// extensions if present.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct RequestId(pub String);

--- a/model_gateway/src/middleware/scheduler/engine.rs
+++ b/model_gateway/src/middleware/scheduler/engine.rs
@@ -1,0 +1,256 @@
+//! Priority-aware admission scheduler engine.
+//!
+//! Owns the [`SlotPool`], per-class [`ClassQueue`]s, and the inflight
+//! registry. Construction validates that the configured reservations
+//! fit under the live backend capacity; runtime admission lives in
+//! follow-on commits.
+
+use std::{collections::HashMap, sync::Arc};
+
+use parking_lot::RwLock;
+use smg_auth::RequestId;
+use thiserror::Error;
+use tokio::sync::Notify;
+
+use super::{
+    inflight::InflightHandle,
+    queue::{ClassQueue, FifoClassQueue},
+    slots::SlotPool,
+    Class, ClassRuntimeConfig, SchedulerSettings,
+};
+
+/// Construction-time failures for [`PriorityScheduler::new`].
+///
+/// Capacity-vs-reserved is the only invariant the scheduler can check —
+/// per-field validation already happened in
+/// [`SchedulerSettings::from_cli_and_yaml`].
+#[derive(Debug, Error, PartialEq)]
+pub enum SchedulerInitError {
+    #[error("sum of class reservations ({reserved}) exceeds capacity ({capacity})")]
+    ReservationsExceedCapacity { reserved: u32, capacity: u16 },
+}
+
+/// Priority-aware admission scheduler.
+///
+/// Construction wires up the slot pool, per-class queues, and an empty
+/// inflight registry. Admission / dispatch / capacity-watch land in
+/// follow-on commits; this commit exposes the read-only constructor
+/// plus an internal `acquire_inflight` so [`SchedulerPermit`] can be
+/// exercised against a real slot pool from tests.
+pub struct PriorityScheduler {
+    slot_pool: SlotPool,
+    #[expect(dead_code, reason = "consumed by admit and dispatcher")]
+    class_queues: [Arc<dyn ClassQueue>; 4],
+    inflight_registry: RwLock<HashMap<RequestId, Arc<InflightHandle>>>,
+    pub(super) release_notify: Notify,
+    #[expect(dead_code, reason = "consumed by admit and dispatcher")]
+    class_config: [ClassRuntimeConfig; 4],
+}
+
+impl PriorityScheduler {
+    /// Build a scheduler against the given settings and live backend
+    /// capacity. Refuses if the configured reservations sum to more than
+    /// the available capacity (the scheduler would otherwise lock itself
+    /// out of its own non-reserved classes).
+    pub fn new(
+        settings: &SchedulerSettings,
+        capacity: u16,
+    ) -> Result<Arc<Self>, SchedulerInitError> {
+        let total_reserved: u32 = Class::ALL
+            .iter()
+            .map(|c| u32::from(settings.class_config(*c).reserved))
+            .sum();
+        if total_reserved > u32::from(capacity) {
+            return Err(SchedulerInitError::ReservationsExceedCapacity {
+                reserved: total_reserved,
+                capacity,
+            });
+        }
+
+        let reserved_arr = Class::ALL.map(|c| settings.class_config(c).reserved);
+        let class_queues: [Arc<dyn ClassQueue>; 4] =
+            Class::ALL.map(|c| queue_for(settings, c, capacity));
+        let class_config: [ClassRuntimeConfig; 4] =
+            Class::ALL.map(|c| ClassRuntimeConfig::from_class_config(settings.class_config(c)));
+
+        Ok(Arc::new(Self {
+            slot_pool: SlotPool::new(capacity, reserved_arr),
+            class_queues,
+            inflight_registry: RwLock::new(HashMap::new()),
+            release_notify: Notify::new(),
+            class_config,
+        }))
+    }
+
+    /// Try to acquire a slot under `class` for the given request id.
+    /// Returns `Some(permit)` on success and `None` if the slot pool
+    /// refuses (e.g. capacity exhausted or reservation guard blocks the
+    /// class). The admission middleware's fast path calls this directly;
+    /// the queue / preempt paths layer on top in follow-on commits.
+    pub fn acquire_inflight(
+        self: &Arc<Self>,
+        class: Class,
+        request_id: RequestId,
+    ) -> Option<SchedulerPermit> {
+        if !self.slot_pool.try_acquire(class) {
+            return None;
+        }
+        let handle = Arc::new(InflightHandle::new(class, request_id));
+        self.inflight_registry
+            .write()
+            .insert(handle.request_id().clone(), Arc::clone(&handle));
+        Some(SchedulerPermit {
+            scheduler: Arc::clone(self),
+            handle,
+        })
+    }
+
+    /// Remove a handle from the registry, release its slot, and notify
+    /// the dispatcher. Called from [`SchedulerPermit`]'s `Drop`.
+    fn release_inflight(&self, handle: &InflightHandle) {
+        self.inflight_registry.write().remove(handle.request_id());
+        self.slot_pool.release(handle.class());
+        self.release_notify.notify_one();
+    }
+}
+
+/// Compute the effective per-class queue limit for a given backend
+/// capacity: `max(queue_size, ceil(queue_size_per_slot * capacity))`.
+fn queue_for(settings: &SchedulerSettings, class: Class, capacity: u16) -> Arc<dyn ClassQueue> {
+    let cfg = settings.class_config(class);
+    let multiplier = (cfg.queue_size_per_slot * f32::from(capacity)).ceil() as u32;
+    let limit = cfg.queue_size.max(multiplier) as usize;
+    Arc::new(FifoClassQueue::new(limit))
+}
+
+/// RAII handle on one admitted request. Holding a permit keeps the slot
+/// reserved; dropping it returns the slot, removes the handle from the
+/// inflight registry, and notifies the dispatcher.
+pub struct SchedulerPermit {
+    scheduler: Arc<PriorityScheduler>,
+    handle: Arc<InflightHandle>,
+}
+
+impl SchedulerPermit {
+    /// Borrow the underlying inflight handle (for TTFT marking and
+    /// preemption coordination in follow-on commits).
+    pub fn handle(&self) -> &Arc<InflightHandle> {
+        &self.handle
+    }
+}
+
+impl Drop for SchedulerPermit {
+    fn drop(&mut self) {
+        self.scheduler.release_inflight(&self.handle);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{sync::Arc, time::Duration};
+
+    use super::*;
+
+    fn default_settings() -> SchedulerSettings {
+        SchedulerSettings::from_cli_and_yaml(true, Class::Default, 32, None).unwrap()
+    }
+
+    fn rid(s: &str) -> RequestId {
+        RequestId(s.to_string())
+    }
+
+    #[test]
+    fn test_new_succeeds_when_reservations_fit() {
+        // Built-in defaults: Σ reserved = 128 (Interactive) + 32 (System) = 160.
+        let s = default_settings();
+        assert!(PriorityScheduler::new(&s, 256).is_ok());
+    }
+
+    #[test]
+    fn test_new_rejects_when_reservations_exceed_capacity() {
+        let s = default_settings();
+        let result = PriorityScheduler::new(&s, 100);
+        assert!(matches!(
+            result,
+            Err(SchedulerInitError::ReservationsExceedCapacity {
+                reserved: 160,
+                capacity: 100
+            })
+        ));
+    }
+
+    #[test]
+    fn test_acquire_returns_permit_when_slot_available() {
+        let s = default_settings();
+        let scheduler = PriorityScheduler::new(&s, 256).unwrap();
+        let permit = scheduler.acquire_inflight(Class::Default, rid("req-1"));
+        assert!(permit.is_some());
+    }
+
+    #[test]
+    fn test_acquire_returns_none_when_reservation_guard_blocks() {
+        // Capacity 200, reservations 160 (Interactive=128, System=32). Bulk
+        // is the lowest class so it gets capacity - 160 = 40 slots before
+        // the guard refuses further admissions.
+        let s = default_settings();
+        let scheduler = PriorityScheduler::new(&s, 200).unwrap();
+        let mut held = Vec::new();
+        for i in 0..40 {
+            held.push(
+                scheduler
+                    .acquire_inflight(Class::Bulk, rid(&format!("req-{i}")))
+                    .expect("under guard"),
+            );
+        }
+        assert!(scheduler
+            .acquire_inflight(Class::Bulk, rid("overflow"))
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn test_permit_drop_releases_slot_and_notifies_dispatcher() {
+        let s = default_settings();
+        let scheduler = PriorityScheduler::new(&s, 256).unwrap();
+        let permit = scheduler
+            .acquire_inflight(Class::Default, rid("req-1"))
+            .expect("admitted");
+        assert_eq!(scheduler.slot_pool.inflight(Class::Default), 1);
+
+        let notified = scheduler.release_notify.notified();
+        drop(permit);
+
+        assert_eq!(scheduler.slot_pool.inflight(Class::Default), 0);
+        tokio::time::timeout(Duration::from_millis(100), notified)
+            .await
+            .expect("release_notify fires on drop");
+    }
+
+    #[tokio::test]
+    async fn test_registry_inserts_on_acquire_and_removes_on_drop() {
+        let s = default_settings();
+        let scheduler = PriorityScheduler::new(&s, 256).unwrap();
+        let id = rid("req-1");
+        let permit = scheduler
+            .acquire_inflight(Class::Default, id.clone())
+            .expect("admitted");
+        assert!(scheduler.inflight_registry.read().contains_key(&id));
+        drop(permit);
+        assert!(!scheduler.inflight_registry.read().contains_key(&id));
+    }
+
+    #[tokio::test]
+    async fn test_permit_keeps_scheduler_alive_via_arc() {
+        let s = default_settings();
+        let scheduler = PriorityScheduler::new(&s, 256).unwrap();
+        let weak = Arc::downgrade(&scheduler);
+        let permit = scheduler
+            .acquire_inflight(Class::Default, rid("req-1"))
+            .expect("admitted");
+        drop(scheduler);
+        // Permit holds a strong ref, so weak still upgrades.
+        assert!(weak.upgrade().is_some());
+        drop(permit);
+        // All strong refs gone now.
+        assert!(weak.upgrade().is_none());
+    }
+}

--- a/model_gateway/src/middleware/scheduler/engine.rs
+++ b/model_gateway/src/middleware/scheduler/engine.rs
@@ -292,7 +292,7 @@ impl PriorityScheduler {
     /// scheduler alive past its last external strong reference. Drop
     /// on the scheduler fires `release_notify`, which lets the
     /// dispatcher observe the failed upgrade and exit.
-    pub fn spawn_dispatcher(self: &Arc<Self>, mut capacity_watch: watch::Receiver<u16>) {
+    pub fn spawn_dispatcher(self: &Arc<Self>, capacity_watch: watch::Receiver<u16>) {
         let weak = Arc::downgrade(self);
         let notify = Arc::clone(&self.release_notify);
         #[expect(
@@ -300,25 +300,38 @@ impl PriorityScheduler {
             reason = "dispatcher loop holds only a Weak<Self> and exits when the scheduler is dropped (Drop fires release_notify)"
         )]
         tokio::spawn(async move {
+            // `Option<watch::Receiver>` so we can drop the receiver once the
+            // upstream sender is closed. A bare `Receiver` whose sender is
+            // gone makes `changed()` resolve `Err` immediately on every
+            // poll — the `select!` would otherwise pick that arm forever
+            // and burn CPU.
+            let mut capacity_watch = Some(capacity_watch);
             loop {
-                tokio::select! {
-                    () = notify.notified() => {
-                        let Some(scheduler) = weak.upgrade() else { break };
-                        while scheduler.wake_next_waiter() {}
+                let new_capacity = match capacity_watch.as_mut() {
+                    Some(rx) => tokio::select! {
+                        () = notify.notified() => None,
+                        result = rx.changed() => match result {
+                            Ok(()) => Some(*rx.borrow()),
+                            Err(_) => {
+                                // Upstream sender dropped. Stop watching;
+                                // the dispatcher keeps serving release
+                                // events via the other arm.
+                                capacity_watch = None;
+                                continue;
+                            }
+                        },
+                    },
+                    None => {
+                        notify.notified().await;
+                        None
                     }
-                    changed = capacity_watch.changed() => {
-                        if changed.is_err() {
-                            // WorkerCapacity dropped its sender — keep
-                            // serving release events but stop watching
-                            // capacity. The next release_notify await
-                            // will drive us; if that channel is also
-                            // dead we'll exit via the Weak upgrade.
-                            continue;
-                        }
-                        let new_capacity = *capacity_watch.borrow();
-                        let Some(scheduler) = weak.upgrade() else { break };
-                        scheduler.apply_new_capacity(new_capacity);
-                    }
+                };
+                let Some(scheduler) = weak.upgrade() else {
+                    break;
+                };
+                match new_capacity {
+                    Some(new_cap) => scheduler.apply_new_capacity(new_cap),
+                    None => while scheduler.wake_next_waiter() {},
                 }
             }
         });
@@ -787,6 +800,37 @@ mod tests {
         let before = scheduler.slot_pool.reserved(Class::Interactive);
         scheduler.apply_new_capacity(256);
         assert_eq!(scheduler.slot_pool.reserved(Class::Interactive), before);
+    }
+
+    #[tokio::test]
+    async fn test_dispatcher_keeps_serving_after_capacity_watch_sender_drops() {
+        // After the WorkerCapacity sender is dropped, the dispatcher must
+        // continue handling release events from release_notify. The earlier
+        // implementation hot-looped on the closed watch arm; this test
+        // exercises the post-drop path end-to-end.
+        let s = settings_with(Class::Default, 8, 60);
+        let scheduler = PriorityScheduler::new(&s, 1).unwrap();
+        let (capacity_tx, capacity_rx) = watch::channel(1u16);
+        scheduler.spawn_dispatcher(capacity_rx);
+
+        drop(capacity_tx); // close the watch — the failing branch trigger.
+                           // Yield so the dispatcher observes the drop and disables that arm.
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        let held = scheduler
+            .acquire_inflight(Class::Default, rid("held"))
+            .unwrap();
+        let scheduler_for_admit = Arc::clone(&scheduler);
+        let admit_future = async move {
+            scheduler_for_admit
+                .admit(Class::Default, rid("queued"), CancellationToken::new())
+                .await
+        };
+        let (outcome, ()) = tokio::join!(admit_future, async move {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            drop(held);
+        });
+        assert!(matches!(outcome, AdmitOutcome::Admitted(_)));
     }
 
     #[tokio::test]

--- a/model_gateway/src/middleware/scheduler/engine.rs
+++ b/model_gateway/src/middleware/scheduler/engine.rs
@@ -65,8 +65,20 @@ pub struct PriorityScheduler {
     slot_pool: SlotPool,
     class_queues: [Arc<dyn ClassQueue>; 4],
     inflight_registry: RwLock<HashMap<RequestId, Arc<InflightHandle>>>,
-    pub(super) release_notify: Notify,
+    /// Arc so the dispatcher task can await on it without holding a strong
+    /// reference to the scheduler. On scheduler `Drop` we fire `notify_one`
+    /// so the dispatcher wakes, observes the failed `Weak::upgrade`, and
+    /// exits cleanly.
+    pub(super) release_notify: Arc<Notify>,
     class_config: [ClassRuntimeConfig; 4],
+}
+
+impl Drop for PriorityScheduler {
+    fn drop(&mut self) {
+        // Kick the dispatcher one last time so it can observe the Weak
+        // upgrade failure and exit instead of awaiting forever.
+        self.release_notify.notify_one();
+    }
 }
 
 impl PriorityScheduler {
@@ -99,7 +111,7 @@ impl PriorityScheduler {
             slot_pool: SlotPool::new(capacity, reserved_arr),
             class_queues,
             inflight_registry: RwLock::new(HashMap::new()),
-            release_notify: Notify::new(),
+            release_notify: Arc::new(Notify::new()),
             class_config,
         }))
     }
@@ -181,6 +193,110 @@ impl PriorityScheduler {
         self.inflight_registry.write().remove(handle.request_id());
         self.slot_pool.release(handle.class());
         self.release_notify.notify_one();
+    }
+
+    /// Try to admit one queued waiter. Returns `true` if a waiter was
+    /// successfully admitted (caller should call again to drain), `false`
+    /// if nothing was admittable this pass.
+    ///
+    /// Honors two policies in order:
+    /// 1. **Starvation override** — scans Bulk → Default → Interactive for
+    ///    a head waiter that has aged past its class's
+    ///    `starvation_threshold`. The first such waiter is admitted via
+    ///    `try_acquire_ignoring_reservations`, bypassing the reservation
+    ///    guard so a starved low-class waiter can take a slot that a
+    ///    higher class has reserved-but-not-used.
+    /// 2. **Normal priority** — System → Interactive → Default → Bulk.
+    ///    Each class's queue is drained one waiter at a time so the
+    ///    caller's outer loop can interleave drains across classes.
+    pub fn wake_next_waiter(self: &Arc<Self>) -> bool {
+        // Starvation override — lowest priority first (the ones most at
+        // risk of starving).
+        for class in [Class::Bulk, Class::Default, Class::Interactive] {
+            let idx = class as usize;
+            self.class_queues[idx].drop_cancelled_head();
+            let Some(head_age) = self.class_queues[idx].head_age() else {
+                continue;
+            };
+            if head_age <= self.class_config[idx].starvation_threshold {
+                continue;
+            }
+            if self.slot_pool.try_acquire_ignoring_reservations(class) {
+                if self.send_to_head(class) {
+                    return true;
+                }
+                // Acquired a slot but the head was gone (racy cancel).
+                // Release and fall through to normal priority.
+                self.slot_pool.release(class);
+            }
+        }
+
+        // Normal priority — highest class first.
+        for class in [
+            Class::System,
+            Class::Interactive,
+            Class::Default,
+            Class::Bulk,
+        ] {
+            let idx = class as usize;
+            self.class_queues[idx].drop_cancelled_head();
+            if self.class_queues[idx].depth() == 0 {
+                continue;
+            }
+            if self.slot_pool.try_acquire(class) {
+                if self.send_to_head(class) {
+                    return true;
+                }
+                self.slot_pool.release(class);
+            }
+        }
+
+        false
+    }
+
+    /// Pop the head waiter for `class` and deliver a permit through its
+    /// oneshot. Returns `false` if the queue was empty (race with a
+    /// cancellation that drained the head between the depth check and
+    /// the pop).
+    ///
+    /// The caller must have already acquired a slot under `class`.
+    fn send_to_head(self: &Arc<Self>, class: Class) -> bool {
+        let Some(Waiter {
+            request_id,
+            permit_tx,
+            ..
+        }) = self.class_queues[class as usize].pop_eligible()
+        else {
+            return false;
+        };
+        let permit = self.register_inflight(class, request_id);
+        // If the receiver was dropped, the permit goes out of scope here
+        // and its Drop releases the slot back. The dispatcher's outer
+        // loop will try another waiter on the next iteration.
+        let _ = permit_tx.send(permit);
+        true
+    }
+
+    /// Spawn the dispatcher background task. It awaits `release_notify`,
+    /// then drains as many queued waiters as the slot pool can accept,
+    /// then awaits again. Holds only a `Weak<Self>` so the task does not
+    /// keep the scheduler alive past its last external strong reference.
+    pub fn spawn_dispatcher(self: &Arc<Self>) {
+        let weak = Arc::downgrade(self);
+        let notify = Arc::clone(&self.release_notify);
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "dispatcher loop holds only a Weak<Self> and exits when the scheduler is dropped (Drop fires release_notify)"
+        )]
+        tokio::spawn(async move {
+            loop {
+                notify.notified().await;
+                let Some(scheduler) = weak.upgrade() else {
+                    break;
+                };
+                while scheduler.wake_next_waiter() {}
+            }
+        });
     }
 }
 
@@ -423,6 +539,134 @@ mod tests {
             outcome,
             AdmitOutcome::Rejected(RejectionReason::ClientCancelled)
         ));
+    }
+
+    // ── wake_next_waiter / dispatcher ───────────────────────────────
+
+    fn enqueue_waiter(
+        scheduler: &Arc<PriorityScheduler>,
+        class: Class,
+    ) -> oneshot::Receiver<SchedulerPermit> {
+        let (tx, rx) = oneshot::channel();
+        let waiter = Waiter::new(class, CancellationToken::new(), rid("queued"), tx);
+        scheduler.class_queues[class as usize]
+            .try_enqueue(waiter)
+            .expect("queue had room");
+        rx
+    }
+
+    #[test]
+    fn test_wake_next_waiter_returns_false_when_no_slot_available() {
+        let s = settings_with(Class::Default, 8, 60);
+        let scheduler = PriorityScheduler::new(&s, 1).unwrap();
+        let _held = scheduler
+            .acquire_inflight(Class::Default, rid("held"))
+            .unwrap();
+        let _rx = enqueue_waiter(&scheduler, Class::Default);
+        assert!(!scheduler.wake_next_waiter(), "no slot to give");
+    }
+
+    #[tokio::test]
+    async fn test_wake_next_waiter_admits_queued_waiter() {
+        let s = settings_with(Class::Default, 8, 60);
+        let scheduler = PriorityScheduler::new(&s, 1).unwrap();
+        let held = scheduler
+            .acquire_inflight(Class::Default, rid("held"))
+            .unwrap();
+        let mut rx = enqueue_waiter(&scheduler, Class::Default);
+        drop(held);
+        assert!(scheduler.wake_next_waiter());
+        let permit = rx.try_recv().expect("permit delivered");
+        assert_eq!(permit.handle().class(), Class::Default);
+    }
+
+    #[tokio::test]
+    async fn test_wake_next_waiter_honors_priority_order() {
+        // Interactive beats Bulk when both are queued and a slot frees.
+        let s = settings_with(Class::Bulk, 8, 60); // Bulk queue=8 (interactive defaults too)
+        let scheduler = PriorityScheduler::new(&s, 1).unwrap();
+        let held = scheduler
+            .acquire_inflight(Class::Default, rid("held"))
+            .unwrap();
+
+        let mut bulk_rx = enqueue_waiter(&scheduler, Class::Bulk);
+        let mut interactive_rx = enqueue_waiter(&scheduler, Class::Interactive);
+
+        drop(held);
+        assert!(scheduler.wake_next_waiter());
+        // Interactive should be served first; bulk still waiting.
+        assert!(interactive_rx.try_recv().is_ok());
+        assert!(bulk_rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn test_starvation_override_promotes_stale_bulk_head() {
+        // Bulk starvation_threshold=0s (anything older than 0 wins), with
+        // capacity entirely reserved by Interactive — without the
+        // override Bulk could never advance.
+        use std::collections::HashMap as StdMap;
+        let mut classes = StdMap::new();
+        for c in Class::ALL {
+            let mut cfg = ClassConfig::default_for(c);
+            cfg.reserved = 0;
+            // Set tiny starvation threshold for Bulk so an immediate
+            // enqueue is "stale" by the time wake fires.
+            if c == Class::Bulk {
+                cfg.starvation_threshold_secs = 1;
+                cfg.queue_size = 4;
+                cfg.queue_size_per_slot = 0.0;
+            }
+            // Interactive holds the full capacity in reservation.
+            if c == Class::Interactive {
+                cfg.reserved = 1;
+            }
+            classes.insert(c, cfg);
+        }
+        let yaml = PrioritySchedulerYaml {
+            classes,
+            tenant_policies: StdMap::new(),
+        };
+        let settings =
+            SchedulerSettings::from_cli_and_yaml(true, Class::Default, 32, Some(&yaml)).unwrap();
+
+        let scheduler = PriorityScheduler::new(&settings, 1).unwrap();
+        let mut bulk_rx = enqueue_waiter(&scheduler, Class::Bulk);
+
+        // Sleep past the starvation threshold so head_age > threshold.
+        tokio::time::sleep(Duration::from_millis(1100)).await;
+
+        // No regular path admits Bulk under the Interactive reservation,
+        // but the starvation override should.
+        assert!(scheduler.wake_next_waiter(), "starvation override fires");
+        assert!(bulk_rx.try_recv().is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_spawn_dispatcher_admits_queued_waiter_on_release() {
+        let s = settings_with(Class::Default, 8, 60);
+        let scheduler = PriorityScheduler::new(&s, 1).unwrap();
+        scheduler.spawn_dispatcher();
+
+        let held = scheduler
+            .acquire_inflight(Class::Default, rid("held"))
+            .unwrap();
+
+        // Kick off an admit that must go to the slow path.
+        let scheduler_for_admit = Arc::clone(&scheduler);
+        let admit_future = async move {
+            scheduler_for_admit
+                .admit(Class::Default, rid("queued"), CancellationToken::new())
+                .await
+        };
+
+        // Race: release the slot, then await admit. The dispatcher
+        // should observe the release and admit the queued waiter.
+        let (admit_outcome, ()) = tokio::join!(admit_future, async move {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            drop(held);
+        });
+
+        assert!(matches!(admit_outcome, AdmitOutcome::Admitted(_)));
     }
 
     #[tokio::test]

--- a/model_gateway/src/middleware/scheduler/engine.rs
+++ b/model_gateway/src/middleware/scheduler/engine.rs
@@ -10,8 +10,9 @@ use std::{collections::HashMap, sync::Arc};
 use parking_lot::RwLock;
 use smg_auth::RequestId;
 use thiserror::Error;
-use tokio::sync::{oneshot, Notify};
+use tokio::sync::{oneshot, watch, Notify};
 use tokio_util::sync::CancellationToken;
+use tracing::warn;
 
 use super::{
     inflight::InflightHandle,
@@ -277,11 +278,21 @@ impl PriorityScheduler {
         true
     }
 
-    /// Spawn the dispatcher background task. It awaits `release_notify`,
-    /// then drains as many queued waiters as the slot pool can accept,
-    /// then awaits again. Holds only a `Weak<Self>` so the task does not
-    /// keep the scheduler alive past its last external strong reference.
-    pub fn spawn_dispatcher(self: &Arc<Self>) {
+    /// Spawn the dispatcher background task. `select!`s over two
+    /// signals:
+    ///
+    /// - `release_notify` — slot was released (or a waiter enqueued
+    ///   via Drop-fire on scheduler shutdown). Drain queued waiters
+    ///   until none can be admitted.
+    /// - `capacity_watch.changed()` — backend capacity changed. Apply
+    ///   the new value (scaling reservations down if they no longer
+    ///   fit) and kick the drain.
+    ///
+    /// Holds only a `Weak<Self>` so the task does not keep the
+    /// scheduler alive past its last external strong reference. Drop
+    /// on the scheduler fires `release_notify`, which lets the
+    /// dispatcher observe the failed upgrade and exit.
+    pub fn spawn_dispatcher(self: &Arc<Self>, mut capacity_watch: watch::Receiver<u16>) {
         let weak = Arc::downgrade(self);
         let notify = Arc::clone(&self.release_notify);
         #[expect(
@@ -290,13 +301,64 @@ impl PriorityScheduler {
         )]
         tokio::spawn(async move {
             loop {
-                notify.notified().await;
-                let Some(scheduler) = weak.upgrade() else {
-                    break;
-                };
-                while scheduler.wake_next_waiter() {}
+                tokio::select! {
+                    () = notify.notified() => {
+                        let Some(scheduler) = weak.upgrade() else { break };
+                        while scheduler.wake_next_waiter() {}
+                    }
+                    changed = capacity_watch.changed() => {
+                        if changed.is_err() {
+                            // WorkerCapacity dropped its sender — keep
+                            // serving release events but stop watching
+                            // capacity. The next release_notify await
+                            // will drive us; if that channel is also
+                            // dead we'll exit via the Weak upgrade.
+                            continue;
+                        }
+                        let new_capacity = *capacity_watch.borrow();
+                        let Some(scheduler) = weak.upgrade() else { break };
+                        scheduler.apply_new_capacity(new_capacity);
+                    }
+                }
             }
         });
+    }
+
+    /// Apply a new backend capacity from the WorkerCapacity watch.
+    ///
+    /// On shrink past `Σ reserved`, scales reservations down
+    /// proportionally so the new capacity remains usable. On grow,
+    /// fires `release_notify` so the dispatcher re-evaluates queued
+    /// waiters under the larger ceiling.
+    fn apply_new_capacity(&self, new_capacity: u16) {
+        let old = self.slot_pool.set_capacity(new_capacity);
+        if new_capacity == old {
+            return;
+        }
+
+        let total_reserved: u32 = Class::ALL
+            .iter()
+            .map(|c| u32::from(self.slot_pool.reserved(*c)))
+            .sum();
+        if total_reserved > u32::from(new_capacity) && total_reserved > 0 {
+            let scale = f64::from(new_capacity) / f64::from(total_reserved as u16);
+            for class in Class::ALL {
+                let r = self.slot_pool.reserved(class);
+                let scaled = (f64::from(r) * scale).floor() as u16;
+                self.slot_pool.set_reserved(class, scaled);
+            }
+            warn!(
+                old_total_reserved = total_reserved,
+                new_capacity,
+                scale = scale,
+                "scheduler: reserved slots scaled down after capacity shrink"
+            );
+        }
+
+        if new_capacity > old {
+            // Capacity grew — wake the dispatcher to drain.
+            self.release_notify.notify_one();
+        }
     }
 }
 
@@ -641,11 +703,20 @@ mod tests {
         assert!(bulk_rx.try_recv().is_ok());
     }
 
+    fn dummy_capacity_watch(initial: u16) -> watch::Receiver<u16> {
+        // Construct a watch receiver whose sender is intentionally kept
+        // alive for the test's duration. Leaking is fine — these tests
+        // run in isolation.
+        let (tx, rx) = watch::channel(initial);
+        std::mem::forget(tx);
+        rx
+    }
+
     #[tokio::test]
     async fn test_spawn_dispatcher_admits_queued_waiter_on_release() {
         let s = settings_with(Class::Default, 8, 60);
         let scheduler = PriorityScheduler::new(&s, 1).unwrap();
-        scheduler.spawn_dispatcher();
+        scheduler.spawn_dispatcher(dummy_capacity_watch(1));
 
         let held = scheduler
             .acquire_inflight(Class::Default, rid("held"))
@@ -667,6 +738,84 @@ mod tests {
         });
 
         assert!(matches!(admit_outcome, AdmitOutcome::Admitted(_)));
+    }
+
+    // ── apply_new_capacity / capacity watch ─────────────────────────
+
+    #[test]
+    fn test_apply_new_capacity_grow_fires_release_notify() {
+        let s = default_settings();
+        let scheduler = PriorityScheduler::new(&s, 256).unwrap();
+        // Notify already has whatever permits prior tests fired; reset by
+        // taking a fresh notified() before the apply.
+        let notified = scheduler.release_notify.notified();
+        scheduler.apply_new_capacity(512);
+        assert_eq!(scheduler.slot_pool.capacity(), 512);
+        // Grow path must have signaled the dispatcher.
+        tokio::pin!(notified);
+        let polled = futures::FutureExt::now_or_never(notified);
+        assert!(polled.is_some(), "release_notify fires on capacity grow");
+    }
+
+    #[test]
+    fn test_apply_new_capacity_shrink_below_reserved_scales_reservations() {
+        // Built-in defaults: Interactive reserves 128, System reserves 32
+        // = 160 total. Shrink to 80; reservations should scale by 0.5 so
+        // the new sum fits.
+        let s = default_settings();
+        let scheduler = PriorityScheduler::new(&s, 256).unwrap();
+        scheduler.apply_new_capacity(80);
+        assert_eq!(scheduler.slot_pool.capacity(), 80);
+        let new_total: u32 = Class::ALL
+            .iter()
+            .map(|c| u32::from(scheduler.slot_pool.reserved(*c)))
+            .sum();
+        assert!(
+            new_total <= 80,
+            "scaled reservations ({new_total}) must fit under new capacity"
+        );
+        // Each individual class is also scaled down proportionally
+        // (floor rounding).
+        assert_eq!(scheduler.slot_pool.reserved(Class::Interactive), 64);
+        assert_eq!(scheduler.slot_pool.reserved(Class::System), 16);
+    }
+
+    #[test]
+    fn test_apply_new_capacity_no_op_when_value_unchanged() {
+        let s = default_settings();
+        let scheduler = PriorityScheduler::new(&s, 256).unwrap();
+        let before = scheduler.slot_pool.reserved(Class::Interactive);
+        scheduler.apply_new_capacity(256);
+        assert_eq!(scheduler.slot_pool.reserved(Class::Interactive), before);
+    }
+
+    #[tokio::test]
+    async fn test_capacity_watch_grow_drains_queue() {
+        // Capacity 1 (slot held), queue has one waiter. Grow capacity to
+        // 2 via the watch — dispatcher should drain the queued waiter.
+        let s = settings_with(Class::Default, 8, 60);
+        let scheduler = PriorityScheduler::new(&s, 1).unwrap();
+        let (tx, rx) = watch::channel(1u16);
+        scheduler.spawn_dispatcher(rx);
+
+        let _held = scheduler
+            .acquire_inflight(Class::Default, rid("held"))
+            .unwrap();
+
+        let scheduler_for_admit = Arc::clone(&scheduler);
+        let admit_future = async move {
+            scheduler_for_admit
+                .admit(Class::Default, rid("queued"), CancellationToken::new())
+                .await
+        };
+
+        let (outcome, ()) = tokio::join!(admit_future, async move {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            tx.send(2).unwrap();
+        });
+
+        assert!(matches!(outcome, AdmitOutcome::Admitted(_)));
+        assert_eq!(scheduler.slot_pool.capacity(), 2);
     }
 
     #[tokio::test]

--- a/model_gateway/src/middleware/scheduler/engine.rs
+++ b/model_gateway/src/middleware/scheduler/engine.rs
@@ -399,7 +399,14 @@ impl PriorityScheduler {
             .map(|c| u32::from(self.slot_pool.reserved(*c)))
             .sum();
         if total_reserved > u32::from(new_capacity) && total_reserved > 0 {
-            let scale = f64::from(new_capacity) / f64::from(total_reserved as u16);
+            // total_reserved is u32; converting via `as u16` would
+            // silently truncate any value > u16::MAX. Today the
+            // invariant `Σ reserved ≤ initial_capacity ≤ u16::MAX`
+            // holds (PriorityScheduler::new enforces it and this method
+            // only scales down), but the cast is fragile against future
+            // code paths that might increase a reservation. f64 holds
+            // u32 losslessly (53-bit mantissa > 32 bits).
+            let scale = f64::from(new_capacity) / f64::from(total_reserved);
             for class in Class::ALL {
                 let r = self.slot_pool.reserved(class);
                 let scaled = (f64::from(r) * scale).floor() as u16;

--- a/model_gateway/src/middleware/scheduler/engine.rs
+++ b/model_gateway/src/middleware/scheduler/engine.rs
@@ -164,9 +164,14 @@ impl PriorityScheduler {
             return AdmitOutcome::Admitted(permit);
         }
 
-        // Slow path: enqueue and wait.
+        // Slow path: enqueue and wait. The waiter holds a child cancel
+        // token of the caller's `cancel` so the queue's
+        // `drop_cancelled_head` GC sees the cancellation regardless of
+        // which select arm fires below — client cancel propagates via
+        // the parent, queue timeout fires the child explicitly.
         let (tx, rx) = oneshot::channel::<SchedulerPermit>();
-        let waiter = Waiter::new(class, cancel.clone(), request_id, tx);
+        let waiter_cancel = cancel.child_token();
+        let waiter = Waiter::new(class, waiter_cancel.clone(), request_id, tx);
         if self.class_queues[class as usize]
             .try_enqueue(waiter)
             .is_err()
@@ -175,7 +180,7 @@ impl PriorityScheduler {
         }
 
         let timeout = self.class_config[class as usize].queue_timeout;
-        tokio::select! {
+        let outcome = tokio::select! {
             result = rx => match result {
                 Ok(permit) => AdmitOutcome::Admitted(permit),
                 // The dispatcher dropped our sender without admitting us.
@@ -185,7 +190,13 @@ impl PriorityScheduler {
             },
             () = tokio::time::sleep(timeout) => AdmitOutcome::Rejected(RejectionReason::QueueTimeout),
             () = cancel.cancelled() => AdmitOutcome::Rejected(RejectionReason::ClientCancelled),
-        }
+        };
+
+        // Mark the waiter cancelled on any exit path so the queue's
+        // `drop_cancelled_head` reaps it. Harmless if the waiter was
+        // already popped (Admitted path) — the token has no other readers.
+        waiter_cancel.cancel();
+        outcome
     }
 
     /// Remove a handle from the registry, release its slot, and notify
@@ -594,6 +605,36 @@ mod tests {
             outcome,
             AdmitOutcome::Rejected(RejectionReason::QueueTimeout)
         ));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_admit_timeout_marks_waiter_for_gc() {
+        // After QueueTimeout fires, the Waiter still sits in the FIFO
+        // until something reaps it. The cancel token on the Waiter must
+        // be fired so a future drop_cancelled_head call evicts it,
+        // preventing false QueueFull on later admissions.
+        let s = settings_with(Class::Default, 16, 1);
+        let scheduler = PriorityScheduler::new(&s, 1).unwrap();
+        let _held = scheduler
+            .acquire_inflight(Class::Default, rid("held"))
+            .expect("admitted directly");
+
+        let outcome = scheduler
+            .admit(Class::Default, rid("w1"), CancellationToken::new())
+            .await;
+        assert!(matches!(
+            outcome,
+            AdmitOutcome::Rejected(RejectionReason::QueueTimeout)
+        ));
+
+        // The waiter is still in the queue (one entry), but cancelled.
+        assert_eq!(scheduler.class_queues[Class::Default as usize].depth(), 1);
+        scheduler.class_queues[Class::Default as usize].drop_cancelled_head();
+        assert_eq!(
+            scheduler.class_queues[Class::Default as usize].depth(),
+            0,
+            "drop_cancelled_head must reap the timed-out waiter"
+        );
     }
 
     #[tokio::test]

--- a/model_gateway/src/middleware/scheduler/engine.rs
+++ b/model_gateway/src/middleware/scheduler/engine.rs
@@ -10,11 +10,12 @@ use std::{collections::HashMap, sync::Arc};
 use parking_lot::RwLock;
 use smg_auth::RequestId;
 use thiserror::Error;
-use tokio::sync::Notify;
+use tokio::sync::{oneshot, Notify};
+use tokio_util::sync::CancellationToken;
 
 use super::{
     inflight::InflightHandle,
-    queue::{ClassQueue, FifoClassQueue},
+    queue::{ClassQueue, FifoClassQueue, Waiter},
     slots::SlotPool,
     Class, ClassRuntimeConfig, SchedulerSettings,
 };
@@ -30,6 +31,29 @@ pub enum SchedulerInitError {
     ReservationsExceedCapacity { reserved: u32, capacity: u16 },
 }
 
+/// Outcome of an [`PriorityScheduler::admit`] call.
+pub enum AdmitOutcome {
+    Admitted(SchedulerPermit),
+    Rejected(RejectionReason),
+}
+
+/// Why an admission was rejected. Maps directly to the HTTP response
+/// status in the admission middleware.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RejectionReason {
+    /// Per-class queue is at its configured limit. → 429.
+    QueueFull,
+    /// Queued waiter aged past `queue_timeout`. → 408.
+    QueueTimeout,
+    /// Scheduler cancelled this inflight to admit a higher-priority
+    /// waiter. → 503 + Retry-After. Lands in a later commit.
+    Preempted,
+    /// The caller's cancellation token fired before admission completed
+    /// (typically the HTTP client disconnected). Never serialized — the
+    /// client is already gone.
+    ClientCancelled,
+}
+
 /// Priority-aware admission scheduler.
 ///
 /// Construction wires up the slot pool, per-class queues, and an empty
@@ -39,11 +63,9 @@ pub enum SchedulerInitError {
 /// exercised against a real slot pool from tests.
 pub struct PriorityScheduler {
     slot_pool: SlotPool,
-    #[expect(dead_code, reason = "consumed by admit and dispatcher")]
     class_queues: [Arc<dyn ClassQueue>; 4],
     inflight_registry: RwLock<HashMap<RequestId, Arc<InflightHandle>>>,
     pub(super) release_notify: Notify,
-    #[expect(dead_code, reason = "consumed by admit and dispatcher")]
     class_config: [ClassRuntimeConfig; 4],
 }
 
@@ -95,14 +117,62 @@ impl PriorityScheduler {
         if !self.slot_pool.try_acquire(class) {
             return None;
         }
+        Some(self.register_inflight(class, request_id))
+    }
+
+    /// Register a handle in the registry and wrap it in a permit.
+    /// Caller already acquired a slot via the pool.
+    fn register_inflight(self: &Arc<Self>, class: Class, request_id: RequestId) -> SchedulerPermit {
         let handle = Arc::new(InflightHandle::new(class, request_id));
         self.inflight_registry
             .write()
             .insert(handle.request_id().clone(), Arc::clone(&handle));
-        Some(SchedulerPermit {
+        SchedulerPermit {
             scheduler: Arc::clone(self),
             handle,
-        })
+        }
+    }
+
+    /// Admit a request under `class`. Tries the fast path first; if the
+    /// slot pool refuses, enqueues a waiter and awaits the dispatcher
+    /// (or a queue timeout, or a client-side cancel).
+    ///
+    /// The `cancel` token is monitored for the duration of the wait —
+    /// fires it to short-circuit a queued admission when the client
+    /// disconnects.
+    pub async fn admit(
+        self: &Arc<Self>,
+        class: Class,
+        request_id: RequestId,
+        cancel: CancellationToken,
+    ) -> AdmitOutcome {
+        // Fast path: slot available, admit synchronously.
+        if let Some(permit) = self.acquire_inflight(class, request_id.clone()) {
+            return AdmitOutcome::Admitted(permit);
+        }
+
+        // Slow path: enqueue and wait.
+        let (tx, rx) = oneshot::channel::<SchedulerPermit>();
+        let waiter = Waiter::new(class, cancel.clone(), request_id, tx);
+        if self.class_queues[class as usize]
+            .try_enqueue(waiter)
+            .is_err()
+        {
+            return AdmitOutcome::Rejected(RejectionReason::QueueFull);
+        }
+
+        let timeout = self.class_config[class as usize].queue_timeout;
+        tokio::select! {
+            result = rx => match result {
+                Ok(permit) => AdmitOutcome::Admitted(permit),
+                // The dispatcher dropped our sender without admitting us.
+                // Treat as a cancellation rather than a timeout — the
+                // dispatcher only drops if it knows we no longer need a slot.
+                Err(_) => AdmitOutcome::Rejected(RejectionReason::ClientCancelled),
+            },
+            () = tokio::time::sleep(timeout) => AdmitOutcome::Rejected(RejectionReason::QueueTimeout),
+            () = cancel.cancelled() => AdmitOutcome::Rejected(RejectionReason::ClientCancelled),
+        }
     }
 
     /// Remove a handle from the registry, release its slot, and notify
@@ -139,6 +209,17 @@ impl SchedulerPermit {
     }
 }
 
+impl std::fmt::Debug for SchedulerPermit {
+    // Hand-rolled to avoid recursing into Arc<PriorityScheduler>, which
+    // doesn't itself derive Debug (it contains atomics and a Notify).
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SchedulerPermit")
+            .field("class", &self.handle.class())
+            .field("request_id", self.handle.request_id())
+            .finish()
+    }
+}
+
 impl Drop for SchedulerPermit {
     fn drop(&mut self) {
         self.scheduler.release_inflight(&self.handle);
@@ -150,6 +231,7 @@ mod tests {
     use std::{sync::Arc, time::Duration};
 
     use super::*;
+    use crate::middleware::scheduler::{ClassConfig, PrioritySchedulerYaml};
 
     fn default_settings() -> SchedulerSettings {
         SchedulerSettings::from_cli_and_yaml(true, Class::Default, 32, None).unwrap()
@@ -236,6 +318,111 @@ mod tests {
         assert!(scheduler.inflight_registry.read().contains_key(&id));
         drop(permit);
         assert!(!scheduler.inflight_registry.read().contains_key(&id));
+    }
+
+    // ── admit ────────────────────────────────────────────────────────
+
+    /// Build settings with zero reservations on every class (so we can
+    /// run admit tests against small capacities without tripping the
+    /// reserved-vs-capacity guard) and an override on one class's
+    /// queue_size + queue_timeout.
+    fn settings_with(class: Class, queue_size: u32, queue_timeout_secs: u64) -> SchedulerSettings {
+        use std::collections::HashMap as StdMap;
+
+        let mut classes = StdMap::new();
+        for c in Class::ALL {
+            let mut cfg = ClassConfig::default_for(c);
+            cfg.reserved = 0;
+            if c == class {
+                cfg.queue_size = queue_size;
+                cfg.queue_size_per_slot = 0.0;
+                cfg.queue_timeout_secs = queue_timeout_secs;
+            }
+            classes.insert(c, cfg);
+        }
+        let yaml = PrioritySchedulerYaml {
+            classes,
+            tenant_policies: StdMap::new(),
+        };
+        SchedulerSettings::from_cli_and_yaml(true, Class::Default, 32, Some(&yaml)).unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_admit_fast_path_when_slot_available() {
+        let s = default_settings();
+        let scheduler = PriorityScheduler::new(&s, 256).unwrap();
+        let outcome = scheduler
+            .admit(Class::Default, rid("req-1"), CancellationToken::new())
+            .await;
+        assert!(matches!(outcome, AdmitOutcome::Admitted(_)));
+    }
+
+    #[tokio::test]
+    async fn test_admit_rejects_when_queue_full() {
+        // Capacity 1 (slot held), Default queue_size=1 (one waiter pre-stuffed
+        // directly into the queue): the next admit takes the slow path and
+        // hits a full queue.
+        let s = settings_with(Class::Default, 1, 60);
+        let scheduler = PriorityScheduler::new(&s, 1).unwrap();
+        let _held = scheduler
+            .acquire_inflight(Class::Default, rid("held"))
+            .expect("admitted directly");
+
+        let (queued_tx, _queued_rx) = oneshot::channel();
+        let queued = Waiter::new(
+            Class::Default,
+            CancellationToken::new(),
+            rid("queued"),
+            queued_tx,
+        );
+        scheduler.class_queues[Class::Default as usize]
+            .try_enqueue(queued)
+            .expect("queue had room for one");
+
+        let outcome = scheduler
+            .admit(Class::Default, rid("w2"), CancellationToken::new())
+            .await;
+        assert!(matches!(
+            outcome,
+            AdmitOutcome::Rejected(RejectionReason::QueueFull)
+        ));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_admit_rejects_on_queue_timeout() {
+        // Capacity 1 forces enqueue; queue_timeout=1s; never release → QueueTimeout.
+        let s = settings_with(Class::Default, 16, 1);
+        let scheduler = PriorityScheduler::new(&s, 1).unwrap();
+        let _held = scheduler
+            .acquire_inflight(Class::Default, rid("held"))
+            .expect("admitted directly");
+
+        let admit_future = scheduler.admit(Class::Default, rid("w1"), CancellationToken::new());
+        let outcome = admit_future.await;
+        assert!(matches!(
+            outcome,
+            AdmitOutcome::Rejected(RejectionReason::QueueTimeout)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_admit_rejects_on_client_cancel() {
+        // Pre-cancel the token before admit is called; the fast path fails
+        // (slot held), the slow path enqueues, then the cancel arm of select!
+        // fires immediately.
+        let s = settings_with(Class::Default, 16, 60);
+        let scheduler = PriorityScheduler::new(&s, 1).unwrap();
+        let _held = scheduler
+            .acquire_inflight(Class::Default, rid("held"))
+            .expect("admitted directly");
+
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+        let outcome = scheduler.admit(Class::Default, rid("w1"), cancel).await;
+        assert!(matches!(
+            outcome,
+            AdmitOutcome::Rejected(RejectionReason::ClientCancelled)
+        ));
     }
 
     #[tokio::test]

--- a/model_gateway/src/middleware/scheduler/engine.rs
+++ b/model_gateway/src/middleware/scheduler/engine.rs
@@ -275,26 +275,37 @@ impl PriorityScheduler {
     }
 
     /// Pop the head waiter for `class` and deliver a permit through its
-    /// oneshot. Returns `false` if the queue was empty (race with a
-    /// cancellation that drained the head between the depth check and
-    /// the pop).
+    /// oneshot. Drains waiters whose receivers have already been
+    /// dropped (admit timed out / client cancelled between pop and send)
+    /// without performing the wasted `register_inflight` + immediate
+    /// release for each. Returns `false` if the queue is exhausted
+    /// without finding a live waiter.
     ///
     /// The caller must have already acquired a slot under `class`.
     fn send_to_head(self: &Arc<Self>, class: Class) -> bool {
-        let Some(Waiter {
-            request_id,
-            permit_tx,
-            ..
-        }) = self.class_queues[class as usize].pop_eligible()
-        else {
-            return false;
-        };
-        let permit = self.register_inflight(class, request_id);
-        // If the receiver was dropped, the permit goes out of scope here
-        // and its Drop releases the slot back. The dispatcher's outer
-        // loop will try another waiter on the next iteration.
-        let _ = permit_tx.send(permit);
-        true
+        loop {
+            let Some(Waiter {
+                request_id,
+                permit_tx,
+                ..
+            }) = self.class_queues[class as usize].pop_eligible()
+            else {
+                return false;
+            };
+            if permit_tx.is_closed() {
+                // Receiver gone — skip the registry write and the
+                // matched permit-drop release. Try the next waiter
+                // using the same slot we already acquired.
+                continue;
+            }
+            let permit = self.register_inflight(class, request_id);
+            // If the receiver was dropped between is_closed() above and
+            // send below (unlikely race window), the permit goes out of
+            // scope and its Drop releases the slot back; the caller's
+            // outer loop will try again.
+            let _ = permit_tx.send(permit);
+            return true;
+        }
     }
 
     /// Spawn the dispatcher background task. `select!`s over two
@@ -692,6 +703,55 @@ mod tests {
             .try_enqueue(waiter)
             .expect("queue had room");
         rx
+    }
+
+    #[tokio::test]
+    async fn test_send_to_head_skips_waiters_with_closed_receivers() {
+        // Stuff a queue with one waiter whose receiver is dropped (admit
+        // has already timed out / been cancelled) followed by a live
+        // waiter. wake_next_waiter should admit the live waiter without
+        // touching the inflight registry for the dead one.
+        let s = settings_with(Class::Default, 8, 60);
+        let scheduler = PriorityScheduler::new(&s, 1).unwrap();
+        let _held = scheduler
+            .acquire_inflight(Class::Default, rid("held"))
+            .unwrap();
+
+        // Dead waiter — drop the receiver immediately.
+        let (dead_tx, dead_rx) = oneshot::channel::<SchedulerPermit>();
+        drop(dead_rx);
+        let dead = Waiter::new(
+            Class::Default,
+            CancellationToken::new(),
+            rid("dead"),
+            dead_tx,
+        );
+        scheduler.class_queues[Class::Default as usize]
+            .try_enqueue(dead)
+            .unwrap();
+
+        // Live waiter.
+        let (live_tx, mut live_rx) = oneshot::channel::<SchedulerPermit>();
+        let live = Waiter::new(
+            Class::Default,
+            CancellationToken::new(),
+            rid("live"),
+            live_tx,
+        );
+        scheduler.class_queues[Class::Default as usize]
+            .try_enqueue(live)
+            .unwrap();
+
+        // Release the slot.
+        drop(_held);
+        assert!(scheduler.wake_next_waiter(), "live waiter admitted");
+
+        let permit = live_rx.try_recv().expect("live permit delivered");
+        assert_eq!(permit.handle().request_id().0, "live");
+        // Registry should hold only the live request — never the dead one.
+        let registry = scheduler.inflight_registry.read();
+        assert!(registry.contains_key(&rid("live")));
+        assert!(!registry.contains_key(&rid("dead")));
     }
 
     #[test]

--- a/model_gateway/src/middleware/scheduler/engine.rs
+++ b/model_gateway/src/middleware/scheduler/engine.rs
@@ -204,6 +204,12 @@ impl PriorityScheduler {
         // `drop_cancelled_head` reaps it. Harmless if the waiter was
         // already popped (Admitted path) — the token has no other readers.
         waiter_cancel.cancel();
+        // Kick the dispatcher so head GC runs promptly. Without this,
+        // a `queue_size = 1` queue could reject the *next* admit as
+        // QueueFull for up to one full periodic tick (5s on defaults)
+        // even though the head waiter has already timed out / been
+        // cancelled.
+        self.release_notify.notify_one();
         outcome
     }
 
@@ -646,6 +652,36 @@ mod tests {
             outcome,
             AdmitOutcome::Rejected(RejectionReason::QueueTimeout)
         ));
+    }
+
+    #[tokio::test]
+    async fn test_admit_timeout_kicks_dispatcher_to_reap_stale_head() {
+        // After admit timeout marks the queued waiter cancelled, the
+        // dispatcher must be nudged so drop_cancelled_head runs
+        // promptly — otherwise a queue_size=1 queue would reject the
+        // next admit as QueueFull until the next periodic tick.
+        let s = settings_with(Class::Default, 1, 1); // queue_size=1, timeout=1s
+        let scheduler = PriorityScheduler::new(&s, 1).unwrap();
+        scheduler.spawn_dispatcher(dummy_capacity_watch(1));
+        let _held = scheduler
+            .acquire_inflight(Class::Default, rid("held"))
+            .unwrap();
+
+        let outcome = scheduler
+            .admit(Class::Default, rid("w1"), CancellationToken::new())
+            .await;
+        assert!(matches!(
+            outcome,
+            AdmitOutcome::Rejected(RejectionReason::QueueTimeout)
+        ));
+
+        // Let the dispatcher's notify_one wakeup run drop_cancelled_head.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(
+            scheduler.class_queues[Class::Default as usize].depth(),
+            0,
+            "dispatcher should reap the cancelled head promptly"
+        );
     }
 
     #[tokio::test(start_paused = true)]

--- a/model_gateway/src/middleware/scheduler/engine.rs
+++ b/model_gateway/src/middleware/scheduler/engine.rs
@@ -179,6 +179,14 @@ impl PriorityScheduler {
             return AdmitOutcome::Rejected(RejectionReason::QueueFull);
         }
 
+        // Lost-wakeup guard: a slot may have been released after our
+        // fast-path try_acquire failed but before try_enqueue returned.
+        // That `notify_one` already fired and the dispatcher already
+        // drained — without an extra nudge here, our newly-queued waiter
+        // would sit behind a now-free slot until the next unrelated
+        // release event. Re-kick the dispatcher to re-evaluate.
+        self.release_notify.notify_one();
+
         let timeout = self.class_config[class as usize].queue_timeout;
         let outcome = tokio::select! {
             result = rx => match result {
@@ -306,6 +314,15 @@ impl PriorityScheduler {
     pub fn spawn_dispatcher(self: &Arc<Self>, capacity_watch: watch::Receiver<u16>) {
         let weak = Arc::downgrade(self);
         let notify = Arc::clone(&self.release_notify);
+        // Periodic tick so the starvation override can fire even when no
+        // release events arrive. Set to the smallest per-class
+        // starvation_threshold so a head waiter never ages past its
+        // threshold by more than ~one tick before the dispatcher checks.
+        let tick_period = Class::ALL
+            .iter()
+            .map(|c| self.class_config[*c as usize].starvation_threshold)
+            .min()
+            .unwrap_or(std::time::Duration::from_secs(60));
         #[expect(
             clippy::disallowed_methods,
             reason = "dispatcher loop holds only a Weak<Self> and exits when the scheduler is dropped (Drop fires release_notify)"
@@ -317,10 +334,13 @@ impl PriorityScheduler {
             // poll — the `select!` would otherwise pick that arm forever
             // and burn CPU.
             let mut capacity_watch = Some(capacity_watch);
+            let mut tick = tokio::time::interval(tick_period);
+            tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
             loop {
                 let new_capacity = match capacity_watch.as_mut() {
                     Some(rx) => tokio::select! {
                         () = notify.notified() => None,
+                        _ = tick.tick() => None,
                         result = rx.changed() => match result {
                             Ok(()) => Some(*rx.borrow()),
                             Err(_) => {
@@ -333,7 +353,10 @@ impl PriorityScheduler {
                         },
                     },
                     None => {
-                        notify.notified().await;
+                        tokio::select! {
+                            () = notify.notified() => {}
+                            _ = tick.tick() => {}
+                        }
                         None
                     }
                 };
@@ -713,6 +736,50 @@ mod tests {
         // Interactive should be served first; bulk still waiting.
         assert!(interactive_rx.try_recv().is_ok());
         assert!(bulk_rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn test_dispatcher_periodic_tick_promotes_stale_waiter_without_release() {
+        // No slot release ever fires. The dispatcher's periodic tick
+        // must wake on its own, observe that the Bulk head has aged
+        // past its starvation_threshold, and admit via the override.
+        use std::collections::HashMap as StdMap;
+        let mut classes = StdMap::new();
+        for c in Class::ALL {
+            let mut cfg = ClassConfig::default_for(c);
+            cfg.reserved = 0;
+            // Tight thresholds so the test runs fast.
+            cfg.starvation_threshold_secs = 1;
+            if c == Class::Bulk {
+                cfg.queue_size = 4;
+                cfg.queue_size_per_slot = 0.0;
+            }
+            // Interactive reserves the entire capacity, locking Bulk out
+            // of the normal-priority admission path.
+            if c == Class::Interactive {
+                cfg.reserved = 1;
+            }
+            classes.insert(c, cfg);
+        }
+        let yaml = PrioritySchedulerYaml {
+            classes,
+            tenant_policies: StdMap::new(),
+        };
+        let settings =
+            SchedulerSettings::from_cli_and_yaml(true, Class::Default, 32, Some(&yaml)).unwrap();
+        let scheduler = PriorityScheduler::new(&settings, 1).unwrap();
+        scheduler.spawn_dispatcher(dummy_capacity_watch(1));
+
+        // Admit a Bulk request. No slot release ever fires; the only way
+        // for it to be admitted is the dispatcher's periodic tick + the
+        // starvation override.
+        let outcome = tokio::time::timeout(
+            Duration::from_secs(3),
+            scheduler.admit(Class::Bulk, rid("bulk"), CancellationToken::new()),
+        )
+        .await
+        .expect("admit completes within timeout");
+        assert!(matches!(outcome, AdmitOutcome::Admitted(_)));
     }
 
     #[tokio::test]

--- a/model_gateway/src/middleware/scheduler/inflight.rs
+++ b/model_gateway/src/middleware/scheduler/inflight.rs
@@ -25,6 +25,7 @@ use super::Class;
 /// `try_mark_first_byte` clamps `now_ms` to `[1, u64::MAX - 1]` so a
 /// TTFT measurement can never collide with either the unset state or
 /// the preempt sentinel.
+#[derive(Debug)]
 pub struct InflightHandle {
     class: Class,
     request_id: RequestId,

--- a/model_gateway/src/middleware/scheduler/inflight.rs
+++ b/model_gateway/src/middleware/scheduler/inflight.rs
@@ -2,6 +2,10 @@
 
 use std::sync::atomic::{AtomicU64, Ordering};
 
+use smg_auth::RequestId;
+
+use super::Class;
+
 /// Tracks a single admitted request from admission until its response body
 /// finishes draining (or the scheduler preempts it).
 ///
@@ -22,6 +26,8 @@ use std::sync::atomic::{AtomicU64, Ordering};
 /// TTFT measurement can never collide with either the unset state or
 /// the preempt sentinel.
 pub struct InflightHandle {
+    class: Class,
+    request_id: RequestId,
     first_byte_at: AtomicU64,
 }
 
@@ -30,10 +36,26 @@ impl InflightHandle {
     /// this request for preemption.
     const PREEMPTED_SENTINEL: u64 = u64::MAX;
 
-    pub fn new() -> Self {
+    /// Construct a handle for a freshly admitted request. The scheduler
+    /// inserts the resulting `Arc<Self>` into its inflight registry, keyed
+    /// by `request_id`, so per-class iteration (preemption, metrics)
+    /// can find it.
+    pub fn new(class: Class, request_id: RequestId) -> Self {
         Self {
+            class,
+            request_id,
             first_byte_at: AtomicU64::new(0),
         }
+    }
+
+    /// Class this admission consumed a slot under.
+    pub fn class(&self) -> Class {
+        self.class
+    }
+
+    /// Request id this handle tracks (registry key).
+    pub fn request_id(&self) -> &RequestId {
+        &self.request_id
     }
 
     /// Attempt to mark this request as preempted. Returns `true` on the
@@ -79,21 +101,19 @@ impl InflightHandle {
     }
 }
 
-impl Default for InflightHandle {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::sync::atomic::Ordering;
 
     use super::*;
 
+    fn handle() -> InflightHandle {
+        InflightHandle::new(Class::Default, RequestId("test".to_string()))
+    }
+
     #[test]
     fn test_try_mark_preempted_succeeds_then_fails() {
-        let handle = InflightHandle::new();
+        let handle = handle();
         assert!(
             handle.try_mark_preempted(),
             "first preempt CAS should succeed"
@@ -106,7 +126,7 @@ mod tests {
 
     #[test]
     fn test_try_mark_preempted_stores_sentinel() {
-        let handle = InflightHandle::new();
+        let handle = handle();
         handle.try_mark_preempted();
         assert_eq!(
             handle.first_byte_at_raw(Ordering::Acquire),
@@ -117,7 +137,7 @@ mod tests {
 
     #[test]
     fn test_try_mark_first_byte_succeeds_then_fails() {
-        let handle = InflightHandle::new();
+        let handle = handle();
         assert!(
             handle.try_mark_first_byte(42),
             "first TTFT CAS should succeed"
@@ -130,7 +150,7 @@ mod tests {
 
     #[test]
     fn test_ttft_loses_race_against_preempt() {
-        let handle = InflightHandle::new();
+        let handle = handle();
         assert!(handle.try_mark_preempted());
         assert!(
             !handle.try_mark_first_byte(5),
@@ -140,7 +160,7 @@ mod tests {
 
     #[test]
     fn test_preempt_loses_race_against_ttft() {
-        let handle = InflightHandle::new();
+        let handle = handle();
         assert!(handle.try_mark_first_byte(5));
         assert!(
             !handle.try_mark_preempted(),
@@ -153,14 +173,14 @@ mod tests {
         // u64::MAX is the preempt sentinel; a TTFT measurement that happens
         // to equal that value would falsely appear as "preempted" to any
         // reader. Clamp to u64::MAX - 1.
-        let handle = InflightHandle::new();
+        let handle = handle();
         assert!(handle.try_mark_first_byte(u64::MAX));
         assert_eq!(handle.first_byte_at_raw(Ordering::Acquire), u64::MAX - 1);
     }
 
     #[test]
     fn test_initial_state_is_zero() {
-        let handle = InflightHandle::new();
+        let handle = handle();
         assert_eq!(handle.first_byte_at_raw(Ordering::Acquire), 0);
     }
 
@@ -170,7 +190,7 @@ mod tests {
         // admission) must not write 0 into first_byte_at. If it did, a
         // subsequent try_mark_preempted would see the "unset" sentinel
         // and succeed, breaking mutual exclusion.
-        let handle = InflightHandle::new();
+        let handle = handle();
         assert!(handle.try_mark_first_byte(0), "first call must succeed");
         assert!(
             handle.first_byte_at_raw(Ordering::Acquire) != 0,

--- a/model_gateway/src/middleware/scheduler/mod.rs
+++ b/model_gateway/src/middleware/scheduler/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod class;
 pub mod config;
+pub mod engine;
 pub mod inflight;
 pub mod policy;
 pub mod queue;
@@ -12,4 +13,5 @@ pub use config::{
     ClassConfig, ClassRuntimeConfig, PrioritySchedulerYaml, SchedulerSettings,
     SettingsValidationError, TenantPolicyConfig,
 };
+pub use engine::{PriorityScheduler, SchedulerInitError, SchedulerPermit};
 pub use policy::{StaticTenantPolicyResolver, TenantPolicy, TenantPolicyResolver};

--- a/model_gateway/src/middleware/scheduler/queue.rs
+++ b/model_gateway/src/middleware/scheduler/queue.rs
@@ -1,4 +1,4 @@
-//! Per-class waiter queue used by [`super::scheduler`] to hold admission
+//! Per-class waiter queue used by [`super::engine`] to hold admission
 //! candidates while their class is at capacity.
 
 use std::{
@@ -7,30 +7,45 @@ use std::{
 };
 
 use parking_lot::Mutex;
+use smg_auth::RequestId;
+use tokio::sync::oneshot;
 use tokio_util::sync::CancellationToken;
 
-use super::Class;
+use super::{engine::SchedulerPermit, Class};
 
 /// A request waiting for admission in a class queue.
 ///
-/// Carries only what the queue and dispatcher need: which class to admit
-/// under, when the wait started (for starvation tracking), and the
-/// cancellation token the client owns (so we can GC walkaway clients
-/// without admitting them). Additional fields (tenant key, request id,
-/// permit channel) are attached at higher layers as they're needed.
+/// Carries the class lane to admit under, the wait-start instant (used
+/// by the dispatcher's starvation override), the request id (carried
+/// so admit can build the inflight handle after dequeue), the
+/// cancellation token the client owns (lets the queue GC walkaway
+/// clients without admitting them), and the oneshot the dispatcher
+/// uses to hand back the [`SchedulerPermit`] when this waiter is
+/// admitted. Rejections (queue full, queue timeout, client cancelled)
+/// are returned synchronously from `admit` and never go through the
+/// channel, so this carries only the success case.
 #[derive(Debug)]
 pub struct Waiter {
     pub class: Class,
     pub queued_at: Instant,
     pub cancel: CancellationToken,
+    pub request_id: RequestId,
+    pub permit_tx: oneshot::Sender<SchedulerPermit>,
 }
 
 impl Waiter {
-    pub fn new(class: Class, cancel: CancellationToken) -> Self {
+    pub fn new(
+        class: Class,
+        cancel: CancellationToken,
+        request_id: RequestId,
+        permit_tx: oneshot::Sender<SchedulerPermit>,
+    ) -> Self {
         Self {
             class,
             queued_at: Instant::now(),
             cancel,
+            request_id,
+            permit_tx,
         }
     }
 }
@@ -120,7 +135,13 @@ mod tests {
     use crate::middleware::scheduler::Class;
 
     fn waiter(class: Class) -> Waiter {
-        Waiter::new(class, CancellationToken::new())
+        let (tx, _rx) = oneshot::channel();
+        Waiter::new(class, CancellationToken::new(), RequestId("t".into()), tx)
+    }
+
+    fn waiter_with_cancel(class: Class, cancel: CancellationToken) -> Waiter {
+        let (tx, _rx) = oneshot::channel();
+        Waiter::new(class, cancel, RequestId("t".into()), tx)
     }
 
     #[test]
@@ -180,7 +201,7 @@ mod tests {
         let q = FifoClassQueue::new(4);
         let cancelled = CancellationToken::new();
         cancelled.cancel();
-        q.try_enqueue(Waiter::new(Class::Default, cancelled))
+        q.try_enqueue(waiter_with_cancel(Class::Default, cancelled))
             .unwrap();
         q.try_enqueue(waiter(Class::Interactive)).unwrap();
         assert_eq!(q.depth(), 2);
@@ -219,7 +240,7 @@ mod tests {
         for _ in 0..3 {
             let cancelled = CancellationToken::new();
             cancelled.cancel();
-            q.try_enqueue(Waiter::new(Class::Default, cancelled))
+            q.try_enqueue(waiter_with_cancel(Class::Default, cancelled))
                 .unwrap();
         }
         q.try_enqueue(waiter(Class::Interactive)).unwrap();

--- a/model_gateway/src/middleware/scheduler/slots.rs
+++ b/model_gateway/src/middleware/scheduler/slots.rs
@@ -122,12 +122,18 @@ impl SlotPool {
     /// `false` if `class` has no headroom under the reservation guard.
     /// Bounded loop — re-reads on each failed CAS and exits as soon as
     /// the slot is genuinely full.
+    ///
+    /// `capacity` and the reservation snapshot are re-read on every
+    /// iteration so a live `set_capacity` / `set_reserved` from the
+    /// dispatcher can't be missed mid-retry. Otherwise a long-running
+    /// contention loop could commit against the stale pre-shrink
+    /// ceiling.
     pub fn try_acquire(&self, class: Class) -> bool {
         let lane = class as usize;
-        let capacity = self.capacity.load(Ordering::Acquire);
-        let reserved = self.snapshot_reserved();
         let mut cur = self.inflight_packed.load(Ordering::Acquire);
         loop {
+            let capacity = self.capacity.load(Ordering::Acquire);
+            let reserved = self.snapshot_reserved();
             let mut counts = unpack(cur);
             if slots_available_to(counts, reserved, capacity, class) == 0 {
                 return false;
@@ -150,11 +156,14 @@ impl SlotPool {
     /// ceiling applies. Used by the dispatcher's starvation override so
     /// a starved low-class waiter can consume a reserved-but-unused slot
     /// rather than wait indefinitely.
+    ///
+    /// As with `try_acquire`, `capacity` is re-read every iteration so
+    /// the loop honors live `set_capacity` updates mid-retry.
     pub fn try_acquire_ignoring_reservations(&self, class: Class) -> bool {
         let lane = class as usize;
-        let capacity = self.capacity.load(Ordering::Acquire);
         let mut cur = self.inflight_packed.load(Ordering::Acquire);
         loop {
+            let capacity = self.capacity.load(Ordering::Acquire);
             let mut counts = unpack(cur);
             let used_total: u16 = counts.iter().copied().fold(0, u16::saturating_add);
             if used_total >= capacity {
@@ -314,6 +323,36 @@ mod tests {
         assert!(
             pool.try_acquire_ignoring_reservations(Class::Bulk),
             "starvation-override path bypasses the reservation guard"
+        );
+    }
+
+    #[test]
+    fn test_try_acquire_honors_live_capacity_shrink() {
+        // Pre-fill, then shrink below the current inflight count. Any
+        // subsequent try_acquire must refuse on first iteration because
+        // the loop re-reads capacity (this would have committed against
+        // the old larger ceiling if capacity were cached pre-loop).
+        let pool = SlotPool::new(100, [0, 0, 0, 0]);
+        for _ in 0..50 {
+            assert!(pool.try_acquire(Class::Default));
+        }
+        pool.set_capacity(40); // used_total (50) > new capacity (40)
+        assert!(
+            !pool.try_acquire(Class::Default),
+            "must refuse against the new (lower) capacity"
+        );
+    }
+
+    #[test]
+    fn test_try_acquire_ignoring_reservations_honors_live_capacity_shrink() {
+        let pool = SlotPool::new(100, [0, 0, 0, 0]);
+        for _ in 0..50 {
+            assert!(pool.try_acquire_ignoring_reservations(Class::Bulk));
+        }
+        pool.set_capacity(40);
+        assert!(
+            !pool.try_acquire_ignoring_reservations(Class::Bulk),
+            "starvation-override acquire must also honor the new capacity"
         );
     }
 

--- a/model_gateway/src/middleware/scheduler/slots.rs
+++ b/model_gateway/src/middleware/scheduler/slots.rs
@@ -84,6 +84,31 @@ impl SlotPool {
         unpack(self.inflight_packed.load(Ordering::Acquire))[class as usize]
     }
 
+    /// Current total backend capacity. Read by `try_acquire` on every
+    /// admission attempt.
+    pub fn capacity(&self) -> u16 {
+        self.capacity.load(Ordering::Acquire)
+    }
+
+    /// Update the total backend capacity. Returns the previous value.
+    /// Called by the scheduler when the WorkerCapacity watch channel
+    /// signals a change.
+    pub fn set_capacity(&self, new_capacity: u16) -> u16 {
+        self.capacity.swap(new_capacity, Ordering::AcqRel)
+    }
+
+    /// Reservation held by `class`.
+    pub fn reserved(&self, class: Class) -> u16 {
+        self.reserved[class as usize].load(Ordering::Acquire)
+    }
+
+    /// Update the reservation held by `class`. Used by the scheduler's
+    /// capacity-shrink path to scale reservations down proportionally
+    /// when `Σ reserved` would otherwise exceed the new capacity.
+    pub fn set_reserved(&self, class: Class, new_reserved: u16) {
+        self.reserved[class as usize].store(new_reserved, Ordering::Release);
+    }
+
     fn snapshot_reserved(&self) -> [u16; 4] {
         [
             self.reserved[0].load(Ordering::Relaxed),


### PR DESCRIPTION
## Description

### Problem

M2a (#1546) added the data layer for the priority scheduler — `InflightHandle`, `FifoClassQueue`, `SlotPool`. They were reachable from the module path but no production code constructed them.

This PR is **M2b**, the second half of M2 (scheduler core). It introduces `PriorityScheduler` — the engine that wires the data layer into actual admission, queue dispatch, and capacity-watch reactivity. Still no production wiring yet — admit / dispatcher / capacity-watch are reachable from `crate::middleware::scheduler::*` but no call site constructs the scheduler. `main` behavior unchanged.

M3 (preemption) and M4 (CLI flags + `priority_admission_middleware` + cancel-token plumbing) follow.

### Solution

Four commits, one per task in M2b:

1. **`feat(scheduler): PriorityScheduler::new + RAII SchedulerPermit`** — Engine type owns the slot pool, per-class queues (with `max(queue_size, ceil(queue_size_per_slot * capacity))` limits derived at construction), inflight registry keyed by `RequestId`, release notify, and the per-class `ClassRuntimeConfig`. `new()` refuses if `Σ class.reserved > capacity`. `SchedulerPermit` is RAII — Drop releases the slot, removes the handle from the registry, and notifies the dispatcher.

2. **`feat(scheduler): admission fast path + enqueue path`** — `admit(class, request_id, cancel)` returns `AdmitOutcome::{Admitted(permit), Rejected(reason)}`. Fast path is one packed CAS via `acquire_inflight`; enqueue path holds a `oneshot::Sender<SchedulerPermit>` on the `Waiter`. `select!` covers the three rejection cases that don't need the dispatcher: `QueueFull` at enqueue time, `QueueTimeout` via `tokio::time::sleep`, `ClientCancelled` via the cancel token.

3. **`feat(scheduler): wake_next_waiter + dispatcher with starvation override`** — Two-pass scan: (1) starvation override scans lowest classes first (`Bulk → Default → Interactive`) for any head waiter past its `starvation_threshold`, admitting via `try_acquire_ignoring_reservations` so a starved low-class waiter can take a reserved-but-unused slot; (2) normal priority order (`System → Interactive → Default → Bulk`) with the standard reservation guard. `spawn_dispatcher` runs a Weak-ref'd background task that awaits `release_notify` and drains.

4. **`feat(scheduler): spawn_dispatcher consumes WorkerCapacity watch`** — Dispatcher now `select!`s over both `release_notify` and `capacity_watch.changed()`. On capacity change, `apply_new_capacity` updates the slot pool's atomic ceiling, scales reservations down proportionally on shrink (if `Σ reserved > new_capacity`), and fires `release_notify` on grow so queued waiters re-evaluate.

## Changes

| Layer / File(s) | Summary |
|---|---|
| **Engine** <br> `model_gateway/src/middleware/scheduler/engine.rs` *(new)* | `PriorityScheduler`, `SchedulerPermit` (RAII + hand-rolled Debug), `AdmitOutcome`, `RejectionReason`, `SchedulerInitError`. Owns slot pool / queues / registry / notify / class config. `admit()` fast+queue paths, `wake_next_waiter` priority+starvation, `spawn_dispatcher` Weak-ref'd background task with `release_notify ∪ capacity_watch.changed()` select. Drop on the scheduler kicks `release_notify` so the dispatcher exits via `Weak::upgrade` failure. |
| **Slot pool capacity & reservation setters** <br> `model_gateway/src/middleware/scheduler/slots.rs` | `capacity()`, `set_capacity()`, `reserved(class)`, `set_reserved(class, _)`. Used by `apply_new_capacity` to update the live ceiling without re-constructing the pool. |
| **Waiter carries oneshot** <br> `model_gateway/src/middleware/scheduler/queue.rs` | Adds `request_id` + `permit_tx: oneshot::Sender<SchedulerPermit>` to `Waiter` so the dispatcher can hand back a permit asynchronously. |
| **InflightHandle carries class + request_id** <br> `model_gateway/src/middleware/scheduler/inflight.rs` | New fields are the registry key and the slot-release lane. `new()` now takes them. |
| **RequestId Hash/Eq derives** <br> `crates/auth/src/lib.rs` | `#[derive(PartialEq, Eq, Hash)]` so `RequestId` can be a `HashMap` key (used by the inflight registry). |
| **Module re-exports** <br> `model_gateway/src/middleware/scheduler/mod.rs` | `pub use engine::{PriorityScheduler, SchedulerInitError, SchedulerPermit};` |

## Test Plan

Each task: failing test → verify FAIL → implement → verify PASS → commit. 24 new unit tests on top of M2a's 26.

- **Engine construction** (5): `new` succeeds when reservations fit; rejects with `ReservationsExceedCapacity` when they don't; `acquire_inflight` returns a permit / returns None when the reservation guard blocks; permit's Arc keeps the scheduler alive.
- **Permit RAII** (2): drop releases the slot AND fires `release_notify`; drop unregisters the handle from the registry.
- **Admit** (4): fast path admits synchronously; queue-full → `QueueFull`; queue-timeout → `QueueTimeout`; client-cancel → `ClientCancelled`.
- **wake_next_waiter** (3): returns false when no slot available; admits queued waiter on slot release; honors priority order (Interactive beats Bulk).
- **Starvation override** (1): Bulk head past threshold takes a slot that Interactive has reserved.
- **spawn_dispatcher** (1): release-then-await actually drives a queued admit to completion.
- **apply_new_capacity** (3): grow fires `release_notify`; shrink past reservations scales them down proportionally (`160 → 80` halves Interactive/System); no-op when unchanged.
- **capacity watch end-to-end** (1): `watch::Sender::send(2)` causes a queued waiter to be admitted under the new ceiling.

```bash
$ cargo test --package smg --lib middleware::scheduler
... 79 passed; 0 failed
```

```bash
$ cargo clippy --package smg --all-targets --all-features -- -D warnings
... Finished `dev` profile, no warnings
```

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes (enforced by pre-commit hook)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] (Optional) Documentation updated — implementation plan at `.claude/docs/scheduler/02-priority-scheduler-plan.md` (in #1541)
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Priority-aware admission scheduler with per-class reservations, dynamic capacity adjustments, and a background dispatcher.
  * Admission permits with automatic release, queue timeouts, and client cancellation handling.
  * Live capacity updates that immediately affect admission behavior.

* **Improvements**
  * Better request tracking via enhanced request identifiers, surfaced in scheduling and wait queues.
  * Starvation prevention to ensure lower-priority requests are eventually admitted.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightseekorg/smg/pull/1550?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->