### PR TITLE
fix(tokenizer): drain consumed tokens in DecodeStream to bound memory

### DIFF
--- a/crates/tokenizer/README.md
+++ b/crates/tokenizer/README.md
@@ -107,6 +107,8 @@ as of `tokenizer/src/*`.
 - Each `step` decodes the known prefix and the new slice; when the new slice produces additional
   UTF-8 text (and does not end in the replacement character `�`), it returns the incremental chunk
   and updates offsets. Otherwise it returns `None` and waits for more tokens.
+- Consumed tokens below the prefix window are drained after each successful step, so retained
+  history stays bounded regardless of generation length.
 - `step_batch` and `flush` offer convenience for batching and draining remaining text.
 
 ### `Sequence` (`sequence.rs`)

--- a/crates/tokenizer/src/stream.rs
+++ b/crates/tokenizer/src/stream.rs
@@ -6,7 +6,7 @@ use anyhow::Result;
 
 use crate::traits::{self, TokenIdType};
 
-const INITIAL_INCREMENTAL_DETOKENIZATION_OFFSET: usize = 5;
+pub(crate) const INITIAL_INCREMENTAL_DETOKENIZATION_OFFSET: usize = 5;
 
 /// DecodeStream will keep the state necessary to produce individual chunks of
 /// strings given an input stream of token_ids
@@ -71,6 +71,15 @@ impl DecodeStream {
             self.prefix_offset = self.read_offset;
             self.read_offset = self.all_token_ids.len();
 
+            // Drain tokens below the prefix window; they can no longer affect
+            // any future decode. Rebase offsets to keep retained history bounded.
+            if self.prefix_offset > 0 {
+                let drained = self.prefix_offset;
+                self.all_token_ids.drain(..drained);
+                self.prefix_offset -= drained;
+                self.read_offset -= drained;
+            }
+
             Ok(Some(new_text))
         } else {
             Ok(None)
@@ -109,7 +118,10 @@ impl DecodeStream {
         Ok(None)
     }
 
-    /// Get all tokens processed so far
+    /// Get the retained token window (sliding buffer, not full history).
+    ///
+    /// Consumed tokens are drained after each successful step to bound memory,
+    /// so this returns only the tokens still needed for incremental decoding.
     pub fn tokens(&self) -> &[u32] {
         &self.all_token_ids
     }

--- a/crates/tokenizer/src/tests.rs
+++ b/crates/tokenizer/src/tests.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use crate::{
     mock,
+    stream::INITIAL_INCREMENTAL_DETOKENIZATION_OFFSET,
     traits::{Decoder, Encoder},
     Tokenizer,
 };
@@ -71,8 +72,9 @@ fn test_decode_stream_basic() {
     let result = stream.step(3).unwrap();
     assert_eq!(result, Some(" test".to_string()));
 
-    // The stream should now track all three tokens
-    assert_eq!(stream.tokens(), &[1, 2, 3]);
+    // Consumed tokens are drained after a successful step; only the retained
+    // window remains.
+    assert_eq!(stream.tokens(), &[3]);
 }
 
 #[test]
@@ -98,7 +100,7 @@ fn test_decode_stream_multiple_steps() {
     let result = stream.step(3).unwrap();
     assert_eq!(result, Some(" test".to_string()));
 
-    assert_eq!(stream.tokens(), &[1, 2, 3]);
+    assert_eq!(stream.tokens(), &[3]);
 }
 
 #[test]
@@ -249,4 +251,38 @@ fn test_decode_stream_multibyte_char_boundary() {
     //   "byte index 3 is not a char boundary; it is inside '🎉' (bytes 2..6)"
     let result = stream.step(3).unwrap();
     assert_eq!(result, Some("\u{1F389}".to_string()));
+}
+
+/// Retained token history must stay bounded across many steps (no per-stream
+/// unbounded growth), while accumulated output still matches a full decode.
+#[test]
+fn test_decode_stream_history_bounded() {
+    let mock_tokenizer = Arc::new(mock::MockTokenizer::new());
+    let tokenizer = Tokenizer::from_arc(mock_tokenizer);
+
+    let mut stream = tokenizer.decode_stream(&[], false);
+
+    let mut all_token_ids = Vec::new();
+    let mut output = String::new();
+    for i in 0..1000u32 {
+        let token_id = (i % 4) + 1; // cycle through mock word tokens
+        all_token_ids.push(token_id);
+        if let Some(text) = stream.step(token_id).unwrap() {
+            output.push_str(&text);
+        }
+        // Buffer holds at most the prefix window plus the newest token, never
+        // the full history.
+        assert!(
+            stream.tokens().len() <= INITIAL_INCREMENTAL_DETOKENIZATION_OFFSET + 1,
+            "retained history grew to {} tokens",
+            stream.tokens().len()
+        );
+    }
+
+    if let Some(text) = stream.flush().unwrap() {
+        output.push_str(&text);
+    }
+
+    let expected = tokenizer.decode(&all_token_ids, false).unwrap();
+    assert_eq!(output, expected, "drained output must match full decode");
 }


### PR DESCRIPTION
## Description

### Problem

`DecodeStream::step` appends every generated token to its internal `all_token_ids` buffer but never drains it. The two offsets (`prefix_offset`, `read_offset`) advance, yet the consumed tokens below `prefix_offset` are kept for the entire lifetime of the stream. For a long-lived streaming response this is unbounded memory growth per stream — the buffer grows by one entry per generated token even though only the small prefix window is ever read by subsequent `decode()` calls.

This mirrors a class of issue already solved elsewhere in the crate: the `Decoder::decode_step` default and `Sequence` both drain consumed tokens to keep memory bounded; `DecodeStream` was the outlier.

### Solution

After each successful step (the branch that emits a chunk and advances the offsets), drain the tokens below the prefix window and rebase both offsets:

```rust
self.prefix_offset = self.read_offset;
self.read_offset = self.all_token_ids.len();

if self.prefix_offset > 0 {
    let drained = self.prefix_offset;
    self.all_token_ids.drain(..drained);
    self.prefix_offset -= drained;
    self.read_offset -= drained;
}
```

The active decode windows (`prefix_offset..read_offset` and `read_offset..`) are preserved exactly, so incremental output and `flush()` behavior are unchanged. Only tokens that can no longer affect any future decode are removed. The public `tokens()` accessor now returns the retained sliding window rather than full history (documented), matching `Sequence::token_ids()`.

## Changes

- `crates/tokenizer/src/stream.rs`: drain consumed tokens below `prefix_offset` and rebase offsets after a successful step; update `tokens()` doc to reflect the sliding-window semantics. Made `INITIAL_INCREMENTAL_DETOKENIZATION_OFFSET` `pub(crate)` so the test can assert against the real window size.
- `crates/tokenizer/src/tests.rs`: added `test_decode_stream_history_bounded` (1000 steps, asserts the retained buffer stays within the detokenization window and that accumulated output equals a full decode); updated two existing `tokens()` assertions for the new draining behavior.
- `crates/tokenizer/README.md`: note that consumed tokens are drained so retained history stays bounded.

## Test Plan

Scenario: stream 1000 tokens through a single `DecodeStream` and assert (a) the retained token buffer never exceeds the detokenization window (`INITIAL_INCREMENTAL_DETOKENIZATION_OFFSET + 1`) regardless of total tokens, and (b) accumulated incremental output still equals a full decode of all tokens. Correctness is additionally guarded end-to-end by the existing real-tokenizer integration tests `test_decode_stream` and `test_long_sequence_incremental_decode_with_prefill`, which compare accumulated `step()` output against the original prompt.

Gate (sccache disabled, scoped to the changed crate `llm-tokenizer`):

```
$ cargo +nightly fmt --all
(clean, exit 0)

$ RUSTC_WRAPPER="" cargo clippy -p llm-tokenizer --all-targets -- -D warnings
    Checking llm-tokenizer v1.3.2 (crates/tokenizer)
    Finished `dev` profile [unoptimized + debuginfo] target(s)
clippy exit: 0

$ RUSTC_WRAPPER="" cargo test -p llm-tokenizer
test tests::test_decode_stream_history_bounded ... ok
test test_decode_stream ... ok
test test_long_sequence_incremental_decode_with_prefill ... ok
test result: ok. 132 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out   (lib)
... (all binaries)
aggregate: 199 passed; 0 failed; 13 ignored
```

From the codebase audit: crates/tokenizer/src/stream.rs:48 — DecodeStream never drains all_token_ids: unbounded memory per stream.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token stream management to drain consumed tokens and keep retained history bounded, preventing unbounded memory growth during streaming operations.

* **Documentation**
  * Clarified token stream behavior documentation to reflect the bounded token window retention model.

* **Tests**
  * Strengthened validation tests to verify bounded token history behavior and added regression test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->