### PR TITLE
feat(smg): MeshAdapters composition root — register CRDT engines before gossip, start inbound sync

### DIFF
--- a/model_gateway/benches/wasm_middleware_latency.rs
+++ b/model_gateway/benches/wasm_middleware_latency.rs
@@ -79,6 +79,7 @@ fn bench_wasm_middleware_buffering(c: &mut Criterion) {
         concurrency_queue_tx: None,
         router_manager: None,
         mesh_handler: None,
+        mesh_adapters: None,
     });
 
     c.bench_function("wasm_middleware_pre_fix_latency", |b| {

--- a/model_gateway/src/config/mod.rs
+++ b/model_gateway/src/config/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod validation;
 
 pub use builder::*;
 pub use types::*;
+pub use validation::validate_mesh_server_name;
 
 #[derive(Debug, thiserror::Error)]
 pub enum ConfigError {

--- a/model_gateway/src/config/validation.rs
+++ b/model_gateway/src/config/validation.rs
@@ -2,6 +2,21 @@ use axum::http::HeaderName;
 
 use super::*;
 
+/// Validate a user-supplied mesh server name. The name keys rate-limit
+/// shards as `rl:{counter}:{name}`, so an empty name or one containing the
+/// separator would corrupt shard keys; rejecting at config time avoids a
+/// panic at mesh adapter construction during startup.
+pub fn validate_mesh_server_name(name: &str) -> ConfigResult<()> {
+    if name.is_empty() || name.contains(':') {
+        return Err(ConfigError::InvalidValue {
+            field: "mesh_server_name".to_string(),
+            value: name.to_string(),
+            reason: "must be non-empty and must not contain ':'".to_string(),
+        });
+    }
+    Ok(())
+}
+
 /// Configuration validator
 pub(crate) struct ConfigValidator;
 
@@ -783,6 +798,27 @@ impl ConfigValidator {
 mod tests {
     use super::*;
     use crate::worker::ConnectionMode;
+
+    #[test]
+    fn mesh_server_name_with_colon_is_rejected() {
+        assert!(matches!(
+            validate_mesh_server_name("node:a"),
+            Err(ConfigError::InvalidValue { ref field, .. }) if field == "mesh_server_name"
+        ));
+    }
+
+    #[test]
+    fn empty_mesh_server_name_is_rejected() {
+        assert!(matches!(
+            validate_mesh_server_name(""),
+            Err(ConfigError::InvalidValue { ref field, .. }) if field == "mesh_server_name"
+        ));
+    }
+
+    #[test]
+    fn valid_mesh_server_name_is_accepted() {
+        assert!(validate_mesh_server_name("node-a").is_ok());
+    }
 
     #[test]
     fn test_validate_regular_mode() {

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -4,10 +4,10 @@ use clap::{ArgAction, Parser, Subcommand, ValueEnum};
 use rand::{distr::Alphanumeric, Rng};
 use smg::{
     config::{
-        CircuitBreakerConfig, ConfigError, ConfigResult, DiscoveryConfig, HealthCheckConfig,
-        HistoryBackend, ManualAssignmentMode, MetricsConfig, OracleConfig, PolicyConfig,
-        PostgresConfig, RedisConfig, RetryConfig, RouterConfig, RoutingMode, SchemaConfig,
-        TokenizerCacheConfig, TraceConfig,
+        validate_mesh_server_name, CircuitBreakerConfig, ConfigError, ConfigResult,
+        DiscoveryConfig, HealthCheckConfig, HistoryBackend, ManualAssignmentMode, MetricsConfig,
+        OracleConfig, PolicyConfig, PostgresConfig, RedisConfig, RetryConfig, RouterConfig,
+        RoutingMode, SchemaConfig, TokenizerCacheConfig, TraceConfig,
     },
     observability::{
         metrics::PrometheusConfig,
@@ -861,17 +861,7 @@ impl CliArgs {
         }
 
         let self_name = if let Some(name) = &self.mesh_server_name {
-            // The name keys rate-limit shards as `rl:{counter}:{name}`, so an
-            // empty name or one containing the separator would corrupt shard
-            // keys; reject at config time instead of panicking at adapter
-            // construction.
-            if name.is_empty() || name.contains(':') {
-                return Err(ConfigError::InvalidValue {
-                    field: "mesh_server_name".to_string(),
-                    value: name.clone(),
-                    reason: "must be non-empty and must not contain ':'".to_string(),
-                });
-            }
+            validate_mesh_server_name(name)?;
             name.to_string()
         } else {
             let mut rng = rand::rng();
@@ -1480,48 +1470,4 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         shutdown_otel();
     }
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn mesh_args(extra: &[&str]) -> CliArgs {
-        let mut argv = vec!["smg", "--enable-mesh", "--mesh-host", "127.0.0.1"];
-        argv.extend_from_slice(extra);
-        CliArgs::try_parse_from(argv).expect("cli args parse")
-    }
-
-    #[test]
-    fn mesh_server_name_with_colon_is_rejected_at_config_time() {
-        let result = mesh_args(&["--mesh-server-name", "node:a"]).build_mesh_server_config();
-        assert!(
-            matches!(
-                result,
-                Err(ConfigError::InvalidValue { ref field, .. }) if field == "mesh_server_name"
-            ),
-            "':' in the name must be a config error, not a startup panic"
-        );
-    }
-
-    #[test]
-    fn empty_mesh_server_name_is_rejected_at_config_time() {
-        let result = mesh_args(&["--mesh-server-name", ""]).build_mesh_server_config();
-        assert!(
-            matches!(
-                result,
-                Err(ConfigError::InvalidValue { ref field, .. }) if field == "mesh_server_name"
-            ),
-            "empty name must be a config error"
-        );
-    }
-
-    #[test]
-    fn valid_mesh_server_name_is_accepted() {
-        let config = mesh_args(&["--mesh-server-name", "node-a"])
-            .build_mesh_server_config()
-            .expect("valid name passes config validation")
-            .expect("mesh is enabled");
-        assert_eq!(config.self_name, "node-a");
-    }
 }

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -861,6 +861,17 @@ impl CliArgs {
         }
 
         let self_name = if let Some(name) = &self.mesh_server_name {
+            // The name keys rate-limit shards as `rl:{counter}:{name}`, so an
+            // empty name or one containing the separator would corrupt shard
+            // keys; reject at config time instead of panicking at adapter
+            // construction.
+            if name.is_empty() || name.contains(':') {
+                return Err(ConfigError::InvalidValue {
+                    field: "mesh_server_name".to_string(),
+                    value: name.clone(),
+                    reason: "must be non-empty and must not contain ':'".to_string(),
+                });
+            }
             name.to_string()
         } else {
             let mut rng = rand::rng();
@@ -1469,4 +1480,48 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         shutdown_otel();
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mesh_args(extra: &[&str]) -> CliArgs {
+        let mut argv = vec!["smg", "--enable-mesh", "--mesh-host", "127.0.0.1"];
+        argv.extend_from_slice(extra);
+        CliArgs::try_parse_from(argv).expect("cli args parse")
+    }
+
+    #[test]
+    fn mesh_server_name_with_colon_is_rejected_at_config_time() {
+        let result = mesh_args(&["--mesh-server-name", "node:a"]).build_mesh_server_config();
+        assert!(
+            matches!(
+                result,
+                Err(ConfigError::InvalidValue { ref field, .. }) if field == "mesh_server_name"
+            ),
+            "':' in the name must be a config error, not a startup panic"
+        );
+    }
+
+    #[test]
+    fn empty_mesh_server_name_is_rejected_at_config_time() {
+        let result = mesh_args(&["--mesh-server-name", ""]).build_mesh_server_config();
+        assert!(
+            matches!(
+                result,
+                Err(ConfigError::InvalidValue { ref field, .. }) if field == "mesh_server_name"
+            ),
+            "empty name must be a config error"
+        );
+    }
+
+    #[test]
+    fn valid_mesh_server_name_is_accepted() {
+        let config = mesh_args(&["--mesh-server-name", "node-a"])
+            .build_mesh_server_config()
+            .expect("valid name passes config validation")
+            .expect("mesh is enabled");
+        assert_eq!(config.self_name, "node-a");
+    }
 }

--- a/model_gateway/src/mesh/mod.rs
+++ b/model_gateway/src/mesh/mod.rs
@@ -3,5 +3,7 @@
 //! and shutdown wiring added in later steps.
 
 pub mod adapters;
+pub mod wiring;
 
 pub use adapters::{RateLimitSyncAdapter, TreeDelta, TreeSyncAdapter, WorkerSyncAdapter};
+pub use wiring::MeshAdapters;

--- a/model_gateway/src/mesh/wiring.rs
+++ b/model_gateway/src/mesh/wiring.rs
@@ -17,18 +17,10 @@ use crate::worker::WorkerRegistry;
 /// Owns the started mesh sync adapters. Mesh on means every adapter here is
 /// constructed, its namespace registered, and its inbound loop running —
 /// mesh off is represented by the absence of the whole struct.
+#[derive(Debug)]
 pub struct MeshAdapters {
     worker: Arc<WorkerSyncAdapter>,
     rate_limit: Arc<RateLimitSyncAdapter>,
-}
-
-impl std::fmt::Debug for MeshAdapters {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("MeshAdapters")
-            .field("worker", &self.worker)
-            .field("rate_limit", &self.rate_limit)
-            .finish()
-    }
 }
 
 impl MeshAdapters {
@@ -105,7 +97,7 @@ mod tests {
         };
         adapters.worker().on_worker_changed("w1", &state);
 
-        for _ in 0..20 {
+        for _ in 0..100 {
             if registry.get_by_url("http://remote:8080").is_some() {
                 return;
             }

--- a/model_gateway/src/mesh/wiring.rs
+++ b/model_gateway/src/mesh/wiring.rs
@@ -1,0 +1,144 @@
+//! Composition root for the gateway's mesh sync adapters.
+//!
+//! [`MeshAdapters::start`] is the single call server startup makes to bring
+//! the CRDT bridge online: it registers each adapter's namespace with the
+//! right merge strategy, constructs the adapters against the gateway's
+//! registries, and starts their inbound sync loops. It must run before the
+//! mesh server's gossip starts so every remote op merges through its
+//! registered engine.
+
+use std::sync::Arc;
+
+use smg_mesh::{MergeStrategy, MeshKV};
+
+use super::adapters::{RateLimitSyncAdapter, WorkerSyncAdapter};
+use crate::worker::WorkerRegistry;
+
+/// Owns the started mesh sync adapters. Mesh on means every adapter here is
+/// constructed, its namespace registered, and its inbound loop running —
+/// mesh off is represented by the absence of the whole struct.
+pub struct MeshAdapters {
+    worker: Arc<WorkerSyncAdapter>,
+    rate_limit: Arc<RateLimitSyncAdapter>,
+}
+
+impl std::fmt::Debug for MeshAdapters {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MeshAdapters")
+            .field("worker", &self.worker)
+            .field("rate_limit", &self.rate_limit)
+            .finish()
+    }
+}
+
+impl MeshAdapters {
+    /// Register the `worker:` (last-writer-wins) and `rl:` (epoch-max-wins)
+    /// CRDT namespaces, construct the adapters, and start their inbound sync
+    /// loops. One call because the adapters' `start` methods are not
+    /// idempotent (each call spawns another subscription task).
+    ///
+    /// MUST be called before `MeshServer::start` spawns gossip: a remote op
+    /// arriving for an unregistered prefix would merge through the default
+    /// last-writer-wins engine with the wrong semantics.
+    ///
+    /// # Panics
+    ///
+    /// Panics if either prefix is already configured (double call) or if
+    /// `node_name` is empty or contains `':'` (the rate-limit shard-key
+    /// separator).
+    pub fn start(
+        mesh_kv: &MeshKV,
+        node_name: String,
+        worker_registry: Arc<WorkerRegistry>,
+    ) -> Arc<Self> {
+        let worker_ns = mesh_kv.configure_crdt_prefix("worker:", MergeStrategy::LastWriterWins);
+        let rl_ns = mesh_kv.configure_crdt_prefix("rl:", MergeStrategy::EpochMaxWins);
+        let worker = WorkerSyncAdapter::new(worker_ns, worker_registry);
+        let rate_limit = RateLimitSyncAdapter::new(rl_ns, node_name);
+        worker.start();
+        rate_limit.start();
+        Arc::new(Self { worker, rate_limit })
+    }
+
+    /// Worker sync adapter — outbound publish seam and tests.
+    pub fn worker(&self) -> &Arc<WorkerSyncAdapter> {
+        &self.worker
+    }
+
+    /// Rate-limit sync adapter — counter sync and aggregate reads for the
+    /// distributed rate-limit middleware.
+    pub fn rate_limit(&self) -> &Arc<RateLimitSyncAdapter> {
+        &self.rate_limit
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use smg_mesh::WorkerState;
+    use tokio::time::sleep;
+
+    use super::*;
+
+    fn started(mesh: &MeshKV) -> Arc<MeshAdapters> {
+        MeshAdapters::start(mesh, "node-a".into(), Arc::new(WorkerRegistry::new()))
+    }
+
+    #[tokio::test]
+    async fn start_wires_worker_inbound_end_to_end() {
+        let mesh = MeshKV::new("node-a".into());
+        let registry = Arc::new(WorkerRegistry::new());
+        let adapters = MeshAdapters::start(&mesh, "node-a".into(), registry.clone());
+
+        // A put through the adapter echoes back through the namespace
+        // subscription, exercising the registered prefix and the live
+        // inbound loop end to end.
+        let state = WorkerState {
+            worker_id: "w1".into(),
+            model_id: "llama-3".into(),
+            url: "http://remote:8080".into(),
+            health: true,
+            load: 0.0,
+            version: 1,
+            spec: vec![],
+        };
+        adapters.worker().on_worker_changed("w1", &state);
+
+        for _ in 0..20 {
+            if registry.get_by_url("http://remote:8080").is_some() {
+                return;
+            }
+            sleep(Duration::from_millis(10)).await;
+        }
+        panic!("inbound worker sync loop is not running");
+    }
+
+    #[tokio::test]
+    async fn rl_namespace_uses_epoch_max_wins() {
+        let mesh = MeshKV::new("node-a".into());
+        let adapters = started(&mesh);
+
+        // Under EpochMaxWins a lower-epoch write cannot rewind the shard;
+        // under a mis-registered LWW engine the later write would win and
+        // the aggregate would read 100.
+        adapters.rate_limit().sync_counter("global", 2, 5);
+        adapters.rate_limit().sync_counter("global", 1, 100);
+        assert_eq!(adapters.rate_limit().get_aggregate("global"), 5);
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "already configured")]
+    async fn start_panics_on_second_call() {
+        let mesh = MeshKV::new("node-a".into());
+        let _adapters = started(&mesh);
+        let _again = started(&mesh);
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "must not contain ':'")]
+    async fn start_panics_on_colon_node_name() {
+        let mesh = MeshKV::new("node-a".into());
+        let _ = MeshAdapters::start(&mesh, "node:a".into(), Arc::new(WorkerRegistry::new()));
+    }
+}

--- a/model_gateway/src/mesh/wiring.rs
+++ b/model_gateway/src/mesh/wiring.rs
@@ -52,13 +52,12 @@ impl MeshAdapters {
         Arc::new(Self { worker, rate_limit })
     }
 
-    /// Worker sync adapter — outbound publish seam and tests.
+    /// Worker sync adapter.
     pub fn worker(&self) -> &Arc<WorkerSyncAdapter> {
         &self.worker
     }
 
-    /// Rate-limit sync adapter — counter sync and aggregate reads for the
-    /// distributed rate-limit middleware.
+    /// Rate-limit sync adapter.
     pub fn rate_limit(&self) -> &Arc<RateLimitSyncAdapter> {
         &self.rate_limit
     }

--- a/model_gateway/src/server.rs
+++ b/model_gateway/src/server.rs
@@ -45,6 +45,7 @@ use wfaas::LoggingSubscriber;
 use crate::{
     app_context::AppContext,
     config::{RouterConfig, RoutingMode},
+    mesh::MeshAdapters,
     middleware::{self, AuthConfig, QueuedRequest},
     observability::{
         logging::{self, LoggingConfig},
@@ -80,6 +81,7 @@ pub struct AppState {
     pub concurrency_queue_tx: Option<mpsc::Sender<QueuedRequest>>,
     pub router_manager: Option<Arc<RouterManager>>,
     pub mesh_handler: Option<Arc<MeshServerHandler>>,
+    pub mesh_adapters: Option<Arc<MeshAdapters>>,
 }
 
 async fn parse_function_call(
@@ -1051,24 +1053,16 @@ pub async fn startup(config: ServerConfig) -> Result<(), Box<dyn std::error::Err
             (None, None)
         };
 
-    // Initialize mesh server if configured, it will return a handler for mesh management
-    let mesh_handler = if let Some(mesh_server_config) = &config.mesh_server_config {
-        // Create mesh server builder and build with stores
-        let (mesh_server, handler) = MeshServerBuilder::from(mesh_server_config).build();
-
-        #[expect(
-            clippy::disallowed_methods,
-            reason = "mesh server runs for the lifetime of the process; shutdown is handled by the mesh handler"
-        )]
-        spawn(async move {
-            if let Err(e) = mesh_server.start().await {
-                tracing::error!("Mesh server failed: {}", e);
-            }
-        });
-
-        Some(Arc::new(handler))
-    } else {
-        None
+    // Build the mesh server if configured. Starting gossip is deferred until
+    // MeshAdapters has registered the `worker:`/`rl:` CRDT namespaces below —
+    // a remote op arriving for an unregistered prefix would merge through the
+    // default last-writer-wins engine with the wrong semantics.
+    let (mesh_server, mesh_handler) = match &config.mesh_server_config {
+        Some(mesh_server_config) => {
+            let (server, handler) = MeshServerBuilder::from(mesh_server_config).build();
+            (Some(server), Some(Arc::new(handler)))
+        }
+        None => (None, None),
     };
 
     info!(
@@ -1089,6 +1083,27 @@ pub async fn startup(config: ServerConfig) -> Result<(), Box<dyn std::error::Err
         )
         .await?,
     );
+
+    // Register the CRDT namespaces and start the inbound sync adapters, then
+    // start gossip. Order matters: see the note at the mesh build above.
+    let mesh_adapters = mesh_handler.as_ref().map(|handler| {
+        MeshAdapters::start(
+            handler.mesh_kv(),
+            handler.self_name.clone(),
+            app_context.worker_registry.clone(),
+        )
+    });
+    if let Some(mesh_server) = mesh_server {
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "mesh server runs for the lifetime of the process; shutdown is handled by the mesh handler"
+        )]
+        spawn(async move {
+            if let Err(e) = mesh_server.start().await {
+                tracing::error!("Mesh server failed: {}", e);
+            }
+        });
+    }
 
     if config.prometheus_config.is_some() {
         app_context.inflight_tracker.start_sampler(20);
@@ -1288,11 +1303,9 @@ pub async fn startup(config: ServerConfig) -> Result<(), Box<dyn std::error::Err
         }
     }
 
-    // v1 mesh sync (set_mesh_sync, WorkerStateSubscriber, TreeStateSubscriber)
-    // is removed in this PR. State sync across mesh peers is not wired in this
-    // branch — v2 adapters in `model_gateway/src/mesh/adapters/` are built and
-    // tested but not yet started from `server.rs`. That wiring lands in a
-    // follow-up PR.
+    // v2 mesh adapters are constructed and started by `MeshAdapters::start`
+    // above (inbound sync live). Outbound publish (WorkerEvent -> mesh) lands
+    // in a follow-up PR.
 
     // Get mesh cluster state and port before moving mesh_handler into app_state
     let mesh_cluster_state = mesh_handler.as_ref().map(|h| h.state.clone());
@@ -1307,6 +1320,7 @@ pub async fn startup(config: ServerConfig) -> Result<(), Box<dyn std::error::Err
         concurrency_queue_tx: limiter.queue_tx.clone(),
         router_manager: Some(router_manager),
         mesh_handler,
+        mesh_adapters,
     });
     if let Some(service_discovery_config) = config.service_discovery_config {
         if service_discovery_config.enabled {

--- a/model_gateway/src/server.rs
+++ b/model_gateway/src/server.rs
@@ -1303,10 +1303,6 @@ pub async fn startup(config: ServerConfig) -> Result<(), Box<dyn std::error::Err
         }
     }
 
-    // v2 mesh adapters are constructed and started by `MeshAdapters::start`
-    // above (inbound sync live). Outbound publish (WorkerEvent -> mesh) lands
-    // in a follow-up PR.
-
     // Get mesh cluster state and port before moving mesh_handler into app_state
     let mesh_cluster_state = mesh_handler.as_ref().map(|h| h.state.clone());
     let mesh_port = config

--- a/model_gateway/tests/common/test_app.rs
+++ b/model_gateway/tests/common/test_app.rs
@@ -103,6 +103,7 @@ pub fn create_test_app(
         concurrency_queue_tx: None,
         router_manager: None,
         mesh_handler: None,
+        mesh_adapters: None,
     });
 
     // Configure request ID headers (use defaults if not specified)
@@ -145,6 +146,7 @@ pub fn create_test_app_with_context(
         concurrency_queue_tx: None,
         router_manager: None,
         mesh_handler: None,
+        mesh_adapters: None,
     });
 
     // Get config from the context

--- a/model_gateway/tests/wasm_test.rs
+++ b/model_gateway/tests/wasm_test.rs
@@ -193,6 +193,7 @@ async fn create_test_app_with_wasm() -> (axum::Router, Arc<AppContext>, TempDir)
         concurrency_queue_tx: None,
         router_manager: None,
         mesh_handler: None,
+        mesh_adapters: None,
     });
 
     let request_id_headers = vec!["x-request-id".to_string(), "x-correlation-id".to_string()];


### PR DESCRIPTION
## Description

### Problem

No mesh sync adapter runs in production: every `*Adapter::new` call is `#[cfg(test)]`-only, so the CRDT gossip machinery (#1570/#1586/#1592) moves data between mesh nodes but nothing in the gateway produces or consumes it. The `worker:`/`rl:` CRDT namespaces are never registered either — and server.rs spawns `mesh_server.start()` at build time, so even registering them later would race gossip: a remote op arriving for an unregistered prefix merges through the default last-writer-wins engine with the wrong semantics (`rl:` needs epoch-max-wins).

### Solution

Add **`MeshAdapters`** — a thin composition root (`mesh/wiring.rs`) that registers the `worker:` (LWW) and `rl:` (EpochMaxWins) namespaces, constructs the existing adapters against the gateway's registries, and starts their inbound sync loops in one call. server.rs builds the mesh server **without** starting it, calls `MeshAdapters::start` once the worker registry exists, and only then spawns gossip — engine registration always precedes remote traffic.

The detail adapters (`WorkerSyncAdapter`, `RateLimitSyncAdapter`, `TreeSyncAdapter`) are **unchanged** — this PR only calls their existing public APIs. Mesh-off is represented by the absence of the whole struct (one `Option` at the AppState level, no per-adapter fields).

## Changes

- **`model_gateway/src/mesh/wiring.rs`** (new): `MeshAdapters::start(mesh_kv, node_name, worker_registry)` + `worker()` / `rate_limit()` accessors (the seams for the follow-up outbound-publish and rate-limit-middleware PRs). Single `start` (no separate `new`) because the adapters' `start()` methods are not idempotent and duplicate prefix registration panics — double-construction fails fast at startup.
- **`model_gateway/src/server.rs`**: mesh build block no longer spawns; new block after `app_context` creation constructs `MeshAdapters` then spawns gossip; `AppState.mesh_adapters: Option<Arc<MeshAdapters>>`; stale "not yet started from server.rs" comment updated.
- Test/bench `AppState` literals gain `mesh_adapters: None`.

### Behavior changes

- **Inbound worker sync goes live**: remote `worker:` states now register workers on this node (inert in practice until the outbound PR makes nodes publish).
- A mesh `self_name` containing `:` now panics at startup (the rate-limit shard-key invariant surfacing at wiring time) — fail-fast by design.

## Test Plan

- `cargo test -p smg` — full suite green (mesh-off path: `mesh_server_config = None` ⇒ identical behavior to today).
- `cargo clippy -p smg --all-targets --all-features -- -D warnings` — clean.

New tests in `wiring.rs`:

- `start_wires_worker_inbound_end_to_end` — put through the adapter echoes back through the registered namespace into the WorkerRegistry (proves registration + live inbound loop).
- `rl_namespace_uses_epoch_max_wins` — `sync_counter(epoch=2, 5)` then `(epoch=1, 100)` aggregates to **5**; a mis-registered LWW engine would give 100 (observably pins the merge strategy).
- `start_panics_on_second_call` / `start_panics_on_colon_node_name` — fail-fast invariants.

Follow-up PR (outbound): registry `WorkerOrigin` tracking, mesh-id adoption, echo suppression, `WorkerEvent` → mesh publish loop, inbound tombstone → remove.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * New mesh adapters initialization integrated into gateway startup; mesh server spawn is deferred until adapters are started. App state now holds an optional mesh adapters handle.

* **Bug Fixes**
  * Mesh server name validation now rejects empty or invalid names (e.g., containing ':') during config build.

* **Tests**
  * Updated tests and benchmarks to populate the new state field and validate adapter and config behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->