### PR TITLE
feat(scheduler): capacity-proportional reservations (floor + share)

### DIFF
--- a/docs/concepts/reliability/priority-scheduling.md
+++ b/docs/concepts/reliability/priority-scheduling.md
@@ -112,7 +112,7 @@ The dispatcher checks for starved waiters **lowest priority first** (the classes
 The priority scheduler is designed to **fail safe**. It only takes over when it is both enabled and able to start cleanly:
 
 - If the scheduler is **disabled** (the default), the gateway wires the legacy concurrency-limit middleware — no scheduler is even constructed.
-- If the scheduler is **enabled but misconfigured** — unparseable YAML, or reservations that sum to more than the live capacity — the gateway logs the failure at `ERROR` and **falls back to legacy admission** rather than aborting startup. A broken scheduler config must never take the data plane down.
+- If the scheduler is **enabled but misconfigured** — unparsable YAML, or reservations that sum to more than the live capacity — the gateway logs the failure at `ERROR` and **falls back to legacy admission** rather than aborting startup. A broken scheduler config must never take the data plane down.
 
 In both cases the request path is the familiar token-bucket concurrency limiter described in [Rate Limiting](rate-limiting.md). The admission path is chosen once at startup.
 

--- a/docs/reference/priority-scheduler.md
+++ b/docs/reference/priority-scheduler.md
@@ -76,7 +76,7 @@ smg \
 | `--priority-scheduler-tenant-metric-top-n` | `32` | Intended cap on per-tenant metric label cardinality. **Not yet enforced** — the value is stored but no top-N bucketing is applied today; per-tenant counters currently intern the raw tenant. |
 
 !!! warning "Fail-safe startup"
-    If the scheduler is enabled but cannot start — unparseable YAML, or class reservations that sum to more than the live backend capacity — the gateway logs at `ERROR` and **falls back to legacy admission** instead of aborting. It does not take the data plane down.
+    If the scheduler is enabled but cannot start — unparsable YAML, or class reservation floors + shares that sum to more than the live backend capacity — the gateway logs at `ERROR` and **falls back to legacy admission** instead of aborting. It does not take the data plane down.
 
 ---
 
@@ -88,13 +88,14 @@ The file referenced by `--priority-scheduler-config` has two top-level maps, bot
 # Per-class tuning. Any class you omit keeps its built-in default.
 classes:
   interactive:
-    reserved: 128
+    reserved_floor: 128       # always at least 128 slots
+    reserved_per_slot: 0.25   # ...and 25% of capacity once the fleet is large
     queue_size: 256
     queue_timeout_secs: 30
     starvation_threshold_secs: 5
     can_preempt: true
   bulk:
-    reserved: 0
+    reserved_floor: 0
     queue_size: 1024
     queue_timeout_secs: 300
     starvation_threshold_secs: 120
@@ -117,7 +118,8 @@ Each entry under `classes` accepts the following fields. All are per-class.
 
 | Field | Type | Meaning |
 |-------|------|---------|
-| `reserved` | integer (slots) | Slots reserved for this class. A higher class's *unused* reservation is held back from lower classes; a class's own reservation never reduces its own headroom. The sum across all classes must fit under live capacity. |
+| `reserved_floor` | integer (slots) | Minimum slots reserved for this class — the value the effective reservation never drops below. A higher class's *unused* reservation is held back from lower classes; a class's own reservation never reduces its own headroom. |
+| `reserved_per_slot` | float (0.0–1.0+) | Share of live capacity reserved for this class, on top of the floor: `effective = max(reserved_floor, ceil(reserved_per_slot × capacity))`, recomputed as capacity changes so the reservation tracks the fleet. `0.0` (the default) means purely absolute (just the floor). Must be finite and ≥ 0. At startup, if the floors + shares exceed capacity the scheduler fails safe to legacy admission; at runtime a capacity dip is absorbed by clamping the lowest classes first. |
 | `queue_size` | integer | Per-class queue depth limit. A request that arrives when the queue is full is rejected with **429**. |
 | `queue_timeout_secs` | integer (seconds) | How long a queued request waits before it is rejected with **408**. Must be `> 0`. |
 | `starvation_threshold_secs` | integer (seconds) | Head-of-queue age past which the dispatcher promotes a waiter out of normal priority order (and lets it use a reserved-but-unused slot) to avoid starvation. Must be `> 0`. |
@@ -127,14 +129,14 @@ Each entry under `classes` accepts the following fields. All are per-class.
 
 These apply to any class with no YAML override.
 
-| Class | `reserved` | `queue_size` | `queue_timeout_secs` | `starvation_threshold_secs` | `can_preempt` |
-|-------|-----------:|-------------:|---------------------:|----------------------------:|:-------------:|
-| `system` | 32 | 64 | 30 | 5 | `true` |
-| `interactive` | 128 | 256 | 30 | 5 | `true` |
-| `default` | 0 | 512 | 60 | 30 | `false` |
-| `bulk` | 0 | 1024 | 300 | 120 | `false` |
+| Class | `reserved_floor` | `reserved_per_slot` | `queue_size` | `queue_timeout_secs` | `starvation_threshold_secs` | `can_preempt` |
+|-------|-----------------:|--------------------:|-------------:|---------------------:|----------------------------:|:-------------:|
+| `system` | 32 | 0.0 | 64 | 30 | 5 | `true` |
+| `interactive` | 128 | 0.25 | 256 | 30 | 5 | `true` |
+| `default` | 0 | 0.10 | 512 | 60 | 30 | `false` |
+| `bulk` | 0 | 0.0 | 1024 | 300 | 120 | `false` |
 
-Higher classes fail fast (short queues, short timeouts) and reserve capacity; lower classes wait patiently (deep queues, long timeouts) and reserve nothing.
+Higher classes fail fast (short queues, short timeouts) and reserve capacity — `interactive` and `default` reserve a share that grows with the fleet, while `system` keeps a fixed floor (control-plane traffic is low-volume regardless of fleet size). Lower classes wait patiently (deep queues, long timeouts) and reserve nothing.
 
 ### Validation
 

--- a/model_gateway/benches/scheduler_admission.rs
+++ b/model_gateway/benches/scheduler_admission.rs
@@ -45,7 +45,7 @@ use smg_auth::RequestId;
 use tokio::runtime::Builder;
 use tokio_util::sync::CancellationToken;
 
-/// Build settings with `reserved = 0` on every class (so admission is
+/// Build settings with no reservations on any class (so admission is
 /// purely capacity-bound and small capacities don't trip the
 /// reserved-vs-capacity guard) and the given per-class `queue_size`.
 /// Other per-class fields stay at their built-in defaults.
@@ -55,7 +55,8 @@ fn settings(queue_size: u32) -> SchedulerSettings {
     let mut classes = HashMap::new();
     for c in Class::ALL {
         let mut cfg = ClassConfig::default_for(c);
-        cfg.reserved = 0;
+        cfg.reserved_floor = 0;
+        cfg.reserved_per_slot = 0.0;
         cfg.queue_size = queue_size;
         classes.insert(c, cfg);
     }

--- a/model_gateway/src/middleware/scheduler/config.rs
+++ b/model_gateway/src/middleware/scheduler/config.rs
@@ -15,10 +15,18 @@ use crate::tenant::TenantKey;
 /// don't repeat the conversion.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct ClassConfig {
-    /// Slots reserved for this class. Higher-class reservations are
-    /// honored by lower-class admissions via the packed-CAS slot
-    /// accounting in [`super::scheduler`].
-    pub reserved: u16,
+    /// Absolute minimum slots reserved for this class — the value the
+    /// effective reservation never drops below. Higher-class reservations
+    /// are honored by lower-class admissions via the packed-CAS slot
+    /// accounting in [`super::slots`].
+    pub reserved_floor: u16,
+    /// Share of backend capacity reserved for this class, on top of the
+    /// floor: `effective = max(reserved_floor, ceil(reserved_per_slot ×
+    /// capacity))`, recomputed as capacity changes. `0.0` (the default) is
+    /// purely absolute — identical to a fixed `reserved_floor`. Must be
+    /// finite and non-negative.
+    #[serde(default)]
+    pub reserved_per_slot: f64,
     /// Per-class queue depth limit.
     pub queue_size: u32,
     /// How long a queued waiter waits before the admission middleware
@@ -42,28 +50,32 @@ impl ClassConfig {
     pub fn default_for(class: Class) -> Self {
         match class {
             Class::System => Self {
-                reserved: 32,
+                reserved_floor: 32,
+                reserved_per_slot: 0.0,
                 queue_size: 64,
                 queue_timeout_secs: 30,
                 starvation_threshold_secs: 5,
                 can_preempt: true,
             },
             Class::Interactive => Self {
-                reserved: 128,
+                reserved_floor: 128,
+                reserved_per_slot: 0.25,
                 queue_size: 256,
                 queue_timeout_secs: 30,
                 starvation_threshold_secs: 5,
                 can_preempt: true,
             },
             Class::Default => Self {
-                reserved: 0,
+                reserved_floor: 0,
+                reserved_per_slot: 0.10,
                 queue_size: 512,
                 queue_timeout_secs: 60,
                 starvation_threshold_secs: 30,
                 can_preempt: false,
             },
             Class::Bulk => Self {
-                reserved: 0,
+                reserved_floor: 0,
+                reserved_per_slot: 0.0,
                 queue_size: 1024,
                 queue_timeout_secs: 300,
                 starvation_threshold_secs: 120,
@@ -75,8 +87,9 @@ impl ClassConfig {
 
 /// Runtime view of [`ClassConfig`] — only the fields the dispatcher
 /// reads on its hot path, with seconds pre-converted to [`Duration`].
-/// `reserved` and `queue_size` live elsewhere (the packed-CAS array
-/// and the per-class queue impl), so they don't appear here.
+/// `reserved_floor`/`reserved_per_slot` and `queue_size` live elsewhere
+/// (the packed-CAS array and the per-class queue impl), so they don't
+/// appear here.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ClassRuntimeConfig {
     pub queue_timeout: Duration,
@@ -119,15 +132,18 @@ pub struct PrioritySchedulerYaml {
 }
 
 /// Per-field validation failures discovered while assembling
-/// [`SchedulerSettings`]. Capacity-vs-reserved validation is not in
-/// scope here — the scheduler performs it at construction time, once
-/// the live backend capacity is known.
+/// [`SchedulerSettings`]. Capacity-vs-reserved is not checked here: the
+/// scheduler derives effective reservations from the floors + shares and
+/// clamps them to the live capacity (priority-ordered), so reservations
+/// can never exceed capacity and there is nothing to reject.
 #[derive(Debug, thiserror::Error, PartialEq)]
 pub enum SettingsValidationError {
     #[error("class {class:?}: queue_timeout_secs must be > 0")]
     ZeroQueueTimeout { class: Class },
     #[error("class {class:?}: starvation_threshold_secs must be > 0")]
     ZeroStarvationThreshold { class: Class },
+    #[error("class {class:?}: reserved_per_slot must be finite and >= 0")]
+    InvalidReservedPerSlot { class: Class },
 }
 
 /// Runtime scheduler configuration assembled from CLI flags + the
@@ -165,8 +181,8 @@ impl SchedulerSettings {
     }
 
     /// Assemble settings from CLI flags + optional YAML, validating
-    /// per-field invariants. Capacity-vs-reserved validation is the
-    /// scheduler's job at construction time.
+    /// per-field invariants. Reservations are clamped to the live capacity
+    /// by the scheduler, so there is no capacity-vs-reserved check here.
     ///
     /// Merge order: built-in defaults → YAML overrides per class. CLI
     /// flags supply the top-level fields (`enabled`, `default_max_class`,
@@ -197,6 +213,9 @@ impl SchedulerSettings {
             }
             if cfg.starvation_threshold_secs == 0 {
                 return Err(SettingsValidationError::ZeroStarvationThreshold { class });
+            }
+            if !cfg.reserved_per_slot.is_finite() || cfg.reserved_per_slot < 0.0 {
+                return Err(SettingsValidationError::InvalidReservedPerSlot { class });
             }
         }
 
@@ -229,7 +248,7 @@ mod tests {
     #[test]
     fn test_default_for_system() {
         let cfg = ClassConfig::default_for(Class::System);
-        assert_eq!(cfg.reserved, 32);
+        assert_eq!(cfg.reserved_floor, 32);
         assert_eq!(cfg.queue_size, 64);
         assert_eq!(cfg.queue_timeout_secs, 30);
         assert_eq!(cfg.starvation_threshold_secs, 5);
@@ -239,7 +258,7 @@ mod tests {
     #[test]
     fn test_default_for_interactive() {
         let cfg = ClassConfig::default_for(Class::Interactive);
-        assert_eq!(cfg.reserved, 128);
+        assert_eq!(cfg.reserved_floor, 128);
         assert_eq!(cfg.queue_size, 256);
         assert_eq!(cfg.queue_timeout_secs, 30);
         assert_eq!(cfg.starvation_threshold_secs, 5);
@@ -249,7 +268,7 @@ mod tests {
     #[test]
     fn test_default_for_default() {
         let cfg = ClassConfig::default_for(Class::Default);
-        assert_eq!(cfg.reserved, 0);
+        assert_eq!(cfg.reserved_floor, 0);
         assert_eq!(cfg.queue_size, 512);
         assert_eq!(cfg.queue_timeout_secs, 60);
         assert_eq!(cfg.starvation_threshold_secs, 30);
@@ -259,7 +278,7 @@ mod tests {
     #[test]
     fn test_default_for_bulk() {
         let cfg = ClassConfig::default_for(Class::Bulk);
-        assert_eq!(cfg.reserved, 0);
+        assert_eq!(cfg.reserved_floor, 0);
         assert_eq!(cfg.queue_size, 1024);
         assert_eq!(cfg.queue_timeout_secs, 300);
         assert_eq!(cfg.starvation_threshold_secs, 120);
@@ -298,7 +317,7 @@ mod tests {
         let yaml = r"
 classes:
   interactive:
-    reserved: 200
+    reserved_floor: 200
     queue_size: 256
     queue_timeout_secs: 30
     starvation_threshold_secs: 5
@@ -309,7 +328,7 @@ classes:
             .classes
             .get(&Class::Interactive)
             .expect("interactive present");
-        assert_eq!(interactive.reserved, 200);
+        assert_eq!(interactive.reserved_floor, 200);
         // Only one class entry — others are absent (settings layer fills defaults).
         assert_eq!(parsed.classes.len(), 1);
         assert!(parsed.tenant_policies.is_empty());
@@ -382,7 +401,7 @@ tenant_policies:
     fn test_settings_yaml_partial_override_merges_with_defaults() {
         let mut classes = HashMap::new();
         let mut interactive = ClassConfig::default_for(Class::Interactive);
-        interactive.reserved = 64;
+        interactive.reserved_floor = 64;
         classes.insert(Class::Interactive, interactive);
         let yaml = PrioritySchedulerYaml {
             classes,
@@ -390,7 +409,7 @@ tenant_policies:
         };
         let s =
             SchedulerSettings::from_cli_and_yaml(true, Class::Default, 32, Some(&yaml)).unwrap();
-        assert_eq!(s.class_config(Class::Interactive).reserved, 64);
+        assert_eq!(s.class_config(Class::Interactive).reserved_floor, 64);
         // Bulk untouched — still equal to built-in default.
         assert_eq!(
             s.class_config(Class::Bulk),

--- a/model_gateway/src/middleware/scheduler/engine.rs
+++ b/model_gateway/src/middleware/scheduler/engine.rs
@@ -84,11 +84,14 @@ pub struct PriorityScheduler {
     /// exits cleanly.
     pub(super) release_notify: Arc<Notify>,
     class_config: [ClassRuntimeConfig; 4],
-    /// Configured per-class reservations (immutable baseline). The live
-    /// `slot_pool` reservations are recomputed from this on every capacity
-    /// change, so a capacity recovery restores them instead of leaving them
-    /// permanently scaled down.
-    configured_reserved: [u16; 4],
+    /// Per-class reservation floors (immutable baseline). The live
+    /// `slot_pool` reservations are recomputed from the floors + shares on
+    /// every capacity change, so the effective reservation tracks capacity
+    /// and a recovery restores it instead of eroding permanently.
+    reserved_floor: [u16; 4],
+    /// Per-class reservation shares of capacity (immutable baseline).
+    /// Effective = `max(floor, ceil(share × capacity))`.
+    reserved_per_slot: [f64; 4],
 }
 
 impl Drop for PriorityScheduler {
@@ -101,36 +104,39 @@ impl Drop for PriorityScheduler {
 
 impl PriorityScheduler {
     /// Build a scheduler against the given settings and live backend
-    /// capacity. Refuses if the configured reservations sum to more than
-    /// the available capacity (the scheduler would otherwise lock itself
-    /// out of its own non-reserved classes).
+    /// capacity. Refuses if the configured reservation floors + shares, at
+    /// the initial capacity, sum to more than the available capacity (a
+    /// too-small fleet or misconfiguration — the caller falls back to legacy
+    /// admission). Runtime capacity dips are handled gracefully by the
+    /// priority-ordered clamp in `apply_new_capacity`, not by rejection.
     pub fn new(
         settings: &SchedulerSettings,
         capacity: u16,
     ) -> Result<Arc<Self>, SchedulerInitError> {
-        let total_reserved: u32 = Class::ALL
-            .iter()
-            .map(|c| u32::from(settings.class_config(*c).reserved))
-            .sum();
-        if total_reserved > u32::from(capacity) {
+        let reserved_floor = Class::ALL.map(|c| settings.class_config(c).reserved_floor);
+        let reserved_per_slot = Class::ALL.map(|c| settings.class_config(c).reserved_per_slot);
+
+        let desired = desired_reservations(reserved_floor, &reserved_per_slot, capacity);
+        let total: u32 = desired.iter().map(|&r| u32::from(r)).sum();
+        if total > u32::from(capacity) {
             return Err(SchedulerInitError::ReservationsExceedCapacity {
-                reserved: total_reserved,
+                reserved: total,
                 capacity,
             });
         }
 
-        let reserved_arr = Class::ALL.map(|c| settings.class_config(c).reserved);
         let class_queues: [Arc<dyn ClassQueue>; 4] = Class::ALL.map(|c| queue_for(settings, c));
         let class_config: [ClassRuntimeConfig; 4] =
             Class::ALL.map(|c| ClassRuntimeConfig::from_class_config(settings.class_config(c)));
 
         Ok(Arc::new(Self {
-            slot_pool: SlotPool::new(capacity, reserved_arr),
+            slot_pool: SlotPool::new(capacity, desired),
             class_queues,
             inflight_registry: RwLock::new(HashMap::new()),
             release_notify: Arc::new(Notify::new()),
             class_config,
-            configured_reserved: reserved_arr,
+            reserved_floor,
+            reserved_per_slot,
         }))
     }
 
@@ -612,16 +618,14 @@ impl PriorityScheduler {
 
     /// Apply a new backend capacity from the WorkerCapacity watch.
     ///
-    /// Recomputes the live per-class reservations from the configured
-    /// baseline: on shrink past `Σ configured`, scales them down
-    /// proportionally so the new capacity stays usable; otherwise restores
-    /// the configured values. On grow, also fires `release_notify` so the
-    /// dispatcher re-evaluates queued waiters under the larger ceiling.
-    ///
-    /// Driving from the immutable baseline (not the current, possibly
-    /// already-scaled live values) makes this idempotent and lets a capacity
-    /// recovery fully restore the reservations — scaling in place would lose
-    /// the originals and erode them permanently across a shrink/grow cycle.
+    /// Recomputes the live per-class reservations from the immutable floors +
+    /// shares (`desired_reservations`), so the effective reservation tracks
+    /// capacity and a recovery restores it automatically. When the desired
+    /// sum exceeds the new capacity (a runtime dip below what the floors +
+    /// shares want), the priority-ordered clamp keeps the highest classes
+    /// whole and yields the lowest — runtime never rejects. On grow, also
+    /// fires `release_notify` so the dispatcher re-evaluates queued waiters
+    /// under the larger ceiling.
     ///
     /// The capacity and the per-class reservations are separate atomics, so
     /// they cannot be published together. We order the two writes so a
@@ -638,30 +642,22 @@ impl PriorityScheduler {
             return;
         }
 
-        // Effective reservation per class, a pure function of (configured
-        // baseline, new capacity): scale down when the configured sum exceeds
-        // the new capacity, otherwise use the configured value as-is.
-        let configured_total: u32 = self.configured_reserved.iter().map(|&r| u32::from(r)).sum();
-        let scale_down = configured_total > u32::from(new_capacity) && configured_total > 0;
-        let new_reserved = Class::ALL.map(|class| {
-            let base = self.configured_reserved[class as usize];
-            if scale_down {
-                // Exact integer proportional scaling: floor(base * new_capacity
-                // / configured_total). Integer math (u64 temporaries to avoid
-                // overflow) avoids the f64 product/division rounding that could
-                // under-scale a higher class's reservation by one slot and
-                // weaken the reservation guard.
-                ((u64::from(base) * u64::from(new_capacity)) / u64::from(configured_total)) as u16
-            } else {
-                base
-            }
-        });
-        if scale_down {
+        // Desired reservations (floor + share) at the new capacity, then the
+        // priority-ordered clamp if they no longer fit. Pure function of
+        // (immutable baseline, new capacity), so it is idempotent and both
+        // directional.
+        let desired =
+            desired_reservations(self.reserved_floor, &self.reserved_per_slot, new_capacity);
+        let desired_total: u32 = desired.iter().map(|&r| u32::from(r)).sum();
+        let new_reserved = if desired_total > u32::from(new_capacity) {
             warn!(
-                configured_total_reserved = configured_total,
-                new_capacity, "scheduler: reserved slots scaled down after capacity shrink"
+                desired_total_reserved = desired_total,
+                new_capacity, "scheduler: reservations clamped to capacity (priority order)"
             );
-        }
+            clamp_reservations_to_capacity(desired, new_capacity)
+        } else {
+            desired
+        };
 
         if new_capacity > old {
             // Grow: raise the reservations before exposing the larger
@@ -681,6 +677,46 @@ impl PriorityScheduler {
             }
         }
     }
+}
+
+/// Desired per-class reservation at `capacity`:
+/// `max(floor, ceil(per_slot × capacity))`, capped per class at `capacity`.
+/// The per-class result always fits the pool, but `Σ` may exceed `capacity`
+/// (resolved by [`clamp_reservations_to_capacity`]).
+fn desired_reservations(floor: [u16; 4], per_slot: &[f64; 4], capacity: u16) -> [u16; 4] {
+    let cap = u32::from(capacity);
+    Class::ALL.map(|class| {
+        let i = class as usize;
+        // per_slot is validated finite & >= 0 in SchedulerSettings; the guard
+        // and the saturating `as u32` keep a pathological value harmless.
+        let share = (per_slot[i] * f64::from(capacity)).ceil();
+        let share = if share.is_finite() && share >= 0.0 {
+            share as u32
+        } else {
+            0
+        };
+        u32::from(floor[i]).max(share).min(cap) as u16
+    })
+}
+
+/// Clamp desired reservations to fit `capacity`, priority-ordered: fill
+/// System → Bulk, each taking `min(desired, remaining)`. The highest classes
+/// keep their seats under an extreme shrink and the lowest yield first. The
+/// result always sums to `<= capacity`.
+fn clamp_reservations_to_capacity(desired: [u16; 4], capacity: u16) -> [u16; 4] {
+    let mut remaining = capacity;
+    let mut out = [0u16; 4];
+    for class in [
+        Class::System,
+        Class::Interactive,
+        Class::Default,
+        Class::Bulk,
+    ] {
+        let give = desired[class as usize].min(remaining);
+        out[class as usize] = give;
+        remaining -= give;
+    }
+    out
 }
 
 /// Build the per-class queue with its configured fixed depth limit.
@@ -758,19 +794,23 @@ mod tests {
 
     #[test]
     fn test_new_succeeds_when_reservations_fit() {
-        // Built-in defaults: Σ reserved = 128 (Interactive) + 32 (System) = 160.
+        // Built-in defaults at capacity 256: desired Σ = 186 (System 32,
+        // Interactive 128, Default ceil(0.10*256)=26) ≤ 256.
         let s = default_settings();
         assert!(PriorityScheduler::new(&s, 256).is_ok());
     }
 
     #[test]
     fn test_new_rejects_when_reservations_exceed_capacity() {
+        // Capacity 100: desired is System 32, Interactive min(128,100)=100,
+        // Default 10 — Σ 142 > 100, so construction rejects (caller falls
+        // back to legacy).
         let s = default_settings();
         let result = PriorityScheduler::new(&s, 100);
         assert!(matches!(
             result,
             Err(SchedulerInitError::ReservationsExceedCapacity {
-                reserved: 160,
+                reserved: 142,
                 capacity: 100
             })
         ));
@@ -786,13 +826,13 @@ mod tests {
 
     #[test]
     fn test_acquire_returns_none_when_reservation_guard_blocks() {
-        // Capacity 200, reservations 160 (Interactive=128, System=32). Bulk
-        // is the lowest class so it gets capacity - 160 = 40 slots before
-        // the guard refuses further admissions.
+        // Capacity 200, reservations 180 (System 32, Interactive 128, Default
+        // ceil(0.10*200)=20). Bulk is the lowest class so it gets capacity -
+        // 180 = 20 slots before the guard refuses further admissions.
         let s = default_settings();
         let scheduler = PriorityScheduler::new(&s, 200).unwrap();
         let mut held = Vec::new();
-        for i in 0..40 {
+        for i in 0..20 {
             held.push(
                 scheduler
                     .acquire_inflight(Class::Bulk, rid(&format!("req-{i}")))
@@ -847,7 +887,8 @@ mod tests {
         let mut classes = StdMap::new();
         for c in Class::ALL {
             let mut cfg = ClassConfig::default_for(c);
-            cfg.reserved = 0;
+            cfg.reserved_floor = 0;
+            cfg.reserved_per_slot = 0.0;
             if c == class {
                 cfg.queue_size = queue_size;
                 cfg.queue_timeout_secs = queue_timeout_secs;
@@ -1115,7 +1156,8 @@ mod tests {
         let mut classes = StdMap::new();
         for c in Class::ALL {
             let mut cfg = ClassConfig::default_for(c);
-            cfg.reserved = 0;
+            cfg.reserved_floor = 0;
+            cfg.reserved_per_slot = 0.0;
             // Tight thresholds so the test runs fast.
             cfg.starvation_threshold_secs = 1;
             if c == Class::Bulk {
@@ -1124,7 +1166,7 @@ mod tests {
             // Interactive reserves the entire capacity, locking Bulk out
             // of the normal-priority admission path.
             if c == Class::Interactive {
-                cfg.reserved = 1;
+                cfg.reserved_floor = 1;
             }
             classes.insert(c, cfg);
         }
@@ -1158,7 +1200,8 @@ mod tests {
         let mut classes = StdMap::new();
         for c in Class::ALL {
             let mut cfg = ClassConfig::default_for(c);
-            cfg.reserved = 0;
+            cfg.reserved_floor = 0;
+            cfg.reserved_per_slot = 0.0;
             // Set tiny starvation threshold for Bulk so an immediate
             // enqueue is "stale" by the time wake fires.
             if c == Class::Bulk {
@@ -1167,7 +1210,7 @@ mod tests {
             }
             // Interactive holds the full capacity in reservation.
             if c == Class::Interactive {
-                cfg.reserved = 1;
+                cfg.reserved_floor = 1;
             }
             classes.insert(c, cfg);
         }
@@ -1245,10 +1288,11 @@ mod tests {
     }
 
     #[test]
-    fn test_apply_new_capacity_shrink_below_reserved_scales_reservations() {
-        // Built-in defaults: Interactive reserves 128, System reserves 32
-        // = 160 total. Shrink to 80; reservations should scale by 0.5 so
-        // the new sum fits.
+    fn test_apply_new_capacity_shrink_clamps_reservations_priority_ordered() {
+        // Built-in defaults at capacity 80: desired is System 32, Interactive
+        // 128 (floor), Default ceil(0.10*80)=8 — Σ 168 > 80. The
+        // priority-ordered clamp keeps System whole (32), gives Interactive
+        // the remainder (48), and yields Default and Bulk.
         let s = default_settings();
         let scheduler = PriorityScheduler::new(&s, 256).unwrap();
         scheduler.apply_new_capacity(80);
@@ -1259,68 +1303,41 @@ mod tests {
             .sum();
         assert!(
             new_total <= 80,
-            "scaled reservations ({new_total}) must fit under new capacity"
+            "clamped reservations ({new_total}) must fit"
         );
-        // Each individual class is also scaled down proportionally
-        // (floor rounding).
-        assert_eq!(scheduler.slot_pool.reserved(Class::Interactive), 64);
-        assert_eq!(scheduler.slot_pool.reserved(Class::System), 16);
+        assert_eq!(scheduler.slot_pool.reserved(Class::System), 32);
+        assert_eq!(scheduler.slot_pool.reserved(Class::Interactive), 48);
+        assert_eq!(scheduler.slot_pool.reserved(Class::Default), 0);
+        assert_eq!(scheduler.slot_pool.reserved(Class::Bulk), 0);
     }
 
     #[test]
     fn test_apply_new_capacity_restores_reservations_after_recovery() {
-        // One-way-degrade fix: a shrink scales reservations down, but a later
-        // capacity recovery fully restores them (the live values are recomputed
-        // from the configured baseline each time, not eroded in place).
+        // Reservations are recomputed from the floors + shares on every
+        // capacity change, so a shrink-then-recover fully restores them (no
+        // one-way degrade), and the share tracks a growing fleet.
         let s = default_settings();
         let scheduler = PriorityScheduler::new(&s, 256).unwrap();
+        // cap 256: System 32, Interactive max(128, 64)=128, Default ceil(25.6)=26.
         assert_eq!(scheduler.slot_pool.reserved(Class::Interactive), 128);
-        assert_eq!(scheduler.slot_pool.reserved(Class::System), 32);
+        assert_eq!(scheduler.slot_pool.reserved(Class::Default), 26);
 
-        // Shrink to 80 (< 160 reserved) → scale by 0.5.
+        // Shrink to 80: desired Σ 168 > 80 → priority clamp (System 32, the
+        // remaining 48 to Interactive, Default/Bulk yield).
         scheduler.apply_new_capacity(80);
-        assert_eq!(scheduler.slot_pool.reserved(Class::Interactive), 64);
-        assert_eq!(scheduler.slot_pool.reserved(Class::System), 16);
+        assert_eq!(scheduler.slot_pool.reserved(Class::Interactive), 48);
+        assert_eq!(scheduler.slot_pool.reserved(Class::Default), 0);
 
-        // Recover to 256 → reservations fully restored, not stuck at 64/16.
+        // Recover to 256 → fully restored, not stuck at the clamped values.
         scheduler.apply_new_capacity(256);
         assert_eq!(scheduler.slot_pool.reserved(Class::Interactive), 128);
-        assert_eq!(scheduler.slot_pool.reserved(Class::System), 32);
+        assert_eq!(scheduler.slot_pool.reserved(Class::Default), 26);
 
-        // A second shrink recomputes from the baseline (128/32), not from the
-        // restored live value: shrink to 120 → scale 0.75 → 96 / 24.
-        scheduler.apply_new_capacity(120);
-        assert_eq!(scheduler.slot_pool.reserved(Class::Interactive), 96);
-        assert_eq!(scheduler.slot_pool.reserved(Class::System), 24);
-    }
-
-    #[test]
-    fn test_apply_new_capacity_scales_reservations_with_integer_math() {
-        // Exact integer proportional scaling must not under-scale a higher
-        // class's reservation by f64 rounding. One class reserving 22 with
-        // capacity 22 -> 15: exact floor is (22*15)/22 = 15, but the f64 path
-        // (22.0 * (15.0/22.0)).floor() rounds to 14, weakening the guard.
-        use std::collections::HashMap as StdMap;
-        let mut classes = StdMap::new();
-        for c in Class::ALL {
-            let mut cfg = ClassConfig::default_for(c);
-            cfg.reserved = if c == Class::Interactive { 22 } else { 0 };
-            classes.insert(c, cfg);
-        }
-        let yaml = PrioritySchedulerYaml {
-            classes,
-            tenant_policies: StdMap::new(),
-        };
-        let s =
-            SchedulerSettings::from_cli_and_yaml(true, Class::Default, 32, Some(&yaml)).unwrap();
-        let scheduler = PriorityScheduler::new(&s, 22).unwrap();
-
-        scheduler.apply_new_capacity(15);
-        assert_eq!(
-            scheduler.slot_pool.reserved(Class::Interactive),
-            15,
-            "floor(22*15/22) = 15, not the f64-rounded 14"
-        );
+        // Grow past Interactive's floor: at 800 the 0.25 share wins (200 > 128)
+        // and Default's 0.10 share is 80 — reservations track the larger fleet.
+        scheduler.apply_new_capacity(800);
+        assert_eq!(scheduler.slot_pool.reserved(Class::Interactive), 200);
+        assert_eq!(scheduler.slot_pool.reserved(Class::Default), 80);
     }
 
     #[test]
@@ -1330,6 +1347,45 @@ mod tests {
         let before = scheduler.slot_pool.reserved(Class::Interactive);
         scheduler.apply_new_capacity(256);
         assert_eq!(scheduler.slot_pool.reserved(Class::Interactive), before);
+    }
+
+    // ── reservation math helpers ──────────────────────────────────────
+
+    #[test]
+    fn test_desired_reservations_floor_then_share() {
+        // Indexed by `class as usize`: [Bulk, Default, Interactive, System].
+        let floor = [0u16, 0, 128, 32];
+        let per_slot = [0.0f64, 0.10, 0.25, 0.0];
+        // cap 256: floor wins for Interactive (128 > 64); Default share = 26.
+        let d = desired_reservations(floor, &per_slot, 256);
+        assert_eq!(d[Class::System as usize], 32);
+        assert_eq!(d[Class::Interactive as usize], 128);
+        assert_eq!(d[Class::Default as usize], 26);
+        assert_eq!(d[Class::Bulk as usize], 0);
+        // cap 800: Interactive share (200) overtakes its floor; Default = 80.
+        let d = desired_reservations(floor, &per_slot, 800);
+        assert_eq!(d[Class::Interactive as usize], 200);
+        assert_eq!(d[Class::Default as usize], 80);
+        // Each class is capped at capacity (floor 128 capped to 10).
+        let d = desired_reservations(floor, &per_slot, 10);
+        assert_eq!(d[Class::Interactive as usize], 10);
+    }
+
+    #[test]
+    fn test_clamp_reservations_priority_ordered() {
+        // [Bulk, Default, Interactive, System], Σ 185 > 100.
+        let out = clamp_reservations_to_capacity([5, 20, 128, 32], 100);
+        // System keeps its 32, Interactive takes the remaining 68, rest yield.
+        assert_eq!(out[Class::System as usize], 32);
+        assert_eq!(out[Class::Interactive as usize], 68);
+        assert_eq!(out[Class::Default as usize], 0);
+        assert_eq!(out[Class::Bulk as usize], 0);
+        assert_eq!(out.iter().map(|&r| u32::from(r)).sum::<u32>(), 100);
+        // Fits already: every class keeps its full desired value.
+        assert_eq!(
+            clamp_reservations_to_capacity([1, 2, 3, 4], 100),
+            [1, 2, 3, 4]
+        );
     }
 
     #[tokio::test]
@@ -1418,7 +1474,8 @@ mod tests {
         let mut classes = StdMap::new();
         for c in Class::ALL {
             let mut cfg = ClassConfig::default_for(c);
-            cfg.reserved = 0;
+            cfg.reserved_floor = 0;
+            cfg.reserved_per_slot = 0.0;
             cfg.queue_size = 8;
             cfg.queue_timeout_secs = 1;
             classes.insert(c, cfg);

--- a/model_gateway/tests/scheduler_admission_test.rs
+++ b/model_gateway/tests/scheduler_admission_test.rs
@@ -19,7 +19,7 @@
 //!   capacity to exactly one slot — no reliance on the legacy
 //!   `--max-concurrent-requests` fallback (which only applies when zero workers
 //!   are healthy).
-//! * **Reservations.** Every test ships a YAML config that sets `reserved: 0`
+//! * **Reservations.** Every test ships a YAML config that sets `reserved_floor: 0`
 //!   on *all four* classes. This matters: with the built-in defaults
 //!   (Interactive 128 + System 32 = 160) `PriorityScheduler::new` would reject
 //!   the tiny capacities here and `AdmissionMode::from_config` would silently
@@ -61,16 +61,16 @@ use crate::common::{
 
 /// One class's tunables for the generated YAML.
 ///
-/// [`ClassYaml::base`] zeroes `reserved` (see the module docs for why every
-/// class must read 0 to keep small-capacity tests on the priority path); the
-/// starvation test is the sole place that deliberately sets it non-zero.
+/// [`ClassYaml::base`] zeroes `reserved_floor` (see the module docs for why
+/// every class must read 0 to keep small-capacity tests on the priority path);
+/// the starvation test is the sole place that deliberately sets it non-zero.
 #[derive(Clone, Copy)]
 struct ClassYaml {
     queue_size: u32,
     queue_timeout_secs: u64,
     starvation_threshold_secs: u64,
     can_preempt: bool,
-    reserved: u16,
+    reserved_floor: u16,
 }
 
 impl ClassYaml {
@@ -83,7 +83,7 @@ impl ClassYaml {
             queue_timeout_secs: 30,
             starvation_threshold_secs: 3600,
             can_preempt: false,
-            reserved: 0,
+            reserved_floor: 0,
         }
     }
 }
@@ -119,9 +119,9 @@ impl SchedulerYaml {
 fn write_scheduler_yaml(cfg: &SchedulerYaml) -> NamedTempFile {
     fn class_block(name: &str, c: &ClassYaml) -> String {
         format!(
-            "  {name}:\n    reserved: {}\n    queue_size: {}\n    queue_timeout_secs: {}\n    \
+            "  {name}:\n    reserved_floor: {}\n    queue_size: {}\n    queue_timeout_secs: {}\n    \
              starvation_threshold_secs: {}\n    can_preempt: {}\n",
-            c.reserved,
+            c.reserved_floor,
             c.queue_size,
             c.queue_timeout_secs,
             c.starvation_threshold_secs,
@@ -594,7 +594,7 @@ async fn starvation_override_promotes_aged_bulk_request() {
     // Interactive reserves the whole (capacity-1) pool, locking Bulk out of the
     // normal admission path. Reservations sum to 1 == capacity, so the
     // scheduler still builds (no fallback to legacy).
-    yaml.interactive.reserved = 1;
+    yaml.interactive.reserved_floor = 1;
     // Bulk ages out of starvation quickly; keep a real queue to wait in.
     yaml.bulk.starvation_threshold_secs = 1;
     yaml.bulk.queue_size = 4;


### PR DESCRIPTION
## Description

### Problem
Reservations were absolute counts that (a) eroded permanently across a capacity shrink→recover cycle and (b) didn't track a growing fleet — a fixed `interactive=128` becomes a shrinking fraction as the backend scales. (Proposal `04-capacity-proportional-reservations-proposal.md`, Problems A and B.) The standalone Problem-A fix shipped in #1587; this supersedes it with the share model.

### Solution
Each class's reservation is `max(reserved_floor, ⌈reserved_per_slot × capacity⌉)`, recomputed from the immutable floors + shares on every capacity change. Problem A disappears by construction (the live value is always derived from config, both directions); Problem B is solved (the share holds its proportion as the fleet scales).

## Changes
- **`config.rs`** — `ClassConfig.reserved` → `reserved_floor`; new `reserved_per_slot: f64` (serde default `0.0` = purely absolute). Tiered defaults: System `{32, 0.0}`, Interactive `{128, 0.25}`, Default `{0, 0.10}`, Bulk `{0, 0.0}`. `reserved_per_slot` validated finite & ≥ 0 (`SettingsValidationError::InvalidReservedPerSlot`).
- **`engine.rs`** — `desired_reservations(floor, per_slot, capacity)` + `clamp_reservations_to_capacity(desired, capacity)` (priority-ordered System→Bulk). `new` and `apply_new_capacity` derive live reservations through them.
- **Dependent updates (rename ripple):** `benches/scheduler_admission.rs` and `tests/scheduler_admission_test.rs` (from #1584/#1585) updated to the `reserved_floor` schema; both stay green.

## Behavior decisions (confirmed with the owner)
- **Tiered shares** (fleet-tracking on by default for Interactive/Default; System fixed — control-plane is low-volume regardless).
- **Construction = fail-fast:** `new` rejects when floors+shares exceed the initial capacity (→ legacy fallback + ERROR log), surfacing a too-small fleet / misconfig rather than silently weakening guarantees.
- **Runtime = graceful:** `apply_new_capacity` never rejects — the priority-ordered clamp keeps the highest classes whole and yields the lowest on a transient dip.
- Minor, documented deviation from proposal 04 (which clamps at construction too): keeps `new` honestly fallible and avoids churning ~38 call sites.

### Breaking config note
The YAML field `reserved` is renamed to `reserved_floor`. Acceptable now — the scheduler is flag-off (`--priority-scheduler-enabled` default false) and unreleased.

## Test Plan
- `cargo test -p smg --lib scheduler::` → 111 pass (new `desired_reservations`/`clamp_reservations_to_capacity` unit tests; capacity tests rewritten for share+clamp: shrink→priority-clamp, shrink→recover→restore, grow→share-tracks-fleet).
- `cargo test -p smg --lib` → 1009 pass; `--test scheduler_test` → 13; `--test scheduler_admission_test` (#1585) → 15.
- `cargo build -p smg --all-targets`, `cargo clippy -p smg --lib --tests`, `cargo +nightly fmt` all clean.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Redesigned scheduler reservation model to use per-class reservation floors plus capacity-share parameters instead of a single reserved value, improving allocation granularity and capacity handling.

* **Tests**
  * Updated scheduler tests and benchmarks to use the new reservation parameters and validate floor-then-share behavior and clamping.

* **Documentation**
  * Updated Priority Scheduler docs and examples to describe the new floor+share configuration and defaults.

* **Bug Fixes**
  * Added validation for reservation-share inputs to reject invalid/negative values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->