### PR TITLE
chore(wasm): trim stale comments

### DIFF
--- a/crates/wasm/src/module.rs
+++ b/crates/wasm/src/module.rs
@@ -112,7 +112,6 @@ where
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WasmModule {
-    // unique identifier for the module
     pub module_uuid: Uuid,
     pub module_meta: WasmModuleMeta,
 }
@@ -134,35 +133,28 @@ pub struct WasmModuleDescriptor {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WasmModuleMeta {
-    // module name provided by the user
     pub name: String,
-    // path to the module file
     pub file_path: String,
-    // sha256 hash of the module file
     #[serde(
         serialize_with = "serialize_sha256_hash",
         deserialize_with = "deserialize_sha256_hash"
     )]
     pub sha256_hash: [u8; 32],
-    // size of the module file in bytes
     pub size_bytes: u64,
-    // timestamp of when the module was created (nanoseconds since epoch)
+    // nanoseconds since epoch
     #[serde(
         serialize_with = "serialize_timestamp",
         deserialize_with = "deserialize_timestamp"
     )]
     pub created_at: u64,
-    // timestamp of when the module was last accessed (nanoseconds since epoch)
+    // nanoseconds since epoch
     #[serde(
         serialize_with = "serialize_timestamp",
         deserialize_with = "deserialize_timestamp"
     )]
     pub last_accessed_at: u64,
-    // number of times the module was accessed
     pub access_count: u64,
-    // attach points for the module
     pub attach_points: Vec<WasmModuleAttachPoint>,
-    // Pre-loaded WASM component bytes (loaded into memory for faster execution)
     // Wrapped in Arc to avoid cloning full bytes on every execution request.
     #[serde(skip)]
     pub wasm_bytes: Arc<Vec<u8>>,

--- a/crates/wasm/src/module_manager.rs
+++ b/crates/wasm/src/module_manager.rs
@@ -228,9 +228,6 @@ impl WasmModuleManager {
 
     /// Execute a WASM module for a given attach point
     /// Returns the Action if successful, or None if execution failed
-    ///
-    /// This is a convenience method that wraps execute_module_interface and handles
-    /// error logging automatically.
     pub async fn execute_module_for_attach_point(
         &self,
         module: &WasmModule,

--- a/crates/wasm/src/runtime.rs
+++ b/crates/wasm/src/runtime.rs
@@ -268,7 +268,7 @@ impl WasmThreadPool {
 
         wasmtime_config.async_stack_size(config.max_stack_size);
         wasmtime_config.async_support(true);
-        wasmtime_config.wasm_component_model(true); // Enable component model
+        wasmtime_config.wasm_component_model(true);
         wasmtime_config.epoch_interruption(true); // Enable epoch-based timeout interruption
 
         let engine = match Engine::new(&wasmtime_config) {
@@ -294,7 +294,6 @@ impl WasmThreadPool {
             return;
         }
 
-        // SAFETY: 10 is a non-zero literal, so NonZeroUsize::new(10) always returns Some.
         let default_capacity = NonZeroUsize::new(10).unwrap_or(NonZeroUsize::MIN);
         let cache_capacity =
             NonZeroUsize::new(config.module_cache_size).unwrap_or(default_capacity);


### PR DESCRIPTION
## Description

Problem: `crates/wasm/src` carried stale comments that restate the code or mislabel safe code, flagged by the codebase audit (crate-wasm) under comment_bloat. There were also dead_code findings, but every candidate is a `pub` item re-exported at the crate root (and again via `pub use smg_wasm::*` in model_gateway) on this published library crate (v1.1.0) — removing any would be a semver-breaking public-API change — so those were intentionally left untouched.

Solution: trimmed only the flagged comments that add no information; kept all load-bearing comments.

## Changes

- `module.rs`: removed field-name-restating comments on `WasmModule.module_uuid` and on `WasmModuleMeta` (`name`, `file_path`, `sha256_hash`, `size_bytes`, `access_count`, `attach_points`); condensed the two timestamp comments to keep only the load-bearing unit (`nanoseconds since epoch`); kept the `Arc`-clone rationale on `wasm_bytes`.
- `runtime.rs`: dropped the `// Enable component model` comment that restated `wasm_component_model(true)`; removed a misleading `// SAFETY:` label on safe code (`NonZeroUsize::new(10).unwrap_or(...)` — no `unsafe`).
- `module_manager.rs`: removed the convenience-method narrative paragraph on `execute_module_for_attach_point`, keeping the return-contract lines.

Net: 11 comment lines removed (comment-only; no code logic changed). Deletion-heavy cleanup PR (well under 400 lines here).

No dead code removed — see Description for why (all candidates are public API).

## Test Plan

Gate run with sccache disabled, scoped to the changed package (`smg-wasm`), `--all-features`:

```
$ cargo +nightly fmt --all
(no changes)

$ RUSTC_WRAPPER="" cargo clippy -p smg-wasm --all-features --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 40.36s
CLIPPY_EXIT=0
(no error lines; only a pre-existing clippy.toml config diagnostic about uuid::Uuid::new_v4, unrelated to this change)

$ RUSTC_WRAPPER="" cargo test -p smg-wasm --all-features
test result: ok. 24 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 0 passed; 0 failed (doc-tests)
TEST_EXIT=0
```

- [x] `cargo +nightly fmt --all`
- [x] `cargo clippy ... -D warnings`

From the codebase audit (crate-wasm): dead_code + comment_bloat findings.
