### PR TITLE
ci(claude): switch PR review workflow to claude-fable-5

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -192,7 +192,7 @@ jobs:
                Do NOT approve on "synchronize" (incremental) reviews — only
                full reviews have enough context to approve.
           claude_args: |
-            --model claude-opus-4-6
+            --model claude-fable-5
             --max-turns 50
             --allowedTools "Read,Glob,Grep,Bash,Agent,Skill,ToolSearch,TaskCreate,TaskUpdate,TaskGet,mcp__github_inline_comment__create_inline_comment"
           show_full_output: true
@@ -331,7 +331,7 @@ jobs:
         with:
           anthropic_api_key: ${{ env.ANTHROPIC_API_KEY }}
           claude_args: |
-            --model claude-opus-4-6
+            --model claude-fable-5
             --max-turns 30
             --allowedTools "Read,Glob,Grep,Bash,Agent,Skill,ToolSearch,TaskCreate,TaskUpdate,TaskGet,mcp__github_inline_comment__create_inline_comment"
           plugins: "pr-review-toolkit@claude-plugins-official"


### PR DESCRIPTION
## Description

### Problem

The Claude PR review workflow pins `--model claude-opus-4-6` in both of its jobs, so automated reviews and `@claude` mention responses run on an older model.

### Solution

Point both jobs at `claude-fable-5` (Fable 5, the current top-tier model). No other workflow behavior changes.

## Changes

- `.github/workflows/claude-code-review.yml`: replace `--model claude-opus-4-6` with `--model claude-fable-5` in the `review` job (auto PR review) and the `respond` job (`@claude` mentions) — 2 lines.

## Test Plan

- Workflow YAML parse check passes (`ruby -ryaml` load succeeds).
- `cargo +nightly fmt --all` leaves the tree unchanged; this PR touches no Rust code.
- This PR exercises the change itself: `pull_request` runs use the workflow from the merge ref, so the Claude review of this very PR runs on `claude-fable-5` — verify the model and a successful review in this PR's "Claude PR Review" run and its "Review summary" step.
- Cost note: Fable 5 is $10/$50 per MTok vs Opus 4.6's $5/$25, so expect roughly 2× per-review cost; the Usage table in each run's step summary tracks actuals.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes (not run — CI-only YAML change, no Rust modified)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This pull request contains no user-visible changes. It updates internal configuration parameters for automated development tools and does not affect end-user functionality or features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->