### PR TITLE
fix(workflow): don't persist context from skipped steps

### DIFF
--- a/crates/workflow/src/engine.rs
+++ b/crates/workflow/src/engine.rs
@@ -956,11 +956,23 @@ impl<D: WorkflowData, S: StateStore<D> + 'static> WorkflowEngine<D, S> {
 
             let step_duration = step_start.elapsed();
 
-            self.state_store
-                .update(instance_id, |s| {
-                    s.context = context.clone();
-                })
-                .await?;
+            // Persist the step's context mutations — but NOT when the step opted
+            // out via `StepResult::Skip`. Sibling steps that become ready at the
+            // same time run in parallel, and each takes its own `get_context`
+            // snapshot above; the write-back below replaces the *entire* shared
+            // context (last-writer-wins). A skipped step did no work, so its
+            // snapshot is stale relative to a concurrent sibling's write, and
+            // persisting it silently clobbers that sibling's mutations. This was
+            // the worker-registration race: one branch's no-op `Skip` steps wiped
+            // the other branch's `actual_workers`, surfacing downstream as
+            // `register_workers: Context value not found: workers`.
+            if !matches!(result, Ok(Ok(StepResult::Skip))) {
+                self.state_store
+                    .update(instance_id, |s| {
+                        s.context = context.clone();
+                    })
+                    .await?;
+            }
 
             match result {
                 Ok(Ok(StepResult::Success)) => {
@@ -1252,5 +1264,130 @@ impl<D: WorkflowData, S: StateStore<D> + 'static> std::fmt::Debug for WorkflowEn
         f.debug_struct("WorkflowEngine")
             .field("definitions_count", &self.definitions.read().len())
             .finish()
+    }
+}
+
+#[cfg(test)]
+mod skip_clobber_tests {
+    use std::{sync::Arc, time::Duration};
+
+    use async_trait::async_trait;
+    use serde::{Deserialize, Serialize};
+    use tokio::sync::Notify;
+
+    use crate::{
+        StepDefinition, StepExecutor, StepResult, WorkflowContext, WorkflowData,
+        WorkflowDefinition, WorkflowEngine, WorkflowResult, WorkflowStatus,
+    };
+
+    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    struct Data {
+        value: String,
+    }
+
+    impl WorkflowData for Data {
+        fn workflow_type() -> &'static str {
+            "skip_clobber_test"
+        }
+    }
+
+    /// Writes `value = "written"`, but only after the skipper has taken its
+    /// snapshot — so the write is guaranteed to land after that snapshot.
+    struct Writer {
+        skipper_started: Arc<Notify>,
+        writer_done: Arc<Notify>,
+    }
+
+    #[async_trait]
+    impl StepExecutor<Data> for Writer {
+        async fn execute(&self, ctx: &mut WorkflowContext<Data>) -> WorkflowResult<StepResult> {
+            self.skipper_started.notified().await;
+            ctx.data.value = "written".to_string();
+            self.writer_done.notify_one();
+            Ok(StepResult::Success)
+        }
+    }
+
+    /// Returns `Skip` without mutating, but only after the writer has written and
+    /// its write-back has landed. A buggy unconditional write-back of this step's
+    /// stale snapshot would then clobber the writer's value.
+    struct SlowSkipper {
+        skipper_started: Arc<Notify>,
+        writer_done: Arc<Notify>,
+    }
+
+    #[async_trait]
+    impl StepExecutor<Data> for SlowSkipper {
+        async fn execute(&self, _ctx: &mut WorkflowContext<Data>) -> WorkflowResult<StepResult> {
+            // Reaching here implies the engine already snapshotted our context.
+            self.skipper_started.notify_one();
+            self.writer_done.notified().await;
+            // Cushion so the writer's async write-back is fully applied first.
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            Ok(StepResult::Skip)
+        }
+    }
+
+    /// A `Skip` step must not persist its (stale) context snapshot, otherwise it
+    /// clobbers a concurrently-running sibling step's writes. Regression test for
+    /// the worker-registration race (`register_workers: Context value not found:
+    /// workers`).
+    #[tokio::test]
+    async fn skipped_step_does_not_clobber_sibling_context() {
+        let skipper_started = Arc::new(Notify::new());
+        let writer_done = Arc::new(Notify::new());
+
+        // Both steps have no dependencies, so the engine launches them in
+        // parallel — reproducing the sibling-branch race.
+        let def = WorkflowDefinition::<Data>::new("clobber", "Clobber Repro")
+            .add_step(StepDefinition::new(
+                "writer",
+                "Writer",
+                Arc::new(Writer {
+                    skipper_started: skipper_started.clone(),
+                    writer_done: writer_done.clone(),
+                }),
+            ))
+            .add_step(StepDefinition::new(
+                "skipper",
+                "Skipper",
+                Arc::new(SlowSkipper {
+                    skipper_started: skipper_started.clone(),
+                    writer_done: writer_done.clone(),
+                }),
+            ));
+
+        let engine = WorkflowEngine::<Data>::new();
+        let def_id = def.id.clone();
+        engine.register_workflow(def).expect("register workflow");
+
+        let instance = engine
+            .start_workflow(def_id, Data::default())
+            .await
+            .expect("start workflow");
+
+        // Poll for terminal status (wait_for_completion cleans up the state we
+        // need to inspect).
+        let mut state = engine.get_status(instance).await.expect("status");
+        for _ in 0..200 {
+            if matches!(
+                state.status,
+                WorkflowStatus::Completed | WorkflowStatus::Failed
+            ) {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            state = engine.get_status(instance).await.expect("status");
+        }
+
+        assert_eq!(
+            state.status,
+            WorkflowStatus::Completed,
+            "workflow should complete"
+        );
+        assert_eq!(
+            state.context.data.value, "written",
+            "skipped sibling clobbered the writer's context mutation"
+        );
     }
 }


### PR DESCRIPTION
## Description

### Problem

Cloud-gateway startup intermittently fails because the worker is never registered. The `AddWorker` workflow dies at `register_workers` with:

```
WARN  register_workers error="Context value not found: workers" will_retry=false
ERROR Workflow failed ... failed_step=register_workers
WARN  Failed job: type=AddWorker, worker=https://api.openai.com,
      error=Workflow failed at step register_workers: Context value not found: workers
```

`/workers` then stays at `total=0` and the gateway times out. This surfaces as a flaky e2e failure (`TestImageGenerationRegularMcpServer::test_response_is_mcp_call_shape`) that **reproduces on `main`** (e.g. [run 26653116197](https://github.com/lightseekorg/smg/actions/runs/26653116197/job/78556408450), a CPU runner with **no** GPU workers) — so it is independent of GPUs/runners and is masked, not caused, by retries.

**Root cause — last-writer-wins clobber on shared workflow context.** In `execute_step_with_retry`, each step does snapshot → execute → write-back, and the write-back replaced the **entire** shared context (`s.context = context.clone()`), **unconditionally** — even when the step returned `StepResult::Skip`:

```rust
let mut context = self.state_store.get_context(instance_id).await?; // full snapshot
let result = timeout(step_timeout, step.executor.execute(&mut context)).await;
self.state_store.update(instance_id, |s| { s.context = context.clone(); }).await?; // whole-context overwrite
```

The worker-registration DAG fans out from `classify_worker_type` into a **local** branch and an **external** branch that run in parallel and reconverge at `register_workers`. For a cloud (external) worker, every local-branch step is a guard that returns `Skip` immediately (`detect_connection_mode`, `detect_backend`, `discover_metadata`, `discover_dp_info`, `create_local_worker`). But because the engine persisted their **stale** snapshots regardless, a local `Skip` step whose snapshot predated `create_external_workers`' write — and whose write-back landed after it — wiped `actual_workers` from the context. `register_workers` then found nothing.

This contradicts the documented design intent in `data.rs`: *"branch-specific steps check `worker_kind` and return `StepResult::Skip`"* to opt out — which only works if a skipped step's context isn't persisted.

### Solution

Skip the context write-back when a step returns `StepResult::Skip`. A skipped step did no work, so there is nothing to persist, and its stale snapshot must not overwrite a concurrently-running sibling's mutations. `Success`/`Failure` behavior is unchanged.

This is a minimal, general engine fix (one conditional) that makes the existing "return `Skip` to opt out" pattern behave as designed, for all workflows — no changes to the worker-registration definition or the step guards.

## Changes

- `crates/workflow/src/engine.rs` — `execute_step_with_retry` only persists the step's context when the result is not `Skip`.
- `crates/workflow/src/engine.rs` — new `skip_clobber_tests` module: a deterministic regression test where a `Skip` sibling, scheduled (via notifies) to write back after a `Success` writer, must not clobber the writer's context mutation. Fails before the fix (`left: ""`), passes after.

## Test Plan

Before/after, in `crates/workflow`:

```
# regression test fails on the pre-fix engine (unconditional write-back):
#   assertion `left == right` failed: skipped sibling clobbered the writer's context mutation
#     left: ""   right: "written"
cargo test -p wfaas skip_clobber          # passes with the fix
cargo test -p wfaas                        # 21 existing tests + new test, all green
cargo +nightly fmt -p wfaas -- --check     # clean
cargo clippy -p wfaas --all-targets -- -D warnings  # clean (only a pre-existing clippy.toml config note)
```

- [x] Regression test reproduces the bug without the fix and passes with it (verified by temporarily reverting the one-line guard).
- [x] Full `wfaas` suite + doctests pass.
- [x] `cargo +nightly fmt` / `clippy` clean on `wfaas`.
- [ ] `model_gateway` build / full `pre-commit` not run locally (sandbox could not fetch some deps / disk-constrained). Engine public API is unchanged, so the consumer compiles unchanged — relying on CI to confirm. The real end-to-end signal is `e2e_test/responses` no longer flaking on `register_workers: Context value not found: workers`.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes *(verified on the changed crate; full-workspace run deferred to CI — see Test Plan)*
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a critical data loss issue in parallel workflow execution. Previously, when multiple independent steps ran concurrently, skipped steps would incorrectly overwrite context data modifications made by their sibling steps. Workflow data is now correctly preserved, ensuring all step modifications persist properly even when some steps are skipped during parallel execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightseekorg/smg/pull/1573?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->