### PR TITLE
ci(nightly): nightly GHCR releases for SMG + vllm/sglang/trtllm engine images

### DIFF
--- a/.github/workflows/_build-engine-image.yml
+++ b/.github/workflows/_build-engine-image.yml
@@ -53,6 +53,11 @@ on:
         required: false
         default: false
         type: boolean
+      extra_tags:
+        description: 'Additional GHCR tags to push from the same build (newline-separated). Empty = none.'
+        required: false
+        default: ''
+        type: string
 
 jobs:
   build-and-push:
@@ -236,13 +241,23 @@ jobs:
         id: push-ghcr
         env:
           IMAGE_TAG: ${{ steps.resolve.outputs.image_tag }}
+          EXTRA_TAGS: ${{ inputs.extra_tags }}
+          OWNER: ${{ github.repository_owner }}
         run: |
           BASE_IMAGE_TAG="smg-build:${IMAGE_TAG}"
-          TARGET_IMAGE="ghcr.io/${{ github.repository_owner }}/smg:${IMAGE_TAG}"
+          TARGET_IMAGE="ghcr.io/${OWNER}/smg:${IMAGE_TAG}"
           echo "image_name=${TARGET_IMAGE}" >> "$GITHUB_OUTPUT"
           docker tag "${BASE_IMAGE_TAG}" "${TARGET_IMAGE}"
           docker push "${TARGET_IMAGE}"
           echo "**Pushed:** \`${TARGET_IMAGE}\`" >> $GITHUB_STEP_SUMMARY
+          # Push any additional (e.g. floating) tags from the same local image.
+          while IFS= read -r extra; do
+            [ -z "${extra}" ] && continue
+            EXTRA_IMAGE="ghcr.io/${OWNER}/smg:${extra}"
+            docker tag "${BASE_IMAGE_TAG}" "${EXTRA_IMAGE}"
+            docker push "${EXTRA_IMAGE}"
+            echo "**Pushed:** \`${EXTRA_IMAGE}\`" >> $GITHUB_STEP_SUMMARY
+          done <<< "${EXTRA_TAGS}"
 
       # ── Cleanup ──────────────────────────────────────────────────────────────
 
@@ -252,12 +267,18 @@ jobs:
           IMAGE_TAG: ${{ steps.resolve.outputs.image_tag }}
           PUSHED_IMAGE: ${{ steps.push-ghcr.outputs.image_name }}
           BASE_REF: ${{ steps.resolve.outputs.base_image_ref }}
+          EXTRA_TAGS: ${{ inputs.extra_tags }}
+          OWNER: ${{ github.repository_owner }}
         run: |
           docker rmi "smg-build:${IMAGE_TAG}" || true
           docker rmi "${PUSHED_IMAGE}" || true
           if [ -n "${BASE_REF}" ]; then
             docker rmi "${BASE_REF}" || true
           fi
+          while IFS= read -r extra; do
+            [ -z "${extra}" ] && continue
+            docker rmi "ghcr.io/${OWNER}/smg:${extra}" || true
+          done <<< "${EXTRA_TAGS}"
 
       - name: Summary
         if: always()

--- a/.github/workflows/nightly-docker.yml
+++ b/.github/workflows/nightly-docker.yml
@@ -38,13 +38,24 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Compute image tags
+        id: tags
+        run: |
+          SUFFIX="$(date -u +%Y%m%d)-${GITHUB_SHA::7}"
+          {
+            echo "list<<EOF"
+            echo "ghcr.io/lightseekorg/smg:nightly"
+            echo "ghcr.io/lightseekorg/smg:nightly-${SUFFIX}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Build and push
         uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/Dockerfile
           push: true
-          tags: ghcr.io/lightseekorg/smg:nightly
+          tags: ${{ steps.tags.outputs.list }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/nightly-engine-docker.yml
+++ b/.github/workflows/nightly-engine-docker.yml
@@ -12,15 +12,16 @@ concurrency:
   group: nightly-engine-docker
   cancel-in-progress: true
 
+# Least-privilege default for all jobs; the build job elevates to packages: write below.
 permissions:
   contents: read
-  packages: write
 
 jobs:
   prep:
     name: Compute nightly tag suffix
     if: github.repository == 'lightseekorg/smg'
     runs-on: ubuntu-latest
+    # Inherits the workflow default (contents: read only) — no package access needed.
     outputs:
       suffix: ${{ steps.suffix.outputs.suffix }}
     steps:
@@ -32,6 +33,11 @@ jobs:
     name: Build ${{ matrix.engine }} nightly
     needs: [prep]
     if: github.repository == 'lightseekorg/smg'
+    # The reusable workflow checks out SMG and pushes images to ghcr.io, so this
+    # job (not the whole workflow) needs packages: write.
+    permissions:
+      contents: read   # checkout in the reusable workflow
+      packages: write  # push to ghcr.io in the reusable workflow
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/nightly-engine-docker.yml
+++ b/.github/workflows/nightly-engine-docker.yml
@@ -1,4 +1,5 @@
 name: Nightly Engine Docker Build
+run-name: "Nightly engines | smg=${{ github.sha }} | by @${{ github.actor }}"
 
 on:
   schedule:
@@ -48,7 +49,8 @@ jobs:
     with:
       engine: ${{ matrix.engine }}
       base_image_ref: ${{ matrix.base_image_ref }}
-      smg_commit: main
+      smg_commit: ${{ github.sha }}
       tag: nightly-${{ needs.prep.outputs.suffix }}-${{ matrix.engine }}-${{ matrix.engine_ver }}
+      # Floating "latest nightly" pointer for this engine, intentionally overwritten each run.
       extra_tags: nightly-${{ matrix.engine }}
     secrets: inherit

--- a/.github/workflows/nightly-engine-docker.yml
+++ b/.github/workflows/nightly-engine-docker.yml
@@ -1,0 +1,54 @@
+name: Nightly Engine Docker Build
+
+on:
+  schedule:
+    # 07:00 UTC daily — staggered 1 hour after the main nightly (06:00 UTC),
+    # and before the 08:00 UTC nightly benchmarks.
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: nightly-engine-docker
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  prep:
+    name: Compute nightly tag suffix
+    if: github.repository == 'lightseekorg/smg'
+    runs-on: ubuntu-latest
+    outputs:
+      suffix: ${{ steps.suffix.outputs.suffix }}
+    steps:
+      - name: Compute suffix
+        id: suffix
+        run: echo "suffix=$(date -u +%Y%m%d)-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
+  build:
+    name: Build ${{ matrix.engine }} nightly
+    needs: [prep]
+    if: github.repository == 'lightseekorg/smg'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - engine: vllm
+            base_image_ref: vllm/vllm-openai:v0.19.0
+            engine_ver: v0.19.0
+          - engine: sglang
+            base_image_ref: lmsysorg/sglang:v0.5.10
+            engine_ver: v0.5.10
+          - engine: trtllm
+            base_image_ref: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10
+            engine_ver: 1.3.0rc10
+    uses: ./.github/workflows/_build-engine-image.yml
+    with:
+      engine: ${{ matrix.engine }}
+      base_image_ref: ${{ matrix.base_image_ref }}
+      smg_commit: main
+      tag: nightly-${{ needs.prep.outputs.suffix }}-${{ matrix.engine }}-${{ matrix.engine_ver }}
+      extra_tags: nightly-${{ matrix.engine }}
+    secrets: inherit


### PR DESCRIPTION
## Description

### Problem

SMG's nightly Docker story has two gaps:

1. **The main-image nightly uses a single mutable tag.** `nightly-docker.yml` pushes only `ghcr.io/lightseekorg/smg:nightly`, overwriting it in place each run. There's no immutable counterpart, so users can only pin a specific night's build by raw `@sha256:` digest — there's no readable, reproducible tag. ("Which nightly hit this bug?" is unanswerable from a tag.)
2. **The gRPC engine images (vllm/sglang/trtllm) have no nightly at all.** They only build on version-bump push, PR (dry-run), or manual dispatch, so the latest SMG `main` is never exercised against the engines on a schedule.

(Verified the existing main-image nightly *does* build and push successfully — the issue is tag hygiene and missing engine coverage, not a broken build.)

### Solution

- Reuse the existing `_build-engine-image.yml` reusable workflow, extending it with one **optional, backward-compatible** `extra_tags` input so a single build can push multiple GHCR tags from the same loaded image (default `''` = current behavior, release path untouched).
- Add a new scheduled **`nightly-engine-docker.yml`** that builds all three engine images nightly with SMG pinned to the run's `main` HEAD.
- Give every nightly artifact (main + engines) a **floating** tag for convenience and an **immutable** `nightly-<date>-<sha7>` tag for reproducible pinning, both from a single build.

## Changes

- **`.github/workflows/_build-engine-image.yml`** — add optional `extra_tags` input (newline-separated, default `''`); push each extra tag from the same locally-loaded image after the primary push; extend cleanup to remove them. No-op for existing release callers.
- **`.github/workflows/nightly-engine-docker.yml`** (new) — 07:00 UTC (staggered 1h after the 06:00 main nightly) + `workflow_dispatch`. A `prep` job computes a shared `<date>-<sha7>` suffix; a `fail-fast: false` matrix over vllm/sglang/trtllm (latest pinned bases) calls the reusable workflow with `smg_commit: ${{ github.sha }}`, an immutable `tag`, and a floating `extra_tags`.
- **`.github/workflows/nightly-docker.yml`** — compute the same `<date>-<sha7>` suffix in a shell step (works identically on `schedule` and `workflow_dispatch`, unlike `metadata-action`'s `type=schedule`) and push `:nightly` + `:nightly-<date>-<sha7>`.

### Resulting tags per night (example date `20260604`, SMG `main` HEAD `97534f2`)

```
smg:nightly                                       (main, floating)
smg:nightly-20260604-97534f2                      (main, immutable)
smg:nightly-vllm                                  (vllm, floating)
smg:nightly-20260604-97534f2-vllm-v0.19.0         (vllm, immutable)
smg:nightly-sglang                                (sglang, floating)
smg:nightly-20260604-97534f2-sglang-v0.5.10       (sglang, immutable)
smg:nightly-trtllm                                (trtllm, floating)
smg:nightly-20260604-97534f2-trtllm-1.3.0rc10     (trtllm, immutable)
```

All in the single `ghcr.io/lightseekorg/smg` package; the `nightly-` prefix keeps them disjoint from released `<ver>-<engine>-<ver>` tags. The immutable engine tag mirrors the released format with `nightly-<date>-<sha>` standing in for the version field.

## Test Plan

Static validation (CI is YAML-only; no source touched):

- `actionlint` on all three workflows — only pre-existing warnings remain (custom `cpu-e5` runner label; the pervasive unquoted `>> \$GITHUB_STEP_SUMMARY` shellcheck *info/style* idiom). New `nightly-engine-docker.yml` is fully clean; the new heredoc step in `nightly-docker.yml` produces no shellcheck output.
- PyYAML parse of all three — OK.
- Local bash simulation of the `extra_tags` push loop confirms the empty default is a true no-op and non-empty values push exactly once.
- Local simulation of the `$GITHUB_OUTPUT` heredoc confirms a valid newline-separated `tags` list.
- Confirmed `release-{vllm,sglang,trtllm}-docker.yml` don't reference `extra_tags` → unaffected.

Post-merge manual verification (needs runners + GHCR):

- `workflow_dispatch` `release-vllm-docker.yml` (or a PR touching `docker/engine.Dockerfile`) → still builds/pushes only its single release tag (no `nightly-*` tags).
- `workflow_dispatch` `nightly-engine-docker.yml` → each engine pushes both its floating and immutable tag (`docker buildx imagetools inspect ...`).
- `workflow_dispatch` `nightly-docker.yml` → `:nightly` and `:nightly-<date>-<sha7>` both resolve.
- Pin check: an immutable tag's digest is unchanged across nightly runs, while the floating tags move.

> Operational follow-up (not in this PR): confirm the `ghcr.io/lightseekorg/smg` package visibility is **public** if external users are expected to pull nightlies.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes (N/A — no Rust changed)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (N/A — no Rust changed)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Nightly Docker images now include date-stamped and short-commit tags alongside static nightly tags for clearer versioning.
  * Added scheduled nightly builds across multiple engine targets with per-engine floating and detailed nightly tags.

* **Chores**
  * Enhanced image build/push process to support pushing multiple additional registry tags and clean them up locally.
  * Build workflow now outputs computed tag lists for use by downstream steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->