### PR TITLE
feat(background): BGM-PR-06 background driver + sweeper

### DIFF
--- a/model_gateway/src/routers/common/background/driver.rs
+++ b/model_gateway/src/routers/common/background/driver.rs
@@ -1,4 +1,4 @@
-//! Background scheduler driver.
+//! Background-job driver.
 //!
 //! A thin loop over the [`BackgroundResponseRepository`] trait — *not* a bespoke
 //! queue or scheduling algorithm. The durable claim / lease / retry logic lives
@@ -44,7 +44,7 @@ const CLAIM_JITTER_FRACTION: f64 = 0.2;
 /// an `Arc<dyn BackgroundWorker>` (per-job execution), the [`BackgroundConfig`]
 /// that tunes the loops, a stable `worker_id` used for leases, a [`Semaphore`]
 /// sized to the configured worker concurrency, and a claim-wakeup [`Notify`].
-pub struct BackgroundScheduler {
+pub struct BackgroundDriver {
     repository: Arc<dyn BackgroundResponseRepository>,
     worker: Arc<dyn BackgroundWorker>,
     config: BackgroundConfig,
@@ -53,19 +53,19 @@ pub struct BackgroundScheduler {
     claim_wakeup: Arc<Notify>,
 }
 
-/// Handles for the supervised loops a [`BackgroundScheduler`] spawns. Hold this
-/// for the lifetime of the process; dropping the contained [`BackgroundScheduler`]
+/// Handles for the supervised loops a [`BackgroundDriver`] spawns. Hold this
+/// for the lifetime of the process; dropping the contained [`BackgroundDriver`]
 /// `Arc` (and these handles) stops the loops.
-pub struct BackgroundSchedulerHandle {
+pub struct BackgroundDriverHandle {
     /// Kept alive so the loops' `Weak` upgrades keep succeeding.
-    _scheduler: Arc<BackgroundScheduler>,
+    _driver: Arc<BackgroundDriver>,
     _claim_tick: JoinHandle<()>,
     _sweeper: JoinHandle<()>,
 }
 
-impl BackgroundScheduler {
-    /// Construct a scheduler. `worker_id` is generated here and is stable for
-    /// the life of this scheduler instance — it identifies this replica's
+impl BackgroundDriver {
+    /// Construct a driver. `worker_id` is generated here and is stable for
+    /// the life of this driver instance — it identifies this replica's
     /// leases to the repository.
     pub fn new(
         repository: Arc<dyn BackgroundResponseRepository>,
@@ -84,7 +84,7 @@ impl BackgroundScheduler {
         }
     }
 
-    /// The stable lease identity for this scheduler instance.
+    /// The stable lease identity for this driver instance.
     pub fn worker_id(&self) -> &str {
         &self.worker_id
     }
@@ -95,50 +95,54 @@ impl BackgroundScheduler {
         self.claim_wakeup.notify_one();
     }
 
-    /// Consume the scheduler, run the startup claim pass, and spawn the
+    /// Consume the driver, run the startup claim pass, and spawn the
     /// supervised claim-tick and sweeper loops.
     ///
-    /// Returns a [`BackgroundSchedulerHandle`] that owns the scheduler `Arc` and
+    /// Returns a [`BackgroundDriverHandle`] that owns the driver `Arc` and
     /// both task handles; keep it alive for the process lifetime.
-    pub async fn spawn(self) -> BackgroundSchedulerHandle {
-        let scheduler = Arc::new(self);
+    ///
+    /// Not called at startup in BGM-PR-06: the driver is wired and started by
+    /// BGM-PR-07 (#1221) once a real [`BackgroundWorker`] exists. Until then a
+    /// `background=true` request stays durably `queued` (per #1614).
+    pub async fn spawn(self) -> BackgroundDriverHandle {
+        let driver = Arc::new(self);
 
         info!(
-            worker_id = %scheduler.worker_id,
-            concurrency = scheduler.config.worker_concurrency,
-            poll_interval_ms = scheduler.config.poll_interval_ms,
-            sweep_interval_secs = scheduler.config.sweep_interval_secs,
-            "starting background scheduler"
+            worker_id = %driver.worker_id,
+            concurrency = driver.config.worker_concurrency,
+            poll_interval_ms = driver.config.poll_interval_ms,
+            sweep_interval_secs = driver.config.sweep_interval_secs,
+            "starting background driver"
         );
 
         // Startup claim pass: drain everything claimable right now so a fresh
         // replica picks up pending work without waiting for the first tick.
-        scheduler.claim_drain().await;
+        driver.claim_drain().await;
 
-        let claim_interval = scheduler.jittered_claim_interval();
+        let claim_interval = driver.jittered_claim_interval();
         let claim_tick = spawn_supervised_periodic(
             "background-claim-tick",
-            Arc::downgrade(&scheduler),
+            Arc::downgrade(&driver),
             claim_interval,
-            Some(Arc::downgrade(&scheduler.claim_wakeup)),
-            |s: Arc<BackgroundScheduler>| async move {
+            Some(Arc::downgrade(&driver.claim_wakeup)),
+            |s: Arc<BackgroundDriver>| async move {
                 s.claim_drain().await;
             },
         );
 
         let sweeper = spawn_supervised_periodic(
             "background-sweeper",
-            Arc::downgrade(&scheduler),
-            scheduler.config.sweep_interval(),
+            Arc::downgrade(&driver),
+            driver.config.sweep_interval(),
             // The sweeper is purely time-driven; it has no early wakeup.
             None,
-            |s: Arc<BackgroundScheduler>| async move {
+            |s: Arc<BackgroundDriver>| async move {
                 s.sweep_once().await;
             },
         );
 
-        BackgroundSchedulerHandle {
-            _scheduler: scheduler,
+        BackgroundDriverHandle {
+            _driver: driver,
             _claim_tick: claim_tick,
             _sweeper: sweeper,
         }
@@ -206,6 +210,10 @@ impl BackgroundScheduler {
         permit: OwnedSemaphorePermit,
     ) {
         let worker = Arc::clone(&self.worker);
+        // Cloned into the task so we can nudge the claim loop the instant this
+        // job's permit frees, instead of leaving the freed slot idle until the
+        // next poll tick (which would cap throughput at one batch per interval).
+        let claim_wakeup = Arc::clone(&self.claim_wakeup);
         let response_id = job.response_id.0.clone();
         debug!(
             worker_id = %self.worker_id,
@@ -218,8 +226,11 @@ impl BackgroundScheduler {
         )]
         tokio::spawn(async move {
             worker.execute(job).await;
-            // Permit is released here when it drops, freeing the slot.
+            // Release the permit, then wake the claim loop so it immediately
+            // re-claims into the freed slot rather than idling until the next
+            // poll tick.
             drop(permit);
+            claim_wakeup.notify_one();
             debug!(response_id = %response_id, "background job execution finished");
         });
     }
@@ -362,8 +373,8 @@ mod tests {
             worker_concurrency: 4,
             ..Default::default()
         };
-        let scheduler = BackgroundScheduler::new(Arc::clone(&repo), worker_dyn, config);
-        let _handle = scheduler.spawn().await;
+        let driver = BackgroundDriver::new(Arc::clone(&repo), worker_dyn, config);
+        let _handle = driver.spawn().await;
 
         // All five enqueued jobs must be seen and terminalized.
         let done = timeout(Duration::from_secs(5), async {
@@ -413,8 +424,8 @@ mod tests {
             worker_concurrency: 2,
             ..Default::default()
         };
-        let scheduler = BackgroundScheduler::new(Arc::clone(&repo), worker_dyn, config);
-        let _handle = scheduler.spawn().await;
+        let driver = BackgroundDriver::new(Arc::clone(&repo), worker_dyn, config);
+        let _handle = driver.spawn().await;
 
         // Wait until 2 jobs are in flight (the cap), then confirm it never
         // exceeds 2 while they're held.
@@ -462,14 +473,14 @@ mod tests {
     #[tokio::test]
     async fn sweeper_reclaims_expired_lease() {
         // Claim a job out-of-band with a short lease, let it expire, and assert
-        // the scheduler's sweeper reclaims it (queue becomes claimable again).
+        // the driver's sweeper reclaims it (queue becomes claimable again).
         let rs = Arc::new(MemoryResponseStorage::new());
         let repo: Arc<dyn BackgroundResponseRepository> =
             Arc::new(MemoryBackgroundRepository::new(Arc::clone(&rs)));
         repo.enqueue(enqueue_req("r1"), None, None).await.unwrap();
 
         // Out-of-band claim with a 1s lease by a different worker so the
-        // scheduler's own claim loop can't grab it first.
+        // driver's own claim loop can't grab it first.
         let claimed = repo
             .claim_next("external", Utc::now(), Duration::from_secs(1))
             .await
@@ -478,7 +489,7 @@ mod tests {
         assert_eq!(claimed.response_id, ResponseId::from("r1"));
 
         // A no-op worker: we only care about the sweeper reclaiming, not
-        // execution. (It will finalize whatever the scheduler later claims.)
+        // execution. (It will finalize whatever the driver later claims.)
         struct NoopFinalizeWorker {
             repository: Arc<dyn BackgroundResponseRepository>,
         }
@@ -505,7 +516,7 @@ mod tests {
         let worker: Arc<dyn BackgroundWorker> = Arc::new(NoopFinalizeWorker {
             repository: Arc::clone(&repo),
         });
-        // Fast sweep so the test doesn't wait long; long poll so the scheduler's
+        // Fast sweep so the test doesn't wait long; long poll so the driver's
         // claim loop doesn't race the assertion before the lease expires.
         let config = BackgroundConfig {
             worker_concurrency: 4,
@@ -514,11 +525,11 @@ mod tests {
             poll_interval_ms: 50,
             ..Default::default()
         };
-        let scheduler = BackgroundScheduler::new(Arc::clone(&repo), worker, config);
-        let _handle = scheduler.spawn().await;
+        let driver = BackgroundDriver::new(Arc::clone(&repo), worker, config);
+        let _handle = driver.spawn().await;
 
         // After the lease (1s) expires and the sweeper (1s) runs, the row is
-        // requeued and the scheduler re-claims + finalizes it. Eventually the
+        // requeued and the driver re-claims + finalizes it. Eventually the
         // queue is empty (job terminalized via the re-claim path).
         let terminalized = timeout(Duration::from_secs(8), async {
             loop {
@@ -526,8 +537,8 @@ mod tests {
                     .claim_next("probe", Utc::now(), Duration::from_secs(30))
                     .await
                     .unwrap();
-                // `probe` claims only if the scheduler hasn't already taken it.
-                // Once terminal, neither probe nor scheduler can claim, so put
+                // `probe` claims only if the driver hasn't already taken it.
+                // Once terminal, neither probe nor driver can claim, so put
                 // any probe-claim back by finalizing it (keeps the loop honest).
                 match probe {
                     Some(job) => {
@@ -547,7 +558,7 @@ mod tests {
                         break;
                     }
                     None => {
-                        // Could be in-progress (scheduler holds it) or terminal.
+                        // Could be in-progress (driver holds it) or terminal.
                         // Check the stored payload: terminal means done.
                         use smg_data_connector::ResponseStorage;
                         let stored = rs.get_response(&ResponseId::from("r1")).await.unwrap();

--- a/model_gateway/src/routers/common/background/mod.rs
+++ b/model_gateway/src/routers/common/background/mod.rs
@@ -1,10 +1,15 @@
-//! Background-mode shared handlers.
+//! Background-mode shared handlers and execution driver.
 
 pub mod create;
+pub mod scheduler;
+pub mod supervisor;
+pub mod worker;
 
 use std::sync::Arc;
 
+pub use scheduler::{BackgroundScheduler, BackgroundSchedulerHandle};
 use smg_data_connector::BackgroundResponseRepository;
+pub use worker::{BackgroundWorker, UnavailableBackgroundWorker, BACKGROUND_EXECUTION_UNAVAILABLE};
 
 use crate::config::BackgroundConfig;
 
@@ -32,4 +37,24 @@ impl BackgroundServices {
     pub fn config(&self) -> &BackgroundConfig {
         &self.config
     }
+}
+
+/// Construct and spawn the background scheduler driver over `repository`.
+///
+/// Wires the default [`UnavailableBackgroundWorker`] (BGM-PR-07 swaps in the
+/// real worker), runs the startup claim pass, and starts the supervised
+/// claim-tick and sweeper loops. The returned [`BackgroundSchedulerHandle`] owns
+/// the spawned tasks and the scheduler `Arc`; the caller must hold it for the
+/// process lifetime, otherwise the loops stop when it drops.
+///
+/// Callers gate this on `background_repository` being present; when no durable
+/// (or memory) background repository is configured, nothing is spawned.
+pub async fn start_background_scheduler(
+    repository: Arc<dyn BackgroundResponseRepository>,
+    config: BackgroundConfig,
+) -> BackgroundSchedulerHandle {
+    let worker: Arc<dyn BackgroundWorker> =
+        Arc::new(UnavailableBackgroundWorker::new(Arc::clone(&repository)));
+    let scheduler = BackgroundScheduler::new(repository, worker, config);
+    scheduler.spawn().await
 }

--- a/model_gateway/src/routers/common/background/mod.rs
+++ b/model_gateway/src/routers/common/background/mod.rs
@@ -1,13 +1,13 @@
 //! Background-mode shared handlers and execution driver.
 
 pub mod create;
-pub mod scheduler;
+pub mod driver;
 pub mod supervisor;
 pub mod worker;
 
 use std::sync::Arc;
 
-pub use scheduler::{BackgroundScheduler, BackgroundSchedulerHandle};
+pub use driver::{BackgroundDriver, BackgroundDriverHandle};
 use smg_data_connector::BackgroundResponseRepository;
 pub use worker::{BackgroundWorker, UnavailableBackgroundWorker, BACKGROUND_EXECUTION_UNAVAILABLE};
 
@@ -39,22 +39,14 @@ impl BackgroundServices {
     }
 }
 
-/// Construct and spawn the background scheduler driver over `repository`.
-///
-/// Wires the default [`UnavailableBackgroundWorker`] (BGM-PR-07 swaps in the
-/// real worker), runs the startup claim pass, and starts the supervised
-/// claim-tick and sweeper loops. The returned [`BackgroundSchedulerHandle`] owns
-/// the spawned tasks and the scheduler `Arc`; the caller must hold it for the
-/// process lifetime, otherwise the loops stop when it drops.
-///
-/// Callers gate this on `background_repository` being present; when no durable
-/// (or memory) background repository is configured, nothing is spawned.
-pub async fn start_background_scheduler(
-    repository: Arc<dyn BackgroundResponseRepository>,
-    config: BackgroundConfig,
-) -> BackgroundSchedulerHandle {
-    let worker: Arc<dyn BackgroundWorker> =
-        Arc::new(UnavailableBackgroundWorker::new(Arc::clone(&repository)));
-    let scheduler = BackgroundScheduler::new(repository, worker, config);
-    scheduler.spawn().await
-}
+// NOTE: BGM-PR-06 deliberately does *not* start the [`driver::BackgroundDriver`]
+// at process startup. The only [`BackgroundWorker`] that exists today is
+// [`UnavailableBackgroundWorker`], which finalizes every claimed job as
+// `failed`; running the driver with it would regress #1614's durable `queued`
+// contract (a `background=true` response that clients can poll) into immediate
+// failure for every gateway with a background repository — including the default
+// `history_backend=memory`. So PR-06 lands the driver + its tests but leaves it
+// unspawned; `background=true` requests stay durably `queued` (per #1614).
+//
+// BGM-PR-07 (#1221) wires `BackgroundDriver::spawn(...)` with the real
+// `BackgroundWorker` and gates it on `background_repository` being present.

--- a/model_gateway/src/routers/common/background/scheduler.rs
+++ b/model_gateway/src/routers/common/background/scheduler.rs
@@ -1,0 +1,570 @@
+//! Background scheduler driver.
+//!
+//! A thin loop over the [`BackgroundResponseRepository`] trait — *not* a bespoke
+//! queue or scheduling algorithm. The durable claim / lease / retry logic lives
+//! in the repository; this driver only decides *when* to call it:
+//!
+//! - a **startup claim pass** that drains everything claimable as soon as the
+//!   process comes up (so a replica restart picks up in-flight work
+//!   immediately),
+//! - a **claim-tick loop** that periodically (jittered) — and on an in-process
+//!   wakeup [`Notify`] — claims runnable jobs while concurrency permits are
+//!   available and hands each to the [`BackgroundWorker`],
+//! - a **sweeper loop** that periodically calls
+//!   [`BackgroundResponseRepository::requeue_expired`] and nudges the claim loop
+//!   when it reclaims anything.
+//!
+//! The periodic tick + startup pass are the correctness path; the `Notify`
+//! nudge is a latency optimization (mirroring `LISTEN/NOTIFY` for the durable
+//! backends, which is explicitly *not* required for correctness — see the
+//! recovered design, Part A.9).
+
+use std::{sync::Arc, time::Duration};
+
+use rand::Rng as _;
+use smg_data_connector::BackgroundResponseRepository;
+use tokio::{
+    sync::{Notify, OwnedSemaphorePermit, Semaphore},
+    task::JoinHandle,
+};
+use tracing::{debug, error, info};
+use uuid::Uuid;
+
+use super::{supervisor::spawn_supervised_periodic, worker::BackgroundWorker};
+use crate::config::BackgroundConfig;
+
+/// Upper bound on the random jitter added to the claim-tick interval, expressed
+/// as a fraction of the base interval. Spreads claim ticks across replicas so
+/// they don't stampede the backend on the same cadence.
+const CLAIM_JITTER_FRACTION: f64 = 0.2;
+
+/// Drives background-job execution by polling the repository trait.
+///
+/// Holds an `Arc<dyn BackgroundResponseRepository>` (durable claim/lease logic),
+/// an `Arc<dyn BackgroundWorker>` (per-job execution), the [`BackgroundConfig`]
+/// that tunes the loops, a stable `worker_id` used for leases, a [`Semaphore`]
+/// sized to the configured worker concurrency, and a claim-wakeup [`Notify`].
+pub struct BackgroundScheduler {
+    repository: Arc<dyn BackgroundResponseRepository>,
+    worker: Arc<dyn BackgroundWorker>,
+    config: BackgroundConfig,
+    worker_id: String,
+    permits: Arc<Semaphore>,
+    claim_wakeup: Arc<Notify>,
+}
+
+/// Handles for the supervised loops a [`BackgroundScheduler`] spawns. Hold this
+/// for the lifetime of the process; dropping the contained [`BackgroundScheduler`]
+/// `Arc` (and these handles) stops the loops.
+pub struct BackgroundSchedulerHandle {
+    /// Kept alive so the loops' `Weak` upgrades keep succeeding.
+    _scheduler: Arc<BackgroundScheduler>,
+    _claim_tick: JoinHandle<()>,
+    _sweeper: JoinHandle<()>,
+}
+
+impl BackgroundScheduler {
+    /// Construct a scheduler. `worker_id` is generated here and is stable for
+    /// the life of this scheduler instance — it identifies this replica's
+    /// leases to the repository.
+    pub fn new(
+        repository: Arc<dyn BackgroundResponseRepository>,
+        worker: Arc<dyn BackgroundWorker>,
+        config: BackgroundConfig,
+    ) -> Self {
+        let concurrency = config.worker_concurrency.max(1) as usize;
+        let worker_id = format!("bg-{}", Uuid::now_v7());
+        Self {
+            repository,
+            worker,
+            config,
+            worker_id,
+            permits: Arc::new(Semaphore::new(concurrency)),
+            claim_wakeup: Arc::new(Notify::new()),
+        }
+    }
+
+    /// The stable lease identity for this scheduler instance.
+    pub fn worker_id(&self) -> &str {
+        &self.worker_id
+    }
+
+    /// Wake the claim loop early (e.g. right after a job is enqueued). This is a
+    /// latency optimization only; the periodic tick would claim the job anyway.
+    pub fn notify_claim(&self) {
+        self.claim_wakeup.notify_one();
+    }
+
+    /// Consume the scheduler, run the startup claim pass, and spawn the
+    /// supervised claim-tick and sweeper loops.
+    ///
+    /// Returns a [`BackgroundSchedulerHandle`] that owns the scheduler `Arc` and
+    /// both task handles; keep it alive for the process lifetime.
+    pub async fn spawn(self) -> BackgroundSchedulerHandle {
+        let scheduler = Arc::new(self);
+
+        info!(
+            worker_id = %scheduler.worker_id,
+            concurrency = scheduler.config.worker_concurrency,
+            poll_interval_ms = scheduler.config.poll_interval_ms,
+            sweep_interval_secs = scheduler.config.sweep_interval_secs,
+            "starting background scheduler"
+        );
+
+        // Startup claim pass: drain everything claimable right now so a fresh
+        // replica picks up pending work without waiting for the first tick.
+        scheduler.claim_drain().await;
+
+        let claim_interval = scheduler.jittered_claim_interval();
+        let claim_tick = spawn_supervised_periodic(
+            "background-claim-tick",
+            Arc::downgrade(&scheduler),
+            claim_interval,
+            Some(Arc::downgrade(&scheduler.claim_wakeup)),
+            |s: Arc<BackgroundScheduler>| async move {
+                s.claim_drain().await;
+            },
+        );
+
+        let sweeper = spawn_supervised_periodic(
+            "background-sweeper",
+            Arc::downgrade(&scheduler),
+            scheduler.config.sweep_interval(),
+            // The sweeper is purely time-driven; it has no early wakeup.
+            None,
+            |s: Arc<BackgroundScheduler>| async move {
+                s.sweep_once().await;
+            },
+        );
+
+        BackgroundSchedulerHandle {
+            _scheduler: scheduler,
+            _claim_tick: claim_tick,
+            _sweeper: sweeper,
+        }
+    }
+
+    /// Compute the claim-tick interval with a small additive jitter so replicas
+    /// don't poll in lockstep.
+    fn jittered_claim_interval(&self) -> Duration {
+        let base = self.config.poll_interval();
+        let jitter_ceiling = base.as_secs_f64() * CLAIM_JITTER_FRACTION;
+        let jitter = rand::rng().random_range(0.0..=jitter_ceiling.max(0.0));
+        base + Duration::from_secs_f64(jitter)
+    }
+
+    /// Claim and dispatch runnable jobs until either no concurrency permit is
+    /// free or the repository has nothing left to claim. Each dispatched job
+    /// runs on its own task holding a concurrency permit until it finishes.
+    async fn claim_drain(self: &Arc<Self>) {
+        loop {
+            // Acquire an owned permit *before* claiming so a claimed job always
+            // has a slot to run in; if none is free, stop and let the running
+            // jobs (or the next tick) make progress.
+            let Ok(permit) = Arc::clone(&self.permits).try_acquire_owned() else {
+                debug!(
+                    worker_id = %self.worker_id,
+                    "background claim loop: no concurrency permit available; yielding"
+                );
+                return;
+            };
+
+            let now = chrono::Utc::now();
+            let lease = self.config.lease_duration();
+            let claimed = match self
+                .repository
+                .claim_next(&self.worker_id, now, lease)
+                .await
+            {
+                Ok(job) => job,
+                Err(e) => {
+                    // Drop the permit (it falls out of scope) and back off until
+                    // the next tick rather than hot-looping on a backend error.
+                    error!(
+                        worker_id = %self.worker_id,
+                        error = %e,
+                        "background claim_next failed; will retry on next tick"
+                    );
+                    return;
+                }
+            };
+
+            let Some(job) = claimed else {
+                // Nothing to claim; the permit is released as it drops.
+                return;
+            };
+
+            self.dispatch(job, permit);
+        }
+    }
+
+    /// Spawn the execution of one claimed job, moving the concurrency `permit`
+    /// into the task so the slot stays reserved until execution finishes.
+    fn dispatch(
+        self: &Arc<Self>,
+        job: smg_data_connector::LeasedJob,
+        permit: OwnedSemaphorePermit,
+    ) {
+        let worker = Arc::clone(&self.worker);
+        let response_id = job.response_id.0.clone();
+        debug!(
+            worker_id = %self.worker_id,
+            response_id = %response_id,
+            "dispatching background job"
+        );
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "per-job execution task; the moved permit bounds concurrency and is released on completion"
+        )]
+        tokio::spawn(async move {
+            worker.execute(job).await;
+            // Permit is released here when it drops, freeing the slot.
+            drop(permit);
+            debug!(response_id = %response_id, "background job execution finished");
+        });
+    }
+
+    /// Run one sweeper pass: requeue expired leases and, if anything was
+    /// reclaimed, nudge the claim loop so the reclaimed jobs are picked up
+    /// without waiting for the next claim tick.
+    async fn sweep_once(self: &Arc<Self>) {
+        let now = chrono::Utc::now();
+        match self.repository.requeue_expired(now).await {
+            Ok(0) => {}
+            Ok(n) => {
+                info!(
+                    worker_id = %self.worker_id,
+                    requeued = n,
+                    "background sweeper requeued expired leases"
+                );
+                self.claim_wakeup.notify_one();
+            }
+            Err(e) => {
+                error!(
+                    worker_id = %self.worker_id,
+                    error = %e,
+                    "background sweeper requeue_expired failed"
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::HashSet,
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Mutex,
+        },
+        time::Duration,
+    };
+
+    use async_trait::async_trait;
+    use chrono::Utc;
+    use serde_json::json;
+    use smg_data_connector::{
+        BackgroundResponseRepository, EnqueueRequest, FinalizeRequest, FinalizeStatus, LeasedJob,
+        MemoryBackgroundRepository, MemoryResponseStorage, ResponseId,
+    };
+    use tokio::time::timeout;
+
+    use super::*;
+    use crate::routers::common::background::worker::BackgroundWorker;
+
+    fn enqueue_req(id: &str) -> EnqueueRequest {
+        EnqueueRequest::new(
+            ResponseId::from(id),
+            "gpt-5.1".to_string(),
+            json!({"model": "gpt-5.1"}),
+            json!([]),
+            json!({"id": id, "status": "queued"}),
+            false,
+            0,
+        )
+    }
+
+    /// Records the response ids it sees and finalizes each job as completed so
+    /// the row terminalizes (and is not re-claimed). Optionally blocks on a
+    /// barrier so a test can observe the concurrency cap.
+    struct RecordingWorker {
+        repository: Arc<dyn BackgroundResponseRepository>,
+        seen: Mutex<Vec<String>>,
+        in_flight: AtomicUsize,
+        max_in_flight: AtomicUsize,
+        hold: Option<Arc<Notify>>,
+    }
+
+    impl RecordingWorker {
+        fn new(
+            repository: Arc<dyn BackgroundResponseRepository>,
+            hold: Option<Arc<Notify>>,
+        ) -> Self {
+            Self {
+                repository,
+                seen: Mutex::new(Vec::new()),
+                in_flight: AtomicUsize::new(0),
+                max_in_flight: AtomicUsize::new(0),
+                hold,
+            }
+        }
+
+        fn seen_ids(&self) -> Vec<String> {
+            self.seen.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait]
+    impl BackgroundWorker for RecordingWorker {
+        async fn execute(&self, job: LeasedJob) {
+            let cur = self.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+            self.max_in_flight.fetch_max(cur, Ordering::SeqCst);
+            self.seen.lock().unwrap().push(job.response_id.0.clone());
+
+            if let Some(hold) = &self.hold {
+                hold.notified().await;
+            }
+
+            let now = Utc::now();
+            let _ = self
+                .repository
+                .finalize(
+                    FinalizeRequest::new(
+                        job.response_id.clone(),
+                        job.worker_id.clone(),
+                        FinalizeStatus::Completed,
+                        json!({"id": job.response_id.0, "status": "completed"}),
+                        now,
+                    ),
+                    now,
+                )
+                .await;
+
+            self.in_flight.fetch_sub(1, Ordering::SeqCst);
+        }
+    }
+
+    #[tokio::test]
+    async fn startup_pass_dispatches_all_jobs_to_terminal() {
+        let rs = Arc::new(MemoryResponseStorage::new());
+        let repo: Arc<dyn BackgroundResponseRepository> =
+            Arc::new(MemoryBackgroundRepository::new(Arc::clone(&rs)));
+        for i in 0..5 {
+            repo.enqueue(enqueue_req(&format!("r{i}")), None, None)
+                .await
+                .unwrap();
+        }
+
+        let worker = Arc::new(RecordingWorker::new(Arc::clone(&repo), None));
+        let worker_dyn: Arc<dyn BackgroundWorker> = Arc::clone(&worker) as _;
+        let config = BackgroundConfig {
+            worker_concurrency: 4,
+            ..Default::default()
+        };
+        let scheduler = BackgroundScheduler::new(Arc::clone(&repo), worker_dyn, config);
+        let _handle = scheduler.spawn().await;
+
+        // All five enqueued jobs must be seen and terminalized.
+        let done = timeout(Duration::from_secs(5), async {
+            loop {
+                let seen: HashSet<String> = worker.seen_ids().into_iter().collect();
+                if seen.len() == 5 {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await;
+        assert!(
+            done.is_ok(),
+            "not all jobs dispatched: {:?}",
+            worker.seen_ids()
+        );
+
+        // The queue must be empty: nothing left to claim.
+        let leftover = repo
+            .claim_next("probe", Utc::now(), Duration::from_secs(30))
+            .await
+            .unwrap();
+        assert!(leftover.is_none(), "expected all jobs terminalized");
+    }
+
+    #[tokio::test]
+    async fn respects_concurrency_cap() {
+        let rs = Arc::new(MemoryResponseStorage::new());
+        let repo: Arc<dyn BackgroundResponseRepository> =
+            Arc::new(MemoryBackgroundRepository::new(Arc::clone(&rs)));
+        for i in 0..6 {
+            repo.enqueue(enqueue_req(&format!("r{i}")), None, None)
+                .await
+                .unwrap();
+        }
+
+        // Workers block on `hold` until we release them, so we can observe how
+        // many run concurrently. Cap is 2.
+        let hold = Arc::new(Notify::new());
+        let worker = Arc::new(RecordingWorker::new(
+            Arc::clone(&repo),
+            Some(Arc::clone(&hold)),
+        ));
+        let worker_dyn: Arc<dyn BackgroundWorker> = Arc::clone(&worker) as _;
+        let config = BackgroundConfig {
+            worker_concurrency: 2,
+            ..Default::default()
+        };
+        let scheduler = BackgroundScheduler::new(Arc::clone(&repo), worker_dyn, config);
+        let _handle = scheduler.spawn().await;
+
+        // Wait until 2 jobs are in flight (the cap), then confirm it never
+        // exceeds 2 while they're held.
+        let reached = timeout(Duration::from_secs(3), async {
+            loop {
+                if worker.in_flight.load(Ordering::SeqCst) >= 2 {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await;
+        assert!(reached.is_ok(), "never reached the concurrency cap");
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(
+            worker.in_flight.load(Ordering::SeqCst) <= 2,
+            "exceeded concurrency cap"
+        );
+
+        // Release all held workers; everything must drain.
+        for _ in 0..6 {
+            hold.notify_one();
+        }
+        // Some workers were not yet started (blocked behind the cap); keep
+        // notifying as they come online.
+        let drained = timeout(Duration::from_secs(5), async {
+            loop {
+                hold.notify_one();
+                let seen: HashSet<String> = worker.seen_ids().into_iter().collect();
+                if seen.len() == 6 {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await;
+        assert!(drained.is_ok(), "jobs did not drain after release");
+        assert!(
+            worker.max_in_flight.load(Ordering::SeqCst) <= 2,
+            "max concurrency {} exceeded cap of 2",
+            worker.max_in_flight.load(Ordering::SeqCst)
+        );
+    }
+
+    #[tokio::test]
+    async fn sweeper_reclaims_expired_lease() {
+        // Claim a job out-of-band with a short lease, let it expire, and assert
+        // the scheduler's sweeper reclaims it (queue becomes claimable again).
+        let rs = Arc::new(MemoryResponseStorage::new());
+        let repo: Arc<dyn BackgroundResponseRepository> =
+            Arc::new(MemoryBackgroundRepository::new(Arc::clone(&rs)));
+        repo.enqueue(enqueue_req("r1"), None, None).await.unwrap();
+
+        // Out-of-band claim with a 1s lease by a different worker so the
+        // scheduler's own claim loop can't grab it first.
+        let claimed = repo
+            .claim_next("external", Utc::now(), Duration::from_secs(1))
+            .await
+            .unwrap()
+            .expect("claimed");
+        assert_eq!(claimed.response_id, ResponseId::from("r1"));
+
+        // A no-op worker: we only care about the sweeper reclaiming, not
+        // execution. (It will finalize whatever the scheduler later claims.)
+        struct NoopFinalizeWorker {
+            repository: Arc<dyn BackgroundResponseRepository>,
+        }
+        #[async_trait]
+        impl BackgroundWorker for NoopFinalizeWorker {
+            async fn execute(&self, job: LeasedJob) {
+                let now = Utc::now();
+                let _ = self
+                    .repository
+                    .finalize(
+                        FinalizeRequest::new(
+                            job.response_id.clone(),
+                            job.worker_id.clone(),
+                            FinalizeStatus::Completed,
+                            json!({"id": job.response_id.0, "status": "completed"}),
+                            now,
+                        ),
+                        now,
+                    )
+                    .await;
+            }
+        }
+
+        let worker: Arc<dyn BackgroundWorker> = Arc::new(NoopFinalizeWorker {
+            repository: Arc::clone(&repo),
+        });
+        // Fast sweep so the test doesn't wait long; long poll so the scheduler's
+        // claim loop doesn't race the assertion before the lease expires.
+        let config = BackgroundConfig {
+            worker_concurrency: 4,
+            lease_duration_secs: 1,
+            sweep_interval_secs: 1,
+            poll_interval_ms: 50,
+            ..Default::default()
+        };
+        let scheduler = BackgroundScheduler::new(Arc::clone(&repo), worker, config);
+        let _handle = scheduler.spawn().await;
+
+        // After the lease (1s) expires and the sweeper (1s) runs, the row is
+        // requeued and the scheduler re-claims + finalizes it. Eventually the
+        // queue is empty (job terminalized via the re-claim path).
+        let terminalized = timeout(Duration::from_secs(8), async {
+            loop {
+                let probe = repo
+                    .claim_next("probe", Utc::now(), Duration::from_secs(30))
+                    .await
+                    .unwrap();
+                // `probe` claims only if the scheduler hasn't already taken it.
+                // Once terminal, neither probe nor scheduler can claim, so put
+                // any probe-claim back by finalizing it (keeps the loop honest).
+                match probe {
+                    Some(job) => {
+                        let now = Utc::now();
+                        let _ = repo
+                            .finalize(
+                                FinalizeRequest::new(
+                                    job.response_id.clone(),
+                                    "probe".to_string(),
+                                    FinalizeStatus::Completed,
+                                    json!({"status": "completed"}),
+                                    now,
+                                ),
+                                now,
+                            )
+                            .await;
+                        break;
+                    }
+                    None => {
+                        // Could be in-progress (scheduler holds it) or terminal.
+                        // Check the stored payload: terminal means done.
+                        use smg_data_connector::ResponseStorage;
+                        let stored = rs.get_response(&ResponseId::from("r1")).await.unwrap();
+                        if let Some(s) = stored {
+                            if s.raw_response["status"] == "completed" {
+                                break;
+                            }
+                        }
+                        tokio::time::sleep(Duration::from_millis(50)).await;
+                    }
+                }
+            }
+        })
+        .await;
+        assert!(
+            terminalized.is_ok(),
+            "sweeper did not reclaim the expired-lease job"
+        );
+    }
+}

--- a/model_gateway/src/routers/common/background/supervisor.rs
+++ b/model_gateway/src/routers/common/background/supervisor.rs
@@ -1,0 +1,279 @@
+//! Supervised periodic task primitive.
+//!
+//! A small generic helper that runs an async callback on a fixed interval,
+//! additionally waking early when an optional [`Notify`] is signalled, and
+//! restarts the whole loop after a short backoff if the callback panics.
+//!
+//! This mirrors the supervision shape of
+//! [`crate::worker::capacity::WorkerCapacity::spawn`] (catch-unwind +
+//! restart-with-backoff + `Weak` references so the spawned task never keeps the
+//! owning state alive), but factored out as a reusable primitive so the
+//! background scheduler's claim-tick and sweeper loops share one
+//! implementation instead of hand-rolling a third and fourth copy.
+
+use std::{future::Future, sync::Weak, time::Duration};
+
+use futures::FutureExt as _;
+use tokio::{sync::Notify, task::JoinHandle, time::MissedTickBehavior};
+
+/// Backoff applied before restarting the loop after the callback panics.
+const PANIC_RESTART_BACKOFF: Duration = Duration::from_secs(1);
+
+/// Spawn a supervised task that invokes `tick` every `interval`, or sooner when
+/// `wakeup` (if provided) is notified.
+///
+/// The task owns a `Weak<S>` to some shared state `S`. On each wake it upgrades
+/// the weak reference and passes the strong `Arc<S>` to `tick`; if the upgrade
+/// fails (the owner dropped its last `Arc`), the task exits cleanly. This keeps
+/// the long-lived task from forming an `Arc` cycle with the state it drives —
+/// exactly the lifecycle contract `WorkerCapacity` documents.
+///
+/// `tick` is invoked once immediately on each wake (interval tick or notify);
+/// any panic inside it is caught, logged, and the supervisor restarts the inner
+/// loop after [`PANIC_RESTART_BACKOFF`]. A clean return from the inner loop
+/// (only reachable when the weak state is gone) terminates the task.
+///
+/// `name` is used purely for log lines so operators can tell the loops apart.
+///
+/// Returns the [`JoinHandle`]; callers should retain it for the lifetime of the
+/// process (dropping it detaches the task, dropping the last `Arc<S>` stops it).
+pub fn spawn_supervised_periodic<S, F, Fut>(
+    name: &'static str,
+    state: Weak<S>,
+    interval: Duration,
+    wakeup: Option<Weak<Notify>>,
+    tick: F,
+) -> JoinHandle<()>
+where
+    S: Send + Sync + 'static,
+    F: Fn(std::sync::Arc<S>) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = ()> + Send,
+{
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "supervised long-lived task: panics are caught and the loop restarts; holds Weak refs so it cannot keep the owning state alive"
+    )]
+    tokio::spawn(async move {
+        loop {
+            let result = std::panic::AssertUnwindSafe(run_loop(
+                name,
+                state.clone(),
+                interval,
+                wakeup.clone(),
+                &tick,
+            ))
+            .catch_unwind()
+            .await;
+
+            match result {
+                Ok(()) => break,
+                Err(payload) => {
+                    let msg = panic_message(&payload);
+                    tracing::error!(
+                        task = name,
+                        panic.message = %msg,
+                        backoff_secs = PANIC_RESTART_BACKOFF.as_secs(),
+                        "supervised periodic task panicked; restarting"
+                    );
+                    tokio::time::sleep(PANIC_RESTART_BACKOFF).await;
+                }
+            }
+        }
+    })
+}
+
+/// The inner loop, separated so the supervisor can `catch_unwind` around it.
+async fn run_loop<S, F, Fut>(
+    name: &'static str,
+    state: Weak<S>,
+    interval: Duration,
+    wakeup: Option<Weak<Notify>>,
+    tick: &F,
+) where
+    S: Send + Sync + 'static,
+    F: Fn(std::sync::Arc<S>) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = ()> + Send,
+{
+    let mut ticker = tokio::time::interval(interval);
+    // A panic-restart or a slow tick must not produce a burst of catch-up
+    // ticks; one wake per missed period is enough for a poll loop.
+    ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    // The first `tick()` on a fresh interval returns immediately; the caller's
+    // startup pass (if any) already drained the queue, so consume that eager
+    // tick up front and wait a full period before the first scheduled wake.
+    ticker.tick().await;
+
+    loop {
+        // Upgrade the wakeup each iteration so a dropped owner lets it go.
+        let notified = async {
+            match wakeup.as_ref().and_then(Weak::upgrade) {
+                Some(n) => n.notified().await,
+                // No wakeup configured (or it was dropped): fall back to the
+                // interval alone by never resolving this branch.
+                None => std::future::pending::<()>().await,
+            }
+        };
+
+        tokio::select! {
+            _ = ticker.tick() => {}
+            () = notified => {}
+        }
+
+        let Some(state) = state.upgrade() else {
+            tracing::debug!(
+                task = name,
+                "supervised periodic task exiting: owner dropped"
+            );
+            return;
+        };
+        tick(state).await;
+    }
+}
+
+/// Best-effort extraction of a panic message for logging.
+fn panic_message(payload: &Box<dyn std::any::Any + Send>) -> String {
+    payload
+        .downcast_ref::<&str>()
+        .map(|s| (*s).to_string())
+        .or_else(|| payload.downcast_ref::<String>().cloned())
+        .unwrap_or_else(|| "(non-string panic)".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        atomic::{AtomicU32, Ordering},
+        Arc,
+    };
+
+    use tokio::time::{timeout, Duration};
+
+    use super::*;
+
+    struct Counter {
+        ticks: AtomicU32,
+    }
+
+    #[tokio::test]
+    async fn fires_on_notify_before_interval_elapses() {
+        let state = Arc::new(Counter {
+            ticks: AtomicU32::new(0),
+        });
+        let notify = Arc::new(Notify::new());
+
+        // Long interval so any tick within the test window must come from the
+        // notify path, not the timer.
+        let _handle = spawn_supervised_periodic(
+            "test-notify",
+            Arc::downgrade(&state),
+            Duration::from_secs(3600),
+            Some(Arc::downgrade(&notify)),
+            |s: Arc<Counter>| async move {
+                s.ticks.fetch_add(1, Ordering::SeqCst);
+            },
+        );
+
+        notify.notify_one();
+
+        let observed = timeout(Duration::from_secs(2), async {
+            loop {
+                if state.ticks.load(Ordering::SeqCst) >= 1 {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await;
+        assert!(observed.is_ok(), "notify did not trigger a tick");
+    }
+
+    #[tokio::test]
+    async fn fires_on_interval_without_notify() {
+        let state = Arc::new(Counter {
+            ticks: AtomicU32::new(0),
+        });
+
+        let _handle = spawn_supervised_periodic(
+            "test-interval",
+            Arc::downgrade(&state),
+            Duration::from_millis(20),
+            None,
+            |s: Arc<Counter>| async move {
+                s.ticks.fetch_add(1, Ordering::SeqCst);
+            },
+        );
+
+        let observed = timeout(Duration::from_secs(2), async {
+            loop {
+                if state.ticks.load(Ordering::SeqCst) >= 2 {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await;
+        assert!(observed.is_ok(), "interval did not produce repeated ticks");
+    }
+
+    #[tokio::test]
+    async fn restarts_loop_after_panic() {
+        let state = Arc::new(Counter {
+            ticks: AtomicU32::new(0),
+        });
+
+        // Each tick panics after bumping the counter. The supervisor must
+        // restart the loop (after backoff) so the counter keeps climbing past
+        // the first panic.
+        let _handle = spawn_supervised_periodic(
+            "test-panic",
+            Arc::downgrade(&state),
+            Duration::from_millis(10),
+            None,
+            |s: Arc<Counter>| async move {
+                s.ticks.fetch_add(1, Ordering::SeqCst);
+                panic!("boom");
+            },
+        );
+
+        // Backoff is 1s per restart, so within ~4s we expect at least 2 ticks
+        // (the initial tick + at least one post-restart tick).
+        let observed = timeout(Duration::from_secs(4), async {
+            loop {
+                if state.ticks.load(Ordering::SeqCst) >= 2 {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await;
+        assert!(observed.is_ok(), "loop did not restart after panic");
+    }
+
+    #[tokio::test]
+    async fn exits_when_owner_dropped() {
+        let state = Arc::new(Counter {
+            ticks: AtomicU32::new(0),
+        });
+        let weak = Arc::downgrade(&state);
+
+        let handle = spawn_supervised_periodic(
+            "test-exit",
+            weak.clone(),
+            Duration::from_millis(10),
+            None,
+            |s: Arc<Counter>| async move {
+                s.ticks.fetch_add(1, Ordering::SeqCst);
+            },
+        );
+
+        // Drop the only strong ref; the next upgrade fails and the task ends.
+        drop(state);
+
+        let joined = timeout(Duration::from_secs(2), handle).await;
+        assert!(
+            joined.is_ok(),
+            "task did not exit after owner dropped its Arc"
+        );
+        assert!(weak.upgrade().is_none(), "state should be fully dropped");
+    }
+}

--- a/model_gateway/src/routers/common/background/supervisor.rs
+++ b/model_gateway/src/routers/common/background/supervisor.rs
@@ -8,7 +8,7 @@
 //! [`crate::worker::capacity::WorkerCapacity::spawn`] (catch-unwind +
 //! restart-with-backoff + `Weak` references so the spawned task never keeps the
 //! owning state alive), but factored out as a reusable primitive so the
-//! background scheduler's claim-tick and sweeper loops share one
+//! background driver's claim-tick and sweeper loops share one
 //! implementation instead of hand-rolling a third and fourth copy.
 
 use std::{future::Future, sync::Weak, time::Duration};
@@ -54,6 +54,11 @@ where
         reason = "supervised long-lived task: panics are caught and the loop restarts; holds Weak refs so it cannot keep the owning state alive"
     )]
     tokio::spawn(async move {
+        // The very first run consumes the interval's eager first tick (the
+        // startup pass, if any, already drained the queue). After a panic we
+        // restart having already slept the backoff, so we must NOT swallow
+        // another full interval — let the restarted loop fire immediately.
+        let mut skip_first_tick = true;
         loop {
             let result = std::panic::AssertUnwindSafe(run_loop(
                 name,
@@ -61,9 +66,11 @@ where
                 interval,
                 wakeup.clone(),
                 &tick,
+                skip_first_tick,
             ))
             .catch_unwind()
             .await;
+            skip_first_tick = false;
 
             match result {
                 Ok(()) => break,
@@ -83,12 +90,20 @@ where
 }
 
 /// The inner loop, separated so the supervisor can `catch_unwind` around it.
+///
+/// `skip_first_tick` controls the interval's eager first tick: on normal
+/// startup it is `true`, so the immediate tick is consumed and the first
+/// scheduled wake waits a full period (the startup pass already drained the
+/// queue). On a panic-restart it is `false`: the supervisor already slept
+/// [`PANIC_RESTART_BACKOFF`], so the loop fires right away instead of waiting an
+/// extra full interval before the next callback.
 async fn run_loop<S, F, Fut>(
     name: &'static str,
     state: Weak<S>,
     interval: Duration,
     wakeup: Option<Weak<Notify>>,
     tick: &F,
+    skip_first_tick: bool,
 ) where
     S: Send + Sync + 'static,
     F: Fn(std::sync::Arc<S>) -> Fut + Send + Sync + 'static,
@@ -98,25 +113,40 @@ async fn run_loop<S, F, Fut>(
     // A panic-restart or a slow tick must not produce a burst of catch-up
     // ticks; one wake per missed period is enough for a poll loop.
     ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
-    // The first `tick()` on a fresh interval returns immediately; the caller's
-    // startup pass (if any) already drained the queue, so consume that eager
-    // tick up front and wait a full period before the first scheduled wake.
-    ticker.tick().await;
+    // The first `tick()` on a fresh interval returns immediately. On normal
+    // startup the caller's startup pass (if any) already drained the queue, so
+    // consume that eager tick and wait a full period before the first scheduled
+    // wake. After a panic we skip this so the restarted loop fires immediately
+    // (the backoff already elapsed in the supervisor).
+    if skip_first_tick {
+        ticker.tick().await;
+    }
 
-    loop {
-        // Upgrade the wakeup each iteration so a dropped owner lets it go.
-        let notified = async {
+    // Pin the wakeup future once and only rebuild it when it resolves, so a
+    // notification that arrives while the tick callback runs (or while the
+    // other `select!` branch is polled) stays registered instead of being
+    // dropped with a freshly-created future each iteration. `make_notified`
+    // re-upgrades the `Weak` on every rebuild, preserving "a dropped wakeup
+    // owner lets it go" (it then parks on `pending`, leaving the interval as
+    // the sole driver). Loop exit is governed by `state.upgrade()` below, not
+    // by the wakeup, so the owner-dropped contract is unaffected.
+    let make_notified = || {
+        let wakeup = wakeup.clone();
+        async move {
             match wakeup.as_ref().and_then(Weak::upgrade) {
                 Some(n) => n.notified().await,
-                // No wakeup configured (or it was dropped): fall back to the
-                // interval alone by never resolving this branch.
                 None => std::future::pending::<()>().await,
             }
-        };
+        }
+    };
+    let mut notified = Box::pin(make_notified());
 
+    loop {
         tokio::select! {
             _ = ticker.tick() => {}
-            () = notified => {}
+            () = &mut notified => {
+                notified = Box::pin(make_notified());
+            }
         }
 
         let Some(state) = state.upgrade() else {

--- a/model_gateway/src/routers/common/background/worker.rs
+++ b/model_gateway/src/routers/common/background/worker.rs
@@ -1,6 +1,6 @@
 //! Background worker seam.
 //!
-//! The scheduler claims jobs from the [`BackgroundResponseRepository`] and hands
+//! The driver claims jobs from the [`BackgroundResponseRepository`] and hands
 //! each one to a [`BackgroundWorker`] for execution. This module defines that
 //! seam plus a default implementation used until the real executor lands in
 //! BGM-PR-07.
@@ -22,7 +22,7 @@ pub const BACKGROUND_EXECUTION_UNAVAILABLE: &str = "background_execution_unavail
 
 /// Executes a single leased background job end to end.
 ///
-/// The scheduler owns the concurrency permit and the claim/sweep loops; an
+/// The driver owns the concurrency permit and the claim/sweep loops; an
 /// implementation of this trait owns everything from "I have a leased job" to
 /// "the response row is terminal" (running the model, persisting stream events,
 /// honoring cancel/retry, and calling
@@ -31,7 +31,7 @@ pub const BACKGROUND_EXECUTION_UNAVAILABLE: &str = "background_execution_unavail
 #[async_trait]
 pub trait BackgroundWorker: Send + Sync {
     /// Execute one claimed job. The implementation is responsible for driving
-    /// the job to a terminal state (typically via `finalize`); the scheduler
+    /// the job to a terminal state (typically via `finalize`); the driver
     /// holds the concurrency permit until this future resolves.
     async fn execute(&self, job: LeasedJob);
 }

--- a/model_gateway/src/routers/common/background/worker.rs
+++ b/model_gateway/src/routers/common/background/worker.rs
@@ -1,0 +1,171 @@
+//! Background worker seam.
+//!
+//! The scheduler claims jobs from the [`BackgroundResponseRepository`] and hands
+//! each one to a [`BackgroundWorker`] for execution. This module defines that
+//! seam plus a default implementation used until the real executor lands in
+//! BGM-PR-07.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use chrono::Utc;
+use serde_json::{json, Value};
+use smg_data_connector::{
+    BackgroundResponseRepository, FinalizeRequest, FinalizeStatus, LeasedJob,
+};
+use tracing::warn;
+
+/// Error code stamped on the response that the [`UnavailableBackgroundWorker`]
+/// finalizes. Distinct, greppable, and stable so operators and tests can key
+/// off it.
+pub const BACKGROUND_EXECUTION_UNAVAILABLE: &str = "background_execution_unavailable";
+
+/// Executes a single leased background job end to end.
+///
+/// The scheduler owns the concurrency permit and the claim/sweep loops; an
+/// implementation of this trait owns everything from "I have a leased job" to
+/// "the response row is terminal" (running the model, persisting stream events,
+/// honoring cancel/retry, and calling
+/// [`BackgroundResponseRepository::finalize`]). The real implementation lands in
+/// BGM-PR-07; [`UnavailableBackgroundWorker`] is the placeholder until then.
+#[async_trait]
+pub trait BackgroundWorker: Send + Sync {
+    /// Execute one claimed job. The implementation is responsible for driving
+    /// the job to a terminal state (typically via `finalize`); the scheduler
+    /// holds the concurrency permit until this future resolves.
+    async fn execute(&self, job: LeasedJob);
+}
+
+/// Default [`BackgroundWorker`] that terminalizes every claimed job as `failed`.
+///
+/// Real execution is not wired yet (BGM-PR-07). Without a worker, a claimed job
+/// would sit `in_progress` until its lease expired, get requeued by the sweeper,
+/// be re-claimed, and loop forever. This placeholder instead finalizes each
+/// claimed job as [`FinalizeStatus::Failed`] with a clear reason, so jobs reach
+/// a terminal state cleanly and `GET /v1/responses/{id}` returns a `failed`
+/// payload rather than a perpetual `in_progress`.
+pub struct UnavailableBackgroundWorker {
+    repository: Arc<dyn BackgroundResponseRepository>,
+}
+
+impl UnavailableBackgroundWorker {
+    pub fn new(repository: Arc<dyn BackgroundResponseRepository>) -> Self {
+        Self { repository }
+    }
+
+    /// Build the `failed` `raw_response` payload stored for the job. Mirrors the
+    /// shape of the queued skeleton produced by the create path (`id`,
+    /// `object`, `status`, `model`, `output`) and adds an OpenAI-style `error`
+    /// object so the failure reason is visible to clients.
+    fn failed_raw_response(job: &LeasedJob) -> Value {
+        json!({
+            "id": job.response_id.0,
+            "object": "response",
+            "status": "failed",
+            "model": job.model,
+            "output": [],
+            "error": {
+                "code": BACKGROUND_EXECUTION_UNAVAILABLE,
+                "message": "background worker not yet implemented",
+            },
+        })
+    }
+}
+
+#[async_trait]
+impl BackgroundWorker for UnavailableBackgroundWorker {
+    async fn execute(&self, job: LeasedJob) {
+        let now = Utc::now();
+        let finalize = FinalizeRequest::new(
+            job.response_id.clone(),
+            job.worker_id.clone(),
+            FinalizeStatus::Failed,
+            Self::failed_raw_response(&job),
+            now,
+        );
+
+        match self.repository.finalize(finalize, now).await {
+            Ok(result) => {
+                warn!(
+                    response_id = %job.response_id.0,
+                    final_status = ?result.final_status,
+                    cancel_won = result.cancel_won,
+                    "background execution unavailable; finalized job as failed (BGM-PR-07 not yet wired)"
+                );
+            }
+            Err(e) => {
+                // A lease that expired before finalize, or a row already made
+                // terminal by a concurrent cancel, is expected and harmless:
+                // the sweeper requeues genuinely-stuck rows and a terminal row
+                // needs no further action. Log and move on.
+                warn!(
+                    response_id = %job.response_id.0,
+                    error = %e,
+                    "failed to finalize background job in unavailable worker"
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use serde_json::json;
+    use smg_data_connector::{
+        EnqueueRequest, MemoryBackgroundRepository, MemoryResponseStorage, ResponseId,
+        ResponseStorage,
+    };
+
+    use super::*;
+
+    fn enqueue_req(id: &str) -> EnqueueRequest {
+        EnqueueRequest::new(
+            ResponseId::from(id),
+            "gpt-5.1".to_string(),
+            json!({"model": "gpt-5.1"}),
+            json!([]),
+            json!({"id": id, "status": "queued"}),
+            false,
+            0,
+        )
+    }
+
+    #[tokio::test]
+    async fn unavailable_worker_finalizes_claimed_job_as_failed() {
+        let rs = Arc::new(MemoryResponseStorage::new());
+        let repo: Arc<dyn BackgroundResponseRepository> =
+            Arc::new(MemoryBackgroundRepository::new(Arc::clone(&rs)));
+        repo.enqueue(enqueue_req("r1"), None, None).await.unwrap();
+
+        let job = repo
+            .claim_next("w1", Utc::now(), Duration::from_secs(60))
+            .await
+            .unwrap()
+            .expect("claim");
+
+        let worker = UnavailableBackgroundWorker::new(Arc::clone(&repo));
+        worker.execute(job).await;
+
+        // The mirrored response storage must now show a terminal failed payload
+        // carrying the unavailable reason.
+        let stored = rs
+            .get_response(&ResponseId::from("r1"))
+            .await
+            .unwrap()
+            .expect("response present");
+        assert_eq!(stored.raw_response["status"], "failed");
+        assert_eq!(
+            stored.raw_response["error"]["code"],
+            BACKGROUND_EXECUTION_UNAVAILABLE
+        );
+
+        // The row is terminal, so it is no longer claimable.
+        let reclaim = repo
+            .claim_next("w2", Utc::now(), Duration::from_secs(60))
+            .await
+            .unwrap();
+        assert!(reclaim.is_none(), "failed job must not be re-claimable");
+    }
+}

--- a/model_gateway/src/server.rs
+++ b/model_gateway/src/server.rs
@@ -54,7 +54,10 @@ use crate::{
         otel_trace,
     },
     routers::{
-        common::background::create::{handle_background_create, BackgroundCreateDeps},
+        common::background::{
+            create::{handle_background_create, BackgroundCreateDeps},
+            start_background_scheduler,
+        },
         conversations,
         openai::realtime::ws::RealtimeQueryParams,
         parse, responses as response_handlers,
@@ -1257,6 +1260,26 @@ pub async fn startup(config: ServerConfig) -> Result<(), Box<dyn std::error::Err
         worker_monitor.start_event_loop();
         debug!("Started WorkerMonitor event loop");
     }
+
+    // Background-mode scheduler driver. Only spawned when a background
+    // repository is configured (capability-gated by the active history
+    // backend); a gateway with no background repo is entirely unaffected. The
+    // handle owns the supervised claim-tick + sweeper tasks and must outlive
+    // the server, so it is bound for the lifetime of `startup`. BGM-PR-07 swaps
+    // the default "execution unavailable" worker for the real executor.
+    let _background_scheduler = match app_context.background_repository.clone() {
+        Some(repository) => {
+            let handle =
+                start_background_scheduler(repository, config.router_config.background.clone())
+                    .await;
+            info!("Background scheduler started");
+            Some(handle)
+        }
+        None => {
+            debug!("No background repository configured; background scheduler not started");
+            None
+        }
+    };
 
     let (limiter, processor) = middleware::ConcurrencyLimiter::new(
         app_context.rate_limiter.clone(),

--- a/model_gateway/src/server.rs
+++ b/model_gateway/src/server.rs
@@ -54,10 +54,7 @@ use crate::{
         otel_trace,
     },
     routers::{
-        common::background::{
-            create::{handle_background_create, BackgroundCreateDeps},
-            start_background_scheduler,
-        },
+        common::background::create::{handle_background_create, BackgroundCreateDeps},
         conversations,
         openai::realtime::ws::RealtimeQueryParams,
         parse, responses as response_handlers,
@@ -1261,25 +1258,16 @@ pub async fn startup(config: ServerConfig) -> Result<(), Box<dyn std::error::Err
         debug!("Started WorkerMonitor event loop");
     }
 
-    // Background-mode scheduler driver. Only spawned when a background
-    // repository is configured (capability-gated by the active history
-    // backend); a gateway with no background repo is entirely unaffected. The
-    // handle owns the supervised claim-tick + sweeper tasks and must outlive
-    // the server, so it is bound for the lifetime of `startup`. BGM-PR-07 swaps
-    // the default "execution unavailable" worker for the real executor.
-    let _background_scheduler = match app_context.background_repository.clone() {
-        Some(repository) => {
-            let handle =
-                start_background_scheduler(repository, config.router_config.background.clone())
-                    .await;
-            info!("Background scheduler started");
-            Some(handle)
-        }
-        None => {
-            debug!("No background repository configured; background scheduler not started");
-            None
-        }
-    };
+    // Background-mode driver (claim-tick + sweeper over the background
+    // repository) is intentionally NOT started here in BGM-PR-06. The only
+    // BackgroundWorker that exists yet is the placeholder
+    // UnavailableBackgroundWorker, which finalizes every claimed job as `failed`;
+    // spawning the driver with it would regress #1614's durable `queued`
+    // contract into immediate failure for every gateway with a background
+    // repository (including the default history_backend=memory). So
+    // `background=true` requests keep returning `queued` until BGM-PR-07 (#1221)
+    // wires `BackgroundDriver::spawn(...)` with the real worker. See
+    // `routers::common::background` for the driver + its tests.
 
     let (limiter, processor) = middleware::ConcurrencyLimiter::new(
         app_context.rate_limiter.clone(),


### PR DESCRIPTION
## Description

### Problem

Background `/v1/responses` requests enqueue (BGM-PR-04, #1614) but nothing claims or sweeps them. SMG's existing `middleware/scheduler/` is a live-request **admission** controller (wrong concern); the durable claim/lease/retry logic already lives in the `BackgroundResponseRepository` trait — so this is a thin **driver**, not a scheduler.

### Solution

A small supervised-periodic helper plus a `BackgroundDriver` that runs a startup-claim pass, a claim-tick loop (`claim_next` → dispatch to a `BackgroundWorker`), and a sweeper loop (`requeue_expired`). Adds the `BackgroundWorker` trait seam; the real executor is BGM-PR-07 (#1221).

**The driver is intentionally NOT started at startup in this PR.** Wiring it with the placeholder worker under the default `memory` backend would regress #1614's durable `queued` contract (jobs would be claimed and immediately failed). BGM-PR-07 starts `BackgroundDriver::spawn(...)` with the real worker, so `background=true` continues to return a durable `queued` response until then.

## Changes

- `routers/common/background/supervisor.rs` — `spawn_supervised_periodic` (`Weak` + `catch_unwind` restart + `select!{ notify, interval }`; the `notified()` future is pinned; panic restarts skip the eager first tick).
- `routers/common/background/worker.rs` — `BackgroundWorker` trait + `UnavailableBackgroundWorker` (a `pub` "no executor" default; not auto-used).
- `routers/common/background/driver.rs` — `BackgroundDriver`: startup claim pass, claim-tick loop (permit-before-claim → concurrency cap; re-nudged when a permit frees), sweeper loop; `BackgroundDriverHandle`.
- 8 unit tests against the in-memory repo (startup dispatch, concurrency cap, sweeper reclaim, default-worker terminalization, supervisor behaviors).
- Not wired into `server.rs` startup — deferred to #1221 with the real worker.

## Test Plan

- `cargo +nightly fmt --all`; `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cargo test -p data-connector -p smg` — data-connector 260, smg lib 1006; **0 failures**.
- Runtime behavior unchanged (the driver is not started); `background=true` still returns `queued`.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

Part of #1214. Closes #1220.
