### PR TITLE
refactor(multimodal): Multimodal ABI generalization

### DIFF
--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -100,7 +100,19 @@ jobs:
       - name: Test import
         run: |
           pip install crates/grpc_client/python/dist/*.whl
-          python -c "from smg_grpc_proto import sglang_scheduler_pb2; print('OK')"
+          python - <<'PY'
+          from smg_grpc_proto import sglang_scheduler_pb2, tokenspeed_scheduler_pb2
+
+          fields = tokenspeed_scheduler_pb2.TensorData.DESCRIPTOR.fields_by_name
+          assert "data" not in fields
+          assert fields["shape"].number == 1
+          assert fields["dtype"].number == 2
+          assert fields["inline"].number == 3
+          assert fields["shm"].number == 4
+          assert fields["remote"].number == 5
+
+          print("OK")
+          PY
 
   build-wheel:
     runs-on: k8s-runner-gpu

--- a/crates/grpc_client/proto/tokenspeed_scheduler.proto
+++ b/crates/grpc_client/proto/tokenspeed_scheduler.proto
@@ -101,6 +101,7 @@ message GenerateRequest {
 
   // Preprocessed multimodal payload. Absent for text-only requests.
   MultimodalInputs mm_inputs = 9;
+
 }
 
 message TokenizedInput {
@@ -121,6 +122,21 @@ message PlaceholderRange {
   uint32 length = 2;
 }
 
+enum Modality {
+  MODALITY_UNSPECIFIED = 0;
+  IMAGE = 1;
+  AUDIO = 2;
+  VIDEO = 3;
+}
+
+message MultimodalItem {
+  Modality modality = 1;
+  bytes content_hash = 2;
+  map<string, TensorData> tensors = 3;
+  repeated PlaceholderRange placeholders = 4;
+  optional uint32 placeholder_token_id = 5;
+}
+
 // Multimodal inputs for vision/audio models. Tensors are produced by the
 // gateway's per-model preprocessor (crates/multimodal); the servicer
 // only reconstructs them and hands them to the engine — no preprocess.
@@ -136,6 +152,10 @@ message MultimodalInputs {
 
   // Placeholder offsets: where each image's tokens are in input_ids.
   repeated PlaceholderRange mm_placeholders = 4;
+
+  // V2 itemized payload for mixed-modality and video/audio requests. When
+  // present, servicers must prefer this over the legacy image-only fields.
+  repeated MultimodalItem items = 10;
 }
 
 message GenerateResponse {
@@ -242,6 +262,8 @@ message GetModelInfoResponse {
   // router's mm_inputs handling (router rejects mm requests for
   // non-vision workers before tokenization).
   bool supports_vision = 14;
+  bool supports_multimodal = 15;
+  repeated Modality supported_modalities = 16;
 }
 
 message GetServerInfoRequest {}

--- a/crates/grpc_client/proto/tokenspeed_scheduler.proto
+++ b/crates/grpc_client/proto/tokenspeed_scheduler.proto
@@ -109,18 +109,22 @@ message TokenizedInput {
   string original_text = 2; // cosmetic, for worker logs
 }
 
-// A typed tensor: shape + dtype + transport-specific payload.
+// A typed tensor: raw little-endian bytes + shape + dtype.
+//
+// Keep tags 1/2/3 compatible with the original image-only ABI so rolling
+// gateway/worker upgrades do not reinterpret existing tensor fields.
 message TensorData {
-  repeated uint32 shape = 1;   // Dimension sizes
-  string dtype = 2;            // "float32", "bfloat16", "float16", "int64", "uint32"
+  bytes data = 1;              // Legacy inline bytes.
+  repeated uint32 shape = 2;   // Dimension sizes
+  string dtype = 3;            // "float32", "bfloat16", "float16", "int64", "uint32"
 
   oneof payload {
-    // Current path: raw little-endian bytes carried in the gRPC message.
-    bytes inline = 3;
+    // New inline path. Producers may also use legacy field 1 for compatibility.
+    bytes inline = 4;
     // Same-host CPU shared memory path.
-    ShmHandle shm = 4;
+    ShmHandle shm = 5;
     // Transport-specific remote descriptor (NIXL/RDMA/object-store/etc.).
-    RemoteTensorHandle remote = 5;
+    RemoteTensorHandle remote = 6;
   }
 }
 

--- a/crates/grpc_client/proto/tokenspeed_scheduler.proto
+++ b/crates/grpc_client/proto/tokenspeed_scheduler.proto
@@ -109,22 +109,19 @@ message TokenizedInput {
   string original_text = 2; // cosmetic, for worker logs
 }
 
-// A typed tensor: raw little-endian bytes + shape + dtype.
-//
-// Keep tags 1/2/3 compatible with the original image-only ABI so rolling
-// gateway/worker upgrades do not reinterpret existing tensor fields.
+// A typed tensor descriptor. The raw tensor bytes live in exactly one payload
+// transport; shape and dtype describe how the receiver should interpret them.
 message TensorData {
-  bytes data = 1;              // Legacy inline bytes.
-  repeated uint32 shape = 2;   // Dimension sizes
-  string dtype = 3;            // "float32", "bfloat16", "float16", "int64", "uint32"
+  repeated uint32 shape = 1;   // Dimension sizes
+  string dtype = 2;            // "float32", "bfloat16", "float16", "int64", "uint32"
 
   oneof payload {
-    // New inline path. Producers may also use legacy field 1 for compatibility.
-    bytes inline = 4;
+    // Current path: raw little-endian bytes carried in the gRPC message.
+    bytes inline = 3;
     // Same-host CPU shared memory path.
-    ShmHandle shm = 5;
+    ShmHandle shm = 4;
     // Transport-specific remote descriptor (NIXL/RDMA/object-store/etc.).
-    RemoteTensorHandle remote = 6;
+    RemoteTensorHandle remote = 5;
   }
 }
 

--- a/crates/grpc_client/proto/tokenspeed_scheduler.proto
+++ b/crates/grpc_client/proto/tokenspeed_scheduler.proto
@@ -8,7 +8,7 @@ import "common.proto";
 
 // TokenSpeed scheduler gRPC service. Self-contained wire definition apart
 // from the cross-engine admin messages in smg.grpc.common (flush/profile).
-// Trimmed to text+image generation (no embed, no PD-disaggregated, no
+// Trimmed to text+multimodal generation (no embed, no PD-disaggregated, no
 // LoRA, no hidden-state forwarding). Multimodal carries preprocessed
 // tensors only — image fetch + per-model preprocess happen in the
 // gateway (see crates/multimodal).
@@ -109,11 +109,34 @@ message TokenizedInput {
   string original_text = 2; // cosmetic, for worker logs
 }
 
-// A typed tensor: raw little-endian bytes + shape + dtype.
+// A typed tensor: shape + dtype + transport-specific payload.
 message TensorData {
-  bytes data = 1;              // Raw little-endian bytes (f32/i64/u32)
-  repeated uint32 shape = 2;   // Dimension sizes
-  string dtype = 3;            // "float32", "int64", "uint32"
+  repeated uint32 shape = 1;   // Dimension sizes
+  string dtype = 2;            // "float32", "bfloat16", "float16", "int64", "uint32"
+
+  oneof payload {
+    // Current path: raw little-endian bytes carried in the gRPC message.
+    bytes inline = 3;
+    // Same-host CPU shared memory path.
+    ShmHandle shm = 4;
+    // Transport-specific remote descriptor (NIXL/RDMA/object-store/etc.).
+    RemoteTensorHandle remote = 5;
+  }
+}
+
+message ShmHandle {
+  string name = 1;
+  uint64 offset = 2;
+  uint64 nbytes = 3;
+  // Producer/lifetime owner. Used by implementations to coordinate cleanup.
+  string owner_id = 4;
+}
+
+message RemoteTensorHandle {
+  // Examples: "nixl", "ucx", "object_store".
+  string transport = 1;
+  bytes descriptor = 2;
+  uint64 nbytes = 3;
 }
 
 // Where a multimodal item's tokens sit inside input_ids.
@@ -132,30 +155,23 @@ enum Modality {
 message MultimodalItem {
   Modality modality = 1;
   bytes content_hash = 2;
-  map<string, TensorData> tensors = 3;
-  repeated PlaceholderRange placeholders = 4;
-  optional uint32 placeholder_token_id = 5;
+  // Primary input to the multimodal encoder for this item. For vision models
+  // this is the preprocessed image/video tensor; for audio models this can be
+  // audio features or waveform-derived encoder input.
+  TensorData encoder_input = 3;
+  // Model-specific side tensors (image_grid_thw, video_grid_thw, etc.).
+  map<string, TensorData> model_specific_tensors = 4;
+  repeated PlaceholderRange placeholders = 5;
+  optional uint32 placeholder_token_id = 6;
 }
 
 // Multimodal inputs for vision/audio models. Tensors are produced by the
 // gateway's per-model preprocessor (crates/multimodal); the servicer
 // only reconstructs them and hands them to the engine — no preprocess.
 message MultimodalInputs {
-  // Preprocessed pixel values tensor.
-  TensorData pixel_values = 1;
-
-  // Model-specific tensors (image_grid_thw, aspect_ratios, etc.).
-  map<string, TensorData> model_specific_tensors = 2;
-
-  // Image token id used for placeholder expansion.
-  optional uint32 im_token_id = 3;
-
-  // Placeholder offsets: where each image's tokens are in input_ids.
-  repeated PlaceholderRange mm_placeholders = 4;
-
-  // V2 itemized payload for mixed-modality and video/audio requests. When
-  // present, servicers must prefer this over the legacy image-only fields.
-  repeated MultimodalItem items = 10;
+  // Per-modality itemized payload. Each item owns its tensor payload,
+  // placeholder metadata, and modality-specific token id.
+  repeated MultimodalItem items = 1;
 }
 
 message GenerateResponse {
@@ -264,6 +280,8 @@ message GetModelInfoResponse {
   bool supports_vision = 14;
   bool supports_multimodal = 15;
   repeated Modality supported_modalities = 16;
+  string model_dtype = 17;
+  string multimodal_encoder_dtype = 18;
 }
 
 message GetServerInfoRequest {}

--- a/crates/grpc_client/src/tokenspeed_scheduler.rs
+++ b/crates/grpc_client/src/tokenspeed_scheduler.rs
@@ -25,7 +25,12 @@ use crate::{AbortOnDropClient, BoxedTraceInjector, NoopTraceInjector};
 
 #[expect(clippy::allow_attributes)]
 pub mod tokenspeed_proto {
-    #![allow(clippy::all, clippy::absolute_paths, unused_qualifications)]
+    #![allow(
+        clippy::all,
+        clippy::absolute_paths,
+        clippy::trivially_copy_pass_by_ref,
+        unused_qualifications
+    )]
     tonic::include_proto!("tokenspeed.grpc.scheduler");
 }
 

--- a/crates/mock_worker/src/grpc.rs
+++ b/crates/mock_worker/src/grpc.rs
@@ -128,6 +128,7 @@ impl TokenSpeedScheduler for MockScheduler {
             weight_version: "mock".to_string(),
             default_sampling_params_json: String::new(),
             supports_vision: false,
+            ..Default::default()
         }))
     }
 

--- a/crates/multimodal/Cargo.toml
+++ b/crates/multimodal/Cargo.toml
@@ -27,6 +27,7 @@ reqwest = { workspace = true, features = ["stream"] }
 serde = { workspace = true, features = ["derive"] }
 serde_bytes = "0.11"
 serde_json.workspace = true
+tempfile = "3.8"
 thiserror.workspace = true
 tokio = { workspace = true, features = ["sync", "fs", "rt-multi-thread"] }
 url = "2.5.4"
@@ -39,7 +40,6 @@ blake3.workspace = true
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }
 npyz = { version = "0.9", features = ["npz"] }
-tempfile = "3.8"
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 
 [[bench]]

--- a/crates/multimodal/benches/image_preprocess.rs
+++ b/crates/multimodal/benches/image_preprocess.rs
@@ -11,10 +11,9 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use image::{imageops::FilterType, DynamicImage, RgbImage};
 use llm_multimodal::vision::{
-    image_processor::ImagePreProcessor,
     preprocessor_config::PreProcessorConfig,
     processors::{Llama4VisionProcessor, Qwen2VLProcessor, Qwen3VLProcessor},
-    transforms,
+    transforms, VisionPreProcessor,
 };
 
 /// Create a synthetic RGB image with some variation (not all zeros).

--- a/crates/multimodal/src/error.rs
+++ b/crates/multimodal/src/error.rs
@@ -26,6 +26,8 @@ pub enum MediaConnectorError {
     Blocking(#[from] tokio::task::JoinError),
     #[error("image decode error: {0}")]
     Image(#[from] image::ImageError),
+    #[error("video decode error: {0}")]
+    VideoDecode(String),
     #[error("media fetch timed out after {0:?}")]
     Timeout(Duration),
 }

--- a/crates/multimodal/src/hasher.rs
+++ b/crates/multimodal/src/hasher.rs
@@ -5,7 +5,8 @@ pub fn hash_image(raw_bytes: &[u8]) -> String {
     blake3::hash(raw_bytes).to_hex().to_string()
 }
 
-/// TODO: YECHAN - Hash 를 video 전체로 하는게 맞나? 어떤 level에서의 hash 인거지?
+/// TODO(yechan): Decide whether video hashes should cover the full encoded
+/// payload or a normalized representation of the sampled frames.
 /// Compute a blake3 hex-digest hash for a single video's raw bytes.
 pub fn hash_video(raw_bytes: &[u8]) -> String {
     blake3::hash(raw_bytes).to_hex().to_string()

--- a/crates/multimodal/src/hasher.rs
+++ b/crates/multimodal/src/hasher.rs
@@ -5,6 +5,12 @@ pub fn hash_image(raw_bytes: &[u8]) -> String {
     blake3::hash(raw_bytes).to_hex().to_string()
 }
 
+/// TODO: YECHAN - Hash 를 video 전체로 하는게 맞나? 어떤 level에서의 hash 인거지?
+/// Compute a blake3 hex-digest hash for a single video's raw bytes.
+pub fn hash_video(raw_bytes: &[u8]) -> String {
+    blake3::hash(raw_bytes).to_hex().to_string()
+}
+
 /// Compute per-image hashes keyed by modality.
 ///
 /// Returns a `BTreeMap` of per-modality hash lists,

--- a/crates/multimodal/src/hub.rs
+++ b/crates/multimodal/src/hub.rs
@@ -2,7 +2,8 @@
 //!
 //! When the model source is a HuggingFace model ID (e.g. `Qwen/Qwen3-VL-8B-Instruct`)
 //! rather than a local directory, this module downloads `config.json` and
-//! `preprocessor_config.json` to the local HF cache and returns the resolved path.
+//! `preprocessor_config.json` / video processor config files to the local HF
+//! cache and returns the resolved path.
 
 use std::path::{Path, PathBuf};
 
@@ -15,7 +16,7 @@ const HF_TOKEN_ENV: &str = "HF_TOKEN";
 ///
 /// If the source is already a local directory with `config.json`, returns it as-is.
 /// Otherwise, treats the source as a HuggingFace model ID and downloads
-/// `config.json` (and `preprocessor_config.json` if available) to the local HF cache.
+/// `config.json` plus optional processor configs to the local HF cache.
 pub async fn resolve_model_config_dir(source: &str) -> anyhow::Result<PathBuf> {
     let path = Path::new(source);
     if path.join("config.json").exists() {
@@ -38,8 +39,10 @@ pub async fn resolve_model_config_dir(source: &str) -> anyhow::Result<PathBuf> {
         .await
         .with_context(|| format!("Failed to download config.json for model '{source}'"))?;
 
-    // Best-effort download of preprocessor_config.json (not all models have it)
+    // Best-effort download of processor configs (not all models have them).
     let _ = repo.get("preprocessor_config.json").await;
+    let _ = repo.get("video_preprocessor_config.json").await;
+    let _ = repo.get("processor_config.json").await;
 
     config_path
         .parent()

--- a/crates/multimodal/src/lib.rs
+++ b/crates/multimodal/src/lib.rs
@@ -8,12 +8,15 @@ pub mod types;
 pub mod vision;
 
 pub use error::{MediaConnectorError, MultiModalError, MultiModalResult};
-pub use media::{ImageFetchConfig, MediaConnector, MediaConnectorConfig, MediaSource};
+pub use media::{
+    ImageFetchConfig, MediaConnector, MediaConnectorConfig, MediaSource, VideoFetchConfig,
+};
 pub use registry::{ModelMetadata, ModelProcessorSpec, ModelRegistry};
 pub use tracker::{AsyncMultiModalTracker, TrackerOutput};
 pub use types::{
     FieldLayout, ImageDetail, ImageFrame, ImageSize, ImageSource, MediaContentPart, Modality,
     MultiModalData, MultiModalUUIDs, PlaceholderRange, PromptReplacement, TokenId, TrackedMedia,
+    VideoClip, VideoSource,
 };
 // Re-export vision processing components
 pub use vision::{

--- a/crates/multimodal/src/lib.rs
+++ b/crates/multimodal/src/lib.rs
@@ -20,6 +20,6 @@ pub use types::{
 };
 // Re-export vision processing components
 pub use vision::{
-    ImagePreProcessor, ImageProcessorRegistry, LlavaNextProcessor, LlavaProcessor,
-    ModelSpecificValue, PreProcessorConfig, PreprocessedImages, TransformError,
+    LlavaNextProcessor, LlavaProcessor, ModelSpecificValue, PreProcessorConfig,
+    PreprocessedEncoderInputs, TransformError, VisionPreProcessor, VisionProcessorRegistry,
 };

--- a/crates/multimodal/src/media.rs
+++ b/crates/multimodal/src/media.rs
@@ -459,7 +459,9 @@ fn probe_video_duration_seconds_with_ffmpeg(
     input_path: &std::path::Path,
 ) -> Result<f64, MediaConnectorError> {
     let mut command = Command::new("ffmpeg");
-    command.args(["-hide_banner", "-nostdin", "-i"]).arg(input_path);
+    command
+        .args(["-hide_banner", "-nostdin", "-i"])
+        .arg(input_path);
     let output = run_video_command_output(command, "ffmpeg")?;
 
     let stderr = String::from_utf8_lossy(&output.stderr);

--- a/crates/multimodal/src/media.rs
+++ b/crates/multimodal/src/media.rs
@@ -1,4 +1,6 @@
-use std::{collections::HashSet, path::PathBuf, sync::Arc, time::Duration};
+use std::{
+    collections::HashSet, io::Write, path::PathBuf, process::Command, sync::Arc, time::Duration,
+};
 
 use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine};
 use bytes::Bytes;
@@ -8,7 +10,7 @@ use url::Url;
 
 use super::{
     error::MediaConnectorError,
-    types::{ImageDetail, ImageFrame, ImageSource},
+    types::{ImageDetail, ImageFrame, ImageSource, VideoClip, VideoSource},
 };
 
 #[derive(Clone)]
@@ -37,6 +39,23 @@ impl Default for ImageFetchConfig {
     fn default() -> Self {
         Self {
             detail: ImageDetail::Auto,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct VideoFetchConfig {
+    pub min_frames: usize,
+    pub max_frames: usize,
+    pub sample_fps: f32,
+}
+
+impl Default for VideoFetchConfig {
+    fn default() -> Self {
+        Self {
+            min_frames: 4,
+            max_frames: 768,
+            sample_fps: 2.0,
         }
     }
 }
@@ -96,6 +115,22 @@ impl MediaConnector {
         }
     }
 
+    pub async fn fetch_video(
+        &self,
+        source: MediaSource,
+        cfg: VideoFetchConfig,
+    ) -> Result<Arc<VideoClip>, MediaConnectorError> {
+        match source {
+            MediaSource::Url(url) => self.fetch_http_video(url, cfg).await,
+            MediaSource::DataUrl(data_url) => self.fetch_video_data_url(data_url, cfg).await,
+            MediaSource::InlineBytes(bytes) => {
+                self.decode_video(bytes.into(), cfg, VideoSource::InlineBytes)
+                    .await
+            }
+            MediaSource::File(path) => self.fetch_video_file(path, cfg).await,
+        }
+    }
+
     async fn fetch_http_image(
         &self,
         url: String,
@@ -150,6 +185,27 @@ impl MediaConnector {
             .await
     }
 
+    async fn fetch_video_data_url(
+        &self,
+        data_url: String,
+        cfg: VideoFetchConfig,
+    ) -> Result<Arc<VideoClip>, MediaConnectorError> {
+        let (metadata, data) = data_url
+            .split_once(',')
+            .ok_or_else(|| MediaConnectorError::DataUrl("missing comma in data url".into()))?;
+
+        if !metadata.ends_with(";base64") {
+            return Err(MediaConnectorError::DataUrl(
+                "only base64 encoded data URLs are supported".into(),
+            ));
+        }
+
+        let data = data.trim();
+        let decoded = BASE64_STANDARD.decode(data)?;
+        self.decode_video(decoded.into(), cfg, VideoSource::DataUrl)
+            .await
+    }
+
     async fn fetch_file(
         &self,
         path: PathBuf,
@@ -174,6 +230,61 @@ impl MediaConnector {
             ImageSource::File { path: canonical },
         )
         .await
+    }
+
+    async fn fetch_http_video(
+        &self,
+        url: String,
+        cfg: VideoFetchConfig,
+    ) -> Result<Arc<VideoClip>, MediaConnectorError> {
+        let parsed = Url::parse(&url).map_err(|_| MediaConnectorError::InvalidUrl(url.clone()))?;
+        self.ensure_domain_allowed(&parsed)?;
+
+        let mut req = self.client.get(parsed.as_str());
+        if self.fetch_timeout > Duration::ZERO {
+            req = req.timeout(self.fetch_timeout);
+        }
+
+        let resp = req.send().await.map_err(|err| {
+            if err.is_timeout() {
+                MediaConnectorError::Timeout(self.fetch_timeout)
+            } else {
+                MediaConnectorError::Http(err)
+            }
+        })?;
+
+        let resp = resp.error_for_status()?;
+        let bytes = resp.bytes().await?;
+        self.decode_video(
+            bytes,
+            cfg,
+            VideoSource::Url {
+                url: parsed.to_string(),
+            },
+        )
+        .await
+    }
+
+    async fn fetch_video_file(
+        &self,
+        path: PathBuf,
+        cfg: VideoFetchConfig,
+    ) -> Result<Arc<VideoClip>, MediaConnectorError> {
+        let allowed_root = self
+            .allowed_local_media_path
+            .as_ref()
+            .ok_or_else(|| MediaConnectorError::DisallowedLocalPath(path.display().to_string()))?;
+
+        let canonical = fs::canonicalize(&path).await?;
+        if !canonical.starts_with(allowed_root) {
+            return Err(MediaConnectorError::DisallowedLocalPath(
+                path.display().to_string(),
+            ));
+        }
+
+        let bytes = fs::read(&canonical).await?;
+        self.decode_video(bytes.into(), cfg, VideoSource::File { path: canonical })
+            .await
     }
 
     fn ensure_domain_allowed(&self, url: &Url) -> Result<(), MediaConnectorError> {
@@ -207,5 +318,246 @@ impl MediaConnector {
         Ok(Arc::new(ImageFrame::new(
             image, bytes, detail, source, hash,
         )))
+    }
+
+    async fn decode_video(
+        &self,
+        bytes: Bytes,
+        cfg: VideoFetchConfig,
+        source: VideoSource,
+    ) -> Result<Arc<VideoClip>, MediaConnectorError> {
+        if cfg.max_frames == 0 {
+            return Err(MediaConnectorError::VideoDecode(
+                "max_frames must be greater than 0".to_string(),
+            ));
+        }
+        if cfg.min_frames == 0 {
+            return Err(MediaConnectorError::VideoDecode(
+                "min_frames must be greater than 0".to_string(),
+            ));
+        }
+        if cfg.min_frames > cfg.max_frames {
+            return Err(MediaConnectorError::VideoDecode(
+                "min_frames must be less than or equal to max_frames".to_string(),
+            ));
+        }
+        if cfg.sample_fps <= 0.0 {
+            return Err(MediaConnectorError::VideoDecode(
+                "sample_fps must be greater than 0".to_string(),
+            ));
+        }
+
+        let hash = crate::hasher::hash_video(&bytes);
+        let input = bytes.clone();
+        let frames = task::spawn_blocking(move || decode_video_with_ffmpeg(&input, cfg))
+            .await
+            .map_err(MediaConnectorError::Blocking)??;
+
+        Ok(Arc::new(VideoClip::new(frames, bytes, source, hash)))
+    }
+}
+
+fn decode_video_with_ffmpeg(
+    bytes: &[u8],
+    cfg: VideoFetchConfig,
+) -> Result<Vec<image::DynamicImage>, MediaConnectorError> {
+    let mut input_file = tempfile::Builder::new()
+        .prefix("smg-video-")
+        .suffix(".mp4")
+        .tempfile()?;
+    input_file.write_all(bytes)?;
+    input_file.flush()?;
+
+    let fps_filter = fps_filter_for_video(input_file.path(), cfg);
+    let max_frames = cfg.max_frames.to_string();
+    let output = Command::new("ffmpeg")
+        .args(["-hide_banner", "-loglevel", "error", "-i"])
+        .arg(input_file.path())
+        .args([
+            "-vf",
+            &fps_filter,
+            "-frames:v",
+            &max_frames,
+            "-f",
+            "image2pipe",
+            "-vcodec",
+            "png",
+            "pipe:1",
+        ])
+        .output()
+        .map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                MediaConnectorError::VideoDecode(
+                    "ffmpeg executable not found; install ffmpeg to decode video_url inputs"
+                        .to_string(),
+                )
+            } else {
+                MediaConnectorError::Io(e)
+            }
+        })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(MediaConnectorError::VideoDecode(format!(
+            "ffmpeg failed: {stderr}"
+        )));
+    }
+
+    let pngs = split_png_stream(&output.stdout)?;
+    let mut frames = Vec::with_capacity(pngs.len());
+    for png in pngs {
+        frames.push(image::load_from_memory(png)?);
+    }
+    if frames.is_empty() {
+        return Err(MediaConnectorError::VideoDecode(
+            "ffmpeg produced no frames".to_string(),
+        ));
+    }
+    Ok(frames)
+}
+
+fn fps_filter_for_video(input_path: &std::path::Path, cfg: VideoFetchConfig) -> String {
+    if let Ok(duration) = probe_video_duration_seconds(input_path) {
+        if duration.is_finite() && duration > 0.0 {
+            let target_frames = (duration * cfg.sample_fps as f64)
+                .round()
+                .clamp(cfg.min_frames as f64, cfg.max_frames as f64);
+            let fps = (target_frames / duration).max(f64::EPSILON);
+            return format!("fps={fps:.6}");
+        }
+    }
+
+    format!("fps={}", cfg.sample_fps)
+}
+
+fn probe_video_duration_seconds(input_path: &std::path::Path) -> Result<f64, MediaConnectorError> {
+    match Command::new("ffprobe")
+        .args([
+            "-v",
+            "error",
+            "-show_entries",
+            "format=duration",
+            "-of",
+            "default=noprint_wrappers=1:nokey=1",
+        ])
+        .arg(input_path)
+        .output()
+    {
+        Ok(output) if output.status.success() => {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            stdout.trim().parse::<f64>().map_err(|err| {
+                MediaConnectorError::VideoDecode(format!("failed to parse ffprobe duration: {err}"))
+            })
+        }
+        Ok(_) | Err(_) => probe_video_duration_seconds_with_ffmpeg(input_path),
+    }
+}
+
+fn probe_video_duration_seconds_with_ffmpeg(
+    input_path: &std::path::Path,
+) -> Result<f64, MediaConnectorError> {
+    let output = Command::new("ffmpeg")
+        .args(["-hide_banner", "-i"])
+        .arg(input_path)
+        .output()
+        .map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                MediaConnectorError::VideoDecode(
+                    "ffmpeg executable not found; cannot probe video duration".to_string(),
+                )
+            } else {
+                MediaConnectorError::Io(e)
+            }
+        })?;
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    parse_ffmpeg_duration_seconds(&stderr).ok_or_else(|| {
+        MediaConnectorError::VideoDecode("failed to parse ffmpeg duration".to_string())
+    })
+}
+
+fn parse_ffmpeg_duration_seconds(stderr: &str) -> Option<f64> {
+    let marker = "Duration:";
+    let start = stderr.find(marker)? + marker.len();
+    let duration = stderr[start..].trim_start().split(',').next()?.trim();
+    let mut parts = duration.split(':');
+    let hours = parts.next()?.parse::<f64>().ok()?;
+    let minutes = parts.next()?.parse::<f64>().ok()?;
+    let seconds = parts.next()?.parse::<f64>().ok()?;
+    Some(hours * 3600.0 + minutes * 60.0 + seconds)
+}
+
+fn split_png_stream(bytes: &[u8]) -> Result<Vec<&[u8]>, MediaConnectorError> {
+    const PNG_SIG: &[u8; 8] = b"\x89PNG\r\n\x1a\n";
+    const IEND: &[u8; 4] = b"IEND";
+
+    let mut frames = Vec::new();
+    let mut pos = 0;
+    while pos < bytes.len() {
+        let Some(rel_start) = bytes[pos..]
+            .windows(PNG_SIG.len())
+            .position(|w| w == PNG_SIG)
+        else {
+            break;
+        };
+        let start = pos + rel_start;
+        let mut cursor = start + PNG_SIG.len();
+
+        loop {
+            if cursor + 12 > bytes.len() {
+                return Err(MediaConnectorError::VideoDecode(
+                    "truncated PNG frame in ffmpeg output".to_string(),
+                ));
+            }
+            let mut len_bytes = [0_u8; 4];
+            len_bytes.copy_from_slice(&bytes[cursor..cursor + 4]);
+            let len = u32::from_be_bytes(len_bytes) as usize;
+            let chunk_type = &bytes[cursor + 4..cursor + 8];
+            cursor += 8 + len + 4;
+            if cursor > bytes.len() {
+                return Err(MediaConnectorError::VideoDecode(
+                    "truncated PNG chunk in ffmpeg output".to_string(),
+                ));
+            }
+            if chunk_type == IEND {
+                frames.push(&bytes[start..cursor]);
+                pos = cursor;
+                break;
+            }
+        }
+    }
+
+    Ok(frames)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_ffmpeg_duration_seconds, split_png_stream};
+
+    const TINY_PNG: &[u8] = &[
+        137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0, 1, 0, 0, 0, 1, 8, 4,
+        0, 0, 0, 181, 28, 12, 2, 0, 0, 0, 11, 73, 68, 65, 84, 120, 218, 99, 96, 96, 0, 0, 0, 3, 0,
+        1, 43, 9, 141, 84, 0, 0, 0, 0, 73, 69, 78, 68, 174, 66, 96, 130,
+    ];
+
+    #[test]
+    fn splits_concatenated_png_stream() {
+        let mut stream = Vec::new();
+        stream.extend_from_slice(TINY_PNG);
+        stream.extend_from_slice(TINY_PNG);
+
+        let frames = match split_png_stream(&stream) {
+            Ok(frames) => frames,
+            Err(err) => panic!("split png stream failed: {err}"),
+        };
+        assert_eq!(frames.len(), 2);
+        assert_eq!(frames[0], TINY_PNG);
+        assert_eq!(frames[1], TINY_PNG);
+    }
+
+    #[test]
+    fn parses_ffmpeg_duration() {
+        let stderr = "Input #0, mov,mp4,m4a,3gp,3g2,mj2, from 'video.mp4':\n  Duration: 00:01:23.45, start: 0.000000, bitrate: 123 kb/s";
+        assert_eq!(parse_ffmpeg_duration_seconds(stderr), Some(83.45));
     }
 }

--- a/crates/multimodal/src/media.rs
+++ b/crates/multimodal/src/media.rs
@@ -1,5 +1,11 @@
 use std::{
-    collections::HashSet, io::Write, path::PathBuf, process::Command, sync::Arc, time::Duration,
+    collections::HashSet,
+    io::{Read, Write},
+    path::PathBuf,
+    process::{Command, Output, Stdio},
+    sync::Arc,
+    thread,
+    time::{Duration, Instant},
 };
 
 use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine};
@@ -12,6 +18,10 @@ use super::{
     error::MediaConnectorError,
     types::{ImageDetail, ImageFrame, ImageSource, VideoClip, VideoSource},
 };
+
+const DEFAULT_VIDEO_PROCESS_TIMEOUT: Duration = Duration::from_secs(30);
+const VIDEO_PROCESS_POLL_INTERVAL: Duration = Duration::from_millis(10);
+const VIDEO_PROCESS_TIMEOUT_ENV: &str = "SMG_VIDEO_PROCESS_TIMEOUT_SECS";
 
 #[derive(Clone)]
 pub struct MediaConnectorConfig {
@@ -370,8 +380,9 @@ fn decode_video_with_ffmpeg(
 
     let fps_filter = fps_filter_for_video(input_file.path(), cfg);
     let max_frames = cfg.max_frames.to_string();
-    let output = Command::new("ffmpeg")
-        .args(["-hide_banner", "-loglevel", "error", "-i"])
+    let mut command = Command::new("ffmpeg");
+    command
+        .args(["-hide_banner", "-nostdin", "-loglevel", "error", "-i"])
         .arg(input_file.path())
         .args([
             "-vf",
@@ -383,18 +394,8 @@ fn decode_video_with_ffmpeg(
             "-vcodec",
             "png",
             "pipe:1",
-        ])
-        .output()
-        .map_err(|e| {
-            if e.kind() == std::io::ErrorKind::NotFound {
-                MediaConnectorError::VideoDecode(
-                    "ffmpeg executable not found; install ffmpeg to decode video_url inputs"
-                        .to_string(),
-                )
-            } else {
-                MediaConnectorError::Io(e)
-            }
-        })?;
+        ]);
+    let output = run_video_command_output(command, "ffmpeg")?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -431,18 +432,19 @@ fn fps_filter_for_video(input_path: &std::path::Path, cfg: VideoFetchConfig) -> 
 }
 
 fn probe_video_duration_seconds(input_path: &std::path::Path) -> Result<f64, MediaConnectorError> {
-    match Command::new("ffprobe")
+    let mut command = Command::new("ffprobe");
+    command
         .args([
             "-v",
             "error",
+            "-nostdin",
             "-show_entries",
             "format=duration",
             "-of",
             "default=noprint_wrappers=1:nokey=1",
         ])
-        .arg(input_path)
-        .output()
-    {
+        .arg(input_path);
+    match run_video_command_output(command, "ffprobe") {
         Ok(output) if output.status.success() => {
             let stdout = String::from_utf8_lossy(&output.stdout);
             stdout.trim().parse::<f64>().map_err(|err| {
@@ -456,19 +458,9 @@ fn probe_video_duration_seconds(input_path: &std::path::Path) -> Result<f64, Med
 fn probe_video_duration_seconds_with_ffmpeg(
     input_path: &std::path::Path,
 ) -> Result<f64, MediaConnectorError> {
-    let output = Command::new("ffmpeg")
-        .args(["-hide_banner", "-i"])
-        .arg(input_path)
-        .output()
-        .map_err(|e| {
-            if e.kind() == std::io::ErrorKind::NotFound {
-                MediaConnectorError::VideoDecode(
-                    "ffmpeg executable not found; cannot probe video duration".to_string(),
-                )
-            } else {
-                MediaConnectorError::Io(e)
-            }
-        })?;
+    let mut command = Command::new("ffmpeg");
+    command.args(["-hide_banner", "-nostdin", "-i"]).arg(input_path);
+    let output = run_video_command_output(command, "ffmpeg")?;
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     parse_ffmpeg_duration_seconds(&stderr).ok_or_else(|| {
@@ -485,6 +477,77 @@ fn parse_ffmpeg_duration_seconds(stderr: &str) -> Option<f64> {
     let minutes = parts.next()?.parse::<f64>().ok()?;
     let seconds = parts.next()?.parse::<f64>().ok()?;
     Some(hours * 3600.0 + minutes * 60.0 + seconds)
+}
+
+fn video_process_timeout() -> Duration {
+    std::env::var(VIDEO_PROCESS_TIMEOUT_ENV)
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .map(Duration::from_secs)
+        .filter(|timeout| *timeout > Duration::ZERO)
+        .unwrap_or(DEFAULT_VIDEO_PROCESS_TIMEOUT)
+}
+
+fn run_video_command_output(
+    mut command: Command,
+    program: &'static str,
+) -> Result<Output, MediaConnectorError> {
+    command.stdout(Stdio::piped()).stderr(Stdio::piped());
+    let mut child = command.spawn().map_err(|error| {
+        if error.kind() == std::io::ErrorKind::NotFound {
+            MediaConnectorError::VideoDecode(format!(
+                "{program} executable not found; install ffmpeg to decode video_url inputs"
+            ))
+        } else {
+            MediaConnectorError::Io(error)
+        }
+    })?;
+
+    let mut stdout = child.stdout.take().ok_or_else(|| {
+        MediaConnectorError::VideoDecode(format!("{program} stdout pipe was not captured"))
+    })?;
+    let mut stderr = child.stderr.take().ok_or_else(|| {
+        MediaConnectorError::VideoDecode(format!("{program} stderr pipe was not captured"))
+    })?;
+
+    let stdout_handle = thread::spawn(move || {
+        let mut buffer = Vec::new();
+        stdout.read_to_end(&mut buffer).map(|_| buffer)
+    });
+    let stderr_handle = thread::spawn(move || {
+        let mut buffer = Vec::new();
+        stderr.read_to_end(&mut buffer).map(|_| buffer)
+    });
+
+    let timeout = video_process_timeout();
+    let start = Instant::now();
+    let status = loop {
+        if let Some(status) = child.try_wait()? {
+            break status;
+        }
+        if start.elapsed() >= timeout {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(MediaConnectorError::VideoDecode(format!(
+                "{program} timed out after {:.1}s",
+                timeout.as_secs_f64()
+            )));
+        }
+        thread::sleep(VIDEO_PROCESS_POLL_INTERVAL);
+    };
+
+    let stdout = stdout_handle.join().map_err(|_| {
+        MediaConnectorError::VideoDecode(format!("{program} stdout reader panicked"))
+    })??;
+    let stderr = stderr_handle.join().map_err(|_| {
+        MediaConnectorError::VideoDecode(format!("{program} stderr reader panicked"))
+    })??;
+
+    Ok(Output {
+        status,
+        stdout,
+        stderr,
+    })
 }
 
 fn split_png_stream(bytes: &[u8]) -> Result<Vec<&[u8]>, MediaConnectorError> {
@@ -504,7 +567,8 @@ fn split_png_stream(bytes: &[u8]) -> Result<Vec<&[u8]>, MediaConnectorError> {
         let mut cursor = start + PNG_SIG.len();
 
         loop {
-            if cursor + 12 > bytes.len() {
+            let remaining = bytes.len() - cursor;
+            if remaining < 12 {
                 return Err(MediaConnectorError::VideoDecode(
                     "truncated PNG frame in ffmpeg output".to_string(),
                 ));
@@ -513,12 +577,12 @@ fn split_png_stream(bytes: &[u8]) -> Result<Vec<&[u8]>, MediaConnectorError> {
             len_bytes.copy_from_slice(&bytes[cursor..cursor + 4]);
             let len = u32::from_be_bytes(len_bytes) as usize;
             let chunk_type = &bytes[cursor + 4..cursor + 8];
-            cursor += 8 + len + 4;
-            if cursor > bytes.len() {
+            if remaining - 12 < len {
                 return Err(MediaConnectorError::VideoDecode(
                     "truncated PNG chunk in ffmpeg output".to_string(),
                 ));
             }
+            cursor += 12 + len;
             if chunk_type == IEND {
                 frames.push(&bytes[start..cursor]);
                 pos = cursor;

--- a/crates/multimodal/src/media.rs
+++ b/crates/multimodal/src/media.rs
@@ -130,6 +130,9 @@ impl MediaConnector {
         source: MediaSource,
         cfg: VideoFetchConfig,
     ) -> Result<Arc<VideoClip>, MediaConnectorError> {
+        // TODO: add a configurable max-video-bytes guard before fully buffering
+        // URL/data/file/inline payloads. VideoClip retains the original bytes,
+        // so oversized inputs should be rejected before decode.
         match source {
             MediaSource::Url(url) => self.fetch_http_video(url, cfg).await,
             MediaSource::DataUrl(data_url) => self.fetch_video_data_url(data_url, cfg).await,

--- a/crates/multimodal/src/registry/kimi_k25.rs
+++ b/crates/multimodal/src/registry/kimi_k25.rs
@@ -5,7 +5,7 @@ use serde_json::{json, Value};
 use crate::{
     registry::{ModelMetadata, ModelProcessorSpec, ModelRegistryError, RegistryResult},
     types::{FieldLayout, Modality, PromptReplacement, TokenId},
-    vision::image_processor::PreprocessedImages,
+    vision::processor::PreprocessedEncoderInputs,
 };
 
 pub(super) struct KimiK25VisionSpec;
@@ -57,12 +57,12 @@ impl ModelProcessorSpec for KimiK25VisionSpec {
     fn prompt_replacements(
         &self,
         metadata: &ModelMetadata,
-        preprocessed: &PreprocessedImages,
+        preprocessed: &PreprocessedEncoderInputs,
     ) -> RegistryResult<Vec<PromptReplacement>> {
         let pad_token_id = Self::pad_token_id(metadata)?;
         let placeholder_token = self.placeholder_token(metadata)?;
         Ok(preprocessed
-            .num_img_tokens
+            .feature_token_counts
             .iter()
             .map(|&num_tokens| {
                 PromptReplacement::repeated(
@@ -77,7 +77,7 @@ impl ModelProcessorSpec for KimiK25VisionSpec {
 
     fn field_layouts(&self) -> HashMap<String, FieldLayout> {
         // Kimi-K2.5 uses NaViT-style patchification:
-        // pixel_values is [total_patches, patch_features], split by patches_per_image.
+        // encoder_input is [total_patches, patch_features], split by patches_per_image.
         // grid_thws is [num_images, 3] with (temporal, height, width) grid dimensions.
         HashMap::from([
             (

--- a/crates/multimodal/src/registry/llama4.rs
+++ b/crates/multimodal/src/registry/llama4.rs
@@ -5,7 +5,7 @@ use serde_json::{json, Value};
 use crate::{
     registry::{ModelMetadata, ModelProcessorSpec, RegistryResult},
     types::{FieldLayout, Modality, PromptReplacement, TokenId},
-    vision::image_processor::{ModelSpecificValue, PreprocessedImages},
+    vision::processor::{ModelSpecificValue, PreprocessedEncoderInputs},
 };
 
 pub(super) struct Llama4Spec;
@@ -50,7 +50,7 @@ impl Llama4Spec {
     /// `aspect_ratios` tensor.  Falls back to deriving tile counts from
     /// the original image sizes when aspect_ratios are unavailable.
     fn extract_aspect_ratios(
-        preprocessed: &PreprocessedImages,
+        preprocessed: &PreprocessedEncoderInputs,
         tile_size: usize,
     ) -> Vec<(usize, usize)> {
         if let Some(ModelSpecificValue::IntTensor { data, shape }) =
@@ -65,7 +65,7 @@ impl Llama4Spec {
         }
         // Fallback: derive from original image sizes (height, width).
         preprocessed
-            .image_sizes
+            .item_sizes
             .iter()
             .map(|&(h, w)| {
                 let h_tiles = (h as usize).div_ceil(tile_size);
@@ -115,7 +115,7 @@ impl ModelProcessorSpec for Llama4Spec {
     fn prompt_replacements(
         &self,
         metadata: &ModelMetadata,
-        preprocessed: &PreprocessedImages,
+        preprocessed: &PreprocessedEncoderInputs,
     ) -> RegistryResult<Vec<PromptReplacement>> {
         let patch_token_id = self.placeholder_token_id(metadata)?;
         let placeholder = self.placeholder_token(metadata)?;
@@ -170,7 +170,7 @@ impl ModelProcessorSpec for Llama4Spec {
     }
 
     fn field_layouts(&self) -> HashMap<String, FieldLayout> {
-        // pixel_values is [total_tiles, C, H, W] — variable tiles per image.
+        // encoder_input is [total_tiles, C, H, W] — variable tiles per image.
         // aspect_ratios and patches_per_image are [num_images, ...].
         HashMap::from([
             (

--- a/crates/multimodal/src/registry/llava.rs
+++ b/crates/multimodal/src/registry/llava.rs
@@ -5,7 +5,7 @@ use serde_json::{json, Value};
 use crate::{
     registry::{ModelMetadata, ModelProcessorSpec, RegistryResult},
     types::{FieldLayout, Modality, PromptReplacement, TokenId},
-    vision::image_processor::PreprocessedImages,
+    vision::processor::PreprocessedEncoderInputs,
 };
 
 pub(super) struct LlavaSpec;
@@ -54,18 +54,21 @@ impl ModelProcessorSpec for LlavaSpec {
     fn prompt_replacements(
         &self,
         metadata: &ModelMetadata,
-        preprocessed: &PreprocessedImages,
+        preprocessed: &PreprocessedEncoderInputs,
     ) -> RegistryResult<Vec<PromptReplacement>> {
         let token_id = self.placeholder_token_id(metadata)?;
         let token = self.placeholder_token(metadata)?;
-        if let Some(&count) = preprocessed.num_img_tokens.first() {
+        if let Some(&count) = preprocessed.feature_token_counts.first() {
             // For LLaVA 1.5, all images produce the same number of tokens.
             let replacement = PromptReplacement::repeated(Modality::Image, &token, token_id, count);
             debug_assert!(
-                preprocessed.num_img_tokens.iter().all(|&c| c == count),
+                preprocessed
+                    .feature_token_counts
+                    .iter()
+                    .all(|&c| c == count),
                 "LlavaSpec assumes all images produce the same number of tokens"
             );
-            Ok(vec![replacement; preprocessed.num_img_tokens.len()])
+            Ok(vec![replacement; preprocessed.feature_token_counts.len()])
         } else {
             Ok(vec![])
         }
@@ -105,24 +108,24 @@ impl ModelProcessorSpec for LlavaNextSpec {
     fn prompt_replacements(
         &self,
         metadata: &ModelMetadata,
-        preprocessed: &PreprocessedImages,
+        preprocessed: &PreprocessedEncoderInputs,
     ) -> RegistryResult<Vec<PromptReplacement>> {
         // LLaVA-Next token counts differ from plain LLaVA because of
         // anyres multi-crop + spatial_unpad.  The correct per-image counts
         // are already computed by LlavaNextProcessor::calculate_num_tokens
-        // and stored in preprocessed.num_img_tokens.
+        // and stored in preprocessed.feature_token_counts.
         let token_id = LlavaSpec.placeholder_token_id(metadata)?;
         let token = LlavaSpec.placeholder_token(metadata)?;
         Ok(preprocessed
-            .num_img_tokens
+            .feature_token_counts
             .iter()
             .map(|&count| PromptReplacement::repeated(Modality::Image, &token, token_id, count))
             .collect())
     }
 
     fn field_layouts(&self) -> HashMap<String, FieldLayout> {
-        // pixel_values is [num_images, max_patches, C, H, W] (5D, batched).
-        // image_sizes is [num_images, 2] (batched).
+        // encoder_input is [num_images, max_patches, C, H, W] (5D, batched).
+        // image_sizes is [num_images, 2] (batched), matching HF/vLLM kwargs.
         HashMap::from([
             ("pixel_values".to_string(), FieldLayout::Batched),
             ("image_sizes".to_string(), FieldLayout::Batched),
@@ -154,7 +157,7 @@ mod tests {
         };
         let registry = ModelRegistry::new();
         let spec = registry.lookup(&metadata).expect("llava spec");
-        // Token count comes from preprocessed.num_img_tokens (set by
+        // Token count comes from preprocessed.feature_token_counts (set by
         // LlavaProcessor::calculate_num_tokens), not from image dimensions.
         let preprocessed = test_preprocessed_with_tokens(&[ImageSize::new(336, 336)], &[576]);
         let replacements = spec.prompt_replacements(&metadata, &preprocessed).unwrap();

--- a/crates/multimodal/src/registry/llava.rs
+++ b/crates/multimodal/src/registry/llava.rs
@@ -58,20 +58,11 @@ impl ModelProcessorSpec for LlavaSpec {
     ) -> RegistryResult<Vec<PromptReplacement>> {
         let token_id = self.placeholder_token_id(metadata)?;
         let token = self.placeholder_token(metadata)?;
-        if let Some(&count) = preprocessed.feature_token_counts.first() {
-            // For LLaVA 1.5, all images produce the same number of tokens.
-            let replacement = PromptReplacement::repeated(Modality::Image, &token, token_id, count);
-            debug_assert!(
-                preprocessed
-                    .feature_token_counts
-                    .iter()
-                    .all(|&c| c == count),
-                "LlavaSpec assumes all images produce the same number of tokens"
-            );
-            Ok(vec![replacement; preprocessed.feature_token_counts.len()])
-        } else {
-            Ok(vec![])
-        }
+        Ok(preprocessed
+            .feature_token_counts
+            .iter()
+            .map(|&count| PromptReplacement::repeated(Modality::Image, &token, token_id, count))
+            .collect())
     }
 }
 
@@ -162,6 +153,33 @@ mod tests {
         let preprocessed = test_preprocessed_with_tokens(&[ImageSize::new(336, 336)], &[576]);
         let replacements = spec.prompt_replacements(&metadata, &preprocessed).unwrap();
         assert_eq!(replacements[0].tokens.len(), 576);
+    }
+
+    #[test]
+    fn llava_prompt_replacement_uses_per_image_token_counts() {
+        let tokenizer = TestTokenizer::new(&[("<image>", 32000)]);
+        let config = json!({
+            "model_type": "llava",
+            "image_token_index": 32000,
+            "vision_config": {"patch_size": 14}
+        });
+        let metadata = ModelMetadata {
+            model_id: "llava-v1.5",
+            tokenizer: &tokenizer,
+            config: &config,
+        };
+        let registry = ModelRegistry::new();
+        let spec = registry.lookup(&metadata).expect("llava spec");
+        let preprocessed = test_preprocessed_with_tokens(
+            &[ImageSize::new(336, 336), ImageSize::new(448, 448)],
+            &[576, 1024],
+        );
+
+        let replacements = spec.prompt_replacements(&metadata, &preprocessed).unwrap();
+
+        assert_eq!(replacements.len(), 2);
+        assert_eq!(replacements[0].tokens.len(), 576);
+        assert_eq!(replacements[1].tokens.len(), 1024);
     }
 
     #[test]

--- a/crates/multimodal/src/registry/mod.rs
+++ b/crates/multimodal/src/registry/mod.rs
@@ -79,7 +79,7 @@ pub(super) mod test_helpers {
 
     use crate::{
         types::ImageSize,
-        vision::image_processor::{ModelSpecificValue, PreprocessedImages},
+        vision::processor::{ModelSpecificValue, PreprocessedEncoderInputs},
     };
 
     pub struct TestTokenizer {
@@ -155,24 +155,24 @@ pub(super) mod test_helpers {
     }
 
     pub fn test_preprocessed_with_tokens(
-        image_sizes: &[ImageSize],
-        num_img_tokens: &[usize],
-    ) -> PreprocessedImages {
-        let sizes: Vec<(u32, u32)> = image_sizes.iter().map(|s| (s.height, s.width)).collect();
-        PreprocessedImages {
-            pixel_values: ndarray::ArrayD::zeros(vec![1, 3, 336, 336]),
-            num_img_tokens: num_img_tokens.to_vec(),
-            image_sizes: sizes,
+        item_sizes: &[ImageSize],
+        feature_token_counts: &[usize],
+    ) -> PreprocessedEncoderInputs {
+        let sizes: Vec<(u32, u32)> = item_sizes.iter().map(|s| (s.height, s.width)).collect();
+        PreprocessedEncoderInputs {
+            encoder_input: ndarray::ArrayD::zeros(vec![1, 3, 336, 336]),
+            feature_token_counts: feature_token_counts.to_vec(),
+            item_sizes: sizes,
             model_specific: HashMap::new(),
         }
     }
 
-    /// Build `PreprocessedImages` with explicit aspect_ratios (for Llama4 tests).
+    /// Build `PreprocessedEncoderInputs` with explicit aspect_ratios (for Llama4 tests).
     pub fn test_preprocessed_with_aspects(
-        image_sizes: &[ImageSize],
+        item_sizes: &[ImageSize],
         aspect_ratios: &[(i64, i64)],
-    ) -> PreprocessedImages {
-        let sizes: Vec<(u32, u32)> = image_sizes.iter().map(|s| (s.height, s.width)).collect();
+    ) -> PreprocessedEncoderInputs {
+        let sizes: Vec<(u32, u32)> = item_sizes.iter().map(|s| (s.height, s.width)).collect();
         let flat: Vec<i64> = aspect_ratios
             .iter()
             .flat_map(|&(h, w)| vec![h, w])
@@ -186,10 +186,10 @@ pub(super) mod test_helpers {
                 shape: vec![batch, 2],
             },
         );
-        PreprocessedImages {
-            pixel_values: ndarray::ArrayD::zeros(vec![1, 3, 336, 336]),
-            num_img_tokens: vec![0; sizes.len()],
-            image_sizes: sizes,
+        PreprocessedEncoderInputs {
+            encoder_input: ndarray::ArrayD::zeros(vec![1, 3, 336, 336]),
+            feature_token_counts: vec![0; sizes.len()],
+            item_sizes: sizes,
             model_specific,
         }
     }

--- a/crates/multimodal/src/registry/phi3_v.rs
+++ b/crates/multimodal/src/registry/phi3_v.rs
@@ -5,7 +5,7 @@ use serde_json::{json, Value};
 use crate::{
     registry::{ModelMetadata, ModelProcessorSpec, RegistryResult},
     types::{FieldLayout, Modality, PromptReplacement, TokenId},
-    vision::image_processor::PreprocessedImages,
+    vision::processor::PreprocessedEncoderInputs,
 };
 
 pub(super) struct Phi3VisionSpec;
@@ -52,12 +52,12 @@ impl ModelProcessorSpec for Phi3VisionSpec {
     fn prompt_replacements(
         &self,
         metadata: &ModelMetadata,
-        preprocessed: &PreprocessedImages,
+        preprocessed: &PreprocessedEncoderInputs,
     ) -> RegistryResult<Vec<PromptReplacement>> {
         let token_id = self.placeholder_token_id(metadata)?;
         let token = self.placeholder_token(metadata)?;
         Ok(preprocessed
-            .num_img_tokens
+            .feature_token_counts
             .iter()
             .map(|&count| PromptReplacement::repeated(Modality::Image, &token, token_id, count))
             .collect())

--- a/crates/multimodal/src/registry/qwen3_vl.rs
+++ b/crates/multimodal/src/registry/qwen3_vl.rs
@@ -1,23 +1,124 @@
 use std::collections::HashMap;
 
+use llm_tokenizer::Encoding;
 use serde_json::{json, Value};
 
 use crate::{
     registry::{ModelMetadata, ModelProcessorSpec, ModelRegistryError, RegistryResult},
     types::{FieldLayout, Modality, PromptReplacement, TokenId},
-    vision::image_processor::PreprocessedImages,
+    vision::image_processor::{ModelSpecificValue, PreprocessedImages},
 };
 
 pub(super) struct Qwen3VLVisionSpec;
 
 impl Qwen3VLVisionSpec {
-    fn pad_token_id(metadata: &ModelMetadata) -> RegistryResult<TokenId> {
+    fn image_pad_token_id(metadata: &ModelMetadata) -> RegistryResult<TokenId> {
         metadata
             .config_u32(&["image_token_id"])
             .map(|v| v as TokenId)
             .ok_or_else(|| ModelRegistryError::MissingConfigField {
                 field: "image_token_id".to_string(),
             })
+    }
+
+    fn video_pad_token_id(metadata: &ModelMetadata) -> RegistryResult<TokenId> {
+        metadata
+            .config_u32(&["video_token_id"])
+            .map(|v| v as TokenId)
+            .ok_or_else(|| ModelRegistryError::MissingConfigField {
+                field: "video_token_id".to_string(),
+            })
+    }
+
+    fn vision_start_token_id(metadata: &ModelMetadata) -> Option<TokenId> {
+        metadata
+            .config_u32(&["vision_start_token_id"])
+            .map(|v| v as TokenId)
+    }
+
+    fn vision_end_token_id(metadata: &ModelMetadata) -> Option<TokenId> {
+        metadata
+            .config_u32(&["vision_end_token_id"])
+            .map(|v| v as TokenId)
+    }
+
+    fn token_for_id(
+        metadata: &ModelMetadata,
+        token_id: TokenId,
+        field: &str,
+    ) -> RegistryResult<String> {
+        metadata
+            .tokenizer
+            .id_to_token(token_id as u32)
+            .ok_or_else(|| ModelRegistryError::TokenNotFound {
+                token: format!("{field}:{token_id}"),
+            })
+    }
+
+    fn is_qwen3_5(metadata: &ModelMetadata) -> bool {
+        let id = metadata.model_id.to_ascii_lowercase();
+        let model_type = metadata.config_model_type();
+        id.contains("qwen3.5")
+            || id.contains("qwen3.6")
+            || model_type.is_some_and(|mt| mt == "qwen3_5" || mt == "qwen3_5_moe")
+    }
+
+    fn video_grid_t(preprocessed: &PreprocessedImages) -> Option<usize> {
+        match preprocessed.model_specific.get("video_grid_thw") {
+            Some(ModelSpecificValue::IntTensor { data, shape })
+                if shape == &[1, 3] && !data.is_empty() =>
+            {
+                usize::try_from(data[0]).ok()
+            }
+            _ => None,
+        }
+    }
+
+    fn encode_plain_text(metadata: &ModelMetadata, text: &str) -> Vec<TokenId> {
+        metadata
+            .tokenizer
+            .encode(text, false)
+            .ok()
+            .map(|encoding| match encoding {
+                Encoding::Hf(inner) => inner
+                    .get_ids()
+                    .iter()
+                    .map(|&id| id as TokenId)
+                    .collect::<Vec<_>>(),
+                Encoding::Plain(ids) | Encoding::Tiktoken(ids) => {
+                    ids.into_iter().map(|id| id as TokenId).collect()
+                }
+            })
+            .unwrap_or_default()
+    }
+
+    fn qwen3_5_video_replacement_tokens(
+        metadata: &ModelMetadata,
+        pad_token_id: TokenId,
+        num_tokens: usize,
+        grid_t: usize,
+    ) -> Option<Vec<TokenId>> {
+        if grid_t <= 1 || num_tokens == 0 || num_tokens % grid_t != 0 {
+            return None;
+        }
+        let vision_start = Self::vision_start_token_id(metadata)?;
+        let vision_end = Self::vision_end_token_id(metadata)?;
+        let tokens_per_grid = num_tokens / grid_t;
+        let mut tokens = Vec::with_capacity(num_tokens + (grid_t.saturating_sub(1)) * 8);
+
+        for grid_idx in 0..grid_t {
+            if grid_idx > 0 {
+                tokens.push(vision_end);
+                tokens.extend(Self::encode_plain_text(
+                    metadata,
+                    &format!("<{grid_idx}.0 seconds>"),
+                ));
+                tokens.push(vision_start);
+            }
+            tokens.extend(std::iter::repeat_n(pad_token_id, tokens_per_grid));
+        }
+
+        Some(tokens)
     }
 }
 
@@ -38,24 +139,60 @@ impl ModelProcessorSpec for Qwen3VLVisionSpec {
     }
 
     fn placeholder_token(&self, metadata: &ModelMetadata) -> RegistryResult<String> {
-        let token_id = Self::pad_token_id(metadata)? as u32;
-        metadata
-            .tokenizer
-            .id_to_token(token_id)
-            .ok_or_else(|| ModelRegistryError::TokenNotFound {
-                token: format!("image_token_id:{token_id}"),
-            })
+        Self::token_for_id(
+            metadata,
+            Self::image_pad_token_id(metadata)?,
+            "image_token_id",
+        )
     }
 
     fn placeholder_token_id(&self, metadata: &ModelMetadata) -> RegistryResult<TokenId> {
-        Self::pad_token_id(metadata)
+        Self::image_pad_token_id(metadata)
+    }
+
+    fn placeholder_token_for(
+        &self,
+        metadata: &ModelMetadata,
+        modality: Modality,
+    ) -> RegistryResult<String> {
+        match modality {
+            Modality::Image => self.placeholder_token(metadata),
+            Modality::Video => Self::token_for_id(
+                metadata,
+                Self::video_pad_token_id(metadata)?,
+                "video_token_id",
+            ),
+            _ => Err(ModelRegistryError::UnsupportedModality {
+                spec: self.name(),
+                modality,
+            }),
+        }
+    }
+
+    fn placeholder_token_id_for(
+        &self,
+        metadata: &ModelMetadata,
+        modality: Modality,
+    ) -> RegistryResult<TokenId> {
+        match modality {
+            Modality::Image => Self::image_pad_token_id(metadata),
+            Modality::Video => Self::video_pad_token_id(metadata),
+            _ => Err(ModelRegistryError::UnsupportedModality {
+                spec: self.name(),
+                modality,
+            }),
+        }
     }
 
     fn modality_limits(
         &self,
-        _metadata: &ModelMetadata,
+        metadata: &ModelMetadata,
     ) -> RegistryResult<HashMap<Modality, usize>> {
-        Ok(HashMap::from([(Modality::Image, 10)]))
+        let mut limits = HashMap::from([(Modality::Image, 10)]);
+        if metadata.config_u32(&["video_token_id"]).is_some() {
+            limits.insert(Modality::Video, 1);
+        }
+        Ok(limits)
     }
 
     fn processor_kwargs(&self, _metadata: &ModelMetadata) -> RegistryResult<Value> {
@@ -67,7 +204,7 @@ impl ModelProcessorSpec for Qwen3VLVisionSpec {
         metadata: &ModelMetadata,
         preprocessed: &PreprocessedImages,
     ) -> RegistryResult<Vec<PromptReplacement>> {
-        let pad_token_id = Self::pad_token_id(metadata)?;
+        let pad_token_id = Self::image_pad_token_id(metadata)?;
         let placeholder_token = self.placeholder_token(metadata)?;
         // The chat template already wraps each image with <|vision_start|> ... <|vision_end|>,
         // so we only expand the single <|image_pad|> placeholder to N pad tokens.
@@ -81,6 +218,47 @@ impl ModelProcessorSpec for Qwen3VLVisionSpec {
             .collect())
     }
 
+    fn prompt_replacements_for(
+        &self,
+        metadata: &ModelMetadata,
+        preprocessed: &PreprocessedImages,
+        modality: Modality,
+    ) -> RegistryResult<Vec<PromptReplacement>> {
+        match modality {
+            Modality::Image => self.prompt_replacements(metadata, preprocessed),
+            Modality::Video => {
+                let pad_token_id = Self::video_pad_token_id(metadata)?;
+                let placeholder_token = self.placeholder_token_for(metadata, Modality::Video)?;
+                let video_grid_t = Self::video_grid_t(preprocessed);
+                Ok(preprocessed
+                    .num_img_tokens
+                    .iter()
+                    .map(|&num_tokens| {
+                        let tokens = if Self::is_qwen3_5(metadata) {
+                            video_grid_t
+                                .and_then(|grid_t| {
+                                    Self::qwen3_5_video_replacement_tokens(
+                                        metadata,
+                                        pad_token_id,
+                                        num_tokens,
+                                        grid_t,
+                                    )
+                                })
+                                .unwrap_or_else(|| vec![pad_token_id; num_tokens])
+                        } else {
+                            vec![pad_token_id; num_tokens]
+                        };
+                        PromptReplacement::sequence(Modality::Video, &placeholder_token, tokens)
+                    })
+                    .collect())
+            }
+            _ => Err(ModelRegistryError::UnsupportedModality {
+                spec: self.name(),
+                modality,
+            }),
+        }
+    }
+
     fn field_layouts(&self) -> HashMap<String, FieldLayout> {
         // pixel_values is patchified: [total_patches, patch_features].
         // patches_per_image tells how many patches belong to each image.
@@ -92,11 +270,13 @@ impl ModelProcessorSpec for Qwen3VLVisionSpec {
             ),
             ("image_grid_thw".to_string(), FieldLayout::Batched),
             ("patches_per_image".to_string(), FieldLayout::Batched),
+            ("video_grid_thw".to_string(), FieldLayout::Batched),
+            ("patches_per_video".to_string(), FieldLayout::Batched),
         ])
     }
 
     fn keep_on_cpu_keys(&self) -> Vec<String> {
-        vec!["image_grid_thw".to_string()]
+        vec!["image_grid_thw".to_string(), "video_grid_thw".to_string()]
     }
 }
 
@@ -138,6 +318,72 @@ mod tests {
         assert_eq!(replacements[0].tokens.len(), 196);
         assert_eq!(replacements[0].tokens[0], 151655); // pad (image_token_id)
         assert_eq!(*replacements[0].tokens.last().unwrap(), 151655); // pad
+    }
+
+    #[test]
+    fn qwen3_vl_video_pad_replacement() {
+        let tokenizer = TestTokenizer::new(&[("<|video_pad|>", 151656)]);
+        let config = json!({
+            "model_type": "qwen3_5",
+            "image_token_id": 151655,
+            "video_token_id": 151656,
+        });
+        let metadata = ModelMetadata {
+            model_id: "Qwen3.5-VL-7B",
+            tokenizer: &tokenizer,
+            config: &config,
+        };
+        let registry = ModelRegistry::new();
+        let spec = registry.lookup(&metadata).expect("qwen3.5 spec");
+        let replacements = spec
+            .prompt_replacements_for(
+                &metadata,
+                &test_preprocessed_with_tokens(&[ImageSize::new(448, 448)], &[128]),
+                crate::types::Modality::Video,
+            )
+            .unwrap();
+
+        assert_eq!(replacements[0].modality, crate::types::Modality::Video);
+        assert_eq!(replacements[0].tokens.len(), 128);
+        assert_eq!(replacements[0].tokens[0], 151656);
+    }
+
+    #[test]
+    fn qwen3_5_video_replacement_splits_temporal_grid() {
+        let tokenizer = TestTokenizer::new(&[
+            ("<|video_pad|>", 151656),
+            ("<|vision_start|>", 151652),
+            ("<|vision_end|>", 151653),
+        ]);
+        let config = json!({
+            "model_type": "qwen3_5",
+            "image_token_id": 151655,
+            "video_token_id": 151656,
+            "vision_start_token_id": 151652,
+            "vision_end_token_id": 151653,
+        });
+        let metadata = ModelMetadata {
+            model_id: "Qwen/Qwen3.5-4B",
+            tokenizer: &tokenizer,
+            config: &config,
+        };
+        let registry = ModelRegistry::new();
+        let spec = registry.lookup(&metadata).expect("qwen3.5 spec");
+        let preprocessed = test_preprocessed_with_tokens(&[ImageSize::new(320, 256)], &[160])
+            .with_extra(
+                "video_grid_thw",
+                crate::vision::image_processor::ModelSpecificValue::int_2d(vec![2, 16, 20], 1, 3),
+            );
+        let replacements = spec
+            .prompt_replacements_for(&metadata, &preprocessed, crate::types::Modality::Video)
+            .unwrap();
+
+        let tokens = &replacements[0].tokens;
+        assert_eq!(tokens.len(), 162);
+        assert!(tokens[..80].iter().all(|&token| token == 151656));
+        assert_eq!(tokens[80], 151653);
+        assert_eq!(tokens[81], 151652);
+        assert!(tokens[82..].iter().all(|&token| token == 151656));
     }
 
     #[test]

--- a/crates/multimodal/src/registry/qwen3_vl.rs
+++ b/crates/multimodal/src/registry/qwen3_vl.rs
@@ -6,7 +6,7 @@ use serde_json::{json, Value};
 use crate::{
     registry::{ModelMetadata, ModelProcessorSpec, ModelRegistryError, RegistryResult},
     types::{FieldLayout, Modality, PromptReplacement, TokenId},
-    vision::image_processor::{ModelSpecificValue, PreprocessedImages},
+    vision::processor::{ModelSpecificValue, PreprocessedEncoderInputs},
 };
 
 pub(super) struct Qwen3VLVisionSpec;
@@ -63,7 +63,7 @@ impl Qwen3VLVisionSpec {
             || model_type.is_some_and(|mt| mt == "qwen3_5" || mt == "qwen3_5_moe")
     }
 
-    fn video_grid_t(preprocessed: &PreprocessedImages) -> Option<usize> {
+    fn video_grid_t(preprocessed: &PreprocessedEncoderInputs) -> Option<usize> {
         match preprocessed.model_specific.get("video_grid_thw") {
             Some(ModelSpecificValue::IntTensor { data, shape })
                 if shape == &[1, 3] && !data.is_empty() =>
@@ -98,21 +98,33 @@ impl Qwen3VLVisionSpec {
         num_tokens: usize,
         grid_t: usize,
     ) -> Option<Vec<TokenId>> {
-        if grid_t <= 1 || num_tokens == 0 || num_tokens % grid_t != 0 {
+        if grid_t <= 1 || num_tokens == 0 || !num_tokens.is_multiple_of(grid_t) {
             return None;
         }
         let vision_start = Self::vision_start_token_id(metadata)?;
         let vision_end = Self::vision_end_token_id(metadata)?;
         let tokens_per_grid = num_tokens / grid_t;
         let mut tokens = Vec::with_capacity(num_tokens + (grid_t.saturating_sub(1)) * 8);
+        let temporal_patch_size = metadata
+            .config_u32(&["vision_config", "temporal_patch_size"])
+            .unwrap_or(2) as f64;
+        // SMG currently samples Qwen videos at the HF default 2 fps. Match HF's
+        // prompt timestamp convention: timestamp each temporal patch by the
+        // average frame time and format it with one decimal place.
+        let sample_fps = 2.0_f64;
 
         for grid_idx in 0..grid_t {
+            let seconds = (grid_idx as f64 * temporal_patch_size
+                + (temporal_patch_size - 1.0) / 2.0)
+                / sample_fps;
             if grid_idx > 0 {
                 tokens.push(vision_end);
-                tokens.extend(Self::encode_plain_text(
-                    metadata,
-                    &format!("<{grid_idx}.0 seconds>"),
-                ));
+            }
+            tokens.extend(Self::encode_plain_text(
+                metadata,
+                &format!("<{seconds:.1} seconds>"),
+            ));
+            if grid_idx > 0 {
                 tokens.push(vision_start);
             }
             tokens.extend(std::iter::repeat_n(pad_token_id, tokens_per_grid));
@@ -202,14 +214,14 @@ impl ModelProcessorSpec for Qwen3VLVisionSpec {
     fn prompt_replacements(
         &self,
         metadata: &ModelMetadata,
-        preprocessed: &PreprocessedImages,
+        preprocessed: &PreprocessedEncoderInputs,
     ) -> RegistryResult<Vec<PromptReplacement>> {
         let pad_token_id = Self::image_pad_token_id(metadata)?;
         let placeholder_token = self.placeholder_token(metadata)?;
         // The chat template already wraps each image with <|vision_start|> ... <|vision_end|>,
         // so we only expand the single <|image_pad|> placeholder to N pad tokens.
         Ok(preprocessed
-            .num_img_tokens
+            .feature_token_counts
             .iter()
             .map(|&num_tokens| {
                 let tokens = vec![pad_token_id; num_tokens];
@@ -221,7 +233,7 @@ impl ModelProcessorSpec for Qwen3VLVisionSpec {
     fn prompt_replacements_for(
         &self,
         metadata: &ModelMetadata,
-        preprocessed: &PreprocessedImages,
+        preprocessed: &PreprocessedEncoderInputs,
         modality: Modality,
     ) -> RegistryResult<Vec<PromptReplacement>> {
         match modality {
@@ -231,7 +243,7 @@ impl ModelProcessorSpec for Qwen3VLVisionSpec {
                 let placeholder_token = self.placeholder_token_for(metadata, Modality::Video)?;
                 let video_grid_t = Self::video_grid_t(preprocessed);
                 Ok(preprocessed
-                    .num_img_tokens
+                    .feature_token_counts
                     .iter()
                     .map(|&num_tokens| {
                         let tokens = if Self::is_qwen3_5(metadata) {
@@ -260,7 +272,7 @@ impl ModelProcessorSpec for Qwen3VLVisionSpec {
     }
 
     fn field_layouts(&self) -> HashMap<String, FieldLayout> {
-        // pixel_values is patchified: [total_patches, patch_features].
+        // encoder_input is patchified: [total_patches, patch_features].
         // patches_per_image tells how many patches belong to each image.
         // image_grid_thw is [num_images, 3].
         HashMap::from([
@@ -287,6 +299,7 @@ mod tests {
     use crate::{
         registry::{test_helpers::*, ModelMetadata, ModelRegistry},
         types::ImageSize,
+        vision::processor::ModelSpecificValue,
     };
 
     #[test]
@@ -372,7 +385,7 @@ mod tests {
         let preprocessed = test_preprocessed_with_tokens(&[ImageSize::new(320, 256)], &[160])
             .with_extra(
                 "video_grid_thw",
-                crate::vision::image_processor::ModelSpecificValue::int_2d(vec![2, 16, 20], 1, 3),
+                ModelSpecificValue::int_2d(vec![2, 16, 20], 1, 3),
             );
         let replacements = spec
             .prompt_replacements_for(&metadata, &preprocessed, crate::types::Modality::Video)

--- a/crates/multimodal/src/registry/qwen_vl.rs
+++ b/crates/multimodal/src/registry/qwen_vl.rs
@@ -5,7 +5,7 @@ use serde_json::{json, Value};
 use crate::{
     registry::{ModelMetadata, ModelProcessorSpec, ModelRegistryError, RegistryResult},
     types::{FieldLayout, Modality, PromptReplacement, TokenId},
-    vision::image_processor::PreprocessedImages,
+    vision::processor::PreprocessedEncoderInputs,
 };
 
 pub(super) struct QwenVLVisionSpec;
@@ -58,14 +58,14 @@ impl ModelProcessorSpec for QwenVLVisionSpec {
     fn prompt_replacements(
         &self,
         metadata: &ModelMetadata,
-        preprocessed: &PreprocessedImages,
+        preprocessed: &PreprocessedEncoderInputs,
     ) -> RegistryResult<Vec<PromptReplacement>> {
         let pad_token_id = Self::pad_token_id(metadata)?;
         let placeholder_token = self.placeholder_token(metadata)?;
         // The chat template already wraps each image with <|vision_start|> ... <|vision_end|>,
         // so we only expand the single <image> placeholder to N pad tokens.
         Ok(preprocessed
-            .num_img_tokens
+            .feature_token_counts
             .iter()
             .map(|&num_tokens| {
                 let tokens = vec![pad_token_id; num_tokens];
@@ -75,7 +75,7 @@ impl ModelProcessorSpec for QwenVLVisionSpec {
     }
 
     fn field_layouts(&self) -> HashMap<String, FieldLayout> {
-        // pixel_values is patchified: [total_patches, patch_features].
+        // encoder_input is patchified: [total_patches, patch_features].
         // patches_per_image tells how many patches belong to each image.
         // image_grid_thw is [num_images, 3].
         HashMap::from([

--- a/crates/multimodal/src/registry/traits.rs
+++ b/crates/multimodal/src/registry/traits.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 
 use crate::{
     types::{FieldLayout, Modality, PromptReplacement, TokenId},
-    vision::image_processor::PreprocessedImages,
+    vision::processor::PreprocessedEncoderInputs,
 };
 
 #[derive(Debug, Error)]
@@ -94,7 +94,7 @@ pub trait ModelProcessorSpec: Send + Sync {
     fn modality_limits(&self, metadata: &ModelMetadata)
         -> RegistryResult<HashMap<Modality, usize>>;
     fn processor_kwargs(&self, metadata: &ModelMetadata) -> RegistryResult<Value>;
-    /// Compute per-image prompt replacement token sequences.
+    /// Compute per-media prompt replacement token sequences.
     ///
     /// Receives the full preprocessed output so each model can extract whatever
     /// metadata it needs (e.g. aspect_ratios for tile-based models).  This
@@ -102,12 +102,12 @@ pub trait ModelProcessorSpec: Send + Sync {
     fn prompt_replacements(
         &self,
         metadata: &ModelMetadata,
-        preprocessed: &PreprocessedImages,
+        preprocessed: &PreprocessedEncoderInputs,
     ) -> RegistryResult<Vec<PromptReplacement>>;
     fn prompt_replacements_for(
         &self,
         metadata: &ModelMetadata,
-        preprocessed: &PreprocessedImages,
+        preprocessed: &PreprocessedEncoderInputs,
         modality: Modality,
     ) -> RegistryResult<Vec<PromptReplacement>> {
         match modality {
@@ -119,12 +119,13 @@ pub trait ModelProcessorSpec: Send + Sync {
         }
     }
 
-    /// Declare how each tensor's first dimension maps to images.
+    /// Declare how each tensor's first dimension maps to media items.
     ///
-    /// Keys not listed are treated as shared (replicated across all images).
-    /// The `"pixel_values"` key should be included when it differs from batched.
+    /// Keys not listed are treated as shared (replicated across all media items).
+    /// The `"pixel_values"` key mirrors HF/vLLM vision kwargs and should be
+    /// included when the primary encoder input differs from batched layout.
     fn field_layouts(&self) -> HashMap<String, FieldLayout> {
-        // Default: pixel_values is batched (most models).
+        // Default: encoder_input is batched (most models).
         HashMap::from([("pixel_values".to_string(), FieldLayout::Batched)])
     }
 

--- a/crates/multimodal/src/registry/traits.rs
+++ b/crates/multimodal/src/registry/traits.rs
@@ -17,6 +17,11 @@ pub enum ModelRegistryError {
     TokenNotFound { token: String },
     #[error("missing config field '{field}'")]
     MissingConfigField { field: String },
+    #[error("modality {modality} is not supported by model spec {spec}")]
+    UnsupportedModality {
+        spec: &'static str,
+        modality: Modality,
+    },
 }
 
 pub type RegistryResult<T> = Result<T, ModelRegistryError>;
@@ -60,6 +65,32 @@ pub trait ModelProcessorSpec: Send + Sync {
     fn matches(&self, metadata: &ModelMetadata) -> bool;
     fn placeholder_token(&self, metadata: &ModelMetadata) -> RegistryResult<String>;
     fn placeholder_token_id(&self, metadata: &ModelMetadata) -> RegistryResult<TokenId>;
+    fn placeholder_token_for(
+        &self,
+        metadata: &ModelMetadata,
+        modality: Modality,
+    ) -> RegistryResult<String> {
+        match modality {
+            Modality::Image => self.placeholder_token(metadata),
+            _ => Err(ModelRegistryError::UnsupportedModality {
+                spec: self.name(),
+                modality,
+            }),
+        }
+    }
+    fn placeholder_token_id_for(
+        &self,
+        metadata: &ModelMetadata,
+        modality: Modality,
+    ) -> RegistryResult<TokenId> {
+        match modality {
+            Modality::Image => self.placeholder_token_id(metadata),
+            _ => Err(ModelRegistryError::UnsupportedModality {
+                spec: self.name(),
+                modality,
+            }),
+        }
+    }
     fn modality_limits(&self, metadata: &ModelMetadata)
         -> RegistryResult<HashMap<Modality, usize>>;
     fn processor_kwargs(&self, metadata: &ModelMetadata) -> RegistryResult<Value>;
@@ -73,6 +104,20 @@ pub trait ModelProcessorSpec: Send + Sync {
         metadata: &ModelMetadata,
         preprocessed: &PreprocessedImages,
     ) -> RegistryResult<Vec<PromptReplacement>>;
+    fn prompt_replacements_for(
+        &self,
+        metadata: &ModelMetadata,
+        preprocessed: &PreprocessedImages,
+        modality: Modality,
+    ) -> RegistryResult<Vec<PromptReplacement>> {
+        match modality {
+            Modality::Image => self.prompt_replacements(metadata, preprocessed),
+            _ => Err(ModelRegistryError::UnsupportedModality {
+                spec: self.name(),
+                modality,
+            }),
+        }
+    }
 
     /// Declare how each tensor's first dimension maps to images.
     ///

--- a/crates/multimodal/src/tracker.rs
+++ b/crates/multimodal/src/tracker.rs
@@ -4,7 +4,7 @@ use tokio::task::JoinHandle;
 
 use super::{
     error::{MultiModalError, MultiModalResult},
-    media::{ImageFetchConfig, MediaConnector, MediaSource},
+    media::{ImageFetchConfig, MediaConnector, MediaSource, VideoFetchConfig},
     types::{
         ImageDetail, MediaContentPart, Modality, MultiModalData, MultiModalUUIDs, TrackedMedia,
     },
@@ -58,6 +58,20 @@ impl AsyncMultiModalTracker {
             MediaContentPart::ImageEmbeds { .. } => {
                 return Err(MultiModalError::UnsupportedContent("image_embeds"));
             }
+            MediaContentPart::VideoUrl { url, uuid } => {
+                let source = match url::Url::parse(&url) {
+                    Ok(parsed) if parsed.scheme() == "data" => MediaSource::DataUrl(url),
+                    _ => MediaSource::Url(url),
+                };
+                self.enqueue_video(source, uuid);
+            }
+            MediaContentPart::VideoData {
+                data,
+                mime_type: _,
+                uuid,
+            } => {
+                self.enqueue_video(MediaSource::InlineBytes(data), uuid);
+            }
         }
         Ok(())
     }
@@ -93,6 +107,25 @@ impl AsyncMultiModalTracker {
                 .fetch_image(source, ImageFetchConfig { detail })
                 .await?;
             Ok(TrackedMedia::Image(frame))
+        });
+
+        self.pending.entry(modality).or_default().push(handle);
+    }
+
+    fn enqueue_video(&mut self, source: MediaSource, uuid: Option<String>) {
+        let modality = Modality::Video;
+        self.uuids.entry(modality).or_default().push(uuid);
+
+        let connector = Arc::clone(&self.media_connector);
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "spawn handle is stored in self.pending and awaited in finalize(); fire-and-forget is intentional for concurrent media fetching"
+        )]
+        let handle = tokio::spawn(async move {
+            let clip = connector
+                .fetch_video(source, VideoFetchConfig::default())
+                .await?;
+            Ok(TrackedMedia::Video(clip))
         });
 
         self.pending.entry(modality).or_default().push(handle);

--- a/crates/multimodal/src/types.rs
+++ b/crates/multimodal/src/types.rs
@@ -195,16 +195,16 @@ pub type MultiModalUUIDs = HashMap<Modality, Vec<Option<String>>>;
 
 pub type TokenId = i32;
 
-/// Declares how a multimodal tensor's first dimension maps to items (images).
+/// Declares how a multimodal tensor's first dimension maps to media items.
 ///
 /// Used by [`ModelProcessorSpec::field_layouts`] to tell the backend how to
 /// split tensors for per-item scheduling (vLLM `MultiModalFieldConfig`).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FieldLayout {
-    /// First dimension equals num_images (one slice per image).
+    /// First dimension equals number of media items (one slice per item).
     Batched,
-    /// Variable-length slices per image.  The sizes are stored in the
-    /// tensor named by `sizes_key` (e.g. `"patches_per_image"`).
+    /// Variable-length slices per item. The sizes are stored in the tensor
+    /// named by `sizes_key` (e.g. `"patches_per_image"` or `"patches_per_video"`).
     Flat { sizes_key: String },
 }
 

--- a/crates/multimodal/src/types.rs
+++ b/crates/multimodal/src/types.rs
@@ -63,12 +63,34 @@ pub enum MediaContentPart {
         #[serde(skip_serializing_if = "Option::is_none")]
         uuid: Option<String>,
     },
+    VideoUrl {
+        url: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        uuid: Option<String>,
+    },
+    VideoData {
+        data: Vec<u8>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        mime_type: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        uuid: Option<String>,
+    },
 }
 
 /// Image source metadata (useful for hashing & tracing).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum ImageSource {
+    Url { url: String },
+    DataUrl,
+    InlineBytes,
+    File { path: PathBuf },
+}
+
+/// Video source metadata (useful for hashing & tracing).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum VideoSource {
     Url { url: String },
     DataUrl,
     InlineBytes,
@@ -84,6 +106,44 @@ pub struct ImageFrame {
     pub source: ImageSource,
     /// Blake3 hex-digest of raw_bytes, computed at decode time.
     pub hash: String,
+}
+
+/// Decoded video payload captured by the media connector.
+#[derive(Debug, Clone)]
+pub struct VideoClip {
+    pub frames: Vec<DynamicImage>,
+    pub raw_bytes: bytes::Bytes,
+    pub source: VideoSource,
+    /// Blake3 hex-digest of raw_bytes, computed at decode time.
+    pub hash: String,
+}
+
+impl VideoClip {
+    pub fn new(
+        frames: Vec<DynamicImage>,
+        raw_bytes: bytes::Bytes,
+        source: VideoSource,
+        hash: String,
+    ) -> Self {
+        Self {
+            frames,
+            raw_bytes,
+            source,
+            hash,
+        }
+    }
+
+    pub fn frames(&self) -> &[DynamicImage] {
+        &self.frames
+    }
+
+    pub fn raw_bytes(&self) -> &[u8] {
+        &self.raw_bytes
+    }
+
+    pub fn source(&self) -> &VideoSource {
+        &self.source
+    }
 }
 
 impl ImageFrame {
@@ -124,9 +184,9 @@ impl ImageFrame {
 #[derive(Debug, Clone)]
 pub enum TrackedMedia {
     Image(Arc<ImageFrame>),
+    Video(Arc<VideoClip>),
     /// Placeholder variants for future modalities.
     Audio,
-    Video,
     Embeddings,
 }
 

--- a/crates/multimodal/src/vision/image_processor.rs
+++ b/crates/multimodal/src/vision/image_processor.rs
@@ -297,6 +297,22 @@ pub trait ImagePreProcessor: Send + Sync {
         config: &PreProcessorConfig,
     ) -> Result<PreprocessedImages, TransformError>;
 
+    /// Preprocess one decoded video clip represented as sampled frames.
+    ///
+    /// Implementations that support video should emit the same primary
+    /// `pixel_values` tensor shape used by the image path, plus video-specific
+    /// model metadata such as `video_grid_thw`.
+    fn preprocess_video(
+        &self,
+        _frames: &[DynamicImage],
+        _config: &PreProcessorConfig,
+    ) -> Result<PreprocessedImages, TransformError> {
+        Err(TransformError::ShapeError(format!(
+            "{} does not support video preprocessing",
+            self.model_name()
+        )))
+    }
+
     /// Calculate the number of image tokens for a given image size.
     ///
     /// This is used to determine how many placeholder tokens to insert

--- a/crates/multimodal/src/vision/mod.rs
+++ b/crates/multimodal/src/vision/mod.rs
@@ -1,7 +1,7 @@
 //! Pure Rust vision processing module for multimodal models.
 //!
-//! This module provides image preprocessing pipelines that match HuggingFace processor
-//! outputs without requiring Python dependencies.
+//! This module provides vision preprocessing pipelines that match HuggingFace
+//! processor outputs without requiring Python dependencies.
 //!
 //! # Architecture
 //!
@@ -9,7 +9,7 @@
 //!
 //! - `transforms`: Core image transformations (resize, normalize, crop, etc.)
 //! - `preprocessor_config`: HuggingFace config parsing
-//! - `image_processor`: Trait and output types for processors
+//! - `processor`: Trait and output types for processors
 //! - `processors`: Model-specific implementations (LLaVA, Qwen-VL, etc.)
 //!
 //! # Usage
@@ -18,7 +18,7 @@
 //! use smg::multimodal::vision::{
 //!     PreProcessorConfig,
 //!     processors::LlavaProcessor,
-//!     ImagePreProcessor,
+//!     VisionPreProcessor,
 //! };
 //!
 //! // Load config from HuggingFace
@@ -29,16 +29,16 @@
 //! let result = processor.preprocess(&images, &config)?;
 //! ```
 
-pub mod image_processor;
 pub mod preprocessor_config;
+pub mod processor;
 pub mod processors;
 pub mod transforms;
 
 // Re-export commonly used types
-pub use image_processor::{
-    ImagePreProcessor, ImageProcessorRegistry, ModelSpecificValue, PreprocessedImages,
-};
 pub use preprocessor_config::PreProcessorConfig;
+pub use processor::{
+    ModelSpecificValue, PreprocessedEncoderInputs, VisionPreProcessor, VisionProcessorRegistry,
+};
 pub use processors::{
     Llama4VisionProcessor, LlavaNextProcessor, LlavaProcessor, Phi3VisionProcessor,
     Phi4VisionProcessor, PixtralProcessor, Qwen2VLProcessor, Qwen3VLProcessor,

--- a/crates/multimodal/src/vision/preprocessor_config.rs
+++ b/crates/multimodal/src/vision/preprocessor_config.rs
@@ -192,7 +192,7 @@ pub struct PreProcessorConfig {
     #[serde(default)]
     pub max_image_tiles: Option<usize>,
 
-    /// Fixed number of image tokens (some models use this)
+    /// Fixed number of image tokens (some model configs use this HF field name).
     #[serde(default)]
     pub num_img_tokens: Option<usize>,
 

--- a/crates/multimodal/src/vision/preprocessor_config.rs
+++ b/crates/multimodal/src/vision/preprocessor_config.rs
@@ -349,6 +349,23 @@ impl PreProcessorConfig {
         })
     }
 
+    /// Get a scalar value from the `size` map, such as `shortest_edge` or
+    /// `longest_edge`.
+    pub fn get_size_value(&self, key: &str) -> Option<usize> {
+        self.size
+            .as_ref()
+            .and_then(|s| s.get(key))
+            .map(|v| *v as usize)
+    }
+
+    pub fn get_shortest_edge(&self) -> Option<usize> {
+        self.get_size_value("shortest_edge")
+    }
+
+    pub fn get_longest_edge(&self) -> Option<usize> {
+        self.get_size_value("longest_edge")
+    }
+
     /// Get crop size.
     ///
     /// Returns (height, width).

--- a/crates/multimodal/src/vision/processor.rs
+++ b/crates/multimodal/src/vision/processor.rs
@@ -1,7 +1,7 @@
-//! Image processor trait and output types.
+//! Vision processor trait and encoder-output types.
 //!
-//! This module defines the interface for model-specific image processors
-//! and the common output format for preprocessed images.
+//! This module defines the interface for model-specific vision processors
+//! and the common output format for preprocessed encoder inputs.
 
 use std::{borrow::Cow, collections::HashMap};
 
@@ -11,7 +11,7 @@ use ndarray::{Array4, ArrayD};
 use super::{preprocessor_config::PreProcessorConfig, transforms::TransformError};
 use crate::types::FieldLayout;
 
-/// Helper to extract a dimension from pixel_values given an ndim-dependent axis index.
+/// Helper to extract a dimension from encoder_input given an ndim-dependent axis index.
 /// Returns `Err` if the ndim is not 4 or 5.
 fn dim_for_ndim(
     ndim: usize,
@@ -23,7 +23,7 @@ fn dim_for_ndim(
         4 => Ok(shape[axis_4d]),
         5 => Ok(shape[axis_5d]),
         _ => Err(TransformError::InvalidShape {
-            expected: format!("4D or 5D pixel_values tensor, got {ndim}D"),
+            expected: format!("4D or 5D encoder_input tensor, got {ndim}D"),
             actual: shape.to_vec(),
         }),
     }
@@ -31,7 +31,7 @@ fn dim_for_ndim(
 
 /// Model-specific output values that vary by architecture.
 ///
-/// Different vision models require different auxiliary outputs beyond pixel_values.
+/// Different vision models require different auxiliary outputs beyond encoder_input.
 /// This enum captures the common types of such outputs.
 #[derive(Debug, Clone)]
 pub enum ModelSpecificValue {
@@ -112,67 +112,73 @@ impl ModelSpecificValue {
     }
 }
 
-/// Preprocessed images ready for model consumption.
+/// Preprocessed encoder inputs ready for model consumption.
 ///
-/// This struct contains all the outputs needed by the SGLang scheduler
-/// to construct `MultimodalInputs` for the model.
+/// This struct contains the processor outputs needed by serving backends to
+/// construct `MultimodalInputs` for the model. Vision processors currently
+/// produce this from images or sampled video frames; future modality processors
+/// can reuse the same output contract for audio features or other encoder inputs.
 #[derive(Debug, Clone)]
-pub struct PreprocessedImages {
-    /// Pixel values as a dynamic-dimensional float32 tensor.
+pub struct PreprocessedEncoderInputs {
+    /// Primary encoder input as a dynamic-dimensional float32 tensor.
     ///
-    /// This is the primary input to the vision encoder.
-    /// Shape varies by model:
+    /// For vision models this is typically the preprocessed image/video tensor.
+    /// Shape varies by model and modality:
     /// - Standard: [B, C, H, W] (4D)
     /// - Phi3-Vision: [B, num_crops+1, C, H, W] (5D)
-    pub pixel_values: ArrayD<f32>,
+    pub encoder_input: ArrayD<f32>,
 
-    /// Number of image tokens per image in the batch.
+    /// Number of encoder feature tokens per media item in the batch.
     ///
-    /// Used to expand placeholder tokens in the text input.
+    /// Used to expand placeholder tokens in the text input. For vision this is
+    /// usually an image patch or video patch count; for audio this could be an
+    /// audio feature-frame count.
     /// For example, LLaVA with 336x336 and patch_size=14 produces 576 tokens.
-    pub num_img_tokens: Vec<usize>,
+    pub feature_token_counts: Vec<usize>,
 
-    /// Original image sizes as (width, height) before preprocessing.
+    /// Modality-specific item size metadata before preprocessing.
     ///
-    /// Some models need this for proper attention masking or position encoding.
-    pub image_sizes: Vec<(u32, u32)>,
+    /// Vision processors use this for image/frame dimensions, but the exact
+    /// tuple order follows each processor/model contract. Model-specific shape
+    /// tensors that need a fixed order should also be emitted in `model_specific`.
+    pub item_sizes: Vec<(u32, u32)>,
 
     /// Model-specific auxiliary outputs.
     ///
     /// Examples:
     /// - Qwen-VL: `image_grid_thw` for rotary position encoding
     /// - LLaMA-Vision: `aspect_ratio_ids`, `aspect_ratio_mask`
-    /// - Phi3-Vision: `num_img_tokens` per crop
+    /// - Phi3-Vision: `num_img_tokens` auxiliary metadata
     pub model_specific: HashMap<String, ModelSpecificValue>,
 }
 
-impl PreprocessedImages {
-    /// Create a new PreprocessedImages with required fields (4D pixel values).
+impl PreprocessedEncoderInputs {
+    /// Create a new PreprocessedEncoderInputs with required fields (4D encoder input).
     pub fn new(
-        pixel_values: Array4<f32>,
-        num_img_tokens: Vec<usize>,
-        image_sizes: Vec<(u32, u32)>,
+        encoder_input: Array4<f32>,
+        feature_token_counts: Vec<usize>,
+        item_sizes: Vec<(u32, u32)>,
     ) -> Self {
         Self {
-            pixel_values: pixel_values.into_dyn(),
-            num_img_tokens,
-            image_sizes,
+            encoder_input: encoder_input.into_dyn(),
+            feature_token_counts,
+            item_sizes,
             model_specific: HashMap::new(),
         }
     }
 
-    /// Create a new PreprocessedImages with dynamic-dimensional pixel values.
+    /// Create a new PreprocessedEncoderInputs with dynamic-dimensional encoder input.
     ///
     /// Use this for models like Phi3-Vision that have 5D tensors.
     pub fn new_dynamic(
-        pixel_values: ArrayD<f32>,
-        num_img_tokens: Vec<usize>,
-        image_sizes: Vec<(u32, u32)>,
+        encoder_input: ArrayD<f32>,
+        feature_token_counts: Vec<usize>,
+        item_sizes: Vec<(u32, u32)>,
     ) -> Self {
         Self {
-            pixel_values,
-            num_img_tokens,
-            image_sizes,
+            encoder_input,
+            feature_token_counts,
+            item_sizes,
             model_specific: HashMap::new(),
         }
     }
@@ -185,7 +191,7 @@ impl PreprocessedImages {
 
     /// Get the batch size.
     pub fn batch_size(&self) -> usize {
-        self.pixel_values.shape()[0]
+        self.encoder_input.shape()[0]
     }
 
     /// Get the number of channels.
@@ -194,9 +200,9 @@ impl PreprocessedImages {
     /// For 5D tensors [B, N, C, H, W] (Phi3-Vision), returns shape[2].
     ///
     /// # Errors
-    /// Returns `TransformError::InvalidShape` if pixel_values is not 4D or 5D.
+    /// Returns `TransformError::InvalidShape` if encoder_input is not 4D or 5D.
     pub fn channels(&self) -> Result<usize, TransformError> {
-        dim_for_ndim(self.pixel_values.ndim(), 1, 2, self.pixel_values.shape())
+        dim_for_ndim(self.encoder_input.ndim(), 1, 2, self.encoder_input.shape())
     }
 
     /// Get the height of processed images.
@@ -205,9 +211,9 @@ impl PreprocessedImages {
     /// For 5D tensors [B, N, C, H, W] (Phi3-Vision), returns shape[3].
     ///
     /// # Errors
-    /// Returns `TransformError::InvalidShape` if pixel_values is not 4D or 5D.
+    /// Returns `TransformError::InvalidShape` if encoder_input is not 4D or 5D.
     pub fn height(&self) -> Result<usize, TransformError> {
-        dim_for_ndim(self.pixel_values.ndim(), 2, 3, self.pixel_values.shape())
+        dim_for_ndim(self.encoder_input.ndim(), 2, 3, self.encoder_input.shape())
     }
 
     /// Get the width of processed images.
@@ -216,37 +222,37 @@ impl PreprocessedImages {
     /// For 5D tensors [B, N, C, H, W] (Phi3-Vision), returns shape[4].
     ///
     /// # Errors
-    /// Returns `TransformError::InvalidShape` if pixel_values is not 4D or 5D.
+    /// Returns `TransformError::InvalidShape` if encoder_input is not 4D or 5D.
     pub fn width(&self) -> Result<usize, TransformError> {
-        dim_for_ndim(self.pixel_values.ndim(), 3, 4, self.pixel_values.shape())
+        dim_for_ndim(self.encoder_input.ndim(), 3, 4, self.encoder_input.shape())
     }
 
-    /// Get the number of dimensions of pixel_values.
+    /// Get the number of dimensions of encoder_input.
     pub fn ndim(&self) -> usize {
-        self.pixel_values.ndim()
+        self.encoder_input.ndim()
     }
 
-    /// Get total number of image tokens across all images.
-    pub fn total_tokens(&self) -> usize {
-        self.num_img_tokens.iter().sum()
+    /// Get total number of encoder feature tokens across all media items.
+    pub fn total_feature_tokens(&self) -> usize {
+        self.feature_token_counts.iter().sum()
     }
 
-    /// Get pixel values as a flat f32 slice without copying if possible.
-    pub fn pixel_values_flat(&self) -> Cow<'_, [f32]> {
-        match self.pixel_values.as_slice() {
+    /// Get the primary encoder input as a flat f32 slice without copying if possible.
+    pub fn encoder_input_flat(&self) -> Cow<'_, [f32]> {
+        match self.encoder_input.as_slice() {
             Some(slice) => Cow::Borrowed(slice),
-            None => Cow::Owned(self.pixel_values.iter().copied().collect()),
+            None => Cow::Owned(self.encoder_input.iter().copied().collect()),
         }
     }
 
-    /// Get the shape of pixel values as a vector.
-    pub fn pixel_values_shape(&self) -> Vec<usize> {
-        self.pixel_values.shape().to_vec()
+    /// Get the shape of the primary encoder input as a vector.
+    pub fn encoder_input_shape(&self) -> Vec<usize> {
+        self.encoder_input.shape().to_vec()
     }
 
-    /// Number of images in this batch.
-    pub fn num_images(&self) -> usize {
-        self.image_sizes.len()
+    /// Number of media items in this batch.
+    pub fn num_media_items(&self) -> usize {
+        self.item_sizes.len()
     }
 
     /// Extract batched tensor keys from explicit field layout declarations.
@@ -272,11 +278,11 @@ impl PreprocessedImages {
     }
 }
 
-/// Trait for model-specific image preprocessors.
+/// Trait for model-specific vision preprocessors.
 ///
 /// Each vision model (LLaVA, Qwen-VL, Phi3-Vision, etc.) implements this trait
 /// to provide the correct preprocessing pipeline.
-pub trait ImagePreProcessor: Send + Sync {
+pub trait VisionPreProcessor: Send + Sync {
     /// Default normalization mean for this model family.
     fn default_mean(&self) -> [f64; 3];
 
@@ -290,30 +296,30 @@ pub trait ImagePreProcessor: Send + Sync {
     /// * `config` - Preprocessor configuration from HuggingFace
     ///
     /// # Returns
-    /// Preprocessed images ready for the model, or an error.
+    /// Preprocessed encoder inputs ready for the model, or an error.
     fn preprocess(
         &self,
         images: &[DynamicImage],
         config: &PreProcessorConfig,
-    ) -> Result<PreprocessedImages, TransformError>;
+    ) -> Result<PreprocessedEncoderInputs, TransformError>;
 
     /// Preprocess one decoded video clip represented as sampled frames.
     ///
     /// Implementations that support video should emit the same primary
-    /// `pixel_values` tensor shape used by the image path, plus video-specific
+    /// `encoder_input` tensor shape used by the image path, plus video-specific
     /// model metadata such as `video_grid_thw`.
     fn preprocess_video(
         &self,
         _frames: &[DynamicImage],
         _config: &PreProcessorConfig,
-    ) -> Result<PreprocessedImages, TransformError> {
+    ) -> Result<PreprocessedEncoderInputs, TransformError> {
         Err(TransformError::ShapeError(format!(
             "{} does not support video preprocessing",
             self.model_name()
         )))
     }
 
-    /// Calculate the number of image tokens for a given image size.
+    /// Calculate the number of vision tokens for a given image size.
     ///
     /// This is used to determine how many placeholder tokens to insert
     /// in the text input before the image has been fully processed.
@@ -335,12 +341,12 @@ pub trait ImagePreProcessor: Send + Sync {
     }
 }
 
-/// Registry of available image processors.
-pub struct ImageProcessorRegistry {
-    processors: HashMap<String, Box<dyn ImagePreProcessor>>,
+/// Registry of available vision processors.
+pub struct VisionProcessorRegistry {
+    processors: HashMap<String, Box<dyn VisionPreProcessor>>,
 }
 
-impl ImageProcessorRegistry {
+impl VisionProcessorRegistry {
     /// Create a new empty registry.
     pub fn new() -> Self {
         Self {
@@ -349,19 +355,23 @@ impl ImageProcessorRegistry {
     }
 
     /// Register a processor for a model pattern.
-    pub fn register(&mut self, pattern: impl Into<String>, processor: Box<dyn ImagePreProcessor>) {
+    pub fn register(&mut self, pattern: impl Into<String>, processor: Box<dyn VisionPreProcessor>) {
         self.processors.insert(pattern.into(), processor);
     }
 
     /// Find a processor for the given model ID, falling back to model_type.
     ///
     /// Matches by substring containment (case-insensitive).
-    pub fn find(&self, model_id: &str, model_type: Option<&str>) -> Option<&dyn ImagePreProcessor> {
+    pub fn find(
+        &self,
+        model_id: &str,
+        model_type: Option<&str>,
+    ) -> Option<&dyn VisionPreProcessor> {
         self.find_in_candidate(model_id)
             .or_else(|| model_type.and_then(|mt| self.find_in_candidate(mt)))
     }
 
-    fn find_in_candidate(&self, candidate: &str) -> Option<&dyn ImagePreProcessor> {
+    fn find_in_candidate(&self, candidate: &str) -> Option<&dyn VisionPreProcessor> {
         let candidate = candidate.to_lowercase();
         for (pattern, processor) in &self.processors {
             if candidate.contains(&pattern.to_lowercase()) {
@@ -377,13 +387,13 @@ impl ImageProcessorRegistry {
     }
 }
 
-impl Default for ImageProcessorRegistry {
+impl Default for VisionProcessorRegistry {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl ImageProcessorRegistry {
+impl VisionProcessorRegistry {
     /// Create a registry with all built-in processors registered.
     ///
     /// Currently registers:
@@ -521,30 +531,33 @@ mod tests {
     use crate::vision::processors::LlavaProcessor;
 
     #[test]
-    fn test_preprocessed_images_accessors() {
-        let pixel_values = Array4::<f32>::zeros((2, 3, 336, 336));
-        let images =
-            PreprocessedImages::new(pixel_values, vec![576, 576], vec![(640, 480), (800, 600)]);
+    fn test_preprocessed_encoder_inputs_accessors() {
+        let encoder_input = Array4::<f32>::zeros((2, 3, 336, 336));
+        let inputs = PreprocessedEncoderInputs::new(
+            encoder_input,
+            vec![576, 576],
+            vec![(640, 480), (800, 600)],
+        );
 
-        assert_eq!(images.batch_size(), 2);
-        assert_eq!(images.channels().unwrap(), 3);
-        assert_eq!(images.height().unwrap(), 336);
-        assert_eq!(images.width().unwrap(), 336);
-        assert_eq!(images.total_tokens(), 1152);
+        assert_eq!(inputs.batch_size(), 2);
+        assert_eq!(inputs.channels().unwrap(), 3);
+        assert_eq!(inputs.height().unwrap(), 336);
+        assert_eq!(inputs.width().unwrap(), 336);
+        assert_eq!(inputs.total_feature_tokens(), 1152);
     }
 
     #[test]
-    fn test_preprocessed_images_with_extra() {
-        let pixel_values = Array4::<f32>::zeros((1, 3, 224, 224));
-        let images = PreprocessedImages::new(pixel_values, vec![196], vec![(224, 224)])
+    fn test_preprocessed_encoder_inputs_with_extra() {
+        let encoder_input = Array4::<f32>::zeros((1, 3, 224, 224));
+        let inputs = PreprocessedEncoderInputs::new(encoder_input, vec![196], vec![(224, 224)])
             .with_extra(
                 "image_grid_thw",
                 ModelSpecificValue::uint_1d(vec![1, 16, 16]),
             )
             .with_extra("aspect_ratio_id", ModelSpecificValue::Int(0));
 
-        assert!(images.model_specific.contains_key("image_grid_thw"));
-        assert!(images.model_specific.contains_key("aspect_ratio_id"));
+        assert!(inputs.model_specific.contains_key("image_grid_thw"));
+        assert!(inputs.model_specific.contains_key("aspect_ratio_id"));
     }
 
     #[test]
@@ -587,22 +600,22 @@ mod tests {
     }
 
     #[test]
-    fn test_pixel_values_flat() {
-        let mut pixel_values = Array4::<f32>::zeros((1, 1, 2, 2));
-        pixel_values[[0, 0, 0, 0]] = 1.0;
-        pixel_values[[0, 0, 0, 1]] = 2.0;
-        pixel_values[[0, 0, 1, 0]] = 3.0;
-        pixel_values[[0, 0, 1, 1]] = 4.0;
+    fn test_encoder_input_flat() {
+        let mut encoder_input = Array4::<f32>::zeros((1, 1, 2, 2));
+        encoder_input[[0, 0, 0, 0]] = 1.0;
+        encoder_input[[0, 0, 0, 1]] = 2.0;
+        encoder_input[[0, 0, 1, 0]] = 3.0;
+        encoder_input[[0, 0, 1, 1]] = 4.0;
 
-        let images = PreprocessedImages::new(pixel_values, vec![4], vec![(2, 2)]);
-        let flat = images.pixel_values_flat();
+        let inputs = PreprocessedEncoderInputs::new(encoder_input, vec![4], vec![(2, 2)]);
+        let flat = inputs.encoder_input_flat();
 
         assert_eq!(flat, vec![1.0, 2.0, 3.0, 4.0]);
     }
 
     #[test]
     fn test_registry_with_defaults() {
-        let registry = ImageProcessorRegistry::with_defaults();
+        let registry = VisionProcessorRegistry::with_defaults();
 
         // Should find LLaVA processor
         assert!(registry.find("llava-hf/llava-1.5-7b-hf", None).is_some());
@@ -623,7 +636,7 @@ mod tests {
 
     #[test]
     fn test_registry_find() {
-        let mut registry = ImageProcessorRegistry::new();
+        let mut registry = VisionProcessorRegistry::new();
 
         // Create a mock processor using LlavaProcessor
         registry.register("test-model", Box::new(LlavaProcessor::new()));
@@ -635,7 +648,7 @@ mod tests {
 
     #[test]
     fn test_registry_find_falls_back_to_model_type() {
-        let registry = ImageProcessorRegistry::with_defaults();
+        let registry = VisionProcessorRegistry::with_defaults();
 
         assert!(registry.find("custom-model", None).is_none());
 
@@ -647,7 +660,7 @@ mod tests {
 
     #[test]
     fn test_registry_find_preserves_fast_path() {
-        let registry = ImageProcessorRegistry::with_defaults();
+        let registry = VisionProcessorRegistry::with_defaults();
 
         let processor = registry
             .find("Qwen3-VL-30B-A3B-Instruct", Some("qwen2_vl"))
@@ -657,7 +670,7 @@ mod tests {
 
     #[test]
     fn test_registry_find_phi3_model_type_fallback() {
-        let registry = ImageProcessorRegistry::with_defaults();
+        let registry = VisionProcessorRegistry::with_defaults();
 
         let processor = registry
             .find("custom-model", Some("phi3_v"))

--- a/crates/multimodal/src/vision/processor.rs
+++ b/crates/multimodal/src/vision/processor.rs
@@ -5,6 +5,7 @@
 
 use std::{borrow::Cow, collections::HashMap};
 
+use anyhow::{Context, Result as AnyhowResult};
 use image::DynamicImage;
 use ndarray::{Array4, ArrayD};
 
@@ -110,6 +111,94 @@ impl ModelSpecificValue {
             _ => None,
         }
     }
+
+    /// Interpret this value as per-item flat sizes.
+    pub fn as_flat_sizes(&self) -> AnyhowResult<Vec<usize>> {
+        match self {
+            Self::IntTensor { data, .. } => data
+                .iter()
+                .map(|&v| usize::try_from(v).context("negative flat size"))
+                .collect(),
+            Self::UintTensor { data, .. } => Ok(data.iter().map(|&v| v as usize).collect()),
+            Self::IntVec(values) => values
+                .iter()
+                .map(|&v| usize::try_from(v).context("negative flat size"))
+                .collect(),
+            Self::UintVec(values) => Ok(values.iter().map(|&v| v as usize).collect()),
+            _ => Err(anyhow::anyhow!("unsupported flat sizes value type")),
+        }
+    }
+
+    /// Slice item-batched metadata along the first dimension.
+    pub fn slice_first_dim(&self, start: usize, len: usize) -> AnyhowResult<Self> {
+        match self {
+            Self::Tensor { data, shape } => {
+                let (data, shape) = slice_tensor_first_dim(data, shape, start, len)?;
+                Ok(Self::Tensor { data, shape })
+            }
+            Self::IntTensor { data, shape } => {
+                let (data, shape) = slice_tensor_first_dim(data, shape, start, len)?;
+                Ok(Self::IntTensor { data, shape })
+            }
+            Self::UintTensor { data, shape } => {
+                let (data, shape) = slice_tensor_first_dim(data, shape, start, len)?;
+                Ok(Self::UintTensor { data, shape })
+            }
+            Self::IntVec(values) => Ok(Self::IntVec(slice_1d(values, start, len)?.to_vec())),
+            Self::UintVec(values) => Ok(Self::UintVec(slice_1d(values, start, len)?.to_vec())),
+            Self::FloatVec(values) => Ok(Self::FloatVec(slice_1d(values, start, len)?.to_vec())),
+            Self::TupleVec(values) => Ok(Self::TupleVec(slice_1d(values, start, len)?.to_vec())),
+            _ => Ok(self.clone()),
+        }
+    }
+}
+
+fn slice_tensor_first_dim<T: Clone>(
+    data: &[T],
+    shape: &[usize],
+    start: usize,
+    len: usize,
+) -> AnyhowResult<(Vec<T>, Vec<usize>)> {
+    let first_dim = *shape
+        .first()
+        .ok_or_else(|| anyhow::anyhow!("cannot slice scalar tensor"))?;
+    let end = start
+        .checked_add(len)
+        .ok_or_else(|| anyhow::anyhow!("tensor slice range overflow"))?;
+    anyhow::ensure!(
+        end <= first_dim,
+        "tensor first-dimension slice {start}..{end} exceeds {first_dim}"
+    );
+    let row_width = shape[1..]
+        .iter()
+        .try_fold(1usize, |acc, &dim| acc.checked_mul(dim))
+        .ok_or_else(|| anyhow::anyhow!("tensor row width overflow"))?;
+    let data_start = start
+        .checked_mul(row_width)
+        .ok_or_else(|| anyhow::anyhow!("tensor data start overflow"))?;
+    let data_len = len
+        .checked_mul(row_width)
+        .ok_or_else(|| anyhow::anyhow!("tensor data length overflow"))?;
+    let data_end = data_start
+        .checked_add(data_len)
+        .ok_or_else(|| anyhow::anyhow!("tensor data end overflow"))?;
+    anyhow::ensure!(
+        data_end <= data.len(),
+        "tensor slice data range {data_start}..{data_end} exceeds {}",
+        data.len()
+    );
+    let mut new_shape = shape.to_vec();
+    new_shape[0] = len;
+    Ok((data[data_start..data_end].to_vec(), new_shape))
+}
+
+fn slice_1d<T>(values: &[T], start: usize, len: usize) -> AnyhowResult<&[T]> {
+    let end = start
+        .checked_add(len)
+        .ok_or_else(|| anyhow::anyhow!("slice range overflow"))?;
+    values
+        .get(start..end)
+        .ok_or_else(|| anyhow::anyhow!("slice range {start}..{end} exceeds {}", values.len()))
 }
 
 /// Preprocessed encoder inputs ready for model consumption.

--- a/crates/multimodal/src/vision/processor.rs
+++ b/crates/multimodal/src/vision/processor.rs
@@ -278,9 +278,9 @@ impl PreprocessedEncoderInputs {
         self
     }
 
-    /// Get the batch size.
+    /// Get the number of media items represented by this preprocessed batch.
     pub fn batch_size(&self) -> usize {
-        self.encoder_input.shape()[0]
+        self.item_sizes.len()
     }
 
     /// Get the number of channels.

--- a/crates/multimodal/src/vision/processors/kimi_k25.rs
+++ b/crates/multimodal/src/vision/processors/kimi_k25.rs
@@ -16,8 +16,8 @@ use image::{DynamicImage, GenericImageView};
 use ndarray::Array3;
 
 use crate::vision::{
-    image_processor::{ImagePreProcessor, ModelSpecificValue, PreprocessedImages},
     preprocessor_config::PreProcessorConfig,
+    processor::{ModelSpecificValue, PreprocessedEncoderInputs, VisionPreProcessor},
     transforms::{self, TransformError},
 };
 
@@ -233,7 +233,7 @@ impl KimiK25Processor {
     }
 }
 
-impl ImagePreProcessor for KimiK25Processor {
+impl VisionPreProcessor for KimiK25Processor {
     fn default_mean(&self) -> [f64; 3] {
         KIMI_K25_MEAN
     }
@@ -246,19 +246,19 @@ impl ImagePreProcessor for KimiK25Processor {
         &self,
         images: &[DynamicImage],
         config: &PreProcessorConfig,
-    ) -> Result<PreprocessedImages, TransformError> {
+    ) -> Result<PreprocessedEncoderInputs, TransformError> {
         if images.is_empty() {
             return Err(TransformError::EmptyBatch);
         }
 
-        let image_sizes: Vec<(u32, u32)> = images.iter().map(|img| img.dimensions()).collect();
+        let item_sizes: Vec<(u32, u32)> = images.iter().map(|img| img.dimensions()).collect();
         let mean = config.get_image_mean();
         let std = config.get_image_std();
 
         let mut all_patches: Vec<f32> = Vec::new();
         let mut patches_per_image: Vec<i64> = Vec::with_capacity(images.len());
         let mut grid_thw_data = Vec::with_capacity(images.len() * 3);
-        let mut num_img_tokens = Vec::with_capacity(images.len());
+        let mut feature_token_counts = Vec::with_capacity(images.len());
 
         for image in images {
             let (w, h) = image.dimensions();
@@ -278,7 +278,7 @@ impl ImagePreProcessor for KimiK25Processor {
             grid_thw_data.push(grid_w as i64);
 
             let num_patches = grid_h * grid_w;
-            num_img_tokens.push(cfg.num_tokens);
+            feature_token_counts.push(cfg.num_tokens);
 
             let patches = Self::extract_patches(&tensor, self.patch_size);
             all_patches.extend(patches);
@@ -286,27 +286,30 @@ impl ImagePreProcessor for KimiK25Processor {
         }
 
         let total_patches: usize = patches_per_image.iter().map(|&n| n as usize).sum();
-        let pixel_values = ndarray::Array4::from_shape_vec(
+        let encoder_input = ndarray::Array4::from_shape_vec(
             (total_patches, 3, self.patch_size, self.patch_size),
             all_patches,
         )
         .map_err(|e| {
             TransformError::ShapeError(format!(
-                "Failed to create pixel_values [{total_patches}, 3, {}, {}]: {e}",
+                "Failed to create encoder_input [{total_patches}, 3, {}, {}]: {e}",
                 self.patch_size, self.patch_size
             ))
         })?;
 
-        let result =
-            PreprocessedImages::new_dynamic(pixel_values.into_dyn(), num_img_tokens, image_sizes)
-                .with_extra(
-                    "grid_thws",
-                    ModelSpecificValue::int_2d(grid_thw_data, images.len(), 3),
-                )
-                .with_extra(
-                    "patches_per_image",
-                    ModelSpecificValue::int_1d(patches_per_image),
-                );
+        let result = PreprocessedEncoderInputs::new_dynamic(
+            encoder_input.into_dyn(),
+            feature_token_counts,
+            item_sizes,
+        )
+        .with_extra(
+            "grid_thws",
+            ModelSpecificValue::int_2d(grid_thw_data, images.len(), 3),
+        )
+        .with_extra(
+            "patches_per_image",
+            ModelSpecificValue::int_1d(patches_per_image),
+        );
 
         Ok(result)
     }
@@ -413,14 +416,14 @@ mod tests {
         let result = p.preprocess(&[image], &config).unwrap();
 
         // 4D output: [total_patches, 3, 14, 14]
-        assert_eq!(result.pixel_values.ndim(), 4);
-        assert_eq!(result.pixel_values.shape()[1], 3);
-        assert_eq!(result.pixel_values.shape()[2], 14);
-        assert_eq!(result.pixel_values.shape()[3], 14);
+        assert_eq!(result.encoder_input.ndim(), 4);
+        assert_eq!(result.encoder_input.shape()[1], 3);
+        assert_eq!(result.encoder_input.shape()[2], 14);
+        assert_eq!(result.encoder_input.shape()[3], 14);
 
         assert!(result.model_specific.contains_key("grid_thws"));
         assert!(result.model_specific.contains_key("patches_per_image"));
-        assert!(result.num_img_tokens[0] > 0);
+        assert!(result.feature_token_counts[0] > 0);
     }
 
     #[test]
@@ -434,10 +437,10 @@ mod tests {
 
         let result = p.preprocess(&images, &config).unwrap();
 
-        assert_eq!(result.image_sizes.len(), 2);
-        assert_eq!(result.num_img_tokens.len(), 2);
-        assert_eq!(result.pixel_values.ndim(), 4);
-        assert_eq!(result.pixel_values.shape()[1], 3);
+        assert_eq!(result.item_sizes.len(), 2);
+        assert_eq!(result.feature_token_counts.len(), 2);
+        assert_eq!(result.encoder_input.ndim(), 4);
+        assert_eq!(result.encoder_input.shape()[1], 3);
 
         if let Some(ModelSpecificValue::IntTensor { data, shape }) =
             result.model_specific.get("grid_thws")
@@ -452,7 +455,7 @@ mod tests {
             result.model_specific.get("patches_per_image")
         {
             let total: i64 = data.iter().sum();
-            assert_eq!(total as usize, result.pixel_values.shape()[0]);
+            assert_eq!(total as usize, result.encoder_input.shape()[0]);
         }
     }
 
@@ -493,7 +496,7 @@ mod tests {
         let image = create_test_image(100, 100, Rgb([255, 255, 255]));
         let result = p.preprocess(&[image], &config).unwrap();
 
-        let flat = result.pixel_values_flat();
+        let flat = result.encoder_input_flat();
         // Padded region should be normalized black (-1.0)
         let has_neg_ones = flat.iter().any(|&v| (v - (-1.0)).abs() < 1e-6);
         assert!(
@@ -520,9 +523,9 @@ mod tests {
         };
         let image = create_test_image(1, 1, Rgb([128, 128, 128]));
         let result = p.preprocess(&[image], &config).unwrap();
-        assert_eq!(result.pixel_values.ndim(), 4);
-        assert!(result.pixel_values.shape()[0] > 0);
-        assert!(result.num_img_tokens[0] > 0);
+        assert_eq!(result.encoder_input.ndim(), 4);
+        assert!(result.encoder_input.shape()[0] > 0);
+        assert!(result.feature_token_counts[0] > 0);
     }
 
     #[test]

--- a/crates/multimodal/src/vision/processors/llama4_vision.rs
+++ b/crates/multimodal/src/vision/processors/llama4_vision.rs
@@ -34,8 +34,8 @@ use image::{imageops::FilterType, DynamicImage, GenericImageView};
 use ndarray::{s, Array3, Array4};
 
 use crate::vision::{
-    image_processor::{ImagePreProcessor, ModelSpecificValue, PreprocessedImages},
     preprocessor_config::PreProcessorConfig,
+    processor::{ModelSpecificValue, PreprocessedEncoderInputs, VisionPreProcessor},
     transforms::{self, TransformError},
 };
 
@@ -417,7 +417,7 @@ impl Llama4VisionProcessor {
     }
 }
 
-impl ImagePreProcessor for Llama4VisionProcessor {
+impl VisionPreProcessor for Llama4VisionProcessor {
     fn default_mean(&self) -> [f64; 3] {
         self.mean
     }
@@ -430,7 +430,7 @@ impl ImagePreProcessor for Llama4VisionProcessor {
         &self,
         images: &[DynamicImage],
         config: &PreProcessorConfig,
-    ) -> Result<PreprocessedImages, TransformError> {
+    ) -> Result<PreprocessedEncoderInputs, TransformError> {
         if images.is_empty() {
             return Err(TransformError::InvalidShape {
                 expected: "non-empty image batch".to_string(),
@@ -452,8 +452,8 @@ impl ImagePreProcessor for Llama4VisionProcessor {
 
         let mut all_outputs = Vec::new();
         let mut all_aspect_ratios = Vec::new();
-        let mut image_sizes = Vec::new();
-        let mut num_img_tokens = Vec::new();
+        let mut item_sizes = Vec::new();
+        let mut feature_token_counts = Vec::new();
 
         for image in images {
             let (output, aspect_ratio) = processor.process_single_image(image);
@@ -461,8 +461,8 @@ impl ImagePreProcessor for Llama4VisionProcessor {
 
             all_outputs.push(output);
             all_aspect_ratios.push(aspect_ratio);
-            image_sizes.push((image.height(), image.width()));
-            num_img_tokens.push(tokens);
+            item_sizes.push((image.height(), image.width()));
+            feature_token_counts.push(tokens);
         }
 
         // Per-image tile counts (must be computed before remove/concatenate)
@@ -471,7 +471,7 @@ impl ImagePreProcessor for Llama4VisionProcessor {
         // Concatenate all tiles from all images into a single 4D tensor
         // [total_tiles, C, H, W] — no batch dimension, no zero-padding.
         // This matches what sglang and vLLM vision models expect.
-        let pixel_values = if all_outputs.len() == 1 {
+        let encoder_input = if all_outputs.len() == 1 {
             all_outputs.remove(0)
         } else {
             let tile_views: Vec<ndarray::ArrayView4<f32>> =
@@ -501,10 +501,10 @@ impl ImagePreProcessor for Llama4VisionProcessor {
             ModelSpecificValue::int_1d(patches_per_image),
         );
 
-        Ok(PreprocessedImages {
-            pixel_values: pixel_values.into_dyn(),
-            num_img_tokens,
-            image_sizes,
+        Ok(PreprocessedEncoderInputs {
+            encoder_input: encoder_input.into_dyn(),
+            feature_token_counts,
+            item_sizes,
             model_specific,
         })
     }
@@ -622,12 +622,12 @@ mod tests {
         let result = processor.preprocess(&[image], &config).unwrap();
 
         // 4D output: [total_tiles, C, H, W]
-        assert_eq!(result.pixel_values.ndim(), 4);
-        assert_eq!(result.num_img_tokens.len(), 1);
-        assert!(result.num_img_tokens[0] > 0);
+        assert_eq!(result.encoder_input.ndim(), 4);
+        assert_eq!(result.feature_token_counts.len(), 1);
+        assert!(result.feature_token_counts[0] > 0);
 
         // Check pixel values are normalized
-        let flat = result.pixel_values_flat();
+        let flat = result.encoder_input_flat();
         assert!(flat.iter().all(|&v| (-1.5..=1.5).contains(&v)));
     }
 
@@ -640,8 +640,8 @@ mod tests {
         let result = processor.preprocess(&[image], &config).unwrap();
 
         // 4D output: [total_tiles, C, H, W]
-        assert_eq!(result.pixel_values.ndim(), 4);
-        assert_eq!(result.num_img_tokens.len(), 1);
+        assert_eq!(result.encoder_input.ndim(), 4);
+        assert_eq!(result.feature_token_counts.len(), 1);
         // Wide image should have more tiles in width direction
         let aspect_ratios = result.model_specific.get("aspect_ratios").unwrap();
         if let ModelSpecificValue::IntTensor { data, .. } = aspect_ratios {
@@ -664,11 +664,11 @@ mod tests {
         let result = processor.preprocess(&images, &config).unwrap();
 
         // 4D output: [total_tiles, C, H, W] — tiles from both images concatenated
-        assert_eq!(result.pixel_values.ndim(), 4);
-        assert_eq!(result.num_img_tokens.len(), 2);
-        assert_eq!(result.image_sizes.len(), 2);
+        assert_eq!(result.encoder_input.ndim(), 4);
+        assert_eq!(result.feature_token_counts.len(), 2);
+        assert_eq!(result.item_sizes.len(), 2);
         // Total tiles should be > 2 (at least 1 tile per image)
-        assert!(result.pixel_values.shape()[0] >= 2);
+        assert!(result.encoder_input.shape()[0] >= 2);
     }
 
     #[test]
@@ -689,7 +689,7 @@ mod tests {
             if num_tiles > 1 {
                 // 4D output: [total_tiles, C, H, W]
                 // total_tiles = num_tiles + 1 (global tile)
-                let shape = result.pixel_values.shape();
+                let shape = result.encoder_input.shape();
                 assert_eq!(shape[0], num_tiles + 1);
             }
         }

--- a/crates/multimodal/src/vision/processors/llama4_vision.rs
+++ b/crates/multimodal/src/vision/processors/llama4_vision.rs
@@ -461,7 +461,7 @@ impl VisionPreProcessor for Llama4VisionProcessor {
 
             all_outputs.push(output);
             all_aspect_ratios.push(aspect_ratio);
-            item_sizes.push((image.height(), image.width()));
+            item_sizes.push(image.dimensions());
             feature_token_counts.push(tokens);
         }
 

--- a/crates/multimodal/src/vision/processors/llava.rs
+++ b/crates/multimodal/src/vision/processors/llava.rs
@@ -38,8 +38,8 @@ use image::{DynamicImage, GenericImageView};
 use ndarray::{self, Array3};
 
 use crate::vision::{
-    image_processor::{ImagePreProcessor, ModelSpecificValue, PreprocessedImages},
     preprocessor_config::PreProcessorConfig,
+    processor::{ModelSpecificValue, PreprocessedEncoderInputs, VisionPreProcessor},
     transforms::{
         center_crop, expand_to_square, mean_to_rgb, normalize, pil_to_filter, resize, stack_batch,
         to_tensor, TransformError,
@@ -264,7 +264,7 @@ impl LlavaProcessor {
     }
 }
 
-impl ImagePreProcessor for LlavaProcessor {
+impl VisionPreProcessor for LlavaProcessor {
     fn default_mean(&self) -> [f64; 3] {
         CLIP_MEAN
     }
@@ -277,13 +277,13 @@ impl ImagePreProcessor for LlavaProcessor {
         &self,
         images: &[DynamicImage],
         config: &PreProcessorConfig,
-    ) -> Result<PreprocessedImages, TransformError> {
+    ) -> Result<PreprocessedEncoderInputs, TransformError> {
         if images.is_empty() {
             return Err(TransformError::EmptyBatch);
         }
 
         // Store original sizes
-        let image_sizes: Vec<(u32, u32)> = images.iter().map(|img| img.dimensions()).collect();
+        let item_sizes: Vec<(u32, u32)> = images.iter().map(|img| img.dimensions()).collect();
 
         // Process each image
         let tensors: Vec<Array3<f32>> = images
@@ -292,18 +292,18 @@ impl ImagePreProcessor for LlavaProcessor {
             .collect();
 
         // Stack into batch
-        let pixel_values = stack_batch(&tensors)?;
+        let encoder_input = stack_batch(&tensors)?;
 
         // Calculate token counts
-        let num_img_tokens: Vec<usize> = images
+        let feature_token_counts: Vec<usize> = images
             .iter()
             .map(|_| self.calculate_num_tokens(self.image_size, self.image_size, config))
             .collect();
 
-        Ok(PreprocessedImages::new(
-            pixel_values,
-            num_img_tokens,
-            image_sizes,
+        Ok(PreprocessedEncoderInputs::new(
+            encoder_input,
+            feature_token_counts,
+            item_sizes,
         ))
     }
 
@@ -514,7 +514,7 @@ impl LlavaNextProcessor {
     }
 }
 
-impl ImagePreProcessor for LlavaNextProcessor {
+impl VisionPreProcessor for LlavaNextProcessor {
     fn default_mean(&self) -> [f64; 3] {
         CLIP_MEAN
     }
@@ -527,14 +527,14 @@ impl ImagePreProcessor for LlavaNextProcessor {
         &self,
         images: &[DynamicImage],
         config: &PreProcessorConfig,
-    ) -> Result<PreprocessedImages, TransformError> {
+    ) -> Result<PreprocessedEncoderInputs, TransformError> {
         if images.is_empty() {
             return Err(TransformError::EmptyBatch);
         }
 
         let mut patches_per_image: Vec<Vec<Array3<f32>>> = Vec::with_capacity(images.len());
-        let mut num_img_tokens = Vec::with_capacity(images.len());
-        let mut image_sizes = Vec::with_capacity(images.len());
+        let mut feature_token_counts = Vec::with_capacity(images.len());
+        let mut item_sizes = Vec::with_capacity(images.len());
 
         let filter = pil_to_filter(config.resampling);
         let target_size = config
@@ -545,7 +545,7 @@ impl ImagePreProcessor for LlavaNextProcessor {
 
         for image in images {
             let original_size = image.dimensions();
-            image_sizes.push(original_size);
+            item_sizes.push(original_size);
 
             let best_resolution = self.select_best_resolution(original_size);
             let image_padded = self.resize_and_pad_image(image, best_resolution);
@@ -560,14 +560,14 @@ impl ImagePreProcessor for LlavaNextProcessor {
                 .collect();
             patches_per_image.push(patches);
 
-            num_img_tokens.push(self.calculate_num_tokens(
+            feature_token_counts.push(self.calculate_num_tokens(
                 original_size.0,
                 original_size.1,
                 config,
             ));
         }
 
-        // Build 5D pixel_values [num_images, max_patches, C, H, W] matching the
+        // Build 5D encoder_input [num_images, max_patches, C, H, W] matching the
         // HF LlavaNextImageProcessor output that vLLM expects with Batched layout.
         let max_patches = patches_per_image.iter().map(|p| p.len()).max().unwrap_or(0);
         let (c, h, w) = if let Some(first) = patches_per_image.iter().find_map(|p| p.first()) {
@@ -578,24 +578,27 @@ impl ImagePreProcessor for LlavaNextProcessor {
         };
 
         let num_images = images.len();
-        let mut pixel_values = ndarray::Array5::<f32>::zeros((num_images, max_patches, c, h, w));
+        let mut encoder_input = ndarray::Array5::<f32>::zeros((num_images, max_patches, c, h, w));
         for (i, patches) in patches_per_image.iter().enumerate() {
             for (j, patch) in patches.iter().enumerate() {
-                pixel_values
+                encoder_input
                     .slice_mut(ndarray::s![i, j, .., .., ..])
                     .assign(patch);
             }
         }
 
-        // Build image_sizes tensor as [num_images, 2] in (height, width) order
+        // Build model-specific image_sizes tensor as [num_images, 2] in (height, width) order
         // to match the HF LlavaNextImageProcessor output format that vLLM expects.
-        let image_sizes_flat: Vec<i64> = image_sizes
+        let image_sizes_flat: Vec<i64> = item_sizes
             .iter()
             .flat_map(|&(w, h)| [h as i64, w as i64])
             .collect();
 
-        let mut result =
-            PreprocessedImages::new_dynamic(pixel_values.into_dyn(), num_img_tokens, image_sizes);
+        let mut result = PreprocessedEncoderInputs::new_dynamic(
+            encoder_input.into_dyn(),
+            feature_token_counts,
+            item_sizes,
+        );
         result.model_specific.insert(
             "image_sizes".to_string(),
             ModelSpecificValue::int_2d(image_sizes_flat, num_images, 2),
@@ -837,7 +840,7 @@ mod tests {
         assert_eq!(result.batch_size(), 1);
         assert_eq!(result.height().unwrap(), 336);
         assert_eq!(result.width().unwrap(), 336);
-        assert_eq!(result.num_img_tokens[0], 576);
+        assert_eq!(result.feature_token_counts[0], 576);
     }
 
     #[test]
@@ -938,7 +941,7 @@ mod tests {
         // 5D: [num_images=1, num_patches, C, H, W]
         assert_eq!(result.batch_size(), 1);
         // Should have multiple patches (original + crops) in the second dimension
-        assert!(result.pixel_values.shape()[1] > 1);
+        assert!(result.encoder_input.shape()[1] > 1);
     }
 
     #[test]

--- a/crates/multimodal/src/vision/processors/mod.rs
+++ b/crates/multimodal/src/vision/processors/mod.rs
@@ -1,6 +1,6 @@
-//! Model-specific image processors.
+//! Model-specific vision processors.
 //!
-//! This module contains implementations of `ImagePreProcessor` for various
+//! This module contains implementations of `VisionPreProcessor` for various
 //! vision-language model families.
 //!
 //! # Supported Models

--- a/crates/multimodal/src/vision/processors/phi3_vision.rs
+++ b/crates/multimodal/src/vision/processors/phi3_vision.rs
@@ -23,8 +23,8 @@ use image::{imageops::FilterType, DynamicImage, GenericImageView, Rgb, RgbImage}
 use ndarray::{s, Array3, Array4, IxDyn};
 
 use crate::vision::{
-    image_processor::{ImagePreProcessor, ModelSpecificValue, PreprocessedImages},
     preprocessor_config::PreProcessorConfig,
+    processor::{ModelSpecificValue, PreprocessedEncoderInputs, VisionPreProcessor},
     transforms::{self, TransformError},
 };
 
@@ -287,12 +287,12 @@ impl Phi3VisionProcessor {
         // Calculate token count
         let num_tokens = self.calculate_num_tokens(hd_h as usize, hd_w as usize);
 
-        // image_sizes is the HD-transformed size
+        // The returned size is the HD-transformed image size.
         (output, (hd_h as usize, hd_w as usize), num_tokens)
     }
 }
 
-impl ImagePreProcessor for Phi3VisionProcessor {
+impl VisionPreProcessor for Phi3VisionProcessor {
     fn default_mean(&self) -> [f64; 3] {
         self.mean
     }
@@ -305,7 +305,7 @@ impl ImagePreProcessor for Phi3VisionProcessor {
         &self,
         images: &[DynamicImage],
         config: &PreProcessorConfig,
-    ) -> Result<PreprocessedImages, TransformError> {
+    ) -> Result<PreprocessedEncoderInputs, TransformError> {
         if images.is_empty() {
             return Err(TransformError::InvalidShape {
                 expected: "at least one image".to_string(),
@@ -318,8 +318,8 @@ impl ImagePreProcessor for Phi3VisionProcessor {
         let mut all_num_tokens = Vec::with_capacity(images.len());
 
         for image in images {
-            let (pixel_values, image_size, num_tokens) = self.process_single_image(image, config);
-            all_pixel_values.push(pixel_values);
+            let (encoder_input, image_size, num_tokens) = self.process_single_image(image, config);
+            all_pixel_values.push(encoder_input);
             all_image_sizes.push((image_size.1 as u32, image_size.0 as u32)); // (width, height)
             all_num_tokens.push(num_tokens);
         }
@@ -343,7 +343,7 @@ impl ImagePreProcessor for Phi3VisionProcessor {
         let shape = batch_tensor.shape().to_vec();
         let (flat_data, _offset) = batch_tensor.into_raw_vec_and_offset();
 
-        // Store image_sizes as model-specific data
+        // Store model-specific image_sizes data.
         let mut model_specific = std::collections::HashMap::new();
 
         // image_sizes as [batch, 2] tensor (h, w for each image)
@@ -359,7 +359,7 @@ impl ImagePreProcessor for Phi3VisionProcessor {
             },
         );
 
-        // num_img_tokens as list
+        // feature_token_counts as list
         model_specific.insert(
             "num_img_tokens".to_string(),
             ModelSpecificValue::IntVec(all_num_tokens.iter().map(|&t| t as i64).collect()),
@@ -367,16 +367,16 @@ impl ImagePreProcessor for Phi3VisionProcessor {
 
         // Convert 5D tensor to appropriate format
         // Phi3-Vision expects [B, num_crops+1, C, H, W]
-        let pixel_values = ndarray::ArrayD::<f32>::from_shape_vec(IxDyn(&shape), flat_data)
+        let encoder_input = ndarray::ArrayD::<f32>::from_shape_vec(IxDyn(&shape), flat_data)
             .map_err(|e| TransformError::InvalidShape {
                 expected: format!("valid 5D shape, but failed with error: {e}"),
                 actual: shape.clone(),
             })?;
 
-        Ok(PreprocessedImages {
-            pixel_values,
-            num_img_tokens: all_num_tokens,
-            image_sizes: all_image_sizes,
+        Ok(PreprocessedEncoderInputs {
+            encoder_input,
+            feature_token_counts: all_num_tokens,
+            item_sizes: all_image_sizes,
             model_specific,
         })
     }
@@ -490,7 +490,7 @@ mod tests {
         assert_eq!(result.batch_size(), 1);
 
         // Check output shape is [1, num_crops+1, 3, 336, 336]
-        let shape = result.pixel_values.shape();
+        let shape = result.encoder_input.shape();
         assert_eq!(shape.len(), 5);
         assert_eq!(shape[0], 1); // batch
         assert_eq!(shape[1], 17); // num_crops + 1
@@ -516,8 +516,8 @@ mod tests {
         let result = processor.preprocess(&images, &config).unwrap();
 
         assert_eq!(result.batch_size(), 2);
-        assert_eq!(result.image_sizes.len(), 2);
-        assert_eq!(result.num_img_tokens.len(), 2);
+        assert_eq!(result.item_sizes.len(), 2);
+        assert_eq!(result.feature_token_counts.len(), 2);
     }
 
     #[test]

--- a/crates/multimodal/src/vision/processors/phi4_vision.rs
+++ b/crates/multimodal/src/vision/processors/phi4_vision.rs
@@ -39,8 +39,8 @@ use image::{imageops::FilterType, DynamicImage, GenericImageView, Rgb, RgbImage}
 use ndarray::{s, Array2, Array3, Array4, IxDyn};
 
 use crate::vision::{
-    image_processor::{ImagePreProcessor, ModelSpecificValue, PreprocessedImages},
     preprocessor_config::PreProcessorConfig,
+    processor::{ModelSpecificValue, PreprocessedEncoderInputs, VisionPreProcessor},
     transforms::{self, TransformError},
 };
 
@@ -63,7 +63,7 @@ pub const MASK_RESOLUTION: usize = 32;
 pub const PATCH_SIZE: usize = 14;
 
 /// Result type for single image processing.
-/// Contains (pixel_values, attention_mask, (height, width), num_tokens).
+/// Contains (encoder_input, attention_mask, (height, width), num_tokens).
 type SingleImageResult = (Array4<f32>, Array3<u32>, (u32, u32), usize);
 
 /// Phi4-Vision image processor.
@@ -442,7 +442,7 @@ impl Phi4VisionProcessor {
     }
 }
 
-impl ImagePreProcessor for Phi4VisionProcessor {
+impl VisionPreProcessor for Phi4VisionProcessor {
     fn default_mean(&self) -> [f64; 3] {
         self.mean
     }
@@ -455,7 +455,7 @@ impl ImagePreProcessor for Phi4VisionProcessor {
         &self,
         images: &[DynamicImage],
         config: &PreProcessorConfig,
-    ) -> Result<PreprocessedImages, TransformError> {
+    ) -> Result<PreprocessedEncoderInputs, TransformError> {
         if images.is_empty() {
             return Err(TransformError::InvalidShape {
                 expected: "non-empty image batch".to_string(),
@@ -471,15 +471,15 @@ impl ImagePreProcessor for Phi4VisionProcessor {
 
         let mut all_outputs = Vec::new();
         let mut all_masks = Vec::new();
-        let mut image_sizes = Vec::new();
-        let mut num_img_tokens = Vec::new();
+        let mut item_sizes = Vec::new();
+        let mut feature_token_counts = Vec::new();
 
         for image in images {
             let (output, mask, size, tokens) = processor.process_single_image(image);
             all_outputs.push(output);
             all_masks.push(mask);
-            image_sizes.push(size);
-            num_img_tokens.push(tokens);
+            item_sizes.push(size);
+            feature_token_counts.push(tokens);
         }
 
         // Find max crops across batch for padding
@@ -493,7 +493,7 @@ impl ImagePreProcessor for Phi4VisionProcessor {
 
         // Pad all outputs to max_crops
         let batch_size = images.len();
-        let mut pixel_values =
+        let mut encoder_input =
             ndarray::ArrayD::<f32>::zeros(IxDyn(&[batch_size, max_crops, 3, base, base]));
         let mut attention_masks =
             ndarray::ArrayD::<u32>::zeros(IxDyn(&[batch_size, max_crops, mask_res, mask_res]));
@@ -504,7 +504,7 @@ impl ImagePreProcessor for Phi4VisionProcessor {
                 for c in 0..3 {
                     for y in 0..base {
                         for x in 0..base {
-                            pixel_values[[b, t, c, y, x]] = output[[t, c, y, x]];
+                            encoder_input[[b, t, c, y, x]] = output[[t, c, y, x]];
                         }
                     }
                 }
@@ -531,7 +531,7 @@ impl ImagePreProcessor for Phi4VisionProcessor {
         );
 
         // Store image sizes (H, W after HD transform)
-        let sizes_flat: Vec<i64> = image_sizes
+        let sizes_flat: Vec<i64> = item_sizes
             .iter()
             .flat_map(|&(h, w)| vec![h as i64, w as i64])
             .collect();
@@ -543,10 +543,10 @@ impl ImagePreProcessor for Phi4VisionProcessor {
             },
         );
 
-        Ok(PreprocessedImages {
-            pixel_values: pixel_values.into_dyn(),
-            num_img_tokens,
-            image_sizes,
+        Ok(PreprocessedEncoderInputs {
+            encoder_input: encoder_input.into_dyn(),
+            feature_token_counts,
+            item_sizes,
             model_specific,
         })
     }
@@ -672,10 +672,10 @@ mod tests {
         let result = processor.preprocess(&[image], &config).unwrap();
 
         assert_eq!(result.batch_size(), 1);
-        assert!(result.num_img_tokens[0] > 256); // At least global tokens
+        assert!(result.feature_token_counts[0] > 256); // At least global tokens
 
         // Check pixel values are normalized
-        let flat = result.pixel_values_flat();
+        let flat = result.encoder_input_flat();
         assert!(flat.iter().all(|&v| (-1.5..=1.5).contains(&v)));
     }
 
@@ -689,7 +689,7 @@ mod tests {
 
         assert_eq!(result.batch_size(), 1);
         // Wide image should have more crops in width direction
-        assert!(result.image_sizes[0].1 >= result.image_sizes[0].0);
+        assert!(result.item_sizes[0].1 >= result.item_sizes[0].0);
     }
 
     #[test]
@@ -705,8 +705,8 @@ mod tests {
         let result = processor.preprocess(&images, &config).unwrap();
 
         assert_eq!(result.batch_size(), 2);
-        assert_eq!(result.image_sizes.len(), 2);
-        assert_eq!(result.num_img_tokens.len(), 2);
+        assert_eq!(result.item_sizes.len(), 2);
+        assert_eq!(result.feature_token_counts.len(), 2);
     }
 
     #[test]

--- a/crates/multimodal/src/vision/processors/pixtral.rs
+++ b/crates/multimodal/src/vision/processors/pixtral.rs
@@ -16,8 +16,8 @@ use image::{imageops::FilterType, DynamicImage};
 use ndarray::{Array4, IxDyn};
 
 use crate::vision::{
-    image_processor::{ImagePreProcessor, ModelSpecificValue, PreprocessedImages},
     preprocessor_config::PreProcessorConfig,
+    processor::{ModelSpecificValue, PreprocessedEncoderInputs, VisionPreProcessor},
     transforms::{self, TransformError},
 };
 
@@ -162,7 +162,7 @@ impl PixtralProcessor {
     }
 }
 
-impl ImagePreProcessor for PixtralProcessor {
+impl VisionPreProcessor for PixtralProcessor {
     fn default_mean(&self) -> [f64; 3] {
         self.image_mean
     }
@@ -175,7 +175,7 @@ impl ImagePreProcessor for PixtralProcessor {
         &self,
         images: &[DynamicImage],
         config: &PreProcessorConfig,
-    ) -> Result<PreprocessedImages, TransformError> {
+    ) -> Result<PreprocessedEncoderInputs, TransformError> {
         if images.is_empty() {
             return Err(TransformError::InvalidShape {
                 expected: "non-empty image batch".to_string(),
@@ -197,7 +197,7 @@ impl ImagePreProcessor for PixtralProcessor {
         let mut all_pixel_values = Vec::new();
         let mut all_image_sizes = Vec::new();
         let mut original_sizes = Vec::new();
-        let mut num_img_tokens = Vec::new();
+        let mut feature_token_counts = Vec::new();
 
         for image in images {
             let (pixels, size) = processor.process_single_image(image)?;
@@ -206,7 +206,7 @@ impl ImagePreProcessor for PixtralProcessor {
             all_pixel_values.push(pixels);
             all_image_sizes.push(size);
             original_sizes.push((image.height(), image.width()));
-            num_img_tokens.push(tokens);
+            feature_token_counts.push(tokens);
         }
 
         // Pad images to the same size for batching
@@ -248,10 +248,10 @@ impl ImagePreProcessor for PixtralProcessor {
             },
         );
 
-        Ok(PreprocessedImages {
-            pixel_values: batch_tensor,
-            num_img_tokens,
-            image_sizes: original_sizes,
+        Ok(PreprocessedEncoderInputs {
+            encoder_input: batch_tensor,
+            feature_token_counts,
+            item_sizes: original_sizes,
             model_specific,
         })
     }
@@ -358,8 +358,8 @@ mod tests {
         // First image: 150x200 -> 160x208
         // Second image: 100x300 -> 112x304 (ceil(100/16)=7, ceil(300/16)=19)
         // Batch padded to max: 160x304
-        assert_eq!(result.pixel_values.shape()[0], 2); // batch size
-        assert_eq!(result.pixel_values.shape()[1], 3); // channels
+        assert_eq!(result.encoder_input.shape()[0], 2); // batch size
+        assert_eq!(result.encoder_input.shape()[1], 3); // channels
     }
 
     #[test]

--- a/crates/multimodal/src/vision/processors/qwen2_vl.rs
+++ b/crates/multimodal/src/vision/processors/qwen2_vl.rs
@@ -23,8 +23,8 @@ use image::DynamicImage;
 
 use super::qwen_vl_base::{QwenVLConfig, QwenVLProcessorBase};
 use crate::vision::{
-    image_processor::{ImagePreProcessor, PreprocessedImages},
     preprocessor_config::PreProcessorConfig,
+    processor::{PreprocessedEncoderInputs, VisionPreProcessor},
     transforms::TransformError,
 };
 
@@ -197,7 +197,7 @@ impl Deref for Qwen2VLProcessor {
     }
 }
 
-impl ImagePreProcessor for Qwen2VLProcessor {
+impl VisionPreProcessor for Qwen2VLProcessor {
     fn default_mean(&self) -> [f64; 3] {
         self.inner.default_mean()
     }
@@ -210,7 +210,7 @@ impl ImagePreProcessor for Qwen2VLProcessor {
         &self,
         images: &[DynamicImage],
         config: &PreProcessorConfig,
-    ) -> Result<PreprocessedImages, TransformError> {
+    ) -> Result<PreprocessedEncoderInputs, TransformError> {
         self.inner.preprocess(images, config)
     }
 
@@ -232,7 +232,7 @@ mod tests {
     use image::{Rgb, RgbImage};
 
     use super::*;
-    use crate::vision::{image_processor::ModelSpecificValue, preprocessor_config::PatchSize};
+    use crate::vision::{preprocessor_config::PatchSize, processor::ModelSpecificValue};
 
     fn create_test_image(width: u32, height: u32, color: Rgb<u8>) -> DynamicImage {
         DynamicImage::from(RgbImage::from_pixel(width, height, color))
@@ -366,12 +366,12 @@ mod tests {
         let image = create_test_image(600, 400, Rgb([128, 128, 128]));
         let result = processor.preprocess(&[image], &config).unwrap();
 
-        // pixel_values is patchified: [total_patches, patch_features]
-        assert_eq!(result.pixel_values.ndim(), 2);
-        assert!(result.pixel_values.shape()[0] > 0); // total_patches > 0
+        // encoder_input is patchified: [total_patches, patch_features]
+        assert_eq!(result.encoder_input.ndim(), 2);
+        assert!(result.encoder_input.shape()[0] > 0); // total_patches > 0
 
         // Check pixel values are normalized
-        let flat = result.pixel_values_flat();
+        let flat = result.encoder_input_flat();
         // After normalization with CLIP mean/std, gray (0.5) should be near 0
         // (0.5 - 0.48) / 0.27 ≈ 0.07
         assert!(flat.iter().all(|&v| v.abs() < 1.0)); // Should be normalized
@@ -381,7 +381,7 @@ mod tests {
         assert!(result.model_specific.contains_key("patches_per_image"));
 
         // Verify token count is reasonable
-        assert!(result.num_img_tokens[0] > 0);
+        assert!(result.feature_token_counts[0] > 0);
     }
 
     #[test]
@@ -397,11 +397,11 @@ mod tests {
         let result = processor.preprocess(&images, &config).unwrap();
 
         // Both images processed
-        assert_eq!(result.image_sizes.len(), 2);
-        assert_eq!(result.num_img_tokens.len(), 2);
+        assert_eq!(result.item_sizes.len(), 2);
+        assert_eq!(result.feature_token_counts.len(), 2);
 
-        // pixel_values is 2D [total_patches, patch_features]
-        assert_eq!(result.pixel_values.ndim(), 2);
+        // encoder_input is 2D [total_patches, patch_features]
+        assert_eq!(result.encoder_input.ndim(), 2);
 
         // Check grid_thw shape
         if let Some(ModelSpecificValue::IntTensor { data, shape }) =
@@ -420,7 +420,7 @@ mod tests {
             assert_eq!(shape, &[2]); // 2 images
             assert_eq!(data.len(), 2);
             let total: i64 = data.iter().sum();
-            assert_eq!(total as usize, result.pixel_values.shape()[0]);
+            assert_eq!(total as usize, result.encoder_input.shape()[0]);
         } else {
             panic!("Expected patches_per_image to be IntTensor");
         }

--- a/crates/multimodal/src/vision/processors/qwen3_vl.rs
+++ b/crates/multimodal/src/vision/processors/qwen3_vl.rs
@@ -121,8 +121,14 @@ impl Qwen3VLProcessor {
             inner: QwenVLProcessorBase::new(QwenVLConfig {
                 patch_size: config.get_patch_size(DEFAULT_PATCH_SIZE),
                 merge_size: config.merge_size.unwrap_or(DEFAULT_MERGE_SIZE),
-                min_pixels: config.min_pixels.unwrap_or(DEFAULT_MIN_PIXELS),
-                max_pixels: config.max_pixels.unwrap_or(DEFAULT_MAX_PIXELS),
+                min_pixels: config
+                    .min_pixels
+                    .or_else(|| config.get_shortest_edge())
+                    .unwrap_or(DEFAULT_MIN_PIXELS),
+                max_pixels: config
+                    .max_pixels
+                    .or_else(|| config.get_longest_edge())
+                    .unwrap_or(DEFAULT_MAX_PIXELS),
                 temporal_patch_size: config
                     .temporal_patch_size
                     .unwrap_or(DEFAULT_TEMPORAL_PATCH_SIZE),
@@ -215,6 +221,14 @@ impl ImagePreProcessor for Qwen3VLProcessor {
         self.inner.preprocess(images, config)
     }
 
+    fn preprocess_video(
+        &self,
+        frames: &[DynamicImage],
+        config: &PreProcessorConfig,
+    ) -> Result<PreprocessedImages, TransformError> {
+        self.inner.preprocess_video(frames, config)
+    }
+
     fn calculate_num_tokens(&self, width: u32, height: u32, config: &PreProcessorConfig) -> usize {
         self.inner.calculate_num_tokens(width, height, config)
     }
@@ -230,6 +244,8 @@ impl ImagePreProcessor for Qwen3VLProcessor {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use image::{Rgb, RgbImage};
 
     use super::*;
@@ -408,6 +424,36 @@ mod tests {
     }
 
     #[test]
+    fn test_qwen3_vl_preprocess_video() {
+        let processor = Qwen3VLProcessor::new();
+        let config = PreProcessorConfig {
+            image_mean: Some(QWEN3_MEAN.to_vec()),
+            image_std: Some(QWEN3_STD.to_vec()),
+            ..Default::default()
+        };
+
+        let frames = vec![
+            create_test_image(640, 480, Rgb([100, 100, 100])),
+            create_test_image(640, 480, Rgb([150, 150, 150])),
+            create_test_image(640, 480, Rgb([200, 200, 200])),
+        ];
+
+        let result = processor.preprocess_video(&frames, &config).unwrap();
+        assert_eq!(result.pixel_values.ndim(), 2);
+        assert_eq!(result.num_img_tokens.len(), 1);
+        assert!(result.model_specific.contains_key("video_grid_thw"));
+
+        if let Some(ModelSpecificValue::IntTensor { data, shape }) =
+            result.model_specific.get("video_grid_thw")
+        {
+            assert_eq!(shape, &[1, 3]);
+            assert_eq!(data[0], 2); // 3 frames padded to 4, temporal_patch_size=2
+        } else {
+            panic!("Expected video_grid_thw to be IntTensor");
+        }
+    }
+
+    #[test]
     fn test_qwen3_vl_from_config() {
         let config = PreProcessorConfig {
             patch_size: Some(PatchSize {
@@ -428,6 +474,26 @@ mod tests {
         assert_eq!(processor.min_pixels(), 100000);
         assert_eq!(processor.max_pixels(), 500000);
         assert_eq!(processor.temporal_patch_size(), 4);
+    }
+
+    #[test]
+    fn test_qwen3_vl_video_config_uses_size_edges() {
+        let config = PreProcessorConfig {
+            size: Some(HashMap::from([
+                ("shortest_edge".to_string(), 4096),
+                ("longest_edge".to_string(), 25165824),
+            ])),
+            ..Default::default()
+        };
+
+        let processor = Qwen3VLProcessor::from_preprocessor_config(&config);
+
+        assert_eq!(processor.min_pixels(), 4096);
+        assert_eq!(processor.max_pixels(), 25165824);
+        assert_eq!(
+            processor.inner.smart_resize_video(239, 720, 1280).unwrap(),
+            (224, 416)
+        );
     }
 
     #[test]

--- a/crates/multimodal/src/vision/processors/qwen3_vl.rs
+++ b/crates/multimodal/src/vision/processors/qwen3_vl.rs
@@ -22,8 +22,8 @@ use image::DynamicImage;
 
 use super::qwen_vl_base::{QwenVLConfig, QwenVLProcessorBase};
 use crate::vision::{
-    image_processor::{ImagePreProcessor, PreprocessedImages},
     preprocessor_config::PreProcessorConfig,
+    processor::{PreprocessedEncoderInputs, VisionPreProcessor},
     transforms::TransformError,
 };
 
@@ -204,7 +204,7 @@ impl Deref for Qwen3VLProcessor {
     }
 }
 
-impl ImagePreProcessor for Qwen3VLProcessor {
+impl VisionPreProcessor for Qwen3VLProcessor {
     fn default_mean(&self) -> [f64; 3] {
         self.inner.default_mean()
     }
@@ -217,7 +217,7 @@ impl ImagePreProcessor for Qwen3VLProcessor {
         &self,
         images: &[DynamicImage],
         config: &PreProcessorConfig,
-    ) -> Result<PreprocessedImages, TransformError> {
+    ) -> Result<PreprocessedEncoderInputs, TransformError> {
         self.inner.preprocess(images, config)
     }
 
@@ -225,7 +225,7 @@ impl ImagePreProcessor for Qwen3VLProcessor {
         &self,
         frames: &[DynamicImage],
         config: &PreProcessorConfig,
-    ) -> Result<PreprocessedImages, TransformError> {
+    ) -> Result<PreprocessedEncoderInputs, TransformError> {
         self.inner.preprocess_video(frames, config)
     }
 
@@ -249,7 +249,7 @@ mod tests {
     use image::{Rgb, RgbImage};
 
     use super::*;
-    use crate::vision::{image_processor::ModelSpecificValue, preprocessor_config::PatchSize};
+    use crate::vision::{preprocessor_config::PatchSize, processor::ModelSpecificValue};
 
     fn create_test_image(width: u32, height: u32, color: Rgb<u8>) -> DynamicImage {
         DynamicImage::from(RgbImage::from_pixel(width, height, color))
@@ -357,12 +357,12 @@ mod tests {
         let image = create_test_image(640, 480, Rgb([128, 128, 128]));
         let result = processor.preprocess(&[image], &config).unwrap();
 
-        // pixel_values is patchified: [total_patches, patch_features]
-        assert_eq!(result.pixel_values.ndim(), 2);
-        assert!(result.pixel_values.shape()[0] > 0); // total_patches > 0
+        // encoder_input is patchified: [total_patches, patch_features]
+        assert_eq!(result.encoder_input.ndim(), 2);
+        assert!(result.encoder_input.shape()[0] > 0); // total_patches > 0
 
         // Check pixel values are normalized
-        let flat = result.pixel_values_flat();
+        let flat = result.encoder_input_flat();
         // After normalization with [0.5, 0.5, 0.5] mean/std:
         // (0.5 - 0.5) / 0.5 = 0.0 for gray
         // Values should be in [-1, 1] range
@@ -373,7 +373,7 @@ mod tests {
         assert!(result.model_specific.contains_key("patches_per_image"));
 
         // Verify token count is reasonable
-        assert!(result.num_img_tokens[0] > 0);
+        assert!(result.feature_token_counts[0] > 0);
     }
 
     #[test]
@@ -393,11 +393,11 @@ mod tests {
         let result = processor.preprocess(&images, &config).unwrap();
 
         // Both images processed
-        assert_eq!(result.image_sizes.len(), 2);
-        assert_eq!(result.num_img_tokens.len(), 2);
+        assert_eq!(result.item_sizes.len(), 2);
+        assert_eq!(result.feature_token_counts.len(), 2);
 
-        // pixel_values is 2D [total_patches, patch_features]
-        assert_eq!(result.pixel_values.ndim(), 2);
+        // encoder_input is 2D [total_patches, patch_features]
+        assert_eq!(result.encoder_input.ndim(), 2);
 
         // Check grid_thw shape
         if let Some(ModelSpecificValue::IntTensor { data, shape }) =
@@ -415,9 +415,9 @@ mod tests {
         {
             assert_eq!(shape, &[2]); // 2 images
             assert_eq!(data.len(), 2);
-            // Total patches should match pixel_values first dim
+            // Total patches should match encoder_input first dim
             let total: i64 = data.iter().sum();
-            assert_eq!(total as usize, result.pixel_values.shape()[0]);
+            assert_eq!(total as usize, result.encoder_input.shape()[0]);
         } else {
             panic!("Expected patches_per_image to be IntTensor");
         }
@@ -439,8 +439,8 @@ mod tests {
         ];
 
         let result = processor.preprocess_video(&frames, &config).unwrap();
-        assert_eq!(result.pixel_values.ndim(), 2);
-        assert_eq!(result.num_img_tokens.len(), 1);
+        assert_eq!(result.encoder_input.ndim(), 2);
+        assert_eq!(result.feature_token_counts.len(), 1);
         assert!(result.model_specific.contains_key("video_grid_thw"));
 
         if let Some(ModelSpecificValue::IntTensor { data, shape }) =

--- a/crates/multimodal/src/vision/processors/qwen3_vl.rs
+++ b/crates/multimodal/src/vision/processors/qwen3_vl.rs
@@ -139,6 +139,20 @@ impl Qwen3VLProcessor {
         }
     }
 
+    fn with_preprocessor_config(&self, config: &PreProcessorConfig) -> Self {
+        if config.patch_size.is_some()
+            || config.merge_size.is_some()
+            || config.min_pixels.is_some()
+            || config.max_pixels.is_some()
+            || config.temporal_patch_size.is_some()
+            || config.size.is_some()
+        {
+            Self::from_preprocessor_config(config)
+        } else {
+            self.clone()
+        }
+    }
+
     /// Get the patch size.
     pub fn patch_size(&self) -> usize {
         self.inner.patch_size()
@@ -218,7 +232,8 @@ impl VisionPreProcessor for Qwen3VLProcessor {
         images: &[DynamicImage],
         config: &PreProcessorConfig,
     ) -> Result<PreprocessedEncoderInputs, TransformError> {
-        self.inner.preprocess(images, config)
+        let processor = self.with_preprocessor_config(config);
+        processor.inner.preprocess(images, config)
     }
 
     fn preprocess_video(
@@ -226,11 +241,13 @@ impl VisionPreProcessor for Qwen3VLProcessor {
         frames: &[DynamicImage],
         config: &PreProcessorConfig,
     ) -> Result<PreprocessedEncoderInputs, TransformError> {
-        self.inner.preprocess_video(frames, config)
+        let processor = self.with_preprocessor_config(config);
+        processor.inner.preprocess_video(frames, config)
     }
 
     fn calculate_num_tokens(&self, width: u32, height: u32, config: &PreProcessorConfig) -> usize {
-        self.inner.calculate_num_tokens(width, height, config)
+        let processor = self.with_preprocessor_config(config);
+        processor.inner.calculate_num_tokens(width, height, config)
     }
 
     fn model_name(&self) -> &'static str {

--- a/crates/multimodal/src/vision/processors/qwen_vl_base.rs
+++ b/crates/multimodal/src/vision/processors/qwen_vl_base.rs
@@ -25,8 +25,8 @@ use image::{DynamicImage, GenericImageView};
 use ndarray::{Array2, Array3};
 
 use crate::vision::{
-    image_processor::{ImagePreProcessor, ModelSpecificValue, PreprocessedImages},
     preprocessor_config::PreProcessorConfig,
+    processor::{ModelSpecificValue, PreprocessedEncoderInputs, VisionPreProcessor},
     transforms::{pil_to_filter, resize, to_tensor, to_tensor_and_normalize, TransformError},
 };
 
@@ -421,9 +421,12 @@ impl QwenVLProcessorBase {
 
                     for mh in 0..merge_size {
                         for mw in 0..merge_size {
-                            for c in 0..channel {
-                                for tp in 0..temporal_patch_size {
-                                    let plane = frame_planes[frame_start + tp][c];
+                            let frame_window =
+                                &frame_planes[frame_start..frame_start + temporal_patch_size];
+                            for channel_frames in (0..channel).map(|channel_idx| {
+                                frame_window.iter().map(move |planes| planes[channel_idx])
+                            }) {
+                                for plane in channel_frames {
                                     for py in 0..patch_size {
                                         let row = (y0 + mh * patch_size + py) * width
                                             + x0
@@ -444,7 +447,7 @@ impl QwenVLProcessorBase {
     }
 }
 
-impl ImagePreProcessor for QwenVLProcessorBase {
+impl VisionPreProcessor for QwenVLProcessorBase {
     fn default_mean(&self) -> [f64; 3] {
         self.config.mean
     }
@@ -457,13 +460,13 @@ impl ImagePreProcessor for QwenVLProcessorBase {
         &self,
         images: &[DynamicImage],
         config: &PreProcessorConfig,
-    ) -> Result<PreprocessedImages, TransformError> {
+    ) -> Result<PreprocessedEncoderInputs, TransformError> {
         if images.is_empty() {
             return Err(TransformError::EmptyBatch);
         }
 
         // Store original sizes
-        let image_sizes: Vec<(u32, u32)> = images.iter().map(|img| img.dimensions()).collect();
+        let item_sizes: Vec<(u32, u32)> = images.iter().map(|img| img.dimensions()).collect();
 
         let mean = config.get_image_mean();
         let std = config.get_image_std();
@@ -486,7 +489,7 @@ impl ImagePreProcessor for QwenVLProcessorBase {
         let mut all_patches: Vec<f32> = Vec::with_capacity(estimated_total);
         let mut patches_per_image: Vec<i64> = Vec::with_capacity(images.len());
         let mut grid_thw_data = Vec::with_capacity(images.len() * 3);
-        let mut num_img_tokens = Vec::with_capacity(images.len());
+        let mut feature_token_counts = Vec::with_capacity(images.len());
 
         for image in images {
             let (w, h) = image.dimensions();
@@ -511,7 +514,7 @@ impl ImagePreProcessor for QwenVLProcessorBase {
 
             let num_patches = grid_t * grid_h * grid_w;
             let tokens = self.calculate_tokens_from_grid(grid_t, grid_h, grid_w);
-            num_img_tokens.push(tokens);
+            feature_token_counts.push(tokens);
 
             // Convert to tensor [C, H, W] and normalize in one fused pass
             let tensor = if config.do_normalize.unwrap_or(true) {
@@ -526,23 +529,26 @@ impl ImagePreProcessor for QwenVLProcessorBase {
         }
 
         let total_patches: usize = patches_per_image.iter().map(|&n| n as usize).sum();
-        let pixel_values =
+        let encoder_input =
             Array2::from_shape_vec((total_patches, patch_features), all_patches).map_err(|e| {
                 TransformError::ShapeError(format!(
-                    "Failed to create patchified pixel_values [{total_patches}, {patch_features}]: {e}"
+                    "Failed to create patchified encoder_input [{total_patches}, {patch_features}]: {e}"
                 ))
             })?;
 
-        let result =
-            PreprocessedImages::new_dynamic(pixel_values.into_dyn(), num_img_tokens, image_sizes)
-                .with_extra(
-                    "image_grid_thw",
-                    ModelSpecificValue::int_2d(grid_thw_data, images.len(), 3),
-                )
-                .with_extra(
-                    "patches_per_image",
-                    ModelSpecificValue::int_1d(patches_per_image),
-                );
+        let result = PreprocessedEncoderInputs::new_dynamic(
+            encoder_input.into_dyn(),
+            feature_token_counts,
+            item_sizes,
+        )
+        .with_extra(
+            "image_grid_thw",
+            ModelSpecificValue::int_2d(grid_thw_data, images.len(), 3),
+        )
+        .with_extra(
+            "patches_per_image",
+            ModelSpecificValue::int_1d(patches_per_image),
+        );
 
         Ok(result)
     }
@@ -551,13 +557,13 @@ impl ImagePreProcessor for QwenVLProcessorBase {
         &self,
         frames: &[DynamicImage],
         config: &PreProcessorConfig,
-    ) -> Result<PreprocessedImages, TransformError> {
+    ) -> Result<PreprocessedEncoderInputs, TransformError> {
         if frames.is_empty() {
             return Err(TransformError::EmptyBatch);
         }
 
         let (w, h) = frames[0].dimensions();
-        let image_sizes = vec![(w, h)];
+        let item_sizes = vec![(w, h)];
         let mean = config.get_image_mean();
         let std = config.get_image_std();
         let filter = pil_to_filter(config.resampling);
@@ -595,31 +601,30 @@ impl ImagePreProcessor for QwenVLProcessorBase {
         let mut all_patches = Vec::with_capacity(num_patches * patch_features);
         self.patchify_video_into(&tensors, grid_t, grid_h, grid_w, &mut all_patches)?;
 
-        let pixel_values = Array2::from_shape_vec((num_patches, patch_features), all_patches)
+        let encoder_input = Array2::from_shape_vec((num_patches, patch_features), all_patches)
             .map_err(|e| {
                 TransformError::ShapeError(format!(
-                    "Failed to create video pixel_values [{num_patches}, {patch_features}]: {e}"
+                    "Failed to create video encoder_input [{num_patches}, {patch_features}]: {e}"
                 ))
             })?;
 
-        let result =
-            PreprocessedImages::new_dynamic(pixel_values.into_dyn(), vec![tokens], image_sizes)
-                .with_extra(
-                    "video_grid_thw",
-                    ModelSpecificValue::int_2d(
-                        vec![grid_t as i64, grid_h as i64, grid_w as i64],
-                        1,
-                        3,
-                    ),
-                )
-                .with_extra(
-                    "patches_per_video",
-                    ModelSpecificValue::int_1d(vec![num_patches as i64]),
-                )
-                .with_extra(
-                    "patches_per_image",
-                    ModelSpecificValue::int_1d(vec![num_patches as i64]),
-                );
+        let result = PreprocessedEncoderInputs::new_dynamic(
+            encoder_input.into_dyn(),
+            vec![tokens],
+            item_sizes,
+        )
+        .with_extra(
+            "video_grid_thw",
+            ModelSpecificValue::int_2d(vec![grid_t as i64, grid_h as i64, grid_w as i64], 1, 3),
+        )
+        .with_extra(
+            "patches_per_video",
+            ModelSpecificValue::int_1d(vec![num_patches as i64]),
+        )
+        .with_extra(
+            "patches_per_image",
+            ModelSpecificValue::int_1d(vec![num_patches as i64]),
+        );
 
         Ok(result)
     }

--- a/crates/multimodal/src/vision/processors/qwen_vl_base.rs
+++ b/crates/multimodal/src/vision/processors/qwen_vl_base.rs
@@ -194,6 +194,61 @@ impl QwenVLProcessorBase {
         Ok((h_bar, w_bar))
     }
 
+    /// Smart resize for Qwen3-style video processors.
+    ///
+    /// Unlike image resize, the pixel budget is applied to the full sampled
+    /// video volume (`T * H * W`), matching HuggingFace's Qwen3 video
+    /// processor.
+    pub fn smart_resize_video(
+        &self,
+        num_frames: usize,
+        height: usize,
+        width: usize,
+    ) -> Result<(usize, usize), TransformError> {
+        let factor = self.get_factor();
+
+        if height < factor || width < factor {
+            return Err(TransformError::InvalidShape {
+                expected: format!("height and width >= factor ({factor})"),
+                actual: vec![height, width],
+            });
+        }
+
+        let max_dim = height.max(width) as f64;
+        let min_dim = height.min(width) as f64;
+        let aspect_ratio = max_dim / min_dim;
+        if aspect_ratio > 200.0 {
+            return Err(TransformError::InvalidShape {
+                expected: "aspect ratio < 200:1".to_string(),
+                actual: vec![height, width],
+            });
+        }
+
+        let mut h_bar = round_half_to_even(height as f64 / factor as f64) as usize * factor;
+        let mut w_bar = round_half_to_even(width as f64 / factor as f64) as usize * factor;
+        h_bar = h_bar.max(factor);
+        w_bar = w_bar.max(factor);
+
+        let t_bar =
+            num_frames.div_ceil(self.config.temporal_patch_size) * self.config.temporal_patch_size;
+        let resized_pixels = (t_bar * h_bar * w_bar) as f64;
+        if resized_pixels > self.config.max_pixels as f64 {
+            let beta =
+                ((num_frames * height * width) as f64 / self.config.max_pixels as f64).sqrt();
+            h_bar = ((height as f64 / beta / factor as f64).floor() as usize) * factor;
+            w_bar = ((width as f64 / beta / factor as f64).floor() as usize) * factor;
+            h_bar = h_bar.max(factor);
+            w_bar = w_bar.max(factor);
+        } else if resized_pixels < self.config.min_pixels as f64 {
+            let beta =
+                (self.config.min_pixels as f64 / (num_frames * height * width) as f64).sqrt();
+            h_bar = ((height as f64 * beta / factor as f64).ceil() as usize) * factor;
+            w_bar = ((width as f64 * beta / factor as f64).ceil() as usize) * factor;
+        }
+
+        Ok((h_bar, w_bar))
+    }
+
     /// Calculate the grid dimensions (T, H, W) for an image.
     ///
     /// For single images, T=1. For video, T = num_frames / temporal_patch_size.
@@ -285,6 +340,85 @@ impl QwenVLProcessorBase {
                         for mw in 0..merge_size {
                             for plane in &planes {
                                 for _tp in 0..temporal_patch_size {
+                                    for py in 0..patch_size {
+                                        let row = (y0 + mh * patch_size + py) * width
+                                            + x0
+                                            + mw * patch_size;
+                                        output[out_idx..out_idx + patch_size]
+                                            .copy_from_slice(&plane[row..row + patch_size]);
+                                        out_idx += patch_size;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Patchify a sequence of frame tensors into Qwen's video patch layout.
+    ///
+    /// `tensors` must already be resized and normalized to the same spatial
+    /// shape. If the frame count is not divisible by `temporal_patch_size`,
+    /// the caller should pad by repeating the final frame before calling this.
+    pub fn patchify_video_into(
+        &self,
+        tensors: &[Array3<f32>],
+        grid_t: usize,
+        grid_h: usize,
+        grid_w: usize,
+        output: &mut Vec<f32>,
+    ) -> Result<(), TransformError> {
+        if tensors.is_empty() {
+            return Err(TransformError::EmptyBatch);
+        }
+
+        let channel = tensors[0].shape()[0];
+        let height = tensors[0].shape()[1];
+        let width = tensors[0].shape()[2];
+        let patch_size = self.config.patch_size;
+        let merge_size = self.config.merge_size;
+        let temporal_patch_size = self.config.temporal_patch_size;
+
+        debug_assert_eq!(height, grid_h * patch_size);
+        debug_assert_eq!(width, grid_w * patch_size);
+        debug_assert_eq!(tensors.len(), grid_t * temporal_patch_size);
+
+        let num_patches = grid_t * grid_h * grid_w;
+        let patch_features = channel * temporal_patch_size * patch_size * patch_size;
+        let base_idx = output.len();
+        output.resize(base_idx + num_patches * patch_features, 0.0);
+
+        let frame_planes: Vec<Vec<&[f32]>> = tensors
+            .iter()
+            .map(|tensor| {
+                let flat = tensor.as_slice().ok_or_else(|| {
+                    TransformError::ShapeError("video frame tensor is not contiguous".to_string())
+                })?;
+                Ok((0..channel)
+                    .map(|c| &flat[c * height * width..(c + 1) * height * width])
+                    .collect::<Vec<_>>())
+            })
+            .collect::<Result<_, TransformError>>()?;
+
+        let merged_patch = merge_size * patch_size;
+        let mut out_idx = base_idx;
+
+        for gt in 0..grid_t {
+            let frame_start = gt * temporal_patch_size;
+            for pr in 0..grid_h / merge_size {
+                for pc in 0..grid_w / merge_size {
+                    let y0 = pr * merged_patch;
+                    let x0 = pc * merged_patch;
+
+                    for mh in 0..merge_size {
+                        for mw in 0..merge_size {
+                            for c in 0..channel {
+                                for tp in 0..temporal_patch_size {
+                                    let plane = frame_planes[frame_start + tp][c];
                                     for py in 0..patch_size {
                                         let row = (y0 + mh * patch_size + py) * width
                                             + x0
@@ -403,6 +537,79 @@ impl ImagePreProcessor for QwenVLProcessorBase {
                 .with_extra(
                     "patches_per_image",
                     ModelSpecificValue::int_1d(patches_per_image),
+                );
+
+        Ok(result)
+    }
+
+    fn preprocess_video(
+        &self,
+        frames: &[DynamicImage],
+        config: &PreProcessorConfig,
+    ) -> Result<PreprocessedImages, TransformError> {
+        if frames.is_empty() {
+            return Err(TransformError::EmptyBatch);
+        }
+
+        let (w, h) = frames[0].dimensions();
+        let image_sizes = vec![(w, h)];
+        let mean = config.get_image_mean();
+        let std = config.get_image_std();
+        let filter = pil_to_filter(config.resampling);
+
+        let temporal_patch_size = self.config.temporal_patch_size;
+        let padded_frames = frames.len().div_ceil(temporal_patch_size) * temporal_patch_size;
+        let (target_h, target_w) = self.smart_resize_video(frames.len(), h as usize, w as usize)?;
+        let (tw32, th32) = (target_w as u32, target_h as u32);
+        let (grid_t, grid_h, grid_w) = self.calculate_grid_thw(target_h, target_w, padded_frames);
+
+        let mut tensors = Vec::with_capacity(padded_frames);
+        for idx in 0..padded_frames {
+            let frame = &frames[idx.min(frames.len() - 1)];
+            let needs_resize = config.do_resize.unwrap_or(true)
+                && (frame.width() != tw32 || frame.height() != th32);
+            let resized;
+            let frame_ref = if needs_resize {
+                resized = resize(frame, tw32, th32, filter);
+                &resized
+            } else {
+                frame
+            };
+            let tensor = if config.do_normalize.unwrap_or(true) {
+                to_tensor_and_normalize(frame_ref, &mean, &std)
+            } else {
+                to_tensor(frame_ref)
+            };
+            tensors.push(tensor);
+        }
+
+        let patch_size = self.config.patch_size;
+        let patch_features = 3 * temporal_patch_size * patch_size * patch_size;
+        let num_patches = grid_t * grid_h * grid_w;
+        let tokens = self.calculate_tokens_from_grid(grid_t, grid_h, grid_w);
+        let mut all_patches = Vec::with_capacity(num_patches * patch_features);
+        self.patchify_video_into(&tensors, grid_t, grid_h, grid_w, &mut all_patches)?;
+
+        let pixel_values = Array2::from_shape_vec((num_patches, patch_features), all_patches)
+            .map_err(|e| {
+                TransformError::ShapeError(format!(
+                    "Failed to create video pixel_values [{num_patches}, {patch_features}]: {e}"
+                ))
+            })?;
+
+        let result =
+            PreprocessedImages::new_dynamic(pixel_values.into_dyn(), vec![tokens], image_sizes)
+                .with_extra(
+                    "video_grid_thw",
+                    ModelSpecificValue::int_2d(
+                        vec![grid_t as i64, grid_h as i64, grid_w as i64],
+                        1,
+                        3,
+                    ),
+                )
+                .with_extra(
+                    "patches_per_video",
+                    ModelSpecificValue::int_1d(vec![num_patches as i64]),
                 );
 
         Ok(result)

--- a/crates/multimodal/src/vision/processors/qwen_vl_base.rs
+++ b/crates/multimodal/src/vision/processors/qwen_vl_base.rs
@@ -207,6 +207,13 @@ impl QwenVLProcessorBase {
     ) -> Result<(usize, usize), TransformError> {
         let factor = self.get_factor();
 
+        if num_frames == 0 {
+            return Err(TransformError::InvalidShape {
+                expected: "num_frames > 0".to_string(),
+                actual: vec![num_frames],
+            });
+        }
+
         if height < factor || width < factor {
             return Err(TransformError::InvalidShape {
                 expected: format!("height and width >= factor ({factor})"),
@@ -233,15 +240,13 @@ impl QwenVLProcessorBase {
             num_frames.div_ceil(self.config.temporal_patch_size) * self.config.temporal_patch_size;
         let resized_pixels = (t_bar * h_bar * w_bar) as f64;
         if resized_pixels > self.config.max_pixels as f64 {
-            let beta =
-                ((num_frames * height * width) as f64 / self.config.max_pixels as f64).sqrt();
+            let beta = ((t_bar * height * width) as f64 / self.config.max_pixels as f64).sqrt();
             h_bar = ((height as f64 / beta / factor as f64).floor() as usize) * factor;
             w_bar = ((width as f64 / beta / factor as f64).floor() as usize) * factor;
             h_bar = h_bar.max(factor);
             w_bar = w_bar.max(factor);
         } else if resized_pixels < self.config.min_pixels as f64 {
-            let beta =
-                (self.config.min_pixels as f64 / (num_frames * height * width) as f64).sqrt();
+            let beta = (self.config.min_pixels as f64 / (t_bar * height * width) as f64).sqrt();
             h_bar = ((height as f64 * beta / factor as f64).ceil() as usize) * factor;
             w_bar = ((width as f64 * beta / factor as f64).ceil() as usize) * factor;
         }
@@ -609,6 +614,10 @@ impl ImagePreProcessor for QwenVLProcessorBase {
                 )
                 .with_extra(
                     "patches_per_video",
+                    ModelSpecificValue::int_1d(vec![num_patches as i64]),
+                )
+                .with_extra(
+                    "patches_per_image",
                     ModelSpecificValue::int_1d(vec![num_patches as i64]),
                 );
 

--- a/crates/multimodal/tests/vision_golden_tests.rs
+++ b/crates/multimodal/tests/vision_golden_tests.rs
@@ -31,9 +31,9 @@
 use std::{fs::File, io::Read, path::Path};
 
 use llm_multimodal::vision::{
-    image_processor::ModelSpecificValue, ImagePreProcessor, Llama4VisionProcessor, LlavaProcessor,
-    Phi3VisionProcessor, Phi4VisionProcessor, PixtralProcessor, PreProcessorConfig,
-    Qwen2VLProcessor, Qwen3VLProcessor,
+    Llama4VisionProcessor, LlavaProcessor, ModelSpecificValue, Phi3VisionProcessor,
+    Phi4VisionProcessor, PixtralProcessor, PreProcessorConfig, Qwen2VLProcessor, Qwen3VLProcessor,
+    VisionPreProcessor,
 };
 use ndarray::{Array4, Array5};
 
@@ -143,7 +143,7 @@ fn run_golden_test(mode: &str, image_name: &str) {
 
     let image = image::open(&image_path).expect("Failed to open image");
 
-    let processor: Box<dyn ImagePreProcessor> = match mode {
+    let processor: Box<dyn VisionPreProcessor> = match mode {
         "llava" => Box::new(LlavaProcessor::new()),
         "llava_pad" => Box::new(LlavaProcessor::new_with_pad()),
         _ => panic!("Unknown test mode: {mode}"),
@@ -153,10 +153,10 @@ fn run_golden_test(mode: &str, image_name: &str) {
         .preprocess(&[image], &config)
         .expect("Processing failed");
 
-    let diff = max_diff(&golden, &result.pixel_values);
+    let diff = max_diff(&golden, &result.encoder_input);
     println!("{mode} - {image_name} image - Max difference: {diff:.6}");
     println!("Golden shape: {:?}", golden.shape());
-    println!("Rust shape: {:?}", result.pixel_values.shape());
+    println!("Rust shape: {:?}", result.encoder_input.shape());
 
     // Allow tolerance for floating point and interpolation algorithm differences
     // Different interpolation implementations (Rust vs Python/PIL) can produce
@@ -372,7 +372,7 @@ fn run_qwen2_vl_golden_test(image_name: &str) {
     );
 
     // Compare token counts
-    let rust_num_tokens = result.num_img_tokens[0];
+    let rust_num_tokens = result.feature_token_counts[0];
     println!(
         "qwen2_vl - {image_name} image - Tokens: golden={golden_num_tokens}, rust={rust_num_tokens}"
     );
@@ -382,10 +382,10 @@ fn run_qwen2_vl_golden_test(image_name: &str) {
     );
 
     // pixel_values is now already patchified: [total_patches, patch_features]
-    let rust_patches = result.pixel_values_flat();
+    let rust_patches = result.encoder_input_flat();
     let rust_shape = (
-        result.pixel_values.shape()[0],
-        result.pixel_values.shape()[1],
+        result.encoder_input.shape()[0],
+        result.encoder_input.shape()[1],
     );
 
     println!(
@@ -523,7 +523,7 @@ fn run_qwen3_vl_golden_test(image_name: &str) {
     );
 
     // Compare token counts
-    let rust_num_tokens = result.num_img_tokens[0];
+    let rust_num_tokens = result.feature_token_counts[0];
     println!(
         "qwen3_vl - {image_name} image - Tokens: golden={golden_num_tokens}, rust={rust_num_tokens}"
     );
@@ -533,10 +533,10 @@ fn run_qwen3_vl_golden_test(image_name: &str) {
     );
 
     // pixel_values is now already patchified: [total_patches, patch_features]
-    let rust_patches = result.pixel_values_flat();
+    let rust_patches = result.encoder_input_flat();
     let rust_shape = (
-        result.pixel_values.shape()[0],
-        result.pixel_values.shape()[1],
+        result.encoder_input.shape()[0],
+        result.encoder_input.shape()[1],
     );
 
     println!(
@@ -767,7 +767,7 @@ fn run_phi3_vision_golden_test(image_name: &str) {
         .expect("Processing failed");
 
     // Check output shape
-    let rust_shape = result.pixel_values.shape();
+    let rust_shape = result.encoder_input.shape();
     let golden_shape = golden_pixels.shape();
     println!(
         "phi3_vision - {image_name} image - Shape: golden={golden_shape:?}, rust={rust_shape:?}"
@@ -800,17 +800,17 @@ fn run_phi3_vision_golden_test(image_name: &str) {
     // Check num_img_tokens
     println!(
         "phi3_vision - {image_name} image - Num tokens: golden={golden_num_tokens:?}, rust={:?}",
-        result.num_img_tokens
+        result.feature_token_counts
     );
     assert_eq!(
-        golden_num_tokens, result.num_img_tokens,
+        golden_num_tokens, result.feature_token_counts,
         "num_img_tokens mismatch for {image_name}"
     );
 
     // Compare pixel values
     // Convert rust ArrayD to Array5 for comparison
     let rust_pixels = result
-        .pixel_values
+        .encoder_input
         .clone()
         .into_dimensionality::<ndarray::Ix5>()
         .expect("Failed to convert to Ix5");
@@ -970,7 +970,7 @@ fn run_phi4_vision_golden_test(image_name: &str) {
         .expect("Processing failed");
 
     // Check output shape
-    let rust_shape = result.pixel_values.shape();
+    let rust_shape = result.encoder_input.shape();
     let golden_shape = golden_pixels.shape();
     println!(
         "phi4_vision - {image_name} image - Shape: golden={golden_shape:?}, rust={rust_shape:?}"
@@ -1002,16 +1002,16 @@ fn run_phi4_vision_golden_test(image_name: &str) {
     // Check num_img_tokens
     println!(
         "phi4_vision - {image_name} image - Num tokens: golden={golden_num_tokens:?}, rust={:?}",
-        result.num_img_tokens
+        result.feature_token_counts
     );
     assert_eq!(
-        golden_num_tokens, result.num_img_tokens,
+        golden_num_tokens, result.feature_token_counts,
         "num_img_tokens mismatch for {image_name}"
     );
 
     // Compare pixel values
     let rust_pixels = result
-        .pixel_values
+        .encoder_input
         .clone()
         .into_dimensionality::<ndarray::Ix5>()
         .expect("Failed to convert to Ix5");
@@ -1195,7 +1195,7 @@ fn run_llama4_vision_golden_test(image_name: &str) {
     );
 
     // Check num_tokens
-    let rust_num_tokens = result.num_img_tokens[0];
+    let rust_num_tokens = result.feature_token_counts[0];
     println!(
         "llama4_vision - {image_name} image - Tokens: golden={golden_num_tokens}, rust={rust_num_tokens}"
     );
@@ -1205,7 +1205,7 @@ fn run_llama4_vision_golden_test(image_name: &str) {
     );
 
     // Check output shape - both HuggingFace and Rust output 4D (total_tiles, C, H, W)
-    let rust_shape = result.pixel_values.shape();
+    let rust_shape = result.encoder_input.shape();
     println!(
         "llama4_vision - {image_name} image - Shape: golden={golden_shape:?}, rust={rust_shape:?}"
     );
@@ -1223,7 +1223,7 @@ fn run_llama4_vision_golden_test(image_name: &str) {
     );
 
     // Compare pixel values
-    let rust_pixels = result.pixel_values_flat();
+    let rust_pixels = result.encoder_input_flat();
     let num_golden_elements: usize = golden_shape.iter().product();
 
     // Find the max difference for the actual tiles (not padding)
@@ -1381,7 +1381,7 @@ fn run_pixtral_golden_test(image_name: &str) {
     );
 
     // Check num_tokens
-    let rust_num_tokens = result.num_img_tokens[0];
+    let rust_num_tokens = result.feature_token_counts[0];
     println!(
         "pixtral - {image_name} image - Tokens: golden={golden_num_tokens}, rust={rust_num_tokens}"
     );
@@ -1391,7 +1391,7 @@ fn run_pixtral_golden_test(image_name: &str) {
     );
 
     // Check output shape
-    let rust_shape = result.pixel_values.shape();
+    let rust_shape = result.encoder_input.shape();
     println!("pixtral - {image_name} image - Shape: golden={golden_shape:?}, rust={rust_shape:?}");
 
     // Pixtral outputs [batch, C, H, W] with padding to max size in batch
@@ -1412,7 +1412,7 @@ fn run_pixtral_golden_test(image_name: &str) {
     );
 
     // Compare pixel values - only compare the actual image region, not padding
-    let rust_pixels = result.pixel_values_flat();
+    let rust_pixels = result.encoder_input_flat();
     let golden_pixels_flat: Vec<f32> = golden_pixels.iter().copied().collect();
 
     // Calculate indices for the actual image region (not padding)

--- a/grpc_servicer/smg_grpc_servicer/tokenspeed/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/tokenspeed/servicer.py
@@ -894,10 +894,15 @@ class TokenSpeedSchedulerServicer(tokenspeed_scheduler_pb2_grpc.TokenSpeedSchedu
             items.append(mm_item)
 
             if item_proto.HasField("placeholder_token_id"):
+                placeholder_token_id = int(item_proto.placeholder_token_id)
                 if modality == Modality.IMAGE:
-                    im_token_id = int(item_proto.placeholder_token_id)
+                    im_token_id = self._merge_placeholder_token_id(
+                        im_token_id, placeholder_token_id, modality
+                    )
                 elif modality == Modality.VIDEO:
-                    video_token_id = int(item_proto.placeholder_token_id)
+                    video_token_id = self._merge_placeholder_token_id(
+                        video_token_id, placeholder_token_id, modality
+                    )
 
         if not items:
             raise ValueError("MultimodalInputs.items is empty")
@@ -916,6 +921,18 @@ class TokenSpeedSchedulerServicer(tokenspeed_scheduler_pb2_grpc.TokenSpeedSchedu
         if modality == getattr(tokenspeed_scheduler_pb2, "AUDIO", 2):
             raise ValueError("TokenSpeed audio multimodal inputs are not supported yet")
         raise ValueError(f"Unsupported multimodal item modality: {modality}")
+
+    @staticmethod
+    def _merge_placeholder_token_id(
+        current: int | None,
+        incoming: int,
+        modality: Modality,
+    ) -> int:
+        if current is not None and current != incoming:
+            raise ValueError(
+                f"Conflicting placeholder_token_id for {modality.name}: {current} != {incoming}"
+            )
+        return incoming
 
     @staticmethod
     def _validate_item_tensor_consistency(

--- a/grpc_servicer/smg_grpc_servicer/tokenspeed/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/tokenspeed/servicer.py
@@ -375,14 +375,11 @@ class TokenSpeedSchedulerServicer(tokenspeed_scheduler_pb2_grpc.TokenSpeedSchedu
         supports_vision = bool(getattr(model_config, "is_multimodal", False))
         image_modality = getattr(tokenspeed_scheduler_pb2, "IMAGE", 1)
         video_modality = getattr(tokenspeed_scheduler_pb2, "VIDEO", 3)
-        audio_modality = getattr(tokenspeed_scheduler_pb2, "AUDIO", 2)
         supported_modalities = []
         if supports_vision:
             supported_modalities.append(image_modality)
             if hf_config is not None and getattr(hf_config, "video_token_id", None) is not None:
                 supported_modalities.append(video_modality)
-            if hf_config is not None and getattr(hf_config, "audio_token_id", None) is not None:
-                supported_modalities.append(audio_modality)
 
         response_kwargs = dict(
             model_path=model_path,
@@ -901,9 +898,9 @@ class TokenSpeedSchedulerServicer(tokenspeed_scheduler_pb2_grpc.TokenSpeedSchedu
             items.append(mm_item)
 
             if item_proto.HasField("placeholder_token_id"):
-                if modality is Modality.IMAGE:
+                if modality == Modality.IMAGE:
                     im_token_id = int(item_proto.placeholder_token_id)
-                elif modality is Modality.VIDEO:
+                elif modality == Modality.VIDEO:
                     video_token_id = int(item_proto.placeholder_token_id)
 
         if not items:
@@ -921,7 +918,7 @@ class TokenSpeedSchedulerServicer(tokenspeed_scheduler_pb2_grpc.TokenSpeedSchedu
         if modality == getattr(tokenspeed_scheduler_pb2, "VIDEO", 3):
             return Modality.VIDEO
         if modality == getattr(tokenspeed_scheduler_pb2, "AUDIO", 2):
-            return Modality.AUDIO
+            raise ValueError("TokenSpeed audio multimodal inputs are not supported yet")
         raise ValueError(f"Unsupported multimodal item modality: {modality}")
 
     @staticmethod
@@ -930,11 +927,11 @@ class TokenSpeedSchedulerServicer(tokenspeed_scheduler_pb2_grpc.TokenSpeedSchedu
     ) -> None:
         has_image_grid = "image_grid_thw" in model_specific_data
         has_video_grid = "video_grid_thw" in model_specific_data
-        if modality is Modality.IMAGE and has_video_grid:
+        if modality == Modality.IMAGE and has_video_grid:
             raise ValueError("IMAGE MultimodalItem must not carry video_grid_thw")
-        if modality is Modality.VIDEO and has_image_grid:
+        if modality == Modality.VIDEO and has_image_grid:
             raise ValueError("VIDEO MultimodalItem must not carry image_grid_thw")
-        if modality is Modality.VIDEO and not has_video_grid:
+        if modality == Modality.VIDEO and not has_video_grid:
             raise ValueError("VIDEO MultimodalItem must carry video_grid_thw")
 
     @staticmethod
@@ -986,6 +983,9 @@ class TokenSpeedSchedulerServicer(tokenspeed_scheduler_pb2_grpc.TokenSpeedSchedu
             raise ValueError("TensorData.shm payload is not implemented yet")
         if payload == "remote":
             raise ValueError("TensorData.remote payload is not implemented yet")
+        legacy_data = getattr(tensor_data, "data", b"")
+        if legacy_data:
+            return bytes(legacy_data)
         raise ValueError("TensorData payload is required")
 
     @staticmethod

--- a/grpc_servicer/smg_grpc_servicer/tokenspeed/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/tokenspeed/servicer.py
@@ -858,9 +858,7 @@ class TokenSpeedSchedulerServicer(tokenspeed_scheduler_pb2_grpc.TokenSpeedSchedu
             if LOG_MM_TENSOR_DATA:
                 encoder_input = item_proto.encoder_input
                 payload = encoder_input.WhichOneof("payload")
-                inline_nbytes = (
-                    len(encoder_input.inline) if payload == "inline" else None
-                )
+                inline_nbytes = len(encoder_input.inline) if payload == "inline" else None
                 logger.info(
                     "Multimodal encoder_input received: modality=%s proto_dtype=%s "
                     "shape=%s payload=%s inline_nbytes=%s torch_dtype=%s cast_to=%s",
@@ -882,9 +880,7 @@ class TokenSpeedSchedulerServicer(tokenspeed_scheduler_pb2_grpc.TokenSpeedSchedu
                 raise ValueError("MultimodalItem carried no placeholders")
             if any(p.length <= 0 for p in item_proto.placeholders):
                 raise ValueError("MultimodalItem.placeholders.length must be > 0")
-            offsets = [
-                (p.offset, p.offset + p.length - 1) for p in item_proto.placeholders
-            ]
+            offsets = [(p.offset, p.offset + p.length - 1) for p in item_proto.placeholders]
 
             content_hash = bytes(item_proto.content_hash)
             mm_item = MultimodalDataItem(
@@ -955,9 +951,9 @@ class TokenSpeedSchedulerServicer(tokenspeed_scheduler_pb2_grpc.TokenSpeedSchedu
                     f"TensorData byte length mismatch for bfloat16 shape={shape}: "
                     f"expected {expected}, got {len(raw)}"
                 )
-            t = torch.from_numpy(
-                np.frombuffer(raw, dtype=np.uint16).reshape(shape)
-            ).view(torch.bfloat16)
+            t = torch.from_numpy(np.frombuffer(raw, dtype=np.uint16).reshape(shape)).view(
+                torch.bfloat16
+            )
         else:
             dtype = np.dtype(tensor_data.dtype)
             expected = int(np.prod(shape, dtype=np.int64)) * dtype.itemsize
@@ -966,9 +962,7 @@ class TokenSpeedSchedulerServicer(tokenspeed_scheduler_pb2_grpc.TokenSpeedSchedu
                     f"TensorData byte length mismatch for dtype={tensor_data.dtype}, "
                     f"shape={shape}: expected {expected}, got {len(raw)}"
                 )
-            t = torch.from_numpy(
-                np.frombuffer(raw, dtype=dtype).reshape(shape)
-            )
+            t = torch.from_numpy(np.frombuffer(raw, dtype=dtype).reshape(shape))
 
         if cast_to is not None and t.dtype != cast_to and t.is_floating_point():
             return t.to(cast_to)

--- a/grpc_servicer/smg_grpc_servicer/tokenspeed/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/tokenspeed/servicer.py
@@ -46,6 +46,11 @@ logger = logging.getLogger(__name__)
 HEALTH_CHECK_TIMEOUT = int(os.getenv("TOKENSPEED_HEALTH_CHECK_TIMEOUT", "20"))
 # Profile round-trips include trace serialization, which can take minutes.
 PROFILE_TIMEOUT = 600.0
+LOG_MM_TENSOR_DATA = os.getenv("TOKENSPEED_LOG_MM_TENSOR_DATA", "").lower() in (
+    "1",
+    "true",
+    "yes",
+)
 
 
 def _lazy_generate_req_input():
@@ -400,6 +405,11 @@ class TokenSpeedSchedulerServicer(tokenspeed_scheduler_pb2_grpc.TokenSpeedSchedu
             response_kwargs["supports_multimodal"] = supports_vision
         if "supported_modalities" in fields:
             response_kwargs["supported_modalities"] = supported_modalities
+        dtype = self._torch_dtype_to_proto(getattr(model_config, "dtype", None))
+        if "model_dtype" in fields:
+            response_kwargs["model_dtype"] = dtype
+        if "multimodal_encoder_dtype" in fields:
+            response_kwargs["multimodal_encoder_dtype"] = dtype
         return tokenspeed_scheduler_pb2.GetModelInfoResponse(**response_kwargs)
 
     # ------------------------------------------------------------------
@@ -830,41 +840,7 @@ class TokenSpeedSchedulerServicer(tokenspeed_scheduler_pb2_grpc.TokenSpeedSchedu
         (``precomputed_multimodal_inputs`` is set); this just boxes the tensors and
         placeholder offsets into the engine's data class.
         """
-        if getattr(mm_inputs, "items", None):
-            return self._mm_inputs_from_itemized_proto(mm_inputs, model_dtype=model_dtype)
-
-        if not mm_inputs.HasField("pixel_values"):
-            raise ValueError(
-                "MultimodalInputs carried neither v2 items nor legacy pixel_values"
-            )
-
-        feature = self._tensor_from_proto(mm_inputs.pixel_values, cast_to=model_dtype)
-        model_specific_data = {}
-        for name, tensor_data in mm_inputs.model_specific_tensors.items():
-            model_specific_data[name] = self._tensor_from_proto(tensor_data, cast_to=model_dtype)
-
-        if not mm_inputs.mm_placeholders:
-            raise ValueError(
-                "multimodal request carried no placeholders; "
-                "the image token was not located in input_ids"
-            )
-        if any(p.length <= 0 for p in mm_inputs.mm_placeholders):
-            raise ValueError("mm_placeholders.length must be > 0")
-        # Placeholders arrive as (offset, length); the engine wants inclusive (start, end).
-        offsets = [(p.offset, p.offset + p.length - 1) for p in mm_inputs.mm_placeholders]
-
-        mm_item = MultimodalDataItem(
-            modality=Modality.IMAGE,
-            feature=feature,
-            model_specific_data=model_specific_data,
-            offsets=offsets,
-        )
-        # pad_value must exist before the engine splices features into the embedding
-        # stream, otherwise it fails inferring a dtype from None.
-        mm_item.set_pad_value()
-
-        im_token_id = mm_inputs.im_token_id if mm_inputs.HasField("im_token_id") else None
-        return MultimodalInputs(mm_items=[mm_item], im_token_id=im_token_id)
+        return self._mm_inputs_from_itemized_proto(mm_inputs, model_dtype=model_dtype)
 
     def _mm_inputs_from_itemized_proto(
         self,
@@ -878,14 +854,30 @@ class TokenSpeedSchedulerServicer(tokenspeed_scheduler_pb2_grpc.TokenSpeedSchedu
 
         for item_proto in mm_inputs.items:
             modality = self._modality_from_proto(item_proto.modality)
-            tensors = dict(item_proto.tensors)
-            if "pixel_values" not in tensors:
-                raise ValueError("MultimodalItem.tensors must include 'pixel_values'")
+            if not item_proto.HasField("encoder_input"):
+                raise ValueError("MultimodalItem must include encoder_input")
 
-            feature = self._tensor_from_proto(tensors.pop("pixel_values"), cast_to=model_dtype)
+            feature = self._tensor_from_proto(item_proto.encoder_input, cast_to=model_dtype)
+            if LOG_MM_TENSOR_DATA:
+                encoder_input = item_proto.encoder_input
+                payload = encoder_input.WhichOneof("payload")
+                inline_nbytes = (
+                    len(encoder_input.inline) if payload == "inline" else None
+                )
+                logger.info(
+                    "Multimodal encoder_input received: modality=%s proto_dtype=%s "
+                    "shape=%s payload=%s inline_nbytes=%s torch_dtype=%s cast_to=%s",
+                    modality,
+                    encoder_input.dtype,
+                    list(encoder_input.shape),
+                    payload,
+                    inline_nbytes,
+                    feature.dtype,
+                    model_dtype,
+                )
             model_specific_data = {
                 name: self._tensor_from_proto(tensor_data, cast_to=model_dtype)
-                for name, tensor_data in tensors.items()
+                for name, tensor_data in item_proto.model_specific_tensors.items()
             }
             self._validate_item_tensor_consistency(modality, model_specific_data)
 
@@ -956,33 +948,55 @@ class TokenSpeedSchedulerServicer(tokenspeed_scheduler_pb2_grpc.TokenSpeedSchedu
         copied so it never aliases the transient proto bytes.
         """
         shape = list(tensor_data.shape)
+        raw = TokenSpeedSchedulerServicer._tensor_payload_bytes(tensor_data)
 
         if tensor_data.dtype == "bfloat16":
             # numpy has no bfloat16 — read the raw bits as uint16, reinterpret.
             expected = int(np.prod(shape, dtype=np.int64)) * np.dtype(np.uint16).itemsize
-            if len(tensor_data.data) != expected:
+            if len(raw) != expected:
                 raise ValueError(
                     f"TensorData byte length mismatch for bfloat16 shape={shape}: "
-                    f"expected {expected}, got {len(tensor_data.data)}"
+                    f"expected {expected}, got {len(raw)}"
                 )
             t = torch.from_numpy(
-                np.frombuffer(tensor_data.data, dtype=np.uint16).reshape(shape)
+                np.frombuffer(raw, dtype=np.uint16).reshape(shape)
             ).view(torch.bfloat16)
         else:
             dtype = np.dtype(tensor_data.dtype)
             expected = int(np.prod(shape, dtype=np.int64)) * dtype.itemsize
-            if len(tensor_data.data) != expected:
+            if len(raw) != expected:
                 raise ValueError(
                     f"TensorData byte length mismatch for dtype={tensor_data.dtype}, "
-                    f"shape={shape}: expected {expected}, got {len(tensor_data.data)}"
+                    f"shape={shape}: expected {expected}, got {len(raw)}"
                 )
             t = torch.from_numpy(
-                np.frombuffer(tensor_data.data, dtype=dtype).reshape(shape)
+                np.frombuffer(raw, dtype=dtype).reshape(shape)
             )
 
         if cast_to is not None and t.dtype != cast_to and t.is_floating_point():
             return t.to(cast_to)
         return t.clone()
+
+    @staticmethod
+    def _tensor_payload_bytes(tensor_data: tokenspeed_scheduler_pb2.TensorData) -> bytes:
+        payload = tensor_data.WhichOneof("payload")
+        if payload == "inline":
+            return bytes(tensor_data.inline)
+        if payload == "shm":
+            raise ValueError("TensorData.shm payload is not implemented yet")
+        if payload == "remote":
+            raise ValueError("TensorData.remote payload is not implemented yet")
+        raise ValueError("TensorData payload is required")
+
+    @staticmethod
+    def _torch_dtype_to_proto(dtype: torch.dtype | None) -> str:
+        if dtype is torch.bfloat16:
+            return "bfloat16"
+        if dtype is torch.float16:
+            return "float16"
+        if dtype is torch.float32:
+            return "float32"
+        return ""
 
     def _generated_output_ids(
         self,

--- a/grpc_servicer/smg_grpc_servicer/tokenspeed/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/tokenspeed/servicer.py
@@ -983,9 +983,6 @@ class TokenSpeedSchedulerServicer(tokenspeed_scheduler_pb2_grpc.TokenSpeedSchedu
             raise ValueError("TensorData.shm payload is not implemented yet")
         if payload == "remote":
             raise ValueError("TensorData.remote payload is not implemented yet")
-        legacy_data = getattr(tensor_data, "data", b"")
-        if legacy_data:
-            return bytes(legacy_data)
         raise ValueError("TensorData payload is required")
 
     @staticmethod

--- a/grpc_servicer/smg_grpc_servicer/tokenspeed/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/tokenspeed/servicer.py
@@ -368,8 +368,18 @@ class TokenSpeedSchedulerServicer(tokenspeed_scheduler_pb2_grpc.TokenSpeedSchedu
             self.server_args, "tokenizer_path", ""
         )
         supports_vision = bool(getattr(model_config, "is_multimodal", False))
+        image_modality = getattr(tokenspeed_scheduler_pb2, "IMAGE", 1)
+        video_modality = getattr(tokenspeed_scheduler_pb2, "VIDEO", 3)
+        audio_modality = getattr(tokenspeed_scheduler_pb2, "AUDIO", 2)
+        supported_modalities = []
+        if supports_vision:
+            supported_modalities.append(image_modality)
+            if hf_config is not None and getattr(hf_config, "video_token_id", None) is not None:
+                supported_modalities.append(video_modality)
+            if hf_config is not None and getattr(hf_config, "audio_token_id", None) is not None:
+                supported_modalities.append(audio_modality)
 
-        return tokenspeed_scheduler_pb2.GetModelInfoResponse(
+        response_kwargs = dict(
             model_path=model_path,
             tokenizer_path=tokenizer_path or "",
             default_sampling_params_json=self.server_args.preferred_sampling_params or "",
@@ -385,6 +395,12 @@ class TokenSpeedSchedulerServicer(tokenspeed_scheduler_pb2_grpc.TokenSpeedSchedu
             max_req_input_len=int(max_req_input_len),
             supports_vision=supports_vision,
         )
+        fields = tokenspeed_scheduler_pb2.GetModelInfoResponse.DESCRIPTOR.fields_by_name
+        if "supports_multimodal" in fields:
+            response_kwargs["supports_multimodal"] = supports_vision
+        if "supported_modalities" in fields:
+            response_kwargs["supported_modalities"] = supported_modalities
+        return tokenspeed_scheduler_pb2.GetModelInfoResponse(**response_kwargs)
 
     # ------------------------------------------------------------------
     # GetServerInfo (unary)
@@ -678,7 +694,7 @@ class TokenSpeedSchedulerServicer(tokenspeed_scheduler_pb2_grpc.TokenSpeedSchedu
 
         # Decode the precomputed multimodal payload, if the request carries one.
         precomputed_mm = None
-        if request.HasField("mm_inputs") and request.mm_inputs.HasField("pixel_values"):
+        if request.HasField("mm_inputs"):
             precomputed_mm = self._mm_inputs_from_proto(
                 request.mm_inputs,
                 model_dtype=getattr(self.async_llm.model_config, "dtype", None),
@@ -814,6 +830,14 @@ class TokenSpeedSchedulerServicer(tokenspeed_scheduler_pb2_grpc.TokenSpeedSchedu
         (``precomputed_multimodal_inputs`` is set); this just boxes the tensors and
         placeholder offsets into the engine's data class.
         """
+        if getattr(mm_inputs, "items", None):
+            return self._mm_inputs_from_itemized_proto(mm_inputs, model_dtype=model_dtype)
+
+        if not mm_inputs.HasField("pixel_values"):
+            raise ValueError(
+                "MultimodalInputs carried neither v2 items nor legacy pixel_values"
+            )
+
         feature = self._tensor_from_proto(mm_inputs.pixel_values, cast_to=model_dtype)
         model_specific_data = {}
         for name, tensor_data in mm_inputs.model_specific_tensors.items():
@@ -842,6 +866,85 @@ class TokenSpeedSchedulerServicer(tokenspeed_scheduler_pb2_grpc.TokenSpeedSchedu
         im_token_id = mm_inputs.im_token_id if mm_inputs.HasField("im_token_id") else None
         return MultimodalInputs(mm_items=[mm_item], im_token_id=im_token_id)
 
+    def _mm_inputs_from_itemized_proto(
+        self,
+        mm_inputs: tokenspeed_scheduler_pb2.MultimodalInputs,
+        *,
+        model_dtype: torch.dtype | None = None,
+    ):
+        items = []
+        im_token_id = None
+        video_token_id = None
+
+        for item_proto in mm_inputs.items:
+            modality = self._modality_from_proto(item_proto.modality)
+            tensors = dict(item_proto.tensors)
+            if "pixel_values" not in tensors:
+                raise ValueError("MultimodalItem.tensors must include 'pixel_values'")
+
+            feature = self._tensor_from_proto(tensors.pop("pixel_values"), cast_to=model_dtype)
+            model_specific_data = {
+                name: self._tensor_from_proto(tensor_data, cast_to=model_dtype)
+                for name, tensor_data in tensors.items()
+            }
+            self._validate_item_tensor_consistency(modality, model_specific_data)
+
+            if not item_proto.placeholders:
+                raise ValueError("MultimodalItem carried no placeholders")
+            if any(p.length <= 0 for p in item_proto.placeholders):
+                raise ValueError("MultimodalItem.placeholders.length must be > 0")
+            offsets = [
+                (p.offset, p.offset + p.length - 1) for p in item_proto.placeholders
+            ]
+
+            content_hash = bytes(item_proto.content_hash)
+            mm_item = MultimodalDataItem(
+                modality=modality,
+                feature=feature,
+                model_specific_data=model_specific_data,
+                offsets=offsets,
+                hash=int.from_bytes(content_hash[:8], "little") if content_hash else None,
+            )
+            mm_item.set_pad_value()
+            items.append(mm_item)
+
+            if item_proto.HasField("placeholder_token_id"):
+                if modality is Modality.IMAGE:
+                    im_token_id = int(item_proto.placeholder_token_id)
+                elif modality is Modality.VIDEO:
+                    video_token_id = int(item_proto.placeholder_token_id)
+
+        if not items:
+            raise ValueError("MultimodalInputs.items is empty")
+        return MultimodalInputs(
+            mm_items=items,
+            im_token_id=im_token_id,
+            video_token_id=video_token_id,
+        )
+
+    @staticmethod
+    def _modality_from_proto(modality: int) -> Modality:
+        if modality == getattr(tokenspeed_scheduler_pb2, "IMAGE", 1):
+            return Modality.IMAGE
+        if modality == getattr(tokenspeed_scheduler_pb2, "VIDEO", 3):
+            return Modality.VIDEO
+        if modality == getattr(tokenspeed_scheduler_pb2, "AUDIO", 2):
+            return Modality.AUDIO
+        raise ValueError(f"Unsupported multimodal item modality: {modality}")
+
+    @staticmethod
+    def _validate_item_tensor_consistency(
+        modality: Modality, model_specific_data: dict[str, torch.Tensor]
+    ) -> None:
+        has_image_grid = "image_grid_thw" in model_specific_data
+        has_video_grid = "video_grid_thw" in model_specific_data
+        if modality is Modality.IMAGE and has_video_grid:
+            raise ValueError("IMAGE MultimodalItem must not carry video_grid_thw")
+        if modality is Modality.VIDEO and has_image_grid:
+            raise ValueError("VIDEO MultimodalItem must not carry image_grid_thw")
+        if modality is Modality.VIDEO and not has_video_grid:
+            raise ValueError("VIDEO MultimodalItem must carry video_grid_thw")
+
     @staticmethod
     def _tensor_from_proto(
         tensor_data: tokenspeed_scheduler_pb2.TensorData,
@@ -853,14 +956,28 @@ class TokenSpeedSchedulerServicer(tokenspeed_scheduler_pb2_grpc.TokenSpeedSchedu
         copied so it never aliases the transient proto bytes.
         """
         shape = list(tensor_data.shape)
+
         if tensor_data.dtype == "bfloat16":
             # numpy has no bfloat16 — read the raw bits as uint16, reinterpret.
+            expected = int(np.prod(shape, dtype=np.int64)) * np.dtype(np.uint16).itemsize
+            if len(tensor_data.data) != expected:
+                raise ValueError(
+                    f"TensorData byte length mismatch for bfloat16 shape={shape}: "
+                    f"expected {expected}, got {len(tensor_data.data)}"
+                )
             t = torch.from_numpy(
                 np.frombuffer(tensor_data.data, dtype=np.uint16).reshape(shape)
             ).view(torch.bfloat16)
         else:
+            dtype = np.dtype(tensor_data.dtype)
+            expected = int(np.prod(shape, dtype=np.int64)) * dtype.itemsize
+            if len(tensor_data.data) != expected:
+                raise ValueError(
+                    f"TensorData byte length mismatch for dtype={tensor_data.dtype}, "
+                    f"shape={shape}: expected {expected}, got {len(tensor_data.data)}"
+                )
             t = torch.from_numpy(
-                np.frombuffer(tensor_data.data, dtype=np.dtype(tensor_data.dtype)).reshape(shape)
+                np.frombuffer(tensor_data.data, dtype=dtype).reshape(shape)
             )
 
         if cast_to is not None and t.dtype != cast_to and t.is_floating_point():

--- a/model_gateway/Cargo.toml
+++ b/model_gateway/Cargo.toml
@@ -81,6 +81,7 @@ smg-grpc-client.workspace = true
 bincode = "1.3"
 clap = { version = "4", features = ["derive", "env"] }
 axum-server = { version = "0.8.0", default-features = false, features = ["tls-rustls-no-provider"] }
+ndarray = "0.17"
 tower = { version = "0.5", features = ["full"] }
 tower-http = { version = "0.6", features = ["trace", "compression-gzip", "cors", "timeout", "limit", "request-id", "util"] }
 serde_json = { version = "1.0", default-features = false, features = ["std", "preserve_order"] }

--- a/model_gateway/src/routers/grpc/multimodal.rs
+++ b/model_gateway/src/routers/grpc/multimodal.rs
@@ -29,6 +29,7 @@ use tracing::{debug, warn};
 
 use crate::routers::grpc::{
     client::GrpcClient,
+    context::WorkerSelection,
     proto_wrapper::{
         SglangMultimodalData, TensorBytes, TokenSpeedModality, TokenSpeedMultimodalData,
         TrtllmMultimodalData, VllmMultimodalData,
@@ -852,6 +853,7 @@ fn expand_tokens(
 pub(crate) fn assemble_multimodal_data(
     intermediate: MultimodalIntermediate,
     client: &GrpcClient,
+    workers: Option<&WorkerSelection>,
 ) -> Result<MultimodalData> {
     match intermediate {
         MultimodalIntermediate::Precomputed(precomputed) => match client {
@@ -868,7 +870,10 @@ pub(crate) fn assemble_multimodal_data(
                 Ok(MultimodalData::Trtllm(assemble_trtllm(precomputed)))
             }
             GrpcClient::TokenSpeed(_) => {
-                Ok(MultimodalData::TokenSpeed(assemble_tokenspeed(precomputed)))
+                Ok(MultimodalData::TokenSpeed(assemble_tokenspeed(
+                    precomputed,
+                    workers,
+                )))
             }
             GrpcClient::Mlx(_) => unreachable!(
                 "caller rejects multimodal for MLX in build_chat_request/build_messages_request"
@@ -951,9 +956,14 @@ fn assemble_trtllm(intermediate: PrecomputedMultimodalIntermediate) -> TrtllmMul
     TrtllmMultimodalData { image_data }
 }
 
-fn assemble_tokenspeed(intermediate: PrecomputedMultimodalIntermediate) -> TokenSpeedMultimodalData {
+fn assemble_tokenspeed(
+    intermediate: PrecomputedMultimodalIntermediate,
+    workers: Option<&WorkerSelection>,
+) -> TokenSpeedMultimodalData {
     // Use patch-only offsets when available and non-empty; fall back to full structural ranges.
-    let (pixel_values, pixel_values_shape) = serialize_pixel_values(&intermediate.preprocessed);
+    let encoder_input_dtype = tokenspeed_encoder_input_dtype(intermediate.modality, workers);
+    let (pixel_values, pixel_values_shape, encoder_input_dtype) =
+        serialize_pixel_values_as_dtype(&intermediate.preprocessed, &encoder_input_dtype);
     let model_specific_tensors = serialize_model_specific(intermediate.preprocessed.model_specific);
     let mm_placeholders = intermediate
         .patch_offsets
@@ -982,6 +992,7 @@ fn assemble_tokenspeed(intermediate: PrecomputedMultimodalIntermediate) -> Token
         modality,
         pixel_values,
         pixel_values_shape,
+        encoder_input_dtype,
         model_specific_tensors,
         placeholder_token_id: intermediate.placeholder_token_id,
         mm_placeholders,
@@ -1030,13 +1041,151 @@ fn serialize_pixel_values(preprocessed: &PreprocessedImages) -> (Vec<u8>, Vec<u3
             .flat_map(|v| v.to_le_bytes())
             .collect()
     };
-    let pixel_shape: Vec<u32> = preprocessed
+    (pixel_bytes, pixel_values_shape(preprocessed))
+}
+
+/// Serialize pixel values to the requested wire dtype.
+fn serialize_pixel_values_as_dtype(
+    preprocessed: &PreprocessedImages,
+    dtype: &str,
+) -> (Vec<u8>, Vec<u32>, String) {
+    match canonical_float_dtype(dtype).as_deref() {
+        Some("float32") => {
+            let (data, shape) = serialize_pixel_values(preprocessed);
+            (data, shape, "float32".to_string())
+        }
+        Some("bfloat16") => (
+            preprocessed
+                .pixel_values
+                .iter()
+                .flat_map(|value| f32_to_bf16_bits(*value).to_le_bytes())
+                .collect(),
+            pixel_values_shape(preprocessed),
+            "bfloat16".to_string(),
+        ),
+        Some("float16") => (
+            preprocessed
+                .pixel_values
+                .iter()
+                .flat_map(|value| f32_to_f16_bits(*value).to_le_bytes())
+                .collect(),
+            pixel_values_shape(preprocessed),
+            "float16".to_string(),
+        ),
+        _ => {
+            warn!(
+                dtype,
+                "Unsupported TokenSpeed encoder input dtype; falling back to float32"
+            );
+            let (data, shape) = serialize_pixel_values(preprocessed);
+            (data, shape, "float32".to_string())
+        }
+    }
+}
+
+fn tokenspeed_encoder_input_dtype(
+    modality: Modality,
+    workers: Option<&WorkerSelection>,
+) -> String {
+    if let Some(dtype) = tokenspeed_encoder_input_dtype_from_env(modality) {
+        return dtype;
+    }
+    if let Some(dtype) = tokenspeed_encoder_input_dtype_from_worker(workers) {
+        return dtype;
+    }
+    "float32".to_string()
+}
+
+fn tokenspeed_encoder_input_dtype_from_env(modality: Modality) -> Option<String> {
+    let modality_env = match modality {
+        Modality::Image | Modality::ImageEmbeds => "SMG_TOKENSPEED_IMAGE_ENCODER_INPUT_DTYPE",
+        Modality::Video => "SMG_TOKENSPEED_VIDEO_ENCODER_INPUT_DTYPE",
+        Modality::Audio => "SMG_TOKENSPEED_AUDIO_ENCODER_INPUT_DTYPE",
+    };
+    std::env::var(modality_env)
+        .or_else(|_| std::env::var("SMG_TOKENSPEED_ENCODER_INPUT_DTYPE"))
+        .ok()
+        .filter(|dtype| !dtype.is_empty())
+}
+
+fn tokenspeed_encoder_input_dtype_from_worker(workers: Option<&WorkerSelection>) -> Option<String> {
+    let worker = match workers? {
+        WorkerSelection::Single { worker } => worker,
+        WorkerSelection::Dual { prefill, .. } => prefill,
+    };
+    worker
+        .metadata()
+        .spec
+        .labels
+        .get("multimodal_encoder_dtype")
+        .filter(|dtype| !dtype.is_empty())
+        .cloned()
+}
+
+fn canonical_float_dtype(dtype: &str) -> Option<String> {
+    match dtype.trim().to_ascii_lowercase().as_str() {
+        "float32" | "fp32" | "f32" => Some("float32".to_string()),
+        "bfloat16" | "bf16" => Some("bfloat16".to_string()),
+        "float16" | "fp16" | "f16" | "half" => Some("float16".to_string()),
+        _ => None,
+    }
+}
+
+fn pixel_values_shape(preprocessed: &PreprocessedImages) -> Vec<u32> {
+    preprocessed
         .pixel_values
         .shape()
         .iter()
         .map(|&d| d as u32)
-        .collect();
-    (pixel_bytes, pixel_shape)
+        .collect()
+}
+
+fn f32_to_bf16_bits(value: f32) -> u16 {
+    let bits = value.to_bits();
+    let lsb = (bits >> 16) & 1;
+    let rounding_bias = 0x7fff + lsb;
+    (bits.wrapping_add(rounding_bias) >> 16) as u16
+}
+
+fn f32_to_f16_bits(value: f32) -> u16 {
+    let bits = value.to_bits();
+    let sign = ((bits >> 16) & 0x8000) as u16;
+    let exp = ((bits >> 23) & 0xff) as i32;
+    let mant = bits & 0x7fffff;
+
+    if exp == 0xff {
+        return if mant == 0 {
+            sign | 0x7c00
+        } else {
+            sign | 0x7e00
+        };
+    }
+
+    let half_exp = exp - 127 + 15;
+    if half_exp >= 0x1f {
+        return sign | 0x7c00;
+    }
+    if half_exp <= 0 {
+        if half_exp < -10 {
+            return sign;
+        }
+        let mantissa = mant | 0x800000;
+        let shift = (14 - half_exp) as u32;
+        let mut half_mant = (mantissa >> shift) as u16;
+        let round_bit = (mantissa >> (shift - 1)) & 1;
+        let sticky = mantissa & ((1u32 << (shift - 1)) - 1);
+        if round_bit != 0 && (sticky != 0 || (half_mant & 1) != 0) {
+            half_mant += 1;
+        }
+        return sign | half_mant;
+    }
+
+    let mut half = sign | ((half_exp as u16) << 10) | ((mant >> 13) as u16);
+    let round = mant & 0x1fff;
+    if round > 0x1000 || (round == 0x1000 && (half & 1) != 0) {
+        half += 1;
+    }
+    half
 }
 
 /// Serialize model-specific values to TensorBytes, consuming the map to avoid key clones.

--- a/model_gateway/src/routers/grpc/multimodal.rs
+++ b/model_gateway/src/routers/grpc/multimodal.rs
@@ -991,7 +991,7 @@ fn assemble_tokenspeed(
         Modality::ImageEmbeds => TokenSpeedModality::Image,
     };
 
-    let item_count = tokenspeed_item_count(&intermediate)?;
+    let item_count = precomputed_multimodal_item_count(&intermediate)?;
     let items = (0..item_count)
         .map(|item_index| {
             let item_encoder_input = encoder_input_for_item(
@@ -1027,7 +1027,9 @@ fn assemble_tokenspeed(
     Ok(TokenSpeedMultimodalData { items })
 }
 
-fn tokenspeed_item_count(intermediate: &PrecomputedMultimodalIntermediate) -> Result<usize> {
+fn precomputed_multimodal_item_count(
+    intermediate: &PrecomputedMultimodalIntermediate,
+) -> Result<usize> {
     let media_count = match intermediate.modality {
         Modality::Image | Modality::ImageEmbeds => intermediate.images.len(),
         Modality::Video => intermediate.videos.len(),
@@ -1038,23 +1040,23 @@ fn tokenspeed_item_count(intermediate: &PrecomputedMultimodalIntermediate) -> Re
     let item_count = token_count.max(media_count).max(placeholder_count);
     anyhow::ensure!(
         item_count > 0,
-        "TokenSpeed multimodal assembly requires at least one item"
+        "precomputed multimodal assembly requires at least one item"
     );
     if media_count > 0 {
         anyhow::ensure!(
             media_count == item_count,
-            "TokenSpeed multimodal assembly media count mismatch: modality={}, media_count={media_count}, item_count={item_count}",
+            "precomputed multimodal assembly media count mismatch: modality={}, media_count={media_count}, item_count={item_count}",
             intermediate.modality
         );
     }
     anyhow::ensure!(
         token_count == item_count,
-        "TokenSpeed multimodal assembly token count mismatch: modality={}, token_count={token_count}, item_count={item_count}",
+        "precomputed multimodal assembly token count mismatch: modality={}, token_count={token_count}, item_count={item_count}",
         intermediate.modality
     );
     anyhow::ensure!(
         placeholder_count == item_count,
-        "TokenSpeed multimodal assembly placeholder count mismatch: modality={}, placeholder_count={placeholder_count}, item_count={item_count}",
+        "precomputed multimodal assembly placeholder count mismatch: modality={}, placeholder_count={placeholder_count}, item_count={item_count}",
         intermediate.modality
     );
     Ok(item_count)
@@ -1089,12 +1091,14 @@ fn serialize_model_specific_for_item(
     let mut serialized = HashMap::with_capacity(model_specific.len());
     for (key, value) in model_specific {
         let item_value = match field_layouts.get(key) {
-            Some(FieldLayout::Batched) => slice_model_specific_first_dim(value, item_index, 1)
+            Some(FieldLayout::Batched) => value
+                .slice_first_dim(item_index, 1)
                 .with_context(|| format!("failed to slice model_specific tensor {key}"))?,
             Some(FieldLayout::Flat { sizes_key }) => {
                 let sizes = tensor_sizes_from_model_specific(model_specific, sizes_key)?;
                 let (start, len) = item_span(&sizes, item_index)?;
-                slice_model_specific_first_dim(value, start, len)
+                value
+                    .slice_first_dim(start, len)
                     .with_context(|| format!("failed to slice flat model_specific tensor {key}"))?
             }
             None => value.clone(),
@@ -1171,23 +1175,9 @@ fn tensor_sizes_from_model_specific(
     let value = model_specific
         .get(key)
         .ok_or_else(|| anyhow::anyhow!("missing flat sizes tensor {key}"))?;
-    match value {
-        ModelSpecificValue::IntTensor { data, .. } => data
-            .iter()
-            .map(|&v| usize::try_from(v).context("negative flat size"))
-            .collect(),
-        ModelSpecificValue::UintTensor { data, .. } => {
-            Ok(data.iter().map(|&v| v as usize).collect())
-        }
-        ModelSpecificValue::IntVec(values) => values
-            .iter()
-            .map(|&v| usize::try_from(v).context("negative flat size"))
-            .collect(),
-        ModelSpecificValue::UintVec(values) => Ok(values.iter().map(|&v| v as usize).collect()),
-        _ => Err(anyhow::anyhow!(
-            "flat sizes tensor {key} has unsupported value type"
-        )),
-    }
+    value
+        .as_flat_sizes()
+        .with_context(|| format!("invalid flat sizes tensor {key}"))
 }
 
 fn item_span(sizes: &[usize], item_index: usize) -> Result<(usize, usize)> {
@@ -1199,88 +1189,6 @@ fn item_span(sizes: &[usize], item_index: usize) -> Result<(usize, usize)> {
         .try_fold(0usize, |acc, &size| acc.checked_add(size))
         .ok_or_else(|| anyhow::anyhow!("flat size offset overflow"))?;
     Ok((start, len))
-}
-
-fn slice_model_specific_first_dim(
-    value: &ModelSpecificValue,
-    start: usize,
-    len: usize,
-) -> Result<ModelSpecificValue> {
-    match value {
-        ModelSpecificValue::Tensor { data, shape } => {
-            let (data, shape) = slice_first_dim(data, shape, start, len)?;
-            Ok(ModelSpecificValue::Tensor { data, shape })
-        }
-        ModelSpecificValue::IntTensor { data, shape } => {
-            let (data, shape) = slice_first_dim(data, shape, start, len)?;
-            Ok(ModelSpecificValue::IntTensor { data, shape })
-        }
-        ModelSpecificValue::UintTensor { data, shape } => {
-            let (data, shape) = slice_first_dim(data, shape, start, len)?;
-            Ok(ModelSpecificValue::UintTensor { data, shape })
-        }
-        ModelSpecificValue::IntVec(values) => Ok(ModelSpecificValue::IntVec(
-            slice_1d(values, start, len)?.to_vec(),
-        )),
-        ModelSpecificValue::UintVec(values) => Ok(ModelSpecificValue::UintVec(
-            slice_1d(values, start, len)?.to_vec(),
-        )),
-        ModelSpecificValue::FloatVec(values) => Ok(ModelSpecificValue::FloatVec(
-            slice_1d(values, start, len)?.to_vec(),
-        )),
-        ModelSpecificValue::TupleVec(values) => Ok(ModelSpecificValue::TupleVec(
-            slice_1d(values, start, len)?.to_vec(),
-        )),
-        _ => Ok(value.clone()),
-    }
-}
-
-fn slice_first_dim<T: Clone>(
-    data: &[T],
-    shape: &[usize],
-    start: usize,
-    len: usize,
-) -> Result<(Vec<T>, Vec<usize>)> {
-    let first_dim = *shape
-        .first()
-        .ok_or_else(|| anyhow::anyhow!("cannot slice scalar tensor"))?;
-    let end = start
-        .checked_add(len)
-        .ok_or_else(|| anyhow::anyhow!("tensor slice range overflow"))?;
-    anyhow::ensure!(
-        end <= first_dim,
-        "tensor first-dimension slice {start}..{end} exceeds {first_dim}"
-    );
-    let row_width = shape[1..]
-        .iter()
-        .try_fold(1usize, |acc, &dim| acc.checked_mul(dim))
-        .ok_or_else(|| anyhow::anyhow!("tensor row width overflow"))?;
-    let data_start = start
-        .checked_mul(row_width)
-        .ok_or_else(|| anyhow::anyhow!("tensor data start overflow"))?;
-    let data_len = len
-        .checked_mul(row_width)
-        .ok_or_else(|| anyhow::anyhow!("tensor data length overflow"))?;
-    let data_end = data_start
-        .checked_add(data_len)
-        .ok_or_else(|| anyhow::anyhow!("tensor data end overflow"))?;
-    anyhow::ensure!(
-        data_end <= data.len(),
-        "tensor slice data range {data_start}..{data_end} exceeds {}",
-        data.len()
-    );
-    let mut new_shape = shape.to_vec();
-    new_shape[0] = len;
-    Ok((data[data_start..data_end].to_vec(), new_shape))
-}
-
-fn slice_1d<T>(values: &[T], start: usize, len: usize) -> Result<&[T]> {
-    let end = start
-        .checked_add(len)
-        .ok_or_else(|| anyhow::anyhow!("slice range overflow"))?;
-    values
-        .get(start..end)
-        .ok_or_else(|| anyhow::anyhow!("slice range {start}..{end} exceeds {}", values.len()))
 }
 
 fn hash_hex_strings<'a>(hashes: impl Iterator<Item = &'a str>) -> Vec<u8> {

--- a/model_gateway/src/routers/grpc/multimodal.rs
+++ b/model_gateway/src/routers/grpc/multimodal.rs
@@ -1517,6 +1517,36 @@ mod tests {
         assert!(reg.get("tok-uuid-nopp").is_some());
     }
 
+    #[test]
+    fn load_video_preprocessor_config_ignores_missing_video_processor_key() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("processor_config.json"),
+            r#"{"image_processor":{"image_processor_type":"Qwen3VLImageProcessor"}}"#,
+        )
+        .unwrap();
+
+        assert!(load_video_preprocessor_config(tmp.path()).is_none());
+    }
+
+    #[test]
+    fn load_video_preprocessor_config_reads_video_processor_key() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("processor_config.json"),
+            r#"{"video_processor":{"image_processor_type":"Qwen3VLVideoProcessor","do_resize":true}}"#,
+        )
+        .unwrap();
+
+        let config =
+            load_video_preprocessor_config(tmp.path()).expect("video_processor should parse");
+        assert_eq!(
+            config.image_processor_type.as_deref(),
+            Some("Qwen3VLVideoProcessor")
+        );
+        assert_eq!(config.do_resize, Some(true));
+    }
+
     #[tokio::test]
     async fn registry_remove_drops_cached_entry() {
         let reg = MultimodalConfigRegistry::new();

--- a/model_gateway/src/routers/grpc/multimodal.rs
+++ b/model_gateway/src/routers/grpc/multimodal.rs
@@ -1850,6 +1850,112 @@ mod tests {
         );
     }
 
+    #[test]
+    fn assemble_tokenspeed_splits_video_items() {
+        let mut model_specific = HashMap::new();
+        model_specific.insert(
+            "patches_per_video".to_string(),
+            ModelSpecificValue::UintTensor {
+                data: vec![2, 2],
+                shape: vec![2],
+            },
+        );
+        model_specific.insert(
+            "video_grid_thw".to_string(),
+            ModelSpecificValue::UintTensor {
+                data: vec![1, 2, 3, 4, 5, 6],
+                shape: vec![2, 3],
+            },
+        );
+
+        let preprocessed = PreprocessedEncoderInputs {
+            encoder_input: ArrayD::from_shape_vec(
+                IxDyn(&[4, 2]),
+                vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
+            )
+            .unwrap(),
+            feature_token_counts: vec![2, 2],
+            item_sizes: vec![(1, 1), (1, 1)],
+            model_specific,
+        };
+
+        let videos = vec![
+            Arc::new(VideoClip::new(
+                vec![image::DynamicImage::new_rgb8(1, 1)],
+                bytes::Bytes::from_static(b"a"),
+                llm_multimodal::VideoSource::InlineBytes,
+                "video-hash-a".to_string(),
+            )),
+            Arc::new(VideoClip::new(
+                vec![image::DynamicImage::new_rgb8(1, 1)],
+                bytes::Bytes::from_static(b"b"),
+                llm_multimodal::VideoSource::InlineBytes,
+                "video-hash-b".to_string(),
+            )),
+        ];
+
+        let intermediate = PrecomputedMultimodalIntermediate {
+            modality: Modality::Video,
+            preprocessed,
+            images: vec![],
+            videos,
+            placeholders: vec![
+                PlaceholderRange {
+                    offset: 30,
+                    length: 2,
+                },
+                PlaceholderRange {
+                    offset: 40,
+                    length: 2,
+                },
+            ],
+            patch_offsets: Some(vec![(30, 2), (40, 2)]),
+            placeholder_token_id: Some(151656),
+            field_layouts: HashMap::from([
+                (
+                    "pixel_values".to_string(),
+                    FieldLayout::flat("patches_per_video"),
+                ),
+                ("patches_per_video".to_string(), FieldLayout::Batched),
+                ("video_grid_thw".to_string(), FieldLayout::Batched),
+            ]),
+            keep_on_cpu_keys: vec![],
+        };
+
+        let assembled = assemble_tokenspeed(intermediate, None).unwrap();
+        assert_eq!(assembled.items.len(), 2);
+
+        let first = &assembled.items[0];
+        assert_eq!(first.modality, TokenSpeedModality::Video);
+        assert_eq!(first.encoder_input_shape, vec![2, 2]);
+        assert_eq!(first.encoder_input.len(), 4 * size_of::<f32>());
+        assert_eq!(first.mm_placeholders, vec![(30, 2)]);
+        assert_eq!(
+            first.content_hash,
+            hash_hex_strings(std::iter::once("video-hash-a"))
+        );
+        assert_eq!(
+            first.model_specific_tensors["video_grid_thw"].shape,
+            vec![1, 3]
+        );
+        assert_eq!(
+            first.model_specific_tensors["patches_per_video"].shape,
+            vec![1]
+        );
+
+        let second = &assembled.items[1];
+        assert_eq!(second.encoder_input_shape, vec![2, 2]);
+        assert_eq!(second.mm_placeholders, vec![(40, 2)]);
+        assert_eq!(
+            second.content_hash,
+            hash_hex_strings(std::iter::once("video-hash-b"))
+        );
+        assert_eq!(
+            second.model_specific_tensors["video_grid_thw"].shape,
+            vec![1, 3]
+        );
+    }
+
     // ------------------------------------------------------------------
     // MultimodalConfigRegistry tests
     // ------------------------------------------------------------------

--- a/model_gateway/src/routers/grpc/multimodal.rs
+++ b/model_gateway/src/routers/grpc/multimodal.rs
@@ -18,12 +18,13 @@ use std::{
 use anyhow::{Context, Result};
 use dashmap::DashMap;
 use llm_multimodal::{
-    AsyncMultiModalTracker, FieldLayout, ImageDetail, ImageFrame, ImageProcessorRegistry,
-    MediaConnector, MediaConnectorConfig, MediaContentPart, Modality, ModelMetadata, ModelRegistry,
-    ModelSpecificValue, PlaceholderRange, PreProcessorConfig, PreprocessedImages,
-    PromptReplacement, TrackedMedia, TrackerOutput, VideoClip,
+    AsyncMultiModalTracker, FieldLayout, ImageDetail, ImageFrame, MediaConnector,
+    MediaConnectorConfig, MediaContentPart, Modality, ModelMetadata, ModelRegistry,
+    ModelSpecificValue, PlaceholderRange, PreProcessorConfig, PreprocessedEncoderInputs,
+    PromptReplacement, TrackedMedia, TrackerOutput, VideoClip, VisionProcessorRegistry,
 };
 use llm_tokenizer::TokenizerTrait;
+use ndarray::{ArrayD, Axis, Slice};
 use openai_protocol::{
     chat::{ChatMessage, MessageContent},
     common::ContentPart,
@@ -36,7 +37,7 @@ use crate::routers::grpc::{
     context::WorkerSelection,
     proto_wrapper::{
         SglangMultimodalData, TensorBytes, TokenSpeedModality, TokenSpeedMultimodalData,
-        TrtllmMultimodalData, VllmMultimodalData,
+        TokenSpeedMultimodalItem, TrtllmMultimodalData, VllmMultimodalData,
     },
     MultimodalData,
 };
@@ -117,7 +118,7 @@ impl MultimodalConfigRegistry {
                 })
             })?;
 
-        // preprocessor_config.json is optional — each image processor supplies
+        // preprocessor_config.json is optional — each vision processor supplies
         // its own model-specific defaults, so missing/unparsable files fall
         // back to `PreProcessorConfig::default()`. This matches the bundle
         // preload path in `try_load_multimodal_config`.
@@ -211,9 +212,7 @@ pub(crate) fn load_video_preprocessor_config(base_dir: &Path) -> Option<PreProce
         }
     };
 
-    let Some(video_processor) = processor_config.get("video_processor") else {
-        return None;
-    };
+    let video_processor = processor_config.get("video_processor")?;
     match PreProcessorConfig::from_value(video_processor.clone()) {
         Ok(config) => Some(config),
         Err(error) => {
@@ -230,7 +229,7 @@ pub(crate) fn load_video_preprocessor_config(base_dir: &Path) -> Option<PreProce
 /// Shared multimodal components injected at router creation time.
 pub(crate) struct MultimodalComponents {
     pub media_connector: Arc<MediaConnector>,
-    pub image_processor_registry: Arc<ImageProcessorRegistry>,
+    pub vision_processor_registry: Arc<VisionProcessorRegistry>,
     pub model_registry: Arc<ModelRegistry>,
     /// Shared reference to the app-level multimodal config cache.
     pub config_registry: Arc<MultimodalConfigRegistry>,
@@ -249,7 +248,7 @@ impl MultimodalComponents {
 
         Ok(Self {
             media_connector: Arc::new(media_connector),
-            image_processor_registry: Arc::new(ImageProcessorRegistry::with_defaults()),
+            vision_processor_registry: Arc::new(VisionProcessorRegistry::with_defaults()),
             model_registry: Arc::new(ModelRegistry::default()),
             config_registry,
         })
@@ -258,7 +257,7 @@ impl MultimodalComponents {
 
 /// Output of the multimodal processing pipeline.
 pub(crate) struct MultimodalOutput {
-    /// Token IDs with placeholder tokens expanded to the correct count per image.
+    /// Token IDs with placeholder tokens expanded to the correct count per media item.
     pub expanded_token_ids: Vec<u32>,
     /// Lightweight intermediate holding preprocessing results.
     /// Assembled into backend-specific `MultimodalData` in request_building.
@@ -279,8 +278,8 @@ pub(crate) enum MultimodalIntermediate {
 pub(crate) struct PrecomputedMultimodalIntermediate {
     /// Active modality for this preprocessed payload.
     pub modality: Modality,
-    /// Preprocessed pixel values and model-specific tensors (not yet serialized).
-    pub preprocessed: PreprocessedImages,
+    /// Preprocessed encoder input and model-specific tensors (not yet serialized).
+    pub preprocessed: PreprocessedEncoderInputs,
     /// Raw image frames (bytes + blake3 hashes).
     pub images: Vec<Arc<ImageFrame>>,
     /// Raw video clips (bytes + blake3 hashes + sampled frames).
@@ -613,7 +612,7 @@ async fn process_multimodal_parts(
         Modality::Image => {
             debug!(
                 image_count = images.len(),
-                image_sizes = ?images.iter().map(|f| (f.image.width(), f.image.height())).collect::<Vec<_>>(),
+                item_sizes = ?images.iter().map(|f| (f.image.width(), f.image.height())).collect::<Vec<_>>(),
                 "Fetched images for multimodal processing"
             );
         }
@@ -646,7 +645,7 @@ async fn process_multimodal_parts(
         .lookup(&metadata)
         .ok_or_else(|| anyhow::anyhow!("Multimodal not supported for model: {model_id}"))?;
 
-    // Run CPU-intensive image preprocessing on a blocking thread pool so it
+    // Run CPU-intensive vision preprocessing on a blocking thread pool so it
     // doesn't block the tokio async runtime under concurrent load.
     // TODO: consider making the thread pool size configurable.
     let pp_config = match modality {
@@ -656,17 +655,17 @@ async fn process_multimodal_parts(
             .unwrap_or_else(|| model_config.preprocessor_config.clone()),
         _ => model_config.preprocessor_config.clone(),
     };
-    let registry = components.image_processor_registry.clone();
+    let registry = components.vision_processor_registry.clone();
     let model_id_owned = model_id.to_string();
     let model_type_owned = model_type.map(String::from);
     let images_for_preprocess = images.clone(); // cheap Arc refcount bumps
     let videos_for_preprocess = videos.clone(); // cheap Arc refcount bumps
 
-    let preprocessed: PreprocessedImages = tokio::task::spawn_blocking(move || {
+    let preprocessed: PreprocessedEncoderInputs = tokio::task::spawn_blocking(move || {
         let processor = registry
             .find(&model_id_owned, model_type_owned.as_deref())
             .ok_or_else(|| {
-                anyhow::anyhow!("No image processor found for model: {model_id_owned}")
+                anyhow::anyhow!("No vision processor found for model: {model_id_owned}")
             })?;
 
         match modality {
@@ -699,8 +698,8 @@ async fn process_multimodal_parts(
 
     debug!(
         ?modality,
-        item_count = preprocessed.num_img_tokens.len(),
-        total_tokens = preprocessed.num_img_tokens.iter().sum::<usize>(),
+        item_count = preprocessed.feature_token_counts.len(),
+        total_tokens = preprocessed.feature_token_counts.iter().sum::<usize>(),
         "Multimodal preprocessing complete"
     );
 
@@ -885,12 +884,10 @@ pub(crate) fn assemble_multimodal_data(
                 ensure_image_only(&precomputed, "TRT-LLM")?;
                 Ok(MultimodalData::Trtllm(assemble_trtllm(precomputed)))
             }
-            GrpcClient::TokenSpeed(_) => {
-                Ok(MultimodalData::TokenSpeed(assemble_tokenspeed(
-                    precomputed,
-                    workers,
-                )))
-            }
+            GrpcClient::TokenSpeed(_) => Ok(MultimodalData::TokenSpeed(assemble_tokenspeed(
+                precomputed,
+                workers,
+            )?)),
             GrpcClient::Mlx(_) => unreachable!(
                 "caller rejects multimodal for MLX in build_chat_request/build_messages_request"
             ),
@@ -898,7 +895,10 @@ pub(crate) fn assemble_multimodal_data(
     }
 }
 
-fn ensure_image_only(intermediate: &PrecomputedMultimodalIntermediate, backend: &str) -> Result<()> {
+fn ensure_image_only(
+    intermediate: &PrecomputedMultimodalIntermediate,
+    backend: &str,
+) -> Result<()> {
     if intermediate.modality != Modality::Image {
         return Err(anyhow::anyhow!(
             "{backend} multimodal path currently supports image inputs only; got {}",
@@ -909,7 +909,7 @@ fn ensure_image_only(intermediate: &PrecomputedMultimodalIntermediate, backend: 
 }
 
 fn assemble_sglang(intermediate: PrecomputedMultimodalIntermediate) -> SglangMultimodalData {
-    let (pixel_values, pixel_values_shape) = serialize_pixel_values(&intermediate.preprocessed);
+    let (pixel_values, pixel_values_shape) = serialize_encoder_input(&intermediate.preprocessed);
     let model_specific_tensors = serialize_model_specific(intermediate.preprocessed.model_specific);
     let image_data = intermediate
         .images
@@ -939,7 +939,7 @@ fn assemble_sglang(intermediate: PrecomputedMultimodalIntermediate) -> SglangMul
 }
 
 fn assemble_vllm(intermediate: PrecomputedMultimodalIntermediate) -> VllmMultimodalData {
-    let (pixel_values, pixel_values_shape) = serialize_pixel_values(&intermediate.preprocessed);
+    let (pixel_values, pixel_values_shape) = serialize_encoder_input(&intermediate.preprocessed);
     let model_specific_tensors = serialize_model_specific(intermediate.preprocessed.model_specific);
     let mm_hashes = intermediate.images.iter().map(|f| f.hash.clone()).collect();
     let mm_placeholders = intermediate
@@ -947,8 +947,8 @@ fn assemble_vllm(intermediate: PrecomputedMultimodalIntermediate) -> VllmMultimo
         .iter()
         .map(|p| (p.offset as u32, p.length as u32))
         .collect();
-    let batched_keys = PreprocessedImages::batched_keys(&intermediate.field_layouts);
-    let flat_keys = PreprocessedImages::flat_keys(&intermediate.field_layouts);
+    let batched_keys = PreprocessedEncoderInputs::batched_keys(&intermediate.field_layouts);
+    let flat_keys = PreprocessedEncoderInputs::flat_keys(&intermediate.field_layouts);
 
     VllmMultimodalData {
         pixel_values,
@@ -975,22 +975,14 @@ fn assemble_trtllm(intermediate: PrecomputedMultimodalIntermediate) -> TrtllmMul
 fn assemble_tokenspeed(
     intermediate: PrecomputedMultimodalIntermediate,
     workers: Option<&WorkerSelection>,
-) -> TokenSpeedMultimodalData {
+) -> Result<TokenSpeedMultimodalData> {
     // Use patch-only offsets when available and non-empty; fall back to full structural ranges.
     let encoder_input_dtype = tokenspeed_encoder_input_dtype(intermediate.modality, workers);
-    let (pixel_values, pixel_values_shape, encoder_input_dtype) =
-        serialize_pixel_values_as_dtype(&intermediate.preprocessed, &encoder_input_dtype);
-    let model_specific_tensors = serialize_model_specific(intermediate.preprocessed.model_specific);
-    let mm_placeholders = intermediate
+    let patch_offsets = intermediate
         .patch_offsets
+        .clone()
         .filter(|offsets| !offsets.is_empty())
-        .unwrap_or_else(|| {
-            intermediate
-                .placeholders
-                .iter()
-                .map(|p| (p.offset as u32, p.length as u32))
-                .collect()
-        });
+        .unwrap_or_default();
 
     let modality = match intermediate.modality {
         Modality::Image => TokenSpeedModality::Image,
@@ -998,22 +990,297 @@ fn assemble_tokenspeed(
         Modality::Audio => TokenSpeedModality::Audio,
         Modality::ImageEmbeds => TokenSpeedModality::Image,
     };
-    let content_hash = match intermediate.modality {
-        Modality::Image => hash_hex_strings(intermediate.images.iter().map(|f| f.hash.as_str())),
-        Modality::Video => hash_hex_strings(intermediate.videos.iter().map(|v| v.hash.as_str())),
-        _ => Vec::new(),
-    };
 
-    TokenSpeedMultimodalData {
-        modality,
-        pixel_values,
-        pixel_values_shape,
-        encoder_input_dtype,
-        model_specific_tensors,
-        placeholder_token_id: intermediate.placeholder_token_id,
-        mm_placeholders,
-        content_hash,
+    let item_count = tokenspeed_item_count(&intermediate)?;
+    let items = (0..item_count)
+        .map(|item_index| {
+            let item_encoder_input = encoder_input_for_item(
+                &intermediate.preprocessed,
+                &intermediate.field_layouts,
+                item_index,
+            )?;
+            let (encoder_input, encoder_input_shape, encoder_input_dtype) =
+                serialize_array_as_dtype(&item_encoder_input, &encoder_input_dtype);
+            let model_specific_tensors = serialize_model_specific_for_item(
+                &intermediate.preprocessed.model_specific,
+                &intermediate.field_layouts,
+                item_index,
+            )?;
+            let mm_placeholders =
+                placeholders_for_item(item_index, &intermediate.placeholders, &patch_offsets);
+            let content_hash =
+                content_hash_for_item(intermediate.modality, &intermediate, item_index);
+
+            Ok(TokenSpeedMultimodalItem {
+                modality,
+                encoder_input,
+                encoder_input_shape,
+                encoder_input_dtype,
+                model_specific_tensors,
+                placeholder_token_id: intermediate.placeholder_token_id,
+                mm_placeholders,
+                content_hash,
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    Ok(TokenSpeedMultimodalData { items })
+}
+
+fn tokenspeed_item_count(intermediate: &PrecomputedMultimodalIntermediate) -> Result<usize> {
+    let media_count = match intermediate.modality {
+        Modality::Image | Modality::ImageEmbeds => intermediate.images.len(),
+        Modality::Video => intermediate.videos.len(),
+        Modality::Audio => 0,
+    };
+    let token_count = intermediate.preprocessed.feature_token_counts.len();
+    let placeholder_count = intermediate.placeholders.len();
+    let item_count = token_count.max(media_count).max(placeholder_count);
+    anyhow::ensure!(
+        item_count > 0,
+        "TokenSpeed multimodal assembly requires at least one item"
+    );
+    if media_count > 0 {
+        anyhow::ensure!(
+            media_count == item_count,
+            "TokenSpeed multimodal assembly media count mismatch: modality={}, media_count={media_count}, item_count={item_count}",
+            intermediate.modality
+        );
     }
+    anyhow::ensure!(
+        token_count == item_count,
+        "TokenSpeed multimodal assembly token count mismatch: modality={}, token_count={token_count}, item_count={item_count}",
+        intermediate.modality
+    );
+    anyhow::ensure!(
+        placeholder_count == item_count,
+        "TokenSpeed multimodal assembly placeholder count mismatch: modality={}, placeholder_count={placeholder_count}, item_count={item_count}",
+        intermediate.modality
+    );
+    Ok(item_count)
+}
+
+fn encoder_input_for_item(
+    preprocessed: &PreprocessedEncoderInputs,
+    field_layouts: &HashMap<String, FieldLayout>,
+    item_index: usize,
+) -> Result<ArrayD<f32>> {
+    // The field layout key remains "pixel_values" because it mirrors the
+    // HuggingFace/vLLM vision kwargs contract. Internally this tensor is the
+    // modality encoder input we pass to TokenSpeed.
+    let layout = field_layouts
+        .get("pixel_values")
+        .unwrap_or(&FieldLayout::Batched);
+    match layout {
+        FieldLayout::Batched => slice_array_axis0(&preprocessed.encoder_input, item_index, 1),
+        FieldLayout::Flat { sizes_key } => {
+            let sizes = tensor_sizes_from_model_specific(&preprocessed.model_specific, sizes_key)?;
+            let (start, len) = item_span(&sizes, item_index)?;
+            slice_array_axis0(&preprocessed.encoder_input, start, len)
+        }
+    }
+}
+
+fn serialize_model_specific_for_item(
+    model_specific: &HashMap<String, ModelSpecificValue>,
+    field_layouts: &HashMap<String, FieldLayout>,
+    item_index: usize,
+) -> Result<HashMap<String, TensorBytes>> {
+    let mut serialized = HashMap::with_capacity(model_specific.len());
+    for (key, value) in model_specific {
+        let item_value = match field_layouts.get(key) {
+            Some(FieldLayout::Batched) => slice_model_specific_first_dim(value, item_index, 1)
+                .with_context(|| format!("failed to slice model_specific tensor {key}"))?,
+            Some(FieldLayout::Flat { sizes_key }) => {
+                let sizes = tensor_sizes_from_model_specific(model_specific, sizes_key)?;
+                let (start, len) = item_span(&sizes, item_index)?;
+                slice_model_specific_first_dim(value, start, len)
+                    .with_context(|| format!("failed to slice flat model_specific tensor {key}"))?
+            }
+            None => value.clone(),
+        };
+        if let Some(tensor) = model_specific_to_tensor_bytes(&item_value) {
+            serialized.insert(key.clone(), tensor);
+        } else {
+            warn!(tensor_key = %key, "Dropping unsupported model_specific value during multimodal serialization");
+        }
+    }
+    Ok(serialized)
+}
+
+fn placeholders_for_item(
+    item_index: usize,
+    placeholders: &[PlaceholderRange],
+    patch_offsets: &[(u32, u32)],
+) -> Vec<(u32, u32)> {
+    let Some(placeholder) = placeholders.get(item_index) else {
+        return Vec::new();
+    };
+    let start = placeholder.offset as u32;
+    let end = start + placeholder.length as u32;
+    let item_patch_offsets = patch_offsets
+        .iter()
+        .copied()
+        .filter(|(offset, length)| *offset >= start && offset.saturating_add(*length) <= end)
+        .collect::<Vec<_>>();
+    if item_patch_offsets.is_empty() {
+        vec![(start, end - start)]
+    } else {
+        item_patch_offsets
+    }
+}
+
+fn content_hash_for_item(
+    modality: Modality,
+    intermediate: &PrecomputedMultimodalIntermediate,
+    item_index: usize,
+) -> Vec<u8> {
+    match modality {
+        Modality::Image | Modality::ImageEmbeds => intermediate
+            .images
+            .get(item_index)
+            .map(|image| hash_hex_strings(std::iter::once(image.hash.as_str())))
+            .unwrap_or_default(),
+        Modality::Video => intermediate
+            .videos
+            .get(item_index)
+            .map(|video| hash_hex_strings(std::iter::once(video.hash.as_str())))
+            .unwrap_or_default(),
+        Modality::Audio => Vec::new(),
+    }
+}
+
+fn slice_array_axis0(array: &ArrayD<f32>, start: usize, len: usize) -> Result<ArrayD<f32>> {
+    let end = start
+        .checked_add(len)
+        .ok_or_else(|| anyhow::anyhow!("array slice range overflow"))?;
+    let rows = array.shape().first().copied().unwrap_or(0);
+    anyhow::ensure!(
+        end <= rows,
+        "array first-dimension slice {start}..{end} exceeds {rows}"
+    );
+    Ok(array
+        .slice_axis(Axis(0), Slice::from(start..end))
+        .to_owned())
+}
+
+fn tensor_sizes_from_model_specific(
+    model_specific: &HashMap<String, ModelSpecificValue>,
+    key: &str,
+) -> Result<Vec<usize>> {
+    let value = model_specific
+        .get(key)
+        .ok_or_else(|| anyhow::anyhow!("missing flat sizes tensor {key}"))?;
+    match value {
+        ModelSpecificValue::IntTensor { data, .. } => data
+            .iter()
+            .map(|&v| usize::try_from(v).context("negative flat size"))
+            .collect(),
+        ModelSpecificValue::UintTensor { data, .. } => {
+            Ok(data.iter().map(|&v| v as usize).collect())
+        }
+        ModelSpecificValue::IntVec(values) => values
+            .iter()
+            .map(|&v| usize::try_from(v).context("negative flat size"))
+            .collect(),
+        ModelSpecificValue::UintVec(values) => Ok(values.iter().map(|&v| v as usize).collect()),
+        _ => Err(anyhow::anyhow!(
+            "flat sizes tensor {key} has unsupported value type"
+        )),
+    }
+}
+
+fn item_span(sizes: &[usize], item_index: usize) -> Result<(usize, usize)> {
+    let len = *sizes
+        .get(item_index)
+        .ok_or_else(|| anyhow::anyhow!("missing flat size for item {item_index}"))?;
+    let start = sizes[..item_index]
+        .iter()
+        .try_fold(0usize, |acc, &size| acc.checked_add(size))
+        .ok_or_else(|| anyhow::anyhow!("flat size offset overflow"))?;
+    Ok((start, len))
+}
+
+fn slice_model_specific_first_dim(
+    value: &ModelSpecificValue,
+    start: usize,
+    len: usize,
+) -> Result<ModelSpecificValue> {
+    match value {
+        ModelSpecificValue::Tensor { data, shape } => {
+            let (data, shape) = slice_first_dim(data, shape, start, len)?;
+            Ok(ModelSpecificValue::Tensor { data, shape })
+        }
+        ModelSpecificValue::IntTensor { data, shape } => {
+            let (data, shape) = slice_first_dim(data, shape, start, len)?;
+            Ok(ModelSpecificValue::IntTensor { data, shape })
+        }
+        ModelSpecificValue::UintTensor { data, shape } => {
+            let (data, shape) = slice_first_dim(data, shape, start, len)?;
+            Ok(ModelSpecificValue::UintTensor { data, shape })
+        }
+        ModelSpecificValue::IntVec(values) => Ok(ModelSpecificValue::IntVec(
+            slice_1d(values, start, len)?.to_vec(),
+        )),
+        ModelSpecificValue::UintVec(values) => Ok(ModelSpecificValue::UintVec(
+            slice_1d(values, start, len)?.to_vec(),
+        )),
+        ModelSpecificValue::FloatVec(values) => Ok(ModelSpecificValue::FloatVec(
+            slice_1d(values, start, len)?.to_vec(),
+        )),
+        ModelSpecificValue::TupleVec(values) => Ok(ModelSpecificValue::TupleVec(
+            slice_1d(values, start, len)?.to_vec(),
+        )),
+        _ => Ok(value.clone()),
+    }
+}
+
+fn slice_first_dim<T: Clone>(
+    data: &[T],
+    shape: &[usize],
+    start: usize,
+    len: usize,
+) -> Result<(Vec<T>, Vec<usize>)> {
+    let first_dim = *shape
+        .first()
+        .ok_or_else(|| anyhow::anyhow!("cannot slice scalar tensor"))?;
+    let end = start
+        .checked_add(len)
+        .ok_or_else(|| anyhow::anyhow!("tensor slice range overflow"))?;
+    anyhow::ensure!(
+        end <= first_dim,
+        "tensor first-dimension slice {start}..{end} exceeds {first_dim}"
+    );
+    let row_width = shape[1..]
+        .iter()
+        .try_fold(1usize, |acc, &dim| acc.checked_mul(dim))
+        .ok_or_else(|| anyhow::anyhow!("tensor row width overflow"))?;
+    let data_start = start
+        .checked_mul(row_width)
+        .ok_or_else(|| anyhow::anyhow!("tensor data start overflow"))?;
+    let data_len = len
+        .checked_mul(row_width)
+        .ok_or_else(|| anyhow::anyhow!("tensor data length overflow"))?;
+    let data_end = data_start
+        .checked_add(data_len)
+        .ok_or_else(|| anyhow::anyhow!("tensor data end overflow"))?;
+    anyhow::ensure!(
+        data_end <= data.len(),
+        "tensor slice data range {data_start}..{data_end} exceeds {}",
+        data.len()
+    );
+    let mut new_shape = shape.to_vec();
+    new_shape[0] = len;
+    Ok((data[data_start..data_end].to_vec(), new_shape))
+}
+
+fn slice_1d<T>(values: &[T], start: usize, len: usize) -> Result<&[T]> {
+    let end = start
+        .checked_add(len)
+        .ok_or_else(|| anyhow::anyhow!("slice range overflow"))?;
+    values
+        .get(start..end)
+        .ok_or_else(|| anyhow::anyhow!("slice range {start}..{end} exceeds {}", values.len()))
 }
 
 fn hash_hex_strings<'a>(hashes: impl Iterator<Item = &'a str>) -> Vec<u8> {
@@ -1028,64 +1295,60 @@ fn hash_hex_strings<'a>(hashes: impl Iterator<Item = &'a str>) -> Vec<u8> {
 // Serialization helpers
 // ---------------------------------------------------------------------------
 
-/// Serialize pixel values ndarray to raw little-endian f32 bytes + shape.
-fn serialize_pixel_values(preprocessed: &PreprocessedImages) -> (Vec<u8>, Vec<u32>) {
-    let pixel_bytes: Vec<u8> = if let Some(pixel_slice) = preprocessed
-        .pixel_values
+/// Serialize the primary encoder input ndarray to raw little-endian f32 bytes + shape.
+fn serialize_encoder_input(preprocessed: &PreprocessedEncoderInputs) -> (Vec<u8>, Vec<u32>) {
+    serialize_array(&preprocessed.encoder_input)
+}
+
+fn serialize_array(encoder_input: &ArrayD<f32>) -> (Vec<u8>, Vec<u32>) {
+    let encoder_bytes: Vec<u8> = if let Some(encoder_slice) = encoder_input
         .as_slice()
-        .or_else(|| preprocessed.pixel_values.as_slice_memory_order())
+        .or_else(|| encoder_input.as_slice_memory_order())
     {
         // Zero-copy reinterpret: &[f32] → &[u8] on little-endian (x86).
         // This replaces the per-element flat_map(to_le_bytes) which was the
         // #1 CPU hotspot (13% of SMG CPU in profiling).
         #[cfg(target_endian = "little")]
         {
-            let byte_slice: &[u8] = bytemuck::cast_slice(pixel_slice);
+            let byte_slice: &[u8] = bytemuck::cast_slice(encoder_slice);
             byte_slice.to_vec()
         }
         #[cfg(not(target_endian = "little"))]
         {
-            pixel_slice.iter().flat_map(|v| v.to_le_bytes()).collect()
+            encoder_slice.iter().flat_map(|v| v.to_le_bytes()).collect()
         }
     } else {
         // Non-C-contiguous array: .iter() walks in logical (row-major) order,
         // which matches the shape — unlike as_slice_memory_order() which would
         // silently serialize in wrong dimension order for Fortran-contiguous arrays.
-        preprocessed
-            .pixel_values
-            .iter()
-            .flat_map(|v| v.to_le_bytes())
-            .collect()
+        encoder_input.iter().flat_map(|v| v.to_le_bytes()).collect()
     };
-    (pixel_bytes, pixel_values_shape(preprocessed))
+    (encoder_bytes, array_shape(encoder_input))
 }
 
-/// Serialize pixel values to the requested wire dtype.
-fn serialize_pixel_values_as_dtype(
-    preprocessed: &PreprocessedImages,
+fn serialize_array_as_dtype(
+    encoder_input: &ArrayD<f32>,
     dtype: &str,
 ) -> (Vec<u8>, Vec<u32>, String) {
     match canonical_float_dtype(dtype).as_deref() {
         Some("float32") => {
-            let (data, shape) = serialize_pixel_values(preprocessed);
+            let (data, shape) = serialize_array(encoder_input);
             (data, shape, "float32".to_string())
         }
         Some("bfloat16") => (
-            preprocessed
-                .pixel_values
+            encoder_input
                 .iter()
                 .flat_map(|value| f32_to_bf16_bits(*value).to_le_bytes())
                 .collect(),
-            pixel_values_shape(preprocessed),
+            array_shape(encoder_input),
             "bfloat16".to_string(),
         ),
         Some("float16") => (
-            preprocessed
-                .pixel_values
+            encoder_input
                 .iter()
                 .flat_map(|value| f32_to_f16_bits(*value).to_le_bytes())
                 .collect(),
-            pixel_values_shape(preprocessed),
+            array_shape(encoder_input),
             "float16".to_string(),
         ),
         _ => {
@@ -1093,16 +1356,13 @@ fn serialize_pixel_values_as_dtype(
                 dtype,
                 "Unsupported TokenSpeed encoder input dtype; falling back to float32"
             );
-            let (data, shape) = serialize_pixel_values(preprocessed);
+            let (data, shape) = serialize_array(encoder_input);
             (data, shape, "float32".to_string())
         }
     }
 }
 
-fn tokenspeed_encoder_input_dtype(
-    modality: Modality,
-    workers: Option<&WorkerSelection>,
-) -> String {
+fn tokenspeed_encoder_input_dtype(modality: Modality, workers: Option<&WorkerSelection>) -> String {
     if let Some(dtype) = tokenspeed_encoder_input_dtype_from_env(modality) {
         return dtype;
     }
@@ -1119,25 +1379,18 @@ fn tokenspeed_encoder_input_dtype_from_env(modality: Modality) -> Option<String>
     static DEFAULT_DTYPE: OnceLock<Option<String>> = OnceLock::new();
 
     let modality_dtype = match modality {
-        Modality::Image | Modality::ImageEmbeds => cached_env_dtype(
-            &IMAGE_DTYPE,
-            "SMG_TOKENSPEED_IMAGE_ENCODER_INPUT_DTYPE",
-        ),
-        Modality::Video => cached_env_dtype(
-            &VIDEO_DTYPE,
-            "SMG_TOKENSPEED_VIDEO_ENCODER_INPUT_DTYPE",
-        ),
-        Modality::Audio => cached_env_dtype(
-            &AUDIO_DTYPE,
-            "SMG_TOKENSPEED_AUDIO_ENCODER_INPUT_DTYPE",
-        ),
+        Modality::Image | Modality::ImageEmbeds => {
+            cached_env_dtype(&IMAGE_DTYPE, "SMG_TOKENSPEED_IMAGE_ENCODER_INPUT_DTYPE")
+        }
+        Modality::Video => {
+            cached_env_dtype(&VIDEO_DTYPE, "SMG_TOKENSPEED_VIDEO_ENCODER_INPUT_DTYPE")
+        }
+        Modality::Audio => {
+            cached_env_dtype(&AUDIO_DTYPE, "SMG_TOKENSPEED_AUDIO_ENCODER_INPUT_DTYPE")
+        }
     };
-    modality_dtype.or_else(|| {
-        cached_env_dtype(
-            &DEFAULT_DTYPE,
-            "SMG_TOKENSPEED_ENCODER_INPUT_DTYPE",
-        )
-    })
+    modality_dtype
+        .or_else(|| cached_env_dtype(&DEFAULT_DTYPE, "SMG_TOKENSPEED_ENCODER_INPUT_DTYPE"))
 }
 
 fn cached_env_dtype(cell: &'static OnceLock<Option<String>>, name: &str) -> Option<String> {
@@ -1168,13 +1421,8 @@ fn canonical_float_dtype(dtype: &str) -> Option<String> {
     }
 }
 
-fn pixel_values_shape(preprocessed: &PreprocessedImages) -> Vec<u32> {
-    preprocessed
-        .pixel_values
-        .shape()
-        .iter()
-        .map(|&d| d as u32)
-        .collect()
+fn array_shape(encoder_input: &ArrayD<f32>) -> Vec<u32> {
+    encoder_input.shape().iter().map(|&d| d as u32).collect()
 }
 
 fn f32_to_bf16_bits(value: f32) -> u16 {
@@ -1280,8 +1528,9 @@ fn model_specific_to_tensor_bytes(value: &ModelSpecificValue) -> Option<TensorBy
 
 #[cfg(test)]
 mod tests {
-    use std::fs;
+    use std::{fs, mem::size_of};
 
+    use ndarray::IxDyn;
     use openai_protocol::common::{ImageUrl, VideoUrl};
     use tempfile::TempDir;
 
@@ -1491,6 +1740,114 @@ mod tests {
         assert_eq!(parse_detail("LOW"), Some(ImageDetail::Low));
         assert_eq!(parse_detail("high"), Some(ImageDetail::High));
         assert_eq!(parse_detail("unknown"), None);
+    }
+
+    #[test]
+    fn assemble_tokenspeed_splits_image_items() {
+        let mut model_specific = HashMap::new();
+        model_specific.insert(
+            "patches_per_image".to_string(),
+            ModelSpecificValue::UintTensor {
+                data: vec![2, 2],
+                shape: vec![2],
+            },
+        );
+        model_specific.insert(
+            "image_grid_thw".to_string(),
+            ModelSpecificValue::UintTensor {
+                data: vec![1, 2, 3, 4, 5, 6],
+                shape: vec![2, 3],
+            },
+        );
+
+        let preprocessed = PreprocessedEncoderInputs {
+            encoder_input: ArrayD::from_shape_vec(
+                IxDyn(&[4, 2]),
+                vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
+            )
+            .unwrap(),
+            feature_token_counts: vec![2, 2],
+            item_sizes: vec![(1, 1), (1, 1)],
+            model_specific,
+        };
+
+        let images = vec![
+            Arc::new(ImageFrame::new(
+                image::DynamicImage::new_rgb8(1, 1),
+                bytes::Bytes::from_static(b"a"),
+                ImageDetail::Auto,
+                llm_multimodal::ImageSource::InlineBytes,
+                "hash-a".to_string(),
+            )),
+            Arc::new(ImageFrame::new(
+                image::DynamicImage::new_rgb8(1, 1),
+                bytes::Bytes::from_static(b"b"),
+                ImageDetail::Auto,
+                llm_multimodal::ImageSource::InlineBytes,
+                "hash-b".to_string(),
+            )),
+        ];
+
+        let intermediate = PrecomputedMultimodalIntermediate {
+            modality: Modality::Image,
+            preprocessed,
+            images,
+            videos: vec![],
+            placeholders: vec![
+                PlaceholderRange {
+                    offset: 10,
+                    length: 2,
+                },
+                PlaceholderRange {
+                    offset: 20,
+                    length: 2,
+                },
+            ],
+            patch_offsets: Some(vec![(10, 2), (20, 2)]),
+            placeholder_token_id: Some(151655),
+            field_layouts: HashMap::from([
+                (
+                    "pixel_values".to_string(),
+                    FieldLayout::flat("patches_per_image"),
+                ),
+                ("patches_per_image".to_string(), FieldLayout::Batched),
+                ("image_grid_thw".to_string(), FieldLayout::Batched),
+            ]),
+            keep_on_cpu_keys: vec![],
+        };
+
+        let assembled = assemble_tokenspeed(intermediate, None).unwrap();
+        assert_eq!(assembled.items.len(), 2);
+
+        let first = &assembled.items[0];
+        assert_eq!(first.modality, TokenSpeedModality::Image);
+        assert_eq!(first.encoder_input_shape, vec![2, 2]);
+        assert_eq!(first.encoder_input.len(), 4 * size_of::<f32>());
+        assert_eq!(first.mm_placeholders, vec![(10, 2)]);
+        assert_eq!(
+            first.content_hash,
+            hash_hex_strings(std::iter::once("hash-a"))
+        );
+        assert_eq!(
+            first.model_specific_tensors["image_grid_thw"].shape,
+            vec![1, 3]
+        );
+        assert_eq!(
+            first.model_specific_tensors["patches_per_image"].shape,
+            vec![1]
+        );
+
+        let second = &assembled.items[1];
+        assert_eq!(second.encoder_input_shape, vec![2, 2]);
+        assert_eq!(second.mm_placeholders, vec![(20, 2)]);
+        assert_eq!(
+            second.content_hash,
+            hash_hex_strings(std::iter::once("hash-b"))
+        );
+        assert_eq!(
+            second.model_specific_tensors["image_grid_thw"].shape,
+            vec![1, 3]
+        );
     }
 
     // ------------------------------------------------------------------

--- a/model_gateway/src/routers/grpc/multimodal.rs
+++ b/model_gateway/src/routers/grpc/multimodal.rs
@@ -9,7 +9,7 @@
 //! functions differ because they work with different input types (`ChatMessage` vs
 //! `InputMessage`).
 
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, path::Path, sync::Arc};
 
 use anyhow::{Context, Result};
 use dashmap::DashMap;
@@ -17,7 +17,7 @@ use llm_multimodal::{
     AsyncMultiModalTracker, FieldLayout, ImageDetail, ImageFrame, ImageProcessorRegistry,
     MediaConnector, MediaConnectorConfig, MediaContentPart, Modality, ModelMetadata, ModelRegistry,
     ModelSpecificValue, PlaceholderRange, PreProcessorConfig, PreprocessedImages,
-    PromptReplacement, TrackedMedia, TrackerOutput,
+    PromptReplacement, TrackedMedia, TrackerOutput, VideoClip,
 };
 use llm_tokenizer::TokenizerTrait;
 use openai_protocol::{
@@ -30,8 +30,8 @@ use tracing::{debug, warn};
 use crate::routers::grpc::{
     client::GrpcClient,
     proto_wrapper::{
-        SglangMultimodalData, TensorBytes, TokenSpeedMultimodalData, TrtllmMultimodalData,
-        VllmMultimodalData,
+        SglangMultimodalData, TensorBytes, TokenSpeedModality, TokenSpeedMultimodalData,
+        TrtllmMultimodalData, VllmMultimodalData,
     },
     MultimodalData,
 };
@@ -43,6 +43,8 @@ pub(crate) struct MultimodalModelConfig {
     pub config: serde_json::Value,
     /// Preprocessor config (preprocessor_config.json)
     pub preprocessor_config: PreProcessorConfig,
+    /// Video-specific preprocessor config, when provided by the model repo.
+    pub video_preprocessor_config: Option<PreProcessorConfig>,
 }
 
 /// Shared cache of multimodal model configuration files keyed by tokenizer UUID.
@@ -115,39 +117,21 @@ impl MultimodalConfigRegistry {
         // back to `PreProcessorConfig::default()`. This matches the bundle
         // preload path in `try_load_multimodal_config`.
         let pp_config_path = base_dir.join("preprocessor_config.json");
-        let preprocessor_config = if pp_config_path.exists() {
-            match std::fs::read_to_string(&pp_config_path) {
-                Ok(pp_str) => match PreProcessorConfig::from_json(&pp_str) {
-                    Ok(c) => c,
-                    Err(e) => {
-                        warn!(
-                            path = %pp_config_path.display(),
-                            error = %e,
-                            "Failed to parse preprocessor_config.json; falling back to defaults"
-                        );
-                        PreProcessorConfig::default()
-                    }
-                },
-                Err(e) => {
-                    warn!(
+        let preprocessor_config =
+            load_preprocessor_config_file(&pp_config_path, "preprocessor_config.json")
+                .unwrap_or_else(|| {
+                    debug!(
                         path = %pp_config_path.display(),
-                        error = %e,
-                        "Failed to read preprocessor_config.json; falling back to defaults"
+                        "No preprocessor_config.json found; using PreProcessorConfig defaults"
                     );
                     PreProcessorConfig::default()
-                }
-            }
-        } else {
-            debug!(
-                path = %pp_config_path.display(),
-                "No preprocessor_config.json found; using PreProcessorConfig defaults"
-            );
-            PreProcessorConfig::default()
-        };
+                });
+        let video_preprocessor_config = load_video_preprocessor_config(&base_dir);
 
         let model_config = Arc::new(MultimodalModelConfig {
             config,
             preprocessor_config,
+            video_preprocessor_config,
         });
 
         self.configs
@@ -161,6 +145,67 @@ impl MultimodalConfigRegistry {
 impl Default for MultimodalConfigRegistry {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+pub(crate) fn load_preprocessor_config_file(
+    path: &Path,
+    label: &str,
+) -> Option<PreProcessorConfig> {
+    if !path.exists() {
+        return None;
+    }
+
+    match std::fs::read_to_string(path) {
+        Ok(config_str) => match PreProcessorConfig::from_json(&config_str) {
+            Ok(config) => Some(config),
+            Err(e) => {
+                warn!(
+                    path = %path.display(),
+                    error = %e,
+                    "Failed to parse {label}"
+                );
+                None
+            }
+        },
+        Err(e) => {
+            warn!(
+                path = %path.display(),
+                error = %e,
+                "Failed to read {label}"
+            );
+            None
+        }
+    }
+}
+
+pub(crate) fn load_video_preprocessor_config(base_dir: &Path) -> Option<PreProcessorConfig> {
+    let video_path = base_dir.join("video_preprocessor_config.json");
+    if let Some(config) =
+        load_preprocessor_config_file(&video_path, "video_preprocessor_config.json")
+    {
+        return Some(config);
+    }
+
+    let processor_path = base_dir.join("processor_config.json");
+    if !processor_path.exists() {
+        return None;
+    }
+
+    match std::fs::read_to_string(&processor_path)
+        .ok()
+        .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
+        .and_then(|v| v.get("video_processor").cloned())
+        .and_then(|v| PreProcessorConfig::from_value(v).ok())
+    {
+        Some(config) => Some(config),
+        None => {
+            warn!(
+                path = %processor_path.display(),
+                "Failed to load video_processor from processor_config.json"
+            );
+            None
+        }
     }
 }
 
@@ -208,17 +253,26 @@ pub(crate) struct MultimodalOutput {
 /// The assembly stage converts this into a backend-specific [`MultimodalData`]
 /// variant once the target backend is known (after worker selection).
 #[derive(Debug)]
-pub(crate) struct MultimodalIntermediate {
+pub(crate) enum MultimodalIntermediate {
+    Precomputed(PrecomputedMultimodalIntermediate),
+}
+
+#[derive(Debug)]
+pub(crate) struct PrecomputedMultimodalIntermediate {
+    /// Active modality for this preprocessed payload.
+    pub modality: Modality,
     /// Preprocessed pixel values and model-specific tensors (not yet serialized).
     pub preprocessed: PreprocessedImages,
     /// Raw image frames (bytes + blake3 hashes).
     pub images: Vec<Arc<ImageFrame>>,
+    /// Raw video clips (bytes + blake3 hashes + sampled frames).
+    pub videos: Vec<Arc<VideoClip>>,
     /// Full structural placeholder ranges (offset, length).
     pub placeholders: Vec<PlaceholderRange>,
     /// Patch-only placeholder offsets for sglang.
     pub patch_offsets: Option<Vec<(u32, u32)>>,
-    /// Image token ID from model config.
-    pub im_token_id: Option<u32>,
+    /// Placeholder token ID from model config for the active modality.
+    pub placeholder_token_id: Option<u32>,
     /// Per-tensor field layout classification from the model spec.
     pub field_layouts: HashMap<String, FieldLayout>,
     /// Tensor keys that should remain on CPU (vLLM `keep_on_cpu` hint).
@@ -237,6 +291,7 @@ pub(crate) async fn resolve_placeholder_token(
     components: &MultimodalComponents,
     tokenizer_id: &str,
     tokenizer_source: &str,
+    modality: Modality,
 ) -> Result<Option<String>> {
     let model_config = components
         .config_registry
@@ -251,14 +306,22 @@ pub(crate) async fn resolve_placeholder_token(
         Some(s) => s,
         None => return Ok(None),
     };
-    Ok(Some(spec.placeholder_token(&metadata).map_err(|e| {
-        anyhow::anyhow!("Failed to get placeholder token: {e}")
-    })?))
+    Ok(Some(
+        spec.placeholder_token_for(&metadata, modality)
+            .map_err(|e| anyhow::anyhow!("Failed to get placeholder token: {e}"))?,
+    ))
 }
 
-/// Check if any messages in the request contain multimodal content (images).
-pub(crate) fn has_multimodal_content(messages: &[ChatMessage]) -> bool {
-    messages.iter().any(|msg| {
+/// Return the multimodal modalities present in OpenAI chat messages.
+pub(crate) fn chat_modalities(messages: &[ChatMessage]) -> Vec<Modality> {
+    let mut modalities = Vec::new();
+    let mut push_unique = |modality| {
+        if !modalities.contains(&modality) {
+            modalities.push(modality);
+        }
+    };
+
+    for msg in messages {
         let content = match msg {
             ChatMessage::User { content, .. } => Some(content),
             ChatMessage::System { content, .. } => Some(content),
@@ -266,13 +329,25 @@ pub(crate) fn has_multimodal_content(messages: &[ChatMessage]) -> bool {
             ChatMessage::Tool { content, .. } => Some(content),
             _ => None,
         };
-        content.is_some_and(|c| match c {
-            MessageContent::Parts(parts) => parts
-                .iter()
-                .any(|p| matches!(p, ContentPart::ImageUrl { .. })),
-            MessageContent::Text(_) => false,
-        })
-    })
+
+        if let Some(MessageContent::Parts(parts)) = content {
+            for part in parts {
+                match part {
+                    ContentPart::ImageUrl { .. } => push_unique(Modality::Image),
+                    ContentPart::VideoUrl { .. } => push_unique(Modality::Video),
+                    ContentPart::Text { .. } => {}
+                }
+            }
+        }
+    }
+
+    modalities
+}
+
+/// Check if any messages in the request contain multimodal content.
+#[cfg(test)]
+pub(crate) fn has_multimodal_content(messages: &[ChatMessage]) -> bool {
+    !chat_modalities(messages).is_empty()
 }
 
 /// Extract multimodal content parts from OpenAI chat messages,
@@ -303,7 +378,12 @@ fn extract_content_parts(messages: &[ChatMessage]) -> Vec<MediaContentPart> {
                     ContentPart::Text { text } => {
                         parts.push(MediaContentPart::Text { text: text.clone() });
                     }
-                    ContentPart::VideoUrl { .. } => {} // Skip VideoUrl for now
+                    ContentPart::VideoUrl { video_url } => {
+                        parts.push(MediaContentPart::VideoUrl {
+                            url: video_url.url.clone(),
+                            uuid: None,
+                        });
+                    }
                 }
             }
         }
@@ -476,19 +556,60 @@ async fn process_multimodal_parts(
         })
         .unwrap_or_default();
 
-    if images.is_empty() {
+    let videos: Vec<Arc<VideoClip>> = tracker_output
+        .data
+        .get(&Modality::Video)
+        .map(|media_vec| {
+            media_vec
+                .iter()
+                .filter_map(|m| match m {
+                    TrackedMedia::Video(clip) => Some(clip.clone()),
+                    _ => None,
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let modality = match (images.is_empty(), videos.is_empty()) {
+        (false, true) => Modality::Image,
+        (true, false) => Modality::Video,
+        (false, false) => {
+            return Err(anyhow::anyhow!(
+                "Mixed image and video multimodal requests are not supported yet"
+            ));
+        }
+        (true, true) => {
+            return Err(anyhow::anyhow!(
+                "No media was successfully fetched for multimodal request"
+            ));
+        }
+    };
+
+    if modality == Modality::Video && videos.len() != 1 {
         return Err(anyhow::anyhow!(
-            "No images were successfully fetched for multimodal request"
+            "Exactly one video is supported per request for the initial video path"
         ));
     }
 
-    debug!(
-        image_count = images.len(),
-        image_sizes = ?images.iter().map(|f| (f.image.width(), f.image.height())).collect::<Vec<_>>(),
-        "Fetched images for multimodal processing"
-    );
+    match modality {
+        Modality::Image => {
+            debug!(
+                image_count = images.len(),
+                image_sizes = ?images.iter().map(|f| (f.image.width(), f.image.height())).collect::<Vec<_>>(),
+                "Fetched images for multimodal processing"
+            );
+        }
+        Modality::Video => {
+            debug!(
+                video_count = videos.len(),
+                frame_count = videos.first().map_or(0, |v| v.frames.len()),
+                "Fetched video for multimodal processing"
+            );
+        }
+        _ => {}
+    }
 
-    // Step 2: Resolve model spec and preprocess images
+    // Step 2: Resolve model spec and preprocess media.
     let model_config = components
         .config_registry
         .get_or_load(tokenizer_id, tokenizer_source)
@@ -510,50 +631,76 @@ async fn process_multimodal_parts(
     // Run CPU-intensive image preprocessing on a blocking thread pool so it
     // doesn't block the tokio async runtime under concurrent load.
     // TODO: consider making the thread pool size configurable.
-    let pp_config = model_config.preprocessor_config.clone();
+    let pp_config = match modality {
+        Modality::Video => model_config
+            .video_preprocessor_config
+            .clone()
+            .unwrap_or_else(|| model_config.preprocessor_config.clone()),
+        _ => model_config.preprocessor_config.clone(),
+    };
     let registry = components.image_processor_registry.clone();
     let model_id_owned = model_id.to_string();
     let model_type_owned = model_type.map(String::from);
     let images_for_preprocess = images.clone(); // cheap Arc refcount bumps
+    let videos_for_preprocess = videos.clone(); // cheap Arc refcount bumps
 
     let preprocessed: PreprocessedImages = tokio::task::spawn_blocking(move || {
-        // Extract DynamicImages inside the blocking closure so the expensive
-        // clone happens off the tokio async runtime.
-        let raw_images: Vec<image::DynamicImage> = images_for_preprocess
-            .iter()
-            .map(|f| f.image.clone())
-            .collect();
         let processor = registry
             .find(&model_id_owned, model_type_owned.as_deref())
             .ok_or_else(|| {
                 anyhow::anyhow!("No image processor found for model: {model_id_owned}")
             })?;
-        processor
-            .preprocess(&raw_images, &pp_config)
-            .map_err(|e| anyhow::anyhow!("Image preprocessing failed: {e}"))
+
+        match modality {
+            Modality::Image => {
+                // Extract DynamicImages inside the blocking closure so the expensive
+                // clone happens off the tokio async runtime.
+                let raw_images: Vec<image::DynamicImage> = images_for_preprocess
+                    .iter()
+                    .map(|f| f.image.clone())
+                    .collect();
+                processor
+                    .preprocess(&raw_images, &pp_config)
+                    .map_err(|e| anyhow::anyhow!("Image preprocessing failed: {e}"))
+            }
+            Modality::Video => {
+                let video = videos_for_preprocess
+                    .first()
+                    .ok_or_else(|| anyhow::anyhow!("No video available for preprocessing"))?;
+                let frames: Vec<image::DynamicImage> = video.frames.iter().cloned().collect();
+                processor
+                    .preprocess_video(&frames, &pp_config)
+                    .map_err(|e| anyhow::anyhow!("Video preprocessing failed: {e}"))
+            }
+            _ => Err(anyhow::anyhow!(
+                "Unsupported modality for preprocessing: {modality}"
+            )),
+        }
     })
     .await
     .map_err(|e| anyhow::anyhow!("Preprocessing task panicked: {e}"))??;
 
     debug!(
-        num_images = preprocessed.num_img_tokens.len(),
+        ?modality,
+        item_count = preprocessed.num_img_tokens.len(),
         total_tokens = preprocessed.num_img_tokens.iter().sum::<usize>(),
-        "Image preprocessing complete"
+        "Multimodal preprocessing complete"
     );
 
     // Step 3: Compute prompt replacements and expand tokens.
     let prompt_replacements = spec
-        .prompt_replacements(&metadata, &preprocessed)
+        .prompt_replacements_for(&metadata, &preprocessed, modality)
         .map_err(|e| anyhow::anyhow!("Failed to compute prompt replacements: {e}"))?;
 
     // Two token IDs may differ for the same placeholder:
     // - search_token_id: what the tokenizer actually emits (e.g. 200090 for "<|image|>")
-    // - im_token_id: what the model config declares (e.g. config.image_token_index = 200092)
+    // - placeholder_token_id: what the model config declares (e.g. image_token_id/video_token_id)
     let placeholder_token = spec
-        .placeholder_token(&metadata)
+        .placeholder_token_for(&metadata, modality)
         .map_err(|e| anyhow::anyhow!("Failed to get placeholder token: {e}"))?;
     let search_token_id = tokenizer.token_to_id(&placeholder_token);
-    let im_token_id: Option<u32> = match spec.placeholder_token_id(&metadata) {
+    let placeholder_token_id: Option<u32> = match spec.placeholder_token_id_for(&metadata, modality)
+    {
         Ok(id) => Some(id as u32),
         Err(e) => {
             warn!(
@@ -568,7 +715,7 @@ async fn process_multimodal_parts(
     let expanded = expand_tokens(
         &token_ids,
         search_token_id,
-        im_token_id,
+        placeholder_token_id,
         &prompt_replacements,
     );
 
@@ -577,20 +724,22 @@ async fn process_multimodal_parts(
         expanded_len = expanded.token_ids.len(),
         placeholder_count = expanded.placeholders.len(),
         ?search_token_id,
-        ?im_token_id,
+        ?placeholder_token_id,
         "Token expansion complete"
     );
 
     // Step 4: Build lightweight intermediate (defers tensor serialization to assembly)
-    let intermediate = MultimodalIntermediate {
+    let intermediate = MultimodalIntermediate::Precomputed(PrecomputedMultimodalIntermediate {
+        modality,
         preprocessed,
         images,
+        videos,
         placeholders: expanded.placeholders,
         patch_offsets: expanded.patch_offsets,
-        im_token_id,
+        placeholder_token_id,
         field_layouts: spec.field_layouts(),
         keep_on_cpu_keys: spec.keep_on_cpu_keys(),
-    };
+    });
 
     Ok(MultimodalOutput {
         expanded_token_ids: expanded.token_ids,
@@ -703,19 +852,42 @@ fn expand_tokens(
 pub(crate) fn assemble_multimodal_data(
     intermediate: MultimodalIntermediate,
     client: &GrpcClient,
-) -> MultimodalData {
-    match client {
-        GrpcClient::Sglang(_) => MultimodalData::Sglang(assemble_sglang(intermediate)),
-        GrpcClient::Vllm(_) => MultimodalData::Vllm(assemble_vllm(intermediate)),
-        GrpcClient::Trtllm(_) => MultimodalData::Trtllm(assemble_trtllm(intermediate)),
-        GrpcClient::TokenSpeed(_) => MultimodalData::TokenSpeed(assemble_tokenspeed(intermediate)),
-        GrpcClient::Mlx(_) => unreachable!(
-            "caller rejects multimodal for MLX in build_chat_request/build_messages_request"
-        ),
+) -> Result<MultimodalData> {
+    match intermediate {
+        MultimodalIntermediate::Precomputed(precomputed) => match client {
+            GrpcClient::Sglang(_) => {
+                ensure_image_only(&precomputed, "SGLang")?;
+                Ok(MultimodalData::Sglang(assemble_sglang(precomputed)))
+            }
+            GrpcClient::Vllm(_) => {
+                ensure_image_only(&precomputed, "vLLM")?;
+                Ok(MultimodalData::Vllm(assemble_vllm(precomputed)))
+            }
+            GrpcClient::Trtllm(_) => {
+                ensure_image_only(&precomputed, "TRT-LLM")?;
+                Ok(MultimodalData::Trtllm(assemble_trtllm(precomputed)))
+            }
+            GrpcClient::TokenSpeed(_) => {
+                Ok(MultimodalData::TokenSpeed(assemble_tokenspeed(precomputed)))
+            }
+            GrpcClient::Mlx(_) => unreachable!(
+                "caller rejects multimodal for MLX in build_chat_request/build_messages_request"
+            ),
+        },
     }
 }
 
-fn assemble_sglang(intermediate: MultimodalIntermediate) -> SglangMultimodalData {
+fn ensure_image_only(intermediate: &PrecomputedMultimodalIntermediate, backend: &str) -> Result<()> {
+    if intermediate.modality != Modality::Image {
+        return Err(anyhow::anyhow!(
+            "{backend} multimodal path currently supports image inputs only; got {}",
+            intermediate.modality
+        ));
+    }
+    Ok(())
+}
+
+fn assemble_sglang(intermediate: PrecomputedMultimodalIntermediate) -> SglangMultimodalData {
     let (pixel_values, pixel_values_shape) = serialize_pixel_values(&intermediate.preprocessed);
     let model_specific_tensors = serialize_model_specific(intermediate.preprocessed.model_specific);
     let image_data = intermediate
@@ -740,12 +912,12 @@ fn assemble_sglang(intermediate: MultimodalIntermediate) -> SglangMultimodalData
         pixel_values,
         pixel_values_shape,
         model_specific_tensors,
-        im_token_id: intermediate.im_token_id,
+        im_token_id: intermediate.placeholder_token_id,
         mm_placeholders,
     }
 }
 
-fn assemble_vllm(intermediate: MultimodalIntermediate) -> VllmMultimodalData {
+fn assemble_vllm(intermediate: PrecomputedMultimodalIntermediate) -> VllmMultimodalData {
     let (pixel_values, pixel_values_shape) = serialize_pixel_values(&intermediate.preprocessed);
     let model_specific_tensors = serialize_model_specific(intermediate.preprocessed.model_specific);
     let mm_hashes = intermediate.images.iter().map(|f| f.hash.clone()).collect();
@@ -761,7 +933,7 @@ fn assemble_vllm(intermediate: MultimodalIntermediate) -> VllmMultimodalData {
         pixel_values,
         pixel_values_shape,
         model_specific_tensors,
-        im_token_id: intermediate.im_token_id,
+        im_token_id: intermediate.placeholder_token_id,
         mm_placeholders,
         mm_hashes,
         batched_keys,
@@ -770,7 +942,7 @@ fn assemble_vllm(intermediate: MultimodalIntermediate) -> VllmMultimodalData {
     }
 }
 
-fn assemble_trtllm(intermediate: MultimodalIntermediate) -> TrtllmMultimodalData {
+fn assemble_trtllm(intermediate: PrecomputedMultimodalIntermediate) -> TrtllmMultimodalData {
     let image_data = intermediate
         .images
         .iter()
@@ -779,7 +951,7 @@ fn assemble_trtllm(intermediate: MultimodalIntermediate) -> TrtllmMultimodalData
     TrtllmMultimodalData { image_data }
 }
 
-fn assemble_tokenspeed(intermediate: MultimodalIntermediate) -> TokenSpeedMultimodalData {
+fn assemble_tokenspeed(intermediate: PrecomputedMultimodalIntermediate) -> TokenSpeedMultimodalData {
     // Use patch-only offsets when available and non-empty; fall back to full structural ranges.
     let (pixel_values, pixel_values_shape) = serialize_pixel_values(&intermediate.preprocessed);
     let model_specific_tensors = serialize_model_specific(intermediate.preprocessed.model_specific);
@@ -794,13 +966,35 @@ fn assemble_tokenspeed(intermediate: MultimodalIntermediate) -> TokenSpeedMultim
                 .collect()
         });
 
+    let modality = match intermediate.modality {
+        Modality::Image => TokenSpeedModality::Image,
+        Modality::Video => TokenSpeedModality::Video,
+        Modality::Audio => TokenSpeedModality::Audio,
+        Modality::ImageEmbeds => TokenSpeedModality::Image,
+    };
+    let content_hash = match intermediate.modality {
+        Modality::Image => hash_hex_strings(intermediate.images.iter().map(|f| f.hash.as_str())),
+        Modality::Video => hash_hex_strings(intermediate.videos.iter().map(|v| v.hash.as_str())),
+        _ => Vec::new(),
+    };
+
     TokenSpeedMultimodalData {
+        modality,
         pixel_values,
         pixel_values_shape,
         model_specific_tensors,
-        im_token_id: intermediate.im_token_id,
+        placeholder_token_id: intermediate.placeholder_token_id,
         mm_placeholders,
+        content_hash,
     }
+}
+
+fn hash_hex_strings<'a>(hashes: impl Iterator<Item = &'a str>) -> Vec<u8> {
+    let mut hasher = blake3::Hasher::new();
+    for hash in hashes {
+        hasher.update(hash.as_bytes());
+    }
+    hasher.finalize().as_bytes().to_vec()
 }
 
 // ---------------------------------------------------------------------------
@@ -902,7 +1096,7 @@ fn model_specific_to_tensor_bytes(value: &ModelSpecificValue) -> Option<TensorBy
 mod tests {
     use std::fs;
 
-    use openai_protocol::common::ImageUrl;
+    use openai_protocol::common::{ImageUrl, VideoUrl};
     use tempfile::TempDir;
 
     use super::*;
@@ -925,6 +1119,21 @@ mod tests {
         }];
 
         assert!(has_multimodal_content(&messages));
+    }
+
+    #[test]
+    fn test_has_multimodal_content_with_video() {
+        let messages = vec![ChatMessage::User {
+            content: MessageContent::Parts(vec![ContentPart::VideoUrl {
+                video_url: VideoUrl {
+                    url: "https://example.com/clip.mp4".to_string(),
+                },
+            }]),
+            name: None,
+        }];
+
+        assert!(has_multimodal_content(&messages));
+        assert_eq!(chat_modalities(&messages), vec![Modality::Video]);
     }
 
     #[test]
@@ -986,6 +1195,27 @@ mod tests {
                 assert_eq!(*detail, Some(ImageDetail::High));
             }
             _ => panic!("Expected ImageUrl part"),
+        }
+    }
+
+    #[test]
+    fn test_extract_video_content_parts() {
+        let messages = vec![ChatMessage::User {
+            content: MessageContent::Parts(vec![ContentPart::VideoUrl {
+                video_url: VideoUrl {
+                    url: "https://example.com/video.mp4".to_string(),
+                },
+            }]),
+            name: None,
+        }];
+
+        let parts = extract_content_parts(&messages);
+        assert_eq!(parts.len(), 1);
+        match &parts[0] {
+            MediaContentPart::VideoUrl { url, .. } => {
+                assert_eq!(url, "https://example.com/video.mp4");
+            }
+            _ => panic!("Expected VideoUrl part"),
         }
     }
 
@@ -1134,6 +1364,7 @@ mod tests {
                 r#"{"image_processor_type":"Phi3VImageProcessor"}"#,
             )
             .unwrap(),
+            video_preprocessor_config: None,
         });
         reg.insert("tok-uuid-rm".to_string(), cfg.clone());
         assert!(reg.get("tok-uuid-rm").is_some());
@@ -1157,6 +1388,7 @@ mod tests {
                 r#"{"image_processor_type":"Phi3VImageProcessor"}"#,
             )
             .unwrap(),
+            video_preprocessor_config: None,
         });
         reg.insert("tok-uuid-3".to_string(), cfg.clone());
 

--- a/model_gateway/src/routers/grpc/multimodal.rs
+++ b/model_gateway/src/routers/grpc/multimodal.rs
@@ -193,17 +193,30 @@ pub(crate) fn load_video_preprocessor_config(base_dir: &Path) -> Option<PreProce
         return None;
     }
 
-    match std::fs::read_to_string(&processor_path)
+    let processor_config = match std::fs::read_to_string(&processor_path)
         .ok()
         .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
-        .and_then(|v| v.get("video_processor").cloned())
-        .and_then(|v| PreProcessorConfig::from_value(v).ok())
     {
-        Some(config) => Some(config),
+        Some(config) => config,
         None => {
             warn!(
                 path = %processor_path.display(),
-                "Failed to load video_processor from processor_config.json"
+                "Failed to load processor_config.json for video_processor"
+            );
+            return None;
+        }
+    };
+
+    let Some(video_processor) = processor_config.get("video_processor") else {
+        return None;
+    };
+    match PreProcessorConfig::from_value(video_processor.clone()) {
+        Ok(config) => Some(config),
+        Err(error) => {
+            warn!(
+                path = %processor_path.display(),
+                error = %error,
+                "Failed to parse video_processor from processor_config.json"
             );
             None
         }

--- a/model_gateway/src/routers/grpc/multimodal.rs
+++ b/model_gateway/src/routers/grpc/multimodal.rs
@@ -9,7 +9,11 @@
 //! functions differ because they work with different input types (`ChatMessage` vs
 //! `InputMessage`).
 
-use std::{collections::HashMap, path::Path, sync::Arc};
+use std::{
+    collections::HashMap,
+    path::Path,
+    sync::{Arc, OnceLock},
+};
 
 use anyhow::{Context, Result};
 use dashmap::DashMap;
@@ -681,9 +685,8 @@ async fn process_multimodal_parts(
                 let video = videos_for_preprocess
                     .first()
                     .ok_or_else(|| anyhow::anyhow!("No video available for preprocessing"))?;
-                let frames: Vec<image::DynamicImage> = video.frames.iter().cloned().collect();
                 processor
-                    .preprocess_video(&frames, &pp_config)
+                    .preprocess_video(video.frames.as_slice(), &pp_config)
                     .map_err(|e| anyhow::anyhow!("Video preprocessing failed: {e}"))
             }
             _ => Err(anyhow::anyhow!(
@@ -1110,15 +1113,36 @@ fn tokenspeed_encoder_input_dtype(
 }
 
 fn tokenspeed_encoder_input_dtype_from_env(modality: Modality) -> Option<String> {
-    let modality_env = match modality {
-        Modality::Image | Modality::ImageEmbeds => "SMG_TOKENSPEED_IMAGE_ENCODER_INPUT_DTYPE",
-        Modality::Video => "SMG_TOKENSPEED_VIDEO_ENCODER_INPUT_DTYPE",
-        Modality::Audio => "SMG_TOKENSPEED_AUDIO_ENCODER_INPUT_DTYPE",
+    static IMAGE_DTYPE: OnceLock<Option<String>> = OnceLock::new();
+    static VIDEO_DTYPE: OnceLock<Option<String>> = OnceLock::new();
+    static AUDIO_DTYPE: OnceLock<Option<String>> = OnceLock::new();
+    static DEFAULT_DTYPE: OnceLock<Option<String>> = OnceLock::new();
+
+    let modality_dtype = match modality {
+        Modality::Image | Modality::ImageEmbeds => cached_env_dtype(
+            &IMAGE_DTYPE,
+            "SMG_TOKENSPEED_IMAGE_ENCODER_INPUT_DTYPE",
+        ),
+        Modality::Video => cached_env_dtype(
+            &VIDEO_DTYPE,
+            "SMG_TOKENSPEED_VIDEO_ENCODER_INPUT_DTYPE",
+        ),
+        Modality::Audio => cached_env_dtype(
+            &AUDIO_DTYPE,
+            "SMG_TOKENSPEED_AUDIO_ENCODER_INPUT_DTYPE",
+        ),
     };
-    std::env::var(modality_env)
-        .or_else(|_| std::env::var("SMG_TOKENSPEED_ENCODER_INPUT_DTYPE"))
-        .ok()
-        .filter(|dtype| !dtype.is_empty())
+    modality_dtype.or_else(|| {
+        cached_env_dtype(
+            &DEFAULT_DTYPE,
+            "SMG_TOKENSPEED_ENCODER_INPUT_DTYPE",
+        )
+    })
+}
+
+fn cached_env_dtype(cell: &'static OnceLock<Option<String>>, name: &str) -> Option<String> {
+    cell.get_or_init(|| std::env::var(name).ok().filter(|dtype| !dtype.is_empty()))
+        .clone()
 }
 
 fn tokenspeed_encoder_input_dtype_from_worker(workers: Option<&WorkerSelection>) -> Option<String> {

--- a/model_gateway/src/routers/grpc/proto_wrapper.rs
+++ b/model_gateway/src/routers/grpc/proto_wrapper.rs
@@ -81,6 +81,7 @@ pub struct TokenSpeedMultimodalData {
     pub modality: TokenSpeedModality,
     pub pixel_values: Vec<u8>,
     pub pixel_values_shape: Vec<u32>,
+    pub encoder_input_dtype: String,
     pub model_specific_tensors: HashMap<String, TensorBytes>,
     pub placeholder_token_id: Option<u32>,
     pub mm_placeholders: Vec<(u32, u32)>,
@@ -199,32 +200,17 @@ impl TrtllmMultimodalData {
 impl TokenSpeedMultimodalData {
     /// Convert to TokenSpeed proto MultimodalInputs.
     pub fn into_proto(self) -> tokenspeed::MultimodalInputs {
-        let model_specific_tensors: HashMap<_, _> = self
-            .model_specific_tensors
-            .clone()
-            .into_iter()
-            .map(|(k, v)| (k, tensor_bytes_to_tokenspeed(v)))
-            .collect();
-
         let mm_placeholders = self
             .mm_placeholders
-            .iter()
-            .map(|&(offset, length)| tokenspeed::PlaceholderRange { offset, length })
+            .into_iter()
+            .map(|(offset, length)| tokenspeed::PlaceholderRange { offset, length })
             .collect::<Vec<_>>();
 
-        let mut item_tensors = self
+        let model_specific_tensors = self
             .model_specific_tensors
             .into_iter()
             .map(|(k, v)| (k, tensor_bytes_to_tokenspeed(v)))
             .collect::<HashMap<_, _>>();
-        item_tensors.insert(
-            "pixel_values".to_string(),
-            tokenspeed::TensorData {
-                data: self.pixel_values.clone(),
-                shape: self.pixel_values_shape.clone(),
-                dtype: "float32".to_string(),
-            },
-        );
 
         let item = tokenspeed::MultimodalItem {
             modality: match self.modality {
@@ -233,42 +219,25 @@ impl TokenSpeedMultimodalData {
                 TokenSpeedModality::Video => tokenspeed::Modality::Video as i32,
             },
             content_hash: self.content_hash,
-            tensors: item_tensors,
-            placeholders: mm_placeholders.clone(),
+            encoder_input: Some(tensor_bytes_to_tokenspeed(TensorBytes {
+                data: self.pixel_values,
+                shape: self.pixel_values_shape,
+                dtype: self.encoder_input_dtype,
+            })),
+            model_specific_tensors,
+            placeholders: mm_placeholders,
             placeholder_token_id: self.placeholder_token_id,
         };
 
-        let (pixel_values, legacy_model_specific, im_token_id, legacy_placeholders) =
-            if self.modality == TokenSpeedModality::Image {
-                (
-                    Some(tokenspeed::TensorData {
-                        data: self.pixel_values,
-                        shape: self.pixel_values_shape,
-                        dtype: "float32".to_string(),
-                    }),
-                    model_specific_tensors,
-                    self.placeholder_token_id,
-                    mm_placeholders,
-                )
-            } else {
-                (None, HashMap::new(), None, Vec::new())
-            };
-
-        tokenspeed::MultimodalInputs {
-            pixel_values,
-            model_specific_tensors: legacy_model_specific,
-            im_token_id,
-            mm_placeholders: legacy_placeholders,
-            items: vec![item],
-        }
+        tokenspeed::MultimodalInputs { items: vec![item] }
     }
 }
 
 fn tensor_bytes_to_tokenspeed(value: TensorBytes) -> tokenspeed::TensorData {
     tokenspeed::TensorData {
-        data: value.data,
         shape: value.shape,
         dtype: value.dtype,
+        payload: Some(tokenspeed::tensor_data::Payload::Inline(value.data)),
     }
 }
 
@@ -1282,6 +1251,43 @@ mod tests {
     use super::*;
 
     #[test]
+    fn tokenspeed_image_into_proto_uses_itemized_payload() {
+        let mut model_specific_tensors = HashMap::new();
+        model_specific_tensors.insert(
+            "image_grid_thw".to_string(),
+            TensorBytes {
+                data: vec![1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0],
+                shape: vec![1, 3],
+                dtype: "uint32".to_string(),
+            },
+        );
+
+        let proto = TokenSpeedMultimodalData {
+            modality: TokenSpeedModality::Image,
+            pixel_values: vec![42; 8],
+            pixel_values_shape: vec![1, 2],
+            encoder_input_dtype: "float32".to_string(),
+            model_specific_tensors,
+            placeholder_token_id: Some(151655),
+            mm_placeholders: vec![(4, 2)],
+            content_hash: vec![7; 32],
+        }
+        .into_proto();
+
+        assert_eq!(proto.items.len(), 1);
+        let item = &proto.items[0];
+        assert_eq!(item.modality, tokenspeed::Modality::Image as i32);
+        assert_eq!(item.placeholder_token_id, Some(151655));
+        assert_eq!(item.placeholders[0].offset, 4);
+        assert_eq!(item.placeholders[0].length, 2);
+        assert_eq!(
+            inline_tensor_data(item.encoder_input.as_ref().unwrap()),
+            &[42; 8]
+        );
+        assert!(item.model_specific_tensors.contains_key("image_grid_thw"));
+    }
+
+    #[test]
     fn tokenspeed_video_into_proto_uses_itemized_payload() {
         let mut model_specific_tensors = HashMap::new();
         model_specific_tensors.insert(
@@ -1297,6 +1303,7 @@ mod tests {
             modality: TokenSpeedModality::Video,
             pixel_values: vec![0; 8],
             pixel_values_shape: vec![1, 2],
+            encoder_input_dtype: "float32".to_string(),
             model_specific_tensors,
             placeholder_token_id: Some(151656),
             mm_placeholders: vec![(4, 2)],
@@ -1304,14 +1311,20 @@ mod tests {
         }
         .into_proto();
 
-        assert!(proto.pixel_values.is_none());
         assert_eq!(proto.items.len(), 1);
         let item = &proto.items[0];
         assert_eq!(item.modality, tokenspeed::Modality::Video as i32);
-        assert!(item.tensors.contains_key("pixel_values"));
-        assert!(item.tensors.contains_key("video_grid_thw"));
+        assert!(item.encoder_input.is_some());
+        assert!(item.model_specific_tensors.contains_key("video_grid_thw"));
         assert_eq!(item.placeholder_token_id, Some(151656));
         assert_eq!(item.placeholders[0].offset, 4);
         assert_eq!(item.placeholders[0].length, 2);
+    }
+
+    fn inline_tensor_data(tensor: &tokenspeed::TensorData) -> &[u8] {
+        match tensor.payload.as_ref() {
+            Some(tokenspeed::tensor_data::Payload::Inline(data)) => data,
+            _ => panic!("expected inline TensorData payload"),
+        }
     }
 }

--- a/model_gateway/src/routers/grpc/proto_wrapper.rs
+++ b/model_gateway/src/routers/grpc/proto_wrapper.rs
@@ -78,11 +78,20 @@ pub struct TrtllmMultimodalData {
 /// TokenSpeed multimodal data: preprocessed tensors with patch-only placeholders.
 #[derive(Debug)]
 pub struct TokenSpeedMultimodalData {
+    pub modality: TokenSpeedModality,
     pub pixel_values: Vec<u8>,
     pub pixel_values_shape: Vec<u32>,
     pub model_specific_tensors: HashMap<String, TensorBytes>,
-    pub im_token_id: Option<u32>,
+    pub placeholder_token_id: Option<u32>,
     pub mm_placeholders: Vec<(u32, u32)>,
+    pub content_hash: Vec<u8>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TokenSpeedModality {
+    Image,
+    Audio,
+    Video,
 }
 
 /// Raw tensor bytes with shape and dtype metadata.
@@ -190,37 +199,76 @@ impl TrtllmMultimodalData {
 impl TokenSpeedMultimodalData {
     /// Convert to TokenSpeed proto MultimodalInputs.
     pub fn into_proto(self) -> tokenspeed::MultimodalInputs {
-        let model_specific_tensors = self
+        let model_specific_tensors: HashMap<_, _> = self
             .model_specific_tensors
+            .clone()
             .into_iter()
-            .map(|(k, v)| {
-                (
-                    k,
-                    tokenspeed::TensorData {
-                        data: v.data,
-                        shape: v.shape,
-                        dtype: v.dtype,
-                    },
-                )
-            })
+            .map(|(k, v)| (k, tensor_bytes_to_tokenspeed(v)))
             .collect();
 
         let mm_placeholders = self
             .mm_placeholders
+            .iter()
+            .map(|&(offset, length)| tokenspeed::PlaceholderRange { offset, length })
+            .collect::<Vec<_>>();
+
+        let mut item_tensors = self
+            .model_specific_tensors
             .into_iter()
-            .map(|(offset, length)| tokenspeed::PlaceholderRange { offset, length })
-            .collect();
+            .map(|(k, v)| (k, tensor_bytes_to_tokenspeed(v)))
+            .collect::<HashMap<_, _>>();
+        item_tensors.insert(
+            "pixel_values".to_string(),
+            tokenspeed::TensorData {
+                data: self.pixel_values.clone(),
+                shape: self.pixel_values_shape.clone(),
+                dtype: "float32".to_string(),
+            },
+        );
+
+        let item = tokenspeed::MultimodalItem {
+            modality: match self.modality {
+                TokenSpeedModality::Image => tokenspeed::Modality::Image as i32,
+                TokenSpeedModality::Audio => tokenspeed::Modality::Audio as i32,
+                TokenSpeedModality::Video => tokenspeed::Modality::Video as i32,
+            },
+            content_hash: self.content_hash,
+            tensors: item_tensors,
+            placeholders: mm_placeholders.clone(),
+            placeholder_token_id: self.placeholder_token_id,
+        };
+
+        let (pixel_values, legacy_model_specific, im_token_id, legacy_placeholders) =
+            if self.modality == TokenSpeedModality::Image {
+                (
+                    Some(tokenspeed::TensorData {
+                        data: self.pixel_values,
+                        shape: self.pixel_values_shape,
+                        dtype: "float32".to_string(),
+                    }),
+                    model_specific_tensors,
+                    self.placeholder_token_id,
+                    mm_placeholders,
+                )
+            } else {
+                (None, HashMap::new(), None, Vec::new())
+            };
 
         tokenspeed::MultimodalInputs {
-            pixel_values: Some(tokenspeed::TensorData {
-                data: self.pixel_values,
-                shape: self.pixel_values_shape,
-                dtype: "float32".to_string(),
-            }),
-            model_specific_tensors,
-            im_token_id: self.im_token_id,
-            mm_placeholders,
+            pixel_values,
+            model_specific_tensors: legacy_model_specific,
+            im_token_id,
+            mm_placeholders: legacy_placeholders,
+            items: vec![item],
         }
+    }
+}
+
+fn tensor_bytes_to_tokenspeed(value: TensorBytes) -> tokenspeed::TensorData {
+    tokenspeed::TensorData {
+        data: value.data,
+        shape: value.shape,
+        dtype: value.dtype,
     }
 }
 
@@ -1226,5 +1274,44 @@ impl ProtoEmbedComplete {
             Self::Sglang(r) => r.embedding_dim,
             Self::Vllm(r) => r.embedding_dim,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tokenspeed_video_into_proto_uses_itemized_payload() {
+        let mut model_specific_tensors = HashMap::new();
+        model_specific_tensors.insert(
+            "video_grid_thw".to_string(),
+            TensorBytes {
+                data: vec![1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0],
+                shape: vec![1, 3],
+                dtype: "uint32".to_string(),
+            },
+        );
+
+        let proto = TokenSpeedMultimodalData {
+            modality: TokenSpeedModality::Video,
+            pixel_values: vec![0; 8],
+            pixel_values_shape: vec![1, 2],
+            model_specific_tensors,
+            placeholder_token_id: Some(151656),
+            mm_placeholders: vec![(4, 2)],
+            content_hash: vec![7; 32],
+        }
+        .into_proto();
+
+        assert!(proto.pixel_values.is_none());
+        assert_eq!(proto.items.len(), 1);
+        let item = &proto.items[0];
+        assert_eq!(item.modality, tokenspeed::Modality::Video as i32);
+        assert!(item.tensors.contains_key("pixel_values"));
+        assert!(item.tensors.contains_key("video_grid_thw"));
+        assert_eq!(item.placeholder_token_id, Some(151656));
+        assert_eq!(item.placeholders[0].offset, 4);
+        assert_eq!(item.placeholders[0].length, 2);
     }
 }

--- a/model_gateway/src/routers/grpc/proto_wrapper.rs
+++ b/model_gateway/src/routers/grpc/proto_wrapper.rs
@@ -29,10 +29,10 @@ use smg_grpc_client::{
 /// Backend-specific multimodal data produced by the assembly stage.
 ///
 /// Each variant carries only the fields its backend needs:
-/// - SGLang: pixel_values + model_specific_tensors + patch-only placeholders
-/// - vLLM: pixel_values + model_specific_tensors + structural placeholders + hashes + field keys
+/// - SGLang: preprocessed vision tensor + model-specific tensors + patch-only placeholders
+/// - vLLM: preprocessed vision tensor + model-specific tensors + structural placeholders + hashes + field keys
 /// - TRT-LLM: raw image bytes only (preprocessing handled server-side)
-/// - TokenSpeed: pixel_values + model_specific_tensors + patch-only placeholders
+/// - TokenSpeed: encoder_input + model_specific_tensors + patch-only placeholders
 #[derive(Debug)]
 pub enum MultimodalData {
     Sglang(SglangMultimodalData),
@@ -78,9 +78,14 @@ pub struct TrtllmMultimodalData {
 /// TokenSpeed multimodal data: preprocessed tensors with patch-only placeholders.
 #[derive(Debug)]
 pub struct TokenSpeedMultimodalData {
+    pub items: Vec<TokenSpeedMultimodalItem>,
+}
+
+#[derive(Debug)]
+pub struct TokenSpeedMultimodalItem {
     pub modality: TokenSpeedModality,
-    pub pixel_values: Vec<u8>,
-    pub pixel_values_shape: Vec<u32>,
+    pub encoder_input: Vec<u8>,
+    pub encoder_input_shape: Vec<u32>,
     pub encoder_input_dtype: String,
     pub model_specific_tensors: HashMap<String, TensorBytes>,
     pub placeholder_token_id: Option<u32>,
@@ -200,7 +205,18 @@ impl TrtllmMultimodalData {
 impl TokenSpeedMultimodalData {
     /// Convert to TokenSpeed proto MultimodalInputs.
     pub fn into_proto(self) -> tokenspeed::MultimodalInputs {
-        let mm_placeholders = self
+        let items = self
+            .items
+            .into_iter()
+            .map(TokenSpeedMultimodalItem::into_proto)
+            .collect();
+        tokenspeed::MultimodalInputs { items }
+    }
+}
+
+impl TokenSpeedMultimodalItem {
+    fn into_proto(self) -> tokenspeed::MultimodalItem {
+        let placeholders = self
             .mm_placeholders
             .into_iter()
             .map(|(offset, length)| tokenspeed::PlaceholderRange { offset, length })
@@ -212,7 +228,7 @@ impl TokenSpeedMultimodalData {
             .map(|(k, v)| (k, tensor_bytes_to_tokenspeed(v)))
             .collect::<HashMap<_, _>>();
 
-        let item = tokenspeed::MultimodalItem {
+        tokenspeed::MultimodalItem {
             modality: match self.modality {
                 TokenSpeedModality::Image => tokenspeed::Modality::Image as i32,
                 TokenSpeedModality::Audio => tokenspeed::Modality::Audio as i32,
@@ -220,16 +236,14 @@ impl TokenSpeedMultimodalData {
             },
             content_hash: self.content_hash,
             encoder_input: Some(tensor_bytes_to_tokenspeed(TensorBytes {
-                data: self.pixel_values,
-                shape: self.pixel_values_shape,
+                data: self.encoder_input,
+                shape: self.encoder_input_shape,
                 dtype: self.encoder_input_dtype,
             })),
             model_specific_tensors,
-            placeholders: mm_placeholders,
+            placeholders,
             placeholder_token_id: self.placeholder_token_id,
-        };
-
-        tokenspeed::MultimodalInputs { items: vec![item] }
+        }
     }
 }
 
@@ -1265,14 +1279,16 @@ mod tests {
         );
 
         let proto = TokenSpeedMultimodalData {
-            modality: TokenSpeedModality::Image,
-            pixel_values: vec![42; 8],
-            pixel_values_shape: vec![1, 2],
-            encoder_input_dtype: "float32".to_string(),
-            model_specific_tensors,
-            placeholder_token_id: Some(151655),
-            mm_placeholders: vec![(4, 2)],
-            content_hash: vec![7; 32],
+            items: vec![TokenSpeedMultimodalItem {
+                modality: TokenSpeedModality::Image,
+                encoder_input: vec![42; 8],
+                encoder_input_shape: vec![1, 2],
+                encoder_input_dtype: "float32".to_string(),
+                model_specific_tensors,
+                placeholder_token_id: Some(151655),
+                mm_placeholders: vec![(4, 2)],
+                content_hash: vec![7; 32],
+            }],
         }
         .into_proto();
 
@@ -1302,14 +1318,16 @@ mod tests {
         );
 
         let proto = TokenSpeedMultimodalData {
-            modality: TokenSpeedModality::Video,
-            pixel_values: vec![0; 8],
-            pixel_values_shape: vec![1, 2],
-            encoder_input_dtype: "float32".to_string(),
-            model_specific_tensors,
-            placeholder_token_id: Some(151656),
-            mm_placeholders: vec![(4, 2)],
-            content_hash: vec![7; 32],
+            items: vec![TokenSpeedMultimodalItem {
+                modality: TokenSpeedModality::Video,
+                encoder_input: vec![0; 8],
+                encoder_input_shape: vec![1, 2],
+                encoder_input_dtype: "float32".to_string(),
+                model_specific_tensors,
+                placeholder_token_id: Some(151656),
+                mm_placeholders: vec![(4, 2)],
+                content_hash: vec![7; 32],
+            }],
         }
         .into_proto();
 

--- a/model_gateway/src/routers/grpc/proto_wrapper.rs
+++ b/model_gateway/src/routers/grpc/proto_wrapper.rs
@@ -1263,6 +1263,8 @@ impl ProtoEmbedComplete {
 
 #[cfg(test)]
 mod tests {
+    use prost::Message;
+
     use super::*;
 
     #[test]
@@ -1319,7 +1321,7 @@ mod tests {
         let proto = TokenSpeedMultimodalData {
             items: vec![TokenSpeedMultimodalItem {
                 modality: TokenSpeedModality::Video,
-                encoder_input: vec![0; 8],
+                encoder_input: vec![42; 8],
                 encoder_input_shape: vec![1, 2],
                 encoder_input_dtype: "float32".to_string(),
                 model_specific_tensors,
@@ -1333,11 +1335,32 @@ mod tests {
         assert_eq!(proto.items.len(), 1);
         let item = &proto.items[0];
         assert_eq!(item.modality, tokenspeed::Modality::Video as i32);
-        assert!(item.encoder_input.is_some());
-        assert!(item.model_specific_tensors.contains_key("video_grid_thw"));
         assert_eq!(item.placeholder_token_id, Some(151656));
         assert_eq!(item.placeholders[0].offset, 4);
         assert_eq!(item.placeholders[0].length, 2);
+        assert_eq!(
+            inline_tensor_data(item.encoder_input.as_ref().unwrap()),
+            &[42; 8]
+        );
+        assert!(item.model_specific_tensors.contains_key("video_grid_thw"));
+    }
+
+    #[test]
+    fn tokenspeed_tensor_data_uses_clean_payload_tags() {
+        let tensor = tensor_bytes_to_tokenspeed(TensorBytes {
+            data: vec![0xaa, 0xbb],
+            shape: vec![2, 3],
+            dtype: "uint32".to_string(),
+        });
+
+        assert_eq!(
+            tensor.encode_to_vec(),
+            vec![
+                0x0a, 0x02, 0x02, 0x03, // shape = 1, packed uint32 [2, 3]
+                0x12, 0x06, b'u', b'i', b'n', b't', b'3', b'2', // dtype = 2
+                0x1a, 0x02, 0xaa, 0xbb, // inline = 3
+            ]
+        );
     }
 
     fn inline_tensor_data(tensor: &tokenspeed::TensorData) -> &[u8] {

--- a/model_gateway/src/routers/grpc/proto_wrapper.rs
+++ b/model_gateway/src/routers/grpc/proto_wrapper.rs
@@ -234,10 +234,12 @@ impl TokenSpeedMultimodalData {
 }
 
 fn tensor_bytes_to_tokenspeed(value: TensorBytes) -> tokenspeed::TensorData {
+    let data = value.data;
     tokenspeed::TensorData {
+        data: data.clone(),
         shape: value.shape,
         dtype: value.dtype,
-        payload: Some(tokenspeed::tensor_data::Payload::Inline(value.data)),
+        payload: Some(tokenspeed::tensor_data::Payload::Inline(data)),
     }
 }
 

--- a/model_gateway/src/routers/grpc/proto_wrapper.rs
+++ b/model_gateway/src/routers/grpc/proto_wrapper.rs
@@ -250,7 +250,6 @@ impl TokenSpeedMultimodalItem {
 fn tensor_bytes_to_tokenspeed(value: TensorBytes) -> tokenspeed::TensorData {
     let data = value.data;
     tokenspeed::TensorData {
-        data: data.clone(),
         shape: value.shape,
         dtype: value.dtype,
         payload: Some(tokenspeed::tensor_data::Payload::Inline(data)),

--- a/model_gateway/src/routers/grpc/regular/stages/chat/preparation.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/chat/preparation.rs
@@ -53,8 +53,16 @@ impl ChatPreparationStage {
         // The placeholder is passed to process_chat_messages so that string-format chat
         // templates insert it per image instead of stripping image parts.  The remaining
         // fields are reused by process_multimodal to avoid duplicate lookups.
-        let is_multimodal = multimodal::has_multimodal_content(&request.messages);
-        let (image_placeholder, mm_context) = if is_multimodal {
+        let modalities = multimodal::chat_modalities(&request.messages);
+        if modalities.len() > 1 {
+            // TODO: Support mixed multimodal requests
+            return Err(error::bad_request(
+                "mixed_multimodal_not_supported",
+                "Mixed image and video requests are not supported yet".to_string(),
+            ));
+        }
+        let request_modality = modalities.first().copied();
+        let (image_placeholder, mm_context) = if let Some(request_modality) = request_modality {
             if let Some(mm_components) = ctx.components.multimodal.as_ref() {
                 let model_id = ctx.input.model_id.as_str();
                 let entry = ctx
@@ -84,6 +92,7 @@ impl ChatPreparationStage {
                     mm_components,
                     &tokenizer_id,
                     &tokenizer_source,
+                    request_modality,
                 )
                 .await
                 .map_err(|e| {

--- a/model_gateway/src/routers/grpc/regular/stages/chat/request_building.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/chat/request_building.rs
@@ -86,7 +86,9 @@ impl PipelineStage for ChatRequestBuildingStage {
         // Assemble backend-specific multimodal data now that the backend is known
         let multimodal_data = processed_messages
             .multimodal_intermediate
-            .map(|intermediate| assemble_multimodal_data(intermediate, builder_client))
+            .map(|intermediate| {
+                assemble_multimodal_data(intermediate, builder_client, ctx.state.workers.as_ref())
+            })
             .transpose()
             .map_err(|e| {
                 error!(function = "ChatRequestBuildingStage::execute", error = %e, "Failed to assemble multimodal request");

--- a/model_gateway/src/routers/grpc/regular/stages/chat/request_building.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/chat/request_building.rs
@@ -86,7 +86,12 @@ impl PipelineStage for ChatRequestBuildingStage {
         // Assemble backend-specific multimodal data now that the backend is known
         let multimodal_data = processed_messages
             .multimodal_intermediate
-            .map(|intermediate| assemble_multimodal_data(intermediate, builder_client));
+            .map(|intermediate| assemble_multimodal_data(intermediate, builder_client))
+            .transpose()
+            .map_err(|e| {
+                error!(function = "ChatRequestBuildingStage::execute", error = %e, "Failed to assemble multimodal request");
+                error::bad_request("multimodal_not_supported", format!("{e}"))
+            })?;
 
         let mut proto_request = builder_client
             .build_chat_request(

--- a/model_gateway/src/routers/grpc/regular/stages/messages/preparation.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/messages/preparation.rs
@@ -2,6 +2,7 @@
 
 use async_trait::async_trait;
 use axum::response::Response;
+use llm_multimodal::Modality;
 use openai_protocol::{
     common::{StringOrArray, ToolChoice, ToolChoiceValue},
     messages::CreateMessageRequest,
@@ -106,6 +107,7 @@ impl MessagePreparationStage {
                     mm_components,
                     &tokenizer_id,
                     &tokenizer_source,
+                    Modality::Image,
                 )
                 .await
                 .map_err(|e| {

--- a/model_gateway/src/routers/grpc/regular/stages/messages/request_building.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/messages/request_building.rs
@@ -87,7 +87,9 @@ impl PipelineStage for MessageRequestBuildingStage {
         // Assemble backend-specific multimodal data now that the backend is known
         let multimodal_data = processed_messages
             .multimodal_intermediate
-            .map(|intermediate| assemble_multimodal_data(intermediate, builder_client))
+            .map(|intermediate| {
+                assemble_multimodal_data(intermediate, builder_client, ctx.state.workers.as_ref())
+            })
             .transpose()
             .map_err(|e| {
                 error!(function = "MessageRequestBuildingStage::execute", error = %e, "Failed to assemble multimodal request");

--- a/model_gateway/src/routers/grpc/regular/stages/messages/request_building.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/messages/request_building.rs
@@ -87,7 +87,12 @@ impl PipelineStage for MessageRequestBuildingStage {
         // Assemble backend-specific multimodal data now that the backend is known
         let multimodal_data = processed_messages
             .multimodal_intermediate
-            .map(|intermediate| assemble_multimodal_data(intermediate, builder_client));
+            .map(|intermediate| assemble_multimodal_data(intermediate, builder_client))
+            .transpose()
+            .map_err(|e| {
+                error!(function = "MessageRequestBuildingStage::execute", error = %e, "Failed to assemble multimodal request");
+                error::bad_request("multimodal_not_supported", format!("{e}"))
+            })?;
 
         let mut proto_request = builder_client
             .build_messages_request(

--- a/model_gateway/src/routers/grpc/utils/chat_utils.rs
+++ b/model_gateway/src/routers/grpc/utils/chat_utils.rs
@@ -153,7 +153,7 @@ pub(crate) fn process_content_format(
 /// Transform a single content field based on content format.
 ///
 /// When `image_placeholder` is provided and the content format is `String`,
-/// each `image_url` part is replaced with the placeholder string instead of
+/// each media URL part is replaced with the placeholder string instead of
 /// being stripped.  This mirrors vLLM's behavior of injecting model-specific
 /// placeholder tokens (e.g. `"<|image|>"`) so that the tokenizer produces
 /// token IDs the multimodal expansion step can find and replace.
@@ -177,6 +177,7 @@ fn transform_content_field(
                     match type_str {
                         "text" => obj.get("text")?.as_str().map(String::from),
                         "image_url" => image_placeholder.map(String::from),
+                        "video_url" => image_placeholder.map(String::from),
                         _ => None,
                     }
                 })

--- a/model_gateway/src/routers/grpc/utils/chat_utils.rs
+++ b/model_gateway/src/routers/grpc/utils/chat_utils.rs
@@ -586,7 +586,7 @@ mod tests {
     use llm_tokenizer::chat_template::ChatTemplateContentFormat;
     use openai_protocol::{
         chat::{ChatMessage, MessageContent},
-        common::{ContentPart, ImageUrl},
+        common::{ContentPart, ImageUrl, VideoUrl},
     };
     use serde_json::json;
 
@@ -624,6 +624,35 @@ mod tests {
             "Hello\nWorld"
         );
         assert_eq!(transformed_message["role"].as_str().unwrap(), "user");
+    }
+
+    #[test]
+    fn test_transform_messages_string_format_with_video_placeholder() {
+        let messages = vec![ChatMessage::User {
+            content: MessageContent::Parts(vec![
+                ContentPart::Text {
+                    text: "Watch this".to_string(),
+                },
+                ContentPart::VideoUrl {
+                    video_url: VideoUrl {
+                        url: "https://example.com/video.mp4".to_string(),
+                    },
+                },
+            ]),
+            name: None,
+        }];
+
+        let result = process_content_format(
+            &messages,
+            ChatTemplateContentFormat::String,
+            Some("<|video|>"),
+        )
+        .unwrap();
+
+        assert_eq!(
+            result[0]["content"].as_str().unwrap(),
+            "Watch this\n<|video|>"
+        );
     }
 
     #[test]

--- a/model_gateway/src/workflow/tokenizer_registration.rs
+++ b/model_gateway/src/workflow/tokenizer_registration.rs
@@ -26,8 +26,12 @@ use wfaas::{
 
 use super::data::TokenizerWorkflowData;
 use crate::{
-    app_context::AppContext, config::TokenizerCacheConfig,
-    routers::grpc::multimodal::MultimodalModelConfig, worker::ConnectionMode,
+    app_context::AppContext,
+    config::TokenizerCacheConfig,
+    routers::grpc::multimodal::{
+        load_preprocessor_config_file, load_video_preprocessor_config, MultimodalModelConfig,
+    },
+    worker::ConnectionMode,
 };
 
 /// Configuration for adding a tokenizer
@@ -264,33 +268,18 @@ fn try_load_multimodal_config(tokenizer_dir: &std::path::Path) -> Option<Multimo
     };
 
     let preprocessor_config = if pp_config_path.exists() {
-        match std::fs::read_to_string(&pp_config_path) {
-            Ok(pp_str) => match llm_multimodal::PreProcessorConfig::from_json(&pp_str) {
-                Ok(c) => c,
-                Err(e) => {
-                    warn!(
-                        "Failed to parse preprocessor_config.json from bundle: {e}; \
-                         falling back to defaults"
-                    );
-                    llm_multimodal::PreProcessorConfig::default()
-                }
-            },
-            Err(e) => {
-                warn!(
-                    "Failed to read preprocessor_config.json from bundle: {e}; \
-                     falling back to defaults"
-                );
-                llm_multimodal::PreProcessorConfig::default()
-            }
-        }
+        load_preprocessor_config_file(&pp_config_path, "preprocessor_config.json")
+            .unwrap_or_default()
     } else {
         debug!("No preprocessor_config.json in bundle; using PreProcessorConfig defaults");
         llm_multimodal::PreProcessorConfig::default()
     };
+    let video_preprocessor_config = load_video_preprocessor_config(tokenizer_dir);
 
     Some(MultimodalModelConfig {
         config,
         preprocessor_config,
+        video_preprocessor_config,
     })
 }
 


### PR DESCRIPTION
## Description

  ### Problem

  SMG multimodal support was still structured around an image-only payload shape. This makes it hard to extend the existing precomputed multimodal path to additional modalities such as video and audio without adding more image-specific fields and special cases.

  The gateway also needed a cleaner foundation for passing preprocessed multimodal encoder inputs, model-specific metadata, placeholder ranges, and modality information to TokenSpeed.

  ### Solution

  This PR generalizes the TokenSpeed multimodal ABI from a single image payload into itemized multimodal inputs. Each multimodal item now carries its own modality, encoder input tensor, model-specific side tensors, placeholder metadata, placeholder token id, and content hash.

  This keeps the current precomputed multimodal design, but removes the image-only payload assumption so later PRs can add video and transport optimizations on top of the same structure.

  ## Changes

  - Generalized TokenSpeed MultimodalInputs to contain repeated MultimodalItems.
  - Added modality metadata for image, video, and audio.
  - Replaced image-specific TokenSpeed fields with per-item:
      - encoder_input
      - model_specific_tensors
      - placeholders
      - placeholder_token_id
      - content_hash

  - Updated SMG TokenSpeed proto conversion to emit itemized multimodal payloads.
  - Updated the TokenSpeed Python servicer to consume the itemized multimodal payload.
  - Preserved existing image behavior on top of the new generalized payload structure.
  - Added model/tokenizer config loading support needed for multimodal preprocessor metadata.
  - Avoided warning spam when processor_config.json exists but does not contain video_processor.
  - Added regression coverage for video_processor config loading behavior.

  ## Test Plan

  - Verified the stacked branch diff against the original implementation branch.
  - Verified whitespace/diff hygiene:

    git diff --check
  <details>
  <summary>Checklist</summary>

  - [ ] cargo +nightly fmt passes
  - [ ] cargo clippy --all-targets --all-features -- -D warnings passes
  - [ ] (Optional) Documentation updated
  - [ ] (Optional) Please join us on Slack #sig-smg (https://slack.lightseek.org) to discuss, review, and merge PRs
  </details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full video support alongside images: fetching, decoding, frame sampling, and preprocessing.
  * Modality-aware multimodal requests and placeholder handling (image vs video).
  * Itemized encoder-input payloads with flexible tensor transport (inline, shared memory, remote).
  * Model info now reports multimodal capability, supported modalities, and encoder dtypes.
  * Deterministic media content hashing and improved preprocessor config loading.

* **Bug Fixes**
  * Rejects mixed image+video requests; stronger multimodal payload validation and decoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->