### PR TITLE
fix(policies): stop BucketPolicy adjustment thread on drop

### DIFF
--- a/model_gateway/src/policies/bucket.rs
+++ b/model_gateway/src/policies/bucket.rs
@@ -1,7 +1,6 @@
 use std::{
     collections::{HashMap, HashSet, VecDeque},
     sync::Arc,
-    thread,
     time::{Duration, SystemTime},
 };
 
@@ -12,8 +11,8 @@ use tracing::{debug, info, warn};
 use uuid::Uuid;
 
 use super::{
-    get_healthy_worker_indices, normalize_model_key, BucketConfig, LoadBalancingPolicy,
-    SelectWorkerInfo,
+    get_healthy_worker_indices, normalize_model_key, utils::PeriodicTask, BucketConfig,
+    LoadBalancingPolicy, SelectWorkerInfo,
 };
 use crate::worker::Worker;
 
@@ -21,20 +20,12 @@ use crate::worker::Worker;
 pub struct BucketPolicy {
     config: BucketConfig,
     buckets: Arc<DashMap<String, Arc<RwLock<Bucket>>>>,
-    adjustment_handle: Option<thread::JoinHandle<()>>,
+    _adjustment_task: Option<PeriodicTask>,
 }
 
 impl Default for BucketPolicy {
     fn default() -> Self {
         Self::new()
-    }
-}
-
-impl Drop for BucketPolicy {
-    fn drop(&mut self) {
-        if let Some(handle) = self.adjustment_handle.take() {
-            drop(handle);
-        }
     }
 }
 
@@ -46,26 +37,26 @@ impl BucketPolicy {
     pub fn with_config(config: BucketConfig) -> Self {
         let buckets = Arc::new(DashMap::<String, Arc<RwLock<Bucket>>>::new());
 
-        let adjustment_handle = {
+        let adjustment_task = {
             let buckets_clone = Arc::clone(&buckets);
 
-            let interval_secs = config.bucket_adjust_interval_secs;
-
-            Some(thread::spawn(move || loop {
-                thread::sleep(Duration::from_secs(interval_secs as u64));
-
-                for bucket_ref in buckets_clone.iter() {
-                    let bucket = bucket_ref.value();
-                    let mut bucket_guard = bucket.write();
-                    bucket_guard.adjust_boundary();
-                }
-            }))
+            Some(PeriodicTask::spawn(
+                config.bucket_adjust_interval_secs as u64,
+                "BucketAdjustment",
+                move || {
+                    for bucket_ref in buckets_clone.iter() {
+                        let bucket = bucket_ref.value();
+                        let mut bucket_guard = bucket.write();
+                        bucket_guard.adjust_boundary();
+                    }
+                },
+            ))
         };
 
         Self {
             config,
             buckets,
-            adjustment_handle,
+            _adjustment_task: adjustment_task,
         }
     }
 
@@ -572,6 +563,30 @@ mod tests {
             disable_health_check: true,
             ..Default::default()
         }
+    }
+
+    #[test]
+    fn test_drop_stops_adjustment_thread() {
+        let config = BucketConfig {
+            // Long interval so the thread is parked in its sleep loop at drop time.
+            bucket_adjust_interval_secs: 3600,
+            ..Default::default()
+        };
+        let policy = BucketPolicy::with_config(config);
+
+        // Clones alive here: the policy's own, the adjustment thread's, and this
+        // one. If the thread leaks on drop, its clone outlives the policy and the
+        // count stays above 1.
+        let buckets = Arc::clone(&policy.buckets);
+        assert_eq!(Arc::strong_count(&buckets), 3);
+
+        drop(policy);
+
+        assert_eq!(
+            Arc::strong_count(&buckets),
+            1,
+            "adjustment thread should be joined on drop, releasing its Arc clone"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Description

### Problem

`BucketPolicy` spawns a background thread in `with_config` that runs an infinite bucket-boundary adjustment loop. Its `Drop` impl only called `drop(handle)` on the `JoinHandle`. Dropping a `JoinHandle` detaches the thread rather than stopping it, so the adjustment loop kept running for the rest of the process lifetime after the policy was dropped — a thread (and the `Arc<DashMap>` state it captured) leaked on every policy teardown (e.g. router/policy rebuilds).

### Solution

Spawn the adjustment loop via `PeriodicTask::spawn` (the existing helper in `policies/utils.rs`), which carries an `AtomicBool` shutdown flag and joins the thread on drop. This is the same pattern already used by `CacheAwarePolicy` and `ManualPolicy` for their eviction threads. The hand-rolled `Drop` impl is removed since `PeriodicTask` now owns shutdown.

## Changes

- `model_gateway/src/policies/bucket.rs`:
  - Replace the `adjustment_handle: Option<JoinHandle<()>>` field with `_adjustment_task: Option<PeriodicTask>`.
  - Spawn the boundary-adjustment loop via `PeriodicTask::spawn` instead of a raw `thread::spawn` + manual sleep loop.
  - Remove the `Drop for BucketPolicy` impl that detached the thread.
  - Add `test_drop_stops_adjustment_thread`, which asserts the spawned thread releases its `Arc` clone once the policy is dropped (count returns to 1), proving join-on-drop.

## Test Plan

Scenario: drop a `BucketPolicy` whose adjustment thread is parked on a long interval and confirm the thread is joined (not leaked). The new `test_drop_stops_adjustment_thread` clones the policy's `buckets` `Arc`, asserts `strong_count == 3` (policy + thread + test), drops the policy, then asserts `strong_count == 1` — only the leaked thread's clone could keep it above 1.

Gate (sccache disabled, scoped to `smg`):

```
$ cargo +nightly fmt --all
(clean)

$ RUSTC_WRAPPER="" cargo clippy -p smg --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 31s
clippy exit: 0

$ RUSTC_WRAPPER="" cargo test -p smg --lib policies::bucket
running 5 tests
test policies::bucket::tests::test_drop_stops_adjustment_thread ... ok
test policies::bucket::tests::test_adjust_boundary_1 ... ok
test policies::bucket::tests::test_adjust_boundary_2 ... ok
test policies::bucket::tests::test_not_adjust_boundary ... ok
test policies::bucket::tests::test_load_balancing_conditions ... ok
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 1003 filtered out

$ RUSTC_WRAPPER="" cargo test -p smg --lib
test result: ok. 1004 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out

$ RUSTC_WRAPPER="" cargo test -p smg --test api_tests
test result: ok. 105 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

From the codebase audit: model_gateway/src/policies/bucket.rs:33 — BucketPolicy leaks its adjustment thread on drop.

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved bucket boundary adjustment scheduling mechanism for better resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->