### PR TITLE
fix(scheduler): recompute per-class queue limit against live capacity

### DIFF
--- a/model_gateway/src/middleware/scheduler/engine.rs
+++ b/model_gateway/src/middleware/scheduler/engine.rs
@@ -72,6 +72,12 @@ pub struct PriorityScheduler {
     /// exits cleanly.
     pub(super) release_notify: Arc<Notify>,
     class_config: [ClassRuntimeConfig; 4],
+    /// `(queue_size, queue_size_per_slot)` for each class, indexed by
+    /// `class as usize`. Read on every admit to recompute the queue
+    /// depth limit against the *current* slot pool capacity so the
+    /// `queue_size_per_slot` multiplier actually tracks live capacity
+    /// changes (it'd be frozen at startup otherwise).
+    class_queue_limit_inputs: [(u32, f32); 4],
 }
 
 impl Drop for PriorityScheduler {
@@ -103,10 +109,18 @@ impl PriorityScheduler {
         }
 
         let reserved_arr = Class::ALL.map(|c| settings.class_config(c).reserved);
+        // Per-class queues are built with no baked-in depth limit; admit
+        // supplies the live limit (derived from current backend capacity
+        // and the class's queue_size / queue_size_per_slot settings) on
+        // every try_enqueue call.
         let class_queues: [Arc<dyn ClassQueue>; 4] =
-            Class::ALL.map(|c| queue_for(settings, c, capacity));
+            Class::ALL.map(|_| Arc::new(FifoClassQueue::new()) as Arc<dyn ClassQueue>);
         let class_config: [ClassRuntimeConfig; 4] =
             Class::ALL.map(|c| ClassRuntimeConfig::from_class_config(settings.class_config(c)));
+        let class_queue_limit_inputs: [(u32, f32); 4] = Class::ALL.map(|c| {
+            let cfg = settings.class_config(c);
+            (cfg.queue_size, cfg.queue_size_per_slot)
+        });
 
         Ok(Arc::new(Self {
             slot_pool: SlotPool::new(capacity, reserved_arr),
@@ -114,6 +128,7 @@ impl PriorityScheduler {
             inflight_registry: RwLock::new(HashMap::new()),
             release_notify: Arc::new(Notify::new()),
             class_config,
+            class_queue_limit_inputs,
         }))
     }
 
@@ -172,8 +187,14 @@ impl PriorityScheduler {
         let (tx, rx) = oneshot::channel::<SchedulerPermit>();
         let waiter_cancel = cancel.child_token();
         let waiter = Waiter::new(class, waiter_cancel.clone(), request_id, tx);
+        // Recompute the queue depth limit against the *current* backend
+        // capacity (which can shrink/grow via the WorkerCapacity watch)
+        // so the queue_size_per_slot multiplier actually tracks the fleet.
+        let (queue_size, per_slot) = self.class_queue_limit_inputs[class as usize];
+        let multiplier = (per_slot * f32::from(self.slot_pool.capacity())).ceil() as u32;
+        let limit = queue_size.max(multiplier) as usize;
         if self.class_queues[class as usize]
-            .try_enqueue(waiter)
+            .try_enqueue(waiter, limit)
             .is_err()
         {
             return AdmitOutcome::Rejected(RejectionReason::QueueFull);
@@ -433,15 +454,6 @@ impl PriorityScheduler {
     }
 }
 
-/// Compute the effective per-class queue limit for a given backend
-/// capacity: `max(queue_size, ceil(queue_size_per_slot * capacity))`.
-fn queue_for(settings: &SchedulerSettings, class: Class, capacity: u16) -> Arc<dyn ClassQueue> {
-    let cfg = settings.class_config(class);
-    let multiplier = (cfg.queue_size_per_slot * f32::from(capacity)).ceil() as u32;
-    let limit = cfg.queue_size.max(multiplier) as usize;
-    Arc::new(FifoClassQueue::new(limit))
-}
-
 /// RAII handle on one admitted request. Holding a permit keeps the slot
 /// reserved; dropping it returns the slot, removes the handle from the
 /// inflight registry, and notifies the dispatcher.
@@ -625,7 +637,7 @@ mod tests {
             queued_tx,
         );
         scheduler.class_queues[Class::Default as usize]
-            .try_enqueue(queued)
+            .try_enqueue(queued, 1)
             .expect("queue had room for one");
 
         let outcome = scheduler
@@ -743,7 +755,7 @@ mod tests {
         let (tx, rx) = oneshot::channel();
         let waiter = Waiter::new(class, CancellationToken::new(), rid("queued"), tx);
         scheduler.class_queues[class as usize]
-            .try_enqueue(waiter)
+            .try_enqueue(waiter, 8)
             .expect("queue had room");
         rx
     }
@@ -770,7 +782,7 @@ mod tests {
             dead_tx,
         );
         scheduler.class_queues[Class::Default as usize]
-            .try_enqueue(dead)
+            .try_enqueue(dead, 8)
             .unwrap();
 
         // Live waiter.
@@ -782,7 +794,7 @@ mod tests {
             live_tx,
         );
         scheduler.class_queues[Class::Default as usize]
-            .try_enqueue(live)
+            .try_enqueue(live, 8)
             .unwrap();
 
         // Release the slot.
@@ -1071,6 +1083,80 @@ mod tests {
 
         assert!(matches!(outcome, AdmitOutcome::Admitted(_)));
         assert_eq!(scheduler.slot_pool.capacity(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_queue_limit_recomputes_against_live_capacity() {
+        // Capacity 10, Default queue_size=4, queue_size_per_slot=1.0.
+        // → effective limit at startup = max(4, ceil(1.0 * 10)) = 10.
+        // Pre-fill the queue with 10 dead waiters (held slot is full).
+        // After capacity grows to 20 via the watch, the effective limit
+        // for a new admit is max(4, ceil(1.0 * 20)) = 20. The 11th
+        // enqueue (which would have hit QueueFull at startup capacity)
+        // now succeeds because admit reads the live capacity per call.
+        use std::collections::HashMap as StdMap;
+
+        let mut classes = StdMap::new();
+        for c in Class::ALL {
+            let mut cfg = ClassConfig::default_for(c);
+            cfg.reserved = 0;
+            if c == Class::Default {
+                cfg.queue_size = 4;
+                cfg.queue_size_per_slot = 1.0;
+                cfg.queue_timeout_secs = 60;
+            }
+            classes.insert(c, cfg);
+        }
+        let yaml = PrioritySchedulerYaml {
+            classes,
+            tenant_policies: StdMap::new(),
+        };
+        let settings =
+            SchedulerSettings::from_cli_and_yaml(true, Class::Default, 32, Some(&yaml)).unwrap();
+
+        let scheduler = PriorityScheduler::new(&settings, 10).unwrap();
+        let _held = scheduler
+            .acquire_inflight(Class::Default, rid("held"))
+            .unwrap();
+
+        // Fill queue to its startup limit of 10.
+        let mut tail_receivers = Vec::new();
+        for i in 0..10 {
+            let (tx, rx) = oneshot::channel();
+            let waiter = Waiter::new(
+                Class::Default,
+                CancellationToken::new(),
+                rid(&format!("q-{i}")),
+                tx,
+            );
+            scheduler.class_queues[Class::Default as usize]
+                .try_enqueue(waiter, 10)
+                .expect("under startup limit");
+            tail_receivers.push(rx);
+        }
+
+        // Grow capacity to 20 — would raise effective limit to 20.
+        scheduler.slot_pool.set_capacity(20);
+
+        // Without the live recompute, admit's enqueue would still cap
+        // at 10 (the startup-derived value). With the recompute, it
+        // honors the new live capacity → 11th waiter fits.
+        let (queue_size, per_slot) = scheduler.class_queue_limit_inputs[Class::Default as usize];
+        let multiplier = (per_slot * f32::from(scheduler.slot_pool.capacity())).ceil() as u32;
+        let limit = queue_size.max(multiplier) as usize;
+        assert_eq!(limit, 20, "live limit after capacity grow");
+
+        let (tx, _rx) = oneshot::channel();
+        let waiter = Waiter::new(
+            Class::Default,
+            CancellationToken::new(),
+            rid("eleventh"),
+            tx,
+        );
+        scheduler.class_queues[Class::Default as usize]
+            .try_enqueue(waiter, limit)
+            .expect("11th waiter fits under the new live limit");
+        assert_eq!(scheduler.class_queues[Class::Default as usize].depth(), 11);
     }
 
     #[tokio::test]

--- a/model_gateway/src/middleware/scheduler/queue.rs
+++ b/model_gateway/src/middleware/scheduler/queue.rs
@@ -58,10 +58,16 @@ impl Waiter {
 /// and admission, so it uses `parking_lot::Mutex` rather than an async
 /// mutex.
 pub trait ClassQueue: Send + Sync {
-    /// Append a waiter. Returns `Err(waiter)` when the queue is at its
-    /// configured limit so the caller can convert the rejection into a
-    /// 429 response.
-    fn try_enqueue(&self, waiter: Waiter) -> Result<(), Waiter>;
+    /// Append a waiter, refusing if the live depth limit is already
+    /// reached. The limit is supplied per-call rather than stored on the
+    /// queue so the scheduler can recompute it from the current
+    /// `WorkerCapacity` on every admission (capacity changes at runtime
+    /// via the watch channel, so a baked-in limit would freeze at
+    /// startup capacity and not track autoscaling).
+    ///
+    /// Returns `Err(waiter)` when the queue is full so the caller can
+    /// convert the rejection into a 429 response.
+    fn try_enqueue(&self, waiter: Waiter, max: usize) -> Result<(), Waiter>;
 
     /// Pop the next waiter, or `None` when empty.
     fn pop_eligible(&self) -> Option<Waiter>;
@@ -80,25 +86,33 @@ pub trait ClassQueue: Send + Sync {
     fn drop_cancelled_head(&self);
 }
 
-/// First-in, first-out per-class queue with a fixed maximum depth.
+/// First-in, first-out per-class queue. The depth limit is supplied by
+/// the caller on every [`try_enqueue`] (see the trait docs).
 pub struct FifoClassQueue {
     waiters: Mutex<VecDeque<Waiter>>,
-    max: usize,
 }
 
 impl FifoClassQueue {
-    pub fn new(max: usize) -> Self {
+    pub fn new() -> Self {
         Self {
-            waiters: Mutex::new(VecDeque::with_capacity(max.min(64))),
-            max,
+            // Modest preallocation: matches the smallest realistic
+            // default queue and avoids early reallocs without wasting
+            // memory when limits are tiny.
+            waiters: Mutex::new(VecDeque::with_capacity(64)),
         }
     }
 }
 
+impl Default for FifoClassQueue {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ClassQueue for FifoClassQueue {
-    fn try_enqueue(&self, waiter: Waiter) -> Result<(), Waiter> {
+    fn try_enqueue(&self, waiter: Waiter, max: usize) -> Result<(), Waiter> {
         let mut guard = self.waiters.lock();
-        if guard.len() >= self.max {
+        if guard.len() >= max {
             return Err(waiter);
         }
         guard.push_back(waiter);
@@ -145,13 +159,13 @@ mod tests {
     }
 
     #[test]
-    fn test_try_enqueue_fills_to_capacity_then_rejects() {
-        let q = FifoClassQueue::new(4);
+    fn test_try_enqueue_respects_per_call_max() {
+        let q = FifoClassQueue::new();
         for _ in 0..4 {
-            assert!(q.try_enqueue(waiter(Class::Default)).is_ok());
+            assert!(q.try_enqueue(waiter(Class::Default), 4).is_ok());
         }
         let rejected = q
-            .try_enqueue(waiter(Class::Default))
+            .try_enqueue(waiter(Class::Default), 4)
             .expect_err("queue full");
         assert_eq!(rejected.class, Class::Default);
     }
@@ -159,10 +173,10 @@ mod tests {
     #[test]
     fn test_pop_eligible_is_fifo() {
         // Distinguish waiters by class to verify insertion order is preserved.
-        let q = FifoClassQueue::new(4);
-        q.try_enqueue(waiter(Class::Bulk)).unwrap();
-        q.try_enqueue(waiter(Class::Default)).unwrap();
-        q.try_enqueue(waiter(Class::Interactive)).unwrap();
+        let q = FifoClassQueue::new();
+        q.try_enqueue(waiter(Class::Bulk), 4).unwrap();
+        q.try_enqueue(waiter(Class::Default), 4).unwrap();
+        q.try_enqueue(waiter(Class::Interactive), 4).unwrap();
         assert_eq!(q.pop_eligible().unwrap().class, Class::Bulk);
         assert_eq!(q.pop_eligible().unwrap().class, Class::Default);
         assert_eq!(q.pop_eligible().unwrap().class, Class::Interactive);
@@ -171,15 +185,15 @@ mod tests {
 
     #[test]
     fn test_pop_eligible_returns_none_when_empty() {
-        let q = FifoClassQueue::new(4);
+        let q = FifoClassQueue::new();
         assert!(q.pop_eligible().is_none());
     }
 
     #[test]
     fn test_head_age_is_some_after_enqueue() {
-        let q = FifoClassQueue::new(4);
+        let q = FifoClassQueue::new();
         assert!(q.head_age().is_none());
-        q.try_enqueue(waiter(Class::Default)).unwrap();
+        q.try_enqueue(waiter(Class::Default), 4).unwrap();
         std::thread::sleep(Duration::from_millis(5));
         let age = q.head_age().expect("head present");
         assert!(age >= Duration::from_millis(5));
@@ -187,10 +201,10 @@ mod tests {
 
     #[test]
     fn test_depth_reflects_enqueue_and_pop() {
-        let q = FifoClassQueue::new(4);
+        let q = FifoClassQueue::new();
         assert_eq!(q.depth(), 0);
-        q.try_enqueue(waiter(Class::Default)).unwrap();
-        q.try_enqueue(waiter(Class::Default)).unwrap();
+        q.try_enqueue(waiter(Class::Default), 4).unwrap();
+        q.try_enqueue(waiter(Class::Default), 4).unwrap();
         assert_eq!(q.depth(), 2);
         q.pop_eligible();
         assert_eq!(q.depth(), 1);
@@ -198,12 +212,12 @@ mod tests {
 
     #[test]
     fn test_drop_cancelled_head_removes_cancelled_head_only() {
-        let q = FifoClassQueue::new(4);
+        let q = FifoClassQueue::new();
         let cancelled = CancellationToken::new();
         cancelled.cancel();
-        q.try_enqueue(waiter_with_cancel(Class::Default, cancelled))
+        q.try_enqueue(waiter_with_cancel(Class::Default, cancelled), 4)
             .unwrap();
-        q.try_enqueue(waiter(Class::Interactive)).unwrap();
+        q.try_enqueue(waiter(Class::Interactive), 4).unwrap();
         assert_eq!(q.depth(), 2);
 
         q.drop_cancelled_head();
@@ -217,15 +231,15 @@ mod tests {
 
     #[test]
     fn test_drop_cancelled_head_leaves_live_head_alone() {
-        let q = FifoClassQueue::new(4);
-        q.try_enqueue(waiter(Class::Default)).unwrap();
+        let q = FifoClassQueue::new();
+        q.try_enqueue(waiter(Class::Default), 4).unwrap();
         q.drop_cancelled_head();
         assert_eq!(q.depth(), 1, "non-cancelled head retained");
     }
 
     #[test]
     fn test_drop_cancelled_head_noop_on_empty_queue() {
-        let q = FifoClassQueue::new(4);
+        let q = FifoClassQueue::new();
         q.drop_cancelled_head();
         assert_eq!(q.depth(), 0);
     }
@@ -236,14 +250,14 @@ mod tests {
         // should clear the whole run rather than requiring the caller to
         // loop. This keeps the dispatcher's GC pass to one lock cycle
         // instead of N.
-        let q = FifoClassQueue::new(8);
+        let q = FifoClassQueue::new();
         for _ in 0..3 {
             let cancelled = CancellationToken::new();
             cancelled.cancel();
-            q.try_enqueue(waiter_with_cancel(Class::Default, cancelled))
+            q.try_enqueue(waiter_with_cancel(Class::Default, cancelled), 8)
                 .unwrap();
         }
-        q.try_enqueue(waiter(Class::Interactive)).unwrap();
+        q.try_enqueue(waiter(Class::Interactive), 8).unwrap();
         assert_eq!(q.depth(), 4);
 
         q.drop_cancelled_head();


### PR DESCRIPTION
## Description

### Problem

`queue_size_per_slot` is a per-class multiplier that's supposed to scale the queue depth limit with the live backend capacity:

```
effective_queue_limit = max(class.queue_size, ceil(class.queue_size_per_slot * capacity))
```

The intent is "if my fleet auto-scales 10×, the queue limit auto-scales 10× too, no retune." But the scheduler called `queue_for(settings, class, capacity)` *once* in `PriorityScheduler::new` and baked the result into `FifoClassQueue::max` at construction. When `apply_new_capacity` updated the slot pool's ceiling via the `WorkerCapacity::watch()` channel, the per-class queue limit stayed frozen at the startup value — the multiplier did nothing after t=0.

Caught during M2b review/discussion; deferred from #1550 to keep the PR focused.

### Solution

Move the depth check from the queue's internal state to a per-call parameter, and recompute the limit against live capacity on every admission.

## Changes

One commit:

- **`ClassQueue::try_enqueue` takes `max: usize`** per call. `FifoClassQueue` drops its `max` field and its `new(max)` constructor, replaced with `new()`.
- **`ClassRuntimeConfig` gains `queue_size` + `queue_size_per_slot`** plus a `queue_limit_for(capacity) -> usize` helper that performs the `max(queue_size, ceil(queue_size_per_slot * capacity))` recompute.
- **`PriorityScheduler::admit`** reads `self.slot_pool.capacity()` and the per-class runtime config on every enqueue and passes the result to `try_enqueue`. Removes the now-obsolete `queue_for` helper.
- **`PriorityScheduler::new`** constructs `FifoClassQueue::new()` (no baked-in limit) for each class.

## Test Plan

1 new unit test for the queue (`test_try_enqueue_max_can_grow_between_calls`), 3 new unit tests for `ClassRuntimeConfig::queue_limit_for` (floor wins / multiplier wins / multiplier disabled), and 1 end-to-end integration test that exercises the autoscaling path:

```
build scheduler with capacity=10, queue_size=4, queue_size_per_slot=1.0
  → startup limit = max(4, ceil(1.0 * 10)) = 10
fill queue to 10 (each enqueue under startup limit succeeds)
set_capacity(20) via the slot pool
  → live limit = max(4, ceil(1.0 * 20)) = 20
try_enqueue(eleventh-waiter, live_limit=20) → succeeds
```

The previous code would have rejected the 11th waiter with `QueueFull` because `FifoClassQueue::max` was still 10.

```bash
$ cargo test --package smg --lib middleware::scheduler
... 91 passed; 0 failed
```

```bash
$ cargo clippy --package smg --all-targets --all-features -- -D warnings
... no warnings
```

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes (enforced by pre-commit hook)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] (Optional) Documentation updated — design doc §3 already specified live recompute; code now matches
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Queue scheduling now dynamically adjusts admission limits based on current backend capacity, allowing additional requests to be accepted when capacity increases
  * Scheduler behavior adapts to live capacity changes instead of using fixed startup limits

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightseekorg/smg/pull/1557?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->