### PR TITLE
docs(scheduler): document the priority scheduler

### DIFF
--- a/docs/concepts/reliability/index.md
+++ b/docs/concepts/reliability/index.md
@@ -7,5 +7,6 @@ SMG provides several mechanisms to ensure high availability and stability.
 *   **[Circuit Breakers](./circuit-breakers.md)**: Automatically detect failing workers and temporarily stop sending traffic to them until they recover.
 *   **[Retries & Backoff](./retries.md)**: Configurable retry logic with exponential backoff to handle transient network issues or worker busy states.
 *   **[Rate Limiting](./rate-limiting.md)**: Protect your workers from being overwhelmed by controlling the concurrency and request rate.
+*   **[Priority Scheduling](./priority-scheduling.md)**: Admit higher-priority traffic first with reserved slots, per-class queues, and TTFT-aware preemption.
 *   **[Health Checks](./health-checks.md)**: Active and passive monitoring of worker health to remove unhealthy nodes from the rotation.
 *   **[Graceful Shutdown](./graceful-shutdown.md)**: Ensure in-flight requests complete before the server stops.

--- a/docs/concepts/reliability/priority-scheduling.md
+++ b/docs/concepts/reliability/priority-scheduling.md
@@ -67,9 +67,10 @@ When no slot is immediately available, a request does not fail right away — it
 
 - If the queue is already at its configured depth, the request is rejected immediately (**429**).
 - If the request waits longer than the class's timeout, it is rejected (**408**).
-- If the client disconnects while waiting, the wait is abandoned (**499**).
 
-Higher classes have shorter queues and shorter timeouts (fail fast, the latency matters); lower classes have deeper queues and longer timeouts (wait patiently, throughput matters). The dispatcher drains queues in priority order — `system` → `interactive` → `default` → `bulk` — admitting one waiter per class per pass so a flood in one class cannot fully starve the drain of another.
+A client that disconnects *while queued* is not currently detected — its place is held until that timeout fires, because the cancel signal isn't yet wired to client disconnect at this stage. (The **499** code exists for this case but isn't emitted today.)
+
+Higher classes have shorter queues and shorter timeouts (fail fast, the latency matters); lower classes have deeper queues and longer timeouts (wait patiently, throughput matters). The dispatcher drains queues in **strict priority order** — `system` first, then `interactive`, `default`, and `bulk`, fully draining a higher tier before serving a lower one. A sustained higher-priority flood *will* hold off a lower tier; the [starvation guard](#starvation-promotion) below is what keeps that from lasting forever.
 
 ---
 
@@ -88,7 +89,7 @@ The TTFT boundary is the rule that makes this safe:
 A preempted request receives **503** with `Retry-After: 1` and an `X-SMG-Preempted: true` header, so clients and proxies can tell a preemption apart from an ordinary overload and retry promptly. If the victim's slot does not free within a short budget, the preemptor simply falls through to the queue — the cancel has already fired, so the slot frees shortly regardless.
 
 !!! warning "Preemption requires cancel-aware handlers"
-    A victim only actually unwinds if its request handler honors the scheduler's cancel signal. Until every long-running handler is wired to that signal, `can_preempt` is expected to stay off in practice even though the machinery is in place — a marked-but-unwound victim has its first data frame truncated rather than its upstream work stopped.
+    A victim only actually unwinds if its request handler honors the scheduler's cancel signal. Until every long-running handler is wired to that signal, `can_preempt` is expected to stay off in practice even though the machinery is in place — a marked-but-not-unwound victim has its first data frame truncated rather than its upstream work stopped.
 
 ---
 

--- a/docs/concepts/reliability/priority-scheduling.md
+++ b/docs/concepts/reliability/priority-scheduling.md
@@ -1,0 +1,170 @@
+---
+title: Priority Scheduling
+---
+
+# Priority Scheduling
+
+When the gateway is at capacity, a single global queue makes every request compete on first-come-first-served terms. A latency-sensitive chat completion ends up waiting behind whatever batch job happened to arrive first. The **priority scheduler** replaces that flat queue with a priority-aware admission layer: clients declare a class with the `x-smg-priority` header, the gateway admits higher classes first, reserves capacity for them, and — when it has to — preempts a lower-class request that has not yet started streaming.
+
+The priority scheduler is **opt-in**. When it is disabled (the default), the gateway keeps its [legacy concurrency-limit admission path](rate-limiting.md), so existing deployments see zero behavior change.
+
+---
+
+## A busy restaurant
+
+The mechanics are easier to hold in your head with an analogy:
+
+- **Tables are slots.** The dining room seats a fixed number of guests — the gateway's live backend capacity. A guest occupies a table for the length of their meal, the way a request holds a slot until its response finishes streaming.
+- **Guest tiers are priority classes.** Walk-ins, regulars, and VIPs get different treatment. SMG has four tiers: `system`, `interactive`, `default`, and `bulk`.
+- **The host is the scheduler.** The host decides who gets seated now, who waits by the door, and in what order the waiting line is called.
+- **Reserved tables are reserved slots.** A few tables are kept open for VIPs even when the room looks full, so a VIP rarely waits.
+- **Bumping a guest whose food has not arrived is preemption.** If a VIP walks in and every table is taken, the host may clear a table occupied by a walk-in *who has not been served yet* — nobody's dinner gets thrown away. A guest already eating is never bumped.
+- **Calling a long-waiting walk-in out of turn is starvation promotion.** If someone has waited by the door far too long, the host seats them next even though higher tiers are still in line, so they are not stuck forever.
+
+The rest of this page is the real mechanics behind that picture.
+
+---
+
+## Priority classes
+
+Every admitted request is assigned one of four classes. They are strictly ordered — higher classes win contention, get reservations, and may preempt lower ones.
+
+| Class | Rank | Intended traffic | Preempts lower classes? |
+|-------|------|------------------|-------------------------|
+| `system` | highest | Internal control-plane callers | Yes |
+| `interactive` | high | Latency-sensitive (chat completions, autocomplete) | Yes |
+| `default` | middle | Unlabeled traffic — what a request gets with no header | No |
+| `bulk` | lowest | Background / batch jobs | No |
+
+A request's class comes from the `x-smg-priority` header, then is **clamped down** to the maximum class the tenant is allowed to use. The header can only ever *lower* a request's class relative to the tenant cap — it can never promote a tenant above its ceiling. A free-tier tenant cannot escalate itself to `system` by setting a header. See the [reference page](../../reference/priority-scheduler.md) for the exact header contract.
+
+!!! note "`system` is for the control plane"
+    `system` is reserved for internal control-plane traffic. In practice the tenant clamp keeps external tenants out of it: their policy caps them below `system`, so no external request lands there regardless of the header they send.
+
+---
+
+## Slots and capacity
+
+The scheduler admits against a pool of **slots**. Total slot capacity is the gateway's live backend capacity — it is read from the worker fleet, not a static number, and the scheduler reacts when it changes (workers scaling up or down). A request holds exactly one slot from the moment it is admitted until its response body finishes draining (or it is preempted or the client disconnects), at which point the slot returns to the pool.
+
+When a slot frees, the scheduler's dispatcher wakes and tries to admit waiting requests, highest class first.
+
+### Reserved slots
+
+Each class can reserve a share of capacity. A reservation is a floor, not a fixed partition:
+
+- A higher class's **unused** reservation is held back from lower classes. If `interactive` has reserved slots it is not currently using, `bulk` and `default` cannot consume them — they stay available so an arriving `interactive` request is admitted immediately instead of queueing.
+- Once a higher class **actually uses** a reserved slot, the hold collapses one-for-one; the slot is simply in flight.
+- A class's own reservation never counts against its own headroom.
+
+This is why `system` and `interactive` ship with reservations by default while `default` and `bulk` reserve nothing — interactive traffic should almost never wait behind a batch burst. The sum of all reservations must fit under capacity; if it does not at startup, the scheduler refuses to build and the gateway falls back to legacy admission.
+
+---
+
+## Per-class queues
+
+When no slot is immediately available, a request does not fail right away — it joins a **per-class FIFO queue**. Each class has its own queue with its own depth limit and its own wait timeout:
+
+- If the queue is already at its configured depth, the request is rejected immediately (**429**).
+- If the request waits longer than the class's timeout, it is rejected (**408**).
+- If the client disconnects while waiting, the wait is abandoned (**499**).
+
+Higher classes have shorter queues and shorter timeouts (fail fast, the latency matters); lower classes have deeper queues and longer timeouts (wait patiently, throughput matters). The dispatcher drains queues in priority order — `system` → `interactive` → `default` → `bulk` — admitting one waiter per class per pass so a flood in one class cannot fully starve the drain of another.
+
+---
+
+## Preemption
+
+Reservations alone are not enough. If `bulk` fills its share *and* spills into unreserved capacity at the same moment an `interactive` request arrives, reservations leave a gap. Preemption closes it.
+
+When a preempt-capable request (`system` or `interactive` by default) finds no free slot and no reservation to draw on, the scheduler looks for a **victim**: a strictly-lower-class request that is still in flight **but has not yet emitted its first response byte**. If it finds one, it cancels that request and claims the freed slot.
+
+The TTFT boundary is the rule that makes this safe:
+
+- **Only pre-first-byte requests are eligible.** A request that has already streamed a byte to its client is *never* preempted — the user is already seeing output, and truncating it would be worse than making the higher-priority request wait. The handoff is decided by a single atomic compare-and-swap on the victim: whichever happens first wins, "first byte emitted" or "selected for preemption," and the loser backs off.
+- **Victim selection minimizes wasted work.** Among eligible victims the scheduler prefers the **lowest class** (cheapest to cancel) and, within that class, the **most-recently-admitted** request (the least upstream work thrown away).
+- **At most one victim per admission.** No cascading preemptions.
+
+A preempted request receives **503** with `Retry-After: 1` and an `X-SMG-Preempted: true` header, so clients and proxies can tell a preemption apart from an ordinary overload and retry promptly. If the victim's slot does not free within a short budget, the preemptor simply falls through to the queue — the cancel has already fired, so the slot frees shortly regardless.
+
+!!! warning "Preemption requires cancel-aware handlers"
+    A victim only actually unwinds if its request handler honors the scheduler's cancel signal. Until every long-running handler is wired to that signal, `can_preempt` is expected to stay off in practice even though the machinery is in place — a marked-but-unwound victim has its first data frame truncated rather than its upstream work stopped.
+
+---
+
+## TTFT protection
+
+The flip side of preemption is a guarantee for the request being served: **once you have produced a first byte, you are safe.** The scheduler tracks time-to-first-byte per in-flight request. The response-body wrapper marks the first *data* frame, and from that instant the request is no longer a preemption candidate. This bounds the blast radius of a priority surge — a higher-priority spike can reclaim slots from work that has not visibly started, but it can never tear down responses already streaming to users.
+
+---
+
+## Starvation promotion
+
+Strict priority ordering risks starving the lowest classes: if higher classes stay busy, a `bulk` request could wait at the head of its queue indefinitely. To prevent that, each class has a **starvation threshold**. When the request at the head of a queue has waited longer than its class's threshold, the dispatcher promotes it out of normal priority order and admits it next — even letting it consume a slot that a higher class had reserved but is not using.
+
+The dispatcher checks for starved waiters **lowest priority first** (the classes most at risk), before it does its normal high-to-low drain. The tradeoff is deliberate: avoiding indefinite starvation is worth occasionally lending out a reserved-but-idle slot.
+
+---
+
+## Fallback to legacy admission
+
+The priority scheduler is designed to **fail safe**. It only takes over when it is both enabled and able to start cleanly:
+
+- If the scheduler is **disabled** (the default), the gateway wires the legacy concurrency-limit middleware — no scheduler is even constructed.
+- If the scheduler is **enabled but misconfigured** — unparseable YAML, or reservations that sum to more than the live capacity — the gateway logs the failure at `ERROR` and **falls back to legacy admission** rather than aborting startup. A broken scheduler config must never take the data plane down.
+
+In both cases the request path is the familiar token-bucket concurrency limiter described in [Rate Limiting](rate-limiting.md). The admission path is chosen once at startup.
+
+---
+
+## Observability
+
+The scheduler emits Prometheus metrics for admission outcomes, queue waits, preemptions, priority clamps, and per-class capacity pressure. These are the signals you watch to size reservations and queue depths, and to detect clients mis-setting the priority header. The full list is in the [Metrics Reference](../../reference/metrics.md).
+
+---
+
+## What's Next?
+
+<div class="grid" markdown>
+
+<div class="card" markdown>
+
+### :material-file-document-outline: Priority Scheduler Reference
+
+The exact header values, response codes, and configuration knobs.
+
+[Priority Scheduler Reference →](../../reference/priority-scheduler.md)
+
+</div>
+
+<div class="card" markdown>
+
+### :material-tray-full: Rate Limiting
+
+The legacy concurrency-limit path the scheduler falls back to.
+
+[Rate Limiting →](rate-limiting.md)
+
+</div>
+
+<div class="card" markdown>
+
+### :material-electric-switch: Circuit Breakers
+
+Isolate failing workers to prevent cascade failures.
+
+[Circuit Breakers →](circuit-breakers.md)
+
+</div>
+
+<div class="card" markdown>
+
+### :material-chart-box: Metrics Reference
+
+Scheduler admission, queue, and preemption metrics.
+
+[Metrics Reference →](../../reference/metrics.md)
+
+</div>
+
+</div>

--- a/docs/reference/priority-scheduler.md
+++ b/docs/reference/priority-scheduler.md
@@ -73,7 +73,7 @@ smg \
 | `--priority-scheduler-enabled` | `false` | Master switch. When unset, the legacy concurrency-limit middleware stays wired and no scheduler is constructed. |
 | `--priority-scheduler-default-max-class` | `default` | Maximum class for tenants not listed in the YAML (`system` \| `interactive` \| `default` \| `bulk`). Parsed with the same rules as the header — an unknown value falls back to `default`. |
 | `--priority-scheduler-config` | unset | Path to the optional priority-scheduler YAML (per-class overrides + per-tenant policy). Absent → built-in defaults and an empty tenant policy map. |
-| `--priority-scheduler-tenant-metric-top-n` | `32` | Cap on per-tenant scheduler metric label cardinality. Tenants past the top N are bucketed under `tenant="other"`. |
+| `--priority-scheduler-tenant-metric-top-n` | `32` | Intended cap on per-tenant metric label cardinality. **Not yet enforced** — the value is stored but no top-N bucketing is applied today; per-tenant counters currently intern the raw tenant. |
 
 !!! warning "Fail-safe startup"
     If the scheduler is enabled but cannot start — unparseable YAML, or class reservations that sum to more than the live backend capacity — the gateway logs at `ERROR` and **falls back to legacy admission** instead of aborting. It does not take the data plane down.

--- a/docs/reference/priority-scheduler.md
+++ b/docs/reference/priority-scheduler.md
@@ -1,0 +1,220 @@
+---
+title: Priority Scheduler Reference
+---
+
+# Priority Scheduler Reference
+
+Precise contract for the priority-aware admission scheduler: the request header clients send, the response codes the gateway returns, and every configuration knob with its exact name and default. For how it works conceptually, see [Priority Scheduling](../concepts/reliability/priority-scheduling.md).
+
+The scheduler is **disabled by default**. When off, the gateway uses its [legacy concurrency-limit admission path](../concepts/reliability/rate-limiting.md).
+
+---
+
+## Request header: `x-smg-priority`
+
+Clients request a priority class with the `x-smg-priority` request header.
+
+| Property | Behavior |
+|----------|----------|
+| **Header name** | `x-smg-priority` |
+| **Values** | `system`, `interactive`, `default`, `bulk` |
+| **Case** | Case-insensitive (`Bulk`, `INTERACTIVE`, `SyStEm` all parse). Surrounding whitespace is trimmed. |
+| **Missing header** | Treated as `default`. |
+| **Unknown value** | Any unrecognized value (including the empty string) silently degrades to `default` — admission never fails because of a typo in this header. Counted under `smg_scheduler_unknown_priority_value_total`. |
+
+### Tenant clamp
+
+The header chooses a class; the **tenant's configured maximum class caps it**. The effective class is:
+
+```text
+effective = min(requested_class, tenant_max_class)
+```
+
+- The clamp only ever moves a request **down**. The header can never promote a request above the tenant's ceiling.
+- A tenant whose `max_class` is `default` that sends `x-smg-priority: system` is admitted as `default`.
+- A clamp (effective class below requested) is counted under `smg_scheduler_clamp_total`.
+
+A tenant's `max_class` comes from the per-tenant policy in the YAML config, or from the gateway-wide default (`--priority-scheduler-default-max-class`) for tenants not listed. See [Tenant policy](#tenant-policy).
+
+---
+
+## Response codes
+
+The scheduler surfaces admission and preemption outcomes as HTTP status codes. Each rejection also carries the gateway's standard JSON error body and `X-SMG-Error-Code` header.
+
+| Status | Condition | `X-SMG-Error-Code` | Extra headers |
+|--------|-----------|--------------------|---------------|
+| **503** Service Unavailable | **Preempted** — admitted, then cancelled before its first byte to make room for a higher-priority request | `scheduler_preempted` | `X-SMG-Preempted: true`, `Retry-After: 1` |
+| **429** Too Many Requests | **Queue full** — the request's per-class queue is at its configured depth | `scheduler_queue_full` | — |
+| **408** Request Timeout | **Queue timeout** — the request waited longer than its class's `queue_timeout` | `scheduler_queue_timeout` | — |
+| **499** Client Closed Request | **Client gone** — the client disconnected before admission completed (nginx convention; never actually read) | `scheduler_client_cancelled` | — |
+
+!!! tip "Telling a preemption apart from an overload"
+    Both preemption and a genuinely overloaded backend can return `503`. The `X-SMG-Preempted: true` header is what distinguishes a preemption. A preempted request is safe to retry immediately, which is why it carries `Retry-After: 1`.
+
+---
+
+## Enabling the scheduler
+
+The scheduler is controlled by CLI flags (also settable in the config file). Per-class tuning and per-tenant policy live in a separate optional YAML file.
+
+```bash
+smg \
+  --worker-urls http://w1:8000 http://w2:8000 \
+  --priority-scheduler-enabled \
+  --priority-scheduler-default-max-class interactive \
+  --priority-scheduler-config /etc/smg/priority.yaml
+```
+
+### CLI flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--priority-scheduler-enabled` | `false` | Master switch. When unset, the legacy concurrency-limit middleware stays wired and no scheduler is constructed. |
+| `--priority-scheduler-default-max-class` | `default` | Maximum class for tenants not listed in the YAML (`system` \| `interactive` \| `default` \| `bulk`). Parsed with the same rules as the header — an unknown value falls back to `default`. |
+| `--priority-scheduler-config` | unset | Path to the optional priority-scheduler YAML (per-class overrides + per-tenant policy). Absent → built-in defaults and an empty tenant policy map. |
+| `--priority-scheduler-tenant-metric-top-n` | `32` | Cap on per-tenant scheduler metric label cardinality. Tenants past the top N are bucketed under `tenant="other"`. |
+
+!!! warning "Fail-safe startup"
+    If the scheduler is enabled but cannot start — unparseable YAML, or class reservations that sum to more than the live backend capacity — the gateway logs at `ERROR` and **falls back to legacy admission** instead of aborting. It does not take the data plane down.
+
+---
+
+## YAML configuration
+
+The file referenced by `--priority-scheduler-config` has two top-level maps, both optional. An empty or absent file means "use built-in defaults for every class, no per-tenant overrides."
+
+```yaml
+# Per-class tuning. Any class you omit keeps its built-in default.
+classes:
+  interactive:
+    reserved: 128
+    queue_size: 256
+    queue_timeout_secs: 30
+    starvation_threshold_secs: 5
+    can_preempt: true
+  bulk:
+    reserved: 0
+    queue_size: 1024
+    queue_timeout_secs: 300
+    starvation_threshold_secs: 120
+    can_preempt: false
+
+# Per-tenant priority ceiling. Tenants not listed use
+# --priority-scheduler-default-max-class.
+tenant_policies:
+  "auth:acme":
+    max_class: interactive
+  "auth:internal-cron":
+    max_class: system
+```
+
+Class keys and `max_class` values are lowercase: `system`, `interactive`, `default`, `bulk`. An unknown class name in the YAML is a parse error (which triggers the fail-safe fallback above), unlike the lenient request header.
+
+### Per-class knobs
+
+Each entry under `classes` accepts the following fields. All are per-class.
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `reserved` | integer (slots) | Slots reserved for this class. A higher class's *unused* reservation is held back from lower classes; a class's own reservation never reduces its own headroom. The sum across all classes must fit under live capacity. |
+| `queue_size` | integer | Per-class queue depth limit. A request that arrives when the queue is full is rejected with **429**. |
+| `queue_timeout_secs` | integer (seconds) | How long a queued request waits before it is rejected with **408**. Must be `> 0`. |
+| `starvation_threshold_secs` | integer (seconds) | Head-of-queue age past which the dispatcher promotes a waiter out of normal priority order (and lets it use a reserved-but-unused slot) to avoid starvation. Must be `> 0`. |
+| `can_preempt` | boolean | Whether admissions in this class may preempt a lower-class in-flight request that has not yet emitted its first byte. |
+
+### Built-in defaults
+
+These apply to any class with no YAML override.
+
+| Class | `reserved` | `queue_size` | `queue_timeout_secs` | `starvation_threshold_secs` | `can_preempt` |
+|-------|-----------:|-------------:|---------------------:|----------------------------:|:-------------:|
+| `system` | 32 | 64 | 30 | 5 | `true` |
+| `interactive` | 128 | 256 | 30 | 5 | `true` |
+| `default` | 0 | 512 | 60 | 30 | `false` |
+| `bulk` | 0 | 1024 | 300 | 120 | `false` |
+
+Higher classes fail fast (short queues, short timeouts) and reserve capacity; lower classes wait patiently (deep queues, long timeouts) and reserve nothing.
+
+### Validation
+
+At startup the scheduler validates:
+
+- `queue_timeout_secs > 0` for every class (else startup fails for that class).
+- `starvation_threshold_secs > 0` for every class.
+- The sum of all `reserved` values must not exceed the live backend capacity. On a capacity *shrink* that would otherwise break this invariant, the scheduler scales reservations down proportionally rather than locking itself out.
+
+Any validation failure triggers the [fail-safe fallback to legacy admission](#enabling-the-scheduler).
+
+---
+
+## Tenant policy
+
+A tenant's priority ceiling is resolved per request:
+
+1. If the tenant key appears in `tenant_policies`, its `max_class` is used.
+2. Otherwise the gateway-wide `--priority-scheduler-default-max-class` applies.
+
+The resolved `max_class` is the upper bound for the [tenant clamp](#tenant-clamp). Tenant keys are the same keys the gateway uses elsewhere for tenancy (for example `auth:acme`).
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `max_class` | `system` \| `interactive` \| `default` \| `bulk` | Highest class this tenant may be admitted under. A request's effective class is `min(header_class, max_class)`. |
+
+---
+
+## Metrics
+
+The scheduler exposes these Prometheus metrics (see the [Metrics Reference](metrics.md) for the full catalog):
+
+| Metric | Type | Key labels | Use |
+|--------|------|------------|-----|
+| `smg_scheduler_admit_total` | Counter | `class`, `outcome` | Admission outcomes (`admitted`, `rejected_queue_full`, `rejected_queue_timeout`, `preempted`, `client_cancelled`). |
+| `smg_scheduler_queue_wait_seconds` | Histogram | `class` | Time spent queued before admission, timeout, or cancel. |
+| `smg_scheduler_preemption_total` | Counter | `victim_class`, `by_class` | Successful preemptions. Authoritative preemption count. |
+| `smg_scheduler_clamp_total` | Counter | `tenant`, `requested_class`, `effective_class` | Requests clamped below the class they asked for. |
+| `smg_scheduler_unknown_priority_value_total` | Counter | `tenant` | Requests with an unrecognized `x-smg-priority` value. |
+| `smg_scheduler_starvation_promotion_total` | Counter | `class` | Waiters admitted via the starvation override. |
+| `smg_scheduler_inflight` | Gauge | `class` | Current in-flight requests per class. |
+| `smg_scheduler_queue_depth` | Gauge | `class` | Current queued waiters per class. |
+| `smg_scheduler_queue_size_limit` | Gauge | `class` | Configured queue limit per class. |
+| `smg_scheduler_utilization` | Gauge | — | Total in-flight divided by backend capacity. |
+| `smg_scheduler_class_capacity_pressure` | Gauge | `class` | Normalized 0.0–1.0 pressure (worse of queue and slot pressure). |
+
+---
+
+## See also
+
+<div class="grid" markdown>
+
+<div class="card" markdown>
+
+### :material-priority-high: Priority Scheduling Concept
+
+How slots, reservations, preemption, and starvation promotion fit together.
+
+[Priority Scheduling →](../concepts/reliability/priority-scheduling.md)
+
+</div>
+
+<div class="card" markdown>
+
+### :material-cog: Configuration Reference
+
+All gateway CLI flags and configuration options.
+
+[Configuration →](configuration.md)
+
+</div>
+
+<div class="card" markdown>
+
+### :material-chart-box: Metrics Reference
+
+Full catalog of Prometheus metrics.
+
+[Metrics →](metrics.md)
+
+</div>
+
+</div>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -178,6 +178,7 @@ nav:
       - Reliability:
           - Circuit Breakers: concepts/reliability/circuit-breakers.md
           - Rate Limiting: concepts/reliability/rate-limiting.md
+          - Priority Scheduling: concepts/reliability/priority-scheduling.md
           - Retries: concepts/reliability/retries.md
           - Health Checks: concepts/reliability/health-checks.md
           - Graceful Shutdown: concepts/reliability/graceful-shutdown.md
@@ -194,6 +195,7 @@ nav:
           - Admin API: reference/api/admin.md
           - Gateway Extensions: reference/api/extensions.md
       - Configuration: reference/configuration.md
+      - Priority Scheduler: reference/priority-scheduler.md
       - Metrics: reference/metrics.md
       - Internal MCP Servers: reference/mcp-internal-servers.md
   - Contributing:


### PR DESCRIPTION
## Description

### Problem
The priority scheduler (M1–M6) shipped with no user-facing docs — no reference for the `x-smg-priority` header, response codes, or config knobs.

### Solution
Add a concept page (how it works) and a reference page (exact contract), wired into the mkdocs nav.

## Changes
- `docs/concepts/reliability/priority-scheduling.md` (new) — classes, slots/reservations, per-class queues, preemption + TTFT protection, starvation promotion, fail-safe fallback.
- `docs/reference/priority-scheduler.md` (new) — `x-smg-priority` + tenant clamp, response codes (503/429/408/499 + headers), CLI flags, YAML schema, built-in defaults, metrics.
- Nav: both pages registered under Reliability / Reference.

## Test Plan
- Docs-only. Values cross-checked against `config.rs` / `error.rs` / `metrics.rs`. `mkdocs build --strict` runs in CI.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes (no code changes)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (no code changes)
- [x] Documentation updated

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Priority Scheduling concept page explaining an opt-in, priority-aware admission layer with multiple classes, slot-based capacity, per-class queues, preemption behavior, starvation prevention, and fallback to legacy admission.
  * Added Priority Scheduler reference detailing request outcomes, configuration options, startup/fail-safe behavior, tenant limits, and exposed metrics; navigation updated accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->