### PR TITLE
fix(grpc_servicer): fix sglang grpc binds wrong IPC socket when --skip-tokenizer-init

### DIFF
--- a/grpc_servicer/smg_grpc_servicer/sglang/request_manager.py
+++ b/grpc_servicer/smg_grpc_servicer/sglang/request_manager.py
@@ -184,8 +184,14 @@ class GrpcRequestManager:
         self.context = zmq.asyncio.Context(2)
 
         # Socket for receiving outputs from scheduler
+        # If skip_tokenizer_init mode, scheduler sends outputs to tokenizer_ipc_name.
+        self.recv_ipc_name = (
+            port_args.tokenizer_ipc_name
+            if server_args.skip_tokenizer_init
+            else port_args.detokenizer_ipc_name
+        )
         self.recv_from_scheduler = get_zmq_socket(
-            self.context, zmq.PULL, port_args.detokenizer_ipc_name, bind=True
+            self.context, zmq.PULL, self.recv_ipc_name, bind=True
         )
 
         # Socket for sending requests to scheduler
@@ -225,7 +231,7 @@ class GrpcRequestManager:
 
         logger.info(
             f"GrpcRequestManager initialized with ZMQ IPC: "
-            f"recv={port_args.detokenizer_ipc_name}, "
+            f"recv={self.recv_ipc_name}, "
             f"send={port_args.scheduler_input_ipc_name}"
         )
         if self.bootstrap_server:


### PR DESCRIPTION

## Description

### Problem
GrpcRequestManager hardcodes recv_from_scheduler to port_args.detokenizer_ipc_name, but the sglang scheduler routes its output to port_args.tokenizer_ipc_name whenever --skip-tokenizer-init is enabled. The two ends bind different
  sockets, so every message the scheduler pushes is silently dropped by ZMQ.
<!-- What problem is this PR trying to solve? -->

### Solution

<!-- How does this PR solve the problem? -->
  Pick the IPC name that matches what the scheduler is actually sending to, based on server_args.skip_tokenizer_init:

  self.recv_ipc_name = (
      port_args.tokenizer_ipc_name
      if server_args.skip_tokenizer_init
      else port_args.detokenizer_ipc_name
  )
  self.recv_from_scheduler = get_zmq_socket(
      self.context, zmq.PULL, self.recv_ipc_name, bind=True
  )

## Changes
  Single-file change in grpc_servicer/smg_grpc_servicer/sglang/request_manager.py.
<!-- - Describe your changes here. -->

## Test Plan
lmsysorg/sglang:v0.5.12.post1-cu130
llama3.1-8b 1p1d disagg on 2*H200

<details>
<summary>Reproduce step</summary>

```bash
# prefill
python -m sglang.launch_server \
  --model-path /scratch1/Llama-3.1-8B-Instruct \
  --served-model-name llama3.1 \
  --grpc-mode \
  --skip-tokenizer-init \
  --host 0.0.0.0 --port 31050 \
  --tp 1 \
  --disaggregation-mode prefill \
  --disaggregation-transfer-backend mooncake \
  --disaggregation-bootstrap-port 8998 \
  --kv-events-config '{"publisher":"zmq","endpoint":"tcp://*:6620"}' \
  --trust-remote-code \
  --mem-fraction-static 0.80

# decode
export CUDA_VISIBLE_DEVICES=1
python -m sglang.launch_server \
  --model-path /scratch1/Llama-3.1-8B-Instruct \
  --served-model-name llama3.1 \
  --grpc-mode \
  --skip-tokenizer-init \
  --host 0.0.0.0 --port 31051 \
  --tp 1 \
  --disaggregation-mode decode \
  --disaggregation-transfer-backend mooncake \
  --disaggregation-bootstrap-port 9111 \
  --kv-events-config '{"publisher":"zmq","endpoint":"tcp://*:6630"}' \
  --trust-remote-code \
  --mem-fraction-static 0.80

# router
python -m sglang_router.launch_router \
  --host 0.0.0.0 --port 8080 \
  --pd-disaggregation \
  --prefill grpc://127.0.0.1:31050 8998 \
  --decode  grpc://127.0.0.1:31051 \
  --policy round_robin \
  --model-path /scratch1/Llama-3.1-8B-Instruct \
  --tokenizer-path /scratch1/Llama-3.1-8B-Instruct \
  --log-level info

# curl.sh
curl -X POST http://127.0.0.1:8080/v1/chat/completions \
      -H "Content-Type: application/json" \
      -d '{
        "model": "llama3.1",
        "messages": [{"role": "user", "content": "hi"}],
        "max_tokens": 16
      }'
```

</details>

```
before:
2026-06-03 13:22:17 ERROR http_request{method=POST uri=/v1/chat/completions version=HTTP/1.1 module="smg" request_id="chatcmpl-yyTrUY77Dq8VsE17moxcWCOq"}: smg::routers::grpc::utils: /build/sgl-model-gateway/src/routers/grpc/utils.rs:72: Tokenizer not found for model function=ChatPreparationStage::prepare_chat model=llama3.1
{"error":{"type":"Internal Server Error","code":"tokenizer_not_found","message":"Tokenizer not found for model: llama3.1"}}

after fix:
{"id":"chatcmpl-478a1bb5-07cd-47ad-9c13-62f2daa7d0b8","object":"chat.completion","created":1780489378,"model":"llama3.1","choices":[{"index":0,"message":{"role":"assistant","content":"It's nice to meet you. Is there something I can help you with,","reasoning_content":null},"finish_reason":"length"}],"usage":{"prompt_tokens":36,"completion_tokens":16,"total_tokens":52},"system_fingerprint":"default"}

```
<!-- Provide a thorough reproducible test showing before and after behavior. -->

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of request manager initialization when tokenizer setup is skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->