### PR TITLE
fix(mesh): track op-id in CRDT send watermark (replica tie-break)

### DIFF
--- a/crates/mesh/src/crdt_kv/replica.rs
+++ b/crates/mesh/src/crdt_kv/replica.rs
@@ -12,6 +12,11 @@ use uuid::Uuid;
 pub struct ReplicaId(Uuid);
 
 impl ReplicaId {
+    /// Greatest possible replica id. As a watermark tie-breaker it makes a
+    /// `(timestamp, MAX)` entry suppress every op at or below that timestamp —
+    /// the timestamp-only semantics legacy acks (no `replica_id`) speak.
+    pub const MAX: Self = Self(Uuid::max());
+
     /// Generate a new replica ID
     pub fn new() -> Self {
         Self(Uuid::now_v7())

--- a/crates/mesh/src/crdt_kv/watermark.rs
+++ b/crates/mesh/src/crdt_kv/watermark.rs
@@ -1,18 +1,28 @@
 use std::collections::HashMap;
 
-use super::operation::Operation;
+use super::{operation::Operation, replica::ReplicaId};
+
+/// A CRDT write's identity and order: `(Lamport timestamp, replica_id)`. This
+/// is exactly the key LWW uses to pick a winner (`max_by_key((timestamp,
+/// replica_id))`), so a watermark built from it advances in lockstep with the
+/// merge — including the replica tie-break when two writes share a timestamp.
+pub type CrdtVersion = (u64, ReplicaId);
 
 /// Per-peer CRDT send watermark, keyed by KEY (not by author replica). Tracks
-/// the highest version (Lamport timestamp) a peer has acknowledged for each
-/// key, so the sender can skip re-broadcasting keys the peer already has.
+/// the op-id `(timestamp, replica_id)` a peer has acknowledged for each key, so
+/// the sender can skip re-broadcasting keys the peer already has.
 ///
-/// Keying by key — not by replica — is what keeps this correct on our
-/// compacted, multi-author op-log: each key is tracked independently, so a
-/// dropped or late op only delays that one key (resent next round) and can
-/// never be hidden behind a higher version on a different key.
+/// Keying by key — not by replica — keeps this correct on our compacted,
+/// multi-author op-log: each key is tracked independently, so a dropped or late
+/// op only delays that one key (resent next round) and can never be hidden
+/// behind a higher version on a different key.
+///
+/// The op-id, not just the timestamp, is the watermark value: equal timestamps
+/// from different replicas are ordered by `replica_id` (the LWW tie-break), so
+/// a same-timestamp winner change must still be sent.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct CrdtWatermark {
-    versions: HashMap<String, u64>,
+    versions: HashMap<String, CrdtVersion>,
 }
 
 impl CrdtWatermark {
@@ -21,41 +31,71 @@ impl CrdtWatermark {
         Self::default()
     }
 
-    /// Build from a set of ops, keeping the max version per key. Used by the
-    /// receiver to ack the versions it just merged.
+    /// Build from a set of ops, keeping the max op-id per key. Used by the
+    /// receiver to ack the versions it just merged. Clones a key only when
+    /// first seen, so allocation is O(distinct keys), not O(ops).
     pub fn from_ops(ops: &[Operation]) -> Self {
-        let mut versions = HashMap::new();
+        let mut versions: HashMap<String, CrdtVersion> = HashMap::new();
         for op in ops {
-            let entry = versions.entry(op.key().to_owned()).or_insert(0);
-            *entry = (*entry).max(op.timestamp());
+            let id = (op.timestamp(), op.replica_id());
+            match versions.get_mut(op.key()) {
+                Some(existing) => *existing = (*existing).max(id),
+                None => {
+                    versions.insert(op.key().to_owned(), id);
+                }
+            }
         }
         Self { versions }
     }
 
-    /// True if `op` is newer than what the peer has acked for its key. An
-    /// unacked key counts as version 0, so it is always allowed.
+    /// True if `op` is a newer write than what the peer has acked for its key,
+    /// by `(timestamp, replica_id)` order. An unacked key always sends.
     pub fn allows(&self, op: &Operation) -> bool {
-        op.timestamp() > self.get(op.key())
-    }
-
-    /// The acked version for `key` (0 if never acked).
-    pub fn get(&self, key: &str) -> u64 {
-        self.versions.get(key).copied().unwrap_or(0)
-    }
-
-    /// Advance toward `other`, taking the per-key maximum. Monotone,
-    /// idempotent, and commutative, so out-of-order or duplicate acks are
-    /// self-correcting.
-    pub fn merge_max(&mut self, other: &CrdtWatermark) {
-        for (key, &version) in &other.versions {
-            let entry = self.versions.entry(key.clone()).or_insert(0);
-            *entry = (*entry).max(version);
+        match self.get(op.key()) {
+            Some(acked) => (op.timestamp(), op.replica_id()) > acked,
+            None => true,
         }
     }
 
-    /// Iterate `(key, version)` pairs — used by the wire codec.
-    pub fn iter(&self) -> impl Iterator<Item = (&str, u64)> {
-        self.versions.iter().map(|(k, &v)| (k.as_str(), v))
+    /// The acked op-id for `key`, if the peer has acked it.
+    pub fn get(&self, key: &str) -> Option<CrdtVersion> {
+        self.versions.get(key).copied()
+    }
+
+    /// Advance toward `other`, taking the per-key maximum op-id. Monotone,
+    /// idempotent, and commutative, so out-of-order or duplicate acks are
+    /// self-correcting.
+    pub fn merge_max(&mut self, other: &CrdtWatermark) {
+        for (key, &id) in &other.versions {
+            match self.versions.get_mut(key) {
+                Some(existing) => *existing = (*existing).max(id),
+                None => {
+                    self.versions.insert(key.clone(), id);
+                }
+            }
+        }
+    }
+
+    /// Advance from owned `(key, op-id)` pairs in place, taking the key only
+    /// when inserting a new entry. Avoids cloning keys / a temp map when
+    /// merging a received ack on the hot path.
+    pub fn merge_max_owned<I>(&mut self, iter: I)
+    where
+        I: IntoIterator<Item = (String, CrdtVersion)>,
+    {
+        for (key, id) in iter {
+            match self.versions.get_mut(&key) {
+                Some(existing) => *existing = (*existing).max(id),
+                None => {
+                    self.versions.insert(key, id);
+                }
+            }
+        }
+    }
+
+    /// Iterate `(key, op-id)` pairs — used by the wire codec.
+    pub fn iter(&self) -> impl Iterator<Item = (&str, CrdtVersion)> {
+        self.versions.iter().map(|(k, &id)| (k.as_str(), id))
     }
 
     /// True if no key has been acked yet.
@@ -64,32 +104,38 @@ impl CrdtWatermark {
     }
 }
 
-impl FromIterator<(String, u64)> for CrdtWatermark {
-    /// Build from `(key, version)` pairs, keeping the max version per key. Used
-    /// by the wire codec to rebuild a watermark from a received ack.
-    fn from_iter<I: IntoIterator<Item = (String, u64)>>(iter: I) -> Self {
-        let mut versions = HashMap::new();
-        for (key, version) in iter {
-            let entry = versions.entry(key).or_insert(0);
-            *entry = (*entry).max(version);
-        }
-        Self { versions }
+impl FromIterator<(String, CrdtVersion)> for CrdtWatermark {
+    /// Build from `(key, op-id)` pairs, keeping the max op-id per key. Used by
+    /// the wire codec to rebuild a watermark from a received ack.
+    fn from_iter<I: IntoIterator<Item = (String, CrdtVersion)>>(iter: I) -> Self {
+        let mut watermark = Self::new();
+        watermark.merge_max_owned(iter);
+        watermark
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::crdt_kv::ReplicaId;
+
+    /// Deterministic replica id `00…00NN` so tie-break tests are reproducible
+    /// (higher `n` => higher `ReplicaId`).
+    fn replica(n: u8) -> ReplicaId {
+        ReplicaId::from_string(&format!("00000000-0000-0000-0000-0000000000{n:02x}")).unwrap()
+    }
 
     fn op(key: &str, ts: u64) -> Operation {
-        Operation::insert(key.to_owned(), vec![1], ts, ReplicaId::new())
+        op_r(key, ts, 1)
+    }
+
+    fn op_r(key: &str, ts: u64, n: u8) -> Operation {
+        Operation::insert(key.to_owned(), vec![1], ts, replica(n))
     }
 
     #[test]
-    fn unknown_key_is_version_zero_and_allowed() {
+    fn unknown_key_is_unset_and_allowed() {
         let wm = CrdtWatermark::new();
-        assert_eq!(wm.get("worker:a"), 0);
+        assert_eq!(wm.get("worker:a"), None);
         assert!(wm.allows(&op("worker:a", 1)));
     }
 
@@ -97,7 +143,7 @@ mod tests {
     fn allows_only_strictly_newer_versions() {
         let wm = CrdtWatermark::from_ops(&[op("k", 5)]);
         assert!(!wm.allows(&op("k", 4)), "older version already acked");
-        assert!(!wm.allows(&op("k", 5)), "equal version already acked");
+        assert!(!wm.allows(&op("k", 5)), "equal op-id already acked");
         assert!(wm.allows(&op("k", 6)), "newer version must be sent");
         assert!(
             wm.allows(&op("other", 1)),
@@ -106,10 +152,27 @@ mod tests {
     }
 
     #[test]
-    fn from_ops_keeps_max_version_per_key() {
+    fn same_timestamp_higher_replica_is_a_newer_winner() {
+        // The replica tie-break: at equal timestamps LWW orders by replica_id,
+        // so a same-timestamp, higher-replica write is a newer winner and must
+        // be sent — a timestamp-only watermark would wrongly drop it.
+        let wm = CrdtWatermark::from_ops(&[op_r("k", 5, 1)]);
+        assert!(!wm.allows(&op_r("k", 5, 1)), "same op-id already acked");
+        assert!(
+            wm.allows(&op_r("k", 5, 2)),
+            "same timestamp, higher replica is a newer winner"
+        );
+        assert!(
+            !wm.allows(&op_r("k", 5, 0)),
+            "same timestamp, lower replica is older"
+        );
+    }
+
+    #[test]
+    fn from_ops_keeps_max_op_id_per_key() {
         let wm = CrdtWatermark::from_ops(&[op("k", 3), op("k", 9), op("k", 7), op("j", 2)]);
-        assert_eq!(wm.get("k"), 9);
-        assert_eq!(wm.get("j"), 2);
+        assert_eq!(wm.get("k"), Some((9, replica(1))));
+        assert_eq!(wm.get("j"), Some((2, replica(1))));
     }
 
     #[test]
@@ -117,9 +180,13 @@ mod tests {
         let mut a = CrdtWatermark::from_ops(&[op("k", 5), op("j", 8)]);
         let b = CrdtWatermark::from_ops(&[op("k", 3), op("j", 12), op("new", 1)]);
         a.merge_max(&b);
-        assert_eq!(a.get("k"), 5, "existing higher value is not lowered");
-        assert_eq!(a.get("j"), 12, "existing value is raised");
-        assert_eq!(a.get("new"), 1, "new key is added");
+        assert_eq!(
+            a.get("k"),
+            Some((5, replica(1))),
+            "higher op-id not lowered"
+        );
+        assert_eq!(a.get("j"), Some((12, replica(1))), "op-id raised");
+        assert_eq!(a.get("new"), Some((1, replica(1))), "new key added");
     }
 
     #[test]
@@ -128,15 +195,33 @@ mod tests {
         let b = a.clone();
         a.merge_max(&b);
         a.merge_max(&b);
-        assert_eq!(a.get("k"), 5);
+        assert_eq!(a.get("k"), Some((5, replica(1))));
+    }
+
+    #[test]
+    fn merge_max_owned_takes_per_key_maximum() {
+        let mut a = CrdtWatermark::from_ops(&[op("k", 5)]);
+        a.merge_max_owned([
+            ("k".to_owned(), (3, replica(1))),
+            ("j".to_owned(), (8, replica(2))),
+        ]);
+        assert_eq!(a.get("k"), Some((5, replica(1))), "lower op-id ignored");
+        assert_eq!(a.get("j"), Some((8, replica(2))), "new key added");
     }
 
     #[test]
     fn iter_yields_all_key_versions() {
         let wm = CrdtWatermark::from_ops(&[op("k", 5), op("j", 8)]);
-        let mut pairs: Vec<(String, u64)> = wm.iter().map(|(k, v)| (k.to_owned(), v)).collect();
+        let mut pairs: Vec<(String, CrdtVersion)> =
+            wm.iter().map(|(k, id)| (k.to_owned(), id)).collect();
         pairs.sort();
-        assert_eq!(pairs, vec![("j".to_owned(), 8), ("k".to_owned(), 5)]);
+        assert_eq!(
+            pairs,
+            vec![
+                ("j".to_owned(), (8, replica(1))),
+                ("k".to_owned(), (5, replica(1))),
+            ]
+        );
     }
 
     #[test]
@@ -148,13 +233,13 @@ mod tests {
     #[test]
     fn from_iter_takes_max_per_key() {
         let wm: CrdtWatermark = [
-            ("k".to_owned(), 3),
-            ("k".to_owned(), 9),
-            ("j".to_owned(), 2),
+            ("k".to_owned(), (3, replica(1))),
+            ("k".to_owned(), (9, replica(1))),
+            ("j".to_owned(), (2, replica(1))),
         ]
         .into_iter()
         .collect();
-        assert_eq!(wm.get("k"), 9);
-        assert_eq!(wm.get("j"), 2);
+        assert_eq!(wm.get("k"), Some((9, replica(1))));
+        assert_eq!(wm.get("j"), Some((2, replica(1))));
     }
 }

--- a/crates/mesh/src/proto/gossip.proto
+++ b/crates/mesh/src/proto/gossip.proto
@@ -107,6 +107,7 @@ message CrdtBatch {
 message CrdtKeyVersion {
   string key = 1;
   uint64 version = 2; // highest Lamport timestamp the receiver holds for this key
+  string replica_id = 3; // ReplicaId UUID text; tie-breaks equal versions (matches LWW order)
 }
 
 // Acknowledgement for a received CrdtBatch: the receiver's current version for

--- a/crates/mesh/src/tests/crdt_integration.rs
+++ b/crates/mesh/src/tests/crdt_integration.rs
@@ -216,19 +216,19 @@ fn ack_advances_watermark_to_delivered_version() {
     let receiver = MeshKV::new("receiver".to_string());
     receiver.configure_crdt_prefix("worker:", MergeStrategy::LastWriterWins);
 
-    let sent_version = pending_ops(&sender, &CrdtWatermark::new())
+    let sent_op_id = pending_ops(&sender, &CrdtWatermark::new())
         .iter()
         .find(|op| op.key() == "worker:a")
-        .map(|op| op.timestamp())
+        .map(|op| (op.timestamp(), op.replica_id()))
         .expect("worker:a is pending before any ack");
 
     let mut acked = CrdtWatermark::new();
-    assert_eq!(acked.get("worker:a"), 0);
+    assert_eq!(acked.get("worker:a"), None);
     deliver_crdt_watermarked(&sender, &receiver, &mut acked);
     assert_eq!(
         acked.get("worker:a"),
-        sent_version,
-        "ack advances the watermark to the delivered version"
+        Some(sent_op_id),
+        "ack advances the watermark to the delivered op-id"
     );
 }
 

--- a/crates/mesh/src/transport/crdt_batch.rs
+++ b/crates/mesh/src/transport/crdt_batch.rs
@@ -134,13 +134,24 @@ pub fn watermark_to_crdt_ack(watermark: &CrdtWatermark) -> CrdtAck {
 /// Decode a received [`CrdtAck`] into a [`CrdtWatermark`] for merging into the
 /// sender's per-peer send watermark. Entries with an unparsable `replica_id`
 /// are dropped (mirrors `proto_to_op`).
+///
+/// A legacy peer acks without `replica_id` (proto3 decodes the missing field as
+/// `""`); that entry maps to `(version, ReplicaId::MAX)`, which suppresses
+/// every op at or below the acked timestamp — the timestamp-only semantics the
+/// old peer speaks. Dropping it instead would leave the watermark stuck and
+/// re-send the full set every round for the whole rolling-upgrade window. (A
+/// nil sentinel would not help: the acked winner `(v, R)` compares above
+/// `(v, nil)` and would still re-send every round.)
 pub fn crdt_ack_to_watermark(ack: CrdtAck) -> CrdtWatermark {
     ack.entries
         .into_iter()
         .filter_map(|entry| {
-            ReplicaId::from_string(&entry.replica_id)
-                .ok()
-                .map(|replica| (entry.key, (entry.version, replica)))
+            let replica = if entry.replica_id.is_empty() {
+                ReplicaId::MAX
+            } else {
+                ReplicaId::from_string(&entry.replica_id).ok()?
+            };
+            Some((entry.key, (entry.version, replica)))
         })
         .collect()
 }
@@ -262,6 +273,40 @@ mod tests {
         ]);
         let back = crdt_ack_to_watermark(watermark_to_crdt_ack(&wm));
         assert_eq!(back, wm);
+    }
+
+    #[test]
+    fn legacy_ack_without_replica_suppresses_by_timestamp() {
+        // A legacy peer acks without replica_id (proto3 -> ""). The entry maps
+        // to (version, ReplicaId::MAX): ops at or below the acked timestamp
+        // are suppressed (no per-key resend every round), newer ops still send.
+        let ack = CrdtAck {
+            entries: vec![CrdtKeyVersion {
+                key: "worker:a".to_string(),
+                version: 5,
+                replica_id: String::new(),
+            }],
+        };
+        let wm = crdt_ack_to_watermark(ack);
+        let replica = ReplicaId::new();
+        let at = Operation::insert("worker:a".to_string(), b"v".to_vec(), 5, replica);
+        let older = Operation::insert("worker:a".to_string(), b"v".to_vec(), 4, replica);
+        let newer = Operation::insert("worker:a".to_string(), b"v".to_vec(), 6, replica);
+        assert!(!wm.allows(&at), "acked timestamp is suppressed");
+        assert!(!wm.allows(&older), "older ops are suppressed");
+        assert!(wm.allows(&newer), "newer ops still send");
+    }
+
+    #[test]
+    fn ack_with_unparsable_replica_id_is_dropped() {
+        let ack = CrdtAck {
+            entries: vec![CrdtKeyVersion {
+                key: "worker:a".to_string(),
+                version: 5,
+                replica_id: "not-a-uuid".to_string(),
+            }],
+        };
+        assert!(crdt_ack_to_watermark(ack).is_empty());
     }
 
     #[test]

--- a/crates/mesh/src/transport/crdt_batch.rs
+++ b/crates/mesh/src/transport/crdt_batch.rs
@@ -115,25 +115,33 @@ pub fn wrap_crdt_batch(batch: CrdtBatch, sequence: u64, self_name: &str) -> Stre
     }
 }
 
-/// Encode a [`CrdtWatermark`] as a wire [`CrdtAck`] — one entry per known key.
+/// Encode a [`CrdtWatermark`] as a wire [`CrdtAck`] — one entry per known key,
+/// carrying the op-id `(version, replica_id)` so the peer can apply the same
+/// `(timestamp, replica_id)` ordering the merge uses.
 pub fn watermark_to_crdt_ack(watermark: &CrdtWatermark) -> CrdtAck {
     CrdtAck {
         entries: watermark
             .iter()
-            .map(|(key, version)| CrdtKeyVersion {
+            .map(|(key, (version, replica))| CrdtKeyVersion {
                 key: key.to_owned(),
                 version,
+                replica_id: replica.to_string(),
             })
             .collect(),
     }
 }
 
 /// Decode a received [`CrdtAck`] into a [`CrdtWatermark`] for merging into the
-/// sender's per-peer send watermark.
+/// sender's per-peer send watermark. Entries with an unparsable `replica_id`
+/// are dropped (mirrors `proto_to_op`).
 pub fn crdt_ack_to_watermark(ack: CrdtAck) -> CrdtWatermark {
     ack.entries
         .into_iter()
-        .map(|entry| (entry.key, entry.version))
+        .filter_map(|entry| {
+            ReplicaId::from_string(&entry.replica_id)
+                .ok()
+                .map(|replica| (entry.key, (entry.version, replica)))
+        })
         .collect()
 }
 


### PR DESCRIPTION
## Description

### Problem

Follow-up to #1586. The per-key CRDT send watermark stored only the Lamport **timestamp**, but LWW orders winners by `(timestamp, replica_id)` (`lww_fold`: `max_by_key((timestamp, replica_id))`). After two concurrent same-timestamp writes to a key, a peer that acked `(k, t)` from replica `R1` would **never** receive the new winner `(k, t)` from a higher replica `R2` — `allows` checks `t > t` (false) — so the peer stays permanently diverged. (Reported by Codex review on #1586, P1.)

Same-timestamp collisions across replicas are reachable: replicas advance their Lamport clocks independently, so two can stamp the same value.

### Solution

Track the full op-id `(timestamp, replica_id)` per key and compare with the **same ordering the merge uses**, so a same-timestamp winner change is sent. `CrdtKeyVersion` gains a `replica_id` field (additive, wire-compatible). This also tightens EpochMaxWins (same-timestamp winner changes are now sent there too).

Folds in the review's allocation nits while touching these methods: `from_ops` / `merge_max` use `get_mut` so key allocation is O(distinct keys), not O(ops); a new `merge_max_owned` advances from owned ack pairs without cloning keys.

**Known limitation (deferred):** for EpochMaxWins the exported op-id is the frontier's *max* version, so a late lower-version point can change a shard's value without changing its op-id — a generic op-id watermark can't catch that. Low-impact: `rl:` values are tiny, and any later write to the key bumps the timestamp and unsticks it. A full fix needs engine-aware value-versioning.

## Changes

- **`CrdtWatermark`** (`crdt_kv/watermark.rs`): value is now `CrdtVersion = (u64, ReplicaId)`; `allows` compares op-ids lexicographically; `get` returns `Option<CrdtVersion>`; `from_ops` / `merge_max` use `get_mut`; add `merge_max_owned`.
- **proto**: `CrdtKeyVersion` gains `replica_id` (field 3).
- **codec** (`transport/crdt_batch.rs`): `watermark_to_crdt_ack` emits `replica_id`; `crdt_ack_to_watermark` parses it (dropping entries with an unparsable id, mirroring `proto_to_op`).
- **tests**: new `same_timestamp_higher_replica_is_a_newer_winner` (the P1 regression) and `merge_max_owned_takes_per_key_maximum`; existing unit/integration assertions updated for the op-id shape.

## Test Plan

- `cargo test -p smg-mesh` — **183 pass**.
- `cargo clippy -p smg-mesh --all-targets --all-features -- -D warnings` — clean.

The headline regression `same_timestamp_higher_replica_is_a_newer_winner` asserts that, after acking `(k, t, R1)`, a write `(k, t, R2)` with `R2 > R1` is still allowed (and `(k, t, R0)` with `R0 < R1` is not) — the exact divergence the timestamp-only watermark allowed.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Watermark versions now include a replica tie-breaker for deterministic ordering across replicas.

* **Bug Fixes**
  * Watermark advancement and comparison correctly use full operation identifiers, preventing incorrect suppression or advancement.

* **Tests**
  * Updated/added tests to cover tie-break behavior, per-key max selection, merging, iteration, and legacy cases.

* **Documentation**
  * Documentation updated to describe the new ordering semantics and legacy handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->