### PR TITLE
fix(grpc): make NIXL PD actually transfer KV cache (relay kv_transfer_params)

### DIFF
--- a/.github/workflows/pr-test-rust.yml
+++ b/.github/workflows/pr-test-rust.yml
@@ -232,6 +232,14 @@ jobs:
           python3 -m pip install pytest pytest-cov pytest-xdist
           pytest -q tests --cov=smg --cov-config=.coveragerc --cov-report=term-missing --cov-fail-under=80
 
+      - name: Run grpc_servicer unit tests
+        run: |
+          rm -f crates/grpc_client/python/smg_grpc_proto/proto
+          mkdir -p crates/grpc_client/python/smg_grpc_proto/proto
+          cp crates/grpc_client/proto/*.proto crates/grpc_client/python/smg_grpc_proto/proto/
+          pip install ./crates/grpc_client/python
+          pytest -q grpc_servicer/tests
+
   unit-tests:
     needs: [detect-changes]
     if: >-

--- a/crates/grpc_client/proto/vllm_engine.proto
+++ b/crates/grpc_client/proto/vllm_engine.proto
@@ -160,13 +160,20 @@ message GenerateRequest {
 
   // KV transfer parameters for PD disaggregation (Mooncake)
   // Decode worker uses this to fetch KV cache from prefill worker
+  // Deprecated: use kv_transfer_params_json instead
   KvTransferParams kv_transfer_params = 6;
 
   // Optional multimodal data (images for vision models)
   MultimodalInputs mm_inputs = 7;
+
+  // Connector KV-transfer params as a JSON object, passed verbatim to the
+  // engine (e.g. NIXL's do_remote_prefill/remote_block_ids/remote_host/...).
+  // Preferred over the legacy typed kv_transfer_params field.
+  optional string kv_transfer_params_json = 8;
 }
 
 // KV cache transfer parameters for Mooncake PD disaggregation
+// Deprecated: use kv_transfer_params_json on GenerateRequest/GenerateComplete
 message KvTransferParams {
   string remote_host = 1;  // Prefill worker's side-channel host
   uint32 remote_port = 2;  // Prefill worker's side-channel port
@@ -241,6 +248,7 @@ message GenerateComplete {
 
   // KV transfer parameters returned by prefill worker (Mooncake PD)
   // Contains prefill's side-channel address for decode to fetch KV cache
+  // Deprecated: use kv_transfer_params_json instead
   KvTransferParams kv_transfer_params = 9;
 
   // Matched stop information (for stop sequences)
@@ -248,6 +256,10 @@ message GenerateComplete {
     uint32 matched_token_id = 10;
     string matched_stop_str = 11;
   }
+
+  // Connector KV-transfer params returned by the engine, as a JSON object
+  // (e.g. NIXL's handoff for the decode worker). Forwarded verbatim by the router.
+  optional string kv_transfer_params_json = 12;
 }
 
 // =====================

--- a/crates/grpc_client/python/pyproject.toml
+++ b/crates/grpc_client/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "smg-grpc-proto"
-version = "0.4.8"
+version = "0.4.9"
 description = "SMG gRPC proto definitions for SGLang, vLLM, TRT-LLM, and MLX"
 requires-python = ">=3.10"
 dependencies = [

--- a/crates/grpc_client/src/vllm_engine.rs
+++ b/crates/grpc_client/src/vllm_engine.rs
@@ -126,6 +126,7 @@ impl VllmEngineClient {
             sampling_params: Some(sampling_params),
             stream: body.stream,
             kv_transfer_params: None,
+            kv_transfer_params_json: None,
             mm_inputs,
         };
 
@@ -158,6 +159,7 @@ impl VllmEngineClient {
             sampling_params: Some(sampling_params),
             stream: body.stream,
             kv_transfer_params: None,
+            kv_transfer_params_json: None,
             mm_inputs: None,
         };
 
@@ -194,6 +196,7 @@ impl VllmEngineClient {
             sampling_params: Some(sampling_params),
             stream: body.stream.unwrap_or(false),
             kv_transfer_params: None,
+            kv_transfer_params_json: None,
             mm_inputs: None,
         };
 
@@ -398,6 +401,7 @@ impl VllmEngineClient {
             sampling_params: Some(sampling_params),
             stream: body.stream.unwrap_or(false),
             kv_transfer_params: None,
+            kv_transfer_params_json: None,
             mm_inputs: multimodal_inputs,
         };
 
@@ -460,6 +464,7 @@ impl VllmEngineClient {
             sampling_params: Some(sampling_params),
             stream: body.stream,
             kv_transfer_params: None,
+            kv_transfer_params_json: None,
             mm_inputs: None,
         };
 
@@ -701,6 +706,7 @@ mod tests {
             sampling_params: Some(sampling_params),
             stream: false,
             kv_transfer_params: None,
+            kv_transfer_params_json: None,
             mm_inputs: None,
         };
 

--- a/docs/concepts/routing/pd-disaggregation.md
+++ b/docs/concepts/routing/pd-disaggregation.md
@@ -114,10 +114,10 @@ SGLang uses **parallel dispatch** with bootstrap-based coordination:
 
 vLLM uses **sequential dispatch** with NIXL or Mooncake KV transfer:
 
-1. SMG sends request to prefill worker with `max_tokens=1`
-2. Prefill computes KV cache and returns (response discarded)
-3. SMG sends original request to decode worker
-4. KV backend (NIXL/Mooncake) transparently transfers KV cache
+1. SMG sends request to prefill worker with `max_tokens=1` (tagged with `do_remote_decode=true` for NIXL)
+2. Prefill computes KV cache and returns its KV handoff params (output tokens discarded)
+3. SMG sends original request to decode worker with the relayed `kv_transfer_params`
+4. Decode worker pulls the KV cache from prefill (NIXL RDMA / Mooncake)
 5. Decode streams tokens back to client
 
 ### Request Flow
@@ -302,15 +302,15 @@ The KV cache is transferred between workers using the backend's native mechanism
 | Backend | Transfer Method | Coordination |
 |---------|-----------------|--------------|
 | SGLang | NCCL/Gloo over network | Bootstrap metadata (host/port/room) |
-| vLLM + NIXL | RDMA | Automatic prefix matching |
+| vLLM + NIXL | RDMA | `kv_transfer_params` relayed by SMG |
 | vLLM + Mooncake | TCP/RDMA | P2P handshake via master server |
 
 **SGLang**: SMG injects bootstrap metadata (`DisaggregatedParams`) into requests, enabling workers to coordinate KV transfer through a shared "room".
 
-**vLLM**: SMG uses the simple proxy pattern—sends `max_tokens=1` to prefill to trigger KV cache computation, then the KV backend (NIXL or Mooncake) automatically discovers and transfers the cache to decode. No protocol changes required.
+**vLLM**: SMG uses the standard proxy pattern — sends `max_tokens=1` to prefill to trigger KV cache computation, then relays the engine's KV-transfer metadata to the decode request:
 
-- **NIXL**: Uses RDMA for high-bandwidth KV transfer with automatic prefix matching
-- **Mooncake**: Supports both TCP and RDMA, uses P2P handshake for coordination (no external metadata server required)
+- **NIXL**: SMG tags the prefill request with `do_remote_decode=true`; the engine holds its KV blocks and returns handoff params (e.g. `remote_engine_id`, `remote_request_id`, `remote_block_ids`, `remote_host`/`remote_port`, `tp_size`) that SMG forwards verbatim with the decode request, which pulls the blocks over RDMA
+- **Mooncake**: SMG injects the prefill worker's bootstrap host/port; workers coordinate via P2P handshake (no external metadata server required)
 
 ---
 

--- a/docs/getting-started/pd-disaggregation.md
+++ b/docs/getting-started/pd-disaggregation.md
@@ -79,7 +79,10 @@ smg \
 
 ## vLLM PD
 
-SMG sends to prefill first with `max_tokens=1`, then sends the original request to decode. The KV backend (NIXL or Mooncake) transfers the cache transparently.
+SMG sends to prefill first with `max_tokens=1`, then sends the original request to decode, relaying KV-transfer metadata between the two legs:
+
+- **NIXL**: SMG tags the prefill request with `do_remote_decode=true`, harvests the `kv_transfer_params` the prefill engine returns (engine id, request id, block ids, side-channel address, TP size), and forwards them verbatim with the decode request so decode pulls the KV cache over NIXL.
+- **Mooncake**: SMG injects the prefill worker's bootstrap host/port into the decode request.
 
 ### Start vLLM Workers with NIXL
 
@@ -98,6 +101,18 @@ python -m vllm.entrypoints.grpc_server \
   --port 50052 \
   --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_consumer"}'
 ```
+
+`VLLM_NIXL_SIDE_CHANNEL_PORT` must be unique per worker on the same host (with
+data parallelism each rank uses `port + dp_rank`). When prefill and decode run
+on different machines, also set `VLLM_NIXL_SIDE_CHANNEL_HOST` to an address
+reachable from the decode worker — prefill embeds this host/port in the
+handoff params that decode uses to fetch the KV cache.
+
+To verify KV transfer is active, send a request and look for `Transfer plan:`
+in the decode worker log (vLLM >= 0.20). If the router logs
+`prefill returned no kv_transfer_params`, upgrade the servicer
+(smg-grpc-servicer >= 0.5.4, smg-grpc-proto >= 0.4.9) or check the
+`--kv-transfer-config` on the workers.
 
 ### Start SMG
 

--- a/e2e_test/infra/worker.py
+++ b/e2e_test/infra/worker.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import signal
@@ -40,6 +41,7 @@ class Worker:
     mode: ConnectionMode = ConnectionMode.HTTP
     worker_type: WorkerType = WorkerType.REGULAR
     bootstrap_port: int | None = None
+    nixl_port: int | None = None
     ib_device: str | None = None
     log_dir: str | None = None
     process: subprocess.Popen | None = field(default=None, repr=False)
@@ -157,6 +159,9 @@ class Worker:
         release_port(self.port)
         if self.bootstrap_port is not None:
             release_port(self.bootstrap_port)
+        if self.nixl_port is not None:
+            release_port(self.nixl_port)
+            self.nixl_port = None
 
     def is_alive(self) -> bool:
         """Check if the worker process is still running."""
@@ -265,6 +270,17 @@ class Worker:
             "--gpu-memory-utilization",
             "0.9",
         ]
+
+        # PD disaggregation: NIXL KV transfer roles
+        if self.worker_type in (WorkerType.PREFILL, WorkerType.DECODE):
+            kv_role = "kv_producer" if self.worker_type == WorkerType.PREFILL else "kv_consumer"
+            cmd.extend(
+                [
+                    "--kv-transfer-config",
+                    json.dumps({"kv_connector": "NixlConnector", "kv_role": kv_role}),
+                ]
+            )
+
         extra = spec.get("vllm_args", [])
         if extra:
             cmd.extend(extra)
@@ -364,6 +380,11 @@ class Worker:
         env = os.environ.copy()
         env.setdefault("PYTHONUNBUFFERED", "1")
         env["CUDA_VISIBLE_DEVICES"] = ",".join(map(str, self.gpu_ids))
+
+        # vLLM PD workers need a unique NIXL side-channel port per worker
+        if self.engine == "vllm" and self.worker_type in (WorkerType.PREFILL, WorkerType.DECODE):
+            self.nixl_port = get_open_port()
+            env["VLLM_NIXL_SIDE_CHANNEL_PORT"] = str(self.nixl_port)
 
         # TRT-LLM multi-GPU needs NCCL tuning for CI compatibility
         if self.engine == "trtllm" and len(self.gpu_ids) > 1:

--- a/e2e_test/router/test_pd_nixl.py
+++ b/e2e_test/router/test_pd_nixl.py
@@ -1,0 +1,141 @@
+"""NIXL KV-transfer verification for vLLM PD disaggregation (gRPC mode).
+
+Unlike the MMLU PD tests, output correctness alone cannot catch a broken KV
+transfer: the decode worker silently recomputes the prefill and still produces
+correct answers. This test asserts the transfer actually happens by checking:
+
+1. The router harvested kv_transfer_params from prefill and relayed them to
+   decode (router debug log).
+2. The decode worker performed a NIXL handshake with the prefill worker
+   ("Transfer plan" log, vLLM >= 0.20; handshake markers on older versions).
+
+Requirements:
+    - vLLM with NixlConnector support (workers launched with
+      kv_role=kv_producer / kv_consumer by the worker fixture)
+    - 2 GPUs (1 prefill + 1 decode)
+
+Usage:
+    E2E_RUNTIME=vllm pytest e2e_test/router/test_pd_nixl.py -v
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+logger = logging.getLogger(__name__)
+
+# Router logs land here via the gateway marker (rolling files named smg.YYYY-MM-DD).
+# Worker logs go to E2E_LOG_DIR when set (CI), otherwise setup_backend reuses this dir.
+_LOG_DIR = Path(tempfile.gettempdir()) / f"smg-e2e-pd-nixl-{os.getpid()}"
+
+RELAY_MARKER = "relaying prefill kv_transfer_params"
+NO_PARAMS_MARKER = "prefill returned no kv_transfer_params"
+# "Transfer plan" was introduced in vLLM 0.20; v0.19 logs
+# "NIXL compatibility check passed" at INFO during the handshake
+HANDSHAKE_MARKERS = (
+    "Transfer plan",
+    "NIXL compatibility check passed",
+    "NIXL handshake",
+    "Registering remote agent",
+)
+
+_LOG_FLUSH_TIMEOUT_S = 15.0
+
+
+def _worker_log_dir() -> Path:
+    return Path(os.environ.get("E2E_LOG_DIR") or _LOG_DIR)
+
+
+def _read_logs(log_dir: Path, pattern: str) -> str:
+    return "\n".join(
+        path.read_text(encoding="utf-8", errors="replace")
+        for path in sorted(log_dir.glob(pattern))
+        if path.is_file()
+    )
+
+
+def _wait_for_marker(log_dir: Path, pattern: str, marker: str | tuple[str, ...]) -> str:
+    # Both the router file appender and worker pipes flush asynchronously
+    markers = (marker,) if isinstance(marker, str) else marker
+    deadline = time.monotonic() + _LOG_FLUSH_TIMEOUT_S
+    logs = ""
+    while time.monotonic() < deadline:
+        logs = _read_logs(log_dir, pattern)
+        if any(m in logs for m in markers):
+            return logs
+        time.sleep(0.5)
+    return logs
+
+
+def _unique_prompt() -> str:
+    # Unique filler defeats prefix caching so every request exercises a fresh
+    # prefill -> transfer -> decode cycle
+    filler = " ".join(uuid.uuid4().hex for _ in range(24))
+    return (
+        f"Session token: {filler}\n"
+        "Ignoring the session token above, explain in two sentences why the "
+        "sky appears blue during the day."
+    )
+
+
+@pytest.mark.engine("vllm")
+@pytest.mark.gpu(2)
+@pytest.mark.model("meta-llama/Llama-3.1-8B-Instruct")
+@pytest.mark.e2e
+@pytest.mark.gateway(log_level="debug", log_dir=str(_LOG_DIR))
+@pytest.mark.parametrize("setup_backend", ["pd_grpc"], indirect=True)
+class TestPDNixlKvTransfer:
+    """Verify KV cache actually moves from prefill to decode over NIXL."""
+
+    def test_kv_transfer_params_relayed(self, setup_backend):
+        backend, model, client, *_ = setup_backend
+
+        for _ in range(3):
+            response = client.chat.completions.create(
+                model=model,
+                messages=[{"role": "user", "content": _unique_prompt()}],
+                max_tokens=64,
+                temperature=0.0,
+            )
+            choice = response.choices[0]
+            assert choice.message.content, "Empty completion from PD pipeline"
+
+        router_logs = _wait_for_marker(_LOG_DIR, "smg*", RELAY_MARKER)
+        assert NO_PARAMS_MARKER not in router_logs, (
+            "Router reported prefill returned no kv_transfer_params — "
+            "NIXL handoff is broken (decode recomputed the prefill)"
+        )
+        assert RELAY_MARKER in router_logs, (
+            f"Router never relayed kv_transfer_params to decode; checked logs under {_LOG_DIR}"
+        )
+
+    def test_decode_worker_performed_nixl_handshake(self, setup_backend):
+        backend, model, client, *_ = setup_backend
+
+        response = client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": _unique_prompt()}],
+            max_tokens=32,
+            temperature=0.0,
+        )
+        assert response.choices[0].message.content
+
+        worker_dir = _worker_log_dir()
+        worker_logs = _wait_for_marker(worker_dir, "worker-*.log", HANDSHAKE_MARKERS)
+        if not worker_logs:
+            pytest.skip(
+                "No worker log files captured (SHOW_WORKER_LOGS=1?); "
+                "cannot assert on NIXL handshake"
+            )
+        assert any(marker in worker_logs for marker in HANDSHAKE_MARKERS), (
+            "No NIXL handshake found in worker logs — the decode worker never "
+            f"pulled KV from prefill; checked {worker_dir}/worker-*.log for "
+            f"{HANDSHAKE_MARKERS}"
+        )

--- a/grpc_servicer/pyproject.toml
+++ b/grpc_servicer/pyproject.toml
@@ -4,11 +4,11 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "smg-grpc-servicer"
-version = "0.5.3"
+version = "0.5.4"
 description = "SMG gRPC servicer implementations for LLM inference engines (vLLM, SGLang, MLX, TokenSpeed)"
 requires-python = ">=3.10"
 dependencies = [
-    "smg-grpc-proto>=0.4.7",
+    "smg-grpc-proto>=0.4.9",
     "grpcio>=1.78.0",
     "grpcio-reflection>=1.78.0",
     "grpcio-health-checking>=1.78.0",

--- a/grpc_servicer/smg_grpc_servicer/vllm/kv_transfer.py
+++ b/grpc_servicer/smg_grpc_servicer/vllm/kv_transfer.py
@@ -1,0 +1,65 @@
+"""KV-transfer param passthrough between the vLLM engine proto and connector dicts."""
+
+import json
+import logging
+
+from smg_grpc_proto import vllm_engine_pb2
+
+logger = logging.getLogger(__name__)
+
+
+def params_from_request(
+    request: vllm_engine_pb2.GenerateRequest,
+) -> dict | None:
+    """Extract KV-transfer params; JSON field preferred, legacy typed field as fallback.
+
+    Raises:
+        ValueError: If the JSON field is malformed or the legacy field is invalid.
+    """
+    if request.HasField("kv_transfer_params_json"):
+        try:
+            params = json.loads(request.kv_transfer_params_json)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Invalid kv_transfer_params_json: {e}") from e
+        if not isinstance(params, dict):
+            raise ValueError("kv_transfer_params_json must be a JSON object")
+        return params
+    if request.HasField("kv_transfer_params"):
+        remote_host = request.kv_transfer_params.remote_host
+        remote_port = request.kv_transfer_params.remote_port
+        if not remote_host or not (1 <= remote_port <= 65535):
+            raise ValueError(
+                "Invalid kv_transfer_params: remote_host must be set and remote_port must be in [1, 65535]."
+            )
+        return {"remote_host": remote_host, "remote_port": remote_port}
+    return None
+
+
+def params_to_response_fields(
+    params: dict | None,
+) -> tuple[vllm_engine_pb2.KvTransferParams | None, str | None]:
+    """Map engine-returned params to (legacy typed message, JSON field) for GenerateComplete."""
+    if not params:
+        return None, None
+
+    params_json = None
+    try:
+        params_json = json.dumps(params)
+    except (TypeError, ValueError):
+        logger.warning("Dropping non-JSON-serializable kv_transfer_params: %r", params)
+
+    # Legacy mirror for old routers; built only when host/port are valid (Mooncake shape)
+    legacy = None
+    remote_host = params.get("remote_host", "")
+    remote_port = params.get("remote_port", 0)
+    if (
+        isinstance(remote_host, str)
+        and remote_host
+        and isinstance(remote_port, int)
+        and 1 <= remote_port <= 65535
+    ):
+        legacy = vllm_engine_pb2.KvTransferParams(
+            remote_host=remote_host,
+            remote_port=remote_port,
+        )
+    return legacy, params_json

--- a/grpc_servicer/smg_grpc_servicer/vllm/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/vllm/servicer.py
@@ -32,6 +32,7 @@ from vllm.outputs import CompletionOutput, RequestOutput
 from vllm.sampling_params import RequestOutputKind, StructuredOutputsParams
 
 from smg_grpc_servicer.tokenizer_bundle import CHUNK_SIZE, build_tokenizer_zip
+from smg_grpc_servicer.vllm.kv_transfer import params_from_request, params_to_response_fields
 
 logger = init_logger(__name__)
 SAMPLING_DEFAULT_KEYS = (
@@ -126,8 +127,11 @@ class VllmEngineServicer(vllm_engine_pb2_grpc.VllmEngineServicer):
             has_preprocessed_mm,
         )
 
+        kv_transfer_params: dict | None = None
+        engine_started = False
         try:
             arrival_time = time.time()
+            kv_transfer_params = params_from_request(request)
 
             if has_preprocessed_mm and input_type == "tokenized":
                 # Preprocessed multimodal from Rust router.
@@ -147,9 +151,7 @@ class VllmEngineServicer(vllm_engine_pb2_grpc.VllmEngineServicer):
             sampling_params = self._sampling_params_from_proto(
                 request.sampling_params,
                 stream=request.stream,
-                kv_transfer_params=request.kv_transfer_params
-                if request.HasField("kv_transfer_params")
-                else None,
+                kv_transfer_params=kv_transfer_params,
             )
             tokenization_kwargs = self._tokenization_kwargs_from_proto(request.sampling_params)
 
@@ -166,6 +168,7 @@ class VllmEngineServicer(vllm_engine_pb2_grpc.VllmEngineServicer):
                 request_id=request_id,
                 tokenization_kwargs=tokenization_kwargs,
             ):
+                engine_started = True
                 # For streaming, send chunks for EACH completion output (n outputs)
                 if request.stream:
                     for completion in output.outputs:
@@ -203,10 +206,40 @@ class VllmEngineServicer(vllm_engine_pb2_grpc.VllmEngineServicer):
 
         except ValueError as e:
             # Invalid request error (equiv to 400).
+            await self._notify_kv_transfer_rejected(request_id, kv_transfer_params, engine_started)
             await context.abort(grpc.StatusCode.INVALID_ARGUMENT, str(e))
         except Exception as e:
             logger.exception("Error in Generate for request %s", request_id)
+            await self._notify_kv_transfer_rejected(request_id, kv_transfer_params, engine_started)
             await context.abort(grpc.StatusCode.INTERNAL, str(e))
+
+    async def _notify_kv_transfer_rejected(
+        self,
+        request_id: str,
+        kv_transfer_params: dict | None,
+        engine_started: bool,
+    ) -> None:
+        """Free remote prefill blocks early when a decode request dies pre-admission.
+
+        Without this, the prefill engine keeps the blocks pinned until the NIXL
+        lease expires (30s default).
+        """
+        if engine_started or not kv_transfer_params:
+            return
+        if not kv_transfer_params.get("do_remote_prefill"):
+            return
+        # Older vLLM releases lack this hook; the lease expiry covers them
+        notify = getattr(self.engine, "notify_kv_transfer_request_rejected", None)
+        if notify is None:
+            return
+        try:
+            await notify(request_id, kv_transfer_params)
+        except Exception:
+            logger.warning(
+                "Failed to notify KV connector about rejected request %s",
+                request_id,
+                exc_info=True,
+            )
 
     async def Embed(
         self,
@@ -543,7 +576,7 @@ class VllmEngineServicer(vllm_engine_pb2_grpc.VllmEngineServicer):
     def _sampling_params_from_proto(
         params: vllm_engine_pb2.SamplingParams,
         stream: bool = True,
-        kv_transfer_params: vllm_engine_pb2.KvTransferParams | None = None,
+        kv_transfer_params: dict | None = None,
     ) -> SamplingParams:
         """
         Convert protobuf SamplingParams to vLLM SamplingParams.
@@ -551,7 +584,7 @@ class VllmEngineServicer(vllm_engine_pb2_grpc.VllmEngineServicer):
         Args:
             params: Protobuf SamplingParams message
             stream: Whether streaming is enabled
-            kv_transfer_params: KV transfer params proto for Mooncake PD
+            kv_transfer_params: Connector KV-transfer params dict (PD disaggregation)
 
         Returns:
             vLLM SamplingParams with detokenize=False and structured_outputs
@@ -577,26 +610,8 @@ class VllmEngineServicer(vllm_engine_pb2_grpc.VllmEngineServicer):
             elif constraint_field == "choice":
                 structured_outputs = StructuredOutputsParams(choice=list(params.choice.choices))
 
-        # Build extra_args for kv_transfer_params (Mooncake PD)
-        extra_args = None
-        if kv_transfer_params:
-            remote_host = kv_transfer_params.remote_host
-            remote_port = kv_transfer_params.remote_port
-            if not remote_host or not (1 <= remote_port <= 65535):
-                raise ValueError(
-                    "Invalid kv_transfer_params: remote_host must be set and remote_port must be in [1, 65535]."
-                )
-            logger.debug(
-                "kv_transfer_params={remote_host=%s, remote_port=%d}",
-                remote_host,
-                remote_port,
-            )
-            extra_args = {
-                "kv_transfer_params": {
-                    "remote_host": remote_host,
-                    "remote_port": remote_port,
-                }
-            }
+        # Opaque connector params, passed to the engine verbatim (NIXL/Mooncake)
+        extra_args = {"kv_transfer_params": kv_transfer_params} if kv_transfer_params else None
 
         # Create SamplingParams
         # output_kind=DELTA: Return only new tokens in each chunk (for streaming)
@@ -849,13 +864,10 @@ class VllmEngineServicer(vllm_engine_pb2_grpc.VllmEngineServicer):
             num_prompt_logprobs,
         )
 
-        # Build kv_transfer_params if present (Mooncake PD)
-        kv_transfer_params = None
-        if output.kv_transfer_params:
-            kv_transfer_params = vllm_engine_pb2.KvTransferParams(
-                remote_host=output.kv_transfer_params.get("remote_host", ""),
-                remote_port=output.kv_transfer_params.get("remote_port", 0),
-            )
+        # Connector KV-transfer params returned by the engine (PD prefill leg)
+        kv_transfer_params, kv_transfer_params_json = params_to_response_fields(
+            output.kv_transfer_params
+        )
 
         # Build matched_stop kwargs from stop_reason (int token ID or str stop sequence)
         stop_kwargs = {}
@@ -880,6 +892,7 @@ class VllmEngineServicer(vllm_engine_pb2_grpc.VllmEngineServicer):
                 input_logprobs=input_logprobs,
                 index=completion.index,
                 kv_transfer_params=kv_transfer_params,
+                kv_transfer_params_json=kv_transfer_params_json,
                 **stop_kwargs,
             ),
         )

--- a/grpc_servicer/tests/test_kv_transfer_params.py
+++ b/grpc_servicer/tests/test_kv_transfer_params.py
@@ -1,0 +1,143 @@
+"""Unit tests for KV-transfer param passthrough (engine-free, no vLLM required).
+
+Run with: pytest grpc_servicer/tests/test_kv_transfer_params.py
+"""
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("smg_grpc_proto")
+from smg_grpc_proto import vllm_engine_pb2  # noqa: E402
+
+# Import the module directly to avoid pulling vllm via the package __init__
+_MODULE_PATH = Path(__file__).parents[1] / "smg_grpc_servicer" / "vllm" / "kv_transfer.py"
+_spec = importlib.util.spec_from_file_location("kv_transfer", _MODULE_PATH)
+kv_transfer = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(kv_transfer)
+
+NIXL_HANDOFF = {
+    "do_remote_prefill": True,
+    "do_remote_decode": False,
+    "remote_engine_id": "engine-1",
+    "remote_request_id": "req-1",
+    "remote_block_ids": [[1, 2, 3]],
+    "remote_host": "10.0.0.1",
+    "remote_port": 5600,
+    "tp_size": 2,
+}
+
+
+class TestParamsFromRequest:
+    def test_no_params_returns_none(self):
+        request = vllm_engine_pb2.GenerateRequest()
+        assert kv_transfer.params_from_request(request) is None
+
+    def test_json_field_parsed_verbatim(self):
+        request = vllm_engine_pb2.GenerateRequest(kv_transfer_params_json=json.dumps(NIXL_HANDOFF))
+        assert kv_transfer.params_from_request(request) == NIXL_HANDOFF
+
+    def test_json_field_preferred_over_typed_field(self):
+        request = vllm_engine_pb2.GenerateRequest(
+            kv_transfer_params=vllm_engine_pb2.KvTransferParams(
+                remote_host="typed-host", remote_port=8998
+            ),
+            kv_transfer_params_json='{"do_remote_decode": true}',
+        )
+        assert kv_transfer.params_from_request(request) == {"do_remote_decode": True}
+
+    def test_invalid_json_raises_value_error(self):
+        request = vllm_engine_pb2.GenerateRequest(kv_transfer_params_json="{not json")
+        with pytest.raises(ValueError, match="Invalid kv_transfer_params_json"):
+            kv_transfer.params_from_request(request)
+
+    def test_non_object_json_raises_value_error(self):
+        request = vllm_engine_pb2.GenerateRequest(kv_transfer_params_json="[1, 2]")
+        with pytest.raises(ValueError, match="must be a JSON object"):
+            kv_transfer.params_from_request(request)
+
+    def test_typed_fallback_builds_mooncake_dict(self):
+        request = vllm_engine_pb2.GenerateRequest(
+            kv_transfer_params=vllm_engine_pb2.KvTransferParams(
+                remote_host="prefill-host", remote_port=8998
+            )
+        )
+        assert kv_transfer.params_from_request(request) == {
+            "remote_host": "prefill-host",
+            "remote_port": 8998,
+        }
+
+    @pytest.mark.parametrize("host,port", [("", 8998), ("host", 0), ("host", 65536)])
+    def test_typed_fallback_validates_host_and_port(self, host, port):
+        request = vllm_engine_pb2.GenerateRequest(
+            kv_transfer_params=vllm_engine_pb2.KvTransferParams(remote_host=host, remote_port=port)
+        )
+        with pytest.raises(ValueError, match="Invalid kv_transfer_params"):
+            kv_transfer.params_from_request(request)
+
+
+class TestParamsToResponseFields:
+    def test_none_and_empty_yield_unset_fields(self):
+        assert kv_transfer.params_to_response_fields(None) == (None, None)
+        assert kv_transfer.params_to_response_fields({}) == (None, None)
+
+    def test_nixl_handoff_roundtrips_through_json(self):
+        legacy, params_json = kv_transfer.params_to_response_fields(NIXL_HANDOFF)
+        assert json.loads(params_json) == NIXL_HANDOFF
+        roundtripped = json.loads(params_json)
+        assert roundtripped["remote_port"] == 5600
+        assert roundtripped["remote_block_ids"] == [[1, 2, 3]]
+        # Legacy mirror carries host/port for old routers
+        assert legacy.remote_host == "10.0.0.1"
+        assert legacy.remote_port == 5600
+
+    def test_tuple_block_ids_serialize_as_lists(self):
+        params = dict(NIXL_HANDOFF, remote_block_ids=((1, 2), (3,)))
+        _, params_json = kv_transfer.params_to_response_fields(params)
+        assert json.loads(params_json)["remote_block_ids"] == [[1, 2], [3]]
+
+    def test_legacy_mirror_skipped_for_non_scalar_host_port(self):
+        legacy, params_json = kv_transfer.params_to_response_fields(
+            {"remote_host": ["not", "a", "string"], "remote_port": 5600}
+        )
+        assert legacy is None
+        assert params_json is not None
+
+    @pytest.mark.parametrize(
+        "params",
+        [
+            {"do_remote_prefill": True},
+            {"remote_host": "", "remote_port": 5600},
+            {"remote_host": "h", "remote_port": 0},
+            {"remote_host": "h", "remote_port": 65536},
+        ],
+    )
+    def test_legacy_mirror_skipped_for_missing_or_invalid_host_port(self, params):
+        legacy, params_json = kv_transfer.params_to_response_fields(params)
+        assert legacy is None
+        assert params_json is not None
+
+    def test_non_serializable_params_drop_json_but_keep_mirror(self):
+        legacy, params_json = kv_transfer.params_to_response_fields(
+            {"remote_host": "h", "remote_port": 1, "bad": object()}
+        )
+        assert params_json is None
+        assert legacy.remote_host == "h"
+
+    def test_response_proto_accepts_fields(self):
+        legacy, params_json = kv_transfer.params_to_response_fields(NIXL_HANDOFF)
+        complete = vllm_engine_pb2.GenerateComplete(
+            kv_transfer_params=legacy,
+            kv_transfer_params_json=params_json,
+        )
+        assert complete.HasField("kv_transfer_params_json")
+        assert json.loads(complete.kv_transfer_params_json) == NIXL_HANDOFF
+
+    def test_unset_json_field_when_none(self):
+        complete = vllm_engine_pb2.GenerateComplete(
+            kv_transfer_params=None,
+            kv_transfer_params_json=None,
+        )
+        assert not complete.HasField("kv_transfer_params_json")

--- a/model_gateway/src/routers/grpc/common/stages/helpers.rs
+++ b/model_gateway/src/routers/grpc/common/stages/helpers.rs
@@ -254,8 +254,7 @@ fn apply_tokenspeed_sampling_defaults(
 /// Inject PD bootstrap metadata for SGLang if needed.
 ///
 /// SGLang uses DisaggregatedParams with bootstrap host/port/room.
-/// vLLM uses different mechanisms: NIXL (automatic prefix matching) or
-/// Mooncake (kv_transfer_params injected in request_execution stage).
+/// vLLM kv_transfer_params are handled in the request_execution stage.
 pub(crate) fn maybe_inject_pd_metadata(
     request: &mut ProtoGenerateRequest,
     workers: &WorkerSelection,

--- a/model_gateway/src/routers/grpc/common/stages/request_execution.rs
+++ b/model_gateway/src/routers/grpc/common/stages/request_execution.rs
@@ -12,14 +12,47 @@ use crate::{
             context::{
                 ClientSelection, ExecutionResult, LoadGuards, RequestContext, WorkerSelection,
             },
-            proto_wrapper::{ProtoEmbedRequest, ProtoGenerateRequest, ProtoRequest, ProtoStream},
+            proto_wrapper::{
+                ProtoEmbedRequest, ProtoGenerateRequest, ProtoRequest, ProtoResponseVariant,
+                ProtoStream,
+            },
             utils::tonic_ext::{TonicResultExt, TonicStatusExt},
         },
     },
-    worker::{RuntimeType, DEFAULT_BOOTSTRAP_PORT, MOONCAKE_CONNECTOR},
+    worker::{RuntimeType, DEFAULT_BOOTSTRAP_PORT, MOONCAKE_CONNECTOR, NIXL_CONNECTOR},
 };
 
 type StreamResult = Result<ProtoStream, tonic::Status>;
+
+/// KV-transfer params tagged onto the NIXL prefill leg so the engine pins its
+/// KV blocks and returns the handoff params for the decode worker.
+const NIXL_PREFILL_KV_PARAMS: &str = r#"{"do_remote_decode":true,"do_remote_prefill":false}"#;
+
+/// PD KV-transfer behavior derived from prefill worker metadata.
+#[derive(Debug, Clone, PartialEq)]
+enum KvConnectorMode {
+    /// MooncakeConnector: inject bootstrap host/port into the decode request.
+    Mooncake { host: String, port: u32 },
+    /// NixlConnector: tag prefill with do_remote_decode, relay returned params to decode.
+    Nixl,
+    /// Unknown/absent connector: relay returned params opportunistically.
+    Passthrough,
+}
+
+fn kv_connector_mode(
+    kv_connector: Option<&str>,
+    bootstrap_host: &str,
+    bootstrap_port: Option<u16>,
+) -> KvConnectorMode {
+    match kv_connector {
+        Some(MOONCAKE_CONNECTOR) => KvConnectorMode::Mooncake {
+            host: bootstrap_host.to_string(),
+            port: u32::from(bootstrap_port.unwrap_or(DEFAULT_BOOTSTRAP_PORT)),
+        },
+        Some(NIXL_CONNECTOR) => KvConnectorMode::Nixl,
+        _ => KvConnectorMode::Passthrough,
+    }
+}
 
 /// Request execution stage: Execute gRPC requests (single or dual dispatch)
 pub(crate) struct RequestExecutionStage {
@@ -103,7 +136,7 @@ impl PipelineStage for RequestExecutionStage {
                     ExecutionMode::DualDispatch => {
                         // Dispatch based on runtime type:
                         // - SGLang: parallel dual dispatch with bootstrap metadata
-                        // - vLLM: sequential prefill-then-decode (NIXL handles KV transfer)
+                        // - vLLM: sequential prefill-then-decode with kv_transfer_params relay
                         let runtime_type = workers.pd_runtime_type();
                         match runtime_type {
                             Some(RuntimeType::Vllm) => {
@@ -275,11 +308,11 @@ impl RequestExecutionStage {
     }
 
     /// Execute vLLM PD: send to prefill with max_tokens=1 first, wait for completion,
-    /// then send original request to decode. NIXL/Mooncake handles KV cache transfer.
+    /// then send original request to decode.
     ///
-    /// For Mooncake: uses bootstrap_host/port from prefill worker metadata to inject
-    /// kv_transfer_params into decode request so decode knows where to fetch KV cache.
-    /// For NIXL: no kv_transfer_params needed (uses prompt prefix matching).
+    /// For Mooncake: injects bootstrap_host/port from prefill worker metadata into
+    /// the decode request. For NIXL: tags the prefill request with do_remote_decode,
+    /// then relays the kv_transfer_params returned by the prefill engine to decode.
     async fn execute_sequential_pd(
         &self,
         proto_request: ProtoGenerateRequest,
@@ -297,46 +330,59 @@ impl RequestExecutionStage {
             )
         })?;
 
-        // Get bootstrap info from prefill worker metadata (only for Mooncake PD)
-        // NIXL uses prefix matching and doesn't need kv_transfer_params
-        let kv_transfer_params: Option<(String, u32)> = workers
+        let mode = workers
             .prefill_worker()
-            .map(|w| w.metadata())
-            .filter(|meta| meta.spec.kv_connector.as_deref() == Some(MOONCAKE_CONNECTOR))
-            .map(|meta| {
-                let port = meta.spec.bootstrap_port.unwrap_or(DEFAULT_BOOTSTRAP_PORT);
-                (meta.spec.bootstrap_host.clone(), port as u32)
-            });
+            .map(|w| {
+                let meta = w.metadata();
+                kv_connector_mode(
+                    meta.spec.kv_connector.as_deref(),
+                    &meta.spec.bootstrap_host,
+                    meta.spec.bootstrap_port,
+                )
+            })
+            .unwrap_or(KvConnectorMode::Passthrough);
 
-        if let Some((ref host, port)) = kv_transfer_params {
-            debug!(
+        match &mode {
+            KvConnectorMode::Mooncake { host, port } => debug!(
                 bootstrap_host = %host,
                 bootstrap_port = port,
                 "vLLM PD (Mooncake): will inject kv_transfer_params into decode request"
-            );
-        } else {
-            // Log at info level since this could indicate misconfiguration if user expects Mooncake
-            // NIXL doesn't need kv_transfer_params (uses automatic prefix matching)
-            // If user expects Mooncake but kv_connector wasn't discovered, they can manually set
-            // labels: { "kv_connector": "MooncakeConnector" } in worker config
-            let has_kv_connector = workers
-                .prefill_worker()
-                .map(|w| w.metadata().spec.kv_connector.is_some())
-                .unwrap_or(false);
-            if has_kv_connector {
-                debug!("vLLM PD (NIXL): using automatic prefix matching for KV transfer");
-            } else {
-                debug!(
-                    "vLLM PD: no kv_connector detected (server may not support GetServerInfo kv fields). \
-                     Assuming NIXL mode. For Mooncake, set labels.kv_connector=MooncakeConnector in worker config"
-                );
+            ),
+            KvConnectorMode::Nixl => debug!(
+                "vLLM PD (NIXL): will tag prefill with do_remote_decode and relay returned kv_transfer_params to decode"
+            ),
+            KvConnectorMode::Passthrough => {
+                // Warn once: PD without a discovered connector usually means GetServerInfo
+                // lacks kv fields or labels.kv_connector is missing in worker config
+                static WARN_ONCE: std::sync::Once = std::sync::Once::new();
+                WARN_ONCE.call_once(|| {
+                    tracing::warn!(
+                        "vLLM PD: no kv_connector detected on prefill worker; KV transfer params \
+                         will only be relayed if the engine returns them"
+                    );
+                });
             }
         }
 
-        // Clone request and set max_tokens=1, stream=false for prefill
+        // NIXL handoff is single-consumer: with n>1 each fan-out child on decode would
+        // pull, and the first completion frees the prefill blocks under its siblings
+        let relay_kv_params = proto_request.sampling_n() <= 1;
+
+        // Clone request and sanitize sampling (max_tokens=1, n=1), stream=false for prefill
         let mut prefill_request = proto_request.clone_inner();
-        prefill_request.set_max_tokens_for_prefill(1);
+        prefill_request.sanitize_sampling_for_prefill(1);
         prefill_request.set_stream(false);
+        if mode == KvConnectorMode::Nixl {
+            if relay_kv_params {
+                prefill_request.set_kv_transfer_params_json(NIXL_PREFILL_KV_PARAMS.to_string());
+            } else {
+                debug!(
+                    request_id = %prefill_request.request_id(),
+                    "vLLM PD (NIXL): n>1 request, skipping kv_transfer_params relay \
+                     (decode recomputes the prompt locally)"
+                );
+            }
+        }
 
         debug!(
             request_id = %prefill_request.request_id(),
@@ -353,11 +399,16 @@ impl RequestExecutionStage {
                 e.to_http_error("prefill_worker_failed_to_start", format!("Prefill worker failed to start: {}", e.message()))
             })?;
 
-        // Drain prefill response (we just need to wait for completion)
+        // Drain prefill response, harvesting connector params from the Complete frame
+        let mut prefill_kv_params: Option<String> = None;
         while let Some(result) = prefill_stream.next().await {
             match result {
-                Ok(_response) => {
-                    // Just consume the response, we use bootstrap info from worker metadata
+                Ok(response) => {
+                    if let ProtoResponseVariant::Complete(complete) = response.into_response() {
+                        if let Some(json) = complete.kv_transfer_params_json() {
+                            prefill_kv_params = Some(json.to_owned());
+                        }
+                    }
                 }
                 Err(e) => {
                     workers.record_outcome_prefill(e.http_status().as_u16());
@@ -374,15 +425,38 @@ impl RequestExecutionStage {
 
         debug!("vLLM PD: prefill completed, sending decode request");
 
-        // Clone original request and inject kv_transfer_params if present (Mooncake)
+        // Decode reuses proto_request as-is; same request_id as the prefill leg is
+        // load-bearing for NIXL P/D correlation on vLLM < 0.13
         let mut decode_request = proto_request;
-        if let Some((remote_host, remote_port)) = kv_transfer_params {
-            debug!(
-                remote_host = %remote_host,
-                remote_port = remote_port,
-                "vLLM PD: injecting kv_transfer_params into decode request"
-            );
-            decode_request.set_kv_transfer_params(remote_host, remote_port);
+        match (&mode, prefill_kv_params) {
+            // Mooncake is n>1-safe: host/port is connection info, not a single-consumer handoff
+            (KvConnectorMode::Mooncake { host, port }, _) => {
+                debug!(
+                    remote_host = %host,
+                    remote_port = port,
+                    "vLLM PD: injecting kv_transfer_params into decode request"
+                );
+                decode_request.set_kv_transfer_params(host.clone(), *port);
+            }
+            (KvConnectorMode::Nixl | KvConnectorMode::Passthrough, Some(json))
+                if relay_kv_params =>
+            {
+                debug!(
+                    request_id = %decode_request.request_id(),
+                    params_len = json.len(),
+                    "vLLM PD: relaying prefill kv_transfer_params to decode request"
+                );
+                decode_request.set_kv_transfer_params_json(json);
+            }
+            (KvConnectorMode::Nixl, None) if relay_kv_params => {
+                tracing::warn!(
+                    request_id = %decode_request.request_id(),
+                    "vLLM PD (NIXL): prefill returned no kv_transfer_params; decode will \
+                     recompute the prompt locally (outdated smg-grpc-servicer or missing \
+                     kv-transfer-config?)"
+                );
+            }
+            _ => {}
         }
 
         // Send request to decode
@@ -400,5 +474,151 @@ impl RequestExecutionStage {
         Ok(ExecutionResult::Single {
             stream: decode_stream,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use smg_grpc_client::vllm_proto as vllm;
+
+    use super::*;
+
+    #[test]
+    fn kv_connector_mode_mooncake_uses_bootstrap_metadata() {
+        let mode = kv_connector_mode(Some(MOONCAKE_CONNECTOR), "prefill-host", Some(9090));
+        assert_eq!(
+            mode,
+            KvConnectorMode::Mooncake {
+                host: "prefill-host".to_string(),
+                port: 9090,
+            }
+        );
+    }
+
+    #[test]
+    fn kv_connector_mode_mooncake_defaults_port() {
+        let mode = kv_connector_mode(Some(MOONCAKE_CONNECTOR), "prefill-host", None);
+        assert_eq!(
+            mode,
+            KvConnectorMode::Mooncake {
+                host: "prefill-host".to_string(),
+                port: u32::from(DEFAULT_BOOTSTRAP_PORT),
+            }
+        );
+    }
+
+    #[test]
+    fn kv_connector_mode_nixl() {
+        assert_eq!(
+            kv_connector_mode(Some(NIXL_CONNECTOR), "ignored", Some(9090)),
+            KvConnectorMode::Nixl
+        );
+    }
+
+    #[test]
+    fn kv_connector_mode_unknown_or_missing_is_passthrough() {
+        assert_eq!(
+            kv_connector_mode(Some("LMCacheConnector"), "host", None),
+            KvConnectorMode::Passthrough
+        );
+        assert_eq!(
+            kv_connector_mode(None, "host", None),
+            KvConnectorMode::Passthrough
+        );
+    }
+
+    #[test]
+    fn nixl_prefill_kv_params_is_valid_json() {
+        let value: serde_json::Value = serde_json::from_str(NIXL_PREFILL_KV_PARAMS).unwrap();
+        assert_eq!(value["do_remote_decode"], true);
+        assert_eq!(value["do_remote_prefill"], false);
+        assert_eq!(value.as_object().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn sanitize_sampling_for_prefill_forces_length_capped_finish() {
+        let mut request = ProtoGenerateRequest::Vllm(Box::new(vllm::GenerateRequest {
+            sampling_params: Some(vllm::SamplingParams {
+                max_tokens: Some(128),
+                min_tokens: 16,
+                n: 4,
+                stop: vec!["</s>".to_string()],
+                stop_token_ids: vec![2],
+                ignore_eos: false,
+                ..Default::default()
+            }),
+            ..Default::default()
+        }));
+        request.sanitize_sampling_for_prefill(1);
+        let ProtoGenerateRequest::Vllm(req) = request else {
+            panic!("expected vLLM request");
+        };
+        let params = req.sampling_params.unwrap();
+        assert_eq!(params.max_tokens, Some(1));
+        assert_eq!(params.min_tokens, 0);
+        assert_eq!(params.n, 1);
+        assert!(params.stop.is_empty());
+        assert!(params.stop_token_ids.is_empty());
+        assert!(params.ignore_eos);
+    }
+
+    #[test]
+    fn sampling_n_defaults_to_one() {
+        let unset = ProtoGenerateRequest::Vllm(Box::default());
+        assert_eq!(unset.sampling_n(), 1);
+
+        let zero = ProtoGenerateRequest::Vllm(Box::new(vllm::GenerateRequest {
+            sampling_params: Some(vllm::SamplingParams {
+                n: 0,
+                ..Default::default()
+            }),
+            ..Default::default()
+        }));
+        assert_eq!(zero.sampling_n(), 1);
+
+        let four = ProtoGenerateRequest::Vllm(Box::new(vllm::GenerateRequest {
+            sampling_params: Some(vllm::SamplingParams {
+                n: 4,
+                ..Default::default()
+            }),
+            ..Default::default()
+        }));
+        assert_eq!(four.sampling_n(), 4);
+    }
+
+    #[test]
+    fn kv_transfer_params_json_request_roundtrip() {
+        let mut request = ProtoGenerateRequest::Vllm(Box::default());
+        request.set_kv_transfer_params_json(NIXL_PREFILL_KV_PARAMS.to_string());
+        let ProtoGenerateRequest::Vllm(req) = request else {
+            panic!("expected vLLM request");
+        };
+        assert_eq!(
+            req.kv_transfer_params_json.as_deref(),
+            Some(NIXL_PREFILL_KV_PARAMS)
+        );
+    }
+
+    #[test]
+    fn kv_transfer_params_json_complete_accessor_filters_empty() {
+        use crate::routers::grpc::proto_wrapper::ProtoGenerateComplete;
+
+        let complete = ProtoGenerateComplete::Vllm(vllm::GenerateComplete {
+            kv_transfer_params_json: Some(r#"{"do_remote_prefill":true}"#.to_string()),
+            ..Default::default()
+        });
+        assert_eq!(
+            complete.kv_transfer_params_json(),
+            Some(r#"{"do_remote_prefill":true}"#)
+        );
+
+        let empty = ProtoGenerateComplete::Vllm(vllm::GenerateComplete {
+            kv_transfer_params_json: Some(String::new()),
+            ..Default::default()
+        });
+        assert_eq!(empty.kv_transfer_params_json(), None);
+
+        let unset = ProtoGenerateComplete::Vllm(vllm::GenerateComplete::default());
+        assert_eq!(unset.kv_transfer_params_json(), None);
     }
 }

--- a/model_gateway/src/routers/grpc/proto_wrapper.rs
+++ b/model_gateway/src/routers/grpc/proto_wrapper.rs
@@ -454,23 +454,26 @@ impl ProtoGenerateRequest {
         matches!(self, Self::TokenSpeed(_))
     }
 
-    /// Set max_tokens for prefill-only execution (vLLM PD mode).
-    /// The prefill request uses max_tokens=1 to trigger KV cache computation
-    /// without generating unnecessary tokens.
-    pub fn set_max_tokens_for_prefill(&mut self, max_tokens: u32) {
+    /// Sanitize sampling params for the prefill-only leg (vLLM PD mode).
+    /// max_tokens=1 computes KV without generating; min_tokens is cleared so the
+    /// engine accepts it; n=1 so the prefill returns a single kv_transfer_params dict.
+    /// Stop criteria are cleared and EOS ignored so the leg always finishes
+    /// length-capped — vLLM < 0.20 returns the NIXL handoff only for that status.
+    pub fn sanitize_sampling_for_prefill(&mut self, max_tokens: u32) {
         match self {
             Self::Vllm(req) => {
-                if let Some(ref mut params) = req.sampling_params {
-                    params.max_tokens = Some(max_tokens);
-                } else {
-                    req.sampling_params = Some(vllm::SamplingParams {
-                        max_tokens: Some(max_tokens),
-                        ..Default::default()
-                    });
-                }
+                let params = req.sampling_params.get_or_insert_with(Default::default);
+                params.max_tokens = Some(max_tokens);
+                params.min_tokens = 0;
+                params.n = 1;
+                params.stop.clear();
+                params.stop_token_ids.clear();
+                params.ignore_eos = true;
             }
             Self::Sglang(_) | Self::Trtllm(_) | Self::Mlx(_) | Self::TokenSpeed(_) => {
-                tracing::warn!("set_max_tokens_for_prefill called on non-vLLM request, ignoring");
+                tracing::warn!(
+                    "sanitize_sampling_for_prefill called on non-vLLM request, ignoring"
+                );
             }
         }
     }
@@ -529,6 +532,30 @@ impl ProtoGenerateRequest {
             }
             Self::Sglang(_) | Self::Trtllm(_) | Self::Mlx(_) | Self::TokenSpeed(_) => {
                 tracing::warn!("set_kv_transfer_params called on non-vLLM request, ignoring");
+            }
+        }
+    }
+
+    /// Number of parallel samples requested (vLLM only; 1 when unset).
+    pub fn sampling_n(&self) -> u32 {
+        match self {
+            Self::Vllm(req) => req
+                .sampling_params
+                .as_ref()
+                .map(|p| p.n)
+                .filter(|&n| n > 0)
+                .unwrap_or(1),
+            Self::Sglang(_) | Self::Trtllm(_) | Self::Mlx(_) | Self::TokenSpeed(_) => 1,
+        }
+    }
+
+    /// Set opaque connector KV-transfer params as JSON (vLLM only).
+    /// Passed verbatim to the engine (NIXL handoff, etc.).
+    pub fn set_kv_transfer_params_json(&mut self, json: String) {
+        match self {
+            Self::Vllm(req) => req.kv_transfer_params_json = Some(json),
+            Self::Sglang(_) | Self::Trtllm(_) | Self::Mlx(_) | Self::TokenSpeed(_) => {
+                tracing::warn!("set_kv_transfer_params_json called on non-vLLM request, ignoring");
             }
         }
     }
@@ -1048,6 +1075,17 @@ impl ProtoGenerateComplete {
                 .kv_transfer_params
                 .as_ref()
                 .map(|params| (params.remote_host.clone(), params.remote_port)),
+            Self::Sglang(_) | Self::Trtllm(_) | Self::Mlx(_) | Self::TokenSpeed(_) => None,
+        }
+    }
+
+    /// Get opaque connector KV-transfer params JSON returned by the engine (vLLM only).
+    pub fn kv_transfer_params_json(&self) -> Option<&str> {
+        match self {
+            Self::Vllm(c) => c
+                .kv_transfer_params_json
+                .as_deref()
+                .filter(|s| !s.is_empty()),
             Self::Sglang(_) | Self::Trtllm(_) | Self::Mlx(_) | Self::TokenSpeed(_) => None,
         }
     }

--- a/model_gateway/src/routers/grpc/regular/stages/generate/request_building.rs
+++ b/model_gateway/src/routers/grpc/regular/stages/generate/request_building.rs
@@ -57,11 +57,16 @@ impl PipelineStage for GenerateRequestBuildingStage {
             ClientSelection::Dual { prefill, .. } => prefill,
         };
 
-        // Build generate request
-        let request_id = generate_request
-            .rid
-            .clone()
-            .unwrap_or_else(|| format!("gen-{}", Uuid::now_v7()));
+        // Build generate request. PD retries re-run this stage, and a NIXL-tagged
+        // prefill keeps the request_id alive on the worker until the KV lease
+        // expires, so client rids get a unique per-attempt engine id in PD mode.
+        let request_id = match generate_request.rid.clone() {
+            Some(rid) if matches!(clients, ClientSelection::Dual { .. }) => {
+                format!("{rid}-{}", Uuid::now_v7())
+            }
+            Some(rid) => rid,
+            None => format!("gen-{}", Uuid::now_v7()),
+        };
 
         // Build proto request using centralized dispatch
         let mut proto_request = builder_client

--- a/model_gateway/src/worker/mod.rs
+++ b/model_gateway/src/worker/mod.rs
@@ -47,5 +47,5 @@ pub use sampling_defaults::DEFAULT_SAMPLING_PARAMS_LABEL;
 pub use service::WorkerService;
 pub use worker::{
     AttachedBody, BasicWorker, ConnectionMode, RuntimeType, Worker, WorkerLoadGuard, WorkerType,
-    DEFAULT_BOOTSTRAP_PORT, MOONCAKE_CONNECTOR,
+    DEFAULT_BOOTSTRAP_PORT, MOONCAKE_CONNECTOR, NIXL_CONNECTOR,
 };

--- a/model_gateway/src/worker/worker.rs
+++ b/model_gateway/src/worker/worker.rs
@@ -35,6 +35,9 @@ pub const DEFAULT_BOOTSTRAP_PORT: u16 = 8998;
 /// vLLM Mooncake KV connector name
 pub const MOONCAKE_CONNECTOR: &str = "MooncakeConnector";
 
+/// vLLM NIXL KV connector name
+pub const NIXL_CONNECTOR: &str = "NixlConnector";
+
 pub struct WorkerRoutingKeyLoad {
     url: String,
     active_routing_keys: dashmap::DashMap<String, usize>,


### PR DESCRIPTION
## Description

### Problem

NIXL PD over the gRPC path never transfers KV cache — the decode worker silently recomputes the full prefill, making PD strictly worse than a single worker (it adds a serialized prefill pass whose output is discarded). The router assumed NIXL uses "automatic prefix matching" across engines; no such mechanism exists in vLLM's `NixlConnector`:

- The router builds `kv_transfer_params` only when the prefill worker's connector is Mooncake (`request_execution.rs`), never sets `do_remote_decode=true` on the prefill request, and drains/discards the prefill response — so the prefill engine frees its KV blocks immediately and returns no handoff.
- The proto `KvTransferParams` message only carries Mooncake's `remote_host`/`remote_port`; it physically cannot represent the NIXL handoff (`do_remote_prefill`, `remote_block_ids`, `remote_engine_id`, `tp_size`, ...).
- The servicer reduces `kv_transfer_params` to host/port in both directions, dropping everything NIXL needs.
- With no params, `NixlConnector.get_num_new_matched_tokens` returns `(0, False)` and the decode engine computes the prompt locally. The throughput stats confirm it: decode logs full prompt-token processing; the prefill worker's 1-token output is discarded.

This went unnoticed because output-correctness tests cannot catch it — decode recomputes and still answers correctly. The e2e PD fixture also launched vLLM workers without any `--kv-transfer-config` (lost in a worker.py refactor after #293), so CI never exercised a connector at all.

### Solution

Implement the standard NIXL proxy relay (same recipe as vLLM's `toy_proxy_server.py`), with `kv_transfer_params` passed opaquely end-to-end:

1. **Tag**: the router tags the NIXL prefill request with `{"do_remote_decode": true, "do_remote_prefill": false}` so the prefill engine pins its KV blocks and returns the handoff params.
2. **Harvest**: the router reads the `kv_transfer_params` JSON from the prefill `Complete` frame instead of discarding it.
3. **Relay**: the params are forwarded verbatim into the decode request; decode pulls the blocks over NIXL.

The wire format is a new opaque passthrough field (`optional string kv_transfer_params_json`) on `GenerateRequest` (field 8) and `GenerateComplete` (field 12). Unknown-field semantics make every router/servicer version-skew combination degrade to today's behavior (with an explicit router warn) instead of breaking, and the format is version-proof as vLLM's NIXL keys evolve. The legacy typed `KvTransferParams` stays as a validated Mooncake fallback; Mooncake's wire behavior is unchanged.

Edge cases handled (found via adversarial review against the vLLM source):

- **Prefill-leg sanitization**: `min_tokens` is reset (vLLM rejects `min_tokens > max_tokens` once `max_tokens=1`) and `n=1` (parallel sampling would return per-child handoff dicts).
- **`n>1` requests skip the relay entirely**: the NIXL handoff is single-consumer — with `n>1` every fan-out child on decode pulls the same blocks and the first completion notification frees the prefill blocks under its siblings (silent KV corruption). Decode recomputes locally for `n>1`, which is the previous (correct) behavior.
- **`/generate` retries**: client-supplied `rid` now gets a per-attempt engine id in PD mode — a NIXL-tagged prefill keeps the request id alive on the worker until the KV lease expires, and re-sending the same id on retry trips vLLM's duplicate-request assert (EngineCore crash).
- **Pre-admission decode failures**: the servicer best-effort calls `notify_kv_transfer_request_rejected` so prefill blocks free immediately instead of waiting out the 30s NIXL lease (guarded with `getattr` for vLLM releases without the hook).
- Same request id on both legs is kept (load-bearing for NIXL P/D correlation on vLLM < 0.13).

## Changes

- `crates/grpc_client/proto/vllm_engine.proto`: add `kv_transfer_params_json` to `GenerateRequest` (8) and `GenerateComplete` (12); deprecate the typed message in comments. Release `smg-grpc-proto` 0.4.9.
- `model_gateway` gRPC router: `KvConnectorMode` (Mooncake / Nixl / Passthrough) derived from prefill worker metadata; tag–harvest–relay for NIXL; Mooncake injection unchanged; warn-once when PD runs with no detected connector; delete all "automatic prefix matching" comments; unit tests.
- `grpc_servicer`: new `vllm/kv_transfer.py` (JSON-first request decode with typed fallback, opaque outbound encode with legacy host/port mirror); params reach the engine via `SamplingParams.extra_args["kv_transfer_params"]`; rejection notification; engine-free unit tests wired into the `python-unit-tests` CI job. Release `smg-grpc-servicer` 0.5.4 (requires `smg-grpc-proto>=0.4.9`).
- `e2e_test`: restore NixlConnector `--kv-transfer-config` + unique `VLLM_NIXL_SIDE_CHANNEL_PORT` for vLLM PD workers (restores #293, lost in a refactor); new `test_pd_nixl.py` asserting the router relayed params and the decode worker performed the NIXL handshake — assertions that catch this bug class, unlike output-correctness tests.
- `docs`: replace the "automatic prefix matching / transparent transfer" description with the actual mechanism; document side-channel host/port reachability and how to verify transfer.

## Test Plan

- `cargo clippy --all-targets` clean; `cargo test -p smg --lib`: 1007 passed (includes new tests for connector-mode mapping, prefill sanitization, JSON field round-trips).
- `pytest grpc_servicer/tests`: 16 passed (JSON precedence/validation, int fidelity through the JSON round-trip incl. `remote_block_ids`, legacy mirror rules). Now runs in the `python-unit-tests` CI job.
- New GPU e2e `e2e_test/router/test_pd_nixl.py` (runs in `e2e-2gpu-pd`, vLLM leg): sends prefix-cache-defeating prompts through the PD gateway, then asserts (1) the router log shows `relaying prefill kv_transfer_params` and no `prefill returned no kv_transfer_params`, and (2) a worker log shows the NIXL handshake (`Transfer plan` on vLLM ≥ 0.20, `NIXL compatibility check passed` on 0.19).
- Mooncake regression: existing `test_pd_mmlu.py` coverage; the Mooncake wire path is byte-identical.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * JSON-based KV-transfer parameters, explicit NIXL and Mooncake KV-cache transfer flows, per-attempt request IDs, and NIXL connector made available for configuration.

* **Documentation**
  * Clarified PD disaggregation flow, explicit KV-transfer coordination, and NIXL setup/troubleshooting guidance.

* **Tests**
  * New unit tests for KV-transfer parsing/serialization and new end-to-end NIXL KV-transfer tests.

* **Chores**
  * Package version bumps and CI extended to run additional servicer unit tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->