### PR TITLE
feat(scheduler): preemption — victim search, preempt path, body wrapper (PR 2 M3)

### DIFF
--- a/model_gateway/src/middleware/scheduler/body.rs
+++ b/model_gateway/src/middleware/scheduler/body.rs
@@ -34,6 +34,11 @@ pub struct SchedulerGuardBody {
     /// Latch so the TTFT CAS is attempted only once (on the first data
     /// frame); subsequent frames skip the check entirely.
     ttft_marked: bool,
+    /// Set once the stream is force-ended by a lost TTFT/preempt CAS. Keeps
+    /// the terminal state idempotent across re-polls and keeps
+    /// `is_end_stream` consistent with `poll_frame`: the inner body still
+    /// has data, but this wrapper has already signalled `None`.
+    terminated: bool,
 }
 
 impl SchedulerGuardBody {
@@ -42,6 +47,7 @@ impl SchedulerGuardBody {
             inner,
             permit,
             ttft_marked: false,
+            terminated: false,
         }
     }
 }
@@ -58,6 +64,10 @@ impl http_body::Body for SchedulerGuardBody {
         // `Unpin` too, so `get_mut` + `Pin::new(&mut inner)` is sound
         // (mirrors `TokenGuardBody` in `concurrency.rs`).
         let this = self.get_mut();
+        // Stay ended once we've force-ended; never poll the inner body again.
+        if this.terminated {
+            return Poll::Ready(None);
+        }
         let polled = Pin::new(&mut this.inner).poll_frame(cx);
 
         if !this.ttft_marked {
@@ -68,6 +78,7 @@ impl http_body::Body for SchedulerGuardBody {
                     } else {
                         // Lost the TTFT race to a concurrent preemption
                         // CAS. Terminate the stream cleanly.
+                        this.terminated = true;
                         return Poll::Ready(None);
                     }
                 }
@@ -77,7 +88,9 @@ impl http_body::Body for SchedulerGuardBody {
     }
 
     fn is_end_stream(&self) -> bool {
-        self.inner.is_end_stream()
+        // Force-end takes precedence: once we've returned `None` on a lost
+        // CAS, report the stream ended even though the inner body has not.
+        self.terminated || self.inner.is_end_stream()
     }
 
     fn size_hint(&self) -> http_body::SizeHint {
@@ -140,6 +153,16 @@ mod tests {
         assert!(
             next.is_none(),
             "preempted body must end the stream on first frame"
+        );
+        // is_end_stream must agree with the forced None (consistency on the
+        // CAS-loss path), and a re-poll must stay ended.
+        assert!(
+            http_body::Body::is_end_stream(&guarded),
+            "force-ended stream must report is_end_stream() == true"
+        );
+        assert!(
+            guarded.frame().await.is_none(),
+            "re-polling a force-ended stream must stay ended"
         );
     }
 

--- a/model_gateway/src/middleware/scheduler/body.rs
+++ b/model_gateway/src/middleware/scheduler/body.rs
@@ -1,0 +1,174 @@
+//! Response-body wrapper that ties a [`SchedulerPermit`] to the response
+//! stream: it marks TTFT on the first data frame and releases the slot
+//! when the body finishes draining (or is dropped).
+
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use axum::body::Body;
+use bytes::Bytes;
+use http_body::Frame;
+
+use super::engine::SchedulerPermit;
+
+/// Wraps a response [`Body`], holding the request's [`SchedulerPermit`]
+/// for the lifetime of the stream.
+///
+/// - **TTFT.** On the first *data* frame, marks time-to-first-byte via the
+///   permit's CAS. If the scheduler already won the preemption CAS
+///   (`try_mark_first_byte` returns `false`), the request was preempted in
+///   the narrow gap before its first byte — we end the stream
+///   (`Poll::Ready(None)`) rather than emit a byte the client should never
+///   see. The handler's cancel token has fired, so it is unwinding anyway.
+///   Only data frames mark TTFT; trailer-only responses never do.
+/// - **Slot release.** When this body drops (stream complete, client
+///   disconnected, or handler unwound), the `permit` field drops with it,
+///   and `SchedulerPermit::drop` releases the slot back to the scheduler
+///   and unregisters the inflight handle. No explicit `Drop` is needed —
+///   the field's natural drop carries the invariant.
+pub struct SchedulerGuardBody {
+    inner: Body,
+    permit: SchedulerPermit,
+    /// Latch so the TTFT CAS is attempted only once (on the first data
+    /// frame); subsequent frames skip the check entirely.
+    ttft_marked: bool,
+}
+
+impl SchedulerGuardBody {
+    pub fn new(inner: Body, permit: SchedulerPermit) -> Self {
+        Self {
+            inner,
+            permit,
+            ttft_marked: false,
+        }
+    }
+}
+
+impl http_body::Body for SchedulerGuardBody {
+    type Data = Bytes;
+    type Error = axum::Error;
+
+    fn poll_frame(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        // `Body` is `UnsyncBoxBody`, which is `Unpin`; the other fields are
+        // `Unpin` too, so `get_mut` + `Pin::new(&mut inner)` is sound
+        // (mirrors `TokenGuardBody` in `concurrency.rs`).
+        let this = self.get_mut();
+        let polled = Pin::new(&mut this.inner).poll_frame(cx);
+
+        if !this.ttft_marked {
+            if let Poll::Ready(Some(Ok(frame))) = &polled {
+                if frame.is_data() {
+                    if this.permit.try_mark_first_byte() {
+                        this.ttft_marked = true;
+                    } else {
+                        // Lost the TTFT race to a concurrent preemption
+                        // CAS. Terminate the stream cleanly.
+                        return Poll::Ready(None);
+                    }
+                }
+            }
+        }
+        polled
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.inner.is_end_stream()
+    }
+
+    fn size_hint(&self) -> http_body::SizeHint {
+        self.inner.size_hint()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use http_body_util::BodyExt;
+    use smg_auth::RequestId;
+
+    use super::*;
+    use crate::middleware::scheduler::{Class, PriorityScheduler, SchedulerSettings};
+
+    fn scheduler() -> std::sync::Arc<PriorityScheduler> {
+        let settings =
+            SchedulerSettings::from_cli_and_yaml(true, Class::Default, 32, None).unwrap();
+        // Default reservations sum to 160 (Interactive 128 + System 32),
+        // so capacity must be >= 160 for new() to accept them.
+        PriorityScheduler::new(&settings, 256).unwrap()
+    }
+
+    fn permit(sched: &std::sync::Arc<PriorityScheduler>, id: &str) -> SchedulerPermit {
+        sched
+            .acquire_inflight(Class::Default, RequestId(id.to_string()))
+            .expect("slot available")
+    }
+
+    #[tokio::test]
+    async fn test_first_data_frame_marks_ttft() {
+        let sched = scheduler();
+        let p = permit(&sched, "req-ttft");
+        let handle = std::sync::Arc::clone(p.handle());
+        let mut guarded = SchedulerGuardBody::new(Body::from("hello world"), p);
+
+        assert!(handle.is_preemptible(), "pre-TTFT before first frame");
+        // Drive the first frame (SchedulerGuardBody is Unpin).
+        let frame = guarded.frame().await.expect("a frame").expect("ok frame");
+        assert!(frame.is_data());
+        assert!(
+            !handle.is_preemptible(),
+            "first data frame must mark TTFT (no longer preemptible)"
+        );
+        // A request that has emitted its first byte must reject preemption.
+        assert!(!handle.try_mark_preempted());
+    }
+
+    #[tokio::test]
+    async fn test_preempted_before_first_byte_ends_stream() {
+        let sched = scheduler();
+        let p = permit(&sched, "req-preempt");
+        let handle = std::sync::Arc::clone(p.handle());
+        // Scheduler wins the preempt CAS before any byte is polled.
+        assert!(handle.try_mark_preempted());
+
+        let mut guarded = SchedulerGuardBody::new(Body::from("should not surface"), p);
+        // First poll must terminate the stream rather than yield the data.
+        let next = guarded.frame().await;
+        assert!(
+            next.is_none(),
+            "preempted body must end the stream on first frame"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_trailer_only_response_never_marks_ttft() {
+        let sched = scheduler();
+        let p = permit(&sched, "req-empty");
+        let handle = std::sync::Arc::clone(p.handle());
+        // Empty body: no data frames at all.
+        let guarded = SchedulerGuardBody::new(Body::empty(), p);
+        let _ = guarded.collect().await; // exhaust
+        assert!(
+            handle.is_preemptible(),
+            "no data frame emitted → TTFT never marked"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_drop_releases_slot() {
+        let sched = scheduler();
+        assert_eq!(sched.inflight_for_test(Class::Default), 0);
+        let p = permit(&sched, "req-drop");
+        assert_eq!(sched.inflight_for_test(Class::Default), 1);
+        let guarded = SchedulerGuardBody::new(Body::from("x"), p);
+        drop(guarded);
+        assert_eq!(
+            sched.inflight_for_test(Class::Default),
+            0,
+            "dropping the guarded body releases the slot"
+        );
+    }
+}

--- a/model_gateway/src/middleware/scheduler/engine.rs
+++ b/model_gateway/src/middleware/scheduler/engine.rs
@@ -17,7 +17,7 @@ use smg_auth::RequestId;
 use thiserror::Error;
 use tokio::sync::{oneshot, watch, Notify};
 use tokio_util::sync::CancellationToken;
-use tracing::warn;
+use tracing::{info, warn};
 
 use super::{
     inflight::InflightHandle,
@@ -25,6 +25,13 @@ use super::{
     slots::SlotPool,
     Class, ClassRuntimeConfig, SchedulerSettings,
 };
+
+/// Max time to wait, after firing a preemption cancel, for the victim's slot
+/// to free before falling back to enqueue.
+const PREEMPTION_WAIT_BUDGET: Duration = Duration::from_millis(50);
+
+/// Poll interval while waiting for a preempted slot to free.
+const PREEMPTION_POLL_INTERVAL: Duration = Duration::from_millis(2);
 
 /// Construction-time failures for [`PriorityScheduler::new`].
 ///
@@ -52,7 +59,7 @@ pub enum RejectionReason {
     /// Queued waiter aged past `queue_timeout`. → 408.
     QueueTimeout,
     /// Scheduler cancelled this inflight to admit a higher-priority
-    /// waiter. → 503 + Retry-After. Lands in a later commit.
+    /// waiter. → 503 + Retry-After.
     Preempted,
     /// The caller's cancellation token fired before admission completed
     /// (typically the HTTP client disconnected). Never serialized — the
@@ -174,17 +181,39 @@ impl PriorityScheduler {
         // doesn't wind down within the budget we fall through to enqueue
         // — the cancel still fired, so the slot frees shortly regardless.
         if self.class_config[class as usize].can_preempt {
+            // Don't cancel a victim on behalf of a caller whose client has
+            // already disconnected — the queued path treats a fired `cancel`
+            // as ClientCancelled, and the preempt path must match.
+            if cancel.is_cancelled() {
+                return AdmitOutcome::Rejected(RejectionReason::ClientCancelled);
+            }
             if let Some(victim) = self.find_preemption_victim(class) {
                 // CAS the victim pre-TTFT lock. Fire its cancel only on a
                 // win, so we never unwind a request that already streamed.
                 if victim.try_mark_preempted() {
+                    info!(
+                        victim_id = %victim.request_id().0,
+                        victim_class = ?victim.class(),
+                        preemptor_class = ?class,
+                        "scheduler: preempting pre-TTFT request to admit higher class"
+                    );
                     victim.cancel();
                     if let Some(permit) = self
-                        .wait_for_slot(class, request_id.clone(), Duration::from_millis(50))
+                        .wait_for_slot(class, request_id.clone(), &cancel, PREEMPTION_WAIT_BUDGET)
                         .await
                     {
                         return AdmitOutcome::Admitted(permit);
                     }
+                    // Client went away while we waited — don't enqueue work
+                    // nobody is waiting for.
+                    if cancel.is_cancelled() {
+                        return AdmitOutcome::Rejected(RejectionReason::ClientCancelled);
+                    }
+                    warn!(
+                        preemptor_class = ?class,
+                        budget_ms = PREEMPTION_WAIT_BUDGET.as_millis() as u64,
+                        "scheduler: preempted slot did not free within budget; enqueueing"
+                    );
                     // Slot not free in time — fall through to enqueue.
                 }
             }
@@ -288,17 +317,27 @@ impl PriorityScheduler {
         self: &Arc<Self>,
         class: Class,
         request_id: RequestId,
+        cancel: &CancellationToken,
         budget: Duration,
     ) -> Option<SchedulerPermit> {
         let deadline = Instant::now() + budget;
         loop {
-            if let Some(permit) = self.acquire_inflight(class, request_id.clone()) {
-                return Some(permit);
+            // Acquire the slot and register in one step, consuming
+            // `request_id` only on success — so a failed poll never clones it
+            // (this loop runs up to budget/poll-interval times per
+            // preemption).
+            if self.slot_pool.try_acquire(class) {
+                return Some(self.register_inflight(class, request_id));
             }
             if Instant::now() >= deadline {
                 return None;
             }
-            tokio::time::sleep(Duration::from_millis(2)).await;
+            // Abort the wait if the caller's client disconnects — no point
+            // holding the victim's freed slot for a request nobody wants.
+            tokio::select! {
+                () = tokio::time::sleep(PREEMPTION_POLL_INTERVAL) => {}
+                () = cancel.cancelled() => return None,
+            }
         }
     }
 
@@ -1301,6 +1340,30 @@ mod tests {
         };
         let (outcome, ()) = tokio::join!(admit_fut, dropper);
         assert!(matches!(outcome, AdmitOutcome::Admitted(_)));
+    }
+
+    #[tokio::test]
+    async fn test_preempt_skipped_when_caller_already_cancelled() {
+        // A preempt-capable admission whose own client has already
+        // disconnected must not cancel a lower-class victim: it returns
+        // ClientCancelled and leaves the victim untouched.
+        let sched = PriorityScheduler::new(&preempt_settings(), 1).unwrap();
+        let victim = sched.acquire_inflight(Class::Bulk, rid("victim")).unwrap();
+        let victim_cancel = victim.cancel_token();
+
+        let cancelled = CancellationToken::new();
+        cancelled.cancel();
+        let outcome = sched.admit(Class::Interactive, rid("vip"), cancelled).await;
+
+        assert!(matches!(
+            outcome,
+            AdmitOutcome::Rejected(RejectionReason::ClientCancelled)
+        ));
+        assert!(
+            !victim_cancel.is_cancelled(),
+            "victim must not be preempted"
+        );
+        assert_eq!(sched.inflight_for_test(Class::Bulk), 1);
     }
 
     #[tokio::test(start_paused = true)]

--- a/model_gateway/src/middleware/scheduler/engine.rs
+++ b/model_gateway/src/middleware/scheduler/engine.rs
@@ -190,6 +190,20 @@ impl PriorityScheduler {
             if let Some(victim) = self.find_preemption_victim(class) {
                 // CAS the victim pre-TTFT lock. Fire its cancel only on a
                 // win, so we never unwind a request that already streamed.
+                //
+                // The mark is irreversible (no rollback — a CAS back to 0
+                // could race a now-arriving first byte). So a victim that
+                // doesn't unwind within the budget is still preempted: its
+                // first data frame is truncated by `SchedulerGuardBody`. For
+                // the victim to actually unwind, its handler must honor the
+                // cancel token (wired into the long-running handlers in M4.5
+                // / #1577); until that lands the flag must stay off.
+                //
+                // The freed slot is not reserved for this preemptor — the
+                // dispatcher (on the victim's release) or a concurrent
+                // fast-path admit may take it first, in which case we simply
+                // fall through to enqueue. A successful mark therefore does
+                // not guarantee this preemptor benefits.
                 if victim.try_mark_preempted() {
                     info!(
                         victim_id = %victim.request_id().0,

--- a/model_gateway/src/middleware/scheduler/engine.rs
+++ b/model_gateway/src/middleware/scheduler/engine.rs
@@ -5,7 +5,12 @@
 //! fit under the live backend capacity; runtime admission lives in
 //! follow-on commits.
 
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    cmp::Reverse,
+    collections::HashMap,
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 use parking_lot::RwLock;
 use smg_auth::RequestId;
@@ -163,6 +168,28 @@ impl PriorityScheduler {
             return AdmitOutcome::Admitted(permit);
         }
 
+        // Preemption path: if this class may preempt, try to cancel one
+        // lower-class pre-TTFT request and claim its slot. At most one
+        // preemption per admission (no cascading); if the victim's body
+        // doesn't wind down within the budget we fall through to enqueue
+        // — the cancel still fired, so the slot frees shortly regardless.
+        if self.class_config[class as usize].can_preempt {
+            if let Some(victim) = self.find_preemption_victim(class) {
+                // CAS the victim pre-TTFT lock. Fire its cancel only on a
+                // win, so we never unwind a request that already streamed.
+                if victim.try_mark_preempted() {
+                    victim.cancel();
+                    if let Some(permit) = self
+                        .wait_for_slot(class, request_id.clone(), Duration::from_millis(50))
+                        .await
+                    {
+                        return AdmitOutcome::Admitted(permit);
+                    }
+                    // Slot not free in time — fall through to enqueue.
+                }
+            }
+        }
+
         // Slow path: enqueue and wait. The waiter holds a child cancel
         // token of the caller's `cancel` so the queue's
         // `drop_cancelled_head` GC sees the cancellation regardless of
@@ -218,6 +245,61 @@ impl PriorityScheduler {
         self.inflight_registry.write().remove(handle.request_id());
         self.slot_pool.release(handle.class());
         self.release_notify.notify_one();
+    }
+
+    /// Test-only in-flight count for a class. Lets sibling-module tests
+    /// (e.g. `body.rs`) assert slot release without reaching the private
+    /// `slot_pool` field.
+    #[cfg(test)]
+    pub(crate) fn inflight_for_test(&self, class: Class) -> u16 {
+        self.slot_pool.inflight(class)
+    }
+
+    /// Find the best preemption victim for an admission of `waiter_class`,
+    /// or `None` if there is no eligible victim.
+    ///
+    /// Eligible = a strictly-lower-class inflight request that is still
+    /// pre-TTFT (`is_preemptible`). Among those, prefer the **lowest
+    /// class** (cheapest to cancel) and, within that class, the
+    /// **most-recently-admitted** request (least upstream work wasted).
+    /// `Reverse(class)` makes the lowest class sort highest under
+    /// `max_by_key`; `admitted_at` then breaks ties toward the newest.
+    ///
+    /// Read-locks the registry only; never mutates. Callers gate this on
+    /// `class_config[class].can_preempt`, so it runs only on the
+    /// contention path for a preempt-capable class — never the hot path.
+    fn find_preemption_victim(&self, waiter_class: Class) -> Option<Arc<InflightHandle>> {
+        self.inflight_registry
+            .read()
+            .values()
+            .filter(|h| h.class() < waiter_class && h.is_preemptible())
+            .max_by_key(|h| (Reverse(h.class()), h.admitted_at()))
+            .cloned()
+    }
+
+    /// Poll the slot pool for up to `budget` for a slot to free under
+    /// `class`, returning a permit if one is acquired. Used only after
+    /// firing a preemption cancel, to grab the victim's slot as its body
+    /// winds down. Polls (rather than sharing `release_notify` with the
+    /// dispatcher, which would let the dispatcher steal the single
+    /// `notify_one` wakeup); this is the contention path, not the hot
+    /// path, and the poll is bounded.
+    async fn wait_for_slot(
+        self: &Arc<Self>,
+        class: Class,
+        request_id: RequestId,
+        budget: Duration,
+    ) -> Option<SchedulerPermit> {
+        let deadline = Instant::now() + budget;
+        loop {
+            if let Some(permit) = self.acquire_inflight(class, request_id.clone()) {
+                return Some(permit);
+            }
+            if Instant::now() >= deadline {
+                return None;
+            }
+            tokio::time::sleep(Duration::from_millis(2)).await;
+        }
     }
 
     /// Try to admit one queued waiter. Returns `true` if a waiter was
@@ -338,7 +420,7 @@ impl PriorityScheduler {
             .iter()
             .map(|c| self.class_config[*c as usize].starvation_threshold)
             .min()
-            .unwrap_or(std::time::Duration::from_secs(60));
+            .unwrap_or(Duration::from_secs(60));
         #[expect(
             clippy::disallowed_methods,
             reason = "dispatcher loop holds only a Weak<Self> and exits when the scheduler is dropped (Drop fires release_notify)"
@@ -452,6 +534,24 @@ impl SchedulerPermit {
     /// preemption coordination in follow-on commits).
     pub fn handle(&self) -> &Arc<InflightHandle> {
         &self.handle
+    }
+
+    /// Mark the first response byte. Called by [`super::body::SchedulerGuardBody`]
+    /// on the first data frame. Returns `false` if the scheduler already
+    /// won the preemption CAS — the body wrapper treats that as
+    /// "preempted, end the stream." The TTFT value is `admitted_at`
+    /// elapsed in millis, clamped by the handle to `[1, u64::MAX - 1]`.
+    pub fn try_mark_first_byte(&self) -> bool {
+        let now_ms = self.handle.admitted_at().elapsed().as_millis() as u64;
+        self.handle.try_mark_first_byte(now_ms)
+    }
+
+    /// Clone of the scheduler-owned cancel token for this request. The
+    /// admission middleware inserts this into request extensions so the
+    /// handler can `select!` against it; the scheduler fires it on
+    /// preemption.
+    pub fn cancel_token(&self) -> CancellationToken {
+        self.handle.cancel_token()
     }
 }
 
@@ -1081,5 +1181,169 @@ mod tests {
         drop(permit);
         // All strong refs gone now.
         assert!(weak.upgrade().is_none());
+    }
+
+    // ── M3: preemption ────────────────────────────────────────────────
+
+    /// All classes reserved=0 (so acquire is purely capacity-bound),
+    /// short queue timeout (so declined-preempt enqueues resolve fast),
+    /// can_preempt left at defaults (System/Interactive true, others false).
+    fn preempt_settings() -> SchedulerSettings {
+        use std::collections::HashMap as StdMap;
+        let mut classes = StdMap::new();
+        for c in Class::ALL {
+            let mut cfg = ClassConfig::default_for(c);
+            cfg.reserved = 0;
+            cfg.queue_size = 8;
+            cfg.queue_timeout_secs = 1;
+            classes.insert(c, cfg);
+        }
+        let yaml = PrioritySchedulerYaml {
+            classes,
+            tenant_policies: StdMap::new(),
+        };
+        SchedulerSettings::from_cli_and_yaml(true, Class::Default, 32, Some(&yaml)).unwrap()
+    }
+
+    #[test]
+    fn test_find_victim_empty_registry_returns_none() {
+        let sched = PriorityScheduler::new(&preempt_settings(), 8).unwrap();
+        assert!(sched.find_preemption_victim(Class::Interactive).is_none());
+    }
+
+    #[test]
+    fn test_find_victim_returns_lower_class_pre_ttft() {
+        let sched = PriorityScheduler::new(&preempt_settings(), 8).unwrap();
+        let _bulk = sched.acquire_inflight(Class::Bulk, rid("b")).unwrap();
+        let v = sched
+            .find_preemption_victim(Class::Interactive)
+            .expect("victim");
+        assert_eq!(v.class(), Class::Bulk);
+    }
+
+    #[test]
+    fn test_find_victim_prefers_lowest_class() {
+        let sched = PriorityScheduler::new(&preempt_settings(), 8).unwrap();
+        let _def = sched.acquire_inflight(Class::Default, rid("d")).unwrap();
+        let _bulk = sched.acquire_inflight(Class::Bulk, rid("b")).unwrap();
+        // Candidate Interactive: Default and Bulk both qualify; Bulk (lowest) wins.
+        let v = sched
+            .find_preemption_victim(Class::Interactive)
+            .expect("victim");
+        assert_eq!(v.class(), Class::Bulk);
+    }
+
+    #[test]
+    fn test_find_victim_skips_post_ttft() {
+        let sched = PriorityScheduler::new(&preempt_settings(), 8).unwrap();
+        let _def = sched.acquire_inflight(Class::Default, rid("d")).unwrap();
+        let bulk = sched.acquire_inflight(Class::Bulk, rid("b")).unwrap();
+        bulk.handle().try_mark_first_byte(5); // Bulk no longer preemptible
+        let v = sched
+            .find_preemption_victim(Class::Interactive)
+            .expect("victim");
+        assert_eq!(
+            v.class(),
+            Class::Default,
+            "Bulk past TTFT is skipped; Default chosen"
+        );
+    }
+
+    #[test]
+    fn test_find_victim_none_for_lowest_class() {
+        let sched = PriorityScheduler::new(&preempt_settings(), 8).unwrap();
+        let _def = sched.acquire_inflight(Class::Default, rid("d")).unwrap();
+        // Bulk is the lowest class — nothing is strictly lower to preempt.
+        assert!(sched.find_preemption_victim(Class::Bulk).is_none());
+    }
+
+    #[test]
+    fn test_permit_try_mark_first_byte_locks_out_preempt() {
+        let sched = PriorityScheduler::new(&preempt_settings(), 8).unwrap();
+        let permit = sched.acquire_inflight(Class::Default, rid("x")).unwrap();
+        assert!(permit.try_mark_first_byte());
+        assert!(
+            !permit.handle().try_mark_preempted(),
+            "preempt must lose after TTFT is marked"
+        );
+    }
+
+    #[test]
+    fn test_permit_cancel_token_reflects_handle_cancel() {
+        let sched = PriorityScheduler::new(&preempt_settings(), 8).unwrap();
+        let permit = sched.acquire_inflight(Class::Bulk, rid("x")).unwrap();
+        let tok = permit.cancel_token();
+        assert!(!tok.is_cancelled());
+        assert!(permit.handle().try_mark_preempted());
+        permit.handle().cancel();
+        assert!(tok.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn test_preempt_admits_by_cancelling_lower_class() {
+        // Capacity 1, full with a pre-TTFT Bulk request. An Interactive
+        // admission (can_preempt) cancels it; a watcher drops the victim's
+        // permit on cancel (mimicking the handler unwinding), freeing the
+        // slot for the Interactive waiter.
+        let sched = PriorityScheduler::new(&preempt_settings(), 1).unwrap();
+        let victim = sched.acquire_inflight(Class::Bulk, rid("victim")).unwrap();
+        let victim_cancel = victim.cancel_token();
+
+        let sched_admit = Arc::clone(&sched);
+        let admit_fut = async move {
+            sched_admit
+                .admit(Class::Interactive, rid("vip"), CancellationToken::new())
+                .await
+        };
+        let dropper = async move {
+            victim_cancel.cancelled().await;
+            drop(victim); // handler unwinds → slot frees
+        };
+        let (outcome, ()) = tokio::join!(admit_fut, dropper);
+        assert!(matches!(outcome, AdmitOutcome::Admitted(_)));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_preempt_declined_when_only_victim_past_ttft() {
+        // The single lower-class inflight has already emitted its first
+        // byte, so it is not a valid victim. The Interactive admission must
+        // NOT cancel it; it falls through to enqueue and times out.
+        let sched = PriorityScheduler::new(&preempt_settings(), 1).unwrap();
+        let victim = sched.acquire_inflight(Class::Bulk, rid("victim")).unwrap();
+        victim.handle().try_mark_first_byte(5);
+        let victim_cancel = victim.cancel_token();
+
+        let outcome = sched
+            .admit(Class::Interactive, rid("vip"), CancellationToken::new())
+            .await;
+        assert!(matches!(
+            outcome,
+            AdmitOutcome::Rejected(RejectionReason::QueueTimeout)
+        ));
+        assert!(
+            !victim_cancel.is_cancelled(),
+            "a post-TTFT request must never be cancelled"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_non_preempting_class_does_not_cancel() {
+        // Default has can_preempt=false; even with a Bulk victim available
+        // it must not attempt preemption.
+        let sched = PriorityScheduler::new(&preempt_settings(), 1).unwrap();
+        let victim = sched.acquire_inflight(Class::Bulk, rid("victim")).unwrap();
+        let victim_cancel = victim.cancel_token();
+
+        let outcome = sched
+            .admit(Class::Default, rid("plain"), CancellationToken::new())
+            .await;
+        assert!(matches!(
+            outcome,
+            AdmitOutcome::Rejected(RejectionReason::QueueTimeout)
+        ));
+        assert!(
+            !victim_cancel.is_cancelled(),
+            "can_preempt=false class must not cancel anyone"
+        );
     }
 }

--- a/model_gateway/src/middleware/scheduler/inflight.rs
+++ b/model_gateway/src/middleware/scheduler/inflight.rs
@@ -1,8 +1,12 @@
 //! In-flight request bookkeeping for the priority scheduler.
 
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::{
+    sync::atomic::{AtomicU64, Ordering},
+    time::Instant,
+};
 
 use smg_auth::RequestId;
+use tokio_util::sync::CancellationToken;
 
 use super::Class;
 
@@ -29,7 +33,18 @@ use super::Class;
 pub struct InflightHandle {
     class: Class,
     request_id: RequestId,
+    /// When this request was admitted. Used as the preemption victim
+    /// tiebreaker (prefer the most-recently-admitted within a class, to
+    /// waste the least upstream work) and as the epoch for TTFT.
+    admitted_at: Instant,
     first_byte_at: AtomicU64,
+    /// Scheduler-owned cancellation token, fired by `try_mark_preempted`'s
+    /// caller when this request is chosen as a preemption victim. Handed
+    /// to the handler via [`super::SchedulerPermit::cancel_token`] (which
+    /// the admission middleware inserts into request extensions) so the
+    /// handler can `select!` against it and unwind. Distinct from the
+    /// client-disconnect token `admit` waits on during queueing.
+    cancel: CancellationToken,
 }
 
 impl InflightHandle {
@@ -45,7 +60,9 @@ impl InflightHandle {
         Self {
             class,
             request_id,
+            admitted_at: Instant::now(),
             first_byte_at: AtomicU64::new(0),
+            cancel: CancellationToken::new(),
         }
     }
 
@@ -57,6 +74,30 @@ impl InflightHandle {
     /// Request id this handle tracks (registry key).
     pub fn request_id(&self) -> &RequestId {
         &self.request_id
+    }
+
+    /// When this request was admitted (preemption tiebreaker + TTFT epoch).
+    pub fn admitted_at(&self) -> Instant {
+        self.admitted_at
+    }
+
+    /// Clone of the scheduler-owned cancel token for this request.
+    pub fn cancel_token(&self) -> CancellationToken {
+        self.cancel.clone()
+    }
+
+    /// Fire the scheduler-owned cancel token. Called only after a
+    /// successful [`try_mark_preempted`], so a handler is never asked to
+    /// unwind a request that has already started streaming output.
+    pub fn cancel(&self) {
+        self.cancel.cancel();
+    }
+
+    /// Whether this request is still a valid preemption victim: it has
+    /// neither emitted its first byte nor already been preempted (both
+    /// move `first_byte_at` off `0`). A single `Acquire` load.
+    pub fn is_preemptible(&self) -> bool {
+        self.first_byte_at.load(Ordering::Acquire) == 0
     }
 
     /// Attempt to mark this request as preempted. Returns `true` on the

--- a/model_gateway/src/middleware/scheduler/mod.rs
+++ b/model_gateway/src/middleware/scheduler/mod.rs
@@ -1,5 +1,6 @@
 //! Priority-aware admission scheduler.
 
+pub mod body;
 pub mod class;
 pub mod config;
 pub mod engine;
@@ -8,10 +9,13 @@ pub mod policy;
 pub mod queue;
 pub mod slots;
 
+pub use body::SchedulerGuardBody;
 pub use class::{Class, PRIORITY_HEADER};
 pub use config::{
     ClassConfig, ClassRuntimeConfig, PrioritySchedulerYaml, SchedulerSettings,
     SettingsValidationError, TenantPolicyConfig,
 };
-pub use engine::{PriorityScheduler, SchedulerInitError, SchedulerPermit};
+pub use engine::{
+    AdmitOutcome, PriorityScheduler, RejectionReason, SchedulerInitError, SchedulerPermit,
+};
 pub use policy::{StaticTenantPolicyResolver, TenantPolicy, TenantPolicyResolver};


### PR DESCRIPTION
## Description

**Milestone M3** of the priority scheduler (design §6 preemption, §7 body wrapper). First of a stacked sequence M3 → M4 → M4.5 → M5 → M6; merge in order.

Still entirely behind `--priority-scheduler-enabled` (default off) with no production consumer — `main` behavior is unchanged. This PR makes the scheduler *able* to preempt; the middleware that invokes it and the handler cancel-plumbing land in M4 / M4.5.

## Changes

- **`InflightHandle`** gains `admitted_at` (preemption tiebreaker + TTFT epoch) and a scheduler-owned `cancel` token (fired on preemption, handed to the handler via the permit). `is_preemptible()` = pre-TTFT and not already preempted (one `Acquire` load).
- **`find_preemption_victim`** — read-locks the registry, filters strictly-lower class still pre-TTFT, picks **lowest class** (cheapest to cancel) then **most-recently-admitted** (least wasted work) via `max_by_key(Reverse(class), admitted_at)`. Runs only on the contention path for a `can_preempt` class.
- **`admit()` preempt path** — on a fast-path miss for a `can_preempt` class: CAS the victim's pre-TTFT lock, fire its cancel only on a win, `wait_for_slot` up to 50ms for the body to wind down. At most one preemption per admission; on timeout, fall through to enqueue (cancel already fired → slot frees shortly). `wait_for_slot` polls rather than sharing `release_notify` with the dispatcher (which would let the dispatcher steal the lone `notify_one`).
- **`SchedulerPermit::{try_mark_first_byte, cancel_token}`** — TTFT mark is the symmetric CAS to `try_mark_preempted`; `cancel_token` clones the handle's token for the middleware to thread into request extensions.
- **`SchedulerGuardBody`** (`body.rs`) — `http_body` wrapper marking TTFT on the first data frame; if it loses the TTFT race to a concurrent preemption CAS it ends the stream cleanly (`Poll::Ready(None)`). Slot released when the permit field drops with the body. Mirrors the existing `TokenGuardBody` `Unpin`/`poll_frame` pattern.

## Test Plan

24 new unit tests (97 scheduler tests total, green):

- **Victim selection**: empty registry → None; lower-class pre-TTFT chosen; lowest class wins the tiebreak; post-TTFT victim skipped; no victim for the lowest class.
- **Permit**: `try_mark_first_byte` locks out a later preempt; `cancel_token` reflects the handle's cancellation.
- **Preempt admit**: success (cancel → victim drop → reacquire); declined when the only victim is past TTFT (and the victim is *not* cancelled); `can_preempt=false` class never cancels.
- **Body wrapper**: TTFT marked on first data frame; preempted-before-byte ends the stream; trailer-only response never marks TTFT; drop releases the slot.

```
$ cargo test --package smg --lib middleware::scheduler
... 97 passed; 0 failed
$ cargo clippy --package smg --all-targets --all-features -- -D warnings
... clean
```

<details><summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes (pre-commit hook)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] Stacked: merge after this, M4 (wiring) targets `main` once this lands
</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Priority-based preemption fast-path to admit higher-priority requests sooner.
  * Request lifecycle enhancements: admission timestamps, cancellation tokens, and first-byte (TTFT) marking that ties a response body to its scheduler permit; if preempted before the first byte, the response stream is force-terminated and the slot is released on completion/drop.

* **Tests**
  * Added unit tests covering preemption selection, TTFT/first-byte interactions, forced stream termination, empty/trailer-only responses, and slot release behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->