### PR TITLE
feat(scheduler): wire priority admission middleware + cancel propagation (PR 2 M4)

### DIFF
--- a/model_gateway/src/config/builder.rs
+++ b/model_gateway/src/config/builder.rs
@@ -225,6 +225,28 @@ impl RouterConfigBuilder {
         self
     }
 
+    // ==================== Priority Scheduler ====================
+
+    pub fn priority_scheduler_enabled(mut self, enabled: bool) -> Self {
+        self.config.priority_scheduler_enabled = enabled;
+        self
+    }
+
+    pub fn priority_scheduler_default_max_class(mut self, class: impl Into<String>) -> Self {
+        self.config.priority_scheduler_default_max_class = class.into();
+        self
+    }
+
+    pub fn priority_scheduler_config(mut self, path: Option<String>) -> Self {
+        self.config.priority_scheduler_config = path;
+        self
+    }
+
+    pub fn priority_scheduler_tenant_metric_top_n(mut self, n: u32) -> Self {
+        self.config.priority_scheduler_tenant_metric_top_n = n;
+        self
+    }
+
     // ==================== Security & CORS ====================
 
     pub fn api_key<S: Into<String>>(mut self, key: S) -> Self {

--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -116,6 +116,23 @@ pub struct RouterConfig {
     pub queue_timeout_secs: u64,
     /// If not set, defaults to max_concurrent_requests
     pub rate_limit_tokens_per_second: Option<i32>,
+    /// Enable the priority-aware admission scheduler. When false (default),
+    /// the legacy concurrency-limit middleware stays wired — zero behavior
+    /// change for existing deployments.
+    #[serde(default)]
+    pub priority_scheduler_enabled: bool,
+    /// Max priority class applied to tenants not listed in the scheduler
+    /// YAML (`system` | `interactive` | `default` | `bulk`).
+    #[serde(default = "default_priority_scheduler_max_class")]
+    pub priority_scheduler_default_max_class: String,
+    /// Optional path to the priority-scheduler YAML (per-class + per-tenant
+    /// overrides). Absent → built-in defaults, empty tenant policy map.
+    #[serde(default)]
+    pub priority_scheduler_config: Option<String>,
+    /// Cap on per-tenant scheduler metric label cardinality (top-N tenants
+    /// by inflight; the remainder bucket under `tenant="other"`).
+    #[serde(default = "default_priority_scheduler_tenant_metric_top_n")]
+    pub priority_scheduler_tenant_metric_top_n: u32,
     pub cors_allowed_origins: Vec<String>,
     pub retry: RetryConfig,
     pub circuit_breaker: CircuitBreakerConfig,
@@ -256,6 +273,14 @@ impl Default for TokenizerCacheConfig {
             l1_max_memory: default_l1_max_memory(),
         }
     }
+}
+
+fn default_priority_scheduler_max_class() -> String {
+    "default".to_string()
+}
+
+fn default_priority_scheduler_tenant_metric_top_n() -> u32 {
+    32
 }
 
 fn default_history_backend() -> HistoryBackend {
@@ -662,6 +687,11 @@ impl Default for RouterConfig {
             queue_size: 100,
             queue_timeout_secs: 60,
             rate_limit_tokens_per_second: None,
+            priority_scheduler_enabled: false,
+            priority_scheduler_default_max_class: default_priority_scheduler_max_class(),
+            priority_scheduler_config: None,
+            priority_scheduler_tenant_metric_top_n: default_priority_scheduler_tenant_metric_top_n(
+            ),
             cors_allowed_origins: vec![],
             retry: RetryConfig::default(),
             circuit_breaker: CircuitBreakerConfig::default(),

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -351,6 +351,25 @@ struct CliArgs {
     #[arg(long, default_value_t = 60, help_heading = "Rate Limiting")]
     queue_timeout_secs: u64,
 
+    // ==================== Priority Scheduler ====================
+    /// Enable the priority-aware admission scheduler. When unset (default),
+    /// the legacy concurrency-limit middleware stays wired.
+    #[arg(long, help_heading = "Priority Scheduler")]
+    priority_scheduler_enabled: bool,
+
+    /// Max priority class for tenants not listed in the scheduler YAML
+    /// (system | interactive | default | bulk).
+    #[arg(long, default_value = "default", help_heading = "Priority Scheduler")]
+    priority_scheduler_default_max_class: String,
+
+    /// Optional path to the priority-scheduler YAML config.
+    #[arg(long, help_heading = "Priority Scheduler")]
+    priority_scheduler_config: Option<String>,
+
+    /// Cap on per-tenant scheduler metric label cardinality (top-N + "other").
+    #[arg(long, default_value_t = 32, help_heading = "Priority Scheduler")]
+    priority_scheduler_tenant_metric_top_n: u32,
+
     /// Token bucket refill rate (tokens per second)
     #[arg(long, help_heading = "Rate Limiting")]
     rate_limit_tokens_per_second: Option<i32>,
@@ -1210,6 +1229,10 @@ impl CliArgs {
             .max_concurrent_requests(self.max_concurrent_requests)
             .queue_size(self.queue_size)
             .queue_timeout_secs(self.queue_timeout_secs)
+            .priority_scheduler_enabled(self.priority_scheduler_enabled)
+            .priority_scheduler_default_max_class(self.priority_scheduler_default_max_class.clone())
+            .priority_scheduler_config(self.priority_scheduler_config.clone())
+            .priority_scheduler_tenant_metric_top_n(self.priority_scheduler_tenant_metric_top_n)
             .cors_allowed_origins(self.cors_allowed_origins.clone())
             .retry_config(RetryConfig {
                 max_retries: self.retry_max_retries,

--- a/model_gateway/src/middleware/scheduler/admission.rs
+++ b/model_gateway/src/middleware/scheduler/admission.rs
@@ -1,0 +1,100 @@
+//! `priority_admission_middleware`: the axum layer that runs the priority
+//! scheduler on protected routes when it is enabled.
+//!
+//! Pipeline position (route_layer order): runs after tenant resolution
+//! (so `RouteRequestMeta.tenant_key` is in extensions for the clamp) and
+//! before the handler. On admission it inserts the permit's cancel token
+//! into request extensions (so long-running handlers can `select!` against
+//! it for preemption) and wraps the response body in `SchedulerGuardBody`
+//! (TTFT marking + slot release).
+
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc,
+};
+
+use axum::{
+    body::Body,
+    extract::State,
+    http::Request,
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+use smg_auth::RequestId;
+use tokio_util::sync::CancellationToken;
+
+use super::{
+    state::SchedulerState, AdmitOutcome, Class, SchedulerError, SchedulerGuardBody, PRIORITY_HEADER,
+};
+use crate::{
+    middleware::RouteRequestMeta,
+    observability::metrics::{metrics_labels, Metrics},
+    tenant::TenantKey,
+};
+
+/// Monotonic source of registry keys for admitted requests. Each admission
+/// gets a unique key, so the inflight registry can never be clobbered by a
+/// duplicate client-supplied `x-request-id` (the collision hazard flagged
+/// in earlier review). The client request id is still used for logging.
+static NEXT_ADMISSION_ID: AtomicU64 = AtomicU64::new(0);
+
+fn next_registry_id() -> RequestId {
+    let n = NEXT_ADMISSION_ID.fetch_add(1, Ordering::Relaxed);
+    RequestId(format!("sched-{n}"))
+}
+
+/// Resolve the effective class: parse the priority header, then clamp it
+/// down to the tenant's configured `max_class` (a low-tier tenant cannot
+/// self-promote by setting the header). `min` is the clamp because of the
+/// `Ord` derive on `Class`.
+fn effective_class(req: &Request<Body>, state: &SchedulerState) -> Class {
+    let header_class = req
+        .headers()
+        .get(PRIORITY_HEADER)
+        .and_then(|h| h.to_str().ok())
+        .map(Class::parse_header)
+        .unwrap_or(Class::Default);
+    let tenant = req
+        .extensions()
+        .get::<RouteRequestMeta>()
+        .map(|m| m.tenant_key().clone())
+        .unwrap_or_else(|| TenantKey::new("anonymous"));
+    header_class.min(state.resolver.policy(&tenant).max_class)
+}
+
+pub async fn priority_admission_middleware(
+    State(state): State<Arc<SchedulerState>>,
+    mut req: Request<Body>,
+    next: Next,
+) -> Response {
+    // RPS sibling check (only set when an explicit per-second limit is
+    // configured). Checked before admission so a rejected request never
+    // consumes a slot. Tokens are not returned — refill is time-based.
+    if let Some(bucket) = &state.rate_limiter {
+        if bucket.try_acquire(1.0).is_err() {
+            Metrics::record_http_rate_limit(metrics_labels::RATE_LIMIT_REJECTED);
+            return SchedulerError::QueueFull.into_response();
+        }
+    }
+
+    let class = effective_class(&req, &state);
+    let request_id = next_registry_id();
+
+    // NOTE: client-disconnect detection during the queue wait is not yet
+    // wired (axum does not surface it to a middleware pre-`next.run`), so we
+    // pass a fresh token; queued waits are bounded by `queue_timeout`. A
+    // real disconnect drops the response future (and the SchedulerGuardBody)
+    // once admitted, releasing the slot.
+    let cancel = CancellationToken::new();
+
+    match state.scheduler.admit(class, request_id, cancel).await {
+        AdmitOutcome::Admitted(permit) => {
+            // Hand the handler the cancel token (for preemption select!).
+            req.extensions_mut().insert(permit.cancel_token());
+            let response = next.run(req).await;
+            let (parts, body) = response.into_parts();
+            Response::from_parts(parts, Body::new(SchedulerGuardBody::new(body, permit)))
+        }
+        AdmitOutcome::Rejected(reason) => SchedulerError::from(reason).into_response(),
+    }
+}

--- a/model_gateway/src/middleware/scheduler/error.rs
+++ b/model_gateway/src/middleware/scheduler/error.rs
@@ -1,0 +1,161 @@
+//! HTTP mapping for priority-scheduler admission outcomes.
+//!
+//! [`SchedulerError`] is the response-facing form of a rejected admission
+//! (and of a mid-flight preemption). The admission middleware converts a
+//! [`RejectionReason`] into one of these; long-running handlers return
+//! [`SchedulerError::Preempted`] when their cancel token fires.
+
+use axum::{
+    http::{header::RETRY_AFTER, HeaderValue, StatusCode},
+    response::{IntoResponse, Response},
+};
+
+use super::engine::RejectionReason;
+use crate::routers::error::create_error;
+
+/// Response header set on a preempted request so clients/proxies can tell a
+/// preemption 503 apart from an ordinary overload 503.
+pub const HEADER_X_SMG_PREEMPTED: &str = "X-SMG-Preempted";
+
+/// Client-Closed-Request (nginx convention). Used for `ClientCancelled`,
+/// which is essentially never read — the client has already disconnected.
+const STATUS_CLIENT_CLOSED_REQUEST: u16 = 499;
+
+/// How the scheduler's admission decision surfaces to the client.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SchedulerError {
+    /// Per-class queue at its configured limit. → 429.
+    QueueFull,
+    /// Queued waiter aged past `queue_timeout`. → 408.
+    QueueTimeout,
+    /// Cancelled in-flight to admit a higher-priority waiter, before TTFT.
+    /// → 503 + `Retry-After: 1` + `X-SMG-Preempted: true`.
+    Preempted,
+    /// The client disconnected before admission completed. → 499 (never
+    /// actually read; the connection is gone).
+    ClientCancelled,
+}
+
+impl SchedulerError {
+    fn status(self) -> StatusCode {
+        match self {
+            Self::QueueFull => StatusCode::TOO_MANY_REQUESTS,
+            Self::QueueTimeout => StatusCode::REQUEST_TIMEOUT,
+            Self::Preempted => StatusCode::SERVICE_UNAVAILABLE,
+            // `unwrap_or` (not `unwrap`/`expect`, both denied) — 499 is a
+            // valid code so the fallback is never taken.
+            Self::ClientCancelled => StatusCode::from_u16(STATUS_CLIENT_CLOSED_REQUEST)
+                .unwrap_or(StatusCode::REQUEST_TIMEOUT),
+        }
+    }
+
+    fn code(self) -> &'static str {
+        match self {
+            Self::QueueFull => "scheduler_queue_full",
+            Self::QueueTimeout => "scheduler_queue_timeout",
+            Self::Preempted => "scheduler_preempted",
+            Self::ClientCancelled => "scheduler_client_cancelled",
+        }
+    }
+
+    fn message(self) -> &'static str {
+        match self {
+            Self::QueueFull => "request queue is full for this priority class",
+            Self::QueueTimeout => "timed out waiting for an admission slot",
+            Self::Preempted => "request preempted by higher-priority traffic",
+            Self::ClientCancelled => "client closed the request before admission",
+        }
+    }
+}
+
+impl From<RejectionReason> for SchedulerError {
+    fn from(reason: RejectionReason) -> Self {
+        match reason {
+            RejectionReason::QueueFull => Self::QueueFull,
+            RejectionReason::QueueTimeout => Self::QueueTimeout,
+            RejectionReason::Preempted => Self::Preempted,
+            RejectionReason::ClientCancelled => Self::ClientCancelled,
+        }
+    }
+}
+
+impl IntoResponse for SchedulerError {
+    fn into_response(self) -> Response {
+        // Reuse the gateway's standard error shape (JSON body + the
+        // X-SMG-Error-Code header), then layer the preemption-specific
+        // headers on top.
+        let mut resp = create_error(self.status(), self.code(), self.message());
+        if self == Self::Preempted {
+            let headers = resp.headers_mut();
+            headers.insert(RETRY_AFTER, HeaderValue::from_static("1"));
+            headers.insert(HEADER_X_SMG_PREEMPTED, HeaderValue::from_static("true"));
+        }
+        resp
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_queue_full_maps_to_429() {
+        let resp = SchedulerError::QueueFull.into_response();
+        assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+    }
+
+    #[test]
+    fn test_queue_timeout_maps_to_408() {
+        let resp = SchedulerError::QueueTimeout.into_response();
+        assert_eq!(resp.status(), StatusCode::REQUEST_TIMEOUT);
+    }
+
+    #[test]
+    fn test_preempted_maps_to_503_with_headers() {
+        let resp = SchedulerError::Preempted.into_response();
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(
+            resp.headers().get(RETRY_AFTER).map(|v| v.to_str().unwrap()),
+            Some("1")
+        );
+        assert_eq!(
+            resp.headers()
+                .get(HEADER_X_SMG_PREEMPTED)
+                .map(|v| v.to_str().unwrap()),
+            Some("true")
+        );
+    }
+
+    #[test]
+    fn test_client_cancelled_maps_to_499() {
+        let resp = SchedulerError::ClientCancelled.into_response();
+        assert_eq!(resp.status().as_u16(), 499);
+    }
+
+    #[test]
+    fn test_non_preempt_has_no_preempt_headers() {
+        let resp = SchedulerError::QueueFull.into_response();
+        assert!(resp.headers().get(HEADER_X_SMG_PREEMPTED).is_none());
+        assert!(resp.headers().get(RETRY_AFTER).is_none());
+    }
+
+    #[test]
+    fn test_from_rejection_reason_is_one_to_one() {
+        assert_eq!(
+            SchedulerError::from(RejectionReason::QueueFull),
+            SchedulerError::QueueFull
+        );
+        assert_eq!(
+            SchedulerError::from(RejectionReason::QueueTimeout),
+            SchedulerError::QueueTimeout
+        );
+        assert_eq!(
+            SchedulerError::from(RejectionReason::Preempted),
+            SchedulerError::Preempted
+        );
+        assert_eq!(
+            SchedulerError::from(RejectionReason::ClientCancelled),
+            SchedulerError::ClientCancelled
+        );
+    }
+}

--- a/model_gateway/src/middleware/scheduler/extract.rs
+++ b/model_gateway/src/middleware/scheduler/extract.rs
@@ -1,0 +1,100 @@
+//! Handler-side preemption integration.
+//!
+//! `priority_admission_middleware` inserts the admission cancel token into
+//! request extensions. Long-running handlers opt into preemption by taking a
+//! `PreemptionGuard` extractor and running their upstream work through
+//! [`PreemptionGuard::guard`], which races the work against the token: if the
+//! request is preempted before the response is produced, the work future is
+//! dropped (cancelling the upstream call) and a `Preempted` response is
+//! returned instead.
+//!
+//! Once a streaming response has been produced, preemption is handled by the
+//! response body wrapper (see `body.rs`), not here — so `guard` only needs to
+//! cover the pre-response window, which is exactly the pre-TTFT window a
+//! preemption victim sits in.
+
+use std::{convert::Infallible, future::Future};
+
+use axum::{
+    extract::FromRequestParts,
+    http::request::Parts,
+    response::{IntoResponse, Response},
+};
+use tokio_util::sync::CancellationToken;
+
+use super::SchedulerError;
+
+/// Infallible extractor for the per-request preemption token. In priority
+/// mode the admission middleware inserts the token; in legacy mode it is
+/// absent and this yields a default token that never fires, so wrapped
+/// handlers behave identically to today.
+#[derive(Clone, Default)]
+pub struct PreemptionGuard(CancellationToken);
+
+impl<S> FromRequestParts<S> for PreemptionGuard
+where
+    S: Send + Sync,
+{
+    type Rejection = Infallible;
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Infallible> {
+        Ok(Self(
+            parts
+                .extensions
+                .get::<CancellationToken>()
+                .cloned()
+                .unwrap_or_default(),
+        ))
+    }
+}
+
+impl PreemptionGuard {
+    /// Run `fut`, returning its response — unless the request is preempted
+    /// first, in which case `fut` is dropped (cancelling the upstream call)
+    /// and a `Preempted` response is returned.
+    pub async fn guard<F>(self, fut: F) -> Response
+    where
+        F: Future<Output = Response>,
+    {
+        tokio::select! {
+            resp = fut => resp,
+            () = self.0.cancelled() => SchedulerError::Preempted.into_response(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::future::pending;
+
+    use axum::http::StatusCode;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn guard_returns_inner_response_when_not_cancelled() {
+        let guard = PreemptionGuard(CancellationToken::new());
+        let resp = guard.guard(async { StatusCode::OK.into_response() }).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn default_token_never_fires_so_inner_response_passes_through() {
+        // Legacy mode: the extractor yields a default token. Even racing a
+        // never-completing future, the only way to return is the inner arm,
+        // so a default-token guard must never short-circuit to Preempted.
+        let guard = PreemptionGuard::default();
+        let resp = guard.guard(async { StatusCode::OK.into_response() }).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn guard_returns_preempted_when_token_cancelled() {
+        let token = CancellationToken::new();
+        token.cancel();
+        let guard = PreemptionGuard(token);
+        // The work future never completes, so only the cancel arm can win.
+        let resp = guard.guard(pending::<Response>()).await;
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+}

--- a/model_gateway/src/middleware/scheduler/mod.rs
+++ b/model_gateway/src/middleware/scheduler/mod.rs
@@ -6,6 +6,7 @@ pub mod class;
 pub mod config;
 pub mod engine;
 pub mod error;
+pub mod extract;
 pub mod inflight;
 pub mod policy;
 pub mod queue;
@@ -23,5 +24,6 @@ pub use engine::{
     AdmitOutcome, PriorityScheduler, RejectionReason, SchedulerInitError, SchedulerPermit,
 };
 pub use error::{SchedulerError, HEADER_X_SMG_PREEMPTED};
+pub use extract::PreemptionGuard;
 pub use policy::{StaticTenantPolicyResolver, TenantPolicy, TenantPolicyResolver};
 pub use state::{AdmissionMode, SchedulerState};

--- a/model_gateway/src/middleware/scheduler/mod.rs
+++ b/model_gateway/src/middleware/scheduler/mod.rs
@@ -4,6 +4,7 @@ pub mod body;
 pub mod class;
 pub mod config;
 pub mod engine;
+pub mod error;
 pub mod inflight;
 pub mod policy;
 pub mod queue;
@@ -18,4 +19,5 @@ pub use config::{
 pub use engine::{
     AdmitOutcome, PriorityScheduler, RejectionReason, SchedulerInitError, SchedulerPermit,
 };
+pub use error::{SchedulerError, HEADER_X_SMG_PREEMPTED};
 pub use policy::{StaticTenantPolicyResolver, TenantPolicy, TenantPolicyResolver};

--- a/model_gateway/src/middleware/scheduler/mod.rs
+++ b/model_gateway/src/middleware/scheduler/mod.rs
@@ -1,5 +1,6 @@
 //! Priority-aware admission scheduler.
 
+pub mod admission;
 pub mod body;
 pub mod class;
 pub mod config;
@@ -9,7 +10,9 @@ pub mod inflight;
 pub mod policy;
 pub mod queue;
 pub mod slots;
+pub mod state;
 
+pub use admission::priority_admission_middleware;
 pub use body::SchedulerGuardBody;
 pub use class::{Class, PRIORITY_HEADER};
 pub use config::{
@@ -21,3 +24,4 @@ pub use engine::{
 };
 pub use error::{SchedulerError, HEADER_X_SMG_PREEMPTED};
 pub use policy::{StaticTenantPolicyResolver, TenantPolicy, TenantPolicyResolver};
+pub use state::{AdmissionMode, SchedulerState};

--- a/model_gateway/src/middleware/scheduler/state.rs
+++ b/model_gateway/src/middleware/scheduler/state.rs
@@ -1,0 +1,131 @@
+//! Startup wiring for the priority scheduler: builds the admission mode
+//! the route layer branches on.
+
+use std::sync::Arc;
+
+use tracing::{error, info};
+
+use super::{
+    Class, PriorityScheduler, SchedulerSettings, StaticTenantPolicyResolver, TenantPolicyResolver,
+};
+use crate::{
+    config::types::RouterConfig,
+    middleware::token_bucket::TokenBucket,
+    worker::{CapacityTrackerSettings, WorkerCapacity, WorkerRegistry},
+};
+
+/// State handed to `priority_admission_middleware` via `from_fn_with_state`.
+/// Cheap to clone (all `Arc`).
+pub struct SchedulerState {
+    pub scheduler: Arc<PriorityScheduler>,
+    pub resolver: Arc<dyn TenantPolicyResolver>,
+    /// Per-second RPS sibling check, run before admission. Set only when an
+    /// explicit `rate_limit_tokens_per_second` is configured; the bucket's
+    /// concurrency-cap role is owned by the scheduler, so we must not consult
+    /// it as a concurrency limiter (that would double-limit). `None` =
+    /// no RPS limit.
+    pub rate_limiter: Option<Arc<TokenBucket>>,
+}
+
+/// Which admission path the protected routes use. Chosen once at startup.
+#[derive(Clone)]
+pub enum AdmissionMode {
+    /// Legacy `concurrency_limit_middleware` (default; zero behavior change).
+    Legacy,
+    /// Priority scheduler enabled.
+    Priority(Arc<SchedulerState>),
+}
+
+impl AdmissionMode {
+    /// Build the admission mode from runtime config.
+    ///
+    /// When `priority_scheduler_enabled` is false, returns `Legacy` without
+    /// constructing anything. When true, constructs `WorkerCapacity` over
+    /// the worker fleet, builds the scheduler against its current capacity,
+    /// spawns the dispatcher on its watch channel, and returns
+    /// `Priority(..)`.
+    ///
+    /// On any startup error (bad YAML, reservations exceed capacity), logs
+    /// at ERROR and falls back to `Legacy` rather than aborting the whole
+    /// gateway — a misconfigured scheduler must not take the data plane down.
+    pub fn from_config(
+        rc: &RouterConfig,
+        registry: Arc<WorkerRegistry>,
+        rate_limiter: Option<Arc<TokenBucket>>,
+    ) -> Self {
+        if !rc.priority_scheduler_enabled {
+            return Self::Legacy;
+        }
+        match Self::try_build_priority(rc, registry, rate_limiter) {
+            Ok(mode) => {
+                info!("priority scheduler enabled");
+                mode
+            }
+            Err(e) => {
+                error!(
+                    error = %e,
+                    "priority scheduler failed to start; falling back to legacy admission"
+                );
+                Self::Legacy
+            }
+        }
+    }
+
+    fn try_build_priority(
+        rc: &RouterConfig,
+        registry: Arc<WorkerRegistry>,
+        rate_limiter: Option<Arc<TokenBucket>>,
+    ) -> Result<Self, String> {
+        // Tier-4 fallback for WorkerCapacity comes from the legacy
+        // --max-concurrent-requests (clamped to u16; <=0 means "disabled",
+        // for which we keep the tracker default).
+        let cap_settings = CapacityTrackerSettings {
+            legacy_max_concurrent_requests: u16::try_from(rc.max_concurrent_requests)
+                .unwrap_or_else(|_| {
+                    CapacityTrackerSettings::default().legacy_max_concurrent_requests
+                }),
+            ..CapacityTrackerSettings::default()
+        };
+        let worker_capacity = WorkerCapacity::spawn(registry, cap_settings);
+
+        let default_max_class = Class::parse_header(&rc.priority_scheduler_default_max_class);
+        let yaml = load_yaml(rc.priority_scheduler_config.as_deref())?;
+        let settings = SchedulerSettings::from_cli_and_yaml(
+            true,
+            default_max_class,
+            rc.priority_scheduler_tenant_metric_top_n,
+            yaml.as_ref(),
+        )
+        .map_err(|e| e.to_string())?;
+
+        let scheduler = PriorityScheduler::new(&settings, worker_capacity.current())
+            .map_err(|e| e.to_string())?;
+        scheduler.spawn_dispatcher(worker_capacity.watch());
+
+        let resolver: Arc<dyn TenantPolicyResolver> =
+            Arc::new(StaticTenantPolicyResolver::from_settings(&settings));
+
+        // The scheduler owns concurrency, so the shared bucket only survives
+        // as an RPS check when an explicit per-second limit is configured.
+        let rate_limiter = match rc.rate_limit_tokens_per_second {
+            Some(rps) if rps > 0 => rate_limiter,
+            _ => None,
+        };
+
+        Ok(Self::Priority(Arc::new(SchedulerState {
+            scheduler,
+            resolver,
+            rate_limiter,
+        })))
+    }
+}
+
+/// Load + parse the optional priority-scheduler YAML file.
+fn load_yaml(path: Option<&str>) -> Result<Option<super::PrioritySchedulerYaml>, String> {
+    let Some(path) = path else {
+        return Ok(None);
+    };
+    let contents = std::fs::read_to_string(path).map_err(|e| format!("reading {path}: {e}"))?;
+    let parsed = serde_yaml::from_str(&contents).map_err(|e| format!("parsing {path}: {e}"))?;
+    Ok(Some(parsed))
+}

--- a/model_gateway/src/server.rs
+++ b/model_gateway/src/server.rs
@@ -180,11 +180,15 @@ async fn generate(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
     Extension(tenant_meta): Extension<middleware::TenantRequestMeta>,
+    cancel: middleware::scheduler::PreemptionGuard,
     Json(body): Json<GenerateRequest>,
 ) -> Response {
-    state
-        .router
-        .route_generate(Some(&headers), &tenant_meta, &body, &body.model)
+    cancel
+        .guard(
+            state
+                .router
+                .route_generate(Some(&headers), &tenant_meta, &body, &body.model),
+        )
         .await
 }
 
@@ -192,11 +196,15 @@ async fn v1_chat_completions(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
     Extension(tenant_meta): Extension<middleware::TenantRequestMeta>,
+    cancel: middleware::scheduler::PreemptionGuard,
     ValidatedJson(body): ValidatedJson<ChatCompletionRequest>,
 ) -> Response {
-    state
-        .router
-        .route_chat(Some(&headers), &tenant_meta, &body, &body.model)
+    cancel
+        .guard(
+            state
+                .router
+                .route_chat(Some(&headers), &tenant_meta, &body, &body.model),
+        )
         .await
 }
 
@@ -204,11 +212,15 @@ async fn v1_completions(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
     Extension(tenant_meta): Extension<middleware::TenantRequestMeta>,
+    cancel: middleware::scheduler::PreemptionGuard,
     ValidatedJson(body): ValidatedJson<CompletionRequest>,
 ) -> Response {
-    state
-        .router
-        .route_completion(Some(&headers), &tenant_meta, &body, &body.model)
+    cancel
+        .guard(
+            state
+                .router
+                .route_completion(Some(&headers), &tenant_meta, &body, &body.model),
+        )
         .await
 }
 
@@ -216,11 +228,15 @@ async fn rerank(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
     Extension(tenant_meta): Extension<middleware::TenantRequestMeta>,
+    cancel: middleware::scheduler::PreemptionGuard,
     ValidatedJson(body): ValidatedJson<RerankRequest>,
 ) -> Response {
-    state
-        .router
-        .route_rerank(Some(&headers), &tenant_meta, &body, &body.model)
+    cancel
+        .guard(
+            state
+                .router
+                .route_rerank(Some(&headers), &tenant_meta, &body, &body.model),
+        )
         .await
 }
 
@@ -228,17 +244,17 @@ async fn v1_rerank(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
     Extension(tenant_meta): Extension<middleware::TenantRequestMeta>,
+    cancel: middleware::scheduler::PreemptionGuard,
     Json(body): Json<V1RerankReqInput>,
 ) -> Response {
     let rerank_body: RerankRequest = body.into();
-    state
-        .router
-        .route_rerank(
+    cancel
+        .guard(state.router.route_rerank(
             Some(&headers),
             &tenant_meta,
             &rerank_body,
             &rerank_body.model,
-        )
+        ))
         .await
 }
 
@@ -246,11 +262,15 @@ async fn v1_responses(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
     Extension(tenant_meta): Extension<middleware::TenantRequestMeta>,
+    cancel: middleware::scheduler::PreemptionGuard,
     ValidatedJson(body): ValidatedJson<ResponsesRequest>,
 ) -> Response {
-    state
-        .router
-        .route_responses(Some(&headers), &tenant_meta, &body, &body.model)
+    cancel
+        .guard(
+            state
+                .router
+                .route_responses(Some(&headers), &tenant_meta, &body, &body.model),
+        )
         .await
 }
 
@@ -258,12 +278,16 @@ async fn v1_interactions(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
     Extension(tenant_meta): Extension<middleware::TenantRequestMeta>,
+    cancel: middleware::scheduler::PreemptionGuard,
     ValidatedJson(body): ValidatedJson<InteractionsRequest>,
 ) -> Response {
     let model_id = body.model.as_deref().or(body.agent.as_deref());
-    state
-        .router
-        .route_interactions(Some(&headers), &tenant_meta, &body, model_id)
+    cancel
+        .guard(
+            state
+                .router
+                .route_interactions(Some(&headers), &tenant_meta, &body, model_id),
+        )
         .await
 }
 
@@ -271,11 +295,15 @@ async fn v1_embeddings(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
     Extension(tenant_meta): Extension<middleware::TenantRequestMeta>,
+    cancel: middleware::scheduler::PreemptionGuard,
     Json(body): Json<EmbeddingRequest>,
 ) -> Response {
-    state
-        .router
-        .route_embeddings(Some(&headers), &tenant_meta, &body, &body.model)
+    cancel
+        .guard(
+            state
+                .router
+                .route_embeddings(Some(&headers), &tenant_meta, &body, &body.model),
+        )
         .await
 }
 
@@ -283,11 +311,15 @@ async fn v1_messages(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
     Extension(tenant_meta): Extension<middleware::TenantRequestMeta>,
+    cancel: middleware::scheduler::PreemptionGuard,
     ValidatedJson(body): ValidatedJson<CreateMessageRequest>,
 ) -> Response {
-    state
-        .router
-        .route_messages(Some(&headers), &tenant_meta, &body, &body.model)
+    cancel
+        .guard(
+            state
+                .router
+                .route_messages(Some(&headers), &tenant_meta, &body, &body.model),
+        )
         .await
 }
 
@@ -295,11 +327,15 @@ async fn v1_classify(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
     Extension(tenant_meta): Extension<middleware::TenantRequestMeta>,
+    cancel: middleware::scheduler::PreemptionGuard,
     Json(body): Json<ClassifyRequest>,
 ) -> Response {
-    state
-        .router
-        .route_classify(Some(&headers), &tenant_meta, &body, &body.model)
+    cancel
+        .guard(
+            state
+                .router
+                .route_classify(Some(&headers), &tenant_meta, &body, &body.model),
+        )
         .await
 }
 
@@ -307,17 +343,17 @@ async fn v1_audio_transcriptions(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
     Extension(tenant_meta): Extension<middleware::TenantRequestMeta>,
+    cancel: middleware::scheduler::PreemptionGuard,
     AudioTranscriptionMultipart { request, audio }: AudioTranscriptionMultipart,
 ) -> Response {
-    state
-        .router
-        .route_audio_transcriptions(
+    cancel
+        .guard(state.router.route_audio_transcriptions(
             Some(&headers),
             &tenant_meta,
             &request,
             audio,
             &request.model,
-        )
+        ))
         .await
 }
 

--- a/model_gateway/src/server.rs
+++ b/model_gateway/src/server.rs
@@ -764,6 +764,34 @@ pub struct ServerConfig {
     pub webrtc_stun_server: Option<String>,
 }
 
+/// Apply the request-admission layer to a protected route group.
+///
+/// `AdmissionMode::Priority` installs the priority scheduler middleware
+/// (carrying its own `Arc<SchedulerState>`); `AdmissionMode::Legacy` installs
+/// the original `concurrency_limit_middleware`. Either runs innermost of the
+/// protective layers (closest to the handler), after tenant resolution has
+/// populated `RouteRequestMeta`.
+fn with_admission_layer(
+    router: Router<Arc<AppState>>,
+    admission_mode: &middleware::scheduler::AdmissionMode,
+    app_state: Arc<AppState>,
+) -> Router<Arc<AppState>> {
+    match admission_mode {
+        middleware::scheduler::AdmissionMode::Priority(scheduler_state) => {
+            router.route_layer(axum::middleware::from_fn_with_state(
+                scheduler_state.clone(),
+                middleware::scheduler::priority_admission_middleware,
+            ))
+        }
+        middleware::scheduler::AdmissionMode::Legacy => {
+            router.route_layer(axum::middleware::from_fn_with_state(
+                app_state,
+                middleware::concurrency_limit_middleware,
+            ))
+        }
+    }
+}
+
 pub fn build_app(
     app_state: Arc<AppState>,
     auth_config: AuthConfig,
@@ -790,114 +818,121 @@ pub fn build_app(
                     .and_then(|skill_service| skill_service.tenant_alias_store()),
             );
 
-    let protected_routes = Router::new()
-        .route("/v1/responses", post(v1_responses))
-        .route("/v1/responses/{response_id}", get(v1_responses_get))
-        .route(
-            "/v1/responses/{response_id}/cancel",
-            post(v1_responses_cancel),
-        )
-        .route("/v1/responses/{response_id}", delete(v1_responses_delete))
-        .route(
-            "/v1/responses/{response_id}/input_items",
-            get(v1_responses_list_input_items),
-        )
-        .route("/v1/conversations", post(v1_conversations_create))
-        .route(
-            "/v1/conversations/{conversation_id}",
-            get(v1_conversations_get)
-                .post(v1_conversations_update)
-                .delete(v1_conversations_delete),
-        )
-        .route(
-            "/v1/conversations/{conversation_id}/items",
-            get(v1_conversations_list_items).post(v1_conversations_create_items),
-        )
-        .route(
-            "/v1/conversations/{conversation_id}/items/{item_id}",
-            get(v1_conversations_get_item).delete(v1_conversations_delete_item),
-        )
-        .route_layer(axum::middleware::from_fn_with_state(
-            app_state.clone(),
-            middleware::storage_context_middleware,
-        ))
-        .route("/generate", post(generate))
-        .route("/v1/chat/completions", post(v1_chat_completions))
-        .route("/v1/completions", post(v1_completions))
-        .route("/rerank", post(rerank))
-        .route("/v1/rerank", post(v1_rerank))
-        .route("/v1/embeddings", post(v1_embeddings))
-        .route("/v1/messages", post(v1_messages))
-        .route("/v1/interactions", post(v1_interactions))
-        .route("/v1/classify", post(v1_classify))
-        // Tokenize / Detokenize endpoints
-        .route("/v1/tokenize", post(v1_tokenize))
-        .route("/v1/detokenize", post(v1_detokenize))
-        // Realtime REST endpoints (same middleware as other protected routes)
-        .route("/v1/realtime/sessions", post(v1_realtime_session))
-        .route(
-            "/v1/realtime/client_secrets",
-            post(v1_realtime_client_secret),
-        )
-        .route(
-            "/v1/realtime/transcription_sessions",
-            post(v1_realtime_transcription_session),
-        )
-        .route_layer(axum::middleware::from_fn_with_state(
-            app_state.clone(),
-            middleware::concurrency_limit_middleware,
-        ))
-        .route_layer(axum::middleware::from_fn_with_state(
-            tenant_resolution_state.clone(),
-            middleware::route_request_meta_middleware,
-        ))
-        .route_layer(axum::middleware::from_fn_with_state(
-            auth_config.clone(),
-            middleware::auth_middleware,
-        ))
-        .route_layer(axum::middleware::from_fn_with_state(
-            app_state.clone(),
-            middleware::wasm_middleware,
-        ));
+    // Choose the admission path once at startup: priority scheduler when
+    // enabled (and it starts cleanly), otherwise the legacy concurrency limit.
+    let admission_mode = middleware::scheduler::AdmissionMode::from_config(
+        &app_state.context.router_config,
+        app_state.context.worker_registry.clone(),
+        app_state.context.rate_limiter.clone(),
+    );
+
+    let protected_routes = with_admission_layer(
+        Router::new()
+            .route("/v1/responses", post(v1_responses))
+            .route("/v1/responses/{response_id}", get(v1_responses_get))
+            .route(
+                "/v1/responses/{response_id}/cancel",
+                post(v1_responses_cancel),
+            )
+            .route("/v1/responses/{response_id}", delete(v1_responses_delete))
+            .route(
+                "/v1/responses/{response_id}/input_items",
+                get(v1_responses_list_input_items),
+            )
+            .route("/v1/conversations", post(v1_conversations_create))
+            .route(
+                "/v1/conversations/{conversation_id}",
+                get(v1_conversations_get)
+                    .post(v1_conversations_update)
+                    .delete(v1_conversations_delete),
+            )
+            .route(
+                "/v1/conversations/{conversation_id}/items",
+                get(v1_conversations_list_items).post(v1_conversations_create_items),
+            )
+            .route(
+                "/v1/conversations/{conversation_id}/items/{item_id}",
+                get(v1_conversations_get_item).delete(v1_conversations_delete_item),
+            )
+            .route_layer(axum::middleware::from_fn_with_state(
+                app_state.clone(),
+                middleware::storage_context_middleware,
+            ))
+            .route("/generate", post(generate))
+            .route("/v1/chat/completions", post(v1_chat_completions))
+            .route("/v1/completions", post(v1_completions))
+            .route("/rerank", post(rerank))
+            .route("/v1/rerank", post(v1_rerank))
+            .route("/v1/embeddings", post(v1_embeddings))
+            .route("/v1/messages", post(v1_messages))
+            .route("/v1/interactions", post(v1_interactions))
+            .route("/v1/classify", post(v1_classify))
+            // Tokenize / Detokenize endpoints
+            .route("/v1/tokenize", post(v1_tokenize))
+            .route("/v1/detokenize", post(v1_detokenize))
+            // Realtime REST endpoints (same middleware as other protected routes)
+            .route("/v1/realtime/sessions", post(v1_realtime_session))
+            .route(
+                "/v1/realtime/client_secrets",
+                post(v1_realtime_client_secret),
+            )
+            .route(
+                "/v1/realtime/transcription_sessions",
+                post(v1_realtime_transcription_session),
+            ),
+        &admission_mode,
+        app_state.clone(),
+    )
+    .route_layer(axum::middleware::from_fn_with_state(
+        tenant_resolution_state.clone(),
+        middleware::route_request_meta_middleware,
+    ))
+    .route_layer(axum::middleware::from_fn_with_state(
+        auth_config.clone(),
+        middleware::auth_middleware,
+    ))
+    .route_layer(axum::middleware::from_fn_with_state(
+        app_state.clone(),
+        middleware::wasm_middleware,
+    ));
 
     // WebSocket and WebRTC routes: auth + concurrency but NO WASM middleware.
     // WASM OnResponse reconstructs the response from status/headers/body,
     // dropping the response extensions that carry the WebSocket upgrade future.
-    let realtime_routes = Router::new()
-        .route("/v1/realtime", get(v1_realtime_ws))
-        .route("/v1/realtime/calls", post(v1_realtime_webrtc))
-        .route_layer(axum::middleware::from_fn_with_state(
-            app_state.clone(),
-            middleware::concurrency_limit_middleware,
-        ))
-        .route_layer(axum::middleware::from_fn_with_state(
-            tenant_resolution_state.clone(),
-            middleware::route_request_meta_middleware,
-        ))
-        .route_layer(axum::middleware::from_fn_with_state(
-            auth_config.clone(),
-            middleware::auth_middleware,
-        ));
+    let realtime_routes = with_admission_layer(
+        Router::new()
+            .route("/v1/realtime", get(v1_realtime_ws))
+            .route("/v1/realtime/calls", post(v1_realtime_webrtc)),
+        &admission_mode,
+        app_state.clone(),
+    )
+    .route_layer(axum::middleware::from_fn_with_state(
+        tenant_resolution_state.clone(),
+        middleware::route_request_meta_middleware,
+    ))
+    .route_layer(axum::middleware::from_fn_with_state(
+        auth_config.clone(),
+        middleware::auth_middleware,
+    ));
 
     // Multipart upload routes: auth + concurrency but NO WASM middleware.
     // The WASM OnRequest phase buffers the full body into a `Vec<u8>` subject
     // to the WASM manager's `max_body_size` (10MB default). Audio uploads
     // routinely exceed that, so WASM middleware would reject them with 400
     // before reaching the handler.
-    let multipart_upload_routes = Router::new()
-        .route("/v1/audio/transcriptions", post(v1_audio_transcriptions))
-        .route_layer(axum::middleware::from_fn_with_state(
-            app_state.clone(),
-            middleware::concurrency_limit_middleware,
-        ))
-        .route_layer(axum::middleware::from_fn_with_state(
-            tenant_resolution_state,
-            middleware::route_request_meta_middleware,
-        ))
-        .route_layer(axum::middleware::from_fn_with_state(
-            auth_config.clone(),
-            middleware::auth_middleware,
-        ));
+    let multipart_upload_routes = with_admission_layer(
+        Router::new().route("/v1/audio/transcriptions", post(v1_audio_transcriptions)),
+        &admission_mode,
+        app_state.clone(),
+    )
+    .route_layer(axum::middleware::from_fn_with_state(
+        tenant_resolution_state,
+        middleware::route_request_meta_middleware,
+    ))
+    .route_layer(axum::middleware::from_fn_with_state(
+        auth_config.clone(),
+        middleware::auth_middleware,
+    ));
 
     let public_routes = Router::new()
         .route("/liveness", get(liveness))


### PR DESCRIPTION
## Description

### Problem

M3 (#1572) added the preemption mechanics to the scheduler engine, but nothing constructs the scheduler at startup or routes traffic through it. The master flag has nothing to toggle.

### Solution

Wires the priority scheduler into the request path behind `--priority-scheduler-enabled` (default **off** → zero behavior change), and makes preemption actually free slots by propagating the cancel token into the long-running handlers.

Stacked on #1572 — review/merge that first.

## Changes

- **CLI + config** (`main.rs`, `config/`): `--priority-scheduler-enabled`, `--priority-scheduler-default-max-class`, `--priority-scheduler-config` (YAML path), `--priority-scheduler-tenant-metric-top-n`, threaded into `RouterConfig`.
- **`SchedulerError` + `IntoResponse`** (`scheduler/error.rs`): `QueueFull`→429, `QueueTimeout`→408, `Preempted`→503 + `Retry-After: 1` + `X-SMG-Preempted: true`, `ClientCancelled`→499.
- **`AdmissionMode` + startup wiring** (`scheduler/state.rs`, `server.rs`): `AdmissionMode::from_config` constructs `WorkerCapacity` over the fleet, builds the scheduler against current capacity, and spawns the dispatcher on the capacity watch. A startup error logs at ERROR and falls back to legacy admission rather than taking the data plane down. `with_admission_layer` branches the three protected route groups between the scheduler and the legacy `concurrency_limit_middleware`.
- **`priority_admission_middleware`** (`scheduler/admission.rs`): parses the priority header, clamps to the tenant's `max_class`, mints a unique registry id per admission (so a duplicate client `x-request-id` can't clobber the inflight registry), runs the optional RPS sibling check, calls `scheduler.admit`, and on admission inserts the cancel token into extensions + wraps the body in `SchedulerGuardBody`.
- **Cancel propagation** (`scheduler/extract.rs`, `server.rs`): `PreemptionGuard`, an infallible extractor yielding the cancel token (never-firing default in legacy mode), plus a `guard()` combinator wired into every long-running proxy handler. On preemption the work future is dropped (cancelling upstream) and a `Preempted` response is returned.

The RPS bucket is consulted only when `rate_limit_tokens_per_second` is set; its concurrency-cap role is replaced by the scheduler, so consulting it unconditionally would double-limit (see design §1, §8 — deviation from the plan's looser wording noted in the deviations doc).

## Test Plan

- `cargo test -p smg --lib scheduler::` — 107 unit tests pass (engine, slots, queue, body, extract).
- New `scheduler::extract` tests cover the guard: passthrough when not cancelled, never-fire default token (legacy), and `Preempted` (503) when cancelled.
- Default off: `with_admission_layer` installs the unchanged `concurrency_limit_middleware`; the `PreemptionGuard` default token never fires, so wrapped handlers behave identically to today.
- End-to-end admission/preemption integration tests land in M6.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Priority scheduler with configurable enable/disable, max class, and YAML config support.
  * Priority-based request admission for protected API endpoints.
  * Queue management with per-tenant metric tracking.
  * Request preemption support with Retry-After headers.
  * New HTTP status codes: 429 (queue full), 408 (queue timeout), 503 (preempted), 499 (client cancelled).

* **Tests**
  * Added error handling and preemption scenario tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->