### PR TITLE
fix(grpc-client): set num_waiting_uncached_tokens in vLLM SchedulerLoad conversion

### DIFF
--- a/crates/grpc_client/src/vllm_engine.rs
+++ b/crates/grpc_client/src/vllm_engine.rs
@@ -701,6 +701,8 @@ impl From<proto::SchedulerLoad> for openai_protocol::worker::SchedulerLoadSnapsh
             dp_rank: load.dp_rank,
             num_running_reqs: load.num_running_reqs,
             num_waiting_reqs: load.num_waiting_reqs,
+            // vLLM does not report queued token-work; degrade to 0.
+            num_waiting_uncached_tokens: 0,
             num_total_reqs: load.num_total_reqs,
             num_used_tokens: load.num_used_tokens,
             max_total_num_tokens: load.max_total_num_tokens,


### PR DESCRIPTION
## Description

### Problem

`main` does not compile (E0063), which fails the `build-wheel` and `unit-tests` CI jobs:

```
error[E0063]: missing field `num_waiting_uncached_tokens` in initializer
 of `openai_protocol::worker::SchedulerLoadSnapshot`
  --> crates/grpc_client/src/vllm_engine.rs:700:9
```

This is a semantic merge conflict between two PRs that each passed CI independently:

- **#1647** (`feat(policies): route least_load by token-work expected-wait`) added the `num_waiting_uncached_tokens` field to `SchedulerLoadSnapshot` and updated the sglang/tokenspeed constructors.
- **#1630** (`feat(grpc): add GetLoads endpoint to the vLLM engine service`) independently added a new `From<proto::SchedulerLoad>` constructor in `vllm_engine.rs`.

#1647 was never rebased on top of #1630, so the vLLM constructor never received the new field. The conflicting code only coexists after both merge, so neither PR's CI caught it.

### Solution

The vLLM `SchedulerLoad` proto does not report queued token-work, so degrade the field to `0` in the `From<proto::SchedulerLoad>` impl — matching the existing `tokenspeed_scheduler.rs` constructor and the struct's documented "`0` when the backend does not report it — callers degrade gracefully" contract.

## Changes

- `crates/grpc_client/src/vllm_engine.rs`: set `num_waiting_uncached_tokens: 0` in the vLLM `SchedulerLoad` → `SchedulerLoadSnapshot` conversion.

## Test Plan

Before: `cargo build`/`cargo clippy` fail on `main` with the E0063 above (reproduced from the failing CI run).

After: the affected crate compiles and lints clean. Verified locally:

- `cargo +nightly fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p smg-grpc-client`

<details>
<summary>Checklist</summary>

- [x] `cargo +nightly fmt` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] (Optional) Documentation updated
- [ ] (Optional) Please join us on Slack [#sig-smg](https://slack.lightseek.org) to discuss, review, and merge PRs

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scheduler load reporting to accurately reflect queued token-work for uncached tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->