### PR TITLE
fix(reasoning): use fresh parser on non-streaming path to avoid shared mutex

### DIFF
--- a/model_gateway/src/routers/grpc/regular/processor.rs
+++ b/model_gateway/src/routers/grpc/regular/processor.rs
@@ -97,37 +97,35 @@ impl ResponseProcessor {
         let mut processed_text = final_text;
 
         if original_request.separate_reasoning && reasoning_parser_available {
-            let pooled_parser = utils::get_reasoning_parser(
+            // Fresh parser per request: non-streaming extraction keeps no state
+            // across requests, so avoid serializing on the shared pooled mutex.
+            if let Some(mut parser) = utils::create_reasoning_parser(
                 &self.reasoning_parser_factory,
                 self.configured_reasoning_parser.as_deref(),
                 &original_request.model,
-            );
-
-            let mut parser = pooled_parser.lock().await;
-            // Reset pooled parser to clean state before each request
-            parser.reset();
-
-            // If the template injected `<think>` in the prefill (thinking toggle
-            // is supported and effectively ON), start in reasoning mode.
-            if utils::should_mark_reasoning_started(
-                utils::extract_thinking_from_kwargs(
-                    original_request.chat_template_kwargs.as_ref(),
-                    tokenizer.as_ref(),
-                ),
-                tokenizer.as_ref(),
             ) {
-                parser.mark_reasoning_started();
-            }
-
-            match parser.detect_and_parse_reasoning(&processed_text) {
-                Ok(result) => {
-                    if !result.reasoning_text.is_empty() {
-                        reasoning_text = Some(result.reasoning_text);
-                    }
-                    processed_text = result.normal_text;
+                // If the template injected `<think>` in the prefill (thinking toggle
+                // is supported and effectively ON), start in reasoning mode.
+                if utils::should_mark_reasoning_started(
+                    utils::extract_thinking_from_kwargs(
+                        original_request.chat_template_kwargs.as_ref(),
+                        tokenizer.as_ref(),
+                    ),
+                    tokenizer.as_ref(),
+                ) {
+                    parser.mark_reasoning_started();
                 }
-                Err(e) => {
-                    warn!("Reasoning parsing error, skipping parsing: {e}");
+
+                match parser.detect_and_parse_reasoning(&processed_text) {
+                    Ok(result) => {
+                        if !result.reasoning_text.is_empty() {
+                            reasoning_text = Some(result.reasoning_text);
+                        }
+                        processed_text = result.normal_text;
+                    }
+                    Err(e) => {
+                        warn!("Reasoning parsing error, skipping parsing: {e}");
+                    }
                 }
             }
         }
@@ -588,39 +586,38 @@ impl ResponseProcessor {
         let mut processed_text = final_text;
 
         if reasoning_parser_available {
-            let pooled_parser = utils::get_reasoning_parser(
+            // Fresh parser per request: non-streaming extraction keeps no state
+            // across requests, so avoid serializing on the shared pooled mutex.
+            if let Some(mut parser) = utils::create_reasoning_parser(
                 &self.reasoning_parser_factory,
                 self.configured_reasoning_parser.as_deref(),
                 &messages_request.model,
-            );
-            let mut parser = pooled_parser.lock().await;
-            // Reset pooled parser to clean state before each request
-            parser.reset();
-
-            // If thinking is effectively ON and template has a toggle, start in reasoning mode.
-            {
-                let user_thinking = match &messages_request.thinking {
-                    Some(
-                        messages::ThinkingConfig::Enabled { .. }
-                        | messages::ThinkingConfig::Adaptive { .. },
-                    ) => Some(true),
-                    Some(messages::ThinkingConfig::Disabled) => Some(false),
-                    None => None,
-                };
-                if utils::should_mark_reasoning_started(user_thinking, tokenizer.as_ref()) {
-                    parser.mark_reasoning_started();
-                }
-            }
-
-            match parser.detect_and_parse_reasoning(&processed_text) {
-                Ok(result) => {
-                    if !result.reasoning_text.is_empty() {
-                        reasoning_text = Some(result.reasoning_text);
+            ) {
+                // If thinking is effectively ON and template has a toggle, start in reasoning mode.
+                {
+                    let user_thinking = match &messages_request.thinking {
+                        Some(
+                            messages::ThinkingConfig::Enabled { .. }
+                            | messages::ThinkingConfig::Adaptive { .. },
+                        ) => Some(true),
+                        Some(messages::ThinkingConfig::Disabled) => Some(false),
+                        None => None,
+                    };
+                    if utils::should_mark_reasoning_started(user_thinking, tokenizer.as_ref()) {
+                        parser.mark_reasoning_started();
                     }
-                    processed_text = result.normal_text;
                 }
-                Err(e) => {
-                    warn!("Reasoning parsing error, skipping parsing: {e}");
+
+                match parser.detect_and_parse_reasoning(&processed_text) {
+                    Ok(result) => {
+                        if !result.reasoning_text.is_empty() {
+                            reasoning_text = Some(result.reasoning_text);
+                        }
+                        processed_text = result.normal_text;
+                    }
+                    Err(e) => {
+                        warn!("Reasoning parsing error, skipping parsing: {e}");
+                    }
                 }
             }
         }

--- a/model_gateway/src/routers/grpc/utils/mod.rs
+++ b/model_gateway/src/routers/grpc/utils/mod.rs
@@ -21,6 +21,6 @@ pub(crate) use logprobs::{
 pub(crate) use metrics::{error_type_from_status, route_to_endpoint};
 pub(crate) use parsers::{
     check_reasoning_parser_availability, check_tool_parser_availability, create_reasoning_parser,
-    create_tool_parser, extract_thinking_from_kwargs, get_reasoning_parser, get_tool_parser,
+    create_tool_parser, extract_thinking_from_kwargs, get_tool_parser,
     should_mark_reasoning_started,
 };

--- a/model_gateway/src/routers/grpc/utils/parsers.rs
+++ b/model_gateway/src/routers/grpc/utils/parsers.rs
@@ -4,9 +4,7 @@ use llm_tokenizer::{
     chat_template::{ThinkingKeyName, ThinkingToggle},
     traits::Tokenizer,
 };
-use reasoning_parser::{
-    ParserFactory as ReasoningParserFactory, PooledParser as ReasoningPooledParser, ReasoningParser,
-};
+use reasoning_parser::{ParserFactory as ReasoningParserFactory, ReasoningParser};
 use serde_json::Value;
 use tool_parser::{
     ParserFactory as ToolParserFactory, PooledParser as ToolPooledParser, ToolParser,
@@ -75,35 +73,10 @@ pub(crate) fn check_tool_parser_availability(
     }
 }
 
-/// Get the appropriate reasoning parser for a model
+/// Create a fresh reasoning parser instance.
 ///
-/// If a parser name is explicitly configured, use that parser.
-/// Otherwise, auto-detect based on the model name.
-/// Get a pooled reasoning parser (for non-streaming where state doesn't matter)
-pub(crate) fn get_reasoning_parser(
-    reasoning_parser_factory: &ReasoningParserFactory,
-    configured_parser: Option<&str>,
-    model: &str,
-) -> ReasoningPooledParser {
-    if let Some(parser_name) = configured_parser {
-        // Use configured parser if specified
-        reasoning_parser_factory
-            .registry()
-            .get_pooled_parser(parser_name)
-            .unwrap_or_else(|| {
-                warn!(
-                    "Configured reasoning parser '{}' not found, falling back to model-based selection",
-                    parser_name
-                );
-                reasoning_parser_factory.get_pooled(model)
-            })
-    } else {
-        // Auto-detect based on model
-        reasoning_parser_factory.get_pooled(model)
-    }
-}
-
-/// Create a fresh reasoning parser instance (for streaming where state isolation is needed)
+/// Used for both streaming (state isolation across chunks) and non-streaming
+/// (avoids serializing on the shared pooled parser mutex).
 pub(crate) fn create_reasoning_parser(
     reasoning_parser_factory: &ReasoningParserFactory,
     configured_parser: Option<&str>,
@@ -176,5 +149,44 @@ pub(crate) fn create_tool_parser(
     } else {
         // Auto-detect based on model
         tool_parser_factory.registry().create_for_model(model)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_reasoning_parser_returns_independent_instances() {
+        let factory = ReasoningParserFactory::new();
+
+        // qwen3 starts with in_reasoning=false (explicit <think> required).
+        let mut a =
+            create_reasoning_parser(&factory, None, "qwen3").expect("qwen3 has a reasoning parser");
+        let mut b =
+            create_reasoning_parser(&factory, None, "qwen3").expect("qwen3 has a reasoning parser");
+
+        // Each call returns an independent instance: state mutated on one parser
+        // must not leak into the other (the shared pooled parser the non-streaming
+        // path used to take would have violated this).
+        a.mark_reasoning_started();
+        assert!(a.is_in_reasoning());
+        assert!(!b.is_in_reasoning());
+
+        // The untouched instance still parses a full document correctly.
+        let rb = b
+            .detect_and_parse_reasoning("<think>reasoning</think>answer")
+            .unwrap();
+        assert_eq!(rb.normal_text, "answer");
+        assert_eq!(rb.reasoning_text, "reasoning");
+    }
+
+    #[test]
+    fn create_reasoning_parser_honors_configured_parser() {
+        let factory = ReasoningParserFactory::new();
+
+        let parser = create_reasoning_parser(&factory, Some("qwen3"), "unknown-model")
+            .expect("configured qwen3 parser exists");
+        assert_eq!(parser.model_type(), "qwen3");
     }
 }

--- a/model_gateway/src/routers/parse/handlers.rs
+++ b/model_gateway/src/routers/parse/handlers.rs
@@ -73,14 +73,15 @@ pub async fn parse_reasoning(ctx: &Arc<AppContext>, req: &SeparateReasoningReque
         );
     };
 
-    let Some(pooled_parser) = factory.registry().get_pooled_parser(&req.reasoning_parser) else {
+    // Fresh parser per request: non-streaming extraction keeps no state across
+    // requests, so avoid serializing on the shared pooled mutex.
+    let Some(mut parser) = factory.registry().create_parser(&req.reasoning_parser) else {
         return error_response(
             StatusCode::BAD_REQUEST,
             &format!("Unknown reasoning parser: {}", req.reasoning_parser),
         );
     };
 
-    let mut parser = pooled_parser.lock().await;
     match parser.detect_and_parse_reasoning(&req.text) {
         Ok(result) => (
             StatusCode::OK,


### PR DESCRIPTION
## Description

### Problem

Non-streaming reasoning extraction served all requests for a given model from one **pooled** parser instance (`Arc<Mutex<Box<dyn ReasoningParser>>>`). Every non-streaming request would `lock().await` that single mutex, `reset()` the parser, run `detect_and_parse_reasoning`, then drop the state — so concurrent requests for the same model **serialized** on one mutex despite needing no shared state. The streaming path already avoids this by creating a fresh parser per request/index for state isolation.

From the codebase audit: crates/reasoning_parser/src/factory.rs:64 — Non-streaming requests serialize on one shared parser mutex per model.

### Solution

Switch the non-streaming paths to a fresh, owned per-request parser via `create_parser` / `create_reasoning_parser` (the same approach the streaming path already uses). A fresh parser is inherently clean, so the explicit `reset()` and the `lock().await` are no longer needed, removing the per-model contention entirely. The now-unused pooled helper `get_reasoning_parser` is dropped.

## Changes

- `model_gateway/src/routers/grpc/regular/processor.rs`: both non-streaming sites (chat completions + Anthropic messages) now take a fresh parser via `utils::create_reasoning_parser(...)` instead of the pooled parser + `lock().await` + `reset()`.
- `model_gateway/src/routers/parse/handlers.rs`: the `/separate_reasoning` endpoint uses `registry().create_parser(...)` instead of `get_pooled_parser(...).lock().await`.
- `model_gateway/src/routers/grpc/utils/parsers.rs`: removed the now-unused `get_reasoning_parser` pooled helper (and its unused `PooledParser` import); refreshed the `create_reasoning_parser` doc to note it serves both streaming and non-streaming. Added unit tests.
- `model_gateway/src/routers/grpc/utils/mod.rs`: dropped the `get_reasoning_parser` re-export.

The tool-parser pooled path is intentionally left unchanged (separate concern/finding).

## Test Plan

Added focused unit tests in `parsers.rs`:
- `create_reasoning_parser_returns_independent_instances` — two parsers created for the same model are independent: `mark_reasoning_started()` on one does not flip the other's `is_in_reasoning()`, and the untouched instance still parses a full `<think>…</think>` document correctly. This is exactly the isolation the shared pooled parser violated.
- `create_reasoning_parser_honors_configured_parser` — the configured-parser path resolves to the requested parser.

Gate (sccache disabled, scoped to `smg`):

```
$ cargo +nightly fmt --all
(clean, exit 0)

$ RUSTC_WRAPPER="" cargo clippy -p smg --all-targets -- -D warnings
    Checking smg v1.4.1
    Finished `dev` profile [unoptimized + debuginfo] target(s)
(no warnings, exit 0)

$ RUSTC_WRAPPER="" cargo test -p smg
running 2 tests
test routers::grpc::utils::parsers::tests::create_reasoning_parser_honors_configured_parser ... ok
test routers::grpc::utils::parsers::tests::create_reasoning_parser_returns_independent_instances ... ok
...
test result: ok. 1005 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out
     Running tests/api_tests.rs
test result: ok. 105 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
     Running tests/routing_tests.rs
test result: ok. 92 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
     Running tests/spec_test.rs
test result: ok. 95 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out
     Running tests/security_tests.rs
test result: ok. 48 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
     (all remaining integration test binaries: ok, 0 failed)
```

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor
* Improved reasoning parser handling by creating independent parser instances per request instead of using shared pooled parsers, enhancing reliability and reducing contention.

## Tests
* Added tests to verify parser isolation and correct parser selection based on configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->