### PR TITLE
fix(scripts): accept HF repo IDs and extra vLLM args in launch-pd-workers

### DIFF
--- a/scripts/launch-pd-workers.sh
+++ b/scripts/launch-pd-workers.sh
@@ -17,6 +17,7 @@
 #   GPU_MEM_UTIL=0.9       GPU memory utilization (default: 0.9)
 #   TP_SIZE=1              Tensor parallel size (default: 1)
 #   KV_BACKEND=nixl        KV transfer backend for vLLM: nixl or mooncake (default: nixl)
+#   EXTRA_VLLM_ARGS        Extra args appended to each vLLM worker (e.g. --trust-remote-code)
 #
 # Mooncake environment variables:
 #   MOONCAKE_BOOTSTRAP_PORT  Bootstrap port for Mooncake prefill workers (default: 8998)
@@ -71,6 +72,11 @@ KV_BACKEND="${KV_BACKEND:-nixl}"
 # Each prefill worker needs a unique bootstrap port
 MOONCAKE_BOOTSTRAP_PORT="${MOONCAKE_BOOTSTRAP_PORT:-8998}"
 
+# Extra args appended to every vLLM worker command (space-separated).
+# Useful for model-specific flags, e.g.:
+#   EXTRA_VLLM_ARGS="--trust-remote-code --max-num-seqs 256"
+read -ra EXTRA_VLLM_ARGS <<< "${EXTRA_VLLM_ARGS:-}"
+
 info() {
     echo -e "${GREEN}[INFO]${NC} $1"
 }
@@ -91,7 +97,7 @@ print_usage() {
     echo ""
     echo "Arguments:"
     echo "  runtime     Runtime type: 'sglang' or 'vllm'"
-    echo "  model_path  Path to the model directory"
+    echo "  model_path  Local model directory or HuggingFace repo ID"
     echo ""
     echo "Environment variables:"
     echo "  PREFILL_GPU           GPU ID for prefill worker (default: 0)"
@@ -106,6 +112,7 @@ print_usage() {
     echo "vLLM-specific environment variables:"
     echo "  KV_BACKEND              KV transfer backend: 'nixl' or 'mooncake' (default: nixl)"
     echo "  MOONCAKE_BOOTSTRAP_PORT Bootstrap port for Mooncake prefill (default: 8998)"
+    echo "  EXTRA_VLLM_ARGS         Extra args for each vLLM worker (e.g. --trust-remote-code)"
     echo ""
     echo "Examples:"
     echo "  # SGLang PD"
@@ -208,7 +215,8 @@ launch_vllm_pd_nixl() {
         --tensor-parallel-size "$TP_SIZE" \
         --max-model-len "$MAX_MODEL_LEN" \
         --gpu-memory-utilization "$GPU_MEM_UTIL" \
-        --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_producer"}' &
+        --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_producer"}' \
+        "${EXTRA_VLLM_ARGS[@]}" &
 
     local prefill_pid=$!
     info "Prefill worker started (PID: $prefill_pid)"
@@ -227,7 +235,8 @@ launch_vllm_pd_nixl() {
         --tensor-parallel-size "$TP_SIZE" \
         --max-model-len "$MAX_MODEL_LEN" \
         --gpu-memory-utilization "$GPU_MEM_UTIL" \
-        --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_consumer"}' &
+        --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_consumer"}' \
+        "${EXTRA_VLLM_ARGS[@]}" &
 
     local decode_pid=$!
     info "Decode worker started (PID: $decode_pid)"
@@ -270,7 +279,8 @@ launch_vllm_pd_mooncake() {
         --tensor-parallel-size "$TP_SIZE" \
         --max-model-len "$MAX_MODEL_LEN" \
         --gpu-memory-utilization "$GPU_MEM_UTIL" \
-        --kv-transfer-config "$prefill_kv_config" &
+        --kv-transfer-config "$prefill_kv_config" \
+        "${EXTRA_VLLM_ARGS[@]}" &
 
     local prefill_pid=$!
     info "Prefill worker started (PID: $prefill_pid)"
@@ -288,7 +298,8 @@ launch_vllm_pd_mooncake() {
         --tensor-parallel-size "$TP_SIZE" \
         --max-model-len "$MAX_MODEL_LEN" \
         --gpu-memory-utilization "$GPU_MEM_UTIL" \
-        --kv-transfer-config "$decode_kv_config" &
+        --kv-transfer-config "$decode_kv_config" \
+        "${EXTRA_VLLM_ARGS[@]}" &
 
     local decode_pid=$!
     info "Decode worker started (PID: $decode_pid)"
@@ -316,9 +327,18 @@ main() {
     local runtime="$1"
     local model_path="$2"
 
-    # Validate model path
-    if [[ ! -d "$model_path" ]]; then
+    # Validate model path: accept either a local directory or a HuggingFace
+    # repo ID. vLLM/SGLang accept a repo ID via --model/--model-path and
+    # download it on first use, so only reject paths that are clearly meant
+    # to be local (absolute, or ./ ../ ~) but do not exist on disk.
+    if [[ -d "$model_path" ]]; then
+        :  # local model directory
+    elif [[ "$model_path" == /* || "$model_path" == .* || "$model_path" == "~"* ]]; then
         error "Model path does not exist: $model_path"
+    elif [[ "$model_path" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]]; then
+        info "Treating '$model_path' as a HuggingFace repo ID (downloaded if not cached)"
+    else
+        error "Model '$model_path' is neither an existing directory nor a valid HuggingFace repo ID"
     fi
 
     # Validate GPU IDs are different


### PR DESCRIPTION
## Description

### Problem

`scripts/launch-pd-workers.sh` rejected HuggingFace repo IDs: model-path validation required an existing local directory (`[[ ! -d ]]`), so `./scripts/launch-pd-workers.sh vllm nvidia/...` failed with "Model path does not exist" even though vLLM accepts a repo ID and downloads it. The script also had no way to pass model-specific vLLM flags (e.g. `--trust-remote-code`).

### Solution

Accept a repo ID in validation (only reject paths that look local — absolute or `./ ../ ~` — but don't exist), and add an `EXTRA_VLLM_ARGS` passthrough appended to every vLLM worker.

## Changes

- `scripts/launch-pd-workers.sh`:
  - Model-path validation accepts a HuggingFace repo ID (`org/name`) in addition to a local directory.
  - New `EXTRA_VLLM_ARGS` env var, appended (as a quoted array) to all vLLM prefill/decode workers for both NIXL and Mooncake.
  - Usage/help text updated.

## Test Plan

Shell-only change — no Rust/Python/protocols/bindings touched, so the cargo gate is N/A. Verified:

- `shellcheck scripts/launch-pd-workers.sh` and `bash -n scripts/launch-pd-workers.sh` — both clean.
- Model-path validation: `nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16` and `meta-llama/Llama-3.1-8B-Instruct` → accepted as repo IDs; existing dir → accepted; `/raid/models/missing`, `./nope`, `garbage` → rejected.
- `EXTRA_VLLM_ARGS` under `set -euo pipefail`: unset → 0 args (no error); `"--trust-remote-code --max-num-seqs 256"` → 3 args appended in order.

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes (N/A — shell-only)
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes (N/A — shell-only)
- [x] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for passing additional vLLM CLI arguments via an environment variable.
  * Model path validation now accepts HuggingFace-style repository IDs in addition to local directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->