### PR TITLE
refactor(mesh): make OperationLog strategy-free; engines own merge/compact

### DIFF
--- a/crates/mesh/src/crdt_kv/engine/lww.rs
+++ b/crates/mesh/src/crdt_kv/engine/lww.rs
@@ -231,9 +231,39 @@ impl LwwEngine {
     }
 
     fn append_op(&self, op: Operation) {
-        self.log
-            .write()
-            .append_with_strategy(op, |_| crate::crdt_kv::MergeStrategy::LastWriterWins);
+        let mut log = self.log.write();
+        log.append(op);
+        if log.len() > OperationLog::AUTO_COMPACT_THRESHOLD {
+            Self::compact_log(&mut log);
+        }
+    }
+
+    /// LWW per-key fold: the winning op is the one with the maximum
+    /// `(timestamp, replica_id)` tuple. Tombstones and inserts share the
+    /// ordering - the newer wins regardless of kind.
+    fn lww_fold(ops: &[Operation]) -> Option<Operation> {
+        ops.iter()
+            .max_by_key(|op| (op.timestamp(), op.replica_id()))
+            .cloned()
+    }
+
+    /// Compact the log per LWW rules and, as a safety valve, truncate the
+    /// oldest entries if compaction still leaves the log oversized (a
+    /// many-thousand-unique-key pathology). Truncated keys re-sync from
+    /// peers on the next merge.
+    fn compact_log(log: &mut OperationLog) {
+        log.compact_by_key(Self::lww_fold);
+        if log.len() > OperationLog::AUTO_COMPACT_THRESHOLD {
+            let keep = OperationLog::AUTO_COMPACT_THRESHOLD * 3 / 4;
+            let drain_count = log.len() - keep;
+            tracing::warn!(
+                total = log.len(),
+                draining = drain_count,
+                keeping = keep,
+                "LwwEngine log still over threshold after compaction, truncating oldest entries"
+            );
+            log.operations_mut().drain(..drain_count);
+        }
     }
 }
 
@@ -331,14 +361,23 @@ impl NamespaceCrdtEngine for LwwEngine {
             .collect();
         unseen.sort_by_key(|op| (op.timestamp(), op.replica_id()));
 
-        // Merge into the log first so subsequent compaction sees the full
-        // set, then compact. Strategy callback is LWW since this engine only
-        // hosts LWW keys.
+        // LWW op-id collision policy is dedup: an op already in the log by
+        // `(replica_id, timestamp)` is a no-op. Append unseen ops, then
+        // compact per LWW rules.
         {
             let mut log = self.log.write();
-            let incoming = OperationLog::from_operations(ops);
-            log.merge_with_strategy(&incoming, |_| crate::crdt_kv::MergeStrategy::LastWriterWins);
-            log.compact_with_strategy(|_| crate::crdt_kv::MergeStrategy::LastWriterWins);
+            let local_op_ids: std::collections::HashSet<(ReplicaId, u64)> = log
+                .operations()
+                .iter()
+                .map(|op| (op.replica_id(), op.timestamp()))
+                .collect();
+            for op in &ops {
+                let id = (op.replica_id(), op.timestamp());
+                if !local_op_ids.contains(&id) {
+                    log.append(op.clone());
+                }
+            }
+            Self::compact_log(&mut log);
         }
 
         // Apply unseen ops to live state. Lamport clock observes each remote

--- a/crates/mesh/src/crdt_kv/engine/lww.rs
+++ b/crates/mesh/src/crdt_kv/engine/lww.rs
@@ -234,7 +234,24 @@ impl LwwEngine {
         let mut log = self.log.write();
         log.append(op);
         if log.len() > OperationLog::AUTO_COMPACT_THRESHOLD {
-            Self::compact_log_and_truncate(&mut log);
+            Self::compact_log(&mut log);
+            // Safety valve for the many-thousand-unique-key pathology: if
+            // compaction couldn't bring the log below the threshold, drop
+            // the oldest entries. Only safe on this local-write path -
+            // truncating in `apply_remote_ops` would silently drop
+            // remotely-learned keys from the log even though they are live
+            // in state, breaking downstream sync from this node.
+            if log.len() > OperationLog::AUTO_COMPACT_THRESHOLD {
+                let keep = OperationLog::AUTO_COMPACT_THRESHOLD * 3 / 4;
+                let drain_count = log.len() - keep;
+                tracing::warn!(
+                    total = log.len(),
+                    draining = drain_count,
+                    keeping = keep,
+                    "LwwEngine log still over threshold after compaction, truncating oldest entries"
+                );
+                log.operations_mut().drain(..drain_count);
+            }
         }
     }
 
@@ -247,32 +264,12 @@ impl LwwEngine {
             .cloned()
     }
 
-    /// Compact the log per LWW rules. Used by `apply_remote_ops` after
-    /// absorbing a remote batch; never drops keys, only collapses duplicates
-    /// per `(timestamp, replica_id)` per key.
+    /// Compact the log per LWW rules: collapse all ops for a key down to the
+    /// one with maximum `(timestamp, replica_id)`. Never drops keys outright -
+    /// the truncate-oldest safety valve lives only on the `append_op`
+    /// local-write path.
     fn compact_log(log: &mut OperationLog) {
         log.compact_by_key(Self::lww_fold);
-    }
-
-    /// Compact and, if the log is still oversized after compaction, truncate
-    /// the oldest entries as a safety valve for the many-thousand-unique-key
-    /// pathology. Used only by `append_op` (local writes) - truncating during
-    /// `apply_remote_ops` would silently drop remotely-learned keys from the
-    /// log even though they are live in state, breaking downstream sync from
-    /// this node.
-    fn compact_log_and_truncate(log: &mut OperationLog) {
-        Self::compact_log(log);
-        if log.len() > OperationLog::AUTO_COMPACT_THRESHOLD {
-            let keep = OperationLog::AUTO_COMPACT_THRESHOLD * 3 / 4;
-            let drain_count = log.len() - keep;
-            tracing::warn!(
-                total = log.len(),
-                draining = drain_count,
-                keeping = keep,
-                "LwwEngine log still over threshold after compaction, truncating oldest entries"
-            );
-            log.operations_mut().drain(..drain_count);
-        }
     }
 }
 

--- a/crates/mesh/src/crdt_kv/engine/lww.rs
+++ b/crates/mesh/src/crdt_kv/engine/lww.rs
@@ -234,7 +234,7 @@ impl LwwEngine {
         let mut log = self.log.write();
         log.append(op);
         if log.len() > OperationLog::AUTO_COMPACT_THRESHOLD {
-            Self::compact_log(&mut log);
+            Self::compact_log_and_truncate(&mut log);
         }
     }
 
@@ -247,12 +247,21 @@ impl LwwEngine {
             .cloned()
     }
 
-    /// Compact the log per LWW rules and, as a safety valve, truncate the
-    /// oldest entries if compaction still leaves the log oversized (a
-    /// many-thousand-unique-key pathology). Truncated keys re-sync from
-    /// peers on the next merge.
+    /// Compact the log per LWW rules. Used by `apply_remote_ops` after
+    /// absorbing a remote batch; never drops keys, only collapses duplicates
+    /// per `(timestamp, replica_id)` per key.
     fn compact_log(log: &mut OperationLog) {
         log.compact_by_key(Self::lww_fold);
+    }
+
+    /// Compact and, if the log is still oversized after compaction, truncate
+    /// the oldest entries as a safety valve for the many-thousand-unique-key
+    /// pathology. Used only by `append_op` (local writes) - truncating during
+    /// `apply_remote_ops` would silently drop remotely-learned keys from the
+    /// log even though they are live in state, breaking downstream sync from
+    /// this node.
+    fn compact_log_and_truncate(log: &mut OperationLog) {
+        Self::compact_log(log);
         if log.len() > OperationLog::AUTO_COMPACT_THRESHOLD {
             let keep = OperationLog::AUTO_COMPACT_THRESHOLD * 3 / 4;
             let drain_count = log.len() - keep;
@@ -362,20 +371,13 @@ impl NamespaceCrdtEngine for LwwEngine {
         unseen.sort_by_key(|op| (op.timestamp(), op.replica_id()));
 
         // LWW op-id collision policy is dedup: an op already in the log by
-        // `(replica_id, timestamp)` is a no-op. Append unseen ops, then
-        // compact per LWW rules.
+        // `(replica_id, timestamp)` is a no-op. `unseen` was already filtered
+        // against the local log above; append it directly and compact (no
+        // truncate - this path must not drop remotely-learned keys).
         {
             let mut log = self.log.write();
-            let local_op_ids: std::collections::HashSet<(ReplicaId, u64)> = log
-                .operations()
-                .iter()
-                .map(|op| (op.replica_id(), op.timestamp()))
-                .collect();
-            for op in &ops {
-                let id = (op.replica_id(), op.timestamp());
-                if !local_op_ids.contains(&id) {
-                    log.append(op.clone());
-                }
+            for op in &unseen {
+                log.append(op.clone());
             }
             Self::compact_log(&mut log);
         }

--- a/crates/mesh/src/crdt_kv/engine/lww.rs
+++ b/crates/mesh/src/crdt_kv/engine/lww.rs
@@ -360,12 +360,19 @@ impl NamespaceCrdtEngine for LwwEngine {
             .map(|op| (op.replica_id(), op.timestamp()))
             .collect();
 
+        // Consume `ops` here so the filter moves each surviving Operation
+        // (including its `Vec<u8>` payload) into `unseen` without cloning.
         let mut unseen: Vec<Operation> = ops
-            .iter()
+            .into_iter()
             .filter(|op| !seen.contains(&(op.replica_id(), op.timestamp())))
-            .cloned()
             .collect();
         unseen.sort_by_key(|op| (op.timestamp(), op.replica_id()));
+
+        // Nothing new to apply: skip the write lock, compaction, and the
+        // clock/state replay loop entirely.
+        if unseen.is_empty() {
+            return;
+        }
 
         // LWW op-id collision policy is dedup: an op already in the log by
         // `(replica_id, timestamp)` is a no-op. `unseen` was already filtered

--- a/crates/mesh/src/crdt_kv/engine/lww.rs
+++ b/crates/mesh/src/crdt_kv/engine/lww.rs
@@ -235,22 +235,16 @@ impl LwwEngine {
         log.append(op);
         if log.len() > OperationLog::AUTO_COMPACT_THRESHOLD {
             Self::compact_log(&mut log);
-            // Safety valve for the many-thousand-unique-key pathology: if
-            // compaction couldn't bring the log below the threshold, drop
-            // the oldest entries. Only safe on this local-write path -
-            // truncating in `apply_remote_ops` would silently drop
-            // remotely-learned keys from the log even though they are live
-            // in state, breaking downstream sync from this node.
-            if log.len() > OperationLog::AUTO_COMPACT_THRESHOLD {
-                let keep = OperationLog::AUTO_COMPACT_THRESHOLD * 3 / 4;
-                let drain_count = log.len() - keep;
+            // Local-write path only: dropping oldest on the remote-merge path
+            // would shed remotely-learned keys (see the helper's docs).
+            let dropped = log.truncate_oldest_over_threshold();
+            if dropped > 0 {
                 tracing::warn!(
+                    dropped,
                     total = log.len(),
-                    draining = drain_count,
-                    keeping = keep,
-                    "LwwEngine log still over threshold after compaction, truncating oldest entries"
+                    "LwwEngine log over threshold after compaction; dropped oldest \
+                     entries (out-of-spec distinct-key count)"
                 );
-                log.operations_mut().drain(..drain_count);
             }
         }
     }

--- a/crates/mesh/src/crdt_kv/engine/rate_limit.rs
+++ b/crates/mesh/src/crdt_kv/engine/rate_limit.rs
@@ -65,7 +65,7 @@ impl RateLimitEngine {
         let mut log = self.log.write();
         log.append(op);
         if log.len() > OperationLog::AUTO_COMPACT_THRESHOLD {
-            Self::compact_log(&mut log);
+            Self::compact_log_and_truncate(&mut log);
         }
     }
 
@@ -77,11 +77,19 @@ impl RateLimitEngine {
         ratelimit::compact_operations(ops.iter())
     }
 
-    /// Compact the log via EpochMaxWins per-key fold, with the same
-    /// truncate-oldest safety valve `LwwEngine` uses if the log is still
-    /// oversized afterward (many-thousand-unique-key pathology).
+    /// Compact the log via EpochMaxWins per-key fold. Used by
+    /// `apply_remote_ops` after absorbing a remote batch; never drops keys.
     fn compact_log(log: &mut OperationLog) {
         log.compact_by_key(Self::epoch_max_wins_fold);
+    }
+
+    /// Compact and, if the log is still oversized, truncate oldest entries as
+    /// a safety valve for the many-thousand-unique-key pathology. Used only
+    /// by `append_op` (local writes) - truncating during `apply_remote_ops`
+    /// would silently drop remotely-learned shards from the log even though
+    /// they are live in state, breaking downstream sync from this node.
+    fn compact_log_and_truncate(log: &mut OperationLog) {
+        Self::compact_log(log);
         if log.len() > OperationLog::AUTO_COMPACT_THRESHOLD {
             let keep = OperationLog::AUTO_COMPACT_THRESHOLD * 3 / 4;
             let drain_count = log.len() - keep;

--- a/crates/mesh/src/crdt_kv/engine/rate_limit.rs
+++ b/crates/mesh/src/crdt_kv/engine/rate_limit.rs
@@ -62,9 +62,37 @@ impl RateLimitEngine {
     }
 
     fn append_op(&self, op: Operation) {
-        self.log
-            .write()
-            .append_with_strategy(op, |_| crate::crdt_kv::MergeStrategy::EpochMaxWins);
+        let mut log = self.log.write();
+        log.append(op);
+        if log.len() > OperationLog::AUTO_COMPACT_THRESHOLD {
+            Self::compact_log(&mut log);
+        }
+    }
+
+    /// EpochMaxWins per-key fold: defer to `epoch_max_wins::compact_operations`,
+    /// which folds every op for the key through `RateLimitState::merge`,
+    /// respecting tombstone boundaries and embedding the merged
+    /// `tombstone_version` into the compacted snapshot.
+    fn epoch_max_wins_fold(ops: &[Operation]) -> Option<Operation> {
+        ratelimit::compact_operations(ops.iter())
+    }
+
+    /// Compact the log via EpochMaxWins per-key fold, with the same
+    /// truncate-oldest safety valve `LwwEngine` uses if the log is still
+    /// oversized afterward (many-thousand-unique-key pathology).
+    fn compact_log(log: &mut OperationLog) {
+        log.compact_by_key(Self::epoch_max_wins_fold);
+        if log.len() > OperationLog::AUTO_COMPACT_THRESHOLD {
+            let keep = OperationLog::AUTO_COMPACT_THRESHOLD * 3 / 4;
+            let drain_count = log.len() - keep;
+            tracing::warn!(
+                total = log.len(),
+                draining = drain_count,
+                keeping = keep,
+                "RateLimitEngine log still over threshold after compaction, truncating oldest entries"
+            );
+            log.operations_mut().drain(..drain_count);
+        }
     }
 
     fn current_encoded(&self, key: &str) -> Option<Vec<u8>> {
@@ -330,11 +358,36 @@ impl NamespaceCrdtEngine for RateLimitEngine {
         // so generation only bumps when state truly changes.
         ops.sort_by_key(|op| (op.timestamp(), op.replica_id()));
 
+        // EpochMaxWins op-id collision policy: fold the existing log op and
+        // the incoming op via `compact_operations` so a compacted snapshot
+        // replaces a previously-seen raw payload at the same op-id (the bug
+        // class addressed in #1469). Unseen incoming ops are appended.
+        // Compaction then runs across the full log per the same fold rule.
         {
             let mut log = self.log.write();
-            let incoming = OperationLog::from_operations(ops.clone());
-            log.merge_with_strategy(&incoming, |_| crate::crdt_kv::MergeStrategy::EpochMaxWins);
-            log.compact_with_strategy(|_| crate::crdt_kv::MergeStrategy::EpochMaxWins);
+            let mut local_index: std::collections::HashMap<(ReplicaId, u64), usize> = log
+                .operations()
+                .iter()
+                .enumerate()
+                .map(|(idx, op)| ((op.replica_id(), op.timestamp()), idx))
+                .collect();
+            for op in &ops {
+                let id = (op.replica_id(), op.timestamp());
+                match local_index.get(&id).copied() {
+                    Some(local_idx) => {
+                        let folded =
+                            ratelimit::compact_operations([&log.operations()[local_idx], op]);
+                        if let Some(folded) = folded {
+                            log.operations_mut()[local_idx] = folded;
+                        }
+                    }
+                    None => {
+                        local_index.insert(id, log.operations().len());
+                        log.append(op.clone());
+                    }
+                }
+            }
+            Self::compact_log(&mut log);
         }
 
         for op in ops {

--- a/crates/mesh/src/crdt_kv/engine/rate_limit.rs
+++ b/crates/mesh/src/crdt_kv/engine/rate_limit.rs
@@ -66,22 +66,16 @@ impl RateLimitEngine {
         log.append(op);
         if log.len() > OperationLog::AUTO_COMPACT_THRESHOLD {
             Self::compact_log(&mut log);
-            // Safety valve for the many-thousand-unique-key pathology: if
-            // compaction couldn't bring the log below the threshold, drop
-            // the oldest entries. Only safe on this local-write path -
-            // truncating in `apply_remote_ops` would silently drop
-            // remotely-learned shards from the log even though they are
-            // live in state, breaking downstream sync from this node.
-            if log.len() > OperationLog::AUTO_COMPACT_THRESHOLD {
-                let keep = OperationLog::AUTO_COMPACT_THRESHOLD * 3 / 4;
-                let drain_count = log.len() - keep;
+            // Local-write path only: dropping oldest on the remote-merge path
+            // would shed remotely-learned shards (see the helper's docs).
+            let dropped = log.truncate_oldest_over_threshold();
+            if dropped > 0 {
                 tracing::warn!(
+                    dropped,
                     total = log.len(),
-                    draining = drain_count,
-                    keeping = keep,
-                    "RateLimitEngine log still over threshold after compaction, truncating oldest entries"
+                    "RateLimitEngine log over threshold after compaction; dropped oldest \
+                     entries (out-of-spec distinct-key count)"
                 );
-                log.operations_mut().drain(..drain_count);
             }
         }
     }

--- a/crates/mesh/src/crdt_kv/engine/rate_limit.rs
+++ b/crates/mesh/src/crdt_kv/engine/rate_limit.rs
@@ -65,7 +65,24 @@ impl RateLimitEngine {
         let mut log = self.log.write();
         log.append(op);
         if log.len() > OperationLog::AUTO_COMPACT_THRESHOLD {
-            Self::compact_log_and_truncate(&mut log);
+            Self::compact_log(&mut log);
+            // Safety valve for the many-thousand-unique-key pathology: if
+            // compaction couldn't bring the log below the threshold, drop
+            // the oldest entries. Only safe on this local-write path -
+            // truncating in `apply_remote_ops` would silently drop
+            // remotely-learned shards from the log even though they are
+            // live in state, breaking downstream sync from this node.
+            if log.len() > OperationLog::AUTO_COMPACT_THRESHOLD {
+                let keep = OperationLog::AUTO_COMPACT_THRESHOLD * 3 / 4;
+                let drain_count = log.len() - keep;
+                tracing::warn!(
+                    total = log.len(),
+                    draining = drain_count,
+                    keeping = keep,
+                    "RateLimitEngine log still over threshold after compaction, truncating oldest entries"
+                );
+                log.operations_mut().drain(..drain_count);
+            }
         }
     }
 
@@ -77,30 +94,11 @@ impl RateLimitEngine {
         ratelimit::compact_operations(ops.iter())
     }
 
-    /// Compact the log via EpochMaxWins per-key fold. Used by
-    /// `apply_remote_ops` after absorbing a remote batch; never drops keys.
+    /// Compact the log via EpochMaxWins per-key fold. Never drops keys
+    /// outright - the truncate-oldest safety valve lives only on the
+    /// `append_op` local-write path.
     fn compact_log(log: &mut OperationLog) {
         log.compact_by_key(Self::epoch_max_wins_fold);
-    }
-
-    /// Compact and, if the log is still oversized, truncate oldest entries as
-    /// a safety valve for the many-thousand-unique-key pathology. Used only
-    /// by `append_op` (local writes) - truncating during `apply_remote_ops`
-    /// would silently drop remotely-learned shards from the log even though
-    /// they are live in state, breaking downstream sync from this node.
-    fn compact_log_and_truncate(log: &mut OperationLog) {
-        Self::compact_log(log);
-        if log.len() > OperationLog::AUTO_COMPACT_THRESHOLD {
-            let keep = OperationLog::AUTO_COMPACT_THRESHOLD * 3 / 4;
-            let drain_count = log.len() - keep;
-            tracing::warn!(
-                total = log.len(),
-                draining = drain_count,
-                keeping = keep,
-                "RateLimitEngine log still over threshold after compaction, truncating oldest entries"
-            );
-            log.operations_mut().drain(..drain_count);
-        }
     }
 
     fn current_encoded(&self, key: &str) -> Option<Vec<u8>> {

--- a/crates/mesh/src/crdt_kv/operation.rs
+++ b/crates/mesh/src/crdt_kv/operation.rs
@@ -156,16 +156,29 @@ impl OperationLog {
     /// replica_id)`. Strategy-agnostic - the caller's `fold` decides what
     /// "winner" means (LWW: max by version; EpochMaxWins:
     /// `epoch_max_wins::compact_operations`).
+    ///
+    /// Grouping is done by sorting in-place and scanning contiguous runs,
+    /// avoiding the `String` allocation per op that a `HashMap<String, _>`
+    /// grouping would require.
     pub(super) fn compact_by_key<F>(&mut self, fold: F)
     where
         F: Fn(&[Operation]) -> Option<Operation>,
     {
-        let mut by_key: HashMap<String, Vec<Operation>> = HashMap::new();
-        for op in self.operations.drain(..) {
-            by_key.entry(op.key().to_string()).or_default().push(op);
+        self.operations
+            .sort_unstable_by(|a, b| a.key().cmp(b.key()));
+        let mut folded: Vec<Operation> = Vec::with_capacity(self.operations.len());
+        let mut start = 0;
+        while start < self.operations.len() {
+            let key = self.operations[start].key();
+            let mut end = start + 1;
+            while end < self.operations.len() && self.operations[end].key() == key {
+                end += 1;
+            }
+            if let Some(winner) = fold(&self.operations[start..end]) {
+                folded.push(winner);
+            }
+            start = end;
         }
-        let mut folded: Vec<Operation> =
-            by_key.into_values().filter_map(|ops| fold(&ops)).collect();
         folded.sort_by_key(|op| (op.timestamp(), op.replica_id()));
         self.operations = folded;
     }

--- a/crates/mesh/src/crdt_kv/operation.rs
+++ b/crates/mesh/src/crdt_kv/operation.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
-use super::{epoch_max_wins, merge_strategy::MergeStrategy, replica::ReplicaId};
+use super::replica::ReplicaId;
 
 // ============================================================================
 // Operation Type Definition - Atomic Unit of State Change
@@ -69,30 +69,29 @@ impl Operation {
             Self::Remove { replica_id, .. } => *replica_id,
         }
     }
-
-    fn operation_id(&self) -> (ReplicaId, u64) {
-        (self.replica_id(), self.timestamp())
-    }
 }
 
 // ============================================================================
 // Operation Log - State Operation Pipeline
 // ============================================================================
 
-/// Operation log, recording all state changes
+/// Strategy-agnostic append-only log of CRDT operations.
+///
+/// Each engine owns one `OperationLog` instance holding only its own
+/// namespace's operations; the log itself carries no merge-strategy knowledge.
+/// Engines drive merge (op-id collision policy) and compaction (per-key fold
+/// rule) themselves via [`Self::operations`], [`Self::operations_mut`], and
+/// [`Self::compact_by_key`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OperationLog {
     operations: Vec<Operation>,
 }
 
 impl OperationLog {
-    fn decode_counter_payload(value: &[u8]) -> Option<i64> {
-        bincode::deserialize::<i64>(value).ok().or_else(|| {
-            bincode::deserialize::<HashMap<String, i64>>(value)
-                .ok()
-                .and_then(|map| map.get("value").copied())
-        })
-    }
+    /// Threshold at which engine-driven auto-compaction triggers. Engines
+    /// check this against `len()` after each append and run their own
+    /// per-key fold to bring the log back down.
+    pub(super) const AUTO_COMPACT_THRESHOLD: usize = 10_000;
 
     /// Create empty operation log
     pub fn new() -> Self {
@@ -108,49 +107,22 @@ impl OperationLog {
         Self { operations }
     }
 
-    /// Threshold at which auto-compaction triggers. After compaction, the log
-    /// shrinks to at most one entry per unique key, so the next compaction
-    /// won't trigger until enough new operations accumulate again.
-    const AUTO_COMPACT_THRESHOLD: usize = 10_000;
-
-    /// Append operation to log. Auto-compacts when the log exceeds the threshold.
-    /// Compaction keeps only the latest operation per key, providing hysteresis:
-    /// if there are N unique keys, the next compaction triggers after N + (threshold - N)
-    /// new appends, not on every append. If compaction doesn't reduce below
-    /// threshold (very high key cardinality), the oldest entries are truncated.
+    /// Append an operation. Strategy-free: engines call this then run their
+    /// own compaction policy on whatever threshold they want.
     pub fn append(&mut self, operation: Operation) {
-        self.append_with_strategy(operation, |_| MergeStrategy::LastWriterWins);
-    }
-
-    pub(super) fn append_with_strategy<F>(&mut self, operation: Operation, strategy_for_key: F)
-    where
-        F: Fn(&str) -> MergeStrategy,
-    {
         self.operations.push(operation);
-        if self.operations.len() > Self::AUTO_COMPACT_THRESHOLD {
-            self.compact_with_strategy(strategy_for_key);
-            // If still over threshold after dedup (extremely high key cardinality
-            // >10K unique keys), truncate oldest entries. This drops state for the
-            // oldest keys, which will be re-synced from peers on the next merge.
-            // This is a safety valve — in practice mesh stores have hundreds
-            // of keys, not tens of thousands.
-            if self.operations.len() > Self::AUTO_COMPACT_THRESHOLD {
-                let keep = Self::AUTO_COMPACT_THRESHOLD * 3 / 4;
-                let drain_count = self.operations.len() - keep;
-                tracing::warn!(
-                    total = self.operations.len(),
-                    draining = drain_count,
-                    keeping = keep,
-                    "Operation log still over threshold after compaction, truncating oldest entries"
-                );
-                self.operations.drain(..drain_count);
-            }
-        }
     }
 
     /// Get all operations
     pub fn operations(&self) -> &[Operation] {
         &self.operations
+    }
+
+    /// Mutable access to the underlying op vector. Engines need this to merge
+    /// in-place with their own op-id collision policy (LWW dedups; EpochMaxWins
+    /// folds via `epoch_max_wins::compact_operations`).
+    pub(super) fn operations_mut(&mut self) -> &mut Vec<Operation> {
+        &mut self.operations
     }
 
     /// Serialize to bincode bytes.
@@ -173,79 +145,29 @@ impl OperationLog {
         self.operations.is_empty()
     }
 
-    fn latest_lww_operation<'a, I>(operations: I) -> Option<&'a Operation>
-    where
-        I: IntoIterator<Item = &'a Operation>,
-    {
-        operations
-            .into_iter()
-            .max_by_key(|operation| (operation.timestamp(), operation.replica_id()))
-    }
-
-    fn latest_epoch_max_wins_operation<'a>(
-        operations: impl IntoIterator<Item = &'a Operation>,
-    ) -> Option<Operation> {
-        epoch_max_wins::compact_operations(operations)
-    }
-
-    fn latest_operations_by_key_with_strategy<F>(
-        &self,
-        strategy_for_key: F,
-    ) -> HashMap<String, Operation>
-    where
-        F: Fn(&str) -> MergeStrategy,
-    {
-        let mut operations_by_key: HashMap<String, Vec<&Operation>> = HashMap::new();
-
-        for operation in &self.operations {
-            operations_by_key
-                .entry(operation.key().to_string())
-                .or_default()
-                .push(operation);
-        }
-
-        operations_by_key
-            .into_iter()
-            .filter_map(|(key, operations)| {
-                let latest = match strategy_for_key(&key) {
-                    MergeStrategy::LastWriterWins => {
-                        Self::latest_lww_operation(operations).cloned()
-                    }
-                    MergeStrategy::EpochMaxWins => {
-                        Self::latest_epoch_max_wins_operation(operations)
-                    }
-                }?;
-                Some((key, latest))
-            })
-            .collect()
-    }
-
-    pub(super) fn compact_with_strategy<F>(&mut self, strategy_for_key: F)
-    where
-        F: Fn(&str) -> MergeStrategy,
-    {
-        self.operations = self
-            .latest_operations_by_key_with_strategy(strategy_for_key)
-            .into_values()
-            .collect::<Vec<_>>();
-        self.operations
-            .sort_by_key(|operation| (operation.timestamp(), operation.replica_id()));
-    }
-
     /// Drop operations with timestamp <= watermark.
     pub fn compact_up_to(&mut self, watermark: u64) {
         self.operations
             .retain(|operation| operation.timestamp() > watermark);
     }
 
-    /// Build a latest-state snapshot with the configured merge strategy and clear the operation log.
-    pub fn snapshot_and_truncate<F>(&mut self, strategy_for_key: F) -> HashMap<String, Operation>
+    /// Group operations by key, fold each group via `fold`, and replace the
+    /// log with the resulting per-key winners sorted by `(timestamp,
+    /// replica_id)`. Strategy-agnostic - the caller's `fold` decides what
+    /// "winner" means (LWW: max by version; EpochMaxWins:
+    /// `epoch_max_wins::compact_operations`).
+    pub(super) fn compact_by_key<F>(&mut self, fold: F)
     where
-        F: Fn(&str) -> MergeStrategy,
+        F: Fn(&[Operation]) -> Option<Operation>,
     {
-        let snapshot = self.latest_operations_by_key_with_strategy(strategy_for_key);
-        self.operations.clear();
-        snapshot
+        let mut by_key: HashMap<String, Vec<Operation>> = HashMap::new();
+        for op in self.operations.drain(..) {
+            by_key.entry(op.key().to_string()).or_default().push(op);
+        }
+        let mut folded: Vec<Operation> =
+            by_key.into_values().filter_map(|ops| fold(&ops)).collect();
+        folded.sort_by_key(|op| (op.timestamp(), op.replica_id()));
+        self.operations = folded;
     }
 
     /// Decode the latest known counter value for a key from log payloads.
@@ -257,7 +179,7 @@ impl OperationLog {
             .max_by_key(|operation| (operation.timestamp(), operation.replica_id()))?;
 
         match latest {
-            Operation::Insert { value, .. } => Self::decode_counter_payload(value),
+            Operation::Insert { value, .. } => decode_counter_payload(value),
             Operation::Remove { .. } => None,
         }
     }
@@ -270,49 +192,8 @@ impl OperationLog {
             .max_by_key(|operation| (operation.timestamp(), operation.replica_id()))?;
 
         match latest {
-            Operation::Insert { value, .. } => Self::decode_counter_payload(value),
+            Operation::Insert { value, .. } => decode_counter_payload(value),
             Operation::Remove { .. } => None,
-        }
-    }
-
-    /// Per-key strategy-aware merge. For `EpochMaxWins` keys, an incoming
-    /// operation that collides on `(replica_id, timestamp)` with an existing
-    /// local op is folded via `epoch_max_wins::compact_operations` so a
-    /// compacted payload (carrying an embedded tombstone_version or richer
-    /// frontier) replaces the older raw payload at the same op id. LWW keys
-    /// dedup by op id.
-    pub(super) fn merge_with_strategy<F>(&mut self, other: &OperationLog, strategy_for_key: F)
-    where
-        F: Fn(&str) -> MergeStrategy,
-    {
-        let mut local_index: HashMap<(ReplicaId, u64), usize> = self
-            .operations
-            .iter()
-            .enumerate()
-            .map(|(idx, op)| (op.operation_id(), idx))
-            .collect();
-
-        for operation in &other.operations {
-            let op_id = operation.operation_id();
-            match local_index.get(&op_id).copied() {
-                None => {
-                    local_index.insert(op_id, self.operations.len());
-                    self.operations.push(operation.clone());
-                }
-                Some(local_idx) => {
-                    if matches!(
-                        strategy_for_key(operation.key()),
-                        MergeStrategy::EpochMaxWins
-                    ) {
-                        let local_op = self.operations[local_idx].clone();
-                        if let Some(folded) =
-                            epoch_max_wins::compact_operations([&local_op, operation])
-                        {
-                            self.operations[local_idx] = folded;
-                        }
-                    }
-                }
-            }
         }
     }
 }
@@ -321,4 +202,12 @@ impl Default for OperationLog {
     fn default() -> Self {
         Self::new()
     }
+}
+
+fn decode_counter_payload(value: &[u8]) -> Option<i64> {
+    bincode::deserialize::<i64>(value).ok().or_else(|| {
+        bincode::deserialize::<HashMap<String, i64>>(value)
+            .ok()
+            .and_then(|map| map.get("value").copied())
+    })
 }

--- a/crates/mesh/src/crdt_kv/operation.rs
+++ b/crates/mesh/src/crdt_kv/operation.rs
@@ -125,6 +125,30 @@ impl OperationLog {
         &mut self.operations
     }
 
+    /// Memory backstop: if the log is still over `AUTO_COMPACT_THRESHOLD`
+    /// after the caller has compacted it, drop the oldest entries down to 75%
+    /// of the threshold. Returns the number of entries dropped (0 if under
+    /// threshold) so the caller can log with its own context.
+    ///
+    /// This only fires when distinct live keys exceed the threshold - far
+    /// beyond the design's expected key count. It trades convergence for the
+    /// dropped keys against unbounded log growth; that trade is only
+    /// acceptable because reaching it signals an out-of-spec key count in the
+    /// first place.
+    ///
+    /// Callers MUST invoke this only on the local-write path. Dropping on a
+    /// remote-merge path would shed remotely-learned keys that are live in
+    /// state, breaking downstream sync from this node.
+    pub(super) fn truncate_oldest_over_threshold(&mut self) -> usize {
+        if self.operations.len() <= Self::AUTO_COMPACT_THRESHOLD {
+            return 0;
+        }
+        let keep = Self::AUTO_COMPACT_THRESHOLD * 3 / 4;
+        let drain_count = self.operations.len() - keep;
+        self.operations.drain(..drain_count);
+        drain_count
+    }
+
     /// Serialize to bincode bytes.
     pub fn to_bytes(&self) -> Result<Vec<u8>, Box<bincode::ErrorKind>> {
         bincode::serialize(self)

--- a/crates/mesh/src/crdt_kv/tests.rs
+++ b/crates/mesh/src/crdt_kv/tests.rs
@@ -7,7 +7,7 @@ use tracing_subscriber::{
 
 use super::{
     crdt::CrdtOrMap,
-    epoch_max_wins::{decode, encode, EpochCount},
+    epoch_max_wins::{self, decode, encode, EpochCount},
     merge_strategy::MergeStrategy,
     operation::{Operation, OperationLog},
     replica::ReplicaId,
@@ -849,23 +849,30 @@ fn test_operation_log_binary_serialization() {
 }
 
 #[test]
-fn test_operation_log_merge_deduplicates() {
+fn test_lww_apply_remote_ops_is_idempotent() {
+    // LWW dedups by op-id on remote apply: a log already absorbed once must
+    // not grow the local log when re-applied. Previously tested via
+    // `OperationLog::merge_with_strategy`; now that merge policy lives in
+    // `LwwEngine::apply_remote_ops`, exercise it through `CrdtOrMap`.
     init_test_logging();
-    let map = CrdtOrMap::new();
+    let source = CrdtOrMap::new();
+    source.insert("key1".to_string(), b"value1".to_vec());
+    source.insert("key2".to_string(), b"value2".to_vec());
+    source.remove("key1");
 
-    map.insert("key1".to_string(), b"value1".to_vec());
-    map.insert("key2".to_string(), b"value2".to_vec());
-    map.remove("key1");
+    let log = source.get_operation_log();
+    let receiver = CrdtOrMap::new();
 
-    let log = map.get_operation_log();
+    receiver.merge(&log);
+    let after_first = receiver.get_operation_log().len();
 
-    let mut merged_log = OperationLog::new();
-    merged_log.merge_with_strategy(&log, |_| MergeStrategy::LastWriterWins);
-    let merged_once_len = merged_log.len();
+    receiver.merge(&log);
+    let after_second = receiver.get_operation_log().len();
 
-    // Re-merging the same log should be a no-op for log length.
-    merged_log.merge_with_strategy(&log, |_| MergeStrategy::LastWriterWins);
-    assert_eq!(merged_log.len(), merged_once_len);
+    assert_eq!(
+        after_first, after_second,
+        "re-applying the same log must be a no-op for log length",
+    );
 }
 
 #[test]
@@ -884,20 +891,18 @@ fn test_operation_log_snapshot_uses_merge_strategy() {
     log.append(stale_newer_timestamp);
     log.append(epoch_winner_older_timestamp);
 
-    let snapshot = log.snapshot_and_truncate(|key| {
-        if key.starts_with("rl:") {
-            MergeStrategy::EpochMaxWins
-        } else {
-            MergeStrategy::LastWriterWins
-        }
-    });
+    log.compact_by_key(|ops| epoch_max_wins::compact_operations(ops.iter()));
+    let winner = log
+        .operations()
+        .iter()
+        .find(|op| op.key() == key)
+        .expect("compaction keeps rl shard");
 
-    let Operation::Insert { value, .. } = snapshot.get(key).expect("snapshot keeps rl shard")
-    else {
-        panic!("snapshot should keep an insert");
+    let Operation::Insert { value, .. } = winner else {
+        panic!("compaction should keep an insert");
     };
     assert_eq!(decode(value), Some(EpochCount { epoch: 6, count: 0 }));
-    assert!(log.is_empty(), "snapshot truncates the source log");
+    assert_eq!(log.len(), 1, "compaction folds duplicates per key");
 }
 
 #[test]
@@ -951,16 +956,10 @@ fn test_operation_log_epoch_max_wins_tombstone_selection_is_order_independent() 
             log.append(operation);
         }
 
-        let snapshot = log.snapshot_and_truncate(|key| {
-            if key.starts_with("rl:") {
-                MergeStrategy::EpochMaxWins
-            } else {
-                MergeStrategy::LastWriterWins
-            }
-        });
-
-        let Some(Operation::Remove { timestamp, .. }) = snapshot.get(key) else {
-            panic!("tombstone should win consistently for order {snapshot:?}");
+        log.compact_by_key(|ops| epoch_max_wins::compact_operations(ops.iter()));
+        let winner = log.operations().iter().find(|op| op.key() == key);
+        let Some(Operation::Remove { timestamp, .. }) = winner else {
+            panic!("tombstone should win consistently; got {winner:?}");
         };
         assert_eq!(*timestamp, 95);
     }
@@ -1017,19 +1016,13 @@ fn test_operation_log_epoch_max_wins_post_tombstone_insert_revives_key() {
             log.append(operation);
         }
 
-        let snapshot = log.snapshot_and_truncate(|key| {
-            if key.starts_with("rl:") {
-                MergeStrategy::EpochMaxWins
-            } else {
-                MergeStrategy::LastWriterWins
-            }
-        });
-
+        log.compact_by_key(|ops| epoch_max_wins::compact_operations(ops.iter()));
+        let winner = log.operations().iter().find(|op| op.key() == key);
         let Some(Operation::Insert {
             value, timestamp, ..
-        }) = snapshot.get(key)
+        }) = winner
         else {
-            panic!("post-tombstone insert should revive key for order {snapshot:?}");
+            panic!("post-tombstone insert should revive key; got {winner:?}");
         };
         assert_eq!(*timestamp, 100);
         assert_eq!(decode(value), Some(EpochCount { epoch: 6, count: 0 }));
@@ -1054,17 +1047,11 @@ fn test_operation_log_epoch_max_wins_post_tombstone_insert_wins_over_pre_tombsto
     log.append(tombstone_between);
     log.append(newer_insert);
 
-    let snapshot = log.snapshot_and_truncate(|key| {
-        if key.starts_with("rl:") {
-            MergeStrategy::EpochMaxWins
-        } else {
-            MergeStrategy::LastWriterWins
-        }
-    });
-
+    log.compact_by_key(|ops| epoch_max_wins::compact_operations(ops.iter()));
+    let winner = log.operations().iter().find(|op| op.key() == key);
     let Some(Operation::Insert {
         value, timestamp, ..
-    }) = snapshot.get(key)
+    }) = winner
     else {
         panic!("newer equal-value insert should win over intermediate tombstone");
     };


### PR DESCRIPTION
## Description

### Problem

After #1539 split CRDT logic into per-namespace engines and #1549 made the rate-limit engine typed, every callsite of `OperationLog`'s strategy-aware methods (`append_with_strategy`, `merge_with_strategy`, `compact_with_strategy`) passed a constant closure:

```rust
log.append_with_strategy(op, |_| MergeStrategy::LastWriterWins);
log.merge_with_strategy(&incoming, |_| MergeStrategy::EpochMaxWins);
log.compact_with_strategy(|_| MergeStrategy::EpochMaxWins);
```

The closure parameter existed for a world where one shared log served multiple strategies and had to dispatch per-key. Now each engine's log only ever holds its own strategy's ops, so the parameter is dead architecture — but every callsite still has to remember to pass it, and `OperationLog` still carries strategy knowledge it doesn't need.

Plus `OperationLog::snapshot_and_truncate` was public API with zero production callers (only 4 test sites referenced it).

### Solution

Make `OperationLog` strategy-free; move merge and compact policy into each engine, where the typed knowledge already lives. This closes migration step 6 from #1540 ("Make `OperationLog::merge` non-public or engine-owned, so there is no default-to-LWW path for non-LWW data").

### Old vs new callsite flow

**Before this PR — strategy knowledge threaded through OperationLog on every call:**

```
LwwEngine::append_op(op)
    → log.append_with_strategy(op, |_| LWW)
        → push op + (if oversized) compact_with_strategy(|_| LWW) + truncate-oldest

LwwEngine::apply_remote_ops(ops)
    → log.merge_with_strategy(&incoming, |_| LWW)    // append unseen, branch on strategy per-collision
    → log.compact_with_strategy(|_| LWW)             // group by key, branch on strategy per-group

RateLimitEngine::append_op(op)
    → log.append_with_strategy(op, |_| EpochMaxWins)
        → push op + (if oversized) compact_with_strategy(|_| EpochMaxWins) + truncate-oldest

RateLimitEngine::apply_remote_ops(ops)
    → log.merge_with_strategy(&incoming, |_| EpochMaxWins)  // op-id collision branches: dedup vs fold
    → log.compact_with_strategy(|_| EpochMaxWins)           // per-key fold branches on strategy

OperationLog had to know: which strategy each key uses,
how to dedup vs fold on op-id collision, how to compact per key per strategy.
```

**After this PR — strategy knowledge lives in the engine; OperationLog is pure data:**

```
LwwEngine::append_op(op)
    → log.append(op)
    → if oversized:
        Self::compact_log(log)              // log.compact_by_key(lww_fold)
        if STILL oversized: drain oldest    // safety-valve truncate, INLINE here

LwwEngine::apply_remote_ops(ops)
    → compute `unseen` (ops not in log by op-id)        // LWW dedup policy: skip seen
    → for op in unseen: log.append(op)
    → Self::compact_log(log)                            // compact only, no truncate

RateLimitEngine::append_op(op)
    → log.append(op)
    → if oversized:
        Self::compact_log(log)              // log.compact_by_key(epoch_max_wins_fold)
        if STILL oversized: drain oldest    // safety-valve truncate, INLINE here

RateLimitEngine::apply_remote_ops(ops)
    → for op in ops: if op-id collision: fold via compact_operations    // EMW collision policy
                     else: append
    → Self::compact_log(log)                            // compact only, no truncate

OperationLog knows: nothing strategy-specific.
Provides: append(op), operations(), operations_mut(),
          compact_by_key(fold) where the caller picks the fold.
```

Two structural properties the new shape makes visible:

1. **Strategy lives with the engine.** Each engine names its own per-key `fold` function (`lww_fold` or `epoch_max_wins_fold`) and its own op-id collision policy. No closure of strategy enums threaded through anything. Adding a third engine doesn't touch `OperationLog`.

2. **Truncate-oldest fires only on the local-write path.** The safety valve is inlined inside `append_op`, not behind a helper that `apply_remote_ops` could accidentally call. Truncating in `apply_remote_ops` would silently drop remotely-learned keys from the log (still live in state) and break downstream sync from this node — the asymmetry is now structural, not just policy.

## Changes

**`crates/mesh/src/crdt_kv/operation.rs`** — `OperationLog` becomes a thin strategy-free log:
- Deleted: `append_with_strategy`, `merge_with_strategy`, `compact_with_strategy`, `latest_operations_by_key_with_strategy`, `latest_lww_operation`, `latest_epoch_max_wins_operation`, `snapshot_and_truncate`, `operation_id` (unused).
- `append(op)` is now strategy-free, no auto-compact.
- Added `compact_by_key(fold)`: strategy-agnostic group-by-key + per-key fold helper, using in-place sort-and-scan to avoid per-op `String` allocations (~10K allocations saved per compaction at threshold).
- Added `operations_mut()` for in-place merging by engines.
- `AUTO_COMPACT_THRESHOLD` exposed as `pub(super) const` for engines to gate their own auto-compact policy.
- `MergeStrategy` no longer appears in this file.

**`crates/mesh/src/crdt_kv/engine/lww.rs`** — owns LWW merge and compaction:
- `lww_fold`: per-key fold returns the op with max `(timestamp, replica_id)`.
- `compact_log`: runs `compact_by_key(lww_fold)`. Used by both `append_op` and `apply_remote_ops`. Never drops keys.
- `append_op`: appends + if oversized, compacts + inline safety-valve truncate.
- `apply_remote_ops`: pre-filters `unseen` ops by op-id under the read lock, appends them under the write lock, compacts (no truncate). LWW op-id collision policy is dedup.

**`crates/mesh/src/crdt_kv/engine/rate_limit.rs`** — owns EpochMaxWins merge and compaction:
- `epoch_max_wins_fold`: per-key fold delegates to `epoch_max_wins::compact_operations`.
- `compact_log`: runs `compact_by_key(epoch_max_wins_fold)`. Same shape as LWW. Never drops keys.
- `append_op`: same auto-compact pattern with inline safety-valve truncate.
- `apply_remote_ops`: EMW op-id collision policy is *fold*, not dedup — when an incoming op matches a local op's `(replica_id, timestamp)`, fold the pair via `compact_operations` so a compacted snapshot replaces a previously-seen raw payload at the same op-id. Preserves the #1469 fix.

**`crates/mesh/src/crdt_kv/tests.rs`** — test updates:
- 4 `snapshot_and_truncate` sites use the new `compact_by_key` helper directly with `epoch_max_wins::compact_operations` as the fold. Properties tested unchanged.
- `test_operation_log_merge_deduplicates` (tested LWW dedup via the deleted `merge_with_strategy`) is replaced by `test_lww_apply_remote_ops_is_idempotent` exercising the same property through `CrdtOrMap::merge`.

## Test Plan

- [x] `cargo test -p smg-mesh --lib` — 150 passed, 0 failed
- [x] `cargo clippy -p smg-mesh --all-targets` — clean
- [x] `cargo check --workspace` — clean

Net: **+222 / -250 ≈ -28 lines** across the four files.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust remote replication: incoming operations are filtered and applied idempotently to avoid duplicate or conflicting entries.
  * Deterministic conflict resolution for concurrent operations.

* **Performance & Reliability**
  * Improved operation-log compaction for better space efficiency.
  * Added safety truncation and warnings when compaction cannot reduce log size.

* **Tests**
  * Updated CRDT tests and added an idempotency test for remote apply behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightseekorg/smg/pull/1560?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->