### PR TITLE
fix(build): keep debug symbols in release binaries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,7 +128,7 @@ doc_lazy_continuation = "allow"
 opt-level = "z"     # Optimize for size
 lto = "fat"         # Full LTO for smaller binaries
 codegen-units = 1   # Better optimization, slower compile
-strip = true        # Strip debug symbols
+strip = false       # Keep symbols so production CPU profiles/flamegraphs are readable (#1575)
 
 [profile.ci]
 inherits = "release"


### PR DESCRIPTION
## Description

### Problem
`[profile.release]` sets `strip = true`, so production binaries ship without symbols. CPU profiles/flamegraphs are unreadable, making it impossible to locate hot spots under load (reported at ~2000 workers with >1s tail latencies). #1575

### Solution
Set `strip = false` in `[profile.release]` so release builds keep symbols. The reporter validated this locally — it let them capture a flamegraph and find #1576 (a 5× `GET /workers` speedup).

## Changes
- `Cargo.toml` `[profile.release]`: `strip = true` → `false`. Trade-off: larger binary in exchange for readable production profiles.

## Test Plan
- `cargo metadata` parses; change touches no source, so fmt/clippy/tests are unaffected.
- CI release build validates the profile; the resulting binary retains symbols (`perf`/`nm` resolve function names).

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes (no source changes)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (no source changes)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

Fixes #1575


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production build configuration to retain debugging symbols for enhanced profiling and diagnostic capabilities in production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->