### PR TITLE
fix(mlx-bench): request-bound runs and compare on equal sample size

### DIFF
--- a/.github/workflows/nightly-mlx-bench.yml
+++ b/.github/workflows/nightly-mlx-bench.yml
@@ -14,18 +14,30 @@ on:
         description: "Phases to run (space-separated subset of 'mlx grpc')."
         required: false
         default: "mlx grpc"
-      concurrencies:
-        description: "Space-separated concurrencies"
-        required: false
-        default: "1 4 16 64"
       scenarios:
         description: "Space-separated scenarios (chat agent)"
         required: false
         default: "chat agent"
-      duration_min:
-        description: "Minutes per cell"
+      chat_concurrencies:
+        description: "Space-separated concurrencies for the chat scenario"
         required: false
-        default: "10"
+        default: "1 4"
+      agent_concurrencies:
+        description: "Space-separated concurrencies for the agent scenario"
+        required: false
+        default: "1 4"
+      chat_requests:
+        description: "Completed-request target per chat cell (runs are request-bounded)"
+        required: false
+        default: "60"
+      agent_requests:
+        description: "Completed-request target per agent cell (runs are request-bounded)"
+        required: false
+        default: "40"
+      duration_min:
+        description: "Per-cell wall-clock backstop (minutes); safety cap only, not the primary limit"
+        required: false
+        default: "30"
 
 permissions:
   contents: read
@@ -38,23 +50,27 @@ jobs:
   bench:
     name: MLX bench (mlx-lm vs SMG+gRPC)
     runs-on: macos-latest
-    # 4 concurrencies × 2 scenarios × 2 backends × 10 min ≈ 2.7 h, plus
-    # build + model download. Cap at 5 h for safety.
+    # Request-bounded sweep: chat c1/c4 (60 reqs) + agent c1/c4 (40 reqs), both
+    # backends. From observed RPS that's ~2.5-3 h of benchmarking plus build +
+    # model download. The 30-min/cell backstop caps a stalled cell; cap the job
+    # at 5 h for safety. (c16/c64 are excluded — see scripts/mlx_bench.sh.)
     timeout-minutes: 300
     env:
       MODEL: ${{ github.event.inputs.model || 'mlx-community/gemma-3-4b-it-qat-4bit' }}
       PHASES: >-
         ${{ github.event.inputs.phases || 'mlx grpc' }}
-      CONCURRENCIES: >-
-        ${{ github.event.inputs.concurrencies
-        || (github.event_name == 'pull_request' && '1 4'
-        || '1 4 16 64') }}
       SCENARIOS: >-
         ${{ github.event.inputs.scenarios || 'chat agent' }}
+      CHAT_CONCURRENCIES: >-
+        ${{ github.event.inputs.chat_concurrencies || '1 4' }}
+      AGENT_CONCURRENCIES: >-
+        ${{ github.event.inputs.agent_concurrencies || '1 4' }}
+      CHAT_REQUESTS: >-
+        ${{ github.event.inputs.chat_requests || '60' }}
+      AGENT_REQUESTS: >-
+        ${{ github.event.inputs.agent_requests || '40' }}
       DURATION_MIN: >-
-        ${{ github.event.inputs.duration_min
-        || (github.event_name == 'pull_request' && '3'
-        || '10') }}
+        ${{ github.event.inputs.duration_min || '30' }}
       RESULTS_DIR: bench-results
       PYTHONUNBUFFERED: "1"
     steps:

--- a/scripts/mlx_bench.sh
+++ b/scripts/mlx_bench.sh
@@ -11,16 +11,33 @@
 # Usage:
 #   ./scripts/mlx_bench.sh                          # both phases
 #   PHASES=mlx ./scripts/mlx_bench.sh               # only mlx-lm.server
-#   CONCURRENCIES="1 4" ./scripts/mlx_bench.sh      # quick sweep
+#   CHAT_CONCURRENCIES="1" CHAT_REQUESTS=20 ./scripts/mlx_bench.sh   # quick sweep
 
 set -euo pipefail
 
 PHASES="${PHASES:-mlx grpc}"
 MODEL="${MODEL:-mlx-community/gemma-3-4b-it-qat-4bit}"
-CONCURRENCIES="${CONCURRENCIES:-1 4 16 64}"
 SCENARIOS="${SCENARIOS:-chat agent}"
-DURATION_MIN="${DURATION_MIN:-5}"
-MAX_REQUESTS="${MAX_REQUESTS:-100000}"
+
+# Per-scenario concurrency sweep. c16/c64 are intentionally excluded:
+#   - c64 saturates the server (mlx-lm.server returns 503 for every request;
+#     the gRPC path queues with 0 completions in the window).
+#   - the gRPC path stalls at c16 — ~20 requests complete then ~9 min of zero
+#     completions, no result emitted (concurrency ceiling in the serving path).
+# c1/c4 give a clean, symmetric sweep that both backends actually complete.
+CHAT_CONCURRENCIES="${CHAT_CONCURRENCIES:-1 4}"
+AGENT_CONCURRENCIES="${AGENT_CONCURRENCIES:-1 4}"
+
+# Request-bounded, not time-bounded: every cell targets a fixed number of
+# completed requests so latency percentiles are computed over the same sample
+# size across backends. agent prefill (~2.5k tok) is ~3x slower per request, so
+# it gets a smaller target to stay within the time backstop.
+CHAT_REQUESTS="${CHAT_REQUESTS:-60}"
+AGENT_REQUESTS="${AGENT_REQUESTS:-40}"
+
+# Wall-clock safety backstop per cell (minutes). Real cells finish in 6-27 min;
+# this only caps a cell that stalls or runs unexpectedly slowly.
+DURATION_MIN="${DURATION_MIN:-30}"
 RESULTS_DIR="${RESULTS_DIR:-bench-results}"
 SMG_BIN="${SMG_BIN:-target/release/smg}"
 
@@ -34,6 +51,22 @@ scenario_traffic() {
     case "$1" in
         chat)  echo "D(100,256)" ;;
         agent) echo "D(2500,256)" ;;
+        *)     echo "" ;;
+    esac
+}
+
+scenario_concurrencies() {
+    case "$1" in
+        chat)  echo "$CHAT_CONCURRENCIES" ;;
+        agent) echo "$AGENT_CONCURRENCIES" ;;
+        *)     echo "" ;;
+    esac
+}
+
+scenario_requests() {
+    case "$1" in
+        chat)  echo "$CHAT_REQUESTS" ;;
+        agent) echo "$AGENT_REQUESTS" ;;
         *)     echo "" ;;
     esac
 }
@@ -111,11 +144,14 @@ run_bench_cell() {
         return 1
     fi
 
+    local max_requests
+    max_requests="$(scenario_requests "$scenario")"
+
     local exp_name="${label}_${scenario}_c${concurrency}"
     local exp_dir="$RESULTS_DIR/$exp_name"
     mkdir -p "$exp_dir"
 
-    log "[$exp_name] genai-bench scenario=$traffic c=$concurrency duration=${DURATION_MIN}m"
+    log "[$exp_name] genai-bench scenario=$traffic c=$concurrency requests=$max_requests backstop=${DURATION_MIN}m"
 
     if ! genai-bench benchmark \
         --api-backend openai \
@@ -126,13 +162,22 @@ run_bench_cell() {
         --task text-to-text \
         --num-concurrency "$concurrency" \
         --traffic-scenario "$traffic" \
-        --max-requests-per-run "$MAX_REQUESTS" \
+        --max-requests-per-run "$max_requests" \
         --max-time-per-run "$DURATION_MIN" \
         --experiment-folder-name "$exp_name" \
         --experiment-base-dir "$RESULTS_DIR"
     then
         log "[$exp_name] FAILED — recording marker, continuing"
         date -u +"%Y-%m-%dT%H:%M:%SZ" >"$exp_dir/.failed"
+        return
+    fi
+
+    # genai-bench exits 0 even when no request completes within the backstop
+    # (it writes only experiment_metadata.json). Mark that explicitly so the
+    # aggregator renders an honest "0 completed" row instead of a silent blank.
+    if ! ls "$exp_dir"/*text-to-text*.json >/dev/null 2>&1; then
+        log "[$exp_name] no result JSON — 0 completed within ${DURATION_MIN}m backstop"
+        date -u +"%Y-%m-%dT%H:%M:%SZ" >"$exp_dir/.empty"
     fi
 }
 
@@ -147,7 +192,7 @@ run_phase_mlx() {
     log "mlx-lm.server up on :$MLX_PORT (pid=$pid)"
 
     for scenario in $SCENARIOS; do
-        for c in $CONCURRENCIES; do
+        for c in $(scenario_concurrencies "$scenario"); do
             run_bench_cell "mlx" "http://127.0.0.1:$MLX_PORT" "$scenario" "$c"
         done
     done
@@ -181,7 +226,7 @@ run_phase_grpc() {
     log "SMG router up on :$ROUTER_PORT (pid=$router_pid)"
 
     for scenario in $SCENARIOS; do
-        for c in $CONCURRENCIES; do
+        for c in $(scenario_concurrencies "$scenario"); do
             run_bench_cell "grpc" "http://127.0.0.1:$ROUTER_PORT" "$scenario" "$c"
         done
     done

--- a/scripts/mlx_bench.sh
+++ b/scripts/mlx_bench.sh
@@ -175,7 +175,8 @@ run_bench_cell() {
     # genai-bench exits 0 even when no request completes within the backstop
     # (it writes only experiment_metadata.json). Mark that explicitly so the
     # aggregator renders an honest "0 completed" row instead of a silent blank.
-    if ! ls "$exp_dir"/*text-to-text*.json >/dev/null 2>&1; then
+    local result_files=("$exp_dir"/*text-to-text*.json)
+    if [ ! -e "${result_files[0]:-}" ]; then
         log "[$exp_name] no result JSON — 0 completed within ${DURATION_MIN}m backstop"
         date -u +"%Y-%m-%dT%H:%M:%SZ" >"$exp_dir/.empty"
     fi
@@ -237,6 +238,15 @@ run_phase_grpc() {
     PIDS=()
     sleep 3
 }
+
+# Validate scenarios up front — before any model server loads — so a typo in
+# SCENARIOS fails loudly instead of silently skipping cells and exiting green.
+for scenario in $SCENARIOS; do
+    if [ -z "$(scenario_traffic "$scenario")" ]; then
+        log "Unknown scenario: $scenario (expected one of: chat agent)"
+        exit 1
+    fi
+done
 
 for phase in $PHASES; do
     case "$phase" in

--- a/scripts/mlx_bench_aggregate.py
+++ b/scripts/mlx_bench_aggregate.py
@@ -42,6 +42,9 @@ class Cell:
     completed: list[dict[str, Any]]
     # True when the cell produced no result JSON (0 completed within backstop).
     empty: bool = False
+    # True when the run exited non-zero (`.failed` marker) rather than merely
+    # completing nothing — rendered as `0 (failed)` so crashes are triageable.
+    failed: bool = False
 
 
 def _find_result_json(folder: Path) -> Path | None:
@@ -55,21 +58,32 @@ def _find_result_json(folder: Path) -> Path | None:
 def _read_cell(folder: Path) -> Cell | None:
     """Return a Cell for a run dir, or None if the dir isn't a benchmark cell.
 
-    A dir that ran but completed nothing (only experiment_metadata.json, or a
-    `.empty` / `.failed` marker) yields an empty Cell so the row is rendered
-    rather than silently dropped.
+    A dir that ran but produced no result JSON yields an empty Cell so the row
+    is rendered rather than silently dropped: `.failed` (run exited non-zero) is
+    kept distinct from `.empty` (ran to the backstop with zero completions).
     """
     j = _find_result_json(folder)
     if j is None:
-        if (folder / ".empty").exists() or (folder / ".failed").exists():
+        if (folder / ".failed").exists():
+            return Cell(agg={}, completed=[], empty=True, failed=True)
+        if (folder / ".empty").exists():
             return Cell(agg={}, completed=[], empty=True)
         return None
     try:
         data = json.loads(j.read_text())
     except json.JSONDecodeError:
         return None
-    agg = data.get("aggregated_metrics", {})
-    completed = [r for r in data.get("individual_request_metrics", []) if not r.get("error_code")]
+    # genai-bench output is trusted, but tolerate malformed/partial JSON rather
+    # than crashing the whole aggregation on one bad cell.
+    if not isinstance(data, dict):
+        return None
+    agg = data.get("aggregated_metrics")
+    if not isinstance(agg, dict):
+        agg = {}
+    individual = data.get("individual_request_metrics")
+    if not isinstance(individual, list):
+        individual = []
+    completed = [r for r in individual if isinstance(r, dict) and not r.get("error_code")]
     return Cell(agg=agg, completed=completed, empty=not completed)
 
 
@@ -143,7 +157,10 @@ def build_section(
         present = [
             results[(label, scenario, c)] for label in labels if (label, scenario, c) in results
         ]
-        completed_counts = [len(cell.completed) for cell in present if cell.completed]
+        # Include zero-completion cells: if a present backend completed nothing,
+        # N collapses to 0 and the surviving backend's latency is left blank —
+        # there is no equal-N peer to compare it against.
+        completed_counts = [len(cell.completed) for cell in present]
         n = min(completed_counts) if completed_counts else 0
 
         for label in labels:
@@ -154,15 +171,16 @@ def build_section(
                 continue
             if cell.empty or not cell.completed:
                 err = cell.agg.get("error_codes_frequency") or {}
-                note = (
-                    f"0 ({', '.join(f'{k}×{v}' for k, v in err.items())})"
-                    if err
-                    else "0 (timed out)"
-                )
+                if cell.failed:
+                    note = "0 (failed)"
+                elif err:
+                    note = f"0 ({', '.join(f'{k}×{v}' for k, v in err.items())})"
+                else:
+                    note = "0 (timed out)"
                 lines.append(f"| {c} | {pretty} | {note} | — | 0.00 | 0.0 | — | — | — |")
                 continue
 
-            sample = cell.completed[:n] if n else cell.completed
+            sample = cell.completed[:n]
             ttft = _vals(sample, "ttft")
             tpot = _vals(sample, "tpot")
             lines.append(
@@ -180,8 +198,9 @@ def build_section(
             "",
             "> `N (compared)` = min completed across backends for the cell; TTFT/TPOT "
             "are computed over each backend's first N completed requests so the latency "
-            "comparison uses an equal sample size. RPS, output tok/s and `Completed` are "
-            "whole-run values.",
+            "comparison uses an equal sample size. When a backend completed 0 (timed "
+            "out / failed / saturated), N is 0 and latency is left blank — there is no "
+            "equal-N peer. RPS, output tok/s and `Completed` are whole-run values.",
             "",
         ]
     )

--- a/scripts/mlx_bench_aggregate.py
+++ b/scripts/mlx_bench_aggregate.py
@@ -4,13 +4,21 @@ Walks $RESULTS_DIR for sub-directories matching `{label}_{scenario}_c{n}/`
 (label ∈ {mlx, grpc}) and renders one section per scenario. Rows for
 backends that produced no JSON are omitted, so a PHASES=mlx run renders
 as single-backend rather than padding with `—`.
+
+Latency columns (TTFT / TPOT) are computed over the first N completed
+requests per cell, where N = min(completed) across the backends present for
+that cell. This makes the two backends comparable on an equal sample size even
+when one finished more requests than the other within the backstop. Throughput
+columns (RPS, output tok/s) and the `Completed` count remain whole-run values.
 """
 
 from __future__ import annotations
 
 import argparse
 import json
+import math
 import re
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -25,26 +33,48 @@ LABEL_DESCRIPTION = {
 WAY_NAME = {1: "Single-backend", 2: "Two-Way"}
 
 
+@dataclass
+class Cell:
+    """One benchmarked (label, scenario, concurrency) cell."""
+
+    agg: dict[str, Any]
+    # Completed (error-free) per-request metrics, in genai-bench's order.
+    completed: list[dict[str, Any]]
+    # True when the cell produced no result JSON (0 completed within backstop).
+    empty: bool = False
+
+
 def _find_result_json(folder: Path) -> Path | None:
-    for p in folder.rglob("*.json"):
+    for p in sorted(folder.rglob("*.json")):
         if "experiment_metadata" in p.name or "gpu_utilization" in p.name:
             continue
         return p
     return None
 
 
-def _read(folder: Path) -> dict[str, Any] | None:
+def _read_cell(folder: Path) -> Cell | None:
+    """Return a Cell for a run dir, or None if the dir isn't a benchmark cell.
+
+    A dir that ran but completed nothing (only experiment_metadata.json, or a
+    `.empty` / `.failed` marker) yields an empty Cell so the row is rendered
+    rather than silently dropped.
+    """
     j = _find_result_json(folder)
     if j is None:
+        if (folder / ".empty").exists() or (folder / ".failed").exists():
+            return Cell(agg={}, completed=[], empty=True)
         return None
     try:
-        return json.loads(j.read_text())
+        data = json.loads(j.read_text())
     except json.JSONDecodeError:
         return None
+    agg = data.get("aggregated_metrics", {})
+    completed = [r for r in data.get("individual_request_metrics", []) if not r.get("error_code")]
+    return Cell(agg=agg, completed=completed, empty=not completed)
 
 
-def collect(results_dir: Path) -> dict[tuple[str, str, int], dict[str, Any]]:
-    out: dict[tuple[str, str, int], dict[str, Any]] = {}
+def collect(results_dir: Path) -> dict[tuple[str, str, int], Cell]:
+    out: dict[tuple[str, str, int], Cell] = {}
     # Aggregate runs under `if: always()`; return empty instead of crashing
     # when no phase produced output.
     if not results_dir.is_dir():
@@ -55,39 +85,46 @@ def collect(results_dir: Path) -> dict[tuple[str, str, int], dict[str, Any]]:
         m = DIRNAME_RE.match(sub.name)
         if not m:
             continue
-        data = _read(sub)
-        if data is None:
+        cell = _read_cell(sub)
+        if cell is None:
             continue
-        out[(m.group("label"), m.group("scenario"), int(m.group("concurrency")))] = data
+        out[(m.group("label"), m.group("scenario"), int(m.group("concurrency")))] = cell
     return out
 
 
-def _stat(d: dict[str, Any], path: str) -> float | None:
-    cur: Any = d
-    for part in path.split("."):
-        if not isinstance(cur, dict) or part not in cur:
-            return None
-        cur = cur[part]
-    if isinstance(cur, (int, float)):
-        return float(cur)
-    return None
+def _percentile(xs: list[float], p: float) -> float | None:
+    if not xs:
+        return None
+    xs = sorted(xs)
+    if len(xs) == 1:
+        return xs[0]
+    k = (len(xs) - 1) * (p / 100.0)
+    lo = math.floor(k)
+    hi = math.ceil(k)
+    if lo == hi:
+        return xs[int(k)]
+    return xs[lo] * (hi - k) + xs[hi] * (k - lo)
+
+
+def _mean(xs: list[float]) -> float | None:
+    return sum(xs) / len(xs) if xs else None
+
+
+def _vals(reqs: list[dict[str, Any]], key: str) -> list[float]:
+    return [r[key] for r in reqs if isinstance(r.get(key), (int, float))]
 
 
 def fmt_float(v: float | None, places: int = 2) -> str:
-    if v is None:
-        return "—"
-    return f"{v:.{places}f}"
+    return "—" if v is None else f"{v:.{places}f}"
 
 
 def fmt_ms(v_seconds: float | None) -> str:
     """genai-bench latency stats are in seconds; render as ms."""
-    if v_seconds is None:
-        return "—"
-    return f"{v_seconds * 1000:.0f}"
+    return "—" if v_seconds is None else f"{v_seconds * 1000:.0f}"
 
 
 def build_section(
-    results: dict[tuple[str, str, int], dict[str, Any]],
+    results: dict[tuple[str, str, int], Cell],
     scenario: str,
     concurrencies: list[int],
     labels: list[str],
@@ -96,31 +133,62 @@ def build_section(
         "",
         f"### Scenario `{scenario}`",
         "",
-        "| Concurrency | Backend | RPS | Output tok/s | TTFT mean (ms) | TTFT p99 (ms) | TPOT mean (ms) | Completed |",
-        "|---|---|---|---|---|---|---|---|",
+        "| Concurrency | Backend | Completed | N (compared) | RPS | Output tok/s "
+        "| TTFT mean (ms) | TTFT p99 (ms) | TPOT mean (ms) |",
+        "|---|---|---|---|---|---|---|---|---|",
     ]
     for c in concurrencies:
+        # Equal-N: compare the backends present for this cell on the smaller of
+        # their completed counts.
+        present = [
+            results[(label, scenario, c)] for label in labels if (label, scenario, c) in results
+        ]
+        completed_counts = [len(cell.completed) for cell in present if cell.completed]
+        n = min(completed_counts) if completed_counts else 0
+
         for label in labels:
-            r = results.get((label, scenario, c))
             pretty = LABEL_PRETTY[label]
-            if r is None:
-                lines.append(f"| {c} | {pretty} | — | — | — | — | — | — |")
+            cell = results.get((label, scenario, c))
+            if cell is None:
+                lines.append(f"| {c} | {pretty} | — | — | — | — | — | — | — |")
                 continue
-            agg = r.get("aggregated_metrics", {})
+            if cell.empty or not cell.completed:
+                err = cell.agg.get("error_codes_frequency") or {}
+                note = (
+                    f"0 ({', '.join(f'{k}×{v}' for k, v in err.items())})"
+                    if err
+                    else "0 (timed out)"
+                )
+                lines.append(f"| {c} | {pretty} | {note} | — | 0.00 | 0.0 | — | — | — |")
+                continue
+
+            sample = cell.completed[:n] if n else cell.completed
+            ttft = _vals(sample, "ttft")
+            tpot = _vals(sample, "tpot")
             lines.append(
                 f"| {c} | {pretty} | "
-                f"{fmt_float(agg.get('requests_per_second'))} | "
-                f"{fmt_float(agg.get('mean_output_throughput_tokens_per_s'), 1)} | "
-                f"{fmt_ms(_stat(agg, 'stats.ttft.mean'))} | "
-                f"{fmt_ms(_stat(agg, 'stats.ttft.p99'))} | "
-                f"{fmt_ms(_stat(agg, 'stats.tpot.mean'))} | "
-                f"{agg.get('num_completed_requests', '?')} |"
+                f"{cell.agg.get('num_completed_requests', len(cell.completed))} | "
+                f"{n} | "
+                f"{fmt_float(cell.agg.get('requests_per_second'))} | "
+                f"{fmt_float(cell.agg.get('mean_output_throughput_tokens_per_s'), 1)} | "
+                f"{fmt_ms(_mean(ttft))} | "
+                f"{fmt_ms(_percentile(ttft, 99))} | "
+                f"{fmt_ms(_mean(tpot))} |"
             )
-    lines.append("")
+    lines.extend(
+        [
+            "",
+            "> `N (compared)` = min completed across backends for the cell; TTFT/TPOT "
+            "are computed over each backend's first N completed requests so the latency "
+            "comparison uses an equal sample size. RPS, output tok/s and `Completed` are "
+            "whole-run values.",
+            "",
+        ]
+    )
     return lines
 
 
-def build_table(results: dict[tuple[str, str, int], dict[str, Any]], model: str) -> str:
+def build_table(results: dict[tuple[str, str, int], Cell], model: str) -> str:
     if not results:
         return "_No results found._"
     present = {k[0] for k in results}
@@ -141,7 +209,8 @@ def build_table(results: dict[tuple[str, str, int], dict[str, Any]], model: str)
         "- `agent` = `D(2500,256)` — ~2.5k token context + medium output "
         "(RAG / code-edit / Cursor-style local agent traffic)",
         "",
-        f"**Concurrencies:** {', '.join(str(c) for c in concurrencies)}",
+        f"**Concurrencies:** {', '.join(str(c) for c in concurrencies)} "
+        "(runs are request-bounded — each cell targets a fixed number of completed requests)",
         "",
         "Backends:",
     ]

--- a/scripts/mlx_bench_aggregate.py
+++ b/scripts/mlx_bench_aggregate.py
@@ -62,9 +62,12 @@ def _read_cell(folder: Path) -> Cell | None:
     is rendered rather than silently dropped: `.failed` (run exited non-zero) is
     kept distinct from `.empty` (ran to the backstop with zero completions).
     """
+    # Run status (failed/empty markers) is tracked independently of whether the
+    # result JSON has usable per-request samples.
+    failed = (folder / ".failed").exists()
     j = _find_result_json(folder)
     if j is None:
-        if (folder / ".failed").exists():
+        if failed:
             return Cell(agg={}, completed=[], empty=True, failed=True)
         if (folder / ".empty").exists():
             return Cell(agg={}, completed=[], empty=True)
@@ -84,7 +87,7 @@ def _read_cell(folder: Path) -> Cell | None:
     if not isinstance(individual, list):
         individual = []
     completed = [r for r in individual if isinstance(r, dict) and not r.get("error_code")]
-    return Cell(agg=agg, completed=completed, empty=not completed)
+    return Cell(agg=agg, completed=completed, empty=not completed, failed=failed)
 
 
 def collect(results_dir: Path) -> dict[tuple[str, str, int], Cell]:
@@ -140,7 +143,6 @@ def fmt_ms(v_seconds: float | None) -> str:
 def build_section(
     results: dict[tuple[str, str, int], Cell],
     scenario: str,
-    concurrencies: list[int],
     labels: list[str],
 ) -> list[str]:
     lines = [
@@ -151,6 +153,10 @@ def build_section(
         "| TTFT mean (ms) | TTFT p99 (ms) | TPOT mean (ms) |",
         "|---|---|---|---|---|---|---|---|---|",
     ]
+    # Only the concurrencies actually present for THIS scenario — scenarios can
+    # be swept at different concurrencies, so a global union would render an
+    # unrequested cell as a misleading "not-run" (—) row.
+    concurrencies = sorted({k[2] for k in results if k[1] == scenario})
     for c in concurrencies:
         # Equal-N: compare the backends present for this cell on the smaller of
         # their completed counts.
@@ -170,14 +176,23 @@ def build_section(
                 lines.append(f"| {c} | {pretty} | — | — | — | — | — | — | — |")
                 continue
             if cell.empty or not cell.completed:
+                # No usable latency samples — blank TTFT/TPOT/N. But keep any
+                # whole-run aggregates that were recorded (a result with valid
+                # aggregated_metrics but no per-request samples shouldn't lose
+                # its RPS/throughput/count).
                 err = cell.agg.get("error_codes_frequency") or {}
                 if cell.failed:
-                    note = "0 (failed)"
+                    status = "failed"
                 elif err:
-                    note = f"0 ({', '.join(f'{k}×{v}' for k, v in err.items())})"
+                    status = ", ".join(f"{k}×{v}" for k, v in err.items())
                 else:
-                    note = "0 (timed out)"
-                lines.append(f"| {c} | {pretty} | {note} | — | 0.00 | 0.0 | — | — | — |")
+                    status = "timed out"
+                done = int(cell.agg.get("num_completed_requests") or 0)
+                rps = fmt_float(cell.agg.get("requests_per_second") or 0.0)
+                tok = fmt_float(cell.agg.get("mean_output_throughput_tokens_per_s") or 0.0, 1)
+                lines.append(
+                    f"| {c} | {pretty} | {done} ({status}) | — | {rps} | {tok} | — | — | — |"
+                )
                 continue
 
             sample = cell.completed[:n]
@@ -213,7 +228,7 @@ def build_table(results: dict[tuple[str, str, int], Cell], model: str) -> str:
     present = {k[0] for k in results}
     labels = [label for label in LABEL_ORDER if label in present]
     scenarios = sorted({k[1] for k in results})
-    concurrencies = sorted({k[2] for k in results})
+    concurrencies = sorted({k[2] for k in results})  # union, for the intro line only
     way = WAY_NAME.get(len(labels), f"{len(labels)}-way")
     lines = [
         f"## MLX {way} Benchmark",
@@ -235,7 +250,7 @@ def build_table(results: dict[tuple[str, str, int], Cell], model: str) -> str:
     ]
     lines.extend(f"- {LABEL_DESCRIPTION[label]}" for label in labels)
     for s in scenarios:
-        lines.extend(build_section(results, s, concurrencies, labels))
+        lines.extend(build_section(results, s, labels))
     return "\n".join(lines)
 
 


### PR DESCRIPTION
## Description

### Problem

The nightly MLX benchmark was **time-bounded** (10 min/cell, with `--max-requests-per-run 100000` that never binds on a slow Apple-Silicon model). Each cell therefore completed however many requests it could fit in the window — anywhere from 12 to 96 — and the SUMMARY then compared TTFT/TPOT percentiles across those **unequal, tiny samples**. A 12-sample p99 against a 20-sample p99 isn't a real comparison, and 12–20 samples is far too few for a stable percentile.

Two further symptoms in [run 26815055120](https://github.com/lightseekorg/smg/actions/runs/26815055120):

- **Concurrency 16/64 silently produced no result.** At c64 the server saturates (`mlx-lm.server` returns `503` for every request; the gRPC path queues to 0 completions). At c16 the **gRPC path stalls** — ~20 requests complete, then ~9 min of zero completions, no result emitted — while `mlx-lm.server` handled the same cell fine (96 completed). These rows rendered as blank `—`, looking like "not run" rather than "failed".

### Solution

Make every cell complete the **same number of requests**, drop the concurrency levels that can't produce a symmetric comparison, and compare latency on an equal sample size.

## Changes

- **`scripts/mlx_bench.sh`** — request-bounded runs (chat 60, agent 40 completed reqs/cell); `DURATION_MIN` repurposed as a 30-min wall-clock backstop. Per-scenario concurrency sweep, now `c1`/`c4` only (c16 dropped for the gRPC stall, c64 for server saturation). Writes a `.empty` marker when a cell completes nothing so it is surfaced instead of dropped.
- **`scripts/mlx_bench_aggregate.py`** — computes TTFT/TPOT over each backend's first `N = min(completed)` requests so latency uses an equal sample size; adds an `N (compared)` column and renders empty/saturated cells honestly (e.g. `0 (timed out)`, `0 (503×22)`). Throughput (RPS, tok/s) and `Completed` stay whole-run.
- **`.github/workflows/nightly-mlx-bench.yml`** — per-scenario request/concurrency `workflow_dispatch` inputs and a backstop-duration input; corrected timeout rationale.

## Test Plan

Validated `mlx_bench_aggregate.py` against the artifact from run 26815055120. Equal-N output matches a manual re-aggregation, e.g. chat c1 `smg → mlx-grpc`: TTFT mean 1035 ms / p99 1946 ms over N=38 (vs the old whole-run 1034/1918 over 40). Empty cells now render as `0 (timed out)` / `0 (503×22)` instead of blank.

```
$ python3 scripts/mlx_bench_aggregate.py --results-dir <unzipped-artifact> --out /tmp/SUMMARY.md
$ ruff check scripts/ && ruff format --check scripts/   # clean
$ bash -n scripts/mlx_bench.sh                          # ok
$ pre-commit run --files scripts/mlx_bench.sh scripts/mlx_bench_aggregate.py .github/workflows/nightly-mlx-bench.yml   # all passed
```

> Note: the gRPC c16 stall looks like a real concurrency ceiling in the serving path, not just a benchmark artifact. It's tracked separately and is not part of this PR.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes (no Rust changed)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (no Rust changed)
- [x] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Benchmark workflow now supports separate chat vs agent settings, scenario-specific concurrency/requests, and a longer default run duration (30 min).
  * Bench runs are request-bounded per scenario, validate scenarios up front, use scenario-specific experiment names, and mark run outcomes explicitly (empty/failed).
* **Bug Fixes**
  * Aggregation tolerates missing/partial results, records empty/failed cells, and computes equalized latency metrics (N compared) for fair comparisons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->