### PR TITLE
revert: ci(claude): switch PR review workflow to claude-fable-5

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -192,7 +192,7 @@ jobs:
                Do NOT approve on "synchronize" (incremental) reviews — only
                full reviews have enough context to approve.
           claude_args: |
-            --model claude-fable-5
+            --model claude-opus-4-6
             --max-turns 50
             --allowedTools "Read,Glob,Grep,Bash,Agent,Skill,ToolSearch,TaskCreate,TaskUpdate,TaskGet,mcp__github_inline_comment__create_inline_comment"
           show_full_output: true
@@ -331,7 +331,7 @@ jobs:
         with:
           anthropic_api_key: ${{ env.ANTHROPIC_API_KEY }}
           claude_args: |
-            --model claude-fable-5
+            --model claude-opus-4-6
             --max-turns 30
             --allowedTools "Read,Glob,Grep,Bash,Agent,Skill,ToolSearch,TaskCreate,TaskUpdate,TaskGet,mcp__github_inline_comment__create_inline_comment"
           plugins: "pr-review-toolkit@claude-plugins-official"


### PR DESCRIPTION
## Description

### Problem

#1623 moved the Claude PR review workflow (auto-review + `@claude` responder) from `claude-opus-4-6` to `claude-fable-5`. The review run on #1623 itself failed, and we're reverting to the known-good model.

Context for the record: that failure was the action's GitHub-app token exchange rejecting the run with `401 - Workflow validation failed. The workflow file must … have identical content to the version on the repository's default branch` — the expected outcome for any PR that modifies the Claude workflow file itself, so `claude-fable-5` was never actually exercised. Reverting regardless, per maintainer decision; we can re-attempt the model bump deliberately later.

### Solution

Revert commit 905a7efe (#1623), restoring `--model claude-opus-4-6` in both jobs.

## Changes

- `.github/workflows/claude-code-review.yml`: `--model claude-fable-5` → `--model claude-opus-4-6` in the `review` and `respond` jobs (2 lines; exact inverse of #1623).

## Test Plan

- `git diff e030ec10 HEAD -- .github/workflows/claude-code-review.yml` is empty — the file is byte-identical to main as it was before #1623.
- Workflow YAML parse check passes.
- No Rust code touched; `cargo +nightly fmt --all` verified clean on this tree earlier in the session.
- Heads-up: this PR's own "Claude PR Review" run will fail with the same expected 401 workflow-file-mismatch error (it modifies the workflow file again). Judge this PR by the other CI checks; the review workflow returns to normal once merged.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes (not run — CI-only YAML revert, no Rust modified)
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD automation tooling to use an enhanced model for code review processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->