### PR TITLE
feat(mesh): per-key CRDT send watermark + ack + retry

### DIFF
--- a/crates/mesh/src/crdt_kv/mod.rs
+++ b/crates/mesh/src/crdt_kv/mod.rs
@@ -9,6 +9,7 @@ mod kv_store;
 mod merge_strategy;
 mod operation;
 mod replica;
+mod watermark;
 
 // Export core types
 pub use crdt::CrdtOrMap;
@@ -16,6 +17,7 @@ pub use epoch_max_wins::{decode, encode, EpochCount, EPOCH_MAX_WINS_ENCODED_LEN}
 pub use merge_strategy::MergeStrategy;
 pub use operation::{CrdtChange, Operation, OperationLog};
 pub use replica::ReplicaId;
+pub use watermark::CrdtWatermark;
 
 #[cfg(test)]
 mod tests;

--- a/crates/mesh/src/crdt_kv/watermark.rs
+++ b/crates/mesh/src/crdt_kv/watermark.rs
@@ -1,0 +1,160 @@
+use std::collections::HashMap;
+
+use super::operation::Operation;
+
+/// Per-peer CRDT send watermark, keyed by KEY (not by author replica). Tracks
+/// the highest version (Lamport timestamp) a peer has acknowledged for each
+/// key, so the sender can skip re-broadcasting keys the peer already has.
+///
+/// Keying by key — not by replica — is what keeps this correct on our
+/// compacted, multi-author op-log: each key is tracked independently, so a
+/// dropped or late op only delays that one key (resent next round) and can
+/// never be hidden behind a higher version on a different key.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CrdtWatermark {
+    versions: HashMap<String, u64>,
+}
+
+impl CrdtWatermark {
+    /// Empty watermark — every op is allowed (a fresh peer gets the full set).
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Build from a set of ops, keeping the max version per key. Used by the
+    /// receiver to ack the versions it just merged.
+    pub fn from_ops(ops: &[Operation]) -> Self {
+        let mut versions = HashMap::new();
+        for op in ops {
+            let entry = versions.entry(op.key().to_owned()).or_insert(0);
+            *entry = (*entry).max(op.timestamp());
+        }
+        Self { versions }
+    }
+
+    /// True if `op` is newer than what the peer has acked for its key. An
+    /// unacked key counts as version 0, so it is always allowed.
+    pub fn allows(&self, op: &Operation) -> bool {
+        op.timestamp() > self.get(op.key())
+    }
+
+    /// The acked version for `key` (0 if never acked).
+    pub fn get(&self, key: &str) -> u64 {
+        self.versions.get(key).copied().unwrap_or(0)
+    }
+
+    /// Advance toward `other`, taking the per-key maximum. Monotone,
+    /// idempotent, and commutative, so out-of-order or duplicate acks are
+    /// self-correcting.
+    pub fn merge_max(&mut self, other: &CrdtWatermark) {
+        for (key, &version) in &other.versions {
+            let entry = self.versions.entry(key.clone()).or_insert(0);
+            *entry = (*entry).max(version);
+        }
+    }
+
+    /// Iterate `(key, version)` pairs — used by the wire codec.
+    pub fn iter(&self) -> impl Iterator<Item = (&str, u64)> {
+        self.versions.iter().map(|(k, &v)| (k.as_str(), v))
+    }
+
+    /// True if no key has been acked yet.
+    pub fn is_empty(&self) -> bool {
+        self.versions.is_empty()
+    }
+}
+
+impl FromIterator<(String, u64)> for CrdtWatermark {
+    /// Build from `(key, version)` pairs, keeping the max version per key. Used
+    /// by the wire codec to rebuild a watermark from a received ack.
+    fn from_iter<I: IntoIterator<Item = (String, u64)>>(iter: I) -> Self {
+        let mut versions = HashMap::new();
+        for (key, version) in iter {
+            let entry = versions.entry(key).or_insert(0);
+            *entry = (*entry).max(version);
+        }
+        Self { versions }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crdt_kv::ReplicaId;
+
+    fn op(key: &str, ts: u64) -> Operation {
+        Operation::insert(key.to_owned(), vec![1], ts, ReplicaId::new())
+    }
+
+    #[test]
+    fn unknown_key_is_version_zero_and_allowed() {
+        let wm = CrdtWatermark::new();
+        assert_eq!(wm.get("worker:a"), 0);
+        assert!(wm.allows(&op("worker:a", 1)));
+    }
+
+    #[test]
+    fn allows_only_strictly_newer_versions() {
+        let wm = CrdtWatermark::from_ops(&[op("k", 5)]);
+        assert!(!wm.allows(&op("k", 4)), "older version already acked");
+        assert!(!wm.allows(&op("k", 5)), "equal version already acked");
+        assert!(wm.allows(&op("k", 6)), "newer version must be sent");
+        assert!(
+            wm.allows(&op("other", 1)),
+            "other key tracked independently"
+        );
+    }
+
+    #[test]
+    fn from_ops_keeps_max_version_per_key() {
+        let wm = CrdtWatermark::from_ops(&[op("k", 3), op("k", 9), op("k", 7), op("j", 2)]);
+        assert_eq!(wm.get("k"), 9);
+        assert_eq!(wm.get("j"), 2);
+    }
+
+    #[test]
+    fn merge_max_takes_per_key_maximum() {
+        let mut a = CrdtWatermark::from_ops(&[op("k", 5), op("j", 8)]);
+        let b = CrdtWatermark::from_ops(&[op("k", 3), op("j", 12), op("new", 1)]);
+        a.merge_max(&b);
+        assert_eq!(a.get("k"), 5, "existing higher value is not lowered");
+        assert_eq!(a.get("j"), 12, "existing value is raised");
+        assert_eq!(a.get("new"), 1, "new key is added");
+    }
+
+    #[test]
+    fn merge_max_is_idempotent() {
+        let mut a = CrdtWatermark::from_ops(&[op("k", 5)]);
+        let b = a.clone();
+        a.merge_max(&b);
+        a.merge_max(&b);
+        assert_eq!(a.get("k"), 5);
+    }
+
+    #[test]
+    fn iter_yields_all_key_versions() {
+        let wm = CrdtWatermark::from_ops(&[op("k", 5), op("j", 8)]);
+        let mut pairs: Vec<(String, u64)> = wm.iter().map(|(k, v)| (k.to_owned(), v)).collect();
+        pairs.sort();
+        assert_eq!(pairs, vec![("j".to_owned(), 8), ("k".to_owned(), 5)]);
+    }
+
+    #[test]
+    fn is_empty_reflects_contents() {
+        assert!(CrdtWatermark::new().is_empty());
+        assert!(!CrdtWatermark::from_ops(&[op("k", 1)]).is_empty());
+    }
+
+    #[test]
+    fn from_iter_takes_max_per_key() {
+        let wm: CrdtWatermark = [
+            ("k".to_owned(), 3),
+            ("k".to_owned(), 9),
+            ("j".to_owned(), 2),
+        ]
+        .into_iter()
+        .collect();
+        assert_eq!(wm.get("k"), 9);
+        assert_eq!(wm.get("j"), 2);
+    }
+}

--- a/crates/mesh/src/gossip_controller.rs
+++ b/crates/mesh/src/gossip_controller.rs
@@ -54,9 +54,13 @@ use super::{
     },
 };
 use crate::{
+    crdt_kv::CrdtWatermark,
     metrics,
     transport::{
-        crdt_batch::{build_crdt_batches, dispatch_crdt_batch, wrap_crdt_batch},
+        crdt_batch::{
+            build_crdt_batches, crdt_ack_to_watermark, dispatch_crdt_batch, wrap_crdt_ack,
+            wrap_crdt_batch,
+        },
         limits::{MAX_MESSAGE_SIZE, MAX_STREAM_CHUNK_BYTES, STREAM_IDLE_TIMEOUT},
         sync_stream::{
             build_heartbeat, build_peer_stream_batches, dispatch_stream_batch, wrap_stream_batch,
@@ -448,6 +452,12 @@ impl GossipController {
 
                 let sequence = Arc::new(AtomicU64::new(0));
 
+                // Per-peer CRDT send watermark (per-key acked versions). The
+                // incremental sender filters by it; the inbound loop advances it
+                // on CrdtAck and emits acks for received batches.
+                let acked: Arc<RwLock<CrdtWatermark>> =
+                    Arc::new(RwLock::new(CrdtWatermark::new()));
+
                 // Send initial heartbeat
                 let heartbeat =
                     build_heartbeat(sequence.fetch_add(1, Ordering::Relaxed), &self_name);
@@ -463,6 +473,7 @@ impl GossipController {
                     let peer_name_incremental = peer_name.clone();
                     let shared_sequence = sequence.clone();
                     let stream_batch_handle = current_stream_batch.clone();
+                    let acked_incremental = acked.clone();
 
                     #[expect(clippy::disallowed_methods, reason = "incremental sender handle is stored and aborted when the parent sync_stream handler exits")]
                     tokio::spawn(async move {
@@ -516,36 +527,43 @@ impl GossipController {
                                         }
                                     }
                                 }
+                            }
 
-                                // CRDT op-log: broadcast the full snapshot for
-                                // this round, split into frames that stay under
-                                // the gRPC message cap. Merge is idempotent by
-                                // op-id so re-sending seen ops is a no-op.
-                                for crdt_batch in build_crdt_batches(
-                                    &stream_batch.crdt_ops,
-                                    MAX_STREAM_CHUNK_BYTES,
-                                ) {
-                                    let msg = wrap_crdt_batch(
-                                        crdt_batch,
-                                        shared_sequence.fetch_add(1, Ordering::Relaxed),
-                                        &self_name_incremental,
-                                    );
-                                    match tx_incremental.try_send(msg) {
-                                        Ok(()) => {}
-                                        Err(mpsc::error::TrySendError::Full(_)) => {
-                                            log::debug!(
-                                                peer = %peer_name_incremental,
-                                                "crdt batch dropped on backpressure"
-                                            );
-                                            break;
-                                        }
-                                        Err(mpsc::error::TrySendError::Closed(_)) => {
-                                            log::warn!(
-                                                peer = %peer_name_incremental,
-                                                "crdt sender: channel closed, stopping"
-                                            );
-                                            return;
-                                        }
+                            // CRDT op-log: evaluated every tick (acks shrink the
+                            // delta even when the stream batch is unchanged).
+                            // Send only ops this peer has not acked; the
+                            // watermark advances solely on CrdtAck, so unacked
+                            // keys retry next round.
+                            let crdt_ops: Vec<_> = {
+                                let acked = acked_incremental.read();
+                                stream_batch
+                                    .crdt_ops
+                                    .iter()
+                                    .filter(|op| acked.allows(op))
+                                    .cloned()
+                                    .collect()
+                            };
+                            for crdt_batch in build_crdt_batches(&crdt_ops, MAX_STREAM_CHUNK_BYTES) {
+                                let msg = wrap_crdt_batch(
+                                    crdt_batch,
+                                    shared_sequence.fetch_add(1, Ordering::Relaxed),
+                                    &self_name_incremental,
+                                );
+                                match tx_incremental.try_send(msg) {
+                                    Ok(()) => {}
+                                    Err(mpsc::error::TrySendError::Full(_)) => {
+                                        log::debug!(
+                                            peer = %peer_name_incremental,
+                                            "crdt batch dropped on backpressure"
+                                        );
+                                        break;
+                                    }
+                                    Err(mpsc::error::TrySendError::Closed(_)) => {
+                                        log::warn!(
+                                            peer = %peer_name_incremental,
+                                            "crdt sender: channel closed, stopping"
+                                        );
+                                        return;
                                     }
                                 }
                             }
@@ -624,8 +642,26 @@ impl GossipController {
                                 StreamMessageType::CrdtBatch => {
                                     if let Some(mesh_kv) = &mesh_kv {
                                         if let Some(StreamPayload::CrdtBatch(batch)) = msg.payload {
-                                            dispatch_crdt_batch(mesh_kv, batch);
+                                            // Merge, then ack the per-key
+                                            // versions so the peer can advance
+                                            // its send watermark. Ack loss is
+                                            // fine (peer resends), so drop on a
+                                            // full channel rather than block.
+                                            let ack = dispatch_crdt_batch(mesh_kv, batch);
+                                            if !ack.is_empty() {
+                                                let _ = tx.try_send(wrap_crdt_ack(
+                                                    &ack,
+                                                    sequence.fetch_add(1, Ordering::Relaxed),
+                                                    &self_name,
+                                                ));
+                                            }
                                         }
+                                    }
+                                }
+                                // CRDT delivery ack: advance this peer's send watermark.
+                                StreamMessageType::CrdtAck => {
+                                    if let Some(StreamPayload::CrdtAck(ack)) = msg.payload {
+                                        acked.write().merge_max(&crdt_ack_to_watermark(ack));
                                     }
                                 }
                             }

--- a/crates/mesh/src/gossip_service.rs
+++ b/crates/mesh/src/gossip_service.rs
@@ -43,6 +43,7 @@ use tracing as log;
 use tracing::instrument;
 
 use super::{
+    crdt_kv::CrdtWatermark,
     metrics::{record_ack, record_nack, record_peer_reconnect, update_peer_connections},
     mtls::MTLSManager,
     partition::PartitionDetector,
@@ -56,7 +57,10 @@ use super::{
         try_ping, ClusterState,
     },
     transport::{
-        crdt_batch::{build_crdt_batches, dispatch_crdt_batch, wrap_crdt_batch},
+        crdt_batch::{
+            build_crdt_batches, crdt_ack_to_watermark, dispatch_crdt_batch, wrap_crdt_ack,
+            wrap_crdt_batch,
+        },
         limits::{MAX_MESSAGE_SIZE, MAX_STREAM_CHUNK_BYTES, STREAM_IDLE_TIMEOUT},
         sync_stream::{
             build_heartbeat, build_peer_stream_batches, dispatch_stream_batch, wrap_stream_batch,
@@ -261,6 +265,13 @@ impl Gossip for GossipService {
         let learned_peer: Arc<parking_lot::RwLock<Option<String>>> =
             Arc::new(parking_lot::RwLock::new(None));
 
+        // Per-peer CRDT send watermark: the highest version this peer has acked
+        // for each key. The sender filters the op-log by it; the inbound handler
+        // advances it on CrdtAck. Keyed by key so a dropped/late op only delays
+        // that one key (resent next round), never strands it.
+        let acked: Arc<parking_lot::RwLock<CrdtWatermark>> =
+            Arc::new(parking_lot::RwLock::new(CrdtWatermark::new()));
+
         // Server-side stream sender: periodically emit fresh stream batches
         // (broadcast drain_entries + targeted entries addressed to the
         // learned peer). Skipped when no current_stream_batch is attached.
@@ -268,6 +279,7 @@ impl Gossip for GossipService {
             let tx_sender = tx.clone();
             let self_name_sender = self_name.clone();
             let learned_peer_sender = learned_peer.clone();
+            let acked_sender = acked.clone();
             #[expect(
                 clippy::disallowed_methods,
                 reason = "server-side sender bound to sync_stream lifetime; terminates when channel closes or handle is aborted on disconnect"
@@ -290,45 +302,48 @@ impl Gossip for GossipService {
                     }
 
                     let stream_batch = stream_batch_handle.read().clone();
-                    let batches = {
+
+                    // Stream batches: gated by learned peer + Arc-freshness. A
+                    // skipped tick leaves `last_stream_batch` untouched so the
+                    // same RoundBatch is re-evaluated later.
+                    let stream_tick = {
                         let guard = learned_peer_sender.read();
-                        match plan_sender_tick(
+                        plan_sender_tick(
                             last_stream_batch.as_ref(),
                             &stream_batch,
                             guard.as_deref(),
-                        ) {
-                            SenderTick::SkipPeerUnknown | SenderTick::SkipBatchUnchanged => {
-                                continue
-                            }
-                            SenderTick::Emit(b) => b,
-                        }
+                        )
                     };
-                    // Only mark this batch consumed after building with a
-                    // real peer_id. If `plan_sender_tick` short-circuited
-                    // (peer unknown or batch unchanged), `last_stream_batch`
-                    // is untouched and the same RoundBatch will be
-                    // re-evaluated on a later tick.
-                    last_stream_batch = Some(stream_batch.clone());
-
-                    for batch in batches {
-                        sequence_counter += 1;
-                        let msg = wrap_stream_batch(batch, sequence_counter, &self_name_sender);
-                        match tx_sender.try_send(Ok(msg)) {
-                            Ok(()) => {}
-                            Err(mpsc::error::TrySendError::Full(_)) => {
-                                log::debug!("server-side stream batch dropped on backpressure");
-                                break;
+                    if let SenderTick::Emit(batches) = stream_tick {
+                        last_stream_batch = Some(stream_batch.clone());
+                        for batch in batches {
+                            sequence_counter += 1;
+                            let msg = wrap_stream_batch(batch, sequence_counter, &self_name_sender);
+                            match tx_sender.try_send(Ok(msg)) {
+                                Ok(()) => {}
+                                Err(mpsc::error::TrySendError::Full(_)) => {
+                                    log::debug!("server-side stream batch dropped on backpressure");
+                                    break;
+                                }
+                                Err(mpsc::error::TrySendError::Closed(_)) => return,
                             }
-                            Err(mpsc::error::TrySendError::Closed(_)) => return,
                         }
                     }
 
-                    // CRDT op-log: broadcast the full snapshot this round,
-                    // split to stay under the gRPC message cap (idempotent
-                    // merge on the peer).
-                    for crdt_batch in
-                        build_crdt_batches(&stream_batch.crdt_ops, MAX_STREAM_CHUNK_BYTES)
-                    {
+                    // CRDT op-log: evaluated every tick (acks shrink the delta
+                    // even when the RoundBatch is unchanged). Send only ops the
+                    // peer has not acked; the watermark advances solely on
+                    // CrdtAck, so unacked keys retry next round.
+                    let crdt_ops: Vec<_> = {
+                        let acked = acked_sender.read();
+                        stream_batch
+                            .crdt_ops
+                            .iter()
+                            .filter(|op| acked.allows(op))
+                            .cloned()
+                            .collect()
+                    };
+                    for crdt_batch in build_crdt_batches(&crdt_ops, MAX_STREAM_CHUNK_BYTES) {
                         sequence_counter += 1;
                         let msg = wrap_crdt_batch(crdt_batch, sequence_counter, &self_name_sender);
                         match tx_sender.try_send(Ok(msg)) {
@@ -347,6 +362,7 @@ impl Gossip for GossipService {
         };
 
         let learned_peer_inbound = learned_peer.clone();
+        let acked_inbound = acked.clone();
         #[expect(
             clippy::disallowed_methods,
             reason = "server-side inbound handler bound to sync_stream lifetime; terminates when the stream closes"
@@ -425,7 +441,20 @@ impl Gossip for GossipService {
                             Some(gossip::stream_message::Payload::CrdtBatch(batch)),
                         ) = (&mesh_kv, msg.payload)
                         {
-                            dispatch_crdt_batch(mesh_kv, batch);
+                            // Merge, then ack the per-key versions back so the
+                            // peer can advance its send watermark. Ack loss is
+                            // fine — the peer resends unacked keys next round —
+                            // so drop it on a full channel rather than block.
+                            let ack = dispatch_crdt_batch(mesh_kv, batch);
+                            if !ack.is_empty() {
+                                let _ = tx.try_send(Ok(wrap_crdt_ack(&ack, sequence, &self_name)));
+                            }
+                        }
+                    }
+                    // CRDT delivery ack: advance this peer's send watermark.
+                    StreamMessageType::CrdtAck => {
+                        if let Some(gossip::stream_message::Payload::CrdtAck(ack)) = msg.payload {
+                            acked_inbound.write().merge_max(&crdt_ack_to_watermark(ack));
                         }
                     }
                     StreamMessageType::IncrementalUpdate

--- a/crates/mesh/src/proto/gossip.proto
+++ b/crates/mesh/src/proto/gossip.proto
@@ -65,6 +65,7 @@ enum StreamMessageType {
   HEARTBEAT = 6;
   STREAM_BATCH = 7;
   CRDT_BATCH = 8;
+  CRDT_ACK = 9;
 }
 
 message StreamMessage {
@@ -76,6 +77,7 @@ message StreamMessage {
     StreamAck ack = 5;
     StreamBatch stream_batch = 8;
     CrdtBatch crdt_batch = 9;
+    CrdtAck crdt_ack = 10;
   }
   uint64 sequence = 6; // Sequence number for ordering
   string peer_id = 7;   // Sender peer ID
@@ -97,6 +99,21 @@ message CrdtOp {
 // idempotent by op-id, so re-sending already-seen ops is a no-op.
 message CrdtBatch {
   repeated CrdtOp ops = 1;
+}
+
+// One key's acknowledged version on a peer. The receiver of a CrdtBatch sends
+// these back so the sender can advance its per-(peer, key) send watermark and
+// stop re-broadcasting keys the peer already has.
+message CrdtKeyVersion {
+  string key = 1;
+  uint64 version = 2; // highest Lamport timestamp the receiver holds for this key
+}
+
+// Acknowledgement for a received CrdtBatch: the receiver's current version for
+// each key in that batch. Advances the sender's per-key send watermark; keys
+// the ack omits stay un-acked and are resent next round.
+message CrdtAck {
+  repeated CrdtKeyVersion entries = 1;
 }
 
 // Incremental state update (steady-state)

--- a/crates/mesh/src/tests/crdt_integration.rs
+++ b/crates/mesh/src/tests/crdt_integration.rs
@@ -14,7 +14,9 @@ use bytes::Bytes;
 use tokio::sync::mpsc::error::TryRecvError;
 
 use crate::{
-    crdt_kv::{decode as decode_epoch_count, encode as encode_epoch_count, EpochCount},
+    crdt_kv::{
+        decode as decode_epoch_count, encode as encode_epoch_count, CrdtWatermark, EpochCount,
+    },
     kv::MeshKV,
     transport::{
         crdt_batch::{build_crdt_batches, dispatch_crdt_batch},
@@ -29,6 +31,29 @@ fn deliver_crdt(sender: &MeshKV, receiver: &MeshKV) {
     let ops = sender.collect_round_batch().crdt_ops;
     for batch in build_crdt_batches(&ops, MAX_STREAM_CHUNK_BYTES) {
         dispatch_crdt_batch(receiver, batch);
+    }
+}
+
+/// Snapshot the ops the sender would send this round: the op-log filtered by
+/// the per-key send watermark. Mirrors the live sender's filter step.
+fn pending_ops(sender: &MeshKV, acked: &CrdtWatermark) -> Vec<crate::crdt_kv::Operation> {
+    sender
+        .collect_round_batch()
+        .crdt_ops
+        .into_iter()
+        .filter(|op| acked.allows(op))
+        .collect()
+}
+
+/// One watermark-filtered round: send only ops the peer has not acked, then
+/// advance `acked` from the per-key versions the receiver acks back. Mirrors
+/// the live sender/receiver loop (filter → dispatch → ack → merge_max) without
+/// gossip tasks.
+fn deliver_crdt_watermarked(sender: &MeshKV, receiver: &MeshKV, acked: &mut CrdtWatermark) {
+    let ops = pending_ops(sender, acked);
+    for batch in build_crdt_batches(&ops, MAX_STREAM_CHUNK_BYTES) {
+        let ack = dispatch_crdt_batch(receiver, batch);
+        acked.merge_max(&ack);
     }
 }
 
@@ -162,4 +187,145 @@ async fn remote_tombstone_after_insert_notifies_none() {
     assert_eq!(key, "worker:a");
     assert!(payload.is_none(), "tombstone notifies None");
     assert_eq!(r_ns.get("worker:a"), None);
+}
+
+#[test]
+fn caught_up_peer_is_sent_nothing() {
+    let sender = MeshKV::new("sender".to_string());
+    let s_ns = sender.configure_crdt_prefix("worker:", MergeStrategy::LastWriterWins);
+    s_ns.put("worker:a", b"v1".to_vec());
+
+    let receiver = MeshKV::new("receiver".to_string());
+    receiver.configure_crdt_prefix("worker:", MergeStrategy::LastWriterWins);
+
+    let mut acked = CrdtWatermark::new();
+    deliver_crdt_watermarked(&sender, &receiver, &mut acked);
+
+    assert!(
+        pending_ops(&sender, &acked).is_empty(),
+        "once acked, a caught-up peer is sent nothing"
+    );
+}
+
+#[test]
+fn ack_advances_watermark_to_delivered_version() {
+    let sender = MeshKV::new("sender".to_string());
+    let s_ns = sender.configure_crdt_prefix("worker:", MergeStrategy::LastWriterWins);
+    s_ns.put("worker:a", b"v1".to_vec());
+
+    let receiver = MeshKV::new("receiver".to_string());
+    receiver.configure_crdt_prefix("worker:", MergeStrategy::LastWriterWins);
+
+    let sent_version = pending_ops(&sender, &CrdtWatermark::new())
+        .iter()
+        .find(|op| op.key() == "worker:a")
+        .map(|op| op.timestamp())
+        .expect("worker:a is pending before any ack");
+
+    let mut acked = CrdtWatermark::new();
+    assert_eq!(acked.get("worker:a"), 0);
+    deliver_crdt_watermarked(&sender, &receiver, &mut acked);
+    assert_eq!(
+        acked.get("worker:a"),
+        sent_version,
+        "ack advances the watermark to the delivered version"
+    );
+}
+
+#[test]
+fn lost_ack_resends_key_until_acked() {
+    let sender = MeshKV::new("sender".to_string());
+    let s_ns = sender.configure_crdt_prefix("worker:", MergeStrategy::LastWriterWins);
+    s_ns.put("worker:a", b"v1".to_vec());
+
+    let receiver = MeshKV::new("receiver".to_string());
+    let r_ns = receiver.configure_crdt_prefix("worker:", MergeStrategy::LastWriterWins);
+
+    // Round 1: the batch is delivered and merged, but the ack is lost — the
+    // sender does NOT advance its watermark.
+    let mut acked = CrdtWatermark::new();
+    for batch in build_crdt_batches(&pending_ops(&sender, &acked), MAX_STREAM_CHUNK_BYTES) {
+        let _lost_ack = dispatch_crdt_batch(&receiver, batch);
+    }
+    assert_eq!(
+        r_ns.get("worker:a"),
+        Some(b"v1".to_vec()),
+        "the batch merged even though its ack was lost"
+    );
+
+    // Round 2: with no ack, the key is still pending and gets resent.
+    assert!(
+        !pending_ops(&sender, &acked).is_empty(),
+        "a lost ack leaves the key pending, so it is resent"
+    );
+
+    // Once an ack lands, the watermark advances and the key is suppressed.
+    deliver_crdt_watermarked(&sender, &receiver, &mut acked);
+    assert!(
+        pending_ops(&sender, &acked).is_empty(),
+        "the key stops resending once acked"
+    );
+}
+
+#[test]
+fn dropping_one_keys_batch_does_not_strand_it() {
+    // The per-key regression: with a per-replica watermark, acking one key
+    // could advance past a lower-versioned op of the same author on a DIFFERENT
+    // key and strand it forever. Per-key tracking resends only the dropped key.
+    let sender = MeshKV::new("sender".to_string());
+    let s_ns = sender.configure_crdt_prefix("worker:", MergeStrategy::LastWriterWins);
+    s_ns.put("worker:a", vec![0u8; 200]);
+    s_ns.put("worker:b", vec![1u8; 200]);
+
+    let receiver = MeshKV::new("receiver".to_string());
+    let r_ns = receiver.configure_crdt_prefix("worker:", MergeStrategy::LastWriterWins);
+
+    let mut acked = CrdtWatermark::new();
+    // A budget that fits one ~200-byte op per frame forces two separate batches.
+    let batches = build_crdt_batches(&pending_ops(&sender, &acked), 300);
+    assert!(
+        batches.len() >= 2,
+        "two large keys must split into separate batches"
+    );
+
+    // Deliver + ack only the first batch; the rest are "dropped on backpressure".
+    let ack = dispatch_crdt_batch(&receiver, batches[0].clone());
+    acked.merge_max(&ack);
+    let delivered = [r_ns.get("worker:a"), r_ns.get("worker:b")]
+        .iter()
+        .filter(|v| v.is_some())
+        .count();
+    assert_eq!(
+        delivered, 1,
+        "exactly one key delivered; the other was dropped"
+    );
+
+    // The dropped key was never acked, so the next round resends it (and the
+    // delivered key, now acked, is suppressed). Both converge.
+    deliver_crdt_watermarked(&sender, &receiver, &mut acked);
+    assert_eq!(r_ns.get("worker:a"), Some(vec![0u8; 200]));
+    assert_eq!(r_ns.get("worker:b"), Some(vec![1u8; 200]));
+}
+
+#[test]
+fn filter_is_per_key_selective() {
+    let sender = MeshKV::new("sender".to_string());
+    let s_ns = sender.configure_crdt_prefix("worker:", MergeStrategy::LastWriterWins);
+    s_ns.put("worker:a", b"a".to_vec());
+
+    let receiver = MeshKV::new("receiver".to_string());
+    let r_ns = receiver.configure_crdt_prefix("worker:", MergeStrategy::LastWriterWins);
+
+    let mut acked = CrdtWatermark::new();
+    deliver_crdt_watermarked(&sender, &receiver, &mut acked);
+
+    // A new key is added after worker:a is acked; only the new key is sent.
+    s_ns.put("worker:b", b"b".to_vec());
+    let pending = pending_ops(&sender, &acked);
+    assert_eq!(pending.len(), 1, "only the unacked key is sent");
+    assert_eq!(pending[0].key(), "worker:b");
+
+    deliver_crdt_watermarked(&sender, &receiver, &mut acked);
+    assert_eq!(r_ns.get("worker:a"), Some(b"a".to_vec()));
+    assert_eq!(r_ns.get("worker:b"), Some(b"b".to_vec()));
 }

--- a/crates/mesh/src/transport/crdt_batch.rs
+++ b/crates/mesh/src/transport/crdt_batch.rs
@@ -8,17 +8,19 @@
 //!   message cap; [`wrap_crdt_batch`] builds the `StreamMessage` envelope.
 //! - Inbound: [`dispatch_crdt_batch`] decodes a received `CrdtBatch` back into
 //!   `Operation`s and merges them into the local CRDT store via `MeshKV`.
+//! - Ack: [`dispatch_crdt_batch`] returns a [`CrdtWatermark`] of the per-key
+//!   versions it merged; [`wrap_crdt_ack`] / [`watermark_to_crdt_ack`] /
+//!   [`crdt_ack_to_watermark`] carry it back over the wire so a sender can skip
+//!   keys the peer already holds.
 //!
-//! The op-log is broadcast in full each round; merge is idempotent by op-id,
-//! so re-sending already-seen ops is a no-op. Per-peer watermark filtering (to
-//! send only ops the peer has not acked) is a follow-up.
+//! Merge is idempotent by op-id, so re-sending already-seen ops is a no-op.
 
 use crate::{
-    crdt_kv::{Operation, ReplicaId},
+    crdt_kv::{CrdtWatermark, Operation, ReplicaId},
     kv::MeshKV,
     service::gossip::{
-        stream_message::Payload as StreamPayload, CrdtBatch, CrdtOp, StreamMessage,
-        StreamMessageType,
+        stream_message::Payload as StreamPayload, CrdtAck, CrdtBatch, CrdtKeyVersion, CrdtOp,
+        StreamMessage, StreamMessageType,
     },
 };
 
@@ -113,17 +115,56 @@ pub fn wrap_crdt_batch(batch: CrdtBatch, sequence: u64, self_name: &str) -> Stre
     }
 }
 
+/// Encode a [`CrdtWatermark`] as a wire [`CrdtAck`] — one entry per known key.
+pub fn watermark_to_crdt_ack(watermark: &CrdtWatermark) -> CrdtAck {
+    CrdtAck {
+        entries: watermark
+            .iter()
+            .map(|(key, version)| CrdtKeyVersion {
+                key: key.to_owned(),
+                version,
+            })
+            .collect(),
+    }
+}
+
+/// Decode a received [`CrdtAck`] into a [`CrdtWatermark`] for merging into the
+/// sender's per-peer send watermark.
+pub fn crdt_ack_to_watermark(ack: CrdtAck) -> CrdtWatermark {
+    ack.entries
+        .into_iter()
+        .map(|entry| (entry.key, entry.version))
+        .collect()
+}
+
+/// Wrap a [`CrdtWatermark`] in a `CrdtAck` `StreamMessage` envelope.
+pub fn wrap_crdt_ack(watermark: &CrdtWatermark, sequence: u64, self_name: &str) -> StreamMessage {
+    StreamMessage {
+        message_type: StreamMessageType::CrdtAck as i32,
+        payload: Some(StreamPayload::CrdtAck(watermark_to_crdt_ack(watermark))),
+        sequence,
+        peer_id: self_name.to_owned(),
+    }
+}
+
 /// Receiver-side dispatch for a `CrdtBatch`: decode each op and merge the batch
 /// into the local CRDT store, firing subscribers for keys whose value changed
 /// (via `MeshKV::merge_crdt_ops`). Ops with an unparsable `replica_id` are
 /// skipped. Merge is idempotent by op-id, so a batch the node has already
 /// absorbed is a no-op and fires no subscriber event.
-pub fn dispatch_crdt_batch(mesh_kv: &MeshKV, batch: CrdtBatch) {
+///
+/// Returns the per-key versions of the ops just received as a [`CrdtWatermark`],
+/// which the caller sends back as a [`CrdtAck`] so the peer can advance its
+/// send watermark for those keys. An empty/all-invalid batch returns an empty
+/// watermark (nothing to ack).
+pub fn dispatch_crdt_batch(mesh_kv: &MeshKV, batch: CrdtBatch) -> CrdtWatermark {
     let ops: Vec<Operation> = batch.ops.into_iter().filter_map(proto_to_op).collect();
     if ops.is_empty() {
-        return;
+        return CrdtWatermark::new();
     }
+    let ack = CrdtWatermark::from_ops(&ops);
     mesh_kv.merge_crdt_ops(ops);
+    ack
 }
 
 #[cfg(test)]
@@ -202,5 +243,31 @@ mod tests {
         assert_eq!(msg.sequence, 11);
         assert_eq!(msg.peer_id, "node-1");
         assert!(matches!(msg.payload, Some(StreamPayload::CrdtBatch(_))));
+    }
+
+    #[test]
+    fn watermark_round_trips_through_ack() {
+        let replica = ReplicaId::new();
+        let wm = CrdtWatermark::from_ops(&[
+            Operation::insert("worker:a".to_string(), b"v".to_vec(), 5, replica),
+            Operation::insert("rl:c".to_string(), b"x".to_vec(), 9, replica),
+        ]);
+        let back = crdt_ack_to_watermark(watermark_to_crdt_ack(&wm));
+        assert_eq!(back, wm);
+    }
+
+    #[test]
+    fn wrap_crdt_ack_envelope_shape() {
+        let wm = CrdtWatermark::from_ops(&[Operation::insert(
+            "worker:a".to_string(),
+            b"v".to_vec(),
+            5,
+            ReplicaId::new(),
+        )]);
+        let msg = wrap_crdt_ack(&wm, 12, "node-1");
+        assert_eq!(msg.message_type, StreamMessageType::CrdtAck as i32);
+        assert_eq!(msg.sequence, 12);
+        assert_eq!(msg.peer_id, "node-1");
+        assert!(matches!(msg.payload, Some(StreamPayload::CrdtAck(_))));
     }
 }


### PR DESCRIPTION
## Description

### Problem

Every node broadcasts its **entire** CRDT op-log to **every** peer every gossip round (`collect_round_batch` → full `get_operation_log()` snapshot). It is correct and self-healing (merge is idempotent by op-id), but gossip bandwidth scales with *total state size × peers* — roughly `O(N²)` cluster-wide — instead of with *change rate*. In an active cluster the full log re-ships every second even when almost nothing changed.

### Solution

Add a per-`(peer, key)` send watermark with ack + retry. Each `sync_stream` connection tracks the highest version a peer has acked for each key; the sender filters the op-log by it, the receiver acks the per-key versions it merged, and the sender advances and stops re-sending. The watermark advances **only on ack**, so a dropped batch or ack is resent next round — at-least-once delivery is preserved.

Keyed by **key**, not by author replica: a dropped or late op only delays that one key (resent next round) and can never be hidden behind a higher version on a *different* key. A per-replica watermark loses data on our compacted, multi-author op-log (the op-log is a per-engine concatenation, not globally sorted; EpochMaxWins collapses author identity; a receiver mixes ops from multiple peers). Per-key matches the deleted v1 `collector.rs` model and the design's own memory budget (`35 keys × N peers`).

## Changes

- **`CrdtWatermark`** (`crdt_kv/watermark.rs`): per-key version map — `from_ops` / `allows` / `merge_max`; an unacked key is version 0, so it is always sent.
- **proto**: `CrdtAck` / `CrdtKeyVersion` messages + `CRDT_ACK` stream message type.
- **codec** (`transport/crdt_batch.rs`): `wrap_crdt_ack` / `watermark_to_crdt_ack` / `crdt_ack_to_watermark`; `dispatch_crdt_batch` now returns the merged per-key versions to ack.
- **`gossip_service` / `gossip_controller`**: a shared per-stream watermark; the CRDT send is decoupled from the stream freshness gate and filtered by the watermark; the inbound handler emits acks for received batches and advances the watermark on received acks. Acks are dropped (not blocked) on a full channel, since loss is recovered by the next round's resend.

## Test Plan

- `cargo test -p smg-mesh` — **181 pass** (5 new in-process integration tests, no gossip tasks needed).
- `cargo clippy -p smg-mesh --all-targets --all-features -- -D warnings` — clean.

New integration tests (`tests/crdt_integration.rs`) drive the live `filter → dispatch → ack → merge_max` loop:

- `caught_up_peer_is_sent_nothing` — once acked, the filter drops everything.
- `ack_advances_watermark_to_delivered_version` — the ack moves the per-key mark.
- `lost_ack_resends_key_until_acked` — a dropped ack leaves the key pending so it is resent, then suppressed once acked (at-least-once via retry).
- `dropping_one_keys_batch_does_not_strand_it` — **the per-key regression**: drop one key's batch while acking another → the dropped key is resent and converges (a per-replica watermark would strand it).
- `filter_is_per_key_selective` — a newly written key is sent while an already-acked key is suppressed in the same round.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented CRDT acknowledgement tracking for efficient incremental operation delivery. Peers now receive only unacknowledged operations per key, reducing redundant data transfers.
  * Enhanced gossip protocol with acknowledgement message support.

* **Tests**
  * Added comprehensive test suite validating watermark tracking, selective resend logic, and acknowledgement semantics across peer communication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->