### PR TITLE
chore(routers/http): remove dead code and trim stale comments

### DIFF
--- a/model_gateway/src/routers/http/pd_router.rs
+++ b/model_gateway/src/routers/http/pd_router.rs
@@ -234,7 +234,6 @@ impl PDRouter {
                 ports.push(prefill_worker.bootstrap_port());
                 rooms.push(super::pd_types::generate_room_id());
             }
-            // Use static string keys to avoid per-request allocations
             obj.insert(
                 Self::BOOTSTRAP_HOST_KEY.to_string(),
                 Value::Array(hosts.into_iter().map(Value::from).collect()),
@@ -256,7 +255,6 @@ impl PDRouter {
                 Value::Array(rooms.into_iter().map(Value::from).collect()),
             );
         } else {
-            // Use static string keys to avoid per-request allocations
             obj.insert(
                 Self::BOOTSTRAP_HOST_KEY.to_string(),
                 Value::from(prefill_worker.bootstrap_host()),
@@ -422,7 +420,6 @@ impl PDRouter {
                                 context,
                                 Arc::clone(&prefill),
                                 Arc::clone(&decode),
-                                start_time,
                             )
                             .await;
 
@@ -603,7 +600,6 @@ impl PDRouter {
     }
 
     // Internal method that performs the actual dual dispatch (without retry logic)
-    #[expect(clippy::too_many_arguments)]
     async fn execute_dual_dispatch_internal(
         &self,
         headers: Option<&HeaderMap>,
@@ -612,7 +608,6 @@ impl PDRouter {
         context: PDRequestContext<'_>,
         prefill: Arc<dyn Worker>,
         decode: Arc<dyn Worker>,
-        _start_time: Instant,
     ) -> Response {
         // For non-streaming: use guard for automatic load management
         // For streaming: load will be managed in create_streaming_response
@@ -1277,8 +1272,6 @@ impl RouterTrait for PDRouter {
     }
 
     async fn get_server_info(&self, _req: Request<Body>) -> Response {
-        // Get info from the first decode server to match sglang's server info format
-        // Note: We use decode workers for server info to match expected format
         self.proxy_to_first_prefill_worker("get_server_info", None)
             .await
     }

--- a/model_gateway/src/routers/http/pd_types.rs
+++ b/model_gateway/src/routers/http/pd_types.rs
@@ -1,39 +1,5 @@
 //! Types and utilities for the prefill-decode (PD) disaggregated router.
 
-/// Custom error type for PD router operations
-#[derive(Debug, thiserror::Error)]
-pub enum PDRouterError {
-    #[error("Worker already exists: {url}")]
-    WorkerAlreadyExists { url: String },
-
-    #[error("Worker not found: {url}")]
-    WorkerNotFound { url: String },
-
-    #[error("Lock acquisition failed: {operation}")]
-    LockError { operation: String },
-
-    #[error("Health check failed for worker: {url}")]
-    HealthCheckFailed { url: String },
-
-    #[error("Invalid worker configuration: {reason}")]
-    InvalidConfiguration { reason: String },
-
-    #[error("Network error: {message}")]
-    NetworkError { message: String },
-
-    #[error("Timeout waiting for worker: {url}")]
-    Timeout { url: String },
-}
-
-/// Construct a full API URL from a base URL and path.
-pub fn api_path(url: &str, api_path: &str) -> String {
-    if api_path.starts_with('/') {
-        format!("{url}{api_path}")
-    } else {
-        format!("{url}/{api_path}")
-    }
-}
-
 use serde::Serialize;
 
 /// Optimized bootstrap wrapper for single requests.
@@ -44,16 +10,6 @@ pub struct RequestWithBootstrap<'a, T: Serialize> {
     pub bootstrap_host: String,
     pub bootstrap_port: Option<u16>,
     pub bootstrap_room: u64,
-}
-
-/// Optimized bootstrap wrapper for batch requests.
-#[derive(Serialize)]
-pub struct BatchRequestWithBootstrap<'a, T: Serialize> {
-    #[serde(flatten)]
-    pub original: &'a T,
-    pub bootstrap_host: Vec<String>,
-    pub bootstrap_port: Vec<Option<u16>>,
-    pub bootstrap_room: Vec<u64>,
 }
 
 /// Generate a random bootstrap room ID.


### PR DESCRIPTION
## Description

Problem: the HTTP/PD routers carry provably-dead internal code and stale comments flagged by the codebase audit (gw-routers-http) — an unused error enum, an unused URL helper, an unused bootstrap-wrapper struct, a dead function parameter, and comments that are either wrong or merely restate the code.

Solution: removed the dead internal items and trimmed the flagged comments. No behavior change.

From the codebase audit (gw-routers-http): dead_code + comment_bloat findings.

## Changes

Dead code (4 internal items, all re-verified unused repo-wide incl. tests/benches/bindings/clients):
- `pd_types.rs`: removed unused `PDRouterError` enum (zero constructors anywhere), `api_path` helper (no callers), and `BatchRequestWithBootstrap` struct (no references). The `smg` crate is consumed only by the in-workspace bindings, which glob-import the crate root (`use smg::*`); the root does not re-export `pd_types`, so these `pub` items are unreachable as external API.
- `pd_router.rs`: dropped the unread `_start_time: Instant` parameter from `execute_dual_dispatch_internal` (and its now-unnecessary `#[expect(clippy::too_many_arguments)]`, which became unfulfilled at 6 args).

Comments (4 lines, 3 sites):
- `pd_router.rs` `get_server_info`: deleted two stale comments claiming server info comes from the "decode server" — the code proxies to the first **prefill** worker.
- `pd_router.rs` `inject_bootstrap_into_value`: removed the two repeated "Use static string keys to avoid per-request allocations" comments that restate the code (and are partially inaccurate, since the `Map` insert still allocates an owned `String` key).

Kept (re-verified as live test/bench fixtures, not dead): `RequestWithBootstrap` (used by `benches/request_processing.rs`) and `PDSelectionPolicy` (used by `tests/routing/test_pd_routing.rs`).

Net: 51 deletions across 2 files (deletion-heavy cleanup; well under 400 lines).

## Test Plan

Gate run with sccache disabled, scoped to the `smg` package (CI runs the full `--all-features` workspace gate):

`cargo +nightly fmt --all` — clean (pure deletions, no reformatting).

`RUSTC_WRAPPER="" cargo clippy -p smg --all-targets -- -D warnings`:
```
    Checking smg v1.4.1 (.../model_gateway)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 12s
```
(only pre-existing workspace notes: non-root profiles, duplicate `main.rs` build target — unrelated to this change)

`RUSTC_WRAPPER="" cargo test -p smg`:
```
test result: ok. 1003 passed; 0 failed; 4 ignored (lib)
api_tests: 105 passed; 0 failed
routing_tests: 92 passed; 0 failed
reliability_tests: 26 passed; 0 failed
security_tests: 48 passed; 0 failed
... all integration + doc suites: 0 failed
```

- [x] `cargo +nightly fmt --all`
- [x] `cargo clippy --all-targets -- -D warnings`