### PR TITLE
fix(ci): use NVMe storage for H100 runner workspaces

### DIFF
--- a/scripts/k8s-runner-resources/README.md
+++ b/scripts/k8s-runner-resources/README.md
@@ -119,6 +119,16 @@ kubectl get pods -n actions-runner-system
 
 Each runner set should have a listener pod in `Running` state. Runner pods will be created on-demand when workflows target the corresponding `runs-on` label (matching `runnerScaleSetName` in each values file).
 
+## H100 Runner NVMe Storage
+
+The H100 runner scale-set values mount `/raid/actions-runner` from the host into each runner pod. Workspace, cache, temp, and Docker storage paths use `subPathExpr: $(POD_NAME)/...` so concurrent pods on the same node do not share mutable state.
+
+Because Kubernetes does not garbage collect `hostPath` contents when a pod is deleted, the H100 values also mount the parent NVMe path into the dind sidecar-style init container and use a `preStop` hook to remove `/runner-nvme/${POD_NAME:?}` during normal pod termination. This cleanup is best-effort; force deletion or node failure can still leave orphaned directories. Add host-level pruning if the cluster needs stronger cleanup guarantees.
+
+Do not copy this exact `/raid/actions-runner` setup to non-H100 runner values unless the target node pool has the same NVMe layout and enough free space. During Moirai validation, A10 nodes did not safely support this path.
+
+For the legacy `actions.summerwind.dev` `RunnerDeployment` controller, the generated dind lifecycle is controller-managed, so dind `preStop` hooks from the template may not survive into pods. Use the official GitHub ARC scale-set values above for this configuration, or validate any Summerwind-specific cleanup separately.
+
 ## Upgrading
 
 To update a runner set (e.g. after changing values):

--- a/scripts/k8s-runner-resources/runner-values-1-gpu-h100.yaml
+++ b/scripts/k8s-runner-resources/runner-values-1-gpu-h100.yaml
@@ -46,10 +46,16 @@ template:
 
     volumes:
       - name: work
-        emptyDir: {}
+        hostPath:
+          path: /raid/actions-runner
+          type: DirectoryOrCreate
       - name: model-cache
         persistentVolumeClaim:
           claimName: model-cache
+      - name: runner-nvme
+        hostPath:
+          path: /raid/actions-runner
+          type: DirectoryOrCreate
       - name: dshm
         emptyDir:
           medium: Memory
@@ -59,7 +65,9 @@ template:
       - name: dind-externals
         emptyDir: {}
       - name: docker-storage
-        emptyDir: {}
+        hostPath:
+          path: /raid/actions-runner
+          type: DirectoryOrCreate
 
     containers:
       - name: runner
@@ -71,6 +79,10 @@ template:
             value: unix:///var/run/docker.sock
           - name: RUNNER_WAIT_FOR_DOCKER_IN_SECONDS
             value: '120'
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
         resources:
           requests:
             cpu: "8"
@@ -84,12 +96,36 @@ template:
             mountPath: /dev/shm
           - name: work
             mountPath: /home/runner/_work
+            subPathExpr: $(POD_NAME)/_work
+          - name: runner-nvme
+            mountPath: /home/runner/.cache
+            subPathExpr: $(POD_NAME)/.cache
+          - name: runner-nvme
+            mountPath: /tmp
+            subPathExpr: $(POD_NAME)/tmp
           - name: dind-sock
             mountPath: /var/run
           - name: docker-storage
             mountPath: /var/lib/docker
+            subPathExpr: $(POD_NAME)/docker
 
     initContainers:
+      - name: prepare-runner-nvme
+        image: fra.ocir.io/idqj093njucb/docker:dind
+        command:
+          - sh
+          - -c
+          - mkdir -p /runner-nvme/${POD_NAME}/_work /runner-nvme/${POD_NAME}/.cache /runner-nvme/${POD_NAME}/tmp /runner-nvme/${POD_NAME}/docker /models/.locks /models/hub /models/hub/.locks && chown -R 1001:1001 /runner-nvme/${POD_NAME} && chown 1001:1001 /models/.locks /models/hub /models/hub/.locks && chmod 1777 /runner-nvme/${POD_NAME}/tmp /models/.locks /models/hub/.locks
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+        volumeMounts:
+          - mountPath: /runner-nvme
+            name: runner-nvme
+          - mountPath: /models
+            name: model-cache
       - name: init-dind-externals
         args:
           - '-r'
@@ -109,10 +145,21 @@ template:
         env:
           - name: DOCKER_GROUP_GID
             value: '123'
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
         image: fra.ocir.io/idqj093njucb/docker:dind
         restartPolicy: Always
         securityContext:
           privileged: true
+        lifecycle:
+          preStop:
+            exec:
+              command:
+                - sh
+                - -c
+                - rm -rf -- "/runner-nvme/${POD_NAME:?}"
         startupProbe:
           exec:
             command:
@@ -122,11 +169,15 @@ template:
           initialDelaySeconds: 0
           periodSeconds: 5
         volumeMounts:
+          - mountPath: /runner-nvme
+            name: runner-nvme
           - mountPath: /home/runner/_work
             name: work
+            subPathExpr: $(POD_NAME)/_work
           - mountPath: /var/run
             name: dind-sock
           - mountPath: /home/runner/externals
             name: dind-externals
           - name: docker-storage
             mountPath: /var/lib/docker
+            subPathExpr: $(POD_NAME)/docker

--- a/scripts/k8s-runner-resources/runner-values-2-gpu-h100.yaml
+++ b/scripts/k8s-runner-resources/runner-values-2-gpu-h100.yaml
@@ -46,10 +46,16 @@ template:
 
     volumes:
       - name: work
-        emptyDir: {}
+        hostPath:
+          path: /raid/actions-runner
+          type: DirectoryOrCreate
       - name: model-cache
         persistentVolumeClaim:
           claimName: model-cache
+      - name: runner-nvme
+        hostPath:
+          path: /raid/actions-runner
+          type: DirectoryOrCreate
       - name: dshm
         emptyDir:
           medium: Memory
@@ -59,7 +65,9 @@ template:
       - name: dind-externals
         emptyDir: {}
       - name: docker-storage
-        emptyDir: {}
+        hostPath:
+          path: /raid/actions-runner
+          type: DirectoryOrCreate
 
     containers:
       - name: runner
@@ -71,6 +79,10 @@ template:
             value: unix:///var/run/docker.sock
           - name: RUNNER_WAIT_FOR_DOCKER_IN_SECONDS
             value: '120'
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
         resources:
           requests:
             cpu: "16"
@@ -84,12 +96,36 @@ template:
             mountPath: /dev/shm
           - name: work
             mountPath: /home/runner/_work
+            subPathExpr: $(POD_NAME)/_work
+          - name: runner-nvme
+            mountPath: /home/runner/.cache
+            subPathExpr: $(POD_NAME)/.cache
+          - name: runner-nvme
+            mountPath: /tmp
+            subPathExpr: $(POD_NAME)/tmp
           - name: dind-sock
             mountPath: /var/run
           - name: docker-storage
             mountPath: /var/lib/docker
+            subPathExpr: $(POD_NAME)/docker
 
     initContainers:
+      - name: prepare-runner-nvme
+        image: fra.ocir.io/idqj093njucb/docker:dind
+        command:
+          - sh
+          - -c
+          - mkdir -p /runner-nvme/${POD_NAME}/_work /runner-nvme/${POD_NAME}/.cache /runner-nvme/${POD_NAME}/tmp /runner-nvme/${POD_NAME}/docker /models/.locks /models/hub /models/hub/.locks && chown -R 1001:1001 /runner-nvme/${POD_NAME} && chown 1001:1001 /models/.locks /models/hub /models/hub/.locks && chmod 1777 /runner-nvme/${POD_NAME}/tmp /models/.locks /models/hub/.locks
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+        volumeMounts:
+          - mountPath: /runner-nvme
+            name: runner-nvme
+          - mountPath: /models
+            name: model-cache
       - name: init-dind-externals
         args:
           - '-r'
@@ -109,10 +145,21 @@ template:
         env:
           - name: DOCKER_GROUP_GID
             value: '123'
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
         image: fra.ocir.io/idqj093njucb/docker:dind
         restartPolicy: Always
         securityContext:
           privileged: true
+        lifecycle:
+          preStop:
+            exec:
+              command:
+                - sh
+                - -c
+                - rm -rf -- "/runner-nvme/${POD_NAME:?}"
         startupProbe:
           exec:
             command:
@@ -122,11 +169,15 @@ template:
           initialDelaySeconds: 0
           periodSeconds: 5
         volumeMounts:
+          - mountPath: /runner-nvme
+            name: runner-nvme
           - mountPath: /home/runner/_work
             name: work
+            subPathExpr: $(POD_NAME)/_work
           - mountPath: /var/run
             name: dind-sock
           - mountPath: /home/runner/externals
             name: dind-externals
           - name: docker-storage
             mountPath: /var/lib/docker
+            subPathExpr: $(POD_NAME)/docker

--- a/scripts/k8s-runner-resources/runner-values-4-gpu-h100.yaml
+++ b/scripts/k8s-runner-resources/runner-values-4-gpu-h100.yaml
@@ -45,10 +45,16 @@ template:
 
     volumes:
       - name: work
-        emptyDir: {}
+        hostPath:
+          path: /raid/actions-runner
+          type: DirectoryOrCreate
       - name: model-cache
         persistentVolumeClaim:
           claimName: model-cache
+      - name: runner-nvme
+        hostPath:
+          path: /raid/actions-runner
+          type: DirectoryOrCreate
       - name: dshm
         emptyDir:
           medium: Memory
@@ -58,7 +64,9 @@ template:
       - name: dind-externals
         emptyDir: {}
       - name: docker-storage
-        emptyDir: {}
+        hostPath:
+          path: /raid/actions-runner
+          type: DirectoryOrCreate
 
     containers:
       - name: runner
@@ -70,6 +78,10 @@ template:
             value: unix:///var/run/docker.sock
           - name: RUNNER_WAIT_FOR_DOCKER_IN_SECONDS
             value: '120'
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
         resources:
           requests:
             cpu: "32"
@@ -83,12 +95,36 @@ template:
             mountPath: /dev/shm
           - name: work
             mountPath: /home/runner/_work
+            subPathExpr: $(POD_NAME)/_work
+          - name: runner-nvme
+            mountPath: /home/runner/.cache
+            subPathExpr: $(POD_NAME)/.cache
+          - name: runner-nvme
+            mountPath: /tmp
+            subPathExpr: $(POD_NAME)/tmp
           - name: dind-sock
             mountPath: /var/run
           - name: docker-storage
             mountPath: /var/lib/docker
+            subPathExpr: $(POD_NAME)/docker
 
     initContainers:
+      - name: prepare-runner-nvme
+        image: fra.ocir.io/idqj093njucb/docker:dind
+        command:
+          - sh
+          - -c
+          - mkdir -p /runner-nvme/${POD_NAME}/_work /runner-nvme/${POD_NAME}/.cache /runner-nvme/${POD_NAME}/tmp /runner-nvme/${POD_NAME}/docker /models/.locks /models/hub /models/hub/.locks && chown -R 1001:1001 /runner-nvme/${POD_NAME} && chown 1001:1001 /models/.locks /models/hub /models/hub/.locks && chmod 1777 /runner-nvme/${POD_NAME}/tmp /models/.locks /models/hub/.locks
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+        volumeMounts:
+          - mountPath: /runner-nvme
+            name: runner-nvme
+          - mountPath: /models
+            name: model-cache
       - name: init-dind-externals
         args:
           - '-r'
@@ -108,10 +144,21 @@ template:
         env:
           - name: DOCKER_GROUP_GID
             value: '123'
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
         image: fra.ocir.io/idqj093njucb/docker:dind
         restartPolicy: Always
         securityContext:
           privileged: true
+        lifecycle:
+          preStop:
+            exec:
+              command:
+                - sh
+                - -c
+                - rm -rf -- "/runner-nvme/${POD_NAME:?}"
         startupProbe:
           exec:
             command:
@@ -121,11 +168,15 @@ template:
           initialDelaySeconds: 0
           periodSeconds: 5
         volumeMounts:
+          - mountPath: /runner-nvme
+            name: runner-nvme
           - mountPath: /home/runner/_work
             name: work
+            subPathExpr: $(POD_NAME)/_work
           - mountPath: /var/run
             name: dind-sock
           - mountPath: /home/runner/externals
             name: dind-externals
           - name: docker-storage
             mountPath: /var/lib/docker
+            subPathExpr: $(POD_NAME)/docker


### PR DESCRIPTION
## Description

### Problem

H100 GitHub Actions runners can evict CI jobs when model downloads, workspaces, temp files, or Docker layer data consume the node boot volume. The live Moirai runners were fixed by moving heavy runner paths onto the local NVMe-backed `/raid/actions-runner` path and by preparing writable model cache lock directories.

### Solution

Persist the same H100-only storage layout in the ARC runner scale-set values. The H100 runner pods now use per-pod `subPathExpr` directories under `/raid/actions-runner` for workspace, cache, temp, and Docker storage, and an init container prepares ownership and model cache lock directories before the runner starts. The dind sidecar-style init container also gets a `preStop` hook that removes `/raid/actions-runner/<pod-name>` through the mounted parent path to avoid orphaning heavy hostPath directories after normal pod termination.

## Changes

- Update `runner-values-1-gpu-h100.yaml`, `runner-values-2-gpu-h100.yaml`, and `runner-values-4-gpu-h100.yaml`.
- Move `/home/runner/_work`, `/home/runner/.cache`, `/tmp`, and `/var/lib/docker` onto `/raid/actions-runner` with per-pod subdirectories.
- Add `POD_NAME` env wiring for `subPathExpr` in the runner and dind containers.
- Add `prepare-runner-nvme` init container to create/chown runner NVMe directories and prepare `/models/.locks`, `/models/hub`, and `/models/hub/.locks`.
- Mount the parent NVMe path into dind and add a `preStop` cleanup hook for `/runner-nvme/${POD_NAME:?}`.
- Leave non-H100 runner values unchanged because A10 nodes did not safely support the same `/raid/actions-runner` path during live validation.
- Document the H100 hostPath cleanup behavior, best-effort cleanup caveat, and the controller-specific Summerwind caveat in the runner resource README.

## Test Plan

Live validation in the Moirai dev cluster:

- Verified the 1-GPU H100 runner patch allowed model download to pass after the earlier `/models/.locks` permission failure.
- Verified live H100 runner pods mounted `/runner/_work` or `/home/runner/_work`, `/home/runner/.cache`, `/tmp`, and `/models` on the 28T NVMe volume.
- Verified `/models/.locks` and `/models/hub/.locks` are writable by the `runner` user.
- Verified `arc-runner-2-gpu-h100` and `arc-runner-4-gpu-h100` live pods started with the same NVMe mount pattern.
- Added cleanup for normal pod termination. This is still best-effort because Kubernetes `preStop` hooks do not run for hard node failure or force deletion, so host-level pruning can still be added later as defense in depth.

Local validation:

```bash
git diff --check origin/main...HEAD
```

Reviewed `scripts/k8s-runner-resources/README.md` to confirm the H100 NVMe cleanup note documents the hostPath garbage-collection risk and the Summerwind controller caveat.

```bash
ruby -ryaml -e 'ARGV.each { |f| data = YAML.load_file(f); spec = data.fetch("template").fetch("spec"); dind = spec.fetch("initContainers").find { |c| c["name"] == "dind" }; mounts = dind.fetch("volumeMounts").map { |m| [m["mountPath"], m["name"]] }.to_h; raise "#{f}: dind missing /runner-nvme mount" unless mounts["/runner-nvme"] == "runner-nvme"; cmd = dind.dig("lifecycle", "preStop", "exec", "command"); raise "#{f}: missing preStop cleanup" unless cmd&.join(" ")&.include?("/runner-nvme/${POD_NAME:?"); puts "OK #{File.basename(f)}" }' scripts/k8s-runner-resources/runner-values-1-gpu-h100.yaml scripts/k8s-runner-resources/runner-values-2-gpu-h100.yaml scripts/k8s-runner-resources/runner-values-4-gpu-h100.yaml
```

Rendered all three H100 values files with the ARC chart:

```bash
helm template 1-gpu-h100 oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set --namespace actions-runner-system -f scripts/k8s-runner-resources/runner-values-1-gpu-h100.yaml --set controllerServiceAccount.namespace=actions-runner-system --set controllerServiceAccount.name=arc-gha-runner-scale-set-controller --show-only templates/autoscalingrunnerset.yaml
helm template 2-gpu-h100 oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set --namespace actions-runner-system -f scripts/k8s-runner-resources/runner-values-2-gpu-h100.yaml --set controllerServiceAccount.namespace=actions-runner-system --set controllerServiceAccount.name=arc-gha-runner-scale-set-controller --show-only templates/autoscalingrunnerset.yaml
helm template 4-gpu-h100 oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set --namespace actions-runner-system -f scripts/k8s-runner-resources/runner-values-4-gpu-h100.yaml --set controllerServiceAccount.namespace=actions-runner-system --set controllerServiceAccount.name=arc-gha-runner-scale-set-controller --show-only templates/autoscalingrunnerset.yaml
```

<details>
<summary>Checklist</summary>

- [ ] `cargo +nightly fmt` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Switched runner pods to persistent host-path backed storage for work, cache and Docker data to improve retention and isolation.
  * Introduced per-pod directory scoping for work, caches and Docker storage to prevent conflicts across concurrent pods.
  * Injected pod identity into containers; init step now prepares per-pod directories and a lifecycle cleanup removes them on termination.
* **Documentation**
  * Added guidance describing the H100 runner NVMe storage layout, isolation behavior and cleanup considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->