### PR TITLE
perf(anthropic): use shared SseEncoder for streaming SSE output

### DIFF
--- a/model_gateway/src/routers/anthropic/sse.rs
+++ b/model_gateway/src/routers/anthropic/sse.rs
@@ -19,7 +19,7 @@ use tracing::{debug, error, warn};
 
 use super::mcp::{IterationResult, McpToolCall};
 use crate::routers::{
-    common::sse::{SseDecodeError, SseDecoder, SseFrame},
+    common::sse::{SseEncodeError, SseEncoder, SseDecodeError, SseDecoder, SseFrame},
     error::internal_error,
 };
 
@@ -95,23 +95,39 @@ pub(crate) fn build_sse_response(
 /// Format and send an SSE event through the channel.
 ///
 /// Returns `true` if the send succeeded, `false` if the receiver was dropped.
+/// The caller supplies a reusable [`SseEncoder`] so the serialization buffer is
+/// shared across every event in the stream (one allocation per event instead of
+/// the previous `to_string` + `format!` pair).
 pub(crate) async fn send_event(
     tx: &mpsc::Sender<Result<Bytes, io::Error>>,
+    enc: &mut SseEncoder,
     event_type: &str,
     data: &Value,
 ) -> bool {
-    let bytes = format_sse_event(event_type, data);
+    let bytes = format_sse_event(enc, event_type, data);
     tx.send(Ok(bytes)).await.is_ok()
 }
 
 /// Format a `MessageStreamEvent` as SSE bytes: `event: <type>\ndata: <json>\n\n`
-fn format_sse_event(event_type: &str, data: &Value) -> Bytes {
-    let json = serde_json::to_string(data).unwrap_or_else(|_| "{}".to_string());
-    Bytes::from(format!("event: {event_type}\ndata: {json}\n\n"))
+fn format_sse_event(enc: &mut SseEncoder, event_type: &str, data: &Value) -> Bytes {
+    enc.encode_event(event_type, data)
+        .unwrap_or_else(|e| match e {
+            // `encode_event` rejected the event type for containing CR/LF. Do NOT
+            // echo it back via `format!` — that would reintroduce the exact framing
+            // break the encoder guards against. Emit a safe, well-formed frame.
+            SseEncodeError::InvalidEventType => Bytes::from_static(b"event: error\ndata: {}\n\n"),
+            // Serialization failure (practically impossible for a JSON value). The
+            // event type is known-safe here, so an empty-object data frame is fine.
+            SseEncodeError::Json(_) => Bytes::from(format!("event: {event_type}\ndata: {{}}\n\n")),
+        })
 }
 
 /// Send an SSE error event.
-pub(crate) async fn send_error(tx: &mpsc::Sender<Result<Bytes, io::Error>>, message: &str) -> bool {
+pub(crate) async fn send_error(
+    tx: &mpsc::Sender<Result<Bytes, io::Error>>,
+    enc: &mut SseEncoder,
+    message: &str,
+) -> bool {
     let data = serde_json::json!({
         "type": "error",
         "error": {
@@ -119,13 +135,14 @@ pub(crate) async fn send_error(tx: &mpsc::Sender<Result<Bytes, io::Error>>, mess
             "message": message
         }
     });
-    send_event(tx, "error", &data).await
+    send_event(tx, enc, "error", &data).await
 }
 
 /// Emit `content_block_start` + `content_block_stop` events for an
 /// `mcp_tool_result` block.
 pub(crate) async fn emit_mcp_tool_result(
     tx: &mpsc::Sender<Result<Bytes, io::Error>>,
+    enc: &mut SseEncoder,
     call: &McpToolCall,
     global_index: &mut u32,
 ) -> bool {
@@ -146,7 +163,7 @@ pub(crate) async fn emit_mcp_tool_result(
         }
     });
 
-    if !send_event(tx, "content_block_start", &block_start).await {
+    if !send_event(tx, enc, "content_block_start", &block_start).await {
         return false;
     }
 
@@ -156,7 +173,7 @@ pub(crate) async fn emit_mcp_tool_result(
         "index": index
     });
 
-    if !send_event(tx, "content_block_stop", &block_stop).await {
+    if !send_event(tx, enc, "content_block_stop", &block_stop).await {
         return false;
     }
 
@@ -167,6 +184,7 @@ pub(crate) async fn emit_mcp_tool_result(
 /// Emit the final `message_delta` and `message_stop` events.
 pub(crate) async fn emit_final(
     tx: &mpsc::Sender<Result<Bytes, io::Error>>,
+    enc: &mut SseEncoder,
     stop_reason: Option<&StopReason>,
     total_input_tokens: u32,
     total_output_tokens: u32,
@@ -187,14 +205,14 @@ pub(crate) async fn emit_final(
         }
     });
 
-    if !send_event(tx, "message_delta", &message_delta).await {
+    if !send_event(tx, enc, "message_delta", &message_delta).await {
         debug!("Failed to send final message_delta — channel closed");
     }
 
     let message_stop = serde_json::json!({
         "type": "message_stop"
     });
-    if !send_event(tx, "message_stop", &message_stop).await {
+    if !send_event(tx, enc, "message_stop", &message_stop).await {
         debug!("Failed to send message_stop — channel closed");
     }
 }
@@ -210,6 +228,7 @@ pub(crate) async fn emit_final(
 /// decoupling this function from `McpToolSession`.
 pub(crate) async fn consume_and_forward<F>(
     tx: &mpsc::Sender<Result<Bytes, io::Error>>,
+    enc: &mut SseEncoder,
     response: reqwest::Response,
     global_index: &mut u32,
     is_first_iteration: bool,
@@ -220,8 +239,13 @@ where
 {
     let mut stream = response.bytes_stream();
     let mut decoder = SseDecoder::with_max_size(MAX_SSE_BUFFER_SIZE);
-    let mut processor =
-        EventProcessor::new(tx, global_index, is_first_iteration, resolve_server_name);
+    let mut processor = EventProcessor::new(
+        tx,
+        enc,
+        global_index,
+        is_first_iteration,
+        resolve_server_name,
+    );
 
     while let Some(chunk_result) = stream.next().await {
         let chunk = chunk_result.map_err(|e| format!("Stream read error: {e}"))?;
@@ -424,6 +448,7 @@ impl BlockAccumulator {
 /// tool names to MCP server labels.
 struct EventProcessor<'a, F> {
     tx: &'a mpsc::Sender<Result<Bytes, io::Error>>,
+    enc: &'a mut SseEncoder,
     global_index: &'a mut u32,
     index_base: u32,
     is_first_iteration: bool,
@@ -439,6 +464,7 @@ where
 {
     fn new(
         tx: &'a mpsc::Sender<Result<Bytes, io::Error>>,
+        enc: &'a mut SseEncoder,
         global_index: &'a mut u32,
         is_first_iteration: bool,
         resolve_server_name: F,
@@ -446,6 +472,7 @@ where
         let index_base = *global_index;
         Self {
             tx,
+            enc,
             global_index,
             index_base,
             is_first_iteration,
@@ -469,8 +496,8 @@ where
     }
 
     /// Send an SSE event to the client, returning `Err` on disconnect.
-    async fn send(&self, event_type: &str, data: &Value) -> Result<(), String> {
-        if !send_event(self.tx, event_type, data).await {
+    async fn send(&mut self, event_type: &str, data: &Value) -> Result<(), String> {
+        if !send_event(self.tx, self.enc, event_type, data).await {
             return Err(CLIENT_DISCONNECTED_ERROR.into());
         }
         Ok(())
@@ -752,7 +779,8 @@ mod tests {
     #[test]
     fn test_format_sse_event() {
         let data = serde_json::json!({"type": "ping"});
-        let bytes = format_sse_event("ping", &data);
+        let mut enc = SseEncoder::new();
+        let bytes = format_sse_event(&mut enc, "ping", &data);
         let text = String::from_utf8(bytes.to_vec()).unwrap();
         assert!(text.starts_with("event: ping\n"));
         assert!(text.contains("data: "));

--- a/model_gateway/src/routers/anthropic/sse.rs
+++ b/model_gateway/src/routers/anthropic/sse.rs
@@ -19,7 +19,7 @@ use tracing::{debug, error, warn};
 
 use super::mcp::{IterationResult, McpToolCall};
 use crate::routers::{
-    common::sse::{SseEncodeError, SseEncoder, SseDecodeError, SseDecoder, SseFrame},
+    common::sse::{SseDecodeError, SseDecoder, SseEncodeError, SseEncoder, SseFrame},
     error::internal_error,
 };
 

--- a/model_gateway/src/routers/anthropic/sse.rs
+++ b/model_gateway/src/routers/anthropic/sse.rs
@@ -95,9 +95,6 @@ pub(crate) fn build_sse_response(
 /// Format and send an SSE event through the channel.
 ///
 /// Returns `true` if the send succeeded, `false` if the receiver was dropped.
-/// The caller supplies a reusable [`SseEncoder`] so the serialization buffer is
-/// shared across every event in the stream (one allocation per event instead of
-/// the previous `to_string` + `format!` pair).
 pub(crate) async fn send_event(
     tx: &mpsc::Sender<Result<Bytes, io::Error>>,
     enc: &mut SseEncoder,
@@ -112,12 +109,7 @@ pub(crate) async fn send_event(
 fn format_sse_event(enc: &mut SseEncoder, event_type: &str, data: &Value) -> Bytes {
     enc.encode_event(event_type, data)
         .unwrap_or_else(|e| match e {
-            // `encode_event` rejected the event type for containing CR/LF. Do NOT
-            // echo it back via `format!` — that would reintroduce the exact framing
-            // break the encoder guards against. Emit a safe, well-formed frame.
             SseEncodeError::InvalidEventType => Bytes::from_static(b"event: error\ndata: {}\n\n"),
-            // Serialization failure (practically impossible for a JSON value). The
-            // event type is known-safe here, so an empty-object data frame is fine.
             SseEncodeError::Json(_) => Bytes::from(format!("event: {event_type}\ndata: {{}}\n\n")),
         })
 }

--- a/model_gateway/src/routers/anthropic/streaming.rs
+++ b/model_gateway/src/routers/anthropic/streaming.rs
@@ -23,7 +23,7 @@ use super::{
 use crate::{
     observability::metrics::{metrics_labels, Metrics},
     routers::{
-        common::mcp_utils::DEFAULT_MAX_ITERATIONS,
+        common::{mcp_utils::DEFAULT_MAX_ITERATIONS, sse::SseEncoder},
         error::{self as router_error, extract_error_code_from_response},
     },
 };
@@ -164,7 +164,8 @@ fn execute_mcp_streaming(router: &RouterContext, req_ctx: RequestContext) -> Res
                 return;
             }
             warn!(error = %e, "Streaming tool loop failed");
-            let _ = sse::send_error(&tx, &e).await;
+            let mut enc = SseEncoder::new();
+            let _ = sse::send_error(&tx, &mut enc, &e).await;
         }
     });
 
@@ -200,6 +201,8 @@ async fn run_tool_loop(
     let mut total_input_tokens: u32 = 0;
     let mut total_output_tokens: u32 = 0;
     let mut is_first_iteration = true;
+    // Reusable SSE encoder shared across every event emitted for this stream.
+    let mut encoder = SseEncoder::new();
 
     for _iteration in 0..DEFAULT_MAX_ITERATIONS {
         Metrics::record_mcp_tool_iteration(&req_ctx.model_id);
@@ -216,6 +219,7 @@ async fn run_tool_loop(
         // Consume the upstream SSE stream
         let result = sse::consume_and_forward(
             &tx,
+            &mut encoder,
             response,
             &mut global_index,
             is_first_iteration,
@@ -239,6 +243,7 @@ async fn run_tool_loop(
             mcp::ToolLoopAction::Done => {
                 sse::emit_final(
                     &tx,
+                    &mut encoder,
                     consumed.iteration.stop_reason.as_ref(),
                     total_input_tokens,
                     total_output_tokens,
@@ -252,7 +257,8 @@ async fn run_tool_loop(
             mcp::ToolLoopAction::Continue(cont) => {
                 // Emit mcp_tool_result events for each completed tool call
                 for call in &cont.mcp_calls {
-                    if !sse::emit_mcp_tool_result(&tx, call, &mut global_index).await {
+                    if !sse::emit_mcp_tool_result(&tx, &mut encoder, call, &mut global_index).await
+                    {
                         return Ok(());
                     }
                 }
@@ -276,7 +282,7 @@ async fn run_tool_loop(
         DEFAULT_MAX_ITERATIONS
     );
     let error_msg = format!("MCP tool loop exceeded maximum iterations ({DEFAULT_MAX_ITERATIONS})");
-    let _ = sse::send_error(&tx, &error_msg).await;
+    let _ = sse::send_error(&tx, &mut encoder, &error_msg).await;
     Ok(())
 }
 


### PR DESCRIPTION
## Description

### Problem

The Anthropic MCP streaming path encoded every SSE event with a fresh `serde_json::to_string` + `format!("event: …\ndata: …")` pair — 2 heap allocations per event in the streaming hot path.

### Solution

Use the shared `common::sse::SseEncoder`. A single encoder is created once per stream in `run_tool_loop` and threaded through `consume_and_forward` / `EventProcessor` and the `emit_final` / `emit_mcp_tool_result` / `send_error` helpers, so the serialization buffer is reused across every event (1 allocation per event instead of 2). No behavior change — identical wire output.

## Changes

- Thread a per-stream `SseEncoder` through the Anthropic streaming emit path (`sse.rs`, `streaming.rs`).
- `format_sse_event` serializes via the encoder; on the (practically impossible) `InvalidEventType` error it now emits a safe `event: error\ndata: {}` frame instead of echoing the rejected event type back through `format!` (addressing review feedback).

## Test Plan

- `cargo +nightly fmt` ✅ and `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `cargo test -p smg --lib anthropic::sse` ✅ (8 passed)
- e2e GPU pipeline green on this branch — `anthropic-messages` and all `e2e-*` download/chat/gateway jobs pass.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized Server-Sent Events (SSE) formatting through a shared encoder so all outgoing SSE frames (including streaming output, tool-loop results, and error events) are generated consistently.
* **Tests**
  * Updated the SSE formatting unit test to match the new shared-encoder behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->