### PR TITLE
fix(mcp): classify image_generation builtin in session bindings

### DIFF
--- a/crates/mcp/src/core/config.rs
+++ b/crates/mcp/src/core/config.rs
@@ -307,6 +307,25 @@ pub enum BuiltinToolType {
 }
 
 impl BuiltinToolType {
+    /// Every builtin tool type. The exhaustive `match` makes a new variant
+    /// fail to compile until it is added here, so callers that enumerate all
+    /// builtins (e.g. session builtin classification) cannot silently miss it.
+    pub fn all() -> [BuiltinToolType; 4] {
+        // The match exists solely for its exhaustiveness check.
+        let _exhaustive = |t: BuiltinToolType| match t {
+            BuiltinToolType::WebSearchPreview => (),
+            BuiltinToolType::CodeInterpreter => (),
+            BuiltinToolType::FileSearch => (),
+            BuiltinToolType::ImageGeneration => (),
+        };
+        [
+            BuiltinToolType::WebSearchPreview,
+            BuiltinToolType::CodeInterpreter,
+            BuiltinToolType::FileSearch,
+            BuiltinToolType::ImageGeneration,
+        ]
+    }
+
     /// Get the corresponding response format for this built-in type.
     pub fn response_format(self) -> ResponseFormatConfig {
         match self {
@@ -1224,6 +1243,19 @@ policy:
 
             let deserialized: BuiltinToolType = serde_json::from_str(&serialized).unwrap();
             assert_eq!(deserialized, builtin_type);
+        }
+    }
+
+    #[test]
+    fn test_builtin_tool_type_all_includes_every_variant() {
+        let all = BuiltinToolType::all();
+        for variant in [
+            BuiltinToolType::WebSearchPreview,
+            BuiltinToolType::CodeInterpreter,
+            BuiltinToolType::FileSearch,
+            BuiltinToolType::ImageGeneration,
+        ] {
+            assert!(all.contains(&variant), "all() missing {variant}");
         }
     }
 

--- a/crates/mcp/src/core/session.rs
+++ b/crates/mcp/src/core/session.rs
@@ -595,15 +595,11 @@ impl<'a> McpToolSession<'a> {
     }
 
     fn builtin_tool_bindings(orchestrator: &McpOrchestrator) -> HashSet<QualifiedToolName> {
-        [
-            BuiltinToolType::WebSearchPreview,
-            BuiltinToolType::CodeInterpreter,
-            BuiltinToolType::FileSearch,
-        ]
-        .into_iter()
-        .filter_map(|builtin_type| orchestrator.find_builtin_server(builtin_type))
-        .map(|(server_key, tool_name)| QualifiedToolName::new(server_key, tool_name))
-        .collect()
+        BuiltinToolType::all()
+            .into_iter()
+            .filter_map(|builtin_type| orchestrator.find_builtin_server(builtin_type))
+            .map(|(server_key, tool_name)| QualifiedToolName::new(server_key, tool_name))
+            .collect()
     }
 
     fn builtin_binding_for_entry(
@@ -1028,6 +1024,49 @@ mod tests {
         assert!(session.is_builtin_tool("brave_web_search"));
         assert!(!session.is_builtin_tool("internal_non_builtin_tool"));
         assert!(session.is_internal_non_builtin_tool("internal_non_builtin_tool"));
+    }
+
+    #[test]
+    fn test_is_builtin_tool_classifies_image_generation() {
+        use crate::core::config::{BuiltinToolType, McpConfig, McpServerConfig, McpTransport};
+
+        let orchestrator = McpOrchestrator::new_test_with_config(McpConfig {
+            servers: vec![McpServerConfig {
+                name: "image-server".to_string(),
+                transport: McpTransport::Sse {
+                    url: "http://localhost:3000/sse".to_string(),
+                    token: None,
+                    headers: HashMap::new(),
+                },
+                proxy: None,
+                required: false,
+                tools: None,
+                builtin_type: Some(BuiltinToolType::ImageGeneration),
+                builtin_tool_name: Some("generate_image".to_string()),
+                internal: false,
+            }],
+            ..Default::default()
+        });
+
+        orchestrator
+            .tool_inventory()
+            .insert_entry(ToolEntry::from_server_tool(
+                "image-server",
+                create_test_tool("generate_image"),
+            ));
+
+        let session = McpToolSession::new(
+            &orchestrator,
+            vec![McpServerBinding {
+                label: "image".to_string(),
+                server_key: "image-server".to_string(),
+                allowed_tools: None,
+            }],
+            "test-request",
+        );
+
+        assert!(session.is_builtin_tool("generate_image"));
+        assert!(session.is_builtin_server_label("image"));
     }
 
     #[test]


### PR DESCRIPTION
## Description

### Problem

`McpToolSession::builtin_tool_bindings` enumerated only `WebSearchPreview`, `CodeInterpreter`, and `FileSearch`, omitting `BuiltinToolType::ImageGeneration` even though that variant exists with its own `response_format` and `Display` impl. As a result, a server configured with `builtin_type: image_generation` had its tool treated as a normal tool: `is_builtin_tool()` returned `false`, `is_builtin_server_label` did not recognize it, and builtin-routed redaction/format selection misbehaved.

### Solution

Add `BuiltinToolType::all()` as a single, compiler-enforced source of builtin variants (an exhaustive `match` makes a newly added variant fail to compile until it is listed), and iterate it in `builtin_tool_bindings`. This both fixes the missing `ImageGeneration` classification and prevents future variants from being silently dropped.

## Changes

- `crates/mcp/src/core/config.rs`: add `BuiltinToolType::all()` returning every variant, guarded by an exhaustive `match`.
- `crates/mcp/src/core/session.rs`: `builtin_tool_bindings` now iterates `BuiltinToolType::all()` instead of a hand-maintained 3-element array.
- Tests: `test_builtin_tool_type_all_includes_every_variant` (config) and `test_is_builtin_tool_classifies_image_generation` (session).

## Test Plan

Scenario: configure an MCP server with `builtin_type: image_generation` and a tool, bind it into a session, and assert the tool classifies as builtin (`is_builtin_tool` / `is_builtin_server_label`). Verified the new session test FAILS against the previous 3-variant array and PASSES with the fix.

Gate (sccache disabled, scoped to `smg-mcp`):

```
$ cargo +nightly fmt --all
(no output)

$ RUSTC_WRAPPER="" cargo clippy -p smg-mcp --all-targets -- -D warnings
    Checking smg-mcp v2.2.0 (/Users/simolin/opensource/smg/crates/mcp)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 17.54s

$ RUSTC_WRAPPER="" cargo test -p smg-mcp
test core::config::tests::test_builtin_tool_type_all_includes_every_variant ... ok
test core::session::tests::test_is_builtin_tool_classifies_image_generation ... ok
test result: ok. 160 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
   Doc-tests smg_mcp
test result: ok. 0 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out
```

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>

From the codebase audit: crates/mcp/src/core/session.rs:597 — ImageGeneration builtin type silently dropped from session builtin classification.
