### PR TITLE
feat(scheduler): autoscaling gauges via metrics sampler (PR 2 M5b)

### DIFF
--- a/model_gateway/src/middleware/scheduler/engine.rs
+++ b/model_gateway/src/middleware/scheduler/engine.rs
@@ -526,6 +526,84 @@ impl PriorityScheduler {
         });
     }
 
+    /// Spawn the metrics sampler: every `interval`, refresh the point-in-time
+    /// capacity / autoscaling gauges from the slot pool and queues. Keeping
+    /// these off the admission path means the hot path only does cheap
+    /// counter increments. Holds only a `Weak<Self>`; exits within one
+    /// interval of the scheduler being dropped.
+    pub fn spawn_sampler(self: &Arc<Self>, interval: Duration) {
+        let weak = Arc::downgrade(self);
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "sampler holds only a Weak<Self> and exits when the scheduler is dropped"
+        )]
+        tokio::spawn(async move {
+            let mut tick = tokio::time::interval(interval);
+            tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            loop {
+                tick.tick().await;
+                let Some(scheduler) = weak.upgrade() else {
+                    break;
+                };
+                scheduler.sample_metrics();
+            }
+        });
+    }
+
+    /// Refresh the capacity / autoscaling gauges. Reads the slot pool and
+    /// queues under their own locks; never touches the inflight registry.
+    fn sample_metrics(&self) {
+        let capacity = self.slot_pool.capacity();
+        let mut total_inflight: u32 = 0;
+        for class in Class::ALL {
+            let inflight = self.slot_pool.inflight(class);
+            total_inflight += u32::from(inflight);
+            let depth = self.class_queues[class as usize].depth();
+            let limit = self.class_queues[class as usize].capacity();
+            super::metrics::set_inflight(class, inflight);
+            super::metrics::set_queue_depth(class, depth);
+            super::metrics::set_queue_size_limit(class, limit);
+            super::metrics::set_class_capacity_pressure(
+                class,
+                self.class_pressure(class, inflight, depth, limit, capacity),
+            );
+        }
+        let utilization = if capacity == 0 {
+            0.0
+        } else {
+            f64::from(total_inflight) / f64::from(capacity)
+        };
+        super::metrics::set_utilization(utilization);
+    }
+
+    /// Normalized 0.0–1.0 pressure for `class`: the worse of queue pressure
+    /// (`depth / limit`) and slot pressure (`max(0, inflight − reserved)`
+    /// over the capacity not reserved by higher classes).
+    fn class_pressure(
+        &self,
+        class: Class,
+        inflight: u16,
+        depth: usize,
+        limit: usize,
+        capacity: u16,
+    ) -> f64 {
+        let queue_pressure = if limit == 0 {
+            0.0
+        } else {
+            depth as f64 / limit as f64
+        };
+        let higher_reserved: u32 = Class::ALL
+            .iter()
+            .filter(|&&c| c > class)
+            .map(|&c| u32::from(self.slot_pool.reserved(c)))
+            .sum();
+        let headroom = u32::from(capacity).saturating_sub(higher_reserved).max(1);
+        let overflow =
+            u32::from(inflight).saturating_sub(u32::from(self.slot_pool.reserved(class)));
+        let slot_pressure = f64::from(overflow) / f64::from(headroom);
+        queue_pressure.max(slot_pressure).min(1.0)
+    }
+
     /// Apply a new backend capacity from the WorkerCapacity watch.
     ///
     /// On shrink past `Σ reserved`, scales reservations down
@@ -1382,6 +1460,21 @@ mod tests {
             "victim must not be preempted"
         );
         assert_eq!(sched.inflight_for_test(Class::Bulk), 1);
+    }
+
+    #[test]
+    fn test_class_pressure_takes_worse_of_queue_and_slot() {
+        // preempt_settings reserves 0 for every class, so higher_reserved=0
+        // and slot pressure is inflight/capacity.
+        let sched = PriorityScheduler::new(&preempt_settings(), 100).unwrap();
+        // Queue pressure (8/10) dominates slot pressure (10/100).
+        assert!((sched.class_pressure(Class::Default, 10, 8, 10, 100) - 0.8).abs() < 1e-9);
+        // Slot pressure (50/100) dominates queue pressure (1/10).
+        assert!((sched.class_pressure(Class::Default, 50, 1, 10, 100) - 0.5).abs() < 1e-9);
+        // Clamped to 1.0 when oversubscribed.
+        assert!((sched.class_pressure(Class::Default, 200, 100, 10, 100) - 1.0).abs() < 1e-9);
+        // No queue limit and no inflight → zero, no div-by-zero.
+        assert_eq!(sched.class_pressure(Class::Bulk, 0, 0, 0, 100), 0.0);
     }
 
     #[tokio::test(start_paused = true)]

--- a/model_gateway/src/middleware/scheduler/metrics.rs
+++ b/model_gateway/src/middleware/scheduler/metrics.rs
@@ -1,10 +1,11 @@
 //! Prometheus metrics for the priority scheduler.
 //!
 //! Split to match design §9: this module holds the **operational** counters
-//! and the queue-wait histogram (recorded on the admission / queue paths).
-//! The point-in-time **capacity / autoscaling** gauges (inflight, queue
-//! depth, utilization, per-tenant, …) are computed by the sampler task so
-//! the hot admission path only does cheap counter increments.
+//! and the queue-wait histogram (recorded on the admission / queue paths),
+//! plus the **capacity / autoscaling** gauge setters. The gauges are
+//! point-in-time state (inflight, queue depth, utilization, capacity
+//! pressure) refreshed by the scheduler's sampler task, so the hot
+//! admission path only does cheap counter increments.
 //!
 //! All names carry the `smg_` prefix to match the rest of the gateway's
 //! metrics. Class/outcome labels are `&'static str` (no per-request
@@ -12,7 +13,7 @@
 
 use std::time::Duration;
 
-use metrics::{counter, describe_counter, describe_histogram, histogram};
+use metrics::{counter, describe_counter, describe_gauge, describe_histogram, gauge, histogram};
 
 use super::Class;
 use crate::observability::metrics::intern_string;
@@ -23,6 +24,13 @@ const PREEMPTION_TOTAL: &str = "smg_scheduler_preemption_total";
 const CLAMP_TOTAL: &str = "smg_scheduler_clamp_total";
 const UNKNOWN_PRIORITY_TOTAL: &str = "smg_scheduler_unknown_priority_value_total";
 const STARVATION_PROMOTION_TOTAL: &str = "smg_scheduler_starvation_promotion_total";
+
+// Capacity / autoscaling gauges, refreshed by the sampler task.
+const INFLIGHT: &str = "smg_scheduler_inflight";
+const QUEUE_DEPTH: &str = "smg_scheduler_queue_depth";
+const UTILIZATION: &str = "smg_scheduler_utilization";
+const QUEUE_SIZE_LIMIT: &str = "smg_scheduler_queue_size_limit";
+const CLASS_CAPACITY_PRESSURE: &str = "smg_scheduler_class_capacity_pressure";
 
 /// `outcome` label values for [`record_admit`].
 pub mod outcome {
@@ -63,6 +71,17 @@ pub fn describe() {
     describe_counter!(
         STARVATION_PROMOTION_TOTAL,
         "Queued waiters admitted via the starvation override path"
+    );
+    describe_gauge!(INFLIGHT, "Current in-flight request count per class");
+    describe_gauge!(QUEUE_DEPTH, "Current queued waiter count per class");
+    describe_gauge!(
+        UTILIZATION,
+        "Total in-flight requests divided by backend capacity (0.0-1.0+)"
+    );
+    describe_gauge!(QUEUE_SIZE_LIMIT, "Configured queue limit per class");
+    describe_gauge!(
+        CLASS_CAPACITY_PRESSURE,
+        "Normalized 0.0-1.0 per-class pressure (max of queue and slot pressure)"
     );
 }
 
@@ -109,4 +128,29 @@ pub fn record_unknown_priority(tenant: &str) {
 /// Record a starvation-override promotion.
 pub fn record_starvation_promotion(class: Class) {
     counter!(STARVATION_PROMOTION_TOTAL, "class" => class.as_str()).increment(1);
+}
+
+/// Set the in-flight gauge for a class (sampler).
+pub fn set_inflight(class: Class, count: u16) {
+    gauge!(INFLIGHT, "class" => class.as_str()).set(f64::from(count));
+}
+
+/// Set the queue-depth gauge for a class (sampler).
+pub fn set_queue_depth(class: Class, depth: usize) {
+    gauge!(QUEUE_DEPTH, "class" => class.as_str()).set(depth as f64);
+}
+
+/// Set the overall utilization gauge: total in-flight / capacity (sampler).
+pub fn set_utilization(utilization: f64) {
+    gauge!(UTILIZATION).set(utilization);
+}
+
+/// Set the queue-size-limit gauge for a class (sampler).
+pub fn set_queue_size_limit(class: Class, limit: usize) {
+    gauge!(QUEUE_SIZE_LIMIT, "class" => class.as_str()).set(limit as f64);
+}
+
+/// Set the normalized capacity-pressure gauge for a class (sampler).
+pub fn set_class_capacity_pressure(class: Class, pressure: f64) {
+    gauge!(CLASS_CAPACITY_PRESSURE, "class" => class.as_str()).set(pressure);
 }

--- a/model_gateway/src/middleware/scheduler/queue.rs
+++ b/model_gateway/src/middleware/scheduler/queue.rs
@@ -73,6 +73,9 @@ pub trait ClassQueue: Send + Sync {
     /// Current depth, including waiters whose cancel token has fired.
     fn depth(&self) -> usize;
 
+    /// Configured maximum depth (the queue-size limit), for metrics.
+    fn capacity(&self) -> usize;
+
     /// Drain any leading run of waiters whose cancel token has fired
     /// (clients that walked away while queued). One call removes every
     /// consecutive cancelled head in a single lock acquisition; the
@@ -115,6 +118,10 @@ impl ClassQueue for FifoClassQueue {
 
     fn depth(&self) -> usize {
         self.waiters.lock().len()
+    }
+
+    fn capacity(&self) -> usize {
+        self.max
     }
 
     fn drop_cancelled_head(&self) {

--- a/model_gateway/src/middleware/scheduler/state.rs
+++ b/model_gateway/src/middleware/scheduler/state.rs
@@ -1,7 +1,7 @@
 //! Startup wiring for the priority scheduler: builds the admission mode
 //! the route layer branches on.
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use tracing::{error, info};
 
@@ -13,6 +13,9 @@ use crate::{
     middleware::token_bucket::TokenBucket,
     worker::{CapacityTrackerSettings, WorkerCapacity, WorkerRegistry},
 };
+
+/// How often the metrics sampler refreshes the capacity / autoscaling gauges.
+const SAMPLER_INTERVAL: Duration = Duration::from_secs(5);
 
 /// State handed to `priority_admission_middleware` via `from_fn_with_state`.
 /// Cheap to clone (all `Arc`).
@@ -101,6 +104,7 @@ impl AdmissionMode {
         let scheduler = PriorityScheduler::new(&settings, worker_capacity.current())
             .map_err(|e| e.to_string())?;
         scheduler.spawn_dispatcher(worker_capacity.watch());
+        scheduler.spawn_sampler(SAMPLER_INTERVAL);
 
         let resolver: Arc<dyn TenantPolicyResolver> =
             Arc::new(StaticTenantPolicyResolver::from_settings(&settings));


### PR DESCRIPTION
## Description

### Problem

Autoscalers need point-in-time signals (utilization, per-class pressure) to drive scale up/down decisions. M5a added the operational counters; this adds the capacity/autoscaling gauges.

### Solution

A sampler task (5s interval, holds only a `Weak<Self>`) refreshes the gauges off the admission path, so the hot path stays counter-only. Stacked on #1579.

## Changes

- `spawn_sampler` + `sample_metrics` + `class_pressure` on `PriorityScheduler`; sampler spawned from `AdmissionMode::from_config` alongside the dispatcher.
- Gauges (design §9 capacity/autoscaling table):
  - `smg_scheduler_inflight{class}`, `smg_scheduler_queue_depth{class}`
  - `smg_scheduler_utilization` (Σ inflight / capacity)
  - `smg_scheduler_queue_size_limit{class}`
  - `smg_scheduler_class_capacity_pressure{class}` — `max(depth/limit, max(0, inflight−reserved)/max(1, capacity−Σ_higher_reserved))`, clamped 0.0–1.0
- `ClassQueue::capacity()` accessor for the queue-size-limit gauge.
- Unit test pinning the `class_pressure` formula (queue-dominates, slot-dominates, clamp, div-by-zero guard).

### Deferred (documented in the deviations doc)
- **Per-tenant gauges** (`scheduler_tenant_inflight`/`queued`): require threading a `tenant` field through every `InflightHandle` + `Waiter` + the `admit`/`register_inflight` signatures (~20 test call-site edits) for a secondary "noisy-tenant" metric. Deferred pending sign-off on the invasiveness.
- **`scheduler_queue_wait_p95_seconds`**: derivable from the `smg_scheduler_queue_wait_seconds` histogram via `histogram_quantile` in PromQL; the standalone sliding-window gauge isn't worth a bespoke estimator.

## Test Plan

- `cargo test -p smg --lib scheduler::` — 108 unit tests green (incl. the new `class_pressure` test).
- Gauge scrape assertions land with the M6 integration tests (the sampler needs a running runtime).

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added periodic background metrics sampling to the scheduler, collecting capacity, utilization, queue depth, inflight counts, and per-class pressure calculations for improved observability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->