### PR TITLE
feat(mesh): gossip CRDT operation log over the wire (d-3a)

### DIFF
--- a/crates/mesh/src/crdt_kv/crdt.rs
+++ b/crates/mesh/src/crdt_kv/crdt.rs
@@ -22,7 +22,7 @@ use tracing::info;
 use super::{
     engine::{EngineHandle, LwwEngine, RateLimitEngine},
     merge_strategy::MergeStrategy,
-    operation::{Operation, OperationLog},
+    operation::{CrdtChange, Operation, OperationLog},
     replica::{LamportClock, ReplicaId},
 };
 
@@ -214,7 +214,7 @@ impl CrdtOrMap {
     /// (longest-prefix-match) and hands each engine its slice. Engines
     /// canonicalise (merge → compact → apply) internally, so dominated ops
     /// in the incoming batch never reach live state.
-    pub fn merge(&self, log: &OperationLog) {
+    pub fn merge(&self, log: &OperationLog) -> Vec<CrdtChange> {
         info!(
             "Merging {} operations into replica {}",
             log.len(),
@@ -235,6 +235,9 @@ impl CrdtOrMap {
             buckets[idx].push(op.clone());
         }
 
+        // Concatenate each engine's changed-key deltas so the caller can fire
+        // subscribers once for the whole merge.
+        let mut changes = Vec::new();
         for (idx, ops) in buckets.into_iter().enumerate() {
             if ops.is_empty() {
                 continue;
@@ -244,8 +247,9 @@ impl CrdtOrMap {
             } else {
                 Arc::clone(&engines[idx].1)
             };
-            engine.apply_remote_ops(ops);
+            changes.extend(engine.apply_remote_ops(ops));
         }
+        changes
     }
 
     /// Convenience: merge another replica's full log.

--- a/crates/mesh/src/crdt_kv/engine/lww.rs
+++ b/crates/mesh/src/crdt_kv/engine/lww.rs
@@ -23,7 +23,7 @@ use tracing::debug;
 use super::NamespaceCrdtEngine;
 use crate::crdt_kv::{
     kv_store::KvStore,
-    operation::{Operation, OperationLog},
+    operation::{CrdtChange, Operation, OperationLog},
     replica::{LamportClock, ReplicaId},
 };
 
@@ -339,9 +339,9 @@ impl NamespaceCrdtEngine for LwwEngine {
         self.log.read().operations().to_vec()
     }
 
-    fn apply_remote_ops(&self, ops: Vec<Operation>) {
+    fn apply_remote_ops(&self, ops: Vec<Operation>) -> Vec<CrdtChange> {
         if ops.is_empty() {
-            return;
+            return Vec::new();
         }
 
         // Determine which incoming ops the local log has not yet seen. LWW
@@ -367,7 +367,7 @@ impl NamespaceCrdtEngine for LwwEngine {
         // clock/state replay loop entirely. Critical fast path when gossip
         // resends a fully-redundant log.
         if unseen_ids.is_empty() {
-            return;
+            return Vec::new();
         }
 
         // Keep every batch op whose id the log has not seen. Use `contains`
@@ -395,6 +395,19 @@ impl NamespaceCrdtEngine for LwwEngine {
             Self::compact_log(&mut log);
         }
 
+        // Snapshot the observable value of every key this batch touches before
+        // applying, so we emit a `CrdtChange` only when `get` actually changes.
+        // Keying off observable value (not op acceptance) suppresses spurious
+        // events from a newer-version op that rewrites byte-identical bytes or
+        // from a dominated op.
+        let mut before: std::collections::HashMap<String, Option<Vec<u8>>> =
+            std::collections::HashMap::new();
+        for op in &unseen {
+            before
+                .entry(op.key().to_string())
+                .or_insert_with(|| self.store.get(op.key()));
+        }
+
         // Apply unseen ops to live state. Lamport clock observes each remote
         // timestamp so subsequent local ticks beat it.
         for op in unseen {
@@ -417,6 +430,16 @@ impl NamespaceCrdtEngine for LwwEngine {
                 }
             }
         }
+
+        // Emit one CrdtChange per key whose observable value changed, carrying
+        // the canonical post-merge value (matching `get`).
+        before
+            .into_iter()
+            .filter_map(|(key, prior)| {
+                let value = self.store.get(&key);
+                (value != prior).then_some(CrdtChange { key, value })
+            })
+            .collect()
     }
 
     fn gc_tombstones(&self, grace: Duration) -> usize {

--- a/crates/mesh/src/crdt_kv/engine/lww.rs
+++ b/crates/mesh/src/crdt_kv/engine/lww.rs
@@ -403,9 +403,11 @@ impl NamespaceCrdtEngine for LwwEngine {
         let mut before: std::collections::HashMap<String, Option<Vec<u8>>> =
             std::collections::HashMap::new();
         for op in &unseen {
-            before
-                .entry(op.key().to_string())
-                .or_insert_with(|| self.store.get(op.key()));
+            // `contains_key` with a borrowed key avoids allocating a `String`
+            // for keys already snapshotted (a batch may repeat a key).
+            if !before.contains_key(op.key()) {
+                before.insert(op.key().to_string(), self.store.get(op.key()));
+            }
         }
 
         // Apply unseen ops to live state. Lamport clock observes each remote

--- a/crates/mesh/src/crdt_kv/engine/mod.rs
+++ b/crates/mesh/src/crdt_kv/engine/mod.rs
@@ -15,7 +15,7 @@
 
 use std::{sync::Arc, time::Duration};
 
-use super::operation::Operation;
+use super::operation::{CrdtChange, Operation};
 
 mod lww;
 mod rate_limit;
@@ -73,7 +73,13 @@ pub(super) trait NamespaceCrdtEngine: Send + Sync {
     ///
     /// Takes ownership so the engine can move the batch into its operation
     /// log without an extra clone.
-    fn apply_remote_ops(&self, ops: Vec<Operation>);
+    ///
+    /// Returns one [`CrdtChange`] per key whose live value actually changed,
+    /// each carrying the canonical post-merge value (matching [`Self::get`]).
+    /// The router concatenates these so the gossip receive path can fire
+    /// subscribers with the same value shape `get` returns. Keys touched by
+    /// dominated/idempotent ops (no observable change) are not reported.
+    fn apply_remote_ops(&self, ops: Vec<Operation>) -> Vec<CrdtChange>;
 
     // ---- Maintenance ----
 

--- a/crates/mesh/src/crdt_kv/engine/rate_limit.rs
+++ b/crates/mesh/src/crdt_kv/engine/rate_limit.rs
@@ -386,9 +386,11 @@ impl NamespaceCrdtEngine for RateLimitEngine {
         let mut before: std::collections::HashMap<String, Option<Vec<u8>>> =
             std::collections::HashMap::new();
         for op in &ops {
-            before
-                .entry(op.key().to_string())
-                .or_insert_with(|| self.current_encoded(op.key()));
+            // `contains_key` with a borrowed key avoids allocating a `String`
+            // for keys already snapshotted (a batch may repeat a key).
+            if !before.contains_key(op.key()) {
+                before.insert(op.key().to_string(), self.current_encoded(op.key()));
+            }
         }
 
         for op in ops {

--- a/crates/mesh/src/crdt_kv/engine/rate_limit.rs
+++ b/crates/mesh/src/crdt_kv/engine/rate_limit.rs
@@ -27,7 +27,7 @@ use tracing::debug;
 use super::NamespaceCrdtEngine;
 use crate::crdt_kv::{
     epoch_max_wins::{self as ratelimit, RateLimitState, RateLimitVersion},
-    operation::{Operation, OperationLog},
+    operation::{CrdtChange, Operation, OperationLog},
     replica::{LamportClock, ReplicaId},
 };
 
@@ -346,9 +346,9 @@ impl NamespaceCrdtEngine for RateLimitEngine {
         self.log.read().operations().to_vec()
     }
 
-    fn apply_remote_ops(&self, mut ops: Vec<Operation>) {
+    fn apply_remote_ops(&self, mut ops: Vec<Operation>) -> Vec<CrdtChange> {
         if ops.is_empty() {
-            return;
+            return Vec::new();
         }
 
         // EpochMaxWins always replays incoming ops to state because a
@@ -377,6 +377,20 @@ impl NamespaceCrdtEngine for RateLimitEngine {
             Self::compact_log(&mut log);
         }
 
+        // Snapshot the observable (encoded-live) value of every key this batch
+        // touches before applying, so we emit a `CrdtChange` only when `get`
+        // actually changes. Tombstone-version bumps and frontier reshuffles
+        // that leave `encode_live` unchanged (e.g. Tombstone -> newer
+        // Tombstone, both encoding to `None`) bump generation/state but fire no
+        // subscriber event.
+        let mut before: std::collections::HashMap<String, Option<Vec<u8>>> =
+            std::collections::HashMap::new();
+        for op in &ops {
+            before
+                .entry(op.key().to_string())
+                .or_insert_with(|| self.current_encoded(op.key()));
+        }
+
         for op in ops {
             self.clock.update(op.timestamp());
             let changed = match op {
@@ -402,6 +416,17 @@ impl NamespaceCrdtEngine for RateLimitEngine {
                 self.generation.fetch_add(1, Ordering::Release);
             }
         }
+
+        // Emit one CrdtChange per key whose observable value changed, carrying
+        // the canonical post-merge value (the encoded live shard, matching
+        // `get`).
+        before
+            .into_iter()
+            .filter_map(|(key, prior)| {
+                let value = self.current_encoded(&key);
+                (value != prior).then_some(CrdtChange { key, value })
+            })
+            .collect()
     }
 
     fn gc_tombstones(&self, grace: Duration) -> usize {

--- a/crates/mesh/src/crdt_kv/mod.rs
+++ b/crates/mesh/src/crdt_kv/mod.rs
@@ -14,7 +14,8 @@ mod replica;
 pub use crdt::CrdtOrMap;
 pub use epoch_max_wins::{decode, encode, EpochCount, EPOCH_MAX_WINS_ENCODED_LEN};
 pub use merge_strategy::MergeStrategy;
-pub use operation::OperationLog;
+pub use operation::{CrdtChange, Operation, OperationLog};
+pub use replica::ReplicaId;
 
 #[cfg(test)]
 mod tests;

--- a/crates/mesh/src/crdt_kv/operation.rs
+++ b/crates/mesh/src/crdt_kv/operation.rs
@@ -71,6 +71,18 @@ impl Operation {
     }
 }
 
+/// An observable change to a key's live value produced by a remote merge.
+/// `value` is the canonical post-merge value (matching `get(key)`): `Some` for
+/// a key that is live after the merge, `None` for a key that is now tombstoned.
+/// Engines emit one `CrdtChange` per key whose live value actually changed, so
+/// the merge caller can fire subscribers with the same value shape `get`
+/// returns.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CrdtChange {
+    pub key: String,
+    pub value: Option<Vec<u8>>,
+}
+
 // ============================================================================
 // Operation Log - State Operation Pipeline
 // ============================================================================

--- a/crates/mesh/src/crdt_kv/tests.rs
+++ b/crates/mesh/src/crdt_kv/tests.rs
@@ -145,6 +145,115 @@ fn test_merge_two_replicas() {
 }
 
 #[test]
+fn test_merge_emits_change_for_new_value() {
+    init_test_logging();
+    let map = CrdtOrMap::new();
+    let mut log = OperationLog::new();
+    log.append(Operation::insert(
+        "worker:a".to_string(),
+        b"v".to_vec(),
+        5,
+        ReplicaId::new(),
+    ));
+
+    let changes = map.merge(&log);
+    assert_eq!(changes.len(), 1);
+    assert_eq!(changes[0].key, "worker:a");
+    assert_eq!(changes[0].value, Some(b"v".to_vec()));
+}
+
+#[test]
+fn test_merge_no_change_on_byte_identical_newer_insert() {
+    // A newer-version insert that rewrites byte-identical bytes is accepted by
+    // LWW (advances the winner's version) but does not change the observable
+    // `get` value, so `merge` must report no CrdtChange.
+    init_test_logging();
+    let map = CrdtOrMap::new();
+
+    let mut first = OperationLog::new();
+    first.append(Operation::insert(
+        "worker:a".to_string(),
+        b"v".to_vec(),
+        5,
+        ReplicaId::new(),
+    ));
+    assert_eq!(map.merge(&first).len(), 1, "first insert is a change");
+
+    let mut identical_newer = OperationLog::new();
+    identical_newer.append(Operation::insert(
+        "worker:a".to_string(),
+        b"v".to_vec(),
+        10,
+        ReplicaId::new(),
+    ));
+    assert!(
+        map.merge(&identical_newer).is_empty(),
+        "byte-identical newer-version rewrite must fire no CrdtChange"
+    );
+}
+
+#[test]
+fn test_merge_no_change_on_tombstone_for_never_seen_key() {
+    // A remove for a key that was never live leaves `get` at None before and
+    // after, so it must fire no CrdtChange (both LWW and EpochMaxWins).
+    init_test_logging();
+    let map = CrdtOrMap::new();
+    map.register_merge_strategy("rl:".to_string(), MergeStrategy::EpochMaxWins);
+
+    let mut log = OperationLog::new();
+    log.append(Operation::remove(
+        "rl:global:node-a".to_string(),
+        50,
+        ReplicaId::new(),
+    ));
+    assert!(
+        map.merge(&log).is_empty(),
+        "tombstone for a never-seen key must fire no CrdtChange"
+    );
+
+    let mut worker_tombstone = OperationLog::new();
+    worker_tombstone.append(Operation::remove(
+        "worker:ghost".to_string(),
+        50,
+        ReplicaId::new(),
+    ));
+    assert!(
+        map.merge(&worker_tombstone).is_empty(),
+        "LWW tombstone for a never-seen key must fire no CrdtChange"
+    );
+}
+
+#[test]
+fn test_merge_emits_none_when_tombstone_kills_live_key() {
+    init_test_logging();
+    let map = CrdtOrMap::new();
+    let replica = ReplicaId::new();
+
+    let mut insert = OperationLog::new();
+    insert.append(Operation::insert(
+        "worker:a".to_string(),
+        b"v".to_vec(),
+        5,
+        replica,
+    ));
+    map.merge(&insert);
+
+    let mut tombstone = OperationLog::new();
+    tombstone.append(Operation::remove(
+        "worker:a".to_string(),
+        10,
+        ReplicaId::new(),
+    ));
+    let changes = map.merge(&tombstone);
+    assert_eq!(changes.len(), 1);
+    assert_eq!(changes[0].key, "worker:a");
+    assert_eq!(
+        changes[0].value, None,
+        "killing a live key emits value None"
+    );
+}
+
+#[test]
 fn test_concurrent_insert_same_key() {
     init_test_logging();
     let replica1 = CrdtOrMap::new();

--- a/crates/mesh/src/gossip_controller.rs
+++ b/crates/mesh/src/gossip_controller.rs
@@ -56,6 +56,7 @@ use super::{
 use crate::{
     metrics,
     transport::{
+        crdt_batch::{build_crdt_batch, dispatch_crdt_batch, wrap_crdt_batch},
         limits::{MAX_MESSAGE_SIZE, STREAM_IDLE_TIMEOUT},
         sync_stream::{
             build_heartbeat, build_peer_stream_batches, dispatch_stream_batch, wrap_stream_batch,
@@ -515,6 +516,35 @@ impl GossipController {
                                         }
                                     }
                                 }
+
+                                // CRDT op-log: broadcast the full snapshot for
+                                // this round. Merge is idempotent by op-id so
+                                // re-sending seen ops is a no-op on the peer.
+                                if let Some(crdt_batch) =
+                                    build_crdt_batch(&stream_batch.crdt_ops)
+                                {
+                                    let msg = wrap_crdt_batch(
+                                        crdt_batch,
+                                        shared_sequence.fetch_add(1, Ordering::Relaxed),
+                                        &self_name_incremental,
+                                    );
+                                    match tx_incremental.try_send(msg) {
+                                        Ok(()) => {}
+                                        Err(mpsc::error::TrySendError::Full(_)) => {
+                                            log::debug!(
+                                                peer = %peer_name_incremental,
+                                                "crdt batch dropped on backpressure"
+                                            );
+                                        }
+                                        Err(mpsc::error::TrySendError::Closed(_)) => {
+                                            log::warn!(
+                                                peer = %peer_name_incremental,
+                                                "crdt sender: channel closed, stopping"
+                                            );
+                                            return;
+                                        }
+                                    }
+                                }
                             }
 
                             let round_elapsed = round_start.elapsed();
@@ -585,6 +615,13 @@ impl GossipController {
                                                 &msg.peer_id,
                                                 batch.entries,
                                             );
+                                        }
+                                    }
+                                }
+                                StreamMessageType::CrdtBatch => {
+                                    if let Some(mesh_kv) = &mesh_kv {
+                                        if let Some(StreamPayload::CrdtBatch(batch)) = msg.payload {
+                                            dispatch_crdt_batch(mesh_kv, batch);
                                         }
                                     }
                                 }

--- a/crates/mesh/src/gossip_controller.rs
+++ b/crates/mesh/src/gossip_controller.rs
@@ -56,8 +56,8 @@ use super::{
 use crate::{
     metrics,
     transport::{
-        crdt_batch::{build_crdt_batch, dispatch_crdt_batch, wrap_crdt_batch},
-        limits::{MAX_MESSAGE_SIZE, STREAM_IDLE_TIMEOUT},
+        crdt_batch::{build_crdt_batches, dispatch_crdt_batch, wrap_crdt_batch},
+        limits::{MAX_MESSAGE_SIZE, MAX_STREAM_CHUNK_BYTES, STREAM_IDLE_TIMEOUT},
         sync_stream::{
             build_heartbeat, build_peer_stream_batches, dispatch_stream_batch, wrap_stream_batch,
         },
@@ -518,11 +518,13 @@ impl GossipController {
                                 }
 
                                 // CRDT op-log: broadcast the full snapshot for
-                                // this round. Merge is idempotent by op-id so
-                                // re-sending seen ops is a no-op on the peer.
-                                if let Some(crdt_batch) =
-                                    build_crdt_batch(&stream_batch.crdt_ops)
-                                {
+                                // this round, split into frames that stay under
+                                // the gRPC message cap. Merge is idempotent by
+                                // op-id so re-sending seen ops is a no-op.
+                                for crdt_batch in build_crdt_batches(
+                                    &stream_batch.crdt_ops,
+                                    MAX_STREAM_CHUNK_BYTES,
+                                ) {
                                     let msg = wrap_crdt_batch(
                                         crdt_batch,
                                         shared_sequence.fetch_add(1, Ordering::Relaxed),
@@ -535,6 +537,7 @@ impl GossipController {
                                                 peer = %peer_name_incremental,
                                                 "crdt batch dropped on backpressure"
                                             );
+                                            break;
                                         }
                                         Err(mpsc::error::TrySendError::Closed(_)) => {
                                             log::warn!(

--- a/crates/mesh/src/gossip_service.rs
+++ b/crates/mesh/src/gossip_service.rs
@@ -56,8 +56,8 @@ use super::{
         try_ping, ClusterState,
     },
     transport::{
-        crdt_batch::{build_crdt_batch, dispatch_crdt_batch, wrap_crdt_batch},
-        limits::{MAX_MESSAGE_SIZE, STREAM_IDLE_TIMEOUT},
+        crdt_batch::{build_crdt_batches, dispatch_crdt_batch, wrap_crdt_batch},
+        limits::{MAX_MESSAGE_SIZE, MAX_STREAM_CHUNK_BYTES, STREAM_IDLE_TIMEOUT},
         sync_stream::{
             build_heartbeat, build_peer_stream_batches, dispatch_stream_batch, wrap_stream_batch,
         },
@@ -323,15 +323,19 @@ impl Gossip for GossipService {
                         }
                     }
 
-                    // CRDT op-log: broadcast the full snapshot this round
-                    // (idempotent merge on the peer).
-                    if let Some(crdt_batch) = build_crdt_batch(&stream_batch.crdt_ops) {
+                    // CRDT op-log: broadcast the full snapshot this round,
+                    // split to stay under the gRPC message cap (idempotent
+                    // merge on the peer).
+                    for crdt_batch in
+                        build_crdt_batches(&stream_batch.crdt_ops, MAX_STREAM_CHUNK_BYTES)
+                    {
                         sequence_counter += 1;
                         let msg = wrap_crdt_batch(crdt_batch, sequence_counter, &self_name_sender);
                         match tx_sender.try_send(Ok(msg)) {
                             Ok(()) => {}
                             Err(mpsc::error::TrySendError::Full(_)) => {
                                 log::debug!("server-side crdt batch dropped on backpressure");
+                                break;
                             }
                             Err(mpsc::error::TrySendError::Closed(_)) => return,
                         }

--- a/crates/mesh/src/gossip_service.rs
+++ b/crates/mesh/src/gossip_service.rs
@@ -56,6 +56,7 @@ use super::{
         try_ping, ClusterState,
     },
     transport::{
+        crdt_batch::{build_crdt_batch, dispatch_crdt_batch, wrap_crdt_batch},
         limits::{MAX_MESSAGE_SIZE, STREAM_IDLE_TIMEOUT},
         sync_stream::{
             build_heartbeat, build_peer_stream_batches, dispatch_stream_batch, wrap_stream_batch,
@@ -321,6 +322,20 @@ impl Gossip for GossipService {
                             Err(mpsc::error::TrySendError::Closed(_)) => return,
                         }
                     }
+
+                    // CRDT op-log: broadcast the full snapshot this round
+                    // (idempotent merge on the peer).
+                    if let Some(crdt_batch) = build_crdt_batch(&stream_batch.crdt_ops) {
+                        sequence_counter += 1;
+                        let msg = wrap_crdt_batch(crdt_batch, sequence_counter, &self_name_sender);
+                        match tx_sender.try_send(Ok(msg)) {
+                            Ok(()) => {}
+                            Err(mpsc::error::TrySendError::Full(_)) => {
+                                log::debug!("server-side crdt batch dropped on backpressure");
+                            }
+                            Err(mpsc::error::TrySendError::Closed(_)) => return,
+                        }
+                    }
                 }
             }))
         } else {
@@ -398,6 +413,15 @@ impl Gossip for GossipService {
                         ) = (&mesh_kv, msg.payload)
                         {
                             dispatch_stream_batch(mesh_kv, &msg.peer_id, batch.entries);
+                        }
+                    }
+                    StreamMessageType::CrdtBatch => {
+                        if let (
+                            Some(mesh_kv),
+                            Some(gossip::stream_message::Payload::CrdtBatch(batch)),
+                        ) = (&mesh_kv, msg.payload)
+                        {
+                            dispatch_crdt_batch(mesh_kv, batch);
                         }
                     }
                     StreamMessageType::IncrementalUpdate
@@ -489,6 +513,7 @@ mod sender_tick_tests {
                 .into_iter()
                 .map(|(t, k, v)| (t.to_string(), k.to_string(), Bytes::copy_from_slice(v)))
                 .collect(),
+            crdt_ops: Vec::new(),
         })
     }
 

--- a/crates/mesh/src/kv.rs
+++ b/crates/mesh/src/kv.rs
@@ -20,7 +20,7 @@ use parking_lot::RwLock;
 use tokio::sync::mpsc;
 
 use crate::{
-    crdt_kv::{CrdtOrMap, MergeStrategy},
+    crdt_kv::{CrdtOrMap, MergeStrategy, Operation, OperationLog},
     transport::chunk_assembler::ChunkAssembler,
 };
 
@@ -261,9 +261,14 @@ impl CrdtNamespace {
             "key '{key}' does not match prefix '{}'",
             self.prefix
         );
-        self.store.insert(key.to_string(), value.clone());
+        self.store.insert(key.to_string(), value);
+        // Notify with the canonical post-insert value (matching `get`), not the
+        // raw caller payload: for normalizing engines (e.g. `rl:`) the stored
+        // shard differs from the input, so this keeps the local-write and
+        // remote-merge notification shapes identical.
+        let canonical = self.store.get(key);
         self.subscriber_registry
-            .notify(key, Some(vec![Bytes::from(value)]));
+            .notify(key, canonical.map(|v| vec![Bytes::from(v)]));
     }
 
     /// Get the current value for a key, or None if not present or tombstoned.
@@ -429,6 +434,10 @@ pub struct RoundBatch {
     /// Values are `Bytes` so per-peer senders clone by Arc-refcount bump when
     /// fanning out, not by a full heap copy per peer.
     pub drain_entries: Vec<(String, Bytes)>,
+    /// Snapshot of the CRDT operation log for this round. Broadcast in full to
+    /// every peer; merge is idempotent by op-id so re-sending seen ops is a
+    /// no-op. Per-peer watermark filtering is a follow-up.
+    pub crdt_ops: Vec<Operation>,
 }
 
 /// Generic, application-agnostic mesh transport. Provides explicit namespace
@@ -631,9 +640,32 @@ impl MeshKV {
         // Broadcast traffic (td:*) flows through this path.
         let drain_entries = self.drain_registry.drain_all();
 
+        // Snapshot the CRDT op-log so the per-peer senders can broadcast it
+        // alongside the stream traffic this round.
+        let crdt_ops = self.store.get_operation_log().operations().to_vec();
+
         RoundBatch {
             targeted_entries,
             drain_entries,
+            crdt_ops,
+        }
+    }
+
+    /// Merge a batch of CRDT operations received from a peer into the local
+    /// store and fire subscribers for keys whose live value changed. Used by
+    /// the gossip receive path (`dispatch_crdt_batch`). Merge is idempotent by
+    /// op-id, so re-applying an already-seen batch is a no-op and fires no
+    /// subscriber events. Notifications carry the canonical post-merge value
+    /// (matching `get`), so remote-merge subscribers see the same value shape
+    /// as local writes.
+    pub(crate) fn merge_crdt_ops(&self, ops: Vec<Operation>) {
+        let mut log = OperationLog::new();
+        for op in ops {
+            log.append(op);
+        }
+        for change in self.store.merge(&log) {
+            self.subscriber_registry
+                .notify(&change.key, change.value.map(|v| vec![Bytes::from(v)]));
         }
     }
 

--- a/crates/mesh/src/lib.rs
+++ b/crates/mesh/src/lib.rs
@@ -22,7 +22,7 @@ mod tests;
 
 // Re-export commonly used types
 pub use crdt_kv::{
-    decode as decode_epoch_count, encode as encode_epoch_count, CrdtOrMap, EpochCount,
+    decode as decode_epoch_count, encode as encode_epoch_count, CrdtChange, CrdtOrMap, EpochCount,
     MergeStrategy, OperationLog, EPOCH_MAX_WINS_ENCODED_LEN,
 };
 pub use kv::{

--- a/crates/mesh/src/proto/gossip.proto
+++ b/crates/mesh/src/proto/gossip.proto
@@ -64,6 +64,7 @@ enum StreamMessageType {
   NACK = 5;
   HEARTBEAT = 6;
   STREAM_BATCH = 7;
+  CRDT_BATCH = 8;
 }
 
 message StreamMessage {
@@ -74,9 +75,28 @@ message StreamMessage {
     SnapshotChunk snapshot_chunk = 4;
     StreamAck ack = 5;
     StreamBatch stream_batch = 8;
+    CrdtBatch crdt_batch = 9;
   }
   uint64 sequence = 6; // Sequence number for ordering
   string peer_id = 7;   // Sender peer ID
+}
+
+// One CRDT operation, mirroring the in-crate Operation enum. `tombstone`
+// distinguishes a Remove (true, `value` empty) from an Insert (false). The
+// (timestamp, replica_id) pair is the Lamport op-id used for dedup/merge.
+message CrdtOp {
+  string key = 1;
+  bytes value = 2;
+  bool tombstone = 3;
+  uint64 timestamp = 4;
+  string replica_id = 5; // ReplicaId UUID, text form (ReplicaId::from_string)
+}
+
+// A batch of CRDT operations delivered in a single gossip round. The receiver
+// reconstructs an OperationLog and merges it into its CrdtOrMap; merge is
+// idempotent by op-id, so re-sending already-seen ops is a no-op.
+message CrdtBatch {
+  repeated CrdtOp ops = 1;
 }
 
 // Incremental state update (steady-state)

--- a/crates/mesh/src/tests/crdt_integration.rs
+++ b/crates/mesh/src/tests/crdt_integration.rs
@@ -1,0 +1,162 @@
+//! End-to-end tests for the CRDT-over-gossip path (d-3a).
+//!
+//! These exercise the full producer→consumer round trip without gRPC: the
+//! sender's op-log snapshot is encoded with
+//! [`build_crdt_batch`](crate::transport::crdt_batch::build_crdt_batch) and fed
+//! into the receiver's
+//! [`dispatch_crdt_batch`](crate::transport::crdt_batch::dispatch_crdt_batch),
+//! which decodes, merges into the receiver's store, and fires subscribers. In
+//! production the batch serialises through the `Gossip::sync_stream` RPC; here
+//! we bypass prost and route the ops directly, matching the chunking
+//! integration tests.
+
+use bytes::Bytes;
+use tokio::sync::mpsc::error::TryRecvError;
+
+use crate::{
+    crdt_kv::{decode as decode_epoch_count, encode as encode_epoch_count, EpochCount},
+    kv::MeshKV,
+    transport::crdt_batch::{build_crdt_batch, dispatch_crdt_batch},
+    MergeStrategy,
+};
+
+/// Simulate one gossip round of CRDT delivery: snapshot the sender's op-log,
+/// encode it, and dispatch it into the receiver.
+fn deliver_crdt(sender: &MeshKV, receiver: &MeshKV) {
+    let ops = sender.collect_round_batch().crdt_ops;
+    if let Some(batch) = build_crdt_batch(&ops) {
+        dispatch_crdt_batch(receiver, batch);
+    }
+}
+
+fn flatten(fragments: &[Bytes]) -> Vec<u8> {
+    fragments.iter().flat_map(|b| b.iter().copied()).collect()
+}
+
+#[test]
+fn remote_crdt_batch_converges_store() {
+    let sender = MeshKV::new("sender".to_string());
+    let s_ns = sender.configure_crdt_prefix("worker:", MergeStrategy::LastWriterWins);
+    s_ns.put("worker:a", b"v1".to_vec());
+
+    let receiver = MeshKV::new("receiver".to_string());
+    let r_ns = receiver.configure_crdt_prefix("worker:", MergeStrategy::LastWriterWins);
+    assert_eq!(r_ns.get("worker:a"), None);
+
+    deliver_crdt(&sender, &receiver);
+    assert_eq!(
+        r_ns.get("worker:a"),
+        Some(b"v1".to_vec()),
+        "CRDT op-log delivered over the wire converges the receiver's store"
+    );
+}
+
+#[tokio::test]
+async fn remote_merge_fires_subscriber_with_value() {
+    let sender = MeshKV::new("sender".to_string());
+    let s_ns = sender.configure_crdt_prefix("worker:", MergeStrategy::LastWriterWins);
+    s_ns.put("worker:a", b"v1".to_vec());
+
+    let receiver = MeshKV::new("receiver".to_string());
+    let r_ns = receiver.configure_crdt_prefix("worker:", MergeStrategy::LastWriterWins);
+    let mut sub = r_ns.subscribe("");
+
+    deliver_crdt(&sender, &receiver);
+
+    let (key, payload) = sub
+        .receiver
+        .recv()
+        .await
+        .expect("remote merge fires a subscriber event");
+    assert_eq!(key, "worker:a");
+    assert_eq!(flatten(&payload.expect("insert delivers a value")), b"v1");
+}
+
+#[tokio::test]
+async fn redelivering_same_batch_fires_no_new_event() {
+    let sender = MeshKV::new("sender".to_string());
+    let s_ns = sender.configure_crdt_prefix("worker:", MergeStrategy::LastWriterWins);
+    s_ns.put("worker:a", b"v1".to_vec());
+
+    let receiver = MeshKV::new("receiver".to_string());
+    let r_ns = receiver.configure_crdt_prefix("worker:", MergeStrategy::LastWriterWins);
+    let mut sub = r_ns.subscribe("");
+
+    deliver_crdt(&sender, &receiver);
+    let _ = sub.receiver.recv().await.expect("first delivery fires");
+
+    // Merge is idempotent by op-id: re-delivering the same batch changes no
+    // live value, so no subscriber event fires.
+    deliver_crdt(&sender, &receiver);
+    assert!(
+        matches!(sub.receiver.try_recv(), Err(TryRecvError::Empty)),
+        "idempotent re-delivery must not fire a subscriber event"
+    );
+}
+
+#[tokio::test]
+async fn rl_remote_merge_subscriber_sees_canonical_shard() {
+    // The sender writes the raw 16-byte (epoch, count) payload; the engine
+    // normalises it into a shard. The remote-merge subscriber must see the
+    // canonical shard shape (matching `get`), not the raw input — migration
+    // step 7's value-shape alignment.
+    let sender = MeshKV::new("sender".to_string());
+    let s_ns = sender.configure_crdt_prefix("rl:", MergeStrategy::EpochMaxWins);
+    s_ns.put("rl:global:node-a", encode_epoch_count(7, 42).to_vec());
+
+    let receiver = MeshKV::new("receiver".to_string());
+    let r_ns = receiver.configure_crdt_prefix("rl:", MergeStrategy::EpochMaxWins);
+    let mut sub = r_ns.subscribe("");
+
+    deliver_crdt(&sender, &receiver);
+
+    let (key, payload) = sub
+        .receiver
+        .recv()
+        .await
+        .expect("rl remote merge fires a subscriber event");
+    assert_eq!(key, "rl:global:node-a");
+    let bytes = flatten(&payload.expect("insert delivers a value"));
+    assert_ne!(
+        bytes.len(),
+        encode_epoch_count(7, 42).len(),
+        "subscriber sees the encoded shard, not the raw 16-byte payload"
+    );
+    assert_eq!(
+        decode_epoch_count(&bytes),
+        Some(EpochCount {
+            epoch: 7,
+            count: 42
+        })
+    );
+    assert_eq!(
+        r_ns.get("rl:global:node-a"),
+        Some(bytes),
+        "remote-merge notification shape matches get()"
+    );
+}
+
+#[tokio::test]
+async fn remote_tombstone_after_insert_notifies_none() {
+    let sender = MeshKV::new("sender".to_string());
+    let s_ns = sender.configure_crdt_prefix("worker:", MergeStrategy::LastWriterWins);
+    s_ns.put("worker:a", b"v1".to_vec());
+
+    let receiver = MeshKV::new("receiver".to_string());
+    let r_ns = receiver.configure_crdt_prefix("worker:", MergeStrategy::LastWriterWins);
+    let mut sub = r_ns.subscribe("");
+
+    deliver_crdt(&sender, &receiver);
+    let (_, payload) = sub.receiver.recv().await.expect("insert fires");
+    assert!(payload.is_some());
+
+    // Delete on the sender; the tombstone propagates and the receiver fires a
+    // `None` event as worker:a transitions live -> tombstoned.
+    s_ns.delete("worker:a");
+    deliver_crdt(&sender, &receiver);
+
+    let (key, payload) = sub.receiver.recv().await.expect("tombstone fires");
+    assert_eq!(key, "worker:a");
+    assert!(payload.is_none(), "tombstone notifies None");
+    assert_eq!(r_ns.get("worker:a"), None);
+}

--- a/crates/mesh/src/tests/crdt_integration.rs
+++ b/crates/mesh/src/tests/crdt_integration.rs
@@ -16,15 +16,18 @@ use tokio::sync::mpsc::error::TryRecvError;
 use crate::{
     crdt_kv::{decode as decode_epoch_count, encode as encode_epoch_count, EpochCount},
     kv::MeshKV,
-    transport::crdt_batch::{build_crdt_batch, dispatch_crdt_batch},
+    transport::{
+        crdt_batch::{build_crdt_batches, dispatch_crdt_batch},
+        limits::MAX_STREAM_CHUNK_BYTES,
+    },
     MergeStrategy,
 };
 
 /// Simulate one gossip round of CRDT delivery: snapshot the sender's op-log,
-/// encode it, and dispatch it into the receiver.
+/// encode it into size-bounded batches, and dispatch each into the receiver.
 fn deliver_crdt(sender: &MeshKV, receiver: &MeshKV) {
     let ops = sender.collect_round_batch().crdt_ops;
-    if let Some(batch) = build_crdt_batch(&ops) {
+    for batch in build_crdt_batches(&ops, MAX_STREAM_CHUNK_BYTES) {
         dispatch_crdt_batch(receiver, batch);
     }
 }

--- a/crates/mesh/src/tests/mod.rs
+++ b/crates/mesh/src/tests/mod.rs
@@ -4,4 +4,6 @@
 
 #[cfg(test)]
 mod chunking_integration;
+#[cfg(test)]
+mod crdt_integration;
 pub(crate) mod test_utils;

--- a/crates/mesh/src/transport/crdt_batch.rs
+++ b/crates/mesh/src/transport/crdt_batch.rs
@@ -2,10 +2,10 @@
 //!
 //! Mirrors [`sync_stream`](crate::transport::sync_stream) for the CRDT data
 //! path:
-//! - Outbound: [`build_crdt_batch`] converts an [`Operation`] slice (the local
-//!   op-log snapshot carried in [`RoundBatch`](crate::kv::RoundBatch)) into a
-//!   wire [`CrdtBatch`]; [`wrap_crdt_batch`] builds the `StreamMessage`
-//!   envelope.
+//! - Outbound: [`build_crdt_batches`] converts an [`Operation`] slice (the
+//!   local op-log snapshot carried in [`RoundBatch`](crate::kv::RoundBatch))
+//!   into one or more wire [`CrdtBatch`]es, each bounded below the gRPC
+//!   message cap; [`wrap_crdt_batch`] builds the `StreamMessage` envelope.
 //! - Inbound: [`dispatch_crdt_batch`] decodes a received `CrdtBatch` back into
 //!   `Operation`s and merges them into the local CRDT store via `MeshKV`.
 //!
@@ -65,15 +65,42 @@ fn proto_to_op(op: CrdtOp) -> Option<Operation> {
     })
 }
 
-/// Build a [`CrdtBatch`] from an op-log snapshot. Returns `None` for an empty
-/// snapshot so the caller can skip sending an empty message.
-pub fn build_crdt_batch(ops: &[Operation]) -> Option<CrdtBatch> {
-    if ops.is_empty() {
-        return None;
+/// Conservative estimate of a `CrdtOp`'s encoded size: the variable-length
+/// fields plus a constant covering proto field tags, length varints, the
+/// timestamp/tombstone fields, and the repeated-field wrapper in `CrdtBatch`.
+fn estimated_op_size(op: &CrdtOp) -> usize {
+    op.key.len() + op.value.len() + op.replica_id.len() + 24
+}
+
+/// Split an op-log snapshot into one or more [`CrdtBatch`]es, each estimated to
+/// stay under `max_bytes` so the wrapped `StreamMessage` does not exceed the
+/// gRPC message cap. Returns an empty `Vec` for an empty snapshot. Without this
+/// bound, a large op-log (broadcast in full each round until per-peer watermark
+/// filtering lands) could produce a single frame above `MAX_MESSAGE_SIZE`,
+/// which tonic rejects on encode/decode and which would tear down the
+/// sync_stream. A single op larger than `max_bytes` is emitted alone (best
+/// effort); `worker:`/`rl:`/`config:` values are far below the cap, so in
+/// practice this only bounds the op count per frame.
+pub fn build_crdt_batches(ops: &[Operation], max_bytes: usize) -> Vec<CrdtBatch> {
+    let mut out = Vec::new();
+    let mut current: Vec<CrdtOp> = Vec::new();
+    let mut current_bytes = 0usize;
+    for op in ops {
+        let proto = op_to_proto(op);
+        let size = estimated_op_size(&proto);
+        if !current.is_empty() && current_bytes + size > max_bytes {
+            out.push(CrdtBatch {
+                ops: std::mem::take(&mut current),
+            });
+            current_bytes = 0;
+        }
+        current_bytes += size;
+        current.push(proto);
     }
-    Some(CrdtBatch {
-        ops: ops.iter().map(op_to_proto).collect(),
-    })
+    if !current.is_empty() {
+        out.push(CrdtBatch { ops: current });
+    }
+    out
 }
 
 /// Wrap a [`CrdtBatch`] in a `StreamMessage` envelope.
@@ -87,9 +114,10 @@ pub fn wrap_crdt_batch(batch: CrdtBatch, sequence: u64, self_name: &str) -> Stre
 }
 
 /// Receiver-side dispatch for a `CrdtBatch`: decode each op and merge the batch
-/// into the local CRDT store. Ops with an unparsable `replica_id` are skipped.
-/// Merge is idempotent by op-id, so a batch the node has already absorbed is a
-/// no-op. (Subscriber notification on remote merge is a follow-up — d-3a-2.)
+/// into the local CRDT store, firing subscribers for keys whose value changed
+/// (via `MeshKV::merge_crdt_ops`). Ops with an unparsable `replica_id` are
+/// skipped. Merge is idempotent by op-id, so a batch the node has already
+/// absorbed is a no-op and fires no subscriber event.
 pub fn dispatch_crdt_batch(mesh_kv: &MeshKV, batch: CrdtBatch) {
     let ops: Vec<Operation> = batch.ops.into_iter().filter_map(proto_to_op).collect();
     if ops.is_empty() {
@@ -115,8 +143,8 @@ mod tests {
     }
 
     #[test]
-    fn build_crdt_batch_skips_empty() {
-        assert!(build_crdt_batch(&[]).is_none());
+    fn build_crdt_batches_empty_and_single() {
+        assert!(build_crdt_batches(&[], 1024).is_empty());
         let replica = ReplicaId::new();
         let ops = vec![Operation::insert(
             "rl:c".to_string(),
@@ -124,10 +152,35 @@ mod tests {
             1,
             replica,
         )];
-        let batch = build_crdt_batch(&ops).expect("non-empty op-log yields a batch");
-        assert_eq!(batch.ops.len(), 1);
-        assert_eq!(batch.ops[0].key, "rl:c");
-        assert!(!batch.ops[0].tombstone);
+        let batches = build_crdt_batches(&ops, 1024);
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].ops.len(), 1);
+        assert_eq!(batches[0].ops[0].key, "rl:c");
+        assert!(!batches[0].ops[0].tombstone);
+    }
+
+    #[test]
+    fn build_crdt_batches_splits_over_budget() {
+        let replica = ReplicaId::new();
+        let ops: Vec<Operation> = (0..50)
+            .map(|i| Operation::insert(format!("worker:{i}"), vec![0u8; 100], i, replica))
+            .collect();
+        // Each op is ~100 bytes of value + overhead; a 300-byte budget forces
+        // several batches.
+        let batches = build_crdt_batches(&ops, 300);
+        assert!(
+            batches.len() > 1,
+            "large op-log must split into many batches"
+        );
+        // Every op is preserved exactly once across all batches.
+        let total: usize = batches.iter().map(|b| b.ops.len()).sum();
+        assert_eq!(total, ops.len());
+        // No batch exceeds the budget (except a lone oversized op, which none
+        // of these are).
+        for batch in &batches {
+            let bytes: usize = batch.ops.iter().map(estimated_op_size).sum();
+            assert!(bytes <= 300 || batch.ops.len() == 1);
+        }
     }
 
     #[test]

--- a/crates/mesh/src/transport/crdt_batch.rs
+++ b/crates/mesh/src/transport/crdt_batch.rs
@@ -1,0 +1,153 @@
+//! CRDT batch wire-message helpers for the `Gossip::sync_stream` RPC.
+//!
+//! Mirrors [`sync_stream`](crate::transport::sync_stream) for the CRDT data
+//! path:
+//! - Outbound: [`build_crdt_batch`] converts an [`Operation`] slice (the local
+//!   op-log snapshot carried in [`RoundBatch`](crate::kv::RoundBatch)) into a
+//!   wire [`CrdtBatch`]; [`wrap_crdt_batch`] builds the `StreamMessage`
+//!   envelope.
+//! - Inbound: [`dispatch_crdt_batch`] decodes a received `CrdtBatch` back into
+//!   `Operation`s and merges them into the local CRDT store via `MeshKV`.
+//!
+//! The op-log is broadcast in full each round; merge is idempotent by op-id,
+//! so re-sending already-seen ops is a no-op. Per-peer watermark filtering (to
+//! send only ops the peer has not acked) is a follow-up.
+
+use crate::{
+    crdt_kv::{Operation, ReplicaId},
+    kv::MeshKV,
+    service::gossip::{
+        stream_message::Payload as StreamPayload, CrdtBatch, CrdtOp, StreamMessage,
+        StreamMessageType,
+    },
+};
+
+/// Convert an in-crate [`Operation`] into its wire form. A `Remove` carries an
+/// empty `value` and `tombstone = true`; an `Insert` carries the value bytes
+/// and `tombstone = false`. The `replica_id` UUID is rendered to text.
+fn op_to_proto(op: &Operation) -> CrdtOp {
+    match op {
+        Operation::Insert {
+            key,
+            value,
+            timestamp,
+            replica_id,
+        } => CrdtOp {
+            key: key.clone(),
+            value: value.clone(),
+            tombstone: false,
+            timestamp: *timestamp,
+            replica_id: replica_id.to_string(),
+        },
+        Operation::Remove {
+            key,
+            timestamp,
+            replica_id,
+        } => CrdtOp {
+            key: key.clone(),
+            value: Vec::new(),
+            tombstone: true,
+            timestamp: *timestamp,
+            replica_id: replica_id.to_string(),
+        },
+    }
+}
+
+/// Convert a wire [`CrdtOp`] back into an [`Operation`]. Returns `None` if the
+/// `replica_id` field is not a valid UUID — a malformed/hostile peer's op is
+/// dropped rather than poisoning the merge.
+fn proto_to_op(op: CrdtOp) -> Option<Operation> {
+    let replica_id = ReplicaId::from_string(&op.replica_id).ok()?;
+    Some(if op.tombstone {
+        Operation::remove(op.key, op.timestamp, replica_id)
+    } else {
+        Operation::insert(op.key, op.value, op.timestamp, replica_id)
+    })
+}
+
+/// Build a [`CrdtBatch`] from an op-log snapshot. Returns `None` for an empty
+/// snapshot so the caller can skip sending an empty message.
+pub fn build_crdt_batch(ops: &[Operation]) -> Option<CrdtBatch> {
+    if ops.is_empty() {
+        return None;
+    }
+    Some(CrdtBatch {
+        ops: ops.iter().map(op_to_proto).collect(),
+    })
+}
+
+/// Wrap a [`CrdtBatch`] in a `StreamMessage` envelope.
+pub fn wrap_crdt_batch(batch: CrdtBatch, sequence: u64, self_name: &str) -> StreamMessage {
+    StreamMessage {
+        message_type: StreamMessageType::CrdtBatch as i32,
+        payload: Some(StreamPayload::CrdtBatch(batch)),
+        sequence,
+        peer_id: self_name.to_owned(),
+    }
+}
+
+/// Receiver-side dispatch for a `CrdtBatch`: decode each op and merge the batch
+/// into the local CRDT store. Ops with an unparsable `replica_id` are skipped.
+/// Merge is idempotent by op-id, so a batch the node has already absorbed is a
+/// no-op. (Subscriber notification on remote merge is a follow-up — d-3a-2.)
+pub fn dispatch_crdt_batch(mesh_kv: &MeshKV, batch: CrdtBatch) {
+    let ops: Vec<Operation> = batch.ops.into_iter().filter_map(proto_to_op).collect();
+    if ops.is_empty() {
+        return;
+    }
+    mesh_kv.merge_crdt_ops(ops);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn op_round_trips_through_proto() {
+        let replica = ReplicaId::new();
+        let insert = Operation::insert("worker:a".to_string(), b"v".to_vec(), 5, replica);
+        let remove = Operation::remove("worker:b".to_string(), 7, replica);
+
+        let back_insert = proto_to_op(op_to_proto(&insert)).expect("valid insert round-trips");
+        let back_remove = proto_to_op(op_to_proto(&remove)).expect("valid remove round-trips");
+        assert_eq!(back_insert, insert);
+        assert_eq!(back_remove, remove);
+    }
+
+    #[test]
+    fn build_crdt_batch_skips_empty() {
+        assert!(build_crdt_batch(&[]).is_none());
+        let replica = ReplicaId::new();
+        let ops = vec![Operation::insert(
+            "rl:c".to_string(),
+            b"x".to_vec(),
+            1,
+            replica,
+        )];
+        let batch = build_crdt_batch(&ops).expect("non-empty op-log yields a batch");
+        assert_eq!(batch.ops.len(), 1);
+        assert_eq!(batch.ops[0].key, "rl:c");
+        assert!(!batch.ops[0].tombstone);
+    }
+
+    #[test]
+    fn proto_to_op_rejects_bad_replica_id() {
+        let bad = CrdtOp {
+            key: "worker:a".to_string(),
+            value: Vec::new(),
+            tombstone: false,
+            timestamp: 1,
+            replica_id: "not-a-uuid".to_string(),
+        };
+        assert!(proto_to_op(bad).is_none());
+    }
+
+    #[test]
+    fn wrap_crdt_batch_envelope_shape() {
+        let msg = wrap_crdt_batch(CrdtBatch::default(), 11, "node-1");
+        assert_eq!(msg.message_type, StreamMessageType::CrdtBatch as i32);
+        assert_eq!(msg.sequence, 11);
+        assert_eq!(msg.peer_id, "node-1");
+        assert!(matches!(msg.payload, Some(StreamPayload::CrdtBatch(_))));
+    }
+}

--- a/crates/mesh/src/transport/mod.rs
+++ b/crates/mesh/src/transport/mod.rs
@@ -4,5 +4,6 @@
 
 pub mod chunk_assembler;
 pub mod chunking;
+pub mod crdt_batch;
 pub mod limits;
 pub mod sync_stream;

--- a/crates/mesh/src/transport/sync_stream.rs
+++ b/crates/mesh/src/transport/sync_stream.rs
@@ -163,6 +163,7 @@ mod tests {
                 .into_iter()
                 .map(|(t, k, v)| (t.to_string(), k.to_string(), Bytes::copy_from_slice(v)))
                 .collect(),
+            crdt_ops: Vec::new(),
         }
     }
 

--- a/model_gateway/src/mesh/adapters/rate_limit_sync.rs
+++ b/model_gateway/src/mesh/adapters/rate_limit_sync.rs
@@ -12,10 +12,11 @@
 //! `u64` big-endian epoch in bytes 0..8, `i64` big-endian count in
 //! bytes 8..16. The mesh CRDT normalizes stored `rl:` values into a
 //! rate-limit shard state that also remembers live/tombstone merge
-//! metadata. [`decode_epoch_count`] reads that shard state back into
-//! plain epoch/count and also accepts the raw write payload that local
-//! namespace subscribers can observe before CRDT normalization, so the
-//! adapter never handles CRDT internals.
+//! metadata. Subscribers observe the canonical normalized shard
+//! (matching `get`) for both local writes and remote merges.
+//! [`decode_epoch_count`] reads that shard state back into plain
+//! epoch/count; it also still accepts the raw 16-byte payload as a
+//! defensive backstop, so the adapter never handles CRDT internals.
 //!
 //! The caller owns the epoch clock — typically
 //! `now.as_secs() / window.as_secs()`. `sync_counter` writes the


### PR DESCRIPTION
## Description

### Problem

The mesh-v2 gap analysis (`.claude/docs/mesh/mesh-v2-gap-analysis.md`) flagged the **d-3 cutover** as the single largest gap: CRDT operations never reached the wire. `CrdtNamespace::put`/`delete` only mutated the local op-log, `CrdtOrMap::merge` was reachable only from tests, and the gossip loop carried stream traffic (`td:`/`tree:*`) only. So the `worker:`, `rl:`, and `config:` CRDT namespaces were silent across nodes, and remote CRDT changes never reached local subscribers.

### Solution

Wire the CRDT data path onto the existing `sync_stream` transport (this is **d-3a**; the adapter wiring in `server.rs` and rate-limit enforcement are follow-ups). Two halves, in one PR:

1. **CRDT op-log over the wire** — state converges across nodes.
2. **Subscriber fan-out on remote merge** + value-shape alignment (migration step 7) — remote changes reach subscribers with the same value shape `get` returns.

## Changes

**Wire format** (`crates/mesh/src/proto/gossip.proto`)
- `CrdtOp { key, value, tombstone, timestamp, replica_id }` + `CrdtBatch { ops }` + `CRDT_BATCH` `StreamMessageType` + a `crdt_batch` arm in the `StreamMessage` oneof. `CrdtOp` mirrors the in-crate `Operation`; `replica_id` is the `ReplicaId` UUID in text form. Field-by-field (not an opaque bincode blob) for a language-agnostic schema.

**Codec** (`crates/mesh/src/transport/crdt_batch.rs`, new)
- `build_crdt_batch` (op-log → `CrdtBatch`), `wrap_crdt_batch` (envelope), `dispatch_crdt_batch` (decode → merge). Ops with an unparsable `replica_id` are dropped rather than poisoning the merge.

**Producer / consumer**
- `RoundBatch` gains a `crdt_ops` snapshot, filled in `collect_round_batch` from the store's op-log. Both per-peer senders (`gossip_controller` dialed streams, `gossip_service` accepted streams) broadcast the snapshot each round alongside the stream batch. Merge is idempotent by op-id, so re-sending seen ops is a no-op — **per-peer watermark filtering is a follow-up**.
- Both inbound dispatch blocks gain a `CrdtBatch` arm → `dispatch_crdt_batch`.

**Fan-out + step 7** (`engine/mod.rs`, `engine/lww.rs`, `engine/rate_limit.rs`, `crdt.rs`, `kv.rs`)
- `NamespaceCrdtEngine::apply_remote_ops` now returns `Vec<CrdtChange>`; `CrdtOrMap::merge` concatenates per-engine changes; `MeshKV::merge_crdt_ops` fires `SubscriberRegistry::notify` per change with the canonical post-merge value (matching `get`).
- `CrdtNamespace::put` now notifies the canonical post-insert value instead of the raw caller payload, so local-write and remote-merge subscribers see one shape (the `rl:` adapter no longer needs to special-case the raw payload; its module doc is updated).
- **Change detection emits a `CrdtChange` iff the observable `get(key)` value actually changes** (snapshot before/after the apply loop), not on mere op acceptance. This suppresses spurious events: a newer-version insert rewriting byte-identical bytes, and a tombstone for an already-absent key (`Tombstone→Tombstone` or `vacant→Tombstone`, both encoding to `None`). Generation/log semantics are unchanged.

### Verification

An adversarial multi-agent pass reviewed the change-detection for missed/spurious/wrong-value events. It found **no missed events and no convergence bugs**, and two P2 spurious-event classes — both fixed by the observable-value diff above. (Two findings were correct-as-is: a frontier reshuffle that changes the encoded shard bytes correctly fires, and a benign concurrency TOCTOU where the emitted value is always a valid `get` snapshot and converges.)

## Test Plan

- [x] `cargo test -p smg-mesh --lib` — **165 passed**, 0 failed (+15 over baseline)
  - codec: round-trip, envelope shape, empty-skip, bad-replica-id reject
  - end-to-end (no gRPC, `tests/crdt_integration.rs`): convergence, remote-merge subscriber fan-out, idempotent re-delivery fires nothing, `rl:` canonical-shard shape, tombstone→None
  - `CrdtOrMap::merge` change-detection contract: new value, byte-identical no-op, never-seen tombstone no-op, kill-live emits `None`
- [x] `cargo build -p smg` + `cargo test -p smg --lib mesh::adapters` — pass (downstream unaffected)
- [x] `cargo clippy -p smg-mesh --all-targets` + `cargo fmt` — clean

Net: **+635 / −21** across 18 files.

### Follow-ups (not in this PR)
- Per-peer CRDT send watermark (bandwidth + at-least-once retry).
- Initial CRDT snapshot-on-join / partition heal.
- Wire the v2 adapters (`worker:`/`rl:`/tree) into `server.rs` and connect outbound change paths (d-3 PR 2/3); rate-limit middleware enforcement (d-3b).

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CRDT operation batches now synchronize across peers via gossip.
  * Subscribers are notified with the canonical post-merge value; notifications are only emitted when a key’s observable value actually changes.
  * Deletes propagate as notifications with a None payload.

* **Tests**
  * Integration tests for remote CRDT delivery, convergence, idempotency, canonical shard shape, and tombstone propagation.
  * Unit tests for change-reporting and tombstone edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightseekorg/smg/pull/1570?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->