### PR TITLE
fix(metrics): add /v1/messages to route_to_endpoint match

### DIFF
--- a/model_gateway/src/routers/grpc/utils/metrics.rs
+++ b/model_gateway/src/routers/grpc/utils/metrics.rs
@@ -12,6 +12,7 @@ pub(crate) fn route_to_endpoint(route: &str) -> &'static str {
         "/v1/completions" => metrics_labels::ENDPOINT_COMPLETIONS,
         "/v1/rerank" => metrics_labels::ENDPOINT_RERANK,
         "/v1/responses" => metrics_labels::ENDPOINT_RESPONSES,
+        "/v1/messages" => metrics_labels::ENDPOINT_MESSAGES,
         "/v1/audio/transcriptions" => metrics_labels::ENDPOINT_AUDIO_TRANSCRIPTIONS,
         _ => "other",
     }


### PR DESCRIPTION
Without this, all Messages API metrics from the HTTP router get bucketed under "other" instead of the existing ENDPOINT_MESSAGES label.

## Description

### Problem

<!-- What problem is this PR trying to solve? -->

### Solution

<!-- How does this PR solve the problem? -->

## Changes

<!-- - Describe your changes here. -->

## Test Plan

<!-- Provide a thorough reproducible test showing before and after behavior. -->

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced metrics tracking for message endpoints to improve service observability and monitoring capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightseekorg/smg/pull/1564?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->