### PR TITLE
fix(tool_parser): add (?s) DOTALL to Kimi-K2 regexes for multi-line JSON args

### DIFF
--- a/crates/tool_parser/src/parsers/kimik2.rs
+++ b/crates/tool_parser/src/parsers/kimik2.rs
@@ -106,15 +106,15 @@ impl KimiK2Parser {
     )]
     pub fn new() -> Self {
         // Pattern for complete tool calls
-        let tool_call_pattern = r"<\|tool_call_begin\|>\s*(?P<tool_call_id>[\w\.]+:\d+)\s*<\|tool_call_argument_begin\|>\s*(?P<function_arguments>\{.*?\})\s*<\|tool_call_end\|>";
+        let tool_call_pattern = r"(?s)<\|tool_call_begin\|>\s*(?P<tool_call_id>[\w\.]+:\d+)\s*<\|tool_call_argument_begin\|>\s*(?P<function_arguments>\{.*?\})\s*<\|tool_call_end\|>";
         let tool_call_extractor = Regex::new(tool_call_pattern).expect("Valid regex pattern");
 
         // Pattern for streaming (partial) tool calls
-        let stream_pattern = r"<\|tool_call_begin\|>\s*(?P<tool_call_id>[\w\.]+:\d+)\s*<\|tool_call_argument_begin\|>\s*(?P<function_arguments>\{.*)";
+        let stream_pattern = r"(?s)<\|tool_call_begin\|>\s*(?P<tool_call_id>[\w\.]+:\d+)\s*<\|tool_call_argument_begin\|>\s*(?P<function_arguments>\{.*)";
         let stream_tool_call_extractor = Regex::new(stream_pattern).expect("Valid regex pattern");
 
         // Pattern for removing completed tool calls
-        let end_pattern = r"<\|tool_call_begin\|>.*?<\|tool_call_end\|>";
+        let end_pattern = r"(?s)<\|tool_call_begin\|>.*?<\|tool_call_end\|>";
         let tool_call_end_pattern = Regex::new(end_pattern).expect("Valid regex pattern");
 
         // Robust parser for ids like "functions.search:0" or fallback "search:0"

--- a/crates/tool_parser/tests/tool_parser_kimik2.rs
+++ b/crates/tool_parser/tests/tool_parser_kimik2.rs
@@ -92,6 +92,58 @@ async fn test_kimik2_streaming() {
     assert!(found_name, "Should have found tool name during streaming");
 }
 
+#[tokio::test]
+async fn test_kimik2_multiline_arguments() {
+    let parser = KimiK2Parser::new();
+
+    // Pretty-printed JSON arguments span multiple lines; the regex must use DOTALL.
+    let input = "Sure.\n\
+<|tool_calls_section_begin|>\n\
+<|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{\n  \"location\": \"Tokyo\",\n  \"note\": \"line one\\nline two\"\n}<|tool_call_end|>\n\
+<|tool_calls_section_end|>";
+
+    let (normal_text, tools) = parser.parse_complete(input).await.unwrap();
+    assert_eq!(tools.len(), 1);
+    assert_eq!(normal_text, "Sure.\n");
+    assert_eq!(tools[0].function.name, "get_weather");
+
+    let args: serde_json::Value = serde_json::from_str(&tools[0].function.arguments).unwrap();
+    assert_eq!(args["location"], "Tokyo");
+    assert_eq!(args["note"], "line one\nline two");
+}
+
+#[tokio::test]
+async fn test_kimik2_streaming_multiline_arguments() {
+    let tools = create_test_tools();
+    let mut parser = KimiK2Parser::new();
+
+    let chunks = vec![
+        "<|tool_calls_section_begin|>\n",
+        "<|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>",
+        "{\n  \"location\": ",
+        "\"Tokyo\"\n}",
+        "<|tool_call_end|>\n",
+        "<|tool_calls_section_end|>",
+    ];
+
+    let mut found_name = false;
+    let mut streamed_args = String::new();
+    for chunk in chunks {
+        let result = parser.parse_incremental(chunk, &tools).await.unwrap();
+        for call in result.calls {
+            if let Some(name) = call.name {
+                assert_eq!(name, "get_weather");
+                found_name = true;
+            }
+            streamed_args.push_str(&call.parameters);
+        }
+    }
+
+    assert!(found_name, "Should have found tool name during streaming");
+    let args: serde_json::Value = serde_json::from_str(&streamed_args).unwrap();
+    assert_eq!(args["location"], "Tokyo");
+}
+
 #[test]
 fn test_kimik2_format_detection() {
     let parser = KimiK2Parser::new();


### PR DESCRIPTION
## Description

### Problem

The three Kimi-K2 tool-call regexes in `crates/tool_parser/src/parsers/kimik2.rs` (complete, streaming, and end patterns) omit the `(?s)` DOTALL flag that every other regex-based parser in this crate uses (deepseek, glm, qwen, step3, minimax, dsml). Without `(?s)`, `.` does not match `\n`, so any Kimi-K2 tool call whose JSON arguments span multiple lines — pretty-printed JSON, or a string value containing a newline — fails to match. `parse_complete` then falls back to returning the whole text as normal text, and streaming never detects the call.

### Solution

Prefix the three patterns with `(?s)`, matching the rest of the crate. The id pattern is left unchanged: it is anchored (`^...$`) over an id that never contains newlines, so DOTALL is irrelevant there.

## Changes

- `crates/tool_parser/src/parsers/kimik2.rs`: add `(?s)` to `tool_call_pattern`, `stream_pattern`, and `end_pattern`.
- `crates/tool_parser/tests/tool_parser_kimik2.rs`: add `test_kimik2_multiline_arguments` (non-streaming, pretty-printed args with an embedded newline string value) and `test_kimik2_streaming_multiline_arguments` (streaming chunks containing newlines).

## Test Plan

Scenario: a Kimi-K2 tool call whose JSON arguments are pretty-printed across multiple lines and contain a string value with an embedded `\n`.

- Before: both new tests fail on unpatched code — `parse_complete` returns `tools.len() == 0` (whole text returned as normal text), and the streaming path produces no parseable arguments.
- After: both pass; arguments parse back to the expected JSON.

Gate (sccache disabled, scoped to the changed crate `tool-parser`):

```
$ cargo +nightly fmt --all
(no output, exit 0)

$ RUSTC_WRAPPER="" cargo clippy -p tool-parser --all-targets -- -D warnings
    Checking tool-parser v1.2.0 (/Users/simolin/opensource/smg/.../crates/tool_parser)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 16.89s
(exit 0, no lint warnings)

$ RUSTC_WRAPPER="" cargo test -p tool-parser
     Running unittests src/lib.rs
running 59 tests
test result: ok. 59 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
...
     Running tests/tool_parser_kimik2.rs
running 10 tests
test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
...
   Doc-tests tool_parser
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
(exit 0)
```

From the codebase audit: crates/tool_parser/src/parsers/kimik2.rs:109 — Kimi-K2 regexes omit (?s) DOTALL, breaking multi-line JSON arguments.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool call parsing to correctly handle tool calls and JSON arguments that span multiple lines in the input buffer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->