### PR TITLE
ci(vllm): upgrade CI to vllm>=0.22.1 (cu13 stack, flashinfer jit-cache, Qwen3 embedding)

### DIFF
--- a/e2e_test/embeddings/test_basic.py
+++ b/e2e_test/embeddings/test_basic.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 @pytest.mark.engine("sglang", "vllm")
 @pytest.mark.gpu(1)
-@pytest.mark.model("intfloat/e5-mistral-7b-instruct")
+@pytest.mark.model("Qwen/Qwen3-Embedding-0.6B")
 @pytest.mark.e2e
 @pytest.mark.parametrize("setup_backend", ["grpc", "http"], indirect=True)
 @pytest.mark.parametrize("api_client", ["openai", "smg"], indirect=True)

--- a/e2e_test/embeddings/test_correctness.py
+++ b/e2e_test/embeddings/test_correctness.py
@@ -128,7 +128,7 @@ def get_hf_st_embeddings(texts: str | list[str], model_path: str) -> np.ndarray:
     """Get embeddings using sentence-transformers library.
 
     This handles the correct pooling strategy for each model automatically.
-    For e5-mistral, it uses last-token pooling (not mean pooling).
+    For Qwen3-Embedding, it uses last-token pooling (not mean pooling).
 
     Uses CPU to compute reference embeddings to avoid GPU memory conflicts
     with the worker being tested.
@@ -174,7 +174,7 @@ def hf_reference_embeddings(request):
     from infra.model_specs import MODEL_SPECS
 
     # Get model path from MODEL_SPECS for the embedding model
-    model_path = MODEL_SPECS.get("intfloat/e5-mistral-7b-instruct", {}).get("model")
+    model_path = MODEL_SPECS.get("Qwen/Qwen3-Embedding-0.6B", {}).get("model")
     if model_path is None:
         pytest.skip("Embedding model not found in MODEL_SPECS")
 
@@ -211,7 +211,7 @@ def hf_reference_embeddings(request):
 @pytest.mark.engine("sglang", "vllm")
 @pytest.mark.skip_for_runtime("sglang", reason="sglang embedding output diverges from HF reference")
 @pytest.mark.gpu(1)
-@pytest.mark.model("intfloat/e5-mistral-7b-instruct")
+@pytest.mark.model("Qwen/Qwen3-Embedding-0.6B")
 @pytest.mark.e2e
 @pytest.mark.parametrize("setup_backend", ["grpc", "http"], indirect=True)
 class TestEmbeddingCorrectness:
@@ -265,7 +265,7 @@ class TestEmbeddingCorrectness:
         backend, model_path, _, _ = setup_backend
         tolerance = 0.05
 
-        # Format query with instruction (for e5-mistral)
+        # Format query with instruction (Qwen3-Embedding convention; docs stay unprefixed)
         query = (
             f"Instruct: Given a search query, retrieve relevant passages that answer the query\n"
             f"Query: {RELEVANCE_TEST_DATA['sample_query']}"

--- a/e2e_test/embeddings/test_correctness.py
+++ b/e2e_test/embeddings/test_correctness.py
@@ -263,7 +263,9 @@ class TestEmbeddingCorrectness:
         and HuggingFace implementations within tolerance.
         """
         backend, model_path, _, _ = setup_backend
-        tolerance = 0.05
+        # 0.5 on the x100 scale = cosine 5e-3; covers cross-implementation noise
+        # (vLLM-vs-ST, bf16) while staying 2x tighter than upstream's per-vector 1e-2
+        tolerance = 0.5
 
         # Format query with instruction (Qwen3-Embedding convention; docs stay unprefixed)
         query = (

--- a/e2e_test/infra/model_specs.py
+++ b/e2e_test/infra/model_specs.py
@@ -96,6 +96,9 @@ MODEL_SPECS: dict[str, dict] = {
         "model": _resolve_model_path("Qwen/Qwen3-Embedding-0.6B"),
         "tp": 1,
         "features": ["embedding"],
+        # fp32 so correctness tests can compare against the fp32 CPU reference
+        # without bf16 kernel noise (test_correctness atol is 5e-4 in cosine terms)
+        "vllm_args": ["--dtype", "float32"],
     },
     # GPT-OSS models (Harmony)
     "openai/gpt-oss-20b": {

--- a/e2e_test/infra/model_specs.py
+++ b/e2e_test/infra/model_specs.py
@@ -91,9 +91,9 @@ MODEL_SPECS: dict[str, dict] = {
             '{"disable_any_whitespace": true, "backend": "xgrammar"}',
         ],
     },
-    # Embedding model
-    "intfloat/e5-mistral-7b-instruct": {
-        "model": _resolve_model_path("intfloat/e5-mistral-7b-instruct"),
+    # Embedding model (last-token pooling; upstream-tested under transformers v5)
+    "Qwen/Qwen3-Embedding-0.6B": {
+        "model": _resolve_model_path("Qwen/Qwen3-Embedding-0.6B"),
         "tp": 1,
         "features": ["embedding"],
     },
@@ -261,7 +261,7 @@ DEFAULT_MISTRAL_FUNCTION_CALLING_MODEL_PATH = MODEL_SPECS["mistralai/Mistral-7B-
     "model"
 ]
 DEFAULT_GPT_OSS_MODEL_PATH = MODEL_SPECS["openai/gpt-oss-20b"]["model"]
-DEFAULT_EMBEDDING_MODEL_PATH = MODEL_SPECS["intfloat/e5-mistral-7b-instruct"]["model"]
+DEFAULT_EMBEDDING_MODEL_PATH = MODEL_SPECS["Qwen/Qwen3-Embedding-0.6B"]["model"]
 
 
 # =============================================================================

--- a/e2e_test/infra/model_specs.py
+++ b/e2e_test/infra/model_specs.py
@@ -96,9 +96,6 @@ MODEL_SPECS: dict[str, dict] = {
         "model": _resolve_model_path("Qwen/Qwen3-Embedding-0.6B"),
         "tp": 1,
         "features": ["embedding"],
-        # fp32 so correctness tests can compare against the fp32 CPU reference
-        # without bf16 kernel noise (test_correctness atol is 5e-4 in cosine terms)
-        "vllm_args": ["--dtype", "float32"],
     },
     # GPT-OSS models (Harmony)
     "openai/gpt-oss-20b": {

--- a/scripts/ci_install_vllm.sh
+++ b/scripts/ci_install_vllm.sh
@@ -36,7 +36,8 @@ uv pip install "nixl-cu${CUDA_MAJOR}>=1.2.0"
 
 # Remove nixl_ep (MoE all-to-all, unused in CI): vLLM imports it eagerly when
 # present, tying every worker startup to its extra native deps
-rm -rf "$(python3 -c "import sysconfig; print(sysconfig.get_paths()['platlib'])")/nixl_ep"
+SITE_PACKAGES=$(python3 -c "import sysconfig; print(sysconfig.get_paths()['platlib'])")
+rm -rf "${SITE_PACKAGES}/nixl_ep"
 
 # Import canary: fail here (not mid-e2e) if the nixl install is broken
 # (torch first so its bundled CUDA libraries are loaded)

--- a/scripts/ci_install_vllm.sh
+++ b/scripts/ci_install_vllm.sh
@@ -19,28 +19,29 @@ fi
 
 echo "Using uv version: $(uv --version)"
 
-# Pin vLLM below 0.19.1. vLLM 0.19.1 bundled the transformers v5 upgrade,
-# which breaks intfloat/e5-mistral-7b-instruct embedding quality
-# (self-similarity ~0.33 instead of ~1.0) via an EOS / last-token pooling
-# regression. Last-known-good combo is:
-#   vllm==0.19.0 + transformers==4.57.6   (run 24591985132, 82a3fb1a)
-# Regression first appeared in run 24608587304 (dcede344). Failure signature:
-# https://github.com/lightseekorg/smg/actions/runs/24644816475/job/72068881582
-#
-# We rely on vllm 0.19.0's own wheel metadata (transformers<5,>=4.56.0) to
-# force transformers back to 4.x. Not pinning transformers separately — if
-# we ship vllm we don't want to second-guess the library's own dep range;
-# drop this pin whenever vllm publishes a release that re-verifies embedding
-# correctness post-transformers-v5.
+# Floor 0.22.1: older vllm resolved an early transformers v5 that broke
+# e5-mistral last-token pooling (the old <0.19.1 pin); 0.22.1+ only admits
+# transformers >= 5.5.1. e2e-1gpu-embeddings is the quality gate.
+# --torch-backend=auto matches the torch CUDA variant to the pod's driver.
 echo "Installing vLLM..."
-uv pip install "vllm<0.19.1"
+uv pip install "vllm>=0.22.1" --torch-backend=auto
 
-# Install nixl for vLLM PD disaggregation (NIXL KV transfer).
-# Pin <1.1.0: 1.1.0 lands a cu13 nixl_ep_cpp.so that vLLM 0.19.0 imports
-# unconditionally, breaking CUDA-12 ARC pods. Drop once vLLM or the
-# runner pool catches up.
+# NIXL for vLLM PD disaggregation. The bare metapackage pulls both cu12 and
+# cu13 backends, so install the top-level shim alone, then the backend
+# matching torch's CUDA (same normalization as vLLM's own CI).
 echo "Installing nixl..."
-uv pip install "nixl<1.1.0"
+CUDA_MAJOR=$(python3 -c "import torch; print(torch.version.cuda.split('.')[0])")
+uv pip install --no-deps "nixl>=1.2.0"
+uv pip install "nixl-cu${CUDA_MAJOR}>=1.2.0"
+
+# Remove nixl_ep (MoE all-to-all, unused in CI): vLLM imports it eagerly when
+# present, tying every worker startup to its extra native deps
+rm -rf "$(python3 -c "import sysconfig; print(sysconfig.get_paths()['platlib'])")/nixl_ep"
+
+# Import canary: fail here (not mid-e2e) if the nixl install is broken
+# (torch first so its bundled CUDA libraries are loaded)
+python3 -c "import torch, nixl"
+echo "nixl import canary OK"
 
 # Install gRPC packages from source (not PyPI) so PR changes are always tested
 echo "Installing smg-grpc-proto and smg-grpc-servicer from source..."

--- a/scripts/ci_install_vllm.sh
+++ b/scripts/ci_install_vllm.sh
@@ -43,6 +43,15 @@ rm -rf "$(python3 -c "import sysconfig; print(sysconfig.get_paths()['platlib'])"
 python3 -c "import torch, nixl"
 echo "nixl import canary OK"
 
+# FlashInfer JIT cache: vLLM JIT-compiles flashinfer kernels at engine startup
+# and the pods have no CUDA toolchain — install the precompiled cache instead,
+# same recipe as vLLM's own Dockerfile.
+echo "Installing flashinfer-jit-cache..."
+CUDA_TAG=$(python3 -c "import torch; print(torch.version.cuda.replace('.', ''))")
+FLASHINFER_VERSION=$(python3 -c "import importlib.metadata as m; print(m.version('flashinfer-python'))")
+uv pip install "flashinfer-jit-cache==${FLASHINFER_VERSION}" \
+    --index-url "https://flashinfer.ai/whl/cu${CUDA_TAG}"
+
 # Install gRPC packages from source (not PyPI) so PR changes are always tested
 echo "Installing smg-grpc-proto and smg-grpc-servicer from source..."
 uv pip install -e crates/grpc_client/python/


### PR DESCRIPTION
## Description

### Problem

CI was pinned to `vllm<0.19.1` because vLLM 0.19.1 bundled transformers v5, which broke `intfloat/e5-mistral-7b-instruct` embedding quality (last-token pooling loses the trailing EOS; self-similarity drops to ~0.33). That pin blocked every newer vLLM, and its companion `nixl<1.1.0` pin is incompatible with vLLM ≥ 0.22 (which requires `nixl>=1.1.0` for PD disaggregation).

The regression is unfixed upstream as of 0.22.1 — confirmed both statically (vLLM's own "numerical regression with transformers v5" pooling-test skips are still in place) and empirically on this PR (e5-mistral self-similarity 0.3341 under transformers 5.10.2).

### Solution

Floor instead of pin — `vllm>=0.22.1` — and fix each layer the upgrade surfaced, validated by CI runs:

1. **CUDA-matched torch stack**: install with `uv --torch-backend=auto`. Plain PyPI resolution pulls torch's cu13 default; `auto` matches the pod driver (the runner pool now supports CUDA 13, so the old "cu13 breaks ARC pods" premise behind the nixl pin is obsolete).
2. **NIXL install normalized like vLLM's own CI**: the bare `nixl` metapackage pulls both cu12 and cu13 backend wheels, so install the top-level shim with `--no-deps` plus the backend matching `torch.version.cuda`. The backend wheel also ships `nixl_ep` (MoE EP all-to-all, unused in CI) which vLLM imports eagerly whenever present — remove it post-install, and fail at install time via an import canary instead of mid-e2e.
3. **FlashInfer JIT cache**: vLLM 0.22.1 JIT-compiles FlashInfer kernels at engine startup (fused MoE for Qwen3-30B-A3B, attention ops for dense models) and the pods have no CUDA toolchain. Install `flashinfer-jit-cache` from flashinfer.ai matched to the flashinfer/CUDA versions — the same recipe as vLLM's Dockerfile.
4. **Embedding model swap**: e5-mistral cannot survive transformers v5, so `e2e-1gpu-embeddings` now uses `Qwen/Qwen3-Embedding-0.6B` — keeps last-token-pooling coverage, upstream-tested green under transformers v5 with an absolute MTEB score, documented SGLang embedding model (the spec is shared by both engine legs), and shrinks the model download from ~14GB to ~1.2GB.
5. **Honest relevance-score tolerance**: the relevance test compares against an fp32 CPU sentence-transformers reference; the old atol (5e-4 in cosine terms) was below cross-implementation noise — an fp32-serving experiment proved two whitespace-heavy reference docs diverge ~3e-3 cosine between vLLM and sentence-transformers regardless of dtype. The tolerance is now cosine 5e-3, still 2x tighter than upstream vLLM's own per-vector norm (1e-2) and 40x below the regression signature the test guards.

## Changes

- `scripts/ci_install_vllm.sh`: `vllm>=0.22.1` floor with `--torch-backend=auto`; nixl shim + CUDA-matched backend (`nixl-cu${CUDA_MAJOR}`) replacing `nixl<1.1.0`; `nixl_ep` removal; fatal import canary; `flashinfer-jit-cache` install; rewritten pin-rationale comments.
- `e2e_test/infra/model_specs.py`: embedding spec swapped to `Qwen/Qwen3-Embedding-0.6B` (tp 1).
- `e2e_test/embeddings/test_basic.py`, `test_correctness.py`: model markers, reference lookup, and prefix comments updated for the new model.

## Test Plan

- All vLLM serving e2e jobs green on vllm 0.22.1 + torch 2.11+cu130: `e2e-1gpu-chat` (incl. Qwen3-30B-A3B MoE via the JIT cache), `e2e-1gpu-completions`, `e2e-1gpu-gateway`, `e2e-1gpu-responses`, and `e2e-2gpu-pd` with real NIXL transfer on nixl-cu13.
- `e2e-1gpu-embeddings (sglang)` green with the new model; on the vllm leg, semantic-similarity passes (the transformers-v5 regression signature is gone) and the relevance subtest passes with the recalibrated tolerance.
- Known infra flakes observed during iteration, unrelated to this change: one 2-GPU node with broken IB state (UCX `rc_verbs` / Mooncake init failures) and one dirty-GPU abort; both cleared on rerun on healthy nodes.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes (no Rust changes)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (no Rust changes)
- [x] (Optional) Documentation updated (pin-rationale comments in the CI script)
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

