### PR TITLE
fix(bindings): expose `consistent_hashing` and `prefix_hash` in python CLI

### DIFF
--- a/bindings/python/src/smg/router_args.py
+++ b/bindings/python/src/smg/router_args.py
@@ -10,6 +10,19 @@ from smg.smg_rs import get_available_reasoning_parsers, get_available_tool_call_
 logger = logging.getLogger(__name__)
 
 
+COMMON_POLICY_CHOICES = [
+    "random",
+    "round_robin",
+    "cache_aware",
+    "power_of_two",
+    "manual",
+    "consistent_hashing",
+    "prefix_hash",
+]
+
+PREFILL_POLICY_CHOICES = [*COMMON_POLICY_CHOICES, "bucket"]
+
+
 @dataclasses.dataclass
 class RouterArgs:
     # Worker configuration
@@ -286,7 +299,7 @@ class RouterArgs:
             f"--{prefix}policy",
             type=str,
             default=RouterArgs.policy,
-            choices=["random", "round_robin", "cache_aware", "power_of_two", "manual"],
+            choices=COMMON_POLICY_CHOICES,
             help=(
                 "Load balancing policy to use. In PD mode, this is used for both prefill and decode"
                 " unless overridden"
@@ -296,14 +309,7 @@ class RouterArgs:
             f"--{prefix}prefill-policy",
             type=str,
             default=None,
-            choices=[
-                "random",
-                "round_robin",
-                "cache_aware",
-                "power_of_two",
-                "manual",
-                "bucket",
-            ],
+            choices=PREFILL_POLICY_CHOICES,
             help=(
                 "Specific policy for prefill nodes in PD mode."
                 " If not specified, uses the main policy"
@@ -313,7 +319,7 @@ class RouterArgs:
             f"--{prefix}decode-policy",
             type=str,
             default=None,
-            choices=["random", "round_robin", "cache_aware", "power_of_two", "manual"],
+            choices=COMMON_POLICY_CHOICES,
             help=(
                 "Specific policy for decode nodes in PD mode."
                 " If not specified, uses the main policy"

--- a/bindings/python/tests/test_arg_parser.py
+++ b/bindings/python/tests/test_arg_parser.py
@@ -464,6 +464,8 @@ class TestPolicyFromStr:
         assert policy_from_str("round_robin") == PolicyType.RoundRobin
         assert policy_from_str("cache_aware") == PolicyType.CacheAware
         assert policy_from_str("power_of_two") == PolicyType.PowerOfTwo
+        assert policy_from_str("consistent_hashing") == PolicyType.ConsistentHashing
+        assert policy_from_str("prefix_hash") == PolicyType.PrefixHash
 
     def test_invalid_policy(self):
         """Test conversion of invalid policy string."""
@@ -525,6 +527,65 @@ class TestParseRouterArgs:
         assert router_args.decode_urls == ["http://decode1:8001", "http://decode2:8001"]
         assert router_args.prefill_policy == "power_of_two"
         assert router_args.decode_policy == "round_robin"
+
+    def test_parse_pd_args_with_new_policies(self):
+        """Test parsing PD disaggregated mode arguments with new policy options."""
+        # Test consistent_hashing for both prefill and decode
+        args = [
+            "--pd-disaggregation",
+            "--prefill",
+            "http://prefill1:8000",
+            "--decode",
+            "http://decode1:8001",
+            "--prefill-policy",
+            "consistent_hashing",
+            "--decode-policy",
+            "consistent_hashing",
+        ]
+
+        router_args = parse_router_args(args)
+
+        assert router_args.pd_disaggregation is True
+        assert router_args.prefill_policy == "consistent_hashing"
+        assert router_args.decode_policy == "consistent_hashing"
+
+        # Test prefix_hash for both prefill and decode
+        args = [
+            "--pd-disaggregation",
+            "--prefill",
+            "http://prefill1:8000",
+            "--decode",
+            "http://decode1:8001",
+            "--prefill-policy",
+            "prefix_hash",
+            "--decode-policy",
+            "prefix_hash",
+        ]
+
+        router_args = parse_router_args(args)
+
+        assert router_args.pd_disaggregation is True
+        assert router_args.prefill_policy == "prefix_hash"
+        assert router_args.decode_policy == "prefix_hash"
+
+        # Test mixed policies
+        args = [
+            "--pd-disaggregation",
+            "--prefill",
+            "http://prefill1:8000",
+            "--decode",
+            "http://decode1:8001",
+            "--prefill-policy",
+            "consistent_hashing",
+            "--decode-policy",
+            "prefix_hash",
+        ]
+
+        router_args = parse_router_args(args)
+
+        assert router_args.pd_disaggregation is True
+        assert router_args.prefill_policy == "consistent_hashing"
+        assert router_args.decode_policy == "prefix_hash"
 
     def test_parse_service_discovery_args(self):
         """Test parsing service discovery arguments."""
@@ -684,6 +745,30 @@ class TestParseRouterArgs:
         # Note: model-path and tokenizer-path arguments are not available in current implementation
         # This test is skipped until those arguments are added
         pytest.skip("Tokenizer arguments not available in current implementation")
+
+    def test_parse_valid_policies(self):
+        """Test parsing all valid policy arguments."""
+        # Test consistent_hashing policy
+        router_args = parse_router_args(["--policy", "consistent_hashing"])
+        assert router_args.policy == "consistent_hashing"
+
+        # Test prefix_hash policy
+        router_args = parse_router_args(["--policy", "prefix_hash"])
+        assert router_args.policy == "prefix_hash"
+
+        # Test all policies in the choices list
+        valid_policies = [
+            "random",
+            "round_robin",
+            "cache_aware",
+            "power_of_two",
+            "manual",
+            "consistent_hashing",
+            "prefix_hash",
+        ]
+        for policy in valid_policies:
+            router_args = parse_router_args(["--policy", policy])
+            assert router_args.policy == policy
 
     def test_parse_invalid_args(self):
         """Test parsing invalid arguments."""

--- a/model_gateway/src/policies/factory.rs
+++ b/model_gateway/src/policies/factory.rs
@@ -136,6 +136,12 @@ mod tests {
 
         let policy = PolicyFactory::create_from_config(&PolicyConfig::ConsistentHashing);
         assert_eq!(policy.name(), "consistent_hashing");
+
+        let policy = PolicyFactory::create_from_config(&PolicyConfig::PrefixHash {
+            prefix_token_count: 100,
+            load_factor: 0.8,
+        });
+        assert_eq!(policy.name(), "prefix_hash");
     }
 
     #[tokio::test]
@@ -154,6 +160,8 @@ mod tests {
         assert!(PolicyFactory::create_by_name("Manual").is_some());
         assert!(PolicyFactory::create_by_name("consistent_hashing").is_some());
         assert!(PolicyFactory::create_by_name("ConsistentHashing").is_some());
+        assert!(PolicyFactory::create_by_name("prefix_hash").is_some());
+        assert!(PolicyFactory::create_by_name("PrefixHash").is_some());
         assert!(PolicyFactory::create_by_name("unknown").is_none());
     }
 }


### PR DESCRIPTION
## Description

### Problem

<!-- What problem is this PR trying to solve? -->

`consistent_hashing` and `prefix_hash` policies are implemented in rust, but they are not exposed in python CLI. So user can't select `consistent_hashing` and `prefix_hash` like below:

```
python3 -m smg.launch_router --policy consistent_hashing
launch_router.py: error: argument --policy: invalid choice: 'consistent_hashing' (choose from 'random', 'round_robin', 'cache_aware', 'power_of_two', 'manual')

python3 -m smg.launch_router --prefill-policy consistent_hashing
launch_router.py: error: argument --prefill-policy: invalid choice: 'consistent_hashing' (choose from 'random', 'round_robin', 'cache_aware', 'power_of_two', 'manual', 'bucket')

python3 -m smg.launch_router --decode-policy consistent_hashing
launch_router.py: error: argument --decode-policy: invalid choice: 'consistent_hashing' (choose from 'random', 'round_robin', 'cache_aware', 'power_of_two', 'manual')
```

refs: https://github.com/sgl-project/sglang/pull/17972

### Solution

<!-- How does this PR solve the problem? -->

Add `consistent_hashing` and `prefix_hash` to `choices` list for `--policy`, `--prefill-policy`, and `-decode-policy` in `bindings/python/src/smg/router_args.py`.

## Changes

<!-- - Describe your changes here. -->

Add `consistent_hashing` and `prefix_hash` to `choices` list for `--policy`, `--prefill-policy`, and `-decode-policy` in `bindings/python/src/smg/router_args.py`.

## Test Plan

<!-- Provide a thorough reproducible test showing before and after behavior. -->

Add related test cases in `bindings/python/tests/test_arg_parser.py` and `model_gateway/src/policies/factory.rs`.
Plus, user can select `consistent_hashing` and `prefix_hash` without above error message.

```
python3 -m smg.launch_router --policy consistent_hashing
python3 -m smg.launch_router --prefill-policy consistent_hashing
python3 -m smg.launch_router --decode-policy consistent_hashing
python3 -m smg.launch_router --policy prefix_hash
python3 -m smg.launch_router --prefill-policy prefix_hash
python3 -m smg.launch_router --decode-policy prefix_hash
```

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two new routing policy options: consistent_hashing and prefix_hash
  * These policies can be selected via CLI for policy, prefill-policy, and decode-policy

* **Tests**
  * Expanded test coverage for CLI parsing and policy handling, including mixed prefill/decode combinations
  * Added tests verifying acceptance and preservation of the new policy values
<!-- end of auto-generated comment: release notes by coderabbit.ai -->