### PR TITLE
test(scheduler): add admission micro-benchmark and concurrent load harness

### DIFF
--- a/model_gateway/Cargo.toml
+++ b/model_gateway/Cargo.toml
@@ -205,5 +205,15 @@ name = "workers_endpoint"
 harness = false
 path = "benches/workers_endpoint.rs"
 
+[[bench]]
+name = "scheduler_admission"
+harness = false
+path = "benches/scheduler_admission.rs"
+
+[[bench]]
+name = "scheduler_load"
+harness = false
+path = "benches/scheduler_load.rs"
+
 [lints]
 workspace = true

--- a/model_gateway/benches/scheduler_admission.rs
+++ b/model_gateway/benches/scheduler_admission.rs
@@ -42,7 +42,7 @@ use smg::middleware::{
     TokenBucket,
 };
 use smg_auth::RequestId;
-use tokio::runtime::Runtime;
+use tokio::runtime::Builder;
 use tokio_util::sync::CancellationToken;
 
 /// Build settings with `reserved = 0` on every class (so admission is
@@ -99,7 +99,7 @@ fn bench_fast_path_admit(c: &mut Criterion) {
     // (b) Real entry point, async, driven through a current-thread runtime.
     // Difference vs (a) is the cost of entering the future + the fast-path
     // branch checks in `admit`.
-    let rt = Runtime::new().unwrap();
+    let rt = Builder::new_current_thread().enable_all().build().unwrap();
     group.bench_function("admit_async", |b| {
         b.iter(|| {
             rt.block_on(async {
@@ -145,7 +145,7 @@ fn bench_admit_at_capacity(c: &mut Criterion) {
         );
     }
 
-    let rt = Runtime::new().unwrap();
+    let rt = Builder::new_current_thread().enable_all().build().unwrap();
     let request_id = rid("bench-at-capacity");
     group.bench_function("queue_full_reject", |b| {
         b.iter(|| {
@@ -193,7 +193,7 @@ fn bench_preemption_victim_search(c: &mut Criterion) {
             held.push(permit);
         }
 
-        let rt = Runtime::new().unwrap();
+        let rt = Builder::new_current_thread().enable_all().build().unwrap();
         let request_id = rid("preemptor");
         group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, _| {
             b.iter(|| {
@@ -244,7 +244,7 @@ fn bench_baseline_token_bucket(c: &mut Criterion) {
     // block_on-wrapped: same work under the same per-iteration runtime
     // overhead as `fast_path_admit/admit_async`, for an apples-to-apples
     // delta.
-    let rt = Runtime::new().unwrap();
+    let rt = Builder::new_current_thread().enable_all().build().unwrap();
     group.bench_function("try_acquire_return_block_on", |b| {
         b.iter(|| {
             rt.block_on(async {

--- a/model_gateway/benches/scheduler_admission.rs
+++ b/model_gateway/benches/scheduler_admission.rs
@@ -1,0 +1,269 @@
+//! Admission-path microbenchmarks for the priority scheduler.
+//!
+//! The priority-admission scheduler sits on the request hot path: every
+//! inbound request calls [`PriorityScheduler::admit`] before it reaches a
+//! backend. This bench quantifies that per-request cost and contrasts it
+//! with the legacy [`TokenBucket`] limiter it replaces.
+//!
+//! Groups:
+//!
+//! - **fast_path_admit** — the number that matters. Ample capacity, a slot
+//!   is always free, so `admit` takes the synchronous fast path: a packed
+//!   CAS on the slot pool, an `Arc` clone, an `InflightHandle` alloc, and a
+//!   registry insert. Each iteration drops the permit so the next starts
+//!   from an identical state (slot released, registry empty). Two flavors:
+//!     - `acquire_inflight_sync`: the synchronous core, no runtime — the
+//!       purest admission cost.
+//!     - `admit_async`: the real entry point as production calls it, driven
+//!       through a `current_thread` runtime with `block_on`.
+//! - **admit_at_capacity** — scheduler saturated, target class has a
+//!   zero-depth queue, so `admit` fails the fast path and the immediate
+//!   enqueue rejects with `QueueFull`. The rejection hot path (a 429).
+//! - **preemption_victim_search** — capacity full of N pre-marked
+//!   (post-TTFT, non-preemptible) low-class inflights. A preempt-capable
+//!   admission scans the whole inflight registry looking for a victim,
+//!   finds none, and falls through to a `QueueFull` rejection. Isolates the
+//!   O(N) registry scan cost.
+//! - **baseline_token_bucket** — `TokenBucket::try_acquire(1.0)` +
+//!   `return_tokens(1.0)`, the thing being replaced. Measured both
+//!   sync-direct and wrapped in `block_on`, so the per-iteration runtime
+//!   overhead can be subtracted when comparing against `admit_async`.
+
+#![expect(clippy::unwrap_used, clippy::expect_used)]
+
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use smg::middleware::{
+    scheduler::{
+        AdmitOutcome, Class, ClassConfig, PriorityScheduler, PrioritySchedulerYaml,
+        RejectionReason, SchedulerPermit, SchedulerSettings,
+    },
+    TokenBucket,
+};
+use smg_auth::RequestId;
+use tokio::runtime::Runtime;
+use tokio_util::sync::CancellationToken;
+
+/// Build settings with `reserved = 0` on every class (so admission is
+/// purely capacity-bound and small capacities don't trip the
+/// reserved-vs-capacity guard) and the given per-class `queue_size`.
+/// Other per-class fields stay at their built-in defaults.
+fn settings(queue_size: u32) -> SchedulerSettings {
+    use std::collections::HashMap;
+
+    let mut classes = HashMap::new();
+    for c in Class::ALL {
+        let mut cfg = ClassConfig::default_for(c);
+        cfg.reserved = 0;
+        cfg.queue_size = queue_size;
+        classes.insert(c, cfg);
+    }
+    let yaml = PrioritySchedulerYaml {
+        classes,
+        tenant_policies: HashMap::new(),
+    };
+    SchedulerSettings::from_cli_and_yaml(true, Class::Default, 32, Some(&yaml)).unwrap()
+}
+
+fn rid(s: &str) -> RequestId {
+    RequestId(s.to_string())
+}
+
+/// fast_path_admit: the per-request admission hot path with a slot always
+/// available.
+fn bench_fast_path_admit(c: &mut Criterion) {
+    let mut group = c.benchmark_group("fast_path_admit");
+
+    // Ample capacity, generous queue (never reached on this path).
+    let scheduler = PriorityScheduler::new(&settings(512), 4096).unwrap();
+    // Stable request id reused every iteration. `admit`/`acquire_inflight`
+    // take ownership, so the clone (a `String` clone) is part of the
+    // measured per-request cost — exactly what production pays, since each
+    // real request carries a distinct id.
+    let request_id = rid("bench-fast-path");
+
+    // (a) Synchronous core: try_acquire CAS + registry insert + handle
+    // alloc, then drop releases the slot and clears the registry. No async
+    // machinery — the purest admission cost.
+    group.bench_function("acquire_inflight_sync", |b| {
+        b.iter(|| {
+            let permit = scheduler
+                .acquire_inflight(black_box(Class::Default), black_box(request_id.clone()))
+                .expect("slot available");
+            black_box(&permit);
+            // Drop here releases the slot for the next iteration.
+        });
+    });
+
+    // (b) Real entry point, async, driven through a current-thread runtime.
+    // Difference vs (a) is the cost of entering the future + the fast-path
+    // branch checks in `admit`.
+    let rt = Runtime::new().unwrap();
+    group.bench_function("admit_async", |b| {
+        b.iter(|| {
+            rt.block_on(async {
+                let outcome = scheduler
+                    .admit(
+                        black_box(Class::Default),
+                        black_box(request_id.clone()),
+                        CancellationToken::new(),
+                    )
+                    .await;
+                // Ample capacity → always Admitted. Hold then drop the
+                // outcome (and its permit) so the slot frees for the next
+                // iteration. `assert!` keeps the path honest without the
+                // (deny-listed) `unreachable!`.
+                assert!(matches!(outcome, AdmitOutcome::Admitted(_)));
+                black_box(outcome);
+            });
+        });
+    });
+
+    group.finish();
+}
+
+/// admit_at_capacity: scheduler saturated, queue depth 0 → immediate
+/// `QueueFull` rejection. Uses `Class::Default` (can_preempt = false) so the
+/// preemption block is skipped and the path is purely fast-path-miss →
+/// enqueue-reject.
+fn bench_admit_at_capacity(c: &mut Criterion) {
+    let mut group = c.benchmark_group("admit_at_capacity");
+
+    const CAP: u16 = 256;
+    // queue_size = 0 so the slow-path enqueue rejects instantly with no
+    // queue contention and no awaiting.
+    let scheduler = PriorityScheduler::new(&settings(0), CAP).unwrap();
+
+    // Saturate every slot with held Default permits.
+    let mut held: Vec<SchedulerPermit> = Vec::with_capacity(CAP as usize);
+    for i in 0..CAP {
+        held.push(
+            scheduler
+                .acquire_inflight(Class::Default, rid(&format!("held-{i}")))
+                .expect("under capacity"),
+        );
+    }
+
+    let rt = Runtime::new().unwrap();
+    let request_id = rid("bench-at-capacity");
+    group.bench_function("queue_full_reject", |b| {
+        b.iter(|| {
+            rt.block_on(async {
+                let outcome = scheduler
+                    .admit(
+                        black_box(Class::Default),
+                        black_box(request_id.clone()),
+                        CancellationToken::new(),
+                    )
+                    .await;
+                assert!(matches!(
+                    outcome,
+                    AdmitOutcome::Rejected(RejectionReason::QueueFull)
+                ));
+            });
+        });
+    });
+
+    drop(held);
+    group.finish();
+}
+
+/// preemption_victim_search: with N inflight low-class requests, all marked
+/// post-TTFT (non-preemptible), a preempt-capable admission scans the full
+/// registry, finds no eligible victim, and rejects with `QueueFull`
+/// (queue_size = 0). Isolates the O(N) `find_preemption_victim` scan.
+fn bench_preemption_victim_search(c: &mut Criterion) {
+    let mut group = c.benchmark_group("preemption_victim_search");
+
+    for &n in &[64usize, 256, 1024] {
+        let cap = n as u16;
+        let scheduler = PriorityScheduler::new(&settings(0), cap).unwrap();
+
+        // Fill capacity with Bulk inflights and mark each past TTFT so it is
+        // present in the registry but NOT a valid preemption victim. The
+        // search must therefore iterate all N and reject every one.
+        let mut held: Vec<SchedulerPermit> = Vec::with_capacity(n);
+        for i in 0..n {
+            let permit = scheduler
+                .acquire_inflight(Class::Bulk, rid(&format!("victim-{i}")))
+                .expect("under capacity");
+            // try_mark_first_byte(1) → is_preemptible() == false.
+            assert!(permit.handle().try_mark_first_byte(1));
+            held.push(permit);
+        }
+
+        let rt = Runtime::new().unwrap();
+        let request_id = rid("preemptor");
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, _| {
+            b.iter(|| {
+                rt.block_on(async {
+                    // Interactive can_preempt = true → runs the victim scan.
+                    // No victim is eligible → falls through to enqueue →
+                    // QueueFull (queue_size = 0).
+                    let outcome = scheduler
+                        .admit(
+                            black_box(Class::Interactive),
+                            black_box(request_id.clone()),
+                            CancellationToken::new(),
+                        )
+                        .await;
+                    assert!(matches!(
+                        outcome,
+                        AdmitOutcome::Rejected(RejectionReason::QueueFull)
+                    ));
+                });
+            });
+        });
+
+        drop(held);
+    }
+
+    group.finish();
+}
+
+/// baseline_token_bucket: the legacy limiter being replaced. A successful
+/// `try_acquire(1.0)` plus the matching `return_tokens(1.0)` — the analogue
+/// of one admit + one permit release. Measured sync-direct and through
+/// `block_on` so the runtime overhead in `admit_async` can be subtracted.
+fn bench_baseline_token_bucket(c: &mut Criterion) {
+    let mut group = c.benchmark_group("baseline_token_bucket");
+
+    // Pure concurrency limiter: large capacity, refill_rate = 0 (tokens only
+    // return via return_tokens), mirroring the scheduler's slot semantics.
+    let bucket = TokenBucket::new(4096, 0);
+
+    // Sync-direct: the actual cost of the limiter's acquire+release.
+    group.bench_function("try_acquire_return_sync", |b| {
+        b.iter(|| {
+            black_box(bucket.try_acquire(black_box(1.0))).unwrap();
+            bucket.return_tokens(black_box(1.0));
+        });
+    });
+
+    // block_on-wrapped: same work under the same per-iteration runtime
+    // overhead as `fast_path_admit/admit_async`, for an apples-to-apples
+    // delta.
+    let rt = Runtime::new().unwrap();
+    group.bench_function("try_acquire_return_block_on", |b| {
+        b.iter(|| {
+            rt.block_on(async {
+                black_box(bucket.try_acquire(black_box(1.0))).unwrap();
+                bucket.return_tokens(black_box(1.0));
+            });
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default();
+    targets =
+        bench_fast_path_admit,
+        bench_admit_at_capacity,
+        bench_preemption_victim_search,
+        bench_baseline_token_bucket,
+}
+criterion_main!(benches);

--- a/model_gateway/benches/scheduler_load.rs
+++ b/model_gateway/benches/scheduler_load.rs
@@ -154,10 +154,15 @@ async fn run_load(
 
                 match outcome {
                     AdmitOutcome::Admitted(permit) => {
-                        st.admitted += 1;
-                        st.lat[class as usize].push(lat);
+                        // `admitted` and `preempted` are kept mutually exclusive: a
+                        // request bumped during its pre-TTFT window counts ONLY as
+                        // preempted (and its latency is not recorded as a successful
+                        // admit), so the outcome totals and per-class latencies stay
+                        // accurate under saturation.
                         if service.is_zero() {
-                            // pure-contention mode: release immediately.
+                            // pure-contention mode: no preemption window.
+                            st.admitted += 1;
+                            st.lat[class as usize].push(lat);
                             drop(permit);
                         } else {
                             // Pre-TTFT window: preemptible. Race reaching the
@@ -165,10 +170,17 @@ async fn run_load(
                             let cancel = permit.cancel_token();
                             tokio::select! {
                                 () = tokio::time::sleep(ttft) => {
-                                    let _ = permit.try_mark_first_byte(); // now protected
-                                    let rest = service.saturating_sub(ttft);
-                                    if !rest.is_zero() {
-                                        tokio::time::sleep(rest).await;
+                                    if permit.try_mark_first_byte() {
+                                        // Reached first byte → protected; runs to completion.
+                                        st.admitted += 1;
+                                        st.lat[class as usize].push(lat);
+                                        let rest = service.saturating_sub(ttft);
+                                        if !rest.is_zero() {
+                                            tokio::time::sleep(rest).await;
+                                        }
+                                    } else {
+                                        // Scheduler won the preemption race right at the wire.
+                                        st.preempted += 1;
                                     }
                                 }
                                 () = cancel.cancelled() => {

--- a/model_gateway/benches/scheduler_load.rs
+++ b/model_gateway/benches/scheduler_load.rs
@@ -1,0 +1,314 @@
+//! End-to-end concurrent **load** benchmark for the priority scheduler.
+//!
+//! Unlike `scheduler_admission.rs` (a single-threaded micro-benchmark of one
+//! `admit()` call), this drives the *real* [`PriorityScheduler`] — with its
+//! dispatcher running so queued waiters are actually admitted on slot release —
+//! under genuine multi-threaded concurrency, modeling a realistic request
+//! lifecycle:
+//!
+//! ```text
+//!   admit() ──▶ pre-TTFT window (preemptible) ──▶ first byte ──▶ service ──▶ release
+//!                     │ preempted (cancel fires)                  │
+//!                     └──────────── release ───────────────────────
+//! ```
+//!
+//! Two views:
+//!
+//! - **contended_throughput** — capacity is ample so every request is admitted;
+//!   `K` concurrent tasks loop `admit → release` with no service hold. This is
+//!   the scheduler's sustained ops/sec under real lock/atomic contention (the
+//!   slot-pool CAS, the per-class queue mutex, the inflight-registry rwlock) as
+//!   `K` rises. Answers "is the scheduler itself fast under concurrency?".
+//!
+//! - **saturated_load** — capacity is fixed and offered concurrency
+//!   oversubscribes it, with a modeled per-request service time so queues
+//!   actually form. Prints a per-class admit-latency (p50/p99) + outcome report
+//!   (admitted / 429 queue-full / 503 preempted), then times sustained
+//!   throughput. Shows the scheduler *doing its job* under load.
+
+#![expect(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::disallowed_methods,
+    clippy::print_stderr,
+    reason = "benchmark harness: unwrap/expect on known-good setup; tokio::spawn is the point; eprintln is the report output"
+)]
+
+use std::{
+    sync::{
+        atomic::{AtomicI64, AtomicU64, Ordering},
+        Arc, Once,
+    },
+    time::{Duration, Instant},
+};
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use smg::middleware::scheduler::{
+    AdmitOutcome, Class, ClassConfig, PriorityScheduler, PrioritySchedulerYaml, RejectionReason,
+    SchedulerSettings,
+};
+use smg_auth::RequestId;
+use tokio::{runtime::Runtime, sync::watch};
+use tokio_util::sync::CancellationToken;
+
+/// Realistic settings: built-in per-class defaults (reservations,
+/// preemption, queue depths) left intact, so the load test exercises the
+/// real reservation + preemption behavior — not a flattened config.
+fn settings() -> SchedulerSettings {
+    use std::collections::HashMap;
+
+    let mut classes = HashMap::new();
+    for c in Class::ALL {
+        classes.insert(c, ClassConfig::default_for(c));
+    }
+    let yaml = PrioritySchedulerYaml {
+        classes,
+        tenant_policies: HashMap::new(),
+    };
+    SchedulerSettings::from_cli_and_yaml(true, Class::Default, 32, Some(&yaml)).unwrap()
+}
+
+/// Build a scheduler with its dispatcher running at a fixed capacity. The
+/// returned `watch::Sender` must be kept alive for the dispatcher to live.
+fn build_running(capacity: u16) -> (Arc<PriorityScheduler>, watch::Sender<u16>) {
+    let scheduler = PriorityScheduler::new(&settings(), capacity).expect("valid settings");
+    let (cap_tx, cap_rx) = watch::channel(capacity);
+    scheduler.spawn_dispatcher(cap_rx);
+    (scheduler, cap_tx)
+}
+
+/// Weighted request class mix, ~ a real gateway: mostly `default`, a strong
+/// `interactive` minority, a little `bulk` and `system`.
+fn pick_class(seq: u64) -> Class {
+    match seq % 20 {
+        0..=11 => Class::Default,      // 60%
+        12..=16 => Class::Interactive, // 25%
+        17..=18 => Class::Bulk,        // 10%
+        _ => Class::System,            // 5%
+    }
+}
+
+#[derive(Default)]
+struct Stats {
+    admitted: u64,
+    queue_full: u64,
+    queue_timeout: u64,
+    preempted: u64, // victim: cancel fired in the pre-TTFT window
+    cancelled: u64,
+    /// Admit latency (ns) for admitted requests, per `Class as usize`.
+    lat: [Vec<u32>; 4],
+}
+
+impl Stats {
+    fn merge(&mut self, o: Stats) {
+        self.admitted += o.admitted;
+        self.queue_full += o.queue_full;
+        self.queue_timeout += o.queue_timeout;
+        self.preempted += o.preempted;
+        self.cancelled += o.cancelled;
+        for i in 0..4 {
+            self.lat[i].extend_from_slice(&o.lat[i]);
+        }
+    }
+}
+
+fn pct(sorted: &[u32], p: f64) -> u32 {
+    if sorted.is_empty() {
+        return 0;
+    }
+    let idx = (((sorted.len() - 1) as f64) * p).round() as usize;
+    sorted[idx]
+}
+
+/// Run `total` requests across `concurrency` concurrent client tasks against a
+/// shared running scheduler. Each admitted request models a `service`-long hold
+/// with a `ttft`-long preemptible head; if `service` is zero it releases
+/// immediately (pure-contention throughput mode).
+async fn run_load(
+    scheduler: &Arc<PriorityScheduler>,
+    seq: &Arc<AtomicU64>,
+    concurrency: usize,
+    total: u64,
+    service: Duration,
+    ttft: Duration,
+) -> Stats {
+    let remaining = Arc::new(AtomicI64::new(total as i64));
+    let mut handles = Vec::with_capacity(concurrency);
+
+    for _ in 0..concurrency {
+        let scheduler = scheduler.clone();
+        let remaining = remaining.clone();
+        let seq = seq.clone();
+        handles.push(tokio::spawn(async move {
+            let mut st = Stats::default();
+            while remaining.fetch_sub(1, Ordering::Relaxed) > 0 {
+                let id = seq.fetch_add(1, Ordering::Relaxed);
+                let class = pick_class(id);
+                let request_id = RequestId(format!("ld-{id}"));
+
+                let t0 = Instant::now();
+                let outcome = scheduler
+                    .admit(class, request_id, CancellationToken::new())
+                    .await;
+                let lat = t0.elapsed().as_nanos().min(u128::from(u32::MAX)) as u32;
+
+                match outcome {
+                    AdmitOutcome::Admitted(permit) => {
+                        st.admitted += 1;
+                        st.lat[class as usize].push(lat);
+                        if service.is_zero() {
+                            // pure-contention mode: release immediately.
+                            drop(permit);
+                        } else {
+                            // Pre-TTFT window: preemptible. Race reaching the
+                            // first byte against the scheduler preempting us.
+                            let cancel = permit.cancel_token();
+                            tokio::select! {
+                                () = tokio::time::sleep(ttft) => {
+                                    let _ = permit.try_mark_first_byte(); // now protected
+                                    let rest = service.saturating_sub(ttft);
+                                    if !rest.is_zero() {
+                                        tokio::time::sleep(rest).await;
+                                    }
+                                }
+                                () = cancel.cancelled() => {
+                                    st.preempted += 1; // bumped before first byte
+                                }
+                            }
+                            drop(permit); // releases the slot
+                        }
+                    }
+                    AdmitOutcome::Rejected(RejectionReason::QueueFull) => st.queue_full += 1,
+                    AdmitOutcome::Rejected(RejectionReason::QueueTimeout) => st.queue_timeout += 1,
+                    AdmitOutcome::Rejected(RejectionReason::Preempted) => st.preempted += 1,
+                    AdmitOutcome::Rejected(RejectionReason::ClientCancelled) => st.cancelled += 1,
+                }
+            }
+            st
+        }));
+    }
+
+    let mut total_stats = Stats::default();
+    for h in handles {
+        total_stats.merge(h.await.unwrap());
+    }
+    total_stats
+}
+
+fn multi_thread_rt() -> Runtime {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+}
+
+/// Print a one-shot saturated-load report (latency percentiles + outcomes).
+fn print_report(label: &str, st: &mut Stats) {
+    let total = st.admitted + st.queue_full + st.queue_timeout + st.preempted + st.cancelled;
+    eprintln!("\n=== scheduler load report: {label} ===");
+    eprintln!(
+        "requests={total}  admitted={}  429_queue_full={}  408_timeout={}  503_preempted={}  client_cancelled={}",
+        st.admitted, st.queue_full, st.queue_timeout, st.preempted, st.cancelled
+    );
+    eprintln!("admit latency by class (microseconds):");
+    eprintln!(
+        "  {:<12} {:>8} {:>10} {:>10}",
+        "class", "count", "p50_us", "p99_us"
+    );
+    for c in Class::ALL {
+        let v = &mut st.lat[c as usize];
+        if v.is_empty() {
+            continue;
+        }
+        v.sort_unstable();
+        eprintln!(
+            "  {:<12} {:>8} {:>10.1} {:>10.1}",
+            format!("{c:?}"),
+            v.len(),
+            f64::from(pct(v, 0.50)) / 1000.0,
+            f64::from(pct(v, 0.99)) / 1000.0,
+        );
+    }
+    eprintln!();
+}
+
+/// contended_throughput: ample capacity (everything admits), K concurrent
+/// tasks loop admit→release with no hold. Pure scheduler ops/sec under
+/// real K-way contention on the slot pool, queue locks, and registry.
+fn bench_contended_throughput(c: &mut Criterion) {
+    let rt = multi_thread_rt();
+    // spawn_dispatcher uses tokio::spawn → build inside the runtime context,
+    // but drop the enter guard before block_on (block_on can't nest in enter).
+    let (scheduler, _cap_tx) = {
+        let _enter = rt.enter();
+        build_running(8192)
+    };
+    let seq = Arc::new(AtomicU64::new(0));
+
+    let mut group = c.benchmark_group("contended_throughput");
+    const N: u64 = 100_000;
+    group.throughput(Throughput::Elements(N));
+    for k in [1usize, 8, 32, 128, 512] {
+        group.bench_with_input(BenchmarkId::from_parameter(k), &k, |b, &k| {
+            b.iter(|| {
+                rt.block_on(run_load(
+                    &scheduler,
+                    &seq,
+                    k,
+                    N,
+                    Duration::ZERO,
+                    Duration::ZERO,
+                ));
+            });
+        });
+    }
+    group.finish();
+}
+
+/// saturated_load: fixed capacity, offered concurrency oversubscribes it, with
+/// a modeled service time so queues form and preemption can fire. Prints a
+/// per-class latency + outcome report once, then times sustained throughput.
+fn bench_saturated_load(c: &mut Criterion) {
+    const CAPACITY: u16 = 256;
+    const OFFERED: usize = 1024; // 4x oversubscription
+    let service = Duration::from_micros(800);
+    let ttft = Duration::from_micros(150);
+
+    let rt = multi_thread_rt();
+    let (scheduler, _cap_tx) = {
+        let _enter = rt.enter();
+        build_running(CAPACITY)
+    };
+    let seq = Arc::new(AtomicU64::new(0));
+
+    // One-shot instrumented run → human-readable report (printed once).
+    static REPORT: Once = Once::new();
+    REPORT.call_once(|| {
+        let mut st = rt.block_on(run_load(&scheduler, &seq, OFFERED, 16_384, service, ttft));
+        print_report(
+            &format!(
+                "cap={CAPACITY} offered={OFFERED} service={}us ttft={}us",
+                service.as_micros(),
+                ttft.as_micros()
+            ),
+            &mut st,
+        );
+    });
+
+    let mut group = c.benchmark_group("saturated_load");
+    const N: u64 = 8_192;
+    group.throughput(Throughput::Elements(N));
+    group.bench_function(format!("offered_{OFFERED}"), |b| {
+        b.iter(|| {
+            rt.block_on(run_load(&scheduler, &seq, OFFERED, N, service, ttft));
+        });
+    });
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default();
+    targets = bench_contended_throughput, bench_saturated_load,
+}
+criterion_main!(benches);


### PR DESCRIPTION
## Description

### Problem
The priority scheduler sits on every request's hot path, but had no performance coverage — nothing proving the admission decision is cheap, and no characterization under concurrent load.

### Solution
Two criterion benches:
- **`scheduler_admission`** — single-call micro-benchmark of `admit()` / `acquire_inflight()`, contrasted with the legacy `TokenBucket` it replaces.
- **`scheduler_load`** — concurrent **load** harness: drives the real `PriorityScheduler` (dispatcher running) under multi-threaded oversubscription with a modeled request lifecycle (`admit → TTFT → service → release`, preemptible pre-first-byte), reporting throughput-vs-concurrency and per-class admit-latency + outcome breakdown under saturation.

## Changes
- `model_gateway/benches/scheduler_admission.rs` (new)
- `model_gateway/benches/scheduler_load.rs` (new)
- `model_gateway/Cargo.toml` — two `[[bench]]` entries

## Test Plan
Indicative local numbers (`cargo bench`):
- **micro:** fast-path admit ~102 ns (sync core) / ~181 ns (full async); legacy `TokenBucket` ~34 ns.
- **contended throughput:** ~4.2M admits/s @1 thread → ~1.0M/s @8–512 threads (admissions serialize on the inflight-registry lock; still far above realistic gateway load).
- **saturated (cap 256, 4× oversubscribed):** admit-decision p50 ~1–2 µs; **p99 strictly priority-ordered** — System 10 ms < Interactive 19 ms < Default 87 ms < Bulk 261 ms; preemption fires; 429 sheds excess.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (benches)

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added new performance benchmarking suites for the scheduler: microbenchmarks that compare admission paths versus a legacy limiter, and end-to-end concurrent-load benchmarks.
  * Measures throughput and latency (p50/p99) and reports outcomes such as admitted requests, queue-full/timeouts, preemptions, and cancellations across contended-throughput and saturated-load scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->