### PR TITLE
ci: fix YAML comment swallowing echo in cancel-merged-pr-tests

### DIFF
--- a/.github/workflows/cancel-merged-pr-tests.yml
+++ b/.github/workflows/cancel-merged-pr-tests.yml
@@ -17,7 +17,8 @@ jobs:
       group: gateway-tests-pr-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     steps:
-      - run: echo "Cancelling in-progress PR Test (SMG) runs for merged PR #${{ github.event.pull_request.number }}."
+      - run: |
+          echo "Cancelling in-progress PR Test (SMG) runs for merged PR #${{ github.event.pull_request.number }}."
 
   mlx-tests:
     name: Cancel PR Test (MLX)
@@ -27,4 +28,5 @@ jobs:
       group: mlx-tests-pr-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     steps:
-      - run: echo "Cancelling in-progress PR Test (MLX) runs for merged PR #${{ github.event.pull_request.number }}."
+      - run: |
+          echo "Cancelling in-progress PR Test (MLX) runs for merged PR #${{ github.event.pull_request.number }}."


### PR DESCRIPTION
## Description

### Problem

Every merged PR now shows red "Cancel PR Test (SMG)" and "Cancel PR Test (MLX)" checks from the `Cancel Merged PR Tests` workflow added in #1530. Examples on #1555 and #1550.

The two `run:` lines in `.github/workflows/cancel-merged-pr-tests.yml` are YAML plain scalars containing `#${{ github.event.pull_request.number }}`. YAML treats a whitespace-prefixed `#` as a comment, so the parser truncates the value at `#`, and bash ends up running an `echo "..."` with no closing quote:

```
/home/runner/work/_temp/<id>.sh: line 1: unexpected EOF while looking for matching `"'
##[error]Process completed with exit code 2.
```

Note: the underlying concurrency-group cancellation still works — it's evaluated when the runner picks up the job, before the step executes. The bug is cosmetic (misleading red ✗ on every merged PR) rather than functional.

### Solution

Switch both `run:` lines to `|` block scalars. Inside a block scalar, `#` is literal content rather than a comment delimiter, so the full echo string reaches bash intact.

## Changes

- `.github/workflows/cancel-merged-pr-tests.yml`: convert the two inline `run: echo ...` lines to `run: |` block scalars.

## Test Plan

- Confirmed the bash error in failing runs for #1555 and #1550 — log message above.
- Verified YAML round-trip locally (`check yaml` pre-commit hook passes).
- Workflow fires only on `pull_request: closed (merged == true)`, so end-to-end validation will happen the next time a PR merges to main after this lands. Expected: both jobs go green and any in-progress `gateway-tests-pr-<N>` / `mlx-tests-pr-<N>` runs are still cancelled as before.

<details>
<summary>Checklist</summary>

- [x] \`cargo +nightly fmt\` passes — N/A, YAML-only change
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` passes — N/A, YAML-only change
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD workflow formatting for consistency and maintainability. No user-facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightseekorg/smg/pull/1556?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->