### PR TITLE
fix(responses): preserve empty output_text annotations

### DIFF
--- a/crates/protocols/src/responses.rs
+++ b/crates/protocols/src/responses.rs
@@ -2087,7 +2087,6 @@ pub enum ResponseContentPart {
     OutputText {
         text: String,
         #[serde(default)]
-        #[serde(skip_serializing_if = "Vec::is_empty")]
         annotations: Vec<Annotation>,
         #[serde(skip_serializing_if = "Option::is_none")]
         logprobs: Option<ChatLogProbs>,

--- a/model_gateway/src/routers/openai/responses/route.rs
+++ b/model_gateway/src/routers/openai/responses/route.rs
@@ -394,4 +394,29 @@ mod tests {
         assert_eq!(annotations[2]["type"], json!("file_path"));
         assert_eq!(annotations[2]["index"], json!(2));
     }
+
+    #[test]
+    fn router_serialization_preserves_empty_annotations_on_output_text() {
+        let req = ResponsesRequest {
+            model: "gpt-5.4".to_string(),
+            input: ResponseInput::Items(vec![ResponseInputOutputItem::Message {
+                id: "msg_prior".to_string(),
+                role: "assistant".to_string(),
+                content: vec![ResponseContentPart::OutputText {
+                    text: "Prior answer.".to_string(),
+                    annotations: vec![],
+                    logprobs: None,
+                }],
+                status: Some("completed".to_string()),
+                phase: None,
+            }]),
+            ..Default::default()
+        };
+
+        let payload = serialize_like_router(&req);
+        let output_text = &payload["input"][0]["content"][0];
+
+        assert_eq!(output_text["type"], json!("output_text"));
+        assert_eq!(output_text["annotations"], json!([]));
+    }
 }


### PR DESCRIPTION
## Description

### Problem

vLLM's OpenAI-compatible Responses validation requires every `output_text` content part to include an `annotations` field. Even when there are no annotations, the field must be present as an empty array.

When SMG replays prior assistant output for `previous_response_id`, an empty `annotations` vector was serialized by omitting the field. That turns a valid replay item like this:

```json
{"type":"output_text","text":"...","annotations":[]}
```

into this:

```json
{"type":"output_text","text":"..."}
```

Strict Responses validation then rejects the replayed history with an error like:

```text
3 validation errors for ValidatorIterator
0.ResponseOutputTextParam.annotations
  Field required [type=missing, input_value={'type': 'output_text', 'text': '...'}, input_type=dict]
0.ResponseOutputRefusalParam.refusal
  Field required [type=missing, input_value={'type': 'output_text', 'text': '...'}, input_type=dict]
0.ResponseOutputRefusalParam.type
  Input should be 'refusal' [type=literal_error, input_value='output_text', input_type=str]
```

### Solution

Always serialize `ResponseContentPart::OutputText.annotations`, including the empty array case. This preserves the OpenAI Responses wire shape for replayed assistant messages and keeps `previous_response_id` payloads accepted by strict upstream validators.

## Changes

- Removed the `Vec::is_empty` serialization skip from `output_text.annotations`.
- Added a regression test that verifies router serialization preserves `"annotations": []` for replayed `output_text` content.

## Test Plan

Reproduced the failure mode conceptually by serializing a Responses replay message containing an assistant `output_text` part with no annotations. Before this change, the serialized payload omitted `annotations`, which matches the vLLM validation error above. After this change, the same replay item serializes with `"annotations": []`.

Validated with:

```bash
cargo test -p smg --lib router_serialization_preserves_empty_annotations_on_output_text
pre-commit run --all-files
```

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved serialization handling of response annotations to ensure consistent behavior when annotations are missing from payloads.

* **Tests**
  * Added test coverage to verify response serialization properly handles empty annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->