### PR TITLE
feat(messages): support adaptive thinking on /v1/messages

### DIFF
--- a/crates/protocols/src/messages.rs
+++ b/crates/protocols/src/messages.rs
@@ -787,6 +787,8 @@ pub enum ThinkingConfig {
     Enabled {
         /// Budget in tokens for thinking (minimum 1024)
         budget_tokens: u32,
+        /// How thinking content is returned in the response.
+        display: Option<ThinkingDisplay>,
     },
     /// Disable extended thinking
     Disabled,
@@ -2242,12 +2244,41 @@ mod tests {
         assert!(matches!(
             cfg,
             ThinkingConfig::Enabled {
-                budget_tokens: 1024
+                budget_tokens: 1024,
+                display: None
             }
         ));
 
         let cfg: ThinkingConfig = serde_json::from_str(r#"{"type":"disabled"}"#).unwrap();
         assert!(matches!(cfg, ThinkingConfig::Disabled));
+    }
+
+    #[test]
+    fn test_thinking_config_enabled_with_display() {
+        let cfg: ThinkingConfig = serde_json::from_str(
+            r#"{"type":"enabled","budget_tokens":2048,"display":"summarized"}"#,
+        )
+        .unwrap();
+        match cfg {
+            ThinkingConfig::Enabled {
+                budget_tokens,
+                display,
+            } => {
+                assert_eq!(budget_tokens, 2048);
+                assert_eq!(display, Some(ThinkingDisplay::Summarized));
+            }
+            other => panic!("expected Enabled, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_thinking_config_enabled_round_trip_omits_null_display() {
+        let cfg = ThinkingConfig::Enabled {
+            budget_tokens: 1024,
+            display: None,
+        };
+        let json = serde_json::to_string(&cfg).unwrap();
+        assert_eq!(json, r#"{"type":"enabled","budget_tokens":1024}"#);
     }
 
     #[test]

--- a/crates/protocols/src/messages.rs
+++ b/crates/protocols/src/messages.rs
@@ -779,6 +779,7 @@ pub enum ToolChoice {
 // ============================================================================
 
 /// Configuration for extended thinking
+#[serde_with::skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ThinkingConfig {
@@ -789,6 +790,22 @@ pub enum ThinkingConfig {
     },
     /// Disable extended thinking
     Disabled,
+    /// Let the model decide when and how much to think. Required on Opus 4.7.
+    Adaptive {
+        /// How thinking content is returned in the response.
+        /// Defaults vary by model (Opus 4.7 / Mythos default to `Omitted`; others to `Summarized`).
+        display: Option<ThinkingDisplay>,
+    },
+}
+
+/// How thinking content is returned in API responses
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ThinkingDisplay {
+    /// Thinking blocks contain summarized reasoning text
+    Summarized,
+    /// Thinking blocks return empty text; signature still carries encrypted content
+    Omitted,
 }
 
 // ============================================================================
@@ -2179,6 +2196,58 @@ mod tests {
         request.mcp_servers = Some(vec![mcp_server_config()]);
 
         assert!(request.validate().is_err());
+    }
+
+    #[test]
+    fn test_thinking_config_adaptive_minimal() {
+        let cfg: ThinkingConfig = serde_json::from_str(r#"{"type":"adaptive"}"#).unwrap();
+        match cfg {
+            ThinkingConfig::Adaptive { display } => assert_eq!(display, None),
+            other => panic!("expected Adaptive, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_thinking_config_adaptive_with_display() {
+        let cfg: ThinkingConfig =
+            serde_json::from_str(r#"{"type":"adaptive","display":"omitted"}"#).unwrap();
+        match cfg {
+            ThinkingConfig::Adaptive { display } => {
+                assert_eq!(display, Some(ThinkingDisplay::Omitted));
+            }
+            other => panic!("expected Adaptive, got {other:?}"),
+        }
+
+        let cfg: ThinkingConfig =
+            serde_json::from_str(r#"{"type":"adaptive","display":"summarized"}"#).unwrap();
+        match cfg {
+            ThinkingConfig::Adaptive { display } => {
+                assert_eq!(display, Some(ThinkingDisplay::Summarized));
+            }
+            other => panic!("expected Adaptive, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_thinking_config_adaptive_round_trip_omits_null_display() {
+        let cfg = ThinkingConfig::Adaptive { display: None };
+        let json = serde_json::to_string(&cfg).unwrap();
+        assert_eq!(json, r#"{"type":"adaptive"}"#);
+    }
+
+    #[test]
+    fn test_thinking_config_existing_variants_still_work() {
+        let cfg: ThinkingConfig =
+            serde_json::from_str(r#"{"type":"enabled","budget_tokens":1024}"#).unwrap();
+        assert!(matches!(
+            cfg,
+            ThinkingConfig::Enabled {
+                budget_tokens: 1024
+            }
+        ));
+
+        let cfg: ThinkingConfig = serde_json::from_str(r#"{"type":"disabled"}"#).unwrap();
+        assert!(matches!(cfg, ThinkingConfig::Disabled));
     }
 
     #[test]

--- a/model_gateway/src/routers/grpc/regular/processor.rs
+++ b/model_gateway/src/routers/grpc/regular/processor.rs
@@ -516,7 +516,10 @@ impl ResponseProcessor {
         // as thinking content, breaking tool use and producing incorrect content blocks.
         let separate_reasoning = matches!(
             &messages_request.thinking,
-            Some(messages::ThinkingConfig::Enabled { .. })
+            Some(
+                messages::ThinkingConfig::Enabled { .. }
+                    | messages::ThinkingConfig::Adaptive { .. }
+            )
         );
         let reasoning_parser_available = separate_reasoning
             && utils::check_reasoning_parser_availability(
@@ -597,7 +600,10 @@ impl ResponseProcessor {
             // If thinking is effectively ON and template has a toggle, start in reasoning mode.
             {
                 let user_thinking = match &messages_request.thinking {
-                    Some(messages::ThinkingConfig::Enabled { .. }) => Some(true),
+                    Some(
+                        messages::ThinkingConfig::Enabled { .. }
+                        | messages::ThinkingConfig::Adaptive { .. },
+                    ) => Some(true),
                     Some(messages::ThinkingConfig::Disabled) => Some(false),
                     None => None,
                 };

--- a/model_gateway/src/routers/grpc/regular/streaming.rs
+++ b/model_gateway/src/routers/grpc/regular/streaming.rs
@@ -1606,7 +1606,10 @@ impl StreamingProcessor {
         // Only run reasoning parser when the user explicitly enabled thinking.
         let separate_reasoning = matches!(
             &original_request.thinking,
-            Some(messages::ThinkingConfig::Enabled { .. })
+            Some(
+                messages::ThinkingConfig::Enabled { .. }
+                    | messages::ThinkingConfig::Adaptive { .. }
+            )
         );
         let reasoning_parser_available = separate_reasoning
             && utils::check_reasoning_parser_availability(
@@ -1617,7 +1620,10 @@ impl StreamingProcessor {
 
         // Determine if thinking is effectively ON (for mark_reasoning_started).
         let user_thinking = match &original_request.thinking {
-            Some(messages::ThinkingConfig::Enabled { .. }) => Some(true),
+            Some(
+                messages::ThinkingConfig::Enabled { .. }
+                | messages::ThinkingConfig::Adaptive { .. },
+            ) => Some(true),
             Some(messages::ThinkingConfig::Disabled) => Some(false),
             None => None,
         };

--- a/model_gateway/src/routers/grpc/utils/message_utils.rs
+++ b/model_gateway/src/routers/grpc/utils/message_utils.rs
@@ -76,8 +76,9 @@ pub fn process_messages(
 
     // Pass both `enable_thinking` (Qwen3) and `thinking` (Kimi-K2.5) since
     // different model templates use different kwarg names for the same concept.
+    // Adaptive mode is treated as "thinking on"; the model decides whether to actually emit it.
     match &request.thinking {
-        Some(ThinkingConfig::Enabled { .. }) => {
+        Some(ThinkingConfig::Enabled { .. } | ThinkingConfig::Adaptive { .. }) => {
             combined_template_kwargs.insert("enable_thinking".to_string(), json!(true));
             combined_template_kwargs.insert("thinking".to_string(), json!(true));
         }


### PR DESCRIPTION
## Description

### Problem

The Anthropic Messages API endpoint (`/v1/messages`) rejects payloads with `thinking: {"type": "adaptive"}` at the `ValidatedJson` extractor with `unknown variant 'adaptive', expected 'enabled' or 'disabled'`. Adaptive thinking is required on Claude Opus 4.7 and recommended on Opus 4.6 / Sonnet 4.6 (see [docs](https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking)), so users are stuck running a wrapper proxy to rewrite the request before it hits SMG.

A related silent-data-loss bug: Anthropic also accepts a `display` field on `{"type":"enabled",...}`, but since the `Enabled` variant didn't model it, the field was silently dropped during serde round-trip and the upstream worker never saw it.

### Solution

Add `ThinkingConfig::Adaptive { display: Option<ThinkingDisplay> }` and add the same `display: Option<ThinkingDisplay>` field to `ThinkingConfig::Enabled`. In the gRPC router path, `Adaptive` is treated the same as `Enabled` for chat-template kwargs (`enable_thinking`/`thinking`) and for reasoning-parser gating — the model itself decides whether to actually emit thinking content. The HTTP router proxies the request body byte-for-byte, so no special handling is needed there.

## Changes

- `crates/protocols/src/messages.rs`:
  - Add `ThinkingDisplay` enum (`Summarized` / `Omitted`).
  - Add `ThinkingConfig::Adaptive { display }` variant.
  - Add `display: Option<ThinkingDisplay>` field to `ThinkingConfig::Enabled`.
  - 6 deserialize tests covering both variants × (minimal form, `display` field, no-`display` round-trip).
- `model_gateway/src/routers/grpc/utils/message_utils.rs`: include `Adaptive` in the "thinking on" arm of the template kwargs match.
- `model_gateway/src/routers/grpc/regular/processor.rs` (2 sites): include `Adaptive` in `separate_reasoning` `matches!` and `user_thinking` match.
- `model_gateway/src/routers/grpc/regular/streaming.rs` (2 sites): same pair of updates for the streaming path.

All existing pattern matches on `Enabled` already use `{ .. }`, so adding `display` to the variant is non-breaking for them.

## Test Plan

**Before** (current `main`):
```
$ echo '{"type":"adaptive"}' | serde_json::from_str::<ThinkingConfig>
REJECTED: unknown variant `adaptive`, expected `enabled` or `disabled`
```

**After** (this PR):
```
$ cargo test -p openai-protocol --lib messages
test messages::tests::test_thinking_config_adaptive_minimal ... ok
test messages::tests::test_thinking_config_adaptive_with_display ... ok
test messages::tests::test_thinking_config_adaptive_round_trip_omits_null_display ... ok
test messages::tests::test_thinking_config_enabled_with_display ... ok
test messages::tests::test_thinking_config_enabled_round_trip_omits_null_display ... ok
test messages::tests::test_thinking_config_existing_variants_still_work ... ok
test result: ok. 23 passed; 0 failed
```

Reproduction with the previously-failing payload:
```rust
let payload = r#"{"thinking":{"type":"adaptive"}, ...}"#;
let req: CreateMessageRequest = serde_json::from_str(payload).unwrap();
// thinking = Some(Adaptive { display: None })
// re-serialized: {"type":"adaptive"}   ← no spurious "display":null
```

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (for `openai-protocol` and `smg`)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

## Follow-ups (separate PRs)

- Preserve unknown top-level fields on `CreateMessageRequest` (e.g. `output_config`, `context_management`) — currently silently dropped during serde round-trip, which means the upstream worker never sees them. Idiomatic fix: add `#[serde(flatten)] pub extra: HashMap<String, Value>`, matching the existing pattern on [`InputSchema`](crates/protocols/src/messages.rs).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added adaptive thinking mode with configurable display options (omitted or summarized).

* **Improvements**
  * Adaptive mode is now handled consistently with enabled mode across reasoning and streaming paths, ensuring uniform behavior and overrides.

* **Tests**
  * Added unit tests covering adaptive mode parsing, serialization round-trips, and continued compatibility with existing modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightseekorg/smg/pull/1555?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->