### PR TITLE
feat(background): BGM-PR-04 create path + snapshot resolution

### DIFF
--- a/crates/data_connector/src/background.rs
+++ b/crates/data_connector/src/background.rs
@@ -357,10 +357,17 @@ pub enum DeleteResult {
 pub trait BackgroundResponseRepository: Send + Sync {
     /// Insert a new response + queue row atomically, transitioning
     /// `status='queued'`.
+    ///
+    /// When `max_queue_depth` is `Some(limit)` the implementation MUST count
+    /// current queued rows and reject with
+    /// [`BackgroundRepositoryError::QueueFull`] when that count is already at
+    /// or above the limit, under the same lock / transaction as the insert so
+    /// the check is atomic with the write. `None` disables the cap.
     async fn enqueue(
         &self,
         req: EnqueueRequest,
         request_context: Option<RequestContext>,
+        max_queue_depth: Option<u64>,
     ) -> BackgroundRepositoryResult<QueuedResponse>;
 
     /// Claim the next runnable queue row using `FOR UPDATE SKIP LOCKED` (or the

--- a/crates/data_connector/src/memory_background.rs
+++ b/crates/data_connector/src/memory_background.rs
@@ -179,6 +179,7 @@ impl BackgroundResponseRepository for MemoryBackgroundRepository {
         &self,
         req: EnqueueRequest,
         request_context: Option<RequestContext>,
+        max_queue_depth: Option<u64>,
     ) -> BackgroundRepositoryResult<QueuedResponse> {
         let now = Utc::now();
         let response_id = req.response_id.clone();
@@ -189,6 +190,17 @@ impl BackgroundResponseRepository for MemoryBackgroundRepository {
                 "response {} already exists",
                 req.response_id
             )));
+        }
+
+        if let Some(limit) = max_queue_depth {
+            let current = state
+                .entries
+                .values()
+                .filter(|e| e.status == InternalStatus::Queued)
+                .count() as u64;
+            if current >= limit {
+                return Err(BackgroundRepositoryError::QueueFull { current, limit });
+            }
         }
 
         let entry = Entry {
@@ -561,7 +573,7 @@ mod tests {
     #[tokio::test]
     async fn enqueue_creates_queued_response() {
         let repo = MemoryBackgroundRepository::new_standalone();
-        let ack = repo.enqueue(enqueue_req("r1"), None).await.unwrap();
+        let ack = repo.enqueue(enqueue_req("r1"), None, None).await.unwrap();
         assert_eq!(ack.response_id, ResponseId::from("r1"));
         assert_eq!(ack.queue_depth_at_insert, 1);
     }
@@ -571,7 +583,7 @@ mod tests {
         // GET /v1/responses/{id} must see background-mode writes.
         let rs = Arc::new(MemoryResponseStorage::new());
         let repo = MemoryBackgroundRepository::new(Arc::clone(&rs));
-        repo.enqueue(enqueue_req("r1"), None).await.unwrap();
+        repo.enqueue(enqueue_req("r1"), None, None).await.unwrap();
         let stored = rs.get_response(&ResponseId::from("r1")).await.unwrap();
         assert!(
             stored.is_some(),
@@ -583,7 +595,7 @@ mod tests {
     async fn finalize_and_delete_mirror_into_shared_response_storage() {
         let rs = Arc::new(MemoryResponseStorage::new());
         let repo = MemoryBackgroundRepository::new(Arc::clone(&rs));
-        repo.enqueue(enqueue_req("r1"), None).await.unwrap();
+        repo.enqueue(enqueue_req("r1"), None, None).await.unwrap();
 
         let claim_time = Utc::now();
         let _ = repo
@@ -628,7 +640,7 @@ mod tests {
         // GET /v1/responses/{id} stays stuck on the in-progress state).
         let rs = Arc::new(MemoryResponseStorage::new());
         let repo = MemoryBackgroundRepository::new(Arc::clone(&rs));
-        repo.enqueue(enqueue_req("r1"), None).await.unwrap();
+        repo.enqueue(enqueue_req("r1"), None, None).await.unwrap();
 
         let claim_time = Utc::now();
         let _ = repo
@@ -670,7 +682,7 @@ mod tests {
     async fn queued_cancel_mirrors_cancelled_payload_into_shared_storage() {
         let rs = Arc::new(MemoryResponseStorage::new());
         let repo = MemoryBackgroundRepository::new(Arc::clone(&rs));
-        repo.enqueue(enqueue_req("r1"), None).await.unwrap();
+        repo.enqueue(enqueue_req("r1"), None, None).await.unwrap();
         assert_eq!(
             repo.request_cancel(&ResponseId::from("r1")).await.unwrap(),
             StoredCancelResult::QueuedCancelled
@@ -684,10 +696,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn enqueue_rejects_when_queue_depth_at_limit() {
+        let repo = MemoryBackgroundRepository::new_standalone();
+        repo.enqueue(enqueue_req("r1"), None, Some(2))
+            .await
+            .unwrap();
+        repo.enqueue(enqueue_req("r2"), None, Some(2))
+            .await
+            .unwrap();
+        let err = repo
+            .enqueue(enqueue_req("r3"), None, Some(2))
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, BackgroundRepositoryError::QueueFull { current, limit } if current == 2 && limit == 2),
+            "expected QueueFull, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
     async fn enqueue_rejects_duplicate() {
         let repo = MemoryBackgroundRepository::new_standalone();
-        repo.enqueue(enqueue_req("r1"), None).await.unwrap();
-        let err = repo.enqueue(enqueue_req("r1"), None).await.unwrap_err();
+        repo.enqueue(enqueue_req("r1"), None, None).await.unwrap();
+        let err = repo
+            .enqueue(enqueue_req("r1"), None, None)
+            .await
+            .unwrap_err();
         assert!(matches!(
             err,
             BackgroundRepositoryError::InvalidTransition(_)
@@ -706,9 +740,9 @@ mod tests {
         r2.priority = 1;
         let mut r3 = enqueue_req("r3");
         r3.priority = 5;
-        repo.enqueue(r1, None).await.unwrap();
-        repo.enqueue(r2, None).await.unwrap();
-        repo.enqueue(r3, None).await.unwrap();
+        repo.enqueue(r1, None, None).await.unwrap();
+        repo.enqueue(r2, None, None).await.unwrap();
+        repo.enqueue(r3, None, None).await.unwrap();
 
         let now = Utc::now();
         let lease = Duration::from_secs(60);
@@ -738,8 +772,8 @@ mod tests {
         r1.priority = 1;
         let mut r2 = enqueue_req("r2");
         r2.priority = 5;
-        repo.enqueue(r1, None).await.unwrap();
-        repo.enqueue(r2, None).await.unwrap();
+        repo.enqueue(r1, None, None).await.unwrap();
+        repo.enqueue(r2, None, None).await.unwrap();
 
         // 1. Claim r1 (higher priority), ask to cancel → r1 becomes
         //    InProgress with cancel_requested=true.
@@ -791,7 +825,7 @@ mod tests {
     #[tokio::test]
     async fn claim_on_cancel_requested_skips_worker_and_marks_cancelled() {
         let repo = MemoryBackgroundRepository::new_standalone();
-        repo.enqueue(enqueue_req("r1"), None).await.unwrap();
+        repo.enqueue(enqueue_req("r1"), None, None).await.unwrap();
         assert!(matches!(
             repo.request_cancel(&ResponseId::from("r1")).await.unwrap(),
             StoredCancelResult::QueuedCancelled
@@ -806,7 +840,7 @@ mod tests {
     #[tokio::test]
     async fn heartbeat_requires_active_lease() {
         let repo = MemoryBackgroundRepository::new_standalone();
-        repo.enqueue(enqueue_req("r1"), None).await.unwrap();
+        repo.enqueue(enqueue_req("r1"), None, None).await.unwrap();
 
         let err = repo
             .heartbeat(
@@ -861,7 +895,7 @@ mod tests {
             StoredCancelResult::NotFound
         );
 
-        repo.enqueue(enqueue_req("r1"), None).await.unwrap();
+        repo.enqueue(enqueue_req("r1"), None, None).await.unwrap();
         assert_eq!(
             repo.request_cancel(&ResponseId::from("r1")).await.unwrap(),
             StoredCancelResult::QueuedCancelled
@@ -871,7 +905,7 @@ mod tests {
             StoredCancelResult::AlreadyTerminal
         );
 
-        repo.enqueue(enqueue_req("r2"), None).await.unwrap();
+        repo.enqueue(enqueue_req("r2"), None, None).await.unwrap();
         let _ = repo
             .claim_next("w1", Utc::now(), Duration::from_secs(60))
             .await
@@ -885,7 +919,7 @@ mod tests {
     #[tokio::test]
     async fn append_and_load_stream_events_monotonic() {
         let repo = MemoryBackgroundRepository::new_standalone();
-        repo.enqueue(enqueue_req("r1"), None).await.unwrap();
+        repo.enqueue(enqueue_req("r1"), None, None).await.unwrap();
         let id = ResponseId::from("r1");
 
         let e0 = repo
@@ -914,7 +948,7 @@ mod tests {
     #[tokio::test]
     async fn finalize_writes_terminal_and_clears_lease() {
         let repo = MemoryBackgroundRepository::new_standalone();
-        repo.enqueue(enqueue_req("r1"), None).await.unwrap();
+        repo.enqueue(enqueue_req("r1"), None, None).await.unwrap();
         let claim_time = Utc::now();
         let _ = repo
             .claim_next("w1", claim_time, Duration::from_secs(60))
@@ -947,7 +981,7 @@ mod tests {
         // `GET /v1/responses/{id}` must see status=cancelled in the persisted
         // payload, not the original queued snapshot.
         let repo = MemoryBackgroundRepository::new_standalone();
-        repo.enqueue(enqueue_req("r1"), None).await.unwrap();
+        repo.enqueue(enqueue_req("r1"), None, None).await.unwrap();
         assert_eq!(
             repo.request_cancel(&ResponseId::from("r1")).await.unwrap(),
             StoredCancelResult::QueuedCancelled
@@ -960,7 +994,7 @@ mod tests {
     #[tokio::test]
     async fn finalize_cancel_wins_over_worker_status() {
         let repo = MemoryBackgroundRepository::new_standalone();
-        repo.enqueue(enqueue_req("r1"), None).await.unwrap();
+        repo.enqueue(enqueue_req("r1"), None, None).await.unwrap();
         let claim_time = Utc::now();
         let _ = repo
             .claim_next("w1", claim_time, Duration::from_secs(60))
@@ -993,7 +1027,7 @@ mod tests {
     #[tokio::test]
     async fn finalize_rejects_non_lease_holder() {
         let repo = MemoryBackgroundRepository::new_standalone();
-        repo.enqueue(enqueue_req("r1"), None).await.unwrap();
+        repo.enqueue(enqueue_req("r1"), None, None).await.unwrap();
         let claim_time = Utc::now();
         let _ = repo
             .claim_next("w1", claim_time, Duration::from_secs(60))
@@ -1019,7 +1053,7 @@ mod tests {
         // not be able to commit terminal state, even if `requeue_expired`
         // hasn't run yet.
         let repo = MemoryBackgroundRepository::new_standalone();
-        repo.enqueue(enqueue_req("r1"), None).await.unwrap();
+        repo.enqueue(enqueue_req("r1"), None, None).await.unwrap();
         let claim_time = Utc::now();
         let _ = repo
             .claim_next("w1", claim_time, Duration::from_secs(60))
@@ -1043,7 +1077,7 @@ mod tests {
     #[tokio::test]
     async fn requeue_expired_moves_in_progress_back_to_queued() {
         let repo = MemoryBackgroundRepository::new_standalone();
-        repo.enqueue(enqueue_req("r1"), None).await.unwrap();
+        repo.enqueue(enqueue_req("r1"), None, None).await.unwrap();
         let claim_time = Utc::now();
         let _ = repo
             .claim_next("w1", claim_time, Duration::from_secs(60))
@@ -1082,7 +1116,7 @@ mod tests {
         let mut ctx = RequestContext::default();
         ctx.set("tenant_id", "acme");
         ctx.set("principal", "alice");
-        repo.enqueue(enqueue_req("r1"), Some(ctx.clone()))
+        repo.enqueue(enqueue_req("r1"), Some(ctx.clone()), None)
             .await
             .unwrap();
         let loaded = repo
@@ -1092,7 +1126,7 @@ mod tests {
             .expect("context must round-trip");
         assert_eq!(loaded.data(), ctx.data());
 
-        repo.enqueue(enqueue_req("r2"), None).await.unwrap();
+        repo.enqueue(enqueue_req("r2"), None, None).await.unwrap();
         assert!(repo
             .load_request_context(&ResponseId::from("r2"))
             .await
@@ -1110,7 +1144,7 @@ mod tests {
             DeleteResult::NotFound
         );
 
-        repo.enqueue(enqueue_req("r1"), None).await.unwrap();
+        repo.enqueue(enqueue_req("r1"), None, None).await.unwrap();
         assert_eq!(
             repo.delete_background_response(&ResponseId::from("r1"))
                 .await
@@ -1118,7 +1152,7 @@ mod tests {
             DeleteResult::Deleted
         );
 
-        repo.enqueue(enqueue_req("r2"), None).await.unwrap();
+        repo.enqueue(enqueue_req("r2"), None, None).await.unwrap();
         let claim_time = Utc::now();
         let _ = repo
             .claim_next("w1", claim_time, Duration::from_secs(60))

--- a/e2e_test/responses/test_background_mode.py
+++ b/e2e_test/responses/test_background_mode.py
@@ -1,0 +1,451 @@
+"""End-to-end coverage for `POST /v1/responses` with `background=true`.
+
+The gateway accepts `background=true` requests and enqueues them through
+`MemoryBackgroundRepository` when `--history-backend=memory` (the default).
+The queued skeleton is mirrored into `MemoryResponseStorage` so
+`GET /v1/responses/{id}` reads it back unchanged until a worker updates it.
+
+Scope:
+
+* Layer-1 validator rejections (`ValidatedJson` via
+  `validate_responses_cross_parameters` in `crates/protocols/src/responses.rs`).
+* Shared create handler (`model_gateway/src/routers/common/background/create.rs`)
+  happy path, GET read-back, and the two state-dependent 404 branches.
+* `history_backend=none` produces `background_not_supported`.
+
+Out of scope:
+
+* `queued → in_progress → completed` transitions. No queue consumer exists
+  yet in production code — `MemoryBackgroundRepository::claim_next` has no
+  caller outside unit tests. Full completion scenarios stay behind
+  `@pytest.mark.skip` in `test_basic_crud.py::test_background_response`
+  until the worker loop lands.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import httpx
+import pytest
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Raw-httpx helpers (validation/error-envelope assertions need exact wire shape)
+# ---------------------------------------------------------------------------
+
+
+def _post_responses(gateway, body: dict, timeout: float = 30.0) -> httpx.Response:
+    """POST a raw JSON body to ``{gateway.base_url}/v1/responses``.
+
+    Validation rejections need exact-envelope checks that the OpenAI SDK
+    would hide behind a typed exception, so all negative-path tests use
+    ``httpx`` directly.
+    """
+    api_key = os.environ.get("OPENAI_API_KEY", "sk-not-used")
+    return httpx.post(
+        f"{gateway.base_url}/v1/responses",
+        json=body,
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+        timeout=timeout,
+    )
+
+
+def _assert_validator_400(resp: httpx.Response, expected_message_substring: str) -> None:
+    """Assert the gateway returned the Layer-1 validator envelope.
+
+    ``ValidatedJson`` in ``crates/protocols/src/validated.rs:91-103`` maps a
+    ``Validate`` failure to ``400`` with
+    ``{error: {type: "invalid_request_error", code: 400, message: "..."}}``.
+    ``message`` is produced by ``ValidationErrors::to_string()``, which emits
+    ``"__all__: <human message>"`` — it surfaces the ``ValidationError::message``
+    field, not the machine ``code`` (e.g. ``background_requires_store``), so
+    the only observable substring on the wire is the human text.
+    """
+    assert resp.status_code == 400, f"expected HTTP 400, got {resp.status_code}: body={resp.text!r}"
+    body = resp.json()
+    err = body.get("error")
+    assert isinstance(err, dict), f"expected error object, got {body!r}"
+    assert err.get("type") == "invalid_request_error", (
+        f"expected invalid_request_error, got {err!r}"
+    )
+    message = err.get("message", "")
+    assert isinstance(message, str) and expected_message_substring in message, (
+        f"expected message containing {expected_message_substring!r}, got {message!r}"
+    )
+
+
+def _assert_handler_error(resp: httpx.Response, expected_status: int, expected_code: str) -> None:
+    """Assert a handler-layer (Layer 3) error envelope.
+
+    ``routers::error`` emits
+    ``{error: {code: "<kebab>", message: "...", type: "invalid_request_error"}}``
+    — asserting on ``code`` (string) distinguishes these from Layer-1
+    validator rejections (which use integer ``code: 400``).
+    """
+    assert resp.status_code == expected_status, (
+        f"expected HTTP {expected_status}, got {resp.status_code}: body={resp.text!r}"
+    )
+    body = resp.json()
+    err = body.get("error")
+    assert isinstance(err, dict), f"expected error object, got {body!r}"
+    assert err.get("code") == expected_code, f"expected code={expected_code!r}, got {err!r}"
+
+
+# ===========================================================================
+# Layer 1 — cross-parameter validator rejections
+# ===========================================================================
+
+
+@pytest.mark.vendor("openai")
+@pytest.mark.gpu(0)
+@pytest.mark.parametrize("setup_backend", ["openai"], indirect=True)
+class TestBackgroundModeValidation:
+    """Layer-1 validator (``validate_responses_cross_parameters``) coverage.
+
+    Cloud backend is fine — these requests short-circuit inside
+    ``ValidatedJson`` before any upstream call.
+    """
+
+    def test_background_plus_stream_rejected_400(self, setup_backend):
+        """``background=true`` + ``stream=true`` → ``background_conflicts_with_stream``.
+
+        Pinned at ``crates/protocols/src/responses.rs:3127-3132``.
+        """
+        _, model, _, gw = setup_backend
+        resp = _post_responses(
+            gw,
+            {
+                "model": model,
+                "input": "hello",
+                "background": True,
+                "stream": True,
+            },
+        )
+        # Message text pinned in crates/protocols/src/responses.rs:3130.
+        _assert_validator_400(resp, "Cannot use background mode with streaming")
+
+    def test_background_plus_store_false_rejected_400(self, setup_backend):
+        """``background=true`` + explicit ``store=false`` → ``background_requires_store``.
+
+        Pinned at ``crates/protocols/src/responses.rs:3134-3140``.
+        """
+        _, model, _, gw = setup_backend
+        resp = _post_responses(
+            gw,
+            {
+                "model": model,
+                "input": "hello",
+                "background": True,
+                "store": False,
+            },
+        )
+        # Message text pinned in crates/protocols/src/responses.rs:3138.
+        _assert_validator_400(resp, "Background mode requires 'store' to be true")
+
+    def test_background_with_store_unset_is_accepted(self, setup_backend):
+        """``store`` unset defaults to ``true`` per the OpenAI spec.
+
+        The validator only rejects ``store=Some(false)`` — ``None`` must pass.
+        We verify by asserting the request is NOT rejected at the validator
+        layer (status is either 200 with queued body, or a handler-level
+        error — anything that is not the validator's 400 envelope).
+        """
+        _, model, _, gw = setup_backend
+        resp = _post_responses(
+            gw,
+            {
+                "model": model,
+                "input": "hello",
+                "background": True,
+            },
+        )
+        # Server errors (5xx) must never be tolerated — they would let a
+        # broken gateway pass this test silently.
+        assert resp.status_code < 500, (
+            f"store=None must not surface a 5xx; got {resp.status_code}: {resp.text!r}"
+        )
+        if resp.status_code == 400:
+            body = resp.json()
+            err = body.get("error", {})
+            # Layer-1 validator envelope is the only 400 we explicitly
+            # forbid here: handler-layer 400s (e.g. `background_not_supported`
+            # when the gateway is misconfigured to history_backend=none) are
+            # legitimate fail paths for store=None — the validator must just
+            # not be the one rejecting it.
+            is_layer1_validator_error = (
+                isinstance(err, dict)
+                and err.get("type") == "invalid_request_error"
+                and err.get("code") == 400
+            )
+            assert not is_layer1_validator_error, (
+                f"store=None must not trip the Layer-1 validator; got {body!r}"
+            )
+
+
+# ===========================================================================
+# Layer 3 — shared handler: enqueue + GET read-back + state-dependent 404s
+# ===========================================================================
+
+
+@pytest.mark.vendor("openai")
+@pytest.mark.gpu(0)
+@pytest.mark.parametrize("setup_backend", ["openai"], indirect=True)
+class TestBackgroundModeEnqueue:
+    """Shared-handler happy path and state-dependent error branches.
+
+    Uses the default ``history_backend=memory`` so
+    ``AppContext.background_repository`` is ``Some(MemoryBackgroundRepository)``
+    (wired in ``crates/data_connector/src/factory.rs:67-83``).
+    """
+
+    def test_enqueue_returns_queued_skeleton(self, model, api_client):
+        """POST ``background=true`` returns the initial queued response shape.
+
+        Verifies the JSON built in
+        ``routers/common/background/create.rs::initial_queued_response``:
+        ``status == "queued"``, ``background == true``, id prefix ``resp_``,
+        empty ``output``, matching ``model``.
+        """
+        resp = api_client.responses.create(
+            model=model,
+            input="Write a short story",
+            background=True,
+            max_output_tokens=100,
+        )
+        assert resp.id.startswith("resp_"), f"expected resp_ prefix, got {resp.id!r}"
+        assert resp.status == "queued", f"expected queued, got {resp.status!r}"
+        assert resp.background is True, f"expected background=True, got {resp.background!r}"
+        assert resp.model == model, f"expected model {model!r}, got {resp.model!r}"
+        assert resp.output == [], f"expected empty output, got {resp.output!r}"
+        assert resp.error is None, f"expected no error, got {resp.error!r}"
+
+    def test_queued_response_readable_via_get(self, model, api_client):
+        """``GET /v1/responses/{id}`` returns the mirrored queued skeleton.
+
+        ``MemoryBackgroundRepository::enqueue`` mirrors the response into
+        ``MemoryResponseStorage`` under the same lock
+        (``memory_background.rs:234``), so the read path sees the queued
+        state immediately.
+        """
+        created = api_client.responses.create(
+            model=model,
+            input="hello",
+            background=True,
+            max_output_tokens=100,
+        )
+        assert created.status == "queued"
+
+        retrieved = api_client.responses.retrieve(response_id=created.id)
+        assert retrieved.id == created.id
+        assert retrieved.status == "queued"
+        assert retrieved.background is True
+        assert retrieved.error is None
+
+    def test_background_with_unknown_previous_response_id_returns_404(self, model, setup_backend):
+        """Chaining to a missing prior response → 404 ``previous_response_not_found``.
+
+        Pinned at
+        ``routers/common/background/create.rs::append_prev_chain_items`` →
+        ``chain.responses.is_empty()`` branch.
+        """
+        _, model_path, _, gw = setup_backend
+        resp = _post_responses(
+            gw,
+            {
+                "model": model_path,
+                "input": "hello",
+                "background": True,
+                "store": True,
+                "previous_response_id": "resp_does_not_exist_zzz",
+            },
+        )
+        _assert_handler_error(resp, 404, "previous_response_not_found")
+
+    def test_background_with_unknown_conversation_returns_404(self, model, setup_backend):
+        """Resolving a missing conversation → 404 ``conversation_not_found``.
+
+        Pinned at
+        ``routers/common/background/create.rs::append_conversation_items`` →
+        ``conv_storage.get_conversation`` ``Ok(None)`` branch.
+        """
+        _, model_path, _, gw = setup_backend
+        resp = _post_responses(
+            gw,
+            {
+                "model": model_path,
+                "input": "hello",
+                "background": True,
+                "store": True,
+                "conversation": "conv_does_not_exist_zzz",
+            },
+        )
+        _assert_handler_error(resp, 404, "conversation_not_found")
+
+
+# ===========================================================================
+# history_backend=none → background disabled at the handler layer
+# ===========================================================================
+
+
+@pytest.mark.vendor("openai")
+@pytest.mark.gpu(0)
+@pytest.mark.storage("none")
+@pytest.mark.parametrize("setup_backend", ["openai"], indirect=True)
+class TestBackgroundModeUnsupportedBackend:
+    """When the gateway runs with ``--history-backend none``,
+    ``StorageBundle.background_repository == None`` (``factory.rs:84-93``),
+    so any ``background=true`` request must fail fast with
+    ``background_not_supported`` — the shared handler's repo guard.
+    """
+
+    def test_background_returns_400_when_repo_missing(self, setup_backend):
+        _, model_path, _, gw = setup_backend
+        resp = _post_responses(
+            gw,
+            {
+                "model": model_path,
+                "input": "hello",
+                "background": True,
+                "store": True,
+            },
+        )
+        _assert_handler_error(resp, 400, "background_not_supported")
+
+
+# ===========================================================================
+# Local engine coverage — gRPC router against sglang/vllm with a real model
+# ===========================================================================
+
+
+def _assert_queued_skeleton(resp_body: dict, expected_model: str) -> None:
+    """Shape assertions for the queued response skeleton.
+
+    Pinned at ``routers/common/background/create.rs::initial_queued_response``.
+    Shared between the cloud and local-engine test classes so they exercise
+    identical invariants on identical wire shape.
+    """
+    assert resp_body.get("status") == "queued", f"expected queued, got {resp_body.get('status')!r}"
+    assert resp_body.get("background") is True, (
+        f"expected background=True, got {resp_body.get('background')!r}"
+    )
+    assert resp_body.get("model") == expected_model, (
+        f"expected model {expected_model!r}, got {resp_body.get('model')!r}"
+    )
+    assert resp_body.get("output") == [], f"expected empty output, got {resp_body.get('output')!r}"
+    rid = resp_body.get("id", "")
+    assert isinstance(rid, str) and rid.startswith("resp_"), f"expected resp_ prefix, got {rid!r}"
+
+
+@pytest.mark.gpu(1)
+@pytest.mark.model("Qwen/Qwen2.5-14B-Instruct")
+@pytest.mark.gateway(extra_args=["--history-backend", "memory"])
+@pytest.mark.parametrize("setup_backend", ["grpc"], indirect=True)
+class TestBackgroundModeLocal:
+    """Background-mode enqueue against a local gRPC backend (sglang / vllm).
+
+    Validates the full request path with a real model and the gRPC router
+    selection — confirming the axum-layer dispatch (`server.rs::v1_responses`)
+    short-circuits before any router-specific code runs, regardless of which
+    engine backs the model.
+    """
+
+    def test_enqueue_returns_queued_skeleton_local(self, model, setup_backend):
+        _, model_path, _, gw = setup_backend
+        resp = _post_responses(
+            gw,
+            {
+                "model": model_path,
+                "input": "hello",
+                "background": True,
+                "store": True,
+                "max_output_tokens": 16,
+            },
+        )
+        assert resp.status_code == 200, f"expected 200, got {resp.status_code}: body={resp.text!r}"
+        _assert_queued_skeleton(resp.json(), model_path)
+
+    def test_queued_response_readable_via_get_local(self, model, setup_backend):
+        _, model_path, _, gw = setup_backend
+        create = _post_responses(
+            gw,
+            {
+                "model": model_path,
+                "input": "hello",
+                "background": True,
+                "store": True,
+                "max_output_tokens": 16,
+            },
+        )
+        assert create.status_code == 200
+        rid = create.json()["id"]
+
+        get = httpx.get(
+            f"{gw.base_url}/v1/responses/{rid}",
+            headers={"Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY', 'sk-not-used')}"},
+            timeout=30.0,
+        )
+        assert get.status_code == 200, f"expected 200, got {get.status_code}: body={get.text!r}"
+        body = get.json()
+        assert body["id"] == rid
+        _assert_queued_skeleton(body, model_path)
+
+
+@pytest.mark.gpu(1)
+@pytest.mark.model("openai/gpt-oss-20b")
+@pytest.mark.gateway(extra_args=["--history-backend", "memory"])
+@pytest.mark.parametrize("setup_backend", ["grpc"], indirect=True)
+class TestBackgroundModeGptOss:
+    """Background-mode enqueue against gpt-oss-20b (Harmony) on local gRPC.
+
+    Same shape assertions as the dense-model class, exercising the
+    Harmony-protocol path through the axum dispatch. Background dispatch
+    is router-agnostic, so this should produce the identical queued
+    skeleton as the cloud OpenAI path.
+    """
+
+    def test_enqueue_returns_queued_skeleton_gpt_oss(self, model, setup_backend):
+        _, model_path, _, gw = setup_backend
+        resp = _post_responses(
+            gw,
+            {
+                "model": model_path,
+                "input": "hello",
+                "background": True,
+                "store": True,
+                "max_output_tokens": 16,
+            },
+        )
+        assert resp.status_code == 200, f"expected 200, got {resp.status_code}: body={resp.text!r}"
+        _assert_queued_skeleton(resp.json(), model_path)
+
+    def test_queued_response_readable_via_get_gpt_oss(self, model, setup_backend):
+        _, model_path, _, gw = setup_backend
+        create = _post_responses(
+            gw,
+            {
+                "model": model_path,
+                "input": "hello",
+                "background": True,
+                "store": True,
+                "max_output_tokens": 16,
+            },
+        )
+        assert create.status_code == 200
+        rid = create.json()["id"]
+
+        get = httpx.get(
+            f"{gw.base_url}/v1/responses/{rid}",
+            headers={"Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY', 'sk-not-used')}"},
+            timeout=30.0,
+        )
+        assert get.status_code == 200
+        body = get.json()
+        assert body["id"] == rid
+        _assert_queued_skeleton(body, model_path)

--- a/e2e_test/responses/test_background_mode.py
+++ b/e2e_test/responses/test_background_mode.py
@@ -113,10 +113,14 @@ class TestBackgroundModeValidation:
     ``ValidatedJson`` before any upstream call.
     """
 
-    def test_background_plus_stream_rejected_400(self, setup_backend):
-        """``background=true`` + ``stream=true`` → ``background_conflicts_with_stream``.
+    def test_background_plus_stream_is_accepted(self, setup_backend):
+        """``background=true`` + ``stream=true`` is allowed by the validator.
 
-        Pinned at ``crates/protocols/src/responses.rs:3127-3132``.
+        ``validate_responses_cross_parameters`` (BGM-PR-01, #1609) intentionally
+        permits streaming background create — the SSE stream is sourced from the
+        persisted event log — so this combination must NOT trip the Layer-1
+        validator. We assert no validator 400 (a queued 200 or a handler-layer
+        error are both acceptable; only the validator envelope is forbidden).
         """
         _, model, _, gw = setup_backend
         resp = _post_responses(
@@ -128,13 +132,28 @@ class TestBackgroundModeValidation:
                 "stream": True,
             },
         )
-        # Message text pinned in crates/protocols/src/responses.rs:3130.
-        _assert_validator_400(resp, "Cannot use background mode with streaming")
+        # Server errors (5xx) must never be tolerated — they would let a broken
+        # gateway pass silently.
+        assert resp.status_code < 500, (
+            f"background+stream must not surface a 5xx; got {resp.status_code}: {resp.text!r}"
+        )
+        if resp.status_code == 400:
+            body = resp.json()
+            err = body.get("error", {})
+            is_layer1_validator_error = (
+                isinstance(err, dict)
+                and err.get("type") == "invalid_request_error"
+                and err.get("code") == 400
+            )
+            assert not is_layer1_validator_error, (
+                f"background+stream must not trip the Layer-1 validator; got {body!r}"
+            )
 
     def test_background_plus_store_false_rejected_400(self, setup_backend):
         """``background=true`` + explicit ``store=false`` → ``background_requires_store``.
 
-        Pinned at ``crates/protocols/src/responses.rs:3134-3140``.
+        Pinned at ``validate_responses_cross_parameters`` in
+        ``crates/protocols/src/responses.rs`` (rule 3, background-requires-store).
         """
         _, model, _, gw = setup_backend
         resp = _post_responses(
@@ -146,8 +165,9 @@ class TestBackgroundModeValidation:
                 "store": False,
             },
         )
-        # Message text pinned in crates/protocols/src/responses.rs:3138.
-        _assert_validator_400(resp, "Background mode requires 'store' to be true")
+        # Message text pinned to `ValidationError::message` for
+        # `background_requires_store` in responses.rs.
+        _assert_validator_400(resp, "Background mode requires store=true")
 
     def test_background_with_store_unset_is_accepted(self, setup_backend):
         """``store`` unset defaults to ``true`` per the OpenAI spec.
@@ -386,11 +406,13 @@ class TestBackgroundModeLocal:
         assert create.status_code == 200
         rid = create.json()["id"]
 
-        get = httpx.get(
-            f"{gw.base_url}/v1/responses/{rid}",
-            headers={"Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY', 'sk-not-used')}"},
-            timeout=30.0,
-        )
+        with httpx.Client(timeout=30.0) as client:
+            get = client.get(
+                f"{gw.base_url}/v1/responses/{rid}",
+                headers={
+                    "Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY', 'sk-not-used')}"
+                },
+            )
         assert get.status_code == 200, f"expected 200, got {get.status_code}: body={get.text!r}"
         body = get.json()
         assert body["id"] == rid
@@ -440,11 +462,13 @@ class TestBackgroundModeGptOss:
         assert create.status_code == 200
         rid = create.json()["id"]
 
-        get = httpx.get(
-            f"{gw.base_url}/v1/responses/{rid}",
-            headers={"Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY', 'sk-not-used')}"},
-            timeout=30.0,
-        )
+        with httpx.Client(timeout=30.0) as client:
+            get = client.get(
+                f"{gw.base_url}/v1/responses/{rid}",
+                headers={
+                    "Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY', 'sk-not-used')}"
+                },
+            )
         assert get.status_code == 200
         body = get.json()
         assert body["id"] == rid

--- a/model_gateway/src/routers/common/background/create.rs
+++ b/model_gateway/src/routers/common/background/create.rs
@@ -1,0 +1,750 @@
+//! Background create path: resolve input snapshot + enqueue.
+
+use std::sync::Arc;
+
+use axum::{
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    Json,
+};
+use openai_protocol::responses::{
+    generate_id, ResponseContentPart, ResponseInputOutputItem, ResponsesRequest,
+};
+use serde_json::{json, Value};
+use smg_data_connector::{
+    BackgroundRepositoryError, BackgroundResponseRepository, ConversationId, ConversationItem,
+    ConversationItemStorage, ConversationStorage, EnqueueRequest,
+    RequestContext as StorageRequestContext, ResponseId, ResponseStorage, StoredResponse,
+};
+use tracing::warn;
+use uuid::Uuid;
+
+use crate::{
+    config::BackgroundConfig,
+    routers::{common::persistence_utils::split_stored_message_content, error},
+};
+
+const MAX_SNAPSHOT_ITEMS: usize = 100;
+
+/// Storage handles the background create path needs. Passed in from the
+/// caller so the handler doesn't reach into `AppContext` directly — every
+/// entry point (HTTP regular, OpenAI, gRPC) assembles these from whatever
+/// shape its context already has.
+pub struct BackgroundCreateDeps<'a> {
+    pub repository: Option<&'a Arc<dyn BackgroundResponseRepository>>,
+    pub response_storage: &'a dyn ResponseStorage,
+    pub conversation_storage: &'a dyn ConversationStorage,
+    pub conversation_item_storage: &'a dyn ConversationItemStorage,
+    pub background_config: &'a BackgroundConfig,
+    /// Forwarded to `enqueue` so the worker replays the caller's tenant /
+    /// principal identity when it later writes the finalized response.
+    pub request_context: Option<&'a StorageRequestContext>,
+}
+
+/// Handle `POST /v1/responses` with `background=true`.
+///
+/// Returns a JSON `Response` object with `status: "queued"`, or an HTTP error
+/// response when validation / snapshot resolution / enqueue fails.
+pub async fn handle_background_create(
+    deps: BackgroundCreateDeps<'_>,
+    request: &ResponsesRequest,
+    model_id: &str,
+) -> Response {
+    let Some(repository) = deps.repository else {
+        return error::bad_request(
+            "background_not_supported",
+            "Background mode is not supported on this history_backend. \
+             Use memory, postgres, or oracle.",
+        );
+    };
+
+    let snapshot = match resolve_snapshot(&deps, request).await {
+        Ok(s) => s,
+        Err(resp) => return resp,
+    };
+
+    let response_id = ResponseId::from(format!("resp_{}", Uuid::now_v7()).as_str());
+    let now_unix = chrono::Utc::now().timestamp();
+    let initial_raw = initial_queued_response(&response_id, model_id, now_unix, request);
+    let request_json = serde_json::to_value(request).unwrap_or_else(|e| {
+        warn!(error = %e, "failed to serialize ResponsesRequest for background enqueue");
+        Value::Null
+    });
+
+    let mut enqueue_req = EnqueueRequest::new(
+        response_id.clone(),
+        model_id.to_string(),
+        request_json,
+        Value::Array(snapshot),
+        initial_raw.clone(),
+        false,
+        request.priority,
+    );
+    enqueue_req.conversation_id = request.conversation.as_ref().map(|c| c.as_id().to_string());
+    // Synchronous storage paths fall back to `request.user` when
+    // `safety_identifier` is unset (see `routers/common/persistence_utils`).
+    // Mirror that here so identifier-based queries see queued responses too.
+    enqueue_req.safety_identifier = request
+        .safety_identifier
+        .clone()
+        .or_else(|| request.user.clone());
+    enqueue_req.previous_response_id = request
+        .previous_response_id
+        .as_deref()
+        .map(ResponseId::from);
+
+    let max_depth = u64::from(deps.background_config.max_queue_depth);
+    let request_context = deps.request_context.cloned();
+    match repository
+        .enqueue(enqueue_req, request_context, Some(max_depth))
+        .await
+    {
+        Ok(_) => Json(initial_raw).into_response(),
+        Err(BackgroundRepositoryError::QueueFull { current, limit }) => error::create_error(
+            StatusCode::TOO_MANY_REQUESTS,
+            "queue_full",
+            format!("Background queue is at capacity ({current}/{limit})."),
+        ),
+        Err(BackgroundRepositoryError::InvalidTransition(msg)) => {
+            error::create_error(StatusCode::CONFLICT, "invalid_transition", msg)
+        }
+        Err(e) => error::internal_error("background_enqueue_failed", e.to_string()),
+    }
+}
+
+/// Build the execution-time input snapshot by resolving `previous_response_id`
+/// or `conversation` and appending the request's own `input` items.
+async fn resolve_snapshot(
+    deps: &BackgroundCreateDeps<'_>,
+    request: &ResponsesRequest,
+) -> Result<Vec<Value>, Response> {
+    let mut items: Vec<Value> = Vec::new();
+
+    if let Some(prev_id_str) = request.previous_response_id.as_deref() {
+        append_prev_chain_items(deps.response_storage, prev_id_str, &mut items).await?;
+    } else if let Some(conv_ref) = request.conversation.as_ref() {
+        append_conversation_items(
+            deps.conversation_storage,
+            deps.conversation_item_storage,
+            conv_ref.as_id(),
+            &mut items,
+        )
+        .await?;
+    }
+
+    let request_input_json = serde_json::to_value(&request.input).unwrap_or(Value::Null);
+    if let Some(arr) = request_input_json.as_array() {
+        // Each item must carry a stable `id` so subsequent
+        // `GET /v1/responses/{id}/input_items` calls return matching
+        // `first_id`/`last_id` instead of synthesizing fresh ids per read.
+        // Synchronous persistence does the same up-front normalisation.
+        for item in arr {
+            items.push(ensure_item_id(item.clone()));
+        }
+    } else if !request_input_json.is_null() {
+        // ResponseInput::String — wrap as a single user message the worker
+        // can execute. Stable `id` matches the synchronous-persistence
+        // normalisation so `GET /v1/responses/{id}/input_items` returns the
+        // same `first_id`/`last_id` across calls.
+        items.push(json!({
+            "id": generate_id("msg"),
+            "type": "message",
+            "role": "user",
+            "content": request_input_json,
+        }));
+    }
+
+    if items.len() > MAX_SNAPSHOT_ITEMS {
+        return Err(error::create_error(
+            StatusCode::CONFLICT,
+            "resolved_snapshot_too_large",
+            format!(
+                "Resolved snapshot has {} items, exceeds the cap of {}.",
+                items.len(),
+                MAX_SNAPSHOT_ITEMS
+            ),
+        ));
+    }
+
+    Ok(items)
+}
+
+async fn append_prev_chain_items(
+    storage: &dyn ResponseStorage,
+    prev_id_str: &str,
+    items: &mut Vec<Value>,
+) -> Result<(), Response> {
+    let prev_id = ResponseId::from(prev_id_str);
+    // Bound the chain walk to one past the snapshot cap. Once we've loaded
+    // more than `MAX_SNAPSHOT_ITEMS` ancestors there is no way the resolved
+    // snapshot fits, so don't pull unbounded history out of storage.
+    let chain = match storage
+        .get_response_chain(&prev_id, Some(MAX_SNAPSHOT_ITEMS + 1))
+        .await
+    {
+        Ok(chain) => chain,
+        Err(e) => {
+            return Err(error::internal_error(
+                "load_previous_response_chain_failed",
+                format!("Failed to load previous response chain for {prev_id_str}: {e}"),
+            ));
+        }
+    };
+    if chain.responses.is_empty() {
+        return Err(error::not_found(
+            "previous_response_not_found",
+            format!("Previous response with id '{prev_id_str}' not found."),
+        ));
+    }
+
+    for stored in &chain.responses {
+        if let Err(boxed) = check_prev_response_usable(stored) {
+            return Err(*boxed);
+        }
+        append_stored_response_items(stored, items);
+    }
+    Ok(())
+}
+
+fn check_prev_response_usable(stored: &StoredResponse) -> Result<(), Box<Response>> {
+    // Use the stored response's own id, not the caller's
+    // `previous_response_id`, so an unusable *ancestor* surfaces with the
+    // accurate id rather than the chain leaf's.
+    let response_id = &stored.id.0;
+    let status = stored
+        .raw_response
+        .get("status")
+        .and_then(Value::as_str)
+        .unwrap_or("completed");
+    match status {
+        "queued" | "in_progress" => Err(Box::new(error::create_error(
+            StatusCode::CONFLICT,
+            "previous_response_not_ready",
+            format!(
+                "Previous response '{response_id}' is still {status}; \
+                 cannot chain until it reaches a terminal state."
+            ),
+        ))),
+        "failed" | "cancelled" => Err(Box::new(error::create_error(
+            StatusCode::CONFLICT,
+            "previous_response_not_usable",
+            format!(
+                "Previous response '{response_id}' is {status}; \
+                 only completed or incomplete responses can be chained."
+            ),
+        ))),
+        _ => Ok(()),
+    }
+}
+
+fn append_stored_response_items(stored: &StoredResponse, items: &mut Vec<Value>) {
+    if let Some(arr) = stored.input.as_array() {
+        items.extend(arr.iter().cloned());
+    }
+    if let Some(out_arr) = stored.raw_response.get("output").and_then(Value::as_array) {
+        items.extend(out_arr.iter().cloned());
+    }
+}
+
+async fn append_conversation_items(
+    conv_storage: &dyn ConversationStorage,
+    item_storage: &dyn ConversationItemStorage,
+    conv_id_str: &str,
+    items: &mut Vec<Value>,
+) -> Result<(), Response> {
+    let conv_id = ConversationId::from(conv_id_str.to_string());
+    match conv_storage.get_conversation(&conv_id).await {
+        Ok(Some(_)) => {}
+        Ok(None) => {
+            return Err(error::not_found(
+                "conversation_not_found",
+                format!("Conversation '{conv_id_str}' not found."),
+            ));
+        }
+        Err(e) => {
+            return Err(error::internal_error(
+                "load_conversation_failed",
+                format!("Failed to load conversation '{conv_id_str}': {e}"),
+            ));
+        }
+    }
+
+    // Page through the conversation in fixed batches and convert as we go.
+    // The cap applies to *replayable* items, but the converter drops
+    // non-replayable rows (reasoning), so a single fixed window can either
+    // miss late replayable turns or reject a still-fitting conversation.
+    // Looping until either the replayable count exceeds the cap or storage
+    // is exhausted gives strict semantics regardless of how rows are mixed.
+    const PAGE_SIZE: usize = 64;
+    let mut converted: Vec<Value> = Vec::new();
+    let mut after: Option<String> = None;
+    loop {
+        let list_params = smg_data_connector::ListParams {
+            limit: PAGE_SIZE,
+            order: smg_data_connector::SortOrder::Asc,
+            after: after.clone(),
+        };
+        let batch = match item_storage.list_items(&conv_id, list_params).await {
+            Ok(items) => items,
+            Err(e) => {
+                return Err(error::internal_error(
+                    "load_conversation_items_failed",
+                    format!("Failed to load conversation items for '{conv_id_str}': {e}"),
+                ));
+            }
+        };
+        if batch.is_empty() {
+            break;
+        }
+        let next_after = batch.last().map(|i| i.id.0.clone());
+        for ci in batch {
+            match conversation_item_to_snapshot_value(ci, conv_id_str) {
+                Ok(Some(value)) => converted.push(value),
+                Ok(None) => {}
+                Err(boxed) => return Err(*boxed),
+            }
+            if converted.len() > MAX_SNAPSHOT_ITEMS {
+                return Err(error::create_error(
+                    StatusCode::CONFLICT,
+                    "conversation_too_large",
+                    format!(
+                        "Conversation '{conv_id_str}' resolves to more than \
+                         {MAX_SNAPSHOT_ITEMS} replayable items; background \
+                         snapshots cannot exceed this cap."
+                    ),
+                ));
+            }
+        }
+        after = next_after;
+        if after.is_none() {
+            break;
+        }
+    }
+
+    items.extend(converted);
+    Ok(())
+}
+
+/// Convert a stored `ConversationItem` row into the `ResponseInputOutputItem`
+/// wire shape the worker consumes.
+///
+/// `Ok(None)` marks an item that is intentionally omitted from the snapshot
+/// (reasoning rows, unknown types). `Err` is boxed to keep the success
+/// variant small.
+fn conversation_item_to_snapshot_value(
+    ci: ConversationItem,
+    conv_id_str: &str,
+) -> Result<Option<Value>, Box<Response>> {
+    let converted: Option<ResponseInputOutputItem> = match ci.item_type.as_str() {
+        "message" => {
+            let (content_value, stored_phase) = split_stored_message_content(ci.content);
+            let content_parts: Vec<ResponseContentPart> =
+                match serde_json::from_value(content_value) {
+                    Ok(parts) => parts,
+                    Err(e) => {
+                        return Err(Box::new(error::internal_error(
+                            "deserialize_conversation_item_failed",
+                            format!(
+                                "Failed to deserialize message content for conversation \
+                                 '{conv_id_str}' item '{}': {e}",
+                                ci.id.0
+                            ),
+                        )));
+                    }
+                };
+            Some(ResponseInputOutputItem::Message {
+                id: ci.id.0,
+                role: ci.role.unwrap_or_else(|| "user".to_string()),
+                content: content_parts,
+                status: ci.status,
+                phase: stored_phase,
+            })
+        }
+        "reasoning" => None,
+        // Every other replayable item type — function calls, MCP, web search,
+        // computer/shell/apply-patch tool calls, image generation, etc. — is
+        // stored as a `ResponseInputOutputItem` JSON blob. Round-trip it
+        // through serde so we don't silently drop tool-call history.
+        other => match serde_json::from_value::<ResponseInputOutputItem>(ci.content) {
+            Ok(item) => Some(item),
+            Err(e) => {
+                return Err(Box::new(error::internal_error(
+                    "deserialize_conversation_item_failed",
+                    format!(
+                        "Failed to deserialize {other} content for conversation \
+                         '{conv_id_str}' item '{}': {e}",
+                        ci.id.0
+                    ),
+                )));
+            }
+        },
+    };
+
+    match converted {
+        Some(item) => match serde_json::to_value(&item) {
+            Ok(v) => Ok(Some(v)),
+            Err(e) => Err(Box::new(error::internal_error(
+                "serialize_conversation_item_failed",
+                format!("Failed to serialize conversation item for '{conv_id_str}': {e}"),
+            ))),
+        },
+        None => Ok(None),
+    }
+}
+
+/// Inject a synthetic `id` on an input item that lacks one, so the queued
+/// snapshot has stable identifiers for `GET /v1/responses/{id}/input_items`.
+/// Items that already carry an `id` are returned unchanged.
+fn ensure_item_id(mut item: Value) -> Value {
+    if let Some(obj) = item.as_object_mut() {
+        if !obj.contains_key("id") {
+            let prefix = obj
+                .get("type")
+                .and_then(Value::as_str)
+                .and_then(item_id_prefix)
+                .unwrap_or("msg");
+            obj.insert("id".to_string(), Value::String(generate_id(prefix)));
+        }
+    }
+    item
+}
+
+/// Map an input-item `type` discriminator to its conventional id prefix.
+/// Mirrors the prefixes used by the protocol so synthetic ids are
+/// indistinguishable from the ones a synchronous request would produce.
+fn item_id_prefix(item_type: &str) -> Option<&'static str> {
+    match item_type {
+        "message" => Some("msg"),
+        "function_call" => Some("fc"),
+        "function_call_output" => Some("fco"),
+        "reasoning" => Some("r"),
+        _ => None,
+    }
+}
+
+fn initial_queued_response(
+    response_id: &ResponseId,
+    model_id: &str,
+    created_at_unix: i64,
+    request: &ResponsesRequest,
+) -> Value {
+    let mut obj = json!({
+        "id": response_id.0,
+        "object": "response",
+        "created_at": created_at_unix,
+        "status": "queued",
+        "background": true,
+        "model": model_id,
+        "output": [],
+    });
+
+    if let Some(conv) = request.conversation.as_ref() {
+        obj["conversation"] = Value::String(conv.as_id().to_string());
+    }
+    if let Some(prev_id) = request.previous_response_id.as_ref() {
+        obj["previous_response_id"] = Value::String(prev_id.clone());
+    }
+    obj
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::body::to_bytes;
+    use openai_protocol::responses::ResponseInput;
+    use smg_data_connector::{
+        MemoryBackgroundRepository, MemoryConversationItemStorage, MemoryConversationStorage,
+        MemoryResponseStorage,
+    };
+
+    use super::*;
+
+    struct Harness {
+        bg: Arc<dyn BackgroundResponseRepository>,
+        response_storage: Arc<MemoryResponseStorage>,
+        conversation_storage: Arc<MemoryConversationStorage>,
+        conversation_item_storage: Arc<MemoryConversationItemStorage>,
+        config: BackgroundConfig,
+    }
+
+    impl Harness {
+        fn new(max_queue_depth: u32) -> Self {
+            let rs = Arc::new(MemoryResponseStorage::new());
+            let bg: Arc<dyn BackgroundResponseRepository> =
+                Arc::new(MemoryBackgroundRepository::new(Arc::clone(&rs)));
+            let config = BackgroundConfig {
+                max_queue_depth,
+                ..Default::default()
+            };
+            Self {
+                bg,
+                response_storage: rs,
+                conversation_storage: Arc::new(MemoryConversationStorage::new()),
+                conversation_item_storage: Arc::new(MemoryConversationItemStorage::new()),
+                config,
+            }
+        }
+
+        fn deps_with_repo(&self) -> BackgroundCreateDeps<'_> {
+            BackgroundCreateDeps {
+                repository: Some(&self.bg),
+                response_storage: self.response_storage.as_ref(),
+                conversation_storage: self.conversation_storage.as_ref(),
+                conversation_item_storage: self.conversation_item_storage.as_ref(),
+                background_config: &self.config,
+                request_context: None,
+            }
+        }
+
+        fn deps_without_repo(&self) -> BackgroundCreateDeps<'_> {
+            BackgroundCreateDeps {
+                repository: None,
+                response_storage: self.response_storage.as_ref(),
+                conversation_storage: self.conversation_storage.as_ref(),
+                conversation_item_storage: self.conversation_item_storage.as_ref(),
+                background_config: &self.config,
+                request_context: None,
+            }
+        }
+    }
+
+    fn bg_req() -> ResponsesRequest {
+        ResponsesRequest {
+            background: Some(true),
+            store: Some(true),
+            input: ResponseInput::Text("hello".to_string()),
+            ..Default::default()
+        }
+    }
+
+    async fn body_json(resp: Response) -> Value {
+        let (_parts, body) = resp.into_parts();
+        let bytes = to_bytes(body, 1024 * 1024).await.unwrap();
+        serde_json::from_slice(&bytes).unwrap_or(Value::Null)
+    }
+
+    #[tokio::test]
+    async fn returns_bad_request_when_repository_missing() {
+        let h = Harness::new(10);
+        let resp = handle_background_create(h.deps_without_repo(), &bg_req(), "gpt-5.1").await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = body_json(resp).await;
+        assert_eq!(body["error"]["code"], "background_not_supported");
+    }
+
+    #[tokio::test]
+    async fn happy_path_returns_queued_response() {
+        let h = Harness::new(10);
+        let resp = handle_background_create(h.deps_with_repo(), &bg_req(), "gpt-5.1").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp).await;
+        assert_eq!(body["status"], "queued");
+        assert_eq!(body["background"], true);
+        assert_eq!(body["model"], "gpt-5.1");
+        assert!(body["id"].as_str().unwrap().starts_with("resp_"));
+    }
+
+    #[tokio::test]
+    async fn returns_too_many_requests_when_queue_at_cap() {
+        let h = Harness::new(1);
+        let first = handle_background_create(h.deps_with_repo(), &bg_req(), "gpt-5.1").await;
+        assert_eq!(first.status(), StatusCode::OK);
+        let second = handle_background_create(h.deps_with_repo(), &bg_req(), "gpt-5.1").await;
+        assert_eq!(second.status(), StatusCode::TOO_MANY_REQUESTS);
+        let body = body_json(second).await;
+        assert_eq!(body["error"]["code"], "queue_full");
+    }
+
+    #[tokio::test]
+    async fn returns_not_found_when_previous_response_missing() {
+        let h = Harness::new(10);
+        let mut req = bg_req();
+        req.previous_response_id = Some("resp_missing".to_string());
+        let resp = handle_background_create(h.deps_with_repo(), &req, "gpt-5.1").await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let body = body_json(resp).await;
+        assert_eq!(body["error"]["code"], "previous_response_not_found");
+    }
+
+    #[tokio::test]
+    async fn returns_conflict_when_previous_response_still_queued() {
+        let h = Harness::new(10);
+        // First background create leaves r1 in status=queued in the mirrored
+        // response storage. Chaining to it must fail with `not_ready`.
+        let mut first = bg_req();
+        let resp = handle_background_create(h.deps_with_repo(), &first, "gpt-5.1").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let first_body = body_json(resp).await;
+        let first_id = first_body["id"].as_str().unwrap().to_string();
+
+        first = bg_req();
+        first.previous_response_id = Some(first_id);
+        let resp = handle_background_create(h.deps_with_repo(), &first, "gpt-5.1").await;
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+        let body = body_json(resp).await;
+        assert_eq!(body["error"]["code"], "previous_response_not_ready");
+    }
+
+    #[tokio::test]
+    async fn returns_conflict_when_previous_response_cancelled() {
+        let h = Harness::new(10);
+        // Seed the response storage with a cancelled response manually.
+        use smg_data_connector::ResponseStorage;
+        let mut prior = StoredResponse::new(None);
+        prior.id = ResponseId::from("resp_cancelled");
+        prior.raw_response = json!({"id": "resp_cancelled", "status": "cancelled"});
+        h.response_storage.store_response(prior).await.unwrap();
+
+        let mut req = bg_req();
+        req.previous_response_id = Some("resp_cancelled".to_string());
+        let resp = handle_background_create(h.deps_with_repo(), &req, "gpt-5.1").await;
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+        let body = body_json(resp).await;
+        assert_eq!(body["error"]["code"], "previous_response_not_usable");
+    }
+
+    async fn seed_conversation(h: &Harness, conv_id_str: &str, item_count: usize) {
+        use smg_data_connector::{
+            ConversationItemStorage, ConversationStorage, NewConversation, NewConversationItem,
+        };
+        let conv_id = ConversationId::from(conv_id_str.to_string());
+        h.conversation_storage
+            .create_conversation(NewConversation {
+                id: Some(conv_id.clone()),
+                metadata: None,
+            })
+            .await
+            .unwrap();
+        for i in 0..item_count {
+            let item = h
+                .conversation_item_storage
+                .create_item(NewConversationItem {
+                    id: None,
+                    response_id: None,
+                    item_type: "message".to_string(),
+                    role: Some("user".to_string()),
+                    content: json!([{"type": "input_text", "text": format!("turn {i}")}]),
+                    status: Some("completed".to_string()),
+                })
+                .await
+                .unwrap();
+            h.conversation_item_storage
+                .link_item(&conv_id, &item.id, chrono::Utc::now())
+                .await
+                .unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn conversation_snapshot_uses_response_input_output_shape() {
+        // Snapshot must carry `ResponseInputOutputItem` (`type`/`content`),
+        // not raw `ConversationItem` storage rows (`item_type`/`created_at`).
+        let h = Harness::new(10);
+        seed_conversation(&h, "conv_snapshot", 1).await;
+
+        let mut req = bg_req();
+        req.conversation = Some(openai_protocol::common::ConversationRef::Id(
+            "conv_snapshot".to_string(),
+        ));
+        let resp = handle_background_create(h.deps_with_repo(), &req, "gpt-5.1").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let job =
+            h.bg.claim_next(
+                "test-worker",
+                chrono::Utc::now(),
+                std::time::Duration::from_secs(30),
+            )
+            .await
+            .unwrap()
+            .expect("enqueued job is claimable");
+        let input = job.input.as_array().expect("snapshot is an array");
+        let first = &input[0];
+        assert_eq!(
+            first["type"], "message",
+            "conversation item should use ResponseInputOutputItem shape"
+        );
+        assert_eq!(first["role"], "user");
+        assert_eq!(
+            first["content"][0]["type"], "input_text",
+            "content parts should be preserved"
+        );
+        assert!(
+            first.get("item_type").is_none(),
+            "ConversationItem shape (item_type) must not leak into the snapshot"
+        );
+    }
+
+    #[tokio::test]
+    async fn conversation_too_large_returns_conflict() {
+        let h = Harness::new(10);
+        seed_conversation(&h, "conv_overflow", MAX_SNAPSHOT_ITEMS + 1).await;
+
+        let mut req = bg_req();
+        req.conversation = Some(openai_protocol::common::ConversationRef::Id(
+            "conv_overflow".to_string(),
+        ));
+        let resp = handle_background_create(h.deps_with_repo(), &req, "gpt-5.1").await;
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+        let body = body_json(resp).await;
+        assert_eq!(body["error"]["code"], "conversation_too_large");
+    }
+
+    #[tokio::test]
+    async fn conversation_with_reasoning_rows_below_cap_is_accepted() {
+        // The cap counts replayable items, not raw storage rows. Seeding a
+        // conversation with more storage rows than the cap but where
+        // reasoning items take the excess must still succeed.
+        use smg_data_connector::{ConversationItemStorage, NewConversationItem};
+        let h = Harness::new(10);
+        seed_conversation(&h, "conv_mixed", MAX_SNAPSHOT_ITEMS - 1).await;
+        let conv_id = ConversationId::from("conv_mixed".to_string());
+        // Append two reasoning rows — they are dropped by the converter,
+        // pushing raw row count to MAX_SNAPSHOT_ITEMS + 1 while the
+        // replayable count stays at MAX_SNAPSHOT_ITEMS - 1.
+        for _ in 0..2 {
+            let item = h
+                .conversation_item_storage
+                .create_item(NewConversationItem {
+                    id: None,
+                    response_id: None,
+                    item_type: "reasoning".to_string(),
+                    role: None,
+                    content: json!({"summary": []}),
+                    status: None,
+                })
+                .await
+                .unwrap();
+            h.conversation_item_storage
+                .link_item(&conv_id, &item.id, chrono::Utc::now())
+                .await
+                .unwrap();
+        }
+
+        let mut req = bg_req();
+        req.conversation = Some(openai_protocol::common::ConversationRef::Id(
+            "conv_mixed".to_string(),
+        ));
+        let resp = handle_background_create(h.deps_with_repo(), &req, "gpt-5.1").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn priority_is_propagated_to_enqueue() {
+        let h = Harness::new(10);
+        let mut req = bg_req();
+        req.priority = 7;
+        let resp = handle_background_create(h.deps_with_repo(), &req, "gpt-5.1").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let job =
+            h.bg.claim_next(
+                "test-worker",
+                chrono::Utc::now(),
+                std::time::Duration::from_secs(30),
+            )
+            .await
+            .unwrap()
+            .expect("enqueued job is claimable");
+        assert_eq!(job.priority, 7);
+    }
+}

--- a/model_gateway/src/routers/common/background/create.rs
+++ b/model_gateway/src/routers/common/background/create.rs
@@ -66,10 +66,19 @@ pub async fn handle_background_create(
     let response_id = ResponseId::from(format!("resp_{}", Uuid::now_v7()).as_str());
     let now_unix = chrono::Utc::now().timestamp();
     let initial_raw = initial_queued_response(&response_id, model_id, now_unix, request);
-    let request_json = serde_json::to_value(request).unwrap_or_else(|e| {
-        warn!(error = %e, "failed to serialize ResponsesRequest for background enqueue");
-        Value::Null
-    });
+    // Falling back to `Value::Null` here would enqueue an unreplayable job (the
+    // worker reconstructs the accepted contract from `request_json`), so a
+    // serialize failure must fail the request rather than dead-letter silently.
+    let request_json = match serde_json::to_value(request) {
+        Ok(v) => v,
+        Err(e) => {
+            warn!(error = %e, "failed to serialize ResponsesRequest for background enqueue");
+            return error::internal_error(
+                "background_enqueue_failed",
+                format!("Failed to serialize background request: {e}"),
+            );
+        }
+    };
 
     let mut enqueue_req = EnqueueRequest::new(
         response_id.clone(),
@@ -77,7 +86,7 @@ pub async fn handle_background_create(
         request_json,
         Value::Array(snapshot),
         initial_raw.clone(),
-        false,
+        request.stream.unwrap_or(false),
         request.priority,
     );
     enqueue_req.conversation_id = request.conversation.as_ref().map(|c| c.as_id().to_string());
@@ -141,29 +150,26 @@ async fn resolve_snapshot(
         for item in arr {
             items.push(ensure_item_id(item.clone()));
         }
-    } else if !request_input_json.is_null() {
+    } else if let Some(text) = request_input_json.as_str() {
         // ResponseInput::String — wrap as a single user message the worker
-        // can execute. Stable `id` matches the synchronous-persistence
-        // normalisation so `GET /v1/responses/{id}/input_items` returns the
-        // same `first_id`/`last_id` across calls.
+        // can execute. Mirror the synchronous persistence normalisation
+        // (`persistence_utils::extract_input_items`): the raw string becomes an
+        // `input_text` content part (not stored verbatim) with `status` and a
+        // stable `msg_` id, so `GET /v1/responses/{id}/input_items` and the
+        // worker's later deserialization both see the canonical array shape.
         items.push(json!({
             "id": generate_id("msg"),
             "type": "message",
             "role": "user",
-            "content": request_input_json,
+            "content": [{"type": "input_text", "text": text}],
+            "status": "completed",
         }));
     }
 
+    // The chain/conversation appends short-circuit on the cap as they grow;
+    // this final guard covers the request's own input items appended above.
     if items.len() > MAX_SNAPSHOT_ITEMS {
-        return Err(error::create_error(
-            StatusCode::CONFLICT,
-            "resolved_snapshot_too_large",
-            format!(
-                "Resolved snapshot has {} items, exceeds the cap of {}.",
-                items.len(),
-                MAX_SNAPSHOT_ITEMS
-            ),
-        ));
+        return Err(snapshot_too_large_error(items.len()));
     }
 
     Ok(items)
@@ -197,11 +203,21 @@ async fn append_prev_chain_items(
         ));
     }
 
+    // `get_response_chain` returns responses in chronological order (oldest
+    // first) — both the default `ResponseStorage` impl and the in-memory
+    // override reverse the backward `previous_response_id` walk before
+    // returning (see `data_connector::core`/`memory`). Appending in iteration
+    // order therefore yields a chronological snapshot, so do NOT reverse here.
     for stored in &chain.responses {
         if let Err(boxed) = check_prev_response_usable(stored) {
             return Err(*boxed);
         }
-        append_stored_response_items(stored, items);
+        // Check the global cap before cloning each ancestor's items so an
+        // oversized chain short-circuits instead of cloning the whole history
+        // and rejecting afterwards.
+        if let Err(boxed) = append_stored_response_items(stored, items) {
+            return Err(*boxed);
+        }
     }
     Ok(())
 }
@@ -237,13 +253,43 @@ fn check_prev_response_usable(stored: &StoredResponse) -> Result<(), Box<Respons
     }
 }
 
-fn append_stored_response_items(stored: &StoredResponse, items: &mut Vec<Value>) {
+fn append_stored_response_items(
+    stored: &StoredResponse,
+    items: &mut Vec<Value>,
+) -> Result<(), Box<Response>> {
+    // Count this ancestor's contribution before cloning anything. If it would
+    // push the snapshot past the cap we bail immediately rather than cloning a
+    // chain we are about to reject — this short-circuits unbounded growth.
+    let input_len = stored.input.as_array().map_or(0, Vec::len);
+    let output_len = stored
+        .raw_response
+        .get("output")
+        .and_then(Value::as_array)
+        .map_or(0, Vec::len);
+    if items.len() + input_len + output_len > MAX_SNAPSHOT_ITEMS {
+        return Err(Box::new(snapshot_too_large_error(
+            items.len() + input_len + output_len,
+        )));
+    }
+
     if let Some(arr) = stored.input.as_array() {
         items.extend(arr.iter().cloned());
     }
     if let Some(out_arr) = stored.raw_response.get("output").and_then(Value::as_array) {
         items.extend(out_arr.iter().cloned());
     }
+    Ok(())
+}
+
+/// Shared CONFLICT error for a resolved snapshot that exceeds the global cap.
+fn snapshot_too_large_error(item_count: usize) -> Response {
+    error::create_error(
+        StatusCode::CONFLICT,
+        "resolved_snapshot_too_large",
+        format!(
+            "Resolved snapshot has {item_count} items, exceeds the cap of {MAX_SNAPSHOT_ITEMS}."
+        ),
+    )
 }
 
 async fn append_conversation_items(
@@ -296,6 +342,9 @@ async fn append_conversation_items(
         if batch.is_empty() {
             break;
         }
+        // A short page means storage is exhausted — stop after processing it
+        // instead of issuing a redundant round-trip that would return empty.
+        let is_last_page = batch.len() < PAGE_SIZE;
         let next_after = batch.last().map(|i| i.id.0.clone());
         for ci in batch {
             match conversation_item_to_snapshot_value(ci, conv_id_str) {
@@ -314,6 +363,9 @@ async fn append_conversation_items(
                     ),
                 ));
             }
+        }
+        if is_last_page {
+            break;
         }
         after = next_after;
         if after.is_none() {

--- a/model_gateway/src/routers/common/background/mod.rs
+++ b/model_gateway/src/routers/common/background/mod.rs
@@ -1,7 +1,6 @@
-//! Background-mode shared handler scaffolding.
-//!
-//! BGM-PR-03 ships only [`BackgroundServices`]. Concrete create / cancel /
-//! resume handlers land in later PRs.
+//! Background-mode shared handlers.
+
+pub mod create;
 
 use std::sync::Arc;
 

--- a/model_gateway/src/routers/grpc/regular/responses/handlers.rs
+++ b/model_gateway/src/routers/grpc/regular/responses/handlers.rs
@@ -12,9 +12,6 @@
 //! 1. **Synchronous** - Returns complete response immediately (non_streaming.rs)
 //! 2. **Streaming** - Returns SSE stream with real-time events (streaming.rs)
 //!
-//! Note: Background mode is no longer supported. Requests with background=true
-//! will be rejected with a 400 error.
-//!
 //! # Request Flow
 //!
 //! ```text
@@ -54,13 +51,11 @@ pub(crate) async fn route_responses(
     tenant_request_meta: crate::middleware::TenantRequestMeta,
     model_id: String,
 ) -> Response {
-    // BGM-PR-04 replaces this with delegation to routers/common/background/
-    // when ctx.app_context.background_repository is Some.
     let is_background = request.background.unwrap_or(false);
     if is_background {
         return error::bad_request(
             "unsupported_parameter",
-            "Background mode is not supported. Please set 'background' to false or omit it.",
+            "Background mode is not supported on the gRPC router; use the HTTP API.",
         );
     }
 

--- a/model_gateway/src/server.rs
+++ b/model_gateway/src/server.rs
@@ -54,8 +54,12 @@ use crate::{
         otel_trace,
     },
     routers::{
-        conversations, openai::realtime::ws::RealtimeQueryParams, parse,
-        responses as response_handlers, router_manager::RouterManager, tokenize, RouterTrait,
+        common::background::create::{handle_background_create, BackgroundCreateDeps},
+        conversations,
+        openai::realtime::ws::RealtimeQueryParams,
+        parse, responses as response_handlers,
+        router_manager::RouterManager,
+        tokenize, RouterTrait,
     },
     service_discovery::{start_service_discovery, ServiceDiscoveryConfig},
     wasm::route::{add_wasm_module, list_wasm_modules, remove_wasm_module},
@@ -280,6 +284,18 @@ async fn v1_responses(
     cancel: middleware::scheduler::PreemptionGuard,
     ValidatedJson(body): ValidatedJson<ResponsesRequest>,
 ) -> Response {
+    if body.background.unwrap_or(false) {
+        let request_context = smg_data_connector::current_request_context();
+        let deps = BackgroundCreateDeps {
+            repository: state.context.background_repository.as_ref(),
+            response_storage: state.context.response_storage.as_ref(),
+            conversation_storage: state.context.conversation_storage.as_ref(),
+            conversation_item_storage: state.context.conversation_item_storage.as_ref(),
+            background_config: &state.context.router_config.background,
+            request_context: request_context.as_ref(),
+        };
+        return handle_background_create(deps, &body, &body.model).await;
+    }
     cancel
         .guard(
             state

--- a/model_gateway/tests/api/api_endpoints_test.rs
+++ b/model_gateway/tests/api/api_endpoints_test.rs
@@ -777,7 +777,13 @@ mod responses_endpoint_tests {
     }
 
     #[tokio::test]
-    async fn test_v1_responses_cancel() {
+    async fn test_v1_responses_background_create_enqueues() {
+        // BGM-PR-04: `background=true` is intercepted by the axum v1_responses
+        // handler and routed to the shared background create path (it no longer
+        // proxies to the worker). With a background repository configured (the
+        // test context mirrors the production memory backend), the create
+        // enqueues and returns a queued `Response`. The background cancel/poll
+        // round trip is wired by later PRs (BGM-PR-05/06/07).
         let ctx = AppTestContext::new(vec![MockWorkerConfig {
             port: 18953,
             worker_type: WorkerType::Regular,
@@ -789,15 +795,12 @@ mod responses_endpoint_tests {
 
         let app = ctx.create_app();
 
-        // First create a response to obtain an id
-        let resp_id = "test-cancel-resp-id-456";
         let payload = json!({
             "input": "Hello Responses API",
             "model": "mock-model",
             "stream": false,
             "store": true,
             "background": true,
-            "request_id": resp_id
         });
         let req = Request::builder()
             .method("POST")
@@ -807,11 +810,23 @@ mod responses_endpoint_tests {
             .unwrap();
         let resp = app.clone().oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let create_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(create_json["status"], "queued");
+        assert_eq!(create_json["background"], true);
+        let resp_id = create_json["id"]
+            .as_str()
+            .expect("queued response must carry an id")
+            .to_string();
+        assert!(resp_id.starts_with("resp_"));
 
-        // Cancel the response
+        // The queued response is mirrored into the shared response storage, so
+        // GET /v1/responses/{id} observes it immediately.
         let req = Request::builder()
-            .method("POST")
-            .uri(format!("/v1/responses/{resp_id}/cancel"))
+            .method("GET")
+            .uri(format!("/v1/responses/{resp_id}"))
             .body(Body::empty())
             .unwrap();
         let resp = app.clone().oneshot(req).await.unwrap();
@@ -819,8 +834,8 @@ mod responses_endpoint_tests {
         let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
             .await
             .unwrap();
-        let cancel_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
-        assert_eq!(cancel_json["status"], "cancelled");
+        let get_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(get_json["status"], "queued");
 
         ctx.shutdown().await;
     }

--- a/model_gateway/tests/common/mod.rs
+++ b/model_gateway/tests/common/mod.rs
@@ -37,7 +37,8 @@ use smg::{
     workflow::Job,
 };
 use smg_data_connector::{
-    MemoryConversationItemStorage, MemoryConversationStorage, MemoryResponseStorage,
+    MemoryBackgroundRepository, MemoryConversationItemStorage, MemoryConversationStorage,
+    MemoryResponseStorage,
 };
 #[allow(unused_imports)]
 pub use test_config::{TestRouterConfig, TestWorkerConfig};
@@ -339,10 +340,16 @@ pub fn create_test_context(
         let worker_registry = Arc::new(WorkerRegistry::new());
         let policy_registry = Arc::new(PolicyRegistry::new(config.policy.clone()));
 
-        // Initialize storage backends (Memory for tests)
+        // Initialize storage backends (Memory for tests). Mirror the production
+        // memory backend (`create_storage`): the background repository shares the
+        // same `MemoryResponseStorage` so background-mode writes are visible to
+        // GET /v1/responses/{id} and the create dispatch can enqueue.
         let response_storage = Arc::new(MemoryResponseStorage::new());
         let conversation_storage = Arc::new(MemoryConversationStorage::new());
         let conversation_item_storage = Arc::new(MemoryConversationItemStorage::new());
+        let background_repository = Arc::new(MemoryBackgroundRepository::new(Arc::clone(
+            &response_storage,
+        )));
 
         // Initialize load monitor
         let worker_monitor = Some(Arc::new(WorkerMonitor::new(
@@ -370,6 +377,7 @@ pub fn create_test_context(
                 .response_storage(response_storage)
                 .conversation_storage(conversation_storage)
                 .conversation_item_storage(conversation_item_storage)
+                .background_repository(Some(background_repository))
                 .worker_monitor(worker_monitor)
                 .worker_job_queue(worker_job_queue)
                 .workflow_engines(workflow_engines)
@@ -481,10 +489,16 @@ pub fn create_test_context_with_parsers(
         let worker_registry = Arc::new(WorkerRegistry::new());
         let policy_registry = Arc::new(PolicyRegistry::new(config.policy.clone()));
 
-        // Initialize storage backends (Memory for tests)
+        // Initialize storage backends (Memory for tests). Mirror the production
+        // memory backend (`create_storage`): the background repository shares the
+        // same `MemoryResponseStorage` so background-mode writes are visible to
+        // GET /v1/responses/{id} and the create dispatch can enqueue.
         let response_storage = Arc::new(MemoryResponseStorage::new());
         let conversation_storage = Arc::new(MemoryConversationStorage::new());
         let conversation_item_storage = Arc::new(MemoryConversationItemStorage::new());
+        let background_repository = Arc::new(MemoryBackgroundRepository::new(Arc::clone(
+            &response_storage,
+        )));
 
         // Initialize load monitor
         let worker_monitor = Some(Arc::new(WorkerMonitor::new(
@@ -516,6 +530,7 @@ pub fn create_test_context_with_parsers(
                 .response_storage(response_storage)
                 .conversation_storage(conversation_storage)
                 .conversation_item_storage(conversation_item_storage)
+                .background_repository(Some(background_repository))
                 .worker_monitor(worker_monitor)
                 .worker_job_queue(worker_job_queue)
                 .workflow_engines(workflow_engines)
@@ -630,10 +645,16 @@ pub fn create_test_context_with_mcp_config(
         let worker_registry = Arc::new(WorkerRegistry::new());
         let policy_registry = Arc::new(PolicyRegistry::new(config.policy.clone()));
 
-        // Initialize storage backends (Memory for tests)
+        // Initialize storage backends (Memory for tests). Mirror the production
+        // memory backend (`create_storage`): the background repository shares the
+        // same `MemoryResponseStorage` so background-mode writes are visible to
+        // GET /v1/responses/{id} and the create dispatch can enqueue.
         let response_storage = Arc::new(MemoryResponseStorage::new());
         let conversation_storage = Arc::new(MemoryConversationStorage::new());
         let conversation_item_storage = Arc::new(MemoryConversationItemStorage::new());
+        let background_repository = Arc::new(MemoryBackgroundRepository::new(Arc::clone(
+            &response_storage,
+        )));
 
         // Initialize load monitor
         let worker_monitor = Some(Arc::new(WorkerMonitor::new(
@@ -661,6 +682,7 @@ pub fn create_test_context_with_mcp_config(
                 .response_storage(response_storage)
                 .conversation_storage(conversation_storage)
                 .conversation_item_storage(conversation_item_storage)
+                .background_repository(Some(background_repository))
                 .worker_monitor(worker_monitor)
                 .worker_job_queue(worker_job_queue)
                 .workflow_engines(workflow_engines)


### PR DESCRIPTION
## Description

### Problem

Background `/v1/responses` (`background=true`) had no create/enqueue path — the gateway rejected it. BGM-PR-04 (#1218) provides it; the prior attempt (#1375) went stale 147 commits back.

### Solution

Rebased the create-path work onto current `main` and wired `background=true` to enqueue a durable, pollable `queued` response — resolving the input snapshot from `previous_response_id` (chain) or `conversation` (items) — over the existing `BackgroundResponseRepository` trait. The protocol-layer pieces (typed `incomplete_details`, `background+stream`, `background⇒store`) already landed in #1609, so they are not duplicated here. **Enqueue-only**: the scheduler/worker that execute queued jobs are follow-ups (#1220 / #1221).

## Changes

- `model_gateway/src/routers/common/background/create.rs` (new) — `handle_background_create` + `BackgroundCreateDeps`: validate, resolve the input snapshot (chronological, with a 100-item cap), enqueue, and mirror a `queued` `Response` into response storage so `GET /v1/responses/{id}` observes it.
- In-memory repository support + queue-depth enforcement (`crates/data_connector` `background.rs` / `memory_background.rs`).
- `model_gateway/src/server.rs` — the `v1_responses` axum handler dispatches `background=true` to the create path before normal routing.
- gRPC router keeps rejecting `background=true` (clearer message; background runs on the HTTP path).
- Tests: e2e for non-streaming background create; the shared test context now wires a `MemoryBackgroundRepository` (mirroring `factory.rs`); the former `cancel` test is refocused to an enqueue test (background cancel lands with #1222).

## Test Plan

- `cargo build --workspace`; `cargo +nightly fmt --all`; `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cargo test -p openai-protocol -p data-connector -p smg` (lib + integration incl. `spec_test`, `api_tests`, the `background::create` unit tests) — green.
- e2e `test_background_mode.py`: create → `status:"queued"` → `GET` read-back → state-dependent 404/409.
- Behavior: `background=true` with a configured repository → 200 + `status:"queued"`; without one (`history_backend=none`) → 400 `background_not_supported`. Queued jobs do not execute yet (worker is #1221).

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

Closes #1218.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added background mode for asynchronous response processing via `POST /v1/responses` with `background=true`.
  * Implemented queue depth limiting to prevent queue overflow; requests exceeding the limit return HTTP 429.
  * Added support for chaining from previous responses or replaying conversations in background mode.
  * Returns queued response with generated ID immediately upon successful enqueue.

* **Improvements**
  * Enhanced error messaging for unsupported background mode on gRPC endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->