### PR TITLE
chore(workflow): remove dead code and trim stale comments

### DIFF
--- a/crates/workflow/src/definition.rs
+++ b/crates/workflow/src/definition.rs
@@ -251,7 +251,6 @@ impl<D: WorkflowData> WorkflowDefinition<D> {
     /// On success, pre-computes reverse dependencies for O(1) dependent lookup.
     #[must_use = "validation result should be checked"]
     pub fn validate(&mut self) -> Result<(), ValidationError> {
-        // Build HashMap for O(1) lookup instead of O(n) linear search
         let steps_map: HashMap<&StepId, &StepDefinition<D>> =
             self.steps.iter().map(|s| (&s.id, s)).collect();
 
@@ -321,7 +320,6 @@ impl<D: WorkflowData> WorkflowDefinition<D> {
         visited.insert(step_id);
         rec_stack.insert(step_id);
 
-        // O(1) lookup instead of linear search
         // Check both depends_on and depends_on_any for cycles
         if let Some(step) = steps_map.get(step_id) {
             for dep in step.all_dependencies() {

--- a/crates/workflow/src/engine.rs
+++ b/crates/workflow/src/engine.rs
@@ -6,7 +6,6 @@
 
 use std::{
     collections::{HashMap, HashSet, VecDeque},
-    marker::PhantomData,
     sync::{
         atomic::{AtomicUsize, Ordering},
         Arc,
@@ -187,7 +186,6 @@ pub struct WorkflowEngine<D: WorkflowData, S: StateStore<D> = InMemoryStore<D>> 
     shutdown_tx: Arc<watch::Sender<bool>>,
     /// Count of active workflow executions
     active_workflows: Arc<AtomicUsize>,
-    _phantom: PhantomData<D>,
 }
 
 impl<D: WorkflowData> WorkflowEngine<D, InMemoryStore<D>> {
@@ -206,7 +204,6 @@ impl<D: WorkflowData, S: StateStore<D> + 'static> WorkflowEngine<D, S> {
             event_bus: Arc::new(EventBus::new()),
             shutdown_tx: Arc::new(shutdown_tx),
             active_workflows: Arc::new(AtomicUsize::new(0)),
-            _phantom: PhantomData,
         }
     }
 
@@ -520,7 +517,6 @@ impl<D: WorkflowData, S: StateStore<D> + 'static> WorkflowEngine<D, S> {
             }
 
             // Phase 1: Check waiting steps + deps-ready steps + blocked detection
-            // Single lock acquisition for all read operations
             let (
                 newly_ready_from_wait,
                 deps_ready_indices,
@@ -556,7 +552,6 @@ impl<D: WorkflowData, S: StateStore<D> + 'static> WorkflowEngine<D, S> {
             };
 
             // Phase 2: Process waiting and deps-ready steps, update waiting_until
-            // Single write lock for all mutations
             // Returns (ready_to_launch, steps_added_to_waiting)
             let (ready_to_launch, steps_added_to_waiting) = {
                 let now = std::time::Instant::now();
@@ -605,7 +600,6 @@ impl<D: WorkflowData, S: StateStore<D> + 'static> WorkflowEngine<D, S> {
                 (ready, added_to_waiting)
             };
 
-            // Check if we're done
             if total_processed == step_count {
                 break;
             }
@@ -645,7 +639,6 @@ impl<D: WorkflowData, S: StateStore<D> + 'static> WorkflowEngine<D, S> {
                 return Ok(());
             }
 
-            // Launch ready steps in parallel
             let tasks_launched = ready_to_launch.len();
             if tasks_launched > 0 {
                 let mut t = tracker.write();
@@ -811,7 +804,6 @@ impl<D: WorkflowData, S: StateStore<D> + 'static> WorkflowEngine<D, S> {
                 });
             }
 
-            // Single lock read for both checks
             let (has_running, has_waiting) = {
                 let t = tracker.read();
                 (
@@ -821,7 +813,6 @@ impl<D: WorkflowData, S: StateStore<D> + 'static> WorkflowEngine<D, S> {
             };
 
             if has_running {
-                // Wait for a step to complete; Phase 0 will drain any others
                 if let Some((completed_step_id, result)) = rx.recv().await {
                     tracing::debug!(
                         step_id = %completed_step_id,
@@ -1176,7 +1167,6 @@ impl<D: WorkflowData, S: StateStore<D> + 'static> WorkflowEngine<D, S> {
             event_bus: Arc::clone(&self.event_bus),
             shutdown_tx: Arc::clone(&self.shutdown_tx),
             active_workflows: Arc::clone(&self.active_workflows),
-            _phantom: PhantomData,
         }
     }
 }

--- a/crates/workflow/src/state.rs
+++ b/crates/workflow/src/state.rs
@@ -1,6 +1,6 @@
 //! Workflow state management
 
-use std::{collections::HashMap, marker::PhantomData, sync::Arc, time::Duration};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use parking_lot::RwLock;
@@ -57,14 +57,12 @@ pub trait StateStore<D: WorkflowData>: Send + Sync + Clone {
 #[derive(Clone)]
 pub struct InMemoryStore<D: WorkflowData> {
     states: Arc<RwLock<HashMap<WorkflowInstanceId, WorkflowState<D>>>>,
-    _phantom: PhantomData<D>,
 }
 
 impl<D: WorkflowData> InMemoryStore<D> {
     pub fn new() -> Self {
         Self {
             states: Arc::new(RwLock::new(HashMap::new())),
-            _phantom: PhantomData,
         }
     }
 


### PR DESCRIPTION
## Description

Problem: The `wfaas` (crate-workflow) crate carries stale, restating-the-code comments and a few provably-dead internal items flagged by the codebase audit.

Solution: Removed the noise comments and the provably-dead internal code. No public API was touched — `wfaas` is a published, semver-versioned library (v1.0.3), so all `pub` items (including the audit's D1-D5: `EventBus::{publish_and_wait,unsubscribe,with_timeout}`, `InMemoryStore::{count,count_by_status}`, `StateStore::list_all`, `FunctionStep`) are public API and were intentionally left in place.

From the codebase audit (crate-workflow): dead_code + comment_bloat findings.

## Changes

- Dead code (D6, internal only): removed the redundant private `_phantom: PhantomData<D>` field from `WorkflowEngine` and `InMemoryStore` (`D` is already used by other fields in both structs) and dropped the now-unused `PhantomData` imports — 2 fields, 2 imports, 3 construction sites.
  - Note: `FunctionStep`'s `PhantomData` was deliberately kept — its `D` appears only in the `F` where-bound, not a field, so the marker is load-bearing (removing it would be `E0392`).
- Comment bloat (C1, C3): trimmed 8 restating-the-code / duplicated-complexity comments — 2 in `definition.rs` ("O(1) lookup instead of linear search" x2) and 6 in `engine.rs` ("Single lock acquisition for all read operations", "Single write lock for all mutations", "Check if we're done", "Launch ready steps in parallel", "Single lock read for both checks", "Wait for a step to complete"). Load-bearing Phase/invariant comments were kept.

Net: 3 files changed, 1 insertion, 15 deletions (deletion-heavy cleanup, well under 400 lines).

## Test Plan

Gate run with sccache disabled, scoped to the changed package (`wfaas`); CI runs the full `--all-features` workspace gate.

```
$ cargo +nightly fmt --all
(clean — no reformatting introduced)

$ RUSTC_WRAPPER="" cargo clippy -p wfaas --all-targets -- -D warnings
    Checking wfaas v1.0.3 (.../crates/workflow)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 22.34s
CLIPPY REAL EXIT: 0
(no code-level warnings; only a pre-existing clippy.toml config notice unrelated to this change)

$ RUSTC_WRAPPER="" cargo test -p wfaas
test result: ok. 2 passed; 0 failed; 0 ignored   (lib unit tests)
test result: ok. 21 passed; 0 failed; 0 ignored  (tests/workflow_test.rs)
test result: ok. 0 passed; 0 failed; 2 ignored   (doc-tests)
```

- [x] `cargo +nightly fmt --all` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes (scoped to `wfaas`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed unnecessary internal code patterns and streamlined implementation details to improve code clarity without affecting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->