### PR TITLE
fix(scheduler): restore reservations after backend capacity recovers

### DIFF
--- a/model_gateway/src/middleware/scheduler/engine.rs
+++ b/model_gateway/src/middleware/scheduler/engine.rs
@@ -84,6 +84,11 @@ pub struct PriorityScheduler {
     /// exits cleanly.
     pub(super) release_notify: Arc<Notify>,
     class_config: [ClassRuntimeConfig; 4],
+    /// Configured per-class reservations (immutable baseline). The live
+    /// `slot_pool` reservations are recomputed from this on every capacity
+    /// change, so a capacity recovery restores them instead of leaving them
+    /// permanently scaled down.
+    configured_reserved: [u16; 4],
 }
 
 impl Drop for PriorityScheduler {
@@ -125,6 +130,7 @@ impl PriorityScheduler {
             inflight_registry: RwLock::new(HashMap::new()),
             release_notify: Arc::new(Notify::new()),
             class_config,
+            configured_reserved: reserved_arr,
         }))
     }
 
@@ -606,40 +612,45 @@ impl PriorityScheduler {
 
     /// Apply a new backend capacity from the WorkerCapacity watch.
     ///
-    /// On shrink past `Σ reserved`, scales reservations down
-    /// proportionally so the new capacity remains usable. On grow,
-    /// fires `release_notify` so the dispatcher re-evaluates queued
-    /// waiters under the larger ceiling.
+    /// Recomputes the live per-class reservations from the configured
+    /// baseline: on shrink past `Σ configured`, scales them down
+    /// proportionally so the new capacity stays usable; otherwise restores
+    /// the configured values. On grow, also fires `release_notify` so the
+    /// dispatcher re-evaluates queued waiters under the larger ceiling.
+    ///
+    /// Driving from the immutable baseline (not the current, possibly
+    /// already-scaled live values) makes this idempotent and lets a capacity
+    /// recovery fully restore the reservations — scaling in place would lose
+    /// the originals and erode them permanently across a shrink/grow cycle.
     fn apply_new_capacity(&self, new_capacity: u16) {
         let old = self.slot_pool.set_capacity(new_capacity);
         if new_capacity == old {
             return;
         }
 
-        let total_reserved: u32 = Class::ALL
-            .iter()
-            .map(|c| u32::from(self.slot_pool.reserved(*c)))
-            .sum();
-        if total_reserved > u32::from(new_capacity) && total_reserved > 0 {
-            // total_reserved is u32; converting via `as u16` would
-            // silently truncate any value > u16::MAX. Today the
-            // invariant `Σ reserved ≤ initial_capacity ≤ u16::MAX`
-            // holds (PriorityScheduler::new enforces it and this method
-            // only scales down), but the cast is fragile against future
-            // code paths that might increase a reservation. f64 holds
-            // u32 losslessly (53-bit mantissa > 32 bits).
-            let scale = f64::from(new_capacity) / f64::from(total_reserved);
+        let configured_total: u32 = self.configured_reserved.iter().map(|&r| u32::from(r)).sum();
+        if configured_total > u32::from(new_capacity) && configured_total > 0 {
+            // f64 holds u32 losslessly (53-bit mantissa > 32 bits), so the
+            // scale ratio is exact for any reservation sum.
+            let scale = f64::from(new_capacity) / f64::from(configured_total);
             for class in Class::ALL {
-                let r = self.slot_pool.reserved(class);
-                let scaled = (f64::from(r) * scale).floor() as u16;
+                let base = self.configured_reserved[class as usize];
+                let scaled = (f64::from(base) * scale).floor() as u16;
                 self.slot_pool.set_reserved(class, scaled);
             }
             warn!(
-                old_total_reserved = total_reserved,
+                configured_total_reserved = configured_total,
                 new_capacity,
                 scale = scale,
                 "scheduler: reserved slots scaled down after capacity shrink"
             );
+        } else {
+            // Configured reservations fit — restore them. Idempotent, and the
+            // grow-side restore the scale-in-place version was missing.
+            for class in Class::ALL {
+                self.slot_pool
+                    .set_reserved(class, self.configured_reserved[class as usize]);
+            }
         }
 
         if new_capacity > old {
@@ -1231,6 +1242,33 @@ mod tests {
         // (floor rounding).
         assert_eq!(scheduler.slot_pool.reserved(Class::Interactive), 64);
         assert_eq!(scheduler.slot_pool.reserved(Class::System), 16);
+    }
+
+    #[test]
+    fn test_apply_new_capacity_restores_reservations_after_recovery() {
+        // One-way-degrade fix: a shrink scales reservations down, but a later
+        // capacity recovery fully restores them (the live values are recomputed
+        // from the configured baseline each time, not eroded in place).
+        let s = default_settings();
+        let scheduler = PriorityScheduler::new(&s, 256).unwrap();
+        assert_eq!(scheduler.slot_pool.reserved(Class::Interactive), 128);
+        assert_eq!(scheduler.slot_pool.reserved(Class::System), 32);
+
+        // Shrink to 80 (< 160 reserved) → scale by 0.5.
+        scheduler.apply_new_capacity(80);
+        assert_eq!(scheduler.slot_pool.reserved(Class::Interactive), 64);
+        assert_eq!(scheduler.slot_pool.reserved(Class::System), 16);
+
+        // Recover to 256 → reservations fully restored, not stuck at 64/16.
+        scheduler.apply_new_capacity(256);
+        assert_eq!(scheduler.slot_pool.reserved(Class::Interactive), 128);
+        assert_eq!(scheduler.slot_pool.reserved(Class::System), 32);
+
+        // A second shrink recomputes from the baseline (128/32), not from the
+        // restored live value: shrink to 120 → scale 0.75 → 96 / 24.
+        scheduler.apply_new_capacity(120);
+        assert_eq!(scheduler.slot_pool.reserved(Class::Interactive), 96);
+        assert_eq!(scheduler.slot_pool.reserved(Class::System), 24);
     }
 
     #[test]

--- a/model_gateway/src/middleware/scheduler/engine.rs
+++ b/model_gateway/src/middleware/scheduler/engine.rs
@@ -642,22 +642,24 @@ impl PriorityScheduler {
         // baseline, new capacity): scale down when the configured sum exceeds
         // the new capacity, otherwise use the configured value as-is.
         let configured_total: u32 = self.configured_reserved.iter().map(|&r| u32::from(r)).sum();
-        let scale = (configured_total > u32::from(new_capacity) && configured_total > 0)
-            // f64 holds u32 losslessly (53-bit mantissa > 32 bits).
-            .then(|| f64::from(new_capacity) / f64::from(configured_total));
+        let scale_down = configured_total > u32::from(new_capacity) && configured_total > 0;
         let new_reserved = Class::ALL.map(|class| {
             let base = self.configured_reserved[class as usize];
-            match scale {
-                Some(s) => (f64::from(base) * s).floor() as u16,
-                None => base,
+            if scale_down {
+                // Exact integer proportional scaling: floor(base * new_capacity
+                // / configured_total). Integer math (u64 temporaries to avoid
+                // overflow) avoids the f64 product/division rounding that could
+                // under-scale a higher class's reservation by one slot and
+                // weaken the reservation guard.
+                ((u64::from(base) * u64::from(new_capacity)) / u64::from(configured_total)) as u16
+            } else {
+                base
             }
         });
-        if let Some(s) = scale {
+        if scale_down {
             warn!(
                 configured_total_reserved = configured_total,
-                new_capacity,
-                scale = s,
-                "scheduler: reserved slots scaled down after capacity shrink"
+                new_capacity, "scheduler: reserved slots scaled down after capacity shrink"
             );
         }
 
@@ -1290,6 +1292,35 @@ mod tests {
         scheduler.apply_new_capacity(120);
         assert_eq!(scheduler.slot_pool.reserved(Class::Interactive), 96);
         assert_eq!(scheduler.slot_pool.reserved(Class::System), 24);
+    }
+
+    #[test]
+    fn test_apply_new_capacity_scales_reservations_with_integer_math() {
+        // Exact integer proportional scaling must not under-scale a higher
+        // class's reservation by f64 rounding. One class reserving 22 with
+        // capacity 22 -> 15: exact floor is (22*15)/22 = 15, but the f64 path
+        // (22.0 * (15.0/22.0)).floor() rounds to 14, weakening the guard.
+        use std::collections::HashMap as StdMap;
+        let mut classes = StdMap::new();
+        for c in Class::ALL {
+            let mut cfg = ClassConfig::default_for(c);
+            cfg.reserved = if c == Class::Interactive { 22 } else { 0 };
+            classes.insert(c, cfg);
+        }
+        let yaml = PrioritySchedulerYaml {
+            classes,
+            tenant_policies: StdMap::new(),
+        };
+        let s =
+            SchedulerSettings::from_cli_and_yaml(true, Class::Default, 32, Some(&yaml)).unwrap();
+        let scheduler = PriorityScheduler::new(&s, 22).unwrap();
+
+        scheduler.apply_new_capacity(15);
+        assert_eq!(
+            scheduler.slot_pool.reserved(Class::Interactive),
+            15,
+            "floor(22*15/22) = 15, not the f64-rounded 14"
+        );
     }
 
     #[test]

--- a/model_gateway/src/middleware/scheduler/engine.rs
+++ b/model_gateway/src/middleware/scheduler/engine.rs
@@ -622,40 +622,61 @@ impl PriorityScheduler {
     /// already-scaled live values) makes this idempotent and lets a capacity
     /// recovery fully restore the reservations — scaling in place would lose
     /// the originals and erode them permanently across a shrink/grow cycle.
+    ///
+    /// The capacity and the per-class reservations are separate atomics, so
+    /// they cannot be published together. We order the two writes so a
+    /// concurrent fast-path `try_acquire` never sees the larger capacity
+    /// paired with the old, understated reservations (which would let a
+    /// low-priority admission slip into space a higher class is about to
+    /// reserve, and that request would hold the slot past the restore). The
+    /// rule: publish the more-restrictive value first. The transient is then
+    /// always conservative — `slots_available_to` saturates, so a brief
+    /// `Σ reserved > capacity` only under-admits, never over-admits.
     fn apply_new_capacity(&self, new_capacity: u16) {
-        let old = self.slot_pool.set_capacity(new_capacity);
+        let old = self.slot_pool.capacity();
         if new_capacity == old {
             return;
         }
 
+        // Effective reservation per class, a pure function of (configured
+        // baseline, new capacity): scale down when the configured sum exceeds
+        // the new capacity, otherwise use the configured value as-is.
         let configured_total: u32 = self.configured_reserved.iter().map(|&r| u32::from(r)).sum();
-        if configured_total > u32::from(new_capacity) && configured_total > 0 {
-            // f64 holds u32 losslessly (53-bit mantissa > 32 bits), so the
-            // scale ratio is exact for any reservation sum.
-            let scale = f64::from(new_capacity) / f64::from(configured_total);
-            for class in Class::ALL {
-                let base = self.configured_reserved[class as usize];
-                let scaled = (f64::from(base) * scale).floor() as u16;
-                self.slot_pool.set_reserved(class, scaled);
+        let scale = (configured_total > u32::from(new_capacity) && configured_total > 0)
+            // f64 holds u32 losslessly (53-bit mantissa > 32 bits).
+            .then(|| f64::from(new_capacity) / f64::from(configured_total));
+        let new_reserved = Class::ALL.map(|class| {
+            let base = self.configured_reserved[class as usize];
+            match scale {
+                Some(s) => (f64::from(base) * s).floor() as u16,
+                None => base,
             }
+        });
+        if let Some(s) = scale {
             warn!(
                 configured_total_reserved = configured_total,
                 new_capacity,
-                scale = scale,
+                scale = s,
                 "scheduler: reserved slots scaled down after capacity shrink"
             );
-        } else {
-            // Configured reservations fit — restore them. Idempotent, and the
-            // grow-side restore the scale-in-place version was missing.
-            for class in Class::ALL {
-                self.slot_pool
-                    .set_reserved(class, self.configured_reserved[class as usize]);
-            }
         }
 
         if new_capacity > old {
-            // Capacity grew — wake the dispatcher to drain.
+            // Grow: raise the reservations before exposing the larger
+            // capacity, then wake the dispatcher to drain under the new ceiling.
+            for class in Class::ALL {
+                self.slot_pool
+                    .set_reserved(class, new_reserved[class as usize]);
+            }
+            self.slot_pool.set_capacity(new_capacity);
             self.release_notify.notify_one();
+        } else {
+            // Shrink: drop the capacity before lowering the reservations.
+            self.slot_pool.set_capacity(new_capacity);
+            for class in Class::ALL {
+                self.slot_pool
+                    .set_reserved(class, new_reserved[class as usize]);
+            }
         }
     }
 }


### PR DESCRIPTION
## Description

### Problem
`apply_new_capacity` scales the live per-class reservations **down in place** on a capacity shrink and never restores them on grow — the grow branch only fires `release_notify`. So a *transient* capacity dip permanently erodes the priority reservations: a worker dropping then rejoining halves `interactive`'s 128 reserved slots to 64, and they stay at 64 forever, silently weakening the exact guarantee the scheduler exists to provide. (This is "Problem A" in `.claude/docs/scheduler/04-capacity-proportional-reservations-proposal.md`.)

### Solution
Keep the configured reservations as an **immutable baseline** (`configured_reserved`) and recompute the live values from it on every capacity change:
- configured sum **exceeds** the new capacity → scale down proportionally from the baseline;
- otherwise → **restore** the configured values.

Driving from the baseline makes it idempotent and both-directional: a recovery fully restores, and repeated shrinks recompute from the original rather than compounding the rounding.

## Changes
- `engine.rs`: add `configured_reserved: [u16; 4]` to `PriorityScheduler` (set from the same `reserved_arr` already built in `new`); rewrite `apply_new_capacity` to recompute live reservations from it (scale-down branch + grow-side restore branch).
- New test `test_apply_new_capacity_restores_reservations_after_recovery`: shrink (128→64) → recover (→128) → second shrink recomputes from the baseline (→96), not from the restored live value.

## Test Plan
- `cargo test -p smg --lib scheduler::` → 109 pass (108 + the new test).
- The existing single-shrink test is unchanged (first shrink computes identically whether from live or baseline, since they're equal initially).
- `cargo clippy -p smg --lib` clean; `cargo +nightly fmt` clean.

## Follow-up
This is the standalone correctness fix. The broader **capacity-proportional reservations** change (proposal `04`, which expresses reservations as a fraction of capacity and would subsume this fix by construction) is a separate PR pending owner review.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reservation handling on capacity changes now recomputes from an immutable configured baseline, preventing one-way degradation; shrinking scales reservations proportionally and capacity increases resume queued work.

* **Tests**
  * Added tests validating full reservation restore after shrink/recovery and exact integer proportional scaling to avoid rounding under-allocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->