### PR TITLE
feat(scheduler): operational metrics + tracing (PR 2 M5a)

### DIFF
--- a/model_gateway/src/middleware/scheduler/admission.rs
+++ b/model_gateway/src/middleware/scheduler/admission.rs
@@ -22,9 +22,11 @@ use axum::{
 };
 use smg_auth::RequestId;
 use tokio_util::sync::CancellationToken;
+use tracing::trace;
 
 use super::{
-    state::SchedulerState, AdmitOutcome, Class, SchedulerError, SchedulerGuardBody, PRIORITY_HEADER,
+    metrics as sched_metrics, state::SchedulerState, AdmitOutcome, Class, RejectionReason,
+    SchedulerError, SchedulerGuardBody, HEADER_X_SMG_PREEMPTED, PRIORITY_HEADER,
 };
 use crate::{
     middleware::RouteRequestMeta,
@@ -43,23 +45,51 @@ fn next_registry_id() -> RequestId {
     RequestId(format!("sched-{n}"))
 }
 
+/// The class a request resolves to, plus what it asked for.
+struct ResolvedPriority {
+    /// Post-clamp class the request is admitted under.
+    effective: Class,
+    /// Class parsed from the header before the tenant clamp.
+    requested: Class,
+    /// Header carried a non-empty value that didn't name a known class.
+    unknown: bool,
+}
+
 /// Resolve the effective class: parse the priority header, then clamp it
 /// down to the tenant's configured `max_class` (a low-tier tenant cannot
 /// self-promote by setting the header). `min` is the clamp because of the
 /// `Ord` derive on `Class`.
-fn effective_class(req: &Request<Body>, state: &SchedulerState) -> Class {
-    let header_class = req
+fn resolve_priority(
+    req: &Request<Body>,
+    state: &SchedulerState,
+    tenant: &TenantKey,
+) -> ResolvedPriority {
+    let raw = req
         .headers()
         .get(PRIORITY_HEADER)
-        .and_then(|h| h.to_str().ok())
-        .map(Class::parse_header)
-        .unwrap_or(Class::Default);
-    let tenant = req
-        .extensions()
-        .get::<RouteRequestMeta>()
-        .map(|m| m.tenant_key().clone())
-        .unwrap_or_else(|| TenantKey::new("anonymous"));
-    header_class.min(state.resolver.policy(&tenant).max_class)
+        .and_then(|h| h.to_str().ok());
+    let requested = raw.map(Class::parse_header).unwrap_or(Class::Default);
+    // Unknown = present, non-empty, not "default", yet still parsed to
+    // Default (i.e. an unrecognized value silently downgraded).
+    let unknown = raw.map(str::trim).is_some_and(|v| {
+        !v.is_empty() && !v.eq_ignore_ascii_case("default") && requested == Class::Default
+    });
+    let max_class = state.resolver.policy(tenant).max_class;
+    ResolvedPriority {
+        effective: requested.min(max_class),
+        requested,
+        unknown,
+    }
+}
+
+/// Map an admit rejection to an `admit_total` outcome label.
+fn rejection_outcome(reason: RejectionReason) -> &'static str {
+    match reason {
+        RejectionReason::QueueFull => sched_metrics::outcome::REJECTED_QUEUE_FULL,
+        RejectionReason::QueueTimeout => sched_metrics::outcome::REJECTED_QUEUE_TIMEOUT,
+        RejectionReason::Preempted => sched_metrics::outcome::PREEMPTED,
+        RejectionReason::ClientCancelled => sched_metrics::outcome::CLIENT_CANCELLED,
+    }
 }
 
 pub async fn priority_admission_middleware(
@@ -67,9 +97,25 @@ pub async fn priority_admission_middleware(
     mut req: Request<Body>,
     next: Next,
 ) -> Response {
+    let tenant = req
+        .extensions()
+        .get::<RouteRequestMeta>()
+        .map(|m| m.tenant_key().clone())
+        .unwrap_or_else(|| TenantKey::new("anonymous"));
+    let resolved = resolve_priority(&req, &state, &tenant);
+    let class = resolved.effective;
+
+    if resolved.unknown {
+        sched_metrics::record_unknown_priority();
+    }
+    if class < resolved.requested {
+        sched_metrics::record_clamp(resolved.requested, class);
+    }
+
     // RPS sibling check (only set when an explicit per-second limit is
     // configured). Checked before admission so a rejected request never
     // consumes a slot. Tokens are not returned — refill is time-based.
+    // Tracked by smg_http_rate_limit_total, so not double-counted here.
     if let Some(bucket) = &state.rate_limiter {
         if bucket.try_acquire(1.0).is_err() {
             Metrics::record_http_rate_limit(metrics_labels::RATE_LIMIT_REJECTED);
@@ -77,7 +123,6 @@ pub async fn priority_admission_middleware(
         }
     }
 
-    let class = effective_class(&req, &state);
     let request_id = next_registry_id();
 
     // NOTE: client-disconnect detection during the queue wait is not yet
@@ -92,9 +137,35 @@ pub async fn priority_admission_middleware(
             // Hand the handler the cancel token (for preemption select!).
             req.extensions_mut().insert(permit.cancel_token());
             let response = next.run(req).await;
+            // The handler's PreemptionGuard tags a preempted response; treat
+            // that as the `preempted` outcome rather than plain admitted.
+            let outcome = if response.headers().contains_key(HEADER_X_SMG_PREEMPTED) {
+                sched_metrics::outcome::PREEMPTED
+            } else {
+                sched_metrics::outcome::ADMITTED
+            };
+            sched_metrics::record_admit(class, outcome);
+            trace!(
+                scheduler.class = class.as_str(),
+                scheduler.requested_class = resolved.requested.as_str(),
+                scheduler.tenant = %tenant,
+                scheduler.admit_outcome = outcome,
+                "scheduler admission decision"
+            );
             let (parts, body) = response.into_parts();
             Response::from_parts(parts, Body::new(SchedulerGuardBody::new(body, permit)))
         }
-        AdmitOutcome::Rejected(reason) => SchedulerError::from(reason).into_response(),
+        AdmitOutcome::Rejected(reason) => {
+            let outcome = rejection_outcome(reason);
+            sched_metrics::record_admit(class, outcome);
+            trace!(
+                scheduler.class = class.as_str(),
+                scheduler.requested_class = resolved.requested.as_str(),
+                scheduler.tenant = %tenant,
+                scheduler.admit_outcome = outcome,
+                "scheduler admission decision"
+            );
+            SchedulerError::from(reason).into_response()
+        }
     }
 }

--- a/model_gateway/src/middleware/scheduler/admission.rs
+++ b/model_gateway/src/middleware/scheduler/admission.rs
@@ -106,10 +106,10 @@ pub async fn priority_admission_middleware(
     let class = resolved.effective;
 
     if resolved.unknown {
-        sched_metrics::record_unknown_priority();
+        sched_metrics::record_unknown_priority(tenant.as_str());
     }
     if class < resolved.requested {
-        sched_metrics::record_clamp(resolved.requested, class);
+        sched_metrics::record_clamp(resolved.requested, class, tenant.as_str());
     }
 
     // RPS sibling check (only set when an explicit per-second limit is
@@ -137,8 +137,14 @@ pub async fn priority_admission_middleware(
             // Hand the handler the cancel token (for preemption select!).
             req.extensions_mut().insert(permit.cancel_token());
             let response = next.run(req).await;
-            // The handler's PreemptionGuard tags a preempted response; treat
-            // that as the `preempted` outcome rather than plain admitted.
+            // Best-effort: the handler's PreemptionGuard tags a *pre-response*
+            // preemption (a 503 carrying this header), which we count as
+            // `preempted`. A preemption that fires after the handler produced
+            // its 200 headers but before the first body byte is truncated by
+            // SchedulerGuardBody and shows here as `admitted` — the response
+            // headers are already flushed, so the marker cannot be added. The
+            // authoritative preemption count is `smg_scheduler_preemption_total`
+            // (recorded at the preemptor side), not this bucket.
             let outcome = if response.headers().contains_key(HEADER_X_SMG_PREEMPTED) {
                 sched_metrics::outcome::PREEMPTED
             } else {

--- a/model_gateway/src/middleware/scheduler/engine.rs
+++ b/model_gateway/src/middleware/scheduler/engine.rs
@@ -212,6 +212,7 @@ impl PriorityScheduler {
                         "scheduler: preempting pre-TTFT request to admit higher class"
                     );
                     victim.cancel();
+                    super::metrics::record_preemption(victim.class(), class);
                     if let Some(permit) = self
                         .wait_for_slot(class, request_id.clone(), &cancel, PREEMPTION_WAIT_BUDGET)
                         .await
@@ -247,6 +248,7 @@ impl PriorityScheduler {
         {
             return AdmitOutcome::Rejected(RejectionReason::QueueFull);
         }
+        let enqueued_at = Instant::now();
 
         // Lost-wakeup guard: a slot may have been released after our
         // fast-path try_acquire failed but before try_enqueue returned.
@@ -268,6 +270,7 @@ impl PriorityScheduler {
             () = tokio::time::sleep(timeout) => AdmitOutcome::Rejected(RejectionReason::QueueTimeout),
             () = cancel.cancelled() => AdmitOutcome::Rejected(RejectionReason::ClientCancelled),
         };
+        super::metrics::record_queue_wait(class, enqueued_at.elapsed());
 
         // Mark the waiter cancelled on any exit path so the queue's
         // `drop_cancelled_head` reaps it. Harmless if the waiter was
@@ -383,6 +386,7 @@ impl PriorityScheduler {
             }
             if self.slot_pool.try_acquire_ignoring_reservations(class) {
                 if self.send_to_head(class) {
+                    super::metrics::record_starvation_promotion(class);
                     return true;
                 }
                 // Acquired a slot but the head was gone (racy cancel).

--- a/model_gateway/src/middleware/scheduler/metrics.rs
+++ b/model_gateway/src/middleware/scheduler/metrics.rs
@@ -1,0 +1,107 @@
+//! Prometheus metrics for the priority scheduler.
+//!
+//! Split to match design §9: this module holds the **operational** counters
+//! and the queue-wait histogram (recorded on the admission / queue paths).
+//! The point-in-time **capacity / autoscaling** gauges (inflight, queue
+//! depth, utilization, per-tenant, …) are computed by the sampler task so
+//! the hot admission path only does cheap counter increments.
+//!
+//! All names carry the `smg_` prefix to match the rest of the gateway's
+//! metrics. Class/outcome labels are `&'static str` (no per-request
+//! allocation).
+
+use std::time::Duration;
+
+use metrics::{counter, describe_counter, describe_histogram, histogram};
+
+use super::Class;
+
+const ADMIT_TOTAL: &str = "smg_scheduler_admit_total";
+const QUEUE_WAIT_SECONDS: &str = "smg_scheduler_queue_wait_seconds";
+const PREEMPTION_TOTAL: &str = "smg_scheduler_preemption_total";
+const CLAMP_TOTAL: &str = "smg_scheduler_clamp_total";
+const UNKNOWN_PRIORITY_TOTAL: &str = "smg_scheduler_unknown_priority_value_total";
+const STARVATION_PROMOTION_TOTAL: &str = "smg_scheduler_starvation_promotion_total";
+
+/// `outcome` label values for [`record_admit`].
+pub mod outcome {
+    /// Admitted (fast path or after queueing — not distinguished).
+    pub const ADMITTED: &str = "admitted";
+    /// Per-class queue was at its limit.
+    pub const REJECTED_QUEUE_FULL: &str = "rejected_queue_full";
+    /// Queued waiter aged past `queue_timeout`.
+    pub const REJECTED_QUEUE_TIMEOUT: &str = "rejected_queue_timeout";
+    /// The request was admitted but then preempted before producing a byte.
+    pub const PREEMPTED: &str = "preempted";
+    /// The caller's client disconnected before admission completed.
+    pub const CLIENT_CANCELLED: &str = "client_cancelled";
+}
+
+/// Register descriptions. Called once from `observability::metrics::init_metrics`.
+pub fn describe() {
+    describe_counter!(
+        ADMIT_TOTAL,
+        "Priority-scheduler admission outcomes by class and outcome"
+    );
+    describe_histogram!(
+        QUEUE_WAIT_SECONDS,
+        "Time a request spent queued before admission, timeout, or cancel"
+    );
+    describe_counter!(
+        PREEMPTION_TOTAL,
+        "Successful preemptions by victim class and preempting class"
+    );
+    describe_counter!(
+        CLAMP_TOTAL,
+        "Requests whose priority was clamped below the requested class by tenant policy"
+    );
+    describe_counter!(
+        UNKNOWN_PRIORITY_TOTAL,
+        "Requests with an unrecognized priority header value (treated as default)"
+    );
+    describe_counter!(
+        STARVATION_PROMOTION_TOTAL,
+        "Queued waiters admitted via the starvation override path"
+    );
+}
+
+/// Record the outcome of an admission attempt for `class`.
+pub fn record_admit(class: Class, outcome: &'static str) {
+    counter!(ADMIT_TOTAL, "class" => class.as_str(), "outcome" => outcome).increment(1);
+}
+
+/// Record the time a request waited in a class queue.
+pub fn record_queue_wait(class: Class, wait: Duration) {
+    histogram!(QUEUE_WAIT_SECONDS, "class" => class.as_str()).record(wait.as_secs_f64());
+}
+
+/// Record a successful preemption.
+pub fn record_preemption(victim_class: Class, by_class: Class) {
+    counter!(
+        PREEMPTION_TOTAL,
+        "victim_class" => victim_class.as_str(),
+        "by_class" => by_class.as_str()
+    )
+    .increment(1);
+}
+
+/// Record a priority clamp (only when the effective class is below the
+/// requested class).
+pub fn record_clamp(requested: Class, effective: Class) {
+    counter!(
+        CLAMP_TOTAL,
+        "requested_class" => requested.as_str(),
+        "effective_class" => effective.as_str()
+    )
+    .increment(1);
+}
+
+/// Record an unrecognized priority header value.
+pub fn record_unknown_priority() {
+    counter!(UNKNOWN_PRIORITY_TOTAL).increment(1);
+}
+
+/// Record a starvation-override promotion.
+pub fn record_starvation_promotion(class: Class) {
+    counter!(STARVATION_PROMOTION_TOTAL, "class" => class.as_str()).increment(1);
+}

--- a/model_gateway/src/middleware/scheduler/metrics.rs
+++ b/model_gateway/src/middleware/scheduler/metrics.rs
@@ -15,6 +15,7 @@ use std::time::Duration;
 use metrics::{counter, describe_counter, describe_histogram, histogram};
 
 use super::Class;
+use crate::observability::metrics::intern_string;
 
 const ADMIT_TOTAL: &str = "smg_scheduler_admit_total";
 const QUEUE_WAIT_SECONDS: &str = "smg_scheduler_queue_wait_seconds";
@@ -86,19 +87,23 @@ pub fn record_preemption(victim_class: Class, by_class: Class) {
 }
 
 /// Record a priority clamp (only when the effective class is below the
-/// requested class).
-pub fn record_clamp(requested: Class, effective: Class) {
+/// requested class). `tenant` is interned — clamps are rare, so its
+/// cardinality is bounded by the set of tenants that actually over-ask.
+pub fn record_clamp(requested: Class, effective: Class, tenant: &str) {
     counter!(
         CLAMP_TOTAL,
+        "tenant" => intern_string(tenant),
         "requested_class" => requested.as_str(),
         "effective_class" => effective.as_str()
     )
     .increment(1);
 }
 
-/// Record an unrecognized priority header value.
-pub fn record_unknown_priority() {
-    counter!(UNKNOWN_PRIORITY_TOTAL).increment(1);
+/// Record an unrecognized priority header value. `tenant` is interned (bad
+/// header values are rare), and is the actionable dimension — it tells ops
+/// which tenant is mis-setting the priority header.
+pub fn record_unknown_priority(tenant: &str) {
+    counter!(UNKNOWN_PRIORITY_TOTAL, "tenant" => intern_string(tenant)).increment(1);
 }
 
 /// Record a starvation-override promotion.

--- a/model_gateway/src/middleware/scheduler/mod.rs
+++ b/model_gateway/src/middleware/scheduler/mod.rs
@@ -8,6 +8,7 @@ pub mod engine;
 pub mod error;
 pub mod extract;
 pub mod inflight;
+pub mod metrics;
 pub mod policy;
 pub mod queue;
 pub mod slots;

--- a/model_gateway/src/observability/metrics.rs
+++ b/model_gateway/src/observability/metrics.rs
@@ -333,6 +333,11 @@ pub(crate) fn init_metrics() {
 
     // Initialize mesh metrics
     smg_mesh::init_mesh_metrics();
+
+    // Priority scheduler metrics (no-op at scrape time unless the scheduler
+    // is enabled and recording).
+    use crate::middleware::scheduler::metrics as scheduler_metrics;
+    scheduler_metrics::describe();
 }
 
 #[expect(


### PR DESCRIPTION
## Description

### Problem

The scheduler had no observability — no way to see admission outcomes, preemptions, clamps, or queue waits.

### Solution

Adds the **operational** half of design §9: counters + the queue-wait histogram, plus structured tracing on the admission decision. Stacked on #1577. The point-in-time capacity/autoscaling gauges (inflight, utilization, per-tenant, p95) land in the follow-up M5b PR via a sampler task, so the hot admission path here only does cheap counter increments.

## Changes

- New `scheduler/metrics.rs`:
  - `smg_scheduler_admit_total{class, outcome}` — outcome ∈ {admitted, rejected_queue_full, rejected_queue_timeout, preempted, client_cancelled}
  - `smg_scheduler_queue_wait_seconds{class}` (histogram)
  - `smg_scheduler_preemption_total{victim_class, by_class}`
  - `smg_scheduler_clamp_total{requested_class, effective_class}`
  - `smg_scheduler_unknown_priority_value_total`
  - `smg_scheduler_starvation_promotion_total{class}`
- Wired into `admit` (queue wait, preemption), `wake_next_waiter` (starvation), and `priority_admission_middleware` (admit outcome, clamp, unknown header).
- The admission middleware emits a structured `trace!` event carrying `scheduler.class` / `requested_class` / `tenant` / `admit_outcome`.
- `describe()` hooked into `observability::metrics::init_metrics`.

### Deviations from the plan (tracked in the deviations doc)
- Metric names carry the `smg_` prefix to match the rest of the gateway (plan used bare `scheduler_*`).
- `admit_total` drops the `tenant` label to bound cardinality; per-tenant slicing comes from the sampler gauges in M5b.
- Tracing is a structured event rather than recorded span fields, to avoid per-request span machinery on the hot path; same field names.

## Test Plan

- `cargo test -p smg --lib scheduler::` — 107 unit tests green.
- End-to-end `/metrics` scrape assertions land with the integration tests in M6.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced observability for the priority scheduler with detailed metrics tracking admission outcomes, queue wait times, preemption events, and priority adjustments.
  * Improved monitoring visibility into scheduler behavior including rejected requests, successful admissions, and resource contention patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->