### PR TITLE
feat(multimodal): route Qwen3.5 family to Qwen3-VL processor

### DIFF
--- a/crates/multimodal/src/registry/qwen3_vl.rs
+++ b/crates/multimodal/src/registry/qwen3_vl.rs
@@ -28,10 +28,13 @@ impl ModelProcessorSpec for Qwen3VLVisionSpec {
 
     fn matches(&self, metadata: &ModelMetadata) -> bool {
         let id = metadata.model_id.to_ascii_lowercase();
-        id.contains("qwen3") && id.contains("vl")
-            || metadata
-                .config_model_type()
-                .is_some_and(|mt| mt == "qwen3_vl")
+        let model_type = metadata.config_model_type();
+        let is_qwen3_vl = id.contains("qwen3") && id.contains("vl")
+            || model_type.is_some_and(|mt| mt == "qwen3_vl");
+        let is_qwen3_5 = id.contains("qwen3.5")
+            || id.contains("qwen3.6")
+            || model_type.is_some_and(|mt| mt == "qwen3_5" || mt == "qwen3_5_moe");
+        is_qwen3_vl || is_qwen3_5
     }
 
     fn placeholder_token(&self, metadata: &ModelMetadata) -> RegistryResult<String> {
@@ -176,6 +179,25 @@ mod tests {
         let spec = registry
             .lookup(&metadata)
             .expect("should match qwen3 alias");
+        assert_eq!(spec.name(), "qwen3_vl");
+    }
+
+    #[test]
+    fn qwen3_5_matches_alias_via_model_type() {
+        let tokenizer = TestTokenizer::new(&[("<|image_pad|>", 151655)]);
+        let config = json!({
+            "model_type": "qwen3_5_moe",
+            "image_token_id": 151655,
+        });
+        let metadata = ModelMetadata {
+            model_id: "custom-model",
+            tokenizer: &tokenizer,
+            config: &config,
+        };
+        let registry = ModelRegistry::new();
+        let spec = registry
+            .lookup(&metadata)
+            .expect("should match qwen3.5 alias");
         assert_eq!(spec.name(), "qwen3_vl");
     }
 }

--- a/crates/multimodal/src/vision/image_processor.rs
+++ b/crates/multimodal/src/vision/image_processor.rs
@@ -376,6 +376,7 @@ impl ImageProcessorRegistry {
     /// - `qwen2-vl` -> Qwen2VLProcessor
     /// - `qwen2.5-vl` -> Qwen2VLProcessor (same preprocessing as Qwen2-VL)
     /// - `qwen3-vl` -> Qwen3VLProcessor (patch_size=16, [0.5,0.5,0.5] normalization)
+    /// - `qwen3.5` / `qwen3_5` -> Qwen3VLProcessor (Qwen3.5 reuses Qwen3-VL preprocessing)
     /// - `phi-3-vision` -> Phi3VisionProcessor (HD transform with 336x336 tiles)
     pub fn with_defaults() -> Self {
         let mut registry = Self::new();
@@ -413,6 +414,24 @@ impl ImageProcessorRegistry {
         );
         registry.register(
             "qwen3_vl",
+            Box::new(super::processors::Qwen3VLProcessor::new()),
+        );
+
+        // Qwen3.5 family (and Qwen3.6: same arch) reuses Qwen3-VL preprocessing.
+        registry.register(
+            "qwen3.5",
+            Box::new(super::processors::Qwen3VLProcessor::new()),
+        );
+        registry.register(
+            "qwen3_5",
+            Box::new(super::processors::Qwen3VLProcessor::new()),
+        );
+        registry.register(
+            "qwen3.6",
+            Box::new(super::processors::Qwen3VLProcessor::new()),
+        );
+        registry.register(
+            "qwen3_6",
             Box::new(super::processors::Qwen3VLProcessor::new()),
         );
 


### PR DESCRIPTION
## Description

### Problem

`Qwen3.5-*` model ids hit `Multimodal not supported for model: <id>` at the preparation stage. The existing workaround is to alias the served name to include a `qwen3-vl` substring.

### Solution

Qwen3.5 unifies the vision tower into the base model: every official `Qwen3.5-*` checkpoint ships `vision_config` and reuses Qwen3-VL preprocessing. `Qwen3.6-*` keeps the same `Qwen3_5(Moe)ForConditionalGeneration` arch and `qwen3_5` / `qwen3_5_moe` `model_type`. Extend the existing Qwen3-VL dispatch on both registries to recognize this family.

## Changes

- `crates/multimodal/src/registry/qwen3_vl.rs`: extend `Qwen3VLVisionSpec::matches` to also accept `qwen3.5` / `qwen3.6` model_id substrings and `qwen3_5` / `qwen3_5_moe` model_types; add a unit test mirroring `qwen3_vl_matches_alias_via_model_type`.
- `crates/multimodal/src/vision/image_processor.rs`: register `qwen3.5` / `qwen3_5` patterns so `Qwen3VLProcessor` is selected for them.

## Test Plan

- `cargo +nightly fmt --all` — clean.
- `cargo clippy -p llm-multimodal --all-targets --all-features -- -D warnings` — clean.
- `cargo test -p llm-multimodal` — 156 passed, including new `qwen3_5_matches_alias_via_model_type`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended recognition for additional Qwen variants: Qwen3.5 (including MOE) and Qwen3.6 are now treated as aliases of the Qwen3-VL processor.

* **Documentation**
  * Clarified preprocessing reuse for Qwen3.x variants and documented the aliasing behavior.

* **Tests**
  * Added unit test coverage to verify model-variant recognition and alias matching.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightseekorg/smg/pull/1563?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->