### PR TITLE
fix(reasoning_parser): detect end token split across stream chunks

### DIFF
--- a/crates/reasoning_parser/src/parsers/base.rs
+++ b/crates/reasoning_parser/src/parsers/base.rs
@@ -41,6 +41,20 @@ impl BaseReasoningParser {
             || (self.config.think_end_token.starts_with(text)
                 && self.config.think_end_token != text)
     }
+
+    /// Byte length of the longest suffix of `text` that is a non-empty proper
+    /// prefix of `think_end_token` — i.e. an end token split across chunks.
+    fn partial_end_suffix_len(&self, text: &str) -> usize {
+        let end = &self.config.think_end_token;
+        let max = text.len().min(end.len().saturating_sub(1));
+        for len in (1..=max).rev() {
+            let start = text.len() - len;
+            if text.is_char_boundary(start) && end.starts_with(&text[start..]) {
+                return len;
+            }
+        }
+        0
+    }
 }
 
 impl ReasoningParser for BaseReasoningParser {
@@ -133,9 +147,12 @@ impl ReasoningParser for BaseReasoningParser {
 
         // Continue with reasoning content
         if self.in_reasoning && self.config.stream_reasoning {
-            // Stream the content immediately
-            let reasoning_text = current_text;
-            self.buffer.clear();
+            // Hold back a trailing partial end token so a `</think>` split across
+            // chunks is detected on the next call instead of leaking as reasoning.
+            let hold = self.partial_end_suffix_len(&current_text);
+            let split = current_text.len() - hold;
+            let reasoning_text = current_text[..split].to_string();
+            self.buffer = current_text[split..].to_string();
             Ok(ParserResult::reasoning(reasoning_text))
         } else if !self.in_reasoning {
             // If we're not in a reasoning block, return as normal text
@@ -306,6 +323,78 @@ mod tests {
             .unwrap();
         assert_eq!(result3.normal_text, " normal");
         assert_eq!(result3.reasoning_text, "more");
+    }
+
+    #[test]
+    fn test_streaming_end_token_split_across_chunks() {
+        let mut parser = create_test_parser(false, true);
+
+        parser
+            .parse_reasoning_streaming_incremental("<think>reasoning ")
+            .unwrap();
+
+        // Chunk ends mid-`</think>`: the partial suffix must be held back, not leaked.
+        let split = parser
+            .parse_reasoning_streaming_incremental("done</thi")
+            .unwrap();
+        assert_eq!(split.reasoning_text, "done");
+        assert_eq!(split.normal_text, "");
+
+        // Remainder completes the end token; the answer must be normal text.
+        let rest = parser
+            .parse_reasoning_streaming_incremental("nk>answer")
+            .unwrap();
+        assert_eq!(rest.reasoning_text, "");
+        assert_eq!(rest.normal_text, "answer");
+    }
+
+    #[test]
+    fn test_streaming_end_token_split_multibyte() {
+        let config = ParserConfig {
+            think_start_token: "◁think▷".to_string(),
+            think_end_token: "◁/think▷".to_string(),
+            ..Default::default()
+        };
+        let mut parser = BaseReasoningParser::new(config);
+
+        parser
+            .parse_reasoning_streaming_incremental("◁think▷cot ")
+            .unwrap();
+
+        let split = parser
+            .parse_reasoning_streaming_incremental("more◁/th")
+            .unwrap();
+        assert_eq!(split.reasoning_text, "more");
+        assert_eq!(split.normal_text, "");
+
+        let rest = parser
+            .parse_reasoning_streaming_incremental("ink▷answer")
+            .unwrap();
+        assert_eq!(rest.reasoning_text, "");
+        assert_eq!(rest.normal_text, "answer");
+    }
+
+    #[test]
+    fn test_streaming_partial_end_suffix_disambiguated_as_reasoning() {
+        let mut parser = create_test_parser(false, true);
+
+        parser
+            .parse_reasoning_streaming_incremental("<think>reasoning ")
+            .unwrap();
+
+        // Tail looks like a partial `</think>` and is held back.
+        let held = parser
+            .parse_reasoning_streaming_incremental("done</th")
+            .unwrap();
+        assert_eq!(held.reasoning_text, "done");
+
+        // Next chunk shows it was not the end token: the held suffix must surface
+        // as reasoning, not be dropped.
+        let next = parser
+            .parse_reasoning_streaming_incremental("eory")
+            .unwrap();
+        assert_eq!(next.reasoning_text, "</theory");
+        assert_eq!(next.normal_text, "");
     }
 
     #[test]


### PR DESCRIPTION
## Description

### Problem

In streaming mode with `stream_reasoning = true` (every configured parser), the
`in_reasoning` branch flushed the entire accumulated buffer on every call and
cleared it. So when `think_end_token` was split across chunks — e.g. chunk A =
`"... done</thi"`, chunk B = `"nk>answer"` — the parser streamed `"... done</thi"`
as reasoning and dropped the buffer. The next chunk `"nk>answer"` never matched
`</think>`, so the real answer leaked into `reasoning_text` and the `</think>`
boundary was lost permanently. `is_partial_token` only guards the case where the
*entire* buffer is a token prefix, which stops applying once reasoning content is
flowing — so this only ever worked for the start token before reasoning began.

### Solution

When `in_reasoning && stream_reasoning` and no complete end token is present, hold
back the longest trailing suffix of the buffer that is a proper prefix of
`think_end_token`, stream only the safe prefix as reasoning, and re-buffer the
suffix. The next chunk either completes the end token (handled by the existing
end-detection path) or disambiguates it (the held suffix then surfaces as
reasoning). Suffix candidates are checked on UTF-8 char boundaries, so multibyte
delimiters (e.g. Kimi's `◁/think▷`) split mid-token are handled too.

## Changes

- `crates/reasoning_parser/src/parsers/base.rs`: add `partial_end_suffix_len`
  helper; in the streaming reasoning branch, buffer the partial-end suffix instead
  of flushing the whole buffer.
- Tests: `test_streaming_end_token_split_across_chunks` (ASCII `</think>` split),
  `test_streaming_end_token_split_multibyte` (Unicode `◁/think▷` split), and
  `test_streaming_partial_end_suffix_disambiguated_as_reasoning` (held suffix
  surfaces as reasoning when not actually the end token).

## Test Plan

Scenario: feed a reasoning stream where `</think>` (and the multibyte `◁/think▷`)
straddle a chunk boundary, and assert the answer lands in `normal_text` (not
`reasoning_text`); also assert a partial suffix that turns out not to be the end
token is re-emitted as reasoning rather than dropped.

Gate (crate-scoped, `RUSTC_WRAPPER=""`):

```
$ cargo +nightly fmt --all
(no changes)

$ RUSTC_WRAPPER="" cargo clippy -p reasoning-parser --all-targets -- -D warnings
    Checking reasoning-parser v1.2.3 (/Users/.../crates/reasoning_parser)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 27.74s

$ RUSTC_WRAPPER="" cargo test -p reasoning-parser
test parsers::base::tests::test_streaming_end_token_split_across_chunks ... ok
test parsers::base::tests::test_streaming_end_token_split_multibyte ... ok
test parsers::base::tests::test_streaming_partial_end_suffix_disambiguated_as_reasoning ... ok
test result: ok. 77 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
   Doc-tests reasoning_parser
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

From the codebase audit: crates/reasoning_parser/src/parsers/base.rs:97 — End token split across stream chunks is never detected.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming token boundary handling to prevent incomplete end-tokens from being incorrectly processed as content.
  * Enhanced support for multibyte and unicode character handling in streaming scenarios.

* **Tests**
  * Added test coverage for token boundary edge cases in streaming mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->