### PR TITLE
feat(policies): add least_load load-balancing policy

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -13,6 +13,7 @@ pub enum PolicyType {
     RoundRobin,
     CacheAware,
     PowerOfTwo,
+    LeastLoad,
     Bucket,
     Manual,
     ConsistentHashing,
@@ -514,6 +515,10 @@ impl Router {
                 },
                 PolicyType::PowerOfTwo => ConfigPolicyConfig::PowerOfTwo {
                     load_check_interval_secs: 5,
+                },
+                PolicyType::LeastLoad => ConfigPolicyConfig::LeastLoad {
+                    load_check_interval_secs: 5,
+                    lambda: 1.5,
                 },
                 PolicyType::Bucket => ConfigPolicyConfig::Bucket {
                     balance_abs_threshold: self.balance_abs_threshold,

--- a/bindings/python/src/smg/router.py
+++ b/bindings/python/src/smg/router.py
@@ -25,6 +25,7 @@ def policy_from_str(policy_str: str | None) -> PolicyType:
         "round_robin": PolicyType.RoundRobin,
         "cache_aware": PolicyType.CacheAware,
         "power_of_two": PolicyType.PowerOfTwo,
+        "least_load": PolicyType.LeastLoad,
         "bucket": PolicyType.Bucket,
         "manual": PolicyType.Manual,
         "consistent_hashing": PolicyType.ConsistentHashing,
@@ -143,6 +144,8 @@ class Router:
               balance
             - PolicyType.PowerOfTwo: Select best of two random workers based on load
               (PD mode only)
+            - PolicyType.LeastLoad: Route to the worker with the lowest load score
+              (in-flight requests plus KV-cache pressure)
         host: Host address to bind the router server. Supports IPv4, IPv6 (e.g., ::,
             ::1), or 0.0.0.0 for all interfaces. Default: '0.0.0.0'
         port: Port number to bind the router server. Default: 3001

--- a/bindings/python/src/smg/router_args.py
+++ b/bindings/python/src/smg/router_args.py
@@ -15,6 +15,7 @@ COMMON_POLICY_CHOICES = [
     "round_robin",
     "cache_aware",
     "power_of_two",
+    "least_load",
     "manual",
     "consistent_hashing",
     "prefix_hash",

--- a/bindings/python/tests/test_router_config.py
+++ b/bindings/python/tests/test_router_config.py
@@ -339,6 +339,7 @@ class TestRouterConfigValidation:
         assert policy_from_str("round_robin") == PolicyType.RoundRobin
         assert policy_from_str("cache_aware") == PolicyType.CacheAware
         assert policy_from_str("power_of_two") == PolicyType.PowerOfTwo
+        assert policy_from_str("least_load") == PolicyType.LeastLoad
 
     def test_invalid_policy_enum_conversion(self):
         """Test invalid policy string to enum conversion."""

--- a/bindings/python/tests/test_startup_sequence.py
+++ b/bindings/python/tests/test_startup_sequence.py
@@ -75,12 +75,13 @@ class TestPolicyFromStr:
     def test_policy_conversion_in_startup(self):
         """Test policy conversion during startup sequence."""
         # Test all valid policies
-        policies = ["random", "round_robin", "cache_aware", "power_of_two"]
+        policies = ["random", "round_robin", "cache_aware", "power_of_two", "least_load"]
         expected_enums = [
             PolicyType.Random,
             PolicyType.RoundRobin,
             PolicyType.CacheAware,
             PolicyType.PowerOfTwo,
+            PolicyType.LeastLoad,
         ]
 
         for policy_str, expected_enum in zip(policies, expected_enums):

--- a/bindings/python/tests/test_validation.py
+++ b/bindings/python/tests/test_validation.py
@@ -318,7 +318,7 @@ class TestConfigurationValidation:
     def test_policy_validation(self):
         """Test policy configuration validation."""
         # Valid policies
-        valid_policies = ["random", "round_robin", "cache_aware", "power_of_two"]
+        valid_policies = ["random", "round_robin", "cache_aware", "power_of_two", "least_load"]
 
         for policy in valid_policies:
             args = RouterArgs(policy=policy)
@@ -327,7 +327,7 @@ class TestConfigurationValidation:
     def test_pd_policy_validation(self):
         """Test PD policy configuration validation."""
         # Valid PD policies
-        valid_policies = ["random", "round_robin", "cache_aware", "power_of_two"]
+        valid_policies = ["random", "round_robin", "cache_aware", "power_of_two", "least_load"]
 
         for prefill_policy in valid_policies:
             for decode_policy in valid_policies:

--- a/model_gateway/src/config/types.rs
+++ b/model_gateway/src/config/types.rs
@@ -373,6 +373,19 @@ pub enum PolicyConfig {
     #[serde(rename = "power_of_two")]
     PowerOfTwo { load_check_interval_secs: u64 },
 
+    /// Least-load policy: routes to the worker minimizing
+    /// `in_flight + lambda * k/(1-k)` — the real-time in-flight request count plus
+    /// a convex KV-cache pressure term from the load monitor.
+    /// See `policies/least_load.rs`.
+    #[serde(rename = "least_load")]
+    LeastLoad {
+        #[serde(default = "default_least_load_interval")]
+        load_check_interval_secs: u64,
+        /// KV-pressure weight (request-equivalents per unit of M/M/1 congestion).
+        #[serde(default = "default_least_load_lambda")]
+        lambda: f64,
+    },
+
     #[serde(rename = "bucket")]
     Bucket {
         /// Absolute load difference threshold for load balancing
@@ -445,6 +458,14 @@ fn default_manual_max_idle_secs() -> u64 {
     4 * 3600
 }
 
+fn default_least_load_interval() -> u64 {
+    10
+}
+
+fn default_least_load_lambda() -> f64 {
+    1.5
+}
+
 impl PolicyConfig {
     pub fn name(&self) -> &'static str {
         match self {
@@ -452,6 +473,7 @@ impl PolicyConfig {
             PolicyConfig::RoundRobin => "round_robin",
             PolicyConfig::CacheAware { .. } => "cache_aware",
             PolicyConfig::PowerOfTwo { .. } => "power_of_two",
+            PolicyConfig::LeastLoad { .. } => "least_load",
             PolicyConfig::Bucket { .. } => "bucket",
             PolicyConfig::Manual { .. } => "manual",
             PolicyConfig::ConsistentHashing => "consistent_hashing",

--- a/model_gateway/src/config/validation.rs
+++ b/model_gateway/src/config/validation.rs
@@ -323,6 +323,26 @@ impl ConfigValidator {
                     });
                 }
             }
+            PolicyConfig::LeastLoad {
+                load_check_interval_secs,
+                lambda,
+            } => {
+                if *load_check_interval_secs == 0 {
+                    return Err(ConfigError::InvalidValue {
+                        field: "load_check_interval_secs".to_string(),
+                        value: load_check_interval_secs.to_string(),
+                        reason: "Must be > 0".to_string(),
+                    });
+                }
+
+                if !lambda.is_finite() || *lambda < 0.0 {
+                    return Err(ConfigError::InvalidValue {
+                        field: "lambda".to_string(),
+                        value: lambda.to_string(),
+                        reason: "Must be finite and >= 0.0".to_string(),
+                    });
+                }
+            }
             PolicyConfig::Bucket {
                 balance_abs_threshold: _,
                 balance_rel_threshold,

--- a/model_gateway/src/main.rs
+++ b/model_gateway/src/main.rs
@@ -149,7 +149,7 @@ struct CliArgs {
 
     // ==================== Routing Policy ====================
     /// Load balancing policy to use
-    #[arg(long, default_value = "cache_aware", value_parser = ["random", "round_robin", "cache_aware", "power_of_two", "prefix_hash", "consistent_hashing", "manual", "bucket"], help_heading = "Routing Policy")]
+    #[arg(long, default_value = "cache_aware", value_parser = ["random", "round_robin", "cache_aware", "power_of_two", "least_load", "prefix_hash", "consistent_hashing", "manual", "bucket"], help_heading = "Routing Policy")]
     policy: String,
 
     /// Cache threshold (0.0-1.0) for cache-aware routing
@@ -214,11 +214,11 @@ struct CliArgs {
     decode: Vec<String>,
 
     /// Specific policy for prefill nodes in PD mode
-    #[arg(long, value_parser = ["random", "round_robin", "cache_aware", "power_of_two", "prefix_hash", "consistent_hashing", "manual", "bucket"], help_heading = "PD Disaggregation")]
+    #[arg(long, value_parser = ["random", "round_robin", "cache_aware", "power_of_two", "least_load", "prefix_hash", "consistent_hashing", "manual", "bucket"], help_heading = "PD Disaggregation")]
     prefill_policy: Option<String>,
 
     /// Specific policy for decode nodes in PD mode
-    #[arg(long, value_parser = ["random", "round_robin", "cache_aware", "power_of_two", "prefix_hash", "consistent_hashing", "manual", "bucket"], help_heading = "PD Disaggregation")]
+    #[arg(long, value_parser = ["random", "round_robin", "cache_aware", "power_of_two", "least_load", "prefix_hash", "consistent_hashing", "manual", "bucket"], help_heading = "PD Disaggregation")]
     decode_policy: Option<String>,
 
     /// Timeout in seconds for worker startup and registration
@@ -927,6 +927,10 @@ impl CliArgs {
             },
             "power_of_two" => PolicyConfig::PowerOfTwo {
                 load_check_interval_secs: 5,
+            },
+            "least_load" => PolicyConfig::LeastLoad {
+                load_check_interval_secs: 5,
+                lambda: 1.5,
             },
             "prefix_hash" => PolicyConfig::PrefixHash {
                 prefix_token_count: self.prefix_token_count,

--- a/model_gateway/src/policies/factory.rs
+++ b/model_gateway/src/policies/factory.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 
 use super::{
     BucketConfig, BucketPolicy, CacheAwareConfig, CacheAwarePolicy, ConsistentHashingPolicy,
-    LoadBalancingPolicy, ManualConfig, ManualPolicy, PowerOfTwoPolicy, PrefixHashConfig,
-    PrefixHashPolicy, RandomPolicy, RoundRobinPolicy,
+    LeastLoadPolicy, LoadBalancingPolicy, ManualConfig, ManualPolicy, PowerOfTwoPolicy,
+    PrefixHashConfig, PrefixHashPolicy, RandomPolicy, RoundRobinPolicy,
 };
 use crate::config::PolicyConfig;
 
@@ -19,6 +19,9 @@ impl PolicyFactory {
             PolicyConfig::Random => Arc::new(RandomPolicy::new()),
             PolicyConfig::RoundRobin => Arc::new(RoundRobinPolicy::new()),
             PolicyConfig::PowerOfTwo { .. } => Arc::new(PowerOfTwoPolicy::new()),
+            PolicyConfig::LeastLoad { lambda, .. } => {
+                Arc::new(LeastLoadPolicy::with_lambda(*lambda))
+            }
             PolicyConfig::CacheAware {
                 cache_threshold,
                 balance_abs_threshold,
@@ -81,6 +84,7 @@ impl PolicyFactory {
             "random" => Some(Arc::new(RandomPolicy::new())),
             "round_robin" | "roundrobin" => Some(Arc::new(RoundRobinPolicy::new())),
             "power_of_two" | "poweroftwo" => Some(Arc::new(PowerOfTwoPolicy::new())),
+            "least_load" | "leastload" => Some(Arc::new(LeastLoadPolicy::new())),
             "cache_aware" | "cacheaware" => Some(Arc::new(CacheAwarePolicy::new())),
             "bucket" => Some(Arc::new(BucketPolicy::new())),
             "manual" => Some(Arc::new(ManualPolicy::new())),

--- a/model_gateway/src/policies/least_load.rs
+++ b/model_gateway/src/policies/least_load.rs
@@ -1,0 +1,222 @@
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock},
+};
+
+use openai_protocol::worker::WorkerLoadResponse;
+use tracing::debug;
+
+use super::{get_healthy_worker_indices, LoadBalancingPolicy, SelectWorkerInfo};
+use crate::worker::Worker;
+
+/// Default KV-pressure weight (request-equivalents per unit of M/M/1 congestion).
+pub const DEFAULT_LAMBDA: f64 = 1.5;
+
+#[derive(Debug)]
+pub struct LeastLoadPolicy {
+    /// Cached load reports from the worker monitor (keyed by worker URL).
+    cached_loads: RwLock<HashMap<String, WorkerLoadResponse>>,
+    /// KV-pressure weight.
+    lambda: f64,
+}
+
+impl LeastLoadPolicy {
+    pub fn new() -> Self {
+        Self::with_lambda(DEFAULT_LAMBDA)
+    }
+
+    pub fn with_lambda(lambda: f64) -> Self {
+        Self {
+            cached_loads: RwLock::new(HashMap::new()),
+            lambda: if lambda.is_finite() && lambda >= 0.0 {
+                lambda
+            } else {
+                DEFAULT_LAMBDA
+            },
+        }
+    }
+
+    /// Least-load score for a worker (lower is better).
+    fn score(
+        &self,
+        worker: &Arc<dyn Worker>,
+        loads: Option<&HashMap<String, WorkerLoadResponse>>,
+    ) -> f64 {
+        let in_flight = worker.load() as f64;
+        // KV-cache utilization from the latest load report; absent -> 0 (no barrier).
+        let k = loads
+            .and_then(|m| m.get(worker.url()))
+            .map(|l| l.effective_token_usage().clamp(0.0, 0.999))
+            .unwrap_or(0.0);
+        in_flight + self.lambda * k / (1.0 - k)
+    }
+}
+
+impl LoadBalancingPolicy for LeastLoadPolicy {
+    fn select_worker(
+        &self,
+        workers: &[Arc<dyn Worker>],
+        _info: &SelectWorkerInfo,
+    ) -> Option<usize> {
+        let healthy = get_healthy_worker_indices(workers);
+        if healthy.is_empty() {
+            return None;
+        }
+        if healthy.len() == 1 {
+            return Some(healthy[0]);
+        }
+
+        let guard = self.cached_loads.read().ok();
+        let loads = guard.as_deref();
+
+        let mut best = healthy[0];
+        let mut best_score = self.score(&workers[best], loads);
+        for &idx in &healthy[1..] {
+            let s = self.score(&workers[idx], loads);
+            if s < best_score {
+                best = idx;
+                best_score = s;
+            }
+        }
+
+        debug!(
+            "least_load selected {} (score {:.4}, in_flight {})",
+            workers[best].url(),
+            best_score,
+            workers[best].load()
+        );
+        workers[best].increment_processed();
+        Some(best)
+    }
+
+    fn name(&self) -> &'static str {
+        "least_load"
+    }
+
+    fn update_loads(&self, loads: &HashMap<String, WorkerLoadResponse>) {
+        if let Ok(mut cached) = self.cached_loads.write() {
+            cached.extend(loads.iter().map(|(k, v)| (k.clone(), v.clone())));
+        }
+    }
+
+    fn remove_worker(&self, url: &str) {
+        if let Ok(mut cached) = self.cached_loads.write() {
+            cached.remove(url);
+        }
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+impl Default for LeastLoadPolicy {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use openai_protocol::worker::{HealthCheckConfig, SchedulerLoadSnapshot};
+
+    use super::*;
+    use crate::worker::{BasicWorkerBuilder, WorkerType};
+
+    fn no_health_check() -> HealthCheckConfig {
+        HealthCheckConfig {
+            disable_health_check: true,
+            ..Default::default()
+        }
+    }
+
+    fn make_load(token_usage: f64) -> WorkerLoadResponse {
+        WorkerLoadResponse {
+            timestamp: String::new(),
+            dp_rank_count: 1,
+            loads: vec![SchedulerLoadSnapshot {
+                dp_rank: 0,
+                num_running_reqs: 0,
+                num_waiting_reqs: 0,
+                num_total_reqs: 0,
+                num_used_tokens: 0,
+                max_total_num_tokens: 0,
+                token_usage,
+                gen_throughput: 0.0,
+                cache_hit_rate: 0.0,
+                utilization: 0.0,
+                max_running_requests: 0,
+            }],
+        }
+    }
+
+    fn mk(url: &str) -> Arc<dyn Worker> {
+        Arc::new(
+            BasicWorkerBuilder::new(url)
+                .worker_type(WorkerType::Regular)
+                .health_config(no_health_check())
+                .build(),
+        )
+    }
+
+    #[test]
+    fn picks_lowest_in_flight() {
+        let policy = LeastLoadPolicy::new();
+        let a = mk("http://a:8000");
+        let b = mk("http://b:8000");
+        for _ in 0..5 {
+            a.increment_load();
+        }
+        let workers = vec![a, b];
+        // No load reports -> pure in-flight; b (0) beats a (5).
+        assert_eq!(
+            policy.select_worker(&workers, &SelectWorkerInfo::default()),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn kv_barrier_avoids_full_worker() {
+        let policy = LeastLoadPolicy::with_lambda(2.0);
+        let a = mk("http://a:8000"); // idle but KV-full
+        let b = mk("http://b:8000"); // 1 in-flight but KV empty
+        b.increment_load();
+        let workers = vec![a, b];
+        let mut loads = HashMap::new();
+        loads.insert("http://a:8000".to_string(), make_load(0.95)); // barrier 2*0.95/0.05 = 38
+        loads.insert("http://b:8000".to_string(), make_load(0.0));
+        policy.update_loads(&loads);
+        // a: 0 + 38 = 38 ; b: 1 + 0 = 1 -> pick b.
+        assert_eq!(
+            policy.select_worker(&workers, &SelectWorkerInfo::default()),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn single_worker_always_selected() {
+        let policy = LeastLoadPolicy::new();
+        let workers = vec![mk("http://a:8000")];
+        assert_eq!(
+            policy.select_worker(&workers, &SelectWorkerInfo::default()),
+            Some(0)
+        );
+    }
+
+    #[test]
+    fn remove_worker_prunes_cached_load() {
+        let policy = LeastLoadPolicy::new();
+        let mut loads = HashMap::new();
+        loads.insert("http://a:8000".to_string(), make_load(0.5));
+        loads.insert("http://b:8000".to_string(), make_load(0.3));
+        policy.update_loads(&loads);
+        assert_eq!(policy.cached_loads.read().unwrap().len(), 2);
+
+        // Removing a worker drops only its entry (no unbounded growth on churn).
+        policy.remove_worker("http://a:8000");
+        let cached = policy.cached_loads.read().unwrap();
+        assert_eq!(cached.len(), 1);
+        assert!(!cached.contains_key("http://a:8000"));
+        assert!(cached.contains_key("http://b:8000"));
+    }
+}

--- a/model_gateway/src/policies/mod.rs
+++ b/model_gateway/src/policies/mod.rs
@@ -14,6 +14,7 @@ mod cache_aware;
 mod consistent_hashing;
 mod dp_min_token;
 mod factory;
+mod least_load;
 mod manual;
 mod power_of_two;
 mod prefix_hash;
@@ -29,6 +30,7 @@ pub use dp_min_token::MinimumTokensPolicy;
 pub use factory::PolicyFactory;
 // Re-export PrefixMatchResult from kv_index for production use
 pub use kv_index::PrefixMatchResult;
+pub use least_load::LeastLoadPolicy;
 pub use manual::{ManualConfig, ManualPolicy};
 pub use power_of_two::PowerOfTwoPolicy;
 pub use prefix_hash::{PrefixHashConfig, PrefixHashPolicy};
@@ -72,6 +74,15 @@ pub trait LoadBalancingPolicy: Send + Sync + Debug {
     /// This is called periodically with current load information for load-aware policies.
     fn update_loads(&self, _loads: &std::collections::HashMap<String, WorkerLoadResponse>) {
         // Default: no-op for policies that don't use load information
+    }
+
+    /// Drop any cached per-worker state for a removed worker.
+    ///
+    /// Called when a worker leaves the registry so load-aware policies don't
+    /// accumulate stale load reports under worker churn (autoscaling, rolling
+    /// updates). Default is a no-op for stateless policies.
+    fn remove_worker(&self, _url: &str) {
+        // Default: no-op for policies that don't cache per-worker state
     }
 
     /// Reset any internal state

--- a/model_gateway/src/policies/power_of_two.rs
+++ b/model_gateway/src/policies/power_of_two.rs
@@ -119,6 +119,12 @@ impl LoadBalancingPolicy for PowerOfTwoPolicy {
         }
     }
 
+    fn remove_worker(&self, url: &str) {
+        if let Ok(mut cached) = self.cached_loads.write() {
+            cached.remove(url);
+        }
+    }
+
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }

--- a/model_gateway/src/policies/registry.rs
+++ b/model_gateway/src/policies/registry.rs
@@ -290,12 +290,19 @@ impl PolicyRegistry {
             .unwrap_or_else(|| self.get_default_policy())
     }
 
-    /// Get all PowerOfTwo policies that need load updates (lock-free)
-    pub fn get_all_power_of_two_policies(&self) -> Vec<Arc<dyn LoadBalancingPolicy>> {
-        let mut power_of_two_policies = Vec::new();
+    /// Get all load-aware policies that need periodic load updates (lock-free).
+    ///
+    /// These are policies whose routing depends on the worker load monitor:
+    /// `power_of_two` and `least_load`.
+    pub fn get_all_load_aware_policies(&self) -> Vec<Arc<dyn LoadBalancingPolicy>> {
+        fn is_load_aware(name: &str) -> bool {
+            name == "power_of_two" || name == "least_load"
+        }
 
-        if self.default_policy.name() == "power_of_two" {
-            power_of_two_policies.push(Arc::clone(&self.default_policy));
+        let mut policies = Vec::new();
+
+        if is_load_aware(self.default_policy.name()) {
+            policies.push(Arc::clone(&self.default_policy));
         }
 
         // Get prefill and decode policies (lock-free via OnceLock::get)
@@ -303,31 +310,31 @@ impl PolicyRegistry {
         let decode_policy_opt = self.decode_policy.get();
 
         if let Some(policy) = prefill_policy_opt {
-            if policy.name() == "power_of_two" && !Arc::ptr_eq(policy, &self.default_policy) {
-                power_of_two_policies.push(Arc::clone(policy));
+            if is_load_aware(policy.name()) && !Arc::ptr_eq(policy, &self.default_policy) {
+                policies.push(Arc::clone(policy));
             }
         }
 
         if let Some(policy) = decode_policy_opt {
-            if policy.name() == "power_of_two"
+            if is_load_aware(policy.name())
                 && !Arc::ptr_eq(policy, &self.default_policy)
                 && !prefill_policy_opt.is_some_and(|p| Arc::ptr_eq(p, policy))
             {
-                power_of_two_policies.push(Arc::clone(policy));
+                policies.push(Arc::clone(policy));
             }
         }
 
         for entry in self.model_policies.iter() {
             let policy = entry.value();
-            if policy.name() == "power_of_two" {
-                let already_added = power_of_two_policies.iter().any(|p| Arc::ptr_eq(p, policy));
+            if is_load_aware(policy.name()) {
+                let already_added = policies.iter().any(|p| Arc::ptr_eq(p, policy));
                 if !already_added {
-                    power_of_two_policies.push(Arc::clone(policy));
+                    policies.push(Arc::clone(policy));
                 }
             }
         }
 
-        power_of_two_policies
+        policies
     }
 
     /// Initialize cache-aware policy with workers if applicable
@@ -383,6 +390,18 @@ impl PolicyRegistry {
                     }
                 }
             }
+        }
+    }
+
+    /// Drop a removed worker's cached load report from all load-aware policies
+    /// (`power_of_two`, `least_load`).
+    ///
+    /// These policies cache per-worker load reports keyed by URL; without this
+    /// their caches would grow unbounded under worker churn. Called on worker
+    /// removal alongside the cache-aware cleanup above.
+    pub fn remove_worker_from_load_aware(&self, worker_url: &str) {
+        for policy in self.get_all_load_aware_policies() {
+            policy.remove_worker(worker_url);
         }
     }
 

--- a/model_gateway/src/worker/monitor.rs
+++ b/model_gateway/src/worker/monitor.rs
@@ -588,9 +588,8 @@ async fn group_monitor_loop(
             return;
         };
 
-        let power_of_two_policies = monitor.policy_registry.get_all_power_of_two_policies();
-        if power_of_two_policies.is_empty()
-            && monitor.policy_registry.get_dp_rank_policy().is_none()
+        let load_aware_policies = monitor.policy_registry.get_all_load_aware_policies();
+        if load_aware_policies.is_empty() && monitor.policy_registry.get_dp_rank_policy().is_none()
         {
             debug!("No load-aware policies, skipping load fetch for group {group_key}");
             drop(monitor);
@@ -675,7 +674,7 @@ async fn group_monitor_loop(
             workers.len()
         );
 
-        for policy in &power_of_two_policies {
+        for policy in &load_aware_policies {
             policy.update_loads(&group_loads);
         }
         monitor.worker_load_manager.update_dp_loads(&group_dp_loads);

--- a/model_gateway/src/workflow/steps/local/remove_from_policy_registry.rs
+++ b/model_gateway/src/workflow/steps/local/remove_from_policy_registry.rs
@@ -51,6 +51,12 @@ impl StepExecutor<WorkerRemovalWorkflowData> for RemoveFromPolicyRegistryStep {
                 .policy_registry
                 .remove_worker_from_pd_cache_aware(worker_url);
 
+            // Drop the worker's cached load report from load-aware policies
+            // (power_of_two, least_load) so their caches don't leak under churn.
+            app_context
+                .policy_registry
+                .remove_worker_from_load_aware(worker_url);
+
             // Notify policy registry
             app_context.policy_registry.on_worker_removed(&model_id);
         }


### PR DESCRIPTION
## Description

### Problem

SMG has no load-aware routing policy that accounts for KV-cache pressure. `power_of_two` compares two random workers on a single metric, and the count-based policies ignore how full each worker's KV cache is — so traffic can pile onto a worker that is about to hit the KV preemption/recompute cliff, spiking TTFT.

### Solution

Add `least_load`: a policy that scores every healthy worker 

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] (Optional) Documentation updated — rustdoc on the policy and config variant
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org)

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "least_load" routing policy that prefers workers with the lowest combined score (in-flight + cache pressure). Exposed in CLI and Python bindings and selectable alongside existing policies.
* **Documentation**
  * Router option docs updated to include the new policy.
* **Tests**
  * Unit and integration tests added/updated for parsing, validation, and selection behavior.
* **Chores**
  * Worker removal now clears per-worker load caches for load-aware policies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->