### PR TITLE
fix(kv_index): bound worker interning to avoid OOB panic at capacity

### DIFF
--- a/crates/kv_index/benches/throughput_bench.rs
+++ b/crates/kv_index/benches/throughput_bench.rs
@@ -667,7 +667,9 @@ async fn run_benchmark(args: &Args, traces: Vec<Vec<TimedEntry>>) -> BenchmarkRe
 
     let num_total_workers = args.num_workers * args.duplication_factor;
     for w in 0..num_total_workers {
-        indexer.intern_worker(&format!("worker-{w}"));
+        indexer
+            .intern_worker(&format!("worker-{w}"))
+            .expect("worker count exceeds indexer capacity");
     }
 
     let traces: Vec<Arc<Vec<TimedEntry>>> = traces.into_iter().map(Arc::new).collect();

--- a/crates/kv_index/src/event_tree.rs
+++ b/crates/kv_index/src/event_tree.rs
@@ -505,23 +505,33 @@ impl PositionalIndexer {
     // -----------------------------------------------------------------------
 
     /// Intern a worker URL to an internal u32 ID.
+    ///
+    /// Returns `None` once `MAX_WORKERS` distinct workers have been interned. The id
+    /// is reserved only when under the limit, so an over-limit worker is never
+    /// recorded in `worker_to_id` and `next_worker_id` never exceeds `MAX_WORKERS`
+    /// (keeping every `tree_sizes` index in bounds).
+    ///
     /// Fast path: DashMap shard read (no lock). Slow path: DashMap entry API (once per worker).
-    pub fn intern_worker(&self, worker: &str) -> u32 {
+    pub fn intern_worker(&self, worker: &str) -> Option<u32> {
         // Fast path: already interned
         if let Some(entry) = self.worker_to_id.get(worker) {
-            return *entry.value();
+            return Some(*entry.value());
         }
-        // Slow path: DashMap entry API handles the race — or_insert_with runs at most once.
-        let id = *self
-            .worker_to_id
-            .entry(Arc::from(worker))
-            .or_insert_with(|| self.next_worker_id.fetch_add(1, Ordering::Relaxed))
-            .value();
-        assert!(
-            (id as usize) < MAX_WORKERS,
-            "worker count {id} exceeds MAX_WORKERS ({MAX_WORKERS})"
-        );
-        id
+        // Slow path: the entry API serializes concurrent first-inserts for this URL.
+        match self.worker_to_id.entry(Arc::from(worker)) {
+            Entry::Occupied(occ) => Some(*occ.get()),
+            Entry::Vacant(vac) => {
+                // Reserve an id only while under the limit; bail before mutating if full.
+                let reserved = self
+                    .next_worker_id
+                    .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |id| {
+                        ((id as usize) < MAX_WORKERS).then_some(id + 1)
+                    })
+                    .ok()?;
+                vac.insert(reserved);
+                Some(reserved)
+            }
+        }
     }
 
     // -----------------------------------------------------------------------
@@ -810,7 +820,7 @@ mod tests {
     fn test_store_and_find_single_worker() {
         let indexer = PositionalIndexer::new(64);
         let blocks = make_blocks(&[10, 20, 30]);
-        let w1 = indexer.intern_worker("http://w1:8000");
+        let w1 = indexer.intern_worker("http://w1:8000").unwrap();
         let mut wb1 = WorkerBlockMap::default();
         indexer.apply_stored(w1, &blocks, None, &mut wb1).unwrap();
 
@@ -823,7 +833,7 @@ mod tests {
     fn test_store_partial_prefix_match() {
         let indexer = PositionalIndexer::new(64);
         let blocks = make_blocks(&[10, 20, 30]);
-        let w1 = indexer.intern_worker("http://w1:8000");
+        let w1 = indexer.intern_worker("http://w1:8000").unwrap();
         let mut wb1 = WorkerBlockMap::default();
         indexer.apply_stored(w1, &blocks, None, &mut wb1).unwrap();
 
@@ -836,7 +846,7 @@ mod tests {
     fn test_store_no_match() {
         let indexer = PositionalIndexer::new(64);
         let blocks = make_blocks(&[10, 20, 30]);
-        let w1 = indexer.intern_worker("http://w1:8000");
+        let w1 = indexer.intern_worker("http://w1:8000").unwrap();
         let mut wb1 = WorkerBlockMap::default();
         indexer.apply_stored(w1, &blocks, None, &mut wb1).unwrap();
 
@@ -849,8 +859,8 @@ mod tests {
         let indexer = PositionalIndexer::new(64);
         let blocks_w1 = make_blocks(&[10, 20, 30]);
         let blocks_w2 = make_blocks(&[10, 20]);
-        let w1 = indexer.intern_worker("http://w1:8000");
-        let w2 = indexer.intern_worker("http://w2:8000");
+        let w1 = indexer.intern_worker("http://w1:8000").unwrap();
+        let w2 = indexer.intern_worker("http://w2:8000").unwrap();
         let mut wb1 = WorkerBlockMap::default();
         let mut wb2 = WorkerBlockMap::default();
         indexer
@@ -870,7 +880,7 @@ mod tests {
         let indexer = PositionalIndexer::new(64);
         let blocks = make_blocks(&[10, 20, 30]);
         let seq_hash_of_30 = blocks[2].seq_hash;
-        let w1 = indexer.intern_worker("http://w1:8000");
+        let w1 = indexer.intern_worker("http://w1:8000").unwrap();
         let mut wb1 = WorkerBlockMap::default();
         indexer.apply_stored(w1, &blocks, None, &mut wb1).unwrap();
         indexer.apply_removed(w1, &[seq_hash_of_30], &mut wb1);
@@ -886,8 +896,8 @@ mod tests {
         let indexer = PositionalIndexer::new(64);
         let blocks_w1 = make_blocks(&[10, 20, 30]);
         let blocks_w2 = make_blocks(&[10, 20]);
-        let w1 = indexer.intern_worker("http://w1:8000");
-        let w2 = indexer.intern_worker("http://w2:8000");
+        let w1 = indexer.intern_worker("http://w1:8000").unwrap();
+        let w2 = indexer.intern_worker("http://w2:8000").unwrap();
         let mut wb1 = WorkerBlockMap::default();
         let mut wb2 = WorkerBlockMap::default();
         indexer
@@ -909,8 +919,8 @@ mod tests {
         let indexer = PositionalIndexer::new(64);
         let blocks_w1 = make_blocks(&[10, 20, 30]);
         let blocks_w2 = make_blocks(&[10, 20]);
-        let w1 = indexer.intern_worker("http://w1:8000");
-        let w2 = indexer.intern_worker("http://w2:8000");
+        let w1 = indexer.intern_worker("http://w1:8000").unwrap();
+        let w2 = indexer.intern_worker("http://w2:8000").unwrap();
         let mut wb1 = WorkerBlockMap::default();
         let mut wb2 = WorkerBlockMap::default();
         indexer
@@ -931,7 +941,7 @@ mod tests {
         // First store: blocks at positions 0, 1
         let blocks1 = make_blocks(&[10, 20]);
         let parent_seq_hash = blocks1[1].seq_hash;
-        let w1 = indexer.intern_worker("http://w1:8000");
+        let w1 = indexer.intern_worker("http://w1:8000").unwrap();
         let mut wb1 = WorkerBlockMap::default();
         indexer.apply_stored(w1, &blocks1, None, &mut wb1).unwrap();
 
@@ -959,7 +969,7 @@ mod tests {
     fn test_store_with_parent_error_worker_not_tracked() {
         let indexer = PositionalIndexer::new(64);
         let blocks = make_blocks(&[10, 20]);
-        let w1 = indexer.intern_worker("http://w1:8000");
+        let w1 = indexer.intern_worker("http://w1:8000").unwrap();
         let mut wb1 = WorkerBlockMap::default();
         let result = indexer.apply_stored(w1, &blocks, Some(SequenceHash(999)), &mut wb1);
         assert!(matches!(result, Err(ApplyError::WorkerNotTracked)));
@@ -969,7 +979,7 @@ mod tests {
     fn test_store_with_parent_error_parent_not_found() {
         let indexer = PositionalIndexer::new(64);
         let blocks1 = make_blocks(&[10, 20]);
-        let w1 = indexer.intern_worker("http://w1:8000");
+        let w1 = indexer.intern_worker("http://w1:8000").unwrap();
         let mut wb1 = WorkerBlockMap::default();
         indexer.apply_stored(w1, &blocks1, None, &mut wb1).unwrap();
 
@@ -982,7 +992,7 @@ mod tests {
     fn test_remove_missing_block_is_noop() {
         let indexer = PositionalIndexer::new(64);
         let blocks = make_blocks(&[10, 20, 30]);
-        let w1 = indexer.intern_worker("http://w1:8000");
+        let w1 = indexer.intern_worker("http://w1:8000").unwrap();
         let mut wb1 = WorkerBlockMap::default();
         indexer.apply_stored(w1, &blocks, None, &mut wb1).unwrap();
 
@@ -993,7 +1003,7 @@ mod tests {
     #[test]
     fn test_remove_unknown_worker_is_noop() {
         let indexer = PositionalIndexer::new(64);
-        let w1 = indexer.intern_worker("http://unknown:8000");
+        let w1 = indexer.intern_worker("http://unknown:8000").unwrap();
         let mut wb1 = WorkerBlockMap::default();
         indexer.apply_removed(w1, &[SequenceHash(1)], &mut wb1);
     }
@@ -1002,7 +1012,7 @@ mod tests {
     fn test_remove_worker() {
         let indexer = PositionalIndexer::new(64);
         let blocks = make_blocks(&[10, 20, 30]);
-        let w1 = indexer.intern_worker("http://w1:8000");
+        let w1 = indexer.intern_worker("http://w1:8000").unwrap();
         let mut wb1 = WorkerBlockMap::default();
         indexer.apply_stored(w1, &blocks, None, &mut wb1).unwrap();
         indexer.remove_worker(w1, wb1);
@@ -1015,9 +1025,9 @@ mod tests {
     #[test]
     fn test_multiple_workers_same_position() {
         let indexer = PositionalIndexer::new(64);
-        let w1 = indexer.intern_worker("http://w1:8000");
-        let w2 = indexer.intern_worker("http://w2:8000");
-        let w3 = indexer.intern_worker("http://w3:8000");
+        let w1 = indexer.intern_worker("http://w1:8000").unwrap();
+        let w2 = indexer.intern_worker("http://w2:8000").unwrap();
+        let w3 = indexer.intern_worker("http://w3:8000").unwrap();
         let mut wb1 = WorkerBlockMap::default();
         let mut wb2 = WorkerBlockMap::default();
         let mut wb3 = WorkerBlockMap::default();
@@ -1040,7 +1050,7 @@ mod tests {
     #[test]
     fn test_empty_blocks_is_noop() {
         let indexer = PositionalIndexer::new(64);
-        let w1 = indexer.intern_worker("http://w1:8000");
+        let w1 = indexer.intern_worker("http://w1:8000").unwrap();
         let mut wb1 = WorkerBlockMap::default();
         indexer.apply_stored(w1, &[], None, &mut wb1).unwrap();
         assert_eq!(indexer.current_size(), 0);
@@ -1050,7 +1060,7 @@ mod tests {
     fn test_single_block_sequence() {
         let indexer = PositionalIndexer::new(64);
         let blocks = make_blocks(&[42]);
-        let w1 = indexer.intern_worker("http://w1:8000");
+        let w1 = indexer.intern_worker("http://w1:8000").unwrap();
         let mut wb1 = WorkerBlockMap::default();
         indexer.apply_stored(w1, &blocks, None, &mut wb1).unwrap();
 
@@ -1081,7 +1091,7 @@ mod tests {
         let indexer = PositionalIndexer::new(4); // small jump_size to exercise jump logic
         let values: Vec<u64> = (1..=20).collect();
         let blocks = make_blocks(&values);
-        let w1 = indexer.intern_worker("http://w1:8000");
+        let w1 = indexer.intern_worker("http://w1:8000").unwrap();
         let mut wb1 = WorkerBlockMap::default();
         indexer.apply_stored(w1, &blocks, None, &mut wb1).unwrap();
 
@@ -1095,8 +1105,8 @@ mod tests {
         // w1 has 10 blocks, w2 has 6
         let values_w1: Vec<u64> = (1..=10).collect();
         let values_w2: Vec<u64> = (1..=6).collect();
-        let w1 = indexer.intern_worker("http://w1:8000");
-        let w2 = indexer.intern_worker("http://w2:8000");
+        let w1 = indexer.intern_worker("http://w1:8000").unwrap();
+        let w2 = indexer.intern_worker("http://w2:8000").unwrap();
         let mut wb1 = WorkerBlockMap::default();
         let mut wb2 = WorkerBlockMap::default();
         indexer
@@ -1119,9 +1129,9 @@ mod tests {
         let v1: Vec<u64> = (1..=12).collect();
         let v2: Vec<u64> = (1..=7).collect();
         let v3: Vec<u64> = (1..=4).collect();
-        let w1 = indexer.intern_worker("http://w1:8000");
-        let w2 = indexer.intern_worker("http://w2:8000");
-        let w3 = indexer.intern_worker("http://w3:8000");
+        let w1 = indexer.intern_worker("http://w1:8000").unwrap();
+        let w2 = indexer.intern_worker("http://w2:8000").unwrap();
+        let w3 = indexer.intern_worker("http://w3:8000").unwrap();
         let mut wb1 = WorkerBlockMap::default();
         let mut wb2 = WorkerBlockMap::default();
         let mut wb3 = WorkerBlockMap::default();
@@ -1152,7 +1162,9 @@ mod tests {
         let writer = thread::spawn(move || {
             for i in 0..100u64 {
                 let blocks = make_blocks(&[i * 10, i * 10 + 1, i * 10 + 2]);
-                let wid = indexer_writer.intern_worker(&format!("http://w{i}:8000"));
+                let wid = indexer_writer
+                    .intern_worker(&format!("http://w{i}:8000"))
+                    .unwrap();
                 let mut wb = WorkerBlockMap::default();
                 let _ = indexer_writer.apply_stored(wid, &blocks, None, &mut wb);
             }
@@ -1181,8 +1193,8 @@ mod tests {
             seq_hash: SequenceHash(100),
             content_hash: ContentHash(10),
         }];
-        let w1 = indexer.intern_worker("http://w1:8000");
-        let w2 = indexer.intern_worker("http://w2:8000");
+        let w1 = indexer.intern_worker("http://w1:8000").unwrap();
+        let w2 = indexer.intern_worker("http://w2:8000").unwrap();
         let mut wb1 = WorkerBlockMap::default();
         let mut wb2 = WorkerBlockMap::default();
         indexer
@@ -1212,8 +1224,8 @@ mod tests {
         // Worker 1: position 0 = content 10, position 1 = content 99
         // Prefix at pos 1 = XXH3(10 || 99)
         let blocks_w1 = make_blocks(&[10, 99]);
-        let w1 = indexer.intern_worker("http://w1:8000");
-        let w2 = indexer.intern_worker("http://w2:8000");
+        let w1 = indexer.intern_worker("http://w1:8000").unwrap();
+        let w2 = indexer.intern_worker("http://w2:8000").unwrap();
         let mut wb1 = WorkerBlockMap::default();
         let mut wb2 = WorkerBlockMap::default();
         indexer
@@ -1245,7 +1257,7 @@ mod tests {
     fn test_early_exit_returns_score_one() {
         let indexer = PositionalIndexer::new(64);
         let blocks = make_blocks(&[10, 20, 30]);
-        let w1 = indexer.intern_worker("http://w1:8000");
+        let w1 = indexer.intern_worker("http://w1:8000").unwrap();
         let mut wb1 = WorkerBlockMap::default();
         indexer.apply_stored(w1, &blocks, None, &mut wb1).unwrap();
 
@@ -1260,7 +1272,7 @@ mod tests {
     fn test_early_exit_no_match() {
         let indexer = PositionalIndexer::new(64);
         let blocks = make_blocks(&[10, 20, 30]);
-        let w1 = indexer.intern_worker("http://w1:8000");
+        let w1 = indexer.intern_worker("http://w1:8000").unwrap();
         let mut wb1 = WorkerBlockMap::default();
         indexer.apply_stored(w1, &blocks, None, &mut wb1).unwrap();
 
@@ -1281,12 +1293,42 @@ mod tests {
     #[test]
     fn test_worker_id_after_store() {
         let indexer = PositionalIndexer::default();
-        let w1 = indexer.intern_worker("http://w1:8000");
+        let w1 = indexer.intern_worker("http://w1:8000").unwrap();
         let mut wb1 = WorkerBlockMap::default();
         indexer
             .apply_stored(w1, &make_blocks(&[10]), None, &mut wb1)
             .unwrap();
         assert!(indexer.worker_id("http://w1:8000").is_some());
+    }
+
+    #[test]
+    fn test_intern_worker_over_limit_returns_none_without_corrupting_state() {
+        let indexer = PositionalIndexer::default();
+
+        for i in 0..MAX_WORKERS {
+            assert_eq!(
+                indexer.intern_worker(&format!("http://w{i}:8000")),
+                Some(i as u32)
+            );
+        }
+
+        // The (MAX_WORKERS + 1)th distinct worker has no slot: refuse it rather
+        // than persist an over-limit id that would later index tree_sizes OOB.
+        assert_eq!(indexer.intern_worker("http://overflow:8000"), None);
+        assert!(indexer.worker_id("http://overflow:8000").is_none());
+
+        // Re-interning still returns None (no bad state was recorded on the first try).
+        assert_eq!(indexer.intern_worker("http://overflow:8000"), None);
+
+        // current_size() slices tree_sizes[..next_worker_id]; it must stay in bounds.
+        assert_eq!(indexer.current_size(), 0);
+
+        // An already-interned worker is unaffected by hitting the cap.
+        let last = MAX_WORKERS - 1;
+        assert_eq!(
+            indexer.intern_worker(&format!("http://w{last}:8000")),
+            Some(last as u32)
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -1297,7 +1339,7 @@ mod tests {
     fn test_tree_sizes_after_store_and_remove() {
         let indexer = PositionalIndexer::new(64);
         let blocks = make_blocks(&[10, 20, 30, 40, 50]);
-        let w1 = indexer.intern_worker("http://w1:8000");
+        let w1 = indexer.intern_worker("http://w1:8000").unwrap();
         let mut wb1 = WorkerBlockMap::default();
         indexer.apply_stored(w1, &blocks, None, &mut wb1).unwrap();
         assert_eq!(indexer.current_size(), 5);
@@ -1315,7 +1357,7 @@ mod tests {
     fn test_duplicate_store_does_not_inflate_tree_size() {
         let indexer = PositionalIndexer::new(64);
         let blocks = make_blocks(&[10, 20, 30]);
-        let w1 = indexer.intern_worker("http://w1:8000");
+        let w1 = indexer.intern_worker("http://w1:8000").unwrap();
         let mut wb1 = WorkerBlockMap::default();
 
         // First store: 3 new blocks
@@ -1339,7 +1381,7 @@ mod tests {
     #[test]
     fn test_remove_worker_nonexistent_is_noop() {
         let indexer = PositionalIndexer::default();
-        let w = indexer.intern_worker("http://ghost:8000");
+        let w = indexer.intern_worker("http://ghost:8000").unwrap();
         indexer.remove_worker(w, WorkerBlockMap::default()); // no-op, no panic
         assert_eq!(indexer.current_size(), 0);
     }
@@ -1349,7 +1391,7 @@ mod tests {
         let indexer = Arc::new(PositionalIndexer::new(4));
         let content: Vec<u64> = (1..=20).collect();
         let blocks = make_blocks(&content);
-        let w1 = indexer.intern_worker("http://w1:8000");
+        let w1 = indexer.intern_worker("http://w1:8000").unwrap();
         let mut wb1 = WorkerBlockMap::default();
         indexer.apply_stored(w1, &blocks, None, &mut wb1).unwrap();
 
@@ -1374,7 +1416,7 @@ mod tests {
             let worker_content: Vec<u64> = (1..=5).collect();
             handles.push(std::thread::spawn(move || {
                 let worker = format!("http://writer{i}:8000");
-                let wid = idx.intern_worker(&worker);
+                let wid = idx.intern_worker(&worker).unwrap();
                 let mut wb = WorkerBlockMap::default();
                 let blks = make_blocks(&worker_content);
                 for _ in 0..50 {
@@ -1396,8 +1438,8 @@ mod tests {
     fn test_dashmap_cleanup_no_memory_leak() {
         let indexer = PositionalIndexer::default();
         let blocks = make_blocks(&[10, 20, 30]);
-        let w1 = indexer.intern_worker("http://w1:8000");
-        let w2 = indexer.intern_worker("http://w2:8000");
+        let w1 = indexer.intern_worker("http://w1:8000").unwrap();
+        let w2 = indexer.intern_worker("http://w2:8000").unwrap();
         let mut wb1 = WorkerBlockMap::default();
         let mut wb2 = WorkerBlockMap::default();
         indexer.apply_stored(w1, &blocks, None, &mut wb1).unwrap();
@@ -1446,7 +1488,7 @@ mod tests {
     fn test_query_prefix_of_stored() {
         let indexer = PositionalIndexer::default();
         let blocks = make_blocks(&[10, 20, 30, 40, 50]);
-        let w1 = indexer.intern_worker("http://w1:8000");
+        let w1 = indexer.intern_worker("http://w1:8000").unwrap();
         let mut wb1 = WorkerBlockMap::default();
         indexer.apply_stored(w1, &blocks, None, &mut wb1).unwrap();
 
@@ -1460,8 +1502,8 @@ mod tests {
         let indexer = PositionalIndexer::default();
         let blocks_w1 = make_blocks(&[10, 20, 30]);
         let blocks_w2 = make_blocks(&[99, 88, 77]);
-        let w1 = indexer.intern_worker("http://w1:8000");
-        let w2 = indexer.intern_worker("http://w2:8000");
+        let w1 = indexer.intern_worker("http://w1:8000").unwrap();
+        let w2 = indexer.intern_worker("http://w2:8000").unwrap();
         let mut wb1 = WorkerBlockMap::default();
         let mut wb2 = WorkerBlockMap::default();
         indexer
@@ -1492,8 +1534,8 @@ mod tests {
         assert_eq!(indexer.current_size(), 0);
 
         let blocks = make_blocks(&[10, 20, 30]);
-        let w1 = indexer.intern_worker("http://w1:8000");
-        let w2 = indexer.intern_worker("http://w2:8000");
+        let w1 = indexer.intern_worker("http://w1:8000").unwrap();
+        let w2 = indexer.intern_worker("http://w2:8000").unwrap();
         let mut wb1 = WorkerBlockMap::default();
         let mut wb2 = WorkerBlockMap::default();
         indexer.apply_stored(w1, &blocks, None, &mut wb1).unwrap();
@@ -1591,7 +1633,7 @@ mod tests {
             })
             .collect();
 
-        let w1 = indexer.intern_worker("http://w1:8000");
+        let w1 = indexer.intern_worker("http://w1:8000").unwrap();
         let mut wb1 = WorkerBlockMap::default();
         indexer.apply_stored(w1, &blocks, None, &mut wb1).unwrap();
 
@@ -1614,7 +1656,7 @@ mod tests {
                 content_hash: compute_content_hash(chunk),
             })
             .collect();
-        let w1 = indexer.intern_worker("http://w1:8000");
+        let w1 = indexer.intern_worker("http://w1:8000").unwrap();
         let mut wb1 = WorkerBlockMap::default();
         indexer.apply_stored(w1, &blocks, None, &mut wb1).unwrap();
 
@@ -1653,8 +1695,8 @@ mod tests {
             })
             .collect();
 
-        let sglang = indexer.intern_worker("http://sglang:8000");
-        let vllm = indexer.intern_worker("http://vllm:8000");
+        let sglang = indexer.intern_worker("http://sglang:8000").unwrap();
+        let vllm = indexer.intern_worker("http://vllm:8000").unwrap();
         let mut wb_sg = WorkerBlockMap::default();
         let mut wb_vl = WorkerBlockMap::default();
         indexer
@@ -1682,7 +1724,7 @@ mod tests {
         chunk_size: usize,
         worker_blocks: &mut WorkerBlockMap,
     ) {
-        let worker_id = indexer.intern_worker(worker);
+        let worker_id = indexer.intern_worker(worker).unwrap();
         let all_blocks = make_blocks(content);
         let mut offset = 0;
         let mut parent: Option<SequenceHash> = None;
@@ -1702,7 +1744,7 @@ mod tests {
         let indexer = PositionalIndexer::new(32);
         let full: Vec<u64> = (1..=128).collect();
         let full_blocks = make_blocks(&full);
-        let full_id = indexer.intern_worker("http://full:8000");
+        let full_id = indexer.intern_worker("http://full:8000").unwrap();
         let mut wb_full = WorkerBlockMap::default();
         indexer
             .apply_stored(full_id, &full_blocks, None, &mut wb_full)
@@ -1711,7 +1753,7 @@ mod tests {
         for &depth in &[31, 32, 33] {
             let partial_blocks = make_blocks(&full[..depth]);
             let worker = format!("http://depth{depth}:8000");
-            let wid = indexer.intern_worker(&worker);
+            let wid = indexer.intern_worker(&worker).unwrap();
             let mut wb = WorkerBlockMap::default();
             indexer
                 .apply_stored(wid, &partial_blocks, None, &mut wb)
@@ -1721,7 +1763,7 @@ mod tests {
         for &depth in &[63, 64, 65] {
             let partial_blocks = make_blocks(&full[..depth]);
             let worker = format!("http://depth{depth}:8000");
-            let wid = indexer.intern_worker(&worker);
+            let wid = indexer.intern_worker(&worker).unwrap();
             let mut wb = WorkerBlockMap::default();
             indexer
                 .apply_stored(wid, &partial_blocks, None, &mut wb)
@@ -1745,7 +1787,7 @@ mod tests {
             let content: Vec<u64> = (1..=len as u64).collect();
             let blocks = make_blocks(&content);
             let worker = format!("http://len{len}:8000");
-            let wid = indexer.intern_worker(&worker);
+            let wid = indexer.intern_worker(&worker).unwrap();
             let mut wb = WorkerBlockMap::default();
             indexer.apply_stored(wid, &blocks, None, &mut wb).unwrap();
 
@@ -1767,7 +1809,7 @@ mod tests {
             let content = &full[..len];
             let blocks = make_blocks(content);
             let worker = format!("http://len{len}:8000");
-            let wid = indexer.intern_worker(&worker);
+            let wid = indexer.intern_worker(&worker).unwrap();
             let mut wb = WorkerBlockMap::default();
             indexer.apply_stored(wid, &blocks, None, &mut wb).unwrap();
 
@@ -1789,7 +1831,7 @@ mod tests {
         for &depth in &depths {
             let blocks = make_blocks(&full[..depth]);
             let worker = format!("http://w{depth}:8000");
-            let wid = indexer.intern_worker(&worker);
+            let wid = indexer.intern_worker(&worker).unwrap();
             let mut wb = WorkerBlockMap::default();
             indexer.apply_stored(wid, &blocks, None, &mut wb).unwrap();
         }
@@ -1814,9 +1856,9 @@ mod tests {
         let mut content_w1 = shared.clone();
         content_w1.extend(1001..=1060);
         let blocks_w1 = make_blocks(&content_w1);
-        let w1 = indexer.intern_worker("http://w1:8000");
-        let w2 = indexer.intern_worker("http://w2:8000");
-        let w3 = indexer.intern_worker("http://w3:8000");
+        let w1 = indexer.intern_worker("http://w1:8000").unwrap();
+        let w2 = indexer.intern_worker("http://w2:8000").unwrap();
+        let w3 = indexer.intern_worker("http://w3:8000").unwrap();
         let mut wb1 = WorkerBlockMap::default();
         let mut wb2 = WorkerBlockMap::default();
         let mut wb3 = WorkerBlockMap::default();
@@ -1847,7 +1889,7 @@ mod tests {
         let indexer = PositionalIndexer::new(64);
         let content: Vec<u64> = (1..=1000).collect();
         let blocks = make_blocks(&content);
-        let w1 = indexer.intern_worker("http://w1:8000");
+        let w1 = indexer.intern_worker("http://w1:8000").unwrap();
         let mut wb1 = WorkerBlockMap::default();
         indexer.apply_stored(w1, &blocks, None, &mut wb1).unwrap();
 
@@ -1904,7 +1946,7 @@ mod tests {
     #[test]
     fn test_multiple_disjoint_sequences_per_worker() {
         let indexer = PositionalIndexer::new(64);
-        let w1 = indexer.intern_worker("http://w1:8000");
+        let w1 = indexer.intern_worker("http://w1:8000").unwrap();
         let mut wb1 = WorkerBlockMap::default();
 
         let blocks1 = make_blocks(&[10, 20, 30]);
@@ -1929,7 +1971,7 @@ mod tests {
         let indexer = PositionalIndexer::new(32);
         let content: Vec<u64> = (1..=100).collect();
         let blocks = make_blocks(&content);
-        let w1 = indexer.intern_worker("http://w1:8000");
+        let w1 = indexer.intern_worker("http://w1:8000").unwrap();
         let mut wb1 = WorkerBlockMap::default();
         indexer.apply_stored(w1, &blocks, None, &mut wb1).unwrap();
 
@@ -1949,7 +1991,7 @@ mod tests {
     fn test_remove_parent_does_not_cascade() {
         let indexer = PositionalIndexer::new(1);
         let blocks = make_blocks(&[10, 20, 30, 40, 50]);
-        let w1 = indexer.intern_worker("http://w1:8000");
+        let w1 = indexer.intern_worker("http://w1:8000").unwrap();
         let mut wb1 = WorkerBlockMap::default();
         indexer.apply_stored(w1, &blocks, None, &mut wb1).unwrap();
 
@@ -1964,7 +2006,7 @@ mod tests {
     #[test]
     fn test_long_sequence_clear_and_rebuild() {
         let indexer = PositionalIndexer::new(32);
-        let w1 = indexer.intern_worker("http://w1:8000");
+        let w1 = indexer.intern_worker("http://w1:8000").unwrap();
         let mut wb1 = WorkerBlockMap::default();
 
         let original: Vec<u64> = (1..=100).collect();
@@ -1996,7 +2038,7 @@ mod tests {
         for &depth in &depths {
             let blocks = make_blocks(&content[..depth]);
             let worker = format!("http://w{depth}:8000");
-            let wid = indexer.intern_worker(&worker);
+            let wid = indexer.intern_worker(&worker).unwrap();
             let mut wb = WorkerBlockMap::default();
             indexer.apply_stored(wid, &blocks, None, &mut wb).unwrap();
         }

--- a/model_gateway/benches/radix_tree_benchmark.rs
+++ b/model_gateway/benches/radix_tree_benchmark.rs
@@ -445,7 +445,7 @@ fn build_populated_indexer(
     let mut all_worker_chunks = Vec::with_capacity(workers.len());
 
     for worker in workers {
-        let worker_id = indexer.intern_worker(worker);
+        let worker_id = indexer.intern_worker(worker).unwrap();
         let mut wb = WorkerBlockMap::default();
         indexer
             .apply_stored(worker_id, &shared_blocks, None, &mut wb)
@@ -500,7 +500,7 @@ macro_rules! bench_indexer_store {
                 for _ in 0..iters {
                     let indexer = PositionalIndexer::new(32);
                     for worker in &workers {
-                        let worker_id = indexer.intern_worker(worker);
+                        let worker_id = indexer.intern_worker(worker).unwrap();
                         let mut wb = WorkerBlockMap::default();
                         let chunks = generate_token_chunks($blocks_per_worker, $block_size);
                         let blocks = chunks_to_stored_blocks(&chunks);
@@ -596,7 +596,7 @@ macro_rules! bench_indexer_concurrent {
             (0..$num_threads)
                 .map(|t| {
                     let chunks = &worker_chunks[t % workers.len()];
-                    let worker_id = indexer.intern_worker(&workers[t % workers.len()]);
+                    let worker_id = indexer.intern_worker(&workers[t % workers.len()]).unwrap();
 
                     // Read data: pre-computed content hashes
                     let query_tokens = flatten_tokens(chunks);

--- a/model_gateway/src/policies/cache_aware.rs
+++ b/model_gateway/src/policies/cache_aware.rs
@@ -1465,7 +1465,7 @@ mod tests {
         jump_size: usize,
     ) -> Arc<PositionalIndexer> {
         let indexer = Arc::new(PositionalIndexer::new(jump_size));
-        let worker_id = indexer.intern_worker(worker_url);
+        let worker_id = indexer.intern_worker(worker_url).unwrap();
         let mut wb = WorkerBlockMap::default();
         let blocks: Vec<StoredBlock> = token_chunks
             .iter()
@@ -1581,8 +1581,8 @@ mod tests {
 
         // Store same blocks for both workers (equal overlap)
         let indexer = Arc::new(PositionalIndexer::new(4));
-        let w1_id = indexer.intern_worker("http://w1:8000");
-        let w2_id = indexer.intern_worker("http://w2:8000");
+        let w1_id = indexer.intern_worker("http://w1:8000").unwrap();
+        let w2_id = indexer.intern_worker("http://w2:8000").unwrap();
         let mut wb1 = WorkerBlockMap::default();
         let mut wb2 = WorkerBlockMap::default();
         let blocks = vec![StoredBlock {
@@ -1625,8 +1625,8 @@ mod tests {
         policy.init_workers(&workers);
 
         let indexer = Arc::new(PositionalIndexer::new(4));
-        let w1_id = indexer.intern_worker("http://w1:8000");
-        let w2_id = indexer.intern_worker("http://w2:8000");
+        let w1_id = indexer.intern_worker("http://w1:8000").unwrap();
+        let w2_id = indexer.intern_worker("http://w2:8000").unwrap();
         let mut wb1 = WorkerBlockMap::default();
         let mut wb2 = WorkerBlockMap::default();
 
@@ -1694,8 +1694,8 @@ mod tests {
         policy.init_workers(&workers);
 
         let indexer = Arc::new(PositionalIndexer::new(4));
-        let w1_id = indexer.intern_worker("http://w1:8000");
-        let w2_id = indexer.intern_worker("http://w2:8000");
+        let w1_id = indexer.intern_worker("http://w1:8000").unwrap();
+        let w2_id = indexer.intern_worker("http://w2:8000").unwrap();
         let mut wb1 = WorkerBlockMap::default();
         let mut wb2 = WorkerBlockMap::default();
 
@@ -1944,7 +1944,7 @@ mod tests {
 
         // Store blocks using block_size=8 (tokens chunked in groups of 8)
         let indexer = Arc::new(PositionalIndexer::new(4));
-        let w1_id = indexer.intern_worker("http://w1:8000");
+        let w1_id = indexer.intern_worker("http://w1:8000").unwrap();
         let mut wb = WorkerBlockMap::default();
         let block = vec![StoredBlock {
             seq_hash: SequenceHash(1),

--- a/model_gateway/src/worker/kv_event_monitor.rs
+++ b/model_gateway/src/worker/kv_event_monitor.rs
@@ -308,7 +308,13 @@ impl KvEventMonitor {
         model_id: String,
         mut shutdown_rx: oneshot::Receiver<()>,
     ) {
-        let worker_id = indexer.intern_worker(&worker_url);
+        let Some(worker_id) = indexer.intern_worker(&worker_url) else {
+            warn!(
+                worker_url = %worker_url,
+                "Indexer worker capacity reached, skipping KV event subscription for this worker"
+            );
+            return;
+        };
         let mut worker_blocks = WorkerBlockMap::default();
         let mut last_seq: u64 = 0;
         let mut reconnect_delay_ms = INITIAL_RECONNECT_DELAY_MS;
@@ -673,7 +679,7 @@ mod tests {
     #[test]
     fn test_apply_stored_no_parent() {
         let indexer = PositionalIndexer::new(64);
-        let w1 = indexer.intern_worker("http://w1:8000");
+        let w1 = indexer.intern_worker("http://w1:8000").unwrap();
         let mut wb = WorkerBlockMap::default();
         let stored = KvBlocksStored {
             blocks: vec![
@@ -702,7 +708,7 @@ mod tests {
     #[test]
     fn test_apply_stored_with_parent() {
         let indexer = PositionalIndexer::new(64);
-        let w1 = indexer.intern_worker("http://w1:8000");
+        let w1 = indexer.intern_worker("http://w1:8000").unwrap();
         let mut wb = WorkerBlockMap::default();
 
         let stored1 = KvBlocksStored {
@@ -734,7 +740,7 @@ mod tests {
     #[test]
     fn test_apply_stored_fallback_on_worker_not_tracked() {
         let indexer = PositionalIndexer::new(64);
-        let w1 = indexer.intern_worker("http://new-worker:8000");
+        let w1 = indexer.intern_worker("http://new-worker:8000").unwrap();
         let mut wb = WorkerBlockMap::default();
 
         // Pass parent_block_hash for an untracked worker — should fallback to no parent.
@@ -755,7 +761,7 @@ mod tests {
     #[test]
     fn test_apply_removed() {
         let indexer = PositionalIndexer::new(64);
-        let w1 = indexer.intern_worker("http://w1:8000");
+        let w1 = indexer.intern_worker("http://w1:8000").unwrap();
         let mut wb = WorkerBlockMap::default();
 
         let stored = KvBlocksStored {
@@ -790,7 +796,7 @@ mod tests {
     #[test]
     fn test_apply_cleared_event() {
         let indexer = PositionalIndexer::new(64);
-        let w1 = indexer.intern_worker("http://w1:8000");
+        let w1 = indexer.intern_worker("http://w1:8000").unwrap();
         let mut wb = WorkerBlockMap::default();
 
         let stored = KvBlocksStored {
@@ -813,7 +819,7 @@ mod tests {
     #[test]
     fn test_apply_event_dispatch_stored() {
         let indexer = PositionalIndexer::new(64);
-        let w1 = indexer.intern_worker("http://w1:8000");
+        let w1 = indexer.intern_worker("http://w1:8000").unwrap();
         let mut wb = WorkerBlockMap::default();
         let event = KvCacheEvent {
             event_id: 1,
@@ -836,7 +842,7 @@ mod tests {
     #[test]
     fn test_apply_event_dispatch_removed() {
         let indexer = PositionalIndexer::new(64);
-        let w1 = indexer.intern_worker("http://w1:8000");
+        let w1 = indexer.intern_worker("http://w1:8000").unwrap();
         let mut wb = WorkerBlockMap::default();
 
         let stored_event = KvCacheEvent {
@@ -868,7 +874,7 @@ mod tests {
     #[test]
     fn test_apply_event_dispatch_cleared() {
         let indexer = PositionalIndexer::new(64);
-        let w1 = indexer.intern_worker("http://w1:8000");
+        let w1 = indexer.intern_worker("http://w1:8000").unwrap();
         let mut wb = WorkerBlockMap::default();
 
         KvEventMonitor::apply_event(
@@ -908,7 +914,7 @@ mod tests {
     #[test]
     fn test_apply_event_no_data() {
         let indexer = PositionalIndexer::new(64);
-        let w1 = indexer.intern_worker("http://w1:8000");
+        let w1 = indexer.intern_worker("http://w1:8000").unwrap();
         let mut wb = WorkerBlockMap::default();
         let event = KvCacheEvent {
             event_id: 1,


### PR DESCRIPTION
## Description

### Problem

`PositionalIndexer::intern_worker` inserted the worker into `worker_to_id` and incremented `next_worker_id` **before** asserting `(id as usize) < MAX_WORKERS` (2048). So the 2049th distinct worker was durably recorded (id=2048, `next_worker_id`=2049) and *then* the assert panicked. Because the bad state was persisted, every subsequent call kept panicking, and `current_size()` sliced `tree_sizes[..next_worker_id]` = `tree_sizes[..2049]` against a length-2048 `Vec`, which itself panics with index-out-of-bounds. `apply_stored` / `apply_removed` / `remove_worker` / `apply_cleared` index `tree_sizes[worker_id as usize]` too. In a long-lived gateway that churns >2048 distinct worker URLs over its lifetime (autoscaling, restarts producing new URLs), this is a hard crash / DoS.

From the codebase audit: crates/kv_index/src/event_tree.rs:509 — intern_worker persists over-limit worker before asserting; current_size then indexes OOB.

### Solution

Check the limit **before** mutating any state: reserve the id with a bounded `next_worker_id.fetch_update` that refuses to go past `MAX_WORKERS`, and only insert into `worker_to_id` once a slot is reserved. `intern_worker` now returns `Option<u32>` (`None` at capacity), so an over-limit worker is never recorded and `next_worker_id` never exceeds `MAX_WORKERS` — every `tree_sizes` index (including the `current_size()` slice) stays in bounds by construction. The KV event subscription loop logs and skips a worker when capacity is reached instead of crashing.

## Changes

- `crates/kv_index/src/event_tree.rs`: `intern_worker` returns `Option<u32>`; reserve the id via bounded `fetch_update` before inserting; removed the after-the-fact `assert!`. Added `test_intern_worker_over_limit_returns_none_without_corrupting_state` covering the capacity boundary, the `None` retry path, and that `current_size()` stays in bounds.
- `model_gateway/src/worker/kv_event_monitor.rs`: `subscription_loop` logs a warning and returns when the indexer is at worker capacity.
- Updated call sites in tests/benches (`cache_aware.rs`, `kv_event_monitor.rs` tests, `radix_tree_benchmark.rs`, `throughput_bench.rs`) for the new signature.

## Test Plan

Scenario: intern `MAX_WORKERS` distinct workers (each returns `Some(i)`), then the next distinct worker returns `None` without being recorded; re-interning it still returns `None`; `current_size()` returns 0 (does not panic slicing `tree_sizes`); an already-interned worker still resolves. Covered by `test_intern_worker_over_limit_returns_none_without_corrupting_state`.

Gate run with sccache disabled (`RUSTC_WRAPPER=""`), scoped to the changed crates `kv-index` and `smg`:

```
$ cargo +nightly fmt --all
(no output)

$ RUSTC_WRAPPER="" cargo clippy -p kv-index --all-targets -- -D warnings
    Checking kv-index v1.2.0 (/.../crates/kv_index)
    Checking criterion v0.8.2
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 23.25s

$ RUSTC_WRAPPER="" cargo test -p kv-index
test event_tree::tests::test_intern_worker_over_limit_returns_none_without_corrupting_state ... ok
test result: ok. 192 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

$ RUSTC_WRAPPER="" cargo clippy -p smg --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.30s

$ RUSTC_WRAPPER="" cargo test -p smg
(aggregate) TOTAL passed=1506 failed=0
```

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential data corruption by implementing capacity limits for worker registration. The system now gracefully rejects excess workers and logs warnings instead of proceeding with invalid state.

* **Improvements**
  * Enhanced event monitoring to handle worker capacity constraints gracefully, improving system reliability and observability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->