### PR TITLE
perf(mesh): size apply_remote_ops dedup to the incoming batch

### DIFF
--- a/crates/mesh/src/crdt_kv/engine/lww.rs
+++ b/crates/mesh/src/crdt_kv/engine/lww.rs
@@ -345,28 +345,44 @@ impl NamespaceCrdtEngine for LwwEngine {
         }
 
         // Determine which incoming ops the local log has not yet seen. LWW
-        // dedups by op-id; an op already in the log is a no-op.
-        let seen: std::collections::HashSet<(ReplicaId, u64)> = self
-            .log
-            .read()
-            .operations()
-            .iter()
-            .map(|op| (op.replica_id(), op.timestamp()))
-            .collect();
-
-        // Consume `ops` here so the filter moves each surviving Operation
-        // (including its `Vec<u8>` payload) into `unseen` without cloning.
-        let mut unseen: Vec<Operation> = ops
-            .into_iter()
-            .filter(|op| !seen.contains(&(op.replica_id(), op.timestamp())))
-            .collect();
-        unseen.sort_by_key(|op| (op.timestamp(), op.replica_id()));
+        // dedups by op-id; an op already in the log is a no-op. The lookup set
+        // is sized to the incoming BATCH, not the whole log: seed it with the
+        // batch op-ids, then strike the ids the log already holds in a single
+        // log pass. What remains is exactly the op-ids the log has not seen.
+        let mut unseen_ids: std::collections::HashSet<(ReplicaId, u64)> =
+            std::collections::HashSet::with_capacity(ops.len());
+        for op in &ops {
+            unseen_ids.insert((op.replica_id(), op.timestamp()));
+        }
+        {
+            let log = self.log.read();
+            for op in log.operations() {
+                if unseen_ids.is_empty() {
+                    break;
+                }
+                unseen_ids.remove(&(op.replica_id(), op.timestamp()));
+            }
+        }
 
         // Nothing new to apply: skip the write lock, compaction, and the
-        // clock/state replay loop entirely.
-        if unseen.is_empty() {
+        // clock/state replay loop entirely. Critical fast path when gossip
+        // resends a fully-redundant log.
+        if unseen_ids.is_empty() {
             return;
         }
+
+        // Keep every batch op whose id the log has not seen. Use `contains`
+        // (not `remove`) so within-batch duplicate op-ids are all retained,
+        // matching the prior log-sized-set filter - the apply loop below calls
+        // `clock.update` once per retained op, and `LamportClock::update` is
+        // not idempotent, so dropping a within-batch duplicate would diverge
+        // the shared clock. `ops` is consumed so survivors move without
+        // cloning their payloads.
+        let mut unseen: Vec<Operation> = ops
+            .into_iter()
+            .filter(|op| unseen_ids.contains(&(op.replica_id(), op.timestamp())))
+            .collect();
+        unseen.sort_by_key(|op| (op.timestamp(), op.replica_id()));
 
         // LWW op-id collision policy is dedup: an op already in the log by
         // `(replica_id, timestamp)` is a no-op. `unseen` was already filtered

--- a/crates/mesh/src/crdt_kv/engine/lww.rs
+++ b/crates/mesh/src/crdt_kv/engine/lww.rs
@@ -349,11 +349,10 @@ impl NamespaceCrdtEngine for LwwEngine {
         // is sized to the incoming BATCH, not the whole log: seed it with the
         // batch op-ids, then strike the ids the log already holds in a single
         // log pass. What remains is exactly the op-ids the log has not seen.
-        let mut unseen_ids: std::collections::HashSet<(ReplicaId, u64)> =
-            std::collections::HashSet::with_capacity(ops.len());
-        for op in &ops {
-            unseen_ids.insert((op.replica_id(), op.timestamp()));
-        }
+        let mut unseen_ids: std::collections::HashSet<(ReplicaId, u64)> = ops
+            .iter()
+            .map(|op| (op.replica_id(), op.timestamp()))
+            .collect();
         {
             let log = self.log.read();
             for op in log.operations() {

--- a/crates/mesh/src/crdt_kv/engine/rate_limit.rs
+++ b/crates/mesh/src/crdt_kv/engine/rate_limit.rs
@@ -358,34 +358,21 @@ impl NamespaceCrdtEngine for RateLimitEngine {
         // so generation only bumps when state truly changes.
         ops.sort_by_key(|op| (op.timestamp(), op.replica_id()));
 
-        // EpochMaxWins op-id collision policy: fold the existing log op and
-        // the incoming op via `compact_operations` so a compacted snapshot
-        // replaces a previously-seen raw payload at the same op-id (the bug
-        // class addressed in #1469). Unseen incoming ops are appended.
-        // Compaction then runs across the full log per the same fold rule.
+        // Merge incoming ops into the log by appending them all and letting
+        // compaction fold per key. `compact_by_key` groups by key and folds
+        // each group via `compact_operations`; because ops sharing an op-id
+        // share a key (op-id is unique per logical op), a compacted snapshot
+        // and a previously-seen raw payload at the same op-id land in the same
+        // group and fold together - preserving the embedded `tombstone_version`
+        // (the bug class addressed in #1469) with no separate op-id index.
+        // `RateLimitState::merge` is associative, so folding the whole group at
+        // once matches the prior incremental per-op-id fold; identical ops fold
+        // idempotently, so no duplicate survives. compact_log does not truncate,
+        // so remotely-learned keys are never dropped.
         {
             let mut log = self.log.write();
-            let mut local_index: std::collections::HashMap<(ReplicaId, u64), usize> = log
-                .operations()
-                .iter()
-                .enumerate()
-                .map(|(idx, op)| ((op.replica_id(), op.timestamp()), idx))
-                .collect();
             for op in &ops {
-                let id = (op.replica_id(), op.timestamp());
-                match local_index.get(&id).copied() {
-                    Some(local_idx) => {
-                        let folded =
-                            ratelimit::compact_operations([&log.operations()[local_idx], op]);
-                        if let Some(folded) = folded {
-                            log.operations_mut()[local_idx] = folded;
-                        }
-                    }
-                    None => {
-                        local_index.insert(id, log.operations().len());
-                        log.append(op.clone());
-                    }
-                }
+                log.append(op.clone());
             }
             Self::compact_log(&mut log);
         }

--- a/crates/mesh/src/crdt_kv/operation.rs
+++ b/crates/mesh/src/crdt_kv/operation.rs
@@ -80,7 +80,7 @@ impl Operation {
 /// Each engine owns one `OperationLog` instance holding only its own
 /// namespace's operations; the log itself carries no merge-strategy knowledge.
 /// Engines drive merge (op-id collision policy) and compaction (per-key fold
-/// rule) themselves via [`Self::operations`], [`Self::operations_mut`], and
+/// rule) themselves via [`Self::operations`], [`Self::append`], and
 /// [`Self::compact_by_key`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OperationLog {
@@ -116,13 +116,6 @@ impl OperationLog {
     /// Get all operations
     pub fn operations(&self) -> &[Operation] {
         &self.operations
-    }
-
-    /// Mutable access to the underlying op vector. Engines need this to merge
-    /// in-place with their own op-id collision policy (LWW dedups; EpochMaxWins
-    /// folds via `epoch_max_wins::compact_operations`).
-    pub(super) fn operations_mut(&mut self) -> &mut Vec<Operation> {
-        &mut self.operations
     }
 
     /// Memory backstop: if the log is still over `AUTO_COMPACT_THRESHOLD`

--- a/crates/mesh/src/crdt_kv/tests.rs
+++ b/crates/mesh/src/crdt_kv/tests.rs
@@ -613,6 +613,13 @@ fn test_epoch_max_wins_same_op_id_folds_within_single_batch() {
     ));
     batch.append(snapshot_op);
     receiver.merge(&batch);
+    // The two same-op-id ops must append-then-compact to a single exported op,
+    // not survive as two entries masked by the state merge.
+    assert_eq!(
+        receiver.get_operation_log().operations().len(),
+        1,
+        "same-op-id batch must fold to a single exported op",
+    );
     assert_eq!(
         decode(&receiver.get(key).expect("post-tombstone shard remains")),
         Some(EpochCount { epoch: 6, count: 1 }),
@@ -983,6 +990,44 @@ fn test_lww_apply_remote_ops_keeps_within_batch_duplicate_op_ids() {
         receiver.get_operation_log().len(),
         1,
         "duplicate op-ids fold to a single log entry",
+    );
+
+    // The store value and the folded log are identical whether the duplicate
+    // is kept or dropped, so they cannot distinguish `contains` from `remove`.
+    // The observable effect of keeping the duplicate is that the apply loop
+    // calls the non-idempotent `LamportClock::update` once per copy. Compare a
+    // two-copy merge against a one-copy merge: the extra `update` must make the
+    // next local write land at a strictly higher timestamp. A regression back
+    // to within-batch dedup collapses both paths and fails this assertion.
+    let single = CrdtOrMap::new();
+    let mut single_batch = OperationLog::new();
+    single_batch.append(Operation::insert(
+        "k".to_string(),
+        b"v".to_vec(),
+        5,
+        replica,
+    ));
+    single.merge(&single_batch);
+
+    receiver.insert("after_dup".to_string(), b"x".to_vec());
+    single.insert("after_single".to_string(), b"x".to_vec());
+
+    let local_write_ts = |map: &CrdtOrMap, key: &str| {
+        map.get_operation_log()
+            .operations()
+            .iter()
+            .find_map(|op| match op {
+                Operation::Insert {
+                    key: k, timestamp, ..
+                } if k == key => Some(*timestamp),
+                _ => None,
+            })
+            .expect("local write should be in the log")
+    };
+    assert!(
+        local_write_ts(&receiver, "after_dup") > local_write_ts(&single, "after_single"),
+        "two same-op-id remote copies must advance the Lamport clock one step \
+         more than a single copy",
     );
 }
 

--- a/crates/mesh/src/crdt_kv/tests.rs
+++ b/crates/mesh/src/crdt_kv/tests.rs
@@ -563,6 +563,82 @@ fn test_epoch_max_wins_compacted_snapshot_applies_when_op_id_already_seen() {
 }
 
 #[test]
+fn test_epoch_max_wins_same_op_id_folds_within_single_batch() {
+    // The raw post-tombstone insert and the compacted snapshot that reuses its
+    // op-id (and embeds tombstone_version=65) arrive in the SAME batch.
+    // apply_remote_ops appends both and lets per-key compaction fold them, so
+    // the snapshot's tombstone_version must survive without a separate op-id
+    // index - otherwise a later delayed pre-tombstone insert resurrects the
+    // deleted high-epoch shard.
+    init_test_logging();
+    let key = "rl:global:node-a";
+
+    let pre_tombstone_replica = ReplicaId::new();
+    let tombstone_replica = ReplicaId::new();
+    let post_tombstone_replica = ReplicaId::new();
+
+    // Produce the compacted snapshot op: a single Insert at op-id
+    // (70, post_tombstone_replica) embedding tombstone_version=65.
+    let source = CrdtOrMap::new();
+    source.register_merge_strategy("rl:".to_string(), MergeStrategy::EpochMaxWins);
+    let mut source_log = OperationLog::new();
+    source_log.append(Operation::insert(
+        key.to_string(),
+        encode(7, 99).to_vec(),
+        60,
+        pre_tombstone_replica,
+    ));
+    source_log.append(Operation::remove(key.to_string(), 65, tombstone_replica));
+    source_log.append(Operation::insert(
+        key.to_string(),
+        encode(6, 1).to_vec(),
+        70,
+        post_tombstone_replica,
+    ));
+    source.merge(&source_log);
+    let compacted = source.get_operation_log();
+    assert_eq!(compacted.operations().len(), 1);
+    let snapshot_op = compacted.operations()[0].clone();
+
+    // Receiver gets BOTH the raw post-tombstone insert and the compacted
+    // snapshot (same op-id) in one batch.
+    let receiver = CrdtOrMap::new();
+    receiver.register_merge_strategy("rl:".to_string(), MergeStrategy::EpochMaxWins);
+    let mut batch = OperationLog::new();
+    batch.append(Operation::insert(
+        key.to_string(),
+        encode(6, 1).to_vec(),
+        70,
+        post_tombstone_replica,
+    ));
+    batch.append(snapshot_op);
+    receiver.merge(&batch);
+    assert_eq!(
+        decode(&receiver.get(key).expect("post-tombstone shard remains")),
+        Some(EpochCount { epoch: 6, count: 1 }),
+    );
+
+    // Delayed pre-tombstone insert must be suppressed by the folded-in tombstone.
+    let mut delayed = OperationLog::new();
+    delayed.append(Operation::insert(
+        key.to_string(),
+        encode(7, 99).to_vec(),
+        60,
+        ReplicaId::new(),
+    ));
+    receiver.merge(&delayed);
+    assert_eq!(
+        decode(
+            &receiver
+                .get(key)
+                .expect("post-tombstone live point still survives")
+        ),
+        Some(EpochCount { epoch: 6, count: 1 }),
+        "same-op-id snapshot folded within one batch must preserve the tombstone",
+    );
+}
+
+#[test]
 fn test_epoch_max_wins_remove_for_never_seen_key_blocks_delayed_pre_tombstone_insert() {
     // Replica receives a tombstone for a key it has never seen, then later
     // receives a delayed pre-tombstone insert for the same key. The tombstone
@@ -872,6 +948,41 @@ fn test_lww_apply_remote_ops_is_idempotent() {
     assert_eq!(
         after_first, after_second,
         "re-applying the same log must be a no-op for log length",
+    );
+}
+
+#[test]
+fn test_lww_apply_remote_ops_keeps_within_batch_duplicate_op_ids() {
+    // A single batch may carry duplicate op-ids (e.g. a concatenated gossip
+    // log). The batch-sized dedup filters only against the local log (via
+    // `contains`), so it keeps every batch op - duplicates included - exactly
+    // as the prior log-sized-set filter did. Compaction folds the duplicates
+    // to one winner, and the clock advances once per applied op (matching the
+    // non-idempotent `LamportClock::update`).
+    init_test_logging();
+    let receiver = CrdtOrMap::new();
+    let replica = ReplicaId::new();
+
+    let mut batch = OperationLog::new();
+    batch.append(Operation::insert(
+        "k".to_string(),
+        b"v".to_vec(),
+        5,
+        replica,
+    ));
+    batch.append(Operation::insert(
+        "k".to_string(),
+        b"v".to_vec(),
+        5,
+        replica,
+    ));
+    receiver.merge(&batch);
+
+    assert_eq!(receiver.get("k"), Some(b"v".to_vec()));
+    assert_eq!(
+        receiver.get_operation_log().len(),
+        1,
+        "duplicate op-ids fold to a single log entry",
     );
 }
 


### PR DESCRIPTION
## Description

### Problem

Follow-up to #1560. Both CRDT engines' `apply_remote_ops` built an op-id lookup structure sized to the **entire local operation log** on every remote merge:

- `LwwEngine`: a `HashSet<(ReplicaId, u64)>` of every log op-id, used to dedup the incoming batch.
- `RateLimitEngine`: a `HashMap<(ReplicaId, u64), usize>` over the whole log (built inside the write lock), used to locate same-op-id fold targets.

When the incoming gossip batch is a delta (much smaller than the log), sizing these to the log is wasteful. This was flagged as P1#1 / P1#4 in the #1560 review and deferred.

### Solution

Re-shape both so the work scales with the incoming **batch** instead of the log.

**LwwEngine (P1#1):** seed the lookup set from the incoming batch, then strike the ids the log already holds in a single log pass; the survivors are the unseen ops. Memory drops from `O(log)` to `O(batch)` — strictly not worse, much smaller for deltas. The filter uses `contains` (not `remove`) so within-batch duplicate op-ids are all retained: the apply loop calls `LamportClock::update` once per applied op, and that update is `max(cur, remote) + 1` (**not idempotent**), so deduping within the batch would advance the shared clock differently and diverge from prior behavior. The fully-redundant-batch early return is preserved.

**RateLimitEngine (P1#4):** drop the per-log index and the in-place op-id fold entirely. Append all incoming ops and let `compact_log` (`compact_by_key`) fold per key. Because ops sharing an op-id share a key, a compacted snapshot and a previously-seen raw payload at the same op-id land in the same per-key group and fold together via `compact_operations` — preserving the embedded `tombstone_version` (#1469) with no separate index. `RateLimitState::merge` is associative, so folding the whole group at once equals the prior incremental fold; identical ops fold idempotently. Primarily a **simplification**: `compact_by_key` becomes the single fold authority.

**Trade-off (called out for review):** the RateLimit path's transient log peak is `log + batch` before compaction (vs the prior index's `log + unseen`), so a full-log resync briefly holds ~2×. The steady-state delta path is strictly lighter. `compact_log` never truncates, so remotely-learned keys are never dropped on this path. If gossip is wired to send full logs rather than watermark deltas, this transient is worth revisiting.

Also removes the now-unused `OperationLog::operations_mut` (its only caller was the RateLimit in-place fold).

## Changes

- `crates/mesh/src/crdt_kv/engine/lww.rs` — batch-sized dedup set; `contains` filter; early return preserved.
- `crates/mesh/src/crdt_kv/engine/rate_limit.rs` — append-all + `compact_log`; index removed.
- `crates/mesh/src/crdt_kv/operation.rs` — remove orphaned `operations_mut`; doc fixup.
- `crates/mesh/src/crdt_kv/tests.rs` — two regression tests (below).

### Verification

Semantic equivalence for both was checked by an adversarial review pass before implementation. That pass **caught a real bug** in the first LWW draft: an earlier version deduped within-batch via `HashSet::remove`, which dropped duplicate ops and thus changed how often `LamportClock::update` ran — diverging the shared clock (observable on the next local write). The shipped version uses `contains` to preserve the exact per-op clock progression.

## Test Plan

- [x] `cargo test -p smg-mesh --lib` — 152 passed, 0 failed (was 150; +2 new).
- [x] `cargo clippy -p smg-mesh --all-targets` — clean (no dead-code warnings after removing `operations_mut`).

New regression tests:
- `test_lww_apply_remote_ops_keeps_within_batch_duplicate_op_ids` — a batch with duplicate op-ids is retained and folds to one log entry (locks in the `contains` behavior).
- `test_epoch_max_wins_same_op_id_folds_within_single_batch` — a raw insert and a compacted snapshot sharing an op-id arrive in one batch; the snapshot's `tombstone_version` is preserved so a delayed pre-tombstone insert stays suppressed (locks in the append-all fold for #1469).

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized remote merge/dedup logic to use less memory, avoid unnecessary locking, and improve conflict handling; streamlined internal operation-log access for more predictable merges.

* **Tests**
  * Added tests covering duplicate-operation merges and tombstone boundary scenarios to ensure consistent merge outcomes and correct clock advancement.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightseekorg/smg/pull/1569?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->