### PR TITLE
test(grpc): cover TokenSpeed and SGLang server-info label conversion

### DIFF
--- a/docs/reference/api/admin.md
+++ b/docs/reference/api/admin.md
@@ -363,7 +363,7 @@ Returns available models (proxied to workers).
 GET /get_model_info
 ```
 
-Returns detailed model information (proxied to workers).
+Returns detailed model information (proxied to HTTP workers).
 
 **Response:** `200 OK`
 ```json
@@ -374,6 +374,13 @@ Returns detailed model information (proxied to workers).
 }
 ```
 
+!!! note "gRPC workers"
+    This endpoint is not proxied for gRPC-connected workers. The gateway calls
+    the backend's `GetModelInfo` RPC once at worker registration and surfaces
+    the result as worker labels (`model_path`, `served_model_name`,
+    `vocab_size`, `max_context_length`, ...) in
+    [`GET /workers`](extensions.md#worker-management).
+
 ---
 
 ### Get Server Info
@@ -382,7 +389,7 @@ Returns detailed model information (proxied to workers).
 GET /get_server_info
 ```
 
-Returns server information (proxied to workers).
+Returns server information (proxied to HTTP workers).
 
 **Response:** `200 OK`
 ```json
@@ -392,6 +399,15 @@ Returns server information (proxied to workers).
   "gpu_count": 8
 }
 ```
+
+!!! note "gRPC workers"
+    This endpoint is not proxied for gRPC-connected workers. The gateway calls
+    the backend's `GetServerInfo` RPC once at worker registration and surfaces
+    a curated subset of `server_args` (`tp_size`, `dp_size`,
+    `max_total_tokens`, `version`, ...) as worker labels in
+    [`GET /workers`](extensions.md#worker-management). Live scheduler state
+    (running/waiting requests, KV utilization) is served by
+    [`GET /get_loads`](#get-loads) instead.
 
 ---
 

--- a/model_gateway/src/routers/grpc/client.rs
+++ b/model_gateway/src/routers/grpc/client.rs
@@ -834,3 +834,155 @@ fn pick_prost_fields(labels: &mut HashMap<String, String>, s: &prost_types::Stru
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use smg_grpc_client::{sglang_proto, tokenspeed_proto};
+
+    use super::{ModelInfo, ServerInfo};
+
+    fn string_value(s: &str) -> prost_types::Value {
+        prost_types::Value {
+            kind: Some(prost_types::value::Kind::StringValue(s.to_string())),
+        }
+    }
+
+    fn number_value(n: f64) -> prost_types::Value {
+        prost_types::Value {
+            kind: Some(prost_types::value::Kind::NumberValue(n)),
+        }
+    }
+
+    /// The `/workers` metadata path for TokenSpeed: curated `server_args` keys
+    /// become labels, everything else (unlisted keys, scheduler_info, runtime
+    /// state) stays out.
+    #[test]
+    fn server_info_to_labels_tokenspeed_picks_curated_keys_and_version() {
+        let info = ServerInfo::TokenSpeed(Box::new(tokenspeed_proto::GetServerInfoResponse {
+            server_args: Some(prost_types::Struct {
+                fields: BTreeMap::from([
+                    ("model".to_string(), string_value("Qwen/Qwen3-8B")),
+                    ("tokenizer".to_string(), string_value("Qwen/Qwen3-8B")),
+                    ("tp_size".to_string(), number_value(2.0)),
+                    ("max_total_tokens".to_string(), number_value(8192.0)),
+                    // Not in TOKENSPEED_GRPC_KEYS — must not become a label.
+                    ("host".to_string(), string_value("127.0.0.1")),
+                ]),
+            }),
+            scheduler_info: Some(prost_types::Struct {
+                fields: BTreeMap::from([("status".to_string(), string_value("ready"))]),
+            }),
+            active_requests: 3,
+            uptime_seconds: 12.5,
+            max_total_num_tokens: 8192,
+            tokenspeed_version: "0.1.0".to_string(),
+            ..Default::default()
+        }));
+
+        let labels = info.to_labels();
+
+        assert_eq!(
+            labels.get("model").map(String::as_str),
+            Some("Qwen/Qwen3-8B")
+        );
+        assert_eq!(
+            labels.get("tokenizer").map(String::as_str),
+            Some("Qwen/Qwen3-8B")
+        );
+        // Integral numbers are formatted without a decimal point.
+        assert_eq!(labels.get("tp_size").map(String::as_str), Some("2"));
+        assert_eq!(
+            labels.get("max_total_tokens").map(String::as_str),
+            Some("8192")
+        );
+        assert_eq!(labels.get("version").map(String::as_str), Some("0.1.0"));
+        assert!(!labels.contains_key("host"));
+        // scheduler_info and transient runtime state never become labels.
+        assert!(!labels.contains_key("status"));
+        assert!(!labels.contains_key("active_requests"));
+        assert!(!labels.contains_key("uptime_seconds"));
+    }
+
+    #[test]
+    fn server_info_to_labels_sglang_picks_curated_keys_and_version() {
+        let info = ServerInfo::Sglang(Box::new(sglang_proto::GetServerInfoResponse {
+            server_args: Some(prost_types::Struct {
+                fields: BTreeMap::from([
+                    ("model_path".to_string(), string_value("Qwen/Qwen3-8B")),
+                    ("dp_size".to_string(), number_value(4.0)),
+                    (
+                        "is_embedding".to_string(),
+                        prost_types::Value {
+                            kind: Some(prost_types::value::Kind::BoolValue(false)),
+                        },
+                    ),
+                    // Not in SGLANG_GRPC_KEYS — must not become a label.
+                    ("api_key".to_string(), string_value("secret")),
+                ]),
+            }),
+            sglang_version: "0.4.0".to_string(),
+            ..Default::default()
+        }));
+
+        let labels = info.to_labels();
+
+        assert_eq!(
+            labels.get("model_path").map(String::as_str),
+            Some("Qwen/Qwen3-8B")
+        );
+        assert_eq!(labels.get("dp_size").map(String::as_str), Some("4"));
+        // Booleans are kept even when false (embedding detection relies on it).
+        assert_eq!(
+            labels.get("is_embedding").map(String::as_str),
+            Some("false")
+        );
+        assert_eq!(labels.get("version").map(String::as_str), Some("0.4.0"));
+        assert!(!labels.contains_key("api_key"));
+    }
+
+    /// `GetModelInfoResponse` is flat for every backend, so it serializes via
+    /// `flat_labels`: empty strings and zero numbers are skipped, booleans are
+    /// kept, arrays are JSON-encoded.
+    #[test]
+    fn model_info_to_labels_tokenspeed_flat_serializes_skipping_empty_and_zero() {
+        let info = ModelInfo::TokenSpeed(Box::new(tokenspeed_proto::GetModelInfoResponse {
+            model_path: "Qwen/Qwen3-8B".to_string(),
+            tokenizer_path: String::new(), // empty — skipped
+            served_model_name: "qwen3-8b".to_string(),
+            architectures: vec!["Qwen3ForCausalLM".to_string()],
+            max_context_length: 32768,
+            vocab_size: 151_936,
+            pad_token_id: 0, // zero — skipped
+            supports_vision: false,
+            ..Default::default()
+        }));
+
+        let labels = info.to_labels();
+
+        assert_eq!(
+            labels.get("model_path").map(String::as_str),
+            Some("Qwen/Qwen3-8B")
+        );
+        assert_eq!(
+            labels.get("served_model_name").map(String::as_str),
+            Some("qwen3-8b")
+        );
+        assert_eq!(
+            labels.get("max_context_length").map(String::as_str),
+            Some("32768")
+        );
+        assert_eq!(labels.get("vocab_size").map(String::as_str), Some("151936"));
+        assert_eq!(
+            labels.get("architectures").map(String::as_str),
+            Some(r#"["Qwen3ForCausalLM"]"#)
+        );
+        assert_eq!(
+            labels.get("supports_vision").map(String::as_str),
+            Some("false")
+        );
+        assert!(!labels.contains_key("tokenizer_path"));
+        assert!(!labels.contains_key("pad_token_id"));
+    }
+}


### PR DESCRIPTION
## Description

Follow-up to #1574 (closed). For gRPC-connected workers, backend server/model
info is not served by a router endpoint: the worker registration workflow calls
the backend's `GetModelInfo` / `GetServerInfo` RPCs (`discover_metadata.rs`) and
surfaces the results as worker labels in `GET /workers`. The TokenSpeed arms of
that pipeline landed with #1351, but the label-conversion layer
(`ModelInfo::to_labels` / `ServerInfo::to_labels`) had no unit coverage, and the
admin API docs did not say where this data lives in gRPC mode.

## Changes

- Add unit tests for the worker-label conversion in `routers/grpc/client.rs`:
  - TokenSpeed `ServerInfo`: curated `TOKENSPEED_GRPC_KEYS` picked from the
    `server_args` Struct, integral numbers formatted without a decimal point,
    `tokenspeed_version` → `version`, unlisted keys / `scheduler_info` /
    transient runtime state excluded.
  - SGLang `ServerInfo`: same contract via `SGLANG_GRPC_KEYS`, including
    `is_embedding=false` kept as a label (embedding detection relies on it) and
    non-curated keys (e.g. `api_key`) excluded.
  - TokenSpeed `ModelInfo`: `flat_labels` skip/keep rules — empty strings and
    zero numbers skipped, `false` booleans kept, arrays JSON-encoded.
- `docs/reference/api/admin.md`: note on `/get_server_info` and
  `/get_model_info` that they are HTTP-worker passthroughs; gRPC workers expose
  the same metadata as labels in `GET /workers`, with live scheduler state on
  `/get_loads`.

## Test Plan

```
$ cargo +nightly fmt --all
(clean)

$ cargo clippy --all-targets --all-features -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 05s

$ cargo test -p smg --lib routers::grpc::client::tests
running 3 tests
test routers::grpc::client::tests::server_info_to_labels_tokenspeed_picks_curated_keys_and_version ... ok
test routers::grpc::client::tests::server_info_to_labels_sglang_picks_curated_keys_and_version ... ok
test routers::grpc::client::tests::model_info_to_labels_tokenspeed_flat_serializes_skipping_empty_and_zero ... ok
test result: ok. 3 passed; 0 failed

$ cargo test
86 suites, all `test result: ok`, 0 failures
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API documentation to clarify that worker information endpoints are only available for HTTP-connected workers. Added details on how the gateway exposes and manages worker information through the API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->