### PR TITLE
refactor(reasoning-parser): rename Glm45Parser to GlmParser with catch-all "glm" pattern

### DIFF
--- a/crates/reasoning_parser/README.md
+++ b/crates/reasoning_parser/README.md
@@ -47,7 +47,7 @@ async fn main() {
 | DeepSeek-R1 | `<think>`/`</think>` | Starts in reasoning mode |
 | Qwen3 | `<think>`/`</think>` | Explicit reasoning blocks |
 | Qwen3-Thinking | `<think>`/`</think>` | Starts in reasoning mode |
-| GLM-4.5/4.6/4.7 | `<think>`/`</think>` | Explicit reasoning blocks |
+| GLM (4.5/4.7/5/5.1) | `<think>`/`</think>` | Explicit reasoning blocks |
 | Kimi | `◁think▷`/`◁/think▷` | Unicode delimiters |
 | Step3 | `<think>`/`</think>` | Starts in reasoning mode |
 | MiniMax M2 | `<think>`/`</think>` | Auto-prepends start token |
@@ -252,7 +252,7 @@ Pattern priority (first match wins):
 1. `deepseek-r1` → DeepSeekR1Parser
 2. `qwen3-thinking` / `qwen-thinking` → QwenThinkingParser
 3. `qwen3` / `qwen` → Qwen3Parser
-4. `glm45` / `glm46` / `glm47` → Glm45Parser
+4. `glm` → GlmParser
 5. `kimi` → KimiParser
 6. `step3` → Step3Parser
 7. `minimax` / `mm-m2` → MiniMaxParser

--- a/crates/reasoning_parser/src/README.md
+++ b/crates/reasoning_parser/src/README.md
@@ -25,7 +25,7 @@ The reasoning parser layer provides a unified interface for detecting and extrac
 
 ### Architecture Highlights
 
-- **Model-Specific Parsers**: DeepSeek-R1, Qwen3, Kimi, GLM45, GLM47, Step3 variants
+- **Model-Specific Parsers**: DeepSeek-R1, Qwen3, Kimi, GLM, Step3 variants
 - **Parser Pooling**: Singleton instances per model type for memory efficiency
 - **High Concurrency**: Mutex-protected parsers handle 1000+ req/sec
 - **Buffer Overflow Protection**: Configurable max buffer size (default 64KB)
@@ -55,7 +55,7 @@ graph TB
         PP --> QW[Qwen3]
         PP --> QWT[Qwen3-Thinking]
         PP --> KM[Kimi]
-        PP --> GL[GLM45/GLM47]
+        PP --> GL[GLM]
         PP --> S3[Step3]
         PP --> PT[Passthrough]
     end
@@ -196,7 +196,7 @@ classDiagram
         +new() Self
     }
 
-    class Glm45Parser {
+    class GlmParser {
         -base: BaseReasoningParser
         +new() Self
     }
@@ -229,14 +229,14 @@ classDiagram
     ReasoningParser <|.. Qwen3Parser
     ReasoningParser <|.. QwenThinkingParser
     ReasoningParser <|.. KimiParser
-    ReasoningParser <|.. Glm45Parser
+    ReasoningParser <|.. GlmParser
     ReasoningParser <|.. Step3Parser
 
     DeepSeekR1Parser o-- BaseReasoningParser
     Qwen3Parser o-- BaseReasoningParser
     QwenThinkingParser o-- BaseReasoningParser
     KimiParser o-- BaseReasoningParser
-    Glm45Parser o-- BaseReasoningParser
+    GlmParser o-- BaseReasoningParser
     Step3Parser o-- BaseReasoningParser
 
     BaseReasoningParser o-- ParserConfig
@@ -325,7 +325,7 @@ classDiagram
 - `qwen3`: Qwen3 base model (initial_in_reasoning=false)
 - `qwen3_thinking`: Qwen3 thinking variant (initial_in_reasoning=true)
 - `kimi`: Kimi with Unicode tokens
-- `glm45`: GLM-4.5 / GLM-4.6 / GLM-4.7 parser
+- `glm`: GLM series parser (4.5, 4.7, 5, 5.1, etc.)
 - `step3`: Step3 parser
 - `passthrough`: No-op fallback parser
 
@@ -336,8 +336,7 @@ classDiagram
 "qwen-thinking" → "qwen3_thinking"
 "qwen3" → "qwen3"
 "qwen" → "qwen3"
-"glm45" → "glm45"
-"glm47" → "glm45"
+"glm" → "glm"
 "kimi" → "kimi"
 "step3" → "step3"
 ```

--- a/crates/reasoning_parser/src/factory.rs
+++ b/crates/reasoning_parser/src/factory.rs
@@ -8,7 +8,7 @@ use tokio::sync::Mutex;
 
 use crate::{
     parsers::{
-        BaseReasoningParser, CohereCmdParser, DeepSeekR1Parser, Glm45Parser, KimiParser,
+        BaseReasoningParser, CohereCmdParser, DeepSeekR1Parser, GlmParser, KimiParser,
         MiniMaxParser, NanoV3Parser, PassthroughParser, Qwen3Parser, QwenThinkingParser,
         Step3Parser,
     },
@@ -192,8 +192,8 @@ impl ParserFactory {
         // Register Kimi parser with Unicode tokens (starts with in_reasoning=false)
         registry.register_parser("kimi", || Box::new(KimiParser::new()));
 
-        // Register GLM45 parser (same format as Qwen3 but separate for debugging)
-        registry.register_parser("glm45", || Box::new(Glm45Parser::new()));
+        // Register GLM parser (same format as Qwen3 but separate for debugging)
+        registry.register_parser("glm", || Box::new(GlmParser::new()));
 
         // Register Step3 parser (same format as DeepSeek-R1 but separate for debugging)
         registry.register_parser("step3", || Box::new(Step3Parser::new()));
@@ -251,8 +251,7 @@ impl ParserFactory {
         registry.register_pattern("qwen-thinking", "qwen3_thinking");
         registry.register_pattern("qwen3", "qwen3");
         registry.register_pattern("qwen", "qwen3");
-        registry.register_pattern("glm45", "glm45");
-        registry.register_pattern("glm47", "glm45"); // glm47 uses same reasoning format as glm45
+        registry.register_pattern("glm", "glm");
         registry.register_pattern("kimi-k2-thinking", "kimi_thinking");
         registry.register_pattern("kimi-k2.5", "kimi_k25");
         registry.register_pattern("kimi", "kimi"); // legacy: Kimi-K2-Instruct with unicode tokens
@@ -392,10 +391,10 @@ mod tests {
     }
 
     #[test]
-    fn test_glm45_model() {
+    fn test_glm_model() {
         let factory = ParserFactory::new();
-        let glm45 = factory.create("glm45-v2");
-        assert_eq!(glm45.model_type(), "glm45");
+        let glm = factory.create("glm45-v2");
+        assert_eq!(glm.model_type(), "glm");
     }
 
     #[test]

--- a/crates/reasoning_parser/src/factory.rs
+++ b/crates/reasoning_parser/src/factory.rs
@@ -393,8 +393,18 @@ mod tests {
     #[test]
     fn test_glm_model() {
         let factory = ParserFactory::new();
-        let glm = factory.create("glm45-v2");
-        assert_eq!(glm.model_type(), "glm");
+
+        // Direct parser name
+        assert_eq!(factory.create("glm").model_type(), "glm");
+
+        // Substring matching for existing and future GLM versions
+        assert_eq!(factory.create("glm45-v2").model_type(), "glm");
+        assert_eq!(factory.create("glm47-chat").model_type(), "glm");
+        assert_eq!(factory.create("glm5-chat").model_type(), "glm");
+        assert_eq!(factory.create("glm51-chat").model_type(), "glm");
+
+        // has_parser exact match (used by --reasoning-parser validation)
+        assert!(factory.registry().has_parser("glm"));
     }
 
     #[test]

--- a/crates/reasoning_parser/src/lib.rs
+++ b/crates/reasoning_parser/src/lib.rs
@@ -4,7 +4,7 @@ pub mod traits;
 
 pub use factory::{ParserFactory, ParserRegistry, PooledParser};
 pub use parsers::{
-    BaseReasoningParser, CohereCmdParser, DeepSeekR1Parser, Glm45Parser, KimiParser, MiniMaxParser,
+    BaseReasoningParser, CohereCmdParser, DeepSeekR1Parser, GlmParser, KimiParser, MiniMaxParser,
     NanoV3Parser, PassthroughParser, Qwen3Parser, QwenThinkingParser, Step3Parser,
 };
 pub use traits::{

--- a/crates/reasoning_parser/src/parsers/glm.rs
+++ b/crates/reasoning_parser/src/parsers/glm.rs
@@ -1,4 +1,4 @@
-// GLM45 specific reasoning parser.
+// GLM reasoning parser.
 // Uses the same format as Qwen3 but has its own implementation for debugging.
 
 use crate::{
@@ -6,16 +6,17 @@ use crate::{
     traits::{ParseError, ParserConfig, ParserResult, ReasoningParser, DEFAULT_MAX_BUFFER_SIZE},
 };
 
-/// GLM45 reasoning parser.
+/// GLM reasoning parser.
 ///
-/// This parser uses the same format as Qwen3 (<think>...</think>) but has
-/// its own implementation for better debugging and potential future customization.
-pub struct Glm45Parser {
+/// GLM series (4.5, 4.7, 5, 5.1, etc.) all use the same format as Qwen3
+/// (<think>...</think>) but has its own implementation for better debugging
+/// and potential future customization.
+pub struct GlmParser {
     base: BaseReasoningParser,
 }
 
-impl Glm45Parser {
-    /// Create a new GLM45 parser.
+impl GlmParser {
+    /// Create a new GLM parser.
     pub fn new() -> Self {
         let config = ParserConfig {
             think_start_token: "<think>".to_string(),
@@ -26,18 +27,18 @@ impl Glm45Parser {
         };
 
         Self {
-            base: BaseReasoningParser::new(config).with_model_type("glm45".to_string()),
+            base: BaseReasoningParser::new(config).with_model_type("glm".to_string()),
         }
     }
 }
 
-impl Default for Glm45Parser {
+impl Default for GlmParser {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl ReasoningParser for Glm45Parser {
+impl ReasoningParser for GlmParser {
     fn detect_and_parse_reasoning(&mut self, text: &str) -> Result<ParserResult, ParseError> {
         self.base.detect_and_parse_reasoning(text)
     }
@@ -75,8 +76,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_glm45_initial_state() {
-        let mut parser = Glm45Parser::new();
+    fn test_glm_initial_state() {
+        let mut parser = GlmParser::new();
 
         // Should NOT treat text as reasoning without start token
         let result = parser
@@ -87,8 +88,8 @@ mod tests {
     }
 
     #[test]
-    fn test_glm45_with_tokens() {
-        let mut parser = Glm45Parser::new();
+    fn test_glm_with_tokens() {
+        let mut parser = GlmParser::new();
 
         // Should extract reasoning with proper tokens
         let result = parser
@@ -99,8 +100,8 @@ mod tests {
     }
 
     #[test]
-    fn test_glm45_streaming() {
-        let mut parser = Glm45Parser::new();
+    fn test_glm_streaming() {
+        let mut parser = GlmParser::new();
 
         // First chunk - normal text
         let result1 = parser
@@ -126,7 +127,7 @@ mod tests {
 
     #[test]
     fn test_model_type() {
-        let parser = Glm45Parser::new();
-        assert_eq!(parser.model_type(), "glm45");
+        let parser = GlmParser::new();
+        assert_eq!(parser.model_type(), "glm");
     }
 }

--- a/crates/reasoning_parser/src/parsers/mod.rs
+++ b/crates/reasoning_parser/src/parsers/mod.rs
@@ -1,7 +1,7 @@
 pub mod base;
 pub mod cohere_cmd;
 pub mod deepseek_r1;
-pub mod glm45;
+pub mod glm;
 pub mod kimi;
 pub mod minimax;
 pub mod nano_v3;
@@ -12,7 +12,7 @@ pub mod step3;
 pub use base::BaseReasoningParser;
 pub use cohere_cmd::CohereCmdParser;
 pub use deepseek_r1::DeepSeekR1Parser;
-pub use glm45::Glm45Parser;
+pub use glm::GlmParser;
 pub use kimi::KimiParser;
 pub use minimax::MiniMaxParser;
 pub use nano_v3::NanoV3Parser;

--- a/docs/concepts/architecture/grpc-pipeline.md
+++ b/docs/concepts/architecture/grpc-pipeline.md
@@ -151,14 +151,14 @@ smg --reasoning-parser kimi
 
 <div class="card" markdown>
 
-**GLM-4.5**
+**GLM**
 
-- Pattern: `*glm45*`, `*glm47*`
+- Pattern: `*glm*`
 - Initial state: Not in reasoning
 - Tokens: `<think>` / `</think>`
 
 ```bash
-smg --reasoning-parser glm45
+smg --reasoning-parser glm
 ```
 
 </div>
@@ -173,7 +173,7 @@ smg --reasoning-parser glm45
 | `qwen3` | `*qwen3*` | Not in reasoning | `<think>` / `</think>` |
 | `qwen3_thinking` | `*qwen-thinking*` | In reasoning | `<think>` / `</think>` |
 | `kimi` | `*kimi*` | Not in reasoning | Unicode markers |
-| `glm45` | `*glm45*`, `*glm47*` | Not in reasoning | `<think>` / `</think>` |
+| `glm` | `*glm*` | Not in reasoning | `<think>` / `</think>` |
 | `step3` | `*step3*` | In reasoning | `<think>` / `</think>` |
 | `minimax` | `*minimax*`, `*mm-m2*` | In reasoning | `<think>` appended |
 

--- a/docs/getting-started/grpc-workers.md
+++ b/docs/getting-started/grpc-workers.md
@@ -157,7 +157,7 @@ Auto-detected from the model name. Override with `--reasoning-parser` if needed.
 | `qwen3` | Qwen3 |
 | `qwen3_thinking` | Qwen3-Thinking |
 | `kimi` | Kimi |
-| `glm45` | GLM-4.5, GLM-4.7 |
+| `glm` | GLM-4.5, GLM-4.7, GLM-5, GLM-5.1 |
 | `step3` | Step-3 |
 | `minimax` | MiniMax, MiniMax-M2 |
 | `cohere_cmd` | Command-R, Command-A, C4AI |


### PR DESCRIPTION
## Description

### Problem

The `Glm45Parser` is specific to GLM-4.5 in name but has been used for GLM-4.7 and confirmed compatible with GLM-5/GLM-5.1 (all use `<think>`/`</think>` format). Every new GLM release requires manually adding a `register_pattern` entry.

### Solution

Rename `Glm45Parser` to `GlmParser` and replace per-version pattern registrations (`glm45`, `glm47`) with a single catch-all `"glm"` pattern. Future GLM versions (5, 5.1, 6, etc.) are automatically recognized via substring matching.

## Changes

- Rename `src/parsers/glm45.rs` → `src/parsers/glm.rs` with `Glm45Parser` → `GlmParser`
- Replace `register_pattern("glm45", ...)` + `register_pattern("glm47", ...)` with `register_pattern("glm", "glm")`
- Update `mod.rs`, `lib.rs`, `factory.rs` imports and re-exports
- Update both READMEs to reflect the generic GLM naming

## Test Plan

- `cargo +nightly fmt --all` — clean
- `cargo clippy -p reasoning-parser --all-targets --all-features -- -D warnings` — clean
- `cargo test -p reasoning-parser` — 74 passed, 0 failed

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated supported GLM models to list a unified "GLM" entry and include GLM-4.5, GLM-4.7, GLM-5, and GLM-5.1 with <think>…</think> reasoning tokens.

* **Refactor**
  * Consolidated multiple GLM parser variants into a single unified GLM parser and updated model-pattern routing to resolve all GLM variants to that parser.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightseekorg/smg/pull/1566?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->