### PR TITLE
perf(gateway): Make `/workers` 5x faster

### DIFF
--- a/bindings/golang/src/policy.rs
+++ b/bindings/golang/src/policy.rs
@@ -70,7 +70,7 @@ impl GrpcWorker {
         spec.runtime_type = RuntimeType::Sglang;
 
         let metadata = WorkerMetadata {
-            spec,
+            spec: Arc::new(spec),
             health_config: HealthCheckConfig::default(),
             health_endpoint: "/health".to_string(),
         };

--- a/crates/protocols/Cargo.toml
+++ b/crates/protocols/Cargo.toml
@@ -23,7 +23,7 @@ bitflags.workspace = true
 bytes = "1.8.0"
 chrono.workspace = true
 rand.workspace = true
-serde = { workspace = true, features = ["derive"] }
+serde = { workspace = true, features = ["derive", "rc"] }
 serde_json = { workspace = true, features = ["preserve_order"] }
 serde_with.workspace = true
 tokio.workspace = true

--- a/crates/protocols/src/worker.rs
+++ b/crates/protocols/src/worker.rs
@@ -5,6 +5,7 @@
 //! request/response boundaries and internal runtime state.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 #[cfg(feature = "axum")]
 use axum::{
@@ -702,8 +703,11 @@ pub struct WorkerInfo {
     pub model_id: Option<String>,
 
     /// Worker identity and configuration.
+    ///
+    /// Stored behind an `Arc` so building a `WorkerInfo` for a response (e.g.
+    /// `GET /workers`) shares the spec instead of deep-cloning it per worker.
     #[serde(flatten)]
-    pub spec: WorkerSpec,
+    pub spec: Arc<WorkerSpec>,
 
     /// Whether the worker is healthy.
     pub is_healthy: bool,
@@ -726,7 +730,7 @@ impl WorkerInfo {
         Self {
             id: worker_id.to_string(),
             model_id: None,
-            spec: WorkerSpec::new(url),
+            spec: Arc::new(WorkerSpec::new(url)),
             is_healthy: false,
             status: Some(WorkerStatus::Pending),
             load: 0,

--- a/crates/protocols/src/worker.rs
+++ b/crates/protocols/src/worker.rs
@@ -4,8 +4,7 @@
 //! enums, and core configuration. These types are shared across API
 //! request/response boundaries and internal runtime state.
 
-use std::collections::HashMap;
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 #[cfg(feature = "axum")]
 use axum::{

--- a/model_gateway/Cargo.toml
+++ b/model_gateway/Cargo.toml
@@ -200,5 +200,10 @@ name = "sync_alloc_bench"
 harness = false
 path = "benches/sync_alloc_bench.rs"
 
+[[bench]]
+name = "workers_endpoint"
+harness = false
+path = "benches/workers_endpoint.rs"
+
 [lints]
 workspace = true

--- a/model_gateway/benches/workers_endpoint.rs
+++ b/model_gateway/benches/workers_endpoint.rs
@@ -43,10 +43,16 @@ fn make_labels() -> HashMap<String, String> {
         ("runtime_version", "0.0.0"),
         ("arch_family", "example_arch"),
         ("served_model_name", "example-org/example-model-v1"),
-        ("model_path", "storage://example-bucket/models/example-model-v1"),
+        (
+            "model_path",
+            "storage://example-bucket/models/example-model-v1",
+        ),
         ("deploy_zone", "zone-a"),
     ];
-    pairs.iter().map(|(k, v)| (k.to_string(), v.to_string())).collect()
+    pairs
+        .iter()
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect()
 }
 
 fn make_model() -> ModelCard {
@@ -65,12 +71,13 @@ fn make_worker(i: usize) -> Arc<dyn Worker> {
         1 => WorkerType::Decode,
         _ => WorkerType::Regular,
     };
-    let worker = BasicWorkerBuilder::new(format!("http://worker-{i}.example.svc.cluster.local:30000"))
-        .worker_type(worker_type)
-        .status(WorkerStatus::Ready)
-        .labels(make_labels())
-        .model(make_model())
-        .build();
+    let worker =
+        BasicWorkerBuilder::new(format!("http://worker-{i}.example.svc.cluster.local:30000"))
+            .worker_type(worker_type)
+            .status(WorkerStatus::Ready)
+            .labels(make_labels())
+            .model(make_model())
+            .build();
     Arc::new(worker)
 }
 
@@ -99,7 +106,11 @@ struct Stats {
     decode_count: usize,
     regular_count: usize,
 }
-const STATS: Stats = Stats { prefill_count: 0, decode_count: 0, regular_count: 0 };
+const STATS: Stats = Stats {
+    prefill_count: 0,
+    decode_count: 0,
+    regular_count: 0,
+};
 
 #[derive(Serialize)]
 struct Body<'a> {
@@ -118,7 +129,12 @@ fn serialize_value(infos: &[WorkerInfo]) -> Vec<u8> {
 }
 
 fn serialize_direct(infos: &[WorkerInfo]) -> Vec<u8> {
-    serde_json::to_vec(&Body { workers: infos, total: infos.len(), stats: STATS }).unwrap_or_default()
+    serde_json::to_vec(&Body {
+        workers: infos,
+        total: infos.len(),
+        stats: STATS,
+    })
+    .unwrap_or_default()
 }
 
 // Stage 1: deep clone + serde_json::Value.

--- a/model_gateway/benches/workers_endpoint.rs
+++ b/model_gateway/benches/workers_endpoint.rs
@@ -1,0 +1,171 @@
+//! Microbenchmark for the `GET /workers` response path.
+//!
+//! Measures the full per-request cost (build + serialize) across three points,
+//! all using the real `WorkerInfo` type (no parallel/duplicate response shape):
+//!
+//!   1. `original_value_plus_deepclone` — deep-clone each `WorkerSpec` into a
+//!      `WorkerInfo`, then build an intermediate `serde_json::Value` (`json!`)
+//!      and serialize that. A per-worker hash map plus a double pass.
+//!   2. `serde_direct_plus_deepclone` — still deep-clones the spec, but
+//!      serializes a typed struct directly (single `serde_json::to_vec`).
+//!   3. `serde_direct_plus_arc` — `WorkerSpec` is shared via `Arc`, so building
+//!      each `WorkerInfo` (`worker_to_info`) is a refcount bump, then serialize
+//!      directly. This is the shipped path.
+//!
+//! Worker data is entirely synthetic/generic (no proprietary specs).
+//! Run: `cargo bench -p smg --bench workers_endpoint`
+
+use std::{collections::HashMap, hint::black_box, sync::Arc};
+
+use criterion::{criterion_group, criterion_main, Criterion, Throughput};
+use openai_protocol::{
+    model_card::ModelCard,
+    model_type::ModelType,
+    worker::{WorkerInfo, WorkerStatus},
+};
+use serde::Serialize;
+use smg::worker::{worker::worker_to_info, BasicWorkerBuilder, Worker, WorkerType};
+
+/// ~16 generic labels approximating a realistic worker's label payload size.
+fn make_labels() -> HashMap<String, String> {
+    let pairs = [
+        ("tensor_parallel", "4"),
+        ("pipeline_parallel", "1"),
+        ("data_parallel", "1"),
+        ("max_seq_len", "262144"),
+        ("max_running_requests", "512"),
+        ("is_generation", "true"),
+        ("is_embedding", "false"),
+        ("has_image_understanding", "true"),
+        ("has_audio_understanding", "false"),
+        ("load_balance_method", "round_robin"),
+        ("weight_version", "default"),
+        ("runtime_version", "0.0.0"),
+        ("arch_family", "example_arch"),
+        ("served_model_name", "example-org/example-model-v1"),
+        ("model_path", "storage://example-bucket/models/example-model-v1"),
+        ("deploy_zone", "zone-a"),
+    ];
+    pairs.iter().map(|(k, v)| (k.to_string(), v.to_string())).collect()
+}
+
+fn make_model() -> ModelCard {
+    let mut card = ModelCard::new("example-org/example-model-v1")
+        .with_model_type(ModelType::VISION_LLM)
+        .with_context_length(262_144)
+        .with_tokenizer_path("example-org/example-model-tokenizer");
+    card.hf_model_type = Some("example_arch".to_string());
+    card.architectures = vec!["ExampleForCausalLM".to_string()];
+    card
+}
+
+fn make_worker(i: usize) -> Arc<dyn Worker> {
+    let worker_type = match i % 3 {
+        0 => WorkerType::Prefill,
+        1 => WorkerType::Decode,
+        _ => WorkerType::Regular,
+    };
+    let worker = BasicWorkerBuilder::new(format!("http://worker-{i}.example.svc.cluster.local:30000"))
+        .worker_type(worker_type)
+        .status(WorkerStatus::Ready)
+        .labels(make_labels())
+        .model(make_model())
+        .build();
+    Arc::new(worker)
+}
+
+fn build_workers(n: usize) -> Vec<Arc<dyn Worker>> {
+    (0..n).map(make_worker).collect()
+}
+
+/// Replicates the OLD per-worker cost: deep-clone the whole `WorkerSpec`.
+fn deep_clone_info(w: &Arc<dyn Worker>) -> WorkerInfo {
+    let meta = w.metadata();
+    let status = w.status();
+    WorkerInfo {
+        id: w.url().to_string(),
+        model_id: meta.spec.models.primary().map(|m| m.id.clone()),
+        spec: Arc::new((*meta.spec).clone()), // deep clone, then wrap
+        is_healthy: status == WorkerStatus::Ready,
+        status: Some(status),
+        load: w.load(),
+        job_status: None,
+    }
+}
+
+#[derive(Serialize)]
+struct Stats {
+    prefill_count: usize,
+    decode_count: usize,
+    regular_count: usize,
+}
+const STATS: Stats = Stats { prefill_count: 0, decode_count: 0, regular_count: 0 };
+
+#[derive(Serialize)]
+struct Body<'a> {
+    workers: &'a [WorkerInfo],
+    total: usize,
+    stats: Stats,
+}
+
+fn serialize_value(infos: &[WorkerInfo]) -> Vec<u8> {
+    let value = serde_json::json!({
+        "workers": infos,
+        "total": infos.len(),
+        "stats": { "prefill_count": 0, "decode_count": 0, "regular_count": 0 }
+    });
+    serde_json::to_vec(&value).unwrap_or_default()
+}
+
+fn serialize_direct(infos: &[WorkerInfo]) -> Vec<u8> {
+    serde_json::to_vec(&Body { workers: infos, total: infos.len(), stats: STATS }).unwrap_or_default()
+}
+
+// Stage 1: deep clone + serde_json::Value.
+fn stage_original(workers: &[Arc<dyn Worker>]) -> Vec<u8> {
+    let infos: Vec<WorkerInfo> = workers.iter().map(deep_clone_info).collect();
+    serialize_value(&infos)
+}
+
+// Stage 2: deep clone + direct serialize.
+fn stage_direct_deepclone(workers: &[Arc<dyn Worker>]) -> Vec<u8> {
+    let infos: Vec<WorkerInfo> = workers.iter().map(deep_clone_info).collect();
+    serialize_direct(&infos)
+}
+
+// Stage 3: Arc-shared spec (worker_to_info) + direct serialize. (Shipped.)
+fn stage_arc_direct(workers: &[Arc<dyn Worker>]) -> Vec<u8> {
+    let infos: Vec<WorkerInfo> = workers.iter().map(worker_to_info).collect();
+    serialize_direct(&infos)
+}
+
+fn bench_workers(c: &mut Criterion) {
+    const N: usize = 2000;
+    let workers = build_workers(N);
+
+    // Sanity: all three implementations produce equivalent JSON.
+    let s1 = stage_original(&workers);
+    let s2 = stage_direct_deepclone(&workers);
+    let s3 = stage_arc_direct(&workers);
+    let v1: serde_json::Value = serde_json::from_slice(&s1).unwrap_or_default();
+    let v2: serde_json::Value = serde_json::from_slice(&s2).unwrap_or_default();
+    let v3: serde_json::Value = serde_json::from_slice(&s3).unwrap_or_default();
+    assert_eq!(v1, v2, "direct must match original");
+    assert_eq!(v1, v3, "arc must match original");
+
+    let mut group = c.benchmark_group("workers_endpoint");
+    group.throughput(Throughput::Bytes(s3.len() as u64));
+    group.bench_function("1_original_value_plus_deepclone", |b| {
+        b.iter(|| black_box(stage_original(black_box(&workers))));
+    });
+    group.bench_function("2_serde_direct_plus_deepclone", |b| {
+        b.iter(|| black_box(stage_direct_deepclone(black_box(&workers))));
+    });
+    group.bench_function("3_serde_direct_plus_arc", |b| {
+        b.iter(|| black_box(stage_arc_direct(black_box(&workers))));
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench_workers);
+criterion_main!(benches);

--- a/model_gateway/src/worker/builder.rs
+++ b/model_gateway/src/worker/builder.rs
@@ -241,7 +241,7 @@ impl BasicWorkerBuilder {
             .unwrap_or_else(|| self.spec.health.apply_to(&HealthCheckConfig::default()));
 
         let metadata = WorkerMetadata {
-            spec: self.spec,
+            spec: Arc::new(self.spec),
             health_config,
             health_endpoint: self.health_endpoint,
         };

--- a/model_gateway/src/worker/service.rs
+++ b/model_gateway/src/worker/service.rs
@@ -161,7 +161,7 @@ impl IntoResponse for UpdateWorkerResult {
     }
 }
 
-/// Result of listing workers
+/// Result of listing workers.
 #[derive(Debug)]
 pub struct ListWorkersResult {
     pub workers: Vec<WorkerInfo>,
@@ -173,16 +173,31 @@ pub struct ListWorkersResult {
 
 impl IntoResponse for ListWorkersResult {
     fn into_response(self) -> Response {
-        let response = json!({
-            "workers": self.workers,
-            "total": self.total,
-            "stats": {
-                "prefill_count": self.prefill_count,
-                "decode_count": self.decode_count,
-                "regular_count": self.regular_count,
-            }
-        });
-        Json(response).into_response()
+        // Serialize the typed response directly with `Json` (a single
+        // `serde_json::to_vec` pass) instead of building an intermediate
+        // `serde_json::Value` via `json!`.
+        #[derive(serde::Serialize)]
+        struct Body {
+            workers: Vec<WorkerInfo>,
+            total: usize,
+            stats: Stats,
+        }
+        #[derive(serde::Serialize)]
+        struct Stats {
+            prefill_count: usize,
+            decode_count: usize,
+            regular_count: usize,
+        }
+        Json(Body {
+            workers: self.workers,
+            total: self.total,
+            stats: Stats {
+                prefill_count: self.prefill_count,
+                decode_count: self.decode_count,
+                regular_count: self.regular_count,
+            },
+        })
+        .into_response()
     }
 }
 
@@ -322,7 +337,9 @@ impl WorkerService {
         Ok(UpdateWorkerResult { worker_id, url })
     }
 
-    /// List all workers with their info
+    /// List all workers with their info. Building each `WorkerInfo` is cheap:
+    /// `WorkerSpec` is shared via `Arc`, so there is no per-worker spec deep
+    /// clone on this path.
     pub fn list_workers(&self) -> ListWorkersResult {
         let workers = self.worker_registry.get_all_with_ids();
         let worker_infos: Vec<WorkerInfo> = workers

--- a/model_gateway/src/worker/worker.rs
+++ b/model_gateway/src/worker/worker.rs
@@ -428,7 +428,11 @@ impl WorkerTypeExt for WorkerType {
 #[derive(Debug, Clone)]
 pub struct WorkerMetadata {
     /// Protocol-level worker identity and configuration.
-    pub spec: WorkerSpec,
+    ///
+    /// Behind an `Arc` so it can be shared into response `WorkerInfo`s (e.g.
+    /// `GET /workers`) without a per-worker deep clone. Set once at construction
+    /// and not mutated afterwards.
+    pub spec: Arc<WorkerSpec>,
     /// Resolved health check config (router defaults + per-worker overrides).
     /// This is the concrete config used at runtime; `spec.health` only stores
     /// the partial overrides from the API layer.
@@ -1909,7 +1913,7 @@ mod tests {
     #[test]
     fn test_worker_metadata_empty_models_accepts_all() {
         let metadata = WorkerMetadata {
-            spec: WorkerSpec::new("http://test:8080"),
+            spec: Arc::new(WorkerSpec::new("http://test:8080")),
             health_config: HealthCheckConfig::default(),
             health_endpoint: "/health".to_string(),
         };
@@ -1932,7 +1936,7 @@ mod tests {
         let mut spec = WorkerSpec::new("http://test:8080");
         spec.models = WorkerModels::from(vec![model1, model2]);
         let metadata = WorkerMetadata {
-            spec,
+            spec: Arc::new(spec),
             health_config: HealthCheckConfig::default(),
             health_endpoint: "/health".to_string(),
         };


### PR DESCRIPTION

<img width="1021" height="502" alt="image" src="https://github.com/user-attachments/assets/f50a7a3b-47e8-4da5-bbaf-b6720feb69eb" />


The `/workers` endpoint would copy/clone the whole workers object into a `serde_json::Value`, and then re-serialize it one more time into a string. This removes the double-clone (2x speedup) and then also avoids cloning the expensive `WorkerSpec` object as well (total of 5x speedup).

We noticed this because `/workers` serialization specifically was a CPU bottleneck for large deployments with thousands of GPUs. That endpoint would end up blocking the tokio executor thread for a significant chunk of time.

Full report and benchmark: https://gistpreview.github.io/?0693dbbd3f9927f88dde38163611c808


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Worker metadata now uses a shared spec representation to reduce copies and improve serialization efficiency.

* **Chores**
  * Added a microbenchmark for the workers endpoint to measure serialization/build performance.
  * Enabled an additional serialization feature to support shared-data workflows.

* **Documentation**
  * Expanded comments documenting worker listing and spec-sharing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->