### PR TITLE
feat(grpc): add GetLoads endpoint to the vLLM engine service

### DIFF
--- a/crates/grpc_client/proto/vllm_engine.proto
+++ b/crates/grpc_client/proto/vllm_engine.proto
@@ -26,6 +26,9 @@ service VllmEngine {
   // Get server information
   rpc GetServerInfo(GetServerInfoRequest) returns (GetServerInfoResponse);
 
+  // Get scheduler load metrics
+  rpc GetLoads(GetLoadsRequest) returns (GetLoadsResponse);
+
   // Get tokenizer artifacts for remote construction
   rpc GetTokenizer(smg.grpc.common.GetTokenizerRequest) returns (stream smg.grpc.common.GetTokenizerChunk);
 
@@ -330,4 +333,47 @@ message GetServerInfoResponse {
   // KV transfer config (for PD disaggregation)
   string kv_connector = 6;  // "MooncakeConnector", "NixlConnector", "" if not configured
   string kv_role = 7;       // "kv_producer", "kv_consumer", "kv_both", "" if not configured
+}
+
+// =====================
+// Load Metrics
+// =====================
+
+message GetLoadsRequest {
+  // Optional: filter to a specific DP rank.
+  optional int32 dp_rank = 1;
+
+  // Sections to include (e.g. "core"). vLLM currently emits only core metrics.
+  repeated string include = 2;
+}
+
+message GetLoadsResponse {
+  // ISO 8601 timestamp.
+  string timestamp = 1;
+
+  // vLLM version.
+  string version = 2;
+
+  // Number of DP ranks reported.
+  int32 dp_rank_count = 3;
+
+  // Per-DP-rank load metrics.
+  repeated SchedulerLoad loads = 4;
+}
+
+// Per-DP-rank scheduler load snapshot. vLLM populates the fields it can read
+// cheaply from the engine's scheduler stats; unset fields are 0.
+message SchedulerLoad {
+  int32 dp_rank = 1;
+  int32 num_running_reqs = 2;
+  int32 num_waiting_reqs = 3;
+  int32 num_total_reqs = 4;
+  int32 num_used_tokens = 5;
+  int32 max_total_num_tokens = 6;
+  // KV-cache utilization in [0,1) (vLLM SchedulerStats.kv_cache_usage).
+  double token_usage = 7;
+  double gen_throughput = 8;
+  double cache_hit_rate = 9;
+  double utilization = 10;
+  int32 max_running_requests = 11;
 }

--- a/crates/grpc_client/src/vllm_engine.rs
+++ b/crates/grpc_client/src/vllm_engine.rs
@@ -95,6 +95,23 @@ impl VllmEngineClient {
     crate::impl_get_tokenizer!();
     crate::impl_subscribe_kv_events!();
 
+    /// Get load metrics from the vLLM engine.
+    pub async fn get_loads(
+        &self,
+        include: Vec<String>,
+    ) -> Result<proto::GetLoadsResponse, tonic::Status> {
+        debug!("Requesting vLLM load metrics");
+        let request = Request::new(proto::GetLoadsRequest {
+            dp_rank: None,
+            include,
+        });
+
+        let mut client = self.client.clone();
+        let response = client.get_loads(request).await?;
+        debug!("vLLM load metrics response received");
+        Ok(response.into_inner())
+    }
+
     /// Build a single vLLM GenerateRequest from OpenAI ChatCompletionRequest
     #[expect(
         clippy::unused_self,
@@ -671,6 +688,38 @@ impl VllmEngineClient {
         sampling.constraint = Self::build_single_constraint_from_plain(p)?;
 
         Ok(sampling)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Proto → protocol type conversions (load metrics)
+// ---------------------------------------------------------------------------
+
+impl From<proto::SchedulerLoad> for openai_protocol::worker::SchedulerLoadSnapshot {
+    fn from(load: proto::SchedulerLoad) -> Self {
+        Self {
+            dp_rank: load.dp_rank,
+            num_running_reqs: load.num_running_reqs,
+            num_waiting_reqs: load.num_waiting_reqs,
+            num_total_reqs: load.num_total_reqs,
+            num_used_tokens: load.num_used_tokens,
+            max_total_num_tokens: load.max_total_num_tokens,
+            token_usage: load.token_usage,
+            gen_throughput: load.gen_throughput,
+            cache_hit_rate: load.cache_hit_rate,
+            utilization: load.utilization,
+            max_running_requests: load.max_running_requests,
+        }
+    }
+}
+
+impl From<proto::GetLoadsResponse> for openai_protocol::worker::WorkerLoadResponse {
+    fn from(resp: proto::GetLoadsResponse) -> Self {
+        Self {
+            timestamp: resp.timestamp,
+            dp_rank_count: resp.dp_rank_count,
+            loads: resp.loads.into_iter().map(Into::into).collect(),
+        }
     }
 }
 

--- a/grpc_servicer/smg_grpc_servicer/vllm/servicer.py
+++ b/grpc_servicer/smg_grpc_servicer/vllm/servicer.py
@@ -10,6 +10,7 @@ import itertools
 import json
 import time
 from collections.abc import AsyncGenerator, AsyncIterator
+from datetime import datetime, timezone
 from pathlib import Path
 
 import grpc
@@ -70,17 +71,58 @@ def _tensor_from_proto(td: vllm_engine_pb2.TensorData) -> torch.Tensor:
     return torch.frombuffer(bytearray(td.data), dtype=torch_dtype).reshape(*td.shape)
 
 
+try:
+    from vllm.version import __version__ as VLLM_VERSION
+except Exception:  # pragma: no cover - version lookup is best-effort
+    VLLM_VERSION = ""
+
+
+def _latest_scheduler_stats(engine, engine_idx: int = 0):
+    """Best-effort read of the most recent ``SchedulerStats`` snapshot.
+
+    vLLM has no synchronous "current stats" accessor on ``AsyncLLM``/``EngineClient``;
+    ``SchedulerStats`` arrive asynchronously and are cached on the stat loggers. This
+    reaches into ``engine.logger_manager.stat_loggers`` and returns the freshest
+    snapshot, handling the logger-shape variants:
+
+    - ``LoggingStatLogger``                  -> ``.last_scheduler_stats``
+    - ``AggregatedLoggingStatLogger`` (DP)   -> ``.last_scheduler_stats_dict[idx]``
+    - ``PerEngineStatLoggerAdapter``         -> ``.per_engine_stat_loggers[idx]``
+    - ``PrometheusStatLogger``               -> skipped (no cached snapshot)
+
+    Returns ``None`` when stats logging is disabled (``--disable-log-stats``) or no
+    engine step has produced outputs yet.
+    """
+    logger_manager = getattr(engine, "logger_manager", None)
+    if logger_manager is None:
+        return None
+    for sl in getattr(logger_manager, "stat_loggers", None) or []:
+        per = getattr(sl, "last_scheduler_stats_dict", None)
+        if isinstance(per, dict) and engine_idx in per:
+            return per[engine_idx]
+        stats = getattr(sl, "last_scheduler_stats", None)
+        if stats is not None:
+            return stats
+        per_engine = getattr(sl, "per_engine_stat_loggers", None)
+        if isinstance(per_engine, dict) and engine_idx in per_engine:
+            nested = getattr(per_engine[engine_idx], "last_scheduler_stats", None)
+            if nested is not None:
+                return nested
+    return None
+
+
 class VllmEngineServicer(vllm_engine_pb2_grpc.VllmEngineServicer):
     """
     gRPC servicer implementing the VllmEngine service.
 
-    Handles 7 RPCs:
+    Handles 8 RPCs:
     - Generate: Streaming text generation
     - Embed: Embeddings
     - HealthCheck: Health probe
     - Abort: Cancel requests out-of-band
     - GetModelInfo: Model metadata
     - GetServerInfo: Server state
+    - GetLoads: Scheduler load metrics
     - GetTokenizer: Stream tokenizer artifacts
     """
 
@@ -421,6 +463,61 @@ class VllmEngineServicer(vllm_engine_pb2_grpc.VllmEngineServicer):
         return vllm_engine_pb2.GetServerInfoResponse(
             kv_connector=kv_connector,
             kv_role=kv_role,
+        )
+
+    async def GetLoads(
+        self,
+        request: vllm_engine_pb2.GetLoadsRequest,
+        context: grpc.aio.ServicerContext,
+    ) -> vllm_engine_pb2.GetLoadsResponse:
+        """
+        Handle load-metric requests.
+
+        Reads the latest SchedulerStats snapshot cached on the engine's stat
+        loggers and maps it onto a single-DP-rank SchedulerLoad: ``token_usage``
+        carries KV-cache utilization ([0,1)) and ``num_running_reqs`` /
+        ``num_waiting_reqs`` report queue depth.
+
+        Always returns exactly one SchedulerLoad entry (zero-filled when no
+        snapshot is available yet, e.g. with --disable-log-stats or before the
+        first engine step) so callers treat the worker as responsive rather than
+        dropping the poll.
+
+        Note: ``request.dp_rank`` and ``request.include`` are accepted but not yet
+        applied — vLLM reports a single DP rank (``dp_rank_count=1``) with only
+        core metrics, so there is nothing to filter. They are reserved for future
+        multi-DP / sectioned-metrics support.
+
+        Args:
+            request: The GetLoadsRequest protobuf
+            context: gRPC context
+
+        Returns:
+            GetLoadsResponse protobuf
+        """
+        stats = _latest_scheduler_stats(self.engine)
+        if stats is not None:
+            num_running = int(getattr(stats, "num_running_reqs", 0) or 0)
+            num_waiting = int(getattr(stats, "num_waiting_reqs", 0) or 0)
+            kv_usage = float(getattr(stats, "kv_cache_usage", 0.0) or 0.0)
+        else:
+            num_running = 0
+            num_waiting = 0
+            kv_usage = 0.0
+
+        load = vllm_engine_pb2.SchedulerLoad(
+            dp_rank=0,
+            num_running_reqs=num_running,
+            num_waiting_reqs=num_waiting,
+            num_total_reqs=num_running + num_waiting,
+            token_usage=max(0.0, kv_usage),
+        )
+
+        return vllm_engine_pb2.GetLoadsResponse(
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            version=VLLM_VERSION,
+            dp_rank_count=1,
+            loads=[load],
         )
 
     async def GetTokenizer(

--- a/model_gateway/src/routers/grpc/client.rs
+++ b/model_gateway/src/routers/grpc/client.rs
@@ -247,6 +247,10 @@ impl GrpcClient {
                 let resp = client.get_loads(vec!["core".to_string()]).await?;
                 Ok(WorkerLoadResponse::from(resp))
             }
+            Self::Vllm(client) => {
+                let resp = client.get_loads(vec!["core".to_string()]).await?;
+                Ok(WorkerLoadResponse::from(resp))
+            }
             _ => Err(tonic::Status::unimplemented(
                 "GetLoads RPC not supported for this backend",
             )),


### PR DESCRIPTION
## Description

### Problem

SMG's load monitor can pull scheduler load (KV/queue stats) from SGLang workers over gRPC, but `GrpcClient::get_loads()` returns `Unimplemented` for vLLM. So load-aware policies (`power_of_two`, and the new `least_load`) can't see real KV pressure on vLLM workers — they fall back to in-flight counts only.

### Solution

Implement the `GetLoads` RPC for the vLLM engine service so the monitor can poll a vLLM worker's scheduler load exactly as it does for SGLang. vLLM's gRPC server imports its proto and servicer from this repo, so **no change to the vLLM repo is required** — the servicer auto-registers via `add_VllmEngineServicer_to_server`.

## Changes

- `crates/grpc_client/proto/vllm_engine.proto` — `GetLoads` RPC + `GetLoadsRequest` / `GetLoadsResponse` / `SchedulerLoad` messages.
- `crates/grpc_client/src/vllm_engine.rs` — `VllmEngineClient::get_loads()` + `From<proto::{SchedulerLoad, GetLoadsResponse}>` into `WorkerLoadResponse`.
- `model_gateway/src/routers/grpc/client.rs` — `GrpcClient::get_loads()` vLLM arm (was `Unimplemented`).
- `grpc_servicer/smg_grpc_servicer/vllm/servicer.py` — `GetLoads` handler + `_latest_scheduler_stats()` reach-in: maps vLLM `SchedulerStats.kv_cache_usage` -> `token_usage`, handles the stat-logger shape variants and `--disable-log-stats`, and always returns `>=1` load entry so a poll is never dropped.

## Test Plan

**Python unit tests** (mock engine, no GPU): the handler maps `kv_cache_usage`->`token_usage` and running/waiting counts; returns zeros (not an error) when `logger_manager is None`; and `_latest_scheduler_stats()` finds the snapshot across `LoggingStatLogger` / `AggregatedLoggingStatLogger` / `PerEngineStatLoggerAdapter` while skipping `PrometheusStatLogger`.

**gRPC round-trip** (mock engine over a real socket): `add_VllmEngineServicer_to_server` registration + a stub `GetLoads` call returns a correct `GetLoadsResponse`.

**Live end-to-end** (2x vLLM gRPC workers + SMG, single GPU each):
1. Launch two `python -m vllm.entrypoints.grpc_server` workers (`--max-num-seqs 256 --max-model-len 8192`).
2. Launch SMG `--worker-urls grpc://127.0.0.1:50051 grpc://127.0.0.1:50052 --policy power_of_two`.
3. **Before:** vLLM `get_loads()` returned `Unimplemented`; the monitor logged no usable loads for vLLM workers.
4. **After:** idle -> `GetLoads` returns `token_usage=0`; under 8 concurrent completions the monitor logs `Fetched loads from 2/2 workers`, `token_usage` rose to `0.038` / `0.023`, and `power_of_two` split load `5/3` across the two workers.

**Pre-PR gate (this env has no nightly toolchain; used stable `cargo fmt`):**
- `cargo fmt --all --check` — passes (only nightly-only import-grouping options warn).
- `cargo clippy --all-targets --all-features -- -D warnings` — passes (clean, 0 warnings).
- `cargo test -p smg-grpc-client -p smg` — `smg-grpc-client` + `smg` lib **1007 passed / 0 failed**; integration suites pass except the same **pre-existing** `test_openai_router_circuit_breaker` failure (reproduces on `main`, unrelated to this change — diff touches only the gRPC client/proto/servicer).
- Python servicer: `python -m py_compile` clean; behavior covered by the unit + round-trip + live tests above.

<details>
<summary>Checklist</summary>

- [x] `cargo fmt` passes (stable; `cargo +nightly` unavailable in this environment)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] (Optional) Documentation updated — rustdoc + proto comments + servicer docstrings
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org)

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new RPC to retrieve scheduler load metrics from the vLLM engine. Returns timestamped, versioned per-rank snapshots with running/waiting/total request counts, token counts and usage, throughput, cache-hit/utilization stats, and max concurrent running requests.
  * API surface now exposes this endpoint and the gateway forwards vLLM load requests so load data is available through existing client paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->