### PR TITLE
refactor(scheduler): remove queue_size_per_slot multiplier

### DIFF
--- a/model_gateway/src/middleware/scheduler/config.rs
+++ b/model_gateway/src/middleware/scheduler/config.rs
@@ -19,12 +19,8 @@ pub struct ClassConfig {
     /// honored by lower-class admissions via the packed-CAS slot
     /// accounting in [`super::scheduler`].
     pub reserved: u16,
-    /// Absolute floor on the per-class queue depth.
+    /// Per-class queue depth limit.
     pub queue_size: u32,
-    /// Optional multiplier: effective limit =
-    /// `max(queue_size, ceil(queue_size_per_slot * capacity))`.
-    /// `0.0` disables the multiplier (use the absolute floor only).
-    pub queue_size_per_slot: f32,
     /// How long a queued waiter waits before the admission middleware
     /// returns 408. Seconds at rest; converted to [`Duration`] in
     /// [`ClassRuntimeConfig`].
@@ -48,7 +44,6 @@ impl ClassConfig {
             Class::System => Self {
                 reserved: 32,
                 queue_size: 64,
-                queue_size_per_slot: 0.0,
                 queue_timeout_secs: 30,
                 starvation_threshold_secs: 5,
                 can_preempt: true,
@@ -56,7 +51,6 @@ impl ClassConfig {
             Class::Interactive => Self {
                 reserved: 128,
                 queue_size: 256,
-                queue_size_per_slot: 0.25,
                 queue_timeout_secs: 30,
                 starvation_threshold_secs: 5,
                 can_preempt: true,
@@ -64,7 +58,6 @@ impl ClassConfig {
             Class::Default => Self {
                 reserved: 0,
                 queue_size: 512,
-                queue_size_per_slot: 0.5,
                 queue_timeout_secs: 60,
                 starvation_threshold_secs: 30,
                 can_preempt: false,
@@ -72,7 +65,6 @@ impl ClassConfig {
             Class::Bulk => Self {
                 reserved: 0,
                 queue_size: 1024,
-                queue_size_per_slot: 1.0,
                 queue_timeout_secs: 300,
                 starvation_threshold_secs: 120,
                 can_preempt: false,
@@ -83,9 +75,8 @@ impl ClassConfig {
 
 /// Runtime view of [`ClassConfig`] — only the fields the dispatcher
 /// reads on its hot path, with seconds pre-converted to [`Duration`].
-/// `reserved`, `queue_size`, and `queue_size_per_slot` live elsewhere
-/// (the packed-CAS array and the per-class queue impl), so they don't
-/// appear here.
+/// `reserved` and `queue_size` live elsewhere (the packed-CAS array
+/// and the per-class queue impl), so they don't appear here.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ClassRuntimeConfig {
     pub queue_timeout: Duration,
@@ -133,8 +124,6 @@ pub struct PrioritySchedulerYaml {
 /// the live backend capacity is known.
 #[derive(Debug, thiserror::Error, PartialEq)]
 pub enum SettingsValidationError {
-    #[error("class {class:?}: queue_size_per_slot must be a finite, non-negative number")]
-    InvalidMultiplier { class: Class },
     #[error("class {class:?}: queue_timeout_secs must be > 0")]
     ZeroQueueTimeout { class: Class },
     #[error("class {class:?}: starvation_threshold_secs must be > 0")]
@@ -203,9 +192,6 @@ impl SchedulerSettings {
 
         for class in Class::ALL {
             let cfg = &classes[class as usize];
-            if !cfg.queue_size_per_slot.is_finite() || cfg.queue_size_per_slot < 0.0 {
-                return Err(SettingsValidationError::InvalidMultiplier { class });
-            }
             if cfg.queue_timeout_secs == 0 {
                 return Err(SettingsValidationError::ZeroQueueTimeout { class });
             }
@@ -245,7 +231,6 @@ mod tests {
         let cfg = ClassConfig::default_for(Class::System);
         assert_eq!(cfg.reserved, 32);
         assert_eq!(cfg.queue_size, 64);
-        assert_eq!(cfg.queue_size_per_slot, 0.0);
         assert_eq!(cfg.queue_timeout_secs, 30);
         assert_eq!(cfg.starvation_threshold_secs, 5);
         assert!(cfg.can_preempt);
@@ -256,7 +241,6 @@ mod tests {
         let cfg = ClassConfig::default_for(Class::Interactive);
         assert_eq!(cfg.reserved, 128);
         assert_eq!(cfg.queue_size, 256);
-        assert_eq!(cfg.queue_size_per_slot, 0.25);
         assert_eq!(cfg.queue_timeout_secs, 30);
         assert_eq!(cfg.starvation_threshold_secs, 5);
         assert!(cfg.can_preempt);
@@ -267,7 +251,6 @@ mod tests {
         let cfg = ClassConfig::default_for(Class::Default);
         assert_eq!(cfg.reserved, 0);
         assert_eq!(cfg.queue_size, 512);
-        assert_eq!(cfg.queue_size_per_slot, 0.5);
         assert_eq!(cfg.queue_timeout_secs, 60);
         assert_eq!(cfg.starvation_threshold_secs, 30);
         assert!(!cfg.can_preempt);
@@ -278,7 +261,6 @@ mod tests {
         let cfg = ClassConfig::default_for(Class::Bulk);
         assert_eq!(cfg.reserved, 0);
         assert_eq!(cfg.queue_size, 1024);
-        assert_eq!(cfg.queue_size_per_slot, 1.0);
         assert_eq!(cfg.queue_timeout_secs, 300);
         assert_eq!(cfg.starvation_threshold_secs, 120);
         assert!(!cfg.can_preempt);
@@ -318,7 +300,6 @@ classes:
   interactive:
     reserved: 200
     queue_size: 256
-    queue_size_per_slot: 0.25
     queue_timeout_secs: 30
     starvation_threshold_secs: 5
     can_preempt: true
@@ -438,26 +419,6 @@ tenant_policies:
     }
 
     #[test]
-    fn test_settings_rejects_negative_multiplier() {
-        let mut classes = HashMap::new();
-        let mut interactive = ClassConfig::default_for(Class::Interactive);
-        interactive.queue_size_per_slot = -1.0;
-        classes.insert(Class::Interactive, interactive);
-        let yaml = PrioritySchedulerYaml {
-            classes,
-            tenant_policies: Default::default(),
-        };
-        let err = SchedulerSettings::from_cli_and_yaml(true, Class::Default, 32, Some(&yaml))
-            .unwrap_err();
-        assert!(matches!(
-            err,
-            SettingsValidationError::InvalidMultiplier {
-                class: Class::Interactive
-            }
-        ));
-    }
-
-    #[test]
     fn test_settings_rejects_zero_queue_timeout() {
         let mut classes = HashMap::new();
         let mut bulk = ClassConfig::default_for(Class::Bulk);
@@ -472,67 +433,6 @@ tenant_policies:
         assert!(matches!(
             err,
             SettingsValidationError::ZeroQueueTimeout { class: Class::Bulk }
-        ));
-    }
-
-    #[test]
-    fn test_settings_rejects_nan_multiplier_from_yaml() {
-        // serde_yaml parses `.nan` into f32::NAN. Without an explicit
-        // is_finite() check, the comparison `< 0.0` is false for NaN and the
-        // bad value slips through to garbage queue-limit math later.
-        let yaml = r"
-classes:
-  interactive:
-    reserved: 128
-    queue_size: 256
-    queue_size_per_slot: .nan
-    queue_timeout_secs: 30
-    starvation_threshold_secs: 5
-    can_preempt: true
-";
-        let parsed: PrioritySchedulerYaml = serde_yaml::from_str(yaml).unwrap();
-        assert!(
-            parsed.classes[&Class::Interactive]
-                .queue_size_per_slot
-                .is_nan(),
-            "serde_yaml deserialized .nan as NaN"
-        );
-        let err = SchedulerSettings::from_cli_and_yaml(true, Class::Default, 32, Some(&parsed))
-            .unwrap_err();
-        assert!(matches!(
-            err,
-            SettingsValidationError::InvalidMultiplier {
-                class: Class::Interactive
-            }
-        ));
-    }
-
-    #[test]
-    fn test_settings_rejects_infinity_multiplier_from_yaml() {
-        let yaml = r"
-classes:
-  interactive:
-    reserved: 128
-    queue_size: 256
-    queue_size_per_slot: .inf
-    queue_timeout_secs: 30
-    starvation_threshold_secs: 5
-    can_preempt: true
-";
-        let parsed: PrioritySchedulerYaml = serde_yaml::from_str(yaml).unwrap();
-        assert!(
-            parsed.classes[&Class::Interactive]
-                .queue_size_per_slot
-                .is_infinite(),
-            "serde_yaml deserialized .inf as +Infinity"
-        );
-        let err = SchedulerSettings::from_cli_and_yaml(true, Class::Default, 32, Some(&parsed))
-            .unwrap_err();
-        assert!(matches!(
-            err,
-            SettingsValidationError::InvalidMultiplier {
-                class: Class::Interactive
-            }
         ));
     }
 

--- a/model_gateway/src/middleware/scheduler/engine.rs
+++ b/model_gateway/src/middleware/scheduler/engine.rs
@@ -103,8 +103,7 @@ impl PriorityScheduler {
         }
 
         let reserved_arr = Class::ALL.map(|c| settings.class_config(c).reserved);
-        let class_queues: [Arc<dyn ClassQueue>; 4] =
-            Class::ALL.map(|c| queue_for(settings, c, capacity));
+        let class_queues: [Arc<dyn ClassQueue>; 4] = Class::ALL.map(|c| queue_for(settings, c));
         let class_config: [ClassRuntimeConfig; 4] =
             Class::ALL.map(|c| ClassRuntimeConfig::from_class_config(settings.class_config(c)));
 
@@ -433,13 +432,11 @@ impl PriorityScheduler {
     }
 }
 
-/// Compute the effective per-class queue limit for a given backend
-/// capacity: `max(queue_size, ceil(queue_size_per_slot * capacity))`.
-fn queue_for(settings: &SchedulerSettings, class: Class, capacity: u16) -> Arc<dyn ClassQueue> {
-    let cfg = settings.class_config(class);
-    let multiplier = (cfg.queue_size_per_slot * f32::from(capacity)).ceil() as u32;
-    let limit = cfg.queue_size.max(multiplier) as usize;
-    Arc::new(FifoClassQueue::new(limit))
+/// Build the per-class queue with its configured fixed depth limit.
+fn queue_for(settings: &SchedulerSettings, class: Class) -> Arc<dyn ClassQueue> {
+    Arc::new(FifoClassQueue::new(
+        settings.class_config(class).queue_size as usize,
+    ))
 }
 
 /// RAII handle on one admitted request. Holding a permit keeps the slot
@@ -584,7 +581,6 @@ mod tests {
             cfg.reserved = 0;
             if c == class {
                 cfg.queue_size = queue_size;
-                cfg.queue_size_per_slot = 0.0;
                 cfg.queue_timeout_secs = queue_timeout_secs;
             }
             classes.insert(c, cfg);
@@ -855,7 +851,6 @@ mod tests {
             cfg.starvation_threshold_secs = 1;
             if c == Class::Bulk {
                 cfg.queue_size = 4;
-                cfg.queue_size_per_slot = 0.0;
             }
             // Interactive reserves the entire capacity, locking Bulk out
             // of the normal-priority admission path.
@@ -900,7 +895,6 @@ mod tests {
             if c == Class::Bulk {
                 cfg.starvation_threshold_secs = 1;
                 cfg.queue_size = 4;
-                cfg.queue_size_per_slot = 0.0;
             }
             // Interactive holds the full capacity in reservation.
             if c == Class::Interactive {


### PR DESCRIPTION
## Description

### Problem

`queue_size_per_slot` was intended to scale per-class queue depth with the live `WorkerCapacity`:

```
effective_limit = max(queue_size, ceil(queue_size_per_slot * capacity))
```

But it was captured at `PriorityScheduler::new` and baked into `FifoClassQueue::max`. When `apply_new_capacity` updated the slot pool's ceiling via the `WorkerCapacity::watch()` channel, the queue limit stayed frozen at the startup value — the multiplier did nothing after t=0.

### Solution

Make it actually live (two options: trait signature change so `try_enqueue` takes a `max` param, or a pre-check in `admit` before delegating) or drop the field. Both fixes are heavier than the autoscaling benefit justifies right now:

- No production path constructs a `PriorityScheduler` yet — the feature has zero users.
- Operators today get fixed `queue_size`, same semantics as the existing `concurrency_limit_middleware`.
- The multiplier can be re-added later (correctly) if an autoscaling deployment actually files an issue.

So: drop the field.

## Changes

One commit. ~9 insertions, ~115 deletions.

- **`ClassConfig`**: removed `queue_size_per_slot: f32` and removed it from all four `default_for` arms.
- **`SchedulerSettings::from_cli_and_yaml`**: dropped the `!is_finite() || < 0.0` validation block.
- **`SettingsValidationError`**: dropped the `InvalidMultiplier` variant.
- **`queue_for` (engine.rs)**: now `Arc::new(FifoClassQueue::new(queue_size as usize))` — no `capacity` parameter, no multiplier math.
- **Tests**: dropped 3 multiplier-validation tests (negative / NaN / +Infinity) and the `queue_size_per_slot` assertions in the four `default_for` tests; dropped the field from the YAML round-trip fixture and from the engine.rs `settings_with` helper.

### Backward compat

`serde` silently ignores unknown fields by default, so YAML files that still set `queue_size_per_slot: X` continue to parse — the value is just dropped on load. No operator action required.

### Design doc follow-up

`.claude/docs/scheduler/02-priority-scheduler-design.md` §3 still describes the multiplier (defaults table, YAML schema, \"Effective queue limit\" subsection). That needs a follow-up update from @slin1237 to match the implementation. Flagging here so it doesn't slip.

## Test Plan

```bash
$ cargo test --package smg --lib middleware::scheduler
... 83 passed; 0 failed
```

```bash
$ cargo clippy --package smg --all-targets --all-features -- -D warnings
... no warnings
```

Test count dropped from 86 to 83: the 3 removed tests covered the validation for a field that no longer exists.

<details>
<summary>Checklist</summary>

- [x] \`cargo +nightly fmt\` passes (enforced by pre-commit hook)
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` passes
- [ ] (Optional) Documentation updated — design doc needs follow-up from owner; flagged above
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Changes**
  * Scheduler queue configuration simplified: the multiplier-based `queue_size_per_slot` field has been removed and replaced with direct `queue_size` specification for clearer queue depth control.
  * Queue depth is now determined solely from the configured queue size value.

* **Tests**
  * Scheduler queue tests updated to reflect simplified queue calculation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightseekorg/smg/pull/1559?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->