### PR TITLE
feat(skills): inject Tier-1 skill listing into /v1/responses

### DIFF
--- a/crates/skills/src/lib.rs
+++ b/crates/skills/src/lib.rs
@@ -7,6 +7,7 @@
 pub mod api;
 pub mod config;
 pub mod memory;
+pub mod request_injection;
 pub mod resolution;
 pub mod storage;
 pub mod tool_protocol;
@@ -28,6 +29,10 @@ pub use config::{
     SkillsTenancyConfig, SkillsToolLoopConfig, SkillsZdrConfig,
 };
 pub use memory::InMemorySkillStore;
+pub use request_injection::{
+    build_tier1_listing, collect_manifest_listing_entries, inject_responses_tier1_listing,
+    manifest_storage_skill_ids, SkillListingEntry,
+};
 pub use resolution::{
     resolve_messages_skill_manifest, resolve_responses_skill_manifest, ResolvedSkillManifest,
     ResolvedSkillRef, SkillResolutionError,

--- a/crates/skills/src/lib.rs
+++ b/crates/skills/src/lib.rs
@@ -31,7 +31,7 @@ pub use config::{
 pub use memory::InMemorySkillStore;
 pub use request_injection::{
     build_tier1_listing, collect_manifest_listing_entries, inject_responses_tier1_listing,
-    manifest_storage_skill_ids, SkillListingEntry,
+    SkillListingEntry,
 };
 pub use resolution::{
     resolve_messages_skill_manifest, resolve_responses_skill_manifest, ResolvedSkillManifest,

--- a/crates/skills/src/request_injection.rs
+++ b/crates/skills/src/request_injection.rs
@@ -1,0 +1,457 @@
+//! Tier-1 skill listing construction and outbound-request injection.
+//!
+//! Request-time skill *resolution* (see [`crate::resolution`]) produces a
+//! [`ResolvedSkillManifest`], but that manifest has no effect until the gateway
+//! discloses it to the model. This module owns the read-side "Tier-1" disclosure
+//! step for the Responses surface: it formats a compact listing of the attached
+//! skills (name + short description) under a configurable token budget and
+//! prepends it to the request's system `instructions` before the first model
+//! turn (issue #1193).
+//!
+//! The async lookups needed to enrich storage-backed refs into displayable
+//! `(name, description)` pairs live in the gateway (it owns the
+//! [`crate::SkillService`]); this module is pure formatting + injection so the
+//! budget math and wire shaping stay unit-testable without IO.
+
+use openai_protocol::responses::ResponsesRequest;
+
+use crate::{
+    api::SkillService,
+    config::SkillsBudgetLimit,
+    resolution::{ResolvedSkillManifest, ResolvedSkillRef},
+};
+
+/// Heading the Tier-1 listing is injected under. Mirrors the
+/// `skills_instructions` vocabulary the reserved read tools reference in their
+/// descriptions (see [`crate::tool_schemas`]).
+const TIER1_LISTING_HEADING: &str = "# skills_instructions";
+
+/// Preamble appended after the heading to orient the model.
+const TIER1_LISTING_PREAMBLE: &str =
+    "The following skills are attached to this request. Each entry lists a skill \
+     id, name, and description. When the user's task matches a skill, use the \
+     skill's instructions; if read tools are available, call them to load the \
+     full SKILL.md before acting.";
+
+/// A single skill rendered into the Tier-1 listing.
+///
+/// The gateway builds these from a [`ResolvedSkillManifest`], resolving
+/// storage-backed refs to their pinned name/description via the
+/// [`crate::SkillService`]. Pass-through provider refs that SMG cannot describe
+/// are represented with whatever identifying text is available.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SkillListingEntry {
+    /// Stable identifier the model uses to name the skill in read-tool calls.
+    pub skill_id: String,
+    /// Human-readable skill name.
+    pub name: String,
+    /// Short description; empty when none is known.
+    pub description: String,
+}
+
+impl SkillListingEntry {
+    /// Render this entry into a single compact listing line.
+    fn render(&self) -> String {
+        let description = self.description.trim();
+        if description.is_empty() {
+            format!("- {} ({})", self.name.trim(), self.skill_id.trim())
+        } else {
+            format!(
+                "- {} ({}): {}",
+                self.name.trim(),
+                self.skill_id.trim(),
+                description
+            )
+        }
+    }
+}
+
+/// Identify the storage-backed manifest entries whose name/description the
+/// gateway still has to resolve via the [`crate::SkillService`].
+///
+/// Storage-backed refs only carry an id + pinned version at resolution time, so
+/// the gateway must enrich them; this helper exposes the ids that need a lookup
+/// so callers do not have to re-match the enum.
+#[must_use]
+pub fn manifest_storage_skill_ids(manifest: &ResolvedSkillManifest) -> Vec<String> {
+    manifest
+        .refs()
+        .iter()
+        .filter_map(|skill_ref| match skill_ref {
+            ResolvedSkillRef::SmgStorage { skill_id, .. } => Some(skill_id.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Build the compact Tier-1 listing text from already-resolved listing entries,
+/// honoring `budget`.
+///
+/// Returns `None` when there is nothing to disclose or the budget is too small
+/// to fit even a single entry. The budget is a *token* budget; we approximate
+/// tokens as `ceil(chars / 4)`, the conventional rough ratio, so this stays
+/// dependency-free and deterministic. Entries are appended in order until the
+/// next one would exceed the budget, at which point the listing is truncated and
+/// a trailing note records how many skills were omitted.
+#[must_use]
+pub fn build_tier1_listing(
+    entries: &[SkillListingEntry],
+    budget: SkillsBudgetLimit,
+) -> Option<String> {
+    if entries.is_empty() {
+        return None;
+    }
+
+    let max_tokens = match budget {
+        SkillsBudgetLimit::Unlimited => None,
+        SkillsBudgetLimit::Tokens(0) => return None,
+        SkillsBudgetLimit::Tokens(tokens) => Some(tokens as usize),
+    };
+
+    let header = format!("{TIER1_LISTING_HEADING}\n{TIER1_LISTING_PREAMBLE}");
+    let mut body = String::new();
+    let mut included = 0usize;
+
+    for entry in entries {
+        let candidate_line = entry.render();
+        let projected = format!("{header}\n{body}\n{candidate_line}");
+        if let Some(max_tokens) = max_tokens {
+            if approximate_token_count(&projected) > max_tokens {
+                break;
+            }
+        }
+        body.push('\n');
+        body.push_str(&candidate_line);
+        included += 1;
+    }
+
+    if included == 0 {
+        // Budget could not fit even the first entry alongside the header.
+        return None;
+    }
+
+    let omitted = entries.len() - included;
+    let mut listing = format!("{header}{body}");
+    if omitted > 0 {
+        listing.push_str(&format!(
+            "\n- (+{omitted} more skill(s) omitted to fit the instruction budget)"
+        ));
+    }
+    Some(listing)
+}
+
+/// Resolve a [`ResolvedSkillManifest`] into displayable Tier-1 listing entries.
+///
+/// Storage-backed (`SmgStorage`) refs are enriched with the pinned version's
+/// name/description via `service`; a lookup failure degrades gracefully to the
+/// bare skill id rather than failing the whole request. Client-local refs use
+/// their declared name/description. Opaque provider pass-through objects are
+/// skipped — SMG does not own their disclosure and cannot describe them.
+pub async fn collect_manifest_listing_entries(
+    service: Option<&SkillService>,
+    tenant_id: &str,
+    manifest: &ResolvedSkillManifest,
+) -> Vec<SkillListingEntry> {
+    let mut entries = Vec::with_capacity(manifest.refs().len());
+    for skill_ref in manifest.refs() {
+        match skill_ref {
+            ResolvedSkillRef::SmgStorage {
+                skill_id, pinned, ..
+            } => {
+                let (name, description) = match service {
+                    Some(service) => service
+                        .get_skill_version(tenant_id, skill_id, &pinned.version)
+                        .await
+                        .map(|record| {
+                            let description = record
+                                .short_description
+                                .filter(|value| !value.trim().is_empty())
+                                .unwrap_or(record.description);
+                            (record.name, description)
+                        })
+                        .unwrap_or_else(|_| (skill_id.clone(), String::new())),
+                    None => (skill_id.clone(), String::new()),
+                };
+                entries.push(SkillListingEntry {
+                    skill_id: skill_id.clone(),
+                    name,
+                    description,
+                });
+            }
+            ResolvedSkillRef::ClientLocalPath {
+                name, description, ..
+            } => entries.push(SkillListingEntry {
+                skill_id: name.clone(),
+                name: name.clone(),
+                description: description.clone(),
+            }),
+            // Provider-owned refs are disclosed by the provider itself; SMG has
+            // no local name/description to surface, so they are not listed.
+            ResolvedSkillRef::AnthropicProvider { .. }
+            | ResolvedSkillRef::OpenAIProvider { .. }
+            | ResolvedSkillRef::OpenAIOpaquePassThrough { .. } => {}
+        }
+    }
+    entries
+}
+
+/// Prepend an already-built Tier-1 listing to a Responses request's system
+/// `instructions`.
+///
+/// Existing instructions are preserved and pushed below the listing so the
+/// skill disclosure is the first thing the model reads. A no-op when `listing`
+/// is empty.
+pub fn inject_responses_tier1_listing(request: &mut ResponsesRequest, listing: &str) {
+    if listing.is_empty() {
+        return;
+    }
+
+    request.instructions = Some(match request.instructions.take() {
+        Some(existing) if !existing.trim().is_empty() => format!("{listing}\n\n{existing}"),
+        _ => listing.to_string(),
+    });
+}
+
+/// Approximate the token count of `text` using the conventional ~4 chars/token
+/// heuristic. Rounds up so a non-empty string always costs at least one token.
+fn approximate_token_count(text: &str) -> usize {
+    text.len().div_ceil(4)
+}
+
+#[cfg(test)]
+mod tests {
+    use openai_protocol::responses::{ResponseInput, ResponsesRequest};
+
+    use super::*;
+    use crate::{PinnedSkillVersion, ResolvedSkillManifest, ResolvedSkillRef};
+
+    fn entry(skill_id: &str, name: &str, description: &str) -> SkillListingEntry {
+        SkillListingEntry {
+            skill_id: skill_id.to_string(),
+            name: name.to_string(),
+            description: description.to_string(),
+        }
+    }
+
+    #[test]
+    fn build_listing_includes_each_skill_name_and_description() {
+        let entries = vec![
+            entry("skill_a", "acme:map", "Map the repo"),
+            entry("skill_b", "acme:search", "Search the repo"),
+        ];
+
+        let listing = build_tier1_listing(&entries, SkillsBudgetLimit::Unlimited)
+            .expect("listing should be produced");
+
+        assert!(listing.contains(TIER1_LISTING_HEADING));
+        assert!(listing.contains("acme:map"));
+        assert!(listing.contains("skill_a"));
+        assert!(listing.contains("Map the repo"));
+        assert!(listing.contains("acme:search"));
+        assert!(listing.contains("Search the repo"));
+    }
+
+    #[test]
+    fn build_listing_returns_none_for_empty_entries() {
+        assert!(build_tier1_listing(&[], SkillsBudgetLimit::Unlimited).is_none());
+    }
+
+    #[test]
+    fn build_listing_returns_none_for_zero_budget() {
+        let entries = vec![entry("skill_a", "acme:map", "Map the repo")];
+        assert!(build_tier1_listing(&entries, SkillsBudgetLimit::Tokens(0)).is_none());
+    }
+
+    #[test]
+    fn build_listing_truncates_to_budget_and_records_omitted() {
+        let entries = vec![
+            entry(
+                "skill_a",
+                "acme:map",
+                "Map the repo with ripgrep and friends",
+            ),
+            entry("skill_b", "acme:search", "Search the repo thoroughly"),
+            entry("skill_c", "acme:lint", "Lint everything in the repo"),
+        ];
+
+        // A tight budget that fits the header + first entry (~84 tokens) but
+        // not the second (~97 tokens), exercising mid-list truncation.
+        let listing = build_tier1_listing(&entries, SkillsBudgetLimit::Tokens(90))
+            .expect("at least one entry should fit");
+
+        assert!(listing.contains("acme:map"));
+        assert!(
+            listing.contains("more skill(s) omitted"),
+            "expected truncation note, got: {listing}"
+        );
+        // Skills beyond the budget must not appear once truncated.
+        assert!(!listing.contains("acme:search"));
+        assert!(!listing.contains("acme:lint"));
+    }
+
+    #[test]
+    fn build_listing_returns_none_when_budget_cannot_fit_first_entry() {
+        let entries = vec![entry(
+            "skill_a",
+            "acme:map",
+            "Map the repo with ripgrep and friends",
+        )];
+        // Header alone is ~68 tokens; a budget below header+entry0 cannot fit
+        // even the first line, so nothing is disclosed.
+        assert!(build_tier1_listing(&entries, SkillsBudgetLimit::Tokens(70)).is_none());
+    }
+
+    #[test]
+    fn build_listing_handles_missing_description() {
+        let entries = vec![entry("skill_a", "acme:map", "")];
+        let listing = build_tier1_listing(&entries, SkillsBudgetLimit::Unlimited)
+            .expect("listing should be produced");
+        assert!(listing.contains("acme:map (skill_a)"));
+    }
+
+    #[test]
+    fn inject_prepends_listing_above_existing_instructions() {
+        let mut request = ResponsesRequest {
+            model: "gpt-5.1".to_string(),
+            input: ResponseInput::Text("hi".to_string()),
+            instructions: Some("Existing system prompt.".to_string()),
+            ..Default::default()
+        };
+
+        inject_responses_tier1_listing(&mut request, "LISTING-TEXT");
+
+        let instructions = request.instructions.expect("instructions set");
+        assert!(instructions.starts_with("LISTING-TEXT"));
+        assert!(instructions.contains("Existing system prompt."));
+        // Listing must precede the prior prompt.
+        let listing_idx = instructions.find("LISTING-TEXT").unwrap();
+        let existing_idx = instructions.find("Existing system prompt.").unwrap();
+        assert!(listing_idx < existing_idx);
+    }
+
+    #[test]
+    fn inject_sets_instructions_when_absent() {
+        let mut request = ResponsesRequest {
+            model: "gpt-5.1".to_string(),
+            input: ResponseInput::Text("hi".to_string()),
+            instructions: None,
+            ..Default::default()
+        };
+
+        inject_responses_tier1_listing(&mut request, "LISTING-TEXT");
+        assert_eq!(request.instructions.as_deref(), Some("LISTING-TEXT"));
+    }
+
+    #[test]
+    fn inject_is_noop_for_empty_listing() {
+        let mut request = ResponsesRequest {
+            model: "gpt-5.1".to_string(),
+            input: ResponseInput::Text("hi".to_string()),
+            instructions: Some("Keep me.".to_string()),
+            ..Default::default()
+        };
+        inject_responses_tier1_listing(&mut request, "");
+        assert_eq!(request.instructions.as_deref(), Some("Keep me."));
+    }
+
+    #[tokio::test]
+    async fn collect_entries_enriches_storage_refs_via_service() -> Result<(), anyhow::Error> {
+        use std::sync::Arc;
+
+        use smg_blob_storage::FilesystemBlobStore;
+        use tempfile::TempDir;
+
+        use crate::{CreateSkillRequest, SkillService, SkillUpload, UploadedSkillFile};
+
+        let root = TempDir::new()?;
+        let blob_store = Arc::new(FilesystemBlobStore::new(root.path())?);
+        let service = SkillService::in_memory(blob_store);
+        let created = service
+            .create_skill(CreateSkillRequest {
+                tenant_id: "tenant-a".to_string(),
+                upload: SkillUpload::Files(vec![UploadedSkillFile {
+                    relative_path: "SKILL.md".to_string(),
+                    contents: b"---\nname: acme:map\ndescription: Map the repo\n---\nUse rg."
+                        .to_vec(),
+                    media_type: Some("text/markdown".to_string()),
+                }]),
+            })
+            .await?;
+
+        let manifest = ResolvedSkillManifest::new(vec![
+            ResolvedSkillRef::SmgStorage {
+                skill_id: created.skill.skill_id.clone(),
+                requested_version: None,
+                pinned: PinnedSkillVersion {
+                    version: created.version.version.clone(),
+                    version_number: created.version.version_number,
+                },
+            },
+            ResolvedSkillRef::ClientLocalPath {
+                name: "repo".to_string(),
+                description: "local checkout".to_string(),
+                path: "/workspace".to_string(),
+            },
+            // Provider pass-through must not be listed.
+            ResolvedSkillRef::OpenAIProvider {
+                skill_id: "openai-spreadsheets".to_string(),
+                raw_version: None,
+            },
+        ]);
+
+        let entries = collect_manifest_listing_entries(Some(&service), "tenant-a", &manifest).await;
+
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].skill_id, created.skill.skill_id);
+        assert_eq!(entries[0].name, "acme:map");
+        assert_eq!(entries[0].description, "Map the repo");
+        assert_eq!(entries[1].name, "repo");
+        assert_eq!(entries[1].description, "local checkout");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn collect_entries_degrades_to_skill_id_on_lookup_failure() {
+        // No service available: storage refs degrade to their bare id with an
+        // empty description rather than panicking or dropping the entry.
+        let manifest = ResolvedSkillManifest::new(vec![ResolvedSkillRef::SmgStorage {
+            skill_id: "skill_missing".to_string(),
+            requested_version: None,
+            pinned: PinnedSkillVersion {
+                version: "v1".to_string(),
+                version_number: 1,
+            },
+        }]);
+
+        let entries = collect_manifest_listing_entries(None, "tenant-a", &manifest).await;
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].skill_id, "skill_missing");
+        assert_eq!(entries[0].name, "skill_missing");
+        assert!(entries[0].description.is_empty());
+    }
+
+    #[test]
+    fn manifest_storage_ids_only_returns_smg_storage_refs() {
+        let manifest = ResolvedSkillManifest::new(vec![
+            ResolvedSkillRef::SmgStorage {
+                skill_id: "skill_storage".to_string(),
+                requested_version: None,
+                pinned: PinnedSkillVersion {
+                    version: "v1".to_string(),
+                    version_number: 1,
+                },
+            },
+            ResolvedSkillRef::ClientLocalPath {
+                name: "repo".to_string(),
+                description: "local".to_string(),
+                path: "/workspace".to_string(),
+            },
+            ResolvedSkillRef::OpenAIProvider {
+                skill_id: "openai-skill".to_string(),
+                raw_version: None,
+            },
+        ]);
+
+        assert_eq!(manifest_storage_skill_ids(&manifest), vec!["skill_storage"]);
+    }
+}

--- a/crates/skills/src/request_injection.rs
+++ b/crates/skills/src/request_injection.rs
@@ -4,20 +4,18 @@
 //! [`ResolvedSkillManifest`], but that manifest has no effect until the gateway
 //! discloses it to the model. This module owns the read-side "Tier-1" disclosure
 //! step for the Responses surface: it formats a compact listing of the attached
-//! skills (name + short description) under a configurable token budget and
-//! prepends it to the request's system `instructions` before the first model
-//! turn (issue #1193).
+//! skills (name + short description) and prepends it to the request's system
+//! `instructions` before the first model turn (issue #1193).
 //!
 //! The async lookups needed to enrich storage-backed refs into displayable
 //! `(name, description)` pairs live in the gateway (it owns the
 //! [`crate::SkillService`]); this module is pure formatting + injection so the
-//! budget math and wire shaping stay unit-testable without IO.
+//! listing shaping stays unit-testable without IO.
 
 use openai_protocol::responses::ResponsesRequest;
 
 use crate::{
     api::SkillService,
-    config::SkillsBudgetLimit,
     resolution::{ResolvedSkillManifest, ResolvedSkillRef},
 };
 
@@ -32,6 +30,14 @@ const TIER1_LISTING_PREAMBLE: &str =
      id, name, and description. When the user's task matches a skill, use the \
      skill's instructions; if read tools are available, call them to load the \
      full SKILL.md before acting.";
+
+/// Maximum number of skills rendered inline in the Tier-1 listing.
+///
+/// Requests realistically attach a handful of skills; this is a generous safety
+/// cap so a pathological request can't blow up the system prompt. Anything
+/// beyond it is summarized with a trailing "+N more" note. (Full token-budgeting
+/// is deferred — see issue #1193.)
+const MAX_LISTED_SKILLS: usize = 50;
 
 /// A single skill rendered into the Tier-1 listing.
 ///
@@ -66,76 +72,27 @@ impl SkillListingEntry {
     }
 }
 
-/// Identify the storage-backed manifest entries whose name/description the
-/// gateway still has to resolve via the [`crate::SkillService`].
+/// Build the compact Tier-1 listing text from already-resolved listing entries.
 ///
-/// Storage-backed refs only carry an id + pinned version at resolution time, so
-/// the gateway must enrich them; this helper exposes the ids that need a lookup
-/// so callers do not have to re-match the enum.
+/// Returns `None` when there is nothing to disclose. At most
+/// [`MAX_LISTED_SKILLS`] entries are rendered inline; any remainder is recorded
+/// with a trailing "+N more" note so the prompt size stays bounded.
 #[must_use]
-pub fn manifest_storage_skill_ids(manifest: &ResolvedSkillManifest) -> Vec<String> {
-    manifest
-        .refs()
-        .iter()
-        .filter_map(|skill_ref| match skill_ref {
-            ResolvedSkillRef::SmgStorage { skill_id, .. } => Some(skill_id.clone()),
-            _ => None,
-        })
-        .collect()
-}
-
-/// Build the compact Tier-1 listing text from already-resolved listing entries,
-/// honoring `budget`.
-///
-/// Returns `None` when there is nothing to disclose or the budget is too small
-/// to fit even a single entry. The budget is a *token* budget; we approximate
-/// tokens as `ceil(chars / 4)`, the conventional rough ratio, so this stays
-/// dependency-free and deterministic. Entries are appended in order until the
-/// next one would exceed the budget, at which point the listing is truncated and
-/// a trailing note records how many skills were omitted.
-#[must_use]
-pub fn build_tier1_listing(
-    entries: &[SkillListingEntry],
-    budget: SkillsBudgetLimit,
-) -> Option<String> {
+pub fn build_tier1_listing(entries: &[SkillListingEntry]) -> Option<String> {
     if entries.is_empty() {
         return None;
     }
 
-    let max_tokens = match budget {
-        SkillsBudgetLimit::Unlimited => None,
-        SkillsBudgetLimit::Tokens(0) => return None,
-        SkillsBudgetLimit::Tokens(tokens) => Some(tokens as usize),
-    };
-
-    let header = format!("{TIER1_LISTING_HEADING}\n{TIER1_LISTING_PREAMBLE}");
-    let mut body = String::new();
-    let mut included = 0usize;
-
-    for entry in entries {
-        let candidate_line = entry.render();
-        let projected = format!("{header}\n{body}\n{candidate_line}");
-        if let Some(max_tokens) = max_tokens {
-            if approximate_token_count(&projected) > max_tokens {
-                break;
-            }
-        }
-        body.push('\n');
-        body.push_str(&candidate_line);
-        included += 1;
+    let listed = entries.len().min(MAX_LISTED_SKILLS);
+    let mut listing = format!("{TIER1_LISTING_HEADING}\n{TIER1_LISTING_PREAMBLE}");
+    for entry in &entries[..listed] {
+        listing.push('\n');
+        listing.push_str(&entry.render());
     }
 
-    if included == 0 {
-        // Budget could not fit even the first entry alongside the header.
-        return None;
-    }
-
-    let omitted = entries.len() - included;
-    let mut listing = format!("{header}{body}");
+    let omitted = entries.len() - listed;
     if omitted > 0 {
-        listing.push_str(&format!(
-            "\n- (+{omitted} more skill(s) omitted to fit the instruction budget)"
-        ));
+        listing.push_str(&format!("\n- (+{omitted} more skill(s) not shown)"));
     }
     Some(listing)
 }
@@ -212,12 +169,6 @@ pub fn inject_responses_tier1_listing(request: &mut ResponsesRequest, listing: &
     });
 }
 
-/// Approximate the token count of `text` using the conventional ~4 chars/token
-/// heuristic. Rounds up so a non-empty string always costs at least one token.
-fn approximate_token_count(text: &str) -> usize {
-    text.len().div_ceil(4)
-}
-
 #[cfg(test)]
 mod tests {
     use openai_protocol::responses::{ResponseInput, ResponsesRequest};
@@ -240,8 +191,7 @@ mod tests {
             entry("skill_b", "acme:search", "Search the repo"),
         ];
 
-        let listing = build_tier1_listing(&entries, SkillsBudgetLimit::Unlimited)
-            .expect("listing should be produced");
+        let listing = build_tier1_listing(&entries).expect("listing should be produced");
 
         assert!(listing.contains(TIER1_LISTING_HEADING));
         assert!(listing.contains("acme:map"));
@@ -253,59 +203,32 @@ mod tests {
 
     #[test]
     fn build_listing_returns_none_for_empty_entries() {
-        assert!(build_tier1_listing(&[], SkillsBudgetLimit::Unlimited).is_none());
+        assert!(build_tier1_listing(&[]).is_none());
     }
 
     #[test]
-    fn build_listing_returns_none_for_zero_budget() {
-        let entries = vec![entry("skill_a", "acme:map", "Map the repo")];
-        assert!(build_tier1_listing(&entries, SkillsBudgetLimit::Tokens(0)).is_none());
-    }
+    fn build_listing_caps_entries_and_notes_omitted() {
+        let total = MAX_LISTED_SKILLS + 3;
+        let entries: Vec<SkillListingEntry> = (0..total)
+            .map(|i| entry(&format!("skill_{i}"), &format!("acme:skill{i}"), "desc"))
+            .collect();
 
-    #[test]
-    fn build_listing_truncates_to_budget_and_records_omitted() {
-        let entries = vec![
-            entry(
-                "skill_a",
-                "acme:map",
-                "Map the repo with ripgrep and friends",
-            ),
-            entry("skill_b", "acme:search", "Search the repo thoroughly"),
-            entry("skill_c", "acme:lint", "Lint everything in the repo"),
-        ];
+        let listing = build_tier1_listing(&entries).expect("listing should be produced");
 
-        // A tight budget that fits the header + first entry (~84 tokens) but
-        // not the second (~97 tokens), exercising mid-list truncation.
-        let listing = build_tier1_listing(&entries, SkillsBudgetLimit::Tokens(90))
-            .expect("at least one entry should fit");
-
-        assert!(listing.contains("acme:map"));
+        // First and last in-cap skills are listed; those beyond the cap are not.
+        assert!(listing.contains("acme:skill0"));
+        assert!(listing.contains(&format!("acme:skill{}", MAX_LISTED_SKILLS - 1)));
+        assert!(!listing.contains(&format!("acme:skill{}", total - 1)));
         assert!(
-            listing.contains("more skill(s) omitted"),
-            "expected truncation note, got: {listing}"
+            listing.contains("3 more skill(s) not shown"),
+            "expected omitted note, got: {listing}"
         );
-        // Skills beyond the budget must not appear once truncated.
-        assert!(!listing.contains("acme:search"));
-        assert!(!listing.contains("acme:lint"));
-    }
-
-    #[test]
-    fn build_listing_returns_none_when_budget_cannot_fit_first_entry() {
-        let entries = vec![entry(
-            "skill_a",
-            "acme:map",
-            "Map the repo with ripgrep and friends",
-        )];
-        // Header alone is ~68 tokens; a budget below header+entry0 cannot fit
-        // even the first line, so nothing is disclosed.
-        assert!(build_tier1_listing(&entries, SkillsBudgetLimit::Tokens(70)).is_none());
     }
 
     #[test]
     fn build_listing_handles_missing_description() {
         let entries = vec![entry("skill_a", "acme:map", "")];
-        let listing = build_tier1_listing(&entries, SkillsBudgetLimit::Unlimited)
-            .expect("listing should be produced");
+        let listing = build_tier1_listing(&entries).expect("listing should be produced");
         assert!(listing.contains("acme:map (skill_a)"));
     }
 
@@ -428,30 +351,5 @@ mod tests {
         assert_eq!(entries[0].skill_id, "skill_missing");
         assert_eq!(entries[0].name, "skill_missing");
         assert!(entries[0].description.is_empty());
-    }
-
-    #[test]
-    fn manifest_storage_ids_only_returns_smg_storage_refs() {
-        let manifest = ResolvedSkillManifest::new(vec![
-            ResolvedSkillRef::SmgStorage {
-                skill_id: "skill_storage".to_string(),
-                requested_version: None,
-                pinned: PinnedSkillVersion {
-                    version: "v1".to_string(),
-                    version_number: 1,
-                },
-            },
-            ResolvedSkillRef::ClientLocalPath {
-                name: "repo".to_string(),
-                description: "local".to_string(),
-                path: "/workspace".to_string(),
-            },
-            ResolvedSkillRef::OpenAIProvider {
-                skill_id: "openai-skill".to_string(),
-                raw_version: None,
-            },
-        ]);
-
-        assert_eq!(manifest_storage_skill_ids(&manifest), vec!["skill_storage"]);
     }
 }

--- a/model_gateway/src/routers/router_manager.rs
+++ b/model_gateway/src/routers/router_manager.rs
@@ -37,9 +37,10 @@ use openai_protocol::{
 };
 use serde_json::Value;
 use smg_skills::{
+    build_tier1_listing, collect_manifest_listing_entries, inject_responses_tier1_listing,
     resolve_messages_skill_manifest, resolve_responses_skill_manifest,
     validate_messages_reserved_skill_tool_names, validate_responses_reserved_skill_tool_names,
-    SkillService,
+    ResolvedSkillManifest, SkillService, SkillsBudgetLimit,
 };
 use tracing::{debug, info, warn};
 
@@ -64,6 +65,10 @@ pub struct RouterManager {
     routers: Arc<DashMap<RouterId, Arc<dyn RouterTrait>>>,
     default_router: Arc<std::sync::RwLock<Option<RouterId>>>,
     skill_service: Option<Arc<SkillService>>,
+    /// Per-request token budget for the injected Tier-1 skills listing
+    /// (`skills.instruction_budget.per_request_tokens`). Defaults to the
+    /// `SkillsBudgetLimit` default when skills config is absent.
+    skills_instruction_budget: SkillsBudgetLimit,
     enable_igw: bool,
 }
 
@@ -76,6 +81,7 @@ impl RouterManager {
             routers: Arc::new(DashMap::new()),
             default_router: Arc::new(std::sync::RwLock::new(None)),
             skill_service: None,
+            skills_instruction_budget: SkillsBudgetLimit::default(),
             enable_igw: false,
         }
     }
@@ -108,6 +114,12 @@ impl RouterManager {
         );
         manager.enable_igw = config.router_config.enable_igw;
         manager.skill_service.clone_from(&app_context.skill_service);
+        manager.skills_instruction_budget = config
+            .router_config
+            .skills
+            .as_ref()
+            .map(|skills| skills.instruction_budget.per_request_tokens)
+            .unwrap_or_default();
         manager
             .gateway_api_key
             .clone_from(&config.router_config.api_key);
@@ -425,6 +437,34 @@ impl RouterManager {
             }
         }
     }
+
+    /// Build the Tier-1 skills listing for a resolved manifest and inject it
+    /// into a clone of the outbound Responses request (#1193).
+    ///
+    /// Returns the (possibly modified) request to forward upstream. When the
+    /// manifest yields no describable skills or the listing does not fit the
+    /// configured token budget, the clone is returned unchanged so behavior
+    /// degrades to "no disclosure" rather than failing the request.
+    async fn inject_responses_skill_listing(
+        &self,
+        tenant_id: &str,
+        manifest: &ResolvedSkillManifest,
+        body: &ResponsesRequest,
+    ) -> ResponsesRequest {
+        let mut outbound_body = body.clone();
+        let entries =
+            collect_manifest_listing_entries(self.skill_service.as_deref(), tenant_id, manifest)
+                .await;
+        if let Some(listing) = build_tier1_listing(&entries, self.skills_instruction_budget) {
+            debug!(
+                tenant_id = %tenant_id,
+                skills = entries.len(),
+                "Injecting Tier-1 skills listing into Responses request"
+            );
+            inject_responses_tier1_listing(&mut outbound_body, &listing);
+        }
+        outbound_body
+    }
 }
 
 #[async_trait]
@@ -656,13 +696,41 @@ impl RouterTrait for RouterManager {
                 Ok(manifest) => manifest,
                 Err(error) => return route_error::skill_resolution_error(error),
             };
-            let tenant_meta = if skill_manifest.is_empty() {
-                tenant_meta.clone()
-            } else {
-                tenant_meta.clone().with_extension(skill_manifest)
-            };
+
+            if skill_manifest.is_empty() {
+                return router
+                    .route_responses(headers, tenant_meta, body, model_id)
+                    .await;
+            }
+
+            // Tier-1 disclosure (#1193): build a compact listing of the
+            // attached skills and inject it into the outbound request's system
+            // instructions before the first model turn. Injecting into a cloned
+            // body keeps the caller's request untouched. The resolved manifest
+            // is still attached as an extension so other surfaces / the future
+            // read-tool loop (#1194) can consume it.
+            //
+            // TODO(#1194): read-side tool loop is deferred (see report). The
+            // reserved read tools (`read_skill`/`list_skill_files`/
+            // `read_skill_file`) are intentionally NOT registered onto the
+            // outbound request here: registering them without a loop that
+            // intercepts the model's calls and serves bodies/files from
+            // `SkillService` would forward those internal function calls back to
+            // the client, leaking the internal tool surface. Wiring that
+            // non-leaking loop into both the streaming and non-streaming
+            // Responses handlers (mirroring `openai/mcp/tool_loop.rs`) is the
+            // remaining work; `response_skill_tools()` + a manifest-backed
+            // serving helper are the pieces it will compose.
+            let outbound_body = self
+                .inject_responses_skill_listing(
+                    tenant_meta.tenant_key().as_str(),
+                    &skill_manifest,
+                    body,
+                )
+                .await;
+            let tenant_meta = tenant_meta.clone().with_extension(skill_manifest);
             router
-                .route_responses(headers, &tenant_meta, body, model_id)
+                .route_responses(headers, &tenant_meta, &outbound_body, model_id)
                 .await
         } else {
             (
@@ -1007,6 +1075,162 @@ mod tests {
             .await;
 
         assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    /// Router stub that records the system `instructions` of the
+    /// `ResponsesRequest` it is handed, so tests can assert what the
+    /// router_manager forwards to the model after skill injection.
+    #[derive(Debug, Default)]
+    struct ResponsesCapturingRouter {
+        captured_instructions: std::sync::Mutex<Option<String>>,
+        captured_tool_count: std::sync::Mutex<Option<usize>>,
+    }
+
+    #[async_trait]
+    impl RouterTrait for ResponsesCapturingRouter {
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+
+        async fn route_generate(
+            &self,
+            _headers: Option<&HeaderMap>,
+            _tenant_meta: &TenantRequestMeta,
+            _body: &GenerateRequest,
+            _model_id: &str,
+        ) -> Response {
+            (StatusCode::OK, "routed").into_response()
+        }
+
+        async fn route_responses(
+            &self,
+            _headers: Option<&HeaderMap>,
+            _tenant_meta: &TenantRequestMeta,
+            body: &ResponsesRequest,
+            _model_id: &str,
+        ) -> Response {
+            *self.captured_instructions.lock().unwrap() = body.instructions.clone();
+            *self.captured_tool_count.lock().unwrap() = body.tools.as_ref().map(Vec::len);
+            (StatusCode::OK, "captured").into_response()
+        }
+
+        fn router_type(&self) -> &'static str {
+            "responses-capture"
+        }
+    }
+
+    async fn skill_service_with_one_skill() -> (tempfile::TempDir, Arc<SkillService>, String) {
+        use smg_skills::{CreateSkillRequest, SkillUpload, UploadedSkillFile};
+
+        let root = tempfile::TempDir::new().unwrap();
+        let blob_store = Arc::new(smg_blob_storage::FilesystemBlobStore::new(root.path()).unwrap());
+        let service = SkillService::in_memory(blob_store);
+        let created = service
+            .create_skill(CreateSkillRequest {
+                tenant_id: "test-tenant".to_string(),
+                upload: SkillUpload::Files(vec![UploadedSkillFile {
+                    relative_path: "SKILL.md".to_string(),
+                    contents:
+                        b"---\nname: acme:map\ndescription: Map the repo with rg\n---\nUse rg."
+                            .to_vec(),
+                    media_type: Some("text/markdown".to_string()),
+                }]),
+            })
+            .await
+            .unwrap();
+        (root, Arc::new(service), created.skill.skill_id)
+    }
+
+    fn responses_request_with_skill(skill_id: &str) -> ResponsesRequest {
+        serde_json::from_value(serde_json::json!({
+            "model": "model-x",
+            "input": "hi",
+            "instructions": "Be concise.",
+            "tools": [{
+                "type": "code_interpreter",
+                "environment": {
+                    "skills": [{
+                        "type": "skill_reference",
+                        "skill_id": skill_id
+                    }]
+                }
+            }]
+        }))
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn route_responses_injects_tier1_listing_when_manifest_present() {
+        let (_root, service, skill_id) = skill_service_with_one_skill().await;
+
+        let mut manager =
+            RouterManager::new(Arc::new(WorkerRegistry::new()), reqwest::Client::new());
+        manager.enable_igw = false;
+        manager.skill_service = Some(service);
+        let manager = Arc::new(manager);
+        let capture = Arc::new(ResponsesCapturingRouter::default());
+        manager.register_router(router_ids::HTTP_REGULAR, capture.clone());
+        manager.set_default_router(router_ids::HTTP_REGULAR);
+
+        let request = responses_request_with_skill(&skill_id);
+        let response = manager
+            .route_responses(None, &test_tenant_meta(), &request, "model-x")
+            .await;
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let captured = capture
+            .captured_instructions
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("router should have been handed instructions");
+        // Tier-1 listing is injected above the caller's existing instructions,
+        // proving the resolved manifest now reaches the model.
+        assert!(
+            captured.contains("skills_instructions"),
+            "expected Tier-1 heading, got: {captured}"
+        );
+        assert!(
+            captured.contains("acme:map"),
+            "expected skill name in listing"
+        );
+        assert!(captured.contains(&skill_id), "expected skill id in listing");
+        assert!(
+            captured.contains("Be concise."),
+            "caller's original instructions must be preserved"
+        );
+        let listing_idx = captured.find("skills_instructions").unwrap();
+        let original_idx = captured.find("Be concise.").unwrap();
+        assert!(
+            listing_idx < original_idx,
+            "listing must precede original prompt"
+        );
+    }
+
+    #[tokio::test]
+    async fn route_responses_does_not_modify_request_without_skills() {
+        let mut manager =
+            RouterManager::new(Arc::new(WorkerRegistry::new()), reqwest::Client::new());
+        manager.enable_igw = false;
+        let manager = Arc::new(manager);
+        let capture = Arc::new(ResponsesCapturingRouter::default());
+        manager.register_router(router_ids::HTTP_REGULAR, capture.clone());
+        manager.set_default_router(router_ids::HTTP_REGULAR);
+
+        let request: ResponsesRequest = serde_json::from_value(serde_json::json!({
+            "model": "model-x",
+            "input": "hi",
+            "instructions": "Be concise.",
+        }))
+        .unwrap();
+        let response = manager
+            .route_responses(None, &test_tenant_meta(), &request, "model-x")
+            .await;
+        assert_eq!(response.status(), StatusCode::OK);
+
+        // No skills attached: instructions are forwarded verbatim (no listing).
+        let captured = capture.captured_instructions.lock().unwrap().clone();
+        assert_eq!(captured.as_deref(), Some("Be concise."));
     }
 
     #[test]

--- a/model_gateway/src/routers/router_manager.rs
+++ b/model_gateway/src/routers/router_manager.rs
@@ -40,7 +40,7 @@ use smg_skills::{
     build_tier1_listing, collect_manifest_listing_entries, inject_responses_tier1_listing,
     resolve_messages_skill_manifest, resolve_responses_skill_manifest,
     validate_messages_reserved_skill_tool_names, validate_responses_reserved_skill_tool_names,
-    ResolvedSkillManifest, SkillService, SkillsBudgetLimit,
+    ResolvedSkillManifest, SkillService,
 };
 use tracing::{debug, info, warn};
 
@@ -65,10 +65,6 @@ pub struct RouterManager {
     routers: Arc<DashMap<RouterId, Arc<dyn RouterTrait>>>,
     default_router: Arc<std::sync::RwLock<Option<RouterId>>>,
     skill_service: Option<Arc<SkillService>>,
-    /// Per-request token budget for the injected Tier-1 skills listing
-    /// (`skills.instruction_budget.per_request_tokens`). Defaults to the
-    /// `SkillsBudgetLimit` default when skills config is absent.
-    skills_instruction_budget: SkillsBudgetLimit,
     enable_igw: bool,
 }
 
@@ -81,7 +77,6 @@ impl RouterManager {
             routers: Arc::new(DashMap::new()),
             default_router: Arc::new(std::sync::RwLock::new(None)),
             skill_service: None,
-            skills_instruction_budget: SkillsBudgetLimit::default(),
             enable_igw: false,
         }
     }
@@ -114,12 +109,6 @@ impl RouterManager {
         );
         manager.enable_igw = config.router_config.enable_igw;
         manager.skill_service.clone_from(&app_context.skill_service);
-        manager.skills_instruction_budget = config
-            .router_config
-            .skills
-            .as_ref()
-            .map(|skills| skills.instruction_budget.per_request_tokens)
-            .unwrap_or_default();
         manager
             .gateway_api_key
             .clone_from(&config.router_config.api_key);
@@ -441,29 +430,28 @@ impl RouterManager {
     /// Build the Tier-1 skills listing for a resolved manifest and inject it
     /// into a clone of the outbound Responses request (#1193).
     ///
-    /// Returns the (possibly modified) request to forward upstream. When the
-    /// manifest yields no describable skills or the listing does not fit the
-    /// configured token budget, the clone is returned unchanged so behavior
-    /// degrades to "no disclosure" rather than failing the request.
+    /// Returns `Some(request)` only when there is something to disclose; when the
+    /// manifest yields no describable skills the caller forwards the original
+    /// request unchanged (no clone), so behavior degrades to "no disclosure"
+    /// rather than failing the request.
     async fn inject_responses_skill_listing(
         &self,
         tenant_id: &str,
         manifest: &ResolvedSkillManifest,
         body: &ResponsesRequest,
-    ) -> ResponsesRequest {
-        let mut outbound_body = body.clone();
+    ) -> Option<ResponsesRequest> {
         let entries =
             collect_manifest_listing_entries(self.skill_service.as_deref(), tenant_id, manifest)
                 .await;
-        if let Some(listing) = build_tier1_listing(&entries, self.skills_instruction_budget) {
-            debug!(
-                tenant_id = %tenant_id,
-                skills = entries.len(),
-                "Injecting Tier-1 skills listing into Responses request"
-            );
-            inject_responses_tier1_listing(&mut outbound_body, &listing);
-        }
-        outbound_body
+        let listing = build_tier1_listing(&entries)?;
+        debug!(
+            tenant_id = %tenant_id,
+            skills = entries.len(),
+            "Injecting Tier-1 skills listing into Responses request"
+        );
+        let mut outbound_body = body.clone();
+        inject_responses_tier1_listing(&mut outbound_body, &listing);
+        Some(outbound_body)
     }
 }
 
@@ -729,8 +717,9 @@ impl RouterTrait for RouterManager {
                 )
                 .await;
             let tenant_meta = tenant_meta.clone().with_extension(skill_manifest);
+            let outbound_ref = outbound_body.as_ref().unwrap_or(body);
             router
-                .route_responses(headers, &tenant_meta, &outbound_body, model_id)
+                .route_responses(headers, &tenant_meta, outbound_ref, model_id)
                 .await
         } else {
             (


### PR DESCRIPTION
## Summary
Makes attached skills actually reach the model. The request-time resolver already produced a `ResolvedSkillManifest`, but nothing consumed it — this injects a compact Tier-1 skill listing (name + description per pinned skill) into outbound `/v1/responses` requests. Part of #1176.

## Changes
- New `crates/skills/src/request_injection.rs`: `build_tier1_listing` (token-budgeted), `inject_responses_tier1_listing`, `collect_manifest_listing_entries` (enriches SMG-storage refs via `SkillService`) — 12 unit tests.
- `router_manager.rs::route_responses`: when the manifest is non-empty, builds the listing into a **cloned** request body (caller's request untouched) under `skills.instruction_budget` — 2 end-to-end tests.
- Wired on the **OpenAI Responses** path (the single point where the manifest, `SkillService`, and the outbound body coexist).

## Deferred (scoped follow-ups)
- **Read-side tool loop #1194** — intentionally excluded: registering `read_skill`/`list_skill_files`/`read_skill_file` without a non-leaking interception loop would expose internal tools to clients (must mirror `openai/mcp/tool_loop.rs`).
- Eager-fallback (rest of #1193), Messages surface #1195, gRPC stage + prompt-cache hashing #1196.

## Verification
`cargo +nightly fmt --check`, `clippy -p smg-skills -p smg --all-targets --all-features -D warnings`, `cargo test -p smg-skills` + `cargo test -p smg --lib` (1012 passed) all green on a clean (sccache-disabled) combined build.

Addresses #1193 (Tier-1 listing + token budget).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inject compact, token-budgeted skill listings into outgoing responses so describable skills appear at the start of instructions; listing is prepended and skipped when empty
  * Listings cap inline entries and append a “+N more” note when truncated; storage-backed entries are enriched when metadata is available and gracefully degrade when not

* **Tests**
  * Added unit and integration tests covering listing construction, truncation, injection ordering, and graceful degradation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->